### PR TITLE
feat(observability): capture a CPU profile of the wedged main thread

### DIFF
--- a/src/server/__tests__/eventloop-watchdog.capture.test.ts
+++ b/src/server/__tests__/eventloop-watchdog.capture.test.ts
@@ -1,0 +1,185 @@
+import { Worker } from 'node:worker_threads';
+import nodeCrypto from 'node:crypto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { WATCHDOG_WORKER_SOURCE, resolveCaptureConfig } from '~/server/eventloop-watchdog';
+
+// The capture half of the worker. Like the detector suite, this drives the REAL
+// inlined source rather than a TypeScript stand-in, because the source is neither
+// type-checked nor linted and that is the only way it gets exercised.
+
+const ENV_KEYS = [
+  'EVENTLOOP_WATCHDOG_CAPTURE_ENABLED',
+  'EVENTLOOP_WATCHDOG_CAPTURE_MS',
+  'EVENTLOOP_WATCHDOG_CAPTURE_INTERVAL_US',
+  'EVENTLOOP_WATCHDOG_CAPTURE_MAX_PER_HOUR',
+  'CPU_PROFILE_S3_KEY_PREFIX',
+] as const;
+let saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  saved = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  for (const k of ENV_KEYS) delete process.env[k];
+  vi.resetModules();
+});
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+describe('capture config', () => {
+  it('is disarmed unless explicitly enabled, independently of the detector', async () => {
+    // Detection is cheap and safe everywhere; capture opens an inspector, drives CDP
+    // and uploads. They must be separate gates or enabling the watchdog silently
+    // enables the expensive half.
+    const { resolveCaptureConfig: resolve } = await import('~/server/eventloop-watchdog');
+    expect(resolve().enabled).toBe(false);
+
+    process.env.EVENTLOOP_WATCHDOG_CAPTURE_ENABLED = 'true';
+    expect((await import('~/server/eventloop-watchdog')).resolveCaptureConfig().enabled).toBe(true);
+  });
+
+  it('clamps duration and sampling interval rather than trusting them', () => {
+    process.env.EVENTLOOP_WATCHDOG_CAPTURE_MS = '999999';
+    expect(resolveCaptureConfig().captureMs).toBe(30_000);
+    process.env.EVENTLOOP_WATCHDOG_CAPTURE_MS = '1';
+    expect(resolveCaptureConfig().captureMs).toBe(1000);
+
+    // 100Hz default. The old in-process path sampled at 1kHz and produced 41-46MB
+    // profiles on SSR, which is why the default is not the V8 default.
+    delete process.env.EVENTLOOP_WATCHDOG_CAPTURE_INTERVAL_US;
+    expect(resolveCaptureConfig().samplingIntervalUs).toBe(10_000);
+  });
+
+  it('defaults the key prefix and carries pool/pod/imageTag for the object key', () => {
+    const cfg = resolveCaptureConfig();
+    expect(cfg.keyPrefix).toBe('cpu-profiles/');
+    expect(cfg).toMatchObject({
+      pool: expect.any(String),
+      pod: expect.any(String),
+      imageTag: expect.any(String),
+    });
+  });
+});
+
+/**
+ * Pull the signer out of the inlined worker source and evaluate it in isolation.
+ * Sliced between markers rather than duplicated, so the test cannot drift from the
+ * code it checks — if the markers move the slice fails loudly instead of testing a
+ * stale copy.
+ */
+function loadSigner() {
+  const from = WATCHDOG_WORKER_SOURCE.indexOf('function hmac(');
+  const to = WATCHDOG_WORKER_SOURCE.indexOf('function putObject(');
+  expect(from, 'signer start marker not found in worker source').toBeGreaterThan(-1);
+  expect(to, 'signer end marker not found in worker source').toBeGreaterThan(from);
+  const src = WATCHDOG_WORKER_SOURCE.slice(from, to);
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  return new Function('crypto', `${src}; return signPut;`)(nodeCrypto) as (opts: {
+    now: Date;
+    host: string;
+    path: string;
+    region: string;
+    accessKeyId: string;
+    secretKey: string;
+    body: Buffer;
+  }) => { amzDate: string; payloadHash: string; authorization: string };
+}
+
+describe('SigV4 signer', () => {
+  const base = {
+    now: new Date('2013-05-24T00:00:00Z'),
+    host: 'examplebucket.s3.amazonaws.com',
+    path: '/examplebucket/test.txt',
+    region: 'us-east-1',
+    accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+    secretKey: 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY',
+    body: Buffer.from('Welcome to Amazon S3.'),
+  };
+
+  it('produces the documented AWS wire format', () => {
+    const signPut = loadSigner();
+    const { amzDate, payloadHash, authorization } = signPut(base);
+
+    expect(amzDate).toBe('20130524T000000Z');
+    // sha256 of the body, which AWS's own PUT example publishes.
+    expect(payloadHash).toBe('44ce7dd67c959e0d3524ffac1771dfbba87d2b6b4b4e99e42034a8b803f8b072');
+    expect(authorization).toMatch(
+      /^AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE\/20130524\/us-east-1\/s3\/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=[0-9a-f]{64}$/
+    );
+  });
+
+  it('is deterministic, and every input actually participates', () => {
+    // A signer that ignores an input is the failure that looks fine until the server
+    // rejects it — and the rejection is a 403 with no detail.
+    const signPut = loadSigner();
+    const sig = (o: Partial<typeof base>) =>
+      signPut({ ...base, ...o }).authorization.split('Signature=')[1];
+
+    expect(sig({})).toBe(sig({}));
+    for (const [label, mutation] of [
+      ['secret', { secretKey: base.secretKey + 'x' }],
+      ['region', { region: 'eu-west-1' }],
+      ['path', { path: '/examplebucket/other.txt' }],
+      ['host', { host: 'other.example.com' }],
+      ['body', { body: Buffer.from('different') }],
+      ['date', { now: new Date('2013-05-25T00:00:00Z') }],
+    ] as const) {
+      expect(sig(mutation), `${label} does not affect the signature`).not.toBe(sig({}));
+    }
+  });
+});
+
+describe('capture metrics', () => {
+  it('exposes every capture series even before anything is captured', async () => {
+    // Absent and zero mean different things to an alert. A pool with capture armed
+    // and nothing yet captured must read 0, not no-series.
+    const sab = new SharedArrayBuffer(8);
+    Atomics.store(new BigInt64Array(sab), 0, BigInt(Date.now()));
+
+    const worker = new Worker(WATCHDOG_WORKER_SOURCE, {
+      eval: true,
+      workerData: {
+        sab,
+        thresholdMs: 1000,
+        port: 0,
+        // Non-empty: the worker fails closed and exits 78 without a token, so an empty
+        // one here would never reach the metrics path at all.
+        token: 'capture-test-token',
+        heartbeatIntervalMs: 100,
+        pollMs: 50,
+        cap: { ...resolveCaptureConfig(), enabled: false },
+        s3: {},
+      },
+    });
+
+    const port = await new Promise<number>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('never listened')), 10_000);
+      worker.on('message', (m: { type?: string; port?: number }) => {
+        if (m?.type === 'listening' && m.port) {
+          clearTimeout(timer);
+          resolve(m.port);
+        }
+      });
+      worker.on('error', reject);
+    });
+
+    const body = await (
+      await fetch(`http://127.0.0.1:${port}/metrics?token=capture-test-token`)
+    ).text();
+    await worker.terminate();
+
+    for (const series of [
+      'civitai_app_watchdog_capture_total{result="ok"} 0',
+      'civitai_app_watchdog_capture_total{result="error"} 0',
+      'civitai_app_watchdog_capture_total{result="skipped-backoff"} 0',
+      'civitai_app_watchdog_capture_total{result="skipped-hourly-cap"} 0',
+      'civitai_app_watchdog_upload_total{result="ok"} 0',
+      'civitai_app_watchdog_upload_bytes_total 0',
+      'civitai_app_watchdog_last_capture_timestamp_seconds 0',
+    ]) {
+      expect(body, series).toContain(series);
+    }
+  });
+});

