### PR TITLE
fix(app-blocks): derive block-upload image geometry from the stored bytes

### DIFF
--- a/src/server/schema/blocks/block-image-upload.schema.ts
+++ b/src/server/schema/blocks/block-image-upload.schema.ts
@@ -18,15 +18,23 @@ import * as z from 'zod';
  *     moderated id + rating + url.
  */
 
-// Mirrors persistListingAssetImageSchema — the CF upload key + intrinsic dims the
-// scanner + validators need. The block uploads via the SAME `useCFImageUpload`
-// path as the listing asset step, so the shape is identical.
+/**
+ * 🔴 `width` / `height` / `mimeType` / `sizeBytes` are NOT persisted. The server
+ * reads the uploaded object back and measures all four, because a row created here
+ * is attachable as app-listing media — `loadValidatedImage` gates on ownership, not
+ * on provenance — and the listing geometry/size/MIME bounds are expressed over
+ * exactly those columns, which nothing else re-derives (issue #3770). The guarantee
+ * is "measured from real bytes at persist time", NOT "still true of the object":
+ * the presigned PUT stays usable for its full expiry, so the key can be overwritten
+ * afterwards. They stay in the contract as optional so clients that still send them
+ * keep working.
+ */
 export const persistBlockUploadImageSchema = z.object({
   // The CF upload key returned by `useCFImageUpload` — imageSchema requires a uuid.
   url: z.string().uuid(),
   name: z.string().max(255).nullish(),
-  width: z.number().int().positive(),
-  height: z.number().int().positive(),
+  width: z.number().int().positive().optional(),
+  height: z.number().int().positive().optional(),
   mimeType: z.string().max(120).optional(),
   sizeBytes: z.number().int().nonnegative().optional(),
 });

