### PR TITLE
feat(placement): sticker placement in feeds, and the moderator removal paths

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260809040000_placement_removed_by_cosmetic_takedown/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260809040000_placement_removed_by_cosmetic_takedown/migration.sql
@@ -6,11 +6,13 @@
 --
 -- The column is TEXT; this constraint is the only thing that has to change.
 --
--- Two statements on purpose. A plain ADD CONSTRAINT ... CHECK takes ACCESS
--- EXCLUSIVE and scans every row with writes blocked; NOT VALID takes the lock
--- only long enough to record the constraint, and VALIDATE then scans under
--- SHARE UPDATE EXCLUSIVE, which writers do not queue behind. Run them
--- separately if "Placement" is large enough for the scan to matter.
+-- Added NOT VALID so this takes ACCESS EXCLUSIVE only long enough to record the
+-- constraint instead of holding it across a full table scan. It is enforced on
+-- every INSERT and UPDATE immediately — NOT VALID skips the check of EXISTING
+-- rows, nothing else — so stopping here is safe, just incomplete.
+--
+-- The scan lives in 20260809041000, which MUST run in its own transaction. See
+-- the note there.
 DO $$
 BEGIN
   IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'Placement_removedBy_check') THEN
@@ -25,8 +27,3 @@ BEGIN
     ) NOT VALID;
 END
 $$;
-
--- The widened constraint accepts everything the old one did, so this cannot
--- fail on existing rows; it is here so the constraint stops being NOT VALID and
--- the planner can rely on it.
-ALTER TABLE "Placement" VALIDATE CONSTRAINT "Placement_removedBy_check";

--- a/packages/civitai-db-schema/prisma/migrations/20260809040000_placement_removed_by_cosmetic_takedown/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260809040000_placement_removed_by_cosmetic_takedown/migration.sql
@@ -4,7 +4,13 @@
 -- folded into 'owner', because the money is the same and the record is not, and
 -- the record is what a reconcile reads to explain why someone was paid.
 --
--- The column is TEXT, so this constraint is the only thing that has to change.
+-- The column is TEXT; this constraint is the only thing that has to change.
+--
+-- Two statements on purpose. A plain ADD CONSTRAINT ... CHECK takes ACCESS
+-- EXCLUSIVE and scans every row with writes blocked; NOT VALID takes the lock
+-- only long enough to record the constraint, and VALIDATE then scans under
+-- SHARE UPDATE EXCLUSIVE, which writers do not queue behind. Run them
+-- separately if "Placement" is large enough for the scan to matter.
 DO $$
 BEGIN
   IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'Placement_removedBy_check') THEN
@@ -16,6 +22,11 @@ BEGIN
     CHECK (
       ("status" <> 'removed' AND "removedBy" IS NULL) OR
       ("status" =  'removed' AND "removedBy" IN ('owner', 'moderator', 'cosmeticTakedown'))
-    );
+    ) NOT VALID;
 END
 $$;
+
+-- The widened constraint accepts everything the old one did, so this cannot
+-- fail on existing rows; it is here so the constraint stops being NOT VALID and
+-- the planner can rely on it.
+ALTER TABLE "Placement" VALIDATE CONSTRAINT "Placement_removedBy_check";

--- a/packages/civitai-db-schema/prisma/migrations/20260809040000_placement_removed_by_cosmetic_takedown/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260809040000_placement_removed_by_cosmetic_takedown/migration.sql
@@ -1,0 +1,21 @@
+-- A cosmetic takedown is a third way a placement can be removed, and it refunds
+-- like an owner's removal rather than a moderator's: the placer holds revoked
+-- artwork instead of having authored it. The reason is recorded rather than
+-- folded into 'owner', because the money is the same and the record is not, and
+-- the record is what a reconcile reads to explain why someone was paid.
+--
+-- The column is TEXT, so this constraint is the only thing that has to change.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'Placement_removedBy_check') THEN
+    ALTER TABLE "Placement" DROP CONSTRAINT "Placement_removedBy_check";
+  END IF;
+
+  ALTER TABLE "Placement"
+    ADD CONSTRAINT "Placement_removedBy_check"
+    CHECK (
+      ("status" <> 'removed' AND "removedBy" IS NULL) OR
+      ("status" =  'removed' AND "removedBy" IN ('owner', 'moderator', 'cosmeticTakedown'))
+    );
+END
+$$;

--- a/packages/civitai-db-schema/prisma/migrations/20260809041000_validate_placement_removed_by_check/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260809041000_validate_placement_removed_by_check/migration.sql
@@ -1,0 +1,13 @@
+-- Validates the constraint added NOT VALID by 20260809040000.
+--
+-- **Its own migration so it cannot share a transaction with the ALTER that
+-- added it.** Postgres holds every lock until the transaction ends, so an
+-- `ADD CONSTRAINT ... NOT VALID` and a `VALIDATE CONSTRAINT` in one transaction
+-- keep the ACCESS EXCLUSIVE from the first across the scan of the second — the
+-- exact blocking the split exists to avoid, plus an extra catalogue update.
+-- Run separately (or under autocommit), never inside `psql --single-transaction`
+-- together with the previous file.
+--
+-- The widened constraint accepts everything the old one did, so this cannot
+-- fail on existing rows.
+ALTER TABLE "Placement" VALIDATE CONSTRAINT "Placement_removedBy_check";

--- a/packages/civitai-db-schema/prisma/migrations/20260809041000_validate_placement_removed_by_check/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260809041000_validate_placement_removed_by_check/migration.sql
@@ -8,6 +8,24 @@
 -- Run separately (or under autocommit), never inside `psql --single-transaction`
 -- together with the previous file.
 --
