### PR TITLE
feat(generation): add Qwen 3 image gen and Seedance 2.5 video gen

### DIFF
--- a/.claude/skills/add-generation-support/SKILL.md
+++ b/.claude/skills/add-generation-support/SKILL.md
@@ -271,13 +271,37 @@ If a dev server is running (check via the `dev-server` skill), ask the user to:
 
 ## Post-onboarding: generation coverage & auction featurability (manual DB steps)
 
-Two DB tables are keyed off the constants **by string** but are **not derived from them** — nothing reconciles them, so they must be hand-seeded. Miss one and the feature silently half-works (the generation form still lights up from the constants, so it *looks* done). This bit us with Anima and Krea 2. Neither table is written by app code today; both need a raw SQL INSERT run against each environment (preview → prod) per our manual-migration rule.
+Three DB tables are keyed off the constants **by string or version id** but are **not derived from them** — nothing reconciles them, so they must be hand-seeded. Miss one and the feature silently half-works (the generation form still lights up from the constants, so it *looks* done). This bit us with Anima and Krea 2. None of these tables are written by app code today; each needs a raw SQL INSERT run against each environment (preview → prod) per our manual-migration rule.
 
 See [docs/features/featured-auction-ecosystem-sync.md](docs/features/featured-auction-ecosystem-sync.md) for the full rationale and architecture; the essentials:
 
-### 1. `GenerationBaseModel` — makes resources GENERATABLE (do this for every generatable ecosystem)
+### 0. First: which branch of `GenerationCoverage` will cover this version?
 
