### PR TITLE
fix(og): unblock the SVG loader Next 16.3.0 leaves blocked, so /api/og stops 500ing

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -323,6 +323,21 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
+      # Not a package suite, and deliberately parked in this job anyway: it needs a completed
+      # `pnpm install` and a job that FAILS the build, and this is the cheapest one that is
+      # both. Adding a fourth job would buy a tidier name for the price of a fourth full
+      # install; the step name is what GitHub shows on a failure, so blame stays readable.
+      #
+      # What it guards: `/api/og` returned 500 on every request for two days because Next
+      # 16.3.0 leaves the libvips SVG loader blocked and `next/og` rasterizes through it. We
+      # carry the upstream one-line fix as a pnpm patch. The behavioural regression test for
+      # that outage lives in the `unit` job above — which is `continue-on-error`, so it cannot
+      # stop the same breakage reaching production a second time. This runs the structural
+      # half of it, against the INSTALLED node_modules rather than the patch file, so a patch
+      # that exists but did not apply is caught. ~50ms, no test runner.
+      - name: Next SVG loader patch applied
+        run: node scripts/ci/assert-next-svg-patch-applied.mjs
+
       - name: Package unit tests
         run: pnpm run test:packages:run --reporter=default --reporter=json --outputFile=packages-report.json
 

--- a/package.json
+++ b/package.json
@@ -431,7 +431,8 @@
       "utf-8-validate"
     ],
     "patchedDependencies": {
-      "@mantine/hooks": "patches/@mantine__hooks.patch"
+      "@mantine/hooks": "patches/@mantine__hooks.patch",
+      "next@16.3.0": "patches/next@16.3.0.patch"
     }
   }
 }

--- a/patches/next@16.3.0.patch
+++ b/patches/next@16.3.0.patch
@@ -1,3 +1,15 @@
+diff --git a/dist/esm/server/image-optimizer.js b/dist/esm/server/image-optimizer.js
+index 09277f1df5ed73d006e1769b405f148cab406dff..50135855db356fa22ab03b050ce24a4182c60a8d 100644
+--- a/dist/esm/server/image-optimizer.js
++++ b/dist/esm/server/image-optimizer.js
+@@ -90,6 +90,7 @@ export function getSharp(concurrency, operationCache) {
+                 'VipsForeignLoadJpeg',
+                 'VipsForeignLoadNsgif',
+                 'VipsForeignLoadPng',
++                'VipsForeignLoadSvg',
+                 'VipsForeignLoadTiff',
+                 'VipsForeignLoadWebp'
+             ]
 diff --git a/dist/server/image-optimizer.js b/dist/server/image-optimizer.js
 index 9be0c9ae912f3824e9253641eee3273f17080a69..31b5c6e3e46f40a994f62c4d43df6a8bbf971869 100644
 --- a/dist/server/image-optimizer.js

--- a/patches/next@16.3.0.patch
+++ b/patches/next@16.3.0.patch
@@ -1,0 +1,12 @@
+diff --git a/dist/server/image-optimizer.js b/dist/server/image-optimizer.js
+index 9be0c9ae912f3824e9253641eee3273f17080a69..31b5c6e3e46f40a994f62c4d43df6a8bbf971869 100644
+--- a/dist/server/image-optimizer.js
++++ b/dist/server/image-optimizer.js
+@@ -210,6 +210,7 @@ function getSharp(concurrency, operationCache) {
+                 'VipsForeignLoadJpeg',
+                 'VipsForeignLoadNsgif',
+                 'VipsForeignLoadPng',
++                'VipsForeignLoadSvg',
+                 'VipsForeignLoadTiff',
+                 'VipsForeignLoadWebp'
+             ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ patchedDependencies:
   '@mantine/hooks':
     hash: b45a85bd4d007c796b93eb90a75d3234b81cce13964921b25721734c7ed79f64
     path: patches/@mantine__hooks.patch
+  next@16.3.0:
+    hash: 9b6ebe47f55d18825f485fb243f076aaa3968476c5e07b8378e08b7f1c7e5ee7
+    path: patches/next@16.3.0.patch
 
 importers:
 
@@ -60,7 +63,7 @@ importers:
         version: link:packages/civitai-db-schema
       '@civitai/next-axiom':
         specifier: ^0.17.0
-        version: 0.17.0(next@16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))
+        version: 0.17.0(next@16.3.0(patch_hash=9b6ebe47f55d18825f485fb243f076aaa3968476c5e07b8378e08b7f1c7e5ee7)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))
       '@civitai/shared':
         specifier: workspace:*
         version: link:packages/civitai-shared
@@ -150,7 +153,7 @@ importers:
         version: 16.3.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@next/third-parties':
         specifier: ^15.0.3
-        version: 15.4.6(next@16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(react@18.3.1)
+        version: 15.4.6(next@16.3.0(patch_hash=9b6ebe47f55d18825f485fb243f076aaa3968476c5e07b8378e08b7f1c7e5ee7)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(react@18.3.1)
       '@node-oauth/oauth2-server':
         specifier: ^5.3.0
         version: 5.3.0
@@ -306,7 +309,7 @@ importers:
         version: 11.17.0(@trpc/server@11.17.0(typescript@5.9.2))(typescript@5.9.2)
       '@trpc/next':
         specifier: ^11.17.0
-        version: 11.17.0(@tanstack/react-query@5.101.0(react@18.3.1))(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@5.9.2))(typescript@5.9.2))(@trpc/react-query@11.17.0(@tanstack/react-query@5.101.0(react@18.3.1))(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@5.9.2))(typescript@5.9.2))(@trpc/server@11.17.0(typescript@5.9.2))(react@18.3.1)(typescript@5.9.2))(@trpc/server@11.17.0(typescript@5.9.2))(next@16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)
+        version: 11.17.0(@tanstack/react-query@5.101.0(react@18.3.1))(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@5.9.2))(typescript@5.9.2))(@trpc/react-query@11.17.0(@tanstack/react-query@5.101.0(react@18.3.1))(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@5.9.2))(typescript@5.9.2))(@trpc/server@11.17.0(typescript@5.9.2))(react@18.3.1)(typescript@5.9.2))(@trpc/server@11.17.0(typescript@5.9.2))(next@16.3.0(patch_hash=9b6ebe47f55d18825f485fb243f076aaa3968476c5e07b8378e08b7f1c7e5ee7)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)
       '@trpc/react-query':
         specifier: ^11.17.0
         version: 11.17.0(@tanstack/react-query@5.101.0(react@18.3.1))(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@5.9.2))(typescript@5.9.2))(@trpc/server@11.17.0(typescript@5.9.2))(react@18.3.1)(typescript@5.9.2)
@@ -474,7 +477,7 @@ importers:
         version: 1.11.5
       next:
         specifier: ^16.3.0
-        version: 16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
+        version: 16.3.0(patch_hash=9b6ebe47f55d18825f485fb243f076aaa3968476c5e07b8378e08b7f1c7e5ee7)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
       nodemailer:
         specifier: ^6.8.0
         version: 6.10.1
