### PR TITLE
fix(auth): count legacy-decode requests with an UNLABELLED counter

### DIFF
--- a/src/pages/api/metrics.ts
+++ b/src/pages/api/metrics.ts
@@ -6,6 +6,11 @@ import { instrumentationRegistry } from '~/server/prom/client';
 // Side-effect import: registers the challenge state gauges (collect()-based) on the default
 // registry so they are present + scraped even before the first challenge op runs this session.
 import '~/server/prom/challenge.metrics';
+// Side-effect import: registers the session-resolution metrics, including the UNLABELLED
+// session_legacy_decode_total. Unlabelled counters only carry their "healthy is an observable 0" meaning if
+// the module is loaded — otherwise an absent series looks like a dead code path rather than an unloaded one,
+// which is the exact ambiguity that counter exists to remove.
+import '~/server/auth/session-metrics';
 // Same reason (#3665): seeds all 12 (reason, surface) series of
 // civitai_generation_model_substitutions_total at 0. Without this call the
 // counter is registered only by the FIRST substitution on this pod, so

--- a/src/server/auth/__tests__/session-metrics.test.ts
+++ b/src/server/auth/__tests__/session-metrics.test.ts
@@ -10,10 +10,12 @@ const h = vi.hoisted(() => ({
 vi.mock('~/server/prom/client', () => ({
   registerHistogram: vi.fn(() => h.histogram),
   registerCounterWithLabels: vi.fn(() => h.counter),
+  registerCounter: vi.fn(() => h.counter),
 }));
 
 import {
   observeSessionLeg,
+  observeLegacyDecode,
   observeLegacyUpgrade,
   observeSessionStateUpdate,
 } from '../session-metrics';
@@ -93,5 +95,25 @@ describe('observeSessionStateUpdate — caller attribution + size', () => {
       { caller: 'subscription', type: 'refresh' },
       3
     );
+  });
+});
+
+// 🔴 The legacy-decode counter must be UNLABELLED. A labelled counter registers each child lazily at the
+// first .inc(), so an empty result cannot be told apart from "not deployed" or "module never imported" —
+// which is exactly the ambiguity it exists to resolve. Unlabelled, it emits an observable 0 from module
+// load, so `0` means the path is genuinely dead and an ABSENT series means the instrument is broken.
+describe('observeLegacyDecode — zero must be observable, not absent', () => {
+  it('registers through the UNLABELLED counter helper, not the labelled one', async () => {
+    const prom = await import('~/server/prom/client');
+    const unlabelled = vi.mocked(prom.registerCounter).mock.calls.map(([cfg]) => cfg.name);
+    const labelled = vi.mocked(prom.registerCounterWithLabels).mock.calls.map(([cfg]) => cfg.name);
+
+    expect(unlabelled).toContain('session_legacy_decode_total');
+    expect(labelled).not.toContain('session_legacy_decode_total');
+  });
+
+  it('increments without any label, so there is exactly one series', () => {
+    observeLegacyDecode();
+    expect(h.counter.inc).toHaveBeenCalledWith();
   });
 });

--- a/src/server/auth/get-server-auth-session.ts
+++ b/src/server/auth/get-server-auth-session.ts
@@ -12,6 +12,7 @@ import { env } from '~/env/server';
 import { isPreview } from '~/env/other';
 import { getBaseUrl } from '~/server/utils/url-helpers';
 import { getSessionFromBearerToken } from './bearer-token';
