### PR TITLE
test(blocks): make the spend-column write-surface guard fast and untimed

### DIFF
--- a/src/server/services/blocks/__tests__/app-spend-tier-privilege.test.ts
+++ b/src/server/services/blocks/__tests__/app-spend-tier-privilege.test.ts
@@ -1,4 +1,5 @@
-import { readdirSync, readFileSync, statSync } from 'fs';
+import { readFileSync } from 'fs';
+import { readdir, readFile, stat } from 'fs/promises';
 import { join, relative } from 'path';
 import { describe, expect, it } from 'vitest';
 
@@ -25,7 +26,45 @@ import { describe, expect, it } from 'vitest';
  * exist can establish.
  */
 
+/**
+ * 🔴 WHY THE SCAN IS SHAPED LIKE THIS — it fixes a measured flake, not a style nit.
+ *
+ * The original scan read all ~3.5k source files with a SERIAL `readFileSync` and
+ * comment-stripped every one, lazily on first use — which charged the entire cost
+ * to the body of whichever test happened to run first. That is LATENCY-bound work
+ * (thousands of blocking syscalls), so it does not degrade like the rest of the
+ * suite: CPU-bound tests slow by a few percent under load, while this one scales
+ * with per-read latency. Observed on CI, unchanged, across three PRs: 6995ms,
+ * 8303ms, then 68197ms — the last one blowing the 60s `testTimeout` and reporting
+ * as a failure of an unrelated change. The run that died was the FASTEST of the
+ * three overall (380s vs 437s) and exactly ONE test inflated, which is the
+ * signature of a latency-bound test rather than a loaded box.
+ *
+ * Three things keep it from coming back. None of them narrows WHAT is scanned —
+ * narrowing is the one change this guard may never make, because a file that is
+ * never read cannot be found guilty:
+ *
+ *  1. ONE pass, at module scope. Every case asserts against a precomputed result
+ *     instead of triggering the scan itself. Module scope also puts it in
+ *     Vitest's COLLECTION phase, which no timeout bounds — see the `testTimeout`
+ *     comment in vitest.config.mts, which prescribes exactly this hoist. A slow
+ *     disk can now make this file slow; it can no longer make it RED.
+ *  2. Reads are issued CONCURRENTLY. Serial blocking reads are the thing that
+ *     multiplies under I/O contention.
+ *  3. Files are prefiltered on their raw BYTES; only the handful that could
+ *     possibly match are decoded and comment-stripped (~30 of ~3553). See
+ *     `INTERESTING` for why that is sound rather than a narrowing.
+ */
+
 const SPEND_FIELDS = ['spendTier', 'spendCapBuzzPerDay', 'spendVelocityMaxGens'] as const;
+
+/**
+ * Positive control on the CASE COUNT. `it.each(SPEND_FIELDS)` generates one test
+ * per entry, so a trimmed — or emptied — list silently generates fewer, or zero,
+ * cases and the suite still reports green. Pinned so shrinking the population is
+ * a failure rather than a quieter pass.
+ */
+const EXPECTED_SPEND_FIELD_COUNT = 3;
 
 /** The ONE module allowed to write the spend columns (mod-gated at the router). */
 const AUTHORISED_WRITER = 'src/server/services/block-registry.service.ts';
@@ -33,60 +72,181 @@ const AUTHORISED_WRITER = 'src/server/services/block-registry.service.ts';
 /** The ONE schema module allowed to declare a spend-column input (mod-only). */
 const AUTHORISED_SCHEMA = 'src/server/schema/blocks/subscription.schema.ts';
 
