### PR TITLE
fix(app-listings): name the pixel cap when an inline icon is over it

### DIFF
--- a/src/server/services/blocks/__tests__/listing-meta.datauri-raster.integration.test.ts
+++ b/src/server/services/blocks/__tests__/listing-meta.datauri-raster.integration.test.ts
@@ -9,7 +9,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  *   (a) raw SVG is NEVER stored/served — the bytes that reach the store are always PNG;
  *   (b) an external SVG resource ref (`file://` / `http://`) is NOT fetched/embedded;
  *   (c) an over-`limitInputPixels` SVG (huge viewBox) is REJECTED cleanly (BAD_REQUEST,
- *       nothing stored) via the EXPLICIT input-pixel cap — not a 500, not an OOM.
+ *       nothing stored) via the EXPLICIT input-pixel cap — not a 500, not an OOM;
+ *   (d) a REAL over-cap raster (5000×5000, ~80KB — under every byte gate) is rejected
+ *       with a message naming the PIXEL bound, not the generic decode failure
+ *       (civitai/cli#270);
+ *   (e) genuinely unreadable bytes still get the decode-failure message;
+ *   (f) a large-but-under-cap icon still ingests, downscaled.
  *
  * Only the downstream store + DB are mocked; sharp/librsvg run for real. Fast + hermetic
  * (no network, tiny inline SVGs).
@@ -20,7 +25,10 @@ vi.mock('~/server/services/image.service', () => ({ createImage: vi.fn() }));
 
 import { uploadImageBufferToStore } from '~/utils/s3-utils';
 import { createImage } from '~/server/services/image.service';
-import { ingestListingAssetFromDataUri } from '~/server/services/blocks/listing-meta.service';
+import {
+  INLINE_ICON_MAX_DECODED_BYTES,
+  ingestListingAssetFromDataUri,
+} from '~/server/services/blocks/listing-meta.service';
 
 const upload = vi.mocked(uploadImageBufferToStore);
 const create = vi.mocked(createImage);
@@ -28,6 +36,17 @@ const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 
 function svgDataUri(inner: string): string {
   return 'data:image/svg+xml,' + encodeURIComponent(inner);
+}
+
+function pngDataUri(png: Buffer): string {
+  return 'data:image/png;base64,' + png.toString('base64');
+}
+
+async function bigFlatPng(width: number, height: number): Promise<Buffer> {
+  const { default: sharp } = await import('sharp');
+  return sharp({ create: { width, height, channels: 3, background: '#3355aa' } })
+    .png({ compressionLevel: 9 })
+    .toBuffer();
 }
 
 beforeEach(() => {
@@ -89,8 +108,63 @@ describe('ingestListingAssetFromDataUri — REAL sharp rasterization (integratio
     );
     await expect(
       ingestListingAssetFromDataUri({ input: { dataUri: svg, kind: 'icon' }, userId: 1 })
-    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('over the 16,777,216 pixel limit'),
+    });
     expect(upload).not.toHaveBeenCalled();
     expect(create).not.toHaveBeenCalled();
+  });
+
+  it('(d) REJECTS a REAL over-cap raster PNG naming the PIXEL bound, not "couldn\'t be read"', async () => {
+    // 5000×5000 flat colour compresses to ~80KB, so it clears BOTH byte gates
+    // (INLINE_ICON_MAX_DECODED_BYTES = 2MiB and the schema's data-URI length cap).
+    // The pixel cap is the ONLY bound it trips — the case that used to surface as a
+    // decode failure (civitai/cli#270).
+    const png = await bigFlatPng(5000, 5000);
+    expect(png.byteLength).toBeLessThan(INLINE_ICON_MAX_DECODED_BYTES);
+
+    await expect(
+      ingestListingAssetFromDataUri({
+        input: { dataUri: pngDataUri(png), kind: 'icon' },
+        userId: 1,
+      })
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message:
+        'That icon is 5000×5000 (25,000,000 pixels), over the 16,777,216 pixel limit. Resize it to 1024×1024 or smaller and upload it manually.',
+    });
+    expect(upload).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('(e) NEGATIVE CONTROL — genuinely unreadable bytes still get the decode-failure message', async () => {
+    await expect(
+      ingestListingAssetFromDataUri({
+        input: {
+          dataUri: 'data:image/png;base64,' + Buffer.from('@not-a-png').toString('base64'),
+          kind: 'icon',
+        },
+        userId: 1,
+      })
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: "That icon couldn't be read. Try uploading it manually.",
+    });
+    expect(upload).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('(f) POSITIVE CONTROL — a large-but-under-cap icon still ingests, downscaled to 1024', async () => {
+    // 4000×4000 = 16,000,000px, just UNDER the 16,777,216 cap. Pairs with (d) at
+    // 25,000,000px so the bound is measured on both sides, not just the failing one.
+    const png = await bigFlatPng(4000, 4000);
+    const res = await ingestListingAssetFromDataUri({
+      input: { dataUri: pngDataUri(png), kind: 'icon' },
+      userId: 1,
+    });
+    expect(res).toEqual({ imageId: 42 });
+    expect(upload).toHaveBeenCalledTimes(1);
+    expect(create).toHaveBeenCalledWith(expect.objectContaining({ width: 1024, height: 1024 }));
   });
 });

