### PR TITLE
fix(notifications): notify bounty entry owners of comments

### DIFF
--- a/src/pages/bounties/entries/[entryId].tsx
+++ b/src/pages/bounties/entries/[entryId].tsx
@@ -1,6 +1,7 @@
 import { dbRead } from '~/server/db/client';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { PageLoader } from '~/components/PageLoader/PageLoader';
+import { forwardQuery } from '~/utils/forward-query';
 
 export const getServerSideProps = createServerSideProps({
   useSSG: true,
@@ -19,22 +20,12 @@ export const getServerSideProps = createServerSideProps({
     // threadUrlMap builds `/bounties/entries/{id}?highlight=…` for every bountyEntry comment
     // notification, and a destination without the query silently drops it — so the comment the
     // notification is about never gets highlighted.
-    const { entryId: _, ...query } = ctx.query;
-    const queryString = new URLSearchParams(
-      Object.entries(query).flatMap(([key, value]) =>
-        value === undefined
-          ? []
-          : Array.isArray(value)
-          ? value.map((v) => [key, v])
-          : [[key, value]]
-      ) as [string, string][]
-    ).toString();
-
     return {
       redirect: {
-        destination: `/bounties/${bountyEntry.bountyId}/entries/${entryId}${
-          queryString ? `?${queryString}` : ''
-        }`,
+        destination: `/bounties/${bountyEntry.bountyId}/entries/${entryId}${forwardQuery(
+          ctx.query,
+          ['entryId']
+        )}`,
         permanent: false,
       },
     };

--- a/src/pages/bounties/entries/[entryId].tsx
+++ b/src/pages/bounties/entries/[entryId].tsx
@@ -16,9 +16,25 @@ export const getServerSideProps = createServerSideProps({
       return { notFound: true };
     }
 
+    // threadUrlMap builds `/bounties/entries/{id}?highlight=…` for every bountyEntry comment
+    // notification, and a destination without the query silently drops it — so the comment the
+    // notification is about never gets highlighted.
+    const { entryId: _, ...query } = ctx.query;
+    const queryString = new URLSearchParams(
+      Object.entries(query).flatMap(([key, value]) =>
+        value === undefined
+          ? []
+          : Array.isArray(value)
+          ? value.map((v) => [key, v])
+          : [[key, value]]
+      ) as [string, string][]
+    ).toString();
+
     return {
       redirect: {
-        destination: `/bounties/${bountyEntry.bountyId}/entries/${entryId}`,
+        destination: `/bounties/${bountyEntry.bountyId}/entries/${entryId}${
+          queryString ? `?${queryString}` : ''
+        }`,
         permanent: false,
       },
     };

--- a/src/server/notifications/__tests__/comment.bounty-entry-owner.test.ts
+++ b/src/server/notifications/__tests__/comment.bounty-entry-owner.test.ts
@@ -36,6 +36,13 @@ describe('new-bounty-entry-comment', () => {
     expect(sql()).toContain(`'username', u.username`);
   });
 
+  it('joins are inner, so a missing row drops the notification instead of NULLing it', () => {
+    // Every `toContain('JOIN ...')` above is also a substring of `LEFT JOIN ...`. Widening the User
+    // join would render "null commented on your entry…"; widening Bounty would produce
+    // /bounties/null/entries/9. Both pass the assertions above.
+    expect(sql()).not.toContain('LEFT JOIN');
+  });
+
   it('skips self-comments, and orphaned entries whose owner was deleted', () => {
     expect(sql()).toContain('c."userId" != be."userId"');
     // BountyEntry."userId" is nullable — NULL > 0 is NULL, so this drops orphans too.
@@ -71,10 +78,9 @@ describe('new-bounty-entry-comment', () => {
     );
   });
 
-  it('links to the canonical entry URL, not the query-dropping redirect', () => {
-    // `/bounties/entries/{id}` is a getServerSideProps redirect whose destination string carries no
-    // query, so routing the notification through it would strip `highlight` and land the reader at
-    // the top of the entry.
+  it('links to the canonical entry URL rather than the redirect', () => {
+    // threadUrlMap only gets the entry id, so it cannot build this URL — it emits the redirect form
+    // instead. Linking canonically skips the hop.
     const message = notificationProcessors['new-bounty-entry-comment'].prepareMessage({
       type: 'new-bounty-entry-comment',
       details: {

--- a/src/server/notifications/__tests__/comment.bounty-entry-owner.test.ts
+++ b/src/server/notifications/__tests__/comment.bounty-entry-owner.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CommentNotificationPriority,
+  commentNotifications,
+} from '~/server/notifications/comment.notifications';
+import { NotificationCategory } from '~/server/common/enums';
+import { notificationProcessors } from '~/server/notifications/utils.notifications';
+
+/**
+ * `bountyEntry` had a `threadUrlMap` entry but no owner processor — the same gap posts had. A comment
+ * on your bounty entry notified nobody unless you were already in the thread.
+ */
+describe('new-bounty-entry-comment', () => {
+  const sql = () =>
+    commentNotifications['new-bounty-entry-comment'].prepareQuery!({
+      lastSent: '2026-01-01',
+      lastSentDate: new Date('2026-01-01'),
+      clickhouse: undefined,
+    }) as string;
+
+  it('notifies the entry owner off the bountyEntryId thread join', () => {
+    expect(sql()).toContain(
+      'JOIN "Thread" t ON t.id = c."threadId" AND t."bountyEntryId" IS NOT NULL'
+    );
+    expect(sql()).toContain('JOIN "BountyEntry" be ON be.id = t."bountyEntryId"');
+    expect(sql()).toContain('be."userId" "ownerId"');
+  });
+
+  it('emits the detail keys prepareMessage reads, off the right rows', () => {
+    expect(sql()).toContain(`'commentId', c.id`);
+    expect(sql()).toContain('JOIN "User" u ON c."userId" = u.id');
+    expect(sql()).toContain(`'bountyEntryId', be.id`);
+    // The URL needs the parent bounty id, which only the Bounty join can supply.
+    expect(sql()).toContain(`'bountyId', b.id`);
+    expect(sql()).toContain('JOIN "Bounty" b ON b.id = be."bountyId"');
+    expect(sql()).toContain(`'username', u.username`);
+  });
+
+  it('skips self-comments, and orphaned entries whose owner was deleted', () => {
+    expect(sql()).toContain('c."userId" != be."userId"');
+    // BountyEntry."userId" is nullable — NULL > 0 is NULL, so this drops orphans too.
+    expect(sql()).toContain('be."userId" > 0');
+  });
+
+  it('floors the lookback so it can never emit the 21k-comment backlog', () => {
+    expect(sql()).toContain(`AND c."createdAt" > '2026-08-06'`);
+    // A future floor would silently disable the processor rather than fail loudly.
+    expect(new Date('2026-08-06').getTime()).toBeLessThan(Date.now());
+    expect(sql()).toContain(`AND c."createdAt" > NOW() - INTERVAL '7 days'`);
+    // Without this it re-selects every comment since the floor on every 1-minute tick.
+    expect(sql()).toContain(`AND c."createdAt" > '2026-01-01'`);
+  });
+
+  it('honors the per-user opt-out row', () => {
+    expect(sql()).toContain(
+      `NOT EXISTS (SELECT 1 FROM "UserNotificationSettings" WHERE "userId" = "ownerId" AND type = 'new-bounty-entry-comment')`
+    );
+  });
+
+  it('is registered and categorized so the settings UI can toggle it', () => {
+    const def = notificationProcessors['new-bounty-entry-comment'];
+    expect(def).toBeDefined();
+    expect(def.category).toBe(NotificationCategory.Comment);
+    expect(def.displayName).toBe('New comments on your bounty entries');
+  });
+
+  it('runs in the EntityOwner batch, behind the mention and reply processors', () => {
+    // Shares the `comment:v2:<id>` dedupe key; a lower number would outrank new-mention.
+    expect(commentNotifications['new-bounty-entry-comment'].priority).toBe(
+      CommentNotificationPriority.EntityOwner
+    );
+  });
+
+  it('links to the canonical entry URL, not the query-dropping redirect', () => {
+    // `/bounties/entries/{id}` is a getServerSideProps redirect whose destination string carries no
+    // query, so routing the notification through it would strip `highlight` and land the reader at
+    // the top of the entry.
+    const message = notificationProcessors['new-bounty-entry-comment'].prepareMessage({
+      type: 'new-bounty-entry-comment',
+      details: {
+        version: 2,
+        bountyEntryId: 9,
+        bountyId: 4,
+        bountyTitle: 'Big Bounty',
+        commentId: 42,
+        username: 'someone',
+      },
+    });
+    expect(message?.url).toBe('/bounties/4/entries/9?highlight=42');
+    expect(message?.message).toBe('someone commented on your entry to the "Big Bounty" bounty');
+  });
+});

--- a/src/server/notifications/__tests__/comment.dedupe-key.test.ts
+++ b/src/server/notifications/__tests__/comment.dedupe-key.test.ts
@@ -87,6 +87,14 @@ describe('comment notifications — shared dedupe key', () => {
     expect(sql).toContain(commentDedupeKeyByVersion);
   });
 
+  it.each(V2_TYPES)('%s stamps details.version, which routes the detail fetch', (type) => {
+    // `comment.detail-fetcher.ts` registers itself for EVERY key in commentNotifications and sends
+    // anything with `version !== 2` to the legacy `Comment` table. Comment and CommentV2 ids
+    // overlap, so a V2 processor that forgets this doesn't fail — it silently attaches a DIFFERENT
+    // comment's body, avatar and username to the notification. Nothing else guards it.
+    expect(sqlFor(type)).toContain(`'version', 2`);
+  });
+
   it('every dedupeKey is derived from commentId only — never from the recipient or the type', () => {
     // A key that varied per user or per type would dedupe nothing; this is the whole mechanism.
     for (const type of [...V1_TYPES, ...V2_TYPES, 'new-thread-response']) {

--- a/src/server/notifications/__tests__/comment.dedupe-key.test.ts
+++ b/src/server/notifications/__tests__/comment.dedupe-key.test.ts
@@ -30,6 +30,7 @@ const V2_TYPES = [
   'new-post-comment',
   'new-article-comment',
   'new-bounty-comment',
+  'new-bounty-entry-comment',
   'new-challenge-comment',
   'new-3d-model-comment',
   'new-3d-model-comment-response',
@@ -260,6 +261,8 @@ describe('a type that claims the dedupe key must render', () => {
         return [{ ...base, version: 2, articleId: 4, articleTitle: 'A' }];
       case 'new-bounty-comment':
         return [{ ...base, version: 2, bountyId: 4, bountyTitle: 'B' }];
+      case 'new-bounty-entry-comment':
+        return [{ ...base, version: 2, bountyEntryId: 9, bountyId: 4, bountyTitle: 'B' }];
       case 'new-challenge-comment':
         return [{ ...base, version: 2, challengeId: 4, challengeTitle: 'C' }];
       case 'new-comment':

--- a/src/server/notifications/comment.notifications.ts
+++ b/src/server/notifications/comment.notifications.ts
@@ -664,6 +664,57 @@ export const commentNotifications = createNotificationProcessor({
         NOT EXISTS (SELECT 1 FROM "UserNotificationSettings" WHERE "userId" = "ownerId" AND type = 'new-bounty-comment');
     `,
   },
+  'new-bounty-entry-comment': {
+    displayName: 'New comments on your bounty entries',
+    category: NotificationCategory.Comment,
+    priority: CommentNotificationPriority.EntityOwner,
+    prepareMessage: ({ details }) => ({
+      message: `${details.username} commented on your entry to the "${details.bountyTitle}" bounty`,
+      // Not threadUrlMap's `/bounties/entries/{id}`: that route is a getServerSideProps redirect to
+      // the canonical URL and the destination string drops the query, taking `highlight` with it.
+      url: `/bounties/${details.bountyId}/entries/${details.bountyEntryId}?highlight=${details.commentId}`,
+    }),
+    prepareQuery: ({ lastSent }) => `
+      WITH new_bounty_entry_comment AS (
+        SELECT DISTINCT
+          be."userId" "ownerId",
+          JSONB_BUILD_OBJECT(
+            'version', 2,
+            'bountyEntryId', be.id,
+            'bountyId', b.id,
+            'bountyTitle', b.name,
+            'commentId', c.id,
+            'username', u.username
+          ) as "details"
+        FROM "CommentV2" c
+        JOIN "User" u ON c."userId" = u.id
+        JOIN "Thread" t ON t.id = c."threadId" AND t."bountyEntryId" IS NOT NULL
+        JOIN "BountyEntry" be ON be.id = t."bountyEntryId"
+        JOIN "Bounty" b ON b.id = be."bountyId"
+        -- BountyEntry."userId" is nullable (SetNull on user delete); NULL > 0 is NULL, so this drops
+        -- orphaned entries as well as system-owned ones.
+        WHERE be."userId" > 0
+          AND c."createdAt" > '${lastSent}'
+          -- A new type has no cursor row until its first successful run, so it inherits the job's
+          -- global last-run: new Date(0) on a fresh DB, stale by the outage duration after any
+          -- send-notifications outage. There are 21,812 historical entry comments across 3,876
+          -- owners. Launch date is the guard new-bounty-comment carries; the rolling window is what
+          -- still holds once that date is behind us.
+          AND c."createdAt" > '2026-08-06'
+          AND c."createdAt" > NOW() - INTERVAL '7 days'
+          AND c."userId" != be."userId"
+      )
+      SELECT
+        concat('new-comment-bounty-entry:owner:v2:', details->>'commentId') "key",
+        ${commentDedupeKey('v2')} "dedupeKey",
+        "ownerId"    "userId",
+        'new-bounty-entry-comment' "type",
+        details
+      FROM new_bounty_entry_comment
+      WHERE
+        NOT EXISTS (SELECT 1 FROM "UserNotificationSettings" WHERE "userId" = "ownerId" AND type = 'new-bounty-entry-comment');
+    `,
+  },
   'new-challenge-comment': {
     displayName: 'New comments on your challenges',
     category: NotificationCategory.Comment,

--- a/src/server/notifications/comment.notifications.ts
+++ b/src/server/notifications/comment.notifications.ts
@@ -670,8 +670,9 @@ export const commentNotifications = createNotificationProcessor({
     priority: CommentNotificationPriority.EntityOwner,
     prepareMessage: ({ details }) => ({
       message: `${details.username} commented on your entry to the "${details.bountyTitle}" bounty`,
-      // Not threadUrlMap's `/bounties/entries/{id}`: that route is a getServerSideProps redirect to
-      // the canonical URL and the destination string drops the query, taking `highlight` with it.
+      // The canonical URL directly, rather than threadUrlMap's `/bounties/entries/{id}` — that one
+      // only reaches the entry via a redirect, and threadUrlMap can't build this form because it is
+      // handed the entry id alone, with no bountyId.
       url: `/bounties/${details.bountyId}/entries/${details.bountyEntryId}?highlight=${details.commentId}`,
     }),
     prepareQuery: ({ lastSent }) => `

--- a/src/utils/__tests__/forward-query.test.ts
+++ b/src/utils/__tests__/forward-query.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { forwardQuery } from '~/utils/forward-query';
+
+describe('forwardQuery', () => {
+  it('returns nothing when there is no query, so the destination is unchanged', () => {
+    expect(forwardQuery({})).toBe('');
+    expect(forwardQuery({ entryId: '9' }, ['entryId'])).toBe('');
+  });
+
+  it('forwards the params a redirect destination would otherwise drop', () => {
+    expect(forwardQuery({ entryId: '9', highlight: '42' }, ['entryId'])).toBe('?highlight=42');
+  });
+
+  it('drops the omitted route param even when the caller also passes it in the query', () => {
+    // Next merges route params into ctx.query, and a user can supply ?entryId= as well.
+    expect(forwardQuery({ entryId: ['9', '10'], highlight: '42' }, ['entryId'])).toBe(
+      '?highlight=42'
+    );
+  });
+
+  it('fans an array-valued param out to repeated keys', () => {
+    expect(forwardQuery({ tag: ['a', 'b'] })).toBe('?tag=a&tag=b');
+  });
+
+  it('cannot escape the path or reach the Location header', () => {
+    // The destination is a relative path built from trusted values; these are the characters that
+    // would break out of it if they survived unencoded.
+    const escaped = forwardQuery({ a: 'b#@evil.com', b: '../../x', c: 'x\r\nX-Injected: 1' });
+    expect(escaped).not.toMatch(/[#\r\n]/);
+    expect(escaped).toContain('b%23%40evil.com');
+    expect(escaped).toContain('..%2F..%2Fx');
+    expect(escaped).toContain('%0D%0A');
+  });
+
+  it('encodes rather than trusting already-encoded input', () => {
+    // Next hands back DECODED values, so re-encoding is correct, not double-encoding.
+    expect(forwardQuery({ q: 'a b' })).toBe('?q=a+b');
+    expect(forwardQuery({ q: '100%' })).toBe('?q=100%25');
+  });
+});

--- a/src/utils/forward-query.ts
+++ b/src/utils/forward-query.ts
@@ -1,0 +1,22 @@
+/**
+ * Rebuilds a request's query string for a redirect `destination`, dropping the route params that are
+ * already encoded in the new path. A Next.js `getServerSideProps` destination is used verbatim, so a
+ * path without this silently discards the query — which is how `/bounties/entries/{id}?highlight=…`
+ * was losing the comment a notification pointed at.
+ *
+ * `URLSearchParams` percent-encodes `#`, `@`, `/`, `\` and CR/LF, so a crafted param can't escape the
+ * path or reach the Location header. Callers must still build the path itself from trusted values.
+ */
+export function forwardQuery(
+  query: Record<string, string | string[] | undefined>,
+  omit: string[] = []
+) {
+  const pairs: [string, string][] = [];
+  for (const [key, value] of Object.entries(query)) {
+    if (omit.includes(key) || value === undefined) continue;
+    for (const v of Array.isArray(value) ? value : [value]) pairs.push([key, v]);
+  }
+
+  const search = new URLSearchParams(pairs).toString();
+  return search ? `?${search}` : '';
+}


### PR DESCRIPTION
Found while fixing #3691 — `bountyEntry` had the identical gap posts did.

## The gap

`bountyEntry` has a `threadUrlMap` entry (`comment.notifications.ts`) but no owner processor. Nothing joined `Thread."bountyEntryId"`, so a comment on your bounty entry notified you only if you were *already* in the thread, via `new-thread-response`. `bounty.notifications.ts` covers award / reaction-milestone / entry-created only.

Measured on prod: **21,812** historical entry comments across **3,876** distinct owners, ~26/day currently.

## The fix

`new-bounty-entry-comment`, mirroring `new-bounty-comment`:

- joins `Thread."bountyEntryId"` → `BountyEntry."userId"`, plus `Bounty` for the title (BountyEntry has no title of its own, so the message names the parent bounty for context)
- `BountyEntry."userId"` is **nullable** (`SetNull` when a user is deleted). `be."userId" > 0` drops those orphans as well as system-owned entries, since `NULL > 0` is `NULL`
- `EntityOwner` priority + the shared `comment:v2:` dedupe key, so a mention or direct reply on the same comment still outranks it
- floored the same way as #3691 (launch date + rolling 7-day window) — a new type has no `last-sent-notification-*` cursor row until its first successful run, so it inherits the job's **global** last-run, which is `new Date(0)` on a fresh DB and stale by the outage duration after any send-notifications outage. Those 21,812 rows are what sits behind that.

## Also: `/bounties/entries/[entryId]` was dropping `highlight`

That route is a `getServerSideProps` redirect to the canonical `/bounties/{bountyId}/entries/{entryId}`, and a `destination` string carries no query — so the query was silently discarded.

This is not hypothetical for this feature: **every existing** bountyEntry comment notification (`new-comment-reply`, `new-thread-response`, `new-mention`) builds its URL through `threadUrlMap`, which emits `/bounties/entries/{id}?highlight=…`. All of them have been landing readers at the top of the entry instead of on the comment. The redirect now forwards the query.

The new processor sidesteps the hop entirely and links to the canonical URL directly — it has `bountyId` from the join, which `threadUrlMap` does not (it only gets `threadParentId`).

Verified the target page honors it: `BountyEntryDiscussion` mounts `RootThreadProvider entityType="bountyEntry"`, which is the same `CommentsProvider` that reads `router.query.highlight`, forwards it as `targetCommentId`, and prepends the target to page 1 so it renders even past the cursor.

## Testing

`src/server/notifications/__tests__/comment.bounty-entry-owner.test.ts` (new), plus `new-bounty-entry-comment` wired into the `comment.dedupe-key.test.ts` matrix (v2 dedupe key, commentId-only derivation, declares a priority, renders a message + URL, distinct `key` namespace).

Every assertion was **verified by mutation** — each was confirmed to go red when the corresponding thing is broken in the source:

| Mutation | Result |
|---|---|
| `be."userId" > 0` → `IS NOT NULL` (orphan guard) | red |
| `'bountyId', b.id` → `be.id` (URL points at the wrong entity) | red |
| `priority: EntityOwner` → `Mention` (would outrank new-mention for the shared key) | red |
| URL → the query-dropping redirect route | red |

`pnpm run typecheck` 0 errors; eslint clean on touched files (1 pre-existing warning); 124 notification tests pass.

No migration. No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)