### PR TITLE
test(watchdog): fix #3773 flake — warm the CPU ring, poll for the counters

### DIFF
--- a/src/server/__tests__/eventloop-watchdog.capture.test.ts
+++ b/src/server/__tests__/eventloop-watchdog.capture.test.ts
@@ -90,7 +90,19 @@ describe('starvation classifier', () => {
     while (Date.now() < until) sink += Math.sqrt(Math.random());
   `;
 
-  async function runWedge(kind: 'starved' | 'executing', backgroundThreads = 0) {
+  // The worker's own sampling cadence. Named so the ring warmup below reads as a
+  // multiple of it rather than as one more bare millisecond guess.
+  const WORKER_POLL_MS = 25;
+
+  /**
+   * @param settleOn series the wedge must make true before the body is read. See
+   *   scrapeUntil — this is WHEN to look, never WHAT to assert.
+   */
+  async function runWedge(
+    kind: 'starved' | 'executing',
+    settleOn: Record<string, number>,
+    backgroundThreads = 0
+  ) {
     const sab = new SharedArrayBuffer(8);
     const beat = new BigInt64Array(sab);
     Atomics.store(beat, 0, BigInt(Date.now()));
@@ -103,7 +115,7 @@ describe('starvation classifier', () => {
         port: 0,
         token: 'classifier-test',
         heartbeatIntervalMs: 50,
-        pollMs: 25,
+        pollMs: WORKER_POLL_MS,
         cap: { ...resolveCaptureConfig(), enabled: false },
         starvedRatio: 0.2,
       },
@@ -114,16 +126,36 @@ describe('starvation classifier', () => {
       () => new Worker(SPINNER, { eval: true, workerData: { ms: 1800 } })
     );
 
-    const port = await new Promise<number>((resolve, reject) => {
-      const timer = setTimeout(() => reject(new Error('never listened')), 10_000);
-      worker.on('message', (m: { type?: string; port?: number }) => {
-        if (m?.type === 'listening' && m.port) {
-          clearTimeout(timer);
-          resolve(m.port);
-        }
+    // Beat from before the worker exists until the wedge starts, so the only stale-beat
+    // window in the run is the one the test opens deliberately, and a slow worker boot
+    // cannot be read as a first, spurious wedge.
+    const beating = setInterval(() => Atomics.store(beat, 0, BigInt(Date.now())), WORKER_POLL_MS);
+    let port: number;
+    try {
+      port = await new Promise<number>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('never listened')), 10_000);
+        worker.on('message', (m: { type?: string; port?: number }) => {
+          if (m?.type === 'listening' && m.port) {
+            clearTimeout(timer);
+            resolve(m.port);
+          }
+        });
+        worker.on('error', reject);
       });
-      worker.on('error', reject);
-    });
+
+      // 🔴 Let the worker's CPU ring accumulate samples that PRE-DATE the wedge. The
+      // classifier reads main-thread CPU over [wedge start, detection] and returns null
+      // — no classification, and at detection no skipped-starved tally — when the ring
+      // cannot reach back that far. The ring starts when the worker boots, so without
+      // this warmup the entire margin is worker startup against the 300ms threshold:
+      // ~20ms boot idle, and the capture gate stops being recorded once boot slips past
+      // ~90ms. That is #3773 — the wedge still classified starved, only the
+      // detection-time counter went missing. Production never sees it: the worker starts
+      // with the process and wedges arrive minutes later, ring long since full.
+      await new Promise((r) => setTimeout(r, WORKER_POLL_MS * 16));
+    } finally {
+      clearInterval(beating);
+    }
 
     // Withhold beats for 1.5s. In the executing case the MAIN thread burns CPU
     // throughout, which is what the classifier has to notice; in the starved case it
@@ -138,11 +170,7 @@ describe('starvation classifier', () => {
     }
 
     Atomics.store(beat, 0, BigInt(Date.now()));
-    await new Promise((r) => setTimeout(r, 250));
-
-    const body = await (
-      await fetch(`http://127.0.0.1:${port}/metrics?token=classifier-test`)
-    ).text();
+    const body = await scrapeUntil(port, settleOn);
     await worker.terminate();
     await Promise.all(spinners.map((s) => s.terminate()));
     return body;
@@ -156,14 +184,57 @@ describe('starvation classifier', () => {
         ?.slice(name.length + 1)
     );
 
+  // Poll for the counters the wedge has to move instead of sleeping a fixed interval
+  // and hoping. Every series here is written by the worker's own poll loop, so "has it
+  // landed yet" is a question about a loaded runner's scheduling, not a constant — a
+  // fixed 250ms guess left ~65ms of slack against worker startup and went red on CI
+  // (#3773). This changes WHEN the body is read, never what is asserted about it: an
+  // expectation that never becomes true is not waited away, it fails here with what it
+  // wanted and what it last saw.
+  async function scrapeUntil(port: number, settleOn: Record<string, number>) {
+    const deadlineMs = 10_000;
+    const deadline = Date.now() + deadlineMs;
+    let body = '';
+    for (;;) {
+      body = await (await fetch(`http://127.0.0.1:${port}/metrics?token=classifier-test`)).text();
+      if (Object.entries(settleOn).every(([name, value]) => read(body, name) === value)) {
+        return body;
+      }
+      if (Date.now() >= deadline) {
+        const wanted = Object.entries(settleOn)
+          .map(([name, value]) => `${name} = ${value}`)
+          .join(', ');
+        const seen = body
+          .split('\n')
+          .filter(
+            (l) =>
+              l.startsWith('civitai_app_watchdog_wedge_kind_total') ||
+              l.startsWith('civitai_app_watchdog_wedge_cpu_ratio_count') ||
+              l.startsWith('civitai_app_watchdog_capture_total')
+          )
+          .join('\n  ');
+        throw new Error(
+          `watchdog metrics never settled: waited ${deadlineMs}ms for ${wanted}.\n` +
+            `  last scrape:\n  ${seen}`
+        );
+      }
+      await new Promise((r) => setTimeout(r, WORKER_POLL_MS));
+    }
+  }
+
   it('🔴 classifies a CPU-burning wedge as executing', async () => {
-    const body = await runWedge('executing');
+    const body = await runWedge('executing', {
+      'civitai_app_watchdog_wedge_kind_total{kind="executing"}': 1,
+    });
     expect(read(body, 'civitai_app_watchdog_wedge_kind_total{kind="executing"}')).toBe(1);
     expect(read(body, 'civitai_app_watchdog_wedge_kind_total{kind="starved"}')).toBe(0);
   }, 30_000);
 
   it('🔴 classifies an idle wedge as starved, and skips the capture', async () => {
-    const body = await runWedge('starved');
+    const body = await runWedge('starved', {
+      'civitai_app_watchdog_wedge_kind_total{kind="starved"}': 1,
+      'civitai_app_watchdog_capture_total{result="skipped-starved"}': 1,
+    });
     expect(read(body, 'civitai_app_watchdog_wedge_kind_total{kind="starved"}')).toBe(1);
     expect(read(body, 'civitai_app_watchdog_wedge_kind_total{kind="executing"}')).toBe(0);
     // The whole point of the gate: a starved wedge has nothing to sample, so no
@@ -185,7 +256,11 @@ describe('starvation classifier', () => {
   it.runIf(process.platform === 'linux')(
     '🔴 classifies a wedge as starved even while OTHER threads burn CPU',
     async () => {
-      const body = await runWedge('starved', 4);
+      const body = await runWedge(
+        'starved',
+        { 'civitai_app_watchdog_wedge_kind_total{kind="starved"}': 1 },
+        4
+      );
       expect(read(body, 'civitai_app_watchdog_cpu_source{source="main-thread"}')).toBe(1);
       expect(read(body, 'civitai_app_watchdog_wedge_kind_total{kind="starved"}')).toBe(1);
       expect(read(body, 'civitai_app_watchdog_wedge_kind_total{kind="executing"}')).toBe(0);
@@ -197,7 +272,9 @@ describe('starvation classifier', () => {
     // A gauge of the last value could not answer "where do starved wedges actually
     // sit" — the continuous profiler adds a CPU floor, so that has to be readable
     // rather than assumed.
-    const body = await runWedge('starved');
+    const body = await runWedge('starved', {
+      civitai_app_watchdog_wedge_cpu_ratio_count: 1,
+    });
     expect(body).toContain('civitai_app_watchdog_wedge_cpu_ratio_bucket{le="0.05"}');
     expect(body).toContain('civitai_app_watchdog_wedge_cpu_ratio_count 1');
     expect(read(body, 'civitai_app_watchdog_starved_ratio_threshold')).toBe(0.2);


### PR DESCRIPTION
Fixes #3773.

## The reported failure is not the mechanism the issue guessed

The issue suspected the fixed 250 ms sleep before scraping `/metrics`. Both candidate
mechanisms were reproduced, and they have **distinguishable signatures**:

| mechanism | `wedge_kind{starved}` | `capture_total{skipped-starved}` | which assertion fails |
|---|---|---|---|
| scrape too early (sleep too short) | **0** | 1 | the first one |
| worker boots late | 1 | **0** | the third one (line 171) |

CI failed the **third**, with the two above it passing. So the cause is worker startup
latency, not the scrape. Polling alone would not have fixed it: the counter never
arrives, so the poll would spin to its deadline and still go red.

## Mechanism

`skipped-starved` is tallied at **detection**, gated on
`cpuRatioSince(wedgeStart, now)` — which returns `null` when the CPU ring cannot reach
back to the wedge start (`wallMs < 200`). The ring starts when the worker boots, and
the test set the beat that *becomes* `wedgeStart` **before** constructing the worker.
So the entire margin was worker startup against the 300 ms threshold: ~20 ms boot on an
idle box, and the tally stops being recorded once boot slips past ~90 ms.

On a `null` early ratio the wedge falls through to `maybeCaptureWedge`, capture is
disabled in this suite, and nothing is tallied at all. The wedge still classifies
`starved` on recovery, because by then the ring spans it — which is exactly the
observed split.

Production never sees this: the watchdog worker starts with the process and wedges
arrive minutes later, ring long since full. The unrealistic part was the test starting
a wedge at process start.

## The change (test only, one file)

1. **Beat from before the worker exists until the wedge starts, then warm the ring for
   16 worker poll ticks.** `wallMs` at detection is now `>= thresholdMs` by
   construction rather than by luck, and a slow boot can no longer be misread as a
   first, spurious wedge.
2. **Replace the fixed 250 ms pre-scrape sleep with a poll** for the counters each test
   is about, 10 s deadline, inside the existing 30 s test timeout. This changes *when*
   the body is read, never *what* is asserted about it — every `expect` is unchanged,
   and a value that never becomes true is not waited away.

## Verification

**Deterministic reproduction.** Injecting a delay between the first beat and
`new Worker` makes the *original* test fail 100 % of the time at >= 90 ms, with the
exact reported signature (`eventloop-watchdog.capture.test.ts:171`,
`expected +0 to be 1`, the other 8 tests passing):

| injected boot delay | original | fixed |
|---|---|---|
| 0 ms | pass | pass |
| 60 ms | pass | — |
| 90 ms | **fail** | pass |
| 200 ms | **fail** | pass |
| 500 ms | **fail** | pass |
| 1500 ms | — | pass |

**Natural reproduction under load** (22 busy threads on a 24-core box, load avg 10–35):
19/20 before — one failure, byte-identical signature to CI — and 20/20 after. That
delta on its own is weak at a ~5 % base rate; the deterministic table above is the
actual evidence.

**The poll can still go red.** Three mutations, each failing with the poll's own
`watchdog metrics never settled` error naming the wanted value and the last scrape —
not an incidental timeout:

| mutation | result |
|---|---|
| delete the `skipped-starved` tally | 1 failed / 8 passed |
| invert the classifier (`starved` <-> `executing`) | 3 failed / 6 passed |
| double-count the tally | 1 failed / 8 passed |

The third one matters separately: it proves the poll settles on **equality**, so an
over-count cannot satisfy it.

Example message, from the deleted-tally mutant — strictly more diagnostic than the
`expected +0 to be 1` this replaces:

```
Error: watchdog metrics never settled: waited 10000ms for
  civitai_app_watchdog_wedge_kind_total{kind="starved"} = 1,
  civitai_app_watchdog_capture_total{result="skipped-starved"} = 1.
  last scrape:
  civitai_app_watchdog_wedge_kind_total{kind="starved"} 1
  civitai_app_watchdog_wedge_kind_total{kind="executing"} 0
  civitai_app_watchdog_wedge_kind_total{kind="unknown"} 0
  civitai_app_watchdog_wedge_cpu_ratio_count 1
  ...
  civitai_app_watchdog_capture_total{result="skipped-starved"} 0
```

**Gates.** `tsconfig.json` excludes `src/**/__tests__/**`, so the file was typechecked
through an ad-hoc config: identical error count at base and at head (the one error is
in an unrelated file and is an artifact of the narrow program), and a planted type
error proved the check actually sees this file. eslint clean, prettier clean, all three
`eventloop-watchdog.*` suites 33/33, `test:lint-rules` 204/204.

## Trade-off worth naming

The poll no longer pins how *fast* a counter appears, only that it appears within 10 s.
The suite never asserted latency, but a regression that made recording very slow would
now pass where the 250 ms sleep would have caught it.