--- a/src/server/services/blocks/__tests__/listing-meta.service.test.ts
+++ b/src/server/services/blocks/__tests__/listing-meta.service.test.ts
@@ -333,4 +333,19 @@ describe('ingestListingAssetFromDataUri', () => {
     expect(mockUploadImageBufferToStore).not.toHaveBeenCalled();
     expect(mockCreateImage).not.toHaveBeenCalled();
   });
+
+  it('keeps the EXPLICIT input-pixel cap on the rasterize (the enforcement backstop)', async () => {
+    // The dimension pre-check that produces the over-cap MESSAGE reads the header
+    // with the cap lifted, so it cannot cover this: the rasterize must still carry
+    // the cap for any input whose header the pre-check could not measure.
+    primeRaster();
+    await ingestListingAssetFromDataUri({
+      input: { dataUri: 'data:image/png;base64,QG5vdC1hLXBuZw==', kind: 'icon' },
+      userId: 7,
+    });
+    expect(mockSharp).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      expect.objectContaining({ density: 96, limitInputPixels: 16 * 1024 * 1024 })
+    );
+  });
 });

--- a/src/server/services/blocks/listing-meta.service.ts
+++ b/src/server/services/blocks/listing-meta.service.ts
@@ -304,11 +304,33 @@ export async function ingestListingAssetFromDataUri(opts: {
     });
   }
 
+  const { default: sharp } = await import('sharp');
+
+  // Header-only dimension read (no pixel data decoded) so an over-cap input is
+  // reported as the pixel-count rejection it is, rather than as the catch-all decode
+  // failure below (civitai/cli#270). The cap must be LIFTED here — that is the only
+  // way to learn the dimensions of an input that exceeds it; the rasterize below
+  // keeps the cap and stays the enforcement point.
+  let source: { width: number; height: number } | undefined;
+  try {
+    const meta = await sharp(parsed.bytes, { density: 96, limitInputPixels: false }).metadata();
+    if (meta.width && meta.height) source = { width: meta.width, height: meta.height };
+  } catch {
+    // Unreadable header — let the rasterize below produce the decode-failure message.
+  }
+  if (source && source.width * source.height > INLINE_ICON_MAX_INPUT_PIXELS) {
+    const pixels = (source.width * source.height).toLocaleString('en-US');
+    const limit = INLINE_ICON_MAX_INPUT_PIXELS.toLocaleString('en-US');
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `That icon is ${source.width}×${source.height} (${pixels} pixels), over the ${limit} pixel limit. Resize it to ${INLINE_ICON_RASTER_MAX_PX}×${INLINE_ICON_RASTER_MAX_PX} or smaller and upload it manually.`,
+    });
+  }
+
   // Rasterize to PNG. This is the load-bearing security step: whatever the source
   // (SVG markup or a raster image), the bytes we STORE are always PNG — raw SVG is
   // never persisted or served. sharp reads an SVG via librsvg; `resize(...inside)`
   // bounds the output canvas so a huge intrinsic viewBox can't bomb the pipeline.
-  const { default: sharp } = await import('sharp');
   let png: Buffer;
   let width: number | undefined;
   let height: number | undefined;


### PR DESCRIPTION
Refs civitai/cli#270.

## The bug

`ingestListingAssetFromDataUri` (`src/server/services/blocks/listing-meta.service.ts`) passes
`limitInputPixels: INLINE_ICON_MAX_INPUT_PIXELS` (16,777,216 px) to sharp. The whole rasterize
pipeline sits in one `try`, and the `catch` maps **every** failure — including a `limitInputPixels`
rejection — to:

