### PR TITLE
docs(CLAUDE.md): never `await` a browser-test state that deletes itself

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,19 @@ Use a top-level `import type * as PromClient` — an inline `typeof import('...'
 Several repo conventions are enforced by tests, not by eslint — `pnpm run test:lint-rules` runs all of them:
 `no-wholesale-module-mock` (the `importOriginal` rule above), `no-io-in-transaction`, `no-module-scope-cache`, `no-unloadable-image-fixture`. They live in `src/server/services/__tests__/`. If one fails, fix the code — don't add an exemption without saying why.
 
+#### Never `await` a browser-test state that DELETES ITSELF
+`expect.element` polls — first attempt immediate, then every **50 ms** — against the test's remaining budget (browser-mode `testTimeout` defaults to **15 s**, and the `component` project does not override it). Awaiting a state to **arrive** is safe: load only makes it arrive later and the matcher keeps polling. Awaiting a state that will **leave** — a spinner on a ceiling, a debounce window, anything a component tears down on a timer — is a race the matcher cannot win: once the state is gone it never comes back, so every remaining poll is also too late. Such a test is green on a quiet box, red on a busy one, and has no PR to blame.
+
+Fix it structurally, in this order:
+1. **Make the state absorbing** — drive the component so nothing can take the state away (e.g. `rerender` with a window so large the timer can never fire), *then* assert it. Add a negative control proving the prop change alone did not produce the state.
+2. **Don't assert the transient at all** — await the absorbing end-state, and pin that the intermediate step happened via a non-DOM observable (a mock call count).
+
+🔴 Do **not** widen the matcher budget, add a `retry`, or enlarge the component's own timeout instead. Those convert a fast failure into a slow one and leave the race unwinnable whenever the machine is slow enough — which is exactly when CI runs.
+
+⚠️ **A ~15 s failing test is a candidate filter, NOT a diagnosis.** It means only that some `expect.element` was never satisfied: four *non-race* mutations all failed at 14.97–15.09 s, and two **healthy, passing** tests legitimately run 15.06 s / 15.26 s waiting out a real 15 s product timeout. To tell a self-deleting state from one that never arrived, read the observable **synchronously right after the action** (present-then-gone vs never-present), or **enlarge the component's own window** and see whether the failure disappears — diagnostic only, since shipping that widening is what this rule forbids.
+
+Worked examples of both fixes: the two retry tests in `src/components/Apps/AppsSubmitEditView.browser.test.tsx`. Measurements behind every number above: `claudedocs/rca-appblocks-component-suite-flake-2026-08-05.md` (PR #3645).
+
 ### Database
 ```bash
 pnpm run db:migrate:empty    # Create an empty migration file

--- a/claudedocs/rca-appblocks-component-suite-flake-2026-08-05.md
+++ b/claudedocs/rca-appblocks-component-suite-flake-2026-08-05.md
@@ -319,13 +319,20 @@ suite.** The whole `component` project is green at HEAD.
    component's own window and seeing whether the failure disappears.
 3. **Retain CI task logs (or ship the failure summary into the check) long enough to attribute
    a flake.** Two of three failures here were unattributable purely because logs aged out.
-4. **Consider documenting the absorbing-state rule in `CLAUDE.md`** under `### Testing`, which
-   already carries comparable harness lessons. A draft is in Appendix A — **not applied**; that
-   call belongs to the repo owners.
+4. ✅ **DONE — the absorbing-state rule is documented in `CLAUDE.md`** under `### Testing`,
+   alongside the other harness lessons. See Appendix A.
 
 ---
 
-## Appendix A — proposed `CLAUDE.md` addition (NOT applied)
+## Appendix A — the `CLAUDE.md` addition (✅ APPLIED)
+
+**Applied 2026-08-06** to the root `CLAUDE.md`, as the last `####` block of `### Testing`
+(after *Convention guards run as tests*). The applied text is a condensed form of the draft
+below — `CLAUDE.md` is loaded every session, so it carries the imperative, the two fixes, the
+anti-fix, and the ~15 s correction, and links back here for the evidence. The poll interval
+(50 ms) and the 15 s browser-mode `testTimeout` default were re-derived from the installed
+`vitest@4.0.18` before shipping. The draft is retained for the record: it is the source the
+applied wording was cut down from, not a pending proposal.
 
 ````markdown
 #### Never `await` a browser-test state that DELETES ITSELF


### PR DESCRIPTION
Applies the absorbing-state rule from the #3645 RCA to the root `CLAUDE.md`, under the existing `### Testing` section. The text was written deliberately in that RCA's Appendix A and held back pending approval; approval has been given.

## The rule

**Never `await` a browser-test state that DELETES ITSELF.** Awaiting a state to *arrive* is safe — load only makes it arrive later and `expect.element` keeps polling. Awaiting a state that will *leave* is a race the matcher cannot win: once the state is gone it never comes back, so every remaining poll is also too late. Green on a quiet box, red on a busy one, no PR to blame.

The block carries the two structural fixes (make the state absorbing, or don't assert the transient at all), the explicit ban on widening the matcher budget / adding a `retry` / enlarging the component's own timeout, and — the part that matters most — the audit correction that **a ~15 s failing test is a candidate filter, NOT a diagnosis**: four *non-race* mutations also failed at 14.97–15.09 s, and two *healthy, passing* tests legitimately run 15.06 s / 15.26 s. It pairs that with the signals that actually discriminate (synchronous read right after the action; enlarging the component's own window diagnostically).

Evidence stays in the RCA. `CLAUDE.md` is loaded every session, so the block keeps only the imperative and its widest scope and links out for the measurements.

## Constants re-derived, not copied

The rule cites two numbers, both checked against the installed `vitest@4.0.18` rather than taken from the RCA:

- **Poll interval 50 ms**, first attempt immediate — `createExpectPoll` in `vitest/dist/chunks/vi.2VT5v0um.js`: `const { interval = defaults.interval ?? 50, ... }`, with `fn()` called before any `delay(interval)`.
- **15 s budget** — `resolved.testTimeout ??= resolved.browser.enabled ? 15e3 : 5e3`, and the `component` project in `vitest.config.mts` does not override `testTimeout`. `expect.element` passes `processTimeoutOptions(...)`, which under the playwright provider (no `actionTimeout` set) rewrites the poll timeout to the test's *remaining* budget — so `expect.poll`'s own 1 s default does not apply here.

## Also

The RCA's Appendix A advertised the addition as "NOT applied; that call belongs to the repo owners". That decision has been made, so the appendix now records that it was applied, where, and that the draft is retained only as the source the shipped wording was cut down from.

## Scope

Docs only — two markdown files, no code. `CLAUDE.md` +2,268 bytes (25,851 → 28,119). Prettier covers only `**/*.{ts,tsx}`, so neither file is in its scope.
