### PR TITLE
feat(generation): surface silent model substitutions on the tRPC replies (#3665)

### DIFF
--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -136,6 +136,7 @@ import {
   snapshotFromWorkflow,
   WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY,
 } from '~/server/services/blocks/workflow.service';
+import { projectModelSubstitutions } from '~/shared/data-graph/generation/model-substitution';
 import {
   assertInlineGraphAirsDeclared,
   assertViewerEntitledToInlineResources,
@@ -1090,9 +1091,7 @@ async function createBlockTextToImageStep(opts: {
   // object — so it describes THIS submit and no one else's. Behaviour is
   // unchanged; the caller folds this into the snapshot so the block can detect
   // that it was billed for a model it did not ask for.
-  const modelSubstitutions = externalCtx.modelSubstitutions
-    ?.list()
-    .map(({ requested, applied, reason }) => ({ requested, applied, reason }));
+  const modelSubstitutions = projectModelSubstitutions(externalCtx.modelSubstitutions);
 
   // 🔴 PERSIST it on the workflow's own metadata, not only on the submit reply.
   // A block renders from the TERMINAL POLL (the only snapshot carrying

--- a/src/server/services/blocks/workflow.service.ts
+++ b/src/server/services/blocks/workflow.service.ts
@@ -9,7 +9,10 @@ import { getBaseModelSetType } from '~/shared/constants/generation.constants';
 import { getEcosystem } from '~/shared/constants/basemodel.constants';
 import { isWorkflowAvailable } from '~/shared/data-graph/generation/config/workflows';
 import { resolveVersionWorkflowScope } from '~/shared/data-graph/generation/workflow-capability';
-import { isModelSubstitutionReason } from '~/shared/data-graph/generation/model-substitution';
+import {
+  readModelSubstitutionsFromMetadata,
+  WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY,
+} from '~/shared/data-graph/generation/model-substitution';
 import { getImagesLimit } from '~/shared/data-graph/generation/images-limit';
 import { ModelType } from '~/shared/utils/prisma/enums';
 import type {
@@ -33,8 +36,12 @@ const ORCH_STATUS_MAP: Record<WorkflowStatus, BlockWorkflowSnapshot['status']> =
 };
 
 /**
- * 🔴 KEY under which the submit path stores the request's silent checkpoint
- * substitutions on the ORCHESTRATOR WORKFLOW's `metadata` (issue #3520).
+ * 🔴 The key + reader for silent checkpoint substitutions persisted on the
+ * ORCHESTRATOR WORKFLOW's `metadata` (issue #3520) now live in
+ * `~/shared/data-graph/generation/model-substitution` — the tRPC generation path
+ * needs the identical parse (#3665), and a second copy of a validating predicate
+ * is how the same bug gets fixed at one site and not the other. Re-exported here
+ * because this module is where the block path's callers already look for it.
  *
  * WHY THE ORCHESTRATOR AND NOT A COLUMN. The record is produced during graph
  * validation, which happens once, at submit. But blocks render from the
@@ -43,54 +50,21 @@ const ORCH_STATUS_MAP: Record<WorkflowStatus, BlockWorkflowSnapshot['status']> =
  * `Workflow` with no access to that long-gone request context. A submit-reply-
  * only field is therefore gone by the time there is anything to display beside
  * it, and `block_workflows` does not retain the submitted body, so it is not
- * recoverable afterwards either — i.e. the field would not achieve the thing
- * #3520 asks for ("a caller billed for model A and given model B must be able to
- * find that out").
+ * recoverable afterwards either.
  *
  * `WorkflowTemplate.metadata` is a free-form `{ [key: string]: unknown }` bag
- * that the orchestrator persists and echoes back on every read of the workflow,
- * which makes it the natural carrier: written once at submit, readable on every
- * subsequent poll, and NO database change (no Prisma migration — which in this
- * org is a manually-applied, per-environment human operation, not something a
- * code PR should imply).
+ * that the orchestrator persists and echoes back on every read, which makes it
+ * the natural carrier: written once at submit, readable on every subsequent
+ * poll, and NO database change.
  *
- * The app already relies on this round-trip for its own non-standard top-level
- * metadata keys — `remixOfId` and `isPrivateGeneration` are written here at
- * submit and read back from `workflow.metadata` in
- * `orchestration-new.service.ts`'s workflow formatter — so this is an existing,
- * exercised path rather than a new assumption. The formatter builds its
- * normalized metadata from a fixed key list, so an extra key is inert there.
+ * 🔴 The old note here said the generation formatter "builds its normalized
+ * metadata from a fixed key list, so an extra key is inert there". That was
+ * true, and it was the defect #3665 had to fix: the key round-tripped fine but
+ * `formatGenerationResponse2` dropped it on read-back, so the generation path
+ * could persist the record and still never surface it. The formatter now passes
+ * it through explicitly.
  */
-export const WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY = 'modelSubstitutions';
-
-/**
- * Read substitutions back off a fetched workflow's metadata.
- *
- * 🔴 VALIDATED, not cast. This crosses a service boundary: the value is whatever
- * the orchestrator hands back, and the snapshot it feeds is a public wire
- * contract whose `reason` is also a bounded prom label. So each entry is checked
- * structurally and its `reason` narrowed against the code-owned union; anything
- * else is dropped. Returns `undefined` (not `[]`) when there is nothing to
- * report, so the caller can keep OMITTING the field entirely.
- */
-function readModelSubstitutionsFromMetadata(
-  workflow: Workflow
-): BlockWorkflowSnapshot['modelSubstitutions'] {
-  const raw = (workflow.metadata as Record<string, unknown> | null | undefined)?.[
-    WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY
-  ];
-  if (!Array.isArray(raw)) return undefined;
-  const out: NonNullable<BlockWorkflowSnapshot['modelSubstitutions']> = [];
-  for (const entry of raw) {
-    if (!entry || typeof entry !== 'object') continue;
-    const { requested, applied, reason } = entry as Record<string, unknown>;
-    if (typeof requested !== 'number' || !Number.isFinite(requested)) continue;
-    if (typeof applied !== 'number' || !Number.isFinite(applied)) continue;
-    if (!isModelSubstitutionReason(reason)) continue;
-    out.push({ requested, applied, reason });
-  }
-  return out.length ? out : undefined;
-}
+export { WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY, readModelSubstitutionsFromMetadata };
 
 /**
  * Flatten an orchestrator Workflow into the wire-stable shape the iframe
@@ -186,7 +160,7 @@ export function snapshotFromWorkflow(
   // metadata, which is what makes the field survive to the terminal poll.
   const modelSubstitutions = extra?.modelSubstitutions?.length
     ? extra.modelSubstitutions
-    : readModelSubstitutionsFromMetadata(workflow);
+    : readModelSubstitutionsFromMetadata(workflow.metadata);
   return {
     // A whatif/estimate workflow has no orchestrator id. The block SDK's
     // inbound validator (isValidWorkflowSnapshot) DROPS any snapshot whose

--- a/src/server/services/orchestrator/__tests__/orchestration-new.model-substitutions.test.ts
+++ b/src/server/services/orchestrator/__tests__/orchestration-new.model-substitutions.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * `formatGenerationResponse2` must SURFACE persisted silent-checkpoint
+ * substitutions (#3520 / #3665).
+ *
+ * 🔴 WHY THIS TEST EXISTS AT ALL. `normalizedWfMeta` is built from an explicit
+ * key ALLOWLIST (`params`, `resources`, `remixOfId`, `isPrivateGeneration`),
+ * not a spread. So persisting `modelSubstitutions` on the orchestrator
+ * workflow's metadata — which is what the App Blocks path does, and what the
+ * obvious reading of #3665 says to copy — is NOT sufficient on the generation
+ * path: the key round-trips through the orchestrator perfectly and this
+ * formatter drops it again on read-back. The record would exist, be billed
+ * against, and reach nobody.
+ *
+ * The App Blocks author knew this and said so — the old comment on
+ * `WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY` noted the formatter "builds its
+ * normalized metadata from a fixed key list, so an extra key is inert there."
+ * It was inert. That is precisely the defect, and this pins the fix.
+ *
+ * The fixture carries NO resources, so `getResourceData` is never reached and
+ * this drives the real formatter rather than a mock of it. The mock preamble
+ * mirrors `orchestration-new.air-map.test.ts` — it only keeps the heavy
+ * DB/redis module graph inert so the module imports.
+ */
+
+vi.mock('~/server/redis/client', () => {
+  const make = (): any => new Proxy(() => 'k', { get: () => make() });
+  const keyProxy = make();
+  return {
+    redis: { packed: { get: vi.fn(), set: vi.fn() }, get: vi.fn(), set: vi.fn() },
+    sysRedis: { hGet: vi.fn() },
+    REDIS_KEYS: keyProxy,
+    REDIS_SYS_KEYS: keyProxy,
+    REDIS_SUB_KEYS: keyProxy,
+    withSysReadDeadline: vi.fn((p: Promise<unknown>) => p),
+  };
+});
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: vi.fn() }));
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+vi.mock('~/server/db/pgDb', () => ({ pgDbReadLong: {}, pgDbRead: {}, pgDbWrite: {} }));
+vi.mock('~/server/db/db-lag-helpers', () => ({
+  getDbWithoutLag: vi.fn(),
+  getDbWithoutLagBatch: vi.fn(),
+  preventReplicationLag: vi.fn(),
+}));
+vi.mock('~/server/db/datapacketDb', () => ({ datapacketDbRead: {}, datapacketDbWrite: {} }));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/search-index', () => ({}));
+vi.mock('@civitai/db', () => ({
+  createLagTracker: vi.fn(() => ({})),
+  loadDbEnv: vi.fn(() => ({})),
+}));
+vi.mock('~/server/services/generation/generation.service', () => ({
+  getGenerationEcosystemConfig: vi.fn(async () => ({
+    experimentalEcosystems: [],
+    hasTestingAccess: false,
+  })),
+  getGateRules: vi.fn(async () => []),
+  getSelfHostedDisabledEcosystems: vi.fn(() => [] as string[]),
+  getResourceData: vi.fn(async () => []),
+}));
+vi.mock('~/server/services/image.service', () => ({
+  getAllImages: vi.fn(),
+  enqueueImageIngestion: vi.fn(),
+  imagesForModelVersionsCache: {},
+}));
+
+import { formatGenerationResponse2 } from '~/server/services/orchestrator/orchestration-new.service';
+import { WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY } from '~/shared/data-graph/generation/model-substitution';
+
+const SUBSTITUTION = { requested: 999999999, applied: 2436219, reason: 'unrecognized' as const };
+
+/**
+ * A workflow with workflow-level metadata (`params` present — that is what makes
+ * the formatter take the `hasWfMeta` branch) and no resources of any kind.
+ */
+function workflowWithMetadata(extra: Record<string, unknown>) {
+  return {
+    id: 'wf-1',
+    status: 'succeeded',
+    createdAt: new Date('2020-01-01T00:00:00Z'),
+    steps: [],
+    metadata: { params: { prompt: 'a cat' }, ...extra },
+  } as never;
+}
+
+async function formatOne(extra: Record<string, unknown>) {
+  const [formatted] = await formatGenerationResponse2([workflowWithMetadata(extra)]);
+  return formatted;
+}
+
+describe('formatGenerationResponse2 — persisted modelSubstitutions', () => {
+  it('🔴 surfaces the record persisted on the workflow metadata', async () => {
+    const formatted = await formatOne({
+      [WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY]: [SUBSTITUTION],
+    });
+    expect(formatted.metadata?.modelSubstitutions).toEqual([SUBSTITUTION]);
+  });
+
+  it('POSITIVE CONTROL: the fixture really does reach the metadata branch', async () => {
+    // Without this, an assertion that the key is ABSENT below could pass because
+    // the formatter produced no metadata at all — a green that says nothing.
+    const formatted = await formatOne({});
+    expect(formatted.metadata).toBeDefined();
+    expect(formatted.metadata?.params).toMatchObject({ prompt: 'a cat' });
+  });
+
+  it('omits the key entirely when nothing was substituted', async () => {
+    const formatted = await formatOne({});
+    expect(formatted.metadata && 'modelSubstitutions' in formatted.metadata).toBe(false);
+  });
+
+  it('omits the key when the persisted value is an empty array', async () => {
+    const formatted = await formatOne({ [WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY]: [] });
+    expect(formatted.metadata && 'modelSubstitutions' in formatted.metadata).toBe(false);
+  });
+
+  it('🔴 DROPS malformed entries rather than putting them on the wire', async () => {
+    // This crosses a service boundary — the value is whatever the orchestrator
+    // hands back — and `reason` is simultaneously a wire contract and a BOUNDED
+    // prom label, so an unrecognised value must not survive the read.
+    const formatted = await formatOne({
+      [WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY]: [
+        SUBSTITUTION,
+        { requested: 1, applied: 2, reason: 'not-a-real-reason' },
+        { requested: 'x', applied: 2, reason: 'unrecognized' },
+        { requested: 1, applied: Number.NaN, reason: 'unrecognized' },
+        null,
+        'nonsense',
+      ],
+    });
+    expect(formatted.metadata?.modelSubstitutions).toEqual([SUBSTITUTION]);
+  });
+
+  it('ignores a non-array value', async () => {
+    const formatted = await formatOne({
+      [WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY]: { requested: 1 },
+    });
+    expect(formatted.metadata && 'modelSubstitutions' in formatted.metadata).toBe(false);
+  });
+});

--- a/src/server/services/orchestrator/__tests__/orchestration-new.substitution-replies.test.ts
+++ b/src/server/services/orchestrator/__tests__/orchestration-new.substitution-replies.test.ts
@@ -37,10 +37,12 @@ vi.mock('@civitai/client', () => {
   //
   // vitest validates each NAMED import against the mock and refuses the module
   // if one is missing — including names used only as types, which esbuild does
-  // not always elide. A missing one does not fail the suite: the file collects
-  // ZERO tests and reports `no tests`, which reads as "nothing to see" rather
-  // than as breakage. So the list is exhaustive rather than discovered one
-  // error at a time.
+  // not always elide. A missing one DOES fail the run (`Test Files 1 failed`,
+  // non-zero exit) — an earlier version of this comment wrongly said it did
+  // not — but the `Tests` line reads `no tests`, which is uninformative: it is
+  // a collection error, not an assertion failure, so nothing tells you WHICH
+  // symbol is missing until you read the error above it. Hence an exhaustive
+  // list rather than discovering them one error at a time.
   //
   // Regenerate with:
   //   grep -rhoP "import\s+(type\s+)?\{\K[^}]*(?=\}\s+from\s+'@civitai/client')" src \

--- a/src/server/services/orchestrator/__tests__/orchestration-new.substitution-replies.test.ts
+++ b/src/server/services/orchestrator/__tests__/orchestration-new.substitution-replies.test.ts
@@ -1,0 +1,345 @@
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * 🔴 THE THREE EDITS THAT ARE THE FEATURE (#3665), driven end to end.
+ *
+ * A sibling test covers `formatGenerationResponse2`'s allowlist passthrough.
+ * That is the trap, but it is only ONE of the four production changes, and an
+ * audit proved the other three were untested by deleting each and watching CI
+ * stay green:
+ *
+ *   F — the whatIf reply attach  (the half #3665 says matters most)
+ *   G — the submit reply attach
+ *   H — the metadata persist     (`metadata: workflowMetadata`, dropping the key)
+ *
+ * All three could be removed and every suite passed. That is precisely the
+ * failure this PR exists to prevent, applied to the PR itself: a field that is
+ * plumbed, typechecked, reviewed, and reaches nobody.
+ *
+ * So this drives the REAL `generationGraph.safeParse` through the REAL
+ * `whatIfFromGraph` / `generateFromGraph`, with only the orchestrator HTTP call
+ * and the heavy DB/redis module graph stubbed. The substitution is produced by
+ * the actual clamp on a real `modelLocked` ecosystem — not by hand-feeding a
+ * collector — so a change to the graph that stops recording also fails here.
+ *
+ * 🔴 `TimeSpan` IS STUBBED, AND HAS TO BE. `@civitai/client`'s entry does
+ * `export * from './generated'` — a directory specifier Node ESM rejects — so
+ * under vitest `TimeSpan` resolves to an OBJECT, not a constructor, and
+ * `new TimeSpan(...)` throws at import time. `vi.importActual` fails the same
+ * way. The stub is a plain class with the same shape; nothing here asserts on
+ * it. If this ever starts failing with "TimeSpan is not a constructor", that is
+ * the cause, and the real fix is a vitest alias for that package rather than
+ * more mocking here.
+ */
+
+vi.mock('@civitai/client', () => {
+  // 🔴 EVERY name this repo imports from the package, stubbed.
+  //
+  // vitest validates each NAMED import against the mock and refuses the module
+  // if one is missing — including names used only as types, which esbuild does
+  // not always elide. A missing one does not fail the suite: the file collects
+  // ZERO tests and reports `no tests`, which reads as "nothing to see" rather
+  // than as breakage. So the list is exhaustive rather than discovered one
+  // error at a time.
+  //
+  // Regenerate with:
+  //   grep -rhoP "import\s+(type\s+)?\{\K[^}]*(?=\}\s+from\s+'@civitai/client')" src \
+  //     | tr ',' '\n' | sed 's/type //; s/ as .*//' | tr -d ' ' | sort -u
+  //
+  // 🔴 A PROXY WAS TRIED FIRST AND HUNG collection indefinitely (a
+  // self-referential `get` trap plus `has: () => true` defeats vitest's ESM
+  // interop probing). Explicit is uglier and terminates.
+  const stub = (() => undefined) as never;
+  const names = `
+    AceStepAudioInput AceStepAudioStepTemplate AiToolkitTrainingInput Air AssistantMessage
+    AudioBlob AudioCaptioningStepTemplate BasicAnimationsBlobs Blob BuzzClientAccount
+    ChatCompletionChoice ChatCompletionInput ChatCompletionOutput ChatCompletionStep
+    ChatCompletionStepTemplate ComfyAnimaCreateImageGenInput
+    ComfyBooguBaseCreateImageGenInput ComfyBooguEditImageInput ComfyBooguEditTurboImageInput
+    ComfyBooguTurboCreateImageGenInput ComfyErnieStandardCreateImageGenInput
+    ComfyErnieTurboCreateImageGenInput ComfyHiDreamO1CreateImageGenInput
+    ComfyHiDreamO1DevCreateImageGenInput ComfyHiDreamO1DevEditImageGenInput
+    ComfyHiDreamO1EditImageGenInput ComfyKrea2RawCreateImageGenInput
+    ComfyKrea2TurboCreateImageGenInput ComfyLensNormalCreateImageGenInput
+    ComfyLensTurboCreateImageGenInput ComfyLtx23CreateVideoInput ComfyLtx23EditVideoInput
+    ComfyLtx23ExtendVideoInput ComfyLtx23FirstLastFrameToVideoInput
+    ComfyLtx2CreateVideoInput ComfyLtx2FirstLastFrameToVideoInput
+    ComfyMageFlow4bCreateImageGenInput ComfyMageFlow4bEditImageInput
+    ComfyMageFlow4bEditTurboImageInput ComfyMageFlow4bTurboCreateImageGenInput ComfySampler
+    ComfyScheduler ComfyStepTemplate ConsumerBlobPresignResponse ConvertImageOutput
+    ConvertImageStep ConvertImageStepTemplate CustomComfyStepTemplate
+    Flux1KontextMaxImageGenInput Flux1KontextProImageGenInput Flux2DevImageGenInput
+    Flux2FlexImageGenInput Flux2KleinCreateImageInput Flux2KleinEditImageInput
+    Flux2MaxImageGenInput Flux2ProImageGenInput FluxDevFastImageResourceTrainingInput
+    Gemini25FlashCreateImageGenInput Gemini25FlashEditImageGenInput GetWorkflowData
+    GetWorkflowStepData GrokCreateImageGenInput GrokEditImageGenInput GrokEditVideoInput
+    GrokImageToVideoInput GrokTextToVideoInput GrokV15ImageToVideoInput
+    GrokV15ReferenceToVideoInput GrokV15TextToVideoInput HappyHorseV11ImageToVideoInput
+    HappyHorseV11ReferenceToVideoInput HappyHorseV11TextToVideoInput
+    HappyHorseV1ImageToVideoInput HappyHorseV1ReferenceToVideoInput
+    HappyHorseV1TextToVideoInput HappyHorseV1VideoEditInput
+    Hunyuan3dImageTo3dComfyPolyGenInput HunyuanVdeoGenInput ImageBlob ImageGenInput
+    ImageGenStepTemplate ImageJobControlNet ImageJobNetworkParams
+    ImageResourceTrainingOutput ImageResourceTrainingStep ImageResourceTrainingStepTemplate
+    ImageTransformer Imagen4ImageGenInput JsonPatchFactory KlingModel KlingV3VideoGenInput
+    KlingVideoGenInput KohyaImageResourceTrainingInput Krea2FalImageGenInput
+    Krea2StyleReference MaiImageCreateFalImageGenInput MaiImageEditFalImageGenInput
+    MediaCaptioningStepTemplate MediaHashStep MediaHashStepTemplate MediaRatingOutput
+    MeshyImageTo3dFalPolyGenInput MeshyTextTo3dFalPolyGenInput MiniMaxH3VideoGenInput
+    MochiVideoGenInput Model3dBlob MusubiImageResourceTrainingInput NanoBanana2ImageGenInput
+    NanoBanana2LiteImageGenInput NanoBananaProImageGenInput NsfwLevel
+    OpenAiGpt15CreateImageInput OpenAiGpt15EditImageInput OpenAiGpt1CreateImageInput
+    OpenAiGpt1EditImageInput OpenAiGpt1ImageGenInput OpenAiGpt2CreateImageInput
+    OpenAiGpt2EditImageInput Options PolyGenOutput PolyGenStep PolyGenStepTemplate
+    PreprocessImageInput PreprocessImageStepTemplate Priority PromptEnhancementInput
+    PromptEnhancementOutput PromptEnhancementStep PromptEnhancementStepTemplate
+    Qwen20bCreateImageGenInput Qwen20bEditImageGenInput Qwen2CreateFalImageGenInput
+    Qwen2EditFalImageGenInput ResizeTransform ResourceInfo ReveCreateFalImageGenInput
+    ReveEditFalImageGenInput Scheduler Sd1AiToolkitTrainingInput SdCppSampleMethod
+    SdCppSchedule SdxlAiToolkitTrainingInput SeedanceVideoGenInput SeedreamImageGenInput
+    SeedreamVersion Sora2ImageToVideoInput Sora2TextToVideoInput SubmitWorkflowData
+    TextToImageStep TextToImageStepTemplate TrainingOutput TrainingStep TrainingStepTemplate
+    TransactionInfo TransactionType TripoFalPolyGenInput UpdateWorkflowRequest
+    Veo3VideoGenInput VideoBlob VideoEnhancementInput VideoEnhancementStepTemplate
+    VideoGenStepTemplate VideoInterpolationStepTemplate VideoUpscalerStepTemplate
+    ViduQ3VideoGenInput ViduVideoGenInput Wan21CivitaiVideoGenInput
+    Wan225bFalImageToVideoInput Wan225bFalTextToVideoInput Wan22ComfyVideoGenInput
+    Wan22FalImageToVideoInput Wan22FalTextToVideoInput Wan25FalImageToVideoInput
+    Wan25FalTextToVideoInput Wan27FalEditVideoInput Wan27FalImageEditInput
+    Wan27FalImageToVideoInput Wan27FalReferenceToVideoInput Wan27FalTextToImageInput
+    Wan27FalTextToVideoInput WdTaggingStepTemplate Workflow WorkflowCallback WorkflowCost
+    WorkflowEvent WorkflowStatus WorkflowStep WorkflowStepEvent WorkflowStepJobQueuePosition
+    WorkflowStepTemplate WorkflowTemplate XGuardLabelResult XGuardModerationOutput
+    XGuardModerationStep XGuardModerationStepTemplate ZImageBaseCreateImageGenInput
+    ZImageTurboCreateImageGenInput ZipTrainingData addWorkflowTag applyPatch
+    createCivitaiClient deleteWorkflow getConsumerBlobUploadUrl getResource getWorkflow
+    getWorkflowStep handleError invokeImageUploadStepTemplate
+    invokeVideoEnhancementStepTemplate invokeVideoMetadataStepTemplate patchWorkflow
+    patchWorkflowStep queryWorkflows refreshBlob removeWorkflowTag submitWorkflow
+    updateWorkflow updateWorkflowStep
+  `
+    .split(/\s+/)
+    .filter(Boolean);
+  const mod: Record<string, unknown> = Object.fromEntries(names.map((n) => [n, stub]));
+  // The only export actually CONSTRUCTED by the code under test:
+  // `new TimeSpan(0, 20, 0)` then `.addMinutes(n)` then `.toString([...])`,
+  // used to compute a submit timeout. Nothing here asserts on the value.
+  mod.TimeSpan = class {
+    constructor(public h = 0, public m = 0, public s = 0) {}
+    addMinutes(n: number) {
+      this.m += n;
+      return this;
+    }
+    toString() {
+      return `${this.h}:${this.m}:${this.s}`;
+    }
+  };
+  return mod;
+});
+
+// `vi.hoisted` because `vi.mock` factories are lifted above every top-level
+// binding — referencing a plain `const` from one throws "Cannot access
+// 'submitWorkflow' before initialization", and that surfaces as `no tests`
+// rather than as a failure.
+const { submitWorkflow } = vi.hoisted(() => ({
+  submitWorkflow: vi.fn(async ({ body }: { body: Record<string, unknown> }) => ({
+    id: 'wf-1',
+    status: 'succeeded',
+    createdAt: new Date('2020-01-01T00:00:00Z'),
+    steps: [],
+    cost: { total: 60 },
+    transactions: { list: [] },
+    // The orchestrator echoes the submitted metadata back on every read — that
+    // round-trip is what makes the persisted record survive to later polls.
+    metadata: body.metadata,
+  })),
+}));
+vi.mock('~/server/services/orchestrator/workflows', () => ({ submitWorkflow }));
+
+vi.mock('~/server/redis/client', () => {
+  const make = (): any => new Proxy(() => 'k', { get: () => make() });
+  const keyProxy = make();
+  return {
+    redis: { packed: { get: vi.fn(), set: vi.fn() }, get: vi.fn(), set: vi.fn() },
+    sysRedis: { hGet: vi.fn() },
+    REDIS_KEYS: keyProxy,
+    REDIS_SYS_KEYS: keyProxy,
+    REDIS_SUB_KEYS: keyProxy,
+    withSysReadDeadline: vi.fn((p: Promise<unknown>) => p),
+  };
+});
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: vi.fn() }));
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+vi.mock('~/server/db/pgDb', () => ({ pgDbReadLong: {}, pgDbRead: {}, pgDbWrite: {} }));
+vi.mock('~/server/db/db-lag-helpers', () => ({
+  getDbWithoutLag: vi.fn(),
+  getDbWithoutLagBatch: vi.fn(),
+  preventReplicationLag: vi.fn(),
+}));
+vi.mock('~/server/db/datapacketDb', () => ({ datapacketDbRead: {}, datapacketDbWrite: {} }));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/search-index', () => ({}));
+vi.mock('@civitai/db', () => ({
+  createLagTracker: vi.fn(() => ({})),
+  loadDbEnv: vi.fn(() => ({})),
+}));
+vi.mock('~/server/services/generation/generation.service', () => ({
+  getGenerationEcosystemConfig: vi.fn(async () => ({
+    experimentalEcosystems: [],
+    hasTestingAccess: false,
+  })),
+  getGateRules: vi.fn(async () => []),
+  getSelfHostedDisabledEcosystems: vi.fn(() => [] as string[]),
+  getResourceData: vi.fn(async () => []),
+}));
+vi.mock('~/server/services/image.service', () => ({
+  getAllImages: vi.fn(),
+  enqueueImageIngestion: vi.fn(),
+  imagesForModelVersionsCache: {},
+}));
+// Prompt moderation is not what this file is about; keep it inert. 🔴 These are
+// the paths `orchestration-new.service` actually imports — mocking a plausible
+// but WRONG path (e.g. `~/server/services/moderation/*`) silently loads the real
+// module instead, and the failure surfaces deep inside it rather than as a
+// missing mock.
+vi.mock('~/server/services/orchestrator/promptAuditing', () => ({
+  auditPromptServer: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/services/orchestrator/orchestrator.service', () => ({
+  createXGuardModerationRequest: vi.fn(async () => undefined),
+}));
+
+import {
+  generateFromGraph,
+  whatIfFromGraph,
+} from '~/server/services/orchestrator/orchestration-new.service';
+import {
+  createModelSubstitutionCollector,
+  WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY,
+} from '~/shared/data-graph/generation/model-substitution';
+import { classifyModelSubstitutionReason } from '~/shared/data-graph/generation/workflow-capability';
+import { getWorkflowCapability } from '~/shared/data-graph/generation/workflow-capability';
+
+/** An id no ecosystem has ever heard of — #3665's own probe. */
+const UNRECOGNIZED_ID = 987654321;
+const QWEN_DEFAULT = getWorkflowCapability('Qwen', 'txt2img')?.defaultModelId as number;
+
+/** A server-shaped context carrying a fresh per-request collector. */
+function ctx() {
+  return {
+    limits: { maxQuantity: 4, maxResources: 10, vidQuantity: 1 },
+    user: { isMember: false, tier: 'free' },
+    flags: {},
+    selfHostedDisabledEcosystems: [],
+    selfHostedMode: 'enabled',
+    gateRules: [],
+    modelSubstitutions: createModelSubstitutionCollector(classifyModelSubstitutionReason, 'api'),
+  } as never;
+}
+
+function input(modelVersionId?: number) {
+  return {
+    workflow: 'txt2img',
+    ecosystem: 'Qwen',
+    ...(modelVersionId != null ? { model: { id: modelVersionId } } : {}),
+    resources: [],
+    prompt: 'a cat',
+    sampler: 'Euler',
+    steps: 25,
+    quantity: 1,
+    priority: 'low',
+  };
+}
+
+const common = { userId: 1, isModerator: false, token: 't', experimental: false } as const;
+
+describe('the graph fixture is still what these tests assume', () => {
+  it('Qwen/txt2img is modelLocked with a default', () => {
+    // Guard the guard: if Qwen stops being modelLocked, nothing below
+    // substitutes and every assertion would pass vacuously.
+    expect(getWorkflowCapability('Qwen', 'txt2img')?.modelLocked).toBe(true);
+    expect(typeof QWEN_DEFAULT).toBe('number');
+  });
+});
+
+describe('whatIfFromGraph — reply carries the substitution (mutant F)', () => {
+  it('🔴 reports the swap on the zero-spend estimate', async () => {
+    const result = (await whatIfFromGraph({
+      input: input(UNRECOGNIZED_ID),
+      externalCtx: ctx(),
+      ...common,
+    } as never)) as { modelSubstitutions?: unknown };
+
+    expect(result.modelSubstitutions).toEqual([
+      { requested: UNRECOGNIZED_ID, applied: QWEN_DEFAULT, reason: 'unrecognized' },
+    ]);
+  });
+
+  it('omits the key when the requested version is valid', async () => {
+    const result = (await whatIfFromGraph({
+      input: input(QWEN_DEFAULT),
+      externalCtx: ctx(),
+      ...common,
+    } as never)) as Record<string, unknown>;
+
+    expect('modelSubstitutions' in result).toBe(false);
+  });
+});
+
+describe('generateFromGraph — reply + persistence (mutants G and H)', () => {
+  it('🔴 attaches the substitution to the submit reply', async () => {
+    const result = (await generateFromGraph({
+      input: input(UNRECOGNIZED_ID),
+      externalCtx: ctx(),
+      ...common,
+    } as never)) as { modelSubstitutions?: unknown };
+
+    expect(result.modelSubstitutions).toEqual([
+      { requested: UNRECOGNIZED_ID, applied: QWEN_DEFAULT, reason: 'unrecognized' },
+    ]);
+  });
+
+  it('🔴 PERSISTS it on the submitted workflow metadata — the half that survives to later reads', async () => {
+    submitWorkflow.mockClear();
+    await generateFromGraph({
+      input: input(UNRECOGNIZED_ID),
+      externalCtx: ctx(),
+      ...common,
+    } as never);
+
+    const body = submitWorkflow.mock.calls[0][0].body as Record<string, unknown>;
+    const metadata = body.metadata as Record<string, unknown>;
+    expect(metadata[WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY]).toEqual([
+      { requested: UNRECOGNIZED_ID, applied: QWEN_DEFAULT, reason: 'unrecognized' },
+    ]);
+  });
+
+  it('🔴 the persisted record survives the orchestrator round-trip into the formatted reply', async () => {
+    // The end-to-end property that actually matters: submit -> persisted on the
+    // workflow -> echoed back -> SURFACED by the formatter's allowlist. A poll
+    // or history read rebuilds from exactly this path.
+    const result = (await generateFromGraph({
+      input: input(UNRECOGNIZED_ID),
+      externalCtx: ctx(),
+      ...common,
+    } as never)) as { metadata?: { modelSubstitutions?: unknown } };
+
+    expect(result.metadata?.modelSubstitutions).toEqual([
+      { requested: UNRECOGNIZED_ID, applied: QWEN_DEFAULT, reason: 'unrecognized' },
+    ]);
+  });
+
+  it('writes NO substitution key when the requested version is valid', async () => {
+    submitWorkflow.mockClear();
+    const result = (await generateFromGraph({
+      input: input(QWEN_DEFAULT),
+      externalCtx: ctx(),
+      ...common,
+    } as never)) as Record<string, unknown>;
+
+    const body = submitWorkflow.mock.calls[0][0].body as Record<string, unknown>;
+    const metadata = (body.metadata ?? {}) as Record<string, unknown>;
+    expect(WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY in metadata).toBe(false);
+    expect('modelSubstitutions' in result).toBe(false);
+  });
+});

--- a/src/server/services/orchestrator/orchestration-new.service.ts
+++ b/src/server/services/orchestrator/orchestration-new.service.ts
@@ -48,6 +48,7 @@ import { applicableRulesFor } from '~/shared/data-graph/generation/gates';
 import { emitModelSubstitutions } from '~/server/metrics/emit-model-substitutions';
 import {
   createModelSubstitutionCollector,
+  projectModelSubstitutions,
   readModelSubstitutionsFromMetadata,
   WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY,
   type GenerationSurface,
@@ -1556,9 +1557,7 @@ export async function generateFromGraph({
   // this function (#3520 / #3665). Read off THIS request's per-request collector
   // — never a shared or cached object — so it describes this submit and no one
   // else's. `ecosystem`/`workflow` are dropped: the caller knows what it sent.
-  const modelSubstitutions = externalCtx.modelSubstitutions
-    ?.list()
-    .map(({ requested, applied, reason }) => ({ requested, applied, reason }));
+  const modelSubstitutions = projectModelSubstitutions(externalCtx.modelSubstitutions);
 
   // 🔴 PERSIST, not just reply. `formatGenerationResponse2` recovers this from
   // the workflow's own metadata on EVERY later read, which is what lets a caller
@@ -1607,7 +1606,15 @@ export async function generateFromGraph({
   //
   // Additive: the key is absent when nothing was substituted, so the response is
   // unchanged in the common case.
-  return modelSubstitutions?.length ? { ...formatted, modelSubstitutions } : formatted;
+  //
+  // 🔴 A CONDITIONAL SPREAD, NOT A TERNARY OVER THE WHOLE OBJECT. Writing
+  // `cond ? { ...formatted, modelSubstitutions } : formatted` produces a UNION
+  // return type, and TypeScript will not let a consumer read a property that
+  // exists on only one arm — `result.modelSubstitutions` fails with TS2339 from
+  // the typed tRPC client, so the field ships looking done and is unusable from
+  // the web app. The spread form below infers the optional property instead, and
+  // matches what `whatIfFromGraph` does.
+  return { ...formatted, ...(modelSubstitutions?.length ? { modelSubstitutions } : {}) };
 }
 
 // =============================================================================
@@ -1685,9 +1692,7 @@ export async function whatIfFromGraph({
   //
   // Nothing is persisted on this path, so unlike the submit path the reply is
   // the only carrier; there is no metadata round-trip to fall back on.
-  const modelSubstitutions = externalCtx.modelSubstitutions
-    ?.list()
-    .map(({ requested, applied, reason }) => ({ requested, applied, reason }));
+  const modelSubstitutions = projectModelSubstitutions(externalCtx.modelSubstitutions);
 
   return {
     allowMatureContent: workflow.allowMatureContent,
@@ -1945,6 +1950,17 @@ export interface NormalizedWorkflowMetadata {
    * is built from an explicit key ALLOWLIST, so persisting the key is not enough
    * on its own: before #3665 the generation path could write it and the formatter
    * would silently drop it on read-back. If you add a field here, add it there.
+   *
+   * 🔴 WHERE AN INTEGRATOR READS IT — three places, and they are not the same:
+   *   - `whatIfFromGraph`      → TOP-LEVEL `modelSubstitutions` on the reply.
+   *                              Nothing is persisted on that path, so the reply
+   *                              is the only carrier.
+   *   - `generateFromGraph`    → BOTH top-level (authoritative for the validation
+   *                              just performed) AND here under `metadata`.
+   *   - any LATER read (poll / queryGeneratedImages / history) → HERE ONLY.
+   * A client that only reads the top-level field will see substitutions on the
+   * submit and never again; one that only reads `metadata` will miss the whatIf
+   * entirely. Read both.
    */
   modelSubstitutions?: PersistedModelSubstitution[];
 }

--- a/src/server/services/orchestrator/orchestration-new.service.ts
+++ b/src/server/services/orchestrator/orchestration-new.service.ts
@@ -48,7 +48,10 @@ import { applicableRulesFor } from '~/shared/data-graph/generation/gates';
 import { emitModelSubstitutions } from '~/server/metrics/emit-model-substitutions';
 import {
   createModelSubstitutionCollector,
+  readModelSubstitutionsFromMetadata,
+  WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY,
   type GenerationSurface,
+  type PersistedModelSubstitution,
 } from '~/shared/data-graph/generation/model-substitution';
 import { classifyModelSubstitutionReason } from '~/shared/data-graph/generation/workflow-capability';
 import type { GenerationResource } from '~/shared/types/generation.types';
@@ -1549,6 +1552,30 @@ export async function generateFromGraph({
   const isPrivateGeneration = !!(workflowMetadata as { isPrivateGeneration?: boolean })
     ?.isPrivateGeneration;
 
+  // Silent checkpoint substitutions recorded by the validation at the top of
+  // this function (#3520 / #3665). Read off THIS request's per-request collector
+  // — never a shared or cached object — so it describes this submit and no one
+  // else's. `ecosystem`/`workflow` are dropped: the caller knows what it sent.
+  const modelSubstitutions = externalCtx.modelSubstitutions
+    ?.list()
+    .map(({ requested, applied, reason }) => ({ requested, applied, reason }));
+
+  // 🔴 PERSIST, not just reply. `formatGenerationResponse2` recovers this from
+  // the workflow's own metadata on EVERY later read, which is what lets a caller
+  // that polls or reconnects still find out it was billed for model A and given
+  // model B. A reply-only field is gone the moment the client moves on, and
+  // nothing retains the submitted body to reconstruct it from.
+  //
+  // Byte-identical when nothing was substituted: the key is only added when
+  // there is something to add.
+  const metadataWithSubstitutions =
+    workflowMetadata && modelSubstitutions?.length
+      ? {
+          ...(workflowMetadata as Record<string, unknown>),
+          [WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY]: modelSubstitutions,
+        }
+      : workflowMetadata;
+
   // Submit workflow to orchestrator
   const workflow = (await submitWorkflow({
     token,
@@ -1557,7 +1584,7 @@ export async function generateFromGraph({
       steps,
       tips,
       experimental,
-      metadata: workflowMetadata,
+      metadata: metadataWithSubstitutions,
       callbacks: getOrchestratorCallbacks(userId),
       // Private generation restrictions
       nsfwLevel: isPrivateGeneration ? 'pg13' : undefined,
@@ -1570,7 +1597,17 @@ export async function generateFromGraph({
 
   // Format and return response
   const [formatted] = await formatGenerationResponse2([workflow], { id: userId } as any);
-  return formatted;
+
+  // 🔴 ALSO ON THE REPLY, and deliberately not only via the metadata round-trip.
+  // The formatter recovers substitutions from `workflow.metadata`, but only when
+  // that metadata `hasWfMeta` (a `params` key) — a submit whose graph produced no
+  // workflow metadata would round-trip nothing. Attaching the request's own
+  // record here makes the submit reply authoritative for the validation it just
+  // performed, independent of what the orchestrator echoed back.
+  //
+  // Additive: the key is absent when nothing was substituted, so the response is
+  // unchanged in the common case.
+  return modelSubstitutions?.length ? { ...formatted, modelSubstitutions } : formatted;
 }
 
 // =============================================================================
@@ -1637,11 +1674,31 @@ export async function whatIfFromGraph({
     }
   }
 
+  // Silent checkpoint substitutions from the validation above (#3520 / #3665).
+  //
+  // 🔴 THIS IS THE ONE THAT MATTERS MOST FOR AN EXTERNAL CALLER. A whatIf spends
+  // nothing and creates no persisted workflow, so it is the only place a client
+  // can discover — BEFORE committing buzz — that the model it named is not the
+  // model that will run. It is also the only signal for a SAME-PRICE
+  // substitution: cost divergence only helps if you already knew the expected
+  // price, and a swap between similarly-priced models is otherwise invisible.
+  //
+  // Nothing is persisted on this path, so unlike the submit path the reply is
+  // the only carrier; there is no metadata round-trip to fall back on.
+  const modelSubstitutions = externalCtx.modelSubstitutions
+    ?.list()
+    .map(({ requested, applied, reason }) => ({ requested, applied, reason }));
+
   return {
     allowMatureContent: workflow.allowMatureContent,
     transactions: workflow.transactions?.list,
     cost: workflow.cost,
     ready,
+    // Additive and OMITTED when empty, matching the App Blocks snapshot contract.
+    // 🔴 Consequence a client must know: absence means "no substitution" OR "a
+    // server that predates this field" — the two are indistinguishable. Callers
+    // that need to tell them apart should probe a known-bad version id once.
+    ...(modelSubstitutions?.length ? { modelSubstitutions } : {}),
   };
 }
 
@@ -1874,6 +1931,22 @@ export interface NormalizedWorkflowMetadata {
   remixOfId?: number;
   /** Whether the generation was private */
   isPrivateGeneration?: boolean;
+  /**
+   * Checkpoint versions the graph SILENTLY replaced during the validation that
+   * produced this workflow (issues #3520 / #3665).
+   *
+   * 🔴 PRESENT ON EVERY LATER READ, not just the submit reply — that is the
+   * whole point. It is recovered from the orchestrator workflow's own
+   * `metadata`, so a caller that polls, reconnects, or lists its history still
+   * learns it was billed for model A and given model B. Omitted entirely when
+   * nothing was substituted, which is the overwhelmingly common case.
+   *
+   * 🔴 THE PASSTHROUGH BELOW IS LOAD-BEARING AND EASY TO LOSE. `normalizedWfMeta`
+   * is built from an explicit key ALLOWLIST, so persisting the key is not enough
+   * on its own: before #3665 the generation path could write it and the formatter
+   * would silently drop it on read-back. If you add a field here, add it there.
+   */
+  modelSubstitutions?: PersistedModelSubstitution[];
 }
 
 /** Normalized workflow response */
@@ -2578,6 +2651,13 @@ export async function formatGenerationResponse2(
 
       // Map params to graph format (workflow, ecosystem, aspectRatio resolution)
       const mapped = mapDataToGraphInput(wfParams, wfResources);
+      // 🔴 THIS IS AN ALLOWLIST, NOT A SPREAD. Every key a caller sees has to be
+      // named here; `rawWfMeta` carries others that are deliberately not
+      // surfaced. That is exactly why `modelSubstitutions` needs an explicit
+      // line: the submit path persists it on the orchestrator metadata, and
+      // before #3665 this formatter dropped it again on read-back — the record
+      // round-tripped perfectly and reached no one.
+      const persistedSubstitutions = readModelSubstitutionsFromMetadata(rawWfMeta);
       normalizedWfMeta = {
         params: removeEmpty({ ...wfParams, ...mapped }),
         resources: wfResources,
@@ -2585,6 +2665,7 @@ export async function formatGenerationResponse2(
         ...(rawWfMeta.isPrivateGeneration
           ? { isPrivateGeneration: rawWfMeta.isPrivateGeneration as boolean }
           : {}),
+        ...(persistedSubstitutions ? { modelSubstitutions: persistedSubstitutions } : {}),
       };
     } else if (steps.length > 0) {
       // Historic workflow — no workflow-level metadata.

--- a/src/shared/data-graph/generation/model-substitution.ts
+++ b/src/shared/data-graph/generation/model-substitution.ts
@@ -164,6 +164,72 @@ export type ModelSubstitution = {
 export type ModelSubstitutionEvent = Omit<ModelSubstitution, 'reason'>;
 
 /**
+ * The subset of a {@link ModelSubstitution} that travels on a WIRE — the App
+ * Blocks snapshot, the tRPC generation replies, and the orchestrator workflow
+ * metadata that survives to later reads.
+ *
+ * `ecosystem`/`workflow` are deliberately dropped: the caller already knows what
+ * it submitted, and they are the two fields most likely to change shape as the
+ * graph config evolves.
+ */
+export type PersistedModelSubstitution = {
+  requested: number;
+  applied: number;
+  reason: ModelSubstitutionReason;
+};
+
+/**
+ * The key silent substitutions are persisted under on an orchestrator workflow's
+ * `metadata`.
+ *
+ * 🔴 WHY PERSISTED AT ALL, AND NOT ONLY ON THE SUBMIT REPLY. A reply-only field
+ * is gone before there is anything to show beside it: the render/poll path
+ * rebuilds from a freshly fetched Workflow with none of the submitting request's
+ * context, and neither `block_workflows` nor the generation feed retains the
+ * submitted body to recover it from. Riding on the metadata the submit body
+ * already carries makes it readable on EVERY later read, with no schema or DB
+ * change.
+ */
+export const WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY = 'modelSubstitutions';
+
+/**
+ * Read persisted substitutions back off a workflow's `metadata`.
+ *
+ * 🔴 VALIDATED, NOT CAST. This crosses a service boundary — the value is
+ * whatever the orchestrator hands back — and it feeds public wire contracts
+ * whose `reason` is also a bounded prom label. Each entry is checked
+ * structurally and its `reason` narrowed against the code-owned union; anything
+ * else is dropped.
+ *
+ * Returns `undefined` (not `[]`) when there is nothing to report, so every
+ * caller can keep OMITTING the field rather than emitting an empty array.
+ *
+ * 🔴 DECLARED HERE, IN A MODULE THAT IMPORTS NOTHING, BECAUSE IT HAS TWO
+ * CONSUMERS. It began life private to the App Blocks workflow service; the tRPC
+ * generation path (#3665) needs the identical parse, and a second copy of a
+ * predicate is how the same bug gets fixed at one site and not the other. Keep
+ * it dependency-free so both a server service and shared graph code can use it.
+ */
+export function readModelSubstitutionsFromMetadata(
+  metadata: unknown
+): PersistedModelSubstitution[] | undefined {
+  const raw = (metadata as Record<string, unknown> | null | undefined)?.[
+    WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY
+  ];
+  if (!Array.isArray(raw)) return undefined;
+  const out: PersistedModelSubstitution[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') continue;
+    const { requested, applied, reason } = entry as Record<string, unknown>;
+    if (typeof requested !== 'number' || !Number.isFinite(requested)) continue;
+    if (typeof applied !== 'number' || !Number.isFinite(applied)) continue;
+    if (!isModelSubstitutionReason(reason)) continue;
+    out.push({ requested, applied, reason });
+  }
+  return out.length ? out : undefined;
+}
+
+/**
  * Resolves the REASON for one substitution. Server-supplied (see the module
  * note on why this is injected); `classifyModelSubstitutionReason` in
  * `workflow-capability.ts` is the only implementation.

--- a/src/shared/data-graph/generation/model-substitution.ts
+++ b/src/shared/data-graph/generation/model-substitution.ts
@@ -179,6 +179,32 @@ export type PersistedModelSubstitution = {
 };
 
 /**
+ * Project a request's collector onto the wire shape.
+ *
+ * 🔴 ONE PLACE, because it had become three. The App Blocks bridge, the
+ * generation submit and the whatIf estimate each open-coded the identical
+ * `?.list().map(...)`. That is the same duplication the reader below was
+ * consolidated to remove, and the same argument applies: a projection copied at
+ * N sites is wrong at N−1 of them the day the wire shape changes.
+ *
+ * Returns `undefined` when there is no collector (a client-built context), and
+ * `[]` when a collector recorded nothing — deliberately NOT collapsing the two.
+ * `snapshotFromWorkflow` distinguishes them: an explicit `[]` means "this
+ * request validated and substituted nothing", which SUPPRESSES the fallback read
+ * of the persisted metadata, whereas `undefined` lets that fallback run.
+ * Collapsing them here would silently change the block path's poll behaviour.
+ */
+export function projectModelSubstitutions(
+  collector: Pick<ModelSubstitutionCollector, 'list'> | undefined
+): PersistedModelSubstitution[] | undefined {
+  return collector?.list().map(({ requested, applied, reason }) => ({
+    requested,
+    applied,
+    reason,
+  }));
+}
+
+/**
  * The key silent substitutions are persisted under on an orchestrator workflow's
  * `metadata`.
  *
@@ -211,11 +237,14 @@ export const WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY = 'modelSubstitutions';
  * it dependency-free so both a server service and shared graph code can use it.
  */
 export function readModelSubstitutionsFromMetadata(
-  metadata: unknown
+  // 🔴 NOT `unknown`. This used to take the whole `Workflow` and was moved here
+  // to take its metadata instead, which makes `read…(workflow)` — the exact slip
+  // the move invites — a silent no-op that returns `undefined` forever. Typing
+  // the bag rather than accepting anything makes that a compile error. Both
+  // call sites already pass this shape.
+  metadata: Record<string, unknown> | null | undefined
 ): PersistedModelSubstitution[] | undefined {
-  const raw = (metadata as Record<string, unknown> | null | undefined)?.[
-    WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY
-  ];
+  const raw = metadata?.[WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY];
   if (!Array.isArray(raw)) return undefined;
   const out: PersistedModelSubstitution[] = [];
   for (const entry of raw) {

--- a/src/shared/data-graph/generation/model-substitution.ts
+++ b/src/shared/data-graph/generation/model-substitution.ts
@@ -187,12 +187,22 @@ export type PersistedModelSubstitution = {
  * consolidated to remove, and the same argument applies: a projection copied at
  * N sites is wrong at N−1 of them the day the wire shape changes.
  *
- * Returns `undefined` when there is no collector (a client-built context), and
- * `[]` when a collector recorded nothing — deliberately NOT collapsing the two.
- * `snapshotFromWorkflow` distinguishes them: an explicit `[]` means "this
- * request validated and substituted nothing", which SUPPRESSES the fallback read
- * of the persisted metadata, whereas `undefined` lets that fallback run.
- * Collapsing them here would silently change the block path's poll behaviour.
+ * Returns `undefined` when there is no collector (a client-built context) and
+ * `[]` when a collector recorded nothing.
+ *
+ * 🔴 THOSE TWO ARE CURRENTLY INTERCHANGEABLE, and an earlier version of this
+ * comment claimed otherwise — that an explicit `[]` suppresses
+ * `snapshotFromWorkflow`'s fallback read of the persisted metadata while
+ * `undefined` allows it. That is FALSE and was measured: the fallback is guarded
+ * by `extra?.modelSubstitutions?.length` (`services/blocks/workflow.service.ts`),
+ * and `[].length` is `0`, so an empty array takes the same branch as `undefined`.
+ * Every consumer tests `?.length`, so nothing distinguishes them today.
+ *
+ * They are still not collapsed here, for the narrow reason that this function is
+ * a pure extraction of what three call sites already did — collapsing would be a
+ * behaviour change smuggled into a refactor. If you ever want one, check every
+ * consumer for a PRESENCE test (`!== undefined`, `in`, `?? `) first; that is what
+ * would make the distinction real.
  */
 export function projectModelSubstitutions(
   collector: Pick<ModelSubstitutionCollector, 'list'> | undefined
@@ -237,11 +247,21 @@ export const WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY = 'modelSubstitutions';
  * it dependency-free so both a server service and shared graph code can use it.
  */
 export function readModelSubstitutionsFromMetadata(
-  // 🔴 NOT `unknown`. This used to take the whole `Workflow` and was moved here
-  // to take its metadata instead, which makes `read…(workflow)` — the exact slip
-  // the move invites — a silent no-op that returns `undefined` forever. Typing
-  // the bag rather than accepting anything makes that a compile error. Both
-  // call sites already pass this shape.
+  // Narrower than `unknown` — a primitive is now rejected — but 🔴 BE CLEAR
+  // ABOUT WHAT THIS DOES NOT BUY, because an earlier version of this comment
+  // claimed the opposite. This function used to take the whole `Workflow` and
+  // now takes its metadata, so `read…(workflow)` is the slip the move invites,
+  // and it is a silent no-op that returns `undefined` forever.
+  //
+  // That slip STILL COMPILES. `Workflow` is a type ALIAS, so TypeScript grants
+  // it an implicit index signature and it is assignable to
+  // `Record<string, unknown>` — measured, with a negative control to prove the
+  // probe compiled. Shaping the parameter to exclude it (`& { steps?: never }`)
+  // would also reject the legitimate callers, which pass a plain
+  // `Record<string, unknown>` whose index signature makes `steps` `unknown`.
+  //
+  // So the type is not the guard here; the tests are. If you are calling this,
+  // pass `something.metadata`, not `something`.
   metadata: Record<string, unknown> | null | undefined
 ): PersistedModelSubstitution[] | undefined {
   const raw = metadata?.[WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY];


### PR DESCRIPTION
Closes #3665 (item 1 of its ask). Refs #3520. Companion to #3673, which does item 2.

## What's wrong

`generateFromGraph` / `whatIfFromGraph` substitute the ecosystem default when a submitted `model.id` isn't valid for a `modelLocked` ecosystem, bill the caller for what actually ran, and return a reply byte-indistinguishable from success. From #3665's repro: a **nonexistent** model id returns a clean HTTP 200 at the ecosystem-default price.

The record already existed — `ext.modelSubstitutions.record(...)` in the graph clamp — but only the App Blocks bridge surfaced it, so a CLI or any external integration had no way to detect the swap. `grep -c modelSubstitutions src/server/routers/orchestrator.router.ts` → 0.

**The substitution itself is unchanged.** This surfaces the record that was already being taken. Reject-vs-degrade stays open and stays gated.

## How

- **`whatIfFromGraph`** returns `modelSubstitutions` on its reply. This is the half that matters most for an external caller: it spends nothing and creates no persisted workflow, so it is the only place a client can find out **before committing buzz** that the model it named isn't the model that will run. It's also the only signal for a **same-price** substitution — cost divergence only helps if you already knew the expected price, which #3665 says explicitly.
- **`generateFromGraph`** both persists the record on the orchestrator workflow's `metadata` *and* attaches it to the reply. Persisting is what makes it readable on every **later** read (poll, reconnect, history) — a reply-only field is gone the moment the client moves on, and nothing retains the submitted body to reconstruct it from. Attaching it to the reply keeps the submit authoritative for the validation it just performed, since the metadata round-trip only happens when the graph produced workflow metadata at all.

## 🔴 The trap, because it would have shipped inert

Persisting the key is **not sufficient on its own**, and the failure is silent. `formatGenerationResponse2` builds `normalizedWfMeta` from an explicit key **allowlist** (`params`, `resources`, `remixOfId`, `isPrivateGeneration`) — not a spread. So the key round-trips through the orchestrator perfectly and the formatter drops it again on read-back. The record would exist, be billed against, and reach nobody.

This wasn't a surprise to the codebase — the App Blocks author had written exactly this on the key's docblock: *"The formatter builds its normalized metadata from a fixed key list, so an extra key is inert there."* It was inert. That comment is now corrected, the formatter passes the key through explicitly, and the new test **drives the real formatter** (the fixture carries no resources, so `getResourceData` is never reached) and fails without the passthrough. Verified by removing it: 2 tests go red.

## Consolidation

`WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY` and its validating reader move from `services/blocks/workflow.service` into the zero-import shared `model-substitution` module. Both paths now share one implementation — a second copy of a validating predicate is how the same bug gets fixed at one site and not the other. `workflow.service` re-exports them so its existing callers are untouched.

The reader validates rather than casts: it crosses a service boundary (the value is whatever the orchestrator hands back) and `reason` is simultaneously a wire contract *and* a bounded prom label, so an unrecognised value must not survive the read. Verified by removing the narrowing — the malformed-entry test goes red.

## Compatibility

Additive throughout; the key is **omitted** when nothing was substituted, so every response is unchanged in the common case.

🔴 One consequence a client must know, stated because it's a real limitation and not a nit: **absence means "no substitution" OR "a server predating this field"** — the two are indistinguishable. A caller that needs to tell them apart should probe a known-bad version id once. I chose omit-when-empty to match the existing App Blocks snapshot contract (#3665 asked for "the same key the App Blocks bridge already populates"); an always-present empty array would have made version detection free at the cost of changing every response shape. Happy to flip it if you'd rather have the latter.

## Verification

`pnpm typecheck` 0 errors. Tests green on this branch **and on the tree it creates when merged with #3673** — both branches touch `orchestration-new.service.ts` and `model-substitution.ts`, so I built the merge and ran the suites there rather than reasoning about it: no textual conflict (`merge-tree` exit 0), edits land in disjoint regions, 689 tests green, 0 type errors on the merged tree.

The two PRs are independent and can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
