### PR TITLE
fix(metrics): gate the reaction repair on Flipt instead of an env var

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -396,10 +396,6 @@ export const serverSchema = z
     // loudly at boot instead.
     IMAGE_SCANNING_MAX_PER_RUN: z.coerce.number().int().positive().default(1000),
     IMAGE_SCANNER_NEW: zc.booleanString.default(false),
-    // Arms the reaction reconciliation audit's repair path to WRITE compensating
-    // events to ClickHouse. Off, the hourly path does nothing at all and the
-    // nightly one runs its diff as a dry run for visibility.
-    METRIC_REACTION_REPAIR_ENABLED: zc.booleanString.default(false),
     DELIVERY_WORKER_ENDPOINT: z.string().optional(),
     DELIVERY_WORKER_TOKEN: z.string().optional(),
     STORAGE_RESOLVER_ENDPOINT: z.string().optional(), // URL for storage-resolver microservice

--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -72,6 +72,12 @@ export enum FLIPT_FEATURE_FLAGS {
   // failure. Deliberately does NOT gate /api/admin/temp/minor-hash-sweep, so
   // rollback stays usable after the switch is thrown.
   MINOR_HASH_AUTO_FLAG = 'minor-hash-auto-flag',
+  // Arms the reaction reconciliation audit's repair path to WRITE compensating
+  // events to ClickHouse. Default-off — isFlipt returns false for an unknown flag
+  // or an unreachable Flipt, and for a path that mutates production metrics that
+  // is the safe failure. Off, the hourly path does nothing at all and the nightly
+  // one runs its diff as a dry run for visibility.
+  METRIC_REACTION_REPAIR = 'metric-reaction-repair',
 }
 
 const FLIPT_INIT_TIMEOUT_MS = 5000;

--- a/src/server/jobs/metric-reconciliation-audit.ts
+++ b/src/server/jobs/metric-reconciliation-audit.ts
@@ -1,5 +1,5 @@
 import client from 'prom-client';
-import { env } from '~/env/server';
+import { FLIPT_FEATURE_FLAGS, isFlipt } from '~/server/flipt/client';
 import { logToAxiom } from '~/server/logging/client';
 import { PROM_PREFIX } from '~/server/prom/client';
 import { repairReactionMetrics } from '~/server/services/metric-reaction-repair.service';
