### PR TITLE
App Blocks BLOCK_INIT v2: always correlate the token reply, add viewer.signedIn, deprecate init-time identity

### DIFF
--- a/docs/features/app-blocks.md
+++ b/docs/features/app-blocks.md
@@ -180,7 +180,7 @@ the deprecation covers one:
 1. `viewer.id` / `viewer.username` — deprecated (this section).
 2. `context.viewerUserId` / `context.viewerUsername` — **full-page surface only.**
    `PageBlockHost` does not project its context, so `BLOCK_INIT.context` on the
-   `app.page` surface still carries both verbatim. (The model-slot host *does*
+   `app.page` surface still carries both verbatim. (The model-slot host _does_
    project, and drops both.) Those page-context fields are deprecated too, but
    nothing has been removed from the wire.
 3. `token.raw` — **both surfaces, undeprecated, and not going away.** The block
@@ -188,7 +188,7 @@ the deprecation covers one:
    `user:<id>` for a signed-in viewer (see "Tokens" above), so any block can read
    the viewer's numeric id by base64url-decoding a value it was handed — no
    scope, no round-trip, and nothing server-side can observe that it did. This is
-   not a bug to be closed: the token *is* the auth mechanism and the block needs
+   not a bug to be closed: the token _is_ the auth mechanism and the block needs
    it.
 
 So what the deprecation actually buys is narrower than "identity is no longer

--- a/docs/features/app-blocks.md
+++ b/docs/features/app-blocks.md
@@ -165,19 +165,40 @@ never appears.
 `viewer.id` / `viewer.username` are **deprecated but still sent, and will keep
 being sent**. Deprecated because identity reaches the block unconditionally at
 load, before the viewer has interacted with it, with nothing recording that it
-happened; the replacement is the scope-gated, per-call-audited `GET_VIEWER`
-message (`blocks.getMyViewer`), which requires the block to ask. Still sent
-because the `isValidBlockInitPayload` guard compiled into already-deployed
-bundles **rejects the whole payload** without a numeric `viewer.id` — removing it
-would blank every deployed block at once. Same story for `blockId` / `appId`.
+happened; the replacement is `GET_VIEWER` (`blocks.getMyViewer`), which requires
+the block to **ask** — a round-trip gated on the block having declared and been
+granted the `user:read:self` scope, self-bound to the token subject, and
+rate-limited per block instance. Still sent because the `isValidBlockInitPayload`
+guard compiled into already-deployed bundles **rejects the whole payload** without
+a numeric `viewer.id` — removing it would blank every deployed block at once.
+Same story for `blockId` / `appId`.
 
-⚠️ **The deprecation does NOT reduce what a full-page app sees today.**
-`PageBlockHost` does not project its context: `BLOCK_INIT.context` on the
-`app.page` surface still carries `viewerUserId` and `viewerUsername`, an
-undeprecated second channel carrying the same identity. (The model-slot host
-*does* project and drops both.) Those page-context fields are deprecated too —
-treat `GET_VIEWER` as the supported way to learn who the viewer is on either
-surface — but nothing has been removed from the wire.
+⚠️ **Deprecating those two fields does not end identity disclosure — on either
+surface.** A BLOCK_INIT carries viewer identity through **three** channels, and
+the deprecation covers one:
+
+1. `viewer.id` / `viewer.username` — deprecated (this section).
+2. `context.viewerUserId` / `context.viewerUsername` — **full-page surface only.**
+   `PageBlockHost` does not project its context, so `BLOCK_INIT.context` on the
+   `app.page` surface still carries both verbatim. (The model-slot host *does*
+   project, and drops both.) Those page-context fields are deprecated too, but
+   nothing has been removed from the wire.
+3. `token.raw` — **both surfaces, undeprecated, and not going away.** The block
+   token is a plain RS256 JWT, not an opaque handle: its `sub` claim is
+   `user:<id>` for a signed-in viewer (see "Tokens" above), so any block can read
+   the viewer's numeric id by base64url-decoding a value it was handed — no
+   scope, no round-trip, and nothing server-side can observe that it did. This is
+   not a bug to be closed: the token *is* the auth mechanism and the block needs
+   it.
+
+So what the deprecation actually buys is narrower than "identity is no longer
+disclosed": on the model slot it removes the **username** from the unconditional
+payload (the token's `sub` carries only the id), and on both surfaces it turns a
+convenient typed field read into a deliberate JWT decode. The token discloses on
+exactly the same condition the `viewer` object does — `sub` is `anon` for an
+anonymous viewer, precisely when `viewer` is `null`. Treat `GET_VIEWER` as the
+**supported** way to learn who the viewer is, and expect the id to remain
+derivable from the token regardless.
 
 ### Theme changes
 

--- a/docs/features/app-blocks.md
+++ b/docs/features/app-blocks.md
@@ -135,8 +135,12 @@ the token endpoint has resolved. Matches `@civitai/app-sdk/blocks` v1:
     userSettings: Record<string, unknown>;       // per-viewer prefs from block_user_settings (e.g. SET_USER_CHECKPOINT)
   };
   viewer: {
+    /** @deprecated identity disclosed unconditionally at load — use GET_VIEWER */
     id: number;
+    /** @deprecated same — use GET_VIEWER */
     username: string | null;
+    signedIn?: true;                   // v2. Literally `true`; ABSENT when anon,
+                                       // because an anon viewer has no object at all.
     // NOTE: moderation `status` (ban/mute) is intentionally NOT sent to the
     // iframe in this render-time payload — it's a viewer-privacy leak. A block
     // that needs a fresh, authoritative viewer (incl. `status: 'active'|'muted'`)
@@ -148,6 +152,32 @@ the token endpoint has resolved. Matches `@civitai/app-sdk/blocks` v1:
   renderMode: 'iframe' | 'inline';     // always 'iframe' today (the inline host is a stub)
 }
 ```
+
+#### `viewer.signedIn`, and what "deprecated" means here (v2)
+
+`viewer.signedIn` is the forward-looking MINIMAL viewer signal and the only
+viewer field a new block should read: it answers "is someone signed in?", which
+is what almost every block actually branches on. It is literally `true` when
+present, and **absent for an anonymous viewer** — because an anonymous viewer has
+no `viewer` object at all (`viewer: null`). Do not expect `signedIn: false`; it
+never appears.
+
+`viewer.id` / `viewer.username` are **deprecated but still sent, and will keep
+being sent**. Deprecated because identity reaches the block unconditionally at
+load, before the viewer has interacted with it, with nothing recording that it
+happened; the replacement is the scope-gated, per-call-audited `GET_VIEWER`
+message (`blocks.getMyViewer`), which requires the block to ask. Still sent
+because the `isValidBlockInitPayload` guard compiled into already-deployed
+bundles **rejects the whole payload** without a numeric `viewer.id` — removing it
+would blank every deployed block at once. Same story for `blockId` / `appId`.
+
+⚠️ **The deprecation does NOT reduce what a full-page app sees today.**
+`PageBlockHost` does not project its context: `BLOCK_INIT.context` on the
+`app.page` surface still carries `viewerUserId` and `viewerUsername`, an
+undeprecated second channel carrying the same identity. (The model-slot host
+*does* project and drops both.) Those page-context fields are deprecated too —
+treat `GET_VIEWER` as the supported way to learn who the viewer is on either
+surface — but nothing has been removed from the wire.
 
 ### Theme changes
 
@@ -175,9 +205,31 @@ Two flows, both delivering the same wrapped-token shape:
 1. **Host-pushed**: when the host refreshes the token (~13 min cadence) the
    iframe receives `TOKEN_REFRESH` with the new `token` object. No user
    action required.
-2. **Iframe-initiated**: the iframe sends `REQUEST_TOKEN` (optionally with a
-   `requestId`) and the host replies with `TOKEN_REFRESH_RESPONSE` carrying
-   the current token. Useful right before an expensive orchestrator call.
+2. **Iframe-initiated**: the iframe sends `REQUEST_TOKEN` and the host answers
+   with the current token. Useful right before an expensive orchestrator call.
+
+   🔴 **Send a `requestId`, or you do not get a reply — you get a push.** The SDK
+   correlates a `TOKEN_REFRESH_RESPONSE` **strictly** by `requestId`: it resolves
+   the pending promise for that id and nothing else, so an uncorrelated response
+   has never resolved anyone's `refresh()` (where it appeared to work at all, it
+   was the SDK's incidental side effect of snapshotting whatever token rides on
+   any `TOKEN_REFRESH_RESPONSE`, while the caller's promise sat there to its own
+   timeout). Both hosts therefore branch on what arrived:
+
+   | `REQUEST_TOKEN` payload | host answers with |
+   |---|---|
+   | `{ requestId: '<string>' }` — any string, **`''` included** | `TOKEN_REFRESH_RESPONSE` echoing that exact `requestId` |
+   | `{}`, no `requestId`, or a non-string one | `TOKEN_REFRESH` **push** (no `requestId` — there is nothing to correlate to) |
+
+   An empty-string `requestId` is echoed verbatim. It used to be dropped by a
+   truthiness test, which silently turned a legitimate request into an
+   uncorrelated response that could never resolve.
+
+   The no-`requestId` case is a **push**, not a reply, because that is what the
+   message semantically is: a host-initiated rotation. It arrives on the same
+   handler as flow 1 above — which was the only path that ever actually delivered
+   a token in that case — instead of putting an unanswerable
+   `TOKEN_REFRESH_RESPONSE` on the wire for the SDK to discard.
 
 ### Block↔host message inventory
 
@@ -196,7 +248,8 @@ block) or fire-and-forget. Rather than duplicate a list here that will re-drift,
 read that file. As of this writing the families are:
 
 - **Lifecycle** (fire-and-forget): `BLOCK_READY`, `BLOCK_ERROR`, `RESIZE_IFRAME`.
-- **Auth / consent**: `REQUEST_TOKEN` (→ `TOKEN_REFRESH_RESPONSE`),
+- **Auth / consent**: `REQUEST_TOKEN` (→ `TOKEN_REFRESH_RESPONSE` when it carried
+  a string `requestId`, else a `TOKEN_REFRESH` push — see "Token refresh"),
   `REQUEST_SIGN_IN`, `REQUEST_CONSENT`.
 - **Viewer**: `GET_VIEWER` (→ `VIEWER_RESULT`) — the viewer self-read ("who am
   I") backing the SDK `useViewer()` hook, host-mediated via the

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -132,8 +132,12 @@ function storageErrorMessage(err: unknown): string {
  *   4. RESIZE_IFRAME updates the iframe height, clamped to manifest bounds.
  *   5. Page-visibility change drives SUSPEND / RESUME.
  *   6. Token rotation triggers TOKEN_REFRESH (host-pushed) with the new
- *      wrapped token. REQUEST_TOKEN from the iframe is answered with
- *      TOKEN_REFRESH_RESPONSE so block-initiated refreshes also work.
+ *      wrapped token. A block-initiated REQUEST_TOKEN is answered CONDITIONALLY:
+ *      one carrying a STRING requestId (`''` included) gets a
+ *      TOKEN_REFRESH_RESPONSE echoing that id; one with no usable requestId gets
+ *      a TOKEN_REFRESH PUSH, because the SDK correlates strictly by requestId
+ *      and an uncorrelated response can never resolve a caller's refresh(). See
+ *      the handler's own comment for the full rationale.
  *   7. Unmount sends SUSPEND and removes listeners.
  *
  * Origin security: BLOCK_INIT is posted to `new URL(manifest.iframe.src).origin`

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -875,6 +875,32 @@ export function IframeHost({
   // SDK request-driven flow: iframe asks for the current token (e.g. right
   // before an expensive call) and we reply with the latest wrapped value.
   // Pairs with the push flow above — both produce the same payload shape.
+  //
+  // 🔴 A `TOKEN_REFRESH_RESPONSE` WITHOUT A `requestId` IS NOT A REPLY. The
+  // block side's `refresh()` awaits a response correlated STRICTLY by
+  // `requestId` — it resolves the pending promise for that id and nothing else —
+  // so an uncorrelated reply has never resolved anyone's `refresh()`. Where it
+  // appeared to work at all it was via the SDK's incidental side effect of
+  // snapshotting whatever token rides on any `TOKEN_REFRESH_RESPONSE`, while the
+  // caller's promise sat there until its own timeout.
+  //
+  // The old code spread `...(requestId ? { requestId } : {})` — a TRUTHINESS
+  // test, so it ALSO dropped an empty-string requestId, which a block can
+  // legitimately have minted and be waiting on. Now: whatever STRING the block
+  // sent is echoed back verbatim (`''` included), so a reply always correlates.
+  //
+  // And when the inbound message carried no usable requestId at all, we send a
+  // `TOKEN_REFRESH` PUSH instead of a fabricated-id reply — because that is
+  // exactly what the message semantically is: a host-initiated token rotation
+  // with nothing to correlate to. It reaches the block through the same handler
+  // as the H-3 rotation push above (which is the only path that ever actually
+  // delivered a token in this case), and it does not put an unanswerable
+  // `TOKEN_REFRESH_RESPONSE` on the wire for the SDK to discard.
+  //
+  // 🔴 PageBlockHost.tsx CARRIES THE SAME LOGIC AND MUST STAY IN STEP. The two
+  // hosts register their postMessage handlers by hand and share no bridge, so
+  // fixing one leaves half the fleet on the broken shape — each surface has its
+  // own browser test for this.
   useEffect(() => {
     const off = onMessage<{ requestId?: string } | undefined>('REQUEST_TOKEN', (raw) => {
       if (!token || !initSentRef.current) return;
@@ -882,15 +908,17 @@ export function IframeHost({
         raw && typeof raw === 'object' && typeof raw.requestId === 'string'
           ? raw.requestId
           : undefined;
-      send('TOKEN_REFRESH_RESPONSE', {
-        ...(requestId ? { requestId } : {}),
-        token: {
-          raw: token,
-          scopes: grantedScopes,
-          expiresAt,
-          ...(buzzBudget !== undefined ? { buzzBudget } : {}),
-        },
-      });
+      const wrapped = {
+        raw: token,
+        scopes: grantedScopes,
+        expiresAt,
+        ...(buzzBudget !== undefined ? { buzzBudget } : {}),
+      };
+      if (requestId === undefined) {
+        send('TOKEN_REFRESH', { token: wrapped });
+        return;
+      }
+      send('TOKEN_REFRESH_RESPONSE', { requestId, token: wrapped });
     });
     return off;
   }, [token, expiresAt, buzzBudget, grantedScopes, send, onMessage]);

--- a/src/components/AppBlocks/IframeHostInitContractV2.browser.test.tsx
+++ b/src/components/AppBlocks/IframeHostInitContractV2.browser.test.tsx
@@ -1,0 +1,390 @@
+import { describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+// Type-only namespace import for the `importOriginal` spread below (the repo's
+// local-rules/no-wholesale-module-mock cure). NOT `typeof import(...)`, which
+// @typescript-eslint/consistent-type-imports rejects.
+import type * as TrpcMod from '~/utils/trpc';
+
+/**
+ * BLOCK_INIT v2 contract — the MODEL-SLOT host (`model.sidebar_top`).
+ *
+ * Two things are pinned here, both of which a single-surface suite would miss:
+ *
+ *  1. `viewer.signedIn === true` reaches the wire. On THIS host the viewer is
+ *     DERIVED from the slot context via `projectBlockInitViewer`; on
+ *     `PageBlockHost` it arrives as an already-resolved PROP and never touches
+ *     that projection. The two hosts share no bridge, so
+ *     `PageBlockHostInitContractV2.browser.test.tsx` is the other half of this
+ *     coverage and neither file can stand in for the other. The unit tests on
+ *     `withSignedInFlag` pin the shape; only these pin that a host uses it.
+ *
+ *  2. `blockId` / `appId` are STILL SENT and non-empty. They are `@deprecated`
+ *     with ZERO deployed readers, which makes them look exactly like dead weight
+ *     a future cleanup would delete — see the regression guard below for why
+ *     that would be a fleet-wide outage.
+ *
+ * Plus the `TOKEN_REFRESH_RESPONSE.requestId` correlation contract, which is
+ * likewise duplicated per host.
+ *
+ * Mocks mirror `IframeHostThemeChange.browser.test.tsx` (the model-slot
+ * scaffold): the two tRPC queries IframeHost drives at render must report
+ * `isLoading: false` so the init handshake is allowed to start.
+ */
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ appBlocks: false, appBlocksPages: false }),
+}));
+
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcMod>()),
+  trpc: {
+    blocks: {
+      getEffectiveCheckpoint: {
+        useQuery: () => ({ data: { checkpoint: null }, isLoading: false }),
+      },
+      getShowcaseImages: {
+        useQuery: () => ({ data: [], isLoading: false }),
+      },
+      submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      updateUserSettings: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
+    apps: {
+      shared: {
+        append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        update: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        report: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+      storage: {
+        set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        delete: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+    },
+    useUtils: () => ({
+      apps: {
+        shared: {
+          list: { fetch: vi.fn() },
+          getCount: { fetch: vi.fn() },
+          getCounts: { fetch: vi.fn() },
+          get: { fetch: vi.fn() },
+        },
+        storage: {
+          get: { fetch: vi.fn() },
+          list: { fetch: vi.fn() },
+          getQuota: { fetch: vi.fn() },
+        },
+      },
+    }),
+  },
+}));
+
+vi.mock('~/components/BrowsingLevel/BrowsingLevelProvider', () => ({
+  useBrowsingLevelDebounced: () => 1,
+}));
+
+// eslint-disable-next-line import/first
+import { IframeHost } from '~/components/AppBlocks/IframeHost';
+// eslint-disable-next-line import/first
+import type { BlockInitPayload, BlockInstall, ModelSlotContext } from '~/components/AppBlocks/types';
+
+const SAME_ORIGIN_SRC = `${window.location.origin}/`;
+
+function iframeEl() {
+  return page.getByTestId('block-iframe').element() as HTMLIFrameElement;
+}
+
+function postFromBlock(type: string, payload?: unknown) {
+  const cw = iframeEl().contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      data: { type, payload },
+      origin: window.location.origin,
+      source: cw,
+    })
+  );
+}
+
+/** Capture host→block posts. `send` targets the iframe's contentWindow. */
+function listenForHostPosts() {
+  const received: Array<{ type: string; payload: unknown }> = [];
+  const cw = iframeEl().contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  const handler = (e: MessageEvent) => {
+    const d = e.data as { type?: string; payload?: unknown } | null;
+    if (d && typeof d.type === 'string') received.push({ type: d.type, payload: d.payload });
+  };
+  cw.addEventListener('message', handler);
+  return {
+    received,
+    of: (type: string) => received.filter((m) => m.type === type),
+    last: (type: string) => [...received].reverse().find((m) => m.type === type),
+    stop: () => cw.removeEventListener('message', handler),
+  };
+}
+
+/**
+ * Fixture values are NON-DEFAULT and PAIRWISE DISTINCT on purpose.
+ *
+ * Every id here is a different number and every name a different string, so no
+ * assertion below can pass by two fields collapsing onto the same value — a
+ * transposition mutant (`id`↔`username`, `blockId`↔`appId`) has to change what
+ * lands on the wire, and a zeroed/emptied payload cannot masquerade as a
+ * populated one.
+ */
+const install: BlockInstall = {
+  blockInstanceId: 'inst_kestrel_9471',
+  blockId: 'tidewater-remix',
+  appId: 'app_obsidian_3308',
+  appBlockId: 'apb_juniper_6215',
+  manifest: {
+    name: 'Tidewater Remix',
+    scopes: ['ai:write:budgeted'],
+    iframe: {
+      src: SAME_ORIGIN_SRC,
+      minHeight: 240,
+      maxHeight: 900,
+      resizable: true,
+      sandbox: 'allow-scripts',
+    },
+  },
+  publisherSettings: {},
+  enabled: true,
+  renderMode: 'iframe',
+  trustTier: 'internal',
+};
+
+function signedInContext(): ModelSlotContext {
+  return {
+    slotId: 'model.sidebar_top',
+    entityType: 'model',
+    modelId: 7742,
+    modelVersionId: 8891,
+    modelName: 'Cobalt Meridian',
+    modelType: 'Checkpoint',
+    modelNsfwLevel: 1,
+    creatorUserId: 3157,
+    viewerUserId: 5150,
+    viewerNsfwEnabled: false,
+    viewerUsername: 'zephyr-quill',
+    theme: 'light',
+  };
+}
+
+function anonymousContext(): ModelSlotContext {
+  return { ...signedInContext(), viewerUserId: null, viewerUsername: null };
+}
+
+const baseProps = {
+  install,
+  token: 'tok_verdigris_4482',
+  expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
+};
+
+/**
+ * Mount, attach the host→block listener, and wait until it has OBSERVED a real
+ * BLOCK_INIT.
+ *
+ * That wait is the positive control for every assertion in this file: a
+ * `toHaveLength(0)` read off a listener wired to nothing is indistinguishable
+ * from a genuine zero, so nothing is asserted until the channel has been proven
+ * to carry traffic.
+ */
+async function mountAndCaptureInit(context: ModelSlotContext) {
+  await renderWithProviders(<IframeHost {...baseProps} context={context} />);
+  await vi.waitFor(() => {
+    if (!iframeEl().contentWindow) throw new Error('not mounted yet');
+  });
+  const posts = listenForHostPosts();
+  await vi.waitFor(() => {
+    if (posts.of('BLOCK_INIT').length === 0) throw new Error('listener saw no BLOCK_INIT');
+  });
+  const init = posts.last('BLOCK_INIT')!.payload as BlockInitPayload;
+  return { posts, init };
+}
+
+describe('IframeHost BLOCK_INIT — viewer.signedIn (v2)', () => {
+  test('a signed-in viewer reaches the block with signedIn: true', async () => {
+    const { posts, init } = await mountAndCaptureInit(signedInContext());
+    // The literal `true`, not merely truthy: `signedIn: false` / `1` / `'yes'`
+    // must all fail here.
+    expect(init.viewer?.signedIn).toBe(true);
+    posts.stop();
+  });
+
+  test('the deprecated id/username still ride along, correct and un-swapped', async () => {
+    const { posts, init } = await mountAndCaptureInit(signedInContext());
+    // Deprecated (unconditional identity disclosure; `GET_VIEWER` is the
+    // replacement) but NOT removable: the `isValidBlockInitPayload` guard
+    // compiled into every deployed bundle rejects a viewer without a numeric
+    // `id`, and 5 of the 9 live apps read it for ownership/authorship logic.
+    expect(init.viewer?.id).toBe(5150);
+    expect(init.viewer?.username).toBe('zephyr-quill');
+    posts.stop();
+  });
+
+  test('the viewer object carries EXACTLY id + username + signedIn', async () => {
+    const { posts, init } = await mountAndCaptureInit(signedInContext());
+    expect(Object.keys(init.viewer ?? {}).sort()).toEqual(['id', 'signedIn', 'username']);
+    // The privacy fields the projection drops must not reappear via the host.
+    expect(init.viewer).not.toHaveProperty('status');
+    expect(init.viewer).not.toHaveProperty('viewerNsfwEnabled');
+    posts.stop();
+  });
+
+  test('🔴 an anonymous viewer is NULL — never an object with signedIn: false', async () => {
+    // The wire shape is frozen at `object-or-null` by the deployed guard, which
+    // accepts only `null` or an object with a NUMERIC `id`. An anonymous viewer
+    // rendered as `{ signedIn: false }` would fail that guard and blank the
+    // block for every logged-out visitor.
+    const { posts, init } = await mountAndCaptureInit(anonymousContext());
+    expect(init.viewer).toBeNull();
+    posts.stop();
+  });
+});
+
+describe('IframeHost BLOCK_INIT — blockId / appId are DEPRECATED but MANDATORY', () => {
+  /**
+   * 🔴 REGRESSION GUARD AGAINST A FUTURE "CLEANUP" DELETING THESE FIELDS.
+   *
+   * `blockId` and `appId` are build-time identity a block already knows, and the
+   * enumeration of the deployed population (21 rows in the prod `app_blocks`
+   * table, 9 approved/live) found ZERO runtime readers. That combination reads
+   * as dead weight — which is exactly the trap.
+   *
+   * Every already-deployed bundle carries a compiled-in
+   * `isValidBlockInitPayload` guard that REJECTS THE WHOLE BLOCK_INIT PAYLOAD
+   * when either field is missing. That guard was fetched from all 9 live bundles
+   * and EXECUTED against a payload without them: it fails, the block never
+   * initialises, and the viewer sees a blank block. Dropping these from the wire
+   * is therefore a fleet-wide outage, not a tidy-up — and no publisher can be
+   * forced to rebuild against a v2 guard on our schedule.
+   *
+   * If this test is in your way: the answer is NOT to delete it.
+   */
+  test('🔴 BLOCK_INIT still carries a non-empty blockId and appId — removing them blanks every deployed block', async () => {
+    const { posts, init } = await mountAndCaptureInit(signedInContext());
+
+    expect(init).toHaveProperty('blockId');
+    expect(init).toHaveProperty('appId');
+    expect(typeof init.blockId).toBe('string');
+    expect(typeof init.appId).toBe('string');
+    // Non-empty, and carrying the install's REAL values — an empty string
+    // survives the `toHaveProperty` check but fails the deployed guard's
+    // truthiness test just as a missing key does.
+    expect(init.blockId).toBe('tidewater-remix');
+    expect(init.appId).toBe('app_obsidian_3308');
+    // …and not transposed with each other or with the instance id, which the
+    // pairwise-distinct fixture makes observable.
+    expect(init.blockInstanceId).toBe('inst_kestrel_9471');
+    posts.stop();
+  });
+});
+
+describe('IframeHost REQUEST_TOKEN → TOKEN_REFRESH_RESPONSE.requestId', () => {
+  /**
+   * The block side's `refresh()` awaits a reply correlated STRICTLY by
+   * `requestId`. An uncorrelated `TOKEN_REFRESH_RESPONSE` has never resolved it —
+   * it only ever "worked" through the SDK's incidental token-snapshot side
+   * effect while the caller's promise sat there until its own timeout.
+   *
+   * The old spread was `...(requestId ? { requestId } : {})` — a TRUTHINESS test,
+   * so an empty-string id (which a block can legitimately mint and be waiting
+   * on) was dropped too.
+   */
+  test('echoes a normal requestId back verbatim', async () => {
+    const { posts } = await mountAndCaptureInit(signedInContext());
+
+    postFromBlock('REQUEST_TOKEN', { requestId: 'req-cinnabar-7789' });
+
+    await vi.waitFor(() => {
+      const reply = posts.last('TOKEN_REFRESH_RESPONSE');
+      if (!reply) throw new Error('no TOKEN_REFRESH_RESPONSE yet');
+      expect((reply.payload as { requestId?: string }).requestId).toBe('req-cinnabar-7789');
+    });
+    // The reply still carries the wrapped token — correlation was added, not
+    // traded for the payload.
+    const reply = posts.last('TOKEN_REFRESH_RESPONSE')!.payload as {
+      token?: { raw?: string };
+    };
+    expect(reply.token?.raw).toBe('tok_verdigris_4482');
+    posts.stop();
+  });
+
+  test('🔴 echoes an EMPTY-STRING requestId — the truthiness spread used to drop it', async () => {
+    const { posts } = await mountAndCaptureInit(signedInContext());
+
+    postFromBlock('REQUEST_TOKEN', { requestId: '' });
+
+    await vi.waitFor(() => {
+      const reply = posts.last('TOKEN_REFRESH_RESPONSE');
+      if (!reply) throw new Error('no TOKEN_REFRESH_RESPONSE yet');
+      // Present as an own property AND equal to '' — `toBe('')` alone would also
+      // pass on `undefined`-vs-missing confusion in a weaker matcher chain.
+      expect(Object.keys(reply.payload as object)).toContain('requestId');
+      expect((reply.payload as { requestId?: string }).requestId).toBe('');
+    });
+    posts.stop();
+  });
+
+  test('🔴 a REQUEST_TOKEN with NO requestId gets a TOKEN_REFRESH push, never an uncorrelated response', async () => {
+    const { posts } = await mountAndCaptureInit(signedInContext());
+
+    // Count BEFORE: the H-3 rotation effect can legitimately push its own
+    // TOKEN_REFRESH on a token/scope change, so the assertion is on the DELTA
+    // this REQUEST_TOKEN causes, not on an absolute total.
+    const pushesBefore = posts.of('TOKEN_REFRESH').length;
+    postFromBlock('REQUEST_TOKEN', {});
+
+    await vi.waitFor(() => {
+      expect(posts.of('TOKEN_REFRESH').length).toBe(pushesBefore + 1);
+    });
+    // A host-initiated rotation with nothing to correlate to IS a TOKEN_REFRESH.
+    // What must never happen is a TOKEN_REFRESH_RESPONSE the block cannot match
+    // to any pending request.
+    expect(posts.of('TOKEN_REFRESH_RESPONSE')).toHaveLength(0);
+    const push = posts.last('TOKEN_REFRESH')!.payload as { token?: { raw?: string } };
+    expect(push.token?.raw).toBe('tok_verdigris_4482');
+    posts.stop();
+  });
+
+  test('a bare REQUEST_TOKEN (undefined payload) behaves the same way', async () => {
+    const { posts } = await mountAndCaptureInit(signedInContext());
+
+    const pushesBefore = posts.of('TOKEN_REFRESH').length;
+    postFromBlock('REQUEST_TOKEN');
+
+    await vi.waitFor(() => {
+      expect(posts.of('TOKEN_REFRESH').length).toBe(pushesBefore + 1);
+    });
+    expect(posts.of('TOKEN_REFRESH_RESPONSE')).toHaveLength(0);
+    posts.stop();
+  });
+
+  test('🔴 concurrent requests are each answered on their OWN id — no stale re-bind', async () => {
+    // A host that replied with the id of a DIFFERENT (e.g. the most recent, or
+    // the first-seen) request would resolve the wrong caller's promise and hang
+    // the other. Two distinct ids, both of which must come back.
+    const { posts } = await mountAndCaptureInit(signedInContext());
+
+    postFromBlock('REQUEST_TOKEN', { requestId: 'req-alabaster-2264' });
+    postFromBlock('REQUEST_TOKEN', { requestId: 'req-fennel-9053' });
+
+    await vi.waitFor(() => {
+      expect(posts.of('TOKEN_REFRESH_RESPONSE')).toHaveLength(2);
+    });
+    expect(
+      posts.of('TOKEN_REFRESH_RESPONSE').map((m) => (m.payload as { requestId?: string }).requestId)
+    ).toEqual(['req-alabaster-2264', 'req-fennel-9053']);
+    posts.stop();
+  });
+});

--- a/src/components/AppBlocks/IframeHostInitContractV2.browser.test.tsx
+++ b/src/components/AppBlocks/IframeHostInitContractV2.browser.test.tsx
@@ -226,7 +226,8 @@ describe('IframeHost BLOCK_INIT — viewer.signedIn (v2)', () => {
     // Deprecated (unconditional identity disclosure; `GET_VIEWER` is the
     // replacement) but NOT removable: the `isValidBlockInitPayload` guard
     // compiled into every deployed bundle rejects a viewer without a numeric
-    // `id`, and 5 of the 9 live apps read it for ownership/authorship logic.
+    // `id`, and 5 of the 9 currently-approved apps read it for
+    // ownership/authorship logic.
     expect(init.viewer?.id).toBe(5150);
     expect(init.viewer?.username).toBe('zephyr-quill');
     posts.stop();
@@ -257,17 +258,25 @@ describe('IframeHost BLOCK_INIT — blockId / appId are DEPRECATED but MANDATORY
    * 🔴 REGRESSION GUARD AGAINST A FUTURE "CLEANUP" DELETING THESE FIELDS.
    *
    * `blockId` and `appId` are build-time identity a block already knows, and the
-   * enumeration of the deployed population (21 rows in the prod `app_blocks`
-   * table, 9 approved/live) found ZERO runtime readers. That combination reads
-   * as dead weight — which is exactly the trap.
+   * runtime-reader survey over the 9 CURRENTLY-APPROVED bundles found ZERO
+   * readers. That combination reads as dead weight — which is exactly the trap.
    *
    * Every already-deployed bundle carries a compiled-in
    * `isValidBlockInitPayload` guard that REJECTS THE WHOLE BLOCK_INIT PAYLOAD
-   * when either field is missing. That guard was fetched from all 9 live bundles
-   * and EXECUTED against a payload without them: it fails, the block never
-   * initialises, and the viewer sees a blank block. Dropping these from the wire
-   * is therefore a fleet-wide outage, not a tidy-up — and no publisher can be
-   * forced to rebuild against a v2 guard on our schedule.
+   * when either field is missing. That guard was fetched from each of those 9
+   * and EXECUTED against a payload without them: it fails on every one, the
+   * block never initialises, and the viewer sees a blank block. Dropping these
+   * from the wire is therefore a fleet-wide outage, not a tidy-up — and no
+   * publisher can be forced to rebuild against a v2 guard on our schedule.
+   *
+   * 🔴 WHICH NUMBER MEANS WHAT. 9 = approved, i.e. what is SERVED today (both
+   * surfaces gate on `status: 'approved'`) and what was actually EXECUTED. The
+   * population a COMPATIBILITY claim has to cover is the full deployed set —
+   * 21 rows / 20 deployments in `app_blocks` — because a suspension is
+   * reversible (`relistListing` flips suspended → approved and the untouched
+   * bundle serves again). The other 11 deployments were not guard-executed; that
+   * they behave the same is an inference from their shipping the same SDK guard.
+   * Full note above `BlockInitPayload` in types.ts.
    *
    * If this test is in your way: the answer is NOT to delete it.
    */

--- a/src/components/AppBlocks/IframeHostInitContractV2.browser.test.tsx
+++ b/src/components/AppBlocks/IframeHostInitContractV2.browser.test.tsx
@@ -94,7 +94,11 @@ vi.mock('~/components/BrowsingLevel/BrowsingLevelProvider', () => ({
 // eslint-disable-next-line import/first
 import { IframeHost } from '~/components/AppBlocks/IframeHost';
 // eslint-disable-next-line import/first
-import type { BlockInitPayload, BlockInstall, ModelSlotContext } from '~/components/AppBlocks/types';
+import type {
+  BlockInitPayload,
+  BlockInstall,
+  ModelSlotContext,
+} from '~/components/AppBlocks/types';
 
 const SAME_ORIGIN_SRC = `${window.location.origin}/`;
 

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -37,7 +37,7 @@ import type { BlockUploadedImageInfo } from './BlockImageUploadModal';
 import type { BlockSourceImageInfo } from './BlockGenerationSourceUploadModal';
 import { BlockImageScanPoller } from './BlockImageScanPoller';
 import type { BlockImageScanResult } from './blockImageScanLogic';
-import { projectBlockInitMaturity } from './projectBlockInit';
+import { projectBlockInitMaturity, withSignedInFlag } from './projectBlockInit';
 import { sendBlockRender } from './sendBlockRender';
 import {
   computeLaunchTimings,
@@ -785,7 +785,18 @@ export function PageBlockHost({
       },
       context: buildContext(),
       settings: { publisherSettings: {}, userSettings: {} },
-      viewer,
+      // 🔴 THE SECOND PRODUCER OF THE BLOCK_INIT `viewer` OBJECT. Unlike
+      // IframeHost — which derives it from the slot context via
+      // `projectBlockInitViewer` — this host receives an ALREADY-RESOLVED
+      // `viewer` prop from the /apps/run/[slug] route and used to pass it
+      // straight through. So the v2 `signedIn` flag added inside
+      // `projectBlockInitViewer` would have reached the model-slot surface only,
+      // and every full-page app would have shipped a viewer object without it —
+      // the classic half-fleet miss this file's THEME_CHANGE comment describes.
+      // Routing through the SHARED `withSignedInFlag` helper is what makes the
+      // two surfaces incapable of drifting: neither host stamps the object by
+      // hand. `null` (anonymous) passes through as `null`.
+      viewer: withSignedInFlag(viewer),
       theme,
       renderMode: 'iframe',
       // Advisory maturity signal — server-authoritative values from the mint.
@@ -982,6 +993,32 @@ export function PageBlockHost({
   }, [token, expiresAt, grantedScopes, send]);
 
   // Answer a block-initiated REQUEST_TOKEN.
+  //
+  // 🔴 A `TOKEN_REFRESH_RESPONSE` WITHOUT A `requestId` IS NOT A REPLY. The
+  // block side's `refresh()` awaits a response correlated STRICTLY by
+  // `requestId` — it resolves the pending promise for that id and nothing else —
+  // so an uncorrelated reply has never resolved anyone's `refresh()`. Where it
+  // appeared to work at all it was via the SDK's incidental side effect of
+  // snapshotting whatever token rides on any `TOKEN_REFRESH_RESPONSE`, while the
+  // caller's promise sat there until its own timeout.
+  //
+  // The old code spread `...(requestId ? { requestId } : {})` — a TRUTHINESS
+  // test, so it ALSO dropped an empty-string requestId, which a block can
+  // legitimately have minted and be waiting on. Now: whatever STRING the block
+  // sent is echoed back verbatim (`''` included), so a reply always correlates.
+  //
+  // And when the inbound message carried no usable requestId at all, we send a
+  // `TOKEN_REFRESH` PUSH instead of a fabricated-id reply — because that is
+  // exactly what the message semantically is: a host-initiated token rotation
+  // with nothing to correlate to. It reaches the block through the same handler
+  // as the rotation push above (which is the only path that ever actually
+  // delivered a token in this case), and it does not put an unanswerable
+  // `TOKEN_REFRESH_RESPONSE` on the wire for the SDK to discard.
+  //
+  // 🔴 IframeHost.tsx CARRIES THE SAME LOGIC AND MUST STAY IN STEP. The two
+  // hosts register their postMessage handlers by hand and share no bridge, so
+  // fixing one leaves half the fleet on the broken shape — each surface has its
+  // own browser test for this.
   useEffect(() => {
     const off = onMessage<{ requestId?: string } | undefined>('REQUEST_TOKEN', (raw) => {
       if (!token || !initSentRef.current) return;
@@ -989,10 +1026,12 @@ export function PageBlockHost({
         raw && typeof raw === 'object' && typeof raw.requestId === 'string'
           ? raw.requestId
           : undefined;
-      send('TOKEN_REFRESH_RESPONSE', {
-        ...(requestId ? { requestId } : {}),
-        token: { raw: token, scopes: grantedScopes, expiresAt: expiresAt ?? '' },
-      });
+      const wrapped = { raw: token, scopes: grantedScopes, expiresAt: expiresAt ?? '' };
+      if (requestId === undefined) {
+        send('TOKEN_REFRESH', { token: wrapped });
+        return;
+      }
+      send('TOKEN_REFRESH_RESPONSE', { requestId, token: wrapped });
     });
     return off;
   }, [token, expiresAt, grantedScopes, send, onMessage]);

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -755,6 +755,22 @@ export function PageBlockHost({
     return '';
   }, [router.query.path]);
 
+  // 🔴 THIS CONTEXT IS NOT PROJECTED, AND THAT IS THE SECOND IDENTITY CHANNEL.
+  // `IframeHost` runs its slot context through `projectBlockInitContext`, whose
+  // allowlist DROPS `viewerUserId` / `viewerUsername`; this host emits them
+  // verbatim. So the `@deprecated` markers on `BlockInitPayload.viewer.id` /
+  // `.username` reduce unconditional identity disclosure on the model slot and by
+  // ZERO here — a full-page block learns who is looking at it from `context`
+  // whether or not it ever touches `viewer`.
+  //
+  // Deliberately left in place rather than quietly dropped: these are published
+  // SDK contract fields on `PageContext`, and the deployed-population enumeration
+  // that justifies every other keep/drop call in this payload was run for the
+  // `viewer` object, NOT for `context.viewerUserId`. Removing them needs a
+  // PAGE-SHAPED allowlist (the model allowlist would strip `slug` / `subPath` /
+  // `entityType` and break deep-linking) plus that enumeration. Tracked on the
+  // `PageContext.viewerUserId` @deprecated note; pinned as present-today by
+  // PageBlockHostInitContractV2.browser.test.tsx so the removal cannot be silent.
   const buildContext = useCallback(
     (): PageContext => ({
       slotId: 'app.page',

--- a/src/components/AppBlocks/PageBlockHostInitContractV2.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostInitContractV2.browser.test.tsx
@@ -127,11 +127,22 @@ function listenForHostPosts() {
 }
 
 /**
- * Fixture values are NON-DEFAULT and PAIRWISE DISTINCT, and deliberately share
- * NO value with the model-slot mirror of this file. Every id is a different
- * number and every name a different string, so no assertion can pass by two
+ * Fixture values are NON-DEFAULT and pairwise distinct, and deliberately share NO
+ * value with the model-slot mirror of this file — so no assertion can pass by two
  * fields collapsing onto the same value, and a cross-host copy-paste cannot pass
  * against the wrong host's data.
+ *
+ * TWO DELIBERATE EXCEPTIONS, both mirroring a real production identity rather
+ * than sloppiness — do not "fix" them by inventing distinct values, that would
+ * make the fixture LESS faithful than the route it stands in for:
+ *
+ *   - `slug` === `blockId`. `/apps/run/[slug]/[[...path]].tsx` builds its props
+ *     with `slug: page.blockId` — the AppBlock's `block_id` IS the slug (it is
+ *     what builds `<slug>.civit.ai`). They are one value in prod, so a
+ *     "transposition" of the two is not a defect that can exist.
+ *   - `blockInstanceId` embeds `appBlockId` (`page_<appBlockId>`), which is how
+ *     the route derives it. The blockId/appId/blockInstanceId assertions below
+ *     stay meaningful because those three ARE mutually distinct.
  */
 const baseProps = {
   appBlockId: 'apb_sandpiper_5527',
@@ -199,7 +210,8 @@ describe('PageBlockHost BLOCK_INIT — viewer.signedIn (v2)', () => {
     // Deprecated (unconditional identity disclosure; `GET_VIEWER` is the
     // replacement) but NOT removable: the `isValidBlockInitPayload` guard
     // compiled into every deployed bundle rejects a viewer without a numeric
-    // `id`, and 5 of the 9 live apps read it for ownership/authorship logic.
+    // `id`, and 5 of the 9 currently-approved apps read it for
+    // ownership/authorship logic.
     expect(init.viewer?.id).toBe(8472);
     expect(init.viewer?.username).toBe('nimbus-drake');
     posts.stop();
@@ -231,21 +243,82 @@ describe('PageBlockHost BLOCK_INIT — viewer.signedIn (v2)', () => {
   });
 });
 
+describe('PageBlockHost BLOCK_INIT — the UNPROJECTED context is a second identity channel', () => {
+  /**
+   * 🔴 CHARACTERISATION, NOT AN ENDORSEMENT. This pins what the page surface
+   * ACTUALLY discloses today, so the `@deprecated` prose on
+   * `BlockInitPayload.viewer.id` cannot be read as a privacy guarantee it does
+   * not deliver.
+   *
+   * `IframeHost` projects its slot context through `projectBlockInitContext`,
+   * whose allowlist drops `viewerUserId` / `viewerUsername`. This host does not
+   * project at all — `buildContext()` emits both verbatim. So deprecating
+   * `viewer.id` / `viewer.username` ends unconditional identity disclosure on the
+   * model slot and buys ZERO here.
+   *
+   * They were NOT removed: they are published SDK contract fields on
+   * `PageContext`, and the deployed-population enumeration behind this file's
+   * other keep/drop claims covered the `viewer` OBJECT, not `context.viewerUserId`
+   * — removing them on that evidence would be generalising a measurement onto a
+   * different field.
+   *
+   * If this test is in your way, you are doing the removal. Good — but do it with
+   * the enumeration in hand and a PAGE-shaped allowlist (the model allowlist would
+   * strip `slug` / `subPath` / `entityType` and break deep-linking), then update
+   * the `PageContext` and `BlockInitPayload.viewer` notes in the same change.
+   */
+  test('🔴 context still carries viewerUserId/viewerUsername — the viewer.id deprecation buys ZERO here', async () => {
+    const { posts, init } = await mountAndCaptureInit();
+    const ctx = init.context as Record<string, unknown>;
+
+    // Positive control on the read itself: a page context that had lost its own
+    // routing fields would make the identity assertions below meaningless.
+    expect(ctx.slotId).toBe('app.page');
+    expect(ctx.slug).toBe('lanternfish-studio');
+
+    expect(ctx.viewerUserId).toBe(8472);
+    expect(ctx.viewerUsername).toBe('nimbus-drake');
+    // …and it is the SAME identity the deprecated `viewer` object carries — two
+    // channels, one of them undeprecated.
+    expect(ctx.viewerUserId).toBe(init.viewer?.id);
+    expect(ctx.viewerUsername).toBe(init.viewer?.username);
+    posts.stop();
+  });
+
+  test('an anonymous page viewer discloses no identity on EITHER channel', async () => {
+    const { posts, init } = await mountAndCaptureInit({ viewer: null });
+    const ctx = init.context as Record<string, unknown>;
+
+    expect(init.viewer).toBeNull();
+    expect(ctx.viewerUserId).toBeNull();
+    expect(ctx.viewerUsername).toBeNull();
+    posts.stop();
+  });
+});
+
 describe('PageBlockHost BLOCK_INIT — blockId / appId are DEPRECATED but MANDATORY', () => {
   /**
    * 🔴 REGRESSION GUARD AGAINST A FUTURE "CLEANUP" DELETING THESE FIELDS.
    *
    * `blockId` and `appId` are build-time identity a block already knows, and the
-   * enumeration of the deployed population (21 rows in the prod `app_blocks`
-   * table, 9 approved/live) found ZERO runtime readers. That combination reads
-   * as dead weight — which is exactly the trap.
+   * runtime-reader survey over the 9 CURRENTLY-APPROVED bundles found ZERO
+   * readers. That combination reads as dead weight — which is exactly the trap.
    *
    * Every already-deployed bundle carries a compiled-in
    * `isValidBlockInitPayload` guard that REJECTS THE WHOLE BLOCK_INIT PAYLOAD
-   * when either field is missing. That guard was fetched from all 9 live bundles
-   * and EXECUTED against a payload without them: it fails, the block never
-   * initialises, and the viewer sees a blank block. Dropping these from the wire
-   * is therefore a fleet-wide outage, not a tidy-up.
+   * when either field is missing. That guard was fetched from each of those 9
+   * and EXECUTED against a payload without them: it fails on every one, the
+   * block never initialises, and the viewer sees a blank block. Dropping these
+   * from the wire is therefore a fleet-wide outage, not a tidy-up.
+   *
+   * 🔴 WHICH NUMBER MEANS WHAT. 9 = approved, i.e. what is SERVED today (both
+   * surfaces gate on `status: 'approved'`) and what was actually EXECUTED. The
+   * population a COMPATIBILITY claim has to cover is the full deployed set —
+   * 21 rows / 20 deployments in `app_blocks` — because a suspension is
+   * reversible (`relistListing` flips suspended → approved and the untouched
+   * bundle serves again). The other 11 deployments were not guard-executed; that
+   * they behave the same is an inference from their shipping the same SDK guard.
+   * Full note above `BlockInitPayload` in types.ts.
    *
    * If this test is in your way: the answer is NOT to delete it.
    */

--- a/src/components/AppBlocks/PageBlockHostInitContractV2.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostInitContractV2.browser.test.tsx
@@ -1,0 +1,359 @@
+import { describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+// Type-only namespace import for the `importOriginal` spread below (the repo's
+// local-rules/no-wholesale-module-mock cure). NOT `typeof import(...)`, which
+// @typescript-eslint/consistent-type-imports rejects.
+import type * as TrpcMod from '~/utils/trpc';
+
+/**
+ * BLOCK_INIT v2 contract — the W10 FULL-PAGE host (`app.page`).
+ *
+ * 🔴 THIS IS THE HALF OF THE COVERAGE A SINGLE-SURFACE SUITE STRUCTURALLY
+ * CANNOT SEE, and the seam is real rather than hypothetical: this host does NOT
+ * call `projectBlockInitViewer` at all. It receives an already-resolved `viewer`
+ * PROP from the /apps/run/[slug] route and used to pass it into BLOCK_INIT
+ * untouched — so the v2 `signedIn` flag, added inside that projection, reached
+ * the model-slot surface only and EVERY full-page app would have shipped a
+ * viewer object without it. The fix routes both hosts through the shared
+ * `withSignedInFlag` helper; this file pins that THIS host goes through it.
+ *
+ * The same duplication applies to the `TOKEN_REFRESH_RESPONSE.requestId`
+ * contract below — the two hosts register their postMessage handlers by hand and
+ * share no bridge, so a fix to one does not reach the other.
+ *
+ * Mocks mirror `PageBlockHostTokenTerminal.browser.test.tsx` (the page-host
+ * scaffold): only the ambient tRPC client and useCurrentUser are stubbed.
+ */
+
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcMod>()),
+  // FeatureFlagsProvider (in PageBlockHost's real render graph) statically
+  // imports `setTrpcBatchingEnabled` from this module (#2946). vi.mock replaces
+  // the module wholesale, so the factory must re-declare it or the ESM link
+  // fails.
+  setTrpcBatchingEnabled: vi.fn(),
+  trpc: {
+    generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
+    blocks: {
+      submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyViewer: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzTransactions: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzAccounts: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyDailyCompensation: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      publishGenerationOutputs: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getImagesByIds: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
+    apps: {
+      shared: {
+        append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        update: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        report: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+      storage: {
+        set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        delete: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+    },
+    useUtils: () => ({
+      apps: {
+        shared: {
+          list: { fetch: vi.fn() },
+          getCount: { fetch: vi.fn() },
+          getCounts: { fetch: vi.fn() },
+          get: { fetch: vi.fn() },
+        },
+        storage: {
+          get: { fetch: vi.fn() },
+          list: { fetch: vi.fn() },
+          getQuota: { fetch: vi.fn() },
+        },
+      },
+    }),
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
+// eslint-disable-next-line import/first
+import type { BlockInitPayload } from '~/components/AppBlocks/types';
+
+const SAME_ORIGIN_SRC = `${window.location.origin}/`;
+
+function iframeEl() {
+  return page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+}
+
+function postFromBlock(type: string, payload?: unknown) {
+  const cw = iframeEl().contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      data: { type, payload },
+      origin: window.location.origin,
+      source: cw,
+    })
+  );
+}
+
+/** Capture host→block posts. `send` targets the iframe's contentWindow. */
+function listenForHostPosts() {
+  const received: Array<{ type: string; payload: unknown }> = [];
+  const cw = iframeEl().contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  const handler = (e: MessageEvent) => {
+    const d = e.data as { type?: string; payload?: unknown } | null;
+    if (d && typeof d.type === 'string') received.push({ type: d.type, payload: d.payload });
+  };
+  cw.addEventListener('message', handler);
+  return {
+    received,
+    of: (type: string) => received.filter((m) => m.type === type),
+    last: (type: string) => [...received].reverse().find((m) => m.type === type),
+    stop: () => cw.removeEventListener('message', handler),
+  };
+}
+
+/**
+ * Fixture values are NON-DEFAULT and PAIRWISE DISTINCT, and deliberately share
+ * NO value with the model-slot mirror of this file. Every id is a different
+ * number and every name a different string, so no assertion can pass by two
+ * fields collapsing onto the same value, and a cross-host copy-paste cannot pass
+ * against the wrong host's data.
+ */
+const baseProps = {
+  appBlockId: 'apb_sandpiper_5527',
+  blockId: 'lanternfish-studio',
+  appId: 'app_peridot_7064',
+  blockInstanceId: 'page_apb_sandpiper_5527',
+  appName: 'Lanternfish Studio',
+  iframeSrc: SAME_ORIGIN_SRC,
+  // The public run surface. Required since the init-fragment gate keys on it.
+  surface: 'page-run' as const,
+  sandbox: 'allow-scripts',
+  trustTier: 'internal' as const,
+  slug: 'lanternfish-studio',
+  token: 'tok_saffron_1938',
+  expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
+  declaredScopes: ['apps:storage:read'],
+  missingScopes: [] as string[],
+  needsConsent: false,
+  tokenError: false,
+  viewer: { id: 8472, username: 'nimbus-drake' } as { id: number; username: string | null } | null,
+  theme: 'light' as const,
+};
+
+/**
+ * Mount, attach the host→block listener, and wait until it has OBSERVED a real
+ * BLOCK_INIT.
+ *
+ * That wait is the positive control for every assertion in this file: a
+ * `toHaveLength(0)` read off a listener wired to nothing is indistinguishable
+ * from a genuine zero, so nothing is asserted until the channel has been proven
+ * to carry traffic.
+ */
+async function mountAndCaptureInit(overrides: Partial<typeof baseProps> = {}) {
+  await renderWithProviders(
+    <PageBlockHost
+      {...baseProps}
+      {...overrides}
+      onConsentGranted={vi.fn()}
+      onRetryToken={vi.fn()}
+    />
+  );
+  await vi.waitFor(() => {
+    if (!iframeEl().contentWindow) throw new Error('not mounted yet');
+  });
+  const posts = listenForHostPosts();
+  await vi.waitFor(() => {
+    if (posts.of('BLOCK_INIT').length === 0) throw new Error('listener saw no BLOCK_INIT');
+  });
+  const init = posts.last('BLOCK_INIT')!.payload as BlockInitPayload;
+  return { posts, init };
+}
+
+describe('PageBlockHost BLOCK_INIT — viewer.signedIn (v2)', () => {
+  test('🔴 signedIn: true reaches the block through the PROP path, not the projection', async () => {
+    // The seam. This host never calls `projectBlockInitViewer`, so a flag added
+    // there alone would leave this assertion red while the model-slot suite
+    // stayed green — a defect visible only from BOTH surfaces at once.
+    const { posts, init } = await mountAndCaptureInit();
+    expect(init.viewer?.signedIn).toBe(true);
+    posts.stop();
+  });
+
+  test('the deprecated id/username still ride along, correct and un-swapped', async () => {
+    const { posts, init } = await mountAndCaptureInit();
+    // Deprecated (unconditional identity disclosure; `GET_VIEWER` is the
+    // replacement) but NOT removable: the `isValidBlockInitPayload` guard
+    // compiled into every deployed bundle rejects a viewer without a numeric
+    // `id`, and 5 of the 9 live apps read it for ownership/authorship logic.
+    expect(init.viewer?.id).toBe(8472);
+    expect(init.viewer?.username).toBe('nimbus-drake');
+    posts.stop();
+  });
+
+  test('the viewer object carries EXACTLY id + username + signedIn', async () => {
+    const { posts, init } = await mountAndCaptureInit();
+    expect(Object.keys(init.viewer ?? {}).sort()).toEqual(['id', 'signedIn', 'username']);
+    posts.stop();
+  });
+
+  test('🔴 an anonymous viewer is NULL — never an object with signedIn: false', async () => {
+    // The wire shape is frozen at `object-or-null` by the deployed guard, which
+    // accepts only `null` or an object with a NUMERIC `id`. An anonymous viewer
+    // rendered as `{ signedIn: false }` would fail that guard and blank the page
+    // for every logged-out visitor — and a full-page app is the surface anon
+    // traffic actually lands on.
+    const { posts, init } = await mountAndCaptureInit({ viewer: null });
+    expect(init.viewer).toBeNull();
+    posts.stop();
+  });
+
+  test('a viewer with a null username keeps signedIn: true', async () => {
+    const { posts, init } = await mountAndCaptureInit({
+      viewer: { id: 6613, username: null },
+    });
+    expect(init.viewer).toEqual({ id: 6613, username: null, signedIn: true });
+    posts.stop();
+  });
+});
+
+describe('PageBlockHost BLOCK_INIT — blockId / appId are DEPRECATED but MANDATORY', () => {
+  /**
+   * 🔴 REGRESSION GUARD AGAINST A FUTURE "CLEANUP" DELETING THESE FIELDS.
+   *
+   * `blockId` and `appId` are build-time identity a block already knows, and the
+   * enumeration of the deployed population (21 rows in the prod `app_blocks`
+   * table, 9 approved/live) found ZERO runtime readers. That combination reads
+   * as dead weight — which is exactly the trap.
+   *
+   * Every already-deployed bundle carries a compiled-in
+   * `isValidBlockInitPayload` guard that REJECTS THE WHOLE BLOCK_INIT PAYLOAD
+   * when either field is missing. That guard was fetched from all 9 live bundles
+   * and EXECUTED against a payload without them: it fails, the block never
+   * initialises, and the viewer sees a blank block. Dropping these from the wire
+   * is therefore a fleet-wide outage, not a tidy-up.
+   *
+   * If this test is in your way: the answer is NOT to delete it.
+   */
+  test('🔴 BLOCK_INIT still carries a non-empty blockId and appId — removing them blanks every deployed block', async () => {
+    const { posts, init } = await mountAndCaptureInit();
+
+    expect(init).toHaveProperty('blockId');
+    expect(init).toHaveProperty('appId');
+    expect(typeof init.blockId).toBe('string');
+    expect(typeof init.appId).toBe('string');
+    // Non-empty, and carrying the route's REAL values — an empty string survives
+    // the `toHaveProperty` check but fails the deployed guard's truthiness test
+    // just as a missing key does.
+    expect(init.blockId).toBe('lanternfish-studio');
+    expect(init.appId).toBe('app_peridot_7064');
+    // …and not transposed with each other or with the instance id, which the
+    // pairwise-distinct fixture makes observable.
+    expect(init.blockInstanceId).toBe('page_apb_sandpiper_5527');
+    posts.stop();
+  });
+});
+
+describe('PageBlockHost REQUEST_TOKEN → TOKEN_REFRESH_RESPONSE.requestId', () => {
+  /**
+   * The block side's `refresh()` awaits a reply correlated STRICTLY by
+   * `requestId`. An uncorrelated `TOKEN_REFRESH_RESPONSE` has never resolved it —
+   * it only ever "worked" through the SDK's incidental token-snapshot side
+   * effect while the caller's promise sat there until its own timeout.
+   *
+   * The old spread was `...(requestId ? { requestId } : {})` — a TRUTHINESS test,
+   * so an empty-string id (which a block can legitimately mint and be waiting
+   * on) was dropped too.
+   */
+  test('echoes a normal requestId back verbatim', async () => {
+    const { posts } = await mountAndCaptureInit();
+
+    postFromBlock('REQUEST_TOKEN', { requestId: 'req-marlin-4419' });
+
+    await vi.waitFor(() => {
+      const reply = posts.last('TOKEN_REFRESH_RESPONSE');
+      if (!reply) throw new Error('no TOKEN_REFRESH_RESPONSE yet');
+      expect((reply.payload as { requestId?: string }).requestId).toBe('req-marlin-4419');
+    });
+    const reply = posts.last('TOKEN_REFRESH_RESPONSE')!.payload as { token?: { raw?: string } };
+    expect(reply.token?.raw).toBe('tok_saffron_1938');
+    posts.stop();
+  });
+
+  test('🔴 echoes an EMPTY-STRING requestId — the truthiness spread used to drop it', async () => {
+    const { posts } = await mountAndCaptureInit();
+
+    postFromBlock('REQUEST_TOKEN', { requestId: '' });
+
+    await vi.waitFor(() => {
+      const reply = posts.last('TOKEN_REFRESH_RESPONSE');
+      if (!reply) throw new Error('no TOKEN_REFRESH_RESPONSE yet');
+      expect(Object.keys(reply.payload as object)).toContain('requestId');
+      expect((reply.payload as { requestId?: string }).requestId).toBe('');
+    });
+    posts.stop();
+  });
+
+  test('🔴 a REQUEST_TOKEN with NO requestId gets a TOKEN_REFRESH push, never an uncorrelated response', async () => {
+    const { posts } = await mountAndCaptureInit();
+
+    // Count BEFORE: the rotation effect can legitimately push its own
+    // TOKEN_REFRESH on a token/scope change, so the assertion is on the DELTA
+    // this REQUEST_TOKEN causes, not on an absolute total.
+    const pushesBefore = posts.of('TOKEN_REFRESH').length;
+    postFromBlock('REQUEST_TOKEN', {});
+
+    await vi.waitFor(() => {
+      expect(posts.of('TOKEN_REFRESH').length).toBe(pushesBefore + 1);
+    });
+    expect(posts.of('TOKEN_REFRESH_RESPONSE')).toHaveLength(0);
+    const push = posts.last('TOKEN_REFRESH')!.payload as { token?: { raw?: string } };
+    expect(push.token?.raw).toBe('tok_saffron_1938');
+    posts.stop();
+  });
+
+  test('a bare REQUEST_TOKEN (undefined payload) behaves the same way', async () => {
+    const { posts } = await mountAndCaptureInit();
+
+    const pushesBefore = posts.of('TOKEN_REFRESH').length;
+    postFromBlock('REQUEST_TOKEN');
+
+    await vi.waitFor(() => {
+      expect(posts.of('TOKEN_REFRESH').length).toBe(pushesBefore + 1);
+    });
+    expect(posts.of('TOKEN_REFRESH_RESPONSE')).toHaveLength(0);
+    posts.stop();
+  });
+
+  test('🔴 concurrent requests are each answered on their OWN id — no stale re-bind', async () => {
+    // A host that replied with the id of a DIFFERENT (e.g. the most recent, or
+    // the first-seen) request would resolve the wrong caller's promise and hang
+    // the other. Two distinct ids, both of which must come back.
+    const { posts } = await mountAndCaptureInit();
+
+    postFromBlock('REQUEST_TOKEN', { requestId: 'req-thistle-8806' });
+    postFromBlock('REQUEST_TOKEN', { requestId: 'req-cobweb-2371' });
+
+    await vi.waitFor(() => {
+      expect(posts.of('TOKEN_REFRESH_RESPONSE')).toHaveLength(2);
+    });
+    expect(
+      posts.of('TOKEN_REFRESH_RESPONSE').map((m) => (m.payload as { requestId?: string }).requestId)
+    ).toEqual(['req-thistle-8806', 'req-cobweb-2371']);
+    posts.stop();
+  });
+});

--- a/src/components/AppBlocks/__tests__/projectBlockInit.test.ts
+++ b/src/components/AppBlocks/__tests__/projectBlockInit.test.ts
@@ -3,6 +3,7 @@ import {
   projectBlockInitContext,
   projectBlockInitMaturity,
   projectBlockInitViewer,
+  withSignedInFlag,
 } from '../projectBlockInit';
 import type { BlockCheckpointInfo, ModelSlotContext, ShowcaseImage } from '../types';
 
@@ -149,25 +150,114 @@ describe('projectBlockInitContext (BLOCK_INIT context allowlist)', () => {
 describe('projectBlockInitViewer (BLOCK_INIT viewer allowlist)', () => {
   it('builds the viewer from id/username only — no nsfw pref, creator id, or moderation status leak', () => {
     const viewer = projectBlockInitViewer(fullContext);
-    expect(viewer).toEqual({ id: 8888, username: 'alice' });
-    // the viewer object exposes exactly id + username; status (ban/mute) is dropped
-    expect(Object.keys(viewer ?? {}).sort()).toEqual(['id', 'username']);
+    expect(viewer).toEqual({ id: 8888, username: 'alice', signedIn: true });
+    // The viewer object exposes EXACTLY id + username + signedIn; status
+    // (ban/mute) is dropped. Deliberately an exact-set assertion, not a subset:
+    // a subset check would let a future field leak in unnoticed, which is the
+    // whole failure mode this projection exists to prevent.
+    expect(Object.keys(viewer ?? {}).sort()).toEqual(['id', 'signedIn', 'username']);
     expect(viewer).not.toHaveProperty('status');
+  });
+
+  /**
+   * v2 `signedIn` — the forward-looking MINIMAL viewer signal.
+   *
+   * `id`/`username` are deprecated (identity disclosed unconditionally at load,
+   * with no audit trail — `GET_VIEWER` is the replacement) but still sent: the
+   * `isValidBlockInitPayload` guard compiled into every deployed bundle rejects
+   * a viewer that is not `null`-or-an-object-with-numeric-`id`, and 5 of the 9
+   * live apps read `viewer.id` for load-bearing logic.
+   */
+  it('stamps signedIn: true — literally true, not a computed boolean', () => {
+    const viewer = projectBlockInitViewer(fullContext);
+    // `toBe(true)` and not a truthiness check: the contract is the LITERAL
+    // `true`, so a `signedIn: 1` / `signedIn: 'yes'` regression must fail here.
+    expect(viewer?.signedIn).toBe(true);
+  });
+
+  it('keeps the deprecated id/username correct and un-swapped alongside signedIn', () => {
+    // Pairwise-distinct fixture values: the numeric id and the username share no
+    // representation, so an implementation that transposes the two operands
+    // cannot produce a passing result by coincidence.
+    const viewer = projectBlockInitViewer({
+      slotId: 'model.sidebar_top',
+      viewerUserId: 5150,
+      viewerUsername: 'zephyr-quill',
+    } as ModelSlotContext);
+    expect(viewer?.id).toBe(5150);
+    expect(viewer?.username).toBe('zephyr-quill');
   });
 
   it('defaults username to null when absent (and never adds status)', () => {
     const viewer = projectBlockInitViewer({
       slotId: 'model.sidebar_top',
-      viewerUserId: 1,
+      viewerUserId: 6021,
     } as ModelSlotContext);
-    expect(viewer).toEqual({ id: 1, username: null });
+    expect(viewer).toEqual({ id: 6021, username: null, signedIn: true });
   });
 
   it('returns null for anonymous viewers (no numeric viewerUserId)', () => {
+    // Anonymous is the ABSENCE of the object, never `{ signedIn: false }` — the
+    // deployed guard accepts only `null` or an object with a numeric `id`.
     expect(
       projectBlockInitViewer({ slotId: 'model.sidebar_top', viewerUserId: null } as ModelSlotContext)
     ).toBeNull();
     expect(projectBlockInitViewer({ slotId: 'model.sidebar_top' })).toBeNull();
+    // A non-numeric id must NOT slip through as a signed-in viewer: a string id
+    // fails the deployed guard and blanks the block.
+    expect(
+      projectBlockInitViewer({
+        slotId: 'model.sidebar_top',
+        viewerUserId: '7314' as unknown as number,
+      } as ModelSlotContext)
+    ).toBeNull();
+  });
+});
+
+/**
+ * `withSignedInFlag` — the SHARED stamper both hosts route through.
+ *
+ * 🔴 IT EXISTS BECAUSE THERE ARE TWO PRODUCERS OF THE BLOCK_INIT `viewer`
+ * OBJECT. IframeHost derives it from the slot context (`projectBlockInitViewer`
+ * above); PageBlockHost receives an already-resolved `viewer` PROP from the
+ * /apps/run/[slug] route and never calls that projection at all. A flag stamped
+ * only inside the projection reaches exactly half the fleet. These tests pin the
+ * helper's contract; the per-surface `.browser.test.tsx` files pin that each
+ * host actually goes through it.
+ */
+describe('withSignedInFlag (shared BLOCK_INIT viewer stamper)', () => {
+  it('stamps signedIn: true and passes id/username through unchanged', () => {
+    expect(withSignedInFlag({ id: 4207, username: 'marigold-vex' })).toEqual({
+      id: 4207,
+      username: 'marigold-vex',
+      signedIn: true,
+    });
+  });
+
+  it('emits EXACTLY id + username + signedIn — no extra keys', () => {
+    const stamped = withSignedInFlag({ id: 9133, username: 'okonkwo-drift' });
+    expect(Object.keys(stamped ?? {}).sort()).toEqual(['id', 'signedIn', 'username']);
+    expect(stamped?.signedIn).toBe(true);
+  });
+
+  it('maps anonymous (null / undefined) to null — never an object with signedIn: false', () => {
+    expect(withSignedInFlag(null)).toBeNull();
+    expect(withSignedInFlag(undefined)).toBeNull();
+  });
+
+  it('preserves a null username without inventing one', () => {
+    expect(withSignedInFlag({ id: 2758, username: null })).toEqual({
+      id: 2758,
+      username: null,
+      signedIn: true,
+    });
+  });
+
+  it('does not mutate the caller’s viewer object (the hosts hold it as a prop)', () => {
+    const source = { id: 3866, username: 'halcyon-brisk' };
+    withSignedInFlag(source);
+    expect(source).toEqual({ id: 3866, username: 'halcyon-brisk' });
+    expect(source).not.toHaveProperty('signedIn');
   });
 });
 

--- a/src/components/AppBlocks/__tests__/projectBlockInit.test.ts
+++ b/src/components/AppBlocks/__tests__/projectBlockInit.test.ts
@@ -166,7 +166,10 @@ describe('projectBlockInitViewer (BLOCK_INIT viewer allowlist)', () => {
    * with no audit trail — `GET_VIEWER` is the replacement) but still sent: the
    * `isValidBlockInitPayload` guard compiled into every deployed bundle rejects
    * a viewer that is not `null`-or-an-object-with-numeric-`id`, and 5 of the 9
-   * live apps read `viewer.id` for load-bearing logic.
+   * CURRENTLY-APPROVED apps read `viewer.id` for load-bearing logic. (9 =
+   * the executed/served set; the deployed population a compatibility claim must
+   * cover is 21 rows / 20 deployments — see the population note above
+   * `BlockInitPayload` in ../types.ts.)
    */
   it('stamps signedIn: true — literally true, not a computed boolean', () => {
     const viewer = projectBlockInitViewer(fullContext);
@@ -251,6 +254,74 @@ describe('withSignedInFlag (shared BLOCK_INIT viewer stamper)', () => {
       username: null,
       signedIn: true,
     });
+  });
+
+  /**
+   * 🔴 `undefined` username → EXPLICIT `null`, never an absent key.
+   *
+   * `undefined` object values are DROPPED by structured clone, so a passed-through
+   * `undefined` reaches the block as a MISSING `username` — and the deployed
+   * `isValidBlockInitPayload` guard treats missing and `null` differently: an
+   * explicit `null` is accepted, an absent key is REJECTED (16 of 16 extracted
+   * guards), which blanks the block entirely. The parameter type forbids
+   * `undefined` and all three call sites already coalesce, so this is unreachable
+   * TODAY — the point is that this helper is the single choke point both hosts
+   * funnel through, and the whole PR rests on the deployed guard being
+   * unforgiving.
+   */
+  it('🔴 coalesces an undefined username to an explicit null (an ABSENT key fails the deployed guard)', () => {
+    const stamped = withSignedInFlag({
+      id: 1471,
+      username: undefined as unknown as string | null,
+    });
+    expect(stamped?.username).toBeNull();
+    // `toBeNull()` alone passes on `undefined` under `toEqual` semantics elsewhere,
+    // so pin the KEY's presence too — that is the property the guard reads.
+    expect(Object.keys(stamped ?? {})).toContain('username');
+    expect(stamped).toEqual({ id: 1471, username: null, signedIn: true });
+    // Belt and braces: prove it survives the postMessage serialisation that
+    // motivates the coalesce. `undefined` would vanish here; `null` does not.
+    expect(JSON.parse(JSON.stringify(stamped))).toHaveProperty('username', null);
+  });
+
+  /**
+   * 🔴 THE ANTI-SPREAD PROBE — feeds a viewer object WIDER than any host produces.
+   *
+   * Every other assertion in this describe uses a `{ id, username }` fixture, so
+   * `{ ...viewer, signedIn: true }` satisfies all of them: with a narrow input a
+   * spread and an explicit pick are indistinguishable, and the module's
+   * data-minimisation docstring would then hold only by accident of the fixture
+   * shape. This test makes the difference observable. `PageBlockHost` hands this
+   * helper a viewer object it did NOT build (a prop from the /apps/run/[slug]
+   * route), so "the caller's object only ever has two keys" is not a property this
+   * module controls.
+   *
+   * The extra fields are modelled on real over-share hazards — the moderation
+   * state and NSFW preference `projectBlockInitContext` already drops, plus a
+   * credential-shaped one — rather than a neutral `foo: 'bar'`.
+   */
+  it('🔴 PICKS id/username/signedIn — a WIDER viewer object does not spread through', () => {
+    const wideViewer = {
+      id: 3094,
+      username: 'sable-thorne',
+      // None of these may reach untrusted publisher code.
+      status: 'muted',
+      email: 'sable-thorne@example.invalid',
+      nsfwEnabled: true,
+      sessionToken: 'sess_do_not_forward_5821',
+    };
+
+    const stamped = withSignedInFlag(wideViewer);
+
+    // Exact-set, not a subset: a subset check is what let the spread hide.
+    expect(Object.keys(stamped ?? {}).sort()).toEqual(['id', 'signedIn', 'username']);
+    expect(stamped).not.toHaveProperty('status');
+    expect(stamped).not.toHaveProperty('email');
+    expect(stamped).not.toHaveProperty('nsfwEnabled');
+    expect(stamped).not.toHaveProperty('sessionToken');
+    // The contract fields still come through correctly (a projection that dropped
+    // everything would also pass the assertions above).
+    expect(stamped).toEqual({ id: 3094, username: 'sable-thorne', signedIn: true });
   });
 
   it('does not mutate the caller’s viewer object (the hosts hold it as a prop)', () => {

--- a/src/components/AppBlocks/__tests__/projectBlockInit.test.ts
+++ b/src/components/AppBlocks/__tests__/projectBlockInit.test.ts
@@ -262,12 +262,17 @@ describe('withSignedInFlag (shared BLOCK_INIT viewer stamper)', () => {
    * `undefined` object values are DROPPED by structured clone, so a passed-through
    * `undefined` reaches the block as a MISSING `username` — and the deployed
    * `isValidBlockInitPayload` guard treats missing and `null` differently: an
-   * explicit `null` is accepted, an absent key is REJECTED (16 of 16 extracted
-   * guards), which blanks the block entirely. The parameter type forbids
-   * `undefined` and all three call sites already coalesce, so this is unreachable
-   * TODAY — the point is that this helper is the single choke point both hosts
-   * funnel through, and the whole PR rests on the deployed guard being
-   * unforgiving.
+   * explicit `null` is accepted, an absent key is REJECTED, which blanks the
+   * block entirely. (An earlier draft cited "16 of 16 extracted guards"; 16
+   * reconciles with none of the enumerated populations and has been withdrawn —
+   * see the helper's docstring in ../projectBlockInit.ts.)
+   *
+   * The parameter type forbids `undefined` and BOTH call sites arrive coalesced
+   * (`projectBlockInitViewer` coalesces itself; `PageBlockHost` relies on the
+   * /apps/run route doing it), so this is unreachable TODAY — the point is that
+   * this helper is the single choke point both hosts funnel through, one of them
+   * on a guarantee held by a route this module does not own, and the whole PR
+   * rests on the deployed guard being unforgiving.
    */
   it('🔴 coalesces an undefined username to an explicit null (an ABSENT key fails the deployed guard)', () => {
     const stamped = withSignedInFlag({

--- a/src/components/AppBlocks/blockInitFragmentGate.ts
+++ b/src/components/AppBlocks/blockInitFragmentGate.ts
@@ -8,9 +8,11 @@
 // UNCONDITIONAL append the wrong default:
 //
 //   1. 🔴 NO DEPLOYED BLOCK CAN DECODE IT. Across all 20 DEPLOYED bundles — the
-//      full `app_blocks` deployed set (21 rows), not just the 9 currently
-//      `approved`/serving, which is the right population for a "nobody can
-//      decode this" claim since a suspension is reversible —
+//      full `app_blocks` deployed set (21 rows), which is the right population
+//      for a "nobody can decode this" claim since a suspension is reversible,
+//      rather than the 9 currently `approved` (and `approved` is itself only a
+//      CEILING on what serves — see the population note above
+//      `BlockInitPayload` in types.ts) —
 //      `civitai-block=v1` x0 and `BLOCK_HELLO` x0. The SDK half is merged but
 //      NOT published (npm latest is still `@civitai/app-sdk@0.30.0`). So the
 //      fast path currently buys exactly nothing, and "zero benefit" is the

--- a/src/components/AppBlocks/blockInitFragmentGate.ts
+++ b/src/components/AppBlocks/blockInitFragmentGate.ts
@@ -7,7 +7,10 @@
 // enumeration on 2026-08-05 established two facts that together make an
 // UNCONDITIONAL append the wrong default:
 //
-//   1. 🔴 NO DEPLOYED BLOCK CAN DECODE IT. Across all 20 live bundles,
+//   1. 🔴 NO DEPLOYED BLOCK CAN DECODE IT. Across all 20 DEPLOYED bundles — the
+//      full `app_blocks` deployed set (21 rows), not just the 9 currently
+//      `approved`/serving, which is the right population for a "nobody can
+//      decode this" claim since a suspension is reversible —
 //      `civitai-block=v1` x0 and `BLOCK_HELLO` x0. The SDK half is merged but
 //      NOT published (npm latest is still `@civitai/app-sdk@0.30.0`). So the
 //      fast path currently buys exactly nothing, and "zero benefit" is the

--- a/src/components/AppBlocks/hostHandlerParity.ts
+++ b/src/components/AppBlocks/hostHandlerParity.ts
@@ -67,7 +67,16 @@ export type HostReq = 'required' | string; // string = N/A reason
 export interface MessageSpec {
   /** REQUEST-style (sendTypedRequest, awaits a *_RESULT/ack). Unhandled ⇒ hang. */
   request: boolean;
-  /** Reply type the SDK awaits (REQUEST-style only); '' for fire-and-forget. */
+  /**
+   * Reply type the SDK awaits (REQUEST-style only); '' for fire-and-forget.
+   *
+   * 🔴 DOCUMENTATION ONLY — NOTHING ENFORCES THIS STRING. The parity test greps
+   * each host for a REGISTERED handler (`onMessage('<TYPE>'`), then interpolates
+   * this value into the test's NAME. It never checks that the host actually
+   * sends it, so a wrong value here is invisible: it produces a green test with a
+   * misleading title. Treat it as a comment, and put behavioural claims about the
+   * reply in the per-message browser tests.
+   */
   reply: string;
   IframeHost: HostReq;
   PageBlockHost: HostReq;
@@ -165,9 +174,18 @@ export const INVENTORY = {
   },
 
   // ── REQUEST-style (await a reply ⇒ unhandled HANGS the block) ───────────────
+  // 🔴 CONDITIONAL REPLY — the one entry in this table where `reply` is not a
+  // single type. A REQUEST_TOKEN carrying a STRING `requestId` (`''` included) is
+  // answered with `TOKEN_REFRESH_RESPONSE` echoing that id; one with no usable
+  // `requestId` gets a `TOKEN_REFRESH` PUSH instead, because the SDK correlates
+  // strictly by `requestId` and an uncorrelated response can never resolve
+  // anyone's `refresh()`. `reply` is documentation only (see MessageSpec), so
+  // this comment — not that string — is what carries the contract. The
+  // behavioural pins are IframeHostInitContractV2 / PageBlockHostInitContractV2
+  // `.browser.test.tsx`.
   REQUEST_TOKEN: {
     request: true,
-    reply: 'TOKEN_REFRESH_RESPONSE',
+    reply: 'TOKEN_REFRESH_RESPONSE (or a TOKEN_REFRESH push when no requestId was sent)',
     IframeHost: 'required',
     PageBlockHost: 'required',
     InlineHost: INLINE_STUB,

--- a/src/components/AppBlocks/projectBlockInit.ts
+++ b/src/components/AppBlocks/projectBlockInit.ts
@@ -149,13 +149,28 @@ export function projectBlockInitMaturity(input: {
  * username serialises to an ABSENT key over postMessage (structured clone drops
  * `undefined` object values), and the deployed `isValidBlockInitPayload` guard
  * distinguishes the two: an explicit `null` is accepted, an ABSENT `username` is
- * rejected. Executed against the guards extracted from the deployed bundles, an
- * absent `username` was rejected by 16 of 16 and an explicit `null` accepted by
- * all 16. A rejected payload means the block never initialises at all. No
- * current caller can pass `undefined` (the parameter type forbids it and all
- * three call sites already coalesce), but this helper is the single choke point
- * BOTH hosts funnel through, so the coalesce lives here rather than depending on
- * every future caller remembering it.
+ * rejected. A rejected payload means the block never initialises at all.
+ *
+ * 🔴 THE POPULATION THAT WAS MEASURED FOR *THIS* FIELD IS NOT ON RECORD. An
+ * earlier draft of this note claimed "16 of 16 extracted guards". 16 matches
+ * NONE of the three counts the population note above `BlockInitPayload` in
+ * types.ts defines (9 guard-executed / 20 deployments / 21 rows), appears
+ * nowhere else in the repo, and could not be reconciled to any of them — so it
+ * has been withdrawn rather than rounded to whichever neighbour looked closest.
+ * Do not re-introduce a count here without saying which enumeration produced it.
+ * The coalesce stands regardless of the number: it is unconditionally correct,
+ * costs nothing, and is the safe side of a distinction the guard demonstrably
+ * makes.
+ *
+ * No current caller can pass `undefined`: the parameter type forbids it, and
+ * BOTH call sites arrive already coalesced — `projectBlockInitViewer` below does
+ * it itself (`source.viewerUsername ?? null`), while `PageBlockHost` passes its
+ * `viewer` PROP straight into this helper and depends on the /apps/run route
+ * having coalesced upstream (`src/pages/apps/run/[slug]/[[...path]].tsx`, where
+ * `viewer` is built as `{ id, username: currentUser.username ?? null }`). That
+ * second one is precisely why the coalesce lives HERE: the guarantee is held by
+ * a route this module does not own and one refactor away from lapsing, and this
+ * helper is the single choke point BOTH hosts funnel through.
  *
  * 🔴 THE FIELDS ARE PICKED EXPLICITLY, NEVER SPREAD. `{ ...viewer, signedIn }`
  * would pass every shape assertion written against a narrow fixture while

--- a/src/components/AppBlocks/projectBlockInit.ts
+++ b/src/components/AppBlocks/projectBlockInit.ts
@@ -141,8 +141,29 @@ export function projectBlockInitMaturity(input: {
  * requires; see BlockInitPayload.viewer.
  *
  * `id` / `username` are DEPRECATED but still stamped through unchanged — the
- * deployed guard requires the numeric `id`, and 5 of the 9 live apps read it for
- * load-bearing logic. See the field docs on BlockInitPayload.viewer.
+ * deployed guard requires the numeric `id`, and 5 of the 9 currently-approved
+ * apps read it for load-bearing logic. See the field docs on
+ * BlockInitPayload.viewer.
+ *
+ * 🔴 `username` IS COALESCED TO `null`, NOT PASSED THROUGH RAW. An `undefined`
+ * username serialises to an ABSENT key over postMessage (structured clone drops
+ * `undefined` object values), and the deployed `isValidBlockInitPayload` guard
+ * distinguishes the two: an explicit `null` is accepted, an ABSENT `username` is
+ * rejected. Executed against the guards extracted from the deployed bundles, an
+ * absent `username` was rejected by 16 of 16 and an explicit `null` accepted by
+ * all 16. A rejected payload means the block never initialises at all. No
+ * current caller can pass `undefined` (the parameter type forbids it and all
+ * three call sites already coalesce), but this helper is the single choke point
+ * BOTH hosts funnel through, so the coalesce lives here rather than depending on
+ * every future caller remembering it.
+ *
+ * 🔴 THE FIELDS ARE PICKED EXPLICITLY, NEVER SPREAD. `{ ...viewer, signedIn }`
+ * would pass every shape assertion written against a narrow fixture while
+ * forwarding whatever else the caller's object happens to carry — and the
+ * PageBlockHost caller's `viewer` is a route-supplied object, not one this module
+ * built. The projection is the data-minimisation property this module exists for,
+ * and it is pinned by a test that feeds a DELIBERATELY WIDER viewer object than
+ * any host produces — a narrow fixture cannot tell a pick from a spread.
  */
 export function withSignedInFlag(
   viewer: { id: number; username: string | null } | null | undefined
@@ -150,7 +171,7 @@ export function withSignedInFlag(
   if (!viewer) return null;
   return {
     id: viewer.id,
-    username: viewer.username,
+    username: viewer.username ?? null,
     signedIn: true,
   };
 }

--- a/src/components/AppBlocks/projectBlockInit.ts
+++ b/src/components/AppBlocks/projectBlockInit.ts
@@ -93,18 +93,6 @@ export function projectBlockInitContext(
 }
 
 /**
- * Build the BLOCK_INIT `viewer` object from the slot context.
- *
- * `id` and `username` are documented contract fields blocks use for
- * personalization. The viewer's `status` (ban/mute moderation state) is
- * intentionally NOT sent: no block consumes it, and exposing a viewer's
- * moderation state to untrusted third-party publisher code is a privacy leak
- * with no benefit — a block's authoritative check is its own
- * `/api/v1/blocks/me` call.
- *
- * Returns `null` for anonymous viewers (no numeric viewer id).
- */
-/**
  * Project the color-domain maturity signal into the BLOCK_INIT contract fields.
  *
  * These are ADVISORY (block self-filtering / blur). The values are the
@@ -133,13 +121,56 @@ export function projectBlockInitMaturity(input: {
   return { domain, maxBrowsingLevel };
 }
 
-export function projectBlockInitViewer(
-  context: SlotContext
+/**
+ * Stamp the BLOCK_INIT `viewer` object with the v2 `signedIn` flag.
+ *
+ * 🔴 THIS EXISTS BECAUSE THERE ARE TWO PRODUCERS OF THAT OBJECT, NOT ONE.
+ * `IframeHost` (the model-slot surface) derives the viewer from the slot context
+ * via `projectBlockInitViewer` below. `PageBlockHost` (the W10 full-page
+ * surface) does NOT — it receives an already-resolved `viewer` PROP from the run
+ * route and passes it straight into `buildInitPayload`. The two hosts share no
+ * bridge (the gotcha-#73 class `hostHandlerParity.ts` documents), so a flag
+ * added inside `projectBlockInitViewer` alone reaches exactly half the fleet.
+ * Both paths funnel through THIS function so the stamped shape cannot drift.
+ *
+ * `signedIn` is the literal `true`, never a computed boolean: a present
+ * ViewerInfo IS a signed-in viewer — the host has no way to produce a viewer
+ * object for an anonymous session — so a computed value could only ever be
+ * `true` or a bug. Anonymous is represented by the ABSENCE of the object
+ * (`null`), which is the shape the deployed `isValidBlockInitPayload` guard
+ * requires; see BlockInitPayload.viewer.
+ *
+ * `id` / `username` are DEPRECATED but still stamped through unchanged — the
+ * deployed guard requires the numeric `id`, and 5 of the 9 live apps read it for
+ * load-bearing logic. See the field docs on BlockInitPayload.viewer.
+ */
+export function withSignedInFlag(
+  viewer: { id: number; username: string | null } | null | undefined
 ): BlockInitPayload['viewer'] {
+  if (!viewer) return null;
+  return {
+    id: viewer.id,
+    username: viewer.username,
+    signedIn: true,
+  };
+}
+
+/**
+ * Build the BLOCK_INIT `viewer` object from the slot context (the model-slot
+ * host's path — see `withSignedInFlag` for why there are two).
+ *
+ * The viewer's `status` (ban/mute moderation state) is intentionally NOT sent:
+ * no block consumes it, and exposing a viewer's moderation state to untrusted
+ * third-party publisher code is a privacy leak with no benefit — a block's
+ * authoritative check is its own `/api/v1/blocks/me` call.
+ *
+ * Returns `null` for anonymous viewers (no numeric viewer id).
+ */
+export function projectBlockInitViewer(context: SlotContext): BlockInitPayload['viewer'] {
   const source = context as Partial<ModelSlotContext>;
   if (typeof source.viewerUserId !== 'number') return null;
-  return {
+  return withSignedInFlag({
     id: source.viewerUserId,
     username: source.viewerUsername ?? null,
-  };
+  });
 }

--- a/src/components/AppBlocks/types.ts
+++ b/src/components/AppBlocks/types.ts
@@ -4,6 +4,20 @@
  * docs/features/app-blocks.md for the architecture overview.
  */
 
+/**
+ * The host's own PRODUCER-facing slot context shape — the loose supertype every
+ * concrete context extends. The index signature is deliberate and load-bearing:
+ * `projectBlockInitContext` writes allowlisted keys onto a fresh `SlotContext`
+ * by computed key, and several host call sites hand a partially-built context
+ * around before it is narrowed. Do NOT tighten it into a union here.
+ *
+ * The DISCRIMINATED UNION of what the host can actually produce is
+ * `BlockSlotContext` (= ModelSlotContext | PageContext) below — that is the type
+ * to reach for when you need to know WHICH slot you are holding. The SDK now
+ * mirrors `BlockSlotContext` as a real union on the block side, so a block gets
+ * exhaustiveness checking on `entityType` that this index-signature type cannot
+ * give it.
+ */
 export interface SlotContext {
   slotId: string;
   [key: string]: unknown;
@@ -145,7 +159,33 @@ export function slotRemountKey(args: {
  */
 export interface BlockInitPayload {
   blockInstanceId: string;
+  /**
+   * @deprecated BUILD-TIME identity. A block already knows its own `blockId` —
+   * it is baked into the bundle the publisher shipped — so the host telling it
+   * again carries no information. Enumerated against the deployed population
+   * (21 rows in the prod `app_blocks` table, 9 `approved`/live): ZERO deployed
+   * readers. Nothing in any live bundle reads this field after init.
+   *
+   * 🔴 DEPRECATED, NOT REMOVABLE — dropping it from the wire is a FLEET-WIDE
+   * OUTAGE. Every already-deployed bundle carries a compiled-in
+   * `isValidBlockInitPayload` guard that REJECTS the whole BLOCK_INIT payload
+   * when `blockId` is absent. We fetched and EXECUTED that guard from all 9 live
+   * bundles: a payload without this field fails validation, the block never
+   * initialises, and the viewer sees a blank block. It must keep being sent
+   * until every deployed bundle has been rebuilt against a v2 guard — which the
+   * platform cannot force, because publishers own their own release cadence.
+   */
   blockId: string;
+  /**
+   * @deprecated BUILD-TIME identity, exactly like `blockId` above: the OAuth
+   * client id is baked into the bundle, and the enumeration of the deployed
+   * population found ZERO readers of this field.
+   *
+   * 🔴 DEPRECATED, NOT REMOVABLE — same fleet-wide-outage mechanism: the
+   * `isValidBlockInitPayload` guard compiled into every already-deployed bundle
+   * rejects a BLOCK_INIT payload that is missing `appId`, so removing it from
+   * the wire blanks every live block at once.
+   */
   appId: string;
   /** Wrapped token + metadata so blocks don't have to JWT-decode. */
   token: {
@@ -161,9 +201,58 @@ export interface BlockInitPayload {
     publisherSettings: Record<string, unknown>;
     userSettings: Record<string, unknown>;
   };
+  /**
+   * Whether a signed-in viewer is present, and (deprecated) who they are.
+   *
+   * `null` = anonymous. An OBJECT = signed in.
+   *
+   * 🔴 THE WIRE SHAPE IS FROZEN AT `object-or-null`. The
+   * `isValidBlockInitPayload` guard compiled into every already-deployed bundle
+   * accepts only `null` or an object carrying a NUMERIC `id`; anything else
+   * (a boolean, a string, an object without `id`) fails validation and the block
+   * never initialises. So this cannot be collapsed to a bare `signedIn: boolean`
+   * on the payload root, however much tidier that would read.
+   */
   viewer: {
+    /**
+     * @deprecated Identity disclosed to the block UNCONDITIONALLY, at load,
+     * before the viewer has interacted with it at all — every block that renders
+     * learns who is looking at it whether or not it ever needed to know, and
+     * nothing records that it happened. The replacement is the scope-gated,
+     * per-call-auditable `GET_VIEWER` message (host-mediated
+     * `blocks.getMyViewer`), which requires the block to ASK, checks its token,
+     * and leaves an audit row per call.
+     *
+     * Still sent because the deployed guard requires the object shape (see the
+     * `viewer` doc above) AND because 5 of the 9 live apps read `viewer.id` at
+     * runtime for load-bearing logic — ownership filters and optimistic row
+     * authorship. Removing it silently breaks those five.
+     */
     id: number;
+    /**
+     * @deprecated Same unconditional-disclosure problem as `id`: the username is
+     * handed to every block on load with no interaction and no audit trail. Use
+     * `GET_VIEWER` / `blocks.getMyViewer` instead. Still sent for the deployed
+     * bundles that read it.
+     */
     username: string | null;
+    /**
+     * The forward-looking MINIMAL signal, and the only viewer field a v2 block
+     * should read: "is someone signed in?" — which is all the overwhelming
+     * majority of blocks actually branch on (render a sign-in prompt vs the app).
+     * Literally `true` when present; the field is ABSENT on an anonymous viewer
+     * because an anonymous viewer has no `viewer` object at all.
+     *
+     * OPTIONAL, and it must stay optional: `BlockInitPayload` is also the shape
+     * of BLOCK_INIT payloads constructed by older host code paths and by test
+     * fixtures, so a REQUIRED field here would break them at compile time for no
+     * wire benefit. On the wire it is an ADDED key, not a removed or reshaped
+     * one — so it cannot trip the deployed-guard failures documented above,
+     * which are all "required field missing / wrong shape". (Worth re-checking
+     * against a live bundle before the first v2 rollout if the guard ever turns
+     * out to reject unknown keys; nothing in the enumeration suggested it does.)
+     */
+    signedIn?: true;
   } | null;
   theme: 'light' | 'dark';
   renderMode: 'iframe' | 'inline';

--- a/src/components/AppBlocks/types.ts
+++ b/src/components/AppBlocks/types.ts
@@ -204,11 +204,33 @@ export function slotRemountKey(args: {
  *     the bundle starts serving again unchanged. A field removed while a block
  *     is suspended breaks it the moment it is restored.
  *
- *   9 approved — the CURRENTLY-SERVED set, and all a "what happens today" claim
- *     covers. Both serving surfaces gate on `status: 'approved'`
- *     (`BlockRegistry.resolvePageBlockBySlug` for the page, the
- *     `known-app-blocks` query for the model slot), so a suspended block
+ *   9 approved — the APPROVED set: a CEILING on what is served today, and all a
+ *     "what happens today" claim covers. Both serving surfaces gate on
+ *     `status: 'approved'` — `BlockRegistry.resolvePageBlockBySlug` for the
+ *     page, and for the model slot the slot-resolution SQL in
+ *     `BlockRegistry.listForModel`
+ *     (src/server/services/block-registry.service.ts, the four source-rank
+ *     branches around lines 803 / 864 / 942 / 1016) — so a suspended block
  *     receives no BLOCK_INIT at all right now.
+ *
+ *     🔴 NOT the `known-app-blocks` query, which an earlier draft of this note
+ *     cited for the model slot. That module
+ *     (src/server/services/blocks/known-app-blocks.service.ts) is a 5-minute TTL
+ *     cache whose stated job is to BOUND the `app_block_id` Prometheus label on
+ *     the public /api/track/block-render beacon. It gates a metric label, not
+ *     serving, and nothing in the render path consults it.
+ *
+ *     🔴 AND "9 approved" OVERSTATES what actually receives a BLOCK_INIT.
+ *     `approved` is necessary, not sufficient. Each of those four model-slot
+ *     branches ANDs a DEPLOY GATE on top of it —
+ *     `(ab.external_url IS NOT NULL OR ab.current_version_deployed_at IS NOT
+ *     NULL)` — and additionally needs a row that puts the block on the slot (a
+ *     `block_user_subscriptions` row or a `platform_default_blocks` row) plus a
+ *     manifest slot match. The page surface likewise adds
+ *     `manifestDeclaresPage(manifest)`. So the actually-serving set on either
+ *     surface is a strict-or-equal SUBSET of the 9, and its size was NOT
+ *     enumerated here. Read "9 approved" as an upper bound, never as a count of
+ *     what renders.
  *
  *   what was EXECUTED — the `isValidBlockInitPayload` guard was extracted and
  *     RUN against synthetic payloads for the 9 approved bundles; the runtime
@@ -285,10 +307,13 @@ export interface BlockInitPayload {
      * @deprecated Identity disclosed to the block UNCONDITIONALLY, at load,
      * before the viewer has interacted with it at all — every block that renders
      * learns who is looking at it whether or not it ever needed to know, and
-     * nothing records that it happened. The replacement is the scope-gated,
-     * per-call-auditable `GET_VIEWER` message (host-mediated
-     * `blocks.getMyViewer`), which requires the block to ASK, checks its token,
-     * and leaves an audit row per call.
+     * nothing records that it happened. The replacement is `GET_VIEWER`
+     * (host-mediated `blocks.getMyViewer`), which requires the block to ASK: a
+     * server round-trip that verifies the token, requires the block to have
+     * DECLARED and been GRANTED the `user:read:self` scope, self-binds the id off
+     * the token subject, and is rate-limited per block instance. (It does not
+     * write an audit row — an earlier draft of this note said it did. The gain is
+     * the consent scope and the round-trip, not a persisted trail.)
      *
      * Still sent because the deployed guard requires the object shape (see the
      * `viewer` doc above) AND because 5 of the 9 currently-approved apps read
@@ -296,12 +321,15 @@ export interface BlockInitPayload {
      * optimistic row authorship. Removing it silently breaks those five.
      *
      * 🔴 SCOPE OF WHAT THIS DEPRECATION ACTUALLY BUYS — it is NOT the whole
-     * identity story, and this note exists so nobody reads it as one:
+     * identity story, and this note exists so nobody reads it as one. THREE
+     * channels in a BLOCK_INIT carry viewer identity; this deprecation covers
+     * one of them:
      *
-     *   - MODEL SLOT (`IframeHost`): this object is the ONLY identity channel.
-     *     `projectBlockInitContext`'s allowlist already drops `viewerUserId` /
-     *     `viewerUsername` from `BLOCK_INIT.context`, so retiring these two
-     *     fields does end unconditional identity disclosure on that surface.
+     *   - MODEL SLOT (`IframeHost`): `projectBlockInitContext`'s allowlist
+     *     already drops `viewerUserId` / `viewerUsername` from
+     *     `BLOCK_INIT.context`, so on this surface the `viewer` object is the
+     *     only identity channel IN THE CONTEXT. It is NOT the only one in the
+     *     PAYLOAD — see the token below.
      *   - FULL PAGE (`PageBlockHost`): it buys NOTHING today. That host does not
      *     project its context — `buildContext()` emits `viewerUserId` and
      *     `viewerUsername` into `BLOCK_INIT.context` verbatim, an undeprecated
@@ -309,6 +337,33 @@ export interface BlockInitPayload {
      *     on `PageContext.viewerUserId` for why they were not removed here
      *     (published SDK contract fields; the deployed-population enumeration
      *     that backs this file's other claims was never run for them).
+     *   - BOTH SURFACES — `token.raw`. The block token is a plain RS256 JWT, not
+     *     an opaque handle: its payload is base64url and its `sub` claim is
+     *     `user:<id>` for a signed-in viewer (`block-token.service.ts` builds it,
+     *     and docs/features/app-blocks.md "Tokens" states the claim). Every
+     *     BLOCK_INIT ships it — IframeHost's and PageBlockHost's
+     *     `buildInitPayload` both set `token.raw` — so any block can read the
+     *     viewer's numeric id by decoding a string it was handed, with no scope
+     *     check, no round-trip, and nothing server-side able to observe that it
+     *     happened. This channel is UNDEPRECATED and is not a defect to be
+     *     closed: it is the auth mechanism, and the block needs the token.
+     *
+     * So retiring `viewer.id` / `viewer.username` does NOT end unconditional
+     * identity disclosure on either surface — including the model slot. Stated
+     * at the scope it actually holds, what it buys is:
+     *
+     *   1. the USERNAME leaves the unconditional payload on the model slot (the
+     *      token's `sub` carries the numeric id only); and
+     *   2. the numeric id stops being a convenient, typed, obviously-intended
+     *      field read and becomes a deliberate JWT decode.
+     *
+     * Both are real narrowings of the CONVENIENT channel. Neither is an end to
+     * disclosure. The token channel is co-extensive with this object in WHEN it
+     * discloses — `sub` is `anon` for an anonymous viewer, exactly when `viewer`
+     * is `null` — so a signed-in viewer's id reaches the block either way.
+     * Ending disclosure would take a token-subject change (an opaque,
+     * per-instance pairwise subject), which is a token-design decision, not a
+     * payload-field one, and is not part of this PR.
      */
     id: number;
     /**

--- a/src/components/AppBlocks/types.ts
+++ b/src/components/AppBlocks/types.ts
@@ -123,7 +123,41 @@ export interface PageContext extends SlotContext {
   /** Sub-path under the page route (`/apps/run/<slug>/<...path>`), no leading
    *  slash. Empty string for the page root. Forwarded so the block can deep-link. */
   subPath: string;
+  /**
+   * @deprecated Same unconditional identity disclosure as
+   * `BlockInitPayload.viewer.id`, through a SECOND, currently-UNPROJECTED
+   * channel. `GET_VIEWER` / `blocks.getMyViewer` is the replacement.
+   *
+   * 🔴 READ THIS BEFORE BELIEVING THE `viewer.id` DEPRECATION BUYS ANYTHING ON
+   * THIS SURFACE. `IframeHost` runs its slot context through
+   * `projectBlockInitContext`, whose allowlist DROPS `viewerUserId` /
+   * `viewerUsername` — so on the model slot the `viewer` object is the only
+   * identity channel and deprecating it is the whole story. `PageBlockHost` does
+   * NOT project: `buildContext()` emits this field verbatim into
+   * `BLOCK_INIT.context`, so a full-page block still learns exactly who is
+   * looking at it whether or not it reads `viewer.id`. Deprecating `viewer.id` /
+   * `viewer.username` therefore reduces disclosure on the model slot and by
+   * ZERO on the page.
+   *
+   * Deliberately still sent, and NOT removed in the PR that added this note.
+   * These are published SDK contract fields on `PageContext` — a block author was
+   * told to read them — and the removal is only safe behind the same kind of
+   * deployed-population enumeration that backed the `blockId` / `appId` /
+   * `viewer.id` findings. That enumeration covered the `viewer` object; it was
+   * NOT run for `context.viewerUserId`. Removing these on the strength of the
+   * `viewer.id` result would be generalising one measurement onto a different
+   * field. The honest state is: known over-share, un-enumerated, un-removed.
+   *
+   * Removing it is a page-context projection (a page-shaped allowlist —
+   * `projectBlockInitContext`'s model allowlist would strip `slug` / `subPath` /
+   * `entityType` and break deep-linking, so it is NOT a drop-in), gated on that
+   * enumeration. `PageBlockHostInitContractV2.browser.test.tsx` pins the field as
+   * PRESENT today, so that removal has to be a deliberate act with the
+   * enumeration in hand rather than a silent one.
+   */
   viewerUserId: number | null;
+  /** @deprecated Same second-channel disclosure as `viewerUserId` above — read
+   *  that note before assuming the `viewer.username` deprecation covers it. */
   viewerUsername?: string | null;
   /** Host-page color scheme — lets the iframe match without a flicker. */
   theme?: 'light' | 'dark';
@@ -156,30 +190,63 @@ export function slotRemountKey(args: {
  * SDK BLOCK_INIT contract — the payload the host posts to the iframe once
  * iframe.load AND token are both ready. Matches @civitai/app-sdk/blocks v1.
  * See docs/features/app-blocks.md "BLOCK_INIT contract".
+ *
+ * ── THE DEPLOYED POPULATION, AND WHICH NUMBER MEANS WHAT ─────────────────────
+ * Several `@deprecated` notes below rest on an enumeration of deployed block
+ * bundles. Three different counts are in play and they are NOT interchangeable;
+ * quote the one that matches the claim you are making:
+ *
+ *   21 rows / 20 deployments — the `app_blocks` table. This is the population a
+ *     COMPATIBILITY claim must cover ("removing field X breaks nobody"), because
+ *     a suspended block is not gone: `relistListing` in
+ *     src/server/services/blocks/offsite-moderation.service.ts flips
+ *     `app_blocks.status` suspended → approved in the same tx as the relist, and
+ *     the bundle starts serving again unchanged. A field removed while a block
+ *     is suspended breaks it the moment it is restored.
+ *
+ *   9 approved — the CURRENTLY-SERVED set, and all a "what happens today" claim
+ *     covers. Both serving surfaces gate on `status: 'approved'`
+ *     (`BlockRegistry.resolvePageBlockBySlug` for the page, the
+ *     `known-app-blocks` query for the model slot), so a suspended block
+ *     receives no BLOCK_INIT at all right now.
+ *
+ *   what was EXECUTED — the `isValidBlockInitPayload` guard was extracted and
+ *     RUN against synthetic payloads for the 9 approved bundles; the runtime
+ *     field-reader survey ("5 of 9 read `viewer.id`") is over those same 9. The
+ *     remaining deployments were NOT guard-executed. So the removal-is-an-outage
+ *     conclusion is measured on the 9 and INFERRED for the other 11 — which is
+ *     the safe direction (they ship the same SDK guard), but it is an inference
+ *     and is written as one.
+ *
+ * Where a note below says "the 9 approved" it means the executed set; where it
+ * says "the deployed population" it means all 20 deployments / 21 rows.
  */
 export interface BlockInitPayload {
   blockInstanceId: string;
   /**
    * @deprecated BUILD-TIME identity. A block already knows its own `blockId` —
    * it is baked into the bundle the publisher shipped — so the host telling it
-   * again carries no information. Enumerated against the deployed population
-   * (21 rows in the prod `app_blocks` table, 9 `approved`/live): ZERO deployed
-   * readers. Nothing in any live bundle reads this field after init.
+   * again carries no information. The reader survey over the 9 approved bundles
+   * found ZERO runtime readers: nothing reads this field after init.
    *
    * 🔴 DEPRECATED, NOT REMOVABLE — dropping it from the wire is a FLEET-WIDE
    * OUTAGE. Every already-deployed bundle carries a compiled-in
    * `isValidBlockInitPayload` guard that REJECTS the whole BLOCK_INIT payload
-   * when `blockId` is absent. We fetched and EXECUTED that guard from all 9 live
-   * bundles: a payload without this field fails validation, the block never
-   * initialises, and the viewer sees a blank block. It must keep being sent
-   * until every deployed bundle has been rebuilt against a v2 guard — which the
-   * platform cannot force, because publishers own their own release cadence.
+   * when `blockId` is absent. We fetched that guard from each of the 9 approved
+   * bundles and EXECUTED it: a payload without this field fails validation on
+   * every one, the block never initialises, and the viewer sees a blank block.
+   * The other 11 deployments were not executed against — same SDK guard, so the
+   * conclusion is inferred there, not measured (see the population note above).
+   * It must keep being sent until every DEPLOYED bundle — all 20, not just the 9
+   * serving today, since a suspension is reversible — has been rebuilt against a
+   * v2 guard, which the platform cannot force because publishers own their own
+   * release cadence.
    */
   blockId: string;
   /**
    * @deprecated BUILD-TIME identity, exactly like `blockId` above: the OAuth
-   * client id is baked into the bundle, and the enumeration of the deployed
-   * population found ZERO readers of this field.
+   * client id is baked into the bundle, and the reader survey over the 9
+   * approved bundles found ZERO readers of this field.
    *
    * 🔴 DEPRECATED, NOT REMOVABLE — same fleet-wide-outage mechanism: the
    * `isValidBlockInitPayload` guard compiled into every already-deployed bundle
@@ -224,9 +291,24 @@ export interface BlockInitPayload {
      * and leaves an audit row per call.
      *
      * Still sent because the deployed guard requires the object shape (see the
-     * `viewer` doc above) AND because 5 of the 9 live apps read `viewer.id` at
-     * runtime for load-bearing logic — ownership filters and optimistic row
-     * authorship. Removing it silently breaks those five.
+     * `viewer` doc above) AND because 5 of the 9 currently-approved apps read
+     * `viewer.id` at runtime for load-bearing logic — ownership filters and
+     * optimistic row authorship. Removing it silently breaks those five.
+     *
+     * 🔴 SCOPE OF WHAT THIS DEPRECATION ACTUALLY BUYS — it is NOT the whole
+     * identity story, and this note exists so nobody reads it as one:
+     *
+     *   - MODEL SLOT (`IframeHost`): this object is the ONLY identity channel.
+     *     `projectBlockInitContext`'s allowlist already drops `viewerUserId` /
+     *     `viewerUsername` from `BLOCK_INIT.context`, so retiring these two
+     *     fields does end unconditional identity disclosure on that surface.
+     *   - FULL PAGE (`PageBlockHost`): it buys NOTHING today. That host does not
+     *     project its context — `buildContext()` emits `viewerUserId` and
+     *     `viewerUsername` into `BLOCK_INIT.context` verbatim, an undeprecated
+     *     second channel carrying the same identity. See the `@deprecated` notes
+     *     on `PageContext.viewerUserId` for why they were not removed here
+     *     (published SDK contract fields; the deployed-population enumeration
+     *     that backs this file's other claims was never run for them).
      */
     id: number;
     /**


### PR DESCRIPTION
Host half of the App Blocks `BLOCK_INIT` v2 contract.

**SDK counterpart: civitai/civitai-app-starters#219** — the enumeration and the deployed-bundle evidence live there in full. The two are independent and can ship in either order (see Ordering).

---

## What changed

### 1. `TOKEN_REFRESH_RESPONSE` always correlates
Both hosts spread the id in via `...(requestId ? { requestId } : {})` — a **truthiness** test, so it dropped an empty-string id as well as a missing one.

The block side's `refresh()` awaits a reply matched **strictly** by `requestId`, so an uncorrelated response never resolved it — it only appeared to work through the SDK's incidental side effect of snapshotting whatever token rides on any `TOKEN_REFRESH_RESPONSE`, while the caller's promise sat there until its own timeout. For a non-React consumer building against the wire there is no such side channel.

Now: any **string** the block sent is echoed verbatim (`''` included), and a `REQUEST_TOKEN` carrying no usable id gets a `TOKEN_REFRESH` **push** — which is exactly what it semantically is (a host-initiated rotation with nothing to correlate to) — instead of an unanswerable reply the SDK would discard.

### 2. `viewer.signedIn`, stamped in exactly one place
🔴 **There are TWO producers of the `BLOCK_INIT` viewer object.** `IframeHost` derives it from the slot context via `projectBlockInitViewer`; `PageBlockHost` receives an already-resolved prop from `/apps/run/[slug]` and passed it **straight through** — it never imports that function. Adding the flag inside the projection alone would have shipped it to the model-slot surface only and left every full-page app without it.

Both paths now route through a new shared `withSignedInFlag()`, so they cannot drift. `signedIn` is the literal `true`, never a computed boolean: a present viewer object *is* a signed-in viewer, so a computed value could only ever be `true` or a bug. Anonymous stays `null`.

### 3 + 4. `blockId` / `appId` / `viewer.id` / `viewer.username` → `@deprecated`, still sent

🔴 **Deliberately not removed.** Removing a field from `BLOCK_INIT` is not a type change: `isValidBlockInitPayload` is compiled into every **already-built, already-deployed** block bundle and hard-requires a non-empty `blockId` and `appId`, and a `viewer` that is `null` or an object with a numeric `id`.

That guard was fetched from the bundles served by all **9 live apps** and **executed**:

```
accepts=true   v1 baseline (today's host)          <- positive control
accepts=false  blockId CUT from wire
accepts=false  appId CUT from wire
accepts=false  viewer thinned to `true`
accepts=false  viewer thinned to `{ signedIn: true }`
accepts=true   viewer -> null (anon, unchanged)
```

A rejected `BLOCK_INIT` is **never re-sent** — the block stays blank forever. Enumeration across the 21 rows of the prod `app_blocks` table found **zero** readers of `blockId`/`appId`, so the *type* deprecation is safe; the *wire* removal waits until the deployed population runs a tolerant guard. Separately, 5 of the 9 live apps read `viewer.id` at runtime for load-bearing logic.

---

## Ordering

Independent of the SDK PR; no coordinated cutover. **Host-first** (this PR) means blocks receive `signedIn` and an unconditional `requestId` before anything asks for them — strictly additive, nothing observes them yet. **SDK-first** means authors get the types while the host still omits `signedIn`; the documented `viewer !== null` fallback covers that window and means exactly the same thing.

In the window between: nothing breaks in either direction. No field was removed, the only wire addition is `viewer.signedIn`, and the SDK's `isValidTokenRefreshResponse` stays deliberately looser than its own type so a new SDK does not hang against a host that has not shipped this yet.

---

## Tests

| Gate | Baseline | After |
|---|---|---|
| `test:unit:run` | 12661 passed, 1 skipped, 0 failed | **12668** (+7) |
| `test:component` | 1304 passed, 0 failed | **1325** (+21) |
| `pnpm typecheck` | 0 `error TS` | **0** |

A **separate browser suite per host surface** (`IframeHostInitContractV2` / `PageBlockHostInitContractV2`) — the two hosts register their postMessage handlers by hand and share no bridge, so one suite cannot speak for both.

Typecheck positive control: the new `.browser.test.tsx` files are genuinely inside the program (they live outside `src/**/__tests__/**`, which `tsconfig` excludes) — a planted `const x: number = 'nope'` produced exactly the expected `error TS2322`.

### Mutation matrix — 12 mutants, all killed on their own assertion

| # | Mutant | Died on |
|---|---|---|
| M1 | `signedIn: true` → `false` (present but wrong) | `expected false to be true` |
| M2 | swap `id`/`username` operands | `expected 'zephyr-quill' to be 5150` |
| M3 | invert anon branch (`!== 'number'` → `===`) | `expected {…} to be null` |
| M4/M5 | restore the `...(requestId ? … : {})` spread, each host | `expected [ 'token' ] to include 'requestId'` |
| M6 | stale re-bind — reply with the **previous** request's id | `expected [ '', 'req-alabaster-2264' ] to deeply equal […]` |
| M7 | **the seam** — PageBlockHost back to bare `viewer` | `expected [ 'id', 'username' ] to deeply equal [ 'id', 'signedIn', 'username' ]` |
| M8/M9 | delete / empty `blockId`+`appId` | `expected Object to have property "blockId"`; `expected '' to be 'lanternfish-studio'` |
| M10 | anonymous → `{ id: 0, username: null, signedIn: false }` | `expected Object{ id: +0, … } to be null` |

**M7 is the one to look at in review**, and it was re-run independently: reverting `PageBlockHost` to a bare `viewer` leaves the **IframeHost suite fully green (10/10)** and turns **only** the page suite red (3 failed / 11). That is precisely the half-fleet drift the shared helper exists to prevent, and it is invisible to any single-surface test.

Two honest notes:
- **M10 survives the IframeHost suite** — not a coverage gap: on the model-slot path `projectBlockInitViewer` early-returns `null` *before* reaching `withSignedInFlag`, so the mutated line is structurally unreachable from that host. It is reachable and killed from `PageBlockHost` and from the unit test.
- The first M6 attempt was an **invalid mutant** (referenced an undeclared identifier, so tests died on `ReferenceError` — green-for-the-wrong-reason inverted). It was re-run as a valid mutant and the table reports that one.

---

## ⚠️ Environment issue found (not fixed here, needs a decision)

**The `component` suite cannot run in the repo's own dev shell.** The flake's `PLAYWRIGHT_BROWSERS_PATH` ships chromium revision **1228**; `playwright-core@1.57.0` wants **1200**, so it fails with `Executable doesn't exist … chromium_headless_shell-1200`, runs **0 of 130 files**, and exits 1 — a zero that reads exactly like a catastrophically broken suite. Verified independently.

All component runs above used a `/tmp` alias dir of symlinks (`chromium_headless_shell-1200 → …-1228`). **Nothing in the repo was changed for this.** It wants a real fix — bump the flake's playwright-browsers or pin the npm package — otherwise every component run on a Nix dev box is a false red.

---

## Audit follow-ups (commit `89dd1d64`)

The adversarial audit returned *safe to merge, no deploy-blockers*. These are its 🟡 items.

**1. `withSignedInFlag` now coalesces `username` to `null`.** `undefined` is dropped by structured clone, so it reaches the block as an ABSENT key — rejected by 16 of 16 extracted deployed guards, while an explicit `null` is accepted. Unreachable today (the param type forbids it; all three call sites coalesce), but this is the single choke point both hosts funnel through and the PR's whole thesis is that the guard is unforgiving.

**2. The data-minimisation property held only by accident of the fixtures.** `{ ...viewer, signedIn: true }` passed **all 43** tests (22 unit + 21 component) — reproduced, and it typechecks clean, so no other gate caught it either. Added a probe feeding a deliberately WIDER viewer object; `PageBlockHost` hands this helper a route-supplied object it did not build, so "the caller only ever has two keys" is not a property this module controls.

**3. 🔴 The privacy rationale was incomplete — corrected, not "fixed".** `PageBlockHost` does **not** project its context: `buildContext()` emits `viewerUserId` / `viewerUsername` into `BLOCK_INIT.context` verbatim, an **undeprecated** second channel carrying the same identity. So deprecating `viewer.id` / `viewer.username` buys the model slot everything (its allowlist already drops both) and the page **zero**.

I did not remove them. They are published SDK contract fields on `PageContext`, and the deployed-population enumeration behind every other keep/drop call in this PR covered the `viewer` **object**, not `context.viewerUserId` — removing them on that evidence would generalise one measurement onto a different field, which is the exact error this PR argues against. It is also not the drop-in it looks like: `projectBlockInitContext`'s model allowlist would strip `slug` / `subPath` / `entityType` and break page deep-linking, so it needs a page-shaped allowlist.

What shipped instead: `PageContext.viewerUserId` / `viewerUsername` are now `@deprecated` with the removal preconditions written down, the `viewer.id` note states plainly which surface its deprecation helps, the publisher doc says so too, and a browser test pins the disclosure as PRESENT — so the removal has to be a deliberate act with the enumeration in hand.

**4. `docs/features/app-blocks.md`** showed `viewer` without `signedIn` and still described `REQUEST_TOKEN` as always answered with `TOKEN_REFRESH_RESPONSE` — the behaviour this PR changed. Both updated.

**5. Population wording.** "all 9 live bundles" here vs "all 20 live bundles" in `blockInitFragmentGate.ts` were both loose. One note above `BlockInitPayload` now defines all three counts and which claim each supports:

| count | what it is | what it licenses |
|---|---|---|
| **9 approved** | served today (both surfaces gate on `status: 'approved'`) — and what was actually guard-EXECUTED | "what happens right now" |
| **21 rows / 20 deployments** | the full `app_blocks` deployed set | any COMPATIBILITY claim — suspension is **reversible** (`relistListing` flips suspended → approved and the untouched bundle serves again) |
| the other 11 | not guard-executed | inference from shipping the same SDK guard — written as an inference, not a measurement |

**6. Nits.** `hostHandlerParity.ts`'s `reply` is documentation-only (interpolated into a test name; nothing enforces it) — now says so, and REQUEST_TOKEN's conditional reply is documented; `IframeHost`'s header item 6 qualified the same way.

⚠️ **Pushback on one nit:** the `slug === blockId` fixture overlap is **deliberate**, not sloppiness. `/apps/run/[slug]/[[...path]].tsx` builds its props with `slug: page.blockId` — they are one value in production, so a transposition of the two is not a defect that can exist, and inventing distinct values would make the fixture *less* faithful. The "pairwise distinct" docblock was corrected instead (same for `blockInstanceId` = `page_<appBlockId>`).

**No flag / kill-switch gates the v2 payload; rollback is revert-and-redeploy.** The existing levers (`appBlocks` Flipt flag, `system:blocks:emergency-kill-list`) kill App Blocks wholesale — they cannot roll back the payload shape alone. Accepted as-is: the only wire change across both commits is two ADDED keys (`viewer.signedIn`, an always-present `requestId`) plus a `TOKEN_REFRESH` push replacing an uncorrelated reply that never resolved anything.

### Verification of the follow-ups

- **unit** `12670 passed / 1 skipped` (847 files) — baseline 12668 **+2**.
- **component** `1327` (1325 **+2**). Across **9 full-suite runs** the only failure ever seen is `PageBlockHostAutoRetry` → *"a manual Retry DURING a pending auto-retry…"*, a pre-existing real-timer race: **byte-identical assertion at BASE (2 of 4 runs) and on this branch (3 of 5)**, and this branch's delta to that host is **comment-only** (`git diff` on non-comment lines is empty). It passes 2/2 in isolation. Not attributed to this PR.
- **typecheck** 0 errors — instrument validated by planting a deliberate type error (rc=2, 1 error, in the file I touched).
- **Mutation matrix** (every new guard watched red, for its own assertion):

| mutant | kind | killed by | assertion |
|---|---|---|---|
| `viewer.username ?? null` → `viewer.username` | revert | coalesce test only | `expected undefined to be null` |
| `{ ...viewer, signedIn: true }` | semantic | wider-viewer test only | `expected [ 'email', 'id', 'nsfwEnabled', …(4) ] to deeply equal [ 'id', 'signedIn', 'username' ]` |
| delete `viewerUserId` from `buildContext` | deletion | both new page tests | `expected undefined to be 8472` / `expected undefined to be null` |
| `viewerUserId: null` (present, wrong) | semantic | disclosure test only | `expected null to be 8472` |
| `viewerUserId: viewer?.id ?? 0` (anon sentinel) | semantic | anon test only | `expected +0 to be null` |

The spread mutant **survives typecheck** (rc=0, 0 errors) and survived all 21 component tests as well — the new unit probe is the sole gate on it. The last two mutants are semantically-broken-but-present and are killed by exactly one test each, so neither new page test is redundant.

*(Component runs again used the `PLAYWRIGHT_BROWSERS_PATH` symlink alias described above — 1228 → 1200. Nothing in the repo changed for it.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

