### PR TITLE
feat(observability): detect event-loop wedges from a worker thread

### DIFF
--- a/src/instrumentation.node.ts
+++ b/src/instrumentation.node.ts
@@ -17,6 +17,7 @@ import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { registerCpuProfiler, registerEventLoopStallProfiler } from '~/server/cpu-profiler';
 import { registerEventLoopLongTaskDetector } from '~/server/eventloop-longtask';
 import { registerLivenessHeartbeat } from '~/server/liveness-heartbeat';
+import { registerEventLoopWatchdog } from '~/server/eventloop-watchdog';
 import { registerPyroscope } from '~/server/pyroscope';
 import { registerEnumArrayTypeParsers } from '@civitai/db/kysely';
 import { pgDbWrite } from '~/server/db/pgDb';
@@ -86,6 +87,17 @@ registerEventLoopLongTaskDetector();
 // because it's served by the same saturated loop. See liveness-heartbeat.ts and
 // the liveness history in datapacket-talos deployment-api.yaml.
 registerLivenessHeartbeat();
+
+// Spawn the off-loop event-loop wedge detector. Everything else that watches the
+// loop — the loopstall self-trigger above, the long-task detector, /api/metrics —
+// runs ON the loop and therefore cannot report while it is pinned. This puts the
+// observer in a worker thread that reads a SharedArrayBuffer heartbeat and serves
+// its own metrics port, so a wedged main thread is still visible from outside.
+// Registered AFTER the heartbeat so the first beat is already stored when the
+// worker starts polling. DISARMED by default (no worker, no port, nothing
+// installed) unless EVENTLOOP_WATCHDOG_ENABLED='true'.
+// See src/server/eventloop-watchdog.ts.
+registerEventLoopWatchdog();
 
 // Kick the in-process route warmer (fire-and-forget). Next standalone
 // lazy-require()s each route on first hit; the dependency-only readiness probe

--- a/src/pages/api/testing/eventloop-stall.ts
+++ b/src/pages/api/testing/eventloop-stall.ts
@@ -37,6 +37,11 @@
  * The response is sent AFTER the stall completes — the loop cannot serve it any
  * earlier — so the client sees a hung request for the duration. That is the
  * endpoint working, not failing.
+ *
+ * NOT SELF-DRIVABLE FROM INSIDE THE POD. Gate 1 needs the real Host, so hitting the
+ * pod IP directly renders HTML instead of reaching this route. Drive it through the
+ * ingress hostname. (Relatedly, next-server binds $HOSTNAME rather than 0.0.0.0, so
+ * 127.0.0.1:3000 is not reachable in-container either — the watchdog's own :9099 is.)
  */
 
 import type { NextApiRequest, NextApiResponse } from 'next';

--- a/src/pages/api/testing/eventloop-stall.ts
+++ b/src/pages/api/testing/eventloop-stall.ts
@@ -11,9 +11,9 @@
  * It is gated TWICE: the module only builds a real handler when
  * EVENTLOOP_WATCHDOG_STALL_ENDPOINT === 'true' (otherwise this route is a bare 404
  * with no auth path and no reachable stall code), and when it is enabled it still
- * requires the WEBHOOK_TOKEN. The duration is clamped server-side regardless of
- * what is asked for, so the worst case is bounded even if both gates are somehow
- * open.
+ * requires the WEBHOOK_TOKEN. The duration is clamped server-side regardless of what
+ * is asked for, and a cooldown is enforced between stalls, so even with both gates
+ * open a caller cannot hold the loop pinned continuously.
  *
  * Usage:
  *   POST /api/testing/eventloop-stall?token=$WEBHOOK_TOKEN
@@ -41,6 +41,10 @@ const MAX_DURATION_MS = 10_000;
 const MIN_DURATION_MS = 1;
 const DEFAULT_DURATION_MS = 3000;
 const BURN_BATCH = 100_000;
+// Enforced after each stall, so a caller looping the endpoint cannot hold the loop
+// pinned continuously. Generous relative to the 10s ceiling: the point is to make
+// sustained pinning impossible, not to make repeat testing painful.
+const COOLDOWN_MS = 30_000;
 
 // Resolved at module load. When false, nothing below this line is reachable: the
 // default export is a 404 that never consults a token and never calls stall().
@@ -98,6 +102,12 @@ export function stall(durationMs: number, mode: 'spin' | 'alloc'): number {
   return iterations;
 }
 
+// The per-request clamp bounds ONE stall; it does nothing about a caller looping the
+// endpoint, which pins the loop indefinitely and would cross the liveness threshold.
+// Defence in depth — it needs both gates open to matter — but a bounded primitive that
+// is unbounded in aggregate is not really bounded.
+let cooldownUntil = 0;
+
 const buildHandler = () =>
   WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse) => {
     const parsed = resolveStallRequest({ ...req.query, ...(req.body ?? {}) });
@@ -105,7 +115,19 @@ const buildHandler = () =>
       return res.status(400).json({ error: parsed.error.flatten() });
     }
 
+    const now = Date.now();
+    if (now < cooldownUntil) {
+      return res.status(429).json({
+        error: 'stall cooling down',
+        retryAfterMs: cooldownUntil - now,
+      });
+    }
+
     const { durationMs, mode } = parsed.value;
+    // Set BEFORE stalling. The loop is blocked for the whole stall, so no concurrent
+    // request can be serviced anyway; what this bounds is the next one, and it must
+    // already be in place when the loop starts serving again.
+    cooldownUntil = now + durationMs + COOLDOWN_MS;
     const startedAt = Date.now();
     console.warn(
       `[eventloop-stall] SYNTHETIC STALL starting: ${durationMs}ms mode=${mode} — this pod is ` +

--- a/src/pages/api/testing/eventloop-stall.ts
+++ b/src/pages/api/testing/eventloop-stall.ts
@@ -8,12 +8,19 @@
  *
  * 🔴 This endpoint deliberately hard-locks the Node process serving it. Every
  * request to that pod — including its own response — stops until the stall ends.
- * It is gated TWICE: the module only builds a real handler when
- * EVENTLOOP_WATCHDOG_STALL_ENDPOINT === 'true' (otherwise this route is a bare 404
- * with no auth path and no reachable stall code), and when it is enabled it still
- * requires the WEBHOOK_TOKEN. The duration is clamped server-side regardless of what
- * is asked for, and a cooldown is enforced between stalls, so even with both gates
- * open a caller cannot hold the loop pinned continuously.
+ *
+ * Three gates, in the order a request meets them:
+ *   1. Host must be a preview host (route guard, see middleware/testing-route-access).
+ *      Convenience only — the Host header is client-controlled, so this is not a
+ *      boundary.
+ *   2. EVENTLOOP_WATCHDOG_STALL_ENDPOINT === 'true', read at MODULE LOAD. This is the
+ *      one that matters: without it no handler is constructed at all, so the route is
+ *      a bare 404 with no auth path and no reachable stall code.
+ *   3. WEBHOOK_TOKEN.
+ *
+ * The duration is clamped server-side regardless of what is asked for, and a cooldown
+ * is enforced between stalls, so even with all three open a caller cannot hold the
+ * loop pinned continuously.
  *
  * Usage:
  *   POST /api/testing/eventloop-stall?token=$WEBHOOK_TOKEN

--- a/src/pages/api/testing/eventloop-stall.ts
+++ b/src/pages/api/testing/eventloop-stall.ts
@@ -1,0 +1,125 @@
+/**
+ * Synthetic event-loop stall, for validating the off-loop watchdog.
+ * =============================================================================
+ *
+ * A preview environment will not wedge on its own, so without this there is no way
+ * to prove the watchdog (src/server/eventloop-watchdog.ts) detects and reports a
+ * wedge before it reaches production.
+ *
+ * 🔴 This endpoint deliberately hard-locks the Node process serving it. Every
+ * request to that pod — including its own response — stops until the stall ends.
+ * It is gated TWICE: the module only builds a real handler when
+ * EVENTLOOP_WATCHDOG_STALL_ENDPOINT === 'true' (otherwise this route is a bare 404
+ * with no auth path and no reachable stall code), and when it is enabled it still
+ * requires the WEBHOOK_TOKEN. The duration is clamped server-side regardless of
+ * what is asked for, so the worst case is bounded even if both gates are somehow
+ * open.
+ *
+ * Usage:
+ *   POST /api/testing/eventloop-stall?token=$WEBHOOK_TOKEN
+ *   Content-Type: application/json
+ *   Body: { "durationMs": 5000, "mode": "spin" }
+ *
+ * Params:
+ *   durationMs  - number, 1..10000, default 3000. Clamped, never rejected.
+ *   mode        - 'spin' | 'alloc', default 'spin'.
+ *                 spin  = non-allocating tight loop (no GC safepoints; the harder
+ *                         case for anything that needs to interrupt the isolate)
+ *                 alloc = allocating loop (produces GC pauses, closer to a real
+ *                         traffic-driven pin)
+ *
+ * The response is sent AFTER the stall completes — the loop cannot serve it any
+ * earlier — so the client sees a hung request for the duration. That is the
+ * endpoint working, not failing.
+ */
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+import * as z from 'zod';
+import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
+
+const MAX_DURATION_MS = 10_000;
+const MIN_DURATION_MS = 1;
+const DEFAULT_DURATION_MS = 3000;
+const BURN_BATCH = 100_000;
+
+// Resolved at module load. When false, nothing below this line is reachable: the
+// default export is a 404 that never consults a token and never calls stall().
+const stallEndpointEnabled = process.env.EVENTLOOP_WATCHDOG_STALL_ENDPOINT === 'true';
+
+const schema = z.object({
+  // Clamp rather than reject, matching cpu-profiler.ts's handling of a
+  // fat-fingered duration.
+  durationMs: z.coerce
+    .number()
+    .transform((v) => Math.min(Math.max(Math.round(v), MIN_DURATION_MS), MAX_DURATION_MS))
+    .default(DEFAULT_DURATION_MS),
+  mode: z.enum(['spin', 'alloc']).default('spin'),
+});
+
+export type StallRequest = z.infer<typeof schema>;
+
+/**
+ * Exported so the clamp can be verified without a unit test that actually stalls for
+ * the clamped ceiling — a 10s hard-locked thread inside a parallel suite is both slow
+ * and a good way to make unrelated tests time out.
+ */
+export function resolveStallRequest(
+  input: unknown
+): { ok: true; value: StallRequest } | { ok: false; error: z.ZodError } {
+  const parsed = schema.safeParse(input);
+  return parsed.success ? { ok: true, value: parsed.data } : { ok: false, error: parsed.error };
+}
+
+export function stall(durationMs: number, mode: 'spin' | 'alloc'): number {
+  const end = Date.now() + durationMs;
+  let iterations = 0;
+  if (mode === 'alloc') {
+    let sink: unknown;
+    while (Date.now() < end) {
+      sink = { i: iterations, pad: new Array(64).fill(0) };
+      iterations++;
+    }
+    void sink;
+  } else {
+    // The accumulator is SEPARATE from the counter on purpose. `|0` keeps the burn
+    // loop non-allocating (the whole point of spin mode), but it is signed 32-bit, so
+    // it wraps negative after a few passes — counting with it made `iterations` a
+    // meaningless, sometimes-negative number in the response body.
+    let acc = 0;
+    // Only check the clock every BURN_BATCH iterations so the loop body stays free of
+    // calls; a Date.now() per iteration would make this a call-heavy loop rather than
+    // the tight-spin case it is meant to reproduce.
+    while (Date.now() < end) {
+      for (let i = 0; i < BURN_BATCH; i++) acc = (acc + i) | 0;
+      iterations += BURN_BATCH;
+    }
+    void acc;
+  }
+  return iterations;
+}
+
+const handler = WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse) => {
+  const parsed = resolveStallRequest({ ...req.query, ...(req.body ?? {}) });
+  if (!parsed.ok) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+
+  const { durationMs, mode } = parsed.value;
+  const startedAt = Date.now();
+  console.warn(
+    `[eventloop-stall] SYNTHETIC STALL starting: ${durationMs}ms mode=${mode} — this pod is ` +
+      `intentionally wedged and will not serve any request until it ends`
+  );
+
+  const iterations = stall(durationMs, mode);
+  const actualMs = Date.now() - startedAt;
+
+  console.warn(`[eventloop-stall] synthetic stall complete after ${actualMs}ms`);
+  return res.status(200).json({ requestedMs: durationMs, actualMs, mode, iterations });
+});
+
+const notFound = (_req: NextApiRequest, res: NextApiResponse) => {
+  res.status(404).end();
+};
+
+export default stallEndpointEnabled ? handler : notFound;

--- a/src/pages/api/testing/eventloop-stall.ts
+++ b/src/pages/api/testing/eventloop-stall.ts
@@ -98,28 +98,39 @@ export function stall(durationMs: number, mode: 'spin' | 'alloc'): number {
   return iterations;
 }
 
-const handler = WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse) => {
-  const parsed = resolveStallRequest({ ...req.query, ...(req.body ?? {}) });
-  if (!parsed.ok) {
-    return res.status(400).json({ error: parsed.error.flatten() });
-  }
+const buildHandler = () =>
+  WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse) => {
+    const parsed = resolveStallRequest({ ...req.query, ...(req.body ?? {}) });
+    if (!parsed.ok) {
+      return res.status(400).json({ error: parsed.error.flatten() });
+    }
 
-  const { durationMs, mode } = parsed.value;
-  const startedAt = Date.now();
-  console.warn(
-    `[eventloop-stall] SYNTHETIC STALL starting: ${durationMs}ms mode=${mode} — this pod is ` +
-      `intentionally wedged and will not serve any request until it ends`
-  );
+    const { durationMs, mode } = parsed.value;
+    const startedAt = Date.now();
+    console.warn(
+      `[eventloop-stall] SYNTHETIC STALL starting: ${durationMs}ms mode=${mode} — this pod is ` +
+        `intentionally wedged and will not serve any request until it ends`
+    );
 
-  const iterations = stall(durationMs, mode);
-  const actualMs = Date.now() - startedAt;
+    const iterations = stall(durationMs, mode);
+    const actualMs = Date.now() - startedAt;
 
-  console.warn(`[eventloop-stall] synthetic stall complete after ${actualMs}ms`);
-  return res.status(200).json({ requestedMs: durationMs, actualMs, mode, iterations });
-});
+    console.warn(`[eventloop-stall] synthetic stall complete after ${actualMs}ms`);
+    return res.status(200).json({ requestedMs: durationMs, actualMs, mode, iterations });
+  });
 
 const notFound = (_req: NextApiRequest, res: NextApiResponse) => {
   res.status(404).end();
 };
 
