### PR TITLE
fix(app-listings): measure uploaded listing media instead of trusting the client

### DIFF
--- a/src/server/schema/blocks/app-listing.schema.ts
+++ b/src/server/schema/blocks/app-listing.schema.ts
@@ -24,6 +24,17 @@ export const MAX_LISTING_ICON_SIZE_BYTES = 1 * 1024 * 1024; // 1 MiB
 export const MAX_LISTING_COVER_SIZE_BYTES = 4 * 1024 * 1024; // 4 MiB
 
 /**
+ * The loosest per-kind byte cap. Bytes above this satisfy NO asset kind, so an
+ * upload-time path that does not yet know the kind can reject there — and bound
+ * how much it reads back out of the store to measure an upload.
+ */
+export const MAX_LISTING_ASSET_SIZE_BYTES = Math.max(
+  MAX_LISTING_ICON_SIZE_BYTES,
+  MAX_LISTING_COVER_SIZE_BYTES,
+  MAX_LISTING_SCREENSHOT_SIZE_BYTES
+);
+
+/**
  * Aspect (= width / height) + minimum-dimension caps per asset kind:
  *   - icon    — square-ish (a store avatar). Rejects wildly non-square images.
  *   - cover   — landscape hero (roughly 4:3 → 21:9).
@@ -53,6 +64,21 @@ export const LISTING_ASSET_MAX_DIMENSION_PX = 8192;
 
 /** Only real raster image MIME types (mirrors E5 SCREENSHOT_EXTENSIONS). */
 export const LISTING_ASSET_ALLOWED_MIME = ['image/png', 'image/jpeg', 'image/webp'] as const;
+
+/**
+ * A decoded container format (sharp's `metadata().format`) → the listing MIME it
+ * is stored as, for ingest paths that read the MIME off the DECODED BYTES instead
+ * of a client-declared content type. Doubles as the format allowlist for those
+ * paths: a format absent here is rejected at ingest.
+ */
+export const LISTING_ASSET_FORMAT_TO_MIME: Record<
+  string,
+  (typeof LISTING_ASSET_ALLOWED_MIME)[number]
+> = {
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  webp: 'image/webp',
+};
 
 /** Max caption length (a one-line gallery caption, not markdown). */
 export const LISTING_SCREENSHOT_CAPTION_MAX = 280;

