### PR TITLE
fix(observability): make watchdog worker_started a spawn fact, and label worker deaths

### DIFF
--- a/src/server/__tests__/eventloop-watchdog.test.ts
+++ b/src/server/__tests__/eventloop-watchdog.test.ts
@@ -40,16 +40,35 @@ async function loadWatchdog() {
 async function registrationsDuring(act: () => void): Promise<string[]> {
   const promClient = await import('~/server/prom/client');
   const register = vi.mocked(promClient.registerInstrumentationMetric);
-  const { registerEventLoopWatchdog, shutdownEventLoopWatchdog } = await loadWatchdog();
+  const { registerEventLoopWatchdog, shutdownEventLoopWatchdog, __getWatchdogWorkerForTests } =
+    await loadWatchdog();
 
   const before = register.mock.calls.length;
   try {
     registerEventLoopWatchdog();
     act();
   } finally {
-    shutdownEventLoopWatchdog();
+    // AWAIT the exit, don't just request it. `vi.resetModules()` gives the next test a
+    // fresh module, but a still-running worker from this one keeps the OLD module's
+    // exit handler alive — and that handler calls the same process-wide
+    // `registerInstrumentationMetric` mock, so its metrics land in the NEXT test's
+    // recording. That leak made an intentional shutdown look like a no-token death.
+    await stopAndAwaitExit(__getWatchdogWorkerForTests(), shutdownEventLoopWatchdog);
   }
   return register.mock.calls.slice(before).map((call) => String(call[0]));
+}
+
+async function stopAndAwaitExit(
+  worker: { once: (event: 'exit', cb: (code: number) => void) => void } | undefined,
+  stop: () => void
+): Promise<number | undefined> {
+  if (!worker) {
+    stop();
+    return undefined;
+  }
+  const exited = new Promise<number>((resolve) => worker.once('exit', (code) => resolve(code)));
+  stop();
+  return exited;
 }
 
 describe('watchdog config resolution', () => {
@@ -132,11 +151,12 @@ describe('watchdog config resolution', () => {
     });
 
     expect(registered).not.toContain('civitai_app_watchdog_worker_started');
+    expect(registered).not.toContain('civitai_app_watchdog_worker_exits_total');
   });
 
-  it('POSITIVE CONTROL: registers it once armed', async () => {
-    // Without this, the assertion above would pass just as happily against a gauge
-    // that is never registered at all.
+  it('POSITIVE CONTROL: registers both series once armed', async () => {
+    // Without this, the assertion above would pass just as happily against metrics
+    // that are never registered at all.
     process.env.EVENTLOOP_WATCHDOG_ENABLED = 'true';
     // Port 0 so an armed test can never collide with a real 9099 or another suite.
     process.env.WATCHDOG_METRICS_PORT = '0';
@@ -144,6 +164,88 @@ describe('watchdog config resolution', () => {
     const registered = await registrationsDuring(() => undefined);
 
     expect(registered).toContain('civitai_app_watchdog_worker_started');
+    // Registered eagerly at 0 rather than on the first death: absent and zero mean
+    // different things to an alert, and it cannot tell them apart.
+    expect(registered).toContain('civitai_app_watchdog_worker_exits_total');
+  });
+
+  /**
+   * Drive an armed watchdog and return the recorded metric calls. `WEBHOOK_TOKEN`
+   * matters: without it the worker fails closed and exits 78 before anything else can
+   * happen, which is a different scenario entirely (and one the second test uses).
+   */
+  async function armAndStop({ token }: { token: string | undefined }) {
+    process.env.EVENTLOOP_WATCHDOG_ENABLED = 'true';
+    process.env.WATCHDOG_METRICS_PORT = '0';
+    const savedToken = process.env.WEBHOOK_TOKEN;
+    if (token === undefined) delete process.env.WEBHOOK_TOKEN;
+    else process.env.WEBHOOK_TOKEN = token;
+
+    const promClient = await import('~/server/prom/client');
+    const metrics = new Map<
+      string,
+      { set: ReturnType<typeof vi.fn>; inc: ReturnType<typeof vi.fn> }
+    >();
+    vi.mocked(promClient.registerInstrumentationMetric).mockImplementation(((name: string) => {
+      if (!metrics.has(name)) metrics.set(name, { set: vi.fn(), inc: vi.fn() });
+      return metrics.get(name);
+    }) as never);
+
+    try {
+      const { registerEventLoopWatchdog, shutdownEventLoopWatchdog, __getWatchdogWorkerForTests } =
+        await loadWatchdog();
+      registerEventLoopWatchdog();
+
+      const worker = __getWatchdogWorkerForTests();
+      expect(worker, 'expected an armed worker').toBeDefined();
+
+      const exited = new Promise<number>((resolve) =>
+        worker?.once('exit', (code) => resolve(code))
+      );
+      shutdownEventLoopWatchdog();
+      const exitCode = await exited;
+
+      return {
+        exitCode,
+        startedCalls: metrics.get('civitai_app_watchdog_worker_started')!.set.mock.calls,
+        exitCalls: metrics.get('civitai_app_watchdog_worker_exits_total')!.inc.mock.calls,
+      };
+    } finally {
+      if (savedToken === undefined) delete process.env.WEBHOOK_TOKEN;
+      else process.env.WEBHOOK_TOKEN = savedToken;
+      vi.mocked(promClient.registerInstrumentationMetric).mockImplementation((() => ({
+        set: vi.fn(),
+        inc: vi.fn(),
+        dec: vi.fn(),
+        observe: vi.fn(),
+      })) as never);
+    }
+  }
+
+  it('🔴 an intentional shutdown is not counted as a death', async () => {
+    const { exitCode, startedCalls, exitCalls } = await armAndStop({ token: 'test-token' });
+
+    expect(exitCode).toBe(0);
+    // set(1) at spawn and never again — in particular never set(0) on exit.
+    expect(startedCalls).toEqual([[1]]);
+    // Only the two zero-seeds. Counting our own shutdown would make the "worker died"
+    // alert fire on every ordinary pod termination.
+    expect(exitCalls).toEqual([
+      [{ reason: 'crash' }, 0],
+      [{ reason: 'no-token' }, 0],
+    ]);
+  });
+
+  it('🔴 a missing token is counted as no-token, not as a crash', async () => {
+    // A configuration fault and a runtime death have different owners and different
+    // fixes. Without the label they share a signature, which is the gap that made the
+    // previous "died after starting" alert unfireable one layer up.
+    const { exitCode, startedCalls, exitCalls } = await armAndStop({ token: undefined });
+
+    expect(exitCode).toBe(78);
+    expect(startedCalls).toEqual([[1]]);
+    expect(exitCalls).toContainEqual([{ reason: 'no-token' }]);
+    expect(exitCalls).not.toContainEqual([{ reason: 'crash' }]);
   });
 });
 

--- a/src/server/__tests__/eventloop-watchdog.worker.test.ts
+++ b/src/server/__tests__/eventloop-watchdog.worker.test.ts
@@ -211,9 +211,12 @@ describe('event-loop watchdog worker', () => {
       });
     });
 
-    expect(exitCode).not.toBe(0);
     expect(messages).not.toContain('LISTENING');
     expect(messages.join(' ')).toContain('refusing to serve metrics');
+    // 78 (sysexits EX_CONFIG), not just "non-zero". The parent keys the exit REASON on
+    // this code, so that a configuration fault is distinguishable from a crash — the
+    // postMessage above races the exit event and cannot be relied on for that.
+    expect(exitCode).toBe(78);
   });
 
   it('404s anything that is not exactly GET /metrics', async () => {

--- a/src/server/eventloop-watchdog.ts
+++ b/src/server/eventloop-watchdog.ts
@@ -135,12 +135,27 @@ export function resolveWatchdogPort(): number {
  * tell "the watchdog is absent" from "no wedges occurred", which is the failure mode
  * the inline-source note above describes. Together they separate five states:
  *
- *                                 watchdog_up   worker_started
- *   healthy                            1              1
+ *                                 watchdog_up   worker_started   worker_exits_total
+ *   healthy                            1              1            0 (both reasons)
  *   MAIN THREAD WEDGED                 1           absent   (only past the scrape timeout — see below)
- *   worker died after starting     absent             1
- *   worker never spawned (threw)   absent             0
- *   pod gone                       absent          absent
+ *   worker crashed after starting  absent             1          >=1 {reason="crash"}
+ *   WEBHOOK_TOKEN missing          absent             1        >=1 {reason="no-token"}
+ *   worker never spawned (threw)   absent             0            0 (both reasons)
+ *   pod gone                       absent          absent            absent
+ *
+ * The counter is labelled because the fail-closed exit on a missing token is a
+ * CONFIGURATION fault and a crash is a runtime one — different owner, different fix —
+ * and without the label they share a signature. An intentional shutdown is not
+ * counted at all, or the "worker died" alert would fire on every pod termination.
+ *
+ * `worker_started` is a SPAWN fact and deliberately not a liveness fact — liveness is
+ * what watchdog_up is for. An earlier revision reset it to 0 when the worker died,
+ * which collapsed rows 3 and 4 onto the same signature and made "died after starting"
+ * indistinguishable from "never spawned". Those have different causes (a runtime
+ * crash versus the build-tracing failure this file's inline-source note is about) and
+ * different fixes, and distinguishing them was the argument for carrying two metrics
+ * at all. The exits counter makes a death positively observable rather than inferred
+ * from an absence.
  *
  * Row 2 is SCRAPE-TIMEOUT-BOUND, not instant. A wedged main thread does not refuse
  * the /api/metrics request, it queues it and answers on recovery — measured in
@@ -163,11 +178,32 @@ function workerStartedGauge() {
     () =>
       new client.Gauge({
         name: PROM_PREFIX + 'watchdog_worker_started',
-        help: 'Whether the main thread successfully spawned the event-loop watchdog worker (1) or tried and failed (0). Absent means either the watchdog is disarmed on this pod or the main thread cannot serve /api/metrics — compare against the worker-served civitai_app_watchdog_up to tell those apart.',
+        help: 'Whether the main thread successfully spawned the event-loop watchdog worker (1) or tried and failed (0). A SPAWN fact, not a liveness one — it stays 1 if the worker later dies; pair it with civitai_app_watchdog_worker_exits_total for that. Absent means either the watchdog is disarmed on this pod or the main thread cannot serve /api/metrics — compare against the worker-served civitai_app_watchdog_up to tell those apart.',
         registers: [instrumentationRegistry],
       })
   );
 }
+
+/**
+ * Deaths of a successfully-spawned worker. Registered in the arm path alongside the
+ * gauge, for the same reason: a disarmed pod should have no series at all rather than
+ * a zero that reads like a healthy armed one.
+ */
+function workerExitsCounter() {
+  return registerInstrumentationMetric(
+    PROM_PREFIX + 'watchdog_worker_exits_total',
+    () =>
+      new client.Counter({
+        name: PROM_PREFIX + 'watchdog_worker_exits_total',
+        help: 'Unintended exits of the event-loop watchdog worker after a successful spawn, by reason. `no-token` is a configuration fault (WEBHOOK_TOKEN missing, so the worker fails closed rather than serving metrics unauthenticated); `crash` is a runtime death. Non-zero with watchdog_up absent means the worker died, as opposed to never having started (watchdog_worker_started=0). An intentional shutdown does NOT count. The worker is not respawned, so any non-zero value means off-loop observability has ended for this pod.',
+        labelNames: ['reason'] as const,
+        registers: [instrumentationRegistry],
+      })
+  );
+}
+
+/** Exit code the worker uses when it refuses to serve for lack of a token. */
+const EXIT_CODE_NO_TOKEN = 78;
 
 /**
  * The worker runs as CommonJS (`eval: true` does not imply ESM) and imports nothing
@@ -267,7 +303,10 @@ if (!token) {
       message: 'refusing to serve metrics: no token configured (WEBHOOK_TOKEN unset)',
     });
   }
-  process.exit(1);
+  // 78 is sysexits' EX_CONFIG. A distinct code — not the postMessage above — is what
+  // the parent keys the exit reason on: the message and the exit event race, the code
+  // arrives with the exit itself.
+  process.exit(78);
 }
 
 function tokenAccepted(url) {
@@ -407,21 +446,33 @@ export function registerEventLoopWatchdog(): void {
       }
     });
 
+    // Neither handler touches workerStartedGauge: the spawn DID happen, and zeroing it
+    // here is what made a runtime death indistinguishable from never having started.
     worker.on('error', (err) => {
       console.error('[eventloop-watchdog] worker threw; watchdog is no longer running:', err);
-      workerStartedGauge().set(0);
+      workerExitsCounter().inc({ reason: 'crash' });
       worker = undefined;
     });
 
     worker.on('exit', (code) => {
-      if (code !== 0) {
-        console.error(`[eventloop-watchdog] worker exited unexpectedly with code ${code}`);
-      }
-      workerStartedGauge().set(0);
       worker = undefined;
+      // Code 0 is our own shutdown path; counting it would make the "worker died"
+      // alert fire during every ordinary pod termination.
+      if (code === 0) return;
+
+      const reason = code === EXIT_CODE_NO_TOKEN ? 'no-token' : 'crash';
+      console.error(
+        `[eventloop-watchdog] worker exited with code ${code} (${reason}); watchdog is no longer running`
+      );
+      workerExitsCounter().inc({ reason });
     });
 
     workerStartedGauge().set(1);
+    // Seed both label values at 0 rather than waiting for a death, so an
+    // armed-and-healthy pod reports `exits_total 0` instead of no series at all.
+    // Absent and zero mean different things and an alert cannot tell them apart.
+    workerExitsCounter().inc({ reason: 'crash' }, 0);
+    workerExitsCounter().inc({ reason: 'no-token' }, 0);
 
     // Guarded, not `once`: `once` still ADDS a listener per successful spawn, so a
     // respawn after a worker death accumulates them until the MaxListeners warning


### PR DESCRIPTION
Follow-up to #3752. Two defects in the observability contract that shipped with it, both found in review rather than by me, plus a test leak that was hiding one of them.

## 1. `worker_started` was a liveness fact pretending to be a spawn fact

The exit and error handlers set it to `0`:

```js
worker.on('exit', (code) => { … workerStartedGauge().set(0); … });
```

So a runtime death had **the exact signature of a spawn that never happened**:

| | `watchdog_up` | `worker_started` |
|---|---|---|
| worker never spawned (threw) | absent | 0 |
| worker died after starting | absent | **0** — documented as 1 |

Two rows of the documented state table collapsed onto one, and the alert keyed on `started == 1 unless up` could never be true at the moment it was meant to fire. Permanently green — and green in the worst way, reading as "no problem" rather than "never evaluated". The two states have different causes (a build-tracing failure versus a runtime crash) and different owners, and distinguishing them was the whole argument for carrying two metrics.

`worker_started` is now a **spawn** fact and stays `1` if the worker later dies. Liveness is what `watchdog_up` is for. Death is positively observable through a new `civitai_app_watchdog_worker_exits_total` rather than inferred from an absence.

## 2. The fail-closed exit was indistinguishable from a crash

The worker exits rather than serving metrics unauthenticated when `WEBHOOK_TOKEN` is missing — but that death would have incremented the same unlabelled counter as a crash, so a **configuration** fault presented as a **runtime** one. Those are precisely the two the counter exists to separate.

The worker now exits **78** (sysexits `EX_CONFIG`) and the counter carries `reason="no-token" | "crash"`. The exit *code* carries the reason, not the existing `postMessage` — that message races the exit event, so it cannot be relied on for the classification.

```
                               watchdog_up   worker_started   worker_exits_total
healthy                             1              1            0 (both reasons)
worker crashed after starting    absent            1          >=1 {reason="crash"}
WEBHOOK_TOKEN missing            absent            1        >=1 {reason="no-token"}
worker never spawned (threw)     absent            0            0 (both reasons)
```

**An intentional shutdown is not counted at all** — counting it would fire the "worker died" alert on every ordinary pod termination. Both label values are seeded at `0` on arm, so a healthy pod reports zero rather than no series; absent and zero mean different things and an alert cannot tell them apart.

## 3. A test leak that was hiding it

`registrationsDuring` asked the worker to stop without **awaiting** its exit. `vi.resetModules()` gives the next test a fresh module — it does not stop the previous one's thread. So a still-running worker kept the *old* module's exit handler alive, and that handler calls the same process-wide `registerInstrumentationMetric` mock, landing its metrics in the **next** test's recording. That is what made an intentional shutdown look like a `no-token` death, and it sent me looking at the wrong code first.

## Verification

- **Mutation-tested, so the new assertion isn't vacuous**: restoring `workerStartedGauge().set(0)` in the exit handler fails it — `expected [[1],[+0]] to deeply equal [[1]]`.
- **Three repeat runs** of the suite that had the leak: 16/16 each.
- 46/46 across the five watchdog suites.
- `pnpm typecheck` 0 errors, eslint clean, prettier clean.
- Full unit suite: **16 failed / 13647 passed / 887 files** — all 16 pre-existing on `main`, verified against a stashed baseline earlier today.

## Note for whoever wires the alerts

If the cold-compile startup wedge seen in preview (14.65 s on a fresh pod) reproduces fleet-wide, **`wedge_total >= 1` is the normal state for a healthy pod** — the worker spawns during instrumentation `register()`, so it is watching while the rest of the boot compiles. Don't build a rate-based rule on `wedge_total`: it would measure rollouts, not wedge waves.

The exposure is on any *duration* rule that fires without a `for:` window. 14.65 s sits under a 30 s threshold, but if the startup stall has a tail past one, a rollout pages on every pod that crosses it, simultaneously, for a deploy rather than a defect.

The clean remedy is a `for:` window rather than a time-based carve-out. `current_wedge_seconds` climbs monotonically through a wedge, so `for:` acts as a **duration filter**: a ~35 s startup stall holds above a 30 s threshold for only ~5 s and never satisfies `for: 1m`, while a 4–5 minute wedge satisfies it comfortably. That separates the two classes structurally, with no number chosen from today's boot times to go stale later.
