### PR TITLE
fix(app-blocks): tell the block when a consent request can never be granted

### DIFF
--- a/src/components/AppBlocks/PageBlockHost.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHost.browser.test.tsx
@@ -139,6 +139,34 @@ function postFromBlock(type: string, payload?: unknown) {
   );
 }
 
+/**
+ * Capture host→block posts. `send` targets the iframe's contentWindow, so the
+ * assertable record of what the HOST told the BLOCK is a listener on that
+ * window (same helper shape as PageBlockHostThemeChange / -Storage).
+ *
+ * Attach it AFTER the iframe is in the DOM (i.e. after `driveToReady`); it is
+ * structurally blind to anything posted before it subscribes, which is fine for
+ * the consent path — every message under test is a response to a REQUEST_CONSENT
+ * the test itself posts later.
+ */
+function listenForHostPosts() {
+  const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+  const cw = el.contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  const received: Array<{ type: string; payload: unknown }> = [];
+  const handler = (e: MessageEvent) => {
+    const d = e.data as { type?: string; payload?: unknown } | null;
+    if (d && typeof d.type === 'string') received.push({ type: d.type, payload: d.payload });
+  };
+  cw.addEventListener('message', handler);
+  return {
+    received,
+    of: (type: string) => received.filter((m) => m.type === type),
+    clear: () => received.splice(0, received.length),
+    stop: () => cw.removeEventListener('message', handler),
+  };
+}
+
 // Same-origin so trustTier='internal' yields a pinned (non-opaque) transport
 // whose expectedOrigin equals this frame's origin.
 const SAME_ORIGIN_SRC = `${window.location.origin}/`;
@@ -336,6 +364,95 @@ describe('PageBlockHost REQUEST_CONSENT (W10 lazy-consent wiring)', () => {
     });
     // No consent dialog is opened for an un-grantable scope.
     expect(useDialogStore.getState().dialogs).toHaveLength(0);
