### PR TITLE
fix(app-blocks): PageBlockHost's status gates read a stale closure at commit

### DIFF
--- a/src/components/AppBlocks/PageBlockHost.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHost.browser.test.tsx
@@ -230,13 +230,13 @@ describe('PageBlockHost REQUEST_CONSENT (W10 lazy-consent wiring)', () => {
     // The block claims a WIDER set than the host withheld — the host must ignore
     // the claim and grant only its server-known missingScopes.
     //
-    // Re-post REQUEST_CONSENT INSIDE the waitFor: driveToReady only guarantees the
-    // DOM `data-block-ready` attribute, but the host's message-gate state can lag
-    // it by a tick — so a single fire-once REQUEST_CONSENT can land while the gate
-    // still reads "not ready", get dropped (see the "before BLOCK_READY is dropped"
-    // test), and never retried → the dialog never opens (a 10s CI-contention flake).
-    // Re-posting until the dialog appears mirrors driveToReady's BLOCK_READY retry;
-    // waitFor exits on the first success, so exactly one post opens exactly one dialog.
+    // Posted inside the waitFor purely so the assertion retries if the DIALOG has
+    // not rendered yet. The gate itself no longer lags: the host reads a
+    // render-body-updated `statusRef`, so once `data-block-ready` is "true" the
+    // handler is live. (This used to say the message-gate state could lag the DOM
+    // attribute by a tick and a dropped fire-and-forget post was never retried —
+    // true before the stale-closure fix, false now.) waitFor exits on the first
+    // success, so exactly one post opens exactly one dialog.
     await vi.waitFor(() => {
       postFromBlock('REQUEST_CONSENT', { scopes: ['ai:write:budgeted', 'buzz:spend:self'] });
       expect(useDialogStore.getState().dialogs).toHaveLength(1);
@@ -288,8 +288,25 @@ describe('PageBlockHost REQUEST_CONSENT (W10 lazy-consent wiring)', () => {
     );
 
     await driveToReady();
-    // baseProps.declaredScopes already carries ai:write:budgeted, so with nothing
-    // missing it is ALREADY granted → benign re-request → no dialog AND no toast.
+
+    // 🔴 POSITIVE CONTROL, and it is not optional. Everything this test asserts is a
+    // ZERO — no dialog, no toast — and a host that simply DROPPED the message
+    // produces that same zero. Before the stale-closure fix that was a live
+    // possibility: the handler closed over `status` and stayed non-ready until a
+    // passive effect re-registered it, so this test could pass without ever
+    // exercising its own subject ("nothing missing is a no-op").
+    //
+    // `models:read:self` is neither granted (not in declaredScopes) nor grantable
+    // (missingScopes is empty), so it is UN-GRANTABLE and must surface a toast —
+    // proving the handler is live under exactly these props before the zero is read.
+    postFromBlock('REQUEST_CONSENT', { scopes: ['models:read:self'] });
+    await vi.waitFor(() => expect(showNotificationSpy).toHaveBeenCalledTimes(1));
+    showNotificationSpy.mockClear();
+
+    // THE SUBJECT: baseProps.declaredScopes already carries ai:write:budgeted, so
+    // with nothing missing it is ALREADY granted → benign re-request → no dialog AND
+    // no toast. This zero is now a measurement, because the control above proved a
+    // non-zero is reachable on this very mount.
     postFromBlock('REQUEST_CONSENT', { scopes: ['ai:write:budgeted'] });
 
     await new Promise((r) => setTimeout(r, 150));
@@ -432,58 +449,50 @@ describe('PageBlockHost loading indicator (Task 1)', () => {
     expect(page.getByTestId('app-page-loading').query()).toBeNull();
   });
 
-  test(
-    'loader clears after the BLOCK_READY timeout (timeout terminal path)',
-    async () => {
-      // token present so the init controller arms its readiness timeout, but we
-      // NEVER ack BLOCK_READY → after BLOCK_READY_TIMEOUT_MS (10s) onReadyTimeout
-      // flips status 'loading' → 'timeout', clearing the loader and rendering the
-      // fallback.
-      useFakeClock();
-      renderWithProviders(<PageBlockHost {...baseProps} onConsentGranted={vi.fn()} />);
+  test('loader clears after the BLOCK_READY timeout (timeout terminal path)', async () => {
+    // token present so the init controller arms its readiness timeout, but we
+    // NEVER ack BLOCK_READY → after BLOCK_READY_TIMEOUT_MS (10s) onReadyTimeout
+    // flips status 'loading' → 'timeout', clearing the loader and rendering the
+    // fallback.
+    useFakeClock();
+    renderWithProviders(<PageBlockHost {...baseProps} onConsentGranted={vi.fn()} />);
 
-      await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
+    await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
 
-      // Jump the 10s readiness window on the fake clock instead of sleeping through it.
-      await advancePastWindow(11_000);
-      // The loader must clear and the timeout fallback render.
-      await vi.waitFor(
-        () => {
-          expect(page.getByTestId('app-page-loading').query()).toBeNull();
-        },
-        { timeout: 5_000, interval: 100 }
-      );
-      await expect.element(page.getByTestId('app-page-fallback')).toBeInTheDocument();
-    },
-    20_000
-  );
+    // Jump the 10s readiness window on the fake clock instead of sleeping through it.
+    await advancePastWindow(11_000);
+    // The loader must clear and the timeout fallback render.
+    await vi.waitFor(
+      () => {
+        expect(page.getByTestId('app-page-loading').query()).toBeNull();
+      },
+      { timeout: 5_000, interval: 100 }
+    );
+    await expect.element(page.getByTestId('app-page-fallback')).toBeInTheDocument();
+  }, 20_000);
 
-  test(
-    'loader clears after the token-wait timeout (no_token terminal path)',
-    async () => {
-      // token=null and tokenError=false → no init controller (shouldStartInit
-      // needs a token) and no synchronous error flip; the token-wait effect's
-      // TOKEN_WAIT_TIMEOUT_MS (15s) timer flips status 'loading' → 'no_token',
-      // clearing the loader and rendering the fallback. (With a null token the
-      // iframe still mounts in the loading state, so the overlay is shown first.)
-      useFakeClock();
-      renderWithProviders(
-        <PageBlockHost {...baseProps} token={null} tokenError={false} onConsentGranted={vi.fn()} />
-      );
+  test('loader clears after the token-wait timeout (no_token terminal path)', async () => {
+    // token=null and tokenError=false → no init controller (shouldStartInit
+    // needs a token) and no synchronous error flip; the token-wait effect's
+    // TOKEN_WAIT_TIMEOUT_MS (15s) timer flips status 'loading' → 'no_token',
+    // clearing the loader and rendering the fallback. (With a null token the
+    // iframe still mounts in the loading state, so the overlay is shown first.)
+    useFakeClock();
+    renderWithProviders(
+      <PageBlockHost {...baseProps} token={null} tokenError={false} onConsentGranted={vi.fn()} />
+    );
 
-      await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
+    await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
 
-      await advancePastWindow(16_000);
-      await vi.waitFor(
-        () => {
-          expect(page.getByTestId('app-page-loading').query()).toBeNull();
-        },
-        { timeout: 5_000, interval: 100 }
-      );
-      await expect.element(page.getByTestId('app-page-fallback')).toBeInTheDocument();
-    },
-    25_000
-  );
+    await advancePastWindow(16_000);
+    await vi.waitFor(
+      () => {
+        expect(page.getByTestId('app-page-loading').query()).toBeNull();
+      },
+      { timeout: 5_000, interval: 100 }
+    );
+    await expect.element(page.getByTestId('app-page-fallback')).toBeInTheDocument();
+  }, 25_000);
 });
 
 // Drive the host to the `fatal` terminal state via its REAL status machine:
@@ -509,9 +518,7 @@ describe('PageBlockHost terminal error surface (Task: readable error + Retry)', 
     await driveToFatal();
 
     // Readable message (app name surfaced on the fatal path) — NOT "reported an error".
-    await expect
-      .element(page.getByText('Budgeted Generator failed to load'))
-      .toBeInTheDocument();
+    await expect.element(page.getByText('Budgeted Generator failed to load')).toBeInTheDocument();
     // Retry button present.
     await expect.element(page.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
     // Loader is gone (no infinite spinner behind the fallback).
@@ -524,62 +531,48 @@ describe('PageBlockHost terminal error surface (Task: readable error + Retry)', 
     );
     await expect.element(page.getByTestId('app-page-fallback')).toBeInTheDocument();
 
-    await expect
-      .element(page.getByText("Couldn't authenticate this app"))
-      .toBeInTheDocument();
+    await expect.element(page.getByText("Couldn't authenticate this app")).toBeInTheDocument();
     await expect.element(page.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
     expect(page.getByTestId('app-page-loading').query()).toBeNull();
   });
 
-  test(
-    'timeout terminal state: readable timeout message + Retry, not the loader',
-    async () => {
-      // token present, never ack BLOCK_READY → readiness timeout (10s) → 'timeout'.
-      useFakeClock();
-      renderWithProviders(<PageBlockHost {...baseProps} onConsentGranted={vi.fn()} />);
-      await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
+  test('timeout terminal state: readable timeout message + Retry, not the loader', async () => {
+    // token present, never ack BLOCK_READY → readiness timeout (10s) → 'timeout'.
+    useFakeClock();
+    renderWithProviders(<PageBlockHost {...baseProps} onConsentGranted={vi.fn()} />);
+    await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
 
-      await advancePastWindow(11_000);
-      await vi.waitFor(
-        () => {
-          expect(page.getByTestId('app-page-fallback').query()).not.toBeNull();
-        },
-        { timeout: 5_000, interval: 100 }
-      );
-      await expect
-        .element(page.getByText("This app didn't load in time"))
-        .toBeInTheDocument();
-      await expect.element(page.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
-      expect(page.getByTestId('app-page-loading').query()).toBeNull();
-    },
-    20_000
-  );
+    await advancePastWindow(11_000);
+    await vi.waitFor(
+      () => {
+        expect(page.getByTestId('app-page-fallback').query()).not.toBeNull();
+      },
+      { timeout: 5_000, interval: 100 }
+    );
+    await expect.element(page.getByText("This app didn't load in time")).toBeInTheDocument();
+    await expect.element(page.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+    expect(page.getByTestId('app-page-loading').query()).toBeNull();
+  }, 20_000);
 
-  test(
-    'no_token terminal state: readable auth message + Retry, not the loader',
-    async () => {
-      // token=null, no error → token-wait timeout (15s) → 'no_token' → token_error copy.
-      useFakeClock();
-      renderWithProviders(
-        <PageBlockHost {...baseProps} token={null} tokenError={false} onConsentGranted={vi.fn()} />
-      );
-      await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
+  test('no_token terminal state: readable auth message + Retry, not the loader', async () => {
+    // token=null, no error → token-wait timeout (15s) → 'no_token' → token_error copy.
+    useFakeClock();
+    renderWithProviders(
+      <PageBlockHost {...baseProps} token={null} tokenError={false} onConsentGranted={vi.fn()} />
+    );
+    await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
 
-      await advancePastWindow(16_000);
-      await vi.waitFor(
-        () => {
-          expect(page.getByTestId('app-page-fallback').query()).not.toBeNull();
-        },
-        { timeout: 5_000, interval: 100 }
-      );
-      await expect
-        .element(page.getByText("Couldn't authenticate this app"))
-        .toBeInTheDocument();
-      await expect.element(page.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
-      expect(page.getByTestId('app-page-loading').query()).toBeNull();
-    },
-    25_000
-  );
+    await advancePastWindow(16_000);
+    await vi.waitFor(
+      () => {
+        expect(page.getByTestId('app-page-fallback').query()).not.toBeNull();
+      },
+      { timeout: 5_000, interval: 100 }
+    );
+    await expect.element(page.getByText("Couldn't authenticate this app")).toBeInTheDocument();
+    await expect.element(page.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+    expect(page.getByTestId('app-page-loading').query()).toBeNull();
+  }, 25_000);
 });
 
 describe('PageBlockHost Retry (Task: re-attempt load from terminal fallback)', () => {
@@ -696,41 +689,37 @@ describe('PageBlockHost Retry re-mints the token on AUTH failures (the HIGH)', (
     expect(page.getByTestId('app-page-fallback').query()).toBeNull();
   });
 
-  test(
-    'no_token (token never arrived): Retry calls onRetryToken AND returns to loading',
-    async () => {
-      const onRetryToken = vi.fn();
-      // token=null, no error → token-wait timeout (15s) → `no_token` terminal.
-      useFakeClock();
-      renderWithProviders(
-        <PageBlockHost
-          {...baseProps}
-          token={null}
-          tokenError={false}
-          onConsentGranted={vi.fn()}
-          onRetryToken={onRetryToken}
-        />
-      );
-      // The loader is the precondition — and it also guarantees the render has committed
-      // (so the product's token-wait timer is on the fake clock) before we advance it.
-      await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
-      await advancePastWindow(16_000);
-      await vi.waitFor(
-        () => {
-          expect(page.getByTestId('app-page-fallback').query()).not.toBeNull();
-        },
-        { timeout: 5_000, interval: 100 }
-      );
-      expect(onRetryToken).not.toHaveBeenCalled();
+  test('no_token (token never arrived): Retry calls onRetryToken AND returns to loading', async () => {
+    const onRetryToken = vi.fn();
+    // token=null, no error → token-wait timeout (15s) → `no_token` terminal.
+    useFakeClock();
+    renderWithProviders(
+      <PageBlockHost
+        {...baseProps}
+        token={null}
+        tokenError={false}
+        onConsentGranted={vi.fn()}
+        onRetryToken={onRetryToken}
+      />
+    );
+    // The loader is the precondition — and it also guarantees the render has committed
+    // (so the product's token-wait timer is on the fake clock) before we advance it.
+    await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
+    await advancePastWindow(16_000);
+    await vi.waitFor(
+      () => {
+        expect(page.getByTestId('app-page-fallback').query()).not.toBeNull();
+      },
+      { timeout: 5_000, interval: 100 }
+    );
+    expect(onRetryToken).not.toHaveBeenCalled();
 
-      await page.getByRole('button', { name: 'Retry' }).click();
+    await page.getByRole('button', { name: 'Retry' }).click();
 
-      expect(onRetryToken).toHaveBeenCalledTimes(1);
-      await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
-      expect(page.getByTestId('app-page-fallback').query()).toBeNull();
-    },
-    25_000
-  );
+    expect(onRetryToken).toHaveBeenCalledTimes(1);
+    await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
+    expect(page.getByTestId('app-page-fallback').query()).toBeNull();
+  }, 25_000);
 
   test('fatal (non-auth): Retry returns to loading + remounts but does NOT re-mint the token', async () => {
     const onRetryToken = vi.fn();
@@ -754,35 +743,31 @@ describe('PageBlockHost Retry re-mints the token on AUTH failures (the HIGH)', (
     expect(onRetryToken).not.toHaveBeenCalled();
   });
 
-  test(
-    'timeout (non-auth): Retry returns to loading but does NOT re-mint the token',
-    async () => {
-      const onRetryToken = vi.fn();
-      // token present, never ack BLOCK_READY → readiness timeout (10s) → `timeout`.
-      useFakeClock();
-      renderWithProviders(
-        <PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={onRetryToken} />
-      );
-      // The loader is the precondition — and it also guarantees the render has committed
-      // (so the product's readiness timer is on the fake clock) before we advance it.
-      await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
-      await advancePastWindow(11_000);
-      await vi.waitFor(
-        () => {
-          expect(page.getByTestId('app-page-fallback').query()).not.toBeNull();
-        },
-        { timeout: 5_000, interval: 100 }
-      );
+  test('timeout (non-auth): Retry returns to loading but does NOT re-mint the token', async () => {
+    const onRetryToken = vi.fn();
+    // token present, never ack BLOCK_READY → readiness timeout (10s) → `timeout`.
+    useFakeClock();
+    renderWithProviders(
+      <PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={onRetryToken} />
+    );
+    // The loader is the precondition — and it also guarantees the render has committed
+    // (so the product's readiness timer is on the fake clock) before we advance it.
+    await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
+    await advancePastWindow(11_000);
+    await vi.waitFor(
+      () => {
+        expect(page.getByTestId('app-page-fallback').query()).not.toBeNull();
+      },
+      { timeout: 5_000, interval: 100 }
+    );
 
-      await page.getByRole('button', { name: 'Retry' }).click();
+    await page.getByRole('button', { name: 'Retry' }).click();
 
-      await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
-      expect(page.getByTestId('app-page-fallback').query()).toBeNull();
-      // Token was fine on a timeout → no re-mint (remount-only path unchanged).
-      expect(onRetryToken).not.toHaveBeenCalled();
-    },
-    20_000
-  );
+    await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
+    expect(page.getByTestId('app-page-fallback').query()).toBeNull();
+    // Token was fine on a timeout → no re-mint (remount-only path unchanged).
+    expect(onRetryToken).not.toHaveBeenCalled();
+  }, 20_000);
 });
 
 describe('PageBlockHost block render/impression (Analytics Phase 2)', () => {
@@ -813,9 +798,7 @@ describe('PageBlockHost block render/impression (Analytics Phase 2)', () => {
   beforeEach(() => {
     // vi.spyOn dedupes to the same mock when fetch is already spied, so its
     // .mock.calls would accumulate across tests — clear it each time.
-    fetchSpy = vi
-      .spyOn(globalThis, 'fetch')
-      .mockResolvedValue(new Response(null, { status: 200 }));
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 200 }));
     fetchSpy.mockClear();
   });
 

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -29,6 +29,7 @@ import {
   resolveReviewConsentNotice,
   resolveUngrantableConsentScopes,
   shouldEmitMidSessionLossBeacon,
+  toHostGateStatus,
 } from './pageBlockHostLogic';
 import ConfirmDialog from '~/components/Dialog/Common/ConfirmDialog';
 import { projectSafeGenerationResource } from '~/server/schema/blocks/generation-resource-projection';
@@ -376,11 +377,48 @@ export function PageBlockHost({
   const reviewNack = reviewMode && !reviewRunForReal;
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const [status, setStatus] = useState<Status>('loading');
-  // Mirror of `status` for the Retry handler to read the prior terminal state
-  // WITHOUT putting a side-effect (onRetryToken) inside the setStatus updater
-  // (which React may double-invoke under StrictMode → a double re-mint). Kept in
-  // sync via the effect below.
+  // Mirror of `status`, read by the Retry handler (for the prior terminal state,
+  // WITHOUT putting a side-effect (onRetryToken) inside the setStatus updater —
+  // which React may double-invoke under StrictMode → a double re-mint) AND by the
+  // four status-gated message handlers via `readGateStatus` below.
+  //
+  // 🔴 ASSIGNED IN THE RENDER BODY, NOT IN AN EFFECT — that placement IS the fix,
+  // and an effect here is the bug. React writes the `data-block-ready` DOM
+  // attribute (and every other commit-time output) during the COMMIT, but flushes
+  // PASSIVE effects in a LATER scheduler task whenever the commit exhausts the 5ms
+  // frame budget (scheduler 0.23.2, MessageChannel transport, `frameYieldMs = 5`).
+  // So an effect-updated mirror is stale for exactly the window in which the host
+  // has already publicly announced readiness — measured with a MutationObserver on
+  // the attribute: at the instant it flips to "true" the gated handlers still drop
+  // the message, 6 runs out of 6. A render-body assignment happens BEFORE the
+  // commit, so by the time anything observable says "ready" the mirror already is.
+  // Updating it from an effect would have precisely the deferral being fixed.
+  //
+  // CONCURRENT-RENDERING SAFETY. Writing a ref during render is impure, so the
+  // three ways that bites were each checked rather than assumed:
+  //   • StrictMode double-render writes the SAME value twice — idempotent.
+  //   • An interrupted/discarded concurrent render can leave the ref holding a
+  //     status that never committed. It converges: React always eventually renders
+  //     the latest state, and that render overwrites the ref. The transient
+  //     disagreement is only ever "ref is AHEAD of the DOM", which is the
+  //     PERMISSIVE direction — it can open the gate a beat early, never drop.
+  //   • It is only ever written from `status` (component state), never derived
+  //     from props or anything a parent can change mid-render.
+  //
+  // RESIDUAL WINDOW, stated rather than hidden: this closes the commit→passive-
+  // effect gap, NOT the larger message-received→render gap. `status` becomes
+  // 'ready' only as a RESULT of the block's own BLOCK_READY being processed
+  // (setStatus → render → commit), so a block that posts a gated request in the
+  // SAME turn as BLOCK_READY still meets a 'loading' mirror — React has not
+  // rendered yet. Mirroring the ready transition into the ref from inside the
+  // BLOCK_READY handler was considered and REJECTED: the handler would have to
+  // re-implement the updater's `current === 'loading'` predicate against the ref,
+  // which disagrees with React's own resolution whenever another setStatus is
+  // already queued (the exact eager-updater hazard the impression-beacon comment
+  // below documents at length). The NACKs on the two repliable gates are what
+  // cover that remainder — a drop there fails FAST instead of hanging.
   const statusRef = useRef<Status>('loading');
+  statusRef.current = status;
   // #4 Retry: bumped by the terminal-fallback Retry button to re-key the
   // <iframe> below. Re-keying forces React to unmount + remount the iframe (a
   // fresh `contentWindow`), so the re-armed init handshake talks to a clean
@@ -497,8 +535,10 @@ export function PageBlockHost({
   // mis-reporting — the right side to err on for an alerting signal.
   //
   // 🔴 The DECLARATION ORDER below is load-bearing: this effect must be declared
-  // BEFORE the status-sync effect that sets `reachedReadyRef`, so that a commit
-  // changing both `blockInstanceId` and `status` resets first and latches second.
+  // BEFORE the reachedReady-latch effect, so that a commit changing both
+  // `blockInstanceId` and `status` resets first and latches second. (That effect
+  // used to sync `statusRef` too; the mirror now lives in the render body — see
+  // its 🔴 note — but the reset/latch ordering constraint is unchanged.)
   // No current test detects a swap (no reachable case distinguishes them today) —
   // so if you reorder these, reason it through rather than trusting the suite.
   //
@@ -558,16 +598,31 @@ export function PageBlockHost({
     marks.tokenAt = nowMs();
   }, [token]);
 
-  // Keep statusRef tracking the live status so handleRetry can branch on the
-  // prior terminal state without reading it inside the setStatus updater.
+  // `statusRef` is kept current in the RENDER BODY above (see the 🔴 note there —
+  // an effect is exactly the deferral this component was losing messages to).
+  // This effect keeps ONLY the reachedReady latch, which deliberately wants the
+  // COMMITTED status: for the same reason the impression beacon does (see its
+  // comment), keying off a setStatus updater's side effect silently drops the
+  // observation whenever another state update is already queued on this component.
   useEffect(() => {
-    statusRef.current = status;
-    // Latch "this mount reached ready" off the COMMITTED status, for the same
-    // reason the impression beacon does (see its comment): keying off a
-    // setStatus updater's side effect silently drops the observation whenever
-    // another state update is already queued on this component.
     if (status === 'ready') reachedReadyRef.current = true;
   }, [status]);
+
+  /**
+   * The ONE way a message handler asks "is the host ready?".
+   *
+   * Reads the RENDER-BODY-updated `statusRef` rather than closing over `status`,
+   * so the answer is current the moment the render that made the host ready is
+   * committed — not one scheduler task later, when React gets around to flushing
+   * passive effects and re-registering the listener with a fresh closure.
+   *
+   * Stable identity (`[]` deps, ref read only) is load-bearing in its own right:
+   * it lets the four gated effects DROP `status` from their dependency arrays, so
+   * they now subscribe ONCE per mount instead of tearing down and re-registering
+   * on every status transition. The window this fix is about cannot exist if the
+   * listener never needs replacing.
+   */
+  const readGateStatus = useCallback(() => toHostGateStatus(statusRef.current), []);
 
   // BOUNDED AUTO-RETRY — the single decision both consumers read (the scheduling
   // effect near `handleRetry`, and the render-FAILURE beacon below), so they can
@@ -1060,15 +1115,19 @@ export function PageBlockHost({
   // the void and the block hung on "confirm in the Civitai dialog".
   useEffect(() => {
     const off = onMessage<{ scopes?: unknown } | undefined>('REQUEST_CONSENT', (payload) => {
-      // PageBlockHost's local Status carries an extra terminal `'error'` variant
-      // (a hard mint failure) the shared gate's HostStatus union doesn't model.
-      // The gate only ever grants when status === 'ready', and `'error'` is a
-      // disjoint terminal state (the iframe isn't even rendered), so collapse it
-      // to a non-ready sentinel before delegating — semantics are unchanged (it
-      // would return null either way), this just satisfies the union type.
-      const gateStatus = status === 'error' ? 'no_token' : status;
+      // `readGateStatus()` (not a closed-over `status`) — see its definition: it
+      // reads the render-body-updated mirror, so it is current at COMMIT rather
+      // than one scheduler task later. The 'error' → 'no_token' collapse lives in
+      // `toHostGateStatus`, one place for all four gates.
+      const gateStatus = readGateStatus();
       // Only act on a post-handshake request; a pre-handshake block never gets a
       // modal OR a toast (same posture as the consent gate itself).
+      //
+      // NO NACK HERE, deliberately. REQUEST_CONSENT is fire-and-forget in both
+      // directions: the SDK sends it with `dispatch` (blocks-react 0.39.0
+      // `useRequestConsent`), its payload is `{ scopes? }` with NO requestId, and
+      // there is no host→block reply message for it — so there is nothing to
+      // reply TO and no promise to fail fast. Dropping it cannot hang the block.
       if (gateStatus !== 'ready') return;
 
       // reviewMode: a consent grant re-mints the token with WIDER scopes — never
@@ -1153,9 +1212,13 @@ export function PageBlockHost({
       });
     });
     return off;
+    // `status` is deliberately ABSENT: the handler reads it through
+    // `readGateStatus` (a render-body-updated ref) instead of closing over it, so
+    // this subscribes ONCE per mount. Re-registering on every status transition is
+    // what opened the commit→passive-effect window in the first place.
   }, [
     onMessage,
-    status,
+    readGateStatus,
     missingScopes,
     grantedScopes,
     appBlockId,
@@ -1179,7 +1242,11 @@ export function PageBlockHost({
       // review flow (to a page a pending app doesn't even have). Fire-and-forget
       // ⇒ dropping it never hangs the block.
       if (reviewMode) return;
-      if (status !== 'ready') return; // pre-handshake blocks can't drive nav
+      // FIFTH status-gated handler (the four money/permission gates are the
+      // others) — it reads the same render-body mirror for the same reason. No
+      // NACK: NAVIGATE is fire-and-forget with no requestId, so a drop is
+      // incapable of hanging the block.
+      if (readGateStatus() !== 'ready') return; // pre-handshake blocks can't drive nav
       const rawPath = raw && typeof raw === 'object' ? (raw as { path?: unknown }).path : undefined;
       if (typeof rawPath !== 'string') return;
       // Normalize: strip a single leading slash; reject anything unsafe.
@@ -1187,11 +1254,14 @@ export function PageBlockHost({
       if (cleaned.startsWith('/') || cleaned.includes('//') || cleaned.split('/').includes('..')) {
         return;
       }
-      const target = cleaned ? `/apps/run/${encodeURIComponent(slug)}/${cleaned}` : `/apps/run/${encodeURIComponent(slug)}`;
+      const target = cleaned
+        ? `/apps/run/${encodeURIComponent(slug)}/${cleaned}`
+        : `/apps/run/${encodeURIComponent(slug)}`;
       void router.push(target, undefined, { shallow: true });
     });
     return off;
-  }, [onMessage, status, router, slug, reviewMode]);
+    // `status` deliberately absent — see the REQUEST_CONSENT deps note.
+  }, [onMessage, readGateStatus, router, slug, reviewMode]);
 
   // Forward host-side navigation (back/forward, or our own shallow push) into
   // the block so it can re-render the right view. Fires whenever the resolved
@@ -1299,43 +1369,40 @@ export function PageBlockHost({
   useEffect(() => {
     const off = onMessage<
       { requestId?: unknown; body?: unknown; idempotencyKey?: unknown } | undefined
-    >(
-      'SUBMIT_WORKFLOW',
-      async (raw) => {
-        if (reviewNack) {
-          // Real Buzz spend — NACK with the failure snapshot the block awaits so
-          // it fails fast (never a hang) and never reaches submitWorkflowMutation.
-          if (raw && typeof raw.requestId === 'string') {
-            send('WORKFLOW_SUBMITTED', {
-              requestId: raw.requestId,
-              snapshot: failureSnapshot(new Error(REVIEW_NACK_MESSAGE)),
-            });
-          }
-          return;
-        }
-        if (!raw || typeof raw.requestId !== 'string' || !token) return;
-        const requestId = raw.requestId;
-        // Idempotency (item 2, gen half): forward the OPTIONAL client key to the
-        // server so a lost-response retry collapses to one Buzz charge. Host-first:
-        // accept it defensively (only when a non-empty string) so older SDKs that
-        // never send it are unaffected and a garbage value is ignored.
-        const idempotencyKey =
-          typeof raw.idempotencyKey === 'string' && raw.idempotencyKey.length > 0
-            ? raw.idempotencyKey
-            : undefined;
-        try {
-          const { snapshot } = await submitWorkflowMutation.mutateAsync({
-            blockToken: token,
-            // Schema-validated server-side; the host never trusts this shape.
-            body: raw.body as never,
-            ...(idempotencyKey ? { idempotencyKey } : {}),
+    >('SUBMIT_WORKFLOW', async (raw) => {
+      if (reviewNack) {
+        // Real Buzz spend — NACK with the failure snapshot the block awaits so
+        // it fails fast (never a hang) and never reaches submitWorkflowMutation.
+        if (raw && typeof raw.requestId === 'string') {
+          send('WORKFLOW_SUBMITTED', {
+            requestId: raw.requestId,
+            snapshot: failureSnapshot(new Error(REVIEW_NACK_MESSAGE)),
           });
-          send('WORKFLOW_SUBMITTED', { requestId, snapshot });
-        } catch (err) {
-          send('WORKFLOW_SUBMITTED', { requestId, snapshot: failureSnapshot(err) });
         }
+        return;
       }
-    );
+      if (!raw || typeof raw.requestId !== 'string' || !token) return;
+      const requestId = raw.requestId;
+      // Idempotency (item 2, gen half): forward the OPTIONAL client key to the
+      // server so a lost-response retry collapses to one Buzz charge. Host-first:
+      // accept it defensively (only when a non-empty string) so older SDKs that
+      // never send it are unaffected and a garbage value is ignored.
+      const idempotencyKey =
+        typeof raw.idempotencyKey === 'string' && raw.idempotencyKey.length > 0
+          ? raw.idempotencyKey
+          : undefined;
+      try {
+        const { snapshot } = await submitWorkflowMutation.mutateAsync({
+          blockToken: token,
+          // Schema-validated server-side; the host never trusts this shape.
+          body: raw.body as never,
+          ...(idempotencyKey ? { idempotencyKey } : {}),
+        });
+        send('WORKFLOW_SUBMITTED', { requestId, snapshot });
+      } catch (err) {
+        send('WORKFLOW_SUBMITTED', { requestId, snapshot: failureSnapshot(err) });
+      }
+    });
     return off;
   }, [onMessage, send, token, submitWorkflowMutation, reviewNack]);
 
@@ -1642,31 +1709,28 @@ export function PageBlockHost({
   // handlers' error-carrying result shape. A missing requestId is still dropped
   // without replying (mirrors every other handler — there's nothing to reply to).
   useEffect(() => {
-    const off = onMessage<{ requestId?: unknown } | undefined>(
-      'GET_BUZZ_BALANCE',
-      async (raw) => {
-        if (!raw || typeof raw.requestId !== 'string') return;
-        const requestId = raw.requestId;
-        if (reviewNack) {
-          // Private financial read — NACK (the review token has no buzz:read:self).
-          send('BUZZ_BALANCE_RESULT', { requestId, error: REVIEW_NACK_MESSAGE });
-          return;
-        }
-        if (!token) {
-          send('BUZZ_BALANCE_RESULT', { requestId, error: 'no block token' });
-          return;
-        }
-        try {
-          const balance = await getMyBuzzBalanceMutation.mutateAsync({ blockToken: token });
-          send('BUZZ_BALANCE_RESULT', { requestId, balance });
-        } catch (err) {
-          send('BUZZ_BALANCE_RESULT', {
-            requestId,
-            error: err instanceof Error ? err.message : 'unknown',
-          });
-        }
+    const off = onMessage<{ requestId?: unknown } | undefined>('GET_BUZZ_BALANCE', async (raw) => {
+      if (!raw || typeof raw.requestId !== 'string') return;
+      const requestId = raw.requestId;
+      if (reviewNack) {
+        // Private financial read — NACK (the review token has no buzz:read:self).
+        send('BUZZ_BALANCE_RESULT', { requestId, error: REVIEW_NACK_MESSAGE });
+        return;
       }
-    );
+      if (!token) {
+        send('BUZZ_BALANCE_RESULT', { requestId, error: 'no block token' });
+        return;
+      }
+      try {
+        const balance = await getMyBuzzBalanceMutation.mutateAsync({ blockToken: token });
+        send('BUZZ_BALANCE_RESULT', { requestId, balance });
+      } catch (err) {
+        send('BUZZ_BALANCE_RESULT', {
+          requestId,
+          error: err instanceof Error ? err.message : 'unknown',
+        });
+      }
+    });
     return off;
   }, [onMessage, send, token, getMyBuzzBalanceMutation, reviewNack]);
 
@@ -1716,30 +1780,27 @@ export function PageBlockHost({
   // balances (spendable + creator payout pools). Same host-mediated + consent +
   // reply-always contract as GET_BUZZ_TRANSACTIONS.
   useEffect(() => {
-    const off = onMessage<{ requestId?: unknown } | undefined>(
-      'GET_BUZZ_ACCOUNTS',
-      async (raw) => {
-        if (!raw || typeof raw.requestId !== 'string') return;
-        const requestId = raw.requestId;
-        if (reviewNack) {
-          send('BUZZ_ACCOUNTS_RESULT', { requestId, error: REVIEW_NACK_MESSAGE });
-          return;
-        }
-        if (!token) {
-          send('BUZZ_ACCOUNTS_RESULT', { requestId, error: 'no block token' });
-          return;
-        }
-        try {
-          const result = await getMyBuzzAccountsMutation.mutateAsync({ blockToken: token });
-          send('BUZZ_ACCOUNTS_RESULT', { requestId, result });
-        } catch (err) {
-          send('BUZZ_ACCOUNTS_RESULT', {
-            requestId,
-            error: err instanceof Error ? err.message : 'unknown',
-          });
-        }
+    const off = onMessage<{ requestId?: unknown } | undefined>('GET_BUZZ_ACCOUNTS', async (raw) => {
+      if (!raw || typeof raw.requestId !== 'string') return;
+      const requestId = raw.requestId;
+      if (reviewNack) {
+        send('BUZZ_ACCOUNTS_RESULT', { requestId, error: REVIEW_NACK_MESSAGE });
+        return;
       }
-    );
+      if (!token) {
+        send('BUZZ_ACCOUNTS_RESULT', { requestId, error: 'no block token' });
+        return;
+      }
+      try {
+        const result = await getMyBuzzAccountsMutation.mutateAsync({ blockToken: token });
+        send('BUZZ_ACCOUNTS_RESULT', { requestId, result });
+      } catch (err) {
+        send('BUZZ_ACCOUNTS_RESULT', {
+          requestId,
+          error: err instanceof Error ? err.message : 'unknown',
+        });
+      }
+    });
     return off;
   }, [onMessage, send, token, getMyBuzzAccountsMutation, reviewNack]);
 
@@ -1791,26 +1852,23 @@ export function PageBlockHost({
   // we reply with the ERROR variant (mirrors GET_BUZZ_BALANCE) rather than
   // dropping. A missing requestId is still dropped without replying.
   useEffect(() => {
-    const off = onMessage<{ requestId?: unknown } | undefined>(
-      'GET_VIEWER',
-      async (raw) => {
-        if (!raw || typeof raw.requestId !== 'string') return;
-        const requestId = raw.requestId;
-        if (!token) {
-          send('VIEWER_RESULT', { requestId, error: 'no block token' });
-          return;
-        }
-        try {
-          const viewer = await getMyViewerMutation.mutateAsync({ blockToken: token });
-          send('VIEWER_RESULT', { requestId, viewer });
-        } catch (err) {
-          send('VIEWER_RESULT', {
-            requestId,
-            error: err instanceof Error ? err.message : 'unknown',
-          });
-        }
+    const off = onMessage<{ requestId?: unknown } | undefined>('GET_VIEWER', async (raw) => {
+      if (!raw || typeof raw.requestId !== 'string') return;
+      const requestId = raw.requestId;
+      if (!token) {
+        send('VIEWER_RESULT', { requestId, error: 'no block token' });
+        return;
       }
-    );
+      try {
+        const viewer = await getMyViewerMutation.mutateAsync({ blockToken: token });
+        send('VIEWER_RESULT', { requestId, viewer });
+      } catch (err) {
+        send('VIEWER_RESULT', {
+          requestId,
+          error: err instanceof Error ? err.message : 'unknown',
+        });
+      }
+    });
     return off;
   }, [onMessage, send, token, getMyViewerMutation]);
 
@@ -1842,14 +1900,32 @@ export function PageBlockHost({
           }
           return;
         }
-        // PageBlockHost's local Status carries an extra terminal `'error'`
-        // variant the shared gate's HostStatus union doesn't model; collapse it
-        // to a non-ready sentinel (the gate only ever opens when status ===
-        // 'ready', so this is semantics-preserving) — same shim as the consent
-        // gate above.
-        const gateStatus = status === 'error' ? 'no_token' : status;
+        // `readGateStatus()` (not a closed-over `status`) — see its definition.
+        const gateStatus = readGateStatus();
         const requestId = resolveBuzzPurchaseRequest(gateStatus, raw);
-        if (requestId == null || !raw) return; // !raw implied; narrows for TS
+        if (requestId == null || !raw) {
+          // NEVER HANG. `resolveBuzzPurchaseRequest` returns null for TWO
+          // different reasons, and they need different answers:
+          //
+          //   • malformed payload (no string requestId) — UNREPLIABLE. There is
+          //     no id to thread a reply back on, so it can only be dropped.
+          //   • host not ready — REPLIABLE, and it must be replied to. The block
+          //     is awaiting BUZZ_PURCHASE_RESULT on a promise that rejects only
+          //     at the SDK's 30s default request timeout (blocks-react 0.39.0,
+          //     `DEFAULT_REQUEST_TIMEOUT_MS`), and a retry carrying the same
+          //     requestId is swallowed by usePostMessage's 5s transport-level
+          //     dedup — so a silent drop strands the user's click.
+          //
+          // `purchased: false` is exactly the reply the reviewMode branch above
+          // already sends for its own refusal, and exactly what the SDK's
+          // `useBuzzPurchase` reads as "no purchase happened". Refusing is
+          // unchanged — no modal opens, nothing is charged; the block just finds
+          // out now instead of in 30 seconds.
+          if (raw && typeof raw.requestId === 'string' && raw.requestId.length > 0) {
+            send('BUZZ_PURCHASE_RESULT', { requestId: raw.requestId, purchased: false });
+          }
+          return;
+        }
         const rawAmount =
           typeof raw.suggestedAmount === 'number' && Number.isFinite(raw.suggestedAmount)
             ? raw.suggestedAmount
@@ -1892,7 +1968,8 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, status, appId, appBlockId, blockInstanceId, reviewNack]);
+    // `status` deliberately absent — see the REQUEST_CONSENT deps note.
+  }, [onMessage, send, readGateStatus, appId, appBlockId, blockInstanceId, reviewNack]);
 
   // ── Sign-in bridge: REQUEST_SIGN_IN (anonymous conversion) ─────────────────
   //
@@ -1912,8 +1989,13 @@ export function PageBlockHost({
   // semantics-preserving — same shim as the consent + buzz handlers).
   useEffect(() => {
     const off = onMessage<{ returnUrl?: unknown } | undefined>('REQUEST_SIGN_IN', (raw) => {
-      const gateStatus = status === 'error' ? 'no_token' : status;
+      // `readGateStatus()` (not a closed-over `status`) — see its definition.
+      const gateStatus = readGateStatus();
       const resolved = resolveRequestSignIn(gateStatus, raw);
+      // NO NACK HERE, deliberately — same reason as REQUEST_CONSENT. The SDK
+      // sends this with `dispatch` (blocks-react 0.39.0 `useRequestSignIn`), the
+      // payload is `{ returnUrl? }` with NO requestId, and there is no host→block
+      // reply message for it. Nothing to reply to; a drop cannot hang the block.
       if (resolved == null) return; // not ready — drop (gate centralises the rules)
       // Hub-driven login (popup to auth.civitai.com). Falls back to the current page when the
       // block didn't supply a sanitised same-origin returnUrl. `reason` rides to the hub for the
@@ -1922,7 +2004,8 @@ export function PageBlockHost({
       openLoginPopup(resolved.returnUrl ?? here, 'image-gen');
     });
     return off;
-  }, [onMessage, status]);
+    // `status` deliberately absent — see the REQUEST_CONSENT deps note.
+  }, [onMessage, readGateStatus]);
 
   // ── App Blocks KV datastore bridge (W4-v0) ─────────────────────────────────
   //
@@ -2110,7 +2193,8 @@ export function PageBlockHost({
           requestId,
           keys: result.keys.map((k) => ({
             key: k.key,
-            updatedAt: k.updatedAt instanceof Date ? k.updatedAt.toISOString() : String(k.updatedAt),
+            updatedAt:
+              k.updatedAt instanceof Date ? k.updatedAt.toISOString() : String(k.updatedAt),
           })),
           nextCursor: result.nextCursor,
         });
@@ -2127,45 +2211,42 @@ export function PageBlockHost({
 
   // APP_STORAGE_QUOTA → apps.storage.getQuota → APP_STORAGE_QUOTA_RESULT.
   useEffect(() => {
-    const off = onMessage<{ requestId?: unknown } | undefined>(
-      'APP_STORAGE_QUOTA',
-      async (raw) => {
-        if (reviewNack) {
-          if (raw && typeof raw.requestId === 'string') {
-            send('APP_STORAGE_QUOTA_RESULT', {
-              requestId: raw.requestId,
-              usedBytes: 0,
-              rowCount: 0,
-              limitBytes: 0,
-              limitRows: 0,
-              error: REVIEW_NACK_MESSAGE,
-            });
-          }
-          return;
-        }
-        if (!raw || typeof raw.requestId !== 'string' || !token) return;
-        const requestId = raw.requestId;
-        try {
-          const result = await trpcUtils.apps.storage.getQuota.fetch({ blockToken: token });
+    const off = onMessage<{ requestId?: unknown } | undefined>('APP_STORAGE_QUOTA', async (raw) => {
+      if (reviewNack) {
+        if (raw && typeof raw.requestId === 'string') {
           send('APP_STORAGE_QUOTA_RESULT', {
-            requestId,
-            usedBytes: result.usedBytes,
-            rowCount: result.rowCount,
-            limitBytes: result.limitBytes,
-            limitRows: result.limitRows,
-          });
-        } catch (err) {
-          send('APP_STORAGE_QUOTA_RESULT', {
-            requestId,
+            requestId: raw.requestId,
             usedBytes: 0,
             rowCount: 0,
             limitBytes: 0,
             limitRows: 0,
-            error: storageErrorMessage(err),
+            error: REVIEW_NACK_MESSAGE,
           });
         }
+        return;
       }
-    );
+      if (!raw || typeof raw.requestId !== 'string' || !token) return;
+      const requestId = raw.requestId;
+      try {
+        const result = await trpcUtils.apps.storage.getQuota.fetch({ blockToken: token });
+        send('APP_STORAGE_QUOTA_RESULT', {
+          requestId,
+          usedBytes: result.usedBytes,
+          rowCount: result.rowCount,
+          limitBytes: result.limitBytes,
+          limitRows: result.limitRows,
+        });
+      } catch (err) {
+        send('APP_STORAGE_QUOTA_RESULT', {
+          requestId,
+          usedBytes: 0,
+          rowCount: 0,
+          limitBytes: 0,
+          limitRows: 0,
+          error: storageErrorMessage(err),
+        });
+      }
+    });
     return off;
   }, [onMessage, send, token, trpcUtils, reviewNack]);
 
@@ -2424,7 +2505,10 @@ export function PageBlockHost({
           return;
         const requestId = raw.requestId;
         try {
-          const result = await sharedUnvoteMutation.mutateAsync({ blockToken: token, key: raw.key });
+          const result = await sharedUnvoteMutation.mutateAsync({
+            blockToken: token,
+            key: raw.key,
+          });
           send('SHARED_UNVOTE_RESULT', { requestId, count: result.count });
         } catch (err) {
           send('SHARED_UNVOTE_RESULT', { requestId, error: storageErrorMessage(err) });
@@ -2442,7 +2526,10 @@ export function PageBlockHost({
         if (reviewMode) {
           // Cross-user shared datastore WRITE (withdraw) — NACK even in run-for-real.
           if (raw && typeof raw.requestId === 'string') {
-            send('SHARED_WITHDRAW_RESULT', { requestId: raw.requestId, error: REVIEW_NACK_MESSAGE });
+            send('SHARED_WITHDRAW_RESULT', {
+              requestId: raw.requestId,
+              error: REVIEW_NACK_MESSAGE,
+            });
           }
           return;
         }
@@ -2490,9 +2577,13 @@ export function PageBlockHost({
                   value: it.value,
                   count: it.count,
                   createdAt:
-                    it.createdAt instanceof Date ? it.createdAt.toISOString() : String(it.createdAt),
+                    it.createdAt instanceof Date
+                      ? it.createdAt.toISOString()
+                      : String(it.createdAt),
                   updatedAt:
-                    it.updatedAt instanceof Date ? it.updatedAt.toISOString() : String(it.updatedAt),
+                    it.updatedAt instanceof Date
+                      ? it.updatedAt.toISOString()
+                      : String(it.updatedAt),
                   viewerVoted: it.viewerVoted,
                 }
               : null,
@@ -2825,122 +2916,147 @@ export function PageBlockHost({
     const off = onMessage<
       { requestId?: unknown; purpose?: unknown; asyncScan?: unknown } | undefined
     >('OPEN_IMAGE_UPLOAD', (raw) => {
-        if (reviewMode) {
-          // Host-mediated upload runs under the MOD's REAL session (createImage /
-          // consumer blob) — never let untrusted review code open it. Reply the
-          // bare (cancelled) result the block awaits so it fails fast (no hang).
-          if (raw && typeof (raw as { requestId?: unknown }).requestId === 'string') {
-            send('IMAGE_UPLOAD_RESULT', {
-              requestId: (raw as { requestId: string }).requestId,
-            });
-          }
-          return;
-        }
-        const gateStatus = status === 'error' ? 'no_token' : status;
-        if (gateStatus !== 'ready') return; // pre-handshake block — drop
-        const req = resolveImageUploadRequest(raw);
-        if (!req) return; // missing / non-string requestId → drop, never open the modal
-        const { requestId, purpose, asyncScan } = req;
-
-        // generationSource: UNSCANNED private img2img source (orchestrator scans
-        // the OUTPUT). Reply carries the source shape { url, width, height }; the
-        // moderated 'display' branch below is untouched.
-        if (purpose === 'generationSource') {
-          let resolvedSource: BlockSourceImageInfo | null = null;
-          dialogStore.trigger({
-            id: `block-generation-source-upload-${requestId}`,
-            component: BlockGenerationSourceUploadModal,
-            props: {
-              onResolved: (result: BlockSourceImageInfo) => {
-                resolvedSource = result;
-              },
-            },
-            options: {
-              onClose: () => {
-                if (resolvedSource) {
-                  send('IMAGE_UPLOAD_RESULT', { requestId, selected: resolvedSource });
-                } else {
-                  send('IMAGE_UPLOAD_RESULT', { requestId });
-                }
-              },
-            },
+      if (reviewMode) {
+        // Host-mediated upload runs under the MOD's REAL session (createImage /
+        // consumer blob) — never let untrusted review code open it. Reply the
+        // bare (cancelled) result the block awaits so it fails fast (no hang).
+        if (raw && typeof (raw as { requestId?: unknown }).requestId === 'string') {
+          send('IMAGE_UPLOAD_RESULT', {
+            requestId: (raw as { requestId: string }).requestId,
           });
-          return;
         }
-
-        // display + asyncScan: NON-BLOCKING moderated path. The host modal resolves
-        // EARLY on persist (returning a PENDING handle — the author's own preview
-        // URL) and CLOSES; a host-mounted BlockImageScanPoller (registered below,
-        // which SURVIVES this modal's unmount) polls the authoritative scan gate and
-        // streams the verdict to the block via the parent→block IMAGE_SCAN_RESOLVED
-        // push. The server gate is UNCHANGED — nothing cross-user is persisted until
-        // the app sees a `scanned` verdict, and `gate` still only ever returns a
-        // moderated projection on Scanned + within-SFW-ceiling + unflagged.
-        if (asyncScan) {
-          let accepted = false;
-          dialogStore.trigger({
-            id: `block-image-upload-${requestId}`,
-            component: BlockImageUploadModal,
-            props: {
-              // BLOCKING-mode callback — unused in async mode (onAccepted drives the
-              // early resolve); a no-op that satisfies the modal's required prop.
-              onResolved: () => undefined,
-              onAccepted: ({ imageId, url }: { imageId: number; url: string }) => {
-                accepted = true;
-                // Early-resolve: the upload is accepted (image persisted, scan still
-                // in-flight). Hand the block the PENDING handle and register the
-                // background poller keyed by requestId.
-                send('IMAGE_UPLOAD_RESULT', {
-                  requestId,
-                  selected: { status: 'pending', imageId, url },
-                });
-                setImageScanPollers((prev) =>
-                  prev.some((p) => p.requestId === requestId)
-                    ? prev
-                    : [...prev, { requestId, imageId }]
-                );
-              },
-            },
-            options: {
-              onClose: () => {
-                // Dismissed WITHOUT accepting → bare (cancelled) result, no poller.
-                // On accept, onClose fires AFTER onAccepted set `accepted`, so the
-                // early-resolve reply is not followed by a spurious cancel.
-                if (!accepted) send('IMAGE_UPLOAD_RESULT', { requestId });
-              },
-            },
+        return;
+      }
+      // `readGateStatus()` (not a closed-over `status`) — see its definition.
+      const gateStatus = readGateStatus();
+      if (gateStatus !== 'ready') {
+        // NEVER HANG — pre-handshake block: refuse the modal (unchanged) but
+        // REPLY, exactly as the reviewMode branch six lines above already does
+        // for its own refusal ("so it fails fast (no hang)"). This branch is the
+        // one that didn't, and it is the expensive one to get wrong: the SDK's
+        // `useImageUpload` sends OPEN_IMAGE_UPLOAD with
+        // `PICKER_REQUEST_TIMEOUT_MS` (blocks-react 0.39.0 — 10 MINUTES, not the
+        // 30s default), and a same-requestId retry is swallowed by
+        // usePostMessage's 5s transport dedup, so a silent drop strands the
+        // block's promise for ten minutes with no error anywhere.
+        //
+        // A bare `{ requestId }` is the cancelled/dismissed shape the SDK
+        // already handles (`if (!selected) return null; // dismissed`). Nothing
+        // is uploaded and no modal opens — the refusal is unchanged.
+        if (raw && typeof (raw as { requestId?: unknown }).requestId === 'string') {
+          send('IMAGE_UPLOAD_RESULT', {
+            requestId: (raw as { requestId: string }).requestId,
           });
-          return;
         }
+        return;
+      }
+      const req = resolveImageUploadRequest(raw);
+      // Legitimately UNREPLIABLE: a missing / non-string requestId leaves no id
+      // to thread a reply back on. Drop, never open the modal. (Not a hang risk
+      // either — the SDK always mints a requestId, so a payload without one
+      // never came from a promise anybody is awaiting.)
+      if (!req) return;
+      const { requestId, purpose, asyncScan } = req;
 
-        // display (default): moderated public-image path — UNCHANGED.
-        let resolved: BlockUploadedImageInfo | null = null;
+      // generationSource: UNSCANNED private img2img source (orchestrator scans
+      // the OUTPUT). Reply carries the source shape { url, width, height }; the
+      // moderated 'display' branch below is untouched.
+      if (purpose === 'generationSource') {
+        let resolvedSource: BlockSourceImageInfo | null = null;
         dialogStore.trigger({
-          // Per-request id so multiple OPEN_IMAGE_UPLOAD calls don't dedup against
-          // each other in the dialog store's exists-check.
-          id: `block-image-upload-${requestId}`,
-          component: BlockImageUploadModal,
+          id: `block-generation-source-upload-${requestId}`,
+          component: BlockGenerationSourceUploadModal,
           props: {
-            onResolved: (result: BlockUploadedImageInfo) => {
-              resolved = result;
+            onResolved: (result: BlockSourceImageInfo) => {
+              resolvedSource = result;
             },
           },
           options: {
             onClose: () => {
-              // A successful upload set `resolved` before the modal closed itself;
-              // otherwise the user cancelled → reply with a bare (cancelled) result.
-              if (resolved) {
-                send('IMAGE_UPLOAD_RESULT', { requestId, selected: resolved });
+              if (resolvedSource) {
+                send('IMAGE_UPLOAD_RESULT', { requestId, selected: resolvedSource });
               } else {
                 send('IMAGE_UPLOAD_RESULT', { requestId });
               }
             },
           },
         });
+        return;
       }
-    );
+
+      // display + asyncScan: NON-BLOCKING moderated path. The host modal resolves
+      // EARLY on persist (returning a PENDING handle — the author's own preview
+      // URL) and CLOSES; a host-mounted BlockImageScanPoller (registered below,
+      // which SURVIVES this modal's unmount) polls the authoritative scan gate and
+      // streams the verdict to the block via the parent→block IMAGE_SCAN_RESOLVED
+      // push. The server gate is UNCHANGED — nothing cross-user is persisted until
+      // the app sees a `scanned` verdict, and `gate` still only ever returns a
+      // moderated projection on Scanned + within-SFW-ceiling + unflagged.
+      if (asyncScan) {
+        let accepted = false;
+        dialogStore.trigger({
+          id: `block-image-upload-${requestId}`,
+          component: BlockImageUploadModal,
+          props: {
+            // BLOCKING-mode callback — unused in async mode (onAccepted drives the
+            // early resolve); a no-op that satisfies the modal's required prop.
+            onResolved: () => undefined,
+            onAccepted: ({ imageId, url }: { imageId: number; url: string }) => {
+              accepted = true;
+              // Early-resolve: the upload is accepted (image persisted, scan still
+              // in-flight). Hand the block the PENDING handle and register the
+              // background poller keyed by requestId.
+              send('IMAGE_UPLOAD_RESULT', {
+                requestId,
+                selected: { status: 'pending', imageId, url },
+              });
+              setImageScanPollers((prev) =>
+                prev.some((p) => p.requestId === requestId)
+                  ? prev
+                  : [...prev, { requestId, imageId }]
+              );
+            },
+          },
+          options: {
+            onClose: () => {
+              // Dismissed WITHOUT accepting → bare (cancelled) result, no poller.
+              // On accept, onClose fires AFTER onAccepted set `accepted`, so the
+              // early-resolve reply is not followed by a spurious cancel.
+              if (!accepted) send('IMAGE_UPLOAD_RESULT', { requestId });
+            },
+          },
+        });
+        return;
+      }
+
+      // display (default): moderated public-image path — UNCHANGED.
+      let resolved: BlockUploadedImageInfo | null = null;
+      dialogStore.trigger({
+        // Per-request id so multiple OPEN_IMAGE_UPLOAD calls don't dedup against
+        // each other in the dialog store's exists-check.
+        id: `block-image-upload-${requestId}`,
+        component: BlockImageUploadModal,
+        props: {
+          onResolved: (result: BlockUploadedImageInfo) => {
+            resolved = result;
+          },
+        },
+        options: {
+          onClose: () => {
+            // A successful upload set `resolved` before the modal closed itself;
+            // otherwise the user cancelled → reply with a bare (cancelled) result.
+            if (resolved) {
+              send('IMAGE_UPLOAD_RESULT', { requestId, selected: resolved });
+            } else {
+              send('IMAGE_UPLOAD_RESULT', { requestId });
+            }
+          },
+        },
+      });
+    });
     return off;
-  }, [onMessage, send, status, reviewMode]);
+    // `status` deliberately absent — see the REQUEST_CONSENT deps note.
+  }, [onMessage, send, readGateStatus, reviewMode]);
 
   // ── SET_USER_CHECKPOINT → USER_CHECKPOINT_SET (fail-fast NACK on a page) ──────
   //
@@ -3338,10 +3454,7 @@ export function PageBlockHost({
                       visible copy below so the two can't disagree. */}
                   {(Array.from(launchName)[0] ?? '').toUpperCase()}
                 </Avatar>
-                <Loader
-                  size="sm"
-                  aria-label={`Loading ${launchName}`}
-                />
+                <Loader size="sm" aria-label={`Loading ${launchName}`} />
                 <Text size="sm" c="dimmed">
                   {/* IN-PROGRESS FEEDBACK. `reloadNonce` counts re-attempts
                       (manual AND automatic — both go through performRetry), so
@@ -3368,7 +3481,10 @@ export function PageBlockHost({
           )}
         </Box>
       ) : fallbackReason ? (
-        <Box style={{ flex: 1, padding: 'var(--mantine-spacing-md)' }} data-testid="app-page-fallback">
+        <Box
+          style={{ flex: 1, padding: 'var(--mantine-spacing-md)' }}
+          data-testid="app-page-fallback"
+        >
           <BlockFallback
             reason={fallbackReason}
             blockName={sanitizeAppChromeName(appName) || blockId}

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -399,11 +399,27 @@ export function PageBlockHost({
   //   • StrictMode double-render writes the SAME value twice — idempotent.
   //   • An interrupted/discarded concurrent render can leave the ref holding a
   //     status that never committed. It converges: React always eventually renders
-  //     the latest state, and that render overwrites the ref. The transient
-  //     disagreement is only ever "ref is AHEAD of the DOM", which is the
-  //     PERMISSIVE direction — it can open the gate a beat early, never drop.
+  //     the latest state, and that render overwrites the ref.
   //   • It is only ever written from `status` (component state), never derived
   //     from props or anything a parent can change mid-render.
+  //
+  // 🔴 WHICH DIRECTION THAT TRANSIENT DISAGREEMENT RUNS IN — read this before
+  // pointing a NEW gate at the ref. "Ref ahead of the DOM" is NOT always the
+  // permissive direction; it inherits the direction of the transition in flight,
+  // and this component has transitions BOTH ways:
+  //   • loading → ready is PERMISSIVE. The ref says ready while `data-block-ready`
+  //     still reads "false", so a gate can open a beat before the host has publicly
+  //     announced readiness. Harmless, and it is the whole point of the fix.
+  //   • ready → error (the mid-session token loss at the `setStatus` below) and
+  //     ready → fatal (`BLOCK_ERROR{fatal:true}`) are RESTRICTIVE. A concurrent
+  //     render writes `statusRef.current = 'error'`, yields before commit, and a
+  //     queued OPEN_BUZZ_PURCHASE arriving in that gap is REFUSED while
+  //     `data-block-ready` still reads "true".
+  // The restrictive case is deliberate and is the safer side of the trade: the ref
+  // is the host's freshest knowledge of its own state, so refusing a spend on a
+  // host that has already decided it is broken is correct, and the DOM attribute is
+  // the thing lagging. A gate that must NOT tighten early (there is none today)
+  // would have to key off the committed `status`, not this ref.
   //
   // RESIDUAL WINDOW, stated rather than hidden: this closes the commit→passive-
   // effect gap, NOT the larger message-received→render gap. `status` becomes
@@ -1912,9 +1928,8 @@ export function PageBlockHost({
           //   • host not ready — REPLIABLE, and it must be replied to. The block
           //     is awaiting BUZZ_PURCHASE_RESULT on a promise that rejects only
           //     at the SDK's 30s default request timeout (blocks-react 0.39.0,
-          //     `DEFAULT_REQUEST_TIMEOUT_MS`), and a retry carrying the same
-          //     requestId is swallowed by usePostMessage's 5s transport-level
-          //     dedup — so a silent drop strands the user's click.
+          //     `DEFAULT_REQUEST_TIMEOUT_MS`), so a silent drop costs the user's
+          //     click plus half a minute of nothing happening.
           //
           // `purchased: false` is exactly the reply the reviewMode branch above
           // already sends for its own refusal, and exactly what the SDK's
@@ -2936,9 +2951,8 @@ export function PageBlockHost({
         // one that didn't, and it is the expensive one to get wrong: the SDK's
         // `useImageUpload` sends OPEN_IMAGE_UPLOAD with
         // `PICKER_REQUEST_TIMEOUT_MS` (blocks-react 0.39.0 — 10 MINUTES, not the
-        // 30s default), and a same-requestId retry is swallowed by
-        // usePostMessage's 5s transport dedup, so a silent drop strands the
-        // block's promise for ten minutes with no error anywhere.
+        // 30s default), so a silent drop strands the block's promise for ten
+        // minutes with no error anywhere.
         //
         // A bare `{ requestId }` is the cancelled/dismissed shape the SDK
         // already handles (`if (!selected) return null; // dismissed`). Nothing

--- a/src/components/AppBlocks/PageBlockHostImageUpload.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostImageUpload.browser.test.tsx
@@ -5,6 +5,7 @@ import type { BlockUploadedImageInfo } from '~/components/AppBlocks/BlockImageUp
 import type { BlockSourceImageInfo } from '~/components/AppBlocks/BlockGenerationSourceUploadModal';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
+import { onReadyAttributeWrite } from '../../../test/commitWindow';
 
 /**
  * App Blocks PAGE image upload (OPEN_IMAGE_UPLOAD) — the host-handler BRANCH test.
@@ -162,87 +163,58 @@ async function driveToReady() {
 }
 
 /**
- * Post OPEN_IMAGE_UPLOAD and RETRY WITH A FRESH `requestId` until the host actually
- * accepts it. Returns the requestId that landed — assert against THAT, never a literal.
- *
- * 🔴 BOTH HALVES ARE LOAD-BEARING, and neither is obvious. This helper exists because
- * a one-shot post here was a real, CI-observed flake (civitai#3659: the same commit
- * `f1044a1446` ran the component suite three times — twice `1280 passed`, once
- * `1 failed | 1279 passed` with this file's first test failing at 11205ms on
- * `expected [] to have a length of 1`).
- *
- * WHY A RETRY. `driveToReady` gates on the `data-block-ready` DOM attribute, which
- * React writes during the COMMIT (`isReady = status === 'ready'`). But the host's
- * OPEN_IMAGE_UPLOAD listener early-returns (`gateStatus !== 'ready'` -> drop) until the
- * `useEffect` that closes over `status` RE-REGISTERS — and React flushes passive
- * effects in a LATER task than the commit. So `data-block-ready === 'true'` is NOT
- * evidence that the handler is live; it is evidence that it is about to be. Measured
- * with a MutationObserver on the attribute: at the instant it flips to "true" the
- * handler still drops the message, 6 runs out of 6. A fire-and-forget post that lands
- * in that window is gone for good — nothing re-sends it — and the `vi.waitFor` that
- * follows just burns its full (10s, see test/component-setup.tsx) timeout before
- * reporting an empty dialog list. On a quiet box the next 50ms poll happens after the
- * flush and the test passes; on a saturated CI runner it doesn't. That is the whole
- * flake.
- *
- * WHY A FRESH ID PER ATTEMPT. Re-posting the SAME requestId does NOT work.
- * `usePostMessage` dedups on `payload.requestId` for `DEDUP_WINDOW_MS` (5s) at the
- * TRANSPORT layer — before the handler's status gate — so the first, dropped attempt
- * poisons every retry of that id. Measured: 30 same-id retries over 1500ms, never
- * delivered. A retry loop that keeps the id is therefore INERT: it looks like a fix and
- * changes nothing.
- *
- * `closeAll()` per attempt keeps the assertion honest — whatever dialog is present
- * afterwards provably came from THIS attempt, not an earlier post landing late. It
- * does not run `options.onClose`, so it can never manufacture an IMAGE_UPLOAD_RESULT.
- *
- * The dialog store is written synchronously from the message handler, so checking
- * immediately after the dispatch is correct: an accepted post is visible at once.
+ * Wait for the iframe to mount, then post BLOCK_READY on a CANCELLABLE interval.
+ * Used by the commit-window guard, which must NOT await readiness before acting —
+ * the whole point is to act during the commit that establishes it. Callers stop the
+ * drive in a `finally` so it can never post into the next test's host.
  */
-async function openUploadModal(payload: Record<string, unknown> = {}) {
-  let attempt = 0;
-  let requestId = '';
-  await vi.waitFor(() => {
-    attempt += 1;
-    requestId = `rq_${attempt}`;
-    useDialogStore.getState().closeAll();
-    postFromBlock('OPEN_IMAGE_UPLOAD', { requestId, ...payload });
-    if (useDialogStore.getState().dialogs.length !== 1) {
-      throw new Error(`OPEN_IMAGE_UPLOAD opened no modal (attempt ${attempt})`);
-    }
-  });
-  return requestId;
-}
-
-/**
- * Drive to ready and hand control back at the EARLIEST instant `data-block-ready`
- * reports "true": the MutationObserver microtask checkpoint that ends the task which
- * COMMITTED the DOM. React flushes passive effects in a LATER task, so this is exactly
- * the window a loaded CI runner's 50ms `vi.waitFor` poll lands in — the one that made
- * this file flake. Reproducing it deterministically is what lets the guard below be a
- * real regression test instead of a coin flip.
- */
-async function driveToReadyAtCommit() {
+async function startReadyDrive() {
   await vi.waitFor(() => {
     const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
     if (!el.contentWindow) throw new Error('not mounted yet');
   });
-  const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
-  let resolveFlip!: () => void;
-  const flipped = new Promise<void>((r) => (resolveFlip = r));
-  const obs = new MutationObserver(() => {
-    if (el.getAttribute('data-block-ready') === 'true') resolveFlip();
-  });
-  obs.observe(el, { attributes: true, attributeFilter: ['data-block-ready'] });
-  const driving = vi.waitFor(() => {
-    postFromBlock('BLOCK_READY', {});
-    const cur = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
-    if (cur.getAttribute('data-block-ready') !== 'true') throw new Error('not ready yet');
-  });
-  await flipped;
-  obs.disconnect();
-  // Hand back the still-pending drive so the caller can settle it before finishing.
-  return () => driving;
+  const timer = setInterval(() => postFromBlock('BLOCK_READY', {}), 10);
+  postFromBlock('BLOCK_READY', {});
+  return () => clearInterval(timer);
+}
+
+/**
+ * Post OPEN_IMAGE_UPLOAD after the host is ready and return the requestId used.
+ *
+ * ── HISTORY, because RETIRING the workaround is the point ────────────────────────
+ *
+ * This used to be a RETRY LOOP that re-posted with a FRESH `requestId` until the host
+ * accepted one, and its comment called both halves load-bearing. It was a TEST-SIDE
+ * workaround for a PRODUCTION bug (civitai#3659: the same commit `f1044a1446` ran the
+ * component suite three times — twice `1280 passed`, once `1 failed | 1279 passed`
+ * with this file's first test failing at 11205ms). The host's OPEN_IMAGE_UPLOAD
+ * listener closed over `status`, so it dropped messages until a passive effect
+ * re-registered it, and `data-block-ready === 'true'` was NOT evidence the handler was
+ * live.
+ *
+ * The host now reads a render-body-updated `statusRef`, so the handler IS live at the
+ * instant the attribute is written and the retry can never take a second attempt. It
+ * is deleted rather than left in place: an inert retry whose comment insists it is
+ * load-bearing is a false claim about current behaviour, and the next person to hit a
+ * similar flake would copy it. The one-shot post below now FAILS LOUDLY if the host
+ * ever drops a post-ready request again — which is the regression signal we want.
+ *
+ * The claim about the transport's 5s `requestId` dedup that used to live here is gone
+ * too, and not because the dedup was removed: it is real in `usePostMessage` but
+ * UNREACHABLE from the SDK, whose `nextRequestId()` is `random6 + a monotonic
+ * counter`, so every call mints a fresh id and the window can never see a repeat.
+ *
+ * The dialog store is written synchronously from the message handler, so checking
+ * immediately after the dispatch is correct: an accepted post is visible at once.
+ */
+function openUploadModal(payload: Record<string, unknown> = {}) {
+  const requestId = 'rq_1';
+  useDialogStore.getState().closeAll();
+  postFromBlock('OPEN_IMAGE_UPLOAD', { requestId, ...payload });
+  if (useDialogStore.getState().dialogs.length !== 1) {
+    throw new Error('OPEN_IMAGE_UPLOAD opened no modal — the host dropped a post-ready request');
+  }
+  return requestId;
 }
 
 describe('PageBlockHost OPEN_IMAGE_UPLOAD (purpose branch)', () => {
@@ -251,32 +223,47 @@ describe('PageBlockHost OPEN_IMAGE_UPLOAD (purpose branch)', () => {
   });
 
   /**
-   * REGRESSION GUARD for the civitai#3659 flake — it pins `openUploadModal`'s retry,
-   * which IS the fix. Deliberately FIRST in the file: the coldest mount is the one
-   * whose commit most reliably exhausts React's 5ms frame budget and therefore yields
-   * before the passive-effect flush, which is the window this guard has to exist
-   * inside. Proven reachable by mutation — swap the retry back for the old one-shot
-   * post and this goes red.
+   * REGRESSION GUARD for the civitai#3659 flake. It used to pin `openUploadModal`'s
+   * fresh-id RETRY — a test-side workaround. It now pins the PRODUCTION fix: the host
+   * reading a render-body-updated `statusRef` instead of a closed-over `status`.
    *
-   * It can never false-FAIL: if the effects happen to have flushed already, the retry
-   * simply succeeds on its first attempt.
+   * 🔴 The post is driven from `onReadyAttributeWrite`, NOT the MutationObserver this
+   * guard originally used — see test/commitWindow.tsx. The observer's callback is a
+   * microtask that runs at the END of the scheduler task, by which point React has
+   * often already flushed the passive effects; measured, the observer-driven version
+   * of this guard survived the mutant roughly one run in three. The old comment's
+   * "it can never false-FAIL" was an admission of exactly that: a guard that silently
+   * degrades to a no-op is not a regression test. `setAttribute` is on React's own
+   * call stack, so there is no queue to lose a race to.
    */
   test("a request posted in React's commit→passive-effect gap still opens the modal", async () => {
     renderWithProviders(<PageBlockHost {...baseProps} />);
-    const settleDrive = await driveToReadyAtCommit();
-
-    const requestId = await openUploadModal({ purpose: 'generationSource' });
-    expect(lastDialog().id).toBe(`block-generation-source-upload-${requestId}`);
-
-    await settleDrive();
+    let opened: string | number | symbol | null = null;
+    const unpatch = onReadyAttributeWrite(() => {
+      postFromBlock('OPEN_IMAGE_UPLOAD', { requestId: 'rq_gap', purpose: 'generationSource' });
+      opened = useDialogStore.getState().dialogs[0]?.id ?? null;
+    });
+    try {
+      const stopDrive = await startReadyDrive();
+      try {
+        await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+      } finally {
+        stopDrive();
+      }
+    } finally {
+      unpatch();
+    }
+    // Asserted on the value captured INSIDE the window, so this cannot pass on a
+    // dialog that only appeared after the passive flush.
+    expect(opened).toBe('block-generation-source-upload-rq_gap');
   });
 
-  test("generationSource opens the UNSCANNED consumer-blob modal (NOT the moderated one) and replies { url, width, height }", async () => {
+  test('generationSource opens the UNSCANNED consumer-blob modal (NOT the moderated one) and replies { url, width, height }', async () => {
     renderWithProviders(<PageBlockHost {...baseProps} />);
     await driveToReady();
     const replies = listenForReply();
 
-    const requestId = await openUploadModal({ purpose: 'generationSource' });
+    const requestId = openUploadModal({ purpose: 'generationSource' });
 
     // The generationSource branch opens the generation-source modal — proof it
     // does NOT route to the moderated scan/gate modal.
@@ -302,19 +289,20 @@ describe('PageBlockHost OPEN_IMAGE_UPLOAD (purpose branch)', () => {
       // EXACTLY the source projection — no imageId / nsfwLevel / contentRating.
       expect(r.payload).toEqual({ requestId, selected: source });
     });
-    const sel = (replies.last('IMAGE_UPLOAD_RESULT')!.payload as { selected: Record<string, unknown> })
-      .selected;
+    const sel = (
+      replies.last('IMAGE_UPLOAD_RESULT')!.payload as { selected: Record<string, unknown> }
+    ).selected;
     expect(Object.keys(sel).sort()).toEqual(['height', 'url', 'width']);
     for (const k of ['imageId', 'nsfwLevel', 'contentRating']) expect(sel).not.toHaveProperty(k);
     replies.stop();
   });
 
-  test("display (explicit) opens the MODERATED modal and replies the moderated projection (unchanged)", async () => {
+  test('display (explicit) opens the MODERATED modal and replies the moderated projection (unchanged)', async () => {
     renderWithProviders(<PageBlockHost {...baseProps} />);
     await driveToReady();
     const replies = listenForReply();
 
-    const requestId = await openUploadModal({ purpose: 'display' });
+    const requestId = openUploadModal({ purpose: 'display' });
 
     expect(lastDialog().id).toBe(`block-image-upload-${requestId}`);
 
@@ -342,7 +330,7 @@ describe('PageBlockHost OPEN_IMAGE_UPLOAD (purpose branch)', () => {
     await driveToReady();
 
     // Exactly what the current SDK sends today: a bare requestId, no purpose.
-    const requestId = await openUploadModal();
+    const requestId = openUploadModal();
 
     expect(lastDialog().id).toBe(`block-image-upload-${requestId}`);
   });
@@ -352,7 +340,7 @@ describe('PageBlockHost OPEN_IMAGE_UPLOAD (purpose branch)', () => {
     await driveToReady();
     const replies = listenForReply();
 
-    const requestId = await openUploadModal({ purpose: 'generationSource' });
+    const requestId = openUploadModal({ purpose: 'generationSource' });
 
     // User dismisses without a successful upload — onResolved never called, so
     // the dialog's options.onClose posts a bare (cancelled) result.
@@ -379,7 +367,7 @@ describe('PageBlockHost OPEN_IMAGE_UPLOAD (purpose branch)', () => {
     // `closeAll` does not run `options.onClose`, so this cannot post a reply of its own
     // — re-asserted immediately, so a future change that made it reply would be caught
     // here rather than silently satisfying the real assertion further down.
-    await openUploadModal({ purpose: 'generationSource' });
+    openUploadModal({ purpose: 'generationSource' });
     useDialogStore.getState().closeAll();
     expect(replies.last('IMAGE_UPLOAD_RESULT')).toBeUndefined();
 

--- a/src/components/AppBlocks/PageBlockHostImageUploadAsync.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostImageUploadAsync.browser.test.tsx
@@ -92,7 +92,11 @@ function postFromBlock(type: string, payload?: unknown) {
   const cw = iframeEl.contentWindow;
   if (!cw) throw new Error('iframe contentWindow missing');
   window.dispatchEvent(
-    new MessageEvent('message', { data: { type, payload }, origin: window.location.origin, source: cw })
+    new MessageEvent('message', {
+      data: { type, payload },
+      origin: window.location.origin,
+      source: cw,
+    })
   );
 }
 
@@ -156,6 +160,38 @@ async function driveToReady() {
   });
 }
 
+/**
+ * Drive to ready and hand control back at the EARLIEST instant `data-block-ready`
+ * reports "true": the MutationObserver microtask checkpoint that ends the task which
+ * COMMITTED the DOM. React flushes passive effects in a LATER task, so a handler that
+ * closes over `status` is still the PREVIOUS render's closure — holding
+ * `status === 'loading'` — at this exact moment.
+ *
+ * The drive is a CANCELLABLE interval rather than `vi.waitFor`: a floating waitFor
+ * keeps posting BLOCK_READY after this returns, and that stray post lands in the NEXT
+ * test — measured, it turned an unrelated pre-handshake guard red.
+ */
+async function driveToReadyAtCommit() {
+  await vi.waitFor(() => {
+    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+    if (!el.contentWindow) throw new Error('not mounted yet');
+  });
+  const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+  let timer: ReturnType<typeof setInterval> | undefined;
+  await new Promise<void>((resolve) => {
+    const obs = new MutationObserver(() => {
+      if (el.getAttribute('data-block-ready') === 'true') {
+        if (timer) clearInterval(timer);
+        obs.disconnect();
+        resolve();
+      }
+    });
+    obs.observe(el, { attributes: true, attributeFilter: ['data-block-ready'] });
+    timer = setInterval(() => postFromBlock('BLOCK_READY', {}), 10);
+    postFromBlock('BLOCK_READY', {});
+  });
+}
+
 // Open the async upload, capture the modal's onAccepted, then simulate the modal's
 // early-resolve (persist done → onAccepted → modal closes).
 function acceptUpload(requestId: string, handle: { imageId: number; url: string }) {
@@ -181,6 +217,71 @@ describe('PageBlockHost OPEN_IMAGE_UPLOAD (asyncScan branch)', () => {
     h.gateMutateAsync.mockReset();
   });
 
+  /**
+   * REGRESSION GUARD for the host-ready stale-closure race, on the upload gate.
+   *
+   * Deliberately FIRST in the file: the coldest mount is the one whose commit most
+   * reliably exhausts React's 5ms frame budget and therefore yields before the
+   * passive-effect flush — the window this guard has to exist inside.
+   *
+   * The cost of a drop here is the worst of the four gates: `useImageUpload` sends
+   * OPEN_IMAGE_UPLOAD with `PICKER_REQUEST_TIMEOUT_MS` (@civitai/blocks-react 0.39.0
+   * — 10 MINUTES, not the 30s default), and a same-requestId retry is swallowed by
+   * usePostMessage's 5s transport dedup.
+   *
+   * Proven reachable by mutation: move `statusRef.current = status` out of the render
+   * body and back into an effect and this goes red on
+   * `expected [] to have a length of 1`.
+   */
+  test("OPEN_IMAGE_UPLOAD posted in React's commit→passive-effect gap still opens the modal", async () => {
+    h.gateMutateAsync.mockResolvedValue({ status: 'pending' });
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReadyAtCommit();
+
+    postFromBlock('OPEN_IMAGE_UPLOAD', { requestId: 'rq_gap', asyncScan: true });
+
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+    expect(lastDialog().id).toBe('block-image-upload-rq_gap');
+  });
+
+  /**
+   * The gate's REFUSAL is unchanged — a pre-handshake block never gets the upload
+   * modal. What changed is that the refusal is now SPOKEN.
+   *
+   * The reviewMode branch in this same handler already replied a bare (cancelled)
+   * result for its own refusal, with the comment "so it fails fast (no hang)". The
+   * not-ready branch six lines below it did not — that asymmetry was the bug, and it
+   * is the one that costs ten minutes of a hung promise.
+   *
+   * A bare `{ requestId }` is the dismissed shape the SDK already handles
+   * (`if (!selected) return null; // dismissed`). Nothing is uploaded.
+   */
+  test('OPEN_IMAGE_UPLOAD before BLOCK_READY opens no modal and NACKs (never hangs)', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    // Do NOT drive to ready — fire while status is still 'loading'.
+    await vi.waitFor(() => {
+      const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+      if (!el.contentWindow) throw new Error('not mounted yet');
+    });
+    const replies = listenForReply();
+
+    postFromBlock('OPEN_IMAGE_UPLOAD', { requestId: 'rq_early', asyncScan: true });
+
+    await vi.waitFor(() => {
+      const r = replies.last('IMAGE_UPLOAD_RESULT');
+      if (!r) throw new Error('no NACK yet');
+    });
+    // THE security property, unchanged: no upload modal for a pre-handshake block.
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+    // THE new property: replied on the block's own requestId, with NO `selected` —
+    // the cancelled shape. Asserted with toEqual so a future leak of an imageId or
+    // a moderated projection into this reply fails here.
+    expect(replies.last('IMAGE_UPLOAD_RESULT')!.payload).toEqual({ requestId: 'rq_early' });
+    // The scan gate was never consulted — refusing must not touch the server.
+    expect(h.gateMutateAsync).not.toHaveBeenCalled();
+    replies.stop();
+  });
+
   test('early-resolve: accept replies a PENDING handle and closes the modal', async () => {
     // Gate never asked to resolve within this test — keep it pending so no verdict races.
     h.gateMutateAsync.mockResolvedValue({ status: 'pending' });
@@ -193,14 +294,21 @@ describe('PageBlockHost OPEN_IMAGE_UPLOAD (asyncScan branch)', () => {
     // The MODERATED modal is opened (async is a display-only mode).
     expect(lastDialog().id).toBe('block-image-upload-rq_async');
 
-    acceptUpload('rq_async', { imageId: 77, url: 'https://image.civitai.com/xG/77/width=1200/x.jpeg' });
+    acceptUpload('rq_async', {
+      imageId: 77,
+      url: 'https://image.civitai.com/xG/77/width=1200/x.jpeg',
+    });
 
     await vi.waitFor(() => {
       const r = replies.last('IMAGE_UPLOAD_RESULT');
       if (!r) throw new Error('no reply yet');
       expect(r.payload).toEqual({
         requestId: 'rq_async',
-        selected: { status: 'pending', imageId: 77, url: 'https://image.civitai.com/xG/77/width=1200/x.jpeg' },
+        selected: {
+          status: 'pending',
+          imageId: 77,
+          url: 'https://image.civitai.com/xG/77/width=1200/x.jpeg',
+        },
       });
     });
     // Auto-close semantics: the host replied EXACTLY ONCE on accept — the modal's
@@ -254,7 +362,11 @@ describe('PageBlockHost OPEN_IMAGE_UPLOAD (asyncScan branch)', () => {
     await vi.waitFor(() => {
       const r = replies.last('IMAGE_SCAN_RESOLVED');
       if (!r) throw new Error('no verdict yet');
-      const payload = r.payload as { requestId: string; imageId: number; result: Record<string, unknown> };
+      const payload = r.payload as {
+        requestId: string;
+        imageId: number;
+        result: Record<string, unknown>;
+      };
       expect(payload.requestId).toBe('rq_block');
       expect(payload.result.status).toBe('blocked');
       expect(payload.result.reason).toContain('rejected during scanning');
@@ -265,7 +377,10 @@ describe('PageBlockHost OPEN_IMAGE_UPLOAD (asyncScan branch)', () => {
   });
 
   test('scan error: a NOT_FOUND / network gate throw streams a RETRYABLE error (not blocked)', async () => {
-    h.gateMutateAsync.mockRejectedValue({ data: { code: 'NOT_FOUND' }, message: 'Image not found' });
+    h.gateMutateAsync.mockRejectedValue({
+      data: { code: 'NOT_FOUND' },
+      message: 'Image not found',
+    });
     renderWithProviders(<PageBlockHost {...baseProps} />);
     await driveToReady();
     const replies = listenForReply();

--- a/src/components/AppBlocks/PageBlockHostImageUploadAsync.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostImageUploadAsync.browser.test.tsx
@@ -4,6 +4,7 @@ import { useDialogStore } from '~/components/Dialog/dialogStore';
 import type { BlockUploadedImageInfo } from '~/components/AppBlocks/BlockImageUploadModal';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
+import { onReadyAttributeWrite } from '../../../test/commitWindow';
 
 /**
  * App Blocks PAGE image upload — the ASYNC (non-blocking) scan branch of
@@ -161,35 +162,20 @@ async function driveToReady() {
 }
 
 /**
- * Drive to ready and hand control back at the EARLIEST instant `data-block-ready`
- * reports "true": the MutationObserver microtask checkpoint that ends the task which
- * COMMITTED the DOM. React flushes passive effects in a LATER task, so a handler that
- * closes over `status` is still the PREVIOUS render's closure — holding
- * `status === 'loading'` — at this exact moment.
+ * Wait for the iframe to mount, then post BLOCK_READY on a CANCELLABLE interval.
  *
- * The drive is a CANCELLABLE interval rather than `vi.waitFor`: a floating waitFor
- * keeps posting BLOCK_READY after this returns, and that stray post lands in the NEXT
- * test — measured, it turned an unrelated pre-handshake guard red.
+ * Cancellable is load-bearing: a drive left running past the end of a test posts
+ * BLOCK_READY into the NEXT test's freshly-mounted host — measured, that turned an
+ * unrelated pre-handshake guard red. Callers stop it in a `finally`.
  */
-async function driveToReadyAtCommit() {
+async function startReadyDrive() {
   await vi.waitFor(() => {
     const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
     if (!el.contentWindow) throw new Error('not mounted yet');
   });
-  const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
-  let timer: ReturnType<typeof setInterval> | undefined;
-  await new Promise<void>((resolve) => {
-    const obs = new MutationObserver(() => {
-      if (el.getAttribute('data-block-ready') === 'true') {
-        if (timer) clearInterval(timer);
-        obs.disconnect();
-        resolve();
-      }
-    });
-    obs.observe(el, { attributes: true, attributeFilter: ['data-block-ready'] });
-    timer = setInterval(() => postFromBlock('BLOCK_READY', {}), 10);
-    postFromBlock('BLOCK_READY', {});
-  });
+  const timer = setInterval(() => postFromBlock('BLOCK_READY', {}), 10);
+  postFromBlock('BLOCK_READY', {});
+  return () => clearInterval(timer);
 }
 
 // Open the async upload, capture the modal's onAccepted, then simulate the modal's
@@ -220,14 +206,15 @@ describe('PageBlockHost OPEN_IMAGE_UPLOAD (asyncScan branch)', () => {
   /**
    * REGRESSION GUARD for the host-ready stale-closure race, on the upload gate.
    *
-   * Deliberately FIRST in the file: the coldest mount is the one whose commit most
-   * reliably exhausts React's 5ms frame budget and therefore yields before the
-   * passive-effect flush — the window this guard has to exist inside.
-   *
-   * The cost of a drop here is the worst of the four gates: `useImageUpload` sends
+   * The cost of a drop here is the worst of the five gates: `useImageUpload` sends
    * OPEN_IMAGE_UPLOAD with `PICKER_REQUEST_TIMEOUT_MS` (@civitai/blocks-react 0.39.0
-   * — 10 MINUTES, not the 30s default), and a same-requestId retry is swallowed by
-   * usePostMessage's 5s transport dedup.
+   * — 10 MINUTES, not the 30s default), so the block's promise is simply stuck.
+   *
+   * 🔴 The post is driven from `onReadyAttributeWrite`, NOT a MutationObserver — see
+   * test/commitWindow.tsx. A MutationObserver callback is a microtask that runs at the
+   * END of the scheduler task, often after React has already flushed the passive
+   * effects, which made the first version of this guard survive the mutant about one
+   * run in three.
    *
    * Proven reachable by mutation: move `statusRef.current = status` out of the render
    * body and back into an effect and this goes red on
@@ -236,11 +223,19 @@ describe('PageBlockHost OPEN_IMAGE_UPLOAD (asyncScan branch)', () => {
   test("OPEN_IMAGE_UPLOAD posted in React's commit→passive-effect gap still opens the modal", async () => {
     h.gateMutateAsync.mockResolvedValue({ status: 'pending' });
     renderWithProviders(<PageBlockHost {...baseProps} />);
-    await driveToReadyAtCommit();
-
-    postFromBlock('OPEN_IMAGE_UPLOAD', { requestId: 'rq_gap', asyncScan: true });
-
-    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+    const unpatch = onReadyAttributeWrite(() =>
+      postFromBlock('OPEN_IMAGE_UPLOAD', { requestId: 'rq_gap', asyncScan: true })
+    );
+    try {
+      const stopDrive = await startReadyDrive();
+      try {
+        await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+      } finally {
+        stopDrive();
+      }
+    } finally {
+      unpatch();
+    }
     expect(lastDialog().id).toBe('block-image-upload-rq_gap');
   });
 

--- a/src/components/AppBlocks/PageBlockHostReviewMode.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostReviewMode.browser.test.tsx
@@ -331,8 +331,10 @@ describe('PageBlockHost reviewMode — REQUEST_CONSENT gives the mod feedback, n
     renderWithProviders(<PageBlockHost {...baseProps} reviewMode onConsentGranted={vi.fn()} />);
     await driveToReady();
 
-    // Re-post inside waitFor: `data-block-ready` can lead the host's message-gate
-    // state by a tick, and a dropped fire-and-forget message is never retried.
+    // Posted inside waitFor so the assertion can retry while the notification
+    // renders. The gate no longer lags `data-block-ready` — the host reads a
+    // render-body-updated `statusRef` — so the post is not being re-sent to beat a
+    // stale handler.
     await vi.waitFor(() => {
       postFromBlock('REQUEST_CONSENT', { scopes: ['buzz:read:self'] });
       expect(showNotificationSpy).toHaveBeenCalledTimes(1);

--- a/src/components/AppBlocks/PageBlockHostSignIn.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSignIn.browser.test.tsx
@@ -3,6 +3,7 @@ import { page } from 'vitest/browser';
 import { useDialogStore } from '~/components/Dialog/dialogStore';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
+import { onReadyAttributeWrite } from '../../../test/commitWindow';
 
 /**
  * W10 sign-in-bridge gap regression (page surface).
@@ -150,38 +151,21 @@ async function driveToReady() {
 }
 
 /**
- * Drive to ready and hand control back at the EARLIEST instant `data-block-ready`
- * reports "true": the MutationObserver microtask checkpoint that ends the task which
- * COMMITTED the DOM. React flushes passive effects in a LATER task, so a handler that
- * closes over `status` is still the PREVIOUS render's closure — holding
- * `status === 'loading'` — at this exact moment. Everything posted from here therefore
- * exercises the commit→passive-effect window deterministically, instead of hoping a
- * 50ms `vi.waitFor` poll happens to land in it.
+ * Wait for the iframe to mount, then post BLOCK_READY on a CANCELLABLE interval.
  *
- * The drive is a CANCELLABLE interval rather than `vi.waitFor`: a floating waitFor
- * keeps posting BLOCK_READY after this returns, and that stray post lands in the NEXT
- * test — measured, it turned the "before BLOCK_READY is dropped" guard red for a
- * reason that has nothing to do with the race under study.
+ * Cancellable is load-bearing: a drive left running past the end of a test posts
+ * BLOCK_READY into the NEXT test's freshly-mounted host — measured, that turned the
+ * "before BLOCK_READY is dropped" guard below red for a reason having nothing to do
+ * with the race under study. Callers stop it in a `finally`.
  */
-async function driveToReadyAtCommit() {
+async function startReadyDrive() {
   await vi.waitFor(() => {
     const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
     if (!el.contentWindow) throw new Error('not mounted yet');
   });
-  const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
-  let timer: ReturnType<typeof setInterval> | undefined;
-  await new Promise<void>((resolve) => {
-    const obs = new MutationObserver(() => {
-      if (el.getAttribute('data-block-ready') === 'true') {
-        if (timer) clearInterval(timer);
-        obs.disconnect();
-        resolve();
-      }
-    });
-    obs.observe(el, { attributes: true, attributeFilter: ['data-block-ready'] });
-    timer = setInterval(() => postFromBlock('BLOCK_READY', {}), 10);
-    postFromBlock('BLOCK_READY', {});
-  });
+  const timer = setInterval(() => postFromBlock('BLOCK_READY', {}), 10);
+  postFromBlock('BLOCK_READY', {});
+  return () => clearInterval(timer);
 }
 
 describe('PageBlockHost REQUEST_SIGN_IN (W10 anonymous-conversion wiring)', () => {
@@ -200,25 +184,35 @@ describe('PageBlockHost REQUEST_SIGN_IN (W10 anonymous-conversion wiring)', () =
    * render-body-updated `statusRef` instead of a closed-over `status`) has to hold
    * for this handler.
    *
-   * Proven reachable by mutation: move the `statusRef.current = status` assignment
-   * out of the render body and back into an effect and this goes red on
-   * `expected "openLoginPopup" to be called 1 times, but got 0 times`.
+   * 🔴 The post is driven from `onReadyAttributeWrite`, NOT from a MutationObserver.
+   * That is the difference between a guard and a coin flip — see test/commitWindow.tsx
+   * for the two approaches that were measured and rejected. The short version: a
+   * MutationObserver callback is a microtask that runs at the END of the scheduler
+   * task, by which point React has often already flushed the passive effects, so the
+   * first version of this guard survived the mutant roughly one run in three.
    *
-   * It can never false-FAIL: if the passive effects happen to have flushed already,
-   * the handler is live and the post lands anyway.
+   * Proven reachable by mutation: move `statusRef.current = status` out of the render
+   * body and back into an effect and this goes red on `expected "openLoginPopup" to
+   * be called 1 times, but got 0 times`.
    */
   test("REQUEST_SIGN_IN posted in React's commit→passive-effect gap still starts the login", async () => {
     renderWithProviders(<PageBlockHost {...baseProps} />);
-    await driveToReadyAtCommit();
-    expect(openLoginPopup).not.toHaveBeenCalled();
-
-    // Synchronous dispatch from inside the commit-window checkpoint: the handler
-    // runs NOW, before React can flush passive effects and re-register a listener.
-    postFromBlock('REQUEST_SIGN_IN', {});
-
-    await vi.waitFor(() => {
-      expect(openLoginPopup).toHaveBeenCalledTimes(1);
-    });
+    // Fires synchronously on React's own stack, at the instant the host writes
+    // data-block-ready="true" — strictly before this commit's passive effects
+    // re-register a listener holding the fresh status.
+    const unpatch = onReadyAttributeWrite(() => postFromBlock('REQUEST_SIGN_IN', {}));
+    try {
+      const stopDrive = await startReadyDrive();
+      try {
+        await vi.waitFor(() => {
+          expect(openLoginPopup).toHaveBeenCalledTimes(1);
+        });
+      } finally {
+        stopDrive();
+      }
+    } finally {
+      unpatch();
+    }
   });
 
   test('after BLOCK_READY, REQUEST_SIGN_IN starts the hub login (defaults to the current page)', async () => {

--- a/src/components/AppBlocks/PageBlockHostSignIn.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSignIn.browser.test.tsx
@@ -149,10 +149,76 @@ async function driveToReady() {
   });
 }
 
+/**
+ * Drive to ready and hand control back at the EARLIEST instant `data-block-ready`
+ * reports "true": the MutationObserver microtask checkpoint that ends the task which
+ * COMMITTED the DOM. React flushes passive effects in a LATER task, so a handler that
+ * closes over `status` is still the PREVIOUS render's closure — holding
+ * `status === 'loading'` — at this exact moment. Everything posted from here therefore
+ * exercises the commit→passive-effect window deterministically, instead of hoping a
+ * 50ms `vi.waitFor` poll happens to land in it.
+ *
+ * The drive is a CANCELLABLE interval rather than `vi.waitFor`: a floating waitFor
+ * keeps posting BLOCK_READY after this returns, and that stray post lands in the NEXT
+ * test — measured, it turned the "before BLOCK_READY is dropped" guard red for a
+ * reason that has nothing to do with the race under study.
+ */
+async function driveToReadyAtCommit() {
+  await vi.waitFor(() => {
+    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+    if (!el.contentWindow) throw new Error('not mounted yet');
+  });
+  const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+  let timer: ReturnType<typeof setInterval> | undefined;
+  await new Promise<void>((resolve) => {
+    const obs = new MutationObserver(() => {
+      if (el.getAttribute('data-block-ready') === 'true') {
+        if (timer) clearInterval(timer);
+        obs.disconnect();
+        resolve();
+      }
+    });
+    obs.observe(el, { attributes: true, attributeFilter: ['data-block-ready'] });
+    timer = setInterval(() => postFromBlock('BLOCK_READY', {}), 10);
+    postFromBlock('BLOCK_READY', {});
+  });
+}
+
 describe('PageBlockHost REQUEST_SIGN_IN (W10 anonymous-conversion wiring)', () => {
   beforeEach(() => {
     useDialogStore.getState().closeAll();
     vi.mocked(openLoginPopup).mockClear();
+  });
+
+  /**
+   * REGRESSION GUARD for the host-ready stale-closure race.
+   *
+   * REQUEST_SIGN_IN is fire-and-forget — it carries no requestId and has no reply
+   * message — so a post dropped in this window is gone for good and the anonymous
+   * viewer's click on "Sign in" does nothing at all, silently. There is no NACK
+   * available to soften it, which is exactly why the root-cause fix (reading a
+   * render-body-updated `statusRef` instead of a closed-over `status`) has to hold
+   * for this handler.
+   *
+   * Proven reachable by mutation: move the `statusRef.current = status` assignment
+   * out of the render body and back into an effect and this goes red on
+   * `expected "openLoginPopup" to be called 1 times, but got 0 times`.
+   *
+   * It can never false-FAIL: if the passive effects happen to have flushed already,
+   * the handler is live and the post lands anyway.
+   */
+  test("REQUEST_SIGN_IN posted in React's commit→passive-effect gap still starts the login", async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReadyAtCommit();
+    expect(openLoginPopup).not.toHaveBeenCalled();
+
+    // Synchronous dispatch from inside the commit-window checkpoint: the handler
+    // runs NOW, before React can flush passive effects and re-register a listener.
+    postFromBlock('REQUEST_SIGN_IN', {});
+
+    await vi.waitFor(() => {
+      expect(openLoginPopup).toHaveBeenCalledTimes(1);
+    });
   });
 
   test('after BLOCK_READY, REQUEST_SIGN_IN starts the hub login (defaults to the current page)', async () => {

--- a/src/components/AppBlocks/PageBlockHostWorkflow.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostWorkflow.browser.test.tsx
@@ -518,26 +518,38 @@ describe('PageBlockHost workflow bridge (W10 money-path wiring)', () => {
    *
    * POSITIVE CONTROL is load-bearing here: this asserts a ZERO (no modal, no reply),
    * and a host whose listener was never live produces that same zero. The control
-   * proves the handler is live and replying BEFORE the zero is read, so the zero is
-   * a measurement rather than an artefact of a dead listener.
+   * proves the handler is live AND that a BUZZ_PURCHASE_RESULT is observable at all
+   * before the zero is read, so the zero is a measurement rather than an artefact.
+   *
+   * 🔴 COUNT ONLY `BUZZ_PURCHASE_RESULT`, never `received.length`. The host pushes
+   * unrelated messages of its own (BLOCK_INIT, TOKEN_REFRESH, ROUTE_CHANGED) from
+   * effects, on a schedule this test does not control — so a TOTAL message count
+   * drifts for reasons that have nothing to do with the assertion. Measured: an
+   * earlier draft counting `received.length` failed on `expected 1 to be +0`
+   * against a host that was behaving perfectly, once the drive handed back inside
+   * React's commit window.
    */
   test('OPEN_BUZZ_PURCHASE with NO requestId is dropped silently (nothing to reply to)', async () => {
     renderWithProviders(<PageBlockHost {...baseProps} />);
     await driveToReady();
     const replies = listenForReply();
+    const buzzReplies = () => replies.received.filter((m) => m.type === 'BUZZ_PURCHASE_RESULT');
 
-    // POSITIVE CONTROL: a well-formed request DOES get through and open the modal.
+    // POSITIVE CONTROL: a well-formed request DOES get through and open the modal,
+    // and closing it DOES produce an observable BUZZ_PURCHASE_RESULT.
     postFromBlock('OPEN_BUZZ_PURCHASE', { requestId: 'rq_control', suggestedAmount: 10 });
     await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+    useDialogStore.getState().dialogs[0].options?.onClose?.();
+    await vi.waitFor(() => expect(buzzReplies()).toHaveLength(1));
     useDialogStore.getState().closeAll();
-    const repliesBefore = replies.received.length;
 
     // The real case: no requestId at all.
     postFromBlock('OPEN_BUZZ_PURCHASE', { suggestedAmount: 1000 });
 
     await new Promise((r) => setTimeout(r, 150));
     expect(useDialogStore.getState().dialogs).toHaveLength(0);
-    expect(replies.received.length).toBe(repliesBefore);
+    // Still exactly the control's reply — the malformed post added none.
+    expect(buzzReplies()).toHaveLength(1);
     replies.stop();
   });
 

--- a/src/components/AppBlocks/PageBlockHostWorkflow.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostWorkflow.browser.test.tsx
@@ -184,6 +184,39 @@ async function driveToReady() {
   });
 }
 
+/**
+ * Drive to ready and hand control back at the EARLIEST instant `data-block-ready`
+ * reports "true": the MutationObserver microtask checkpoint that ends the task which
+ * COMMITTED the DOM. React flushes passive effects in a LATER task, so a handler that
+ * closes over `status` is still the PREVIOUS render's closure — holding
+ * `status === 'loading'` — at this exact moment.
+ *
+ * The drive is a CANCELLABLE interval rather than `vi.waitFor`: a floating waitFor
+ * keeps posting BLOCK_READY after this returns, and that stray post lands in the NEXT
+ * test — measured, it turned the "before BLOCK_READY is dropped" guard below red for
+ * a reason that has nothing to do with the race under study.
+ */
+async function driveToReadyAtCommit() {
+  await vi.waitFor(() => {
+    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+    if (!el.contentWindow) throw new Error('not mounted yet');
+  });
+  const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+  let timer: ReturnType<typeof setInterval> | undefined;
+  await new Promise<void>((resolve) => {
+    const obs = new MutationObserver(() => {
+      if (el.getAttribute('data-block-ready') === 'true') {
+        if (timer) clearInterval(timer);
+        obs.disconnect();
+        resolve();
+      }
+    });
+    obs.observe(el, { attributes: true, attributeFilter: ['data-block-ready'] });
+    timer = setInterval(() => postFromBlock('BLOCK_READY', {}), 10);
+    postFromBlock('BLOCK_READY', {});
+  });
+}
+
 describe('PageBlockHost workflow bridge (W10 money-path wiring)', () => {
   beforeEach(() => {
     mocks.submit.mockReset();
@@ -414,7 +447,45 @@ describe('PageBlockHost workflow bridge (W10 money-path wiring)', () => {
     expect(dialogProps.minBuzzAmount).toBe(50_000);
   });
 
-  test('OPEN_BUZZ_PURCHASE before BLOCK_READY is dropped (no pre-handshake spend modal)', async () => {
+  /**
+   * REGRESSION GUARD for the host-ready stale-closure race, on the money gate.
+   *
+   * OPEN_BUZZ_PURCHASE is request/response: the block awaits BUZZ_PURCHASE_RESULT
+   * on a promise that rejects only at the SDK's 30s default request timeout
+   * (`DEFAULT_REQUEST_TIMEOUT_MS`, @civitai/blocks-react 0.39.0), and a retry
+   * carrying the same requestId is swallowed by usePostMessage's 5s transport-level
+   * dedup — so a drop here is expensive.
+   *
+   * Proven reachable by mutation: move `statusRef.current = status` out of the
+   * render body and back into an effect and this goes red on
+   * `expected [] to have a length of 1`.
+   */
+  test("OPEN_BUZZ_PURCHASE posted in React's commit→passive-effect gap still opens the modal", async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReadyAtCommit();
+
+    postFromBlock('OPEN_BUZZ_PURCHASE', { requestId: 'rq_gap', suggestedAmount: 1000 });
+
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+    // Pin the per-request dialog id, so this proves THIS post opened the modal.
+    expect(useDialogStore.getState().dialogs[0].id).toBe('block-buy-buzz-rq_gap');
+  });
+
+  /**
+   * The gate's REFUSAL is unchanged — no pre-handshake spend modal, ever. What
+   * changed is that the refusal is now SPOKEN instead of silent.
+   *
+   * Previously this branch dropped the message with a bare `return`, leaving the
+   * block's promise to hang for the SDK's full 30s request timeout with a requestId
+   * that the transport's 5s dedup makes un-retryable. The reviewMode branch a few
+   * lines above in the handler already replied for exactly this reason ("Reply the
+   * not-purchased result the block awaits (fail-fast, no hang)"); this branch simply
+   * did not, and that asymmetry was the bug.
+   *
+   * `purchased: false` is the same shape reviewMode sends and the same shape
+   * `useBuzzPurchase` reads as "no purchase happened". Nothing is charged.
+   */
+  test('OPEN_BUZZ_PURCHASE before BLOCK_READY opens no modal and NACKs (never hangs)', async () => {
     renderWithProviders(<PageBlockHost {...baseProps} />);
     // Do NOT drive to ready — fire while status is still 'loading'.
     await vi.waitFor(() => {
@@ -425,9 +496,48 @@ describe('PageBlockHost workflow bridge (W10 money-path wiring)', () => {
 
     postFromBlock('OPEN_BUZZ_PURCHASE', { requestId: 'rq_buzz_early', suggestedAmount: 1000 });
 
+    await vi.waitFor(() => {
+      const r = replies.last('BUZZ_PURCHASE_RESULT');
+      if (!r) throw new Error('no NACK yet');
+    });
+    // THE security property, unchanged: the spend modal never opened.
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+    // THE new property: the block was told, on its own requestId, so it fails fast.
+    expect(replies.last('BUZZ_PURCHASE_RESULT')!.payload).toEqual({
+      requestId: 'rq_buzz_early',
+      purchased: false,
+    });
+    replies.stop();
+  });
+
+  /**
+   * The OTHER reason `resolveBuzzPurchaseRequest` returns null: a malformed payload
+   * with no string requestId. That one is legitimately UNREPLIABLE — there is no id
+   * to thread a reply back on — so it must still be dropped in total silence, and
+   * the NACK above must not have widened into "reply to everything".
+   *
+   * POSITIVE CONTROL is load-bearing here: this asserts a ZERO (no modal, no reply),
+   * and a host whose listener was never live produces that same zero. The control
+   * proves the handler is live and replying BEFORE the zero is read, so the zero is
+   * a measurement rather than an artefact of a dead listener.
+   */
+  test('OPEN_BUZZ_PURCHASE with NO requestId is dropped silently (nothing to reply to)', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    // POSITIVE CONTROL: a well-formed request DOES get through and open the modal.
+    postFromBlock('OPEN_BUZZ_PURCHASE', { requestId: 'rq_control', suggestedAmount: 10 });
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+    useDialogStore.getState().closeAll();
+    const repliesBefore = replies.received.length;
+
+    // The real case: no requestId at all.
+    postFromBlock('OPEN_BUZZ_PURCHASE', { suggestedAmount: 1000 });
+
     await new Promise((r) => setTimeout(r, 150));
     expect(useDialogStore.getState().dialogs).toHaveLength(0);
-    expect(replies.last('BUZZ_PURCHASE_RESULT')).toBeUndefined();
+    expect(replies.received.length).toBe(repliesBefore);
     replies.stop();
   });
 
@@ -831,9 +941,9 @@ describe('PageBlockHost workflow bridge (W10 money-path wiring)', () => {
       const r = replies.last('WORKFLOW_SUBMITTED');
       if (!r) throw new Error('no reply yet');
       expect(r.payload).toEqual({ requestId: 'rq_acct', snapshot });
-      expect((r.payload as { snapshot: { spentAccountType?: string } }).snapshot.spentAccountType).toBe(
-        'green'
-      );
+      expect(
+        (r.payload as { snapshot: { spentAccountType?: string } }).snapshot.spentAccountType
+      ).toBe('green');
     });
     replies.stop();
   });

--- a/src/components/AppBlocks/PageBlockHostWorkflow.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostWorkflow.browser.test.tsx
@@ -3,6 +3,7 @@ import { page } from 'vitest/browser';
 import { useDialogStore } from '~/components/Dialog/dialogStore';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
+import { onReadyAttributeWrite } from '../../../test/commitWindow';
 
 /**
  * W10 money-path bridge gap regression (page surface).
@@ -185,36 +186,21 @@ async function driveToReady() {
 }
 
 /**
- * Drive to ready and hand control back at the EARLIEST instant `data-block-ready`
- * reports "true": the MutationObserver microtask checkpoint that ends the task which
- * COMMITTED the DOM. React flushes passive effects in a LATER task, so a handler that
- * closes over `status` is still the PREVIOUS render's closure — holding
- * `status === 'loading'` — at this exact moment.
+ * Wait for the iframe to mount, then post BLOCK_READY on a CANCELLABLE interval.
  *
- * The drive is a CANCELLABLE interval rather than `vi.waitFor`: a floating waitFor
- * keeps posting BLOCK_READY after this returns, and that stray post lands in the NEXT
- * test — measured, it turned the "before BLOCK_READY is dropped" guard below red for
- * a reason that has nothing to do with the race under study.
+ * Cancellable is load-bearing: a drive left running past the end of a test posts
+ * BLOCK_READY into the NEXT test's freshly-mounted host — measured, that turned the
+ * "before BLOCK_READY is dropped" guard below red for a reason having nothing to do
+ * with the race under study. Callers stop it in a `finally`.
  */
-async function driveToReadyAtCommit() {
+async function startReadyDrive() {
   await vi.waitFor(() => {
     const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
     if (!el.contentWindow) throw new Error('not mounted yet');
   });
-  const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
-  let timer: ReturnType<typeof setInterval> | undefined;
-  await new Promise<void>((resolve) => {
-    const obs = new MutationObserver(() => {
-      if (el.getAttribute('data-block-ready') === 'true') {
-        if (timer) clearInterval(timer);
-        obs.disconnect();
-        resolve();
-      }
-    });
-    obs.observe(el, { attributes: true, attributeFilter: ['data-block-ready'] });
-    timer = setInterval(() => postFromBlock('BLOCK_READY', {}), 10);
-    postFromBlock('BLOCK_READY', {});
-  });
+  const timer = setInterval(() => postFromBlock('BLOCK_READY', {}), 10);
+  postFromBlock('BLOCK_READY', {});
+  return () => clearInterval(timer);
 }
 
 describe('PageBlockHost workflow bridge (W10 money-path wiring)', () => {
@@ -450,23 +436,36 @@ describe('PageBlockHost workflow bridge (W10 money-path wiring)', () => {
   /**
    * REGRESSION GUARD for the host-ready stale-closure race, on the money gate.
    *
-   * OPEN_BUZZ_PURCHASE is request/response: the block awaits BUZZ_PURCHASE_RESULT
-   * on a promise that rejects only at the SDK's 30s default request timeout
-   * (`DEFAULT_REQUEST_TIMEOUT_MS`, @civitai/blocks-react 0.39.0), and a retry
-   * carrying the same requestId is swallowed by usePostMessage's 5s transport-level
-   * dedup — so a drop here is expensive.
+   * OPEN_BUZZ_PURCHASE is request/response: the block awaits BUZZ_PURCHASE_RESULT on
+   * a promise that rejects only at the SDK's 30s default request timeout
+   * (`DEFAULT_REQUEST_TIMEOUT_MS`, @civitai/blocks-react 0.39.0) — so a drop here
+   * costs the user's click plus half a minute of nothing.
    *
-   * Proven reachable by mutation: move `statusRef.current = status` out of the
-   * render body and back into an effect and this goes red on
-   * `expected [] to have a length of 1`.
+   * 🔴 The post is driven from `onReadyAttributeWrite`, NOT a MutationObserver — see
+   * test/commitWindow.tsx. A MutationObserver callback is a microtask that runs at the
+   * END of the scheduler task, often after React has already flushed the passive
+   * effects, which made the first version of this guard survive the mutant about one
+   * run in three.
+   *
+   * Proven reachable by mutation: move `statusRef.current = status` out of the render
+   * body and back into an effect and this goes red on `expected [] to have a length
+   * of 1`.
    */
   test("OPEN_BUZZ_PURCHASE posted in React's commit→passive-effect gap still opens the modal", async () => {
     renderWithProviders(<PageBlockHost {...baseProps} />);
-    await driveToReadyAtCommit();
-
-    postFromBlock('OPEN_BUZZ_PURCHASE', { requestId: 'rq_gap', suggestedAmount: 1000 });
-
-    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+    const unpatch = onReadyAttributeWrite(() =>
+      postFromBlock('OPEN_BUZZ_PURCHASE', { requestId: 'rq_gap', suggestedAmount: 1000 })
+    );
+    try {
+      const stopDrive = await startReadyDrive();
+      try {
+        await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+      } finally {
+        stopDrive();
+      }
+    } finally {
+      unpatch();
+    }
     // Pin the per-request dialog id, so this proves THIS post opened the modal.
     expect(useDialogStore.getState().dialogs[0].id).toBe('block-buy-buzz-rq_gap');
   });
@@ -476,8 +475,8 @@ describe('PageBlockHost workflow bridge (W10 money-path wiring)', () => {
    * changed is that the refusal is now SPOKEN instead of silent.
    *
    * Previously this branch dropped the message with a bare `return`, leaving the
-   * block's promise to hang for the SDK's full 30s request timeout with a requestId
-   * that the transport's 5s dedup makes un-retryable. The reviewMode branch a few
+   * block's promise to hang for the SDK's full 30s request timeout. The reviewMode
+   * branch a few
    * lines above in the handler already replied for exactly this reason ("Reply the
    * not-purchased result the block awaits (fail-fast, no hang)"); this branch simply
    * did not, and that asymmetry was the bug.

--- a/src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts
+++ b/src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts
@@ -19,6 +19,7 @@ import {
   resolveResourcePickerRequest,
   resolveReviewConsentNotice,
   resolveUngrantableConsentScopes,
+  toHostGateStatus,
   PAGE_RESOURCE_PICKER_TYPES,
   type PageHostStatus,
 } from '../pageBlockHostLogic';
@@ -870,5 +871,41 @@ describe('MID_SESSION_LOSS_ERROR_CLASS survives the server-side allowlist', () =
     // Control: an unknown class really does collapse, so the assertion above is
     // proving membership rather than proving normalizeErrorClass is a no-op.
     expect(normalizeErrorClass('error', 'not_a_real_class')).toBe('other');
+  });
+});
+
+/**
+ * `toHostGateStatus` — the ONE copy of the status shim the five status-gated
+ * PageBlockHost message handlers share (REQUEST_CONSENT, OPEN_BUZZ_PURCHASE,
+ * REQUEST_SIGN_IN, OPEN_IMAGE_UPLOAD, NAVIGATE). It used to be open-coded at every
+ * one of them.
+ *
+ * The property that actually matters is NOT the specific `'error' → 'no_token'`
+ * pairing — it is that `'ready'` is the ONLY input that survives as `'ready'`.
+ * Every gate is `=== 'ready'`, so any mapping that invented a `'ready'` would
+ * open a money/permission gate on a terminal host. That is asserted
+ * exhaustively over the whole `PageHostStatus` union below rather than by
+ * spot-checking, so a future variant added to the union cannot slip through
+ * unmapped.
+ */
+describe('toHostGateStatus', () => {
+  const ALL: PageHostStatus[] = ['loading', 'ready', 'timeout', 'fatal', 'no_token', 'error'];
+
+  it("maps PageBlockHost's extra terminal 'error' onto a non-ready sentinel", () => {
+    expect(toHostGateStatus('error')).toBe('no_token');
+  });
+
+  it('passes every other variant through unchanged', () => {
+    for (const s of ALL.filter((v) => v !== 'error')) {
+      expect(toHostGateStatus(s)).toBe(s);
+    }
+  });
+
+  it("yields 'ready' for 'ready' and for NOTHING else (the gate-opening property)", () => {
+    // Positive control first: the mapping can produce 'ready' at all, so the
+    // zero below is a measurement and not a function that returns a constant.
+    expect(toHostGateStatus('ready')).toBe('ready');
+    const openers = ALL.filter((s) => toHostGateStatus(s) === 'ready');
+    expect(openers).toEqual(['ready']);
   });
 });

--- a/src/components/AppBlocks/pageBlockHostLogic.ts
+++ b/src/components/AppBlocks/pageBlockHostLogic.ts
@@ -4,14 +4,32 @@
 // collects `*.test.ts`). Mirrors the IframeHost `hostRenderDecision` pattern.
 
 import { isKnownBlockScope } from '~/shared/constants/block-scope.constants';
+import type { HostStatus } from './openBuzzPurchaseGate';
 
-export type PageHostStatus =
-  | 'loading'
-  | 'ready'
-  | 'timeout'
-  | 'fatal'
-  | 'no_token'
-  | 'error';
+export type PageHostStatus = 'loading' | 'ready' | 'timeout' | 'fatal' | 'no_token' | 'error';
+
+/**
+ * Collapse PageBlockHost's local `Status` onto the shared `HostStatus` union the
+ * status-gated message handlers speak: `resolveRequestConsent`,
+ * `resolveBuzzPurchaseRequest`, `resolveRequestSignIn`, the inline
+ * OPEN_IMAGE_UPLOAD gate, and NAVIGATE.
+ *
+ * PageBlockHost carries one extra terminal variant — `'error'`, a hard mint
+ * failure — that the shared union does not model. Every gate opens ONLY on
+ * `'ready'` and `'error'` is a disjoint terminal state (the iframe isn't even
+ * rendered), so mapping it to another non-ready sentinel is semantics-preserving:
+ * the gate would return null either way. This just satisfies the union type.
+ *
+ * ONE RULE, ONE PLACE. This shim used to be open-coded at four of those call
+ * sites (NAVIGATE hand-rolled a fifth, slightly different comparison). N copies of
+ * a predicate is N chances to fix N−1 of them; it is centralised here so the
+ * mapping is unit-testable and can only ever be changed in one place. Callers read
+ * it through PageBlockHost's `readGateStatus`, which additionally sources the
+ * status from a render-body-updated ref rather than a stale effect closure.
+ */
+export function toHostGateStatus(status: PageHostStatus): HostStatus {
+  return status === 'error' ? 'no_token' : status;
+}
 
 /**
  * #3/#6: the scopes the minted page JWT ACTUALLY carries — the page manifest's
@@ -57,9 +75,7 @@ export function resolveUngrantableConsentScopes(
   missingScopes: string[] | undefined
 ): string[] {
   if (!Array.isArray(rawScopesHint)) return [];
-  const requested = rawScopesHint.filter(
-    (s): s is string => typeof s === 'string' && s.length > 0
-  );
+  const requested = rawScopesHint.filter((s): s is string => typeof s === 'string' && s.length > 0);
   if (requested.length === 0) return [];
   const granted = new Set<string>(grantedScopes);
   const missing = new Set<string>(missingScopes ?? []);
@@ -289,7 +305,11 @@ export function resolveResourcePickerRequest(raw: unknown): ResourcePickerReques
       ? obj.baseModelGroup
       : undefined;
 
-  return { requestId: obj.requestId, resourceType: canonical, ...(baseModelGroup ? { baseModelGroup } : {}) };
+  return {
+    requestId: obj.requestId,
+    resourceType: canonical,
+    ...(baseModelGroup ? { baseModelGroup } : {}),
+  };
 }
 
 // ── OPEN_CHECKPOINT_PICKER (parity with the model-slot IframeHost) ────────────
@@ -463,9 +483,7 @@ export function resolveGetImagesByIdsRequest(raw: unknown): GetImagesByIdsReques
   const obj = raw as Record<string, unknown>;
   if (typeof obj.requestId !== 'string' || obj.requestId.length === 0) return null;
   const imageIds = Array.isArray(obj.imageIds)
-    ? obj.imageIds.filter(
-        (n): n is number => typeof n === 'number' && Number.isInteger(n) && n > 0
-      )
+    ? obj.imageIds.filter((n): n is number => typeof n === 'number' && Number.isInteger(n) && n > 0)
     : [];
   return { requestId: obj.requestId, imageIds };
 }
@@ -617,9 +635,7 @@ export function worstReachableLaunchMs(): number {
 
 /** Terminal statuses a bounded auto-retry may attempt to recover from. */
 export function isAutoRetryableStatus(status: PageHostStatus): boolean {
-  return (
-    status === 'timeout' || status === 'fatal' || status === 'no_token' || status === 'error'
-  );
+  return status === 'timeout' || status === 'fatal' || status === 'no_token' || status === 'error';
 }
 
 /**

--- a/test/commitWindow.tsx
+++ b/test/commitWindow.tsx
@@ -1,0 +1,70 @@
+/**
+ * A DETERMINISTIC foothold inside React's commit→passive-effect window, for the
+ * browser tier.
+ *
+ * ── WHAT WINDOW, AND WHY IT NEEDS REPRODUCING ───────────────────────────────────
+ *
+ * A host component gates a postMessage handler on a piece of state. React writes
+ * commit-time output (a DOM attribute) during the COMMIT, but the `useEffect` that
+ * re-registers the handler with the fresh state is a PASSIVE effect, flushed later.
+ * A message arriving in between meets the PREVIOUS render's closure. Any guard for
+ * that bug has to post its message inside the window, on purpose, every run.
+ *
+ * ── TWO OBVIOUS APPROACHES, BOTH MEASURED, BOTH WRONG ───────────────────────────
+ *
+ * 1. `MutationObserver` on the attribute. Its callback is a MICROTASK: it runs when
+ *    the JS stack unwinds, i.e. at the END of the whole scheduler task. React's work
+ *    loop keeps running callbacks inside that SAME MessageChannel task while
+ *    `shouldYieldToHost()` is false, so the passive flush frequently happens BEFORE
+ *    the checkpoint. Measured: a MutationObserver-driven guard killed its mutant
+ *    2 / 2 / 3 times over three runs — each guard survived roughly one run in three.
+ *    A guard that is a coin flip is not a regression test.
+ *
+ * 2. A SIBLING component with `useLayoutEffect`. Layout effects genuinely are ordered
+ *    before the same commit's passive effects, so the ordering reasoning is sound —
+ *    but the premise is not: the host's internal `setStatus` re-renders the HOST, not
+ *    its sibling, so the sibling's layout effect never runs again after mount.
+ *    Measured: exactly ONE layout tick, observing `data-block-ready="false"`, and the
+ *    probe never fired at all.
+ *
+ * ── WHAT ACTUALLY WORKS: THE ATTRIBUTE WRITE ITSELF ─────────────────────────────
+ *
+ * React writes the attribute with `Element.prototype.setAttribute` during the
+ * commit's MUTATION phase. Wrapping that method means the callback runs
+ * SYNCHRONOUSLY, on React's own stack, at the exact instant the host publishes
+ * readiness — strictly before the layout phase and therefore strictly before ANY of
+ * this commit's passive effects. There is no scheduling involved, so there is
+ * nothing to lose a race to: it is ordered by the call stack, not by a queue.
+ *
+ * That is deliberately invasive, and it is scoped accordingly: the patch is
+ * installed for the duration of one drive and removed by the returned disposer,
+ * which callers run in a `finally`.
+ */
+
+/**
+ * Run `run()` exactly once, synchronously, the first time any element's
+ * `data-block-ready` attribute is set to `"true"` — i.e. inside React's commit,
+ * before this commit's passive effects flush.
+ *
+ * Returns a disposer that restores the original `setAttribute`. ALWAYS call it in a
+ * `finally`: leaving a patched prototype behind would leak into every later test in
+ * the file.
+ */
+export function onReadyAttributeWrite(run: () => void): () => void {
+  const original = Element.prototype.setAttribute;
+  let fired = false;
+  Element.prototype.setAttribute = function patched(
+    this: Element,
+    name: string,
+    value: string
+  ): void {
+    original.call(this, name, value);
+    if (fired) return;
+    if (name !== 'data-block-ready' || value !== 'true') return;
+    fired = true;
+    run();
+  };
+  return () => {
+    Element.prototype.setAttribute = original;
+  };
+}


### PR DESCRIPTION
> **Revised after an independent adversarial audit.** The audit found no functional defect in the shipped code, but four of my claims did not hold and one was load-bearing (the regression guards were stochastic). All four are fixed in `2ad2800b47`; the numbers below are the post-fix, re-measured ones.

## What

`PageBlockHost`'s status-gated postMessage handlers close over `status` from the render that registered them. React writes the `data-block-ready` DOM attribute during the **commit**, but flushes passive effects — the ones that re-register the listener with a fresh `status` — later. So there is a window in which the host publicly reports ready while the live handler still holds `status === 'loading'` and drops the message.

Two independent changes.

**1. Root cause.** `statusRef.current = status` moves to the **render body**; it was updated in an effect, which has exactly the deferral being fixed. The handlers read it through one shared `readGateStatus()` instead of four open-coded copies of the `'error' → 'no_token'` shim (plus a fifth, slightly different comparison hand-rolled in `NAVIGATE`). The shim is now a single unit-tested pure function, `toHostGateStatus`. `status` drops out of those five effects' dependency arrays, so they subscribe **once per mount** rather than re-registering on every status transition — the window cannot exist if the listener never needs replacing.

The audit independently confirmed the handler enumeration is complete: all 42 `onMessage` registrations reviewed, exactly five gate on `status`, no sixth.

**2. Never hang.** The two gates that carry a `requestId` now NACK when they genuinely refuse, mirroring the `reviewMode` branches in the same handlers that already did this ("Reply the bare (cancelled) result the block awaits so it fails fast (no hang)"). The refusals themselves are unchanged — no modal opens, nothing is charged.

| Gate | NACK? | Why |
|---|---|---|
| `OPEN_IMAGE_UPLOAD` | bare `{ requestId }` | Request/response. `useImageUpload` sends it with `PICKER_REQUEST_TIMEOUT_MS` — **10 minutes**, not the 30s default. Bare is the `dismissed` shape the SDK already handles. |
| `OPEN_BUZZ_PURCHASE` | `{ requestId, purchased: false }` | Request/response, SDK's 30s `DEFAULT_REQUEST_TIMEOUT_MS`. Same shape `reviewMode` already sends. |
| `REQUEST_SIGN_IN` | no | Fire-and-forget `dispatch`, no `requestId`, no reply message exists. |
| `REQUEST_CONSENT` | no | Same — documented fire-and-forget. |
| `NAVIGATE` | no | Same — no `requestId`. |
| missing/non-string `requestId` | no | Legitimately **unrepliable**. Still silent, and pinned by a guard so the NACK cannot widen into "reply to everything". |

## Measured vs inferred

**Measured.**
- The handler is stale at the instant `data-block-ready` is written — pinned deterministically, see below.
- SDK contract, read from the real `@civitai/blocks-react@0.39.0` tarball: `IframeTransport` auto-sends `BLOCK_READY` on `BLOCK_INIT`; request timeouts are 30s default and 10min for the picker; a dropped `IMAGE_UPLOAD_RESULT` with no `selected` reads as `dismissed`.
- Structural: there is **no host→block "host is ready" message**. `status` becomes `'ready'` only as a *result* of the block's own `BLOCK_READY` being processed.

**Inferred, NOT observed.**
- That a deployed block hits this. **No SDK code path auto-posts a gated request on ready** — all four are `useCallback`s the app invokes. Reaching the window needs *app* code that calls one in the same turn it observes ready. No such block was observed; I established the absence of an **SDK** caller and did not enumerate deployed third-party block source. **This is a latent defect being closed, not a reported outage.**

**Residual window.** This closes the commit→passive-effect gap, not the larger message-received→render gap: a block posting in the *same turn* as its own `BLOCK_READY` still meets a `'loading'` mirror. Mirroring the transition into the ref from the `BLOCK_READY` handler was considered and rejected (it re-implements the updater's predicate against the ref and disagrees whenever another `setStatus` is queued). The NACKs cover that remainder.

**Concurrent-rendering safety — corrected.** My original claim that ref-ahead-of-DOM is "always the permissive direction, never a drop" was **wrong**, and it is the sentence a maintainer would rely on when pointing a new gate at this ref. It inherits the direction of the transition in flight, and this component has both:
- `loading → ready` is **permissive** — the ref says ready while the attribute still reads `false`. Harmless; it is the point of the fix.
- `ready → error` (mid-session token loss, `:857`) and `ready → fatal` (`BLOCK_ERROR{fatal:true}`, `:1031`) are **restrictive** — a concurrent render can write `'error'`, yield before commit, and refuse a queued `OPEN_BUZZ_PURCHASE` while the attribute still reads `true`.

The restrictive case is deliberate and is the safer side: the ref is the host's freshest knowledge of its own state. Corrected in the source comment, which is where it matters.

## Verification

**The guards are now deterministic — this was the audit's most serious finding.** The first version drove the window from a `MutationObserver`; that callback is a *microtask* running at the end of the scheduler task, while React's work loop keeps going inside the same MessageChannel task while `shouldYieldToHost()` is false. Measured: the mutant was killed **2 / 2 / 3** times across three runs — each guard survived about one run in three, and my "3 red" was not reproducible. My own comment "it can never false-FAIL" was an admission the guard silently degrades to a no-op.

Now driven by `onReadyAttributeWrite` (`test/commitWindow.tsx`): React calls `Element.prototype.setAttribute` during the commit's mutation phase, so the callback runs **synchronously on React's own stack** — ordered by the call stack, not by a queue.

A sibling `useLayoutEffect` probe was tried first and rejected: the ordering argument is sound but the premise is not — the host's `setStatus` re-renders the host, not its sibling, so the sibling's layout effect never runs again after mount (measured: one tick, `data-block-ready="false"`, probe never fired). Both dead ends are documented in the helper.

**Mutation sweep**, run over the whole 342-test AppBlocks browser suite. Each mutant red at *its own* assertion:

| Mutant | Result |
|---|---|
| harness positive control (upload handler never opens a modal) | **12 red** — the harness provably observes |
| `statusRef` back in an effect (= pre-change code) | **4 red**, exactly the four commit-window guards — and **5/5 runs, 20/20 per-guard** |
| kill the `REQUEST_CONSENT` gate | **13 red**, including the no-op test below — proving its new control observes |
| drop the `OPEN_BUZZ_PURCHASE` NACK | **1 red** |
| drop the `OPEN_IMAGE_UPLOAD` NACK | **1 red** |
| widen the buzz NACK to answer the unrepliable case | **1 red** |
| `toHostGateStatus` returns `'ready'` for everything | **4 red** — the pre-handshake security gates are pinned |

| Check | Base `27431d86d9` | HEAD |
|---|---|---|
| all `src/components/AppBlocks` browser | — | **342/342** |
| `pageBlockHostLogic` unit | 77/77 | **80/80** |
| typecheck (`scripts/typecheck.mjs`) | — | **0 errors** |
| prettier, changed files | — | clean |
| eslint, touched files | 7 errors | **7 errors — zero delta** |

**Two things I withdrew rather than defended.**

- **"9 exposed tests" is retracted as a measurement.** It counted tests the race turned *red*, and is structurally blind to those it made vacuously *green*; the auditor's equivalent experiment gave 11/51, and with the stochastic drive neither number was stable. The blind spot that mattered was real: `REQUEST_CONSENT with nothing missing is a no-op` asserts only zeros, and a host that **dropped** the message produces the same zeros — so it could pass without exercising its own subject. It now posts an un-grantable scope first and waits for the toast, proving the handler is live before the zero is read.
- **The "same-requestId retry is swallowed by the 5s dedup" argument is dropped.** True of `usePostMessage` in isolation, but unreachable from the SDK: `nextRequestId()` is `random6 + a monotonic counter`, so every call mints a fresh id. The 10-minute / 30-second hang argument stands on its own.

**Inert workaround retired.** `openUploadModal`'s fresh-id retry loop was a test-side workaround for this production bug and can no longer take a second attempt. It is deleted, not left in place — an inert retry whose comment calls both halves load-bearing is a false claim, and the next person to hit a similar flake would copy it. The stale comments in `PageBlockHost.browser.test.tsx` and `PageBlockHostReviewMode.browser.test.tsx` describing the gate as lagging `data-block-ready` are corrected too.

## What I could not verify

- **The canonical component tier.** Everything ran locally on a nixpkgs `chrome-headless-shell` (Chrome for Testing 149), not CI's bundled Chromium. CI's `preview / component-tests` is the only authority; I am not claiming that tier green.
- **Whether any deployed block reaches the window** — see "inferred" above.
- `hiddenBlocks.test.ts` has **7 pre-existing failures**, identical at the base commit with the changed files reverted. Unrelated.

## Follow-up filed

#3685 — after this PR, `OPEN_BUZZ_PURCHASE` has two observable behaviours: the page host replies in a tick, `IframeHost` still hangs the block for 30s, and `useBuzzPurchase` is host-agnostic. `hostHandlerParity.ts` records only message *types*, so nothing in the repo will catch the divergence. Filed rather than fixed here — the measured evidence is all on `PageBlockHost`.

## Note for the reviewer

The diff is inflated: `main` was already prettier-non-conformant on `PageBlockHost.tsx` and `pageBlockHostLogic.ts`, so running the formatter produced reformat hunks around a much smaller real change. The behavioural change is confined to the `statusRef`/`readGateStatus` block, the five gate call sites, and the two NACK branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aj1HosDFkP6LgxMAtJdDmJ
