### PR TITLE
fix(notifications): fail soft on unread-count client errors

### DIFF
--- a/src/server/services/notification.service.ts
+++ b/src/server/services/notification.service.ts
@@ -87,7 +87,16 @@ export async function getUserNotificationCount({
   unread: boolean;
   category?: NotificationCategory;
 }) {
-  return notifications.countNotifications({ userId, unread, category });
+  // Unread counts drive a polled badge, so a transient notifications-service failure must degrade to
+  // zero rather than fail the request — the next poll corrects it. Mirrors markNotificationsRead.
+  // Deliberately NOT applied to the notification LIST: an empty list misrepresents the user's data,
+  // where a stale-zero badge only under-reports for one poll interval.
+  try {
+    return await notifications.countNotifications({ userId, unread, category });
+  } catch (e) {
+    if (e instanceof NotificationsClientError) return [];
+    throw e;
+  }
 }
 
 export const markNotificationsRead = async ({


### PR DESCRIPTION
## What

`getUserNotificationCount` now returns an empty count on `NotificationsClientError` instead of letting it become a tRPC error.

```ts
try {
  return await notifications.countNotifications({ userId, unread, category });
} catch (e) {
  if (e instanceof NotificationsClientError) return [];
  throw e;
}
```

`countNotifications` returns `NotificationCategoryCount[]`, so `[]` reduces to `{ all: 0 }` — a zero badge, not an error state.

## Why

During the 2026-08-07 Redis incident (02:50–04:50 UTC) this path produced **42,036 `user.checkNotifications` failures — 63% of all user-facing errors in the window**.

The monolith never touched Redis here. It calls `apps/notifications` over HTTP; that service threw a node-redis `getSlotRandomNode` TypeError against a slot map with missing entries and returned a 500, which we faithfully rethrew:

```
notifications request failed (500): {"statusCode":500,"error":"Internal Server Error",
 "message":"Cannot read properties of undefined (reading 'replicas')"}
```

An unread count drives a polled badge. A transient failure should degrade, not fail the request — the next poll corrects it. `markNotificationsRead` twenty lines away already does exactly this, with a comment saying why; the read path just never got the same branch.

## Scope decisions

**In the service, not the controller** — so it also covers the count leg of `notification.getAllByUser` (2,604 failures in the same window).

**Not applied to the notification list.** An empty list tells the user they have no notifications, which is false. A stale-zero badge under-reports for one poll interval and self-corrects. Different blast radius, different call.

**Not applied centrally in `withClusterRoutingRetry`.** That was the original plan and it would have been a mistake — the same window contains `reaction.toggle` (489), `post.addImage` (65), `post.update` (28) and `training.getAutoLabelUploadUrl` (44). A blanket soft-fail turns 626 failed **writes** into writes that silently appear to succeed, which is worse than the 500s: a 500 gets retried, a vanished reaction doesn't, and the user gets no signal either way.

## Not covered here

The other 22,104 direct failures are a long tail across ~40 procedures (`commentv2.getInfinite`, `tag.getAll`, `announcement.getAnnouncements`, `hiddenPreferences.getHidden`, …). Those need per-call-site judgement about what "degraded" means and are a separate change. Mutations should keep throwing.

The underlying client bug is unfixed upstream — `getSlotRandomNode` dereferences `this.slots[n]` without a null check in **every** published `@redis/client` line (5.8.3, 5.12.1, 6.2.0 are byte-identical), and `#discover` returns `true` for a `CLUSTER SLOTS` response that omits ranges. An upstream issue is being drafted. This PR does not depend on it.

Infra side is tracked in talos-infra #895 / #896 / #897.

## Testing

- `pnpm typecheck` — clean
- notification unit tests — 17/17 pass
- `pnpm exec prettier` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
