### PR TITLE
DO NOT MERGE — temporary type error to verify a CI check reports failures

### DIFF
--- a/src/utils/ci-typecheck-probe.ts
+++ b/src/utils/ci-typecheck-probe.ts
@@ -1,0 +1,14 @@
+// TEMPORARY — DO NOT MERGE. Delete this file along with its PR.
+//
+// This file exists to make `pnpm run typecheck` fail on purpose, exactly once,
+// so we can confirm that a newly-added CI check actually reports a FAILURE and
+// not just a success. A check that has only ever been observed green has not
+// been shown to work: it is indistinguishable from one that reports green
+// unconditionally. The only way to tell the two apart is to make it go red on
+// demand and watch.
+//
+// The error below is a plain assignability violation, chosen because it needs no
+// imports, touches no runtime code path, and cannot be "fixed" incidentally by a
+// lint autofix or a formatter.
+
+export const ciTypecheckProbe: number = 'this is deliberately not a number';


### PR DESCRIPTION
Draft, temporary, and will be closed as soon as it has served its purpose. **Do not merge.**

## Why

A CI check that has only ever been observed **green** has not been shown to work — it is indistinguishable from one that reports green unconditionally. A newly-added typecheck reporter is in that state right now: every run so far has passed, so we have confirmed it can say "success" and nothing else.

The only way to tell a working gate from a vacuous one is to make it go red on demand and watch. This PR does that once.

## What

One new file, `src/utils/ci-typecheck-probe.ts`, containing a plain assignability violation (`const x: number = <string>`). It has no imports and is on no runtime code path, so it cannot be incidentally "fixed" by a lint autofix or a formatter, and it cannot affect anything at runtime.

Verified locally before pushing: `tsc` reports `TS2322` on line 14.

## Expected outcome

The typecheck checks on this PR go **red**. That is the pass condition. I will close this PR and delete the branch immediately afterwards.