-export default stallEndpointEnabled ? handler : notFound;
+// Selection happens ONCE, at module load, and the disabled build never even
+// constructs the stall handler — `buildHandler()` is not called, so no token check
+// and no route to `stall()` exists to be reached. This is deliberately not a runtime
+// `if` inside a live handler: an authenticated endpoint whose job is to hard-lock an
+// app server is a DoS primitive, and a runtime refusal leaves the path present and
+// one bug away from reachable.
+//
+// Honest limit of that claim: `stall` is exported for the unit test, so the function
+// remains in the bundle and importable in-process. Nothing imports it outside the
+// test. What is absent in a disabled build is any way to reach it over HTTP.
+export default stallEndpointEnabled ? buildHandler() : notFound;

--- a/src/pages/api/testing/eventloop-stall.ts
+++ b/src/pages/api/testing/eventloop-stall.ts
@@ -10,9 +10,8 @@
  * request to that pod — including its own response — stops until the stall ends.
  *
  * Three gates, in the order a request meets them:
- *   1. Host must be a preview host (route guard, see middleware/testing-route-access).
- *      Convenience only — the Host header is client-controlled, so this is not a
- *      boundary.
+ *   1. Host must be a non-production host (route guard, see
+ *      middleware/testing-route-access). A routing check, not a boundary.
  *   2. EVENTLOOP_WATCHDOG_STALL_ENDPOINT === 'true', read at MODULE LOAD. This is the
  *      one that matters: without it no handler is constructed at all, so the route is
  *      a bare 404 with no auth path and no reachable stall code.

--- a/src/server/__tests__/eventloop-stall-endpoint.test.ts
+++ b/src/server/__tests__/eventloop-stall-endpoint.test.ts
@@ -152,9 +152,13 @@ describe('synthetic stall endpoint gating', () => {
   it('stalls for AT LEAST the requested duration in both modes', async () => {
     const { stall } = await import('~/pages/api/testing/eventloop-stall');
 
+    // Deliberately short. This is the only test in the repo that pins a core on
+    // purpose, and it runs inside an 885-file parallel suite alongside tests whose
+    // `vi.waitFor` budgets are as low as 1s. 50ms proves the property just as well as
+    // 120ms and takes less from everyone else.
     for (const mode of ['spin', 'alloc'] as const) {
       const startedAt = Date.now();
-      const iterations = stall(120, mode);
+      const iterations = stall(50, mode);
       const elapsed = Date.now() - startedAt;
 
       // REGRESSION: spin mode used to count with its own `|0` accumulator, which is
@@ -164,8 +168,8 @@ describe('synthetic stall endpoint gating', () => {
       // endpoint could report a negative iteration count to its caller.
       expect(iterations, mode).toBeGreaterThan(0);
       expect(Number.isSafeInteger(iterations), `${mode} iterations=${iterations}`).toBe(true);
-      // 10ms of slack for coarse timer granularity.
-      expect(elapsed, mode).toBeGreaterThanOrEqual(110);
+      // A little slack for coarse timer granularity.
+      expect(elapsed, mode).toBeGreaterThanOrEqual(45);
     }
   });
 

--- a/src/server/__tests__/eventloop-stall-endpoint.test.ts
+++ b/src/server/__tests__/eventloop-stall-endpoint.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `endpoint-helpers` spreads `env.TRPC_ORIGINS` at module load, so an unmocked
+// import of the page throws `env.TRPC_ORIGINS is not iterable`. Stub the wrapper
+// itself, per the pattern in
+// src/server/utils/__tests__/public-endpoint-maxage.test.ts. The gate under test
+// here is the module-load env check, which sits in front of the wrapper.
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  WebhookEndpoint: (handler: unknown) => handler,
+}));
+
+const GATE = 'EVENTLOOP_WATCHDOG_STALL_ENDPOINT';
+
+let saved: string | undefined;
+
+beforeEach(() => {
+  saved = process.env[GATE];
+  delete process.env[GATE];
+  vi.resetModules();
+});
+
+afterEach(() => {
+  if (saved === undefined) delete process.env[GATE];
+  else process.env[GATE] = saved;
+});
+
+function mockRes() {
+  return {
+    status: vi.fn().mockReturnThis(),
+    end: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  };
+}
+
+describe('synthetic stall endpoint gating', () => {
+  it('404s and never stalls when the env gate is unset', async () => {
+    const mod = await import('~/pages/api/testing/eventloop-stall');
+    const res = mockRes();
+
+    const startedAt = Date.now();
+    await mod.default({ query: { durationMs: 5000 }, body: {} } as never, res as never);
+    const elapsed = Date.now() - startedAt;
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    // A disabled endpoint that merely refuses AFTER doing the work is not disabled.
+    // Asking for a 5s stall and returning immediately is the assertion that the
+    // stall path is unreachable, not just unauthorised.
+    expect(elapsed).toBeLessThan(1000);
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('404s for every value of the gate except the exact string "true"', async () => {
+    for (const value of ['1', 'yes', 'TRUE', 'false', '']) {
+      vi.resetModules();
+      process.env[GATE] = value;
+      const mod = await import('~/pages/api/testing/eventloop-stall');
+      const res = mockRes();
+
+      await mod.default({ query: {}, body: {} } as never, res as never);
+
+      expect(res.status, `gate value ${JSON.stringify(value)}`).toHaveBeenCalledWith(404);
+    }
+  });
+
+  it('NEGATIVE CONTROL: serves a real stall when the gate is on', async () => {
+    // Without this the 404 tests above would pass just as happily against an
+    // endpoint that is broken in some unrelated way.
+    process.env[GATE] = 'true';
+    const mod = await import('~/pages/api/testing/eventloop-stall');
+    const res = mockRes();
+
+    await mod.default({ query: {}, body: { durationMs: 60, mode: 'spin' } } as never, res as never);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ requestedMs: 60, mode: 'spin' })
+    );
+  });
+
+  it('clamps the requested duration into [1, 10000] without rejecting', async () => {
+    // Purely on the resolver. Driving this through the handler would mean actually
+    // hard-locking the thread for the clamped ceiling, which is a 10s test that also
+    // starves whatever else the suite is running in parallel.
+    const { resolveStallRequest } = await import('~/pages/api/testing/eventloop-stall');
+
+    const clamped = (durationMs: unknown) => {
+      const parsed = resolveStallRequest({ durationMs, mode: 'spin' });
+      if (!parsed.ok) throw new Error('expected a clamp, got a rejection');
+      return parsed.value.durationMs;
+    };
+
+    expect(clamped(900_000)).toBe(10_000);
+    expect(clamped(10_001)).toBe(10_000);
+    expect(clamped(0)).toBe(1);
+    expect(clamped(-5)).toBe(1);
+    expect(clamped(3000)).toBe(3000);
+    expect(resolveStallRequest({}).ok && resolveStallRequest({}).value.durationMs).toBe(3000);
+  });
+
+  it('stalls for AT LEAST the requested duration in both modes', async () => {
+    const { stall } = await import('~/pages/api/testing/eventloop-stall');
+
+    for (const mode of ['spin', 'alloc'] as const) {
+      const startedAt = Date.now();
+      const iterations = stall(120, mode);
+      const elapsed = Date.now() - startedAt;
+
+      // REGRESSION: spin mode used to count with its own `|0` accumulator, which is
+      // signed 32-bit and wraps negative after ~4 batches. Whether the reported count
+      // came out positive depended on where the accumulator happened to land when the
+      // clock ran out, so this assertion passed alone and failed under load — and the
+      // endpoint could report a negative iteration count to its caller.
+      expect(iterations, mode).toBeGreaterThan(0);
+      expect(Number.isSafeInteger(iterations), `${mode} iterations=${iterations}`).toBe(true);
+      // 10ms of slack for coarse timer granularity.
+      expect(elapsed, mode).toBeGreaterThanOrEqual(110);
+    }
+  });
+
+  // NO UPPER BOUND ON `elapsed` ABOVE, DELIBERATELY. An earlier revision asserted
+  // `elapsed < 3000`, which passed in isolation and failed in the full 885-file suite
+  // — a CPU-bound loop's wall-clock is set by a scheduler this process does not
+  // control, so any ceiling is green on a quiet box and red on a busy one, which is
+  // exactly when CI runs. Overshooting the request is the OS, not a defect: the only
+  // property worth asserting is that the loop blocked for at least as long as asked.
+});

--- a/src/server/__tests__/eventloop-stall-endpoint.test.ts
+++ b/src/server/__tests__/eventloop-stall-endpoint.test.ts
@@ -5,8 +5,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // itself, per the pattern in
 // src/server/utils/__tests__/public-endpoint-maxage.test.ts. The gate under test
 // here is the module-load env check, which sits in front of the wrapper.
+const webhookEndpoint = vi.fn((handler: unknown) => handler);
 vi.mock('~/server/utils/endpoint-helpers', () => ({
-  WebhookEndpoint: (handler: unknown) => handler,
+  WebhookEndpoint: (handler: unknown) => webhookEndpoint(handler),
 }));
 
 const GATE = 'EVENTLOOP_WATCHDOG_STALL_ENDPOINT';
