### PR TITLE
test(blocks): mutation-verified coverage for two inline-ComfyUI guards (AIR source allowlist — uncovered; owner Private/epoch subscription gate)

### DIFF
--- a/src/server/services/blocks/__tests__/inline-comfy.guards.test.ts
+++ b/src/server/services/blocks/__tests__/inline-comfy.guards.test.ts
@@ -34,35 +34,66 @@ import { assertViewerEntitledToInlineResources } from '~/server/services/blocks/
  *     cannot fire at all, and (b) asserts the source guard's own distinct
  *     wording — including that the message does NOT mention `AIR type`.
  *
- *   GUARD 2 — the non-moderator entitlement gate for Private / epoch resources
+ *   GUARD 2 — the SUBSCRIPTION requirement on Private / epoch resources
  *     (`if (hasPrivateOrEpoch && !opts.user.isModerator)`).
  *
- *     🔴 THIS IS A LIVE GATE ON A REACHABLE, BUZZ-SPENDING PATH — NOT DEAD CODE.
- *     An earlier draft of this comment said non-moderators cannot obtain an App
- *     Blocks dev token, so the gate could never be reached by one. That was
- *     WRONG, and it was wrong in the direction that invites deleting this file:
- *     a maintainer reading "unreachable" has every reason to drop the coverage.
+ *     🔴 READ THIS BEFORE ASSUMING WHAT THESE TESTS COVER. This gate does NOT
+ *     stop an untrusted developer pinning a Private resource they do not own.
+ *     A DIFFERENT guard does that, one check EARLIER — `!resource.canGenerate`
+ *     — and a non-owner never reaches line 452 at all. Establishing that took a
+ *     live production run; two prior drafts of this comment described the wrong
+ *     population, so the mechanism is written out here rather than re-guessed.
  *
- *     What the code actually says (`server/services/app-blocks-flag.ts`):
- *     `isAppBlocksAuthorEnabled` returns true for a moderator floor **OR** a
- *     per-user Flipt eval of `app-blocks-author`, whose rollout carries a
- *     curated non-moderator author cohort alongside `moderators`. The mint
- *     endpoint's own comment at `pages/api/v1/blocks/dev-token.ts` says it
- *     plainly: "a curated non-mod cohort can mint a dev token for `dev:live`".
- *     So a non-moderator in that cohort reaches this belt whenever that cohort
- *     is populated. (Deliberately NOT "reaches it today": live Flipt state is
- *     something this repo cannot settle, and a claim it cannot check is a claim
- *     that rots. The reachable-by-construction fact is what matters here.)
+ *     WHY A NON-OWNER CANNOT REACH IT (`generation.service.ts`, canGenerate):
+ *       isPrivate   = availability === 'Private' || status in {Draft, Training}
+ *       canGenerate = covered && hasValidStatus &&
+ *                     (!isPrivate || isOwnedByUser || user.isModerator)
+ *     and `getEpochDetails` returns non-null ONLY when `status !== 'Published'`,
+ *     so an epoch resource is always Draft/Training. Therefore EVERY resource
+ *     that can set `hasPrivateOrEpoch` also sets `isPrivate` — which forces
+ *     `canGenerate = false` for a non-owner non-moderator, and the canGenerate
+ *     guard throws before `hasPrivateOrEpoch` is ever computed.
  *
- *     🔴 AND THE OBSERVATION THAT PRODUCED THE WRONG CLAIM COULD NOT HAVE
- *     SUPPORTED IT. It was a single account's 403 from that endpoint —
- *     generalised into a claim about every non-moderator. Worse, that endpoint
- *     returns the SAME "Apps are restricted to the Civitai team" body from the
- *     BANNED check and from the author gate (`dev-token.ts`, two adjacent
- *     branches), so the response cannot even distinguish which one fired, let
- *     alone establish anything about a population of one. Sampling is not
- *     enumerating: the authoritative surface is the flag resolver, not one
- *     account's rejection.
+ *     🔴 SO WHAT LINE 452 ACTUALLY GATES: the OWNER of a Private/epoch resource
+ *     who lacks an active subscription. Owners get `canGenerate: true` on their
+ *     own private resources, so they are the population that arrives here.
+ *     Moderators are exempt at BOTH layers.
+ *
+ *     That is exactly what the fixtures below encode, and it is why they are
+ *     correct as written: a row with `availability: 'Private'` AND
+ *     `canGenerate: true` for a non-moderator viewer IS the owner case. Keep
+ *     them; only the description of the population was ever wrong.
+ *
+ *     🔴 ESTABLISHED BY LIVE MEASUREMENT, NOT INFERENCE — and note HOW, because
+ *     the obvious method does not work. A genuine non-moderator (author-cohort
+ *     enrolled) submitted an inline body pinning a Private version owned by
+ *     someone else: 403, zero Buzz. Positive control — byte-identical body, one
+ *     AIR swapped for a public version — 200, workflow minted. But the MESSAGE
+ *     could not attribute the refusal: the anti-drop guard and the canGenerate
+ *     guard emit VERBATIM IDENTICAL text (`model version <id> is not available
+ *     for generation`), so the response cannot say which fired. It was
+ *     discriminated by a MODERATOR CONTRAST on the identical negative body (200,
+ *     accepted): `resourceDataCache`'s lookup takes only ids and filters on
+ *     `mv.id IN (…)` alone — no status, no availability, no user parameter — so
+ *     row PRESENCE is user-independent. A moderator succeeding proves the row
+ *     was there, which excludes anti-drop and leaves canGenerate.
+ *
+ *     🔴 KNOWN LIMIT — THE SUBSCRIPTION BRANCH ITSELF HAS STILL NEVER EXECUTED
+ *     IN A NON-MODERATOR PRODUCTION RUN. The test account owns zero models, so
+ *     the owner-without-subscription case could not be constructed live. Its
+ *     reachability is established from the source above; its BEHAVIOUR is
+ *     pinned only by the fixtures below. Do not upgrade that to "verified in
+ *     production" without an owning account.
+ *
+ *     (Reachability of the App Blocks path at all: `isAppBlocksAuthorEnabled`
+ *     is a moderator floor OR a per-user eval of `app-blocks-author`, whose
+ *     rollout carries a curated non-moderator author cohort — see
+ *     `server/services/app-blocks-flag.ts` and the mint endpoint's own comment
+ *     at `pages/api/v1/blocks/dev-token.ts`. An earlier draft claimed
+ *     non-moderators cannot obtain a dev token at all; that was false, and was
+ *     derived by generalising ONE account's 403 — from an endpoint that returns
+ *     the SAME body from its banned branch and its author gate, so it could not
+ *     attribute even that one rejection.)
  *
  * 🔴 NOTHING HERE DEPENDS ON `INLINE_NODEPACKS_ENABLED`. Both `comfyregistry`
  * (source) and `nodepack` (type) are keyed off that kill switch, so a fixture