--- a/src/server/services/blocks/__tests__/block-image-upload.persist.test.ts
+++ b/src/server/services/blocks/__tests__/block-image-upload.persist.test.ts
@@ -1,0 +1,263 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import sharp from 'sharp';
+
+import { validateListingImage } from '~/server/schema/blocks/app-listing.schema';
+import { persistBlockUploadImageSchema } from '~/server/schema/blocks/block-image-upload.schema';
+import type * as S3Utils from '~/utils/s3-utils';
+
+/**
+ * `blockImageUpload.persist` — DECLARED-vs-ACTUAL geometry (issue #3770).
+ *
+ * A row this proc creates is attachable as app-listing media: `loadValidatedImage`
+ * gates attach on ownership, not on how the row was made, and the per-kind rules it
+ * then applies (`validateListingImage`) read `Image.width` / `height` / `mimeType` /
+ * `metadata.size`. Ingestion writes scan state only — it never re-derives geometry —
+ * so persisting the uploader's declared values made every one of those rules
+ * self-reported. These pin that the columns describe the stored bytes instead.
+ *
+ * Only the store accessor is replaced; the probe and its sharp decode run for real
+ * against real image bytes.
+ */
+
+const { mockCreateImage } = vi.hoisted(() => ({
+  mockCreateImage: vi.fn(async (..._a: unknown[]) => ({ id: 777 })),
+}));
+const { mockS3Send } = vi.hoisted(() => ({ mockS3Send: vi.fn() }));
+
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (u: string) => `edge:${u}` }));
+vi.mock('~/server/services/image.service', () => ({ createImage: mockCreateImage }));
+vi.mock('~/utils/s3-utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof S3Utils>()),
+  getImageUploadBackend: async () => ({
+    s3: { send: mockS3Send },
+    bucket: 'test-image-bucket',
+    backend: 'backblaze' as const,
+  }),
+}));
+
+const fixtureCache = new Map<string, Buffer>();
+async function cachedFixture(key: string, make: () => Promise<Buffer>) {
+  const hit = fixtureCache.get(key);
+  if (hit) return hit;
+  const made = await make();
+  fixtureCache.set(key, made);
+  return made;
+}
+
+function flatPng(width: number, height: number) {
+  return cachedFixture(`png:${width}x${height}`, () =>
+    sharp({ create: { width, height, channels: 3, background: { r: 8, g: 8, b: 8 } } })
+      .png()
+      .toBuffer()
+  );
+}
+function flatGif(width: number, height: number) {
+  return cachedFixture(`gif:${width}x${height}`, () =>
+    sharp({ create: { width, height, channels: 3, background: { r: 8, g: 8, b: 8 } } })
+      .gif()
+      .toBuffer()
+  );
+}
+
+/** Answer the probe's ranged GET. `totalSize` is what the store reports as the
+ *  object's real length, which is how an oversize object is detected without
+ *  downloading it — so that case needs no large fixture. */
+function storeObject(bytes: Buffer, opts: { totalSize?: number } = {}) {
+  const totalSize = opts.totalSize ?? bytes.byteLength;
+  mockS3Send.mockResolvedValue({
+    Body: { transformToByteArray: async () => new Uint8Array(bytes) },
+    ContentRange: `bytes 0-${bytes.byteLength - 1}/${totalSize}`,
+  });
+}
+
+async function persist(input: Record<string, unknown>, userId = CALLER) {
+  const { persistBlockUploadImage } = await import('../block-image-upload.service');
+  return persistBlockUploadImage({ input: input as never, userId });
+}
+
+function persistedRow() {
+  const arg = mockCreateImage.mock.calls[0][0] as {
+    type: string;
+    width?: number;
+    height?: number;
+    mimeType?: string;
+    metadata?: { size?: number };
+  };
+  return {
+    type: arg.type,
+    width: arg.width,
+    height: arg.height,
+    mimeType: arg.mimeType,
+    sizeBytes: arg.metadata?.size ?? null,
+  };
+}
+
+const CALLER = 42;
+const KEY = '33333333-3333-4333-8333-333333333333';
+
+/** Declares a shape that clears every cover bound: aspect 1.78, 800px wide. */
+const DECLARED_COVER = {
+  url: KEY,
+  name: 'cover.png',
+  width: 800,
+  height: 450,
+  mimeType: 'image/png',
+};
+
+/** The block-image byte cap this path probes with (40 MiB). */
+const BLOCK_IMAGE_MAX_BYTES_EXPECTED = 40 * 1024 * 1024;
+
+beforeEach(() => {
+  mockCreateImage.mockReset().mockResolvedValue({ id: 777 });
+  mockS3Send.mockReset();
+});
+
+describe('persistBlockUploadImage (measures the uploaded bytes)', () => {
+  it('persists the ACTUAL dimensions, so the listing cover gate rejects a mismatched upload', async () => {
+    // Premise: the DECLARED pair really does clear the gate the bytes cannot.
+    expect(
+      validateListingImage(
+        { type: 'image', width: 800, height: 450, mimeType: 'image/png', sizeBytes: 4096 },
+        'cover'
+      )
+    ).toEqual({ ok: true });
+
+    // 200×200 bytes behind that declaration: square, and 440px short of the 640px
+    // cover floor.
+    storeObject(await flatPng(200, 200));
+
+    await persist(DECLARED_COVER);
+
+    expect(persistedRow()).toMatchObject({ width: 200, height: 200 });
+    expect(validateListingImage(persistedRow(), 'cover')).toMatchObject({ ok: false });
+  });
+
+  it('NEGATIVE CONTROL: an honest upload still persists and still passes the gate', async () => {
+    storeObject(await flatPng(800, 450));
+
+    const res = await persist(DECLARED_COVER);
+
+    expect(res).toEqual({ imageId: 777 });
+    expect(persistedRow()).toMatchObject({ width: 800, height: 450, mimeType: 'image/png' });
+    expect(validateListingImage(persistedRow(), 'cover')).toEqual({ ok: true });
+  });
+
+  it('persists the ACTUAL byte size, not the declared one', async () => {
+    const bytes = await flatPng(800, 450);
+    storeObject(bytes);
+
+    await persist({ ...DECLARED_COVER, sizeBytes: 1 });
+
+    expect(persistedRow().sizeBytes).toBe(bytes.byteLength);
+  });
+
+  it('derives the MIME from the bytes, not the declared content type', async () => {
+    storeObject(await flatPng(800, 450));
+
+    await persist({ ...DECLARED_COVER, mimeType: 'image/webp' });
+
+    expect(persistedRow().mimeType).toBe('image/png');
+  });
+
+  it('measures an upload that declares nothing at all', async () => {
+    storeObject(await flatPng(800, 450));
+
+    await persist({ url: KEY });
+
+    expect(persistedRow()).toMatchObject({ width: 800, height: 450, mimeType: 'image/png' });
+  });
+
+  it('reports a quarter-turned JPEG the way a renderer shows it', async () => {
+    storeObject(
+      await sharp({
+        create: { width: 450, height: 800, channels: 3, background: { r: 8, g: 8, b: 8 } },
+      })
+        .withMetadata({ orientation: 6 })
+        .jpeg()
+        .toBuffer()
+    );
+
+    await persist(DECLARED_COVER);
+
+    expect(persistedRow()).toMatchObject({ width: 800, height: 450, mimeType: 'image/jpeg' });
+  });
+
+  it('rejects a format outside the allowlist however it is declared', async () => {
+    storeObject(await flatGif(800, 450));
+
+    await expect(persist(DECLARED_COVER)).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('"gif"'),
+    });
+    expect(mockCreateImage).not.toHaveBeenCalled();
+  });
+
+  it('rejects an upload whose bytes are not there', async () => {
+    mockS3Send.mockRejectedValue(
+      Object.assign(new Error('NoSuchKey'), {
+        name: 'NoSuchKey',
+        $metadata: { httpStatusCode: 404 },
+      })
+    );
+
+    await expect(persist(DECLARED_COVER)).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(mockCreateImage).not.toHaveBeenCalled();
+  });
+
+  it('rejects bytes that are not a decodable image', async () => {
+    storeObject(Buffer.from('<!doctype html><html>not an image</html>'));
+
+    await expect(persist(DECLARED_COVER)).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(mockCreateImage).not.toHaveBeenCalled();
+  });
+
+  it('rejects an object above the block-image byte cap without downloading it', async () => {
+    storeObject(await flatPng(800, 450), { totalSize: BLOCK_IMAGE_MAX_BYTES_EXPECTED + 1 });
+
+    await expect(persist(DECLARED_COVER)).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('40 MiB'),
+    });
+    const command = mockS3Send.mock.calls[0][0] as { input: { Range?: string } };
+    expect(command.input.Range).toBe(`bytes=0-${BLOCK_IMAGE_MAX_BYTES_EXPECTED}`);
+    expect(mockCreateImage).not.toHaveBeenCalled();
+  });
+
+  it('a store outage is an INTERNAL error, not the uploader being blamed', async () => {
+    mockS3Send.mockRejectedValue(
+      Object.assign(new Error('boom'), { $metadata: { httpStatusCode: 503 } })
+    );
+
+    await expect(persist(DECLARED_COVER)).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+    });
+    expect(mockCreateImage).not.toHaveBeenCalled();
+  });
+
+  it('still creates the row OWNED BY THE CALLER and WITHOUT skipIngestion', async () => {
+    storeObject(await flatPng(800, 450));
+
+    await persist(DECLARED_COVER, 99);
+
+    const arg = mockCreateImage.mock.calls[0][0] as Record<string, unknown>;
+    expect(arg.userId).toBe(99);
+    expect(arg.skipIngestion).toBeFalsy();
+    expect('skipIngestion' in arg && arg.skipIngestion === true).toBe(false);
+    expect(arg).toMatchObject({ url: KEY, type: 'image', name: 'cover.png' });
+  });
+});
+
+describe('persistBlockUploadImageSchema', () => {
+  it('accepts an upload that omits the measured fields', () => {
+    expect(persistBlockUploadImageSchema.parse({ url: KEY })).toEqual({ url: KEY });
+  });
+
+  it('still accepts a client that sends them', () => {
+    expect(persistBlockUploadImageSchema.parse(DECLARED_COVER)).toMatchObject({
+      url: KEY,
+      width: 800,
+      height: 450,
+    });
+  });
+});

