### PR TITLE
fix(challenges): don't let Community wins trigger the Daily winner cooldown

### DIFF
--- a/src/server/jobs/__tests__/daily-challenge-processing.winner-cooldown.test.ts
+++ b/src/server/jobs/__tests__/daily-challenge-processing.winner-cooldown.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type * as FliptClient from '~/server/flipt/client';
 
 // #3774: winning a Community (source=User) challenge put the user on the System Daily winner
 // cooldown. `getJudgedEntries` already skipped the cooldown when the challenge being judged is
@@ -51,7 +52,7 @@ vi.mock('~/server/events', () => ({
 }));
 
 vi.mock('~/server/flipt/client', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('~/server/flipt/client')>();
+  const actual = await importOriginal<typeof FliptClient>();
   return { ...actual, isFlipt: mockIsFlipt };
 });
 

--- a/src/server/jobs/__tests__/daily-challenge-processing.winner-cooldown.test.ts
+++ b/src/server/jobs/__tests__/daily-challenge-processing.winner-cooldown.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// #3774: winning a Community (source=User) challenge put the user on the System Daily winner
+// cooldown. `getJudgedEntries` already skipped the cooldown when the challenge being judged is
+// source=User, but the lookback query never filtered the source of the WINS it counted, so a
+// Community win disqualified the user from Daily prizes for 7 days.
+//
+// Same mock preamble as daily-challenge-processing.judging-categories.test.ts: `~/server/events`
+// and the heavy service modules are cut so daily-challenge-processing can load, while the pure
+// ranking/cooldown helpers stay real.
+
+const {
+  mockDbReadQueryRaw,
+  mockDbReadChallengeFindUnique,
+  mockDbWriteQueryRaw,
+  mockDbWriteExecuteRaw,
+  mockDbWriteChallengeUpdate,
+  mockDbWriteChallengeFindUnique,
+  mockIsFlipt,
+  mockGetChallengeConfig,
+  mockGetJudgingConfig,
+} = vi.hoisted(() => ({
+  mockDbReadQueryRaw: vi.fn(),
+  mockDbReadChallengeFindUnique: vi.fn(),
+  mockDbWriteQueryRaw: vi.fn(),
+  mockDbWriteExecuteRaw: vi.fn().mockResolvedValue(1),
+  mockDbWriteChallengeUpdate: vi.fn().mockResolvedValue(undefined),
+  mockDbWriteChallengeFindUnique: vi.fn().mockResolvedValue({
+    prizePool: 0,
+    prizeDistribution: null,
+  }),
+  mockIsFlipt: vi.fn().mockResolvedValue(false),
+  mockGetChallengeConfig: vi.fn(),
+  mockGetJudgingConfig: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: {
+    $queryRaw: mockDbReadQueryRaw,
+    challenge: { findUnique: mockDbReadChallengeFindUnique },
+  },
+  dbWrite: {
+    $queryRaw: mockDbWriteQueryRaw,
+    $executeRaw: mockDbWriteExecuteRaw,
+    challenge: { update: mockDbWriteChallengeUpdate, findUnique: mockDbWriteChallengeFindUnique },
+  },
+}));
+
+vi.mock('~/server/events', () => ({
+  eventEngine: { processEngagement: vi.fn().mockResolvedValue(undefined) },
+}));
+
+vi.mock('~/server/flipt/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/server/flipt/client')>();
+  return { ...actual, isFlipt: mockIsFlipt };
+});
+
+vi.mock('~/server/games/daily-challenge/daily-challenge.utils', async () => {
+  const real = await import('~/server/games/daily-challenge/daily-challenge-scoring');
+  return {
+    SCORE_WEIGHTS: real.SCORE_WEIGHTS,
+    calculateWeightedScore: real.calculateWeightedScore,
+    challengeToLegacyFormat: vi.fn(),
+    deriveChallengeNsfwLevel: vi.fn(() => 1),
+    endChallenge: vi.fn().mockResolvedValue(undefined),
+    getActiveChallenges: vi.fn(),
+    getChallengeConfig: mockGetChallengeConfig,
+    getJudgingConfig: mockGetJudgingConfig,
+    getUpcomingSystemChallenge: vi.fn(),
+  };
+});
+
+vi.mock('~/server/games/daily-challenge/challenge-helpers', () => ({
+  claimChallengeForCompletion: vi.fn().mockResolvedValue(true),
+  computeDynamicPool: vi.fn(),
+  distributePrizes: vi.fn(),
+  createChallengeRecord: vi.fn(),
+  createChallengeWinner: vi.fn().mockResolvedValue(undefined),
+  getChallengeById: vi.fn(),
+  getChallengeEntryCount: vi.fn().mockResolvedValue(0),
+  getExistingWinnersForRetry: vi.fn().mockResolvedValue([]),
+  incrementOperationSpent: vi.fn().mockResolvedValue(undefined),
+  resolveEventContext: vi.fn().mockResolvedValue(undefined),
+  setChallengeActive: vi.fn(),
+  updateChallengeStatus: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/games/daily-challenge/challenge-rewards', () => ({
+  distributeParticipationPrizes: vi.fn().mockResolvedValue([]),
+  promoteChallengeEntries: vi.fn().mockResolvedValue(0),
+}));
+
+vi.mock('~/server/games/daily-challenge/generative-content', () => ({
+  estimateBuzzCost: vi.fn().mockReturnValue(0),
+  generateArticle: vi.fn(),
+  generateCollectionDetails: vi.fn(),
+  generateReview: vi.fn(),
+  generateWinners: vi.fn(),
+}));
+
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransactionMany: vi.fn().mockResolvedValue(undefined),
+  getTransactionByExternalId: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('~/server/services/commentsv2.service', () => ({
+  upsertComment: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/services/notification.service', () => ({
+  createNotification: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/services/reaction.service', () => ({
+  toggleReaction: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/games/daily-challenge/challenge-funding', () => ({
+  refundUserChallengeFunds: vi.fn().mockResolvedValue({ refundedEntries: 0 }),
+  getChallengeBuzzType: vi.fn(async () => 'yellow'),
+  buildWinnerPayoutTransactions: vi.fn(() => []),
+  reportPoolFundingShortfall: vi.fn(),
+}));
+
+vi.mock('~/utils/logging', () => ({
+  createLogger: vi.fn(() => vi.fn()),
+}));
+
+const { getJudgedEntries } = await import('~/server/jobs/daily-challenge-processing');
+const { ChallengeSource } = await import('~/shared/utils/prisma/enums');
+
+const BASE_CONFIG = {
+  challengeType: 'world-morph',
+  challengeCollectionId: 1,
+  judgedTagId: 11,
+  reviewMeTagId: 12,
+  userCooldown: '14 day',
+  resourceCooldown: '90 day',
+  winnerCooldown: '7 day',
+  prizes: [],
+  entryPrizeRequirement: 10,
+  entryPrize: { buzz: 0, points: 0 },
+  reviewAmount: { min: 6, max: 12 },
+  maxScoredPerUser: 5,
+  finalReviewAmount: 10,
+  resourceCosmeticId: null,
+  articleTagId: 1,
+  defaultJudgeId: 1,
+  defaultJudge: null,
+} as never;
+
+function judgedEntry(userId: number, username: string, imageId: number) {
+  return {
+    imageId,
+    userId,
+    username,
+    note: JSON.stringify({
+      score: { theme: 10, aesthetic: 10, humor: 10, wittiness: 10 },
+      summary: `entry from ${username}`,
+    }),
+  };
+}
+
+function cooldownSql() {
+  return (mockDbWriteQueryRaw.mock.calls[0][0] as unknown as string[]).join('');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetChallengeConfig.mockResolvedValue(BASE_CONFIG);
+  mockDbReadQueryRaw.mockResolvedValue([judgedEntry(100, 'alice', 1)]);
+  mockDbWriteQueryRaw.mockResolvedValue([]);
+});
+
+describe('getJudgedEntries — winner cooldown ignores user-challenge wins', () => {
+  it('excludes user-sourced wins from the global cooldown lookback', async () => {
+    await getJudgedEntries(100, BASE_CONFIG, undefined, ChallengeSource.System, undefined);
+
+    expect(mockDbWriteQueryRaw).toHaveBeenCalledTimes(1);
+    expect(cooldownSql()).toMatch(/c\."source"\s*<>\s*'User'/);
+  });
+
+  it('excludes user-sourced wins from the event-scoped cooldown lookback', async () => {
+    await getJudgedEntries(
+      100,
+      BASE_CONFIG,
+      { eventId: 7, winnerCooldownDays: 14 },
+      ChallengeSource.System,
+      undefined
+    );
+
+    expect(mockDbWriteQueryRaw).toHaveBeenCalledTimes(1);
+    expect(cooldownSql()).toMatch(/c\."source"\s*<>\s*'User'/);
+  });
+
+  it('still drops entrants the lookback reports as recent winners', async () => {
+    // Two entrants so filterRecentWinners' all-on-cooldown fallback can't mask the filtering.
+    mockDbReadQueryRaw.mockResolvedValue([
+      judgedEntry(100, 'alice', 1),
+      judgedEntry(200, 'bob', 2),
+    ]);
+    mockDbWriteQueryRaw.mockResolvedValue([{ userId: 100 }]);
+
+    const result = await getJudgedEntries(
+      100,
+      BASE_CONFIG,
+      undefined,
+      ChallengeSource.System,
+      undefined
+    );
+
+    expect(result.map((e) => e.userId)).toEqual([200]);
+  });
+});

