### PR TITLE
fix(challenge): treat an already-refunded prefix as a no-op, not a refund failure

### DIFF
--- a/src/server/games/daily-challenge/challenge-funding.test.ts
+++ b/src/server/games/daily-challenge/challenge-funding.test.ts
@@ -1,3 +1,4 @@
+import { BuzzApiError } from '@civitai/buzz';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { TRPCError } from '@trpc/server';
 
@@ -475,6 +476,46 @@ describe('refundUserChallengeFunds — void refunds pool legs only', () => {
     );
 
     await expect(refundUserChallengeFunds(CHALLENGE_ID)).resolves.toEqual({ refundedEntries: 0 });
+  });
+
+  // 409 (→ BAD_REQUEST) is what the buzz service returns for a prefix whose transactions were
+  // ALREADY reversed — a refunded externalTransactionId stays occupied in the ledger. A challenge
+  // voided first and deleted afterwards hits this on the delete, and treating it as a failure
+  // aborted the delete and left the challenge undeletable forever.
+  it('tolerates the buzz conflict when a prefix was already refunded', async () => {
+    mockChallengeFindUnique.mockResolvedValue({
+      source: ChallengeSource.User,
+      basePrizePool: 500,
+      createdById: USER_ID,
+      entryFee: ENTRY_FEE,
+    });
+    mockRefundMultiAccountTransaction.mockRejectedValue(
+      new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'There is a conflict with the transaction',
+        cause: new BuzzApiError(409, 'Conflict'),
+      })
+    );
+
+    await expect(refundUserChallengeFunds(CHALLENGE_ID)).resolves.toEqual({ refundedEntries: 0 });
+  });
+
+  // Tolerance is keyed to the buzz status, not to BAD_REQUEST — a bad request from anywhere else
+  // is still a real failure.
+  it('rethrows a BAD_REQUEST that did not come from the buzz service', async () => {
+    mockChallengeFindUnique.mockResolvedValue({
+      source: ChallengeSource.User,
+      basePrizePool: 0,
+      createdById: USER_ID,
+      entryFee: ENTRY_FEE,
+    });
+    mockRefundMultiAccountTransaction.mockRejectedValue(
+      new TRPCError({ code: 'BAD_REQUEST', message: 'There is a conflict with the transaction' })
+    );
+
+    await expect(refundUserChallengeFunds(CHALLENGE_ID)).rejects.toThrow(
+      'There is a conflict with the transaction'
+    );
   });
 
   // A non-404 buzz failure is a real error and must still propagate.

--- a/src/server/games/daily-challenge/challenge-funding.ts
+++ b/src/server/games/daily-challenge/challenge-funding.ts
@@ -39,6 +39,7 @@ import {
   getTransactionByExternalId,
   refundMultiAccountTransaction,
 } from '~/server/services/buzz.service';
