### PR TITLE
fix(oauth): grant the civitai-cli client the AI-services scopes so `civitai generate` works (#3681)

### DIFF
--- a/apps/auth/src/lib/server/oauth/__tests__/scope.test.ts
+++ b/apps/auth/src/lib/server/oauth/__tests__/scope.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { TokenScope, ALL_SCOPES } from '@civitai/auth/token-scope';
+
+import { hasScope, scopeToString, stringToScope, scopeLabels } from '../scope';
+
+/**
+ * `apps/auth/src/lib/server/oauth/scope.ts` — the hub's only scope encode/decode +
+ * ceiling-test helpers, and the source of the CONSENT SCREEN's permission list.
+ *
+ * The label half is the user-visible half: `scopeLabels` is what the device-verify
+ * and authorize screens render before someone grants a client authority over their
+ * account. Widening the `civitai-cli` client to AI-services scopes (issue #3681)
+ * adds Buzz-SPENDING authority — `AIServicesWrite` implicitly authorises orchestrator
+ * buzz spend — so the strings a user actually sees for bits 14/15/16 are pinned here
+ * as literals rather than derived from `tokenScopeLabels` (deriving the expectation
+ * from the implementation would leave a silently-blank label green).
+ */
+
+/** The `civitai-cli` client's `allowedScopes` after the AI-services widening. */
+const CLI_ALLOWED_AFTER = 100777985;
+
+describe('scopeLabels', () => {
+  it('renders the AI-services and Buzz labels for bits 14/15/16', () => {
+    expect(scopeLabels(TokenScope.AIServicesRead)).toEqual(['View generation & training history']);
+    expect(scopeLabels(TokenScope.AIServicesWrite)).toEqual(['Generate, train & scan']);
+    expect(scopeLabels(TokenScope.BuzzRead)).toEqual(['View buzz balance & history']);
+  });
+
+  it('renders every label for the widened civitai-cli consent screen, in bit order', () => {
+    expect(scopeLabels(CLI_ALLOWED_AFTER)).toEqual([
+      'Read profile, settings & email',
+      'View generation & training history',
+      'Generate, train & scan',
+      'View buzz balance & history',
+      'Submit Apps for review',
+      'Open on-site dev tunnels',
+    ]);
+  });
+
+  it('does NOT render those labels for the pre-fix mask (negative control)', () => {
+    // Without this, a `scopeLabels` that returned every label unconditionally would
+    // satisfy the assertions above.
+    const before = 100663297; // UserRead|AppBlocksSubmit|AppBlocksDevTunnel
+    expect(scopeLabels(before)).toEqual([
+      'Read profile, settings & email',
+      'Submit Apps for review',
+      'Open on-site dev tunnels',
+    ]);
+  });
+
+  it('renders nothing for the empty mask', () => {
+    expect(scopeLabels(0)).toEqual([]);
+  });
+
+  it('never renders a blank string for a bit it claims to cover', () => {
+    // A missing `tokenScopeLabels` entry would show the user an empty bullet on the
+    // consent screen rather than failing loudly.
+    for (const label of scopeLabels(ALL_SCOPES)) {
+      expect(label.length).toBeGreaterThan(0);
+    }
+    // Positive control on the loop above — it must have iterated.
+    expect(scopeLabels(ALL_SCOPES).length).toBeGreaterThanOrEqual(27);
+  });
+});
+
+describe('hasScope', () => {
+  it('is a SUBSET test against the ceiling, not an intersection test', () => {
+    const ceiling = CLI_ALLOWED_AFTER | TokenScope.UserRead;
+    expect(hasScope(ceiling, TokenScope.AIServicesWrite)).toBe(true);
+    expect(hasScope(ceiling, TokenScope.AIServicesRead | TokenScope.BuzzRead)).toBe(true);
+    // Partially-overlapping request: one granted bit + one ungranted bit must be
+    // REJECTED as a whole. This is the all-or-nothing property the device flow
+    // depends on (and why a client's grant must be widened before the CLI asks).
+    expect(hasScope(ceiling, TokenScope.AIServicesRead | TokenScope.VaultRead)).toBe(false);
+    expect(hasScope(ceiling, TokenScope.Full)).toBe(false);
+  });
+});
+
+describe('stringToScope / scopeToString', () => {
+  it('round-trips a mask through the library string form', () => {
+    expect(scopeToString(CLI_ALLOWED_AFTER)).toEqual(['100777985']);
+    expect(stringToScope(scopeToString(CLI_ALLOWED_AFTER))).toBe(CLI_ALLOWED_AFTER);
+    expect(stringToScope('100777985')).toBe(CLI_ALLOWED_AFTER);
+  });
+
+  it('bounds against ALL_SCOPES, not Full — an opt-in bit survives decoding', () => {
+    // Clamping to `Full` (33554431) would silently drop bits 25/26 here.
+    expect(CLI_ALLOWED_AFTER).toBeGreaterThan(TokenScope.Full);
+    expect(stringToScope(String(ALL_SCOPES))).toBe(ALL_SCOPES);
+    expect(stringToScope(String(ALL_SCOPES + 1))).toBe(0); // out of range → deny
+    expect(stringToScope('-1')).toBe(0);
+    expect(stringToScope('not-a-number')).toBe(0);
+    expect(stringToScope(undefined)).toBe(0);
+  });
+});

--- a/apps/auth/src/routes/api/auth/oauth/device/__tests__/server.test.ts
+++ b/apps/auth/src/routes/api/auth/oauth/device/__tests__/server.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TokenScope, ALL_SCOPES } from '@civitai/auth/token-scope';
+
+/**
+ * Device-authorization (RFC 8628) SCOPE VALIDATION — `POST /api/auth/oauth/device`.
+ *
+ * This is the FIRST of the two places a device-flow token's ceiling is enforced
+ * (the second is the mint in `device-token/+server.ts`, covered by its own test).
+ * It is also the one that decides whether `civitai login` succeeds at all, so its
+ * exact semantics matter to every CLI release:
+ *
+ *   🔴 the check REJECTS, it does not CLAMP. `hasScope(allowedScopes, requested)`
+ *   is all-or-nothing — a request carrying ONE bit outside the client's ceiling
+ *   gets `invalid_scope` / 400 and the whole login fails. That is why widening a
+ *   client's `allowedScopes` (a manual-apply DB migration) must land BEFORE any
+ *   CLI release that requests the wider scope. Issue #3681.
+ *
+ * The `civitai-cli` cases below are written as a BEFORE/AFTER pair against the two
+ * real `allowedScopes` values so the deploy-ordering constraint is asserted rather
+ * than only described: the pre-fix ceiling REJECTS the AI-services request; the
+ * post-fix ceiling ACCEPTS it.
+ */
+
+const h = vi.hoisted(() => ({
+  hSet: vi.fn(),
+  hExpire: vi.fn(),
+  clientRow: undefined as unknown,
+}));
+
+// Kysely db — the handler selects the whole OauthClient row.
+vi.mock('$lib/server/db/db', () => ({
+  db: {
+    selectFrom() {
+      const qb: Record<string, unknown> = {};
+      qb.selectAll = () => qb;
+      qb.where = () => qb;
+      qb.executeTakeFirst = () => Promise.resolve(h.clientRow);
+      return qb;
+    },
+  },
+}));
+
+vi.mock('$lib/server/redis', () => ({
+  getRedis: () => ({ packed: { hSet: h.hSet }, hExpire: h.hExpire }),
+}));
+
+vi.mock('$lib/server/oauth/rate-limit', () => ({
+  checkOAuthRateLimit: vi.fn().mockResolvedValue(true),
+}));
+
+import { POST } from '../+server';
+
+/** The client's `allowedScopes` before this fix — bits 0/25/26. */
+const CLI_ALLOWED_BEFORE = 100663297;
+/** ...and after the AI-services widening — bits 0/14/15/16/25/26. */
+const CLI_ALLOWED_AFTER = 100777985;
+/** What `civitai generate` needs: AIServicesRead|AIServicesWrite|BuzzRead. */
+const AI_SERVICES_REQUEST =
+  TokenScope.AIServicesRead | TokenScope.AIServicesWrite | TokenScope.BuzzRead;
+
+function clientRow(allowedScopes: number, overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'civitai-cli',
+    grants: ['authorization_code', 'refresh_token', 'urn:ietf:params:oauth:grant-type:device_code'],
+    allowedScopes,
+    ...overrides,
+  };
+}
+
+function makeEvent(body: Record<string, string>) {
+  return {
+    request: new Request('https://auth.civitai.com/api/auth/oauth/device', {
+      method: 'POST',
+      body: new URLSearchParams(body),
+    }),
+    url: new URL('https://auth.civitai.com/api/auth/oauth/device'),
+  } as never;
+}
+
+/**
+ * The `scope` field the handler persisted onto the pending device code, as a number.
+ * The handler writes TWO hashes (the device-code record and the user-code → device-code
+ * index); only the first carries a record object, so it is selected by shape rather
+ * than by call order.
+ */
+function storedScope(): number {
+  const records = h.hSet.mock.calls
+    .map((c) => c[2])
+    .filter(
+      (v): v is { scope: string } =>
+        typeof v === 'object' && v !== null && typeof (v as { scope?: unknown }).scope === 'string'
+    );
+  expect(records).toHaveLength(1);
+  return parseInt(records[0].scope, 10);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.clientRow = undefined;
+  h.hSet.mockResolvedValue(1);
+  h.hExpire.mockResolvedValue(1);
+});
+
+describe('device authorization — requested-scope validation', () => {
+  it('accepts a request that is a strict SUBSET of allowedScopes', async () => {
+    h.clientRow = clientRow(CLI_ALLOWED_AFTER);
+    const res = await POST(
+      makeEvent({ client_id: 'civitai-cli', scope: String(TokenScope.AIServicesRead) })
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.device_code).toEqual(expect.any(String));
+    expect(body.user_code).toMatch(/^[A-Z2-9]{4}-[A-Z2-9]{4}$/);
+    // Subset preserved intact (plus the UserRead baseline), never clamped away.
+    expect(storedScope()).toBe(TokenScope.AIServicesRead | TokenScope.UserRead);
+  });
+
+  it('rejects a request carrying ANY bit outside allowedScopes, with invalid_scope', async () => {
+    h.clientRow = clientRow(CLI_ALLOWED_AFTER);
+    // One bit outside the ceiling (VaultRead is not granted), everything else inside.
+    const res = await POST(
+      makeEvent({
+        client_id: 'civitai-cli',
+        scope: String(AI_SERVICES_REQUEST | TokenScope.VaultRead),
+      })
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: 'invalid_scope',
+      error_description: 'Requested scope exceeds client permissions',
+    });
+    // Fail closed: nothing is persisted for a rejected request.
+    expect(h.hSet).not.toHaveBeenCalled();
+  });
+
+  it('REJECTS rather than CLAMPS — the whole request dies, the in-ceiling bits are not granted', async () => {
+    h.clientRow = clientRow(CLI_ALLOWED_AFTER);
+    const res = await POST(
+      makeEvent({
+        client_id: 'civitai-cli',
+        scope: String(AI_SERVICES_REQUEST | TokenScope.VaultRead),
+      })
+    );
+    expect(res.status).toBe(400);
+    // The distinguishing assertion: a CLAMPING implementation would have stored
+    // AI_SERVICES_REQUEST|UserRead here and returned 200.
+    expect(h.hSet).not.toHaveBeenCalled();
+  });
+
+  it('OR-s the UserRead baseline in even when the request omits it', async () => {
+    h.clientRow = clientRow(CLI_ALLOWED_AFTER);
+    const res = await POST(
+      makeEvent({ client_id: 'civitai-cli', scope: String(AI_SERVICES_REQUEST) })
+    );
+    expect(res.status).toBe(200);
+    expect(AI_SERVICES_REQUEST & TokenScope.UserRead).toBe(0); // control: it really was absent
+    expect(storedScope() & TokenScope.UserRead).toBe(TokenScope.UserRead);
+    expect(storedScope()).toBe(AI_SERVICES_REQUEST | TokenScope.UserRead);
+  });
+
+  it('allows the UserRead baseline even when the client does not list it', async () => {
+    // The ceiling the handler enforces is `allowedScopes | UserRead`, so a client
+    // whose grant omits bit 0 still gets it rather than a 400.
+    h.clientRow = clientRow(TokenScope.AIServicesRead); // no UserRead in allowedScopes
+    const res = await POST(
+      makeEvent({ client_id: 'civitai-cli', scope: String(TokenScope.AIServicesRead) })
+    );
+    expect(res.status).toBe(200);
+    expect(storedScope()).toBe(TokenScope.AIServicesRead | TokenScope.UserRead);
+  });
+
+  it('rejects a scope value above ALL_SCOPES', async () => {
+    h.clientRow = clientRow(CLI_ALLOWED_AFTER);
+    const res = await POST(makeEvent({ client_id: 'civitai-cli', scope: String(ALL_SCOPES + 1) }));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_scope' }); // the bound check, no description
+    expect(h.hSet).not.toHaveBeenCalled();
+  });
+
+  describe('issue #3681 — the civitai-cli AI-services grant, before and after', () => {
+    it('the PRE-fix ceiling rejects the generate scopes (this is the reported bug)', async () => {
+      h.clientRow = clientRow(CLI_ALLOWED_BEFORE);
+      // Control: the request really does exceed the pre-fix ceiling.
+      expect(AI_SERVICES_REQUEST & ~CLI_ALLOWED_BEFORE).not.toBe(0);
+
+      const res = await POST(
+        makeEvent({ client_id: 'civitai-cli', scope: String(AI_SERVICES_REQUEST) })
+      );
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toBe('invalid_scope');
+      expect(h.hSet).not.toHaveBeenCalled();
+    });
+
+    it('the POST-fix ceiling accepts them, with every requested bit preserved', async () => {
+      h.clientRow = clientRow(CLI_ALLOWED_AFTER);
+      const res = await POST(
+        makeEvent({ client_id: 'civitai-cli', scope: String(AI_SERVICES_REQUEST) })
+      );
+      expect(res.status).toBe(200);
+      const stored = storedScope();
+      expect(stored & TokenScope.AIServicesRead).toBe(TokenScope.AIServicesRead);
+      expect(stored & TokenScope.AIServicesWrite).toBe(TokenScope.AIServicesWrite);
+      expect(stored & TokenScope.BuzzRead).toBe(TokenScope.BuzzRead);
+    });
+
+    it('the app-block scopes still round-trip on the widened ceiling (no regression)', async () => {
+      h.clientRow = clientRow(CLI_ALLOWED_AFTER);
+      const appBlockRequest = TokenScope.AppBlocksSubmit | TokenScope.AppBlocksDevTunnel;
+      const res = await POST(
+        makeEvent({ client_id: 'civitai-cli', scope: String(appBlockRequest) })
+      );
+      expect(res.status).toBe(200);
+      expect(storedScope()).toBe(appBlockRequest | TokenScope.UserRead);
+    });
+
+    it('the widened ceiling is still NOT a superset of Full', () => {
+      // The invariant `blocks.router.getMyAppAnalytics` depends on; asserted here too
+      // because this file is where the number is most likely to be edited next.
+      expect(CLI_ALLOWED_AFTER | TokenScope.Full).not.toBe(CLI_ALLOWED_AFTER);
+      expect(CLI_ALLOWED_AFTER).toBe(
+        TokenScope.UserRead |
+          TokenScope.AIServicesRead |
+          TokenScope.AIServicesWrite |
+          TokenScope.BuzzRead |
+          TokenScope.AppBlocksSubmit |
+          TokenScope.AppBlocksDevTunnel
+      );
+    });
+  });
+});

