### PR TITLE
security(auth): enforce hub admin authorization in hooks.server

### DIFF
--- a/apps/auth/src/hooks.server.ts
+++ b/apps/auth/src/hooks.server.ts
@@ -3,8 +3,14 @@ import { SESSION_COOKIE } from '$lib/server/auth/session';
 import { verifier } from '$lib/server/auth/verifier';
 import { getOrProduceSessionUser } from '$lib/server/auth/session-producer';
 import { allowedCorsOrigin } from '$lib/server/cors';
+import { isAdminPath, isHubAdmin } from '$lib/server/auth/admin';
 import { unhandledErrorsTotal } from '$lib/server/metrics';
 import { logAxiomError } from '$lib/server/axiom';
+
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+// One body for every rejection, so the response says nothing about which admin routes exist.
+const forbidden = () => new Response('Forbidden', { status: 403 });
 
 // CORS preflight headers — credentialed, so Allow-Origin MUST echo the exact origin (never `*`).
 const preflightHeaders = (origin: string) => ({
@@ -40,6 +46,28 @@ export const handle: Handle = async ({ event, resolve }) => {
       event.locals.tokenId = claims.jti;
       // Impersonation (F): the moderator's id, if this is an impersonation session — read by the exit route.
       event.locals.impersonatedBy = claims.impersonatedBy;
+    }
+  }
+
+  // Authorization for the admin area. This is the gate: it runs ahead of routing, so one check covers every
+  // request method and every route under /admin, including routes added after this was written.
+  // +layout.server.ts keeps its own equivalent check as a second layer.
+  if (isAdminPath(event.url.pathname)) {
+    // Scoped stand-in for SvelteKit's form-origin check, which is disabled app-wide for the OAuth machine
+    // endpoints (see svelte.config.js).
+    const origin = event.request.headers.get('origin');
+    if (MUTATING_METHODS.has(event.request.method) && origin !== event.url.origin)
+      return forbidden();
+
+    if (!isHubAdmin(event.locals.user)) {
+      if (!event.locals.user && event.request.method === 'GET') {
+        const returnUrl = encodeURIComponent(event.url.pathname + event.url.search);
+        return new Response(null, {
+          status: 303,
+          headers: { location: `/login?returnUrl=${returnUrl}` },
+        });
+      }
+      return forbidden();
     }
   }
 

--- a/apps/auth/src/hooks.server.ts
+++ b/apps/auth/src/hooks.server.ts
@@ -3,7 +3,7 @@ import { SESSION_COOKIE } from '$lib/server/auth/session';
 import { verifier } from '$lib/server/auth/verifier';
 import { getOrProduceSessionUser } from '$lib/server/auth/session-producer';
 import { allowedCorsOrigin } from '$lib/server/cors';
-import { isAdminPath, isHubAdmin } from '$lib/server/auth/admin';
+import { isAdminRequest, isHubAdmin } from '$lib/server/auth/admin';
 import { unhandledErrorsTotal } from '$lib/server/metrics';
 import { logAxiomError } from '$lib/server/axiom';
 
@@ -49,10 +49,10 @@ export const handle: Handle = async ({ event, resolve }) => {
     }
   }
 
-  // Authorization for the admin area. This is the gate: it runs ahead of routing, so one check covers every
-  // request method and every route under /admin, including routes added after this was written.
+  // Authorization for the admin area. This is the gate: it runs before any route's own code, so one check
+  // covers every request method and every route under /admin, including routes added after this was written.
   // +layout.server.ts keeps its own equivalent check as a second layer.
