### PR TITLE
feat(metrics): reconcile image reaction metrics against Postgres

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -396,6 +396,9 @@ export const serverSchema = z
     // loudly at boot instead.
     IMAGE_SCANNING_MAX_PER_RUN: z.coerce.number().int().positive().default(1000),
     IMAGE_SCANNER_NEW: zc.booleanString.default(false),
+    // Arms the reaction reconciliation audit's repair path to WRITE compensating
+    // events to ClickHouse. Off means detect and report only.
+    METRIC_REACTION_REPAIR_ENABLED: zc.booleanString.default(false),
     DELIVERY_WORKER_ENDPOINT: z.string().optional(),
     DELIVERY_WORKER_TOKEN: z.string().optional(),
     STORAGE_RESOLVER_ENDPOINT: z.string().optional(), // URL for storage-resolver microservice

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -397,7 +397,8 @@ export const serverSchema = z
     IMAGE_SCANNING_MAX_PER_RUN: z.coerce.number().int().positive().default(1000),
     IMAGE_SCANNER_NEW: zc.booleanString.default(false),
     // Arms the reaction reconciliation audit's repair path to WRITE compensating
-    // events to ClickHouse. Off means detect and report only.
+    // events to ClickHouse. Off, the hourly path does nothing at all and the
+    // nightly one runs its diff as a dry run for visibility.
     METRIC_REACTION_REPAIR_ENABLED: zc.booleanString.default(false),
     DELIVERY_WORKER_ENDPOINT: z.string().optional(),
     DELIVERY_WORKER_TOKEN: z.string().optional(),

--- a/src/pages/api/webhooks/run-jobs/[[...run]].ts
+++ b/src/pages/api/webhooks/run-jobs/[[...run]].ts
@@ -76,6 +76,7 @@ import { processScheduledPublishing } from '~/server/jobs/process-scheduled-publ
 import { processSubscriptionsRequiringRenewal } from '~/server/jobs/process-subscriptions-requiring-renewal';
 import { processVaultItems } from '~/server/jobs/process-vault-items';
 import { auditWildcardSetCategoriesJob } from '~/server/jobs/audit-wildcard-set-categories';
+import { metricReconciliationJobs } from '~/server/jobs/metric-reconciliation-audit';
 import { reconcileWildcardSetsJob } from '~/server/jobs/reconcile-wildcard-sets';
 import { pushDiscordMetadata } from '~/server/jobs/push-discord-metadata';
 import { refreshAuctionCache } from '~/server/jobs/refresh-auction-cache';
