### PR TITLE
test: fail loudly when a submodule is missing, instead of losing 971 tests quietly

### DIFF
--- a/claudedocs/red-test-triage-2026-08-10.md
+++ b/claudedocs/red-test-triage-2026-08-10.md
@@ -1,0 +1,194 @@
+# Triage: the "16 pre-existing test failures on main"
+
+**Measured 2026-08-10.** Baseline commit `a43e49a4ba` (`origin/main`, "5.0.2262"), plus a
+second baseline at `2a2fe66428` — the tip of `main` on 2026-08-08, the day the ticket was
+filed. Every run below was made in a clean throwaway worktree off the remote tip, with a
+fresh `pnpm install --frozen-lockfile` and the `event-engine-common` submodule initialised
+unless stated otherwise.
+
+## Headline
+
+**The 16 failures do not exist on `main`, and did not exist on `main` on the day they were
+reported.** The full `unit` project is green at both commits, under three different Node
+versions, and so are the `packages` and `apps` projects. All five suites the ticket names
+by name pass, each collecting a non-zero number of tests.
+
+The failures were real observations of a real problem — but the problem was in the
+*environment the suite was run in*, not in the tests. A fresh `git worktree` does not check
+out submodules and does not carry the repo's gitignored `.envrc`, and each of those omissions
+produces a distinct block of false reds. That trap has been documented in prose in `CLAUDE.md`
+since #3567 (2026-08-04) and was walked into anyway, four days later, by three agents in a row.
+
+## Phase 1 — the measured baseline
+
+Three numbers, not one, because the failure mode at issue moves between them.
+
+| Run | Commit | Node | Failed FILES | Failed TESTS | Passed TESTS | Skipped | exit |
+|---|---|---|---|---|---|---|---|
+| unit, submodule **absent** | `a43e49a4ba` | 22.22.2 (flake) | **73** / 891 | **0** | 12,782 | 4 | 1 |
+| unit, submodule present | `a43e49a4ba` | 22.22.2 (flake) | 0 / 891 | 0 | 13,753 | 1 | 0 |
+| unit, submodule present | `a43e49a4ba` | 24.18.1 (`.nvmrc`/CI) | 0 / 891 | 0 | 13,753 | 1 | 1 † |
+| unit, submodule present | `a43e49a4ba` | 26.5.0 (ambient) | 1 / 891 | **7** | 13,746 | 1 | 1 |
+| unit, submodule present | `2a2fe66428` (2026-08-08) | 22.22.2 (flake) | 0 / 889 | 0 | 13,713 | 1 | 0 |
+| `packages` | `a43e49a4ba` | 22.22.2 | 0 / 73 (2 skipped) | 0 | 1,002 | 4 | 0 |
+| `apps` | `a43e49a4ba` | 22.22.2 | 0 / 53 | 0 | 507 | 0 | 0 |
+
+† 0 failed tests but a non-zero exit — see "Finding 3".
+
+The `component` (browser-mode) project was **not** run; it needs a Chromium whose revision
+matches the repo's Playwright pin, which this host does not currently have. That is stated
+as unmeasured, not as green.
+
+### Collected-tests-per-failing-file, for the one red run
+
+Of the 73 failing files in the submodule-absent run, **72 collected ZERO tests**. The 73rd
+(`prisma-inconsistent-orphan-relations.test.ts`) collected 6 and skipped 3, and failed via an
+unhandled rejection rather than an assertion.
+
+That is the whole shape of the trap: 72 files that *fail* without *failing a test*. The run
+reports **0 failed tests** and 12,782 passed. The green run reports 13,753 passed. So the
+broken run silently removed **971 tests** while its failed-test count read zero. A reader
+comparing failed-test counts sees "0 either way"; a reader comparing passed-test totals to a
+remembered number sees a drop with nothing to attribute it to.
+
+Root cause of all 73: `Cannot find module '../../../event-engine-common/...'` — the submodule
+is not checked out by `git worktree add`. 58 of the 73 name it directly in their error; the
+remainder are `vi.mock` factory errors cascading from the same unresolved import.
+
+## Phase 2 — classification
+
+Every suite the ticket names is **green and non-vacuous**. Each was mutation-tested: the thing
+it guards was broken on purpose, and the guard was watched to go red **with its own specific
+error message**, on an input no earlier check short-circuits.
+
+| Suite | Kind | State on `main` | Verdict |
+|---|---|---|---|
+| `src/server/services/__tests__/no-wholesale-module-mock.test.ts` | quality guard (ESLint RuleTester, 97 tests) | green | **Keep. Not vacuous — proven.** |
+| `src/server/middleware/__tests__/block-scope.normalize-endpoint.test.ts` | route-drift guard (27 tests) | green | **Keep. Not vacuous — proven.** |
+| `src/server/services/blocks/__tests__/app-spend-tier-privilege.test.ts` | privilege-surface drift guard (9 tests) | green | **Keep. Not vacuous — proven.** |
+| `src/server/services/comics/__tests__/orchestrator-chat.wait-unit.test.ts` | ledger drift guard (12 tests) | green | **Keep. Not vacuous — proven.** |
+| `scripts/__tests__/typecheck.test.ts` | wrapper-behaviour guard (5 tests) | green | **Keep. Not vacuous — proven.** |
+
+### Mutation evidence
+
+| Guard | Mutation applied | Result |
+|---|---|---|
+| `no-wholesale-module-mock` | Reintroduced the historical **textual** check in `eslint-local-rules.js` — treat any factory whose source text contains `importOriginal` as safe | 97 → **29 failed / 68 passed**, `AssertionError: Should have 1 error but had 0: []`. The killed cases are exactly the laundering cases (unused `importOriginal` param, a comment mentioning it, the bare string `'importOriginal'` as a value). |
+| route drift | Added `src/pages/api/v1/blocks/mutation-probe.ts` exporting `withBlockScope(...)` | 27 → **2 failed**: *"the allowlist is EXACTLY the static segments of the wrapped routes"* and *"pins the current set, so adding a route is a deliberate act"*, both diffing on the literal `"mutation-probe"`. |
+| spend-tier privilege | Added `const __probe = { spendTier: 'premium' }` to `src/pages/api/v1/developer/block-manifests.ts` (a publisher-reachable module) | 9 → **3 failed**, incl. `AssertionError: src/pages/api/v1/developer/block-manifests.ts must not reference spendTier in code`. |
+| wait-unit ledger | Added `src/server/services/comics/mutation-probe.ts` with `export const probeQuery = { wait: 60000 }` | 12 → **2 failed**: *"no statically-resolvable wait exceeds the seconds envelope"* and *"matches the known ledger of numeric wait sites"*, naming `server/services/comics/mutation-probe.ts:60000`. |
+| typecheck wrapper | Moved the one-line crash verdict from stdout to stderr in `scripts/typecheck.mjs` | 5 → **3 failed**, `AssertionError: expected '' to contain 'TYPECHECK CRASHED'`. |
+
+Every mutation was reverted and the five suites re-run together afterwards: **150 tests, all
+passing**, tracked tree byte-clean.
+
+### One scope correction to the ticket
+
+The ticket says `block-scope.normalize-endpoint.test.ts` "is exactly the guard that would have
+had an opinion about" the new `/api/testing/eventloop-stall` route added in #3752.
+
+It would not have, and this is worth knowing rather than assuming. That guard's walk matches
+only files whose default export is wrapped in `withBlockScope(...)`. `eventloop-stall.ts` is
+not block-scoped, so the guard is correctly silent about it. It *is* live for the routes it
+covers — the mutation above proves that — but it is a **block-scope allowlist** drift guard,
+not a general new-route detector. No such general guard exists. If one is wanted, that is a
+new piece of work, not a repair.
+
+## Phase 3 — what actually produced the 16
+
+Not reproduced exactly, and I will not claim otherwise. What *is* measured:
+
+**Finding 1 — the submodule (this is the big one).** Detailed above: 73 files fail, 72 collect
+zero tests, failed-test count reads 0, 971 tests vanish. An independent agent measuring a
+baseline on this same commit on the same day reported **73 failed files / 12,782 passed / 4
+skipped**, and 12 `pnpm typecheck` errors all from an un-checked-out `event-engine-common` —
+byte-for-byte the same artifact, arrived at independently. Their baseline is not `main`'s state.
+
+**Finding 2 — the missing `.envrc`.** `.envrc` is gitignored, so a fresh worktree silently gets
+system Node instead of the flake's pinned version. Measured here: under the ambient **Node
+26.5.0**, `hiddenBlocks.test.ts` fails **7** tests with `TypeError: Cannot read properties of
+undefined (reading 'clear')` on `window.localStorage` under happy-dom. Under the flake's Node
+22 and under Node 24, the same file passes. Running outside the flake also loses the Prisma
+engine env: I measured **6** `PrismaClientInitializationError: could not locate the Query Engine
+for runtime "linux-nixos"` unhandled rejections.
+
+`CLAUDE.md` already records this exact pair from a previous encounter: *"system Node 26.5.0
+against the flake's 22.22.2 produced 7 spurious `window.localStorage is undefined` failures
+under happy-dom plus 8 Prisma `linux-nixos` engine errors — every one a false red."* **7 + 8 =
+15**, against a reported 16. That is the closest match to the ticket's number that any
+mechanism here produces, it is the mechanism the repo had already written down, and the two
+halves are independently reproducible.
+
+**Finding 3 — under CI's own Node, the unit suite exits non-zero with zero failing tests.**
+At `a43e49a4ba` under Node 24.18.1 (what `.nvmrc` pins and what the CI job uses via
+`node-version-file`), the run reports 891/891 files and 13,753 passed, **0 failed** — and then
+`Errors 6 errors` and a non-zero exit, from Prisma-engine unhandled rejections. The CI `unit`
+job carries `continue-on-error: true`, so this is invisible there today. It will start
+mattering the moment that job is flipped to blocking, which its own comment says is the plan.
+Flagged, not fixed — the fix is environment-shaped and overlaps PR #3779.
+
+**Finding 4 — `git stash` was in the loop.** The ticket says the set "reproduces on a stashed
+clean tree". `git stash` is repo-**global**: `refs/stash` lives in the common git dir and is
+shared by every one of this clone's worktrees. Three agents stashing concurrently across a
+shared clone are not each producing a clean tree; they are pushing and popping one shared
+stack. That is consistent with three agents reporting an *identical* set from three different
+branches, and it is a hazard worth retiring independently of this ticket. Stated as mechanism,
+not as measurement — I did not reproduce it.
+
+## What was changed
+
+One file added: **`src/__tests__/submodules-checked-out.test.ts`**.
+
+It converts Finding 1 from a silent subtraction into one legible red line. It reads the
+submodule paths out of `.gitmodules` rather than hardcoding them, so a submodule added later is
+covered without anyone remembering, and it asserts three specific entry points so a *partial*
+checkout — which produces the identical vanish-without-failing symptom — is caught too. It
+imports nothing from the submodule, because a guard that fails to load for the very reason it
+exists to report is not a guard.
+
+Controls run on it, both directions:
+
+- **Green state:** 5 tests collected, 5 passed.
+- **Negative control, empty gitlink directory:** 4 failed / 1 passed, `AssertionError:
+  submodule "event-engine-common" is present but EMPTY — an uninitialised gitlink. Fix: git
+  submodule update --init --recursive`.
+- **Negative control, directory absent entirely:** 4 failed / 1 passed, `AssertionError:
+  submodule "event-engine-common" is not checked out. …`.
+- **Reachability:** in both broken states the file still **collected 5 tests** while 72 other
+  files were collecting zero. It is visible precisely when everything else has gone quiet.
+- **Vacuity control:** the `it.each` populations are derived, so an unparseable `.gitmodules`
+  would generate zero cases and pass green. The first test pins `DECLARED.length > 0` and pins
+  that `event-engine-common` is among them.
+
+Nothing was deleted, disabled, skipped, or quarantined.
+
+## Recommendations for the human — no guard deletions proposed
+
+I am not recommending that any guard be deleted. All five are live, specific, and cheap
+(150 tests, ~0.9s combined). The ticket's premise for deleting them — that they are red and
+therefore inert — does not hold.
+
+Three things are worth a decision, none of which I made:
+
+1. **Close the ticket as "not reproducible on `main`; environment artifact"**, with Findings
+   1–2 as the record. The instinct behind it was right; the target was wrong.
+2. **Finding 3** — the unit suite exits non-zero on CI's own Node while reporting zero failed
+   tests. Needs resolving before that job is flipped to blocking. Overlaps PR #3779; I did not
+   touch it.
+3. **Finding 4** — `git stash` in a 30-worktree shared clone. Independent of this ticket, and
+   the most likely reason three agents agreed on a wrong answer.
+
+## Reproducing any of this
+
+```bash
+CIVITAI=/path/to/civitai
+WT=/tmp/civitai-baseline
+git -C "$CIVITAI" fetch origin main
+git -C "$CIVITAI" worktree add --detach "$WT" origin/main
+git -C "$WT" submodule update --init --recursive     # ← the step that decides the answer
+printf 'use flake\n' > "$WT/.envrc" && direnv allow "$WT"
+(cd "$WT" && direnv exec . pnpm install --frozen-lockfile && direnv exec . pnpm run test:unit:run)
+```
+
+Read the **content**, not the exit code, and read all three numbers — failed files, failed
+tests, passed tests. A run whose failed-test count is 0 is not necessarily a run that passed.