-  if (isAdminPath(event.url.pathname)) {
+  if (isAdminRequest(event.url.pathname, event.route?.id)) {
     // Scoped stand-in for SvelteKit's form-origin check, which is disabled app-wide for the OAuth machine
     // endpoints (see svelte.config.js).
     const origin = event.request.headers.get('origin');

--- a/apps/auth/src/lib/server/auth/admin.ts
+++ b/apps/auth/src/lib/server/auth/admin.ts
@@ -26,9 +26,16 @@ export function isAdminPath(pathname: string): boolean {
   return pathname === '/admin' || pathname.startsWith('/admin/');
 }
 
-// Mirrors SvelteKit's own `decode_pathname` (src/utils/url.js), which is what it matches routes against.
-// %25 is held back so an encoded percent is not decoded twice.
-function decodePathname(pathname: string): string {
+/**
+ * Mirror of SvelteKit's `decode_pathname` (src/utils/url.js) — the form it resolves routes against. Holding
+ * `%25` back keeps an encoded percent from decoding twice, and an undecodable path is returned verbatim so it
+ * still matches the prefix rather than slipping past it.
+ *
+ * Exported so a test can pin the mirror against literal expected output. Going through `isAdminRequest`
+ * cannot do that: several wrong rewrites of this function produce the same admin/not-admin verdict, so the
+ * only thing that catches them drifting from kit is the returned string itself.
+ */
+export function decodePathname(pathname: string): string {
   try {
     return pathname.split('%25').map(decodeURI).join('%25');
   } catch {
@@ -39,15 +46,14 @@ function decodePathname(pathname: string): string {
 /**
  * Whether a request belongs to the admin area.
  *
- * `routeId` is the authoritative arm: SvelteKit resolves routes against the DECODED pathname while
- * `url.pathname` keeps the spelling the client sent, so the two can disagree and the routed id is what
- * actually executes. The pathname arms are kept so an /admin request that matches no route is still
- * rejected here rather than falling through.
+ * The decoded pathname is what SvelteKit resolves routes against, so it is what has to agree with the router;
+ * `url.pathname` keeps whatever spelling the client sent and can differ. The raw pathname needs no arm of its
+ * own — it contains no escape to decode, so it survives `decodePathname` unchanged.
+ *
+ * `routeId` adds nothing while this app configures no `reroute` hook and no `paths.base`, since the routed id
+ * then always agrees with the decoded pathname. It is here as cover for the day one of those is added, which
+ * would let a request reach an admin route from a path that does not resemble one.
  */
 export function isAdminRequest(pathname: string, routeId: string | null | undefined): boolean {
-  return (
-    isAdminPath(pathname) ||
-    isAdminPath(decodePathname(pathname)) ||
-    (!!routeId && isAdminPath(routeId))
-  );
+  return isAdminPath(decodePathname(pathname)) || (!!routeId && isAdminPath(routeId));
 }

--- a/apps/auth/src/lib/server/auth/admin.ts
+++ b/apps/auth/src/lib/server/auth/admin.ts
@@ -17,3 +17,11 @@ export const ADMIN_USER_IDS: ReadonlySet<number> = new Set(
 export function isHubAdmin(user: Pick<SessionUser, 'id'> | undefined | null): boolean {
   return !!user && ADMIN_USER_IDS.has(user.id);
 }
+
+/**
+ * Paths belonging to the admin area. Matched on the path prefix rather than against the route table so that
+ * a route added under /admin later is covered by the guard without anyone having to remember to list it.
+ */
+export function isAdminPath(pathname: string): boolean {
+  return pathname === '/admin' || pathname.startsWith('/admin/');
+}

--- a/apps/auth/src/lib/server/auth/admin.ts
+++ b/apps/auth/src/lib/server/auth/admin.ts
@@ -19,9 +19,35 @@ export function isHubAdmin(user: Pick<SessionUser, 'id'> | undefined | null): bo
 }
 
 /**
- * Paths belonging to the admin area. Matched on the path prefix rather than against the route table so that
- * a route added under /admin later is covered by the guard without anyone having to remember to list it.
+ * Paths and route ids belonging to the admin area. Matched on the prefix rather than against a list of known
+ * routes so that a route added under /admin later is covered without anyone having to remember to list it.
  */
 export function isAdminPath(pathname: string): boolean {
   return pathname === '/admin' || pathname.startsWith('/admin/');
+}
+
+// Mirrors SvelteKit's own `decode_pathname` (src/utils/url.js), which is what it matches routes against.
+// %25 is held back so an encoded percent is not decoded twice.
+function decodePathname(pathname: string): string {
+  try {
+    return pathname.split('%25').map(decodeURI).join('%25');
+  } catch {
+    return pathname;
+  }
+}
+
+/**
+ * Whether a request belongs to the admin area.
+ *
+ * `routeId` is the authoritative arm: SvelteKit resolves routes against the DECODED pathname while
+ * `url.pathname` keeps the spelling the client sent, so the two can disagree and the routed id is what
+ * actually executes. The pathname arms are kept so an /admin request that matches no route is still
+ * rejected here rather than falling through.
+ */
+export function isAdminRequest(pathname: string, routeId: string | null | undefined): boolean {
+  return (
+    isAdminPath(pathname) ||
+    isAdminPath(decodePathname(pathname)) ||
+    (!!routeId && isAdminPath(routeId))
+  );
 }

--- a/apps/auth/src/routes/admin/+layout.server.ts
+++ b/apps/auth/src/routes/admin/+layout.server.ts
@@ -2,8 +2,8 @@ import { error, redirect } from '@sveltejs/kit';
 import type { LayoutServerLoad } from './$types';
 import { isHubAdmin } from '$lib/server/auth/admin';
 
-// Gate for the whole /admin area. Runs for every route under /admin, so the 403 here protects the
-// landing page AND every sub-page (e.g. /admin/spoke-domains) — no per-page check needed.
+// Second layer only. The gate for /admin is in hooks.server.ts, which is what covers form actions and any
+// other non-GET request; a layout `load` does not run early enough to be relied on for that.
 export const load: LayoutServerLoad = async ({ locals, url }) => {
   if (!locals.user) {
     redirect(303, `/login?returnUrl=${encodeURIComponent(url.pathname + url.search)}`);

--- a/apps/auth/src/routes/admin/__tests__/admin-allowlist.test.ts
+++ b/apps/auth/src/routes/admin/__tests__/admin-allowlist.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `admin.ts` parses AUTH_ADMIN_USER_IDS once at module load and documents that it fails CLOSED — a missing or
+ * unusable value must grant nobody, never everybody. Nothing exercised that: the guard suite always sets a
+ * populated allowlist, so a "no admins configured means no restriction" regression passed every test there.
+ *
+ * Each case re-imports the module under a different env, since the allowlist is built at load.
+ */
+async function loadWith(value: string | undefined) {
+  vi.resetModules();
+  const previous = process.env.AUTH_ADMIN_USER_IDS;
+  if (value === undefined) delete process.env.AUTH_ADMIN_USER_IDS;
+  else process.env.AUTH_ADMIN_USER_IDS = value;
+  try {
+    return await import('$lib/server/auth/admin');
+  } finally {
+    if (previous === undefined) delete process.env.AUTH_ADMIN_USER_IDS;
+    else process.env.AUTH_ADMIN_USER_IDS = previous;
+  }
+}
+
+afterEach(() => vi.resetModules());
+
+describe('hub admin allowlist', () => {
+  // Positive control: proves this loader can produce a populated allowlist, so the empty results below are
+  // a fact about the parsing and not about the harness.
+  it('admits a listed id when the allowlist is populated', async () => {
+    const { ADMIN_USER_IDS, isHubAdmin } = await loadWith('1,5');
+
+    expect([...ADMIN_USER_IDS].sort()).toEqual([1, 5]);
+    expect(isHubAdmin({ id: 5 })).toBe(true);
+    expect(isHubAdmin({ id: 9 })).toBe(false);
+  });
+
+  it.each([
+    ['unset', undefined],
+    ['empty', ''],
+    ['whitespace', '   '],
+    ['non-numeric', 'admin,root'],
+    ['zero and negative', '0,-1'],
+    ['separators only', ',,,'],
+  ])('grants nobody when the allowlist is %s', async (_label, value) => {
+    const { ADMIN_USER_IDS, isHubAdmin } = await loadWith(value);
+
+    expect(ADMIN_USER_IDS.size).toBe(0);
+    expect(isHubAdmin({ id: 1 })).toBe(false);
+    expect(isHubAdmin({ id: 0 })).toBe(false);
+  });
+
+  it('keeps only the valid ids when the value is partly unusable', async () => {
+    const { ADMIN_USER_IDS, isHubAdmin } = await loadWith('1,abc,-2,7');
+
+    expect([...ADMIN_USER_IDS].sort()).toEqual([1, 7]);
+    expect(isHubAdmin({ id: 1 })).toBe(true);
+    expect(isHubAdmin({ id: 2 })).toBe(false);
+  });
+
+  it('admits nobody when there is no user, whatever the allowlist says', async () => {
+    const { isHubAdmin } = await loadWith('1');
+
+    expect(isHubAdmin(undefined)).toBe(false);
+    expect(isHubAdmin(null)).toBe(false);
+  });
+});

--- a/apps/auth/src/routes/admin/__tests__/admin-guard.test.ts
+++ b/apps/auth/src/routes/admin/__tests__/admin-guard.test.ts
@@ -212,12 +212,25 @@ const ADMIN_ACTIONS: Scenario[] = [
 /**
  * Drives the real `handle` hook the way SvelteKit does — the hook wraps `resolve`, and the form action runs
  * inside `resolve`. So `resolve` never being called is exactly "the action never ran".
+ *
+ * The requested path and the routed id are settable INDEPENDENTLY on purpose. SvelteKit matches routes on the
+ * decoded pathname while `event.url.pathname` stays as sent, so the two can legitimately disagree; a harness
+ * that derives one from the other cannot express that case at all, and silently shares whatever assumption
+ * the code under test makes. `routedId: null` models "no route matched".
  */
 async function post(
   scenario: Scenario,
-  opts: { sessionUserId?: number; origin?: string | null } = {}
+  opts: {
+    sessionUserId?: number;
+    origin?: string | null;
+    rawPath?: string;
+    routedId?: string | null;
+  } = {}
 ) {
-  const url = new URL(`${ORIGIN}${scenario.path}?/${scenario.action}`);
+  const rawPath = opts.rawPath ?? scenario.path;
+  const routedId = opts.routedId === undefined ? scenario.routeId : opts.routedId;
+
+  const url = new URL(`${ORIGIN}${rawPath}?/${scenario.action}`);
   const headers = new Headers({ 'content-type': 'application/x-www-form-urlencoded' });
   const origin = opts.origin === undefined ? ORIGIN : opts.origin;
   if (origin !== null) headers.set('origin', origin);
@@ -234,13 +247,15 @@ async function post(
   const event = {
     url,
     request,
+    route: { id: routedId },
     params: scenario.params ?? {},
     locals: {} as Record<string, unknown>,
     cookies: { get: (name: string) => cookies.get(name) },
   };
 
   const resolve = vi.fn(async (ev: typeof event) => {
-    const mod = await ACTION_MODULES[scenario.routeId]();
+    if (routedId === null) return new Response('Not found', { status: 404 });
+    const mod = await ACTION_MODULES[routedId]();
     const action = mod.actions[scenario.action] as (arg: unknown) => Promise<unknown>;
     const result = await action({
       request: ev.request,
@@ -255,6 +270,9 @@ async function post(
   const response = await handle({ event: event as any, resolve: resolve as any });
   return { response, actionRan: resolve.mock.calls.length > 0 };
 }
+
+/** Percent-encode the first character of a path segment — decodes back to the same route. */
+const encodeFirstChar = (path: string) => `/%${path.charCodeAt(1).toString(16)}${path.slice(2)}`;
 
 beforeEach(() => {
   writes.length = 0;
@@ -297,23 +315,95 @@ describe('hub /admin authorization', () => {
       expect(actionRan).toBe(false);
       expect(response.status).toBe(403);
     });
+
+    // A missing Origin must be treated as untrusted, not waved through. Without this case a guard that
+    // fails open on the absent header passes every other test in this file.
+    it('is rejected with 403 and performs no write when the Origin header is absent', async () => {
+      const { response, actionRan } = await post(scenario, {
+        sessionUserId: ADMIN_USER_ID,
+        origin: null,
+      });
+
+      expect(writes).toEqual([]);
+      expect(actionRan).toBe(false);
+      expect(response.status).toBe(403);
+    });
+
+    // SvelteKit routes on the decoded pathname, so a percent-encoded path reaches the same action while
+    // spelling `event.url.pathname` differently. The guard has to agree with the router, not with the string.
+    it('is rejected with 403 and performs no write for a percent-encoded path that routes here', async () => {
+      const { response, actionRan } = await post(scenario, {
+        rawPath: encodeFirstChar(scenario.path),
+      });
+
+      expect(writes).toEqual([]);
+      expect(actionRan).toBe(false);
+      expect(response.status).toBe(403);
+    });
   });
 });
 
 describe('hub /admin guard shape', () => {
   const anyScenario = ADMIN_ACTIONS[0];
 
-  it('answers identically for a real and an unknown admin route, so it leaks no route inventory', async () => {
+  // Scope: this is about the hook's OWN responses. SvelteKit normalizes a trailing slash with a 308 before
+  // `handle` runs, and only for a path that matched a route, so the hook is not the only thing answering and
+  // cannot make every /admin request indistinguishable.
+  it('answers identically for a matched and an unmatched admin path', async () => {
     const real = await post(anyScenario);
-    const unknown = await post({ ...anyScenario, path: '/admin/no-such-route-here' });
+    const unknown = await post(anyScenario, {
+      rawPath: '/admin/no-such-route-here',
+      routedId: null,
+    });
 
     expect(real.response.status).toBe(403);
     expect(unknown.response.status).toBe(403);
     expect(await unknown.response.text()).toBe(await real.response.text());
   });
 
-  it('covers an admin route that does not exist yet, because it matches on path not on route id', async () => {
-    const { response, actionRan } = await post({ ...anyScenario, path: '/admin/future-route' });
+  it('rejects an unmatched /admin path rather than letting it fall through', async () => {
+    const { response, actionRan } = await post(anyScenario, {
+      rawPath: '/admin/future-route',
+      routedId: null,
+    });
+
+    expect(actionRan).toBe(false);
+    expect(response.status).toBe(403);
+  });
+
+  it('rejects a request routed to an admin route however the path was spelled', async () => {
+    const { response, actionRan } = await post(anyScenario, {
+      rawPath: '/%61dmin/spoke-domains',
+      routedId: '/admin/spoke-domains',
+    });
+
+    expect(writes).toEqual([]);
+    expect(actionRan).toBe(false);
+    expect(response.status).toBe(403);
+  });
+
+  // The two arms of the guard cover different failure modes and would otherwise mask each other, so each
+  // gets a case the other cannot answer.
+
+  // Routed-id arm alone: a `reroute` hook or a configured base path can route a request to an admin route
+  // from a path that does not resemble one, and no amount of decoding recovers that.
+  it('rejects a request whose path is not admin-like but which routes to an admin route', async () => {
+    const { response, actionRan } = await post(anyScenario, {
+      rawPath: '/somewhere-else-entirely',
+      routedId: '/admin/spoke-domains',
+    });
+
+    expect(writes).toEqual([]);
+    expect(actionRan).toBe(false);
+    expect(response.status).toBe(403);
+  });
+
+  // Decoded-pathname arm alone: an encoded admin path that matches no route has no routed id to consult.
+  it('rejects an encoded admin path that matches no route', async () => {
+    const { response, actionRan } = await post(anyScenario, {
+      rawPath: '/%61dmin/no-such-route-here',
+      routedId: null,
+    });
 
     expect(actionRan).toBe(false);
     expect(response.status).toBe(403);
@@ -324,6 +414,7 @@ describe('hub /admin guard shape', () => {
     const event = {
       url,
       request: new Request(url, { method: 'GET' }),
+      route: { id: '/admin/spoke-domains' },
       params: {},
       locals: {} as Record<string, unknown>,
       cookies: { get: () => undefined },
@@ -345,6 +436,7 @@ describe('hub /admin guard shape', () => {
     const event = {
       url,
       request: new Request(url, { method: 'POST', body: new URLSearchParams({ a: 'b' }) }),
+      route: { id: '/login' },
       params: {},
       locals: {} as Record<string, unknown>,
       cookies: { get: () => undefined },

--- a/apps/auth/src/routes/admin/__tests__/admin-guard.test.ts
+++ b/apps/auth/src/routes/admin/__tests__/admin-guard.test.ts
@@ -382,11 +382,10 @@ describe('hub /admin guard shape', () => {
     expect(response.status).toBe(403);
   });
 
-  // The two arms of the guard cover different failure modes and would otherwise mask each other, so each
-  // gets a case the other cannot answer.
+  // The guard's two arms would otherwise mask each other, so each gets a case the other cannot answer.
 
-  // Routed-id arm alone: a `reroute` hook or a configured base path can route a request to an admin route
-  // from a path that does not resemble one, and no amount of decoding recovers that.
+  // Routed-id arm alone. Nothing produces this shape while the app configures no `reroute` hook and no
+  // `paths.base`; the case is here so the arm covering that eventuality cannot rot unnoticed until it does.
   it('rejects a request whose path is not admin-like but which routes to an admin route', async () => {
     const { response, actionRan } = await post(anyScenario, {
       rawPath: '/somewhere-else-entirely',

--- a/apps/auth/src/routes/admin/__tests__/admin-guard.test.ts
+++ b/apps/auth/src/routes/admin/__tests__/admin-guard.test.ts
@@ -1,0 +1,360 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as MembershipModule from '$lib/server/auth/membership';
+import type * as RolesModule from '$lib/server/auth/roles';
+
+// `$lib/server/auth/admin` parses AUTH_ADMIN_USER_IDS once at module load, and hooks.server.ts imports it,
+// so the allowlist has to exist before either module is evaluated.
+const { writes, ADMIN_USER_ID } = vi.hoisted(() => {
+  const ADMIN_USER_ID = 1;
+  process.env.AUTH_ADMIN_USER_IDS = String(ADMIN_USER_ID);
+  return { writes: [] as string[], ADMIN_USER_ID };
+});
+
+const NON_ADMIN_USER_ID = 99;
+
+vi.mock('$lib/server/axiom', () => ({
+  logAxiomError: vi.fn(),
+  logToAxiom: vi.fn(async () => undefined),
+}));
+
+// db.ts builds a pg Pool at module load and throws without DATABASE_URL. The stub records the mutating
+// builder entrypoints, which is the write signal for the two routes that hit Kysely directly.
+vi.mock('$lib/server/db/db', () => {
+  const queryChain = (): unknown => {
+    const chain: unknown = new Proxy(
+      {},
+      {
+        get(_target, prop) {
+          if (prop === 'then') return undefined;
+          if (prop === 'execute') return async () => [];
+          if (prop === 'executeTakeFirst') return async () => ({ id: 1 });
+          return () => chain;
+        },
+      }
+    );
+    return chain;
+  };
+  return {
+    db: {
+      selectFrom: () => queryChain(),
+      insertInto: (table: string) => {
+        writes.push(`insertInto:${table}`);
+        return queryChain();
+      },
+      updateTable: (table: string) => {
+        writes.push(`updateTable:${table}`);
+        return queryChain();
+      },
+      deleteFrom: (table: string) => {
+        writes.push(`deleteFrom:${table}`);
+        return queryChain();
+      },
+    },
+  };
+});
+
+vi.mock('$lib/server/oauth/first-party', () => ({ invalidateDomainCache: vi.fn() }));
+vi.mock('$lib/server/oauth/access', () => ({ invalidateRoleCache: vi.fn() }));
+
+vi.mock('$lib/server/auth/verifier', () => ({
+  verifier: { verifyToken: async (token: string) => ({ sub: token, jti: 'jti-test' }) },
+}));
+
+vi.mock('$lib/server/auth/session-producer', () => ({
+  getOrProduceSessionUser: async (id: number) => ({ id, username: `user${id}` }),
+  invalidateSessionUser: vi.fn(),
+}));
+
+// Only the writes are replaced. The validators these actions gate on (`isOverrideTier`, `roleId`) stay real,
+// so a request that reaches the write had to pass the route's own input checks first.
+vi.mock('$lib/server/auth/membership', async (importOriginal) => ({
+  ...(await importOriginal<typeof MembershipModule>()),
+  setOverride: vi.fn(async () => {
+    writes.push('membership.setOverride');
+    return { ok: true as const, user: { id: 7, username: 'target' } };
+  }),
+  removeOverride: vi.fn(async () => {
+    writes.push('membership.removeOverride');
+  }),
+}));
+
+vi.mock('$lib/server/auth/roles', async (importOriginal) => ({
+  ...(await importOriginal<typeof RolesModule>()),
+  createRole: vi.fn(async () => {
+    writes.push('roles.createRole');
+    return true;
+  }),
+  deleteRole: vi.fn(async () => {
+    writes.push('roles.deleteRole');
+  }),
+  addMember: vi.fn(async () => {
+    writes.push('roles.addMember');
+    return { ok: true as const, user: { id: 7, username: 'target' } };
+  }),
+  removeMember: vi.fn(async () => {
+    writes.push('roles.removeMember');
+  }),
+}));
+
+import { handle } from '../../../hooks.server';
+import { SESSION_COOKIE } from '$lib/server/auth/session';
+
+const ORIGIN = 'https://auth.example.test';
+
+const ACTION_MODULES: Record<string, () => Promise<{ actions: Record<string, unknown> }>> = {
+  '/admin/spoke-domains': () => import('../spoke-domains/+page.server'),
+  '/admin/membership': () => import('../membership/+page.server'),
+  '/admin/access': () => import('../access/+page.server'),
+  '/admin/roles': () => import('../roles/+page.server'),
+  '/admin/roles/[role]': () => import('../roles/[role]/+page.server'),
+};
+
+type Scenario = {
+  name: string;
+  routeId: string;
+  path: string;
+  action: string;
+  form: Record<string, string>;
+  params?: Record<string, string>;
+  write: string;
+};
+
+/**
+ * Every named form action the admin area exposes, with input that the route's OWN validation accepts.
+ * That matters: an action rejected for a bad tier or an unparseable id would never reach its write, and a
+ * test that went green on that would prove nothing about authorization.
+ */
+const ADMIN_ACTIONS: Scenario[] = [
+  {
+    name: 'spoke-domains create',
+    routeId: '/admin/spoke-domains',
+    path: '/admin/spoke-domains',
+    action: 'create',
+    form: { domain: 'attacker.example.com', includeSubdomains: 'on', enabled: 'on', label: 'x' },
+    write: 'insertInto:TrustedSpokeDomain',
+  },
+  {
+    name: 'spoke-domains update',
+    routeId: '/admin/spoke-domains',
+    path: '/admin/spoke-domains',
+    action: 'update',
+    form: { id: '1', domain: 'attacker.example.com', enabled: 'on' },
+    write: 'updateTable:TrustedSpokeDomain',
+  },
+  {
+    name: 'spoke-domains delete',
+    routeId: '/admin/spoke-domains',
+    path: '/admin/spoke-domains',
+    action: 'delete',
+    form: { id: '1' },
+    write: 'deleteFrom:TrustedSpokeDomain',
+  },
+  {
+    name: 'membership set',
+    routeId: '/admin/membership',
+    path: '/admin/membership',
+    action: 'set',
+    form: { user: '7', tier: 'gold', note: 'x' },
+    write: 'membership.setOverride',
+  },
+  {
+    name: 'membership remove',
+    routeId: '/admin/membership',
+    path: '/admin/membership',
+    action: 'remove',
+    form: { userId: '7' },
+    write: 'membership.removeOverride',
+  },
+  {
+    name: 'access setMode',
+    routeId: '/admin/access',
+    path: '/admin/access',
+    action: 'setMode',
+    form: { id: 'some-client', accessMode: 'open' },
+    write: 'updateTable:OauthClient',
+  },
+  {
+    name: 'roles create',
+    routeId: '/admin/roles',
+    path: '/admin/roles',
+    action: 'create',
+    form: { app: 'spoke', name: 'tester', description: 'x' },
+    write: 'roles.createRole',
+  },
+  {
+    name: 'roles delete',
+    routeId: '/admin/roles',
+    path: '/admin/roles',
+    action: 'delete',
+    form: { id: 'spoke:tester' },
+    write: 'roles.deleteRole',
+  },
+  {
+    name: 'roles/[role] add',
+    routeId: '/admin/roles/[role]',
+    path: '/admin/roles/tester',
+    action: 'add',
+    form: { user: '7', note: 'x' },
+    params: { role: 'tester' },
+    write: 'roles.addMember',
+  },
+  {
+    name: 'roles/[role] remove',
+    routeId: '/admin/roles/[role]',
+    path: '/admin/roles/tester',
+    action: 'remove',
+    form: { userId: '7' },
+    params: { role: 'tester' },
+    write: 'roles.removeMember',
+  },
+];
+
+/**
+ * Drives the real `handle` hook the way SvelteKit does — the hook wraps `resolve`, and the form action runs
+ * inside `resolve`. So `resolve` never being called is exactly "the action never ran".
+ */
+async function post(
+  scenario: Scenario,
+  opts: { sessionUserId?: number; origin?: string | null } = {}
+) {
+  const url = new URL(`${ORIGIN}${scenario.path}?/${scenario.action}`);
+  const headers = new Headers({ 'content-type': 'application/x-www-form-urlencoded' });
+  const origin = opts.origin === undefined ? ORIGIN : opts.origin;
+  if (origin !== null) headers.set('origin', origin);
+
+  const cookies = new Map<string, string>();
+  if (opts.sessionUserId !== undefined) cookies.set(SESSION_COOKIE, String(opts.sessionUserId));
+
+  const request = new Request(url, {
+    method: 'POST',
+    headers,
+    body: new URLSearchParams(scenario.form),
+  });
+
+  const event = {
+    url,
+    request,
+    params: scenario.params ?? {},
+    locals: {} as Record<string, unknown>,
+    cookies: { get: (name: string) => cookies.get(name) },
+  };
+
+  const resolve = vi.fn(async (ev: typeof event) => {
+    const mod = await ACTION_MODULES[scenario.routeId]();
+    const action = mod.actions[scenario.action] as (arg: unknown) => Promise<unknown>;
+    const result = await action({
+      request: ev.request,
+      locals: ev.locals,
+      params: ev.params,
+      url: ev.url,
+    });
+    return new Response(JSON.stringify(result ?? null), { status: 200 });
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const response = await handle({ event: event as any, resolve: resolve as any });
+  return { response, actionRan: resolve.mock.calls.length > 0 };
+}
+
+beforeEach(() => {
+  writes.length = 0;
+});
+
+describe('hub /admin authorization', () => {
+  // Positive control. Without this, "0 writes" below is indistinguishable from a harness wired to nothing.
+  describe.each(ADMIN_ACTIONS)('$name', (scenario) => {
+    it('performs its write for a hub admin', async () => {
+      const { response, actionRan } = await post(scenario, { sessionUserId: ADMIN_USER_ID });
+
+      expect(actionRan).toBe(true);
+      expect(writes).toEqual([scenario.write]);
+      expect(response.status).toBe(200);
+    });
+
+    it('is rejected with 403 and performs no write without a session', async () => {
+      const { response, actionRan } = await post(scenario);
+
+      expect(writes).toEqual([]);
+      expect(actionRan).toBe(false);
+      expect(response.status).toBe(403);
+    });
+
+    it('is rejected with 403 and performs no write for a signed-in non-admin', async () => {
+      const { response, actionRan } = await post(scenario, { sessionUserId: NON_ADMIN_USER_ID });
+
+      expect(writes).toEqual([]);
+      expect(actionRan).toBe(false);
+      expect(response.status).toBe(403);
+    });
+
+    it('is rejected with 403 and performs no write for a cross-origin post', async () => {
+      const { response, actionRan } = await post(scenario, {
+        sessionUserId: ADMIN_USER_ID,
+        origin: 'https://attacker.example.test',
+      });
+
+      expect(writes).toEqual([]);
+      expect(actionRan).toBe(false);
+      expect(response.status).toBe(403);
+    });
+  });
+});
+
+describe('hub /admin guard shape', () => {
+  const anyScenario = ADMIN_ACTIONS[0];
+
+  it('answers identically for a real and an unknown admin route, so it leaks no route inventory', async () => {
+    const real = await post(anyScenario);
+    const unknown = await post({ ...anyScenario, path: '/admin/no-such-route-here' });
+
+    expect(real.response.status).toBe(403);
+    expect(unknown.response.status).toBe(403);
+    expect(await unknown.response.text()).toBe(await real.response.text());
+  });
+
+  it('covers an admin route that does not exist yet, because it matches on path not on route id', async () => {
+    const { response, actionRan } = await post({ ...anyScenario, path: '/admin/future-route' });
+
+    expect(actionRan).toBe(false);
+    expect(response.status).toBe(403);
+  });
+
+  it('redirects an unauthenticated browser GET to login instead of 403ing it', async () => {
+    const url = new URL(`${ORIGIN}/admin/spoke-domains`);
+    const event = {
+      url,
+      request: new Request(url, { method: 'GET' }),
+      params: {},
+      locals: {} as Record<string, unknown>,
+      cookies: { get: () => undefined },
+    };
+    const resolve = vi.fn(async () => new Response('ok', { status: 200 }));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const response = await handle({ event: event as any, resolve: resolve as any });
+
+    expect(resolve).not.toHaveBeenCalled();
+    expect(response.status).toBe(303);
+    expect(response.headers.get('location')).toBe(
+      `/login?returnUrl=${encodeURIComponent('/admin/spoke-domains')}`
+    );
+  });
+
+  it('leaves non-admin routes alone', async () => {
+    const url = new URL(`${ORIGIN}/login`);
+    const event = {
+      url,
+      request: new Request(url, { method: 'POST', body: new URLSearchParams({ a: 'b' }) }),
+      params: {},
+      locals: {} as Record<string, unknown>,
+      cookies: { get: () => undefined },
+    };
+    const resolve = vi.fn(async () => new Response('ok', { status: 200 }));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const response = await handle({ event: event as any, resolve: resolve as any });
+
+    expect(resolve).toHaveBeenCalled();
+    expect(response.status).toBe(200);
+  });
+});

--- a/apps/auth/src/routes/admin/__tests__/admin-path-matching.test.ts
+++ b/apps/auth/src/routes/admin/__tests__/admin-path-matching.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { decodePathname, isAdminPath, isAdminRequest } from '$lib/server/auth/admin';
+
+/**
+ * `decodePathname` exists to reproduce SvelteKit's `decode_pathname` exactly, because the guard's decision has
+ * to agree with the router's. Nothing about "does this look like an admin path" can defend that: three wrong
+ * rewrites of it (dropping the %25 hold-back, using decodeURIComponent, decoding twice) all leave the
+ * admin/not-admin answer unchanged on most inputs. So the mirror is pinned on the STRING it returns.
+ *
+ * Expected values are the literal output SvelteKit produces, not a restatement of our implementation.
+ */
+describe('decodePathname mirrors SvelteKit route decoding', () => {
+  it.each([
+    ['leaves an already-decoded path alone', '/admin/x', '/admin/x'],
+    ['decodes an escaped character once', '/%61dmin/x', '/admin/x'],
+    ['holds %25 back rather than decoding it to a percent', '/%2561dmin/x', '/%2561dmin/x'],
+    ['does not decode a reserved character', '/%2Fadmin/x', '/%2Fadmin/x'],
+    ['does not decode a reserved character mid-path', '/admin%2Fx', '/admin%2Fx'],
+    ['returns a malformed escape verbatim', '/admin/%zz', '/admin/%zz'],
+    ['returns a bare percent verbatim', '/%', '/%'],
+  ])('%s', (_label, input, expected) => {
+    expect(decodePathname(input)).toBe(expected);
+  });
+});
+
+describe('isAdminRequest', () => {
+  // The security-critical direction: an escaped path that the router still delivers to an admin route must be
+  // treated as one here. A guard that skipped decoding entirely would answer false for these.
+  it.each([
+    ['a plain admin path', '/admin/spoke-domains'],
+    ['the admin root', '/admin'],
+    ['an escaped admin path', '/%61dmin/spoke-domains'],
+    ['an escaped character later in the segment', '/adm%69n/spoke-domains'],
+    // Undecodable, so it never reaches a route — but it still reads as an admin path and is treated as one
+    // rather than being handed onward on the strength of a decode failure.
+    ['an admin path with a malformed escape', '/admin/%zz'],
+  ])('treats %s as an admin request', (_label, pathname) => {
+    expect(isAdminRequest(pathname, null)).toBe(true);
+  });
+
+  it.each([
+    ['a doubly-escaped path, which the router does not resolve to /admin', '/%2561dmin/x'],
+    ['an escaped slash, which is not a path separator to the router', '/%2Fadmin/x'],
+    ['a path that merely starts with the same letters', '/administrators'],
+    ['an unrelated path', '/login'],
+    ['the site root', '/'],
+  ])('does not treat %s as an admin request', (_label, pathname) => {
+    expect(isAdminRequest(pathname, null)).toBe(false);
+  });
+
+  it('treats a request routed to an admin route as one whatever the path looks like', () => {
+    expect(isAdminRequest('/somewhere-else', '/admin/spoke-domains')).toBe(true);
+    expect(isAdminRequest('/somewhere-else', '/admin/roles/[role]')).toBe(true);
+  });
+
+  it('does not treat a request routed elsewhere as an admin request', () => {
+    expect(isAdminRequest('/login', '/login')).toBe(false);
+    expect(isAdminRequest('/login', null)).toBe(false);
+    expect(isAdminRequest('/login', undefined)).toBe(false);
+  });
+});
+
+describe('isAdminPath', () => {
+  it('matches the admin area and paths under it, and nothing that merely looks like one', () => {
+    expect(isAdminPath('/admin')).toBe(true);
+    expect(isAdminPath('/admin/')).toBe(true);
+    expect(isAdminPath('/admin/roles/x/__data.json')).toBe(true);
+    expect(isAdminPath('/administrators')).toBe(false);
+    expect(isAdminPath('/adm')).toBe(false);
+    expect(isAdminPath('/')).toBe(false);
+    expect(isAdminPath('')).toBe(false);
+  });
+});

--- a/apps/auth/src/routes/admin/__tests__/admin-route-ledger.test.ts
+++ b/apps/auth/src/routes/admin/__tests__/admin-route-ledger.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join, relative, resolve, sep } from 'node:path';
+import { isAdminPath } from '$lib/server/auth/admin';
+
+/**
+ * The behavioural guard test proves the five admin form-action routes that exist TODAY are covered. This
+ * pins the thing that actually recurs: someone adds a sixth privileged route, or moves one, and the
+ * coverage silently stops matching the inventory.
+ *
+ * It asserts a LEDGER rather than a floor, so it fails when the set grows AND when it shrinks — a route
+ * quietly disappearing from the guarded set is the same defect as one appearing outside it.
+ */
+
+const routesDir = resolve(fileURLToPath(new URL('../../..', import.meta.url)), 'routes');
+
+function pageServerFiles(dir: string): string[] {
+  const found: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === '__tests__') continue;
+      found.push(...pageServerFiles(full));
+    } else if (entry.name === '+page.server.ts') {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+/** Route ids (`/admin/roles/[role]`) for every page that exports form actions. */
+function actionRouteIds(): string[] {
+  return pageServerFiles(routesDir)
+    .filter((file) => /^export const actions\b/m.test(readFileSync(file, 'utf8')))
+    .map((file) => `/${relative(routesDir, file).split(sep).slice(0, -1).join('/')}`)
+    .sort();
+}
+
+// Routes whose form actions are reachable without a hub-admin session BY DESIGN — they are the
+// unauthenticated / pre-consent steps of signing in. Anything else showing up outside /admin is a new
+// privileged surface that has to be looked at, which is what makes this list worth pinning.
+const PUBLIC_ACTION_ROUTES = ['/login', '/login/oauth/authorize', '/login/oauth/device'];
+
+const ADMIN_ACTION_ROUTES = [
+  '/admin/access',
+  '/admin/membership',
+  '/admin/roles',
+  '/admin/roles/[role]',
+  '/admin/spoke-domains',
+];
+
+describe('hub form-action route ledger', () => {
+  const discovered = actionRouteIds();
+
+  // Positive control: a scanner that silently found nothing would make every assertion below vacuous.
+  it('discovers the form-action routes on disk', () => {
+    expect(discovered.length).toBeGreaterThan(0);
+    expect(discovered).toContain('/admin/spoke-domains');
+  });
+
+  it('is the exact set of form-action routes in the app', () => {
+    expect(discovered).toEqual([...ADMIN_ACTION_ROUTES, ...PUBLIC_ACTION_ROUTES].sort());
+  });
+
+  it('routes every admin form-action route through the guard matcher', () => {
+    const admin = discovered.filter((id) => id.startsWith('/admin'));
+
+    expect(admin).toEqual(ADMIN_ACTION_ROUTES);
+    for (const id of admin) {
+      // Substitute a concrete value for any dynamic segment — the matcher sees request paths, not route ids.
+      expect(isAdminPath(id.replace(/\[[^\]]+\]/g, 'x'))).toBe(true);
+    }
+  });
+
+  it('matches the admin area itself and paths under it, and nothing that merely looks like one', () => {
+    expect(isAdminPath('/admin')).toBe(true);
+    expect(isAdminPath('/admin/')).toBe(true);
+    expect(isAdminPath('/admin/roles/x/__data.json')).toBe(true);
+    expect(isAdminPath('/administrators')).toBe(false);
+    expect(isAdminPath('/login')).toBe(false);
+    expect(isAdminPath('/')).toBe(false);
+  });
+});

--- a/apps/auth/src/routes/admin/__tests__/admin-route-ledger.test.ts
+++ b/apps/auth/src/routes/admin/__tests__/admin-route-ledger.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { readFileSync, readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { join, relative, resolve, sep } from 'node:path';
-import { isAdminPath } from '$lib/server/auth/admin';
+import { isAdminPath, isAdminRequest } from '$lib/server/auth/admin';
 
 /**
  * The behavioural guard test proves the five admin form-action routes that exist TODAY are covered. This
@@ -68,8 +68,10 @@ describe('hub form-action route ledger', () => {
 
     expect(admin).toEqual(ADMIN_ACTION_ROUTES);
     for (const id of admin) {
-      // Substitute a concrete value for any dynamic segment — the matcher sees request paths, not route ids.
-      expect(isAdminPath(id.replace(/\[[^\]]+\]/g, 'x'))).toBe(true);
+      // Substitute a concrete value for any dynamic segment — the pathname arm sees request paths.
+      expect(isAdminRequest(id.replace(/\[[^\]]+\]/g, 'x'), null)).toBe(true);
+      // ...and the routed-id arm must cover it on its own, whatever path spelling reached it.
+      expect(isAdminRequest('/', id)).toBe(true);
     }
   });
 

--- a/apps/auth/svelte.config.js
+++ b/apps/auth/svelte.config.js
@@ -13,6 +13,8 @@ const config = {
     // It can't be scoped per-route (it runs before the handle hook) and trustedOrigins can't cover the
     // no-Origin server-to-server case. These endpoints have their own protection (client_secret/PKCE,
     // per-client allowedOrigins, CORS); the session cookie is SameSite=Lax for the form actions.
+    // The /admin form actions do not rely on that alone — hooks.server.ts applies an equivalent
+    // same-origin check scoped to that area, where it costs nothing to be strict.
     csrf: { checkOrigin: false },
   },
 };


### PR DESCRIPTION
## What

Authorization for the auth hub's `/admin` area now runs in `apps/auth/src/hooks.server.ts` instead of only in `apps/auth/src/routes/admin/+layout.server.ts`.

The layout `load` was the only gate. It does not run early enough in SvelteKit's request lifecycle to cover **form actions**, so the admin form actions were not covered by it. The layout also carried a comment asserting that its check protected every route under `/admin` and that no per-page check was needed; that comment was wrong and has been corrected.

## How

The hook runs **before any route's own code** — loads, actions, endpoints — so one check covers every request method and every route under `/admin`. Note this is *not* the same as running before route resolution: SvelteKit resolves the route first and then calls `handle`. That distinction matters, and getting it wrong is what an earlier revision of this PR did.

The guard matches on:

- **the decoded pathname** — the form SvelteKit resolves routes against, so it is what has to agree with the router. This is the arm that does the work.
- **the routed id** (`event.route.id`) — which adds nothing while this app configures no `reroute` hook and no `paths.base` (both verified absent), since the routed id then always agrees with the decoded pathname. It is cover for the day one of those is added.

There is deliberately no separate raw-pathname arm: an admin path contains no escape to decode, so it survives decoding unchanged, and an undecodable path is returned verbatim. An arm for it could never be the sole reason the guard matched, and removing it is what makes the decode-failure fallback observable to the tests.

Matching is by prefix, not against a list of known routes, so a route added under `/admin` later is covered without anyone having to remember to list it. A per-route guard list is the thing that drifts the moment a sixth route appears.

### Pinning the decode mirror

The decoded arm's correctness rests on `decodePathname` reproducing SvelteKit's `decode_pathname` exactly. That cannot be defended through the admin/not-admin verdict — three wrong rewrites (dropping the `%25` hold-back, using `decodeURIComponent`, decoding twice) leave that verdict unchanged on almost every input. So the mirror is pinned on **the string it returns**, against literal expected values.

`+layout.server.ts` keeps its equivalent check as a second layer.

### On response uniformity

The hook returns one uniform `403` body for every rejection, so **the hook itself** distinguishes nothing between admin routes. That is a claim about the hook only, and an earlier revision of this PR overstated it: SvelteKit normalizes a trailing slash with a `308` before `handle` runs, and only for a path that matched a route, so `/admin/<real>/` and `/admin/<unknown>/` are still distinguishable upstream of anything this PR controls. Closing that would mean changing trailing-slash handling, which is out of scope here.

An unauthenticated browser `GET` still redirects to login.

## `csrf.checkOrigin` stays disabled — deliberately

I checked whether it could be turned back on. It cannot, and the existing comment in `svelte.config.js` is accurate.

SvelteKit's check runs before routing and applies to **every** form-content-type mutating request app-wide; it cannot be scoped per route. It rejects requests whose `Origin` does not match, **including requests with no `Origin` header at all**, and `trustedOrigins` has no way to express "no Origin". The OAuth token/revoke/device endpoints are form-encoded per spec and are called server-to-server by third-party clients, which send no `Origin`. Enabling it would break third-party token exchange.

Instead, the hook applies an **equivalent same-origin check scoped to `/admin`** for mutating methods — the protection SvelteKit's check would have given those routes, without touching the OAuth endpoints. A missing `Origin` is treated as untrusted there. (The session cookie is already `SameSite=Lax`; this is defence in depth, not the only control.)

## Tests

`apps/auth/src/routes/admin/__tests__/` — 100 tests across four files.

- **`admin-guard.test.ts`** (67) drives the real `handle` hook the way SvelteKit does — the hook wraps `resolve`, and the action runs inside `resolve`, so "resolve was never called" is exactly "the action never ran". Every named admin form action is exercised for the unauthenticated, signed-in-non-admin, cross-origin, and missing-`Origin` cases, asserting both the rejected response and that **no write is reached**. Each action also has an **admin-session positive control** asserting the write *does* happen — without it, "0 writes" would be indistinguishable from a harness wired to nothing. Inputs are valid for each route's own validation, so a test cannot pass because a field failed to parse.

  The harness sets the **requested path and the routed id independently**. An earlier revision derived the module to invoke from the requested path, which silently baked in the same assumption the code made and left a whole class of input inexpressible. Each arm of the guard now has a case the other cannot answer.

- **`admin-path-matching.test.ts`** (20) pins the decode mirror by literal string output, plus the admin/not-admin verdict for escaped, doubly-escaped, reserved-character and malformed-escape paths.

- **`admin-allowlist.test.ts`** (9) pins the documented fail-closed behaviour of the admin allowlist when it is unset, empty, whitespace, non-numeric or separators-only, with a populated-allowlist positive control.

- **`admin-route-ledger.test.ts`** (4) scans the route tree for pages exporting `actions` and pins the exact set, split into admin-guarded and public-by-design (the login/consent steps). It fails when that set **grows or shrinks**, and asserts both guard arms cover every admin action route.

### Suite counts

| Run | Files | Tests |
|---|---|---|
| base `c25f555b62` | 1 failed / 29 passed (30) | **33 failed** / 248 passed (281) |
| HEAD | 33 passed | **337 passed** (337) |

At base, all 30 rejection tests failed with the write having actually committed (e.g. `expected [ 'insertInto:TrustedSpokeDomain' ] to deeply equal []`) — the defect itself, not an incidental error.

### Mutation testing

Fourteen semantic mutants, all killed:

| Mutant | Tests failed |
|---|---|
| Decode without the `%25` hold-back | 1 |
| `decodeURIComponent` instead of `decodeURI` | 2 |
| Decode twice | 2 |
| No decode at all | 4 |
| Decode-failure fallback returns `''` | 3 |
| Decoded-pathname arm dropped | 9 |
| Routed-id arm dropped | 3 |
| `isAdminPath` prefix loosened to `startsWith('/admin')` | 3 |
| Fail open when `Origin` is absent | 10 |
| Inverted origin comparison | 30 |
| Guard disabled, text still present | 56 |
| Unauthenticated non-`GET` redirects instead of 403 | 25 |
| Authorization branch inverted | 46 |
| Allowlist fails open when unset | 6 |

Several of these **survived earlier revisions of the suite** and are why specific cases exist. The missing-`Origin` and allowlist mutants drove those test files. The first mutant here is killed by exactly **one** assertion — the literal-string row for a doubly-escaped path — which is the concrete reason the mirror is pinned on output rather than on the verdict. The emptied-fallback mutant changed nothing until the redundant raw-pathname arm was removed.

## Note for reviewers: no GitHub Actions job runs these tests

`vitest.config.mts` registers `packages/*/vitest.config.ts` as projects but **not** `apps/*/vitest.config.ts`, and the workflow jobs run `--project unit` (root-relative `src/**`, `scripts/**`) and `--project '@civitai/*'`. I confirmed empirically that `test:packages:run` executes 70 files / 953 tests, none from `apps/`. Measured locally, all four app suites are green and total **461 tests** no workflow job executes (auth 337, notifications 101, storage 17, orchestrator-gateway 6).

**Caveat I could not resolve:** the preview pipeline reports a `preview / auth-tests` check ("Auth suites passed", report-only). It is defined outside this repo, so I could not confirm what it runs — it executes against a deployed preview URL, which suggests the hub e2e specs rather than this vitest suite. **Someone with visibility into that pipeline should confirm whether these unit tests are covered there** before concluding either way; my claim above is specific to the workflows in this repo.

Either way the gap is the same class the `packages` job and `scripts/ci/assert-package-suites-ran.mjs` were added to close. I have deliberately **not** folded it into this PR — expanding the CI surface is a separate change with its own blast radius and deserves its own review — but the tests above are only as good as their being run.
