### PR TITLE
fix(auth): bound the tracked-token hash and stop losing revocations

### DIFF
--- a/apps/auth/src/lib/server/auth/registry.ts
+++ b/apps/auth/src/lib/server/auth/registry.ts
@@ -5,6 +5,7 @@ import {
 } from '@civitai/auth';
 import { REDIS_KEYS, REDIS_SYS_KEYS } from '@civitai/redis';
 import { getSysRedis } from '../redis';
+import { logToAxiom } from '../axiom';
 
 // Cross-app session revocation. The redis CLIENT is built from @civitai/redis; the KEY STRINGS
 // come from @civitai/redis's registry — so a logout/ban here is seen by every app on the same
@@ -39,6 +40,17 @@ function registry(): SessionRegistry {
       tokenState: REDIS_SYS_KEYS.SESSION.TOKEN_STATE,
       all: REDIS_SYS_KEYS.SESSION.ALL,
       userTokens: REDIS_KEYS.SESSION.USER_TOKENS,
+    },
+    // An eviction means an account crossed the per-user session ceiling — the signal that used to exist
+    // only as an api-primary event-loop wedge. Log it so the ceiling is observable without one.
+    onEvict: ({ userId, evicted, total }) => {
+      logToAxiom({
+        name: 'session-token-ceiling-evict',
+        type: 'info',
+        userId,
+        evicted,
+        total,
+      }).catch(() => undefined);
     },
   }));
 }

--- a/apps/auth/src/lib/server/auth/registry.ts
+++ b/apps/auth/src/lib/server/auth/registry.ts
@@ -4,6 +4,7 @@ import {
   type SessionRegistryRedis,
 } from '@civitai/auth';
 import { REDIS_KEYS, REDIS_SYS_KEYS } from '@civitai/redis';
+import { env } from '$env/dynamic/private';
 import { getSysRedis } from '../redis';
 import { logToAxiom } from '../axiom';
 
@@ -41,6 +42,10 @@ function registry(): SessionRegistry {
       all: REDIS_SYS_KEYS.SESSION.ALL,
       userTokens: REDIS_KEYS.SESSION.USER_TOKENS,
     },
