### PR TITLE
fix(db-schema): unblock the drift gate on two cosmeticId findings the stale snapshot invents

### DIFF
--- a/.github/workflows/schema-drift.yml
+++ b/.github/workflows/schema-drift.yml
@@ -2,7 +2,7 @@ name: Schema drift gate
 
 # Fails a pull request that makes the gap between `schema.full.prisma` and the production
 # database WORSE, and only that. Pre-existing drift is warned about, never failed on — the
-# database carries 61 accepted findings today, and a gate red on every run is a gate everyone
+# database carries 63 accepted findings today, and a gate red on every run is a gate everyone
 # learns to click through.
 #
 # "Fails", not "blocks": `main` has branch protection but no `required_status_checks`, so a red

--- a/packages/civitai-db-schema/src/schema-drift/README.md
+++ b/packages/civitai-db-schema/src/schema-drift/README.md
@@ -180,20 +180,23 @@ pnpm --filter @civitai/db-schema drift \
 ```
 
 ```
-declared owning-side relations : 476
+declared owning-side relations : 485
 checked against the database   : 445
-skipped (view / absent table)  : 31
+skipped (view / absent table)  : 40
 MISSING foreign key            : 37
 wrong referential action       : 0   <- see below
 MISSING column                 : 12
 nullability checked            : 2383
-nullability drift              : 11
+nullability drift              : 13
 uniqueness declarations checked: 122
 missing unique index           : 1
 ```
 
-61 findings in total. The 11 nullability findings are `Purchase.userId`,
-`ChallengeEvent.createdById`, and nine `*Metric.updatedAt` columns. The 12 missing columns are
+63 findings in total. The 13 nullability findings are `Purchase.userId`,
+`ChallengeEvent.createdById`, nine `*Metric.updatedAt` columns, and
+`CosmeticShopItem.cosmeticId` / `UserCosmeticShopPurchases.cosmeticId`. Those last two are
+artefacts of the snapshot's age, not live drift: the packs migration made them nullable on
+2026-08-04 and the database has it. A recapture drops them. The 12 missing columns are
 `ModelFlag.sfwOnly`, `UserCosmeticShopPurchases.meta`, and ten
 `UserRank.thumbs{Up,Down}Count*Rank`. The single uniqueness finding is
 `ImageResource(modelVersionId, name, imageId)`.
@@ -317,11 +320,11 @@ signal, not an interlock. Adding `Schema drift gate` to the required checks is w
 
 ### Why a baseline and not `--strict`
 
-`--strict` fails on any finding, and there are 61 on `main` today. A gate red on every run
+`--strict` fails on any finding, and there are 63 on `main` today. A gate red on every run
 teaches everyone to click through it, so it would be switched off within a week — the same
 reasoning behind the report-only ESLint and Prettier steps in `.github/workflows/lint.yml`.
 
-`drift-baseline.json`, next to this README, records those 61 as accepted. The gate reports
+`drift-baseline.json`, next to this README, records those 63 as accepted. The gate reports
 only what is **not** in it. The baseline is committed, so accepting new drift is a reviewable
 act: the gate tells you the exact command, and the resulting diff shows a reviewer precisely
 which constraint the change gave up on.

--- a/packages/civitai-db-schema/src/schema-drift/__tests__/gate.test.ts
+++ b/packages/civitai-db-schema/src/schema-drift/__tests__/gate.test.ts
@@ -790,10 +790,10 @@ describe('drift-gate CLI', { timeout: 60_000 }, () => {
       const workBaseline = freshCopy(committed.entries);
       const result = await gate(['--update-baseline', '--baseline', workBaseline]);
       expect(result.code).toBe(0);
-      expect(result.stdout).toMatch(/Wrote 61 accepted finding\(s\)/);
+      expect(result.stdout).toMatch(/Wrote 63 accepted finding\(s\)/);
       // The PAIR, not a bare zero: "0 absorbed" and "nothing was compared" must not be the
       // same output. This is what makes the escalation report falsifiable.
-      expect(result.stdout).toMatch(/escalations absorbed: 0 \(compared against 61 previous/);
+      expect(result.stdout).toMatch(/escalations absorbed: 0 \(compared against 63 previous/);
     });
 
     it('is byte-idempotent — a no-op refresh rewrites the same file', async () => {
@@ -841,7 +841,7 @@ describe('drift-gate CLI', { timeout: 60_000 }, () => {
       expect(result.stdout).toMatch(/not "no escalations found"/);
       expect(result.stderr).not.toMatch(/Cannot read properties/);
       // the refresh still completed
-      expect((JSON.parse(readFileSync(path, 'utf8')) as Baseline).entries).toHaveLength(61);
+      expect((JSON.parse(readFileSync(path, 'utf8')) as Baseline).entries).toHaveLength(63);
     });
 
     it('says it SKIPPED when there was no previous baseline at all', async () => {

--- a/packages/civitai-db-schema/src/schema-drift/drift-baseline.json
+++ b/packages/civitai-db-schema/src/schema-drift/drift-baseline.json
@@ -596,6 +596,17 @@
       "field": "updatedAt"
     },
     {
+      "fingerprint": "nullability|CosmeticShopItem|cosmeticId|CosmeticShopItem|cosmeticId|optional",
+      "kind": "nullability",
+      "tier": "enforced",
+      "table": "CosmeticShopItem",
+      "columns": [
+        "cosmeticId"
+      ],
+      "model": "CosmeticShopItem",
+      "field": "cosmeticId"
+    },
+    {
       "fingerprint": "nullability|ModelMetric|updatedAt|ModelMetric|updatedAt|required",
       "kind": "nullability",
       "tier": "enforced",
@@ -649,6 +660,17 @@
       ],
       "model": "TagMetric",
       "field": "updatedAt"
+    },
+    {
+      "fingerprint": "nullability|UserCosmeticShopPurchases|cosmeticId|UserCosmeticShopPurchases|cosmeticId|optional",
+      "kind": "nullability",
+      "tier": "enforced",
+      "table": "UserCosmeticShopPurchases",
+      "columns": [
+        "cosmeticId"
+      ],
+      "model": "UserCosmeticShopPurchases",
+      "field": "cosmeticId"
     },
     {
       "fingerprint": "nullability|UserMetric|updatedAt|UserMetric|updatedAt|required",

--- a/packages/civitai-db-schema/src/schema-drift/gate.ts
+++ b/packages/civitai-db-schema/src/schema-drift/gate.ts
@@ -5,7 +5,7 @@
  *
  * WHAT THIS GATE IS FOR. The detector reports the drift that exists; a gate has to answer a
  * narrower question — did THIS change make it worse? Blocking on the whole report would be
- * red on every run (there are 61 findings on `main` today) and a permanently-red gate just
+ * red on every run (there are 63 findings on `main` today) and a permanently-red gate just
  * teaches everyone to click through it. So the shape here is the one this org already runs
  * in its infrastructure repo: block only a PASS->FAIL regression the change introduces,
  * warn about everything that was already broken, and never block on a pre-existing finding.


### PR DESCRIPTION
## What's broken

The **Schema drift gate** fails on every PR against `main`, regardless of content:

```
NEW, enforced (blocking)       : 2
  nullability  CosmeticShopItem.cosmeticId          declared: optional / database: NOT NULL
  nullability  UserCosmeticShopPurchases.cosmeticId declared: optional / database: NOT NULL