> That icon couldn't be read. Try uploading it manually.

The file is perfectly readable. It just has too many pixels, and the author is told something that
is both false and unactionable.

**It is reachable.** A 5000×5000 flat-colour PNG compresses to **~80 KB**, so it clears both byte
gates — `INLINE_ICON_MAX_DECODED_BYTES` (2 MiB) and the schema's data-URI length cap — and the pixel
cap is the only bound it trips. Measured with real sharp (0.32.6 / libvips 8.14.5): 81,988 bytes for
25,000,000 px.

## The fix

Read the source dimensions from the header **before** rasterizing, and reject an over-cap input with
a message that states the measured size, the real bound, and the size to resize to:

> That icon is 5000×5000 (25,000,000 pixels), over the 16,777,216 pixel limit. Resize it to 1024×1024
> or smaller and upload it manually.

Why a pre-check rather than inspecting the error in the `catch`: sharp's rejection is a plain
`Error` whose only distinguishing feature is its message text, and this file's own comment already
warns that a sharp/libvips/librsvg bump can change that behaviour. Matching on a library's error
string is exactly the dependency the comment is arguing against. Measuring the dimensions is
deterministic, and it lets the message quote the value — matching how the other listing-asset
validators report (`icon must be square-ish (aspect 2.00 outside 0.9–1.1)`).

`limitInputPixels: false` on that read is deliberate and scoped:

- it reads the **header only** — no pixel data is decoded. Measured: **0.4 ms / no RSS growth** for a
  25 MP PNG, **1.1 ms / +3 MiB** for a 3.6-gigapixel SVG viewBox;
- lifting it is the only way to learn the dimensions of an input that exceeds the cap (`metadata()`
  enforces `limitInputPixels` too, so it throws instead of reporting them);
- the 2 MiB decoded-byte cap still gates what reaches it.

**Nothing about the security properties moves.** The bound is unchanged, the rasterize keeps
`limitInputPixels: INLINE_ICON_MAX_INPUT_PIXELS` and remains the enforcement point, raw SVG is still
never stored or served, and the standard scan pipeline is untouched.

## Tests

**Red at `origin/main`, green at HEAD** — same tests both sides, only the service source differed:

| | Test Files | Tests |
|---|---|---|
| source at `origin/main` | 1 failed / 1 passed | **2 failed / 20 passed (22)** |
| source at HEAD | 2 passed | **22 passed (22)** |

The two reds were `(c)` and `(d)` — both failing with the actual `"That icon couldn't be read"`
message, which is the bug reproduced.

Added to `listing-meta.datauri-raster.integration.test.ts` (**real sharp**, not a mock):

- **(d)** a genuinely generated 5000×5000 PNG, asserted under `INLINE_ICON_MAX_DECODED_BYTES`, must
  produce the new message verbatim;
- **(c)** extended — the huge-viewBox SVG now asserts the pixel message, not just `BAD_REQUEST`;
- **(e) negative control** — genuinely unreadable bytes still get
  `"That icon couldn't be read. Try uploading it manually."` Without this, routing *everything* to
  the new message would look green;
- **(f) positive control** — 4000×4000 (16,000,000 px, just under the cap) still ingests and is
  downscaled to 1024. So the bound is measured on both sides, not only the failing one.

Added to `listing-meta.service.test.ts`: a guard that the rasterize still carries the explicit cap.
The pre-check reads the header with the cap lifted, so it cannot cover the backstop — and without
this guard, deleting the backstop would have been silent.

Mutation-checked, each mutant killed by the intended test and no other:

| mutant | killed by |
|---|---|
| drop the pre-check (i.e. revert to `main`) | (c), (d) — via the generic message |
| drop `limitInputPixels` from the rasterize | the backstop guard, and only that |
| make the pre-check always trip | (a), (f) + the mocked happy path — proves it does not over-reject |

Full unit suite green: **869 files / 13,145 passed / 1 skipped**. Typecheck 0 errors. Note
`tsconfig.json` excludes `src/**/__tests__/**`, so the two test files were typechecked explicitly
under a config that includes them (0 errors in them; verified against a positive control that the
invocation can see an injected error). ESLint and Prettier clean on all three files.

## Not addressed here

The issue thread also notes that `persistListingAssetImageSchema` takes `width`/`height`/`sizeBytes`
from the client without verifying them against the uploaded bytes. That is a separate change on a
different code path and is out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
