### PR TITLE
feat(moderator): XGuard label lab

### DIFF
--- a/apps/moderator/.env.example
+++ b/apps/moderator/.env.example
@@ -30,6 +30,14 @@ WEBHOOK_TOKEN=
 # Point write at the primary and read at a replica (use the same URL for both if you have no replica).
 # `sslmode=no-verify` is forced in code for the cnpg pooler's self-signed cert, so the URLs here don't need it.
 DATABASE_URL=postgresql://user:pass@localhost:5432/civitai
+# The MODERATOR database - moderation data that has never lived in Civitai's Postgres, plus the
+# XGuard label lab tables. Separate instance, no foreign keys into the main database.
+# Prod: internal-tools-db-rw.cnpg-database.svc.cluster.local:5432/internal_tools (via bastion)
+# Local: docker compose -f xguard-lab/docker-compose.yml up -d
+# Shared with the moderator app's own tables, so it deliberately carries NO search_path - setting
+# one here would silently reorder name resolution for every other consumer.
+MODERATOR_DATABASE_URL=postgres://xguard:xguard@localhost:5433/xguard_lab
+
 DATABASE_REPLICA_URL=postgresql://user:pass@localhost:5432/civitai
 
 # --- Moderator database (single read-write Kysely client, src/lib/server/moderator-db.ts) ---

--- a/apps/moderator/src/lib/eval-metrics.ts
+++ b/apps/moderator/src/lib/eval-metrics.ts
@@ -1,0 +1,22 @@
+/**
+ * Derive precision and recall from the stored counters rather than reading the columns.
+ *
+ * `eval_run.precision` / `.recall` were written as `0` before those columns were made nullable, so
+ * early runs render "P 0.000" — which reads as "the policy got everything wrong" when it means
+ * "there was nothing to measure". Deriving is correct for those rows and for every future one, and
+ * it is one fewer thing to remember to backfill.
+ */
+export type Counters = { tp: number; fp: number; fn: number };
+
+export function precisionOf(r: Counters): number | null {
+  return r.tp + r.fp === 0 ? null : r.tp / (r.tp + r.fp);
+}
+
+export function recallOf(r: Counters): number | null {
+  return r.tp + r.fn === 0 ? null : r.tp / (r.tp + r.fn);
+}
+
+/** `n/a`, never `0.000`. An undefined metric is not a bad score. */
+export function fmtMetric(n: number | null): string {
+  return n === null ? 'n/a' : n.toFixed(3);
+}

--- a/apps/moderator/src/lib/highlight-terms.ts
+++ b/apps/moderator/src/lib/highlight-terms.ts
@@ -1,0 +1,101 @@
+/**
+ * Highlighting for the parts of a prompt that matter, driven by rows in `label_term`.
+ *
+ * These do NOT decide anything. The verdict comes from the rater and the human; this is purely
+ * "here is where to look" in a prompt that can run hundreds of tokens with the deciding word buried
+ * in a non-English tail or a LoRA filename.
+ *
+ * The terms live in the database, not here. Which vocabulary matters depends on the label being
+ * reviewed, and the lists get edited constantly as tuning surfaces spellings moderators miss - a
+ * constant in the repo makes every one of those edits a deploy. Seeded by
+ * `xguard-lab/seed-terms.ts`.
+ *
+ * The main app has its own hardcoded copy at `src/shared/constants/scanner-label-highlight-terms.ts`
+ * driving Briant's regex auditor. That one highlights what the REGEX FILTER matched and injects
+ * HTML; this one highlights label vocabulary and emits offsets. They are different tools.
+ */
+export type TermKind = 'trigger' | 'counter' | 'soft';
+
+/** A row from `label_term`, as handed to the client by a page load. */
+export type LabelTerm = { label: string; term: string; kind: TermKind };
+
+export type TermSpan = { start: number; end: number; kind: TermKind; label?: string };
+
+// Stated adult ages need a pattern, not a word list. Bare "18".."30" matched "steps 20" and
+// "cfg 25", rendering sampler settings green as evidence against a youth reading, while "18yo"
+// matched nothing at all - inverted, on a page whose whole job is calibrating an age label.
+const ADULT_AGE_PATTERNS = [
+  /(?<![a-zA-Z0-9])(?:1[89]|[2-9]\d)\s*(?:\+|yo\b|y\.o\.?|yrs?\b|years?[\s-]*old|year[\s-]*old)/gi,
+  /(?<![a-zA-Z0-9])age\s*[:=]?\s*(?:1[89]|[2-9]\d)(?![a-zA-Z0-9])/gi,
+];
+
+const ASCII = /^[\x20-\x7e]+$/;
+
+function escape(term: string): string {
+  return term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Zero-width alphanumeric boundaries, so "ass" does not match inside "grass" and "cub" does not
+ * match inside "incubus" - the exact substring-matching failure that makes the current regex filter
+ * so annoying. CJK and Cyrillic terms get no boundary, because they do not sit between word
+ * characters the way Latin ones do.
+ */
+function patternFor(term: string): RegExp {
+  const body = escape(term);
+  return ASCII.test(term)
+    ? new RegExp(`(?<![a-zA-Z0-9])${body}(?![a-zA-Z0-9])`, 'gi')
+    : new RegExp(body, 'gi');
+}
+
+type Compiled = { kind: TermKind; label: string; re: RegExp };
+
+const compiledCache = new WeakMap<object, Compiled[]>();
+
+function compile(terms: LabelTerm[]): Compiled[] {
+  const cached = compiledCache.get(terms);
+  if (cached) return cached;
+  // Longest first, so "little girl" claims the span over "girl".
+  const built = [...terms]
+    .sort((a, b) => b.term.length - a.term.length)
+    .map((t) => ({ kind: t.kind, label: t.label, re: patternFor(t.term) }));
+  compiledCache.set(terms, built);
+  return built;
+}
+
+/** Non-overlapping term spans, longest match winning where two terms cover the same text. */
+export function findTermSpans(text: string, terms: LabelTerm[]): TermSpan[] {
+  if (!text || terms.length === 0) return [];
+  const taken: TermSpan[] = [];
+
+  // Age patterns first, so a stated age claims the span over any weaker term overlapping it.
+  for (const re of ADULT_AGE_PATTERNS) {
+    re.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) {
+      taken.push({ start: m.index, end: m.index + m[0].length, kind: 'counter' });
+    }
+  }
+
+  for (const { kind, label, re } of compile(terms)) {
+    re.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) {
+      const start = m.index;
+      const end = start + m[0].length;
+      if (!taken.some((s) => start < s.end && end > s.start)) taken.push({ start, end, kind, label });
+      if (m[0].length === 0) re.lastIndex++;
+    }
+  }
+
+  return taken.sort((a, b) => a.start - b.start);
+}
+
+// Colour by what the term ARGUES, not by which label owns it - a reviewer needs to see both pulls
+// at a glance, and the label name is available on the span for a tooltip. The theme only defines
+// blue / chart / dark / green / red, and blue is reserved for the rater's citation ring.
+export const TERM_STYLES: Record<TermKind, { className: string; label: string }> = {
+  trigger: { className: 'bg-red-8/45 text-red-1', label: 'argues for' },
+  counter: { className: 'bg-green-8/35 text-green-2', label: 'argues against' },
+  soft: { className: 'bg-dark-3/40 text-dark-0', label: 'weak signal' },
+};

--- a/apps/moderator/src/lib/server/access.ts
+++ b/apps/moderator/src/lib/server/access.ts
@@ -89,6 +89,10 @@ export const NAVIGATION: NavLink[] = [
   },
   { path: '/comics-review', label: 'Comics Review' },
   { path: '/blocklists', label: 'Blocklists' },
+  // One grant covers the whole lab. Its sub-pages (labels, runs, docs) resolve here by prefix rather than
+  // being listed: they are steps of one loop, and granting a reviewer the queue but not the run history
+  // would hide the numbers their review produces.
+  { path: '/xguard', label: 'XGuard Lab' },
   { path: '/users', label: 'Users' },
   { path: '/admin', label: 'Permissions' },
   { path: '/page-visits', label: 'Page Usage' },

--- a/apps/moderator/src/lib/server/xguard-lab.ts
+++ b/apps/moderator/src/lib/server/xguard-lab.ts
@@ -1,0 +1,139 @@
+import { createKyselyClients, type Generated } from '@civitai/db/kysely';
+import { env } from '$env/dynamic/private';
+
+// The XGuard label lab's tables, in the MODERATOR database - separate from Civitai's Postgres,
+// with no foreign keys into it.
+//
+// MERGE NOTE: PR #3573 adds `moderator-db.ts` exposing `getModeratorDb()` over this same
+// connection string, plus a `ModeratorDB` type. When that lands, fold `LabDB` into `ModeratorDB`
+// and delete this module - one database should not have two clients. Kept separate only because
+// that PR is unmerged and this branch cannot import a file it does not have.
+//
+// Schema lives in apps/moderator/xguard-lab/schema.sql. Kept as a hand-written interface rather
+// than generated types because it is small and changes with the label work, not with the app.
+
+export interface LabDB {
+  sample: {
+    id: Generated<string>;
+    prompt_hash: string | null;
+    source: string;
+    batch: string;
+    user_id: number | null;
+    positive_prompt: string;
+    negative_prompt: string | null;
+    live_scores: Record<string, number> | null;
+    prompt_created_at: Date | null;
+    created_at: Generated<Date>;
+  };
+  machine_judgement: {
+    id: Generated<string>;
+    sample_id: string;
+    label: string;
+    source: 'xguard' | 'ai';
+    model: string | null;
+    score: number | null;
+    verdict: boolean;
+    reason: string | null;
+    highlights: { positive?: Span[]; negative?: Span[] } | null;
+    policy_id: string | null;
+    created_at: Generated<Date>;
+  };
+  human_judgement: {
+    id: Generated<string>;
+    sample_id: string;
+    label: string;
+    reviewed_judgement_id: string | null;
+    agreed: boolean | null;
+    verdict: boolean;
+    note: string | null;
+    reviewer_id: number;
+    duration_ms: number | null;
+    // Null means the judgement counts. Non-null retires it without deleting the evidence.
+    excluded_reason: string | null;
+    created_at: Generated<Date>;
+  };
+  eval_run: {
+    id: Generated<string>;
+    label: string;
+    policy_id: string | null;
+    policy_label: string;
+    threshold: number;
+    batch: string | null;
+    status: Generated<string>;
+    total: Generated<number>;
+    scored: Generated<number>;
+    errors: Generated<number>;
+    tp: Generated<number>;
+    fp: Generated<number>;
+    tn: Generated<number>;
+    fn: Generated<number>;
+    precision: number | null;
+    recall: number | null;
+    f1: number | null;
+    note: string | null;
+    started_at: Generated<Date>;
+    finished_at: Date | null;
+  };
+  eval_result: {
+    id: Generated<string>;
+    run_id: string;
+    sample_id: string;
+    score: number | null;
+    predicted: boolean | null;
+    expected: boolean;
+    bucket: string | null;
+    reason: string | null;
+    error: string | null;
+  };
+  label_def: {
+    name: string;
+    description: string;
+    status: Generated<string>;
+    created_at: Generated<Date>;
+  };
+  label_term: {
+    id: Generated<string>;
+    label: string;
+    term: string;
+    kind: 'trigger' | 'counter' | 'soft';
+    note: string | null;
+    created_at: Generated<Date>;
+  };
+  label_policy: {
+    id: Generated<string>;
+    label: string;
+    version: number;
+    policy: string;
+    threshold: number;
+    action: Generated<string>;
+    note: string | null;
+    created_at: Generated<Date>;
+  };
+}
+
+export type Span = { start: number; end: number; text: string };
+
+function labUrl(): string {
+  const url = env.MODERATOR_DATABASE_URL;
+  if (!url) throw new Error('MODERATOR_DATABASE_URL is not configured');
+  return url;
+}
+
+// `sslNoVerify` turns SSL ON while skipping cert verification, which is what the cnpg cluster
+// needs and what a plain local docker Postgres rejects outright ("The server does not support SSL
+// connections"). Decide from the host so the same code works in both places.
+function isLocalHost(url: string): boolean {
+  try {
+    const { hostname } = new URL(url);
+    return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+  } catch {
+    return false;
+  }
+}
+
+// No replica; reads and writes both go to the single instance.
+export const { dbWrite: labDb } = createKyselyClients<LabDB>({
+  connectionString: labUrl(),
+  replicaConnectionString: labUrl(),
+  sslNoVerify: !isLocalHost(labUrl()),
+});

--- a/apps/moderator/src/routes/xguard/+page.server.ts
+++ b/apps/moderator/src/routes/xguard/+page.server.ts
@@ -1,0 +1,235 @@
+import { fail } from '@sveltejs/kit';
+import type { Actions, PageServerLoad } from './$types';
+import { requireAccess } from '$lib/server/access';
+import { labDb } from '$lib/server/xguard-lab';
+
+// Review queue for the XGuard label lab. One item is one (sample, label) pair the current
+// reviewer has not judged yet, shown with whatever the AI rater decided so the reviewer only
+// has to agree or disagree.
+//
+// `?sample=` pins one pair instead of taking the head of the queue, which is how both "undo the
+// last one" and a deep link out of an evaluation's FP list arrive here.
+
+// Skips live in the URL, not the database. A skip means "not now", so it has to survive an
+// invalidate and still be gone by the next session - a human_judgement row would make it permanent.
+const MAX_SKIPS = 100;
+
+// These ids reach a bigint column. Anything non-numeric makes Postgres raise `invalid input syntax
+// for type bigint`, which is a 500 on a page whose state lives in a hand-editable URL - so junk is
+// dropped rather than surfaced as an error.
+function asId(raw: string | null): string | null {
+  return raw && /^\d+$/.test(raw) ? raw : null;
+}
+
+function parseSkips(raw: string | null): string[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .filter((v) => /^\d+$/.test(v))
+    .slice(-MAX_SKIPS);
+}
+
+export const load: PageServerLoad = async ({ locals, url }) => {
+  requireAccess(locals.user, url.pathname);
+
+  const label = url.searchParams.get('label') ?? 'AgeAsserted';
+  const pinnedSampleId = asId(url.searchParams.get('sample'));
+  const skipped = parseSkips(url.searchParams.get('skip'));
+  const reviewerId = locals.user?.id ?? 0;
+
+  const selection = [
+    'm.id as judgementId',
+    'm.verdict as aiVerdict',
+    'm.reason as aiReason',
+    'm.highlights',
+    'm.model',
+    's.id as sampleId',
+    's.positive_prompt as positivePrompt',
+    's.negative_prompt as negativePrompt',
+    's.live_scores as liveScores',
+    's.batch',
+  ] as const;
+
+  // Independent queries, so they go out together. Sequential awaits cost a full round trip each,
+  // which is invisible against a local lab DB and very much not once this moves to the cluster.
+  const labelsQuery = labDb
+    .selectFrom('label_def')
+    .select(['name', 'description'])
+    .orderBy('name')
+    .execute();
+
+  let itemQuery = labDb
+    .selectFrom('machine_judgement as m')
+    .innerJoin('sample as s', 's.id', 'm.sample_id')
+    .select([...selection])
+    .where('m.label', '=', label)
+    .where('m.source', '=', 'ai');
+
+  if (pinnedSampleId) {
+    itemQuery = itemQuery.where('m.sample_id', '=', pinnedSampleId);
+  } else {
+    itemQuery = itemQuery
+      .where(({ not, exists, selectFrom }) =>
+        not(
+          exists(
+            selectFrom('human_judgement as h')
+              .select('h.id')
+              .whereRef('h.sample_id', '=', 'm.sample_id')
+              .where('h.label', '=', label)
+              .where('h.reviewer_id', '=', reviewerId)
+          )
+        )
+      )
+      // Rater-positives first. Most of a stratified sample is uncontroversially negative, and an
+      // evaluation cannot measure recall until some positives have been confirmed - so the queue
+      // spends a reviewer's attention where it actually changes a number.
+      .orderBy('m.verdict', 'desc')
+      .orderBy('m.sample_id');
+    if (skipped.length) itemQuery = itemQuery.where('m.sample_id', 'not in', skipped);
+  }
+
+  const countsQuery = labDb
+    .selectFrom('machine_judgement as m')
+    .select(({ fn }) => [fn.countAll<string>().as('rated')])
+    .where('m.label', '=', label)
+    .where('m.source', '=', 'ai')
+    .executeTakeFirst();
+
+  const reviewedQuery = labDb
+    .selectFrom('human_judgement')
+    .select(({ fn }) => [
+      fn.countAll<string>().as('total'),
+      fn.count<string>('id').filterWhere('agreed', '=', false).as('disagreed'),
+      fn.count<string>('id').filterWhere('verdict', '=', true).as('positives'),
+    ])
+    .where('label', '=', label)
+    .where('reviewer_id', '=', reviewerId)
+    .where('excluded_reason', 'is', null)
+    .executeTakeFirst();
+
+  // Confirmed positives across every reviewer, because that is what makes recall measurable - one
+  // reviewer's own tally does not answer "can this label be evaluated yet".
+  const labelPositivesQuery = labDb
+    .selectFrom('human_judgement')
+    .select(({ fn }) => [fn.count<string>('sample_id').distinct().as('positives')])
+    .where('label', '=', label)
+    .where('verdict', '=', true)
+    .where('excluded_reason', 'is', null)
+    .executeTakeFirst();
+
+  const lastReviewedQuery = labDb
+    .selectFrom('human_judgement')
+    .select(['sample_id as sampleId'])
+    .where('label', '=', label)
+    .where('reviewer_id', '=', reviewerId)
+    .where('excluded_reason', 'is', null)
+    .orderBy('created_at', 'desc')
+    .orderBy('id', 'desc')
+    .limit(1)
+    .executeTakeFirst();
+
+  const existingQuery = pinnedSampleId
+    ? labDb
+        .selectFrom('human_judgement')
+        .select(['agreed', 'verdict', 'note'])
+        .where('label', '=', label)
+        .where('reviewer_id', '=', reviewerId)
+        .where('sample_id', '=', pinnedSampleId)
+        .executeTakeFirst()
+    : Promise.resolve(undefined);
+
+  const [labels, item, counts, reviewed, labelPositives, lastReviewed, existing] =
+    await Promise.all([
+      labelsQuery,
+      itemQuery.limit(1).executeTakeFirst(),
+      countsQuery,
+      reviewedQuery,
+      labelPositivesQuery,
+      lastReviewedQuery,
+      existingQuery,
+    ]);
+
+  // Highlight vocabulary for this label. Lives in `label_term` rather than a constant so it can be
+  // edited per label without a deploy.
+  const terms = await labDb
+    .selectFrom('label_term')
+    .select(['label', 'term', 'kind'])
+    .where('label', '=', label)
+    .execute();
+
+  // @civitai/db registers a process-global INT8 parser, so bigint ids arrive as JS numbers even
+  // though LabDB types them as strings. Normalise here or every `id === param` comparison on the
+  // client silently never matches.
+  const normalised = item
+    ? { ...item, sampleId: String(item.sampleId), judgementId: String(item.judgementId) }
+    : null;
+
+  return {
+    label,
+    labels,
+    terms,
+    item: normalised,
+    pinned: Boolean(pinnedSampleId),
+    existing: existing ?? null,
+    skipped,
+    lastReviewedSampleId: lastReviewed ? String(lastReviewed.sampleId) : null,
+    progress: {
+      rated: Number(counts?.rated ?? 0),
+      reviewed: Number(reviewed?.total ?? 0),
+      disagreed: Number(reviewed?.disagreed ?? 0),
+      myPositives: Number(reviewed?.positives ?? 0),
+      labelPositives: Number(labelPositives?.positives ?? 0),
+    },
+  };
+};
+
+export const actions: Actions = {
+  judge: async ({ request, locals, url }) => {
+    requireAccess(locals.user, url.pathname);
+    const reviewerId = locals.user?.id;
+    if (!reviewerId) return fail(401, { message: 'Not signed in' });
+
+    const form = await request.formData();
+    const sampleId = asId(String(form.get('sampleId') ?? ''));
+    const label = String(form.get('label') ?? '');
+    const judgementId = asId(String(form.get('judgementId') ?? ''));
+    const agreed = form.get('agreed') === 'true';
+    const aiVerdict = form.get('aiVerdict') === 'true';
+    const durationMs = Number(form.get('durationMs') ?? 0) || null;
+    const note = String(form.get('note') ?? '').trim() || null;
+
+    if (!sampleId || !label) return fail(400, { message: 'Missing sample or label' });
+
+    await labDb
+      .insertInto('human_judgement')
+      .values({
+        sample_id: sampleId,
+        label,
+        reviewed_judgement_id: judgementId || null,
+        agreed,
+        // Disagreeing means the opposite of what the rater said. Stored explicitly so the
+        // training set reads off one column instead of a join and a conditional.
+        verdict: agreed ? aiVerdict : !aiVerdict,
+        note,
+        reviewer_id: reviewerId,
+        duration_ms: durationMs,
+      })
+      .onConflict((oc) =>
+        oc.columns(['sample_id', 'label', 'reviewer_id']).doUpdateSet({
+          // Re-reviewing a retired judgement makes it valid again.
+          excluded_reason: null,
+          agreed,
+          verdict: agreed ? aiVerdict : !aiVerdict,
+          reviewed_judgement_id: judgementId || null,
+          note,
+          duration_ms: durationMs,
+          // The row holds one current verdict per reviewer, so a re-review replaces the whole
+          // record - including when it happened, which is what "go back one" reads to find it.
+          created_at: new Date(),
+        })
+      )
+      .execute();
+
+    return { success: true };
+  },
+};