+/**
+ * The developer-reachable write paths, enumerated explicitly: the JOB_TOKEN
+ * manifest endpoint, the build callback, the moderator approve/publish flow and
+ * the offsite/screenshot services. None of them may carry a spend field — new
+ * rows take the DB default ('standard'), forever, unless a moderator acts.
+ */
+const PUBLISHER_REACHABLE = [
+  'src/pages/api/v1/developer/block-manifests.ts',
+  'src/pages/api/internal/blocks/build-callback.ts',
+  'src/server/services/blocks/publish-request.service.ts',
+  'src/server/services/blocks/offsite-moderation.service.ts',
+  'src/server/services/blocks/autogenerate-screenshot.service.ts',
+  'src/server/routers/blocks.router.ts',
+];
+
+/** The snake_case column name, checked alongside the camelCase Prisma fields. */
+const RAW_COLUMN = 'spend_tier';
+
+const APPBLOCK_WRITE = /appBlock\.(create|update|updateMany|upsert)\b/;
+
+/** The literal every `APPBLOCK_WRITE` match necessarily contains. */
+const APPBLOCK_LITERAL = 'appBlock.';
+
+/**
+ * Every token whose presence has to be decided from the CODE view.
+ *
+ * 🔴 Prefiltering on raw bytes and comment-stripping only the survivors is SOUND,
+ * not a narrowing, because stripping can only ever REMOVE occurrences: a block
+ * comment is replaced by a single space, a line comment by the character that
+ * preceded it (the newline survives — `.` does not match `\n`). Neither
+ * substitution can splice a NEW token into existence, because every token here is
+ * whitespace-free and the only thing either one inserts is whitespace that was
+ * already adjacent. So `stripped ⊆ raw` for these needles, and a file whose bytes
+ * lack the token cannot hold it in code. Bytes are searched directly rather than
+ * decoded first, which is exact for ASCII needles (no UTF-8 multi-byte sequence
+ * contains an ASCII byte) and skips decoding ~27MB to learn nothing.
+ *
+ * Verified empirically against the whole tree as well as argued: scanning every
+ * file both ways, the set found by the byte prefilter was a superset of the set
+ * found from stripped code for every token, with nothing missed.
+ */
+const INTERESTING = [...SPEND_FIELDS, RAW_COLUMN, APPBLOCK_LITERAL] as const;
+
 const ROOT = process.cwd();
 
-function walk(dir: string, out: string[] = []): string[] {
-  for (const entry of readdirSync(dir)) {
-    if (entry === 'node_modules' || entry === '.next' || entry === '.git') continue;
-    const full = join(dir, entry);
-    const st = statSync(full);
-    if (st.isDirectory()) walk(full, out);
-    else if (/\.tsx?$/.test(entry)) out.push(full);
+/** How many reads to keep in flight. The point is to overlap syscall latency. */
+const READ_CONCURRENCY = 32;
+
+async function walk(dir: string, out: string[]): Promise<string[]> {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === '.next' || entry.name === '.git') continue;
+    const full = join(dir, entry.name);
+    // `withFileTypes` reports a symlink as neither file nor directory, whereas
+    // the `statSync` walk this replaced FOLLOWED symlinks. Resolve them, so a
+    // symlinked source directory keeps being scanned — silently skipping one
+    // would be exactly the narrowing this guard must not do.
+    const isDirectory = entry.isSymbolicLink()
+      ? (await stat(full)).isDirectory()
+      : entry.isDirectory();
+    if (isDirectory) await walk(full, out);
+    else if (/\.tsx?$/.test(entry.name)) out.push(full);
   }
   return out;
 }
 
-/** Every non-test .ts/.tsx under src/, as repo-relative paths. */
-function sourceFiles(): string[] {
-  return walk(join(ROOT, 'src'))
-    .map((f) => relative(ROOT, f))
-    .filter((f) => !/__tests__|\.test\.tsx?$|(^|\/)src\/tests\//.test(f));
+async function forEachConcurrent<T>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T) => Promise<void>
+): Promise<void> {
+  let cursor = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    for (let i = cursor++; i < items.length; i = cursor++) await fn(items[i]);
+  });
+  await Promise.all(workers);
 }
