### PR TITLE
fix(upload): log the SHAPE of a multipart completion, not just that it happened

### DIFF
--- a/src/pages/api/upload/complete.ts
+++ b/src/pages/api/upload/complete.ts
@@ -30,7 +30,25 @@ const upload = async (req: NextApiRequest, res: NextApiResponse) => {
   }
   try {
     const result = await completeMultipartUpload(bucket, key, uploadId, parts, s3);
-    await logToAxiom({ name: 's3-upload-complete', userId, type, key, uploadId, backend });
+    // Log the SHAPE of the completion, not just that it happened. A completion can
+    // resolve without throwing and still leave the multipart session unfinished with
+    // no object — S3 documents that CompleteMultipartUpload "can contain either a
+    // success or an error" and that an error "might be embedded in the 200 OK
+    // response", so a non-throwing call is not proof of a finalized object. Without
+    // partCount/location/etag there is nothing in the log to tell an apparently-good
+    // completion from a silently-empty one after the fact, and the resulting rows are
+    // indistinguishable from healthy ones. partCount also catches a truncated manifest.
+    await logToAxiom({
+      name: 's3-upload-complete',
+      userId,
+      type,
+      key,
+      uploadId,
+      backend,
+      partCount: Array.isArray(parts) ? parts.length : null,
+      location: result?.Location ?? null,
+      etag: result?.ETag ?? null,
+    });
 
     res.status(200).json(result.Location);
   } catch (e) {

--- a/src/server/__tests__/upload-complete-endpoint.test.ts
+++ b/src/server/__tests__/upload-complete-endpoint.test.ts
@@ -54,6 +54,8 @@ vi.mock('~/server/db/client', () => ({ dbWrite: {}, dbRead: {} }));
 // every .ts under src/pages/api as an API route and its route-type validator
 // rejects a test module.
 import handler from '~/pages/api/upload/complete';
+// Mocked in ~/__tests__/setup as vi.fn(); imported here so the LOG PAYLOAD is assertable.
+import { logToAxiom } from '~/server/logging/client';
 
 function makeRes() {
   const headers: Record<string, string> = {};
@@ -233,5 +235,94 @@ describe('/api/upload/complete — error classification', () => {
     const res = makeRes();
     await handler(makeReq(), res);
     expect(res.statusCode).toBe(500);
+  });
+});
+
+describe('/api/upload/complete — the completion LOG must record the completion SHAPE', () => {
+  /**
+   * WHY THIS EXISTS. A multipart completion can resolve WITHOUT THROWING and still
+   * leave the session unfinished with no object in the bucket. S3 documents that
+   * CompleteMultipartUpload "can contain either a success or an error" and that an
+   * error "might be embedded in the 200 OK response" — so a non-throwing call is not
+   * proof of a finalized object.
+   *
+   * That happened in production: rows were registered 472 ms after a completion the
+   * SDK reported as successful, for sessions the backend still lists as unfinished
+   * with no object. The rows are then indistinguishable from healthy ones, and the
+   * log had nothing in it to tell them apart after the fact.
+   *
+   * 🔴 These assert the PAYLOAD, not that logging happened. Asserting only that
+   * logToAxiom was called passes with the bug fully present — the old payload had no
+   * partCount, no location and no etag, which is exactly why the incident could not
+   * be diagnosed from logs.
+   */
+  const logged = () => {
+    const calls = vi.mocked(logToAxiom).mock.calls.map((c) => c[0] as Record<string, unknown>);
+    return calls.find((c) => c?.name === 's3-upload-complete');
+  };
+
+  const reqWithParts = (parts: unknown) =>
+    ({
+      method: 'POST',
+      body: {
+        // Bucket value is irrelevant to what these tests assert; kept generic on
+        // purpose rather than naming a real one.
+        bucket: 'test-bucket',
+        key: 'some/key.safetensors',
+        type: 'model',
+        uploadId: 'test-upload-id',
+        parts,
+        backend: 'b2',
+      },
+      headers: {},
+      socket: { remoteAddress: '127.0.0.1' },
+    } as unknown as NextApiRequest);
+
+  beforeEach(() => vi.mocked(logToAxiom).mockClear());
+
+  it('records partCount, location and etag on a successful completion', async () => {
+    mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x', ETag: '"abc123"' });
+    await handler(makeReq(), makeRes());
+    const ev = logged();
+    expect(ev).toBeDefined();
+    expect(ev?.partCount).toBe(1);
+    expect(ev?.location).toBe('https://cdn/x');
+    expect(ev?.etag).toBe('"abc123"');
+  });
+
+  it('THE MOTIVATING CASE: a completion that resolves with NO Location is still logged as such', async () => {
+    // The silent-empty shape. Before this change the event carried no `location` key
+    // at all, so this run and a healthy one produced identical log lines.
+    mockCompleteMultipartUpload.mockResolvedValue({});
+    const res = makeRes();
+    await handler(reqWithParts([{ ETag: 'e', PartNumber: 1 }]), res);
+    const ev = logged();
+    expect(ev).toBeDefined();
+    expect(ev).toHaveProperty('location');
+    expect(ev?.location).toBeNull();
+    expect(ev?.etag).toBeNull();
+    // Behaviour is deliberately unchanged — this commit adds visibility only.
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('partCount reflects the manifest length, so a truncated manifest is visible', async () => {
+    mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/y', ETag: '"e"' });
+    await handler(
+      reqWithParts([
+        { ETag: 'a', PartNumber: 1 },
+        { ETag: 'b', PartNumber: 2 },
+        { ETag: 'c', PartNumber: 3 },
+      ]),
+      makeRes()
+    );
+    expect(logged()?.partCount).toBe(3);
+  });
+
+  it('a non-array parts body logs partCount null rather than throwing', async () => {
+    mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/z', ETag: '"e"' });
+    const res = makeRes();
+    await handler(reqWithParts(undefined), res);
+    expect(logged()?.partCount).toBeNull();
+    expect(res.statusCode).toBe(200);
   });
 });


### PR DESCRIPTION
## What

Adds `partCount`, `location` and `etag` to the `s3-upload-complete` log event. **Behaviour is unchanged — this is visibility only.**

## Why

A multipart completion can resolve **without throwing** and still leave the upload session unfinished with no object stored. S3 documents that `CompleteMultipartUpload` [“can contain either a success or an error”](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html) and that an error “might be embedded in the 200 OK response” — so a non-throwing call is not proof of a finalized object.

This has happened in production. For one traced upload, the file-location row was written **472 ms after** an `s3-upload-complete` event the SDK reported as successful — for a session the storage backend still lists as unfinished, with no object. The resulting row is **indistinguishable from a healthy one**, and the log had nothing in it to tell them apart after the fact: the event carried only `userId` / `type` / `key` / `uploadId` / `backend`.

`partCount` additionally makes a **truncated parts manifest** visible, which is one of the candidate mechanisms.

## Why now

Log retention is short relative to how long these rows survive, and nearly every known instance is already past it. **Instrumenting and waiting is the only way to get log-grade evidence** on why a non-throwing completion leaves no object. The phenomenon is still live.

## Tests — 4 added, asserting the PAYLOAD

🔴 They assert the logged payload, **not** that the logger was called. Asserting only that logging happened passes with the problem fully present — which is precisely why this incident could not be diagnosed from logs. One test covers the motivating shape directly: a completion that resolves with **no `Location`** must still be logged as such.

| | |
|---|---|
| red at `6bf01a274d` | **4 failed / 10 passed** — `expected undefined to be 1`; `expected { name: 's3-upload-complete', …(5) } to have property "location"` |
| green at HEAD | **14 passed** |

Run with the repo's own script: `vitest run --project unit`.

## Follow-ups, deliberately not in this PR

- **Verify the object at completion** — `HeadObject` after `completeMultipartUpload` and compare `ContentLength` against the expected size, converting a silent success into a retryable failure while the client can still act. The primitive already exists in this file (`objectExists`, used in the `not-found` branch). Separate PR, same function.
- **A completion-failure path leaks its multipart upload** — one branch in `src/store/s3-upload.store.ts` returns without calling `abortUpload()`, unlike its sibling part-failure branch. Separate PR.
