### PR TITLE
chore(dev-server): spoke apps, branch-switch survival, and per-worktree env

### DIFF
--- a/.claude/skills/dev-server/.env.example
+++ b/.claude/skills/dev-server/.env.example
@@ -17,3 +17,25 @@ RGB_PROXY_PATH=../rgb-proxy
 AUTH_HUB_ENABLED=false
 AUTH_HUB_PATH=apps/auth
 AUTH_HUB_PORT=5173
+
+# In-place branch switching — the daemon watches HEAD and leaves the dev server running through a
+# checkout, so only what changed recompiles. A restart is forced only when node_modules or the
+# generated Prisma client has to change underneath the process.
+BRANCH_WATCH_ENABLED=false
+BRANCH_WATCH_INTERVAL=1000     # ms between HEAD polls (reads .git/HEAD, no subprocess)
+BRANCH_SWITCH_DEBOUNCE=3000    # ms of HEAD quiet before reacting
+KILL_ON_BRANCH_SWITCH=false    # escape hatch: restore kill-and-restart, at a full cold compile
+AUTO_INSTALL=false             # pnpm install on lockfile change; db:generate on schema change
+
+# Routes compiled in the background once ready, and after every branch switch. Comma-separated;
+# EMPTY MEANS NO PREWARMING, which is the default. Prewarm-on-start also needs HEALTH_CHECK_URL
+# set — readiness detected from log patterns alone does not trigger it.
+# Detail pages are separate routes from their list pages, so include a specific id if you want one.
+PREWARM_ROUTES=
+PREWARM_TIMEOUT=300000
+
+# Give each branch its own build dir (.next/branches/<slug>) instead of sharing .next. Only
+# meaningful when the server actually restarts, and each dir grows to several GB.
+PER_BRANCH_DIST_DIR=false
+DIST_CACHE_KEEP=4              # per-branch build dirs to retain (PER_BRANCH_DIST_DIR only)
+DIST_CACHE_MAX_GB=40           # total budget across those dirs; LRU-evicted on start

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -99,6 +99,7 @@ Run `node .claude/skills/dev-server/console.mjs` (or `npm run dev:daemon`) for a
 | `x` | Stop session + exit |
 | `R` | Toggle RGB proxy (start/stop) |
 | `A` | Toggle auth hub (start/stop) |
+| `s` or `Tab` | Switch to the next session (only shown when more than one is running) |
 | `q` | Quit dashboard (server keeps running) |
 | `K` | Kill daemon + quit |
 
@@ -231,6 +232,119 @@ The hub works behind the RGB proxy too. When you browse dev at `https://civitai-
 - **Email magic-link** works out of the box (`EMAIL_*` are set) — no external console changes needed.
 - **Social providers** (GitHub/Google/Discord/Reddit) additionally require the provider console to allow the hub redirect URI `http://localhost:5173/login/<provider>/callback`. Until that's added they fail with `redirect_uri_mismatch`.
 - Any **legacy** `civitai-token` cookie already in your browser still resolves without the hub (verify-only decode) and upgrades to a `civ-token` on next request once the hub is up.
+
+## In-place branch switching
+
+Just run `git checkout <branch>`. The daemon handles the rest — no `rm -rf .next`, no manual reinstall.
+
+What happens on a HEAD move:
+
+1. **The dev server keeps running.** It is not killed. Its in-memory module graph survives the checkout, so only what actually changed recompiles.
+2. **Debounce** (`BRANCH_SWITCH_DEBOUNCE`, default 3s of HEAD quiet) so a rebase or a fast double-switch settles first.
+3. **A restart only if it's unavoidable** — `pnpm-lock.yaml` changed (install, then restart) or `prisma/schema.prisma` changed (`db:generate`, then restart). Those swap `node_modules` and the generated client, which a live process can't pick up. Nothing else forces one.
+4. **Re-prewarm** so the recompile lands on the daemon instead of your next click.
+
+### Why not kill it
+
+That was the original design, on the theory that a checkout mutating the tree under Turbopack's watcher is what wedged the server. Measured, that theory was wrong — killing it is simply worse. Same routes, same machine, switching between two branches:
+
+| | `/models` | `/images` |
+|---|---|---|
+| Cold start after a kill | **42.6s** | 3.1s |
+| Left running, first switch | 23.0s | 0.3s |
+| Left running, subsequent switches | **7.7-9.2s** | 1.0-1.6s |
+
+The server stayed healthy across every switch. Routes it wasn't asked to rebuild stayed warm the whole time.
+
+`KILL_ON_BRANCH_SWITCH=true` restores the old behaviour if a checkout ever does wedge it.
+
+### Per-branch build dirs (off by default)
+
+`PER_BRANCH_DIST_DIR=true` gives each branch its own `.next/branches/<slug>` via `distDir: process.env.NEXT_DIST_DIR || '.next'` in `next.config.mjs`. It only matters when the server actually restarts, so it is off now that switches keep the process alive — and each dir grows to ~4 GB. Sharing one `.next` also lets unchanged modules stay valid across branches, which per-branch dirs threw away.
+
+### Prewarming
+
+`PREWARM_ROUTES` (default `/,/models,/images`) is compiled in the background the moment the server reports ready — on start and after every branch switch. Cold-compiling the first route costs ~45s because it pulls the whole shared graph; prewarming moves that off you.
+
+Measured on a branch with no cache at all:
+
+| | |
+|---|---|
+| Daemon prewarm (background) | `/` 45.2s, `/models` 3.5s, `/images` 2.9s — done at t+62s |
+| Then opening those pages | **0.07-0.14s** |
+| Opening a route *not* in the list (`/articles`) | 10.3s |
+
+Add the routes you actually land on. The cost of a longer list is only more background work, but the list is sequential — parallel requests contend for the same compiler and make the first route land later. Set it empty to disable.
+
+**List pages don't warm their detail pages.** `/models` and `/models/[id]/[[...slug]]` are separate routes with separate compiles — a warm `/models` leaves a model page at a ~30s cold hit. That's why the default list includes a specific model id; the id is arbitrary, only the route it resolves to matters. Redirects are followed, so `/models/<id>` reaches the slug route fine.
+
+The skill `.env` is re-read on every session start, so edits to `PREWARM_ROUTES` apply at the next branch switch without restarting the daemon.
+
+### Why the cache is so big
+
+It is not per-page. Measured from an empty store on this repo:
+
+| Step | Store size | Response |
+|---|---|---|
+| boot + `/api/health` | 1 MB | — |
+| `/models` (first real page) | **3995 MB** | 49.9s |
+| `/images` | 2662 MB | 3.8s |
+| `/articles` | 2822 MB | 8.2s |
+| `/bounties` | 3762 MB | 28.3s |
+
+The first route compiled drags in the whole shared graph — the pages-router `_app` plus its transitive world — and that costs ~4 GB on its own. Every route after adds only a few hundred MB, and the total **oscillates rather than climbs**: it dropped from 3995 to 2662 MB while more routes were being compiled, because compaction reclaimed superseded segments. The store's `LOG` confirms it: single commits of up to 3.4M keys, with `MERGE`/`Compaction` passes running throughout.
+
+So the working set for this app is roughly **2.5-4 GB per branch**, and it is real data, not a leak. It's large because the graph is large (3.4M cache keys, ~210k files in `node_modules`). Source maps are not the driver — they are 0.3% of a sampled segment.
+
+It earns the space: **45.8s cold vs 4.3s warm** on the same route after a restart. Disabling `turbopackFileSystemCacheForDev` trades a 10x slower restart for disk, which is the wrong trade on a machine with room.
+
+Dirs are evicted LRU on every start against **both** budgets: the `DIST_CACHE_KEEP` most recent (default 4) and `DIST_CACHE_MAX_GB` total (default 40). The size cap does the real work — with a ~4 GB working set per branch, a count cap alone lets four branches reach ~16 GB. The active branch is never evicted; if it alone blows the budget the daemon logs a warning instead.
+
+Knobs live in `.claude/skills/dev-server/.env`: `BRANCH_WATCH_ENABLED`, `BRANCH_WATCH_INTERVAL`, `BRANCH_SWITCH_DEBOUNCE`, `DIST_CACHE_KEEP`, `AUTO_INSTALL`.
+
+## Worktrees
+
+One session per worktree, each on its own port (3000, 3001, …). Start one with:
+
+```bash
+node .claude/skills/dev-server/cli.mjs start /path/to/worktree
+```
+
+What's already handled:
+
+- **No per-worktree `.env` needed.** Sessions fall back to the main project root's `.env` (`mainEnvPath`). Verified: a worktree with no `.env` at all boots healthy.
+- **Auth on secondary ports.** `NEXTAUTH_URL`, `NEXTAUTH_URL_INTERNAL`, and `NEXT_PUBLIC_BASE_URL` are rewritten to `http://localhost:<port>`, so logins work on non-3000 sessions instead of bouncing to the primary.
+- **Independent branch watching + prewarming** per session.
+
+Fresh worktrees still need `pnpm install` (or a `node_modules` junction) and `git submodule update --init event-engine-common`.
+
+### Cache cannot be shared between worktrees
+
+Tested directly — copy a warm 12 GB cache from one worktree into another and Turbopack dies on startup:
+
+```
+FATAL: An unexpected Turbopack error occurred.
+Error [TurbopackInternalError]: failed to create junction point at ".next\dev\node_modules\..."
+Caused by: removal of existing symbolic link or junction point failed: The directory is not empty. (os error 145)
+```
+
+Two independent blockers: `.next/dev/node_modules` holds junction points that don't survive a copy, and cache keys embed the absolute project path (~3,000 occurrences of `C:/Dev/Repos/work/model-share` in a single 253 MB segment), so most entries would miss even if it did start.
+
+A single `.next` shared by concurrent sessions is worse — two dev servers writing one LSM store corrupts it.
+
+So a new worktree pays one cold build. The mitigation is prewarming: start the session and let the daemon absorb it in the background rather than waiting on your first click.
+
+## RGB proxy and multiple sessions
+
+`rgb-proxy/index.mjs` registers all three colors — plus the `civitai-dev.cyan` alias — against a hardcoded `http://localhost:3000`. So the color hostnames always reach whichever session holds port 3000; other sessions are reachable on `localhost:<port>` only. The TUI says which case a session is in rather than printing URLs that would silently land on another worktree.
+
+## Windows Defender
+
+Real-time protection scans all ~210k files in `node_modules` plus every build-cache write. Run once from an **elevated** PowerShell:
+
+```powershell
+powershell -File .claude\skills\dev-server\scripts\defender-exclusions.ps1
+```
 
 ## Notes
 

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -40,6 +40,8 @@ node .claude/skills/dev-server/cli.mjs stop <session-id>
 | `stop <session-id>` | Stop a session |
 | `restart <session-id>` | Restart a session |
 | `rgb [subcmd]` | RGB proxy control (`status`\|`start`\|`stop`\|`restart`\|`logs`) |