BLOCKED: 2 drift finding(s) on columns the database already has
```

`@civitai/db-schema`'s `gate.test.ts` fails alongside it, because three assertions hardcode the accepted-finding count at 61 while the real count is now 63.

## Root cause — the snapshot is stale, not the database

The gate never opens a database connection. It compares `schema.full.prisma` against a **committed catalog snapshot**, `catalog-production-2026-08-03.json`.

The packs migration (`20260804230000_add_cosmetic_shop_item_packs`) landed the **day after** that snapshot was captured and does:

```sql
ALTER TABLE "CosmeticShopItem" ALTER COLUMN "cosmeticId" DROP NOT NULL;
ALTER TABLE "UserCosmeticShopPurchases" ALTER COLUMN "cosmeticId" DROP NOT NULL;
```

So the schema says optional, the frozen snapshot still says `NOT NULL`, and the gate reports drift.

**I verified against production: there is no real drift.** Both columns are `is_nullable = YES`, and both pack join tables (`CosmeticShopItemCosmetic`, `UserCosmeticShopPurchaseCosmetic`) exist. The migration has been applied. The schema declarations are correct, deliberate (a pack row has no single cosmetic), and unchanged by this PR.

Why exactly +2 and not more: the two new pack tables are absent from the Aug-3 snapshot, so `compare.ts` skips those models wholesale. Only the two nullability findings on pre-existing tables count. 61 + 2 = 63.

## The fix

Ran the remedy the gate itself prints:

```
pnpm --filter @civitai/db-schema drift:baseline
```

- `drift-baseline.json`: 61 → 63 accepted findings (+2, both `enforced`, 0 escalations absorbed). Diff is exactly the two entries, nothing else.
- `gate.test.ts`: three hardcoded `61`s → `63`. These assert the CLI's own reported totals, so they track the baseline by design; both regexes were verified against real CLI output.
- README / workflow comment: the narrative counts they quote were already stale, refreshed from a real run (nullability 11 → 13, total 61 → 63, relations 476/31 → 485/40).

**No migration is needed, and no schema change was made.** Nothing here needs manual application to any database.

## The real remedy, deliberately not done here

These two entries describe the snapshot's age, not the database, and a **catalog recapture** would delete them outright. I did not do that, because a recapture is a much larger, separate maintenance act. Measured against a live catalog dump, it would take the gate from 63 findings to **103**:

| | committed snapshot | live catalog |
|---|---|---|
| missing foreign key | 37 | 34 |
| wrong referential action | 0 (not measurable) | **45** |
| missing column | 12 | 11 |
| nullability | 13 | **11** ← the two disappear |
| missing unique index | 1 | 2 |

The +45 referential-action findings are the ones the README already predicts arrive "all at once" on recapture (the frozen snapshot carries no `ON DELETE`/`ON UPDATE` data). They need triage by someone who owns that call — that shouldn't ride along on a CI unblock. **Whoever does the recapture should drop these two baseline entries in the same commit.**

## Verification

- `pnpm --filter @civitai/db-schema drift:gate` — **exit 0**, `baseline findings reproduced: 63 of 63`, 0 blocking
- `pnpm run typecheck` — **0 type errors**
- `pnpm run db:check-generated` — **exit 0** on the committed tree (no generated-client churn)
- `drift:baseline` re-run is **byte-idempotent**

### One thing I could not verify locally

`gate.test.ts`, `cli.test.ts` and `dump-catalog-stamp.test.ts` spawn the CLI via `execFile` on `node_modules/.bin/tsx`, which on Windows is the extensionless POSIX script — so all 32 subprocess-backed tests fail with `ENOENT` **on clean `main` too**, before reaching any assertion (every failure reads `expected '' to match ...`). Identical 32 before and after this change; 422 tests collected either way. The three assertions I edited are therefore verified against real CLI output rather than by a green local run. **CI (Linux) is the real check on those.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
