### PR TITLE
feat(collections): auto-apply a configurable tag to images submitted to a collection

### DIFF
--- a/src/server/schema/collection.schema.ts
+++ b/src/server/schema/collection.schema.ts
@@ -140,6 +140,11 @@ export const collectionMetadataSchema = z
     endsAt: z.coerce.date().nullish(),
     challengeDate: z.coerce.date().nullish(),
     maxItemsPerUser: z.coerce.number().optional(),
+    // Tag applied to every image submitted to this collection, whatever the
+    // submission's review status. Lets a collection's content be filtered out of
+    // feeds (the Beggars Board leaking into New & Upcoming is what prompted it)
+    // without hardcoding either the collection or the tag.
+    autoTagId: z.coerce.number().optional(),
     // Empty/absent means every base model is allowed. Values must match ModelVersion.baseModel
     // exactly — an unrecognized one matches no version and locks the contest to zero entries.
     baseModels: z

--- a/src/server/schema/collection.schema.ts
+++ b/src/server/schema/collection.schema.ts
@@ -144,7 +144,7 @@ export const collectionMetadataSchema = z
     // submission's review status. Lets a collection's content be filtered out of
     // feeds (the Beggars Board leaking into New & Upcoming is what prompted it)
     // without hardcoding either the collection or the tag.
-    autoTagId: z.coerce.number().optional(),
+    autoTagId: z.coerce.number().int().positive().optional(),
     // Empty/absent means every base model is allowed. Values must match ModelVersion.baseModel
     // exactly — an unrecognized one matches no version and locks the contest to zero entries.
     baseModels: z

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -54,6 +54,7 @@ import { userWithCosmeticsSelect } from '~/server/selectors/user.selector';
 import type { ArticleGetAll } from '~/server/services/article.service';
 import { getArticles } from '~/server/services/article.service';
 import { homeBlockCacheBust } from '~/server/services/home-block-cache.service';
+import { insertTagsOnImageNew } from '~/server/services/tagsOnImageNew.service';
 import type { ImagesInfiniteModel } from '~/server/services/image.service';
 import type { IngestImageInput } from '~/server/schema/image.schema';
 import { getAllImages, enqueueImageIngestion } from '~/server/services/image.service';
@@ -564,6 +565,60 @@ const inputToCollectionType = {
   postId: CollectionType.Post,
 } as const;
 
