### PR TITLE
fix(auth): dedupe legacy-cookie upgrades instead of minting per request

### DIFF
--- a/apps/auth/src/routes/api/auth/oauth/legacy-exchange/+server.ts
+++ b/apps/auth/src/routes/api/auth/oauth/legacy-exchange/+server.ts
@@ -38,6 +38,12 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
   const user = await getOrProduceSessionUser(userId);
   if (!user) return json({ error: 'not_found' }, { status: 404 });
 
+  // Upgrade-on-read is SILENT and repeats on every request from a client that ignores Set-Cookie, so it is the
+  // one mint path a ban must stop: otherwise a banned automated client keeps minting and tracking a token per
+  // request, growing the very hash the ban has to walk. Deliberately NOT applied to interactive login — a
+  // banned user still needs a session to be shown why they were banned and to appeal.
+  if (user.bannedAt || user.deletedAt) return json({ error: 'account_disabled' }, { status: 403 });
+
   const token = await mintUserSession(user);
 
   // Establish this browser in the device set so the upgraded session gets an account-switcher entry, exactly

--- a/apps/auth/src/routes/api/auth/oauth/legacy-exchange/__tests__/server.test.ts
+++ b/apps/auth/src/routes/api/auth/oauth/legacy-exchange/__tests__/server.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Upgrade-on-read — `POST /api/auth/oauth/legacy-exchange`.
+ *
+ * This is the one mint path a ban has to stop. It is SILENT and it repeats: a client that ignores the
+ * Set-Cookie the spoke writes re-enters it on every request, minting a fresh jti each time, which is what
+ * grew a handful of accounts to tens of thousands of tracked sessions. A banned automated client would
+ * otherwise keep minting and keep growing the very hash the ban has to walk.
+ *
+ * Deliberately NOT symmetric with interactive login: a banned user still needs a session there, to be shown
+ * why they were banned and to appeal. So this test pins the asymmetry, not a general "banned users get no
+ * session" rule.
+ */
+
+const h = vi.hoisted(() => ({
+  verifyToken: vi.fn(),
+  getOrProduceSessionUser: vi.fn(),
+  mintUserSession: vi.fn(),
+  touchAccount: vi.fn(),
+  isInternalRequest: vi.fn(),
+}));
+
+vi.mock('$lib/server/auth/verifier', () => ({ verifier: { verifyToken: h.verifyToken } }));
+vi.mock('$lib/server/auth/session-producer', () => ({
+  getOrProduceSessionUser: h.getOrProduceSessionUser,
+}));
+vi.mock('$lib/server/auth/session', () => ({ mintUserSession: h.mintUserSession }));
+vi.mock('$lib/server/auth/device', () => ({
+  getDeviceId: () => 'dev-1',
+  touchAccount: h.touchAccount,
+}));
+vi.mock('$lib/server/auth/internal', () => ({ isInternalRequest: h.isInternalRequest }));
+
+const call = async () => {
+  const { POST } = await import('../+server');
+  return POST({
+    request: new Request('https://auth.civitai.com/api/auth/oauth/legacy-exchange', {
+      method: 'POST',
+      body: JSON.stringify({ legacyToken: 'legacy.jwe' }),
+    }),
+    cookies: { get: () => undefined },
+  } as never);
+};
+
+describe('legacy-exchange ban gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.isInternalRequest.mockReturnValue(true);
+    h.verifyToken.mockResolvedValue({ sub: '42' });
+    h.mintUserSession.mockResolvedValue('fresh.civ.jwt');
+  });
+
+  it('mints for an ordinary account', async () => {
+    h.getOrProduceSessionUser.mockResolvedValue({ id: 42 });
+    const res = await call();
+    expect(res.status).toBe(200);
+    expect(h.mintUserSession).toHaveBeenCalled();
+  });
+
+  it('refuses to mint for a BANNED account', async () => {
+    h.getOrProduceSessionUser.mockResolvedValue({ id: 42, bannedAt: new Date() });
+    const res = await call();
+    expect(res.status).toBe(403);
+    expect(h.mintUserSession).not.toHaveBeenCalled();
+  });
+
+  it('refuses to mint for a DELETED account', async () => {
+    h.getOrProduceSessionUser.mockResolvedValue({ id: 42, deletedAt: new Date() });
+    const res = await call();
+    expect(res.status).toBe(403);
+    expect(h.mintUserSession).not.toHaveBeenCalled();
+  });
+});