@@ -289,16 +320,25 @@ describe('assertViewerEntitledToInlineResources — the AIR `source` allowlist',
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// GUARD 2 — the non-moderator Private / epoch entitlement gate.
+// GUARD 2 — the SUBSCRIPTION requirement on a Private / epoch resource the
+// viewer can already generate with, i.e. ITS OWNER.
 //
 //   if (hasPrivateOrEpoch && !opts.user.isModerator) { …require subscription… }
+//
+// 🔴 THE POPULATION IS OWNERS, NOT ARBITRARY DEVELOPERS. A non-owner is refused
+// one guard EARLIER by `!resource.canGenerate` and never arrives here — see the
+// derivation in the file header. Every fixture below therefore pairs
+// `availability: 'Private'` (or an epoch) with `canGenerate: true`, which is the
+// shape production produces for an OWNER. That is deliberate, not a convenient
+// mock: with `canGenerate: false` these cases would be rejected by the earlier
+// guard and would prove nothing about this one.
 //
 // Both LEGS are pinned. A test that only asserts the reject leg is killed by
 // deleting the guard but NOT by dropping `!`; a test that only asserts the
 // moderator exemption is killed by dropping `!` but not by deleting the guard.
 // ─────────────────────────────────────────────────────────────────────────────
-describe('assertViewerEntitledToInlineResources — the non-moderator Private/epoch gate', () => {
-  it('🔴 REJECT LEG — a NON-moderator with no subscription is refused a PRIVATE resource', async () => {
+describe('assertViewerEntitledToInlineResources — the owner Private/epoch subscription gate', () => {
+  it('🔴 REJECT LEG — a NON-moderator OWNER with no subscription is refused their PRIVATE resource', async () => {
     mockGetResourceData.mockResolvedValue([
       row({ id: PRIVATE_VERSION_ID, availability: 'Private' }),
     ]);
@@ -350,10 +390,13 @@ describe('assertViewerEntitledToInlineResources — the non-moderator Private/ep
     expect(mockGetHighestTierSubscription).toHaveBeenCalledWith(NON_MODERATOR.id);
   });
 
-  it('🔴 REJECT LEG — the same holds for an EPOCH (early-access) resource', async () => {
+  it('🔴 REJECT LEG — the same holds for an OWNED EPOCH (early-access) resource', async () => {
     // The right-hand leg of `availability === Private || !!epochDetails`. A
     // distinct version id and a Public availability, so this case cannot be
-    // satisfied by the Private branch.
+    // satisfied by the Private branch. (In production an epoch resource is
+    // always Draft/Training — `getEpochDetails` returns non-null only when
+    // `status !== 'Published'` — which is itself `isPrivate`, so this row's
+    // `canGenerate: true` again encodes the OWNER.)
     mockGetResourceData.mockResolvedValue([
       row({
         id: EPOCH_VERSION_ID,

--- a/src/server/services/blocks/__tests__/inline-comfy.guards.test.ts
+++ b/src/server/services/blocks/__tests__/inline-comfy.guards.test.ts
@@ -36,16 +36,43 @@ import { assertViewerEntitledToInlineResources } from '~/server/services/blocks/
  *
  *   GUARD 2 — the non-moderator entitlement gate for Private / epoch resources
  *     (`if (hasPrivateOrEpoch && !opts.user.isModerator)`).
- *     Cannot currently be exercised in production at all: non-moderators cannot
- *     obtain an App Blocks dev token (`POST /api/v1/blocks/dev-token` answers
- *     "Apps are restricted to the Civitai team"), so the gate built to constrain
- *     untrusted developers is unreachable by one. A test is the only coverage
- *     available, and it keeps its value after that restriction lifts.
+ *
+ *     🔴 THIS IS A LIVE GATE ON A REACHABLE, BUZZ-SPENDING PATH — NOT DEAD CODE.
+ *     An earlier draft of this comment said non-moderators cannot obtain an App
+ *     Blocks dev token, so the gate could never be reached by one. That was
+ *     WRONG, and it was wrong in the direction that invites deleting this file:
+ *     a maintainer reading "unreachable" has every reason to drop the coverage.
+ *
+ *     What the code actually says (`server/services/app-blocks-flag.ts`):
+ *     `isAppBlocksAuthorEnabled` returns true for a moderator floor **OR** a
+ *     per-user Flipt eval of `app-blocks-author`, whose rollout carries a
+ *     curated non-moderator author cohort alongside `moderators`. The mint
+ *     endpoint's own comment at `pages/api/v1/blocks/dev-token.ts` says it
+ *     plainly: "a curated non-mod cohort can mint a dev token for `dev:live`".
+ *     So a non-moderator in that cohort reaches this belt in production today.
+ *
+ *     🔴 AND THE OBSERVATION THAT PRODUCED THE WRONG CLAIM COULD NOT HAVE
+ *     SUPPORTED IT. It was a single account's 403 from that endpoint —
+ *     generalised into a claim about every non-moderator. Worse, that endpoint
+ *     returns the SAME "Apps are restricted to the Civitai team" body from the
+ *     BANNED check and from the author gate (`dev-token.ts`, two adjacent
+ *     branches), so the response cannot even distinguish which one fired, let
+ *     alone establish anything about a population of one. Sampling is not
+ *     enumerating: the authoritative surface is the flag resolver, not one
+ *     account's rejection.
  *
  * 🔴 NOTHING HERE DEPENDS ON `INLINE_NODEPACKS_ENABLED`. Both `comfyregistry`
  * (source) and `nodepack` (type) are keyed off that kill switch, so a fixture
  * naming either would change verdict when the switch flips. Every AIR below uses
  * `lora` — unconditionally allowlisted in both states.
+ *
+ * 🔴 WHAT KIND OF COVERAGE THIS IS, STATED HONESTLY. Both guards are live and
+ * CORRECT today, so every case here is green at the base ref and green at HEAD.
+ * None of it is regression coverage in the strict sense — there is no revision
+ * at which one of these went red. They are MUTATION-KILLED INVARIANT GUARDS:
+ * their worth is the recorded fact that breaking each guard makes a NAMED case
+ * fail for THAT guard's own reason, not a red-to-green transition. The mutation
+ * table lives in the PR description; do not restate it here, where it will rot.
  * ─────────────────────────────────────────────────────────────────────────────
  */
 
@@ -57,6 +84,7 @@ const MODERATOR = { id: 8181, isModerator: true };
 const PRIVATE_VERSION_ID = 55501;
 const EPOCH_VERSION_ID = 60602;
 const PUBLIC_VERSION_ID = 70703;
+const UPPERCASE_VERSION_ID = 80804;
 
 const PRIVATE_AIR = `urn:air:zeta:lora:civitai:31337@${PRIVATE_VERSION_ID}`;
 const EPOCH_AIR = `urn:air:eta:lora:civitai:31338@${EPOCH_VERSION_ID}`;
@@ -108,8 +136,9 @@ beforeEach(() => {
 describe('assertViewerEntitledToInlineResources — the AIR `source` allowlist', () => {
   // Each of these four names an ALLOWLISTED type (`lora`), so the sibling type
   // guard is structurally unable to fire: the source guard is the only thing
-  // that can reject them. Verified live (as a moderator, against production)
-  // before this file was written — all four were refused with this message.
+  // that can reject them. All four were also confirmed refused with this exact
+  // message against the live endpoint (from a moderator session) — a check on
+  // THESE four tokens, which is all it licenses; see the KNOWN LIMIT below.
   const REJECTED_SOURCES = ['replicate', 'openai', 's3', 'evilhost'] as const;
 
   for (const source of REJECTED_SOURCES) {
@@ -122,14 +151,16 @@ describe('assertViewerEntitledToInlineResources — the AIR `source` allowlist',
       );
 
       expect(code).toBe('BAD_REQUEST');
-      // The source guard's OWN wording, naming the offending token.
+      // The source guard's OWN wording, naming the offending token. The EXACT
+      // equality is what does the work: it is the assertion a loose
+      // `/is not permitted in an inline workflow/` regex would have skipped,
+      // because the sibling `type` guard emits that identical tail two lines
+      // above. (An additional `not.toMatch(/AIR type/)` used to sit here — it
+      // was DEAD: after an exact `toBe` on a fixed string it can never fail
+      // independently. Removed rather than kept as decorative defence.)
       expect(message).toBe(
         `resource AIR source '${source}' is not permitted in an inline workflow`
       );
-      // …and NOT the sibling's. This is the assertion a loose
-      // `/is not permitted in an inline workflow/` regex would have skipped —
-      // the sibling `type` guard emits the identical tail two lines above.
-      expect(message).not.toMatch(/AIR type/);
 
       // Nothing downstream ran: rejection happened during AIR parsing, before
       // the entitlement belt was consulted.
@@ -177,9 +208,62 @@ describe('assertViewerEntitledToInlineResources — the AIR `source` allowlist',
         user: NON_MODERATOR,
       })
     );
+    // Exact equality again — a `not.toMatch(/AIR source/)` after it would be
+    // dead for the same reason as above.
     expect(message).toBe("resource AIR type 'image' is not permitted in an inline workflow");
-    expect(message).not.toMatch(/AIR source/);
   });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 🔴 CASE-FOLDING. `parseInlineAir` lowercases `source` before BOTH the
+  // allowlist test and the `source !== 'civitai'` branch. The service's own doc
+  // calls a case-SENSITIVE comparison here "a direct bypass", so dropping that
+  // `.toLowerCase()` is the highest-value mutation on this guard — and until
+  // these two cases existed, this file did not catch it at all (every fixture
+  // above is already lowercase, so it survived 13/13). Both consequences of the
+  // fold are pinned, because they fail in OPPOSITE directions.
+  // ───────────────────────────────────────────────────────────────────────────
+  it('🔴 CASE-FOLD (reject side) — an UPPERCASE non-allowlisted source is rejected, named LOWERCASED', async () => {
+    // Without the fold this still rejects — but the message names `REPLICATE`.
+    // Asserting the lowercased token is what makes the fold observable here
+    // rather than incidental.
+    const { code, message } = await captureRejection(
+      assertViewerEntitledToInlineResources({
+        airs: ['urn:air:zeta:lora:REPLICATE:kappa/lambda@71'],
+        user: NON_MODERATOR,
+      })
+    );
+    expect(code).toBe('BAD_REQUEST');
+    expect(message).toBe("resource AIR source 'replicate' is not permitted in an inline workflow");
+  });
+
+  it('🔴 CASE-FOLD (bypass side) — an UPPERCASE `CIVITAI` source still enters the entitlement belt', async () => {
+    // THE ACTUAL BYPASS. A case-sensitive `source !== 'civitai'` sends this down
+    // the non-civitai branch and returns BEFORE any entitlement check — a gated
+    // resource waved through by spelling. Asserting the belt was CALLED (not
+    // merely that this resolves) is what distinguishes "gated and allowed" from
+    // "never gated".
+    mockGetResourceData.mockResolvedValue([row({ id: UPPERCASE_VERSION_ID })]);
+    await expect(
+      assertViewerEntitledToInlineResources({
+        airs: [`urn:air:zeta:lora:CIVITAI:31340@${UPPERCASE_VERSION_ID}`],
+        user: NON_MODERATOR,
+      })
+    ).resolves.toBeUndefined();
+    expect(mockGetResourceData).toHaveBeenCalledWith([UPPERCASE_VERSION_ID], expect.anything());
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 🔴 KNOWN LIMIT — READ THIS BEFORE CONCLUDING "the source allowlist is
+  // covered". The four cases above are a REJECTION sample, not a membership
+  // pin. They catch a widening only if it happens to collide with one of the
+  // four tokens they name: adding an UNFIXTURED token (say `evil-cdn`) to
+  // `INLINE_ALLOWED_AIR_SOURCES` leaves this file green at full count, and the
+  // sibling suite green too. The complementary assertion — pinning the SET's
+  // exact membership, so any addition or removal goes red — is deliberately not
+  // duplicated here (it lands in the follow-up PR that owns it); until that
+  // merges, treat this file as pinning "these four are refused, with this
+  // wording", nothing wider.
+  // ───────────────────────────────────────────────────────────────────────────
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/server/services/blocks/__tests__/inline-comfy.guards.test.ts
+++ b/src/server/services/blocks/__tests__/inline-comfy.guards.test.ts
@@ -49,7 +49,10 @@ import { assertViewerEntitledToInlineResources } from '~/server/services/blocks/
  *     curated non-moderator author cohort alongside `moderators`. The mint
  *     endpoint's own comment at `pages/api/v1/blocks/dev-token.ts` says it
  *     plainly: "a curated non-mod cohort can mint a dev token for `dev:live`".
- *     So a non-moderator in that cohort reaches this belt in production today.
+ *     So a non-moderator in that cohort reaches this belt whenever that cohort
+ *     is populated. (Deliberately NOT "reaches it today": live Flipt state is
+ *     something this repo cannot settle, and a claim it cannot check is a claim
+ *     that rots. The reachable-by-construction fact is what matters here.)
  *
  *     🔴 AND THE OBSERVATION THAT PRODUCED THE WRONG CLAIM COULD NOT HAVE
  *     SUPPORTED IT. It was a single account's 403 from that endpoint —
@@ -221,6 +224,14 @@ describe('assertViewerEntitledToInlineResources — the AIR `source` allowlist',
   // these two cases existed, this file did not catch it at all (every fixture
   // above is already lowercase, so it survived 13/13). Both consequences of the
   // fold are pinned, because they fail in OPPOSITE directions.
+  //
+  // 🔴 SCOPE — ONLY THE `source` FOLD IS PINNED, NOT BOTH. `parseInlineAir`
+  // folds `type` one line ABOVE the `source` fold, and that sibling fold still
+  // survives both suites. It is left uncovered deliberately, not by oversight:
+  // its failure direction is fail-CLOSED (drop it and an uppercase `LORA` starts
+  // being REJECTED — over-strictness, a false reject), which is the safe
+  // direction, whereas the `source` fold guards a routing decision. Do not read
+  // "case-folding is covered" off this block; read "the source fold is".
   // ───────────────────────────────────────────────────────────────────────────
   it('🔴 CASE-FOLD (reject side) — an UPPERCASE non-allowlisted source is rejected, named LOWERCASED', async () => {
     // Without the fold this still rejects — but the message names `REPLICATE`.
@@ -237,11 +248,22 @@ describe('assertViewerEntitledToInlineResources — the AIR `source` allowlist',
   });
 
   it('🔴 CASE-FOLD (bypass side) — an UPPERCASE `CIVITAI` source still enters the entitlement belt', async () => {
-    // THE ACTUAL BYPASS. A case-sensitive `source !== 'civitai'` sends this down
-    // the non-civitai branch and returns BEFORE any entitlement check — a gated
+    // A case-sensitive `source !== 'civitai'` would send this down the
+    // non-civitai branch and return BEFORE any entitlement check — a gated
     // resource waved through by spelling. Asserting the belt was CALLED (not
     // merely that this resolves) is what distinguishes "gated and allowed" from
-    // "never gated".
+    // "never gated", and that assertion is the load-bearing one: a mutant that
+    // inverts the routing so the belt is skipped turns this case red.
+    //
+    // 🔴 BE PRECISE ABOUT WHICH MUTATION THIS CATCHES — an earlier version of
+    // this comment called it "THE ACTUAL BYPASS", which overstated what ONE
+    // change does. Dropping only `.toLowerCase()` on `source` does NOT open the
+    // bypass: the allowlist test folds on the adjacent line and catches
+    // `CIVITAI` first, so the request is REJECTED — fail-CLOSED over-strictness,
+    // not a hole. Reaching the routing bypass takes TWO changes (fold dropped
+    // AND the allowlist made case-insensitive or widened). This case still dies
+    // under the single-change mutant, but it dies at the ALLOWLIST, so do not
+    // read its redness as evidence about the routing branch.
     mockGetResourceData.mockResolvedValue([row({ id: UPPERCASE_VERSION_ID })]);
     await expect(
       assertViewerEntitledToInlineResources({
@@ -294,6 +316,37 @@ describe('assertViewerEntitledToInlineResources — the non-moderator Private/ep
     expect(message).toBe('Using Private resources requires an active subscription.');
     // The gate was genuinely REACHED and consulted the subscription service for
     // THIS viewer — not short-circuited somewhere earlier.
+    expect(mockGetHighestTierSubscription).toHaveBeenCalledWith(NON_MODERATOR.id);
+  });
+
+  it('🔴 MIXED MANIFEST — ONE Private resource among Public ones still rejects (`.some`, not `.every`)', async () => {
+    // 🔴 THE FIXTURE SHAPE IS THE ASSERTION HERE. `hasPrivateOrEpoch` is a
+    // `.some` over the returned rows. Every OTHER fixture in this file and in
+    // the sibling suite is SINGLE-RESOURCE — and on a one-element array `.some`
+    // and `.every` are INDISTINGUISHABLE. So `.some` → `.every` was a live
+    // fail-OPEN that both suites passed 50/50: with `.every`, a manifest mixing
+    // one Private resource with any Public one reports "no private resources
+    // here" and the entitlement gate never runs.
+    //
+    // That is the real-world shape too — an inline graph declaring a Private
+    // LoRA alongside a public checkpoint — and it fails OPEN on a Buzz-spending
+    // path, so it is the direction that matters. No assertion could have caught
+    // it; only a second element in the array can.
+    mockGetResourceData.mockResolvedValue([
+      row({ id: PUBLIC_VERSION_ID, availability: 'Public' }),
+      row({ id: PRIVATE_VERSION_ID, availability: 'Private' }),
+    ]);
+    mockGetHighestTierSubscription.mockResolvedValue(null);
+
+    const { code, message } = await captureRejection(
+      assertViewerEntitledToInlineResources({
+        airs: [PUBLIC_AIR, PRIVATE_AIR],
+        user: NON_MODERATOR,
+      })
+    );
+
+    expect(code).toBe('FORBIDDEN');
+    expect(message).toBe('Using Private resources requires an active subscription.');
     expect(mockGetHighestTierSubscription).toHaveBeenCalledWith(NON_MODERATOR.id);
   });
 

--- a/src/server/services/blocks/__tests__/inline-comfy.guards.test.ts
+++ b/src/server/services/blocks/__tests__/inline-comfy.guards.test.ts
@@ -1,0 +1,299 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetResourceData = vi.fn();
+const mockGetHighestTierSubscription = vi.fn();
+
+vi.mock('~/server/services/generation/generation.service', () => ({
+  getResourceData: (...args: unknown[]) => mockGetResourceData(...args),
+}));
+vi.mock('~/server/services/subscriptions.service', () => ({
+  getHighestTierSubscription: (...args: unknown[]) => mockGetHighestTierSubscription(...args),
+}));
+
+import { assertViewerEntitledToInlineResources } from '~/server/services/blocks/inline-comfy.service';
+
+/**
+ * ─────────────────────────────────────────────────────────────────────────────
+ * TWO GUARDS IN `inline-comfy.service.ts` THAT WERE LIVE BUT UNCOVERED.
+ *
+ * This file exists SEPARATELY from `inline-comfy.service.test.ts` on purpose: it
+ * writes its OWN fixtures and shares no helper with that file, so neither suite
+ * can be quietly disarmed by a change to the other's fixtures.
+ *
+ *   GUARD 1 — the AIR `source` allowlist (`INLINE_ALLOWED_AIR_SOURCES`).
+ *     Measured before writing this: neutering that check left the whole existing
+ *     suite green (35/35), and `grep` found the string `AIR source` in exactly
+ *     ONE place in the repo — the service itself. No test named a source.
+ *
+ *     🔴 THE TRAP THIS FILE IS WRITTEN AROUND. The `type` guard sits two lines
+ *     above the `source` guard and their messages share the tail
+ *     `is not permitted in an inline workflow`. So a `/is not permitted/`
+ *     assertion is satisfied by EITHER guard, and a fixture with a
+ *     non-allowlisted TYPE is rejected before the source guard is ever reached.
+ *     Every case below therefore (a) uses an ALLOWLISTED type, so the sibling
+ *     cannot fire at all, and (b) asserts the source guard's own distinct
+ *     wording — including that the message does NOT mention `AIR type`.
+ *
+ *   GUARD 2 — the non-moderator entitlement gate for Private / epoch resources
+ *     (`if (hasPrivateOrEpoch && !opts.user.isModerator)`).
+ *     Cannot currently be exercised in production at all: non-moderators cannot
+ *     obtain an App Blocks dev token (`POST /api/v1/blocks/dev-token` answers
+ *     "Apps are restricted to the Civitai team"), so the gate built to constrain
+ *     untrusted developers is unreachable by one. A test is the only coverage
+ *     available, and it keeps its value after that restriction lifts.
+ *
+ * 🔴 NOTHING HERE DEPENDS ON `INLINE_NODEPACKS_ENABLED`. Both `comfyregistry`
+ * (source) and `nodepack` (type) are keyed off that kill switch, so a fixture
+ * naming either would change verdict when the switch flips. Every AIR below uses
+ * `lora` — unconditionally allowlisted in both states.
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+
+// Fixture ids are PAIRWISE DISTINCT so a test cannot pass by matching the wrong
+// value: every viewer id, model id and version id below appears exactly once.
+const NON_MODERATOR = { id: 4242, isModerator: false };
+const MODERATOR = { id: 8181, isModerator: true };
+
+const PRIVATE_VERSION_ID = 55501;
+const EPOCH_VERSION_ID = 60602;
+const PUBLIC_VERSION_ID = 70703;
+
+const PRIVATE_AIR = `urn:air:zeta:lora:civitai:31337@${PRIVATE_VERSION_ID}`;
+const EPOCH_AIR = `urn:air:eta:lora:civitai:31338@${EPOCH_VERSION_ID}`;
+const PUBLIC_AIR = `urn:air:theta:lora:civitai:31339@${PUBLIC_VERSION_ID}`;
+
+/**
+ * A `getResourceData` row shaped like the real return. Defaults are the fully
+ * BENIGN case — resolvable, generatable, no substitute, Public, no epoch — so
+ * that any rejection in a test below is attributable to the ONE field that test
+ * overrode, and never to a fixture that happened to trip an earlier gate.
+ */
+function row(over: Record<string, unknown> = {}) {
+  return {
+    id: PUBLIC_VERSION_ID,
+    name: 'fixture resource',
+    canGenerate: true,
+    availability: 'Public',
+    ...over,
+  };
+}
+
+/**
+ * Capture a rejection so the test can assert on the CODE and the EXACT message
+ * rather than a regex a sibling guard could also satisfy.
+ *
+ * 🔴 It THROWS a distinctive error when the call RESOLVES. That is the shape a
+ * removed guard produces, and it must be loud: a `.rejects` matcher that never
+ * runs is the classic vacuous pass.
+ */
+async function captureRejection(p: Promise<unknown>): Promise<{ code?: string; message: string }> {
+  try {
+    await p;
+  } catch (e) {
+    const err = e as { code?: string; message?: string };
+    return { code: err.code, message: String(err.message ?? e) };
+  }
+  throw new Error('expected assertViewerEntitledToInlineResources to REJECT, but it RESOLVED');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetResourceData.mockResolvedValue([row()]);
+  mockGetHighestTierSubscription.mockResolvedValue(null);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GUARD 1 — the AIR `source` allowlist.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('assertViewerEntitledToInlineResources — the AIR `source` allowlist', () => {
+  // Each of these four names an ALLOWLISTED type (`lora`), so the sibling type
+  // guard is structurally unable to fire: the source guard is the only thing
+  // that can reject them. Verified live (as a moderator, against production)
+  // before this file was written — all four were refused with this message.
+  const REJECTED_SOURCES = ['replicate', 'openai', 's3', 'evilhost'] as const;
+
+  for (const source of REJECTED_SOURCES) {
+    it(`🔴 rejects a NON-allowlisted source '${source}' behind an ALLOWLISTED type`, async () => {
+      const { code, message } = await captureRejection(
+        assertViewerEntitledToInlineResources({
+          airs: [`urn:air:zeta:lora:${source}:kappa/lambda@71`],
+          user: NON_MODERATOR,
+        })
+      );
+
+      expect(code).toBe('BAD_REQUEST');
+      // The source guard's OWN wording, naming the offending token.
+      expect(message).toBe(
+        `resource AIR source '${source}' is not permitted in an inline workflow`
+      );
+      // …and NOT the sibling's. This is the assertion a loose
+      // `/is not permitted in an inline workflow/` regex would have skipped —
+      // the sibling `type` guard emits the identical tail two lines above.
+      expect(message).not.toMatch(/AIR type/);
+
+      // Nothing downstream ran: rejection happened during AIR parsing, before
+      // the entitlement belt was consulted.
+      expect(mockGetResourceData).not.toHaveBeenCalled();
+    });
+  }
+
+  it('POSITIVE CONTROL — the SAME AIR with an allowlisted `huggingface` source is accepted', async () => {
+    // Isolates the source token as the cause. Identical ecosystem (`zeta`),
+    // identical type (`lora`), identical id (`kappa/lambda`) and version (`71`)
+    // as the rejected fixtures above — only the source segment differs, and the
+    // rejection disappears. Without this control, those cases are equally
+    // satisfied by a guard rejecting every `kappa/lambda@71` for some other
+    // reason.
+    await expect(
+      assertViewerEntitledToInlineResources({
+        airs: ['urn:air:zeta:lora:huggingface:kappa/lambda@71'],
+        user: NON_MODERATOR,
+      })
+    ).resolves.toBeUndefined();
+    // A huggingface AIR carries no civitai entitlement, so the belt is not
+    // consulted — exempt by construction, not by an accidental early return.
+    expect(mockGetResourceData).not.toHaveBeenCalled();
+  });
+
+  it('POSITIVE CONTROL — an allowlisted `civitai` source proceeds INTO the entitlement belt', async () => {
+    // The other half of the allowlist. `huggingface` passes by returning early;
+    // `civitai` must pass by being GATED. Asserting the belt was called with the
+    // parsed version id is what distinguishes the two.
+    mockGetResourceData.mockResolvedValue([row({ id: PUBLIC_VERSION_ID })]);
+    await expect(
+      assertViewerEntitledToInlineResources({ airs: [PUBLIC_AIR], user: NON_MODERATOR })
+    ).resolves.toBeUndefined();
+    expect(mockGetResourceData).toHaveBeenCalledWith([PUBLIC_VERSION_ID], expect.anything());
+  });
+
+  it('ORDER PIN — a fixture failing BOTH allowlists is rejected on TYPE, not on source', async () => {
+    // The measured evaluation order (type guard, then source guard) is what
+    // makes the "allowlisted type" precondition on every case above load-bearing
+    // rather than decorative. If this ever flips, the cases above would start
+    // being satisfiable by the sibling and this pin goes red first.
+    const { message } = await captureRejection(
+      assertViewerEntitledToInlineResources({
+        airs: ['urn:air:sigma:image:replicate:tau/upsilon@75'],
+        user: NON_MODERATOR,
+      })
+    );
+    expect(message).toBe("resource AIR type 'image' is not permitted in an inline workflow");
+    expect(message).not.toMatch(/AIR source/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GUARD 2 — the non-moderator Private / epoch entitlement gate.
+//
+//   if (hasPrivateOrEpoch && !opts.user.isModerator) { …require subscription… }
+//
+// Both LEGS are pinned. A test that only asserts the reject leg is killed by
+// deleting the guard but NOT by dropping `!`; a test that only asserts the
+// moderator exemption is killed by dropping `!` but not by deleting the guard.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('assertViewerEntitledToInlineResources — the non-moderator Private/epoch gate', () => {
+  it('🔴 REJECT LEG — a NON-moderator with no subscription is refused a PRIVATE resource', async () => {
+    mockGetResourceData.mockResolvedValue([
+      row({ id: PRIVATE_VERSION_ID, availability: 'Private' }),
+    ]);
+    mockGetHighestTierSubscription.mockResolvedValue(null);
+
+    const { code, message } = await captureRejection(
+      assertViewerEntitledToInlineResources({ airs: [PRIVATE_AIR], user: NON_MODERATOR })
+    );
+
+    expect(code).toBe('FORBIDDEN');
+    // EXACT, not a regex. Three OTHER FORBIDDEN messages are reachable from this
+    // same function ("is not available for generation", "never silently
+    // substituted", "epoch that has expired"); an exact match is what proves
+    // THIS gate rejected, and the control below proves none of those could have.
+    expect(message).toBe('Using Private resources requires an active subscription.');
+    // The gate was genuinely REACHED and consulted the subscription service for
+    // THIS viewer — not short-circuited somewhere earlier.
+    expect(mockGetHighestTierSubscription).toHaveBeenCalledWith(NON_MODERATOR.id);
+  });
+
+  it('🔴 REJECT LEG — the same holds for an EPOCH (early-access) resource', async () => {
+    // The right-hand leg of `availability === Private || !!epochDetails`. A
+    // distinct version id and a Public availability, so this case cannot be
+    // satisfied by the Private branch.
+    mockGetResourceData.mockResolvedValue([
+      row({
+        id: EPOCH_VERSION_ID,
+        availability: 'Public',
+        epochDetails: { epochNumber: 5, isExpired: false },
+      }),
+    ]);
+    mockGetHighestTierSubscription.mockResolvedValue(null);
+
+    const { code, message } = await captureRejection(
+      assertViewerEntitledToInlineResources({ airs: [EPOCH_AIR], user: NON_MODERATOR })
+    );
+
+    expect(code).toBe('FORBIDDEN');
+    expect(message).toBe('Using Private resources requires an active subscription.');
+    expect(mockGetHighestTierSubscription).toHaveBeenCalledWith(NON_MODERATOR.id);
+  });
+
+  it('🔴 EXEMPT LEG — a MODERATOR passes the same PRIVATE fixture with no subscription', async () => {
+    mockGetResourceData.mockResolvedValue([
+      row({ id: PRIVATE_VERSION_ID, availability: 'Private' }),
+    ]);
+    mockGetHighestTierSubscription.mockResolvedValue(null);
+
+    await expect(
+      assertViewerEntitledToInlineResources({ airs: [PRIVATE_AIR], user: MODERATOR })
+    ).resolves.toBeUndefined();
+    // Not merely "allowed": the subscription lookup was never even attempted,
+    // which is what `!opts.user.isModerator` short-circuiting actually does.
+    expect(mockGetHighestTierSubscription).not.toHaveBeenCalled();
+  });
+
+  it('🔴 EXEMPT LEG — a MODERATOR passes the same EPOCH fixture with no subscription', async () => {
+    mockGetResourceData.mockResolvedValue([
+      row({
+        id: EPOCH_VERSION_ID,
+        availability: 'Public',
+        epochDetails: { epochNumber: 5, isExpired: false },
+      }),
+    ]);
+    mockGetHighestTierSubscription.mockResolvedValue(null);
+
+    await expect(
+      assertViewerEntitledToInlineResources({ airs: [EPOCH_AIR], user: MODERATOR })
+    ).resolves.toBeUndefined();
+    expect(mockGetHighestTierSubscription).not.toHaveBeenCalled();
+  });
+
+  it('POSITIVE CONTROL — a NON-moderator WITH a subscription passes the PRIVATE fixture', async () => {
+    // Isolates "no subscription" as the cause of the reject-leg rejection. If
+    // this also rejected, the reject-leg cases would be proving nothing about
+    // the subscription requirement.
+    mockGetResourceData.mockResolvedValue([
+      row({ id: PRIVATE_VERSION_ID, availability: 'Private' }),
+    ]);
+    mockGetHighestTierSubscription.mockResolvedValue({ id: 'sub_fixture', tier: 'gold' });
+
+    await expect(
+      assertViewerEntitledToInlineResources({ airs: [PRIVATE_AIR], user: NON_MODERATOR })
+    ).resolves.toBeUndefined();
+    expect(mockGetHighestTierSubscription).toHaveBeenCalledWith(NON_MODERATOR.id);
+  });
+
+  it('🔴 GUARD-ATTRIBUTION CONTROL — the same NON-moderator + no subscription passes a PUBLIC, non-epoch resource', async () => {
+    // This is the control that stops a green for the wrong reason. The nearby
+    // `canGenerate` / anti-drop / anti-substitute checks are NOT moderator-gated
+    // and reject with their own FORBIDDEN. This case holds the viewer, the
+    // subscription state and the row shape fixed and changes ONLY
+    // availability/epoch — and it passes. So the rejections above cannot have
+    // come from those checks; the only thing that changed is what
+    // `hasPrivateOrEpoch` evaluates to.
+    mockGetResourceData.mockResolvedValue([row({ id: PUBLIC_VERSION_ID, availability: 'Public' })]);
+    mockGetHighestTierSubscription.mockResolvedValue(null);
+
+    await expect(
+      assertViewerEntitledToInlineResources({ airs: [PUBLIC_AIR], user: NON_MODERATOR })
+    ).resolves.toBeUndefined();
+    expect(mockGetHighestTierSubscription).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
**Test-only.** `inline-comfy.service.ts` is byte-identical to `origin/main` (`git diff --exit-code origin/main -- <path>` → rc 0). One new file, `src/server/services/blocks/__tests__/inline-comfy.guards.test.ts` (16 tests), deliberately separate from `inline-comfy.service.test.ts` and sharing no fixture with it.

> **Fourth revision, after three adversarial audit rounds.** Round 2 corrected a false reachability claim; round 3 closed a surviving fail-open and three wrong comment claims; round 4 (prose-only, no test changed) corrects **which population guard 2 protects**, after a live production run. **Every mutation table below was re-derived in one pass against the final 16-test file** by a script that asserts each mutation's pattern occurs exactly once and re-checks the tree is pristine after each restore — an earlier revision's table went stale the moment a test was added to it.

---

## 🔴 Round-4 correction: guard 2 protects OWNERS, not "untrusted developers"

The most consequential fix in this PR's history, and it changes what the guard-2 tests *mean* (not whether they are right — the fixtures are unchanged and correct).

Earlier revisions framed `hasPrivateOrEpoch && !opts.user.isModerator` as the gate stopping an untrusted developer from pinning a Private resource they don't own. **It isn't.** A different guard does that one check *earlier* — `!resource.canGenerate` — and a non-owner never reaches line 452.

**Verified from source** (`generation.service.ts`):

```
isPrivate   = availability === 'Private' || status in {Draft, Training}
canGenerate = covered && hasValidStatus && (!isPrivate || isOwnedByUser || user.isModerator)
```

and `getEpochDetails` returns non-null **only** when `status !== 'Published'`, so an epoch resource is always Draft/Training. Therefore **every** resource that can set `hasPrivateOrEpoch` also sets `isPrivate` — which forces `canGenerate = false` for a non-owner non-moderator, and the canGenerate guard throws before `hasPrivateOrEpoch` is even computed.

**So line 452 gates the OWNER of a Private/epoch resource who lacks an active subscription.** Owners get `canGenerate: true` on their own private resources. Moderators are exempt at *both* layers.

The fixtures already encoded exactly this: a row with `availability: 'Private'` **and** `canGenerate: true` for a non-moderator viewer **is** the owner case. Only the prose was wrong. The header now derives the mechanism inline so it isn't re-guessed a fourth time, and the describe block states that the Private + `canGenerate: true` pairing is deliberate — with `canGenerate: false` these cases would be rejected by the earlier guard and would prove nothing about this one.

### How it was established — the method matters, because the obvious one fails

A genuine non-moderator submitted an inline body pinning a Private version owned by someone else → **403, zero Buzz**. Positive control, byte-identical body with one AIR swapped for a public version → **200**, workflow minted.

But **the message cannot attribute the refusal**: the anti-drop guard and the canGenerate guard emit **verbatim identical** text (`model version <id> is not available for generation`). It was discriminated by a **moderator contrast** on the identical negative body (200, accepted): `resourceDataCache`'s lookup takes only ids and filters on `mv.id IN (…)` alone — no status, no availability, **no user parameter** — so row *presence* is user-independent. A moderator succeeding proves the row was there, which excludes anti-drop and leaves canGenerate. (Both premises re-checked against the source before being written into the file.)

### 🟡 KNOWN LIMIT — the subscription branch has still never executed live

The test account owns zero models, so the owner-without-subscription case could not be constructed in production. Its **reachability** is established from source; its **behaviour** is pinned only by the fixtures here. Recorded in the file so nobody upgrades it to "verified in production" without an owning account.

### Reachability of the App Blocks path at all (round-2 correction, still stands)

v1 said non-moderators cannot obtain a dev token. **False:** `isAppBlocksAuthorEnabled` is a **moderator floor OR** a per-user Flipt eval of `app-blocks-author`, whose rollout carries a curated non-moderator author cohort (`app-blocks-flag.ts`; the mint endpoint's own comment says *"a curated non-mod cohort can mint a dev token for `dev:live`"*). That claim was derived by generalising **one** account's 403 — from an endpoint returning the **same** body from its banned branch and its author gate, so it couldn't attribute even that one rejection.

---

## Guard 1 — the AIR `source` allowlist

**Genuinely uncovered:** neutering the check leaves the pre-existing suite at a full **35/35 green**, and `AIR source` appears in exactly one place in the repo — the service.

**The trap:** the sibling `type` guard sits two lines above and both messages end in `is not permitted in an inline workflow`, so a loose regex is satisfied by either. Every case uses an **allowlisted type** (`lora`) so the sibling cannot fire, and asserts the **exact** message.

| # | Mutation | This file | Sibling suite |
|---|---|---|---|
| M1a | delete the source allowlist check | **5 failed** | 35 passed (blind) |
| M1b | widen allowlist with a **fixtured** token (`+'replicate'`) | **2 failed** | 35 passed (blind) |
| M1c | source guard emits the **sibling's** wording | **5 failed** — exact-equality kills a loose regex would miss | 35 passed (blind) |
| M1d | drop `.toLowerCase()` on `source` | **2 failed** | 1 failed |
| M1e | drop `.toLowerCase()` on `type` (sibling fold) | **SURVIVES** | SURVIVES |
| M1f | widen allowlist with an **unfixtured** token (`+'evil-cdn'`) | **SURVIVES** | SURVIVES |

M1b kills two cases, not one: `REPLICATE` folds to `replicate`, so the case-fold case dies alongside the direct one.

**M1d was a real gap in v1** — it survived this file 13/13 because every fixture was already lowercase. Two cases now pin the fold's **opposite** consequences: an uppercase non-allowlisted source is refused with the message naming the *lowercased* token; and an uppercase `CIVITAI` still **enters** the entitlement belt, asserted via `toHaveBeenCalledWith` rather than by resolving.

> ⚠️ **Precision on that second case, corrected in round 3.** v2's comment called it "THE ACTUAL BYPASS", which overstated what one change does. Dropping *only* `.toLowerCase()` makes `CIVITAI` **reject** at the allowlist (which folds on the adjacent line) — fail-**closed** over-strictness, not a hole. The routing bypass needs **two** changes. The case still dies under the single-change mutant, but it dies at the allowlist, and the comment now says so. The assertion is independently load-bearing: a mutant that inverts routing so the belt is skipped turns it red.

### 🟡 KNOWN LIMITS — what "the source allowlist is covered" does *not* mean

Both recorded in the file itself, not only here:

- **M1f — a sample, not a membership pin.** The rejection cases catch a widening only if it collides with a token they name. Adding an unfixtured token leaves both suites green. The set-membership assertion lands in the follow-up PR that owns it.
- **M1e — only the `source` fold is pinned, not both.** The sibling `type` fold survives. Left uncovered deliberately: its direction is fail-**closed** (an uppercase `LORA` would start being rejected — over-strictness), whereas the `source` fold guards a routing decision.

---

## Guard 2 — the OWNER Private / epoch subscription gate

```ts
if (hasPrivateOrEpoch && !opts.user.isModerator) { … require a subscription … }
```

Population: the **owner** of a Private/epoch resource without a subscription — see the round-4 correction above for why a non-owner never gets here.

| # | Mutation | This file | Sibling suite |
|---|---|---|---|
| M2a | drop the `!` | **6 failed** — exempt-leg cases fail with *this guard's own* `FORBIDDEN` / `Using Private resources requires an active subscription.` firing where it must not | 3 failed |
| M2b | drop the moderator clause | **2 failed**, same specific error | 1 failed |
| M2c | delete the gate | **4 failed** | 2 failed |
| M2g | `.some` → `.every` on `hasPrivateOrEpoch` | **1 failed** | 35 passed (blind) |

### 🔴 M2g — a fail-open that both suites were structurally blind to

Round 3's substantive fix. `.some` → `.every` survived **51/51 green across both suites**. The cause was the **fixture shape, not the assertions**: every fixture in both files was **single-resource**, and on a one-element array `.some` and `.every` are indistinguishable. No assertion could have caught it — only a second element in the array.

The new **`MIXED MANIFEST`** case declares one Private resource alongside a Public one — the real-world shape, an inline graph pinning a Private LoRA next to a public checkpoint — for a non-moderator with no subscription. With `.every`, that manifest reports "no private resources here" and the gate never runs: a **fail-open on a Buzz-spending path**. It is now the only case in *either* suite that catches it.

**Honest scope:** unlike guard 1, guard 2 was **not** uncovered on `main` — M2a also fails 3 tests in the sibling suite. This file adds independent, exact-message, both-legs coverage plus the mixed-manifest shape. Audit also found it kills a mutant the sibling does not: looking up the **wrong user's** subscription.

### The "green for the wrong reason" control

Three other reachable `FORBIDDEN`s here are **not** moderator-gated. Guarding against a fixture tripping one and reading as a pass: every assertion is **exact string equality** plus `code === 'FORBIDDEN'` plus `toHaveBeenCalledWith(4242)` on the subscription lookup; and a **`GUARD-ATTRIBUTION CONTROL`** holds viewer, subscription state and row shape fixed, flips **only** `availability`/`epochDetails`, and passes.

---

## What kind of coverage this is

Corrected from v1's "6 red-then-green cases". **Both guards are live and correct, so all 16 cases are green at the base ref and at HEAD** — no revision exists at which any went red. Under this repo's standard **none of it is regression coverage**; it is a set of **mutation-killed invariant guards**, whose worth is the recorded fact that breaking each guard makes a *named* case fail for *that guard's own reason*. The file header says so.

v1 also mislabelled `POSITIVE CONTROL — a NON-moderator WITH a subscription` as green-both-ways; it is killed by M2a and M2c. And two assertions v1 listed as a distinct defence (`not.toMatch(/AIR type/)`, `not.toMatch(/AIR source/)`) were **provably dead** — each followed an exact `toBe` on the same string — and were removed rather than kept as decoration.

## Fixture hygiene

- **Pairwise-distinct fields**: every viewer id (`4242`, `8181`), model id (`31337`–`31340`) and version id (`55501`, `60602`, `70703`, `80804`) appears exactly once.
- **No dependence on `INLINE_NODEPACKS_ENABLED`** — `comfyregistry` and `nodepack` are both keyed off that kill switch, so every AIR uses `lora`, allowlisted in both states.
- `row()` defaults to the fully benign shape, so any rejection is attributable to the single field a test overrode.

## Verification

- **Counts** (ANSI-stripped mark counts, never an exit code): **16 pass / 0 fail** in this file; **51 pass / 0 fail** across both inline-comfy suites.
- **Typecheck**: **0 at base, 0 at HEAD**, both re-measured under current conditions. ⚠️ Earlier revisions of this PR reported "12 pre-existing errors at base and HEAD" — those were `TS2307` module-resolution errors from an untracked `event-engine-common/` directory that was absent from this worktree and has since been populated. Both sides were re-measured after that change rather than carrying the stale pairing forward; the instrument's ability to report non-zero is evidenced by those earlier runs on this same repo.
- **ESLint** clean. **Prettier** clean.
