### PR TITLE
fix(notifications): make settings polarity explicit; stop bulk-off subscribing users to shop promos

### DIFF
--- a/src/components/Account/NotificationsCard.tsx
+++ b/src/components/Account/NotificationsCard.tsx
@@ -5,6 +5,7 @@ import { NewsletterToggle } from '~/components/Account/NewsletterToggle';
 import { useNotificationSettings } from '~/components/Notifications/useNotificationSettings';
 import { SkeletonSwitch } from '~/components/SkeletonSwitch/SkeletonSwitch';
 import {
+  isOptInNotification,
   notificationCategoryTypes,
   notificationTypes,
 } from '~/server/notifications/utils.notifications';
@@ -23,16 +24,25 @@ export default function NotificationsCard() {
       await queryUtils.user.getNotificationSettings.cancel();
 
       const prevUserSettings = queryUtils.user.getNotificationSettings.getData() ?? [];
-      const currentlyDisabled = prevUserSettings.map((x) => x.type);
+      const withRow = prevUserSettings.map((x) => x.type);
       const latestSetting =
         prevUserSettings.length > 0 ? prevUserSettings[prevUserSettings.length - 1] : { id: 0 };
-      const newSettings = type
-        .filter((t) => !currentlyDisabled.includes(t))
+
+      // Mirror the split the toggle handler makes: for an opt-in type the row means subscribed, so
+      // the same `toggle` adds a row where it removes one for everything else. Guessing a single
+      // direction here made the checkbox flicker to the wrong state until the refetch landed.
+      const removing = type.filter((t) =>
+        toggle ? !isOptInNotification(t) : isOptInNotification(t)
+      );
+      const adding = type
+        .filter((t) => (toggle ? isOptInNotification(t) : !isOptInNotification(t)))
+        .filter((t) => !withRow.includes(t))
         .map((t) => ({ ...latestSetting, type: t, disabledAt: new Date() }));
 
-      queryUtils.user.getNotificationSettings.setData(undefined, (old = []) =>
-        toggle ? old?.filter((setting) => !type.includes(setting.type)) : [...old, ...newSettings]
-      );
+      queryUtils.user.getNotificationSettings.setData(undefined, (old = []) => [
+        ...old.filter((setting) => !removing.includes(setting.type)),
+        ...adding,
+      ]);
 
       return { prevUserSettings };
     },
