### PR TITLE
fix(notifications): serve the unread count from the DB when redis fails

### DIFF
--- a/apps/notifications/src/lib/server/operations.countNotifications.test.ts
+++ b/apps/notifications/src/lib/server/operations.countNotifications.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as AxiomClient from './clients/axiom';
 
 // Behavioral coverage for countNotifications' per-key request coalescing (single-flight). The heaviest read
 // on the DB used to fire N concurrent identical `GROUP BY category` scans for the same user (a 43-way
@@ -49,8 +50,16 @@ vi.mock('./cache', () => ({
   },
 }));
 
+// Spread the real module and override only logToAxiom (repo rule: no wholesale module mocks). The cache
+// degradation path logs, and we assert on that log rather than letting a real Axiom call fire in tests.
+vi.mock('./clients/axiom', async (importOriginal) => ({
+  ...(await importOriginal<typeof AxiomClient>()),
+  logToAxiom: vi.fn(async () => {}),
+}));
+
 import { countNotifications, countInFlight } from './operations';
 import { notificationCache } from './cache'; // mocked above — used to assert the bust/primary path is taken
+import { logToAxiom } from './clients/axiom';
 
 // One macrotask hop flushes all currently-queued microtasks — enough to advance the count path up to its
 // pending cancellableQuery.result().
@@ -371,5 +380,74 @@ describe('cacheability gate (unread:true + no category only)', () => {
     expect(r1).toEqual(rows);
     expect(r2).toEqual(rows);
     expect(h.calls).toHaveLength(1);
+  });
+});
+
+// =========================================================================================================
+// Cache-failure degradation. The unread count is DERIVED from the notif DB; redis is only a cache in front
+// of it. cache.ts's withRedisErrorCount rethrows by design, and countNotificationsImpl did not catch — so a
+// redis fault 500'd a query that does not need redis (42,036 user-facing errors on 2026-08-07).
+//
+// Fixture discipline: every userId and every count below is distinct, so a test cannot pass by returning
+// some other case's value, and a DB result can never be mistaken for a cached one.
+describe('cache failures degrade to the notif DB (never a 500)', () => {
+  it('serves the real count from the DB when the cache READ throws', async () => {
+    h.state.getUser = async () => {
+      throw new Error("Cannot read properties of undefined (reading 'replicas')");
+    };
+    h.state.resultImpl = async () => [{ category: 'Comment', count: 7 }];
+
+    const result = await countNotifications({ userId: 91, unread: true });
+
+    expect(result).toEqual([{ category: 'Comment', count: 7 }]); // the REAL number, not [] and not a throw
+    expect(h.calls).toHaveLength(1); // the DB query actually ran
+  });
+
+  it('still returns the DB result when the cache POPULATE throws after a successful read', async () => {
+    h.state.resultImpl = async () => [{ category: 'Milestone', count: 11 }];
+    vi.mocked(notificationCache.setUser).mockRejectedValueOnce(new Error('redis down'));
+
+    const result = await countNotifications({ userId: 92, unread: true });
+
+    // The count was computed and correct; a failure to CACHE it must not discard it.
+    expect(result).toEqual([{ category: 'Milestone', count: 11 }]);
+    expect(h.calls).toHaveLength(1);
+  });
+
+  it('still reads the primary when the recent-writer cache BUST throws', async () => {
+    h.state.isWritePool = true;
+    h.state.resultImpl = async () => [{ category: 'Update', count: 13 }];
+    vi.mocked(notificationCache.bustUser).mockRejectedValueOnce(new Error('redis down'));
+
+    const result = await countNotifications({ userId: 93, unread: true });
+
+    expect(result).toEqual([{ category: 'Update', count: 13 }]);
+    expect(h.calls).toHaveLength(1);
+    expect(notificationCache.getUser).not.toHaveBeenCalled(); // write-pool branch never reads the cache
+  });
+
+  it('logs the degradation rather than failing silently', async () => {
+    h.state.getUser = async () => {
+      throw new Error('redis down');
+    };
+    h.state.resultImpl = async () => [{ category: 'System', count: 17 }];
+
+    await countNotifications({ userId: 94, unread: true });
+
+    expect(logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'notification.countCacheDegraded', operation: 'getUser' })
+    );
+  });
+
+  // Negative control. The swallow is scoped to CACHE calls; if it ever widens to cover the query itself we
+  // would serve a silent wrong answer instead of an error, which is worse than the bug this PR fixes.
+  it('does NOT swallow a DB error — that must still surface', async () => {
+    h.state.resultImpl = async () => {
+      throw new Error('notif db unreachable');
+    };
+
+    await expect(countNotifications({ userId: 95, unread: true })).rejects.toThrow(
+      'notif db unreachable'
+    );
   });
 });

