### PR TITLE
feat(app-blocks): push THEME_CHANGE to mounted blocks on a viewer theme toggle

### DIFF
--- a/docs/features/app-blocks.md
+++ b/docs/features/app-blocks.md
@@ -144,10 +144,29 @@ the token endpoint has resolved. Matches `@civitai/app-sdk/blocks` v1:
     // `blocks.getMyViewer`), the successor to the deprecated /api/v1/blocks/me
     // call.
   } | null;                            // null for anon viewers
-  theme: 'light' | 'dark';             // matches host color scheme
+  theme: 'light' | 'dark';             // host color scheme AT MOUNT — see "Theme changes"
   renderMode: 'iframe' | 'inline';     // always 'iframe' today (the inline host is a stub)
 }
 ```
+
+### Theme changes
+
+`BLOCK_INIT.theme` is the theme **at mount**, and it cannot move afterwards: the
+SDK dedupes `BLOCK_INIT` (only the first is honored) and the host deliberately
+FREEZES the init URL fragment (`#civitai-block=v1&theme=…`, where that gate is
+on) at mount, so a toggle can never re-navigate a third-party frame. The live
+value arrives as a host→block push instead:
+
+- **`THEME_CHANGE`** — pushed whenever the viewer flips the site's color scheme,
+  carrying `{ theme: 'light' | 'dark' }`. Fire-and-forget; nothing is awaited. It
+  is sent only after the first `BLOCK_INIT` has gone out (before that there is
+  nothing to talk to). BOTH host surfaces push it — the model slot
+  (`IframeHost.tsx`) and the `/apps/run/<slug>` page (`PageBlockHost.tsx`).
+
+Handling it is **optional**: a block on an older SDK has no listener, its
+transport drops the message, and it keeps rendering its mount-time theme. A block
+that does listen should re-theme in place — the frame is never re-navigated for a
+theme change.
 
 ### Token refresh
 
@@ -202,8 +221,11 @@ read that file. As of this writing the families are:
   hangs the block). Flip the host entries to `required` in the inventory if/when
   a sink lands.
 
