### PR TITLE
feat(generation): default video generation to Seedance v2 mini

### DIFF
--- a/src/shared/data-graph/generation/ecosystem-graph.ts
+++ b/src/shared/data-graph/generation/ecosystem-graph.ts
@@ -233,7 +233,7 @@ export const ecosystemGraph = new DataGraph<
         ctx.output === 'audio'
           ? 'Ace'
           : ctx.output === 'video'
-          ? 'Kling'
+          ? 'Seedance'
           : ctx.output === 'model3d'
           ? 'PolyGen'
           : 'ZImageTurbo';

--- a/src/shared/data-graph/generation/seedance-graph.ts
+++ b/src/shared/data-graph/generation/seedance-graph.ts
@@ -108,7 +108,7 @@ export const seedanceGraph = new DataGraph<{ ecosystem: string; workflow: string
     () =>
       createCheckpointGraph({
         versions: { options: seedanceVersionOptions },
-        defaultModelId: seedanceVersionIds.v2,
+        defaultModelId: seedanceVersionIds['v2-mini'],
       }),
     []
   )


### PR DESCRIPTION
Switches the default ecosystem for video generation from Kling to Seedance, and makes Seedance default to the `v2 mini` version.

## Changes

- `ecosystem-graph.ts` — the `output === ''video''` branch of `outputDefault` now resolves to `Seedance` instead of `Kling`.
- `seedance-graph.ts` — `createCheckpointGraph`''s `defaultModelId` moves from `v2` to `v2-mini`.

## Notes

- The default is still gate-aware: if Seedance is hidden/disabled/member-only for a user, the node falls through to the first usable compatible ecosystem exactly as before.
- Seedance is in `TXT2VID_IDS`, so it covers both `txt2vid` and `img2vid`. It is not registered for the `img2vid:first-last` or `img2vid:ref2vid` variants (Kling is), so those workflows still resolve to a compatible ecosystem on their own — unchanged behavior.
- The `resolution` node already restricts 1080p to `v2`, so a mini default lands on 720p correctly with no extra guard.
- Users with a stored ecosystem in localStorage keep whatever they had; this only affects fresh/reset forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)