--- a/apps/moderator/src/routes/xguard/+page.svelte
+++ b/apps/moderator/src/routes/xguard/+page.svelte
@@ -1,0 +1,378 @@
+<script lang="ts">
+  import { enhance } from '$app/forms';
+  import { goto, invalidateAll } from '$app/navigation';
+  import type { PageData } from './$types';
+  import type { Span } from '$lib/server/xguard-lab';
+  import { findTermSpans, TERM_STYLES } from '$lib/highlight-terms';
+
+  let { data }: { data: PageData } = $props();
+
+  let shownAt = $state(Date.now());
+  let submitting = $state(false);
+  let form = $state<HTMLFormElement>();
+  let note = $state('');
+
+  // Reset the timer whenever a new item lands, so duration_ms measures time on THIS item.
+  // A reviewer averaging a couple of seconds is rubber-stamping, and that only shows up if
+  // the number is honest.
+  //
+  // Guarded on the id rather than re-running on every `data` change: an unguarded effect would
+  // wipe a half-typed note each time the page reloaded for an unrelated reason.
+  let shownFor = $state<string | null>(null);
+  $effect(() => {
+    const id = data.item?.sampleId ?? null;
+    if (shownFor === id) return;
+    shownFor = id;
+    shownAt = Date.now();
+    note = data.existing?.note ?? '';
+  });
+
+  function queryFor(params: Record<string, string | null>): string {
+    const q = new URLSearchParams();
+    q.set('label', data.label);
+    if (data.skipped.length) q.set('skip', data.skipped.join(','));
+    for (const [k, v] of Object.entries(params)) {
+      if (v === null) q.delete(k);
+      else q.set(k, v);
+    }
+    return `/xguard?${q.toString()}`;
+  }
+
+  const queueHref = $derived(queryFor({ sample: null }));
+  const undoHref = $derived(
+    data.lastReviewedSampleId ? queryFor({ sample: data.lastReviewedSampleId }) : null
+  );
+
+  type Piece = { text: string; className: string; cited: boolean };
+
+  // Two independent sources of highlight, merged into one pass over the text:
+  //
+  //   term spans  - vocabulary we care about, colour-coded by kind. Always shown, so the reviewer
+  //                 can see what the rater DIDN'T cite as easily as what it did.
+  //   rater spans - the exact substrings the model said it judged on. Drawn as a ring on top of
+  //                 whatever colour is underneath, so "the model saw this" and "this is a youth
+  //                 term" are separate facts and either can be present without the other.
+  //
+  // A rater span with no term colour under it means the model reasoned off something not in our
+  // lists - worth noticing. A red term with no ring means the model ignored a word we flag.
+  function pieces(text: string, raterSpans: Span[] | undefined): Piece[] {
+    if (!text) return [];
+
+    const terms = findTermSpans(text, data.terms);
+    const cited = (raterSpans ?? []).filter((s) => s.start < s.end);
+
+    // Every offset where the styling could change.
+    const cuts = new Set<number>([0, text.length]);
+    for (const s of [...terms, ...cited]) {
+      cuts.add(Math.max(0, s.start));
+      cuts.add(Math.min(text.length, s.end));
+    }
+    const points = [...cuts].sort((a, b) => a - b);
+
+    const out: Piece[] = [];
+    for (let i = 0; i < points.length - 1; i++) {
+      const [from, to] = [points[i], points[i + 1]];
+      if (from >= to) continue;
+      const term = terms.find((s) => s.start <= from && s.end >= to);
+      const isCited = cited.some((s) => s.start <= from && s.end >= to);
+      const className = term ? TERM_STYLES[term.kind].className : '';
+      const piece = { text: text.slice(from, to), className, cited: isCited };
+      // Merge into the previous run when nothing changed, so the DOM stays small on long prompts.
+      const prev = out[out.length - 1];
+      if (prev && prev.className === className && prev.cited === isCited) prev.text += piece.text;
+      else out.push(piece);
+    }
+    return out;
+  }
+
+  const positivePieces = $derived(
+    pieces(data.item?.positivePrompt ?? '', data.item?.highlights?.positive)
+  );
+  const negativePieces = $derived(
+    pieces(data.item?.negativePrompt ?? '', data.item?.highlights?.negative)
+  );
+
+  // Set at click time and read in enhance's submit hook. Do NOT route these through hidden
+  // inputs: Svelte 5 flushes DOM writes in a microtask while requestSubmit() dispatches submit
+  // synchronously, so the form would carry the PREVIOUS click's answer. That inverted real
+  // judgements before it was caught.
+  let pendingAgreed = false;
+  let pendingDuration = 0;
+
+  function submit(agreed: boolean) {
+    if (submitting || !data.item) return;
+    pendingAgreed = agreed;
+    pendingDuration = Date.now() - shownAt;
+    submitting = true;
+    form?.requestSubmit();
+  }
+
+  // A skip is deliberately not a verdict. Recording one would remove the item from the queue for
+  // good; parking it in the URL means it comes back the next time the queue is opened fresh.
+  function skip() {
+    if (submitting || !data.item) return;
+    const next = [...data.skipped.filter((id) => id !== data.item?.sampleId), data.item.sampleId];
+    const q = new URLSearchParams({ label: data.label, skip: next.join(',') });
+    void goto(`/xguard?${q.toString()}`);
+  }
+
+  function onKey(e: KeyboardEvent) {
+    if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+    // Ctrl+A is select-all and Ctrl/Cmd+D is bookmark. Without this, either one silently writes a
+    // judgement to the ground-truth table.
+    if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return;
+    if (e.key === 'a') {
+      e.preventDefault();
+      submit(true);
+    }
+    if (e.key === 'd') {
+      e.preventDefault();
+      submit(false);
+    }
+    if (e.key === 's' && !data.pinned) {
+      e.preventDefault();
+      skip();
+    }
+  }
+</script>
+
+<svelte:window onkeydown={onKey} />
+
+<header class="page-header">
+  <h1>XGuard label lab</h1>
+  <p>
+    Agree or disagree with the rating. <kbd>A</kbd> agree, <kbd>D</kbd> disagree, <kbd>S</kbd> skip.
+  </p>
+</header>
+
+<div class="mb-4 flex flex-wrap items-center gap-2">
+  <a href="/xguard/labels" class="rounded bg-dark-7 px-2.5 py-1 text-xs text-dark-2 hover:text-dark-0">
+    All labels
+  </a>
+  <a
+    href="/xguard/runs?label={data.label}"
+    class="rounded bg-dark-7 px-2.5 py-1 text-xs text-dark-2 hover:text-dark-0"
+  >
+    Runs
+  </a>
+  {#each data.labels as l (l.name)}
+    <a
+      href="/xguard?label={l.name}"
+      class="rounded px-2.5 py-1 text-xs font-medium {l.name === data.label
+        ? 'bg-blue-8/25 text-blue-3'
+        : 'bg-dark-7 text-dark-2 hover:text-dark-0'}"
+      title={l.description}
+    >
+      {l.name}
+    </a>
+  {/each}
+  <span class="ml-auto text-xs text-dark-3">
+    {data.progress.reviewed} reviewed of {data.progress.rated} rated
+    {#if data.progress.reviewed > 0}
+      &middot; disagreed on {Math.round((data.progress.disagreed / data.progress.reviewed) * 100)}%
+    {/if}
+  </span>
+</div>
+
+<!-- Confirmed positives, not total reviewed, is what decides whether recall can be measured at all.
+     A reviewer can clear 200 items and still leave the label unevaluable. -->
+<div class="mb-4 flex flex-wrap items-center gap-2 text-xs">
+  <span
+    class="rounded px-2.5 py-1 {data.progress.labelPositives === 0
+      ? 'bg-red-8/20 text-red-3'
+      : 'bg-green-8/20 text-green-3'}"
+  >
+    {data.progress.labelPositives} confirmed positive{data.progress.labelPositives === 1 ? '' : 's'}
+    {#if data.progress.labelPositives === 0}
+      &middot; recall stays unmeasurable until there is at least one
+    {/if}
+  </span>
+  <span class="text-dark-3">{data.progress.myPositives} of them yours</span>
+  {#if data.skipped.length}
+    <a href={queryFor({ skip: null, sample: null })} class="text-blue-4 hover:text-blue-3">
+      {data.skipped.length} skipped this session &middot; bring them back
+    </a>
+  {/if}
+</div>
+
+{#if data.pinned}
+  <div class="mb-4 flex flex-wrap items-center gap-3 rounded-lg bg-dark-7 px-3 py-2 text-xs">
+    <span class="text-dark-1">
+      Revisiting one sample.
+      {#if data.existing}
+        You said <strong class="text-dark-0">{data.existing.agreed ? 'agree' : 'disagree'}</strong>
+        &rarr; verdict <strong class="text-dark-0">{data.existing.verdict ? 'yes' : 'no'}</strong>.
+      {:else}
+        You have not judged this one yet.
+      {/if}
+    </span>
+    <a href={queueHref} class="ml-auto text-blue-4 hover:text-blue-3">Back to the queue &rarr;</a>
+  </div>
+{/if}
+
+{#if !data.item}
+  <section class="rounded-xl border border-dark-4 bg-dark-6 p-8 text-center">
+    <p class="text-sm text-dark-2">
+      Nothing left to review for <strong class="text-dark-0">{data.label}</strong>.
+    </p>
+    {#if data.skipped.length}
+      <a
+        href={queryFor({ skip: null, sample: null })}
+        class="mt-2 inline-block text-sm text-blue-4 hover:text-blue-3"
+      >
+        Except {data.skipped.length} you skipped &mdash; bring them back
+      </a>
+    {/if}
+  </section>
+{:else}
+  <section class="grid gap-4 lg:grid-cols-[1fr_20rem]">
+    <div class="rounded-xl border border-dark-4 bg-dark-6 p-5">
+      <div class="mb-1.5 text-xs font-medium uppercase tracking-wider text-dark-2">Positive prompt</div>
+      <p class="whitespace-pre-wrap break-words font-mono text-sm leading-relaxed text-dark-0">
+        {#each positivePieces as piece, i (i)}{#if piece.className || piece.cited}<mark
+            class="rounded px-0.5 {piece.className} {piece.cited
+              ? 'ring-1 ring-blue-4/70'
+              : ''}">{piece.text}</mark
+          >{:else}{piece.text}{/if}{/each}
+      </p>
+
+      <div class="mt-4 flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-dark-5 pt-3 text-xs text-dark-3">
+        {#each Object.entries(TERM_STYLES) as [kind, style] (kind)}
+          <span class="inline-flex items-center gap-1.5">
+            <span class="inline-block h-2.5 w-2.5 rounded-sm {style.className}"></span>{style.label}
+          </span>
+        {/each}
+        <span class="inline-flex items-center gap-1.5">
+          <span class="inline-block h-2.5 w-2.5 rounded-sm ring-1 ring-blue-4/70"></span>cited by the rater
+        </span>
+      </div>
+
+      {#if data.item.negativePrompt}
+        <div class="mt-4 mb-1.5 text-xs font-medium uppercase tracking-wider text-dark-2">
+          Negative prompt <span class="normal-case text-dark-3">(excluded by the user)</span>
+        </div>
+        <p class="whitespace-pre-wrap break-words font-mono text-sm leading-relaxed text-dark-2">
+          {#each negativePieces as piece, i (i)}{#if piece.className || piece.cited}<mark
+              class="rounded px-0.5 opacity-70 {piece.className} {piece.cited
+                ? 'ring-1 ring-blue-4/70'
+                : ''}">{piece.text}</mark
+            >{:else}{piece.text}{/if}{/each}
+        </p>
+      {/if}
+    </div>
+
+    <div class="flex flex-col gap-4">
+      <div class="rounded-xl border border-dark-4 bg-dark-6 p-5">
+        <div class="mb-2 flex items-center justify-between">
+          <span class="text-xs font-medium uppercase tracking-wider text-dark-2">Rating</span>
+          <span class="text-xs text-dark-3">{data.item.model}</span>
+        </div>
+        <div
+          class="mb-3 inline-block rounded px-2 py-1 text-sm font-semibold {data.item.aiVerdict
+            ? 'bg-red-8/25 text-red-3'
+            : 'bg-green-8/25 text-green-3'}"
+        >
+          {data.item.aiVerdict ? data.label : `not ${data.label}`}
+        </div>
+        <p class="text-sm leading-relaxed text-dark-1">{data.item.aiReason}</p>
+      </div>
+
+      {#if data.item.liveScores}
+        <div class="rounded-xl border border-dark-4 bg-dark-6 p-5">
+          <div class="mb-2 text-xs font-medium uppercase tracking-wider text-dark-2">
+            Live XGuard at sample time
+          </div>
+          <div class="flex flex-col gap-1">
+            {#each Object.entries(data.item.liveScores) as [name, score] (name)}
+              <div class="flex justify-between text-sm">
+                <span class="text-dark-2">{name}</span>
+                <span class="font-mono text-dark-0">{score.toFixed(3)}</span>
+              </div>
+            {/each}
+          </div>
+        </div>
+      {/if}
+
+      <form
+        method="POST"
+        action="?/judge"
+        bind:this={form}
+        use:enhance={({ formData }) => {
+          formData.set('agreed', String(pendingAgreed));
+          formData.set('durationMs', String(pendingDuration));
+          const wasPinned = data.pinned;
+          return async ({ update }) => {
+            await update({ reset: false });
+            // Revisiting is a one-item detour; land back on the queue rather than re-showing the
+            // item that was just re-answered.
+            if (wasPinned) await goto(queueHref, { invalidateAll: true });
+            else await invalidateAll();
+            submitting = false;
+          };
+        }}
+      >
+        <input type="hidden" name="sampleId" value={data.item.sampleId} />
+        <input type="hidden" name="label" value={data.label} />
+        <input type="hidden" name="judgementId" value={data.item.judgementId} />
+        <input type="hidden" name="aiVerdict" value={String(data.item.aiVerdict)} />
+
+        <label class="mb-3 flex flex-col gap-1">
+          <span class="text-xs font-medium uppercase tracking-wider text-dark-2">
+            Note <span class="normal-case text-dark-3">(optional)</span>
+          </span>
+          <textarea
+            name="note"
+            bind:value={note}
+            rows="2"
+            placeholder="why this one is not obvious"
+            class="w-full rounded border border-dark-4 bg-dark-8 px-2 py-1.5 text-sm text-dark-0 focus:border-blue-6 focus:outline-none"
+          ></textarea>
+        </label>
+
+        <div class="flex gap-2">
+          <button
+            type="button"
+            disabled={submitting}
+            onclick={() => submit(true)}
+            class="flex-1 rounded-lg bg-green-8/25 px-3 py-2.5 text-sm font-semibold text-green-3 hover:bg-green-8/40 disabled:opacity-50"
+          >
+            Agree <kbd class="ml-1 text-xs opacity-60">A</kbd>
+          </button>
+          <button
+            type="button"
+            disabled={submitting}
+            onclick={() => submit(false)}
+            class="flex-1 rounded-lg bg-red-8/25 px-3 py-2.5 text-sm font-semibold text-red-3 hover:bg-red-8/40 disabled:opacity-50"
+          >
+            Disagree <kbd class="ml-1 text-xs opacity-60">D</kbd>
+          </button>
+        </div>
+      </form>
+
+      <div class="flex gap-2">
+        {#if !data.pinned}
+          <button
+            type="button"
+            disabled={submitting}
+            onclick={skip}
+            class="flex-1 rounded-lg bg-dark-7 px-3 py-2 text-sm text-dark-1 hover:text-dark-0 disabled:opacity-50"
+          >
+            Skip <kbd class="ml-1 text-xs opacity-60">S</kbd>
+          </button>
+          {#if undoHref}
+            <a
+              href={undoHref}
+              class="flex-1 rounded-lg bg-dark-7 px-3 py-2 text-center text-sm text-dark-1 hover:text-dark-0"
+            >
+              Back one &amp; change it
+            </a>
+          {/if}
+        {/if}
+      </div>
+
+      <p class="text-xs text-dark-3">
+        Batch {data.item.batch}
+      </p>
+    </div>
+  </section>
+{/if}

--- a/apps/moderator/src/routes/xguard/labels/+page.server.ts
+++ b/apps/moderator/src/routes/xguard/labels/+page.server.ts
@@ -1,0 +1,91 @@
+import type { PageServerLoad } from './$types';
+import { requireAccess } from '$lib/server/access';
+import { labDb } from '$lib/server/xguard-lab';
+
+// Per-label state of the lab: how much data exists, how much of it is confirmed, and what the last
+// evaluation said.
+//
+// The number that matters most is `positives` - confirmed ground truth where the answer is yes. A
+// label with 200 confirmed negatives and no positives cannot have its recall measured at all, and
+// nothing else on the page makes that obvious.
+
+export const load: PageServerLoad = async ({ locals, url }) => {
+  requireAccess(locals.user, url.pathname);
+
+  const labels = await labDb
+    .selectFrom('label_def as l')
+    .select((eb) => [
+      'l.name',
+      'l.description',
+      'l.status',
+      eb
+        .selectFrom('machine_judgement as m')
+        .select(({ fn }) => fn.countAll<string>().as('c'))
+        .whereRef('m.label', '=', 'l.name')
+        .where('m.source', '=', 'ai')
+        .as('rated'),
+      eb
+        .selectFrom('machine_judgement as m')
+        .select(({ fn }) => fn.countAll<string>().as('c'))
+        .whereRef('m.label', '=', 'l.name')
+        .where('m.source', '=', 'ai')
+        .where('m.verdict', '=', true)
+        .as('ratedPositive'),
+      eb
+        .selectFrom('human_judgement as h')
+        .select(({ fn }) => fn.count<string>('h.sample_id').distinct().as('c'))
+        .whereRef('h.label', '=', 'l.name')
+        .where('h.excluded_reason', 'is', null)
+        .as('confirmed'),
+      eb
+        .selectFrom('human_judgement as h')
+        .select(({ fn }) => fn.count<string>('h.sample_id').distinct().as('c'))
+        .whereRef('h.label', '=', 'l.name')
+        .where('h.verdict', '=', true)
+        .where('h.excluded_reason', 'is', null)
+        .as('positives'),
+      eb
+        .selectFrom('label_policy as p')
+        .select(({ fn }) => fn.max<number>('p.version').as('v'))
+        .whereRef('p.label', '=', 'l.name')
+        .as('policyVersion'),
+    ])
+    .orderBy('l.name')
+    .execute();
+
+  // Latest completed run per label. One query, then matched up in memory - a lateral join for a
+  // handful of labels is not worth the SQL.
+  const runs = await labDb
+    .selectFrom('eval_run')
+    .select([
+      'id',
+      'label',
+      'policy_label as policyLabel',
+      'threshold',
+      'tp',
+      'fp',
+      'tn',
+      'fn',
+      'precision',
+      'recall',
+      'started_at as startedAt',
+    ])
+    .where('status', '=', 'complete')
+    .orderBy('started_at', 'desc')
+    .execute();
+
+  const latestRun = new Map<string, (typeof runs)[number]>();
+  for (const run of runs) if (!latestRun.has(run.label)) latestRun.set(run.label, run);
+
+  return {
+    labels: labels.map((l) => ({
+      ...l,
+      rated: Number(l.rated ?? 0),
+      ratedPositive: Number(l.ratedPositive ?? 0),
+      confirmed: Number(l.confirmed ?? 0),
+      positives: Number(l.positives ?? 0),
+      policyVersion: l.policyVersion ?? null,
+      lastRun: latestRun.get(l.name) ?? null,
+    })),
+  };
+};

--- a/apps/moderator/src/routes/xguard/labels/+page.svelte
+++ b/apps/moderator/src/routes/xguard/labels/+page.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+  import type { PageData } from './$types';
+  import { fmtMetric, precisionOf, recallOf } from '$lib/eval-metrics';
+
+  let { data }: { data: PageData } = $props();
+
+  // Recall is unmeasurable without confirmed positives, so a label with plenty of reviews and no
+  // positives looks healthy on every other number while being useless for tuning. Say it plainly.
+  function blocker(l: PageData['labels'][number]): string | null {
+    if (l.rated === 0) return 'no AI ratings yet';
+    if (l.confirmed === 0) return 'nothing confirmed by a human yet';
+    if (l.positives === 0) return 'no confirmed positives, so recall cannot be measured';
+    if (!l.policyVersion) return 'no policy imported, so nothing to evaluate';
+    return null;
+  }
+</script>
+
+<header class="page-header">
+  <h1>Labels</h1>
+  <p>What exists, how much of it is confirmed, and what the last evaluation said.</p>
+</header>
+
+{#if data.labels.length === 0}
+  <section class="rounded-xl border border-dark-4 bg-dark-6 p-8 text-center text-sm text-dark-2">
+    No labels yet. Run the rater to create one.
+  </section>
+{:else}
+  <div class="flex flex-col gap-3">
+    {#each data.labels as l (l.name)}
+      {@const stop = blocker(l)}
+      <section class="rounded-xl border border-dark-4 bg-dark-6 p-5">
+        <div class="mb-3 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+          <h2 class="text-base font-semibold text-white">{l.name}</h2>
+          {#if l.policyVersion}
+            <span class="rounded bg-dark-7 px-2 py-0.5 text-xs text-dark-1">policy v{l.policyVersion}</span>
+          {/if}
+          <div class="ml-auto flex gap-3 text-xs">
+            <a href="/xguard/labels/{l.name}" class="text-blue-4 hover:text-blue-3">Policy</a>
+            <a href="/xguard?label={l.name}" class="text-blue-4 hover:text-blue-3">Review &rarr;</a>
+          </div>
+        </div>
+
+        <p class="mb-4 text-sm text-dark-2">{l.description}</p>
+
+        <div class="mb-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
+          {#each [['rated', l.rated], ['rater said yes', l.ratedPositive], ['confirmed', l.confirmed], ['confirmed yes', l.positives]] as [label, value] (label)}
+            <div class="rounded-lg bg-dark-7 px-3 py-2">
+              <div class="text-xs text-dark-3">{label}</div>
+              <div class="font-mono text-lg text-dark-0">{value}</div>
+            </div>
+          {/each}
+        </div>
+
+        {#if stop}
+          <div class="rounded-lg bg-red-8/15 px-3 py-2 text-sm text-red-3">{stop}</div>
+        {:else if l.lastRun}
+          {@const r = l.lastRun}
+          <div class="rounded-lg bg-dark-7 px-3 py-2.5">
+            <div class="mb-1.5 flex items-baseline gap-2 text-xs text-dark-3">
+              <span>last run</span>
+              <span class="text-dark-1">{r.policyLabel} @ {r.threshold}</span>
+              <span class="ml-auto">{new Date(r.startedAt).toLocaleString()}</span>
+            </div>
+            <div class="flex flex-wrap gap-x-5 gap-y-1 font-mono text-sm">
+              <span class="text-green-3">TP {r.tp}</span>
+              <span class="text-red-3">FP {r.fp}</span>
+              <span class="text-dark-1">TN {r.tn}</span>
+              <span class="text-red-3">FN {r.fn}</span>
+              <span class="text-dark-0">P {fmtMetric(precisionOf(r))}</span>
+              <span class="text-dark-0">R {fmtMetric(recallOf(r))}</span>
+            </div>
+          </div>
+        {:else}
+          <div class="rounded-lg bg-dark-7 px-3 py-2 text-sm text-dark-3">
+            Ready to evaluate, but no run yet.
+          </div>
+        {/if}
+      </section>
+    {/each}
+  </div>
+{/if}

--- a/apps/moderator/src/routes/xguard/labels/[name]/+page.server.ts
+++ b/apps/moderator/src/routes/xguard/labels/[name]/+page.server.ts
@@ -1,0 +1,128 @@
+import { error, fail } from '@sveltejs/kit';
+import type { Actions, PageServerLoad } from './$types';
+import { requireAccess } from '$lib/server/access';
+import { labDb } from '$lib/server/xguard-lab';
+import { env } from '$env/dynamic/private';
+import { runEvaluation } from '../../../../../xguard-lab/eval-core';
+
+// Policy editor. Every save is a NEW version, never an update in place: `eval_run.policy_id`
+// points at a specific row, so editing one would silently rewrite what a past run measured.
+
+export const load: PageServerLoad = async ({ locals, url, params }) => {
+  requireAccess(locals.user, '/xguard');
+
+  const label = await labDb
+    .selectFrom('label_def')
+    .select(['name', 'description', 'status'])
+    .where('name', '=', params.name)
+    .executeTakeFirst();
+  if (!label) error(404, `No label named ${params.name}`);
+
+  const [versions, runs, truth] = await Promise.all([
+    labDb
+      .selectFrom('label_policy')
+      .select(['id', 'version', 'policy', 'threshold', 'action', 'note', 'created_at as createdAt'])
+      .where('label', '=', params.name)
+      .orderBy('version', 'desc')
+      .execute(),
+    labDb
+      .selectFrom('eval_run')
+      .select([
+        'id',
+        'policy_label as policyLabel',
+        'threshold',
+        'tp',
+        'fp',
+        'tn',
+        'fn',
+        'precision',
+        'recall',
+        'note',
+        'started_at as startedAt',
+      ])
+      .where('label', '=', params.name)
+      .where('status', '=', 'complete')
+      .orderBy('started_at', 'desc')
+      .limit(15)
+      .execute(),
+    labDb
+      .selectFrom('human_judgement')
+      .select(({ fn }) => [
+        fn.count<string>('sample_id').distinct().as('confirmed'),
+        fn
+          .count<string>('sample_id')
+          .distinct()
+          .filterWhere('verdict', '=', true)
+          .as('positives'),
+      ])
+      .where('label', '=', params.name)
+      .where('excluded_reason', 'is', null)
+      .executeTakeFirst(),
+  ]);
+
+  return {
+    label,
+    versions,
+    runs,
+    groundTruth: {
+      confirmed: Number(truth?.confirmed ?? 0),
+      positives: Number(truth?.positives ?? 0),
+    },
+  };
+};
+
+export const actions: Actions = {
+  // Save the edited prose as the next version. Prose changes need a real evaluation run to mean
+  // anything, so this deliberately does not also run one - saving should stay instant.
+  save: async ({ request, locals, params }) => {
+    requireAccess(locals.user, '/xguard');
+    const form = await request.formData();
+    const policy = String(form.get('policy') ?? '').trim();
+    const threshold = Number(form.get('threshold'));
+    const action = String(form.get('action') ?? 'Scan');
+    const note = String(form.get('note') ?? '').trim() || null;
+
+    if (!policy) return fail(400, { message: 'Policy text is required' });
+    if (!Number.isFinite(threshold) || threshold < 0 || threshold > 1) {
+      return fail(400, { message: 'Threshold must be between 0 and 1' });
+    }
+
+    const next = await labDb
+      .selectFrom('label_policy')
+      .select(({ fn }) => fn.max<number>('version').as('v'))
+      .where('label', '=', params.name)
+      .executeTakeFirst();
+    const version = (next?.v ?? 0) + 1;
+
+    await labDb
+      .insertInto('label_policy')
+      .values({ label: params.name, version, policy, threshold, action, note })
+      .execute();
+
+    return { saved: version };
+  },
+
+  // Same code path as the CLI, so an agent iterating on prose and a human clicking here produce
+  // comparable numbers.
+  evaluate: async ({ request, locals, params }) => {
+    requireAccess(locals.user, '/xguard');
+    const form = await request.formData();
+    const version = Number(form.get('version'));
+    if (!Number.isFinite(version)) return fail(400, { message: 'Pick a version to evaluate' });
+
+    const connectionString = env.MODERATOR_DATABASE_URL;
+    if (!connectionString) return fail(500, { message: 'MODERATOR_DATABASE_URL is not configured' });
+
+    try {
+      const summary = await runEvaluation({
+        connectionString,
+        label: params.name,
+        policyVersion: version,
+        note: `from the policy editor`,
+      });
+      return { evaluated: summary };
+    } catch (err) {
+      return fail(400, { message: (err as Error).message });
+    }
+  },
+};

--- a/apps/moderator/src/routes/xguard/labels/[name]/+page.svelte
+++ b/apps/moderator/src/routes/xguard/labels/[name]/+page.svelte
@@ -1,0 +1,214 @@
+<script lang="ts">
+  import { enhance } from '$app/forms';
+  import type { ActionData, PageData } from './$types';
+  import { fmtMetric, precisionOf, recallOf } from '$lib/eval-metrics';
+
+  let { data, form }: { data: PageData; form: ActionData } = $props();
+
+  const latest = $derived(data.versions[0] ?? null);
+
+  let policy = $state('');
+  let threshold = $state(0.5);
+  let action = $state('Scan');
+  let note = $state('');
+  let evaluating = $state(false);
+
+  // Seed the editor from the newest version whenever the label changes, so opening the page shows
+  // what is current rather than an empty box.
+  let seededFor = $state<string | null>(null);
+  $effect(() => {
+    if (seededFor === data.label.name) return;
+    seededFor = data.label.name;
+    policy = latest?.policy ?? '';
+    threshold = latest?.threshold ?? 0.5;
+    action = latest?.action ?? 'Scan';
+    note = '';
+  });
+
+  const dirty = $derived(
+    latest === null ||
+      policy !== latest.policy ||
+      threshold !== latest.threshold ||
+      action !== latest.action
+  );
+
+  // Recall needs confirmed positives. Saying so up front beats letting someone run an evaluation
+  // and puzzle over a row of n/a.
+  const measurable = $derived(data.groundTruth.positives > 0);
+</script>
+
+<header class="page-header">
+  <h1>{data.label.name}</h1>
+  <p>{data.label.description}</p>
+</header>
+
+<div class="mb-4 flex flex-wrap items-center gap-3 text-xs">
+  <a href="/xguard/labels" class="rounded bg-dark-7 px-2.5 py-1 text-dark-2 hover:text-dark-0">
+    All labels
+  </a>
+  <a href="/xguard?label={data.label.name}" class="rounded bg-dark-7 px-2.5 py-1 text-dark-2 hover:text-dark-0">
+    Review
+  </a>
+  <span class="text-dark-3">
+    {data.groundTruth.confirmed} confirmed &middot; {data.groundTruth.positives} positive
+  </span>
+  {#if !measurable}
+    <span class="rounded bg-red-8/15 px-2 py-1 text-red-3">
+      No confirmed positives, so recall will come back n/a
+    </span>
+  {/if}
+</div>
+
+{#if form && 'message' in form && form.message}
+  <div class="mb-4 rounded-lg bg-red-8/20 px-3 py-2 text-sm text-red-2">{form.message}</div>
+{/if}
+{#if form && 'saved' in form && form.saved}
+  <div class="mb-4 rounded-lg bg-green-8/20 px-3 py-2 text-sm text-green-2">
+    Saved as v{form.saved}.
+  </div>
+{/if}
+{#if form && 'evaluated' in form && form.evaluated}
+  {@const e = form.evaluated}
+  <div class="mb-4 rounded-lg bg-dark-7 px-3 py-2.5">
+    <div class="mb-1 text-xs text-dark-3">run {e.runId} &middot; {e.policyLabel} @ {e.threshold}</div>
+    <div class="flex flex-wrap gap-x-5 gap-y-1 font-mono text-sm">
+      <span class="text-green-3">TP {e.tp}</span>
+      <span class="text-red-3">FP {e.fp}</span>
+      <span class="text-dark-1">TN {e.tn}</span>
+      <span class="text-red-3">FN {e.fn}</span>
+      <span class="text-dark-0">P {fmtMetric(precisionOf(e))}</span>
+      <span class="text-dark-0">R {fmtMetric(recallOf(e))}</span>
+    </div>
+  </div>
+{/if}
+
+<section class="grid gap-4 lg:grid-cols-[1fr_22rem]">
+  <form
+    method="POST"
+    action="?/save"
+    use:enhance
+    class="rounded-xl border border-dark-4 bg-dark-6 p-5"
+  >
+    <div class="mb-3 flex items-baseline justify-between">
+      <span class="text-xs font-medium uppercase tracking-wider text-dark-2">Policy</span>
+      <span class="text-xs text-dark-3">
+        {#if latest}editing from v{latest.version}{:else}no versions yet{/if}
+      </span>
+    </div>
+
+    <textarea
+      name="policy"
+      bind:value={policy}
+      rows="22"
+      spellcheck="false"
+      class="w-full rounded-lg border border-dark-4 bg-dark-8 p-3 font-mono text-xs leading-relaxed text-dark-0 focus:border-blue-6 focus:outline-none"
+    ></textarea>
+
+    <div class="mt-3 flex flex-wrap items-end gap-3">
+      <label class="flex flex-col gap-1">
+        <span class="text-xs text-dark-2">Threshold</span>
+        <input
+          name="threshold"
+          type="number"
+          min="0"
+          max="1"
+          step="0.05"
+          bind:value={threshold}
+          class="w-24 rounded border border-dark-4 bg-dark-8 px-2 py-1 text-sm text-dark-0"
+        />
+      </label>
+      <label class="flex flex-col gap-1">
+        <span class="text-xs text-dark-2">Action</span>
+        <select
+          name="action"
+          bind:value={action}
+          class="rounded border border-dark-4 bg-dark-8 px-2 py-1 text-sm text-dark-0"
+        >
+          <option value="Scan">Scan</option>
+          <option value="Block">Block</option>
+        </select>
+      </label>
+      <label class="flex flex-1 flex-col gap-1">
+        <span class="text-xs text-dark-2">Note</span>
+        <input
+          name="note"
+          bind:value={note}
+          placeholder="what changed and why"
+          class="w-full rounded border border-dark-4 bg-dark-8 px-2 py-1 text-sm text-dark-0"
+        />
+      </label>
+      <button
+        type="submit"
+        disabled={!dirty}
+        class="rounded-lg bg-blue-8/30 px-4 py-2 text-sm font-semibold text-blue-2 hover:bg-blue-8/50 disabled:opacity-40"
+      >
+        {dirty ? 'Save as new version' : 'No changes'}
+      </button>
+    </div>
+  </form>
+
+  <div class="flex flex-col gap-4">
+    <div class="rounded-xl border border-dark-4 bg-dark-6 p-5">
+      <div class="mb-3 text-xs font-medium uppercase tracking-wider text-dark-2">Versions</div>
+      {#if data.versions.length === 0}
+        <p class="text-sm text-dark-3">Nothing saved yet.</p>
+      {:else}
+        <div class="flex flex-col gap-2">
+          {#each data.versions as v (v.id)}
+            <form
+              method="POST"
+              action="?/evaluate"
+              use:enhance={() => {
+                evaluating = true;
+                return async ({ update }) => {
+                  await update({ reset: false });
+                  evaluating = false;
+                };
+              }}
+              class="flex items-center gap-2 rounded-lg bg-dark-7 px-3 py-2"
+            >
+              <input type="hidden" name="version" value={v.version} />
+              <div class="min-w-0 flex-1">
+                <div class="text-sm text-dark-0">v{v.version} &middot; {v.threshold} &middot; {v.action}</div>
+                {#if v.note}<div class="truncate text-xs text-dark-3">{v.note}</div>{/if}
+              </div>
+              <button
+                type="submit"
+                disabled={evaluating}
+                class="shrink-0 rounded bg-dark-5 px-2.5 py-1 text-xs text-dark-1 hover:text-dark-0 disabled:opacity-40"
+              >
+                {evaluating ? 'Running…' : 'Evaluate'}
+              </button>
+            </form>
+          {/each}
+        </div>
+      {/if}
+    </div>
+
+    <div class="rounded-xl border border-dark-4 bg-dark-6 p-5">
+      <div class="mb-3 text-xs font-medium uppercase tracking-wider text-dark-2">Recent runs</div>
+      {#if data.runs.length === 0}
+        <p class="text-sm text-dark-3">No runs yet.</p>
+      {:else}
+        <div class="flex flex-col gap-2">
+          {#each data.runs as r (r.id)}
+            <div class="rounded-lg bg-dark-7 px-3 py-2">
+              <div class="flex items-baseline justify-between text-xs text-dark-3">
+                <span class="text-dark-1">{r.policyLabel} @ {r.threshold}</span>
+                <span>{new Date(r.startedAt).toLocaleString()}</span>
+              </div>
+              <div class="mt-1 flex flex-wrap gap-x-3 font-mono text-xs">
+                <span class="text-green-3">TP {r.tp}</span>
+                <span class="text-red-3">FP {r.fp}</span>
+                <span class="text-dark-1">TN {r.tn}</span>
+                <span class="text-red-3">FN {r.fn}</span>
+                <span class="text-dark-0">P {fmtMetric(precisionOf(r))}</span>
+                <span class="text-dark-0">R {fmtMetric(recallOf(r))}</span>
+              </div>
+            </div>
+          {/each}
+        </div>
+      {/if}
+    </div>
+  </div>
+</section>

--- a/apps/moderator/src/routes/xguard/runs/+page.server.ts
+++ b/apps/moderator/src/routes/xguard/runs/+page.server.ts
@@ -1,0 +1,145 @@
+import { sql } from '@civitai/db/kysely';
+import type { PageServerLoad } from './$types';
+import { requireAccess } from '$lib/server/access';
+import { labDb } from '$lib/server/xguard-lab';
+
+// Evaluation run history, and the per-sample outcomes behind any one run.
+//
+// A run's four counters say whether a policy got better. They do not say why, and "why" is the only
+// question worth opening this page for - so a selected run defaults to its FP and FN rows.
+
+const BUCKETS = ['TP', 'FP', 'TN', 'FN', 'error'] as const;
+type Bucket = (typeof BUCKETS)[number];
+
+// Cap on rows rendered for one run. Big enough to read a whole bad bucket, small enough that a
+// 5k-sample run does not ship 5k prompts to the browser.
+const RESULT_LIMIT = 250;
+
+function bucketsFor(filter: string): Bucket[] {
+  if (filter === 'all') return [...BUCKETS];
+  if (filter === 'wrong') return ['FP', 'FN'];
+  return BUCKETS.includes(filter as Bucket) ? [filter as Bucket] : ['FP', 'FN'];
+}
+
+export const load: PageServerLoad = async ({ locals, url }) => {
+  requireAccess(locals.user, url.pathname);
+
+  const label = url.searchParams.get('label');
+  const runParam = url.searchParams.get('run');
+  const bucketFilter = url.searchParams.get('bucket') ?? 'wrong';
+
+  let runsQuery = labDb
+    .selectFrom('eval_run')
+    .select([
+      'id',
+      'label',
+      'policy_label as policyLabel',
+      'threshold',
+      'batch',
+      'status',
+      'total',
+      'scored',
+      'errors',
+      'tp',
+      'fp',
+      'tn',
+      'fn',
+      'precision',
+      'recall',
+      'f1',
+      'note',
+      'started_at as startedAt',
+      'finished_at as finishedAt',
+    ])
+    .orderBy('started_at', 'desc')
+    .limit(100);
+  if (label) runsQuery = runsQuery.where('label', '=', label);
+
+  const [runRows, labels] = await Promise.all([
+    runsQuery.execute(),
+    labDb.selectFrom('label_def').select(['name']).orderBy('name').execute(),
+  ]);
+
+  // @civitai/db registers a process-global INT8 parser, so bigint ids arrive as JS numbers even
+  // though LabDB types them as strings. Normalise here or `id === searchParam` silently never matches.
+  const runs = runRows.map((r) => ({ ...r, id: String(r.id) }));
+
+  // Selecting nothing shows the newest run rather than an empty right-hand side, because the run
+  // someone came to read is almost always the one they just finished. A `?run=` that is not in this
+  // view - filtered out by `?label=`, or older than the 100-row window - falls back the same way and
+  // says so, rather than rendering a blank pane that reads as broken.
+  const requested = runParam ? runs.find((r) => r.id === runParam) ?? null : null;
+  const selected = requested ?? runs[0] ?? null;
+  const missingRun = runParam !== null && requested === null;
+
+  const empty: Record<string, number> = {};
+  if (!selected) {
+    return {
+      label,
+      labels,
+      runs,
+      selected: null,
+      missingRun,
+      bucketFilter,
+      results: [],
+      bucketCounts: empty,
+      truncated: false,
+    };
+  }
+
+  const wanted = bucketsFor(bucketFilter);
+
+  const [results, tally] = await Promise.all([
+    labDb
+      .selectFrom('eval_result as r')
+      .innerJoin('sample as s', 's.id', 'r.sample_id')
+      .select([
+        'r.id',
+        'r.sample_id as sampleId',
+        'r.score',
+        'r.predicted',
+        'r.expected',
+        'r.bucket',
+        'r.reason',
+        'r.error',
+        's.positive_prompt as positivePrompt',
+        's.batch',
+      ])
+      .where('r.run_id', '=', selected.id)
+      .where('r.bucket', 'in', wanted)
+      // Highest score first: within a bucket, the most confident mistakes are the informative ones.
+      // `nulls last` because score is null exactly when bucket = 'error', and Postgres would
+      // otherwise sort those to the top and let them eat the row cap.
+      .orderBy(sql`r.score desc nulls last`)
+      .limit(RESULT_LIMIT + 1)
+      .execute(),
+    labDb
+      .selectFrom('eval_result')
+      .select(({ fn }) => ['bucket', fn.countAll<string>().as('n')])
+      .where('run_id', '=', selected.id)
+      .groupBy('bucket')
+      .execute(),
+  ]);
+
+  const bucketCounts: Record<string, number> = {};
+  for (const t of tally) if (t.bucket) bucketCounts[t.bucket] = Number(t.n);
+
+  // Every label's terms: a run list can span labels, and a prompt is worth highlighting for
+  // vocabulary the label under test does not own.
+  const terms = await labDb.selectFrom('label_term').select(['label', 'term', 'kind']).execute();
+
+  return {
+    label,
+    labels,
+    terms,
+    runs,
+    selected,
+    missingRun,
+    bucketFilter,
+    results: results
+      .slice(0, RESULT_LIMIT)
+      .map((r) => ({ ...r, id: String(r.id), sampleId: String(r.sampleId) })),
+    bucketCounts,
+    truncated: results.length > RESULT_LIMIT,
+  };
+};

--- a/apps/moderator/src/routes/xguard/runs/+page.svelte
+++ b/apps/moderator/src/routes/xguard/runs/+page.svelte
@@ -1,0 +1,291 @@
+<script lang="ts">
+  import type { PageData } from './$types';
+  import { findTermSpans, TERM_STYLES } from '$lib/highlight-terms';
+
+  let { data }: { data: PageData } = $props();
+
+  let expanded = $state(new Set<string>());
+
+  // A new run means a new result list; keeping old ids expanded would open unrelated rows.
+  let expandedFor = $state<string | null>(null);
+  $effect(() => {
+    const id = data.selected?.id ?? null;
+    if (expandedFor === id) return;
+    expandedFor = id;
+    expanded = new Set();
+  });
+
+  function toggle(id: string) {
+    const next = new Set(expanded);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    expanded = next;
+  }
+
+  // Precision and recall are undefined, not zero, when the denominator is empty. Rendering 0.000
+  // reads as "got everything wrong" for a run that simply had nothing to be right about.
+  //
+  // Recomputed from the counters rather than read off the columns: runs written before precision
+  // and recall became nullable stored 0 for undefined, so the stored value cannot be trusted to
+  // distinguish the two cases.
+  type Counters = { tp: number; fp: number; fn: number };
+  const precisionOf = (r: Counters) => (r.tp + r.fp === 0 ? null : r.tp / (r.tp + r.fp));
+  const recallOf = (r: Counters) => (r.tp + r.fn === 0 ? null : r.tp / (r.tp + r.fn));
+  const pct = (n: number | null) => (n === null ? 'n/a' : n.toFixed(3));
+
+  const COLLAPSED_CHARS = 260;
+
+  type Piece = { text: string; className: string };
+
+  function pieces(text: string): Piece[] {
+    if (!text) return [];
+    const terms = findTermSpans(text, data.terms ?? []);
+    const out: Piece[] = [];
+    let at = 0;
+    for (const s of terms) {
+      if (s.start > at) out.push({ text: text.slice(at, s.start), className: '' });
+      out.push({ text: text.slice(s.start, s.end), className: TERM_STYLES[s.kind].className });
+      at = s.end;
+    }
+    if (at < text.length) out.push({ text: text.slice(at), className: '' });
+    return out;
+  }
+
+  function truncate(list: Piece[], limit: number): Piece[] {
+    const out: Piece[] = [];
+    let used = 0;
+    for (const p of list) {
+      if (used >= limit) break;
+      out.push({ ...p, text: p.text.slice(0, limit - used) });
+      used += p.text.length;
+    }
+    out.push({ text: '…', className: '' });
+    return out;
+  }
+
+  // Highlight each prompt once per result set, not once per render. `pieces` runs ~253 regexes plus
+  // an overlap scan, and calling it inline in the template made a single "Show all" click re-run it
+  // for all 250 rows. Nothing here reads `expanded`, so toggling only reselects an existing array.
+  const rows = $derived(
+    data.results.map((r) => {
+      const full = pieces(r.positivePrompt);
+      const long = r.positivePrompt.length > COLLAPSED_CHARS;
+      return { ...r, full, head: long ? truncate(full, COLLAPSED_CHARS) : full, long };
+    })
+  );
+
+  const BUCKET_STYLE: Record<string, string> = {
+    TP: 'bg-green-8/25 text-green-3',
+    FP: 'bg-red-8/25 text-red-3',
+    TN: 'bg-dark-5 text-dark-1',
+    FN: 'bg-red-8/25 text-red-3',
+    error: 'bg-dark-5 text-dark-2',
+  };
+
+  const FILTERS = [
+    { key: 'wrong', label: 'Mistakes (FP + FN)' },
+    { key: 'FP', label: 'FP' },
+    { key: 'FN', label: 'FN' },
+    { key: 'TP', label: 'TP' },
+    { key: 'TN', label: 'TN' },
+    { key: 'error', label: 'Errors' },
+    { key: 'all', label: 'All' },
+  ];
+
+  function href(params: Record<string, string | null>): string {
+    const q = new URLSearchParams();
+    if (data.label) q.set('label', data.label);
+    if (data.selected) q.set('run', data.selected.id);
+    if (data.bucketFilter !== 'wrong') q.set('bucket', data.bucketFilter);
+    for (const [k, v] of Object.entries(params)) {
+      if (v === null) q.delete(k);
+      else q.set(k, v);
+    }
+    return `/xguard/runs?${q.toString()}`;
+  }
+
+  function countFor(key: string): number | null {
+    const c = data.bucketCounts;
+    if (key === 'wrong') return (c.FP ?? 0) + (c.FN ?? 0);
+    if (key === 'all') return Object.values(c).reduce((a, b) => a + b, 0);
+    return c[key] ?? 0;
+  }
+</script>
+
+<header class="page-header">
+  <h1>Evaluation runs</h1>
+  <p>What a policy scored, and which prompts it got wrong.</p>
+</header>
+
+<div class="mb-4 flex flex-wrap items-center gap-2">
+  <a href="/xguard/labels" class="rounded bg-dark-7 px-2.5 py-1 text-xs text-dark-2 hover:text-dark-0">
+    All labels
+  </a>
+  <a
+    href="/xguard/runs"
+    class="rounded px-2.5 py-1 text-xs font-medium {data.label
+      ? 'bg-dark-7 text-dark-2 hover:text-dark-0'
+      : 'bg-blue-8/25 text-blue-3'}"
+  >
+    Every label
+  </a>
+  {#each data.labels as l (l.name)}
+    <a
+      href="/xguard/runs?label={l.name}"
+      class="rounded px-2.5 py-1 text-xs font-medium {l.name === data.label
+        ? 'bg-blue-8/25 text-blue-3'
+        : 'bg-dark-7 text-dark-2 hover:text-dark-0'}"
+    >
+      {l.name}
+    </a>
+  {/each}
+</div>
+
+{#if data.missingRun}
+  <div class="mb-4 rounded-lg bg-dark-7 px-3 py-2 text-sm text-dark-1">
+    That run is not in this view{data.label ? ` — it may belong to a label other than ${data.label}` : ''}.
+    {#if data.runs.length}Showing the newest one instead.{/if}
+    <a href="/xguard/runs" class="ml-1 text-blue-4 hover:text-blue-3">Show every label</a>
+  </div>
+{/if}
+
+{#if data.runs.length === 0}
+  <section class="rounded-xl border border-dark-4 bg-dark-6 p-8 text-center text-sm text-dark-2">
+    No evaluation runs yet{data.label ? ` for ${data.label}` : ''}. Run one from a label's policy page.
+  </section>
+{:else}
+  <section class="grid gap-4 lg:grid-cols-[24rem_1fr] lg:items-start">
+    <div class="flex flex-col gap-2 lg:max-h-[80vh] lg:overflow-y-auto">
+      {#each data.runs as r (r.id)}
+        {@const active = data.selected?.id === r.id}
+        <a
+          href={href({ run: r.id })}
+          class="block rounded-xl border p-3.5 {active
+            ? 'border-blue-6 bg-dark-6'
+            : 'border-dark-4 bg-dark-6 hover:border-dark-3'}"
+        >
+          <div class="flex items-baseline gap-2">
+            <span class="text-sm font-semibold text-dark-0">{r.label}</span>
+            <span class="rounded bg-dark-7 px-1.5 py-0.5 text-xs text-dark-1">{r.policyLabel}</span>
+            <span class="text-xs text-dark-3">@ {r.threshold}</span>
+            {#if r.status !== 'complete'}
+              <span class="ml-auto rounded bg-dark-5 px-1.5 py-0.5 text-xs text-dark-1">{r.status}</span>
+            {/if}
+          </div>
+
+          <div class="mt-2 flex flex-wrap gap-x-3 gap-y-1 font-mono text-xs">
+            <span class="text-green-3">TP {r.tp}</span>
+            <span class="text-red-3">FP {r.fp}</span>
+            <span class="text-dark-1">TN {r.tn}</span>
+            <span class="text-red-3">FN {r.fn}</span>
+            <span class="text-dark-0">P {pct(precisionOf(r))}</span>
+            <span class="text-dark-0">R {pct(recallOf(r))}</span>
+            {#if r.errors > 0}<span class="text-dark-2">err {r.errors}</span>{/if}
+          </div>
+
+          {#if r.note}
+            <p class="mt-2 text-xs text-dark-2">{r.note}</p>
+          {/if}
+
+          <div class="mt-2 flex flex-wrap gap-x-2 text-xs text-dark-3">
+            <span>{new Date(r.startedAt).toLocaleString()}</span>
+            {#if r.batch}<span>&middot; batch {r.batch}</span>{/if}
+          </div>
+        </a>
+      {/each}
+    </div>
+
+    {#if data.selected}
+      {@const s = data.selected}
+      <div class="flex flex-col gap-3">
+        <div class="rounded-xl border border-dark-4 bg-dark-6 p-5">
+          <div class="mb-3 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+            <h2 class="text-base font-semibold text-white">{s.label}</h2>
+            <span class="rounded bg-dark-7 px-2 py-0.5 text-xs text-dark-1">{s.policyLabel}</span>
+            <span class="text-xs text-dark-3">threshold {s.threshold}</span>
+            <a href="/xguard/labels/{s.label}" class="ml-auto text-xs text-blue-4 hover:text-blue-3">
+              Policy &rarr;
+            </a>
+          </div>
+
+          <!-- Derived from the counters, not from `recall === null`: runs written before those
+               columns became nullable stored 0 for an undefined recall, and trusting the column
+               silently drops the warning on exactly those runs. -->
+          {#if s.tp + s.fn === 0}
+            <div class="mb-3 rounded-lg bg-red-8/15 px-3 py-2 text-sm text-red-3">
+              No confirmed positives in scope, so recall is undefined - this run cannot tell you what the
+              policy misses.
+            </div>
+          {/if}
+
+          <div class="flex flex-wrap gap-2">
+            {#each FILTERS as f (f.key)}
+              <a
+                href={href({ bucket: f.key === 'wrong' ? null : f.key })}
+                class="rounded px-2.5 py-1 text-xs font-medium {f.key === data.bucketFilter
+                  ? 'bg-blue-8/25 text-blue-3'
+                  : 'bg-dark-7 text-dark-2 hover:text-dark-0'}"
+              >
+                {f.label} <span class="font-mono opacity-70">{countFor(f.key)}</span>
+              </a>
+            {/each}
+          </div>
+        </div>
+
+        {#if data.truncated}
+          <p class="text-xs text-dark-3">Showing the first 250 rows by score. Narrow the bucket to see more.</p>
+        {/if}
+
+        {#if rows.length === 0}
+          <section class="rounded-xl border border-dark-4 bg-dark-6 p-8 text-center text-sm text-dark-2">
+            Nothing in this bucket.
+          </section>
+        {:else}
+          {#each rows as r (r.id)}
+            <article class="rounded-xl border border-dark-4 bg-dark-6 p-4">
+              <div class="mb-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+                <span class="rounded px-1.5 py-0.5 font-semibold {BUCKET_STYLE[r.bucket ?? 'error']}">
+                  {r.bucket ?? 'error'}
+                </span>
+                <span class="font-mono text-dark-0">
+                  {r.score === null ? 'no score' : r.score.toFixed(3)}
+                </span>
+                <span class="text-dark-3">expected {r.expected ? 'yes' : 'no'}</span>
+                <span class="text-dark-3">batch {r.batch}</span>
+                <a
+                  href="/xguard?label={s.label}&sample={r.sampleId}"
+                  class="ml-auto text-blue-4 hover:text-blue-3"
+                >
+                  Review this sample &rarr;
+                </a>
+              </div>
+
+              <p class="whitespace-pre-wrap break-words font-mono text-sm leading-relaxed text-dark-0">
+                {#each expanded.has(r.id) ? r.full : r.head as piece, i (i)}{#if piece.className}<mark
+                    class="rounded px-0.5 {piece.className}">{piece.text}</mark
+                  >{:else}{piece.text}{/if}{/each}
+              </p>
+
+              {#if r.long}
+                <button
+                  type="button"
+                  onclick={() => toggle(r.id)}
+                  class="mt-1 text-xs text-blue-4 hover:text-blue-3"
+                >
+                  {expanded.has(r.id) ? 'Show less' : `Show all ${r.positivePrompt.length} chars`}
+                </button>
+              {/if}
+
+              {#if r.reason}
+                <p class="mt-2 border-t border-dark-5 pt-2 text-sm leading-relaxed text-dark-1">{r.reason}</p>
+              {/if}
+              {#if r.error}
+                <p class="mt-2 rounded bg-red-8/15 px-2 py-1 text-xs text-red-3">{r.error}</p>
+              {/if}
+            </article>
+          {/each}
+        {/if}
+      </div>
+    {/if}
+  </section>
+{/if}

--- a/apps/moderator/vite.config.ts
+++ b/apps/moderator/vite.config.ts
@@ -12,6 +12,22 @@ export default defineConfig(({ mode }) => {
 
   return {
     plugins: [tailwindcss(), sveltekit()],
+    // Precompile the routes at startup instead of on first request. Vite dev compiles a route the
+    // first time it is hit, which on this app is tens of seconds — long enough to read as a hang
+    // rather than a cold start, and it recurs after every restart.
+    server: {
+      warmup: {
+        ssrFiles: [
+          './src/routes/+layout.server.ts',
+          './src/routes/xguard/+page.server.ts',
+          './src/routes/xguard/+page.svelte',
+          './src/routes/xguard/labels/+page.svelte',
+          './src/routes/xguard/labels/[name]/+page.svelte',
+          './src/routes/xguard/runs/+page.svelte',
+        ],
+      },
+    },
+
     // @civitai/* packages ship raw TS (main: ./src/index.ts) — let Vite transpile them.
     // (Their deps like pg/kysely/jose stay external/node_modules.)
     ssr: {

--- a/apps/moderator/xguard-lab/README.md
+++ b/apps/moderator/xguard-lab/README.md
@@ -1,0 +1,69 @@
+# XGuard label lab
+
+Infrastructure for developing XGuard labels: sample live prompts, have a model rate them, have a human confirm or overturn that rating, and end up with a labelled set the tuning harness can measure against.
+
+The point is the loop, not any one label. Adding a label is adding an entry to `labels.ts` and running the rater again over samples you already have.
+
+Scoping doc: `_local/docs/plans/xguard-regex-retirement-scoping.md`. Tuning harness: `_local/docs/plans/xguard-age-labels/`.
+
+## Running it
+
+```bash
+# 1. lab database (standalone, port 5433 so it can't collide with a local Civitai Postgres)
+docker compose -f apps/moderator/xguard-lab/docker-compose.yml up -d
+
+# 2. sample live prompts, stratified across a label's score bands
+pnpm exec tsx --env-file=.env apps/moderator/xguard-lab/sample.ts \
+  --batch 2026-08-04-age --size 250 --label Young
+
+# 3. AI baseline rating for one label
+pnpm exec tsx --env-file=.env apps/moderator/xguard-lab/rate.ts \
+  --batch 2026-08-04-age --label AgeAsserted
+
+# 4. review at /xguard
+pnpm dev:moderator
+```
+
+The route needs `moderator:senior` and a signed-in session, so the auth hub has to be running too.
+
+## Why stratified sampling
+
+`Young` scores >= 0.5 on 81% of all live traffic. A uniform sample would be almost entirely high-score rows and would say nothing about where the boundary sits. Equal-sized score bands put review time where the decision is actually in doubt.
+
+## Why the rater comes first
+
+Prompts run hundreds of tokens with the deciding term buried in style boilerplate, a non-English tail, or a LoRA filename. Asking a moderator to form a verdict from scratch is slow and error-prone - on the last tuning pass, 4 of 7 false positives I read by hand looked like moderator mistakes, including a prompt that literally says `teen-ager` verdicted as a false positive.
+
+So the model reads carefully once and returns the exact spans it judged on. Those spans become the highlights, and the reviewer glances at three highlighted words instead of re-reading 800 tokens. `human_judgement` stores whether they **agreed**, plus the resulting verdict either way.
+
+### Raters refuse
+
+Safety-tuned models refuse some of this material outright and answer in prose instead of JSON. On the first 244-prompt run, `xiaomi/mimo-v2.5` refused 33 (14%).
+
+A refusal is not a verdict. Recording it as `false` would quietly bias the training set on exactly the worst prompts, so `rate.ts` detects a non-JSON response, counts it, and retries on `--fallback-model` (`deepseek/deepseek-v4-flash` by default). Anything both models refuse stays unrated rather than being guessed at.
+
+## Data model
+
+The unit of work is a **(sample, label) pair**, not a sample. A prompt sampled today for age can be judged for sexual content next month without being re-sampled.
+
+| table | holds |
+|---|---|
+| `sample` | prompt text, live XGuard scores at sample time, which batch |
+| `label_def` / `label_policy` | the label set, and every revision of its policy prose |
+| `machine_judgement` | what XGuard or the AI rater said, with reason and highlight spans |
+| `human_judgement` | agree/disagree, resulting verdict, reviewer, time on item |
+| `ground_truth` (view) | current verdict per pair, with reviewer count and whether contested |
+
+Judgements reference an exact `label_policy` row, so editing a policy never silently rewrites past results. `duration_ms` is recorded because a reviewer averaging two seconds is rubber-stamping, and that only shows up if the number is honest.
+
+The lab database has **no foreign keys into the Civitai database**. Moving it to its own cluster instance is a connection-string change.
+
+## Scope
+
+Age and sexual labels only. Celebrity/POI stays on the existing regex list - it's an intentional block on a name list, users aren't hitting it by accident, and a list is the right tool for that. Violence is deferred.
+
+## Known gaps
+
+- `orchestration.xguardPromptResults` has no `negativePrompt` column, so `sample.negative_prompt` is null for everything sampled from it. Asked Koen to add it; the schema and the rater already handle it.
+- That table's `blocked` column is `false` on all 2.26M rows.
+- Neither the model reasoning nor the generated image's maturity is persisted there yet.

--- a/apps/moderator/xguard-lab/docker-compose.yml
+++ b/apps/moderator/xguard-lab/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  xguard-lab-db:
+    image: postgres:16-alpine
+    container_name: xguard-lab-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: xguard
+      POSTGRES_PASSWORD: xguard
+      POSTGRES_DB: xguard_lab
+    # 5433 so it cannot collide with a local Civitai Postgres on 5432.
+    ports:
+      - '5433:5432'
+    volumes:
+      - xguard-lab-data:/var/lib/postgresql/data
+      - ./schema.sql:/docker-entrypoint-initdb.d/01-schema.sql:ro
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U xguard -d xguard_lab']
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+volumes:
+  xguard-lab-data:

--- a/apps/moderator/xguard-lab/eval-core.ts
+++ b/apps/moderator/xguard-lab/eval-core.ts
@@ -1,0 +1,241 @@
+/**
+ * Run a label's policy against the ground truth humans have confirmed, and record what it got
+ * wrong. This is the piece that closes the loop: review builds ground truth, this measures a
+ * policy against it, and the per-row results say which prompts to look at next.
+ *
+ * Owns its own `pg` connection from a connection string rather than taking a client, so the CLI
+ * and the SvelteKit route can both call it without agreeing on a database library.
+ *
+ * Ids are cast to text in SQL rather than left to pg's type parser. `@civitai/db` calls
+ * `setTypeParser(INT8, parseFloat)` on pg's PROCESS-GLOBAL registry, so a bigint comes back as a
+ * number once that module has loaded and as a string when it has not - meaning this file would
+ * return different types from the SvelteKit route than from the CLI. Casting makes it string in
+ * both, which is what the types here claim.
+ */
+import pg from 'pg';
+import { scan, type LabelPolicy } from './xguard-client';
+
+export type EvalOptions = {
+  connectionString: string;
+  label: string;
+  /** Omit to measure whatever the live registry currently has. That is the baseline. */
+  policyVersion?: number;
+  /** Restrict to one sampling batch. Omit for every sample with ground truth. */
+  batch?: string;
+  thresholdOverride?: number;
+  concurrency?: number;
+  limit?: number;
+  note?: string;
+  onProgress?: (done: number, total: number) => void;
+};
+
+export type EvalSummary = {
+  runId: string;
+  label: string;
+  policyLabel: string;
+  threshold: number;
+  total: number;
+  scored: number;
+  errors: number;
+  tp: number;
+  fp: number;
+  tn: number;
+  fn: number;
+  // Null, not zero, when undefined. With no positives in the ground truth, precision has no
+  // value - reporting 0.000 reads as "it got everything wrong" when it means "nothing to measure".
+  precision: number | null;
+  recall: number | null;
+  f1: number | null;
+};
+
+type GroundTruthRow = {
+  sample_id: string;
+  positive_prompt: string;
+  negative_prompt: string | null;
+  expected: boolean;
+  reviewers: string;
+};
+
+/**
+ * Majority vote across reviewers. A tie is dropped rather than broken arbitrarily - a prompt two
+ * moderators genuinely disagree on is not ground truth, and quietly picking a side would put an
+ * unearned number in the evaluation.
+ */
+const GROUND_TRUTH_SQL = `
+  SELECT h.sample_id::text AS sample_id,
+         s.positive_prompt,
+         s.negative_prompt,
+         count(*) FILTER (WHERE h.verdict) > count(*) FILTER (WHERE NOT h.verdict) AS expected,
+         count(*) AS reviewers
+    FROM human_judgement h
+    JOIN sample s ON s.id = h.sample_id
+   WHERE h.label = $1
+     AND h.excluded_reason IS NULL
+     AND ($2::text IS NULL OR s.batch = $2)
+   GROUP BY h.sample_id, s.positive_prompt, s.negative_prompt
+  HAVING count(*) FILTER (WHERE h.verdict) <> count(*) FILTER (WHERE NOT h.verdict)
+   ORDER BY h.sample_id
+`;
+
+export async function runEvaluation(opts: EvalOptions): Promise<EvalSummary> {
+  const client = new pg.Client({ connectionString: opts.connectionString });
+  await client.connect();
+
+  try {
+    // Resolve the policy under test.
+    let policy: LabelPolicy;
+    let policyId: string | null = null;
+    let policyLabel: string;
+
+    if (opts.policyVersion !== undefined) {
+      const { rows } = await client.query<{
+        id: string;
+        policy: string;
+        threshold: number;
+        action: string;
+      }>(
+        `SELECT id::text, policy, threshold, action FROM label_policy WHERE label = $1 AND version = $2`,
+        [opts.label, opts.policyVersion]
+      );
+      if (rows.length === 0) {
+        throw new Error(`no policy version ${opts.policyVersion} for label "${opts.label}"`);
+      }
+      policyId = rows[0].id;
+      policy = {
+        label: opts.label,
+        policy: rows[0].policy,
+        threshold: opts.thresholdOverride ?? rows[0].threshold,
+        action: rows[0].action,
+      };
+      policyLabel = `v${opts.policyVersion}`;
+    } else {
+      // Empty policy = don't send an override = measure the live registry.
+      policy = { label: opts.label, policy: '', threshold: opts.thresholdOverride ?? 0.4 };
+      policyLabel = 'live';
+    }
+
+    const { rows: truth } = await client.query<GroundTruthRow>(GROUND_TRUTH_SQL, [
+      opts.label,
+      opts.batch ?? null,
+    ]);
+    const rows = opts.limit ? truth.slice(0, opts.limit) : truth;
+    if (rows.length === 0) {
+      throw new Error(
+        `no confirmed ground truth for "${opts.label}"${opts.batch ? ` in batch ${opts.batch}` : ''}. Review some samples first.`
+      );
+    }
+
+    const { rows: runRows } = await client.query<{ id: string }>(
+      `INSERT INTO eval_run (label, policy_id, policy_label, threshold, batch, total, note)
+       VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id::text`,
+      [opts.label, policyId, policyLabel, policy.threshold, opts.batch ?? null, rows.length, opts.note ?? null]
+    );
+    const runId = runRows[0].id;
+
+    let next = 0;
+    let done = 0;
+    let errors = 0;
+    const concurrency = Math.min(opts.concurrency ?? 6, rows.length);
+
+    await Promise.all(
+      Array.from({ length: concurrency }, async () => {
+        for (;;) {
+          const i = next++;
+          if (i >= rows.length) return;
+          const row = rows[i];
+
+          let score: number | null = null;
+          let reason: string | null = null;
+          let error: string | null = null;
+          try {
+            const results = await scan({
+              input: { positivePrompt: row.positive_prompt, negativePrompt: row.negative_prompt },
+              policies: [policy],
+            });
+            const hit = results.find((r) => r.label?.toLowerCase() === opts.label.toLowerCase());
+            if (!hit) {
+              // With no policy override the orchestrator only knows labels in its live registry, so
+              // a candidate label that has never shipped comes back empty. Say that, rather than
+              // reporting an empty result list.
+              throw new Error(
+                policyId === null
+                  ? `"${opts.label}" is not in the live XGuard registry, so there is no baseline to measure. Import a policy and pass --policy-version.`
+                  : `label missing from output (got ${results.map((r) => r.label).join(', ') || 'nothing'})`
+              );
+            }
+            score = typeof hit.score === 'number' ? hit.score : null;
+            reason = hit.modelReason || null;
+          } catch (err) {
+            error = (err as Error).message;
+            errors++;
+          }
+
+          const predicted = score === null ? null : score >= policy.threshold;
+          const bucket =
+            predicted === null
+              ? 'error'
+              : predicted && row.expected
+                ? 'TP'
+                : predicted && !row.expected
+                  ? 'FP'
+                  : !predicted && !row.expected
+                    ? 'TN'
+                    : 'FN';
+
+          await client.query(
+            `INSERT INTO eval_result (run_id, sample_id, score, predicted, expected, bucket, reason, error)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+             ON CONFLICT (run_id, sample_id) DO NOTHING`,
+            [runId, row.sample_id, score, predicted, row.expected, bucket, reason, error]
+          );
+
+          done++;
+          opts.onProgress?.(done, rows.length);
+        }
+      })
+    );
+
+    const { rows: tally } = await client.query<{ bucket: string; n: string }>(
+      `SELECT bucket, count(*) AS n FROM eval_result WHERE run_id = $1 GROUP BY bucket`,
+      [runId]
+    );
+    const count = (b: string) => Number(tally.find((t) => t.bucket === b)?.n ?? 0);
+    const tp = count('TP');
+    const fp = count('FP');
+    const tn = count('TN');
+    const fn = count('FN');
+    const precision = tp + fp === 0 ? null : tp / (tp + fp);
+    const recall = tp + fn === 0 ? null : tp / (tp + fn);
+    const f1 =
+      precision === null || recall === null || precision + recall === 0
+        ? null
+        : (2 * precision * recall) / (precision + recall);
+
+    await client.query(
+      `UPDATE eval_run
+          SET status = 'complete', scored = $2, errors = $3, tp = $4, fp = $5, tn = $6, fn = $7,
+              precision = $8, recall = $9, f1 = $10, finished_at = now()
+        WHERE id = $1`,
+      [runId, tp + fp + tn + fn, errors, tp, fp, tn, fn, precision, recall, f1]
+    );
+
+    return {
+      runId,
+      label: opts.label,
+      policyLabel,
+      threshold: policy.threshold,
+      total: rows.length,
+      scored: tp + fp + tn + fn,
+      errors,
+      tp,
+      fp,
+      tn,
+      fn,
+      precision,
+      recall,
+      f1,
+    };
+  } finally {
+    await client.end();
+  }
+}

--- a/apps/moderator/xguard-lab/import-policy.ts
+++ b/apps/moderator/xguard-lab/import-policy.ts
@@ -1,0 +1,66 @@
+/**
+ * Import a policy-set JSON into `label_policy` as the next version of each label it defines.
+ *
+ *   pnpm exec tsx --env-file=.env apps/moderator/xguard-lab/import-policy.ts \
+ *     --file _local/docs/plans/xguard-age-labels/policies/age-split-v6-block.json
+ *
+ * Same shape the tuning harness uses:
+ *   { name, note?, combine?, labels: [{ label, policy, threshold, action? }] }
+ *
+ * Versions are per-label and only ever go up, so importing the same file twice gives you two
+ * versions with identical text rather than overwriting history an evaluation already points at.
+ */
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import pg from 'pg';
+
+type PolicySet = {
+  name: string;
+  note?: string;
+  labels: Array<{ label: string; policy: string; threshold: number; action?: string }>;
+};
+
+const argv = process.argv.slice(2);
+const get = (f: string) => {
+  const i = argv.indexOf(f);
+  return i === -1 ? undefined : argv[i + 1];
+};
+
+const file = get('--file');
+if (!file) throw new Error('--file is required');
+
+const set = JSON.parse(readFileSync(resolve(file), 'utf8')) as PolicySet;
+if (!set.labels?.length) throw new Error('policy set defines no labels');
+
+const client = new pg.Client({
+  connectionString:
+    get('--lab-db') ??
+    process.env.MODERATOR_DATABASE_URL ??
+    'postgres://xguard:xguard@localhost:5433/xguard_lab',
+});
+await client.connect();
+
+try {
+  for (const def of set.labels) {
+    await client.query(
+      `INSERT INTO label_def (name, description) VALUES ($1, $2) ON CONFLICT (name) DO NOTHING`,
+      [def.label, `Imported from ${set.name}`]
+    );
+
+    const { rows } = await client.query<{ next: number }>(
+      `SELECT COALESCE(max(version), 0) + 1 AS next FROM label_policy WHERE label = $1`,
+      [def.label]
+    );
+    const version = rows[0].next;
+
+    await client.query(
+      `INSERT INTO label_policy (label, version, policy, threshold, action, note)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [def.label, version, def.policy, def.threshold, def.action ?? 'Scan', set.note ?? set.name]
+    );
+
+    console.log(`${def.label}  ->  v${version}  (threshold ${def.threshold}, ${def.action ?? 'Scan'})`);
+  }
+} finally {
+  await client.end();
+}

--- a/apps/moderator/xguard-lab/labels.ts
+++ b/apps/moderator/xguard-lab/labels.ts
@@ -1,0 +1,92 @@
+/**
+ * The label set under development.
+ *
+ * These rubrics are what the AI rater judges against. They are deliberately NOT
+ * the same text as the XGuard policies: XGuard policies are written to steer a
+ * small guard model with an `- x:` / `sec` grammar, while these are written to
+ * be read by a strong model and, just as importantly, by the moderator deciding
+ * whether they agree. If the two ever disagree, this file is the intent.
+ *
+ * Scope note: age and sexual only for now. Celebrity/POI stays on the existing
+ * regex list - it is an intentional block on a name list, and a list is the
+ * right tool for that. Violence is deferred.
+ */
+export const LABELS = {
+  AgeAsserted: {
+    description: 'The prompt names a person under 18 in words you can quote.',
+    rubric: `TRUE when the prompt names a person under 18 in words you can point at and quote.
+
+Counts as an assertion:
+- An explicit age under 18 in any format: "12yo", "16 years old", "aged 9", "age:14".
+- An unambiguous minor noun: child, toddler, kid, baby, infant, preschooler, elementary student, middle schooler, little girl, little boy, loli, shota, cub, preteen, tween, teen, teenager.
+- A transliterated or non-Latin minor term: imouto, otouto, youjo, shoujo, JK, JS, JC, ロリ, ショタ, 少女, 女子高生, 小学生, 妹, 여학생, 소녀, học sinh, девочка.
+- A mangled tag spelling of one of the above: "sshotA", "Sh0ta", "l0li", "lo_li".
+- Family child-framing in a sexual context: "mom and son", "father and daughter".
+- Any of the above inside a LoRA, embedding or model filename.
+
+FALSE for:
+- Situational or stylistic youth coding on its own: school uniform, classroom, seifuku, twintails, pigtails, flat chest, petite, cute. Another label covers those.
+- Art style: anime, cartoon, chibi, stylised.
+- Character names from anime, games or comics, however that character is usually drawn.
+- Franchise, series or doujin titles, unless the title itself contains a minor term.
+- Quality and score boilerplate: masterpiece, best quality, absurdres, score_9, source_anime.
+- Embedding helper tags: zPDXL3, easynegative, PonyXLV6_Scores.
+- A minor term appearing only inside an unrelated word: "cub" in "incubus", "kid" in "kidney", "lolita" as a fashion style.
+- Anthro, furry, feral, monster-girl or kemono subjects, unless an explicit minor term is also present.`,
+  },
+
+  AgeNegated: {
+    description: 'The prompt states the subject is an adult.',
+    rubric: `TRUE when the prompt states, in words, that the subject is an adult.
+
+Counts as an adult assertion:
+- A stated adult age: 18, 19, 20, 21 or above, "in her 20s", "early twenties", "middle aged".
+- An explicit adult noun applied to the subject: adult, grown woman, grown man, mature, MILF, GILF, cougar, elderly, old woman, granny.
+- Either of the above even when youth-coded terms are also present. "schoolgirl, 25 years old" is TRUE. That combination is the reason this label exists.
+
+FALSE for:
+- Adulthood that is merely likely. An unspecified subject is not an adult assertion.
+- Sexual or explicit content. That is not an age statement.
+- Body descriptions: large breasts, curves, voluptuous, thick, tall, muscular.
+- Adult professions or venues on their own: nurse, teacher, office, bar, wedding.
+- "young woman", "young man", "young lady". Adult vocabulary, but they state no age.
+- An adult term describing someone other than the subject, or an object.`,
+  },
+
+  SexualNudity: {
+    description: 'The prompt requests nudity or exposed genitals, without necessarily requesting an act.',
+    rubric: `TRUE when the prompt requests a subject who is nude, partially nude, or has genitals, breasts or buttocks exposed.
+
+Counts:
+- Explicit nudity terms: nude, naked, topless, bottomless, fully nude, no clothes.
+- Named exposed anatomy: nipples, areola, genitals, penis, vulva, pussy, anus, bare breasts, exposed ass.
+- Clothing described as removed or displaced to expose: shirt lift, skirt lift, clothes pulled aside, one breast exposed, no panties, no bra with exposure.
+
+FALSE for:
+- Lingerie, swimwear, or revealing clothing that still covers. Suggestive is not nudity.
+- Anatomical or medical description without exposure framing.
+- Bare shoulders, midriff, legs, or feet.
+- Nudity requested only in the negative prompt.
+- Artistic nude as a genre reference without a nude subject being requested.`,
+  },
+
+  SexualAct: {
+    description: 'The prompt requests a sex act taking place.',
+    rubric: `TRUE when the prompt requests a sexual act being performed, not merely a nude or posed subject.
+
+Counts:
+- Named acts: sex, intercourse, penetration, oral, blowjob, fellatio, cunnilingus, anal, handjob, footjob, masturbation, fingering, humping.
+- Position names used as the requested activity: doggystyle, cowgirl, missionary, reverse cowgirl, mating press.
+- Depicted aftermath or in-progress markers: creampie, cum on body, cum inside, ahegao during an act.
+- Non-consent framing of an act still counts as an act.
+
+FALSE for:
+- Nudity, posing, or suggestive framing with no act. That is the nudity label.
+- Sex-adjacent objects with no act: dildo on a table, condom in frame.
+- Position names used to describe a pet or animal's pose rather than an act.
+- Kissing, hugging, or romantic framing without sexual activity.
+- An act named only in the negative prompt.`,
+  },
+} as const;
+
+export type LabName = keyof typeof LABELS;

--- a/apps/moderator/xguard-lab/rate.ts
+++ b/apps/moderator/xguard-lab/rate.ts
@@ -1,0 +1,239 @@
+/**
+ * AI baseline rating pass: judge every unrated sample in a batch for a label.
+ *
+ *   pnpm exec tsx --env-file=.env apps/moderator/xguard-lab/rate.ts \
+ *     --batch 2026-08-04-age --label AgeAsserted
+ *
+ * The rater is the baseline a human confirms rather than the final answer.
+ * Prompts are long and the deciding term is easy to miss, so the model reads
+ * carefully once and the reviewer only has to agree or disagree.
+ *
+ * It must return the exact spans it judged on. Those become the highlights in
+ * the review UI, which is the difference between a reviewer re-reading 800
+ * tokens and glancing at three highlighted words.
+ *
+ * Runs against OpenRouter. Writes to the lab DB only.
+ */
+import pg from 'pg';
+import { LABELS, type LabName } from './labels';
+
+type Args = { batch: string; label: LabName; model: string; fallbackModel: string; concurrency: number; limit?: number; labDb: string };
+
+function parseArgs(argv: string[]): Args {
+  const get = (f: string) => {
+    const i = argv.indexOf(f);
+    return i === -1 ? undefined : argv[i + 1];
+  };
+  const batch = get('--batch');
+  const label = get('--label') as LabName | undefined;
+  if (!batch) throw new Error('--batch is required');
+  if (!label || !LABELS[label]) {
+    throw new Error(`--label must be one of: ${Object.keys(LABELS).join(', ')}`);
+  }
+  return {
+    batch,
+    label,
+    model: get('--model') ?? 'xiaomi/mimo-v2.5',
+    fallbackModel: get('--fallback-model') ?? 'deepseek/deepseek-v4-flash',
+    concurrency: Number(get('--concurrency') ?? 6),
+    limit: get('--limit') ? Number(get('--limit')) : undefined,
+    labDb:
+      get('--lab-db') ??
+      process.env.MODERATOR_DATABASE_URL ??
+      'postgres://xguard:xguard@localhost:5433/xguard_lab',
+  };
+}
+
+class RaterRefusal extends Error {
+  constructor(sample: string) {
+    super(`rater refused: ${sample}`);
+    this.name = 'RaterRefusal';
+  }
+}
+
+type Rating = { verdict: boolean; reason: string; spans: string[] };
+
+async function rate(args: {
+  positivePrompt: string;
+  negativePrompt: string | null;
+  label: LabName;
+  model: string;
+}): Promise<Rating> {
+  const key = process.env.OPENROUTER_API_KEY;
+  if (!key) throw new Error('OPENROUTER_API_KEY not set');
+  const def = LABELS[args.label];
+
+  const system = `You judge image-generation prompts for a single label. Answer only for the label described; ignore every other concern.
+
+LABEL: ${args.label}
+${def.rubric}
+
+The prompt may be hundreds of tokens of style boilerplate with the deciding term buried in it, in a non-English section, or inside a LoRA or embedding filename. Read all of it.
+
+A term appearing ONLY in the negative prompt is an exclusion. The user is asking to avoid it, so it must never make the verdict true.
+
+Reply with JSON only:
+{"verdict": <true|false>, "reason": "<one or two sentences>", "spans": ["<exact substring you judged on>", ...]}
+
+Every span must be an exact substring of the prompt text, copied character for character. Return an empty array when nothing in the prompt is relevant.`;
+
+  const user = `POSITIVE PROMPT:\n${args.positivePrompt}\n\nNEGATIVE PROMPT:\n${args.negativePrompt ?? '(none)'}`;
+
+  const res = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      model: args.model,
+      temperature: 0,
+      response_format: { type: 'json_object' },
+      messages: [
+        { role: 'system', content: system },
+        { role: 'user', content: user },
+      ],
+    }),
+  });
+  if (!res.ok) throw new Error(`openrouter ${res.status}: ${(await res.text()).slice(0, 300)}`);
+
+  const json = (await res.json()) as { choices?: Array<{ message?: { content?: string } }> };
+  const content = json.choices?.[0]?.message?.content;
+  if (!content) throw new Error('no content in openrouter response');
+
+  const cleaned = content.replace(/^```(?:json)?|```$/g, '').trim();
+  // Safety-tuned raters refuse outright on some of this material and answer in prose. That is a
+  // refusal, not a malformed response, and it must not be recorded as a verdict - defaulting a
+  // refusal to false would quietly bias the training set on exactly the worst prompts.
+  if (!cleaned.startsWith('{')) throw new RaterRefusal(cleaned.slice(0, 120));
+
+  const parsed = JSON.parse(cleaned) as Partial<Rating>;
+  return {
+    verdict: Boolean(parsed.verdict),
+    reason: String(parsed.reason ?? ''),
+    // Drop hallucinated spans rather than highlighting text that is not there.
+    spans: (parsed.spans ?? []).filter(
+      (s) =>
+        typeof s === 'string' &&
+        s.length > 0 &&
+        (args.positivePrompt.includes(s) || (args.negativePrompt ?? '').includes(s))
+    ),
+  };
+}
+
+/** Character offsets so the UI does not have to re-find the spans. */
+function offsetsFor(text: string, spans: string[]) {
+  return spans.flatMap((span) => {
+    const out: Array<{ start: number; end: number; text: string }> = [];
+    let from = 0;
+    for (;;) {
+      const at = text.indexOf(span, from);
+      if (at === -1) break;
+      out.push({ start: at, end: at + span.length, text: span });
+      from = at + span.length;
+    }
+    return out;
+  });
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const client = new pg.Client({ connectionString: args.labDb });
+  await client.connect();
+
+  try {
+    await client.query(
+      `INSERT INTO label_def (name, description) VALUES ($1, $2) ON CONFLICT (name) DO NOTHING`,
+      [args.label, LABELS[args.label].description]
+    );
+
+    const { rows } = await client.query<{
+      id: string;
+      positive_prompt: string;
+      negative_prompt: string | null;
+    }>(
+      `SELECT s.id, s.positive_prompt, s.negative_prompt
+         FROM sample s
+        WHERE s.batch = $1
+          AND NOT EXISTS (
+            SELECT 1 FROM machine_judgement m
+             WHERE m.sample_id = s.id AND m.label = $2 AND m.source = 'ai'
+          )
+        ORDER BY s.id
+        ${args.limit ? `LIMIT ${args.limit}` : ''}`,
+      [args.batch, args.label]
+    );
+
+    console.log(`rating ${rows.length} unrated samples for ${args.label} with ${args.model}`);
+    if (rows.length === 0) return;
+
+    let next = 0;
+    let done = 0;
+    let failed = 0;
+    let refused = 0;
+
+    await Promise.all(
+      Array.from({ length: Math.min(args.concurrency, rows.length) }, async () => {
+        for (;;) {
+          const i = next++;
+          if (i >= rows.length) return;
+          const row = rows[i];
+          try {
+            const call = (model: string) =>
+              rate({
+                positivePrompt: row.positive_prompt,
+                negativePrompt: row.negative_prompt,
+                label: args.label,
+                model,
+              });
+            let usedModel = args.model;
+            let r;
+            try {
+              r = await call(args.model);
+            } catch (err) {
+              if (!(err instanceof RaterRefusal)) throw err;
+              refused++;
+              usedModel = args.fallbackModel;
+              r = await call(args.fallbackModel);
+            }
+            await client.query(
+              `INSERT INTO machine_judgement (sample_id, label, source, model, verdict, reason, highlights)
+               VALUES ($1, $2, 'ai', $3, $4, $5, $6)`,
+              [
+                row.id,
+                args.label,
+                usedModel,
+                r.verdict,
+                r.reason,
+                JSON.stringify({
+                  positive: offsetsFor(row.positive_prompt, r.spans),
+                  negative: offsetsFor(row.negative_prompt ?? '', r.spans),
+                }),
+              ]
+            );
+          } catch (err) {
+            failed++;
+            console.error(`  sample ${row.id}: ${(err as Error).message}`);
+          }
+          done++;
+          if (done % 25 === 0) console.log(`  ${done}/${rows.length}${failed ? ` (${failed} failed)` : ''}`);
+        }
+      })
+    );
+
+    const { rows: summary } = await client.query<{ verdict: boolean; n: string }>(
+      `SELECT verdict, count(*) AS n FROM machine_judgement
+        WHERE label = $1 AND source = 'ai'
+          AND sample_id IN (SELECT id FROM sample WHERE batch = $2)
+        GROUP BY verdict`,
+      [args.label, args.batch]
+    );
+    console.log(`\n${args.label}: ${summary.map((s) => `${s.verdict ? 'true' : 'false'}=${s.n}`).join('  ')}`);
+    if (refused) console.log(`${refused} refused by ${args.model}, retried on ${args.fallbackModel}`);
+    if (failed) console.log(`${failed} still unrated`);
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/moderator/xguard-lab/run-eval.ts
+++ b/apps/moderator/xguard-lab/run-eval.ts
@@ -1,0 +1,57 @@
+/**
+ * CLI for an evaluation run. Same code path the UI uses, so an agent iterating on policy prose and
+ * a human clicking a button produce comparable numbers.
+ *
+ *   # baseline: whatever the live registry has today
+ *   pnpm exec tsx --env-file=.env apps/moderator/xguard-lab/run-eval.ts --label AgeAsserted
+ *
+ *   # a candidate policy version, at a chosen threshold
+ *   pnpm exec tsx --env-file=.env apps/moderator/xguard-lab/run-eval.ts \
+ *     --label AgeAsserted --policy-version 2 --threshold 0.25
+ */
+import { runEvaluation } from './eval-core';
+
+function parseArgs(argv: string[]) {
+  const get = (f: string) => {
+    const i = argv.indexOf(f);
+    return i === -1 ? undefined : argv[i + 1];
+  };
+  const label = get('--label');
+  if (!label) throw new Error('--label is required');
+  return {
+    label,
+    policyVersion: get('--policy-version') ? Number(get('--policy-version')) : undefined,
+    batch: get('--batch'),
+    thresholdOverride: get('--threshold') ? Number(get('--threshold')) : undefined,
+    concurrency: Number(get('--concurrency') ?? 6),
+    limit: get('--limit') ? Number(get('--limit')) : undefined,
+    note: get('--note'),
+    connectionString:
+      get('--lab-db') ??
+      process.env.MODERATOR_DATABASE_URL ??
+      'postgres://xguard:xguard@localhost:5433/xguard_lab',
+  };
+}
+
+const args = parseArgs(process.argv.slice(2));
+
+const summary = await runEvaluation({
+  ...args,
+  onProgress: (done, total) => {
+    if (done % 25 === 0 || done === total) console.log(`  ${done}/${total}`);
+  },
+});
+
+// n/a rather than 0.000 when the ground truth has no positives to measure against.
+const pct = (n: number | null) => (n === null ? 'n/a' : n.toFixed(3));
+console.log(`
+run ${summary.runId}  ${summary.label} @ ${summary.policyLabel}  threshold ${summary.threshold}
+  TP ${summary.tp}   FP ${summary.fp}   TN ${summary.tn}   FN ${summary.fn}${summary.errors ? `   errors ${summary.errors}` : ''}
+  precision ${pct(summary.precision)}   recall ${pct(summary.recall)}   f1 ${pct(summary.f1)}
+`);
+
+if (summary.tp + summary.fn === 0) {
+  console.log(
+    'No positives in the ground truth yet, so recall is unmeasurable. Review some prompts the rater flagged true.\n'
+  );
+}

--- a/apps/moderator/xguard-lab/sample.ts
+++ b/apps/moderator/xguard-lab/sample.ts
@@ -1,0 +1,134 @@
+/**
+ * Pull a stratified sample of live prompts from ClickHouse into the lab DB.
+ *
+ *   pnpm exec tsx --env-file=.env apps/moderator/xguard-lab/sample.ts \
+ *     --batch 2026-08-04-age --size 500
+ *
+ * Stratifies on a label's live XGuard score rather than sampling uniformly.
+ * `Young` currently scores >= 0.5 on 81% of all traffic, so a uniform sample is
+ * almost entirely high-score rows and tells us nothing about where the boundary
+ * actually sits. Equal-sized score bands spend review time where the decision
+ * is genuinely in doubt.
+ *
+ * Read-only against ClickHouse. Writes only to the lab Postgres.
+ */
+import pg from 'pg';
+
+type Args = {
+  batch: string;
+  size: number;
+  label: string;
+  bands: number;
+  days: number;
+  labDb: string;
+};
+
+function parseArgs(argv: string[]): Args {
+  const get = (flag: string) => {
+    const i = argv.indexOf(flag);
+    return i === -1 ? undefined : argv[i + 1];
+  };
+  const batch = get('--batch');
+  if (!batch) throw new Error('--batch is required (e.g. --batch 2026-08-04-age)');
+  return {
+    batch,
+    size: Number(get('--size') ?? 500),
+    label: get('--label') ?? 'Young',
+    bands: Number(get('--bands') ?? 5),
+    days: Number(get('--days') ?? 7),
+    labDb:
+      get('--lab-db') ??
+      process.env.MODERATOR_DATABASE_URL ??
+      'postgres://xguard:xguard@localhost:5433/xguard_lab',
+  };
+}
+
+type ChRow = {
+  promptHash: string;
+  promptCreatedAt: string;
+  userId: number;
+  positivePrompt: string;
+  scores: Record<string, number>;
+};
+
+async function clickhouse<T>(sql: string): Promise<T[]> {
+  const host = process.env.CLICKHOUSE_HOST;
+  if (!host) throw new Error('CLICKHOUSE_HOST not set');
+  const auth = Buffer.from(
+    `${process.env.CLICKHOUSE_USERNAME ?? 'default'}:${process.env.CLICKHOUSE_PASSWORD ?? ''}`
+  ).toString('base64');
+
+  const res = await fetch(host, {
+    method: 'POST',
+    headers: { Authorization: `Basic ${auth}`, 'Content-Type': 'text/plain' },
+    body: `${sql} FORMAT JSONEachRow`,
+  });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`clickhouse ${res.status}: ${text.slice(0, 400)}`);
+  return text
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((l) => JSON.parse(l) as T);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const perBand = Math.max(1, Math.floor(args.size / args.bands));
+
+  // One query per band. Cheaper and clearer than a windowed single query, and it
+  // makes a short band obvious instead of silently rebalancing.
+  const rows: ChRow[] = [];
+  for (let b = 0; b < args.bands; b++) {
+    const lo = b / args.bands;
+    const hi = (b + 1) / args.bands;
+    const band = await clickhouse<ChRow>(`
+      SELECT promptHash, toString(createdAt) AS promptCreatedAt, userId, positivePrompt, scores
+      FROM orchestration.xguardPromptResults
+      WHERE createdAt >= now() - INTERVAL ${args.days} DAY
+        AND mapContains(scores, '${args.label}')
+        AND scores['${args.label}'] >= ${lo} AND scores['${args.label}'] < ${hi}
+        AND length(positivePrompt) BETWEEN 10 AND 8000
+      ORDER BY cityHash64(promptHash)
+      LIMIT ${perBand}
+    `);
+    console.log(`  band ${lo.toFixed(2)}-${hi.toFixed(2)}: ${band.length} rows`);
+    rows.push(...band);
+  }
+
+  // Same prompt can land in one band only, but guard anyway - a hash colliding
+  // across bands would violate the (batch, prompt_hash) unique constraint.
+  const seen = new Set<string>();
+  const unique = rows.filter((r) => !seen.has(r.promptHash) && seen.add(r.promptHash));
+
+  const client = new pg.Client({ connectionString: args.labDb });
+  await client.connect();
+  try {
+    let inserted = 0;
+    for (const r of unique) {
+      const res = await client.query(
+        `INSERT INTO sample
+           (prompt_hash, source, batch, user_id, positive_prompt, live_scores, prompt_created_at)
+         VALUES ($1, 'xguardPromptResults', $2, $3, $4, $5, $6)
+         ON CONFLICT (batch, prompt_hash) DO NOTHING`,
+        [
+          r.promptHash,
+          args.batch,
+          r.userId,
+          r.positivePrompt,
+          JSON.stringify(r.scores),
+          r.promptCreatedAt,
+        ]
+      );
+      inserted += res.rowCount ?? 0;
+    }
+    console.log(`\nbatch "${args.batch}": ${inserted} inserted, ${unique.length - inserted} already present`);
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/moderator/xguard-lab/schema-constraints.sql
+++ b/apps/moderator/xguard-lab/schema-constraints.sql
@@ -1,0 +1,29 @@
+-- Foreign keys on the label columns of both judgement tables.
+--
+-- `sample_id` already referenced `sample`; `label` referencing nothing was an oversight rather
+-- than a decision. `label_def.name` is the PK and the rater upserts the parent row before any
+-- judgement exists, so nothing legitimate is blocked by this.
+--
+-- RESTRICT, never CASCADE. `label_def.status` exists so a label can be retired without deleting
+-- its history, and CASCADE would turn a stray DELETE on a parent row into silent destruction of
+-- the ground truth these constraints are meant to protect. Failing loudly is the point.
+--
+-- Both tables get it together: an AI judgement under a label a human judgement would refuse is a
+-- worse inconsistency than having neither constraint.
+
+ALTER TABLE human_judgement
+  DROP CONSTRAINT IF EXISTS human_judgement_label_fkey;
+ALTER TABLE human_judgement
+  ADD CONSTRAINT human_judgement_label_fkey
+  FOREIGN KEY (label) REFERENCES label_def(name) ON DELETE RESTRICT;
+
+ALTER TABLE machine_judgement
+  DROP CONSTRAINT IF EXISTS machine_judgement_label_fkey;
+ALTER TABLE machine_judgement
+  ADD CONSTRAINT machine_judgement_label_fkey
+  FOREIGN KEY (label) REFERENCES label_def(name) ON DELETE RESTRICT;
+
+-- Not closed here: `reviewed_judgement_id` is still not checked to belong to the same sample. A
+-- composite FK would need a redundant unique key on machine_judgement(id, sample_id). A wrong
+-- value there degrades provenance rather than corrupting a verdict, so it is guarded in the
+-- action instead.

--- a/apps/moderator/xguard-lab/schema-eval.sql
+++ b/apps/moderator/xguard-lab/schema-eval.sql
@@ -1,0 +1,49 @@
+-- Evaluation runs: score a label's policy against the ground truth humans have confirmed.
+--
+-- Additive to schema.sql. Apply with:
+--   docker exec -i xguard-lab-db psql -U xguard -d xguard_lab < schema-eval.sql
+
+CREATE TABLE IF NOT EXISTS eval_run (
+  id            bigserial PRIMARY KEY,
+  label         text NOT NULL,
+  -- Which policy was under test. Null means "whatever the live registry had", which is the
+  -- baseline every candidate gets compared against.
+  policy_id     bigint REFERENCES label_policy(id),
+  policy_label  text NOT NULL,
+  threshold     real NOT NULL,
+  -- Restrict to one sampling batch, or null for every sample with ground truth.
+  batch         text,
+  status        text NOT NULL DEFAULT 'running',
+  total         int NOT NULL DEFAULT 0,
+  scored        int NOT NULL DEFAULT 0,
+  errors        int NOT NULL DEFAULT 0,
+  tp            int NOT NULL DEFAULT 0,
+  fp            int NOT NULL DEFAULT 0,
+  tn            int NOT NULL DEFAULT 0,
+  fn            int NOT NULL DEFAULT 0,
+  precision     real,
+  recall        real,
+  f1            real,
+  note          text,
+  started_at    timestamptz NOT NULL DEFAULT now(),
+  finished_at   timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS eval_run_label_idx ON eval_run (label, started_at DESC);
+
+-- Per-sample outcome, so a run can be drilled into rather than just reporting four numbers.
+-- This is what makes "show me what it got wrong" possible.
+CREATE TABLE IF NOT EXISTS eval_result (
+  id            bigserial PRIMARY KEY,
+  run_id        bigint NOT NULL REFERENCES eval_run(id) ON DELETE CASCADE,
+  sample_id     bigint NOT NULL REFERENCES sample(id) ON DELETE CASCADE,
+  score         real,
+  predicted     boolean,
+  expected      boolean NOT NULL,
+  bucket        text,
+  reason        text,
+  error         text,
+  UNIQUE (run_id, sample_id)
+);
+
+CREATE INDEX IF NOT EXISTS eval_result_run_bucket_idx ON eval_result (run_id, bucket);

--- a/apps/moderator/xguard-lab/schema-exclude.sql
+++ b/apps/moderator/xguard-lab/schema-exclude.sql
@@ -1,0 +1,21 @@
+-- Let a judgement be retired without deleting it.
+--
+-- The first 37 rows were produced while a stale-DOM-read bug submitted the previous click's
+-- answer, so the sequence is shifted by one and the verdicts cannot be trusted. Deleting them
+-- would also delete the evidence that the bug was real (the duration_ms pattern: 8 nulls and a
+-- 1ms minimum), and "just remember not to use those" is not a mechanism - the ground-truth query
+-- would pick them straight back up.
+--
+-- NULL means valid. Anything non-null is a reason the row is retired, which reads better in a
+-- query than a bare boolean and forces whoever excludes a row to say why.
+
+ALTER TABLE human_judgement
+  ADD COLUMN IF NOT EXISTS excluded_reason text;
+
+CREATE INDEX IF NOT EXISTS human_judgement_valid_idx
+  ON human_judgement (label, sample_id) WHERE excluded_reason IS NULL;
+
+UPDATE human_judgement
+   SET excluded_reason = 'stale-submit bug: recorded the previous click''s answer'
+ WHERE excluded_reason IS NULL
+   AND created_at < timestamptz '2026-08-05 00:00:00+00';

--- a/apps/moderator/xguard-lab/schema-terms.sql
+++ b/apps/moderator/xguard-lab/schema-terms.sql
@@ -1,0 +1,23 @@
+-- Highlight terms, per label, editable without a deploy.
+--
+-- These were a hardcoded constant. That was wrong for two reasons: the vocabulary that matters
+-- differs per label (youth nouns mean nothing when reviewing a sexual-content label), and the list
+-- gets edited constantly as tuning surfaces spellings moderators miss. A constant in the repo makes
+-- every one of those edits a code change.
+--
+-- CASCADE here, unlike the judgement tables: terms are owned by their label and mean nothing
+-- without it, whereas a judgement is evidence that must outlive a label being retired.
+
+CREATE TABLE IF NOT EXISTS label_term (
+  id          bigserial PRIMARY KEY,
+  label       text NOT NULL REFERENCES label_def(name) ON DELETE CASCADE,
+  term        text NOT NULL,
+  -- trigger: argues FOR the label firing.  counter: argues against.
+  -- soft:    weak on its own, meaningful when several stack.
+  kind        text NOT NULL CHECK (kind IN ('trigger', 'counter', 'soft')),
+  note        text,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (label, term)
+);
+
+CREATE INDEX IF NOT EXISTS label_term_label_idx ON label_term (label);

--- a/apps/moderator/xguard-lab/schema.sql
+++ b/apps/moderator/xguard-lab/schema.sql
@@ -1,0 +1,120 @@
+-- XGuard label lab: standalone Postgres schema.
+--
+-- Deliberately has NO foreign keys into the Civitai database. userId and
+-- promptHash are carried as plain values so this can live in its own instance
+-- (local docker now, its own cluster instance later) without coupling.
+--
+-- The unit of work is a (sample, label) pair: one prompt judged for one label.
+-- A prompt sampled once can be judged for age today and for sexual content next
+-- month without being re-sampled.
+
+CREATE TABLE IF NOT EXISTS label_def (
+  name          text PRIMARY KEY,
+  description   text NOT NULL,
+  -- Free text so a label can be retired without deleting its history.
+  status        text NOT NULL DEFAULT 'active',
+  created_at    timestamptz NOT NULL DEFAULT now()
+);
+
+-- Every revision of a label's policy prose. Judgements point at the exact
+-- revision that produced them, so changing a policy never silently invalidates
+-- or rewrites past results.
+CREATE TABLE IF NOT EXISTS label_policy (
+  id            bigserial PRIMARY KEY,
+  label         text NOT NULL REFERENCES label_def(name) ON DELETE CASCADE,
+  version       int NOT NULL,
+  policy        text NOT NULL,
+  threshold     real NOT NULL,
+  action        text NOT NULL DEFAULT 'Scan',
+  note          text,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (label, version)
+);
+
+-- A prompt pulled from orchestration.xguardPromptResults (or anywhere else).
+CREATE TABLE IF NOT EXISTS sample (
+  id                bigserial PRIMARY KEY,
+  -- Int64 in ClickHouse. Null when a sample did not come from that table.
+  prompt_hash       bigint,
+  source            text NOT NULL DEFAULT 'xguardPromptResults',
+  -- Which sampling run produced this, so a batch can be evaluated as a unit.
+  batch             text NOT NULL,
+  user_id           int,
+  positive_prompt   text NOT NULL,
+  negative_prompt   text,
+  -- Scores XGuard had at sample time, as a label -> score object.
+  live_scores       jsonb,
+  prompt_created_at timestamptz,
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (batch, prompt_hash)
+);
+
+CREATE INDEX IF NOT EXISTS sample_batch_idx ON sample (batch);
+CREATE INDEX IF NOT EXISTS sample_prompt_hash_idx ON sample (prompt_hash);
+
+-- What a model said about (sample, label). Covers both XGuard and the AI rater;
+-- `source` distinguishes them and `model` records which one.
+CREATE TABLE IF NOT EXISTS machine_judgement (
+  id            bigserial PRIMARY KEY,
+  sample_id     bigint NOT NULL REFERENCES sample(id) ON DELETE CASCADE,
+  label         text NOT NULL,
+  source        text NOT NULL CHECK (source IN ('xguard', 'ai')),
+  model         text,
+  -- Set for XGuard. The AI rater returns a verdict, not a probability.
+  score         real,
+  verdict       boolean NOT NULL,
+  reason        text,
+  -- Character spans worth highlighting, as [{start, end, field, kind}].
+  highlights    jsonb,
+  policy_id     bigint REFERENCES label_policy(id),
+  created_at    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS machine_judgement_sample_idx ON machine_judgement (sample_id, label);
+CREATE INDEX IF NOT EXISTS machine_judgement_lookup_idx ON machine_judgement (label, source, created_at DESC);
+
+-- A human agreeing or disagreeing with a machine judgement. The whole point of
+-- the review UI: confirming a decision is faster and more accurate than forming
+-- one from scratch, so we store the agreement, not a fresh verdict.
+--
+-- `verdict` is the resulting ground truth either way: on agreement it copies the
+-- machine verdict, on disagreement it is the opposite. Storing it explicitly
+-- means the training set is one column, not a join and a conditional.
+CREATE TABLE IF NOT EXISTS human_judgement (
+  id                    bigserial PRIMARY KEY,
+  sample_id             bigint NOT NULL REFERENCES sample(id) ON DELETE CASCADE,
+  label                 text NOT NULL,
+  -- Which machine judgement was on screen. Null if reviewed cold.
+  reviewed_judgement_id bigint REFERENCES machine_judgement(id) ON DELETE SET NULL,
+  agreed                boolean,
+  verdict               boolean NOT NULL,
+  -- Reviewer's own note. Rare, and worth reading when present.
+  note                  text,
+  reviewer_id           int NOT NULL,
+  -- Wall-clock seconds on the item. A reviewer averaging 2s is rubber-stamping.
+  duration_ms           int,
+  created_at            timestamptz NOT NULL DEFAULT now(),
+  -- One verdict per reviewer per (sample, label); re-reviewing overwrites.
+  UNIQUE (sample_id, label, reviewer_id)
+);
+
+CREATE INDEX IF NOT EXISTS human_judgement_label_idx ON human_judgement (label, created_at DESC);
+
+-- Convenience view: the current ground truth per (sample, label), with the
+-- number of reviewers behind it. Single-reviewer labels were the binding
+-- constraint on the last tuning pass, so agreement count is surfaced here
+-- rather than left to be recomputed by every consumer.
+CREATE OR REPLACE VIEW ground_truth AS
+SELECT
+  h.sample_id,
+  h.label,
+  bool_or(h.verdict)                             AS any_true,
+  count(*)                                       AS reviewer_count,
+  count(*) FILTER (WHERE h.verdict)              AS true_count,
+  count(*) FILTER (WHERE NOT h.verdict)          AS false_count,
+  count(*) FILTER (WHERE h.verdict) > count(*) FILTER (WHERE NOT h.verdict) AS verdict,
+  count(*) > 1
+    AND count(*) FILTER (WHERE h.verdict) > 0
+    AND count(*) FILTER (WHERE NOT h.verdict) > 0 AS contested
+FROM human_judgement h
+GROUP BY h.sample_id, h.label;

--- a/apps/moderator/xguard-lab/seed-terms.ts
+++ b/apps/moderator/xguard-lab/seed-terms.ts
@@ -1,0 +1,138 @@
+/**
+ * Seed `label_term` from the lists that used to be hardcoded in `src/lib/highlight-terms.ts`.
+ *
+ *   pnpm exec tsx --env-file=.env apps/moderator/xguard-lab/seed-terms.ts
+ *
+ * Idempotent: `ON CONFLICT (label, term) DO UPDATE` refreshes the kind, so re-running after editing
+ * this file corrects a mis-categorised term rather than silently skipping it. It does NOT delete
+ * terms that have been removed here — pass `--prune` for that, which will also drop anything added
+ * through the UI, so do not make it the default.
+ */
+import pg from 'pg';
+
+const TERMS: Record<string, { trigger?: string[]; counter?: string[]; soft?: string[] }> = {
+  AgeAsserted: {
+    trigger: [
+      'child', 'children', 'kid', 'kids', 'toddler', 'baby', 'infant',
+      'minor', 'minors', 'underage',
+      'loli', 'lolicon', 'shota', 'shotacon', 'cub', 'cunny',
+      'schoolgirl', 'schoolboy', 'schoolgirls', 'schoolboys',
+      'elementary student', 'middle schooler', 'kindergartner', 'preschooler',
+      'aged down', 'age regression', 'age-regressed', 'de-aged',
+      'teen', 'teens', 'teenage', 'teenager', 'teenagers', 'teen-ager',
+      'preteen', 'pre-teen', 'tween', 'jailbait',
+      'little girl', 'little boy', 'little child', 'little kid',
+      'young son', 'young daughter', 'young child', 'young kid',
+      'toddler body', 'baby body', 'infant body',
+      // Transliterated. These were the misses during tuning.
+      'imouto', 'otouto', 'youjo', 'shoujo', 'shounen',
+      'học sinh', 'em gái', 'девочка', '学生', '女子高生', '女子中学生', '小学生',
+      '少女', '妹', 'ロリ', 'ショタ', '여학생', '소녀',
+      // Mangled tag spellings seen in real prompts.
+      'sshota', 'sh0ta', 'l0li', 'lo_li', 'loli_girl',
+      'mom and son', 'father and daughter', 'mother and son', 'dad and daughter',
+    ],
+    counter: [
+      'adult', 'mature', 'milf', 'gilf', 'elderly', 'old woman', 'old man',
+      'cougar', 'granny', 'matron', 'voluptuous adult', 'mature female', 'mature woman',
+      'grown woman', 'grown man',
+      'young woman', 'young man', 'young female', 'young lady',
+      'young actor', 'young model', 'young athlete', 'young professional',
+      'young couple', 'young college girl', 'young adult',
+      'in her 20s', 'in his 20s', 'in her 30s', 'in his 30s',
+      'early twenties', 'late teens', '20-something', 'thirtysomething', 'middle aged',
+    ],
+    soft: [
+      'young', 'petite', 'shortstack', 'small frame', 'cute face', 'cute',
+      'small body', 'tiny body', 'slim', 'slender', 'delicate', 'flat chest',
+      'smooth skin', 'soft features', 'innocent', 'naive', 'shy', 'pure',
+      'chibi', 'chibi proportions', 'twintails', 'pigtails', 'sidelocks',
+      '1girl', '1boy', '2girls', '2boys', 'girl', 'boy',
+      'school uniform', 'seifuku', 'classroom', 'playground', 'gym uniform',
+    ],
+  },
+
+  AgeNegated: {
+    trigger: [
+      'adult', 'mature', 'mature woman', 'mature female', 'milf', 'gilf', 'cougar',
+      'elderly', 'old woman', 'old man', 'granny', 'matron', 'grown woman', 'grown man',
+      'in her 20s', 'in his 20s', 'in her 30s', 'in his 30s',
+      'early twenties', '20-something', 'thirtysomething', 'middle aged',
+      'of legal age', 'over 18',
+    ],
+    counter: [
+      'child', 'loli', 'shota', 'schoolgirl', 'teen', 'teenager', 'little girl', 'little boy',
+    ],
+    soft: ['young woman', 'young man', 'young lady', 'college', 'university student'],
+  },
+
+  SexualNudity: {
+    trigger: [
+      'nude', 'naked', 'topless', 'bottomless', 'no clothes', 'undressed',
+      'nipples', 'areola', 'genitals', 'genitalia', 'penis', 'vulva', 'pussy', 'anus',
+      'bare breasts', 'shirt lift', 'skirt lift', 'no panties', 'no bra',
+      'exposed breasts', 'exposed ass', 'full frontal',
+    ],
+    counter: ['clothed', 'fully dressed', 'modest', 'covered'],
+    soft: ['lingerie', 'swimsuit', 'bikini', 'suggestive', 'seductive', 'sensual', 'revealing'],
+  },
+
+  SexualAct: {
+    trigger: [
+      'sex', 'intercourse', 'penetration', 'oral', 'blowjob', 'blow job', 'fellatio',
+      'cunnilingus', 'anal', 'handjob', 'footjob', 'masturbation', 'masturbate',
+      'fingering', 'humping', 'creampie', 'gangbang', 'mating press',
+      'doggystyle', 'doggy style', 'cowgirl', 'missionary',
+    ],
+    counter: ['solo', 'portrait', 'standing', 'posing'],
+    soft: ['cum', 'ahegao', 'hentai', 'porn', 'explicit', 'nsfw'],
+  },
+};
+
+const DESCRIPTIONS: Record<string, string> = {
+  AgeAsserted: 'The prompt names a person under 18 in words you can quote.',
+  AgeNegated: 'The prompt states the subject is an adult.',
+  SexualNudity: 'The prompt requests nudity or exposed genitals.',
+  SexualAct: 'The prompt requests a sex act taking place.',
+};
+
+const prune = process.argv.includes('--prune');
+const client = new pg.Client({
+  connectionString:
+    process.env.MODERATOR_DATABASE_URL ?? 'postgres://xguard:xguard@localhost:5433/xguard_lab',
+});
+await client.connect();
+
+try {
+  for (const [label, kinds] of Object.entries(TERMS)) {
+    await client.query(
+      `INSERT INTO label_def (name, description) VALUES ($1, $2) ON CONFLICT (name) DO NOTHING`,
+      [label, DESCRIPTIONS[label] ?? label]
+    );
+
+    let n = 0;
+    for (const [kind, terms] of Object.entries(kinds)) {
+      for (const term of terms ?? []) {
+        await client.query(
+          `INSERT INTO label_term (label, term, kind) VALUES ($1, $2, $3)
+           ON CONFLICT (label, term) DO UPDATE SET kind = EXCLUDED.kind`,
+          [label, term, kind]
+        );
+        n++;
+      }
+    }
+
+    if (prune) {
+      const all = Object.values(kinds).flatMap((t) => t ?? []);
+      const { rowCount } = await client.query(
+        `DELETE FROM label_term WHERE label = $1 AND term <> ALL($2::text[])`,
+        [label, all]
+      );
+      if (rowCount) console.log(`  pruned ${rowCount} from ${label}`);
+    }
+
+    console.log(`${label}: ${n} terms`);
+  }
+} finally {
+  await client.end();
+}

--- a/apps/moderator/xguard-lab/xguard-client.ts
+++ b/apps/moderator/xguard-lab/xguard-client.ts
@@ -1,0 +1,98 @@
+/**
+ * Direct orchestrator client for XGuard prompt scans.
+ *
+ * Two things verified against prod that this relies on:
+ *   - A label in `labelOverrides` does NOT have to exist in the live registry, so a candidate
+ *     label set can be evaluated without writing anything to the orchestrator.
+ *   - Passing `labels` restricts evaluation to those labels only: one model call per row instead
+ *     of fourteen.
+ *
+ * `storeFullResponse` is what makes the model's explanation come back. Without it `modelReason` is
+ * an empty string with `finishReason: 'length'`, which reads like a bug and is really an opt-in.
+ */
+export type LabelPolicy = {
+  label: string;
+  policy: string;
+  threshold: number;
+  action?: string;
+};
+
+export type LabelResult = {
+  label: string;
+  score: number;
+  triggered: boolean;
+  topToken?: string;
+  modelReason?: string;
+  finishReason?: string;
+  policyHash?: string;
+};
+
+export type XGuardInput = {
+  positivePrompt: string;
+  negativePrompt?: string | null;
+};
+
+type WorkflowResponse = {
+  status?: string;
+  steps?: Array<{ $type?: string; output?: { results?: LabelResult[] } }>;
+};
+
+export function orchestratorConfig() {
+  const endpoint = process.env.ORCHESTRATOR_ENDPOINT;
+  const token = process.env.ORCHESTRATOR_ACCESS_TOKEN ?? process.env.ORCHESTRATOR_TOKEN;
+  if (!endpoint) throw new Error('ORCHESTRATOR_ENDPOINT not set');
+  if (!token) throw new Error('ORCHESTRATOR_ACCESS_TOKEN not set');
+  return { endpoint: endpoint.replace(/\/$/, ''), token };
+}
+
+export async function scan(args: {
+  input: XGuardInput;
+  policies: LabelPolicy[];
+  wait?: number;
+  withReason?: boolean;
+}): Promise<LabelResult[]> {
+  const { endpoint, token } = orchestratorConfig();
+  const { input, policies, wait = 60, withReason = true } = args;
+
+  // An empty policy string means "use whatever the live registry has", so it must not be sent as
+  // an override - that is how a baseline run works.
+  const overrides = policies
+    .filter((p) => p.policy.trim().length > 0)
+    .map((p) => ({
+      label: p.label,
+      action: p.action ?? 'Scan',
+      threshold: p.threshold,
+      policy: p.policy,
+    }));
+
+  const body = {
+    steps: [
+      {
+        $type: 'xGuardModeration',
+        input: {
+          mode: 'prompt',
+          positivePrompt: input.positivePrompt,
+          negativePrompt: input.negativePrompt ?? '',
+          labels: policies.map((p) => p.label),
+          storeFullResponse: withReason,
+          ...(overrides.length > 0 ? { labelOverrides: overrides } : {}),
+        },
+      },
+    ],
+  };
+
+  const res = await fetch(`${endpoint}/v2/consumer/workflows?wait=${wait}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`orchestrator HTTP ${res.status}: ${(await res.text()).slice(0, 300)}`);
+  }
+
+  const json = (await res.json()) as WorkflowResponse;
+  const step = json.steps?.find((s) => s.$type === 'xGuardModeration');
+  const results = step?.output?.results;
+  if (!results) throw new Error(`no xGuardModeration output (status ${json.status})`);
+  return results;
+}

--- a/packages/civitai-db/src/kysely.ts
+++ b/packages/civitai-db/src/kysely.ts
@@ -3,7 +3,7 @@ import { Pool, types, type PoolConfig } from 'pg';
 
 // Re-export `sql` so apps build raw fragments without a direct kysely dependency — the db layer owns it.
 export { sql } from 'kysely';
-export type { RawBuilder } from 'kysely';
+export type { Generated, RawBuilder } from 'kysely';
 
 // Kysely client builder. Standalone — imports only kysely + pg (NOT the Prisma client /
 // db-helpers / env), so a Vite/SSR app can import `@civitai/db/kysely` without pulling Prisma.


### PR DESCRIPTION
Infrastructure for developing XGuard labels, so the legacy regex prompt filter can eventually be retired. Scoped out of the 2026-07-29 eng call with Koen and Briant.

**Based on `moderator-app-pages` (#3573), not `main`** — that branch is the real base for this app. Rebased onto it; the diff below is only the lab.

## The loop

Sample live prompts → a model rates them → a human confirms or overturns → measure a policy against the resulting ground truth → edit the policy → repeat.

The unit of work is a **(sample, label) pair**, not a sample, so a prompt sampled for age today can be judged for sexual content next month without being re-sampled. Adding a label is a rubric plus a rater run.

| Route | What it does |
|---|---|
| `/xguard` | Review queue — hotkeys, notes, undo, skip, term highlighting |
| `/xguard/labels` | Coverage per label, and *why* a label is not yet measurable |
| `/xguard/labels/[name]` | Policy editor, versioned, with an evaluate button |
| `/xguard/runs` | Run history and FP/FN drill-down |
| `xguard-lab/*.ts` | CLI parity — agents drive prose development, humans review behaviour |

## How it lands on #3573

Only four files overlap with that branch, and three auto-merged (`.env.example`, `vite.config.ts`, `packages/civitai-db/src/kysely.ts`). The fourth is `access.ts`, resolved entirely in favour of the new grant model:

- **`/xguard` is registered in `NAVIGATION` as a single leaf**, so one grant covers the whole lab. Its sub-pages resolve by prefix rather than being listed separately — they are steps of one loop, and granting someone the review queue but not the run history would hide the numbers their review produces. Happy to split it into a group with children if you'd rather it be granular.
- **⚠️ Somebody has to make that grant on `/admin` after deploy.** Under the old tier model `moderator:senior` reached the lab automatically; under the grant model an ungranted path is reachable only by `moderator:admin`. So on first deploy the lab will look broken to everyone else until the grant exists. Flagging because it reads as a deploy failure rather than a missing row.

**Review question:** the `+page.server.ts` files still call `requireAccess(locals.user, url.pathname)` per page. Your `hooks.server.ts` now gates centrally and `apps/moderator/CLAUDE.md` says to register the page rather than check per-page — happy to strip those calls, I left them rather than guess during a rebase.

## Notes for review

- **Lab tables live in the moderator database** (`MODERATOR_DATABASE_URL`), which has no foreign keys into Civitai's Postgres. That variable is now deployed pointing at the `internal_tools` instance (talos-infra#885). Schema is in `xguard-lab/*.sql` and is applied **by hand**, as with every other migration in this repo.
- **Precision and recall are nullable throughout** and render `n/a`, never `0.000`. With no confirmed positives they are mathematically undefined, and `0.000` reads as "the policy got everything wrong".
- One line outside `apps/moderator`: `packages/civitai-db/src/kysely.ts` re-exports the `Generated` type so the app can type the lab schema without taking a direct `kysely` dependency.
- `vite.config.ts` gains `server.warmup` for these routes. Vite compiles routes on first request, which on this app is tens of seconds and reads as a hang.

## Known, deliberate

- **`LabDB` types every bigint as `Generated<string>`** while `@civitai/db` installs a process-global `INT8 → parseFloat` parser, so they arrive as numbers. Normalised at load boundaries with comments; the declaration is still wrong. Left as a deliberate decision rather than a mid-PR change because retyping cascades through the scripts.
- **`xguard-lab.ts` is a second client over `MODERATOR_DATABASE_URL`**, alongside this branch's `moderator-db.ts`. One database should not have two clients — `LabDB` should fold into `ModeratorDB` and this module should go. Left for a follow-up rather than done here, so the fold is reviewable on its own.

## Not in this PR

An agent-facing JSON API for the tuning loop (the reason for deploying this at all — other teams' agents driving the loop) was prototyped and pulled back out. It needs a decision on how a Civitai API key gets resolved to a user, which is a hub question rather than a lab one. Written up separately and sent to @bkdiehl; the prototype is parked on `feat/xguard-agent-api-prototype`.

## Testing

`pnpm --filter @civitai/moderator-app typecheck` clean on the new base. Driven end to end against a live database: 244 sampled prompts, 244 AI ratings, evaluation runs recorded. An adversarial review by a separate agent found seven issues in an earlier revision, all fixed — including a Svelte 5 flush bug where `requestSubmit()` read stale hidden inputs and recorded the previous click's answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