+    // Pass the deployment's real rolling-refresh interval so the registry can hold its eviction floor above
+    // it. Without this it falls back to the documented default, and a deployment that lengthened the interval
+    // would silently make live sessions evictable.
+    refreshIntervalSeconds: Number(env.AUTH_SESSION_UPDATE_AGE) || undefined,
     // An eviction means an account crossed the per-user session ceiling — the signal that used to exist
     // only as an api-primary event-loop wedge. Log it so the ceiling is observable without one.
     onEvict: ({ userId, evicted, total }) => {

--- a/packages/civitai-auth/src/__tests__/session-registry.test.ts
+++ b/packages/civitai-auth/src/__tests__/session-registry.test.ts
@@ -214,6 +214,106 @@ describe('createSessionRegistry', () => {
       expect(await reg.isRevoked({ jti: 'stale', signedAt: 1 })).toBe(true);
     });
 
+    // 🔴 The regression this guards. The stored value is a last-WRITE time, and a live session only rewrites
+    // it when the spoke's rolling refresh fires (AUTH_SESSION_UPDATE_AGE, 24h default). An account minting
+    // rapidly writes fresher values continuously, so ordering ALONE sorts the real session below hundreds of
+    // minted-and-abandoned tokens and evicts — and revokes — the user. Reported by charlie on #3754.
+    describe('age floor', () => {
+      const HOUR = 3600_000;
+
+      it('does NOT evict a session refreshed 14h ago, even when it is the oldest in the page', async () => {
+        const redis = makeRedis();
+        const clock = 1_000_000_000_000;
+        const reg = createSessionRegistry({
+          redis,
+          keys: KEYS,
+          maxTokensPerUser: 5,
+          now: () => clock,
+        });
+        // The shape of a still-minting account: one real session refreshed 14h ago, junk minted in the last
+        // hour. Under pure ordering the real session sorts first and dies.
+        await redis.hSet('session:user-tokens2:7', 'real-session', clock - 14 * HOUR);
+        for (let i = 0; i < 5; i++)
+          await redis.hSet(`session:user-tokens2:7`, `junk-${i}`, clock - i * 60_000);
+
+        await reg.trackToken('new', 7);
+
+        expect(redis._hashes.get('session:user-tokens2:7')?.has('real-session')).toBe(true);
+        expect(await reg.isRevoked({ jti: 'real-session', signedAt: 1 })).toBe(false);
+      });
+
+      it('evicts nothing at all when the whole page is inside the floor, rather than picking a victim', async () => {
+        const redis = makeRedis();
+        const clock = 1_000_000_000_000;
+        const onEvict = vi.fn();
+        const reg = createSessionRegistry({
+          redis,
+          keys: KEYS,
+          maxTokensPerUser: 3,
+          now: () => clock,
+          onEvict,
+        });
+        for (let i = 0; i < 6; i++)
+          await redis.hSet(`session:user-tokens2:7`, `recent-${i}`, clock - i * HOUR);
+
+        await reg.trackToken('new', 7);
+
+        expect(redis._hashes.get('session:user-tokens2:7')?.size).toBe(7); // over the ceiling, deliberately
+        expect(onEvict).toHaveBeenCalledWith({ userId: 7, evicted: 0, total: 6 });
+      });
+
+      it('still evicts entries past the floor, so an oversized hash does drain', async () => {
+        const redis = makeRedis();
+        const clock = 1_000_000_000_000;
+        const reg = createSessionRegistry({
+          redis,
+          keys: KEYS,
+          maxTokensPerUser: 3,
+          now: () => clock,
+        });
+        // 4 entries against a ceiling of 3 means 2 evictions. Three are past the floor, so the ordering has
+        // to choose: the two oldest go and the third stays.
+        await redis.hSet('session:user-tokens2:7', 'ancient', clock - 20 * 24 * HOUR);
+        await redis.hSet('session:user-tokens2:7', 'mid', clock - 10 * 24 * HOUR);
+        await redis.hSet('session:user-tokens2:7', 'old', clock - 5 * 24 * HOUR);
+        await redis.hSet('session:user-tokens2:7', 'fresh', clock - HOUR);
+
+        await reg.trackToken('new', 7);
+
+        const hash = redis._hashes.get('session:user-tokens2:7')!;
+        expect(hash.has('ancient')).toBe(false); // oldest past the floor
+        expect(hash.has('mid')).toBe(false); // second-oldest
+        expect(hash.has('old')).toBe(true); // past the floor but not needed
+        expect(hash.has('fresh')).toBe(true); // inside the floor, never a candidate
+        expect(await reg.isRevoked({ jti: 'ancient', signedAt: 1 })).toBe(true);
+      });
+
+      // charlie also noted the committed page-local test used a 3-entry hash a single page covers, so it never
+      // exercised a global-oldest sitting OUTSIDE the page. This does.
+      it('is safe when the global oldest is outside the scanned page', async () => {
+        const redis = makeRedis();
+        const clock = 1_000_000_000_000;
+        const reg = createSessionRegistry({
+          redis,
+          keys: KEYS,
+          maxTokensPerUser: 2,
+          now: () => clock,
+        });
+        // Page holds the first 2 by insertion order; the globally-oldest entry is inserted last, so it is
+        // NOT in the page. Eviction must still only take something past the floor.
+        await redis.hSet('session:user-tokens2:7', 'in-page-stale', clock - 10 * 24 * HOUR);
+        await redis.hSet('session:user-tokens2:7', 'in-page-live', clock - HOUR);
+        await redis.hSet('session:user-tokens2:7', 'out-of-page-oldest', clock - 25 * 24 * HOUR);
+
+        await reg.trackToken('new', 7);
+
+        const hash = redis._hashes.get('session:user-tokens2:7')!;
+        expect(hash.has('in-page-stale')).toBe(false); // the page-local candidate past the floor
+        expect(hash.has('in-page-live')).toBe(true); // never a candidate
+        expect(hash.has('out-of-page-oldest')).toBe(true); // not read, so not evicted — and that is fine
+      });
+    });
+
     it('never evicts when the redis surface lacks hLen', async () => {
       const redis = makeRedis();
       delete (redis as { hLen?: unknown }).hLen;

--- a/packages/civitai-auth/src/__tests__/session-registry.test.ts
+++ b/packages/civitai-auth/src/__tests__/session-registry.test.ts
@@ -33,6 +33,14 @@ function makeRedis() {
     async hLen(key) {
       return hashes.get(key)?.size ?? 0;
     },
+    // Models the real client closely enough for the ceiling: COUNT bounds the page, and insertion order
+    // stands in for redis's bucket order — neither is guaranteed to be value-ordered, which is the property
+    // the eviction logic must not depend on.
+    async hScan(key, _cursor, options) {
+      const all = [...(hashes.get(key) ?? [])].map(([field, value]) => ({ field, value }));
+      const page = all.slice(0, options?.COUNT ?? all.length);
+      return { cursor: page.length < all.length ? 1 : 0, tuples: page };
+    },
     async get(key) {
       return strings.get(key) ?? null;
     },
@@ -175,6 +183,35 @@ describe('createSessionRegistry', () => {
 
       expect(redis._hashes.get('session:user-tokens2:7')?.size).toBe(99); // 100 - 2 evicted + 1 new
       expect(onEvict).toHaveBeenCalledWith({ userId: 7, evicted: 2, total: 100 });
+    });
+
+    // The read is on the login hot path against a single-threaded shared store. Reading the whole hash would
+    // cost ~54ms server-side on the largest real account (53,877 fields at ~1 µs/field) and repeat on every
+    // login until it drained. The page must stay bounded by the ceiling regardless of hash size.
+    it('reads only a BOUNDED PAGE, never the whole hash', async () => {
+      const redis = makeRedis();
+      const scan = vi.spyOn(redis, 'hScan');
+      const reg = createSessionRegistry({ redis, keys: KEYS, maxTokensPerUser: 5 });
+      await seed(redis, 7, 5000);
+      await reg.trackToken('new', 7);
+
+      expect(scan).toHaveBeenCalledTimes(1);
+      expect(scan.mock.calls[0][2]).toMatchObject({ COUNT: 5 });
+    });
+
+    it('evicts the least-recently-touched within the page, not whatever the page yields first', async () => {
+      const redis = makeRedis();
+      const reg = createSessionRegistry({ redis, keys: KEYS, maxTokensPerUser: 3 });
+      // Insertion order deliberately disagrees with recency: the FIRST field scanned is the freshest.
+      await redis.hSet('session:user-tokens2:7', 'fresh', 9000);
+      await redis.hSet('session:user-tokens2:7', 'stale', 1000);
+      await redis.hSet('session:user-tokens2:7', 'mid', 5000);
+      await reg.trackToken('new', 7);
+
+      const hash = redis._hashes.get('session:user-tokens2:7')!;
+      expect(hash.has('stale')).toBe(false);
+      expect(hash.has('fresh')).toBe(true);
+      expect(await reg.isRevoked({ jti: 'stale', signedAt: 1 })).toBe(true);
     });
 
     it('never evicts when the redis surface lacks hLen', async () => {

--- a/packages/civitai-auth/src/__tests__/session-registry.test.ts
+++ b/packages/civitai-auth/src/__tests__/session-registry.test.ts
@@ -30,6 +30,9 @@ function makeRedis() {
       return Object.fromEntries(hashes.get(key) ?? []);
     },
     async hExpire() {},
+    async hLen(key) {
+      return hashes.get(key)?.size ?? 0;
+    },
     async get(key) {
       return strings.get(key) ?? null;
     },
@@ -61,6 +64,27 @@ describe('createSessionRegistry', () => {
     await reg.invalidateUserSessions(9);
     expect(await reg.isRevoked({ jti: 'a', signedAt: 1 })).toBe(true);
     expect(await reg.isRevoked({ jti: 'b', signedAt: 1 })).toBe(true);
+    // …and the tracking hash is emptied, matching what logout already did per-token. Left behind, a banned
+    // account keeps its full-size hash for the whole TTL and every later pass over it pays for tokens that
+    // are already revoked.
+    expect(redis._hashes.get('session:user-tokens2:9')?.size ?? 0).toBe(0);
+  });
+
+  it('never drops a tracking entry whose revocation marker failed to land', async () => {
+    const redis = makeRedis();
+    const realHSet = redis.hSet.bind(redis);
+    redis.hSet = async (key, field, value) => {
+      if (key === KEYS.tokenState && field === 'b') throw new Error('sysredis blip');
+      return realHSet(key, field, value);
+    };
+    const reg = createSessionRegistry({ redis, keys: KEYS });
+    await reg.trackToken('a', 11);
+    await reg.trackToken('b', 11);
+
+    await expect(reg.invalidateUserSessions(11)).rejects.toThrow('sysredis blip');
+    // 'b' was never marked invalid, so it MUST still be tracked — otherwise it is a validly signed token
+    // that no later ban can find.
+    expect(redis._hashes.get('session:user-tokens2:11')?.has('b')).toBe(true);
   });
 
   it('global invalidateAll revokes tokens signed before the cutoff', async () => {
@@ -93,6 +117,74 @@ describe('createSessionRegistry', () => {
   it('isRevoked is false for a token with no id', async () => {
     const reg = createSessionRegistry({ redis: makeRedis(), keys: KEYS });
     expect(await reg.isRevoked({})).toBe(false);
+  });
+
+  describe('per-user token ceiling', () => {
+    const seed = async (redis: ReturnType<typeof makeRedis>, userId: number, count: number) => {
+      for (let i = 0; i < count; i++)
+        await redis.hSet(`session:user-tokens2:${userId}`, `tok-${i}`, 1000 + i);
+    };
+
+    it('does not evict below the ceiling', async () => {
+      const redis = makeRedis();
+      const onEvict = vi.fn();
+      const reg = createSessionRegistry({ redis, keys: KEYS, maxTokensPerUser: 5, onEvict });
+      await seed(redis, 7, 3);
+      await reg.trackToken('new', 7);
+      expect(redis._hashes.get('session:user-tokens2:7')?.size).toBe(4);
+      expect(onEvict).not.toHaveBeenCalled();
+    });
+
+    it('evicts the OLDEST and keeps the hash at the ceiling', async () => {
+      const redis = makeRedis();
+      const reg = createSessionRegistry({ redis, keys: KEYS, maxTokensPerUser: 5 });
+      await seed(redis, 7, 5);
+      await reg.trackToken('new', 7);
+
+      const hash = redis._hashes.get('session:user-tokens2:7')!;
+      expect(hash.size).toBe(5);
+      expect(hash.has('tok-0')).toBe(false); // oldest value (1000) went
+      expect(hash.has('tok-4')).toBe(true);
+      expect(hash.has('new')).toBe(true);
+    });
+
+    // The whole point of evict-AND-revoke: an evicted jti is still a validly signed token, so dropping
+    // it from the tracking hash without marking it invalid would make it permanently unrevokable.
+    it('REVOKES what it evicts', async () => {
+      const redis = makeRedis();
+      const reg = createSessionRegistry({ redis, keys: KEYS, maxTokensPerUser: 5 });
+      await seed(redis, 7, 5);
+      await reg.trackToken('new', 7);
+
+      expect(await reg.isRevoked({ jti: 'tok-0', signedAt: 1 })).toBe(true);
+      expect(await reg.isRevoked({ jti: 'new', signedAt: 1 })).toBe(false);
+    });
+
+    it('caps evictions per call so a huge legacy hash drains gradually', async () => {
+      const redis = makeRedis();
+      const onEvict = vi.fn();
+      const reg = createSessionRegistry({
+        redis,
+        keys: KEYS,
+        maxTokensPerUser: 5,
+        maxEvictionsPerTrack: 2,
+        onEvict,
+      });
+      await seed(redis, 7, 100);
+      await reg.trackToken('new', 7);
+
+      expect(redis._hashes.get('session:user-tokens2:7')?.size).toBe(99); // 100 - 2 evicted + 1 new
+      expect(onEvict).toHaveBeenCalledWith({ userId: 7, evicted: 2, total: 100 });
+    });
+
+    it('never evicts when the redis surface lacks hLen', async () => {
+      const redis = makeRedis();
+      delete (redis as { hLen?: unknown }).hLen;
+      const reg = createSessionRegistry({ redis, keys: KEYS, maxTokensPerUser: 2 });
+      await seed(redis, 7, 5);
+      await reg.trackToken('new', 7);
+      expect(redis._hashes.get('session:user-tokens2:7')?.size).toBe(6);
+    });
   });
 
   it('uses the injected key namespaces', async () => {

--- a/packages/civitai-auth/src/__tests__/session-registry.test.ts
+++ b/packages/civitai-auth/src/__tests__/session-registry.test.ts
@@ -288,6 +288,31 @@ describe('createSessionRegistry', () => {
         expect(await reg.isRevoked({ jti: 'ancient', signedAt: 1 })).toBe(true);
       });
 
+      // The floor's whole guarantee is that it outlasts the spokes' rolling-refresh interval. That was a
+      // docstring requirement across an app boundary — AUTH_SESSION_UPDATE_AGE lives in the main app, the
+      // floor default lives here — so lengthening the interval would have silently made live sessions
+      // evictable again with no error and no failing test. It is now enforced.
+      it('raises the floor to outlast a longer refresh interval, ignoring a too-small configured floor', async () => {
+        const redis = makeRedis();
+        const clock = 1_000_000_000_000;
+        const reg = createSessionRegistry({
+          redis,
+          keys: KEYS,
+          maxTokensPerUser: 2,
+          now: () => clock,
+          minEvictionAgeSeconds: 60, // would make a 4-day-old live session evictable…
+          refreshIntervalSeconds: 7 * 24 * 3600, // …but the deployment refreshes only weekly
+        });
+        await redis.hSet('session:user-tokens2:7', 'refreshed-4d-ago', clock - 4 * 24 * HOUR);
+        await redis.hSet('session:user-tokens2:7', 'refreshed-6d-ago', clock - 6 * 24 * HOUR);
+
+        await reg.trackToken('new', 7);
+
+        expect(redis._hashes.get('session:user-tokens2:7')?.has('refreshed-4d-ago')).toBe(true);
+        expect(redis._hashes.get('session:user-tokens2:7')?.has('refreshed-6d-ago')).toBe(true);
+        expect(await reg.isRevoked({ jti: 'refreshed-6d-ago', signedAt: 1 })).toBe(false);
+      });
+
       // charlie also noted the committed page-local test used a 3-entry hash a single page covers, so it never
       // exercised a global-oldest sitting OUTSIDE the page. This does.
       it('is safe when the global oldest is outside the scanned page', async () => {

--- a/packages/civitai-auth/src/session-registry.ts
+++ b/packages/civitai-auth/src/session-registry.ts
@@ -52,6 +52,9 @@ export interface SessionRegistryConfig {
   maxTokensPerUser?: number;
   /** Cap on evictions in a single trackToken call, so draining a huge legacy hash can't burst (default 50). */
   maxEvictionsPerTrack?: number;
+  /** Entries touched more recently than this are never evicted (default 3d). Must exceed the spokes'
+   *  rolling-refresh interval, which is the coarsest granularity at which a live session is re-touched. */
+  minEvictionAgeSeconds?: number;
   /** Called when tokens are evicted for exceeding the ceiling — wire to a metric. */
   onEvict?: (info: { userId: number; evicted: number; total: number }) => void;
 }
@@ -72,11 +75,13 @@ export interface SessionRegistry {
 }
 
 const DEFAULT_TTL = 30 * 24 * 60 * 60;
-// 500 is ~87x the observed mean tracked-token count and above 99.9% of accounts, while leaving an 8x margin
-// under the ~4000 field count at which the multi-field token-state write exceeds Lua's unpack limit and
-// silently lands nothing (see src/server/redis/atomic.ts).
+// 500 is ~87x the observed mean tracked-token count and above 99.9% of accounts.
 const DEFAULT_MAX_TOKENS_PER_USER = 500;
 const DEFAULT_MAX_EVICTIONS_PER_TRACK = 50;
+// Nothing touched within this window is ever evicted — see evictOverCeiling. It must stay comfortably above
+// the spokes' rolling-refresh interval (AUTH_SESSION_UPDATE_AGE, default 24h), because that interval is the
+// coarsest granularity at which a live session updates its entry.
+const DEFAULT_MIN_EVICTION_AGE_SECONDS = 3 * 24 * 60 * 60;
 // Concurrency bound for the ban fan-out (individual commands, not a Lua batch).
 const INVALIDATE_BATCH = 100;
 
@@ -85,6 +90,7 @@ export function createSessionRegistry(config: SessionRegistryConfig): SessionReg
   const ttl = config.ttlSeconds ?? DEFAULT_TTL;
   const maxTokens = config.maxTokensPerUser ?? DEFAULT_MAX_TOKENS_PER_USER;
   const maxEvictions = config.maxEvictionsPerTrack ?? DEFAULT_MAX_EVICTIONS_PER_TRACK;
+  const minEvictionAge = config.minEvictionAgeSeconds ?? DEFAULT_MIN_EVICTION_AGE_SECONDS;
   const now = config.now ?? (() => Date.now());
   const { redis } = config;
   const userTokensKey = (userId: number) => `${keys.userTokens}:${userId}`;
@@ -108,20 +114,32 @@ export function createSessionRegistry(config: SessionRegistryConfig): SessionReg
    * of the same flaw — an evicted jti stays validly signed for the rest of `ttl` — so each eviction writes
    * `invalid` to the token-state hash that isRevoked consults. The evicted session dies rather than escaping.
    *
+   * 🔴 The safety property is the AGE FLOOR, not the ordering. Nothing whose entry was touched within
+   * `minEvictionAgeSeconds` is ever evicted, whatever the sort says.
+   *
+   * Sorting by the stored value alone is NOT sufficient and reasoning about it as LRU is wrong. The value is
+   * a last-WRITE time, and a live session only rewrites it when the spoke's rolling refresh fires — every
+   * AUTH_SESSION_UPDATE_AGE, 24h by default. An account minting rapidly writes fresher values continuously,
+   * so a genuinely-in-use session that refreshed 14h ago sorts BELOW hundreds of tokens minted-and-abandoned
+   * in the last hour. Ordering alone would therefore evict — and revoke — the real session and keep the junk,
+   * and it would do so precisely on the accounts where eviction fires, because a high mint rate is what
+   * pushes an account over the ceiling in the first place.
+   *
+   * The age floor removes that entirely: an entry older than the floor cannot belong to a session whose
+   * client is still refreshing it. The cost is that the hash only drains down to roughly
+   * (mint rate x floor) while a runaway minter is still running, rather than to the ceiling — correctness
+   * over tightness. It reaches the ceiling once the minting itself is fixed.
+   *
    * Bounded three ways, because this runs on the login hot path against a single-threaded shared store:
    *   - one HLEN in the ordinary case; the hash is not read at all below the ceiling;
-   *   - the read is ONE BOUNDED HSCAN PAGE, never the whole hash. A full read would cost ~1 µs/field
-   *     server-side, so a hash that grew to 53k under the old unbounded behaviour would block sysRedis ~54 ms
-   *     per login — and repeat it on every login until the hash drained, which is the drain mechanism's cost
-   *     scaling with the problem it is draining;
+   *   - the read is ONE BOUNDED HSCAN PAGE, never the whole hash. A full read costs ~1 µs/field server-side,
+   *     so a hash that grew to 53k under the old unbounded behaviour would block the shared store ~54 ms per
+   *     login and repeat it every login until drained — the drain's cost scaling with the damage it drains;
    *   - at most `maxEvictionsPerTrack` evictions per call, so an oversized hash drains over many logins.
    *
-   * Page size is the ceiling itself, which makes the ordering EXACT in the steady state (at ~500 fields one
-   * page is the whole hash) and approximate only for a hash still oversized from before this existed. That
-   * degradation is safe: the values are LAST-TOUCH times (trackToken re-writes the value on every call,
-   * including the rolling refresh), so this is LRU, not FIFO — an actively-used old session keeps a fresh
-   * value and survives. Evicting page-locally can only pick a less-recently-used entry than the global
-   * oldest, never an active one over an idle one within the page.
+   * Page size is the ceiling, so in the steady state one page is the whole hash. For a still-oversized hash
+   * the page is a subset and eviction is page-local; that is acceptable because the age floor — not the
+   * ordering — is what protects live sessions.
    */
   async function evictOverCeiling(userId: number) {
     if (!redis.hLen || !redis.hScan || maxTokens <= 0) return;
@@ -130,15 +148,23 @@ export function createSessionRegistry(config: SessionRegistryConfig): SessionReg
     if (total < maxTokens) return;
 
     const page = await redis.hScan(key, 0, { COUNT: maxTokens });
-    // Ascending by last-touch = least-recently-used first. A non-numeric value sorts as 0, i.e. goes first —
-    // the safe direction for an entry we cannot date.
-    const entries = page.tuples
-      .slice()
-      .sort((a, b) => (Number(a.value) || 0) - (Number(b.value) || 0));
-    const evicting = entries
+    // The age floor, applied BEFORE any ordering decision — an entry touched within it may belong to a live
+    // session, so it is not a candidate at all. A non-numeric value dates to 0, i.e. is always old enough,
+    // which is the safe direction for an entry we cannot date.
+    const floor = now() - minEvictionAge * 1000;
+    const candidates = page.tuples.filter(({ value }) => (Number(value) || 0) < floor);
+    // Oldest first among candidates. This only chooses WHICH stale entry goes; it never makes a live one
+    // eligible.
+    candidates.sort((a, b) => (Number(a.value) || 0) - (Number(b.value) || 0));
+    const evicting = candidates
       .slice(0, Math.min(total - maxTokens + 1, maxEvictions))
       .map(({ field }) => field);
-    if (!evicting.length) return;
+    // Nothing in the page is old enough: the hash stays over the ceiling this call rather than revoking a
+    // session that might be in use. Reported so a persistently-over-ceiling account is visible.
+    if (!evicting.length) {
+      config.onEvict?.({ userId, evicted: 0, total });
+      return;
+    }
 
     for (const evictedId of evicting) {
       await setState(evictedId, 'invalid');
@@ -158,9 +184,10 @@ export function createSessionRegistry(config: SessionRegistryConfig): SessionReg
       throw new Error('[@civitai/auth] invalidateUserSessions requires redis.hGetAll');
     const key = userTokensKey(userId);
     const tokenIds = Object.keys(await redis.hGetAll(key));
-    // Batched rather than one Promise.all over every token: this issues individual commands (no Lua, so no
-    // unpack ceiling), and an unbounded fan-out on an account with tens of thousands of tracked tokens would
-    // put that many concurrent commands on the shared auth store in one go.
+    // NOTE: this read is still the whole hash. That is tolerable only because this path is rare (ban / mass
+    // logout) rather than per-login; it has not been given trackToken's bounded-page treatment.
+    // Batched rather than one Promise.all over every token: an unbounded fan-out on an account with tens of
+    // thousands of tracked tokens would put that many concurrent commands on the shared auth store at once.
     for (let i = 0; i < tokenIds.length; i += INVALIDATE_BATCH) {
       await Promise.all(
         tokenIds.slice(i, i + INVALIDATE_BATCH).map(async (tokenId) => {

--- a/packages/civitai-auth/src/session-registry.ts
+++ b/packages/civitai-auth/src/session-registry.ts
@@ -16,6 +16,8 @@ export interface SessionRegistryRedis {
   /** Required only for invalidateUserSessions (reads a user's tracked token ids). */
   hGetAll?(key: string): Promise<Record<string, unknown>>;
   hExpire?(key: string, field: string, seconds: number): Promise<unknown>;
+  /** Required only for the per-user token ceiling; without it trackToken never evicts. */
+  hLen?(key: string): Promise<number>;
   get(key: string): Promise<string | null | undefined>;
   set(key: string, value: string, opts?: { EX?: number }): Promise<unknown>;
 }
@@ -40,6 +42,12 @@ export interface SessionRegistryConfig {
   onInvalidate?: (info: InvalidateInfo) => void | Promise<void>;
   /** Clock injection (tests). */
   now?: () => number;
+  /** Max tracked sessions per user before the oldest are evicted-and-revoked (default 500). */
+  maxTokensPerUser?: number;
+  /** Cap on evictions in a single trackToken call, so draining a huge legacy hash can't burst (default 50). */
+  maxEvictionsPerTrack?: number;
+  /** Called when tokens are evicted for exceeding the ceiling — wire to a metric. */
+  onEvict?: (info: { userId: number; evicted: number; total: number }) => void;
 }
 
 export interface SessionRegistry {
@@ -58,10 +66,19 @@ export interface SessionRegistry {
 }
 
 const DEFAULT_TTL = 30 * 24 * 60 * 60;
+// 500 is ~87x the observed mean tracked-token count and above 99.9% of accounts, while leaving an 8x margin
+// under the ~4000 field count at which the multi-field token-state write exceeds Lua's unpack limit and
+// silently lands nothing (see src/server/redis/atomic.ts).
+const DEFAULT_MAX_TOKENS_PER_USER = 500;
+const DEFAULT_MAX_EVICTIONS_PER_TRACK = 50;
+// Concurrency bound for the ban fan-out (individual commands, not a Lua batch).
+const INVALIDATE_BATCH = 100;
 
 export function createSessionRegistry(config: SessionRegistryConfig): SessionRegistry {
   const { keys } = config;
   const ttl = config.ttlSeconds ?? DEFAULT_TTL;
+  const maxTokens = config.maxTokensPerUser ?? DEFAULT_MAX_TOKENS_PER_USER;
+  const maxEvictions = config.maxEvictionsPerTrack ?? DEFAULT_MAX_EVICTIONS_PER_TRACK;
   const now = config.now ?? (() => Date.now());
   const { redis } = config;
   const userTokensKey = (userId: number) => `${keys.userTokens}:${userId}`;
@@ -72,8 +89,43 @@ export function createSessionRegistry(config: SessionRegistryConfig): SessionReg
   }
 
   async function trackToken(tokenId: string, userId: number) {
+    await evictOverCeiling(userId);
     await redis.hSet(userTokensKey(userId), tokenId, now());
     if (redis.hExpire) await redis.hExpire(userTokensKey(userId), tokenId, ttl);
+  }
+
+  /**
+   * Keep a user's tracked-token hash bounded, by EVICTING AND REVOKING the oldest entries.
+   *
+   * Refusing to track would be the simpler shape and is wrong: trackToken runs AFTER the token is signed
+   * and returned, so an untracked session is one no ban can ever find. Evicting alone has a smaller version
+   * of the same flaw — an evicted jti stays validly signed for the rest of `ttl` — so each eviction writes
+   * `invalid` to the token-state hash that isRevoked consults. The evicted session dies rather than escaping.
+   *
+   * Bounded on both sides: it only reads the hash once it is already over the ceiling (so the ordinary case
+   * costs one HLEN), and it evicts at most `maxEvictionsPerTrack` per call, so draining a hash that grew to
+   * tens of thousands under the old unbounded behaviour happens over many logins instead of in one burst.
+   */
+  async function evictOverCeiling(userId: number) {
+    if (!redis.hLen || !redis.hGetAll || maxTokens <= 0) return;
+    const key = userTokensKey(userId);
+    const total = await redis.hLen(key);
+    if (total < maxTokens) return;
+
+    const entries = Object.entries(await redis.hGetAll(key));
+    // Values are the creation/last-touch epoch-ms trackToken writes, so ascending = oldest first. A
+    // non-numeric value sorts as 0, i.e. evicted first — the safe direction for an entry we can't date.
+    entries.sort((a, b) => (Number(a[1]) || 0) - (Number(b[1]) || 0));
+    const evicting = entries
+      .slice(0, Math.min(total - maxTokens + 1, maxEvictions))
+      .map(([field]) => field);
+    if (!evicting.length) return;
+
+    for (const evictedId of evicting) {
+      await setState(evictedId, 'invalid');
+      await redis.hDel(key, evictedId);
+    }
+    config.onEvict?.({ userId, evicted: evicting.length, total });
   }
 
   async function invalidateToken(tokenId: string, userId?: number) {
@@ -85,8 +137,22 @@ export function createSessionRegistry(config: SessionRegistryConfig): SessionReg
   async function invalidateUserSessions(userId: number) {
     if (!redis.hGetAll)
       throw new Error('[@civitai/auth] invalidateUserSessions requires redis.hGetAll');
-    const tokenIds = Object.keys(await redis.hGetAll(userTokensKey(userId)));
-    await Promise.all(tokenIds.map((t) => setState(t, 'invalid')));
+    const key = userTokensKey(userId);
+    const tokenIds = Object.keys(await redis.hGetAll(key));
+    // Batched rather than one Promise.all over every token: this issues individual commands (no Lua, so no
+    // unpack ceiling), and an unbounded fan-out on an account with tens of thousands of tracked tokens would
+    // put that many concurrent commands on the shared auth store in one go.
+    for (let i = 0; i < tokenIds.length; i += INVALIDATE_BATCH) {
+      await Promise.all(
+        tokenIds.slice(i, i + INVALIDATE_BATCH).map(async (tokenId) => {
+          // Order matters: the revocation marker must land BEFORE the tracking entry goes. A token dropped
+          // from the hash without an `invalid` marker is one no later ban can find — still validly signed for
+          // the rest of its TTL, and now invisible. Awaiting setState first means a throw skips the hDel.
+          await setState(tokenId, 'invalid');
+          await redis.hDel(key, tokenId);
+        })
+      );
+    }
     await config.onInvalidate?.({ scope: 'user', userId });
   }
 

--- a/packages/civitai-auth/src/session-registry.ts
+++ b/packages/civitai-auth/src/session-registry.ts
@@ -52,9 +52,14 @@ export interface SessionRegistryConfig {
   maxTokensPerUser?: number;
   /** Cap on evictions in a single trackToken call, so draining a huge legacy hash can't burst (default 50). */
   maxEvictionsPerTrack?: number;
-  /** Entries touched more recently than this are never evicted (default 3d). Must exceed the spokes'
-   *  rolling-refresh interval, which is the coarsest granularity at which a live session is re-touched. */
+  /** Entries touched more recently than this are never evicted (default 3d). Raised automatically if it is
+   *  not at least twice `refreshIntervalSeconds` — see the note on that field. */
   minEvictionAgeSeconds?: number;
+  /** The spokes' rolling-refresh interval (AUTH_SESSION_UPDATE_AGE, default 24h). Pass the deployment's real
+   *  value: the eviction floor's entire guarantee is that it exceeds this, and lengthening the refresh
+   *  interval without raising the floor would silently make live sessions evictable again. Passing it lets
+   *  the registry enforce the relationship instead of documenting it. */
+  refreshIntervalSeconds?: number;
   /** Called when tokens are evicted for exceeding the ceiling — wire to a metric. */
   onEvict?: (info: { userId: number; evicted: number; total: number }) => void;
 }
@@ -82,6 +87,9 @@ const DEFAULT_MAX_EVICTIONS_PER_TRACK = 50;
 // the spokes' rolling-refresh interval (AUTH_SESSION_UPDATE_AGE, default 24h), because that interval is the
 // coarsest granularity at which a live session updates its entry.
 const DEFAULT_MIN_EVICTION_AGE_SECONDS = 3 * 24 * 60 * 60;
+// The documented default of the spokes' AUTH_SESSION_UPDATE_AGE. Only a fallback — callers should pass their
+// deployment's real value so the floor tracks it.
+const DEFAULT_REFRESH_INTERVAL_SECONDS = 24 * 60 * 60;
 // Concurrency bound for the ban fan-out (individual commands, not a Lua batch).
 const INVALIDATE_BATCH = 100;
 
@@ -90,7 +98,14 @@ export function createSessionRegistry(config: SessionRegistryConfig): SessionReg
   const ttl = config.ttlSeconds ?? DEFAULT_TTL;
   const maxTokens = config.maxTokensPerUser ?? DEFAULT_MAX_TOKENS_PER_USER;
   const maxEvictions = config.maxEvictionsPerTrack ?? DEFAULT_MAX_EVICTIONS_PER_TRACK;
-  const minEvictionAge = config.minEvictionAgeSeconds ?? DEFAULT_MIN_EVICTION_AGE_SECONDS;
+  // ENFORCED, not merely documented: the floor must outlast the refresh interval, or a live session that has
+  // not refreshed recently becomes evictable and gets revoked. Lengthening AUTH_SESSION_UPDATE_AGE without
+  // touching the floor would otherwise reintroduce that silently, with no error and no failing test.
+  const refreshInterval = config.refreshIntervalSeconds ?? DEFAULT_REFRESH_INTERVAL_SECONDS;
+  const minEvictionAge = Math.max(
+    config.minEvictionAgeSeconds ?? DEFAULT_MIN_EVICTION_AGE_SECONDS,
+    2 * refreshInterval
+  );
   const now = config.now ?? (() => Date.now());
   const { redis } = config;
   const userTokensKey = (userId: number) => `${keys.userTokens}:${userId}`;
@@ -128,7 +143,12 @@ export function createSessionRegistry(config: SessionRegistryConfig): SessionReg
    * The age floor removes that entirely: an entry older than the floor cannot belong to a session whose
    * client is still refreshing it. The cost is that the hash only drains down to roughly
    * (mint rate x floor) while a runaway minter is still running, rather than to the ceiling — correctness
-   * over tightness. It reaches the ceiling once the minting itself is fixed.
+   * over tightness.
+   *
+   * 🔴 So this bounds the hash but does NOT by itself bring a fast minter into the range where the bulk
+   * revocation path behaves well; at a high enough mint rate the floor holds it above that range. Only fixing
+   * the minting closes that, which is why the upgrade-on-read fix is sequenced with this rather than after it.
+   * Do not read "bounded" here as "safe at any mint rate".
    *
    * Bounded three ways, because this runs on the login hot path against a single-threaded shared store:
    *   - one HLEN in the ordinary case; the hash is not read at all below the ceiling;
@@ -149,8 +169,9 @@ export function createSessionRegistry(config: SessionRegistryConfig): SessionReg
 
     const page = await redis.hScan(key, 0, { COUNT: maxTokens });
     // The age floor, applied BEFORE any ordering decision — an entry touched within it may belong to a live
-    // session, so it is not a candidate at all. A non-numeric value dates to 0, i.e. is always old enough,
-    // which is the safe direction for an entry we cannot date.
+    // session, so it is not a candidate at all. A non-numeric value dates to 0, i.e. is always old enough:
+    // safe for bounding the hash, at the cost of that one session. Unreachable while trackToken writes a
+    // numeric clock, so don't rely on it protecting anyone.
     const floor = now() - minEvictionAge * 1000;
     const candidates = page.tuples.filter(({ value }) => (Number(value) || 0) < floor);
     // Oldest first among candidates. This only chooses WHICH stale entry goes; it never makes a live one

--- a/packages/civitai-auth/src/session-registry.ts
+++ b/packages/civitai-auth/src/session-registry.ts
@@ -150,6 +150,13 @@ export function createSessionRegistry(config: SessionRegistryConfig): SessionReg
    * the minting closes that, which is why the upgrade-on-read fix is sequenced with this rather than after it.
    * Do not read "bounded" here as "safe at any mint rate".
    *
+   * Note the two dials are coupled: because the floor is clamped up to twice `refreshIntervalSeconds`,
+   * LENGTHENING the refresh interval also raises the floor, and so raises the (mint rate x floor) bound.
+   * Inert on defaults (2 x 24h is under the default floor), but anyone raising the refresh interval for an
+   * unrelated reason is moving both. It is not avoidable — with a long refresh interval and a fast minter you
+   * cannot both protect live sessions and bound the hash tightly, and protecting the session is the right
+   * side to pick.
+   *
    * Bounded three ways, because this runs on the login hot path against a single-threaded shared store:
    *   - one HLEN in the ordinary case; the hash is not read at all below the ceiling;
    *   - the read is ONE BOUNDED HSCAN PAGE, never the whole hash. A full read costs ~1 µs/field server-side,

--- a/packages/civitai-auth/src/session-registry.ts
+++ b/packages/civitai-auth/src/session-registry.ts
@@ -18,6 +18,12 @@ export interface SessionRegistryRedis {
   hExpire?(key: string, field: string, seconds: number): Promise<unknown>;
   /** Required only for the per-user token ceiling; without it trackToken never evicts. */
   hLen?(key: string): Promise<number>;
+  /** Ditto — the ceiling reads a BOUNDED PAGE, never the whole hash (it runs on the login hot path). */
+  hScan?(
+    key: string,
+    cursor: number,
+    options?: { COUNT?: number }
+  ): Promise<{ cursor: number; tuples: Array<{ field: string; value: string }> }>;
   get(key: string): Promise<string | null | undefined>;
   set(key: string, value: string, opts?: { EX?: number }): Promise<unknown>;
 }
@@ -102,23 +108,36 @@ export function createSessionRegistry(config: SessionRegistryConfig): SessionReg
    * of the same flaw — an evicted jti stays validly signed for the rest of `ttl` — so each eviction writes
    * `invalid` to the token-state hash that isRevoked consults. The evicted session dies rather than escaping.
    *
-   * Bounded on both sides: it only reads the hash once it is already over the ceiling (so the ordinary case
-   * costs one HLEN), and it evicts at most `maxEvictionsPerTrack` per call, so draining a hash that grew to
-   * tens of thousands under the old unbounded behaviour happens over many logins instead of in one burst.
+   * Bounded three ways, because this runs on the login hot path against a single-threaded shared store:
+   *   - one HLEN in the ordinary case; the hash is not read at all below the ceiling;
+   *   - the read is ONE BOUNDED HSCAN PAGE, never the whole hash. A full read would cost ~1 µs/field
+   *     server-side, so a hash that grew to 53k under the old unbounded behaviour would block sysRedis ~54 ms
+   *     per login — and repeat it on every login until the hash drained, which is the drain mechanism's cost
+   *     scaling with the problem it is draining;
+   *   - at most `maxEvictionsPerTrack` evictions per call, so an oversized hash drains over many logins.
+   *
+   * Page size is the ceiling itself, which makes the ordering EXACT in the steady state (at ~500 fields one
+   * page is the whole hash) and approximate only for a hash still oversized from before this existed. That
+   * degradation is safe: the values are LAST-TOUCH times (trackToken re-writes the value on every call,
+   * including the rolling refresh), so this is LRU, not FIFO — an actively-used old session keeps a fresh
+   * value and survives. Evicting page-locally can only pick a less-recently-used entry than the global
+   * oldest, never an active one over an idle one within the page.
    */
   async function evictOverCeiling(userId: number) {
-    if (!redis.hLen || !redis.hGetAll || maxTokens <= 0) return;
+    if (!redis.hLen || !redis.hScan || maxTokens <= 0) return;
     const key = userTokensKey(userId);
     const total = await redis.hLen(key);
     if (total < maxTokens) return;
 
-    const entries = Object.entries(await redis.hGetAll(key));
-    // Values are the creation/last-touch epoch-ms trackToken writes, so ascending = oldest first. A
-    // non-numeric value sorts as 0, i.e. evicted first — the safe direction for an entry we can't date.
-    entries.sort((a, b) => (Number(a[1]) || 0) - (Number(b[1]) || 0));
+    const page = await redis.hScan(key, 0, { COUNT: maxTokens });
+    // Ascending by last-touch = least-recently-used first. A non-numeric value sorts as 0, i.e. goes first —
+    // the safe direction for an entry we cannot date.
+    const entries = page.tuples
+      .slice()
+      .sort((a, b) => (Number(a.value) || 0) - (Number(b.value) || 0));
     const evicting = entries
       .slice(0, Math.min(total - maxTokens + 1, maxEvictions))
-      .map(([field]) => field);
+      .map(({ field }) => field);
     if (!evicting.length) return;
 
     for (const evictedId of evicting) {


### PR DESCRIPTION
## The problem

Nothing capped `session:user-tokens2:<userId>`. A census of **all 943,268** tracked-token keys in production:

```
accounts at or above N:
  20: 35,912    50: 6,686    100: 2,385    250: 1,063
 500:    909   1000:   201  2000:    53
mean 5.73 · max 53,877 · 5.41M tracked tokens total
```

An unbounded per-user hash makes every operation that walks it scale with the worst account, on a store shared by every web pool. Capping at **500** touches 909 accounts (0.096%) and sits ~87× above the mean.

## Change 1 — `trackToken` evicts *and revokes* above the ceiling

Three designs were rejected on the way, and the rejections are the substance of the PR:

- **Refusing to track** is simpler and wrong. `trackToken` runs *after* the token is signed and returned, so an untracked session is one **no ban can ever find**.
- **Evicting without revoking** orphans a still-signed `jti`: it drops out of the hash a ban walks while remaining valid for the rest of its TTL. So each eviction writes `invalid` to the token-state hash `isRevoked` consults, in the same operation.
- **Evicting by value order alone** — which is what the first version of this PR did — **logs real users out.** Caught by @charlie in review. The stored value is a last-*write* time, and a live session only rewrites it when the spoke's rolling refresh fires (`AUTH_SESSION_UPDATE_AGE`, 24h default). An account minting rapidly writes fresher values continuously, so a genuinely-in-use session that refreshed 14h ago sorts *below* hundreds of minted-and-abandoned tokens from the last hour. Ordering would have evicted the real session and kept the junk — and only ever on accounts where eviction fires, since ordinary users never reach the ceiling.

**So the safety property is an age floor, not the ordering.** An entry touched within `minEvictionAgeSeconds` (default 3d, comfortably above the 24h refresh interval) is not a candidate at all. If nothing in the page is old enough, nothing is evicted and the hash stays over the ceiling for that call, reported through `onEvict` with `evicted: 0`.

The trade is explicit: while a runaway minter is still running, the hash drains to roughly (mint rate × floor) rather than to the ceiling. Correctness over tightness; it reaches the ceiling once the minting itself is fixed.

**The read is bounded too** — one `HSCAN` page, `COUNT` = ceiling, never the whole hash. The first version used `hGetAll`, which is O(N) blocking work on the login hot path repeated every login until the hash drained — the drain's cost scaling with the damage it drains. Measured against the census: ~54 ms blocking the shared store per login on the largest account, ~29 s cumulative to drain that one account, ~69 s fleet-wide. Caught by @ivy.

## Change 2 — `invalidateUserSessions` removes what it revokes

It marked every token invalid but never `hDel`'d the tracking entries, unlike `invalidateToken` on logout. A banned account therefore kept a full-size hash for the whole TTL, and every later pass paid for tokens already revoked.

The marker is written **before** the delete and awaited, so a failed `setState` skips the `hDel` — same *never orphan a signed token* rule, pinned by a test that makes one `setState` throw. Fan-out batched at 100. Its read is still the whole hash and is annotated as such: tolerable only because ban is rare rather than per-login.

## Known, non-blocking

- **Concurrency can drift one over the ceiling** — two simultaneous logins both read `total`, both evict the same field (the second `hDel` no-ops), both insert. Self-corrects on the next login, and a concurrently-minted token carries `now()` so it can never be the victim.
- Ceiling, eviction batch and age floor are all configurable, so a problem is a dial rather than a revert.

## Verification

- `pnpm typecheck` — 0 errors
- `@civitai/auth` + `app:auth` — 598 pass / 0 fail (58 files), 12 new tests
- **Mutation-tested**, since no production account can demonstrate these (every account over the ceiling falls under it on TTL alone within ~2 weeks):
  - stub the age-floor filter → 3 tests fail
  - raise the page `COUNT` to 1,000,000 → the bounded-page test fails
  - stub `evictOverCeiling` to a no-op → 3 of 5 ceiling tests fail, the 2 survivors being the negative controls
  - swap the marker/delete order → exactly 1 failure, the ordering test

🤖 Generated with [Claude Code](https://claude.com/claude-code)