+import { getBuzzApiStatus } from '~/server/utils/buzz-error';
 import { TransactionType } from '~/shared/constants/buzz.constants';
 import {
   CHALLENGE_ENTRY_HOUSE_CUT,
@@ -255,11 +256,15 @@ async function filterChargedImageIds(
  * challenges with no initial prize.
  */
 /**
- * Reverse one challenge-fund prefix, tolerating the buzz service's 404 (→ TRPCError NOT_FOUND)
- * when the prefix matches no transactions. A prefix matches nothing for an entryFee challenge that
- * never took a paid entry (e.g. a cancelled challenge with zero entries), or a prize that was never
- * actually charged — there is nothing to reverse, so that is a zero-refund no-op, not a failure
- * that should abort the surrounding void/delete. Returns the count of transactions reversed.
+ * Reverse one challenge-fund prefix, tolerating both ways the buzz service can say "there is
+ * nothing left to return":
+ *   - 404 (→ NOT_FOUND): the prefix matches no transactions at all — an entryFee challenge that
+ *     never took a paid entry, or a prize that was never actually charged.
+ *   - 409 (→ BAD_REQUEST): the transactions it matches were already reversed. A refunded
+ *     externalTransactionId stays occupied in the ledger (see the header), so re-running a refund
+ *     conflicts rather than no-op'ing. Reached whenever a challenge is voided and then deleted.
+ * Either way zero Buzz is owed, so neither may abort the surrounding void/delete. Returns the
+ * count of transactions reversed.
  */
 async function refundChallengeFundsByPrefix(input: {
   externalTransactionIdPrefix: string;
@@ -270,6 +275,10 @@ async function refundChallengeFundsByPrefix(input: {
     const { refundedTransactions, totalRefunded } = await refundMultiAccountTransaction(input);
     return { count: refundedTransactions.length, amount: totalRefunded };
   } catch (e) {
+    const status = getBuzzApiStatus(e);
+    if (status === 404 || status === 409) return { count: 0, amount: 0 };
+    // Kept for a NOT_FOUND raised without a buzz cause — the tolerance predates mapError
+    // carrying one, and callers below rely on it.
     if (e instanceof TRPCError && e.code === 'NOT_FOUND') return { count: 0, amount: 0 };
     throw e;
   }

--- a/src/server/services/buzz.service.ts
+++ b/src/server/services/buzz.service.ts
@@ -84,18 +84,22 @@ type AccountType = 'User' | 'CreatorProgramBank' | 'CashPending' | 'CashSettled'
 export const buzzService = createBuzzClient({
   endpoint: env.BUZZ_ENDPOINT,
   log: isDev ? (message, ...args) => console.log(message, ...args) : undefined,
+  // Every branch carries the BuzzApiError as `cause`: the mapping is lossy (400 and 409 share one
+  // code and message), so a caller that has to tell them apart has nothing else to read. Recover it
+  // with `getBuzzApiStatus`; tRPC's error shape does not send `cause` to clients.
   mapError: (error) => {
     switch (error.status) {
       case 400:
-        throw throwBadRequestError();
+        throw throwBadRequestError(null, error);
       case 404:
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Not found' });
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Not found', cause: error });
       case 409:
-        throw throwBadRequestError('There is a conflict with the transaction');
+        throw throwBadRequestError('There is a conflict with the transaction', error);
       default:
         throw new TRPCError({
           code: 'INTERNAL_SERVER_ERROR',
           message: 'An unexpected error ocurred, please try again later',
+          cause: error,
         });
     }
   },

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -2151,8 +2151,6 @@ export async function deleteChallenge(id: number) {
         });
       }
     }
-    // Idempotent via deterministic externalTransactionId prefixes (the buzz service dedups), so
-    // re-refunding an already-Cancelled challenge is a net-zero no-op, not a double-spend.
     await refundUserChallengeFunds(id, 'delete');
   }
 

--- a/src/server/utils/__tests__/buzz-error.test.ts
+++ b/src/server/utils/__tests__/buzz-error.test.ts
@@ -1,0 +1,31 @@
+import { BuzzApiError } from '@civitai/buzz';
+import { TRPCError } from '@trpc/server';
+import { describe, expect, it } from 'vitest';
+import { getBuzzApiStatus } from '~/server/utils/buzz-error';
+
+describe('getBuzzApiStatus', () => {
+  it('reads the status straight off a raw BuzzApiError', () => {
+    expect(getBuzzApiStatus(new BuzzApiError(409, 'Conflict'))).toBe(409);
+  });
+
+  // The shape callers actually see: buzz.service's mapError converts every non-2xx into a
+  // TRPCError and carries the original as `cause`.
+  it('recovers the status through the TRPCError mapError produces', () => {
+    const mapped = new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'There is a conflict with the transaction',
+      cause: new BuzzApiError(409, 'Conflict'),
+    });
+    expect(getBuzzApiStatus(mapped)).toBe(409);
+  });
+
+  it('reports undefined for anything that did not come from the buzz service', () => {
+    expect(getBuzzApiStatus(new TRPCError({ code: 'BAD_REQUEST', message: 'nope' }))).toBeUndefined();
+    expect(
+      getBuzzApiStatus(new TRPCError({ code: 'BAD_REQUEST', cause: new Error('boom') }))
+    ).toBeUndefined();
+    expect(getBuzzApiStatus(new Error('boom'))).toBeUndefined();
+    expect(getBuzzApiStatus(null)).toBeUndefined();
+    expect(getBuzzApiStatus({ status: 409 })).toBeUndefined();
+  });
+});

--- a/src/server/utils/buzz-error.ts
+++ b/src/server/utils/buzz-error.ts
@@ -1,0 +1,14 @@
+import { BuzzApiError } from '@civitai/buzz';
+import { TRPCError } from '@trpc/server';
+
+/**
+ * The HTTP status the buzz service actually returned. `buzzService`'s `mapError` collapses every
+ * non-2xx into a TRPCError, and several statuses share one code and message — 400 and 409 both
+ * arrive as BAD_REQUEST — so callers that need to tell them apart read the status here rather
+ * than matching on the mapped prose.
+ */
+export function getBuzzApiStatus(error: unknown): number | undefined {
+  if (error instanceof BuzzApiError) return error.status;
+  if (error instanceof TRPCError && error.cause instanceof BuzzApiError) return error.cause.status;
+  return undefined;
+}


### PR DESCRIPTION
## Problem

The challenge funnel/economy dashboard's **2 failed refund attempts** (`challenge_refund_failures_total`, `source=User reason=delete`) are one user clicking delete twice, 4.5s apart. ([CU 868kn56ww](https://app.clickup.com/t/868kn56ww))

```
2026-08-06T01:46:03.581Z  challenge.deleteUserChallenge  BAD_REQUEST
  "There is a conflict with the transaction"  input {"id":490}  user 8426770
2026-08-06T01:46:08.040Z  (identical)
```

`deleteChallenge` skips the `Scheduled → Cancelled` claim for a challenge that is already `Cancelled` and re-refunds it. Challenge 490 had already been voided, so its escrowed prize was already returned — and the buzz ledger keeps a refunded `externalTransactionId` occupied (documented at the top of `challenge-funding.ts`), so re-running the prefix refund **409s rather than no-op'ing**.

`mapError` turns 409 into a `BAD_REQUEST`, and `refundChallengeFundsByPrefix` only tolerated `NOT_FOUND`, so it escaped: metric incremented, exception rethrown, delete aborted. Every retry repeats identically — **challenge 490 is permanently undeletable**, and its row plus collection 17509138 survive.

Two things wrong, and worth keeping separate:

- **No money was ever at risk.** The 409 is the ledger correctly refusing a *second* refund. The creator's 50 Buzz came back once, on the void.
- **But the metric said otherwise.** A no-op read as a refund failure on the one page people check to decide whether Buzz went missing.

## Fix

Tolerate 409 alongside 404 in `refundChallengeFundsByPrefix`. Both mean zero Buzz is owed — "the prefix matches nothing" and "the prefix was already reversed" — so neither should abort the surrounding void/delete.

**Detected by status, not by message.** `mapError` is lossy: 400 and 409 both surface as `BAD_REQUEST`, and 409 gets a fixed prose string. Matching that literal would work today and break silently the first time someone rewords it. Instead every `mapError` branch now carries the `BuzzApiError` as `cause`, and `getBuzzApiStatus` recovers the real status.

That also leaves the door open for the next caller that needs to tell a 400 from a 409 — this is the second time the distinction has mattered in the challenge refund path.

`tRPC`'s `errorFormatter` returns the default shape, which does not serialize `cause`, so nothing new reaches clients.

The pre-existing `TRPCError.code === 'NOT_FOUND'` check stays, for a NOT_FOUND raised without a buzz cause.

Once deployed, the owner's next delete on 490 succeeds — **no manual DB write needed**.

## Also

Dropped the comment above the delete-path refund claiming re-refunding an already-Cancelled challenge is "a net-zero no-op, not a double-spend". The no-double-spend half is right; the no-op half is exactly this bug.

## Test plan

- `challenge-funding.test.ts`: a 409 carrying `BuzzApiError` now resolves to `{ refundedEntries: 0 }` (reproduced the abort before the fix), plus a guard test that a `BAD_REQUEST` *without* a buzz cause still propagates — the tolerance is keyed to the status, not to the code.
- `buzz-error.test.ts`: `getBuzzApiStatus` across a raw `BuzzApiError`, the mapped-TRPCError shape callers actually see, and the non-buzz cases.
- `pnpm vitest run --project unit src/server/games/daily-challenge/ src/server/services/__tests__/ src/server/utils/__tests__/` → 3161 passed.
- `pnpm run typecheck` → 0 errors.

## Not in this PR

Whether `challenge_refund_failures_total` wants an explicit `already_refunded` outcome label. With this change the tolerated cases no longer reach the counter at all, so the dashboard is accurate either way — a label would only add detail we do not currently need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