--- a/src/server/eventloop-watchdog.ts
+++ b/src/server/eventloop-watchdog.ts
@@ -206,17 +206,316 @@ function workerExitsCounter() {
 const EXIT_CODE_NO_TOKEN = 78;
 
 /**
+ * Wedge capture, appended to the worker source below.
+ *
+ * WHY THE INSPECTOR SERVER AND NOT connectToMainThread(): the two paths behave
+ * differently against a pinned loop, and the difference decides the design.
+ * `connectToMainThread()` is an in-process channel whose `Profiler.enable`/`start`
+ * need main-thread dispatch — measured, they return nothing useful when the loop is
+ * already blocked (2 samples, top frame anonymous), and against a partially-saturated
+ * loop `enable` never settles at all. The inspector SERVER runs on its own thread:
+ * arming 8s into a 20s pin gave enable 1ms / start 11ms / stop 2ms and 5,677 samples
+ * with 97.3% on the pinning frame, verified in a production pod on Node 24.19.
+ *
+ * So the trigger fires SIGUSR1 from this thread, which opens the inspector without
+ * the main thread's help, and drives CDP over loopback.
+ *
+ * 🔴 NOTHING HERE MAY REPORT VIA parentPort.postMessage. That queue is drained by the
+ * main thread, so during a wedge every message buffers until recovery and is lost if
+ * the pod dies first — the reporting path would share the resource being blocked,
+ * which is the exact failure this project exists to end. Capture results go into the
+ * counters served on the worker's own port, and the profile goes straight out over
+ * the worker's own socket.
+ *
+ * `inspector.close()` is main-thread-only, so the port stays open on loopback until
+ * the loop recovers. Bounded to the incident and loopback-only, but real.
+ */
+const WATCHDOG_CAPTURE_SOURCE = String.raw`
+const zlib = require('node:zlib');
+const https = require('node:https');
+const nodeUrl = require('node:url');
+
+// Defaulted, not required: a malformed or absent capture config must never stop the
+// DETECTOR from running. Capture is the optional half, and the detector is not.
+const capCfg =
+  cap && typeof cap === 'object'
+    ? cap
+    : { enabled: false, backoffStartMs: 300000, backoffMaxMs: 3600000, maxPerHour: 0 };
+const s3Cfg = s3 && typeof s3 === 'object' ? s3 : {};
+
+let captureInFlight = false;
+let captureBackoffUntil = 0;
+let captureBackoffMs = capCfg.backoffStartMs;
+let capturesThisHour = 0;
+let capturesHourStart = Date.now();
+const captureResults = Object.create(null);
+const uploadResults = Object.create(null);
+let uploadBytes = 0;
+let lastCaptureAt = 0;
+
+function tallyCapture(result) {
+  captureResults[result] = (captureResults[result] || 0) + 1;
+}
+function tallyUpload(result) {
+  uploadResults[result] = (uploadResults[result] || 0) + 1;
+}
+
+function hmac(key, data) {
+  return crypto.createHmac('sha256', key).update(data, 'utf8').digest();
+}
+function sha256Hex(data) {
+  return crypto.createHash('sha256').update(data).digest('hex');
+}
+
+// Minimal SigV4 for a single S3 PUT. Hand-rolled because the worker may not import a
+// bare specifier: an eval'd worker in the standalone image has no reliable module
+// resolution, which is the same reason the source is inlined at all.
+function signPut(opts) {
+  const amzDate = opts.now.toISOString().replace(/[:-]|\.\d{3}/g, '');
+  const dateStamp = amzDate.slice(0, 8);
+  const payloadHash = sha256Hex(opts.body);
+  const canonicalHeaders =
+    'host:' + opts.host + '\n' +
+    'x-amz-content-sha256:' + payloadHash + '\n' +
+    'x-amz-date:' + amzDate + '\n';
+  const signedHeaders = 'host;x-amz-content-sha256;x-amz-date';
+  const canonicalRequest = [
+    'PUT',
+    opts.path,
+    '',
+    canonicalHeaders,
+    signedHeaders,
+    payloadHash,
+  ].join('\n');
+  const scope = dateStamp + '/' + opts.region + '/s3/aws4_request';
+  const stringToSign = [
+    'AWS4-HMAC-SHA256',
+    amzDate,
+    scope,
+    sha256Hex(canonicalRequest),
+  ].join('\n');
+  const signingKey = hmac(hmac(hmac(hmac('AWS4' + opts.secretKey, dateStamp), opts.region), 's3'), 'aws4_request');
+  const signature = crypto.createHmac('sha256', signingKey).update(stringToSign, 'utf8').digest('hex');
+  return {
+    amzDate: amzDate,
+    payloadHash: payloadHash,
+    authorization:
+      'AWS4-HMAC-SHA256 Credential=' + opts.accessKeyId + '/' + scope +
+      ', SignedHeaders=' + signedHeaders + ', Signature=' + signature,
+  };
+}
+
+function putObject(key, body) {
+  return new Promise(function (resolve) {
+    let parsed;
+    try {
+      parsed = new nodeUrl.URL(s3Cfg.endpoint);
+    } catch (err) {
+      return resolve({ ok: false, reason: 'bad-endpoint' });
+    }
+    const path = '/' + s3Cfg.bucket + '/' + key;
+    const signed = signPut({
+      now: new Date(),
+      host: parsed.host,
+      path: path,
+      region: s3Cfg.region,
+      accessKeyId: s3Cfg.accessKeyId,
+      secretKey: s3Cfg.secretKey,
+      body: body,
+    });
+    const mod = parsed.protocol === 'https:' ? https : http;
+    const req = mod.request(
+      {
+        method: 'PUT',
+        hostname: parsed.hostname,
+        port: parsed.port || (parsed.protocol === 'https:' ? 443 : 80),
+        path: path,
+        headers: {
+          host: parsed.host,
+          'x-amz-date': signed.amzDate,
+          'x-amz-content-sha256': signed.payloadHash,
+          authorization: signed.authorization,
+          'content-length': body.length,
+          'content-type': 'application/gzip',
+        },
+        timeout: capCfg.uploadTimeoutMs,
+      },
+      function (res) {
+        res.resume();
+        res.on('end', function () {
+          resolve(
+            res.statusCode >= 200 && res.statusCode < 300
+              ? { ok: true }
+              : { ok: false, reason: 'http-' + res.statusCode }
+          );
+        });
+      }
+    );
+    req.on('timeout', function () {
+      req.destroy();
+      resolve({ ok: false, reason: 'timeout' });
+    });
+    req.on('error', function () {
+      resolve({ ok: false, reason: 'network' });
+    });
+    req.end(body);
+  });
+}
+
+function cdp(ws, method, params) {
+  return new Promise(function (resolve, reject) {
+    const id = ws.__nextId++;
+    ws.__pending.set(id, resolve);
+    const timer = setTimeout(function () {
+      ws.__pending.delete(id);
+      reject(new Error('cdp timeout: ' + method));
+    }, capCfg.cdpTimeoutMs);
+    ws.__timers.set(id, timer);
+    ws.send(JSON.stringify({ id: id, method: method, params: params }));
+  });
+}
+
+function openInspectorSocket() {
+  return new Promise(function (resolve, reject) {
+    // SIGUSR1 is handled off the main thread, so this opens the inspector even while
+    // the loop is pinned. It is the only reason a trigger-on-detection design works
+    // at all.
+    try {
+      process.kill(process.pid, 'SIGUSR1');
+    } catch (err) {
+      return reject(new Error('sigusr1 failed: ' + err.message));
+    }
+    const deadline = Date.now() + capCfg.inspectorWaitMs;
+    (function attempt() {
+      fetch('http://127.0.0.1:' + capCfg.inspectorPort + '/json/list')
+        .then(function (r) { return r.json(); })
+        .then(function (list) {
+          const target = list && list[0] && list[0].webSocketDebuggerUrl;
+          if (!target) throw new Error('no debugger target');
+          const ws = new WebSocket(target);
+          ws.__nextId = 1;
+          ws.__pending = new Map();
+          ws.__timers = new Map();
+          ws.onmessage = function (ev) {
+            let msg;
+            try { msg = JSON.parse(ev.data); } catch (err) { return; }
+            if (msg.id && ws.__pending.has(msg.id)) {
+              clearTimeout(ws.__timers.get(msg.id));
+              ws.__timers.delete(msg.id);
+              const fn = ws.__pending.get(msg.id);
+              ws.__pending.delete(msg.id);
+              fn(msg.result);
+            }
+          };
+          ws.onopen = function () { resolve(ws); };
+          ws.onerror = function () { reject(new Error('websocket failed')); };
+        })
+        .catch(function (err) {
+          if (Date.now() > deadline) return reject(err);
+          setTimeout(attempt, 100);
+        });
+    })();
+  });
+}
+
+function captureAllowed(now) {
+  if (!capCfg.enabled) return 'disabled';
+  if (captureInFlight) return 'in-flight';
+  if (now < captureBackoffUntil) return 'backoff';
+  if (now - capturesHourStart >= 3600000) {
+    capturesHourStart = now;
+    capturesThisHour = 0;
+  }
+  if (capturesThisHour >= capCfg.maxPerHour) return 'hourly-cap';
+  return 'ok';
+}
+
+async function captureWedge(wedgeStartMs) {
+  captureInFlight = true;
+  capturesThisHour++;
+  let ws;
+  try {
+    ws = await openInspectorSocket();
+    await cdp(ws, 'Profiler.enable');
+    await cdp(ws, 'Profiler.setSamplingInterval', { interval: capCfg.samplingIntervalUs });
+    await cdp(ws, 'Profiler.start');
+    await new Promise(function (r) { setTimeout(r, capCfg.captureMs); });
+    const stopped = await cdp(ws, 'Profiler.stop');
+    const wedgeMs = Math.round(Date.now() - wedgeStartMs);
+    const body = zlib.gzipSync(Buffer.from(JSON.stringify(stopped.profile)));
+    // The image tag here is the RUNTIME tag. The published source-map artifact shares
+    // its sha but carries a different timestamp, so a resolver keyed on the whole tag
+    // 404s — resolve maps by sha.
+    const key =
+      capCfg.keyPrefix + capCfg.pool + '/' + capCfg.pod + '/' +
+      new Date().toISOString().replace(/[:.]/g, '-') + '-' + wedgeMs + 'ms-' + capCfg.imageTag +
+      '.cpuprofile.gz';
+    tallyCapture('ok');
+    lastCaptureAt = Date.now();
+    const put = await putObject(key, body);
+    if (put.ok) {
+      tallyUpload('ok');
+      uploadBytes += body.length;
+    } else {
+      tallyUpload(put.reason);
+    }
+  } catch (err) {
+    tallyCapture('error');
+  } finally {
+    if (ws) { try { ws.close(); } catch (err) { /* already gone */ } }
+    captureInFlight = false;
+    // Exponential, per pod. A sustained wave would otherwise capture the same stack
+    // repeatedly and upload near-identical multi-MB artifacts.
+    captureBackoffUntil = Date.now() + captureBackoffMs;
+    captureBackoffMs = Math.min(captureBackoffMs * 2, capCfg.backoffMaxMs);
+  }
+}
+
+function maybeCaptureWedge(wedgeStartMs) {
+  const verdict = captureAllowed(Date.now());
+  if (verdict !== 'ok') {
+    if (verdict !== 'disabled') tallyCapture('skipped-' + verdict);
+    return;
+  }
+  captureWedge(wedgeStartMs);
+}
+
+function renderCaptureMetrics(out) {
+  out.push('# HELP civitai_app_watchdog_capture_total Wedge CPU-profile captures attempted, by result. skipped-* results mean the trigger fired but was refused by backoff or the hourly capCfg.');
+  out.push('# TYPE civitai_app_watchdog_capture_total counter');
+  const captureKeys = ['ok', 'error', 'skipped-in-flight', 'skipped-backoff', 'skipped-hourly-cap'];
+  for (const k of captureKeys) {
+    out.push('civitai_app_watchdog_capture_total{result="' + k + '"} ' + (captureResults[k] || 0));
+  }
+  out.push('# HELP civitai_app_watchdog_upload_total Profile uploads attempted, by result.');
+  out.push('# TYPE civitai_app_watchdog_upload_total counter');
+  const uploadKeys = Object.keys(uploadResults);
+  if (uploadKeys.indexOf('ok') === -1) uploadKeys.push('ok');
+  for (const k of uploadKeys) {
+    out.push('civitai_app_watchdog_upload_total{result="' + k + '"} ' + (uploadResults[k] || 0));
+  }
+  out.push('# HELP civitai_app_watchdog_upload_bytes_total Compressed profile bytes uploaded.');
+  out.push('# TYPE civitai_app_watchdog_upload_bytes_total counter');
+  out.push('civitai_app_watchdog_upload_bytes_total ' + uploadBytes);
+  out.push('# HELP civitai_app_watchdog_last_capture_timestamp_seconds Unix time of the last successful capture, 0 if none.');
+  out.push('# TYPE civitai_app_watchdog_last_capture_timestamp_seconds gauge');
+  out.push('civitai_app_watchdog_last_capture_timestamp_seconds ' + Math.floor(lastCaptureAt / 1000));
+}
+`;
+
+/**
  * The worker runs as CommonJS (`eval: true` does not imply ESM) and imports nothing
  * but node: builtins — no prom-client, so there is no bare-specifier resolution to
  * go wrong inside an eval'd worker in the standalone image. The Prometheus text is
  * hand-formatted for the same reason.
  */
-export const WATCHDOG_WORKER_SOURCE = String.raw`
+export const WATCHDOG_WORKER_SOURCE =
+  String.raw`
 const { workerData, parentPort } = require('node:worker_threads');
 const http = require('node:http');
 const crypto = require('node:crypto');
 
-const { sab, thresholdMs, port, token, heartbeatIntervalMs, pollMs } = workerData;
+const { sab, thresholdMs, port, token, heartbeatIntervalMs, pollMs, cap, s3 } = workerData;
 const beat = new BigInt64Array(sab);
 
 const BUCKETS = [1, 2, 5, 10, 30, 60, 120, 300, 600];
@@ -248,7 +547,12 @@ setInterval(function () {
   if (wedgeStartedAt === 0) {
     // Date the wedge from the last beat, not from detection, so the reported
     // duration does not silently exclude the threshold.
-    if (age >= thresholdMs) wedgeStartedAt = lastBeat;
+    if (age >= thresholdMs) {
+      wedgeStartedAt = lastBeat;
+      // Fire-and-forget: the capture must not delay the next poll, or the worker
+      // stops being able to report the wedge it is capturing.
+      maybeCaptureWedge(wedgeStartedAt);
+    }
   } else if (age < thresholdMs) {
     observeWedge((now - wedgeStartedAt) / 1000);
     wedgeStartedAt = 0;
@@ -287,6 +591,8 @@ function render() {
   out.push('civitai_app_watchdog_wedge_duration_seconds_bucket{le="+Inf"} ' + wedgeCount);
   out.push('civitai_app_watchdog_wedge_duration_seconds_sum ' + wedgeSumSeconds);
   out.push('civitai_app_watchdog_wedge_duration_seconds_count ' + wedgeCount);
+
+  renderCaptureMetrics(out);
 
   return out.join('\n') + '\n';
 }
@@ -364,7 +670,60 @@ if (parentPort) {
     }
   });
 }
-`;
+` + WATCHDOG_CAPTURE_SOURCE;
+
+/**
+ * Capture is a SEPARATE gate from the watchdog itself. Detection is cheap and safe to
+ * run everywhere; capture opens an inspector, drives CDP and uploads, so it stays off
+ * until deliberately turned on per pool.
+ */
+export function resolveCaptureConfig() {
+  const enabled = process.env.EVENTLOOP_WATCHDOG_CAPTURE_ENABLED === 'true';
+  return {
+    enabled,
+    captureMs: clamp(
+      parsePositiveInt(process.env.EVENTLOOP_WATCHDOG_CAPTURE_MS) ?? 10_000,
+      1000,
+      30_000
+    ),
+    // 100Hz, matching the continuous profiler's rate. The old in-process path sampled
+    // at 1kHz and produced 41-46MB profiles on SSR.
+    samplingIntervalUs: clamp(
+      parsePositiveInt(process.env.EVENTLOOP_WATCHDOG_CAPTURE_INTERVAL_US) ?? 10_000,
+      1000,
+      100_000
+    ),
+    maxPerHour: clamp(
+      parsePositiveInt(process.env.EVENTLOOP_WATCHDOG_CAPTURE_MAX_PER_HOUR) ?? 3,
+      1,
+      60
+    ),
+    backoffStartMs: 5 * 60_000,
+    backoffMaxMs: 60 * 60_000,
+    inspectorPort: parsePositiveInt(process.env.EVENTLOOP_WATCHDOG_INSPECTOR_PORT) ?? 9229,
+    inspectorWaitMs: 5000,
+    cdpTimeoutMs: 15_000,
+    uploadTimeoutMs: 30_000,
+    keyPrefix: process.env.CPU_PROFILE_S3_KEY_PREFIX ?? 'cpu-profiles/',
+    pool: process.env.SERVICE_NAME ?? 'unknown',
+    pod: resolvePodName(),
+    imageTag: process.env.APP_VERSION ?? process.env.IMAGE_TAG ?? 'unknown',
+  };
+}
+
+function resolveS3Config() {
+  return {
+    endpoint: process.env.CPU_PROFILE_S3_ENDPOINT ?? '',
+    bucket: process.env.CPU_PROFILE_S3_BUCKET ?? '',
+    region: process.env.CPU_PROFILE_S3_REGION ?? 'us-east-1',
+    accessKeyId: process.env.CPU_PROFILE_S3_ACCESS_KEY_ID ?? '',
+    secretKey: process.env.CPU_PROFILE_S3_SECRET_ACCESS_KEY ?? '',
+  };
+}
+
+function resolvePodName(): string {
+  return process.env.PODNAME ?? process.env.HOSTNAME ?? 'unknown';
+}
 
 let worker: Worker | undefined;
 let sigtermHooked = false;
@@ -414,6 +773,23 @@ export function registerEventLoopWatchdog(): void {
     const thresholdMs = resolveWatchdogThresholdMs();
     const heartbeatIntervalMs = resolveWatchdogHeartbeatMs();
     const port = resolveWatchdogPort();
+    const captureConfig = resolveCaptureConfig();
+
+    // Fail LOUDLY at boot rather than during the first wedge, when nobody is reading
+    // logs for a capture that silently never happened.
+    if (captureConfig.enabled) {
+      const s3 = resolveS3Config();
+      const missing = (['endpoint', 'bucket', 'accessKeyId', 'secretKey'] as const).filter(
+        (k) => !s3[k]
+      );
+      if (missing.length) {
+        console.error(
+          `[eventloop-watchdog] capture is ENABLED but S3 config is incomplete (missing ${missing.join(
+            ', '
+          )}); wedges will be captured and the upload will fail`
+        );
+      }
+    }
 
     recordWatchdogHeartbeat();
 
@@ -428,6 +804,10 @@ export function registerEventLoopWatchdog(): void {
         token: process.env.WEBHOOK_TOKEN ?? '',
         heartbeatIntervalMs,
         pollMs: Math.min(DEFAULT_POLL_MS, heartbeatIntervalMs),
+        // Resolved on the MAIN thread at spawn, so a missing credential is a boot-time
+        // fact rather than something discovered during the first wedge.
+        cap: captureConfig,
+        s3: resolveS3Config(),
       },
       // The watchdog must never be the reason the process stays up.
       stdout: false,


### PR DESCRIPTION
The watchdog (#3752) can count wedges but not explain them. This captures a CPU profile of the main thread **while it is still pinned**, and uploads it.

## Why the existing auto-capture cannot do this

`cpu-profiler.ts`'s `loopstall-*` trigger reads a lag histogram from a `setInterval` — the timer the wedge stops. Of **15 sampled stalls, all 15 captured the calm aftermath**, largest in-window block 6.8–66.2 ms. It only works for a sustained wave: it fires after block *n* and samples *n+1*. Most of what the watchdog is finding is isolated 1–10 s events, so the existing corpus cannot explain them and no amount of arming fixes that.

## Why the inspector server and not `connectToMainThread()`

This is the whole design, and it was decided by measurement after I got it wrong twice.

| path | arming mid-pin | result |
|---|---|---|
| `connectToMainThread()` (in-process, from the worker) | `enable`/`start` need main-thread dispatch | **2 samples, top frame `(anon)`** — and against a *partially* saturated loop, `enable` never settles at all |
| **inspector server** (`SIGUSR1`, driven over loopback) | own thread, no main-thread cooperation | enable 1 ms / start 11 ms / stop 2 ms, **5,677 samples, 97.3% on the pinning frame** |

Three captures now agree at ~97% single-frame across two mechanisms, two machines and two operating systems — one of them a real production wedge. The in-process path is still the only one that could catch wedges too short to arm inside (~69% of them are 1–2 s); that's a separate, larger change and this doesn't foreclose it.

## Nothing here reports through `postMessage`

That queue is drained by the main thread, so during a wedge every message buffers until recovery and is lost if the pod dies first. A reporting path that shares the resource being blocked is the exact failure this project exists to end — found the hard way in the harness that verified this feature, which produced no output at all and looked like a silent failure.

Results go to counters served on the worker's own port. The profile goes straight out over the worker's own socket.

## Bounds

- **10 s** captures at **100 Hz** — the old in-process path sampled at 1 kHz and produced 41–46 MB profiles on SSR
- exponential per-pod backoff, 5 min → 1 h; hard **3/hour** cap
- gzip before the bytes exist on the wire
- **nothing touches disk**, so `CPU_PROFILE_MAX_FILES` and the harvester's load-bearing remote-delete stop being constraints
- capture is a **separate gate** from detection (`EVENTLOOP_WATCHDOG_CAPTURE_ENABLED`, default off). Detection is cheap and safe everywhere; capture opens an inspector and uploads.

**A malformed or absent capture config cannot stop the detector** — the worker defaults it to disabled rather than throwing. My first wiring got this wrong and took 6 of 8 existing worker tests down with it, which is the right way to find out that the optional half must never take the load-bearing half with it.

## SigV4 is hand-rolled, and tested accordingly

The worker is an `eval: true` string and cannot resolve a bare specifier — the same constraint that put the source inline — so `@aws-sdk/client-s3` is unavailable and the signing is ~60 lines on `node:crypto`.

The presigned-URL alternative was rejected for a structural reason: the URL would need periodic refresh from the main thread, which is unavailable during exactly the event being captured. Same boundary as `postMessage`, one layer out.

Tests slice the signer **out of the real worker source** rather than duplicating it, and check the documented AWS wire format plus **a mutation per input** — secret, region, path, host, body, date. A signer that silently ignores one input is a 403 with no detail, which is indistinguishable from a credential problem.

## 🔴 What is NOT verified, and must gate enabling this anywhere

1. **The end-to-end `SIGUSR1` path needs Linux.** Windows cannot deliver it, so I could not run it locally. The mechanism was verified independently in a production pod, but *this code driving it* has not been.
2. **The upload has never reached a real endpoint.** The credential does not exist yet — every app MinIO secret on the cluster is currently the tenant root identity, so a correctly scoped write-only key is being created rather than reused.

Both are preview gates. Default-off means neither blocks merging, but this should not be turned on until both are green.

## Verification that did happen

- **30/30** across the three watchdog suites, including a real spawned worker driven over real HTTP
- full unit suite **16 failed / 13694 passed / 889 files** — the same 16 pre-existing on `main`, verified against a stashed baseline earlier
- typecheck 0 errors, eslint clean, prettier clean

## New metrics

```
civitai_app_watchdog_capture_total{result="ok|error|skipped-in-flight|skipped-backoff|skipped-hourly-cap"}
civitai_app_watchdog_upload_total{result="ok|http-<code>|timeout|network|bad-endpoint"}
civitai_app_watchdog_upload_bytes_total
civitai_app_watchdog_last_capture_timestamp_seconds
```

All seeded so an armed pod reads `0` rather than no-series — absent and zero mean different things to an alert and it cannot tell them apart.

## Object key

```
cpu-profiles/<pool>/<pod>/<iso8601>-<wedgeMs>ms-<imageTag>.cpuprofile.gz
```

The tag is the **runtime** tag. The published source-map artifact shares its sha but carries a different timestamp, so a resolver keyed on the whole tag 404s — resolve maps by sha.
