### PR TITLE
revert(app-blocks): turn INLINE_NODEPACKS_ENABLED back off — the flip advertises a capability that cannot work

### DIFF
--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -6322,13 +6322,13 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
     // deleting and re-adding coverage, is what makes the flag a genuine one-line
     // switch in both directions.
     //
-    // 🔴 THE REVERT'S REASON IS A DEADLOCK, NOT A SAFETY POSTURE, AND THAT IS WHY
-    // THIS IS A ROUTER TEST AND NOT ONLY A SERVICE TEST. Measured live against
-    // production: a bare `comfy:nodepack` AIR passes civitai's allowlist and is
-    // then 400'd by the ORCHESTRATOR, which prescribes `comfy:nodepacklayer` —
-    // which civitai 400s. Letting the submit through therefore bought nothing
-    // except a second, contradictory error one round-trip later. What this case
-    // pins is that the refusal happens HERE, before any orchestrator call:
+    // 🔴 THE REVERT'S REASON IS THAT THE FLAG GRANTS THE WRONG SPELLING, NOT A
+    // SAFETY POSTURE — AND THAT IS WHY THIS IS A ROUTER TEST AND NOT ONLY A
+    // SERVICE TEST. Measured live against production: a bare `comfy:nodepack`
+    // AIR passes civitai's allowlist and is then 400'd by the ORCHESTRATOR,
+    // which prescribes `comfy:nodepacklayer`. Letting the submit through bought
+    // nothing except a worse error one round-trip later. What this case pins is
+    // that the refusal happens HERE, before any orchestrator call:
     // `mockSubmitWorkflow` must not be reached at all.
     it('🔴 a nodepack URN is REJECTED at the router, and never reaches the orchestrator', async () => {
       const NODEPACK = 'urn:air:comfy:nodepack:comfyregistry:kijai/comfyui-kjnodes@1.4.0';
@@ -6344,12 +6344,14 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
     });
 
     it('🔴 …and so is the LAYER spelling the orchestrator prescribes — one voice, not a circle', async () => {
-      // The other half of the deadlock. Before the revert a developer who
-      // followed the orchestrator's advice landed on the type allowlist's generic
-      // `resource AIR type 'nodepacklayer' is not permitted` — a second,
-      // differently-worded refusal with no way forward. Both spellings now take
-      // the same informative guard, and this asserts that end-to-end through the
-      // router rather than only at the service.
+      // 🔴 THIS REFUSAL IS CIVITAI'S ALONE — the orchestrator ACCEPTS the layer
+      // AIR. Before the revert a developer who followed the orchestrator's
+      // advice landed on the type allowlist's generic `resource AIR type
+      // 'nodepacklayer' is not permitted` and had no way to tell whose gate that
+      // was. Both spellings now take the same informative guard, which says
+      // which side refuses which; this asserts it end-to-end through the router
+      // rather than only at the service. When the layer form is eventually
+      // allowlisted, THIS is the case that should go red and be inverted.
       mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
       happyInline();
       await expect(

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -6315,26 +6315,60 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
       expect(mockGetHighestTierSubscription).not.toHaveBeenCalled();
     });
 
-    // 🔴 INVERTED, NOT DELETED — see `inline-comfy.service.test.ts`. The kill
-    // switch is on, so a nodepack must now reach the orchestrator INTACT. That
-    // last word is the point: it is not enough that the submit succeeds, the
-    // URN has to actually arrive in the step input the worker reads. A flip that
-    // stopped rejecting but silently dropped the URN would look identical from
-    // the caller's side and fail only at ComfyUI load time.
-    it('🔴 a nodepack URN now reaches the orchestrator INTACT in the step input', async () => {
+    // 🔴 INVERTED, NOT DELETED — see `inline-comfy.service.test.ts`. This case has
+    // now been pointed both ways: it asserted REJECT while the kill switch was
+    // off, ACCEPT while #3663 had it on, and REJECT again now that #3663 is
+    // reverted. Keeping one case that flips with the constant, rather than
+    // deleting and re-adding coverage, is what makes the flag a genuine one-line
+    // switch in both directions.
+    //
+    // 🔴 THE REVERT'S REASON IS A DEADLOCK, NOT A SAFETY POSTURE, AND THAT IS WHY
+    // THIS IS A ROUTER TEST AND NOT ONLY A SERVICE TEST. Measured live against
+    // production: a bare `comfy:nodepack` AIR passes civitai's allowlist and is
+    // then 400'd by the ORCHESTRATOR, which prescribes `comfy:nodepacklayer` —
+    // which civitai 400s. Letting the submit through therefore bought nothing
+    // except a second, contradictory error one round-trip later. What this case
+    // pins is that the refusal happens HERE, before any orchestrator call:
+    // `mockSubmitWorkflow` must not be reached at all.
+    it('🔴 a nodepack URN is REJECTED at the router, and never reaches the orchestrator', async () => {
       const NODEPACK = 'urn:air:comfy:nodepack:comfyregistry:kijai/comfyui-kjnodes@1.4.0';
       mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
       happyInline();
-      await caller().submitWorkflow({
-        blockToken: 'tok',
-        body: inlineBody({ resources: [NODEPACK] }),
-      });
-      expect(mockSubmitWorkflow).toHaveBeenCalledTimes(1);
-      const input = mockSubmitWorkflow.mock.calls[0][0].body.steps[0].input;
-      expect(input.resources).toEqual([NODEPACK]);
+      await expect(
+        caller().submitWorkflow({
+          blockToken: 'tok',
+          body: inlineBody({ resources: [NODEPACK] }),
+        })
+      ).rejects.toThrow(/nodepack resources are not permitted/);
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
     });
 
-    it('🔴 an OCI container-image AIR is STILL rejected at the router — the flip is nodepack-only', async () => {
+    it('🔴 …and so is the LAYER spelling the orchestrator prescribes — one voice, not a circle', async () => {
+      // The other half of the deadlock. Before the revert a developer who
+      // followed the orchestrator's advice landed on the type allowlist's generic
+      // `resource AIR type 'nodepacklayer' is not permitted` — a second,
+      // differently-worded refusal with no way forward. Both spellings now take
+      // the same informative guard, and this asserts that end-to-end through the
+      // router rather than only at the service.
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyInline();
+      await expect(
+        caller().submitWorkflow({
+          blockToken: 'tok',
+          body: inlineBody({
+            resources: ['urn:air:comfy:nodepacklayer:comfyregistry:comfyui-kjnodes@1.0.0'],
+          }),
+        })
+      ).rejects.toThrow(/nodepack resources are not permitted/);
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('🔴 an OCI container-image AIR is rejected at the router too — unchanged by the revert', async () => {
+      // The control that keeps the two cases above honest: `image` was never
+      // keyed off the nodepack flag in either direction, so its rejection must
+      // survive the revert unchanged. Asserting the TYPE guard's own token rather
+      // than the shared tail, because the source guard's message ends in the same
+      // words and would otherwise stand in for it.
       mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
       happyInline();
       await expect(
@@ -6342,7 +6376,7 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
           blockToken: 'tok',
           body: inlineBody({ resources: ['urn:air:oci:image:ghcr:evil/comfy@v1'] }),
         })
-      ).rejects.toThrow(/is not permitted in an inline workflow/);
+      ).rejects.toThrow(/AIR type 'image' is not permitted in an inline workflow/);
       expect(mockSubmitWorkflow).not.toHaveBeenCalled();
     });
 

--- a/src/server/services/blocks/__tests__/inline-comfy.service.test.ts
+++ b/src/server/services/blocks/__tests__/inline-comfy.service.test.ts
@@ -15,6 +15,8 @@ import {
   assertViewerEntitledToInlineResources,
   collectInlineAuditText,
   collectInlineGraphStrings,
+  INLINE_ALLOWED_AIR_SOURCES,
+  INLINE_ALLOWED_AIR_TYPES,
   INLINE_NODEPACKS_ENABLED,
 } from '~/server/services/blocks/inline-comfy.service';
 import type { ComfyGraph } from '~/server/services/blocks/recipes';
@@ -170,66 +172,134 @@ describe('collectInlineAuditText — the moderation sweep', () => {
 // (@civitai/client 0.2.0-beta.84) that fails OPEN if the gate is naive.
 // ─────────────────────────────────────────────────────────────────────────────
 describe('assertViewerEntitledToInlineResources — AIR shape', () => {
-  // 🔴 INVERTED, NOT DELETED. These two used to assert a nodepack URN was
-  // REJECTED. The kill switch is now on, so they assert it is ACCEPTED and
-  // reaches the submit path intact. Keeping them inverted rather than removing
-  // them means flipping `INLINE_NODEPACKS_ENABLED` back is still a one-line
-  // change with live coverage on both sides of the decision.
-  it('🔴 ACCEPTS a comfyregistry NODEPACK URN now that the kill switch is on', async () => {
-    expect(INLINE_NODEPACKS_ENABLED).toBe(true);
+  // ───────────────────────────────────────────────────────────────────────────
+  // 🔴 NODEPACKS ARE OFF, AND THE REASON IS A DEADLOCK, NOT A SAFETY POSTURE.
+  // #3663 flipped `INLINE_NODEPACKS_ENABLED` on, and these cases asserted the
+  // ACCEPT behaviour. Measured live against production afterwards: a bare
+  // `comfy:nodepack` AIR passes this allowlist and is then 400'd by the
+  // ORCHESTRATOR, which prescribes `comfy:nodepacklayer` — which THIS module
+  // 400s. The prescribed remediation is refused by the next guard, so the flag
+  // bought nothing except a second, contradictory error message.
+  //
+  // 🔴 INVERTED, NOT DELETED, IN EITHER DIRECTION. The coverage below is the
+  // same shape it was when the flag was on, pointed the other way: the accept
+  // path, the not-widened control, and the sibling-type control all still have a
+  // case. Flipping the constant stays a one-line change with live coverage on
+  // both sides — which is exactly the property that let #3663 happen cheaply and
+  // that lets this revert be equally cheap.
+  // ───────────────────────────────────────────────────────────────────────────
+  it('🔴 REJECTS a comfyregistry NODEPACK URN — the kill switch is off', async () => {
+    expect(INLINE_NODEPACKS_ENABLED).toBe(false);
     await expect(
       assertViewerEntitledToInlineResources({
         airs: ['urn:air:comfy:nodepack:comfyregistry:kijai/comfyui-kjnodes@1.4.0'],
         user: VIEWER,
       })
-    ).resolves.toBeUndefined();
-    // A nodepack carries no civitai entitlement, so the belt is not consulted
-    // for it — the same exempt-by-construction path huggingface weights take.
+    ).rejects.toThrow(/nodepack resources are not permitted in an inline workflow/);
+    // The belt is never reached — the shape gate rejects before any DB work.
     expect(mockGetResourceData).not.toHaveBeenCalled();
   });
 
-  it('🔴 the flip opens COMFYREGISTRY nodepacks only — a civitai-sourced one is still rejected', async () => {
-    // MEASURED, and narrower than "nodepacks are on" implies. `type` and
-    // `source` are separate allowlists, and only `comfyregistry` was added to
-    // the source list. A `civitai`-sourced nodepack passes the TYPE check, then
-    // takes the civitai branch and is gated as a model version — which it is
-    // not, so it resolves to nothing and the anti-drop assert rejects it.
+  it("🔴 …and the message is the DEDICATED guard's, not the type allowlist's generic one", async () => {
+    // MUTATION-DRIVEN. The nodepack guard and the type-allowlist guard are
+    // adjacent, both throw BAD_REQUEST, and both messages end in the same
+    // words. Delete the nodepack guard and a nodepack AIR is STILL rejected —
+    // by the allowlist, with `resource AIR type 'nodepack' is not permitted`.
+    // So a `/is not permitted in an inline workflow/` assertion would stay green
+    // with the guard gone: it would be testing the sibling.
     //
-    // That is fail-CLOSED and it is the behaviour we want: real nodepacks live
-    // in the ComfyUI registry, and no logic was added to carve out a path for a
-    // shape that does not exist. Recorded as a test so the narrowness is a
-    // known property rather than a surprise.
-    mockGetResourceData.mockResolvedValue([]);
+    // This case names a token ONLY the dedicated guard emits, and asserts the
+    // generic wording is ABSENT, so it dies when the guard does.
+    const err = await assertViewerEntitledToInlineResources({
+      airs: ['urn:air:comfy:nodepack:comfyregistry:kijai/comfyui-kjnodes@1.4.0'],
+      user: VIEWER,
+    }).catch((e: Error) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain(
+      'nodepack resources are not permitted in an inline workflow'
+    );
+    expect((err as Error).message).toContain('urn:air:comfy:nodepacklayer');
+    expect((err as Error).message).toContain('ComfyNodepackSnapshot');
+    expect((err as Error).message).not.toContain("resource AIR type 'nodepack' is not permitted");
+  });
+
+  it('🔴 the LAYER spelling the orchestrator prescribes takes the SAME informative refusal', async () => {
+    // THE WHOLE POINT OF THE REVERT. Production 400s a bare pack AIR with
+    // "Declare custom nodes as their install-layer AIR
+    // (urn:air:comfy:nodepacklayer:…). Capture it with a ComfyNodepackSnapshot
+    // step and use its output's layerAir." A developer who follows that advice
+    // used to land on the type allowlist's bare `resource AIR type
+    // 'nodepacklayer' is not permitted in an inline workflow` — a second,
+    // differently-worded refusal with no way forward. Both spellings now get one
+    // message that explains the deadlock.
+    const err = await assertViewerEntitledToInlineResources({
+      airs: ['urn:air:comfy:nodepacklayer:comfyregistry:comfyui-kjnodes@1.0.0'],
+      user: VIEWER,
+    }).catch((e: Error) => e);
+    expect((err as Error).message).toContain(
+      'nodepack resources are not permitted in an inline workflow'
+    );
+    expect((err as Error).message).not.toContain(
+      "resource AIR type 'nodepacklayer' is not permitted"
+    );
+  });
+
+  it('🔴 a civitai-sourced nodepack is rejected too, on the SAME guard', async () => {
+    // With the flag ON this fixture reached the civitai entitlement branch and
+    // was rejected fail-closed as an unresolvable model version — a different
+    // guard, a different message. With the flag OFF the dedicated guard runs
+    // first for EVERY source, so the refusal no longer depends on which source
+    // happens to be spelled. Pinned because the old behaviour was subtle enough
+    // to have its own test.
     await expect(
       assertViewerEntitledToInlineResources({
         airs: ['urn:air:other:nodepack:civitai:123@456'],
         user: VIEWER,
       })
-    ).rejects.toThrow(/not available for generation/);
+    ).rejects.toThrow(/nodepack resources are not permitted in an inline workflow/);
+    expect(mockGetResourceData).not.toHaveBeenCalled();
   });
 
-  it('🔴 enabling nodepacks did NOT widen anything else — a non-nodepack resource is still fully gated', async () => {
-    // The failure this pins: a flag flip that accidentally relaxes the belt for
-    // the rest of `resources`. A nodepack alongside a non-generatable civitai
-    // LoRA must still be rejected, on the LoRA.
+  it('🔴 the revert did NOT narrow anything else — a non-nodepack resource is gated exactly as before', async () => {
+    // The mirror of the test that guarded the flip. The failure it pins: a
+    // revert that accidentally tightens (or loosens) the belt for the rest of
+    // `resources`. A well-formed, generatable civitai LoRA plus a huggingface
+    // weight must still be ACCEPTED, and a non-generatable one still REJECTED,
+    // with nodepacks out of the picture entirely.
+    await expect(
+      assertViewerEntitledToInlineResources({ airs: [LORA_AIR, HF_AIR], user: VIEWER })
+    ).resolves.toBeUndefined();
+
+    vi.clearAllMocks();
     mockGetResourceData.mockResolvedValue([resourceRow({ canGenerate: false })]);
     await expect(
-      assertViewerEntitledToInlineResources({
-        airs: ['urn:air:comfy:nodepack:comfyregistry:kijai/comfyui-kjnodes@1.4.0', LORA_AIR],
-        user: VIEWER,
-      })
+      assertViewerEntitledToInlineResources({ airs: [LORA_AIR], user: VIEWER })
     ).rejects.toThrow(/not available for generation/);
   });
 
-  it('🔴 an OCI container-image AIR is STILL rejected — the flip is nodepack-only', async () => {
-    // `image` was never keyed off the nodepack flag. This is the control that
-    // proves the flip widened one type, not the whole allowlist.
+  it('🔴 COMFYREGISTRY is closed again as a SOURCE, and that is a separate guard from the type', async () => {
+    // `comfyregistry` is in the source allowlist only while the flag is on. With
+    // it off, a NON-nodepack AIR from comfyregistry — which slips past the
+    // nodepack guard entirely — must be rejected by the SOURCE guard. This is
+    // what proves the revert closed both halves, not just the loud one.
+    const err = await assertViewerEntitledToInlineResources({
+      airs: ['urn:air:comfy:lora:comfyregistry:kijai/whatever@1.0.0'],
+      user: VIEWER,
+    }).catch((e: Error) => e);
+    expect((err as Error).message).toContain(
+      "resource AIR source 'comfyregistry' is not permitted in an inline workflow"
+    );
+  });
+
+  it('🔴 an OCI container-image AIR is rejected, on its OWN guard — unchanged by the revert', async () => {
+    // `image` was never keyed off the nodepack flag in either direction. This is
+    // the control that proves the revert narrowed one type, not the whole list.
     await expect(
       assertViewerEntitledToInlineResources({
         airs: ['urn:air:oci:image:ghcr:evil/comfy@v1'],
         user: VIEWER,
       })
-    ).rejects.toThrow(/is not permitted in an inline workflow/);
+    ).rejects.toThrow(/AIR type 'image' is not permitted in an inline workflow/);
   });
 
   // ───────────────────────────────────────────────────────────────────────────
@@ -502,5 +572,97 @@ describe('assertViewerEntitledToInlineResources — Private / epoch subscription
       })
     ).resolves.toBeUndefined();
     expect(mockGetHighestTierSubscription).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MEMBERSHIP GUARD
+//
+// 🔴 READ THIS BEFORE TRUSTING THE BLOCK BELOW. It is NOT a contract test and it
+// is NOT regression coverage. It is an INVARIANT GUARD — a change-detector that
+// makes any edit to the two allowlists a deliberate, reviewed act instead of a
+// silent one. It cannot fail because the orchestrator changed; it can only fail
+// because WE changed.
+//
+// WHY NOT A REAL CONTRACT TEST. #3663's defect was a SEAM: civitai's allowlist
+// and the orchestrator's accepted-AIR set are each individually correct and
+// individually tested, and were broken only in combination. The fix for that
+// class is to pin one side against a machine-generated artifact from the other.
+// That artifact does not exist here. What was searched, and what was found:
+//
+//   • `@civitai/client@0.2.0-beta.84` (the GENERATED orchestrator client), all
+//     46 files under `dist/`, greppable with `grep -a`. `types.gen.js` emits 67
+//     runtime enums; NONE is an AIR type or AIR source enum. Every AIR-bearing field in
+//     the entire generated surface — `CustomComfyInput.resources`,
+//     `ResourceInfo.air`, `ComfyNodepackSnapshotInput.nodepacks`,
+//     `ComfyNodepackSnapshotResult.layerAir` — is typed `string` or
+//     `Array<string>`. There is nothing to pin against.
+//   • `Air.parseSafe` (`dist/utils/Air.js`) is a bare regex; `type` and `source`
+//     are `[a-zA-Z0-9_\-/]+` with no value validation at all.
+//   • No vendored OpenAPI/JSON schema anywhere in the repo — `git ls-files |
+//     grep -iE "openapi|swagger|\.schema\.json"` is empty, and the client ships
+//     zero `.json` files. The spec lives in `civitai-client-javascript`, a
+//     separate repo; this one holds only the published package.
+//   • `src/shared/utils/air.ts`'s `typeUrnMap` is hand-written from civitai's
+//     own Prisma `ModelType` enum. It is the EMIT direction (what we send), not
+//     the ACCEPT direction, and `inline-comfy.service.ts` already documents why
+//     deriving from it would be wrong.
+//
+// So the only in-repo statements about which AIRs the orchestrator accepts are
+// JSDoc prose — and, as `inline-comfy.service.ts`'s header records, that prose
+// CONTRADICTS ITSELF inside a single generated file. Pinning a constant against
+// a docstring that is known-wrong would be worse than pinning nothing: it would
+// look like a contract test and encode the stale half.
+//
+// WHAT THIS BLOCK THEREFORE DOES PROVE: that `INLINE_ALLOWED_AIR_TYPES` and
+// `INLINE_ALLOWED_AIR_SOURCES` contain exactly the values written below, so
+// widening either one cannot land without a reviewer seeing this file change.
+// WHAT IT DOES NOT PROVE: anything whatsoever about what the orchestrator
+// accepts. A divergence introduced by an orchestrator-side change stays
+// invisible to CI, exactly as it was on 2026-08-05.
+//
+// WHAT WOULD MAKE A REAL CONTRACT TEST POSSIBLE (neither exists today): the
+// orchestrator's OpenAPI JSON vendored here behind a re-vendor diff guard, or
+// `@civitai/client` typing those fields as enums instead of `string`.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('INVARIANT GUARD (not a contract test) — allowlist membership', () => {
+  it('pins the exact AIR TYPE allowlist', () => {
+    expect([...INLINE_ALLOWED_AIR_TYPES].sort()).toEqual(
+      [
+        'ag',
+        'checkpoint',
+        'clip',
+        'clipvision',
+        'controlnet',
+        'diffusion_model',
+        'diffusionmodel',
+        'dora',
+        'embedding',
+        'hypernet',
+        'lora',
+        'lycoris',
+        'motion',
+        'text_encoders',
+        'unet',
+        'upscaler',
+        'vae',
+        'visionlanguage',
+      ].sort()
+    );
+  });
+
+  it('pins the exact AIR SOURCE allowlist', () => {
+    expect([...INLINE_ALLOWED_AIR_SOURCES].sort()).toEqual(['civitai', 'huggingface'].sort());
+  });
+
+  it('🔴 neither nodepack spelling is in the ACCEPT list, in either flag state', () => {
+    // `INLINE_NODEPACKS_ENABLED` only ever added `nodepack`. `nodepacklayer` —
+    // the spelling the orchestrator actually prescribes — is absent from the
+    // accept list under BOTH values of the flag, which is precisely why flipping
+    // the flag alone deadlocks rather than working. Stated as an assertion so
+    // the next person reaching for the one-line flip finds it here.
+    expect(INLINE_ALLOWED_AIR_TYPES.has('nodepacklayer')).toBe(false);
+    expect(INLINE_ALLOWED_AIR_TYPES.has('nodepack')).toBe(INLINE_NODEPACKS_ENABLED);
+    expect(INLINE_ALLOWED_AIR_TYPES.has('image')).toBe(false);
   });
 });

--- a/src/server/services/blocks/__tests__/inline-comfy.service.test.ts
+++ b/src/server/services/blocks/__tests__/inline-comfy.service.test.ts
@@ -18,6 +18,7 @@ import {
   INLINE_ALLOWED_AIR_SOURCES,
   INLINE_ALLOWED_AIR_TYPES,
   INLINE_NODEPACKS_ENABLED,
+  inlineAirTypeRefusal,
 } from '~/server/services/blocks/inline-comfy.service';
 import type { ComfyGraph } from '~/server/services/blocks/recipes';
 
@@ -173,20 +174,25 @@ describe('collectInlineAuditText — the moderation sweep', () => {
 // ─────────────────────────────────────────────────────────────────────────────
 describe('assertViewerEntitledToInlineResources — AIR shape', () => {
   // ───────────────────────────────────────────────────────────────────────────
-  // 🔴 NODEPACKS ARE OFF, AND THE REASON IS A DEADLOCK, NOT A SAFETY POSTURE.
-  // #3663 flipped `INLINE_NODEPACKS_ENABLED` on, and these cases asserted the
-  // ACCEPT behaviour. Measured live against production afterwards: a bare
-  // `comfy:nodepack` AIR passes this allowlist and is then 400'd by the
-  // ORCHESTRATOR, which prescribes `comfy:nodepacklayer` — which THIS module
-  // 400s. The prescribed remediation is refused by the next guard, so the flag
-  // bought nothing except a second, contradictory error message.
+  // 🔴 NODEPACKS ARE OFF BECAUSE THE FLAG GRANTS THE WRONG SPELLING, NOT AS A
+  // SAFETY POSTURE. #3663 flipped `INLINE_NODEPACKS_ENABLED` on and these cases
+  // asserted the ACCEPT behaviour. Measured live against production afterwards:
+  // a bare `comfy:nodepack` AIR passes this allowlist and is then 400'd by the
+  // ORCHESTRATOR, which prescribes `comfy:nodepacklayer`. So the flag bought
+  // nothing — it moved the failure one round-trip later, to a worse message.
+  //
+  // 🔴 THE LAYER SPELLING IS REFUSED BY US ALONE — NOT A DEADLOCK. The
+  // orchestrator ACCEPTS `nodepacklayer` (its validator rejects only the bare
+  // `nodepack`); civitai refuses it because it is in neither allowlist. Do not
+  // read the cases below as "the other side is blocking us". See
+  // `INLINE_NODEPACKS_ENABLED` for the sourced version of that claim and its
+  // staleness marker.
   //
   // 🔴 INVERTED, NOT DELETED, IN EITHER DIRECTION. The coverage below is the
   // same shape it was when the flag was on, pointed the other way: the accept
   // path, the not-widened control, and the sibling-type control all still have a
-  // case. Flipping the constant stays a one-line change with live coverage on
-  // both sides — which is exactly the property that let #3663 happen cheaply and
-  // that lets this revert be equally cheap.
+  // case. Flipping the constant back is still one line — but not a free one: it
+  // turns 9 cases red, by design, because they pin the refusal.
   // ───────────────────────────────────────────────────────────────────────────
   it('🔴 REJECTS a comfyregistry NODEPACK URN — the kill switch is off', async () => {
     expect(INLINE_NODEPACKS_ENABLED).toBe(false);
@@ -231,7 +237,8 @@ describe('assertViewerEntitledToInlineResources — AIR shape', () => {
     // used to land on the type allowlist's bare `resource AIR type
     // 'nodepacklayer' is not permitted in an inline workflow` — a second,
     // differently-worded refusal with no way forward. Both spellings now get one
-    // message that explains the deadlock.
+    // message that names which side refuses which, and says the layer form is
+    // the one to build toward.
     const err = await assertViewerEntitledToInlineResources({
       airs: ['urn:air:comfy:nodepacklayer:comfyregistry:comfyui-kjnodes@1.0.0'],
       user: VIEWER,
@@ -655,14 +662,72 @@ describe('INVARIANT GUARD (not a contract test) — allowlist membership', () =>
     expect([...INLINE_ALLOWED_AIR_SOURCES].sort()).toEqual(['civitai', 'huggingface'].sort());
   });
 
-  it('🔴 neither nodepack spelling is in the ACCEPT list, in either flag state', () => {
-    // `INLINE_NODEPACKS_ENABLED` only ever added `nodepack`. `nodepacklayer` —
-    // the spelling the orchestrator actually prescribes — is absent from the
-    // accept list under BOTH values of the flag, which is precisely why flipping
-    // the flag alone deadlocks rather than working. Stated as an assertion so
-    // the next person reaching for the one-line flip finds it here.
+  it('records the CURRENT nodepack membership — a state, not a rule', () => {
+    // 🔴 DELIBERATELY NOT PHRASED AS "nodepacklayer MUST NOT BE ALLOWED". An
+    // earlier version of this case asserted exactly that, which would have made
+    // the correct next step — allowlisting `nodepacklayer` — look like a
+    // regression and put a red test in the way of the fix its own comment
+    // prescribes. A change-detector must not moonlight as a policy.
+    //
+    // If you are here because you just permitted `nodepacklayer`: this line and
+    // the two membership pins above are the ONLY places that need updating, and
+    // the step-aside case below already proves the refusal path yields.
     expect(INLINE_ALLOWED_AIR_TYPES.has('nodepacklayer')).toBe(false);
     expect(INLINE_ALLOWED_AIR_TYPES.has('nodepack')).toBe(INLINE_NODEPACKS_ENABLED);
     expect(INLINE_ALLOWED_AIR_TYPES.has('image')).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 🔴 ANTI-SHADOWING. This is a RELATIONSHIP guard, not a membership one: it pins
+// that the explanatory nodepack refusal YIELDS to the allowlist rather than
+// pre-empting it. That ordering is load-bearing for a change nobody has made
+// yet, which is exactly the kind of property that rots silently — the previous
+// shape asked "is it a nodepack spelling AND is the flag off?" before consulting
+// the allowlist, so permitting `nodepacklayer` would have been swallowed and
+// reported as "nodepack resources are not permitted".
+//
+// `inlineAirTypeRefusal` takes the allowlist as a parameter precisely so this
+// can be MEASURED on a synthetic set instead of asserted in a comment.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('inlineAirTypeRefusal — the refusal must not shadow a future allowlisting', () => {
+  const RAW_LAYER = 'urn:air:comfy:nodepacklayer:comfyregistry:kijai/comfyui-kjnodes@1.4.0';
+  const RAW_PACK = 'urn:air:comfy:nodepack:comfyregistry:kijai/comfyui-kjnodes@1.4.0';
+
+  it('refuses both spellings under the REAL allowlist, with the explanatory message', () => {
+    expect(inlineAirTypeRefusal('nodepack', RAW_PACK)).toContain(
+      'nodepack resources are not permitted in an inline workflow'
+    );
+    expect(inlineAirTypeRefusal('nodepacklayer', RAW_LAYER)).toContain(
+      'nodepack resources are not permitted in an inline workflow'
+    );
+  });
+
+  it('🔴 STEPS ASIDE the moment `nodepacklayer` is allowlisted — the whole point', () => {
+    // The prescribed next step, simulated. If this returns a refusal, a
+    // maintainer who permits the layer spelling gets told "nodepack resources
+    // are not permitted" for a type they just permitted.
+    const permissive = new Set([...INLINE_ALLOWED_AIR_TYPES, 'nodepacklayer']);
+    expect(inlineAirTypeRefusal('nodepacklayer', RAW_LAYER, permissive)).toBeNull();
+  });
+
+  it('🔴 …and does NOT step aside for the bare pack in that same edit', () => {
+    // The half that must survive: permitting the layer must not quietly permit
+    // the bare URN, which the orchestrator refuses. Without this, the case above
+    // is also satisfied by a function that returns null for anything.
+    const permissive = new Set([...INLINE_ALLOWED_AIR_TYPES, 'nodepacklayer']);
+    expect(inlineAirTypeRefusal('nodepack', RAW_PACK, permissive)).toContain(
+      'nodepack resources are not permitted in an inline workflow'
+    );
+  });
+
+  it('POSITIVE CONTROL — an already-allowed type returns null, a stranger gets the BARE message', () => {
+    // Proves the function can return null at all (so the step-aside case is not
+    // vacuously green), and that a non-nodepack type does NOT get the
+    // explanatory message — the two branches are distinguishable.
+    expect(inlineAirTypeRefusal('lora', 'urn:air:sdxl:lora:civitai:1@2')).toBeNull();
+    const stranger = inlineAirTypeRefusal('image', 'urn:air:oci:image:ghcr:evil/comfy@v1');
+    expect(stranger).toContain("resource AIR type 'image' is not permitted in an inline workflow");
+    expect(stranger).not.toContain('nodepack resources are not permitted');
   });
 });

--- a/src/server/services/blocks/inline-comfy.service.ts
+++ b/src/server/services/blocks/inline-comfy.service.ts
@@ -53,47 +53,70 @@ import type { ComfyGraph } from '~/server/services/blocks/recipes';
  * `urn:air:comfy:nodepack:comfyregistry:<publisher>/<pack>@<version>` — which
  * install third-party ComfyUI custom nodes into the worker's container.
  *
- * 🔴 OFF — AND NOT BECAUSE "NODEPACKS ARE UNSAFE". The reason is narrower and
- * more annoying: ENABLING THIS FLAG ALONE PRODUCES A DEADLOCK. The orchestrator
- * and this allowlist demand two DIFFERENT, MUTUALLY EXCLUSIVE spellings of the
- * same thing, and there is no third spelling that satisfies both. With the flag
- * on, the platform does not gain nodepacks; it only moves the refusal from our
- * 400 to theirs, one round-trip later.
+ * 🔴 OFF — AND NOT BECAUSE "NODEPACKS ARE UNSAFE". Turning this flag on grants
+ * the BARE PACK SPELLING, which is the one spelling the orchestrator refuses. It
+ * therefore buys nothing: the submit stops failing here and starts failing one
+ * round-trip later, with a less useful message.
  *
  * 🔴 DO NOT RE-FLIP THIS TO `true` AS A ONE-LINE WIN. That is precisely what
  * #3663 did, on the belief that this allowlist was the only gate. It is not.
- * MEASURED LIVE AGAINST PRODUCTION during a dogfood, both directions:
+ * MEASURED LIVE AGAINST PRODUCTION during a dogfood:
  *
  *   urn:air:comfy:nodepack:comfyregistry:comfyui-kjnodes@1.0.0
- *     → passes this allowlist, then 400 from the ORCHESTRATOR:
+ *     → passes this allowlist (flag on), then 400 from the ORCHESTRATOR:
  *       "Declare custom nodes as their install-layer AIR
  *        (urn:air:comfy:nodepacklayer:…). Capture it with a ComfyNodepackSnapshot
  *        step and use its output's layerAir."
  *
  *   urn:air:comfy:nodepacklayer:comfyregistry:comfyui-kjnodes@1.0.0
- *     → 400 from CIVITAI, i.e. this module:
- *       "resource AIR type 'nodepacklayer' is not permitted in an inline workflow"
+ *     → 400 from CIVITAI, i.e. THIS MODULE, because `nodepacklayer` is not in
+ *       `INLINE_ALLOWED_AIR_TYPES` and `comfyregistry` is not in
+ *       `INLINE_ALLOWED_AIR_SOURCES`.
  *
- * The orchestrator's own prescribed remediation is refused by the very next
- * guard. Four spellings were tried during that dogfood; none work.
+ * 🔴 THAT SECOND REFUSAL IS OURS ALONE — IT IS NOT A DEADLOCK. An earlier
+ * revision of this comment called it one and said re-enabling needed
+ * orchestrator-side work. That was WRONG, and the correction matters because it
+ * inverts who owns the remaining work. Verified by reading
+ * `civitai-orchestration@origin/main` directly (as of 2026-08-06):
  *
- * 🔴 WHY THE #3663 RATIONALE LOOKED SOUND AND WAS STILL WRONG — this is the part
- * worth carrying forward. It was verified against `civitai-orchestration@main`
- * SOURCE: `ComfyRegistryApiClient.cs` resolving the `comfy:nodepack` URN scheme,
+ *   - `CustomComfyInput.cs` → `ValidateNodepacksAreInstallLayers` rejects ONLY
+ *     `air.Type == "nodepack"`. It does not reject `nodepacklayer`. Introduced
+ *     2026-06-23 in `15338ffe3`, i.e. SIX WEEKS BEFORE #3663.
+ *   - `ComfyRegistryRouterResourceProvider.cs` routes `nodepacklayer` to
+ *     `NodepackLayerResourceProvider` and bare `nodepack` to the registry CDN.
+ *   - `samples/sample-customcomfy.http` carries a WORKING customComfy submit
+ *     whose `resources` is a single `urn:air:comfy:nodepacklayer:…` AIR, and
+ *     `wwwroot/openapi/v2-consumers.json` publishes `ComfyNodepackSnapshot` as a
+ *     consumer step template producing exactly that AIR.
+ *
+ * 🔴 THIS IS A CLAIM ABOUT ANOTHER REPO AND NOTHING HERE CAN KEEP IT TRUE. The
+ * `MEMBERSHIP GUARD` block in `inline-comfy.service.test.ts` explains why CI
+ * cannot pin the orchestrator's contract; that argument applies to the paragraph
+ * above too. Re-derive it before acting on it — the symbol to read is
+ * `CustomComfyInput.ValidateNodepacksAreInstallLayers`.
+ *
+ * SO THE REMAINING WORK IS ENTIRELY CIVITAI-SIDE: allow `nodepacklayer` in
+ * `INLINE_ALLOWED_AIR_TYPES`, allow `comfyregistry` in
+ * `INLINE_ALLOWED_AIR_SOURCES`, keep the bare pack refused, and give an inline
+ * body some way to OBTAIN a layer AIR (a ComfyNodepackSnapshot step, or an
+ * already-captured `layerAir` supplied by the app). Still not a one-line flip —
+ * but for that reason, not because anyone else is blocking.
+ *
+ * 🔴 AND THAT PATH IS NOT THIS FLAG. `INLINE_NODEPACKS_ENABLED` grants the BARE
+ * PACK only. Flipping it on is orthogonal to — and strictly worse than —
+ * allowlisting `nodepacklayer`. The type guard is deliberately written so it
+ * cannot shadow that work: see `inlineAirTypeRefusal`, which consults the
+ * allowlist FIRST, so permitting `nodepacklayer` takes effect immediately no
+ * matter what this constant says.
+ *
+ * 🔴 WHY THE #3663 RATIONALE LOOKED SOUND AND WAS STILL WRONG — the reusable
+ * part. It was verified against `civitai-orchestration` SOURCE:
+ * `ComfyRegistryApiClient.cs` resolving the `comfy:nodepack` URN scheme,
  * `ComfyNodepackSnapshotJob.cs`, `CustomComfyJob.cs`'s docs on carrying nodepack
  * URNs. All of that is TRUE, and none of it is the ACCEPT PATH for an inline
- * `customComfy` body. Reading the counterpart's source proved the capability
- * EXISTS; only driving the real submit revealed which AIR the inline endpoint
- * ACCEPTS. The orchestrator has since moved to a layer-based nodepack model and
- * nothing in this repo records that: `nodepacklayer` and `ComfyNodepackSnapshot`
- * appear nowhere in `src/` except in this comment.
- *
- * TURNING THIS BACK ON IS NOT A ONE-LINE CHANGE. At minimum it needs a
- * `nodepacklayer` type in the allowlists below, a way for an inline body to run a
- * ComfyNodepackSnapshot step and thread that step's output `layerAir` into
- * `resources`, and orchestrator-side confirmation that an inline body may carry a
- * layer AIR at all. That is orchestrator-side work and a separate, deliberate
- * decision — not this constant.
+ * `customComfy` body — the validator six weeks older than the PR was never
+ * opened. Reading a counterpart's source proves a capability EXISTS; only
+ * reading its VALIDATOR, or driving the real submit, tells you what it ACCEPTS.
  *
  * The two gates from the inline arm's own belt are unaffected either way and
  * still run over every entry in `resources`: entitlement
@@ -102,13 +125,12 @@ import type { ComfyGraph } from '~/server/services/blocks/recipes';
  *
  * KEPT AS A CONSTANT DELIBERATELY — the one-line kill switch, in both directions.
  * Do not inline `false` and delete it. Both states are tested
- * (`inline-comfy.service.test.ts`), and the source/type allowlists below are
- * keyed off it so flipping it moves nothing else. 🔴 But note what that does and
- * does not mean: flipping it is NECESSARY-BUT-NOT-SUFFICIENT for working
- * nodepacks. The tests pin what this flag CONTROLS; no test in this repo can pin
- * that nodepacks WORK, because the other half of the contract is not in this
- * repo. The `MEMBERSHIP GUARD` block in `inline-comfy.service.test.ts` states
- * exactly how far the in-repo guard reaches, and where it stops.
+ * (`inline-comfy.service.test.ts`). 🔴 Flipping it is NOT free and the tests say
+ * so: it turns 9 of them red, because they pin the refusal. That is the intended
+ * design — a flip should have to argue with its coverage — but do not read the
+ * allowlists being keyed off this constant as "flipping it moves nothing else".
+ * It moves exactly what the tests describe, and no test here can pin that
+ * nodepacks WORK, because the other half of that contract is not in this repo.
  */
 export const INLINE_NODEPACKS_ENABLED = false;
 
@@ -138,14 +160,22 @@ export const INLINE_ALLOWED_AIR_SOURCES: ReadonlySet<string> = new Set(
  * `typeUrnMap` does not contain (it has `diffusionmodel` / `text_encoders`
  * inconsistently). Deriving from it would reject the platform's own live AIRs.
  *
- * Two exclusions are the point of the list, not incidental:
- *   - `nodepack` — see `INLINE_NODEPACKS_ENABLED`. Refused before this list is
- *                  consulted, by a dedicated guard with a message that explains
- *                  the nodepack/nodepacklayer deadlock instead of a bare "type
- *                  not permitted".
- *   - `image`    — an `urn:air:oci:image:…` OCI container image. `comfyImage` is
- *                  already unsettable via the wire schema's `.strict()`; this
- *                  stops the same capability arriving through `resources`.
+ * Three exclusions are the point of the list, not incidental:
+ *   - `nodepack`      — the BARE pack URN. See `INLINE_NODEPACKS_ENABLED`. The
+ *                       orchestrator refuses this spelling too, so permitting it
+ *                       here only moves the failure.
+ *   - `nodepacklayer` — the install-layer AIR, which the orchestrator DOES
+ *                       accept. Absent only because this bridge has no way to
+ *                       obtain one yet; **this is the entry a future fix adds**.
+ *                       Necessary but NOT sufficient on its own: a layer AIR is
+ *                       `comfyregistry`-sourced, so `INLINE_ALLOWED_AIR_SOURCES`
+ *                       needs it too. Those two edits are the whole type/source
+ *                       gate though — `inlineAirTypeRefusal` steps aside by
+ *                       itself, and no third file gates the spelling.
+ *   - `image`         — an `urn:air:oci:image:…` OCI container image.
+ *                       `comfyImage` is already unsettable via the wire schema's
+ *                       `.strict()`; this stops the same capability arriving
+ *                       through `resources`.
  */
 export const INLINE_ALLOWED_AIR_TYPES: ReadonlySet<string> = new Set([
   'checkpoint',
@@ -171,17 +201,58 @@ export const INLINE_ALLOWED_AIR_TYPES: ReadonlySet<string> = new Set([
 
 /**
  * The two AIR `type` spellings that mean "install third-party ComfyUI custom
- * nodes". Both are refused together while `INLINE_NODEPACKS_ENABLED` is off —
- * see the guard in `parseInlineAir` for why refusing only one is worse than
- * refusing both.
+ * nodes".
  *
- * 🔴 NOT the same list as the `nodepack` entry in `INLINE_ALLOWED_AIR_TYPES`
- * above. That list is what may be ACCEPTED; this one is what gets the
- * INFORMATIVE refusal. `nodepacklayer` is deliberately absent from the accept
- * list in BOTH flag states — flipping the flag on would admit `nodepack` only,
- * which is exactly the half-measure that deadlocks.
+ * 🔴 THIS IS NOT AN ACCEPT LIST AND NOT A DENY LIST — it selects which MESSAGE a
+ * refusal gets. `INLINE_ALLOWED_AIR_TYPES` above decides what is permitted;
+ * membership here only means "if this type is being refused, refuse it with the
+ * explanation instead of the bare `type not permitted`". Keeping the two
+ * concerns apart is what lets `nodepacklayer` be allowlisted later without
+ * touching this set.
  */
-const INLINE_NODEPACK_AIR_TYPES: ReadonlySet<string> = new Set(['nodepack', 'nodepacklayer']);
+export const INLINE_NODEPACK_AIR_TYPES: ReadonlySet<string> = new Set([
+  'nodepack',
+  'nodepacklayer',
+]);
+
+/**
+ * The type-level verdict for an inline AIR: the refusal message, or `null` if
+ * the type is permitted. ONE function, so there is ONE ordering.
+ *
+ * 🔴 THE ALLOWLIST IS CONSULTED FIRST, AND THAT ORDER IS THE WHOLE POINT — IT IS
+ * A GUARD AGAINST SHADOWING A FUTURE FIX. The previous shape asked
+ * "is it a nodepack spelling AND is the flag off?" *before* the allowlist, which
+ * meant a maintainer doing the CORRECT next thing — allowlisting `nodepacklayer`
+ * while leaving the bare pack refused — would have seen their change silently
+ * swallowed: the informative guard fired first and reported "nodepack resources
+ * are not permitted" for a type they had just permitted. Hours of confusion,
+ * from a guard whose only job was to be helpful.
+ *
+ * Asking the allowlist first makes that impossible by construction. Permit a
+ * type and every refusal path for it disappears in the same edit, whatever
+ * `INLINE_NODEPACKS_ENABLED` says. The `allowed` parameter is injectable so a
+ * test can prove the step-aside on a synthetic allowlist rather than assert it
+ * in prose — see `inline-comfy.service.test.ts`.
+ */
+export function inlineAirTypeRefusal(
+  type: string,
+  raw: string,
+  allowed: ReadonlySet<string> = INLINE_ALLOWED_AIR_TYPES
+): string | null {
+  if (allowed.has(type)) return null;
+  if (INLINE_NODEPACK_AIR_TYPES.has(type)) {
+    return (
+      `nodepack resources are not permitted in an inline workflow: '${raw.slice(0, 200)}' ` +
+      '— a custom node must be declared as its complete install-layer AIR ' +
+      '(urn:air:comfy:nodepacklayer:…), which the orchestrator DOES accept; the bare ' +
+      'comfy:nodepack URN it does not. This bridge permits neither yet: it has no way for an ' +
+      'inline body to obtain a layer AIR (normally a ComfyNodepackSnapshot step’s output ' +
+      '`layerAir`), so allowing the spelling alone would only move the failure. Enabling this ' +
+      'is civitai-side work — see INLINE_NODEPACKS_ENABLED.'
+    );
+  }
+  return `resource AIR type '${type || '(none)'}' is not permitted in an inline workflow`;
+}
 
 /**
  * Recursion budget for the graph walk. Same value and the same fail-closed
@@ -372,30 +443,12 @@ function parseInlineAir(raw: string): ParsedInlineAir {
   const source = match[3].toLowerCase();
   const rawVersion: string | undefined = match[5];
 
-  // 🔴 BOTH NODEPACK SPELLINGS TAKE THIS BRANCH, AND THAT IS THE POINT. It runs
-  // BEFORE the type allowlist below so the refusal a developer actually reads is
-  // this one and not the allowlist's bare `type '<x>' is not permitted`. The
-  // failure it exists to prevent is a LOOP: the orchestrator answers a bare
-  // `nodepack` AIR by telling you to send `nodepacklayer`, and `nodepacklayer`
-  // is not in the allowlist either — so a developer who follows the advice gets
-  // a second, differently-worded refusal and no way forward. One voice, one
-  // message, one place to look. See INLINE_NODEPACKS_ENABLED for the measured
-  // 400s from both sides.
-  if (INLINE_NODEPACK_AIR_TYPES.has(type) && !INLINE_NODEPACKS_ENABLED) {
-    throw badRequest(
-      `nodepack resources are not permitted in an inline workflow: '${trimmed.slice(0, 200)}' ` +
-        '— the orchestrator now requires a nodepack to be declared as its install-layer AIR ' +
-        '(urn:air:comfy:nodepacklayer:…), captured by a ComfyNodepackSnapshot step, and this ' +
-        'bridge cannot run that step yet. Declaring the bare pack AIR instead is rejected by the ' +
-        'orchestrator. Neither spelling works, so both are refused here rather than one round-trip ' +
-        'later. Re-enabling this needs orchestrator-side work, not a flag flip.'
-    );
-  }
-  if (!INLINE_ALLOWED_AIR_TYPES.has(type)) {
-    throw badRequest(
-      `resource AIR type '${type || '(none)'}' is not permitted in an inline workflow`
-    );
-  }
+  // ONE call, so there is ONE ordering and no second copy of the rule. Both
+  // nodepack spellings get the explanatory refusal; everything else unpermitted
+  // gets the bare one. See `inlineAirTypeRefusal` for why the allowlist is
+  // consulted first (it is what stops this guard shadowing a future fix).
+  const typeRefusal = inlineAirTypeRefusal(type, trimmed);
+  if (typeRefusal) throw badRequest(typeRefusal);
   if (!INLINE_ALLOWED_AIR_SOURCES.has(source)) {
     throw badRequest(
       `resource AIR source '${source || '(none)'}' is not permitted in an inline workflow`

--- a/src/server/services/blocks/inline-comfy.service.ts
+++ b/src/server/services/blocks/inline-comfy.service.ts
@@ -33,6 +33,19 @@ import type { ComfyGraph } from '~/server/services/blocks/recipes';
 // generated type, not from observed orchestrator behaviour. Gate 1 above is what
 // makes it non-load-bearing: if the orchestrator ever DID resolve an AIR the
 // graph names but `resources` omits, containment has already rejected that body.
+//
+// 🔴 AND TREAT THAT DOC COMMENT WITH SUSPICION, BECAUSE ONE CLAUSE OF IT IS
+// MEASURABLY STALE. The same `CustomComfyInput.resources` docstring also says
+// `resources` "Includes … `comfy:nodepack` URNs for runtime-installable custom
+// nodes (e.g. urn:air:comfy:nodepack:comfyregistry:kijai/comfyui-kjnodes@1.4.0)"
+// — and production rejects exactly that, telling you to send a
+// `comfy:nodepacklayer` AIR instead. The contradiction sits INSIDE ONE GENERATED
+// FILE: `@civitai/client@0.2.0-beta.84`'s `types.gen.d.ts` carries that claim at
+// `CustomComfyInput.resources` and its refutation ~500 lines earlier at
+// `ComfyNodepackSnapshotResult.layerAir` — "Consumers declare THIS on a
+// customComfy step's `resources` (not the bare pack URN)". A generated docstring
+// is a snapshot of what someone wrote, not of what the endpoint does. See
+// `INLINE_NODEPACKS_ENABLED` for what believing it cost.
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
@@ -40,47 +53,64 @@ import type { ComfyGraph } from '~/server/services/blocks/recipes';
  * `urn:air:comfy:nodepack:comfyregistry:<publisher>/<pack>@<version>` — which
  * install third-party ComfyUI custom nodes into the worker's container.
  *
- * 🔴 ON, BY AN OWNER DECISION. The previous revision shipped this CLOSED and said
- * the decision had not been made. It has now been made, and the reasoning is
- * recorded here rather than in a PR description that nobody reads at 3am:
+ * 🔴 OFF — AND NOT BECAUSE "NODEPACKS ARE UNSAFE". The reason is narrower and
+ * more annoying: ENABLING THIS FLAG ALONE PRODUCES A DEADLOCK. The orchestrator
+ * and this allowlist demand two DIFFERENT, MUTUALLY EXCLUSIVE spellings of the
+ * same thing, and there is no third spelling that satisfies both. With the flag
+ * on, the platform does not gain nodepacks; it only moves the refusal from our
+ * 400 to theirs, one round-trip later.
  *
- * Nodepacks are a FIRST-CLASS, OWNED ORCHESTRATOR CAPABILITY, not a hazard
- * surface this bridge invents. Verified against `civitai-orchestration@main`:
- *   - `Common/Clients/ComfyRegistry/ComfyRegistryApiClient.cs` resolves
- *     `urn:air:comfy:nodepack:comfyregistry:<publisher>/<name>@<version>`, with
- *     `Grains/Resources/ResourceProviders/ComfyRegistryResourceProvider.cs`
- *     behind it.
- *   - `Grains.Abstractions/Jobs/ComfyNodepackSnapshotJob.cs` installs a pack onto
- *     a comfy image and captures a snapshot.
- *   - `Grains.Abstractions/Jobs/CustomComfyJob.cs` documents carrying
- *     `comfy:nodepack` URNs for runtime-installable custom nodes, with session
- *     affinity for the install and a stable fingerprint of the installed
- *     nodepack set.
- * The block path is another door to that existing system, not a new one.
+ * 🔴 DO NOT RE-FLIP THIS TO `true` AS A ONE-LINE WIN. That is precisely what
+ * #3663 did, on the belief that this allowlist was the only gate. It is not.
+ * MEASURED LIVE AGAINST PRODUCTION during a dogfood, both directions:
  *
- * 🔴 BE PRECISE ABOUT WHAT THAT DOES AND DOES NOT BUY, BECAUSE THE SHORT VERSION
- * OF THIS RATIONALE IS "SECURITY IS HANDLED ORCHESTRATOR-SIDE" AND THAT IS
- * STRONGER THAN WHAT WAS MEASURED. Searching those files for an allowlist,
- * blocklist, publisher-trust check or security scan found NONE — the resolver
- * resolves any pack the public ComfyUI registry serves, and the comment at
- * `ComfyRegistryResourceProvider.cs` notes it does not even validate that the
- * publisher matches (a mismatch simply 404s). So the real trust boundary is
- * **the public registry plus the worker's container sandbox**, and this flag
- * inherits exactly that — no more. If a per-publisher or per-pack allowlist is
- * wanted, it does not exist yet and this flag is not it.
+ *   urn:air:comfy:nodepack:comfyregistry:comfyui-kjnodes@1.0.0
+ *     → passes this allowlist, then 400 from the ORCHESTRATOR:
+ *       "Declare custom nodes as their install-layer AIR
+ *        (urn:air:comfy:nodepacklayer:…). Capture it with a ComfyNodepackSnapshot
+ *        step and use its output's layerAir."
  *
- * The two gates from the inline arm's own belt are UNAFFECTED and still run over
- * every non-nodepack entry in `resources`: entitlement
+ *   urn:air:comfy:nodepacklayer:comfyregistry:comfyui-kjnodes@1.0.0
+ *     → 400 from CIVITAI, i.e. this module:
+ *       "resource AIR type 'nodepacklayer' is not permitted in an inline workflow"
+ *
+ * The orchestrator's own prescribed remediation is refused by the very next
+ * guard. Four spellings were tried during that dogfood; none work.
+ *
+ * 🔴 WHY THE #3663 RATIONALE LOOKED SOUND AND WAS STILL WRONG — this is the part
+ * worth carrying forward. It was verified against `civitai-orchestration@main`
+ * SOURCE: `ComfyRegistryApiClient.cs` resolving the `comfy:nodepack` URN scheme,
+ * `ComfyNodepackSnapshotJob.cs`, `CustomComfyJob.cs`'s docs on carrying nodepack
+ * URNs. All of that is TRUE, and none of it is the ACCEPT PATH for an inline
+ * `customComfy` body. Reading the counterpart's source proved the capability
+ * EXISTS; only driving the real submit revealed which AIR the inline endpoint
+ * ACCEPTS. The orchestrator has since moved to a layer-based nodepack model and
+ * nothing in this repo records that: `nodepacklayer` and `ComfyNodepackSnapshot`
+ * appear nowhere in `src/` except in this comment.
+ *
+ * TURNING THIS BACK ON IS NOT A ONE-LINE CHANGE. At minimum it needs a
+ * `nodepacklayer` type in the allowlists below, a way for an inline body to run a
+ * ComfyNodepackSnapshot step and thread that step's output `layerAir` into
+ * `resources`, and orchestrator-side confirmation that an inline body may carry a
+ * layer AIR at all. That is orchestrator-side work and a separate, deliberate
+ * decision — not this constant.
+ *
+ * The two gates from the inline arm's own belt are unaffected either way and
+ * still run over every entry in `resources`: entitlement
  * (`assertViewerEntitledToInlineResources`) and the prompt sweep
- * (`collectInlineAuditText`). Enabling nodepacks widens what `resources` may
- * NAME; it does not weaken what the rest of it must PASS.
+ * (`collectInlineAuditText`).
  *
- * KEPT AS A CONSTANT DELIBERATELY — this is the one-line kill switch if the
- * decision is revisited. Do not inline `true` and delete it. Both states are
- * tested (`inline-comfy.service.test.ts`), and the source/type allowlists below
- * are keyed off it so flipping it moves nothing else.
+ * KEPT AS A CONSTANT DELIBERATELY — the one-line kill switch, in both directions.
+ * Do not inline `false` and delete it. Both states are tested
+ * (`inline-comfy.service.test.ts`), and the source/type allowlists below are
+ * keyed off it so flipping it moves nothing else. 🔴 But note what that does and
+ * does not mean: flipping it is NECESSARY-BUT-NOT-SUFFICIENT for working
+ * nodepacks. The tests pin what this flag CONTROLS; no test in this repo can pin
+ * that nodepacks WORK, because the other half of the contract is not in this
+ * repo. The `MEMBERSHIP GUARD` block in `inline-comfy.service.test.ts` states
+ * exactly how far the in-repo guard reaches, and where it stops.
  */
-export const INLINE_NODEPACKS_ENABLED = true;
+export const INLINE_NODEPACKS_ENABLED = false;
 
 /**
  * AIR `source` values an inline `resources` entry may name. ALLOWLIST, not a
@@ -92,7 +122,7 @@ export const INLINE_NODEPACKS_ENABLED = true;
  * in `recipes/seamless-pano.recipe.ts`), so it is exempt-by-construction: there
  * is no civitai entitlement to check on a public HF repo.
  */
-const INLINE_ALLOWED_AIR_SOURCES: ReadonlySet<string> = new Set(
+export const INLINE_ALLOWED_AIR_SOURCES: ReadonlySet<string> = new Set(
   INLINE_NODEPACKS_ENABLED
     ? ['civitai', 'huggingface', 'comfyregistry']
     : ['civitai', 'huggingface']
@@ -109,12 +139,15 @@ const INLINE_ALLOWED_AIR_SOURCES: ReadonlySet<string> = new Set(
  * inconsistently). Deriving from it would reject the platform's own live AIRs.
  *
  * Two exclusions are the point of the list, not incidental:
- *   - `nodepack` — arbitrary code execution (see INLINE_NODEPACKS_ENABLED).
+ *   - `nodepack` — see `INLINE_NODEPACKS_ENABLED`. Refused before this list is
+ *                  consulted, by a dedicated guard with a message that explains
+ *                  the nodepack/nodepacklayer deadlock instead of a bare "type
+ *                  not permitted".
  *   - `image`    — an `urn:air:oci:image:…` OCI container image. `comfyImage` is
  *                  already unsettable via the wire schema's `.strict()`; this
  *                  stops the same capability arriving through `resources`.
  */
-const INLINE_ALLOWED_AIR_TYPES: ReadonlySet<string> = new Set([
+export const INLINE_ALLOWED_AIR_TYPES: ReadonlySet<string> = new Set([
   'checkpoint',
   'diffusion_model',
   'diffusionmodel',
@@ -135,6 +168,20 @@ const INLINE_ALLOWED_AIR_TYPES: ReadonlySet<string> = new Set([
   'visionlanguage',
   ...(INLINE_NODEPACKS_ENABLED ? ['nodepack'] : []),
 ]);
+
+/**
+ * The two AIR `type` spellings that mean "install third-party ComfyUI custom
+ * nodes". Both are refused together while `INLINE_NODEPACKS_ENABLED` is off —
+ * see the guard in `parseInlineAir` for why refusing only one is worse than
+ * refusing both.
+ *
+ * 🔴 NOT the same list as the `nodepack` entry in `INLINE_ALLOWED_AIR_TYPES`
+ * above. That list is what may be ACCEPTED; this one is what gets the
+ * INFORMATIVE refusal. `nodepacklayer` is deliberately absent from the accept
+ * list in BOTH flag states — flipping the flag on would admit `nodepack` only,
+ * which is exactly the half-measure that deadlocks.
+ */
+const INLINE_NODEPACK_AIR_TYPES: ReadonlySet<string> = new Set(['nodepack', 'nodepacklayer']);
 
 /**
  * Recursion budget for the graph walk. Same value and the same fail-closed
@@ -325,10 +372,23 @@ function parseInlineAir(raw: string): ParsedInlineAir {
   const source = match[3].toLowerCase();
   const rawVersion: string | undefined = match[5];
 
-  if (type === 'nodepack' && !INLINE_NODEPACKS_ENABLED) {
+  // 🔴 BOTH NODEPACK SPELLINGS TAKE THIS BRANCH, AND THAT IS THE POINT. It runs
+  // BEFORE the type allowlist below so the refusal a developer actually reads is
+  // this one and not the allowlist's bare `type '<x>' is not permitted`. The
+  // failure it exists to prevent is a LOOP: the orchestrator answers a bare
+  // `nodepack` AIR by telling you to send `nodepacklayer`, and `nodepacklayer`
+  // is not in the allowlist either — so a developer who follows the advice gets
+  // a second, differently-worded refusal and no way forward. One voice, one
+  // message, one place to look. See INLINE_NODEPACKS_ENABLED for the measured
+  // 400s from both sides.
+  if (INLINE_NODEPACK_AIR_TYPES.has(type) && !INLINE_NODEPACKS_ENABLED) {
     throw badRequest(
       `nodepack resources are not permitted in an inline workflow: '${trimmed.slice(0, 200)}' ` +
-        '— a node pack installs third-party code into the ComfyUI container at runtime'
+        '— the orchestrator now requires a nodepack to be declared as its install-layer AIR ' +
+        '(urn:air:comfy:nodepacklayer:…), captured by a ComfyNodepackSnapshot step, and this ' +
+        'bridge cannot run that step yet. Declaring the bare pack AIR instead is rejected by the ' +
+        'orchestrator. Neither spelling works, so both are refused here rather than one round-trip ' +
+        'later. Re-enabling this needs orchestrator-side work, not a flag flip.'
     );
   }
   if (!INLINE_ALLOWED_AIR_TYPES.has(type)) {


### PR DESCRIPTION
> ### ⚠️ Correction — this description originally said two things that are false
> An earlier revision of this PR body said "the two sides now deadlock" and "re-enabling needs orchestrator-side work". **Both are wrong.** The orchestrator accepts the install-layer AIR and always has; the second refusal is civitai's alone, and the remaining work is entirely civitai-side. The revert is still correct, for the reason below. Corrected in `720680611b`, which also removes the wrong framing from the code comments, the user-facing 400, and the tests — it had been baked into all three.

## Why

#3663 flipped `INLINE_NODEPACKS_ENABLED` to `true` so an inline `customComfy` body could declare `comfy:nodepack` AIRs. It was a one-line change made on the belief that civitai's allowlist was the only gate. It isn't.

**The flag grants the bare pack spelling — the one spelling the orchestrator refuses.** Measured live against production during a dogfood:

```
urn:air:comfy:nodepack:comfyregistry:comfyui-kjnodes@1.0.0
  -> passes civitai's allowlist (flag on), then 400 from the ORCHESTRATOR:
     "Declare custom nodes as their install-layer AIR
      (urn:air:comfy:nodepacklayer:...). Capture it with a
      ComfyNodepackSnapshot step and use its output's layerAir."

urn:air:comfy:nodepacklayer:comfyregistry:comfyui-kjnodes@1.0.0
  -> 400 from CIVITAI: "resource AIR type 'nodepacklayer' is not permitted"
```

So the flag bought nothing: the submit stopped failing at civitai and started failing one round-trip later, with a worse message. Reverting removes no capability.

## Who actually owns the remaining work — civitai, not the orchestrator

Verified by reading `civitai-orchestration@origin/main` directly (as of 2026-08-06):

- **`CustomComfyInput.cs` → `ValidateNodepacksAreInstallLayers` rejects ONLY `air.Type == "nodepack"`.** It does not reject `nodepacklayer`. Introduced **2026-06-23** in `15338ffe3` — **six weeks before #3663**.
- **`ComfyRegistryRouterResourceProvider.cs`** routes `nodepacklayer` → `NodepackLayerResourceProvider`, bare `nodepack` → the registry CDN.
- **`samples/sample-customcomfy.http`** carries a working customComfy submit whose `resources` is a single `urn:air:comfy:nodepacklayer:…` AIR, and `wwwroot/openapi/v2-consumers.json` publishes `ComfyNodepackSnapshot` as a consumer step template producing exactly that AIR.

**The orchestrator side is finished and shipped.** To enable nodepacks, civitai needs to: permit `nodepacklayer` in `INLINE_ALLOWED_AIR_TYPES`, permit `comfyregistry` in `INLINE_ALLOWED_AIR_SOURCES`, keep the bare pack refused, and give an inline body some way to obtain a layer AIR. Still not a one-line flip — but nobody else is blocking.

That claim is about another repo and nothing in CI can keep it true, so it ships **attributed and dated**, with the symbol to re-read (`CustomComfyInput.ValidateNodepacksAreInstallLayers`).

**The reusable lesson**, recorded in the file: #3663 was verified against orchestrator *source* — `ComfyRegistryApiClient`, `ComfyNodepackSnapshotJob`, `CustomComfyJob`'s docs. All true, none of it the accept path, and a validator six weeks older than the PR was never opened. Reading a counterpart's source proves a capability *exists*; only reading its **validator**, or driving the real submit, tells you what it *accepts*.

## 🔴 The shadowing fix

The guard used to ask *"is it a nodepack spelling AND is the flag off?"* **before** consulting the allowlist. That silently shadows the most likely correct next step: a maintainer who allowlists `nodepacklayer` while keeping the bare pack refused would have been told **"nodepack resources are not permitted"** for a type they had just permitted — by a guard whose only job was to be helpful.

Both type guards are now one function, `inlineAirTypeRefusal(type, raw, allowed)`, which consults the **allowlist first** and only then chooses which message an already-decided refusal gets. Permitting a type removes every refusal path for it in the same edit, whatever the flag says. `allowed` is injectable so the step-aside is **measured on a synthetic allowlist** rather than asserted in prose.

Behaviour today is identical. What changed is that the shadowing is impossible by construction rather than by comment. The membership pin also no longer asserts `has('nodepacklayer') === false` as a *rule* — phrased as policy, it would have made the prescribed fix look like a regression.

## What changes

- `INLINE_NODEPACKS_ENABLED = false`, closing `nodepack` in the type allowlist and `comfyregistry` in the source allowlist.
- Both nodepack spellings get one explanatory refusal naming which side refuses which, instead of `nodepacklayer` falling through to a bare "type not permitted".
- Rationale comment rewritten with both measured 400s, the sourced orchestrator position, and a staleness marker.

## 🔴 Do not read "MERGEABLE / CLEAN" on this PR as "CI verified it"

`main` has branch protection but **no required status checks at all**:

```
gh api repos/civitai/civitai/branches/main/protection
→ required_status_checks = null   enforce_admins = false   required_pull_request_reviews = null
```

So `mergeStateStatus: CLEAN` is not a weak signal here — **it is no signal**. Nothing on the platform prevents this or any other PR merging with every code gate absent, failing, or never having run.

That is not hypothetical on this branch. Commit `720680611b` reported `MERGEABLE` / `CLEAN` while **six of its twelve checks — `Typecheck`, `Unit tests`, `Package unit tests`, `ESLint + Prettier`, `Schema drift gate`, `event-engine-common pin` — never created a run at all.** Not queued, not cancelled: absent. Only the six `preview / *` statuses executed. `f5981a250b` is an empty re-trigger commit (tree OID byte-identical to its parent, `2e3684fe6a…`) pushed solely to re-enqueue them; it vanishes on squash-merge.

**Check the rollup against the current head SHA before trusting a green tick on this repo.** The rollup was also observed non-monotonic (1 → 0 → 6), so a single sample is unreliable in either direction.

## Verification

Everything below is local, counted, and measured on this exact tree — it does not depend on CI having run.

| run | result |
|---|---|
| both suites @ HEAD | **380 passed (380)**, 0 skipped, no timeout panic |
| `inline-comfy.service.test.ts` @ `origin/main` | 35 passed (35) |
| HEAD service tests vs `origin/main` service | **8 failed \| 33 passed (41)** |
| HEAD router tests vs `origin/main` service | **2 failed \| 333 passed (335)** |
| typecheck @ `origin/main` and @ HEAD | **0 errors both** |

**Honest scoping of that "8"**: 5 are behavioural, **3 are structural** (`is not iterable` / `reading 'has'` from constants not yet exported at base). The router matrix is behavioural throughout, and its two failures *are* the bug: nodepack → `promise resolved … instead of rejecting`, layer → `got 'resource AIR type \'nodepacklayer\' i…'`.

**Mutations** (counted, never read from an exit code):

- **Order swapped so the nodepack branch precedes the allowlist** — the shadowing bug reintroduced → `2 failed | 43 passed`; the anti-shadowing case dies on its own assertion, `expected 'nodepack resources are not permitted …' to be null`.
- **Nodepack branch removed** → `8 failed | 372 passed`, every one dying on the **sibling's** message (`resource AIR type 'nodepack' is not…`). The AIRs stay refused; only the message degrades — exactly the green-for-the-wrong-reason case these assertions exist to catch.
- **Flag flipped to `true`** → `9 failed | 371 passed`. That is the measured basis for saying flipping it is *not* free.

## 🔴 Rollout — this does not revert production on merge

Prod deploys from `release`, and **`origin/release` still carries `INLINE_NODEPACKS_ENABLED = true`** (verified directly). Merging to `main` does not take effect until the next release cut.

Impact is bounded: a nodepack submit reserves, gets 400'd by the orchestrator, and `blocks.router.ts`'s catch path refunds all three reservations (`refundBlockBuzzSpend`, `refundAppSpend`, `refundDevSessionBuzz`) and releases the idempotency claim. No money is stranded — but a reviewer should know the revert isn't live on merge.

## Harness traps found while verifying — each returned a reassuring result

1. **A 12-error typecheck "baseline" was purely an uninitialised submodule.** `event-engine-common` is a git submodule a fresh worktree does not populate, so `image.service.ts`/`bitdex-stats.ts` report `TS2307` plus knock-on `TS7006`. Initialised, the count is **0 on both sides**. CI was never affected — its `Typecheck` job checks out with `submodules: true` — so the 12 only ever existed in local worktrees.
2. **`tsconfig.json` excludes `src/**/__tests__/**` — typecheck does not cover test files.** Proven, not assumed: a deliberate type error planted in the test file went **unreported**, while the same error in the service file reported `1 type error(s)`. **"Typecheck clean" is vacuous on a test-only PR here.**
3. **`prettier --check` printed `All matched files use Prettier code style!` while checking ZERO files** — relative paths from the wrong cwd matched nothing, and "nothing matched" is a *pass*. Same shape as a suite reporting `Tests no tests`.

Related: `blocks.router.workflow.test.ts` **cannot run without that submodule** — it reports `Tests no tests`, not a failure, so an un-run suite reads as a pass. Every matrix above was measured with it initialised.

`blocks.router.workflow.test.ts` is **deliberately not reformatted**: `prettier --check` warns on it, but a negative control shows `origin/main`'s own copy is equally dirty and every change it wants lands in pre-existing code, none in the edited region. The nearest (line 6483) sits beside another open PR's hunk in this file.

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>