### PR TITLE
fix(ui): stop tooltips inverting against the page

### DIFF
--- a/src/components/Account/SettingsCard.tsx
+++ b/src/components/Account/SettingsCard.tsx
@@ -150,7 +150,6 @@ export function SettingsCard() {
               <ToggleableFeatures data={assistantToggleableFeatures} />
               <Tooltip
                 withArrow
-                color="gray"
                 offset={-10}
                 label={!flags.assistantPersonality ? 'Available to subscribers only' : undefined}
                 disabled={flags.assistantPersonality}

--- a/src/components/BrowsingMode/BrowsingMode.tsx
+++ b/src/components/BrowsingMode/BrowsingMode.tsx
@@ -71,7 +71,7 @@ export function BrowsingModeMenu({ closeMenu }: { closeMenu?: () => void }) {
                 <Group align="flex-start">
                   <Text style={{ lineHeight: 1 }}>Browsing Level</Text>
                   {showNsfw && features.newOrderGame && (
-                    <Tooltip label="Help us improve by playing!" withArrow color="dark">
+                    <Tooltip label="Help us improve by playing!" withArrow>
                       <Button
                         onClick={closeMenu}
                         component={Link}

--- a/src/components/Bug/Bugs.tsx
+++ b/src/components/Bug/Bugs.tsx
@@ -229,7 +229,7 @@ const BugItem = ({
               <span className="inline-block text-lg font-bold">
                 {isNew && (
                   <div className="mr-1 inline-block">
-                    <Tooltip label="Updated" color="dark" withArrow withinPortal>
+                    <Tooltip label="Updated" withArrow withinPortal>
                       <IconPointFilled color="green" size={18} />
                     </Tooltip>
                   </div>

--- a/src/components/Downloads/DownloadCard.tsx
+++ b/src/components/Downloads/DownloadCard.tsx
@@ -159,7 +159,6 @@ export function DownloadCard({ download, onHide }: Props) {
                 <IconClock size={12} className="text-gray-5 dark:text-dark-3" />
                 <Tooltip
                   label={downloadDate.format('MMMM D, YYYY h:mm A')}
-                  color="dark"
                   withArrow
                   withinPortal
                 >
@@ -172,7 +171,7 @@ export function DownloadCard({ download, onHide }: Props) {
 
             {/* Delete Button - vertically centered */}
             <div className="flex items-center pr-4">
-              <Tooltip label="Remove from history" color="dark" withArrow withinPortal>
+              <Tooltip label="Remove from history" withArrow withinPortal>
                 <ActionIcon
                   variant="subtle"
                   color="gray"

--- a/src/components/Downloads/DownloadFiltersDropdown.tsx
+++ b/src/components/Downloads/DownloadFiltersDropdown.tsx
@@ -69,7 +69,7 @@ function FilterButton({
   return (
     <Popover position="bottom-start" withArrow shadow="md" withinPortal>
       <Popover.Target>
-        <Tooltip label={label} color="dark" withArrow withinPortal>
+        <Tooltip label={label} withArrow withinPortal>
           <ActionIcon
             variant={isActive ? 'light' : 'subtle'}
             color={isActive ? 'blue' : 'gray'}

--- a/src/components/IconBadge/IconBadge.tsx
+++ b/src/components/IconBadge/IconBadge.tsx
@@ -40,7 +40,7 @@ export const IconBadge = forwardRef<HTMLDivElement, IconBadgeProps>(
     if (!tooltip) return badge;
 
     return (
-      <Tooltip label={tooltip} position="top" color="dark" withArrow>
+      <Tooltip label={tooltip} position="top" withArrow>
         {badge}
       </Tooltip>
     );

--- a/src/components/ImageGeneration/GenerationStatusBadge.tsx
+++ b/src/components/ImageGeneration/GenerationStatusBadge.tsx
@@ -30,7 +30,6 @@ export function GenerationStatusBadge({
     <Tooltip
       label={tooltipLabel}
       withArrow
-      color="dark"
       maw={300}
       multiline
       withinPortal

--- a/src/components/ImageGeneration/GenerationTabs.tsx
+++ b/src/components/ImageGeneration/GenerationTabs.tsx
@@ -163,7 +163,6 @@ function GenerationTabsContent({ fullScreen }: { fullScreen?: boolean }) {
                     <Tooltip
                       label={label}
                       position="bottom"
-                      color="dark"
                       openDelay={200}
                       offset={10}
                     >

--- a/src/components/ImageGeneration/QueueItem.tsx
+++ b/src/components/ImageGeneration/QueueItem.tsx
@@ -672,7 +672,6 @@ function WorkflowStatusAlert({
 const tooltipProps: Omit<TooltipProps, 'children' | 'label'> = {
   withinPortal: true,
   withArrow: true,
-  color: 'dark',
   zIndex: imageGenerationDrawerZIndex + 1,
 };
 

--- a/src/components/ImageMeta/ImageMeta.tsx
+++ b/src/components/ImageMeta/ImageMeta.tsx
@@ -146,7 +146,7 @@ export function ImageMeta({
                 {(label === 'Prompt' || label === 'Negative prompt') && (
                   <CopyButton value={value as string}>
                     {({ copied, copy }) => (
-                      <Tooltip label={`Copy ${label.toLowerCase()}`} color="dark" withArrow>
+                      <Tooltip label={`Copy ${label.toLowerCase()}`} withArrow>
                         <LegacyActionIcon
                           variant="transparent"
                           size="xs"
@@ -373,7 +373,7 @@ function GenerationDataButton({
 
   if (!iconOnly) return button;
   return (
-    <Tooltip label={label} color="dark" withArrow withinPortal>
+    <Tooltip label={label} withArrow withinPortal>
       {button}
     </Tooltip>
   );

--- a/src/components/Leaderboard/RankBadge.tsx
+++ b/src/components/Leaderboard/RankBadge.tsx
@@ -32,7 +32,7 @@ export const RankBadge = ({
   const hasLeaderboardCosmetic = !!rank.leaderboardCosmetic;
 
   return (
-    <Tooltip label={`${rank.leaderboardTitle} Rank`} position="top" color="dark" withArrow>
+    <Tooltip label={`${rank.leaderboardTitle} Rank`} position="top" withArrow>
       <Group gap={0} wrap="nowrap" style={{ position: 'relative' }}>
         {rank.leaderboardCosmetic ? (
           <Box pos="relative" style={{ zIndex: 2 }}>

--- a/src/components/Model/ModelVersions/ModelVersionReview.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionReview.tsx
@@ -16,7 +16,6 @@ export function ModelVersionReview({ modelId, versionId, thumbsDownCount, thumbs
       <Tooltip
         label={`${Math.round(positiveRating * 100)}% of reviews are positive`}
         openDelay={500}
-        color="gray"
       >
         <div>
           <Anchor

--- a/src/components/Questions/ReactionBadge.tsx
+++ b/src/components/Questions/ReactionBadge.tsx
@@ -13,7 +13,7 @@ export function ReactionBadge({
   return !tooltip ? (
     button
   ) : (
-    <Tooltip label={tooltip} withArrow withinPortal openDelay={200} color="dark">
+    <Tooltip label={tooltip} withArrow withinPortal openDelay={200}>
       {button}
     </Tooltip>
   );

--- a/src/components/Referrals/ReferralDashboard.tsx
+++ b/src/components/Referrals/ReferralDashboard.tsx
@@ -938,7 +938,7 @@ function ReferralCodeBlock({ code, shareLink }: { code: string; shareLink: strin
               </div>
               <CopyButton value={code}>
                 {({ copied, copy }) => (
-                  <Tooltip label={copied ? 'Copied' : 'Copy code'} color="dark" withArrow>
+                  <Tooltip label={copied ? 'Copied' : 'Copy code'} withArrow>
                     <ActionIcon
                       size="lg"
                       variant="subtle"
@@ -1070,7 +1070,7 @@ function StatBlock({
             </Text>
             {infoSlot ??
               (tooltip && (
-                <Tooltip label={tooltip} color="dark" multiline maw={260} withArrow>
+                <Tooltip label={tooltip} multiline maw={260} withArrow>
                   <IconInfoCircle
                     size={12}
                     style={{ color: 'var(--mantine-color-dimmed)', cursor: 'help' }}
@@ -1244,7 +1244,7 @@ function TierPerksPopover({ tier }: { tier: string }) {
   return (
     <Popover width={320} position="bottom-end" shadow="lg" withArrow withinPortal>
       <Popover.Target>
-        <Tooltip label="See tier perks" color="dark" withArrow>
+        <Tooltip label="See tier perks" withArrow>
           <ActionIcon variant="subtle" size="sm" aria-label="View tier perks">
             <IconInfoCircle size={16} />
           </ActionIcon>
@@ -1511,7 +1511,7 @@ function ExpiringTokensIndicator({
   return (
     <Popover width={260} position="bottom-start" shadow="lg" withArrow withinPortal>
       <Popover.Target>
-        <Tooltip label="Tickets expiring soon" color="dark" withArrow>
+        <Tooltip label="Tickets expiring soon" withArrow>
           <ActionIcon variant="subtle" color="yellow" size="sm" aria-label="View expiring tickets">
             <IconAlertTriangle size={16} />
           </ActionIcon>

--- a/src/components/Referrals/ReferralDashboardFull.tsx
+++ b/src/components/Referrals/ReferralDashboardFull.tsx
@@ -655,7 +655,7 @@ function ReferralCodeBlock({ code, shareLink }: { code: string; shareLink: strin
               </div>
               <CopyButton value={code}>
                 {({ copied, copy }) => (
-                  <Tooltip label={copied ? 'Copied' : 'Copy code'} color="dark" withArrow>
+                  <Tooltip label={copied ? 'Copied' : 'Copy code'} withArrow>
                     <ActionIcon
                       size="lg"
                       variant="subtle"
@@ -787,7 +787,7 @@ function StatBlock({
             </Text>
             {infoSlot ??
               (tooltip && (
-                <Tooltip label={tooltip} color="dark" multiline maw={260} withArrow>
+                <Tooltip label={tooltip} multiline maw={260} withArrow>
                   <IconInfoCircle
                     size={12}
                     style={{ color: 'var(--mantine-color-dimmed)', cursor: 'help' }}
@@ -1014,7 +1014,7 @@ function TierPerksPopover({ tier }: { tier: string }) {
   return (
     <Popover width={320} position="bottom-end" shadow="lg" withArrow withinPortal>
       <Popover.Target>
-        <Tooltip label="See tier perks" color="dark" withArrow>
+        <Tooltip label="See tier perks" withArrow>
           <ActionIcon variant="subtle" size="sm" aria-label="View tier perks">
             <IconInfoCircle size={16} />
           </ActionIcon>
@@ -1283,7 +1283,7 @@ function ExpiringTokensIndicator({
   return (
     <Popover width={260} position="bottom-start" shadow="lg" withArrow withinPortal>
       <Popover.Target>
-        <Tooltip label="Tokens expiring soon" color="dark" withArrow>
+        <Tooltip label="Tokens expiring soon" withArrow>
           <ActionIcon variant="subtle" color="yellow" size="sm" aria-label="View expiring tokens">
             <IconAlertTriangle size={16} />
           </ActionIcon>

--- a/src/components/Referrals/ReferralTimelineProgress.tsx
+++ b/src/components/Referrals/ReferralTimelineProgress.tsx
@@ -90,7 +90,6 @@ export function ReferralTimelineProgress({ grant }: { grant: ReferralGrant | nul
               return (
                 <Tooltip
                   key={`${segment.tier}-${index}`}
-                  color="dark"
                   label={
                     <Stack gap={4}>
                       <Text size="sm" fw={500} tt="capitalize">

--- a/src/components/User/Username.tsx
+++ b/src/components/User/Username.tsx
@@ -67,7 +67,6 @@ export const BadgeDisplay = ({
 
   return (
     <Tooltip
-      color="dark"
       label={
         <div style={{ textAlign: 'center', padding: 4 }}>
           <div>{badge.name}</div>

--- a/src/components/UserAvatar/UserAvatarSimple.tsx
+++ b/src/components/UserAvatar/UserAvatarSimple.tsx
@@ -116,7 +116,7 @@ export function UserAvatarSimple({
             {username}
           </Text>
           {badge?.data.url && (
-            <Tooltip color="dark" label={badge.name} withArrow withinPortal>
+            <Tooltip label={badge.name} withArrow withinPortal>
               <div style={{ display: 'flex', width: 28 }}>
                 <EdgeMedia
                   src={badge.data.url}

--- a/src/pages/bounties/[id]/[[...slug]].tsx
+++ b/src/pages/bounties/[id]/[[...slug]].tsx
@@ -557,7 +557,7 @@ const BountySidebar = ({ bounty }: { bounty: BountyGetById }) => {
           linkToProfile
         />
         {b.awardedToId && (
-          <Tooltip label="This supporter has already awarded an entry" color="dark" withinPortal>
+          <Tooltip label="This supporter has already awarded an entry" withinPortal>
             <IconTrophy color={config.color} fill={config.color} size={18} />
           </Tooltip>
         )}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -101,6 +101,14 @@ button, input, optgroup, select, textarea {
   flex-shrink: 0;
 }
 
+/* Mantine's default inverts the tooltip against the page. Setting the vars it
+   already reads (rather than `background`/`color`) keeps a per-call-site
+   `color` prop winning, since that prop sets the same vars inline. */
+.mantine-Tooltip-tooltip {
+  --tooltip-bg: light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
+  --tooltip-color: light-dark(var(--mantine-color-black), var(--mantine-color-white));
+}
+
 .mantine-Divider-label {
   font-size: var(--mantine-font-size-sm);
   font-weight: bold;


### PR DESCRIPTION
## Problem

Tooltips render light-on-dark in light mode and dark-on-light in dark mode.

This is Mantine's own default, and it inverts **deliberately** — the "tooltips contrast with the page" convention. `src/providers/ThemeProvider.tsx` only ever set `withArrow: true`, never a colour, so the behaviour arrived with the Mantine v7 migration (#1717) and changed app-wide under everyone.

Justin's call: tooltips should **match the surface** — light tooltip in light mode, dark tooltip in dark mode.

## The fix

```css
.mantine-Tooltip-tooltip {
  --tooltip-bg: light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
  --tooltip-color: light-dark(var(--mantine-color-black), var(--mantine-color-white));
}
```

Mantine's rules read exactly these two vars, with the per-scheme colour as the `var()` fallback:

```css
:where([data-mantine-color-scheme='light']) .m_1b3c8819 {
  background-color: var(--tooltip-bg, var(--mantine-color-gray-9));
  color: var(--tooltip-color, var(--mantine-color-white));
}
```

Three consequences worth stating, because they are why this is six lines rather than a theme rewrite:

- Setting the **vars** rather than `background`/`color` means load order and cascade layers are irrelevant — the fallback simply never applies.
- A call-site `color` prop still wins, because that prop sets the same vars as an inline style.
- The arrow is `background-color: inherit`, so it follows for free.

`light-dark()` resolves correctly because Mantine drives the `color-scheme` property off `:root[data-mantine-color-scheme]` (`:root { color-scheme: var(--mantine-color-scheme) }`) — checked in the shipped stylesheet, not assumed. The function is already used ~530 times across this repo.

Dark uses `dark-4` (`#373A40`) rather than Mantine's own dark-mode `gray-9` (`#212529`): gray-9 sits almost exactly on this app's dark-6/dark-7 surfaces and the tooltip would nearly disappear.

## Call-site cleanup

27 hand-rolled overrides were compensating for the old default. Each one now actively fights the new one, so they go in the same commit — the before/after is one decision.

- 24 × `color="dark"` on `<Tooltip>`
- 2 × `color="gray"` (`SettingsCard.tsx`, `ModelVersionReview.tsx`) — same paper-over, different shade
- 1 × `color: 'dark'` inside a shared `TooltipProps` object (`QueueItem.tsx:675`)

That last one is the reason to grep for more than JSX: a `<Tooltip ... color=` search never sees it. Zero call sites used `styles=`/`classNames=` to override tooltip colour, so the `color` prop was the only escape hatch in use.

## Verification

- `pnpm run typecheck` — clean, 0 errors.
- ESLint on the touched files adds no new warnings (`QueueItem.tsx`'s 8 are pre-existing unused-import / `any` noise).
- `globals.css` is **not** prettier-clean on `main`; running prettier over it added 19 lines of unrelated reformatting, so that was reverted and the diff is only the new block.

**Not verified: no visual confirmation.** Nothing here has been eyeballed in a browser. The mechanism is checked against Mantine's shipped CSS, but the colour choice is a judgement call and deserves a look in both themes — particularly `ImageMeta` and `GenerationTabs`, which sit on surfaces that may be intentionally dark and where "match the surface" could read differently than intended.

The unit suite was not cleared; per Justin, skipped for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)