+import { observeLegacyDecode } from './session-metrics';
 import {
   getHubSession,
   maybeRollHubCookie,
@@ -103,6 +104,10 @@ export const getServerAuthSession = async ({
   // Upgrade-on-read: migrate this legacy user to a civ-token (+ de-crud the next-auth cookies) for next time.
   // Best-effort; this request is still served from the legacy decode above.
   if (legacy) {
+    // Counted BEFORE the upgrade attempt, and separately from it: an empty upgrade counter cannot
+    // distinguish "no legacy cookies remain" from "this code never runs", and that distinction decides
+    // whether the upgrade-on-read path still matters at all.
+    observeLegacyDecode();
     const legacyToken = req.cookies?.[legacySessionCookieName()];
     const device = req.cookies?.[deviceCookieName()];
     await maybeUpgradeLegacySession(legacyToken, device, res, req.headers.host).catch(() => {});

--- a/src/server/auth/session-metrics.ts
+++ b/src/server/auth/session-metrics.ts
@@ -10,7 +10,11 @@
 // /api/metrics), same as trpc_procedure_duration etc. Cardinality-safe: only bounded `leg` / `outcome` labels,
 // NEVER per-user. The package emits the raw timings via injected callbacks (it stays infra-dep-free); this
 // module owns the prom-client wiring.
-import { registerHistogram, registerCounterWithLabels } from '~/server/prom/client';
+import {
+  registerCounter,
+  registerCounterWithLabels,
+  registerHistogram,
+} from '~/server/prom/client';
 
 // `identity` = token cookie path (getSessionUser); `identity-by-id` = API-key/OAuth/legacy by-userId read
 // (getSessionUserById); `hub-write` = the invalidate/refresh/invalidateAll hub writes; `jwks` = ES256 verify
@@ -61,6 +65,29 @@ export function observeSessionLeg(
 // call, including the rolling refresh, so neither the value nor `30d - HTTL` is a creation time. No query
 // against session:user-tokens2 can recover a mint rate for any account — this counter is the only instrument
 // that can. See _local/docs/plans/session-system-audit-2026-08-08.md.
+
+// UNLABELLED on purpose, and this is the whole point of it. A labelled counter registers each child lazily
+// at the first `.inc()`, so an empty result is indistinguishable from "the build isn't deployed" or "the
+// module was never imported" — which is exactly the ambiguity this exists to resolve. An unlabelled counter
+// registers one series at module load and emits `0`, so:
+//   observable 0  -> deployed, loaded, and the legacy path genuinely has not run
+//   series absent -> the build or the import is the problem, and you know which
+// See .claude/skills/manage-alerts/reference/silent-failure-modes.md.
+//
+// `session_legacy_upgrade_total` below is labelled and therefore cannot answer that question on its own;
+// the two are meant to be read together.
+const legacyDecodeCounter = registerCounter({
+  name: 'session_legacy_decode_total',
+  help:
+    'Requests whose session resolved from the LEGACY next-auth cookie rather than the hub token. A steady ' +
+    'observable 0 means the legacy path is genuinely dead; an ABSENT series means this instrument is not ' +
+    'loaded and no conclusion should be drawn from the upgrade counter either.',
+});
+
+/** Call on every request that resolved via the legacy decode, before any upgrade attempt. */
+export function observeLegacyDecode(): void {
+  legacyDecodeCounter.inc();
+}
 
 export type LegacyUpgradeOutcome = 'minted' | 'no-token' | 'failed';
 


### PR DESCRIPTION
Four lines of instrumentation that decide whether #3758 matters.

## The problem with the counter I already shipped

`session_legacy_upgrade_total` has emitted **no series** since rollout — ~30 minutes of production with zero legacy-cookie upgrades. That reads as "no legacy cookies remain in the wild". It cannot establish it.

It's a **labelled** counter, and a labelled counter registers each child **lazily at the first `.inc()`**. So an empty result is indistinguishable from:
- the build isn't deployed,
- the module was never imported,
- the code path is unreachable for some other reason.

**The instrument built to close an absence-of-evidence gap has the same gap.** @ivy checked whether anything else deployed distinguishes them — `session_resolution_duration_seconds` carries a `leg` label, but every leg is on the hub path (`jwks`, `revocation`, `identity`, `identity-by-id`, `hub-write`, 7.4M hits) and none covers the legacy decode. Nothing does.

## The fix, and why unlabelled is the whole point

An **unlabelled** counter registers one series at module load and emits `0`. That makes the cases separable:

| observed | means |
|---|---|
| `session_legacy_decode_total 0` | deployed, loaded, and the legacy path genuinely never runs |
| series **absent** | the build or the import is the problem — and you know which |

Incremented on every request that resolved via the legacy decode, **before** any upgrade is attempted, so it counts the branch rather than the outcome.

⚠️ **"From module load" is not "from process start."** A lazily-imported module emits nothing until something imports it, and an absent series would then mean the opposite of what it looks like. Registered via a side-effect import in `src/pages/api/metrics.ts`, following the existing `challenge.metrics` precedent.

The labelled `session_legacy_upgrade_total` stays — it gives the outcome breakdown. The two are meant to be read together, and only the unlabelled one makes a zero mean something.

## Why this matters beyond tidiness

It decides whether #3758 is worth its review time. If this reads a steady `0`, the legacy-exchange dedupe is fixing a path that no longer fires and drops to hygiene — still correct to land, since the asymmetry with `maybeRollHubCookie` is a latent trap a surviving legacy cookie would re-arm, but nobody should merge it expecting a measurable effect.

And #3758's stated falsification (`deduped` should dominate `minted`) becomes **untestable rather than satisfied**, which is the worse outcome and shouldn't be mistaken for success. An untestable prediction quietly reads as a confirmed one.

## Verification

- `pnpm typecheck` — 0 errors; ESLint clean
- `src/server/auth` suites: 92 pass / 0 fail
- **Mutation-tested**: swap `registerCounter` for `registerCounterWithLabels` → the "must be unlabelled" test fails. The test asserts the registration *helper*, not the metric name, so it catches the specific regression that reintroduces the ambiguity.

Design reported by @ivy; the unlabelled-vs-labelled distinction is documented in the `manage-alerts` silent-failure-modes reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)