-The `GenerationCoverage` SQL view gates whether a resource is generatable. One of its inputs is a plain list of base-model strings in `GenerationBaseModel`. A new base model that isn't in this list is **not generatable** even with full form support (this is what silently broke Krea 2).
+`GenerationCoverage` is a three-branch `OR`. **Read the live definition before writing any SQL** — `SELECT pg_get_viewdef('"GenerationCoverage"'::regclass, true)` — because which branch applies decides which table you need, and picking the wrong one produces SQL that runs cleanly and changes nothing.
+
+| Branch | Condition | Typical ecosystem |
+| --- | --- | --- |
+| 1 | `mv.id IN "EcosystemCheckpoints"` — **no status check, no `NOT m.poi` guard** | file-less API checkpoints, `usageControl = 'Generation'` |
+| 2 | `usageControl = 'ExternalGeneration' AND status = 'Published' AND NOT m.poi` | file-less API checkpoints, mod-published |
+| 3 | files + `allowCommercialUse` + `baseModel IN "GenerationBaseModel"` + `CoveredCheckpoint` | downloadable weights |
+
+`GenerationBaseModel` is consulted by **branch 3 only**. For a file-less API model the row is inert — correct to add for the future, but it is not what makes the model generatable, so don't stop there and assume you're done.
+
+### 1a. `EcosystemCheckpoints` — covers a specific VERSION unconditionally
+
+Keyed by `ModelVersion.id`, not by base model or ecosystem. Needed when the version has no files and is `usageControl = 'Generation'` (branch 2 won't fire). `name` is a free-text label with no behaviour attached — match the base model display name.
+
+```sql
+INSERT INTO "EcosystemCheckpoints" (id, name) VALUES (3207633, 'Qwen 3') ON CONFLICT (id) DO NOTHING;
+```
+
+**This is an unconditional override.** Branch 1 has neither a status check nor a PoI guard, so the version stays covered even if it's later unpublished or the model is flagged. That cuts both ways: it's the only way to exercise generation against a **Draft** version pre-publish, and it's a footgun if you expected coverage to track publish state. When the version is `ExternalGeneration`, prefer letting branch 2 handle it — publishing is then the only step, and unpublishing correctly revokes coverage.
+
+Note that sibling versions on one model page routinely land on **different branches** (e.g. Qwen Image 2.0 via branch 1, 3.0 via branch 2; Seedance 2.0 via branch 1, 2.0 Mini via branch 2). That's expected, not drift.
+
+### 1b. `GenerationBaseModel` — makes downloadable resources GENERATABLE
+
+One of branch 3's inputs is a plain list of base-model strings in `GenerationBaseModel`. A new base model that isn't in this list is **not generatable** even with full form support (this is what silently broke Krea 2).
 
 - **`baseModel` must equal the base model *display name*** (`ModelVersion.baseModel`), e.g. `'Krea 2'`, `'Anima'` — **not** the ecosystem key.
 
@@ -308,7 +332,7 @@ FROM "AuctionBase" ab
 WHERE ab.ecosystem = 'Krea2';
 ```
 
-Surface both INSERTs to the user as SQL that needs to be applied manually to each environment — do not assume they auto-run.
+Surface every INSERT above to the user as SQL that needs to be applied manually to each environment — do not assume they auto-run. State which coverage branch you determined applies, so the reader can check your reasoning rather than just running the SQL.
 
 ## Cross-ecosystem compatibility
 

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "@civitai/app-sdk": "^0.14.0",
     "@civitai/auth": "workspace:*",
     "@civitai/buzz": "workspace:*",
-    "@civitai/client": "0.2.0-beta.85",
+    "@civitai/client": "0.2.0-beta.86",
     "@civitai/cybertipline-tools": "^0.1.0",
     "@civitai/db-queries": "workspace:*",
     "@civitai/db-schema": "workspace:*",

--- a/packages/civitai-shared/src/basemodel.constants.ts
+++ b/packages/civitai-shared/src/basemodel.constants.ts
@@ -133,6 +133,7 @@ export const ECO = {
   Flux2Klein_4B_base: 57,
   Qwen: 10,
   Qwen2: 62,
+  Qwen3: 80,
   Chroma: 11,
   HyDit1: 12,
   AuraFlow: 13,
@@ -579,6 +580,13 @@ export const ecosystems: EcosystemRecord[] = [
     familyId: 10,
     sortOrder: 91,
   },
+  {
+    id: ECO.Qwen3,
+    key: 'Qwen3',
+    displayName: 'Qwen 3',
+    familyId: 10,
+    sortOrder: 92,
+  },
 
   // ZImage Family (familyId: 11)
   {
@@ -859,7 +867,8 @@ export const MODEL3D_ECOSYSTEM_KEYS = new Set<string>(
  *  - AceStepAudioInput   → Ace
  *
  * NOTE: lookalikes that are EXTERNAL and must NOT be listed — `Flux2` (≠ Klein),
- * `Qwen2` (≠ Qwen), and all `Wan*` (currently FAL). Keep this in sync when an
+ * `Qwen2` (≠ Qwen, FAL), `Qwen3` (≠ Qwen, Alibaba DashScope), and all `Wan*`
+ * (currently FAL). Keep this in sync when an
  * ecosystem's routing changes.
  */
 export const SELF_HOSTED_ECOSYSTEM_KEYS = [
@@ -979,6 +988,9 @@ export const ecosystemSupport: EcosystemSupport[] = [
 
   // Qwen 2 - checkpoint only
   { ecosystemId: ECO.Qwen2, supportType: 'generation', modelTypes: [ModelType.Checkpoint] },
+
+  // Qwen 3 - checkpoint only
+  { ecosystemId: ECO.Qwen3, supportType: 'generation', modelTypes: [ModelType.Checkpoint] },
 
   // HyV1 (Hunyuan Video) - LORA only
   { ecosystemId: ECO.HyV1, supportType: 'generation', modelTypes: loraOnly },
@@ -1284,6 +1296,14 @@ export const ecosystemSettings: EcosystemSettings[] = [
     defaults: {
       model: { id: 2744101 },
       modelLocked: true,
+    },
+  },
+  {
+    ecosystemId: ECO.Qwen3,
+    defaults: {
+      model: { id: 3207633 },
+      modelLocked: true,
+      engine: 'qwen',
     },
   },
   {
@@ -2031,6 +2051,7 @@ export const BM = {
   Anima: 77,
   Grok: 78,
   Qwen2: 79,
+  Qwen3: 99,
   WanImage27: 86,
   WanVideo27: 81,
   Upscaler: 82,
@@ -2908,6 +2929,14 @@ export const baseModelRecords: BaseModelRecord[] = [
     description: 'Next-generation Qwen image generation model',
     type: 'image',
     ecosystemId: ECO.Qwen2,
+    licenseId: 13,
+  },
+  {
+    id: BM.Qwen3,
+    name: 'Qwen 3',
+    description: "Alibaba's Qwen 3 image generation model",
+    type: 'image',
+    ecosystemId: ECO.Qwen3,
     licenseId: 13,
   },
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,8 +47,8 @@ importers:
         specifier: workspace:*
         version: link:packages/civitai-buzz
       '@civitai/client':
-        specifier: 0.2.0-beta.85
-        version: 0.2.0-beta.85
+        specifier: 0.2.0-beta.86
+        version: 0.2.0-beta.86
       '@civitai/cybertipline-tools':
         specifier: ^0.1.0
         version: 0.1.0
@@ -2044,8 +2044,8 @@ packages:
     resolution: {integrity: sha512-dSXkI8hVoozzlPS9DymzoyncWz8eapH3wkSDzDVGWjjqamXn8Dbcq1hWu5xUZkZmqCaR76F7BS9BQNqvOJ++Sw==}
     engines: {git: '>=2.11.0', node: '>=18.0.0', npm: '>=7.19.0', yarn: '>=1.7.0'}
 
-  '@civitai/client@0.2.0-beta.85':
-    resolution: {integrity: sha512-TFswd8v//BCDYxk7cg8Wgd8rbBb/xXlhoWQspINQXoW8ioQiEVHeCBA5z0CBYZb9hKdePd0/nqsRKocuRhvpog==}
+  '@civitai/client@0.2.0-beta.86':
+    resolution: {integrity: sha512-1Fko63BlENrfRwy/LA4xDmzlWLKXV7Hv6lvW3swpnBCFEIpeqsAVz0Ve5jwjA/U1qsXugkTmBTpNiFPRg+mhnw==}
     engines: {git: '>=2.11.0', node: '>=18.0.0', npm: '>=7.19.0', yarn: '>=1.7.0'}
 
   '@civitai/cybertipline-tools@0.1.0':
@@ -13767,7 +13767,7 @@ snapshots:
       rfc6902: 5.2.0
       tslib: 2.8.1
 
-  '@civitai/client@0.2.0-beta.85':
+  '@civitai/client@0.2.0-beta.86':
     dependencies:
       '@hey-api/client-fetch': 0.1.14
       rfc6902: 5.2.0

--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -288,8 +288,10 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
   const isDraft = version?.status === ModelStatus.Draft;
 
   // const shouldOmit = [1562709, 1672021, 1669468].includes(model.id) && !user?.isModerator;
+  // Drafts hide the action, except for owners/mods on ExternalGeneration versions: those carry no
+  // weights, so generating is the only way to check the wiring before publishing.
   const couldGenerate =
-    !isDraft && // We don't wanna show the action for drafts.
+    (!isDraft || (isExternalGeneration && isOwnerOrMod)) &&
     isSelectableInGenerator &&
     features.imageGeneration &&
     // !shouldOmit &&

--- a/src/server/services/orchestrator/ecosystems/index.ts
+++ b/src/server/services/orchestrator/ecosystems/index.ts
@@ -405,6 +405,7 @@ async function createEcosystemStep(
     // Qwen family
     case 'Qwen':
     case 'Qwen2':
+    case 'Qwen3':
       return createQwenInput(normalizedData, handlerCtx);
 
     // Seedream

--- a/src/server/services/orchestrator/ecosystems/qwen.handler.ts
+++ b/src/server/services/orchestrator/ecosystems/qwen.handler.ts
@@ -1,10 +1,11 @@
 /**
  * Qwen Family Handler
  *
- * Handles Qwen and Qwen 2 workflows using imageGen step type.
+ * Handles Qwen, Qwen 2 and Qwen 3 workflows using imageGen step type.
  * Discriminates between ecosystems:
  * - Qwen: sdcpp engine, model version-based routing, LoRA support
  * - Qwen 2: fal engine, aspect ratio mapped to imageSize enum
+ * - Qwen 3: qwen engine (Alibaba DashScope), explicit width/height
  */
 
 import type {
@@ -12,6 +13,8 @@ import type {
   Qwen20bEditImageGenInput,
   Qwen2CreateFalImageGenInput,
   Qwen2EditFalImageGenInput,
+  QwenApiCreateImageGenInput,
+  QwenApiEditImageGenInput,
   ImageGenStepTemplate,
 } from '@civitai/client';
 import { removeEmpty } from '~/utils/object-helpers';
@@ -21,7 +24,7 @@ import { defineHandler } from './handler-factory';
 
 // Types derived from generation graph
 type EcosystemGraphOutput = Extract<GenerationGraphTypes['Ctx'], { ecosystem: string }>;
-type QwenFamilyCtx = EcosystemGraphOutput & { ecosystem: 'Qwen' | 'Qwen2' };
+type QwenFamilyCtx = EcosystemGraphOutput & { ecosystem: 'Qwen' | 'Qwen2' | 'Qwen3' };
 
 // =============================================================================
 // Qwen version mapping
@@ -53,16 +56,61 @@ const imageSizeMap: Record<string, Qwen2CreateFalImageGenInput['imageSize']> = {
 };
 
 // =============================================================================
+// Qwen 3 model identifiers
+// =============================================================================
+
+const QWEN3_CREATE_MODEL: QwenApiCreateImageGenInput['model'] = '3.0-pro';
+const QWEN3_EDIT_MODEL: QwenApiEditImageGenInput['model'] = '3.0-pro';
+
+// =============================================================================
 // Unified handler
 // =============================================================================
 
 /**
  * Creates imageGen input for Qwen family ecosystems.
- * Routes to Qwen (sdcpp) or Qwen 2 (fal) based on ecosystem.
+ * Routes to Qwen (sdcpp), Qwen 2 (fal) or Qwen 3 (qwen) based on ecosystem.
  */
 export const createQwenInput = defineHandler<QwenFamilyCtx, [ImageGenStepTemplate]>((data, ctx) => {
   const isTxt2Img = data.workflow.startsWith('txt');
   const quantity = data.quantity ?? 1;
+
+  // Qwen 3 — qwen engine (Alibaba DashScope)
+  if (data.ecosystem === 'Qwen3') {
+    const baseInput = {
+      engine: 'qwen' as const,
+      prompt: data.prompt,
+      negativePrompt: 'negativePrompt' in data ? data.negativePrompt : undefined,
+      width: data.aspectRatio?.width,
+      height: data.aspectRatio?.height,
+      promptExtend: 'enablePromptExpansion' in data ? data.enablePromptExpansion : undefined,
+      quantity,
+      seed: data.seed,
+    };
+
+    if (isTxt2Img) {
+      return [
+        {
+          $type: 'imageGen',
+          input: removeEmpty({
+            ...baseInput,
+            model: QWEN3_CREATE_MODEL,
+            operation: 'createImage',
+          }) as QwenApiCreateImageGenInput,
+        },
+      ];
+    }
+    return [
+      {
+        $type: 'imageGen',
+        input: removeEmpty({
+          ...baseInput,
+          model: QWEN3_EDIT_MODEL,
+          operation: 'editImage',
+          images: data.images?.map((x) => x.url) ?? [],
+        }) as QwenApiEditImageGenInput,
+      },
+    ];
+  }
 
   // Qwen 2 — fal engine
   if (data.ecosystem === 'Qwen2') {

--- a/src/shared/data-graph/generation/config/workflows.ts
+++ b/src/shared/data-graph/generation/config/workflows.ts
@@ -52,6 +52,7 @@ const DRAFT_IDS = [...SD_FAMILY_IDS, ECO.Flux1];
 const EDIT_IMG_IDS = [
   ECO.Qwen,
   ECO.Qwen2,
+  ECO.Qwen3,
   ECO.Seedream,
   ECO.NanoBanana,
   ECO.OpenAI,
@@ -95,6 +96,7 @@ const TXT2IMG_IDS = [
   ECO.Chroma,
   ECO.Qwen,
   ECO.Qwen2,
+  ECO.Qwen3,
   ECO.HiDream,
   ECO.HiDreamO1,
   ECO.NanoBanana,

--- a/src/shared/data-graph/generation/ecosystem-graph.ts
+++ b/src/shared/data-graph/generation/ecosystem-graph.ts
@@ -363,7 +363,7 @@ export const ecosystemGraph = new DataGraph<
       graph: fluxGraph,
     },
     // Image ecosystems - individual families
-    { values: ['Qwen', 'Qwen2'] as const, graph: qwenGraph },
+    { values: ['Qwen', 'Qwen2', 'Qwen3'] as const, graph: qwenGraph },
     { values: ['NanoBanana'] as const, graph: nanoBananaGraph },
     { values: ['Seedream'] as const, graph: seedreamGraph },
     { values: ['Imagen4'] as const, graph: imagen4Graph },

--- a/src/shared/data-graph/generation/qwen-graph.ts
+++ b/src/shared/data-graph/generation/qwen-graph.ts
@@ -12,8 +12,13 @@
  * Qwen 2 (fal engine):
  * - Supports txt2img and img2img:edit workflows with locked model
  * - Nodes: aspectRatio (mapped to imageSize in handler), seed, enablePromptExpansion
+ *
+ * Qwen 3 (qwen engine — Alibaba Model Studio / DashScope):
+ * - Supports txt2img and img2img:edit workflows with locked model
+ * - Nodes: aspectRatio, negativePrompt, enablePromptExpansion, seed
  */
 
+import z from 'zod';
 import { DataGraph } from '~/libs/data-graph/data-graph';
 import type { GenerationCtx } from './context';
 import {
@@ -86,6 +91,21 @@ const qwen2AspectRatios = [
 ];
 
 // =============================================================================
+// Qwen 3 Constants
+// =============================================================================
+
+/** Qwen 3 aspect ratios — the Qwen-Image preset resolutions (~1.7MP) */
+const qwen3AspectRatios = [
+  { label: '16:9', value: '16:9', width: 1664, height: 928 },
+  { label: '3:2', value: '3:2', width: 1584, height: 1056 },
+  { label: '4:3', value: '4:3', width: 1472, height: 1140 },
+  { label: '1:1', value: '1:1', width: 1328, height: 1328 },
+  { label: '3:4', value: '3:4', width: 1140, height: 1472 },
+  { label: '2:3', value: '2:3', width: 1056, height: 1584 },
+  { label: '9:16', value: '9:16', width: 928, height: 1664 },
+];
+
+// =============================================================================
 // Types
 // =============================================================================
 
@@ -127,6 +147,31 @@ const qwen2SubGraph = new DataGraph<QwenCtx, GenerationCtx>()
   .merge(negativePromptGraph);
 
 // =============================================================================
+// Qwen 3 Subgraph (qwen engine — DashScope)
+// =============================================================================
+
+const qwen3SubGraph = new DataGraph<QwenCtx, GenerationCtx>()
+  .merge(() => createCheckpointGraph(), [])
+  .node(
+    'aspectRatio',
+    aspectRatioNode({
+      options: qwen3AspectRatios,
+      defaultValue: '1:1',
+      priorityOptions: ['16:9', '4:3', '1:1', '3:4', '9:16'],
+    })
+  )
+  .node(
+    'enablePromptExpansion',
+    () => ({
+      input: z.boolean().optional(),
+      output: z.boolean(),
+      defaultValue: true,
+    }),
+    []
+  )
+  .merge(negativePromptGraph);
+
+// =============================================================================
 // Qwen Family Graph
 // =============================================================================
 
@@ -154,6 +199,7 @@ export const qwenGraph = new DataGraph<QwenCtx, GenerationCtx>()
   .discriminator('ecosystem', {
     Qwen: qwenSubGraph,
     Qwen2: qwen2SubGraph,
+    Qwen3: qwen3SubGraph,
   })
   // Prompt + triggerWords are common to both Qwen and Qwen 2. negativePrompt
   // is merged only inside the Qwen2 branch; its registration effect adds
@@ -163,4 +209,4 @@ export const qwenGraph = new DataGraph<QwenCtx, GenerationCtx>()
   .merge(promptGraph);
 
 // Export constants for use in components and handlers
-export { qwenAspectRatios, qwen2AspectRatios };
+export { qwenAspectRatios, qwen2AspectRatios, qwen3AspectRatios };

--- a/src/shared/data-graph/generation/seedance-graph.ts
+++ b/src/shared/data-graph/generation/seedance-graph.ts
@@ -8,9 +8,10 @@
  * - v2: Standard quality video generation
  * - v2-fast: Faster generation with lower cost
  * - v2-mini: Smaller/cheaper variant (480p/720p only)
+ * - v2.5: Latest generation, up to 30s clips
  *
  * Supports txt2vid and img2vid workflows.
- * Features: aspect ratio, duration (4-15s), resolution (480p/720p),
+ * Features: aspect ratio, duration, resolution (480p/720p/1080p),
  * generateAudio toggle, seed, and images (for I2V).
  */
 
@@ -43,6 +44,7 @@ export const seedanceVersionIds = {
   v2: 2864671,
   'v2-fast': 2868300,
   'v2-mini': 3069790,
+  'v2.5': 3207504,
 } as const;
 
 /** Options for seedance version selector */
@@ -50,6 +52,7 @@ const seedanceVersionOptions = [
   { label: 'v2', value: seedanceVersionIds.v2 },
   { label: 'v2 fast', value: seedanceVersionIds['v2-fast'] },
   { label: 'v2 mini', value: seedanceVersionIds['v2-mini'] },
+  { label: 'v2.5', value: seedanceVersionIds['v2.5'] },
 ];
 
 // =============================================================================
@@ -74,8 +77,7 @@ const seedanceResolutions = [
   { label: '720p', value: '720p' },
 ] as const;
 
-// v2-fast does not support 1080p
-const seedanceResolutionsV2 = [
+const seedanceResolutionsHd = [
   { label: '480p', value: '480p' },
   { label: '720p', value: '720p' },
   { label: '1080p', value: '1080p' },
@@ -113,8 +115,9 @@ export const seedanceGraph = new DataGraph<{ ecosystem: string; workflow: string
   .node(
     'resolution',
     (ctx) => {
-      const supports1080p = ctx.model?.id === seedanceVersionIds.v2;
-      const options = supports1080p ? seedanceResolutionsV2 : seedanceResolutions;
+      const supports1080p =
+        ctx.model?.id === seedanceVersionIds.v2 || ctx.model?.id === seedanceVersionIds['v2.5'];
+      const options = supports1080p ? seedanceResolutionsHd : seedanceResolutions;
       return enumNode({ options, defaultValue: '720p' });
     },
     ['model']
@@ -129,7 +132,16 @@ export const seedanceGraph = new DataGraph<{ ecosystem: string; workflow: string
       }),
     ['resolution']
   )
-  .node('duration', sliderNode({ min: 4, max: 15, defaultValue: 5 }))
+  .node(
+    'duration',
+    (ctx) =>
+      sliderNode({
+        min: 4,
+        max: ctx.model?.id === seedanceVersionIds['v2.5'] ? 30 : 15,
+        defaultValue: 5,
+      }),
+    ['model']
+  )
   .node(
     'generateAudio',
     () => ({


### PR DESCRIPTION
Bumps @civitai/client to 0.2.0-beta.86, which ships the types both features need: QwenApiCreateImageGenInput/QwenApiEditImageGenInput (engine 'qwen', Alibaba DashScope) and SeedanceModel.V2_5.

Qwen 3 gets its own ecosystem (ECO.Qwen3 = 80, BM.Qwen3 = 99) rather than joining ECO.Qwen or ECO.Qwen2: it runs on a third engine, ships no open weights, and no resources cross to it. Supports txt2img and img2img:edit. Prompt rewriting is exposed via the existing enablePromptExpansion node so it reuses the rendered "Enhance prompt" switch instead of adding a control.

Seedance 2.5 lands as a version on the existing ecosystem, matching how the client models it and how v2/v2-fast/v2-mini are already handled. It raises max duration to 30s and adds 1080p; both are model-dependent, so those nodes now derive from ctx.model.

Also allows owners/moderators to see the Generate button on draft ExternalGeneration versions. Those carry no weights, so generating is the only way to verify the wiring before publishing.

Needs manual SQL per environment (baseModel, EcosystemCheckpoints, GenerationBaseModel) - do not apply before this ships, since 'Qwen 3' is an unknown base model to deployed code.