-
-const FILES = sourceFiles();
 
 /**
  * Source with comments removed. Prose ABOUT the spend columns is exactly what
  * we want more of — the thing under test is whether any other module has CODE
  * that touches them. Scanning raw text would punish documentation.
+ *
+ * Load-bearing rather than decorative: `blocks.router.ts` and
+ * `app-spend-cap.service.ts` each name `spendTier` in JSDoc and nowhere else, so
+ * without the strip both would read as offenders.
  */
-function code(file: string): string {
-  return readFileSync(join(ROOT, file), 'utf8')
-    .replace(/\/\*[\s\S]*?\*\//g, ' ')
-    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/(^|[^:])\/\/.*$/gm, '$1');
 }
 
-const codeCache = new Map<string, string>();
-function codeOf(file: string): string {
-  let c = codeCache.get(file);
-  if (c === undefined) {
-    c = code(file);
-    codeCache.set(file, c);
+type Scan = {
+  /** Every non-test .ts/.tsx under src/, as repo-relative paths. */
+  files: string[];
+  /** token -> the files whose CODE (comments stripped) mentions it. */
+  mentions: Record<string, string[]>;
+  /** Files holding a Prisma create/update/upsert against `appBlock`. */
+  appBlockWriteSites: string[];
+  /** Comment-stripped source, for the files the scan kept. */
+  code: Map<string, string>;
+  /** Raw text, kept only for the publisher-facing modules (raw-vs-code control). */
+  raw: Map<string, string>;
+};
+
+const SCANNED_TOKENS = [...SPEND_FIELDS, RAW_COLUMN] as const;
+
+async function scanSourceTree(): Promise<Scan> {
+  const files = (await walk(join(ROOT, 'src'), []))
+    .map((f) => relative(ROOT, f))
+    .filter((f) => !/__tests__|\.test\.tsx?$|(^|\/)src\/tests\//.test(f));
+
+  const code = new Map<string, string>();
+  const raw = new Map<string, string>();
+  // Always decoded, whatever the prefilter says: these are the paths the
+  // publisher-facing assertion names. Reading them unconditionally keeps a
+  // renamed or deleted path a loud ENOENT instead of a silently vacuous pass.
+  const alwaysDecode = new Set<string>(PUBLISHER_REACHABLE);
+
+  await forEachConcurrent(files, READ_CONCURRENCY, async (file) => {
+    const bytes = await readFile(join(ROOT, file));
+    if (!alwaysDecode.has(file) && !INTERESTING.some((t) => bytes.includes(t))) return;
+    const text = bytes.toString('utf8');
+    if (alwaysDecode.has(file)) raw.set(file, text);
+    code.set(file, stripComments(text));
+  });
+
+  // Classify in `files` order, so every list below is deterministic and matches
+  // the order a straight filter over the tree walk would have produced.
+  const mentions: Record<string, string[]> = Object.fromEntries(
+    SCANNED_TOKENS.map((t) => [t, [] as string[]])
+  );
+  const appBlockWriteSites: string[] = [];
+  for (const file of files) {
+    const src = code.get(file);
+    if (src === undefined) continue;
+    for (const token of SCANNED_TOKENS) if (src.includes(token)) mentions[token].push(file);
+    if (APPBLOCK_WRITE.test(src)) appBlockWriteSites.push(file);
   }
-  return c;
+
+  return { files, mentions, appBlockWriteSites, code, raw };
 }
 
-function filesMentioning(token: string): string[] {
-  return FILES.filter((f) => codeOf(f).includes(token));
-}
+// Module scope on purpose — see the cost note above. This lands in Vitest's
+// collection phase, so no per-test timeout is ever charged for it.
+const SCAN = await scanSourceTree();
 
 describe('the spend columns have exactly ONE write surface', () => {
   it('enumerates a non-trivial population (the scan itself is working)', () => {
     // Guard against the vacuous-pass mode: a broken walk would make every
     // assertion below trivially true.
-    expect(FILES.length).toBeGreaterThan(500);
-    expect(FILES).toContain(AUTHORISED_WRITER);
-    expect(FILES).toContain(AUTHORISED_SCHEMA);
+    expect(SCAN.files.length).toBeGreaterThan(500);
+    expect(SCAN.files).toContain(AUTHORISED_WRITER);
+    expect(SCAN.files).toContain(AUTHORISED_SCHEMA);
+
+    // Case-count control: the `it.each` below shrinks silently if SPEND_FIELDS is
+    // ever trimmed, and a zero-case `it.each` reports green.
+    expect(SPEND_FIELDS.length).toBe(EXPECTED_SPEND_FIELD_COUNT);
+  });
+
+  it('the CODE scan can actually see a spend column (positive control)', () => {
+    // Everything below is reassured by an EMPTY list, which a scan wired to
+    // nothing — or a `stripComments` that blanked its input — produces just as
+    // readily. So pin a known TRUE positive first: the mod-only schema declares
+    // all three columns in real code and must be observed doing so.
+    for (const field of SPEND_FIELDS) {
+      expect(SCAN.mentions[field], `nothing was observed to mention ${field} in code`).toContain(
+        AUTHORISED_SCHEMA
+      );
+    }
+
+    // ...and pin that comment stripping is live rather than a no-op: the router
+    // names `spendTier` in JSDoc only, so it must be present in the bytes and
+    // absent from the code view.
+    const router = 'src/server/routers/blocks.router.ts';
+    expect(SCAN.raw.get(router)).toContain('spendTier');
+    expect(SCAN.code.get(router)).not.toContain('spendTier');
   });
 
   it.each(SPEND_FIELDS)(
@@ -100,33 +260,21 @@ describe('the spend columns have exactly ONE write surface', () => {
         'src/server/services/blocks/app-cap-limits.constants.ts',
         'src/server/services/blocks/app-cap-limits.service.ts',
       ]);
-      const offenders = filesMentioning(field).filter((f) => !allowed.has(f));
+      const offenders = SCAN.mentions[field].filter((f) => !allowed.has(f));
       expect(offenders).toEqual([]);
     }
   );
 
   it('no PUBLISHER-facing module mentions the spend columns at all', () => {
-    // The developer-reachable write paths, enumerated explicitly: the JOB_TOKEN
-    // manifest endpoint, the build callback, the moderator approve/publish flow
-    // and the offsite/screenshot services. None of them may carry a spend field
-    // — new rows take the DB default ('standard'), forever, unless a moderator
-    // acts.
-    const publisherReachable = [
-      'src/pages/api/v1/developer/block-manifests.ts',
-      'src/pages/api/internal/blocks/build-callback.ts',
-      'src/server/services/blocks/publish-request.service.ts',
-      'src/server/services/blocks/offsite-moderation.service.ts',
-      'src/server/services/blocks/autogenerate-screenshot.service.ts',
-      'src/server/routers/blocks.router.ts',
-    ];
-    for (const file of publisherReachable) {
+    for (const file of PUBLISHER_REACHABLE) {
       // blocks.router.ts hosts the MOD-ONLY procedures, which reference the
       // schemas by name but never the column names themselves.
-      const src = codeOf(file);
+      const src = SCAN.code.get(file);
+      expect(src, `${file} was not read — is the path stale?`).toBeDefined();
       for (const field of SPEND_FIELDS) {
-        expect(src.includes(field), `${file} must not reference ${field} in code`).toBe(false);
+        expect(src!.includes(field), `${file} must not reference ${field} in code`).toBe(false);
       }
-      expect(src.includes('spend_tier'), `${file} must not reference spend_tier`).toBe(false);
+      expect(src!.includes(RAW_COLUMN), `${file} must not reference ${RAW_COLUMN}`).toBe(false);
     }
   });
 
@@ -134,14 +282,12 @@ describe('the spend columns have exactly ONE write surface', () => {
     // Audit the POPULATION: find every appBlock create/update/upsert in the tree
     // and assert each one either belongs to the authorised writer or carries no
     // spend field. A brand-new write site added later lands here.
-    const writeSites = FILES.filter((f) =>
-      /appBlock\.(create|update|updateMany|upsert)\b/.test(codeOf(f))
-    );
+    const writeSites = SCAN.appBlockWriteSites;
     expect(writeSites.length).toBeGreaterThan(3); // the scan found real sites
     expect(writeSites).toContain(AUTHORISED_WRITER);
     for (const file of writeSites) {
       if (file === AUTHORISED_WRITER) continue;
-      const src = codeOf(file);
+      const src = SCAN.code.get(file)!;
       for (const field of SPEND_FIELDS) {
         expect(src.includes(field), `${file} writes appBlock and references ${field}`).toBe(false);
       }


### PR DESCRIPTION
`app-spend-tier-privilege.test.ts` intermittently takes >60s and dies on the
`testTimeout`, reporting as a failure of whatever unrelated PR happened to be
running. It just got blamed on #3690, which changed one browser test file.

## What I measured

**The reported failure** (given to me, not re-observed): the same unchanged test
took 6995ms on #3688, 8303ms on #3689, and 68197ms on #3690, where it timed out.
#3690's whole unit run was the *fastest* of the three (380s vs 437s) and exactly
one test inflated — load inflates every test, a stuck test inflates one.

**Where the time actually goes.** The hypothesis I was given — that `it.each`
re-walks the tree once per field, so cost scales with the field count — is
**refuted**. The walk happens once at module scope and the comment cache is
module-level and shared, so the *first* case pays everything and the rest are
nearly free. Measured in the full suite, before any change:

| test | ms |
|---|---|
| `spendTier` (first `it.each` case) | 121 |
| `spendCapBuzzPerDay` | 6 |
| `spendVelocityMaxGens` | 6 |
| every Prisma write against appBlock | 8 |

The real cost is the scan itself: **3553 files, 27.1 MB**, read serially with
blocking `readFileSync` and comment-stripped in full — all charged to one test's
60s budget. Decomposed on a warm cache: walk 55ms (4513 `statSync` calls), read
101ms, comment-strip 134ms, search 43ms.

**Why 7s → 68s (the variance).** This is the part I can support with a
measurement rather than a story. The work is latency-bound, not CPU-bound: it is
thousands of *serial* blocking reads, so wall time is `N × per-read latency`, and
serial reads cannot overlap that latency. Evicting `src/` from the page cache
with `posix_fadvise(DONTNEED)` before each run — a state a fresh CI checkout
reads from — the same scan goes from 73.6ms warm to 657.3ms cold, and its cold
spread is wide and unstable. That is the amplification mechanism, and it explains
the signature the reporter saw: it is the only test in the suite doing thousands
of blocking syscalls, so it is the only one that inflates when I/O gets slow,
while CPU-bound tests are unaffected.

**Inferred, not measured:** I could not reproduce 68s on this hardware, and the
`preview / unit-tests` pipeline is not defined in this repo, so I could not
inspect the runner's CPU count, filesystem or worker count. The claim "read
latency on the runner" is the mechanism the local cold-cache experiment supports;
the specific 8.5× on that box is not something I observed.

## The fix

Three changes. **None of them narrows what is scanned** — a file that is never
read cannot be found guilty, so narrowing is the one move this guard may not
make.

1. **One pass at module scope.** Cases assert against a precomputed result. This
   also lands the scan in Vitest's *collection* phase, which no timeout bounds —
   the hoist `vitest.config.mts` already prescribes for this exact class. A slow
   disk can now make this file slow; it can no longer make it red.
2. **Concurrent reads**, so read latency overlaps instead of serialising.
3. **Byte prefilter**: only the ~30 of 3553 files that could possibly match are
   decoded and comment-stripped. Sound rather than a narrowing — comment
   stripping only ever *removes* occurrences (block comment → one space, line
   comment → the preceding char, newline retained), so `stripped ⊆ raw` for
   whitespace-free needles. Argued in the source and **verified against the whole
   tree both ways**: the byte-prefiltered set was a superset of the from-code set
   for every token, nothing missed.

### Runtime

Per-test time in the full suite, `spendTier` case: **121ms → 0ms**; the file's
total test time **104–122ms → 4–7ms** across 5 runs each.

Scan strategies over the identical file list, 8 runs each, page cache evicted
before **every** run:

| | min | median | max |
|---|---|---|---|
| old (serial, strip all) | 256.5 | 573 | 639.0 |
| new (concurrent, prefilter) | 128.2 | 217 | 246.7 |

The distributions do not overlap — the old scan's best cold run is slower than
the new one's worst. Harness validated first: warm 73.6ms vs cold 657.3ms proves
eviction actually does something.

**Honest counterpoint:** on a *warm* cache the new scan is ~20ms **slower**
(median 94ms vs 76ms) — async read overhead with no latency to hide, and a
serial-plus-prefilter variant is fastest warm (58ms) but the *worst* cold
(225–521ms). I chose the cold-case winner deliberately, because the cold case is
the one that fails. That cost is now paid in a phase nothing times.

### Guard strength: unchanged, mutation-tested both sides

Same mutants, same harness, before and after:

| mutant | before | after |
|---|---|---|
| clean tree | 8 pass | 9 pass |
| **M1** new module doing `appBlock.update` with `spendTier` | RED — `spendTier` case + appBlock write audit | RED — same two, same messages |
| **M2** comment-only mention (negative control) | green | green |
| **M3** spend reference added to `build-callback.ts` | RED — publisher-facing + `spendCapBuzzPerDay` case + write audit | RED — same three, same messages |

Every failure lands on the guard's own assertion with its own message
(`… writes appBlock and references spendTier`, `… must not reference … in code`),
not on a collateral error.

### Two controls added

- **Case count.** `it.each(SPEND_FIELDS)` shrinks silently if that list is
  trimmed. Verified: truncating it to 2 fields goes red (`expected 2 to be 3`)
  and the file drops from 9 tests to 8 — the silent shrink the control exists to
  catch.
- **Positive control on the scan.** Every other assertion here is reassured by an
  *empty list*, which a scan wired to nothing produces just as readily. This gap
  was real, not theoretical: with `stripComments` mutated to blank its input, **all
  three `it.each` cases still passed**. Now that mutation fails with `nothing was
  observed to mention spendTier in code`, as does wiring the prefilter to a token
  that matches nothing.

### Timeout

No explicit `testTimeout` added, deliberately. After the change no test body does
I/O — the bodies are 0–1ms in-memory assertions — and the scan is in the
collection phase, which Vitest does not bound at all. A per-test timeout would
bound nothing that can now be slow, so setting one would be decoration rather
than defence.

## Verification

- Full unit suite, green: **829 files / 12344 tests (12343 passed, 1 skipped), 0
  failures**. Baseline on the same tree before the change: 829 / 12343. Delta is
  exactly **+1**, the new positive control.
- `scripts/typecheck.mjs`: **0 errors** (the `event-engine-common` submodule was
  initialised, so none of the usual phantom errors appear).
- Prettier and ESLint clean on the changed file.

## Siblings

Twelve test files walk a directory tree. Two share this one's shape; neither is
at comparable risk, and both are reported rather than changed since neither is
the same one-line fix:

- `src/components/AppBlocks/__tests__/revenue-panel-wiring.test.ts` — walks all
  of `src/` and reads inside a test body, but filters to `src/components/` +
  `src/pages/` before reading. Slowest test 29ms vs this guard's 121ms.
- `src/server/utils/__tests__/client-ip-ledger.test.ts` — walks and reads
  `src/server` at **module scope**, so it is already in the untimed collection
  phase and structurally immune to this failure.

## Unrelated finding, not touched

`src/server/services/block-registry.service.ts` contains a **NUL byte** on
`main`. `grep` therefore classifies it as binary and silently reports no matches
for it — which is how my first pass concluded the authorised writer never
mentions the spend columns. It does; the guard reads bytes in JS and is
unaffected. Worth someone's attention separately, since it makes every
grep-based search over this repo quietly incomplete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
