### PR TITLE
fix(skills): parse Postgres `timestamp` as UTC in the query runners

### DIFF
--- a/.claude/skills/postgres-query/query.mjs
+++ b/.claude/skills/postgres-query/query.mjs
@@ -66,6 +66,13 @@ loadEnv();
 
 const { Client } = pg;
 
+// `timestamp` (OID 1114) carries no offset and node-postgres parses it in the
+// reader's local timezone, silently shifting every value we print as UTC.
+const parseTimestamp = pg.types.getTypeParser(1114);
+pg.types.setTypeParser(1114, (value) =>
+  /^-?infinity$/i.test(value) ? parseTimestamp(value) : new Date(value + 'Z')
+);
+
 const DEFAULT_TIMEOUT_SECONDS = 30;
 
 // Parse arguments

--- a/.claude/skills/retool-query/query.mjs
+++ b/.claude/skills/retool-query/query.mjs
@@ -55,6 +55,14 @@ function loadEnv() {
 loadEnv();
 
 const { Client } = pg;
+
+// `timestamp` (OID 1114) carries no offset and node-postgres parses it in the
+// reader's local timezone, silently shifting every value we print as UTC.
+const parseTimestamp = pg.types.getTypeParser(1114);
+pg.types.setTypeParser(1114, (value) =>
+  /^-?infinity$/i.test(value) ? parseTimestamp(value) : new Date(value + 'Z')
+);
+
 const DEFAULT_TIMEOUT_SECONDS = 30;
 
 // Parse arguments

--- a/apps/event-engine/.claude/skills/postgres-query/query.mjs
+++ b/apps/event-engine/.claude/skills/postgres-query/query.mjs
@@ -62,6 +62,13 @@ loadEnv();
 
 const { Client } = pg;
 
+// `timestamp` (OID 1114) carries no offset and node-postgres parses it in the
+// reader's local timezone, silently shifting every value we print as UTC.
+const parseTimestamp = pg.types.getTypeParser(1114);
+pg.types.setTypeParser(1114, (value) =>
+  /^-?infinity$/i.test(value) ? parseTimestamp(value) : new Date(value + 'Z')
+);
+
 const DEFAULT_TIMEOUT_SECONDS = 30;
 
 // Parse arguments


### PR DESCRIPTION
## The bug

The query skills build their `pg` Client with no `TZ` and no type-parser override. node-postgres parses OID **1114** (`timestamp without time zone`) into a JS `Date` using **the reading machine's local timezone**, and the tool then prints that `Date` as ISO/UTC. Every `timestamp` column read through these skills came back shifted by the reader's local UTC offset.

The trap: `now()` is `timestamptz` (OID 1184) and parses **correctly**. Putting the two side by side looks exactly like a production data bug. This already produced a confident false alarm that `ImageReaction."createdAt"` was being stamped 6 hours in the future, and nearly triggered a "fix" to a perfectly healthy write path.

## Before / after

Same query, same machine (`America/Denver`, UTC-6), against the DataPacket replica:

**Before**
```
now_text          '2026-08-07 18:40:32.559481+00'
now_as_ts_parsed  2026-08-08T00:40:32.559Z     <- same instant, rendered +6h. WRONG.
created_text      '2026-08-07 18:05:28.2'
created_parsed    2026-08-08T00:05:28.200Z     <- WRONG
```

**After**
```
now_text          '2026-08-07 18:42:17.129008+00'
now_as_ts_parsed  2026-08-07T18:42:17.129Z     <- matches now_text
created_text      '2026-08-07 18:05:28.2'
created_parsed    2026-08-07T18:05:28.200Z     <- matches created_text
```

`timestamptz` did not regress — `now()` still returns the correct instant (verified separately as a bare `now()`, not just the `::timestamp` cast).

## Edge cases

Verified against the replica after the change:

```
tstz     2026-08-07T18:42:36.305Z   (timestamptz, unaffected)
pos_inf  Infinity                   ('infinity'::timestamp)
neg_inf  -Infinity                  ('-infinity'::timestamp)
null_ts  null                       (NULL::timestamp)
```

- **`infinity` / `-infinity`** — naively appending `Z` yields `"infinityZ"` and an invalid `Date`, so those two values delegate to the original pg parser and still come back as `±Infinity`.
- **NULL** — pg short-circuits NULL before the parser runs (`pg/lib/result.js`, both `parseRow` and `_parseRowAsArray` guard on `rawValue !== null`), so the parser is never invoked with `null`. Confirmed in source, not assumed, and confirmed at runtime above.
- **OID 1115 (`timestamp[]`) — deliberately not handled.** pg-types builds the array parser over a captured reference to the original element parser, so overriding 1114 does not propagate to it, and rebuilding it would need `postgres-array`, which is not resolvable from the skill directories. There are **zero** `timestamp[]`/`timestamptz[]` columns in the production database (`information_schema.columns where udt_name in ('_timestamp','_timestamptz')` returns no rows) and none in `schema.full.prisma`, so this only affects an ad-hoc `array_agg(<timestamp>)`, which stays shifted. Left alone to keep the diff minimal; noted here so it isn't a surprise.
- **OID 1082 (`date`) is also parsed in local time** (`'2026-08-07'::date` → `2026-08-07T06:00:00.000Z`). Pre-existing, unrelated to the reported bug, and only visible as a rendered midnight offset. Left alone.

Chose `setTypeParser` over `process.env.TZ = 'UTC'`: it fixes the semantics at the parsing boundary instead of depending on an env var other code may also read.

## Scope

Three files — every place under `.claude/skills/` that constructs a `pg` client (`grep` for `from 'pg'` / `require('pg')` found exactly these):

- `.claude/skills/postgres-query/query.mjs`
- `.claude/skills/retool-query/query.mjs`
- `apps/event-engine/.claude/skills/postgres-query/query.mjs`

The one repo consumer of the skill's output, `scripts/oneoffs/ea-price-cap-makegood.mjs`, does not depend on the local-time behaviour — it passes UTC string literals as query bounds and never re-parses the returned `Date`s.

## Why this matters

It silently corrupts every Postgres-vs-ClickHouse time comparison an agent makes. ClickHouse returns UTC; Postgres `timestamp` came back shifted, with no error and no warning, so the two datastores disagree by the reader's local offset on every join, gap analysis, or "is this row late?" check.

Note: these are `.mjs` files under `.claude/skills/` and are **not** covered by `pnpm typecheck` or `pnpm lint` — I did not run those and am not claiming they passed. `pnpm exec prettier --write` on the three files reports them already formatted correctly. The proof is the before/after output above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
