### PR TITLE
fix(feed): fall back to Meili on BitDex failure; empty Following set returns nothing

### DIFF
--- a/src/server/bitdex/__tests__/client-outcome.test.ts
+++ b/src/server/bitdex/__tests__/client-outcome.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// queryBitdex collapses "the request failed" and "the query matched nothing" into the
+// same null, which is why callers that must choose between serving an empty page and
+// falling back to another backend go through queryBitdexOutcome. Both contracts are
+// pinned here: queryBitdex's null-on-failure signature is unchanged for its existing
+// callers, and queryBitdexOutcome distinguishes the two cases.
+
+// BITDEX_URL is captured at module load, so it has to be set before the import.
+process.env.BITDEX_URL = 'http://bitdex.test';
+
+const okBody = { ids: [], total_matched: 0, elapsed_us: 5 };
+
+const jsonResponse = (body: unknown, status = 200) =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response);
+
+describe('queryBitdexOutcome', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('reports ok for a 200 that matched nothing', async () => {
+    const { queryBitdexOutcome } = await import('../client');
+    fetchMock.mockResolvedValue(jsonResponse(okBody));
+
+    await expect(queryBitdexOutcome('civitai', [])).resolves.toEqual({
+      status: 'ok',
+      result: okBody,
+    });
+  });
+
+  it('reports failed for a non-2xx response', async () => {
+    const { queryBitdexOutcome } = await import('../client');
+    fetchMock.mockResolvedValue(jsonResponse({ error: 'boom' }, 503));
+
+    await expect(queryBitdexOutcome('civitai', [])).resolves.toEqual({ status: 'failed' });
+  });
+
+  it('reports failed when the request throws (timeout, network)', async () => {
+    const { queryBitdexOutcome } = await import('../client');
+    fetchMock.mockRejectedValue(new Error('The operation was aborted'));
+
+    await expect(queryBitdexOutcome('civitai', [])).resolves.toEqual({ status: 'failed' });
+  });
+});
+
+describe('queryBitdex null-on-failure contract', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns the result object on success', async () => {
+    const { queryBitdex } = await import('../client');
+    fetchMock.mockResolvedValue(jsonResponse(okBody));
+
+    await expect(queryBitdex('civitai', [])).resolves.toEqual(okBody);
+  });
+
+  it('returns null on failure', async () => {
+    const { queryBitdex } = await import('../client');
+    fetchMock.mockResolvedValue(jsonResponse({ error: 'boom' }, 500));
+
+    await expect(queryBitdex('civitai', [])).resolves.toBeNull();
+  });
+});

--- a/src/server/bitdex/client.ts
+++ b/src/server/bitdex/client.ts
@@ -93,6 +93,14 @@ export interface BitdexQueryResult {
 }
 
 /**
+ * A failed round-trip and a query that legitimately matched nothing are the same
+ * `null` through `queryBitdex`, which is why callers that must choose between
+ * serving an empty feed and falling back to another backend use
+ * `queryBitdexOutcome` instead.
+ */
+export type BitdexQueryOutcome = { status: 'ok'; result: BitdexQueryResult } | { status: 'failed' };
+
+/**
  * Query BitDex with pre-built filter clauses and sort.
  * Returns null on any error (never throws).
  *
@@ -105,9 +113,31 @@ export async function queryBitdex(
   limit = 100,
   cursor?: any,
   offset?: number,
-  includeDocs?: boolean | string[],
+  includeDocs?: boolean | string[]
 ): Promise<BitdexQueryResult | null> {
-  if (!BITDEX_URL) return null;
+  const outcome = await queryBitdexOutcome(
+    indexName,
+    filters,
+    sort,
+    limit,
+    cursor,
+    offset,
+    includeDocs
+  );
+  return outcome.status === 'ok' ? outcome.result : null;
+}
+
+/** Same query as {@link queryBitdex}, with failure distinguishable from an empty match. */
+export async function queryBitdexOutcome(
+  indexName: string,
+  filters: FilterClause[],
+  sort?: SortClause,
+  limit = 100,
+  cursor?: any,
+  offset?: number,
+  includeDocs?: boolean | string[]
+): Promise<BitdexQueryOutcome> {
+  if (!BITDEX_URL) return { status: 'failed' };
   try {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), BITDEX_TIMEOUT_MS);
@@ -139,8 +169,10 @@ export async function queryBitdex(
     clearTimeout(timeout);
     if (!res.ok) {
       const errText = await res.text().catch(() => '');
-      console.error(`[BitDex] Query failed ${res.status} (${Date.now() - start}ms): ${errText.slice(0, 500)}`);
-      return null;
+      console.error(
+        `[BitDex] Query failed ${res.status} (${Date.now() - start}ms): ${errText.slice(0, 500)}`
+      );
+      return { status: 'failed' };
     }
     const result = await withSpan(
       'bitdex:http:parse',
@@ -151,16 +183,19 @@ export async function queryBitdex(
       },
       () => res.json()
     );
-    console.log('[BitDex] result:', JSON.stringify({
-      ms: Date.now() - start,
-      matched: result.total_matched,
-      ids: result.ids?.length ?? 0,
-      docs: result.documents?.length ?? 0,
-      elapsed_us: result.elapsed_us,
-    }));
-    return result;
+    console.log(
+      '[BitDex] result:',
+      JSON.stringify({
+        ms: Date.now() - start,
+        matched: result.total_matched,
+        ids: result.ids?.length ?? 0,
+        docs: result.documents?.length ?? 0,
+        elapsed_us: result.elapsed_us,
+      })
+    );
+    return { status: 'ok', result };
   } catch (err) {
     console.error(`[BitDex] Query error:`, err);
-    return null;
+    return { status: 'failed' };
   }
 }