+/**
+ * Apply each collection's configured `metadata.autoTagId` to the images just added to
+ * it.
+ *
+ * Runs AFTER the write and independently of `CollectionItemStatus`, so a submission
+ * awaiting review is tagged the same as an accepted one — the point is to mark what was
+ * submitted, not what a moderator kept.
+ *
+ * Images only. `insertTagsOnImageNew` handles cache busting and the search-index push
+ * that feed filtering depends on, so nothing else needs syncing here.
+ *
+ * Never throws into the caller: a failed tag must not fail (or roll back) the
+ * submission itself.
+ */
+async function applyCollectionAutoTags(collectionIds: number[], imageIds: number[]) {
+  if (!collectionIds.length || !imageIds.length) return;
+
+  try {
+    const collections = await dbRead.collection.findMany({
+      where: { id: { in: [...new Set(collectionIds)] } },
+      select: { id: true, metadata: true },
+    });
+
+    const tagIds = [
+      ...new Set(
+        collections
+          .map((c) => (c.metadata as CollectionMetadataSchema | null)?.autoTagId)
+          .filter(isDefined)
+      ),
+    ];
+    if (!tagIds.length) return;
+
+    await insertTagsOnImageNew(
+      tagIds.flatMap((tagId) =>
+        [...new Set(imageIds)].map((imageId) => ({
+          imageId,
+          tagId,
+          source: 'User' as const,
+          confidence: 100,
+          automated: true,
+        }))
+      )
+    );
+  } catch (error) {
+    logToAxiom({
+      type: 'error',
+      name: 'collection-auto-tag-failed',
+      message: (error as Error).message,
+      collectionIds,
+      imageIds: imageIds.slice(0, 20),
+    }).catch();
+  }
+}
+
 export const saveItemInCollections = async ({
   input: {
     collections: upsertCollectionItems,
@@ -817,6 +872,12 @@ export const saveItemInCollections = async ({
   }
 
   await dbWrite.$transaction(transactions);
+
+  if (itemKey === 'imageId' && input.imageId)
+    await applyCollectionAutoTags(
+      data.map((d) => d.collectionId),
+      [input.imageId]
+    );
 
   // Check for updates to featured models
   if (input.modelId && collections.some((c) => c.id === FEATURED_MODEL_COLLECTION_ID)) {
@@ -2742,6 +2803,8 @@ export const bulkSaveItems = async ({
   }
 
   const { count } = await dbWrite.collectionItem.createMany({ data });
+
+  await applyCollectionAutoTags([collectionId], data.map((d) => d.imageId).filter(isDefined));
 
   // Entry fee (user challenges): charge AFTER the entries are written so a failed save never
   // leaves a paid-but-missing entry. Charges are idempotent per (challenge, image) and NEVER

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -54,8 +54,8 @@ import { userWithCosmeticsSelect } from '~/server/selectors/user.selector';
 import type { ArticleGetAll } from '~/server/services/article.service';
 import { getArticles } from '~/server/services/article.service';
 import { homeBlockCacheBust } from '~/server/services/home-block-cache.service';
-import { insertTagsOnImageNew } from '~/server/services/tagsOnImageNew.service';
-import { TagType } from '~/shared/utils/prisma/enums';
+import { getModeratedTags } from '~/server/services/system-cache';
+import { applyTagRules, insertTagsOnImageNew } from '~/server/services/tagsOnImageNew.service';
 import type { ImagesInfiniteModel } from '~/server/services/image.service';
 import type { IngestImageInput } from '~/server/schema/image.schema';
 import { getAllImages, enqueueImageIngestion } from '~/server/services/image.service';
@@ -594,16 +594,30 @@ async function applyCollectionAutoTag(
     // Defense in depth. `upsertCollection` already restricts `autoTagId` to moderators,
     // because nothing in the save path validates that the submitter OWNS the images —
     // so a self-owned collection plus someone else's imageIds would otherwise write tags
-    // onto a stranger's content. A MODERATED tag is the sharp end of that: it drives
-    // `updateImageNsfwLevels` and could push another user's image out of view. Refuse
-    // those here too, so a value set outside `upsertCollection` still can't reach it.
-    const tag = await dbRead.tag.findUnique({ where: { id: tagId }, select: { type: true } });
-    if (!tag || tag.type === TagType.Moderation) {
+    // onto a stranger's content. A moderated tag is the sharp end of that: it drives
+    // `updateImageNsfwLevels` and could push another user's image out of view.
+    //
+    // Tested against `getModeratedTags()` — what `updateImageNsfwLevels` itself gates on.
+    // `Tag.type === 'Moderation'` is NOT the same set: it misses ~37 prod tags that are
+    // moderated via `nsfwLevel > PG` or by inheriting a Parent edge, so checking type
+    // would look like a guard while letting all of them through.
+    //
+    // Resolved through `applyTagRules` FIRST, because a TagsOnTags rule can rewrite a
+    // permitted tag into a moderated one (~36 such rules in prod) — checking the raw
+    // `autoTagId` would pass while a moderated row still lands. Test what actually gets
+    // written, not what was configured. Both lookups are in-proc memoized.
+    const resolved = await applyTagRules(
+      imageIds.map((imageId) => ({ imageId, tagId, source: 'User' as const }))
+    );
+    const moderatedTagIds = await getModeratedTags().then((tags) => tags.map((t) => t.id));
+    const offending = resolved.find((t) => moderatedTagIds.includes(t.tagId));
+    if (offending) {
       logToAxiom({
         type: 'warning',
         name: 'collection-auto-tag-refused',
-        message: !tag ? 'autoTagId does not exist' : 'autoTagId is a moderation tag',
+        message: 'autoTagId resolves to a moderated tag',
         tagId,
+        resolvedTagId: offending.tagId,
       }).catch();
       return;
     }
@@ -952,8 +966,25 @@ export const upsertCollection = async ({
   // stamp an arbitrary tag onto a stranger's image — and a MODERATED tag additionally
   // drives `updateImageNsfwLevels`, so it could raise someone else's image out of view.
   // Moderator-only. Every other field here only affects the collection itself.
-  if (metadata && 'autoTagId' in metadata && !isModerator)
-    throw throwAuthorizationError('Only moderators can set a collection auto-tag');
+  // Non-moderators can't set or change it, but the edit modal round-trips the whole
+  // metadata blob — so rejecting on PRESENCE would 403 a co-manager who opened Edit and
+  // hit Save without touching (or knowing about) the field. Pin it to the stored value
+  // instead: their save becomes a no-op on this field rather than a wall.
+  if (!isModerator && metadata) {
+    const storedAutoTagId = id
+      ? (
+          (
+            await dbRead.collection.findUnique({
+              where: { id },
+              select: { metadata: true },
+            })
+          )?.metadata as CollectionMetadataSchema | null
+        )?.autoTagId
+      : undefined;
+
+    if (storedAutoTagId === undefined) delete metadata.autoTagId;
+    else metadata.autoTagId = storedAutoTagId;
+  }
 
   if (id) {
     const permission = await getUserCollectionPermissionsById({

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -55,6 +55,7 @@ import type { ArticleGetAll } from '~/server/services/article.service';
 import { getArticles } from '~/server/services/article.service';
 import { homeBlockCacheBust } from '~/server/services/home-block-cache.service';
 import { insertTagsOnImageNew } from '~/server/services/tagsOnImageNew.service';
+import { TagType } from '~/shared/utils/prisma/enums';
 import type { ImagesInfiniteModel } from '~/server/services/image.service';
 import type { IngestImageInput } from '~/server/schema/image.schema';
 import { getAllImages, enqueueImageIngestion } from '~/server/services/image.service';
@@ -566,54 +567,62 @@ const inputToCollectionType = {
 } as const;
 
 /**
- * Apply each collection's configured `metadata.autoTagId` to the images just added to
- * it.
+ * Apply a collection's configured `metadata.autoTagId` to the images just added to it.
  *
  * Runs AFTER the write and independently of `CollectionItemStatus`, so a submission
  * awaiting review is tagged the same as an accepted one — the point is to mark what was
  * submitted, not what a moderator kept.
  *
- * Images only. `insertTagsOnImageNew` handles cache busting and the search-index push
- * that feed filtering depends on, so nothing else needs syncing here.
+ * Takes the metadata rather than a collection id: both callers already hold the
+ * collection in scope, and re-reading it would add a query to every image submission on
+ * the site for a field almost no collection sets.
+ *
+ * `insertTagsOnImageNew` handles cache busting and the search-index push that feed
+ * filtering depends on, so nothing else needs syncing here.
  *
  * Never throws into the caller: a failed tag must not fail (or roll back) the
  * submission itself.
  */
-async function applyCollectionAutoTags(collectionIds: number[], imageIds: number[]) {
-  if (!collectionIds.length || !imageIds.length) return;
+async function applyCollectionAutoTag(
+  metadata: CollectionMetadataSchema | null | undefined,
+  imageIds: number[]
+) {
+  const tagId = metadata?.autoTagId;
+  if (!tagId || !imageIds.length) return;
 
   try {
-    const collections = await dbRead.collection.findMany({
-      where: { id: { in: [...new Set(collectionIds)] } },
-      select: { id: true, metadata: true },
-    });
-
-    const tagIds = [
-      ...new Set(
-        collections
-          .map((c) => (c.metadata as CollectionMetadataSchema | null)?.autoTagId)
-          .filter(isDefined)
-      ),
-    ];
-    if (!tagIds.length) return;
+    // Defense in depth. `upsertCollection` already restricts `autoTagId` to moderators,
+    // because nothing in the save path validates that the submitter OWNS the images —
+    // so a self-owned collection plus someone else's imageIds would otherwise write tags
+    // onto a stranger's content. A MODERATED tag is the sharp end of that: it drives
+    // `updateImageNsfwLevels` and could push another user's image out of view. Refuse
+    // those here too, so a value set outside `upsertCollection` still can't reach it.
+    const tag = await dbRead.tag.findUnique({ where: { id: tagId }, select: { type: true } });
+    if (!tag || tag.type === TagType.Moderation) {
+      logToAxiom({
+        type: 'warning',
+        name: 'collection-auto-tag-refused',
+        message: !tag ? 'autoTagId does not exist' : 'autoTagId is a moderation tag',
+        tagId,
+      }).catch();
+      return;
+    }
 
     await insertTagsOnImageNew(
-      tagIds.flatMap((tagId) =>
-        [...new Set(imageIds)].map((imageId) => ({
-          imageId,
-          tagId,
-          source: 'User' as const,
-          confidence: 100,
-          automated: true,
-        }))
-      )
+      [...new Set(imageIds)].map((imageId) => ({
+        imageId,
+        tagId,
+        source: 'User' as const,
+        confidence: 100,
+        automated: true,
+      }))
     );
   } catch (error) {
     logToAxiom({
       type: 'error',
       name: 'collection-auto-tag-failed',
       message: (error as Error).message,
-      collectionIds,
+      tagId,
       imageIds: imageIds.slice(0, 20),
     }).catch();
   }
@@ -873,11 +882,15 @@ export const saveItemInCollections = async ({
 
   await dbWrite.$transaction(transactions);
 
-  if (itemKey === 'imageId' && input.imageId)
-    await applyCollectionAutoTags(
-      data.map((d) => d.collectionId),
-      [input.imageId]
-    );
+  if (itemKey === 'imageId' && input.imageId) {
+    const imageId = input.imageId;
+    for (const { collectionId } of data) {
+      const collection = collections.find((c) => c.id === collectionId);
+      await applyCollectionAutoTag(collection?.metadata as CollectionMetadataSchema | null, [
+        imageId,
+      ]);
+    }
+  }
 
   // Check for updates to featured models
   if (input.modelId && collections.some((c) => c.id === FEATURED_MODEL_COLLECTION_ID)) {
@@ -932,6 +945,15 @@ export const upsertCollection = async ({
     tags,
     ...collectionItem
   } = input;
+
+  // `autoTagId` writes tag rows onto every image submitted to the collection, including
+  // images the submitter doesn't own (nothing in the save path validates image
+  // ownership). In a collection anyone can create and manage, that would let a user
+  // stamp an arbitrary tag onto a stranger's image — and a MODERATED tag additionally
+  // drives `updateImageNsfwLevels`, so it could raise someone else's image out of view.
+  // Moderator-only. Every other field here only affects the collection itself.
+  if (metadata && 'autoTagId' in metadata && !isModerator)
+    throw throwAuthorizationError('Only moderators can set a collection auto-tag');
 
   if (id) {
     const permission = await getUserCollectionPermissionsById({
@@ -2803,15 +2825,14 @@ export const bulkSaveItems = async ({
   }
 
   const { count } = await dbWrite.collectionItem.createMany({ data });
-
-  await applyCollectionAutoTags([collectionId], data.map((d) => d.imageId).filter(isDefined));
+  const savedImageIds = data.map((d) => d.imageId).filter(isDefined);
 
   // Entry fee (user challenges): charge AFTER the entries are written so a failed save never
   // leaves a paid-but-missing entry. Charges are idempotent per (challenge, image) and NEVER
   // refunded (see challenge-funding.ts) — on a partial charge we keep the paid entries and
   // roll back only the unpaid rows; a Buzz charge can't be undone by a Postgres rollback.
   if (collection.mode === CollectionMode.Contest) {
-    const chargeImageIds = data.map((d) => d.imageId).filter(isDefined);
+    const chargeImageIds = savedImageIds;
     const rollbackItems = async (imageIds: number[], originalError: unknown) => {
       await dbWrite.collectionItem
         .deleteMany({
@@ -2850,9 +2871,14 @@ export const bulkSaveItems = async ({
 
     if (chargeResult && chargeResult.unpaidImageIds.length > 0) {
       await rollbackItems(chargeResult.unpaidImageIds, new Error('insufficient funds'));
-      // The paid entries above stay committed, so bust the cache before aborting the request.
-      if (chargeResult.paidImageIds.length > 0)
+      // The paid entries above stay committed, so tag and bust the cache before aborting
+      // the request. The unpaid ones were just deleted and must NOT be tagged — a rolled-back
+      // submission that stayed tagged would be filtered out of feeds for an entry that never
+      // landed, with nothing to undo it.
+      if (chargeResult.paidImageIds.length > 0) {
+        await applyCollectionAutoTag(metadata, chargeResult.paidImageIds);
         await homeBlockCacheBust(HomeBlockType.Collection, collectionId);
+      }
       throw throwInsufficientFundsError(
         chargeResult.paidImageIds.length > 0
           ? `You ran out of Buzz partway through: ${chargeResult.paidImageIds.length} ${
@@ -2862,6 +2888,9 @@ export const bulkSaveItems = async ({
       );
     }
   }
+
+  // Tag AFTER the entry-fee block, so anything rolled back for non-payment is never tagged.
+  await applyCollectionAutoTag(metadata, savedImageIds);
 
   // Bust AFTER the write so a concurrent read can't repopulate the cache with pre-write data.
   await homeBlockCacheBust(HomeBlockType.Collection, collectionId);


### PR DESCRIPTION
## Why

The Beggars Board is leaking into **New & Upcoming Creators**. Posts there draw heavy reciprocal reactions (it functions as a reaction ring), so new users who post to it score onto the `images-new` leaderboard, and their beggar posts then surface in the feed that board drives.

Reported by creators in the launch article comments and raised in DMs. Justin's call: filter the content out of feeds; don't try to exclude those reactions from the leaderboard score.

## What

New optional `metadata.autoTagId` on a collection. Every image submitted to that collection gets that tag.

Two properties that matter:

- **Fires regardless of review status.** `CollectionItemStatus` is resolved *before* the insert, and the hook runs after the write, so a submission sitting in `REVIEW` is tagged the same as an `ACCEPTED` one. The point is to mark what was *submitted*, not what a moderator kept.
- **Configurable per collection.** Neither the collection id nor the tag id is hardcoded, so the next collection that needs this is a metadata edit, not a deploy.

Hooked into both write paths in `collection.service.ts` — `saveItemInCollections` and `bulkSaveItems` — which between them cover normal submit, bulk, mod-added, API, and post-publish (how most contest image entries actually arrive).

Failures are logged to Axiom and swallowed. A tag that fails to apply must never fail or roll back the submission itself.

## Feed filtering needs no code

`excludedTagIds` already filters in **all four** image query paths — `getAllImages` (via `TagsOnImageDetails`), the Meili pre-filter, the BitDex pre-filter, and the Meili post-filter. And the browsing-settings addon list that excludes a tag **globally** is Redis-backed, so hiding the tag everywhere is a config change.

`insertTagsOnImageNew` handles the cache busting and the search-index push that those filters depend on, so nothing downstream needs manual syncing.

## Not addressed, deliberately

Tagging filters **content**, not **score**. A beggar can still qualify for the `images-new` board and still ranks on `/leaderboard/images-new`. Excluding those reactions from the score would need a new ClickHouse sync table plus a cron — ClickHouse carries no image tags and no collection membership today. Decided out of scope; revisit if beggars still visibly clutter the leaderboard.

## To activate after merge (no deploy needed)

1. Create the tag (or reuse one) and note its id
2. `UPDATE "Collection" SET metadata = metadata || '{"autoTagId": <id>}' WHERE id = 3870938`
3. Add `<id>` to the browsing-settings addon exclusion list in Redis

Existing items are not backfilled — only new submissions get tagged. A one-off backfill over the ~354 current items is easy if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)