-The `SUSPEND` / `RESUME` messages flow the other direction (parent→block). The
-SDK degrades gracefully when a host does not handle a fire-and-forget surface.
+`SUSPEND` / `RESUME`, `TOKEN_REFRESH` (see "Token refresh") and `THEME_CHANGE`
+(see "Theme changes") flow the other direction (host→block), which is why they
+are absent from that inventory — it covers block→host only. The SDK degrades
+gracefully when a host does not handle a fire-and-forget surface, and a block
+that ignores a host→block push is equally fine.
 
 ### Buzz and per-account spend
 

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -608,6 +608,17 @@ export function IframeHost({
   // used everywhere else modelCtx.slotId is read in this component.
   const slotId = modelCtx.slotId ?? 'model.sidebar_top';
 
+  // The viewer's ACTIVE color scheme, as one value.
+  //
+  // 🔴 ONE PLACE, on purpose. This used to be `modelCtx.theme ?? 'light'`
+  // open-coded at each of its two readers (the init-fragment fields and the
+  // BLOCK_INIT payload); the THEME_CHANGE push below is a THIRD reader, and
+  // three copies of a defaulting expression is how they drift. It is a plain
+  // derived value (ModelVersionDetails threads a live `useComputedColorScheme`
+  // down through the slot context), so it re-renders this component on a toggle
+  // — which is exactly what makes the effect below fire.
+  const activeTheme: 'light' | 'dark' = modelCtx.theme ?? 'light';
+
   // The publisher's declared src. The rendered `src` adds the init-fragment
   // fast path on top ONLY when this block is gated on for it (see
   // blockInitFragmentGate.ts — off by default for every block). The ORIGIN is
@@ -617,7 +628,7 @@ export function IframeHost({
   const iframeSrc = useBlockIframeSrc(
     baseIframeSrc,
     {
-      theme: modelCtx.theme ?? 'light',
+      theme: activeTheme,
       renderMode: install.renderMode,
       blockInstanceId: install.blockInstanceId,
     },
@@ -783,7 +794,7 @@ export function IframeHost({
     // id/username/status are exposed to the iframe. Built via the same pure
     // projection module so the allowlist lives in one tested place.
     viewer: projectBlockInitViewer(context),
-    theme: modelCtx.theme ?? 'light',
+    theme: activeTheme,
     renderMode: install.renderMode,
     // Advisory maturity signal — server-authoritative values from the mint.
     ...projectBlockInitMaturity({ domain, maxBrowsingLevel }),
@@ -826,6 +837,40 @@ export function IframeHost({
       },
     });
   }, [token, expiresAt, buzzBudget, grantedScopes, send]);
+
+  // 🔴 DECLARED BEFORE THE INIT-HANDSHAKE EFFECT ON PURPOSE, and PageBlockHost
+  // places it the same way. React runs effects in declaration order, so on the
+  // FIRST commit this must run while `initSentRef` is still false — otherwise
+  // the gate in it is INERT on mount and the host emits a redundant
+  // THEME_CHANGE immediately after its own BLOCK_INIT (measured on the page
+  // host, where this effect originally sat after the init effect). Reordering
+  // silently re-creates that, which is why
+  // `IframeHostThemeChange.browser.test.tsx` asserts the mount sequence.
+  // Push a THEME_CHANGE when the viewer toggles light/dark WHILE the block is
+  // mounted. Without it the block keeps its mount-time theme until reloaded:
+  // BLOCK_INIT is deduped SDK-side (only the first is honored) and
+  // `useBlockIframeSrc` deliberately FREEZES the URL fragment at mount, so
+  // neither existing channel can carry a later value.
+  //
+  // 🔴 THE SAME WIRING MUST EXIST IN PageBlockHost.tsx. The two hosts do NOT
+  // share a bridge — each registers its own postMessage handlers by hand (the
+  // gotcha-#73 class `hostHandlerParity.ts` documents) — so wiring one surface
+  // and not the other leaves half the blocks stuck. `hostHandlerParity` cannot
+  // catch this one: its INVENTORY covers block→host messages, and this is a
+  // host→block push. The per-surface browser tests are the coverage.
+  //
+  // Gated on `initSentRef` for the same reason TOKEN_REFRESH is: before the FIRST
+  // BLOCK_INIT post there is nothing to talk to. (Note the guard flips on that
+  // POST, not on BLOCK_READY — so a toggle between the post and the ack does
+  // push, into a frame that may not be listening yet. That is harmless and NOT
+  // the safety net: `buildInitPayload` reads `activeTheme` fresh on every retry
+  // tick, so the BLOCK_INIT the block finally accepts carries the current theme
+  // regardless of whether any push was heard.) Deps are [activeTheme, send] only
+  // — this must fire on a THEME change, never on an unrelated re-render.
+  useEffect(() => {
+    if (!initSentRef.current) return;
+    send('THEME_CHANGE', { theme: activeTheme });
+  }, [activeTheme, send]);
 
   // SDK request-driven flow: iframe asks for the current token (e.g. right
   // before an expensive call) and we reply with the latest wrapped value.

--- a/src/components/AppBlocks/IframeHostThemeChange.browser.test.tsx
+++ b/src/components/AppBlocks/IframeHostThemeChange.browser.test.tsx
@@ -1,0 +1,343 @@
+import { describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+// Type-only namespace import for the `importOriginal` spread below (the repo's
+// local-rules/no-wholesale-module-mock cure). NOT `typeof import(...)`, which
+// @typescript-eslint/consistent-type-imports rejects.
+import type * as TrpcMod from '~/utils/trpc';
+
+/**
+ * THEME_CHANGE on the MODEL-SLOT host (`model.sidebar_top`).
+ *
+ * THE GAP: the host handed a block its theme exactly once — in `BLOCK_INIT`, and
+ * (where the gate is on) in the iframe URL fragment. Neither can move afterwards:
+ * the SDK DEDUPES `BLOCK_INIT` (only the first is honored), and
+ * `useBlockIframeSrc` deliberately FREEZES the fragment at mount so a toggle
+ * can't re-navigate a third-party frame. So a viewer flipping dark mode left
+ * every mounted block rendering its mount-time theme until reloaded.
+ *
+ * 🔴 THIS SUITE IS HALF THE COVERAGE. `PageBlockHost` is a SEPARATE surface with
+ * its OWN postMessage bridge — the two share no code path — so it has its own
+ * mirror of this file, and `__tests__/hostThemeChangeParity.test.ts` pins that
+ * BOTH exist. Wiring one host and not the other is the classic miss here, and no
+ * single-surface suite can see it.
+ *
+ * Mocks mirror `IframeHost.browser.test.tsx` (the model-slot scaffold): the two
+ * tRPC queries IframeHost drives at render must report `isLoading: false` so the
+ * init handshake is allowed to start.
+ */
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ appBlocks: false, appBlocksPages: false }),
+}));
+
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcMod>()),
+  trpc: {
+    blocks: {
+      getEffectiveCheckpoint: {
+        useQuery: () => ({ data: { checkpoint: null }, isLoading: false }),
+      },
+      getShowcaseImages: {
+        useQuery: () => ({ data: [], isLoading: false }),
+      },
+      submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      updateUserSettings: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
+    apps: {
+      shared: {
+        append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        update: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        report: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+      storage: {
+        set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        delete: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+    },
+    useUtils: () => ({
+      apps: {
+        shared: {
+          list: { fetch: vi.fn() },
+          getCount: { fetch: vi.fn() },
+          getCounts: { fetch: vi.fn() },
+          get: { fetch: vi.fn() },
+        },
+        storage: {
+          get: { fetch: vi.fn() },
+          list: { fetch: vi.fn() },
+          getQuota: { fetch: vi.fn() },
+        },
+      },
+    }),
+  },
+}));
+
+vi.mock('~/components/BrowsingLevel/BrowsingLevelProvider', () => ({
+  useBrowsingLevelDebounced: () => 1,
+}));
+
+// eslint-disable-next-line import/first
+import { IframeHost } from '~/components/AppBlocks/IframeHost';
+// eslint-disable-next-line import/first
+import type { BlockInstall, ModelSlotContext } from '~/components/AppBlocks/types';
+
+const SAME_ORIGIN_SRC = `${window.location.origin}/`;
+
+function iframeEl() {
+  return page.getByTestId('block-iframe').element() as HTMLIFrameElement;
+}
+
+function postFromBlock(type: string, payload?: unknown) {
+  const cw = iframeEl().contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      data: { type, payload },
+      origin: window.location.origin,
+      source: cw,
+    })
+  );
+}
+
+/** Capture host→block posts. `send` targets the iframe's contentWindow. */
+function listenForHostPosts() {
+  const received: Array<{ type: string; payload: unknown }> = [];
+  const cw = iframeEl().contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  const handler = (e: MessageEvent) => {
+    const d = e.data as { type?: string; payload?: unknown } | null;
+    if (d && typeof d.type === 'string') received.push({ type: d.type, payload: d.payload });
+  };
+  cw.addEventListener('message', handler);
+  return {
+    received,
+    of: (type: string) => received.filter((m) => m.type === type),
+    last: (type: string) => [...received].reverse().find((m) => m.type === type),
+    stop: () => cw.removeEventListener('message', handler),
+  };
+}
+
+const install: BlockInstall = {
+  blockInstanceId: 'inst_test',
+  blockId: 'my-model-app',
+  appId: 'app_test',
+  appBlockId: 'apb_test',
+  manifest: {
+    name: 'Background Remover',
+    scopes: ['ai:write:budgeted'],
+    iframe: {
+      src: SAME_ORIGIN_SRC,
+      minHeight: 200,
+      maxHeight: 800,
+      resizable: true,
+      sandbox: 'allow-scripts',
+    },
+  },
+  publisherSettings: {},
+  enabled: true,
+  renderMode: 'iframe',
+  trustTier: 'internal',
+};
+
+function contextWithTheme(theme: 'light' | 'dark'): ModelSlotContext {
+  return {
+    slotId: 'model.sidebar_top',
+    entityType: 'model',
+    modelId: 123,
+    modelVersionId: 456,
+    modelName: 'Some Model',
+    modelType: 'Checkpoint',
+    modelNsfwLevel: 1,
+    creatorUserId: 7,
+    viewerUserId: 42,
+    viewerNsfwEnabled: false,
+    viewerUsername: 'tester',
+    theme,
+  };
+}
+
+/**
+ * Tap EVERY host→frame `postMessage`, installed BEFORE render.
+ *
+ * The `listenForHostPosts` helper above can only attach once the iframe is in
+ * the DOM — i.e. after React has committed and flushed effects — so it is
+ * structurally blind to anything the host posts on MOUNT. That blindness is
+ * exactly what makes the `initSentRef` gate untestable with it: deleting the
+ * gate makes the host push THEME_CHANGE on mount, and the listener never sees
+ * it. (Measured: that mutation survived the whole suite.)
+ *
+ * This patches the `contentWindow` GETTER on the prototype and wraps
+ * `postMessage` on the real Window it returns. It deliberately returns the REAL
+ * window (not a Proxy) so `usePostMessage`'s `event.source === contentWindow`
+ * identity pin still holds for the block→host direction.
+ */
+function tapFramePosts() {
+  const desc = Object.getOwnPropertyDescriptor(HTMLIFrameElement.prototype, 'contentWindow');
+  if (!desc?.get) throw new Error('contentWindow descriptor missing');
+  const realGet = desc.get;
+  const seen: Array<{ type?: string; payload?: unknown }> = [];
+  const patched = new WeakSet<Window>();
+  Object.defineProperty(HTMLIFrameElement.prototype, 'contentWindow', {
+    configurable: true,
+    get(this: HTMLIFrameElement) {
+      const cw = realGet.call(this) as Window | null;
+      if (cw && !patched.has(cw)) {
+        patched.add(cw);
+        const orig = cw.postMessage.bind(cw);
+        (cw as unknown as { postMessage: unknown }).postMessage = (
+          msg: unknown,
+          target: string
+        ) => {
+          seen.push(msg as { type?: string });
+          return orig(msg as never, target as never);
+        };
+      }
+      return cw;
+    },
+  });
+  return {
+    seen,
+    restore: () => Object.defineProperty(HTMLIFrameElement.prototype, 'contentWindow', desc),
+  };
+}
+
+const baseProps = {
+  install,
+  token: 'tok_abc',
+  expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
+};
+
+describe('IframeHost THEME_CHANGE (model.sidebar_top)', () => {
+  /**
+   * Mount, attach the host→block listener BEFORE the handshake, then ack READY.
+   *
+   * Order matters: the listener has to be attached while BLOCK_INIT posts are
+   * still flowing, so every assertion below rests on a listener PROVEN to
+   * observe real host pushes. Attaching it after READY would leave a quiet
+   * channel, and a `toHaveLength(0)` on a probe wired to nothing is
+   * indistinguishable from a genuine zero.
+   */
+  async function mountAndReady(theme: 'light' | 'dark') {
+    const { rerender } = await renderWithProviders(
+      <IframeHost {...baseProps} context={contextWithTheme(theme)} />
+    );
+    await vi.waitFor(() => {
+      if (!iframeEl().contentWindow) throw new Error('not mounted yet');
+    });
+    const posts = listenForHostPosts();
+    // POSITIVE CONTROL: the listener sees the host's own BLOCK_INIT.
+    await vi.waitFor(() => {
+      if (posts.of('BLOCK_INIT').length === 0) throw new Error('listener saw no BLOCK_INIT');
+    });
+    await vi.waitFor(() => {
+      postFromBlock('BLOCK_READY', {});
+      if (iframeEl().getAttribute('data-block-ready') !== 'true') throw new Error('not ready yet');
+    });
+    return { rerender, posts };
+  }
+
+  test('a mid-session theme toggle pushes THEME_CHANGE with the new theme', async () => {
+    const { rerender, posts } = await mountAndReady('light');
+    expect(posts.of('THEME_CHANGE')).toHaveLength(0);
+
+    // The viewer toggles dark mode: ModelVersionDetails re-renders the slot with
+    // a new `context.theme` (it threads a live useComputedColorScheme down).
+    await rerender(<IframeHost {...baseProps} context={contextWithTheme('dark')} />);
+
+    await vi.waitFor(() => {
+      const m = posts.last('THEME_CHANGE');
+      if (!m) throw new Error('no THEME_CHANGE yet');
+      expect(m.payload).toEqual({ theme: 'dark' });
+    });
+    posts.stop();
+  });
+
+  test('toggling back pushes again — not a one-shot latch', async () => {
+    const { rerender, posts } = await mountAndReady('light');
+
+    await rerender(<IframeHost {...baseProps} context={contextWithTheme('dark')} />);
+    await vi.waitFor(() => expect(posts.of('THEME_CHANGE')).toHaveLength(1));
+
+    await rerender(<IframeHost {...baseProps} context={contextWithTheme('light')} />);
+    await vi.waitFor(() => expect(posts.of('THEME_CHANGE')).toHaveLength(2));
+    expect(posts.of('THEME_CHANGE').map((m) => m.payload)).toEqual([
+      { theme: 'dark' },
+      { theme: 'light' },
+    ]);
+    posts.stop();
+  });
+
+  test('an unrelated re-render (same theme) pushes NOTHING', async () => {
+    const { rerender, posts } = await mountAndReady('dark');
+
+    // Same theme, a different unrelated context field. The effect's deps are
+    // [activeTheme, send] — a re-render must not spam the frame.
+    await rerender(
+      <IframeHost {...baseProps} context={{ ...contextWithTheme('dark'), modelName: 'Renamed' }} />
+    );
+    await new Promise((r) => setTimeout(r, 150));
+    expect(posts.of('THEME_CHANGE')).toHaveLength(0);
+    posts.stop();
+  });
+
+  test('a pre-ack toggle is not lost — the retried BLOCK_INIT carries the CURRENT theme', async () => {
+    // The load-bearing property: a toggle that lands before the block has ACKED
+    // cannot strand it. The retry-until-ready controller rebuilds the payload on
+    // every tick, so the BLOCK_INIT the block finally receives holds the theme
+    // as of that moment — even if the standalone push went out into a frame that
+    // was not listening yet.
+    //
+    // 🔴 Deliberately NOT asserting "no push happened here". `initSentRef` flips
+    // on the first BLOCK_INIT *POST*, not on BLOCK_READY, and that post happens
+    // as soon as the controller starts — so whether a pre-ack toggle also pushes
+    // is a race with the controller's first tick. Pinning either outcome would
+    // be pinning the race. What must hold in BOTH orderings is the assertion
+    // below.
+    const { rerender } = await renderWithProviders(
+      <IframeHost {...baseProps} context={contextWithTheme('light')} />
+    );
+    await vi.waitFor(() => {
+      if (!iframeEl().contentWindow) throw new Error('not mounted yet');
+    });
+    const posts = listenForHostPosts();
+
+    await rerender(<IframeHost {...baseProps} context={contextWithTheme('dark')} />);
+
+    await vi.waitFor(() => {
+      const init = posts.last('BLOCK_INIT');
+      if (!init) throw new Error('no BLOCK_INIT yet');
+      expect((init.payload as { theme: string }).theme).toBe('dark');
+    });
+    posts.stop();
+  });
+
+  test('pushes NOTHING before the first BLOCK_INIT — the initSentRef gate', async () => {
+    // NEGATIVE CONTROL WITH A REAL INSTRUMENT: the tap is installed before
+    // render, so it CAN observe a mount-time post. Without the gate the host
+    // pushes THEME_CHANGE on mount and this reads THEME_CHANGE first.
+    const tap = tapFramePosts();
+    try {
+      await renderWithProviders(<IframeHost {...baseProps} context={contextWithTheme('dark')} />);
+      // POSITIVE CONTROL: the tap observes real traffic.
+      await vi.waitFor(() => {
+        if (tap.seen.length === 0) throw new Error('tap saw nothing at all');
+      });
+      // Settle: give any post-init effect a chance to fire before asserting.
+      await new Promise((r) => setTimeout(r, 300));
+      expect(tap.seen[0]?.type).toBe('BLOCK_INIT');
+      expect(tap.seen.filter((m) => m?.type === 'THEME_CHANGE')).toHaveLength(0);
+    } finally {
+      tap.restore();
+    }
+  });
+});

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -746,6 +746,48 @@ export function PageBlockHost({
     send('BLOCK_INIT', (buildInitPayloadRef.current ?? (() => undefined as never))());
   }, [send]);
 
