### PR TITLE
feat(observability): classify wedges as starved or executing, and gate capture on it

### DIFF
--- a/src/server/__tests__/eventloop-watchdog.capture.test.ts
+++ b/src/server/__tests__/eventloop-watchdog.capture.test.ts
@@ -131,6 +131,100 @@ describe('SigV4 signer', () => {
   });
 });
 
+describe('starvation classifier', () => {
+  // The dominant wedge class on this fleet is the main thread being descheduled, not
+  // looping — sliced production captures showed no JS executing during the wedge,
+  // against 2.28s/s of runqueue wait. A profiler cannot see that. CPU-time against
+  // wall-time can, and this proves the two classes actually separate rather than that
+  // the code runs.
+
+  async function runWedge(kind: 'starved' | 'executing') {
+    const sab = new SharedArrayBuffer(8);
+    const beat = new BigInt64Array(sab);
+    Atomics.store(beat, 0, BigInt(Date.now()));
+
+    const worker = new Worker(WATCHDOG_WORKER_SOURCE, {
+      eval: true,
+      workerData: {
+        sab,
+        thresholdMs: 300,
+        port: 0,
+        token: 'classifier-test',
+        heartbeatIntervalMs: 50,
+        pollMs: 25,
+        cap: { ...resolveCaptureConfig(), enabled: false },
+        s3: {},
+        starvedRatio: 0.2,
+      },
+    });
+
+    const port = await new Promise<number>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('never listened')), 10_000);
+      worker.on('message', (m: { type?: string; port?: number }) => {
+        if (m?.type === 'listening' && m.port) {
+          clearTimeout(timer);
+          resolve(m.port);
+        }
+      });
+      worker.on('error', reject);
+    });
+
+    // Withhold beats for 1.5s. In the executing case the MAIN thread burns CPU
+    // throughout, which is what the classifier has to notice; in the starved case it
+    // does nothing, standing in for a descheduled thread.
+    const until = Date.now() + 1500;
+    if (kind === 'executing') {
+      let sink = 0;
+      while (Date.now() < until) sink += Math.sqrt(Math.random());
+      void sink;
+    } else {
+      await new Promise((r) => setTimeout(r, 1500));
+    }
+
+    Atomics.store(beat, 0, BigInt(Date.now()));
+    await new Promise((r) => setTimeout(r, 250));
+
+    const body = await (
+      await fetch(`http://127.0.0.1:${port}/metrics?token=classifier-test`)
+    ).text();
+    await worker.terminate();
+    return body;
+  }
+
+  const read = (body: string, name: string) =>
+    Number(
+      body
+        .split('\n')
+        .find((l) => l.startsWith(`${name} `))
+        ?.slice(name.length + 1)
+    );
+
+  it('🔴 classifies a CPU-burning wedge as executing', async () => {
+    const body = await runWedge('executing');
+    expect(read(body, 'civitai_app_watchdog_wedge_kind_total{kind="executing"}')).toBe(1);
+    expect(read(body, 'civitai_app_watchdog_wedge_kind_total{kind="starved"}')).toBe(0);
+  }, 30_000);
+
+  it('🔴 classifies an idle wedge as starved, and skips the capture', async () => {
+    const body = await runWedge('starved');
+    expect(read(body, 'civitai_app_watchdog_wedge_kind_total{kind="starved"}')).toBe(1);
+    expect(read(body, 'civitai_app_watchdog_wedge_kind_total{kind="executing"}')).toBe(0);
+    // The whole point of the gate: a starved wedge has nothing to sample, so no
+    // profile is taken and no idle artefact reaches the corpus.
+    expect(read(body, 'civitai_app_watchdog_capture_total{result="skipped-starved"}')).toBe(1);
+  }, 30_000);
+
+  it('exposes the ratio distribution and the threshold echo', async () => {
+    // A gauge of the last value could not answer "where do starved wedges actually
+    // sit" — the continuous profiler adds a CPU floor, so that has to be readable
+    // rather than assumed.
+    const body = await runWedge('starved');
+    expect(body).toContain('civitai_app_watchdog_wedge_cpu_ratio_bucket{le="0.05"}');
+    expect(body).toContain('civitai_app_watchdog_wedge_cpu_ratio_count 1');
+    expect(read(body, 'civitai_app_watchdog_starved_ratio_threshold')).toBe(0.2);
+  }, 30_000);
+});
+
 describe('capture metrics', () => {
   it('exposes every capture series even before anything is captured', async () => {
     // Absent and zero mean different things to an alert. A pool with capture armed

--- a/src/server/eventloop-watchdog.ts
+++ b/src/server/eventloop-watchdog.ts
@@ -130,6 +130,21 @@ export function resolveWatchdogPort(): number {
 }
 
 /**
+ * CPU-seconds per wall-second below which a wedge is classified STARVED rather than
+ * EXECUTING. Measured separation is total — a burning loop reads 0.89, a blocked one
+ * 0.00 — so this sits well clear of both rather than at a midpoint.
+ *
+ * It is deliberately generous on the starved side: the continuous profiler adds a
+ * constant CPU floor on the pools that run it, so a starved wedge need not read
+ * exactly zero. The emitted ratio histogram exists so that floor can be READ off real
+ * pods rather than guessed at here.
+ */
+export function resolveStarvedRatio(): number {
+  const raw = Number.parseFloat(process.env.EVENTLOOP_WATCHDOG_STARVED_RATIO ?? '');
+  return Number.isFinite(raw) && raw > 0 && raw < 1 ? raw : 0.2;
+}
+
+/**
  * Paired with the worker-served `civitai_app_watchdog_up`: this one says the main
  * thread spawned the worker, that one says the worker is alive. Neither alone can
  * tell "the watchdog is absent" from "no wedges occurred", which is the failure mode
@@ -483,7 +498,7 @@ function maybeCaptureWedge(wedgeStartMs) {
 function renderCaptureMetrics(out) {
   out.push('# HELP civitai_app_watchdog_capture_total Wedge CPU-profile captures attempted, by result. skipped-* results mean the trigger fired but was refused by backoff or the hourly capCfg.');
   out.push('# TYPE civitai_app_watchdog_capture_total counter');
-  const captureKeys = ['ok', 'error', 'skipped-in-flight', 'skipped-backoff', 'skipped-hourly-cap'];
+  const captureKeys = ['ok', 'error', 'skipped-in-flight', 'skipped-backoff', 'skipped-hourly-cap', 'skipped-starved'];
   for (const k of captureKeys) {
     out.push('civitai_app_watchdog_capture_total{result="' + k + '"} ' + (captureResults[k] || 0));
   }
@@ -515,7 +530,7 @@ const { workerData, parentPort } = require('node:worker_threads');
 const http = require('node:http');
 const crypto = require('node:crypto');
 
-const { sab, thresholdMs, port, token, heartbeatIntervalMs, pollMs, cap, s3 } = workerData;
+const { sab, thresholdMs, port, token, heartbeatIntervalMs, pollMs, cap, s3, starvedRatio } = workerData;
 const beat = new BigInt64Array(sab);
 
 const BUCKETS = [1, 2, 5, 10, 30, 60, 120, 300, 600];
@@ -540,8 +555,68 @@ function observeWedge(seconds) {
   }
 }
 
+// --- starvation classifier -------------------------------------------------
+//
+// Most wedges on this fleet contain no JS at all: sliced captures showed the thread
+// not executing during the wedge, against runqueue wait of 2.28s per second on nodes
+// at 90% requested CPU. Threads are queuing, not looping. A profiler cannot see that
+// — there is nothing to sample — but CPU time against wall time separates the two
+// classes completely. Measured: a burning loop reads 0.89, a blocked one reads 0.00.
+//
+// process.cpuUsage() is PROCESS-wide, not main-thread-scoped, so it also counts this
+// worker, V8's helpers, and Pyroscope's sampler where that runs. It is a
+// discriminator between ~0 and ~1, not an attribution. Per-thread precision would
+// mean /proc/self/task/<tid>/stat, which is Linux-only and unnecessary while the
+// classes sit two orders apart.
+const starvedCutoff = typeof starvedRatio === 'number' && starvedRatio > 0 ? starvedRatio : 0.2;
+const CPU_RING_MAX = 400;
+const cpuRing = [];
+
+function sampleCpu(now) {
+  const u = process.cpuUsage();
+  cpuRing.push({ at: now, cpuMs: (u.user + u.system) / 1000 });
+  if (cpuRing.length > CPU_RING_MAX) cpuRing.shift();
+}
+
+// CPU-seconds per wall-second since sinceMs, or null when the ring cannot reach back
+// that far. No backticks anywhere in this source -- it lives in a String.raw template
+// and one would terminate it.
+function cpuRatioSince(sinceMs, now) {
+  if (cpuRing.length < 2) return null;
+  let oldest = null;
+  for (let i = 0; i < cpuRing.length; i++) {
+    if (cpuRing[i].at <= sinceMs) oldest = cpuRing[i];
+    else break;
+  }
+  if (!oldest) oldest = cpuRing[0];
+  const latest = cpuRing[cpuRing.length - 1];
+  const wallMs = latest.at - oldest.at;
+  if (wallMs < 200) return null;
+  return (latest.cpuMs - oldest.cpuMs) / wallMs;
+}
+
+const wedgeKinds = { starved: 0, executing: 0, unknown: 0 };
+const RATIO_BUCKETS = [0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 1];
+const ratioBucketCounts = new Array(RATIO_BUCKETS.length).fill(0);
+let ratioCount = 0;
+let ratioSum = 0;
+
+function observeWedgeKind(ratio) {
+  if (ratio === null) {
+    wedgeKinds.unknown++;
+    return;
+  }
+  wedgeKinds[ratio < starvedCutoff ? 'starved' : 'executing']++;
+  ratioCount++;
+  ratioSum += ratio;
+  for (let i = 0; i < RATIO_BUCKETS.length; i++) {
+    if (ratio <= RATIO_BUCKETS[i]) ratioBucketCounts[i]++;
+  }
+}
+
 setInterval(function () {
   const now = Date.now();
+  sampleCpu(now);
   const lastBeat = lastBeatMs();
   const age = now - lastBeat;
   if (wedgeStartedAt === 0) {
@@ -549,12 +624,21 @@ setInterval(function () {
     // duration does not silently exclude the threshold.
     if (age >= thresholdMs) {
       wedgeStartedAt = lastBeat;
-      // Fire-and-forget: the capture must not delay the next poll, or the worker
-      // stops being able to report the wedge it is capturing.
-      maybeCaptureWedge(wedgeStartedAt);
+      // Gate on the ratio SO FAR, which is all that exists at detection. The
+      // classification below uses the whole wedge and is the more accurate of the
+      // two; this one only has to answer "is there anything to sample right now".
+      const earlyRatio = cpuRatioSince(wedgeStartedAt, now);
+      if (earlyRatio !== null && earlyRatio < starvedCutoff) {
+        tallyCapture('skipped-starved');
+      } else {
+        // Fire-and-forget: the capture must not delay the next poll, or the worker
+        // stops being able to report the wedge it is capturing.
+        maybeCaptureWedge(wedgeStartedAt);
+      }
     }
   } else if (age < thresholdMs) {
     observeWedge((now - wedgeStartedAt) / 1000);
+    observeWedgeKind(cpuRatioSince(wedgeStartedAt, now));
     wedgeStartedAt = 0;
   }
 }, pollMs).unref();
@@ -591,6 +675,23 @@ function render() {
   out.push('civitai_app_watchdog_wedge_duration_seconds_bucket{le="+Inf"} ' + wedgeCount);
   out.push('civitai_app_watchdog_wedge_duration_seconds_sum ' + wedgeSumSeconds);
   out.push('civitai_app_watchdog_wedge_duration_seconds_count ' + wedgeCount);
+
+  out.push('# HELP civitai_app_watchdog_wedge_kind_total Completed wedges by whether the main thread was EXECUTING (CPU burned during the wedge, so a profile has something to show) or STARVED (descheduled, waiting for CPU — nothing to sample, and the fix is capacity or scheduling rather than code). unknown means the CPU ring could not cover the wedge.');
+  out.push('# TYPE civitai_app_watchdog_wedge_kind_total counter');
+  out.push('civitai_app_watchdog_wedge_kind_total{kind="starved"} ' + wedgeKinds.starved);
+  out.push('civitai_app_watchdog_wedge_kind_total{kind="executing"} ' + wedgeKinds.executing);
+  out.push('civitai_app_watchdog_wedge_kind_total{kind="unknown"} ' + wedgeKinds.unknown);
+
+  out.push('# HELP civitai_app_watchdog_wedge_cpu_ratio Process CPU-seconds per wall-second over each completed wedge. Distribution, not last-value, so the starved population can be READ rather than assumed — the continuous profiler adds a CPU floor, so starved wedges may not sit at exactly 0.');
+  out.push('# TYPE civitai_app_watchdog_wedge_cpu_ratio histogram');
+  for (let i = 0; i < RATIO_BUCKETS.length; i++) {
+    out.push('civitai_app_watchdog_wedge_cpu_ratio_bucket{le="' + RATIO_BUCKETS[i] + '"} ' + ratioBucketCounts[i]);
+  }
+  out.push('civitai_app_watchdog_wedge_cpu_ratio_bucket{le="+Inf"} ' + ratioCount);
+  out.push('civitai_app_watchdog_wedge_cpu_ratio_sum ' + ratioSum);
+  out.push('civitai_app_watchdog_wedge_cpu_ratio_count ' + ratioCount);
+
+  gauge('civitai_app_watchdog_starved_ratio_threshold', 'Configured CPU-ratio below which a wedge is classified starved. Config echo.', starvedCutoff);
 
   renderCaptureMetrics(out);
 
@@ -807,6 +908,7 @@ export function registerEventLoopWatchdog(): void {
         // Resolved on the MAIN thread at spawn, so a missing credential is a boot-time
         // fact rather than something discovered during the first wedge.
         cap: captureConfig,
+        starvedRatio: resolveStarvedRatio(),
         s3: resolveS3Config(),
       },
       // The watchdog must never be the reason the process stays up.


### PR DESCRIPTION
Follow-up to #3762, and it changes what that PR is for.

## The finding

Sliced production captures over 20 SSR pods caught 19 wedges. **On two of three, the main thread was not executing JavaScript at all** — no hot frame, zero contiguous busy runs ≥900 ms. Cluster side: runqueue wait **2.28 s per second**, nodes at **90% requested CPU**, no CFS throttling.

Threads are queuing for CPU, not looping. **A profiler cannot see that** — there is nothing to sample. So #3762 alone would return mostly-idle profiles for the ~69% of wedges that last 1–2 s, and a corpus of empty captures reads as a broken tool rather than as the answer.

## The instrument that can see it

CPU time against wall time. Measured on Node 24:

```
main thread BURNING 3s   wall 3314ms   processCpu 2953ms   ratio 0.89
main thread BLOCKED 3s   wall 3303ms   processCpu    0ms   ratio 0.00
```

No overlap between the classes. `process.cpuUsage()` costs **1704 ns**, so one read per 50 ms poll is **0.034 ms of CPU per second** — three orders under anything in this project's budget.

## Used twice, for two different questions

- **At detection**, on the ratio so far. All that exists at ~1 s, and it only has to answer *is there anything to sample right now*. If not: count `skipped-starved`, open no inspector, upload nothing. **This prevents the idle corpus rather than labelling it afterwards.**
- **On recovery**, over the whole wedge, to classify it. More accurate, but too late to gate on.

A GC-wedged loop burns CPU, so it classifies as *executing*, gets profiled, and the profile says `(garbage collector)`. The two mechanisms route to the two right places instead of both landing in one bucket.

**This also makes the 1–2 s band explicable for the first time.** Until now we knew those wedges happened and nothing else. Every wedge is now classified on arrival, whether or not it is worth profiling.

## Metrics

```
civitai_app_watchdog_wedge_kind_total{kind="starved|executing|unknown"}
civitai_app_watchdog_wedge_cpu_ratio            histogram
civitai_app_watchdog_starved_ratio_threshold    gauge, config echo
civitai_app_watchdog_capture_total{result="skipped-starved"}
```

**New series, not a label on `wedge_total`** — existing alert rules and every count quoted so far read that counter, and changing its shape underneath them is how a threshold gets silently invalidated.

**A histogram, not a last-value gauge**, because the question "where do starved wedges actually sit" has to be *readable*: the continuous profiler adds a CPU floor on the pools that run it, so a starved wedge need not read exactly 0.00, and the threshold wants measuring rather than inferring. `unknown` covers a wedge the CPU ring could not span.

## Tests prove discrimination, not execution

```
✓ classifies a CPU-burning wedge as executing    executing=1  starved=0
✓ classifies an idle wedge as starved            starved=1    executing=0
                                                 capture_total{skipped-starved}=1
✓ exposes the ratio distribution and the threshold echo
```

Both drive a real spawned worker against a real withheld heartbeat, with the main thread genuinely burning or genuinely idle.

⚠️ **These two are load-sensitive by nature** — they measure CPU, so a sufficiently oversubscribed machine could in principle push the burning case below the 0.2 threshold. The margin is 4.5× against the measured 0.89, and vitest's default `forks` pool means `cpuUsage()` cannot be contaminated by sibling test files. Flagging it rather than discovering it in CI.

## Honest limit, also stated in the code

`process.cpuUsage()` is **process-wide, not main-thread-scoped**, so it counts this worker, V8's helper threads, and any continuous profiler on that pool. It is a discriminator between ~0 and ~1, not an attribution. Per-thread precision would mean `/proc/self/task/<tid>/stat` — Linux-only, and unnecessary while the classes sit two orders apart.

## Verification

- 30/30 across the watchdog suites; 9/9 on the capture suite specifically
- full unit suite **16 failed / 13697 passed / 889 files** — the same 16 pre-existing on `main`
- typecheck 0 errors, eslint clean, prettier clean

Capture remains default-off (`EVENTLOOP_WATCHDOG_CAPTURE_ENABLED`), so merging this changes nothing anywhere. The two gates on #3762 still stand: the end-to-end `SIGUSR1` path needs Linux, and the upload has never reached a real endpoint.