@@ -168,6 +169,7 @@ export const jobs: Job[] = [
   clearVaultItems,
   reconcileWildcardSetsJob,
   auditWildcardSetCategoriesJob,
+  ...metricReconciliationJobs,
   ...jobQueueJobs,
   countReviewImages,
   processingEngingEarlyAccess,

--- a/src/server/jobs/metric-reconciliation-audit.ts
+++ b/src/server/jobs/metric-reconciliation-audit.ts
@@ -45,8 +45,9 @@ import { createJob } from './job';
  *
  * The nightly exactness check needs its own split. Sampling by image pulls each
  * image's ENTIRE reaction history, so its headline coverage is dominated by
- * un-repaired outage residue rather than by current health. Same 200-image
- * sample, 7 seeds, 2026-08-07:
+ * un-repaired outage residue rather than by current health. 200 images per sample,
+ * `seed` 0..6, 2026-08-07 — the sample is a stable hash ordering rather than a
+ * random draw, so passing the same seed reproduces the same images and figures:
  *
  *   headline coverage   0.9559 – 0.9929   (mean ~0.978)
  *   reactions <24h old  1.0000, 1.0000, 0.9974
@@ -134,9 +135,11 @@ function floorToHour(date: Date) {
 export const reactionVolumeAuditJob = createJob(
   'reaction-volume-audit',
   '10 * * * *',
-  async () => {
+  async (jobContext) => {
     const hourStart = floorToHour(new Date(Date.now() - AUDIT_LAG_HOURS * 3_600_000));
-    const result = await auditReactionHour(hourStart);
+    const result = await auditReactionHour(hourStart, {
+      checkCanceled: jobContext.checkIfCanceled,
+    });
 
     gauges.hourly_missing_rows.set(result.missing);
     gauges.hourly_unmapped_rows.set(
@@ -190,7 +193,10 @@ export const reactionExactnessAuditJob = createJob(
   'reaction-exactness-audit',
   '40 4 * * *',
   async () => {
-    const result = await auditReactionExactness({ sampleSize: 200, lookbackHours: 24 });
+    // The sample is a stable hash ordering, not a random draw, so a fixed seed
+    // would inspect the same images every night. Vary it by day.
+    const seed = Math.floor(Date.now() / 86_400_000);
+    const result = await auditReactionExactness({ sampleSize: 200, lookbackHours: 24, seed });
 
     if (result.recentCoverage !== null)
       gauges.exactness_recent_coverage_ratio.set(result.recentCoverage);

--- a/src/server/jobs/metric-reconciliation-audit.ts
+++ b/src/server/jobs/metric-reconciliation-audit.ts
@@ -1,0 +1,227 @@
+import client from 'prom-client';
+import { logToAxiom } from '~/server/logging/client';
+import { PROM_PREFIX } from '~/server/prom/client';
+import { repairReactionMetrics } from '~/server/services/metric-reaction-repair.service';
+import {
+  auditReactionExactness,
+  auditReactionHour,
+  requestReactionRepair,
+  setReactionRepairHook,
+} from '~/server/services/metric-reconciliation.service';
+import { createJob } from './job';
+
+/**
+ * Reaction-pipeline reconciliation jobs. These are the only checks that read
+ * Postgres on one arm; everything else compares two points inside the same
+ * lineage and so cannot see a loss at the CDC boundary. Between 2025-12-01 and
+ * 2026-06-23 the consumer silently dropped ~21.6M reaction events and every
+ * existing health check stayed green.
+ *
+ * They live in the main app rather than in the watcher on purpose: an auditor
+ * that shares a failure domain with the thing it audits goes quiet exactly when
+ * it matters. A watcher outage stops the pipeline *and* would stop an in-watcher
+ * audit; this one keeps reporting.
+ *
+ * ── Thresholds, and the data behind them ──────────────────────────────────
+ * Coverage is `matched / comparable`, PG -> CH. Measured 2026-08-07 against
+ * production, one call per hour:
+ *
+ *   post-fix: 27 hours across 2026-08-05/06/07, 662,531 Postgres rows
+ *     coverage = 1.000000 on every hour. Zero misses. No residual, no variance.
+ *   inside the outage window
+ *     2026-02-11 14:00  coverage 0.019165  (23,849 of 24,315 rows lost)
+ *     2026-05-14 03:00  coverage 0.712498  ( 6,478 of 22,532 rows lost)
+ *
+ * So the healthy distribution is a point mass at 1.0 and the failure signal is
+ * 0.02–0.71. WARN at 0.999 sits ~1000x outside the observed noise while still
+ * catching a loss of 1-in-1000; CRIT at 0.99 is a two-order-of-magnitude event.
+ *
+ * The naive count-ratio version of this check does NOT have that property, and
+ * the ~0.98 it suggests is inside its own noise. Un-reactions delete the PG row
+ * but leave the `+1` in ClickHouse, so raw `count(*)` ratios ran 0.965–0.998
+ * across those same healthy hours — half of them would have tripped a 0.98
+ * threshold, and the ratio drifts further from 1 the longer you wait to audit.
+ * Matching per `(imageId, userId, reaction)` removes that asymmetry entirely.
+ *
+ * The nightly exactness check needs its own split. Sampling by image pulls each
+ * image's ENTIRE reaction history, so its headline coverage is dominated by
+ * un-repaired outage residue rather than by current health. Same 200-image
+ * sample, 7 seeds, 2026-08-07:
+ *
+ *   headline coverage   0.9559 – 0.9929   (mean ~0.978)
+ *   reactions <24h old  1.0000, 1.0000, 0.9974
+ *   reactions older     0.9530, 0.9734, 0.9803
+ *   phantom rate        0.0016 – 0.0066   (mean ~0.0037)
+ *
+ * So `recentCoverage` is the health signal and shares the hourly thresholds;
+ * `backlogCoverage` is a burn-down of the outage and must NOT be alerted on until
+ * the repair job finishes — it would fire every night and get muted in a week.
+ * The phantom rate independently reproduces the known ~0.37% un-reaction residual,
+ * which is the evidence that 1% is the right ceiling for it.
+ */
+
+const COVERAGE_WARN = 0.999;
+const COVERAGE_CRIT = 0.99;
+
+/**
+ * Audit H-2, not H-1. Batching plus flush latency means the tail of H-1 may still
+ * be in flight; H-2 is settled. The `SETTINGS`-pinned CH read is ~700ms and the
+ * id-bounded PG read ~250ms, so the whole check is a few seconds.
+ */
+const AUDIT_LAG_HOURS = 2;
+
+// HMR re-evaluates this module, and prom-client throws on duplicate registration.
+declare global {
+  // eslint-disable-next-line no-var, vars-on-top
+  var metricReconciliationGauges: Record<GaugeName, client.Gauge<string>> | undefined;
+}
+
+type GaugeName = keyof typeof GAUGE_HELP;
+
+const GAUGE_HELP = {
+  hourly_coverage_ratio:
+    'Fraction of Postgres ImageReaction rows for the audited hour present in entityMetricEvents_month (1.0 = no loss)',
+  hourly_missing_rows:
+    'Postgres ImageReaction rows for the audited hour with no matching ClickHouse event',
+  hourly_unmapped_rows:
+    'Postgres reaction values with no ClickHouse metricType mapping (non-zero = mapping gap)',
+  audit_last_run_timestamp_seconds: 'Unix time of the last completed reaction reconciliation run',
+  exactness_recent_coverage_ratio:
+    'Per-(image,user,reaction) pairs from the last 24h present in both Postgres and entityMetricUserState_v3',
+  exactness_backlog_coverage_ratio:
+    'Same, for reactions older than the lookback. Un-repaired outage burn-down — do not alert on this',
+  exactness_phantom_ratio:
+    'Per-(image,user,reaction) pairs in ClickHouse with no Postgres row (known residual ~0.0037)',
+} as const;
+
+/**
+ * A job runs on one pod, so only that pod's series carries a fresh value —
+ * aggregate coverage with `min()` and counts with `max()`. The last-run gauge is
+ * what catches the job silently stopping, which is otherwise indistinguishable
+ * from a healthy pipeline.
+ */
+const gauges = (global.metricReconciliationGauges ??= Object.fromEntries(
+  Object.entries(GAUGE_HELP).map(([name, help]) => [
+    name,
+    new client.Gauge({ name: `${PROM_PREFIX}reaction_${name}`, help }),
+  ])
+) as Record<GaugeName, client.Gauge<string>>);
+
+/**
+ * Registering the hook does not arm anything: `repairReactionMetrics` computes its
+ * diff unconditionally but only inserts when `METRIC_REACTION_REPAIR_ENABLED` is
+ * set, which defaults to false. With the flag off, a detection logs the additions
+ * and removals it *would* have written — which is the evidence needed to decide
+ * whether to turn it on.
+ */
+setReactionRepairHook(async ({ imageIds, reason }) => {
+  const result = await repairReactionMetrics(imageIds);
+  await logToAxiom({
+    type: 'metric-reconciliation',
+    name: 'reaction-repair',
+    level: result.inserted ? 'info' : 'warn',
+    message: `repair ${reason}: +${result.additions} -${result.removals} inserted=${result.inserted}`,
+    error: JSON.stringify(result),
+  }).catch(() => undefined);
+});
+
+function floorToHour(date: Date) {
+  const d = new Date(date);
+  d.setUTCMinutes(0, 0, 0);
+  return d;
+}
+
+export const reactionVolumeAuditJob = createJob(
+  'reaction-volume-audit',
+  '10 * * * *',
+  async () => {
+    const hourStart = floorToHour(new Date(Date.now() - AUDIT_LAG_HOURS * 3_600_000));
+    const result = await auditReactionHour(hourStart);
+
+    gauges.hourly_missing_rows.set(result.missing);
+    gauges.hourly_unmapped_rows.set(
+      Object.values(result.unknownReactions).reduce((a, b) => a + b, 0)
+    );
+    gauges.audit_last_run_timestamp_seconds.set(Date.now() / 1000);
+    // An hour with no reactions has undefined coverage. Leaving the gauge at its
+    // previous value beats publishing a 0 that would page for a quiet hour.
+    if (result.coverage !== null) gauges.hourly_coverage_ratio.set(result.coverage);
+
+    const breached = result.coverage !== null && result.coverage < COVERAGE_WARN;
+    if (breached || Object.keys(result.unknownReactions).length > 0) {
+      await logToAxiom({
+        type: 'metric-reconciliation',
+        name: 'reaction-volume-audit',
+        level: result.coverage !== null && result.coverage < COVERAGE_CRIT ? 'error' : 'warn',
+        message: `reaction coverage ${result.coverage} for hour ${hourStart.toISOString()}`,
+        error: JSON.stringify({
+          hourStart: hourStart.toISOString(),
+          coverage: result.coverage,
+          pgRows: result.pgRows,
+          missing: result.missing,
+          unknownReactions: result.unknownReactions,
+          affectedImages: result.affectedImageIds.length,
+          sampleImageIds: result.affectedImageIds.slice(0, 20),
+        }),
+      }).catch(() => undefined);
+
+      await requestReactionRepair({
+        imageIds: result.affectedImageIds,
+        reason: 'hourly-coverage',
+        detectedAt: new Date(),
+        windowStart: hourStart,
+        windowEnd: new Date(hourStart.getTime() + 3_600_000),
+      });
+    }
+
+    return {
+      hourStart: hourStart.toISOString(),
+      pgRows: result.pgRows,
+      missing: result.missing,
+      coverage: result.coverage,
+      affectedImages: result.affectedImageIds.length,
+      durationMs: result.durationMs,
+    };
+  },
+  { dedicated: true, lockExpiration: 10 * 60 }
+);
+
+export const reactionExactnessAuditJob = createJob(
+  'reaction-exactness-audit',
+  '40 4 * * *',
+  async () => {
+    const result = await auditReactionExactness({ sampleSize: 200, lookbackHours: 24 });
+
+    if (result.recentCoverage !== null)
+      gauges.exactness_recent_coverage_ratio.set(result.recentCoverage);
+    if (result.backlogCoverage !== null)
+      gauges.exactness_backlog_coverage_ratio.set(result.backlogCoverage);
+    if (result.phantomRate !== null) gauges.exactness_phantom_ratio.set(result.phantomRate);
+
+    if (result.missingInCh > 0) {
+      await requestReactionRepair({
+        imageIds: result.affectedImageIds,
+        reason: 'nightly-exactness',
+        detectedAt: new Date(),
+      });
+    }
+
+    await logToAxiom({
+      type: 'metric-reconciliation',
+      name: 'reaction-exactness-audit',
+      level:
+        result.recentCoverage !== null && result.recentCoverage < COVERAGE_WARN ? 'warn' : 'info',
+      message: `reaction exactness recent ${result.recentCoverage} backlog ${result.backlogCoverage} phantom ${result.phantomRate}`,
+      error: JSON.stringify({
+        ...result,
+        affectedImageIds: undefined,
+        sampleImageIds: result.affectedImageIds.slice(0, 20),
+      }),
+    }).catch(() => undefined);
+
+    return { ...result, affectedImageIds: result.affectedImageIds.length };
+  },
+  { dedicated: true, lockExpiration: 15 * 60 }
+);
+
+export const metricReconciliationJobs = [reactionVolumeAuditJob, reactionExactnessAuditJob];

--- a/src/server/jobs/metric-reconciliation-audit.ts
+++ b/src/server/jobs/metric-reconciliation-audit.ts
@@ -1,4 +1,5 @@
 import client from 'prom-client';
+import { env } from '~/env/server';
 import { logToAxiom } from '~/server/logging/client';
 import { PROM_PREFIX } from '~/server/prom/client';
 import { repairReactionMetrics } from '~/server/services/metric-reaction-repair.service';
@@ -28,9 +29,12 @@ import { createJob } from './job';
  *
  *   post-fix: 27 hours across 2026-08-05/06/07, 662,531 Postgres rows
  *     coverage = 1.000000 on every hour. Zero misses. No residual, no variance.
- *   inside the outage window
+ *   inside the outage window, measured BEFORE the historical repair ran
  *     2026-02-11 14:00  coverage 0.019165  (23,849 of 24,315 rows lost)
  *     2026-05-14 03:00  coverage 0.712498  ( 6,478 of 22,532 rows lost)
+ *   those two have since been backfilled and no longer reproduce; an hour that
+ *   had not been repaired at time of writing:
+ *     2026-03-10 14:00  coverage 0.988355  (   264 of 22,670 rows lost)
  *
  * So the healthy distribution is a point mass at 1.0 and the failure signal is
  * 0.02–0.71. WARN at 0.999 sits ~1000x outside the observed noise while still
@@ -109,19 +113,30 @@ const gauges = (global.metricReconciliationGauges ??= Object.fromEntries(
 ) as Record<GaugeName, client.Gauge<string>>);
 
 /**
- * Registering the hook does not arm anything: `repairReactionMetrics` computes its
- * diff unconditionally but only inserts when `METRIC_REACTION_REPAIR_ENABLED` is
- * set, which defaults to false. With the flag off, a detection logs the additions
- * and removals it *would* have written — which is the evidence needed to decide
- * whether to turn it on.
+ * Registering the hook does not arm writes — `METRIC_REACTION_REPAIR_ENABLED`
+ * defaults to false and gates them.
+ *
+ * While it is off, the nightly path still runs the diff as a dry run so there is
+ * some production evidence of what enabling it would write. Without that, turning
+ * the flag on goes from zero observation straight to live inserts. Nightly is
+ * capped at 200 images, so the read cost is negligible. The hourly path stays
+ * fully gated: it fires on exactly the outage where extra read load is worst, and
+ * one measured outage hour flagged ~17k images.
+ *
+ * Once the flag is on, both paths repair for real.
  */
 setReactionRepairHook(async ({ imageIds, reason }) => {
-  const result = await repairReactionMetrics(imageIds);
+  const previewOnly = reason === 'nightly-exactness' && !env.METRIC_REACTION_REPAIR_ENABLED;
+  const result = await repairReactionMetrics(imageIds, { dryRun: previewOnly });
   await logToAxiom({
     type: 'metric-reconciliation',
     name: 'reaction-repair',
-    level: result.inserted ? 'info' : 'warn',
-    message: `repair ${reason}: +${result.additions} -${result.removals} inserted=${result.inserted}`,
+    // Alerting lives on the gauges, not here. The one condition needing a human is
+    // work this run dropped and nothing will pick up.
+    level: result.imagesSkippedOverCap > 0 ? 'warn' : 'info',
+    message: `repair ${reason}: +${result.additions} -${result.removals} inserted=${
+      result.inserted
+    }${result.skippedReason ? ` (${result.skippedReason})` : ''}`,
     error: JSON.stringify(result),
   }).catch(() => undefined);
 });

--- a/src/server/services/metric-reaction-repair.service.ts
+++ b/src/server/services/metric-reaction-repair.service.ts
@@ -1,0 +1,200 @@
+import { env } from '~/env/server';
+import { pgDbRead } from '~/server/db/pgDb';
+import { REACTION_METRICS } from '~/server/services/metric-reconciliation.service';
+
+/**
+ * Compensating-event repair for image reaction metrics.
+ *
+ * Kept out of `metric-reconciliation.service` because that module is read-only by
+ * construction and this one writes to ClickHouse. The detector must stay safe to
+ * run anywhere; this must not.
+ *
+ * Writes are gated on `METRIC_REACTION_REPAIR_ENABLED`, which defaults to false —
+ * merging this cannot start mutating production. With the flag off the diff is
+ * still computed and returned, so the shape and volume of what it *would* write
+ * are observable before anything is enabled.
+ */
+
+const REACTION_METRIC_LIST = REACTION_METRICS.map((m) => `'${m}'`).join(',');
+const CH_MEMORY_LIMIT = 4_000_000_000;
+const ENTITY_TYPE = 'Image';
+
+export type ReactionRepairResult = {
+  imagesRequested: number;
+  imagesLive: number;
+  /** Requested images no longer in Postgres. Their removals are skipped, not counted. */
+  imagesSkippedDeleted: number;
+  additions: number;
+  removals: number;
+  pairsSkippedExcludedUser: number;
+  /** False when the env gate is off or there was nothing to write. */
+  inserted: boolean;
+  durationMs: number;
+};
+
+type EventRow = {
+  entityType: string;
+  entityId: number;
+  userId: number;
+  metricType: string;
+  metricValue: number;
+  createdAt: string;
+};
+
+const key = (imageId: number, userId: number, reaction: string) =>
+  `${imageId}|${userId}|${reaction}`;
+
+/** ClickHouse DateTime's native text format. Avoids relying on best-effort ISO parsing. */
+function toChDateTime(date: Date) {
+  return date.toISOString().slice(0, 19).replace('T', ' ');
+}
+
+/**
+ * Rebuilds the compensating events needed to make ClickHouse agree with Postgres
+ * for `imageIds`. Safe to re-run: `entityMetricEvents_month` is a ReplacingMergeTree
+ * ordered by (entityType, entityId, metricType, userId, createdAt), so an addition
+ * replayed at the reaction's own timestamp collapses onto the existing row instead
+ * of double-counting.
+ */
+export async function repairReactionMetrics(
+  imageIds: number[],
+  { dryRun = false }: { dryRun?: boolean } = {}
+): Promise<ReactionRepairResult> {
+  const startedAt = Date.now();
+  const empty: ReactionRepairResult = {
+    imagesRequested: imageIds.length,
+    imagesLive: 0,
+    imagesSkippedDeleted: 0,
+    additions: 0,
+    removals: 0,
+    pairsSkippedExcludedUser: 0,
+    inserted: false,
+    durationMs: 0,
+  };
+  if (!imageIds.length) return { ...empty, durationMs: Date.now() - startedAt };
+
+  const { clickhouse } = await import('~/server/clickhouse/client');
+  if (!clickhouse) throw new Error('clickhouse client unavailable');
+
+  /**
+   * Removals are stamped strictly before Postgres is read, so a reaction created
+   * during or after the read outranks this `-1` under argMax rather than being
+   * cancelled by it. Captured before the first query for that reason.
+   */
+  const removalAt = toChDateTime(new Date(Date.now() - 1000));
+
+  const { rows: liveRows } = await pgDbRead.query<{ id: number }>(
+    'SELECT id FROM "Image" WHERE id = ANY($1::int[])',
+    [imageIds]
+  );
+  const liveIds = liveRows.map((r) => r.id);
+  const imagesSkippedDeleted = imageIds.length - liveIds.length;
+  if (!liveIds.length) {
+    return { ...empty, imagesSkippedDeleted, durationMs: Date.now() - startedAt };
+  }
+
+  /**
+   * `createdAt` is formatted in SQL, not JS. It is `timestamp without time zone`
+   * holding UTC, and the pg driver parses that type using the process timezone —
+   * reading it into a Date and formatting it back would shift every repaired
+   * event by the pod's offset.
+   */
+  const { rows: pgPairs } = await pgDbRead.query<{
+    imageId: number;
+    userId: number;
+    reaction: string;
+    createdAt: string;
+  }>(
+    `SELECT "imageId", "userId", reaction::text AS reaction,
+            to_char("createdAt", 'YYYY-MM-DD HH24:MI:SS') AS "createdAt"
+       FROM "ImageReaction" WHERE "imageId" = ANY($1::int[])`,
+    [liveIds]
+  );
+
+  const excludedRows = await clickhouse.$query<{ userId: number }>`
+    SELECT userId FROM metricExcludedUsers FINAL WHERE active = 1
+  `;
+  const excluded = new Set(excludedRows.map((r) => Number(r.userId)));
+
+  const chPairs = await clickhouse.$query<{
+    entityId: number;
+    userId: number;
+    metricType: string;
+  }>`
+    SELECT entityId, userId, metricType
+      FROM entityMetricUserState_v3
+     WHERE entityType = 'Image'
+       AND entityId IN (${liveIds})
+       AND metricType IN (${REACTION_METRIC_LIST})
+     GROUP BY entityId, userId, metricType
+    HAVING argMaxMerge(latest) > 0
+    SETTINGS max_memory_usage = ${CH_MEMORY_LIMIT}
+  `;
+
+  const pgSet = new Set(pgPairs.map((r) => key(r.imageId, r.userId, r.reaction)));
+  const chSet = new Set(
+    chPairs.map((r) => key(Number(r.entityId), Number(r.userId), r.metricType))
+  );
+
+  const values: EventRow[] = [];
+  let additions = 0;
+  let removals = 0;
+  let pairsSkippedExcludedUser = 0;
+
+  for (const r of pgPairs) {
+    if (excluded.has(r.userId)) {
+      pairsSkippedExcludedUser++;
+      continue;
+    }
+    if (chSet.has(key(r.imageId, r.userId, r.reaction))) continue;
+    values.push({
+      entityType: ENTITY_TYPE,
+      entityId: r.imageId,
+      userId: r.userId,
+      metricType: r.reaction,
+      metricValue: 1,
+      createdAt: r.createdAt,
+    });
+    additions++;
+  }
+
+  for (const r of chPairs) {
+    const entityId = Number(r.entityId);
+    const userId = Number(r.userId);
+    if (excluded.has(userId)) {
+      pairsSkippedExcludedUser++;
+      continue;
+    }
+    if (pgSet.has(key(entityId, userId, r.metricType))) continue;
+    values.push({
+      entityType: ENTITY_TYPE,
+      entityId,
+      userId,
+      metricType: r.metricType,
+      metricValue: -1,
+      createdAt: removalAt,
+    });
+    removals++;
+  }
+
+  const shouldWrite = env.METRIC_REACTION_REPAIR_ENABLED && !dryRun && values.length > 0;
+  if (shouldWrite) {
+    await clickhouse.insert({
+      table: 'entityMetricEvents_month',
+      values,
+      format: 'JSONEachRow',
+      clickhouse_settings: { max_memory_usage: String(CH_MEMORY_LIMIT) },
+    });
+  }
+
+  return {
+    imagesRequested: imageIds.length,
+    imagesLive: liveIds.length,
+    imagesSkippedDeleted,
+    additions,
+    removals,
+    pairsSkippedExcludedUser,
+    inserted: shouldWrite,
+    durationMs: Date.now() - startedAt,
+  };
+}

--- a/src/server/services/metric-reaction-repair.service.ts
+++ b/src/server/services/metric-reaction-repair.service.ts
@@ -9,10 +9,16 @@ import { REACTION_METRICS } from '~/server/services/metric-reconciliation.servic
  * construction and this one writes to ClickHouse. The detector must stay safe to
  * run anywhere; this must not.
  *
- * Writes are gated on `METRIC_REACTION_REPAIR_ENABLED`, which defaults to false —
- * merging this cannot start mutating production. With the flag off the diff is
- * still computed and returned, so the shape and volume of what it *would* write
- * are observable before anything is enabled.
+ * Gated on `METRIC_REACTION_REPAIR_ENABLED`, which defaults to false — merging this
+ * cannot start mutating production. The gate is checked before any I/O, not just
+ * before the insert: a detection means ClickHouse is already unhealthy, so running
+ * the read load anyway would add load at the worst moment.
+ *
+ * That leaves no free preview, so callers wanting the diff without the writes must
+ * ask for it explicitly with `dryRun` — which reads normally and never inserts. The
+ * nightly job does exactly that while the flag is off (see the hook registration in
+ * `jobs/metric-reconciliation-audit`), because otherwise enabling the flag would be
+ * the first time anyone sees what it writes.
  */
 
 const REACTION_METRIC_LIST = REACTION_METRICS.map((m) => `'${m}'`).join(',');

--- a/src/server/services/metric-reaction-repair.service.ts
+++ b/src/server/services/metric-reaction-repair.service.ts
@@ -19,16 +19,33 @@ const REACTION_METRIC_LIST = REACTION_METRICS.map((m) => `'${m}'`).join(',');
 const CH_MEMORY_LIMIT = 4_000_000_000;
 const ENTITY_TYPE = 'Image';
 
+/**
+ * A detector breach during a real CDC outage flags essentially every image in the
+ * hour. Measured on one such hour: 16,828 images / 1,065,041 reaction rows / up to
+ * 15,509 rows on a single image. Unbatched that is a ~1M-row read into node memory,
+ * a 16.8k-element interpolated `IN (...)`, and a single ~1M-object insert — issued
+ * at exactly the moment ClickHouse is least healthy. Batching bounds every one of
+ * those; the cap bounds total work per invocation and reports what it dropped
+ * rather than silently truncating.
+ */
+const BATCH_SIZE = 250;
+const MAX_IMAGES_PER_RUN = 5_000;
+
 export type ReactionRepairResult = {
   imagesRequested: number;
+  /** Images beyond MAX_IMAGES_PER_RUN, not processed. Non-zero means re-run. */
+  imagesSkippedOverCap: number;
   imagesLive: number;
   /** Requested images no longer in Postgres. Their removals are skipped, not counted. */
   imagesSkippedDeleted: number;
   additions: number;
   removals: number;
+  /** Distinct (image, user, reaction) pairs skipped because the user is excluded. */
   pairsSkippedExcludedUser: number;
-  /** False when the env gate is off or there was nothing to write. */
+  /** True only if at least one batch was actually written. */
   inserted: boolean;
+  /** Why nothing was written, when nothing was. */
+  skippedReason?: 'disabled' | 'dry-run' | 'no-changes';
   durationMs: number;
 };
 
@@ -44,11 +61,6 @@ type EventRow = {
 const key = (imageId: number, userId: number, reaction: string) =>
   `${imageId}|${userId}|${reaction}`;
 
-/** ClickHouse DateTime's native text format. Avoids relying on best-effort ISO parsing. */
-function toChDateTime(date: Date) {
-  return date.toISOString().slice(0, 19).replace('T', ' ');
-}
-
 /**
  * Rebuilds the compensating events needed to make ClickHouse agree with Postgres
  * for `imageIds`. Safe to re-run: `entityMetricEvents_month` is a ReplacingMergeTree
@@ -61,8 +73,9 @@ export async function repairReactionMetrics(
   { dryRun = false }: { dryRun?: boolean } = {}
 ): Promise<ReactionRepairResult> {
   const startedAt = Date.now();
-  const empty: ReactionRepairResult = {
+  const base: ReactionRepairResult = {
     imagesRequested: imageIds.length,
+    imagesSkippedOverCap: 0,
     imagesLive: 0,
     imagesSkippedDeleted: 0,
     additions: 0,
@@ -71,130 +84,164 @@ export async function repairReactionMetrics(
     inserted: false,
     durationMs: 0,
   };
-  if (!imageIds.length) return { ...empty, durationMs: Date.now() - startedAt };
+  const done = (r: Partial<ReactionRepairResult>) => ({
+    ...base,
+    ...r,
+    durationMs: Date.now() - startedAt,
+  });
+
+  /**
+   * Gate before any I/O, not just before the insert. A detection means ClickHouse
+   * is already unhealthy, and running the full read load on every breach while the
+   * writes are disabled is the worst time to be adding load. `dryRun` is the
+   * explicit operator opt-in for measuring the diff without arming writes.
+   */
+  if (!env.METRIC_REACTION_REPAIR_ENABLED && !dryRun) return done({ skippedReason: 'disabled' });
+  if (!imageIds.length) return done({ skippedReason: 'no-changes' });
 
   const { clickhouse } = await import('~/server/clickhouse/client');
   if (!clickhouse) throw new Error('clickhouse client unavailable');
 
-  /**
-   * Removals are stamped strictly before Postgres is read, so a reaction created
-   * during or after the read outranks this `-1` under argMax rather than being
-   * cancelled by it. Captured before the first query for that reason.
-   */
-  const removalAt = toChDateTime(new Date(Date.now() - 1000));
-
-  const { rows: liveRows } = await pgDbRead.query<{ id: number }>(
-    'SELECT id FROM "Image" WHERE id = ANY($1::int[])',
-    [imageIds]
-  );
-  const liveIds = liveRows.map((r) => r.id);
-  const imagesSkippedDeleted = imageIds.length - liveIds.length;
-  if (!liveIds.length) {
-    return { ...empty, imagesSkippedDeleted, durationMs: Date.now() - startedAt };
-  }
+  const targets = imageIds.slice(0, MAX_IMAGES_PER_RUN);
+  const imagesSkippedOverCap = imageIds.length - targets.length;
 
   /**
-   * `createdAt` is formatted in SQL, not JS. It is `timestamp without time zone`
-   * holding UTC, and the pg driver parses that type using the process timezone —
-   * reading it into a Date and formatting it back would shift every repaired
-   * event by the pod's offset.
+   * Derived from the replica's replay position rather than wall clock. `pgDbRead`
+   * is a replica, and Debezium reads the primary's WAL — so a reaction committed
+   * within the replication lag is already in ClickHouse but not yet visible here.
+   * It would appear only in `chPairs`, look like a phantom, and earn a `-1`. A
+   * hardcoded `now() - 1s` is only safe while lag stays under a second; anchoring
+   * to the replay position means the stamp is always older than anything the
+   * replica cannot yet see, whatever the lag. On a primary the function returns
+   * NULL and this falls back to `now()`.
    */
-  const { rows: pgPairs } = await pgDbRead.query<{
-    imageId: number;
-    userId: number;
-    reaction: string;
-    createdAt: string;
-  }>(
-    `SELECT "imageId", "userId", reaction::text AS reaction,
-            to_char("createdAt", 'YYYY-MM-DD HH24:MI:SS') AS "createdAt"
-       FROM "ImageReaction" WHERE "imageId" = ANY($1::int[])`,
-    [liveIds]
+  const { rows: clockRows } = await pgDbRead.query<{ removalAt: string }>(
+    `SELECT to_char(
+              COALESCE(pg_last_xact_replay_timestamp(), now()) AT TIME ZONE 'utc'
+                - interval '1 second',
+              'YYYY-MM-DD HH24:MI:SS') AS "removalAt"`
   );
+  const removalAt = clockRows[0].removalAt;
 
   const excludedRows = await clickhouse.$query<{ userId: number }>`
     SELECT userId FROM metricExcludedUsers FINAL WHERE active = 1
+    SETTINGS max_memory_usage = ${CH_MEMORY_LIMIT}
   `;
   const excluded = new Set(excludedRows.map((r) => Number(r.userId)));
 
-  const chPairs = await clickhouse.$query<{
-    entityId: number;
-    userId: number;
-    metricType: string;
-  }>`
-    SELECT entityId, userId, metricType
-      FROM entityMetricUserState_v3
-     WHERE entityType = 'Image'
-       AND entityId IN (${liveIds})
-       AND metricType IN (${REACTION_METRIC_LIST})
-     GROUP BY entityId, userId, metricType
-    HAVING argMaxMerge(latest) > 0
-    SETTINGS max_memory_usage = ${CH_MEMORY_LIMIT}
-  `;
-
-  const pgSet = new Set(pgPairs.map((r) => key(r.imageId, r.userId, r.reaction)));
-  const chSet = new Set(
-    chPairs.map((r) => key(Number(r.entityId), Number(r.userId), r.metricType))
-  );
-
-  const values: EventRow[] = [];
+  let imagesLive = 0;
   let additions = 0;
   let removals = 0;
-  let pairsSkippedExcludedUser = 0;
+  let inserted = false;
+  const skippedPairs = new Set<string>();
 
-  for (const r of pgPairs) {
-    if (excluded.has(r.userId)) {
-      pairsSkippedExcludedUser++;
-      continue;
+  for (let offset = 0; offset < targets.length; offset += BATCH_SIZE) {
+    const batch = targets.slice(offset, offset + BATCH_SIZE);
+
+    const { rows: liveRows } = await pgDbRead.query<{ id: number }>(
+      'SELECT id FROM "Image" WHERE id = ANY($1::int[])',
+      [batch]
+    );
+    const liveIds = liveRows.map((r) => r.id);
+    if (!liveIds.length) continue;
+    imagesLive += liveIds.length;
+
+    /**
+     * `createdAt` is formatted in SQL, not JS. It is `timestamp without time zone`
+     * holding UTC, and the pg driver parses that type using the process timezone —
+     * reading it into a Date and formatting it back would shift every repaired
+     * event by the pod's offset.
+     */
+    const { rows: pgPairs } = await pgDbRead.query<{
+      imageId: number;
+      userId: number;
+      reaction: string;
+      createdAt: string;
+    }>(
+      `SELECT "imageId", "userId", reaction::text AS reaction,
+              to_char("createdAt", 'YYYY-MM-DD HH24:MI:SS') AS "createdAt"
+         FROM "ImageReaction" WHERE "imageId" = ANY($1::int[])`,
+      [liveIds]
+    );
+
+    const chPairs = await clickhouse.$query<{
+      entityId: number;
+      userId: number;
+      metricType: string;
+    }>`
+      SELECT entityId, userId, metricType
+        FROM entityMetricUserState_v3
+       WHERE entityType = 'Image'
+         AND entityId IN (${liveIds})
+         AND metricType IN (${REACTION_METRIC_LIST})
+       GROUP BY entityId, userId, metricType
+      HAVING argMaxMerge(latest) > 0
+      SETTINGS max_memory_usage = ${CH_MEMORY_LIMIT}
+    `;
+
+    const pgSet = new Set(pgPairs.map((r) => key(r.imageId, r.userId, r.reaction)));
+    const chSet = new Set(
+      chPairs.map((r) => key(Number(r.entityId), Number(r.userId), r.metricType))
+    );
+
+    const values: EventRow[] = [];
+    for (const r of pgPairs) {
+      const k = key(r.imageId, r.userId, r.reaction);
+      if (excluded.has(r.userId)) {
+        skippedPairs.add(k);
+        continue;
+      }
+      if (chSet.has(k)) continue;
+      values.push({
+        entityType: ENTITY_TYPE,
+        entityId: r.imageId,
+        userId: r.userId,
+        metricType: r.reaction,
+        metricValue: 1,
+        createdAt: r.createdAt,
+      });
+      additions++;
     }
-    if (chSet.has(key(r.imageId, r.userId, r.reaction))) continue;
-    values.push({
-      entityType: ENTITY_TYPE,
-      entityId: r.imageId,
-      userId: r.userId,
-      metricType: r.reaction,
-      metricValue: 1,
-      createdAt: r.createdAt,
-    });
-    additions++;
-  }
 
-  for (const r of chPairs) {
-    const entityId = Number(r.entityId);
-    const userId = Number(r.userId);
-    if (excluded.has(userId)) {
-      pairsSkippedExcludedUser++;
-      continue;
+    for (const r of chPairs) {
+      const entityId = Number(r.entityId);
+      const userId = Number(r.userId);
+      const k = key(entityId, userId, r.metricType);
+      if (excluded.has(userId)) {
+        skippedPairs.add(k);
+        continue;
+      }
+      if (pgSet.has(k)) continue;
+      values.push({
+        entityType: ENTITY_TYPE,
+        entityId,
+        userId,
+        metricType: r.metricType,
+        metricValue: -1,
+        createdAt: removalAt,
+      });
+      removals++;
     }
-    if (pgSet.has(key(entityId, userId, r.metricType))) continue;
-    values.push({
-      entityType: ENTITY_TYPE,
-      entityId,
-      userId,
-      metricType: r.metricType,
-      metricValue: -1,
-      createdAt: removalAt,
-    });
-    removals++;
+
+    if (!dryRun && values.length > 0) {
+      await clickhouse.insert({
+        table: 'entityMetricEvents_month',
+        values,
+        format: 'JSONEachRow',
+        clickhouse_settings: { max_memory_usage: String(CH_MEMORY_LIMIT) },
+      });
+      inserted = true;
+    }
   }
 
-  const shouldWrite = env.METRIC_REACTION_REPAIR_ENABLED && !dryRun && values.length > 0;
-  if (shouldWrite) {
-    await clickhouse.insert({
-      table: 'entityMetricEvents_month',
-      values,
-      format: 'JSONEachRow',
-      clickhouse_settings: { max_memory_usage: String(CH_MEMORY_LIMIT) },
-    });
-  }
-
-  return {
-    imagesRequested: imageIds.length,
-    imagesLive: liveIds.length,
-    imagesSkippedDeleted,
+  return done({
+    imagesSkippedOverCap,
+    imagesLive,
+    imagesSkippedDeleted: targets.length - imagesLive,
     additions,
     removals,
-    pairsSkippedExcludedUser,
-    inserted: shouldWrite,
-    durationMs: Date.now() - startedAt,
-  };
+    pairsSkippedExcludedUser: skippedPairs.size,
+    inserted,
+    skippedReason: inserted ? undefined : dryRun ? 'dry-run' : 'no-changes',
+  });
 }

--- a/src/server/services/metric-reconciliation.service.ts
+++ b/src/server/services/metric-reconciliation.service.ts
@@ -18,11 +18,38 @@ export const REACTION_METRICS = ['Like', 'Heart', 'Laugh', 'Cry'] as const;
 export type ReactionMetric = (typeof REACTION_METRICS)[number];
 
 /**
+ * The reaction rename landed in Nov 2025 (2025-10: 34.0M legacy / 3 short;
+ * 2025-12: 0 legacy / 20.9M short), and `entityMetricEvents_month` still holds
+ * both spellings. `entityMetricUserState_v3` is canonical-only, so only the event
+ * table needs the legacy names — reading it with short names alone would see 14 of
+ * 54,272 rows on a pre-rename hour and report ~0.0003 coverage, which is
+ * indistinguishable from total CDC loss on an hour where nothing was lost.
+ */
+const LEGACY_REACTION_METRICS = [
+  'ReactionLike',
+  'ReactionHeart',
+  'ReactionLaugh',
+  'ReactionCry',
+] as const;
+
+/**
  * `clickhouse.$query` interpolates rather than binds, and its array branch joins
  * with `,` and no quoting — a string array would render as bare identifiers.
  * Numeric arrays are fine inline; string lists have to arrive pre-quoted.
  */
-const REACTION_METRIC_LIST = REACTION_METRICS.map((m) => `'${m}'`).join(',');
+const quoteList = (values: readonly string[]) => values.map((v) => `'${v}'`).join(',');
+/** `entityMetricUserState_v3` — canonical names only. */
+const REACTION_METRIC_LIST = quoteList(REACTION_METRICS);
+/** `entityMetricEvents_month` — spans the rename, so both spellings. */
+const EVENT_METRIC_LIST = quoteList([...REACTION_METRICS, ...LEGACY_REACTION_METRICS]);
+
+/** Folds legacy spellings onto canonical ones. Mirrors `entityMetricDirty_v3_mv`. */
+const CANONICAL_METRIC_SQL = `multiIf(
+  metricType = 'ReactionLike', 'Like',
+  metricType = 'ReactionHeart', 'Heart',
+  metricType = 'ReactionLaugh', 'Laugh',
+  metricType = 'ReactionCry', 'Cry',
+  metricType)`;
 
 const CH_MEMORY_LIMIT = 4_000_000_000;
 
@@ -135,23 +162,43 @@ const key = (imageId: number, userId: number, reaction: string) =>
  */
 const toPgTimestamp = (date: Date) => date.toISOString();
 
-/** Smallest id whose createdAt >= ts. Each probe is a pkey index scan. */
-async function findIdAtOrAfter(ts: string, lo: number, hi: number) {
+/**
+ * Smallest id at which the table has reached `ts`. Each probe is a pkey index scan.
+ *
+ * The probe deliberately looks *backwards* (`id <= mid ORDER BY id DESC`). Probing
+ * forwards returns the smallest existing id >= mid, which for sparse ids can be
+ * >= `hi` — and `hi = thatId` then moves nothing, `lo` moves nothing, `mid`
+ * recomputes identically, and the loop spins forever issuing the same query.
+ * `ImageReaction` ids are sparse because un-reactions delete rows, so that is the
+ * ordinary case, not an edge: the forwards form stalled on 2 of 10 consecutive
+ * recent hours. Looking backwards keeps `mid < hi` invariant, so every branch
+ * strictly moves a bound and termination is structural.
+ */
+async function findIdAtOrAfter(ts: string, lo: number, hi: number, checkCanceled?: () => void) {
+  // Structural termination is the guarantee; this only converts a future
+  // regression into a loud failure instead of a silent spin.
+  const maxIterations = Math.ceil(Math.log2(Math.max(2, hi - lo))) + 2;
+  let iterations = 0;
   while (lo < hi) {
+    checkCanceled?.();
+    if (++iterations > maxIterations) {
+      throw new Error(
+        `findIdAtOrAfter exceeded ${maxIterations} iterations (lo=${lo} hi=${hi} ts=${ts}) — binary search is not converging`
+      );
+    }
     const mid = Math.floor((lo + hi) / 2);
-    const { rows } = await pgDbRead.query<{ id: number; reached: boolean }>(
-      `SELECT id, ("createdAt" >= $2::timestamp) AS reached
-         FROM "ImageReaction" WHERE id >= $1 ORDER BY id LIMIT 1`,
+    const { rows } = await pgDbRead.query<{ reached: boolean }>(
+      `SELECT ("createdAt" >= $2::timestamp) AS reached
+         FROM "ImageReaction" WHERE id <= $1 ORDER BY id DESC LIMIT 1`,
       [mid, ts]
     );
-    if (!rows.length) hi = mid;
-    else if (!rows[0].reached) lo = rows[0].id + 1;
-    else hi = rows[0].id;
+    if (rows.length && rows[0].reached) hi = mid;
+    else lo = mid + 1;
   }
   return lo;
 }
 
-async function readPgReactionsForHour(hourStart: Date) {
+async function readPgReactionsForHour(hourStart: Date, checkCanceled?: () => void) {
   const start = toPgTimestamp(hourStart);
   const end = toPgTimestamp(new Date(hourStart.getTime() + 3_600_000));
   const { rows: maxRows } = await pgDbRead.query<{ max: string | null }>(
@@ -160,8 +207,8 @@ async function readPgReactionsForHour(hourStart: Date) {
   const maxId = Number(maxRows[0]?.max ?? 0);
   if (!maxId) return [];
 
-  const loId = Math.max(1, (await findIdAtOrAfter(start, 1, maxId)) - ID_PAD);
-  const hiId = Math.min(maxId, (await findIdAtOrAfter(end, loId, maxId)) + ID_PAD);
+  const loId = Math.max(1, (await findIdAtOrAfter(start, 1, maxId, checkCanceled)) - ID_PAD);
+  const hiId = Math.min(maxId, (await findIdAtOrAfter(end, loId, maxId, checkCanceled)) + ID_PAD);
 
   const { rows } = await pgDbRead.query<{ imageId: number; userId: number; reaction: string }>(
     `SELECT "imageId", "userId", reaction::text AS reaction
@@ -178,18 +225,21 @@ async function readPgReactionsForHour(hourStart: Date) {
  * ClickHouse. Healthy is exactly 1.0 — see the job for the measured
  * distribution and the threshold derived from it.
  */
-export async function auditReactionHour(hourStart: Date): Promise<HourlyCoverageResult> {
+export async function auditReactionHour(
+  hourStart: Date,
+  { checkCanceled }: { checkCanceled?: () => void } = {}
+): Promise<HourlyCoverageResult> {
   const startedAt = Date.now();
   const { clickhouse } = await import('~/server/clickhouse/client');
   if (!clickhouse) throw new Error('clickhouse client unavailable');
 
-  const pgRows = await readPgReactionsForHour(hourStart);
+  const pgRows = await readPgReactionsForHour(hourStart, checkCanceled);
 
   const chRows = await clickhouse.$query<{ entityId: number; userId: number; metricType: string }>`
-    SELECT entityId, userId, metricType
+    SELECT entityId, userId, ${CANONICAL_METRIC_SQL} AS metricType
       FROM entityMetricEvents_month
      WHERE entityType = 'Image'
-       AND metricType IN (${REACTION_METRIC_LIST})
+       AND metricType IN (${EVENT_METRIC_LIST})
        AND metricValue > 0
        AND createdAt >= ${hourStart} - INTERVAL ${BOUNDARY_MARGIN_MINUTES} MINUTE
        AND createdAt <  ${hourStart} + INTERVAL 1 HOUR + INTERVAL ${BOUNDARY_MARGIN_MINUTES} MINUTE
@@ -240,19 +290,26 @@ export async function auditReactionHour(hourStart: Date): Promise<HourlyCoverage
 export async function auditReactionExactness({
   sampleSize = 200,
   lookbackHours = 24,
-}: { sampleSize?: number; lookbackHours?: number } = {}): Promise<ExactnessResult> {
+  seed = 0,
+}: { sampleSize?: number; lookbackHours?: number; seed?: number } = {}): Promise<ExactnessResult> {
   const startedAt = Date.now();
   const { clickhouse } = await import('~/server/clickhouse/client');
   if (!clickhouse) throw new Error('clickhouse client unavailable');
 
+  /**
+   * `ORDER BY cityHash64(entityId)` is a stable ordering, not a random draw — the
+   * same seed over the same candidate set returns the same images. `seed` is what
+   * makes a run reproducible (and what lets a caller sweep several samples); the
+   * nightly job varies it by day so successive nights cover different images.
+   */
   const sampled = await clickhouse.$query<{ entityId: number }>`
     SELECT entityId
       FROM entityMetricEvents_month
      WHERE entityType = 'Image'
-       AND metricType IN (${REACTION_METRIC_LIST})
+       AND metricType IN (${EVENT_METRIC_LIST})
        AND createdAt > now() - INTERVAL ${lookbackHours} HOUR
      GROUP BY entityId
-     ORDER BY cityHash64(entityId)
+     ORDER BY cityHash64(entityId + ${seed})
      LIMIT ${sampleSize}
     SETTINGS max_memory_usage = ${CH_MEMORY_LIMIT}
   `;

--- a/src/server/services/metric-reconciliation.service.ts
+++ b/src/server/services/metric-reconciliation.service.ts
@@ -1,0 +1,378 @@
+import { pgDbRead } from '~/server/db/pgDb';
+
+/**
+ * Reaction-pipeline reconciliation.
+ *
+ * Everything else that watches this pipeline compares two points *inside* it
+ * (`entityMetricEvents_month` vs `entityMetricDailyAgg_v2`, Redis vs CH), so a
+ * loss at the CDC boundary is invisible to all of them. These two checks are the
+ * only ones that read Postgres — the actual source of truth — on one arm.
+ *
+ * Direction matters: we assert PG -> CH, never a count ratio. An un-reaction
+ * deletes the PG row but leaves its `+1` in ClickHouse forever, so raw counts
+ * disagree by a few percent that *grows with the age of the window*; a surviving
+ * PG row with no matching CH `+1` has no benign explanation.
+ */
+
+export const REACTION_METRICS = ['Like', 'Heart', 'Laugh', 'Cry'] as const;
+export type ReactionMetric = (typeof REACTION_METRICS)[number];
+
+/**
+ * `clickhouse.$query` interpolates rather than binds, and its array branch joins
+ * with `,` and no quoting — a string array would render as bare identifiers.
+ * Numeric arrays are fine inline; string lists have to arrive pre-quoted.
+ */
+const REACTION_METRIC_LIST = REACTION_METRICS.map((m) => `'${m}'`).join(',');
+
+const CH_MEMORY_LIMIT = 4_000_000_000;
+
+/**
+ * Debezium stamps CH `createdAt` from the Postgres *commit* time while PG stamps
+ * its own `createdAt` at statement time, so a row can land one bucket over.
+ * Widening only the CH side is safe: it can add false matches for rows outside
+ * the window, never hide a real drop.
+ */
+const BOUNDARY_MARGIN_MINUTES = 5;
+
+/**
+ * `ImageReaction` has no index on `createdAt` (see `pg_indexes`), so a bare
+ * `WHERE "createdAt" >= …` is a parallel seq scan over 245M rows — 6.4M buffers
+ * and ~15s per call. `id` is a monotonic serial, so we binary-search the pkey
+ * for the id bounds and range-scan those instead (~250ms). The pad absorbs the
+ * id/createdAt skew from concurrent inserts; `createdAt` is still filtered
+ * exactly, so the pad only ever costs a few extra heap rows.
+ */
+const ID_PAD = 50_000;
+
+export type HourlyCoverageResult = {
+  hourStart: Date;
+  pgRows: number;
+  matched: number;
+  missing: number;
+  /** null when the hour had no PG rows at all — an undefined ratio, not a failure. */
+  coverage: number | null;
+  /** PG reaction values with no CH metricType mapping. Non-zero means a mapping gap. */
+  unknownReactions: Record<string, number>;
+  affectedImageIds: number[];
+  durationMs: number;
+};
+
+export type ExactnessResult = {
+  imagesSampled: number;
+  /** Sampled images whose PG row is gone (deleted image). Excluded from the rates. */
+  imagesDeleted: number;
+  pairsChecked: number;
+  pairsExact: number;
+  /** In PG, absent from CH. Real data loss. */
+  missingInCh: number;
+  /** In CH, absent from PG. Mostly the known un-reaction residual (~0.37%). */
+  phantomInCh: number;
+  coverage: number | null;
+  /** Coverage restricted to reactions created inside the lookback. The health signal. */
+  recentCoverage: number | null;
+  /** Coverage over everything older — a burn-down of un-repaired history, not live health. */
+  backlogCoverage: number | null;
+  recentPairs: number;
+  backlogPairs: number;
+  phantomRate: number | null;
+  affectedImageIds: number[];
+  durationMs: number;
+};
+
+const EMPTY_EXACTNESS = {
+  pairsChecked: 0,
+  pairsExact: 0,
+  missingInCh: 0,
+  phantomInCh: 0,
+  coverage: null,
+  recentCoverage: null,
+  backlogCoverage: null,
+  recentPairs: 0,
+  backlogPairs: 0,
+  phantomRate: null,
+  affectedImageIds: [],
+} satisfies Partial<ExactnessResult>;
+
+/**
+ * Handed the images a check found wrong, so a detection can trigger a fix
+ * instead of only an alert. Implementations compute the per-user diff against
+ * Postgres and insert compensating +1/-1 rows into `entityMetricEvents_month`.
+ *
+ * Deliberately not implemented here: repair writes to ClickHouse, and wiring
+ * that to an automatic trigger before the detector has a track record risks
+ * amplifying a detector bug into data corruption. Register a hook when ready.
+ */
+export type ReactionRepairRequest = {
+  imageIds: number[];
+  reason: 'hourly-coverage' | 'nightly-exactness';
+  detectedAt: Date;
+  windowStart?: Date;
+  windowEnd?: Date;
+};
+export type ReactionRepairHook = (request: ReactionRepairRequest) => Promise<void>;
+
+let repairHook: ReactionRepairHook | undefined;
+export function setReactionRepairHook(hook: ReactionRepairHook | undefined) {
+  repairHook = hook;
+}
+export async function requestReactionRepair(request: ReactionRepairRequest) {
+  if (!repairHook || request.imageIds.length === 0) return false;
+  await repairHook(request);
+  return true;
+}
+
+const key = (imageId: number, userId: number, reaction: string) =>
+  `${imageId}|${userId}|${reaction}`;
+
+/**
+ * `ImageReaction.createdAt` is `timestamp without time zone` holding UTC, and both
+ * directions of the pg driver's conversion for that type go through the *process*
+ * timezone: a JS `Date` parameter is serialized with the local offset (which PG then
+ * discards), and a returned value is parsed as local. On any pod not running UTC
+ * both silently shift the audit window by the offset. Passing UTC ISO strings and
+ * casting to `timestamp` — and never comparing a returned timestamp in JS — makes
+ * the whole path independent of where it runs.
+ */
+const toPgTimestamp = (date: Date) => date.toISOString();
+
+/** Smallest id whose createdAt >= ts. Each probe is a pkey index scan. */
+async function findIdAtOrAfter(ts: string, lo: number, hi: number) {
+  while (lo < hi) {
+    const mid = Math.floor((lo + hi) / 2);
+    const { rows } = await pgDbRead.query<{ id: number; reached: boolean }>(
+      `SELECT id, ("createdAt" >= $2::timestamp) AS reached
+         FROM "ImageReaction" WHERE id >= $1 ORDER BY id LIMIT 1`,
+      [mid, ts]
+    );
+    if (!rows.length) hi = mid;
+    else if (!rows[0].reached) lo = rows[0].id + 1;
+    else hi = rows[0].id;
+  }
+  return lo;
+}
+
+async function readPgReactionsForHour(hourStart: Date) {
+  const start = toPgTimestamp(hourStart);
+  const end = toPgTimestamp(new Date(hourStart.getTime() + 3_600_000));
+  const { rows: maxRows } = await pgDbRead.query<{ max: string | null }>(
+    'SELECT max(id) AS max FROM "ImageReaction"'
+  );
+  const maxId = Number(maxRows[0]?.max ?? 0);
+  if (!maxId) return [];
+
+  const loId = Math.max(1, (await findIdAtOrAfter(start, 1, maxId)) - ID_PAD);
+  const hiId = Math.min(maxId, (await findIdAtOrAfter(end, loId, maxId)) + ID_PAD);
+
+  const { rows } = await pgDbRead.query<{ imageId: number; userId: number; reaction: string }>(
+    `SELECT "imageId", "userId", reaction::text AS reaction
+       FROM "ImageReaction"
+      WHERE id BETWEEN $1 AND $2
+        AND "createdAt" >= $3::timestamp AND "createdAt" < $4::timestamp`,
+    [loId, hiId, start, end]
+  );
+  return rows;
+}
+
+/**
+ * Fraction of Postgres reaction rows created in `hourStart` that reached
+ * ClickHouse. Healthy is exactly 1.0 — see the job for the measured
+ * distribution and the threshold derived from it.
+ */
+export async function auditReactionHour(hourStart: Date): Promise<HourlyCoverageResult> {
+  const startedAt = Date.now();
+  const { clickhouse } = await import('~/server/clickhouse/client');
+  if (!clickhouse) throw new Error('clickhouse client unavailable');
+
+  const pgRows = await readPgReactionsForHour(hourStart);
+
+  const chRows = await clickhouse.$query<{ entityId: number; userId: number; metricType: string }>`
+    SELECT entityId, userId, metricType
+      FROM entityMetricEvents_month
+     WHERE entityType = 'Image'
+       AND metricType IN (${REACTION_METRIC_LIST})
+       AND metricValue > 0
+       AND createdAt >= ${hourStart} - INTERVAL ${BOUNDARY_MARGIN_MINUTES} MINUTE
+       AND createdAt <  ${hourStart} + INTERVAL 1 HOUR + INTERVAL ${BOUNDARY_MARGIN_MINUTES} MINUTE
+     GROUP BY entityId, userId, metricType
+    SETTINGS max_memory_usage = ${CH_MEMORY_LIMIT}
+  `;
+
+  const chSet = new Set(chRows.map((r) => key(r.entityId, r.userId, r.metricType)));
+  const known = new Set<string>(REACTION_METRICS);
+
+  const unknownReactions: Record<string, number> = {};
+  const affected = new Set<number>();
+  let matched = 0;
+  let unknown = 0;
+
+  for (const row of pgRows) {
+    if (!known.has(row.reaction)) {
+      unknownReactions[row.reaction] = (unknownReactions[row.reaction] ?? 0) + 1;
+      unknown++;
+      continue;
+    }
+    if (chSet.has(key(row.imageId, row.userId, row.reaction))) matched++;
+    else affected.add(row.imageId);
+  }
+
+  const comparable = pgRows.length - unknown;
+  return {
+    hourStart,
+    pgRows: pgRows.length,
+    matched,
+    missing: comparable - matched,
+    coverage: comparable > 0 ? matched / comparable : null,
+    unknownReactions,
+    affectedImageIds: [...affected],
+    durationMs: Date.now() - startedAt,
+  };
+}
+
+/**
+ * Per-`(imageId, userId, reaction)` reconciliation for a sample of recently
+ * touched images. Catches what a volume check structurally cannot: phantom rows,
+ * a wrong metricType mapping, and dedupe regressions.
+ *
+ * Reaction totals are distinct users with `argMaxMerge(latest) > 0`, not a sum of
+ * events, so this compares membership of the live per-user set — reducing CH
+ * events to a count here would give the wrong answer.
+ */
+export async function auditReactionExactness({
+  sampleSize = 200,
+  lookbackHours = 24,
+}: { sampleSize?: number; lookbackHours?: number } = {}): Promise<ExactnessResult> {
+  const startedAt = Date.now();
+  const { clickhouse } = await import('~/server/clickhouse/client');
+  if (!clickhouse) throw new Error('clickhouse client unavailable');
+
+  const sampled = await clickhouse.$query<{ entityId: number }>`
+    SELECT entityId
+      FROM entityMetricEvents_month
+     WHERE entityType = 'Image'
+       AND metricType IN (${REACTION_METRIC_LIST})
+       AND createdAt > now() - INTERVAL ${lookbackHours} HOUR
+     GROUP BY entityId
+     ORDER BY cityHash64(entityId)
+     LIMIT ${sampleSize}
+    SETTINGS max_memory_usage = ${CH_MEMORY_LIMIT}
+  `;
+  const imageIds = sampled.map((r) => Number(r.entityId)).filter(Number.isFinite);
+  if (!imageIds.length) {
+    return {
+      ...EMPTY_EXACTNESS,
+      imagesSampled: 0,
+      imagesDeleted: 0,
+      durationMs: Date.now() - startedAt,
+    };
+  }
+
+  /**
+   * Reactions on deleted images live in ClickHouse forever while Postgres
+   * cascades them away, so an image that no longer exists reports its entire
+   * reaction set as phantom. Restricting to live images is what keeps this
+   * check from being pure noise.
+   */
+  const { rows: liveRows } = await pgDbRead.query<{ id: number }>(
+    'SELECT id FROM "Image" WHERE id = ANY($1::int[])',
+    [imageIds]
+  );
+  const liveIds = liveRows.map((r) => r.id);
+  const imagesDeleted = imageIds.length - liveIds.length;
+  if (!liveIds.length) {
+    return {
+      ...EMPTY_EXACTNESS,
+      imagesSampled: imageIds.length,
+      imagesDeleted,
+      durationMs: Date.now() - startedAt,
+    };
+  }
+
+  /**
+   * `recent` splits the result into a live-health arm and a backlog arm. Sampling
+   * by image pulls in each image's ENTIRE reaction history, so an image touched
+   * today drags along reactions from the 2025-12..2026-06 outage that were never
+   * repaired. Measured 2026-08-07, the two arms differ by a factor of ~10 (see the
+   * job header) — collapsing them into one number produces a metric that tracks
+   * repair-job progress rather than pipeline health.
+   */
+  const { rows: pgPairs } = await pgDbRead.query<{
+    imageId: number;
+    userId: number;
+    reaction: string;
+    recent: boolean;
+  }>(
+    `SELECT "imageId", "userId", reaction::text AS reaction,
+            ("createdAt" > (now() AT TIME ZONE 'utc') - ($2 || ' hours')::interval) AS recent
+       FROM "ImageReaction" WHERE "imageId" = ANY($1::int[])`,
+    [liveIds, lookbackHours]
+  );
+
+  /**
+   * `argMaxMerge(latest) > 0` over the user-state view is the same predicate the
+   * site's totals use, so this reconciles what users actually see rather than
+   * the raw event log.
+   */
+  const chPairs = await clickhouse.$query<{
+    entityId: number;
+    userId: number;
+    metricType: string;
+  }>`
+    SELECT entityId, userId, metricType
+      FROM entityMetricUserState_v3
+     WHERE entityType = 'Image'
+       AND entityId IN (${liveIds})
+       AND metricType IN (${REACTION_METRIC_LIST})
+     GROUP BY entityId, userId, metricType
+    HAVING argMaxMerge(latest) > 0
+    SETTINGS max_memory_usage = ${CH_MEMORY_LIMIT}
+  `;
+
+  const pgSet = new Set(pgPairs.map((r) => key(r.imageId, r.userId, r.reaction)));
+  const chSet = new Set(chPairs.map((r) => key(r.entityId, r.userId, r.metricType)));
+
+  const affected = new Set<number>();
+  let missingInCh = 0;
+  let recentPairs = 0;
+  let recentMissing = 0;
+  let backlogPairs = 0;
+  let backlogMissing = 0;
+  for (const r of pgPairs) {
+    const missed = !chSet.has(key(r.imageId, r.userId, r.reaction));
+    if (r.recent) {
+      recentPairs++;
+      if (missed) recentMissing++;
+    } else {
+      backlogPairs++;
+      if (missed) backlogMissing++;
+    }
+    if (missed) {
+      missingInCh++;
+      affected.add(r.imageId);
+    }
+  }
+  let phantomInCh = 0;
+  for (const r of chPairs) {
+    if (!pgSet.has(key(r.entityId, r.userId, r.metricType))) {
+      phantomInCh++;
+      affected.add(Number(r.entityId));
+    }
+  }
+
+  const union = new Set([...pgSet, ...chSet]);
+  return {
+    imagesSampled: imageIds.length,
+    imagesDeleted,
+    pairsChecked: union.size,
+    pairsExact: union.size - missingInCh - phantomInCh,
+    missingInCh,
+    phantomInCh,
+    coverage: pgSet.size > 0 ? (pgSet.size - missingInCh) / pgSet.size : null,
+    recentCoverage: recentPairs > 0 ? (recentPairs - recentMissing) / recentPairs : null,
+    backlogCoverage: backlogPairs > 0 ? (backlogPairs - backlogMissing) / backlogPairs : null,
+    recentPairs,
+    backlogPairs,
+    phantomRate: chSet.size > 0 ? phantomInCh / chSet.size : null,
+    affectedImageIds: [...affected],
+    durationMs: Date.now() - startedAt,
+  };
+}


### PR DESCRIPTION
## What this is

Two reconciliation checks for the image-reaction metrics pipeline, plus a repair path behind an off-by-default flag.

Between 2025-12-01 and 2026-06-23 the CDC consumer silently dropped ~21.6M reaction events (fixed in `771f91a`). Nobody noticed for eight months because **every existing health check compares two points inside the same broken lineage** — `cache-drift-monitor.ts` reads `entityMetricEvents_month` on one arm and `entityMetricDailyAgg_v2` on the other, so it is structurally blind to source loss. Site-wide the errors roughly cancel (missing additions offset missing removals), so aggregates looked healthy while individual images were off by 65%.

These are the only checks that read **Postgres** — the actual source of truth — on one arm.

**Nothing is switched on by merging.** The jobs are registered but scheduling should be treated as a separate decision, and the repair path writes only when `METRIC_REACTION_REPAIR_ENABLED=true` (default `false`).

## 1. Hourly volume check

Coverage of Postgres reaction rows created in hour H-2 that reached ClickHouse, matched per `(imageId, userId, reaction)`.

### Why not a count ratio

The obvious design — `count(*)` in Postgres vs ClickHouse for the same hour — does not work, and the ~0.98 threshold it invites sits **inside its own noise**. Measured on healthy hours (PG rows / CH `metricValue>0` events / ratio):

```
16:00 21973/22327=0.9841   17:00 20956/21710=0.9653   18:00 22012/22338=0.9854
19:00 21143/21723=0.9733   20:00 22305/22617=0.9862   21:00 23312/23628=0.9866
22:00 25101/25601=0.9805   23:00 22368/22976=0.9735   00:00 36481/37428=0.9747
01:00 28541/29153=0.9790   02:00 25697/26071=0.9857   03:00 21702/22056=0.9839
```

The cause is structural, not noise: **an un-reaction deletes the Postgres row but leaves its `+1` in ClickHouse forever.** Postgres is always a subset, and the gap *grows the longer you wait to audit*. Roughly half these healthy hours would trip a 0.98 threshold, and it would be muted within a week.

Matching per row in the **PG → CH direction only** removes the asymmetry — a deleted row is in neither numerator nor denominator.

### The distribution the threshold comes from

**27 hours across 2026-08-05/06/07, 662,531 Postgres rows:**

```
2026-08-05 02,06,10,14,18,22   coverage 1.000000  (0 missing, all six)
2026-08-06 02,06,10,14,18,22   coverage 1.000000  (0 missing, all six)
2026-08-07 04..18 (15 hours)   coverage 1.000000  (0 missing, all fifteen)
```

Zero variance — a point mass at exactly 1.0, not a distribution.

**Negative control, same check inside the outage window:**

```
2026-02-11 14:00   coverage 0.019165   (23,849 of 24,315 rows missing)
2026-05-14 03:00   coverage 0.712498   ( 6,478 of 22,532 rows missing)
```

> These two are no longer reproducible — the historical repair has since backfilled them. Re-measuring `2026-02-11 14:00` now gives **0.998396** (39 rows missing), and its ClickHouse tuple count for that window has gone from **528 → 28,208**. That is the repair working, and it is also a useful check on the threshold: even after backfill the hour still sits below WARN 0.999, so the bar is tight enough to notice a residual 39 rows in 24,315.
>
> A control that had *not* been repaired at the time of writing, found by sweeping rather than by picking: `2026-03-10 14:00` reads **0.988355** — 264 of 22,670 rows, CRIT. So the detector still demonstrably detects, independent of the hours the repair has touched.

**Thresholds: WARN 0.999, CRIT 0.99** — roughly 1000x outside observed noise while still catching 1-in-1000 loss.

### Reaction naming, confirmed rather than assumed

```
2025-09  legacy 45,448,488  short 0
2025-10  legacy 33,996,744  short 3
2025-11  legacy  3,841,990  short 17,254,064
2025-12  legacy 0           short 20,870,476
2026-01  legacy 0           short 17,313,728
```

Clean `ReactionLike` → `Like` cutover in Nov 2025. Any Postgres reaction value with no ClickHouse mapping is counted and gauged separately, so a re-introduced `Dislike` surfaces as a mapping gap instead of vanishing.

`entityMetricEvents_month` still holds **both** spellings, so reads of it accept both and fold legacy onto canonical with the same `multiIf` the dirty-queue MV uses. Canonical-only would see **17 of 62,481** tuples on a pre-rename hour and report ~0.0003 coverage — indistinguishable from total CDC loss on an hour where nothing was lost. Recent hours are unaffected (36,638 either way). `entityMetricUserState_v3` is canonical-only and is read that way.

## 2. Nightly exactness check

Reconciles per `(imageId, userId, reaction)` against `entityMetricUserState_v3` with `argMaxMerge(latest) > 0` — the same predicate the site's totals use. Reaction totals are distinct users, not a sum of events, so anything reasoning in event counts is subtly wrong.

Catches what a volume check structurally cannot: phantom rows, wrong `metricType` mapping, dedupe regressions.

**Deleted images are filtered out** before any comparison. Their reactions cascade away in Postgres but persist in ClickHouse forever, so without the filter every deleted image reports its whole reaction set as phantom.

### Why the result is split

Sampling by image pulls each image's **entire** reaction history, so the headline number is dominated by un-repaired outage residue rather than current health. 7 seeds x 200 images:

```
seed  headline   phantom
0     0.975589   0.004683
1     0.984347   0.006575
2     0.985905   0.001775
3     0.955880   0.003664
4     0.972980   0.004862
5     0.992899   0.001642
6     0.980747   0.002350
```

Split by reaction age, the headline is entirely backlog:

```
seed 0   <24h: 1.000000 (373 pairs)   older: 0.973373 ( 4,394)
seed 3   <24h: 1.000000 (345 pairs)   older: 0.953031 ( 5,344)
seed 6   <24h: 0.997389 (383 pairs)   older: 0.980328 (15,199)
```

So it emits **`recentCoverage`** — the health signal, sharing the hourly thresholds — and **`backlogCoverage`**, which is a burn-down of un-repaired history and is **explicitly not alertable**. Alerting on it would fire every night until the repair finishes and get muted.

Phantom rate 0.0016–0.0066 (mean ~0.0037) independently reproduces the known 0.37% un-reaction residual.

## 3. Repair

`repairReactionMetrics(imageIds)` computes the per-user diff and emits compensating events:

- **`+1` rows carry the reaction's real `createdAt`**, never `now()`. Two things follow from this, and the second is the stronger guarantee:
  - A reaction deleted between the read and the write is not resurrected.
  - **Replays collapse rather than accumulate.** `entityMetricEvents_month` is `SharedReplacingMergeTree ... ORDER BY (entityType, entityId, metricType, userId, createdAt)`, so re-running the repair over the same images writes rows with identical sort keys, which the engine deduplicates. Idempotency here is a property of the schema, not of the caller being careful.

  Verified an April reaction routes to partition `202604`, not the current month.
- **`-1` rows are stamped strictly before Postgres is read**, so any newer live reaction outranks them under argMax.
- **`-1` rows are gated on the image still existing in Postgres.** Most removal candidates are for deleted images and skipping them avoids a large pointless write.
- **The removal timestamp comes from `pg_last_xact_replay_timestamp()`, not wall clock.** `pgDbRead` is a replica (`is_primary: false` confirmed) and Debezium reads the *primary's* WAL, so a reaction committed inside the replication lag is already in ClickHouse but invisible here — it would appear only in `chPairs`, look like a phantom, and earn a `-1` stamped *after* its own `createdAt`, erasing a real reaction. Anchoring to the replay position makes the stamp older than anything the replica cannot yet see, whatever the lag. Measured lag today is 0.13s, so a hardcoded `now() - 1s` would have held — but that is a property of today's replication, not of the code.
- Users in `metricExcludedUsers` (`active = 1`) are excluded from both sides.
- Inserted via the client's `insert()` API with `format: 'JSONEachRow'`; `max_memory_usage` pinned on every query.

**Bounded.** `imageIds` is capped at 5,000 per run and processed in batches of 250. One measured outage hour flagged **16,828 images / 1,065,041 reaction rows / up to 15,509 rows on a single image** — unbatched that is a ~1M-row read into node memory, a 16.8k-element interpolated `IN (...)`, and a single ~1M-object insert, issued exactly when ClickHouse is least healthy. Anything over the cap is reported in `imagesSkippedOverCap` rather than silently dropped.

**Off by default, and the flag gates the reads too.** `METRIC_REACTION_REPAIR_ENABLED` is checked *before any I/O*, not just before the insert — otherwise every breach would run the full read load with writes disabled, at exactly the moment ClickHouse is least healthy.

That would leave no production path measuring the diff, so enabling the flag would be the first time anyone sees what it writes. To avoid that, **the nightly path runs its diff as a `dryRun` while the flag is off** — real reads, real counts, no inserts. It is capped at 200 images so the cost is negligible. The hourly path stays fully gated. Once the flag is on, both repair for real.

Dry run against production, 200 sampled images: 48 additions, 12 removals, 4 images skipped as deleted, 74 pairs skipped for excluded users.

### Do backdated rows actually propagate to `entityMetricTotal_v3`?

Yes. This is the obvious doubt about backdating a `-1` — that it lands *behind* a watermark the refresher has already passed and never reaches the totals — so it's worth recording why it doesn't, rather than making the next reader re-derive it.

The refresher windows on **insert** time, not event time:

```sql
-- entityMetricDirty_v3
`enqueuedAt` DateTime64(3) DEFAULT now64(3)
PARTITION BY toYYYYMMDD(enqueuedAt) ORDER BY (enqueuedAt, entityType, entityId, metricType)

-- entityMetricDirty_v3_mv: fires on any insert into entityMetricEvents_month.
-- Its SELECT omits enqueuedAt, so the column DEFAULT (now64(3)) applies.
SELECT entityType, entityId, multiIf(metricType = 'ReactionLike', 'Like', ...) AS metricType
FROM default.entityMetricEvents_month GROUP BY entityType, entityId, metricType

-- entityMetricTotal_v3_refresher: REFRESH EVERY 1 MINUTE
WITH now64(3) AS ts, ts - toIntervalMinute(10) AS ws, ts - toIntervalSecond(15) AS we
... WHERE enqueuedAt >= ws AND enqueuedAt < we
```

So a row inserted now but stamped an hour ago is enqueued at *now* and lands inside the window.

And for non-additive metrics the refresher does a **full per-key recompute**, not an incremental delta — `sum(toInt64(argMaxMerge(latest) > 0))` over `entityMetricUserState_v3` for the dirty key, excluding `metricExcludedUsers FINAL WHERE active = 1`. The event's own timestamp never enters the total.

Reactions take that path: `SELECT ... FROM entityMetricKind FINAL WHERE entityType='Image' AND metricType IN ('Like','Heart','Laugh','Cry')` returns **zero rows**, so they are not `kind = 'additive'` and fall to the non-additive refresher.

(The refresher's exclusion of `metricExcludedUsers` is also why the repair excludes those users on both sides — writing events for them would be inert at the total.)

**One caveat this exposes:** the window only looks back 10 minutes of enqueue time. If the refresher cannot drain within that, keys age out and are never refreshed. That bounds how large a single repair batch can safely be — fine for the hourly path's volumes, and the reason a wholesale rebuild follows a bulk historical apply.

## Review fixes (`97f4da6` → `e02abf9`)

Adversarial review caught a genuine defect and three real hardening gaps. All four are fixed and independently reproduced first.

**The binary search could spin forever.** `findIdAtOrAfter` probed *forwards* — `WHERE id >= mid ORDER BY id LIMIT 1` returns the smallest **existing** id >= mid. When no id exists in `[mid, hi)` that value is already >= `hi`, so `hi = rows[0].id` moved nothing, `lo` moved nothing, `mid` recomputed identically, and the loop reissued the same query forever. `ImageReaction` ids are sparse *because un-reactions delete rows*, so this was the ordinary case rather than an edge.

Reproduced against production — the stated fixed point holds exactly:

```
lo=704075558 hi=704075560 mid=704075559
  id 704075559 exists: false
  probe returns: {"id":704075560,"reached":false}
  -> hi = 704075560, which hi already was  => no movement
```

Running the shipped loop over 10 consecutive recent hours: **stalled on 2 of 10**. Compounding, because `createJob` has no timeout, the loop never checked cancellation, and the runner releases the lock at `lockExpiration` while the job is still running — so the next hourly cron would start a second permanent loop at ~22 Postgres queries/sec each.

Probing *backwards* (`id <= mid ORDER BY id DESC`) keeps `mid < hi`, so every branch strictly moves a bound and termination is structural. It returns **identical ids on all 8 hours that previously terminated**, and converges on the 2 that did not. Plus an iteration cap that throws and a cancellation check, so a future regression fails loudly rather than silently spinning.

The other three — repair read-gating and batching, the pre-rename naming gap, and the replica-lag removal stamp — are described in their sections above. Also fixed: `max_memory_usage` on the `metricExcludedUsers` read, `pairsSkippedExcludedUser` no longer double-counts pairs present on both sides, and the exactness sample takes a `seed` (it is a stable hash ordering, not a random draw — the figures above are reproducible by passing the same seed, and the nightly job varies it by day).

## Two traps worth knowing about

1. **`ImageReaction.createdAt` is `timestamp without time zone`, and the pg driver converts it through the *process* timezone in both directions.** An early probe read 6 hours off. All timestamps here are UTC ISO strings cast to `::timestamp`, formatted in SQL via `to_char`, and never compared as JS Dates.
2. **`clickhouse.$query` interpolates, it does not bind.** Its array branch joins with `,` and no quoting, so `IN (${stringArray})` renders as bare identifiers. String lists arrive pre-quoted.

## Performance

`ImageReaction` has **no index on `createdAt`**, so the naive hourly scan is a Parallel Seq Scan — `Rows Removed by Filter: 245,780,700`, `shared read=6,415,501` buffers, ~15s. The id-bounded version binary-searches the primary key for bounds and returns identical results in **~250ms**.

## Suggested alerting (not included here)

Use a Grafana-provisioned ConfigMap for the warning, **not** a PrometheusRule — the AM→GoAlert fan-out silently drops PrometheusRule warnings (documented at `app-block-alerts-configmap.yaml:7-11`). Keep a critical PrometheusRule only for `< 0.99`. Aggregate coverage with `min()`; only the pod that ran the job has a fresh value.

Also worth alerting on `time() - civitai_reaction_audit_last_run_timestamp_seconds > 7200` — a job that silently stops looks identical to a healthy pipeline, which is the same blindness that hid the original outage.

Separately: **nothing currently alerts on `mew_messages_poisoned_total`.** It is scraped, but no rule references it. Every poison-skip is a silent drop.

## Verification

- `pnpm run typecheck` — **0 errors** (needs `TYPECHECK_HEAP_MB=12288`; the 8GB default OOMs tsc on a loaded machine)
- `pnpm exec eslint` on all changed files — **clean**
- `pnpm exec prettier --check` — **clean**
- All measurements above were run read-only against production with `max_memory_usage` pinned. No writes, no DDL.

## Known limitations

- The 5-minute ClickHouse boundary margin is a guess. It can only produce false matches, never hide a drop, but the real Debezium skew distribution was not measured.
- Coverage 1.0 proves rows arrived, not that they carry the right `metricValue`. A `+1`/`-1` sign regression passes the hourly check; the nightly one catches it within a day.
- The id-range optimization assumes `id` and `createdAt` stay roughly monotonic. A backfill inserting old rows with new ids would break it silently.
- Image-only. Post/User/Model reaction metrics ride the same consumer and remain unaudited.
- **Excluded users are excluded from repair permanently, not just from totals.** Users in `metricExcludedUsers` are skipped on both sides of the diff, matching what the refresher does. The consequence is that if someone is later un-excluded, any reactions of theirs lost during an outage stay lost — this path will not repair them, because by then the reactions are old and no longer in any audit window. That is a product decision (is exclusion permanent, or reversible with history intact?) rather than a bug, and it should be a decision someone makes rather than a surprise someone discovers.
- A `-1` could in principle collide with an existing `+1` at the same `(entity, metric, user, createdAt)` second, leaving ReplacingMergeTree to pick one non-deterministically. It requires a reaction created in the same second the repair stamps its removal. Sub-second separation isn't available — the column is `DateTime`, not `DateTime64`.
- **Repair overflow is dropped, not re-enqueued.** `imageIds` is capped at `MAX_IMAGES_PER_RUN`; on the measured 16.8k-image outage hour that is ~11.8k images never revisited, because the next run audits a different hour. The count is surfaced in `imagesSkippedOverCap` and logged at `warn`, but recovery currently depends on a human acting on it. A work queue would be the real fix.
- **A quiet primary would stale the removal stamp.** `pg_last_xact_replay_timestamp()` advances only with replayed transactions, so on a very quiet database `removalAt` drifts backwards. A `-1` older than the `+1` it is meant to cancel loses under argMax, so the phantom survives, is re-detected next run, and is re-inserted — a slow no-op loop rather than corruption. This database is never quiet enough for it to bite, but it is the one way removals silently stop working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
