### PR TITLE
fix(auth): build the session token map in O(n), not O(n^2)

### DIFF
--- a/src/server/auth/__tests__/session-invalidation.test.ts
+++ b/src/server/auth/__tests__/session-invalidation.test.ts
@@ -178,7 +178,43 @@ describe('updateSessionState READ fail-open wrapper (STEP-4 hGetAll)', () => {
     expect(mockHSetMultiWithTTL).not.toHaveBeenCalled();
     expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
     expect(mockLogSysRedisFailOpen.mock.calls[0][0]).toBe('read-degraded');
-    expect(mockLogSysRedisFailOpen.mock.calls[0][3]).toMatchObject({ userId: 123, type: 'refresh' });
+    expect(mockLogSysRedisFailOpen.mock.calls[0][3]).toMatchObject({
+      userId: 123,
+      type: 'refresh',
+    });
+  });
+});
+
+describe('updateSessionState token-map build is linear', () => {
+  /**
+   * The map was built with `tokens.reduce((acc, t) => ({ ...acc, [t]: type }), {})`,
+   * which shallow-copies the accumulator every iteration: O(n^2) property copies,
+   * synchronous, with no yield point.
+   *
+   * Scope: this covers the in-process map build only — `hSetMultiWithTTL` is
+   * mocked here, so a pass says nothing about whether a hash this size can be
+   * written. The budget is deliberately loose (measured: 5.6ms linear vs 21138ms
+   * quadratic at this n), so a slow machine cannot flip it. n is capped at 10k
+   * because the quadratic form blocks the loop, so vitest's timeout cannot fire
+   * until it finishes — a revert must fail on the assertion rather than wedge
+   * the runner.
+   */
+  it('builds the token map in linear time', async () => {
+    const tokenCount = 10_000;
+    const hugeHash: Record<string, string> = {};
+    for (let i = 0; i < tokenCount; i++) hugeHash[`token-${i}`] = 'active';
+    mockHGetAll.mockResolvedValue(hugeHash);
+    mockHSetMultiWithTTL.mockResolvedValue(undefined);
+
+    const startedAt = performance.now();
+    await refreshSession(42, { sendSignal: false });
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(elapsedMs).toBeLessThan(1000);
+
+    const [, , fieldsObj] = mockHSetMultiWithTTL.mock.calls[0];
+    expect(fieldsObj['token-0']).toBe('refresh');
+    expect(fieldsObj[`token-${tokenCount - 1}`]).toBe('refresh');
   });
 });
 

--- a/src/server/auth/session-invalidation.ts
+++ b/src/server/auth/session-invalidation.ts
@@ -32,13 +32,14 @@ async function updateSessionState(userId: number, type: 'refresh' | 'invalid') {
     tokenHash = {};
   }
   const userTokens = Object.keys(tokenHash);
-  const userTokensObj = userTokens.reduce<Record<string, string>>(
-    (acc, token) => ({ ...acc, [token]: type }),
-    {}
+  // Must stay O(n): spreading the accumulator per iteration is O(n^2), which
+  // blocks the event loop for minutes on the largest token hashes.
+  const userTokensObj: Record<string, string> = Object.fromEntries(
+    userTokens.map((token) => [token, type] as const)
   );
 
   await clearSessionCache(userId);
-  if (Object.keys(userTokensObj).length > 0) {
+  if (userTokens.length > 0) {
     // Atomic multi-field set+TTL — single EVAL replaces the sequential
     // hSet (multi-field) + hExpire (multi-field). The previous pair could
     // leave a subset of fields no-TTL if the second call failed; here all


### PR DESCRIPTION
## What

`updateSessionState` built its token-state map with a spread inside a `reduce`:

```js
const userTokensObj = userTokens.reduce((acc, token) => ({ ...acc, [token]: type }), {});
```

Every iteration shallow-copies the whole accumulator, so `n` tokens costs ~n²/2 property copies. It is fully synchronous with no `await` in the loop, so the event loop cannot yield until it finishes — minutes of blocked loop per call on the largest token hashes.

Replaced with `Object.fromEntries` over a `map` — O(n), and behaviourally identical: same keys, same value, same insertion order. Both forms use computed keys, which go through `CreateDataProperty`, so prototype keys such as `__proto__` remain own properties in both and neither can pollute. Verified in node across prototype keys, numeric-like keys, and unicode.

Also drops an `Object.keys(...).length` over the same collection, which rebuilt the key array to answer what `userTokens.length` already answers.

## Measurements

| tokens | before | after |
|---|---|---|
| 5,000 | 4,271 ms | 4.2 ms |
| 10,000 | 21,138 ms | 5.6 ms |
| 20,000 | 123,838 ms | 7.3 ms |

## Test

Covers the in-process map build only — the Redis write is mocked, so a pass says nothing about whether a hash of that size can be written (see follow-up 1).

10k is deliberate. The quadratic form blocks the event loop, so vitest's own timeout cannot fire until the loop completes; at larger n a revert wedges the runner instead of failing it. At 10k a revert fails cleanly on the assertion against the 1s budget, while the linear form finishes in single-digit ms.

## Verification

- `pnpm run typecheck` — clean (exit 0)
- `pnpm exec eslint` on both files — 0 errors (1 pre-existing warning on an untouched line)
- `session-invalidation.test.ts` — 8/8 pass
- Full unit suite — 16 failures in 6 files, all confirmed **pre-existing**: identical count and identical files on a stashed clean tree, all unrelated filesystem-scanning drift guards
- Mutation-tested: reverting the fix fails the new test
- Reviewed adversarially for correctness and for security; both reviewers independently reproduced the follow-up below

## Follow-up, tracked separately

`hSetMultiWithTTL` passes each field through Lua's `unpack`, which has a fixed ceiling. Above it the script aborts before the write, and the caller's fail-open swallows the error — so a sufficiently large hash writes nothing and reports success. Reproduced against a matching Redis version. This is pre-existing and orthogonal to this change, which neither introduces nor worsens it: the same input fails to write today. Fix is to chunk the write; being handled as its own PR alongside wider session-token work.

Investigation and profiling by Ivy; adversarial review by two independent reviewers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
