### PR TITLE
chore(deps): bump @pyroscope/nodejs 0.6.1 -> 0.6.2 (upload-path memory leak fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "@paypal/react-paypal-js": "^8.1.3",
     "@prisma/client": "^6.3.0",
     "@prisma/instrumentation": "^7.4.2",
-    "@pyroscope/nodejs": "0.6.1",
+    "@pyroscope/nodejs": "0.6.2",
     "@react-hook/window-size": "^3.1.1",
     "@react-pdf/renderer": "^3.3.8",
     "@stripe/react-stripe-js": "^2.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,8 +221,8 @@ importers:
         specifier: ^7.4.2
         version: 7.4.2(@opentelemetry/api@1.9.0)
       '@pyroscope/nodejs':
-        specifier: 0.6.1
-        version: 0.6.1(fastify@5.9.0)
+        specifier: 0.6.2
+        version: 0.6.2(fastify@5.9.0)
       '@react-hook/window-size':
         specifier: ^3.1.1
         version: 3.1.1(react@18.3.1)
@@ -4069,8 +4069,8 @@ packages:
   '@protobufjs/utf8@1.1.2':
     resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
-  '@pyroscope/nodejs@0.6.1':
-    resolution: {integrity: sha512-6CiE3Vs+q99flTeJlus03d4cGphYnqPgJLEYbhpRWVtwdvPWYqft0XdTyMi97kFcTTOWjcEHXXhzGUmFQfDTHQ==}
+  '@pyroscope/nodejs@0.6.2':
+    resolution: {integrity: sha512-o1tmdpDiWnY8G1RYid1isLvFPTU5MW0f1B99WjrL9TubsfjSvK+q/I90s5YmooyRRG+3MgcL0RbPQIvEt0oGOA==}
     engines: {node: '>=20.20.2'}
     peerDependencies:
       express: ^4.0.0 || ^5.0.0
@@ -15932,7 +15932,7 @@ snapshots:
 
   '@protobufjs/utf8@1.1.2': {}
 
-  '@pyroscope/nodejs@0.6.1(fastify@5.9.0)':
+  '@pyroscope/nodejs@0.6.2(fastify@5.9.0)':
     dependencies:
       '@datadog/pprof': 5.14.4
       debug: 4.4.3


### PR DESCRIPTION
Bumps `@pyroscope/nodejs` from `0.6.1` to `0.6.2` (published 2026-07-28, current `latest`).

## Why

0.6.2 fixes a **native memory leak in the profile-upload path**. The old FormData/Blob upload pinned an ArrayBuffer per flush: undici's `fetch` serializes Blob parts through `Blob.prototype.stream()`, which retains the source buffer forever. 0.6.2 drops the multipart path entirely and sends the gzipped pprof bytes raw to `/ingest?format=pprof`.

- Upstream fix: grafana/pyroscope-nodejs#316 ("fix: drop multipart upload path; ingest with format=pprof", merged 2026-07-27)
- Underlying Node bug: nodejs/node#63574 ("Blob.prototype.stream() memory-leaks the source buffer")

The leak affects **Node 24.16+**. This app is in that range — `.nvmrc` pins `24.18.0` and the runtime image is `node:24-alpine3.24`.

## What this is not

**We have not observed or measured this leak in our own environment.** It is native memory, so it does not show up in V8 heap snapshots. This is a precautionary bump onto an upstream fix for a version range we are in — not a response to an observed incident.

## Risk

Low. The profiler itself is unchanged — `@datadog/pprof` is pinned to exactly `5.14.4` in both 0.6.1 and 0.6.2, and it stays at `5.14.4` in the lockfile after this bump. Only the SDK's upload path moves.

Comparing the two published tarballs, exactly 9 files differ, and they are all accounted for by this change:

- `pyroscope-api-exporter.{js,d.ts}` (cjs + esm) — the upload path
- `version.{js,d.ts}` (cjs + esm) — version string
- `package.json` — version bump

No files added or removed. `index.d.ts` and `pyroscope-config.d.ts` are **byte-identical**, so the public API surface we consume (`Pyroscope.init(...)` / `Pyroscope.startWallProfiling()` in `src/server/pyroscope.ts`) is unchanged. The only type-level change is a rename of a **private** method (`buildUploadProfileFormData` → `buildUploadProfileBody`).

## Verification

- Lockfile updated with the repo's own pnpm (`10.28.1`); diff is 3 hunks, all `@pyroscope/nodejs` (specifier, integrity hash, snapshot key). No unrelated churn.
- `@datadog/pprof` confirmed unmoved: all 3 occurrences in the lockfile still read `5.14.4`, at the same line numbers as before the bump.
- `pnpm install --frozen-lockfile` passes across all 23 workspace projects (validated against a deliberately mismatched manifest first, which correctly failed with `ERR_PNPM_OUTDATED_LOCKFILE`).