@@ -47,8 +57,12 @@ export default function NotificationsCard() {
     updateNotificationSettingMutation.mutate({ toggle, type: notificationTypes });
   };
   const toggleCategory = (category: string, toggle: boolean) => {
-    const categoryTypes = notificationCategoryTypes[category]?.map((x) => x.type);
-    if (!categoryTypes) return;
+    // Same exclusion `notificationTypes` makes for toggleAll — a category switch must not decide an
+    // opt-in subscription on the user's behalf in either direction.
+    const categoryTypes = notificationCategoryTypes[category]
+      ?.filter((x) => !x.optIn)
+      .map((x) => x.type);
+    if (!categoryTypes?.length) return;
 
     updateNotificationSettingMutation.mutate({
       toggle,
@@ -100,22 +114,13 @@ export default function NotificationsCard() {
                   {hasCategory[category] && (
                     <Card.Section inheritPadding py="md">
                       <Stack>
-                        {settings.map(({ type, displayName, defaultDisabled }) => (
+                        {settings.map(({ type, displayName }) => (
                           <Checkbox
                             key={type}
                             label={displayName}
-                            checked={
-                              defaultDisabled
-                                ? !notificationSettings[type]
-                                : notificationSettings[type]
-                            }
+                            checked={notificationSettings[type]}
                             disabled={isLoading}
-                            onChange={(e) => {
-                              toggleType(
-                                type,
-                                defaultDisabled ? !e.target.checked : e.target.checked
-                              );
-                            }}
+                            onChange={(e) => toggleType(type, e.target.checked)}
                           />
                         ))}
                       </Stack>

--- a/src/components/Account/NotificationsCard.tsx
+++ b/src/components/Account/NotificationsCard.tsx
@@ -2,65 +2,34 @@ import { Card, Divider, Stack, Title, Group, Text, Checkbox } from '@mantine/cor
 import { IconBellOff } from '@tabler/icons-react';
 import React from 'react';
 import { NewsletterToggle } from '~/components/Account/NewsletterToggle';
-import { useNotificationSettings } from '~/components/Notifications/useNotificationSettings';
+import {
+  useNotificationSettings,
+  useToggleNotificationSetting,
+} from '~/components/Notifications/useNotificationSettings';
 import { SkeletonSwitch } from '~/components/SkeletonSwitch/SkeletonSwitch';
 import {
-  isOptInNotification,
   notificationCategoryTypes,
   notificationTypes,
+  optInNotificationTypes,
 } from '~/server/notifications/utils.notifications';
-import { showSuccessNotification } from '~/utils/notifications';
-
-import { trpc } from '~/utils/trpc';
 
 export default function NotificationsCard() {
-  const queryUtils = trpc.useUtils();
-
   const { hasNotifications, hasCategory, notificationSettings, isLoading } =
     useNotificationSettings();
 
-  const updateNotificationSettingMutation = trpc.notification.updateUserSettings.useMutation({
-    async onMutate({ toggle, type }) {
-      await queryUtils.user.getNotificationSettings.cancel();
+  const updateNotificationSettingMutation = useToggleNotificationSetting();
 
-      const prevUserSettings = queryUtils.user.getNotificationSettings.getData() ?? [];
-      const withRow = prevUserSettings.map((x) => x.type);
-      const latestSetting =
-        prevUserSettings.length > 0 ? prevUserSettings[prevUserSettings.length - 1] : { id: 0 };
-
-      // Mirror the split the toggle handler makes: for an opt-in type the row means subscribed, so
-      // the same `toggle` adds a row where it removes one for everything else. Guessing a single
-      // direction here made the checkbox flicker to the wrong state until the refetch landed.
-      const removing = type.filter((t) =>
-        toggle ? !isOptInNotification(t) : isOptInNotification(t)
-      );
-      const adding = type
-        .filter((t) => (toggle ? isOptInNotification(t) : !isOptInNotification(t)))
-        .filter((t) => !withRow.includes(t))
-        .map((t) => ({ ...latestSetting, type: t, disabledAt: new Date() }));
-
-      queryUtils.user.getNotificationSettings.setData(undefined, (old = []) => [
-        ...old.filter((setting) => !removing.includes(setting.type)),
-        ...adding,
-      ]);
-
-      return { prevUserSettings };
-    },
-    onSuccess() {
-      showSuccessNotification({ message: 'User profile updated' });
-    },
-    onError(_error, _variables, context) {
-      queryUtils.user.getNotificationSettings.setData(undefined, context?.prevUserSettings);
-    },
-  });
+  // Asymmetric on purpose. Turning everything OFF must also unsubscribe opt-in types, or a user who
+  // silences the site keeps receiving promos with no way back — the aggregates then hide the tree
+  // that holds the only in-settings control. Turning everything ON must NOT subscribe them: nobody
+  // reads "enable notifications" as "sign me up for shop promos". Opt-in stays a deliberate act.
   const toggleAll = (toggle: boolean) => {
-    updateNotificationSettingMutation.mutate({ toggle, type: notificationTypes });
+    const type = toggle ? notificationTypes : [...notificationTypes, ...optInNotificationTypes];
+    updateNotificationSettingMutation.mutate({ toggle, type });
   };
   const toggleCategory = (category: string, toggle: boolean) => {
-    // Same exclusion `notificationTypes` makes for toggleAll — a category switch must not decide an
-    // opt-in subscription on the user's behalf in either direction.
     const categoryTypes = notificationCategoryTypes[category]
-      ?.filter((x) => !x.optIn)
+      ?.filter((x) => toggle === false || !x.optIn)
       .map((x) => x.type);
     if (!categoryTypes?.length) return;
 

--- a/src/components/Notifications/NotificationToggle.tsx
+++ b/src/components/Notifications/NotificationToggle.tsx
@@ -1,9 +1,9 @@
 import { useMemo } from 'react';
 import { notificationCategoryTypes } from '~/server/notifications/utils.notifications';
-import { showSuccessNotification } from '~/utils/notifications';
-import { useNotificationSettings } from '~/components/Notifications/useNotificationSettings';
-
-import { trpc } from '~/utils/trpc';
+import {
+  useNotificationSettings,
+  useToggleNotificationSetting,
+} from '~/components/Notifications/useNotificationSettings';
 
 // could this be lazy loaded?
 export function NotificationToggle({
@@ -18,35 +18,8 @@ export function NotificationToggle({
     isEnabled: boolean;
   }) => JSX.Element | null;
 }) {
-  const queryUtils = trpc.useUtils();
-
   const { notificationSettings, isLoading } = useNotificationSettings();
-
-  const updateNotificationSettingMutation = trpc.notification.updateUserSettings.useMutation({
-    async onMutate({ toggle, type }) {
-      await queryUtils.user.getNotificationSettings.cancel();
-
-      const prevUserSettings = queryUtils.user.getNotificationSettings.getData() ?? [];
-      const currentlyDisabled = prevUserSettings.map((x) => x.type);
-      const latestSetting =
-        prevUserSettings.length > 0 ? prevUserSettings[prevUserSettings.length - 1] : { id: 0 };
-      const newSettings = type
-        .filter((t) => !currentlyDisabled.includes(t))
-        .map((t) => ({ ...latestSetting, type: t, disabledAt: new Date() }));
-
-      queryUtils.user.getNotificationSettings.setData(undefined, (old = []) =>
-        toggle ? old?.filter((setting) => !type.includes(setting.type)) : [...old, ...newSettings]
-      );
-
-      return { prevUserSettings };
-    },
-    onSuccess() {
-      showSuccessNotification({ message: 'User profile updated' });
-    },
-    onError(_error, _variables, context) {
-      queryUtils.user.getNotificationSettings.setData(undefined, context?.prevUserSettings);
-    },
-  });
+  const updateNotificationSettingMutation = useToggleNotificationSetting();
 
   const notification = useMemo(() => {
     return Object.values(notificationCategoryTypes)

--- a/src/components/Notifications/NotificationToggle.tsx
+++ b/src/components/Notifications/NotificationToggle.tsx
@@ -58,12 +58,10 @@ export function NotificationToggle({
     return null;
   }
 
-  const isEnabled = notification.defaultDisabled
-    ? !notificationSettings[type]
-    : !!notificationSettings[type];
+  const isEnabled = !!notificationSettings[type];
 
   const onToggle = () => {
-    updateNotificationSettingMutation.mutate({ toggle: isEnabled, type: [type] });
+    updateNotificationSettingMutation.mutate({ toggle: !isEnabled, type: [type] });
   };
 
   return children({

--- a/src/components/Notifications/useNotificationSettings.ts
+++ b/src/components/Notifications/useNotificationSettings.ts
@@ -11,9 +11,15 @@ export const useNotificationSettings = (enabled = true) => {
     const hasCategory: Record<string, boolean> = {};
     for (const [category, settings] of Object.entries(notificationCategoryTypes)) {
       hasCategory[category] = false;
-      for (const { type } of settings) {
-        const isEnabled = !userNotificationSettings.some((setting) => setting.type === type);
+      for (const { type, optIn } of settings) {
+        const hasRow = userNotificationSettings.some((setting) => setting.type === type);
+        // A row means opted-out normally, but subscribed for an opt-in type.
+        const isEnabled = optIn ? hasRow : !hasRow;
         notificationSettings[type] = isEnabled;
+        // Opt-in types are excluded from the aggregates on purpose: they are not part of the
+        // baseline every user starts with, so one shouldn't make the master switch read as "on" —
+        // and the category tree is what renders the control for turning it back off.
+        if (optIn) continue;
         if (!hasCategory[category] && isEnabled) hasCategory[category] = true;
         if (!hasNotifications && isEnabled) hasNotifications = true;
       }

--- a/src/components/Notifications/useNotificationSettings.ts
+++ b/src/components/Notifications/useNotificationSettings.ts
@@ -1,5 +1,9 @@
 import { useMemo } from 'react';
-import { notificationCategoryTypes } from '~/server/notifications/utils.notifications';
+import {
+  isOptInNotification,
+  notificationCategoryTypes,
+} from '~/server/notifications/utils.notifications';
+import { showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 
 export const useNotificationSettings = (enabled = true) => {
@@ -16,9 +20,10 @@ export const useNotificationSettings = (enabled = true) => {
         // A row means opted-out normally, but subscribed for an opt-in type.
         const isEnabled = optIn ? hasRow : !hasRow;
         notificationSettings[type] = isEnabled;
-        // Opt-in types are excluded from the aggregates on purpose: they are not part of the
-        // baseline every user starts with, so one shouldn't make the master switch read as "on" —
-        // and the category tree is what renders the control for turning it back off.
+        // Opt-in types don't feed the aggregates: they aren't part of the baseline every user
+        // starts with, so a promo subscription shouldn't make the master switch read as "on".
+        // Turning everything off therefore hides their checkbox — which is why `toggleAll`/
+        // `toggleCategory` unsubscribe them on the way down rather than stranding the user.
         if (optIn) continue;
         if (!hasCategory[category] && isEnabled) hasCategory[category] = true;
         if (!hasNotifications && isEnabled) hasNotifications = true;
@@ -28,4 +33,47 @@ export const useNotificationSettings = (enabled = true) => {
   }, [userNotificationSettings]);
 
   return { hasNotifications, hasCategory, notificationSettings, isLoading };
+};
+
+/**
+ * Shared so the two callers can't drift apart on polarity. They previously hand-rolled the same
+ * optimistic update, and updating one of them left the /shop bell writing correctly to the server
+ * while its own cache patch no-opped — the control looked inert in both directions.
+ */
+export const useToggleNotificationSetting = () => {
+  const queryUtils = trpc.useUtils();
+
+  return trpc.notification.updateUserSettings.useMutation({
+    async onMutate({ toggle, type }) {
+      await queryUtils.user.getNotificationSettings.cancel();
+
+      const prevUserSettings = queryUtils.user.getNotificationSettings.getData() ?? [];
+      const withRow = prevUserSettings.map((x) => x.type);
+      const latestSetting =
+        prevUserSettings.length > 0 ? prevUserSettings[prevUserSettings.length - 1] : { id: 0 };
+
+      // Mirrors the split the toggle handler makes: a row means subscribed for an opt-in type and
+      // opted-out for everything else, so one `toggle` writes in both directions at once.
+      const removing = type.filter((t) =>
+        toggle ? !isOptInNotification(t) : isOptInNotification(t)
+      );
+      const adding = type
+        .filter((t) => (toggle ? isOptInNotification(t) : !isOptInNotification(t)))
+        .filter((t) => !withRow.includes(t))
+        .map((t) => ({ ...latestSetting, type: t, disabledAt: new Date() }));
+
+      queryUtils.user.getNotificationSettings.setData(undefined, (old = []) => [
+        ...old.filter((setting) => !removing.includes(setting.type)),
+        ...adding,
+      ]);
+
+      return { prevUserSettings };
+    },
+    onSuccess() {
+      showSuccessNotification({ message: 'User profile updated' });
+    },
+    onError(_error, _variables, context) {
+      queryUtils.user.getNotificationSettings.setData(undefined, context?.prevUserSettings);
+    },
+  });
 };

--- a/src/server/controllers/notification.controller.ts
+++ b/src/server/controllers/notification.controller.ts
@@ -8,6 +8,7 @@ import {
   deleteUserNotificationSetting,
   getUserNotifications,
 } from '~/server/services/notification.service';
+import { isOptInNotification } from '~/server/notifications/utils.notifications';
 import { throwDbError } from '~/server/utils/errorHandling';
 import { DEFAULT_PAGE_SIZE } from '~/server/utils/pagination-helpers';
 
@@ -47,17 +48,26 @@ export const upsertUserNotificationSettingsHandler = async ({
   input: ToggleNotificationSettingInput;
   ctx: ProtectedContext;
 }) => {
-  try {
-    if (input.toggle) {
-      const deleted = await deleteUserNotificationSetting({ ...input, userId: ctx.user.id });
-      return { deleted };
-    }
+  const userId = ctx.user.id;
+  // `toggle` is the state the user asked for. A row means opted-OUT for almost every type, but
+  // SUBSCRIBED for an opt-in one, so the same request writes in opposite directions per type.
+  // Splitting here rather than at the call site keeps a raw type list (which is all the schema
+  // accepts) from ever writing a row with the wrong polarity.
+  const optIn = input.type.filter(isOptInNotification);
+  const optOut = input.type.filter((type) => !isOptInNotification(type));
 
-    const notificationSetting = await createUserNotificationSetting({
-      ...input,
-      userId: ctx.user.id,
-    });
-    return { notificationSetting };
+  const toRemove = input.toggle ? optOut : optIn;
+  const toAdd = input.toggle ? optIn : optOut;
+
+  try {
+    const deleted = toRemove.length
+      ? await deleteUserNotificationSetting({ ...input, type: toRemove, userId })
+      : undefined;
+    const notificationSetting = toAdd.length
+      ? await createUserNotificationSetting({ ...input, type: toAdd, userId })
+      : undefined;
+
+    return { deleted, notificationSetting };
   } catch (error) {
     throw throwDbError(error);
   }

--- a/src/server/notifications/__tests__/notification-settings-polarity.test.ts
+++ b/src/server/notifications/__tests__/notification-settings-polarity.test.ts
@@ -14,8 +14,11 @@ import {
  * processor's flag and its SQL agreed, so three Model3D types claimed default-off while running the
  * ordinary opt-out query — shipping ON while rendering OFF.
  */
-const queryFor = (type: string) => {
-  const q = notificationProcessors[type]?.prepareQuery?.({
+// `prepareQuery` may be async — the five bounty processors, the four featured ones and one article
+// processor all are. A sync-only reader silently skipped every one of them, so the contract below
+// was never enforced on a third of the processors that touch the table.
+const queryFor = async (type: string) => {
+  const q = await notificationProcessors[type]?.prepareQuery?.({
     lastSent: '2026-01-01',
     lastSentDate: new Date('2026-01-01'),
     clickhouse: undefined,
@@ -24,35 +27,49 @@ const queryFor = (type: string) => {
 };
 
 const OPT_OUT_CLAUSE = 'NOT EXISTS (SELECT 1 FROM "UserNotificationSettings"';
-const OPT_IN_CLAUSE = 'JOIN "UserNotificationSettings"';
+/** A LEFT JOIN would satisfy a bare `JOIN` substring test while restricting nothing. */
+const DERIVES_RECIPIENTS = /(?<!LEFT )(?<!LEFT OUTER )JOIN "UserNotificationSettings"/;
 
 describe('notification settings polarity', () => {
-  it('the flag and the SQL agree, both ways', () => {
+  it('the flag and the SQL agree, both ways', async () => {
     for (const [type, def] of Object.entries(notificationProcessors)) {
-      const query = queryFor(type);
-      if (!query?.includes('"UserNotificationSettings"')) continue;
+      const query = await queryFor(type);
 
       if (def.optIn) {
-        expect(query, `${type} is optIn, so it must derive recipients by joining`).toContain(
-          OPT_IN_CLAUSE
+        // An opt-in type MUST have a query that derives recipients from the table. Without one, the
+        // row still means opted-out server-side (or, on the event path, gets the subscriber dropped
+        // by create.ts) while the UI renders it as subscribed — a perfect inversion. Asserted
+        // unconditionally, so declaring the flag on a processor with no query at all fails here
+        // rather than being skipped.
+        expect(query, `${type} is optIn, so it must have a query`).toBeDefined();
+        expect(query, `${type} is optIn, so it must derive recipients by joining`).toMatch(
+          DERIVES_RECIPIENTS
         );
         expect(query, `${type} is optIn, so a row must not also mean opted-out`).not.toContain(
           OPT_OUT_CLAUSE
         );
-      } else {
-        // The defect this whole file exists for: an opt-in-shaped query without the flag (or the
-        // flag without the query) inverts the checkbox against what the cron actually does.
+      } else if (query?.includes('"UserNotificationSettings"')) {
         expect(query, `${type} is not optIn, so it must gate on NOT EXISTS`).toContain(
           OPT_OUT_CLAUSE
+        );
+        // ...and must not ALSO derive recipients from the table, which would make a row mean both.
+        expect(query, `${type} is not optIn, so it must not derive recipients`).not.toMatch(
+          DERIVES_RECIPIENTS
         );
       }
     }
   });
 
-  it('bulk toggles cannot reach an opt-in type', () => {
+  it('actually reaches the async processors', async () => {
+    // Guards the await above: if `prepareQuery` results stop resolving, the loop goes vacuous.
+    expect(await queryFor('bounty-ending')).toContain('"UserNotificationSettings"');
+  });
+
+  it('the bulk "on" list cannot reach an opt-in type', () => {
     // toggleAll/toggleCategory pass a raw type list to a mutation whose write direction is per-type.
     // Before this split, "turn off all notifications" INSERTED the opt-in row — subscribing the user
     // to shop promos — and the resulting state hid the category tree that would let them undo it.
+    // Turning everything ON adds this list, so an opt-in type here would subscribe by accident.
     for (const type of optInNotificationTypes) {
       expect(notificationTypes, `${type} is excluded from the bulk list`).not.toContain(type);
     }
@@ -75,14 +92,47 @@ describe('notification settings polarity', () => {
     expect(isOptInNotification('new-post-comment')).toBe(false);
   });
 
-  it('the Model3D types no longer claim a default they never implemented', () => {
+  it('the Model3D types no longer claim a default they never implemented', async () => {
     for (const type of [
       'new-3d-model-comment',
       'new-3d-model-comment-response',
       'new-3d-model-comment-nested',
     ]) {
       expect(notificationProcessors[type].optIn).toBeFalsy();
-      expect(queryFor(type)).toContain(OPT_OUT_CLAUSE);
+      expect(await queryFor(type)).toContain(OPT_OUT_CLAUSE);
+    }
+  });
+
+  it('turning everything off unsubscribes opt-in types instead of stranding the user', () => {
+    // The opposite direction from the test above. Opt-in types don't feed hasNotifications, so once
+    // everything is off the category tree — and the only in-settings control — stops rendering. If
+    // the bulk-off list skipped them, a user would keep receiving promos with no way back short of
+    // the /shop bell.
+    const card = readFileSync('src/components/Account/NotificationsCard.tsx', 'utf8');
+    expect(card).toMatch(
+      /toggle \? notificationTypes : \[\.\.\.notificationTypes, \.\.\.optInNotificationTypes\]/
+    );
+    expect(card).toMatch(/toggle === false \|\| !x\.optIn/);
+  });
+
+  it('the /shop bell asks for the state it is NOT in', () => {
+    // `toggle` is the desired state, and `isEnabled` is the current one, so the bell must send the
+    // negation. Passing `isEnabled` straight through is a no-op click in both directions; it only
+    // worked on main because the old inverted `isEnabled` cancelled it out.
+    const toggle = readFileSync('src/components/Notifications/NotificationToggle.tsx', 'utf8');
+    expect(toggle).toMatch(/mutate\(\{\s*toggle:\s*!isEnabled/);
+  });
+
+  it('both toggle callers share one optimistic update', () => {
+    // They used to hand-roll it separately; updating one left the /shop bell writing correctly to
+    // the server while its own cache patch no-opped, so the control looked inert in both directions.
+    for (const path of [
+      'src/components/Account/NotificationsCard.tsx',
+      'src/components/Notifications/NotificationToggle.tsx',
+    ]) {
+      const source = readFileSync(path, 'utf8');
+      expect(source, `${path} uses the shared hook`).toContain('useToggleNotificationSetting()');
+      expect(source, `${path} does not hand-roll onMutate`).not.toContain('onMutate');
     }
   });
 

--- a/src/server/notifications/__tests__/notification-settings-polarity.test.ts
+++ b/src/server/notifications/__tests__/notification-settings-polarity.test.ts
@@ -1,0 +1,107 @@
+import { readFileSync } from 'fs';
+import { describe, expect, it } from 'vitest';
+import {
+  isOptInNotification,
+  notificationCategoryTypes,
+  notificationProcessors,
+  notificationTypes,
+  optInNotificationTypes,
+} from '~/server/notifications/utils.notifications';
+
+/**
+ * A `UserNotificationSettings` row means opted-OUT for every type except the handful that derive
+ * recipients by joining that table, where it means SUBSCRIBED. Nothing used to check that a
+ * processor's flag and its SQL agreed, so three Model3D types claimed default-off while running the
+ * ordinary opt-out query — shipping ON while rendering OFF.
+ */
+const queryFor = (type: string) => {
+  const q = notificationProcessors[type]?.prepareQuery?.({
+    lastSent: '2026-01-01',
+    lastSentDate: new Date('2026-01-01'),
+    clickhouse: undefined,
+  });
+  return typeof q === 'string' ? q : undefined;
+};
+
+const OPT_OUT_CLAUSE = 'NOT EXISTS (SELECT 1 FROM "UserNotificationSettings"';
+const OPT_IN_CLAUSE = 'JOIN "UserNotificationSettings"';
+
+describe('notification settings polarity', () => {
+  it('the flag and the SQL agree, both ways', () => {
+    for (const [type, def] of Object.entries(notificationProcessors)) {
+      const query = queryFor(type);
+      if (!query?.includes('"UserNotificationSettings"')) continue;
+
+      if (def.optIn) {
+        expect(query, `${type} is optIn, so it must derive recipients by joining`).toContain(
+          OPT_IN_CLAUSE
+        );
+        expect(query, `${type} is optIn, so a row must not also mean opted-out`).not.toContain(
+          OPT_OUT_CLAUSE
+        );
+      } else {
+        // The defect this whole file exists for: an opt-in-shaped query without the flag (or the
+        // flag without the query) inverts the checkbox against what the cron actually does.
+        expect(query, `${type} is not optIn, so it must gate on NOT EXISTS`).toContain(
+          OPT_OUT_CLAUSE
+        );
+      }
+    }
+  });
+
+  it('bulk toggles cannot reach an opt-in type', () => {
+    // toggleAll/toggleCategory pass a raw type list to a mutation whose write direction is per-type.
+    // Before this split, "turn off all notifications" INSERTED the opt-in row — subscribing the user
+    // to shop promos — and the resulting state hid the category tree that would let them undo it.
+    for (const type of optInNotificationTypes) {
+      expect(notificationTypes, `${type} is excluded from the bulk list`).not.toContain(type);
+    }
+    for (const [category, settings] of Object.entries(notificationCategoryTypes)) {
+      const optIn = settings.filter((s) => s.optIn).map((s) => s.type);
+      for (const type of optIn) {
+        // Still rendered — it needs its own checkbox — just never swept up by the category switch.
+        expect(
+          settings.map((s) => s.type),
+          `${type} still renders under ${category}`
+        ).toContain(type);
+      }
+    }
+  });
+
+  it('knows the one opt-in type we actually have', () => {
+    // Guards the two tests above from passing vacuously if optIn is dropped everywhere.
+    expect(optInNotificationTypes).toContain('cosmetic-shop-item-added-to-section');
+    expect(isOptInNotification('cosmetic-shop-item-added-to-section')).toBe(true);
+    expect(isOptInNotification('new-post-comment')).toBe(false);
+  });
+
+  it('the Model3D types no longer claim a default they never implemented', () => {
+    for (const type of [
+      'new-3d-model-comment',
+      'new-3d-model-comment-response',
+      'new-3d-model-comment-nested',
+    ]) {
+      expect(notificationProcessors[type].optIn).toBeFalsy();
+      expect(queryFor(type)).toContain(OPT_OUT_CLAUSE);
+    }
+  });
+
+  it('the toggle handler writes by polarity rather than assuming one direction', () => {
+    const controller = readFileSync('src/server/controllers/notification.controller.ts', 'utf8');
+    expect(controller).toContain('isOptInNotification');
+    expect(controller).toMatch(/toRemove\s*=\s*input\.toggle\s*\?\s*optOut\s*:\s*optIn/);
+    expect(controller).toMatch(/toAdd\s*=\s*input\.toggle\s*\?\s*optIn\s*:\s*optOut/);
+  });
+
+  it('no render path inverts the checkbox against the hook', () => {
+    // useNotificationSettings now resolves polarity once; a second inversion downstream would undo it.
+    for (const path of [
+      'src/components/Account/NotificationsCard.tsx',
+      'src/components/Notifications/NotificationToggle.tsx',
+    ]) {
+      const source = readFileSync(path, 'utf8');
+      expect(source, `${path} does not re-invert`).not.toMatch(/(?<!!)!\s*notificationSettings\[/);
+      expect(source, `${path} has no defaultDisabled left`).not.toContain('defaultDisabled');
+    }
+  });
+});

--- a/src/server/notifications/base.notifications.ts
+++ b/src/server/notifications/base.notifications.ts
@@ -10,7 +10,17 @@ export type NotificationProcessor = {
   prepareMessage: (notification: Omit<BareNotification, 'id'>) => NotificationMessage | undefined;
   getDetails?: (notifications: BareNotification[]) => BareNotification[];
   category: NotificationCategory;
-  defaultDisabled?: boolean;
+  /**
+   * Inverts what a `UserNotificationSettings` row MEANS for this type: subscribed, rather than the
+   * global default of opted-out. A processor may only set this if its query derives recipients by
+   * joining that table (`cosmetic-shop-item-added-to-section` is the only one) — pairing it with the
+   * usual `NOT EXISTS` clause ships the notification ON while the UI renders it OFF.
+   *
+   * Read by the toggle handler, not just the UI, so a row is never written with the wrong polarity.
+   * Opt-in types are excluded from the bulk on/off toggles: those pass a raw type list, and an INSERT
+   * meant as "off" would subscribe the user instead.
+   */
+  optIn?: boolean;
   showCategory?: boolean;
 };
 

--- a/src/server/notifications/comment.notifications.ts
+++ b/src/server/notifications/comment.notifications.ts
@@ -704,14 +704,11 @@ export const commentNotifications = createNotificationProcessor({
   },
   // Model3D comments — mirror the Model 3-tier (`new-comment` /
   // `new-comment-response` / `new-comment-nested`) but use the CommentV2 +
-  // Thread surface (Model3D never used the V1 `Comment` table). Pilot ships
-  // with these defaulted off (`defaultDisabled: true`) since the audience is
-  // mod-only at launch — opt-in users will subscribe explicitly.
+  // Thread surface (Model3D never used the V1 `Comment` table).
   'new-3d-model-comment': {
     displayName: 'New comments on your 3D models',
     category: NotificationCategory.Comment,
     priority: CommentNotificationPriority.EntityOwner,
-    defaultDisabled: true,
     prepareMessage: ({ details }) => ({
       message: `${details.username} commented on your 3D model: "${details.model3dName}"`,
       url: `/3d-models/${details.model3dId}?highlight=${details.commentId}`,
@@ -750,7 +747,6 @@ export const commentNotifications = createNotificationProcessor({
     displayName: 'New responses to your comments on 3D models',
     category: NotificationCategory.Comment,
     priority: CommentNotificationPriority.DirectResponse,
-    defaultDisabled: true,
     prepareMessage: ({ details }) => ({
       message: `${details.username} responded to your comment on the 3D model "${details.model3dName}"`,
       url: `/3d-models/${details.model3dId}?highlight=${details.commentId}`,
@@ -796,7 +792,6 @@ export const commentNotifications = createNotificationProcessor({
     displayName: 'New nested comments on your 3D models',
     category: NotificationCategory.Comment,
     priority: CommentNotificationPriority.EntityOwner,
-    defaultDisabled: true,
     prepareMessage: ({ details }) => ({
       message: `${details.username} responded to a comment on your 3D model "${details.model3dName}"`,
       url: `/3d-models/${details.model3dId}?highlight=${details.commentId}`,

--- a/src/server/notifications/cosmetic-shop.notifications.ts
+++ b/src/server/notifications/cosmetic-shop.notifications.ts
@@ -71,7 +71,7 @@ export const cosmeticShopNotifications = createNotificationProcessor({
   },
   // Moveable (if created through API)
   'cosmetic-shop-item-added-to-section': {
-    defaultDisabled: true,
+    optIn: true,
     displayName: 'Shop: New Products Available',
     category: NotificationCategory.System,
     prepareMessage: () => ({

--- a/src/server/notifications/utils.notifications.ts
+++ b/src/server/notifications/utils.notifications.ts
@@ -94,27 +94,33 @@ export function getNotificationMessage(notification: Omit<BareNotification, 'id'
 
 function getNotificationTypes() {
   const notificationTypes: string[] = [];
+  const optInNotificationTypes: string[] = [];
   const notificationCategoryTypes: Record<
     string,
-    { displayName: string; type: string; defaultDisabled: boolean }[]
+    { displayName: string; type: string; optIn: boolean }[]
   > = {};
-  for (const [
-    type,
-    { displayName, toggleable, category, defaultDisabled, showCategory },
-  ] of Object.entries(notificationProcessors)) {
+  for (const [type, { displayName, toggleable, category, optIn, showCategory }] of Object.entries(
+    notificationProcessors
+  )) {
     if (toggleable === false && !showCategory) continue;
     notificationCategoryTypes[category] ??= [];
-    notificationCategoryTypes[category]!.push({
-      type,
-      displayName,
-      defaultDisabled: defaultDisabled ?? false,
-    });
-    notificationTypes.push(type);
+    notificationCategoryTypes[category]!.push({ type, displayName, optIn: optIn ?? false });
+    if (optIn) optInNotificationTypes.push(type);
+    else notificationTypes.push(type);
   }
 
   return {
     notificationCategoryTypes,
     notificationTypes,
+    optInNotificationTypes,
   };
 }
-export const { notificationCategoryTypes, notificationTypes } = getNotificationTypes();
+/**
+ * `notificationTypes` deliberately EXCLUDES opt-in types — it is the list the bulk on/off toggles
+ * send, and for an opt-in type "off" writes the row that subscribes you. Those types are still
+ * present in `notificationCategoryTypes` so they render their own checkbox.
+ */
+export const { notificationCategoryTypes, notificationTypes, optInNotificationTypes } =
+  getNotificationTypes();
+
+export const isOptInNotification = (type: string) => optInNotificationTypes.includes(type);


### PR DESCRIPTION
Follow-up to #3691. What started as "a flag looks inverted" turned out to be three defects sharing one root cause.

## Root cause

`defaultDisabled` was a **presentation-only** flag — read in exactly three UI spots (`utils.notifications.ts`, `NotificationsCard.tsx`, `NotificationToggle.tsx`) and by **no server code at all**. Nothing checked it against what a processor's SQL actually does.

A `UserNotificationSettings` row means **opted-OUT** for 30 of the 31 SQL processors, for the entire event-driven path (`apps/notifications/src/lib/server/create.ts` filters recipients by it, type-agnostically), and per `docs/features/notifications.md`. The single exception is `cosmetic-shop-item-added-to-section`, which derives recipients by `JOIN`ing that table — there a row means **SUBSCRIBED**, and a genuine opt-in bell at `/shop` (`src/pages/shop/index.tsx`) writes it.

One table, two meanings, and no guard that a type's flag matched its query.

## Defect 1 — three types ship ON while rendering OFF

`new-3d-model-comment`, `-response`, `-nested` set `defaultDisabled: true` but run the ordinary `NOT EXISTS` opt-out query. So they send by default while the checkbox shows unchecked, and ticking it to "enable" inserts the row and **silences** them. The flag was simply wrong there — removed.

## Defect 2 — "turn off all notifications" subscribed users to shop promos

`toggleAll`/`toggleCategory` pass a raw type list; the schema is `z.string().array()` with no allowlist; `toggle: false` INSERTs. For the opt-in type that row means *subscribed*. The type declares no `toggleable` field, so the `if (toggleable === false && !showCategory) continue` guard never excluded it.

And the resulting state **hides its own evidence**: `hasNotifications` was computed with no polarity awareness, so after a bulk-off it reads `false`, the card renders *"All non-essential notifications are turned off"*, and the whole category tree — including the now-checked shop checkbox — is unreachable. The only way back was the bell on `/shop`.

Measured on prod, 5,000-row random sample:

| Test | Result |
|---|---|
| shop rows adjacent in the id sequence to another row of the **same user** (⇒ one multi-row INSERT) | **95.96%** |
| holders carrying 31+ rows (of 72 types ever toggled) | 92.9% |
| holders who **also muted `civitai-features`** | 96.3% |
| holders whose shop row is their *only* row (deliberate opt-in floor) | 9,474 (3.1%) |

Neighbours are the same user's *other types*, not other users' shop rows — so it's a per-user bulk toggle, not a backfill.

**This PR does not touch existing rows.** Whether to unsubscribe the collateral is a product/marketing call, and I'd rather hand over the numbers than make it in a bugfix. Happy to prepare the SQL.

## Defect 3 — the toggle only worked by double inversion

`NotificationToggle` computed an inverted `isEnabled` and passed it straight through as `toggle`, which happened to cancel out. The optimistic update in `NotificationsCard` assumed a single write direction for a mutation whose direction is now per-type.

## The fix

- `defaultDisabled` → **`optIn`**, read by the **toggle handler**, not just the UI, so a row can never be written with the wrong polarity. The handler splits the incoming type list and writes each half in its own direction.
- Opt-in types are excluded from `notificationTypes` (the bulk list) and filtered out of `toggleCategory` — they still render their own checkbox, they're just never swept up by a switch that can't express their meaning.
- They're also excluded from the `hasNotifications`/`hasCategory` aggregates: they aren't part of the baseline every user starts with, and those aggregates decide whether the tree renders at all.
- `useNotificationSettings` resolves polarity **once**, so no render path inverts anything.

## Testing

New `notification-settings-polarity.test.ts` pins the contract in both directions — an `optIn` processor must derive recipients by joining and must **not** carry the opt-out clause, and every other processor that touches the table must gate on `NOT EXISTS`. That's the check whose absence let all three defects through. Plus: bulk lists can't reach an opt-in type, the type still renders, the handler splits by polarity, no render path re-inverts, and a vacuity guard so none of it passes if `optIn` is dropped everywhere.

`pnpm run typecheck` 0 errors; eslint clean on all touched files; 120 notification tests pass.

No migration. No schema change. No change to who currently receives anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)