### PR TITLE
test(apps): catch a PARTIAL render in the "Pull from site is GONE" guard

### DIFF
--- a/src/components/Apps/ExternalSubmitForm.browser.test.tsx
+++ b/src/components/Apps/ExternalSubmitForm.browser.test.tsx
@@ -502,7 +502,42 @@ describe('ExternalSubmitForm — auto-trigger, status, re-pull, data-URI icon', 
 
   test('the manual "Pull from site" button is GONE (auto-trigger replaces it)', async () => {
     renderWithProviders(<ExternalSubmitForm />);
-    await page.getByTestId('apps-offsite-submit-url').fill('https://vitrine.civitai.com');
+    const url = page.getByTestId('apps-offsite-submit-url');
+    await url.fill('https://vitrine.civitai.com');
+
+    // 🔴 POSITIVE CONTROL for a PARTIAL render. This test's real assertion is a
+    // ZERO, so something has to establish that the query mechanism observes a
+    // NON-zero on this same render — otherwise the zero reads as "the button is
+    // gone" when it may equally mean "nothing was queried".
+    //
+    // 🔴 BE PRECISE ABOUT WHAT THIS COVERS. The first version of this comment
+    // claimed the test was "green whether or not the wizard rendered at all", and
+    // a mutation matrix falsified that:
+    //   - "NOTHING rendered" was ALREADY covered before this line existed. The
+    //     `.fill()` above waits for the element and throws, so rendering
+    //     `<div data-testid="NOTHING-RENDERED" />` in place of the form fails at
+    //     the `.fill()` on BOTH the old and the new body (measured: TimeoutError,
+    //     `locator.fill`). This control does not even EXECUTE in that case, so it
+    //     can claim no credit for it.
+    //   - What it DOES catch is a PARTIALLY rendered form: the URL input present
+    //     (so `.fill()` succeeds) but the rest of the step missing. Measured with
+    //     `renderWithProviders(<input data-testid="apps-offsite-submit-url" />)` —
+    //     GREEN without this line, RED with it (`expected [] to have a length of 1
+    //     but got +0`). That is the gap this closes, and the only one.
+    expect(page.getByTestId('apps-offsite-wizard-next-url').elements()).toHaveLength(1);
+
+    // 🔴 `apps-offsite-submit-autofill` is the testid the manual "Pull from site"
+    // button REALLY carried until #3427 removed it — verified against the blob at
+    // 0f1cc11330 (`ExternalSubmitForm.tsx`, `data-testid="apps-offsite-submit-autofill"`
+    // on the Button). It is NOT a name nothing ever used, which is what an
+    // absence-assertion has to establish to mean anything.
+    //
+    // 🔴 And the match is EXACT, not a prefix: measured in this browser tier,
+    // `getByTestId('apps-offsite-submit-url')` finds 1 while
+    // `getByTestId('apps-offsite-submit')` finds 0. So this assertion is NOT
+    // satisfied by the four surviving `apps-offsite-submit-autofill-*` status
+    // notes, and equally it would NOT catch the button coming back under a
+    // suffixed id — it pins exactly the id that was removed.
     expect(page.getByTestId('apps-offsite-submit-autofill').elements()).toHaveLength(0);
   });
 


### PR DESCRIPTION
> **Revised after an adversarial audit.** The code is unchanged in substance, but the evidence originally claimed here was **false** and has been replaced with a reproduced matrix. Details below, kept rather than quietly edited out.

## The problem

`ExternalSubmitForm.browser.test.tsx > the manual "Pull from site" button is GONE (auto-trigger replaces it)` ends on an assertion that a testid is **absent**. A zero is also what a form that never rendered its step body produces, so the test needs something establishing that its query can observe a **non-zero** on the same render.

## Demonstrated, not asserted

Running only this test, substituting the render:

| render substituted with | base | with this change |
|---|---|---|
| *(unmutated)* | PASS | PASS |
| `<div data-testid="NOTHING-RENDERED" />` | **FAIL** | **FAIL** |
| `<input data-testid="apps-offsite-submit-url" />` | **PASS** | **FAIL** |

- **The "nothing rendered" case was already covered.** The pre-existing `await page.getByTestId('apps-offsite-submit-url').fill(...)` waits for the element and throws, so both bodies fail there with `TimeoutError: locator.fill: Timeout 14897ms exceeded`. The added assertion **does not even execute** in that case — an earlier check always wins.
- **The gap that *was* open is a PARTIAL render**: the URL input present (so `.fill()` succeeds and the old body sailed past) but the rest of the step missing. That mutation is **PASS before, FAIL after**, with `AssertionError: expected [] to have a length of 1 but got +0`.

So this is a real, *reachable* guard against a partial-render regression.

### Correction to the original version of this PR

The first version claimed the original test was "green whether or not the wizard rendered at all", and cited a `VitestBrowserElementError` from the new control under the NOTHING-RENDERED mutation. Both were wrong, and both are reproduced above as wrong: the base body goes **RED** under that mutation, and the error cited actually comes from the pre-existing `.fill()`, meaning the added control never ran. That is a textbook unreachable-guard claim, and it was mine. The redundant `expect.element(url).toBeInTheDocument()` from that version is also dropped — `.fill()` already proves it.

## Two facts recorded so they are not re-derived

**The testid is not a typo.** `apps-offsite-submit-autofill` appears nowhere in the source *today*, which is what made it look like one. It is the id the manual button really carried until #3427 removed it — verified against the blob at `0f1cc11330`. Only the four suffixed status notes survive now.

**The match is EXACT, not a prefix.** Measured on the same render: `getByTestId('apps-offsite-submit-url')` → **1**, `getByTestId('apps-offsite-submit')` → **0**. So the assertion is not satisfied by the surviving `-applied`/`-partial`/`-empty`/`-error` notes, and equally would *not* catch the button returning under a suffixed id.

## Verification

3/3 green on the full file (28 tests) before and after rebasing onto current `main`; prettier clean in the touched region; typecheck 0 errors in this file.

## Note for whoever touches this file next

It is **already prettier-dirty on `main`** (four hunks at lines 225/270/300/343 — byte-identical before and after this change) and carries **six pre-existing** `local-rules/no-unloadable-image-fixture` errors. Neither is introduced here nor in the touched region, so both are left alone. Suggests the format/lint gate does not cover this file.

## Scope note

This does **not** fix the two `ExternalSubmitForm` flakes on #3676 and #3674 (both 15s timeouts). Neither reproduced locally — evidence in the triage report; no speculative fix shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aj1HosDFkP6LgxMAtJdDmJ