@@ -113,8 +113,8 @@ const gauges = (global.metricReconciliationGauges ??= Object.fromEntries(
 ) as Record<GaugeName, client.Gauge<string>>);
 
 /**
- * Registering the hook does not arm writes — `METRIC_REACTION_REPAIR_ENABLED`
- * defaults to false and gates them.
+ * Registering the hook does not arm writes — the `metric-reaction-repair` Flipt
+ * flag gates them, and reads false until someone turns it on.
  *
  * While it is off, the nightly path still runs the diff as a dry run so there is
  * some production evidence of what enabling it would write. Without that, turning
@@ -126,7 +126,8 @@ const gauges = (global.metricReconciliationGauges ??= Object.fromEntries(
  * Once the flag is on, both paths repair for real.
  */
 setReactionRepairHook(async ({ imageIds, reason }) => {
-  const previewOnly = reason === 'nightly-exactness' && !env.METRIC_REACTION_REPAIR_ENABLED;
+  const repairEnabled = await isFlipt(FLIPT_FEATURE_FLAGS.METRIC_REACTION_REPAIR);
+  const previewOnly = reason === 'nightly-exactness' && !repairEnabled;
   const result = await repairReactionMetrics(imageIds, { dryRun: previewOnly });
   await logToAxiom({
     type: 'metric-reconciliation',

--- a/src/server/services/metric-reaction-repair.service.ts
+++ b/src/server/services/metric-reaction-repair.service.ts
@@ -1,5 +1,5 @@
-import { env } from '~/env/server';
 import { pgDbRead } from '~/server/db/pgDb';
+import { FLIPT_FEATURE_FLAGS, isFlipt } from '~/server/flipt/client';
 import { REACTION_METRICS } from '~/server/services/metric-reconciliation.service';
 
 /**
@@ -9,10 +9,11 @@ import { REACTION_METRICS } from '~/server/services/metric-reconciliation.servic
  * construction and this one writes to ClickHouse. The detector must stay safe to
  * run anywhere; this must not.
  *
- * Gated on `METRIC_REACTION_REPAIR_ENABLED`, which defaults to false — merging this
- * cannot start mutating production. The gate is checked before any I/O, not just
- * before the insert: a detection means ClickHouse is already unhealthy, so running
- * the read load anyway would add load at the worst moment.
+ * Gated on the `metric-reaction-repair` Flipt flag, which is off unless someone
+ * turns it on (and reads false when Flipt is unreachable) — merging this cannot
+ * start mutating production. The gate is checked before any I/O, not just before
+ * the insert: a detection means ClickHouse is already unhealthy, so running the
+ * read load anyway would add load at the worst moment.
  *
  * That leaves no free preview, so callers wanting the diff without the writes must
  * ask for it explicitly with `dryRun` — which reads normally and never inserts. The
@@ -102,7 +103,8 @@ export async function repairReactionMetrics(
    * writes are disabled is the worst time to be adding load. `dryRun` is the
    * explicit operator opt-in for measuring the diff without arming writes.
    */
-  if (!env.METRIC_REACTION_REPAIR_ENABLED && !dryRun) return done({ skippedReason: 'disabled' });
+  if (!dryRun && !(await isFlipt(FLIPT_FEATURE_FLAGS.METRIC_REACTION_REPAIR)))
+    return done({ skippedReason: 'disabled' });
   if (!imageIds.length) return done({ skippedReason: 'no-changes' });
 
   const { clickhouse } = await import('~/server/clickhouse/client');


### PR DESCRIPTION
Moves the reaction-metric repair gate off the `METRIC_REACTION_REPAIR_ENABLED` env var and onto the Flipt flag `metric-reaction-repair`, so the write path can be armed or disarmed without a redeploy.

## What this gates

#3746 added a metrics reconciliation audit plus a repair routine that writes compensating `+1` / `-1` reaction rows into ClickHouse `entityMetricEvents_month`. That repair has always been gated — this PR only changes *how* you flip the switch. An env var meant a redeploy to turn the repair on during an incident, which is the wrong ergonomics for something you reach for precisely when the pipeline is already unhealthy.

## No behaviour change on merge

The flag already exists in `civitai-app/default/features.yaml` at `enabled: false`, synced and confirmed via the Flipt API. The env var it replaces also defaulted to false and was never set. Both the old gate and the new one currently mean **off**, so merging this changes nothing observable.

## Fail-closed

`isFlipt` returns `false` for an unreachable Flipt (`if (!fliptClient) return false`), for an evaluation error (`catch → false`), and for an unknown flag key. So Flipt being down, Flipt erroring, and the flag being absent all mean **writes stay off**. There is no failure path that arms writes. For a routine that mutates production metrics, not writing is the safe failure.

The gate also sits before any I/O rather than just before the insert — a detection means ClickHouse is already unhealthy, so issuing the full read load on every breach while writes are disabled would add load at the worst possible moment.

## `isFlipt`, not `getFliptBoolean`

Deliberate, and worth stating so it doesn't read as an oversight:

- Every sibling job-side gate uses it — `reemit-bitdex-ops.ts:242`, `audit-bitdex-consistency.ts:305`, `minor-hash-sweep.ts:14`.
- Fail-closed semantics are identical to `getFliptBoolean` — same `!fliptClient` guard, same `catch → false`.
- It honours `FLIPT_LOCAL_OVERRIDES`, which `getFliptBoolean` skips. That is what makes the repair exercisable in local dev at all, given the real flag lives in shared GitOps state. `parseLocalOverrides()` returns `{}` when `NODE_ENV === 'production'`, so this adds no production surface.

No explicit `ensureFliptInitialized()` is needed: `isFlipt` awaits `FliptSingleton.getInstance()` itself, and none of the sibling jobs call it either.

## Semantics preserved exactly

| path | flag off | flag on |
|---|---|---|
| nightly (`nightly-exactness`) | dry run — reads and reports what it *would* repair, inserts nothing | repairs |
| hourly (`hourly-coverage`) | fully gated, returns before any I/O | repairs |

`!dryRun` is checked first in the service so a dry run never evaluates the flag, preserving the original short-circuit exactly as it behaved against the env var. Without the nightly preview, turning the flag on would go from zero observation straight to live inserts.

## Changes

- `src/server/flipt/client.ts` — adds `METRIC_REACTION_REPAIR = 'metric-reaction-repair'`.
- `src/server/services/metric-reaction-repair.service.ts` — gate becomes `!dryRun && !(await isFlipt(...))`; `env` import dropped.
- `src/server/jobs/metric-reconciliation-audit.ts` — flag hoisted above `previewOnly`; `env` import dropped.
- `src/env/server-schema.ts` — `METRIC_REACTION_REPAIR_ENABLED` removed. It was the only declaration site; there is no `.env.example` in this repo, and a repo-wide grep for the name now returns nothing.

Comments in all three touched files were updated to describe the flag rather than the env var.

## Verification

- `pnpm run typecheck` — **0 type errors**.
- `pnpm exec prettier --write` on the four changed files — all formatted correctly.
- ESLint on the four changed files — **`No issues found`**.
- Repo-wide `pnpm run lint` exits 1 with 395 errors / 3625 warnings. That is pre-existing on `main` and unrelated: none of the four filenames appear anywhere in the output. Per `.github/workflows/lint.yml`, CI blocks only on added files and runs modified files report-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
