### PR TITLE
BitDex consistency guard: standing PG↔BitDex audit + (gated) scheduled-post sweep

### DIFF
--- a/packages/civitai-telemetry/src/client.ts
+++ b/packages/civitai-telemetry/src/client.ts
@@ -280,6 +280,47 @@ export const reemitSkippedRateLimitCounter = registerCounter({
   help: 'BitDex publish re-emitter fires skipped by the self rate-limit because too little time has passed since the last successful emit (external scheduler over-firing)',
 });
 
+// The re-emitter's second scope: future-scheduled posts, which no trailing-past-window
+// scan can reach. Kept as separate series from the reemit_posts_scanned/images_emitted
+// pair above because this scan's volume is ~100x larger and steady — summing the two
+// would swamp the published-window emission signal.
+export const reemitScheduledPostsScannedCounter = registerCounter({
+  name: 'reemit_scheduled_posts_scanned_total',
+  help: 'Distinct future-scheduled posts (publishedAt > now()) scanned by the BitDex publish re-emitter across all runs',
+});
+export const reemitScheduledImagesEmittedCounter = registerCounter({
+  name: 'reemit_scheduled_images_emitted_total',
+  help: 'BitdexOps rows written by the BitDex publish re-emitter for images of future-scheduled posts across all runs',
+});
+
+// Metrics for the standing PG<->BitDex consistency audit (audit-bitdex-consistency).
+// checked_total is the liveness signal and the denominator; mismatch_total is the
+// alerting series. `stratum` is the sampled population, `kind` the failure mode —
+// both fixed low-cardinality enums (see MISMATCH_KINDS in the job).
+export const bitdexAuditCheckedCounter = registerCounterWithLabels({
+  name: 'bitdex_audit_checked_total',
+  help: 'Images compared between PG and BitDex by the consistency audit, by sample stratum',
+  labelNames: ['stratum'] as const,
+});
+export const bitdexAuditMismatchCounter = registerCounterWithLabels({
+  name: 'bitdex_audit_mismatch_total',
+  help: 'PG<->BitDex disagreements found by the consistency audit, by sample stratum and failure kind',
+  labelNames: ['stratum', 'kind'] as const,
+});
+export const bitdexAuditRunsCounter = registerCounter({
+  name: 'bitdex_audit_runs_total',
+  help: 'BitDex consistency audit runs that completed SUCCESSFULLY (success-only; the liveness signal behind a mismatch alert being trustworthy)',
+});
+export const bitdexAuditErrorsCounter = registerCounter({
+  name: 'bitdex_audit_errors_total',
+  help: 'BitDex consistency audit runs that threw (PG sample or BitDex fetch failed) before rethrowing',
+});
+export const bitdexAuditRunDurationHistogram = registerHistogram({
+  name: 'bitdex_audit_run_duration_seconds',
+  help: 'Wall-clock duration of a BitDex consistency audit run (both strata: PG sample + BitDex fetch + compare)',
+  buckets: [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30],
+});
+
 // Creator compensation metrics
 export const creatorCompCreatorsPaidCounter = registerCounterWithLabels({
   name: 'creator_comp_creators_paid_total',

--- a/src/pages/api/webhooks/run-jobs/[[...run]].ts
+++ b/src/pages/api/webhooks/run-jobs/[[...run]].ts
@@ -3,6 +3,7 @@ import { isProd } from '~/env/other';
 import { env } from '~/env/server';
 import { addOnDemandRunStrategiesJob } from '~/server/jobs/add-on-demand-run-strategies';
 import { announcementMediaCheckJob } from '~/server/jobs/announcement-media-check';
+import { auditBitdexConsistency } from '~/server/jobs/audit-bitdex-consistency';
 import { auditRemixSourcesJob } from '~/server/jobs/audit-remix-sources';
 import { dedupeOfficialUploadsJob } from '~/server/jobs/dedupe-official-uploads';
 import { applyContestTags } from '~/server/jobs/apply-contest-tags';
@@ -124,6 +125,7 @@ export const jobs: Job[] = [
   deliverLeaderboardCosmetics,
   reindexRecentScheduledImages,
   reemitBitdexOps,
+  auditBitdexConsistency,
   pushDiscordMetadata,
   applyVotedTags,
   removeOldDrafts,

--- a/src/server/bitdex/client.ts
+++ b/src/server/bitdex/client.ts
@@ -20,6 +20,9 @@ export type FilterClause =
 export type SortClause = { field: string; direction: 'Asc' | 'Desc' };
 
 const BITDEX_URL = process.env.BITDEX_URL || '';
+// The batch documents endpoint sits behind BitDex's admin bearer token (unlike
+// /query, which is open). Only fetchBitdexDocuments needs this.
+const BITDEX_ADMIN_TOKEN = process.env.BITDEX_ADMIN_TOKEN || '';
 const BITDEX_TIMEOUT_MS = 30000;
 
 export type BitdexDocument = Record<string, unknown> & { id: number };
@@ -41,6 +44,9 @@ export async function fetchBitdexDocuments(
   fields?: string[]
 ): Promise<BitdexDocument[]> {
   if (!BITDEX_URL) throw new Error('BITDEX_URL is not configured');
+  // Fail loudly up front: without the token the endpoint returns 401 on every
+  // call, and the audit must surface "cannot audit" rather than degrade.
+  if (!BITDEX_ADMIN_TOKEN) throw new Error('BITDEX_ADMIN_TOKEN is not configured');
   if (!slotIds.length) return [];
 
   const controller = new AbortController();
@@ -54,7 +60,10 @@ export async function fetchBitdexDocuments(
       () =>
         fetch(url, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${BITDEX_ADMIN_TOKEN}`,
+          },
           body: JSON.stringify({ slot_ids: slotIds, ...(fields ? { fields } : {}) }),
           signal: controller.signal,
         })

--- a/src/server/bitdex/client.ts
+++ b/src/server/bitdex/client.ts
@@ -22,6 +22,56 @@ export type SortClause = { field: string; direction: 'Asc' | 'Desc' };
 const BITDEX_URL = process.env.BITDEX_URL || '';
 const BITDEX_TIMEOUT_MS = 30000;
 
+export type BitdexDocument = Record<string, unknown> & { id: number };
+
+/**
+ * Fetch documents by slot ID (= Postgres ID) from BitDex's batch document endpoint.
+ *
+ * Unlike queryBitdex, this THROWS on any failure. Its caller is the consistency
+ * audit, where a swallowed error would read as "no mismatches found" — a silent
+ * pass is the one outcome an audit must never produce.
+ *
+ * BitDex returns a row for every requested slot; a document that is not on disk
+ * comes back as bare `{ id }` with no other fields, so absence is observable
+ * rather than being conflated with a dropped row.
+ */
+export async function fetchBitdexDocuments(
+  indexName: string,
+  slotIds: number[],
+  fields?: string[]
+): Promise<BitdexDocument[]> {
+  if (!BITDEX_URL) throw new Error('BITDEX_URL is not configured');
+  if (!slotIds.length) return [];
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), BITDEX_TIMEOUT_MS);
+  const url = `${BITDEX_URL}/api/indexes/${indexName}/documents`;
+  const urlAttr = safeUrl(url);
+  try {
+    const res = await withSpan(
+      'bitdex:http:documents',
+      { 'http.method': 'POST', 'http.url': urlAttr, 'bitdex.namespace': indexName },
+      () =>
+        fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ slot_ids: slotIds, ...(fields ? { fields } : {}) }),
+          signal: controller.signal,
+        })
+    );
+    if (!res.ok) {
+      const errText = await res.text().catch(() => '');
+      throw new Error(`BitDex documents fetch failed ${res.status}: ${errText.slice(0, 500)}`);
+    }
+    const body = (await res.json()) as { documents?: BitdexDocument[] };
+    if (!Array.isArray(body?.documents))
+      throw new Error('BitDex documents response missing `documents` array');
+    return body.documents;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 export interface BitdexQueryResult {
   ids: number[];
   total_matched: number;

--- a/src/server/bitdex/client.ts
+++ b/src/server/bitdex/client.ts
@@ -20,8 +20,10 @@ export type FilterClause =
 export type SortClause = { field: string; direction: 'Asc' | 'Desc' };
 
 const BITDEX_URL = process.env.BITDEX_URL || '';
-// The batch documents endpoint sits behind BitDex's admin bearer token (unlike
-// /query, which is open). Only fetchBitdexDocuments needs this.
+// The batch documents endpoint sits in BitDex's admin route group (unlike
+// /query, which is open). require_admin waives auth for no-X-Forwarded-For
+// (in-cluster) traffic, so the token is only required when BITDEX_URL routes
+// through a proxy that adds XFF. Only fetchBitdexDocuments uses this.
 const BITDEX_ADMIN_TOKEN = process.env.BITDEX_ADMIN_TOKEN || '';
 const BITDEX_TIMEOUT_MS = 30000;
 
@@ -44,9 +46,6 @@ export async function fetchBitdexDocuments(
   fields?: string[]
 ): Promise<BitdexDocument[]> {
   if (!BITDEX_URL) throw new Error('BITDEX_URL is not configured');
-  // Fail loudly up front: without the token the endpoint returns 401 on every
-  // call, and the audit must surface "cannot audit" rather than degrade.
-  if (!BITDEX_ADMIN_TOKEN) throw new Error('BITDEX_ADMIN_TOKEN is not configured');
   if (!slotIds.length) return [];
 
   const controller = new AbortController();
@@ -60,9 +59,13 @@ export async function fetchBitdexDocuments(
       () =>
         fetch(url, {
           method: 'POST',
+          // BitDex's require_admin waives auth for traffic without an
+          // X-Forwarded-For header (in-cluster calls); routed-through-proxy
+          // calls need the bearer. Send it when configured; if it's needed
+          // and absent, the 401 fails the fetch loudly — never a silent pass.
           headers: {
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${BITDEX_ADMIN_TOKEN}`,
+            ...(BITDEX_ADMIN_TOKEN ? { Authorization: `Bearer ${BITDEX_ADMIN_TOKEN}` } : {}),
           },
           body: JSON.stringify({ slot_ids: slotIds, ...(fields ? { fields } : {}) }),
           signal: controller.signal,

--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -45,6 +45,11 @@ export enum FLIPT_FEATURE_FLAGS {
   // Gates the reemit-bitdex-ops job (BitDex publish re-emitter). Default-off: the
   // job is registered but no-ops until this flag is flipped on.
   BITDEX_PUBLISH_REEMITTER = 'bitdex-publish-reemitter',
+  // Gates the audit-bitdex-consistency job (standing PG<->BitDex comparison).
+  // Separate from the re-emitter flag on purpose: the audit is read-only and the
+  // healer is write-side, so switching one off must not blind or unblind the other.
+  // Default-off, like every flag here — isFlipt returns false for an unknown flag.
+  BITDEX_CONSISTENCY_AUDIT = 'bitdex-consistency-audit',
   // Routes ImageResourceNew reads to the writer (primary) instead of the read
   // replica while the DataPacket replica is missing historical backfill rows
   // for imageId < ~110M. Flip off once backfill is complete.

--- a/src/server/jobs/__tests__/audit-bitdex-consistency.test.ts
+++ b/src/server/jobs/__tests__/audit-bitdex-consistency.test.ts
@@ -1,0 +1,369 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockDbWrite, mockIsFlipt, mockFetchDocs, mockCounters, mockHistogram } = vi.hoisted(() => ({
+  mockDbWrite: { $queryRaw: vi.fn() },
+  mockIsFlipt: vi.fn(),
+  mockFetchDocs: vi.fn(),
+  mockCounters: {
+    checked: { inc: vi.fn() },
+    mismatch: { inc: vi.fn() },
+    runs: { inc: vi.fn() },
+    errors: { inc: vi.fn() },
+  },
+  mockHistogram: { observe: vi.fn() },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbWrite: mockDbWrite }));
+vi.mock('~/server/bitdex/client', () => ({ fetchBitdexDocuments: mockFetchDocs }));
+vi.mock('~/server/flipt/client', () => ({
+  isFlipt: mockIsFlipt,
+  FLIPT_FEATURE_FLAGS: { BITDEX_CONSISTENCY_AUDIT: 'bitdex-consistency-audit' },
+}));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn(() => Promise.resolve()) }));
+vi.mock('~/server/prom/client', () => ({
+  bitdexAuditCheckedCounter: mockCounters.checked,
+  bitdexAuditMismatchCounter: mockCounters.mismatch,
+  bitdexAuditRunsCounter: mockCounters.runs,
+  bitdexAuditErrorsCounter: mockCounters.errors,
+  bitdexAuditRunDurationHistogram: mockHistogram,
+}));
+// createJob just returns the body fn so the test can invoke it directly.
+vi.mock('~/server/jobs/job', () => ({
+  createJob: (_n: string, _c: string, fn: unknown) => fn,
+}));
+
+import {
+  auditBitdexConsistency,
+  buildPublishedSampleQuery,
+  buildScheduledSampleQuery,
+  compareStratum,
+  getAuditConfig,
+  readDocState,
+} from '~/server/jobs/audit-bitdex-consistency';
+
+const runJob = auditBitdexConsistency as unknown as () => Promise<unknown>;
+
+const AUDIT_ENV = [
+  'BITDEX_AUDIT_SAMPLE_SIZE',
+  'BITDEX_AUDIT_PUBLISHED_WINDOW_SECS',
+  'BITDEX_AUDIT_SORTAT_TOLERANCE_SECS',
+  'BITDEX_AUDIT_SETTLE_SECS',
+];
+
+const clearEnv = () => AUDIT_ENV.forEach((k) => delete process.env[k]);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clearEnv();
+});
+afterEach(clearEnv);
+
+// PG truth for one sampled image. NOW is arbitrary but fixed so drift math is exact.
+const NOW = 1_754_400_000;
+const row = (over: Partial<Record<string, number>> = {}) => ({
+  imageId: 1,
+  postId: 10,
+  publishedAtSecs: NOW,
+  expectedSortAtSecs: NOW,
+  ...over,
+});
+
+describe('buildScheduledSampleQuery', () => {
+  const sql = () => buildScheduledSampleQuery({ sampleSize: 50, settleSecs: 120 }).sql;
+
+  it('samples ONLY future-scheduled posts (the incident class)', () => {
+    expect(sql()).toContain('"publishedAt" > now()');
+    expect(sql()).not.toContain('"publishedAt" <= now()');
+  });
+
+  it('randomizes so repeated runs cover the population, not the same head', () => {
+    expect(sql()).toContain('ORDER BY random()');
+    expect(sql()).toContain('LIMIT');
+  });
+
+  it('skips posts still settling, so lag is not read as a mismatch', () => {
+    expect(sql()).toContain('"updatedAt" < now() - make_interval');
+  });
+
+  it('asks PG for the GREATEST(publishedAt, scannedAt, createdAt) sortAt expectation', () => {
+    // The expectation must be computed with the same semantics the index config
+    // uses, not reimplemented in JS from a partial set of columns.
+    expect(sql()).toMatch(
+      /GREATEST\(p\."publishedAt", i\."scannedAt", i\."createdAt"\)/
+    );
+  });
+
+  it('parameterizes settle and sample size (no literal injection)', () => {
+    const query = buildScheduledSampleQuery({ sampleSize: 50, settleSecs: 120 });
+    expect(query.values).toEqual([120, 50]);
+    expect(query.sql).not.toContain('50');
+  });
+
+  it('is read-only — an audit that writes cannot report an honest rate', () => {
+    // Case-sensitive on purpose: the builders spell keywords in caps, and a
+    // case-insensitive match would hit the `"updatedAt"` column name.
+    expect(sql()).not.toMatch(/\b(INSERT|UPDATE|DELETE)\b/);
+  });
+});
+
+describe('buildPublishedSampleQuery', () => {
+  const args = { sampleSize: 50, publishedWindowSecs: 86400, settleSecs: 120 };
+  const sql = () => buildPublishedSampleQuery(args).sql;
+
+  it('bounds the sample to the recent published window on both sides', () => {
+    expect(sql()).toContain('"publishedAt" > now() - make_interval');
+    expect(sql()).toContain('"publishedAt" <= now()');
+  });
+
+  it('parameterizes window, settle and sample size', () => {
+    expect(buildPublishedSampleQuery(args).values).toEqual([86400, 120, 50]);
+  });
+
+  it('is read-only', () => {
+    expect(sql()).not.toMatch(/\b(INSERT|UPDATE|DELETE)\b/);
+  });
+});
+
+describe('getAuditConfig', () => {
+  it('defaults to 50 samples / 24h window / 5m tolerance / 2m settle', () => {
+    expect(getAuditConfig()).toEqual({
+      sampleSize: 50,
+      publishedWindowSecs: 86400,
+      sortAtToleranceSecs: 300,
+      settleSecs: 120,
+    });
+  });
+
+  it('honors positive env overrides', () => {
+    process.env.BITDEX_AUDIT_SAMPLE_SIZE = '200';
+    process.env.BITDEX_AUDIT_SORTAT_TOLERANCE_SECS = '60';
+    expect(getAuditConfig()).toMatchObject({ sampleSize: 200, sortAtToleranceSecs: 60 });
+  });
+
+  it('falls back to defaults on invalid / non-positive values', () => {
+    process.env.BITDEX_AUDIT_SAMPLE_SIZE = '0';
+    process.env.BITDEX_AUDIT_SETTLE_SECS = 'nope';
+    expect(getAuditConfig()).toMatchObject({ sampleSize: 50, settleSecs: 120 });
+  });
+});
+
+describe('readDocState', () => {
+  it('reports a missing doc as absent, not as unpublished-with-data', () => {
+    expect(readDocState(undefined)).toEqual({ present: false, published: false, sortAtSecs: null });
+  });
+
+  it('treats a bare { id } (no doc on disk) as absent', () => {
+    // The batch endpoint returns just the id for a slot with no stored document.
+    expect(readDocState({ id: 7 })).toMatchObject({ present: false, published: false });
+  });
+
+  it('takes isPublished as the authority when present', () => {
+    expect(readDocState({ id: 7, isPublished: false, publishedAt: NOW })).toMatchObject({
+      present: true,
+      published: false,
+    });
+  });
+
+  it('falls back to publishedAt when isPublished is absent from the payload', () => {
+    // isPublished is an exists_boolean derived FROM publishedAt, so the two carry
+    // the same fact and either one is sufficient to answer "is it published".
+    expect(readDocState({ id: 7, publishedAt: NOW })).toMatchObject({
+      present: true,
+      published: true,
+    });
+    expect(readDocState({ id: 7, publishedAt: null })).toMatchObject({
+      present: true,
+      published: false,
+    });
+  });
+});
+
+describe('compareStratum — scheduled (the incident class)', () => {
+  const compare = (docs: Record<string, unknown>[], rows = [row()]) =>
+    compareStratum('scheduled', rows as never, docs as never, { sortAtToleranceSecs: 300 });
+
+  it('flags a scheduled image BitDex holds as published', () => {
+    const found = compare([{ id: 1, isPublished: true, sortAt: NOW }]);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({
+      kind: 'scheduled_visible',
+      stratum: 'scheduled',
+      imageId: 1,
+      postId: 10,
+    });
+    // The trail an alert needs: both sides of the disagreement, not just a count.
+    expect(found[0].expected).toContain('unpublished');
+    expect(found[0].actual).toContain('isPublished=true');
+  });
+
+  it('accepts a scheduled image held as unpublished', () => {
+    expect(compare([{ id: 1, isPublished: false, publishedAt: null }])).toEqual([]);
+  });
+
+  it('accepts a scheduled image with no doc at all (not yet indexed is legal)', () => {
+    expect(compare([])).toEqual([]);
+  });
+
+  it('does not flag sortAt drift in this stratum — only visibility matters', () => {
+    // A scheduled doc may legitimately carry any sortAt; only "published" is wrong.
+    expect(compare([{ id: 1, isPublished: false, sortAt: NOW + 999_999 }])).toEqual([]);
+  });
+
+  it('flags each offending image independently', () => {
+    const found = compare(
+      [
+        { id: 1, isPublished: true },
+        { id: 2, isPublished: false },
+        { id: 3, isPublished: true },
+      ],
+      [row(), row({ imageId: 2 }), row({ imageId: 3 })]
+    );
+    expect(found.map((m) => m.imageId)).toEqual([1, 3]);
+  });
+});
+
+describe('compareStratum — published_recent', () => {
+  const compare = (docs: Record<string, unknown>[], rows = [row()]) =>
+    compareStratum('published_recent', rows as never, docs as never, { sortAtToleranceSecs: 300 });
+
+  it('flags a published image whose doc is absent from BitDex', () => {
+    const found = compare([]);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({ kind: 'published_missing', imageId: 1 });
+    expect(found[0].actual).toContain('absent');
+  });
+
+  it('flags a published image BitDex holds as unpublished', () => {
+    const found = compare([{ id: 1, isPublished: false, sortAt: NOW }]);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({ kind: 'published_missing' });
+    expect(found[0].actual).toContain('isPublished=false');
+  });
+
+  it('accepts a sortAt inside the tolerance (propagation lag is not a mismatch)', () => {
+    expect(compare([{ id: 1, isPublished: true, sortAt: NOW - 299 }])).toEqual([]);
+    expect(compare([{ id: 1, isPublished: true, sortAt: NOW + 300 }])).toEqual([]);
+  });
+
+  it('flags a sortAt outside the tolerance, in either direction', () => {
+    const late = compare([{ id: 1, isPublished: true, sortAt: NOW + 601 }]);
+    expect(late[0]).toMatchObject({ kind: 'sortat_drift' });
+    expect(late[0].actual).toContain('drift=601s');
+
+    const early = compare([{ id: 1, isPublished: true, sortAt: NOW - 601 }]);
+    expect(early[0]).toMatchObject({ kind: 'sortat_drift' });
+  });
+
+  it('flags a published doc carrying no sortAt at all', () => {
+    const found = compare([{ id: 1, isPublished: true }]);
+    expect(found[0]).toMatchObject({ kind: 'sortat_drift' });
+    expect(found[0].actual).toContain('sortAt=null');
+  });
+
+  it('reports missing-publish rather than drift when both are wrong', () => {
+    // A doc that is not published has no meaningful sortAt to drift; reporting both
+    // would double-count one broken image across two alert series.
+    const found = compare([{ id: 1, isPublished: false, sortAt: 0 }]);
+    expect(found).toHaveLength(1);
+    expect(found[0].kind).toBe('published_missing');
+  });
+});
+
+describe('auditBitdexConsistency job body', () => {
+  const scheduledRows = [row()];
+  const publishedRows = [row({ imageId: 2, postId: 20 })];
+
+  it('no-ops when the Flipt flag is OFF (default-off gate)', async () => {
+    mockIsFlipt.mockResolvedValue(false);
+
+    await runJob();
+
+    expect(mockDbWrite.$queryRaw).not.toHaveBeenCalled();
+    expect(mockFetchDocs).not.toHaveBeenCalled();
+    expect(mockCounters.runs.inc).not.toHaveBeenCalled();
+  });
+
+  it('samples both strata, counts checks, and records a clean run', async () => {
+    mockIsFlipt.mockResolvedValue(true);
+    mockDbWrite.$queryRaw
+      .mockResolvedValueOnce(scheduledRows)
+      .mockResolvedValueOnce(publishedRows);
+    mockFetchDocs
+      .mockResolvedValueOnce([{ id: 1, isPublished: false }])
+      .mockResolvedValueOnce([{ id: 2, isPublished: true, sortAt: NOW }]);
+
+    const result = await runJob();
+
+    expect(mockDbWrite.$queryRaw).toHaveBeenCalledTimes(2);
+    expect(mockFetchDocs).toHaveBeenCalledTimes(2);
+    // Docs are requested by the sampled image ids, from the civitai index.
+    expect(mockFetchDocs.mock.calls[0][0]).toBe('civitai');
+    expect(mockFetchDocs.mock.calls[0][1]).toEqual([1]);
+    expect(mockCounters.checked.inc).toHaveBeenCalledWith({ stratum: 'scheduled' }, 1);
+    expect(mockCounters.checked.inc).toHaveBeenCalledWith({ stratum: 'published_recent' }, 1);
+    expect(mockCounters.mismatch.inc).not.toHaveBeenCalled();
+    expect(mockCounters.runs.inc).toHaveBeenCalledTimes(1);
+    expect(mockHistogram.observe).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      scheduledChecked: 1,
+      scheduledMismatches: 0,
+      publishedChecked: 1,
+      publishedMismatches: 0,
+    });
+  });
+
+  it('counts a mismatch under its stratum and kind', async () => {
+    mockIsFlipt.mockResolvedValue(true);
+    mockDbWrite.$queryRaw
+      .mockResolvedValueOnce(scheduledRows)
+      .mockResolvedValueOnce(publishedRows);
+    mockFetchDocs
+      .mockResolvedValueOnce([{ id: 1, isPublished: true }])
+      .mockResolvedValueOnce([{ id: 2, isPublished: true, sortAt: NOW }]);
+
+    const result = await runJob();
+
+    expect(mockCounters.mismatch.inc).toHaveBeenCalledWith(
+      { stratum: 'scheduled', kind: 'scheduled_visible' },
+      1
+    );
+    expect(result).toMatchObject({ scheduledMismatches: 1, publishedMismatches: 0 });
+    // A run that finds something is still a successful run — the alert reads the
+    // mismatch series, and runs_total has to stay trustworthy as the liveness signal.
+    expect(mockCounters.runs.inc).toHaveBeenCalledTimes(1);
+    expect(mockCounters.errors.inc).not.toHaveBeenCalled();
+  });
+
+  it('skips the BitDex fetch when a stratum sampled nothing', async () => {
+    mockIsFlipt.mockResolvedValue(true);
+    mockDbWrite.$queryRaw.mockResolvedValueOnce([]).mockResolvedValueOnce(publishedRows);
+    mockFetchDocs.mockResolvedValueOnce([{ id: 2, isPublished: true, sortAt: NOW }]);
+
+    const result = await runJob();
+
+    expect(mockFetchDocs).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ scheduledChecked: 0, publishedChecked: 1 });
+  });
+
+  it('errors (does NOT report a clean audit) when the BitDex fetch fails', async () => {
+    mockIsFlipt.mockResolvedValue(true);
+    mockDbWrite.$queryRaw.mockResolvedValue(scheduledRows);
+    mockFetchDocs.mockRejectedValue(new Error('BitDex documents fetch failed 503'));
+
+    await expect(runJob()).rejects.toThrow(/503/);
+    // The one outcome this job must never produce is a silent pass.
+    expect(mockCounters.errors.inc).toHaveBeenCalledTimes(1);
+    expect(mockCounters.runs.inc).not.toHaveBeenCalled();
+    expect(mockCounters.mismatch.inc).not.toHaveBeenCalled();
+    expect(mockHistogram.observe).not.toHaveBeenCalled();
+  });
+
+  it('errors when the PG sample fails', async () => {
+    mockIsFlipt.mockResolvedValue(true);
+    mockDbWrite.$queryRaw.mockRejectedValue(new Error('relation "Post" does not exist'));
+
+    await expect(runJob()).rejects.toThrow(/does not exist/);
+    expect(mockCounters.errors.inc).toHaveBeenCalledTimes(1);
+    expect(mockCounters.runs.inc).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/jobs/__tests__/reemit-bitdex-ops.test.ts
+++ b/src/server/jobs/__tests__/reemit-bitdex-ops.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockDbWrite, mockIsFlipt, mockCounters, mockHistogram, mockGetJobDate, mockSetLastRun } =
+const {
+  mockDbWrite,
+  mockIsFlipt,
+  mockCounters,
+  mockHistogram,
+  mockGetJobDate,
+  mockSetLastRun,
+  mockSetSweepLastRun,
+} =
   vi.hoisted(() => ({
     mockDbWrite: { $queryRaw: vi.fn() },
     mockIsFlipt: vi.fn(),
@@ -16,6 +24,7 @@ const { mockDbWrite, mockIsFlipt, mockCounters, mockHistogram, mockGetJobDate, m
     },
     mockHistogram: { observe: vi.fn() },
     mockSetLastRun: vi.fn(() => Promise.resolve()),
+    mockSetSweepLastRun: vi.fn(() => Promise.resolve()),
     mockGetJobDate: vi.fn(),
   }));
 
@@ -60,9 +69,16 @@ beforeEach(() => {
   delete process.env.REEMIT_SETTLE_SECS;
   delete process.env.REEMIT_MIN_INTERVAL_SECS;
   delete process.env.REEMIT_SCHEDULED_SWEEP_ENABLED;
-  // Default: last emit was long ago (epoch) so the rate-limit never trips unless a
-  // test explicitly pins a recent last-run time.
-  mockGetJobDate.mockResolvedValue([new Date(0), mockSetLastRun]);
+  // Default: both clocks read epoch, so the rate-limit never trips and the sweep is
+  // due, unless a test pins a specific clock. getJobDate is keyed: the job reads two
+  // markers (reemit last-run, scheduled-sweep last-run) with distinct setters.
+  mockGetJobDate.mockImplementation((key: string) =>
+    Promise.resolve(
+      key.includes('scheduled-sweep')
+        ? [new Date(0), mockSetSweepLastRun]
+        : [new Date(0), mockSetLastRun]
+    )
+  );
 });
 
 afterEach(() => {
@@ -217,7 +233,13 @@ describe('reemitBitdexOps job body', () => {
 
   it('skips (rate-limited) when the last emit is inside the min interval', async () => {
     // Last successful emit was 60s ago — well inside the 270s default interval.
-    mockGetJobDate.mockResolvedValue([new Date(Date.now() - 60_000), mockSetLastRun]);
+    mockGetJobDate.mockImplementation((key: string) =>
+      Promise.resolve(
+        key.includes('scheduled-sweep')
+          ? [new Date(0), mockSetSweepLastRun]
+          : [new Date(Date.now() - 60_000), mockSetLastRun]
+      )
+    );
     mockIsFlipt.mockResolvedValue(true);
 
     await runJob();
@@ -231,8 +253,14 @@ describe('reemitBitdexOps job body', () => {
   });
 
   it('runs once the min interval has elapsed and advances the last-run marker', async () => {
-    // Last emit was 5 minutes ago — past the 270s interval.
-    mockGetJobDate.mockResolvedValue([new Date(Date.now() - 300_000), mockSetLastRun]);
+    // Last emit was 5 minutes ago — past the 270s interval. Sweep clock at epoch = due.
+    mockGetJobDate.mockImplementation((key: string) =>
+      Promise.resolve(
+        key.includes('scheduled-sweep')
+          ? [new Date(0), mockSetSweepLastRun]
+          : [new Date(Date.now() - 300_000), mockSetLastRun]
+      )
+    );
     mockIsFlipt.mockResolvedValue(true);
     mockDbWrite.$queryRaw.mockResolvedValue([{ postsScanned: 3, imagesEmitted: 12 }]);
 
@@ -241,8 +269,9 @@ describe('reemitBitdexOps job body', () => {
     expect(mockCounters.skipped.inc).not.toHaveBeenCalled();
     // Both scans ran (the scheduled sweep is on by default).
     expect(mockDbWrite.$queryRaw).toHaveBeenCalledTimes(2);
-    // The window advances only after a successful emit.
+    // Each window advances only after a successful emit — one call per clock.
     expect(mockSetLastRun).toHaveBeenCalledTimes(1);
+    expect(mockSetSweepLastRun).toHaveBeenCalledTimes(1);
   });
 
   it('runs BOTH scans and records per-scope metrics when ON', async () => {
@@ -289,6 +318,30 @@ describe('reemitBitdexOps job body', () => {
     expect(mockDbWrite.$queryRaw.mock.calls[0][0].sql).toContain('"publishedAt" <= now()');
     expect(mockCounters.scheduledPosts.inc).toHaveBeenCalledWith(0);
     expect(mockCounters.scheduledImages.inc).toHaveBeenCalledWith(0);
+    expect(result).toMatchObject({ scheduledPostsScanned: 0, scheduledImagesEmitted: 0 });
+  });
+
+  it('skips the sweep (published scan only) when the sweep interval has not elapsed', async () => {
+    // Sweep ran 5 minutes ago — inside the 1h default sweep interval. Reemit clock
+    // stays at epoch so the published-window scan is not rate-limited.
+    mockGetJobDate.mockImplementation((key: string) =>
+      Promise.resolve(
+        key.includes('scheduled-sweep')
+          ? [new Date(Date.now() - 300_000), mockSetSweepLastRun]
+          : [new Date(0), mockSetLastRun]
+      )
+    );
+    mockIsFlipt.mockResolvedValue(true);
+    mockDbWrite.$queryRaw.mockResolvedValue([{ postsScanned: 3, imagesEmitted: 12 }]);
+
+    const result = await runJob();
+
+    expect(mockDbWrite.$queryRaw).toHaveBeenCalledTimes(1);
+    expect(mockDbWrite.$queryRaw.mock.calls[0][0].sql).toContain('"publishedAt" <= now()');
+    // The sweep clock must NOT advance on a skipped sweep — otherwise a sweep that
+    // never runs keeps pushing its own next run into the future.
+    expect(mockSetSweepLastRun).not.toHaveBeenCalled();
+    expect(mockSetLastRun).toHaveBeenCalledTimes(1);
     expect(result).toMatchObject({ scheduledPostsScanned: 0, scheduledImagesEmitted: 0 });
   });
 

--- a/src/server/jobs/__tests__/reemit-bitdex-ops.test.ts
+++ b/src/server/jobs/__tests__/reemit-bitdex-ops.test.ts
@@ -161,22 +161,25 @@ describe('buildScheduledReemitQuery', () => {
 });
 
 describe('getScheduledSweepEnabled', () => {
-  it('defaults ON — the sweep is the only healer that reaches scheduled posts', () => {
-    expect(getScheduledSweepEnabled()).toBe(true);
+  it('defaults OFF until the engine reschedule fix ships (bitdex-v2 v1.1.53)', () => {
+    // A future-guarded publishedAt REMOVE currently UNSCHEDULES a deferred slot
+    // (engine drops it from the deferred map and activates it as a draft), so the
+    // sweep must not run against a healthy deferred map. See the source comment.
+    expect(getScheduledSweepEnabled()).toBe(false);
   });
 
-  it('honors the off switch in its several spellings', () => {
-    for (const raw of ['false', 'FALSE', '0', 'off', 'no', ' false ']) {
+  it('honors the on switch in its several spellings', () => {
+    for (const raw of ['true', 'TRUE', '1', 'on', 'yes', ' true ']) {
       process.env.REEMIT_SCHEDULED_SWEEP_ENABLED = raw;
-      expect(getScheduledSweepEnabled()).toBe(false);
+      expect(getScheduledSweepEnabled()).toBe(true);
     }
   });
 
-  it('stays ON for anything that is not an off value', () => {
-    process.env.REEMIT_SCHEDULED_SWEEP_ENABLED = 'true';
-    expect(getScheduledSweepEnabled()).toBe(true);
+  it('stays OFF for anything that is not an explicit on value', () => {
     process.env.REEMIT_SCHEDULED_SWEEP_ENABLED = 'gibberish';
-    expect(getScheduledSweepEnabled()).toBe(true);
+    expect(getScheduledSweepEnabled()).toBe(false);
+    delete process.env.REEMIT_SCHEDULED_SWEEP_ENABLED;
+    expect(getScheduledSweepEnabled()).toBe(false);
   });
 });
 
@@ -253,6 +256,7 @@ describe('reemitBitdexOps job body', () => {
   });
 
   it('runs once the min interval has elapsed and advances the last-run marker', async () => {
+    process.env.REEMIT_SCHEDULED_SWEEP_ENABLED = 'true';
     // Last emit was 5 minutes ago — past the 270s interval. Sweep clock at epoch = due.
     mockGetJobDate.mockImplementation((key: string) =>
       Promise.resolve(
@@ -275,6 +279,7 @@ describe('reemitBitdexOps job body', () => {
   });
 
   it('runs BOTH scans and records per-scope metrics when ON', async () => {
+    process.env.REEMIT_SCHEDULED_SWEEP_ENABLED = 'true';
     mockIsFlipt.mockResolvedValue(true);
     mockDbWrite.$queryRaw
       .mockResolvedValueOnce([{ postsScanned: 3, imagesEmitted: 12 }])
@@ -322,6 +327,7 @@ describe('reemitBitdexOps job body', () => {
   });
 
   it('skips the sweep (published scan only) when the sweep interval has not elapsed', async () => {
+    process.env.REEMIT_SCHEDULED_SWEEP_ENABLED = 'true';
     // Sweep ran 5 minutes ago — inside the 1h default sweep interval. Reemit clock
     // stays at epoch so the published-window scan is not rate-limited.
     mockGetJobDate.mockImplementation((key: string) =>
@@ -346,6 +352,7 @@ describe('reemitBitdexOps job body', () => {
   });
 
   it('counts the error and rethrows when the SCHEDULED scan fails', async () => {
+    process.env.REEMIT_SCHEDULED_SWEEP_ENABLED = 'true';
     mockIsFlipt.mockResolvedValue(true);
     mockDbWrite.$queryRaw
       .mockResolvedValueOnce([{ postsScanned: 3, imagesEmitted: 12 }])

--- a/src/server/jobs/__tests__/reemit-bitdex-ops.test.ts
+++ b/src/server/jobs/__tests__/reemit-bitdex-ops.test.ts
@@ -10,6 +10,8 @@ const { mockDbWrite, mockIsFlipt, mockCounters, mockHistogram, mockGetJobDate, m
       errors: { inc: vi.fn() },
       posts: { inc: vi.fn() },
       images: { inc: vi.fn() },
+      scheduledPosts: { inc: vi.fn() },
+      scheduledImages: { inc: vi.fn() },
       skipped: { inc: vi.fn() },
     },
     mockHistogram: { observe: vi.fn() },
@@ -29,6 +31,8 @@ vi.mock('~/server/prom/client', () => ({
   reemitErrorsCounter: mockCounters.errors,
   reemitPostsScannedCounter: mockCounters.posts,
   reemitImagesEmittedCounter: mockCounters.images,
+  reemitScheduledPostsScannedCounter: mockCounters.scheduledPosts,
+  reemitScheduledImagesEmittedCounter: mockCounters.scheduledImages,
   reemitRunDurationHistogram: mockHistogram,
   reemitSkippedRateLimitCounter: mockCounters.skipped,
 }));
@@ -41,8 +45,10 @@ vi.mock('~/server/jobs/job', () => ({
 
 import {
   buildReemitQuery,
+  buildScheduledReemitQuery,
   getReemitConfig,
   getReemitMinIntervalSecs,
+  getScheduledSweepEnabled,
   reemitBitdexOps,
 } from '~/server/jobs/reemit-bitdex-ops';
 
@@ -53,6 +59,7 @@ beforeEach(() => {
   delete process.env.REEMIT_LOOKBACK_SECS;
   delete process.env.REEMIT_SETTLE_SECS;
   delete process.env.REEMIT_MIN_INTERVAL_SECS;
+  delete process.env.REEMIT_SCHEDULED_SWEEP_ENABLED;
   // Default: last emit was long ago (epoch) so the rate-limit never trips unless a
   // test explicitly pins a recent last-run time.
   mockGetJobDate.mockResolvedValue([new Date(0), mockSetLastRun]);
@@ -62,6 +69,7 @@ afterEach(() => {
   delete process.env.REEMIT_LOOKBACK_SECS;
   delete process.env.REEMIT_SETTLE_SECS;
   delete process.env.REEMIT_MIN_INTERVAL_SECS;
+  delete process.env.REEMIT_SCHEDULED_SWEEP_ENABLED;
 });
 
 describe('buildReemitQuery', () => {
@@ -95,6 +103,64 @@ describe('buildReemitQuery', () => {
     expect(query.values).toEqual([900, 10]);
     // The seconds are placeholders, not baked into the text.
     expect(query.sql).not.toContain('900');
+  });
+});
+
+describe('buildScheduledReemitQuery', () => {
+  const sql = () => buildScheduledReemitQuery({ settleSecs: 10 }).sql;
+
+  it('calls BOTH shared PG functions and concatenates them (shape parity)', () => {
+    // The scheduled scope must reuse the shared op shape, never re-spell a
+    // "remove" op locally — bitdex_post_fanout_ops' own CASE guard is what turns a
+    // future publishedAt into remove ops.
+    expect(sql()).toContain('bitdex_post_fanout_ops(p)');
+    expect(sql()).toContain('bitdex_image_sortat_ops(i)');
+    expect(sql()).toMatch(/bitdex_post_fanout_ops\(p\)\s*\|\|\s*bitdex_image_sortat_ops\(i\)/);
+  });
+
+  it('is a single INSERT ... SELECT emission', () => {
+    const text = sql();
+    expect(text.match(/INSERT INTO "BitdexOps"/g)).toHaveLength(1);
+    expect(text).toContain('INSERT INTO "BitdexOps" (entity_id, ops)');
+  });
+
+  it('scans ONLY future-scheduled posts (publishedAt > now(), no lookback bound)', () => {
+    const text = sql();
+    expect(text).toContain('"publishedAt" > now()');
+    // The published-window bounds must not leak in — they are what made scheduled
+    // posts unreachable in the first place.
+    expect(text).not.toContain('"publishedAt" <= now()');
+    expect(text).not.toContain('"publishedAt" >= now() -');
+  });
+
+  it('applies the same settle belt on updatedAt', () => {
+    expect(sql()).toContain('"updatedAt"  <  now() - make_interval');
+  });
+
+  it('parameterizes settle only (no literal injection, no lookback param)', () => {
+    const query = buildScheduledReemitQuery({ settleSecs: 30 });
+    expect(query.values).toEqual([30]);
+    expect(query.sql).not.toContain('30');
+  });
+});
+
+describe('getScheduledSweepEnabled', () => {
+  it('defaults ON — the sweep is the only healer that reaches scheduled posts', () => {
+    expect(getScheduledSweepEnabled()).toBe(true);
+  });
+
+  it('honors the off switch in its several spellings', () => {
+    for (const raw of ['false', 'FALSE', '0', 'off', 'no', ' false ']) {
+      process.env.REEMIT_SCHEDULED_SWEEP_ENABLED = raw;
+      expect(getScheduledSweepEnabled()).toBe(false);
+    }
+  });
+
+  it('stays ON for anything that is not an off value', () => {
+    process.env.REEMIT_SCHEDULED_SWEEP_ENABLED = 'true';
+    expect(getScheduledSweepEnabled()).toBe(true);
+    process.env.REEMIT_SCHEDULED_SWEEP_ENABLED = 'gibberish';
+    expect(getScheduledSweepEnabled()).toBe(true);
   });
 });
 
@@ -173,27 +239,70 @@ describe('reemitBitdexOps job body', () => {
     await runJob();
 
     expect(mockCounters.skipped.inc).not.toHaveBeenCalled();
-    expect(mockDbWrite.$queryRaw).toHaveBeenCalledTimes(1);
+    // Both scans ran (the scheduled sweep is on by default).
+    expect(mockDbWrite.$queryRaw).toHaveBeenCalledTimes(2);
     // The window advances only after a successful emit.
     expect(mockSetLastRun).toHaveBeenCalledTimes(1);
   });
 
-  it('emits once and records metrics from the returned counts when ON', async () => {
+  it('runs BOTH scans and records per-scope metrics when ON', async () => {
+    mockIsFlipt.mockResolvedValue(true);
+    mockDbWrite.$queryRaw
+      .mockResolvedValueOnce([{ postsScanned: 3, imagesEmitted: 12 }])
+      .mockResolvedValueOnce([{ postsScanned: 700, imagesEmitted: 5600 }]);
+
+    const result = await runJob();
+
+    // One statement per scope — the published window first, then the sweep.
+    expect(mockDbWrite.$queryRaw).toHaveBeenCalledTimes(2);
+    expect(mockDbWrite.$queryRaw.mock.calls[0][0].sql).toContain('"publishedAt" <= now()');
+    expect(mockDbWrite.$queryRaw.mock.calls[1][0].sql).toContain('"publishedAt" > now()');
+
+    expect(mockCounters.attempts.inc).toHaveBeenCalledTimes(1);
+    expect(mockCounters.runs.inc).toHaveBeenCalledTimes(1);
+    expect(mockCounters.errors.inc).not.toHaveBeenCalled();
+    // The scheduled volume must NOT be folded into the published-window counters —
+    // it is ~100x larger and would swamp the signal the existing alerts read.
+    expect(mockCounters.posts.inc).toHaveBeenCalledWith(3);
+    expect(mockCounters.images.inc).toHaveBeenCalledWith(12);
+    expect(mockCounters.scheduledPosts.inc).toHaveBeenCalledWith(700);
+    expect(mockCounters.scheduledImages.inc).toHaveBeenCalledWith(5600);
+    expect(mockHistogram.observe).toHaveBeenCalledTimes(1);
+    expect(mockSetLastRun).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      postsScanned: 3,
+      imagesEmitted: 12,
+      scheduledPostsScanned: 700,
+      scheduledImagesEmitted: 5600,
+    });
+  });
+
+  it('skips the second scan (and reports zeroes) when the sweep is switched off', async () => {
+    process.env.REEMIT_SCHEDULED_SWEEP_ENABLED = 'false';
     mockIsFlipt.mockResolvedValue(true);
     mockDbWrite.$queryRaw.mockResolvedValue([{ postsScanned: 3, imagesEmitted: 12 }]);
 
     const result = await runJob();
 
-    // Single statement — exactly one query executed.
+    // The published-window scan is unaffected by the sweep knob.
     expect(mockDbWrite.$queryRaw).toHaveBeenCalledTimes(1);
-    expect(mockCounters.attempts.inc).toHaveBeenCalledTimes(1);
-    expect(mockCounters.runs.inc).toHaveBeenCalledTimes(1);
-    expect(mockCounters.errors.inc).not.toHaveBeenCalled();
-    expect(mockCounters.posts.inc).toHaveBeenCalledWith(3);
-    expect(mockCounters.images.inc).toHaveBeenCalledWith(12);
-    expect(mockHistogram.observe).toHaveBeenCalledTimes(1);
-    expect(mockSetLastRun).toHaveBeenCalledTimes(1);
-    expect(result).toMatchObject({ postsScanned: 3, imagesEmitted: 12 });
+    expect(mockDbWrite.$queryRaw.mock.calls[0][0].sql).toContain('"publishedAt" <= now()');
+    expect(mockCounters.scheduledPosts.inc).toHaveBeenCalledWith(0);
+    expect(mockCounters.scheduledImages.inc).toHaveBeenCalledWith(0);
+    expect(result).toMatchObject({ scheduledPostsScanned: 0, scheduledImagesEmitted: 0 });
+  });
+
+  it('counts the error and rethrows when the SCHEDULED scan fails', async () => {
+    mockIsFlipt.mockResolvedValue(true);
+    mockDbWrite.$queryRaw
+      .mockResolvedValueOnce([{ postsScanned: 3, imagesEmitted: 12 }])
+      .mockRejectedValueOnce(new Error('scheduled scan blew up'));
+
+    await expect(runJob()).rejects.toThrow(/scheduled scan blew up/);
+    expect(mockCounters.errors.inc).toHaveBeenCalledTimes(1);
+    expect(mockCounters.runs.inc).not.toHaveBeenCalled();
+    // A partial run must not advance the rate-limit window.
+    expect(mockSetLastRun).not.toHaveBeenCalled();
   });
 
   it('counts the attempt + error but NOT a run, and rethrows, on a PG error', async () => {

--- a/src/server/jobs/audit-bitdex-consistency.ts
+++ b/src/server/jobs/audit-bitdex-consistency.ts
@@ -1,0 +1,363 @@
+import { Prisma } from '@prisma/client';
+import type { BitdexDocument } from '~/server/bitdex/client';
+import { fetchBitdexDocuments } from '~/server/bitdex/client';
+import { dbWrite } from '~/server/db/client';
+import { FLIPT_FEATURE_FLAGS, isFlipt } from '~/server/flipt/client';
+import { logToAxiom } from '~/server/logging/client';
+import {
+  bitdexAuditCheckedCounter,
+  bitdexAuditErrorsCounter,
+  bitdexAuditMismatchCounter,
+  bitdexAuditRunDurationHistogram,
+  bitdexAuditRunsCounter,
+} from '~/server/prom/client';
+import { createJob } from './job';
+
+// Standing PG <-> BitDex consistency audit.
+//
+// The 2026-08-06 leak (~2,300 scheduled images surfaced at feed tops) was invisible
+// to every existing signal because BitDex was internally consistent about wrong data:
+// its own counters, its verifier, and its query results all agreed with each other.
+// Only a comparison against the other system can catch that class, so this job samples
+// PG truth and asks BitDex what it holds for the same images.
+//
+// This job is READ-ONLY. It never emits ops and never heals — healing is the
+// re-emitter's job (reemit-bitdex-ops). Keeping the detector separate from the healer
+// is deliberate: a detector that repairs what it finds reports zero and hides the rate.
+
+const CADENCE_CRON = '*/10 * * * *';
+const BITDEX_INDEX = 'civitai';
+
+const DEFAULT_SAMPLE_SIZE = 50;
+// Recency window for stratum B. Wide enough to hold several re-emitter windows, so a
+// missed write that the re-emitter is about to heal is still visible to one audit run.
+const DEFAULT_PUBLISHED_WINDOW_SECS = 24 * 60 * 60;
+// sortAt is derived (GREATEST of publishedAt/scannedAt/createdAt) and lands in BitDex
+// through an async pipeline, so exact equality would flag ordinary propagation lag.
+// Only a drift larger than this is a real disagreement about the value.
+const DEFAULT_SORTAT_TOLERANCE_SECS = 5 * 60;
+
+// A freshly (un)published post is mid-flight through the sync pipeline; comparing it
+// would measure propagation lag, not correctness. Same reasoning as the re-emitter's
+// settle belt, and deliberately larger — the audit has no reason to look at the edge.
+const DEFAULT_SETTLE_SECS = 120;
+
+// Doc fields the comparison reads. publishedAt is fetched alongside isPublished
+// because isPublished is an exists_boolean derived FROM publishedAt in the index
+// config: if the boolean is ever absent from a doc payload, publishedAt still carries
+// the same fact, and disagreement between the two would itself be a finding.
+const AUDIT_DOC_FIELDS = ['id', 'isPublished', 'publishedAt', 'sortAt'];
+
+// Cap on mismatch rows written to Axiom per run. The counters carry the rate; the log
+// only has to carry enough ids to start an investigation.
+const MAX_LOGGED_MISMATCHES = 25;
+
+export type AuditStratum = 'scheduled' | 'published_recent';
+export type MismatchKind = 'scheduled_visible' | 'published_missing' | 'sortat_drift';
+
+function parsePositiveInt(raw: string | undefined, fallback: number): number {
+  const n = parseInt(raw ?? '', 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+export type AuditConfig = {
+  sampleSize: number;
+  publishedWindowSecs: number;
+  sortAtToleranceSecs: number;
+  settleSecs: number;
+};
+
+// Env-overridable so sample size and tolerance can be retuned without a redeploy —
+// the same pattern the re-emitter uses for its window.
+export function getAuditConfig(): AuditConfig {
+  return {
+    sampleSize: parsePositiveInt(process.env.BITDEX_AUDIT_SAMPLE_SIZE, DEFAULT_SAMPLE_SIZE),
+    publishedWindowSecs: parsePositiveInt(
+      process.env.BITDEX_AUDIT_PUBLISHED_WINDOW_SECS,
+      DEFAULT_PUBLISHED_WINDOW_SECS
+    ),
+    sortAtToleranceSecs: parsePositiveInt(
+      process.env.BITDEX_AUDIT_SORTAT_TOLERANCE_SECS,
+      DEFAULT_SORTAT_TOLERANCE_SECS
+    ),
+    settleSecs: parsePositiveInt(process.env.BITDEX_AUDIT_SETTLE_SECS, DEFAULT_SETTLE_SECS),
+  };
+}
+
+// One sampled image, carrying PG's answer for everything the comparison checks.
+export type AuditSampleRow = {
+  imageId: number;
+  postId: number;
+  // Post publish time, epoch seconds. Always in the future for the scheduled stratum.
+  publishedAtSecs: number;
+  // What BitDex's sortAt should hold for this image: GREATEST(publishedAt, scannedAt,
+  // createdAt) in epoch seconds — the same expression the index config computes from
+  // publishedAt and existedAt (= max(scannedAt, createdAt)). Computed in PG so the
+  // audit compares against the same GREATEST semantics rather than reimplementing them.
+  expectedSortAtSecs: number;
+};
+
+// Stratum A — the incident class. Images whose parent Post is scheduled to publish in
+// the FUTURE: BitDex must not hold these as published. `ORDER BY random()` over a set
+// this size (~94K images as of 2026-08-06) is cheap and, unlike a fixed ordering,
+// makes repeated runs cover the population instead of re-checking the same head.
+export function buildScheduledSampleQuery({
+  sampleSize,
+  settleSecs,
+}: Pick<AuditConfig, 'sampleSize' | 'settleSecs'>): Prisma.Sql {
+  return Prisma.sql`
+    SELECT
+      i.id AS "imageId",
+      p.id AS "postId",
+      extract(epoch FROM p."publishedAt")::double precision AS "publishedAtSecs",
+      extract(epoch FROM GREATEST(p."publishedAt", i."scannedAt", i."createdAt"))::double precision
+        AS "expectedSortAtSecs"
+    FROM "Post" p
+    JOIN "Image" i ON i."postId" = p.id
+    WHERE p."publishedAt" > now()
+      AND p."updatedAt" < now() - make_interval(secs => ${settleSecs})
+    ORDER BY random()
+    LIMIT ${sampleSize}
+  `;
+}
+
+// Stratum B — the inverse failure. Images whose parent Post published recently: BitDex
+// must hold these as published, with a sortAt that agrees with PG. Catches a dropped
+// publish (content that never became visible), which is the same lost-write class as
+// the incident pointing the other way.
+export function buildPublishedSampleQuery({
+  sampleSize,
+  publishedWindowSecs,
+  settleSecs,
+}: Pick<AuditConfig, 'sampleSize' | 'publishedWindowSecs' | 'settleSecs'>): Prisma.Sql {
+  return Prisma.sql`
+    SELECT
+      i.id AS "imageId",
+      p.id AS "postId",
+      extract(epoch FROM p."publishedAt")::double precision AS "publishedAtSecs",
+      extract(epoch FROM GREATEST(p."publishedAt", i."scannedAt", i."createdAt"))::double precision
+        AS "expectedSortAtSecs"
+    FROM "Post" p
+    JOIN "Image" i ON i."postId" = p.id
+    WHERE p."publishedAt" > now() - make_interval(secs => ${publishedWindowSecs})
+      AND p."publishedAt" <= now()
+      AND p."updatedAt" < now() - make_interval(secs => ${settleSecs})
+    ORDER BY random()
+    LIMIT ${sampleSize}
+  `;
+}
+
+export type BitdexDocState = {
+  // False when BitDex returned no row, or a bare `{ id }` — the batch endpoint's
+  // encoding for "no document on disk for this slot".
+  present: boolean;
+  published: boolean;
+  sortAtSecs: number | null;
+};
+
+// Reads BitDex's answer out of a doc payload. isPublished is the authority when the
+// key is present; publishedAt is the fallback, because the index derives isPublished
+// from it via exists_boolean and the two carry the same fact.
+export function readDocState(doc: BitdexDocument | undefined): BitdexDocState {
+  if (!doc) return { present: false, published: false, sortAtSecs: null };
+
+  const isPublished = doc.isPublished;
+  const publishedAt = doc.publishedAt;
+  const sortAt = doc.sortAt;
+  const present = isPublished !== undefined || publishedAt !== undefined || sortAt !== undefined;
+
+  return {
+    present,
+    published: typeof isPublished === 'boolean' ? isPublished : publishedAt != null,
+    sortAtSecs: typeof sortAt === 'number' ? sortAt : null,
+  };
+}
+
+export type AuditMismatch = {
+  stratum: AuditStratum;
+  kind: MismatchKind;
+  imageId: number;
+  postId: number;
+  expected: string;
+  actual: string;
+};
+
+/**
+ * Pure comparison: PG rows in, BitDex docs in, mismatches out. No IO, so the failure
+ * classification is testable without a database or a BitDex server — which matters
+ * more here than usual, since this logic decides whether an alert fires.
+ */
+export function compareStratum(
+  stratum: AuditStratum,
+  rows: AuditSampleRow[],
+  docs: BitdexDocument[],
+  { sortAtToleranceSecs }: Pick<AuditConfig, 'sortAtToleranceSecs'>
+): AuditMismatch[] {
+  const byId = new Map<number, BitdexDocument>();
+  for (const doc of docs) byId.set(doc.id, doc);
+
+  const mismatches: AuditMismatch[] = [];
+  for (const row of rows) {
+    const state = readDocState(byId.get(row.imageId));
+
+    if (stratum === 'scheduled') {
+      // A doc that is absent, or present and unpublished, is the correct state — a
+      // scheduled post's images are legitimately either not indexed yet or indexed
+      // as unpublished. Only "BitDex says published" is the incident signature.
+      if (state.published) {
+        mismatches.push({
+          stratum,
+          kind: 'scheduled_visible',
+          imageId: row.imageId,
+          postId: row.postId,
+          expected: `unpublished (PG publishedAt=${row.publishedAtSecs} is in the future)`,
+          actual: `isPublished=true, sortAt=${state.sortAtSecs ?? 'null'}`,
+        });
+      }
+      continue;
+    }
+
+    if (!state.present || !state.published) {
+      mismatches.push({
+        stratum,
+        kind: 'published_missing',
+        imageId: row.imageId,
+        postId: row.postId,
+        expected: `published (PG publishedAt=${row.publishedAtSecs})`,
+        actual: state.present ? 'isPublished=false' : 'document absent',
+      });
+      continue;
+    }
+
+    // Only reached for docs BitDex agrees are published, so a drift here is a
+    // disagreement about ordering, not a missing write.
+    const drift =
+      state.sortAtSecs == null ? null : Math.abs(state.sortAtSecs - row.expectedSortAtSecs);
+    if (drift == null || drift > sortAtToleranceSecs) {
+      mismatches.push({
+        stratum,
+        kind: 'sortat_drift',
+        imageId: row.imageId,
+        postId: row.postId,
+        expected: `sortAt~=${row.expectedSortAtSecs} (+/-${sortAtToleranceSecs}s)`,
+        actual: `sortAt=${state.sortAtSecs ?? 'null'}${drift == null ? '' : `, drift=${drift}s`}`,
+      });
+    }
+  }
+
+  return mismatches;
+}
+
+export type AuditScopeResult = {
+  stratum: AuditStratum;
+  checked: number;
+  mismatches: AuditMismatch[];
+};
+
+// Samples one stratum and compares it. A BitDex fetch failure propagates:
+// fetchBitdexDocuments throws rather than returning null precisely so an unreachable
+// index can never be mistaken for a clean audit.
+async function auditStratum(
+  stratum: AuditStratum,
+  query: Prisma.Sql,
+  config: AuditConfig
+): Promise<AuditScopeResult> {
+  // Primary, not the replica: this job's whole output is "PG and BitDex disagree",
+  // and replica lag would manufacture exactly that disagreement. 100 sampled rows
+  // every 10 minutes is nothing against the primary, and it removes a false-positive
+  // source that would be indistinguishable from the real finding in the metric.
+  const rows = await dbWrite.$queryRaw<AuditSampleRow[]>(query);
+  if (!rows.length) return { stratum, checked: 0, mismatches: [] };
+
+  const docs = await fetchBitdexDocuments(
+    BITDEX_INDEX,
+    rows.map((r) => r.imageId),
+    AUDIT_DOC_FIELDS
+  );
+
+  return { stratum, checked: rows.length, mismatches: compareStratum(stratum, rows, docs, config) };
+}
+
+export type AuditResult = {
+  scheduled: AuditScopeResult;
+  publishedRecent: AuditScopeResult;
+};
+
+export async function runAudit(config: AuditConfig): Promise<AuditResult> {
+  const scheduled = await auditStratum(
+    'scheduled',
+    buildScheduledSampleQuery(config),
+    config
+  );
+  const publishedRecent = await auditStratum(
+    'published_recent',
+    buildPublishedSampleQuery(config),
+    config
+  );
+  return { scheduled, publishedRecent };
+}
+
+export const auditBitdexConsistency = createJob(
+  'audit-bitdex-consistency',
+  CADENCE_CRON,
+  async () => {
+    // Default-off: registered and scheduled but no-ops until the flag is flipped on.
+    const enabled = await isFlipt(FLIPT_FEATURE_FLAGS.BITDEX_CONSISTENCY_AUDIT);
+    if (!enabled) return;
+
+    const config = getAuditConfig();
+    const start = Date.now();
+    let result: AuditResult;
+    try {
+      result = await runAudit(config);
+    } catch (e) {
+      bitdexAuditErrorsCounter?.inc();
+      throw e; // createJob logs job-error to Axiom and marks the run failed
+    }
+    const durationSec = (Date.now() - start) / 1000;
+
+    const scopes = [result.scheduled, result.publishedRecent];
+    for (const scope of scopes) {
+      bitdexAuditCheckedCounter?.inc({ stratum: scope.stratum }, scope.checked);
+      for (const mismatch of scope.mismatches)
+        bitdexAuditMismatchCounter?.inc({ stratum: scope.stratum, kind: mismatch.kind }, 1);
+    }
+
+    bitdexAuditRunsCounter?.inc();
+    bitdexAuditRunDurationHistogram?.observe(durationSec);
+
+    const allMismatches = scopes.flatMap((s) => s.mismatches);
+
+    // Logged every run, not only on a finding: a run that checked 0 rows is not the
+    // same as a run that found nothing wrong, and only the log distinguishes them.
+    logToAxiom(
+      {
+        type: 'job',
+        name: 'audit-bitdex-consistency',
+        message: 'audit-complete',
+        scheduledChecked: result.scheduled.checked,
+        scheduledMismatches: result.scheduled.mismatches.length,
+        publishedChecked: result.publishedRecent.checked,
+        publishedMismatches: result.publishedRecent.mismatches.length,
+        // Ids and expected-vs-actual, so a firing alert has a trail to pull on
+        // instead of only a rate.
+        mismatches: allMismatches.slice(0, MAX_LOGGED_MISMATCHES),
+        mismatchesTruncated: Math.max(0, allMismatches.length - MAX_LOGGED_MISMATCHES),
+        durationSec,
+        sampleSize: config.sampleSize,
+        sortAtToleranceSecs: config.sortAtToleranceSecs,
+      },
+      'webhooks'
+    ).catch(() => undefined);
+
+    return {
+      scheduledChecked: result.scheduled.checked,
+      scheduledMismatches: result.scheduled.mismatches.length,
+      publishedChecked: result.publishedRecent.checked,
+      publishedMismatches: result.publishedRecent.mismatches.length,
+      durationSec,
+    };
+  },
+  // Two sampled queries + one batch doc fetch; keep the single-runner lock short.
+  { lockExpiration: 5 * 60 }
+);

--- a/src/server/jobs/reemit-bitdex-ops.ts
+++ b/src/server/jobs/reemit-bitdex-ops.ts
@@ -9,15 +9,22 @@ import {
   reemitPostsScannedCounter,
   reemitRunDurationHistogram,
   reemitRunsCounter,
+  reemitScheduledImagesEmittedCounter,
+  reemitScheduledPostsScannedCounter,
   reemitSkippedRateLimitCounter,
 } from '~/server/prom/client';
 import { createJob, getJobDate } from './job';
 
 // BitDex publish re-emitter: a periodic job that re-asserts the per-image publish
-// values and ingested sortAt for every image whose parent Post was published in the
-// trailing lookback window, by calling the same two shared PG functions the sync
+// values and ingested sortAt by calling the same two shared PG functions the sync
 // triggers use. When BitDex already holds the right values the ops are no-ops; when
 // a write was missed, the re-emit heals it from PG within one window.
+//
+// Two scopes, one run:
+//   1. published window — images whose parent Post published inside the trailing
+//      lookback window (the original scan).
+//   2. scheduled sweep  — images whose parent Post is scheduled to publish in the
+//      FUTURE. Nothing else can heal these; see buildScheduledReemitQuery.
 
 const DEFAULT_LOOKBACK_SECS = 15 * 60;
 const DEFAULT_SETTLE_SECS = 10; // must stay << lookback
@@ -56,7 +63,26 @@ export function getReemitMinIntervalSecs(): number {
   return parsePositiveSecs(process.env.REEMIT_MIN_INTERVAL_SECS, DEFAULT_MIN_INTERVAL_SECS);
 }
 
-export type ReemitResult = { postsScanned: number; imagesEmitted: number };
+// Same reasoning as the min-interval knob: this gates whether the second (scheduled)
+// scan runs at all, it is not a parameter of either emit statement. Default ON —
+// the sweep is the only healer that can reach a future-scheduled post, so it has to
+// be on by default; the env var exists to shed the ~94K-image scan under load.
+export function getScheduledSweepEnabled(): boolean {
+  const raw = process.env.REEMIT_SCHEDULED_SWEEP_ENABLED?.trim().toLowerCase();
+  if (raw === 'false' || raw === '0' || raw === 'off' || raw === 'no') return false;
+  return true;
+}
+
+export type ReemitResult = {
+  postsScanned: number;
+  imagesEmitted: number;
+  scheduledPostsScanned: number;
+  scheduledImagesEmitted: number;
+};
+
+// The counts the two scans return individually, before they are folded into a
+// ReemitResult. Both scans return the same column pair.
+type ScanCounts = { postsScanned: number; imagesEmitted: number };
 
 // This must stay a single data-modifying-CTE statement: the scan, the INSERT, and
 // the count all run under one snapshot, and the BitdexOps id is allocated inside the
@@ -90,15 +116,80 @@ export function buildReemitQuery({ lookbackSecs, settleSecs }: ReemitConfig): Pr
   `;
 }
 
+// Second scan, for posts scheduled to publish in the FUTURE (publishedAt > now()).
+//
+// The published-window scan above can only reach a post whose publishedAt already
+// fell inside a trailing PAST window, so a future-scheduled post whose BitDex state
+// is wrong is unreachable by any healer — that gap is what let the 2026-08-06 leak
+// (posts rescheduled Jul-31 -> Aug-31 whose reschedule ops were lost, then activated
+// by the deferred sweep when the stale Jul-31 date passed) persist for two weeks.
+//
+// Emitting the same two shared functions is correct for this scope precisely because
+// they are shared: bitdex_post_fanout_ops' CASE guard turns a future publishedAt into
+// REMOVE ops, so a correctly-indexed scheduled post gets a no-op reassert and a
+// wrongly-visible one gets pulled back out. There is no future-specific op shape here
+// and there must not be — the shape stays owned by the PG functions.
+//
+// Same single data-modifying-CTE and settle-belt requirements as the scan above; see
+// that comment for why splitting either into a per-row loop reintroduces the ghost
+// re-publish race. No lookback bound: the whole future-scheduled set is the scope
+// (~94K images / ~12K posts as of 2026-08-06), which is why this scan is separately
+// gateable via REEMIT_SCHEDULED_SWEEP_ENABLED.
+export function buildScheduledReemitQuery({
+  settleSecs,
+}: Pick<ReemitConfig, 'settleSecs'>): Prisma.Sql {
+  return Prisma.sql`
+    WITH scanned AS (
+      SELECT
+        p.id AS post_id,
+        i.id AS image_id,
+        bitdex_post_fanout_ops(p) || bitdex_image_sortat_ops(i) AS ops
+      FROM "Post" p
+      JOIN "Image" i ON i."postId" = p.id
+      WHERE p."publishedAt" > now()
+        AND p."updatedAt"  <  now() - make_interval(secs => ${settleSecs})
+    ),
+    ins AS (
+      INSERT INTO "BitdexOps" (entity_id, ops)
+      SELECT image_id, ops FROM scanned
+      RETURNING entity_id
+    )
+    SELECT
+      (SELECT count(*) FROM ins)::int AS "imagesEmitted",
+      (SELECT count(DISTINCT post_id) FROM scanned)::int AS "postsScanned"
+  `;
+}
+
 // bitdex_post_fanout_ops / bitdex_image_sortat_ops are created by the sync-trigger
 // deploy, not this repo. A missing function propagates out of $queryRaw rather than
 // being swallowed, so the run fails loudly instead of silently healing nothing.
+//
+// The two scans are deliberately separate statements rather than one UNIONed scan:
+// each has to stay a single data-modifying CTE, and keeping them apart means the
+// scheduled sweep can be switched off without touching the published-window SQL.
+// They run sequentially — the published window is the latency-sensitive one, so it
+// goes first and is never delayed by the larger scheduled scan.
 export async function runReemit(config: ReemitConfig): Promise<ReemitResult> {
-  const rows = await dbWrite.$queryRaw<ReemitResult[]>(buildReemitQuery(config));
+  const rows = await dbWrite.$queryRaw<ScanCounts[]>(buildReemitQuery(config));
   const row = rows[0];
+
+  let scheduled: ScanCounts = { postsScanned: 0, imagesEmitted: 0 };
+  if (getScheduledSweepEnabled()) {
+    const scheduledRows = await dbWrite.$queryRaw<ScanCounts[]>(
+      buildScheduledReemitQuery({ settleSecs: config.settleSecs })
+    );
+    const scheduledRow = scheduledRows[0];
+    scheduled = {
+      postsScanned: scheduledRow?.postsScanned ?? 0,
+      imagesEmitted: scheduledRow?.imagesEmitted ?? 0,
+    };
+  }
+
   return {
     postsScanned: row?.postsScanned ?? 0,
     imagesEmitted: row?.imagesEmitted ?? 0,
+    scheduledPostsScanned: scheduled.postsScanned,
+    scheduledImagesEmitted: scheduled.imagesEmitted,
   };
 }
 
@@ -129,8 +220,11 @@ export const reemitBitdexOps = createJob(
     const start = Date.now();
     let postsScanned: number;
     let imagesEmitted: number;
+    let scheduledPostsScanned: number;
+    let scheduledImagesEmitted: number;
     try {
-      ({ postsScanned, imagesEmitted } = await runReemit(config));
+      ({ postsScanned, imagesEmitted, scheduledPostsScanned, scheduledImagesEmitted } =
+        await runReemit(config));
     } catch (e) {
       reemitErrorsCounter?.inc();
       throw e; // createJob logs job-error to Axiom and marks the run failed
@@ -142,8 +236,14 @@ export const reemitBitdexOps = createJob(
     await setLastRun();
 
     reemitRunsCounter?.inc();
+    // The scheduled scan gets its own counters rather than being folded into the
+    // published-window ones: its volume is ~100x larger and steady, so summing them
+    // would swamp the published-window emission signal the existing alerts read.
     reemitPostsScannedCounter?.inc(postsScanned);
     reemitImagesEmittedCounter?.inc(imagesEmitted);
+    reemitScheduledPostsScannedCounter?.inc(scheduledPostsScanned);
+    reemitScheduledImagesEmittedCounter?.inc(scheduledImagesEmitted);
+    // Duration covers both scans — it is the guard on the whole emit getting slow.
     reemitRunDurationHistogram?.observe(durationSec);
 
     logToAxiom(
@@ -153,6 +253,9 @@ export const reemitBitdexOps = createJob(
         message: 'reemit-complete',
         postsScanned,
         imagesEmitted,
+        scheduledPostsScanned,
+        scheduledImagesEmitted,
+        scheduledSweepEnabled: getScheduledSweepEnabled(),
         durationSec,
         lookbackSecs: config.lookbackSecs,
         settleSecs: config.settleSecs,
@@ -160,7 +263,13 @@ export const reemitBitdexOps = createJob(
       'webhooks'
     ).catch(() => undefined);
 
-    return { postsScanned, imagesEmitted, durationSec };
+    return {
+      postsScanned,
+      imagesEmitted,
+      scheduledPostsScanned,
+      scheduledImagesEmitted,
+      durationSec,
+    };
   },
   // Cheap statement; keep the single-runner lock short.
   { lockExpiration: 5 * 60 }

--- a/src/server/jobs/reemit-bitdex-ops.ts
+++ b/src/server/jobs/reemit-bitdex-ops.ts
@@ -64,13 +64,21 @@ export function getReemitMinIntervalSecs(): number {
 }
 
 // Same reasoning as the min-interval knob: this gates whether the second (scheduled)
-// scan runs at all, it is not a parameter of either emit statement. Default ON —
-// the sweep is the only healer that can reach a future-scheduled post, so it has to
-// be on by default; the env var exists to shed the ~94K-image scan under load.
+// scan runs at all, it is not a parameter of either emit statement.
+//
+// DEFAULT OFF — DO NOT ENABLE until the BitDex engine ships the
+// remove-with-future-value = reschedule fix (bitdex-v2, targeted v1.1.53).
+// The shared fan-out function emits a future-guarded publishedAt REMOVE, and the
+// current engine treats ANY remove of the deferred source field on a deferred slot
+// as an UNSCHEDULE: the slot leaves the deferred map and activates as a draft,
+// destroying its scheduled Tf activation. On a pod with a healthy deferred map the
+// first sweep pass would unschedule the entire scheduled population (~93K images,
+// 2026-08-07 review finding). Once the engine treats a future-valued remove as a
+// re-arm, this same sweep becomes the standing heal for drained deferred maps —
+// flip the env var on in the deploy AFTER that release is verified in prod.
 export function getScheduledSweepEnabled(): boolean {
   const raw = process.env.REEMIT_SCHEDULED_SWEEP_ENABLED?.trim().toLowerCase();
-  if (raw === 'false' || raw === '0' || raw === 'off' || raw === 'no') return false;
-  return true;
+  return raw === 'true' || raw === '1' || raw === 'on' || raw === 'yes';
 }
 
 // The sweep's own cadence, decoupled from the job's 5-min fire. BitDex suppresses

--- a/src/server/jobs/reemit-bitdex-ops.ts
+++ b/src/server/jobs/reemit-bitdex-ops.ts
@@ -73,6 +73,22 @@ export function getScheduledSweepEnabled(): boolean {
   return true;
 }
 
+// The sweep's own cadence, decoupled from the job's 5-min fire. BitDex suppresses
+// identical sortAt re-sets, but the publish REMOVE ops have no no-op suppression:
+// each of the ~94K rows costs a real bitmap remove + exists_boolean shadow writes +
+// cache invalidation on isPublished/publishedAt — fields nearly every cached feed
+// entry filters on. At 5-min cadence that is standing cache-maintenance churn for
+// a corruption class that needs an ops-loss window to occur at all. Hourly keeps
+// the heal SLA (stale scheduled state visible for at most ~1h) at 1/12th the churn.
+const SCHEDULED_SWEEP_LAST_RUN_KEY = 'reemit-bitdex-ops:scheduled-sweep-last-run';
+const DEFAULT_SCHEDULED_SWEEP_INTERVAL_SECS = 60 * 60;
+export function getScheduledSweepIntervalSecs(): number {
+  return parsePositiveSecs(
+    process.env.REEMIT_SCHEDULED_SWEEP_INTERVAL_SECS,
+    DEFAULT_SCHEDULED_SWEEP_INTERVAL_SECS
+  );
+}
+
 export type ReemitResult = {
   postsScanned: number;
   imagesEmitted: number;
@@ -169,12 +185,18 @@ export function buildScheduledReemitQuery({
 // scheduled sweep can be switched off without touching the published-window SQL.
 // They run sequentially — the published window is the latency-sensitive one, so it
 // goes first and is never delayed by the larger scheduled scan.
-export async function runReemit(config: ReemitConfig): Promise<ReemitResult> {
+export async function runReemit(
+  config: ReemitConfig,
+  // The job passes false when the sweep's own interval hasn't elapsed; the
+  // published-window scan runs regardless. Defaults true so direct callers
+  // (tests, manual heals) get the full behavior.
+  runScheduledSweep = true
+): Promise<ReemitResult> {
   const rows = await dbWrite.$queryRaw<ScanCounts[]>(buildReemitQuery(config));
   const row = rows[0];
 
   let scheduled: ScanCounts = { postsScanned: 0, imagesEmitted: 0 };
-  if (getScheduledSweepEnabled()) {
+  if (runScheduledSweep && getScheduledSweepEnabled()) {
     const scheduledRows = await dbWrite.$queryRaw<ScanCounts[]>(
       buildScheduledReemitQuery({ settleSecs: config.settleSecs })
     );
@@ -216,6 +238,11 @@ export const reemitBitdexOps = createJob(
     // runs_total stays success-only (attempts - runs = the error count).
     reemitAttemptsCounter?.inc();
 
+    // The sweep runs on its own, longer clock (see getScheduledSweepIntervalSecs).
+    const [sweepLastRun, setSweepLastRun] = await getJobDate(SCHEDULED_SWEEP_LAST_RUN_KEY);
+    const sweepDue =
+      (Date.now() - sweepLastRun.getTime()) / 1000 >= getScheduledSweepIntervalSecs();
+
     const config = getReemitConfig();
     const start = Date.now();
     let postsScanned: number;
@@ -224,7 +251,7 @@ export const reemitBitdexOps = createJob(
     let scheduledImagesEmitted: number;
     try {
       ({ postsScanned, imagesEmitted, scheduledPostsScanned, scheduledImagesEmitted } =
-        await runReemit(config));
+        await runReemit(config, sweepDue));
     } catch (e) {
       reemitErrorsCounter?.inc();
       throw e; // createJob logs job-error to Axiom and marks the run failed
@@ -234,6 +261,9 @@ export const reemitBitdexOps = createJob(
     // Only a successful emit advances the rate-limit window: a failed run leaves
     // lastRun untouched so the next fire can retry immediately instead of waiting.
     await setLastRun();
+    // Same success-only rule for the sweep clock. scheduledPostsScanned stays 0 when
+    // the sweep was skipped (due or not), so only an actually-executed sweep counts.
+    if (sweepDue && getScheduledSweepEnabled()) await setSweepLastRun();
 
     reemitRunsCounter?.inc();
     // The scheduled scan gets its own counters rather than being folded into the


### PR DESCRIPTION
## What

Two mechanisms from tonight's scheduled-publish incident (unpublished/old images at feed tops — reschedule ops lost in July heal windows, activated by the deferred sweep when the stale date passed):

1. **`audit-bitdex-consistency` job** (NEW, read-only, Flipt `bitdex-consistency-audit`, default-off): every 10 min samples 50 images from future-scheduled posts + 50 from posts published in the last 24h (PRIMARY db — replica lag would manufacture exactly the disagreement this reports), batch-fetches their BitDex docs, classifies `scheduled_visible | published_missing | sortat_drift` (5-min tolerance) into `bitdex_audit_*` counters + Axiom detail logs. A BitDex fetch failure errors the run — a silent pass is the one outcome an audit must never produce. This catches the incident class the internal canary structurally cannot see (BitDex internally consistent about wrong data).

2. **Scheduled-post sweep in the re-emitter** — re-asserts publish state for ALL future-scheduled posts' images (the population no existing healer can reach). **Shipped DEFAULT OFF**: adversarial review found the engine currently treats the fan-out's future-guarded publishedAt REMOVE on a deferred slot as an *unschedule* (slot leaves the deferred map, activates as draft) — on a healthy deferred map the first pass would unschedule ~93K correctly-scheduled images. Gated behind `REEMIT_SCHEDULED_SWEEP_ENABLED=true` + its own hourly clock; enable only after bitdex-v2 ships remove-with-future-value = reschedule (v1.1.53).

## Review

Adversarially reviewed (independent agent): BLOCK verdict on the sweep-on-by-default version → resolved by the default-off gate; audit half cleared. Notable verified facts: `Post_publishedAt_idx` covers the scan; BitdexOps self-purges via the cursor cleanup trigger; ops ordering is total by outbox id (LIFO last-wins per field); `require_admin` waives no-XFF traffic (bearer sent only when `BITDEX_ADMIN_TOKEN` set).

## Tests

`npx vitest run` on both suites: **60 passed, 0 failed**. Repo-wide typecheck clean.

## Deploy notes

- Audit needs a scheduler entry (jobs refresh) + the Flipt flag `bitdex-consistency-audit` created; flag stays off until both land.
- `BITDEX_ADMIN_TOKEN` env only needed if BITDEX_URL routes through an XFF-adding proxy.
- Do NOT set `REEMIT_SCHEDULED_SWEEP_ENABLED` until the engine fix is verified in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)