@@ -534,7 +537,7 @@ importers:
         version: 7.12.0(algoliasearch@4.25.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-instantsearch-router-nextjs:
         specifier: 7.12.0
-        version: 7.12.0(algoliasearch@4.25.2)(next@16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(react@18.3.1)
+        version: 7.12.0(algoliasearch@4.25.2)(next@16.3.0(patch_hash=9b6ebe47f55d18825f485fb243f076aaa3968476c5e07b8378e08b7f1c7e5ee7)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(react@18.3.1)
       react-intersection-observer:
         specifier: ^9.4.0
         version: 9.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -13804,9 +13807,9 @@ snapshots:
     dependencies:
       fast-xml-parser: 5.10.1
 
-  '@civitai/next-axiom@0.17.0(next@16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))':
+  '@civitai/next-axiom@0.17.0(next@16.3.0(patch_hash=9b6ebe47f55d18825f485fb243f076aaa3968476c5e07b8378e08b7f1c7e5ee7)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))':
     dependencies:
-      next: 16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
+      next: 16.3.0(patch_hash=9b6ebe47f55d18825f485fb243f076aaa3968476c5e07b8378e08b7f1c7e5ee7)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
       whatwg-fetch: 3.6.20
 
   '@clavata/sdk@0.2.3':
@@ -15200,9 +15203,9 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.3.0':
     optional: true
 
-  '@next/third-parties@15.4.6(next@16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(react@18.3.1)':
+  '@next/third-parties@15.4.6(next@16.3.0(patch_hash=9b6ebe47f55d18825f485fb243f076aaa3968476c5e07b8378e08b7f1c7e5ee7)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(react@18.3.1)':
     dependencies:
-      next: 16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
+      next: 16.3.0(patch_hash=9b6ebe47f55d18825f485fb243f076aaa3968476c5e07b8378e08b7f1c7e5ee7)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
       react: 18.3.1
       third-party-capital: 1.0.20
 
@@ -17410,11 +17413,11 @@ snapshots:
       '@trpc/server': 11.17.0(typescript@5.9.2)
       typescript: 5.9.2
 
-  '@trpc/next@11.17.0(@tanstack/react-query@5.101.0(react@18.3.1))(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@5.9.2))(typescript@5.9.2))(@trpc/react-query@11.17.0(@tanstack/react-query@5.101.0(react@18.3.1))(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@5.9.2))(typescript@5.9.2))(@trpc/server@11.17.0(typescript@5.9.2))(react@18.3.1)(typescript@5.9.2))(@trpc/server@11.17.0(typescript@5.9.2))(next@16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)':
+  '@trpc/next@11.17.0(@tanstack/react-query@5.101.0(react@18.3.1))(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@5.9.2))(typescript@5.9.2))(@trpc/react-query@11.17.0(@tanstack/react-query@5.101.0(react@18.3.1))(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@5.9.2))(typescript@5.9.2))(@trpc/server@11.17.0(typescript@5.9.2))(react@18.3.1)(typescript@5.9.2))(@trpc/server@11.17.0(typescript@5.9.2))(next@16.3.0(patch_hash=9b6ebe47f55d18825f485fb243f076aaa3968476c5e07b8378e08b7f1c7e5ee7)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)':
     dependencies:
       '@trpc/client': 11.17.0(@trpc/server@11.17.0(typescript@5.9.2))(typescript@5.9.2)
       '@trpc/server': 11.17.0(typescript@5.9.2)
-      next: 16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
+      next: 16.3.0(patch_hash=9b6ebe47f55d18825f485fb243f076aaa3968476c5e07b8378e08b7f1c7e5ee7)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       typescript: 5.9.2
@@ -23224,7 +23227,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0):
+  next@16.3.0(patch_hash=9b6ebe47f55d18825f485fb243f076aaa3968476c5e07b8378e08b7f1c7e5ee7)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0):
     dependencies:
       '@next/env': 16.3.0
       '@swc/helpers': 0.5.15
@@ -24432,10 +24435,10 @@ snapshots:
       react: 18.3.1
       use-sync-external-store: 1.5.0(react@18.3.1)
 
-  react-instantsearch-router-nextjs@7.12.0(algoliasearch@4.25.2)(next@16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(react@18.3.1):
+  react-instantsearch-router-nextjs@7.12.0(algoliasearch@4.25.2)(next@16.3.0(patch_hash=9b6ebe47f55d18825f485fb243f076aaa3968476c5e07b8378e08b7f1c7e5ee7)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(react@18.3.1):
     dependencies:
       instantsearch.js: 4.73.0(algoliasearch@4.25.2)
-      next: 16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
+      next: 16.3.0(patch_hash=9b6ebe47f55d18825f485fb243f076aaa3968476c5e07b8378e08b7f1c7e5ee7)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
       react-instantsearch-core: 7.12.0(algoliasearch@4.25.2)(react@18.3.1)
     transitivePeerDependencies:
       - algoliasearch

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ patchedDependencies:
     hash: b45a85bd4d007c796b93eb90a75d3234b81cce13964921b25721734c7ed79f64
     path: patches/@mantine__hooks.patch
   next@16.3.0:
-    hash: 9b6ebe47f55d18825f485fb243f076aaa3968476c5e07b8378e08b7f1c7e5ee7
+    hash: d4cabfb715b050babab8b116679e9bd883334feb7bdf383883679c3cf22f94c6
     path: patches/next@16.3.0.patch
 
 importers:
@@ -63,7 +63,7 @@ importers:
         version: link:packages/civitai-db-schema
       '@civitai/next-axiom':
         specifier: ^0.17.0
-        version: 0.17.0(next@16.3.0(patch_hash=9b6ebe47f55d18825f485fb243f076aaa3968476c5e07b8378e08b7f1c7e5ee7)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))
+        version: 0.17.0(next@16.3.0(patch_hash=d4cabfb715b050babab8b116679e9bd883334feb7bdf383883679c3cf22f94c6)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))
       '@civitai/shared':
         specifier: workspace:*
         version: link:packages/civitai-shared
@@ -153,7 +153,7 @@ importers:
         version: 16.3.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@next/third-parties':
         specifier: ^15.0.3
-        version: 15.4.6(next@16.3.0(patch_hash=9b6ebe47f55d18825f485fb243f076aaa3968476c5e07b8378e08b7f1c7e5ee7)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(react@18.3.1)
+        version: 15.4.6(next@16.3.0(patch_hash=d4cabfb715b050babab8b116679e9bd883334feb7bdf383883679c3cf22f94c6)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(react@18.3.1)
       '@node-oauth/oauth2-server':
         specifier: ^5.3.0
         version: 5.3.0
@@ -309,7 +309,7 @@ importers:
         version: 11.17.0(@trpc/server@11.17.0(typescript@5.9.2))(typescript@5.9.2)
       '@trpc/next':
         specifier: ^11.17.0
-        version: 11.17.0(@tanstack/react-query@5.101.0(react@18.3.1))(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@5.9.2))(typescript@5.9.2))(@trpc/react-query@11.17.0(@tanstack/react-query@5.101.0(react@18.3.1))(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@5.9.2))(typescript@5.9.2))(@trpc/server@11.17.0(typescript@5.9.2))(react@18.3.1)(typescript@5.9.2))(@trpc/server@11.17.0(typescript@5.9.2))(next@16.3.0(patch_hash=9b6ebe47f55d18825f485fb243f076aaa3968476c5e07b8378e08b7f1c7e5ee7)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)
+        version: 11.17.0(@tanstack/react-query@5.101.0(react@18.3.1))(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@5.9.2))(typescript@5.9.2))(@trpc/react-query@11.17.0(@tanstack/react-query@5.101.0(react@18.3.1))(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@5.9.2))(typescript@5.9.2))(@trpc/server@11.17.0(typescript@5.9.2))(react@18.3.1)(typescript@5.9.2))(@trpc/server@11.17.0(typescript@5.9.2))(next@16.3.0(patch_hash=d4cabfb715b050babab8b116679e9bd883334feb7bdf383883679c3cf22f94c6)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)
       '@trpc/react-query':
         specifier: ^11.17.0
         version: 11.17.0(@tanstack/react-query@5.101.0(react@18.3.1))(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@5.9.2))(typescript@5.9.2))(@trpc/server@11.17.0(typescript@5.9.2))(react@18.3.1)(typescript@5.9.2)
@@ -477,7 +477,7 @@ importers:
         version: 1.11.5
       next:
         specifier: ^16.3.0
-        version: 16.3.0(patch_hash=9b6ebe47f55d18825f485fb243f076aaa3968476c5e07b8378e08b7f1c7e5ee7)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
+        version: 16.3.0(patch_hash=d4cabfb715b050babab8b116679e9bd883334feb7bdf383883679c3cf22f94c6)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
       nodemailer:
         specifier: ^6.8.0
         version: 6.10.1
