### PR TITLE
test(orchestrator): split the token-cache TTL test by direction to kill a flake

### DIFF
--- a/src/server/orchestrator/__tests__/orchestrator-token-cache.test.ts
+++ b/src/server/orchestrator/__tests__/orchestrator-token-cache.test.ts
@@ -137,8 +137,12 @@ describe('orchestrator-token-cache — env-driven module init', () => {
     // Drop the prior module instance's LRUCache + inflight before the
     // next dynamic-import test. Without this, each `vi.resetModules()`
     // leaves a ttlAutopurge-timer-anchored LRUCache reachable until its
-    // 50ms TTL drains — the round-4 audit measured ~6 leaked instances
-    // across this describe block.
+    // TTL drains — the round-4 audit measured ~6 leaked instances across
+    // this describe block. This became MORE load-bearing when the
+    // cache-hit test moved to a 5-minute TTL: `destroy()` is what cancels
+    // those long autopurge timers (they are `unref()`ed by lru-cache, so
+    // they cannot hold the event loop open, but they do anchor the
+    // instance).
     try {
       const mod = await import('../orchestrator-token-cache');
       mod.__testing.destroy();
@@ -151,14 +155,48 @@ describe('orchestrator-token-cache — env-driven module init', () => {
     vi.useRealTimers();
   });
 
-  it('expires cached entries after the configured TTL (re-mints on next call)', async () => {
-    // Short real TTL is more reliable than mocking `performance.now()`,
-    // which lru-cache v11 reads via the `defaultPerf` time source — that
-    // path is not always intercepted by vi.useFakeTimers({ toFake: [...] })
-    // and the contract risks silently regressing on lru-cache upgrades.
-    // 50ms is long enough to be deterministic on CI, short enough to keep
-    // the suite snappy.
-    process.env.ORCHESTRATOR_TOKEN_CACHE_TTL_MS = '50';
+  // ---------------------------------------------------------------------
+  // The TTL contract is asserted in TWO tests, split BY DIRECTION, because
+  // the two directions have OPPOSITE sensitivity to a scheduler stall and
+  // no single TTL value is safe for both.
+  //
+  // The cache measures elapsed time in REAL time (see the fake-timer note
+  // below), so the wall-clock gap between two adjacent `await`s is not
+  // bounded by anything the test controls — a GC pause or CI contention
+  // can insert an arbitrary delay there.
+  //
+  //   - EXPIRY ("after the TTL, re-mint") is stall-SAFE. The sleep is a
+  //     LOWER bound on elapsed time; a longer stall only makes the entry
+  //     MORE expired. It can use a short TTL and stay deterministic.
+  //
+  //   - CACHE HIT ("within the TTL, do NOT re-mint") is stall-VULNERABLE.
+  //     It needs elapsed time to stay UNDER the TTL, and the test cannot
+  //     stop the clock. These two statements used to share one test with
+  //     `TTL_MS = 50`, so any stall >50ms between the first and second
+  //     call expired the entry, re-minted, and failed with
+  //     `expected 'token-2' to be 'token-1'` — observed intermittently in
+  //     CI's `preview / unit-tests`. No amount of tuning makes a 50ms
+  //     real-time budget safe; the fix is to give the cache-hit direction
+  //     a TTL a plausible stall cannot cross.
+  //
+  // Why not fake timers? lru-cache v11 reads elapsed time through its
+  // `defaultPerf` time source (`performance.now()`, captured at module
+  // load — verified in lru-cache 11.2.2, `this.#perf.now()`), which is
+  // not reliably intercepted by `vi.useFakeTimers({ toFake: [...] })`,
+  // and pinning it would risk silently regressing on an lru-cache
+  // upgrade. Both tests below therefore run on REAL time.
+  // ---------------------------------------------------------------------
+
+  it('serves a second call from cache within the configured TTL (no re-mint)', async () => {
+    // 5 minutes. This test never sleeps — the two calls below are adjacent
+    // awaits — so a long TTL costs zero wall-clock time, and the value is
+    // chosen to make the flake STRUCTURALLY unreachable rather than merely
+    // unlikely: it is 5x the unit project's 60s `testTimeout`
+    // (vitest.config.mts), so any stall long enough to expire this entry
+    // would have already blown the per-test timeout and been reported as a
+    // hang. The wrong-token failure mode this assertion can produce is
+    // therefore bounded by the harness's own hang detector, not by tuning.
+    process.env.ORCHESTRATOR_TOKEN_CACHE_TTL_MS = '300000';
     vi.resetModules();
     const mod = await import('../orchestrator-token-cache');
 
@@ -175,12 +213,37 @@ describe('orchestrator-token-cache — env-driven module init', () => {
     expect(second).toBe('token-1');
     expect(mint).toHaveBeenCalledTimes(1);
 
+    // And it stays a hit — repeat reads must not re-mint either.
+    const third = await mod.getOrMintCachedToken(userId, mint);
+    expect(third).toBe('token-1');
+    expect(mint).toHaveBeenCalledTimes(1);
+
+    mod.__testing.clear();
+  });
+
+  it('expires cached entries after the configured TTL (re-mints on next call)', async () => {
+    // Short real TTL: this direction is stall-safe (see the block comment
+    // above), so 50ms is deterministic here — the 75ms sleep is a LOWER
+    // bound on elapsed time and a stall only widens the margin. Short
+    // enough to keep the suite snappy.
+    process.env.ORCHESTRATOR_TOKEN_CACHE_TTL_MS = '50';
+    vi.resetModules();
+    const mod = await import('../orchestrator-token-cache');
+
+    let mintCalls = 0;
+    const mint = vi.fn(async () => `token-${++mintCalls}`);
+
+    const userId = 1;
+    const first = await mod.getOrMintCachedToken(userId, mint);
+    expect(first).toBe('token-1');
+    expect(mint).toHaveBeenCalledTimes(1);
+
     // Wait past the TTL boundary.
     await new Promise((r) => setTimeout(r, 75));
 
     // After TTL: cache miss, mint runs again.
-    const third = await mod.getOrMintCachedToken(userId, mint);
-    expect(third).toBe('token-2');
+    const second = await mod.getOrMintCachedToken(userId, mint);
+    expect(second).toBe('token-2');
     expect(mint).toHaveBeenCalledTimes(2);
 
     mod.__testing.clear();
@@ -189,7 +252,7 @@ describe('orchestrator-token-cache — env-driven module init', () => {
   it('rejects with timeout error when mint never settles (default behaviour with short MINT_TIMEOUT_MS)', async () => {
     // 50ms timeout: tight enough to keep the test fast, long enough to
     // be deterministic on CI even under jitter. We deliberately don't
-    // use vi.useFakeTimers() — the existing TTL test above documents
+    // use vi.useFakeTimers() — the TTL block comment above documents
     // that fake timers don't intercept lru-cache's perf source, and
     // mixing real + fake timers makes the race semantics nondeterministic.
     process.env.ORCHESTRATOR_TOKEN_CACHE_MINT_TIMEOUT_MS = '50';


### PR DESCRIPTION
## The flake

`orchestrator-token-cache — env-driven module init > expires cached entries after the configured TTL (re-mints on next call)` failed intermittently in `preview / unit-tests`:

```
AssertionError: expected 'token-2' to be 'token-1'
```

Its siblings in the same file passed in the same run, so this was a single-test failure, not load.

**The failing assertion is `expect(second).toBe('token-1')`** — the *"Within TTL: cache hit, no new mint"* check (line 175 pre-fix). It is the only assertion in the file that can produce that exact message; the expiry assertion below it expects `'token-2'`, so its failure would read the other way round.

**Why it flaked.** There is **no sleep before that assertion** — it is two adjacent `await`s after the first mint. But the test set `ORCHESTRATOR_TOKEN_CACHE_TTL_MS = '50'`, and lru-cache measures elapsed time in **real time**. Any scheduler stall >50ms between those two statements (GC pause, CI contention) expired the entry, so the second call re-minted and returned `'token-2'`. The 75ms sleep further down belongs to the *expiry* assertion and was never the culprit.

## Why not fake timers

The existing comment rejecting them was re-checked rather than taken on faith, and it holds. lru-cache **11.2.2** reads elapsed time through a module-level `defaultPerf` (`performance.now()`, captured at module load) via `this.#perf.now()` — a path `vi.useFakeTimers({ toFake: [...] })` does not reliably intercept, and pinning it would risk silently regressing on an lru-cache upgrade. Both tests still run on real time.

## The fix: split by direction

The two directions have **opposite** stall-sensitivity, which is why no single TTL serves both:

| direction | stall behaviour | consequence |
|---|---|---|
| **Expiry** — "after the TTL, re-mint" | stall-**SAFE**: the sleep is a *lower* bound on elapsed time; a longer stall only makes the entry *more* expired | a short TTL is fine |
| **Cache hit** — "within the TTL, do *not* re-mint" | stall-**VULNERABLE**: needs elapsed time to stay *under* the TTL, and the test cannot stop the clock | no tuning makes a 50ms real-time budget safe |

So the one test became two:

- **`serves a second call from cache within the configured TTL (no re-mint)`** — TTL `300000` (5 min). The test never sleeps, so a long TTL costs zero wall time, and the value is picked to make the flake *structurally* unreachable rather than merely unlikely: **300s is 5× the unit project's 60s `testTimeout`** (`vitest.config.mts`), so any stall long enough to expire this entry would have already blown the per-test timeout and been reported as a hang. The wrong-token failure mode is bounded by the harness's own hang detector, not by a tuned margin. A third repeat read was added while here.
- **`expires cached entries after the configured TTL (re-mints on next call)`** — keeps TTL `50` plus the 75ms sleep, which is safe in this direction.

Nothing was deleted, skipped, weakened or `.retry()`ed; both behaviours stay covered. Test count goes 11 → 12. `orchestrator-token-cache.ts` is untouched — this is a test-only change.

## Proof — both directions

**1. The cache-hit test can no longer flake.** A 200ms artificial stall (4× the old 50ms TTL) injected between the first and second `getOrMintCachedToken` calls:

- **New test: PASSES** — `✓ serves a second call from cache within the configured TTL (no re-mint) 203ms`, 12/12 passed.
- **Pre-fix test, same injection: FAILS with the exact CI message** —
  ```
  AssertionError: expected 'token-2' to be 'token-1' // Object.is equality
  Expected: "token-1"   Received: "token-2"
  ❯ .../orchestrator-token-cache.test.ts:178:20
        expect(second).toBe('token-1');
  ```
  (line 178 with the 3 injected lines = line 175 in the original). 1 failed | 10 passed.

That pair is the evidence: the injected stall reproduces the CI failure on the old code and is absorbed by the new code.

**2. The expiry test still catches a broken TTL.** Two independently-constructed mutants of `orchestrator-token-cache.ts`:

- `ttl: TTL_MS` → `ttl: 0` (entries never expire) → **RED at the expiry test's own assertion**, `expect(second).toBe('token-2')` at line 246: `expected 'token-1' to be 'token-2'`. **1 failed | 11 passed.**
- `const TTL_MS = readNonNegativeInt('ORCHESTRATOR_TOKEN_CACHE_TTL_MS', …)` → `const TTL_MS = DEFAULT_TTL_MS` (env TTL ignored) → same test, same assertion, **1 failed | 11 passed.**

Under both mutants the *cache-hit* test correctly stays green — each guard fails for its own property, so the kill is attributed rather than incidental. Both mutations were reverted by copying a pristine copy back and confirming byte-identity with `cmp` (no `git checkout --`).

## Green

- **Typecheck:** `typecheck: OK — 0 type errors in 99s`.
- **Full unit suite:** `Test Files 865 passed (865)` / `Tests 12962 passed | 1 skipped (12963)`.
- **This file, 20 consecutive independent runs:** `Tests 12 passed (12)` on all 20 — **20/20**.

## What this does NOT prove

- 20 clean runs on one unloaded workstation is **absence of recurrence, not proof of absence**. The original flake was intermittent under CI contention that a local loop does not reproduce; the argument that carries the claim is the structural one (300s TTL > 60s `testTimeout`), not the repeat count.
- The 200ms injection demonstrates the mechanism at *one* stall magnitude. It does not enumerate every stall a CI box can produce — it shows the old code fails at a stall the new code absorbs.
- The fake-timer claim is a **re-verification of the mechanism** (lru-cache 11.2.2 does read `performance.now()` through `defaultPerf`), not an exhaustive demonstration that no fake-timer configuration could ever work. It was not falsified, so the existing decision stands.
- Nothing here changes production behaviour or exercises the cache under real load; it is a test-harness fix only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
