### PR TITLE
fix: three bugs found while scoping the Prisma to Kysely migration

### DIFF
--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -10,8 +10,20 @@
 /**
  * no-io-in-transaction
  *
- * Flags awaited external / non-database I/O inside a Prisma interactive
- * transaction callback — `db.$transaction(async (tx) => { ... })`.
+ * Flags awaited external / non-database I/O inside an interactive transaction
+ * callback, in either of this repo's two forms:
+ *   - Prisma — `db.$transaction(async (tx) => { ... })`
+ *   - Kysely — `db.transaction().execute(async (trx) => { ... })`
+ *
+ * 🔴 The Kysely form is matched deliberately, and matching only `$transaction`
+ * was a real hole rather than a hypothetical one. `src/server/db/kyselyDb.ts`
+ * already builds four Kysely clients over the existing pools, `apps/auth` and
+ * `apps/creator-studio` run entirely on Kysely, and any Prisma→Kysely porting
+ * moves transactional units across. A rule keyed to the literal string
+ * `$transaction` goes silently inert as that happens — and this rule's own
+ * fixtures are SOURCE STRINGS, so the suite would stay green while the detector
+ * stopped finding anything. A detector that reports nothing looks identical to a
+ * codebase with no violations. (Found while scoping the Kysely migration.)
  *
  * Interactive transactions hold a DB connection open under a wall-clock
  * timeout (Prisma default 5000ms, or an explicit `{ timeout }`). An awaited
@@ -116,13 +128,13 @@ const noIoInTransaction = {
     type: 'problem',
     docs: {
       description:
-        'Disallow awaited external/network I/O inside a Prisma interactive $transaction callback (blows the txn timeout budget).',
+        'Disallow awaited external/network I/O inside an interactive transaction callback — Prisma `$transaction(cb)` or Kysely `transaction().execute(cb)` (blows the txn timeout budget).',
       recommended: true,
     },
     schema: [],
     messages: {
       ioInTx:
-        "Awaited '{{name}}(...)' performs external I/O inside a $transaction callback — it consumes the transaction's timeout budget. Do this after the transaction commits, or make it fire-and-forget. If intentional, add: // eslint-disable-next-line local-rules/no-io-in-transaction -- <reason>",
+        "Awaited '{{name}}(...)' performs external I/O inside a transaction callback — it consumes the transaction's timeout budget. Do this after the transaction commits, or make it fire-and-forget. If intentional, add: // eslint-disable-next-line local-rules/no-io-in-transaction -- <reason>",
     },
   },
   create(context) {
@@ -132,17 +144,57 @@ const noIoInTransaction = {
     // Function nodes that are transaction callbacks -> their tx param name set.
     const txCallbackFns = new WeakMap();
 
-    function isTransactionCall(node) {
+    /** The call's first argument is an inline function — i.e. an interactive callback. */
+    function hasInlineCallback(node) {
+      const first = node.arguments && node.arguments[0];
+      return (
+        !!first && (first.type === 'ArrowFunctionExpression' || first.type === 'FunctionExpression')
+      );
+    }
+
+    /** `<method>(...)` where the method name matches. */
+    function isMethodCall(node, name) {
       return (
         node.type === 'CallExpression' &&
         node.callee.type === 'MemberExpression' &&
         node.callee.property &&
         node.callee.property.type === 'Identifier' &&
-        node.callee.property.name === '$transaction' &&
-        node.arguments.length > 0 &&
-        (node.arguments[0].type === 'ArrowFunctionExpression' ||
-          node.arguments[0].type === 'FunctionExpression')
+        node.callee.property.name === name
       );
+    }
+
+    /** Prisma: `db.$transaction(async (tx) => ...)`. The array/batch form has no callback. */
+    function isPrismaTransactionCall(node) {
+      return isMethodCall(node, '$transaction') && hasInlineCallback(node);
+    }
+
+    /**
+     * Kysely: `db.transaction().execute(async (trx) => ...)`, including builder
+     * chains such as `.transaction().setIsolationLevel('serializable').execute(cb)`.
+     *
+     * Anchored on `.execute(<inline function>)` and then walking the receiver
+     * chain back to a `.transaction()` call. Both halves are needed: every Kysely
+     * query builder ends in `.execute()`, but only the transaction builder's takes
+     * a callback, and only a `.transaction()` receiver makes it a transaction.
+     */
+    function isKyselyTransactionCall(node) {
+      if (!isMethodCall(node, 'execute') || !hasInlineCallback(node)) return false;
+      let cur = node.callee.object;
+      while (cur) {
+        if (cur.type === 'CallExpression') {
+          if (isMethodCall(cur, 'transaction')) return true;
+          cur = cur.callee;
+        } else if (cur.type === 'MemberExpression') {
+          cur = cur.object;
+        } else {
+          return false;
+        }
+      }
+      return false;
+    }
+
+    function isTransactionCall(node) {
+      return isPrismaTransactionCall(node) || isKyselyTransactionCall(node);
     }
 
     return {
@@ -423,7 +475,14 @@ function canonicalModulePath(specifier, fromFile) {
     const resolved = posixNormalize(`${posixDirname(posixFile)}/${specifier}`);
     // Absolute (how ESLint actually invokes the rule): must land under the
     // repo's OWN src/, not a workspace package's.
-    if (resolved.startsWith('/')) {
+    //
+    // A Windows absolute path is `C:/…` after the separator swap above, not
+    // `/…`, so testing only for a leading slash sent every absolute filename
+    // down the repo-relative branch, where it matches neither `src/` nor
+    // anything else and canonicalises to null. Effect: on Windows this rule
+    // silently stopped matching RELATIVE specifiers — inert locally, working in
+    // CI, with the test suite red only on the developer's machine.
+    if (isPosixAbsolute(resolved)) {
       return resolved.startsWith(`${REPO_SRC}/`)
         ? stripModuleExtension(resolved.slice(REPO_SRC.length + 1))
         : null;
@@ -444,6 +503,10 @@ const pathSep = require('path').sep;
 // The repo root is this file's own directory (ESLint loads `eslint-local-rules`
 // from it), so `<root>/src` is exactly what the `~` alias points at.
 const REPO_SRC = require('path').resolve(__dirname, 'src').split(pathSep).join('/');
+/** Absolute after the separator swap: posix `/x` or Windows `C:/x`. */
+function isPosixAbsolute(p) {
+  return p.startsWith('/') || /^[A-Za-z]:\//.test(p);
+}
 function posixDirname(p) {
   const i = p.lastIndexOf('/');
   return i === -1 ? '.' : p.slice(0, i) || '/';

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -15,15 +15,29 @@
  *   - Prisma — `db.$transaction(async (tx) => { ... })`
  *   - Kysely — `db.transaction().execute(async (trx) => { ... })`
  *
- * 🔴 The Kysely form is matched deliberately, and matching only `$transaction`
- * was a real hole rather than a hypothetical one. `src/server/db/kyselyDb.ts`
- * already builds four Kysely clients over the existing pools, `apps/auth` and
- * `apps/creator-studio` run entirely on Kysely, and any Prisma→Kysely porting
- * moves transactional units across. A rule keyed to the literal string
- * `$transaction` goes silently inert as that happens — and this rule's own
- * fixtures are SOURCE STRINGS, so the suite would stay green while the detector
- * stopped finding anything. A detector that reports nothing looks identical to a
- * codebase with no violations. (Found while scoping the Kysely migration.)
+ * 🔴 THE KYSELY MATCHER IS FORWARD-LOOKING AND CURRENTLY MATCHES NOTHING. Say so
+ * rather than claiming coverage this does not have. Measured: the only Kysely
+ * `.transaction().execute(cb)` sites in the monorepo are in `apps/auth` (1) and
+ * `apps/creator-studio` (2), and neither is lintable — `pnpm lint` is
+ * `eslint src/`, CI filters changed files to `^(src|packages)/`, and
+ * creator-studio has its own `root: true` config without this plugin. `src/` and
+ * `packages/` have ZERO. So the reason to have it is that `src/server/db/kyselyDb.ts`
+ * builds four Kysely clients today and porting will move transactional units
+ * across — not that it is catching anything now. Extending lint scope to `apps/`
+ * is the separate change that would make it bite.
+ *
+ * Keyed to the literal string `$transaction`, this rule would have gone silently
+ * inert as that porting happened, and its fixtures are SOURCE STRINGS, so the
+ * suite would stay green while the detector stopped finding anything.
+ *
+ * KNOWN GAPS (measured, not hypothetical — all currently zero occurrences):
+ *   - `const t = db.transaction(); await t.execute(cb)` — the builder must be
+ *     called inline; a variable breaks the receiver walk.
+ *   - `await getTx().execute(cb)` — same reason.
+ *   - `db.startTransaction()` — Kysely's CONTROLLED transaction has no callback,
+ *     so there is no lexical boundary and this strategy structurally cannot see
+ *     it. I/O between it and `commit()` burns the same budget, invisibly.
+ *   - a named (non-inline) callback, same as the Prisma gap noted below.
  *
  * Interactive transactions hold a DB connection open under a wall-clock
  * timeout (Prisma default 5000ms, or an explicit `{ timeout }`). An awaited
@@ -483,7 +497,7 @@ function canonicalModulePath(specifier, fromFile) {
     // silently stopped matching RELATIVE specifiers — inert locally, working in
     // CI, with the test suite red only on the developer's machine.
     if (isPosixAbsolute(resolved)) {
-      return resolved.startsWith(`${REPO_SRC}/`)
+      return isUnderRepoSrc(resolved)
         ? stripModuleExtension(resolved.slice(REPO_SRC.length + 1))
         : null;
     }
@@ -503,10 +517,27 @@ const pathSep = require('path').sep;
 // The repo root is this file's own directory (ESLint loads `eslint-local-rules`
 // from it), so `<root>/src` is exactly what the `~` alias points at.
 const REPO_SRC = require('path').resolve(__dirname, 'src').split(pathSep).join('/');
-/** Absolute after the separator swap: posix `/x` or Windows `C:/x`. */
+/** Absolute after the separator swap: posix `/x`, Windows `C:/x`, or UNC `//host/share`. */
 function isPosixAbsolute(p) {
   return p.startsWith('/') || /^[A-Za-z]:\//.test(p);
 }
+
+/**
+ * Windows filenames are case-insensitive but `startsWith` is not, and ESLint is
+ * not guaranteed to hand us the same casing `path.resolve` produced: the CLI
+ * normalises the drive to uppercase via `process.cwd()`, while an editor or LSP
+ * passing an explicit path may not. A `c:\…` filename then fails the REPO_SRC
+ * comparison and the rule goes silently inert — the same failure mode as the
+ * leading-slash bug, one layer down. Linux stays byte-exact, where casing is
+ * genuinely significant.
+ */
+const CASE_INSENSITIVE_PATHS = pathSep === '\\';
+function isUnderRepoSrc(p) {
+  const prefix = `${REPO_SRC}/`;
+  const head = p.slice(0, prefix.length);
+  return CASE_INSENSITIVE_PATHS ? head.toLowerCase() === prefix.toLowerCase() : head === prefix;
+}
+
 function posixDirname(p) {
   const i = p.lastIndexOf('/');
   return i === -1 ? '.' : p.slice(0, i) || '/';
@@ -518,7 +549,10 @@ function posixNormalize(p) {
     if (seg === '..') out.pop();
     else out.push(seg);
   }
-  return `${p.startsWith('/') ? '/' : ''}${out.join('/')}`;
+  // A UNC path's leading `//` is part of the root, not a redundant separator —
+  // collapsing it to `/` yields a path that can never match REPO_SRC.
+  const root = p.startsWith('//') ? '//' : p.startsWith('/') ? '/' : '';
+  return `${root}${out.join('/')}`;
 }
 
 /**

--- a/src/pages/api/metrics.ts
+++ b/src/pages/api/metrics.ts
@@ -69,8 +69,17 @@ const prismaMetricsFailures =
 
 // Seeded so a healthy pod reports an observable 0 rather than `no data` — an
 // absent series here is indistinguishable from a scrape that never checked.
-prismaMetricsFailures.inc({ type: 'read' }, 0);
-prismaMetricsFailures.inc({ type: 'write' }, 0);
+//
+// Guarded because this runs at MODULE SCOPE: the `as` cast above is unchecked,
+// so if this name is ever registered elsewhere with a different type or
+// labelset, `inc` throws while the route module is evaluating and 500s the
+// whole scrape — the exact failure the rest of this block exists to prevent.
+try {
+  prismaMetricsFailures.inc({ type: 'read' }, 0);
+  prismaMetricsFailures.inc({ type: 'write' }, 0);
+} catch {
+  // Seeding is a readability nicety; losing it must not cost the scrape.
+}
 
 async function collectPrismaMetrics(db: typeof dbRead | typeof dbWrite, type: 'read' | 'write') {
   try {

--- a/src/pages/api/metrics.ts
+++ b/src/pages/api/metrics.ts
@@ -50,6 +50,37 @@ if (!global.collectMetricsInitialized) {
 // Prometheus' scrape-time `pod` label (honorLabels: true in the ServiceMonitor); an
 // app-emitted `podname` here would be redundant and inconsistent with the siblings.
 
+// `$metrics` is a Prisma PREVIEW feature (previewFeatures = ["metrics"] in
+// schema.full.prisma), so it is one schema/engine change away from throwing —
+// under the queryCompiler engine, for instance, its implementation is a bare
+// `throw new Error("Method not implemented.")`. Awaiting it unguarded put the
+// ENTIRE scrape behind it: one Prisma failure and this endpoint 500s, taking
+// default metrics, the instrumentation registry, and every seeded counter above
+// with it. Degrade to losing just the Prisma series instead.
+const PRISMA_METRICS_FAILURES = 'prisma_metrics_scrape_failures_total';
+const prismaMetricsFailures =
+  (client.register.getSingleMetric(PRISMA_METRICS_FAILURES) as client.Counter<'type'>) ??
+  new client.Counter({
+    name: PRISMA_METRICS_FAILURES,
+    help: "Scrapes where PrismaClient.$metrics.prometheus() threw, so that client's series are absent from the response.",
+    labelNames: ['type'] as const,
+    registers: [client.register],
+  });
+
+// Seeded so a healthy pod reports an observable 0 rather than `no data` — an
+// absent series here is indistinguishable from a scrape that never checked.
+prismaMetricsFailures.inc({ type: 'read' }, 0);
+prismaMetricsFailures.inc({ type: 'write' }, 0);
+
+async function collectPrismaMetrics(db: typeof dbRead | typeof dbWrite, type: 'read' | 'write') {
+  try {
+    return await db.$metrics.prometheus({ globalLabels: { ...labels, type } });
+  } catch {
+    prismaMetricsFailures.inc({ type });
+    return '';
+  }
+}
+
 const handler = WebhookEndpoint(async (_, res: NextApiResponse) => {
   const metrics = await client.register.metrics();
 
@@ -59,19 +90,8 @@ const handler = WebhookEndpoint(async (_, res: NextApiResponse) => {
   // explicitly. See the WHY note on instrumentationRegistry in src/server/prom/client.ts.
   const instrumentationMetrics = await instrumentationRegistry.metrics();
 
-  const readMetrics = await dbRead.$metrics.prometheus({
-    globalLabels: {
-      ...labels,
-      type: 'read',
-    },
-  });
-
-  const writeMetrics = await dbWrite.$metrics.prometheus({
-    globalLabels: {
-      ...labels,
-      type: 'write',
-    },
-  });
+  const readMetrics = await collectPrismaMetrics(dbRead, 'read');
+  const writeMetrics = await collectPrismaMetrics(dbWrite, 'write');
 
   const result = [metrics, instrumentationMetrics, readMetrics, writeMetrics].join(EOL);
 

--- a/src/server/__tests__/metrics-endpoint-prisma-failure.test.ts
+++ b/src/server/__tests__/metrics-endpoint-prisma-failure.test.ts
@@ -1,0 +1,138 @@
+import type { NextApiResponse } from 'next';
+import client from 'prom-client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as PromClient from '~/server/prom/client';
+
+/**
+ * 🔴 THE SEAM: `$metrics` is a Prisma PREVIEW feature, so it is one schema or
+ * engine change away from throwing (under `queryCompiler` its implementation is
+ * a bare `throw new Error("Method not implemented.")`). Awaiting it unguarded
+ * put the ENTIRE scrape behind it — default metrics, the instrumentation
+ * registry, and every counter the page's side-effect imports exist to seed.
+ *
+ * A revert makes tests 1 and 2 reject with the thrown message, in ~1s. Nothing
+ * here loops or waits on a timer.
+ */
+
+// `endpoint-helpers` spreads `env.TRPC_ORIGINS` at module load; stub the wrapper
+// so none of that graph is needed. Same seam as
+// src/server/metrics/__tests__/metrics-endpoint-seeds-substitutions.test.ts.
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  WebhookEndpoint: (handler: unknown) => handler,
+}));
+
+// src/__tests__/setup.ts wholesale-mocks this module and omits
+// `instrumentationRegistry`, which the handler scrapes.
+vi.mock('~/server/prom/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof PromClient>()),
+}));
+
+const readPrometheus = vi.fn();
+const writePrometheus = vi.fn();
+vi.mock('~/server/db/client', () => ({
+  dbRead: { $metrics: { prometheus: (...args: unknown[]) => readPrometheus(...args) } },
+  dbWrite: { $metrics: { prometheus: (...args: unknown[]) => writePrometheus(...args) } },
+}));
+
+type Handler = (req: unknown, res: NextApiResponse) => Promise<void> | void;
+
+const FAILURES = 'prisma_metrics_scrape_failures_total';
+
+function fakeRes() {
+  const state = { body: '', headers: {} as Record<string, string> };
+  const res = {
+    setHeader: (key: string, value: string) => {
+      state.headers[key] = value;
+    },
+    send: (body: string) => {
+      state.body = body;
+    },
+  } as unknown as NextApiResponse;
+  return { res, state };
+}
+
+async function loadHandler() {
+  const mod = await import('~/pages/api/metrics');
+  return mod.default as unknown as Handler;
+}
+
+/** The counter is module-scoped and cumulative across this file, so assert deltas. */
+async function failureCounts(): Promise<Record<string, number>> {
+  const metric = client.register.getSingleMetric(FAILURES) as unknown as
+    | { get(): Promise<{ values: Array<{ labels: Record<string, string>; value: number }> }> }
+    | undefined;
+  if (!metric) return {};
+  const { values } = await metric.get();
+  return Object.fromEntries(values.map((v) => [v.labels.type, v.value]));
+}
+
+describe('/api/metrics survives a throwing PrismaClient.$metrics', () => {
+  beforeEach(() => {
+    readPrometheus.mockReset();
+    writePrometheus.mockReset();
+  });
+
+  it('🔴 still serves the non-Prisma series when dbRead.$metrics rejects', async () => {
+    readPrometheus.mockRejectedValue(new Error('Method not implemented.'));
+    writePrometheus.mockResolvedValue('civitai_write_prisma_series 1');
+
+    const handler = await loadHandler();
+    const { res, state } = fakeRes();
+    await handler({}, res);
+
+    expect(state.headers['Content-type']).toBe(client.register.contentType);
+    expect(state.body).toMatch(/process_cpu_user_seconds_total|nodejs_/);
+    expect(state.body).toContain('civitai_write_prisma_series 1');
+  });
+
+  it('🔴 survives a SYNCHRONOUS throw, not just a rejection', async () => {
+    readPrometheus.mockImplementation(() => {
+      throw new Error('Method not implemented.');
+    });
+    writePrometheus.mockResolvedValue('');
+
+    const handler = await loadHandler();
+    const { res, state } = fakeRes();
+    await handler({}, res);
+
+    expect(state.body).toMatch(/process_cpu_user_seconds_total|nodejs_/);
+  });
+
+  it('counts only the failing client', async () => {
+    readPrometheus.mockRejectedValue(new Error('Method not implemented.'));
+    writePrometheus.mockResolvedValue('');
+
+    const handler = await loadHandler();
+    const before = await failureCounts();
+    const { res } = fakeRes();
+    await handler({}, res);
+    const after = await failureCounts();
+
+    expect(after.read - before.read).toBe(1);
+    expect(after.write - before.write).toBe(0);
+  });
+
+  it('NEGATIVE CONTROL: two healthy clients increment nothing and both bodies land', async () => {
+    readPrometheus.mockResolvedValue('r 1');
+    writePrometheus.mockResolvedValue('w 1');
+
+    const handler = await loadHandler();
+    const before = await failureCounts();
+    const { res, state } = fakeRes();
+    await handler({}, res);
+    const after = await failureCounts();
+
+    expect(state.body).toContain('r 1');
+    expect(state.body).toContain('w 1');
+    expect(after.read - before.read).toBe(0);
+    expect(after.write - before.write).toBe(0);
+  });
+
+  it('seeds both label values at 0 on module load, so a healthy pod is not `no data`', async () => {
+    await loadHandler();
+    expect(await failureCounts()).toMatchObject({
+      read: expect.any(Number),
+      write: expect.any(Number),
+    });
+  });
+});

--- a/src/server/services/__tests__/no-io-in-transaction.test.ts
+++ b/src/server/services/__tests__/no-io-in-transaction.test.ts
@@ -56,8 +56,12 @@ ruleTester.run('no-io-in-transaction', rule, {
     // `execute`-named API taking a callback must NOT open a transaction context —
     // otherwise the matcher flags I/O in every such callback in the repo.
     `async function f(){ await queue.execute(async () => { await fetch('x'); }); }`,
-    // A plain query builder's `.execute()` takes no callback, so it is never matched.
-    `async function f(){ await db.selectFrom('User').execute(); await fetch('x'); }`,
+    // Both matchers require an INLINE callback. Drop that check and these reach
+    // `fn.params` with `fn === undefined` and crash the rule against whatever file
+    // is being linted — a failure with no violation attached to it. RuleTester
+    // reports a rule crash as a test failure, so these are what kill that mutation.
+    `async function f(){ await db.transaction().execute(); }`,
+    `async function f(){ await db.$transaction(); }`,
 
     // ---- REGRESSION GUARD (FALSE NEGATIVE, current behavior) ----
     // A non-inline (named) $transaction callback is NOT analyzed: the rule only

--- a/src/server/services/__tests__/no-io-in-transaction.test.ts
+++ b/src/server/services/__tests__/no-io-in-transaction.test.ts
@@ -19,9 +19,7 @@ const ruleTesterConfig: Record<string, unknown> = {
   parser: require.resolve('@typescript-eslint/parser'),
   parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
 };
-const ruleTester = new RuleTester(
-  ruleTesterConfig as ConstructorParameters<typeof RuleTester>[0]
-);
+const ruleTester = new RuleTester(ruleTesterConfig as ConstructorParameters<typeof RuleTester>[0]);
 
 ruleTester.run('no-io-in-transaction', rule, {
   valid: [
@@ -45,6 +43,21 @@ ruleTester.run('no-io-in-transaction', rule, {
     // Non-awaited (fire-and-forget) I/O is out of scope: the rule only governs
     // awaited calls that consume the txn's wall-clock budget.
     `async function f(){ await db.$transaction(async (tx) => { fetch('x'); await tx.user.update({}); }); }`,
+
+    // ---- Kysely: db.transaction().execute(cb) ----
+    // Only trx.* query-builder calls inside the callback.
+    `async function f(){ await db.transaction().execute(async (trx) => { await trx.updateTable('User').set({}).execute(); }); }`,
+    // I/O performed AFTER the transaction resolves.
+    `async function f(){ const r = await db.transaction().execute(async (trx) => trx.selectFrom('User').execute()); await fetch('x'); }`,
+    // A denylisted NAME that is actually a method on the trx client must be allowed.
+    `async function f(){ await db.transaction().execute(async (trx) => { await trx.thing.refresh(); }); }`,
+    // NEGATIVE CONTROL for the Kysely matcher: `.execute(cb)` is only a transaction
+    // when its receiver chain contains `.transaction()`. Without that, an unrelated
+    // `execute`-named API taking a callback must NOT open a transaction context —
+    // otherwise the matcher flags I/O in every such callback in the repo.
+    `async function f(){ await queue.execute(async () => { await fetch('x'); }); }`,
+    // A plain query builder's `.execute()` takes no callback, so it is never matched.
+    `async function f(){ await db.selectFrom('User').execute(); await fetch('x'); }`,
 
     // ---- REGRESSION GUARD (FALSE NEGATIVE, current behavior) ----
     // A non-inline (named) $transaction callback is NOT analyzed: the rule only
@@ -98,6 +111,37 @@ ruleTester.run('no-io-in-transaction', rule, {
     {
       code: `async function f(){ await db.$transaction(async (tx) => { await imagesSearchIndex.queueUpdate([]); }); }`,
       errors: [{ messageId: 'ioInTx', data: { name: 'queueUpdate' } }],
+    },
+
+    // ---- Kysely: db.transaction().execute(cb) ----
+    // Bare fetch inside a Kysely interactive transaction.
+    {
+      code: `async function f(){ await db.transaction().execute(async (trx) => { await fetch('x'); }); }`,
+      errors: [{ messageId: 'ioInTx', data: { name: 'fetch' } }],
+    },
+    // Builder chain between .transaction() and .execute() must not defeat detection.
+    {
+      code: `async function f(){ await db.transaction().setIsolationLevel('serializable').execute(async (trx) => { await logToAxiom({}); }); }`,
+      errors: [{ messageId: 'ioInTx', data: { name: 'logToAxiom' } }],
+    },
+    // trx.* work is allowed; the search-index queue call beside it is not.
+    {
+      code: `async function f(){ await db.transaction().execute(async (trx) => { await trx.updateTable('Image').set({}).execute(); await imagesSearchIndex.queueUpdate([]); }); }`,
+      errors: [{ messageId: 'ioInTx', data: { name: 'queueUpdate' } }],
+    },
+    // Nested Kysely transactions: inner-callback I/O is still inside a transaction.
+    {
+      code: `async function f(){ await kyselyWrite.transaction().execute(async (trx) => { await kyselyWrite.transaction().execute(async (trx2) => { await fetch('x'); }); }); }`,
+      errors: [{ messageId: 'ioInTx', data: { name: 'fetch' } }],
+    },
+    // Mixed nesting, with the I/O in the OUTER (Kysely) callback so that only the
+    // Kysely matcher can flag it. Putting the I/O inside the inner Prisma callback
+    // instead would be VACUOUS — `$transaction` alone already establishes a context
+    // there, so that fixture passes even with Kysely support removed (verified by
+    // mutation; it is why this one is shaped this way).
+    {
+      code: `async function f(){ await kyselyWrite.transaction().execute(async (trx) => { await db.$transaction(async (tx) => { await tx.user.update({}); }); await fetch('x'); }); }`,
+      errors: [{ messageId: 'ioInTx', data: { name: 'fetch' } }],
     },
 
     // ---- REGRESSION GUARD (FALSE POSITIVE, current behavior) ----


### PR DESCRIPTION
Three unrelated bugs surfaced while scoping the Prisma to Kysely migration. No migration work here — just the fixes. Two rounds of adversarial subagent review have been applied; what they found is folded in below rather than summarised away.

## 1. `/api/metrics` could 500 entirely on one Prisma failure

`$metrics` is a Prisma **preview** feature, so it is one schema or engine change away from throwing — under the `queryCompiler` engine its implementation is literally `throw new Error("Method not implemented.")`. Both `$metrics.prometheus()` calls were awaited unguarded, which put the whole scrape behind them: default metrics, the instrumentation registry, and every counter the side-effect imports at the top of that file exist to seed.

Now degrades to losing only the Prisma series, with a `prisma_metrics_scrape_failures_total{type}` counter.

The seeding is itself guarded. It runs at module scope during route evaluation, and the `as Counter<'type'>` cast is unchecked — so if that name were ever registered elsewhere with a different labelset, `inc` would throw *there* and 500 the scrape, reintroducing the exact bug. tsc would not say a word.

## 2. `no-io-in-transaction` did not see Kysely — but this does not close a live hole

The rule matched the literal string `$transaction`; Kysely's form is `db.transaction().execute(cb)`. It now matches both, including builder chains like `.setIsolationLevel(...)`.

**Stated accurately, because the first version of this PR did not:** the matcher currently matches **nothing that gets linted**. The only Kysely `.transaction().execute(cb)` sites in the monorepo are in `apps/auth` (1) and `apps/creator-studio` (2). None is reachable — `pnpm lint` is `eslint src/`, CI filters changed files to `^(src|packages)/`, and creator-studio has its own `root: true` config without this plugin. `src/` and `packages/` contain zero.

So this is **forward-looking**: `src/server/db/kyselyDb.ts` builds four Kysely clients today, and porting will move transactional units across. Extending lint scope to `apps/` is a separate change that would make it bite. The rule header now says this outright — overstating a detector's reach is the same failure the rule exists to catch, one level up.

Four gaps are documented, all currently zero occurrences. The notable one is Kysely's **controlled** `db.startTransaction()`: no callback, therefore no lexical boundary, so this rule's whole strategy structurally cannot reach it.

## 3. `test:lint-rules` was red on `main` — on Windows only

`canonicalModulePath` treated only a leading `/` as absolute. After the separator swap a Windows path is `C:/…`, so every absolute filename fell to the repo-relative branch and canonicalised to `null` — `no-wholesale-module-mock` silently stopped matching **relative** specifiers on Windows.

Review found two more of the same class, both also silently inert:
- **Lowercase drive letters.** `REPO_SRC` was compared byte-exact; Windows paths are not case-sensitive. Reproduced through the real CLI — `eslint "C:\…"` reports, `eslint "c:\…"` does not. The CLI normalises the drive via `process.cwd()`, but an editor or LSP passing an explicit path may not. Now case-insensitive on Windows only; Linux stays byte-exact, where casing is significant.
- **UNC paths.** `posixNormalize` collapsed a `//host/share` root to `/`, so it could never match `REPO_SRC`. Fixed, but see the caveat below.

## Verification

- `pnpm typecheck` — 0 errors (182s)
- `pnpm test:lint-rules` — **215/215** (was 213/214 on `main` on Windows)
- new `src/server/__tests__/metrics-endpoint-prisma-failure.test.ts` — 5/5, and the pre-existing metrics-endpoint suite still passes alongside it
- `eslint` / `prettier --check` on changed files — clean

**Mutation results**, since a green suite says nothing about how it fails:

| mutation | outcome |
|---|---|
| drop the Kysely matcher | 5 fixtures fail — `Should have 1 error but had 0` |
| drop the `hasInlineCallback` guard (either matcher) | 1 fixture each — **added this round; previously nothing killed it** |
| drop the `.transaction()` receiver walk | the `queue.execute(cb)` negative control fails |
| inspect only one chain level | the `setIsolationLevel` fixture fails |
| remove the metrics `try`/`catch` | 3 tests fail in ~1s with `Method not implemented.` |
| revert the Windows path fix | 1 fixture fails — **on Windows only** |

## What reviewers should know before approving

- **CI cannot protect fix 3.** On Linux the leading-slash and `isPosixAbsolute` predicates are identical, so the covering fixture passes with or without the fix, and every `runs-on:` is `ubuntu-latest`. The protection is "a Windows dev runs the suite," not CI. Stated rather than left to be discovered.
- **The UNC fix is untested.** It is unambiguously correct (collapsing a UNC root to `/` is wrong regardless), but it only changes behaviour if the repo itself lives on a UNC path, which is not testable from here.
- **Two false-positive shapes are reachable in principle** — any non-Kysely API shaped `.transaction()` + `.execute(cb)`. Zero exist in the tree; the decisive check was run, and the new rule's violation set over `src/`+`packages/` is byte-identical to the old rule's.
- **Out of scope, noticed in passing:** `client.register.metrics()` and `instrumentationRegistry.metrics()` in the same handler are still unguarded, so a throwing `collect()` can still take the scrape down. And `src/__tests__/setup.ts` wholesale-mocks `~/server/prom/client` omitting `instrumentationRegistry` — an instance of the very hazard `no-wholesale-module-mock` exists to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
