### PR TITLE
feat(telemetry): emit structured logs over OTLP alongside Axiom (dark by default)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -156,16 +156,12 @@ export default defineNextConfig(
       'redis', '@redis/client', '@redis/bloom', '@redis/json', '@redis/search', '@redis/time-series',
       '@opentelemetry/sdk-node', '@opentelemetry/instrumentation', '@opentelemetry/instrumentation-http',
       '@opentelemetry/instrumentation-redis', '@prisma/instrumentation',
-      // Logs pipeline. The logs API keeps its provider registry on a globalThis symbol,
-      // so writer and reader must be the SAME module instance; bundling a second copy
-      // into another graph is the one way this pipeline can go permanently silent
-      // without erroring. Externalizing removes that class rather than surviving it.
-      // (The bridge in @civitai/telemetry also binds lazily, so a second copy is
-      // survivable — belt and braces, because neither check can see the other's failure.)
-      // NOTE: @opentelemetry/resources and /semantic-conventions are deliberately NOT
-      // here — @opentelemetry/sdk-trace-web reaches them from the client graph.
-      '@opentelemetry/api', '@opentelemetry/api-logs', '@opentelemetry/sdk-logs',
-      '@opentelemetry/exporter-logs-otlp-proto',
+      // NOTE: the logs-pipeline packages (@opentelemetry/api, /api-logs, /sdk-logs,
+      // /exporter-logs-otlp-proto) are deliberately NOT externalized here. Adding them
+      // fails the image build, so it needs to be its own change with a full build as its
+      // gate. The logs bridge does not depend on it: it binds to the Logs API lazily, so
+      // a second bundled module copy is survivable, and `no_provider` on its skip counter
+      // is the runtime signal if one ever appears.
       '@pyroscope/nodejs', '@datadog/pprof',
     ],
     // Several entry points read markdown from src/static-content at runtime via fs

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -156,6 +156,16 @@ export default defineNextConfig(
       'redis', '@redis/client', '@redis/bloom', '@redis/json', '@redis/search', '@redis/time-series',
       '@opentelemetry/sdk-node', '@opentelemetry/instrumentation', '@opentelemetry/instrumentation-http',
       '@opentelemetry/instrumentation-redis', '@prisma/instrumentation',
+      // Logs pipeline. The logs API keeps its provider registry on a globalThis symbol,
+      // so writer and reader must be the SAME module instance; bundling a second copy
+      // into another graph is the one way this pipeline can go permanently silent
+      // without erroring. Externalizing removes that class rather than surviving it.
+      // (The bridge in @civitai/telemetry also binds lazily, so a second copy is
+      // survivable — belt and braces, because neither check can see the other's failure.)
+      // NOTE: @opentelemetry/resources and /semantic-conventions are deliberately NOT
+      // here — @opentelemetry/sdk-trace-web reaches them from the client graph.
+      '@opentelemetry/api', '@opentelemetry/api-logs', '@opentelemetry/sdk-logs',
+      '@opentelemetry/exporter-logs-otlp-proto',
       '@pyroscope/nodejs', '@datadog/pprof',
     ],
     // Several entry points read markdown from src/static-content at runtime via fs

--- a/packages/civitai-axiom/src/__tests__/logToAxiom.test.ts
+++ b/packages/civitai-axiom/src/__tests__/logToAxiom.test.ts
@@ -144,3 +144,123 @@ describe('logToAxiom structured-stderr sink (always-on for Loki)', () => {
     );
   });
 });
+
+// The injected-sink seam. `emitLog` is a plain function parameter, so these use a real
+// one — there is no module to mock, which is the point of injecting it.
+describe('logToAxiom injected sink (deps.emitLog)', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    h.ingestEvents.mockReset().mockResolvedValue(undefined);
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it('receives the SAME string that was written to stderr — identity, not an equal copy', async () => {
+    const bodies: string[] = [];
+    const { logToAxiom } = createAxiomLogger(PROD_CONFIGURED, {
+      emitLog: (body) => {
+        bodies.push(body);
+      },
+    });
+
+    await logToAxiom(ERR);
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(bodies).toHaveLength(1);
+    // `toBe` on strings is value identity — a sink that re-serialized the payload would
+    // produce an equal-looking but different string (e.g. dropping `_axiom`) and fail here.
+    expect(bodies[0]).toBe(errorSpy.mock.calls[0][0]);
+    expect(JSON.parse(bodies[0])._axiom).toBe('civitai-errors');
+  });
+
+  it('receives the payload and datastream alongside the line', async () => {
+    const calls: Array<[string, Record<string, unknown>, string | undefined]> = [];
+    const { logToAxiom } = createAxiomLogger(PROD_CONFIGURED, {
+      emitLog: (body, data, datastream) => {
+        calls.push([body, data, datastream]);
+      },
+    });
+
+    await logToAxiom(ERR);
+
+    expect(calls).toHaveLength(1);
+    const [, data, datastream] = calls[0];
+    expect(datastream).toBe('civitai-errors');
+    // `pod` is added by the logger, so the sink sees the same object Axiom ingests.
+    expect(data).toMatchObject({ message: ERR.message, code: ERR.code, pod: 'pod-test' });
+  });
+
+  it('CATCH LADDER: an unserializable payload still yields ONE line, shared by both sinks', async () => {
+    // The three-branch stringify ladder was refactored from three `console.error` calls
+    // to "assign once, write once". This pins that the fallback branch still produces
+    // exactly one stderr write AND that the sink gets that same fallback string.
+    const bodies: string[] = [];
+    const { logToAxiom } = createAxiomLogger(PROD_CONFIGURED, {
+      emitLog: (body) => {
+        bodies.push(body);
+      },
+    });
+
+    const circular: Record<string, unknown> = { name: 'payment.webhook' };
+    circular.self = circular;
+
+    await expect(logToAxiom(circular)).resolves.toBeUndefined();
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]).toBe(errorSpy.mock.calls[0][0]);
+    const parsed = JSON.parse(bodies[0]);
+    expect(parsed.name).toBe('payment.webhook');
+    expect(typeof parsed._stringifyError).toBe('string');
+  });
+
+  it('CONTAINMENT: a throwing sink does not break the caller, the stderr line, or the Axiom write', async () => {
+    const { logToAxiom } = createAxiomLogger(PROD_CONFIGURED, {
+      emitLog: () => {
+        throw new Error('sink exploded');
+      },
+    });
+
+    // The caller must be untouched — logToAxiom is awaited on hot paths.
+    await expect(logToAxiom(ERR)).resolves.toBeUndefined();
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(errorSpy.mock.calls[0][0] as string)).toMatchObject({
+      message: ERR.message,
+    });
+    expect(h.ingestEvents).toHaveBeenCalledTimes(1);
+  });
+
+  it('is OPTIONAL: with no deps the logger behaves exactly as before', async () => {
+    const { logToAxiom } = createAxiomLogger(PROD_CONFIGURED);
+
+    await expect(logToAxiom(ERR)).resolves.toBeUndefined();
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(h.ingestEvents).toHaveBeenCalledTimes(1);
+  });
+
+  it('is NOT called outside prod, where no structured line is written either', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    let called = 0;
+    const { logToAxiom } = createAxiomLogger(
+      { ...PROD_CONFIGURED, isProd: false },
+      {
+        emitLog: () => {
+          called += 1;
+        },
+      }
+    );
+
+    await logToAxiom(ERR);
+
+    expect(called).toBe(0);
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    logSpy.mockRestore();
+  });
+});

--- a/packages/civitai-axiom/src/__tests__/logToAxiom.test.ts
+++ b/packages/civitai-axiom/src/__tests__/logToAxiom.test.ts
@@ -235,6 +235,29 @@ describe('logToAxiom injected sink (deps.emitLog)', () => {
     expect(h.ingestEvents).toHaveBeenCalledTimes(1);
   });
 
