### PR TITLE
test(auth): make the scan-budget fakes terminate on their own

### DIFF
--- a/src/server/auth/__tests__/session-invalidation.test.ts
+++ b/src/server/auth/__tests__/session-invalidation.test.ts
@@ -295,7 +295,13 @@ describe('updateSessionState scan is bounded in aggregate', () => {
     mockHScanNoValues.mockImplementation(async () => {
       pages++;
       now += 1900; // just under a 2s per-page deadline
-      return { cursor: String(pages), fields: [`token-${pages}`] }; // never returns to '0'
+      // The fake MUST terminate on its own. Without the budget under test this is an infinite loop of
+      // immediately-resolved awaits — a pure microtask loop, which starves the macrotask queue, so vitest's
+      // setTimeout-based testTimeout never fires and CI hangs instead of failing. Measured: 4.19M iterations
+      // in 4s with a 300ms setTimeout that never ran. A regression must fail legibly, not wedge the runner —
+      // same reasoning as the n=10k cap on the linear-map test below.
+      if (pages > 50) return { cursor: '0', fields: [] };
+      return { cursor: String(pages), fields: [`token-${pages}`] }; // otherwise never returns to '0'
     });
 
     await refreshSession(42, { sendSignal: false });
@@ -314,6 +320,7 @@ describe('updateSessionState scan is bounded in aggregate', () => {
     mockHScanNoValues.mockImplementation(async () => {
       pages++;
       now += 1900;
+      if (pages > 50) return { cursor: '0', fields: [] }; // see above — the fake must terminate on its own
       return { cursor: String(pages), fields: [`token-${pages}`] };
     });
 


### PR DESCRIPTION
Follow-up to #3756, reported by @charlie after it merged. Test-only.

## The problem

The two fakes added with the aggregate scan budget return `cursor: String(pages)` and never reach `'0'`, with no cap. Remove the budget under test and the loop is infinite.

The part that makes it bad rather than slow: it's an `await` on an immediately-resolved promise, so it's a pure **microtask** loop. That starves the macrotask queue, and vitest's `testTimeout` is `setTimeout`-based. Measured by @charlie:

```
4,194,305 iterations in 4s
a 300ms setTimeout never fired
(it fired only once the loop was broken manually)
```

So a regression produced **no assertion failure and no timeout** — the unit project would hang until CI killed the job. My own `timeout 120` mutation run confirms it doesn't even OOM inside two minutes.

**Proving a property by absence of termination isn't an observation a test runner can make.** The same trap is already documented a few lines below in the same file, on the linear-map test, where n was capped at 10k specifically so a revert fails in ~21s rather than wedging the runner.

## The fix

One line in each fake: return a terminating page after 50.

A regression now fails legibly and fast. Verified by re-running the mutation with the budget removed:

```
AssertionError: expected 51 to be less than 5
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
Tests  2 failed | 15 passed (17)     exit=1
```

Same proof, sub-second, readable.

## Verification

- Unchanged suite: 17 pass / 0 fail
- Mutation (budget removed): 2 legible failures, exit 1, no hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)