--- a/packages/civitai-db-schema/prisma/migrations/20260806140000_widen_civitai_cli_oauth_client_ai_services_scopes/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260806140000_widen_civitai_cli_oauth_client_ai_services_scopes/migration.sql
@@ -1,0 +1,59 @@
+-- Widen the first-party `civitai-cli` OAuth client's allowedScopes to permit the
+-- AI-services scopes, so the OAuth `civitai login` token can actually run
+-- `civitai generate` (issue #3681). Prior to this the CLI token could carry only
+-- `UserRead | AppBlocksSubmit | AppBlocksDevTunnel`, so every generation
+-- procedure rejected it and users had to fall back to a Full-scope personal API
+-- key. An OAuth access token's ceiling is its client's
+-- `allowedScopes | UserRead` (enforced at device-authorization time AND again at
+-- mint), so a bit the client does not allow cannot even be REQUESTED.
+--
+-- Which bits, and why each one:
+--   - AIServicesRead  (bit 14): orchestrator.whatIfFromGraph (cost estimate),
+--     getWorkflow, queryGeneratedImages — the poll/download half of `generate`.
+--   - AIServicesWrite (bit 15): orchestrator.generateFromGraph (submit) and
+--     cancelWorkflow. Implicitly authorises Buzz spend for orchestrator usage.
+--   - BuzzRead        (bit 16): buzz.getBuzzAccount, read by the CLI's pre-flight
+--     insufficient-balance guard. That guard FAILS SOFT (warns and continues), so
+--     omitting the bit would degrade UX rather than break generation — it is
+--     included so the pre-flight check works rather than silently warning on
+--     every run.
+--
+-- allowedScopes: 100663297 -> 100777985
+--   old = TokenScope.UserRead | TokenScope.AppBlocksSubmit | TokenScope.AppBlocksDevTunnel
+--       = 1 | 33554432 | 67108864
+--       = 100663297
+--   add = TokenScope.AIServicesRead | TokenScope.AIServicesWrite | TokenScope.BuzzRead
+--       = (1<<14) | (1<<15) | (1<<16)
+--       = 16384 | 32768 | 65536
+--       = 114688
+--   new = 100663297 | 114688
+--       = 100777985
+--
+-- 🔴 STILL NOT A SUPERSET OF `Full` (33554431 = bits 0..24). 100777985 carries
+-- bits 0, 14, 15, 16, 25, 26 and NONE of 1..13 or 17..24, so it does not contain
+-- `Full`. That matters because `enforceTokenScope` bypasses the scope gate on
+-- EXACT EQUALITY with `Full` (`ctx.tokenScope === TokenScope.Full`), and a mask
+-- that is a strict superset of `Full` while missing an opt-in bit would flip
+-- `blocks.router.getMyAppAnalytics` from allow to deny. Any FUTURE migration that
+-- grants a client `Full | <opt-in bit>` must revisit that gate — see the invariant
+-- guard in `src/server/routers/__tests__/blocks.router.getMyAppAnalytics.test.ts`.
+--
+-- IDEMPOTENT: the OR-in of the bits is a no-op on re-apply (re-ORing the same bits
+-- leaves the value unchanged); scoped to the single `civitai-cli` row so it can
+-- never touch another client's grant. The WHERE clause also makes a re-apply touch
+-- ZERO rows (so `updatedAt` is not churned).
+--
+-- 🔴 DEPLOY ORDERING: apply this migration BEFORE releasing a civitai CLI that
+-- REQUESTS these bits. The device-authorization scope check is ALL-OR-NOTHING — it
+-- REJECTS a request carrying any bit outside the client ceiling rather than
+-- clamping it — so a CLI that asks for the wider scope before this lands gets
+-- `invalid_scope` and `civitai login` 400s outright.
+--
+-- ⚠️ MANUAL-APPLY: per the cluster ops rule, civitai DB migrations are NOT
+-- auto-applied. A human applies this per environment; this PR does not apply it
+-- anywhere.
+UPDATE "OauthClient"
+SET "allowedScopes" = "allowedScopes" | 114688, -- AIServicesRead|AIServicesWrite|BuzzRead
+    "updatedAt" = CURRENT_TIMESTAMP
+WHERE "id" = 'civitai-cli'
+  AND ("allowedScopes" & 114688) <> 114688; -- no-op once all three bits are set

--- a/packages/civitai-db-schema/prisma/migrations/20260806140000_widen_civitai_cli_oauth_client_ai_services_scopes/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260806140000_widen_civitai_cli_oauth_client_ai_services_scopes/migration.sql
@@ -37,6 +37,12 @@
 -- `blocks.router.getMyAppAnalytics` from allow to deny. Any FUTURE migration that
 -- grants a client `Full | <opt-in bit>` must revisit that gate — see the invariant
 -- guard in `src/server/routers/__tests__/blocks.router.getMyAppAnalytics.test.ts`.
+-- That case is now caught mechanically: `src/server/services/oauth/__tests__/
+-- oauth-client-scope-grants.test.ts` enumerates every migration whose LIVE SQL writes
+-- this column, pins each statement verbatim, and folds the grants per client SEEDED
+-- FROM THE COLUMN DEFAULT (Full) — so ORing an opt-in bit onto a default-created row
+-- goes red there. Editing the statement below without restating that file's declared
+-- table fails the build.
 --
 -- IDEMPOTENT: the OR-in of the bits is a no-op on re-apply (re-ORing the same bits
 -- leaves the value unchanged); scoped to the single `civitai-cli` row so it can
@@ -52,6 +58,28 @@
 -- ⚠️ MANUAL-APPLY: per the cluster ops rule, civitai DB migrations are NOT
 -- auto-applied. A human applies this per environment; this PR does not apply it
 -- anywhere.
+--
+-- 🔴 CHECK THE ROWCOUNT — psql reports success on zero rows. `UPDATE 1` is the
+-- expected result on a first apply. `UPDATE 0` means EITHER the bits were already
+-- set (a genuine re-apply no-op) OR the `civitai-cli` row does not exist in this
+-- environment at all: the 2026-06-19 registration migration is guarded by
+-- `WHERE EXISTS (SELECT 1 FROM "User" WHERE "id" = -1)`, so in any environment
+-- lacking the civitai system account it inserted nothing and this UPDATE has no
+-- row to widen. Those two cases are indistinguishable from the rowcount, so confirm
+-- explicitly:
+--   SELECT "id", "allowedScopes" FROM "OauthClient" WHERE "id" = 'civitai-cli';
+--   -- expect exactly one row, "allowedScopes" = 100777985
+-- No row returned ⇒ register the client first (2026-06-19 migration, with a valid
+-- owner userId) and re-run this one.
+--
+-- ROLLBACK (clears exactly the three bits this migration adds, leaving every other
+-- bit — including AppBlocksSubmit/AppBlocksDevTunnel — untouched):
+--   UPDATE "OauthClient" SET "allowedScopes" = "allowedScopes" & ~114688 WHERE "id" = 'civitai-cli';
+-- Reverting is a NARROWING, so any already-issued CLI access token carrying bits
+-- 14/15/16 keeps them until it expires — the client ceiling is checked at
+-- device-authorization and mint time, not on every request. Revoke outstanding
+-- civitai-cli tokens too if the revert is security-motivated rather than a rollback
+-- of a botched deploy.
 UPDATE "OauthClient"
 SET "allowedScopes" = "allowedScopes" | 114688, -- AIServicesRead|AIServicesWrite|BuzzRead
     "updatedAt" = CURRENT_TIMESTAMP

--- a/src/server/routers/__tests__/blocks.router.getMyAppAnalytics.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getMyAppAnalytics.test.ts
@@ -454,15 +454,18 @@ describe('getMyAppAnalytics — OAuth scope gate', () => {
    *     Full (deliberately, so an opt-in bit is not dropped), so a token's real ceiling is
    *     its client's `allowedScopes | UserRead`.
    *   - `allowedScopes` written by RAW SQL MIGRATION — exactly how the one client
-   *     exceeding Full got its value (civitai-cli, 100663297, which is NOT a superset of
-   *     Full: bit 0 and none of 1..24, which is why the flip is unreachable in practice).
+   *     exceeding Full got its value (civitai-cli, now 100777985 after the AI-services
+   *     widening for issue #3681, which is still NOT a superset of Full: bits 0/14/15/16/
+   *     25/26 and none of 1..13 or 17..24, which is why the flip is unreachable in practice).
    *   - `allowedScopes` written by publish-request.service for `appblk-*` clients. Safe
    *     by construction (mapped bits are all below 25, and `grants: []` means no bearer
    *     token) rather than by any cap this test can assert on.
    *
-   * So: if either cap below is raised, this test goes red. If a MIGRATION grants some
-   * client `Full | <opt-in bit>`, nothing here will notice — that case is held only by
-   * inspection.
+   * So: if either cap below is raised, this test goes red. The MIGRATION case is no longer
+   * held by inspection — `src/server/services/oauth/__tests__/oauth-client-scope-grants.test.ts`
+   * enumerates every migration writing `"OauthClient"."allowedScopes"` and fails if the
+   * folded grant for any client is a strict superset of Full. Neither test covers a grant
+   * written outside a migration (a hand-run UPDATE), which remains inspection-only.
    */
   it('the two zod-validated credential surfaces reject a superset-of-Full mask', async () => {
     const { addApiKeyInputSchema } = await import('~/server/schema/api-key.schema');

--- a/src/server/routers/__tests__/cli-generate-scope-surface.test.ts
+++ b/src/server/routers/__tests__/cli-generate-scope-surface.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import ts from 'typescript';
+
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+/**
+ * 🔴 SUFFICIENCY GUARD for the `civitai generate` OAuth scope grant (issue #3681).
+ *
+ * The fix for #3681 widens the `civitai-cli` OAuth client's `allowedScopes` to
+ * `UserRead | AIServicesRead | AIServicesWrite | BuzzRead | AppBlocksSubmit |
+ * AppBlocksDevTunnel` = 100777985 (see
+ * `packages/civitai-db-schema/prisma/migrations/20260806140000_widen_civitai_cli_oauth_client_ai_services_scopes/migration.sql`).
+ * That is a claim about a SET of procedures: every tRPC call the `generate`
+ * command makes must be satisfiable by that mask. This test IS that claim.
+ *
+ * WHY A SOURCE-LEVEL GUARD. The regression it defends against is not "someone
+ * changes the scope constant" — it is a procedure on the generate path acquiring
+ * a REQUIREMENT the CLI token cannot meet, most cheaply by LOSING its
+ * `.meta({ requiredScope })` line. `enforceTokenScope` treats an un-annotated
+ * procedure as implicitly requiring `TokenScope.Full`
+ * (`src/server/services/oauth/enforce-token-scope.ts`), so deleting a `.meta`
+ * line — the sort of thing that happens in a refactor with no visible symptom —
+ * silently 403s every scoped token, and no behavioural test of that procedure
+ * (which is normally exercised with a session or a Full key) would notice.
+ * Reading the requirement off the SOURCE is the only way to see the ABSENCE of
+ * an annotation; a runtime assertion on a mocked caller cannot distinguish
+ * "annotated with Full" from "not annotated".
+ *
+ * MECHANISM: the TypeScript AST, not a regex — the `.meta(...)` call is located
+ * on the LEFT SPINE of each procedure's builder chain (so a `.meta` appearing
+ * inside a resolver body or an argument cannot be mistaken for the procedure's
+ * own), and `requiredScope` is resolved by enum key against `TokenScope`.
+ *
+ * 🔴 SCOPE OF THIS TEST — what it does NOT prove. It pins the scope REQUIREMENTS
+ * of a named set of procedures. It does not prove that set is what the CLI
+ * actually calls (that lives in the `civitai/cli` repo and cannot be read from
+ * here), nor that the client row in any database really holds 100777985 (the
+ * migration is manual-apply). If the CLI grows a seventh call, adding it here is
+ * a manual step.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+
+/**
+ * The tRPC procedures the `civitai generate` command exercises, by router file
+ * and the exported router const inside it.
+ *
+ * - `whatIfFromGraph`      — pre-submit cost estimate
+ * - `generateFromGraph`    — the submit itself
+ * - `getWorkflow`          — poll a submitted workflow
+ * - `queryGeneratedImages` — collect the results
+ * - `cancelWorkflow`       — Ctrl-C / `--cancel`
+ * - `buzz.getBuzzAccount`  — the pre-flight insufficient-balance guard. This one
+ *   FAILS SOFT in the CLI (it warns and continues), so its bit is a UX
+ *   requirement rather than a functional one — but it is in the grant, so it is
+ *   in this population.
+ */
+const GENERATE_SURFACE: { file: string; routerConst: string; procedures: string[] }[] = [
+  {
+    file: 'src/server/routers/orchestrator.router.ts',
+    routerConst: 'orchestratorRouter',
+    procedures: [
+      'whatIfFromGraph',
+      'generateFromGraph',
+      'getWorkflow',
+      'queryGeneratedImages',
+      'cancelWorkflow',
+    ],
+  },
+  {
+    file: 'src/server/routers/buzz.router.ts',
+    routerConst: 'buzzRouter',
+    procedures: ['getBuzzAccount'],
+  },
+];
+
+const TOTAL_PROCEDURES = GENERATE_SURFACE.reduce((n, g) => n + g.procedures.length, 0);
+
+/**
+ * The mask the widened `civitai-cli` client grants. Pinned as a literal against
+ * the migration (which is the source of truth for the DB value) and cross-checked
+ * against the enum below.
+ */
+const CLI_GRANT = 100777985;
+
+interface ProcedureScope {
+  key: string;
+  /** Resolved `requiredScope`, or `null` when the procedure carries no `.meta({ requiredScope })`. */
+  requiredScope: number | null;
+  /** Enum key as written in source, e.g. `AIServicesWrite`. `null` when absent. */
+  scopeKey: string | null;
+  blockApiKeys: boolean;
+}
+
+function parse(file: string): ts.SourceFile {
+  const full = path.join(REPO_ROOT, file);
+  return ts.createSourceFile(
+    file,
+    fs.readFileSync(full, 'utf8'),
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TS
+  );
+}
+
+/** The object literal passed to `router({ ... })` for `export const <name> = router({...})`. */
+function routerObject(sf: ts.SourceFile, routerConst: string): ts.ObjectLiteralExpression {
+  let found: ts.ObjectLiteralExpression | undefined;
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === routerConst &&
+      node.initializer &&
+      ts.isCallExpression(node.initializer) &&
+      ts.isIdentifier(node.initializer.expression) &&
+      node.initializer.expression.text === 'router' &&
+      node.initializer.arguments[0] &&
+      ts.isObjectLiteralExpression(node.initializer.arguments[0])
+    ) {
+      found = node.initializer.arguments[0] as ts.ObjectLiteralExpression;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  if (!found) throw new Error(`could not locate \`const ${routerConst} = router({...})\``);
+  return found;
+}
+
+/**
+ * Every `.meta(...)` object literal on the LEFT SPINE of a builder chain.
+ * `a.meta(X).input(Y).query(Z)` → walks query → input → meta, never descending
+ * into `X`/`Y`/`Z`, so a `.meta` inside a resolver body is out of reach.
+ */
+function metaObjectsOnSpine(expr: ts.Expression): ts.ObjectLiteralExpression[] {
+  const out: ts.ObjectLiteralExpression[] = [];
+  let cur: ts.Node = expr;
+  while (ts.isCallExpression(cur)) {
+    const callee = cur.expression;
+    if (!ts.isPropertyAccessExpression(callee)) break;
+    if (callee.name.text === 'meta') {
+      const arg = cur.arguments[0];
+      if (arg && ts.isObjectLiteralExpression(arg)) out.push(arg);
+    }
+    cur = callee.expression;
+  }
+  return out;
+}
+
+/** `requiredScope: TokenScope.Foo` → `'Foo'`; anything else → undefined. */
+function readScopeKey(meta: ts.ObjectLiteralExpression): string | undefined {
+  for (const prop of meta.properties) {
+    if (!ts.isPropertyAssignment(prop)) continue;
+    const name = ts.isIdentifier(prop.name) ? prop.name.text : undefined;
+    if (name !== 'requiredScope') continue;
+    const init = prop.initializer;
+    if (
+      ts.isPropertyAccessExpression(init) &&
+      ts.isIdentifier(init.expression) &&
+      init.expression.text === 'TokenScope'
+    ) {
+      return init.name.text;
+    }
+    throw new Error(
+      `requiredScope is not a plain \`TokenScope.<Key>\` reference — this guard cannot resolve it`
+    );
+  }
+  return undefined;
+}
+
+function readBlockApiKeys(meta: ts.ObjectLiteralExpression): boolean {
+  for (const prop of meta.properties) {
+    if (!ts.isPropertyAssignment(prop)) continue;
+    const name = ts.isIdentifier(prop.name) ? prop.name.text : undefined;
+    if (name === 'blockApiKeys' && prop.initializer.kind === ts.SyntaxKind.TrueKeyword) return true;
+  }
+  return false;
+}
+
+function collect(): ProcedureScope[] {
+  const out: ProcedureScope[] = [];
+  for (const group of GENERATE_SURFACE) {
+    const obj = routerObject(parse(group.file), group.routerConst);
+    for (const name of group.procedures) {
+      const prop = obj.properties.find(
+        (p) => ts.isPropertyAssignment(p) && ts.isIdentifier(p.name) && p.name.text === name
+      );
+      if (!prop || !ts.isPropertyAssignment(prop)) {
+        throw new Error(
+          `procedure \`${name}\` not found as a direct property of \`${group.routerConst}\` in ${group.file} — ` +
+            `it was renamed, moved, or deleted. Update GENERATE_SURFACE deliberately.`
+        );
+      }
+      const metas = metaObjectsOnSpine(prop.initializer);
+      const scopeKey = metas.map(readScopeKey).find((k) => k !== undefined) ?? null;
+      const scopes = TokenScope as unknown as Record<string, number>;
+      if (scopeKey !== null && typeof scopes[scopeKey] !== 'number') {
+        throw new Error(`\`TokenScope.${scopeKey}\` (on ${name}) is not a member of the enum`);
+      }
+      out.push({
+        key: `${group.routerConst}.${name}`,
+        requiredScope: scopeKey === null ? null : scopes[scopeKey],
+        scopeKey,
+        blockApiKeys: metas.some(readBlockApiKeys),
+      });
+    }
+  }
+  return out;
+}
+
+describe('civitai generate — OAuth scope surface', () => {
+  it('the AST walk finds every procedure on the generate path', () => {
+    const found = collect();
+    // Positive control: a zero/short result here would make every assertion below
+    // pass vacuously (a union over an empty set is 0, which is trivially covered).
+    expect(found).toHaveLength(TOTAL_PROCEDURES);
+    expect(found.map((p) => p.key).sort()).toEqual(
+      [
+        'buzzRouter.getBuzzAccount',
+        'orchestratorRouter.cancelWorkflow',
+        'orchestratorRouter.generateFromGraph',
+        'orchestratorRouter.getWorkflow',
+        'orchestratorRouter.queryGeneratedImages',
+        'orchestratorRouter.whatIfFromGraph',
+      ].sort()
+    );
+  });
+
+  it('every procedure on the generate path declares an explicit requiredScope', () => {
+    for (const p of collect()) {
+      expect(
+        p.requiredScope,
+        `${p.key} has no \`.meta({ requiredScope })\`. enforceTokenScope then treats it as ` +
+          `implicitly requiring TokenScope.Full, which the scoped \`civitai login\` token can ` +
+          `never satisfy — every \`civitai generate\` run 403s on this call.`
+      ).not.toBeNull();
+    }
+  });
+
+  it('no procedure on the generate path is blockApiKeys', () => {
+    for (const p of collect()) {
+      expect(
+        p.blockApiKeys,
+        `${p.key} is marked blockApiKeys, which forbids ANY token — scope cannot fix it.`
+      ).toBe(false);
+    }
+  });
+
+  it('the union of required scopes is exactly AIServicesRead|AIServicesWrite|BuzzRead', () => {
+    const found = collect();
+    const union = found.reduce((acc, p) => acc | (p.requiredScope ?? TokenScope.Full), 0);
+    expect(union).toBe(
+      TokenScope.AIServicesRead | TokenScope.AIServicesWrite | TokenScope.BuzzRead
+    );
+    expect(union).toBe(114688);
+  });
+
+  it('the widened civitai-cli grant COVERS that union', () => {
+    const found = collect();
+    const union = found.reduce((acc, p) => acc | (p.requiredScope ?? TokenScope.Full), 0);
+    const uncovered = union & ~CLI_GRANT;
+    expect(
+      uncovered,
+      `the generate path requires scope bits ${uncovered} that the civitai-cli client ` +
+        `(allowedScopes=${CLI_GRANT}) does not grant — \`civitai generate\` would 403.`
+    ).toBe(0);
+
+    // The grant literal must agree with the enum, or the check above is about the
+    // wrong number.
+    expect(
+      TokenScope.UserRead |
+        TokenScope.AIServicesRead |
+        TokenScope.AIServicesWrite |
+        TokenScope.BuzzRead |
+        TokenScope.AppBlocksSubmit |
+        TokenScope.AppBlocksDevTunnel
+    ).toBe(CLI_GRANT);
+
+    // Negative control for the coverage assertion: the PRE-fix grant (without bits
+    // 14/15/16) must NOT cover the union. Without this, `uncovered === 0` would be
+    // consistent with a union of 0 or a grant of ~0.
+    const PRE_FIX_GRANT = 100663297;
+    expect(union & ~PRE_FIX_GRANT).not.toBe(0);
+  });
+
+  it('pins each procedure’s individual requiredScope', () => {
+    const byKey = Object.fromEntries(collect().map((p) => [p.key, p.scopeKey]));
+    expect(byKey).toEqual({
+      'orchestratorRouter.whatIfFromGraph': 'AIServicesRead',
+      'orchestratorRouter.generateFromGraph': 'AIServicesWrite',
+      'orchestratorRouter.getWorkflow': 'AIServicesRead',
+      'orchestratorRouter.queryGeneratedImages': 'AIServicesRead',
+      'orchestratorRouter.cancelWorkflow': 'AIServicesWrite',
+      'buzzRouter.getBuzzAccount': 'BuzzRead',
+    });
+  });
+});

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -5388,16 +5388,26 @@ export const blocksRouter = router({
     //     requested scope against `ALL_SCOPES` on purpose (clamping to Full would drop
     //     a legitimately-requested opt-in bit), so a token's ceiling is its client's
     //     `allowedScopes | UserRead`, not Full.
-    //   - The one client exceeding Full (civitai-cli, 100663297) was written by a RAW SQL
-    //     migration, which no zod schema governs.
+    //   - The one client exceeding Full (civitai-cli, now 100777985) was written by RAW SQL
+    //     MIGRATIONS, which no zod schema governs.
     //   - `appblk-*` clients get `allowedScopes` written directly by
     //     publish-request.service (also bypassing zod). Safe by construction, not by cap:
     //     `deriveOauthBitmaskFromBlockScopes` maps only bits below 25, and those clients
     //     carry `grants: []` so they cannot mint an account bearer token at all.
-    // 100663297 is not a superset of Full (it carries bit 0 and none of 1..24), so the
-    // flip is unreachable — but that last part rests on INSPECTION of that migration,
-    // not on a cap. If a future migration grants a client `Full | <some opt-in bit>`,
-    // this gate flips for it and no test will catch it.
+    // 100777985 is not a superset of Full: it carries bits 0, 14, 15, 16, 25 and 26 —
+    // UserRead, AIServicesRead, AIServicesWrite, BuzzRead, AppBlocksSubmit,
+    // AppBlocksDevTunnel — and NONE of 1..13 or 17..24, so it does not contain Full
+    // (33554431) and the flip stays unreachable for it. (Bits 14/15/16 were added by
+    // `20260806140000_widen_civitai_cli_oauth_client_ai_services_scopes` so the
+    // `civitai login` token can run `civitai generate` — issue #3681.)
+    // 🔴 That last part NO LONGER rests on inspection alone. The migration surface is
+    // now pinned by `src/server/services/oauth/__tests__/oauth-client-scope-grants.test.ts`,
+    // which enumerates every migration writing `"OauthClient"."allowedScopes"` off the
+    // tree, folds the grants per client, and fails if any client would hold a STRICT
+    // superset of Full — so a future migration granting `Full | <some opt-in bit>` goes
+    // red there instead of silently flipping this gate. What that guard still cannot see
+    // is a grant written OUTSIDE a migration (a hand-run UPDATE against a database), and
+    // it cannot prove what any environment's row actually holds.
     //
     // Scope provisioning: the civitai-cli client's allowedScopes migration sets bit 25
     // and the login token requests it, so no NEW migration is needed here. Note the

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -5402,12 +5402,18 @@ export const blocksRouter = router({
     // `civitai login` token can run `civitai generate` — issue #3681.)
     // 🔴 That last part NO LONGER rests on inspection alone. The migration surface is
     // now pinned by `src/server/services/oauth/__tests__/oauth-client-scope-grants.test.ts`,
-    // which enumerates every migration writing `"OauthClient"."allowedScopes"` off the
-    // tree, folds the grants per client, and fails if any client would hold a STRICT
-    // superset of Full — so a future migration granting `Full | <some opt-in bit>` goes
-    // red there instead of silently flipping this gate. What that guard still cannot see
-    // is a grant written OUTSIDE a migration (a hand-run UPDATE against a database), and
-    // it cannot prove what any environment's row actually holds.
+    // which enumerates every migration whose LIVE SQL writes `"OauthClient"."allowedScopes"`
+    // off the tree, reconciles the set against a declared table, pins each grant's whole
+    // statement verbatim, folds the grants per client — SEEDED FROM THE COLUMN DEFAULT
+    // (Full), not from 0 — and fails if any client would hold a STRICT superset of Full.
+    // The seed is what makes the claim real: the likely way this gate flips is a migration
+    // that ORs one opt-in bit onto a row created with the column default, landing on
+    // `Full | <bit>`; folding from 0 read that same migration as granting just `<bit>` and
+    // passed clean. Verified by planting exactly that migration and watching the guard go
+    // red on `allowedScopes=100663295`.
+    // What that guard still cannot see is a grant written OUTSIDE a migration (a hand-run
+    // UPDATE against a database), and it cannot prove what any environment's row actually
+    // holds — these migrations are manual-apply.
     //
     // Scope provisioning: the civitai-cli client's allowedScopes migration sets bit 25
     // and the login token requests it, so no NEW migration is needed here. Note the

--- a/src/server/services/oauth/__tests__/oauth-client-scope-grants.test.ts
+++ b/src/server/services/oauth/__tests__/oauth-client-scope-grants.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+/**
+ * 🔴 POPULATION GUARD for OAuth-client `allowedScopes` values written by RAW SQL
+ * MIGRATION — the one credential surface that NO zod schema governs.
+ *
+ * WHY THIS EXISTS. `enforceTokenScope` bypasses the scope gate on EXACT EQUALITY
+ * with `Full` (`ctx.tokenScope !== TokenScope.Full` → then `hasFlag`, see
+ * `src/server/services/oauth/enforce-token-scope.ts`). So for a procedure with an
+ * explicit `.meta({ requiredScope })`, a mask that is a STRICT SUPERSET of `Full`
+ * behaves differently from `Full` itself: it does not take the early return, and
+ * it must carry the annotated bit or it is denied. `blocks.router.getMyAppAnalytics`
+ * documents exactly that flip (`Full|AppBlocksDevTunnel` = 100663295 used to pass
+ * the un-annotated gate and is FORBIDDEN now), and until this file existed the
+ * claim "no issuable credential holds a strict superset of Full" rested on
+ * INSPECTION of the migrations, not on any cap:
+ *
+ *   - personal API keys       → capped at `.max(Full)` by `api-key.schema.ts`
+ *   - OAuth clients via tRPC  → capped at `.max(Full)` by `oauth-client.schema.ts`
+ *   - OAuth ACCESS tokens     → ceiling is the client's `allowedScopes | UserRead`
+ *   - `appblk-*` clients      → written by publish-request.service; safe by
+ *                               construction (mapped bits are all below 25, and
+ *                               `grants: []` means no bearer token can be minted)
+ *   - RAW SQL MIGRATION       → ← THIS FILE. Nothing else checks it.
+ *
+ * Both of the first two caps are pinned by
+ * `src/server/routers/__tests__/blocks.router.getMyAppAnalytics.test.ts`. This
+ * file closes the migration hole that test's own comment names as uncovered.
+ *
+ * MECHANISM — enumerated from the TREE, reconciled against a declared table. The
+ * migration set is read off disk (every `migration.sql` mentioning `"OauthClient"`
+ * and `allowedScopes`), so a NEW migration granting `allowedScopes` fails this
+ * test until someone adds a row to `DECLARED_GRANTS` — which is the reviewable
+ * act. Each declared grant must then match its SQL in the SHAPE its op claims
+ * (`grantPattern` below: `or` and `default` are positional against the assignment
+ * itself), so the table cannot drift away from what the SQL does. The values are
+ * folded per client id in migration (timestamp) order and the resulting mask is
+ * checked.
+ *
+ * WHAT THIS DOES *NOT* DO: it does not parse SQL, it regex-matches statement
+ * shapes. `set` (an `INSERT ... SELECT`, where the value is positional and has no
+ * `allowedScopes` token near it) degrades to "the literal is somewhere in the
+ * statement", so a mis-declared `set` row could pass. It also cannot see a grant
+ * written OUTSIDE a migration (a hand-run `UPDATE`), and it says nothing about what
+ * any environment's row actually holds — these migrations are manual-apply. It is a
+ * ratchet on the POPULATION plus a pin on the VALUES, not a SQL interpreter.
+ */
+
+const MIGRATIONS_DIR = path.resolve(
+  __dirname,
+  '../../../../../packages/civitai-db-schema/prisma/migrations'
+);
+
+/** How a migration writes `allowedScopes`. */
+type GrantOp =
+  /** a `DEFAULT n` on the column itself — applies to every client that omits it */
+  | 'default'
+  /** an INSERT that sets the initial value for one client */
+  | 'set'
+  /** an `UPDATE ... SET "allowedScopes" = "allowedScopes" | n` widening for one client */
+  | 'or';
+
+interface DeclaredGrant {
+  /** The client id the migration targets, or `null` for the column default. */
+  clientId: string | null;
+  op: GrantOp;
+  /** The integer literal the SQL uses. Must appear verbatim in the file. */
+  value: number;
+  /** Why this value is what it is — kept short; the migration header has the detail. */
+  note: string;
+}
+
+/**
+ * Every migration that writes an OAuth-client scope grant, keyed by migration
+ * directory name.
+ *
+ * 🔴 Adding a row means asserting that the resulting mask is safe for the
+ * `enforceTokenScope` exact-equality bypass described above. If your new grant
+ * really does need a strict superset of `Full`, this test is where you have to
+ * change the invariant on purpose — and `getMyAppAnalytics`'s no-regression
+ * argument has to be revisited at the same time.
+ */
+const DECLARED_GRANTS: Record<string, DeclaredGrant[]> = {
+  '20260410140011_add_oauth_tables': [
+    {
+      clientId: null,
+      op: 'default',
+      value: 33554431,
+      note: 'column DEFAULT — exactly TokenScope.Full, so it takes the early return',
+    },
+  ],
+  '20260619120000_register_civitai_cli_oauth_client': [
+    {
+      clientId: 'civitai-cli',
+      op: 'set',
+      value: 33554433,
+      note: 'UserRead | AppBlocksSubmit',
+    },
+  ],
+  '20260706120000_widen_civitai_cli_oauth_client_dev_tunnel_scope': [
+    {
+      clientId: 'civitai-cli',
+      op: 'or',
+      value: 67108864,
+      note: 'AppBlocksDevTunnel (bit 26)',
+    },
+  ],
+  '20260806140000_widen_civitai_cli_oauth_client_ai_services_scopes': [
+    {
+      clientId: 'civitai-cli',
+      op: 'or',
+      value: 114688,
+      note: 'AIServicesRead | AIServicesWrite | BuzzRead (bits 14/15/16) — issue #3681',
+    },
+  ],
+};
+
+/**
+ * The CLI client's `allowedScopes` AFTER every migration above, stated
+ * independently of the fold so the fold has something to be checked against.
+ * Source of truth is the migration SQL, not any TypeScript constant:
+ *   33554433 | 67108864 | 114688 = 100777985.
+ */
+const EXPECTED_CLI_ALLOWED_SCOPES = 100777985;
+
+/** Migration dirs that write an OAuth-client scope grant, read off the tree. */
+function migrationsWritingAllowedScopes(): string[] {
+  return fs
+    .readdirSync(MIGRATIONS_DIR, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .filter((dir) => {
+      const sqlPath = path.join(MIGRATIONS_DIR, dir, 'migration.sql');
+      if (!fs.existsSync(sqlPath)) return false;
+      const sql = fs.readFileSync(sqlPath, 'utf8');
+      return sql.includes('"OauthClient"') && sql.includes('allowedScopes');
+    })
+    .sort();
+}
+
+/** The SQL text of a migration, with `--` comment lines stripped. */
+function migrationSqlBody(dir: string): string {
+  return fs
+    .readFileSync(path.join(MIGRATIONS_DIR, dir, 'migration.sql'), 'utf8')
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('--'))
+    .join('\n');
+}
+
+/**
+ * The SQL shape a declared grant must exhibit — matched against the migration's
+ * SQL with comment lines stripped.
+ *
+ * 🔴 `or` and `default` are POSITIONAL: they pin the literal to the assignment
+ * itself, so moving the number (e.g. leaving it in the idempotency `WHERE
+ * ("allowedScopes" & n) <> n` guard while changing the `SET`) does not satisfy
+ * them. `set` cannot be — an `INSERT ... SELECT` lists the value positionally
+ * with no `allowedScopes` token nearby — so for that op this degrades to "the
+ * literal is somewhere in the statement". Stated plainly rather than implied.
+ */
+function grantPattern(grant: DeclaredGrant): RegExp {
+  const v = grant.value;
+  switch (grant.op) {
+    case 'default':
+      // `"allowedScopes" INTEGER NOT NULL DEFAULT 33554431`
+      return new RegExp(`"allowedScopes"[^,;\\n]*DEFAULT\\s+${v}(?![0-9])`);
+    case 'or':
+      // `SET "allowedScopes" = "allowedScopes" | 114688`
+      return new RegExp(`"allowedScopes"\\s*=\\s*"allowedScopes"\\s*\\|\\s*${v}(?![0-9])`);
+    case 'set':
+      return new RegExp(`(?<![0-9.])${v}(?![0-9])`);
+  }
+}
+
+describe('OAuth client allowedScopes written by raw SQL migration', () => {
+  it('the enumerated migration set matches the declared table (positive control included)', () => {
+    const found = migrationsWritingAllowedScopes();
+
+    // Positive control: the enumeration MUST find something. A zero here would be
+    // indistinguishable from a wrong MIGRATIONS_DIR, and every assertion below
+    // would pass vacuously.
+    expect(found.length).toBeGreaterThanOrEqual(4);
+    expect(found).toContain('20260806140000_widen_civitai_cli_oauth_client_ai_services_scopes');
+
+    expect(found).toEqual(Object.keys(DECLARED_GRANTS).sort());
+  });
+
+  it('every declared grant matches its migration SQL in the shape its op claims', () => {
+    for (const [dir, grants] of Object.entries(DECLARED_GRANTS)) {
+      const sql = migrationSqlBody(dir);
+      for (const grant of grants) {
+        expect(
+          grantPattern(grant).test(sql),
+          `${dir}: declared ${grant.op} of ${grant.value} (${grant.note}) does not appear in ` +
+            `migration.sql in that shape — expected /${grantPattern(grant).source}/`
+        ).toBe(true);
+        if (grant.clientId) {
+          expect(sql, `${dir}: declared client id ${grant.clientId} not found`).toContain(
+            `'${grant.clientId}'`
+          );
+        }
+      }
+    }
+  });
+
+  it('the grant-shape matcher is discriminating (negative control)', () => {
+    // Instrument check for the test above: the patterns must REJECT a value the SQL
+    // does not use in that position. Without this, a pattern that matched anything
+    // (or nothing, inverted) would make the previous test vacuous. `114688` really
+    // is present in the AI-services migration — but only inside the SET clause and
+    // the idempotency WHERE guard — so a neighbouring value must not match, and a
+    // value present in the file in the WRONG shape must not match either.
+    const aiSql = migrationSqlBody(
+      '20260806140000_widen_civitai_cli_oauth_client_ai_services_scopes'
+    );
+    const real: DeclaredGrant = {
+      clientId: 'civitai-cli',
+      op: 'or',
+      value: 114688,
+      note: 'control',
+    };
+    expect(grantPattern(real).test(aiSql)).toBe(true);
+    expect(grantPattern({ ...real, value: 114687 }).test(aiSql)).toBe(false);
+    // 100777985 appears in the header comment only (which is stripped), never as an
+    // `| n` in a SET clause.
+    expect(grantPattern({ ...real, value: 100777985 }).test(aiSql)).toBe(false);
+    // ...and the `default` shape must not match this file at all.
+    expect(grantPattern({ ...real, op: 'default' }).test(aiSql)).toBe(false);
+  });
+
+  it('no client is granted a STRICT superset of Full', () => {
+    // Fold the grants per client, in migration (timestamp) order.
+    const byClient = new Map<string, number>();
+    const defaults: number[] = [];
+    for (const dir of Object.keys(DECLARED_GRANTS).sort()) {
+      for (const grant of DECLARED_GRANTS[dir]) {
+        if (grant.clientId === null) {
+          defaults.push(grant.value);
+          continue;
+        }
+        const prev = byClient.get(grant.clientId) ?? 0;
+        byClient.set(grant.clientId, grant.op === 'set' ? grant.value : prev | grant.value);
+      }
+    }
+
+    expect(byClient.size).toBeGreaterThan(0); // positive control on the fold itself
+    expect(defaults).toEqual([TokenScope.Full]); // the column default IS Full, not a superset
+
+    for (const [clientId, mask] of byClient) {
+      const isSupersetOfFull = (mask | TokenScope.Full) === mask;
+      const isStrictSuperset = isSupersetOfFull && mask !== TokenScope.Full;
+      expect(
+        isStrictSuperset,
+        `client "${clientId}" would hold allowedScopes=${mask}, a STRICT superset of Full ` +
+          `(${TokenScope.Full}). That flips blocks.router.getMyAppAnalytics from allow to deny ` +
+          `for this client — see the comment on that procedure before changing this test.`
+      ).toBe(false);
+    }
+  });
+
+  it('pins the civitai-cli grant at 100777985 and proves it is not a superset of Full', () => {
+    const cliGrants = Object.keys(DECLARED_GRANTS)
+      .sort()
+      .flatMap((dir) => DECLARED_GRANTS[dir])
+      .filter((g) => g.clientId === 'civitai-cli');
+
+    // Derived from the migration SQL literals, NOT from any TokenScope expression
+    // in the app — the point is to catch the DB and the enum disagreeing.
+    const folded = cliGrants.reduce((acc, g) => (g.op === 'set' ? g.value : acc | g.value), 0);
+    expect(folded).toBe(EXPECTED_CLI_ALLOWED_SCOPES);
+
+    // The invariant `getMyAppAnalytics` depends on. `(v | Full) !== v` ⇒ v does not
+    // contain Full.
+    expect(folded | TokenScope.Full).not.toBe(folded);
+
+    // ...and specifically WHICH bits it holds, so a future widening that happens to
+    // stay a non-superset still has to restate the claim here.
+    const bitsSet = [...Array(31).keys()].filter((b) => (folded & (1 << b)) === 1 << b);
+    expect(bitsSet).toEqual([0, 14, 15, 16, 25, 26]);
+
+    // Cross-check the bit list against the enum so a renumbered scope is caught.
+    expect(
+      TokenScope.UserRead |
+        TokenScope.AIServicesRead |
+        TokenScope.AIServicesWrite |
+        TokenScope.BuzzRead |
+        TokenScope.AppBlocksSubmit |
+        TokenScope.AppBlocksDevTunnel
+    ).toBe(EXPECTED_CLI_ALLOWED_SCOPES);
+  });
+});

--- a/src/server/services/oauth/__tests__/oauth-client-scope-grants.test.ts
+++ b/src/server/services/oauth/__tests__/oauth-client-scope-grants.test.ts
@@ -32,22 +32,37 @@ import { TokenScope } from '~/shared/constants/token-scope.constants';
  * file closes the migration hole that test's own comment names as uncovered.
  *
  * MECHANISM — enumerated from the TREE, reconciled against a declared table. The
- * migration set is read off disk (every `migration.sql` mentioning `"OauthClient"`
- * and `allowedScopes`), so a NEW migration granting `allowedScopes` fails this
- * test until someone adds a row to `DECLARED_GRANTS` — which is the reviewable
- * act. Each declared grant must then match its SQL in the SHAPE its op claims
- * (`grantPattern` below: `or` and `default` are positional against the assignment
- * itself), so the table cannot drift away from what the SQL does. The values are
- * folded per client id in migration (timestamp) order and the resulting mask is
- * checked.
+ * migration set is read off disk (every `migration.sql` whose LIVE SQL mentions
+ * `"OauthClient"` and `allowedScopes`), so a NEW migration granting `allowedScopes`
+ * fails this test until someone adds a row to `DECLARED_MIGRATIONS` — which is the
+ * reviewable act. Each declared grant then has to reproduce its migration's LIVE
+ * SQL **verbatim** (`pinnedSql`), so nothing about the statement — the assignment,
+ * the targeting predicate, the idempotency guard, the statement terminator — can be
+ * inverted, broadened, reordered or commented out without restating it here. On top
+ * of the verbatim pin, three purpose-built checks assert the SEMANTICS of a scoped
+ * widening rather than its spelling, so they survive a reformat: the assignment
+ * shape, the single-client-id equality target, and an executable model of the
+ * idempotency predicate. Finally the values are folded per client — SEEDED FROM THE
+ * DECLARED COLUMN DEFAULT, not from 0 — and the resulting mask is checked.
  *
- * WHAT THIS DOES *NOT* DO: it does not parse SQL, it regex-matches statement
- * shapes. `set` (an `INSERT ... SELECT`, where the value is positional and has no
- * `allowedScopes` token near it) degrades to "the literal is somewhere in the
- * statement", so a mis-declared `set` row could pass. It also cannot see a grant
- * written OUTSIDE a migration (a hand-run `UPDATE`), and it says nothing about what
- * any environment's row actually holds — these migrations are manual-apply. It is a
- * ratchet on the POPULATION plus a pin on the VALUES, not a SQL interpreter.
+ * 🔴 WHY THE FOLD SEEDS FROM THE COLUMN DEFAULT. The column default is `Full`
+ * (33554431). A client row created by the ordinary path and later widened by a
+ * migration that ORs in one opt-in bit therefore lands on `Full | <bit>` — a STRICT
+ * superset, and exactly the construction the `getMyAppAnalytics` argument is about.
+ * Folding from 0 reads that same migration as granting just `<bit>` and passes clean,
+ * which is what made an earlier version of this file blind to the likeliest way the
+ * invariant actually breaks. Seeding from the default can only ever OVER-estimate a
+ * client's mask (a client whose row was created below the default by some non-migration
+ * path), and an over-estimate fails LOUDLY — the safe direction.
+ *
+ * WHAT THIS DOES *NOT* DO: it does not parse SQL, it matches statement text and
+ * models one predicate shape. The comment stripper handles `--` to end-of-line and
+ * nestable `/* … *\/` blocks and skips over single-quoted literals, but it does not
+ * understand dollar-quoted bodies (`$$ … $$`) — none of these migrations use one.
+ * It cannot see a grant written OUTSIDE a migration (a hand-run `UPDATE`), and it says
+ * nothing about what any environment's row actually holds — these migrations are
+ * manual-apply. It is a ratchet on the POPULATION plus a pin on the VALUES, not a SQL
+ * interpreter.
  */
 
 const MIGRATIONS_DIR = path.resolve(
@@ -70,8 +85,33 @@ interface DeclaredGrant {
   op: GrantOp;
   /** The integer literal the SQL uses. Must appear verbatim in the file. */
   value: number;
+  /**
+   * The LIVE SQL this grant is carried by — comments stripped, whitespace collapsed
+   * to single spaces — pinned VERBATIM.
+   *
+   * 🔴 For `or` and `set` this is the WHOLE statement INCLUDING its terminating `;`,
+   * which is what makes the targeting predicate and the idempotency guard part of the
+   * reviewable declaration. Changing `WHERE "id" = 'x'` to `WHERE "id" <> 'x'`, or
+   * `<> n` to `= n`, or appending `OR TRUE` before the semicolon, or block-commenting
+   * the statement out, all fail here. For `default` it is the column DEFINITION rather
+   * than the whole `CREATE TABLE`, because that statement's other columns are applied
+   * history and none of this guard's business.
+   */
+  pinnedSql: string;
   /** Why this value is what it is — kept short; the migration header has the detail. */
   note: string;
+}
+
+interface DeclaredMigration {
+  /**
+   * How many times the identifier `allowedScopes` appears in the migration's LIVE
+   * SQL (comments stripped). Declared so that ADDING a second statement that touches
+   * the column — next to a correctly-declared one — cannot slip past unreviewed.
+   * References inside comments do not count, which is why the rollback recipe in a
+   * migration header is free.
+   */
+  liveReferences: number;
+  grants: DeclaredGrant[];
 }
 
 /**
@@ -84,39 +124,71 @@ interface DeclaredGrant {
  * change the invariant on purpose — and `getMyAppAnalytics`'s no-regression
  * argument has to be revisited at the same time.
  */
-const DECLARED_GRANTS: Record<string, DeclaredGrant[]> = {
-  '20260410140011_add_oauth_tables': [
-    {
-      clientId: null,
-      op: 'default',
-      value: 33554431,
-      note: 'column DEFAULT — exactly TokenScope.Full, so it takes the early return',
-    },
-  ],
-  '20260619120000_register_civitai_cli_oauth_client': [
-    {
-      clientId: 'civitai-cli',
-      op: 'set',
-      value: 33554433,
-      note: 'UserRead | AppBlocksSubmit',
-    },
-  ],
-  '20260706120000_widen_civitai_cli_oauth_client_dev_tunnel_scope': [
-    {
-      clientId: 'civitai-cli',
-      op: 'or',
-      value: 67108864,
-      note: 'AppBlocksDevTunnel (bit 26)',
-    },
-  ],
-  '20260806140000_widen_civitai_cli_oauth_client_ai_services_scopes': [
-    {
-      clientId: 'civitai-cli',
-      op: 'or',
-      value: 114688,
-      note: 'AIServicesRead | AIServicesWrite | BuzzRead (bits 14/15/16) — issue #3681',
-    },
-  ],
+const DECLARED_MIGRATIONS: Record<string, DeclaredMigration> = {
+  '20260410140011_add_oauth_tables': {
+    liveReferences: 1,
+    grants: [
+      {
+        clientId: null,
+        op: 'default',
+        value: 33554431,
+        pinnedSql: '"allowedScopes" INTEGER NOT NULL DEFAULT 33554431,',
+        note: 'column DEFAULT — exactly TokenScope.Full, so it takes the early return',
+      },
+    ],
+  },
+  '20260619120000_register_civitai_cli_oauth_client': {
+    liveReferences: 1,
+    grants: [
+      {
+        clientId: 'civitai-cli',
+        op: 'set',
+        value: 33554433,
+        pinnedSql:
+          'INSERT INTO "OauthClient" ( "id", "secret", "name", "description", "logoUrl", ' +
+          '"redirectUris", "allowedOrigins", "grants", "allowedScopes", "isConfidential", ' +
+          '"userId", "isVerified", "createdAt", "updatedAt" ) SELECT ' +
+          "'civitai-cli', NULL, 'Civitai CLI', 'Official Civitai command-line tool. Used to " +
+          "submit App Blocks for review and manage your apps from the terminal.', NULL, " +
+          "ARRAY['http://127.0.0.1/callback', 'http://localhost/callback']::TEXT[], " +
+          "ARRAY[]::TEXT[], ARRAY['authorization_code', 'refresh_token', " +
+          "'urn:ietf:params:oauth:grant-type:device_code']::TEXT[], 33554433, false, -1, true, " +
+          'CURRENT_TIMESTAMP, CURRENT_TIMESTAMP WHERE EXISTS (SELECT 1 FROM "User" WHERE ' +
+          '"id" = -1) ON CONFLICT ("id") DO NOTHING;',
+        note: 'UserRead | AppBlocksSubmit',
+      },
+    ],
+  },
+  '20260706120000_widen_civitai_cli_oauth_client_dev_tunnel_scope': {
+    liveReferences: 3,
+    grants: [
+      {
+        clientId: 'civitai-cli',
+        op: 'or',
+        value: 67108864,
+        pinnedSql:
+          'UPDATE "OauthClient" SET "allowedScopes" = "allowedScopes" | 67108864, ' +
+          '"updatedAt" = CURRENT_TIMESTAMP WHERE "id" = \'civitai-cli\' ' +
+          'AND ("allowedScopes" & 67108864) = 0;',
+        note: 'AppBlocksDevTunnel (bit 26)',
+      },
+    ],
+  },
+  '20260806140000_widen_civitai_cli_oauth_client_ai_services_scopes': {
+    liveReferences: 3,
+    grants: [
+      {
+        clientId: 'civitai-cli',
+        op: 'or',
+        value: 114688,
+        pinnedSql:
+          'UPDATE "OauthClient" SET "allowedScopes" = "allowedScopes" | 114688, ' +
+          '"updatedAt" = CURRENT_TIMESTAMP WHERE "id" = \'civitai-cli\' ' +
+          'AND ("allowedScopes" & 114688) <> 114688;',
+        note: 'AIServicesRead | AIServicesWrite | BuzzRead (bits 14/15/16) — issue #3681',
+      },
+    ],
+  },
 };
 
 /**
@@ -127,42 +199,112 @@ const DECLARED_GRANTS: Record<string, DeclaredGrant[]> = {
  */
 const EXPECTED_CLI_ALLOWED_SCOPES = 100777985;
 
-/** Migration dirs that write an OAuth-client scope grant, read off the tree. */
+/**
+ * Strip SQL comments: `--` to end of line, and nestable `/* … *\/` blocks. Single-quoted
+ * string literals are copied through verbatim (honouring the `''` escape) so a `--` or
+ * `/*` inside a literal is not mistaken for a comment.
+ *
+ * 🔴 Stripping BLOCK comments matters: with only `--` handled, wrapping a whole
+ * migration in `/* … *\/` and appending `SELECT 1;` left every text assertion in this
+ * file matching a statement the database would never execute.
+ */
+function stripSqlComments(sql: string): string {
+  const out: string[] = [];
+  let i = 0;
+  while (i < sql.length) {
+    const two = sql.slice(i, i + 2);
+    if (two === '--') {
+      const nl = sql.indexOf('\n', i);
+      if (nl === -1) break;
+      i = nl;
+      continue;
+    }
+    if (two === '/*') {
+      let depth = 1;
+      i += 2;
+      while (i < sql.length && depth > 0) {
+        if (sql.slice(i, i + 2) === '/*') {
+          depth += 1;
+          i += 2;
+        } else if (sql.slice(i, i + 2) === '*/') {
+          depth -= 1;
+          i += 2;
+        } else {
+          i += 1;
+        }
+      }
+      out.push(' ');
+      continue;
+    }
+    if (sql[i] === "'") {
+      let j = i + 1;
+      while (j < sql.length) {
+        if (sql[j] === "'" && sql[j + 1] === "'") {
+          j += 2;
+          continue;
+        }
+        if (sql[j] === "'") {
+          j += 1;
+          break;
+        }
+        j += 1;
+      }
+      out.push(sql.slice(i, j));
+      i = j;
+      continue;
+    }
+    out.push(sql[i]);
+    i += 1;
+  }
+  return out.join('');
+}
+
+/**
+ * A migration's LIVE SQL: comments stripped, runs of whitespace collapsed to one space.
+ *
+ * 🔴 The SAME function feeds the enumeration and every text assertion. They used to
+ * disagree — enumeration read the raw file, the shape match read a `--`-stripped copy —
+ * so a migration that merely MENTIONED `allowedScopes` in its header was reported as
+ * writing a grant, while one whose statement was block-commented out was reported as
+ * still writing one.
+ */
+function liveSql(dir: string): string {
+  const raw = fs.readFileSync(path.join(MIGRATIONS_DIR, dir, 'migration.sql'), 'utf8');
+  return stripSqlComments(raw).replace(/\s+/g, ' ').trim();
+}
+
+/** Migration dirs whose LIVE SQL writes an OAuth-client scope grant, read off the tree. */
 function migrationsWritingAllowedScopes(): string[] {
   return fs
     .readdirSync(MIGRATIONS_DIR, { withFileTypes: true })
     .filter((e) => e.isDirectory())
     .map((e) => e.name)
     .filter((dir) => {
-      const sqlPath = path.join(MIGRATIONS_DIR, dir, 'migration.sql');
-      if (!fs.existsSync(sqlPath)) return false;
-      const sql = fs.readFileSync(sqlPath, 'utf8');
+      if (!fs.existsSync(path.join(MIGRATIONS_DIR, dir, 'migration.sql'))) return false;
+      const sql = liveSql(dir);
       return sql.includes('"OauthClient"') && sql.includes('allowedScopes');
     })
     .sort();
 }
 
-/** The SQL text of a migration, with `--` comment lines stripped. */
-function migrationSqlBody(dir: string): string {
-  return fs
-    .readFileSync(path.join(MIGRATIONS_DIR, dir, 'migration.sql'), 'utf8')
-    .split('\n')
-    .filter((line) => !line.trimStart().startsWith('--'))
-    .join('\n');
+/** Occurrences of the identifier `allowedScopes` in a migration's LIVE SQL. */
+function countLiveReferences(dir: string): number {
+  return liveSql(dir).split('allowedScopes').length - 1;
 }
 
 /**
- * The SQL shape a declared grant must exhibit — matched against the migration's
- * SQL with comment lines stripped.
+ * The SQL shape a declared grant must exhibit — matched against the grant's pinned
+ * live SQL.
  *
  * 🔴 `or` and `default` are POSITIONAL: they pin the literal to the assignment
  * itself, so moving the number (e.g. leaving it in the idempotency `WHERE
  * ("allowedScopes" & n) <> n` guard while changing the `SET`) does not satisfy
  * them. `set` cannot be — an `INSERT ... SELECT` lists the value positionally
  * with no `allowedScopes` token nearby — so for that op this degrades to "the
- * literal is somewhere in the statement". Stated plainly rather than implied.
+ * literal is somewhere in the statement". That degradation is contained by
+ * `pinnedSql`, which reproduces the whole INSERT verbatim.
  */
-function grantPattern(grant: DeclaredGrant): RegExp {
+function grantPattern(grant: Pick<DeclaredGrant, 'op' | 'value'>): RegExp {
   const v = grant.value;
   switch (grant.op) {
     case 'default':
@@ -176,6 +318,83 @@ function grantPattern(grant: DeclaredGrant): RegExp {
   }
 }
 
+/**
+ * The predicate a scoped widening must use to pick its row: equality against a single
+ * literal client id.
+ *
+ * 🔴 This is deliberately the WHOLE predicate, anchored on `WHERE`, not a substring
+ * search for the quoted id. `expect(sql).toContain("'civitai-cli'")` — which is all this
+ * file used to have — is satisfied by `WHERE "id" <> 'civitai-cli'` (which widens every
+ * OTHER client, including every third-party `appblk-*` app-block client, with AI-services
+ * and Buzz-spend authority) and by `WHERE "userId" = -1 AND "id" >= 'civitai-cli'` (a
+ * lexicographic range scan). Both of those passed. A predicate the id merely appears in
+ * is not a predicate that selects that id.
+ */
+function targetPattern(clientId: string): RegExp {
+  return new RegExp(`WHERE\\s+"id"\\s*=\\s*'${clientId}'(?![\\w-])`);
+}
+
+/**
+ * An executable model of a widening's idempotency guard, parsed out of its pinned SQL.
+ *
+ * Returns a predicate answering "would this migration select a row whose current
+ * `allowedScopes` is `current`?", or `null` if no guard of the recognised shape is
+ * present — which the caller must treat as a failure, not as a pass.
+ */
+function parseIdempotencyGuard(
+  pinnedSql: string
+): { mask: number; selects: (current: number) => boolean } | null {
+  const m = /AND\s+\("allowedScopes"\s*&\s*(\d+)\)\s*(<>|!=|=)\s*(\d+)/.exec(pinnedSql);
+  if (!m) return null;
+  const mask = Number(m[1]);
+  const op = m[2];
+  const rhs = Number(m[3]);
+  return {
+    mask,
+    selects: (current: number) =>
+      op === '=' ? (current & mask) === rhs : (current & mask) !== rhs,
+  };
+}
+
+/** `v` contains every bit of `Full` and at least one more. */
+function isStrictSupersetOfFull(v: number): boolean {
+  return (v | TokenScope.Full) === v && v !== TokenScope.Full;
+}
+
+/** The column DEFAULT in force, taken from the declared table. Exactly one is expected. */
+function declaredColumnDefault(): number {
+  const defaults = Object.values(DECLARED_MIGRATIONS)
+    .flatMap((m) => m.grants)
+    .filter((g) => g.clientId === null)
+    .map((g) => g.value);
+  expect(
+    defaults,
+    'expected exactly one declared column DEFAULT for "OauthClient"."allowedScopes" — ' +
+      'the fold below seeds every client from it, so 0 or 2 of them makes the seed ambiguous'
+  ).toHaveLength(1);
+  return defaults[0];
+}
+
+/**
+ * Fold the declared grants per client, in migration (timestamp) order.
+ *
+ * 🔴 Each client is SEEDED FROM THE COLUMN DEFAULT, not from 0 — see the file header.
+ * A `set` op (an INSERT that states the value explicitly) replaces the seed; an `or`
+ * op widens whatever is there.
+ */
+function foldGrantsByClient(): Map<string, number> {
+  const seed = declaredColumnDefault();
+  const byClient = new Map<string, number>();
+  for (const dir of Object.keys(DECLARED_MIGRATIONS).sort()) {
+    for (const grant of DECLARED_MIGRATIONS[dir].grants) {
+      if (grant.clientId === null) continue;
+      const prev = byClient.get(grant.clientId) ?? seed;
+      byClient.set(grant.clientId, grant.op === 'set' ? grant.value : prev | grant.value);
+    }
+  }
+  return byClient;
+}
+
 describe('OAuth client allowedScopes written by raw SQL migration', () => {
   it('the enumerated migration set matches the declared table (positive control included)', () => {
     const found = migrationsWritingAllowedScopes();
@@ -184,45 +403,145 @@ describe('OAuth client allowedScopes written by raw SQL migration', () => {
     // indistinguishable from a wrong MIGRATIONS_DIR, and every assertion below
     // would pass vacuously.
     expect(found.length).toBeGreaterThanOrEqual(4);
-    expect(found).toContain('20260806140000_widen_civitai_cli_oauth_client_ai_services_scopes');
+    expect(
+      found,
+      'the AI-services widening is missing from the enumerated set — either the migration ' +
+        'was renamed/removed, or its statement is no longer LIVE SQL (block-commented out, ' +
+        'or `--`-commented out) and the database would never execute it'
+    ).toContain('20260806140000_widen_civitai_cli_oauth_client_ai_services_scopes');
 
-    expect(found).toEqual(Object.keys(DECLARED_GRANTS).sort());
+    expect(found).toEqual(Object.keys(DECLARED_MIGRATIONS).sort());
+  });
+
+  it('every declared grant reproduces its migration LIVE SQL verbatim', () => {
+    for (const [dir, decl] of Object.entries(DECLARED_MIGRATIONS)) {
+      const sql = liveSql(dir);
+      for (const grant of decl.grants) {
+        expect(
+          sql,
+          `${dir}: the declared ${grant.op} grant of ${grant.value} (${grant.note}) does not ` +
+            `appear in the migration's LIVE SQL verbatim. Either the SQL changed — in which ` +
+            `case restate \`pinnedSql\` here ON PURPOSE, because the whole statement including ` +
+            `its targeting predicate and idempotency guard is what this pins — or the ` +
+            `statement was commented out.`
+        ).toContain(grant.pinnedSql);
+      }
+      expect(
+        countLiveReferences(dir),
+        `${dir}: the number of LIVE references to \`allowedScopes\` changed. A statement that ` +
+          `touches the column was added or removed alongside the declared one(s); declare it.`
+      ).toBe(decl.liveReferences);
+    }
   });
 
   it('every declared grant matches its migration SQL in the shape its op claims', () => {
-    for (const [dir, grants] of Object.entries(DECLARED_GRANTS)) {
-      const sql = migrationSqlBody(dir);
-      for (const grant of grants) {
+    for (const [dir, decl] of Object.entries(DECLARED_MIGRATIONS)) {
+      const sql = liveSql(dir);
+      for (const grant of decl.grants) {
+        // Against the file, so the table cannot drift away from what the SQL does...
         expect(
           grantPattern(grant).test(sql),
           `${dir}: declared ${grant.op} of ${grant.value} (${grant.note}) does not appear in ` +
             `migration.sql in that shape — expected /${grantPattern(grant).source}/`
         ).toBe(true);
-        if (grant.clientId) {
-          expect(sql, `${dir}: declared client id ${grant.clientId} not found`).toContain(
-            `'${grant.clientId}'`
-          );
-        }
+        // ...and against the pinned text, so the declared `op`/`value` fields cannot drift
+        // away from the statement the same row pins.
+        expect(
+          grantPattern(grant).test(grant.pinnedSql),
+          `${dir}: declared ${grant.op} of ${grant.value} does not appear in that row's own ` +
+            `\`pinnedSql\` in that shape — the declaration contradicts itself`
+        ).toBe(true);
       }
     }
   });
 
+  it('every scoped widening targets exactly one client id by EQUALITY', () => {
+    let checked = 0;
+    for (const [dir, decl] of Object.entries(DECLARED_MIGRATIONS)) {
+      for (const grant of decl.grants) {
+        if (grant.op !== 'or' || !grant.clientId) continue;
+        checked += 1;
+        expect(
+          targetPattern(grant.clientId).test(grant.pinnedSql),
+          `${dir}: the widening does not target \`"id" = '${grant.clientId}'\` by equality. ` +
+            `A predicate that merely MENTIONS the id — \`<>\`, \`>=\`, \`LIKE\`, or a ` +
+            `different column — widens rows this grant was never reviewed for, including ` +
+            `third-party appblk-* app-block clients. Expected ` +
+            `/${targetPattern(grant.clientId).source}/`
+        ).toBe(true);
+      }
+    }
+    // Positive control: a zero here would make the loop above vacuous.
+    expect(checked).toBeGreaterThanOrEqual(2);
+  });
+
+  it('every scoped widening only selects rows that still NEED the bits (idempotency)', () => {
+    let checked = 0;
+    for (const [dir, decl] of Object.entries(DECLARED_MIGRATIONS)) {
+      for (const grant of decl.grants) {
+        if (grant.op !== 'or') continue;
+        checked += 1;
+        const guard = parseIdempotencyGuard(grant.pinnedSql);
+        // A MISSING guard is a failure, not a skip — otherwise deleting the guard
+        // makes this test pass vacuously.
+        expect(
+          guard,
+          `${dir}: no recognised idempotency guard \`AND ("allowedScopes" & n) <op> m\` in the ` +
+            `pinned SQL. Re-applying a manual-apply migration must touch zero rows.`
+        ).not.toBeNull();
+        if (!guard) continue;
+
+        expect(
+          guard.mask,
+          `${dir}: the idempotency guard masks ${guard.mask} but the grant ORs in ${grant.value}`
+        ).toBe(grant.value);
+
+        // The model. These three cases are what distinguish a CORRECT guard from the two
+        // ways it goes wrong, and neither shows up as a text difference you would notice:
+        //   - inverting the comparison (`<> n` → `= n`) makes the migration a PERMANENT
+        //     NO-OP: it would ship, apply "successfully", touch nothing, and `civitai
+        //     generate` would still 403.
+        //   - `& n = 0` on a MULTI-bit mask skips a row that has SOME of the bits, so a
+        //     partially-applied grant never completes.
+        expect(
+          guard.selects(0),
+          `${dir}: the idempotency guard does NOT select a row holding none of the bits — ` +
+            `this migration is a permanent no-op and would apply "successfully" while ` +
+            `granting nothing`
+        ).toBe(true);
+        expect(
+          guard.selects(grant.value),
+          `${dir}: the idempotency guard still selects a row that already holds every bit — ` +
+            `re-applying would churn updatedAt`
+        ).toBe(false);
+        // Every proper subset of the mask must still be selected. (Vacuous for a
+        // single-bit mask, which is why the loop below is guarded by a bit count.)
+        const bits = [...Array(31).keys()].filter((b) => (grant.value & (1 << b)) === 1 << b);
+        if (bits.length > 1) {
+          for (const b of bits) {
+            const partial = grant.value & ~(1 << b);
+            expect(
+              guard.selects(partial),
+              `${dir}: the idempotency guard does not select a row holding ${partial} — a ` +
+                `PARTIALLY applied grant would never complete (an \`& n = 0\` guard on a ` +
+                `multi-bit mask does this)`
+            ).toBe(true);
+          }
+        }
+      }
+    }
+    expect(checked).toBeGreaterThanOrEqual(2); // positive control
+  });
+
   it('the grant-shape matcher is discriminating (negative control)', () => {
-    // Instrument check for the test above: the patterns must REJECT a value the SQL
+    // Instrument check for the tests above: the patterns must REJECT a value the SQL
     // does not use in that position. Without this, a pattern that matched anything
-    // (or nothing, inverted) would make the previous test vacuous. `114688` really
+    // (or nothing, inverted) would make the previous tests vacuous. `114688` really
     // is present in the AI-services migration — but only inside the SET clause and
     // the idempotency WHERE guard — so a neighbouring value must not match, and a
     // value present in the file in the WRONG shape must not match either.
-    const aiSql = migrationSqlBody(
-      '20260806140000_widen_civitai_cli_oauth_client_ai_services_scopes'
-    );
-    const real: DeclaredGrant = {
-      clientId: 'civitai-cli',
-      op: 'or',
-      value: 114688,
-      note: 'control',
-    };
+    const aiSql = liveSql('20260806140000_widen_civitai_cli_oauth_client_ai_services_scopes');
+    const real = { op: 'or' as const, value: 114688 };
     expect(grantPattern(real).test(aiSql)).toBe(true);
     expect(grantPattern({ ...real, value: 114687 }).test(aiSql)).toBe(false);
     // 100777985 appears in the header comment only (which is stripped), never as an
@@ -230,56 +549,86 @@ describe('OAuth client allowedScopes written by raw SQL migration', () => {
     expect(grantPattern({ ...real, value: 100777985 }).test(aiSql)).toBe(false);
     // ...and the `default` shape must not match this file at all.
     expect(grantPattern({ ...real, op: 'default' }).test(aiSql)).toBe(false);
+
+    // The comment stripper must actually remove both comment forms, or every text
+    // assertion above is matching against text the database never executes.
+    expect(stripSqlComments('SELECT 1; -- SELECT 2;\nSELECT 3;')).toBe('SELECT 1; \nSELECT 3;');
+    expect(stripSqlComments('SELECT 1; /* SELECT 2; */ SELECT 3;')).toBe('SELECT 1;   SELECT 3;');
+    expect(stripSqlComments('SELECT 1; /* a /* b */ c */ SELECT 3;')).toBe('SELECT 1;   SELECT 3;');
+    expect(stripSqlComments("SELECT '-- not a comment';")).toBe("SELECT '-- not a comment';");
+    expect(stripSqlComments("SELECT '/* not a comment */';")).toBe("SELECT '/* not a comment */';");
+    // ...and the AI-services statement must survive stripping, so the checks above are
+    // not passing because everything got stripped.
+    expect(aiSql).toContain('UPDATE "OauthClient"');
+
+    // The targeting pattern must reject the two broadenings that used to pass.
+    const t = targetPattern('civitai-cli');
+    expect(t.test(`WHERE "id" = 'civitai-cli' AND x;`)).toBe(true);
+    expect(t.test(`WHERE "id" <> 'civitai-cli' AND x;`)).toBe(false);
+    expect(t.test(`WHERE "userId" = -1 AND "id" >= 'civitai-cli' AND x;`)).toBe(false);
+    expect(t.test(`WHERE "id" LIKE 'civitai-cli%' AND x;`)).toBe(false);
+
+    // The idempotency model must reject the inversion and the wrong-shape multi-bit guard.
+    const ok = parseIdempotencyGuard('AND ("allowedScopes" & 114688) <> 114688;');
+    expect(ok).not.toBeNull();
+    expect(ok?.selects(0)).toBe(true);
+    expect(ok?.selects(114688)).toBe(false);
+    const inverted = parseIdempotencyGuard('AND ("allowedScopes" & 114688) = 114688;');
+    expect(inverted?.selects(0)).toBe(false); // ← the permanent no-op
+    const wrongShape = parseIdempotencyGuard('AND ("allowedScopes" & 114688) = 0;');
+    expect(wrongShape?.selects(16384)).toBe(false); // ← skips a partially-applied row
+    expect(parseIdempotencyGuard('WHERE "id" = \'civitai-cli\';')).toBeNull();
+  });
+
+  it('the superset fold seeds from the column DEFAULT, not from 0', () => {
+    const seed = declaredColumnDefault();
+    expect(
+      seed,
+      'the declared column DEFAULT is no longer Full — the whole superset argument below, ' +
+        'and `blocks.router.getMyAppAnalytics`, rest on it'
+    ).toBe(TokenScope.Full);
+
+    // Prove the seed is LOAD-BEARING rather than incidental: the construction this guard
+    // exists to catch — a future migration ORing one opt-in bit onto a row created with
+    // the column default — is a strict superset ONLY when folded from the default. Folded
+    // from 0 the very same migration reads as harmless, which is how it used to pass.
+    const optInBit = TokenScope.AppBlocksDevTunnel;
+    expect(isStrictSupersetOfFull(seed | optInBit)).toBe(true);
+    expect(isStrictSupersetOfFull(0 | optInBit)).toBe(false);
   });
 
   it('no client is granted a STRICT superset of Full', () => {
-    // Fold the grants per client, in migration (timestamp) order.
-    const byClient = new Map<string, number>();
-    const defaults: number[] = [];
-    for (const dir of Object.keys(DECLARED_GRANTS).sort()) {
-      for (const grant of DECLARED_GRANTS[dir]) {
-        if (grant.clientId === null) {
-          defaults.push(grant.value);
-          continue;
-        }
-        const prev = byClient.get(grant.clientId) ?? 0;
-        byClient.set(grant.clientId, grant.op === 'set' ? grant.value : prev | grant.value);
-      }
-    }
+    const byClient = foldGrantsByClient();
 
     expect(byClient.size).toBeGreaterThan(0); // positive control on the fold itself
-    expect(defaults).toEqual([TokenScope.Full]); // the column default IS Full, not a superset
+    expect(declaredColumnDefault()).toBe(TokenScope.Full); // the default IS Full, not a superset
 
     for (const [clientId, mask] of byClient) {
-      const isSupersetOfFull = (mask | TokenScope.Full) === mask;
-      const isStrictSuperset = isSupersetOfFull && mask !== TokenScope.Full;
       expect(
-        isStrictSuperset,
+        isStrictSupersetOfFull(mask),
         `client "${clientId}" would hold allowedScopes=${mask}, a STRICT superset of Full ` +
           `(${TokenScope.Full}). That flips blocks.router.getMyAppAnalytics from allow to deny ` +
-          `for this client — see the comment on that procedure before changing this test.`
+          `for this client — see the comment on that procedure before changing this test. ` +
+          `(Clients are folded from the column DEFAULT unless a migration \`set\` states the ` +
+          `value explicitly, so a widening applied to a default-created row lands here.)`
       ).toBe(false);
     }
   });
 
   it('pins the civitai-cli grant at 100777985 and proves it is not a superset of Full', () => {
-    const cliGrants = Object.keys(DECLARED_GRANTS)
-      .sort()
-      .flatMap((dir) => DECLARED_GRANTS[dir])
-      .filter((g) => g.clientId === 'civitai-cli');
-
     // Derived from the migration SQL literals, NOT from any TokenScope expression
-    // in the app — the point is to catch the DB and the enum disagreeing.
-    const folded = cliGrants.reduce((acc, g) => (g.op === 'set' ? g.value : acc | g.value), 0);
+    // in the app — the point is to catch the DB and the enum disagreeing. Uses the
+    // same fold as the superset test above, so the two cannot disagree about seeding.
+    const folded = foldGrantsByClient().get('civitai-cli');
     expect(folded).toBe(EXPECTED_CLI_ALLOWED_SCOPES);
 
     // The invariant `getMyAppAnalytics` depends on. `(v | Full) !== v` ⇒ v does not
     // contain Full.
-    expect(folded | TokenScope.Full).not.toBe(folded);
+    expect(folded! | TokenScope.Full).not.toBe(folded);
 
     // ...and specifically WHICH bits it holds, so a future widening that happens to
     // stay a non-superset still has to restate the claim here.
-    const bitsSet = [...Array(31).keys()].filter((b) => (folded & (1 << b)) === 1 << b);
+    const bitsSet = [...Array(31).keys()].filter((b) => (folded! & (1 << b)) === 1 << b);
     expect(bitsSet).toEqual([0, 14, 15, 16, 25, 26]);
 
     // Cross-check the bit list against the enum so a renumbered scope is caught.


### PR DESCRIPTION
Fixes the `civitai login` → `civitai generate` failure reported in #3681, and turns the `getMyAppAnalytics` scope invariant from an inspection-based claim into an asserted one.

Ref: https://github.com/civitai/civitai/issues/3681#issuecomment-5208310465

## Root cause

An OAuth access token's ceiling is its client's `allowedScopes | UserRead`. That ceiling is enforced twice — once when the device authorization is created (`apps/auth/src/routes/api/auth/oauth/device/+server.ts`) and again when the token is minted (`.../device-token/+server.ts`).

The `civitai-cli` OAuth client's `allowedScopes` is `100663297` = `UserRead | AppBlocksSubmit | AppBlocksDevTunnel` (bits 0, 25, 26). Bits 14/15/16 are absent, so the CLI cannot even *request* them, and every procedure on the generate path rejects the resulting token:

| procedure | `requiredScope` |
| --- | --- |
| `orchestrator.whatIfFromGraph` | `AIServicesRead` |
| `orchestrator.generateFromGraph` | `AIServicesWrite` |
| `orchestrator.getWorkflow` | `AIServicesRead` |
| `orchestrator.queryGeneratedImages` | `AIServicesRead` |
| `orchestrator.cancelWorkflow` | `AIServicesWrite` |
| `buzz.getBuzzAccount` | `BuzzRead` |

## The change

One new migration widening that single client row:

```
AIServicesRead  = 1 << 14 = 16384
AIServicesWrite = 1 << 15 = 32768
BuzzRead        = 1 << 16 = 65536
                            114688

100663297 | 114688 = 100777985
```

`BuzzRead` is included for `buzz.getBuzzAccount`, which the CLI reads for its pre-flight insufficient-balance guard. That guard **fails soft** (it warns and continues), so omitting the bit would degrade UX rather than break generation — it is in the grant so the pre-flight check works instead of warning on every run.

## 🔴 Deploy ordering

**This migration must be applied to production BEFORE any CLI release that requests these bits.** The device-authorization scope check is all-or-nothing: it *rejects* a request carrying any bit outside the client ceiling rather than clamping it, so a CLI that asks first gets `invalid_scope` and `civitai login` 400s outright. That ordering is now asserted, not just described — see the before/after pair in the new device-flow test.

**The migration is MANUAL-APPLY and this PR does not apply it anywhere.** Per the repo convention, migrations under `packages/civitai-db-schema/prisma/migrations/` are committed for history and applied per environment by a human. No database was touched by this PR.

## `getMyAppAnalytics` — the non-superset argument

`enforceTokenScope` bypasses the scope gate on **exact equality** with `Full`, so a mask that is a *strict superset* of `Full` while missing an opt-in bit would flip `blocks.router.getMyAppAnalytics` from allow to deny. The comment on that procedure documented the old value and noted the argument rested on inspection of the migration with no test behind it.

`100777985` carries bits 0, 14, 15, 16, 25, 26 — and **none of 1–13 or 17–24** — so it is not a superset of `Full` (33554431) and the flip stays unreachable. The comment is updated to the new value and reasoning.

More importantly, the inspection-only part is now covered: `src/server/services/oauth/__tests__/oauth-client-scope-grants.test.ts` enumerates every migration writing `"OauthClient"."allowedScopes"` off the tree, reconciles them against a declared table, folds the grants per client, and fails if any client would hold a strict superset of `Full`. A future migration granting some client `Full | <opt-in bit>` now goes red there instead of silently flipping the gate.

## Tests

| file | what it covers |
| --- | --- |
| `src/server/services/oauth/__tests__/oauth-client-scope-grants.test.ts` | (new) the migration population guard above + pins the folded `civitai-cli` value at `100777985` |
| `src/server/routers/__tests__/cli-generate-scope-surface.test.ts` | (new) TypeScript-AST guard: the union of `requiredScope` across the six generate-path procedures is exactly `AIServicesRead\|AIServicesWrite\|BuzzRead` and is covered by the grant. Goes red if any of them gains a wider scope **or loses its `.meta({ requiredScope })`** — an un-annotated procedure implicitly requires `Full` and would 403 every scoped token |
| `apps/auth/src/routes/api/auth/oauth/device/__tests__/server.test.ts` | (new) device-flow scope validation: subset accepted, out-of-ceiling bit rejected with `invalid_scope`, reject-not-clamp, `UserRead` baseline OR-ed in on both sides, `ALL_SCOPES` bound, and the #3681 before/after pair |
| `apps/auth/src/lib/server/oauth/__tests__/scope.test.ts` | (new) `scopeLabels` for bits 14/15/16 — the strings a user sees on the consent screen before granting Buzz-spend authority — plus `hasScope` / `stringToScope` |
| `src/server/routers/__tests__/blocks.router.getMyAppAnalytics.test.ts` | (comment only) the "held only by inspection" note now points at the new guard |

**Red-at-base / green-at-HEAD.** Only `oauth-client-scope-grants.test.ts` is regression coverage for this change: with the new migration removed it fails 3 of 5 (`enumerated migration set…`, `every declared grant matches…`, `the grant-shape matcher…`), and passes 5/5 with it. The other three new files pass on pre-change code — they are **invariant guards** against future regressions, not coverage of this bug, and are labelled as such rather than counted as regression tests.

Each guard was mutation-checked: dropping a `.meta({ requiredScope })`, widening one to an ungranted bit, and renaming a procedure each kill the AST guard with its own assertion; adding an undeclared migration, declaring one that grants `Full | <opt-in bit>`, and moving the literal out of the `SET` clause each kill the migration guard with its own assertion; turning the device endpoint's reject into a clamp and removing either `UserRead` OR kill the device-flow tests with theirs.

## Follow-up (not in this PR)

A later change will make `ai:write:budgeted` an **explicit** request in `clampDevScopes` rather than inferring it from the bearer's `AIServicesWrite` bit. Doing it now would be a breaking change for existing personal-API-key users of `civitai app dev-token`, so it is deliberately out of scope here.