--- a/src/server/services/__tests__/bitdex-primary-fallback.test.ts
+++ b/src/server/services/__tests__/bitdex-primary-fallback.test.ts
@@ -240,12 +240,16 @@ describe('BitDex primary username lookup', () => {
     expect(recordBitdexErrorMock).not.toHaveBeenCalled();
   });
 
+  // Guards the other half of the narrowing. This has to REJECT rather than resolve
+  // `{ status: 'failed' }` — a resolved failure never throws, so it would exercise the
+  // accumulation guard instead of the catch and pass no matter what the catch does.
   it('still falls through to Meili for a non-TRPC failure', async () => {
     readUserMock.mockResolvedValue({ id: 77 });
-    queryBitdexOutcomeMock.mockResolvedValue({ status: 'failed' });
+    queryBitdexOutcomeMock.mockRejectedValue(new Error('boom'));
 
     const result = await getImagesFromSearch({ ...withUsername });
 
     expect(result.source).toBe('meili');
+    expect(recordBitdexErrorMock).toHaveBeenCalled();
   });
 });

--- a/src/server/services/__tests__/bitdex-primary-fallback.test.ts
+++ b/src/server/services/__tests__/bitdex-primary-fallback.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// A BitDex query that FAILS and one that legitimately matches nothing both reach
+// fetchBitdexPrimary as an empty accumulation. When the own-excluded second pass is
+// running (logged-in caller, no userId filter, first page) that empty accumulation slips
+// past the `!accumulated.length && !ownExcludedPromise` guard, so getImagesFromSearch
+// receives a truthy `{ data: [] }`, never consults Meilisearch, and the user gets a blank
+// feed instead of a degraded one.
+//
+// Pinned here, end to end through getImagesFromSearch:
+//   - main pass FAILED, nothing accumulated → falls through to Meili (source 'meili')
+//   - main pass returned a legitimate empty 200 → serves the empty BitDex page
+//
+// Minimal-seam mocking follows image-feed-clickhouse-failsoft.test.ts: stub the infra
+// clients and env so importing image.service doesn't boot anything real.
+
+const { queryBitdexOutcomeMock, queryBitdexMock } = vi.hoisted(() => ({
+  queryBitdexOutcomeMock: vi.fn(),
+  queryBitdexMock: vi.fn(),
+}));
+
+vi.mock('~/server/bitdex/client', () => ({
+  queryBitdex: queryBitdexMock,
+  queryBitdexOutcome: queryBitdexOutcomeMock,
+  fetchBitdexDocuments: vi.fn(),
+}));
+
+vi.mock('~/env/server', () => ({
+  env: new Proxy({ LOGGING: [] as string[] } as Record<string, unknown>, {
+    get: (target, prop) => {
+      if (prop in target) return target[prop as string];
+      if (typeof prop === 'string' && (prop.endsWith('_URL') || prop.endsWith('_ENDPOINT')))
+        return 'https://test:test@localhost:5432/test';
+      if (
+        typeof prop === 'string' &&
+        /(_CONCURRENCY|_LIMIT|_MS|_PORT|_TIMEOUT|_MAX|_SIZE|_COUNT)$/.test(prop)
+      )
+        return 1;
+      return undefined;
+    },
+  }),
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/redis/client', () => {
+  const make = (): any => new Proxy(() => 'k', { get: () => make() });
+  const keyProxy = make();
+  return {
+    redis: {
+      get: vi.fn().mockResolvedValue('[]'),
+      set: vi.fn().mockResolvedValue(undefined),
+      packed: { get: vi.fn(), set: vi.fn() },
+    },
+    sysRedis: {},
+    REDIS_KEYS: keyProxy,
+    REDIS_SYS_KEYS: keyProxy,
+  };
+});
+
+// NB: do NOT mock '~/server/flipt/client' — a catch-all Proxy mock wedges image.service's
+// module-load import. The real module loads fine and getFliptBoolean fail-opens to false.
+
+import { getImagesFromSearch } from '../image.service';
+
+// currentUserId with no userId filter and no cursor is exactly the shape that starts the
+// own-excluded second pass — the condition under which the blank feed reproduced.
+const baseInput = {
+  limit: 10,
+  browsingLevel: 1,
+  currentUserId: 500,
+  bitdexMode: 'primary',
+} as any;
+
+const emptyOk = {
+  status: 'ok' as const,
+  result: { ids: [], total_matched: 0, documents: [], elapsed_us: 1 },
+};
+
+describe('BitDex primary fallback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Meilisearch is unconfigured here, so the fall-through path returns an empty page
+    // tagged `source: 'meili'` — enough to observe WHICH backend answered.
+    queryBitdexMock.mockResolvedValue(null);
+  });
+
+  it('falls through to Meili when the main BitDex query fails', async () => {
+    queryBitdexOutcomeMock.mockResolvedValue({ status: 'failed' });
+
+    const result = await getImagesFromSearch(baseInput);
+
+    expect(result.source).toBe('meili');
+  });
+
+  it('serves the empty BitDex page when the main query legitimately matches nothing', async () => {
+    queryBitdexOutcomeMock.mockResolvedValue(emptyOk);
+
+    const result = await getImagesFromSearch(baseInput);
+
+    expect(result.source).toBe('bitdex');
+    expect(result.data).toEqual([]);
+  });
+
+  it('still serves BitDex results when a later pagination pass fails', async () => {
+    queryBitdexOutcomeMock.mockResolvedValueOnce({
+      status: 'ok',
+      result: {
+        ids: [1],
+        total_matched: 1,
+        cursor: { sortAt: 1 },
+        elapsed_us: 1,
+        documents: [
+          {
+            id: 1,
+            url: 'a.jpeg',
+            nsfwLevel: 1,
+            userId: 7,
+            sortAt: 1_700_000_000,
+            publishedAt: 1_700_000_000,
+          },
+        ],
+      },
+    });
+    queryBitdexOutcomeMock.mockResolvedValue({ status: 'failed' });
+
+    const result = await getImagesFromSearch(baseInput);
+
+    expect(result.source).toBe('bitdex');
+    expect(result.data.map((d: { id: number }) => d.id)).toEqual([1]);
+  });
+});

