### PR TITLE
feat(blocks): make budgeted spend an explicitly requestable dev-token grant (#3703 step 1)

### DIFF
--- a/src/pages/api/v1/block-tokens/index.ts
+++ b/src/pages/api/v1/block-tokens/index.ts
@@ -333,8 +333,10 @@ function resolveBuzzBudget(
  *     RUNTIME `submitWorkflow` spends the AUTHOR's OWN Buzz, gated by
  *     `assertViewerIsAppDeveloper(sub)` + the per-call (DEV_BUZZ_BUDGET_CAP) /
  *     per-session / per-day caps. There is NO bearer credential here, so the
- *     dev-token 7f AIServicesWrite ceiling doesn't map → `keyCanSpend: true`; the
- *     runtime author-flag re-check is the substitute spend gate.
+ *     dev-token 7f AIServicesWrite ceiling doesn't map → `spendEntitled: true` (and
+ *     `spendRequested: true`, since this path has no request body — the declaring
+ *     manifest IS the request); the runtime author-flag re-check is the substitute
+ *     spend gate.
  *   - SCOPE SOURCE (the resolver is the single authority — `app.scopes`): the
  *     caller's OWN pending submission's SERVER-READ `manifest.scopes` (pending), else
  *     the AUTHENTICATED CLI's dev-tunnel SESSION `grantedScopes` (brand-new — NEVER a

--- a/src/pages/api/v1/blocks/dev-token.ts
+++ b/src/pages/api/v1/blocks/dev-token.ts
@@ -274,6 +274,25 @@ const requestSchema = z
     scopes: z.array(z.string().min(1).max(64)).max(32).optional(),
     // OPTIONAL dev-requested per-call Buzz budget; clamped to DEV_BUZZ_BUDGET_CAP.
     buzzBudget: z.number().int().positive().optional(),
+    // EXPLICIT budgeted-spend REQUEST (#3703 step 1). Answers "did the caller ask
+    // to spend real Buzz on THIS mint?" — a question the clamp previously never
+    // asked, so a spend-entitled bearer always got `ai:write:budgeted` implicitly
+    // whenever the scope source declared it.
+    //
+    // It is DELIBERATELY DISTINCT from `scopes` above: `scopes` states what the
+    // APP needs (its manifest), this states what THIS token should carry. Without
+    // the distinction a CLI `--spend` flag would be meaningless, because the
+    // manifest alone would keep granting spend.
+    //
+    // 🔴 STEP 1 IS NON-BREAKING: absent still means "grant" (`?? true` at the call
+    // site below), so every existing client is byte-identical. Flipping that
+    // default to `?? false` is a separate, breaking change.
+    //
+    // Semantics are a STRIP, never an error: `true` from a bearer that is not
+    // spend-entitled mints successfully WITHOUT the scope (every other step in the
+    // clamp belt is a strip; erroring would add a new failure mode on the money
+    // path). Non-optional (absent → 400) is a later, deliberate tightening.
+    requestBudgetedSpend: z.boolean().optional(),
   })
   .refine((b) => !!b.appBlockId || !!b.slug, {
     message: 'one of appBlockId or slug is required',
@@ -380,7 +399,13 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
     res.status(400).json({ message: 'Invalid request body', details: parsed.error.flatten() });
     return;
   }
-  const { appBlockId, slug, scopes: requestedScopes, buzzBudget: requestedBudget } = parsed.data;
+  const {
+    appBlockId,
+    slug,
+    scopes: requestedScopes,
+    buzzBudget: requestedBudget,
+    requestBudgetedSpend,
+  } = parsed.data;
 
   // 5. Rate limit — per-user (the stable authenticated identity), client-IP
   // fallback. Same atomic SET NX EX + INCR pattern as submit-version; fail
@@ -511,6 +536,13 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
   // path it has NO durable AppBlock-backed audit rows (the synthetic appId /
   // appBlockId don't resolve), so the log is the only forensic trail.
   let localManifestSlug: string | null = null;
+  // Set ONLY on the APPROVED path so its structured mint-audit log
+  // (`blocks.dev-token.approved-mint`) can fire. Historically this path emitted NO
+  // mint event at all — it writes rows byte-identical to a production page mint, so
+  // an approved-path dev mint was STRUCTURALLY INVISIBLE and could not be separated
+  // from prod traffic after the fact (#3703). The durable AppBlock-backed rows say
+  // what was INVOKED; they never say what was MINTED, nor on what basis.
+  let approvedAppBlockId: string | null = null;
 
   if (block && block.app && block.app.userId === user.id) {
     // Owned approved row → existing-app mode. But an OWNED-yet-not-approved row
@@ -542,6 +574,7 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
     const approvedRaw: unknown[] = Array.isArray(block.approvedScopes)
       ? block.approvedScopes
       : [];
+    approvedAppBlockId = block.id;
     resolved = {
       scopeSource: approvedRaw.filter((s): s is string => typeof s === 'string'),
       oauthAllowed: block.app.allowedScopes ?? 0,
@@ -734,11 +767,13 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
   //      local-manifest paths (no OauthClient),
   //   d) drop the PAGE_FORBIDDEN money/spend scopes (the page hard rule),
   //   e) if the body requested a subset, intersect with it,
-  //   f) BEARER-CREDENTIAL SPEND CEILING (`keyCanSpend`): strip `ai:write:budgeted`
-  //      unless the bearer credential (personal key OR OAuth consent) carries
-  //      AIServicesWrite. `session.tokenScope` is the resolved bitmask for BOTH
-  //      shapes. `AppBlocksSubmit` is the MINT gate (step 1b), `AIServicesWrite`
-  //      the SPEND gate — never conflated.
+  //   f) SPEND CEILING — TWO independent predicates, both required (#3703 step 1):
+  //      `spendEntitled` = the bearer credential (personal key OR OAuth consent)
+  //      carries AIServicesWrite (`session.tokenScope` is the resolved bitmask for
+  //      BOTH shapes; `AppBlocksSubmit` is the MINT gate at step 1b, `AIServicesWrite`
+  //      the SPEND gate — never conflated), AND `spendRequested` = the caller ASKED
+  //      for budgeted spend on this mint. `ai:write:budgeted` survives only when BOTH
+  //      hold; either alone strips it, silently (the mint still succeeds).
   //   g) force-grant `user:read:self` (self-bound read of the dev's OWN identity;
   //      `/blocks/me` for the harness viewer). SAFE: the token `sub` is ALWAYS the
   //      authenticated caller (never the body), so it can only return the caller's
@@ -746,12 +781,21 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
   // Every step is a STRIP (no error) so a partially-disallowed request still mints
   // a usable, safely-clamped token. This bearer path is UNCHANGED by the
   // extraction (a parity test locks it).
-  const keyCanSpend = Flags.hasFlag(session.tokenScope ?? 0, TokenScope.AIServicesWrite);
+  // ENTITLEMENT — unchanged: the bearer credential's AIServicesWrite bit.
+  const spendEntitled = Flags.hasFlag(session.tokenScope ?? 0, TokenScope.AIServicesWrite);
+  // INTENT — did the caller ask to spend on THIS mint?
+  //
+  // 🔴 `?? true` IS THE STEP-1 NON-BREAKING DEFAULT AND MUST STAY. A client that
+  // has never heard of `requestBudgetedSpend` behaves EXACTLY as before: absent →
+  // requested. Flipping this token to `?? false` is the breaking step and ships on
+  // its own, behind the adoption evidence the mint-audit events below produce.
+  const spendRequested = requestBudgetedSpend ?? true;
   const granted = clampDevScopes({
     scopeSource: resolved.scopeSource,
     oauthAllowed: resolved.oauthAllowed,
     requestedScopes,
-    keyCanSpend,
+    spendEntitled,
+    spendRequested,
     allowlist: DEV_TOKEN_SCOPE_ALLOWLIST,
   });
 
@@ -771,10 +815,47 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
   // trail. Emit a structured event (Axiom/Loki-queryable) with the mint metadata —
   // NEVER the token/secret. Placed AFTER the final scope clamp + budget resolution
   // so `scopes`/`spendGranted` reflect the actual minted outcome (7f clamp included).
-  // PENDING-PATH ONLY: the approved path already has durable AppBlock-backed audit
-  // rows (recordSpendAttribution / recordScopeInvocation persist there), so it does
-  // not emit this event. The `mode: 'pending'` field is carried so a future
-  // approved-side log could reuse the same schema.
+  // The `mode` field distinguishes the three mint paths, which since #3703 step 1
+  // ALL emit an event (the approved path emitted none until then — see its branch
+  // below for why its durable rows were not a substitute).
+  //
+  // #3703 step 1 adds TWO things to every one of these events, plus a THIRD event:
+  //
+  //   - `requestBudgetedSpend` — the field EXACTLY as received: `true`, `false`, or
+  //     ABSENT (the key is omitted). Never normalised, because normalising it
+  //     destroys the distinction the adoption gate is built on.
+  //   - `spendGrantBasis` — the DERIVED outcome: 'explicit' (granted because the
+  //     caller asked), 'inferred' (granted only because the step-1 `?? true`
+  //     default filled in for a caller that never asked), or 'none' (not granted).
+  //
+  // BOTH are recorded because ONE value cannot express the pair of questions the
+  // step-3 gate must answer. `spendGrantBasis: 'none'` alone cannot distinguish "the
+  // client asked and was DENIED for lack of entitlement" from "the client never
+  // asked" — opposite conclusions about client adoption, and only the as-received
+  // field separates them. Symmetrically, `requestBudgetedSpend: true` alone does not
+  // say whether the scope was actually granted.
+  //
+  // The step-3 flip is gated on `spendGrantBasis === 'inferred'` falling to zero for
+  // non-internal callers over a rolling window — i.e. nobody is still relying on the
+  // implicit grant. That gate is only measurable because these events exist, which
+  // is why the APPROVED path below is no longer silent.
+  //
+  // 🔴 Flags + identifiers only — NEVER the token, a secret, or PII.
+  const spendGranted = granted.includes('ai:write:budgeted');
+  const spendGrantBasis: 'explicit' | 'inferred' | 'none' = !spendGranted
+    ? 'none'
+    : requestBudgetedSpend === true
+      ? 'explicit'
+      : 'inferred';
+  // `requestBudgetedSpend` is spread so an ABSENT field stays ABSENT in the emitted
+  // event (rather than becoming an invented `false`/`null`), preserving the
+  // three-valued signal the gate reads.
+  const spendAudit = {
+    ...(requestBudgetedSpend === undefined ? {} : { requestBudgetedSpend }),
+    spendGranted,
+    spendGrantBasis,
+  };
+
   if (pendingPublishRequestId) {
     req.log?.info('blocks.dev-token.pending-mint', {
       mode: 'pending',
@@ -782,7 +863,7 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
       slug: resolved.signBlockId,
       publishRequestId: pendingPublishRequestId,
       scopes: granted,
-      spendGranted: granted.includes('ai:write:budgeted'),
+      ...spendAudit,
     });
   } else if (localManifestSlug) {
     // NO-ROW (local-manifest) MINT AUDIT. Same rationale as the pending path:
@@ -796,7 +877,26 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
       userId: user.id,
       slug: localManifestSlug,
       scopes: granted,
-      spendGranted: granted.includes('ai:write:budgeted'),
+      ...spendAudit,
+    });
+  } else if (approvedAppBlockId) {
+    // APPROVED-PATH MINT AUDIT (#3703 step 1) — NEW. This path previously emitted
+    // NOTHING. Unlike the two synthetic-id paths above it DOES write durable rows,
+    // but those rows are byte-identical to a PRODUCTION page mint's, so an
+    // approved-path dev mint could not be told apart from ordinary prod traffic
+    // afterwards, and nothing anywhere recorded on what BASIS spend was granted.
+    // That silence is what makes the step-3 adoption gate blind on this path, so it
+    // is closed here rather than left to the flip.
+    //
+    // Same shape as its siblings (a future consumer can read all three uniformly) —
+    // identifiers already handled by this request only, never the token or a secret.
+    req.log?.info('blocks.dev-token.approved-mint', {
+      mode: 'approved',
+      userId: user.id,
+      slug: resolved.signBlockId,
+      appBlockId: approvedAppBlockId,
+      scopes: granted,
+      ...spendAudit,
     });
   }
 

--- a/src/server/services/blocks/__tests__/dev-scoped-mint.call-site-ledger.test.ts
+++ b/src/server/services/blocks/__tests__/dev-scoped-mint.call-site-ledger.test.ts
@@ -1,0 +1,125 @@
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join, relative, sep } from 'path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * RELATIONSHIP GUARD for the `clampDevScopes` spend ceiling (#3703 step 1).
+ *
+ * The behavioural suites prove each mint path is individually correct. What none of
+ * them can express is the property that actually decays: that the SET of call sites
+ * is closed, and that every member of it answered BOTH spend questions deliberately.
+ *
+ * `clampDevScopes` takes two required, undefaulted predicates — `spendEntitled` (MAY
+ * this context spend?) and `spendRequested` (DID the caller ask to spend on THIS
+ * mint?). The compiler forces a new caller to pass both, but it cannot force anyone
+ * to think about WHICH values, and it says nothing when a caller disappears. So this
+ * ledger names every call site together with the semantic pair it passes, and fails
+ * when the set GROWS (someone added a mint path without deciding) or SHRINKS
+ * (someone removed or renamed one, and the reasoning recorded here went stale).
+ *
+ * A structural check type-checks past a wrong argument, so this is deliberately NOT
+ * the only guard — the behavioural matrix in `dev-scoped-mint.service.test.ts`
+ * (including the ASYMMETRY test that states both halves of the intended divergence)
+ * is what pins the values. This pins the population.
+ *
+ * Test files are OUT of scope on purpose: a test may legitimately call the clamp
+ * with any pair. The ledger is about PRODUCTION call sites.
+ */
+
+const ROOT = process.cwd();
+
+/**
+ * Every PRODUCTION call site of `clampDevScopes`, mapped to the semantic pair it
+ * passes. Update this table in the same commit as any change to the set.
+ */
+const CALL_SITE_LEDGER: Record<string, string> = {
+  'src/pages/api/v1/blocks/dev-token.ts':
+    'BEARER dev-token mint — spendEntitled = the bearer credential’s AIServicesWrite bit; ' +
+    'spendRequested = body.requestBudgetedSpend ?? true (the step-1 non-breaking default).',
+  'src/server/services/blocks/dev-scoped-mint.service.ts':
+    'clampTunnelDeclaredScopes wrapper (dev TUNNEL) — spendEntitled = true (no bearer ceiling; ' +
+    'spend is gated at runtime by the author-flag re-check) and spendRequested = true, ' +
+    'PERMANENTLY: the path has no request body, so starting a tunnel with a manifest that ' +
+    'declares the scope IS the request. A wrong value here strips spend from ALREADY-PERSISTED ' +
+    'tunnel sessions, because startDevTunnel clamps at WRITE into `grantedScopes`.',
+  'src/server/services/blocks/publish-request.service.ts':
+    'MOD-REVIEW sandbox mint — spendEntitled = runForReal and spendRequested = runForReal. ' +
+    'Passing one value to both is correct, not a re-conflation: the mod’s explicit, ' +
+    'consent-gated run-for-real opt-in is simultaneously the authorisation to spend and the ' +
+    'request to spend on this mint.',
+};
+
+/** A CALL — the identifier immediately followed by `(` and an object literal. */
+const CALL_RE = /clampDevScopes\s*\(\s*\{/;
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === '.next' || entry === '.git') continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) walk(full, out);
+    else if (/\.tsx?$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+/** Every non-test .ts/.tsx under src/, as repo-relative POSIX-ish paths. */
+function sourceFiles(): string[] {
+  return walk(join(ROOT, 'src'))
+    .map((f) => relative(ROOT, f).split(sep).join('/'))
+    .filter((f) => !/__tests__|\.test\.tsx?$|(^|\/)src\/tests\//.test(f));
+}
+
+const FILES = sourceFiles();
+
+/**
+ * Source with comments removed — prose ABOUT the clamp is wanted, and there is a lot
+ * of it; only real code should count as a call site.
+ */
+function code(file: string): string {
+  return readFileSync(join(ROOT, file), 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+const CODE = new Map(FILES.map((f) => [f, code(f)] as const));
+const CALLERS = FILES.filter((f) => CALL_RE.test(CODE.get(f)!)).sort();
+
+describe('clampDevScopes call-site ledger (#3703 step 1)', () => {
+  it('POSITIVE CONTROL: the scan enumerates a real population and can match', () => {
+    // A broken walk / a regex that matches nothing would make every assertion below
+    // vacuously true. Prove the instrument works before reading its verdict.
+    expect(FILES.length).toBeGreaterThan(500);
+    expect(FILES).toContain('src/server/services/blocks/dev-scoped-mint.service.ts');
+    expect(CALLERS.length).toBeGreaterThan(0);
+    // …and that it can go RED: a definitely-absent identifier must match nothing.
+    const bogus = FILES.filter((f) => /clampDevScopesNoSuchFunction\s*\(\s*\{/.test(CODE.get(f)!));
+    expect(bogus).toEqual([]);
+  });
+
+  it('the set of production call sites EXACTLY equals the ledger (fails on GROWTH and on SHRINK)', () => {
+    // Enumerated equality, not containment: a 4th caller fails here, and so does
+    // deleting one. The message names the ledger so the fix is obvious.
+    expect(CALLERS).toEqual(Object.keys(CALL_SITE_LEDGER).sort());
+  });
+
+  it('every ledger entry passes BOTH spend predicates explicitly', () => {
+    // A structural check cannot tell a right argument from a wrong one, but it CAN
+    // tell that a call site did not quietly drop back to a single overloaded flag.
+    for (const file of Object.keys(CALL_SITE_LEDGER)) {
+      const src = CODE.get(file);
+      expect(src, `${file} is not in the scanned population`).toBeDefined();
+      expect(src, `${file} must pass spendEntitled`).toContain('spendEntitled');
+      expect(src, `${file} must pass spendRequested`).toContain('spendRequested');
+      // The overloaded predecessor must be gone — a reintroduced `keyCanSpend` is
+      // the exact regression this split exists to prevent.
+      expect(src, `${file} must not reintroduce keyCanSpend`).not.toContain('keyCanSpend');
+    }
+  });
+
+  it('every ledger entry carries a non-trivial rationale for the pair it passes', () => {
+    for (const [file, rationale] of Object.entries(CALL_SITE_LEDGER)) {
+      expect(rationale, `${file} rationale`).toContain('spendEntitled');
+      expect(rationale, `${file} rationale`).toContain('spendRequested');
+    }
+  });
+});

--- a/src/server/services/blocks/__tests__/dev-scoped-mint.service.test.ts
+++ b/src/server/services/blocks/__tests__/dev-scoped-mint.service.test.ts
@@ -11,7 +11,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
  *   - unknown + PAGE_FORBIDDEN + out-of-allowlist scopes are STRIPPED (no error),
  *   - the OAuth ceiling is SKIPPED when oauthAllowed is null (pending/ephemeral —
  *     no client), applied when a bitmask is passed,
- *   - `keyCanSpend:false` strips the budgeted-spend scope,
+ *   - the SPEND ceiling is TWO required predicates: `ai:write:budgeted` survives
+ *     only when `spendEntitled && spendRequested` (#3703 step 1),
  *   - `user:read:self` is force-granted, output deduped + sorted,
  *   - the budget clamps to the LOWER dev cap,
  *   - the signed token is self-bound (userId), forced-SFW, dev:true, page ctx.
@@ -32,6 +33,7 @@ vi.mock('~/server/services/block-token.service', () => ({
 
 import {
   clampDevScopes,
+  clampTunnelDeclaredScopes,
   DEV_BUZZ_BUDGET_CAP,
   DEV_BUZZ_BUDGET_DEFAULT,
   DEV_TOKEN_SCOPE_ALLOWLIST,
@@ -66,7 +68,8 @@ describe('clampDevScopes', () => {
     const granted = clampDevScopes({
       scopeSource: FULL_SOURCE,
       oauthAllowed: null,
-      keyCanSpend: true,
+      spendEntitled: true,
+      spendRequested: true,
       allowlist: TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
     });
     expect(granted).toEqual([
@@ -90,7 +93,8 @@ describe('clampDevScopes', () => {
     const granted = clampDevScopes({
       scopeSource: FULL_SOURCE,
       oauthAllowed: null,
-      keyCanSpend: true,
+      spendEntitled: true,
+      spendRequested: true,
       allowlist: DEV_TOKEN_SCOPE_ALLOWLIST,
     });
     expect(granted).toContain('apps:storage:read');
@@ -103,11 +107,12 @@ describe('clampDevScopes', () => {
     expect(granted).not.toContain('totally:fake:scope');
   });
 
-  it('keyCanSpend:false STRIPS ai:write:budgeted (read/catalog scopes unaffected)', () => {
+  it('spendEntitled:false STRIPS ai:write:budgeted (read/catalog scopes unaffected)', () => {
     const granted = clampDevScopes({
       scopeSource: ['models:read:self', 'ai:write:budgeted'],
       oauthAllowed: null,
-      keyCanSpend: false,
+      spendEntitled: false,
+      spendRequested: false,
       allowlist: TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
     });
     expect(granted).not.toContain('ai:write:budgeted');
@@ -118,7 +123,8 @@ describe('clampDevScopes', () => {
     const withNull = clampDevScopes({
       scopeSource: ['models:read:self', 'ai:write:budgeted'],
       oauthAllowed: null,
-      keyCanSpend: true,
+      spendEntitled: true,
+      spendRequested: true,
       allowlist: TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
     });
     expect(withNull).toContain('models:read:self');
@@ -126,7 +132,8 @@ describe('clampDevScopes', () => {
     const withCeiling = clampDevScopes({
       scopeSource: ['models:read:self', 'ai:write:budgeted'],
       oauthAllowed: AI_WRITE_BIT, // allows ai:write:budgeted, NOT models:read:self
-      keyCanSpend: true,
+      spendEntitled: true,
+      spendRequested: true,
       allowlist: TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
     });
     expect(withCeiling).not.toContain('models:read:self');
@@ -138,7 +145,8 @@ describe('clampDevScopes', () => {
       scopeSource: ['models:read:self', 'media:read:owned', 'ai:write:budgeted'],
       oauthAllowed: null,
       requestedScopes: ['ai:write:budgeted'],
-      keyCanSpend: true,
+      spendEntitled: true,
+      spendRequested: true,
       allowlist: TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
     });
     // Only the requested scope survives — plus the unconditional force-grant.
@@ -149,7 +157,8 @@ describe('clampDevScopes', () => {
     const granted = clampDevScopes({
       scopeSource: [],
       oauthAllowed: null,
-      keyCanSpend: true,
+      spendEntitled: true,
+      spendRequested: true,
       allowlist: TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
     });
     expect(granted).toEqual(['user:read:self']);
@@ -158,10 +167,134 @@ describe('clampDevScopes', () => {
     const dedup = clampDevScopes({
       scopeSource: ['user:read:self', 'models:read:self'],
       oauthAllowed: null,
-      keyCanSpend: true,
+      spendEntitled: true,
+      spendRequested: true,
       allowlist: TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
     });
     expect(dedup).toEqual(['models:read:self', 'user:read:self']);
+  });
+});
+
+/**
+ * #3703 step 1 — the spend ceiling is TWO independent, both-required predicates.
+ *
+ * `spendEntitled` (MAY this context spend?) and `spendRequested` (DID the caller ask
+ * to spend on THIS mint?) are ANDed. The full 2×2 matrix is pinned below on
+ * ENUMERATED granted sets — never `toContain('spend')`-style word checks, which pass
+ * while the hazard exists in a different shape.
+ *
+ * The two false/true rows are what kill an `&&` → `||` mutation, and they kill it in
+ * BOTH directions, so neither can be satisfied by the other's guard.
+ */
+describe('clampDevScopes — the two-predicate spend ceiling (#3703 step 1)', () => {
+  // Source declares spend + a read scope. The tunnel allowlist keeps both, so the
+  // ONLY thing varying across the matrix is the spend ceiling.
+  const SOURCE = ['models:read:self', 'ai:write:budgeted'];
+  const WITH_SPEND = ['ai:write:budgeted', 'models:read:self', 'user:read:self'];
+  const WITHOUT_SPEND = ['models:read:self', 'user:read:self'];
+
+  const clamp = (spendEntitled: boolean, spendRequested: boolean) =>
+    clampDevScopes({
+      scopeSource: SOURCE,
+      oauthAllowed: null,
+      spendEntitled,
+      spendRequested,
+      allowlist: TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
+    });
+
+  it('entitled AND requested → the spend scope SURVIVES (not a blanket deny)', () => {
+    expect(clamp(true, true)).toEqual(WITH_SPEND);
+  });
+
+  it('entitled but NOT requested → the spend scope is STRIPPED (intent binds)', () => {
+    expect(clamp(true, false)).toEqual(WITHOUT_SPEND);
+  });
+
+  it('requested but NOT entitled → the spend scope is STRIPPED (entitlement binds)', () => {
+    // The `&&` → `||` mutant survives every entitled-side test; it dies HERE and on
+    // the row above, each on its own exact array.
+    expect(clamp(false, true)).toEqual(WITHOUT_SPEND);
+  });
+
+  it('neither entitled nor requested → the spend scope is STRIPPED', () => {
+    expect(clamp(false, false)).toEqual(WITHOUT_SPEND);
+  });
+
+  it('a DENIED spend request is a silent STRIP, never an error — the clamp still returns a usable set', () => {
+    // Every other step in this belt is a strip; erroring on the money path would be
+    // a NEW failure mode. Asserting the call does not throw is the point.
+    expect(() => clamp(false, true)).not.toThrow();
+    expect(clamp(false, true)).toEqual(WITHOUT_SPEND);
+  });
+
+  it('the ceiling touches ONLY ai:write:budgeted — read/catalog scopes are untouched by either predicate', () => {
+    const readSource = ['models:read:self', 'buzz:read:self', 'collections:read:self'];
+    const expected = [
+      'buzz:read:self',
+      'collections:read:self',
+      'models:read:self',
+      'user:read:self',
+    ];
+    for (const [e, r] of [
+      [true, true],
+      [true, false],
+      [false, true],
+      [false, false],
+    ] as const) {
+      expect(
+        clampDevScopes({
+          scopeSource: readSource,
+          oauthAllowed: null,
+          spendEntitled: e,
+          spendRequested: r,
+          allowlist: TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
+        })
+      ).toEqual(expected);
+    }
+  });
+
+  /**
+   * RELATIONSHIP GUARD — the two mint paths diverge ON PURPOSE, and the hazard is
+   * that they drift apart later. Both halves of the intended asymmetry are asserted
+   * HERE, in one place, so the divergence is stated once and cannot rot in two.
+   */
+  it('ASYMMETRY: the tunnel path grants spend with NO request input, while a bearer that did not request it does NOT', () => {
+    // TUNNEL half — `clampTunnelDeclaredScopes` takes ONE argument. There is no
+    // request field to pass, because the declaring manifest IS the request; the
+    // wrapper hardcodes spendEntitled/spendRequested = true/true, permanently.
+    expect(clampTunnelDeclaredScopes(SOURCE)).toEqual(WITH_SPEND);
+    expect(clampTunnelDeclaredScopes.length).toBe(1);
+
+    // BEARER half — the same source, the same allowlist, spend-entitled, but the
+    // caller declined spend for this mint → stripped.
+    expect(clamp(true, false)).toEqual(WITHOUT_SPEND);
+
+    // …and the divergence is EXACTLY the spend scope: the rest of the set matches.
+    expect(clampTunnelDeclaredScopes(SOURCE).filter((s) => s !== 'ai:write:budgeted')).toEqual(
+      clamp(true, false)
+    );
+  });
+
+  /**
+   * PARITY WITH BASE — the tunnel path must be BYTE-IDENTICAL to pre-#3703
+   * behaviour. These enumerated sets are the pre-change outputs; they are what a
+   * wrong wrapper value (the persisted-`grantedScopes` hazard) would break.
+   */
+  it('PARITY: clampTunnelDeclaredScopes output is unchanged for the representative inputs', () => {
+    expect(
+      clampTunnelDeclaredScopes([
+        'models:read:self',
+        'ai:write:budgeted',
+        'apps:storage:write', // not in the tunnel allowlist → stripped
+        'social:tip:self', // money OUT → stripped
+        'buzz:read:self',
+      ])
+    ).toEqual(['ai:write:budgeted', 'buzz:read:self', 'models:read:self', 'user:read:self']);
+    expect(clampTunnelDeclaredScopes([])).toEqual(['user:read:self']);
+    expect(clampTunnelDeclaredScopes(['ai:write:budgeted'])).toEqual([
+      'ai:write:budgeted',
+      'user:read:self',
+    ]);
   });
 });
 
@@ -182,7 +315,8 @@ describe('buzz:read:self allowlist membership (own-ledger read, self-bound)', ()
     const granted = clampDevScopes({
       scopeSource: ['buzz:read:self', 'models:read:self'],
       oauthAllowed: null, // pre-approval dev tunnel — no OauthClient
-      keyCanSpend: true,
+      spendEntitled: true,
+      spendRequested: true,
       allowlist: TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
     });
     // The scope survives → the block's REQUEST_CONSENT resolves a real
@@ -195,7 +329,8 @@ describe('buzz:read:self allowlist membership (own-ledger read, self-bound)', ()
     const granted = clampDevScopes({
       scopeSource: ['buzz:read:self', 'models:read:self'],
       oauthAllowed: null,
-      keyCanSpend: false,
+      spendEntitled: false,
+      spendRequested: false,
       allowlist: REVIEW_MINT_SCOPE_ALLOWLIST,
     });
     expect(granted).not.toContain('buzz:read:self');
@@ -224,7 +359,8 @@ describe('clampDevScopes — REVIEW_MINT_SCOPE_ALLOWLIST (mod review sandbox #28
     const granted = clampDevScopes({
       scopeSource: MALICIOUS_MANIFEST_SCOPES,
       oauthAllowed: null, // pending app — no OauthClient
-      keyCanSpend: false, // review preview never spends (belt-and-suspenders)
+      spendEntitled: false,
+      spendRequested: false, // review preview never spends (belt-and-suspenders)
       allowlist: REVIEW_MINT_SCOPE_ALLOWLIST,
     });
     // ONLY the render-only survivors (+ the unconditional user:read:self grant).
@@ -250,13 +386,14 @@ describe('clampDevScopes — REVIEW_MINT_SCOPE_ALLOWLIST (mod review sandbox #28
     }
   });
 
-  it('is STRICTER than the dev-tunnel allowlist — never grants ai:write:budgeted even with keyCanSpend:true', () => {
-    // Even if a caller mistakenly passed keyCanSpend:true, the allowlist itself
+  it('is STRICTER than the dev-tunnel allowlist — never grants ai:write:budgeted even with both spend predicates true', () => {
+    // Even if a caller mistakenly passed both spend predicates true, the allowlist itself
     // omits ai:write:budgeted, so spend can never survive the review clamp.
     const granted = clampDevScopes({
       scopeSource: ['ai:write:budgeted', 'models:read:self'],
       oauthAllowed: null,
-      keyCanSpend: true,
+      spendEntitled: true,
+      spendRequested: true,
       allowlist: REVIEW_MINT_SCOPE_ALLOWLIST,
     });
     expect(granted).not.toContain('ai:write:budgeted');
@@ -267,7 +404,8 @@ describe('clampDevScopes — REVIEW_MINT_SCOPE_ALLOWLIST (mod review sandbox #28
     const granted = clampDevScopes({
       scopeSource: [],
       oauthAllowed: null,
-      keyCanSpend: false,
+      spendEntitled: false,
+      spendRequested: false,
       allowlist: REVIEW_MINT_SCOPE_ALLOWLIST,
     });
     expect(granted).toEqual(['user:read:self']);
@@ -295,7 +433,8 @@ describe('clampDevScopes — REVIEW_RUN_FOR_REAL_MINT_SCOPE_ALLOWLIST (mod opt-i
     const granted = clampDevScopes({
       scopeSource: MALICIOUS_MANIFEST_SCOPES,
       oauthAllowed: null, // pending app — no OauthClient
-      keyCanSpend: true, // run-for-real spends the mod's OWN Buzz
+      spendEntitled: true,
+      spendRequested: true, // run-for-real spends the mod's OWN Buzz
       allowlist: REVIEW_RUN_FOR_REAL_MINT_SCOPE_ALLOWLIST,
     });
     expect(granted).toEqual([
@@ -320,7 +459,7 @@ describe('clampDevScopes — REVIEW_RUN_FOR_REAL_MINT_SCOPE_ALLOWLIST (mod opt-i
     }
   });
 
-  it('NEVER grants social:tip:self even with keyCanSpend:true — the ALLOWLIST is the sole money-out gate (PAGE_FORBIDDEN is empty)', () => {
+  it('NEVER grants social:tip:self even with both spend predicates true — the ALLOWLIST is the sole money-out gate (PAGE_FORBIDDEN is empty)', () => {
     // PAGE_FORBIDDEN_SCOPES is intentionally empty (a PROD page token legitimately
     // carries a bounded social:tip:self tip button), so the review-sandbox exclusion
     // is the allowlist ALONE — assert both the allowlist omits it AND a manifest
@@ -329,18 +468,20 @@ describe('clampDevScopes — REVIEW_RUN_FOR_REAL_MINT_SCOPE_ALLOWLIST (mod opt-i
     const granted = clampDevScopes({
       scopeSource: ['social:tip:self', 'ai:write:budgeted'],
       oauthAllowed: null,
-      keyCanSpend: true,
+      spendEntitled: true,
+      spendRequested: true,
       allowlist: REVIEW_RUN_FOR_REAL_MINT_SCOPE_ALLOWLIST,
     });
     expect(granted).not.toContain('social:tip:self');
     expect(granted).toContain('ai:write:budgeted');
   });
 
-  it('keyCanSpend:false STILL strips the spend scope (belt-and-suspenders) even under the wider allowlist', () => {
+  it('spendEntitled:false STILL strips the spend scope (belt-and-suspenders) even under the wider allowlist', () => {
     const granted = clampDevScopes({
       scopeSource: ['ai:write:budgeted', 'models:read:self'],
       oauthAllowed: null,
-      keyCanSpend: false,
+      spendEntitled: false,
+      spendRequested: false,
       allowlist: REVIEW_RUN_FOR_REAL_MINT_SCOPE_ALLOWLIST,
     });
     expect(granted).not.toContain('ai:write:budgeted');

--- a/src/server/services/blocks/__tests__/dev-tunnel.service.test.ts
+++ b/src/server/services/blocks/__tests__/dev-tunnel.service.test.ts
@@ -313,6 +313,34 @@ describe('startDevTunnel', () => {
     expect(s.grantedScopes).toEqual(['ai:write:budgeted', 'user:read:self']);
   });
 
+  it('#3703 step 1: startDevTunnel STILL PERSISTS ai:write:budgeted into the stored grantedScopes', async () => {
+    // The tunnel wrapper hardcodes spendEntitled/spendRequested = true/true, and it
+    // MUST stay that way: `startDevTunnel` clamps ONCE at WRITE and the result is
+    // what every later reader grants. A wrong value would not merely affect future
+    // mints — it would silently strip spend from ALREADY-STORED live sessions, and
+    // no re-clamp could restore them.
+    //
+    // Asserted at the layer where the value is STORED (the persisted session record
+    // read back out of redis), not merely where it is computed: a clamp that returns
+    // the right array but is never written is exactly the failure this guards.
+    await startDevTunnel({
+      userId: 555,
+      blockId: 'my-app',
+      sshPublicKey: PUBKEY,
+      declaredScopes: ['ai:write:budgeted', 'models:read:self'],
+    });
+    const stored = readSession();
+    // Enumerated set, never a word check.
+    expect(stored.grantedScopes).toEqual([
+      'ai:write:budgeted',
+      'models:read:self',
+      'user:read:self',
+    ]);
+    // And it really came off the persisted record, not an in-memory return value.
+    const raw = sysRedis._store.get('system:blocks:dev-tunnel:session:bki_testsession')!;
+    expect(JSON.parse(raw).grantedScopes).toEqual(stored.grantedScopes);
+  });
+
   it('absent declaredScopes → empty raw declared + read-only granted (user:read:self)', async () => {
     await startDevTunnel({ userId: 555, blockId: 'my-app', sshPublicKey: PUBKEY });
     const s = readSession();

--- a/src/server/services/blocks/__tests__/publish-request.mintReviewToken.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.mintReviewToken.test.ts
@@ -228,7 +228,8 @@ describe('mintReviewBlockToken', () => {
         'models:read:self',
         'user:read:self',
       ]);
-      // Spend-IN survived (keyCanSpend:true) — but every money-OUT / cross-user /
+      // Spend-IN survived (both spend predicates = runForReal = true) — but every
+      // money-OUT / cross-user /
       // private scope the manifest declared is ABSENT.
       expect(scopes).toContain('ai:write:budgeted');
       for (const withheld of [

--- a/src/server/services/blocks/dev-scoped-mint.service.ts
+++ b/src/server/services/blocks/dev-scoped-mint.service.ts
@@ -19,15 +19,20 @@ import { BlockTokenService } from '~/server/services/block-token.service';
  *                                            Uses `DEV_TOKEN_SCOPE_ALLOWLIST`
  *                                            (WITH apps:storage:*) and gates the
  *                                            spend scope on the bearer credential's
- *                                            AIServicesWrite bit (`keyCanSpend`).
+ *                                            AIServicesWrite bit (`spendEntitled`)
+ *                                            AND the body's `requestBudgetedSpend`
+ *                                            (`spendRequested`).
  *   2. `/api/v1/block-tokens` (Phase 2)   — COOKIE-authed author-own dev-tunnel
  *                                            branch, for the SSR dev host at
  *                                            `/apps/dev/<blockId>`. Uses
  *                                            `TUNNEL_HOST_MINT_SCOPE_ALLOWLIST`
  *                                            (WITHOUT apps:storage:* — Decision 1:
  *                                            App Storage stays 403 until approval)
- *                                            and passes `keyCanSpend: true` because
- *                                            there is no bearer ceiling; SPEND is
+ *                                            and passes `spendEntitled: true` +
+ *                                            `spendRequested: true` because there is
+ *                                            no bearer ceiling and no request body
+ *                                            (the declaring manifest IS the
+ *                                            request); SPEND is
  *                                            instead gated at RUNTIME by
  *                                            `assertViewerIsAppDeveloper(sub)` on
  *                                            the token subject (blocks.router
@@ -138,7 +143,7 @@ export const TUNNEL_HOST_MINT_SCOPE_ALLOWLIST: ReadonlySet<string> = new Set<str
  *
  * WITHHELD (stripped regardless of what the pending manifest declares — the clamp
  * drops any scope not in this set, so none of these can EVER reach the review JWT):
- *   - `ai:write:budgeted`         real Buzz spend (ALSO stripped by keyCanSpend:false)
+ *   - `ai:write:budgeted`         real Buzz spend (ALSO stripped by spendEntitled:false)
  *   - `apps:storage:read|write`   per-user App Storage (synthetic appId → no namespace)
  *   - `apps:storage:shared:read|write` cross-user shared datastore (write = abuse)
  *   - `collections:read:private`  the caller's OWN private collections (consent-gated)
@@ -227,21 +232,46 @@ export const REVIEW_RUN_FOR_REAL_MINT_SCOPE_ALLOWLIST: ReadonlySet<string> = new
  *      Retained as the deterministic re-forbid hook; it is NOT the money-out gate
  *      for the review sandbox — that is the allowlist (b), which omits social:tip:self,
  *   e) if the body narrowed, intersect with the requested subset,
- *   f) BEARER-credential spend ceiling — strip `ai:write:budgeted` unless
- *      `keyCanSpend` (dev-token: the bearer's AIServicesWrite bit; host-mint:
- *      `true`, since spend is gated at runtime by the author-flag re-check),
+ *   f) SPEND ceiling — strip `ai:write:budgeted` unless BOTH `spendEntitled` AND
+ *      `spendRequested` (see the two-predicate note below),
  *   g) force-grant `user:read:self` (self-bound read of the caller's OWN identity).
  * Every step is a STRIP (no error). The belt is byte-identical across all callers
  * bar the allowlist + the OAuth-ceiling substitution.
+ *
+ * ─── Step (f): TWO independent predicates, never one (#3703 step 1) ───
+ * The spend ceiling used to be a single `keyCanSpend: boolean`, which meant three
+ * different things at its three call sites — ENTITLEMENT (bearer: the credential's
+ * AIServicesWrite bit), entitlement DEFERRED to a runtime gate (tunnel), and INTENT
+ * (mod review, via `runForReal`). Conflating "may this context spend?" with "did the
+ * caller ask to spend on THIS mint?" is what makes budgeted spend an implicit grant.
+ * They are now separate:
+ *
+ *   - `spendEntitled`  — MAY this context spend? (a credential bit, or a runtime gate)
+ *   - `spendRequested` — DID the caller ask to spend on THIS mint?
+ *
+ * BOTH are REQUIRED and NEITHER is DEFAULTED, deliberately. A default of `false`
+ * would silently strip spend from every dev tunnel — including already-PERSISTED
+ * tunnel sessions, whose `grantedScopes` are clamped once at write
+ * (`dev-tunnel.service.ts` `startDevTunnel`). A default of `true` would re-create the
+ * implicit grant for any future caller. Required parameters make the compiler force
+ * every present and future call site to answer both questions explicitly.
+ *
+ * Deny is a STRIP, never an error: a `spendRequested: true` from a context that is
+ * not entitled mints successfully WITHOUT the scope — erroring would add a new
+ * failure mode on the money path, and every other step in this belt is a strip.
  */
 export function clampDevScopes(opts: {
   scopeSource: string[];
   oauthAllowed: number | null;
   requestedScopes?: string[];
-  keyCanSpend: boolean;
+  /** MAY this context spend? (credential bit, or a runtime gate.) Required. */
+  spendEntitled: boolean;
+  /** DID the caller ask to spend on THIS mint? Required. */
+  spendRequested: boolean;
   allowlist: ReadonlySet<string>;
 }): string[] {
-  const { scopeSource, oauthAllowed, requestedScopes, keyCanSpend, allowlist } = opts;
+  const { scopeSource, oauthAllowed, requestedScopes, spendEntitled, spendRequested, allowlist } =
+    opts;
 
   const forbidden = new Set<string>(PAGE_FORBIDDEN_SCOPES);
 
@@ -265,9 +295,11 @@ export function clampDevScopes(opts: {
     granted = granted.filter((s: string) => want.has(s));
   }
 
-  // Bearer-credential (or runtime-author) spend ceiling: strip the budgeted-spend
-  // scope unless the caller can spend. Read/catalog scopes are unaffected.
-  if (!keyCanSpend) {
+  // SPEND ceiling: the budgeted-spend scope survives ONLY when the context is
+  // ENTITLED to spend AND the caller REQUESTED spend for this mint. Either alone is
+  // insufficient — `&&`, never `||`. Read/catalog scopes are unaffected, and a
+  // denied request is a silent strip (the mint still succeeds).
+  if (!(spendEntitled && spendRequested)) {
     granted = granted.filter((s: string) => s !== 'ai:write:budgeted');
   }
 
@@ -284,9 +316,9 @@ export function clampDevScopes(opts: {
 /**
  * App Dev Tunnel — the SINGLE clamp for a dev-tunnel session's self-declared
  * (`block.manifest.json`) scopes: the fixed TUNNEL belt (no OAuth ceiling — a
- * pre-approval app has no OauthClient; `keyCanSpend: true` — spend is gated at
- * RUNTIME by the author-flag re-check + the dev/session/day Buzz caps, not a bearer
- * here). Used by BOTH the SSR `declaredScopes` surface (block-registry) AND the
+ * pre-approval app has no OauthClient; `spendEntitled: true` / `spendRequested: true`
+ * — see the PERMANENT note on the call below). Used by BOTH the SSR
+ * `declaredScopes` surface (block-registry) AND the
  * on-site block-token mint, so the block's advertised `granted` set and the JWT's
  * actual scopes derive from ONE function and can NEVER drift apart. Idempotent —
  * safe to re-apply to an already-clamped stored set (defense-in-depth over the
@@ -298,7 +330,24 @@ export function clampTunnelDeclaredScopes(scopeSource: string[]): string[] {
   return clampDevScopes({
     scopeSource,
     oauthAllowed: null,
-    keyCanSpend: true,
+    // 🔴 PERMANENTLY true/true — do NOT wire either of these to a request field.
+    //
+    // `spendEntitled: true` — the tunnel has no bearer ceiling; spend is gated at
+    // RUNTIME by `assertViewerIsAppDeveloper(sub)` (the author-flag re-check) plus
+    // the per-call / per-session / per-day Buzz caps.
+    //
+    // `spendRequested: true` — this path has NO request body to carry a per-mint
+    // request. Starting a dev tunnel with a manifest that DECLARES
+    // `ai:write:budgeted` *is* the request; `scopeSource` already carries that
+    // declaration, so a manifest that does not declare the scope never reaches the
+    // spend ceiling at all.
+    //
+    // Getting this wrong is not merely a future-mint bug: `startDevTunnel`
+    // (dev-tunnel.service.ts) clamps ONCE at WRITE and PERSISTS the result as the
+    // session record's `grantedScopes`. A `false` here would silently strip spend
+    // from ALREADY-STORED live tunnel sessions, and no re-clamp could restore them.
+    spendEntitled: true,
+    spendRequested: true,
     allowlist: TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
   });
 }

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -4273,7 +4273,7 @@ export type MintReviewBlockTokenResult = {
  *   - SCOPE-STRIPPED: the pending manifest's declared `scopes` are the SOURCE, but
  *     they are clamped through the SAME audited belt the dev-tunnel host mint uses
  *     (`clampDevScopes`) with the STRICTEST allowlist (`REVIEW_MINT_SCOPE_ALLOWLIST`
- *     — render-only) and `keyCanSpend:false` (belt-and-suspenders strip of the
+ *     — render-only) and BOTH spend predicates false (belt-and-suspenders strip of the
  *     spend scope). A manifest that declares `ai:write:budgeted` / `apps:storage:*`
  *     / `buzz:read:self` gets NONE of them — the review JWT can carry only the
  *     render-only survivors.
@@ -4295,9 +4295,9 @@ export async function mintReviewBlockToken(opts: {
   /**
    * MOD REVIEW SANDBOX "run for real" (#2831). Default false → the render-only
    * sandbox, BYTE-IDENTICAL to the pre-existing behaviour (render-only allowlist,
-   * keyCanSpend:false, no budget, no run-for-real claim). When true (a mod's
-   * EXPLICIT, consent-gated opt-in), the SAME audited clamp belt runs with the
-   * wider `REVIEW_RUN_FOR_REAL_MINT_SCOPE_ALLOWLIST` and `keyCanSpend:true`, a
+   * both spend predicates false, no budget, no run-for-real claim). When true (a
+   * mod's EXPLICIT, consent-gated opt-in), the SAME audited clamp belt runs with the
+   * wider `REVIEW_RUN_FOR_REAL_MINT_SCOPE_ALLOWLIST` and both spend predicates true, a
    * per-call Buzz budget is attached, and a signed `reviewRunForReal` claim
    * selects the tight aggregate session Buzz cap at runtime. STILL: self-bound to
    * the mod, forced-SFW, money-OUT (`social:tip:self`) excluded, and clamped to
@@ -4351,18 +4351,34 @@ export async function mintReviewBlockToken(opts: {
   );
 
   // The AUDITED clamp belt (SAME function both modes — never fork the clamp).
-  //   - render-only (default): render-only allowlist + keyCanSpend:false → the
-  //     spend scope is stripped even if the manifest declares it. BYTE-IDENTICAL
-  //     to the pre-existing sandbox.
-  //   - run-for-real (mod opt-in): the WIDER run-for-real allowlist + keyCanSpend:true.
+  //   - render-only (default): render-only allowlist + no spend → the spend scope
+  //     is stripped even if the manifest declares it. BYTE-IDENTICAL to the
+  //     pre-existing sandbox.
+  //   - run-for-real (mod opt-in): the WIDER run-for-real allowlist + spend.
   //     Granted = (manifest DECLARED scopes) ∩ allowlist ∩ (page money-out forbid),
   //     so a malicious manifest declaring extra scopes still gets ONLY declared∩allowlist.
   // NO OAuth ceiling in either mode (a pending app has no OauthClient; passing 0
   // would wrongly strip every non-skip scope — see clampDevScopes doc).
+  //
+  // 🔴 `runForReal` is passed to BOTH spend predicates, and that is CORRECT here —
+  // it is NOT the old overloaded `keyCanSpend` re-conflated under two names. On this
+  // call site entitlement and intent genuinely COINCIDE, because `runForReal` IS the
+  // moderator's explicit, per-preview, loudly-consented opt-in:
+  //   - as ENTITLEMENT: only that opt-in authorises spending the reviewing mod's own
+  //     Buzz on UNAPPROVED, untrusted code — without it the mod is not entitled at all;
+  //   - as INTENT:      the opt-in is itself the request to spend on THIS mint; there
+  //                     is no second, narrower "and also actually spend" signal, and
+  //                     inventing one would let a mod opt in and still get a token
+  //                     that cannot exercise generation — the whole point of the mode.
+  // So this is the one call site that already had #3703's semantics; it merely
+  // expressed them through a parameter named for entitlement alone. If a separate
+  // per-mint spend request is ever added to the review UI, wire it to
+  // `spendRequested` and leave `spendEntitled: runForReal` alone.
   const granted = clampDevScopes({
     scopeSource: manifestScopes,
     oauthAllowed: null,
-    keyCanSpend: runForReal,
+    spendEntitled: runForReal,
+    spendRequested: runForReal,
     allowlist: runForReal
       ? REVIEW_RUN_FOR_REAL_MINT_SCOPE_ALLOWLIST
       : REVIEW_MINT_SCOPE_ALLOWLIST,

--- a/src/tests/api/v1/blocks/dev-token.test.ts
+++ b/src/tests/api/v1/blocks/dev-token.test.ts
@@ -1417,4 +1417,269 @@ describe('POST /api/v1/blocks/dev-token', () => {
       expect(mockSign).not.toHaveBeenCalled();
     });
   });
+
+  /**
+   * #3703 step 1 — `requestBudgetedSpend`: budgeted spend becomes an EXPLICITLY
+   * REQUESTABLE grant, with the default deliberately left at "infer".
+   *
+   * The clamp now ANDs two independent predicates: `spendEntitled` (the bearer's
+   * AIServicesWrite bit — unchanged) and `spendRequested` (this new body field,
+   * defaulted `?? true` so step 1 changes NO behaviour for existing clients).
+   *
+   * Every assertion below pins an ENUMERATED granted set. A `toContain('spend')`-
+   * style check would pass while the hazard existed in a different shape.
+   */
+  describe('requestBudgetedSpend — explicit budgeted-spend request (#3703 step 1)', () => {
+    // The approved app's snapshot minus the spend scope, in clamp output order.
+    // The bearer allowlist KEEPS apps:storage:read (unlike the tunnel allowlist).
+    const WITHOUT_SPEND = ['apps:storage:read', 'models:read:self', 'user:read:self'];
+    const WITH_SPEND = [
+      'ai:write:budgeted',
+      'apps:storage:read',
+      'models:read:self',
+      'user:read:self',
+    ];
+
+    const logOf = (req: unknown) =>
+      (req as { log: { info: ReturnType<typeof vi.fn> } }).log.info.mock.calls;
+    const eventOf = (req: unknown, name: string) =>
+      logOf(req).find((c) => c[0] === name)?.[1] as Record<string, unknown> | undefined;
+
+    it('1. entitled bearer + requestBudgetedSpend:false → the spend scope is EXCLUDED', async () => {
+      // RED at base: before step 1 the field was ignored entirely, so the granted
+      // set came back WITH_SPEND.
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION); // Full → AIServicesWrite
+      const { req, res } = authPost({ appBlockId: 'apb_abc', requestBudgetedSpend: false });
+      await handler(req as never, res as never);
+      expect(res._getStatusCode()).toBe(200);
+      expect(mockSign.mock.calls[0][0].scopes).toEqual(WITHOUT_SPEND);
+      // No spend scope → no budget claim, on the token AND in the response body.
+      expect(mockSign.mock.calls[0][0].buzzBudget).toBeUndefined();
+      expect((res._getJSONData() as Record<string, unknown>).scopes).toEqual(WITHOUT_SPEND);
+    });
+
+    it('2. entitled bearer + requestBudgetedSpend:true → the spend scope is INCLUDED (not a blanket deny)', async () => {
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+      const { req, res } = authPost({ appBlockId: 'apb_abc', requestBudgetedSpend: true });
+      await handler(req as never, res as never);
+      expect(res._getStatusCode()).toBe(200);
+      expect(mockSign.mock.calls[0][0].scopes).toEqual(WITH_SPEND);
+      expect(mockSign.mock.calls[0][0].buzzBudget).toBe(50);
+    });
+
+    it('3. NOT-entitled bearer + requestBudgetedSpend:true → EXCLUDED, and the mint SUCCEEDS (strip, never error)', async () => {
+      // Two things at once, both load-bearing:
+      //  - entitlement still binds even when the caller explicitly asks. This is the
+      //    case that catches an `&&` → `||` mutation of the ceiling.
+      //  - a denied request is a SILENT STRIP. Erroring here would be a brand-new
+      //    failure mode on the money path; every other step in the belt is a strip.
+      mockGetSession.mockResolvedValueOnce(READONLY_MOD_SESSION); // no AIServicesWrite
+      const { req, res } = authPost({ appBlockId: 'apb_abc', requestBudgetedSpend: true });
+      await handler(req as never, res as never);
+      expect(res._getStatusCode()).toBe(200); // NOT 400/403 — the mint succeeds
+      expect(mockSign).toHaveBeenCalledTimes(1);
+      expect(mockSign.mock.calls[0][0].scopes).toEqual(WITHOUT_SPEND);
+      expect(mockSign.mock.calls[0][0].buzzBudget).toBeUndefined();
+    });
+
+    it('4. INVARIANT GUARD (not regression coverage): the field ABSENT → the spend scope is INCLUDED', async () => {
+      // This pins the DELIBERATE step-1 default `?? true` — the "no behaviour change"
+      // half of this PR. It is an invariant guard, not a red-before-green regression
+      // test: it is green at base too, because base has no field to omit.
+      //
+      // At step 3 this expectation FLIPS to WITHOUT_SPEND. Edit it then; never delete
+      // it — the diff is the audit trail of the breaking change.
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+      const { req, res } = authPost({ appBlockId: 'apb_abc' });
+      await handler(req as never, res as never);
+      expect(res._getStatusCode()).toBe(200);
+      expect(mockSign.mock.calls[0][0].scopes).toEqual(WITH_SPEND);
+    });
+
+    it('the field is OPTIONAL and boolean-typed — a non-boolean is a 400 before any lookup', async () => {
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+      const { req, res } = authPost({
+        appBlockId: 'apb_abc',
+        requestBudgetedSpend: 'yes' as unknown as boolean,
+      });
+      await handler(req as never, res as never);
+      expect(res._getStatusCode()).toBe(400);
+      expect(mockAppBlockFindUnique).not.toHaveBeenCalled();
+      expect(mockSign).not.toHaveBeenCalled();
+    });
+
+    it('applies on the PENDING path too (entitled + false → excluded)', async () => {
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+      mockAppBlockFindUnique.mockResolvedValueOnce(null);
+      mockPublishRequestFindFirst.mockResolvedValueOnce(pendingRequest());
+      const { req, res } = authPost({ slug: 'my-pending-app', requestBudgetedSpend: false });
+      await handler(req as never, res as never);
+      expect(res._getStatusCode()).toBe(200);
+      expect(mockSign.mock.calls[0][0].scopes).toEqual(WITHOUT_SPEND);
+    });
+
+    it('applies on the NO-ROW path too (entitled + false → excluded)', async () => {
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+      mockAppBlockFindUnique.mockResolvedValueOnce(null);
+      mockPublishRequestFindFirst.mockResolvedValueOnce(null);
+      const { req, res } = authPost({
+        slug: 'brand-new-app',
+        scopes: ['ai:write:budgeted', 'models:read:self'],
+        requestBudgetedSpend: false,
+      });
+      await handler(req as never, res as never);
+      expect(res._getStatusCode()).toBe(200);
+      expect(mockSign.mock.calls[0][0].scopes).toEqual(['models:read:self', 'user:read:self']);
+    });
+
+    /**
+     * 7. OBSERVABILITY — every bearer mint path emits a mint-audit event carrying
+     * BOTH the field as-received AND the derived `spendGrantBasis`.
+     *
+     * Recording both is the whole point: `spendGrantBasis:'none'` alone cannot tell
+     * "the client asked and was denied" from "the client never asked", and those
+     * mean opposite things about client adoption. The step-3 gate reads exactly this
+     * distinction, so one value cannot express it.
+     */
+    describe('mint-audit events carry requestBudgetedSpend AND spendGrantBasis', () => {
+      it('APPROVED path — emits blocks.dev-token.approved-mint, which previously emitted NOTHING', async () => {
+        // RED at base: the approved path was structurally invisible — it writes rows
+        // byte-identical to a production page mint and logged no mint event at all.
+        mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+        const { req, res } = authPost({ appBlockId: 'apb_abc', requestBudgetedSpend: true });
+        await handler(req as never, res as never);
+        expect(res._getStatusCode()).toBe(200);
+        const ev = eventOf(req, 'blocks.dev-token.approved-mint');
+        expect(ev).toBeDefined();
+        expect(ev).toEqual({
+          mode: 'approved',
+          userId: OWNER_ID,
+          slug: 'my-page-app',
+          appBlockId: 'apb_abc',
+          scopes: WITH_SPEND,
+          requestBudgetedSpend: true,
+          spendGranted: true,
+          spendGrantBasis: 'explicit',
+        });
+        // 🔴 No token, no secret in the audit event.
+        expect(JSON.stringify(ev)).not.toContain('jwt.signed.value');
+        // Sibling events stay path-scoped.
+        expect(eventOf(req, 'blocks.dev-token.pending-mint')).toBeUndefined();
+        expect(eventOf(req, 'blocks.dev-token.local-mint')).toBeUndefined();
+      });
+
+      it("APPROVED path — field ABSENT is recorded as ABSENT, and the basis is 'inferred'", async () => {
+        // 'inferred' is the signal the step-3 evidence gate counts: spend granted
+        // ONLY because the `?? true` default filled in for a client that never asked.
+        mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+        const { req, res } = authPost({ appBlockId: 'apb_abc' });
+        await handler(req as never, res as never);
+        expect(res._getStatusCode()).toBe(200);
+        const ev = eventOf(req, 'blocks.dev-token.approved-mint')!;
+        expect(ev.spendGrantBasis).toBe('inferred');
+        expect(ev.spendGranted).toBe(true);
+        // ABSENT, not an invented false/null — the three-valued signal is preserved.
+        expect('requestBudgetedSpend' in ev).toBe(false);
+      });
+
+      it("APPROVED path — asked-and-DENIED is distinguishable from never-asked (requestBudgetedSpend:true + basis 'none')", async () => {
+        // The pair that one value cannot express. Same basis as the case below,
+        // opposite meaning for adoption.
+        mockGetSession.mockResolvedValueOnce(READONLY_MOD_SESSION); // not entitled
+        const { req, res } = authPost({ appBlockId: 'apb_abc', requestBudgetedSpend: true });
+        await handler(req as never, res as never);
+        const ev = eventOf(req, 'blocks.dev-token.approved-mint')!;
+        expect(ev.requestBudgetedSpend).toBe(true); // the client DID ask
+        expect(ev.spendGranted).toBe(false); // …and was denied
+        expect(ev.spendGrantBasis).toBe('none');
+      });
+
+      it("APPROVED path — declined-spend is recorded as requestBudgetedSpend:false + basis 'none'", async () => {
+        mockGetSession.mockResolvedValueOnce(MOD_SESSION); // entitled
+        const { req, res } = authPost({ appBlockId: 'apb_abc', requestBudgetedSpend: false });
+        await handler(req as never, res as never);
+        const ev = eventOf(req, 'blocks.dev-token.approved-mint')!;
+        expect(ev.requestBudgetedSpend).toBe(false); // the client explicitly declined
+        expect(ev.spendGranted).toBe(false);
+        expect(ev.spendGrantBasis).toBe('none');
+      });
+
+      it('PENDING path — the pre-existing event now also carries both fields', async () => {
+        mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+        mockAppBlockFindUnique.mockResolvedValueOnce(null);
+        mockPublishRequestFindFirst.mockResolvedValueOnce(pendingRequest());
+        const { req, res } = authPost({ slug: 'my-pending-app', requestBudgetedSpend: true });
+        await handler(req as never, res as never);
+        expect(res._getStatusCode()).toBe(200);
+        const ev = eventOf(req, 'blocks.dev-token.pending-mint')!;
+        expect(ev.requestBudgetedSpend).toBe(true);
+        expect(ev.spendGrantBasis).toBe('explicit');
+        expect(ev.spendGranted).toBe(true);
+        // The approved-mint event must NOT fire on the pending path.
+        expect(eventOf(req, 'blocks.dev-token.approved-mint')).toBeUndefined();
+      });
+
+      it('NO-ROW path — the pre-existing event now also carries both fields', async () => {
+        mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+        mockAppBlockFindUnique.mockResolvedValueOnce(null);
+        mockPublishRequestFindFirst.mockResolvedValueOnce(null);
+        const { req, res } = authPost({
+          slug: 'brand-new-app',
+          scopes: ['ai:write:budgeted', 'models:read:self'],
+          requestBudgetedSpend: false,
+        });
+        await handler(req as never, res as never);
+        expect(res._getStatusCode()).toBe(200);
+        const ev = eventOf(req, 'blocks.dev-token.local-mint')!;
+        expect(ev.requestBudgetedSpend).toBe(false);
+        expect(ev.spendGranted).toBe(false);
+        expect(ev.spendGrantBasis).toBe('none');
+        expect(eventOf(req, 'blocks.dev-token.approved-mint')).toBeUndefined();
+      });
+
+      // The three events are mutually exclusive: exactly ONE fires per mint. Asserted
+      // per path as an enumerated list (not "the other two are undefined"), so an
+      // accidental double-emit fails too.
+      const MINT_EVENTS = [
+        'blocks.dev-token.approved-mint',
+        'blocks.dev-token.pending-mint',
+        'blocks.dev-token.local-mint',
+      ];
+      const fired = (req: unknown) =>
+        (req as { log: { info: ReturnType<typeof vi.fn> } }).log.info.mock.calls
+          .map((c) => c[0] as string)
+          .filter((n) => MINT_EVENTS.includes(n));
+
+      it('exactly ONE mint-audit event fires on the APPROVED path', async () => {
+        mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+        const { req, res } = authPost({ appBlockId: 'apb_abc' });
+        await handler(req as never, res as never);
+        expect(res._getStatusCode()).toBe(200);
+        expect(fired(req)).toEqual(['blocks.dev-token.approved-mint']);
+      });
+
+      it('exactly ONE mint-audit event fires on the PENDING path', async () => {
+        mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+        mockAppBlockFindUnique.mockResolvedValueOnce(null);
+        mockPublishRequestFindFirst.mockResolvedValueOnce(pendingRequest());
+        const { req, res } = authPost({ slug: 'my-pending-app' });
+        await handler(req as never, res as never);
+        expect(res._getStatusCode()).toBe(200);
+        expect(fired(req)).toEqual(['blocks.dev-token.pending-mint']);
+      });
+
+      it('exactly ONE mint-audit event fires on the NO-ROW path', async () => {
+        mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+        mockAppBlockFindUnique.mockResolvedValueOnce(null);
+        mockPublishRequestFindFirst.mockResolvedValueOnce(null);
+        const { req, res } = authPost({
+          slug: 'brand-new-app',
+          scopes: ['models:read:self'],
+        });
+        await handler(req as never, res as never);
+        expect(res._getStatusCode()).toBe(200);
+        expect(fired(req)).toEqual(['blocks.dev-token.local-mint']);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Step 1 of #3703 — makes budgeted spend an **explicitly requestable** grant on the dev-token mint.

## 🔴 No behaviour changes

The default stays **"infer"**, exactly as today. Every existing client — including one that has never heard of the new field — mints byte-identically. This is the non-breaking preparation step; flipping the default is a separate, breaking PR (see the bottom of this description).

## Why split the parameter instead of just adding a field

`clampDevScopes` took a single `keyCanSpend: boolean`, and that one boolean meant three different things at its three call sites: **entitlement** (bearer — the credential's `AIServicesWrite` bit), entitlement **deferred to a runtime gate** (dev tunnel), and **intent** (mod review, via `runForReal`). Conflating "may this context spend?" with "did the caller ask to spend on *this* mint?" is precisely what makes budgeted spend an implicit grant — there was never a place to express the second question.

It is now two independent predicates, **both required, neither defaulted**:

```ts
spendEntitled: boolean;   // MAY this context spend?
spendRequested: boolean;  // DID the caller ask to spend on THIS mint?
```

and the strip is `if (!(spendEntitled && spendRequested))`.

**The absence of defaults is load-bearing, not style.** A default of `false` would silently strip spend from every dev tunnel, including already-persisted sessions. A default of `true` would re-create the implicit grant for any future caller. Required parameters make the compiler force every present *and future* call site to answer both questions — verified by mutation: deleting `spendRequested` from the tunnel wrapper is a hard `TS2345`, not a silent behaviour change.

## Call sites

| call site | `spendEntitled` | `spendRequested` |
|---|---|---|
| `dev-token.ts` (bearer) | the `AIServicesWrite` bit — unchanged | `body.requestBudgetedSpend ?? true` |
| `clampTunnelDeclaredScopes` (dev tunnel) | `true` | `true` — **permanently** |
| `publish-request.service.ts` (mod review) | `runForReal` | `runForReal` |

**The tunnel path is unchanged, and that is critical.** It has no request body: the "request" *is* starting a dev tunnel with a manifest that declares the scope, and entitlement is the runtime author-flag re-check. More importantly, `startDevTunnel` clamps **once at write** and **persists** the result as `grantedScopes` on the tunnel session record — so a wrong value there would not merely affect future mints, it would silently strip spend from **already-stored live sessions**, with no re-clamp able to restore them. That persistence is verified, and there is now a guard asserting it at the layer where the value is *stored*, not merely computed.

At the mod-review call site, passing `runForReal` to both is correct and is **not** the old overloaded flag re-conflated under two names — the mod's explicit, consent-gated opt-in is simultaneously the authorisation to spend their own Buzz on unapproved code and the request to spend on this mint. That reasoning is stated in a comment beside the call so a later reader does not "fix" it.

## Wire format

`requestBudgetedSpend: z.boolean().optional()` on the dev-token request schema, alongside `scopes` and `buzzBudget`. It is deliberately distinct from `scopes`: `scopes` states what the *app* needs, this states what *this token* should carry — without the distinction a client-side `--spend` flag would be meaningless, because the manifest alone would keep granting spend.

**Deny is a silent strip, never an error.** `requestBudgetedSpend: true` from a bearer that is not entitled mints successfully *without* the scope. Every other step in that clamp belt is a strip; erroring would introduce a new failure mode on the money path.

## Observability (a later gate depends on this)

The mint-audit events previously fired only for the pending and no-row paths. **The approved path emitted nothing** — it writes rows byte-identical to a production page mint, so an approved-path dev mint was structurally invisible after the fact. It now emits `blocks.dev-token.approved-mint`.

All three events now carry **both**:

- `requestBudgetedSpend` — exactly as received: `true`, `false`, or **absent** (the key is omitted, never normalised to an invented `false`/`null`);
- `spendGrantBasis` — `'explicit'` | `'inferred'` | `'none'`.

Recording both is the point. `spendGrantBasis: 'none'` alone cannot distinguish *"the client asked and was denied"* from *"the client never asked"*, and those mean opposite things about client adoption. One value cannot express that pair.

**Which gate consumes it:** the step-3 default flip is gated on `spendGrantBasis === 'inferred'` — spend granted *only* because the `?? true` default filled in for a caller that never asked — falling to zero for non-internal callers over a rolling window. That gate is only measurable because these events exist, and it was blind on the approved path until now.

Flags and identifiers already handled by the request only — no tokens, no secrets, no PII.

## Tests

- Full 2×2 spend matrix on **enumerated** granted sets (`toEqual([...])`, never `toContain('spend')`), plus strip-not-error, plus the read/catalog scopes being untouched by either predicate.
- Bearer handler coverage on all three mint paths, including the four cases in the issue: entitled+`false` → excluded (red at base), entitled+`true` → included, **not**-entitled+`true` → excluded **and the mint succeeds**, and field-absent → included (labelled in the test as an invariant guard pinning the deliberate step-1 default, not regression coverage; it flips — as an edit, never a deletion — at step 3).
- **Call-site ledger** — scans the source tree for `clampDevScopes(` calls and asserts the set of containing files *exactly equals* a declared ledger, each entry naming the semantic pair it passes. Fails when the set **grows** and when it **shrinks**; carries a positive control so a broken scan cannot pass vacuously.
- **Asymmetry guard** — both halves of the intended divergence asserted in one place (the tunnel grants spend with no request input; a bearer with `spendRequested: false` does not), so it is stated once and cannot drift.
- **Persisted-state guard** — `startDevTunnel` still persists `ai:write:budgeted` into `grantedScopes`, asserted off the stored record.
- Mutation-checked: `&&`→`||` (dies on both directions, each on its own exact array), `?? true`→`?? false`, deleting `spendRequested` from the tunnel wrapper (compile error), adding a 4th caller, removing a ledger entry, and dropping the approved-path event.

Full unit project green: **848 files / 12 690 passed / 1 skipped**.

## Explicitly out of scope

- **The default flip (`?? true` → `?? false`) is a separate, breaking PR.** It is not in this change.
- The production page/model mint path (`block-tokens/index.ts`'s consent ledger, `partitionByConsent`) is untouched.
- No `TokenScope` values, no OAuth client `allowedScopes`, no migration.
- Consolidating the 9 open-coded `claims.scopes.includes('ai:write:budgeted')` enforcement sites — noted as separate work.

Closes nothing on its own; step 1 of #3703.