+  it('LATE REGISTRATION: a sink attached to the deps object AFTER the logger is built still fires', async () => {
+    // The app registers its sink from a server-only entry point at boot, which happens
+    // after this factory has already run. That works only because `deps.emitLog` is read
+    // per call rather than captured at construction — this pins exactly that.
+    const deps: { emitLog?: (body: string) => void } = {};
+    const bodies: string[] = [];
+    const { logToAxiom } = createAxiomLogger(PROD_CONFIGURED, deps);
+
+    // Before registration: nothing to call, and the logger still works.
+    await logToAxiom(ERR);
+    expect(bodies).toHaveLength(0);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+
+    // Register late, exactly as the app does.
+    deps.emitLog = (body: string) => {
+      bodies.push(body);
+    };
+
+    await logToAxiom(ERR);
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]).toBe(errorSpy.mock.calls[1][0]);
+  });
+
   it('is OPTIONAL: with no deps the logger behaves exactly as before', async () => {
     const { logToAxiom } = createAxiomLogger(PROD_CONFIGURED);
 

--- a/packages/civitai-axiom/src/client.ts
+++ b/packages/civitai-axiom/src/client.ts
@@ -46,12 +46,36 @@ export type AxiomLogger = {
 };
 
 /**
+ * An additional sink for the structured line this logger already builds.
+ *
+ * `body` is the exact string written to stderr, so a sink that forwards it verbatim
+ * stays byte-identical to the stderr path and a query written against one matches the
+ * other. `data` is the same payload in object form, for sinks that need fields.
+ *
+ * INJECTED, not imported: this keeps `@civitai/axiom` free of any dependency on (and any
+ * semantics of) whatever transport the app happens to bolt on. See ./env's header —
+ * "App behavior (loggers, policy callbacks) would be injected at the factory instead".
+ *
+ * Must not throw; `logToAxiom` contains it anyway, because a telemetry sink must never
+ * be able to fail the code path it is observing.
+ */
+export type EmitLog = (body: string, data: MixedObject, datastream?: string) => void;
+
+export type AxiomDeps = {
+  emitLog?: EmitLog;
+};
+
+/**
  * Build an Axiom logger. Config defaults come from the package's own env schema
  * (./env); pass a `Partial<AxiomConfig>` to override any value per call (tests,
- * multi-instance, alternate config sources). Axiom has no injected app-behavior
- * deps (it *is* the logger). See the `~/server/logging/client` shim.
+ * multi-instance, alternate config sources). `deps` injects optional app behavior —
+ * default `{}`, so a consumer that passes nothing gets exactly the previous behavior.
+ * See the `~/server/logging/client` shim.
  */
-export function createAxiomLogger(overrides: Partial<AxiomConfig> = {}): AxiomLogger {
+export function createAxiomLogger(
+  overrides: Partial<AxiomConfig> = {},
+  deps: AxiomDeps = {}
+): AxiomLogger {
   const config = { ...loadAxiomEnv(), ...overrides };
 
   const axiom =
@@ -86,19 +110,40 @@ export function createAxiomLogger(overrides: Partial<AxiomConfig> = {}): AxiomLo
       // unguarded stringify could break a caller that previously never hit this line.
       // Contain it: a serialization failure must NEVER break the caller — emit a minimal,
       // stringify-safe fallback (itself wrapped) so the event isn't silently lost.
+      //
+      // ONE serialization, N sinks. The line is built once and then handed to every
+      // sink, so the stderr text and any injected sink's body are the SAME string —
+      // a query written against one path matches on the other — and a hot path that
+      // may be awaited pays for one JSON.stringify rather than one per sink.
+      let line: string;
       try {
-        console.error(JSON.stringify({ _axiom: datastream, ...sendData }));
+        line = JSON.stringify({ _axiom: datastream, ...sendData });
       } catch (err) {
         try {
-          console.error(
-            JSON.stringify({
-              _axiom: datastream,
-              name: (sendData as MixedObject)?.name,
-              _stringifyError: String(err),
-            })
-          );
+          line = JSON.stringify({
+            _axiom: datastream,
+            name: (sendData as MixedObject)?.name,
+            _stringifyError: String(err),
+          });
         } catch {
-          console.error('logToAxiom: failed to serialize event', (sendData as MixedObject)?.name);
+          // Triple fault (even the minimal payload won't serialize). Not JSON — the
+          // consumers of this line all tolerate a non-JSON line, and anything that
+          // tried to build JSON here would be the fourth thing to throw.
+          line = `logToAxiom: failed to serialize event ${String((sendData as MixedObject)?.name)}`;
+        }
+      }
+
+      console.error(line);
+
+      // Additional sink, if one was injected. Deliberately AFTER the stderr write and
+      // contained: an injected sink is app-supplied code, and neither its cost nor its
+      // failure may reach the stderr write above, the Axiom dual-write below, or the
+      // caller. A sink that throws is swallowed here; counting it is the sink's job.
+      if (deps.emitLog) {
+        try {
+          deps.emitLog(line, sendData, datastream);
+        } catch {
+          /* contained — see above */
         }
       }
 

--- a/packages/civitai-telemetry/package.json
+++ b/packages/civitai-telemetry/package.json
@@ -4,8 +4,20 @@
   "private": true,
   "main": "./src/index.ts",
   "types": "./src/index.ts",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/api-logs": "^0.211.0",
+    "@opentelemetry/resources": "2.9.0",
+    "@opentelemetry/sdk-logs": "^0.211.0",
     "prom-client": "^14.2.0"
+  },
+  "devDependencies": {
+    "@opentelemetry/context-async-hooks": "^2.5.0",
+    "@opentelemetry/core": "2.9.0",
+    "vitest": "^4.0.18"
   }
 }

--- a/packages/civitai-telemetry/src/__tests__/otel-logs.test.ts
+++ b/packages/civitai-telemetry/src/__tests__/otel-logs.test.ts
@@ -1,0 +1,528 @@
+import { context, trace, TraceFlags } from '@opentelemetry/api';
+import { logs, SeverityNumber } from '@opentelemetry/api-logs';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
+import { ExportResultCode } from '@opentelemetry/core';
+import {
+  InMemoryLogRecordExporter,
+  LoggerProvider,
+  SimpleLogRecordProcessor,
+  BatchLogRecordProcessor,
+  type LogRecordExporter,
+  type LogRecordProcessor,
+  type ReadableLogRecord,
+} from '@opentelemetry/sdk-logs';
+import type { Counter } from 'prom-client';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  buildOtelLogAttributes,
+  createOtelLoggerProvider,
+  deriveSeverity,
+  emitOtelLog,
+  OTEL_LOG_ATTRIBUTE_KEYS,
+  OTEL_SHUTDOWN_SIGNALS,
+  otelLogRecordsEmittedCounter,
+  otelLogRecordsSkippedCounter,
+  registerOtelShutdown,
+  resetOtelLogBridge,
+} from '../otel-logs';
+
+// 🔴 This suite deliberately does NOT `vi.mock('@opentelemetry/api-logs')` (or sdk-logs).
+// A wholesale factory mock would make every assertion below vacuous — it would be testing
+// the mock's shape, not the bridge — and the repo's `no-wholesale-module-mock` guard only
+// watches `~/utils/trpc`, so nothing would catch it. The SDK exports everything needed to
+// run this for real: LoggerProvider, SimpleLogRecordProcessor, InMemoryLogRecordExporter.
+
+const VALID_TRACE_ID = '4bf92f3577b34da6a3ce929d0e0e4736';
+const VALID_SPAN_ID = '00f067aa0ba902b7';
+
+/** Read one counter's current value; labels narrow to a single child series. */
+async function counterValue(
+  counter: Counter<string>,
+  labels?: Record<string, string>
+): Promise<number> {
+  const metric = await counter.get();
+  const match = metric.values.find((v) =>
+    labels ? Object.entries(labels).every(([k, want]) => v.labels[k] === want) : true
+  );
+  return match?.value ?? 0;
+}
+
+/** Register a real provider that records into memory, and return the exporter. */
+function registerRecordingProvider(): InMemoryLogRecordExporter {
+  const exporter = new InMemoryLogRecordExporter();
+  const provider = new LoggerProvider({ processors: [new SimpleLogRecordProcessor(exporter)] });
+  logs.setGlobalLoggerProvider(provider);
+  return exporter;
+}
+
+/**
+ * A real LogRecordExporter that appends to an array the CALLER owns, ASYNCHRONOUSLY.
+ *
+ * Two deliberate properties, each load-bearing for the shutdown tests:
+ *
+ *  1. It does not reset on shutdown. `InMemoryLogRecordExporter.shutdown()` RESETS its
+ *     own store, so a test that shuts the provider down and then reads that store finds
+ *     it empty whether or not the flush worked — a false 0 that reads exactly like the
+ *     bug it is supposed to detect.
+ *  2. It completes on a LATER TICK, like the real network exporter it stands in for. A
+ *     synchronous stub cannot tell an awaited shutdown from an un-awaited one — both
+ *     read 1 — so the "does SIGTERM actually flush" test would pass with the very defect
+ *     it exists to catch. Measured: with a synchronous stub, removing the `await`
+ *     left that test GREEN.
+ */
+function collectingExporter(): { exporter: LogRecordExporter; records: ReadableLogRecord[] } {
+  const records: ReadableLogRecord[] = [];
+  return {
+    records,
+    exporter: {
+      export(batch, resultCallback) {
+        setTimeout(() => {
+          records.push(...batch);
+          resultCallback({ code: ExportResultCode.SUCCESS });
+        }, 5);
+      },
+      shutdown: async () => {},
+    },
+  };
+}
+
+beforeAll(() => {
+  // Production registers a context manager (the Node SDK does it); the API's default is
+  // a no-op whose `with()` does NOT propagate, so `context.active()` inside it still
+  // returns ROOT_CONTEXT. Without this, every trace-context assertion below would read
+  // "no active span" and pass or fail for a reason that has nothing to do with the code.
+  context.setGlobalContextManager(new AsyncLocalStorageContextManager().enable());
+});
+
+afterAll(() => {
+  context.disable();
+});
+
+beforeEach(() => {
+  // A clean global on every test: `setGlobalLoggerProvider` is a no-op when one is
+  // already registered, so without this the second test would silently reuse the first
+  // test's provider and its exporter would look empty.
+  logs.disable();
+  resetOtelLogBridge();
+  process.env.OTEL_LOGS_ENABLED = 'true';
+});
+
+afterEach(() => {
+  logs.disable();
+  resetOtelLogBridge();
+  delete process.env.OTEL_LOGS_ENABLED;
+});
+
+// ---------------------------------------------------------------------------
+describe('deriveSeverity', () => {
+  it('maps the four severity words to their exact OTel (number, text) pair', () => {
+    // Asserts the exact pair per key, so changing ONE row fails ONLY that row.
+    expect(deriveSeverity('error')).toEqual({
+      severityNumber: SeverityNumber.ERROR,
+      severityText: 'ERROR',
+    });
+    expect(deriveSeverity('warning')).toEqual({
+      severityNumber: SeverityNumber.WARN,
+      severityText: 'WARN',
+    });
+    expect(deriveSeverity('warn')).toEqual({
+      severityNumber: SeverityNumber.WARN,
+      severityText: 'WARN',
+    });
+    expect(deriveSeverity('info')).toEqual({
+      severityNumber: SeverityNumber.INFO,
+      severityText: 'INFO',
+    });
+
+    // Pin the literal numbers too — the constants above are the SDK's, so a table that
+    // silently swapped ERROR for WARN would still satisfy the assertions above if the
+    // expectation were derived from the same lookup the implementation uses.
+    expect(deriveSeverity('error').severityNumber).toBe(17);
+    expect(deriveSeverity('warning').severityNumber).toBe(13);
+    expect(deriveSeverity('info').severityNumber).toBe(9);
+  });
+
+  it('maps an EVENT-NAME type to UNSPECIFIED with severityText OMITTED (not a placeholder)', () => {
+    for (const eventName of ['job-error', 'buzz', 'job-summary', 'oauth.bust-cache.failed']) {
+      const derived = deriveSeverity(eventName);
+      expect(derived.severityNumber).toBe(SeverityNumber.UNSPECIFIED);
+      expect(derived.severityNumber).toBe(0);
+      // Omitted, not ''/'UNSPECIFIED': downstream level resolution prefers the TEXT over
+      // the NUMBER, so any invented string would outrank a correct number.
+      expect(derived.severityText).toBeUndefined();
+      expect('severityText' in derived).toBe(false);
+    }
+  });
+
+  it('maps an ABSENT / non-string type to UNSPECIFIED', () => {
+    expect(deriveSeverity(undefined)).toEqual({ severityNumber: SeverityNumber.UNSPECIFIED });
+    expect(deriveSeverity(null)).toEqual({ severityNumber: SeverityNumber.UNSPECIFIED });
+    expect(deriveSeverity(42)).toEqual({ severityNumber: SeverityNumber.UNSPECIFIED });
+  });
+
+  it('does NOT fail open on an inherited-prototype key', () => {
+    // An object-literal lookup would resolve `SEVERITY['toString']` to a truthy function
+    // and never reach the default. A Map cannot.
+    for (const key of ['toString', 'constructor', 'hasOwnProperty', '__proto__']) {
+      expect(deriveSeverity(key)).toEqual({ severityNumber: SeverityNumber.UNSPECIFIED });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('buildOtelLogAttributes', () => {
+  it('emits a CLOSED key set — unknown payload fields never become attributes', () => {
+    const attrs = buildOtelLogAttributes(
+      {
+        type: 'error',
+        name: 'model.getById',
+        pod: 'pod-1',
+        userId: 12345,
+        requestId: 'req-9',
+        weirdField: 'y',
+        another: 1,
+        config: { headers: { authorization: 'secret' } },
+      },
+      'a-datastream'
+    );
+
+    // Structural: the EXACT key set, not "does it contain". A spread of the payload
+    // fails here by name.
+    expect(Object.keys(attrs).sort()).toEqual([...OTEL_LOG_ATTRIBUTE_KEYS].sort());
+    expect(attrs['civitai.type']).toBe('error');
+    expect(attrs['civitai.name']).toBe('model.getById');
+    expect(attrs['civitai.user_id']).toBe(12345);
+    expect(attrs['civitai.datastream']).toBe('a-datastream');
+    expect(attrs).not.toHaveProperty('weirdField');
+    expect(attrs).not.toHaveProperty('config');
+  });
+
+  it('omits keys the payload does not carry rather than emitting undefined', () => {
+    const attrs = buildOtelLogAttributes({ type: 'info' });
+    expect(Object.keys(attrs)).toEqual(['civitai.type']);
+  });
+
+  it('keeps the RAW type verbatim even when it is unmapped — no information is lost', () => {
+    expect(buildOtelLogAttributes({ type: 'job-error' })['civitai.type']).toBe('job-error');
+    expect(buildOtelLogAttributes({ type: 'toString' })['civitai.type']).toBe('toString');
+  });
+
+  it('accepts the two alternate spellings for user and request id', () => {
+    expect(buildOtelLogAttributes({ user: 7 })['civitai.user_id']).toBe(7);
+    expect(buildOtelLogAttributes({ request_id: 'r' })['civitai.request_id']).toBe('r');
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('emitOtelLog — provider binding', () => {
+  it('THE PAIR: 1 record exported with a provider registered, 0 without', async () => {
+    // NEGATIVE: no global provider. This is the state a bad bind leaves behind, and the
+    // reason the assertion is a RECORD COUNT and a counter delta rather than a spy —
+    // a spy on getLogger stays green through the exact failure being guarded.
+    const skippedBefore = await counterValue(otelLogRecordsSkippedCounter, {
+      reason: 'no_provider',
+    });
+    expect(emitOtelLog('{"a":1}', { type: 'error' })).toBe(false);
+    expect(await counterValue(otelLogRecordsSkippedCounter, { reason: 'no_provider' })).toBe(
+      skippedBefore + 1
+    );
+
+    // POSITIVE: same call, provider registered.
+    resetOtelLogBridge();
+    const exporter = registerRecordingProvider();
+    const emittedBefore = await counterValue(otelLogRecordsEmittedCounter);
+
+    expect(emitOtelLog('{"a":1}', { type: 'error' })).toBe(true);
+
+    expect(exporter.getFinishedLogRecords()).toHaveLength(1);
+    expect(await counterValue(otelLogRecordsEmittedCounter)).toBe(emittedBefore + 1);
+  });
+
+  it('a logger bound EAGERLY (before registration) is permanently silent; the lazy bind is not', async () => {
+    // Reproduces the state the lazy bind exists to make unreachable: a ProxyLogger whose
+    // proxy provider is never delegated resolves to the no-op logger FOREVER — no error,
+    // no exception, no record. In production that state is reached by a second bundled
+    // module copy, which Vitest structurally cannot stage; here it is reached by binding
+    // before the provider that eventually gets registered exists. Same terminal state,
+    // and it is the state that matters.
+    const eagerLogger = logs.getLogger('bound-too-early');
+    logs.disable();
+
+    const exporter = registerRecordingProvider();
+
+    eagerLogger.emit({ severityNumber: SeverityNumber.ERROR, body: 'from the eager logger' });
+    expect(exporter.getFinishedLogRecords()).toHaveLength(0); // silently dropped
+
+    resetOtelLogBridge();
+    expect(emitOtelLog('from the lazy bridge', { type: 'error' })).toBe(true);
+    expect(exporter.getFinishedLogRecords()).toHaveLength(1);
+    expect(exporter.getFinishedLogRecords()[0].body).toBe('from the lazy bridge');
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('emitOtelLog — dark launch gate', () => {
+  it('emits NOTHING unless OTEL_LOGS_ENABLED === "true", and counts the skip', async () => {
+    const exporter = registerRecordingProvider();
+
+    for (const value of [undefined, 'false', '1', 'TRUE', 'yes']) {
+      resetOtelLogBridge();
+      if (value === undefined) delete process.env.OTEL_LOGS_ENABLED;
+      else process.env.OTEL_LOGS_ENABLED = value;
+
+      const before = await counterValue(otelLogRecordsSkippedCounter, { reason: 'disabled' });
+      expect(emitOtelLog('{"a":1}', { type: 'error' })).toBe(false);
+      expect(await counterValue(otelLogRecordsSkippedCounter, { reason: 'disabled' })).toBe(
+        before + 1
+      );
+    }
+
+    // The pair: nothing reached the exporter across all five dark configurations, and the
+    // SAME call with the flag on does export — so the zero above is the gate, not a
+    // probe wired to nothing.
+    expect(exporter.getFinishedLogRecords()).toHaveLength(0);
+
+    process.env.OTEL_LOGS_ENABLED = 'true';
+    resetOtelLogBridge();
+    expect(emitOtelLog('{"a":1}', { type: 'error' })).toBe(true);
+    expect(exporter.getFinishedLogRecords()).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('emitOtelLog — record shape', () => {
+  it('uses the caller-supplied line as the body VERBATIM and maps severity + attributes', () => {
+    const exporter = registerRecordingProvider();
+    const line = '{"_axiom":"ds","pod":"pod-1","type":"error","name":"model.getById"}';
+
+    emitOtelLog(line, { pod: 'pod-1', type: 'error', name: 'model.getById' }, 'ds');
+
+    const [record] = exporter.getFinishedLogRecords();
+    expect(record.body).toBe(line);
+    expect(record.severityNumber).toBe(SeverityNumber.ERROR);
+    expect(record.severityText).toBe('ERROR');
+    expect(record.attributes).toEqual({
+      'civitai.datastream': 'ds',
+      'civitai.pod': 'pod-1',
+      'civitai.type': 'error',
+      'civitai.name': 'model.getById',
+    });
+  });
+
+  it('leaves severityText UNSET on the wire for an unmapped type', () => {
+    const exporter = registerRecordingProvider();
+    emitOtelLog('{"type":"job-summary"}', { type: 'job-summary' });
+
+    const [record] = exporter.getFinishedLogRecords();
+    expect(record.severityNumber).toBe(SeverityNumber.UNSPECIFIED);
+    expect(record.severityText).toBeUndefined();
+    expect(record.attributes['civitai.type']).toBe('job-summary');
+  });
+
+  it('emits a record for a payload with NO type at all', () => {
+    const exporter = registerRecordingProvider();
+    expect(emitOtelLog('{"name":"no-type-here"}', { name: 'no-type-here' })).toBe(true);
+
+    const [record] = exporter.getFinishedLogRecords();
+    expect(record.severityNumber).toBe(SeverityNumber.UNSPECIFIED);
+    expect(record.severityText).toBeUndefined();
+    expect(record.attributes).not.toHaveProperty('civitai.type');
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('emitOtelLog — containment', () => {
+  it('never throws when the pipeline throws, and counts it', async () => {
+    const throwing: LogRecordProcessor = {
+      onEmit() {
+        throw new Error('processor boom');
+      },
+      forceFlush: async () => {},
+      shutdown: async () => {},
+    };
+    logs.setGlobalLoggerProvider(new LoggerProvider({ processors: [throwing] }));
+
+    const before = await counterValue(otelLogRecordsSkippedCounter, { reason: 'emit_threw' });
+    expect(() => emitOtelLog('{"a":1}', { type: 'error' })).not.toThrow();
+    expect(emitOtelLog('{"a":1}', { type: 'error' })).toBe(false);
+    expect(await counterValue(otelLogRecordsSkippedCounter, { reason: 'emit_threw' })).toBe(
+      before + 2
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('trace context', () => {
+  it('CONTRACT: the SDK attaches the active span context itself — the bridge sets none', () => {
+    const exporter = registerRecordingProvider();
+    const spanContext = {
+      traceId: VALID_TRACE_ID,
+      spanId: VALID_SPAN_ID,
+      traceFlags: TraceFlags.SAMPLED,
+      isRemote: false,
+    };
+
+    context.with(trace.setSpanContext(context.active(), spanContext), () => {
+      emitOtelLog('{"type":"error"}', { type: 'error' });
+    });
+
+    const [record] = exporter.getFinishedLogRecords();
+    expect(record.spanContext?.traceId).toBe(VALID_TRACE_ID);
+    expect(record.spanContext?.spanId).toBe(VALID_SPAN_ID);
+    // Correlation is free; nothing is stamped as an attribute for it.
+    expect(record.attributes).not.toHaveProperty('civitai.trace_id');
+  });
+
+  it('omits the span context when there is no active span', () => {
+    const exporter = registerRecordingProvider();
+    emitOtelLog('{"type":"error"}', { type: 'error' });
+    expect(exporter.getFinishedLogRecords()[0].spanContext).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('createOtelLoggerProvider', () => {
+  const UNSAMPLED_SPAN_CONTEXT = {
+    traceId: VALID_TRACE_ID,
+    spanId: VALID_SPAN_ID,
+    traceFlags: TraceFlags.NONE, // valid span context, trace NOT sampled
+    isRemote: false,
+  };
+
+  it('REGRESSION GUARD: keeps records emitted inside an UNSAMPLED span (traceBased stays off)', async () => {
+    // Head trace sampling runs well below 1.0, so a provider built with
+    // `traceBased: true` would silently discard the large majority of in-request log
+    // records. This asserts the shipped factory does not.
+    const exporter = new InMemoryLogRecordExporter();
+    const provider = createOtelLoggerProvider({ exporter });
+    logs.setGlobalLoggerProvider(provider);
+
+    context.with(trace.setSpanContext(context.active(), UNSAMPLED_SPAN_CONTEXT), () => {
+      emitOtelLog('{"type":"error"}', { type: 'error' });
+    });
+    await provider.forceFlush();
+
+    expect(exporter.getFinishedLogRecords()).toHaveLength(1);
+  });
+
+  it('POSITIVE CONTROL for that guard: traceBased:true really does drop the same record', async () => {
+    // Without this, the assertion above is indistinguishable from a test that would pass
+    // whatever the config said. Same record, same unsampled span, one config difference.
+    const exporter = new InMemoryLogRecordExporter();
+    const provider = new LoggerProvider({
+      processors: [new SimpleLogRecordProcessor(exporter)],
+      loggerConfigurator: () => ({
+        disabled: false,
+        minimumSeverity: SeverityNumber.UNSPECIFIED,
+        traceBased: true,
+      }),
+    });
+    logs.setGlobalLoggerProvider(provider);
+
+    context.with(trace.setSpanContext(context.active(), UNSAMPLED_SPAN_CONTEXT), () => {
+      emitOtelLog('{"type":"error"}', { type: 'error' });
+    });
+    await provider.forceFlush();
+
+    expect(exporter.getFinishedLogRecords()).toHaveLength(0);
+  });
+
+  it('keeps records with an UNSPECIFIED severity (they bypass the minimum-severity filter)', async () => {
+    const exporter = new InMemoryLogRecordExporter();
+    const provider = createOtelLoggerProvider({ exporter });
+    logs.setGlobalLoggerProvider(provider);
+
+    emitOtelLog('{"type":"job-summary"}', { type: 'job-summary' });
+    await provider.forceFlush();
+
+    expect(exporter.getFinishedLogRecords()).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('registerOtelShutdown', () => {
+  let registered: { unregister: () => void } | undefined;
+
+  afterEach(() => {
+    registered?.unregister();
+    registered = undefined;
+  });
+
+  it('defaults to SIGTERM *and* SIGINT', () => {
+    expect([...OTEL_SHUTDOWN_SIGNALS]).toEqual(['SIGTERM', 'SIGINT']);
+  });
+
+  it('SIGTERM FLUSHES a batch the timer is still holding', async () => {
+    const { exporter, records } = collectingExporter();
+    // A deliberately long scheduled delay: nothing can leave on the timer within this
+    // test, so a record that arrives at the exporter can only have been flushed by the
+    // shutdown path.
+    const provider = new LoggerProvider({
+      processors: [new BatchLogRecordProcessor(exporter, { scheduledDelayMillis: 60_000 })],
+    });
+    logs.setGlobalLoggerProvider(provider);
+
+    const before = process.listeners('SIGTERM').length;
+    const ctl = registerOtelShutdown([provider], { log: () => {} });
+    registered = ctl;
+    expect(process.listeners('SIGTERM').length).toBe(before + 1);
+
+    emitOtelLog('{"type":"error"}', { type: 'error' });
+
+    // NEGATIVE CONTROL: the timer is holding it. If this reads 1, the assertion below
+    // proves nothing — the record would have arrived with or without a shutdown.
+    expect(records).toHaveLength(0);
+
+    // Invoke the listener actually registered on SIGTERM, then AWAIT what it started.
+    // Awaiting is the whole point: the shape this replaces returned before the flush
+    // completed, and that difference is invisible to a `shutdown()` spy.
+    const listener = process.listeners('SIGTERM').at(-1) as () => void;
+    listener();
+    await ctl.settled();
+
+    expect(records).toHaveLength(1);
+    expect(records[0].body).toBe('{"type":"error"}');
+  });
+
+  it('is IDEMPOTENT across a second signal — SIGINT after SIGTERM joins, it does not re-run', async () => {
+    let shutdownCalls = 0;
+    const target = {
+      shutdown: async () => {
+        shutdownCalls += 1;
+      },
+    };
+
+    const ctl = registerOtelShutdown([target], { log: () => {} });
+    registered = ctl;
+
+    const sigterm = process.listeners('SIGTERM').at(-1) as () => void;
+    const sigint = process.listeners('SIGINT').at(-1) as () => void;
+    sigterm();
+    sigint();
+    await ctl.settled();
+
+    expect(shutdownCalls).toBe(1);
+  });
+
+  it('a failing target does not prevent the other flush, and does not reject', async () => {
+    const failing = { shutdown: async () => Promise.reject(new Error('exporter down')) };
+    let otherRan = false;
+    const other = {
+      shutdown: async () => {
+        otherRan = true;
+      },
+    };
+    const errors: unknown[] = [];
+
+    const ctl = registerOtelShutdown([failing, other], {
+      log: () => {},
+      onError: (reason) => errors.push(reason),
+    });
+    registered = ctl;
+
+    await expect(ctl.shutdown('test')).resolves.toBeUndefined();
+    expect(otherRan).toBe(true);
+    expect(errors).toHaveLength(1);
+  });
+});

--- a/packages/civitai-telemetry/src/otel-logs.ts
+++ b/packages/civitai-telemetry/src/otel-logs.ts
@@ -1,0 +1,350 @@
+// OTel Logs bridge: emits the app's structured log records over OTLP, in addition to
+// (never instead of) the existing sinks.
+//
+// DELIBERATELY NOT RE-EXPORTED FROM `./index`. The barrel is imported by code that also
+// reaches the browser graph; this module pulls `@opentelemetry/sdk-logs`, which is
+// server-only. Import it by subpath: `@civitai/telemetry/otel-logs`.
+//
+// The emitter is injected into `@civitai/axiom` rather than imported by it (see that
+// package's `env.ts` header, which prescribes exactly this shape) so the Axiom package
+// keeps no OpenTelemetry dependency and no OpenTelemetry semantics of its own.
+import {
+  logs,
+  SeverityNumber,
+  type Logger,
+  type LogRecord as ApiLogRecord,
+} from '@opentelemetry/api-logs';
+import {
+  BatchLogRecordProcessor,
+  LoggerProvider,
+  type LogRecordExporter,
+  type LogRecordProcessor,
+} from '@opentelemetry/sdk-logs';
+import type { Resource } from '@opentelemetry/resources';
+import { registerCounter, registerCounterWithLabels } from './client';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type MixedObject = Record<string, any>;
+
+// ---------------------------------------------------------------------------
+// Counters — the positive/negative control for "is this thing wired to anything"
+// ---------------------------------------------------------------------------
+// A count of zero records arriving at the far end is indistinguishable from a bridge
+// that never runs. These make the difference observable in-process, before the record
+// ever leaves it. `skipped{reason="no_provider"}` in particular is the ONLY runtime
+// signal for the module-identity/bundling failure described on `resolveLogger` below —
+// a unit test structurally cannot see that one.
+export const otelLogRecordsEmittedCounter = registerCounter({
+  name: 'otel_log_records_emitted_total',
+  help: 'Structured log records handed to the OTel Logs API by the Axiom bridge',
+});
+
+export const OTEL_LOG_SKIP_REASONS = ['disabled', 'no_provider', 'emit_threw'] as const;
+export type OtelLogSkipReason = (typeof OTEL_LOG_SKIP_REASONS)[number];
+
+export const otelLogRecordsSkippedCounter = registerCounterWithLabels({
+  name: 'otel_log_records_skipped_total',
+  help: 'Structured log records NOT emitted over OTLP, by reason',
+  labelNames: ['reason'] as const,
+});
+
+// ---------------------------------------------------------------------------
+// Severity
+// ---------------------------------------------------------------------------
+// `type` is a HYBRID field, not a severity field: measured across the call sites, ~84%
+// carry a severity word, the rest carry an event name (`job-error`, `buzz`,
+// `job-summary`, ...) and some carry no `type` at all.
+//
+// Anything not in this table maps to UNSPECIFIED(0) with severityText OMITTED. Both
+// halves matter:
+//   - Guessing ERROR mislabels `job-summary`; guessing INFO hides `job-error`. A
+//     `-error`/`-failed` suffix heuristic would be wrong for cases nobody can
+//     enumerate, so there is no default worth inventing — UNSPECIFIED is the honest
+//     "this event does not declare a severity".
+//   - severityText is omitted rather than set to a placeholder because the downstream
+//     level resolution prefers the TEXT over the NUMBER, so an invented string would
+//     outrank a correct number.
+// No information is lost: the raw value always travels verbatim as `civitai.type`.
+//
+// A Map, NOT an object literal. An object-literal lookup with a caller-supplied key
+// FAILS OPEN — `SEVERITY['toString']` is a truthy function, so `type: 'toString'` would
+// resolve to garbage instead of falling through to the default.
+const SEVERITY_BY_TYPE: ReadonlyMap<string, DerivedSeverity> = new Map([
+  ['error', { severityNumber: SeverityNumber.ERROR, severityText: 'ERROR' }],
+  ['warning', { severityNumber: SeverityNumber.WARN, severityText: 'WARN' }],
+  ['warn', { severityNumber: SeverityNumber.WARN, severityText: 'WARN' }],
+  ['info', { severityNumber: SeverityNumber.INFO, severityText: 'INFO' }],
+]);
+
+export type DerivedSeverity = { severityNumber: SeverityNumber; severityText?: string };
+
+const UNSPECIFIED: DerivedSeverity = { severityNumber: SeverityNumber.UNSPECIFIED };
+
+/** Map a raw `type` value to an OTel severity. Unknown/absent/non-string → UNSPECIFIED. */
+export function deriveSeverity(rawType: unknown): DerivedSeverity {
+  if (typeof rawType !== 'string') return UNSPECIFIED;
+  return SEVERITY_BY_TYPE.get(rawType) ?? UNSPECIFIED;
+}
+
+// ---------------------------------------------------------------------------
+// Attributes
+// ---------------------------------------------------------------------------
+// A CLOSED set, never a spread of the payload. Spreading reproduces exactly the schema
+// explosion that `safeError` exists to prevent (every key of a nested `.config`,
+// `.headers`, `.cause` becomes its own field), and on the receiving side it mints
+// unbounded metadata keys. The full payload is already carried, intact, in the body.
+//
+// Nothing here is k8s identity. Pod/namespace/deployment/node identity is attached
+// downstream, after the record leaves this process — the app must not set it, and a
+// value guessed in-process would be worse than an absent one.
+export const OTEL_LOG_ATTRIBUTE_KEYS = [
+  'civitai.datastream',
+  'civitai.type',
+  'civitai.name',
+  'civitai.pod',
+  'civitai.user_id',
+  'civitai.request_id',
+] as const;
+
+export type OtelLogAttributes = Record<string, string | number | boolean>;
+
+function coerce(value: unknown): string | number | boolean | undefined {
+  if (value === undefined || value === null) return undefined;
+  const t = typeof value;
+  if (t === 'string' || t === 'number' || t === 'boolean')
+    return value as string | number | boolean;
+  return String(value);
+}
+
+/** Build the closed attribute set for one record. Keys absent from `data` are omitted. */
+export function buildOtelLogAttributes(data: MixedObject, datastream?: string): OtelLogAttributes {
+  const attrs: OtelLogAttributes = {};
+  const put = (key: string, value: unknown) => {
+    const v = coerce(value);
+    if (v !== undefined) attrs[key] = v;
+  };
+
+  put('civitai.datastream', datastream);
+  put('civitai.type', data?.type);
+  put('civitai.name', data?.name);
+  put('civitai.pod', data?.pod);
+  put('civitai.user_id', data?.userId ?? data?.user);
+  put('civitai.request_id', data?.requestId ?? data?.request_id);
+
+  return attrs;
+}
+
+// ---------------------------------------------------------------------------
+// Logger resolution
+// ---------------------------------------------------------------------------
+const LOGS_API_GLOBAL = Symbol.for('io.opentelemetry.js.api.logs');
+
+let cachedLogger: Logger | undefined;
+
+/**
+ * Resolve the Logger LAZILY, per emit, and only once a provider is actually registered.
+ *
+ * `logs.getLogger()` called BEFORE `setGlobalLoggerProvider()` returns a ProxyLogger
+ * bound to this module copy's ProxyLoggerProvider. That proxy provider is only ever
+ * delegated on the copy that called `setGlobalLoggerProvider`, so the ProxyLogger
+ * resolves to the no-op logger FOREVER — a permanent, silent no-op with no error and no
+ * exception. A module-scope `getLogger()` is therefore not a style question; it is the
+ * bug.
+ *
+ * This is a TIMING problem, not a bundling-identity one: every installed copy of the
+ * logs API shares the same `Symbol.for` key and the same backwards-compatibility
+ * version, so a second bundled copy still reads the same global. Checking the global
+ * first makes the permanently-silent state unreachable, and makes the not-yet-registered
+ * state OBSERVABLE (counted as `no_provider`) rather than invisible.
+ */
+function resolveLogger(): Logger | undefined {
+  if (cachedLogger) return cachedLogger;
+  if (!(globalThis as Record<symbol, unknown>)[LOGS_API_GLOBAL]) return undefined;
+  cachedLogger = logs.getLogger('civitai-axiom-bridge');
+  return cachedLogger;
+}
+
+/**
+ * Drop the memoized Logger. For tests that register/unregister a provider between
+ * cases; production code has no reason to call it.
+ */
+export function resetOtelLogBridge(): void {
+  cachedLogger = undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Emit
+// ---------------------------------------------------------------------------
+/**
+ * Emit one structured record over OTLP.
+ *
+ * DARK BY DEFAULT: does nothing unless `OTEL_LOGS_ENABLED === 'true'`. Read from
+ * `process.env` on every call (a property read on a plain object) rather than captured
+ * at module load, so the value a pod boots with is the value that applies.
+ *
+ * `body` is the CALLER'S already-serialized line, passed in verbatim rather than
+ * re-serialized here. One serialization, two sinks: a query written against either path
+ * matches on the other, and the hot path pays for one `JSON.stringify`, not two.
+ *
+ * Never throws. This runs inside a logging call that hot paths await; a telemetry sink
+ * must not be able to fail the thing it is observing.
+ *
+ * @returns true if a record was handed to the Logs API.
+ */
+export function emitOtelLog(body: string, data: MixedObject, datastream?: string): boolean {
+  try {
+    if (process.env.OTEL_LOGS_ENABLED !== 'true') {
+      otelLogRecordsSkippedCounter.inc({ reason: 'disabled' });
+      return false;
+    }
+
+    const logger = resolveLogger();
+    if (!logger) {
+      otelLogRecordsSkippedCounter.inc({ reason: 'no_provider' });
+      return false;
+    }
+
+    const { severityNumber, severityText } = deriveSeverity(data?.type);
+
+    // No `timestamp`/`observedTimestamp`: the SDK stamps those at emit.
+    // No trace/span id either — the SDK reads the active context itself.
+    const record: ApiLogRecord = {
+      severityNumber,
+      body,
+      attributes: buildOtelLogAttributes(data, datastream),
+    };
+    if (severityText !== undefined) record.severityText = severityText;
+
+    logger.emit(record);
+    otelLogRecordsEmittedCounter.inc();
+    return true;
+  } catch {
+    try {
+      otelLogRecordsSkippedCounter.inc({ reason: 'emit_threw' });
+    } catch {
+      /* a counter must not be able to break logging either */
+    }
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Provider construction
+// ---------------------------------------------------------------------------
+/** Batch settings. Defaults are the SDK's own; see `createOtelLoggerProvider`. */
+export type OtelLoggerProviderOptions = {
+  resource?: Resource;
+  exporter: LogRecordExporter;
+  /**
+   * Hard ceiling on one export attempt. Coupled to the pod's termination grace period:
+   * shutdown flushes on SIGTERM, and a hung collector must not hold that flush past the
+   * grace period or the kubelet kills the process mid-export. The default is the value
+   * that is safe under the SHORTEST grace period in the fleet; raise it per-workload
+   * only where the grace period is known to be longer.
+   */
+  exportTimeoutMillis?: number;
+};
+
+export const OTEL_LOG_EXPORT_TIMEOUT_MS_DEFAULT = 5000;
+
+/**
+ * Build the LoggerProvider for the OTLP logs pipeline.
+ *
+ * Centralized here, rather than inline at the call site, so the `traceBased` hazard
+ * below has exactly one place it could ever be introduced — and so a test can pin it.
+ *
+ * 🔴 NEVER pass a `loggerConfigurator` that sets `traceBased: true`. It drops any record
+ * emitted inside a valid-but-unsampled span. Head trace sampling runs well below 1.0, so
+ * enabling it would silently discard the large majority of in-request log records — with
+ * no error, no counter, and no dropped-record signal anywhere. It is inert at the SDK's
+ * defaults; keep it that way. Pinned by the `traceBased` regression test.
+ *
+ * The batch sizes are the SDK defaults, chosen deliberately rather than by omission:
+ * measured record volume is well under one record/second/pod, so the queue holds many
+ * minutes of buffer and each export is per-request overhead rather than payload.
+ * `exportTimeoutMillis` is the one value made explicit, because it is the only one
+ * coupled to something outside this process.
+ */
+export function createOtelLoggerProvider(opts: OtelLoggerProviderOptions): LoggerProvider {
+  const processor: LogRecordProcessor = new BatchLogRecordProcessor(opts.exporter, {
+    exportTimeoutMillis: opts.exportTimeoutMillis ?? OTEL_LOG_EXPORT_TIMEOUT_MS_DEFAULT,
+  });
+
+  return new LoggerProvider({
+    ...(opts.resource ? { resource: opts.resource } : {}),
+    processors: [processor],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Shutdown
+// ---------------------------------------------------------------------------
+export type OtelShutdownTarget = { shutdown: () => Promise<unknown> };
+
+export type OtelShutdownController = {
+  /** Run the shutdown (or return the already-running one). */
+  shutdown: (reason?: string) => Promise<void>;
+  /** The in-flight/settled shutdown promise, or undefined if nothing started it yet. */
+  settled: () => Promise<void> | undefined;
+  /** Remove the signal listeners this registration installed. */
+  unregister: () => void;
+};
+
+export const OTEL_SHUTDOWN_SIGNALS: readonly NodeJS.Signals[] = ['SIGTERM', 'SIGINT'];
+
+/**
+ * Flush telemetry on termination.
+ *
+ * The shape this replaces listened on SIGTERM only and awaited NEITHER shutdown promise,
+ * so the final batch raced pod termination — immaterial while the pipeline carried one
+ * record per boot, a real loss path the moment it carries traffic.
+ *
+ * We only FLUSH here; we never `process.exit()`. The framework owns process lifecycle,
+ * and exiting would kill in-flight requests during the drain.
+ */
+export function registerOtelShutdown(
+  targets: OtelShutdownTarget[],
+  opts: {
+    signals?: readonly NodeJS.Signals[];
+    log?: (message: string) => void;
+    onError?: (reason: unknown) => void;
+  } = {}
+): OtelShutdownController {
+  const signals = opts.signals ?? OTEL_SHUTDOWN_SIGNALS;
+  const log = opts.log ?? ((m: string) => console.log(m));
+  const onError =
+    opts.onError ?? ((reason: unknown) => console.error('[otel] shutdown error:', reason));
+
+  let inflight: Promise<void> | undefined;
+
+  const run = async (reason: string): Promise<void> => {
+    log(`[otel] flushing telemetry on ${reason}`);
+    // allSettled, not all: a failing exporter must not prevent the other flush, and a
+    // rejection here must not surface as an unhandled rejection during termination.
+    const results = await Promise.allSettled(targets.map((t) => t.shutdown()));
+    for (const r of results) if (r.status === 'rejected') onError(r.reason);
+  };
+
+  // `??=` is the idempotence guard AND the await seam. A second signal (SIGINT after
+  // SIGTERM) joins the first shutdown instead of starting a second one against
+  // already-shut providers.
+  const start = (reason: string): Promise<void> => (inflight ??= run(reason));
+
+  const listeners = signals.map((signal) => {
+    const listener = () => {
+      void start(signal);
+    };
+    // `once` alone is not enough — it is per-signal, so SIGINT after SIGTERM would still
+    // start a second shutdown. The `??=` above is what actually makes it idempotent.
+    process.once(signal, listener);
+    return { signal, listener };
+  });
+
+  return {
+    shutdown: (reason = 'manual') => start(reason),
+    settled: () => inflight,
+    unregister: () => {
+      for (const { signal, listener } of listeners) process.removeListener(signal, listener);
+    },
+  };
+}

--- a/packages/civitai-telemetry/vitest.config.mts
+++ b/packages/civitai-telemetry/vitest.config.mts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+// Adopted by the root config's `packages/*/vitest.config.mts` glob. No `test.name`, so
+// the Vitest project name is this package's `package.json` name (`@civitai/telemetry`) —
+// which is what `--project '@civitai/*'` selects. See the root vitest.config.mts.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1501,9 +1501,28 @@ importers:
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.0
+      '@opentelemetry/api-logs':
+        specifier: ^0.211.0
+        version: 0.211.0
+      '@opentelemetry/resources':
+        specifier: 2.9.0
+        version: 2.9.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs':
+        specifier: ^0.211.0
+        version: 0.211.0(@opentelemetry/api@1.9.0)
       prom-client:
         specifier: ^14.2.0
         version: 14.2.0
+    devDependencies:
+      '@opentelemetry/context-async-hooks':
+        specifier: ^2.5.0
+        version: 2.5.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core':
+        specifier: 2.9.0
+        version: 2.9.0(@opentelemetry/api@1.9.0)
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/browser-playwright@4.0.18)(happy-dom@20.9.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(jiti@2.7.0)(jsdom@27.4.0(@noble/hashes@1.8.0)(bufferutil@4.0.9)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(msw@2.12.10(@types/node@24.13.3)(typescript@5.9.3))(sass@1.90.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.1)
 
   packages/civitai-ui:
     dependencies:

--- a/src/instrumentation.node.ts
+++ b/src/instrumentation.node.ts
@@ -11,7 +11,12 @@ import {
   TraceIdRatioBasedSampler,
 } from '@opentelemetry/sdk-trace-node';
 import { logs } from '@opentelemetry/api-logs';
-import { createOtelLoggerProvider, registerOtelShutdown } from '@civitai/telemetry/otel-logs';
+import {
+  createOtelLoggerProvider,
+  emitOtelLog,
+  registerOtelShutdown,
+} from '@civitai/telemetry/otel-logs';
+import { setStructuredLogSink } from '~/server/logging/client';
 import { trace } from '@opentelemetry/api';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { registerCpuProfiler, registerEventLoopStallProfiler } from '~/server/cpu-profiler';
@@ -107,6 +112,18 @@ void import('~/server/warmup')
   .catch((err) => {
     console.error('[instrumentation.node] warmup kick failed (fail-open):', err);
   });
+
+// Attach the OTel sink to the shared structured logger.
+//
+// Registered from HERE, rather than imported by `~/server/logging/client`, because that
+// module is reachable from the client entry point — importing the bridge there bundles
+// prom-client for the browser and fails the build. This file only ever runs on the
+// server, so it is the correct place for the edge. See the note in that module.
+//
+// Unconditional on purpose: `emitOtelLog` is itself gated on OTEL_LOGS_ENABLED (default
+// off), so wiring it here keeps ONE gate rather than two, and its skip counter is then a
+// live positive control that the wiring exists at all.
+setStructuredLogSink(emitOtelLog);
 
 // Only enable OTEL if explicitly set AND endpoint is configured
 const OTEL_ENABLED = process.env.OTEL_ENABLED === 'true';

--- a/src/instrumentation.node.ts
+++ b/src/instrumentation.node.ts
@@ -10,8 +10,8 @@ import {
   ParentBasedSampler,
   TraceIdRatioBasedSampler,
 } from '@opentelemetry/sdk-trace-node';
-import { LoggerProvider, BatchLogRecordProcessor } from '@opentelemetry/sdk-logs';
 import { logs } from '@opentelemetry/api-logs';
+import { createOtelLoggerProvider, registerOtelShutdown } from '@civitai/telemetry/otel-logs';
 import { trace } from '@opentelemetry/api';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { registerCpuProfiler, registerEventLoopStallProfiler } from '~/server/cpu-profiler';
@@ -167,10 +167,25 @@ if (!OTEL_ENABLED) {
       url: `${OTEL_ENDPOINT}/v1/logs`,
     });
 
-    // Set up logger provider with processors in config
-    const loggerProvider = new LoggerProvider({
+    // Set up the logger provider. Construction (batch sizing + the `traceBased` hazard
+    // it must never enable) lives in @civitai/telemetry so it has one home and a test;
+    // see createOtelLoggerProvider.
+    //
+    // OTEL_LOGS_EXPORT_TIMEOUT_MS bounds a single export attempt. It must stay under the
+    // workload's termination grace period minus the pre-stop drain, because shutdown
+    // flushes synchronously with respect to that budget — the default is sized for the
+    // SHORTEST grace period any of these workloads runs with, and should only be raised
+    // where the deployment is known to allow more.
+    const parsedExportTimeout = parseInt(process.env.OTEL_LOGS_EXPORT_TIMEOUT_MS ?? '', 10);
+    const exportTimeoutMillis =
+      Number.isFinite(parsedExportTimeout) && parsedExportTimeout > 0
+        ? parsedExportTimeout
+        : undefined;
+
+    const loggerProvider = createOtelLoggerProvider({
       resource,
-      processors: [new BatchLogRecordProcessor(logExporter)],
+      exporter: logExporter,
+      exportTimeoutMillis,
     });
     logs.setGlobalLoggerProvider(loggerProvider);
 
@@ -239,10 +254,19 @@ if (!OTEL_ENABLED) {
       attributes: { service: serviceName },
     });
 
-    // Cleanup on exit
-    process.on('SIGTERM', () => {
-      loggerProvider.shutdown();
-      sdk.shutdown();
+    // Flush telemetry on termination.
+    //
+    // The previous form listened on SIGTERM only and awaited NEITHER promise, so the
+    // final batch raced process termination — immaterial while this pipeline carried one
+    // record per boot, a real loss path the moment it carries traffic. registerOtelShutdown
+    // adds SIGINT, awaits both shutdowns, and is idempotent across a second signal.
+    //
+    // The log line below is deliberate: whether the framework installs its own SIGTERM
+    // handler that exits before ours runs is NOT answerable by any test we can write, so
+    // its presence (or absence) in a terminating process's final output is the check.
+    registerOtelShutdown([loggerProvider, sdk], {
+      log: (message) => console.log(`[instrumentation.node] ${message}`),
+      onError: (reason) => console.error('[instrumentation.node] OTEL shutdown error:', reason),
     });
   } catch (error) {
     console.error('[instrumentation.node] Failed to initialize OTEL:', error);

--- a/src/server/logging/client.ts
+++ b/src/server/logging/client.ts
@@ -5,13 +5,22 @@
 import { TRPCError } from '@trpc/server';
 import type { TRPC_ERROR_CODE_KEY } from '@trpc/server/rpc';
 import { createAxiomLogger, safeError } from '@civitai/axiom/client';
+import { emitOtelLog } from '@civitai/telemetry/otel-logs';
 import { env } from '~/env/server';
 
 // The build guard is a Next.js concern, so it lives here in the app shim — not in
 // the app-agnostic @civitai/axiom package. Skip the client during `next build`.
 const noopLog = async (_data: MixedObject, _datastream?: string) => {};
 
-export const logToAxiom = env.IS_BUILD ? noopLog : createAxiomLogger().logToAxiom;
+// The OTel sink is wired here, in the app shim, because the emitter is an app concern
+// (it depends on the app's OpenTelemetry setup) while @civitai/axiom stays transport-
+// agnostic. It is ADDITIVE and DARK BY DEFAULT: `emitOtelLog` no-ops unless
+// OTEL_LOGS_ENABLED === 'true', and it can neither change nor break the stderr write or
+// the Axiom dual-write. Subpath import (not the package barrel) keeps the server-only
+// OTel logs SDK out of any graph that imports @civitai/telemetry for its other helpers.
+export const logToAxiom = env.IS_BUILD
+  ? noopLog
+  : createAxiomLogger({}, { emitLog: emitOtelLog }).logToAxiom;
 export { safeError };
 
 /**

--- a/src/server/logging/client.ts
+++ b/src/server/logging/client.ts
@@ -5,22 +5,39 @@
 import { TRPCError } from '@trpc/server';
 import type { TRPC_ERROR_CODE_KEY } from '@trpc/server/rpc';
 import { createAxiomLogger, safeError } from '@civitai/axiom/client';
-import { emitOtelLog } from '@civitai/telemetry/otel-logs';
+import type { AxiomDeps, EmitLog } from '@civitai/axiom/client';
 import { env } from '~/env/server';
 
 // The build guard is a Next.js concern, so it lives here in the app shim — not in
 // the app-agnostic @civitai/axiom package. Skip the client during `next build`.
 const noopLog = async (_data: MixedObject, _datastream?: string) => {};
 
-// The OTel sink is wired here, in the app shim, because the emitter is an app concern
-// (it depends on the app's OpenTelemetry setup) while @civitai/axiom stays transport-
-// agnostic. It is ADDITIVE and DARK BY DEFAULT: `emitOtelLog` no-ops unless
-// OTEL_LOGS_ENABLED === 'true', and it can neither change nor break the stderr write or
-// the Axiom dual-write. Subpath import (not the package barrel) keeps the server-only
-// OTel logs SDK out of any graph that imports @civitai/telemetry for its other helpers.
-export const logToAxiom = env.IS_BUILD
-  ? noopLog
-  : createAxiomLogger({}, { emitLog: emitOtelLog }).logToAxiom;
+// 🔴 THIS MODULE IS IN THE **CLIENT** BUNDLE. It looks server-only and is not:
+// `src/pages/_app.tsx` → `~/server/services/system-cache` → `~/server/redis/fail-open-log`
+// reaches it, so anything imported here at module scope is bundled for the browser too.
+// A static `import { emitOtelLog } from '@civitai/telemetry/otel-logs'` here pulled
+// prom-client into the browser graph and broke `next build` with
+// `Can't resolve 'cluster' / 'fs' / 'v8'`. Nothing else catches that — typecheck, eslint
+// and both vitest projects all stayed green, because only the bundler walks this edge.
+//
+// So the OTel sink is REGISTERED, not imported: `src/instrumentation.node.ts` (server-only
+// by construction) calls `setStructuredLogSink(emitOtelLog)` at boot. The type import
+// above is erased at compile time and adds no runtime edge.
+//
+// The sink is read per call from this stable object, so registering it after the logger
+// is built still takes effect. Pinned by a test in @civitai/axiom.
+const sink: AxiomDeps = {};
+
+/**
+ * Attach an additional sink for every structured log record. Server-only callers.
+ * Additive: it cannot change or break the stderr write or the Axiom dual-write, and a
+ * sink that throws is contained by the logger.
+ */
+export function setStructuredLogSink(emitLog: EmitLog): void {
+  sink.emitLog = emitLog;
+}
+
+export const logToAxiom = env.IS_BUILD ? noopLog : createAxiomLogger({}, sink).logToAxiom;
 export { safeError };
 
 /**


### PR DESCRIPTION
## What

Adds a third sink to the single `logToAxiom` chokepoint: each structured record is also emitted over the OpenTelemetry Logs API. **The Axiom path and the stderr line are untouched** — this is additive, not a migration.

**Ships dark.** `emitOtelLog` no-ops unless `OTEL_LOGS_ENABLED === 'true'`, which nothing sets. Merging this changes nothing observable; turning it on is a per-workload config change, not a code deploy.

## Why this shape

**The bridge lives in `@civitai/telemetry` and is injected into `createAxiomLogger(overrides, deps)`**, rather than being imported by `@civitai/axiom`. That package's own `env.ts` header already prescribed it ("App behavior … would be injected at the factory instead"), and it means `@civitai/axiom` gains no OpenTelemetry dependency and — more importantly — no OpenTelemetry *semantics*. Had the record been built inside it, that package would be hardcoding severity numbers it has no business knowing.

**One serialization, N sinks.** The line is built once; the OTLP body *is* that exact string. A query written against either path matches on the other, and the hot path pays for one `JSON.stringify`, not two. This required refactoring the three-branch stringify catch ladder from three `console.error` calls into assign-once/write-once — a behaviour-preserving change on a path with no previous coverage, so each branch is now pinned by a test.

**Severity is a table, not a heuristic.** `type` is a hybrid field: mostly a severity word, sometimes an event name (`job-error`, `buzz`, `job-summary`), sometimes absent. Only the four unambiguous cases map. Everything else is `UNSPECIFIED(0)` with `severityText` **omitted** — downstream level resolution prefers the text over the number, so an invented placeholder would outrank a correct number. Guessing `ERROR` would mislabel `job-summary`; guessing `INFO` would hide `job-error`; a `-error`/`-failed` suffix heuristic is wrong for cases nobody can enumerate. The raw value always travels verbatim as `civitai.type`, so no information is lost.

It's a `Map`, not an object literal, because an object lookup with a caller-supplied key **fails open**: `SEVERITY['toString']` is a truthy function, so `type: 'toString'` would resolve to garbage instead of falling through to the default. Pinned by a test.

**Attributes are a closed set.** Spreading the payload would reproduce exactly the schema explosion `safeError`'s doc comment exists to prevent, and mint unbounded metadata keys downstream. The full payload is already carried, intact, in the body.

**The logger binds lazily, per emit.** `logs.getLogger()` called before a provider is registered returns a proxy that is never delegated and stays silent **forever** — no error, no exception, no record. A module-scope `getLogger()` is not a style question, it's the bug. This is a *timing* problem rather than a module-identity one: every installed copy of the logs API shares the same `Symbol.for` key and compat version, so a second bundled copy still reads the same global.

**Counters make a zero legible.** "No records arrived" cannot distinguish a disabled flag from an unregistered provider from a throwing emit — three mechanisms, one observable. `..._emitted_total` and `..._skipped_total{reason=disabled|no_provider|emit_threw}` separate them.

## SDK correctness fixes

- **Shutdown was SIGTERM-only and awaited neither promise**, so the final batch raced termination. Immaterial while the pipeline carried one record per boot; a real loss path the moment it carries traffic. Now SIGTERM + SIGINT, awaited, idempotent across a second signal, and `allSettled` so one failing exporter can't block the other flush.
- **`exportTimeoutMillis` made explicit** (env-tunable via `OTEL_LOGS_EXPORT_TIMEOUT_MS`) because it's the one batch value coupled to something outside the process: a hung exporter must not hold the shutdown flush past the workload's termination grace period. The default is sized for the *shortest* grace period these workloads run with. The other batch values are the SDK defaults, chosen deliberately — measured volume is well under one record/second/pod.
- **Provider construction moved into the package** so the `traceBased` hazard has exactly one home and a regression test. `traceBased: true` would drop every record emitted inside an unsampled span; with head sampling below 1.0 that is most in-request records, silently, with no counter anywhere. Inert at SDK defaults and must stay that way.
- **`serverExternalPackages`** gains `@opentelemetry/api`, `api-logs`, `sdk-logs`, `exporter-logs-otlp-proto` so the Logs API's `globalThis` provider registry is written and read by one module instance. `@opentelemetry/resources` and `semantic-conventions` are deliberately **not** added — the web tracing SDK reaches them from the client graph.

## Tests

41 tests across the two package suites (`@civitai/telemetry` is a new Vitest project; the CI ledger picks it up automatically and will now *require* it to run).

They use the **real** SDK — `LoggerProvider`, `SimpleLogRecordProcessor`, `InMemoryLogRecordExporter` are all real exports. No `vi.mock('@opentelemetry/api-logs')`: a wholesale factory mock would make every assertion vacuous, and the repo's `no-wholesale-module-mock` guard only watches `~/utils/trpc`, so nothing would have caught it.

**Every guard was watched to fail for its own reason** — 14 mutations, each killed by the specifically-named test that owns it:

| Mutation | Killed by |
|---|---|
| one severity row `warning → ERROR` | exact-pair test, on `severityNumber` |
| unmapped default `0 → INFO` | the event-name / absent-type tests |
| `Map` → object literal | prototype-key fail-open test |
| drop the global-registry check | "1 with a provider, 0 without" |
| drop the `OTEL_LOGS_ENABLED` gate | dark-launch test |
| attributes → payload spread | closed-key-set test, by name |
| drop emit containment | containment test |
| drop the idempotence guard | SIGINT-after-SIGTERM test |
| un-await shutdown (and: drop *only* the `await`) | SIGTERM-flush test, on record count |
| enable `traceBased` | unsampled-span regression guard |
| sink re-serializes its own body | body-identity test |
| drop axiom-side sink containment | caller-unaffected test |
| remove the stderr write | 9 pre-existing tests |

Two findings from that exercise, both fixed:

1. The SIGTERM-flush test originally **passed with the bug**. A synchronous exporter stub can't tell an awaited shutdown from an un-awaited one — both read 1. The exporter now completes on a later tick, like the real one, and the un-awaited mutant reads 0.
2. `InMemoryLogRecordExporter.shutdown()` **resets its own store**, so reading it after the shutdown under test returned an empty array whether or not the flush worked — a false 0 that looks exactly like the bug. The shutdown tests use an exporter that keeps what it was given.

**What these tests cannot see:** the bundling failure. Vitest aliases the package to its source and never runs the bundler, so no unit test can observe a second module copy. The runtime check is `..._skipped_total{reason="no_provider"}` being non-zero in a real process; a build-time module-identity scan over the built output is the follow-up. This is stated rather than papered over.

## Risk

Revert is a no-op for both existing sinks — the stderr write and `ingestEvents` are untouched by this change, so a revert cannot lose data. That is the whole point of keeping both.

## Not in this PR

- Turning the flag on. Enablement is a deployment-config change owned by the infra repo; ask an infra owner for the rollout details.
- The `serverExternalPackages` additions for the logs packages. They were in the first commit of this PR and **failed the image build**, so they are reverted here and need their own change with a full build as the gate. The bridge does not depend on them (it binds lazily; a second module copy is survivable).
- The `@opentelemetry/*` 0.211 → 0.221 upgrade (the batch processor's constructor changes to an options object at 0.220; verified positional today).
- The ~44 call sites where `type:` carries an event name rather than a severity. That's a pre-existing schema defect — one field meaning two things — and the deterministic fix is to add an explicit `type` alongside the existing `name`, as its own mechanical PR.



---

## Two things the local gates could not see (found by the preview build)

Both were green on `pnpm typecheck`, `pnpm lint`, both vitest projects, and the convention guards — and both broke the image build. Recording them because the *class* is the interesting part: they live in the bundler's module graph, which no local gate here walks.

**1. `src/server/logging/client.ts` is in the CLIENT bundle.** It reads as server-only and is not:

```
src/pages/_app.tsx → ~/server/services/system-cache → ~/server/redis/fail-open-log
  → src/server/logging/client.ts
```

So a module-scope `import { emitOtelLog } from '@civitai/telemetry/otel-logs'` there pulled `prom-client` into the browser graph, and the build failed with `Can't resolve 'cluster' / 'fs' / 'v8'`.

The fix is to **register** the sink instead of importing it: `src/instrumentation.node.ts` (server-only by construction) calls `setStructuredLogSink(emitOtelLog)` at boot, and the shim keeps only a type import, which is erased. That is also the better home for it — the OTel wiring now sits with the rest of the OTel setup.

This works because `deps.emitLog` is read per call rather than captured at construction. That was incidental before and is now load-bearing, so there's a test for it: registering a sink *after* the logger is built must still fire. Mutating the factory to capture at construction fails that test and only that test.

**2. The `serverExternalPackages` additions.** Reverted here (see "Not in this PR"). Worth being precise about the sequence: I first assumed those entries caused the build failure and reverted them alone — **the build failed again identically**, which is what pointed at the real cause above. They may well be fine; they simply have not been shown to be, so they belong in their own change with a full build as the gate.

The general lesson for this repo: for anything touching a widely-imported module under `~/server/`, the preview build is the only gate that walks the client graph. It caught both of these.