--- a/src/server/services/__tests__/bitdex-primary-fallback.test.ts
+++ b/src/server/services/__tests__/bitdex-primary-fallback.test.ts
@@ -20,11 +20,23 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // Minimal-seam mocking follows image-feed-clickhouse-failsoft.test.ts: stub the infra
 // clients and env so importing image.service doesn't boot anything real.
 
-const { queryBitdexOutcomeMock, queryBitdexMock, readUserMock, writeUserMock } = vi.hoisted(() => ({
+const {
+  queryBitdexOutcomeMock,
+  queryBitdexMock,
+  readUserMock,
+  writeUserMock,
+  recordBitdexErrorMock,
+} = vi.hoisted(() => ({
   queryBitdexOutcomeMock: vi.fn(),
   queryBitdexMock: vi.fn(),
   readUserMock: vi.fn(),
   writeUserMock: vi.fn(),
+  recordBitdexErrorMock: vi.fn(),
+}));
+
+vi.mock('~/server/bitdex/compare', () => ({
+  recordBitdexError: recordBitdexErrorMock,
+  compareBitdexResults: vi.fn(),
 }));
 
 vi.mock('~/server/bitdex/client', () => ({
@@ -211,5 +223,29 @@ describe('BitDex primary username lookup', () => {
 
     await expect(getImagesFromBitdexPreFilter(withUsername)).resolves.toBeTruthy();
     expect(writeUserMock).not.toHaveBeenCalled();
+  });
+
+  // The NOT_FOUND has to reach the client. Primary mode's catch treats a throw as "BitDex
+  // is broken, try Meili", which would send a rejected request down a second backend to
+  // reach the same 404 and count a client error against BitDex's health.
+  it('propagates NotFound out of primary mode instead of falling through to Meili', async () => {
+    readUserMock.mockResolvedValue(null);
+    writeUserMock.mockResolvedValue(null);
+
+    // Meili is unconfigured here, so consulting it resolves with `source: 'meili'`.
+    // Rejecting is therefore the observable proof that it was never consulted.
+    await expect(getImagesFromSearch({ ...withUsername })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+    expect(recordBitdexErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('still falls through to Meili for a non-TRPC failure', async () => {
+    readUserMock.mockResolvedValue({ id: 77 });
+    queryBitdexOutcomeMock.mockResolvedValue({ status: 'failed' });
+
+    const result = await getImagesFromSearch({ ...withUsername });
+
+    expect(result.source).toBe('meili');
   });
 });

--- a/src/server/services/__tests__/bitdex-primary-fallback.test.ts
+++ b/src/server/services/__tests__/bitdex-primary-fallback.test.ts
@@ -20,9 +20,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // Minimal-seam mocking follows image-feed-clickhouse-failsoft.test.ts: stub the infra
 // clients and env so importing image.service doesn't boot anything real.
 
-const { queryBitdexOutcomeMock, queryBitdexMock } = vi.hoisted(() => ({
+const { queryBitdexOutcomeMock, queryBitdexMock, readUserMock, writeUserMock } = vi.hoisted(() => ({
   queryBitdexOutcomeMock: vi.fn(),
   queryBitdexMock: vi.fn(),
+  readUserMock: vi.fn(),
+  writeUserMock: vi.fn(),
 }));
 
 vi.mock('~/server/bitdex/client', () => ({
@@ -48,10 +50,14 @@ vi.mock('~/env/server', () => ({
 }));
 
 // userEngagement backs the `followed` short-circuit; an empty follow set is the
-// unsatisfiable case exercised below.
+// unsatisfiable case exercised below. user.findUnique backs the username lookup, which
+// reads the replica and falls through to the primary.
 vi.mock('~/server/db/client', () => ({
-  dbRead: { userEngagement: { findMany: vi.fn(async () => [] as unknown[]) } },
-  dbWrite: {},
+  dbRead: {
+    userEngagement: { findMany: vi.fn(async () => [] as unknown[]) },
+    user: { findUnique: readUserMock },
+  },
+  dbWrite: { user: { findUnique: writeUserMock } },
 }));
 vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
 vi.mock('~/server/redis/client', () => {
@@ -72,7 +78,7 @@ vi.mock('~/server/redis/client', () => {
 // NB: do NOT mock '~/server/flipt/client' — a catch-all Proxy mock wedges image.service's
 // module-load import. The real module loads fine and getFliptBoolean fail-opens to false.
 
-import { getImagesFromSearch } from '../image.service';
+import { getImagesFromBitdexPreFilter, getImagesFromSearch } from '../image.service';
 
 // currentUserId with no userId filter and no cursor is exactly the shape that starts the
 // own-excluded second pass — the condition under which the blank feed reproduced.
@@ -167,5 +173,43 @@ describe('BitDex primary fallback', () => {
 
     expect(result.source).toBe('bitdex');
     expect(result.data.map((d: { id: number }) => d.id)).toEqual([1]);
+  });
+});
+
+// The username lookup is the one short-circuit that is NOT an unsatisfiable query: an
+// unknown username is an error everywhere else in the service (getAllImages,
+// getImagesFromSearchPreFilter), and classifying it as "legitimately empty" here would
+// have turned a dead profile into a silent empty gallery. It also has to survive replica
+// lag, or a freshly created user's own profile 404s.
+describe('BitDex primary username lookup', () => {
+  const withUsername = { ...baseInput, username: 'someone' };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryBitdexOutcomeMock.mockResolvedValue(emptyOk);
+  });
+
+  it('throws NotFound for an unknown username rather than serving an empty page', async () => {
+    readUserMock.mockResolvedValue(null);
+    writeUserMock.mockResolvedValue(null);
+
+    await expect(getImagesFromBitdexPreFilter(withUsername)).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('falls through to the primary when the replica has not caught up', async () => {
+    readUserMock.mockResolvedValue(null);
+    writeUserMock.mockResolvedValue({ id: 77 });
+
+    await expect(getImagesFromBitdexPreFilter(withUsername)).resolves.toBeTruthy();
+    expect(writeUserMock).toHaveBeenCalled();
+  });
+
+  it('does not touch the primary when the replica has the user', async () => {
+    readUserMock.mockResolvedValue({ id: 77 });
+
+    await expect(getImagesFromBitdexPreFilter(withUsername)).resolves.toBeTruthy();
+    expect(writeUserMock).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/__tests__/bitdex-primary-fallback.test.ts
+++ b/src/server/services/__tests__/bitdex-primary-fallback.test.ts
@@ -7,8 +7,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // receives a truthy `{ data: [] }`, never consults Meilisearch, and the user gets a blank
 // feed instead of a degraded one.
 //
+// The same null also comes back for queries that CANNOT match — an empty follow set, an
+// unknown username — which short-circuit before any request. Those must not fall back to
+// Meili, and must not reach the own-excluded merge either: a Following feed with nobody
+// followed would otherwise render as the viewer's own private and blocked images.
+//
 // Pinned here, end to end through getImagesFromSearch:
 //   - main pass FAILED, nothing accumulated → falls through to Meili (source 'meili')
+//   - main pass UNSATISFIABLE → empty BitDex page, own-excluded content not merged
 //   - main pass returned a legitimate empty 200 → serves the empty BitDex page
 //
 // Minimal-seam mocking follows image-feed-clickhouse-failsoft.test.ts: stub the infra
@@ -41,7 +47,12 @@ vi.mock('~/env/server', () => ({
   }),
 }));
 
-vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+// userEngagement backs the `followed` short-circuit; an empty follow set is the
+// unsatisfiable case exercised below.
+vi.mock('~/server/db/client', () => ({
+  dbRead: { userEngagement: { findMany: vi.fn(async () => [] as unknown[]) } },
+  dbWrite: {},
+}));
 vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
 vi.mock('~/server/redis/client', () => {
   const make = (): any => new Proxy(() => 'k', { get: () => make() });
@@ -97,6 +108,34 @@ describe('BitDex primary fallback', () => {
     queryBitdexOutcomeMock.mockResolvedValue(emptyOk);
 
     const result = await getImagesFromSearch(baseInput);
+
+    expect(result.source).toBe('bitdex');
+    expect(result.data).toEqual([]);
+  });
+
+  it("serves an empty feed — not the viewer's own excluded content — when the query cannot match", async () => {
+    // Following nobody short-circuits before any request is made. The own-excluded pass
+    // still runs and still returns the viewer's private/blocked/unpublished images; those
+    // must not become the feed.
+    queryBitdexOutcomeMock.mockResolvedValue(emptyOk);
+    queryBitdexMock.mockResolvedValue({
+      ids: [99],
+      total_matched: 1,
+      elapsed_us: 1,
+      documents: [
+        {
+          id: 99,
+          url: 'own-private.jpeg',
+          nsfwLevel: 1,
+          userId: 500,
+          availability: 'Private',
+          postId: 7,
+          sortAt: 1_700_000_000,
+        },
+      ],
+    });
+
+    const result = await getImagesFromSearch({ ...baseInput, followed: true });
 
     expect(result.source).toBe('bitdex');
     expect(result.data).toEqual([]);

--- a/src/server/services/__tests__/image-followed-empty-set.test.ts
+++ b/src/server/services/__tests__/image-followed-empty-set.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `followed` on the Postgres feed path only pushed a `userId IN (...)` clause when the
+// viewer's follow set was non-empty. A user who follows nobody therefore got the
+// UNFILTERED GLOBAL feed rendered under the "Following" label — the same failure mode the
+// adjacent `newCreators` guard already prevents with `1 = 0`, and the same outcome the
+// BitDex path produces by bailing out on an empty follow set.
+//
+// The generated SQL is the observable: mock the query executor and read the clause.
+
+const { queryCaptureMock, getUserFollowsMock } = vi.hoisted(() => ({
+  queryCaptureMock: vi.fn(async () => [] as unknown[]),
+  getUserFollowsMock: vi.fn(),
+}));
+
+vi.mock('~/server/utils/cache-helpers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/server/utils/cache-helpers')>();
+  return { ...actual, queryCacheRaw: () => queryCaptureMock };
+});
+
+vi.mock('~/server/redis/caches', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/server/redis/caches')>();
+  return { ...actual, getUserFollows: getUserFollowsMock };
+});
+
+vi.mock('~/env/server', () => ({
+  env: new Proxy({ LOGGING: [] as string[] } as Record<string, unknown>, {
+    get: (target, prop) => {
+      if (prop in target) return target[prop as string];
+      if (typeof prop === 'string' && (prop.endsWith('_URL') || prop.endsWith('_ENDPOINT')))
+        return 'https://test:test@localhost:5432/test';
+      if (
+        typeof prop === 'string' &&
+        /(_CONCURRENCY|_LIMIT|_MS|_PORT|_TIMEOUT|_MAX|_SIZE|_COUNT)$/.test(prop)
+      )
+        return 1;
+      return undefined;
+    },
+  }),
+}));
+
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: vi.fn(async () => {}),
+  safeError: (e: unknown) => e,
+}));
+
+// The assertion is on the SQL this call BUILDS, not on what it returns. The row set is
+// empty, so every downstream Prisma read is incidental — hand them all an empty result.
+vi.mock('~/server/db/client', () => {
+  const stub = (): any => new Proxy(async () => [], { get: () => stub() });
+  return { dbRead: stub(), dbWrite: stub() };
+});
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/redis/client', () => {
+  const make = (): any => new Proxy(() => 'k', { get: () => make() });
+  const keyProxy = make();
+  return {
+    redis: {
+      get: vi.fn().mockResolvedValue('[]'),
+      set: vi.fn().mockResolvedValue(undefined),
+      packed: { get: vi.fn(), set: vi.fn() },
+    },
+    sysRedis: {},
+    REDIS_KEYS: keyProxy,
+    REDIS_SYS_KEYS: keyProxy,
+  };
+});
+
+import { getAllImages } from '../image.service';
+
+const baseInput = {
+  limit: 10,
+  browsingLevel: 1,
+  period: 'AllTime',
+  periodMode: 'published',
+  sort: 'Newest',
+  followed: true,
+  userId: 500,
+  user: { id: 500, isModerator: false },
+  include: [],
+} as any;
+
+const capturedSql = () => {
+  expect(queryCaptureMock).toHaveBeenCalled();
+  return (queryCaptureMock.mock.calls[0][0] as unknown as { sql: string }).sql;
+};
+
+describe('getAllImages followed filter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryCaptureMock.mockResolvedValue([]);
+  });
+
+  it('returns nothing when the viewer follows nobody', async () => {
+    getUserFollowsMock.mockResolvedValue([]);
+
+    await getAllImages(baseInput);
+
+    expect(capturedSql()).toContain('1 = 0');
+  });
+
+  it('filters to the follow set when the viewer follows someone', async () => {
+    getUserFollowsMock.mockResolvedValue([11, 22]);
+
+    await getAllImages(baseInput);
+
+    const sql = capturedSql();
+    expect(sql).toContain('i."userId" IN');
+    expect(sql).not.toContain('1 = 0');
+  });
+});

--- a/src/server/services/__tests__/image-followed-empty-set.test.ts
+++ b/src/server/services/__tests__/image-followed-empty-set.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as CacheHelpers from '~/server/utils/cache-helpers';
+import type * as RedisCaches from '~/server/redis/caches';
 
 // `followed` on the Postgres feed path only pushed a `userId IN (...)` clause when the
 // viewer's follow set was non-empty. A user who follows nobody therefore got the
@@ -14,12 +16,12 @@ const { queryCaptureMock, getUserFollowsMock } = vi.hoisted(() => ({
 }));
 
 vi.mock('~/server/utils/cache-helpers', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('~/server/utils/cache-helpers')>();
+  const actual = await importOriginal<typeof CacheHelpers>();
   return { ...actual, queryCacheRaw: () => queryCaptureMock };
 });
 
 vi.mock('~/server/redis/caches', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('~/server/redis/caches')>();
+  const actual = await importOriginal<typeof RedisCaches>();
   return { ...actual, getUserFollows: getUserFollowsMock };
 });
 
@@ -40,7 +42,7 @@ vi.mock('~/env/server', () => ({
 }));
 
 vi.mock('~/server/logging/client', () => ({
-  logToAxiom: vi.fn(async () => {}),
+  logToAxiom: vi.fn(async () => undefined),
   safeError: (e: unknown) => e,
 }));
 

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -4038,6 +4038,9 @@ export async function getImagesFromBitdexPreFilter(
 
   // --- Hidden images ---
   if (hidden) {
+    // Plain null, not unsatisfiable: safe only because skipOwnExcluded's `!currentUserId`
+    // term means an anonymous caller never starts the own-excluded pass. If that pass ever
+    // covers anonymous callers, this site must return unsatisfiable() or it becomes a leak.
     if (!currentUserId) return null;
     const hiddenImages = await dbRead.imageEngagement.findMany({
       where: { userId: currentUserId, type: 'Hide' },
@@ -4050,8 +4053,14 @@ export async function getImagesFromBitdexPreFilter(
 
   // --- Username → userId ---
   if (username && !userId) {
-    const targetUser = await dbRead.user.findUnique({ where: { username }, select: { id: true } });
-    if (!targetUser) return unsatisfiable();
+    // Fall through to the primary on a replica miss — a freshly created user's profile
+    // would otherwise 404 on replica lag. Matches getAllImages and
+    // getImagesFromSearchPreFilter, including the 404: an unknown username is an error,
+    // not a legitimately empty gallery.
+    const targetUser =
+      (await dbRead.user.findUnique({ where: { username }, select: { id: true } })) ??
+      (await dbWrite.user.findUnique({ where: { username }, select: { id: true } }));
+    if (!targetUser) throw throwNotFoundError('User not found');
     userId = targetUser.id;
   }
 

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -3009,6 +3009,11 @@ export async function getImagesFromSearch(input: ImageSearchInput) {
       if (result) return { ...result, source: 'bitdex' as const };
       console.log('[BitDex] PRIMARY returned no results, falling through to Meili');
     } catch (err) {
+      // A TRPCError is the request being rejected, not BitDex failing — the only one
+      // this path raises is the username NOT_FOUND. Falling through would re-run the
+      // same lookup on the Meili path to reach the same 404, and would count client
+      // error against BitDex's health.
+      if (err instanceof TRPCError) throw err;
       console.error('[BitDex] PRIMARY error, falling through to Meili:', err);
       recordBitdexError(err);
     }

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -2863,7 +2863,7 @@ async function fetchBitdexPrimary(input: ImageSearchInput) {
   // is fetched in the parallel second pass above and merged after.
   const accumulated: ReturnType<typeof mapBitdexDoc>[] = [];
   let lastCursor: any = undefined;
-  const queryStatus: BitdexQueryStatus = { failed: false };
+  const queryStatus: BitdexQueryStatus = {};
 
   for (let pass = 0; pass < MAX_PASSES && accumulated.length < limit; pass++) {
     const result = await (pass === 0
@@ -2885,10 +2885,11 @@ async function fetchBitdexPrimary(input: ImageSearchInput) {
     if (!result.cursor) break; // no more pages
   }
 
-  // A failed BitDex round-trip is not an empty feed. The own-excluded pass would
-  // otherwise carry an empty accumulation past the guard below and serve a blank
-  // page, so the caller never gets the chance to try Meilisearch.
-  if (queryStatus.failed && !accumulated.length) return null;
+  // "Following nobody" must render as nothing — never as the viewer's own
+  // private/blocked/unpublished images, which is what the merge below would show.
+  if (queryStatus.reason === 'unsatisfiable') return { data: [], nextCursor: undefined };
+  // Null tells the caller to try Meili; a failed round-trip is not an empty feed.
+  if (queryStatus.reason === 'failed' && !accumulated.length) return null;
   if (!accumulated.length && !ownExcludedPromise) return null;
 
   let data = accumulated;
@@ -3940,11 +3941,15 @@ export function mapBitdexDoc(doc: Record<string, unknown>) {
  * @param includeDocs - true to return all doc fields, or an array of field names
  */
 /**
- * Records whether the BitDex round-trip itself failed. `getImagesFromBitdexPreFilter`
- * also returns null for queries that cannot match anything (unknown username, empty
- * follow list) — those short-circuit before any request and leave this untouched.
+ * Why `getImagesFromBitdexPreFilter` returned null — the caller cannot tell from the null
+ * itself, and the two cases need opposite handling:
+ *   'failed'        — the BitDex round-trip failed; the feed should try another backend.
+ *   'unsatisfiable' — the query cannot match anything (unknown username, empty follow
+ *                     set, empty new-creators board, nothing hidden). The feed is
+ *                     legitimately empty and must stay empty.
+ * Left unset when the request succeeded, whatever it matched.
  */
-export type BitdexQueryStatus = { failed: boolean };
+export type BitdexQueryStatus = { reason?: 'failed' | 'unsatisfiable' };
 
 export async function getImagesFromBitdexPreFilter(
   input: ImageSearchInput,
@@ -3952,6 +3957,10 @@ export async function getImagesFromBitdexPreFilter(
   cursor?: any,
   queryStatus?: BitdexQueryStatus
 ) {
+  const unsatisfiable = () => {
+    if (queryStatus) queryStatus.reason = 'unsatisfiable';
+    return null;
+  };
   let { postIds = [] } = input;
   const {
     sort,
@@ -4035,14 +4044,14 @@ export async function getImagesFromBitdexPreFilter(
       select: { imageId: true },
     });
     const imageIds = hiddenImages.map((x) => x.imageId);
-    if (!imageIds.length) return null;
+    if (!imageIds.length) return unsatisfiable();
     filters.push(_in('id', imageIds.map(_int)));
   }
 
   // --- Username → userId ---
   if (username && !userId) {
     const targetUser = await dbRead.user.findUnique({ where: { username }, select: { id: true } });
-    if (!targetUser) return null;
+    if (!targetUser) return unsatisfiable();
     userId = targetUser.id;
   }
 
@@ -4053,14 +4062,14 @@ export async function getImagesFromBitdexPreFilter(
       select: { targetUserId: true },
     });
     const userIds = followedUsers.map((x) => x.targetUserId);
-    if (!userIds.length) return null;
+    if (!userIds.length) return unsatisfiable();
     filters.push(_in('userId', userIds.map(_int)));
   }
 
   // --- New & upcoming creators ---
   if (newCreators) {
     const newCreatorIds = await getNewCreatorUserIds({ entity: 'images', domain });
-    if (!newCreatorIds.length) return null;
+    if (!newCreatorIds.length) return unsatisfiable();
     filters.push(_in('userId', newCreatorIds.map(_int)));
   }
 
@@ -4186,7 +4195,7 @@ export async function getImagesFromBitdexPreFilter(
     includeDocs
   );
   if (outcome.status === 'failed') {
-    if (queryStatus) queryStatus.failed = true;
+    if (queryStatus) queryStatus.reason = 'failed';
     return null;
   }
   return outcome.result;

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -230,7 +230,7 @@ import { resolveMediaLocation } from '~/server/services/storage-resolver';
 import { isDefined, isNumber } from '~/utils/type-guards';
 import { FLIPT_FEATURE_FLAGS, getFliptBoolean, getFliptVariant, isFlipt } from '../flipt/client';
 import { buildFliptContext } from '~/server/services/feature-flags.service';
-import { queryBitdex } from '~/server/bitdex/client';
+import { queryBitdex, queryBitdexOutcome } from '~/server/bitdex/client';
 import type { FilterClause, SortClause, Value } from '~/server/bitdex/client';
 import { compareBitdexResults, recordBitdexError } from '~/server/bitdex/compare';
 
@@ -2856,11 +2856,12 @@ async function fetchBitdexPrimary(input: ImageSearchInput) {
   // is fetched in the parallel second pass above and merged after.
   const accumulated: ReturnType<typeof mapBitdexDoc>[] = [];
   let lastCursor: any = undefined;
+  const queryStatus: BitdexQueryStatus = { failed: false };
 
   for (let pass = 0; pass < MAX_PASSES && accumulated.length < limit; pass++) {
     const result = await (pass === 0
-      ? getImagesFromBitdexPreFilter(input, true, bitdexCursor)
-      : getImagesFromBitdexPreFilter(input, true, lastCursor));
+      ? getImagesFromBitdexPreFilter(input, true, bitdexCursor, queryStatus)
+      : getImagesFromBitdexPreFilter(input, true, lastCursor, queryStatus));
 
     if (!result?.documents?.length) break;
 
@@ -2877,6 +2878,10 @@ async function fetchBitdexPrimary(input: ImageSearchInput) {
     if (!result.cursor) break; // no more pages
   }
 
+  // A failed BitDex round-trip is not an empty feed. The own-excluded pass would
+  // otherwise carry an empty accumulation past the guard below and serve a blank
+  // page, so the caller never gets the chance to try Meilisearch.
+  if (queryStatus.failed && !accumulated.length) return null;
   if (!accumulated.length && !ownExcludedPromise) return null;
 
   let data = accumulated;
@@ -3927,10 +3932,18 @@ export function mapBitdexDoc(doc: Record<string, unknown>) {
  *
  * @param includeDocs - true to return all doc fields, or an array of field names
  */
+/**
+ * Records whether the BitDex round-trip itself failed. `getImagesFromBitdexPreFilter`
+ * also returns null for queries that cannot match anything (unknown username, empty
+ * follow list) — those short-circuit before any request and leave this untouched.
+ */
+export type BitdexQueryStatus = { failed: boolean };
+
 export async function getImagesFromBitdexPreFilter(
   input: ImageSearchInput,
   includeDocs?: boolean | string[],
-  cursor?: any
+  cursor?: any,
+  queryStatus?: BitdexQueryStatus
 ) {
   let { postIds = [] } = input;
   const {
@@ -4156,7 +4169,7 @@ export async function getImagesFromBitdexPreFilter(
   }
 
   // Use keyset cursor when available, fall back to offset
-  const result = await queryBitdex(
+  const outcome = await queryBitdexOutcome(
     'civitai',
     filters,
     bitdexSort,
@@ -4165,7 +4178,11 @@ export async function getImagesFromBitdexPreFilter(
     cursor ? undefined : offset,
     includeDocs
   );
-  return result;
+  if (outcome.status === 'failed') {
+    if (queryStatus) queryStatus.failed = true;
+    return null;
+  }
+  return outcome.result;
 }
 
 export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -1689,9 +1689,16 @@ export const getAllImages = async (
 
   // Filter only followed users
   // [x]
-  if (userId && followed && prefetchedUserFollows?.length) {
+  if (userId && followed) {
     isPersonalized = true; // per-user follow set
-    AND.push(Prisma.sql`i."userId" IN (${Prisma.join(prefetchedUserFollows)})`);
+    // Following nobody must return nothing rather than degrading to the unfiltered
+    // global feed under a "Following" label. Matches the BitDex path, which bails
+    // out when the follow set is empty.
+    AND.push(
+      prefetchedUserFollows?.length
+        ? Prisma.sql`i."userId" IN (${Prisma.join(prefetchedUserFollows)})`
+        : Prisma.sql`1 = 0`
+    );
   }
 
   // Filter to creators on the "new & upcoming" board. Unlike `followed` this set is


### PR DESCRIPTION
Four server-side feed fixes. The first two are live-visible; the last two are correctness and consistency.

## A failed BitDex query renders a blank feed instead of falling back

**Symptom.** In BitDex primary mode, any BitDex failure gives a logged-in user on page 1 an empty feed. Meilisearch is never consulted, even though the whole point of the primary-mode fallthrough is that it should be.

**Mechanism.** `queryBitdex` returns `null` for every failure — non-2xx, the 30s timeout, a parse error. `fetchBitdexPrimary` breaks its accumulation loop on that null, and the guard that would have returned null (letting `getImagesFromSearch` fall through to Meili) is `!accumulated.length && !ownExcludedPromise`. The own-excluded second pass exists whenever the caller is logged in with no userId filter on the first page — the common case — so the guard is bypassed and the caller gets a truthy `{ data: [] }`.

## An unsatisfiable query serves the viewer their own hidden content

**Symptom.** Open a Following feed while following nobody, logged in, on page 1: instead of an empty feed you get your own private, blocked, and unpublished images. Same for an empty new-creators board and a hidden-images view with nothing hidden.

**Mechanism.** The same `null`. `getImagesFromBitdexPreFilter` returns it for queries that cannot match anything, all short-circuiting before any request is made. With nothing accumulated and the own-excluded pass running, the merge step had nothing to merge *into*, so the viewer's excluded content became the entire feed.

## Fix: three outcomes, not one null

A failed round-trip, an unsatisfiable query, and a query that legitimately matched zero rows were indistinguishable. Now:

| Outcome | Behavior |
|---|---|
| `failed` (round-trip failed) with nothing accumulated | return null → caller falls back to Meili |
| `failed` on a later pagination pass | serve the rows already gathered |
| `unsatisfiable` (cannot match; no request made) | return the empty page immediately, **skipping the own-excluded merge** |
| real query, zero rows | unchanged — the merge still runs, since the viewer's own excluded content under real filters is intended |

`queryBitdexOutcome` carries the failure distinction out of the client; `queryBitdex` keeps its null-on-failure signature for its other caller, pinned by a test. `getImagesFromBitdexPreFilter` takes an optional status object and records `unsatisfiable` at the short-circuit sites, so the reason is set where it is known rather than inferred from a null return.

The anonymous hidden-images short-circuit deliberately keeps a plain null. It is safe only because `skipOwnExcluded`'s `!currentUserId` term means an anonymous caller never starts the own-excluded pass — a coupling ~2,200 lines away, now named in a comment at the site, since extending that pass to anonymous callers would turn it into the same leak.

## An unknown username was an empty gallery, not a 404

**Symptom.** On the BitDex path, a dead profile URL rendered an empty gallery instead of a 404 — and under replica lag, so did a freshly created user's own profile.

**Mechanism.** This was the only one of the service's three username lookups that read the replica alone; `getAllImages` and `getImagesFromSearchPreFilter` both fall through to the primary and throw NotFound.

**Fix.** Mirror them: `dbRead ?? dbWrite`, then `throwNotFoundError`. An unknown username is an error, not a legitimately empty state, so it is not classified as unsatisfiable.

That NotFound then has to reach the client. Primary mode's `catch` treats every throw as "BitDex is broken, try Meili", which would send an already-rejected request down a second backend to re-run the same lookup and reach the same 404 — and would count a client error against BitDex's health, on traffic (bots hitting dead profiles) that arrives steadily. The catch now rethrows `TRPCError` and keeps the fall-to-Meili behavior for everything else, which is what the resilience fix above exists for.

Shadow mode branches on the same `bitdexMode` value and so cannot reach that catch. Rather than assume it, shadow was probed with both a failed query and an unknown username, before and after the change: identical outcomes (`{"kind":"resolved","source":"meili","recorded":0}` and `{"kind":"resolved","source":"meili","recorded":1}` respectively, in both builds). In production shadow cannot see an unknown username at all — `await searchFn(input)` runs before the shadow block and throws NotFound from its own lookup.

## A Following feed with an empty follow set serves the global feed

**Symptom (latent).** On the Postgres path, a user who follows nobody sees the unfiltered global feed under the "Following" label.

**Mechanism.** The filter was only applied when the prefetched follow set was non-empty, so an empty set meant no clause at all.

**Fix.** Push `1 = 0` when the set is empty — the same shape as the `newCreators` guard directly below it, and now the same outcome as the BitDex path.

## Verification

`vitest run --project unit` across the three new files: 16 passed. Every fix was confirmed load-bearing by reverting it and watching the corresponding test fail:

- fallback: `expected 'bitdex' to be 'meili'`
- unsatisfiable: `expected [ { id: 99, …(31) } ] to deeply equal []` — the viewer's own private image, leaking into the feed
- username: `promise resolved "null" instead of rejecting`, plus `expected null to be truthy` for the replica-lag case
- rethrow: `promise resolved "{ data: [], …(2) }" instead of rejecting` — the request falling through to Meili instead of 404ing
- follow set: the built SQL not containing `1 = 0`

`node scripts/typecheck.mjs`: OK — 0 type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)