### PR TITLE
feat(feed): let users hide daily-challenge entries

### DIFF
--- a/src/components/Image/Filters/MediaFiltersDropdown.tsx
+++ b/src/components/Image/Filters/MediaFiltersDropdown.tsx
@@ -59,6 +59,7 @@ export function MediaFiltersDropdown({
   // toggle would be a no-op for them. Only logged-in users actually have
   // PG-13 access to opt in/out of.
   const showPG13Toggle = isGreen && !!currentUser;
+  const showChallengeToggle = filterType !== 'modelImages';
 
   const { filters, setFilters } = useFiltersContext((state) => ({
     filters: state[filterType],
@@ -99,6 +100,7 @@ export function MediaFiltersDropdown({
       baseModels: undefined,
       remixesOnly: undefined,
       nonRemixesOnly: undefined,
+      hideChallenges: undefined,
       disablePoi: undefined,
       disableMinor: undefined,
       poiOnly: undefined,
@@ -123,12 +125,21 @@ export function MediaFiltersDropdown({
       });
   }, [onChange, setFilters, filterType]);
 
-  const { opened, toggle, close, mergedFilters, isDirty, patchPending, apply, reset, clearAndClose } =
-    useStagedFilters({
-      committed: committedFilters,
-      onApply: handleApply,
-      onClear: handleClear,
-    });
+  const {
+    opened,
+    toggle,
+    close,
+    mergedFilters,
+    isDirty,
+    patchPending,
+    apply,
+    reset,
+    clearAndClose,
+  } = useStagedFilters({
+    committed: committedFilters,
+    onApply: handleApply,
+    onClear: handleClear,
+  });
 
   // maybe have individual filter length with labels next to them
 
@@ -147,6 +158,7 @@ export function MediaFiltersDropdown({
     (mergedFilters.period && mergedFilters.period !== MetricTimeframe.AllTime ? 1 : 0) +
     (!hideBaseModels ? mergedFilters.baseModels?.length ?? 0 : 0) +
     (!!mergedFilters.remixesOnly || !!mergedFilters.nonRemixesOnly ? 1 : 0) +
+    (showChallengeToggle && mergedFilters.hideChallenges ? 1 : 0) +
     (mergedFilters.poiOnly ? 1 : 0) +
     (mergedFilters.minorOnly ? 1 : 0) +
     (isModerator && mergedFilters.disablePoi ? 1 : 0) +
@@ -166,12 +178,7 @@ export function MediaFiltersDropdown({
       disabled={!filterLength}
       inline
     >
-      <FilterButton
-        {...buttonProps}
-        icon={IconFilter}
-        onClick={toggle}
-        active={opened}
-      >
+      <FilterButton {...buttonProps} icon={IconFilter} onClick={toggle} active={opened}>
         Filters
       </FilterButton>
     </Indicator>
@@ -275,6 +282,16 @@ export function MediaFiltersDropdown({
           >
             <span>Remixes Only</span>
           </FilterChip>
+          {showChallengeToggle && (
+            <FilterChip
+              checked={mergedFilters.hideChallenges}
+              onChange={(checked) => handleChange({ hideChallenges: checked })}
+            >
+              <Tooltip label="Hide entries submitted to daily challenges">
+                <span>Hide challenge entries</span>
+              </Tooltip>
+            </FilterChip>
+          )}
         </div>
 
         {filterType === 'modelImages' && (

--- a/src/components/Image/image.utils.ts
+++ b/src/components/Image/image.utils.ts
@@ -98,6 +98,7 @@ export const imagesQueryParamSchema = z
     disableMinor: booleanString(),
     remixesOnly: booleanString(),
     nonRemixesOnly: booleanString(),
+    hideChallenges: booleanString(),
   })
   .partial();
 

--- a/src/providers/FiltersProvider.tsx
+++ b/src/providers/FiltersProvider.tsx
@@ -90,6 +90,7 @@ const imageFilterSchema = z.object({
   remixesOnly: z.boolean().optional(),
   nonRemixesOnly: z.boolean().optional(),
   requiringMeta: z.boolean().optional(),
+  hideChallenges: z.boolean().optional(),
   poiOnly: z.boolean().optional(),
   minorOnly: z.boolean().optional(),
   disablePoi: z.boolean().optional(),

--- a/src/server/games/daily-challenge/challenge-helpers.ts
+++ b/src/server/games/daily-challenge/challenge-helpers.ts
@@ -296,7 +296,9 @@ export async function getEndedActiveChallengesFromDb(): Promise<ChallengeDetails
  * Returns challenges whose endsAt is within the last windowHours hours, ordered by endsAt ASC
  * (id tiebreak), bounded to CHALLENGE_JOB_BATCH_SIZE per run.
  */
-export async function getChallengesToReconcileFromDb(windowHours = 48): Promise<ChallengeDetails[]> {
+export async function getChallengesToReconcileFromDb(
+  windowHours = 48
+): Promise<ChallengeDetails[]> {
   const rows = await dbRead.$queryRaw<{ id: number }[]>`
     SELECT c.id
     FROM "Challenge" c
@@ -456,7 +458,13 @@ export async function createChallengeCollection(input: {
   const { resolveChallengeCollectionOwnerId } = await import(
     '~/server/games/daily-challenge/challenge-collection-owner'
   );
-  const userId = await resolveChallengeCollectionOwnerId(input.judgeId);
+  const { getChallengeConfig } = await import(
+    '~/server/games/daily-challenge/daily-challenge.utils'
+  );
+  const [userId, config] = await Promise.all([
+    resolveChallengeCollectionOwnerId(input.judgeId),
+    getChallengeConfig(),
+  ]);
 
   const collection = await dbWrite.collection.create({
     data: {
@@ -468,6 +476,7 @@ export async function createChallengeCollection(input: {
         maxItemsPerUser: input.maxEntriesPerUser,
         submissionStartDate: input.startsAt,
         submissionEndDate: input.endsAt,
+        autoTagId: config.challengeTagId,
         forcedBrowsingLevel: input.allowedNsfwLevel ?? sfwBrowsingLevelsFlag, // Enforce NSFW restrictions
       },
     },

--- a/src/server/games/daily-challenge/challenge-helpers.ts
+++ b/src/server/games/daily-challenge/challenge-helpers.ts
@@ -296,9 +296,7 @@ export async function getEndedActiveChallengesFromDb(): Promise<ChallengeDetails
  * Returns challenges whose endsAt is within the last windowHours hours, ordered by endsAt ASC
  * (id tiebreak), bounded to CHALLENGE_JOB_BATCH_SIZE per run.
  */
-export async function getChallengesToReconcileFromDb(
-  windowHours = 48
-): Promise<ChallengeDetails[]> {
+export async function getChallengesToReconcileFromDb(windowHours = 48): Promise<ChallengeDetails[]> {
   const rows = await dbRead.$queryRaw<{ id: number }[]>`
     SELECT c.id
     FROM "Challenge" c
@@ -458,13 +456,7 @@ export async function createChallengeCollection(input: {
   const { resolveChallengeCollectionOwnerId } = await import(
     '~/server/games/daily-challenge/challenge-collection-owner'
   );
-  const { getChallengeConfig } = await import(
-    '~/server/games/daily-challenge/daily-challenge.utils'
-  );
-  const [userId, config] = await Promise.all([
-    resolveChallengeCollectionOwnerId(input.judgeId),
-    getChallengeConfig(),
-  ]);
+  const userId = await resolveChallengeCollectionOwnerId(input.judgeId);
 
   const collection = await dbWrite.collection.create({
     data: {
@@ -476,7 +468,6 @@ export async function createChallengeCollection(input: {
         maxItemsPerUser: input.maxEntriesPerUser,
         submissionStartDate: input.startsAt,
         submissionEndDate: input.endsAt,
-        autoTagId: config.challengeTagId,
         forcedBrowsingLevel: input.allowedNsfwLevel ?? sfwBrowsingLevelsFlag, // Enforce NSFW restrictions
       },
     },

--- a/src/server/games/daily-challenge/daily-challenge.utils.ts
+++ b/src/server/games/daily-challenge/daily-challenge.utils.ts
@@ -44,6 +44,7 @@ const challengeConfigSchema = z.object({
   challengeType: z.string(),
   challengeCollectionId: z.number(),
   judgedTagId: z.number(),
+  challengeTagId: z.number(),
   reviewMeTagId: z.number(),
   userCooldown: z.string(),
   resourceCooldown: z.string(),
@@ -76,6 +77,7 @@ export const dailyChallengeConfig: ChallengeConfig = {
   challengeType: 'world-morph',
   challengeCollectionId: 6236625,
   judgedTagId: 299729,
+  challengeTagId: 676575, // collection:daily-challenge — applied to every entry via Collection.metadata.autoTagId.
   reviewMeTagId: 301770,
   userCooldown: '14 day',
   resourceCooldown: '90 day',

--- a/src/server/games/daily-challenge/daily-challenge.utils.ts
+++ b/src/server/games/daily-challenge/daily-challenge.utils.ts
@@ -77,7 +77,9 @@ export const dailyChallengeConfig: ChallengeConfig = {
   challengeType: 'world-morph',
   challengeCollectionId: 6236625,
   judgedTagId: 299729,
-  challengeTagId: 676575, // collection:daily-challenge — applied to every entry via Collection.metadata.autoTagId.
+  // collection:daily-challenge — set as the daily collection's autoTagId so entries are tagged on
+  // submission. Daily only: mod- and user-created challenges deliberately go untagged.
+  challengeTagId: 676575,
   reviewMeTagId: 301770,
   userCooldown: '14 day',
   resourceCooldown: '90 day',

--- a/src/server/jobs/__tests__/daily-challenge-auto-tag.test.ts
+++ b/src/server/jobs/__tests__/daily-challenge-auto-tag.test.ts
@@ -75,7 +75,10 @@ vi.mock('~/server/games/daily-challenge/daily-challenge.utils', async (importOri
 import { createChallengesBatch } from '../daily-challenge-processing';
 import { dailyChallengeConfig } from '~/server/games/daily-challenge/daily-challenge.utils';
 
-const CHALLENGE_TAG_ID = dailyChallengeConfig.challengeTagId;
+// The literal, not `dailyChallengeConfig.challengeTagId`. Reading the id from config makes the
+// assertion below `undefined === undefined` on a tree where the field doesn't exist yet — it would
+// pass against the exact code it exists to reject.
+const CHALLENGE_TAG_ID = 676575;
 
 // Routes each dbRead.$queryRaw by a fragment unique to that query.
 function routeQuery(strings: TemplateStringsArray | string[]) {
@@ -120,6 +123,10 @@ describe('daily challenge creation applies the challenge auto-tag', () => {
     mockCollectionCreate.mockResolvedValue({ id: 4242 });
     mockCreateChallengeRecord.mockResolvedValue(31337);
     mockGetChallengeConfig.mockResolvedValue(configWithJudge());
+  });
+
+  it('carries the challenge tag id in the daily config', () => {
+    expect(dailyChallengeConfig.challengeTagId).toBe(CHALLENGE_TAG_ID);
   });
 
   it('sets metadata.autoTagId to the configured challenge tag id', async () => {

--- a/src/server/jobs/__tests__/daily-challenge-auto-tag.test.ts
+++ b/src/server/jobs/__tests__/daily-challenge-auto-tag.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type * as GenerativeContent from '~/server/games/daily-challenge/generative-content';
+import type * as ChallengeHelpers from '~/server/games/daily-challenge/challenge-helpers';
+import type * as DailyChallengeUtils from '~/server/games/daily-challenge/daily-challenge.utils';
+
+// The daily job must set `metadata.autoTagId` on the collection it creates — that field is the
+// entire mechanism by which challenge entries get tagged (applyCollectionAutoTag reads it on
+// submission), and the "hide challenge entries" feed filter is worthless without it.
+//
+// This drives the real `createChallengesBatch` down to the `dbWrite.collection.create` call rather
+// than asserting on source text, so it pins the tag to the code path that actually runs. Tagging
+// added to a helper the job never calls would leave this red.
+//
+// `dbRead.$queryRaw` is routed by SQL shape, not call order, so reordering or adding an unrelated
+// query upstream doesn't silently mis-feed the test.
+
+const {
+  mockDbReadQueryRaw,
+  mockDbWriteQueryRawUnsafe,
+  mockDbWriteExecuteRaw,
+  mockDbWriteExecuteRawUnsafe,
+  mockCollectionCreate,
+  mockGetChallengeConfig,
+  mockCreateChallengeRecord,
+  mockGenerateCollectionDetails,
+  mockGenerateArticle,
+} = vi.hoisted(() => ({
+  mockDbReadQueryRaw: vi.fn(),
+  mockDbWriteQueryRawUnsafe: vi.fn().mockResolvedValue([{ id: 1000 }]),
+  mockDbWriteExecuteRaw: vi.fn().mockResolvedValue(1),
+  mockDbWriteExecuteRawUnsafe: vi.fn().mockResolvedValue(1),
+  mockCollectionCreate: vi.fn().mockResolvedValue({ id: 4242 }),
+  mockGetChallengeConfig: vi.fn(),
+  mockCreateChallengeRecord: vi.fn().mockResolvedValue(31337),
+  mockGenerateCollectionDetails: vi.fn().mockResolvedValue({ name: 'Challenge collection' }),
+  mockGenerateArticle: vi.fn().mockResolvedValue({
+    title: 'A challenge',
+    content: 'body',
+    theme: 'theme',
+    invitation: 'invitation',
+    themeElements: ['a'],
+  }),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { $queryRaw: mockDbReadQueryRaw },
+  dbWrite: {
+    $queryRawUnsafe: mockDbWriteQueryRawUnsafe,
+    $executeRaw: mockDbWriteExecuteRaw,
+    $executeRawUnsafe: mockDbWriteExecuteRawUnsafe,
+    collection: { create: mockCollectionCreate },
+  },
+}));
+
+// Imported at module scope but not reached by the creation path; cuts its
+// clickhouse/redis/discord chain.
+vi.mock('~/server/events', () => ({ eventEngine: {} }));
+
+vi.mock('~/server/games/daily-challenge/generative-content', async (importOriginal) => ({
+  ...(await importOriginal<typeof GenerativeContent>()),
+  generateCollectionDetails: mockGenerateCollectionDetails,
+  generateArticle: mockGenerateArticle,
+}));
+
+vi.mock('~/server/games/daily-challenge/challenge-helpers', async (importOriginal) => ({
+  ...(await importOriginal<typeof ChallengeHelpers>()),
+  createChallengeRecord: mockCreateChallengeRecord,
+}));
+
+vi.mock('~/server/games/daily-challenge/daily-challenge.utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof DailyChallengeUtils>()),
+  getChallengeConfig: mockGetChallengeConfig,
+}));
+
+import { createChallengesBatch } from '../daily-challenge-processing';
+import { dailyChallengeConfig } from '~/server/games/daily-challenge/daily-challenge.utils';
+
+const CHALLENGE_TAG_ID = dailyChallengeConfig.challengeTagId;
+
+// Routes each dbRead.$queryRaw by a fragment unique to that query.
+function routeQuery(strings: TemplateStringsArray | string[]) {
+  const sql = Array.isArray(strings) ? strings.join(' ') : String(strings);
+  if (sql.includes('DISTINCT m."userId"')) return [{ userId: 11 }]; // source-collection creators
+  if (sql.includes('resourceUserId')) return []; // users on cooldown
+  if (sql.includes('unnest')) return []; // resources on cooldown
+  if (sql.includes('DATE_TRUNC')) return []; // no challenge exists for the date yet
+  if (sql.includes('DISTINCT(ci."modelId")')) return [{ id: 555 }];
+  if (sql.includes('as creator')) return [{ modelId: 555, creator: 'someone', title: 'A model' }];
+  if (sql.includes('FROM "ModelVersion" mv')) return [{ id: 777 }];
+  if (sql.includes('JOIN "Post" p')) return [{ id: 999, url: 'cover-url' }]; // cover image
+  throw new Error(`Unrouted dbRead.$queryRaw in test: ${sql.slice(0, 120)}`);
+}
+
+// preComputeContext throws unless defaultJudge is populated.
+const configWithJudge = (overrides: Record<string, unknown> = {}) => ({
+  ...dailyChallengeConfig,
+  defaultJudge: {
+    judgeId: 1,
+    userId: 5,
+    sourceCollectionId: 123,
+    prompts: {
+      systemMessage: '',
+      collection: '',
+      article: '',
+      content: '',
+      review: '',
+      winner: '',
+    },
+    reviewTemplate: null,
+  },
+  ...overrides,
+});
+
+describe('daily challenge creation applies the challenge auto-tag', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDbReadQueryRaw.mockImplementation((strings: TemplateStringsArray) =>
+      Promise.resolve(routeQuery(strings))
+    );
+    mockCollectionCreate.mockResolvedValue({ id: 4242 });
+    mockCreateChallengeRecord.mockResolvedValue(31337);
+    mockGetChallengeConfig.mockResolvedValue(configWithJudge());
+  });
+
+  it('sets metadata.autoTagId to the configured challenge tag id', async () => {
+    const result = await createChallengesBatch([new Date('2026-09-01T00:00:00Z')]);
+
+    // createChallengesBatch swallows per-challenge errors into `failed`, so a green assertion
+    // below would be meaningless without confirming the creation actually completed.
+    expect(result).toMatchObject({ created: 1, failed: 0 });
+
+    expect(mockCollectionCreate).toHaveBeenCalledTimes(1);
+    const metadata = mockCollectionCreate.mock.calls[0][0].data.metadata;
+    expect(metadata.autoTagId).toBe(CHALLENGE_TAG_ID);
+  });
+
+  it('takes the tag id from config rather than a hardcoded literal', async () => {
+    mockGetChallengeConfig.mockResolvedValue(configWithJudge({ challengeTagId: 999001 }));
+
+    const result = await createChallengesBatch([new Date('2026-09-01T00:00:00Z')]);
+    expect(result).toMatchObject({ created: 1, failed: 0 });
+
+    const metadata = mockCollectionCreate.mock.calls[0][0].data.metadata;
+    expect(metadata.autoTagId).toBe(999001);
+  });
+});

--- a/src/server/jobs/daily-challenge-processing.ts
+++ b/src/server/jobs/daily-challenge-processing.ts
@@ -339,6 +339,7 @@ async function createChallengeFromSelection(
         challengeDate,
         maxItemsPerUser: config.entryPrizeRequirement * 2,
         endsAt,
+        autoTagId: config.challengeTagId,
         disableTagRequired: true,
         disableFollowOnSubmission: true,
       },
@@ -588,7 +589,8 @@ export async function reviewEntries() {
       logToAxiom({
         type: 'warning',
         name: 'daily-challenge-process-entries',
-        message: 'Active challenge count hit the batch ceiling; excess challenges roll to the next tick',
+        message:
+          'Active challenge count hit the batch ceiling; excess challenges roll to the next tick',
         count: activeChallenges.length,
       });
     }
@@ -1581,7 +1583,8 @@ export async function pickWinnersForChallenge(
         await logToAxiom({
           type: 'info',
           name: 'challenge-partial-winner-residual',
-          message: 'User challenge completed with fewer winners than prize places; buzz not paid out',
+          message:
+            'User challenge completed with fewer winners than prize places; buzz not paid out',
           challengeId: currentChallenge.challengeId,
           residualBuzz,
           winnersCount: winningEntries.length,

--- a/src/server/schema/image.schema.ts
+++ b/src/server/schema/image.schema.ts
@@ -353,6 +353,9 @@ export const getInfiniteImagesSchema = baseQuerySchema
     // board id is resolved server-side from this flag plus the request domain —
     // the client never supplies a user list.
     newCreators: z.boolean().optional(),
+    // Hide daily-challenge entries. The server resolves this to the challenge
+    // tag id and unions it into `excludedTagIds` — the client never sends tag ids.
+    hideChallenges: z.boolean().optional(),
     // view: z.enum(['categories', 'feed']),
     withMeta: z.boolean().default(false),
     requiringMeta: z.boolean().optional(),

--- a/src/server/services/__tests__/image-hide-challenges-exclusion.test.ts
+++ b/src/server/services/__tests__/image-hide-challenges-exclusion.test.ts
@@ -65,7 +65,10 @@ vi.mock('~/server/services/blocked-browsing-tags.service', () => ({
 import { getAllImages, getAllImagesIndex } from '../image.service';
 import { dailyChallengeConfig } from '~/server/games/daily-challenge/daily-challenge.utils';
 
-const CHALLENGE_TAG_ID = dailyChallengeConfig.challengeTagId;
+// The literal, not `dailyChallengeConfig.challengeTagId`. Reading the id from config makes the
+// exclusion assertions compare against `undefined` on a tree where the field doesn't exist, which
+// passes for the wrong reason. The config is tied to this literal by its own test below.
+const CHALLENGE_TAG_ID = 676575;
 
 type FeedInput = Record<string, unknown>;
 
@@ -92,8 +95,8 @@ describe('hideChallenges → excludedTagIds', () => {
     vi.clearAllMocks();
   });
 
-  it('is a real tag id, not a placeholder', () => {
-    expect(CHALLENGE_TAG_ID).toBe(676575);
+  it('maps to the tag id the daily config assigns to challenge collections', () => {
+    expect(dailyChallengeConfig.challengeTagId).toBe(CHALLENGE_TAG_ID);
   });
 
   describe.each(entryPoints)('%s', (_name, run) => {
@@ -101,7 +104,9 @@ describe('hideChallenges → excludedTagIds', () => {
       const input = { ...baseInput(), hideChallenges: true };
       await run(input);
 
-      expect(input.excludedTagIds).toContain(CHALLENGE_TAG_ID);
+      // `?? []` so an unmapped flag fails as "[] does not contain 676575" rather than as an
+      // invalid-argument error about `undefined`.
+      expect(input.excludedTagIds ?? []).toContain(CHALLENGE_TAG_ID);
     });
 
     it('unions with caller-supplied excludedTagIds rather than replacing them', async () => {

--- a/src/server/services/__tests__/image-hide-challenges-exclusion.test.ts
+++ b/src/server/services/__tests__/image-hide-challenges-exclusion.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type * as PromClient from '~/server/prom/client';
+
+// `hideChallenges` is a boolean the client sends; the SERVER owns the tag id and unions it into
+// `excludedTagIds`, which every image query path already filters on. These tests pin that mapping
+// at both service entry points, because that is the only place it happens — a path that stopped
+// going through getAllImages / getAllImagesIndex would silently serve an unfiltered feed.
+//
+// Both entry points mutate `input` in place (mirroring enforceBlockedBrowsingTags), so the
+// assertions read the input object after the call. The calls are expected to reject once they
+// reach real infra; the mapping runs before that, which is exactly what makes this cheap to test.
+//
+// Mock recipe follows getAllImages-prioritized-guards.test.ts: stub env + infra clients + the
+// event-engine-common submodule so importing image.service boots no real infra.
+
+vi.mock('~/server/prom/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof PromClient>();
+  return { ...actual, registerCounter: () => ({ inc: vi.fn() }) };
+});
+
+vi.mock('../../../../event-engine-common/services/metrics', () => ({
+  MetricService: class {
+    fetch = vi.fn();
+  },
+}));
+vi.mock('../../../../event-engine-common/feeds', () => ({ ImagesFeed: class {} }));
+vi.mock('../../../../event-engine-common/services/cache', () => ({ CacheService: class {} }));
+
+vi.mock('~/env/server', () => ({
+  env: new Proxy({ LOGGING: [] as string[] } as Record<string, unknown>, {
+    get: (target, prop) => {
+      if (prop in target) return target[prop as string];
+      if (typeof prop === 'string' && (prop.endsWith('_URL') || prop.endsWith('_ENDPOINT')))
+        return 'https://test:test@localhost:5432/test';
+      if (
+        typeof prop === 'string' &&
+        /(_CONCURRENCY|_LIMIT|_MS|_PORT|_TIMEOUT|_MAX|_SIZE|_COUNT)$/.test(prop)
+      )
+        return 1;
+      return undefined;
+    },
+  }),
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/redis/client', () => {
+  type KeyProxy = (() => string) & { [key: string]: KeyProxy };
+  const make = (): KeyProxy => new Proxy((() => 'k') as KeyProxy, { get: () => make() });
+  const keyProxy = make();
+  return {
+    redis: { packed: { get: vi.fn(), set: vi.fn() } },
+    sysRedis: {},
+    REDIS_KEYS: keyProxy,
+    REDIS_SYS_KEYS: keyProxy,
+  };
+});
+
+// The mapping sits directly after this call in both entry points — a non-empty result lets
+// execution reach it.
+vi.mock('~/server/services/blocked-browsing-tags.service', () => ({
+  enforceBlockedBrowsingTags: vi.fn().mockResolvedValue({ emptyResult: false }),
+}));
+
+import { getAllImages, getAllImagesIndex } from '../image.service';
+import { dailyChallengeConfig } from '~/server/games/daily-challenge/daily-challenge.utils';
+
+const CHALLENGE_TAG_ID = dailyChallengeConfig.challengeTagId;
+
+type FeedInput = Record<string, unknown>;
+
+// Both entry points reject once they reach real infra; the mapping has already run by then.
+const entryPoints: [string, (input: FeedInput) => Promise<unknown>][] = [
+  [
+    'getAllImages',
+    (input) =>
+      getAllImages(input as unknown as Parameters<typeof getAllImages>[0]).catch(() => undefined),
+  ],
+  [
+    'getAllImagesIndex',
+    (input) =>
+      getAllImagesIndex(input as unknown as Parameters<typeof getAllImagesIndex>[0]).catch(
+        () => undefined
+      ),
+  ],
+];
+
+const baseInput = (): FeedInput => ({ browsingLevel: 1, include: [] });
+
+describe('hideChallenges → excludedTagIds', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('is a real tag id, not a placeholder', () => {
+    expect(CHALLENGE_TAG_ID).toBe(676575);
+  });
+
+  describe.each(entryPoints)('%s', (_name, run) => {
+    it('adds the challenge tag id when hideChallenges is true', async () => {
+      const input = { ...baseInput(), hideChallenges: true };
+      await run(input);
+
+      expect(input.excludedTagIds).toContain(CHALLENGE_TAG_ID);
+    });
+
+    it('unions with caller-supplied excludedTagIds rather than replacing them', async () => {
+      const input = { ...baseInput(), hideChallenges: true, excludedTagIds: [42] };
+      await run(input);
+
+      expect(input.excludedTagIds).toEqual(expect.arrayContaining([42, CHALLENGE_TAG_ID]));
+    });
+
+    it('does not add the tag id when hideChallenges is absent', async () => {
+      const input = { ...baseInput(), excludedTagIds: [42] };
+      await run(input);
+
+      expect(input.excludedTagIds).not.toContain(CHALLENGE_TAG_ID);
+    });
+
+    it('does not add the tag id when hideChallenges is false', async () => {
+      const input = { ...baseInput(), hideChallenges: false, excludedTagIds: [42] };
+      await run(input);
+
+      expect(input.excludedTagIds).not.toContain(CHALLENGE_TAG_ID);
+    });
+  });
+});

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -37,6 +37,7 @@ import {
 import { datapacketDbRead } from '~/server/db/datapacketDb';
 import { pgDbRead, pgDbWrite } from '~/server/db/pgDb';
 import {
+  dailyChallengeConfig,
   parseJudgeScore,
   type JudgeScore,
 } from '~/server/games/daily-challenge/daily-challenge.utils';
@@ -1384,6 +1385,23 @@ const imageMetricsClickhouseTimeoutCounter = registerCounter({
   help: 'getImageMetricsObject ClickHouse read exceeded the soft-fallback timeout (served empty metrics)',
 });
 
+/**
+ * Resolve the `hideChallenges` flag into an `excludedTagIds` entry, in place.
+ * Mirrors `enforceBlockedBrowsingTags`: the client sends intent, the server owns
+ * the tag id, and every query path picks it up from `excludedTagIds` unchanged.
+ * Reads the static config rather than `getChallengeConfig()` so the feed doesn't
+ * take a sysRedis round-trip per request.
+ */
+function applyHideChallengesExclusion(input: {
+  hideChallenges?: boolean;
+  excludedTagIds?: number[];
+}) {
+  if (!input.hideChallenges) return;
+  input.excludedTagIds = [
+    ...new Set([...(input.excludedTagIds ?? []), dailyChallengeConfig.challengeTagId]),
+  ];
+}
+
 export const getAllImages = async (
   input: GetAllImagesInput & {
     userId?: number;
@@ -1395,6 +1413,7 @@ export const getAllImages = async (
     isModerator: input.user?.isModerator,
   });
   if (blockedEnforcement.emptyResult) return { nextCursor: undefined, items: [] };
+  applyHideChallengesExclusion(input);
 
   const {
     limit,
@@ -2414,6 +2433,7 @@ export const getAllImagesIndex = async (
     isModerator: user?.isModerator,
   });
   if (blockedEnforcement.emptyResult) return { nextCursor: undefined, items: [] };
+  applyHideChallengesExclusion(input);
 
   // - cursor uses "offset|entryTimestamp" like "500|1724677401898"
   const cursorParsed = input.cursor?.toString().split('|');

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -3067,6 +3067,10 @@ export async function getImagesFromSearch(input: ImageSearchInput) {
   return { ...result, source: 'meili' as const };
 }
 
+// No applyHideChallengesExclusion here: `hideChallenges` cannot reach this function. Its only
+// upstreams are /api/v1/images and /api/v1/blocks/images, whose zod objects declare neither
+// `hideChallenges` nor `excludedTagIds` and strip unknown keys. Adding either key to those
+// schemas would hand the REST API an unfiltered feed — apply the exclusion here first.
 export async function getImagesFromFeedSearch(
   input: ImageSearchInput
 ): Promise<GetAllImagesIndexResult> {

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -3070,7 +3070,10 @@ export async function getImagesFromSearch(input: ImageSearchInput) {
 // No applyHideChallengesExclusion here: `hideChallenges` cannot reach this function. Its only
 // upstreams are /api/v1/images and /api/v1/blocks/images, whose zod objects declare neither
 // `hideChallenges` nor `excludedTagIds` and strip unknown keys. Adding either key to those
-// schemas would hand the REST API an unfiltered feed — apply the exclusion here first.
+// schemas would hand the REST API an unfiltered feed — apply the exclusion here first. Note
+// image-search.service.ts spreads the same `data` into all three branches
+// (getAllImages / getAllImagesIndex / here), so the result wouldn't be uniformly unfiltered:
+// two branches would filter and this one wouldn't, which reads as a caching bug, not a gap.
 export async function getImagesFromFeedSearch(
   input: ImageSearchInput
 ): Promise<GetAllImagesIndexResult> {


### PR DESCRIPTION
## Why

Daily-challenge entries are roughly **27% of the images feed when sorted by Newest**. For anyone who isn't following the challenges, that's a quarter of the feed they didn't ask for and can't currently turn off. This adds an opt-in filter, and makes sure future daily challenges stay taggable so the filter keeps working.

## What

**Tagging (so new daily challenges keep working).** Entries get tag `676575` (`collection:daily-challenge`, System, unlisted) via the already-shipped `Collection.metadata.autoTagId` mechanism (`applyCollectionAutoTag`). Existing challenge collections were backfilled in the DB, but every new challenge creates a new collection — so the daily-challenge job now sets `autoTagId` on the collection it creates. The id lives once in the daily-challenge config as `challengeTagId`, alongside `judgedTagId`.

**Scope is daily-only, deliberately.** Mod-created challenges (`upsertChallenge`) and user-created challenges (`upsertUserChallenge`) build their own collections in `challenge.service.ts` and are left untagged, so the toggle hides daily entries and nothing else.

**The toggle.** New "Hide challenge entries" chip in the media filters dropdown on the images and videos feeds, **off by default** — nothing changes for anyone who never opens the filter panel. The client only ever sends a boolean — `hideChallenges` — and the server resolves it to the tag id and unions it into `excludedTagIds`. All four image query paths (`getAllImages`, `getImagesFromSearchPreFilter`, `getImagesFromBitdexPreFilter`, `getImagesFromSearchPostFilter`) already filter on `excludedTagIds`, so no new filtering logic was added; the mapping happens once at each of the two service entry points (`getAllImages`, `getAllImagesIndex`), which is where every one of those paths is reached from.

## Notes for review

- `applyHideChallengesExclusion` mutates `input` in place, mirroring `enforceBlockedBrowsingTags` directly above it.
- It reads the static `dailyChallengeConfig` rather than `getChallengeConfig()` — the feed path shouldn't take a sysRedis round-trip per request. The daily job uses the redis-merged config, so an override there still lands on new collections.
- `MediaFiltersDropdown.tsx` has more diff than the change warrants: the file was already not prettier-clean on `main`, and the required `prettier --write` reformatted a couple of untouched blocks.
- The chip is hidden on `modelImages` (model gallery) — the filter is aimed at the browse feeds.
- Unrelated to this PR but found while tracing the creation paths: `createChallengeCollection` and `createChallengeWithCollection` in `challenge-helpers.ts` have **no callers anywhere** in `src/`, `apps/`, or `packages/`. Left alone here; worth a separate cleanup.

## Verification

- `pnpm run typecheck` — 15 errors, all pre-existing stale-package errors (`@civitai/buzz`, `@civitai/client`) in files this branch doesn't touch.
- `pnpm exec eslint` on the changed files — 0 new errors (image.service.ts has pre-existing ones far from this change).
- `pnpm run test:unit:run` — 16 failures in 6 files, **identical on the base commit** (repo-wide drift-guard scanners, unrelated).