+  });
+
+  /**
+   * The refusal must be observable to the BLOCK, not only to the viewer.
+   *
+   * The host-side toast renders in the HOST frame. Nothing was posted back over
+   * the bridge, so the block could not tell "the user hasn't confirmed the dialog
+   * yet" from "this environment will never grant this scope" — and its own UI kept
+   * telling the developer to retry an action that can never succeed, directly
+   * contradicting the corner toast on the same screen.
+   */
+  test('Issue B: an UN-GRANTABLE REQUEST_CONSENT posts CONSENT_UNAVAILABLE to the block with the refused scopes', async () => {
+    renderWithProviders(
+      <PageBlockHost
+        {...baseProps}
+        declaredScopes={['models:read:self']}
+        missingScopes={[]}
+        needsConsent={false}
+        onConsentGranted={vi.fn()}
+      />
+    );
+
+    await driveToReady();
+    const posts = listenForHostPosts();
+    try {
+      // Post exactly ONCE, outside the waitFor. `send` → `contentWindow.postMessage`
+      // is delivered asynchronously, so a post INSIDE a retrying waitFor fires
+      // several REQUEST_CONSENTs before the first CONSENT_UNAVAILABLE lands and the
+      // extra replies arrive later — which makes the count untrustworthy here and
+      // actively broke the benign test's zero below. `driveToReady` already proved
+      // the handler is live (it reads a render-body ref, not a stale closure), so
+      // one post is enough; the waitFor only awaits DELIVERY.
+      postFromBlock('REQUEST_CONSENT', { scopes: ['apps:storage:write', 'apps:storage:read'] });
+      await vi.waitFor(() => expect(posts.of('CONSENT_UNAVAILABLE')).toHaveLength(1));
+
+      const msg = posts.of('CONSENT_UNAVAILABLE')[0];
+      expect(msg.payload).toEqual({
+        reason: 'ungrantable',
+        // The host's own computed un-grantable set (sorted+deduped), not the
+        // block's raw hint echoed back.
+        scopes: ['apps:storage:read', 'apps:storage:write'],
+      });
+
+      // ADDITIVE, not a replacement: the viewer-facing toast still fires, and the
+      // un-grantable path still opens no consent dialog.
+      expect(showNotificationSpy).toHaveBeenCalled();
+      expect(useDialogStore.getState().dialogs).toHaveLength(0);
+    } finally {
+      posts.stop();
+    }
+  });
+
+  test('the BENIGN already-granted REQUEST_CONSENT posts NO CONSENT_UNAVAILABLE (the silent no-op stays silent)', async () => {
+    renderWithProviders(
+      <PageBlockHost
+        {...baseProps}
+        missingScopes={[]}
+        needsConsent={false}
+        onConsentGranted={vi.fn()}
+      />
+    );
+
+    await driveToReady();
+    const posts = listenForHostPosts();
+    try {
+      // 🔴 POSITIVE CONTROL. The subject of this test is a ZERO, and a host that
+      // dropped the message — or a listener wired to nothing — produces the same
+      // zero. `models:read:self` is neither granted (absent from declaredScopes)
+      // nor grantable (missingScopes is empty), so it is UN-GRANTABLE and MUST
+      // produce a CONSENT_UNAVAILABLE on this very mount. Watch the count move
+      // before reading the zero. ONE post (see the note in the test above), so the
+      // exactly-one assertion also proves nothing is still in flight when we clear.
+      postFromBlock('REQUEST_CONSENT', { scopes: ['models:read:self'] });
+      await vi.waitFor(() => expect(posts.of('CONSENT_UNAVAILABLE')).toHaveLength(1));
+      posts.clear();
+      showNotificationSpy.mockClear();
+
+      // THE SUBJECT: `ai:write:budgeted` is in declaredScopes and nothing is
+      // withheld, so the block is re-requesting a scope it ALREADY holds. Nothing
+      // is blocked ⇒ no toast AND no bridge message. Emitting here would train
+      // blocks to render a "permission unavailable" state on a working permission.
+      postFromBlock('REQUEST_CONSENT', { scopes: ['ai:write:budgeted'] });
+      await new Promise((r) => setTimeout(r, 150));
+      expect(posts.of('CONSENT_UNAVAILABLE')).toHaveLength(0);
+      expect(showNotificationSpy).not.toHaveBeenCalled();
+      expect(useDialogStore.getState().dialogs).toHaveLength(0);
+    } finally {
+      posts.stop();
+    }
   });
 
   test('reviewMode surfaces a passive reduced-permissions notice and NEVER a consent modal', async () => {

--- a/src/components/AppBlocks/PageBlockHost.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHost.browser.test.tsx
@@ -167,6 +167,46 @@ function listenForHostPosts() {
   };
 }
 
+/**
+ * Record the ORDER of the two host-side effects on the un-grantable branch: the
+ * CONSENT_UNAVAILABLE bridge push and the host toast.
+ *
+ * `listenForHostPosts` above structurally CANNOT do this. `send` →
+ * `contentWindow.postMessage` is delivered asynchronously, so its listener always
+ * runs after the whole handler has returned — a `vi.fn()` toast spy that cannot
+ * throw plus an async delivery means moving `send` below `showNotification` in the
+ * product changes nothing any of those assertions can see.
+ *
+ * The CALL to `postMessage` is synchronous, so patching it on the target window
+ * records the two markers in the order the handler actually performs them. Only
+ * CONSENT_UNAVAILABLE is recorded — the host also posts BLOCK_INIT/TOKEN_REFRESH
+ * through the same window.
+ */
+function recordConsentEffectOrder() {
+  const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+  const cw = el.contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  const order: string[] = [];
+  const original = cw.postMessage.bind(cw) as (message: unknown, targetOrigin: string) => void;
+  cw.postMessage = ((message: unknown, targetOrigin: string) => {
+    const type = (message as { type?: string } | null)?.type;
+    if (type === 'CONSENT_UNAVAILABLE') order.push('send');
+    original(message, targetOrigin);
+  }) as unknown as Window['postMessage'];
+  showNotificationSpy.mockImplementation(() => {
+    order.push('toast');
+  });
+  return {
+    order,
+    stop: () => {
+      cw.postMessage = original as unknown as Window['postMessage'];
+      // mockClear() (the beforeEach) keeps implementations — reset so the marker
+      // impl cannot leak into another test.
+      showNotificationSpy.mockReset();
+    },
+  };
+}
+
 // Same-origin so trustTier='internal' yields a pinned (non-opaque) transport
 // whose expectedOrigin equals this frame's origin.
 const SAME_ORIGIN_SRC = `${window.location.origin}/`;
@@ -402,8 +442,8 @@ describe('PageBlockHost REQUEST_CONSENT (W10 lazy-consent wiring)', () => {
       const msg = posts.of('CONSENT_UNAVAILABLE')[0];
       expect(msg.payload).toEqual({
         reason: 'ungrantable',
-        // The host's own computed un-grantable set (sorted+deduped), not the
-        // block's raw hint echoed back.
+        // The host's own computed un-grantable set (sorted+deduped), filtered to
+        // the known block-scope vocabulary — not the block's raw hint echoed back.
         scopes: ['apps:storage:read', 'apps:storage:write'],
       });
 
@@ -413,6 +453,104 @@ describe('PageBlockHost REQUEST_CONSENT (W10 lazy-consent wiring)', () => {
       expect(useDialogStore.getState().dialogs).toHaveLength(0);
     } finally {
       posts.stop();
+    }
+  });
+
+  /**
+   * 🔴 The payload is UNTRUSTED BLOCK INPUT until the host filters it.
+   *
+   * `payload.scopes` on a REQUEST_CONSENT is whatever the block's own frame put
+   * there, and the CONSENT_UNAVAILABLE push hands it to block UI to render. The
+   * host therefore names only scopes from the fixed platform vocabulary.
+   *
+   * The decision to refuse is NOT filtered, and that half is the more important
+   * one: the un-grantable set is the trigger as well as the payload, so filtering
+   * the trigger would make a request for an un-grantable scope the vocabulary
+   * doesn't know produce no message and no toast — silently deleting the existing
+   * user-visible behaviour in the name of sanitising it.
+   */
+  test('Issue B: unknown/garbage/oversized scopes are DROPPED from the CONSENT_UNAVAILABLE payload, and the message + toast still fire', async () => {
+    renderWithProviders(
+      <PageBlockHost
+        {...baseProps}
+        declaredScopes={['models:read:self']}
+        missingScopes={[]}
+        needsConsent={false}
+        onConsentGranted={vi.fn()}
+      />
+    );
+
+    await driveToReady();
+    const posts = listenForHostPosts();
+    try {
+      // Every requested scope is un-grantable AND outside the vocabulary.
+      postFromBlock('REQUEST_CONSENT', {
+        scopes: ['<img src=x onerror=alert(1)>', 'not:a:real:scope', 'A'.repeat(5000)],
+      });
+      await vi.waitFor(() => expect(posts.of('CONSENT_UNAVAILABLE')).toHaveLength(1));
+
+      // The refusal is still delivered — with NO names, because none survived.
+      expect(posts.of('CONSENT_UNAVAILABLE')[0].payload).toEqual({
+        reason: 'ungrantable',
+        scopes: [],
+      });
+      // …and the existing host-side behaviour is byte-for-byte unchanged.
+      expect(showNotificationSpy).toHaveBeenCalledTimes(1);
+      expect(useDialogStore.getState().dialogs).toHaveLength(0);
+    } finally {
+      posts.stop();
+    }
+  });
+
+  test('Issue B: a MIXED hint names only the KNOWN scopes in the payload (sorted order preserved)', async () => {
+    renderWithProviders(
+      <PageBlockHost
+        {...baseProps}
+        declaredScopes={['models:read:self']}
+        missingScopes={[]}
+        needsConsent={false}
+        onConsentGranted={vi.fn()}
+      />
+    );
+
+    await driveToReady();
+    const posts = listenForHostPosts();
+    try {
+      postFromBlock('REQUEST_CONSENT', {
+        scopes: ['apps:storage:write', 'not:a:real:scope', 'apps:storage:read'],
+      });
+      await vi.waitFor(() => expect(posts.of('CONSENT_UNAVAILABLE')).toHaveLength(1));
+
+      expect(posts.of('CONSENT_UNAVAILABLE')[0].payload).toEqual({
+        reason: 'ungrantable',
+        scopes: ['apps:storage:read', 'apps:storage:write'],
+      });
+    } finally {
+      posts.stop();
+    }
+  });
+
+  test('Issue B: the CONSENT_UNAVAILABLE push happens BEFORE the toast', async () => {
+    renderWithProviders(
+      <PageBlockHost
+        {...baseProps}
+        declaredScopes={['models:read:self']}
+        missingScopes={[]}
+        needsConsent={false}
+        onConsentGranted={vi.fn()}
+      />
+    );
+
+    await driveToReady();
+    const rec = recordConsentEffectOrder();
+    try {
+      postFromBlock('REQUEST_CONSENT', { scopes: ['apps:storage:write'] });
+      await vi.waitFor(() => expect(rec.order).toHaveLength(2));
+      // The block's signal must not be reachable only past a notification layer
+      // that can throw. Asserted on the synchronous CALLS — see the helper.
+      expect(rec.order).toEqual(['send', 'toast']);
+    } finally {
+      rec.stop();
     }
   });
 

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -1318,6 +1318,26 @@ export function PageBlockHost({
         missingScopes
       );
       if (ungrantable.length === 0) return; // already-granted or no hint — drop
+      // 🔴 Tell the BLOCK, not just the viewer. The toast below renders in the
+      // HOST frame; before this push nothing came back over the bridge, so the
+      // block could not tell "the user hasn't confirmed the dialog yet" from
+      // "this environment will never grant this scope" — and its own UI went on
+      // telling the developer to retry an action that can never succeed, right
+      // next to a host toast saying the opposite. This is a fire-and-forget PUSH
+      // (REQUEST_CONSENT carries no `requestId`, so there is nothing to correlate
+      // a `*_RESULT` reply to), matching the other uncorrelated host→block pushes
+      // (`TOKEN_REFRESH`, `ROUTE_CHANGED`, `SUSPEND`/`RESUME`).
+      //
+      // Sent BEFORE the toast so the block's signal cannot be lost to a throwing
+      // notification layer. It ADDS a channel — the toast is unchanged. The
+      // BENIGN already-granted case returns above and stays silent in BOTH
+      // channels: a block that got a message there would render a
+      // permission-unavailable state over a permission that actually works.
+      //
+      // `scopes` is the host's OWN computed un-grantable set (sorted+deduped by
+      // `resolveUngrantableConsentScopes`), not the block's raw hint echoed back,
+      // and it is delivered solely to the frame that asked.
+      send('CONSENT_UNAVAILABLE', { reason: 'ungrantable', scopes: ungrantable });
       showNotification({
         color: 'yellow',
         title: 'Permission unavailable',
@@ -1331,6 +1351,7 @@ export function PageBlockHost({
     // what opened the commit→passive-effect window in the first place.
   }, [
     onMessage,
+    send,
     readGateStatus,
     missingScopes,
     grantedScopes,

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -27,7 +27,7 @@ import {
   resolvePublishGenerationOutputsRequest,
   resolveResourcePickerRequest,
   resolveReviewConsentNotice,
-  resolveUngrantableConsentScopes,
+  resolveUngrantableConsentNotice,
   shouldEmitMidSessionLossBeacon,
   toHostGateStatus,
 } from './pageBlockHostLogic';
@@ -1312,12 +1312,12 @@ export function PageBlockHost({
       // and can never be added via consent here — e.g. a dev-tunnel preview token
       // that doesn't carry it). Only the latter, proven from the block's advisory
       // `scopes` hint, surfaces a message so the app doesn't silently look dead.
-      const ungrantable = resolveUngrantableConsentScopes(
+      const ungrantable = resolveUngrantableConsentNotice(
         payload?.scopes,
         grantedScopes,
         missingScopes
       );
-      if (ungrantable.length === 0) return; // already-granted or no hint — drop
+      if (!ungrantable.notify) return; // already-granted or no hint — drop
       // 🔴 Tell the BLOCK, not just the viewer. The toast below renders in the
       // HOST frame; before this push nothing came back over the bridge, so the
       // block could not tell "the user hasn't confirmed the dialog yet" from
@@ -1328,16 +1328,27 @@ export function PageBlockHost({
       // a `*_RESULT` reply to), matching the other uncorrelated host→block pushes
       // (`TOKEN_REFRESH`, `ROUTE_CHANGED`, `SUSPEND`/`RESUME`).
       //
-      // Sent BEFORE the toast so the block's signal cannot be lost to a throwing
-      // notification layer. It ADDS a channel — the toast is unchanged. The
-      // BENIGN already-granted case returns above and stays silent in BOTH
-      // channels: a block that got a message there would render a
-      // permission-unavailable state over a permission that actually works.
+      // It ADDS a channel — the toast is unchanged. The BENIGN already-granted
+      // case returns above and stays silent in BOTH channels: a block that got a
+      // message there would render a permission-unavailable state over a
+      // permission that actually works.
       //
-      // `scopes` is the host's OWN computed un-grantable set (sorted+deduped by
-      // `resolveUngrantableConsentScopes`), not the block's raw hint echoed back,
-      // and it is delivered solely to the frame that asked.
-      send('CONSENT_UNAVAILABLE', { reason: 'ungrantable', scopes: ungrantable });
+      // Sent BEFORE the toast so the block's signal cannot be lost to a throwing
+      // notification layer. That ordering is pinned by
+      // `PageBlockHost.browser.test.tsx` → "the CONSENT_UNAVAILABLE push happens
+      // BEFORE the toast", which asserts the order of the SYNCHRONOUS calls; a
+      // spy on the delivered message cannot see it (delivery is async).
+      //
+      // 🔴 WHAT `scopes` IS. It is NOT the block's raw hint. `notify` above is
+      // decided on the full un-grantable set (requested − granted − missing), but
+      // `ungrantable.scopes` is that set filtered to the known block-scope
+      // vocabulary — the hint is untrusted block input and this payload is
+      // rendered by block UI, so nothing outside the fixed vocabulary is echoed
+      // back out of the host. The two are deliberately different sets: when every
+      // requested scope is unrecognised this still sends, with `scopes: []`. The
+      // refusal is the signal; the names are advisory. Delivered solely to the
+      // frame that asked.
+      send('CONSENT_UNAVAILABLE', { reason: 'ungrantable', scopes: ungrantable.scopes });
       showNotification({
         color: 'yellow',
         title: 'Permission unavailable',

--- a/src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts
+++ b/src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts
@@ -18,7 +18,7 @@ import {
   resolveImageUploadRequest,
   resolveResourcePickerRequest,
   resolveReviewConsentNotice,
-  resolveUngrantableConsentScopes,
+  resolveUngrantableConsentNotice,
   toHostGateStatus,
   PAGE_RESOURCE_PICKER_TYPES,
   type PageHostStatus,
@@ -63,60 +63,113 @@ describe('grantedPageScopes (#3/#6 — BLOCK_INIT carries the JWT scopes, not []
   });
 });
 
-describe('resolveUngrantableConsentScopes (Issue B — un-grantable dev-preview consent → toast)', () => {
-  it('returns the un-grantable subset when a requested scope is neither granted NOR missing (clamped at mint)', () => {
+describe('resolveUngrantableConsentNotice (Issue B — un-grantable dev-preview consent → toast)', () => {
+  it('notifies and NAMES the un-grantable subset when a requested scope is neither granted NOR missing (clamped at mint)', () => {
     // dev-tunnel preview: the token carries models:read:self; the block asks for
     // a scope the tunnel allowlist withheld → not granted, not addable via consent.
-    const out = resolveUngrantableConsentScopes(['apps:storage:read'], ['models:read:self'], []);
-    expect(out).toEqual(['apps:storage:read']);
+    expect(
+      resolveUngrantableConsentNotice(['apps:storage:read'], ['models:read:self'], [])
+    ).toEqual({ notify: true, scopes: ['apps:storage:read'] });
   });
 
-  it('returns EMPTY for the BENIGN already-granted case (block re-requests a held scope) — no toast', () => {
+  it('does NOT notify for the BENIGN already-granted case (block re-requests a held scope)', () => {
     expect(
-      resolveUngrantableConsentScopes(
+      resolveUngrantableConsentNotice(
         ['buzz:read:self'],
         ['buzz:read:self', 'models:read:self'],
         []
       )
-    ).toEqual([]);
+    ).toEqual({ notify: false, scopes: [] });
   });
 
-  it('returns EMPTY when the requested scope is grantable via consent (it is in missingScopes) — modal path owns it', () => {
+  it('does NOT notify when the requested scope is grantable via consent (it is in missingScopes) — modal path owns it', () => {
     expect(
-      resolveUngrantableConsentScopes(
+      resolveUngrantableConsentNotice(
         ['ai:write:budgeted'],
         ['models:read:self'],
         ['ai:write:budgeted']
       )
-    ).toEqual([]);
+    ).toEqual({ notify: false, scopes: [] });
   });
 
-  it('returns EMPTY when the block sends no hint / a garbage hint (never a fragile heuristic)', () => {
-    expect(resolveUngrantableConsentScopes(undefined, ['models:read:self'], [])).toEqual([]);
-    expect(resolveUngrantableConsentScopes([], ['models:read:self'], [])).toEqual([]);
-    expect(resolveUngrantableConsentScopes('nope', ['models:read:self'], [])).toEqual([]);
-    expect(resolveUngrantableConsentScopes([1, null, ''], ['models:read:self'], [])).toEqual([]);
+  it('does NOT notify when the block sends no hint / a garbage hint (never a fragile heuristic)', () => {
+    const silent = { notify: false, scopes: [] };
+    expect(resolveUngrantableConsentNotice(undefined, ['models:read:self'], [])).toEqual(silent);
+    expect(resolveUngrantableConsentNotice([], ['models:read:self'], [])).toEqual(silent);
+    expect(resolveUngrantableConsentNotice('nope', ['models:read:self'], [])).toEqual(silent);
+    expect(resolveUngrantableConsentNotice([1, null, ''], ['models:read:self'], [])).toEqual(
+      silent
+    );
   });
 
   it('reports ONLY the un-grantable scopes from a mixed hint (drops granted + missing), sorted+deduped', () => {
-    const out = resolveUngrantableConsentScopes(
-      [
-        'apps:storage:write',
-        'apps:storage:read',
-        'apps:storage:write',
-        'buzz:read:self',
-        'ai:write:budgeted',
-      ],
-      ['buzz:read:self'], // already granted
-      ['ai:write:budgeted'] // grantable via consent
-    );
-    expect(out).toEqual(['apps:storage:read', 'apps:storage:write']);
+    expect(
+      resolveUngrantableConsentNotice(
+        [
+          'apps:storage:write',
+          'apps:storage:read',
+          'apps:storage:write',
+          'buzz:read:self',
+          'ai:write:budgeted',
+        ],
+        ['buzz:read:self'], // already granted
+        ['ai:write:budgeted'] // grantable via consent
+      )
+    ).toEqual({ notify: true, scopes: ['apps:storage:read', 'apps:storage:write'] });
   });
 
   it('tolerates an undefined missingScopes', () => {
     expect(
-      resolveUngrantableConsentScopes(['apps:storage:read'], ['models:read:self'], undefined)
-    ).toEqual(['apps:storage:read']);
+      resolveUngrantableConsentNotice(['apps:storage:read'], ['models:read:self'], undefined)
+    ).toEqual({ notify: true, scopes: ['apps:storage:read'] });
+  });
+
+  /**
+   * 🔴 The untrusted-echo half. `rawScopesHint` comes from the block's own frame
+   * and the resulting `scopes` are posted back over the bridge for block UI to
+   * render, so only the fixed platform vocabulary may appear in them — while the
+   * DECISION stays on the unfiltered set, or an un-grantable scope the vocabulary
+   * doesn't know would silently produce no refusal at all.
+   */
+  describe('untrusted hint — the payload is filtered, the decision is not', () => {
+    it('drops markup / junk / oversized strings from `scopes` but STILL notifies', () => {
+      const out = resolveUngrantableConsentNotice(
+        ['<img src=x onerror=alert(1)>', 'not:a:real:scope', 'A'.repeat(5000)],
+        ['models:read:self'],
+        []
+      );
+      // The refusal survives — this is the toast + bridge-push trigger.
+      expect(out.notify).toBe(true);
+      // Nothing untrusted is echoed back.
+      expect(out.scopes).toEqual([]);
+    });
+
+    it('keeps the known scopes and drops the unknown ones from a MIXED hint, order preserved', () => {
+      const out = resolveUngrantableConsentNotice(
+        ['apps:storage:write', 'not:a:real:scope', 'apps:storage:read', '<script>x</script>'],
+        ['models:read:self'],
+        []
+      );
+      expect(out).toEqual({ notify: true, scopes: ['apps:storage:read', 'apps:storage:write'] });
+    });
+
+    it('does not treat inherited Object.prototype keys as known scopes (own-property test)', () => {
+      // `isKnownBlockScope` is `Object.prototype.hasOwnProperty.call(...)`, not
+      // `in` — `in` walked the prototype chain and let these through as "known".
+      const inherited = ['toString', 'constructor', '__proto__', 'valueOf', 'hasOwnProperty'];
+      const out = resolveUngrantableConsentNotice(inherited, ['models:read:self'], []);
+      expect(out.notify).toBe(true);
+      expect(out.scopes).toEqual([]);
+    });
+
+    it('still notifies when the ONLY un-grantable scope is unknown (the refusal is the signal)', () => {
+      // The regression guard for the obvious-but-wrong fix: filtering the
+      // DECISION by `isKnownBlockScope` would make this silent, removing an
+      // existing user-visible behaviour.
+      const out = resolveUngrantableConsentNotice(['totally:made:up'], ['models:read:self'], []);
+      expect(out.notify).toBe(true);
+      expect(out.scopes).toEqual([]);
+    });
   });
 });
 

--- a/src/components/AppBlocks/hostHandlerParity.ts
+++ b/src/components/AppBlocks/hostHandlerParity.ts
@@ -165,6 +165,15 @@ export const INVENTORY = {
     PageBlockHost: 'required',
     InlineHost: INLINE_STUB,
   },
+  // Still `request: false` — the SDK's `useRequestConsent()` posts it with
+  // `sendMessage` and AWAITS nothing, so an unhandled one can never hang a block.
+  // But PageBlockHost does emit ONE uncorrelated host→block PUSH off this
+  // message: when the requested scopes are proven un-grantable (clamped/withheld
+  // at mint, so no consent round-trip can ever resolve them) it sends
+  // `CONSENT_UNAVAILABLE { reason, scopes }` so the block can stop telling the
+  // user to retry. It is a push, not a reply — there is no `requestId` to
+  // correlate — hence `reply` stays `''`. The behavioural pin is
+  // PageBlockHost.browser.test.tsx.
   REQUEST_CONSENT: {
     request: false,
     reply: '',

--- a/src/components/AppBlocks/pageBlockHostLogic.ts
+++ b/src/components/AppBlocks/pageBlockHostLogic.ts
@@ -48,6 +48,24 @@ export function grantedPageScopes(
   return declaredScopes.filter((s) => !withheld.has(s));
 }
 
+/** What an un-grantable (prod-path) REQUEST_CONSENT should produce. */
+export type UngrantableConsentNotice = {
+  /**
+   * Whether the refusal is surfaced at all — the trigger for BOTH the host toast
+   * and the CONSENT_UNAVAILABLE bridge push. Computed on the UNFILTERED
+   * un-grantable set, so an un-grantable scope outside the known vocabulary
+   * still refuses out loud instead of vanishing.
+   */
+  notify: boolean;
+  /**
+   * The refused scopes safe to NAME back to the block: the un-grantable subset
+   * filtered to the known block-scope vocabulary. Can legitimately be EMPTY
+   * while `notify` is true (every requested scope was unrecognised) — the
+   * refusal is the signal, the names are advisory.
+   */
+  scopes: string[];
+};
+
 /**
  * Issue B (defensive UX): decide whether a REQUEST_CONSENT whose grantable set is
  * EMPTY should surface a user-visible "not available in this preview" message
@@ -64,24 +82,45 @@ export function grantedPageScopes(
  *     at mint (e.g. a dev-tunnel token that stripped a scope the tunnel allowlist
  *     doesn't carry), so the block's consent round-trip can never resolve it.
  *
- * Returns the un-grantable subset (requested − granted − missing), sorted+deduped.
- * Returns EMPTY when the hint is absent/garbage OR everything requested is already
- * granted — the caller then keeps the silent no-op (no fragile heuristic: without
- * an explicit requested scope proven un-grantable, we never toast).
+ * `notify` is false when the hint is absent/garbage OR everything requested is
+ * already granted — the caller then keeps the silent no-op (no fragile heuristic:
+ * without an explicit requested scope proven un-grantable, we never surface).
+ *
+ * 🔴 WHY THIS RETURNS TWO FIELDS RATHER THAN ONE LIST (same split, and same
+ * reason, as `resolveReviewConsentNotice` below). `rawScopesHint` is UNTRUSTED —
+ * it is whatever the block's own frame posted, so it can carry markup, junk, or a
+ * 5 KB string. The returned `scopes` therefore pass `isKnownBlockScope`, so only
+ * the fixed platform vocabulary is ever echoed back out of the host.
+ *
+ * That filter must NOT reach the DECISION. The un-grantable set is the trigger as
+ * well as the payload: filter the trigger and a block requesting an un-grantable
+ * scope the vocabulary doesn't know would get no toast and no bridge message at
+ * all — the exact silent dead end this whole path exists to remove, reintroduced
+ * by the security fix. So the decision is taken on the unfiltered set and only the
+ * NAMES are filtered.
+ *
+ * Splitting it also depends on `isKnownBlockScope` being an OWN-property test: it
+ * used to use `in`, which walks the prototype chain and let 12 inherited
+ * `Object.prototype` keys (`constructor`, `__proto__`, `toString`, …) through as
+ * "known scopes". Fixed at the predicate; pinned again in the unit tests here,
+ * because this is a caller that feeds untrusted runtime input to it.
  */
-export function resolveUngrantableConsentScopes(
+export function resolveUngrantableConsentNotice(
   rawScopesHint: unknown,
   grantedScopes: string[],
   missingScopes: string[] | undefined
-): string[] {
-  if (!Array.isArray(rawScopesHint)) return [];
+): UngrantableConsentNotice {
+  if (!Array.isArray(rawScopesHint)) return { notify: false, scopes: [] };
   const requested = rawScopesHint.filter((s): s is string => typeof s === 'string' && s.length > 0);
-  if (requested.length === 0) return [];
+  if (requested.length === 0) return { notify: false, scopes: [] };
   const granted = new Set<string>(grantedScopes);
   const missing = new Set<string>(missingScopes ?? []);
-  return Array.from(
+  const ungrantable = Array.from(
     new Set(requested.filter((s: string) => !granted.has(s) && !missing.has(s)))
   ).sort();
+  // Decision on the UNFILTERED set — see above.
+  if (ungrantable.length === 0) return { notify: false, scopes: [] };
+  return { notify: true, scopes: ungrantable.filter((s) => isKnownBlockScope(s)) };
 }
 
 /** What a reviewMode REQUEST_CONSENT should surface to the moderator. */
@@ -103,7 +142,7 @@ export type ReviewConsentNotice = {
  * round-trip can NEVER resolve. Dropping it silently (the old behaviour) left the
  * app parked on its consent card with zero feedback at the reviewer.
  *
- * Differs from `resolveUngrantableConsentScopes` in exactly one way, and that
+ * Differs from `resolveUngrantableConsentNotice` in exactly one way, and that
  * difference is the bug this fixes: with NO usable `scopes` hint the prod path
  * must stay silent (it can't tell "already granted" from "clamped"), but in
  * review there is nothing to tell apart — consent is structurally unavailable, so


### PR DESCRIPTION
> **Correction (2026-08-07, commit `4312429a5e`).** An earlier version of this description
> said the `CONSENT_UNAVAILABLE` payload was *"the host's own computed refused set … not the
> block's raw hint echoed back"*. That was **wrong**: `payload.scopes` on a `REQUEST_CONSENT`
> comes from the block's own frame, and the un-grantable set was computed from it with only a
> non-empty-string check, so arbitrary strings — markup, junk, a 5 KB string — came straight
> back out in the push that a block is meant to render. The code comment asserting the same
> thing was wrong too. Both are fixed and the payload is now filtered to the known scope
> vocabulary; the refusal decision is deliberately **not** filtered. Details below and in the
> commit message.

## The problem

A full-page App Block asks the host for a consent-gated scope with `REQUEST_CONSENT`. When nothing is grantable, `PageBlockHost` distinguishes two cases:

- **benign** — the block re-requested a scope it already holds → silent no-op;
- **un-grantable** — a scope was clamped/withheld at mint and can never be added via consent here.

The un-grantable case called `showNotification({ title: 'Permission unavailable', … })` and returned. That toast renders in the **host frame**. **Nothing was posted back to the block.**

So the block had no way to tell *"the user has not confirmed the dialog yet"* from *"this environment will never grant this scope"* — the two states are indistinguishable from inside the iframe, and the block's only sensible default is to keep waiting.

Measured against the live product on 2026-08-07: an app's own UI showed

> **Grant access to generate** — Confirm in the Civitai dialog. If you dismissed it, click Generate again

front and centre — telling the developer to retry an action that can never succeed — while the host's corner toast said the permission was unavailable. Two contradictory messages on one screen, and the misleading one is where the developer is looking. The platform knew exactly what went wrong and told the app something else.

## The fix

On the un-grantable branch, also post over the existing host↔block bridge:

```ts
send('CONSENT_UNAVAILABLE', { reason: 'ungrantable', scopes: ungrantable.scopes });
```

- **Follows the existing bridge conventions.** It goes through the same `usePostMessage` `send` every other host→block message uses (origin-pinned / opaque-aware transport). It is a **fire-and-forget push**, not a `*_RESULT` reply — `REQUEST_CONSENT` carries no `requestId`, so there is nothing to correlate a reply to, exactly like the other uncorrelated pushes (`TOKEN_REFRESH`, `ROUTE_CHANGED`, `SUSPEND`/`RESUME`). No parallel channel was invented.
- **`scopes` is the refused set filtered to the known block-scope vocabulary** (`isKnownBlockScope`), not the block's raw hint echoed back. **The refusal itself is decided on the UNFILTERED set**, so an un-grantable scope outside the vocabulary still produces a message (with `scopes: []`) and still produces the toast — filtering the trigger would have silently deleted an existing user-visible behaviour. `resolveUngrantableConsentScopes` is now `resolveUngrantableConsentNotice` and returns `{ notify, scopes }`, the same decision/names split `resolveReviewConsentNotice` already uses. See the correction note at the top.
- Sent **before** the toast, so the block's signal cannot be lost to a throwing notification layer — now pinned by a test that records the synchronous calls (a spy on the delivered message cannot see ordering, because delivery is async).
- `send` added to the handler effect's dependency array (same shape as every other `send`-using handler in this file).
- `hostHandlerParity.ts`: comment-only. `REQUEST_CONSENT` stays `request: false` / `reply: ''` (the SDK still awaits nothing), with a note recording that this one push now exists — otherwise the inventory would read as a claim that nothing ever comes back.

### Scope discipline

- **No mint/clamp/grant logic touched.** Which scopes get granted is unchanged; only the signalling is. (There is a separate suspected defect in that area — deliberately not addressed here.)
- **The benign already-granted case stays a silent no-op** in *both* channels. Emitting there would train blocks to render a "permission unavailable" state over a permission that actually works.
- The existing host-side toast is unchanged. This **adds** a signal, it does not replace one.

## Tests — red at base, green at HEAD

Two tests added to `src/components/AppBlocks/PageBlockHost.browser.test.tsx` (real host mounted, real postMessage bridge, following the file's established `postFromBlock` pattern plus a `listenForHostPosts` helper of the same shape as `PageBlockHostThemeChange` / `-Storage`):

1. `Issue B: an UN-GRANTABLE REQUEST_CONSENT posts CONSENT_UNAVAILABLE to the block with the refused scopes`
2. `the BENIGN already-granted REQUEST_CONSENT posts NO CONSENT_UNAVAILABLE (the silent no-op stays silent)`

Both directions are covered: a message **is** posted with the refused scopes; and for the benign case **no** message is posted — the one that would otherwise silently rot.

| | `PageBlockHost.browser.test.tsx` |
|---|---|
| **base** (`origin/main` `ca42d6c8b4`, product file reverted, final test text) | **2 failed** \| 27 passed (29) |
| **HEAD** | **29 passed** (29) |

Both base failures are `expected [] to have a length of 1` — test 1 on its subject, test 2 on its **positive control**. Test 2 deliberately cannot pass without the emit: its subject is a zero, and a host that simply dropped the message produces that same zero, so it first posts an un-grantable scope on the very same mount, watches exactly one `CONSENT_UNAVAILABLE` arrive, then clears and reads the zero.

### Mutation check

Each mutant was applied to a pristine HEAD copy, with the replaced text asserted present so a missed edit could not masquerade as a survivor.

| Mutation | Result | Killed by, and **why** |
|---|---|---|
| **M1** — delete the `send(…)` line | 2 failed \| 27 passed | both tests: `expected [] to have a length of 1` (test 2 dies at its positive control) |
| **M2** — hoist the emit **above** the `if (ungrantable.length === 0) return` guard (emit unconditionally) | 1 failed \| 28 passed | **only** the benign test: `expected [ { …(2) } ] to have a length of +0 but got 1`. Test 1 still passes — so the benign zero is the sole killer, not another assertion tripping. This is the mutation that proves *my* guard is what keeps the benign case silent. |
| **M3** — echo the block's raw `payload?.scopes` instead of the computed set | 1 failed \| 28 passed | **only** test 1, on the payload deep-equality — so the payload assertion is load-bearing, not decorative |

Product file verified byte-identical to HEAD after each mutation.

### Other gates

- `--project component src/components/AppBlocks/` → **32 files / 377 tests passed**
- `--project unit src/components/AppBlocks/` → **32 files / 578 tests passed** (includes the 133-test `hostHandlerParity` suite)
- `pnpm typecheck` → 0 errors. 🔴 **Not evidence about the tests**: `tsconfig.json` excludes `src/**/__tests__/**`, and the browser-test files are not what typecheck's verdict covers. The test evidence is the red/green matrix and the mutation table above.
- `eslint` on the changed files reports **one** error — a pre-existing `local-rules/no-wholesale-module-mock` on the file's existing `vi.mock('~/utils/trpc')` at line 33. Verified identical (same single error) on the unmodified base file; not introduced here and out of scope.
- `prettier --check` on `hostHandlerParity.ts` warns — also **pre-existing on base** (unrelated `INLINE_STUB` / `_SdkCovered` formatting). Deliberately left alone rather than swept into this diff. The two files this PR actually reshapes are prettier-clean.

## Follow-up (deliberately NOT stacked on this PR)

The block-side copy change — making an app's UI render this new `CONSENT_UNAVAILABLE` signal instead of the misleading *"Confirm in the Civitai dialog. If you dismissed it, click Generate again"* retry text — belongs in the **CLI scaffold repo**, not here. It is a separate follow-up against that repo, not stacked on this PR: the platform signal has to exist and ship first before a scaffold can consume it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up commit `4312429a5e` — two review findings

### 1. The payload echoed untrusted block input (the correction at the top)

`resolveUngrantableConsentScopes` kept every non-empty string from `rawScopesHint` and subtracted
granted + missing. It never checked the scope vocabulary, so
`['<img src=x onerror=alert(1)>', 'not:a:real:scope', 'A'.repeat(5000)]` came back verbatim in the
push — and the announced follow-up renders these strings in block UI.

**The obvious fix would have been a regression.** That set is the **trigger** as well as the
payload: `if (ungrantable.length === 0) return;` sits above both the push and the toast. Filtering
it by `isKnownBlockScope` would make a request for an un-grantable scope the vocabulary doesn't
know produce **no message and no toast** — deleting an existing user-visible behaviour.

So the function now mirrors its sibling `resolveReviewConsentNotice`, which already separates the
two concerns. `resolveUngrantableConsentScopes` → `resolveUngrantableConsentNotice`, returning:

- `notify` — decided on the **unfiltered** un-grantable set. Toast behaviour is identical to
  before for every input, unknown scopes included.
- `scopes` — that set filtered to the known vocabulary. When every requested scope is
  unrecognised the message is **still sent**, with `scopes: []`. The refusal is the signal; the
  names are advisory.

`isKnownBlockScope` was checked: it is `Object.prototype.hasOwnProperty.call(...)`, an
own-property test, so inherited `Object.prototype` keys (`toString`, `constructor`, …) do **not**
pass as known scopes. A unit test pins that from this caller.

### 2. The "sent before the toast" claim was undefended

A mutation battery moved the `send` below `showNotification` and **all 29 tests still passed** —
the toast spy is a `vi.fn()` that cannot throw, and postMessage *delivery* is async, so no
existing assertion could observe the order. A new test patches the target window's `postMessage`
and records the **synchronous** calls, so the markers land in the order the handler performs them.

### Tests — red at this PR's previous tip (`4cb0993754`), green now

Same method as above: product files reverted to the previous tip, final test text in place.

| test | tip `4cb0993754` | HEAD |
|---|---|---|
| unknown/garbage/oversized scopes are DROPPED from the payload, message + toast still fire | **FAIL** — payload carried `<img src=x onerror=alert(1)>`, the 5000-char string and `not:a:real:scope` | pass |
| a MIXED hint names only the KNOWN scopes | **FAIL** — payload also carried `not:a:real:scope` | pass |
| the push happens BEFORE the toast | pass | pass |

The third was already true; it was simply undefended. It is an **invariant guard, not a
regression test** — its worth is mutant M7 below, which nothing else kills.

`PageBlockHost.browser.test.tsx` **32 passed** (29 + 3). `pageBlockHostLogic` unit tests
**84 passed** (+7). Wider: `--project unit src/components/AppBlocks/ src/shared/constants/` →
41 files / **722 passed**; `--project component src/components/AppBlocks/` → **380 passed**.

### Mutation check

Each mutant applied to a pristine tree with the replaced text asserted present, so a missed edit
cannot masquerade as a survivor. Mutants are semantic failure modes, not deletions.

| Mutation | Killed by, and by which assertion |
|---|---|
| **M1** invert the payload filter | 7 unit + 3 browser tests |
| **M2** filter the **trigger** instead of the payload (the trap) | browser *"unknown/garbage … message + toast still fire"*: `expected [] to have a length of 1` — the message never arrives at all; plus 3 unit tests on `notify` |
| **M3** drop the payload filter (the original defect) | 4 unit + 2 browser payload assertions |
| **M4** subtract with `\|\|` instead of `&&` | benign + grantable cases: 3 unit, 2 browser |
| **M5** caller gates on `.scopes.length` instead of `.notify` (the same trap, from the call site) | **only** the regression guard, same `expected [] to have a length of 1` |
| **M6** echo `payload?.scopes` in the push | 3 browser payload assertions |
| **M7** send **after** the toast | **only** the new order test: `expected [ 'toast', 'send' ] to deeply equal [ 'send', 'toast' ]` |
| **M8** `isKnownBlockScope` via `in` (prototype-chain bypass) | 2 unit tests — the inherited-keys pins |

### Other gates

- `pnpm typecheck` → **0 errors**. The browser test file is *not* under `src/**/__tests__/**`, so
  unlike the unit test file it **is** in the typecheck program.
- `eslint` on the four changed files → **1 error**, the pre-existing
  `local-rules/no-wholesale-module-mock` on this test file's existing `vi.mock('~/utils/trpc')`.
  Unchanged from base; not introduced here.
- `prettier --check` on the four changed files → clean.