--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -1877,6 +1877,7 @@ export const REDIS_SYS_KEYS = {
   SESSION: {
     ALL: 'session:all',
     TOKEN_STATE: 'session:token-state',
+    LEGACY_UPGRADE_LOCK: 'session:legacy-upgrade-lock',
   },
   JOB: 'job',
   BUZZ_WITHDRAWAL_REQUEST: {

--- a/src/server/auth/__tests__/session-client.test.ts
+++ b/src/server/auth/__tests__/session-client.test.ts
@@ -1,11 +1,24 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as CivitaiAuth from '@civitai/auth';
 
 // Unit-test maybeUpgradeLegacySession's Set-Cookie assembly (the upgrade-on-read path). We stub ONLY the hub
 // session-token client so we can drive exchangeLegacy; setSessionCookie, clearLegacyCookies, and the
 // cookie-name helpers stay REAL, so we assert the actual headers a legacy user's response would carry.
-const h = vi.hoisted(() => ({ exchangeLegacy: vi.fn(), refresh: vi.fn(), revoke: vi.fn() }));
+const h = vi.hoisted(() => ({
+  exchangeLegacy: vi.fn(),
+  refresh: vi.fn(),
+  revoke: vi.fn(),
+  redisSet: vi.fn(),
+}));
+// Hand-listed rather than spread-from-original (matching session-invalidation.test.ts): importOriginal here
+// would construct the real redis clients at module load. Only the upgrade dedupe's SET NX is exercised.
+vi.mock('~/server/redis/client', () => ({
+  sysRedis: { set: h.redisSet },
+  REDIS_SYS_KEYS: { SESSION: { LEGACY_UPGRADE_LOCK: 'session:legacy-upgrade-lock' } },
+  withSysReadDeadline: (p: Promise<unknown>) => p,
+}));
 vi.mock('@civitai/auth', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@civitai/auth')>();
+  const actual = await importOriginal<typeof CivitaiAuth>();
   return {
     ...actual,
     createSessionTokenClient: () => ({
@@ -36,6 +49,7 @@ describe('maybeUpgradeLegacySession — upgrade-on-read Set-Cookie assembly', ()
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    h.redisSet.mockResolvedValue('OK'); // SET NX succeeded — this request owns the upgrade window
     process.env.AUTH_JWT_ISSUER = 'https://auth.civitai.com'; // HUB_ORIGIN truthy + secure cookie naming
     delete process.env.AUTH_COOKIE_DOMAIN;
     delete process.env.NEXTAUTH_COOKIE_DOMAIN;
@@ -105,6 +119,47 @@ describe('maybeUpgradeLegacySession — upgrade-on-read Set-Cookie assembly', ()
 
     await maybeUpgradeLegacySession('legacy.jwe', undefined, res, 'civitai.com');
     expect(h.exchangeLegacy).not.toHaveBeenCalled();
+  });
+
+  // The growth driver: upgrading mints a NEW jti, and the only thing that stopped it repeating was the client
+  // persisting the cookie we set. A client that ignores Set-Cookie re-minted on every request forever.
+  describe('per-cookie dedupe window', () => {
+    it('skips the hub entirely when another request already claimed the window', async () => {
+      h.redisSet.mockResolvedValue(null); // SET NX lost the race — someone already upgraded this cookie
+      const { maybeUpgradeLegacySession } = await import('../session-client');
+      const res = fakeRes();
+
+      await maybeUpgradeLegacySession('legacy.jwe', undefined, res, 'civitai.com');
+
+      expect(h.exchangeLegacy).not.toHaveBeenCalled();
+      expect(res.cookies()).toEqual([]);
+    });
+
+    it('claims the window with SET NX + a TTL, keyed on a HASH of the cookie (never the cookie itself)', async () => {
+      const { maybeUpgradeLegacySession } = await import('../session-client');
+      h.exchangeLegacy.mockResolvedValue({ token: 'fresh.civ.jwt', deviceId: 'd' });
+
+      await maybeUpgradeLegacySession('legacy.jwe', undefined, fakeRes(), 'civitai.com');
+
+      const [key, value, opts] = h.redisSet.mock.calls[0];
+      expect(key).toMatch(/^session:legacy-upgrade-lock:/);
+      expect(key).not.toContain('legacy.jwe');
+      expect(value).toBe('1'); // no credential stored under the marker
+      expect(opts).toMatchObject({ NX: true });
+      expect(opts.EX).toBeGreaterThan(0);
+    });
+
+    it('fails OPEN when sysRedis is unreachable — a blip must not block migration', async () => {
+      h.redisSet.mockRejectedValue(new Error('sysredis down'));
+      h.exchangeLegacy.mockResolvedValue({ token: 'fresh.civ.jwt', deviceId: 'd' });
+      const { maybeUpgradeLegacySession } = await import('../session-client');
+      const res = fakeRes();
+
+      await maybeUpgradeLegacySession('legacy.jwe', undefined, res, 'civitai.com');
+
+      expect(h.exchangeLegacy).toHaveBeenCalled();
+      expect(res.cookies().some((c) => c.includes('fresh.civ.jwt'))).toBe(true);
+    });
   });
 
   it('is fire-safe: a rejecting exchange never throws and sets nothing', async () => {

--- a/src/server/auth/session-client.ts
+++ b/src/server/auth/session-client.ts
@@ -1,4 +1,6 @@
+import { createHash } from 'crypto';
 import type { Session } from '~/types/session';
+import { REDIS_SYS_KEYS, sysRedis, withSysReadDeadline } from '~/server/redis/client';
 import { createSessionClient, createSessionTokenClient, sessionCookieName } from '@civitai/auth';
 import { setSessionCookie, clearLegacyCookies, type CookieWritable } from './civ-cookie';
 import { isRevoked } from './session-verifier';
@@ -86,6 +88,31 @@ export async function maybeRollHubCookie(
   }
 }
 
+// One upgrade per legacy cookie per window, instead of one per REQUEST. Upgrading mints a NEW jti, and the
+// only thing that stopped it repeating was the client persisting the cookie we set — so a client that ignores
+// Set-Cookie (a scripted integration, a cookie-less HTTP client) re-minted on every request indefinitely, with
+// no age gate and no rate limit. Contrast maybeRollHubCookie above, which is both age-gated and jti-preserving.
+//
+// Skipping is safe: the caller already resolved this request's session from the legacy decode, so a skipped
+// upgrade costs the user nothing — the migration just happens on a later request. We key on a HASH of the
+// cookie and store no value, so the marker is not a credential.
+const LEGACY_UPGRADE_WINDOW_SECONDS = 10 * 60;
+
+async function claimLegacyUpgrade(legacyToken: string): Promise<boolean> {
+  try {
+    const fingerprint = createHash('sha256').update(legacyToken).digest('base64url');
+    const key = `${REDIS_SYS_KEYS.SESSION.LEGACY_UPGRADE_LOCK}:${fingerprint}` as const;
+    const claimed = await withSysReadDeadline(
+      sysRedis.set(key as never, '1', { NX: true, EX: LEGACY_UPGRADE_WINDOW_SECONDS })
+    );
+    return claimed !== null;
+  } catch {
+    // Fail OPEN: a sysRedis blip must not block migration off the legacy cookie. The pre-existing behaviour
+    // was to upgrade on every request, so degrading to that is not a regression.
+    return true;
+  }
+}
+
 /**
  * Upgrade-on-read (migration window): when a request authenticated via the LEGACY next-auth cookie, ask the hub
  * to exchange that cookie for a fresh civ-token and set it on this response — so the legacy user migrates to the
@@ -103,6 +130,10 @@ export async function maybeUpgradeLegacySession(
   host?: string
 ): Promise<void> {
   if (!HUB_ORIGIN || !legacyToken || typeof res.setHeader !== 'function') return;
+  if (!(await claimLegacyUpgrade(legacyToken))) {
+    observeLegacyUpgrade('deduped');
+    return;
+  }
   try {
     // Forward any existing civ-device so the hub reuses this browser's device set; for a pure legacy user (no
     // civ-device yet) the hub mints one and returns it. Without this, the upgraded session had NO civ-device

--- a/src/server/auth/session-metrics.ts
+++ b/src/server/auth/session-metrics.ts
@@ -89,7 +89,7 @@ export function observeLegacyDecode(): void {
   legacyDecodeCounter.inc();
 }
 
-export type LegacyUpgradeOutcome = 'minted' | 'no-token' | 'failed';
+export type LegacyUpgradeOutcome = 'minted' | 'deduped' | 'no-token' | 'failed';
 
 const legacyUpgradeCounter = registerCounterWithLabels({
   name: 'session_legacy_upgrade_total',


### PR DESCRIPTION
The growth driver behind the whole session-token incident. Last piece of the audit.

## The bug

`maybeUpgradeLegacySession` mints a **new `jti` on every request** that authenticates via a legacy next-auth cookie. No age gate, no dedupe, no rate limit — and the only thing that ever stopped it repeating was the client persisting the `civ-token` we set in the response.

Compare `maybeRollHubCookie` thirty lines above: age-gated on `AUTH_SESSION_UPDATE_AGE` **and** jti-preserving. The legacy path has neither. That asymmetry is the bug.

A legacy cookie is a self-contained next-auth JWT with no server state to consume, so any client that doesn't persist `Set-Cookie` — a scripted integration, a cookie-less HTTP client, a scraper reusing one config — minted and tracked one token per request until that JWT expired.

Exact mechanical fit for the observed histograms: one account at ~287 tokens/day for fifteen consecutive days (a request every five minutes); another at 44k over two days (~15/min, then its cookie aged out); the largest at 53,877 with **zero API keys and no OAuth rows**, so cookie replay was its only route.

## The fix

`SET NX` with a TTL, keyed on `sha256(legacyToken)`, value `'1'`. Losing the race skips the hub call entirely.

**Skipping is safe**: the caller has *already* resolved this request's session from the legacy decode, so a skipped upgrade costs the user nothing — migration just happens on a later request.

**The marker is not a credential.** Keyed on a hash, stores no value. Nothing about it can be replayed into a session.

## Pre-empting the three things worth challenging

**1. Can the key collide, or be influenced?** No, and this is the one I'd most want to be wrong about. The key is `sha256` of the presented cookie. Two distinct sessions have distinct cookies, hence distinct keys; a collision needs a SHA-256 preimage/collision. Two *different users* can never share a key. And because the marker holds no value, a hit doesn't hand anything to the second request — it only declines to mint. So there's no path to session fixation: the worst case is one client not getting upgraded for up to the window, which is the intended behaviour.

**2. What the fail-open window actually costs.** During a sysRedis blip the dedupe stops and minting returns to one-per-request. Worst observed historical rate was ~22,000/day (~15/min), so a one-hour outage costs ~900 extra tokens on that account. The hash is bounded by the ceiling (#3754) and the write is chunked (#3756), so that is now *bounded work* rather than silent revocation failure — but it is a real cost and it is deliberate. Failing closed on an auth path to bound a hash size trades a login outage for a size problem, which is the wrong direction.

**3. Why the window does NOT need the `AUTH_SESSION_UPDATE_AGE` clamp treatment.** #3754 couples the eviction floor to the refresh interval, enforced rather than documented, because that floor's *correctness* depends on outlasting the interval. This window is different in kind: it bounds how often a cookie may be re-upgraded. Its correctness doesn't depend on the refresh cadence — a shorter or longer `AUTH_SESSION_UPDATE_AGE` changes neither what it protects nor whether it protects it. So it stays an independent constant, on purpose, and this paragraph is the reason rather than an oversight.

## Also here: the ban gate on this path only

Refuses the upgrade for a banned or deleted account. **Deliberately not symmetric with interactive login**, and the asymmetry is pinned by test rather than only commented: this path is silent and repeats every request, so a banned automated client otherwise keeps minting and keeps growing the very hash a ban has to walk. Interactive login still issues a session — a banned user needs one to be shown why they were banned and to appeal.

An earlier version of this put the gate in `mintUserSession`, which would have broken the ban screen and the appeal flow for everyone. Backed out.

## Verification

- `pnpm typecheck` — 0 errors; ESLint clean on changed files
- `app:auth` 358 pass / 0 fail (incl. 3 new ban-gate tests); `src/server/auth` 93 pass / 0 fail
- Full unit project: 13,668 pass, **16 failed — identical to the clean-tree baseline** (6 files, all pre-existing)
- **Mutation-tested**: stub the dedupe guard to always proceed → 2 of the 3 dedupe tests fail; the survivor is the fail-open case, which correctly still passes

## Falsification, stated up front

The dedupe keys on the presented cookie, so it only works when a client re-presents the **same** cookie — which is the inferred shape. If a client instead re-logs-in for a fresh legacy cookie each time, every request has a distinct hash and this is a no-op. The signature of that is per-account mint rate staying high in the `legacy-session-upgraded` Axiom event after this ships, and `session_legacy_upgrade_total{outcome}` showing `minted` rather than `deduped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)