--- The widened constraint accepts everything the old one did, so this cannot
--- fail on existing rows.
-ALTER TABLE "Placement" VALIDATE CONSTRAINT "Placement_removedBy_check";
+-- The guard is the point of the DO block. `VALIDATE CONSTRAINT` on an
+-- already-valid constraint SUCCEEDS as a no-op, so running this file alone
+-- against a database that never got 20260809040000 would find the ORIGINAL
+-- constraint, validate nothing, return success, and leave 'cosmeticTakedown'
+-- still forbidden — with every reason to believe the migration landed.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'Placement_removedBy_check'
+      AND pg_get_constraintdef(oid) LIKE '%cosmeticTakedown%'
+  ) THEN
+    RAISE EXCEPTION
+      'Placement_removedBy_check does not allow cosmeticTakedown — apply 20260809040000 first';
+  END IF;
+
+  -- The widened constraint accepts everything the old one did, so this cannot
+  -- fail on existing rows.
+  ALTER TABLE "Placement" VALIDATE CONSTRAINT "Placement_removedBy_check";
+END
+$$;

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -7569,8 +7569,10 @@ model Placement {
   placer                User      @relation("PlacementPlacer", fields: [placerId], references: [id], onDelete: Cascade)
   data                  Json      @default("{}")
   status                String
-  /// 'owner' | 'moderator', set with status 'removed'. The two removals refund
-  /// opposite amounts, so the status alone cannot settle the money.
+  /// 'owner' | 'moderator' | 'cosmeticTakedown', set with status 'removed'. The
+  /// removals refund different amounts, so the status alone cannot settle the
+  /// money. Constrained by "Placement_removedBy_check" — a new value needs a
+  /// migration even though the column is TEXT.
   removedBy             String?
   /// What the placer paid into escrow, in Buzz. Kept per row rather than read back from
   /// the space, whose price may move between placement and release.

--- a/packages/civitai-db-schema/src/kysely/types.ts
+++ b/packages/civitai-db-schema/src/kysely/types.ts
@@ -2891,8 +2891,10 @@ export type Placement = {
   data: Generated<unknown>;
   status: string;
   /**
-   * 'owner' | 'moderator', set with status 'removed'. The two removals refund
-   * opposite amounts, so the status alone cannot settle the money.
+   * 'owner' | 'moderator' | 'cosmeticTakedown', set with status 'removed'. The
+   * removals refund different amounts, so the status alone cannot settle the
+   * money. Constrained by "Placement_removedBy_check" — a new value needs a
+   * migration even though the column is TEXT.
    */
   removedBy: string | null;
   /**

--- a/src/components/CardTemplates/AspectRatioImageCard.tsx
+++ b/src/components/CardTemplates/AspectRatioImageCard.tsx
@@ -53,6 +53,12 @@ export type AspectRatioImageCardProps<T extends DialogKey> = {
   image?: ImageProps;
   header?: React.ReactNode | ((props: { safe?: boolean }) => React.ReactNode);
   footer?: React.ReactNode | ((props: { safe?: boolean }) => React.ReactNode);
+  /**
+   * Drawn over the media, under the header and footer. Unlike those it gets the
+   * whole content box rather than a padded strip, because what goes here is
+   * positioned against the artwork.
+   */
+  overlay?: React.ReactNode | ((props: { safe?: boolean }) => React.ReactNode);
   footerGradient?: boolean;
   onSite?: boolean;
   routedDialog?: RoutedDialogProps<T>;
@@ -84,6 +90,7 @@ export function AspectRatioImageCard<T extends DialogKey>({
   image,
   header,
   footer,
+  overlay,
   footerGradient,
   onSite,
   routedDialog,
@@ -210,6 +217,7 @@ export function AspectRatioImageCard<T extends DialogKey>({
                     />
                   )}
                 </LinkOrClick>
+                {overlay && (typeof overlay === 'function' ? overlay({ safe }) : overlay)}
                 <div className={cardStyles.header}>
                   <ImageGuard2.BlurToggle
                     className={cardStyles.chip}

--- a/src/components/Cards/ImageCard.tsx
+++ b/src/components/Cards/ImageCard.tsx
@@ -24,9 +24,7 @@ export function ImageCard({ data }: Props) {
         name: 'imageDetail',
         state: { imageId: data.id, images: getImages(), ...context },
       }}
-      overlay={({ safe }) =>
-        safe && <CardStickerOverlay imageId={data.id} width={data.width} height={data.height} />
-      }
+      overlay={({ safe }) => safe && <CardStickerOverlay imageId={data.id} />}
       header={
         <div className="flex w-full items-start justify-between">
           {data.type === 'video' && data.metadata && 'duration' in data.metadata && (

--- a/src/components/Cards/ImageCard.tsx
+++ b/src/components/Cards/ImageCard.tsx
@@ -8,6 +8,7 @@ import { DurationBadge } from '~/components/DurationBadge/DurationBadge';
 import { AspectRatioImageCard } from '~/components/CardTemplates/AspectRatioImageCard';
 import { RemixButton } from '~/components/Cards/components/RemixButton';
 import { CardStickerOverlay } from '~/components/Sticker/CardStickerOverlay';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { StickerPlacementCardBadge } from '~/components/Sticker/StickerPlacementCardBadge';
 import { UserAvatarSimple } from '~/components/UserAvatar/UserAvatarSimple';
 import cardClasses from '~/components/Cards/Cards.module.css';
@@ -15,6 +16,7 @@ import { ThemeIcon } from '@mantine/core';
 
 export function ImageCard({ data }: Props) {
   const { getImages, ...context } = useImagesContext();
+  const features = useFeatureFlags();
 
   return (
     <AspectRatioImageCard
@@ -24,7 +26,12 @@ export function ImageCard({ data }: Props) {
         name: 'imageDetail',
         state: { imageId: data.id, images: getImages(), ...context },
       }}
-      overlay={({ safe }) => safe && <CardStickerOverlay imageId={data.id} />}
+      overlay={({ safe }) =>
+        // Not mounted at all with the flag off. The overlay renders null there
+        // anyway, but a card is rendered by the hundred and this keeps the
+        // flag-off tree identical to what shipped before it.
+        safe && features.stickerPlacement && <CardStickerOverlay imageId={data.id} />
+      }
       header={
         <div className="flex w-full items-start justify-between">
           {data.type === 'video' && data.metadata && 'duration' in data.metadata && (
@@ -56,7 +63,7 @@ export function ImageCard({ data }: Props) {
               targetUserId={data.user.id}
               disableBuzzTip={data.poi}
             />
-            <StickerPlacementCardBadge imageId={data.id} />
+            {features.stickerPlacement && <StickerPlacementCardBadge imageId={data.id} />}
             {data.hasMeta && (
               <ImageMetaPopover2 imageId={data.id} type={data.type}>
                 <ThemeIcon className={cardClasses.infoChip} variant="light">

--- a/src/components/Cards/ImageCard.tsx
+++ b/src/components/Cards/ImageCard.tsx
@@ -7,6 +7,8 @@ import { ImageMetaPopover2 } from '~/components/Image/Meta/ImageMetaPopover';
 import { DurationBadge } from '~/components/DurationBadge/DurationBadge';
 import { AspectRatioImageCard } from '~/components/CardTemplates/AspectRatioImageCard';
 import { RemixButton } from '~/components/Cards/components/RemixButton';
+import { CardStickerOverlay } from '~/components/Sticker/CardStickerOverlay';
+import { StickerPlacementCardBadge } from '~/components/Sticker/StickerPlacementCardBadge';
 import { UserAvatarSimple } from '~/components/UserAvatar/UserAvatarSimple';
 import cardClasses from '~/components/Cards/Cards.module.css';
 import { ThemeIcon } from '@mantine/core';
@@ -22,6 +24,9 @@ export function ImageCard({ data }: Props) {
         name: 'imageDetail',
         state: { imageId: data.id, images: getImages(), ...context },
       }}
+      overlay={({ safe }) =>
+        safe && <CardStickerOverlay imageId={data.id} width={data.width} height={data.height} />
+      }
       header={
         <div className="flex w-full items-start justify-between">
           {data.type === 'video' && data.metadata && 'duration' in data.metadata && (
@@ -53,6 +58,7 @@ export function ImageCard({ data }: Props) {
               targetUserId={data.user.id}
               disableBuzzTip={data.poi}
             />
+            <StickerPlacementCardBadge imageId={data.id} />
             {data.hasMeta && (
               <ImageMetaPopover2 imageId={data.id} type={data.type}>
                 <ThemeIcon className={cardClasses.infoChip} variant="light">

--- a/src/components/Image/Infinite/ImagesCard.tsx
+++ b/src/components/Image/Infinite/ImagesCard.tsx
@@ -149,13 +149,7 @@ function ImagesCardContent({ data, height }: { data: ImagesInfiniteModel; height
                     <MediaHash {...image} />
                   )}
                 </RoutedDialogLink>
-                {safe && (
-                  <CardStickerOverlay
-                    imageId={image.id}
-                    width={image.width}
-                    height={image.height}
-                  />
-                )}
+                {safe && <CardStickerOverlay imageId={image.id} />}
                 <div className="absolute left-2 top-2">
                   <div className="flex flex-nowrap items-center gap-1">
                     <ImageGuard2.BlurToggle radius="xl" h={26} style={{ pointerEvents: 'auto' }} />

--- a/src/components/Image/Infinite/ImagesCard.tsx
+++ b/src/components/Image/Infinite/ImagesCard.tsx
@@ -17,6 +17,8 @@ import { MediaHash } from '~/components/ImageHash/ImageHash';
 import { ElementInView, useElementInView } from '~/components/IntersectionObserver/ElementInView';
 import { Metrics } from '~/components/Metrics';
 import { Reactions } from '~/components/Reaction/Reactions';
+import { CardStickerOverlay } from '~/components/Sticker/CardStickerOverlay';
+import { StickerPlacementCardBadge } from '~/components/Sticker/StickerPlacementCardBadge';
 import { TwCard } from '~/components/TwCard/TwCard';
 import { TwCosmeticWrapper } from '~/components/TwCosmeticWrapper/TwCosmeticWrapper';
 import { VotableTags } from '~/components/VotableTags/VotableTags';
@@ -147,6 +149,13 @@ function ImagesCardContent({ data, height }: { data: ImagesInfiniteModel; height
                     <MediaHash {...image} />
                   )}
                 </RoutedDialogLink>
+                {safe && (
+                  <CardStickerOverlay
+                    imageId={image.id}
+                    width={image.width}
+                    height={image.height}
+                  />
+                )}
                 <div className="absolute left-2 top-2">
                   <div className="flex flex-nowrap items-center gap-1">
                     <ImageGuard2.BlurToggle radius="xl" h={26} style={{ pointerEvents: 'auto' }} />
@@ -171,12 +180,15 @@ function ImagesCardContent({ data, height }: { data: ImagesInfiniteModel; height
                     )}
                     {(currentUser?.id === data.user.id || isModerator) &&
                       data.collectionItemStatus === CollectionItemStatus.REVIEW && (
-                      <Tooltip label="Still being reviewed — not yet eligible for judging" withinPortal>
-                        <Badge variant="filled" radius="xl" h={26} color="yellow">
-                          Pending review
-                        </Badge>
-                      </Tooltip>
-                    )}
+                        <Tooltip
+                          label="Still being reviewed — not yet eligible for judging"
+                          withinPortal
+                        >
+                          <Badge variant="filled" radius="xl" h={26} color="yellow">
+                            Pending review
+                          </Badge>
+                        </Tooltip>
+                      )}
                   </div>
                 </div>
                 {safe && (
@@ -303,8 +315,11 @@ function ImagesCardContent({ data, height }: { data: ImagesInfiniteModel; height
                 {onSite && <OnsiteIndicator isRemix={isRemix} />}
               </div>
               {!contextProps.hideReactions && (
-                <div>
-                  <ImageReactions image={image} readonly={!safe || (isScanned && isBlocked)} />
+                <div className="flex items-center">
+                  <div className="min-w-0 flex-1">
+                    <ImageReactions image={image} readonly={!safe || (isScanned && isBlocked)} />
+                  </div>
+                  <StickerPlacementCardBadge imageId={image.id} className="mr-2" />
                 </div>
               )}
             </>

--- a/src/components/Image/Infinite/ImagesCard.tsx
+++ b/src/components/Image/Infinite/ImagesCard.tsx
@@ -149,7 +149,7 @@ function ImagesCardContent({ data, height }: { data: ImagesInfiniteModel; height
                     <MediaHash {...image} />
                   )}
                 </RoutedDialogLink>
-                {safe && <CardStickerOverlay imageId={image.id} />}
+                {safe && features.stickerPlacement && <CardStickerOverlay imageId={image.id} />}
                 <div className="absolute left-2 top-2">
                   <div className="flex flex-nowrap items-center gap-1">
                     <ImageGuard2.BlurToggle radius="xl" h={26} style={{ pointerEvents: 'auto' }} />
@@ -308,14 +308,25 @@ function ImagesCardContent({ data, height }: { data: ImagesInfiniteModel; height
                 )}
                 {onSite && <OnsiteIndicator isRemix={isRemix} />}
               </div>
-              {!contextProps.hideReactions && (
-                <div className="flex items-center">
-                  <div className="min-w-0 flex-1">
+              {!contextProps.hideReactions &&
+                // The row only becomes a flex container when there is something
+                // to put beside the reactions. `StickerPlacementCardBadge`
+                // returns null with the flag off, so wrapping unconditionally
+                // would still change this card's layout for everyone while
+                // adding nothing — a visual regression with no feature behind
+                // it, on the surface the flag exists to keep clear of.
+                (features.stickerPlacement ? (
+                  <div className="flex items-center">
+                    <div className="min-w-0 flex-1">
+                      <ImageReactions image={image} readonly={!safe || (isScanned && isBlocked)} />
+                    </div>
+                    <StickerPlacementCardBadge imageId={image.id} className="mr-2" />
+                  </div>
+                ) : (
+                  <div>
                     <ImageReactions image={image} readonly={!safe || (isScanned && isBlocked)} />
                   </div>
-                  <StickerPlacementCardBadge imageId={image.id} className="mr-2" />
-                </div>
-              )}
+                ))}
             </>
           )}
         </ImageGuard2>

--- a/src/components/Image/Providers/ImagesProvider.tsx
+++ b/src/components/Image/Providers/ImagesProvider.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useMemo, useRef } from 'react';
+import { StickerPlacementBatchProvider } from '~/components/Sticker/StickerPlacementBatchProvider';
 import type { ImageGetInfinite } from '~/types/router';
 import type { ProfileImage } from '~/server/selectors/image.selector';
 import type { JudgingCategory } from '~/server/games/daily-challenge/daily-challenge-scoring';
@@ -59,5 +60,14 @@ export function ImagesProvider({
     [hideReactionCount, hideReactions, collectionId, judgeInfo, judgingCategories]
   );
 
-  return <ImagesContext.Provider value={state}>{children}</ImagesContext.Provider>;
+  // Not from `imagesRef`: the ref exists to keep `getImages` stable across
+  // renders, and reading it here would leave the batch fetching whatever the
+  // first render happened to see.
+  const imageIds = useMemo(() => (images ?? []).map((image) => image.id), [images]);
+
+  return (
+    <ImagesContext.Provider value={state}>
+      <StickerPlacementBatchProvider imageIds={imageIds}>{children}</StickerPlacementBatchProvider>
+    </ImagesContext.Provider>
+  );
 }

--- a/src/components/Sticker/CardStickerOverlay.tsx
+++ b/src/components/Sticker/CardStickerOverlay.tsx
@@ -10,6 +10,35 @@ const same = (a: Box | null, b: Box) =>
   !!a && a.width === b.width && a.height === b.height && a.left === b.left && a.top === b.top;
 
 /**
+ * Layout position of `el` relative to `stop`, walking the offset chain.
+ *
+ * `offsetLeft`/`offsetTop` rather than `getBoundingClientRect`, because both
+ * card templates scale the media on hover and a rect includes transforms while
+ * a `ResizeObserver` does not fire on one. Measuring with a rect while the
+ * pointer happened to be resting on the card — which is normal, it is the card
+ * you are about to click — captures a box 5% too large and never corrects it.
+ *
+ * The two elements do not share an `offsetParent`: the media sits inside a
+ * positioned link, the overlay is a sibling of that link. Hence the walk rather
+ * than a subtraction of two `offsetLeft`s.
+ */
+const offsetWithin = (el: HTMLElement, stop: Element | null) => {
+  let x = 0;
+  let y = 0;
+  let current: HTMLElement | null = el;
+
+  while (current && current !== stop) {
+    x += current.offsetLeft;
+    y += current.offsetTop;
+    current = current.offsetParent as HTMLElement | null;
+  }
+
+  // Ran off the top without reaching `stop`, so the two are not in one offset
+  // chain and any number here would be a guess.
+  return current === stop ? { x, y } : null;
+};
+
+/**
  * Placed stickers on a feed card.
  *
  * Positions are fractions of the artwork's bounds, so the overlay has to be the
@@ -57,14 +86,19 @@ export function CardStickerOverlay({ imageId }: { imageId: number }) {
     if (!media) return;
 
     const measure = () => {
-      const outer = node.getBoundingClientRect();
-      const inner = media.getBoundingClientRect();
-      if (inner.width <= 0 || inner.height <= 0) return;
+      const element = media as HTMLElement;
+      if (element.offsetWidth <= 0 || element.offsetHeight <= 0) return;
+
+      const stop = node.offsetParent;
+      const at = offsetWithin(element, stop);
+      const self = offsetWithin(node, stop);
+      if (!at || !self) return;
+
       const next = {
-        width: inner.width,
-        height: inner.height,
-        left: inner.left - outer.left,
-        top: inner.top - outer.top,
+        width: element.offsetWidth,
+        height: element.offsetHeight,
+        left: at.x - self.x,
+        top: at.y - self.y,
       };
       // Rects come back fractional and a ResizeObserver fires on every layout
       // pass, so setting state unconditionally re-renders the whole overlay

--- a/src/components/Sticker/CardStickerOverlay.tsx
+++ b/src/components/Sticker/CardStickerOverlay.tsx
@@ -6,6 +6,8 @@ import { useStickerRevealStore } from '~/store/sticker-reveal.store';
 
 type Box = { width: number; height: number; left: number; top: number };
 
+const CARD_ARTWORK_WIDTH = 128;
+
 const same = (a: Box | null, b: Box) =>
   !!a && a.width === b.width && a.height === b.height && a.left === b.left && a.top === b.top;
 
@@ -123,6 +125,11 @@ export function CardStickerOverlay({ imageId }: { imageId: number }) {
             placements={placements}
             viewerId={currentUser?.id}
             interactive={false}
+            sticker={batch?.sticker}
+            // A card is ~450px wide and a sticker is a fraction of it, so 512
+            // is roughly eight times the linear resolution it draws at, on the
+            // hottest path in the product.
+            artworkWidth={CARD_ARTWORK_WIDTH}
           />
         </div>
       )}

--- a/src/components/Sticker/CardStickerOverlay.tsx
+++ b/src/components/Sticker/CardStickerOverlay.tsx
@@ -1,59 +1,39 @@
-import { useCallback, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { StickerPlacementOverlay } from '~/components/Sticker/StickerPlacementOverlay';
 import { useStickerPlacementBatch } from '~/components/Sticker/StickerPlacementBatchProvider';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
-import { useResizeObserver } from '~/hooks/useResizeObserver';
 import { useStickerRevealStore } from '~/store/sticker-reveal.store';
 
 type Box = { width: number; height: number; left: number; top: number };
 
+const same = (a: Box | null, b: Box) =>
+  !!a && a.width === b.width && a.height === b.height && a.left === b.left && a.top === b.top;
+
 /**
  * Placed stickers on a feed card.
  *
- * Card media is `object-fit: cover` with `object-position: top center`, so the
- * rendered artwork is *larger* than the card and cropped by it — not
- * letterboxed the way the detail view is. Positions are fractions of the
- * artwork's bounds, so the overlay has to be the same rectangle the artwork was
- * scaled to, and then clipped. Sizing it to the card instead would slide every
- * sticker relative to the thing it was placed on, worst on exactly the images
- * whose aspect ratio differs most from the card's.
+ * Positions are fractions of the artwork's bounds, so the overlay has to be the
+ * rectangle the artwork was actually scaled to — then clipped by the card.
  *
- * A consequence worth knowing rather than fixing: a sticker placed low on a tall
- * image is outside the crop and therefore not visible in the feed at all.
+ * **That rectangle is measured off the media element, not computed.** Card media
+ * is `object-fit: cover`, but the two card templates lay it out differently
+ * enough that the resulting box differs: one stretches the image to the card
+ * width inside a flex column, the other lets `height: 100%; width: auto`
+ * overflow a block box, which anchors the crop left instead of centring it.
+ * Reproducing that in arithmetic means encoding both templates' CSS here and
+ * being wrong the day either changes — silently, and only for the class of
+ * images whose aspect ratio makes the difference visible. Reading the element's
+ * own rect is correct for whatever the stylesheet does.
+ *
+ * A consequence worth knowing rather than fixing: `cover` crops, so a sticker
+ * placed low on a tall image is outside the visible box and not shown in a feed.
  */
-export function CardStickerOverlay({
-  imageId,
-  width,
-  height,
-}: {
-  imageId: number;
-  width?: number | null;
-  height?: number | null;
-}) {
+export function CardStickerOverlay({ imageId }: { imageId: number }) {
   const currentUser = useCurrentUser();
   const revealed = useStickerRevealStore((state) => state.revealed);
   const batch = useStickerPlacementBatch(imageId);
+  const ref = useRef<HTMLDivElement>(null);
   const [box, setBox] = useState<Box | null>(null);
-
-  const aspectRatio = width && height ? width / height : null;
-
-  const measure = useCallback(
-    (entry: ResizeObserverEntry) => {
-      if (!aspectRatio) return;
-      const { width: cw, height: ch } = entry.contentRect;
-      if (cw <= 0 || ch <= 0) return;
-
-      const covered =
-        aspectRatio > cw / ch
-          ? { width: ch * aspectRatio, height: ch }
-          : { width: cw, height: cw / aspectRatio };
-
-      setBox({ ...covered, left: (cw - covered.width) / 2, top: 0 });
-    },
-    [aspectRatio]
-  );
-
-  const ref = useResizeObserver<HTMLDivElement>(measure);
 
   const placements = batch
     ? revealed
@@ -64,7 +44,42 @@ export function CardStickerOverlay({
         batch.pending
     : [];
 
-  if (!aspectRatio || !placements.length) return null;
+  const hasPlacements = placements.length > 0;
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node || !hasPlacements) return;
+
+    // The media is a sibling subtree, not a child of the overlay: the overlay
+    // must sit above it, and nesting inside the link would make it part of the
+    // card's click target.
+    const media = node.parentElement?.querySelector('img, video');
+    if (!media) return;
+
+    const measure = () => {
+      const outer = node.getBoundingClientRect();
+      const inner = media.getBoundingClientRect();
+      if (inner.width <= 0 || inner.height <= 0) return;
+      const next = {
+        width: inner.width,
+        height: inner.height,
+        left: inner.left - outer.left,
+        top: inner.top - outer.top,
+      };
+      // Rects come back fractional and a ResizeObserver fires on every layout
+      // pass, so setting state unconditionally re-renders the whole overlay
+      // continuously on any page that animates the card (these scale on hover).
+      setBox((current) => (same(current, next) ? current : next));
+    };
+
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(node);
+    observer.observe(media);
+    return () => observer.disconnect();
+  }, [hasPlacements]);
+
+  if (!hasPlacements) return null;
 
   return (
     <div ref={ref} className="pointer-events-none absolute inset-0 overflow-hidden">

--- a/src/components/Sticker/CardStickerOverlay.tsx
+++ b/src/components/Sticker/CardStickerOverlay.tsx
@@ -6,7 +6,21 @@ import { useStickerRevealStore } from '~/store/sticker-reveal.store';
 
 type Box = { width: number; height: number; left: number; top: number };
 
-const CARD_ARTWORK_WIDTH = 128;
+/**
+ * What a card asks the CDN for, against 512 on the detail view.
+ *
+ * A card is 450px wide and a sticker is capped at 0.25 of it by default (0.4 if
+ * the creator raises it), so it draws at ~112 CSS px — but a DPR-2 display wants
+ * 225 device px for that, and most laptops and phones are DPR 2+. 256 covers the
+ * default ceiling on retina and is still a quarter of 512's pixels. The band
+ * between 0.28 and the 0.4 maximum stays slightly soft, which is a creator
+ * opt-in.
+ *
+ * The first version of this was 128, from arithmetic that left device pixel
+ * ratio out and would have upscaled a default-size sticker by 1.8x — soft
+ * artwork a creator was paid for.
+ */
+const CARD_ARTWORK_WIDTH = 256;
 
 const same = (a: Box | null, b: Box) =>
   !!a && a.width === b.width && a.height === b.height && a.left === b.left && a.top === b.top;
@@ -126,9 +140,6 @@ export function CardStickerOverlay({ imageId }: { imageId: number }) {
             viewerId={currentUser?.id}
             interactive={false}
             sticker={batch?.sticker}
-            // A card is ~450px wide and a sticker is a fraction of it, so 512
-            // is roughly eight times the linear resolution it draws at, on the
-            // hottest path in the product.
             artworkWidth={CARD_ARTWORK_WIDTH}
           />
         </div>

--- a/src/components/Sticker/CardStickerOverlay.tsx
+++ b/src/components/Sticker/CardStickerOverlay.tsx
@@ -51,8 +51,8 @@ const offsetWithin = (el: HTMLElement, stop: Element | null) => {
  * overflow a block box, which anchors the crop left instead of centring it.
  * Reproducing that in arithmetic means encoding both templates' CSS here and
  * being wrong the day either changes — silently, and only for the class of
- * images whose aspect ratio makes the difference visible. Reading the element's
- * own rect is correct for whatever the stylesheet does.
+ * images whose aspect ratio makes the difference visible. Measuring the element
+ * is correct for whatever the stylesheet does.
  *
  * A consequence worth knowing rather than fixing: `cover` crops, so a sticker
  * placed low on a tall image is outside the visible box and not shown in a feed.
@@ -100,9 +100,9 @@ export function CardStickerOverlay({ imageId }: { imageId: number }) {
         left: at.x - self.x,
         top: at.y - self.y,
       };
-      // Rects come back fractional and a ResizeObserver fires on every layout
-      // pass, so setting state unconditionally re-renders the whole overlay
-      // continuously on any page that animates the card (these scale on hover).
+      // A ResizeObserver fires on every layout pass, so setting state
+      // unconditionally would re-render the overlay continuously on a page that
+      // animates the card — and these do, on hover.
       setBox((current) => (same(current, next) ? current : next));
     };
 
@@ -119,7 +119,11 @@ export function CardStickerOverlay({ imageId }: { imageId: number }) {
     <div ref={ref} className="pointer-events-none absolute inset-0 overflow-hidden">
       {box && (
         <div className="pointer-events-none absolute" style={box}>
-          <StickerPlacementOverlay placements={placements} viewerId={currentUser?.id} />
+          <StickerPlacementOverlay
+            placements={placements}
+            viewerId={currentUser?.id}
+            interactive={false}
+          />
         </div>
       )}
     </div>

--- a/src/components/Sticker/CardStickerOverlay.tsx
+++ b/src/components/Sticker/CardStickerOverlay.tsx
@@ -1,0 +1,78 @@
+import { useCallback, useState } from 'react';
+import { StickerPlacementOverlay } from '~/components/Sticker/StickerPlacementOverlay';
+import { useStickerPlacementBatch } from '~/components/Sticker/StickerPlacementBatchProvider';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useResizeObserver } from '~/hooks/useResizeObserver';
+import { useStickerRevealStore } from '~/store/sticker-reveal.store';
+
+type Box = { width: number; height: number; left: number; top: number };
+
+/**
+ * Placed stickers on a feed card.
+ *
+ * Card media is `object-fit: cover` with `object-position: top center`, so the
+ * rendered artwork is *larger* than the card and cropped by it — not
+ * letterboxed the way the detail view is. Positions are fractions of the
+ * artwork's bounds, so the overlay has to be the same rectangle the artwork was
+ * scaled to, and then clipped. Sizing it to the card instead would slide every
+ * sticker relative to the thing it was placed on, worst on exactly the images
+ * whose aspect ratio differs most from the card's.
+ *
+ * A consequence worth knowing rather than fixing: a sticker placed low on a tall
+ * image is outside the crop and therefore not visible in the feed at all.
+ */
+export function CardStickerOverlay({
+  imageId,
+  width,
+  height,
+}: {
+  imageId: number;
+  width?: number | null;
+  height?: number | null;
+}) {
+  const currentUser = useCurrentUser();
+  const revealed = useStickerRevealStore((state) => state.revealed);
+  const batch = useStickerPlacementBatch(imageId);
+  const [box, setBox] = useState<Box | null>(null);
+
+  const aspectRatio = width && height ? width / height : null;
+
+  const measure = useCallback(
+    (entry: ResizeObserverEntry) => {
+      if (!aspectRatio) return;
+      const { width: cw, height: ch } = entry.contentRect;
+      if (cw <= 0 || ch <= 0) return;
+
+      const covered =
+        aspectRatio > cw / ch
+          ? { width: ch * aspectRatio, height: ch }
+          : { width: cw, height: cw / aspectRatio };
+
+      setBox({ ...covered, left: (cw - covered.width) / 2, top: 0 });
+    },
+    [aspectRatio]
+  );
+
+  const ref = useResizeObserver<HTMLDivElement>(measure);
+
+  const placements = batch
+    ? revealed
+      ? batch.placements
+      : // Pending rows are scoped server-side to the placer and the owner, so
+        // anything pending here belongs to whoever is looking at it — and they
+        // have a decision to make, which the reveal toggle should not hide.
+        batch.pending
+    : [];
+
+  if (!aspectRatio || !placements.length) return null;
+
+  return (
+    <div ref={ref} className="pointer-events-none absolute inset-0 overflow-hidden">
+      {box && (
+        <div className="pointer-events-none absolute" style={box}>
+          <StickerPlacementOverlay placements={placements} viewerId={currentUser?.id} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Sticker/RemoveReportedPlacement.tsx
+++ b/src/components/Sticker/RemoveReportedPlacement.tsx
@@ -1,6 +1,7 @@
 import { Alert, Button, Group, Stack, Text } from '@mantine/core';
 import { openConfirmModal } from '@mantine/modals';
 import { IconTrash } from '@tabler/icons-react';
+import { useForgetStickerPlacement } from '~/components/Sticker/placement.util';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 
@@ -14,7 +15,7 @@ import { trpc } from '~/utils/trpc';
  * are taking down.
  */
 export function RemoveReportedPlacement({ placementId }: { placementId: number }) {
-  const utils = trpc.useUtils();
+  const forget = useForgetStickerPlacement();
 
   const { data: placement, isLoading } = trpc.placement.getStickerPlacementDetail.useQuery(
     { placementId },
@@ -28,7 +29,7 @@ export function RemoveReportedPlacement({ placementId }: { placementId: number }
           ? 'Placement removed.'
           : 'Nothing to remove — it had already been settled.',
       });
-      await utils.placement.invalidate();
+      await forget(placementId);
     },
     onError: (error) =>
       showErrorNotification({ title: "Couldn't remove it", error: new Error(error.message) }),

--- a/src/components/Sticker/RemoveReportedPlacement.tsx
+++ b/src/components/Sticker/RemoveReportedPlacement.tsx
@@ -1,0 +1,86 @@
+import { Alert, Button, Group, Stack, Text } from '@mantine/core';
+import { openConfirmModal } from '@mantine/modals';
+import { IconTrash } from '@tabler/icons-react';
+import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
+import { trpc } from '~/utils/trpc';
+
+/**
+ * The moderator's action on a sticker report.
+ *
+ * The report has always carried which placement it is about; until now nothing
+ * consumed it, so a moderator read the id out of the details dump and had no way
+ * to act on it. The detail lookup here is what makes the action safe to press —
+ * removal is not reversible, and an id alone does not tell you whose sticker you
+ * are taking down.
+ */
+export function RemoveReportedPlacement({ placementId }: { placementId: number }) {
+  const utils = trpc.useUtils();
+
+  const { data: placement, isLoading } = trpc.placement.getStickerPlacementDetail.useQuery(
+    { placementId },
+    { retry: false }
+  );
+
+  const remove = trpc.placement.removePlacement.useMutation({
+    onSuccess: async (result) => {
+      showSuccessNotification({
+        message: result.removed
+          ? 'Placement removed.'
+          : 'Nothing to remove — it had already been settled.',
+      });
+      await utils.placement.invalidate();
+    },
+    onError: (error) =>
+      showErrorNotification({ title: "Couldn't remove it", error: new Error(error.message) }),
+  });
+
+  if (isLoading) return null;
+
+  // The detail query only returns live placements, so a miss means this one is
+  // already gone — declined, expired, or removed by someone else.
+  if (!placement)
+    return (
+      <Alert color="gray">
+        <Text size="sm">This placement is no longer live. Nothing to remove.</Text>
+      </Alert>
+    );
+
+  const confirm = () =>
+    openConfirmModal({
+      title: 'Remove this placement',
+      children: (
+        <Stack gap="xs">
+          <Text size="sm">
+            {placement.sticker?.name ?? 'This sticker'}, placed by{' '}
+            {placement.placer?.username ?? 'an unknown user'}, comes off the image for everyone.
+          </Text>
+          <Text size="sm" c="dimmed">
+            {placement.status === 'pending'
+              ? 'It never went live, so its escrow is forfeited rather than refunded.'
+              : 'No Buzz moves: the creator was already paid for it, and clawing that back would punish the wrong person. Suspend the placer if the problem is them rather than this one sticker.'}
+          </Text>
+        </Stack>
+      ),
+      labels: { confirm: 'Remove', cancel: 'Cancel' },
+      confirmProps: { color: 'red' },
+      onConfirm: () => remove.mutate({ placementId }),
+    });
+
+  return (
+    <Group justify="space-between">
+      <Text size="sm">
+        {placement.sticker?.name ?? `Placement ${placementId}`} &middot;{' '}
+        {placement.placer?.username ?? 'unknown placer'}
+      </Text>
+      <Button
+        color="red"
+        size="compact-sm"
+        leftSection={<IconTrash size={14} />}
+        loading={remove.isPending}
+        onClick={confirm}
+      >
+        Remove placement
+      </Button>
+    </Group>
+  );
+}

--- a/src/components/Sticker/StickerPlacementBatchProvider.tsx
+++ b/src/components/Sticker/StickerPlacementBatchProvider.tsx
@@ -1,0 +1,125 @@
+import { createContext, useContext, useMemo } from 'react';
+import type { PlacedSticker } from '~/components/Sticker/placement.util';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { useStickerRevealStore } from '~/store/sticker-reveal.store';
+import { trpc } from '~/utils/trpc';
+
+/** Matches the `imageIds` cap on `getStickerPlacementsSchema`. */
+const PLACEMENT_FETCH_CHUNK = 100;
+
+type StickerPlacementBatch = {
+  counts: Record<number, number>;
+  byImage: Map<number, PlacedSticker[]>;
+};
+
+const StickerPlacementBatchContext = createContext<StickerPlacementBatch | null>(null);
+
+/**
+ * Placement data for a whole surface, fetched once for the ids on it.
+ *
+ * The alternative — placement riding along in the feed payload — would mean
+ * joining into `getInfiniteImages`, which is the hottest path in the product and
+ * edge-cached for anonymous users. It is not needed: the count query already
+ * takes an array, so a feed pays one lookup per 100 cards instead of one per
+ * card. tRPC request batching is behind a flag that is off by default, so a
+ * per-card query really is a per-card HTTP request.
+ *
+ * **Chunked in arrival order, not sorted.** Sorting looks tidier and is wrong
+ * here: a feed appends *older* (lower) ids as you scroll, so a sorted list
+ * reshuffles every chunk boundary on every page and refetches the entire feed's
+ * worth of placements each time. Arrival order means an earlier chunk's key
+ * never changes once it is full.
+ */
+export function StickerPlacementBatchProvider({
+  imageIds,
+  children,
+}: {
+  imageIds: number[];
+  children: React.ReactNode;
+}) {
+  const features = useFeatureFlags();
+  const currentUser = useCurrentUser();
+  const revealed = useStickerRevealStore((state) => state.revealed);
+
+  const enabled = !!features.stickers && !!features.stickerPlacement;
+
+  const chunks = useMemo(() => {
+    if (!enabled) return [] as number[][];
+    const unique = [...new Set(imageIds)];
+    const result: number[][] = [];
+    for (let i = 0; i < unique.length; i += PLACEMENT_FETCH_CHUNK)
+      result.push(unique.slice(i, i + PLACEMENT_FETCH_CHUNK));
+    return result;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [imageIds.join(','), enabled]);
+
+  const countQueries = trpc.useQueries((t) =>
+    chunks.map((chunk) =>
+      t.placement.getStickerPlacementCounts({ imageIds: chunk }, { staleTime: 60_000 })
+    )
+  );
+
+  // Same rule as the detail view: a signed-in viewer always fetches, because a
+  // pending placement is one they either paid for or are being asked to answer,
+  // and neither is discoverable from the count (which is approved-only).
+  const wantPlacements = enabled && (revealed || !!currentUser);
+  const placementQueries = trpc.useQueries((t) =>
+    chunks.map((chunk) =>
+      t.placement.getStickerPlacements(
+        { imageIds: chunk },
+        { staleTime: 60_000, enabled: wantPlacements }
+      )
+    )
+  );
+
+  const counts = useMemo(
+    () => Object.assign({}, ...countQueries.map((query) => query.data ?? {})),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [countQueries.map((query) => query.dataUpdatedAt).join(',')]
+  ) as Record<number, number>;
+
+  const byImage = useMemo(() => {
+    const map = new Map<number, PlacedSticker[]>();
+    for (const query of placementQueries)
+      for (const placement of (query.data as PlacedSticker[] | undefined) ?? []) {
+        const list = map.get(placement.imageId) ?? [];
+        list.push(placement);
+        map.set(placement.imageId, list);
+      }
+    return map;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [placementQueries.map((query) => query.dataUpdatedAt).join(',')]);
+
+  const value = useMemo(() => ({ counts, byImage }), [counts, byImage]);
+
+  if (!enabled) return <>{children}</>;
+
+  return (
+    <StickerPlacementBatchContext.Provider value={value}>
+      {children}
+    </StickerPlacementBatchContext.Provider>
+  );
+}
+
+/**
+ * What one card gets, or `null` on a surface with no provider.
+ *
+ * Deliberately no per-card fallback query: a card that quietly fetched for
+ * itself would reintroduce exactly the per-card request this exists to avoid,
+ * and it would do it invisibly, on whichever surface forgot the provider. A
+ * surface without one shows no stickers, which is a thing you can see.
+ */
+export function useStickerPlacementBatch(imageId: number) {
+  const batch = useContext(StickerPlacementBatchContext);
+
+  return useMemo(() => {
+    if (!batch) return null;
+    const placements = batch.byImage.get(imageId) ?? [];
+    return {
+      count: batch.counts[imageId] ?? 0,
+      placements,
+      pending: placements.filter((placement) => placement.isPending),
+    };
+  }, [batch, imageId]);
+}

--- a/src/components/Sticker/StickerPlacementBatchProvider.tsx
+++ b/src/components/Sticker/StickerPlacementBatchProvider.tsx
@@ -94,17 +94,27 @@ export function StickerPlacementBatchProvider({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [placementQueries.map((query) => query.dataUpdatedAt).join(',')]);
 
-  // Resolved here rather than per card. `useStickerCosmetics` chunks at 100 ids
-  // and caches forever, so a whole feed's artwork is a handful of requests —
-  // where a card resolving its own is a request per distinct sticker set, which
-  // is a request per card as soon as stickers vary. Batching the placements and
-  // then paying per card for the artwork needed to draw them would have left the
-  // headline property of this provider true only for the cheap half.
+  // Resolved here rather than per card. `useStickerCosmetics` chunks at 100 ids,
+  // so a whole surface's artwork is a handful of requests — where a card
+  // resolving its own is a request per distinct sticker set, which is a request
+  // per card as soon as stickers vary. Batching the placements and then paying
+  // per card for the artwork needed to draw them would have left the headline
+  // property of this provider true only for the cheap half.
+  //
+  // Per **surface**, not per page: a home page mounts several `ImagesProvider`s
+  // (feed block, collection blocks, profile sections) and each gets its own
+  // provider and its own query, with no sharing even where their sticker sets
+  // overlap. That is the per-surface design rather than a defect, and it is
+  // still far cheaper than the per-card cost it replaced.
+  //
+  // Deduped here as well as inside the hook: the hook's memo key is the joined
+  // id string, and a surface with 500 placements of 20 stickers would otherwise
+  // build and join a 500-element array on every render of this provider.
   const cosmeticIds = useMemo(() => {
-    const ids: number[] = [];
+    const ids = new Set<number>();
     for (const placements of byImage.values())
-      for (const placement of placements) ids.push(placement.data.cosmeticId);
-    return ids;
+      for (const placement of placements) ids.add(placement.data.cosmeticId);
+    return [...ids];
   }, [byImage]);
 
   const { sticker } = useStickerCosmetics(cosmeticIds);

--- a/src/components/Sticker/StickerPlacementBatchProvider.tsx
+++ b/src/components/Sticker/StickerPlacementBatchProvider.tsx
@@ -1,5 +1,7 @@
 import { createContext, useContext, useMemo } from 'react';
 import type { PlacedSticker } from '~/components/Sticker/placement.util';
+import type { ResolvedSticker } from '~/components/Sticker/sticker.util';
+import { useStickerCosmetics } from '~/components/Sticker/sticker.util';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { useStickerRevealStore } from '~/store/sticker-reveal.store';
@@ -11,6 +13,7 @@ const PLACEMENT_FETCH_CHUNK = 100;
 type StickerPlacementBatch = {
   counts: Record<number, number>;
   byImage: Map<number, PlacedSticker[]>;
+  sticker: Map<number, ResolvedSticker>;
 };
 
 const StickerPlacementBatchContext = createContext<StickerPlacementBatch | null>(null);
@@ -91,7 +94,22 @@ export function StickerPlacementBatchProvider({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [placementQueries.map((query) => query.dataUpdatedAt).join(',')]);
 
-  const value = useMemo(() => ({ counts, byImage }), [counts, byImage]);
+  // Resolved here rather than per card. `useStickerCosmetics` chunks at 100 ids
+  // and caches forever, so a whole feed's artwork is a handful of requests —
+  // where a card resolving its own is a request per distinct sticker set, which
+  // is a request per card as soon as stickers vary. Batching the placements and
+  // then paying per card for the artwork needed to draw them would have left the
+  // headline property of this provider true only for the cheap half.
+  const cosmeticIds = useMemo(() => {
+    const ids: number[] = [];
+    for (const placements of byImage.values())
+      for (const placement of placements) ids.push(placement.data.cosmeticId);
+    return ids;
+  }, [byImage]);
+
+  const { sticker } = useStickerCosmetics(cosmeticIds);
+
+  const value = useMemo(() => ({ counts, byImage, sticker }), [counts, byImage, sticker]);
 
   if (!enabled) return <>{children}</>;
 
@@ -120,6 +138,7 @@ export function useStickerPlacementBatch(imageId: number) {
       count: batch.counts[imageId] ?? 0,
       placements,
       pending: placements.filter((placement) => placement.isPending),
+      sticker: batch.sticker,
     };
   }, [batch, imageId]);
 }

--- a/src/components/Sticker/StickerPlacementCardBadge.tsx
+++ b/src/components/Sticker/StickerPlacementCardBadge.tsx
@@ -1,0 +1,57 @@
+import { Button, Text, Tooltip } from '@mantine/core';
+import { IconSticker } from '@tabler/icons-react';
+import clsx from 'clsx';
+import { useStickerPlacementBatch } from '~/components/Sticker/StickerPlacementBatchProvider';
+import { useStickerRevealStore } from '~/store/sticker-reveal.store';
+
+/**
+ * The reaction-bar entry on a feed card: how many stickers are here, and the
+ * reveal toggle.
+ *
+ * No way in to *placing* one, unlike `StickerPlacementBar` on the detail view.
+ * That is a positioning gesture on a card-sized crop of someone else's work, and
+ * the affordance would also cost a per-card query for the space and its price.
+ * The reveal is the same site-wide sticky store, so pressing it here turns
+ * stickers on in the detail view too.
+ */
+export function StickerPlacementCardBadge({
+  imageId,
+  className,
+}: {
+  imageId: number;
+  className?: string;
+}) {
+  const batch = useStickerPlacementBatch(imageId);
+  const revealed = useStickerRevealStore((state) => state.revealed);
+  const toggle = useStickerRevealStore((state) => state.toggle);
+
+  // Approved plus the viewer's own pending, matching what the toggle reveals.
+  const total = batch ? batch.count + batch.pending.length : 0;
+  if (!total) return null;
+
+  return (
+    <Tooltip
+      label={revealed ? 'Hide stickers on all images' : 'Show stickers on all images'}
+      withArrow
+    >
+      <Button
+        size="compact-sm"
+        radius="xl"
+        variant={revealed ? 'light' : 'subtle'}
+        color="gray"
+        className={clsx('pointer-events-auto', className)}
+        onClick={(event: React.MouseEvent) => {
+          // A card is a link, and this sits inside it.
+          event.preventDefault();
+          event.stopPropagation();
+          toggle();
+        }}
+        leftSection={<IconSticker size={16} />}
+      >
+        <Text size="xs" fw={600}>
+          {total}
+        </Text>
+      </Button>
+    </Tooltip>
+  );
+}

--- a/src/components/Sticker/StickerPlacementHoverCard.tsx
+++ b/src/components/Sticker/StickerPlacementHoverCard.tsx
@@ -1,10 +1,14 @@
-import { Anchor, Badge, Group, HoverCard, Skeleton, Text } from '@mantine/core';
-import { IconSticker } from '@tabler/icons-react';
+import { Anchor, Badge, Group, HoverCard, Skeleton, Text, Tooltip } from '@mantine/core';
+import { openConfirmModal } from '@mantine/modals';
+import { IconSticker, IconTrash } from '@tabler/icons-react';
 import dynamic from 'next/dynamic';
+import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
 import type { ReactElement } from 'react';
 import { useState } from 'react';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { daysFromNow, formatDate } from '~/utils/date-helpers';
+import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 
 // Loaded with the hover, not with the page. The creator card drags in profile
@@ -133,6 +137,7 @@ export function StickerPlacementHoverCard({
               Awaiting review
             </Badge>
           )}
+          <ModeratorRemove placementId={placementId} />
         </Group>
 
         {/* A skeleton rather than a spinner: the card's size is known before its
@@ -148,5 +153,66 @@ export function StickerPlacementHoverCard({
         )}
       </HoverCard.Dropdown>
     </HoverCard>
+  );
+}
+
+/**
+ * A moderator taking a sticker off the content it was placed on, from the
+ * sticker itself.
+ *
+ * The report queue is the route for something a user complained about; this is
+ * the route for a moderator who is looking at the image and can see the problem.
+ * Same mutation either way, so the two cannot drift into different rules about
+ * what removal means.
+ *
+ * Nothing else happens: no refund, and nobody is notified (Justin, 2026-08-08).
+ * The escrow on a live placement was paid to a content owner who did not choose
+ * the sticker, and clawing it back would charge them for someone else's problem.
+ *
+ * Rendered for moderators only, which is convenience — `removePlacement` is a
+ * `moderatorProcedure`, so the refusal is on the mutation and stays there.
+ */
+function ModeratorRemove({ placementId }: { placementId: number }) {
+  const currentUser = useCurrentUser();
+  const utils = trpc.useUtils();
+
+  const remove = trpc.placement.removePlacement.useMutation({
+    onSuccess: async () => {
+      showSuccessNotification({ message: 'Placement removed.' });
+      await utils.placement.invalidate();
+    },
+    onError: (error) =>
+      showErrorNotification({ title: "Couldn't remove it", error: new Error(error.message) }),
+  });
+
+  if (!currentUser?.isModerator) return null;
+
+  return (
+    <Tooltip label="Remove this sticker from the content" withArrow>
+      <LegacyActionIcon
+        color="red"
+        variant="subtle"
+        size="sm"
+        className="shrink-0"
+        aria-label="Remove placement"
+        loading={remove.isPending}
+        onClick={() =>
+          openConfirmModal({
+            title: 'Remove this placement',
+            children: (
+              <Text size="sm">
+                The sticker comes off this content for everyone. No Buzz moves and nobody is
+                notified.
+              </Text>
+            ),
+            labels: { confirm: 'Remove', cancel: 'Cancel' },
+            confirmProps: { color: 'red' },
+            onConfirm: () => remove.mutate({ placementId }),
+          })
+        }
+      >
+        <IconTrash size={14} />
+      </LegacyActionIcon>
+    </Tooltip>
   );
 }

--- a/src/components/Sticker/StickerPlacementHoverCard.tsx
+++ b/src/components/Sticker/StickerPlacementHoverCard.tsx
@@ -4,6 +4,7 @@ import { IconSticker, IconTrash } from '@tabler/icons-react';
 import dynamic from 'next/dynamic';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
+import { useForgetStickerPlacement } from '~/components/Sticker/placement.util';
 import type { ReactElement } from 'react';
 import { useState } from 'react';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
@@ -174,12 +175,12 @@ export function StickerPlacementHoverCard({
  */
 function ModeratorRemove({ placementId }: { placementId: number }) {
   const currentUser = useCurrentUser();
-  const utils = trpc.useUtils();
+  const forget = useForgetStickerPlacement();
 
   const remove = trpc.placement.removePlacement.useMutation({
     onSuccess: async () => {
       showSuccessNotification({ message: 'Placement removed.' });
-      await utils.placement.invalidate();
+      await forget(placementId);
     },
     onError: (error) =>
       showErrorNotification({ title: "Couldn't remove it", error: new Error(error.message) }),

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -22,10 +22,21 @@ export function StickerPlacementOverlay({
   placements,
   viewerId,
   className,
+  interactive = true,
 }: {
   placements: PlacedSticker[];
   viewerId?: number;
   className?: string;
+  /**
+   * Off on a feed card, where the card is a link and the layer is clipped.
+   *
+   * An interactive sticker is a hole in the card that does not open the image —
+   * at `scale: 0.3` roughly a third of its width — and the owner's approve /
+   * decline buttons sit below the sticker, so on anything placed low they are
+   * cut off by the card's `overflow-hidden` and offered half-visible. Both are
+   * fine at detail size, which is the only place this rendered before.
+   */
+  interactive?: boolean;
 }) {
   const cosmeticIds = useMemo(
     () => placements.map((placement) => placement.data.cosmeticId),
@@ -50,7 +61,7 @@ export function StickerPlacementOverlay({
         const body = (
           <div
             key={placement.id}
-            className="pointer-events-auto absolute"
+            className={clsx('absolute', interactive && 'pointer-events-auto')}
             style={{
               left: `${placement.data.x * 100}%`,
               top: `${placement.data.y * 100}%`,
@@ -78,6 +89,11 @@ export function StickerPlacementOverlay({
             )}
           </div>
         );
+
+        // A hover card needs something to hover, so a non-interactive layer gets
+        // the sticker alone. The detail view is one click away and carries all
+        // of it.
+        if (!interactive) return body;
 
         if (!placement.isPending)
           return (

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 import { EdgeImage } from '~/components/EdgeMedia/EdgeImage';
+import type { ResolvedSticker } from '~/components/Sticker/sticker.util';
 import { useStickerCosmetics } from '~/components/Sticker/sticker.util';
 import type { PlacedSticker } from '~/components/Sticker/placement.util';
 import { StickerPlacementActions } from '~/components/Sticker/StickerPlacementActions';
@@ -23,6 +24,8 @@ export function StickerPlacementOverlay({
   viewerId,
   className,
   interactive = true,
+  sticker,
+  artworkWidth = 512,
 }: {
   placements: PlacedSticker[];
   viewerId?: number;
@@ -37,19 +40,42 @@ export function StickerPlacementOverlay({
    * fine at detail size, which is the only place this rendered before.
    */
   interactive?: boolean;
+  /**
+   * Artwork already resolved for the whole surface.
+   *
+   * Without it this component resolves its own, which is one query per instance
+   * — fine on the detail view where there is one, and a request per card on a
+   * feed, since cards hold different sticker sets and so produce different query
+   * keys. That is the exact cost the batch provider exists to remove, and it
+   * removed it for placements and counts while the artwork still had to be
+   * fetched to draw anything.
+   */
+  sticker?: Map<number, ResolvedSticker>;
+  /**
+   * Width to request from the CDN. 512 is a sticker's natural size — the
+   * artwork rules cap the long edge there — and right for the detail view. A
+   * card draws one at a fraction of a ~450px box, so it asks for less; the CDN
+   * caches a variant per width, so this mints a second one rather than being
+   * free.
+   */
+  artworkWidth?: number;
 }) {
   const cosmeticIds = useMemo(
-    () => placements.map((placement) => placement.data.cosmeticId),
-    [placements]
+    () =>
+      // Nothing to resolve when the surface already did it. `useStickerCosmetics`
+      // issues no query for an empty list, and a hook cannot be skipped.
+      sticker ? [] : placements.map((placement) => placement.data.cosmeticId),
+    [placements, sticker]
   );
-  const { sticker } = useStickerCosmetics(cosmeticIds);
+  const { sticker: resolved } = useStickerCosmetics(cosmeticIds);
+  const artwork = sticker ?? resolved;
 
   if (!placements.length) return null;
 
   return (
     <div className={clsx('pointer-events-none absolute inset-0 overflow-hidden', className)}>
       {placements.map((placement) => {
-        const art = sticker.get(placement.data.cosmeticId);
+        const art = artwork.get(placement.data.cosmeticId);
         if (!art) return null;
 
         // Pending rows only ever reach a viewer who is party to them — the
@@ -72,10 +98,9 @@ export function StickerPlacementOverlay({
             <EdgeImage
               src={art.url}
               alt={`:${art.slug}:`}
-              // A fixed request width rather than a measured one: the artwork
-              // rules cap a sticker's long edge at 512, so this is its natural
-              // size and the element scales it down in layout.
-              options={{ width: 512, anim: art.animated, optimized: true }}
+              // A fixed request width rather than a measured one: a sticker has
+              // a natural size and the element scales it down in layout.
+              options={{ width: artworkWidth, anim: art.animated, optimized: true }}
               className={clsx(placement.isPending && 'opacity-60')}
               style={{ width: '100%', height: 'auto', display: 'block' }}
             />

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -38,6 +38,12 @@ export function StickerPlacementOverlay({
    * decline buttons sit below the sticker, so on anything placed low they are
    * cut off by the card's `overflow-hidden` and offered half-visible. Both are
    * fine at detail size, which is the only place this rendered before.
+   *
+   * It also takes the hover card with it, and the moderator remove action inside
+   * it — so that action is detail-view only, which is where Justin asked for it.
+   * `key={placement.id}` on `body` below is load-bearing because of this: it was
+   * inert while every return was wrapped in a keyed element, and it is now what
+   * keys the array item on the non-interactive path.
    */
   interactive?: boolean;
   /**

--- a/src/components/Sticker/__tests__/placement-cache.test.ts
+++ b/src/components/Sticker/__tests__/placement-cache.test.ts
@@ -47,14 +47,17 @@ describe('dropping a removed placement out of a cached list', () => {
     expect(result.countedOn).toBeUndefined();
   });
 
-  // The updater runs against every cached chunk, and all but one of them do not
-  // hold the row. Returning a rebuilt array there would replace the cached
-  // reference on every chunk in the feed and re-render all of them.
-  it('leaves a chunk that does not hold the row exactly as it was', () => {
+  // The updater runs against every cached chunk and all but one of them do not
+  // hold the row. Returning the array back — even the same reference — makes
+  // `setQueryData` write it and stamp a fresh `dataUpdatedAt`, which is what the
+  // batch provider memoises on, so every chunk in the feed recomputes.
+  // `undefined` is the only return it skips.
+  it('returns undefined for a chunk that does not hold the row, so the write is skipped', () => {
     const chunk = [OTHER];
     const result = dropPlacementFromList(chunk, APPROVED.id);
 
-    expect(result.placements).toBe(chunk);
+    expect(result.placements).toBeUndefined();
+    expect(chunk).toEqual([OTHER]);
     expect(result.countedOn).toBeUndefined();
   });
 

--- a/src/components/Sticker/__tests__/placement-cache.test.ts
+++ b/src/components/Sticker/__tests__/placement-cache.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import type { PlacedSticker } from '~/components/Sticker/placement.util';
+import {
+  decrementPlacementCount,
+  dropPlacementFromList,
+} from '~/components/Sticker/placement.util';
+
+/**
+ * The cache patch a moderator removal applies instead of invalidating every
+ * placement query on the page.
+ *
+ * These are the two rules that decide whether the reaction bar still agrees with
+ * what is drawn afterwards, and they are pure so they can be checked without a
+ * query client or a browser.
+ */
+
+const placement = (id: number, imageId: number, isPending = false): PlacedSticker => ({
+  id,
+  imageId,
+  placerId: 601,
+  ownerId: 602,
+  status: isPending ? 'pending' : 'approved',
+  amount: 75,
+  data: { cosmeticId: 900, x: 0.5, y: 0.5, scale: 0.2, rotation: 0 },
+  isPending,
+});
+
+const APPROVED = placement(5001, 8100);
+const PENDING = placement(5002, 8101, true);
+const OTHER = placement(5003, 8102);
+
+describe('dropping a removed placement out of a cached list', () => {
+  it('removes the row and reports the image whose count it was in', () => {
+    const result = dropPlacementFromList([APPROVED, OTHER], APPROVED.id);
+
+    expect(result.placements?.map((p) => p.id)).toEqual([OTHER.id]);
+    expect(result.countedOn).toBe(8100);
+  });
+
+  // getStickerPlacementCounts is approved-only, so a pending row was never in
+  // it. Decrementing for one leaves the badge a sticker short of what is drawn,
+  // because the bar adds the viewer's own pending rows on top of the count.
+  it('reports no image to decrement when the row was pending', () => {
+    const result = dropPlacementFromList([PENDING, OTHER], PENDING.id);
+
+    expect(result.placements?.map((p) => p.id)).toEqual([OTHER.id]);
+    expect(result.countedOn).toBeUndefined();
+  });
+
+  // The updater runs against every cached chunk, and all but one of them do not
+  // hold the row. Returning a rebuilt array there would replace the cached
+  // reference on every chunk in the feed and re-render all of them.
+  it('leaves a chunk that does not hold the row exactly as it was', () => {
+    const chunk = [OTHER];
+    const result = dropPlacementFromList(chunk, APPROVED.id);
+
+    expect(result.placements).toBe(chunk);
+    expect(result.countedOn).toBeUndefined();
+  });
+
+  it('survives a cache entry that has no data yet', () => {
+    const result = dropPlacementFromList(undefined, APPROVED.id);
+
+    expect(result.placements).toBeUndefined();
+    expect(result.countedOn).toBeUndefined();
+  });
+});
+
+describe('decrementing the count for that image', () => {
+  it('takes one off the right image and leaves the others alone', () => {
+    expect(decrementPlacementCount({ 8100: 3, 8102: 7 }, 8100)).toEqual({ 8100: 2, 8102: 7 });
+  });
+
+  // A count that is absent or already zero is not a count to take from — going
+  // negative would render as "-1 stickers".
+  it('refuses to go below zero, and ignores an image it has no count for', () => {
+    expect(decrementPlacementCount({ 8100: 0 }, 8100)).toEqual({ 8100: 0 });
+    expect(decrementPlacementCount({ 8102: 7 }, 8100)).toEqual({ 8102: 7 });
+  });
+
+  it('survives a cache entry that has no data yet', () => {
+    expect(decrementPlacementCount(undefined, 8100)).toBeUndefined();
+  });
+});

--- a/src/components/Sticker/placement.util.ts
+++ b/src/components/Sticker/placement.util.ts
@@ -1,4 +1,6 @@
-import { useMemo } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { getQueryKey } from '@trpc/react-query';
+import { useCallback, useMemo } from 'react';
 import { useStickerPlacementDraftStore } from '~/store/sticker-placement-draft.store';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
@@ -67,6 +69,56 @@ export function useStickerPlacementCounts(imageIds: number[], enabled = true) {
   );
 
   return (data ?? {}) as Record<number, number>;
+}
+
+/**
+ * Drops one placement out of whatever is already cached, without refetching.
+ *
+ * `utils.placement.invalidate()` is the obvious call and the wrong one on a
+ * feed: the batch provider holds two queries per 100 cards, so a moderator
+ * removing a sticker after scrolling a couple of thousand images would refetch
+ * forty of them — and tRPC request batching is off by default, so that is forty
+ * HTTP requests for a change that affects one row. The removal is authoritative
+ * server-side; the client only has to stop drawing it.
+ *
+ * The detail query IS invalidated, by id: it is one request, and the surfaces
+ * that offer removal read it to decide whether the placement is still live.
+ */
+export function useForgetStickerPlacement() {
+  const queryClient = useQueryClient();
+  const utils = trpc.useUtils();
+
+  return useCallback(
+    async (placementId: number) => {
+      let imageId: number | undefined;
+
+      queryClient.setQueriesData<PlacedSticker[]>(
+        { queryKey: getQueryKey(trpc.placement.getStickerPlacements), exact: false },
+        (placements) => {
+          const hit = placements?.find((placement) => placement.id === placementId);
+          if (!hit) return placements;
+          imageId = hit.imageId;
+          return placements?.filter((placement) => placement.id !== placementId);
+        }
+      );
+
+      // Only when the placement was actually in a cached list, and only for its
+      // own image — the count is approved-only, so a pending row was never in it
+      // and decrementing would show one fewer sticker than are drawn.
+      if (imageId !== undefined)
+        queryClient.setQueriesData<Record<number, number>>(
+          { queryKey: getQueryKey(trpc.placement.getStickerPlacementCounts), exact: false },
+          (counts) => {
+            const current = counts?.[imageId as number];
+            if (!counts || !current) return counts;
+            return { ...counts, [imageId as number]: current - 1 };
+          }
+        );
+
+      await utils.placement.getStickerPlacementDetail.invalidate({ placementId });
+    },
+    [queryClient, utils]
+  );
 }
 
 export function useImagePlacementSpace(imageId?: number) {

--- a/src/components/Sticker/placement.util.ts
+++ b/src/components/Sticker/placement.util.ts
@@ -119,6 +119,10 @@ export function decrementPlacementCount(
  * HTTP requests for a change that affects one row. The removal is authoritative
  * server-side; the client only has to stop drawing it.
  *
+ * That is reachable from the image detail view too, not only from a feed: the
+ * detail opens as a routed dialog *over* the feed, so the provider and every
+ * chunk it holds stay mounted behind it.
+ *
  * The detail query IS invalidated, by id: it is one request, and the surfaces
  * that offer removal read it to decide whether the placement is still live.
  */

--- a/src/components/Sticker/placement.util.ts
+++ b/src/components/Sticker/placement.util.ts
@@ -84,35 +84,61 @@ export function useStickerPlacementCounts(imageIds: number[], enabled = true) {
  * The detail query IS invalidated, by id: it is one request, and the surfaces
  * that offer removal read it to decide whether the placement is still live.
  */
+/**
+ * The removed row out of one cached list, and the image to decrement — which is
+ * `undefined` unless the row was **approved**.
+ *
+ * `getStickerPlacementCounts` is approved-only, so a pending row was never in
+ * it. Decrementing for one would leave the badge a sticker short of what is
+ * drawn, and the reaction bar adds the viewer's own pending rows to the count.
+ * Exported and pure so this rule is testable without a query client.
+ */
+export function dropPlacementFromList(
+  placements: PlacedSticker[] | undefined,
+  placementId: number
+) {
+  const hit = placements?.find((placement) => placement.id === placementId);
+  if (!hit || !placements) return { placements, countedOn: undefined };
+
+  return {
+    placements: placements.filter((placement) => placement.id !== placementId),
+    countedOn: hit.isPending ? undefined : hit.imageId,
+  };
+}
+
+/** One off the count for that image, and only if there is one to take. */
+export function decrementPlacementCount(
+  counts: Record<number, number> | undefined,
+  imageId: number
+) {
+  const current = counts?.[imageId];
+  if (!counts || !current) return counts;
+  return { ...counts, [imageId]: current - 1 };
+}
+
 export function useForgetStickerPlacement() {
   const queryClient = useQueryClient();
   const utils = trpc.useUtils();
 
   return useCallback(
     async (placementId: number) => {
-      let imageId: number | undefined;
+      let countedOn: number | undefined;
 
       queryClient.setQueriesData<PlacedSticker[]>(
         { queryKey: getQueryKey(trpc.placement.getStickerPlacements), exact: false },
         (placements) => {
-          const hit = placements?.find((placement) => placement.id === placementId);
-          if (!hit) return placements;
-          imageId = hit.imageId;
-          return placements?.filter((placement) => placement.id !== placementId);
+          const result = dropPlacementFromList(placements, placementId);
+          // Assigned only on the one cached chunk that held the row; the rest
+          // return their data untouched and leave this alone.
+          if (result.countedOn !== undefined) countedOn = result.countedOn;
+          return result.placements;
         }
       );
 
-      // Only when the placement was actually in a cached list, and only for its
-      // own image — the count is approved-only, so a pending row was never in it
-      // and decrementing would show one fewer sticker than are drawn.
-      if (imageId !== undefined)
+      if (countedOn !== undefined)
         queryClient.setQueriesData<Record<number, number>>(
           { queryKey: getQueryKey(trpc.placement.getStickerPlacementCounts), exact: false },
-          (counts) => {
-            const current = counts?.[imageId as number];
-            if (!counts || !current) return counts;
-            return { ...counts, [imageId as number]: current - 1 };
-          }
+          (counts) => decrementPlacementCount(counts, countedOn as number)
         );
 
       await utils.placement.getStickerPlacementDetail.invalidate({ placementId });

--- a/src/components/Sticker/placement.util.ts
+++ b/src/components/Sticker/placement.util.ts
@@ -72,19 +72,6 @@ export function useStickerPlacementCounts(imageIds: number[], enabled = true) {
 }
 
 /**
- * Drops one placement out of whatever is already cached, without refetching.
- *
- * `utils.placement.invalidate()` is the obvious call and the wrong one on a
- * feed: the batch provider holds two queries per 100 cards, so a moderator
- * removing a sticker after scrolling a couple of thousand images would refetch
- * forty of them — and tRPC request batching is off by default, so that is forty
- * HTTP requests for a change that affects one row. The removal is authoritative
- * server-side; the client only has to stop drawing it.
- *
- * The detail query IS invalidated, by id: it is one request, and the surfaces
- * that offer removal read it to decide whether the placement is still live.
- */
-/**
  * The removed row out of one cached list, and the image to decrement — which is
  * `undefined` unless the row was **approved**.
  *
@@ -92,13 +79,19 @@ export function useStickerPlacementCounts(imageIds: number[], enabled = true) {
  * it. Decrementing for one would leave the badge a sticker short of what is
  * drawn, and the reaction bar adds the viewer's own pending rows to the count.
  * Exported and pure so this rule is testable without a query client.
+ *
+ * A chunk with no hit yields `undefined` rather than its own array back.
+ * `setQueryData` writes any defined value it is handed and stamps a fresh
+ * `dataUpdatedAt` even for an identical reference — and the batch provider
+ * memoises on exactly that — so `undefined` is the only return that leaves an
+ * untouched chunk genuinely untouched.
  */
 export function dropPlacementFromList(
   placements: PlacedSticker[] | undefined,
   placementId: number
 ) {
   const hit = placements?.find((placement) => placement.id === placementId);
-  if (!hit || !placements) return { placements, countedOn: undefined };
+  if (!hit || !placements) return { placements: undefined, countedOn: undefined };
 
   return {
     placements: placements.filter((placement) => placement.id !== placementId),
@@ -116,6 +109,19 @@ export function decrementPlacementCount(
   return { ...counts, [imageId]: current - 1 };
 }
 
+/**
+ * Drops one placement out of whatever is already cached, without refetching.
+ *
+ * `utils.placement.invalidate()` is the obvious call and the wrong one on a
+ * feed: the batch provider holds two queries per 100 cards, so a moderator
+ * removing a sticker after scrolling a couple of thousand images would refetch
+ * forty of them — and tRPC request batching is off by default, so that is forty
+ * HTTP requests for a change that affects one row. The removal is authoritative
+ * server-side; the client only has to stop drawing it.
+ *
+ * The detail query IS invalidated, by id: it is one request, and the surfaces
+ * that offer removal read it to decide whether the placement is still live.
+ */
 export function useForgetStickerPlacement() {
   const queryClient = useQueryClient();
   const utils = trpc.useUtils();
@@ -128,8 +134,8 @@ export function useForgetStickerPlacement() {
         { queryKey: getQueryKey(trpc.placement.getStickerPlacements), exact: false },
         (placements) => {
           const result = dropPlacementFromList(placements, placementId);
-          // Assigned only on the one cached chunk that held the row; the rest
-          // return their data untouched and leave this alone.
+          // Assigned only on the chunk that held the row; every other chunk
+          // returns `undefined`, which skips the write and leaves this alone.
           if (result.countedOn !== undefined) countedOn = result.countedOn;
           return result.placements;
         }

--- a/src/components/Sticker/sticker.util.ts
+++ b/src/components/Sticker/sticker.util.ts
@@ -67,7 +67,15 @@ export function useOwnedSticker() {
  */
 export function useStickerCosmetics(ids: number[]) {
   const chunks = useMemo(() => {
-    const unique = [...new Set(ids)].sort((a, b) => a - b);
+    // **Insertion order, not sorted.** Sorting makes a key independent of the
+    // order ids arrive in, which is worth a little when two components ask for
+    // the same set differently ordered — and costs a lot to the one consumer
+    // whose list GROWS. A feed appends older, lower cosmetic ids as it pages;
+    // sorted, each one lands mid-list, shifts every chunk boundary after it,
+    // changes every chunk key, and refetches the whole surface's artwork. Below
+    // 100 distinct stickers there is one chunk and no boundary to shift, so this
+    // only bites the case that matters: a long scroll once stickers are popular.
+    const unique = [...new Set(ids)];
     const result: number[][] = [];
     for (let i = 0; i < unique.length; i += STICKER_FETCH_CHUNK)
       result.push(unique.slice(i, i + STICKER_FETCH_CHUNK));
@@ -77,7 +85,13 @@ export function useStickerCosmetics(ids: number[]) {
 
   const queries = trpc.useQueries((t) =>
     chunks.map((chunk) =>
-      t.cosmetic.getSticker({ ids: chunk }, { staleTime: Infinity, gcTime: Infinity })
+      // Sticker artwork is immutable once published, so it never goes stale. It
+      // is not kept forever, though: a growing list mints a new key per page and
+      // the superseded ones are all subsets of the newest, so `gcTime: Infinity`
+      // would accumulate every intermediate list for the length of a session —
+      // the same never-leaves shape this feature keeps producing, in client
+      // memory this time.
+      t.cosmetic.getSticker({ ids: chunk }, { staleTime: Infinity, gcTime: 10 * 60_000 })
     )
   );
 

--- a/src/pages/moderator/reports.tsx
+++ b/src/pages/moderator/reports.tsx
@@ -38,6 +38,7 @@ import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon
 import { Meta } from '~/components/Meta/Meta';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
 import { RenderHtml } from '~/components/RenderHtml/RenderHtml';
+import { RemoveReportedPlacement } from '~/components/Sticker/RemoveReportedPlacement';
 import { env } from '~/env/client';
 import { useIsMobile } from '~/hooks/useIsMobile';
 import { Form, InputTextArea, useForm } from '~/libs/form';
@@ -287,6 +288,10 @@ function ReportDrawer({
   const theme = useMantineTheme();
   const mobile = useIsMobile();
   const href = useMemo(() => (report ? getReportLink(report) : null), [report]);
+  const reportedPlacementId = useMemo(
+    () => (report ? getReportedPlacementId(report) : null),
+    [report]
+  );
   const queryUtils = trpc.useUtils();
 
   const form = useForm({
@@ -351,6 +356,9 @@ function ReportDrawer({
             </Link>
           )}
           <ReportDetails report={report} />
+          {reportedPlacementId !== null && (
+            <RemoveReportedPlacement placementId={reportedPlacementId} />
+          )}
           <Input.Wrapper
             label="Status"
             description="Use this input to set the status of the report"
@@ -444,6 +452,22 @@ function ReportDetails({ report }: { report: ReportDetail }) {
 
   return <DescriptionTable items={detailItems} labelWidth="30%" />;
 }
+
+/**
+ * `details` is untyped JSON off the row, and the form coerces `placementId` from
+ * a radio value, so it can arrive as either a number or its string. Anything
+ * else means this report predates the field or was written by hand, and the
+ * action is not offered rather than pointed at a guess.
+ */
+const getReportedPlacementId = (report: ReportDetail) => {
+  if (report.reason !== ReportReason.StickerPlacement) return null;
+  const { details } = report;
+  if (!details || typeof details !== 'object' || Array.isArray(details)) return null;
+
+  const raw = (details as Record<string, unknown>).placementId;
+  const id = typeof raw === 'string' ? Number(raw) : raw;
+  return typeof id === 'number' && Number.isInteger(id) && id > 0 ? id : null;
+};
 
 const getReportLink = (report: ReportDetail) => {
   if (report.model) return getModelUrl({ modelId: report.model.id, modelName: report.model.name });

--- a/src/server/__tests__/creator-shop-pack-takedown.test.ts
+++ b/src/server/__tests__/creator-shop-pack-takedown.test.ts
@@ -191,12 +191,10 @@ describe('takedownCosmeticShopItem — pack scoping', () => {
     expect(ownerQuery?.where?.claimKey).toEqual({ in: ['pack-tx-1'] });
   });
 
-  // A pack takedown archives the bundle and never delists its members, and it
-  // carries no per-member abuse designation — so sweeping here would remove
-  // every placement of every member site-wide while those members stay
-  // purchasable and immediately re-placeable. Incoherent under either answer to
-  // "should a pack takedown treat every member as abusive", so it waits for the
-  // ruling. Skipping is the additive direction.
+  // Taking a pack down takes down the bundle, not the artwork in it (Justin,
+  // 2026-08-09) — its members stay on sale, so sweeping their placements would
+  // judge artwork nobody judged, and leave it purchasable and immediately
+  // re-placeable. Abusive artwork is taken down per member, and that sweeps.
   const sweepArgs = () => mocks.removePlacementsByCosmetic.mock.calls[0]?.[0];
 
   it('does not sweep placements for a pack takedown', async () => {

--- a/src/server/__tests__/creator-shop-pack-takedown.test.ts
+++ b/src/server/__tests__/creator-shop-pack-takedown.test.ts
@@ -22,6 +22,7 @@ const { mocks } = vi.hoisted(() => ({
     userCosmeticFindMany: vi.fn(),
     userFindUnique: vi.fn(),
     revokeCosmeticsFromUsers: vi.fn(),
+    removePlacementsByCosmetic: vi.fn(),
     refundMultiAccountTransaction: vi.fn(),
     createBuzzTransaction: vi.fn(),
     refundTransaction: vi.fn(),
@@ -59,6 +60,9 @@ vi.mock('~/server/services/cosmetic.service', () => ({
   revokeCosmeticsFromUsers: mocks.revokeCosmeticsFromUsers,
   validateStickerCosmetic: vi.fn(),
   isStickerSlugAvailable: vi.fn(),
+}));
+vi.mock('~/server/services/placement-moderation.service', () => ({
+  removePlacementsByCosmetic: mocks.removePlacementsByCosmetic,
 }));
 vi.mock('~/server/services/notification.service', () => ({
   createNotification: mocks.createNotification,
@@ -110,6 +114,13 @@ beforeEach(() => {
   mocks.shopItemFindFirst.mockResolvedValue(null);
   mocks.shopItemUpdateMany.mockResolvedValue({ count: 0 });
   mocks.revokeCosmeticsFromUsers.mockResolvedValue({ revoked: 0 });
+  mocks.removePlacementsByCosmetic.mockResolvedValue({
+    considered: 0,
+    settled: 0,
+    failed: [],
+    takenDown: 0,
+    hasMore: false,
+  });
   mocks.refundMultiAccountTransaction.mockResolvedValue({
     refundedTransactions: [{ accountType: 'yellow', amount: 5000 }],
   });
@@ -178,6 +189,43 @@ describe('takedownCosmeticShopItem — pack scoping', () => {
     // A wider lookup than the revoke would report owners who keep their items.
     const ownerQuery = mocks.userCosmeticFindMany.mock.calls.at(-1)?.[0];
     expect(ownerQuery?.where?.claimKey).toEqual({ in: ['pack-tx-1'] });
+  });
+
+  // The placement sweep has to inherit the revoke's scope. Unscoped, it removes
+  // placements made with a member someone bought standalone — that person keeps
+  // the cosmetic, gets no refund, and still loses the placement they paid for.
+  const sweepArgs = () => mocks.removePlacementsByCosmetic.mock.calls[0]?.[0];
+
+  it('scopes the placement sweep to the placers whose holdings it revoked', async () => {
+    mocks.purchaseFindMany.mockResolvedValue([
+      purchase('pack-tx-1'),
+      purchase('pack-tx-2', OTHER_OWNER),
+    ]);
+    mocks.userCosmeticFindMany.mockResolvedValue([{ userId: PACK_BUYER }, { userId: OTHER_OWNER }]);
+    await takedownCosmeticShopItem({ id: PACK_ID, reason: 'test', moderatorId: MODERATOR });
+    expect(sweepArgs()?.placerIds).toEqual([PACK_BUYER, OTHER_OWNER]);
+  });
+
+  it('sweeps nobody when the pack never sold, even though the members have owners', async () => {
+    mocks.userCosmeticFindMany.mockResolvedValue([{ userId: PACK_BUYER }, { userId: OTHER_OWNER }]);
+    await takedownCosmeticShopItem({ id: PACK_ID, reason: 'test', moderatorId: MODERATOR });
+    expect(sweepArgs()?.placerIds).toEqual([]);
+  });
+
+  // A single item revokes from everyone who holds it, so the sweep is unscoped
+  // to match. Pinned so the scoping added for packs cannot leak into this path
+  // and quietly leave placements up.
+  it('leaves the sweep unscoped for a single-item takedown', async () => {
+    mocks.shopItemFindUnique.mockResolvedValue({
+      ...packRow,
+      cosmeticId: MEMBER_A,
+      cosmetic: { createdById: 4001, creator: { username: 'someone' } },
+    });
+    mocks.purchaseFindMany.mockResolvedValue([purchase('single-tx')]);
+    mocks.userCosmeticFindMany.mockResolvedValue([{ userId: PACK_BUYER }]);
+    await takedownCosmeticShopItem({ id: PACK_ID, reason: 'test', moderatorId: MODERATOR });
+    expect(sweepArgs()?.placerIds).toBeUndefined();
+    expect(sweepArgs()?.cosmeticIds).toEqual([MEMBER_A]);
   });
 
   it('a single-item takedown is still unscoped', async () => {

--- a/src/server/__tests__/creator-shop-pack-takedown.test.ts
+++ b/src/server/__tests__/creator-shop-pack-takedown.test.ts
@@ -191,41 +191,32 @@ describe('takedownCosmeticShopItem — pack scoping', () => {
     expect(ownerQuery?.where?.claimKey).toEqual({ in: ['pack-tx-1'] });
   });
 
-  // The placement sweep has to inherit the revoke's scope. Unscoped, it removes
-  // placements made with a member someone bought standalone — that person keeps
-  // the cosmetic, gets no refund, and still loses the placement they paid for.
+  // The placement sweep deliberately does NOT inherit the revoke's scope, and it
+  // was written the other way first. A pack's claim keys miss every holding
+  // obtained another way — the maker's own creator grant above all — so a scoped
+  // sweep leaves the abusive artwork up on everything its author placed it on,
+  // which is the one outcome the feature exists to prevent. The cost, accepted:
+  // someone holding the same sticker inside the pack and standalone loses all of
+  // their placements of it.
   const sweepArgs = () => mocks.removePlacementsByCosmetic.mock.calls[0]?.[0];
 
-  it('scopes the placement sweep to the placers whose holdings it revoked', async () => {
+  it('sweeps placements of every member, not only the pack buyers', async () => {
     mocks.purchaseFindMany.mockResolvedValue([
       purchase('pack-tx-1'),
       purchase('pack-tx-2', OTHER_OWNER),
     ]);
     mocks.userCosmeticFindMany.mockResolvedValue([{ userId: PACK_BUYER }, { userId: OTHER_OWNER }]);
     await takedownCosmeticShopItem({ id: PACK_ID, reason: 'test', moderatorId: MODERATOR });
-    expect(sweepArgs()?.placerIds).toEqual([PACK_BUYER, OTHER_OWNER]);
+    expect(sweepArgs()).not.toHaveProperty('placerIds');
+    expect(sweepArgs()?.cosmeticIds).toEqual([MEMBER_A, MEMBER_B]);
   });
 
-  it('sweeps nobody when the pack never sold, even though the members have owners', async () => {
+  // A pack that never sold revokes from nobody — but its members' artwork is
+  // still taken down, so the placements still come off.
+  it('still sweeps when the pack never sold and nothing was revoked', async () => {
     mocks.userCosmeticFindMany.mockResolvedValue([{ userId: PACK_BUYER }, { userId: OTHER_OWNER }]);
     await takedownCosmeticShopItem({ id: PACK_ID, reason: 'test', moderatorId: MODERATOR });
-    expect(sweepArgs()?.placerIds).toEqual([]);
-  });
-
-  // A single item revokes from everyone who holds it, so the sweep is unscoped
-  // to match. Pinned so the scoping added for packs cannot leak into this path
-  // and quietly leave placements up.
-  it('leaves the sweep unscoped for a single-item takedown', async () => {
-    mocks.shopItemFindUnique.mockResolvedValue({
-      ...packRow,
-      cosmeticId: MEMBER_A,
-      cosmetic: { createdById: 4001, creator: { username: 'someone' } },
-    });
-    mocks.purchaseFindMany.mockResolvedValue([purchase('single-tx')]);
-    mocks.userCosmeticFindMany.mockResolvedValue([{ userId: PACK_BUYER }]);
-    await takedownCosmeticShopItem({ id: PACK_ID, reason: 'test', moderatorId: MODERATOR });
-    expect(sweepArgs()?.placerIds).toBeUndefined();
-    expect(sweepArgs()?.cosmeticIds).toEqual([MEMBER_A]);
+    expect(sweepArgs()?.cosmeticIds).toEqual([MEMBER_A, MEMBER_B]);
   });
 
   it('a single-item takedown is still unscoped', async () => {

--- a/src/server/__tests__/creator-shop-pack-takedown.test.ts
+++ b/src/server/__tests__/creator-shop-pack-takedown.test.ts
@@ -205,8 +205,17 @@ describe('takedownCosmeticShopItem — pack scoping', () => {
       purchase('pack-tx-2', OTHER_OWNER),
     ]);
     mocks.userCosmeticFindMany.mockResolvedValue([{ userId: PACK_BUYER }, { userId: OTHER_OWNER }]);
-    await takedownCosmeticShopItem({ id: PACK_ID, reason: 'test', moderatorId: MODERATOR });
+    const result = await takedownCosmeticShopItem({
+      id: PACK_ID,
+      reason: 'test',
+      moderatorId: MODERATOR,
+    });
+
     expect(mocks.removePlacementsByCosmetic).not.toHaveBeenCalled();
+    // Reported, not just logged. The whole justification for skipping is that a
+    // moderator must not be left believing the artwork came down, so the flag
+    // regressing to false silently would take the safety property with it.
+    expect(result.placementsRemoved.skippedForPack).toBe(true);
   });
 
   // A single item DOES sweep, and unscoped — the member cosmetic is delisted
@@ -221,9 +230,15 @@ describe('takedownCosmeticShopItem — pack scoping', () => {
     });
     mocks.purchaseFindMany.mockResolvedValue([purchase('single-tx')]);
     mocks.userCosmeticFindMany.mockResolvedValue([{ userId: PACK_BUYER }]);
-    await takedownCosmeticShopItem({ id: PACK_ID, reason: 'test', moderatorId: MODERATOR });
+    const result = await takedownCosmeticShopItem({
+      id: PACK_ID,
+      reason: 'test',
+      moderatorId: MODERATOR,
+    });
+
     expect(sweepArgs()?.cosmeticIds).toEqual([MEMBER_A]);
     expect(sweepArgs()).not.toHaveProperty('placerIds');
+    expect(result.placementsRemoved.skippedForPack).toBe(false);
   });
 
   it('a single-item takedown is still unscoped', async () => {

--- a/src/server/__tests__/creator-shop-pack-takedown.test.ts
+++ b/src/server/__tests__/creator-shop-pack-takedown.test.ts
@@ -191,32 +191,39 @@ describe('takedownCosmeticShopItem — pack scoping', () => {
     expect(ownerQuery?.where?.claimKey).toEqual({ in: ['pack-tx-1'] });
   });
 
-  // The placement sweep deliberately does NOT inherit the revoke's scope, and it
-  // was written the other way first. A pack's claim keys miss every holding
-  // obtained another way — the maker's own creator grant above all — so a scoped
-  // sweep leaves the abusive artwork up on everything its author placed it on,
-  // which is the one outcome the feature exists to prevent. The cost, accepted:
-  // someone holding the same sticker inside the pack and standalone loses all of
-  // their placements of it.
+  // A pack takedown archives the bundle and never delists its members, and it
+  // carries no per-member abuse designation — so sweeping here would remove
+  // every placement of every member site-wide while those members stay
+  // purchasable and immediately re-placeable. Incoherent under either answer to
+  // "should a pack takedown treat every member as abusive", so it waits for the
+  // ruling. Skipping is the additive direction.
   const sweepArgs = () => mocks.removePlacementsByCosmetic.mock.calls[0]?.[0];
 
-  it('sweeps placements of every member, not only the pack buyers', async () => {
+  it('does not sweep placements for a pack takedown', async () => {
     mocks.purchaseFindMany.mockResolvedValue([
       purchase('pack-tx-1'),
       purchase('pack-tx-2', OTHER_OWNER),
     ]);
     mocks.userCosmeticFindMany.mockResolvedValue([{ userId: PACK_BUYER }, { userId: OTHER_OWNER }]);
     await takedownCosmeticShopItem({ id: PACK_ID, reason: 'test', moderatorId: MODERATOR });
-    expect(sweepArgs()).not.toHaveProperty('placerIds');
-    expect(sweepArgs()?.cosmeticIds).toEqual([MEMBER_A, MEMBER_B]);
+    expect(mocks.removePlacementsByCosmetic).not.toHaveBeenCalled();
   });
 
-  // A pack that never sold revokes from nobody — but its members' artwork is
-  // still taken down, so the placements still come off.
-  it('still sweeps when the pack never sold and nothing was revoked', async () => {
-    mocks.userCosmeticFindMany.mockResolvedValue([{ userId: PACK_BUYER }, { userId: OTHER_OWNER }]);
+  // A single item DOES sweep, and unscoped — the member cosmetic is delisted
+  // everywhere by `delistPacksContaining`, so removing its placements is
+  // consistent with it no longer being for sale. Pinned so the pack guard
+  // cannot widen into the path that has to keep working.
+  it('sweeps every placement of a single-item takedown, unscoped by placer', async () => {
+    mocks.shopItemFindUnique.mockResolvedValue({
+      ...packRow,
+      cosmeticId: MEMBER_A,
+      cosmetic: { createdById: 4001, creator: { username: 'someone' } },
+    });
+    mocks.purchaseFindMany.mockResolvedValue([purchase('single-tx')]);
+    mocks.userCosmeticFindMany.mockResolvedValue([{ userId: PACK_BUYER }]);
     await takedownCosmeticShopItem({ id: PACK_ID, reason: 'test', moderatorId: MODERATOR });
-    expect(sweepArgs()?.cosmeticIds).toEqual([MEMBER_A, MEMBER_B]);
+    expect(sweepArgs()?.cosmeticIds).toEqual([MEMBER_A]);
+    expect(sweepArgs()).not.toHaveProperty('placerIds');
   });
 
   it('a single-item takedown is still unscoped', async () => {

--- a/src/server/routers/placement.router.ts
+++ b/src/server/routers/placement.router.ts
@@ -10,6 +10,7 @@ import {
   placementPriceRangeSchema,
   placementSpaceSchema,
   placerSchema,
+  removePlacementSchema,
   suspendPlacerSchema,
 } from '~/server/schema/placement.schema';
 import { placementPriceRange } from '~/server/services/placement.service';
@@ -23,6 +24,7 @@ import {
 import {
   countPendingPlacementsFrom,
   isPlacementSuspended,
+  removePlacementByModerator,
   removePlacementsByUser,
   restorePlacementPrivileges,
   suspendPlacementPrivileges,
@@ -185,6 +187,17 @@ export const placementRouter = router({
 
     return { removed };
   }),
+
+  /**
+   * Not flag-gated, for the same reason `actOnStickers` isn't: turning the flag
+   * off must not leave a reported placement live with nothing able to take it
+   * down.
+   */
+  removePlacement: moderatorProcedure
+    .input(removePlacementSchema)
+    .mutation(({ input, ctx }) =>
+      removePlacementByModerator({ placementId: input.placementId, actorId: ctx.user.id })
+    ),
 
   restorePlacer: moderatorProcedure
     .input(placerSchema)

--- a/src/server/routers/placement.router.ts
+++ b/src/server/routers/placement.router.ts
@@ -100,7 +100,11 @@ export const placementRouter = router({
   getStickerPlacementDetail: publicProcedure
     .input(getStickerPlacementDetailSchema)
     .query(({ input, ctx }) =>
-      getStickerPlacementDetail({ placementId: input.placementId, viewerId: ctx.user?.id })
+      getStickerPlacementDetail({
+        placementId: input.placementId,
+        viewerId: ctx.user?.id,
+        isModerator: ctx.user?.isModerator,
+      })
     ),
 
   getStickerPlacementCounts: publicProcedure

--- a/src/server/schema/placement.schema.ts
+++ b/src/server/schema/placement.schema.ts
@@ -97,3 +97,5 @@ export const suspendPlacerSchema = z.object({
 });
 
 export const placerSchema = z.object({ userId: z.number().int().positive() });
+
+export const removePlacementSchema = z.object({ placementId: z.number().int().positive() });

--- a/src/server/services/__tests__/creator-shop-takedown.service.test.ts
+++ b/src/server/services/__tests__/creator-shop-takedown.service.test.ts
@@ -159,7 +159,7 @@ describe('takedownCosmeticShopItem', () => {
       moderatorId: 999,
     });
 
-    expect(mocks.removePlacementsByCosmetic).toHaveBeenCalledWith({
+    expect(mocks.removePlacementsByCosmetic.mock.calls[0][0]).toMatchObject({
       cosmeticIds: [7],
       actorId: 999,
     });

--- a/src/server/services/__tests__/creator-shop-takedown.service.test.ts
+++ b/src/server/services/__tests__/creator-shop-takedown.service.test.ts
@@ -15,6 +15,7 @@ const { mocks } = vi.hoisted(() => ({
     refundMultiAccountTransaction: vi.fn(),
     refundTransaction: vi.fn(),
     revokeCosmeticsFromUsers: vi.fn(),
+    removePlacementsByCosmetic: vi.fn(),
     shopItemFindFirst: vi.fn(),
     shopItemUpdateMany: vi.fn(),
     packMemberFindMany: vi.fn(),
@@ -54,6 +55,9 @@ vi.mock('~/server/services/buzz.service', () => ({
 vi.mock('~/server/services/cosmetic.service', () => ({
   revokeCosmeticsFromUsers: mocks.revokeCosmeticsFromUsers,
   validateStickerCosmetic: vi.fn(),
+}));
+vi.mock('~/server/services/placement-moderation.service', () => ({
+  removePlacementsByCosmetic: mocks.removePlacementsByCosmetic,
 }));
 vi.mock('~/server/services/creator-program.service', () => ({
   hasValidCreatorMembership: vi.fn(),
@@ -128,6 +132,76 @@ describe('takedownCosmeticShopItem', () => {
     mocks.createBuzzTransaction.mockResolvedValue({ transactionId: 'tx' });
     mocks.refundTransaction.mockResolvedValue({ transactionId: 'refund-tx' });
     mocks.revokeCosmeticsFromUsers.mockResolvedValue({ revoked: 3 });
+    mocks.removePlacementsByCosmetic.mockResolvedValue({
+      considered: 0,
+      settled: 0,
+      failed: [],
+      takenDown: 0,
+      hasMore: false,
+    });
+  });
+
+  // Revoking the holding leaves stickers already placed on other people's
+  // images untouched — they live in their own table, keyed by a cosmetic id
+  // inside a JSON payload, and nothing else in this takedown looks there.
+  it('takes down every placement made with the cosmetic', async () => {
+    mocks.removePlacementsByCosmetic.mockResolvedValue({
+      considered: 4,
+      settled: 1,
+      failed: [],
+      takenDown: 3,
+      hasMore: false,
+    });
+
+    const result = await takedownCosmeticShopItem({
+      id: 42,
+      reason: 'Abusive artwork',
+      moderatorId: 999,
+    });
+
+    expect(mocks.removePlacementsByCosmetic).toHaveBeenCalledWith({
+      cosmeticIds: [7],
+      actorId: 999,
+    });
+    expect(result.placementsRemoved).toMatchObject({ settled: 1, takenDown: 3 });
+  });
+
+  // Bounded per batch, so one pass would report a clean takedown with the
+  // artwork still on other people's work.
+  it('drains the placement takedown rather than running one batch', async () => {
+    mocks.removePlacementsByCosmetic
+      .mockResolvedValueOnce({ considered: 2, settled: 0, failed: [], takenDown: 2, hasMore: true })
+      .mockResolvedValueOnce({
+        considered: 1,
+        settled: 0,
+        failed: [],
+        takenDown: 1,
+        hasMore: false,
+      });
+
+    const result = await takedownCosmeticShopItem({
+      id: 42,
+      reason: 'Abusive artwork',
+      moderatorId: 999,
+    });
+
+    expect(mocks.removePlacementsByCosmetic).toHaveBeenCalledTimes(2);
+    expect(result.placementsRemoved.takenDown).toBe(3);
+  });
+
+  // A takedown that aborts because placements could not be removed would leave
+  // the buyers unrefunded and the cosmetic on sale.
+  it('finishes the takedown even if the placement sweep throws', async () => {
+    mocks.removePlacementsByCosmetic.mockRejectedValue(new Error('db is having a moment'));
+
+    const result = await takedownCosmeticShopItem({
+      id: 42,
+      reason: 'Abusive artwork',
+      moderatorId: 999,
+    });
+
+    expect(result.revokedFrom).toBe(3);
+    expect(result.placementsRemoved).toMatchObject({ takenDown: 0 });
   });
 
   it('stops sales, refunds every buyer, claws back the creator earnings and strips the cosmetic', async () => {

--- a/src/server/services/__tests__/placement-escrow.service.test.ts
+++ b/src/server/services/__tests__/placement-escrow.service.test.ts
@@ -516,28 +516,32 @@ describe('running a release path twice', () => {
   const hold = () =>
     holdPlacementEscrow({ placementId: 1, placerId: PLACER, surface: 'sticker', amount: 1000 });
 
-  it.each(['approve', 'decline', 'expire', 'removeByOwner', 'removeByModerator'] as const)(
-    'moves no money the second time: %s',
-    async (action) => {
-      givenPlacement();
-      await hold();
-      await settlePlacement({ placementId: 1, action, actorId: OWNER });
+  it.each([
+    'approve',
+    'decline',
+    'expire',
+    'removeByOwner',
+    'removeByModerator',
+    'removeByCosmeticTakedown',
+  ] as const)('moves no money the second time: %s', async (action) => {
+    givenPlacement();
+    await hold();
+    await settlePlacement({ placementId: 1, action, actorId: OWNER });
 
-      const legsAfterFirst = legsFor(1);
-      clearMoneyMocks();
+    const legsAfterFirst = legsFor(1);
+    clearMoneyMocks();
 
-      const second = await settlePlacement({
-        placementId: 1,
-        action,
-        actorId: OWNER,
-        sellerId: SELLER,
-      });
+    const second = await settlePlacement({
+      placementId: 1,
+      action,
+      actorId: OWNER,
+      sellerId: SELLER,
+    });
 
-      expect(second.settled).toBe(false);
-      expect(moneyMoved()).toBe(0);
-      expect(legsFor(1)).toEqual(legsAfterFirst);
-    }
-  );
+    expect(second.settled).toBe(false);
+    expect(moneyMoved()).toBe(0);
+    expect(legsFor(1)).toEqual(legsAfterFirst);
+  });
 
   // A block landing while an approval is in flight, or the expiry sweep firing
   // during a decline: the status transition is the lock, so the loser matches no
@@ -710,6 +714,7 @@ describe('the amounts a resume replays', () => {
       'expire',
       'removeByOwner',
       'removeByModerator',
+      'removeByCosmeticTakedown',
     ] as const) {
       db.placements.clear();
       db.legs.clear();

--- a/src/server/services/__tests__/placement-moderation.service.test.ts
+++ b/src/server/services/__tests__/placement-moderation.service.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const queryRaw = vi.fn();
 const settlePlacement = vi.fn();
 const placementFindMany = vi.fn();
+const placementFindUnique = vi.fn();
 const placementUpdateMany = vi.fn();
 const placementCount = vi.fn();
 const suspensionFindUnique = vi.fn();
@@ -13,6 +14,7 @@ vi.mock('~/server/db/client', () => ({
     $queryRaw: queryRaw,
     placement: {
       findMany: placementFindMany,
+      findUnique: placementFindUnique,
       updateMany: placementUpdateMany,
       count: placementCount,
     },
@@ -31,6 +33,7 @@ const {
   countPendingPlacementsFrom,
   declinePlacementsOnBlock,
   isPlacementBlocked,
+  removePlacementByModerator,
   removePlacementsByUser,
   suspendPlacementPrivileges,
 } = await import('~/server/services/placement-moderation.service');
@@ -43,6 +46,7 @@ beforeEach(() => {
   queryRaw.mockResolvedValue([{ exists: false }]);
   suspensionFindUnique.mockResolvedValue(null);
   placementFindMany.mockResolvedValue([]);
+  placementFindUnique.mockResolvedValue(null);
   placementUpdateMany.mockResolvedValue({ count: 0 });
   settlePlacement.mockResolvedValue({ settled: true });
 });
@@ -293,5 +297,61 @@ describe('the takedown record', () => {
 
     expect(placementUpdateMany.mock.calls[0][0].where).toMatchObject({ id: { in: [1, 2] } });
     expect(result.hasMore).toBe(true);
+  });
+});
+
+describe('removing one reported placement', () => {
+  const APPROVED_PLACEMENT = 3101;
+  const PENDING_PLACEMENT = 3102;
+  const MODERATOR = 47;
+
+  // settlePlacement claims its transition with WHERE status = 'pending', so an
+  // approved row matches nothing and it returns settled: false having moved no
+  // money. Routing a live placement through it is a remove button that does
+  // nothing — and a green settlePlacement mock is exactly what would hide that,
+  // so this asserts the takedown write instead.
+  it('takes a live placement down directly rather than through settlement', async () => {
+    placementFindUnique.mockResolvedValue({ id: APPROVED_PLACEMENT, status: 'approved' });
+    placementUpdateMany.mockResolvedValue({ count: 1 });
+
+    const result = await removePlacementByModerator({
+      placementId: APPROVED_PLACEMENT,
+      actorId: MODERATOR,
+    });
+
+    expect(settlePlacement).not.toHaveBeenCalled();
+    expect(placementUpdateMany.mock.calls[0][0]).toMatchObject({
+      where: { id: APPROVED_PLACEMENT, status: 'approved' },
+      data: { status: 'removed', removedBy: 'moderator', takenDownById: MODERATOR },
+    });
+    expect(result).toMatchObject({ removed: true, wasLive: true });
+  });
+
+  it('settles a pending placement so its escrow is forfeited', async () => {
+    placementFindUnique.mockResolvedValue({ id: PENDING_PLACEMENT, status: 'pending' });
+
+    const result = await removePlacementByModerator({
+      placementId: PENDING_PLACEMENT,
+      actorId: MODERATOR,
+    });
+
+    expect(placementUpdateMany).not.toHaveBeenCalled();
+    expect(settlePlacement.mock.calls[0][0]).toMatchObject({
+      placementId: PENDING_PLACEMENT,
+      action: 'removeByModerator',
+      actorId: MODERATOR,
+    });
+    expect(result).toMatchObject({ removed: true, wasLive: false });
+  });
+
+  it('refuses one that is already settled instead of writing over the record', async () => {
+    placementFindUnique.mockResolvedValue({ id: APPROVED_PLACEMENT, status: 'declined' });
+
+    await expect(
+      removePlacementByModerator({ placementId: APPROVED_PLACEMENT, actorId: MODERATOR })
+    ).rejects.toThrow(/already declined/);
+
+    expect(placementUpdateMany).not.toHaveBeenCalled();
+    expect(settlePlacement).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/__tests__/placement-moderation.service.test.ts
+++ b/src/server/services/__tests__/placement-moderation.service.test.ts
@@ -389,8 +389,8 @@ describe('removing every placement made with a revoked cosmetic', () => {
 
   // The placer is a holder of the revoked cosmetic and is refunded for it
   // everywhere else, so forfeiting their escrow here would punish them for the
-  // maker's abuse. removeByOwner is the only action that returns the whole
-  // escrow — see the label caveat on the service.
+  // maker's abuse. Its own action rather than removeByOwner, which pays the same
+  // and would record a moderator's takedown as the owner's doing.
   it('refunds a pending placement in full rather than forfeiting it', async () => {
     rows([4403], []);
     placementUpdateMany.mockResolvedValue({ count: 0 });
@@ -399,7 +399,7 @@ describe('removing every placement made with a revoked cosmetic', () => {
 
     expect(settlePlacement.mock.calls[0][0]).toMatchObject({
       placementId: 4403,
-      action: 'removeByOwner',
+      action: 'removeByCosmeticTakedown',
       actorId: MODERATOR,
     });
   });

--- a/src/server/services/__tests__/placement-moderation.service.test.ts
+++ b/src/server/services/__tests__/placement-moderation.service.test.ts
@@ -362,6 +362,16 @@ describe('removing every placement made with a revoked cosmetic', () => {
   const PACK_MEMBER = 8802;
   const MODERATOR = 53;
 
+  // Index-independent: the query composes optional fragments, so asserting a
+  // positional argument would quietly point at the wrong value the moment the
+  // SQL gains one. A `Prisma.Sql` fragment carries its own `values`.
+  const rawValues = (call: unknown[]) =>
+    call.flatMap((arg) =>
+      arg && typeof arg === 'object' && 'values' in (arg as { values?: unknown[] })
+        ? (arg as { values: unknown[] }).values
+        : [arg]
+    );
+
   const rows = (pending: number[], approved: number[]) =>
     queryRaw
       .mockResolvedValueOnce(pending.map((id) => ({ id })))
@@ -437,8 +447,7 @@ describe('removing every placement made with a revoked cosmetic', () => {
       actorId: MODERATOR,
     });
 
-    // (strings, status, cosmeticIds, placerIds, placerIds, skipIds, skipIds, limit)
-    expect(queryRaw.mock.calls[0][3]).toEqual([777, 778]);
+    expect(rawValues(queryRaw.mock.calls[0])).toContainEqual([777, 778]);
   });
 
   // Empty must mean "nobody qualifies", not "no filter" — a pack whose only sale
@@ -467,7 +476,7 @@ describe('removing every placement made with a revoked cosmetic', () => {
       actorId: MODERATOR,
     });
 
-    expect(queryRaw.mock.calls[0][5]).toEqual([4407, 4408]);
+    expect(rawValues(queryRaw.mock.calls[0])).toContainEqual([4407, 4408]);
   });
 
   it('does nothing at all with no cosmetics to act on', async () => {

--- a/src/server/services/__tests__/placement-moderation.service.test.ts
+++ b/src/server/services/__tests__/placement-moderation.service.test.ts
@@ -364,13 +364,21 @@ describe('removing every placement made with a revoked cosmetic', () => {
 
   // Index-independent: the query composes optional fragments, so asserting a
   // positional argument would quietly point at the wrong value the moment the
-  // SQL gains one. A `Prisma.Sql` fragment carries its own `values`.
+  // SQL gains one. A `Prisma.Sql` fragment carries its own `strings`/`values`.
+  const hasFragment = (arg: unknown): arg is { strings: string[]; values: unknown[] } =>
+    !!arg && typeof arg === 'object' && 'strings' in (arg as object);
+
   const rawValues = (call: unknown[]) =>
-    call.flatMap((arg) =>
-      arg && typeof arg === 'object' && 'values' in (arg as { values?: unknown[] })
-        ? (arg as { values: unknown[] }).values
-        : [arg]
-    );
+    call.flatMap((arg) => (hasFragment(arg) ? arg.values : [arg]));
+
+  // The bound values alone say nothing about the predicate they are bound to:
+  // swapping `"placerId"` for `"ownerId"` would keep every value assertion
+  // green while removing placements ON the wrong people's content.
+  const rawSql = (call: unknown[]) => {
+    const parts = [...(call[0] as string[])];
+    for (const arg of call.slice(1)) if (hasFragment(arg)) parts.push(...arg.strings);
+    return parts.join(' ');
+  };
 
   const rows = (pending: number[], approved: number[]) =>
     queryRaw
@@ -433,35 +441,21 @@ describe('removing every placement made with a revoked cosmetic', () => {
     expect(result.hasMore).toBe(true);
   });
 
-  // A pack's members are sold standalone too, and `revokeCosmeticsFromUsers` is
-  // scoped by the pack's claim keys for exactly that reason. Unscoped here,
-  // someone who bought a member on its own keeps the cosmetic, gets no refund,
-  // and still loses the placement they paid for.
-  it('sweeps only the placers whose holding was revoked, when told to', async () => {
+  // Scoping this to the placers whose holding was revoked was tried and undone.
+  // `UserCosmetic`'s key is [userId, cosmeticId, claimKey], so a pack's claim
+  // keys miss every holding obtained another way — above all the maker's own
+  // creator grant, which would leave the abusive artwork up on everything its
+  // author placed it on. The sweep follows the artwork, not the placer.
+  it('does not narrow the sweep by who placed it', async () => {
     rows([], [4406]);
     placementUpdateMany.mockResolvedValue({ count: 1 });
 
     await removePlacementsByCosmetic({
       cosmeticIds: [COSMETIC, PACK_MEMBER],
-      placerIds: [777, 778],
       actorId: MODERATOR,
     });
 
-    expect(rawValues(queryRaw.mock.calls[0])).toContainEqual([777, 778]);
-  });
-
-  // Empty must mean "nobody qualifies", not "no filter" — a pack whose only sale
-  // was already refunded revokes from nobody, and widening that to unscoped
-  // would strip every placement of every member from everyone.
-  it('sweeps nothing when the scoped set of placers is empty', async () => {
-    const result = await removePlacementsByCosmetic({
-      cosmeticIds: [COSMETIC],
-      placerIds: [],
-      actorId: MODERATOR,
-    });
-
-    expect(queryRaw).not.toHaveBeenCalled();
-    expect(result).toMatchObject({ considered: 0, takenDown: 0, hasMore: false });
+    expect(rawSql(queryRaw.mock.calls[0])).not.toContain('placerId');
   });
 
   // ORDER BY id is stable, so a row that cannot settle is picked first by every
@@ -477,6 +471,7 @@ describe('removing every placement made with a revoked cosmetic', () => {
     });
 
     expect(rawValues(queryRaw.mock.calls[0])).toContainEqual([4407, 4408]);
+    expect(rawSql(queryRaw.mock.calls[0])).toContain('NOT (id = ANY');
   });
 
   it('does nothing at all with no cosmetics to act on', async () => {

--- a/src/server/services/__tests__/placement-moderation.service.test.ts
+++ b/src/server/services/__tests__/placement-moderation.service.test.ts
@@ -34,6 +34,7 @@ const {
   declinePlacementsOnBlock,
   isPlacementBlocked,
   removePlacementByModerator,
+  removePlacementsByCosmetic,
   removePlacementsByUser,
   suspendPlacementPrivileges,
 } = await import('~/server/services/placement-moderation.service');
@@ -353,5 +354,76 @@ describe('removing one reported placement', () => {
 
     expect(placementUpdateMany).not.toHaveBeenCalled();
     expect(settlePlacement).not.toHaveBeenCalled();
+  });
+});
+
+describe('removing every placement made with a revoked cosmetic', () => {
+  const COSMETIC = 8801;
+  const PACK_MEMBER = 8802;
+  const MODERATOR = 53;
+
+  const rows = (pending: number[], approved: number[]) =>
+    queryRaw
+      .mockResolvedValueOnce(pending.map((id) => ({ id })))
+      .mockResolvedValueOnce(approved.map((id) => ({ id })));
+
+  // The content owner did not choose this sticker and was already paid for it,
+  // so a live placement is taken down without settlement. Settling it would
+  // compute a payout plan and claw that money back off the wrong person.
+  it('takes live placements down without moving money', async () => {
+    rows([], [4401, 4402]);
+    placementUpdateMany.mockResolvedValue({ count: 2 });
+
+    const result = await removePlacementsByCosmetic({
+      cosmeticIds: [COSMETIC],
+      actorId: MODERATOR,
+    });
+
+    expect(settlePlacement).not.toHaveBeenCalled();
+    expect(placementUpdateMany.mock.calls[0][0]).toMatchObject({
+      where: { id: { in: [4401, 4402] } },
+      data: { status: 'removed', removedBy: 'moderator', takenDownById: MODERATOR },
+    });
+    expect(result.takenDown).toBe(2);
+  });
+
+  // The placer is a holder of the revoked cosmetic and is refunded for it
+  // everywhere else, so forfeiting their escrow here would punish them for the
+  // maker's abuse. removeByOwner is the only action that returns the whole
+  // escrow — see the label caveat on the service.
+  it('refunds a pending placement in full rather than forfeiting it', async () => {
+    rows([4403], []);
+    placementUpdateMany.mockResolvedValue({ count: 0 });
+
+    await removePlacementsByCosmetic({ cosmeticIds: [COSMETIC], actorId: MODERATOR });
+
+    expect(settlePlacement.mock.calls[0][0]).toMatchObject({
+      placementId: 4403,
+      action: 'removeByOwner',
+      actorId: MODERATOR,
+    });
+  });
+
+  // A takedown that stopped after one bounded batch would report success with
+  // the artwork still on other people's work.
+  it('says when a batch filled so the caller runs again', async () => {
+    rows([4404, 4405], []);
+    placementUpdateMany.mockResolvedValue({ count: 0 });
+
+    const result = await removePlacementsByCosmetic({
+      cosmeticIds: [COSMETIC, PACK_MEMBER],
+      actorId: MODERATOR,
+      limit: 2,
+    });
+
+    expect(result.hasMore).toBe(true);
+  });
+
+  it('does nothing at all with no cosmetics to act on', async () => {
+    const result = await removePlacementsByCosmetic({ cosmeticIds: [], actorId: MODERATOR });
+
+    expect(queryRaw).not.toHaveBeenCalled();
+    expect(placementUpdateMany).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ considered: 0, takenDown: 0, hasMore: false });
   });
 });

--- a/src/server/services/__tests__/placement-moderation.service.test.ts
+++ b/src/server/services/__tests__/placement-moderation.service.test.ts
@@ -382,7 +382,11 @@ describe('removing every placement made with a revoked cosmetic', () => {
     expect(settlePlacement).not.toHaveBeenCalled();
     expect(placementUpdateMany.mock.calls[0][0]).toMatchObject({
       where: { id: { in: [4401, 4402] } },
-      data: { status: 'removed', removedBy: 'moderator', takenDownById: MODERATOR },
+      // Not 'moderator'. A reconcile has to be able to tell this from a
+      // moderator removing an abusive placer's sticker, which forfeits instead
+      // of refunding — and the live rows are most of a takedown, so recording
+      // them as 'moderator' would leave the new reason written nowhere.
+      data: { status: 'removed', removedBy: 'cosmeticTakedown', takenDownById: MODERATOR },
     });
     expect(result.takenDown).toBe(2);
   });
@@ -417,6 +421,53 @@ describe('removing every placement made with a revoked cosmetic', () => {
     });
 
     expect(result.hasMore).toBe(true);
+  });
+
+  // A pack's members are sold standalone too, and `revokeCosmeticsFromUsers` is
+  // scoped by the pack's claim keys for exactly that reason. Unscoped here,
+  // someone who bought a member on its own keeps the cosmetic, gets no refund,
+  // and still loses the placement they paid for.
+  it('sweeps only the placers whose holding was revoked, when told to', async () => {
+    rows([], [4406]);
+    placementUpdateMany.mockResolvedValue({ count: 1 });
+
+    await removePlacementsByCosmetic({
+      cosmeticIds: [COSMETIC, PACK_MEMBER],
+      placerIds: [777, 778],
+      actorId: MODERATOR,
+    });
+
+    // (strings, status, cosmeticIds, placerIds, placerIds, skipIds, skipIds, limit)
+    expect(queryRaw.mock.calls[0][3]).toEqual([777, 778]);
+  });
+
+  // Empty must mean "nobody qualifies", not "no filter" — a pack whose only sale
+  // was already refunded revokes from nobody, and widening that to unscoped
+  // would strip every placement of every member from everyone.
+  it('sweeps nothing when the scoped set of placers is empty', async () => {
+    const result = await removePlacementsByCosmetic({
+      cosmeticIds: [COSMETIC],
+      placerIds: [],
+      actorId: MODERATOR,
+    });
+
+    expect(queryRaw).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ considered: 0, takenDown: 0, hasMore: false });
+  });
+
+  // ORDER BY id is stable, so a row that cannot settle is picked first by every
+  // later batch and the drain burns its whole budget re-trying it.
+  it('excludes rows an earlier batch could not settle', async () => {
+    rows([], []);
+    placementUpdateMany.mockResolvedValue({ count: 0 });
+
+    await removePlacementsByCosmetic({
+      cosmeticIds: [COSMETIC],
+      skipIds: [4407, 4408],
+      actorId: MODERATOR,
+    });
+
+    expect(queryRaw.mock.calls[0][5]).toEqual([4407, 4408]);
   });
 
   it('does nothing at all with no cosmetics to act on', async () => {

--- a/src/server/services/__tests__/sticker-placement.service.test.ts
+++ b/src/server/services/__tests__/sticker-placement.service.test.ts
@@ -585,6 +585,43 @@ describe('the hover-card detail', () => {
     ).rejects.toThrow(/not available/);
   });
 
+  // A moderator is party to neither side of a pending placement, so the scoping
+  // hides the one row they are most often asked to act on.
+  it('lets a moderator see a pending placement they are not party to', async () => {
+    givenPlacement();
+    cosmeticFindUnique.mockResolvedValue(null);
+
+    await getStickerPlacementDetail({
+      placementId: DETAIL_PLACEMENT,
+      viewerId: STRANGER,
+      isModerator: true,
+    });
+
+    const [query] = placementFindFirst.mock.calls[0] as [{ where: { OR: MixedObject[] } }];
+    expect(query.where.OR.map((clause) => clause.status).sort()).toEqual(['approved', 'pending']);
+  });
+
+  // Widened to the other LIVE status, not to every status. Every consumer reads
+  // a miss as "already gone", so returning a removed row hands the second
+  // moderator on a report a remove button, a dialog claiming no Buzz moves, and
+  // an error when they press it.
+  it('does not hand a moderator placements that are already settled', async () => {
+    givenPlacement();
+    cosmeticFindUnique.mockResolvedValue(null);
+
+    await getStickerPlacementDetail({
+      placementId: DETAIL_PLACEMENT,
+      viewerId: STRANGER,
+      isModerator: true,
+    });
+
+    const [query] = placementFindFirst.mock.calls[0] as [{ where: { OR?: MixedObject[] } }];
+    expect(query.where.OR).toBeDefined();
+    const statuses = query.where.OR?.map((clause) => clause.status) ?? [];
+    for (const settled of ['removed', 'declined', 'expired'])
+      expect(statuses).not.toContain(settled);
+  });
+
   it('asks for approved only when nobody is signed in', async () => {
     givenPlacement();
     cosmeticFindUnique.mockResolvedValue(null);

--- a/src/server/services/creator-shop.service.ts
+++ b/src/server/services/creator-shop.service.ts
@@ -1900,8 +1900,9 @@ export const takedownCosmeticShopItem = async ({
 
   // Revoking the holding does not touch stickers already placed on other
   // people's images — those live in `Placement` with the cosmetic id inside a
-  // JSON payload, and taking down the artwork everywhere is the whole point of
-  // a takedown. Drained rather than run once: the helper is bounded per batch,
+  // JSON payload, and the overlay resolves artwork by cosmetic id with no join
+  // to `UserCosmetic`, so a revoked sticker keeps rendering at full opacity on
+  // everything it was placed on. Taking it down there is the whole point. Drained rather than run once: the helper is bounded per batch,
   // and one pass would report a clean takedown with the artwork still up.
   // Capped so a runaway cannot hold the request; `hasMore` says to run again.
   //
@@ -1931,7 +1932,16 @@ export const takedownCosmeticShopItem = async ({
   // more go before the sweep stops spending batches on it.
   const failureCount = new Map<number, number>();
   const unsettled: number[] = [];
-  let placementsRemoved = { settled: 0, takenDown: 0, failed: 0, hasMore: false };
+  let placementsRemoved = {
+    settled: 0,
+    takenDown: 0,
+    failed: 0,
+    hasMore: false,
+    // Reported, not just logged. A moderator taking a pack down over abusive
+    // artwork will otherwise reasonably believe the artwork is gone from the
+    // images it was placed on, and it is still there and still rendering.
+    skippedForPack: false,
+  };
   for (let batch = 0; batch < 10 && memberIds.length && !isPack; batch++) {
     let result: Awaited<ReturnType<typeof removePlacementsByCosmetic>>;
     try {
@@ -1955,6 +1965,7 @@ export const takedownCosmeticShopItem = async ({
       if (failures > 1) unsettled.push(placementId);
     }
     placementsRemoved = {
+      ...placementsRemoved,
       settled: placementsRemoved.settled + result.settled,
       takenDown: placementsRemoved.takenDown + result.takenDown,
       // Distinct rows, not attempts — a row is selected again on its retry, so
@@ -1965,11 +1976,13 @@ export const takedownCosmeticShopItem = async ({
     if (!result.hasMore) break;
   }
 
-  if (isPack && memberIds.length)
+  if (isPack && memberIds.length) {
+    placementsRemoved.skippedForPack = true;
     await logTakedown('info', 'Placement sweep skipped for a pack takedown', {
       shopItemId: id,
       cosmeticIds: memberIds,
     });
+  }
 
   if (placementsRemoved.hasMore || placementsRemoved.failed)
     await logTakedown('error', 'Placement takedown left work behind', {

--- a/src/server/services/creator-shop.service.ts
+++ b/src/server/services/creator-shop.service.ts
@@ -1902,7 +1902,9 @@ export const takedownCosmeticShopItem = async ({
   // people's images — those live in `Placement` with the cosmetic id inside a
   // JSON payload, and the overlay resolves artwork by cosmetic id with no join
   // to `UserCosmetic`, so a revoked sticker keeps rendering at full opacity on
-  // everything it was placed on. Taking it down there is the whole point. Drained rather than run once: the helper is bounded per batch,
+  // everything it was placed on. Taking it down there is the whole point.
+  //
+  // Drained rather than run once: the helper is bounded per batch,
   // and one pass would report a clean takedown with the artwork still up.
   // Capped so a runaway cannot hold the request; `hasMore` says to run again.
   //

--- a/src/server/services/creator-shop.service.ts
+++ b/src/server/services/creator-shop.service.ts
@@ -1905,14 +1905,19 @@ export const takedownCosmeticShopItem = async ({
   // and one pass would report a clean takedown with the artwork still up.
   // Capped so a runaway cannot hold the request; `hasMore` says to run again.
   //
-  // Scoped to the placers whose holding was actually revoked whenever the
-  // revoke itself was scoped — a pack's members are sold standalone too, and
-  // taking down the bundle is not grounds for removing a placement made with a
-  // copy bought on its own. `ownerIds` is exactly who lost the cosmetic here.
-  const placerIds = packClaimKeys ? ownerIds : undefined;
-  // Rows a batch could not settle, excluded from the next one. `ORDER BY id` is
-  // stable, so without this a permanently failing row is re-selected first every
-  // time and the drain burns all ten iterations on it.
+  // Not scoped to `ownerIds`, though the revoke above is. A pack's claim keys
+  // exclude every holding obtained by another route, and the sharpest of those
+  // is the maker's own creator grant — scoping the sweep the same way leaves the
+  // abusive artwork up on everything its author placed it on. See the note on
+  // `removePlacementsByCosmetic`; the trade is deliberate and was tried the
+  // other way first.
+  // Rows a batch could not settle, excluded once they have failed twice.
+  // `ORDER BY id` is stable, so a permanently failing row is re-selected first
+  // every time and would otherwise burn all ten iterations. Excluding on the
+  // FIRST failure instead would give a transient Buzz or Redis blip zero
+  // retries, and nothing re-runs a takedown afterwards — so each row gets one
+  // more go before the sweep stops spending batches on it.
+  const failureCount = new Map<number, number>();
   const unsettled: number[] = [];
   let placementsRemoved = { settled: 0, takenDown: 0, failed: 0, hasMore: false };
   for (let batch = 0; batch < 10 && memberIds.length; batch++) {
@@ -1920,7 +1925,6 @@ export const takedownCosmeticShopItem = async ({
     try {
       result = await removePlacementsByCosmetic({
         cosmeticIds: memberIds,
-        placerIds,
         skipIds: unsettled,
         actorId: moderatorId,
       });
@@ -1933,7 +1937,11 @@ export const takedownCosmeticShopItem = async ({
       break;
     }
 
-    unsettled.push(...result.failed);
+    for (const placementId of result.failed) {
+      const failures = (failureCount.get(placementId) ?? 0) + 1;
+      failureCount.set(placementId, failures);
+      if (failures > 1) unsettled.push(placementId);
+    }
     placementsRemoved = {
       settled: placementsRemoved.settled + result.settled,
       takenDown: placementsRemoved.takenDown + result.takenDown,

--- a/src/server/services/creator-shop.service.ts
+++ b/src/server/services/creator-shop.service.ts
@@ -1904,11 +1904,26 @@ export const takedownCosmeticShopItem = async ({
   // a takedown. Drained rather than run once: the helper is bounded per batch,
   // and one pass would report a clean takedown with the artwork still up.
   // Capped so a runaway cannot hold the request; `hasMore` says to run again.
+  //
+  // Scoped to the placers whose holding was actually revoked whenever the
+  // revoke itself was scoped — a pack's members are sold standalone too, and
+  // taking down the bundle is not grounds for removing a placement made with a
+  // copy bought on its own. `ownerIds` is exactly who lost the cosmetic here.
+  const placerIds = packClaimKeys ? ownerIds : undefined;
+  // Rows a batch could not settle, excluded from the next one. `ORDER BY id` is
+  // stable, so without this a permanently failing row is re-selected first every
+  // time and the drain burns all ten iterations on it.
+  const unsettled: number[] = [];
   let placementsRemoved = { settled: 0, takenDown: 0, failed: 0, hasMore: false };
   for (let batch = 0; batch < 10 && memberIds.length; batch++) {
     let result: Awaited<ReturnType<typeof removePlacementsByCosmetic>>;
     try {
-      result = await removePlacementsByCosmetic({ cosmeticIds: memberIds, actorId: moderatorId });
+      result = await removePlacementsByCosmetic({
+        cosmeticIds: memberIds,
+        placerIds,
+        skipIds: unsettled,
+        actorId: moderatorId,
+      });
     } catch (error) {
       await logTakedown('error', 'Placement takedown failed', {
         shopItemId: id,
@@ -1918,6 +1933,7 @@ export const takedownCosmeticShopItem = async ({
       break;
     }
 
+    unsettled.push(...result.failed);
     placementsRemoved = {
       settled: placementsRemoved.settled + result.settled,
       takenDown: placementsRemoved.takenDown + result.takenDown,

--- a/src/server/services/creator-shop.service.ts
+++ b/src/server/services/creator-shop.service.ts
@@ -8,6 +8,7 @@ import {
   revokeCosmeticsFromUsers,
   validateStickerCosmetic,
 } from '~/server/services/cosmetic.service';
+import { removePlacementsByCosmetic } from '~/server/services/placement-moderation.service';
 import {
   appendItemHistory,
   buildCosmeticData,
@@ -1897,6 +1898,41 @@ export const takedownCosmeticShopItem = async ({
         })
       : { revoked: 0 };
 
+  // Revoking the holding does not touch stickers already placed on other
+  // people's images — those live in `Placement` with the cosmetic id inside a
+  // JSON payload, and taking down the artwork everywhere is the whole point of
+  // a takedown. Drained rather than run once: the helper is bounded per batch,
+  // and one pass would report a clean takedown with the artwork still up.
+  // Capped so a runaway cannot hold the request; `hasMore` says to run again.
+  let placementsRemoved = { settled: 0, takenDown: 0, failed: 0, hasMore: false };
+  for (let batch = 0; batch < 10 && memberIds.length; batch++) {
+    let result: Awaited<ReturnType<typeof removePlacementsByCosmetic>>;
+    try {
+      result = await removePlacementsByCosmetic({ cosmeticIds: memberIds, actorId: moderatorId });
+    } catch (error) {
+      await logTakedown('error', 'Placement takedown failed', {
+        shopItemId: id,
+        cosmeticIds: memberIds,
+        error: errorMessage(error),
+      });
+      break;
+    }
+
+    placementsRemoved = {
+      settled: placementsRemoved.settled + result.settled,
+      takenDown: placementsRemoved.takenDown + result.takenDown,
+      failed: placementsRemoved.failed + result.failed.length,
+      hasMore: result.hasMore,
+    };
+    if (!result.hasMore) break;
+  }
+
+  if (placementsRemoved.hasMore || placementsRemoved.failed)
+    await logTakedown('error', 'Placement takedown left work behind', {
+      shopItemId: id,
+      ...placementsRemoved,
+    });
+
   if (creatorId) {
     await createNotification({
       type: 'creator-shop-item-taken-down',
@@ -1933,6 +1969,7 @@ export const takedownCosmeticShopItem = async ({
     unrecoveredResellerShare,
     unrecoveredPackPool,
     revokedFrom: revoked,
+    placementsRemoved,
     failures,
   });
 
@@ -1950,6 +1987,7 @@ export const takedownCosmeticShopItem = async ({
     unrecoveredResellerShare,
     unrecoveredPackPool,
     revokedFrom: revoked,
+    placementsRemoved,
     failures,
   };
 };

--- a/src/server/services/creator-shop.service.ts
+++ b/src/server/services/creator-shop.service.ts
@@ -1915,17 +1915,12 @@ export const takedownCosmeticShopItem = async ({
   // `removePlacementsByCosmetic`; the trade is deliberate and was tried the
   // other way first.
   //
-  // **Single items only.** A pack takedown archives the bundle and never
-  // delists its members — that is the comment above, and it is deliberate,
-  // since a member sold standalone is not what was taken down. But this call
-  // takes no per-member abuse designation, so sweeping here would remove every
-  // placement of every member site-wide while those members stay purchasable:
-  // the artwork judged too abusive to sit on anyone's image, still on sale, and
-  // re-placeable the moment someone rebuys it. That is incoherent under either
-  // answer to "should a pack takedown treat every member as abusive", so the
-  // sweep waits for the ruling. Skipping is the additive direction — the
-  // per-member takedown that already exists does sweep, and widening this later
-  // removes nothing.
+  // **Single items only, by decision.** Taking a pack down takes down the
+  // bundle, not the artwork in it (Justin, 2026-08-09) — its members stay on
+  // sale, which is why nothing delists them above. Sweeping here would remove
+  // every placement of every member site-wide while those members remain
+  // purchasable and immediately re-placeable, judging artwork nobody judged.
+  // Abusive artwork is taken down per member, and that path does sweep.
   // Rows a batch could not settle, excluded once they have failed twice.
   // `ORDER BY id` is stable, so a permanently failing row is re-selected first
   // every time and would otherwise burn all ten iterations. Excluding on the

--- a/src/server/services/creator-shop.service.ts
+++ b/src/server/services/creator-shop.service.ts
@@ -1911,6 +1911,18 @@ export const takedownCosmeticShopItem = async ({
   // abusive artwork up on everything its author placed it on. See the note on
   // `removePlacementsByCosmetic`; the trade is deliberate and was tried the
   // other way first.
+  //
+  // **Single items only.** A pack takedown archives the bundle and never
+  // delists its members — that is the comment above, and it is deliberate,
+  // since a member sold standalone is not what was taken down. But this call
+  // takes no per-member abuse designation, so sweeping here would remove every
+  // placement of every member site-wide while those members stay purchasable:
+  // the artwork judged too abusive to sit on anyone's image, still on sale, and
+  // re-placeable the moment someone rebuys it. That is incoherent under either
+  // answer to "should a pack takedown treat every member as abusive", so the
+  // sweep waits for the ruling. Skipping is the additive direction — the
+  // per-member takedown that already exists does sweep, and widening this later
+  // removes nothing.
   // Rows a batch could not settle, excluded once they have failed twice.
   // `ORDER BY id` is stable, so a permanently failing row is re-selected first
   // every time and would otherwise burn all ten iterations. Excluding on the
@@ -1920,7 +1932,7 @@ export const takedownCosmeticShopItem = async ({
   const failureCount = new Map<number, number>();
   const unsettled: number[] = [];
   let placementsRemoved = { settled: 0, takenDown: 0, failed: 0, hasMore: false };
-  for (let batch = 0; batch < 10 && memberIds.length; batch++) {
+  for (let batch = 0; batch < 10 && memberIds.length && !isPack; batch++) {
     let result: Awaited<ReturnType<typeof removePlacementsByCosmetic>>;
     try {
       result = await removePlacementsByCosmetic({
@@ -1945,11 +1957,19 @@ export const takedownCosmeticShopItem = async ({
     placementsRemoved = {
       settled: placementsRemoved.settled + result.settled,
       takenDown: placementsRemoved.takenDown + result.takenDown,
-      failed: placementsRemoved.failed + result.failed.length,
+      // Distinct rows, not attempts — a row is selected again on its retry, so
+      // summing per-batch failures reports double what is actually stuck.
+      failed: failureCount.size,
       hasMore: result.hasMore,
     };
     if (!result.hasMore) break;
   }
+
+  if (isPack && memberIds.length)
+    await logTakedown('info', 'Placement sweep skipped for a pack takedown', {
+      shopItemId: id,
+      cosmeticIds: memberIds,
+    });
 
   if (placementsRemoved.hasMore || placementsRemoved.failed)
     await logTakedown('error', 'Placement takedown left work behind', {

--- a/src/server/services/placement-escrow.service.ts
+++ b/src/server/services/placement-escrow.service.ts
@@ -187,7 +187,13 @@ type SettleAction =
   | 'declineByBlock'
   | 'expire'
   | 'removeByOwner'
-  | 'removeByModerator';
+  | 'removeByModerator'
+  /**
+   * The cosmetic itself was taken down as abusive. Refunds the placer in full:
+   * they are a holder of the revoked artwork, not its author, and the takedown
+   * makes them whole for it everywhere else.
+   */
+  | 'removeByCosmeticTakedown';
 
 const STATUS_FOR_ACTION: Record<SettleAction, 'approved' | 'declined' | 'expired' | 'removed'> = {
   approve: 'approved',
@@ -196,11 +202,13 @@ const STATUS_FOR_ACTION: Record<SettleAction, 'approved' | 'declined' | 'expired
   expire: 'expired',
   removeByOwner: 'removed',
   removeByModerator: 'removed',
+  removeByCosmeticTakedown: 'removed',
 };
 
 const REMOVED_BY_FOR_ACTION: Partial<Record<SettleAction, PlacementRemovedBy>> = {
   removeByOwner: 'owner',
   removeByModerator: 'moderator',
+  removeByCosmeticTakedown: 'cosmeticTakedown',
 };
 
 const isUniqueViolation = (error: unknown) =>
@@ -613,8 +621,12 @@ async function payoutLegsFor(
             { kind: 'feeToOwner', amount: fee },
             { kind: 'principalToPlacer', amount: principal },
           ];
+    // A cosmetic takedown refunds the same as an owner's removal — the placer
+    // holds revoked artwork rather than having authored it — and differs only in
+    // what the row records about who did it and why.
     case 'expired':
     case 'removedByOwner':
+    case 'removedByCosmeticTakedown':
       return [
         { kind: 'principalToPlacer', amount: principal },
         { kind: 'feeToPlacer', amount: fee },

--- a/src/server/services/placement-moderation.service.ts
+++ b/src/server/services/placement-moderation.service.ts
@@ -271,30 +271,32 @@ export async function removePlacementByModerator({
  * the row has to be able to tell "this placer's sticker was abusive, escrow
  * forfeit" from "the artwork's maker was taken down, placer is a victim", and
  * that distinction decides who gets compensated.
+ *
+ * **Not scoped to the placers whose holding was revoked, deliberately, and it
+ * was tried the other way first.** `revokeCosmeticsFromUsers` scopes a pack to
+ * the claim keys it granted, and inheriting that scope here looks fairer: it
+ * spares someone who bought a member standalone. It also defeats the function.
+ * `UserCosmetic`'s key is `[userId, cosmeticId, claimKey]`, so a holding
+ * obtained by any route other than that purchase — above all **the maker's own
+ * creator grant** — is not in the scope. The person the takedown exists to stop
+ * would be the one person whose placements survived it.
+ *
+ * There is no third option: a `Placement` records a cosmetic id and nothing
+ * about which holding paid for it, and `spendStickerUses` drains across
+ * holdings without recording which one funded which placement. Placer identity
+ * is a proxy that is wrong in both directions by construction. So the sweep
+ * follows the artwork, and the cost is real and accepted: someone who owns the
+ * same sticker both inside a taken-down pack and standalone loses all of their
+ * placements of it. Pending ones refund in full; approved ones were already
+ * paid out to content owners and move no money either way.
  */
 export async function removePlacementsByCosmetic({
   cosmeticIds,
-  placerIds,
   skipIds,
   actorId,
   limit = 200,
 }: {
   cosmeticIds: number[];
-  /**
-   * Restricts the sweep to placers whose holding was actually revoked.
-   *
-   * A **pack** takedown needs this, and omitting it removes placements from
-   * people the takedown deliberately leaves alone: `revokeCosmeticsFromUsers` is
-   * scoped by the pack's claim keys, because a member sold standalone is not
-   * what was taken down. Unscoped, someone who bought that member on its own
-   * keeps the cosmetic, gets no refund, and still has their approved placement
-   * removed.
-   *
-   * An EMPTY array means "nobody qualifies" and sweeps nothing. Treating it as
-   * absent would widen a scoped sweep into an unscoped one, which is the bug
-   * this parameter exists to prevent.
-   */
-  placerIds?: number[];
   /** Rows a previous batch in the same run could not settle — see below. */
   skipIds?: number[];
   actorId: number;
@@ -303,22 +305,19 @@ export async function removePlacementsByCosmetic({
   const empty = { considered: 0, settled: 0, failed: [] as number[], takenDown: 0, hasMore: false };
   const ids = [...new Set(cosmeticIds)];
   if (!ids.length) return empty;
-  if (placerIds && !placerIds.length) return empty;
 
-  const placers = placerIds ? [...new Set(placerIds)] : null;
   // Rows that already failed this run are excluded rather than re-selected.
   // `ORDER BY id` is stable, so a permanently failing pending row is picked
   // first by every subsequent batch — 200 of them and the sweep makes zero
   // progress across every iteration of the drain while reporting `hasMore`.
   const skip = skipIds?.length ? [...new Set(skipIds)] : null;
 
-  // Composed as fragments rather than `(${placers}::int[] IS NULL OR …)`.
-  // Whether a JS `null` bound to an array parameter arrives as a castable SQL
-  // NULL is a driver behaviour, and this layer's tests mock Prisma, so nothing
-  // would execute it before production — where the failure is a throw that
-  // fails the sweep closed and leaves the artwork up. An absent filter is not a
-  // filter that has to evaluate to true.
-  const placerFilter = placers ? Prisma.sql`AND "placerId" = ANY(${placers}::int[])` : Prisma.empty;
+  // Composed as a fragment rather than `(${skip}::int[] IS NULL OR …)`. Whether
+  // a JS `null` bound to an array parameter arrives as a castable SQL NULL is a
+  // driver behaviour, and this layer's tests mock Prisma, so nothing would
+  // execute it before production — where the failure is a throw that fails the
+  // sweep closed and leaves the artwork up. An absent filter is not a filter
+  // that has to evaluate to true.
   const skipFilter = skip ? Prisma.sql`AND NOT (id = ANY(${skip}::int[]))` : Prisma.empty;
 
   // Raw, because the cosmetic id lives inside `data` and Prisma's JSON path
@@ -330,7 +329,6 @@ export async function removePlacementsByCosmetic({
       WHERE surface = 'sticker'
         AND status = ${status}
         AND ("data"->>'cosmeticId')::int = ANY(${ids}::int[])
-        ${placerFilter}
         ${skipFilter}
       ORDER BY id
       LIMIT ${limit}

--- a/src/server/services/placement-moderation.service.ts
+++ b/src/server/services/placement-moderation.service.ts
@@ -258,10 +258,16 @@ export async function removePlacementByModerator({
  * artwork that is itself abusive has to come off everyone's work regardless of
  * who placed it. `revokeCosmeticsFromUsers` strips the holding and un-equips
  * profile decorations; it knows nothing about placements, which live in their
- * own table with the cosmetic id inside a JSON payload. Without this the artwork
- * stays on other people's images after being revoked — and once the cosmetic is
- * gone the overlay renders nothing, so the placement is invisible, permanent,
- * and still counted.
+ * own table with the cosmetic id inside a JSON payload.
+ *
+ * Without this the artwork **stays fully visible** on other people's images
+ * after being revoked. Not invisible-but-counted, which is what this comment
+ * used to claim and is worth correcting rather than deleting: a takedown never
+ * writes the `Cosmetic` row, and `getStickerCosmetics` resolves artwork by id
+ * with no join to `UserCosmetic` and no availability check — so revoking every
+ * holding changes nothing about what renders. Reasoning from the old version
+ * leads to "we can skip the sweep, it draws nothing anyway", which is exactly
+ * backwards.
  *
  * Approved placements are taken down without settlement: the content owner was
  * already paid and did not choose this sticker (Justin, 2026-08-08). Pending

--- a/src/server/services/placement-moderation.service.ts
+++ b/src/server/services/placement-moderation.service.ts
@@ -265,7 +265,9 @@ export async function removePlacementByModerator({
  * used to claim and is worth correcting rather than deleting: a takedown never
  * writes the `Cosmetic` row, and `getStickerCosmetics` resolves artwork by id
  * with no join to `UserCosmetic` and no availability check — so revoking every
- * holding changes nothing about what renders. Reasoning from the old version
+ * holding changes nothing about what the placement overlay draws. (It does stop
+ * the picker offering the sticker and un-equips profile decorations; neither is
+ * what this is about.) Reasoning from the old version
  * leads to "we can skip the sweep, it draws nothing anyway", which is exactly
  * backwards.
  *

--- a/src/server/services/placement-moderation.service.ts
+++ b/src/server/services/placement-moderation.service.ts
@@ -249,6 +249,78 @@ export async function removePlacementByModerator({
   return { removed: count > 0, wasLive: true };
 }
 
+/**
+ * Every placement made with a cosmetic that has been taken down.
+ *
+ * The third moderator power in the spec, and the one that is about the *maker*
+ * rather than the placer: a fine sticker used maliciously is a suspension, while
+ * artwork that is itself abusive has to come off everyone's work regardless of
+ * who placed it. `revokeCosmeticsFromUsers` strips the holding and un-equips
+ * profile decorations; it knows nothing about placements, which live in their
+ * own table with the cosmetic id inside a JSON payload. Without this the artwork
+ * stays on other people's images after being revoked — and once the cosmetic is
+ * gone the overlay renders nothing, so the placement is invisible, permanent,
+ * and still counted.
+ *
+ * Approved placements are taken down without settlement: the content owner was
+ * already paid and did not choose this sticker (Justin, 2026-08-08). Pending
+ * ones refund the placer in full, because the placer is a holder of the revoked
+ * cosmetic and is being made whole for it everywhere else.
+ *
+ * ⚠️ That full refund goes through `removeByOwner`, which is the only settle
+ * action whose payout returns the whole escrow — so the row records
+ * `removedBy: 'owner'` for something a moderator did. The money is right and the
+ * label is wrong; fixing the label means a third `PlacementRemovedBy` value and
+ * a payout branch for it, which is a migration.
+ */
+export async function removePlacementsByCosmetic({
+  cosmeticIds,
+  actorId,
+  limit = 200,
+}: {
+  cosmeticIds: number[];
+  actorId: number;
+  limit?: number;
+}) {
+  const ids = [...new Set(cosmeticIds)];
+  if (!ids.length) return { considered: 0, settled: 0, failed: [], takenDown: 0, hasMore: false };
+
+  // Raw, because the cosmetic id lives inside `data` and Prisma's JSON path
+  // filter takes one value at a time — a pack takedown revokes several members
+  // at once, and one query per member is a query per member.
+  const byStatus = (status: string) =>
+    dbWrite.$queryRaw<{ id: number }[]>`
+      SELECT id FROM "Placement"
+      WHERE surface = 'sticker'
+        AND status = ${status}
+        AND ("data"->>'cosmeticId')::int = ANY(${ids}::int[])
+      ORDER BY id
+      LIMIT ${limit}
+    `;
+
+  const pending = await byStatus('pending');
+  const settled = await settleEach(pending, (id) =>
+    settlePlacement({ placementId: id, action: 'removeByOwner', actorId })
+  );
+
+  const approved = await byStatus('approved');
+  const { count: takenDown } = await dbWrite.placement.updateMany({
+    where: { id: { in: approved.map((row) => row.id) }, status: 'approved' },
+    data: {
+      status: 'removed',
+      removedBy: 'moderator',
+      takenDownAt: new Date(),
+      takenDownById: actorId,
+    },
+  });
+
+  return {
+    ...settled,
+    takenDown,
+    hasMore: pending.length === limit || approved.length === limit,
+  };
+}
+
 export async function suspendPlacementPrivileges({
   userId,
   actorId,

--- a/src/server/services/placement-moderation.service.ts
+++ b/src/server/services/placement-moderation.service.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '@prisma/client';
 import { dbWrite } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
 import { settlePlacement } from '~/server/services/placement-escrow.service';
@@ -311,6 +312,15 @@ export async function removePlacementsByCosmetic({
   // progress across every iteration of the drain while reporting `hasMore`.
   const skip = skipIds?.length ? [...new Set(skipIds)] : null;
 
+  // Composed as fragments rather than `(${placers}::int[] IS NULL OR …)`.
+  // Whether a JS `null` bound to an array parameter arrives as a castable SQL
+  // NULL is a driver behaviour, and this layer's tests mock Prisma, so nothing
+  // would execute it before production — where the failure is a throw that
+  // fails the sweep closed and leaves the artwork up. An absent filter is not a
+  // filter that has to evaluate to true.
+  const placerFilter = placers ? Prisma.sql`AND "placerId" = ANY(${placers}::int[])` : Prisma.empty;
+  const skipFilter = skip ? Prisma.sql`AND NOT (id = ANY(${skip}::int[]))` : Prisma.empty;
+
   // Raw, because the cosmetic id lives inside `data` and Prisma's JSON path
   // filter takes one value at a time — a pack takedown revokes several members
   // at once, and one query per member is a query per member.
@@ -320,8 +330,8 @@ export async function removePlacementsByCosmetic({
       WHERE surface = 'sticker'
         AND status = ${status}
         AND ("data"->>'cosmeticId')::int = ANY(${ids}::int[])
-        AND (${placers}::int[] IS NULL OR "placerId" = ANY(${placers}::int[]))
-        AND (${skip}::int[] IS NULL OR NOT (id = ANY(${skip}::int[])))
+        ${placerFilter}
+        ${skipFilter}
       ORDER BY id
       LIMIT ${limit}
     `;

--- a/src/server/services/placement-moderation.service.ts
+++ b/src/server/services/placement-moderation.service.ts
@@ -271,6 +271,9 @@ export async function removePlacementByModerator({
  * leads to "we can skip the sweep, it draws nothing anyway", which is exactly
  * backwards.
  *
+ * Called for a single cosmetic's takedown, never a pack's — a pack takedown
+ * removes the bundle, not the artwork in it (Justin, 2026-08-09).
+ *
  * Approved placements are taken down without settlement: the content owner was
  * already paid and did not choose this sticker (Justin, 2026-08-08). Pending
  * ones refund the placer in full, because the placer is a holder of the revoked

--- a/src/server/services/placement-moderation.service.ts
+++ b/src/server/services/placement-moderation.service.ts
@@ -267,11 +267,6 @@ export async function removePlacementByModerator({
  * ones refund the placer in full, because the placer is a holder of the revoked
  * cosmetic and is being made whole for it everywhere else.
  *
- * ⚠️ That full refund goes through `removeByOwner`, which is the only settle
- * action whose payout returns the whole escrow — so the row records
- * `removedBy: 'owner'` for something a moderator did. The money is right and the
- * label is wrong; fixing the label means a third `PlacementRemovedBy` value and
- * a payout branch for it, which is a migration.
  */
 export async function removePlacementsByCosmetic({
   cosmeticIds,
@@ -300,7 +295,7 @@ export async function removePlacementsByCosmetic({
 
   const pending = await byStatus('pending');
   const settled = await settleEach(pending, (id) =>
-    settlePlacement({ placementId: id, action: 'removeByOwner', actorId })
+    settlePlacement({ placementId: id, action: 'removeByCosmeticTakedown', actorId })
   );
 
   const approved = await byStatus('approved');

--- a/src/server/services/placement-moderation.service.ts
+++ b/src/server/services/placement-moderation.service.ts
@@ -194,6 +194,61 @@ export async function removePlacementsByUser({
   };
 }
 
+/**
+ * One placement, removed by a moderator — the action behind a sticker report.
+ *
+ * **A live placement cannot go through `settlePlacement` alone.** That claims
+ * its transition with `WHERE status = 'pending'`, so an approved row matches
+ * nothing, no money moves, and it returns `settled: false` — a moderator would
+ * press remove on the reported sticker and watch it stay exactly where it is.
+ * Approved placements are taken down by the same write `removePlacementsByUser`
+ * uses, for the same reason: their money was already paid to an owner who did
+ * nothing wrong, so clawing it back punishes the wrong party.
+ *
+ * ⚠️ That the approved case moves no money is provisional pending Justin, and
+ * is the reversible direction — deciding later to claw back is additive.
+ */
+export async function removePlacementByModerator({
+  placementId,
+  actorId,
+}: {
+  placementId: number;
+  actorId: number;
+}) {
+  const placement = await dbWrite.placement.findUnique({
+    where: { id: placementId },
+    select: { id: true, status: true },
+  });
+
+  if (!placement) throw new Error('placement: that placement no longer exists');
+
+  if (placement.status === 'pending') {
+    const { settled } = await settlePlacement({
+      placementId,
+      action: 'removeByModerator',
+      actorId,
+    });
+    return { removed: settled, wasLive: false };
+  }
+
+  if (placement.status !== 'approved')
+    throw new Error(`placement: that placement is already ${placement.status}`);
+
+  const { count } = await dbWrite.placement.updateMany({
+    where: { id: placementId, status: 'approved' },
+    data: {
+      status: 'removed',
+      removedBy: 'moderator',
+      // Not `resolvedAt`/`resolvedById`: those record who approved it, and this
+      // is the one path whose purpose is a moderation record.
+      takenDownAt: new Date(),
+      takenDownById: actorId,
+    },
+  });
+
+  return { removed: count > 0, wasLive: true };
+}
+
 export async function suspendPlacementPrivileges({
   userId,
   actorId,

--- a/src/server/services/placement-moderation.service.ts
+++ b/src/server/services/placement-moderation.service.ts
@@ -265,20 +265,51 @@ export async function removePlacementByModerator({
  * Approved placements are taken down without settlement: the content owner was
  * already paid and did not choose this sticker (Justin, 2026-08-08). Pending
  * ones refund the placer in full, because the placer is a holder of the revoked
- * cosmetic and is being made whole for it everywhere else.
- *
+ * cosmetic and is being made whole for it everywhere else. Both record
+ * `removedBy: 'cosmeticTakedown'` rather than `'moderator'`: a reconcile reading
+ * the row has to be able to tell "this placer's sticker was abusive, escrow
+ * forfeit" from "the artwork's maker was taken down, placer is a victim", and
+ * that distinction decides who gets compensated.
  */
 export async function removePlacementsByCosmetic({
   cosmeticIds,
+  placerIds,
+  skipIds,
   actorId,
   limit = 200,
 }: {
   cosmeticIds: number[];
+  /**
+   * Restricts the sweep to placers whose holding was actually revoked.
+   *
+   * A **pack** takedown needs this, and omitting it removes placements from
+   * people the takedown deliberately leaves alone: `revokeCosmeticsFromUsers` is
+   * scoped by the pack's claim keys, because a member sold standalone is not
+   * what was taken down. Unscoped, someone who bought that member on its own
+   * keeps the cosmetic, gets no refund, and still has their approved placement
+   * removed.
+   *
+   * An EMPTY array means "nobody qualifies" and sweeps nothing. Treating it as
+   * absent would widen a scoped sweep into an unscoped one, which is the bug
+   * this parameter exists to prevent.
+   */
+  placerIds?: number[];
+  /** Rows a previous batch in the same run could not settle — see below. */
+  skipIds?: number[];
   actorId: number;
   limit?: number;
 }) {
+  const empty = { considered: 0, settled: 0, failed: [] as number[], takenDown: 0, hasMore: false };
   const ids = [...new Set(cosmeticIds)];
-  if (!ids.length) return { considered: 0, settled: 0, failed: [], takenDown: 0, hasMore: false };
+  if (!ids.length) return empty;
+  if (placerIds && !placerIds.length) return empty;
+
+  const placers = placerIds ? [...new Set(placerIds)] : null;
+  // Rows that already failed this run are excluded rather than re-selected.
+  // `ORDER BY id` is stable, so a permanently failing pending row is picked
+  // first by every subsequent batch — 200 of them and the sweep makes zero
+  // progress across every iteration of the drain while reporting `hasMore`.
+  const skip = skipIds?.length ? [...new Set(skipIds)] : null;
 
   // Raw, because the cosmetic id lives inside `data` and Prisma's JSON path
   // filter takes one value at a time — a pack takedown revokes several members
@@ -289,6 +320,8 @@ export async function removePlacementsByCosmetic({
       WHERE surface = 'sticker'
         AND status = ${status}
         AND ("data"->>'cosmeticId')::int = ANY(${ids}::int[])
+        AND (${placers}::int[] IS NULL OR "placerId" = ANY(${placers}::int[]))
+        AND (${skip}::int[] IS NULL OR NOT (id = ANY(${skip}::int[])))
       ORDER BY id
       LIMIT ${limit}
     `;
@@ -303,7 +336,7 @@ export async function removePlacementsByCosmetic({
     where: { id: { in: approved.map((row) => row.id) }, status: 'approved' },
     data: {
       status: 'removed',
-      removedBy: 'moderator',
+      removedBy: 'cosmeticTakedown',
       takenDownAt: new Date(),
       takenDownById: actorId,
     },

--- a/src/server/services/sticker-placement.service.ts
+++ b/src/server/services/sticker-placement.service.ts
@@ -264,23 +264,35 @@ export type StickerPlacementView = {
 export async function getStickerPlacementDetail({
   placementId,
   viewerId,
+  isModerator = false,
 }: {
   placementId: number;
   viewerId?: number;
+  /**
+   * A moderator is party to neither side of a pending placement, so the scoping
+   * below hides it from the only role that can act on it — and the surfaces
+   * built on this read then say "no longer live" about something that is
+   * pending, with no action offered. Widened for moderators specifically rather
+   * than loosened for everyone: the rule that a pending placement is visible to
+   * exactly the placer and the owner is what stops it being enumerable.
+   */
+  isModerator?: boolean;
 }) {
   const placement = await dbRead.placement.findFirst({
     where: {
       id: placementId,
       surface: SURFACE,
-      OR: [
-        { status: 'approved' },
-        ...(viewerId
-          ? [
-              { status: 'pending' as const, placerId: viewerId },
-              { status: 'pending' as const, ownerId: viewerId },
-            ]
-          : []),
-      ],
+      OR: isModerator
+        ? undefined
+        : [
+            { status: 'approved' },
+            ...(viewerId
+              ? [
+                  { status: 'pending' as const, placerId: viewerId },
+                  { status: 'pending' as const, ownerId: viewerId },
+                ]
+              : []),
+          ],
     },
     select: {
       id: true,

--- a/src/server/services/sticker-placement.service.ts
+++ b/src/server/services/sticker-placement.service.ts
@@ -275,6 +275,13 @@ export async function getStickerPlacementDetail({
    * pending, with no action offered. Widened for moderators specifically rather
    * than loosened for everyone: the rule that a pending placement is visible to
    * exactly the placer and the owner is what stops it being enumerable.
+   *
+   * **Widened to the other live status, not to every status.** Dropping the
+   * filter would also return declined, expired and removed rows, and every
+   * consumer reads a miss here as "this placement is already gone" — so a
+   * second moderator opening a report someone else has already actioned would
+   * be offered a remove button for a removed placement, told no Buzz moves,
+   * and handed an error when they pressed it.
    */
   isModerator?: boolean;
 }) {
@@ -283,7 +290,7 @@ export async function getStickerPlacementDetail({
       id: placementId,
       surface: SURFACE,
       OR: isModerator
-        ? undefined
+        ? [{ status: 'approved' }, { status: 'pending' }]
         : [
             { status: 'approved' },
             ...(viewerId

--- a/src/shared/utils/__tests__/placement.test.ts
+++ b/src/shared/utils/__tests__/placement.test.ts
@@ -22,6 +22,7 @@ const OUTCOMES: PlacementOutcome[] = [
   'expired',
   'removedByOwner',
   'removedByModerator',
+  'removedByCosmeticTakedown',
 ];
 
 // Boundaries plus the awkward middles. 0 and 1 are included deliberately: the
@@ -95,7 +96,7 @@ describe('splitPlacementPayment — the Buzz-conservation invariant', () => {
   });
 
   it('returns everything on expiry and on owner removal of an auto-approved placement', () => {
-    for (const outcome of ['expired', 'removedByOwner'] as const) {
+    for (const outcome of ['expired', 'removedByOwner', 'removedByCosmeticTakedown'] as const) {
       const split = splitPlacementPayment({
         amount: 250,
         outcome,
@@ -139,6 +140,9 @@ describe('settling a stored placement', () => {
   it('resolves a removal only when it knows who removed it', () => {
     expect(placementOutcomeFromStatus('removed', 'owner')).toBe('removedByOwner');
     expect(placementOutcomeFromStatus('removed', 'moderator')).toBe('removedByModerator');
+    expect(placementOutcomeFromStatus('removed', 'cosmeticTakedown')).toBe(
+      'removedByCosmeticTakedown'
+    );
     expect(() => placementOutcomeFromStatus('removed', null)).toThrow(/who removed it/);
     expect(() => placementOutcomeFromStatus('removed')).toThrow(/who removed it/);
   });

--- a/src/shared/utils/placement.ts
+++ b/src/shared/utils/placement.ts
@@ -24,12 +24,16 @@ export type PlacementStatus = 'pending' | 'approved' | 'declined' | 'expired' | 
 /**
  * Who removed a placement, stored alongside `status: 'removed'`.
  *
- * The two removals have opposite money outcomes — an owner removing an
+ * The removals have different money outcomes — an owner removing an
  * auto-approved placement refunds in full, a moderator removing an abusive one
- * refunds nothing — so `removed` alone cannot tell a reconcile or a retry which
- * one happened.
+ * refunds nothing, and a cosmetic takedown refunds in full because the abuse was
+ * the artwork's maker's rather than the placer's — so `removed` alone cannot
+ * tell a reconcile or a retry which one happened.
+ *
+ * The column is TEXT, not a database enum, so a new value here is a code change
+ * and not a migration.
  */
-export type PlacementRemovedBy = 'owner' | 'moderator';
+export type PlacementRemovedBy = 'owner' | 'moderator' | 'cosmeticTakedown';
 
 /**
  * Every movement of money a placement can make, one row each in the ledger.
@@ -245,7 +249,8 @@ export type PlacementOutcome =
   | 'declined'
   | 'expired'
   | 'removedByOwner'
-  | 'removedByModerator';
+  | 'removedByModerator'
+  | 'removedByCosmeticTakedown';
 
 export type PlacementSplitInput = {
   /** Integer Buzz the placer paid into escrow. */
@@ -310,8 +315,15 @@ export function splitPlacementPayment(input: PlacementSplitInput): PlacementSpli
     // Neither cost the owner any attention, so neither pays a fee. Removing an
     // auto-approved placement pays nothing on purpose: a fee there would reward
     // accepting placements, banking the money and sweeping them off later.
+    // The cosmetic itself was revoked as abusive, which makes the placer a
+    // holder of it rather than the offender — they are refunded for it
+    // everywhere else, so forfeiting their escrow here would charge them for the
+    // maker's abuse. Its own outcome rather than reusing `removedByOwner`: the
+    // money is the same and the record is not, and the record is what a
+    // reconcile reads to explain why.
     case 'expired':
     case 'removedByOwner':
+    case 'removedByCosmeticTakedown':
       return { ...nothing, toPlacer: amount };
     // Not returned — the placement was abusive. It is forfeit rather than paid
     // to the owner, so a removal no one benefits from stays uninteresting to game.
@@ -344,6 +356,7 @@ export function placementOutcomeFromStatus(
     case 'removed':
       if (removedBy === 'owner') return 'removedByOwner';
       if (removedBy === 'moderator') return 'removedByModerator';
+      if (removedBy === 'cosmeticTakedown') return 'removedByCosmeticTakedown';
       throw new Error('placement outcome: a removed placement must record who removed it');
     case 'pending':
       throw new Error('placement outcome: a pending placement has no settled outcome');


### PR DESCRIPTION
Follow-on from chunk D (#3595). Three items Justin triaged on 2026-08-07, plus two he added on 2026-08-08.

## ⚠️ Migration — apply before the image ships

`packages/civitai-db-schema/prisma/migrations/20260809040000_placement_removed_by_cosmetic_takedown` drops and re-adds `Placement_removedBy_check` with a third allowed value. **Code depends on this schema:** without it, a cosmetic takedown that settles a pending placement raises `23514`, the placer is not refunded, and the row stays pending. Needs applying by hand to dev and prod.

It is **two migration directories** on purpose — `20260809040000` adds the constraint `NOT VALID`, `20260809041000` validates it. Postgres holds locks to the end of a transaction, so putting both in one file lets the `ADD`'s ACCESS EXCLUSIVE sit across the validation scan, which is strictly worse than a plain `ADD CONSTRAINT`. They must not be run inside one transaction together. Stopping after the first is safe but incomplete: `NOT VALID` skips only the check of existing rows, so the constraint is enforced on every write immediately.

**Rolling the image back afterwards is not free.** Once a takedown has written `removedBy: 'cosmeticTakedown'`, older code cannot interpret those rows: `placementOutcomeFromStatus` throws on an unrecognised removal reason, so every sweep that touches one — `sweepUnpaidLegs`, `sweepUnplannedSettlements` — throws, is caught, logged, and retried forever. A rollback needs those rows repaired, not just the image reverted.

Nothing else in the branch touches the schema. `schema.full.prisma`'s doc comment for `removedBy` was updated to name the constraint, which changes the generated Kysely types — those are regenerated and committed, and `db:check-generated` is clean.

## What shipped

**1. Placement in feeds.** The reaction-bar entry and the sticker overlay existed only on the image detail view; both now render on feed cards (`ImageCard`, `ImagesCard`).

Nothing joins into `getInfiniteImages`. A `StickerPlacementBatchProvider` mounted inside `ImagesProvider` fetches counts, placements **and the sticker artwork** once per 100 cards, so a feed pays a handful of lookups rather than one per card — tRPC request batching is behind a flag that is off by default, so a per-card query really is a per-card HTTP request.

The artwork belongs in that list and was not there at first: every card resolved its own through `useStickerCosmetics`, keyed on that card's cosmetic ids, so 50 cards carrying 50 distinct stickers fired up to 50 requests to draw them. The batching property held for the cheap half and not for the half you cannot render without.

Two things in there that are load-bearing and not obvious:

- **Chunked in arrival order, not sorted.** A feed appends *older* (lower) ids as it pages, so a sorted list reshuffles every chunk boundary on every page and refetches the whole feed's placements each time. Arrival order means a full chunk's key never changes again.
- **No per-card fallback query.** Card components read the batch from context and render nothing without a provider. A fallback would reintroduce the per-card request this exists to avoid, invisibly, on whichever surface forgot to mount the provider.

`CardStickerOverlay` **measures the media element** rather than computing the cover box. The two card templates lay the media out differently enough that the resulting rectangle differs — one stretches the image to the card width in a flex column, the other lets `height: 100%; width: auto` overflow a block box, anchoring the crop left instead of centring it. Reproducing that in arithmetic means encoding both templates' CSS in the component and being wrong, silently, the day either changes. It measures with `offsetWidth`/`offsetTop` walked up the offset chain, not `getBoundingClientRect` — both templates scale the media on hover, a rect includes transforms, and a `ResizeObserver` does not fire on one.

Cards request artwork at 256px rather than the 512 a detail view uses. A sticker on a card draws at ~112 CSS px at the default 0.25 scale cap, which a DPR-2 display wants 225 device px for — so 256 covers retina at the default ceiling and is still a quarter of 512's pixels. The CDN caches a variant per width, so this mints a second variant rather than being free.

**Consequence, not a bug:** `cover` crops, so a sticker placed low on a tall image is outside the visible box and not shown in a feed.

**2. A moderator can act on a reported placement.** The report already carried `placementId` and nothing consumed it. The report drawer now names the sticker and its placer and offers a remove action.

**3. A moderator can remove from the sticker's hover card, on the image detail view.** Same mutation as the report route, so the two cannot drift. No refund on a live placement and no notification, per Justin. Detail view only: cards render stickers non-interactively (below), which takes the hover card with it.

Stickers on a **feed card** are deliberately non-interactive — no hover card, no owner actions. The sticker body is `pointer-events-auto` for the hover card, which costs nothing at detail size and on a card is a hole in a link that does not open the image; the owner's approve/decline buttons also sit below the sticker, where the card's `overflow-hidden` clips them. Both live on the detail view, one click away.

**4. A cosmetic takedown now takes down its placements.** `takedownCosmeticShopItem` already refunded buyers, clawed the payout back off the seller and stripped the cosmetic from holders — it never touched stickers already placed on other people's images. Those live in their own table with the cosmetic id inside a JSON payload, and the revoke helper only knows about `UserCosmetic` rows and equipped profile decorations.

A takedown never writes the `Cosmetic` row, and the overlay resolves artwork by cosmetic id with no join to `UserCosmetic` and no availability check — so **a revoked sticker keeps rendering at full opacity on every image it was placed on.** (An earlier version of this PR and of the code claimed the opposite, that the placement became invisible-but-counted. It does not, and the true version is worse.)

**The sweep deliberately does not inherit the revoke's scope, and it was built the other way first.** A pack revokes only what its claim keys granted, and inheriting that scope looks fairer — it spares someone who bought a member standalone. It also defeats the function: `UserCosmetic`'s key is `[userId, cosmeticId, claimKey]`, so a holding obtained by any other route is outside the scope, and the sharpest of those is **the maker's own creator grant**. The person the takedown exists to stop would have been the one person whose placements survived it.

There is no third option available. A `Placement` records a cosmetic id and nothing about which holding paid for it, and `spendStickerUses` drains across holdings without recording which one funded which placement — placer identity is a proxy that is wrong in both directions by construction. So the sweep follows the artwork, and the cost is accepted rather than fixed: someone who owns the same sticker both inside a taken-down pack and standalone loses all of their placements of it. Pending ones refund in full; approved ones were already paid out and move no money either way.

**A pack takedown does not sweep placements** (Justin, 2026-08-09: taking down a pack takes down the bundle, not the artwork in it). Its members stay on sale — nothing delists them — so sweeping their placements would judge artwork nobody judged and leave it purchasable and immediately re-placeable. The result reports `skippedForPack` so a moderator is not left believing the artwork came down.

A single-item takedown does sweep, and that path is coherent: `delistPacksContaining` pulls the cosmetic from every pack, so it goes off sale everywhere at the moment its placements come down.

**5. `removedBy: 'cosmeticTakedown'`.** Its own removal reason rather than borrowing `removeByOwner`, whose payout is identical but whose record says the owner did it. A reconcile has to be able to tell "this placer's sticker was abusive, escrow forfeit" from "the artwork's maker was taken down, the placer is a victim".

## Money decisions (Justin, 2026-08-08)

- Cosmetic takedown claws back from the **maker** — unchanged, that is how the existing takedown already worked.
- Holders are refunded **everything they paid** — see the gap below.
- Placements made with a revoked cosmetic are **taken down without clawing back from content creators**: the creator did not choose the sticker and was already paid.
- Pending placements under a cosmetic takedown are **refunded in full** — the placer holds the revoked artwork rather than having authored it.
- A moderator removing one live placement moves **no money** and notifies nobody.

## Things a reviewer would otherwise rediscover

- **`settlePlacement` alone cannot remove a live placement.** It claims its transition with `WHERE status = 'pending'`, so an approved row matches nothing, no money moves, and it returns `settled: false`. The original handoff suggested calling it directly for the report action; that would have been a remove button that did nothing on the only kind of placement anyone reports.
- **There are two switches on the placement outcome**, `splitPlacementPayment` in shared utils and `payoutLegsFor` in the escrow service. Adding an outcome to one and not the other fails at runtime, not at typecheck-time in the obvious place.
- **`Placement.removedBy` is TEXT, but there is a CHECK constraint on its values.** The column type is not the whole story — see the migration above.
- **Moderators are party to neither side of a pending placement**, so `getStickerPlacementDetail`'s scoping used to hide them from the one role that has to act. Widened for moderators to the other *live* status only — every consumer reads a miss from this query as "already gone", so returning settled rows hands the second moderator on a report a remove button and an error.
- **`CardStickerOverlay` measures with `offsetWidth`/`offsetTop`, not `getBoundingClientRect`.** Both card templates scale the media on hover; a rect includes transforms and a `ResizeObserver` does not fire on one, so a measurement taken while the pointer rested on a card stayed 5% wrong afterwards.

## Deliberately out of scope

- **No way to place a sticker from a feed card** — positioning on a card-sized crop is the wrong gesture, and the affordance would cost a per-card query for the space and its price.
- **No separate feed-level reveal preference.** The existing toggle is global and sticky, so feeds inherit it. `04b` raises a second setting as an open product question.
- **`ImagesAsPostsCard` is not wired.** It does not use `ImagesProvider` and needs its own batch mount.
- **Per-use top-up refunds.** A top-up leaves no durable purchase row, so the takedown — which reads `UserCosmeticShopPurchases` — cannot find or refund one. Someone who bought a sticker once and then 500 uses gets the first refunded and not the rest. The fix does **not** need a new table: `buzzTransactions` in ClickHouse already carries `externalTransactionId`, and every top-up is keyed `sticker-topup-<user>-<cosmetic>-<uuid>`. Being written up separately.

## Known limits, stated rather than hidden

- A takedown sweeps at most 2000 pending + 2000 approved placements per invocation. Past that it logs and reports `hasMore`; nothing re-runs it automatically.
- A placement that fails to settle twice in one takedown is skipped for the rest of that run. One retry, not none — a transient Buzz or Redis blip should not become a permanent skip — but a row that fails both times waits for someone to re-run the takedown.
- `wantPlacements` fetches placement rows for every signed-in viewer whether or not stickers are revealed, because a pending placement is not discoverable from the approved-only count. That is one `Placement` `findMany` per 100 cards. `Placement_surface_targetType_targetId_status_idx` covers it as a leading-column match, so it is an index scan rather than a sequential one.

## Verification

- `pnpm run typecheck` — clean.
- `pnpm run lint` on the changed files — 0 errors. The warnings in `creator-shop.service.ts` and `reports.tsx` are pre-existing and untouched.
- `pnpm run test:unit:run` — **16 failures across 6 files, identical with and without this branch.** Baselined by stashing the entire change and re-running the same 6 files: same files, same assertions, same counts. All six scan the repo by path, which is the Windows-only class documented in `CLAUDE.md`. `blocks.router.workflow.test.ts` collected 347 tests, so the submodule is initialised and the run is real rather than silently empty.
- 23 new tests. The load-bearing ones are mutation-tested: routing a live placement through `settlePlacement`, dropping the placement sweep from the takedown, forfeiting a pending placement instead of refunding it, narrowing the sweep by placer, stamping the wrong removal reason, and widening the moderator read to every status each produce a fast, legible failure.
- **Six adversarial review rounds, briefed to refute rather than check.** Round 1: 6 findings, 5 real. Round 2, aimed at the fixes: 6 more, all real — two were regressions from round 1's fixes, one of which required undoing a round 1 fix entirely. Round 3: 4 more, including the pack-sweep incoherence above. Round 4: one structural (the false premise, now corrected in both places) and three small. Round 5, scoped to the one client file twice listed as uncovered: the per-card artwork lookup above, the oversized artwork request, and a second `invalidate` fan-out that the non-interactive card overlay had already closed. Round 6: no correctness defects, and an explicit "nothing blocks the merge" — an under-sized retina artwork request, a sorted-chunk thrash in the shared sticker util (the same hazard the placement chunks document and avoid, one file away), an unbounded client cache, and a per-surface-not-per-page claim. All four fixed. Every finding across all six rounds is fixed here or written down as an accepted cost.
- Flakes seen twice, in `eventloop-watchdog.capture.test.ts` and `eventloop-watchdog.worker.test.ts` — timing suites that fail under full-suite CPU load and pass on their own. Neither is in this diff.
- **Not covered anywhere: a browser.** The card overlay's geometry and the two interaction consequences above are reasoned from the CSS and the offset chain, never observed in a running page. That is the largest untested surface here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
