### PR TITLE
feat(models): add ComfyWorkflows model type

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260806120000_add_comfy_workflows_model_type/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260806120000_add_comfy_workflows_model_type/migration.sql
@@ -1,0 +1,3 @@
+-- ALTER TYPE ... ADD VALUE cannot run inside a transaction block in older
+-- Postgres and is not rolled back, so run this statement on its own.
+ALTER TYPE "ModelType" ADD VALUE IF NOT EXISTS 'ComfyWorkflows';

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -789,6 +789,7 @@ enum ModelType {
   Poses
   Wildcards
   Workflows
+  ComfyWorkflows
   Detection
   VisionLanguage
   CLIP

--- a/packages/civitai-db-schema/src/enums.ts
+++ b/packages/civitai-db-schema/src/enums.ts
@@ -151,6 +151,7 @@ export const ModelType = {
   Poses: 'Poses',
   Wildcards: 'Wildcards',
   Workflows: 'Workflows',
+  ComfyWorkflows: 'ComfyWorkflows',
   Detection: 'Detection',
   VisionLanguage: 'VisionLanguage',
   CLIP: 'CLIP',

--- a/packages/civitai-db-schema/src/kysely/enums.ts
+++ b/packages/civitai-db-schema/src/kysely/enums.ts
@@ -128,6 +128,7 @@ export const ModelType = {
   Poses: 'Poses',
   Wildcards: 'Wildcards',
   Workflows: 'Workflows',
+  ComfyWorkflows: 'ComfyWorkflows',
   Detection: 'Detection',
   VisionLanguage: 'VisionLanguage',
   CLIP: 'CLIP',

--- a/packages/civitai-db-schema/src/models.ts
+++ b/packages/civitai-db-schema/src/models.ts
@@ -26,7 +26,7 @@ export type UserEngagementType = "Follow" | "Hide" | "Block";
 
 export type LinkType = "Sponsorship" | "Social" | "Other";
 
-export type ModelType = "Checkpoint" | "TextualInversion" | "Hypernetwork" | "AestheticGradient" | "LORA" | "LoCon" | "DoRA" | "Controlnet" | "Upscaler" | "MotionModule" | "VAE" | "TextEncoder" | "UNet" | "CLIPVision" | "Poses" | "Wildcards" | "Workflows" | "Detection" | "VisionLanguage" | "CLIP" | "LLM" | "Other";
+export type ModelType = "Checkpoint" | "TextualInversion" | "Hypernetwork" | "AestheticGradient" | "LORA" | "LoCon" | "DoRA" | "Controlnet" | "Upscaler" | "MotionModule" | "VAE" | "TextEncoder" | "UNet" | "CLIPVision" | "Poses" | "Wildcards" | "Workflows" | "ComfyWorkflows" | "Detection" | "VisionLanguage" | "CLIP" | "LLM" | "Other";
 
 export type ImportStatus = "Pending" | "Processing" | "Failed" | "Completed";
 

--- a/src/components/CivitaiLink/shared-types.ts
+++ b/src/components/CivitaiLink/shared-types.ts
@@ -56,6 +56,7 @@ export type ResourceType =
   | 'Other'
   | 'Wildcards'
   | 'Workflows'
+  | 'ComfyWorkflows'
   | 'DoRA'
   | 'Detection'
   | 'VisionLanguage'

--- a/src/components/Resource/Files.tsx
+++ b/src/components/Resource/Files.tsx
@@ -128,6 +128,7 @@ function modelTypeToComponentType(modelType: ModelType): ModelFileComponentType 
     case ModelType.Upscaler:
       return 'Upscaler';
     case ModelType.Workflows:
+    case ModelType.ComfyWorkflows:
       return 'Workflow';
     case ModelType.Other:
     default:

--- a/src/components/Resource/FilesProvider.tsx
+++ b/src/components/Resource/FilesProvider.tsx
@@ -869,6 +869,7 @@ const showConflictNotification = (conflicts: FileFromContextProps[][]) => {
 /** Model types whose primary file is an archive/config rather than model weights */
 const archivePrimaryModelTypes: ModelType[] = [
   ModelType.Workflows,
+  ModelType.ComfyWorkflows,
   ModelType.Poses,
   ModelType.Wildcards,
   ModelType.Other,
@@ -1233,6 +1234,18 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     primary: {
       extensions: [...archiveExts, ...configExts],
       fileTypes: [...primaryFileTypesByModelType.Workflows],
+      maxFiles: 1,
+    },
+    additional: {
+      extensions: [...configExts, ...archiveExts],
+      fileTypes: ['Config', 'Archive', 'Other'],
+      maxFiles: 1,
+    },
+  },
+  ComfyWorkflows: {
+    primary: {
+      extensions: [...archiveExts, ...configExts],
+      fileTypes: [...primaryFileTypesByModelType.ComfyWorkflows],
       maxFiles: 1,
     },
     additional: {

--- a/src/shared/constants/badge-color.constants.ts
+++ b/src/shared/constants/badge-color.constants.ts
@@ -17,6 +17,7 @@ export const modelTypeColors: Partial<Record<ModelType, MantineColor>> = {
   Poses: 'pink',
   Wildcards: 'gray',
   Workflows: 'indigo',
+  ComfyWorkflows: 'grape',
   MotionModule: 'red',
 };
 

--- a/src/shared/constants/generation.constants.ts
+++ b/src/shared/constants/generation.constants.ts
@@ -497,6 +497,7 @@ export const miscModelTypes: ModelType[] = [
   'Poses',
   'Wildcards',
   'Workflows',
+  'ComfyWorkflows',
   'Detection',
   'VisionLanguage',
   'CLIP',

--- a/src/utils/array-helpers.ts
+++ b/src/utils/array-helpers.ts
@@ -51,17 +51,18 @@ const modelTypeOrder: { [k in ModelType]: number } = {
   [ModelType.Upscaler]: 9,
   [ModelType.Controlnet]: 10,
   [ModelType.Workflows]: 11,
-  [ModelType.Wildcards]: 12,
-  [ModelType.Poses]: 13,
-  [ModelType.MotionModule]: 14,
+  [ModelType.ComfyWorkflows]: 12,
+  [ModelType.Wildcards]: 13,
+  [ModelType.Poses]: 14,
+  [ModelType.MotionModule]: 15,
 
-  [ModelType.AestheticGradient]: 15,
-  [ModelType.Hypernetwork]: 16,
-  [ModelType.Detection]: 17,
-  [ModelType.VisionLanguage]: 18,
-  [ModelType.CLIP]: 19,
-  [ModelType.LLM]: 20,
-  [ModelType.Other]: 21,
+  [ModelType.AestheticGradient]: 16,
+  [ModelType.Hypernetwork]: 17,
+  [ModelType.Detection]: 18,
+  [ModelType.VisionLanguage]: 19,
+  [ModelType.CLIP]: 20,
+  [ModelType.LLM]: 21,
+  [ModelType.Other]: 22,
 };
 
 export function sortByModelTypes<T extends { modelType: ModelType | null }>(data: T[] = []) {

--- a/src/utils/file-display-helpers.ts
+++ b/src/utils/file-display-helpers.ts
@@ -304,8 +304,8 @@ export function getFileDescription(file: FileForDisplay): string {
  *  - The download-variant grouper (groupFilesByVariant) to decide which files surface in the
  *    primary download card vs. the optional/components sections.
  *
- * For model types that don't ship a traditional weights file (Workflows, Poses, Wildcards, Other),
- * archive and config files ARE the main download.
+ * For model types that don't ship a traditional weights file, archive and config files ARE the
+ * main download.
  */
 export const primaryFileTypesByModelType: Record<ModelType, readonly ModelFileType[]> = {
   Checkpoint: ['Model', 'Pruned Model', 'UNet', 'Diffusion Model'],
@@ -329,6 +329,7 @@ export const primaryFileTypesByModelType: Record<ModelType, readonly ModelFileTy
   Poses: ['Archive', 'Config'],
   Wildcards: ['Archive', 'Config'],
   Workflows: ['Archive', 'Config'],
+  ComfyWorkflows: ['Archive', 'Config'],
   Other: ['Archive', 'Config', 'Model'],
 };
 

--- a/src/utils/string-helpers.ts
+++ b/src/utils/string-helpers.ts
@@ -47,6 +47,7 @@ const nameOverrides: Record<string, string> = {
   DoRA: 'DoRA',
   scheduler: 'Scheduler',
   TextualInversion: 'Embedding',
+  ComfyWorkflows: 'ComfyUI Workflows',
   MotionModule: 'Motion',
   BenefactorsOnly: 'Supporters Only',
   ModelVersion: 'Model Version',


### PR DESCRIPTION
Adds a ComfyUI-specific `ModelType` alongside the existing generic `Workflows`, so Comfy workflows are browsable and filterable on their own rather than mixed in with every other workflow format.

Closes [CU-868kn5hxv](https://app.clickup.com/t/868kn5hxv).

## What changed

| File | Change |
|---|---|
| `schema.full.prisma:792` | `ComfyWorkflows` enum value |
| `migrations/20260806120000_add_comfy_workflows_model_type/` | `ALTER TYPE "ModelType" ADD VALUE IF NOT EXISTS 'ComfyWorkflows'` |
| `array-helpers.ts:52` | Sort order `12` (directly after `Workflows`); subsequent entries shifted `+1` |
| `file-display-helpers.ts:331` | Primary file types `['Archive', 'Config']` |
| `FilesProvider.tsx:1245` | Dropzone — accepts `.zip` / `.json` / `.yaml` / `.yml` / `.txt`, 1 primary + 1 additional |
| `FilesProvider.tsx:870` | Added to `archivePrimaryModelTypes` |
| `CivitaiLink/shared-types.ts:58` | `ResourceType` union |
| `Files.tsx:130` | `modelTypeToComponentType` → `'Workflow'` |
| `generation.constants.ts:499` | Added to `miscModelTypes` |
| `badge-color.constants.ts:20` | Badge color `grape` |
| `string-helpers.ts:49` | Display name override → `"ComfyUI Workflows"` |

The create-model type select, `/api/v1/enums`, the model filters dropdown and the Meilisearch type-filter all read `Object.values(ModelType)`, so they pick the new type up with no edit.

Both categories of consumer are covered: the TS-forced exhaustive `Record<ModelType>` maps (which the compiler flags), and the hand-maintained narrow unions that silently accept a missing value — `ResourceType`, `modelTypeToComponentType`, `miscModelTypes`, `archivePrimaryModelTypes`, `modelTypeColors`, `modelTypeOrder`, `nameOverrides`.

## Decisions worth a second opinion

- **Name `ComfyWorkflows`** (plural, to parallel `Workflows` / `Wildcards` / `Poses`). Postgres enum values are effectively permanent, so flag it now if you'd prefer `ComfyWorkflow` or `ComfyUI`.
- **Badge color `grape`**; `Workflows` keeps `indigo`.
- **Deliberately not** added to `typeUrnMap` (`air.ts`) or the link-component picker in `Files.tsx`. `Workflows` is in neither, so adding `ComfyWorkflows` there would diverge from its sibling. Consequence: no AIR urn for this type, same as today's `Workflows`.
- **No backfill.** The 3,401 published `Workflows`-typed models with "comfy"/"workflow" in the name stay where they are. Migrating them is a separate script if we want it.

## ⚠️ Deploy ordering — migration is manual

We don't run `prisma migrate deploy`. The migration has to be applied by hand to each environment (preview / staging / prod):

```sql
ALTER TYPE "ModelType" ADD VALUE IF NOT EXISTS 'ComfyWorkflows';
```

**Run it before this code deploys.** It's additive and safe on a live database, but if app code that can write the new value ships first, any read of an affected row errors.

## Verification

- `pnpm run typecheck` → 0 errors
- `pnpm run test:unit:run` → 828 files, 12,323 passed / 1 skipped
- `pnpm run db:check-generated` → clean

## Not included

The ClickUp task's example link never saved (description is literally `"Like this one:"`, with no attachments or comments). This PR is the enum-add that was scoped from that. If the intended example implied more — workflow-JSON parsing, node listing, an "open in ComfyUI" affordance — that's follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