@@ -47,6 +48,28 @@ describe('synthetic stall endpoint gating', () => {
     // stall path is unreachable, not just unauthorised.
     expect(elapsed).toBeLessThan(1000);
     expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('never even CONSTRUCTS the stall handler when disabled', async () => {
+    // The gate has to be module-level absence, not a runtime refusal. An
+    // authenticated endpoint whose job is to hard-lock an app server is a DoS
+    // primitive, and a live handler that checks a flag and returns 403 leaves the
+    // path present and one bug away from reachable. If `WebhookEndpoint` was never
+    // called, there is no wrapped stall handler in this build at all.
+    webhookEndpoint.mockClear();
+
+    await import('~/pages/api/testing/eventloop-stall');
+
+    expect(webhookEndpoint).not.toHaveBeenCalled();
+  });
+
+  it('POSITIVE CONTROL: constructs it when the gate is on', async () => {
+    webhookEndpoint.mockClear();
+    process.env[GATE] = 'true';
+
+    await import('~/pages/api/testing/eventloop-stall');
+
+    expect(webhookEndpoint).toHaveBeenCalledTimes(1);
   });
 
   it('404s for every value of the gate except the exact string "true"', async () => {

--- a/src/server/__tests__/eventloop-stall-endpoint.test.ts
+++ b/src/server/__tests__/eventloop-stall-endpoint.test.ts
@@ -100,6 +100,35 @@ describe('synthetic stall endpoint gating', () => {
     );
   });
 
+  it('enforces a cooldown so repeat calls cannot pin the loop continuously', async () => {
+    // The per-request clamp bounds one stall. Without this, a caller looping the
+    // endpoint pins the loop indefinitely and crosses the liveness threshold — a
+    // bounded primitive that is unbounded in aggregate is not bounded.
+    process.env[GATE] = 'true';
+    const mod = await import('~/pages/api/testing/eventloop-stall');
+
+    const first = mockRes();
+    await mod.default(
+      { query: {}, body: { durationMs: 30, mode: 'spin' } } as never,
+      first as never
+    );
+    expect(first.status).toHaveBeenCalledWith(200);
+
+    const second = mockRes();
+    const startedAt = Date.now();
+    await mod.default(
+      { query: {}, body: { durationMs: 5000, mode: 'spin' } } as never,
+      second as never
+    );
+    const elapsed = Date.now() - startedAt;
+
+    expect(second.status).toHaveBeenCalledWith(429);
+    // Refused, not queued: the second 5s stall must not have run.
+    expect(elapsed).toBeLessThan(1000);
+    const payload = second.json.mock.calls[0]?.[0] as { retryAfterMs: number };
+    expect(payload.retryAfterMs).toBeGreaterThan(0);
+  });
+
   it('clamps the requested duration into [1, 10000] without rejecting', async () => {
     // Purely on the resolver. Driving this through the handler would mean actually
     // hard-locking the thread for the clamped ceiling, which is a 10s test that also

--- a/src/server/__tests__/eventloop-watchdog.test.ts
+++ b/src/server/__tests__/eventloop-watchdog.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ENV_KEYS = [
+  'EVENTLOOP_WATCHDOG_ENABLED',
+  'EVENTLOOP_WATCHDOG_THRESHOLD_MS',
+  'EVENTLOOP_WATCHDOG_HEARTBEAT_MS',
+  'EVENTLOOP_WATCHDOG_STALL_ENDPOINT',
+  'WATCHDOG_METRICS_PORT',
+] as const;
+
+let saved: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> = {};
+
+beforeEach(() => {
+  saved = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  for (const key of ENV_KEYS) delete process.env[key];
+  vi.resetModules();
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const value = saved[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+async function loadWatchdog() {
+  return import('~/server/eventloop-watchdog');
+}
+
+/**
+ * Metric names registered while `registerEventLoopWatchdog()` runs.
+ *
+ * `src/__tests__/setup.ts` stubs `~/server/prom/client` wholesale and does not export
+ * `instrumentationRegistry`, so the registry cannot be inspected directly — but
+ * `registerInstrumentationMetric` is a `vi.fn` there, and its call log is the same
+ * evidence. Measured as a DELTA because the mock is shared process-wide and other
+ * modules register into it.
+ */
+async function registrationsDuring(act: () => void): Promise<string[]> {
+  const promClient = await import('~/server/prom/client');
+  const register = vi.mocked(promClient.registerInstrumentationMetric);
+  const { registerEventLoopWatchdog, shutdownEventLoopWatchdog } = await loadWatchdog();
+
+  const before = register.mock.calls.length;
+  try {
+    registerEventLoopWatchdog();
+    act();
+  } finally {
+    shutdownEventLoopWatchdog();
+  }
+  return register.mock.calls.slice(before).map((call) => String(call[0]));
+}
+
+describe('watchdog config resolution', () => {
+  it('is disarmed unless explicitly enabled', async () => {
+    expect((await loadWatchdog()).watchdogArmed).toBe(false);
+
+    vi.resetModules();
+    process.env.EVENTLOOP_WATCHDOG_ENABLED = 'true';
+    expect((await loadWatchdog()).watchdogArmed).toBe(true);
+  });
+
+  it('only accepts the exact string "true" as armed', async () => {
+    for (const value of ['1', 'yes', 'TRUE', 'true ', '']) {
+      vi.resetModules();
+      process.env.EVENTLOOP_WATCHDOG_ENABLED = value;
+      expect((await loadWatchdog()).watchdogArmed).toBe(false);
+    }
+  });
+
+  it('defaults the threshold to 1000ms', async () => {
+    const { resolveWatchdogThresholdMs } = await loadWatchdog();
+    expect(resolveWatchdogThresholdMs()).toBe(1000);
+  });
+
+  it('clamps a too-small threshold UP to the floor rather than throwing', async () => {
+    // A threshold near the noise level would fire on ordinary GC. Measured loop lag
+    // on these pools already reaches 7.46s max, so a 5ms threshold is a
+    // fat-fingered value, not an intent.
+    const { resolveWatchdogThresholdMs } = await loadWatchdog();
+    process.env.EVENTLOOP_WATCHDOG_THRESHOLD_MS = '5';
+    expect(resolveWatchdogThresholdMs()).toBe(250);
+  });
+
+  it('falls back to the default for junk and non-positive thresholds', async () => {
+    const { resolveWatchdogThresholdMs } = await loadWatchdog();
+    for (const value of ['', 'abc', '0', '-1']) {
+      process.env.EVENTLOOP_WATCHDOG_THRESHOLD_MS = value;
+      expect(resolveWatchdogThresholdMs()).toBe(1000);
+    }
+  });
+
+  it('clamps the heartbeat interval at both ends', async () => {
+    const { resolveWatchdogHeartbeatMs } = await loadWatchdog();
+    expect(resolveWatchdogHeartbeatMs()).toBe(100);
+
+    process.env.EVENTLOOP_WATCHDOG_HEARTBEAT_MS = '1';
+    expect(resolveWatchdogHeartbeatMs()).toBe(20);
+
+    process.env.EVENTLOOP_WATCHDOG_HEARTBEAT_MS = '250';
+    expect(resolveWatchdogHeartbeatMs()).toBe(250);
+
+    // The MAX_HEARTBEAT_MS ceiling is only reachable with a threshold large enough to
+    // satisfy the 3x ratio; at the default 1000ms threshold the ratio binds first and
+    // caps the beat at 333. See the ratio-invariant suite below.
+    process.env.EVENTLOOP_WATCHDOG_THRESHOLD_MS = '5000';
+    process.env.EVENTLOOP_WATCHDOG_HEARTBEAT_MS = '999999';
+    expect(resolveWatchdogHeartbeatMs()).toBe(1000);
+  });
+
+  it('defaults the metrics port to 9099', async () => {
+    const { resolveWatchdogPort } = await loadWatchdog();
+    expect(resolveWatchdogPort()).toBe(9099);
+
+    process.env.WATCHDOG_METRICS_PORT = '9500';
+    expect(resolveWatchdogPort()).toBe(9500);
+  });
+
+  it('does not spawn a worker when disarmed', async () => {
+    const { registerEventLoopWatchdog, __getWatchdogWorkerForTests } = await loadWatchdog();
+    registerEventLoopWatchdog();
+    expect(__getWatchdogWorkerForTests()).toBeUndefined();
+  });
+
+  it('does not register watchdog_worker_started when disarmed', async () => {
+    // prom-client exports a registered-but-never-set gauge as 0, so registering this
+    // at module load would make a pool we simply have not enabled read identically to
+    // a pod whose worker spawn threw — and the `== 0` alert is the deploy-defect page.
+    const registered = await registrationsDuring(() => {
+      /* disarmed: registerEventLoopWatchdog is a no-op */
+    });
+
+    expect(registered).not.toContain('civitai_app_watchdog_worker_started');
+  });
+
+  it('POSITIVE CONTROL: registers it once armed', async () => {
+    // Without this, the assertion above would pass just as happily against a gauge
+    // that is never registered at all.
+    process.env.EVENTLOOP_WATCHDOG_ENABLED = 'true';
+    // Port 0 so an armed test can never collide with a real 9099 or another suite.
+    process.env.WATCHDOG_METRICS_PORT = '0';
+
+    const registered = await registrationsDuring(() => undefined);
+
+    expect(registered).toContain('civitai_app_watchdog_worker_started');
+  });
+});
+
+describe('threshold/beat ratio invariant', () => {
+  // The two settings are only independently meaningful while threshold/beat stays
+  // well above 1. Enforced by lowering the BEAT: the threshold is the operator's
+  // stated intent, so silently raising it would change what the pod detects while the
+  // config still claims otherwise.
+  it('lowers the beat to keep threshold >= 3x beat, leaving the threshold alone', async () => {
+    const { resolveWatchdogHeartbeatMs, resolveWatchdogThresholdMs } = await loadWatchdog();
+
+    process.env.EVENTLOOP_WATCHDOG_THRESHOLD_MS = '250';
+    process.env.EVENTLOOP_WATCHDOG_HEARTBEAT_MS = '100';
+
+    expect(resolveWatchdogThresholdMs()).toBe(250);
+    expect(resolveWatchdogHeartbeatMs()).toBe(83);
+  });
+
+  it('leaves a configured beat untouched when it already satisfies the ratio', async () => {
+    const { resolveWatchdogHeartbeatMs } = await loadWatchdog();
+
+    for (const [threshold, beat] of [
+      ['1000', 100],
+      ['5000', 100],
+      ['1000', 333],
+    ] as const) {
+      process.env.EVENTLOOP_WATCHDOG_THRESHOLD_MS = threshold;
+      process.env.EVENTLOOP_WATCHDOG_HEARTBEAT_MS = String(beat);
+      expect(resolveWatchdogHeartbeatMs(), `${threshold}/${beat}`).toBe(beat);
+    }
+  });
+
+  it('holds the invariant across the whole legal threshold range', async () => {
+    const { resolveWatchdogHeartbeatMs, resolveWatchdogThresholdMs } = await loadWatchdog();
+
+    // Every threshold anyone can configure, against the largest beat anyone can ask
+    // for. `threshold / 3` never approaches the 20ms beat floor, so the clamp always
+    // has room and never has to touch the threshold to satisfy the ratio.
+    for (const threshold of [250, 300, 1000, 2500, 5000, 60_000]) {
+      process.env.EVENTLOOP_WATCHDOG_THRESHOLD_MS = String(threshold);
+      process.env.EVENTLOOP_WATCHDOG_HEARTBEAT_MS = '1000';
+
+      const beat = resolveWatchdogHeartbeatMs();
+      const effectiveThreshold = resolveWatchdogThresholdMs();
+
+      expect(beat, `threshold=${threshold}`).toBeGreaterThanOrEqual(20);
+      expect(beat * 3, `threshold=${threshold}`).toBeLessThanOrEqual(effectiveThreshold);
+      // The threshold itself is never moved to satisfy the ratio.
+      expect(effectiveThreshold, `threshold=${threshold}`).toBe(Math.max(threshold, 250));
+    }
+  });
+});
+
+describe('watchdog heartbeat', () => {
+  it('records the timestamp it is given', async () => {
+    const { recordWatchdogHeartbeat, WATCHDOG_WORKER_SOURCE } = await loadWatchdog();
+    // The store is only observable through the worker, so assert the contract that
+    // matters here: the call is safe to make unconditionally, including when the
+    // watchdog was never armed and no worker exists to read it.
+    expect(() => recordWatchdogHeartbeat(1_700_000_000_000)).not.toThrow();
+    expect(() => recordWatchdogHeartbeat()).not.toThrow();
+    expect(WATCHDOG_WORKER_SOURCE).toContain('civitai_app_watchdog_up');
+  });
+});
+
+// The synthetic stall endpoint is covered separately in
+// eventloop-stall-endpoint.test.ts — it needs endpoint-helpers stubbed at module
+// load, which shouldn't be imposed on this file's graph.

--- a/src/server/__tests__/eventloop-watchdog.test.ts
+++ b/src/server/__tests__/eventloop-watchdog.test.ts
@@ -75,9 +75,9 @@ describe('watchdog config resolution', () => {
   });
 
   it('clamps a too-small threshold UP to the floor rather than throwing', async () => {
-    // A threshold near the noise level would fire on ordinary GC. Measured loop lag
-    // on these pools already reaches 7.46s max, so a 5ms threshold is a
-    // fat-fingered value, not an intent.
+    // A threshold near the noise level would fire on ordinary GC. Baseline loop lag
+    // already reaches multiple seconds at max, so a 5ms threshold is a fat-fingered
+    // value, not an intent.
     const { resolveWatchdogThresholdMs } = await loadWatchdog();
     process.env.EVENTLOOP_WATCHDOG_THRESHOLD_MS = '5';
     expect(resolveWatchdogThresholdMs()).toBe(250);

--- a/src/server/__tests__/eventloop-watchdog.worker.test.ts
+++ b/src/server/__tests__/eventloop-watchdog.worker.test.ts
@@ -1,0 +1,197 @@
+import { Worker } from 'node:worker_threads';
+import { afterEach, describe, expect, it } from 'vitest';
+import { WATCHDOG_WORKER_SOURCE } from '~/server/eventloop-watchdog';
+
+// The worker source is an inline string (see the tracing note in
+// eventloop-watchdog.ts), so it is NOT type-checked and NOT linted. This suite is
+// what stands in for that: it spawns the real string as a real worker and drives it
+// over real HTTP. A syntax error, a bad metric name, or a broken wedge transition
+// fails here and nowhere else.
+
+type Harness = {
+  worker: Worker;
+  port: number;
+  beat: BigInt64Array;
+  scrape: (token?: string) => Promise<{ status: number; body: string }>;
+};
+
+const TOKEN = 'test-watchdog-token';
+const THRESHOLD_MS = 300;
+
+const harnesses: Harness[] = [];
+
+async function startWorker(opts: { thresholdMs?: number; token?: string } = {}): Promise<Harness> {
+  const sab = new SharedArrayBuffer(8);
+  const beat = new BigInt64Array(sab);
+  Atomics.store(beat, 0, BigInt(Date.now()));
+
+  const worker = new Worker(WATCHDOG_WORKER_SOURCE, {
+    eval: true,
+    workerData: {
+      sab,
+      thresholdMs: opts.thresholdMs ?? THRESHOLD_MS,
+      // Port 0 => the OS picks a free one and the worker reports it back, so
+      // concurrent test files can never collide on a fixed port.
+      port: 0,
+      token: opts.token ?? TOKEN,
+      heartbeatIntervalMs: 50,
+      pollMs: 25,
+    },
+  });
+
+  const port = await new Promise<number>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error('worker never reported listening')), 10_000);
+    worker.on('message', (msg: { type?: string; port?: number; message?: string }) => {
+      if (msg?.type === 'listening' && msg.port) {
+        clearTimeout(timeout);
+        resolve(msg.port);
+      } else if (msg?.type === 'error') {
+        clearTimeout(timeout);
+        reject(new Error(`worker reported error: ${msg.message}`));
+      }
+    });
+    worker.on('error', (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+
+  const scrape = async (token: string | undefined = opts.token ?? TOKEN) => {
+    const query = token === undefined ? '' : `?token=${encodeURIComponent(token)}`;
+    const res = await fetch(`http://127.0.0.1:${port}/metrics${query}`);
+    return { status: res.status, body: await res.text() };
+  };
+
+  const harness: Harness = { worker, port, beat, scrape };
+  harnesses.push(harness);
+  return harness;
+}
+
+/** Read a single unlabeled sample out of the Prometheus text exposition. */
+function metric(body: string, name: string): number | undefined {
+  const line = body.split('\n').find((l) => l.startsWith(`${name} `));
+  return line === undefined ? undefined : Number(line.slice(name.length + 1));
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+afterEach(async () => {
+  await Promise.all(harnesses.splice(0).map((h) => h.worker.terminate()));
+});
+
+describe('event-loop watchdog worker', () => {
+  it('serves its metrics while the heartbeat is fresh', async () => {
+    const h = await startWorker();
+    h.beat.set([BigInt(Date.now())]);
+
+    const { status, body } = await h.scrape();
+
+    expect(status).toBe(200);
+    expect(metric(body, 'civitai_app_watchdog_up')).toBe(1);
+    expect(metric(body, 'civitai_app_watchdog_wedged')).toBe(0);
+    expect(metric(body, 'civitai_app_watchdog_current_wedge_seconds')).toBe(0);
+    expect(metric(body, 'civitai_app_watchdog_wedge_total')).toBe(0);
+    expect(metric(body, 'civitai_app_watchdog_threshold_ms')).toBe(THRESHOLD_MS);
+    expect(metric(body, 'civitai_app_watchdog_heartbeat_age_ms')).toBeLessThan(THRESHOLD_MS);
+  });
+
+  it('reports a wedge while the main thread is still stalled', async () => {
+    const h = await startWorker();
+
+    // Withholding beats is an ABSORBING state: nothing can end the wedge except this
+    // test resuming the heartbeat, so there is no window to lose. Asserting the
+    // wedge while it is still in progress is the whole point — the duration
+    // histogram only observes on recovery, so a pod killed mid-wedge would never
+    // report one.
+    await sleep(THRESHOLD_MS * 3);
+
+    const { body } = await h.scrape();
+
+    expect(metric(body, 'civitai_app_watchdog_wedged')).toBe(1);
+    expect(metric(body, 'civitai_app_watchdog_heartbeat_age_ms')).toBeGreaterThanOrEqual(
+      THRESHOLD_MS
+    );
+    expect(metric(body, 'civitai_app_watchdog_current_wedge_seconds')).toBeGreaterThan(0);
+    // Not yet recovered, so nothing has been observed into the histogram.
+    expect(metric(body, 'civitai_app_watchdog_wedge_total')).toBe(0);
+    expect(metric(body, 'civitai_app_watchdog_wedge_duration_seconds_count')).toBe(0);
+  });
+
+  it('closes out the wedge on recovery and dates it from the last beat', async () => {
+    const h = await startWorker();
+
+    const stalledFor = THRESHOLD_MS * 3;
+    await sleep(stalledFor);
+    h.beat.set([BigInt(Date.now())]);
+    // One poll interval is enough for the worker to see the fresh beat.
+    await sleep(150);
+
+    const { body } = await h.scrape();
+
+    expect(metric(body, 'civitai_app_watchdog_wedged')).toBe(0);
+    expect(metric(body, 'civitai_app_watchdog_current_wedge_seconds')).toBe(0);
+    expect(metric(body, 'civitai_app_watchdog_wedge_total')).toBe(1);
+    expect(metric(body, 'civitai_app_watchdog_wedge_duration_seconds_count')).toBe(1);
+
+    // Dated from the last beat, not from detection: the recorded duration must cover
+    // the whole stall including the threshold, not just the part after we noticed.
+    const observed = metric(body, 'civitai_app_watchdog_wedge_duration_seconds_sum') ?? 0;
+    expect(observed).toBeGreaterThanOrEqual((stalledFor / 1000) * 0.9);
+    expect(metric(body, 'civitai_app_watchdog_wedge_longest_seconds')).toBeCloseTo(observed, 5);
+
+    // The +Inf bucket must equal _count, or histogram_quantile() silently misreads.
+    const inf = Number(
+      body
+        .split('\n')
+        .find((l) => l.startsWith('civitai_app_watchdog_wedge_duration_seconds_bucket{le="+Inf"}'))
+        ?.split(' ')
+        .pop()
+    );
+    expect(inf).toBe(1);
+  });
+
+  it('rejects a scrape with a wrong or missing token', async () => {
+    const h = await startWorker();
+
+    expect((await h.scrape('nope')).status).toBe(401);
+    expect((await h.scrape('')).status).toBe(401);
+    // Same length as the real token, to exercise the timing-safe compare rather
+    // than the length short-circuit.
+    expect((await h.scrape('x'.repeat(TOKEN.length))).status).toBe(401);
+    expect((await h.scrape()).status).toBe(200);
+  });
+
+  it('serves unauthenticated only when no token is configured', async () => {
+    const h = await startWorker({ token: '' });
+
+    const res = await fetch(`http://127.0.0.1:${h.port}/metrics`);
+    expect(res.status).toBe(200);
+  });
+
+  it('404s anything that is not GET /metrics', async () => {
+    const h = await startWorker();
+
+    const notMetrics = await fetch(`http://127.0.0.1:${h.port}/`);
+    expect(notMetrics.status).toBe(404);
+
+    const wrongMethod = await fetch(`http://127.0.0.1:${h.port}/metrics?token=${TOKEN}`, {
+      method: 'POST',
+    });
+    expect(wrongMethod.status).toBe(404);
+  });
+
+  it('exits on the shutdown message rather than being terminated', async () => {
+    const h = await startWorker();
+
+    const exitCode = await new Promise<number>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('worker did not exit on shutdown')), 8000);
+      h.worker.once('exit', (code) => {
+        clearTimeout(timeout);
+        resolve(code);
+      });
+      h.worker.postMessage({ type: 'shutdown' });
+    });
+
+    expect(exitCode).toBe(0);
+  });
+});

--- a/src/server/__tests__/eventloop-watchdog.worker.test.ts
+++ b/src/server/__tests__/eventloop-watchdog.worker.test.ts
@@ -80,6 +80,17 @@ afterEach(async () => {
 });
 
 describe('event-loop watchdog worker', () => {
+  it('the source carries no backtick or ${ that would break out of its template', () => {
+    // The source lives inside a String.raw template, so a single backtick anywhere in
+    // it — including in a comment — silently TERMINATES the literal and turns the rest
+    // into TypeScript. That happened once already: a comment reading /anything/metrics
+    // in backticks broke the worker, prettier reformatted the wreckage, and every
+    // spawn died with `ReferenceError: anything is not defined`. It is a whole class
+    // of damage available to an innocuous comment edit, and it costs one assertion.
+    expect(WATCHDOG_WORKER_SOURCE).not.toContain('`');
+    expect(WATCHDOG_WORKER_SOURCE).not.toContain('${');
+  });
+
   it('serves its metrics while the heartbeat is fresh', async () => {
     const h = await startWorker();
     h.beat.set([BigInt(Date.now())]);
@@ -161,18 +172,58 @@ describe('event-loop watchdog worker', () => {
     expect((await h.scrape()).status).toBe(200);
   });
 
-  it('serves unauthenticated only when no token is configured', async () => {
-    const h = await startWorker({ token: '' });
+  it('FAILS CLOSED: refuses to listen at all when no token is configured', async () => {
+    // The listener binds 0.0.0.0, so serving unauthenticated would make the port
+    // cluster-readable and reduce containment to "it isn't on a Service" — a property
+    // of the scrape config rather than of this code. Refusing is a visible failure
+    // (worker_started=0); serving unauthenticated is an invisible one.
+    const sab = new SharedArrayBuffer(8);
+    Atomics.store(new BigInt64Array(sab), 0, BigInt(Date.now()));
 
-    const res = await fetch(`http://127.0.0.1:${h.port}/metrics`);
-    expect(res.status).toBe(200);
+    const worker = new Worker(WATCHDOG_WORKER_SOURCE, {
+      eval: true,
+      workerData: {
+        sab,
+        thresholdMs: 300,
+        port: 0,
+        token: '',
+        heartbeatIntervalMs: 50,
+        pollMs: 25,
+      },
+    });
+
+    const messages: string[] = [];
+    worker.on('message', (msg: { type?: string; message?: string }) => {
+      if (msg?.type === 'error' && msg.message) messages.push(msg.message);
+      // A 'listening' message here would mean it bound the port anyway.
+      if (msg?.type === 'listening') messages.push('LISTENING');
+    });
+
+    const exitCode = await new Promise<number>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('worker never exited')), 10_000);
+      worker.once('exit', (code) => {
+        clearTimeout(timeout);
+        resolve(code);
+      });
+      worker.once('error', (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+    });
+
+    expect(exitCode).not.toBe(0);
+    expect(messages).not.toContain('LISTENING');
+    expect(messages.join(' ')).toContain('refusing to serve metrics');
   });
 
-  it('404s anything that is not GET /metrics', async () => {
+  it('404s anything that is not exactly GET /metrics', async () => {
     const h = await startWorker();
 
-    const notMetrics = await fetch(`http://127.0.0.1:${h.port}/`);
-    expect(notMetrics.status).toBe(404);
+    expect((await fetch(`http://127.0.0.1:${h.port}/`)).status).toBe(404);
+    // Not endsWith: a nested path must not serve.
+    expect((await fetch(`http://127.0.0.1:${h.port}/anything/metrics?token=${TOKEN}`)).status).toBe(
+      404
+    );
 
     const wrongMethod = await fetch(`http://127.0.0.1:${h.port}/metrics?token=${TOKEN}`, {
       method: 'POST',

--- a/src/server/eventloop-watchdog.ts
+++ b/src/server/eventloop-watchdog.ts
@@ -1,0 +1,406 @@
+// Off-loop event-loop wedge detector.
+//
+// WHY: every existing way we watch the event loop runs ON the event loop, so all
+// of them are blind to the thing they are named after. The `loopstall-*`
+// self-trigger in cpu-profiler.ts reads its lag histogram from a setInterval that
+// cannot fire while the loop is pinned, and `/api/metrics` is served by the same
+// pinned loop, so a wedged pod reports nothing at all. Measured over six hours,
+// `nodejs_eventloop_lag_max_seconds` peaked at 7.46s while real wedges ran 4-5
+// minutes.
+//
+// This module puts the observer somewhere the wedge cannot reach it. The main
+// thread stores a millisecond timestamp into a SharedArrayBuffer; a worker thread
+// with its own event loop reads that timestamp and serves its own metrics port.
+// A wedged main thread stops updating the timestamp, and the worker — which is
+// still scheduling normally — reports the staleness.
+//
+// WHY A TIMER AND NOT A PER-TICK HOOK: a wedge IS "no timer has fired in N ms", so
+// a per-tick hook detects nothing a timer does not. The only way to hook every tick
+// is async_hooks, which is the exact per-resource cost instrumentation.node.ts
+// removed from OTEL and that eventloop-longtask.ts gates behind an opt-in tier.
+// Measured: Atomics.store is 7.8-9.0ns, but BigInt(Date.now()) makes the pair
+// 96.5ns, so the timestamp — not the store — would be the per-tick cost. At a 100ms
+// beat the whole mechanism is ~1us/s.
+//
+// WHY THE WORKER CANNOT SERVE /api/metrics: that route concatenates the default
+// registry, the cross-graph instrumentationRegistry, and two async Prisma
+// $metrics.prometheus() calls, several of them collect()-based gauges that compute
+// their values at scrape time on the main thread. None of it is reachable from
+// another thread. The worker therefore serves ONLY worker-owned metrics — which are
+// also the only ones that are still true during a wedge.
+//
+// WHY THE WORKER SOURCE IS AN INLINE STRING: next.config.mjs uses
+// output:'standalone', which traces files with @vercel/nft. The config already
+// carries three outputFileTracingIncludes workarounds for files nft could not
+// follow, one of them recording that /api/og broke this way and became the dominant
+// 500 source. A `new Worker(new URL('./file.js', import.meta.url))` from the
+// Turbopack instrumentation graph is the same failure class, and the failure is the
+// silent kind: the spawn throws, the arm-time catch below (correctly) swallows it,
+// and an absent watchdog reads exactly like a healthy pod. `eval: true` has no
+// tracing surface at all. The tradeoff is that the source is not type-checked, so
+// eventloop-watchdog.worker.test.ts spawns it for real.
+//
+// DISARMED by default, like every other profiler in this directory. Nothing is
+// installed unless EVENTLOOP_WATCHDOG_ENABLED === 'true'.
+//
+// Server-side (nodejs runtime) only. Never imported on the edge/client.
+
+import { Worker } from 'node:worker_threads';
+import client from 'prom-client';
+import { instrumentationRegistry, registerInstrumentationMetric } from '~/server/prom/client';
+
+const PROM_PREFIX = 'civitai_app_';
+
+const DEFAULT_THRESHOLD_MS = 1000;
+// Floor, not a default. A threshold near the noise level fires on ordinary GC:
+// measured loop lag on these pools already reaches 7.46s (api-primary) and 15.62s
+// (SSR) at max, and real wedges last minutes, so sub-second detection latency buys
+// nothing worth the false positives.
+const MIN_THRESHOLD_MS = 250;
+
+const DEFAULT_HEARTBEAT_MS = 100;
+const MIN_HEARTBEAT_MS = 20;
+const MAX_HEARTBEAT_MS = 1000;
+
+const DEFAULT_PORT = 9099;
+const DEFAULT_POLL_MS = 50;
+
+// A wedge is declared after `threshold / beat` missed beats, so the two settings are
+// only independently meaningful while that quotient is comfortably above 1. At 2x —
+// reachable with the legal pair threshold=250, beat=100 — 2.5 missed beats declares a
+// wedge, which scheduler jitter alone can produce on a node at 98-99% of allocatable
+// CPU. Both values would be individually legal and their ratio legal, and the pod
+// would report a rolling wedge that is entirely an artifact of its own config.
+const MIN_THRESHOLD_BEAT_RATIO = 3;
+
+/**
+ * Resolved once at module load so `liveness-heartbeat` can branch on a constant.
+ * Every other gate in this directory (pyroscope, cpu-profiler, eventloop-longtask)
+ * reads its env once at load for the same reason.
+ */
+export const watchdogArmed = process.env.EVENTLOOP_WATCHDOG_ENABLED === 'true';
+
+// 8 bytes, allocated unconditionally. Cheaper than branching on `watchdogArmed` at
+// every call site, and it keeps recordWatchdogHeartbeat() free of a null check.
+const heartbeatBuffer = new SharedArrayBuffer(8);
+const heartbeat = new BigInt64Array(heartbeatBuffer);
+
+export function recordWatchdogHeartbeat(nowMs: number = Date.now()): void {
+  Atomics.store(heartbeat, 0, BigInt(nowMs));
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function parsePositiveInt(raw: string | undefined): number | undefined {
+  const parsed = Number.parseInt(raw ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+export function resolveWatchdogThresholdMs(): number {
+  const parsed = parsePositiveInt(process.env.EVENTLOOP_WATCHDOG_THRESHOLD_MS);
+  return Math.max(parsed ?? DEFAULT_THRESHOLD_MS, MIN_THRESHOLD_MS);
+}
+
+/**
+ * EFFECTIVE beat interval — the tick rate liveness-heartbeat actually runs at, the
+ * resolution of every wedge duration the worker reports, and the value echoed as
+ * `civitai_app_watchdog_heartbeat_interval_ms`. Echoing the requested value while
+ * running a different one would make the config echo a lying metric, which is worse
+ * than a missing one because it survives inspection.
+ *
+ * Enforces MIN_THRESHOLD_BEAT_RATIO by lowering the BEAT, never by raising the
+ * threshold. The threshold is the operator's stated intent — the number that defines
+ * what "wedged" means on this pod — so moving it silently would change what the pod
+ * detects while the config still claims otherwise. The beat is an implementation
+ * detail nobody tunes deliberately. `threshold / 3` is 83ms even at the 250ms
+ * threshold floor, so this always has room above MIN_HEARTBEAT_MS and can never fail
+ * to satisfy the ratio.
+ */
+export function resolveWatchdogHeartbeatMs(): number {
+  const parsed = parsePositiveInt(process.env.EVENTLOOP_WATCHDOG_HEARTBEAT_MS);
+  const configured = clamp(parsed ?? DEFAULT_HEARTBEAT_MS, MIN_HEARTBEAT_MS, MAX_HEARTBEAT_MS);
+  const ratioCeiling = Math.floor(resolveWatchdogThresholdMs() / MIN_THRESHOLD_BEAT_RATIO);
+  return clamp(Math.min(configured, ratioCeiling), MIN_HEARTBEAT_MS, MAX_HEARTBEAT_MS);
+}
+
+export function resolveWatchdogPort(): number {
+  return parsePositiveInt(process.env.WATCHDOG_METRICS_PORT) ?? DEFAULT_PORT;
+}
+
+/**
+ * Paired with the worker-served `civitai_app_watchdog_up`: this one says the main
+ * thread spawned the worker, that one says the worker is alive. Neither alone can
+ * tell "the watchdog is absent" from "no wedges occurred", which is the failure mode
+ * the inline-source note above describes. Together they separate five states:
+ *
+ *                                 watchdog_up   worker_started
+ *   healthy                            1              1
+ *   MAIN THREAD WEDGED                 1           absent   (main can't serve /api/metrics)
+ *   worker died after starting     absent             1
+ *   worker never spawned (threw)   absent             0
+ *   pod gone                       absent          absent
+ *
+ * Registered lazily, INSIDE the arm path, so a disarmed pod reports the series as
+ * absent rather than 0 — prom-client would otherwise export a never-set gauge as 0,
+ * making an un-enabled pool indistinguishable from a real arm failure and turning the
+ * `== 0` alert into a false page on every pool we have not enabled yet.
+ * `registerInstrumentationMetric` is get-or-create, so repeated calls are safe.
+ */
+function workerStartedGauge() {
+  return registerInstrumentationMetric(
+    PROM_PREFIX + 'watchdog_worker_started',
+    () =>
+      new client.Gauge({
+        name: PROM_PREFIX + 'watchdog_worker_started',
+        help: 'Whether the main thread successfully spawned the event-loop watchdog worker (1) or tried and failed (0). Absent means either the watchdog is disarmed on this pod or the main thread cannot serve /api/metrics — compare against the worker-served civitai_app_watchdog_up to tell those apart.',
+        registers: [instrumentationRegistry],
+      })
+  );
+}
+
+/**
+ * The worker runs as CommonJS (`eval: true` does not imply ESM) and imports nothing
+ * but node: builtins — no prom-client, so there is no bare-specifier resolution to
+ * go wrong inside an eval'd worker in the standalone image. The Prometheus text is
+ * hand-formatted for the same reason.
+ */
+export const WATCHDOG_WORKER_SOURCE = String.raw`
+const { workerData, parentPort } = require('node:worker_threads');
+const http = require('node:http');
+const crypto = require('node:crypto');
+
+const { sab, thresholdMs, port, token, heartbeatIntervalMs, pollMs } = workerData;
+const beat = new BigInt64Array(sab);
+
+const BUCKETS = [1, 2, 5, 10, 30, 60, 120, 300, 600];
+const bucketCounts = new Array(BUCKETS.length).fill(0);
+let wedgeCount = 0;
+let wedgeSumSeconds = 0;
+let longestSeconds = 0;
+// Epoch ms of the last beat before the current wedge, or 0 when healthy.
+let wedgeStartedAt = 0;
+const startedAt = Date.now();
+
+function lastBeatMs() {
+  return Number(Atomics.load(beat, 0));
+}
+
+function observeWedge(seconds) {
+  wedgeCount++;
+  wedgeSumSeconds += seconds;
+  if (seconds > longestSeconds) longestSeconds = seconds;
+  for (let i = 0; i < BUCKETS.length; i++) {
+    if (seconds <= BUCKETS[i]) bucketCounts[i]++;
+  }
+}
+
+setInterval(function () {
+  const now = Date.now();
+  const lastBeat = lastBeatMs();
+  const age = now - lastBeat;
+  if (wedgeStartedAt === 0) {
+    // Date the wedge from the last beat, not from detection, so the reported
+    // duration does not silently exclude the threshold.
+    if (age >= thresholdMs) wedgeStartedAt = lastBeat;
+  } else if (age < thresholdMs) {
+    observeWedge((now - wedgeStartedAt) / 1000);
+    wedgeStartedAt = 0;
+  }
+}, pollMs).unref();
+
+function render() {
+  const now = Date.now();
+  const age = now - lastBeatMs();
+  const wedged = wedgeStartedAt === 0 ? 0 : 1;
+  const current = wedgeStartedAt === 0 ? 0 : (now - wedgeStartedAt) / 1000;
+  const out = [];
+  function gauge(name, help, value) {
+    out.push('# HELP ' + name + ' ' + help);
+    out.push('# TYPE ' + name + ' gauge');
+    out.push(name + ' ' + value);
+  }
+  gauge('civitai_app_watchdog_up', 'Event-loop watchdog worker is running and serving. Absence of this series is the signal that the watchdog is not running.', 1);
+  gauge('civitai_app_watchdog_heartbeat_age_ms', 'Milliseconds since the main thread last wrote the shared-memory heartbeat. Grows without bound while the loop is wedged.', age);
+  gauge('civitai_app_watchdog_wedged', 'Whether the main-thread event loop is currently considered wedged (1) or not (0).', wedged);
+  gauge('civitai_app_watchdog_current_wedge_seconds', 'Duration of the IN-PROGRESS wedge, 0 when healthy. The duration histogram only observes on recovery, so this is the only series that moves during a live wedge or if the pod is killed mid-wedge.', current);
+  gauge('civitai_app_watchdog_wedge_longest_seconds', 'Longest completed wedge observed in this process lifetime, seconds.', longestSeconds);
+  gauge('civitai_app_watchdog_started_timestamp_seconds', 'Unix timestamp at which the watchdog worker started.', Math.floor(startedAt / 1000));
+  gauge('civitai_app_watchdog_threshold_ms', 'Configured heartbeat-staleness threshold for declaring a wedge, ms.', thresholdMs);
+  gauge('civitai_app_watchdog_heartbeat_interval_ms', 'Configured main-thread heartbeat interval, ms.', heartbeatIntervalMs);
+
+  out.push('# HELP civitai_app_watchdog_wedge_total Total completed event-loop wedges detected off-loop.');
+  out.push('# TYPE civitai_app_watchdog_wedge_total counter');
+  out.push('civitai_app_watchdog_wedge_total ' + wedgeCount);
+
+  out.push('# HELP civitai_app_watchdog_wedge_duration_seconds Completed event-loop wedge durations, seconds. Observed on RECOVERY only.');
+  out.push('# TYPE civitai_app_watchdog_wedge_duration_seconds histogram');
+  for (let i = 0; i < BUCKETS.length; i++) {
+    out.push('civitai_app_watchdog_wedge_duration_seconds_bucket{le="' + BUCKETS[i] + '"} ' + bucketCounts[i]);
+  }
+  out.push('civitai_app_watchdog_wedge_duration_seconds_bucket{le="+Inf"} ' + wedgeCount);
+  out.push('civitai_app_watchdog_wedge_duration_seconds_sum ' + wedgeSumSeconds);
+  out.push('civitai_app_watchdog_wedge_duration_seconds_count ' + wedgeCount);
+
+  return out.join('\n') + '\n';
+}
+
+function tokenAccepted(url) {
+  if (!token) return true;
+  let given = '';
+  try {
+    given = new URL(url, 'http://localhost').searchParams.get('token') || '';
+  } catch (err) {
+    return false;
+  }
+  const a = Buffer.from(given);
+  const b = Buffer.from(token);
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+
+const server = http.createServer(function (req, res) {
+  const url = req.url || '';
+  if (req.method !== 'GET' || !url.split('?')[0].endsWith('/metrics')) {
+    res.writeHead(404);
+    res.end();
+    return;
+  }
+  if (!tokenAccepted(url)) {
+    res.writeHead(401);
+    res.end();
+    return;
+  }
+  res.writeHead(200, { 'content-type': 'text/plain; version=0.0.4; charset=utf-8' });
+  res.end(render());
+});
+
+server.on('error', function (err) {
+  if (parentPort) parentPort.postMessage({ type: 'error', message: String((err && err.message) || err) });
+});
+
+server.listen(port, '0.0.0.0', function () {
+  const address = server.address();
+  if (parentPort) parentPort.postMessage({ type: 'listening', port: address && address.port });
+});
+
+if (parentPort) {
+  parentPort.on('message', function (msg) {
+    if (msg && msg.type === 'shutdown') {
+      // v1 holds no inspector session, but v2 will, and a session still connected
+      // at exit prints "Waiting for the debugger to disconnect..." and can hold the
+      // process past its termination grace period into a SIGKILL. Wire the teardown
+      // path now so that addition has somewhere to go.
+      server.close(function () {
+        process.exit(0);
+      });
+      // Don't let a hung connection outlive the grace period.
+      setTimeout(function () {
+        process.exit(0);
+      }, 2000).unref();
+    }
+  });
+}
+`;
+
+let worker: Worker | undefined;
+
+/** Test-only accessor for the live worker. */
+export function __getWatchdogWorkerForTests(): Worker | undefined {
+  return worker;
+}
+
+/**
+ * Ask the worker to close its listener and exit. Idempotent; safe to call when the
+ * watchdog was never armed.
+ */
+export function shutdownEventLoopWatchdog(): void {
+  const current = worker;
+  if (!current) return;
+  worker = undefined;
+  try {
+    current.postMessage({ type: 'shutdown' });
+  } catch {
+    // Worker already gone.
+  }
+  // The worker exits itself on the shutdown message; terminate() is the backstop for
+  // a worker that is wedged in its own right.
+  const kill = setTimeout(() => {
+    void current.terminate();
+  }, 3000);
+  kill.unref();
+  current.once('exit', () => clearTimeout(kill));
+}
+
+/**
+ * Spawn the off-loop wedge detector. Safe to call once at server startup, no-op off
+ * the nodejs runtime and unless EVENTLOOP_WATCHDOG_ENABLED === 'true'.
+ *
+ * Arm-time failures must never reject the caller (the OTEL instrumentation
+ * register()), so the whole body is wrapped — but unlike the other profilers here, a
+ * swallowed failure is NOT invisible: workerStartedGauge is set to 0, and the
+ * worker-served `civitai_app_watchdog_up` will be absent.
+ */
+export function registerEventLoopWatchdog(): void {
+  try {
+    if (process.env.NEXT_RUNTIME && process.env.NEXT_RUNTIME !== 'nodejs') return;
+    if (!watchdogArmed) return;
+    if (worker) return;
+
+    const thresholdMs = resolveWatchdogThresholdMs();
+    const heartbeatIntervalMs = resolveWatchdogHeartbeatMs();
+    const port = resolveWatchdogPort();
+
+    recordWatchdogHeartbeat();
+
+    worker = new Worker(WATCHDOG_WORKER_SOURCE, {
+      eval: true,
+      workerData: {
+        sab: heartbeatBuffer,
+        thresholdMs,
+        port,
+        // Same ?token= posture as /api/metrics. Absent token => unauthenticated,
+        // which is only acceptable because the port is never added to a Service.
+        token: process.env.WEBHOOK_TOKEN ?? '',
+        heartbeatIntervalMs,
+        pollMs: Math.min(DEFAULT_POLL_MS, heartbeatIntervalMs),
+      },
+      // The watchdog must never be the reason the process stays up.
+      stdout: false,
+      stderr: false,
+    });
+    worker.unref();
+
+    worker.on('message', (msg: { type?: string; port?: number; message?: string }) => {
+      if (msg?.type === 'listening') {
+        console.log(
+          `[eventloop-watchdog] armed: worker serving /metrics on :${msg.port} ` +
+            `threshold=${thresholdMs}ms heartbeat=${heartbeatIntervalMs}ms`
+        );
+      } else if (msg?.type === 'error') {
+        console.error(`[eventloop-watchdog] worker error: ${msg.message}`);
+      }
+    });
+
+    worker.on('error', (err) => {
+      console.error('[eventloop-watchdog] worker threw; watchdog is no longer running:', err);
+      workerStartedGauge().set(0);
+      worker = undefined;
+    });
+
+    worker.on('exit', (code) => {
+      if (code !== 0) {
+        console.error(`[eventloop-watchdog] worker exited unexpectedly with code ${code}`);
+      }
+      workerStartedGauge().set(0);
+      worker = undefined;
+    });
+
+    workerStartedGauge().set(1);
+
+    process.once('SIGTERM', shutdownEventLoopWatchdog);
+  } catch (err) {
+    workerStartedGauge().set(0);
+    console.error('[eventloop-watchdog] failed to arm; continuing without it:', err);
+  }
+}

--- a/src/server/eventloop-watchdog.ts
+++ b/src/server/eventloop-watchdog.ts
@@ -4,9 +4,9 @@
 // of them are blind to the thing they are named after. The `loopstall-*`
 // self-trigger in cpu-profiler.ts reads its lag histogram from a setInterval that
 // cannot fire while the loop is pinned, and `/api/metrics` is served by the same
-// pinned loop, so a wedged pod reports nothing at all. Measured over six hours,
-// `nodejs_eventloop_lag_max_seconds` peaked at 7.46s while real wedges ran 4-5
-// minutes.
+// pinned loop, so a wedged pod reports nothing at all. Measured over six hours, the
+// scraped event-loop-lag metric peaked several seconds below the shortest real wedge
+// in the same window — wedges run minutes, and the scrape cannot report during one.
 //
 // This module puts the observer somewhere the wedge cannot reach it. The main
 // thread stores a millisecond timestamp into a SharedArrayBuffer; a worker thread
@@ -53,9 +53,9 @@ const PROM_PREFIX = 'civitai_app_';
 
 const DEFAULT_THRESHOLD_MS = 1000;
 // Floor, not a default. A threshold near the noise level fires on ordinary GC:
-// measured loop lag on these pools already reaches 7.46s (api-primary) and 15.62s
-// (SSR) at max, and real wedges last minutes, so sub-second detection latency buys
-// nothing worth the false positives.
+// measured baseline loop lag already reaches multiple seconds at max, and real
+// wedges last minutes, so sub-second detection latency buys nothing worth the false
+// positives.
 const MIN_THRESHOLD_MS = 250;
 
 const DEFAULT_HEARTBEAT_MS = 100;

--- a/src/server/eventloop-watchdog.ts
+++ b/src/server/eventloop-watchdog.ts
@@ -137,10 +137,19 @@ export function resolveWatchdogPort(): number {
  *
  *                                 watchdog_up   worker_started
  *   healthy                            1              1
- *   MAIN THREAD WEDGED                 1           absent   (main can't serve /api/metrics)
+ *   MAIN THREAD WEDGED                 1           absent   (only past the scrape timeout — see below)
  *   worker died after starting     absent             1
  *   worker never spawned (threw)   absent             0
  *   pod gone                       absent          absent
+ *
+ * Row 2 is SCRAPE-TIMEOUT-BOUND, not instant. A wedged main thread does not refuse
+ * the /api/metrics request, it queues it and answers on recovery — measured in
+ * preview, the reply landed 30ms after the wedge cleared. So worker_started only goes
+ * absent once a wedge outlasts the scrape timeout, for roughly max(0, D-timeout)/interval
+ * of scrapes. A short wedge never blanks it. Row 2 is therefore a disambiguator for
+ * the long wedges this exists to catch (the real ones ran 4-5 minutes), not the
+ * detection signal — that is current_wedge_seconds off the worker's own port, which
+ * moves within one poll regardless.
  *
  * Registered lazily, INSIDE the arm path, so a disarmed pod reports the series as
  * absent rather than 0 — prom-client would otherwise export a never-set gauge as 0,

--- a/src/server/eventloop-watchdog.ts
+++ b/src/server/eventloop-watchdog.ts
@@ -228,7 +228,7 @@ function render() {
   gauge('civitai_app_watchdog_wedge_longest_seconds', 'Longest completed wedge observed in this process lifetime, seconds.', longestSeconds);
   gauge('civitai_app_watchdog_started_timestamp_seconds', 'Unix timestamp at which the watchdog worker started.', Math.floor(startedAt / 1000));
   gauge('civitai_app_watchdog_threshold_ms', 'Configured heartbeat-staleness threshold for declaring a wedge, ms.', thresholdMs);
-  gauge('civitai_app_watchdog_heartbeat_interval_ms', 'Configured main-thread heartbeat interval, ms.', heartbeatIntervalMs);
+  gauge('civitai_app_watchdog_heartbeat_interval_ms', 'EFFECTIVE main-thread heartbeat interval, ms — the value actually in use after the threshold/beat ratio clamp, which may be lower than the configured one.', heartbeatIntervalMs);
 
   out.push('# HELP civitai_app_watchdog_wedge_total Total completed event-loop wedges detected off-loop.');
   out.push('# TYPE civitai_app_watchdog_wedge_total counter');
@@ -246,8 +246,22 @@ function render() {
   return out.join('\n') + '\n';
 }
 
+// FAIL CLOSED. The listener binds 0.0.0.0 (Prometheus scrapes the pod IP), so with no
+// token the port is cluster-readable and the whole containment story collapses to
+// "it isn't on a Service" — a property of the scrape config, not of this code. A
+// watchdog that refuses to expose metrics is a visible failure; one that exposes them
+// unauthenticated is an invisible one. Exiting here surfaces as worker_started=0.
+if (!token) {
+  if (parentPort) {
+    parentPort.postMessage({
+      type: 'error',
+      message: 'refusing to serve metrics: no token configured (WEBHOOK_TOKEN unset)',
+    });
+  }
+  process.exit(1);
+}
+
 function tokenAccepted(url) {
-  if (!token) return true;
   let given = '';
   try {
     given = new URL(url, 'http://localhost').searchParams.get('token') || '';
@@ -261,7 +275,8 @@ function tokenAccepted(url) {
 
 const server = http.createServer(function (req, res) {
   const url = req.url || '';
-  if (req.method !== 'GET' || !url.split('?')[0].endsWith('/metrics')) {
+  // Exact path, not endsWith, so a nested path like /anything/metrics cannot serve.
+  if (req.method !== 'GET' || url.split('?')[0] !== '/metrics') {
     res.writeHead(404);
     res.end();
     return;
@@ -304,6 +319,7 @@ if (parentPort) {
 `;
 
 let worker: Worker | undefined;
+let sigtermHooked = false;
 
 /** Test-only accessor for the live worker. */
 export function __getWatchdogWorkerForTests(): Worker | undefined {
@@ -398,7 +414,13 @@ export function registerEventLoopWatchdog(): void {
 
     workerStartedGauge().set(1);
 
-    process.once('SIGTERM', shutdownEventLoopWatchdog);
+    // Guarded, not `once`: `once` still ADDS a listener per successful spawn, so a
+    // respawn after a worker death accumulates them until the MaxListeners warning
+    // fires and shutdown runs twice.
+    if (!sigtermHooked) {
+      sigtermHooked = true;
+      process.on('SIGTERM', shutdownEventLoopWatchdog);
+    }
   } catch (err) {
     workerStartedGauge().set(0);
     console.error('[eventloop-watchdog] failed to arm; continuing without it:', err);

--- a/src/server/liveness-heartbeat.ts
+++ b/src/server/liveness-heartbeat.ts
@@ -1,5 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import {
+  recordWatchdogHeartbeat,
+  resolveWatchdogHeartbeatMs,
+  watchdogArmed,
+} from '~/server/eventloop-watchdog';
 
 /**
  * Liveness heartbeat for an EXEC liveness probe.
@@ -22,8 +27,15 @@ import path from 'node:path';
  * is reaped. That is the correct "tolerate busy, detect dead" semantics, with a
  * real loop-liveness signal instead of probe-latency tolerance tuning.
  *
- * Epoch-SECONDS (not ms) because the runner image is node:20-alpine → busybox
+ * Epoch-SECONDS (not ms) because the runner image is node:24-alpine3.24 → busybox
  * `date` has no `%N`; the probe reads seconds with `date +%s`.
+ *
+ * The same tick also stores a MILLISECOND timestamp into the event-loop watchdog's
+ * SharedArrayBuffer, which a worker thread reads to detect a wedge off-loop. One
+ * timer, two consumers at their own resolutions: the shell probe is stuck at
+ * seconds by busybox, the worker is not. When the watchdog is armed the tick rate
+ * drops to its heartbeat interval and the file write is throttled back to its own
+ * 2s cadence, so the probe's contract is unchanged.
  *
  * Implementation notes:
  * - SYNC write: the whole write completes inside the timer callback, so the file
@@ -36,7 +48,7 @@ import path from 'node:path';
  * - The timer is `unref()`d so it never keeps the process alive on its own.
  */
 const HEARTBEAT_FILE = process.env.LIVENESS_HEARTBEAT_FILE ?? '/tmp/heartbeat';
-const HEARTBEAT_INTERVAL_MS = 2000;
+const HEARTBEAT_FILE_INTERVAL_MS = 2000;
 
 let started = false;
 let loggedError = false;
@@ -74,7 +86,21 @@ export function registerLivenessHeartbeat() {
 
   // Write immediately so the file exists before the startup probe passes and
   // liveness (which gates behind startup) begins checking it.
+  recordWatchdogHeartbeat();
   write();
-  const timer = setInterval(write, HEARTBEAT_INTERVAL_MS);
+
+  const tickMs = watchdogArmed
+    ? Math.min(resolveWatchdogHeartbeatMs(), HEARTBEAT_FILE_INTERVAL_MS)
+    : HEARTBEAT_FILE_INTERVAL_MS;
+
+  let lastFileWrite = Date.now();
+  const timer = setInterval(() => {
+    const now = Date.now();
+    recordWatchdogHeartbeat(now);
+    if (now - lastFileWrite >= HEARTBEAT_FILE_INTERVAL_MS) {
+      lastFileWrite = now;
+      write();
+    }
+  }, tickMs);
   timer.unref();
 }

--- a/src/server/middleware/__tests__/route-guards.testing-stall.test.ts
+++ b/src/server/middleware/__tests__/route-guards.testing-stall.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `isProd` is a module-load constant, and under vitest NODE_ENV is 'test', so without
+// this every guard trivially allows and the suite proves nothing about production
+// behaviour. Force it true so these run the branch that actually ships.
+vi.mock('~/env/other', () => ({
+  isProd: true,
+  isDev: false,
+  isTest: false,
+  isPreview: false,
+}));
+
+// This drives the REAL guard through `routeGuardsMiddleware.handler`, not the pure
+// predicate. The predicate already has its own suite; what this covers is the wiring
+// between them — matcher, `shouldRun`, and the `nextUrl` fields the guard reads. A
+// review found that the tests for this feature all stopped at the module boundary,
+// and the wiring is exactly where a working predicate can still fail to take effect.
+
+type Redirected = { redirectedTo: string } | undefined;
+
+function requestFor(url: string) {
+  const nextUrl = new URL(url);
+  return { nextUrl, url } as never;
+}
+
+async function run(url: string): Promise<Redirected> {
+  const { routeGuardsMiddleware } = await import('~/server/middleware/route-guards.middleware');
+  let redirectedTo: string | undefined;
+  const response = await routeGuardsMiddleware.handler({
+    request: requestFor(url),
+    redirect: ((to: string) => {
+      redirectedTo = to;
+      return { status: 307 } as never;
+    }) as never,
+  });
+  return response ? { redirectedTo: redirectedTo ?? '(unknown)' } : undefined;
+}
+
+async function shouldRun(url: string): Promise<boolean> {
+  const { routeGuardsMiddleware } = await import('~/server/middleware/route-guards.middleware');
+  return routeGuardsMiddleware.shouldRun?.(requestFor(url)) ?? true;
+}
+
+const STALL = '/api/testing/eventloop-stall';
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+describe('route guard wiring for the synthetic stall endpoint (isProd = true)', () => {
+  it('the middleware is even selected for the path (positive control)', async () => {
+    // If `shouldRun` were false the handler would never execute and every assertion
+    // below would pass for the wrong reason.
+    expect(await shouldRun(`https://pr-3752.civitaic.com${STALL}`)).toBe(true);
+  });
+
+  it('🔴 lets the stall endpoint through on a non-production host', async () => {
+    expect(await run(`https://pr-3752.civitaic.com${STALL}`)).toBeUndefined();
+  });
+
+  it('🔴 still redirects the stall endpoint on the production host', async () => {
+    expect(await run(`https://civitai.com${STALL}`)).toEqual({ redirectedTo: '/' });
+  });
+
+  it('🔴 still redirects every other testing route on a non-production host', async () => {
+    for (const path of ['/api/testing/referrals', '/api/testing/gift-membership']) {
+      expect(await run(`https://pr-3752.civitaic.com${path}`), path).toEqual({
+        redirectedTo: '/',
+      });
+    }
+  });
+
+  it('carries the query string without affecting the decision', async () => {
+    // The real call carries ?token=…; a guard reading `href` instead of `pathname`
+    // would break on it and nothing else here would notice.
+    expect(await run(`https://pr-3752.civitaic.com${STALL}?token=abc123`)).toBeUndefined();
+  });
+});

--- a/src/server/middleware/__tests__/route-guards.testing-stall.test.ts
+++ b/src/server/middleware/__tests__/route-guards.testing-stall.test.ts
@@ -18,9 +18,16 @@ vi.mock('~/env/other', () => ({
 
 type Redirected = { redirectedTo: string } | undefined;
 
-function requestFor(url: string) {
+function requestFor(url: string, headerOverrides: Record<string, string> = {}) {
   const nextUrl = new URL(url);
-  return { nextUrl, url } as never;
+  // Default to the realistic shape: the proxy forwards the public host in a header
+  // while the runtime's own view of the URL may be something internal.
+  const headers: Record<string, string> = { host: nextUrl.hostname, ...headerOverrides };
+  return {
+    nextUrl,
+    url,
+    headers: { get: (name: string) => headers[name.toLowerCase()] ?? null },
+  } as never;
 }
 
 async function run(url: string): Promise<Redirected> {
@@ -68,6 +75,25 @@ describe('route guard wiring for the synthetic stall endpoint (isProd = true)', 
         redirectedTo: '/',
       });
     }
+  });
+
+  it('🔴 allows when only the FORWARDED host is the preview host', async () => {
+    // The live failure this was written for: `nextUrl.hostname` is whatever the
+    // runtime resolved behind the proxy, which need not be the public host. If the
+    // guard read `nextUrl.hostname` alone, this case redirects and the endpoint is
+    // unreachable in preview while every unit test still passes.
+    const { routeGuardsMiddleware } = await import('~/server/middleware/route-guards.middleware');
+    const request = requestFor(`https://internal-service.local${STALL}`, {
+      host: 'internal-service.local',
+      'x-forwarded-host': 'pr-3752.civitaic.com',
+    });
+
+    const response = await routeGuardsMiddleware.handler({
+      request,
+      redirect: (() => ({ status: 307 })) as never,
+    });
+
+    expect(response).toBeUndefined();
   });
 
   it('carries the query string without affecting the decision', async () => {

--- a/src/server/middleware/__tests__/testing-route-access.test.ts
+++ b/src/server/middleware/__tests__/testing-route-access.test.ts
@@ -1,5 +1,51 @@
 import { describe, expect, it } from 'vitest';
-import { canAccessTestingRoute } from '~/server/middleware/testing-route-access';
+import {
+  canAccessTestingRoute,
+  resolveRequestHost,
+} from '~/server/middleware/testing-route-access';
+
+function req(headers: Record<string, string>, nextUrlHostname = 'internal.invalid') {
+  return {
+    headers: { get: (name: string) => headers[name.toLowerCase()] ?? null },
+    nextUrl: { hostname: nextUrlHostname },
+  };
+}
+
+describe('resolveRequestHost', () => {
+  // `nextUrl.hostname` is derived from the request as the runtime sees it, and behind
+  // a CDN and an ingress proxy nothing guarantees it carries the public host. These
+  // pin the precedence and the normalisation the suffix test depends on.
+  it('prefers x-forwarded-host, then host, then nextUrl', () => {
+    expect(resolveRequestHost(req({ 'x-forwarded-host': 'pr-1.civitaic.com', host: 'svc' }))).toBe(
+      'pr-1.civitaic.com'
+    );
+    expect(resolveRequestHost(req({ host: 'pr-1.civitaic.com' }))).toBe('pr-1.civitaic.com');
+    expect(resolveRequestHost(req({}, 'pr-1.civitaic.com'))).toBe('pr-1.civitaic.com');
+  });
+
+  it('normalises port, case, and a forwarded chain', () => {
+    expect(resolveRequestHost(req({ host: 'PR-1.CivitaiC.com:3000' }))).toBe('pr-1.civitaic.com');
+    expect(resolveRequestHost(req({ 'x-forwarded-host': 'pr-1.civitaic.com, internal.svc' }))).toBe(
+      'pr-1.civitaic.com'
+    );
+    expect(resolveRequestHost(req({ host: '  pr-1.civitaic.com  ' }))).toBe('pr-1.civitaic.com');
+  });
+
+  it('normalisation cannot manufacture a match', () => {
+    // Everything above trims and lowercases; none of it may turn a non-preview host
+    // into one.
+    for (const host of ['civitai.com:443', 'EVIL-CIVITAIC.COM', 'civitaic.com']) {
+      expect(
+        canAccessTestingRoute({
+          pathname: '/api/testing/eventloop-stall',
+          hostname: resolveRequestHost(req({ host })),
+          isProduction: true,
+        }),
+        host
+      ).toBe(false);
+    }
+  });
+});
 
 // The exemption this covers exists so a preview environment can trigger a synthetic
 // event-loop stall. The endpoint's job is to hard-lock an app server, so the guard is

--- a/src/server/middleware/__tests__/testing-route-access.test.ts
+++ b/src/server/middleware/__tests__/testing-route-access.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { canAccessTestingRoute } from '~/server/middleware/testing-route-access';
+
+// The exemption this covers exists so a preview environment can trigger a synthetic
+// event-loop stall. The endpoint's job is to hard-lock an app server, so the guard is
+// worth pinning case by case rather than trusting a reading of `endsWith`.
+
+const STALL = '/api/testing/eventloop-stall';
+
+describe('canAccessTestingRoute', () => {
+  it('allows everything off production, as before', () => {
+    for (const pathname of [STALL, '/api/testing/referrals', '/api/testing/anything']) {
+      expect(
+        canAccessTestingRoute({ pathname, hostname: 'localhost', isProduction: false }),
+        pathname
+      ).toBe(true);
+    }
+  });
+
+  it('allows the stall endpoint on a preview host', () => {
+    for (const hostname of ['pr-1.civitaic.com', 'pr-3752.civitaic.com', 'a.b.civitaic.com']) {
+      expect(
+        canAccessTestingRoute({ pathname: STALL, hostname, isProduction: true }),
+        hostname
+      ).toBe(true);
+    }
+  });
+
+  it('🔴 refuses the stall endpoint on the production hostname', () => {
+    for (const hostname of ['civitai.com', 'www.civitai.com', 'civitai.red']) {
+      expect(
+        canAccessTestingRoute({ pathname: STALL, hostname, isProduction: true }),
+        hostname
+      ).toBe(false);
+    }
+  });
+
+  it('🔴 refuses hostnames that merely resemble a preview host', () => {
+    // `civitaic.com` and `civitai.com` differ by one character, and the suffix match
+    // has to be anchored on the dot or a lookalike registration would satisfy it.
+    for (const hostname of [
+      'evil-civitaic.com', // no separating dot
+      'civitaic.com', // bare apex, not a preview subdomain
+      'xcivitaic.com',
+      'pr-1.civitaic.com.evil.com', // preview host as a prefix of someone else's domain
+      'civitaic.com.evil.com',
+      'pr-1.civitai.com', // the real domain, preview-shaped
+    ]) {
+      expect(
+        canAccessTestingRoute({ pathname: STALL, hostname, isProduction: true }),
+        hostname
+      ).toBe(false);
+    }
+  });
+
+  it('🔴 does NOT widen any other testing route on a preview host', () => {
+    // The whole argument for touching this shared guard was that it opens exactly one
+    // path. If this ever fails, the blast radius of the change is no longer what was
+    // reviewed.
+    for (const pathname of [
+      '/api/testing/referrals',
+      '/api/testing/gift-membership',
+      '/api/testing/blue-buzz-paid-access',
+      `${STALL}/extra`,
+      '/api/testing/eventloop-stall-other',
+      '/api/testing',
+    ]) {
+      expect(
+        canAccessTestingRoute({ pathname, hostname: 'pr-1.civitaic.com', isProduction: true }),
+        pathname
+      ).toBe(false);
+    }
+  });
+});

--- a/src/server/middleware/__tests__/testing-route-access.test.ts
+++ b/src/server/middleware/__tests__/testing-route-access.test.ts
@@ -17,7 +17,7 @@ describe('canAccessTestingRoute', () => {
     }
   });
 
-  it('allows the stall endpoint on a preview host', () => {
+  it('allows the stall endpoint on a non-production host', () => {
     for (const hostname of ['pr-1.civitaic.com', 'pr-3752.civitaic.com', 'a.b.civitaic.com']) {
       expect(
         canAccessTestingRoute({ pathname: STALL, hostname, isProduction: true }),
@@ -35,7 +35,7 @@ describe('canAccessTestingRoute', () => {
     }
   });
 
-  it('🔴 refuses hostnames that merely resemble a preview host', () => {
+  it('🔴 refuses hostnames that merely resemble a non-production host', () => {
     // `civitaic.com` and `civitai.com` differ by one character, and the suffix match
     // has to be anchored on the dot or a lookalike registration would satisfy it.
     for (const hostname of [
@@ -53,7 +53,7 @@ describe('canAccessTestingRoute', () => {
     }
   });
 
-  it('🔴 does NOT widen any other testing route on a preview host', () => {
+  it('🔴 does NOT widen any other testing route on a non-production host', () => {
     // The whole argument for touching this shared guard was that it opens exactly one
     // path. If this ever fails, the blast radius of the change is no longer what was
     // reviewed.

--- a/src/server/middleware/route-guards.middleware.ts
+++ b/src/server/middleware/route-guards.middleware.ts
@@ -2,7 +2,11 @@ import type { NextRequest } from 'next/server';
 import { createMiddleware } from '~/server/middleware/middleware-utils';
 import { pathToRegexp } from 'path-to-regexp';
 import { isProd } from '~/env/other';
-import { canAccessTestingRoute } from '~/server/middleware/testing-route-access';
+import {
+  canAccessTestingRoute,
+  isNonProdReachableTestingPath,
+  resolveRequestHost,
+} from '~/server/middleware/testing-route-access';
 
 // The session-based PAGE guards (/moderator, /testing) moved to _app getInitialProps — the edge runtime can't
 // resolve the thin hub civ-token to a full user. What's left here is the sessionless /api/testing gate (those
@@ -13,12 +17,27 @@ const routeGuards: RouteGuard[] = [];
 // guard can only ever be additive in the deny direction.
 addRouteGuard({
   matcher: ['/api/testing/:path*'],
-  canAccess: ({ request }) =>
-    canAccessTestingRoute({
-      pathname: request.nextUrl.pathname,
-      hostname: request.nextUrl.hostname,
-      isProduction: isProd,
-    }),
+  canAccess: ({ request }) => {
+    const pathname = request.nextUrl.pathname;
+    const hostname = resolveRequestHost(request);
+    const allowed = canAccessTestingRoute({ pathname, hostname, isProduction: isProd });
+
+    // Only fires when a route that is SUPPOSED to be reachable on a non-production
+    // host is refused — i.e. the exact state where the gate looks broken. Everything
+    // needed to tell which term was false is here, because working that out from
+    // outside cost two people an afternoon: a relative `location:` header made curl
+    // resolve the redirect against the request URL, which looked like evidence about
+    // the app's own view of the host and was not.
+    if (!allowed && isNonProdReachableTestingPath(pathname)) {
+      console.warn(
+        `[route-guards] refused ${pathname} — resolvedHost=${hostname} ` +
+          `nextUrlHostname=${request.nextUrl.hostname} ` +
+          `host=${request.headers.get('host') ?? '(none)'} ` +
+          `xForwardedHost=${request.headers.get('x-forwarded-host') ?? '(none)'}`
+      );
+    }
+    return allowed;
+  },
 });
 //#region Logic
 

--- a/src/server/middleware/route-guards.middleware.ts
+++ b/src/server/middleware/route-guards.middleware.ts
@@ -2,14 +2,23 @@ import type { NextRequest } from 'next/server';
 import { createMiddleware } from '~/server/middleware/middleware-utils';
 import { pathToRegexp } from 'path-to-regexp';
 import { isProd } from '~/env/other';
+import { canAccessTestingRoute } from '~/server/middleware/testing-route-access';
 
 // The session-based PAGE guards (/moderator, /testing) moved to _app getInitialProps — the edge runtime can't
 // resolve the thin hub civ-token to a full user. What's left here is the sessionless /api/testing gate (those
 // debug endpoints are non-prod only), so no getToken is needed.
 const routeGuards: RouteGuard[] = [];
+// Modifying this guard rather than adding a permissive one is forced: the middleware
+// below evaluates EVERY matching guard and redirects if ANY of them denies, so a new
+// guard can only ever be additive in the deny direction.
 addRouteGuard({
   matcher: ['/api/testing/:path*'],
-  canAccess: () => !isProd,
+  canAccess: ({ request }) =>
+    canAccessTestingRoute({
+      pathname: request.nextUrl.pathname,
+      hostname: request.nextUrl.hostname,
+      isProduction: isProd,
+    }),
 });
 //#region Logic
 

--- a/src/server/middleware/testing-route-access.ts
+++ b/src/server/middleware/testing-route-access.ts
@@ -29,6 +29,29 @@ const NON_PROD_HOST_SUFFIX = '.civitaic.com';
 // non-production host by anyone holding the WEBHOOK_TOKEN.
 const NON_PROD_REACHABLE_TESTING_PATHS = new Set(['/api/testing/eventloop-stall']);
 
+/**
+ * The host the request actually arrived at.
+ *
+ * `nextUrl.hostname` is derived from the request as the runtime sees it, and behind a
+ * CDN and an ingress proxy there is no guarantee it carries the public host. The
+ * forwarded headers are what is on the wire, so prefer them and keep `nextUrl` only as
+ * a fallback. Normalised because each source can carry a port, a comma-separated
+ * chain, or mixed case, and the suffix test is exact.
+ *
+ * This does not change the trust story: `x-forwarded-host` is no more attacker-
+ * controlled than `Host` was, and neither is a boundary — see the header note above.
+ */
+export function resolveRequestHost(request: {
+  headers: { get: (name: string) => string | null };
+  nextUrl: { hostname: string };
+}): string {
+  const raw =
+    request.headers.get('x-forwarded-host') ??
+    request.headers.get('host') ??
+    request.nextUrl.hostname;
+  return (raw ?? '').split(',')[0].trim().split(':')[0].toLowerCase();
+}
+
 export function canAccessTestingRoute({
   pathname,
   hostname,
@@ -40,4 +63,15 @@ export function canAccessTestingRoute({
 }): boolean {
   if (!isProduction) return true;
   return NON_PROD_REACHABLE_TESTING_PATHS.has(pathname) && hostname.endsWith(NON_PROD_HOST_SUFFIX);
+}
+
+/**
+ * True when a path is one this module is willing to open on a non-production host.
+ * Exported so the guard can tell "denied a route that is meant to be reachable here"
+ * apart from "denied a route that is never reachable in production", and log only the
+ * former. Without that distinction the diagnostic would fire on every ordinary
+ * production probe of /api/testing/*.
+ */
+export function isNonProdReachableTestingPath(pathname: string): boolean {
+  return NON_PROD_REACHABLE_TESTING_PATHS.has(pathname);
 }

--- a/src/server/middleware/testing-route-access.ts
+++ b/src/server/middleware/testing-route-access.ts
@@ -14,19 +14,20 @@
 // cleanly, and change nothing, while presenting as "the fix didn't work" rather than
 // "the fix isn't there". `request.nextUrl.hostname` is genuinely runtime.
 //
-// 🔴 THIS IS NOT AN AUTHENTICATION BOUNDARY. The hostname comes from the Host header,
-// which the client controls, so anything able to reach a pod directly can satisfy it.
-// What keeps the stall endpoint out of production is that
-// EVENTLOOP_WATCHDOG_STALL_ENDPOINT is unset there, so the route module never
-// constructs a handler and a spoofed Host reaches a bare 404. This check is
-// convenience and defence in depth; do not add a route here on the strength of it
-// alone.
+// 🔴 THIS IS A ROUTING CHECK, NOT AN AUTHENTICATION BOUNDARY. It is defence in depth.
+// What keeps the stall endpoint out of production is EVENTLOOP_WATCHDOG_STALL_ENDPOINT
+// being unset there: the route module then constructs no handler at all, so the path
+// is a bare 404 regardless of how a request reached the pod. Never add a route to the
+// set below on the strength of the hostname check alone.
 
-const PREVIEW_HOST_SUFFIX = '.civitaic.com';
+// The whole non-production family domain, not just ephemeral PR previews — several
+// long-lived non-prod services share it. Narrowness therefore comes from the path set
+// below, not from this suffix.
+const NON_PROD_HOST_SUFFIX = '.civitaic.com';
 
-// Exact paths, never prefixes. Each one must be independently safe to reach on a
-// preview host by anyone holding the WEBHOOK_TOKEN.
-const PREVIEW_REACHABLE_TESTING_PATHS = new Set(['/api/testing/eventloop-stall']);
+// Exact paths, never prefixes. Each one must be independently safe to reach on any
+// non-production host by anyone holding the WEBHOOK_TOKEN.
+const NON_PROD_REACHABLE_TESTING_PATHS = new Set(['/api/testing/eventloop-stall']);
 
 export function canAccessTestingRoute({
   pathname,
@@ -38,5 +39,5 @@ export function canAccessTestingRoute({
   isProduction: boolean;
 }): boolean {
   if (!isProduction) return true;
-  return PREVIEW_REACHABLE_TESTING_PATHS.has(pathname) && hostname.endsWith(PREVIEW_HOST_SUFFIX);
+  return NON_PROD_REACHABLE_TESTING_PATHS.has(pathname) && hostname.endsWith(NON_PROD_HOST_SUFFIX);
 }

--- a/src/server/middleware/testing-route-access.ts
+++ b/src/server/middleware/testing-route-access.ts
@@ -1,0 +1,42 @@
+// Which `/api/testing/*` routes are reachable, given where the request landed.
+//
+// The debug endpoints are non-prod only, and `NODE_ENV=production` is baked into the
+// image every environment deploys — preview included — so in practice they are
+// local-dev only. That is fine for the endpoints that poke at data, and fatal for the
+// synthetic event-loop stall: a preview environment will not wedge on its own, so
+// without a way to trigger one there, the watchdog cannot be validated anywhere
+// except the place it is least needed.
+//
+// WHY THE HOSTNAME AND NOT `IS_PREVIEW`: the preview pipeline injects IS_PREVIEW by
+// rewriting the ConfigMap at DEPLOY time, and it is not a build ARG. Next inlines
+// `process.env.*` into the edge middleware bundle at BUILD time, so an exemption
+// written as `isPreview` compiles to `false` — it would pass review, pass CI, deploy
+// cleanly, and change nothing, while presenting as "the fix didn't work" rather than
+// "the fix isn't there". `request.nextUrl.hostname` is genuinely runtime.
+//
+// 🔴 THIS IS NOT AN AUTHENTICATION BOUNDARY. The hostname comes from the Host header,
+// which the client controls, so anything able to reach a pod directly can satisfy it.
+// What keeps the stall endpoint out of production is that
+// EVENTLOOP_WATCHDOG_STALL_ENDPOINT is unset there, so the route module never
+// constructs a handler and a spoofed Host reaches a bare 404. This check is
+// convenience and defence in depth; do not add a route here on the strength of it
+// alone.
+
+const PREVIEW_HOST_SUFFIX = '.civitaic.com';
+
+// Exact paths, never prefixes. Each one must be independently safe to reach on a
+// preview host by anyone holding the WEBHOOK_TOKEN.
+const PREVIEW_REACHABLE_TESTING_PATHS = new Set(['/api/testing/eventloop-stall']);
+
+export function canAccessTestingRoute({
+  pathname,
+  hostname,
+  isProduction,
+}: {
+  pathname: string;
+  hostname: string;
+  isProduction: boolean;
+}): boolean {
+  if (!isProduction) return true;
+  return PREVIEW_REACHABLE_TESTING_PATHS.has(pathname) && hostname.endsWith(PREVIEW_HOST_SUFFIX);
+}


### PR DESCRIPTION
## Why

Every existing way we watch the event loop runs **on** the event loop, so all of them are blind in exactly the state they exist to detect:

- the `loopstall-*` self-trigger in `cpu-profiler.ts` reads its lag histogram from a `setInterval` that cannot fire while the loop is pinned;
- `/api/metrics` is served by the same pinned loop, so a wedged pod reports nothing at all;
- `nodejs_eventloop_lag_max_seconds` read **7.46 s max over six hours** while real wedges ran **4–5 minutes**.

This puts the observer somewhere the wedge cannot reach it. The main thread stores a millisecond timestamp into a `SharedArrayBuffer`; a worker thread with its own event loop reads that timestamp and serves its own metrics port. A wedged main thread stops updating the timestamp, and the worker — still scheduling normally — reports the staleness.

This is **v1: detection, off-loop metrics, and a gated synthetic trigger.** No probe changes and no CPU capture; those are v2/v3, staged deliberately so the risky parts land separately.

## What's here

- `src/server/eventloop-watchdog.ts` — SAB heartbeat, worker spawn, config resolution, boot gauge.
- `src/server/liveness-heartbeat.ts` — folded in. One timer now feeds two consumers at their own resolutions: the SAB in **milliseconds** for the worker, the `/tmp/heartbeat` file in **epoch-seconds** for the existing exec probe, still on its own 2 s cadence. The probe's contract is unchanged.
- `src/pages/api/testing/eventloop-stall.ts` — synthetic stall, so this can be validated in preview (a preview environment will not wedge on its own).
- `src/instrumentation.node.ts` — registration.
- Three test suites.

**DISARMED by default.** Nothing is installed unless `EVENTLOOP_WATCHDOG_ENABLED=true` — same discipline as `pyroscope.ts`, `cpu-profiler.ts`, and `eventloop-longtask.ts`.

## Metrics

Served by the worker on `:9099` (`WATCHDOG_METRICS_PORT`), `?token=`/`WEBHOOK_TOKEN` as `/api/metrics` already does. **Not on any Service** — scrape config only, and that is the whole containment story.

| metric | type | note |
|---|---|---|
| `civitai_app_watchdog_up` | gauge | always 1 while serving; **absence** is the signal |
| `civitai_app_watchdog_heartbeat_age_ms` | gauge | |
| `civitai_app_watchdog_wedged` | gauge | 0/1 |
| `civitai_app_watchdog_current_wedge_seconds` | gauge | **primary alert** — see below |
| `civitai_app_watchdog_wedge_total` | counter | |
| `civitai_app_watchdog_wedge_duration_seconds` | histogram | observed on recovery only |
| `civitai_app_watchdog_wedge_longest_seconds` | gauge | |
| `civitai_app_watchdog_started_timestamp_seconds` | gauge | |
| `civitai_app_watchdog_threshold_ms` | gauge | config echo |
| `civitai_app_watchdog_heartbeat_interval_ms` | gauge | config echo, **effective** value |

Plus `civitai_app_watchdog_worker_started` on the existing `/api/metrics`, set by the **main thread**.

## Four design decisions worth reviewing

**1. `current_wedge_seconds` exists because the histogram is blind to the wedges that matter.** A duration histogram only observes on *recovery*, so a pod killed mid-wedge never reports one — precisely the case we most need. The gauge moves during a live wedge.

**2. The metric pair distinguishes four states that absence alone cannot.**

```
                          watchdog_up (:9099)   worker_started (/api/metrics)
healthy                            1                      1
MAIN THREAD WEDGED                 1              ABSENT (past the scrape timeout)
worker died after starting     ABSENT                     1
worker never spawned (threw)   ABSENT                     0
pod gone                       ABSENT                  ABSENT
```

Row 2 is **scrape-timeout-bound, not instant** — measured in preview, not assumed. A wedged main thread does not refuse the `/api/metrics` request, it *queues* it and answers on recovery (the reply landed 30 ms after the wedge cleared). So `worker_started` only blanks once a wedge outlasts the scrape timeout, for roughly `max(0, D - timeout) / interval` of scrapes; a short wedge never blanks it. Row 2 is a disambiguator for the long wedges this exists to catch — the real ones ran 4–5 minutes — not the detection signal. Detection is `current_wedge_seconds` off the worker's own port, which moves within one poll regardless.

`worker_started` going absent during a wedge is the design working — the main thread that serves it is the thing that's stuck. Nothing should alert on that. The gauge is registered **inside the arm path**, so a disarmed pod reports the series as absent rather than `0`; otherwise an un-enabled pool is indistinguishable from a real arm failure and false-pages.

**3. No per-tick hook.** A wedge *is* "no timer fired in N ms", so a per-tick hook detects nothing a timer does not, and the only way to hook every tick is `async_hooks` — the exact per-resource cost `instrumentation.node.ts` removed from OTEL. Measured: `Atomics.store` is 7.8–9.0 ns, but `BigInt(Date.now())` makes the pair 96.5 ns, so the timestamp would be the per-tick cost, not the store. At a 100 ms beat the whole mechanism is ~1 µs/s — four orders of magnitude under the ~1.6–1.7% budget.

**4. `threshold >= 3 * beat` is clamped by lowering the BEAT.** Raising the threshold instead would silently change what the pod claims to detect. The threshold is the operator's stated intent; the beat is an implementation detail. `threshold/3` never approaches the 20 ms beat floor anywhere in the legal range (250 → 83 ms), so the clamp always has room. The echo reports the **effective** beat — an echo that reports a requested value while the code runs another is a lying metric, which is worse than a missing one because it survives inspection.

## The worker source is an inline string, on purpose

`next.config.mjs` uses `output: 'standalone'`, which traces with `@vercel/nft`. The config already carries three `outputFileTracingIncludes` workarounds for files nft could not follow — one of them recording that `/api/og` broke this way and became the dominant 500 source. `new Worker(new URL('./file.js', import.meta.url))` from the Turbopack instrumentation graph is the same failure class, and the failure is the silent kind: the spawn throws, the arm-time catch swallows it, and an absent watchdog reads exactly like a healthy pod. `eval: true` has no tracing surface at all.

The tradeoff is that the source is not type-checked or linted, so **`eventloop-watchdog.worker.test.ts` spawns the real string as a real worker and drives it over real HTTP.** A syntax error, a wrong metric name, or a broken wedge transition fails there and nowhere else. This is also the one failure mode that cannot be caught by reasoning about the diff.

## R7: making it validatable in preview (this is a shared-guard change — please read)

The constraint was "it must be testable without a natural wedge". It wasn't. `/api/testing/*` is guarded by `!isProd`, and `NODE_ENV=production` is baked into the image **every** environment deploys, so the redirect fired in middleware before either of the endpoint's own gates. The synthetic trigger worked in local dev only — where a wedge is least interesting and the watchdog least needs proving. Caught in review, not by me.

Two things forced the shape of the fix:

- **A new permissive guard cannot work.** `routeGuardsMiddleware` evaluates *every* matching guard and redirects if *any* denies, so guards are additive only in the deny direction. The broad `/api/testing/:path*` rule had to be modified.
- **`IS_PREVIEW` cannot carry it.** The preview pipeline injects it by rewriting the ConfigMap at *deploy* time and it is not a build `ARG`, while Next inlines `process.env.*` into the edge bundle at *build* time. So `canAccess: () => !isProd || isPreview` compiles to `!isProd || false` — it would pass review, pass CI, deploy cleanly and change nothing, presenting as "the fix didn't work" rather than "the fix isn't there".

So the gate is the request hostname, which is genuinely runtime.

**Resolved from the forwarded headers, not `nextUrl`.** The first attempt read `request.nextUrl.hostname` and still 307'd in preview. `nextUrl` is derived from the request as the runtime sees it, and behind a CDN and an ingress proxy nothing guarantees it carries the public host — the forwarded headers are what is actually on the wire, and they are what the predicate's contract means by "which host did this arrive at". `resolveRequestHost()` prefers `x-forwarded-host`, then `host`, then `nextUrl.hostname`, normalising port, case, and a comma-separated chain because the suffix test is exact. A test asserts that normalisation can never manufacture a match.

Refusing a path that is *supposed* to be reachable on a non-production host also logs the resolved host alongside all three candidate sources, scoped so it cannot fire on ordinary production probes. Working this out from outside cost two people an afternoon — a relative `location:` header made `curl` resolve the redirect against the request URL, which read as evidence about the app's own view of the host and was not.

🔴 **It is not an authentication boundary, and the code says so.** The Host header is client-controlled, so anything able to reach a pod directly can satisfy it. What keeps the stall endpoint out of production is the module-level env gate: `EVENTLOOP_WATCHDOG_STALL_ENDPOINT` is unset there, so no handler is constructed and a spoofed Host reaches a bare 404. The hostname check is convenience and defence in depth.

The predicate is a pure exported function, so these are assertions rather than a comment claiming they hold: the production hostname is refused; `evil-civitaic.com` and the bare apex `civitaic.com` are refused (the suffix is anchored on the dot — `civitaic.com` and `civitai.com` differ by one character); a non-prod host used as a *prefix* of someone else's domain is refused; and **no other `/api/testing` route is widened**, which is the whole argument for touching a shared guard and is therefore pinned by a test.

Note the suffix is the whole **non-production family** domain, not just ephemeral PR previews — several long-lived non-prod services share it. Narrowness comes from the exact-path set, not from the suffix, and the code says so.

### ⚠️ R7 is closed in code; demonstrating it needs one deploy-time step

`EVENTLOOP_WATCHDOG_STALL_ENDPOINT=true` appears **nowhere in this repo** — no yaml, no Dockerfile, no `.env`. That is correct for production safety, and it means the synthetic trigger stays inert until someone sets it in the preview environment's config. Applying the preview label without that step will produce a 404 from the endpoint, which is the gate working, not the gate broken.

Worth knowing: that variable is read in an API route on the Node runtime, so it is not subject to the build-time inlining problem — and if it ever were, it would resolve `undefined` and fail **closed**.

## The synthetic stall endpoint

An authenticated endpoint whose function is to deliberately hard-lock an application server, so it is gated twice:

- the host must be a preview host (above) — convenience, not a boundary;
- the module only builds a real handler when `EVENTLOOP_WATCHDOG_STALL_ENDPOINT === 'true'` — otherwise the route is a bare 404 with **no auth path and no reachable stall code**. `WebhookEndpoint` is never even called, and a test asserts that;
- when enabled it still requires `WEBHOOK_TOKEN`;
- duration is clamped server-side to 10 s, **and a 30 s cooldown is enforced between stalls** (429 with `retryAfterMs`). The per-request clamp bounded one stall and said nothing about a caller looping the endpoint; a primitive bounded per-request and unbounded in aggregate is not bounded.

Tested by requesting a 5 s stall against the disabled endpoint and asserting it returns in under a second — *hidden* is not *unreachable*, and only the timing distinguishes them.

## Known limitations

- **A dead worker is never respawned.** One crash silently ends off-loop observability for that pod's lifetime. It is detectable — `worker_started=1` with `watchdog_up` absent is exactly that state — but nobody will be watching for it unless it is written down, so: it is written down. Respawn-with-backoff is a reasonable follow-up.
- **The watchdog cannot see a state the whole node gets into.** It shares memory with the main thread (which a wedge does not take) and the node's CPU and scheduler with everything else on the box (which a wedge does not take, but a full node does). `absent(watchdog_up)` on many pods at once, arriving together rather than trickling, means look at node capacity — a real watchdog outage is per-pod and uncorrelated.
- **The inline worker source is not free.** It avoids the `@vercel/nft` silent-absence failure, which is the right trade, but the source is neither type-checked nor linted — and a backtick in a *comment* inside it terminates the `String.raw` template. That happened during this PR: prettier reformatted the wreckage and every spawn died with `ReferenceError`. There is now an assertion that the source contains no backtick and no `${`. Anyone reaching for this pattern elsewhere should know that cost up front.

## The pattern this is really about

Four instruments in one week could not see the state they existed to catch:

- the `loopstall-*` capture reads its lag histogram from a `setInterval` that cannot fire while the loop is pinned;
- the scraped lag metric is served by the pinned loop;
- pprof's flush runs on the pinned thread, so wedge samples are lost rather than merely diluted;
- several drift guards have been red long enough to have stopped guarding anything.

Each is fine in isolation and blind in the state that matters. The tell is always the same: you cannot name a state where the detector fails that isn't the state it is for. That question — *what state stops this from working, and is it the state I am trying to catch?* — is the argument for the whole project, and it is worth asking of this PR too. The honest answer here is the node-exhaustion case above.

## Known limit

The worker shares **memory** with the main thread (which a wedge cannot take) and the **node's CPU and scheduler** with everything on the box (which a wedge cannot take, but a full node can).

> The watchdog can see any state the main thread gets into. It cannot see a state the whole node gets into. `absent(up)` on many pods at once, arriving together rather than trickling, means look at node capacity — a real watchdog outage is per-pod and uncorrelated.

## Why not Pyroscope

`src/server/pyroscope.ts` already runs a separate-thread sampler, so the obvious question is whether it already captures this. It was checked against production, and it does not:

- a 4-minute window containing **six** wedges showed the wedging frame at **0.0199% of active-JS**, where faithful representation would be tens of percent — three orders of magnitude light;
- the frame **disappears entirely** when the window is widened, which dilution cannot do. The samples are lost, not averaged down: the flush runs on the main thread, so a wedged pod cannot push and a killed pod never pushes;
- there is **no `pod` label** (`pod`/`hostname`/`instance` all return `numTicks=0`), so per-pod isolation is impossible regardless.

## Validated in preview

Run on `pr-3752-cbd14c3`, with the three env vars set in the ephemeral environment:

- **6 s spin** (the non-allocating case): `wedged=1`, `current_wedge_seconds` 2.693 → 5.635, `heartbeat_age_ms` tracking it exactly (2693 / 5635), back to `0` / `18 ms` on recovery. `wedge_total` +1 per stall, nothing spurious.
- **12 s spin**: detected at `current_wedge_seconds=1.077` against `threshold_ms=1000`. Config echoes correct.
- 21 series served on `:9099`, `watchdog_up 1`.

**It also caught one nobody triggered.** A fresh pod already reported `wedge_total 1` / `wedge_longest_seconds 14.651` before any test was run — a 14.65 s cold-compile startup stall. That is the first event-loop wedge in this codebase that any instrument has recorded on its own, which is the entire point of the project.

Note the endpoint returning 404 before those vars were set was the module-level gate working, not a failure.

## Verification

- `pnpm typecheck` — **0 errors**
- `pnpm exec eslint` on all touched files — clean
- `pnpm exec prettier` — clean
- **26 tests** across the three new suites, including a real worker spawned from the inline source and driven over real HTTP
- full unit suite — **16 failed / 13627 passed / 885 files**. All 16 are pre-existing: the identical set reproduces with this branch's changes stashed on the same base. They are the `blocks` spend-tier and route-drift scans, the `comics` wait-unit ledger, `no-wholesale-module-mock`, and the typecheck-wrapper suite.
- `blocks.router.workflow.test.ts` collected **347 tests**, confirming the worktree's submodule is initialised and the run is not a silent collection void.

One unrelated intermittent seen once and not reproduced: `oauth-scope-audit.test.ts > records one external-oauth row…` failed in a single full-suite run, passed in isolation, and did not recur. Untouched by this branch — flagging rather than chasing.

### A bug this found in its own test subject

The first full-suite run failed `stalls for AT LEAST the requested duration`, which passed in isolation. It was not flakiness. Spin mode counted iterations with the same `|0` accumulator it used for the CPU burn, and `|0` is signed 32-bit:

```
pass 1   704982704      pass 4  -1475036480
pass 2  1409965408      pass 5   -770053776
pass 3  2114948112      pass 6    -65071072
```

It cycles in and out of negative every ~4 batches, so whether the count came out positive depended on where the clock happened to cut the loop — and the endpoint could return a **negative iteration count** to its caller. The burn accumulator is now separate from a plain monotonic counter.

## Follow-ups (not in this PR)

- **v2** — cross-thread `connectToMainThread()` CPU capture + upload. Measured on Node 24: `Profiler.stop` returns in **4 ms** against a 22.8 s pure non-allocating spin, versus 0.8–11.6 s for the current in-process path.
- **v3** — SSR exec liveness probe. No app change; SSR pods already write `/tmp/heartbeat`.
- The watchdog deliberately does **not** drive readiness. Wedges are traffic-driven and therefore correlated, and readiness has no floor, so a wave that wedges the pool would remove every endpoint and turn a latency incident into an outage.
- The existing `loopstall-*` capture should be retired once v2 lands, rather than left racing this.
