### PR TITLE
chore(feature-flags): gate the Flipt debug log behind FLIPT_DEBUG

### DIFF
--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -674,7 +674,9 @@ const hasFeature = (
       fliptContext
     );
     if (fliptResult !== null) {
-      if (isDev) {
+      // Opt-in: this fires once per Flipt-backed flag per evaluation, which is
+      // hundreds of lines per page load and buries everything else in the dev log.
+      if (isDev && process.env.FLIPT_DEBUG === 'true') {
         console.log(`[Flipt] ${key} (${feature.fliptKey}) => ${fliptResult}`);
       }
       return fliptResult;


### PR DESCRIPTION
Cherry-picked from `chore/dev-server-branch-switching` (`9b9480cb66`, Jul 25). That branch was never pushed and has no PR, so this commit existed in exactly one place on one machine — surfaced while auditing worktrees for cleanup.

The Flipt eval log fired once per Flipt-backed flag per evaluation, gated only on `isDev` with no way to turn it off. That is hundreds of lines per page load, and it buries everything else in the dev server output.

```diff
-      if (isDev) {
+      if (isDev && process.env.FLIPT_DEBUG === 'true') {
         console.log(`[Flipt] ${key} (${feature.fliptKey}) => ${fliptResult}`);
```

Opt in with `FLIPT_DEBUG=true`. Dev-only either way — production behaviour is unchanged.

Unmodified from the original commit apart from the rebase onto current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)