+  // 🔴 DECLARED BEFORE THE INIT-HANDSHAKE EFFECT ON PURPOSE, and IframeHost
+  // places it the same way. React runs effects in declaration order, so on the
+  // FIRST commit this must run while `initSentRef` is still false — otherwise
+  // the gate in it is INERT on mount and the host emits a redundant
+  // THEME_CHANGE immediately after its own BLOCK_INIT. Measured: with this
+  // effect declared after the init effect the mount sequence was
+  // BLOCK_INIT → TOKEN_REFRESH → THEME_CHANGE. (The TOKEN_REFRESH in that
+  // sequence is pre-existing and out of scope here.) Moving this effect below
+  // the init effect silently re-creates that, which is why
+  // `PageBlockHostThemeChange.browser.test.tsx` asserts the mount sequence.
+  // Push a THEME_CHANGE when the viewer toggles light/dark WHILE the block is
+  // mounted. `theme` is a PROP — the route computes it from
+  // `useComputedColorScheme`, so it changes on a toggle and re-renders us.
+  //
+  // Without this the block keeps its mount-time theme until reloaded: BLOCK_INIT
+  // is deduped SDK-side (only the first is honored) and `useBlockIframeSrc`
+  // deliberately FREEZES the URL fragment at mount, so neither existing channel
+  // can carry a later value.
+  //
+  // 🔴 THE SAME WIRING MUST EXIST IN IframeHost.tsx (the model-slot surface).
+  // The two hosts do NOT share a bridge — each registers its own postMessage
+  // handlers by hand (the gotcha-#73 class `hostHandlerParity.ts` documents) —
+  // so wiring one and not the other leaves half the blocks stuck.
+  // `hostHandlerParity` cannot catch this one: its INVENTORY covers block→host
+  // messages, and this is a host→block push. The per-surface browser tests are
+  // the coverage.
+  //
+  // Gated on `initSentRef` for the same reason TOKEN_REFRESH is: before the FIRST
+  // BLOCK_INIT post there is nothing to talk to. (Note the guard flips on that
+  // POST, not on BLOCK_READY — so a toggle between the post and the ack does
+  // push, into a frame that may not be listening yet. That is harmless and NOT
+  // the safety net: `buildInitPayload` reads `theme` fresh on every retry tick,
+  // so the BLOCK_INIT the block finally accepts carries the current theme
+  // regardless of whether any push was heard.)
+  // Deliberately NOT gated on `reviewMode`: the theme is neither
+  // side-effecting nor private, and the review sandbox should render in the
+  // moderator's own color scheme like every other surface.
+  useEffect(() => {
+    if (!initSentRef.current) return;
+    send('THEME_CHANGE', { theme });
+  }, [theme, send]);
+
   // Init handshake — start once token is present (no checkpoint dependency for
   // a page). Retry-until-BLOCK_READY via the shared controller.
   useEffect(() => {

--- a/src/components/AppBlocks/PageBlockHostThemeChange.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostThemeChange.browser.test.tsx
@@ -1,0 +1,308 @@
+import { describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+// Type-only namespace import for the `importOriginal` spread below (the repo's
+// local-rules/no-wholesale-module-mock cure). NOT `typeof import(...)`, which
+// @typescript-eslint/consistent-type-imports rejects.
+import type * as TrpcMod from '~/utils/trpc';
+
+/**
+ * THEME_CHANGE on the PAGE host (`/apps/run/<slug>`, slot `app.page`).
+ *
+ * THE GAP: the host handed a block its theme exactly once — in `BLOCK_INIT`, and
+ * (where the gate is on) in the iframe URL fragment. Neither can move afterwards:
+ * the SDK DEDUPES `BLOCK_INIT` (only the first is honored), and
+ * `useBlockIframeSrc` deliberately FREEZES the fragment at mount so a toggle
+ * can't re-navigate a third-party frame. So a viewer flipping dark mode left
+ * every mounted block rendering its mount-time theme until reloaded.
+ *
+ * 🔴 THIS SUITE IS HALF THE COVERAGE — the exact mirror of
+ * `IframeHostThemeChange.browser.test.tsx`. `IframeHost` (model slot) is a
+ * SEPARATE surface with its OWN postMessage bridge; the two share no code path,
+ * so a fix wired into one is invisible to the other's suite. That the pair
+ * EXISTS is pinned structurally by `__tests__/hostThemeChangeParity.test.ts`.
+ *
+ * On this surface `theme` is a PROP: the route (`/apps/run/[slug]`) computes it
+ * from `useComputedColorScheme` and re-renders us on a toggle — which is what
+ * the `rerender` below simulates.
+ *
+ * Mocks mirror `PageBlockHostSignIn.browser.test.tsx` (the page scaffold).
+ */
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcMod>()),
+  // FeatureFlagsProvider (in PageBlockHost's real render graph) statically imports
+  // `setTrpcBatchingEnabled` from this module (#2946). vi.mock replaces the module
+  // wholesale, so the factory must re-declare it or the ESM link fails.
+  setTrpcBatchingEnabled: vi.fn(),
+  trpc: {
+    generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
+    blocks: {
+      submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyViewer: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzTransactions: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzAccounts: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyDailyCompensation: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      publishGenerationOutputs: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getImagesByIds: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
+    apps: {
+      shared: {
+        append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        update: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        report: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+      storage: {
+        set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        delete: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+    },
+    useUtils: () => ({
+      apps: {
+        shared: {
+          list: { fetch: vi.fn() },
+          getCount: { fetch: vi.fn() },
+          getCounts: { fetch: vi.fn() },
+          get: { fetch: vi.fn() },
+        },
+        storage: {
+          get: { fetch: vi.fn() },
+          list: { fetch: vi.fn() },
+          getQuota: { fetch: vi.fn() },
+        },
+      },
+    }),
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
+
+const SAME_ORIGIN_SRC = `${window.location.origin}/`;
+
+function iframeEl() {
+  return page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+}
+
+function postFromBlock(type: string, payload?: unknown) {
+  const cw = iframeEl().contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      data: { type, payload },
+      origin: window.location.origin,
+      source: cw,
+    })
+  );
+}
+
+/** Capture host→block posts. `send` targets the iframe's contentWindow. */
+function listenForHostPosts() {
+  const received: Array<{ type: string; payload: unknown }> = [];
+  const cw = iframeEl().contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  const handler = (e: MessageEvent) => {
+    const d = e.data as { type?: string; payload?: unknown } | null;
+    if (d && typeof d.type === 'string') received.push({ type: d.type, payload: d.payload });
+  };
+  cw.addEventListener('message', handler);
+  return {
+    received,
+    of: (type: string) => received.filter((m) => m.type === type),
+    last: (type: string) => [...received].reverse().find((m) => m.type === type),
+    stop: () => cw.removeEventListener('message', handler),
+  };
+}
+
+/**
+ * Tap EVERY host→frame `postMessage`, installed BEFORE render.
+ *
+ * The `listenForHostPosts` helper above can only attach once the iframe is in
+ * the DOM — i.e. after React has committed and flushed effects — so it is
+ * structurally blind to anything the host posts on MOUNT. That blindness is
+ * exactly what makes the `initSentRef` gate untestable with it: deleting the
+ * gate makes the host push THEME_CHANGE on mount, and the listener never sees
+ * it. (Measured: that mutation survived the whole suite.)
+ *
+ * This patches the `contentWindow` GETTER on the prototype and wraps
+ * `postMessage` on the real Window it returns. It deliberately returns the REAL
+ * window (not a Proxy) so `usePostMessage`'s `event.source === contentWindow`
+ * identity pin still holds for the block→host direction.
+ */
+function tapFramePosts() {
+  const desc = Object.getOwnPropertyDescriptor(HTMLIFrameElement.prototype, 'contentWindow');
+  if (!desc?.get) throw new Error('contentWindow descriptor missing');
+  const realGet = desc.get;
+  const seen: Array<{ type?: string; payload?: unknown }> = [];
+  const patched = new WeakSet<Window>();
+  Object.defineProperty(HTMLIFrameElement.prototype, 'contentWindow', {
+    configurable: true,
+    get(this: HTMLIFrameElement) {
+      const cw = realGet.call(this) as Window | null;
+      if (cw && !patched.has(cw)) {
+        patched.add(cw);
+        const orig = cw.postMessage.bind(cw);
+        (cw as unknown as { postMessage: unknown }).postMessage = (
+          msg: unknown,
+          target: string
+        ) => {
+          seen.push(msg as { type?: string });
+          return orig(msg as never, target as never);
+        };
+      }
+      return cw;
+    },
+  });
+  return {
+    seen,
+    restore: () => Object.defineProperty(HTMLIFrameElement.prototype, 'contentWindow', desc),
+  };
+}
+
+const baseProps = {
+  appBlockId: 'apb_test',
+  blockId: 'my-page-app',
+  appId: 'app_test',
+  blockInstanceId: 'page_apb_test',
+  appName: 'Budgeted Generator',
+  iframeSrc: SAME_ORIGIN_SRC,
+  surface: 'page-run' as const,
+  sandbox: 'allow-scripts',
+  trustTier: 'internal' as const,
+  slug: 'my-page-app',
+  token: 'tok_abc',
+  expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
+  declaredScopes: ['ai:write:budgeted'],
+  missingScopes: [] as string[],
+  needsConsent: false,
+  tokenError: false,
+  viewer: null,
+};
+
+describe('PageBlockHost THEME_CHANGE (app.page)', () => {
+  /**
+   * Mount, attach the host→block listener BEFORE the handshake, then ack READY.
+   *
+   * Order matters: the listener has to be attached while BLOCK_INIT posts are
+   * still flowing, so every assertion below rests on a listener PROVEN to
+   * observe real host pushes. Attaching it after READY would leave a quiet
+   * channel, and a `toHaveLength(0)` on a probe wired to nothing is
+   * indistinguishable from a genuine zero.
+   */
+  async function mountAndReady(theme: 'light' | 'dark') {
+    const { rerender } = await renderWithProviders(<PageBlockHost {...baseProps} theme={theme} />);
+    await vi.waitFor(() => {
+      if (!iframeEl().contentWindow) throw new Error('not mounted yet');
+    });
+    const posts = listenForHostPosts();
+    // POSITIVE CONTROL: the listener sees the host's own BLOCK_INIT.
+    await vi.waitFor(() => {
+      if (posts.of('BLOCK_INIT').length === 0) throw new Error('listener saw no BLOCK_INIT');
+    });
+    await vi.waitFor(() => {
+      postFromBlock('BLOCK_READY', {});
+      if (iframeEl().getAttribute('data-block-ready') !== 'true') throw new Error('not ready yet');
+    });
+    return { rerender, posts };
+  }
+
+  test('a mid-session theme toggle pushes THEME_CHANGE with the new theme', async () => {
+    const { rerender, posts } = await mountAndReady('light');
+    expect(posts.of('THEME_CHANGE')).toHaveLength(0);
+
+    await rerender(<PageBlockHost {...baseProps} theme="dark" />);
+
+    await vi.waitFor(() => {
+      const m = posts.last('THEME_CHANGE');
+      if (!m) throw new Error('no THEME_CHANGE yet');
+      expect(m.payload).toEqual({ theme: 'dark' });
+    });
+    posts.stop();
+  });
+
+  test('toggling back pushes again — not a one-shot latch', async () => {
+    const { rerender, posts } = await mountAndReady('light');
+
+    await rerender(<PageBlockHost {...baseProps} theme="dark" />);
+    await vi.waitFor(() => expect(posts.of('THEME_CHANGE')).toHaveLength(1));
+
+    await rerender(<PageBlockHost {...baseProps} theme="light" />);
+    await vi.waitFor(() => expect(posts.of('THEME_CHANGE')).toHaveLength(2));
+    expect(posts.of('THEME_CHANGE').map((m) => m.payload)).toEqual([
+      { theme: 'dark' },
+      { theme: 'light' },
+    ]);
+    posts.stop();
+  });
+
+  test('an unrelated re-render (same theme) pushes NOTHING', async () => {
+    const { rerender, posts } = await mountAndReady('dark');
+
+    // Same theme, a different unrelated prop. The effect's deps are
+    // [theme, send] — a re-render must not spam the frame.
+    await rerender(<PageBlockHost {...baseProps} theme="dark" appName="Renamed" />);
+    await new Promise((r) => setTimeout(r, 150));
+    expect(posts.of('THEME_CHANGE')).toHaveLength(0);
+    posts.stop();
+  });
+
+  test('a pre-ack toggle is not lost — the retried BLOCK_INIT carries the CURRENT theme', async () => {
+    // The load-bearing property: a toggle that lands before the block has ACKED
+    // cannot strand it. The retry-until-ready controller rebuilds the payload on
+    // every tick, so the BLOCK_INIT the block finally receives holds the theme
+    // as of that moment — even if the standalone push went out into a frame that
+    // was not listening yet.
+    //
+    // 🔴 Deliberately NOT asserting "no push happened here". `initSentRef` flips
+    // on the first BLOCK_INIT *POST*, not on BLOCK_READY, and that post happens
+    // as soon as the controller starts — so whether a pre-ack toggle also pushes
+    // is a race with the controller's first tick. Pinning either outcome would
+    // be pinning the race. What must hold in BOTH orderings is the assertion
+    // below.
+    const { rerender } = await renderWithProviders(<PageBlockHost {...baseProps} theme="light" />);
+    await vi.waitFor(() => {
+      if (!iframeEl().contentWindow) throw new Error('not mounted yet');
+    });
+    const posts = listenForHostPosts();
+
+    await rerender(<PageBlockHost {...baseProps} theme="dark" />);
+
+    await vi.waitFor(() => {
+      const init = posts.last('BLOCK_INIT');
+      if (!init) throw new Error('no BLOCK_INIT yet');
+      expect((init.payload as { theme: string }).theme).toBe('dark');
+    });
+    posts.stop();
+  });
+
+  test('pushes NOTHING before the first BLOCK_INIT — the initSentRef gate', async () => {
+    // NEGATIVE CONTROL WITH A REAL INSTRUMENT: the tap is installed before
+    // render, so it CAN observe a mount-time post. Without the gate the host
+    // pushes THEME_CHANGE on mount and this reads THEME_CHANGE first.
+    const tap = tapFramePosts();
+    try {
+      await renderWithProviders(<PageBlockHost {...baseProps} theme="dark" />);
+      // POSITIVE CONTROL: the tap observes real traffic.
+      await vi.waitFor(() => {
+        if (tap.seen.length === 0) throw new Error('tap saw nothing at all');
+      });
+      // Settle: give any post-init effect a chance to fire before asserting.
+      await new Promise((r) => setTimeout(r, 300));
+      expect(tap.seen[0]?.type).toBe('BLOCK_INIT');
+      expect(tap.seen.filter((m) => m?.type === 'THEME_CHANGE')).toHaveLength(0);
+    } finally {
+      tap.restore();
+    }
+  });
+});

--- a/src/components/AppBlocks/__tests__/hostThemeChangeParity.test.ts
+++ b/src/components/AppBlocks/__tests__/hostThemeChangeParity.test.ts
@@ -1,0 +1,80 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * THEME_CHANGE host-surface LEDGER.
+ *
+ * THE BUG CLASS: App Blocks has more than one host component, and they do NOT
+ * share a postMessage bridge — each registers its own handlers and its own
+ * host→block pushes by hand (`IframeHost.tsx` for the model slot,
+ * `PageBlockHost.tsx` for `/apps/run/<slug>`). A host→block push wired into ONE
+ * of them and not the other leaves half the deployed blocks stuck on their
+ * mount-time theme, and every per-component test still passes: each suite is
+ * scoped to one surface, so none of them ever asks "did the OTHER host get it
+ * too?".
+ *
+ * `hostHandlerParity.ts` cannot cover this. Its INVENTORY is the block→HOST
+ * request protocol (the "no handler → the block hangs" class); `THEME_CHANGE`
+ * is a HOST→block push, so it is legitimately absent there.
+ *
+ * WHAT THIS PINS — a RELATIONSHIP, not a component: the set of host surfaces is
+ * DERIVED from the source (every non-test AppBlocks component that opens a
+ * postMessage bridge via `usePostMessage`), not hardcoded, so the guard fails if
+ * that set GROWS (a new host surface that forgot the push) as well as if an
+ * existing host loses it. The behavioural half — that a toggle actually reaches
+ * the frame — lives in the two `*ThemeChange.browser.test.tsx` suites.
+ */
+
+const HOST_DIR = join(__dirname, '..');
+
+/** Strip block + line comments so a mention inside a comment can't satisfy the grep. */
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+/**
+ * Every AppBlocks component that owns a postMessage bridge to a block frame.
+ * Derived, so a NEW host surface is force-enrolled rather than silently exempt.
+ */
+function discoverHostSurfaces(): string[] {
+  return readdirSync(HOST_DIR)
+    .filter((f) => f.endsWith('.tsx') && !f.includes('.test.'))
+    .filter((f) =>
+      /\busePostMessage\s*\(/.test(stripComments(readFileSync(join(HOST_DIR, f), 'utf8')))
+    )
+    .sort();
+}
+
+describe('THEME_CHANGE host-surface ledger', () => {
+  it('the set of postMessage host surfaces is exactly the two known hosts', () => {
+    // A change here is not necessarily a bug — but it MUST be a decision. A new
+    // host surface has to either push THEME_CHANGE (add it below) or state why
+    // it does not.
+    expect(discoverHostSurfaces()).toEqual(['IframeHost.tsx', 'PageBlockHost.tsx']);
+  });
+
+  it('EVERY host surface pushes THEME_CHANGE', () => {
+    const missing = discoverHostSurfaces().filter(
+      (f) => !/send\(\s*'THEME_CHANGE'/.test(stripComments(readFileSync(join(HOST_DIR, f), 'utf8')))
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it('the grep is not vacuous — it rejects a comment-only mention', () => {
+    // Positive control on the STRIPPER: without it, the long explanatory comment
+    // each host carries about THEME_CHANGE would satisfy the check above on a
+    // host that never actually calls send().
+    const commentOnly = `
+      // send('THEME_CHANGE', { theme });
+      /* send('THEME_CHANGE', { theme }); */
+      export function FakeHost() { usePostMessage({}); return null; }
+    `;
+    const stripped = stripComments(commentOnly);
+    expect(/send\(\s*'THEME_CHANGE'/.test(stripped)).toBe(false);
+    // ...while a real call site still matches.
+    expect(/send\(\s*'THEME_CHANGE'/.test(stripComments("send('THEME_CHANGE', { theme });"))).toBe(
+      true
+    );
+  });
+});

--- a/src/components/AppBlocks/__tests__/hostThemeChangeParity.test.ts
+++ b/src/components/AppBlocks/__tests__/hostThemeChangeParity.test.ts
@@ -1,6 +1,16 @@
-import { readdirSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
 
 /**
  * THEME_CHANGE host-surface LEDGER.
@@ -18,47 +28,206 @@ import { describe, expect, it } from 'vitest';
  * request protocol (the "no handler → the block hangs" class); `THEME_CHANGE`
  * is a HOST→block push, so it is legitimately absent there.
  *
- * WHAT THIS PINS — a RELATIONSHIP, not a component: the set of host surfaces is
- * DERIVED from the source (every non-test AppBlocks component that opens a
- * postMessage bridge via `usePostMessage`), not hardcoded, so the guard fails if
- * that set GROWS (a new host surface that forgot the push) as well as if an
- * existing host loses it. The behavioural half — that a toggle actually reaches
- * the frame — lives in the two `*ThemeChange.browser.test.tsx` suites.
+ * WHAT THIS PINS — a RELATIONSHIP, not a component. Two halves, because either
+ * one alone is satisfiable by a surface that does nothing:
+ *
+ *   1. MEMBERSHIP. The host set is DERIVED from what a host IS — a module that
+ *      IMPORTS the shared bridge hook `usePostMessage` and CALLS it, i.e. owns a
+ *      `send` aimed at a block frame — not from where its file happens to sit.
+ *      Discovery walks `src/` RECURSIVELY over every `.ts`/`.tsx`/`.js`/`.jsx`
+ *      source, so a new host is force-enrolled whether it is a `.ts` hook, sits
+ *      in a subdirectory, or lives outside `src/components/AppBlocks/`
+ *      entirely. (The previous version of this file read ONE directory with a
+ *      `.tsx` filter, so all three of those shapes were discovered as NOTHING
+ *      and both ledger tests still passed. The claim was false; this is the fix.)
+ *
+ *   2. BEHAVIOUR. Every discovered host must have a `*.browser.test.tsx` that
+ *      IMPORTS THAT HOST MODULE (resolved through the import specifier, so a
+ *      rename or a move breaks the link) and asserts on `THEME_CHANGE`. The
+ *      source grep in (1) is a text check and text cannot tell a live call from
+ *      `if (false) { send('THEME_CHANGE', …) }` — only the browser suite, which
+ *      renders the real host against a real frame, can. Without this half a new
+ *      surface could satisfy the ledger while never pushing anything.
+ *
+ * SCOPE OF THE CLAIM, stated so it can be checked rather than believed: the walk
+ * root is `src/` — the directory the `~` alias resolves to, and the only tree in
+ * this repo that references `usePostMessage` at all (measured repo-wide; the
+ * `apps/*` and `packages/*` workspaces cannot reach the hook, they have no path
+ * to it). A host planted outside `src/` would still be missed; if one is ever
+ * added, widen `WALK_ROOTS`.
  */
 
-const HOST_DIR = join(__dirname, '..');
+/** `<repo>/src/components/AppBlocks/__tests__` → `<repo>`. */
+const REPO_ROOT = resolve(__dirname, '..', '..', '..', '..');
+const SRC_ROOT = join(REPO_ROOT, 'src');
+const WALK_ROOTS = [SRC_ROOT];
 
-/** Strip block + line comments so a mention inside a comment can't satisfy the grep. */
+/** The shared bridge hook. Owning a call to it is what MAKES a module a host. */
+const BRIDGE_HOOK = 'usePostMessage';
+
+const SOURCE_FILE = /\.[mc]?[jt]sx?$/;
+const SKIP_DIRS = new Set(['node_modules', '.next', '.git', '__screenshots__', '__snapshots__']);
+/** `.test.`/`.spec.` of any flavour (`.browser.test.tsx`, `.dom.test.ts`), or anything under `__tests__/`. */
+const TEST_FILE = /\.(?:test|spec)\.[^.]+$|[\\/]__tests__[\\/]/;
+
+/** Strip block + line comments so a mention inside a comment can't satisfy a grep. */
 function stripComments(src: string): string {
   return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
 }
 
+/** Every source file under `root`, recursively. Absolute paths, sorted. */
+function walkSourceFiles(root: string): string[] {
+  const out: string[] = [];
+  const stack = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop() as string;
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (!SKIP_DIRS.has(entry.name)) stack.push(full);
+      } else if (entry.isFile() && SOURCE_FILE.test(entry.name)) {
+        out.push(full);
+      }
+    }
+  }
+  return out.sort();
+}
+
+/** `{ a, b as c }` named-import bindings, per `from '…'` clause. Value imports only. */
+const NAMED_IMPORT = /import\s+(type\s+)?\{([^}]*)\}\s*from\s*['"]([^'"]+)['"]/g;
+
 /**
- * Every AppBlocks component that owns a postMessage bridge to a block frame.
- * Derived, so a NEW host surface is force-enrolled rather than silently exempt.
+ * Does this (comment-stripped) source OWN a block bridge?
+ *
+ * Both halves are required. The import is what excludes `usePostMessage.ts`
+ * itself (it DECLARES the hook, so a bare call-shaped grep matches its own
+ * signature); the call is what excludes a module that merely re-exports it. A
+ * `import type { usePostMessage }` is a type reference, not a bridge.
  */
-function discoverHostSurfaces(): string[] {
-  return readdirSync(HOST_DIR)
-    .filter((f) => f.endsWith('.tsx') && !f.includes('.test.'))
-    .filter((f) =>
-      /\busePostMessage\s*\(/.test(stripComments(readFileSync(join(HOST_DIR, f), 'utf8')))
-    )
+function ownsBlockBridge(strippedSrc: string): boolean {
+  if (!new RegExp(String.raw`\b${BRIDGE_HOOK}\s*\(`).test(strippedSrc)) return false;
+  for (const match of strippedSrc.matchAll(NAMED_IMPORT)) {
+    if (match[1]) continue; // `import type { … }`
+    const bindings = match[2].split(',').map((b) =>
+      b
+        .trim()
+        .split(/\s+as\s+/)[0]
+        .trim()
+    );
+    if (bindings.includes(BRIDGE_HOOK)) return true;
+  }
+  return false;
+}
+
+/** Absolute paths of every non-test host surface under `roots`. */
+function findHostSurfaces(roots: string[]): string[] {
+  return roots
+    .flatMap((root) => walkSourceFiles(root))
+    .filter((file) => !TEST_FILE.test(file))
+    .filter((file) => ownsBlockBridge(stripComments(readFileSync(file, 'utf8'))))
     .sort();
 }
 
+/** Repo-root-relative, POSIX separators — so the LOCATION of a host is part of the ledger. */
+function repoRelative(file: string): string {
+  return relative(REPO_ROOT, file).split(sep).join('/');
+}
+
+function discoverHostSurfaces(): string[] {
+  return findHostSurfaces(WALK_ROOTS).map(repoRelative);
+}
+
+/**
+ * Resolve an import specifier to a file on disk. Handles the two forms a host
+ * can be imported by in this repo (`~/…` alias → `src/`, and relative); a bare
+ * package specifier is never a first-party host, so it resolves to null.
+ */
+function resolveImport(fromFile: string, spec: string): string | null {
+  let base: string;
+  if (spec.startsWith('~/')) base = join(SRC_ROOT, spec.slice(2));
+  else if (spec.startsWith('.')) base = resolve(dirname(fromFile), spec);
+  else return null;
+  const candidates = [
+    base,
+    `${base}.tsx`,
+    `${base}.ts`,
+    join(base, 'index.tsx'),
+    join(base, 'index.ts'),
+  ];
+  for (const candidate of candidates) {
+    if (existsSync(candidate) && statSync(candidate).isFile()) return candidate;
+  }
+  return null;
+}
+
+const BROWSER_TESTS = WALK_ROOTS.flatMap((root) => walkSourceFiles(root)).filter((f) =>
+  f.endsWith('.browser.test.tsx')
+);
+
+/** An `expect(…)` whose subject mentions THEME_CHANGE — an assertion, not a mention. */
+const THEME_CHANGE_ASSERTION = /expect\([^;]{0,200}?THEME_CHANGE/;
+
+/**
+ * The browser suites that exercise THIS host's push: they must import the host
+ * module ITSELF (matched on the RESOLVED path, so a rename or a move breaks the
+ * link rather than silently keeping it) and assert on THEME_CHANGE.
+ */
+function browserTestsCovering(hostFile: string): string[] {
+  return BROWSER_TESTS.filter((testFile) => {
+    const src = stripComments(readFileSync(testFile, 'utf8'));
+    if (!THEME_CHANGE_ASSERTION.test(src)) return false;
+    return [...src.matchAll(/from\s*['"]([^'"]+)['"]/g)].some(
+      (m) => resolveImport(testFile, m[1]) === hostFile
+    );
+  }).map(repoRelative);
+}
+
+const IFRAME_HOST = 'src/components/AppBlocks/IframeHost.tsx';
+const PAGE_BLOCK_HOST = 'src/components/AppBlocks/PageBlockHost.tsx';
+
 describe('THEME_CHANGE host-surface ledger', () => {
-  it('the set of postMessage host surfaces is exactly the two known hosts', () => {
+  it('the set of block-bridge host surfaces is exactly the two known hosts', () => {
     // A change here is not necessarily a bug — but it MUST be a decision. A new
     // host surface has to either push THEME_CHANGE (add it below) or state why
-    // it does not.
-    expect(discoverHostSurfaces()).toEqual(['IframeHost.tsx', 'PageBlockHost.tsx']);
+    // it does not. The paths are repo-relative because WHERE a host lives is
+    // part of the claim: a host that moves is a host that moved.
+    expect(discoverHostSurfaces()).toEqual([IFRAME_HOST, PAGE_BLOCK_HOST]);
   });
 
   it('EVERY host surface pushes THEME_CHANGE', () => {
-    const missing = discoverHostSurfaces().filter(
-      (f) => !/send\(\s*'THEME_CHANGE'/.test(stripComments(readFileSync(join(HOST_DIR, f), 'utf8')))
-    );
+    const missing = findHostSurfaces(WALK_ROOTS)
+      .filter((file) => !/send\(\s*'THEME_CHANGE'/.test(stripComments(readFileSync(file, 'utf8'))))
+      .map(repoRelative);
     expect(missing).toEqual([]);
+  });
+
+  it('EVERY host surface has a browser suite that exercises the push', () => {
+    // The behavioural backstop. A source grep is satisfied by a dead branch
+    // (`if (false) { send('THEME_CHANGE', …) }`) — only a suite that renders the
+    // real host against a real frame can tell. This asserts one EXISTS and is
+    // wired to this exact module; what it asserts is that suite's own job.
+    const coverage = Object.fromEntries(
+      findHostSurfaces(WALK_ROOTS).map((file) => [repoRelative(file), browserTestsCovering(file)])
+    );
+    const uncovered = Object.entries(coverage)
+      .filter(([, tests]) => tests.length === 0)
+      .map(([host]) => host);
+    expect(uncovered).toEqual([]);
+  });
+
+  it('the browser-suite mapping DISCRIMINATES — it is not matching everything', () => {
+    // Negative control on `resolveImport`. "Every host has coverage" would also
+    // pass if the resolver said yes to every file, so pin that each host's set
+    // holds ITS suite and NOT its sibling's (both suites assert on THEME_CHANGE,
+    // so only the resolved import distinguishes them).
+    const iframe = browserTestsCovering(join(REPO_ROOT, IFRAME_HOST));
+    const page = browserTestsCovering(join(REPO_ROOT, PAGE_BLOCK_HOST));
+    expect(iframe).toContain('src/components/AppBlocks/IframeHostThemeChange.browser.test.tsx');
+    expect(iframe).not.toContain(
+      'src/components/AppBlocks/PageBlockHostThemeChange.browser.test.tsx'
+    );
+    expect(page).toContain('src/components/AppBlocks/PageBlockHostThemeChange.browser.test.tsx');
+    expect(page).not.toContain('src/components/AppBlocks/IframeHostThemeChange.browser.test.tsx');
   });
 
   it('the grep is not vacuous — it rejects a comment-only mention', () => {
@@ -76,5 +245,91 @@ describe('THEME_CHANGE host-surface ledger', () => {
     expect(/send\(\s*'THEME_CHANGE'/.test(stripComments("send('THEME_CHANGE', { theme });"))).toBe(
       true
     );
+  });
+});
+
+/**
+ * POSITIVE CONTROL ON DISCOVERY ITSELF.
+ *
+ * A discovery that silently matched NOTHING would make the two ledger tests
+ * above green for the wrong reason — `[]` has no member missing the push and no
+ * member missing a browser suite. The exact-set assertion catches the total
+ * failure; these cases catch the PARTIAL one, by driving the same walker +
+ * predicate over a synthetic tree containing precisely the shapes that used to
+ * be invisible: a `.ts` file, a subdirectory, and a location outside
+ * `components/AppBlocks/`.
+ */
+describe('host discovery finds a host by SHAPE, not by filename or directory', () => {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), 'appblocks-host-ledger-'));
+
+  afterAll(() => rmSync(fixtureRoot, { recursive: true, force: true }));
+
+  function write(relPath: string, contents: string): string {
+    const full = join(fixtureRoot, relPath);
+    mkdirSync(dirname(full), { recursive: true });
+    writeFileSync(full, contents, 'utf8');
+    return full;
+  }
+
+  const bridge = (call = `usePostMessage({ iframeRef, expectedOrigin })`) => `
+    import { useRef } from 'react';
+    import { usePostMessage } from '~/components/AppBlocks/usePostMessage';
+    export function Host() {
+      const iframeRef = useRef(null);
+      const { send } = ${call};
+      send('THEME_CHANGE', { theme: 'dark' });
+      return null;
+    }
+  `;
+
+  // The three shapes the old one-directory `.tsx` readdir could not see...
+  const tsHookInSubdir = write('components/AppBlocks/hosts/useBlockBridge.ts', bridge());
+  const deepHost = write('components/Apps/review/nested/StrangeHost.tsx', bridge());
+  const outsideAppBlocks = write('features/embeds/EmbedHost.tsx', bridge());
+
+  // ...and the things that must STAY out.
+  write(
+    'components/Apps/RendersAHost.tsx',
+    `import { PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
+     export const W = () => <PageBlockHost theme="dark" />;`
+  );
+  write(
+    'components/AppBlocks/CommentOnly.tsx',
+    `// PageBlockHost derives its transport internally (usePostMessage), so nothing is needed here.
+     export const C = () => null;`
+  );
+  write(
+    'components/AppBlocks/usePostMessage.ts',
+    `export function usePostMessage(opts: unknown) { return opts; }`
+  );
+  // Synthetic-on-purpose: a call shape whose ONLY import of the hook is
+  // type-only, so the `import type` branch of `ownsBlockBridge` is what excludes
+  // it (the call grep alone would enrol it).
+  write(
+    'components/AppBlocks/TypeOnly.tsx',
+    `import type { usePostMessage } from './usePostMessage';
+     export const shape = usePostMessage({});`
+  );
+  write('components/AppBlocks/SomeHost.browser.test.tsx', bridge());
+  write('components/AppBlocks/__tests__/someLedger.test.ts', bridge());
+
+  it('finds a .ts hook, a nested subdirectory, and a file outside components/AppBlocks', () => {
+    expect(findHostSurfaces([fixtureRoot])).toEqual(
+      [deepHost, outsideAppBlocks, tsHookInSubdir].sort()
+    );
+  });
+
+  it('does not enrol a wrapper, a comment, the hook itself, a type-only import, or a test', () => {
+    const found = findHostSurfaces([fixtureRoot]);
+    for (const notAHost of [
+      'RendersAHost.tsx',
+      'CommentOnly.tsx',
+      'usePostMessage.ts',
+      'TypeOnly.tsx',
+      'SomeHost.browser.test.tsx',
+      'someLedger.test.ts',
+    ]) {
+      expect(found.filter((f) => f.endsWith(notAHost))).toEqual([]);
+    }
   });
 });

--- a/src/components/AppBlocks/blockIframeUrl.ts
+++ b/src/components/AppBlocks/blockIframeUrl.ts
@@ -74,9 +74,11 @@
 // Today nothing changes these three values for a MOUNTED block:
 //   - `renderMode` is a per-install constant (`'iframe'` at every iframe call
 //     site) and cannot change without a remount;
-//   - `theme` CAN change (the viewer toggles dark mode) but the host has never
-//     propagated that to a live block — `BLOCK_INIT` is deduped by the SDK, so
-//     a later theme value never reaches it;
+//   - `theme` CAN change (the viewer toggles dark mode), and the host DOES now
+//     propagate it — over the `THEME_CHANGE` postMessage push, NOT through this
+//     fragment (`BLOCK_INIT` is deduped by the SDK, and re-writing the fragment
+//     would navigate a third-party frame; see `useBlockIframeSrc`'s freeze).
+//     Nothing here changes for a mounted block;
 //   - `blockInstanceId` is immutable per mount.
 // So the hosts FREEZE the fragment at mount (see `useBlockIframeSrc.ts`) and
 // the observable behaviour of a running block is unchanged by this module. The

--- a/src/components/AppBlocks/useBlockIframeSrc.ts
+++ b/src/components/AppBlocks/useBlockIframeSrc.ts
@@ -17,10 +17,16 @@ import { buildBlockIframeSrc, type BlockInitFragmentFields } from './blockIframe
  * If the fragment tracked it, the iframe's `src` ATTRIBUTE would change on a
  * theme toggle — a navigation of a third-party frame where today there is
  * none. At best that is a `hashchange` inside the block; at worst a reload that
- * discards its in-progress state. In exchange for nothing: the host does not
- * propagate live theme changes to blocks today either, because the SDK dedupes
- * `BLOCK_INIT` and no theme-change message exists. Freezing keeps the rendered
- * `src` exactly as stable as it is today.
+ * discards its in-progress state. Freezing keeps the rendered `src` exactly as
+ * stable as it is today.
+ *
+ * A live theme toggle now reaches the block over the `THEME_CHANGE` postMessage
+ * push instead (see the effects in `IframeHost.tsx` / `PageBlockHost.tsx`) — a
+ * message, not a navigation. That is what makes the freeze free: the fragment
+ * is a first-paint fast path only, and it never has to carry an update. An
+ * earlier version of this comment said the host "does not propagate live theme
+ * changes to blocks today either" — true when written, no longer true, and
+ * exactly the sentence that would have justified un-freezing the fragment.
  *
  * This invariant is the safety argument for the whole fast path, so it is
  * pinned directly by `BlockInitFragmentFreeze.browser.test.tsx` — mount, change


### PR DESCRIPTION
Posts a `THEME_CHANGE` message to every mounted block iframe when the viewer toggles the site theme — on **both** host surfaces.

Pairs with the SDK side: **civitai/civitai-app-starters#217**

## The gap

A block gets its theme exactly once. `BLOCK_INIT` carries `theme`, and (where `blockInitFragmentGate` is on) so does the iframe URL fragment. Neither can move afterwards:

- **`BLOCK_INIT` is DEDUPED** SDK-side — only the first is honored, because we re-send it on a ~400ms interval until `BLOCK_READY`.
- **The fragment is FROZEN at mount** by `useBlockIframeSrc`, on purpose: moving the `src` attribute of a live third-party iframe is a navigation.

So a viewer flipping dark mode leaves every open block rendering its mount-time theme until reloaded.

## Both surfaces, because they do not share a bridge

`IframeHost.tsx` (`model.sidebar_top`) and `PageBlockHost.tsx` (`/apps/run/<slug>`) each hand-register their own postMessage wiring. **Wiring one and not the other is the classic miss here**, and no single-surface suite can see it — each suite is scoped to one host, so none of them ever asks whether the other got it too. `hostHandlerParity.ts` can't help either: its `INVENTORY` is the block→**HOST** request protocol (the "no handler → the block hangs" class), and this is a **HOST→block** push, so it legitimately does not belong there.

`__tests__/hostThemeChangeParity.test.ts` closes that seam by pinning a **relationship, not a component**: it *derives* the host set from the source — every non-test AppBlocks component that calls `usePostMessage` — and fails if that set **grows** (a new host surface that forgot the push) as well as if a member drops it. It carries its own positive control proving the comment-stripper isn't satisfied by the long explanatory comment each host now has.

## Effect ordering turned out to be load-bearing

The push effect is declared **before** the init-handshake effect on both hosts. React runs effects in declaration order, so it has to run while `initSentRef` is still `false` — otherwise the gate is **inert on mount**.

Measured: with the effect declared *after* the init effect (where it originally landed on `PageBlockHost`), the mount sequence was `BLOCK_INIT → TOKEN_REFRESH → THEME_CHANGE` — a redundant push immediately after our own init. Both browser suites now assert the mount sequence, so a reorder goes red. (The `TOKEN_REFRESH` in that sequence is pre-existing and out of scope.)

To observe a **mount-time** post at all, the suites install a tap on the `contentWindow` getter *before* render and wrap `postMessage` on the real Window — the normal listener helper can only attach after React commits, so it is structurally blind to exactly the post the gate exists to prevent. The tap returns the **real** window (not a Proxy) so `usePostMessage`'s `event.source === contentWindow` identity pin still holds.

## Also in this PR

- **Consolidation.** `IframeHost` open-coded `modelCtx.theme ?? 'light'` at each reader; the push would have been a third copy, so it is now one `activeTheme`.
- **Comment corrections.** `blockIframeUrl.ts` and `useBlockIframeSrc.ts` both asserted the host "does not propagate live theme changes to blocks today either" — true when written, false now, and precisely the sentence that would justify un-freezing the fragment. The freeze is now *more* clearly correct: the update travels as a message, never as a navigation.
- **`reviewMode`:** deliberately **not** gated. The theme is neither side-effecting nor private, and the mod-review sandbox should render in the moderator's own color scheme like every other surface. Flagged as a small reversible call.

## Back-compat

Additive, and no block is required to do anything. A deployed block on an older SDK has no handler for `THEME_CHANGE` — not `BLOCK_INIT`, not `TOKEN_REFRESH`, no `requestId` to match a pending request, no push listener — so its transport drops it on the no-op tail. Nothing here awaits a reply, so this host is equally correct against old and new blocks.

A pre-ack toggle cannot strand a block either: `buildInitPayload` re-reads the theme on **every** retry tick, so the `BLOCK_INIT` the block finally accepts carries the current theme whether or not any push was heard. That is asserted directly rather than relying on the push.

## Ordering with the SDK PR

**Either can merge first; there is no window in which anything breaks.**

- **This PR needs no new SDK version.** `usePostMessage`'s `send` is `(type: string, payload?: unknown)`, so we post `THEME_CHANGE` without importing the new type. (We pin `@civitai/app-sdk@^0.14.0` and use it only for `BlockToParentMessageType` in `hostHandlerParity.ts`.)
- **Host first:** we push a message no deployed block understands → dropped. Themes behave exactly as today.
- **SDK first:** blocks can handle a message no host sends yet → the theme never moves. Exactly as today.
- The user-visible fix lands once both have shipped **and** a block has upgraded `@civitai/blocks-react` and re-deployed.

## Verification

`pnpm typecheck` (the repo's wrapper, which is what distinguishes a clean run from an OOM abort):

```
typecheck: OK — 0 type errors in 115s (heap cap 8192 MB).
```

`eslint` on every changed file: **0 errors**, 2 warnings — both pre-existing `react-hooks/exhaustive-deps` warnings on hooks this PR does not touch.

> The new browser tests deliberately use the `importOriginal` spread rather than a wholesale `vi.mock('~/utils/trpc')` factory. The wholesale form is what the sibling AppBlocks browser suites do and it **errors** under `local-rules/no-wholesale-module-mock` — the rule that exists because such a factory silently disables an entire file (0 tests collected, reported green). Following the rule instead of copying the violation.

`prettier --check`: the three new files pass. `IframeHost.tsx` / `PageBlockHost.tsx` are flagged, but **so are their `origin/main` versions** — pre-existing, so they are deliberately not reformatted (that would bury this diff). Prettier's output for both files was diffed against the working copy and touches **none** of the added lines.

Test files under `src/**/__tests__/**` are excluded from `tsconfig.json`, so `hostThemeChangeParity.test.ts` was typechecked explicitly via a temporary config: **0 errors in that file**, and `--listFilesOnly` confirms it was actually in the program (positive control). That run also surfaced a **pre-existing 671-error backlog** across the excluded `__tests__` tree, untouched here — worth its own issue.

### Test results — both tiers

```
component (chromium)  src/components/AppBlocks/   30 files, 346 passed (346)
unit                  src/components/AppBlocks/   32 files, 562 passed (562)
```

New: 5 + 5 browser tests (one suite per host) + 3 ledger tests.

### Mutation matrix — every guard was watched go red, for its own reason

| # | Mutation | Component tier | Ledger tier |
|---|---|---|---|
| H1 | Remove the push from **IframeHost only** (the one-surface miss) | 2 failed | **`EVERY host surface pushes THEME_CHANGE` failed** |
| H2 | Remove the push from **PageBlockHost only** | 2 failed | **same ledger test failed** |
| H3 | `IframeHost` sends a constant `'light'` instead of the live theme | 2 failed | passes (correctly — it's a value bug, not a wiring one) |
| H4 | `PageBlockHost` effect fires on every render (deps removed) | 4 failed, incl. `an unrelated re-render pushes NOTHING` | passes |
| H5 | `IframeHost` drops the `initSentRef` gate | 1 failed — `pushes NOTHING before the first BLOCK_INIT` | passes |
| H6 | `PageBlockHost` drops the `initSentRef` gate | 1 failed — same test | passes |
| H7 | Move `PageBlockHost`'s effect **below** the init effect (ordering regression) | 1 failed — same test | passes |

Restored → 346 + 3 passed.

> H5 **survived** on the first run — the gate had no killing test, because the listener could only attach after mount. That is what prompted the `contentWindow` tap and the ordering fix in H7; both were added specifically to make the gate reachable rather than left as an unproven guard.