--- a/apps/notifications/src/lib/server/operations.ts
+++ b/apps/notifications/src/lib/server/operations.ts
@@ -156,6 +156,34 @@ export function countNotifications(input: {
   return inFlight;
 }
 
+// The unread count is DERIVED from the notif DB — the redis hash in cache.ts is only a cache in front of
+// the GROUP BY below. cache.ts's withRedisErrorCount deliberately rethrows, documented as safe because
+// "callers that already .catch() keep degrading to no-op"; that holds for the worker's fire-and-forget
+// increment/decrement, and did NOT hold here. A cache read failure took down a query that does not need
+// the cache: on 2026-08-07 that turned a redis slot-map fault into 42,036 user-facing 500s while the
+// answering query sat three lines below, unreached.
+//
+// Scoped to CACHE calls only, and never wrapped around `db.cancellableQuery` — a DB failure means we have
+// no count and must still surface. `redisErrorsTotal` is already incremented inside withRedisErrorCount,
+// so this only logs; it does not double-count.
+async function swallowCacheError<T>(
+  operation: string,
+  fn: () => Promise<T>
+): Promise<T | undefined> {
+  try {
+    return await fn();
+  } catch (err) {
+    logToAxiom({
+      type: 'warning',
+      name: 'notification.countCacheDegraded',
+      message: `Notification count cache ${operation} failed; serving from the notif DB`,
+      operation,
+      error: safeError(err),
+    }).catch(() => null);
+    return undefined;
+  }
+}
+
 async function countNotificationsImpl(input: {
   userId: number;
   unread: boolean;
@@ -181,9 +209,11 @@ async function countNotificationsImpl(input: {
   const db = await getNotifDbWithoutLag(userId);
   if (cacheable) {
     if (isWritePool(db)) {
-      await notificationCache.bustUser(userId);
+      // A failed bust is safe to ignore ONLY because this branch goes on to read the primary and
+      // repopulate below, overwriting whatever stale value survived.
+      await swallowCacheError('bustUser', () => notificationCache.bustUser(userId));
     } else {
-      const cached = await notificationCache.getUser(userId);
+      const cached = await swallowCacheError('getUser', () => notificationCache.getUser(userId));
       if (cached) return cached;
     }
   }
@@ -204,7 +234,8 @@ async function countNotificationsImpl(input: {
     params
   );
   const result = await query.result();
-  if (cacheable) await notificationCache.setUser(userId, result);
+  if (cacheable)
+    await swallowCacheError('setUser', () => notificationCache.setUser(userId, result));
   return result;
 }
 

--- a/src/server/services/notification.service.ts
+++ b/src/server/services/notification.service.ts
@@ -87,10 +87,13 @@ export async function getUserNotificationCount({
   unread: boolean;
   category?: NotificationCategory;
 }) {
-  // Unread counts drive a polled badge, so a transient notifications-service failure must degrade to
-  // zero rather than fail the request — the next poll corrects it. Mirrors markNotificationsRead.
-  // Deliberately NOT applied to the notification LIST: an empty list misrepresents the user's data,
-  // where a stale-zero badge only under-reports for one poll interval.
+  // Last resort, for when the notifications service is unreachable entirely: degrade the badge to zero
+  // rather than fail the whole request. NOT self-correcting — the client query is staleTime/gcTime
+  // Infinity with no refetchInterval and nothing invalidates it, so a zero here persists for the rest of
+  // the session. Prefer fixing degradation INSIDE the service (it serves this count from the notif DB and
+  // only caches it in redis) so callers get the real number; this branch is what's left when even that
+  // fails. Deliberately NOT applied to the notification LIST: an empty list is a stronger false claim
+  // about the user's data than an under-reported badge.
   try {
     return await notifications.countNotifications({ userId, unread, category });
   } catch (e) {


### PR DESCRIPTION
Follow-up to #3748, which was mitigation. **This is the actual fix.**

## What

`countNotificationsImpl` (`apps/notifications/src/lib/server/operations.ts`) no longer 500s when the redis count cache is unavailable. The unread count is *derived* from the notif DB — redis is only a cache in front of the `GROUP BY`:

```ts
const cached = await notificationCache.getUser(userId);   // ← threw here
if (cached) return cached;
// ...three lines down, the source of truth:
const query = await db.cancellableQuery(`SELECT n.category, COUNT(*) ... GROUP BY category`);
```

Three cache call sites are now guarded by a `swallowCacheError` helper:

| Call | Previously, on redis failure |
|---|---|
| `bustUser` (recent-writer path) | 500 before the DB query |
| `getUser` (cache read) | 500 before the DB query |
| `setUser` (populate) | **500 after a successful DB read, discarding a correct result** |

## Why it happened

`cache.ts`'s `withRedisErrorCount` rethrows deliberately, with a comment saying it's safe because "callers that already `.catch()` keep degrading to no-op." That holds for the worker's fire-and-forget increment/decrement. It does not hold for `countNotificationsImpl`, which doesn't catch. The wrapper was written for one class of caller; the hot read path is the other class.

On 2026-08-07 this turned a redis slot-map fault into **42,036 user-facing 500s** — 63% of all tRPC errors in the window.

## Scope

**Cache calls only.** The swallow is never wrapped around `db.cancellableQuery` — without a count we must surface an error, not serve a silent wrong answer. There's a negative-control test for exactly this.

`redisErrorsTotal` is already incremented inside `withRedisErrorCount`, so the new helper only logs (`notification.countCacheDegraded`); it does not double-count.

## Also: corrects a false comment shipped in #3748

#3748's comment claimed a zero badge self-corrects on "the next poll." **There is no poll.** `src/components/Notifications/notifications.utils.ts:77-81` sets `staleTime: Infinity` / `gcTime: Infinity` with no `refetchInterval`, and nothing anywhere calls `.invalidate()` on it — only optimistic `setData`. A zero persists for the rest of the session.

That made the merged mitigation worse than described. This PR makes the monolith-side soft-fail an actual last resort rather than the primary defense, and rewrites the comment to say so.

## Testing

Five new tests in `operations.countNotifications.test.ts`. Fixture discipline: every `userId` (91–95) and every count (7, 11, 13, 17) is distinct, so no test can pass by returning another case's value and a DB result can't be mistaken for a cached one.

**Mutation-tested — each guard has a discriminating test:**

| Mutation | Result |
|---|---|
| Un-guard the cache READ | 2 failed |
| Un-guard the cache POPULATE | 1 failed |
| Un-guard the cache BUST | 1 failed |
| Widen the swallow to cover the DB query | 2 failed |

The last row is the one I most wanted to confirm: if this guard ever creeps over the DB call, the negative control catches it.

- `pnpm --filter @civitai/notifications-app typecheck` — clean
- root `tsc --noEmit` — clean
- `vitest --project app:notifications` — 106/106, 10 files
- prettier — clean

Root cause tracking: [ClickUp 868knvkr3](https://app.clickup.com/t/868knvkr3) (defect 10). Infra side in talos-infra #895/#896/#897.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
