### PR TITLE
docs(rca): retract the margin clearing that let the component flake survive three fixes

### DIFF
--- a/claudedocs/rca-appblocks-component-suite-flake-2026-08-05.md
+++ b/claudedocs/rca-appblocks-component-suite-flake-2026-08-05.md
@@ -227,13 +227,43 @@ components), with a positive control proving the instrument could see a known me
 answer is the strongest form this claim can take — but note it is a claim about *current*
 members, not that the class is closed.
 
-### Same shape, but NOT at risk — and the discriminator is the MARGIN, not the shape
+### ~~Same shape, but NOT at risk — and the discriminator is the MARGIN, not the shape~~ — 🔴 RETRACTED 2026-08-06, THE WRONG CONSTANT
 
-`PageBlockHost.browser.test.tsx:616,641,773` and `PageBlockHostAutoRetry.browser.test.tsx:728`
-all do `click Retry` → assert a loading state. Their state is also technically self-deleting,
-but the window is `BLOCK_READY_TIMEOUT_MS = 10s` (`pageBlockHostLogic.ts:571`) — a **~128×
-margin** over the measured 40–78ms poll, against the **~2.6×** that actually lost.
-**Deliberately not changed**: no evidence of failure, and touching them is speculative churn.
+> **Original claim, preserved:** `PageBlockHost.browser.test.tsx:616,641,773` and
+> `PageBlockHostAutoRetry.browser.test.tsx:728` all do `click Retry` → assert a loading state.
+> Their state is also technically self-deleting, but the window is `BLOCK_READY_TIMEOUT_MS = 10s`
+> (`pageBlockHostLogic.ts:571`) — a **~128× margin** over the measured 40–78ms poll, against the
+> **~2.6×** that actually lost. **Deliberately not changed**: no evidence of failure, and touching
+> them is speculative churn.
+
+**That is the wrong window, and this paragraph is why the flake survived three more fixes.**
+
+After `driveToFatal()` the host is in a **terminal** state, not `loading`. The timer armed there
+is the auto-retry backoff — `AUTO_RETRY_BACKOFF_MS[0] = 2000ms` (`pageBlockHostLogic.ts:577`) —
+not `BLOCK_READY_TIMEOUT_MS`. The margin is therefore **~26×**, not ~128×, and it is measured
+against a **Playwright driver round-trip**, which this same RCA measured at 40–78ms *on an idle
+box* and elsewhere describes as erased under CI load.
+
+`PageBlockHostAutoRetry.browser.test.tsx:728` subsequently failed in CI on
+`pr-preview-3679-lt4xt` (PR #3679) with:
+
+```
+AssertionError: expected 'Retrying automatically… (attempt 2 of…' to contain 'attempt 1 of 2'
+```
+
+and was reproduced deterministically by inserting a 2.1s sleep before the click — the
+byte-identical message, at a comparable runtime (12632ms local vs 13230ms in CI). Fixed by
+moving it to the virtual clock + a DOM click.
+
+🔴 **The four `PageBlockHost.browser.test.tsx` sites cleared above are still live members** and
+are NOT fixed by that change. The cleanest of them is `error (mint failure): Retry calls
+onRetryToken AND returns to loading` — an AUTH terminal, so the automatic attempt *re-mints*,
+flipping `expect(onRetryToken).not.toHaveBeenCalled()` to 1 and
+`toHaveBeenCalledTimes(1)` to 2.
+
+**Lesson for this document's own method:** the margin argument was sound; the constant fed into
+it was not. When clearing a test by margin, name the state the component is actually IN at the
+assertion and the timer armed by THAT state — not the most prominent timeout in the file.
 
 ---
 


### PR DESCRIPTION
## What this is now

**Doc-only.** The code half of this PR — the fix to `PageBlockHostAutoRetry.browser.test.tsx` — has been **superseded by #3689**, which landed independently on `main` with the same diagnosis ("a driver click racing a 2s real backoff"). Two investigations reached the same root cause from different directions, which is decent corroboration of it. This PR has been rebased onto `main` and reduced to the one piece #3689 did **not** address.

## The problem this fixes

`claudedocs/rca-appblocks-component-suite-flake-2026-08-05.md` cleared four `PageBlockHost*` retry sites by margin, citing `BLOCK_READY_TIMEOUT_MS = 10s` for a ~128x cushion.

**That is the wrong constant.** After `driveToFatal()` the host is **terminal**, not loading, so the timer armed is the auto-retry backoff `AUTO_RETRY_BACKOFF_MS[0] = 2000ms` — a **~26x** margin, measured against a Playwright driver round-trip that this same document clocks at 40-78ms on an idle box and elsewhere describes as erased under CI load.

That paragraph is *why the flake survived three subsequent fix attempts*: each one read it and moved on. `PageBlockHostAutoRetry.browser.test.tsx:728` later failed in CI on PR #3679 and was reproduced deterministically by inserting a 2.1s sleep before the click — byte-identical message, comparable runtime.

**The misleading clearing is still live on `main` today.** Anyone investigating this tier is still talked out of the real cause. A wrong durable document is worse than a missing one.

## What the change does

- Retracts the section, **preserving the original text** rather than deleting it — it was already read and acted on, so a silent rewrite would hide why three fixes missed.
- 🔴 Flags that the **four `PageBlockHost.browser.test.tsx` sites it cleared remain live members** — #3689 fixed one test, not these. Names the cleanest example: an AUTH terminal where the automatic attempt *re-mints*, flipping `expect(onRetryToken).not.toHaveBeenCalled()` to 1.
- Records the method lesson in place: **when clearing a test by margin, name the state the component is actually IN at the assertion and the timer armed by THAT state** — not the most prominent timeout in the file.

## Verification

Documentation only; no code, no test, no config. The patch applies cleanly to current `main` (verified with `git apply --check` before committing). 1 file, 36 insertions, 6 deletions.