--- a/src/server/schema/blocks/app-listing.schema.ts
+++ b/src/server/schema/blocks/app-listing.schema.ts
@@ -71,9 +71,8 @@ export const LISTING_ASSET_ALLOWED_MIME = ['image/png', 'image/jpeg', 'image/web
  * of a client-declared content type. Doubles as the format allowlist for those
  * paths: a format absent here is rejected at ingest.
  */
-export const LISTING_ASSET_FORMAT_TO_MIME: Record<
-  string,
-  (typeof LISTING_ASSET_ALLOWED_MIME)[number]
+export const LISTING_ASSET_FORMAT_TO_MIME: Partial<
+  Record<string, (typeof LISTING_ASSET_ALLOWED_MIME)[number]>
 > = {
   jpeg: 'image/jpeg',
   png: 'image/png',

--- a/src/server/schema/blocks/offsite-listing.schema.ts
+++ b/src/server/schema/blocks/offsite-listing.schema.ts
@@ -308,22 +308,28 @@ export const listOffsiteRequestsSchema = listMySubmissionsSchema;
 export type ListOffsiteRequestsInput = z.infer<typeof listOffsiteRequestsSchema>;
 
 /**
- * AUTHOR: persist a Cloudflare-uploaded image into an `Image` row and return its
- * numeric id, so the submit form's asset step can then attach it to the draft
- * listing via the P1 asset-CRUD procs (`setIcon`/`setCover`/`addScreenshot`,
- * which take a numeric `imageId`). The `url` is the CF upload key (a uuid); the
- * width/height/mime/size come from the client media-preprocess pass and are
- * re-validated for the target asset kind by the P1 attach proc — this proc only
- * MATERIALISES the row (and kicks off ingestion/scan). No listing binding here;
- * ownership is bound to the caller (`userId` from ctx), and the attach proc's
- * owner check gates which listing it can be attached to.
+ * AUTHOR: persist an uploaded image into an `Image` row and return its numeric
+ * id, so the submit form's asset step can then attach it to the draft listing via
+ * the P1 asset-CRUD procs (`setIcon`/`setCover`/`addScreenshot`, which take a
+ * numeric `imageId`). The `url` is the upload key (a uuid) minted by
+ * `/api/v1/image-upload`. This proc only MATERIALISES the row (and kicks off
+ * ingestion/scan); the per-kind rules are applied by the P1 attach proc. No
+ * listing binding here; ownership is bound to the caller (`userId` from ctx), and
+ * the attach proc's owner check gates which listing it can be attached to.
+ *
+ * 🔴 `width` / `height` / `mimeType` / `sizeBytes` are NOT persisted. The server
+ * reads the uploaded object back and derives all four from the bytes, because the
+ * attach proc's geometry/size/MIME bounds are expressed over exactly those columns
+ * — trusting the uploader for them would make every one of those bounds
+ * self-reported. They stay in the contract as optional so released clients that
+ * still send them keep working.
  */
 export const persistListingAssetImageSchema = z.object({
-  // The CF upload key returned by `useCFImageUpload` — imageSchema requires a uuid.
+  // The upload key returned by `/api/v1/image-upload` — imageSchema requires a uuid.
   url: z.string().uuid(),
   name: z.string().max(255).nullish(),
-  width: z.number().int().positive(),
-  height: z.number().int().positive(),
+  width: z.number().int().positive().optional(),
+  height: z.number().int().positive().optional(),
   mimeType: z.string().max(120).optional(),
   sizeBytes: z.number().int().nonnegative().optional(),
 });

--- a/src/server/schema/blocks/offsite-listing.schema.ts
+++ b/src/server/schema/blocks/offsite-listing.schema.ts
@@ -318,11 +318,13 @@ export type ListOffsiteRequestsInput = z.infer<typeof listOffsiteRequestsSchema>
  * the attach proc's owner check gates which listing it can be attached to.
  *
  * 🔴 `width` / `height` / `mimeType` / `sizeBytes` are NOT persisted. The server
- * reads the uploaded object back and derives all four from the bytes, because the
- * attach proc's geometry/size/MIME bounds are expressed over exactly those columns
- * — trusting the uploader for them would make every one of those bounds
- * self-reported. They stay in the contract as optional so released clients that
- * still send them keep working.
+ * reads the uploaded object back and measures all four, because the attach proc's
+ * geometry/size/MIME bounds are expressed over exactly those columns — trusting
+ * the uploader for them would make every one of those bounds self-reported. The
+ * guarantee is "measured from real bytes at persist time", NOT "still true of the
+ * object": the presigned PUT stays usable for its full expiry, so the key can be
+ * overwritten afterwards. These fields stay in the contract as optional so
+ * released clients that still send them keep working.
  */
 export const persistListingAssetImageSchema = z.object({
   // The upload key returned by `/api/v1/image-upload` — imageSchema requires a uuid.

--- a/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TRPCError } from '@trpc/server';
+import sharp from 'sharp';
 
+import {
+  LISTING_ASSET_MAX_DIMENSION_PX,
+  MAX_LISTING_ASSET_SIZE_BYTES,
+  validateListingImage,
+} from '~/server/schema/blocks/app-listing.schema';
 import {
   MAX_PENDING_OFFSITE_SUBMISSIONS,
   OffsiteRequestError,
@@ -14,6 +20,7 @@ import type {
   PersistListingAssetImageInput,
   SubmitExternalListingInput,
 } from '~/server/schema/blocks/offsite-listing.schema';
+import type * as S3Utils from '~/utils/s3-utils';
 
 /**
  * App Store Listings (W13 P3a) — off-site submission SERVICE tests (design B1).
@@ -114,6 +121,11 @@ const { mockRead, mockWrite, ids } = vi.hoisted(() => {
 
 const { mockNotify } = vi.hoisted(() => ({ mockNotify: vi.fn(async () => undefined) }));
 
+// `persistListingAssetImage` measures the uploaded bytes by reading the object
+// back out of the image store. Only the backend accessor is replaced — the probe
+// itself, and the sharp decode inside it, run for real against real bytes.
+const { mockS3Send } = vi.hoisted(() => ({ mockS3Send: vi.fn() }));
+
 vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockWrite }));
 vi.mock('~/server/services/image.service', () => ({ createImage: mockCreateImage }));
 vi.mock('~/server/utils/app-block-ids', () => ({
@@ -124,6 +136,48 @@ vi.mock('~/server/utils/app-block-ids', () => ({
 // approve/reject emit an owner notification post-commit; assert it without pulling
 // the notifications client graph.
 vi.mock('~/server/services/blocks/app-listing-notify', () => ({ notifyAppListingOwner: mockNotify }));
+vi.mock('~/utils/s3-utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof S3Utils>()),
+  getImageUploadBackend: async () => ({
+    s3: { send: mockS3Send },
+    bucket: 'test-image-bucket',
+    backend: 'backblaze' as const,
+  }),
+}));
+
+const fixtureCache = new Map<string, Buffer>();
+async function cachedFixture(key: string, make: () => Promise<Buffer>) {
+  const hit = fixtureCache.get(key);
+  if (hit) return hit;
+  const made = await make();
+  fixtureCache.set(key, made);
+  return made;
+}
+
+/** Real, decodable image bytes — the whole point is that nothing here is declared. */
+function flatPng(width: number, height: number) {
+  return cachedFixture(`png:${width}x${height}`, () =>
+    sharp({ create: { width, height, channels: 3, background: { r: 8, g: 8, b: 8 } } })
+      .png()
+      .toBuffer()
+  );
+}
+function flatGif(width: number, height: number) {
+  return cachedFixture(`gif:${width}x${height}`, () =>
+    sharp({ create: { width, height, channels: 3, background: { r: 8, g: 8, b: 8 } } })
+      .gif()
+      .toBuffer()
+  );
+}
+
+/** Put `bytes` at the key the probe will read, answering its ranged GET. */
+function storeObject(bytes: Buffer, opts: { totalSize?: number } = {}) {
+  const totalSize = opts.totalSize ?? bytes.byteLength;
+  mockS3Send.mockResolvedValue({
+    Body: { transformToByteArray: async () => new Uint8Array(bytes) },
+    ContentRange: `bytes 0-${bytes.byteLength - 1}/${totalSize}`,
+  });
+}
 
 const CALLER = 42;
 const OTHER = 99;
@@ -184,6 +238,7 @@ beforeEach(() => {
     .mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) => cb(mockWrite));
   mockCreateImage.mockReset().mockResolvedValue({ id: 12345 });
   mockNotify.mockReset().mockResolvedValue(undefined);
+  mockS3Send.mockReset();
 });
 
 // ---------------------------------------------------------------------------
@@ -1287,6 +1342,8 @@ describe('persistListingAssetImage (scan invariant)', () => {
     sizeBytes: 4096,
   };
 
+  beforeEach(async () => storeObject(await flatPng(512, 512)));
+
   it('creates the image OWNED BY THE CALLER and WITHOUT skipIngestion (Pending → ingestImage)', async () => {
     const res = await persistListingAssetImage({ input: persistInput, userId: CALLER });
     expect(res).toEqual({ imageId: 12345 });
@@ -1300,7 +1357,7 @@ describe('persistListingAssetImage (scan invariant)', () => {
     expect('skipIngestion' in arg && arg.skipIngestion === true).toBe(false);
     // Sanity: the persisted row carries the byte size the P1 validator reads.
     expect(arg).toMatchObject({ url: persistInput.url, type: 'image', userId: CALLER });
-    expect(arg.metadata).toEqual({ size: 4096 });
+    expect(arg.metadata).toEqual({ size: (await flatPng(512, 512)).byteLength });
   });
 
   it('binds the owner to the caller even for a different user id', async () => {
@@ -1308,5 +1365,164 @@ describe('persistListingAssetImage (scan invariant)', () => {
     const arg = mockCreateImage.mock.calls[0][0] as Record<string, unknown>;
     expect(arg.userId).toBe(OTHER);
     expect(arg.skipIngestion).toBeFalsy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// persistListingAssetImage — DECLARED-vs-ACTUAL geometry
+// ---------------------------------------------------------------------------
+
+/**
+ * The attach procs' per-kind rules (`validateListingImage`) read `Image.width` /
+ * `height` / `mimeType` / `metadata.size`. If those columns carry what the
+ * uploader SAID about the file, every one of those rules is self-reported: a
+ * client can declare a shape that clears the bounds for bytes that do not. These
+ * pin that the columns describe the stored bytes instead — including the
+ * end-to-end consequence, that the gate now rejects the mismatched upload.
+ */
+describe('persistListingAssetImage (measures the uploaded bytes)', () => {
+  const KEY = '22222222-2222-4222-8222-222222222222';
+
+  /** A cover that clears every bound: aspect 1.78, 800px wide. */
+  const HONEST_COVER = { url: KEY, width: 800, height: 450, mimeType: 'image/png' as const };
+
+  function persistedRow() {
+    const arg = mockCreateImage.mock.calls[0][0] as {
+      width?: number;
+      height?: number;
+      mimeType?: string;
+      type: string;
+      metadata?: { size?: number };
+    };
+    return {
+      type: arg.type,
+      width: arg.width,
+      height: arg.height,
+      mimeType: arg.mimeType,
+      sizeBytes: arg.metadata?.size ?? null,
+    };
+  }
+
+  it('persists the ACTUAL dimensions, so the cover gate rejects a mismatched upload', async () => {
+    // 200×200 bytes behind a 800×450 declaration: square, and 600px short of the
+    // 640px cover floor, but the declared pair satisfies both.
+    storeObject(await flatPng(200, 200));
+
+    await persistListingAssetImage({ input: HONEST_COVER, userId: CALLER });
+
+    expect(persistedRow()).toMatchObject({ width: 200, height: 200 });
+    expect(validateListingImage(persistedRow(), 'cover')).toMatchObject({ ok: false });
+  });
+
+  it('NEGATIVE CONTROL: an honest upload still persists and still passes the gate', async () => {
+    storeObject(await flatPng(800, 450));
+
+    await persistListingAssetImage({ input: HONEST_COVER, userId: CALLER });
+
+    expect(persistedRow()).toMatchObject({ width: 800, height: 450, mimeType: 'image/png' });
+    expect(validateListingImage(persistedRow(), 'cover')).toEqual({ ok: true });
+  });
+
+  it('persists the ACTUAL byte size, not the declared one', async () => {
+    const bytes = await flatPng(800, 450);
+    storeObject(bytes);
+
+    await persistListingAssetImage({ input: { ...HONEST_COVER, sizeBytes: 1 }, userId: CALLER });
+
+    expect(persistedRow().sizeBytes).toBe(bytes.byteLength);
+  });
+
+  it('derives the MIME from the bytes, not the declared content type', async () => {
+    storeObject(await flatPng(800, 450));
+
+    await persistListingAssetImage({
+      input: { ...HONEST_COVER, mimeType: 'image/webp' },
+      userId: CALLER,
+    });
+
+    expect(persistedRow().mimeType).toBe('image/png');
+  });
+
+  it('rejects a format outside the allowlist however it is declared', async () => {
+    storeObject(await flatGif(800, 450));
+
+    await expect(
+      persistListingAssetImage({ input: HONEST_COVER, userId: CALLER })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: expect.stringContaining('"gif"') });
+    expect(mockCreateImage).not.toHaveBeenCalled();
+  });
+
+  it('rejects an image past the absolute per-side ceiling', async () => {
+    storeObject(await flatPng(LISTING_ASSET_MAX_DIMENSION_PX + 1, 100));
+
+    await expect(
+      persistListingAssetImage({ input: HONEST_COVER, userId: CALLER })
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining(`${LISTING_ASSET_MAX_DIMENSION_PX}px per side`),
+    });
+    expect(mockCreateImage).not.toHaveBeenCalled();
+  });
+
+  it('reports a quarter-turned JPEG the way a renderer shows it', async () => {
+    // Stored 450×800 with EXIF orientation 6 — every viewer draws it 800×450, and
+    // that is the shape the cover rules are about.
+    storeObject(
+      await sharp({
+        create: { width: 450, height: 800, channels: 3, background: { r: 8, g: 8, b: 8 } },
+      })
+        .withMetadata({ orientation: 6 })
+        .jpeg()
+        .toBuffer()
+    );
+
+    await persistListingAssetImage({ input: HONEST_COVER, userId: CALLER });
+
+    expect(persistedRow()).toMatchObject({ width: 800, height: 450, mimeType: 'image/jpeg' });
+    expect(validateListingImage(persistedRow(), 'cover')).toEqual({ ok: true });
+  });
+
+  it('rejects an upload whose bytes are not there', async () => {
+    mockS3Send.mockRejectedValue(
+      Object.assign(new Error('NoSuchKey'), { name: 'NoSuchKey', $metadata: { httpStatusCode: 404 } })
+    );
+
+    await expect(
+      persistListingAssetImage({ input: HONEST_COVER, userId: CALLER })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(mockCreateImage).not.toHaveBeenCalled();
+  });
+
+  it('rejects an object above the loosest per-kind byte cap without downloading it', async () => {
+    const oversize = MAX_LISTING_ASSET_SIZE_BYTES + 1;
+    // A ranged read: the store reports the true total, we only hold the prefix.
+    storeObject(await flatPng(800, 450), { totalSize: oversize });
+
+    await expect(
+      persistListingAssetImage({ input: HONEST_COVER, userId: CALLER })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    const command = mockS3Send.mock.calls[0][0] as { input: { Range?: string } };
+    expect(command.input.Range).toBe(`bytes=0-${MAX_LISTING_ASSET_SIZE_BYTES}`);
+    expect(mockCreateImage).not.toHaveBeenCalled();
+  });
+
+  it('rejects bytes that are not a decodable image', async () => {
+    storeObject(Buffer.from('<!doctype html><html>not an image</html>'));
+
+    await expect(
+      persistListingAssetImage({ input: HONEST_COVER, userId: CALLER })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(mockCreateImage).not.toHaveBeenCalled();
+  });
+
+  it('a store outage is an INTERNAL error, not the uploader being blamed', async () => {
+    mockS3Send.mockRejectedValue(
+      Object.assign(new Error('boom'), { $metadata: { httpStatusCode: 503 } })
+    );
+
+    await expect(
+      persistListingAssetImage({ input: HONEST_COVER, userId: CALLER })
+    ).rejects.toMatchObject({ code: 'INTERNAL_SERVER_ERROR' });
+    expect(mockCreateImage).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
@@ -3,7 +3,6 @@ import { TRPCError } from '@trpc/server';
 import sharp from 'sharp';
 
 import {
-  LISTING_ASSET_MAX_DIMENSION_PX,
   MAX_LISTING_ASSET_SIZE_BYTES,
   validateListingImage,
 } from '~/server/schema/blocks/app-listing.schema';
@@ -1452,18 +1451,6 @@ describe('persistListingAssetImage (measures the uploaded bytes)', () => {
     expect(mockCreateImage).not.toHaveBeenCalled();
   });
 
-  it('rejects an image past the absolute per-side ceiling', async () => {
-    storeObject(await flatPng(LISTING_ASSET_MAX_DIMENSION_PX + 1, 100));
-
-    await expect(
-      persistListingAssetImage({ input: HONEST_COVER, userId: CALLER })
-    ).rejects.toMatchObject({
-      code: 'BAD_REQUEST',
-      message: expect.stringContaining(`${LISTING_ASSET_MAX_DIMENSION_PX}px per side`),
-    });
-    expect(mockCreateImage).not.toHaveBeenCalled();
-  });
-
   it('reports a quarter-turned JPEG the way a renderer shows it', async () => {
     // Stored 450×800 with EXIF orientation 6 — every viewer draws it 800×450, and
     // that is the shape the cover rules are about.
@@ -1480,6 +1467,21 @@ describe('persistListingAssetImage (measures the uploaded bytes)', () => {
 
     expect(persistedRow()).toMatchObject({ width: 800, height: 450, mimeType: 'image/jpeg' });
     expect(validateListingImage(persistedRow(), 'cover')).toEqual({ ok: true });
+  });
+
+  it('leaves an upright JPEG alone — the transpose is conditional, not per-format', async () => {
+    storeObject(
+      await sharp({
+        create: { width: 800, height: 450, channels: 3, background: { r: 8, g: 8, b: 8 } },
+      })
+        .withMetadata({ orientation: 1 })
+        .jpeg()
+        .toBuffer()
+    );
+
+    await persistListingAssetImage({ input: HONEST_COVER, userId: CALLER });
+
+    expect(persistedRow()).toMatchObject({ width: 800, height: 450 });
   });
 
   it('rejects an upload whose bytes are not there', async () => {

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -8,7 +8,6 @@ import { dbRead, dbWrite } from '~/server/db/client';
 import {
   LISTING_ASSET_ALLOWED_MIME,
   LISTING_ASSET_FORMAT_TO_MIME,
-  LISTING_ASSET_MAX_DIMENSION_PX,
   MAX_LISTING_ASSET_SIZE_BYTES,
 } from '~/server/schema/blocks/app-listing.schema';
 import {
@@ -2645,14 +2644,21 @@ export async function rejectExternalRequest(opts: {
 // ---------------------------------------------------------------------------
 
 /**
- * Measure the bytes the client uploaded to `key` and return the values to persist.
+ * Measure the bytes at `key` and return the values to persist.
  *
  * The per-kind geometry/size/MIME rules the attach procs enforce
  * (`validateListingImage`) read `Image.width` / `height` / `mimeType` /
- * `metadata.size`. Those come from here, so they must describe the stored bytes
- * rather than what the uploader said about them — otherwise every bound is
- * self-reported. The two rejections below are the ones no asset kind could pass
- * anyway, raised here because the kind is not known until attach.
+ * `metadata.size`. Those come from here, so they are measured rather than taken
+ * from the uploader — otherwise every one of those bounds is self-reported.
+ *
+ * What this buys is narrower than "the columns match the object": the presigned
+ * PUT stays usable for its full expiry, so the same key can be overwritten after
+ * this read. It guarantees the values were TRUE OF REAL BYTES AT PROBE TIME, not
+ * that they still describe whatever the key holds later.
+ *
+ * The two rejections below cannot be deferred to the attach proc's per-kind
+ * checks, because the kind is not known until attach: bytes over the loosest cap
+ * (no kind accepts them) and a format outside the allowlist.
  */
 async function measureListingAssetUpload(key: string) {
   const { probeStoredImage, StoredImageProbeError } =
@@ -2673,7 +2679,7 @@ async function measureListingAssetUpload(key: string) {
       err.reason === 'missing'
         ? "We couldn't find that upload — upload the image again."
         : err.reason === 'too-large'
-          ? `that image is over the ${MAX_LISTING_ASSET_SIZE_BYTES}-byte limit for listing media`
+          ? `that image is over the ${MAX_LISTING_ASSET_SIZE_BYTES / 1024 / 1024} MiB limit for listing media`
           : "That image couldn't be read. Try a different PNG, JPEG or WebP.";
     throw new TRPCError({ code: 'BAD_REQUEST', message });
   }
@@ -2687,16 +2693,6 @@ async function measureListingAssetUpload(key: string) {
       )})`,
     });
   }
-  if (
-    probe.width > LISTING_ASSET_MAX_DIMENSION_PX ||
-    probe.height > LISTING_ASSET_MAX_DIMENSION_PX
-  ) {
-    throw new TRPCError({
-      code: 'BAD_REQUEST',
-      message: `that image is ${probe.width}×${probe.height}px (max ${LISTING_ASSET_MAX_DIMENSION_PX}px per side)`,
-    });
-  }
-
   return { width: probe.width, height: probe.height, mimeType, sizeBytes: probe.sizeBytes };
 }
 

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -6,6 +6,12 @@ import { Prisma } from '@prisma/client';
 
 import { dbRead, dbWrite } from '~/server/db/client';
 import {
+  LISTING_ASSET_ALLOWED_MIME,
+  LISTING_ASSET_FORMAT_TO_MIME,
+  LISTING_ASSET_MAX_DIMENSION_PX,
+  MAX_LISTING_ASSET_SIZE_BYTES,
+} from '~/server/schema/blocks/app-listing.schema';
+import {
   assertNoOnPlatformSurface,
   validateExternalUrl,
 } from '~/server/schema/blocks/external-app.schema';
@@ -2639,31 +2645,91 @@ export async function rejectExternalRequest(opts: {
 // ---------------------------------------------------------------------------
 
 /**
- * Materialise a CF-uploaded image into an `Image` row (owned by the caller) and
+ * Measure the bytes the client uploaded to `key` and return the values to persist.
+ *
+ * The per-kind geometry/size/MIME rules the attach procs enforce
+ * (`validateListingImage`) read `Image.width` / `height` / `mimeType` /
+ * `metadata.size`. Those come from here, so they must describe the stored bytes
+ * rather than what the uploader said about them — otherwise every bound is
+ * self-reported. The two rejections below are the ones no asset kind could pass
+ * anyway, raised here because the kind is not known until attach.
+ */
+async function measureListingAssetUpload(key: string) {
+  const { probeStoredImage, StoredImageProbeError } =
+    await import('~/server/utils/stored-image-probe');
+
+  let probe;
+  try {
+    probe = await probeStoredImage(key, { maxBytes: MAX_LISTING_ASSET_SIZE_BYTES });
+  } catch (err) {
+    if (!(err instanceof StoredImageProbeError)) throw err;
+    if (err.reason === 'store-unavailable') {
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: "We couldn't read that upload back to check it. Try again.",
+      });
+    }
+    const message =
+      err.reason === 'missing'
+        ? "We couldn't find that upload — upload the image again."
+        : err.reason === 'too-large'
+          ? `that image is over the ${MAX_LISTING_ASSET_SIZE_BYTES}-byte limit for listing media`
+          : "That image couldn't be read. Try a different PNG, JPEG or WebP.";
+    throw new TRPCError({ code: 'BAD_REQUEST', message });
+  }
+
+  const mimeType = LISTING_ASSET_FORMAT_TO_MIME[probe.format];
+  if (!mimeType) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `unsupported image type "${probe.format}" (allowed: ${LISTING_ASSET_ALLOWED_MIME.join(
+        ', '
+      )})`,
+    });
+  }
+  if (
+    probe.width > LISTING_ASSET_MAX_DIMENSION_PX ||
+    probe.height > LISTING_ASSET_MAX_DIMENSION_PX
+  ) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `that image is ${probe.width}×${probe.height}px (max ${LISTING_ASSET_MAX_DIMENSION_PX}px per side)`,
+    });
+  }
+
+  return { width: probe.width, height: probe.height, mimeType, sizeBytes: probe.sizeBytes };
+}
+
+/**
+ * Materialise an uploaded image into an `Image` row (owned by the caller) and
  * return its numeric id, so the submit form's asset step can attach it to the
  * draft listing via the P1 asset-CRUD procs. Kicks off the standard ingestion/scan
  * pipeline (`createImage` with default ingestion) — the P1 attach proc enforces
- * `ingestion === Scanned` + the per-kind image validation, so this proc does NOT
- * re-validate dimensions/mime (it only persists). `createImage` is dynamically
- * imported so the heavy `image.service` module stays out of this service's static
- * graph (mirrors the router's dynamic-import discipline + keeps the unit tests,
- * which mock only `dbRead`/`dbWrite`, light).
+ * `ingestion === Scanned` + the per-kind image validation.
+ *
+ * The persisted dimensions / MIME / byte size are DERIVED FROM THE STORED BYTES
+ * (see {@link measureListingAssetUpload}); the same fields on the input are
+ * ignored. `createImage` and the probe are dynamically imported so the heavy
+ * `image.service` / `sharp` graphs stay out of this service's static graph
+ * (mirrors the router's dynamic-import discipline + keeps the unit tests, which
+ * mock only `dbRead`/`dbWrite`, light).
  */
 export async function persistListingAssetImage(opts: {
   input: PersistListingAssetImageInput;
   userId: number;
 }): Promise<{ imageId: number }> {
   const { input, userId } = opts;
+  const measured = await measureListingAssetUpload(input.url);
   const { createImage } = await import('~/server/services/image.service');
   const image = await createImage({
     url: input.url,
     name: input.name ?? undefined,
     type: 'image',
-    width: input.width,
-    height: input.height,
-    mimeType: input.mimeType,
+    width: measured.width,
+    height: measured.height,
+    mimeType: measured.mimeType,
     // The P1 image validator reads the byte size from `Image.metadata.size`.
-    metadata: input.sizeBytes != null ? { size: input.sizeBytes } : undefined,
+    metadata: { size: measured.sizeBytes },
     userId,
   });
   return { imageId: image.id };

--- a/src/server/utils/stored-image-probe.ts
+++ b/src/server/utils/stored-image-probe.ts
@@ -1,5 +1,6 @@
 import { GetObjectCommand } from '@aws-sdk/client-s3';
 
+import { logToAxiom } from '~/server/logging/client';
 import { getImageUploadBackend } from '~/utils/s3-utils';
 
 /**
@@ -12,6 +13,11 @@ import { getImageUploadBackend } from '~/utils/s3-utils';
  * server never looked at, so any server-side rule expressed over those fields is
  * only as strong as client honesty. This reads the bytes the client actually
  * stored and reports what they are.
+ *
+ * 🔴 A POINT-IN-TIME reading, not a durable property of the key. The presigned PUT
+ * remains usable for its whole expiry window, so the object can be replaced after
+ * this returns. Callers may record "these values were measured from real bytes",
+ * never "these values describe the object".
  */
 
 export type StoredImageProbeReason =
@@ -27,8 +33,8 @@ export type StoredImageProbeReason =
 export class StoredImageProbeError extends Error {
   readonly reason: StoredImageProbeReason;
 
-  constructor(reason: StoredImageProbeReason, message: string) {
-    super(message);
+  constructor(reason: StoredImageProbeReason, message: string, options?: { cause?: unknown }) {
+    super(message, options);
     this.name = 'StoredImageProbeError';
     this.reason = reason;
   }
@@ -94,11 +100,26 @@ export async function probeStoredImage(
     sizeBytes = parseTotalSize(object.ContentRange, bytes.byteLength);
   } catch (err) {
     if (err instanceof StoredImageProbeError) throw err;
-    if (isNotFoundError(err)) throw new StoredImageProbeError('missing', 'stored image not found');
-    if (isRangeNotSatisfiableError(err)) {
-      throw new StoredImageProbeError('unreadable', 'stored image is empty');
+    if (isNotFoundError(err)) {
+      throw new StoredImageProbeError('missing', 'stored image not found', { cause: err });
     }
-    throw new StoredImageProbeError('store-unavailable', 'could not read the stored image');
+    if (isRangeNotSatisfiableError(err)) {
+      throw new StoredImageProbeError('unreadable', 'stored image is empty', { cause: err });
+    }
+    // `store-unavailable` is the only reason that is OUR fault, and the shapes it
+    // collapses (missing credentials, bad endpoint, 5xx, a rejected Range) are
+    // indistinguishable to the caller — so it is the one that has to be logged.
+    logToAxiom({
+      name: 'stored-image-probe',
+      type: 'error',
+      reason: 'store-unavailable',
+      message: err instanceof Error ? err.message : String(err),
+      errorName: err instanceof Error ? err.name : undefined,
+      statusCode: (err as { $metadata?: { httpStatusCode?: number } })?.$metadata?.httpStatusCode,
+    }).catch(() => null);
+    throw new StoredImageProbeError('store-unavailable', 'could not read the stored image', {
+      cause: err,
+    });
   }
 
   if (sizeBytes > maxBytes) {
@@ -117,8 +138,10 @@ export async function probeStoredImage(
   let orientation: number | undefined;
   try {
     ({ width, height, format, orientation } = await sharp(bytes).metadata());
-  } catch {
-    throw new StoredImageProbeError('unreadable', 'stored image could not be decoded');
+  } catch (err) {
+    throw new StoredImageProbeError('unreadable', 'stored image could not be decoded', {
+      cause: err,
+    });
   }
   if (!format || !width || !height || width <= 0 || height <= 0) {
     throw new StoredImageProbeError('unreadable', 'stored image has no readable dimensions');

--- a/src/server/utils/stored-image-probe.ts
+++ b/src/server/utils/stored-image-probe.ts
@@ -1,0 +1,138 @@
+import { GetObjectCommand } from '@aws-sdk/client-s3';
+
+import { getImageUploadBackend } from '~/utils/s3-utils';
+
+/**
+ * Measure an image that has ALREADY been uploaded to the image store, by reading
+ * the object back and decoding its header.
+ *
+ * The browser-direct / CLI upload flow is: mint a presigned PUT (`/api/v1/image-upload`),
+ * PUT the raw bytes, then tell the server what was uploaded. Everything in that
+ * last step — width, height, MIME, byte size — is a CLIENT CLAIM about bytes the
+ * server never looked at, so any server-side rule expressed over those fields is
+ * only as strong as client honesty. This reads the bytes the client actually
+ * stored and reports what they are.
+ */
+
+export type StoredImageProbeReason =
+  /** No object at that key (nothing was uploaded, or the upload failed). */
+  | 'missing'
+  /** The stored object is bigger than the caller's budget. */
+  | 'too-large'
+  /** Present, but not a decodable image (or zero-length). */
+  | 'unreadable'
+  /** The store itself could not be consulted — infrastructure, not the caller. */
+  | 'store-unavailable';
+
+export class StoredImageProbeError extends Error {
+  readonly reason: StoredImageProbeReason;
+
+  constructor(reason: StoredImageProbeReason, message: string) {
+    super(message);
+    this.name = 'StoredImageProbeError';
+    this.reason = reason;
+  }
+}
+
+export type StoredImageProbe = {
+  /** Width as a viewer sees it — EXIF orientation applied. */
+  width: number;
+  /** Height as a viewer sees it — EXIF orientation applied. */
+  height: number;
+  /** Decoded container format, e.g. `png` / `jpeg` / `webp` / `gif`. */
+  format: string;
+  /** The object's true byte length in the store. */
+  sizeBytes: number;
+};
+
+function isNotFoundError(e: unknown) {
+  const err = e as { name?: string; Code?: string; $metadata?: { httpStatusCode?: number } };
+  return (
+    err?.name === 'NoSuchKey' ||
+    err?.name === 'NotFound' ||
+    err?.Code === 'NoSuchKey' ||
+    err?.$metadata?.httpStatusCode === 404
+  );
+}
+
+/** A zero-length object answers a `bytes=0-N` read with 416, not with 0 bytes. */
+function isRangeNotSatisfiableError(e: unknown) {
+  const err = e as { name?: string; $metadata?: { httpStatusCode?: number } };
+  return err?.name === 'InvalidRange' || err?.$metadata?.httpStatusCode === 416;
+}
+
+/** `bytes 0-16383/16384` → 16384. Falls back to what we actually read. */
+function parseTotalSize(contentRange: string | undefined, readBytes: number): number {
+  const total = contentRange?.split('/')[1];
+  const parsed = total != null ? Number(total) : NaN;
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : readBytes;
+}
+
+/**
+ * Read back the object at `key` in the image-upload store and decode its header.
+ *
+ * The read is a single ranged GET of `maxBytes + 1`, so an oversize object costs
+ * one bounded request rather than a full download: the `Content-Range` total is
+ * the object's real size, and anything at or under the budget arrives whole.
+ * Throws {@link StoredImageProbeError} — callers map `reason` to their own
+ * client-facing error (`store-unavailable` is the only one that is not the
+ * caller's fault).
+ */
+export async function probeStoredImage(
+  key: string,
+  { maxBytes }: { maxBytes: number }
+): Promise<StoredImageProbe> {
+  let bytes: Buffer;
+  let sizeBytes: number;
+  try {
+    const { s3, bucket } = await getImageUploadBackend();
+    const object = await s3.send(
+      new GetObjectCommand({ Bucket: bucket, Key: key, Range: `bytes=0-${maxBytes}` })
+    );
+    if (!object.Body) throw new StoredImageProbeError('unreadable', 'stored image has no body');
+    bytes = Buffer.from(await object.Body.transformToByteArray());
+    sizeBytes = parseTotalSize(object.ContentRange, bytes.byteLength);
+  } catch (err) {
+    if (err instanceof StoredImageProbeError) throw err;
+    if (isNotFoundError(err)) throw new StoredImageProbeError('missing', 'stored image not found');
+    if (isRangeNotSatisfiableError(err)) {
+      throw new StoredImageProbeError('unreadable', 'stored image is empty');
+    }
+    throw new StoredImageProbeError('store-unavailable', 'could not read the stored image');
+  }
+
+  if (sizeBytes > maxBytes) {
+    throw new StoredImageProbeError(
+      'too-large',
+      `stored image is ${sizeBytes} bytes (max ${maxBytes})`
+    );
+  }
+  if (bytes.byteLength === 0)
+    throw new StoredImageProbeError('unreadable', 'stored image is empty');
+
+  const { default: sharp } = await import('sharp');
+  let width: number | undefined;
+  let height: number | undefined;
+  let format: string | undefined;
+  let orientation: number | undefined;
+  try {
+    ({ width, height, format, orientation } = await sharp(bytes).metadata());
+  } catch {
+    throw new StoredImageProbeError('unreadable', 'stored image could not be decoded');
+  }
+  if (!format || !width || !height || width <= 0 || height <= 0) {
+    throw new StoredImageProbeError('unreadable', 'stored image has no readable dimensions');
+  }
+
+  // EXIF orientations 5-8 are quarter turns: the stored raster is transposed
+  // relative to what every renderer shows, and the rules we measure against are
+  // about the displayed image.
+  const quarterTurned = orientation != null && orientation >= 5 && orientation <= 8;
+
+  return {
+    width: quarterTurned ? height : width,
+    height: quarterTurned ? width : height,
+    format,
+    sizeBytes,
+  };
+}


### PR DESCRIPTION
Refs civitai/cli#270 (the "one more finding, unasked" note).

## The gap

`appListings.persistAssetImage` took `width` / `height` / `mimeType` / `sizeBytes` from its input and wrote them straight into the `Image` row (`persistListingAssetImage`, `src/server/services/blocks/offsite-listing.service.ts`). Those are the exact four columns the attach procs' per-kind rules read — `validateListingImage` in `src/server/schema/blocks/app-listing.schema.ts`, reached through `loadValidatedImage` in `app-listing-assets.service.ts`, which `setIcon` / `setCover` / `addScreenshot` all go through.

So the aspect, minimum-dimension, byte and MIME bounds were only as strong as client honesty. A client declaring `1280x720` for a 100x100 file passed every geometry gate; declaring `image/png` for a GIF passed the MIME allowlist. Cover and screenshot both use this path.

Nothing downstream ever corrects it. `image-scan-result.service.ts` contains **0** occurrences of `width` / `height` / `mimeType` (against 24 of `ingestion`) — the `Scanned` transition writes ingestion, nsfwLevel, pHash, blockedFor, needsReview, minor, poi and scannedAt, and nothing else. So the wrong values persist for display and mod review as well as for the gate.

The official CLI declares honestly (it decodes headers itself), so this is not a live incident. The icon data-URI path was never affected — it rasterizes server-side with sharp and derives real dimensions.

## The fix

The bytes are already in the store at the minted key by the time `persistAssetImage` runs, so the server reads them back and derives all four values.

New `src/server/utils/stored-image-probe.ts`:

- One **ranged** GET of `maxBytes + 1`. The `Content-Range` total is the object's real size, so an oversize upload is rejected on a bounded read rather than a full download, and anything within budget arrives whole in the same request.
- `sharp().metadata()` for dimensions and container format — a header read, not a decode.
- EXIF orientations 5-8 are transposed back, so the reported shape is the one a renderer draws.
- Typed `StoredImageProbeError` carrying `reason` and the underlying error as `cause`; the `store-unavailable` branch is logged, since it is the one that is our fault and it collapses several distinct causes into one 500.

### What this does and does not guarantee

It guarantees the persisted values **were measured from real bytes at persist time**. It does *not* guarantee they still describe the object: `/api/v1/image-upload` returns a bare presigned PUT valid for its full expiry window, with no `content-length-range` and no content-type condition, so the same key can be re-PUT after the measurement. Closing that needs a different upload contract and is out of scope here.

## Trade-offs

**Derive and ignore, rather than compare and reject.** The deciding case is EXIF: a browser reports the *display* dimensions of a quarter-turned JPEG while the raster is stored transposed, so `declared != actual` for a completely honest upload. A mismatch rule would reject those. Deriving has no tolerance to tune and no honest-client failure mode.

**Probe at persist, not at attach.** Attach is where the decision is made and where the kind is known, which argues for probing there — but attach runs up to 10 times per listing versus once per upload, and it accepts *any* image the caller owns. Probing at persist fixes the stored row itself, so the gate, the store card and mod review all improve together, at one probe per upload.

**Latency.** One extra store round trip per uploaded asset, on a proc rate-limited to 60/hr, bounded to a 4 MiB read. It sits in a step that already waits on the upload itself and then polls a multi-second content scan. Nothing changes for the attach or submit calls.

**Two rejections move earlier** — from attach to upload — because the asset kind is not known at persist time: bytes above the loosest per-kind cap (4 MiB, which no kind could accept) and a decoded format outside the allowlist. Both already failed at attach; they now fail sooner, with a message naming the bound.

`width` / `height` / `mimeType` / `sizeBytes` stay in the input schema, loosened to optional, so released clients that send them keep working. They are no longer read.

## Known residual — this PR does not close the gate for images from other paths

**It does not contain itself downstream. An image with fabricated geometry can reach a published listing.** An earlier revision of this description claimed otherwise; that claim was wrong and is retracted.

The mechanism: attach accepts any `imageId` the caller owns, on ownership alone. `blockImageUpload.persist` is a plain `protectedProcedure` — any authenticated user — and `block-image-upload.service.ts` writes client-supplied `width` / `height` / `mimeType` / `sizeBytes` verbatim. Such a row holds real, scannable bytes, so it reaches `Scanned` normally; scanning never re-derives geometry, and the go-live gate `assertAssetsScanClean` selects only `{ id, ingestion }`. It is then attached, validated against the lying columns, and published.

So this PR closes the gate for the path the submit form and the CLI use, and leaves that one open. Closing it means probing at attach as well, which is a separate change: attach also accepts long-lived rows from other upload paths, whose bytes are not necessarily readable the same way, so it carries a false-reject risk this change does not.

## Tests

`src/server/services/blocks/__tests__/offsite-listing.service.test.ts` — real PNG/JPEG/GIF bytes and the real sharp decode; only the store accessor is mocked.

Matrix (whole file, `--project unit`, measured on this branch rebased onto current `main`):

| | `origin/main` | HEAD |
|---|---|---|
| offsite-listing.service.test.ts | **10 failed / 64 passed (74)** | **74 passed (74)** |

The load-bearing case — 200x200 bytes behind an `800x450` declaration — fails on `main` with `expected { width: 800 … } to match object { width: 200, height: 200 }`, i.e. for exactly the reason it is meant to catch, and then asserts the consequence: `validateListingImage(row, 'cover')` rejects.

**Two controls pass on both sides.** An honest 800x450 upload with matching declared values still persists and still clears the cover gate; an upright (orientation 1) JPEG is left untransposed. Without the first, breaking every upload would have looked green.

Nine mutants, each killed, each by its own test:

| mutation | test that failed |
|---|---|
| persist the declared values | actual-dimensions (+4 others) |
| EXIF transpose removed | quarter-turned JPEG |
| EXIF range inverted | quarter-turned JPEG |
| EXIF transpose applied unconditionally | upright JPEG + negative control |
| true size ← read length | oversize rejection |
| size cap off-by-one (looser) | oversize rejection |
| width/height swapped | negative control + quarter-turned JPEG |
| format allowlist fails open | allowlist rejection |
| `store-unavailable` branch removed | store-outage classification |

The unconditional-transpose mutant survived the first battery; the upright-JPEG control was added for it.

Also run on the rebased tree: `test:lint-rules` 204/204; a `blocks` + `routers` + `schema` + `utils` sweep of **4684 tests across 227 files**; `pnpm typecheck` 0 errors; eslint 0 errors. `tsconfig.json` excludes `src/**/__tests__/**`, so the test file was typechecked under a temporary config as well — 0 errors in it, verified against a planted type error to confirm the check could see the file at all.

## Deliberately not here

A per-side dimension ceiling on this path. **The byte cap and a per-side pixel ceiling are independent axes, and neither stands in for the other.** At a fixed pixel count, encoded size is set almost entirely by content: across the fixtures sampled below it spans roughly 0.06 MiB to several hundred MiB. That leaves a large ordinary region — flat, gradient, moderately detailed — where an image is comfortably under the 4 MiB cap and still over 8192px per side. Those are exactly the images a new ceiling would newly reject, and they are the reason the ceiling is a real narrowing rather than a formality.

Sampled fixtures, to show the spread. These are properties of the *content*, not of the pixel dimensions, and should not be read as typical:

| | flat | gradient | full-entropy noise |
|---|---|---|---|
| 10000x5000 PNG | 0.06 – 0.15 MiB | 1.55 MiB | ~286 MiB |
| 12000x6000 JPEG q82 | 0.27 – 0.40 MiB | 0.35 – 0.55 MiB | ~45 MiB |

The noise column is from an independent ImageMagick measurement. An earlier revision of this description reported ~1 MiB there from a synthetic "noise" fixture that was not high-entropy — a byte sequence regular enough that PNG's filters compressed it ~120x — and concluded PNG stays under the cap at *every* content type. That conclusion was wrong and is retracted; incompressible content at these dimensions is enormous.

**Not measured by anyone so far: real 4x-upscaled AI artwork**, which is where the practical question actually lives. It sits somewhere between the gradient and noise columns and this description is deliberately not guessing which end. The argument above does not depend on it — it rests only on the ordinary region existing, which every measurement taken agrees on.

There is also no client-side precheck: `ListingAssetStep.tsx` reads the dimensions and discards them, so an author would upload the whole file before hearing about a ceiling. It ships separately, together with that precheck.