--- a/src/server/jobs/daily-challenge-processing.ts
+++ b/src/server/jobs/daily-challenge-processing.ts
@@ -1861,7 +1861,9 @@ export async function getJudgedEntries(
     return [];
   }
 
-  // Exclude users who won a challenge within the cooldown period, scoped by event
+  // Exclude users who won a challenge within the cooldown period, scoped by event. Wins in a user
+  // challenge are excluded from the lookback for the same reason user challenges skip the cooldown
+  // below: the two prize pools are independent in both directions.
   let recentWinnerIds = new Set<number>();
   if (source === ChallengeSource.User) {
     // Paid user challenges never apply the winner cooldown — a recent daily-challenge win
@@ -1888,6 +1890,7 @@ export async function getJudgedEntries(
       JOIN "Challenge" c ON c.id = cw."challengeId"
       WHERE cw."createdAt" > now() - ${cooldownInterval}::interval
         AND c.status = 'Completed'
+        AND c."source" <> 'User'
         ${eventCondition}
     `;
     recentWinnerIds = new Set(recentWinners.map((w) => w.userId));
@@ -1899,6 +1902,7 @@ export async function getJudgedEntries(
       JOIN "Challenge" c ON c.id = cw."challengeId"
       WHERE cw."createdAt" > now() - ${config.winnerCooldown}::interval
         AND c.status = 'Completed'
+        AND c."source" <> 'User'
     `;
     recentWinnerIds = new Set(recentWinners.map((w) => w.userId));
   }

--- a/src/server/services/__tests__/challenge-rescan.service.test.ts
+++ b/src/server/services/__tests__/challenge-rescan.service.test.ts
@@ -204,4 +204,17 @@ describe('getWinnerCooldownStatus', () => {
     expect(result.onCooldown).toBe(true);
     expect(result.lastWinChallengeId).toBe(9);
   });
+
+  // #3774: a Community (source=User) win was reported as a Daily cooldown. The exclusion lives in
+  // SQL, so the query text is the only observable here — the mocked client never evaluates it.
+  it('excludes wins earned in user challenges from the lookback', async () => {
+    mockDbRead.$queryRaw
+      .mockResolvedValueOnce([{ eventId: null, source: 'System' }])
+      .mockResolvedValueOnce([]);
+
+    await getWinnerCooldownStatus(42, 111);
+
+    const winLookupSql = (mockDbRead.$queryRaw.mock.calls[1][0] as unknown as string[]).join('');
+    expect(winLookupSql).toMatch(/ch\."source"\s*<>\s*'User'/);
+  });
 });

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -4124,12 +4124,15 @@ export async function getWinnerCooldownStatus(
       ? Prisma.sql`AND ch."eventId" = ${challenge.eventId}`
       : Prisma.sql`AND ch."eventId" IS NULL`;
 
+  // A user challenge never applies the cooldown to its own winners, so a win in one must not
+  // consume the System/Mod cooldown either. Keep in sync with getJudgedEntries.
   const [lastWin] = await dbRead.$queryRaw<[{ createdAt: Date; challengeId: number }] | []>`
     SELECT cw."createdAt", cw."challengeId"
     FROM "ChallengeWinner" cw
     JOIN "Challenge" ch ON ch.id = cw."challengeId"
     WHERE cw."userId" = ${userId}
       AND ch.status = 'Completed'
+      AND ch."source" <> 'User'
       AND cw."createdAt" > now() - ${cooldownInterval}::interval
       ${eventCondition}
     ORDER BY cw."createdAt" DESC


### PR DESCRIPTION
Fixes #3774. ClickUp: https://app.clickup.com/t/868kp7z8w

## Problem

Winning a Community (`source=User`) challenge put the user on the 7-day **Daily** winner cooldown — they saw "You recently won a challenge! You're on a winner cooldown until …" on Dailies and their Daily entries were dropped from prize eligibility.

The reporter won Community challenge *466 – Grunge Challenge* on Aug 9, and the Aug 10 Daily showed a cooldown through Aug 16.

## Root cause

Both cooldown guards check the source of the **challenge being evaluated**, but neither filters the source of the **wins being looked up**:

- `challenge.service.ts` → `getWinnerCooldownStatus()` early-returns "no cooldown" when the viewed challenge is `source=User`, but its `ChallengeWinner` lookup filtered only on `status='Completed'` + event scope.
- `daily-challenge-processing.ts` → `getJudgedEntries()` skips the cooldown entirely for `source=User` challenges, but both `recentWinners` queries (event-scoped and global fallback) had no source predicate either.

So a Community win with `eventId IS NULL` satisfied `AND "eventId" IS NULL` and counted against the Daily. The service path drives the banner; the job path is what actually costs prizes.

## Fix

Add `AND "source" <> 'User'` to the win lookback at all three query sites. This makes the separation symmetric with the skip that already exists in the other direction — a Daily win has never blocked a paid Community challenge, and now a Community win doesn't block a Daily.

`Mod`-source challenges stay pooled with `System` (unchanged behavior — they're official challenges alongside dailies). Event-scoped challenges keep their existing `eventId` scoping; the source predicate applies on top, so a user challenge attached to an event can't leak into that event's pool either.

## Tests

- `daily-challenge-processing.winner-cooldown.test.ts` (new): pins the exclusion on both the global and event-scoped lookback, plus a behavioral case proving recent winners are still dropped (two entrants, so `filterRecentWinners`' all-on-cooldown fallback can't mask it).
- `challenge-rescan.service.test.ts`: adds the equivalent case for `getWinnerCooldownStatus`.

The exclusion lives in SQL and the unit mocks never evaluate it, so these assert on the query text. Checked the failure mode by reverting the three predicates: 3 assertion failures, one per site, in under a second — no hangs, no silent pass.

**Verification:** `pnpm run typecheck` 0 errors · `pnpm run lint` no new issues · 3123 tests pass across `src/server/jobs/__tests__`, `src/server/games/daily-challenge`, `src/server/services/__tests__`.

## Not included

Any remediation for users currently sitting on a bogus cooldown. Cooldowns are computed from `ChallengeWinner.createdAt` at read time rather than stored, so this fix clears incorrect cooldowns as soon as it deploys — but anyone who was skipped for a Daily prize while it was live is not retroactively compensated by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