--- a/src/server/services/blocks/block-image-upload.service.ts
+++ b/src/server/services/blocks/block-image-upload.service.ts
@@ -9,6 +9,7 @@ import {
 } from '~/server/services/blocks/block-image-upload.logic';
 import type { OffsiteRatingValue } from '~/shared/constants/browsingLevel.constants';
 import type { PersistBlockUploadImageInput } from '~/server/schema/blocks/block-image-upload.schema';
+import { measureUploadedImage } from '~/server/services/blocks/measure-uploaded-image';
 import type { SessionUser } from '~/types/session';
 import { uploadImageBufferToStore } from '~/utils/s3-utils';
 
@@ -25,6 +26,13 @@ import { uploadImageBufferToStore } from '~/utils/s3-utils';
  */
 
 /**
+ * Hard cap on the bytes of any image this module materialises — a fetched workflow
+ * output, or a user upload read back out of the store to be measured. Bounds an
+ * unexpected huge blob.
+ */
+const BLOCK_IMAGE_MAX_BYTES = 40 * 1024 * 1024;
+
+/**
  * Materialise a CF-uploaded image into an `Image` row owned by the caller and
  * kick off the STANDARD scan pipeline — `createImage` with DEFAULT ingestion, i.e.
  * NO `skipIngestion` and NEVER `createStoredImage` (which would trust-stamp the
@@ -32,22 +40,32 @@ import { uploadImageBufferToStore } from '~/utils/s3-utils';
  * NSFW scan; the gate below refuses to return an id until it has. `createImage` is
  * dynamically imported so the heavy `image.service` module stays out of this
  * service's static graph (mirrors `persistListingAssetImage`).
+ *
+ * Dimensions / MIME / byte size are DERIVED FROM THE STORED BYTES; the same fields
+ * on the input are ignored. A row created here is attachable as app-listing media
+ * (`loadValidatedImage` gates on ownership, not on provenance) and the listing
+ * geometry rules read exactly those columns, so persisting the declared values
+ * would leave every one of those rules self-reported — issue #3770.
  */
 export async function persistBlockUploadImage(opts: {
   input: PersistBlockUploadImageInput;
   userId: number;
 }): Promise<{ imageId: number }> {
   const { input, userId } = opts;
+  const measured = await measureUploadedImage(input.url, {
+    maxBytes: BLOCK_IMAGE_MAX_BYTES,
+    subject: 'block images',
+  });
   const { createImage } = await import('~/server/services/image.service');
   const image = await createImage({
     url: input.url,
     name: input.name ?? undefined,
     type: 'image',
-    width: input.width,
-    height: input.height,
-    mimeType: input.mimeType,
+    width: measured.width,
+    height: measured.height,
+    mimeType: measured.mimeType,
     // Byte size is read from `Image.metadata.size` by the image validators.
-    metadata: input.sizeBytes != null ? { size: input.sizeBytes } : undefined,
+    metadata: { size: measured.sizeBytes },
     userId,
   });
   return { imageId: image.id };
@@ -63,9 +81,6 @@ export async function persistBlockUploadImage(opts: {
  * precedent in `app-listing-assets.service.ts`.
  */
 export const BLOCK_PUBLISHED_APP_ID_META_KEY = 'blockPublishedAppId' as const;
-
-/** Hard cap on a published output's bytes — bounds an unexpected huge blob. */
-const BLOCK_PUBLISH_MAX_BYTES = 40 * 1024 * 1024;
 
 /**
  * Max redirect hops we follow when fetching a workflow output blob. The real
@@ -112,7 +127,7 @@ function sniffSupportedImage(b: Buffer): string | null {
  * {@link MAX_OUTPUT_REDIRECTS} hops with the host re-validated against
  * {@link isAllowedOutputHost} BEFORE each hop's socket opens (a real output blob
  * 301s to a same-host content url, so we must follow it, but a redirect can never
- * reach an off-allowlist host), byte-capped ({@link BLOCK_PUBLISH_MAX_BYTES}), and
+ * reach an off-allowlist host), byte-capped ({@link BLOCK_IMAGE_MAX_BYTES}), and
  * magic-byte-validated ({@link sniffSupportedImage} — a spoofed content-type can't
  * smuggle a non-image).
  *
@@ -211,11 +226,11 @@ export async function persistBlockWorkflowOutputImage(opts: {
   }
   // Reject early on a declared oversize, then hard-cap the buffered bytes.
   const declaredLen = Number(response.headers.get('content-length') ?? '');
-  if (Number.isFinite(declaredLen) && declaredLen > BLOCK_PUBLISH_MAX_BYTES) {
+  if (Number.isFinite(declaredLen) && declaredLen > BLOCK_IMAGE_MAX_BYTES) {
     throw new TRPCError({ code: 'BAD_REQUEST', message: 'generation output is too large' });
   }
   const bytes = Buffer.from(await response.arrayBuffer());
-  if (bytes.byteLength === 0 || bytes.byteLength > BLOCK_PUBLISH_MAX_BYTES) {
+  if (bytes.byteLength === 0 || bytes.byteLength > BLOCK_IMAGE_MAX_BYTES) {
     throw new TRPCError({ code: 'BAD_REQUEST', message: 'generation output is too large' });
   }
   // Validate by MAGIC BYTES (not the spoofable content-type header / url ext).
@@ -236,8 +251,10 @@ export async function persistBlockWorkflowOutputImage(opts: {
     url: key,
     type: 'image',
     mimeType: contentType,
-    // Dimensions come from the orchestrator projection (may be null when the
-    // orchestrator hasn't populated them); ingestion re-measures either way.
+    // Server-side values from the orchestrator's own workflow projection, never a
+    // caller claim — they may be null when the orchestrator hasn't populated them.
+    // Nothing downstream re-derives them: ingestion writes scan state only, so an
+    // absent pair stays absent (issue #3770).
     width: width ?? undefined,
     height: height ?? undefined,
     metadata: { size: bytes.byteLength, [BLOCK_PUBLISHED_APP_ID_META_KEY]: appId },

--- a/src/server/services/blocks/measure-uploaded-image.ts
+++ b/src/server/services/blocks/measure-uploaded-image.ts
@@ -1,0 +1,73 @@
+import { TRPCError } from '@trpc/server';
+
+import {
+  LISTING_ASSET_ALLOWED_MIME,
+  LISTING_ASSET_FORMAT_TO_MIME,
+} from '~/server/schema/blocks/app-listing.schema';
+
+export type MeasuredUploadedImage = {
+  width: number;
+  height: number;
+  mimeType: (typeof LISTING_ASSET_ALLOWED_MIME)[number];
+  sizeBytes: number;
+};
+
+/**
+ * Measure the bytes already uploaded at `key` and return the values to persist on
+ * the `Image` row, so `width` / `height` / `mimeType` / `metadata.size` describe
+ * the object rather than what the uploader said about it.
+ *
+ * Every rule the listing attach procs apply (`validateListingImage`) is expressed
+ * over exactly those four columns, and the attach gate is ownership-based — it
+ * cannot tell how a row was created. So any path that lets a caller write them
+ * makes all of those bounds self-reported, which is why the upload paths share
+ * this instead of persisting the declared values.
+ *
+ * The guarantee is narrower than "the columns match the object": the presigned PUT
+ * stays usable for its full expiry, so the same key can be overwritten after this
+ * read. It says the values were true of real bytes AT PROBE TIME.
+ *
+ * `maxBytes` bounds the read back out of the store AND rejects an object above it
+ * (`subject` names the caller's media in that message). A decoded format outside
+ * {@link LISTING_ASSET_FORMAT_TO_MIME} is rejected here rather than deferred,
+ * because no consumer of a measured row accepts one.
+ */
+export async function measureUploadedImage(
+  key: string,
+  { maxBytes, subject }: { maxBytes: number; subject: string }
+): Promise<MeasuredUploadedImage> {
+  const { probeStoredImage, StoredImageProbeError } = await import(
+    '~/server/utils/stored-image-probe'
+  );
+
+  let probe;
+  try {
+    probe = await probeStoredImage(key, { maxBytes });
+  } catch (err) {
+    if (!(err instanceof StoredImageProbeError)) throw err;
+    if (err.reason === 'store-unavailable') {
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: "We couldn't read that upload back to check it. Try again.",
+      });
+    }
+    const message =
+      err.reason === 'missing'
+        ? "We couldn't find that upload — upload the image again."
+        : err.reason === 'too-large'
+        ? `that image is over the ${maxBytes / 1024 / 1024} MiB limit for ${subject}`
+        : "That image couldn't be read. Try a different PNG, JPEG or WebP.";
+    throw new TRPCError({ code: 'BAD_REQUEST', message });
+  }
+
+  const mimeType = LISTING_ASSET_FORMAT_TO_MIME[probe.format];
+  if (!mimeType) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `unsupported image type "${
+        probe.format
+      }" (allowed: ${LISTING_ASSET_ALLOWED_MIME.join(', ')})`,
+    });
+  }
+  return { width: probe.width, height: probe.height, mimeType, sizeBytes: probe.sizeBytes };
+}

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -5,11 +5,7 @@ import { TRPCError } from '@trpc/server';
 import { Prisma } from '@prisma/client';
 
 import { dbRead, dbWrite } from '~/server/db/client';