+| `app` | List the spoke apps and their state |
+| `app <name> [subcmd]` | Spoke app control (`status`\|`start`\|`stop`\|`restart`\|`logs`) |
 | `auth [subcmd]` | Auth hub control (`status`\|`start`\|`stop`\|`restart`\|`logs`) |
 | `shutdown` | Shutdown the daemon |
 
@@ -135,6 +137,56 @@ In the dashboard TUI, press `R` to toggle the proxy.
 ### Admin / sudo requirement
 
 Redbird binds ports 80 and 443. On Windows the daemon must be launched from an elevated terminal; on macOS/Linux start it with `sudo`. If it fails the daemon surfaces `lastError` via `/rgb` status and in RGB proxy logs.
+
+## Spoke Apps
+
+The SvelteKit apps under `apps/` (moderator, creator-studio, storage, notifications) run through the
+daemon the same way the auth hub does, so their logs land in the same place and either a human or an
+agent can start one and read the output.
+
+```bash
+node .claude/skills/dev-server/cli.mjs app                      # list all, with state and URL
+node .claude/skills/dev-server/cli.mjs app moderator start
+node .claude/skills/dev-server/cli.mjs app moderator logs
+node .claude/skills/dev-server/cli.mjs app moderator restart
+node .claude/skills/dev-server/cli.mjs app moderator stop
+```
+
+| App | Port |
+|-----|------|
+| moderator | 5174 |
+| creator-studio | 5175 |
+| storage | 5176 |
+| notifications | 5177 |
+
+Ports are fixed rather than auto-assigned, so a redirect between two apps (moderator sends you to the
+auth hub to sign in) always lands in the same place. `--strictPort` means a collision fails loudly
+instead of silently drifting to the next free port.
+
+Each app needs its own `.env` in its directory — vite loads it, the daemon does not inject it. Start
+from that app's `.env.example`.
+
+**Most spoke pages need the auth hub running**, since they redirect to it to sign in:
+
+```bash
+node .claude/skills/dev-server/cli.mjs auth start
+node .claude/skills/dev-server/cli.mjs app moderator start
+```
+
+### They bind to 127.0.0.1, deliberately
+
+The daemon starts every vite sidecar with `--host 127.0.0.1`. Vite's default binds IPv6 loopback
+only (`[::1]`), and a Windows hosts file that defines `localhost` explicitly lists `127.0.0.1`
+first — so the browser dials an IPv4 socket nothing is listening on and hangs with no error
+anywhere. curl papers over it by falling back to `::1` after a couple hundred milliseconds, which
+makes it look like a slow server rather than a broken one. Forcing the IPv4 bind removes the whole
+class of problem.
+
+### First request is slow
+
+Vite compiles routes on demand in dev. The first hit on a cold app can take **25 seconds or more**
+(the auth hub's `/login` is the worst offender); every hit after is a few hundred milliseconds. A
+browser sitting on a white page right after startup is usually this, not a hang.
 
 ## Auth Hub
 

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -264,7 +264,9 @@ The server stayed healthy across every switch. Routes it wasn't asked to rebuild
 
 ### Prewarming
 
-`PREWARM_ROUTES` (default `/,/models,/images`) is compiled in the background the moment the server reports ready — on start and after every branch switch. Cold-compiling the first route costs ~45s because it pulls the whole shared graph; prewarming moves that off you.
+`PREWARM_ROUTES` is compiled in the background once the server reports ready, and again after every branch switch. Cold-compiling the first route costs ~45s because it pulls the whole shared graph; prewarming moves that off you.
+
+**It is empty by default and the skill `.env` is gitignored, so a fresh checkout does no prewarming at all** — set `PREWARM_ROUTES` yourself (see `.env.example`). Prewarm-on-start also needs `HEALTH_CHECK_URL` configured: readiness detected from log patterns alone does not trigger it. Prewarm after a branch switch runs either way.
 
 Measured on a branch with no cache at all:
 
@@ -276,9 +278,9 @@ Measured on a branch with no cache at all:
 
 Add the routes you actually land on. The cost of a longer list is only more background work, but the list is sequential — parallel requests contend for the same compiler and make the first route land later. Set it empty to disable.
 
-**List pages don't warm their detail pages.** `/models` and `/models/[id]/[[...slug]]` are separate routes with separate compiles — a warm `/models` leaves a model page at a ~30s cold hit. That's why the default list includes a specific model id; the id is arbitrary, only the route it resolves to matters. Redirects are followed, so `/models/<id>` reaches the slug route fine.
+**List pages don't warm their detail pages.** `/models` and `/models/[id]/[[...slug]]` are separate routes with separate compiles — a warm `/models` leaves a model page at a ~30s cold hit. So include a specific model id in your list; the id is arbitrary, only the route it resolves to matters. Redirects are followed, so `/models/<id>` reaches the slug route fine.
 
-The skill `.env` is re-read on every session start, so edits to `PREWARM_ROUTES` apply at the next branch switch without restarting the daemon.
+The skill `.env` is re-read on every session **start**. A keep-alive branch switch does not restart the session, so edits to `PREWARM_ROUTES` reach it only after a switch that forces a restart (lockfile or schema change) or an explicit `restart`.
 
 ### Why the cache is so big
 
@@ -300,7 +302,7 @@ It earns the space: **45.8s cold vs 4.3s warm** on the same route after a restar
 
 Dirs are evicted LRU on every start against **both** budgets: the `DIST_CACHE_KEEP` most recent (default 4) and `DIST_CACHE_MAX_GB` total (default 40). The size cap does the real work — with a ~4 GB working set per branch, a count cap alone lets four branches reach ~16 GB. The active branch is never evicted; if it alone blows the budget the daemon logs a warning instead.
 
-Knobs live in `.claude/skills/dev-server/.env`: `BRANCH_WATCH_ENABLED`, `BRANCH_WATCH_INTERVAL`, `BRANCH_SWITCH_DEBOUNCE`, `DIST_CACHE_KEEP`, `AUTO_INSTALL`.
+Knobs live in `.claude/skills/dev-server/.env`, which is gitignored — copy `.env.example`, which documents all of them: `BRANCH_WATCH_ENABLED`, `BRANCH_WATCH_INTERVAL`, `BRANCH_SWITCH_DEBOUNCE`, `KILL_ON_BRANCH_SWITCH`, `AUTO_INSTALL`, `PREWARM_ROUTES`, `PREWARM_TIMEOUT`, `PER_BRANCH_DIST_DIR`, `DIST_CACHE_KEEP`, `DIST_CACHE_MAX_GB`.
 
 ## Worktrees
 
@@ -312,7 +314,9 @@ node .claude/skills/dev-server/cli.mjs start /path/to/worktree
 
 What's already handled:
 
-- **No per-worktree `.env` needed.** Sessions fall back to the main project root's `.env` (`mainEnvPath`). Verified: a worktree with no `.env` at all boots healthy.
+- **A worktree's own `.env` wins.** A session loads `<worktree>/.env` when one exists, and falls back to the project root's `.env` only when it doesn't — so a worktree with no `.env` still boots healthy. The chosen file is logged as `Env: <path>` at session start and returned as `envPath` in session status.
+
+  **The two are not merged.** Whichever file is chosen supplies every key; nothing is inherited from the other. A worktree `.env` that is a partial copy will therefore be missing whatever it doesn't restate, and different files can point a session at a different database — check the `Env:` line if a session behaves unlike its neighbours.
 - **Auth on secondary ports.** `NEXTAUTH_URL`, `NEXTAUTH_URL_INTERNAL`, and `NEXT_PUBLIC_BASE_URL` are rewritten to `http://localhost:<port>`, so logins work on non-3000 sessions instead of bouncing to the primary.
 - **Independent branch watching + prewarming** per session.
 

--- a/.claude/skills/dev-server/cli.mjs
+++ b/.claude/skills/dev-server/cli.mjs
@@ -272,6 +272,49 @@ async function cmdAuth(subcmd) {
   console.log(JSON.stringify(result.data, null, 2));
 }
 
+async function cmdApp(name, subcmd) {
+  await ensureDaemon();
+
+  // `app` with no name lists what is registered and what each one is doing.
+  if (!name) {
+    const result = await daemonRequest('/apps');
+    if (!result.ok) {
+      console.error('Error:', result.error || JSON.stringify(result.data));
+      process.exit(1);
+    }
+    for (const app of result.data.apps) {
+      const state = app.ready ? 'ready' : app.status;
+      console.log(`${app.name.padEnd(16)} ${state.padEnd(9)} ${app.url}`);
+      if (app.lastError) console.log(`${' '.repeat(16)} ${app.lastError}`);
+    }
+    return;
+  }
+
+  const action = subcmd || 'status';
+  const routes = {
+    status: ['', 'GET'],
+    logs: ['/logs', 'GET'],
+    start: ['/start', 'POST'],
+    stop: ['/stop', 'POST'],
+    restart: ['/restart', 'POST'],
+  };
+  const route = routes[action];
+  if (!route) {
+    console.error(`Unknown app subcommand: ${action}`);
+    console.error('Usage: app <name> [status|start|stop|restart|logs]');
+    process.exit(1);
+  }
+
+  const [suffix, method] = route;
+  const result = await daemonRequest(`/app/${name}${suffix}`, method === 'POST' ? { method } : undefined);
+  if (!result.ok) {
+    console.error('Error:', result.error || result.data?.error || JSON.stringify(result.data));
+    if (result.data?.available) console.error('Available apps:', result.data.available.join(', '));
+    process.exit(1);
+  }
+  console.log(JSON.stringify(result.data, null, 2));
+}
+
 async function cmdShutdown() {
   const result = await daemonRequest('/shutdown', { method: 'POST' });
   if (!result.ok && result.status !== 0) {
@@ -318,6 +361,9 @@ switch (command) {
   case 'auth':
     cmdAuth(arg1);
     break;
+  case 'app':
+    cmdApp(arg1, process.argv[4]);
+    break;
   case 'shutdown':
     cmdShutdown();
     break;
@@ -334,6 +380,8 @@ Commands:
   restart <session-id> Restart a session
   rgb [subcmd]        RGB proxy control (status|start|stop|restart|logs)
   auth [subcmd]       Auth hub control (status|start|stop|restart|logs)
+  app                 List spoke apps (moderator, creator-studio, storage, notifications)
+  app <name> [subcmd] Spoke app control (status|start|stop|restart|logs)
   shutdown            Shutdown the daemon
 `);
     if (command) {

--- a/.claude/skills/dev-server/console.mjs
+++ b/.claude/skills/dev-server/console.mjs
@@ -198,6 +198,7 @@ async function cmdDashboard(initialWorktree) {
   let logCursor = -1;
   let logLines = [];        // all log entries (raw from daemon)
   let lastSession = null;
+  let allSessions = [];     // roster for the switcher, sorted by port
   let lastRgb = null;
   let lastAuth = null;
   let running = true;
@@ -287,6 +288,24 @@ async function cmdDashboard(initialWorktree) {
       case '\x03': // Ctrl+C
         exitDash();
         break;
+
+      // Cycle sessions. Each worktree is its own session, so this is how you move
+      // between branches you have running side by side.
+      case '\t':
+      case 's': {
+        if (allSessions.length < 2) {
+          flash('Only one session running');
+          break;
+        }
+        const idx = allSessions.findIndex((x) => x.id === sessionId);
+        const next = allSessions[(idx + 1) % allSessions.length];
+        sessionId = next.id;
+        logLines = [];
+        logCursor = 0;
+        lastSession = next;
+        flash(`Session ${next.id} — ${next.branch || '?'} :${next.port}`);
+        break;
+      }
 
       case '/':
       case 'f':
@@ -491,6 +510,15 @@ async function cmdDashboard(initialWorktree) {
       const uptimeStr = s.startedAt ? fmtUptime(Math.floor((Date.now() - new Date(s.startedAt).getTime()) / 1000)) : '';
       info = `${s.branch || '?'}  ${C.dim}port${C.r} ${s.port}  ${statusStr}  ${readyStr}  ${C.dim}up${C.r} ${uptimeStr}`;
     }
+    // Session counter, top-right. `n/N` so you know where you are in the rotation.
+    if (allSessions.length) {
+      const pos = allSessions.findIndex((x) => x.id === sessionId) + 1;
+      const label =
+        allSessions.length > 1
+          ? `${C.b}[${pos}/${allSessions.length} sessions]${C.r}${C.bgBlu}${C.wht}`
+          : `${C.dim}[1 session]${C.r}${C.bgBlu}${C.wht}`;
+      info = `${info}  ${label}`;
+    }
     const infoClean = stripAnsi(info);
     const pad = Math.max(0, cols - title.length - infoClean.length - 1);
     buf.push(CLR_LINE + C.bgBlu + C.wht + C.b + title + C.r + C.bgBlu + ' '.repeat(pad) + C.r + C.bgBlu + info + ' ' + C.r + '\n');
@@ -513,7 +541,17 @@ async function cmdDashboard(initialWorktree) {
         else if (st === 'error' || st === 'crashed') authStr = `  ${C.dim}AUTH:${C.r} ${C.red}${st}${C.r}`;
         else if (lastAuth.enabled) authStr = `  ${C.dim}AUTH:${C.r} ${C.ylw}${st}${C.r}`;
       }
-      buf.push(CLR_LINE + `  ${C.dim}URL:${C.r} ${url}  ${C.dim}Session:${C.r} ${s.id}  ${C.dim}${logCount}${C.r}${rgbStr}${authStr}\n`);
+      // The rgb-proxy backs localhost:3000 only, so the color hostnames reach whichever
+      // session holds that port. Say so explicitly rather than printing URLs that
+      // silently land on a different worktree.
+      let hostStr = '';
+      if (lastRgb?.status === 'running') {
+        hostStr =
+          s.port === 3000
+            ? `  ${C.dim}via${C.r} ${C.grn}civitai-dev.{red,green,blue}${C.r}`
+            : `  ${C.dim}via${C.r} ${C.ylw}localhost only (colors -> :3000)${C.r}`;
+      }
+      buf.push(CLR_LINE + `  ${C.dim}URL:${C.r} ${url}${hostStr}  ${C.dim}Session:${C.r} ${s.id}  ${C.dim}${logCount}${C.r}${rgbStr}${authStr}\n`);
     } else {
       buf.push(CLR_LINE + '\n');
     }
@@ -568,6 +606,7 @@ async function cmdDashboard(initialWorktree) {
         `${searchLabel}  ` +
         `${k('a', 'all')}  ` +
         `${C.dim}\u2502${C.r}  ` +
+        (allSessions.length > 1 ? `${k('s', 'ession')}  ` : '') +
         `${k('r', 'estart')}  ` +
         `${k('c', 'lear')}  ` +
         `${k('x', '-stop')}  ` +
@@ -588,6 +627,18 @@ async function cmdDashboard(initialWorktree) {
       const statusResult = await daemonRequest(`/sessions/${sessionId}`);
       if (statusResult.ok) {
         lastSession = statusResult.data.session;
+      }
+
+      // Roster for the session switcher + header count.
+      const listResult = await daemonRequest('/sessions');
+      if (listResult.ok) {
+        allSessions = (listResult.data.sessions || []).sort((a, b) => a.port - b.port);
+        // Current session disappeared (stopped elsewhere) — fall back to the first.
+        if (allSessions.length && !allSessions.some((x) => x.id === sessionId)) {
+          sessionId = allSessions[0].id;
+          logLines = [];
+          logCursor = 0;
+        }
       }
 
       // Fetch logs (always fetch all, filter client-side)

--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -13,11 +13,11 @@
 
 import http from 'http';
 import { spawn, execSync } from 'child_process';
-import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, unlinkSync, statSync, readdirSync, rmSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { createServer } from 'net';
-import { randomBytes } from 'crypto';
+import { randomBytes, createHash } from 'crypto';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const skillDir = resolve(__dirname, '..');
@@ -42,6 +42,16 @@ function loadSkillConfig() {
     authHubEnabled: false,
     authHubPath: 'apps/auth',
     authHubPort: 5173,
+    branchWatchEnabled: true,
+    branchWatchInterval: 1000,
+    branchSwitchDebounce: 3000,
+    distCacheKeep: 4,
+    distCacheMaxGb: 40,
+    perBranchDistDir: false,
+    killOnBranchSwitch: false,
+    autoInstall: true,
+    prewarmRoutes: [],
+    prewarmTimeout: 300000,
   };
 
   if (existsSync(envPath)) {
@@ -78,6 +88,39 @@ function loadSkillConfig() {
           break;
         case 'AUTH_HUB_PORT':
           if (value) config.authHubPort = parseInt(value, 10);
+          break;
+        case 'BRANCH_WATCH_ENABLED':
+          config.branchWatchEnabled = /^(true|1|yes|on)$/i.test(value);
+          break;
+        case 'BRANCH_WATCH_INTERVAL':
+          if (value) config.branchWatchInterval = parseInt(value, 10);
+          break;
+        case 'BRANCH_SWITCH_DEBOUNCE':
+          if (value) config.branchSwitchDebounce = parseInt(value, 10);
+          break;
+        case 'DIST_CACHE_KEEP':
+          if (value) config.distCacheKeep = parseInt(value, 10);
+          break;
+        case 'DIST_CACHE_MAX_GB':
+          if (value) config.distCacheMaxGb = parseFloat(value);
+          break;
+        case 'PER_BRANCH_DIST_DIR':
+          config.perBranchDistDir = /^(true|1|yes|on)$/i.test(value);
+          break;
+        case 'KILL_ON_BRANCH_SWITCH':
+          config.killOnBranchSwitch = /^(true|1|yes|on)$/i.test(value);
+          break;
+        case 'AUTO_INSTALL':
+          config.autoInstall = /^(true|1|yes|on)$/i.test(value);
+          break;
+        case 'PREWARM_ROUTES':
+          config.prewarmRoutes = value
+            .split(',')
+            .map((r) => r.trim())
+            .filter(Boolean);
+          break;
+        case 'PREWARM_TIMEOUT':
+          if (value) config.prewarmTimeout = parseInt(value, 10);
           break;
       }
     }
@@ -208,6 +251,151 @@ function getGitBranch(dir) {
   }
 }
 
+// Locate a worktree's HEAD file. In a linked worktree `.git` is a file pointing at
+// the real gitdir, and that gitdir has its own HEAD — the shared one never moves.
+function resolveGitHeadPath(dir) {
+  const dotGit = resolve(dir, '.git');
+  if (!existsSync(dotGit)) return null;
+  if (statSync(dotGit).isDirectory()) return resolve(dotGit, 'HEAD');
+  const match = readFileSync(dotGit, 'utf-8').match(/^gitdir:\s*(.+)$/m);
+  if (!match) return null;
+  return resolve(dir, match[1].trim(), 'HEAD');
+}
+
+// Branch name (or short sha when detached) straight off HEAD — no git subprocess,
+// so it's cheap enough to poll every second.
+function readHeadRef(headPath) {
+  try {
+    const raw = readFileSync(headPath, 'utf-8').trim();
+    const match = raw.match(/^ref:\s*refs\/heads\/(.+)$/);
+    return match ? match[1] : raw.slice(0, 12);
+  } catch (e) {
+    return null;
+  }
+}
+
+function branchSlug(branch) {
+  const safe = branch.toLowerCase().replace(/[^a-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
+  const digest = createHash('sha1').update(branch).digest('hex').slice(0, 6);
+  return `${safe.slice(0, 48) || 'detached'}-${digest}`;
+}
+
+const distRoot = 'branches';
+
+function distDirForBranch(branch) {
+  return `.next/${distRoot}/${branchSlug(branch)}`;
+}
+
+function fileHash(path) {
+  try {
+    return createHash('sha1').update(readFileSync(path)).digest('hex');
+  } catch (e) {
+    return null;
+  }
+}
+
+function dirSize(dir) {
+  let total = 0;
+  const stack = [dir];
+  while (stack.length) {
+    let entries;
+    try {
+      entries = readdirSync(stack.pop(), { withFileTypes: true });
+    } catch (e) {
+      continue;
+    }
+    for (const entry of entries) {
+      const full = resolve(entry.parentPath ?? entry.path, entry.name);
+      if (entry.isDirectory()) stack.push(full);
+      else {
+        try {
+          total += statSync(full).size;
+        } catch (e) {}
+      }
+    }
+  }
+  return total;
+}
+
+// Evict least-recently-used per-branch build dirs until both budgets hold: at most
+// `keep` dirs, and at most `maxBytes` total. The size cap is the one that matters —
+// Turbopack's store grows ~1GB per route compiled and re-grows on every restart, so
+// a count-only cap bounds nothing. The live dir is never evicted.
+function pruneDistDirs(worktree, keepDir, keep, maxBytes, log) {
+  const root = resolve(worktree, '.next', distRoot);
+  if (!existsSync(root)) return;
+  const active = resolve(worktree, keepDir);
+  let entries;
+  try {
+    entries = readdirSync(root, { withFileTypes: true }).filter((e) => e.isDirectory());
+  } catch (e) {
+    return;
+  }
+
+  const dirs = entries
+    .map((e) => resolve(root, e.name))
+    .map((p) => ({ path: p, mtime: statSync(p).mtimeMs, size: dirSize(p) }))
+    .sort((a, b) => b.mtime - a.mtime);
+
+  const gb = (n) => (n / 1024 ** 3).toFixed(1);
+  let total = dirs.reduce((sum, d) => sum + d.size, 0);
+  log?.('info', `Build cache: ${dirs.length} branch dirs, ${gb(total)} GB total`);
+
+  const evict = (d, why) => {
+    try {
+      rmSync(d.path, { recursive: true, force: true });
+      total -= d.size;
+      log?.('info', `Evicted ${d.path.replace(worktree, '.')} (${gb(d.size)} GB, ${why})`);
+    } catch (e) {
+      log?.('warn', `Could not evict ${d.path}: ${e.message}`);
+    }
+  };
+
+  for (let i = 0; i < dirs.length; i++) {
+    const d = dirs[i];
+    if (d.path === active) continue;
+    if (keep > 0 && i >= keep) evict(d, 'over count');
+    else if (maxBytes > 0 && total > maxBytes) evict(d, 'over size budget');
+  }
+
+  if (maxBytes > 0 && total > maxBytes) {
+    log?.(
+      'warn',
+      `Active branch cache alone is ${gb(total)} GB, over the ${gb(maxBytes)} GB budget — ` +
+        `delete .next/${distRoot} if disk is tight`
+    );
+  }
+}
+
+// Run a package-manager command to completion, streaming into the session log.
+function runCommand(cmd, args, cwd, env, log) {
+  return new Promise((done) => {
+    log('info', `> ${cmd} ${args.join(' ')}`);
+    const child = spawn(cmd, args, {
+      cwd,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: process.platform === 'win32',
+    });
+    const pipe = (stream, level) =>
+      stream.on('data', (d) => {
+        for (const line of d.toString().split('\n')) {
+          if (line.trim()) log(level, line.trim());
+        }
+      });
+    pipe(child.stdout, 'stdout');
+    pipe(child.stderr, 'stderr');
+    child.on('exit', (code) => {
+      log(code === 0 ? 'info' : 'error', `${cmd} exited with code ${code}`);
+      done(code);
+    });
+    child.on('error', (err) => {
+      log('error', `${cmd} failed to start: ${err.message}`);
+      done(-1);
+    });
+  });
+}
+
 // Check if a port is available
 function isPortAvailable(port) {
   return new Promise((resolve) => {
@@ -254,6 +442,32 @@ class DevSession {
     this.healthCheckTimer = null;
     this.healthCheckAbortController = null;
     this.healthCheckRunning = false;
+    this.distDir = null;
+    this.headPath = resolveGitHeadPath(worktree);
+    this.branchWatchTimer = null;
+    this.branchSwitchTimer = null;
+    this.switching = false;
+    this.prewarming = false;
+    this.lockHash = null;
+    this.schemaHash = null;
+  }
+
+  lockfilePath() {
+    return resolve(this.worktree, 'pnpm-lock.yaml');
+  }
+
+  // The authored schema, not `prisma/schema.prisma` — that one is a generated artifact
+  // (scripts/generate-slim-schema.js strips @no-type models out of schema.full.prisma),
+  // so watching it misses schema changes that arrive with a checkout and leaves the
+  // Prisma client stale.
+  schemaPath() {
+    return resolve(
+      this.worktree,
+      'packages',
+      'civitai-db-schema',
+      'prisma',
+      'schema.full.prisma'
+    );
   }
 
   addLog(level, message) {
@@ -284,8 +498,18 @@ class DevSession {
   }
 
   async start() {
-    // Get git branch
-    this.branch = getGitBranch(this.worktree) || 'unknown';
+    // Re-read the skill .env each start so edits to PREWARM_ROUTES et al. take effect
+    // on the next branch switch instead of needing a daemon restart. Mutated in place
+    // because healthCheckConfig aliases this object.
+    Object.assign(skillConfig, loadSkillConfig());
+
+    // Must match what the watcher reads, or a detached HEAD (where `git` reports the
+    // literal "HEAD" and the HEAD file holds a sha) looks like a switch on every tick.
+    this.branch =
+      (this.headPath && readHeadRef(this.headPath)) || getGitBranch(this.worktree) || 'unknown';
+    this.distDir = skillConfig.perBranchDistDir ? distDirForBranch(this.branch) : '.next';
+    this.lockHash = fileHash(this.lockfilePath());
+    this.schemaHash = fileHash(this.schemaPath());
 
     // Load environment variables
     let envVars = loadEnvFile(this.envPath);
@@ -299,6 +523,7 @@ class DevSession {
 
     // Set PORT in environment
     envVars.PORT = String(this.port);
+    envVars.NEXT_DIST_DIR = this.distDir;
 
     // Merge with current process env (for PATH, etc.)
     const env = { ...process.env, ...envVars };
@@ -306,6 +531,17 @@ class DevSession {
     this.addLog('info', `Starting dev server on port ${this.port}`);
     this.addLog('info', `Worktree: ${this.worktree}`);
     this.addLog('info', `Branch: ${this.branch}`);
+    this.addLog('info', `Build dir: ${this.distDir}`);
+
+    if (skillConfig.perBranchDistDir) {
+      pruneDistDirs(
+        this.worktree,
+        this.distDir,
+        skillConfig.distCacheKeep,
+        skillConfig.distCacheMaxGb * 1024 ** 3,
+        (l, m) => this.addLog(l, m)
+      );
+    }
 
     // Spawn npm run dev
     const isWindows = process.platform === 'win32';
@@ -383,14 +619,132 @@ class DevSession {
       this.startHealthCheck();
     }
 
+    this.startBranchWatch();
+
     return {
       id: this.id,
       port: this.port,
       worktree: this.worktree,
       branch: this.branch,
+      distDir: this.distDir,
       status: this.status,
       ready: this.ready,
     };
+  }
+
+  startBranchWatch() {
+    if (!skillConfig.branchWatchEnabled || !this.headPath || this.branchWatchTimer) return;
+
+    this.branchWatchTimer = setInterval(() => {
+      if (this.switching) return;
+      const head = readHeadRef(this.headPath);
+      if (!head || head === this.branch) return;
+      this.onHeadChanged(head);
+    }, skillConfig.branchWatchInterval);
+    this.branchWatchTimer.unref?.();
+  }
+
+  stopBranchWatch() {
+    if (this.branchWatchTimer) {
+      clearInterval(this.branchWatchTimer);
+      this.branchWatchTimer = null;
+    }
+    if (this.branchSwitchTimer) {
+      clearTimeout(this.branchSwitchTimer);
+      this.branchSwitchTimer = null;
+    }
+  }
+
+  // HEAD moved. Measured: leaving the server up through a checkout beats killing it —
+  // its in-memory graph survives, so only what actually changed recompiles (~8s vs a
+  // ~43s cold start), and routes it isn't asked for stay warm. So do nothing here but
+  // wait for the tree to settle. A restart is only forced when node_modules or the
+  // Prisma client must change underneath it (see finishBranchSwitch).
+  onHeadChanged(head) {
+    if (!this.branchSwitchTimer) {
+      this.addLog('info', `HEAD moved to ${head} — waiting for checkout to settle`);
+      if (skillConfig.killOnBranchSwitch) {
+        this.addLog('info', 'KILL_ON_BRANCH_SWITCH set — stopping dev server');
+        this.stopHealthCheck();
+        this.ready = false;
+        this.readyAt = null;
+        this.stop().catch(() => {});
+      }
+    }
+
+    clearTimeout(this.branchSwitchTimer);
+    this.branchSwitchTimer = setTimeout(
+      () => this.finishBranchSwitch(),
+      skillConfig.branchSwitchDebounce
+    );
+  }
+
+  async finishBranchSwitch() {
+    this.branchSwitchTimer = null;
+    this.switching = true;
+    const head = readHeadRef(this.headPath);
+    if (!head) {
+      this.switching = false;
+      return;
+    }
+
+    try {
+      const from = this.branch;
+      this.branch = head;
+      this.addLog('info', `Branch switch: ${from} -> ${head}`);
+
+      const env = { ...process.env, ...loadEnvFile(this.envPath) };
+      const log = (l, m) => this.addLog(l, m);
+      const pnpmCmd = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+
+      const lockHash = fileHash(this.lockfilePath());
+      const schemaHash = fileHash(this.schemaPath());
+      const lockChanged = lockHash !== this.lockHash;
+      const schemaChanged = schemaHash !== this.schemaHash;
+
+      // Only these force a restart: the running process has node_modules and the
+      // generated Prisma client resolved in memory, and neither can be swapped under
+      // it. Everything else the dev server recompiles on its own, faster than a
+      // restart would.
+      const mustRestart = skillConfig.killOnBranchSwitch || lockChanged || schemaChanged;
+
+      if (skillConfig.autoInstall && lockChanged) {
+        this.addLog('info', 'pnpm-lock.yaml changed — installing');
+        await this.stop();
+        // postinstall runs db:generate, so a schema change needs no separate pass.
+        await runCommand(pnpmCmd, ['install', '--prefer-offline'], this.worktree, env, log);
+      } else if (skillConfig.autoInstall && schemaChanged) {
+        this.addLog('info', 'prisma/schema.prisma changed — regenerating client');
+        await this.stop();
+        await runCommand(pnpmCmd, ['run', 'db:generate'], this.worktree, env, log);
+      }
+
+      this.lockHash = lockHash;
+      this.schemaHash = schemaHash;
+
+      if (mustRestart) {
+        await this.stop();
+        this.restartCount++;
+        this.switching = false;
+        await this.start();
+        return;
+      }
+
+      // Server kept running: nothing to restart, just recompile the routes you use
+      // so the switch cost lands on the daemon rather than your next click.
+      this.switching = false;
+      if (skillConfig.perBranchDistDir) {
+        this.addLog(
+          'warn',
+          'PER_BRANCH_DIST_DIR is set but the server was not restarted — it keeps the ' +
+            'build dir it started with. Per-branch dirs only apply on restart.'
+        );
+      }
+      await this.prewarm();
+    } catch (err) {
+      this.switching = false;
+      this.addLog('error', `Branch switch failed: ${err.message}`);
+    }
   }
 
   startHealthCheck() {
@@ -451,6 +805,7 @@ class DevSession {
           this.readyAt = new Date().toISOString();
           this.addLog('info', 'Server ready (health check passed)');
           this.stopHealthCheck();
+          this.prewarm();
         } else {
           // Non-matching status, schedule next check
           scheduleNextCheck();
@@ -480,6 +835,39 @@ class DevSession {
     check();
   }
 
+  // Compile the routes you actually open, in the background, right after the server
+  // comes up. Cold-compiling this app's graph costs ~50s on the first route; the point
+  // is that the daemon eats that while you're still reading the diff, not you when you
+  // click. Sequential on purpose — parallel requests just contend for the same
+  // compiler and make the first route land later.
+  async prewarm() {
+    const routes = skillConfig.prewarmRoutes;
+    if (!routes.length || this.prewarming) return;
+
+    this.prewarming = true;
+    const startedFor = this.branch;
+    this.addLog('info', `Prewarming ${routes.length} route(s): ${routes.join(', ')}`);
+
+    for (const route of routes) {
+      // A branch switch or shutdown mid-prewarm makes the rest pointless.
+      if (!this.prewarming || this.branch !== startedFor || this.status !== 'running') {
+        this.addLog('info', 'Prewarm abandoned (session moved on)');
+        break;
+      }
+      const started = Date.now();
+      try {
+        const res = await fetch(`http://localhost:${this.port}${route}`, {
+          signal: AbortSignal.timeout(skillConfig.prewarmTimeout),
+        });
+        this.addLog('info', `Prewarmed ${route} -> ${res.status} in ${Date.now() - started}ms`);
+      } catch (err) {
+        this.addLog('warn', `Prewarm ${route} failed after ${Date.now() - started}ms: ${err.message}`);
+      }
+    }
+
+    this.prewarming = false;
+  }
+
   stopHealthCheck() {
     if (!this.healthCheckRunning) {
       return;
@@ -503,6 +891,8 @@ class DevSession {
 
   async stop() {
     this.stopHealthCheck();
+    this.stopBranchWatch();
+    this.prewarming = false;
     if (!this.process) return;
 
     this.addLog('info', 'Stopping dev server...');
@@ -539,6 +929,9 @@ class DevSession {
       id: this.id,
       worktree: this.worktree,
       branch: this.branch,
+      distDir: this.distDir,
+      switching: this.switching,
+      prewarming: this.prewarming,
       port: this.port,
       status: this.status,
       ready: this.ready,

--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -531,6 +531,7 @@ class DevSession {
     this.addLog('info', `Starting dev server on port ${this.port}`);
     this.addLog('info', `Worktree: ${this.worktree}`);
     this.addLog('info', `Branch: ${this.branch}`);
+    this.addLog('info', `Env: ${this.envPath}`);
     this.addLog('info', `Build dir: ${this.distDir}`);
 
     if (skillConfig.perBranchDistDir) {
@@ -714,7 +715,7 @@ class DevSession {
         // postinstall runs db:generate, so a schema change needs no separate pass.
         await runCommand(pnpmCmd, ['install', '--prefer-offline'], this.worktree, env, log);
       } else if (skillConfig.autoInstall && schemaChanged) {
-        this.addLog('info', 'prisma/schema.prisma changed — regenerating client');
+        this.addLog('info', 'schema.full.prisma changed — regenerating client');
         await this.stop();
         await runCommand(pnpmCmd, ['run', 'db:generate'], this.worktree, env, log);
       }
@@ -929,6 +930,7 @@ class DevSession {
       id: this.id,
       worktree: this.worktree,
       branch: this.branch,
+      envPath: this.envPath,
       distDir: this.distDir,
       switching: this.switching,
       prewarming: this.prewarming,
@@ -1347,6 +1349,13 @@ const spokeApps = new Map(
   Object.entries(SPOKE_APPS).map(([name, cfg]) => [name, new SpokeApp(name, cfg.path, cfg.port)])
 );
 
+// Spokes bind with --strictPort, so one left running past daemon exit makes the next start of
+// that app fail with EADDRINUSE against a process nothing is tracking any more.
+async function stopSpokeApps() {
+  for (const app of spokeApps.values()) {
+    if (app.status === 'running') await app.stop();
+  }
+}
 
 // Session manager
 const sessions = new Map();
@@ -1758,6 +1767,7 @@ async function main() {
         sessions.clear();
         await rgbProxy.stop();
         await authHub.stop();
+        await stopSpokeApps();
 
         res.writeHead(200);
         res.end(JSON.stringify({ success: true }));
@@ -1824,6 +1834,7 @@ async function main() {
     }
     await rgbProxy.stop();
     await authHub.stop();
+    await stopSpokeApps();
     try { unlinkSync(pidFile); } catch (e) {}
     server.close();
     process.exit(0);
@@ -1836,6 +1847,7 @@ async function main() {
     }
     await rgbProxy.stop();
     await authHub.stop();
+    await stopSpokeApps();
     try { unlinkSync(pidFile); } catch (e) {}
     server.close();
     process.exit(0);

--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -1658,8 +1658,14 @@ async function main() {
           port = await findAvailablePort(config.baseDevPort, usedPorts);
         }
 
-        // Determine env path
-        const resolvedEnvPath = envPath ? resolve(envPath) : mainEnvPath;
+        // A worktree's own .env is the one its branch was written against. Falling back to the
+        // daemon's project root hands every session whichever tree happened to launch the daemon.
+        const worktreeEnvPath = resolve(resolvedWorktree, '.env');
+        const resolvedEnvPath = envPath
+          ? resolve(envPath)
+          : existsSync(worktreeEnvPath)
+            ? worktreeEnvPath
+            : mainEnvPath;
 
         // Create and start session
         const sessionId = generateSessionId();

--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -800,7 +800,7 @@ class AuthHub {
     try {
       proc = spawn(
         pnpmCmd,
-        ['exec', 'vite', 'dev', '--port', String(this.port), '--strictPort'],
+        ['exec', 'vite', 'dev', '--host', '127.0.0.1', '--port', String(this.port), '--strictPort'],
         spawnOptions
       );
     } catch (err) {
@@ -924,6 +924,36 @@ class AuthHub {
 }
 
 const authHub = new AuthHub(skillConfig.authHubPath, skillConfig.authHubPort);
+
+// Every other SvelteKit app under apps/ runs the same way the auth hub does: `vite dev` in the app
+// directory, vite loads that app's own .env. AuthHub already encodes all of that plus the readiness
+// parsing, crash handling and log ring buffer, so a spoke is an AuthHub with a different label.
+//
+// Ports are fixed per app rather than auto-assigned so a redirect between two of them (moderator ->
+// auth) always lands on the same place, and so `--strictPort` fails loudly on a collision instead of
+// silently drifting to the next free port.
+const SPOKE_APPS = {
+  moderator: { path: 'apps/moderator', port: 5174 },
+  'creator-studio': { path: 'apps/creator-studio', port: 5175 },
+  storage: { path: 'apps/storage', port: 5176 },
+  notifications: { path: 'apps/notifications', port: 5177 },
+};
+
+class SpokeApp extends AuthHub {
+  constructor(name, appPath, port) {
+    super(appPath, port);
+    this.name = name;
+  }
+
+  getStatus() {
+    return { ...super.getStatus(), name: this.name, enabled: true };
+  }
+}
+
+const spokeApps = new Map(
+  Object.entries(SPOKE_APPS).map(([name, cfg]) => [name, new SpokeApp(name, cfg.path, cfg.port)])
+);
+
 
 // Session manager
 const sessions = new Map();
@@ -1066,6 +1096,59 @@ async function main() {
         res.writeHead(200);
         res.end(JSON.stringify(status));
         return;
+      }
+
+      // /app/<name>[/logs|/start|/stop|/restart] - spoke app control
+      if (path === '/apps' && req.method === 'GET') {
+        res.writeHead(200);
+        res.end(JSON.stringify({
+          apps: [...spokeApps.values()].map((a) => a.getStatus()),
+        }));
+        return;
+      }
+
+      if (path.startsWith('/app/')) {
+        const [, , name, action] = path.split('/');
+        const app = spokeApps.get(name);
+        if (!app) {
+          res.writeHead(404);
+          res.end(JSON.stringify({
+            error: `Unknown app: ${name}`,
+            available: [...spokeApps.keys()],
+          }));
+          return;
+        }
+
+        if (!action && req.method === 'GET') {
+          res.writeHead(200);
+          res.end(JSON.stringify(app.getStatus()));
+          return;
+        }
+        if (action === 'logs' && req.method === 'GET') {
+          const since = parseInt(url.searchParams.get('since') || '0', 10);
+          const limit = parseInt(url.searchParams.get('limit') || '500', 10);
+          res.writeHead(200);
+          res.end(JSON.stringify({ currentIndex: app.logIndex, logs: app.getLogs(since, limit) }));
+          return;
+        }
+        if (action === 'start' && req.method === 'POST') {
+          const status = app.start();
+          res.writeHead(status.status === 'error' ? 500 : 200);
+          res.end(JSON.stringify(status));
+          return;
+        }
+        if (action === 'stop' && req.method === 'POST') {
+          const status = await app.stop();
+          res.writeHead(200);
+          res.end(JSON.stringify(status));
+          return;
+        }
+        if (action === 'restart' && req.method === 'POST') {
+          const status = await app.restart();
+          res.writeHead(status.status === 'error' ? 500 : 200);
+          res.end(JSON.stringify(status));
+          return;
+        }
       }
 
       // GET /auth - Auth hub status

--- a/.claude/skills/dev-server/scripts/defender-exclusions.ps1
+++ b/.claude/skills/dev-server/scripts/defender-exclusions.ps1
@@ -1,0 +1,32 @@
+# Windows Defender exclusions for the dev environment.
+#
+# Real-time protection scans every file Turbopack and pnpm touch — ~210k files in
+# node_modules plus a multi-GB build cache per branch. Excluding them is the single
+# biggest win for cold-start and branch-switch time on Windows.
+#
+# Must run from an ELEVATED PowerShell (Run as Administrator).
+
+#Requires -RunAsAdministrator
+
+$paths = @(
+  'C:\Dev\Repos\work',
+  "$env:LOCALAPPDATA\pnpm",
+  "$env:LOCALAPPDATA\pnpm-store"
+)
+
+$processes = @('node.exe', 'pnpm.exe', 'npm.exe')
+
+foreach ($p in $paths) {
+  Add-MpPreference -ExclusionPath $p
+  Write-Host "excluded path:    $p"
+}
+
+foreach ($p in $processes) {
+  Add-MpPreference -ExclusionProcess $p
+  Write-Host "excluded process: $p"
+}
+
+Write-Host "`nCurrent exclusions:"
+$pref = Get-MpPreference
+$pref.ExclusionPath | ForEach-Object { "  path    $_" }
+$pref.ExclusionProcess | ForEach-Object { "  process $_" }

--- a/.claude/skills/dev-server/scripts/defender-exclusions.ps1
+++ b/.claude/skills/dev-server/scripts/defender-exclusions.ps1
@@ -8,8 +8,12 @@
 
 #Requires -RunAsAdministrator
 
+# Add-MpPreference accepts a path that does not exist, so a wrong root here reports success and
+# excludes nothing. Override with -ReposRoot on any machine that doesn't use this layout.
+param([string]$ReposRoot = 'C:\Dev\Repos\work')
+
 $paths = @(
-  'C:\Dev\Repos\work',
+  $ReposRoot,
   "$env:LOCALAPPDATA\pnpm",
   "$env:LOCALAPPDATA\pnpm-store"
 )

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -73,6 +73,10 @@ export default defineNextConfig(
     // emits those warnings — an empty config just acknowledges we're on Turbopack
     // and silences Next's "webpack config with no turbopack config" build error.
     turbopack: {},
+    // Per-branch build dir. Turbopack's dev filesystem cache (~8GB) is invalidated
+    // wholesale by an in-place branch switch, so the dev daemon points each branch at
+    // its own dir and keeps them warm instead of purging. Unset -> stock `.next`.
+    distDir: process.env.NEXT_DIST_DIR || '.next',
     allowedDevOrigins: ['civitai-dev.green', 'civitai-dev.blue', 'civitai-dev.red'],
     // Retained for the `next build --webpack` fallback path; ignored under Turbopack.
     webpack: (config) => {


### PR DESCRIPTION
Three changes to the `dev-server` skill. Split out of a debugging session into one PR because they all rewrite `daemon.mjs`.

### 1. Spoke apps as daemon sidecars (`f00ce6b11d`)
The SvelteKit apps under `apps/` now run through the daemon like the auth hub, so their logs land in the same place and either a human or an agent can start one. `SpokeApp extends AuthHub` — a spoke is an AuthHub with a label. Ports are fixed per app so a redirect between two of them always lands in the same place, and `--strictPort` fails loudly on a collision instead of drifting.

This work was already written and sitting uncommitted; it is committed first here so the rest applies on top of it.

### 2. Keep the dev server alive across branch switches (`f333b48f94`)
Cherry-picked unchanged from `chore/dev-server-branch-switching`, which was never merged. Adds `BRANCH_WATCH`, `PREWARM_ROUTES`, `PER_BRANCH_DIST_DIR`, and `defender-exclusions.ps1`.

**Why this matters beyond speed:** `.claude/skills/dev-server/.env` is untracked, so it is machine-global and already documents all of these options — while the code implementing them lived only on an unmerged branch. Anyone running the daemon from a worktree without that commit got a config file describing features the daemon had never heard of. `PREWARM_ROUTES` in particular reads as though five heavy routes are compiled before you touch anything, and it did nothing at all.

### 3. Start a session from its own worktree's `.env` (`04114ab924`)
The env path fell back to the daemon's project root, so **every session in every worktree ran on whichever tree happened to launch the daemon**. Observed live: two sessions on different worktrees, one logging `Using PROD database` and the other `Using LOCAL database`, purely because the daemon had been rooted differently. A `NODE_OPTIONS` set in a worktree `.env` never reached the process at all.

Now prefers the session worktree's `.env`. An explicit `envPath` still wins, and a worktree without a `.env` behaves exactly as before.

### Testing
- Daemon syntax-checked; `existsSync` was already imported.
- Ran a dev server from this worktree through the daemon for the measurements in the companion PR.
- Not verified: the spoke-app routes and the branch-switch path were not exercised end-to-end here. The branch-switch commit carries its author's own measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)