### PR TITLE
fix(app-blocks): IframeHost's status gates read a stale closure at commit

### DIFF
--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -558,6 +558,77 @@ export function IframeHost({
   const features = useFeatureFlags();
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const [status, setStatus] = useState<Status>('loading');
+  // Mirror of `status`, read by the four status-gated message handlers
+  // (RESIZE_IFRAME, REQUEST_SIGN_IN, REQUEST_CONSENT, OPEN_BUZZ_PURCHASE) via
+  // `readGateStatus` below.
+  //
+  // 🔴 ASSIGNED IN THE RENDER BODY, NOT IN AN EFFECT — that placement IS the fix,
+  // and an effect here is the bug. React writes the `data-block-ready` DOM
+  // attribute (and every other commit-time output) during the COMMIT, but flushes
+  // PASSIVE effects in a LATER scheduler task whenever the commit exhausts the 5ms
+  // frame budget (scheduler 0.23.2, MessageChannel transport, `frameYieldMs = 5`).
+  // So an effect-updated mirror is stale for exactly the window in which the host
+  // has already publicly announced readiness. A render-body assignment happens
+  // BEFORE the commit, so by the time anything observable says "ready" the mirror
+  // already is. This is the same defect, and the same fix, as PageBlockHost's —
+  // see the 🔴 note on its own `statusRef` for the measurement.
+  //
+  // CONCURRENT-RENDERING SAFETY. Writing a ref during render is impure, so the
+  // three ways that bites were each checked rather than assumed:
+  //   • StrictMode double-render writes the SAME value twice — idempotent.
+  //   • An interrupted/discarded concurrent render can leave the ref holding a
+  //     status that never committed. It converges: React always eventually renders
+  //     the latest state, and that render overwrites the ref.
+  //   • It is only ever written from `status` (component state), never derived
+  //     from props or anything a parent can change mid-render.
+  //
+  // 🔴 WHICH DIRECTION THAT TRANSIENT DISAGREEMENT RUNS IN — read this before
+  // pointing a NEW gate at the ref. "Ref ahead of the DOM" is NOT always the
+  // permissive direction; it inherits the direction of the transition in flight,
+  // and this component has transitions BOTH ways:
+  //   • loading → ready is PERMISSIVE. The ref says ready while `data-block-ready`
+  //     still reads "false", so a gate can open a beat before the host has publicly
+  //     announced readiness. Harmless, and it is the whole point of the fix.
+  //   • ready → fatal (`BLOCK_ERROR{fatal:true}`, the handler below) is
+  //     RESTRICTIVE. A concurrent render writes `statusRef.current = 'fatal'`,
+  //     yields before commit, and a queued OPEN_BUZZ_PURCHASE arriving in that gap
+  //     is REFUSED while `data-block-ready` still reads "true".
+  // The restrictive case is deliberate and is the safer side of the trade: the ref
+  // is the host's freshest knowledge of its own state, so refusing a spend on a
+  // host that has already decided it is broken is correct, and the DOM attribute is
+  // the thing lagging. A gate that must NOT tighten early (there is none today)
+  // would have to key off the committed `status`, not this ref.
+  //
+  // RESIDUAL WINDOW, stated rather than hidden: this closes the commit→passive-
+  // effect gap, NOT the larger message-received→render gap. `status` becomes
+  // 'ready' only as a RESULT of the block's own BLOCK_READY being processed
+  // (setStatus → render → commit), so a block that posts a gated request in the
+  // SAME turn as BLOCK_READY still meets a 'loading' mirror — React has not
+  // rendered yet. The NACK on OPEN_BUZZ_PURCHASE (the one repliable gate here) is
+  // what covers that remainder — a drop there fails FAST instead of hanging.
+  const statusRef = useRef<Status>('loading');
+  statusRef.current = status;
+  /**
+   * The ONE way a message handler asks "is the host ready?".
+   *
+   * Reads the RENDER-BODY-updated `statusRef` rather than closing over `status`,
+   * so the answer is current the moment the render that made the host ready is
+   * committed — not one scheduler task later, when React gets around to flushing
+   * passive effects and re-registering the listener with a fresh closure.
+   *
+   * No `'error' → 'no_token'` shim, unlike PageBlockHost's version: this host's
+   * local `Status` union is byte-identical to the shared gates' `HostStatus`
+   * (`openBuzzPurchaseGate.ts`), so the value passes straight through. Deliberately
+   * NOT imported from `pageBlockHostLogic` — the page host is a sibling surface,
+   * not a dependency of this one, and there is nothing to share but an identity fn.
+   *
+   * Stable identity (`[]` deps, ref read only) is load-bearing in its own right:
+   * it lets the four gated effects DROP `status` from their dependency arrays, so
+   * they now subscribe ONCE per mount instead of tearing down and re-registering
+   * on every status transition. The window this fix is about cannot exist if the
+   * listener never needs replacing.
+   */
+  const readGateStatus = useCallback((): Status => statusRef.current, []);
   const [iframeHeight, setIframeHeight] = useState<number>(
     install.manifest.iframe?.minHeight ?? 200
   );
@@ -1119,11 +1190,24 @@ export function IframeHost({
       // is visible-but-non-interactive (pointerEvents:none) before ready and
       // pinned at minHeight, so an early RESIZE would let a pre-ready block
       // push the slot height around before the handshake completes.
-      if (status !== 'ready') return;
+      //
+      // `readGateStatus()` (not a closed-over `status`) — see its definition: it
+      // reads the render-body-updated mirror, so it is current at COMMIT rather
+      // than one scheduler task later.
+      //
+      // NO NACK HERE, deliberately. RESIZE_IFRAME is fire-and-forget: it carries
+      // no requestId and there is no host→block reply message for it, so there is
+      // nothing to reply TO and no promise to fail fast. Dropping it costs the
+      // block one un-honoured height, not a hang.
+      if (readGateStatus() !== 'ready') return;
       applyHeight((raw as { height?: unknown }).height);
     });
     return off;
-  }, [onMessage, applyHeight, status]);
+    // `status` is deliberately ABSENT: the handler reads it through
+    // `readGateStatus` (a render-body-updated ref) instead of closing over it, so
+    // this subscribes ONCE per mount. Re-registering on every status transition is
+    // what opened the commit→passive-effect window in the first place.
+  }, [onMessage, applyHeight, readGateStatus]);
 
   useEffect(() => {
     const off = onMessage<unknown>('BLOCK_ERROR', (raw) => {
@@ -1146,7 +1230,14 @@ export function IframeHost({
   // after login). When absent or unsafe we fall through to the current page.
   useEffect(() => {
     const off = onMessage<{ returnUrl?: unknown } | undefined>('REQUEST_SIGN_IN', (raw) => {
-      const resolved = resolveRequestSignIn(status, raw);
+      // `readGateStatus()` (not a closed-over `status`) — see its definition.
+      const resolved = resolveRequestSignIn(readGateStatus(), raw);
+      // NO NACK HERE, deliberately. REQUEST_SIGN_IN is fire-and-forget: the SDK
+      // sends it with `dispatch` (blocks-react 0.39.0 `useRequestSignIn`), the
+      // payload is `{ returnUrl? }` with NO requestId, and there is no host→block
+      // reply message for it. Nothing to reply to; a drop cannot hang the block —
+      // it just silently does nothing, which is precisely why the ROOT-CAUSE half
+      // of this fix has to hold for this handler.
       if (resolved == null) return; // not ready — drop (gate centralises the rules)
       // Open the hub login in a popup (replaces the old in-page LoginModal). The host runs at TOP level — not
       // inside the sandboxed block iframe — so the popup works here; on completion it navigates back.
@@ -1154,7 +1245,8 @@ export function IframeHost({
       openLoginPopup(resolved.returnUrl ?? here, 'image-gen');
     });
     return off;
-  }, [onMessage, status]);
+    // `status` deliberately absent — see the RESIZE_IFRAME deps note.
+  }, [onMessage, readGateStatus]);
 
   // Lazy consent (A6): the block (rendered in full for a logged-in viewer whose
   // token is missing a consent-gated scope) asks the host to open the consent UI
@@ -1168,7 +1260,14 @@ export function IframeHost({
   // and the block retries — there is no host→block reply (fire-and-forget).
   useEffect(() => {
     const off = onMessage<{ scopes?: unknown } | undefined>('REQUEST_CONSENT', () => {
-      const scopesToGrant = resolveRequestConsent(status, missingScopes ?? []);
+      // `readGateStatus()` (not a closed-over `status`) — see its definition.
+      //
+      // NO NACK HERE, deliberately. REQUEST_CONSENT is fire-and-forget in both
+      // directions: the SDK sends it with `dispatch` (blocks-react 0.39.0
+      // `useRequestConsent`), its payload is `{ scopes? }` with NO requestId, and
+      // there is no host→block reply message for it — so there is nothing to
+      // reply TO and no promise to fail fast. Dropping it cannot hang the block.
+      const scopesToGrant = resolveRequestConsent(readGateStatus(), missingScopes ?? []);
       if (scopesToGrant == null) return; // not ready, or nothing missing — drop
       dialogStore.trigger({
         component: BlockConsentModal,
@@ -1183,9 +1282,10 @@ export function IframeHost({
       });
     });
     return off;
+    // `status` deliberately absent — see the RESIZE_IFRAME deps note.
   }, [
     onMessage,
-    status,
+    readGateStatus,
     missingScopes,
     install.appBlockId,
     install.manifest.name,
@@ -1269,9 +1369,35 @@ export function IframeHost({
         // still visible-but-non-interactive (pointerEvents:none). Summoning the
         // money-spend modal pre-ready would let an untrusted block nag the user
         // before any interaction. resolveBuzzPurchaseRequest returns null
-        // (silently dropped) when status !== 'ready' or the payload is bad.
-        const requestId = resolveBuzzPurchaseRequest(status, raw);
-        if (requestId == null || !raw) return; // !raw is implied by requestId != null; narrows for TS
+        // when status !== 'ready' or the payload is bad.
+        //
+        // `readGateStatus()` (not a closed-over `status`) — see its definition.
+        const requestId = resolveBuzzPurchaseRequest(readGateStatus(), raw);
+        if (requestId == null || !raw) {
+          // NEVER HANG. `resolveBuzzPurchaseRequest` returns null for TWO
+          // different reasons, and they need different answers:
+          //
+          //   • malformed payload (no string requestId) — UNREPLIABLE. There is
+          //     no id to thread a reply back on, so it can only be dropped.
+          //   • host not ready — REPLIABLE, and it must be replied to. The block
+          //     is awaiting BUZZ_PURCHASE_RESULT on a promise that rejects only
+          //     at the SDK's 30s default request timeout (blocks-react 0.39.0,
+          //     `DEFAULT_REQUEST_TIMEOUT_MS`), so a silent drop costs the user's
+          //     click plus half a minute of nothing happening.
+          //
+          // `purchased: false` is exactly what the modal's own onClose sends for
+          // a dismissed purchase below, and exactly what the SDK's
+          // `useBuzzPurchase` reads as "no purchase happened". Refusing is
+          // unchanged — no modal opens, nothing is charged; the block just finds
+          // out now instead of in 30 seconds.
+          //
+          // `!raw` is implied by requestId != null; the compound condition also
+          // narrows for TS.
+          if (raw && typeof raw.requestId === 'string' && raw.requestId.length > 0) {
+            send('BUZZ_PURCHASE_RESULT', { requestId: raw.requestId, purchased: false });
+          }
+          return;
+        }
         const rawAmount =
           typeof raw.suggestedAmount === 'number' && Number.isFinite(raw.suggestedAmount)
             ? raw.suggestedAmount
@@ -1333,14 +1459,24 @@ export function IframeHost({
       }
     );
     return off;
+    // `status` deliberately absent — see the RESIZE_IFRAME deps note.
+    //
+    // `modelCtx.slotId` IS present, and it was NOT before: the attribution branch
+    // above reads it, so omitting it was a stale-closure bug of the same family as
+    // the one this change is about. Unreachable today — BlockSlot re-keys this
+    // subtree on (slotId, entityType, entityId), so a slotId change remounts the
+    // host rather than re-rendering it — but the omission was not load-bearing and
+    // silently preserving it while rewriting this array would be inheriting a bug
+    // on purpose.
   }, [
     onMessage,
     send,
-    status,
+    readGateStatus,
     install.appId,
     install.appBlockId,
     install.blockInstanceId,
     modelCtx.modelId,
+    modelCtx.slotId,
   ]);
 
   // Checkpoint picker: the block fires OPEN_CHECKPOINT_PICKER with the

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -1391,6 +1391,25 @@ export function IframeHost({
           // unchanged — no modal opens, nothing is charged; the block just finds
           // out now instead of in 30 seconds.
           //
+          // 🔴 NOT AN UNCONDITIONAL IMPROVEMENT, AND THE HONEST VERSION IS
+          // WORTH THE THREE LINES. `usePostMessage` dedups INBOUND messages by
+          // `payload.requestId` for DEDUP_WINDOW_MS = 5000 (usePostMessage.ts),
+          // and it does so BEFORE any handler runs. So a block that reacts to
+          // this `purchased: false` by retrying with the SAME requestId inside
+          // five seconds is swallowed by the transport and hangs exactly as it
+          // did before — the NACK converts a guaranteed hang into a fast
+          // failure only for a block that retries with a FRESH id (or after the
+          // window). Deliberately not changed here: the dedup is a replay
+          // defense, and relaxing it for one message type would be a wider
+          // change than this fix earns.
+          //
+          // The "30 seconds" above is the SDK-side request timeout carried over
+          // from #3680's reasoning. It is NOT verifiable in this repo:
+          // `@civitai/blocks-react` is not a dependency (0 hits in
+          // pnpm-lock.yaml; the installed SDK is `@civitai/app-sdk@0.14.0`,
+          // which implements neither OPEN_BUZZ_PURCHASE nor a request timeout).
+          // Treat it as the reasonable inference it is, not a measurement.
+          //
           // `!raw` is implied by requestId != null; the compound condition also
           // narrows for TS.
           if (raw && typeof raw.requestId === 'string' && raw.requestId.length > 0) {

--- a/src/components/AppBlocks/IframeHostStatusGates.browser.test.tsx
+++ b/src/components/AppBlocks/IframeHostStatusGates.browser.test.tsx
@@ -222,6 +222,28 @@ const baseProps = {
   expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
 };
 
+// REQUEST_CONSENT is a TWO-condition gate (requestConsentGate.ts): status must be
+// 'ready' AND `missingScopes` must be non-empty. With the default `baseProps` the
+// second condition alone drops every request, so a consent guard mounted on them
+// would pass for a reason that has nothing to do with the status gate — the shape
+// of a vacuous test. These props satisfy the scopes half so the STATUS half is the
+// only thing under test.
+const consentProps = { ...baseProps, missingScopes: ['ai:write:budgeted'] };
+
+// The manifest's minHeight, i.e. the height the iframe is pinned at from mount
+// until something honours a RESIZE_IFRAME. Any assertion that "the height did not
+// move" is an assertion that it is still this.
+const MIN_HEIGHT = 200;
+// A distinct in-bounds height (manifest min 200 / max 800), so a pass cannot be
+// the clamp landing on the default by coincidence.
+const RESIZE_HEIGHT = 640;
+
+// The host renders the negotiated height as an inline style on the iframe.
+function iframeHeightPx(): number {
+  const el = page.getByTestId('block-iframe').element() as HTMLIFrameElement;
+  return parseFloat(el.style.height);
+}
+
 async function waitForMount() {
   await vi.waitFor(() => {
     const el = page.getByTestId('block-iframe').element() as HTMLIFrameElement;
@@ -251,10 +273,27 @@ async function driveToReady() {
  * Unlike `driveToReady` this returns control to the caller WITHOUT waiting for
  * `data-block-ready` — the point is that the `onReadyAttributeWrite` hook fires from
  * inside React's commit, on React's own stack, while this drive is still running.
+ *
+ * 🔴 THE INTERVAL IS BOUNDED BY usePostMessage'S OWN RATE LIMIT, not by taste. That
+ * transport drops inbound messages once RATE_LIMIT_MAX_MESSAGES = 30 have arrived
+ * within RATE_LIMIT_WINDOW_MS = 1000 (usePostMessage.ts), counting only types that
+ * have a subscriber — which BLOCK_READY does. At the original 10ms this drive asked
+ * for 100/s against a 30/s budget, so a drive that ran for a full second would spend
+ * ~70% of it above the limit, dropping its own posts (and the one the commit-window
+ * hook piggybacks) with a `console.warn` each. It worked because the drives are
+ * short and the decisive post lands in the first few ticks — i.e. it was under the
+ * limit by luck of timing, not by construction, and every guard added here narrows
+ * that margin. 40ms is 25/s, which stays under the budget with headroom for the
+ * commit-window post on top. Raise this number, never lower it.
+ *
+ * (Stated as the arithmetic it is: the constants are read from usePostMessage.ts,
+ * the drop count itself was not instrumented.)
  */
+const READY_DRIVE_INTERVAL_MS = 40;
+
 async function startReadyDrive() {
   await waitForMount();
-  const timer = setInterval(() => postFromBlock('BLOCK_READY', {}), 10);
+  const timer = setInterval(() => postFromBlock('BLOCK_READY', {}), READY_DRIVE_INTERVAL_MS);
   postFromBlock('BLOCK_READY', {});
   return () => clearInterval(timer);
 }
@@ -432,5 +471,231 @@ describe('IframeHost status gates — commit→passive-effect window (model.side
 
     await new Promise((r) => setTimeout(r, 150));
     expect(openLoginPopup).not.toHaveBeenCalled();
+  });
+
+  /**
+   * GUARD 6 — RESIZE_IFRAME, the third of the four gated handlers.
+   *
+   * 🔴 WHY THIS EXISTS: MEASURED, TWICE. Before this guard, reverting the
+   * RESIZE_IFRAME handler to its exact pre-#3726 form — closing over `status`, with
+   * `status` back in the effect's dependency array — left the ENTIRE
+   * src/components/AppBlocks component suite green at 380 passed / 33 files. A
+   * quarter of this fix could be silently undone. Guards 1 and 4 cover the money and
+   * sign-in gates; nothing covered this one.
+   *
+   * Like REQUEST_SIGN_IN this handler is fire-and-forget with no NACK to soften a
+   * drop, so the root-cause half (reading a render-body-updated `statusRef` rather
+   * than a closed-over `status`) is the only thing standing between a block that
+   * negotiates its height at ready and a slot stuck at minHeight.
+   *
+   * The observable is the iframe's inline height rather than a mock call count: it
+   * is the actual user-visible effect, and it distinguishes "handler ran" from
+   * "handler ran and the clamp let the value through".
+   */
+  test("RESIZE_IFRAME posted in React's commit→passive-effect gap is still honoured", async () => {
+    renderWithProviders(<IframeHost {...baseProps} />);
+    await waitForMount();
+    // The height the assertion below must move OFF. Read before the drive so a
+    // pass cannot be the iframe having already been at RESIZE_HEIGHT.
+    expect(iframeHeightPx()).toBe(MIN_HEIGHT);
+
+    const unpatch = onReadyAttributeWrite(() =>
+      postFromBlock('RESIZE_IFRAME', { height: RESIZE_HEIGHT })
+    );
+    try {
+      const stopDrive = await startReadyDrive();
+      try {
+        await vi.waitFor(() => expect(iframeHeightPx()).toBe(RESIZE_HEIGHT));
+      } finally {
+        stopDrive();
+      }
+    } finally {
+      unpatch();
+    }
+  });
+
+  /**
+   * GUARD 7 — RESIZE_IFRAME's own refusal, which was ALSO unguarded.
+   *
+   * 🔴 This closes a WIDER gap than the commit-window one, and the PR that
+   * introduced the fix did not disclose it: before this test, DELETING the
+   * `readGateStatus() !== 'ready'` line outright also left the whole suite green. A
+   * pre-handshake block could drive the slot's height around — while the iframe is
+   * still pointerEvents:none and the user has interacted with nothing — and nothing
+   * anywhere went red.
+   *
+   * 🔴 POSITIVE CONTROL is not optional. The first assertion is a ZERO ("the height
+   * did not move"), and a harness that never delivered the message, or that reads an
+   * `el.style.height` the host does not actually write, produces that same zero. The
+   * control fires the SAME message on the SAME host after ready and requires the
+   * height to move, so the zero above it is a measurement rather than an artefact.
+   */
+  test('RESIZE_IFRAME before BLOCK_READY does not move the slot height', async () => {
+    renderWithProviders(<IframeHost {...baseProps} />);
+    // Do NOT drive to ready — fire while status is still 'loading'.
+    await waitForMount();
+    expect(iframeHeightPx()).toBe(MIN_HEIGHT);
+
+    postFromBlock('RESIZE_IFRAME', { height: RESIZE_HEIGHT });
+
+    await new Promise((r) => setTimeout(r, 150));
+    // THE security property: a pre-handshake block cannot resize the slot.
+    expect(iframeHeightPx()).toBe(MIN_HEIGHT);
+
+    // POSITIVE CONTROL: the identical message, once ready, IS honoured — so the
+    // refusal above is the gate refusing, not the probe failing to observe.
+    await driveToReady();
+    postFromBlock('RESIZE_IFRAME', { height: RESIZE_HEIGHT });
+    await vi.waitFor(() => expect(iframeHeightPx()).toBe(RESIZE_HEIGHT));
+  });
+
+  /**
+   * GUARD 8 — REQUEST_CONSENT, the fourth gated handler and the one with the LEAST
+   * coverage of any of them.
+   *
+   * 🔴 MEASURED: reverting this handler to the closed-over `status` (with `status`
+   * back in its deps) left the whole suite green, exactly as for RESIZE_IFRAME. And
+   * REQUEST_CONSENT had ZERO browser coverage against IframeHost anywhere in the
+   * tree before this file — the three other files naming the message target
+   * PageBlockHost or BlockConsentModal, neither of which exercises this handler.
+   *
+   * Fire-and-forget in both directions (no requestId, no host→block reply), so a
+   * drop in the commit window is simply an anonymous-of-a-capability user clicking
+   * "Generate" and getting nothing — no permission modal, no error, no retry.
+   *
+   * The assertion pins the modal's OWN props (`missingScopes`), not just
+   * `dialogs.length`: the store is shared and a length check would be satisfied by
+   * any dialog from any source.
+   */
+  test("REQUEST_CONSENT posted in React's commit→passive-effect gap still opens the consent modal", async () => {
+    renderWithProviders(<IframeHost {...consentProps} />);
+    const unpatch = onReadyAttributeWrite(() => postFromBlock('REQUEST_CONSENT', {}));
+    try {
+      const stopDrive = await startReadyDrive();
+      try {
+        await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+      } finally {
+        stopDrive();
+      }
+    } finally {
+      unpatch();
+    }
+    // Prove it is the CONSENT modal, carrying the server-known missing set — not
+    // some other dialog that happened to be open.
+    expect(
+      (useDialogStore.getState().dialogs[0].props as { missingScopes?: string[] }).missingScopes
+    ).toEqual(['ai:write:budgeted']);
+  });
+
+  /**
+   * GUARD 9 — REQUEST_CONSENT's refusal, the second undisclosed hole.
+   *
+   * 🔴 Deleting this handler's status gate (forcing `resolveRequestConsent` to see
+   * 'ready') also left the whole suite green before this test: a pre-handshake block
+   * could pop the PERMISSION modal — the one that grants it `ai:write:budgeted` —
+   * before the user has interacted with anything.
+   *
+   * POSITIVE CONTROL as in guard 7, and for the same reason: "no modal opened" is
+   * the observable a dead harness also produces.
+   */
+  test('REQUEST_CONSENT before BLOCK_READY opens no consent modal', async () => {
+    renderWithProviders(<IframeHost {...consentProps} />);
+    // Do NOT drive to ready — fire while status is still 'loading'.
+    await waitForMount();
+
+    postFromBlock('REQUEST_CONSENT', {});
+
+    await new Promise((r) => setTimeout(r, 150));
+    // THE security property: no pre-handshake permission prompt.
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+
+    // POSITIVE CONTROL: the identical message, once ready, DOES open it.
+    await driveToReady();
+    postFromBlock('REQUEST_CONSENT', {});
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+    expect(
+      (useDialogStore.getState().dialogs[0].props as { missingScopes?: string[] }).missingScopes
+    ).toEqual(['ai:write:budgeted']);
+  });
+
+  /**
+   * GUARD 10 — the NACK's own predicate, half one: `requestId.length > 0`.
+   *
+   * Guard 3 covers a payload with NO requestId key at all. It does NOT cover an
+   * EMPTY-STRING one, and that is a different branch: `resolveBuzzPurchaseRequest`
+   * rejects `''` (its `length === 0` check), so the message lands in the same
+   * never-hang block — where `raw.requestId.length > 0` is the only thing stopping a
+   * reply addressed to the empty string.
+   *
+   * 🔴 MEASURED: relaxing that to `>= 0` survived the whole suite. A NACK on `''` is
+   * not merely untidy — it is a reply the block cannot correlate (its transport keys
+   * pending requests by id), so it is indistinguishable from the silent drop it was
+   * supposed to replace while adding an unsolicited message to the channel.
+   *
+   * 🔴 COUNT ONLY `BUZZ_PURCHASE_RESULT` — see guard 3's note. Total received drifts
+   * on BLOCK_INIT / TOKEN_REFRESH the host emits on its own schedule.
+   */
+  test('OPEN_BUZZ_PURCHASE with an EMPTY requestId is dropped silently (nothing to reply to)', async () => {
+    renderWithProviders(<IframeHost {...baseProps} />);
+    // Pre-ready: the branch under test is the never-hang block, which this reaches
+    // whether the rejection came from the status or from the payload.
+    await waitForMount();
+    const replies = listenForReply();
+    const buzzReplies = () => replies.received.filter((m) => m.type === 'BUZZ_PURCHASE_RESULT');
+
+    // POSITIVE CONTROL: a well-formed pre-ready request IS NACKed, so a
+    // BUZZ_PURCHASE_RESULT is observable on this host before the zero is read.
+    postFromBlock('OPEN_BUZZ_PURCHASE', { requestId: 'rq_ctl_empty', suggestedAmount: 10 });
+    await vi.waitFor(() => expect(buzzReplies()).toHaveLength(1));
+
+    // The real case: a present-but-empty requestId.
+    postFromBlock('OPEN_BUZZ_PURCHASE', { requestId: '', suggestedAmount: 1000 });
+
+    await new Promise((r) => setTimeout(r, 150));
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+    // Still exactly the control's reply — the empty-id post added none.
+    expect(buzzReplies()).toHaveLength(1);
+    replies.stop();
+  });
+
+  /**
+   * GUARD 11 — the NACK's predicate, half two: `typeof raw.requestId === 'string'`.
+   *
+   * 🔴 THE TWO PAYLOADS HERE ARE NOT REDUNDANT, AND PICKING ONLY THE OBVIOUS ONE
+   * LEAVES THE MUTANT ALIVE. Dropping the `typeof` check leaves
+   * `raw.requestId.length > 0`:
+   *
+   *   • `requestId: 5` — `(5).length` is `undefined`, `undefined > 0` is false, so
+   *     the mutant still sends nothing and a test built on this case alone passes
+   *     against BOTH the fix and the mutant. It is here because it is the payload
+   *     the `typeof` check nominally describes, not because it discriminates.
+   *   • `requestId: ['rq']` — a structured-clonable value with a TRUTHY `.length`.
+   *     This is the one that discriminates: without the `typeof` check the host
+   *     replies with `requestId: ['rq']`, an id of a type the protocol does not
+   *     have. MEASURED: dropping `typeof` survives the whole suite without it.
+   *
+   * Both are equally UNREPLIABLE by the PR's own stated invariant — there is no
+   * string id to thread a reply back on — so both must be dropped in total silence.
+   */
+  test('OPEN_BUZZ_PURCHASE with a NON-STRING requestId is dropped silently (nothing to reply to)', async () => {
+    renderWithProviders(<IframeHost {...baseProps} />);
+    await waitForMount();
+    const replies = listenForReply();
+    const buzzReplies = () => replies.received.filter((m) => m.type === 'BUZZ_PURCHASE_RESULT');
+
+    // POSITIVE CONTROL first — proves the handler is live and a NACK observable.
+    postFromBlock('OPEN_BUZZ_PURCHASE', { requestId: 'rq_ctl_nonstring', suggestedAmount: 10 });
+    await vi.waitFor(() => expect(buzzReplies()).toHaveLength(1));
+
+    // A number: no `.length` at all.
+    postFromBlock('OPEN_BUZZ_PURCHASE', { requestId: 5, suggestedAmount: 1000 });
+    // An array: a non-string that DOES have a truthy `.length`.
+    postFromBlock('OPEN_BUZZ_PURCHASE', { requestId: ['rq'], suggestedAmount: 1000 });
+
+    await new Promise((r) => setTimeout(r, 150));
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+    // Still exactly the control's reply — neither malformed post added one.
+    expect(buzzReplies()).toHaveLength(1);
+    replies.stop();
   });
 });

--- a/src/components/AppBlocks/IframeHostStatusGates.browser.test.tsx
+++ b/src/components/AppBlocks/IframeHostStatusGates.browser.test.tsx
@@ -1,0 +1,436 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
+import { useDialogStore } from '~/components/Dialog/dialogStore';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import { onReadyAttributeWrite } from '../../../test/commitWindow';
+// Type-only namespace import for the `importActual` generic below.
+// `@typescript-eslint/consistent-type-imports` rejects an inline
+// `typeof import('...')` annotation, so the type has to arrive this way.
+import type * as AuthHelpers from '~/utils/auth-helpers';
+import type * as Trpc from '~/utils/trpc';
+
+/**
+ * IframeHost's STATUS-GATED message handlers — the model-slot twin of the
+ * PageBlockHost defect fixed in #3680.
+ *
+ * ── THE DEFECT ──────────────────────────────────────────────────────────────────
+ *
+ * Four IframeHost handlers gate on the host being ready: RESIZE_IFRAME,
+ * REQUEST_SIGN_IN, REQUEST_CONSENT and OPEN_BUZZ_PURCHASE. Each closed over
+ * `status` from the render that registered it, with `status` in its effect's
+ * dependency array — so the LIVE listener only picks up a new status when React
+ * flushes that effect. React writes `data-block-ready` during the COMMIT and
+ * flushes passive effects in a LATER scheduler task, so there is a window in which
+ * the host publicly reports ready while the live handler still holds
+ * `status === 'loading'` and drops the message.
+ *
+ * ── WHY A SEPARATE FILE ─────────────────────────────────────────────────────────
+ *
+ * IframeHost.browser.test.tsx is the beacon/GET_BUZZ_BALANCE suite. These guards
+ * need two things it does not have — a mocked `openLoginPopup` and the dialogStore
+ * — and they mirror PageBlockHostWorkflow/PageBlockHostSignIn rather than that
+ * file, so they live beside it instead of inside it.
+ *
+ * ── WHAT THESE GUARDS CANNOT PROVE ──────────────────────────────────────────────
+ *
+ * That a real deployed block hits the window. As #3680 said of the page host: no
+ * SDK code path auto-posts a gated request on ready — all of them are `useCallback`s
+ * the app invokes — so reaching the window needs app code that calls one in the same
+ * turn it observes ready, and no such block was observed. This is a latent defect
+ * being closed, not a reported outage.
+ */
+
+// Per-test-controllable mutation impls. `vi.mock` is hoisted, so the fns must live
+// in a hoisted block the factory can close over.
+const mocks = vi.hoisted(() => ({
+  balance: vi.fn(),
+}));
+
+// AppBlockChrome (in the host frame) calls useCurrentUser() for the platform-nav
+// moderator gate; these suites render the real host without a CivitaiSessionProvider.
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+// IframeHost reads `appBlocks && appBlocksPages` (the run route's own predicate) to
+// decide whether the chrome may offer `/apps/run/<blockId>` shortcuts; the real hook
+// THROWS without a FeatureFlagsProvider (which this scaffold does not mount). Dark
+// flags = the production default, and these suites assert host gating, not the menu.
+// Deliberately a WHOLE-module factory, not an `importOriginal` spread — see the note
+// in IframeHost.browser.test.tsx.
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ appBlocks: false, appBlocksPages: false }),
+}));
+
+// IframeHost drives two tRPC queries at render (getEffectiveCheckpoint +
+// getShowcaseImages) and wires the workflow/storage bridges. None of that is under
+// test here, so stub it all so the component mounts network-free and the init
+// handshake is ALLOWED to start immediately (getEffectiveCheckpoint must report
+// `isLoading: false` so `shouldStartInit` fires).
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof Trpc>()),
+  trpc: {
+    blocks: {
+      getEffectiveCheckpoint: {
+        useQuery: () => ({ data: { checkpoint: null }, isLoading: false }),
+      },
+      getShowcaseImages: {
+        useQuery: () => ({ data: [], isLoading: false }),
+      },
+      submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      updateUserSettings: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzBalance: { useMutation: () => ({ mutateAsync: mocks.balance }) },
+    },
+    apps: {
+      shared: {
+        append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        update: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        report: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+      storage: {
+        set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        delete: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+    },
+    useUtils: () => ({
+      apps: {
+        shared: {
+          list: { fetch: vi.fn() },
+          getCount: { fetch: vi.fn() },
+          getCounts: { fetch: vi.fn() },
+          get: { fetch: vi.fn() },
+        },
+        storage: {
+          get: { fetch: vi.fn() },
+          list: { fetch: vi.fn() },
+          getQuota: { fetch: vi.fn() },
+        },
+      },
+    }),
+  },
+}));
+
+// useBrowsingLevelDebounced reads a context the network-free scaffold doesn't
+// provide; the value only feeds the (mocked) showcase query, so stub a constant.
+vi.mock('~/components/BrowsingLevel/BrowsingLevelProvider', () => ({
+  useBrowsingLevelDebounced: () => 1,
+}));
+
+// Login is hub-driven (a popup to auth.civitai.com via openLoginPopup). Stub it so
+// the REQUEST_SIGN_IN guard can assert the call without opening a window.
+// IframeHost.browser.test.tsx does NOT mock this module — the sign-in gate is not
+// exercised there — which is one of the two reasons these guards live in their own
+// file.
+vi.mock('~/utils/auth-helpers', async (importActual) => ({
+  ...(await importActual<typeof AuthHelpers>()),
+  openLoginPopup: vi.fn(),
+}));
+
+// eslint-disable-next-line import/first
+import { IframeHost } from '~/components/AppBlocks/IframeHost';
+// eslint-disable-next-line import/first
+import type { BlockInstall, ModelSlotContext } from '~/components/AppBlocks/types';
+// eslint-disable-next-line import/first
+import { openLoginPopup } from '~/utils/auth-helpers';
+
+// Same-origin so trustTier='internal' yields a pinned (non-opaque) transport whose
+// expectedOrigin equals this frame's origin.
+const SAME_ORIGIN_SRC = `${window.location.origin}/`;
+
+// Simulate a message FROM the block by dispatching a MessageEvent whose `source` is
+// the iframe's contentWindow and whose `origin` matches the host's expectedOrigin.
+// This satisfies BOTH authenticating pins usePostMessage enforces.
+function postFromBlock(type: string, payload?: unknown) {
+  const iframeEl = page.getByTestId('block-iframe').element() as HTMLIFrameElement;
+  const cw = iframeEl.contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      data: { type, payload },
+      origin: window.location.origin,
+      source: cw,
+    })
+  );
+}
+
+// Capture host→block replies. `send` posts onto the iframe's contentWindow, so we
+// listen there.
+function listenForReply() {
+  const received: Array<{ type: string; payload: unknown }> = [];
+  const iframeEl = page.getByTestId('block-iframe').element() as HTMLIFrameElement;
+  const cw = iframeEl.contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  const handler = (e: MessageEvent) => {
+    const d = e.data as { type?: string; payload?: unknown } | null;
+    if (d && typeof d.type === 'string') received.push({ type: d.type, payload: d.payload });
+  };
+  cw.addEventListener('message', handler);
+  return {
+    received,
+    last: (type: string) => [...received].reverse().find((m) => m.type === type),
+    stop: () => cw.removeEventListener('message', handler),
+  };
+}
+
+const install: BlockInstall = {
+  blockInstanceId: 'mbi_test',
+  blockId: 'my-model-app',
+  appId: 'app_test',
+  appBlockId: 'apb_test',
+  manifest: {
+    name: 'Background Remover',
+    scopes: ['ai:write:budgeted'],
+    iframe: {
+      src: SAME_ORIGIN_SRC,
+      minHeight: 200,
+      maxHeight: 800,
+      resizable: true,
+      sandbox: 'allow-scripts',
+    },
+  },
+  publisherSettings: {},
+  enabled: true,
+  renderMode: 'iframe',
+  trustTier: 'internal',
+};
+
+// model.sidebar_top is the live production slot.
+const context: ModelSlotContext = {
+  slotId: 'model.sidebar_top',
+  entityType: 'model',
+  modelId: 123,
+  modelVersionId: 456,
+  modelName: 'Some Model',
+  modelType: 'Checkpoint',
+  modelNsfwLevel: 1,
+  creatorUserId: 7,
+  viewerUserId: 42,
+  viewerNsfwEnabled: false,
+  viewerUsername: 'tester',
+  theme: 'light',
+};
+
+const baseProps = {
+  install,
+  context,
+  token: 'tok_abc',
+  expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
+};
+
+async function waitForMount() {
+  await vi.waitFor(() => {
+    const el = page.getByTestId('block-iframe').element() as HTMLIFrameElement;
+    if (!el.contentWindow) throw new Error('not mounted yet');
+  });
+}
+
+// Drive the handshake to BLOCK_READY (status='ready') — the transition a real block
+// hits once it acks the host's BLOCK_INIT.
+async function driveToReady() {
+  await waitForMount();
+  await vi.waitFor(() => {
+    postFromBlock('BLOCK_READY', {});
+    const el = page.getByTestId('block-iframe').element() as HTMLIFrameElement;
+    if (el.getAttribute('data-block-ready') !== 'true') throw new Error('not ready yet');
+  });
+}
+
+/**
+ * Wait for the iframe to mount, then post BLOCK_READY on a CANCELLABLE interval.
+ *
+ * Cancellable is load-bearing: a drive left running past the end of a test posts
+ * BLOCK_READY into the NEXT test's freshly-mounted host — measured on the page host,
+ * that turned a "before BLOCK_READY is dropped" guard red for a reason having nothing
+ * to do with the race under study. Callers stop it in a `finally`.
+ *
+ * Unlike `driveToReady` this returns control to the caller WITHOUT waiting for
+ * `data-block-ready` — the point is that the `onReadyAttributeWrite` hook fires from
+ * inside React's commit, on React's own stack, while this drive is still running.
+ */
+async function startReadyDrive() {
+  await waitForMount();
+  const timer = setInterval(() => postFromBlock('BLOCK_READY', {}), 10);
+  postFromBlock('BLOCK_READY', {});
+  return () => clearInterval(timer);
+}
+
+describe('IframeHost status gates — commit→passive-effect window (model.sidebar_top)', () => {
+  beforeEach(() => {
+    // dialogStore is a module-level zustand store shared across tests — reset it
+    // (the OPEN_BUZZ_PURCHASE handler triggers a dialog on it).
+    useDialogStore.getState().closeAll();
+    vi.mocked(openLoginPopup).mockClear();
+    mocks.balance.mockReset();
+  });
+
+  /**
+   * GUARD 1 — the commit-gap positive, on the money gate.
+   *
+   * OPEN_BUZZ_PURCHASE is request/response: the block awaits BUZZ_PURCHASE_RESULT on
+   * a promise that rejects only at the SDK's 30s default request timeout
+   * (`DEFAULT_REQUEST_TIMEOUT_MS`, @civitai/blocks-react 0.39.0) — so a drop here
+   * costs the user's click plus half a minute of nothing.
+   *
+   * 🔴 The post is driven from `onReadyAttributeWrite`, NOT a MutationObserver — see
+   * test/commitWindow.tsx. A MutationObserver callback is a microtask that runs at the
+   * END of the scheduler task, often after React has already flushed the passive
+   * effects, which made the first version of the page host's guard survive its mutant
+   * about one run in three.
+   *
+   * Proven reachable by mutation: move `statusRef.current = status` out of the render
+   * body and back into an effect and this goes red on `expected [] to have a length
+   * of 1`.
+   */
+  test("OPEN_BUZZ_PURCHASE posted in React's commit→passive-effect gap still opens the modal", async () => {
+    renderWithProviders(<IframeHost {...baseProps} />);
+    const unpatch = onReadyAttributeWrite(() =>
+      postFromBlock('OPEN_BUZZ_PURCHASE', { requestId: 'rq_gap', suggestedAmount: 1000 })
+    );
+    try {
+      const stopDrive = await startReadyDrive();
+      try {
+        await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+      } finally {
+        stopDrive();
+      }
+    } finally {
+      unpatch();
+    }
+    // Pin the per-request dialog id, so this proves THIS post opened the modal.
+    expect(useDialogStore.getState().dialogs[0].id).toBe('block-buy-buzz-rq_gap');
+  });
+
+  /**
+   * GUARD 2 — the refusal is now SPOKEN instead of silent.
+   *
+   * The gate's REFUSAL is unchanged — no pre-handshake spend modal, ever. What
+   * changed is that this branch used to drop the message with a bare `return`,
+   * leaving the block's promise to hang for the SDK's full 30s request timeout.
+   *
+   * `purchased: false` is the same shape the modal's own onClose sends for a
+   * dismissed purchase, and the same shape `useBuzzPurchase` reads as "no purchase
+   * happened". Nothing is charged.
+   *
+   * Proven reachable by mutation: delete the NACK `send` and this goes red on
+   * `no NACK yet`.
+   */
+  test('OPEN_BUZZ_PURCHASE before BLOCK_READY opens no modal and NACKs (never hangs)', async () => {
+    renderWithProviders(<IframeHost {...baseProps} />);
+    // Do NOT drive to ready — fire while status is still 'loading'.
+    await waitForMount();
+    const replies = listenForReply();
+
+    postFromBlock('OPEN_BUZZ_PURCHASE', { requestId: 'rq_buzz_early', suggestedAmount: 1000 });
+
+    await vi.waitFor(() => {
+      const r = replies.last('BUZZ_PURCHASE_RESULT');
+      if (!r) throw new Error('no NACK yet');
+    });
+    // THE security property, unchanged: the spend modal never opened.
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+    // THE new property: the block was told, on its own requestId, so it fails fast.
+    expect(replies.last('BUZZ_PURCHASE_RESULT')!.payload).toEqual({
+      requestId: 'rq_buzz_early',
+      purchased: false,
+    });
+    replies.stop();
+  });
+
+  /**
+   * GUARD 3 — the OTHER reason `resolveBuzzPurchaseRequest` returns null: a malformed
+   * payload with no string requestId. That one is legitimately UNREPLIABLE — there is
+   * no id to thread a reply back on — so it must still be dropped in total silence,
+   * and the NACK above must not have widened into "reply to everything".
+   *
+   * POSITIVE CONTROL is load-bearing here: this asserts a ZERO (no modal, no extra
+   * reply), and a host whose listener was never live produces that same zero. The
+   * control proves the handler is live AND that a BUZZ_PURCHASE_RESULT is observable
+   * at all before the zero is read, so the zero is a measurement rather than an
+   * artefact.
+   *
+   * 🔴 COUNT ONLY `BUZZ_PURCHASE_RESULT`, never `received.length`. The host pushes
+   * unrelated messages of its own (BLOCK_INIT, TOKEN_REFRESH, THEME_CHANGE) from
+   * effects, on a schedule this test does not control — so a TOTAL message count
+   * drifts for reasons that have nothing to do with the assertion. Measured on the
+   * page host: an earlier draft counting `received.length` failed on
+   * `expected 1 to be +0` against a host that was behaving perfectly.
+   */
+  test('OPEN_BUZZ_PURCHASE with NO requestId is dropped silently (nothing to reply to)', async () => {
+    renderWithProviders(<IframeHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+    const buzzReplies = () => replies.received.filter((m) => m.type === 'BUZZ_PURCHASE_RESULT');
+
+    // POSITIVE CONTROL: a well-formed request DOES get through and open the modal,
+    // and closing it DOES produce an observable BUZZ_PURCHASE_RESULT.
+    postFromBlock('OPEN_BUZZ_PURCHASE', { requestId: 'rq_control', suggestedAmount: 10 });
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+    useDialogStore.getState().dialogs[0].options?.onClose?.();
+    await vi.waitFor(() => expect(buzzReplies()).toHaveLength(1));
+    useDialogStore.getState().closeAll();
+
+    // The real case: no requestId at all.
+    postFromBlock('OPEN_BUZZ_PURCHASE', { suggestedAmount: 1000 });
+
+    await new Promise((r) => setTimeout(r, 150));
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+    // Still exactly the control's reply — the malformed post added none.
+    expect(buzzReplies()).toHaveLength(1);
+    replies.stop();
+  });
+
+  /**
+   * GUARD 4 — the ROOT-CAUSE half, on a gate with NO NACK to fall back on.
+   *
+   * REQUEST_SIGN_IN is fire-and-forget — it carries no requestId and has no reply
+   * message — so a post dropped in this window is gone for good and the anonymous
+   * viewer's click on "Sign in" does nothing at all, silently. There is no NACK
+   * available to soften it, which is exactly why the root-cause fix (reading a
+   * render-body-updated `statusRef` instead of a closed-over `status`) has to hold
+   * for this handler. Guard 2's NACK cannot mask a regression here.
+   *
+   * Proven reachable by mutation: revert this handler to the closed-over `status`
+   * (with `status` back in its deps) and this goes red on `expected
+   * "openLoginPopup" to be called 1 times, but got 0 times`.
+   */
+  test("REQUEST_SIGN_IN posted in React's commit→passive-effect gap still starts the login", async () => {
+    renderWithProviders(<IframeHost {...baseProps} />);
+    // Fires synchronously on React's own stack, at the instant the host writes
+    // data-block-ready="true" — strictly before this commit's passive effects
+    // re-register a listener holding the fresh status.
+    const unpatch = onReadyAttributeWrite(() => postFromBlock('REQUEST_SIGN_IN', {}));
+    try {
+      const stopDrive = await startReadyDrive();
+      try {
+        await vi.waitFor(() => {
+          expect(openLoginPopup).toHaveBeenCalledTimes(1);
+        });
+      } finally {
+        stopDrive();
+      }
+    } finally {
+      unpatch();
+    }
+  });
+
+  /**
+   * The gate's own refusal, unchanged: a pre-handshake block cannot pop the login
+   * popup. This is the negative half of guard 4 — without it, "the handler is live"
+   * and "the handler always fires" are indistinguishable.
+   */
+  test('REQUEST_SIGN_IN before BLOCK_READY is dropped (no pre-handshake login popup)', async () => {
+    renderWithProviders(<IframeHost {...baseProps} />);
+    // Do NOT drive to ready — fire while status is still 'loading'.
+    await waitForMount();
+
+    postFromBlock('REQUEST_SIGN_IN', {});
+
+    await new Promise((r) => setTimeout(r, 150));
+    expect(openLoginPopup).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #3685.

The same defect PR #3680 (`5c76917c24`) just fixed in `PageBlockHost.tsx`, on the model-slot host. That fix is now verified live in production; this is its twin.

## What broke

**Root cause — a stale closure.** Four `IframeHost` message handlers gate on the host being ready: `RESIZE_IFRAME`, `REQUEST_SIGN_IN`, `REQUEST_CONSENT` and `OPEN_BUZZ_PURCHASE`. Each closed over `status` from the render that registered it, with `status` in its effect's dependency array — so the LIVE listener only picks up a new status when React flushes that effect.

React writes the `data-block-ready` DOM attribute during the **COMMIT** (`IframeHost.tsx:2075`) but flushes **passive** effects in a LATER scheduler task. So there is a window in which the host publicly reports ready while the live handler still holds `status === 'loading'` and drops the message.

**Never hang.** The one gate carrying a `requestId` silently dropped a refused request. It was self-documenting — a comment reading *"(silently dropped)"* sat directly above `if (requestId == null || !raw) return;`. The block awaits `BUZZ_PURCHASE_RESULT` on a promise the SDK is understood to reject only at a 30s request timeout, so a drop cost the user's click plus half a minute of nothing.

> ⚠️ **That 30s figure is an INFERENCE carried over from #3680, not a measurement, and an earlier revision of this body asserted it as fact.** `@civitai/blocks-react` is **not a dependency of this repo and is not on disk** — 0 hits in `pnpm-lock.yaml` (positive control: `app-sdk` → 3 hits). The installed SDK is `@civitai/app-sdk@0.14.0`, which implements neither `OPEN_BUZZ_PURCHASE` nor any request timeout. So the specific "reject at 30s → resolve immediately" behaviour change **cannot be verified in-tree**; the reasoning stands, the citation does not. What IS verified here is host-side: the refused request is answered rather than dropped.

## Why the render-body ref placement is the fix

`statusRef.current = status` is assigned in the **render body**, not an effect — an effect here is precisely the deferral being fixed. A render-body assignment happens BEFORE the commit, so by the time anything observable says "ready", the mirror already is.

The four handlers read it through one shared `readGateStatus()`. Unlike `PageBlockHost`'s version this needs **no `'error' → 'no_token'` shim**: `IframeHost`'s local `Status` (`:101`) is byte-identical to the shared gates' `HostStatus` (`openBuzzPurchaseGate.ts:16`), so it is simply `() => statusRef.current`. It deliberately does **not** import `toHostGateStatus` / `pageBlockHostLogic` — the page host is a sibling surface, not a dependency of this one, and there is nothing to share but an identity function.

`status` then drops out of those four effects' dependency arrays, so they subscribe **once per mount** instead of tearing down and re-registering on every status transition. The window this fix is about cannot exist if the listener never needs replacing.

The concurrent-rendering safety note is ported from `PageBlockHost.tsx` because its reasoning transfers unchanged — including that the transient ref-vs-DOM disagreement runs in **both** directions. `loading → ready` is permissive (the point of the fix); `ready → fatal` (`BLOCK_ERROR{fatal:true}`) is restrictive, and `IframeHost` has that transition too. Refusing a spend on a host that has already decided it is broken is the safer side of that trade.

## The NACK, and why only one gate gets one

`resolveBuzzPurchaseRequest` returns null for **two** reasons, and they need different answers:

- **malformed payload** (no string requestId) — **UNREPLIABLE**. There is no id to thread a reply back on, so it can only be dropped, in silence.
- **host not ready** — **REPLIABLE**, and it must be answered: `send('BUZZ_PURCHASE_RESULT', { requestId, purchased: false })`, guarded on `typeof raw.requestId === 'string' && raw.requestId.length > 0`.

`purchased: false` is the same shape the modal's own `onClose` sends for a dismissed purchase, and (per the same #3680 inference above, not verifiable here) what the SDK reads as "no purchase happened". **The refusal is unchanged** — no modal opens, nothing is charged; the block just finds out now instead of in 30 seconds.

🔴 **The NACK is not an unconditional improvement, and the code now says so.** `usePostMessage` dedups INBOUND messages by `payload.requestId` for `DEDUP_WINDOW_MS = 5000` (`usePostMessage.ts:46`, logic `:155-173`) **before any handler runs**. A block that reacts to `purchased: false` by retrying with the **same** `requestId` inside five seconds is swallowed by the transport and hangs exactly as it did before. The NACK converts a guaranteed hang into a fast failure only for a block that retries with a FRESH id, or after the window. The dedup is a replay defence and is deliberately **not** changed here.

`RESIZE_IFRAME`, `REQUEST_SIGN_IN` and `REQUEST_CONSENT` get **no** NACK: all three are fire-and-forget with no requestId and no host→block reply message, so there is nothing to reply to and no promise to fail fast.

## One pre-existing bug fixed rather than inherited

The `OPEN_BUZZ_PURCHASE` effect reads `modelCtx.slotId` for FIN-1 attribution but did not list it in its deps. Unreachable today — `BlockSlot.tsx:51` re-keys the subtree on `(slotId, entityType, entityId)`, so a slotId change remounts the host rather than re-rendering it — but it is the same stale-closure family, and silently preserving it while rewriting that array would be inheriting a bug on purpose.

Attribution is otherwise untouched: `deriveScopeFromInstanceId` and the `mbi_*` / `bus_*` / `pdb_*` prefixes live on the success path, after the gate.

## Tests

New `IframeHostStatusGates.browser.test.tsx` mounts the **real** `IframeHost` and drives the **real** postMessage bridge. It is a new file rather than growth of the beacon-focused `IframeHost.browser.test.tsx` because it needs a mocked `openLoginPopup` and the dialogStore, and it mirrors `PageBlockHostWorkflow` / `PageBlockHostSignIn`.

`test/commitWindow.tsx`'s `onReadyAttributeWrite` generalised to `IframeHost` with **zero** changes — it patches `Element.prototype.setAttribute` and fires on the first `data-block-ready="true"` write by any element, synchronously on React's own stack.

Eleven guards (5 in the original round, 6 added after the audit — see the follow-up commit and the comment below):

1. **Commit-gap positive** (`OPEN_BUZZ_PURCHASE`) — posted from inside the commit window; asserts the modal opens, pinning the dialog id `block-buy-buzz-rq_gap` so it proves *this* post opened it.
2. **Pre-ready NACK** — no ready drive; zero dialogs AND a `BUZZ_PURCHASE_RESULT {purchased:false}` on the same requestId.
3. **No-requestId silent drop**, with a positive control that runs **first** and is driven all the way to an observable reply, so the zero is a measurement rather than a probe wired to nothing. 🔴 It counts only `BUZZ_PURCHASE_RESULT`, never `replies.received.length` — #3680 has a follow-up commit precisely because a total count drifted on unrelated host pushes and failed against a correct host.
4. **`REQUEST_SIGN_IN` commit-gap** — the guard that proves the ROOT-CAUSE half on its own. There is no NACK for this message, so guard 2 cannot mask a regression here.
5. **`REQUEST_SIGN_IN` pre-ready drop** — the negative half of 4; without it, "the handler is live" and "the handler always fires" are indistinguishable.
6. **`RESIZE_IFRAME` commit-gap** — asserts the iframe's inline height actually moves off `minHeight`, the user-visible effect rather than a mock call count.
7. **`RESIZE_IFRAME` pre-ready refusal** — the slot height does not move before the handshake, with a positive control (the same message after ready DOES move it).
8. **`REQUEST_CONSENT` commit-gap** — pins the modal's own `missingScopes` prop, not just `dialogs.length`, so any dialog from any source cannot satisfy it.
9. **`REQUEST_CONSENT` pre-ready refusal** — no pre-handshake permission prompt, with the same positive control.
10. **NACK predicate, `requestId.length > 0`** — an EMPTY-STRING id is a different branch from guard 3's missing-key case and must still be dropped in silence.
11. **NACK predicate, `typeof requestId === 'string'`** — 🔴 with **two** payloads, because the obvious one does not discriminate: `requestId: 5` leaves the mutant sending nothing either way (`(5).length` is `undefined`), while `requestId: ['rq']` has a truthy `.length` and makes the mutant reply with an id of a type the protocol does not have.

### Mutation matrix

🔴 **The first round of this PR shipped a matrix that covered the mechanism and not the handlers.** An adversarial audit found half the fix unguarded, and **re-measurement confirmed it**: reverting EITHER `RESIZE_IFRAME` or `REQUEST_CONSENT` to its exact pre-PR form left the whole component suite green at 380/33. Deleting either handler's gate outright survived too — a gap this body did not disclose. The six `n*` mutants below are the repair.

12 mutants × 2 runs, restored **byte-identically** (`cmp`) between each, every kill carrying **that guard's own assertion**:

| mutant | what it breaks | guard(s) killed | runs | assertion |
|---|---|---|---|---|
| `n1_resize_closed_over` | `RESIZE_IFRAME` reverts to closed-over `status` (+ deps) | resize commit-gap | 2/2 | `expected 200 to be 640` |
| `n2_consent_closed_over` | `REQUEST_CONSENT` reverts to closed-over `status` (+ deps) | consent commit-gap | 2/2 | `expected [] to have a length of 1 but got +0` |
| `n3_resize_always_ready` | delete the `RESIZE_IFRAME` status gate | resize pre-ready refusal | 2/2 | `expected 640 to be 200` |
| `n4_consent_always_ready` | force `resolveRequestConsent` to see `'ready'` | consent pre-ready refusal | 2/2 | `expected [...] to have a length of +0 but got 1` |
| `n5_nack_len_ge_zero` | `requestId.length > 0` → `>= 0` | empty-requestId drop | 2/2 | `expected [...] to have a length of 1 but got 2` |
| `n6_nack_no_typeof` | drop `typeof raw.requestId === 'string' &&` | non-string-requestId drop | 2/2 | `expected [...] to have a length of 1 but got 2` |
| `n6b_nack_no_typeof_safe` | same, made null-safe so it cannot die by throwing instead | non-string-requestId drop | 2/2 | `expected [...] to have a length of 1 but got 2` |
| `m1_ref_in_effect` | `statusRef.current = status` back into an effect | buzz / sign-in / **resize** / **consent** commit-gap (4) | 2/2 | `expected [] to have a length of 1`; `… to be called 1 times, but got 0`; `expected 200 to be 640` |
| `m2_no_nack` | delete the NACK `send` | pre-ready NACK + **both** new NACK-predicate guards' positive controls (3) | 2/2 | `Error: no NACK yet`; `expected [] to have a length of 1` ×2 |
| `m3_signin_closed_over` | `REQUEST_SIGN_IN` reverts to closed-over `status` | sign-in commit-gap | 2/2 | `expected "vi.fn()" to be called 1 times, but got 0` |
| `m4_nack_too_wide` | NACK widened to answer the UNREPLIABLE case | no-requestId + **empty** + **non-string** drops (3) | 2/2 | `expected [...] to have a length of 1 but got 2` / `but got 3` |
| `m5_buzz_closed_over` | `OPEN_BUZZ_PURCHASE` reverts to closed-over `status` | buzz commit-gap | 2/2 | `expected [] to have a length of 1` |

Deterministic — no mutant survived either run, and run 2 reproduced run 1 exactly. Note `n6b`: `n6` as literally stated by the audit (`raw.requestId.length`) ALSO throws a `TypeError` on guard 3's no-requestId payload, which would muddy attribution; `n6b` is the null-safe form, and guard 11 is the sole killer of both.

**The original five were re-run after this round's changes** (an audit fix resets the verification gate) and are unchanged except that three of them now die to MORE guards — the new guards' positive controls are themselves sensitive to the mechanism.

#### Harness change

`startReadyDrive`'s interval goes **10 ms → 40 ms**. `usePostMessage` admits 30 inbound messages per 1000 ms among types that have a subscriber (`usePostMessage.ts:44-45,181`); at 10 ms the drive asked for **100/s** against that budget. It worked because the decisive post lands in the first few ticks — i.e. it was under the limit by luck of timing rather than by construction, and each guard added here narrows that margin. 40 ms is 25/s with headroom for the commit-window post. The full 12-mutant matrix above was run **after** this change.

### Gate

- **386/386** AppBlocks browser tests (33 files), up from 380 — read from the output, not the exit code. The status-gates file itself reports **11 tests**.
- Unit project (`vitest --project unit`): **12,942 passed / 7 failed / 1 skipped** (863 files). 🔴 The 7 failures are **pre-existing and unrelated** — every one is `TypeError: Cannot read properties of undefined (reading 'clear'/'setItem')` in `src/components/AppBlocks/__tests__/hiddenBlocks.test.ts`, i.e. `window.localStorage` is undefined in that file's environment. **Control run:** reverting both of this round's files to their parent-commit versions reproduces all 7 identically, and neither file is in that test's import graph. **CI's own `Unit tests` check is SUCCESS on this commit** (`985ea3d`), so this is a local-host artifact — the lockfile and installed `happy-dom` agree at 20.9.0, so it is not a version mismatch.
- Typecheck: **0 errors**, with a positive control — `tsc --listFiles` confirms the test file is in the program, and a deliberately injected `string`-to-`number` error IS reported (`error TS2322`), so the clean run is a measurement.
- ESLint `--max-warnings=0`: 0 errors, 0 warnings on **both** touched files, instrument validated (an injected `var` reports `rc=1` / `no-var`; note `no-console` and `import/first` are NOT enabled in this config, so they are useless as controls).
- Prettier: the new file is clean (CI blocks on added files). `IframeHost.tsx` is **not** reformatted wholesale — it is already Prettier-dirty on `main` (CI is report-only for modified files), and this change adds **zero** new violations: 7 formatting hunks before, 7 after.

## What these tests CANNOT prove

- **That a real deployed block hits the window.** #3680 was explicit that this was inferred, not observed, and the same holds here: no SDK code path auto-posts a gated request on ready — all of these are `useCallback`s the app invokes — so reaching the window needs app code that calls one in the same turn it observes ready. No such block was observed. This is a latent defect being closed, not a reported outage.
- **There is no live-repro path for `IframeHost` at all.** `/apps/dev` renders `PageBlockHost` only, so unlike #3680 there was no manual browser reproduction available even in principle. The evidence here is the mutation matrix, not a live click path.
- ~~**`RESIZE_IFRAME` and `REQUEST_CONSENT` have no dedicated commit-gap guard.**~~ **CLOSED** — that residual was understated and is now fixed. It was not only a per-handler revert that went uncaught: **deleting either handler's status gate outright also survived the whole suite**, so a pre-handshake block could drive the slot height or pop the permission modal with nothing going red. `REQUEST_CONSENT` additionally had **zero** browser coverage against `IframeHost` anywhere in the tree. Guards 6–9 cover both directions for both handlers; `n1`–`n4` above are the proof.
- **The component suite does not run in GitHub Actions.** `lint.yml` runs typecheck, unit, packages and apps — no Chromium. These guards are locally-verified only.
- **The SDK-side half of "never hang" is unverifiable in this repo** — see the callout in *What broke*. `@civitai/blocks-react` is not installed here, so neither the 30s timeout nor `useBuzzPurchase`'s reading of `purchased: false` was checked against real code. Only the host side is measured.
- **A block that retries a refused purchase with the SAME `requestId` inside 5 s still hangs**, swallowed by `usePostMessage`'s inbound dedup before any handler runs. Documented in the code rather than fixed; changing the dedup is a wider change than this PR earns.

Scope was deliberately held to IframeHost's four status gates. The general "every repliable gate answers on the same requestId" parity guard is a separate project — it goes red on ~7 pre-existing sites across both hosts — and `hostHandlerParity.ts` was not extended (its own comment says its `reply` field is "DOCUMENTATION ONLY — NOTHING ENFORCES THIS STRING", and its runtime half is a grep that structurally cannot see this property).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