@@ -537,7 +537,7 @@ importers:
         version: 7.12.0(algoliasearch@4.25.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-instantsearch-router-nextjs:
         specifier: 7.12.0
-        version: 7.12.0(algoliasearch@4.25.2)(next@16.3.0(patch_hash=9b6ebe47f55d18825f485fb243f076aaa3968476c5e07b8378e08b7f1c7e5ee7)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(react@18.3.1)
+        version: 7.12.0(algoliasearch@4.25.2)(next@16.3.0(patch_hash=d4cabfb715b050babab8b116679e9bd883334feb7bdf383883679c3cf22f94c6)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(react@18.3.1)
       react-intersection-observer:
         specifier: ^9.4.0
         version: 9.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -13807,9 +13807,9 @@ snapshots:
     dependencies:
       fast-xml-parser: 5.10.1
 
-  '@civitai/next-axiom@0.17.0(next@16.3.0(patch_hash=9b6ebe47f55d18825f485fb243f076aaa3968476c5e07b8378e08b7f1c7e5ee7)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))':
+  '@civitai/next-axiom@0.17.0(next@16.3.0(patch_hash=d4cabfb715b050babab8b116679e9bd883334feb7bdf383883679c3cf22f94c6)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))':
     dependencies:
-      next: 16.3.0(patch_hash=9b6ebe47f55d18825f485fb243f076aaa3968476c5e07b8378e08b7f1c7e5ee7)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
+      next: 16.3.0(patch_hash=d4cabfb715b050babab8b116679e9bd883334feb7bdf383883679c3cf22f94c6)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
       whatwg-fetch: 3.6.20
 
   '@clavata/sdk@0.2.3':
@@ -15203,9 +15203,9 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.3.0':
     optional: true
 
-  '@next/third-parties@15.4.6(next@16.3.0(patch_hash=9b6ebe47f55d18825f485fb243f076aaa3968476c5e07b8378e08b7f1c7e5ee7)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(react@18.3.1)':
+  '@next/third-parties@15.4.6(next@16.3.0(patch_hash=d4cabfb715b050babab8b116679e9bd883334feb7bdf383883679c3cf22f94c6)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(react@18.3.1)':
     dependencies:
-      next: 16.3.0(patch_hash=9b6ebe47f55d18825f485fb243f076aaa3968476c5e07b8378e08b7f1c7e5ee7)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
+      next: 16.3.0(patch_hash=d4cabfb715b050babab8b116679e9bd883334feb7bdf383883679c3cf22f94c6)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
       react: 18.3.1
       third-party-capital: 1.0.20
 
@@ -17413,11 +17413,11 @@ snapshots:
       '@trpc/server': 11.17.0(typescript@5.9.2)
       typescript: 5.9.2
 
-  '@trpc/next@11.17.0(@tanstack/react-query@5.101.0(react@18.3.1))(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@5.9.2))(typescript@5.9.2))(@trpc/react-query@11.17.0(@tanstack/react-query@5.101.0(react@18.3.1))(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@5.9.2))(typescript@5.9.2))(@trpc/server@11.17.0(typescript@5.9.2))(react@18.3.1)(typescript@5.9.2))(@trpc/server@11.17.0(typescript@5.9.2))(next@16.3.0(patch_hash=9b6ebe47f55d18825f485fb243f076aaa3968476c5e07b8378e08b7f1c7e5ee7)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)':
+  '@trpc/next@11.17.0(@tanstack/react-query@5.101.0(react@18.3.1))(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@5.9.2))(typescript@5.9.2))(@trpc/react-query@11.17.0(@tanstack/react-query@5.101.0(react@18.3.1))(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@5.9.2))(typescript@5.9.2))(@trpc/server@11.17.0(typescript@5.9.2))(react@18.3.1)(typescript@5.9.2))(@trpc/server@11.17.0(typescript@5.9.2))(next@16.3.0(patch_hash=d4cabfb715b050babab8b116679e9bd883334feb7bdf383883679c3cf22f94c6)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)':
     dependencies:
       '@trpc/client': 11.17.0(@trpc/server@11.17.0(typescript@5.9.2))(typescript@5.9.2)
       '@trpc/server': 11.17.0(typescript@5.9.2)
-      next: 16.3.0(patch_hash=9b6ebe47f55d18825f485fb243f076aaa3968476c5e07b8378e08b7f1c7e5ee7)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
+      next: 16.3.0(patch_hash=d4cabfb715b050babab8b116679e9bd883334feb7bdf383883679c3cf22f94c6)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       typescript: 5.9.2
@@ -23227,7 +23227,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@16.3.0(patch_hash=9b6ebe47f55d18825f485fb243f076aaa3968476c5e07b8378e08b7f1c7e5ee7)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0):
+  next@16.3.0(patch_hash=d4cabfb715b050babab8b116679e9bd883334feb7bdf383883679c3cf22f94c6)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0):
     dependencies:
       '@next/env': 16.3.0
       '@swc/helpers': 0.5.15
@@ -24435,10 +24435,10 @@ snapshots:
       react: 18.3.1
       use-sync-external-store: 1.5.0(react@18.3.1)
 
-  react-instantsearch-router-nextjs@7.12.0(algoliasearch@4.25.2)(next@16.3.0(patch_hash=9b6ebe47f55d18825f485fb243f076aaa3968476c5e07b8378e08b7f1c7e5ee7)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(react@18.3.1):
+  react-instantsearch-router-nextjs@7.12.0(algoliasearch@4.25.2)(next@16.3.0(patch_hash=d4cabfb715b050babab8b116679e9bd883334feb7bdf383883679c3cf22f94c6)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(react@18.3.1):
     dependencies:
       instantsearch.js: 4.73.0(algoliasearch@4.25.2)
-      next: 16.3.0(patch_hash=9b6ebe47f55d18825f485fb243f076aaa3968476c5e07b8378e08b7f1c7e5ee7)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
+      next: 16.3.0(patch_hash=d4cabfb715b050babab8b116679e9bd883334feb7bdf383883679c3cf22f94c6)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@24.13.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
       react-instantsearch-core: 7.12.0(algoliasearch@4.25.2)(react@18.3.1)
     transitivePeerDependencies:
       - algoliasearch

--- a/scripts/ci/assert-next-svg-patch-applied.mjs
+++ b/scripts/ci/assert-next-svg-patch-applied.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+/**
+ * Blocking guard: the INSTALLED Next unblocks the libvips SVG loader that `next/og` needs.
+ *
+ * WHY THIS EXISTS AS A SCRIPT AND NOT ONLY AS A TEST. The behavioural regression guard for
+ * the 2026-08-08 `/api/og` outage lives in `src/tests/api/og.image-optimizer-sharp.test.ts`,
+ * which runs in the `Unit tests` job — and that job is `continue-on-error: true`, so it
+ * reports without gating. A guard that cannot fail a build is a notification. This is the
+ * same structural assertion in a form a blocking job can run in ~50ms: no database, no
+ * sharp, no browser, no network, no Next module graph — one file read per installed copy.
+ *
+ * WHAT IT ASSERTS, AND WHY THAT IS THE RIGHT INVARIANT. Next 16.3.0 applies a process-global
+ * libvips block on first image-optimizer use and re-enables only six RASTER loaders; SVG is
+ * not among them, so every `ImageResponse` in the process throws
+ * `Input buffer contains unsupported image format` from then on. We carry upstream
+ * vercel/next.js#96681 as `patches/next@16.3.0.patch` until we are on a Next that contains it.
+ *
+ * The assertion is deliberately "the installed Next unblocks SVG", NOT "our patch file is on
+ * disk" and NOT "we are on 16.3.0":
+ *
+ *   - reading `node_modules` rather than `patches/` is the whole point — a patch that exists
+ *     but did not APPLY (unregistered key, failed hunk, a stale lockfile hash) is exactly the
+ *     silent failure this catches, and a patch-file grep would sail through it;
+ *   - staying version-agnostic means the guard does not have to be retired in the same commit
+ *     that bumps Next. On >= 16.3.1 the entry is present upstream and this still passes; the
+ *     patch itself is separately version-pinned, so the bump fails the install rather than
+ *     silently carrying a stale patch.
+ *
+ * BOTH BUILDS, SKIPPING WHAT IS ABSENT. Next ships this module twice — `dist/server/` (CJS)
+ * and `dist/esm/server/`. A full `pnpm install` has both; the production standalone image has
+ * only the CJS copy, because `@vercel/nft` never traces the ESM twin into the output. So an
+ * absent copy is skipped rather than failed, or this check would be wrong in one of the two
+ * environments it has to be correct in. Zero copies found is a HARD failure: that is the
+ * shape a vacuous pass would take, and a guard that reports OK having read nothing is worse
+ * than no guard.
+ *
+ * Usage:  node scripts/ci/assert-next-svg-patch-applied.mjs
+ * Exit:   0 = every installed copy unblocks SVG · 1 = a copy is missing it, or none was found
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join, relative } from 'node:path';
+
+const REQUIRED_LOADER = 'VipsForeignLoadSvg';
+
+// Relative to the installed `next` package root. Order is reporting order only.
+const COPIES = [
+  { label: 'cjs', path: 'dist/server/image-optimizer.js' },
+  { label: 'esm', path: 'dist/esm/server/image-optimizer.js' },
+];
+
+// The `sharp.unblock({ operation: [...] })` call in `getSharp()`. If Next ever restructures
+// this the regex stops matching, and that is reported as a failure rather than shrugged off:
+// "the shape I knew how to check is gone" must not read the same as "the check passed".
+const UNBLOCK_CALL = /unblock\(\{\s*operation:\s*\[([^\]]*)\]/;
+
+/**
+ * @returns {{ ok: boolean, checked: number, results: Array<{label: string, file: string,
+ *   state: 'ok' | 'missing-loader' | 'no-unblock-call' | 'absent'}>, error?: string }}
+ */
+function checkInstalledNext() {
+  const require = createRequire(import.meta.url);
+
+  let nextRoot;
+  try {
+    nextRoot = dirname(require.resolve('next/package.json'));
+  } catch (error) {
+    return {
+      ok: false,
+      checked: 0,
+      results: [],
+      error:
+        'could not resolve the installed `next` package. This check has measured nothing — ' +
+        `install dependencies before running it. (${error.message})`,
+    };
+  }
+
+  const results = COPIES.map(({ label, path }) => {
+    const file = join(nextRoot, path);
+    if (!existsSync(file)) return { label, file, state: 'absent' };
+
+    const match = UNBLOCK_CALL.exec(readFileSync(file, 'utf8'));
+    if (!match) return { label, file, state: 'no-unblock-call' };
+
+    return { label, file, state: match[1].includes(REQUIRED_LOADER) ? 'ok' : 'missing-loader' };
+  });
+
+  const checked = results.filter((r) => r.state !== 'absent').length;
+  return {
+    ok: checked > 0 && results.every((r) => r.state === 'ok' || r.state === 'absent'),
+    checked,
+    results,
+  };
+}
+
+/** Human-readable lines; stdout is what a failing test surfaces as its message. */
+function formatReport(report) {
+  const lines = [];
+  for (const { label, file, state } of report.results) {
+    const shown = relative(process.cwd(), file);
+    if (state === 'ok') lines.push(`     ok  ${label}  ${shown} unblocks ${REQUIRED_LOADER}`);
+    else if (state === 'absent') lines.push(`   skip  ${label}  ${shown} is not installed`);
+    else if (state === 'no-unblock-call')
+      lines.push(`   FAIL  ${label}  ${shown} has no sharp.unblock({ operation: [...] }) call`);
+    else lines.push(`   FAIL  ${label}  ${shown} does NOT unblock ${REQUIRED_LOADER}`);
+  }
+  lines.push(`copies of image-optimizer.js read: ${report.checked}`);
+  if (report.error) lines.push(`FAIL: ${report.error}`);
+  return lines;
+}
+
+const FAILURE_EXPLANATION =
+  `FAIL: the installed Next does not unblock the libvips SVG loader (${REQUIRED_LOADER}).\n` +
+  'Every `next/og` ImageResponse — i.e. all of /api/og — will return 500 as soon as anything\n' +
+  'touches the image optimizer in that process. Check that `patches/next@16.3.0.patch` is\n' +
+  'still registered under `pnpm.patchedDependencies` in package.json and that\n' +
+  '`pnpm install` applied it; this reads node_modules, so a patch file that exists but did\n' +
+  'not apply fails here. See src/tests/api/og.image-optimizer-sharp.test.ts for the outage.';
+
+const NO_COPIES_EXPLANATION =
+  'FAIL: found no copy of next/dist/**/server/image-optimizer.js to read, so this check ' +
+  'proved nothing. Either dependencies are not installed or Next moved the module.';
+
+// Nothing imports this — the unit test spawns it as a subprocess so that it exercises the
+// exact command CI runs, exit code included. Keep it that way: an importable copy of the
+// assertion is a second copy of the assertion.
+const report = checkInstalledNext();
+for (const line of formatReport(report)) console.log(line);
+
+if (!report.ok) {
+  console.error(`\n${report.checked === 0 ? NO_COPIES_EXPLANATION : FAILURE_EXPLANATION}`);
+  process.exit(1);
+}
+console.log(`\nOK: all ${report.checked} installed copy/copies unblock ${REQUIRED_LOADER}.`);

--- a/src/tests/api/og.image-optimizer-sharp.test.ts
+++ b/src/tests/api/og.image-optimizer-sharp.test.ts
@@ -1,3 +1,6 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
@@ -34,11 +37,33 @@ import type { NextApiRequest, NextApiResponse } from 'next';
  * optimizer is touched. If it ever fails, the harness itself is broken and the
  * second case's verdict means nothing. The second case is the regression guard.
  *
+ * WHERE THE GATING HAPPENS. This whole file runs in the `Unit tests` job, which
+ * is `continue-on-error: true` — it reports, it does not block. The third case
+ * below is the one cheap enough to also run in a job that fails the build (no
+ * database, no sharp, no browser, no Next module graph — just a file read), so
+ * the assertion itself lives in `scripts/ci/assert-next-svg-patch-applied.mjs`
+ * and the `Package unit tests` job runs it directly. Do not re-inline the check
+ * here: the copy that gates is the one that would go stale unnoticed.
+ *
  * Watched red/green (2026-08-09, Next 16.3.0):
  *   - patch REMOVED and reinstalled: case 1 PASSES (harness fine), case 2 FAILS
  *     with "Input buffer contains unsupported image format" — the verbatim
  *     production error — and case 3 FAILS naming the missing loader.
  *   - patch APPLIED: all three pass.
+ *
+ * Re-watched 2026-08-10 after case 3 moved into the script, against the script
+ * as shipped — a mutation that kills a different case than the intended one is
+ * a green for the wrong reason, so each of these was checked for WHICH case
+ * went red and WHY:
+ *   - patch key deleted from `pnpm.patchedDependencies` + reinstalled: the
+ *     script exits 1 reporting both copies, and case 3 fails with that text
+ *     verbatim in the AssertionError (1 failed, 2 skipped under `-t`).
+ *   - ESM copy broken while the CJS copy stays correct: exits 1, reporting the
+ *     ESM copy only. This is what proves the second patch hunk is actually
+ *     covered rather than shadowed by the CJS check.
+ *   - ESM copy absent (the shape of the production standalone image): exits 0,
+ *     reports 1 copy read and the ESM copy as skipped.
+ *   - both copies absent: exits 1 rather than passing vacuously on zero reads.
  *
  * SCOPE / WHAT THIS DOES NOT COVER. This runs in-process, so it does not cover
  * packaging failures under `output: 'standalone'` (the OTHER way `/api/og` has
@@ -163,16 +188,36 @@ describe('/api/og — renders a PNG after the Next image optimizer initializes s
     expectPngResponse(await renderOg({ type: 'model', id: '999999999' }));
   });
 
-  it('the image optimizer un-blocks the SVG loader that next/og depends on', async () => {
+  it('the image optimizer un-blocks the SVG loader that next/og depends on', () => {
     // Structural companion to the behavioural guard above: assert the actual
     // remedy is present in the artifact we install, so a failure says WHY rather
-    // than only that a render broke. Reads Next's shipped source rather than our
-    // patch file, so re-installing without the patch fails here too.
-    const optimizerSource = await import('node:fs').then(({ readFileSync }) =>
-      readFileSync(require.resolve('next/dist/server/image-optimizer.js'), 'utf8')
-    );
-    const unblockCall = /unblock\(\{\s*operation:\s*\[([^\]]*)\]/.exec(optimizerSource);
-    expect(unblockCall, 'next image-optimizer no longer has a sharp.unblock call').not.toBeNull();
-    expect(unblockCall![1]).toContain('VipsForeignLoadSvg');
+    // than only that a render broke. It reads Next's shipped source rather than
+    // our patch file, so re-installing without the patch fails here too.
+    //
+    // The assertion itself lives in the script rather than here, and this case
+    // shells out to it, for two reasons. One rule, one place: this file is in the
+    // report-only `Unit tests` job, and the same check also has to run in a
+    // BLOCKING job — two copies of the regex would drift, and the copy that
+    // gates is the one that would go stale unnoticed. And running it as a
+    // subprocess means this case exercises the exact command CI runs, exit code
+    // included, rather than something merely equivalent to it.
+    const script = join(process.cwd(), 'scripts/ci/assert-next-svg-patch-applied.mjs');
+    // Positive control on the plumbing: from a wrong cwd the spawn below fails
+    // for a reason that has nothing to do with the loader, and the point of this
+    // case is that a failure names the loader.
+    expect(existsSync(script), `guard script not found at ${script}`).toBe(true);
+
+    // `spawnSync`, not `execFileSync`: on a non-zero exit the latter throws an
+    // Error whose message is only "Command failed: node <path>" and keeps stderr
+    // on a property vitest never prints. The whole point of this case is that a
+    // RED run names the missing loader, so the script's own output has to reach
+    // the assertion message.
+    const run = spawnSync(process.execPath, [script], { encoding: 'utf8' });
+    const output = `${run.stdout ?? ''}${run.stderr ?? ''}`;
+    expect(run.status, output).toBe(0);
+    // Never let a silent no-op pass for a green: the script prints how many
+    // copies of image-optimizer.js it actually read, and zero is a vacuous OK.
+    expect(output).toMatch(/copies of image-optimizer\.js read: [1-9]/);
+    expect(output).toContain('VipsForeignLoadSvg');
   });
 });

--- a/src/tests/api/og.image-optimizer-sharp.test.ts
+++ b/src/tests/api/og.image-optimizer-sharp.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+/**
+ * Regression guard for the `/api/og` outage that started 2026-08-08.
+ *
+ * WHAT BROKE. Next 16.3.0 hardened the built-in image optimizer by applying a
+ * process-global libvips operation block the first time it initializes `sharp`:
+ *
+ *     _sharp.block({ operation: ['VipsForeignLoad'] })
+ *     _sharp.unblock({ operation: ['VipsForeignLoadHeif', 'VipsForeignLoadJpeg',
+ *                                  'VipsForeignLoadNsgif', 'VipsForeignLoadPng',
+ *                                  'VipsForeignLoadTiff', 'VipsForeignLoadWebp'] })
+ *
+ * Every raster loader is re-enabled; the SVG loader is not. But `next/og`
+ * rasterizes satori's SVG output through that same `sharp` instance
+ * (`sharp(svgBuffer).resize(w).png().toBuffer()`), so once anything touches the
+ * image optimizer, EVERY `ImageResponse` in the process throws
+ * `Input buffer contains unsupported image format` — and `/api/og` returns 500
+ * for the rest of that pod's life. Upstream: vercel/next.js#96301 introduced it,
+ * vercel/next.js#96681 fixes it by adding `'VipsForeignLoadSvg'` to the unblock
+ * list. We carry that one-line fix as `patches/next.patch` until we are on a
+ * Next release that contains it.
+ *
+ * WHY THIS TEST IS SHAPED THE WAY IT IS. 🔴 The ordering is the whole test.
+ * Rendering an `ImageResponse` in a fresh process SUCCEEDS even on a broken
+ * build — the block has not been applied yet. Any test that renders first is
+ * green through the outage. So `initializeNextImageOptimizerSharp()` below is
+ * not setup noise: it is the step that reproduces the bug, and it deliberately
+ * calls Next's OWN `getSharp()` rather than re-implementing the block list, so
+ * the test tracks whatever Next actually ships instead of a stale copy.
+ *
+ * The first case is the positive control for the harness: it renders BEFORE the
+ * optimizer is touched. If it ever fails, the harness itself is broken and the
+ * second case's verdict means nothing. The second case is the regression guard.
+ *
+ * Watched red/green (2026-08-09, Next 16.3.0):
+ *   - without patches/next.patch: case 1 PASSES, case 2 FAILS with
+ *     "Input buffer contains unsupported image format" — the verbatim
+ *     production error.
+ *   - with patches/next.patch: both pass.
+ *
+ * SCOPE / WHAT THIS DOES NOT COVER. This runs in-process, so it does not cover
+ * packaging failures under `output: 'standalone'` (the OTHER way `/api/og` has
+ * broken — see the `outputFileTracingIncludes['/api/og']` entry in
+ * next.config.mjs and #2509). `tests/preview-og.spec.ts` covers that over HTTP
+ * against the built preview image.
+ */
+
+const PNG_MAGIC = '89504e470d0a1a0a';
+
+// The FallbackCard path — the handler's no-entity branch. `dbRead.model.findFirst`
+// resolving null makes fetchModelData return null, which renders FallbackCard
+// inside the main `try` (NOT via the catch). Chosen deliberately: it is the only
+// /api/og render path with no database, no network and no fixtures, so this test
+// exercises the renderer and nothing else.
+vi.mock('~/server/db/client', () => ({
+  dbRead: {
+    model: { findFirst: vi.fn().mockResolvedValue(null) },
+    modelMetric: { findUnique: vi.fn().mockResolvedValue(null) },
+    image: { findFirst: vi.fn().mockResolvedValue(null) },
+  },
+  dbWrite: {},
+  dbKV: {},
+}));
+
+import handler from '~/pages/api/og';
+
+type CapturedRes = NextApiResponse & {
+  _status: number;
+  _headers: Record<string, string>;
+  _body: unknown;
+};
+
+function makeRes(): CapturedRes {
+  const res = { _status: 200, _headers: {}, _body: undefined } as unknown as CapturedRes;
+  res.status = vi.fn((code: number) => {
+    res._status = code;
+    return res;
+  }) as any;
+  res.setHeader = vi.fn((k: string, v: string) => {
+    res._headers[k.toLowerCase()] = v;
+    return res;
+  }) as any;
+  res.send = vi.fn((body: unknown) => {
+    res._body = body;
+    return res;
+  }) as any;
+  res.json = vi.fn((body: unknown) => {
+    res._body = body;
+    return res;
+  }) as any;
+  res.end = vi.fn(() => res) as any;
+  return res;
+}
+
+function makeReq(query: Record<string, string>): NextApiRequest {
+  return { method: 'GET', query, headers: {} } as unknown as NextApiRequest;
+}
+
+async function renderOg(query: Record<string, string>) {
+  const res = makeRes();
+  await handler(makeReq(query), res);
+  return res;
+}
+
+/**
+ * Do exactly what the running Next server does on the first `/_next/image`
+ * cache miss: initialize the image optimizer's `sharp`, which applies the
+ * process-global libvips block. Imported from Next's own module on purpose —
+ * a hand-copied block list here would keep passing after Next changed it.
+ */
+async function initializeNextImageOptimizerSharp() {
+  const { getSharp } = await import('next/dist/server/image-optimizer.js');
+  // (concurrency, operationCache) — both nullable; the server passes its config
+  // values, and neither affects the block/unblock this test is about.
+  const sharp = getSharp(undefined, undefined);
+  // Positive control on the setup step itself: a no-op `getSharp` (wrong export,
+  // renamed module, silently caught failure) would make the guard below vacuous.
+  expect(typeof sharp).toBe('function');
+  return sharp;
+}
+
+// The handler swallows the real reason: its outer catch logs, and its inner catch
+// is bare, so a 500 body says only "Failed to generate OG image". Capturing the
+// log makes the RED run name the actual defect
+// ("Input buffer contains unsupported image format") instead of just "500 != 200".
+let ogErrorLogs: unknown[][] = [];
+beforeEach(() => {
+  ogErrorLogs = [];
+  vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+    if (String(args[0]).startsWith('OG image generation failed')) ogErrorLogs.push(args);
+  });
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function expectPngResponse(res: CapturedRes) {
+  // Assert the render never fell into the catch first: this is what carries the
+  // real error text into the failure output.
+  expect(ogErrorLogs.map((a) => String(a[1]))).toEqual([]);
+  expect(res._status).toBe(200);
+  expect(res._headers['content-type']).toBe('image/png');
+  expect(Buffer.isBuffer(res._body)).toBe(true);
+  const body = res._body as Buffer;
+  expect(body.subarray(0, 8).toString('hex')).toBe(PNG_MAGIC);
+  // A 1200x630 card is tens of KB; anything under 1 KB is a truncated/blank encode.
+  expect(body.byteLength).toBeGreaterThan(1024);
+}
+
+describe('/api/og — renders a PNG after the Next image optimizer initializes sharp', () => {
+  it('positive control: renders a PNG in a pristine process (optimizer untouched)', async () => {
+    expectPngResponse(await renderOg({ type: 'model', id: '999999999' }));
+  });
+
+  it('still renders a PNG once the image optimizer has applied its sharp block', async () => {
+    await initializeNextImageOptimizerSharp();
+
+    // The bug: this render throws "Input buffer contains unsupported image
+    // format" inside next/og, the handler's inner catch also throws for the same
+    // reason, and the endpoint returns 500 for every request from here on.
+    expectPngResponse(await renderOg({ type: 'model', id: '999999999' }));
+  });
+
+  it('the image optimizer un-blocks the SVG loader that next/og depends on', async () => {
+    // Structural companion to the behavioural guard above: assert the actual
+    // remedy is present in the artifact we install, so a failure says WHY rather
+    // than only that a render broke. Reads Next's shipped source rather than our
+    // patch file, so re-installing without the patch fails here too.
+    const optimizerSource = await import('node:fs').then(({ readFileSync }) =>
+      readFileSync(require.resolve('next/dist/server/image-optimizer.js'), 'utf8')
+    );
+    const unblockCall = /unblock\(\{\s*operation:\s*\[([^\]]*)\]/.exec(optimizerSource);
+    expect(unblockCall, 'next image-optimizer no longer has a sharp.unblock call').not.toBeNull();
+    expect(unblockCall![1]).toContain('VipsForeignLoadSvg');
+  });
+});

--- a/src/tests/api/og.image-optimizer-sharp.test.ts
+++ b/src/tests/api/og.image-optimizer-sharp.test.ts
@@ -19,8 +19,8 @@ import type { NextApiRequest, NextApiResponse } from 'next';
  * `Input buffer contains unsupported image format` — and `/api/og` returns 500
  * for the rest of that pod's life. Upstream: vercel/next.js#96301 introduced it,
  * vercel/next.js#96681 fixes it by adding `'VipsForeignLoadSvg'` to the unblock
- * list. We carry that one-line fix as `patches/next.patch` until we are on a
- * Next release that contains it.
+ * list. We carry that one-line fix as `patches/next@16.3.0.patch` until we are on
+ * a Next release that contains it (stable 16.3.1 is not out yet).
  *
  * WHY THIS TEST IS SHAPED THE WAY IT IS. 🔴 The ordering is the whole test.
  * Rendering an `ImageResponse` in a fresh process SUCCEEDS even on a broken
@@ -35,10 +35,10 @@ import type { NextApiRequest, NextApiResponse } from 'next';
  * second case's verdict means nothing. The second case is the regression guard.
  *
  * Watched red/green (2026-08-09, Next 16.3.0):
- *   - without patches/next.patch: case 1 PASSES, case 2 FAILS with
- *     "Input buffer contains unsupported image format" — the verbatim
- *     production error.
- *   - with patches/next.patch: both pass.
+ *   - patch REMOVED and reinstalled: case 1 PASSES (harness fine), case 2 FAILS
+ *     with "Input buffer contains unsupported image format" — the verbatim
+ *     production error — and case 3 FAILS naming the missing loader.
+ *   - patch APPLIED: all three pass.
  *
  * SCOPE / WHAT THIS DOES NOT COVER. This runs in-process, so it does not cover
  * packaging failures under `output: 'standalone'` (the OTHER way `/api/og` has

--- a/tests/preview-og.spec.ts
+++ b/tests/preview-og.spec.ts
@@ -1,0 +1,159 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * HTTP-level regression guard for `/api/og` (Open Graph preview cards) against a
+ * DEPLOYED, PRODUCTION-BUILT server. Runs under playwright.preview.config.ts —
+ * the `preview-*.spec.ts` filename is what enrolls it in the `preview-smoke`
+ * project, so this needs no pipeline change.
+ *
+ * WHY OVER HTTP AND NOT IN A UNIT TEST. `/api/og` has now broken twice, and both
+ * times the defect lived in the built artifact / the running server rather than
+ * in the card components:
+ *
+ *   1. `@vercel/og`'s dynamic require could not be traced under
+ *      `output: 'standalone'`, so the module was dropped from the image
+ *      (see `outputFileTracingIncludes['/api/og']` in next.config.mjs).
+ *   2. Next's image optimizer applies a process-global libvips block the first
+ *      time it initializes `sharp`, and the SVG loader `next/og` needs was not
+ *      re-enabled — so every render threw once the optimizer had run.
+ *
+ * A test that renders the card component in-process is green through BOTH. This
+ * one boots nothing itself; it exercises the real deployed server.
+ *
+ * 🔴 ORDER IS THE TEST. Case (2) only manifests AFTER the image optimizer has
+ * initialized sharp, which happens on the first `/_next/image` cache MISS — up
+ * to a minute into a pod's life. Request `/api/og` first and it passes on a
+ * broken build. So the first test forces an optimizer cache miss and asserts
+ * `x-nextjs-cache: MISS`, which is what stops the ordering step from silently
+ * becoming a no-op (a cache HIT never calls `getSharp()`).
+ *
+ * HONEST LIMITS.
+ *  - The ordering only holds when the warmup and the `/api/og` request reach the
+ *    same process. A PR preview is a single replica (see the serial/worker notes
+ *    in playwright.preview.config.ts), so it does; pointed at a multi-replica
+ *    deployment the ordering degrades to "probably".
+ *  - Previews are opt-in behind the `preview` label, and the smoke step is
+ *    report-only, so this is a signal rather than a merge gate today.
+ *
+ * The in-process companion guard, which has neither limitation but also cannot
+ * see packaging failures, is `src/tests/api/og.image-optimizer-sharp.test.ts`.
+ */
+
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+// A small PNG that ships in `public/`, so the optimizer resolves it locally with
+// no dependency on remote image hosts.
+const LOCAL_IMAGE = '/images/logo_dark_mode.png';
+
+const bust = () => `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+function expectOgPng(body: Buffer, headers: Record<string, string>) {
+  expect(headers['content-type'], 'content-type').toContain('image/png');
+  expect(
+    body.subarray(0, 8).equals(PNG_MAGIC),
+    `PNG magic (got ${body.subarray(0, 8).toString('hex')})`
+  ).toBe(true);
+  // A 1200x630 card is tens of KB; under 1 KB means a truncated or blank encode.
+  expect(body.byteLength, 'PNG byte length').toBeGreaterThan(1024);
+}
+
+// `w` is the only usable cache-buster. The optimizer key is (url, w, q); `q` must
+// be one of `images.qualities` (default `[75]`), and a query string on a LOCAL
+// `url` is a flat 400 because Next's default `localPatterns` requires an empty
+// search (measured 2026-08-09: `/_next/image?url=%2Fx.png%3Fcb%3D1` → 400). So
+// walk the configured widths — Next's default `imageSizes` then `deviceSizes` —
+// until one is cold. Cheapest first; a fresh pod misses on the very first.
+// A width the server rejects is skipped, not fatal, so re-tuning `images.*`
+// narrows this list instead of breaking the test.
+// (`16` is deliberately absent: this deployment answers 400 for it.)
+const CANDIDATE_WIDTHS = [32, 48, 64, 96, 128, 256, 384, 640, 750, 828, 1080, 1200, 1920, 2048];
+
+// Serial: the warmup must run before the renders, and serial is the only thing
+// that guarantees that independently of the config's `workers`/`fullyParallel`.
+// A failure here correctly aborts the rest of the group — the ordering premise is
+// gone, so their verdicts would be meaningless.
+test.describe('render path (requires the optimizer to have run first)', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('image optimizer initializes sharp (cache miss)', async ({ request }) => {
+    const seen: string[] = [];
+    let servedAnImage = false;
+    let missed = false;
+
+    for (const w of CANDIDATE_WIDTHS) {
+      const resp = await request.get(
+        `/_next/image?url=${encodeURIComponent(LOCAL_IMAGE)}&w=${w}&q=75`
+      );
+      if (resp.status() !== 200) {
+        seen.push(`${w}:HTTP${resp.status()}`);
+        continue;
+      }
+      expect(resp.headers()['content-type'], `optimizer content-type at w=${w}`).toMatch(
+        /^image\//
+      );
+      servedAnImage = true;
+
+      // The header's PRESENCE is what distinguishes "Next's image optimizer served
+      // this" from "a static file server or CDN did" — and only the optimizer path
+      // reaches `getSharp()`.
+      const state = resp.headers()['x-nextjs-cache'];
+      expect(state, `x-nextjs-cache at w=${w} (absent ⇒ the optimizer never ran)`).toBeDefined();
+      seen.push(`${w}:${state}`);
+      if (state === 'MISS') {
+        missed = true;
+        break;
+      }
+    }
+
+    const tried = seen.join(', ');
+    expect(servedAnImage, `the image optimizer served nothing at any width — tried ${tried}`).toBe(
+      true
+    );
+    // A HIT is served straight from the cache WITHOUT calling `getSharp()` — and
+    // that cache is on disk, so it outlives the process. A HIT is therefore not
+    // evidence that sharp was initialized in the process now serving us, and
+    // accepting one would make every assertion below vacuous. Demand a real MISS.
+    //
+    // Exhausting the list means the precondition genuinely could not be established
+    // on this run — a red worth seeing rather than a green worth nothing. It cannot
+    // happen on a freshly deployed preview pod (empty `.next/cache/images`); it does
+    // happen when re-running against an already-warm server.
+    expect(missed, `no cold optimizer width left to force a MISS — tried ${tried}`).toBe(true);
+  });
+
+  test('/api/og renders a PNG for a missing entity (FallbackCard path)', async ({ request }) => {
+    // Deliberately DB-independent: no such model, so the handler renders the
+    // generic card. No fixtures, no seeded ids, nothing to rot.
+    const resp = await request.get(`/api/og?type=model&id=999999999&cb=${bust()}`);
+    const body = await resp.body();
+
+    expect(resp.status(), `status (body: ${body.subarray(0, 200).toString('utf8')})`).toBe(200);
+    expectOgPng(body, resp.headers());
+  });
+
+  test('/api/og renders a PNG for a real model (OgCard path)', async ({ request }) => {
+    // The card branch is separate code from the fallback branch, so cover it too —
+    // but discover the id rather than pinning one, since a preview can point at
+    // either the dev or the prod database.
+    const list = await request.get('/api/v1/models?limit=1&sort=Most%20Downloaded');
+    test.skip(
+      !list.ok(),
+      `could not list models to pick a subject (HTTP ${list.status()}) — OgCard path not covered`
+    );
+    const id = (await list.json())?.items?.[0]?.id as number | undefined;
+    test.skip(typeof id !== 'number', 'no published models available — OgCard path not covered');
+
+    const resp = await request.get(`/api/og?type=model&id=${id}&cb=${bust()}`);
+    const body = await resp.body();
+
+    expect(resp.status(), `status (body: ${body.subarray(0, 200).toString('utf8')})`).toBe(200);
+    expectOgPng(body, resp.headers());
+  });
+});
+
+// Outside the serial group on purpose: it does not depend on the optimizer having
+// run, so it should still report when the renders above are broken.
+test('/api/og rejects a malformed query with 400, not 500', async ({ request }) => {
+  const resp = await request.get(`/api/og?type=nonsense&id=abc&cb=${bust()}`);
+  expect(resp.status()).toBe(400);
+});


### PR DESCRIPTION
## What's broken

`GET /api/og` — the endpoint that renders the Open Graph preview card behind every civitai link shared to Discord, X, Reddit, Slack — returns **HTTP 500 on effectively 100% of origin requests**, and has since **2026-08-08 ~06:00 UTC**. Per-endpoint success rate over the last 43+ hours is **0.00%**; the 16 hours before the break were 100%. It is ~99% of all app 500s (~3,300 req/h).

Two things kept it invisible:

- **Nobody on-site hits it.** Only unfurlers request `/api/og`, so no user-facing page broke.
- **The CDN masks it.** The handler sets `s-maxage=604800`, so the *last successful* render before the break is still being served at the edge for popular entities. A plain `curl https://civitai.com/api/og?type=model&id=<id>` returns `200 image/png`. Cache-busted, **0 of 40** requests to the same URL returned 200.

## Root cause

Next **16.3.0** hardened the built-in image optimizer ([vercel/next.js#96301]). The first time `getSharp()` runs it applies a **process-global** libvips operation block and then re-enables a fixed list:

```js
_sharp.block({ operation: ['VipsForeignLoad'] })
_sharp.unblock({ operation: [
  'VipsForeignLoadHeif', 'VipsForeignLoadJpeg', 'VipsForeignLoadNsgif',
  'VipsForeignLoadPng',  'VipsForeignLoadTiff', 'VipsForeignLoadWebp',
] })
```

Every **raster** loader is back. **SVG is not.** But `next/og` rasterizes satori's SVG output through that same sharp instance — `sharp(svgBuffer).resize(w).png().toBuffer()` in `next/dist/compiled/@vercel/og/index.node.js`. So the moment anything touches the image optimizer — the first `/_next/image` cache miss, tens of seconds into a process's life — **every `ImageResponse` in that process throws `Input buffer contains unsupported image format`, permanently**. Both tiers of `/api/og`'s fallback call `ImageResponse`, so the endpoint 500s outright with `{"error":"Failed to generate OG image"}`.

The version bisect matches the onset exactly: the Next 16.3.0 upgrade (`d1b3241814`, #3742) merged 2026-08-07; the break starts 2026-08-08.

Upstream fixed it in **[vercel/next.js#96681]** — literally one array entry, `'VipsForeignLoadSvg'` — backported in #96733, present from `16.3.1-canary.4`.

## The fix

**Stable 16.3.1 is not released** (npm `latest` is still `16.3.0`), so this carries upstream's one-line change as a `pnpm patch`:

```diff
diff --git a/dist/server/image-optimizer.js b/dist/server/image-optimizer.js
@@ -210,6 +210,7 @@ function getSharp(concurrency, operationCache) {
                  'VipsForeignLoadJpeg',
                  'VipsForeignLoadNsgif',
                  'VipsForeignLoadPng',
 +                'VipsForeignLoadSvg',
                  'VipsForeignLoadTiff',
                  'VipsForeignLoadWebp'
              ]
```

That is the entire patch — one line, no reformatting.

🔴 **Remove `patches/next@16.3.0.patch` and its `patchedDependencies` entry when we move to Next ≥ 16.3.1.** The patch key is version-pinned (`next@16.3.0`), so a Next bump fails the install rather than silently carrying a stale patch forward. Verified rather than assumed — repinning the key to `next@16.3.1` and reinstalling gives:

```
ERR_PNPM_UNUSED_PATCH  The following patches were not used: next@16.3.1
Either remove them from "patchedDependencies" or update them to match packages in your dependencies.
```

exit 1. So the upgrade cannot quietly drop the fix *or* quietly keep a dead patch.

### Alternatives considered and rejected

- **Bump the app's `sharp` `^0.32.6` → `^0.35.3`** so it shares Next's instance. It *would* fix `/api/og`, but it hands the app Next's process-global block and breaks two live App Blocks SVG paths — `app-listing-assets.service.ts`'s `rasterizeSvg()` and `listing-meta.service.ts`'s inline-icon ingest (which accepts `image/svg+xml`). Those work today only because the app's 0.32.6 is a separate, never-blocked instance. The asset backfill has per-row `try/catch`, so it would fail **silently**.
- **`images.dangerouslyAllowSVG`.** Checked against the 16.3.0 source: it gates only the upstream *content-type* check for remote images. There is exactly one `unblock` call site with a fixed list. No effect here.
- **A startup-time `sharp.unblock(...)`.** Inert — Next memoizes `_sharp` and applies the block lazily on first optimizer use, undoing anything done earlier.
- **Upgrading to `16.3.1-canary.9`.** Works, but drags nine canaries of unrelated churn into a production deploy.

## Tests

🔴 **The ordering is the whole test.** Rendering an `ImageResponse` in a fresh process **succeeds** even on a broken build — the block hasn't been applied yet. Any test that requests `/api/og` first is green straight through this outage. That is precisely why nothing caught it, and it is why a unit test that imports and renders the card component would be **worse than no test**: it manufactures the appearance of coverage over the exact gap that keeps producing outages.

Two guards, because the two ways this endpoint has broken need different instruments.

### 1. `src/tests/api/og.image-optimizer-sharp.test.ts` — runs in CI's `Unit tests` job

Initializes sharp through **Next's own `getSharp()`**, imported from `next/dist/server/image-optimizer.js` rather than re-implementing its block list (so it tracks whatever Next actually ships), then drives the **real handler** down its DB-free `FallbackCard` path and asserts `200` + `content-type: image/png` + PNG magic `89504e470d0a1a0a` + a non-trivial body. Three cases:

| # | case | role |
|---|---|---|
| 1 | render in a pristine process, optimizer untouched | **positive control for the harness** — if this fails, case 2's verdict means nothing |
| 2 | render *after* `getSharp()` has applied the block | **the regression guard** |
| 3 | Next's shipped `unblock` list contains `VipsForeignLoadSvg` | structural companion, so a failure says *why* rather than only that a render broke |

Case 2 also spies on the handler's `console.error`, because the handler's inner catch is bare and a 500 body says only "Failed to generate OG image" — this is what carries the real error text into the failure output.

### 2. `tests/preview-og.spec.ts` — HTTP, against the deployed production build

Enrolled in the existing preview smoke project purely by filename; **no pipeline change**. Forces an image-optimizer cache miss, then asserts `200` + PNG on the `FallbackCard` and `OgCard` paths, plus `400` (not 500) on a malformed query.

The warmup step walks the configured widths until it observes `x-nextjs-cache: MISS`. That is a **positive control on the ordering**: a cache HIT is served without calling `getSharp()`, and that cache is on disk so it outlives the process — accepting a HIT would make every following assertion vacuous. If no cold width is left, the test fails naming what it tried, rather than passing on a precondition it never established. (Verified while writing it: re-running against a warm server produces exactly that red, not a false green.)

This is the only one of the two that can see a **packaging** failure under `output: 'standalone'` — which is how `/api/og` broke the previous time (#2509, the `outputFileTracingIncludes['/api/og']` entry in `next.config.mjs`).

Notes on `/_next/image` behaviour, measured rather than assumed:
- A query string on a **local** `url` is a flat **400** — Next's default `localPatterns` requires an empty search. So `w` is the only usable cache-buster; `q` must be one of `images.qualities` (default `[75]`).
- `w=16` answers 400 on this deployment, so it is excluded; a width the server rejects is skipped rather than fatal.

## 🔴 Red/green matrix — watched, not assumed

**Unit test** (`vitest run --project unit src/tests/api/og.image-optimizer-sharp.test.ts`):

| build | case 1 (control) | case 2 (guard) | case 3 (structural) |
|---|---|---|---|
| **without** the patch | ✅ pass | ❌ **fail** | ❌ **fail** |
| **with** the patch | ✅ | ✅ | ✅ (3 passed) |

Verbatim red output for case 2 — the production error, reproduced:

```
AssertionError: expected [ Array(1) ] to deeply equal []
- []
+ [ "Error: Input buffer contains unsupported image format" ]
```

and case 3:

```
AssertionError: expected '\n  \'VipsForeignLoadHe…' to contain 'VipsForeignLoadSvg'
```

**HTTP test** (`playwright test -c playwright.preview.config.ts --project=preview-smoke tests/preview-og.spec.ts`), three targets:

| target | result |
|---|---|
| **production `https://civitai.com`** (the live broken artifact), 2026-08-09 | ❌ warmup ✅ MISS → `FallbackCard` case **fails: HTTP 500, body `{"error":"Failed to generate OG image"}`**; malformed-query 400 case ✅ |
| **local server, patch reverted**, cold optimizer cache | ❌ warmup ✅ MISS → `FallbackCard` case **fails: HTTP 500**, same body |
| **local server, patch applied**, cold optimizer cache | ✅ 3 passed, 1 skipped (`OgCard` case self-skips with a stated reason — no database available locally) |
| **this PR's deployed preview** — a real `output: 'standalone'` production image, patch applied | ✅ **4 passed, 0 skipped** — including the `OgCard` real-entity path |
| **PR #3766's deployed preview** — also `output: 'standalone'`, also Next 16.3.0, **no patch** | ❌ warmup ✅ MISS → `FallbackCard` **fails: HTTP 500, `{"error":"Failed to generate OG image"}`** |

The patch-reverted local run was produced by removing the `patchedDependencies` entry, reinstalling (confirmed `VipsForeignLoadSvg` absent from the installed artifact), and restarting the server — same target, same command, one variable.

The last two rows are the strongest evidence here: **two production standalone builds, the same spec, the same command, differing only in this patch** — one green, one 500. #3766 is an independent, unrelated PR that also branches off `main` after the Next 16.3.0 upgrade and carries only the pre-existing `@mantine/hooks` patch (verified by reading its `package.json` at `065d934f`), so it is a clean negative control rather than a construction of mine.

## Gates

| gate | result |
|---|---|
| `pnpm run typecheck` | **0 type errors** (`typecheck: OK — 0 type errors in 11s`). Watched go red first: it caught a real `TS2554` in the new test, which I fixed — so this verdict is not an empty log. |
| `pnpm run test:unit:run` (full suite) | **892 files, 13,756 passed, 1 skipped, 0 failed**, 0 test-timeout panics. Confirms the new test's process-global sharp block does not leak into other files. |
| `eslint` on the added `src/` file | exit 0 — 5 `no-explicit-any` **warnings** on the hand-rolled `NextApiResponse` mock, matching the existing convention in `src/tests/api/internal/ping.test.ts`. CI's added-file step fails on errors only. |
| `prettier --list-different` on added files | clean. `patches/next@16.3.0.patch` yields `No parser could be inferred` on **stderr** with exit 0 and empty stdout, so CI's added-file step is unaffected (verified with the streams separated). |
| `pnpm-lock.yaml` prettier | differs — **pre-existing**: `origin/main`'s copy differs identically. Modified-file prettier is report-only. |
| clean install | `rm -rf node_modules && pnpm install --frozen-lockfile` → exit 0, patch applied, `VipsForeignLoadSvg` present in `node_modules/next/dist/server/image-optimizer.js`, lockfile unchanged. |
| CI `Unit tests` job on this PR | **892 files, 13,756 passed, 1 skipped**, and the log shows `✓ unit src/tests/api/og.image-optimizer-sharp.test.ts (3 tests)`. Cases 2 and 3 could only pass because CI's own `pnpm install --frozen-lockfile` applied the patch — so this is end-to-end evidence that a clean install in a fresh environment picks it up. |

## Not verified / out of scope

- ~~Not verified in a `next build` / `output: 'standalone'` artifact.~~ **Now closed** — see the last two rows of the matrix above: green on this PR's standalone preview, red on an unpatched one.
- ~~The `OgCard` (real-entity) branch has not been watched green.~~ **Now closed** — it passed against this PR's preview, which has a real database.
- **Coverage is a signal, not a gate.** Previews are opt-in behind the `preview` label and the smoke step is report-only; CI's `Unit tests` job is `continue-on-error`. So neither guard *blocks* a merge today.
- **The ordering guarantee is per-process.** It holds on a single-replica preview; against a multi-replica deployment the warmup and the `/api/og` request may land on different processes.
- **This PR does not make `/api/og` un-500-able.** It fixes *this* cause. Both tiers of the handler's fallback still call `ImageResponse`, so they share every failure mode of that call — the second tier reduces the *input*, not the *machinery*, and both outages to date were machinery failures. A genuinely independent last-resort tier is worth doing separately.

[vercel/next.js#96301]: https://github.com/vercel/next.js/pull/96301
[vercel/next.js#96681]: https://github.com/vercel/next.js/pull/96681

🤖 Generated with [Claude Code](https://claude.com/claude-code)
