### PR TITLE
feat(model-version): gate generation-only usage control to Gold

### DIFF
--- a/apps/creator-studio/src/lib/components/BulkActionDialog.svelte
+++ b/apps/creator-studio/src/lib/components/BulkActionDialog.svelte
@@ -12,6 +12,7 @@
   import { DEFAULT_FEE_IMAGES, feeToRatio, type MonetizationLimits } from '$lib/monetization/fee';
   import {
     DEFAULT_GENERATION_TRIAL_LIMIT,
+    GENERATION_ONLY_HINT,
     MIN_ACCESS_PRICE,
     type CreatorUsageControl,
   } from '$lib/monetization/paid-access';
@@ -57,6 +58,7 @@
       maxEarlyAccessDays: number;
       earlyAccessUsed: number;
       earlyAccessCap: number;
+      canSetGenerationOnly: boolean;
     };
   } = $props();
 
@@ -407,7 +409,13 @@
               </Alert.Root>
             {/if}
           {:else if action === 'usageControl'}
-            <UsageControlPicker bind:value={usageControl} />
+            <UsageControlPicker
+              bind:value={usageControl}
+              allowGenerationOnly={caps.canSetGenerationOnly}
+            />
+            {#if !caps.canSetGenerationOnly}
+              <p class="text-xs text-dark-2">{GENERATION_ONLY_HINT}</p>
+            {/if}
             <p class="text-xs text-dark-2">
               A gated version's price moves to whichever tier survives — no version is left gated
               without a price.

--- a/apps/creator-studio/src/lib/components/PaidAccessEditor.svelte
+++ b/apps/creator-studio/src/lib/components/PaidAccessEditor.svelte
@@ -13,6 +13,7 @@
   import {
     MIN_ACCESS_PRICE,
     DEFAULT_GENERATION_TRIAL_LIMIT,
+    GENERATION_ONLY_HINT,
     monetizationLimits,
     type CreatorUsageControl,
   } from '$lib/monetization/paid-access';
@@ -191,7 +192,13 @@
     </div>
     <form method="POST" action="?/setUsageControl" use:enhance={usageEnhance}>
       <input type="hidden" name="versionId" value={version.id} />
-      <UsageControlPicker bind:value={usageControl} />
+      <UsageControlPicker
+        bind:value={usageControl}
+        allowGenerationOnly={caps.canSetGenerationOnly}
+      />
+      {#if !caps.canSetGenerationOnly}
+        <p class="mt-2 text-xs text-dark-2">{GENERATION_ONLY_HINT}</p>
+      {/if}
       {#if usageControl !== storedUsageControl}
         <div class="mt-3 flex items-center gap-3">
           <Button type="submit" size="sm">Save usage control</Button>

--- a/apps/creator-studio/src/lib/components/monetization/UsageControlPicker.svelte
+++ b/apps/creator-studio/src/lib/components/monetization/UsageControlPicker.svelte
@@ -1,28 +1,37 @@
 <script lang="ts">
-  import { CREATOR_USAGE_CONTROLS, type CreatorUsageControl } from '$lib/monetization/paid-access';
+  import {
+    CREATOR_USAGE_CONTROLS,
+    GENERATION_ONLY_HINT,
+    type CreatorUsageControl,
+  } from '$lib/monetization/paid-access';
 
   let {
     value = $bindable(),
     name = 'usageControl',
     disabled = false,
+    allowGenerationOnly = true,
   }: {
     value: CreatorUsageControl;
     name?: string;
     disabled?: boolean;
+    /** Gold-gated server-side; false greys out the gen-only option but still allows a move back to Download. */
+    allowGenerationOnly?: boolean;
   } = $props();
 </script>
 
 <input type="hidden" {name} {value} />
 <div class="grid grid-cols-2 gap-2">
   {#each CREATOR_USAGE_CONTROLS as opt (opt.value)}
+    {@const optDisabled = disabled || (!allowGenerationOnly && opt.value !== 'Download')}
     <button
       type="button"
-      {disabled}
+      disabled={optDisabled}
+      title={optDisabled && !disabled ? GENERATION_ONLY_HINT : undefined}
       onclick={() => (value = opt.value)}
       class="flex flex-col gap-1 rounded-lg border p-3 text-left transition-colors {value ===
       opt.value
         ? 'border-blue-4 bg-blue-4/10'
-        : 'border-dark-4 hover:border-dark-3'} {disabled ? 'cursor-not-allowed opacity-50' : ''}"
+        : 'border-dark-4 hover:border-dark-3'} {optDisabled ? 'cursor-not-allowed opacity-50' : ''}"
     >
       <span class="text-sm font-semibold text-white">{opt.label}</span>
       <span class="text-xs text-dark-2">{opt.hint}</span>

--- a/apps/creator-studio/src/lib/monetization/paid-access.ts
+++ b/apps/creator-studio/src/lib/monetization/paid-access.ts
@@ -96,5 +96,8 @@ export const CREATOR_USAGE_CONTROLS = [
 
 export type CreatorUsageControl = (typeof CREATOR_USAGE_CONTROLS)[number]['value'];
 
+export const GENERATION_ONLY_HINT =
+  'On-site-generation-only resources require a Gold membership.';
+
 export const isCreatorUsageControl = (v: unknown): v is CreatorUsageControl =>
   CREATOR_USAGE_CONTROLS.some((o) => o.value === v);

--- a/apps/creator-studio/src/lib/server/__tests__/membership.test.ts
+++ b/apps/creator-studio/src/lib/server/__tests__/membership.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import type { SessionUser } from '@civitai/auth';
+import { canSetGenerationOnly } from '../membership';
+
+const user = (over: Partial<SessionUser> = {}) => ({ id: 1, ...over }) as SessionUser;
+
+describe('canSetGenerationOnly', () => {
+  it('denies an anonymous caller', () => {
+    expect(canSetGenerationOnly(undefined)).toBe(false);
+  });
+
+  it('denies a free creator', () => {
+    expect(canSetGenerationOnly(user())).toBe(false);
+  });
+
+  it('denies bronze and silver', () => {
+    expect(canSetGenerationOnly(user({ tier: 'bronze' }))).toBe(false);
+    expect(canSetGenerationOnly(user({ tier: 'silver' }))).toBe(false);
+  });
+
+  it('allows gold', () => {
+    expect(canSetGenerationOnly(user({ tier: 'gold' }))).toBe(true);
+  });
+
+  it('allows a moderator on any tier', () => {
+    expect(canSetGenerationOnly(user({ isModerator: true }))).toBe(true);
+  });
+
+  it('allows an explicit generationOnlyModels grant', () => {
+    expect(canSetGenerationOnly(user({ permissions: ['generationOnlyModels'] }))).toBe(true);
+  });
+
+  it('does not treat an unrelated permission as a grant', () => {
+    expect(canSetGenerationOnly(user({ permissions: ['creatorsProgram'] }))).toBe(false);
+  });
+});

--- a/apps/creator-studio/src/lib/server/generation-only.ts
+++ b/apps/creator-studio/src/lib/server/generation-only.ts
@@ -1,0 +1,28 @@
+import type { SessionUser } from '@civitai/auth';
+import { sql } from '@civitai/db/kysely';
+import { dbRead } from '$lib/server/db';
+import { canSetGenerationOnly, tierGrantsGenerationOnly } from '$lib/server/membership';
+
+// The session tier lags a membership change, so a creator who just upgraded would be refused here while
+// the main app — which re-resolves the feature flag off the fresh subscription tier — accepts them. The
+// DB read only happens when the session already says no: the answer can only go from false to true.
+//
+// Split from membership.ts so that file stays free of a db import; its unit tests load it directly.
+export async function canSetGenerationOnlyFresh(user: SessionUser | undefined): Promise<boolean> {
+  if (!user) return false;
+  if (canSetGenerationOnly(user)) return true;
+  return tierGrantsGenerationOnly(await freshSubscriptionTier(user.id));
+}
+
+// Mirrors the main app's getCapTier: the tier on a subscription still in good standing. Keep the status
+// list in step with subscriptions.service.
+async function freshSubscriptionTier(userId: number): Promise<string | null> {
+  const row = await dbRead
+    .selectFrom('CustomerSubscription as cs')
+    .innerJoin('Product as p', 'p.id', 'cs.productId')
+    .select(sql<string | null>`p.metadata->>'tier'`.as('tier'))
+    .where('cs.userId', '=', userId)
+    .where('cs.status', 'not in', ['canceled', 'incomplete_expired', 'past_due', 'unpaid'])
+    .executeTakeFirst();
+  return row?.tier ?? null;
+}

--- a/apps/creator-studio/src/lib/server/membership.ts
+++ b/apps/creator-studio/src/lib/server/membership.ts
@@ -53,6 +53,10 @@ export function canSetGenerationOnly(user: SessionUser | undefined): boolean {
   return GENERATION_ONLY_TIERS.includes(user.tier ?? '');
 }
 
+export function tierGrantsGenerationOnly(tier: string | null | undefined): boolean {
+  return GENERATION_ONLY_TIERS.includes(tier ?? '');
+}
+
 // No subscription and the 'free' tier are the same thing everywhere — both resolve to 'free', so neither
 // the caps nor the UI ever needs to tell them apart.
 export const displayTier = (m: Membership): string => m.tier ?? 'free';

--- a/apps/creator-studio/src/lib/server/membership.ts
+++ b/apps/creator-studio/src/lib/server/membership.ts
@@ -39,6 +39,20 @@ export function resolveMembership(user: SessionUser | undefined, testCookie?: st
 // Monetization is open to every creator, free tier included (CU 868kj4q49 / 868kj4q4j) — membership decides
 // only HOW MUCH, via maxLicensingFee / maxPaidAccessPrice.
 
+// Usage control is NOT open like monetization is: a non-Download control needs the main app's
+// `generationOnlyModels` feature, whose availability is ['mod', 'granted', 'gold']. Restated here rather
+// than imported because the flag registry lives in the main app and this spoke writes the column directly
+// — if that availability list changes, this has to change with it (CU 868kmy9f3).
+const GENERATION_ONLY_TIERS = ['gold'];
+const GENERATION_ONLY_PERMISSION = 'generationOnlyModels';
+
+export function canSetGenerationOnly(user: SessionUser | undefined): boolean {
+  if (!user) return false;
+  if (user.isModerator) return true;
+  if (user.permissions?.includes(GENERATION_ONLY_PERMISSION)) return true;
+  return GENERATION_ONLY_TIERS.includes(user.tier ?? '');
+}
+
 // No subscription and the 'free' tier are the same thing everywhere — both resolve to 'free', so neither
 // the caps nor the UI ever needs to tell them apart.
 export const displayTier = (m: Membership): string => m.tier ?? 'free';
@@ -59,4 +73,6 @@ export type CreatorCaps = {
   maxEarlyAccessDays: number;
   earlyAccessUsed: number;
   earlyAccessCap: number;
+  /** Whether the creator may move a version off Download — see canSetGenerationOnly. */
+  canSetGenerationOnly: boolean;
 };

--- a/apps/creator-studio/src/lib/server/monetization/paid-access.ts
+++ b/apps/creator-studio/src/lib/server/monetization/paid-access.ts
@@ -11,7 +11,11 @@ import { env } from '$env/dynamic/private';
 import { dbRead, dbWrite } from '$lib/server/db';
 import { mapWithConcurrency, MAIN_APP_WRITE_CONCURRENCY } from '$lib/server/concurrency';
 import { checkbox, optionalBuzz, freePreviewsField } from './form-fields';
-import { isCreatorUsageControl, type CreatorUsageControl } from '$lib/monetization/paid-access';
+import {
+  GENERATION_ONLY_HINT,
+  isCreatorUsageControl,
+  type CreatorUsageControl,
+} from '$lib/monetization/paid-access';
 import type { PaidAccessConfig } from '$lib/monetization/paid-access';
 
 // Paid access is written through the MAIN APP, not kysely: the write has real
@@ -466,17 +470,47 @@ export async function versionsLosingFreeGeneration(userId: number, versionIds: n
     .execute();
 }
 
+/**
+ * A non-Download usage control needs the main app's `generationOnlyModels` entitlement — but only to
+ * MOVE a version off Download. The editor resubmits the stored usage control on every save (including
+ * when clearing paid access), so rejecting outright would make an existing generation-only version
+ * uneditable for a creator who doesn't hold the entitlement — the same stranding this file already
+ * avoids for over-cap prices. Only a version currently on Download is a new grant.
+ */
+async function deniesGenerationOnly(
+  userId: number,
+  versionIds: number[],
+  usageControl: CreatorUsageControl,
+  canSetGenerationOnly: boolean
+): Promise<boolean> {
+  if (usageControl === 'Download' || canSetGenerationOnly) return false;
+  const row = await dbRead
+    .selectFrom('ModelVersion as mv')
+    .innerJoin('Model as m', 'm.id', 'mv.modelId')
+    .where('m.userId', '=', userId)
+    .where('m.deletedAt', 'is', null)
+    .where('mv.id', 'in', versionIds)
+    .where('mv.usageControl', '=', 'Download')
+    .select((eb) => eb.fn.countAll<string>().as('count'))
+    .executeTakeFirst();
+  return Number(row?.count ?? 0) > 0;
+}
+
 export async function bulkSetUsageControl(
   userId: number,
   versionIds: number[],
   usageControl: CreatorUsageControl,
-  cookie: string
+  cookie: string,
+  canSetGenerationOnly: boolean
 ): Promise<
   | { ok: true; updated: number; migrated: number; migrationFailures: number }
   | { ok: false; status: number; error: string }
 > {
   if (versionIds.length === 0)
     return { ok: false, status: 400, error: 'Select at least one version.' };
+
+  if (await deniesGenerationOnly(userId, versionIds, usageControl, canSetGenerationOnly))
+    return { ok: false, status: 403, error: GENERATION_ONLY_HINT };
 
   const gates = await readGates(versionIds);
   const migrations = planUsageControlMigrations(gates, usageControl);
@@ -544,8 +578,12 @@ export async function bulkSetUsageControl(
 export async function setUsageControl(
   userId: number,
   versionId: number,
-  usageControl: CreatorUsageControl
-): Promise<boolean> {
+  usageControl: CreatorUsageControl,
+  canSetGenerationOnly: boolean
+): Promise<{ ok: true; updated: boolean } | { ok: false; status: number; error: string }> {
+  if (await deniesGenerationOnly(userId, [versionId], usageControl, canSetGenerationOnly))
+    return { ok: false, status: 403, error: GENERATION_ONLY_HINT };
+
   const result = await dbWrite
     .updateTable('ModelVersion')
     .set({ usageControl })
@@ -558,7 +596,7 @@ export async function setUsageControl(
         .where('deletedAt', 'is', null)
     )
     .executeTakeFirst();
-  return Number(result.numUpdatedRows ?? 0) > 0;
+  return { ok: true, updated: Number(result.numUpdatedRows ?? 0) > 0 };
 }
 
 export async function isVersionPermanent(versionId: number): Promise<boolean> {

--- a/apps/creator-studio/src/routes/(app)/models/+page.server.ts
+++ b/apps/creator-studio/src/routes/(app)/models/+page.server.ts
@@ -11,7 +11,6 @@ import {
 import {
   resolveMembership,
   cappedTier,
-  canSetGenerationOnly,
   displayTier,
   TEST_MEMBERSHIP_COOKIE,
 } from '$lib/server/membership';
@@ -45,6 +44,7 @@ import {
   freePreviewsField,
 } from '$lib/server/monetization/form-fields';
 import { resolveModelsScore, TEST_MODELS_SCORE_COOKIE } from '$lib/server/creator-score';
+import { canSetGenerationOnlyFresh } from '$lib/server/generation-only';
 import {
   earlyAccessDaysForScore,
   earlyAccessQuantityForScore,
@@ -157,7 +157,7 @@ export const load: PageServerLoad = async ({ locals, parent, url, cookies }) => 
       maxEarlyAccessDays: earlyAccessDaysForScore(modelsScore),
       earlyAccessUsed,
       earlyAccessCap: earlyAccessQuantityForScore(modelsScore),
-      canSetGenerationOnly: canSetGenerationOnly(locals.user),
+      canSetGenerationOnly: await canSetGenerationOnlyFresh(locals.user),
     },
     query: {
       q: q ?? '',
@@ -431,7 +431,7 @@ export const actions: Actions = {
       versionIds.data,
       usageControl,
       cookie,
-      canSetGenerationOnly(locals.user)
+      await canSetGenerationOnlyFresh(locals.user)
     );
     if (!result.ok) return fail(result.status, { bulk: true, error: result.error });
     await bustVersionCache(cookie, versionIds.data);
@@ -463,7 +463,7 @@ export const actions: Actions = {
       [versionId.data],
       usageControl,
       request.headers.get('cookie') ?? '',
-      canSetGenerationOnly(locals.user)
+      await canSetGenerationOnlyFresh(locals.user)
     );
     if (!result.ok) return fail(result.status, { versionId: versionId.data, error: result.error });
     if (result.updated === 0)
@@ -499,7 +499,7 @@ export const actions: Actions = {
           locals.user.id,
           versionId.data,
           usageOnly,
-          canSetGenerationOnly(locals.user)
+          await canSetGenerationOnlyFresh(locals.user)
         );
         if (!usageResult.ok)
           return fail(usageResult.status, { versionId: versionId.data, error: usageResult.error });
@@ -548,7 +548,7 @@ export const actions: Actions = {
         locals.user.id,
         versionId.data,
         usageControl,
-        canSetGenerationOnly(locals.user)
+        await canSetGenerationOnlyFresh(locals.user)
       );
       if (!usageResult.ok)
         return fail(usageResult.status, { versionId: versionId.data, error: usageResult.error });

--- a/apps/creator-studio/src/routes/(app)/models/+page.server.ts
+++ b/apps/creator-studio/src/routes/(app)/models/+page.server.ts
@@ -11,6 +11,7 @@ import {
 import {
   resolveMembership,
   cappedTier,
+  canSetGenerationOnly,
   displayTier,
   TEST_MEMBERSHIP_COOKIE,
 } from '$lib/server/membership';
@@ -156,6 +157,7 @@ export const load: PageServerLoad = async ({ locals, parent, url, cookies }) => 
       maxEarlyAccessDays: earlyAccessDaysForScore(modelsScore),
       earlyAccessUsed,
       earlyAccessCap: earlyAccessQuantityForScore(modelsScore),
+      canSetGenerationOnly: canSetGenerationOnly(locals.user),
     },
     query: {
       q: q ?? '',
@@ -424,7 +426,13 @@ export const actions: Actions = {
       return fail(400, { bulk: true, error: 'Invalid usage control.' });
 
     const cookie = request.headers.get('cookie') ?? '';
-    const result = await bulkSetUsageControl(locals.user.id, versionIds.data, usageControl, cookie);
+    const result = await bulkSetUsageControl(
+      locals.user.id,
+      versionIds.data,
+      usageControl,
+      cookie,
+      canSetGenerationOnly(locals.user)
+    );
     if (!result.ok) return fail(result.status, { bulk: true, error: result.error });
     await bustVersionCache(cookie, versionIds.data);
     return {
@@ -454,7 +462,8 @@ export const actions: Actions = {
       locals.user.id,
       [versionId.data],
       usageControl,
-      request.headers.get('cookie') ?? ''
+      request.headers.get('cookie') ?? '',
+      canSetGenerationOnly(locals.user)
     );
     if (!result.ok) return fail(result.status, { versionId: versionId.data, error: result.error });
     if (result.updated === 0)
@@ -485,8 +494,16 @@ export const actions: Actions = {
       (!permanent && (!Number.isFinite(rawTimeframe) || rawTimeframe <= 0));
     if (turnOff) {
       const usageOnly = form.get('usageControl');
-      if (isCreatorUsageControl(usageOnly))
-        await setUsageControl(locals.user.id, versionId.data, usageOnly);
+      if (isCreatorUsageControl(usageOnly)) {
+        const usageResult = await setUsageControl(
+          locals.user.id,
+          versionId.data,
+          usageOnly,
+          canSetGenerationOnly(locals.user)
+        );
+        if (!usageResult.ok)
+          return fail(usageResult.status, { versionId: versionId.data, error: usageResult.error });
+      }
       const result = await setPaidAccessConfig(cookie, versionId.data, null);
       if (!result.ok)
         return fail(result.status, { versionId: versionId.data, error: result.error });
@@ -526,8 +543,16 @@ export const actions: Actions = {
     const genOnly = usageControl === 'Generation';
     // Persisted BEFORE the gate write: the main-app endpoint validates the terms against the STORED
     // usage control, so a gen-only save would otherwise be judged against the old Download value.
-    if (isCreatorUsageControl(usageControl))
-      await setUsageControl(locals.user.id, versionId.data, usageControl);
+    if (isCreatorUsageControl(usageControl)) {
+      const usageResult = await setUsageControl(
+        locals.user.id,
+        versionId.data,
+        usageControl,
+        canSetGenerationOnly(locals.user)
+      );
+      if (!usageResult.ok)
+        return fail(usageResult.status, { versionId: versionId.data, error: usageResult.error });
+    }
 
     // Only an INCREASE is rejected: the editor resubmits the stored price on every save, so capping the
     // submitted value outright would make an over-cap version uneditable after a lapse (the same class of

--- a/src/server/controllers/model-version.controller.ts
+++ b/src/server/controllers/model-version.controller.ts
@@ -9,6 +9,8 @@ import { getCapTier } from '~/server/services/subscriptions.service';
 import { selectLiveLinkedComponents } from '~/server/utils/model-helpers';
 import { resolveGenerationOnlyGate } from '~/server/utils/model-version-usage-control';
 import { logToAxiom } from '~/server/logging/client';
+import { getFeatureFlagsLazy, userTiers } from '~/server/services/feature-flags.service';
+import type { SessionUser } from '~/types/session';
 import type { BaseModelType } from '~/server/common/constants';
 import { type BaseModel, DEPRECATED_BASE_MODELS } from '~/shared/constants/basemodel.constants';
 import { baseModelLicenses, constants } from '~/server/common/constants';
@@ -363,6 +365,9 @@ export const toggleNotifyEarlyAccessHandler = async ({
   }
 };
 
+const asUserTier = (tier: string | null): SessionUser['tier'] =>
+  (userTiers as readonly string[]).includes(tier ?? '') ? (tier as SessionUser['tier']) : undefined;
+
 export const upsertModelVersionHandler = async ({
   input: { bountyId, ...input },
   ctx,
@@ -386,8 +391,11 @@ export const upsertModelVersionHandler = async ({
     // only how much may be charged. Read fresh (not off the session) so a lapse applies immediately, and
     // memoized because the usage-control audit, paid-access and licensing-fee checks all need it:
     // getAllUserSubscriptions is uncached and hits the primary.
-    let capTier: string | null | undefined;
-    const actorTier = async () => (capTier ??= await getCapTier(ctx.user.id));
+    // Memoize the PROMISE, not the value: getCapTier returns null for anyone without a good-standing
+    // subscription, and `??=` re-assigns on null — so the users this gate denies would re-run an uncached
+    // primary-DB query on every call.
+    let capTierPromise: Promise<string | null> | undefined;
+    const actorTier = () => (capTierPromise ??= getCapTier(ctx.user.id));
 
     // Only MOVING a version off Download is a new grant, matching the Creator Studio rule. Coercing on
     // every non-Download save would strip generation-only from the versions whose owners aren't entitled
@@ -414,9 +422,20 @@ export const upsertModelVersionHandler = async ({
 
     if (grantsGenerationOnly) {
       const requestedUsageControl = input.usageControl;
+      // `ctx.features` resolves off the SESSION tier, which lags a membership change, so a creator who
+      // just upgraded is denied something they now pay for. Re-evaluate the SAME flag with the fresh
+      // subscription tier rather than comparing the tier ourselves: env overrides (the deploy-free kill
+      // switch), region rules and domain gating all still apply, and the availability list stays the one
+      // source of truth for which tiers qualify.
+      const hasFeature =
+        !!ctx.features.generationOnlyModels ||
+        !!getFeatureFlagsLazy({
+          user: { ...ctx.user, tier: asUserTier(await actorTier()) },
+          req: ctx.req,
+        }).generationOnlyModels;
       const gate = resolveGenerationOnlyGate({
         requested: requestedUsageControl,
-        hasFeature: !!ctx.features.generationOnlyModels,
+        hasFeature,
         isModerator: !!ctx.user.isModerator,
         permissions: ctx.user.permissions,
       });
@@ -437,7 +456,8 @@ export const upsertModelVersionHandler = async ({
         storedUsageControl: storedUsageControl ?? null,
         appliedUsageControl: input.usageControl ?? null,
         sessionTier: ctx.user.tier ?? null,
-        subscriptionTier: gate.outcome === 'tier' ? await actorTier() : null,
+        subscriptionTier:
+          gate.outcome === 'tier' || gate.outcome === 'denied' ? await actorTier() : null,
       }).catch(() => null);
     }
 

--- a/src/server/controllers/model-version.controller.ts
+++ b/src/server/controllers/model-version.controller.ts
@@ -7,6 +7,8 @@ import {
 } from '~/server/services/paid-access.service';
 import { getCapTier } from '~/server/services/subscriptions.service';
 import { selectLiveLinkedComponents } from '~/server/utils/model-helpers';
+import { resolveGenerationOnlyGate } from '~/server/utils/model-version-usage-control';
+import { logToAxiom } from '~/server/logging/client';
 import type { BaseModelType } from '~/server/common/constants';
 import { type BaseModel, DEPRECATED_BASE_MODELS } from '~/shared/constants/basemodel.constants';
 import { baseModelLicenses, constants } from '~/server/common/constants';
@@ -380,9 +382,39 @@ export const upsertModelVersionHandler = async ({
       );
     }
 
-    if (!ctx.features.generationOnlyModels && input.usageControl !== ModelUsageControl.Download) {
-      // People without access to thje generationOnlyModels feature can only create download models
-      input.usageControl = ModelUsageControl.Download;
+    // Monetization is open to every creator, free tier included (CU 868kj4q49 / 868kj4q4j) — the tier caps
+    // only how much may be charged. Read fresh (not off the session) so a lapse applies immediately, and
+    // memoized because the usage-control audit, paid-access and licensing-fee checks all need it:
+    // getAllUserSubscriptions is uncached and hits the primary.
+    let capTier: string | null | undefined;
+    const actorTier = async () => (capTier ??= await getCapTier(ctx.user.id));
+
+    if (input.usageControl !== ModelUsageControl.Download) {
+      const requestedUsageControl = input.usageControl;
+      const gate = resolveGenerationOnlyGate({
+        requested: requestedUsageControl,
+        hasFeature: !!ctx.features.generationOnlyModels,
+        isModerator: !!ctx.user.isModerator,
+        permissions: ctx.user.permissions,
+      });
+      input.usageControl = gate.usageControl;
+
+      // The gate coerces instead of rejecting, so a write that passes on the wrong branch produces no
+      // record anywhere. Emit the deciding branch, and on the membership branch the fresh subscription
+      // tier next to the session one — ctx.features resolves off the session tier, which lags a
+      // membership change (CU 868kmy9f3).
+      logToAxiom({
+        name: 'model-version-usage-control-gate',
+        type: 'info',
+        outcome: gate.outcome,
+        userId,
+        modelId: input.modelId,
+        modelVersionId: input.id ?? null,
+        requestedUsageControl: requestedUsageControl ?? null,
+        appliedUsageControl: input.usageControl ?? null,
+        sessionTier: ctx.user.tier ?? null,
+        subscriptionTier: gate.outcome === 'tier' ? await actorTier() : null,
+      }).catch(() => null);
     }
 
     if (input.usageControl === ModelUsageControl.InternalGeneration && !ctx.user.isModerator) {
@@ -396,13 +428,6 @@ export const upsertModelVersionHandler = async ({
     if (input.trainingDetails === null) {
       input.trainingDetails = undefined;
     }
-
-    // Monetization is open to every creator, free tier included (CU 868kj4q49 / 868kj4q4j) — the tier caps
-    // only how much may be charged. Read fresh (not off the session) so a lapse applies immediately, and
-    // memoized because both the paid-access and licensing-fee checks need it: getAllUserSubscriptions is
-    // uncached and hits the primary.
-    let capTier: string | null | undefined;
-    const actorTier = async () => (capTier ??= await getCapTier(ctx.user.id));
 
     await assertPaidAccessCaps({
       userId: ctx.user.id,

--- a/src/server/controllers/model-version.controller.ts
+++ b/src/server/controllers/model-version.controller.ts
@@ -389,7 +389,30 @@ export const upsertModelVersionHandler = async ({
     let capTier: string | null | undefined;
     const actorTier = async () => (capTier ??= await getCapTier(ctx.user.id));
 
-    if (input.usageControl !== ModelUsageControl.Download) {
+    // Only MOVING a version off Download is a new grant, matching the Creator Studio rule. Coercing on
+    // every non-Download save would strip generation-only from the versions whose owners aren't entitled
+    // — silently, on an unrelated edit, since the form resubmits the stored control and an absent one
+    // also lands here.
+    //
+    // A templated write creates a NEW version even with an `id` present, so `id` alone is not "the row
+    // this lands on" — reading the stored control off it would let one generation-only version vouch for
+    // unlimited new ones. Same trap resolveRightsAffirmation documents in the service.
+    const updatesExistingVersion = !!input.id && !input.templateId;
+    // dbWrite, and a miss counts as a grant: this decides an entitlement, and the edit wizard saves again
+    // fast enough to beat replication — a replica miss must not read as "already generation-only".
+    const storedUsageControl = updatesExistingVersion
+      ? (
+          await dbWrite.modelVersion.findUnique({
+            where: { id: input.id },
+            select: { usageControl: true },
+          })
+        )?.usageControl
+      : undefined;
+    const grantsGenerationOnly =
+      input.usageControl !== ModelUsageControl.Download &&
+      (!updatesExistingVersion || storedUsageControl !== ModelUsageControl.Generation);
+
+    if (grantsGenerationOnly) {
       const requestedUsageControl = input.usageControl;
       const gate = resolveGenerationOnlyGate({
         requested: requestedUsageControl,
@@ -411,6 +434,7 @@ export const upsertModelVersionHandler = async ({
         modelId: input.modelId,
         modelVersionId: input.id ?? null,
         requestedUsageControl: requestedUsageControl ?? null,
+        storedUsageControl: storedUsageControl ?? null,
         appliedUsageControl: input.usageControl ?? null,
         sessionTier: ctx.user.tier ?? null,
         subscriptionTier: gate.outcome === 'tier' ? await actorTier() : null,

--- a/src/server/utils/__tests__/model-version-usage-control.test.ts
+++ b/src/server/utils/__tests__/model-version-usage-control.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { resolveGenerationOnlyGate } from '~/server/utils/model-version-usage-control';
+import { ModelUsageControl } from '~/shared/utils/prisma/enums';
+
+const base = {
+  requested: ModelUsageControl.Generation,
+  hasFeature: true,
+  isModerator: false,
+  permissions: undefined as string[] | undefined,
+};
+
+describe('resolveGenerationOnlyGate', () => {
+  it('coerces to Download when the feature is absent', () => {
+    const result = resolveGenerationOnlyGate({ ...base, hasFeature: false });
+    expect(result).toEqual({ usageControl: ModelUsageControl.Download, outcome: 'denied' });
+  });
+
+  it('coerces an absent usage control to Download when the feature is absent', () => {
+    const result = resolveGenerationOnlyGate({
+      ...base,
+      requested: undefined,
+      hasFeature: false,
+    });
+    expect(result.usageControl).toBe(ModelUsageControl.Download);
+  });
+
+  it('keeps the requested control and reports the moderator branch', () => {
+    const result = resolveGenerationOnlyGate({ ...base, isModerator: true });
+    expect(result).toEqual({ usageControl: ModelUsageControl.Generation, outcome: 'moderator' });
+  });
+
+  it('reports the granted branch for an explicit permission grant', () => {
+    const result = resolveGenerationOnlyGate({ ...base, permissions: ['generationOnlyModels'] });
+    expect(result).toEqual({ usageControl: ModelUsageControl.Generation, outcome: 'granted' });
+  });
+
+  it('reports the membership branch when neither moderator nor granted', () => {
+    const result = resolveGenerationOnlyGate(base);
+    expect(result).toEqual({ usageControl: ModelUsageControl.Generation, outcome: 'tier' });
+  });
+
+  it('prefers the moderator branch over an unrelated permission list', () => {
+    const result = resolveGenerationOnlyGate({
+      ...base,
+      isModerator: true,
+      permissions: ['someOtherFeature'],
+    });
+    expect(result.outcome).toBe('moderator');
+  });
+
+  it('does not treat an unrelated permission as a grant', () => {
+    const result = resolveGenerationOnlyGate({ ...base, permissions: ['someOtherFeature'] });
+    expect(result.outcome).toBe('tier');
+  });
+});

--- a/src/server/utils/model-version-usage-control.ts
+++ b/src/server/utils/model-version-usage-control.ts
@@ -1,0 +1,38 @@
+import { ModelUsageControl } from '~/shared/utils/prisma/enums';
+
+export const GENERATION_ONLY_FEATURE_KEY = 'generationOnlyModels';
+
+/**
+ * Which branch of the `generationOnlyModels` gate let a non-Download usage control through.
+ * `tier` is the branch that resolves off the SESSION's tier value, so it is the only outcome
+ * whose correctness depends on how fresh that session is.
+ */
+export type GenerationOnlyGateOutcome = 'moderator' | 'granted' | 'tier' | 'denied';
+
+/**
+ * Decide the usage control a non-Download request may keep. Callers must only invoke this when
+ * the requested control is not `Download` — an absent control counts as non-Download, matching
+ * the write path (an unset control on an update would otherwise leave a stored gen-only value in
+ * place).
+ */
+export function resolveGenerationOnlyGate({
+  requested,
+  hasFeature,
+  isModerator,
+  permissions,
+}: {
+  requested: ModelUsageControl | undefined;
+  hasFeature: boolean;
+  isModerator: boolean;
+  permissions?: string[];
+}): { usageControl: ModelUsageControl | undefined; outcome: GenerationOnlyGateOutcome } {
+  if (!hasFeature) return { usageControl: ModelUsageControl.Download, outcome: 'denied' };
+
+  const outcome: GenerationOnlyGateOutcome = isModerator
+    ? 'moderator'
+    : permissions?.includes(GENERATION_ONLY_FEATURE_KEY)
+    ? 'granted'
+    : 'tier';
+
+  return { usageControl: requested, outcome };
+}


### PR DESCRIPTION
Non-Download usage control now requires the `generationOnlyModels` entitlement (moderator, explicit grant, or Gold tier) in both the main-app upsert path and Creator Studio, which previously let any creator set it. The gate coerces rather than rejects and logs the deciding branch to Axiom, since `ctx.features` resolves off the session tier and can lag a membership change; Creator Studio only blocks moves off Download so existing generation-only versions stay editable.