-import {
-  LISTING_ASSET_ALLOWED_MIME,
-  LISTING_ASSET_FORMAT_TO_MIME,
-  MAX_LISTING_ASSET_SIZE_BYTES,
-} from '~/server/schema/blocks/app-listing.schema';
+import { MAX_LISTING_ASSET_SIZE_BYTES } from '~/server/schema/blocks/app-listing.schema';
 import {
   assertNoOnPlatformSurface,
   validateExternalUrl,
@@ -35,6 +31,7 @@ import {
 } from '~/server/services/blocks/app-listing-assets.service';
 import { assertOffsiteListingActionable } from '~/server/services/blocks/app-listing-actionable.service';
 import { computeListingProblems } from '~/server/services/blocks/listing-problems';
+import { measureUploadedImage } from '~/server/services/blocks/measure-uploaded-image';
 import { notifyAppListingOwner } from '~/server/services/blocks/app-listing-notify';
 import {
   deriveContentRatingFromAssets,
@@ -2644,57 +2641,15 @@ export async function rejectExternalRequest(opts: {
 // ---------------------------------------------------------------------------
 
 /**
- * Measure the bytes at `key` and return the values to persist.
- *
- * The per-kind geometry/size/MIME rules the attach procs enforce
- * (`validateListingImage`) read `Image.width` / `height` / `mimeType` /
- * `metadata.size`. Those come from here, so they are measured rather than taken
- * from the uploader — otherwise every one of those bounds is self-reported.
- *
- * What this buys is narrower than "the columns match the object": the presigned
- * PUT stays usable for its full expiry, so the same key can be overwritten after
- * this read. It guarantees the values were TRUE OF REAL BYTES AT PROBE TIME, not
- * that they still describe whatever the key holds later.
- *
- * The two rejections below cannot be deferred to the attach proc's per-kind
- * checks, because the kind is not known until attach: bytes over the loosest cap
- * (no kind accepts them) and a format outside the allowlist.
+ * The byte cap is the LOOSEST per-kind cap: bytes above it satisfy no kind, and the
+ * kind is not known until attach, so it is the only size rejection that can happen
+ * this early.
  */
-async function measureListingAssetUpload(key: string) {
-  const { probeStoredImage, StoredImageProbeError } =
-    await import('~/server/utils/stored-image-probe');
-
-  let probe;
-  try {
-    probe = await probeStoredImage(key, { maxBytes: MAX_LISTING_ASSET_SIZE_BYTES });
-  } catch (err) {
-    if (!(err instanceof StoredImageProbeError)) throw err;
-    if (err.reason === 'store-unavailable') {
-      throw new TRPCError({
-        code: 'INTERNAL_SERVER_ERROR',
-        message: "We couldn't read that upload back to check it. Try again.",
-      });
-    }
-    const message =
-      err.reason === 'missing'
-        ? "We couldn't find that upload — upload the image again."
-        : err.reason === 'too-large'
-          ? `that image is over the ${MAX_LISTING_ASSET_SIZE_BYTES / 1024 / 1024} MiB limit for listing media`
-          : "That image couldn't be read. Try a different PNG, JPEG or WebP.";
-    throw new TRPCError({ code: 'BAD_REQUEST', message });
-  }
-
-  const mimeType = LISTING_ASSET_FORMAT_TO_MIME[probe.format];
-  if (!mimeType) {
-    throw new TRPCError({
-      code: 'BAD_REQUEST',
-      message: `unsupported image type "${probe.format}" (allowed: ${LISTING_ASSET_ALLOWED_MIME.join(
-        ', '
-      )})`,
-    });
-  }
-  return { width: probe.width, height: probe.height, mimeType, sizeBytes: probe.sizeBytes };
-}
+const measureListingAssetUpload = (key: string) =>
+  measureUploadedImage(key, {
+    maxBytes: MAX_LISTING_ASSET_SIZE_BYTES,
+    subject: 'listing media',
+  });
 
 /**
  * Materialise an uploaded image into an `Image` row (owned by the caller) and


### PR DESCRIPTION
Fixes #3770. Applies #3738's treatment to the second path that writes client-declared image geometry.

## The defect

`blockImageUpload.persist` is a plain `protectedProcedure`, and its service wrote the client's `width` / `height` / `mimeType` / `sizeBytes` straight into `createImage`. Nothing ever reconciled them with the bytes:

- `image-scan-result.service.ts` has **0** occurrences of `width` / `height` / `mimeType` (positive control: 24 of `ingestion`). The `Scanned` update writes scan state only.
- `assertAssetsScanClean` selects `{ id, ingestion }` — it never reads geometry.
- `loadValidatedImage` gates attach on **ownership**, not provenance, and then applies `validateListingImage` over exactly those columns.

So a row created there scans normally against its real bytes, is attachable on ownership alone, and clears the per-kind aspect / minimum-dimension / byte-cap rules on its declared values. It reaches the store card, the listing detail page and moderator review — a reviewer is shown metadata that does not describe the image they are approving.

## The fix

`persistBlockUploadImage` now measures the stored object before creating the row and ignores the declared values, via #3738's `probeStoredImage`.

Rather than a second copy of the mapping around it, #3738's `measureListingAssetUpload` is extracted to `src/server/services/blocks/measure-uploaded-image.ts` and both paths call it. The `StoredImageProbeReason` → `TRPCError` switch and the decoded-format allowlist were the parts that would silently drift; the only per-caller inputs are the byte cap and the noun in the too-large message. Message text is unchanged for the listing path — its existing tests pin the strings and stayed green through the refactor.

## Judgement calls

**Byte cap: 40 MiB, not #3738's 4 MiB.** The probe's `maxBytes` is both the read budget and a rejection threshold, so it becomes this path's size limit. This path has no server-side size limit today, and it is deliberately generic — the modal is "upload an image (avatar / cover / background / reference / whatever the app is for)". Copying 4 MiB would reject uploads that work today. 40 MiB is the cap the *sibling* function in the same module already enforces on block-published image bytes, so the constant is now shared (`BLOCK_PUBLISH_MAX_BYTES` → `BLOCK_IMAGE_MAX_BYTES`) and this introduces no new user-facing restriction relative to what the module already imposes.

The cost is honest: an honest N-MiB upload now costs an N-MiB read-back, bounded at 40 MiB, on a proc rate-limited to 60/hour/user. If we'd rather pay less and accept a tighter limit, that's a product call — say so and I'll lower it.

**Declared fields become optional, and released clients keep working.** Same choice as #3738: `width` / `height` stay in the contract as `.optional()`. The change is strictly widening — anything that parsed before still parses — and it stops a new client being required to compute a value the server discards. The host modal still sends them; leaving that alone matches what #3738 did with `ListingAssetStep`, and stripping the client-side `createImageBitmap` decode from both is a follow-up, not this PR.

**Format allowlist.** The probe's decoded format is now the source of `mimeType`, and a format outside PNG / JPEG / WebP is rejected. That is the modal's own stated contract (`accept="image/png,image/jpeg,image/webp"`, and the in-modal copy says "Upload a PNG, JPEG or WebP") — previously `mimeType` was an unvalidated client string of up to 120 chars. Deriving without rejecting would have been worse than either: `validateListingImage` *skips* its MIME check when the field is absent, so an unmapped format would have passed by omission.

**The NSFW gate is untouched.** It lives in `gateBlockUploadImage`, a separate proc that runs after persist; nothing here reorders or weakens it. The probe runs *before* `createImage`, so a rejected upload creates no row at all — strictly fail-closed. A test pins that the row is still created owned by the caller and without `skipIngestion`.

**Out of scope.** Issue option 3 (have ingestion write measured geometry back, fixing the whole class) is not attempted. Nor is option 1 (probe at attach). `persistBlockWorkflowOutputImage` still takes its dimensions from the orchestrator's workflow projection — server-sourced, not a caller claim — so it is a weaker version of the same gap and is called out in the corrected comment rather than changed here.

## Corrected comments

Both were false and both described a safety property, which is how the next person deletes a guard.

`block-image-upload.schema.ts` said the schema "Mirrors persistListingAssetImageSchema — the CF upload key + intrinsic dims the scanner + validators need", which stopped being true when #3738 made those fields ignored. It now states that the four fields are not persisted, why (the ownership-gated attach reads exactly those columns and nothing re-derives them), and the narrower guarantee that a probe actually buys — measured from real bytes *at persist time*, not still true of the object, since the presigned PUT stays usable for its whole expiry.

`block-image-upload.service.ts` said, of the workflow-output path, "ingestion re-measures either way". It does not. The comment now says the values are the orchestrator's own server-side projection rather than a caller claim, and that an absent pair stays absent.

## Tests

`src/server/services/blocks/__tests__/block-image-upload.persist.test.ts`, 14 cases. Only the store accessor is mocked — `probeStoredImage` and its sharp decode run for real against real image bytes.

**Red at `origin/main` (fe0978b366), green at HEAD.** 11 failed / 3 passed at base; 14/14 at HEAD. The three green at base are the ones that should be: the negative control, the scan-invariant guard (an invariant guard, not regression coverage) and the back-compat check that a client still may send the declared fields.

The load-bearing case declares 800×450 — which the test first asserts really does clear the cover gate — behind 200×200 bytes, and pins that the persisted row is 200×200 and that `validateListingImage` now rejects it. The negative control is an honest 800×450 upload that still persists and still passes.

No test asserts a byte-size bound crossed by fixture *content*, so the low-entropy-fixture trap from #3738's review does not arise: the oversize case is driven by the store's reported `Content-Range` total, which is the real production mechanism, and it pins the `Range` header at `bytes=0-41943040`.

### Mutations

Each guard was broken on purpose and the specific failure recorded. Every mutation died for its own reason:

| Mutation | Tests killed | Message |
|---|---|---|
| persist `input.width/height` | 2 | `expected { width: 800, … } to match object { width: 200, height: 200 }` |
| drop the format-allowlist throw | 2 (both paths) | `promise resolved "{ imageId: 777 }" instead of rejecting` |
| persist `input.sizeBytes` | 1 | `expected 1 to be 2130` |
| cap 40 MiB → 4 MiB | 1 | `expected TRPCError: that image is over the 4 MiB l… to match object { code: 'BAD_REQUEST', … }` |
| persist `input.mimeType` | 3 | `expected 'image/webp' to be 'image/png'` |
| `store-unavailable` → BAD_REQUEST | 2 (both paths) | `expected TRPCError: We couldn't read that upload b… to match object { code: 'INTERNAL_SERVER_ERROR' }` |

The two that killed a test in `offsite-listing.service.test.ts` as well are the extraction's own reachability proof — the shared helper is genuinely the code both paths run.

### Gates

- Full unit suite: **891 files / 13749 passed, 1 skipped**. `blocks.router.workflow.test.ts` collected 347 (submodule sanity).
- `pnpm typecheck`: 0 errors. It excludes `src/**/__tests__/**`, so the test file was typechecked explicitly through its own tsconfig — confirmed in the program via `--listFilesOnly`, and the invocation validated by planting a `TS2322` and watching it report.
- `test:lint-rules`: 204 passed. ESLint on the changed files: 0 errors.
- Prettier: both **new** files are clean (verified by the same invocation that had just flagged them). The two modified files were already Prettier-dirty on `main` and are deliberately left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