--- a/src/__tests__/submodules-checked-out.test.ts
+++ b/src/__tests__/submodules-checked-out.test.ts
@@ -1,0 +1,109 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * A missing submodule does not turn this suite RED. It makes ~70 suites VANISH.
+ *
+ * `event-engine-common` is a git submodule, and `git worktree add` does not
+ * check submodules out. Without it, every file whose module graph reaches
+ * `~/server/services/image.service.ts` (and friends) fails to RESOLVE, so those
+ * files fail to LOAD. A file that fails to load collects **0 tests**: it
+ * contributes nothing to the failed-TEST count, and it silently subtracts its
+ * whole contents from the passed-TEST count.
+ *
+ * Measured on this repo (2026-08-10, same commit, same machine, only the
+ * submodule differing):
+ *
+ *   submodule ABSENT   73 files failed | 818 passed  ->  12,782 tests passed
+ *                      72 of those 73 files collected ZERO tests, and the run
+ *                      reported **0 failed tests**.
+ *   submodule PRESENT  891 files passed              ->  13,753 tests passed
+ *
+ * So the absent case hides 971 tests behind a summary whose failed-test count
+ * is zero. Anyone reading "0 failing tests", or diffing passed-test totals
+ * against a remembered number, is reading a number that means nothing — and a
+ * reassuring zero is exactly what a probe wired to nothing produces.
+ *
+ * CI is not exposed to this (it checks out with `submodules: true`); local
+ * worktrees are, which is where most runs actually happen. The repo's guidance
+ * has documented the trap in prose since #3567, and it was walked into anyway,
+ * because prose cannot fail. This file can.
+ *
+ * It deliberately imports NOTHING from the submodule — a guard that fails to
+ * load for the very reason it exists to report is not a guard.
+ *
+ * Fix when this goes red:
+ *     git submodule update --init --recursive
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const GITMODULES = path.join(REPO_ROOT, '.gitmodules');
+
+/**
+ * The submodule paths git itself is configured to have, read from `.gitmodules`
+ * rather than hardcoded. Deriving the population from the source of truth means
+ * a submodule added later is covered without anyone remembering to come here.
+ */
+function declaredSubmodulePaths(): string[] {
+  const text = readFileSync(GITMODULES, 'utf8');
+  return [...text.matchAll(/^\s*path\s*=\s*(.+?)\s*$/gm)].map((m) => m[1]);
+}
+
+const DECLARED = declaredSubmodulePaths();
+
+describe('git submodules are checked out', () => {
+  /**
+   * Positive control. `it.each` over an empty array generates zero cases and
+   * reports green, so a `.gitmodules` that stopped parsing would turn the check
+   * below into a vacuous pass — the same failure shape this file exists to
+   * catch, one level up.
+   */
+  it('reads at least one submodule out of .gitmodules (positive control)', () => {
+    expect(existsSync(GITMODULES)).toBe(true);
+    expect(DECLARED.length).toBeGreaterThan(0);
+    // Named explicitly: this is the one whose absence removes ~971 tests. If it
+    // is ever renamed or removed, this line is where that decision surfaces.
+    expect(DECLARED).toContain('event-engine-common');
+  });
+
+  it.each(DECLARED)('`%s` is checked out and non-empty', (rel) => {
+    const abs = path.join(REPO_ROOT, rel);
+
+    expect(
+      existsSync(abs),
+      `submodule "${rel}" is not checked out. Suites that import through it will ` +
+        `collect 0 tests instead of failing, so the run's failed-test count will ` +
+        `read 0 while hundreds of tests silently do not run. ` +
+        `Fix: git submodule update --init --recursive`
+    ).toBe(true);
+
+    expect(statSync(abs).isDirectory(), `submodule "${rel}" exists but is not a directory`).toBe(
+      true
+    );
+
+    // An empty directory is what an uninitialised submodule leaves behind, and
+    // it passes an existence check. The gitlink placeholder is a directory too.
+    expect(
+      readdirSync(abs).length,
+      `submodule "${rel}" is present but EMPTY — an uninitialised gitlink. ` +
+        `Fix: git submodule update --init --recursive`
+    ).toBeGreaterThan(0);
+  });
+
+  /**
+   * The specific entry points the failing imports resolved through. Directory
+   * non-emptiness alone would pass on a partial checkout, and a partial
+   * checkout produces the identical vanish-without-failing symptom.
+   */
+  it.each([
+    'event-engine-common/index.ts',
+    'event-engine-common/feeds',
+    'event-engine-common/services',
+  ])('`%s` resolves', (rel) => {
+    expect(
+      existsSync(path.join(REPO_ROOT, rel)),
+      `"${rel}" is missing. Fix: git submodule update --init --recursive`
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Triage of the "16 pre-existing test failures on main". Short version: **they are not on `main`, and were not on `main` on the day they were reported.** The observation was real; the failures were in the environment the suite was run in, not in the tests.

## What I measured

Clean throwaway worktrees off the remote tip, fresh `pnpm install --frozen-lockfile`, submodule initialised unless stated. Three numbers each, because the failure mode at issue moves between them.

| Run | Commit | Node | Failed FILES | Failed TESTS | Passed TESTS | exit |
|---|---|---|---|---|---|---|
| unit, submodule **absent** | `a43e49a4ba` | 22.22.2 (flake) | **73** / 891 | **0** | 12,782 | 1 |
| unit, submodule present | `a43e49a4ba` | 22.22.2 (flake) | 0 / 891 | 0 | 13,753 | 0 |
| unit, submodule present | `a43e49a4ba` | 24.18.1 (`.nvmrc`/CI) | 0 / 891 | 0 | 13,753 | 1 † |
| unit, submodule present | `a43e49a4ba` | 26.5.0 (ambient) | 1 / 891 | **7** | 13,746 | 1 |
| unit, submodule present | `2a2fe66428` (tip on 2026-08-08) | 22.22.2 | 0 / 889 | 0 | 13,713 | 0 |
| `packages` | `a43e49a4ba` | 22.22.2 | 0 / 73 | 0 | 1,002 | 0 |
| `apps` | `a43e49a4ba` | 22.22.2 | 0 / 53 | 0 | 507 | 0 |

The `component` (browser-mode) project was **not** run — this host has no Chromium at the revision the Playwright pin wants. Unmeasured, not green.

## The mechanism this PR closes

Of the 73 failing files in the submodule-absent run, **72 collected ZERO tests**. So that run reports **0 failed tests** and 12,782 passed, against 13,753 in the green run: **971 tests silently did not run**, and nothing was red. A reader comparing failed-test counts sees "0 either way".

Root cause of all 73: `Cannot find module '../../../event-engine-common/...'` — `git worktree add` does not check submodules out. 58 name it directly; the rest are `vi.mock` factory errors cascading from the same unresolved import.

This is what produced the ticket. Three sessions reported "16 pre-existing failures" from environments shaped this way, and while I was working a fourth session independently produced the exact `73 files / 12,782 passed / 4 skipped` numbers above (plus 12 `pnpm typecheck` errors, all from the un-checked-out submodule) while establishing an unrelated baseline.

`CLAUDE.md` has documented the trap in prose since #3567 (2026-08-04). It was walked into anyway, four days later, three times, because prose cannot fail. `src/__tests__/submodules-checked-out.test.ts` can.

It derives the submodule paths from `.gitmodules` rather than hardcoding them, and checks three specific entry points as well as directory non-emptiness, because a *partial* checkout produces the identical symptom. It imports nothing from the submodule — a guard that fails to load for the very reason it exists to report is not a guard.

Controls, both directions:

- green state: 5 collected, 5 passed
- empty gitlink directory: 4 failed / 1 passed — `submodule "event-engine-common" is present but EMPTY — an uninitialised gitlink`
- directory absent: 4 failed / 1 passed — `submodule "event-engine-common" is not checked out`
- **reachability**: in both broken states it still *collected 5 tests* while 72 other files collected zero — it is visible exactly when everything else has gone quiet
- **vacuity**: `it.each` over a derived population passes green when the population is empty, so the first case pins `DECLARED.length > 0` and pins that `event-engine-common` is in it

## The five named drift guards: all live, none inert

Every suite the ticket names is green and collects a non-zero count. Each was mutation-tested — the thing it guards was broken on purpose and the guard watched to go red with **its own** error message:

| Guard | Mutation | Result |
|---|---|---|
| `no-wholesale-module-mock` | reintroduced the historical *textual* check (treat any factory whose source mentions `importOriginal` as safe) | 97 → **29 failed**, `Should have 1 error but had 0: []` — killing exactly the laundering cases |
| `block-scope.normalize-endpoint` | added a new `withBlockScope(...)` route file | 27 → **2 failed**, both diffing on the new segment |
| `app-spend-tier-privilege` | added `spendTier` in code to a publisher-reachable module | 9 → **3 failed**, `… must not reference spendTier in code` |
| `orchestrator-chat.wait-unit` | added a `wait: 60000` site under `src/` | 12 → **2 failed**: envelope + ledger, naming the file |
| `scripts/__tests__/typecheck.test.ts` | moved the crash verdict from stdout to stderr | 5 → **3 failed**, `expected '' to contain 'TYPECHECK CRASHED'` |

All mutations reverted; the five re-run together afterwards: 150 tests, all passing.

**No guard deletions proposed.** The premise for deleting them — that they are red and therefore decoration — does not hold.

One scope correction worth recording: `block-scope.normalize-endpoint` would **not** have had an opinion about `/api/testing/eventloop-stall`. Its walk matches only routes whose default export is wrapped in `withBlockScope(...)`, and that route is not block-scoped. It is a block-scope allowlist drift guard, not a general new-route detector. No general one exists; building one would be new work, not a repair.

## Two things flagged, not fixed

1. **Under CI's own Node the unit suite exits non-zero with zero failing tests.** At `a43e49a4ba` on Node 24.18.1: 891/891 files, 13,753 passed, 0 failed — then `Errors 6 errors` and a non-zero exit, from `PrismaClientInitializationError: could not locate the Query Engine for runtime "linux-nixos"` unhandled rejections outside the flake shell. The CI `unit` job is `continue-on-error: true`, so it is invisible today; it will matter when that job is flipped to blocking, which its own comment says is the plan. Environment-shaped and overlaps #3779, so untouched here.
2. **`.envrc` is gitignored, so a fresh worktree gets system Node.** Under ambient Node 26.5.0, `hiddenBlocks.test.ts` fails 7 tests on `window.localStorage` under happy-dom; under Node 22 and 24 it passes. `CLAUDE.md` already records "7 localStorage + 8 Prisma = 15 false reds" from a previous encounter with this — the closest match to the reported 16 that any mechanism here produces.

## Verification

- full unit suite with this file: **892 files passed, 13,758 passed, 1 skipped**, exit 0
- `pnpm typecheck`: `typecheck: OK — 0 type errors`
- `prettier --check` clean (instrument validated against a deliberately misformatted probe file, which it correctly named); `eslint` clean

Nothing was deleted, disabled, skipped, or quarantined.

Full write-up in `claudedocs/red-test-triage-2026-08-10.md`.
