### PR TITLE
fix(upload): abort the multipart upload when completion fails

### DIFF
--- a/src/store/__tests__/s3-upload.store.test.ts
+++ b/src/store/__tests__/s3-upload.store.test.ts
@@ -17,7 +17,29 @@ import { UploadType } from '~/server/common/enums';
 
 const CHUNK = 1024;
 
+/**
+ * The identity `/api/upload` hands back and that every later call to
+ * `/api/upload/{sign-part,complete,abort}` has to echo. Kept in one place so an
+ * abort assertion checks the identity the server actually issued rather than a
+ * literal retyped in the test.
+ */
+const UPLOAD_IDENTITY = {
+  bucket: 'civitai-modelfiles',
+  key: 'model/42/x.safetensors',
+  uploadId: 'upload-1',
+  backend: 'b2',
+};
+
 type PartResponse = { status: number; etag?: string; retryAfter?: string };
+
+/** Body shape `POST /api/upload/abort` is called with. */
+type AbortBody = {
+  bucket: string;
+  key: string;
+  type: string;
+  uploadId: string;
+  backend: string;
+};
 
 let partHandler: (url: string, partNumber: number) => PartResponse;
 let completeStatus: number;
@@ -26,6 +48,11 @@ let completeStatusQueue: number[];
 let signPartStatus: number;
 let signedUrls: string[];
 let completeCalls: number;
+let abortCalls: AbortBody[];
+/** Simulates the abort request itself failing at the network layer. */
+let abortShouldReject: boolean;
+/** Fires when `/api/upload/complete` is requested, to mutate state mid-flight. */
+let onCompleteRequest: (() => void) | null;
 
 class FakeXHR {
   readyState = 0;
@@ -93,10 +120,7 @@ function makeFetch(partCount: number) {
         ok: true,
         status: 200,
         json: async () => ({
-          bucket: 'civitai-modelfiles',
-          key: 'model/42/x.safetensors',
-          uploadId: 'upload-1',
-          backend: 'b2',
+          ...UPLOAD_IDENTITY,
           chunkSize: CHUNK,
           urls: Array.from({ length: partCount }, (_, i) => ({
             url: partUrl(i + 1),
@@ -117,8 +141,16 @@ function makeFetch(partCount: number) {
     }
     if (url === '/api/upload/complete') {
       completeCalls++;
+      onCompleteRequest?.();
       const status = completeStatusQueue.shift() ?? completeStatus;
       return { ok: status === 200, status, json: async () => null };
+    }
+    if (url === '/api/upload/abort') {
+      abortCalls.push(JSON.parse(init?.body ?? '{}') as AbortBody);
+      // The store fire-and-forgets this response, so only a rejected request can
+      // surface as a throw — which is what `abortShouldReject` reproduces.
+      if (abortShouldReject) throw new TypeError('Failed to fetch');
+      return { ok: true, status: 200, json: async () => ({}) };
     }
     return { ok: true, status: 200, json: async () => null };
   });
@@ -135,6 +167,9 @@ beforeEach(() => {
   signPartStatus = 200;
   signedUrls = [];
   completeCalls = 0;
+  abortCalls = [];
+  abortShouldReject = false;
+  onCompleteRequest = null;
   partHandler = () => ({ status: 200, etag: 'etag' });
   vi.stubGlobal('XMLHttpRequest', FakeXHR);
   vi.stubGlobal('requestAnimationFrame', (cb: () => void) => setTimeout(cb, 0));
@@ -250,5 +285,130 @@ describe('useS3UploadStore.upload', () => {
     expect(completeCalls).toBe(1);
     expect(result).toBeUndefined();
     expect(useS3UploadStore.getState().items[0].status).toBe('error');
+  });
+});
+
+/**
+ * Every give-up path that runs after the server has issued an upload id owes it a
+ * teardown. Without one the multipart session stays open forever — nothing else
+ * ever closes it — and the parts already transferred keep occupying storage with
+ * no way left to finalize them.
+ *
+ * The part-failure path always did this. Its sibling, the failed-completion path,
+ * returned without aborting, so every failed completion leaked one session. These
+ * assert the abort is actually issued, and issued for the right upload: a check
+ * that only looked at the returned value or the row status passes with the leak
+ * fully intact.
+ */
+describe('useS3UploadStore.upload multipart teardown', () => {
+  const expectedAbort = { ...UPLOAD_IDENTITY, type: UploadType.Model };
+
+  it('aborts the upload when completion fails terminally', async () => {
+    vi.stubGlobal('fetch', makeFetch(1));
+    completeStatus = 503;
+
+    const result = await useS3UploadStore
+      .getState()
+      .upload({ file: makeFile(CHUNK), type: UploadType.Model });
+
+    expect(result).toBeUndefined();
+    expect(useS3UploadStore.getState().items[0].status).toBe('error');
+    expect(abortCalls).toEqual([expectedAbort]);
+  });
+
+  it('aborts the upload when completion returns a terminal 422', async () => {
+    // 422 = parts invalid/incomplete. The session is still live and holding every
+    // part that was transferred, so this is the case that leaks the most.
+    vi.stubGlobal('fetch', makeFetch(2));
+    completeStatus = 422;
+
+    await useS3UploadStore.getState().upload({ file: makeFile(CHUNK * 2), type: UploadType.Model });
+
+    expect(completeCalls).toBe(1);
+    expect(abortCalls).toEqual([expectedAbort]);
+  });
+
+  it('aborts the upload when completion returns a terminal 409', async () => {
+    // 409 = already finalized or aborted. Aborting is idempotent server-side, so
+    // this path abandons nothing by trying.
+    vi.stubGlobal('fetch', makeFetch(1));
+    completeStatus = 409;
+
+    await useS3UploadStore.getState().upload({ file: makeFile(CHUNK), type: UploadType.Model });
+
+    expect(abortCalls).toEqual([expectedAbort]);
+  });
+
+  // Invariant guard, not regression cover: this path already aborted. It pins the
+  // behaviour the completion path above was made to match.
+  it('aborts the upload when a part fails terminally', async () => {
+    vi.stubGlobal('fetch', makeFetch(2));
+    partHandler = (_url, partNumber) =>
+      partNumber === 2 ? { status: 400 } : { status: 200, etag: 'etag' };
+
+    await useS3UploadStore.getState().upload({ file: makeFile(CHUNK * 2), type: UploadType.Model });
+
+    expect(useS3UploadStore.getState().items[0].status).toBe('error');
+    expect(abortCalls).toEqual([expectedAbort]);
+  });
+
+  // Negative control: proves these assertions can distinguish abort from no-abort,
+  // rather than passing because something always records a call.
+  it('does not abort an upload that completed successfully', async () => {
+    vi.stubGlobal('fetch', makeFetch(2));
+
+    const result = await useS3UploadStore
+      .getState()
+      .upload({ file: makeFile(CHUNK * 2), type: UploadType.Model });
+
+    expect(result).toBeTruthy();
+    expect(abortCalls).toEqual([]);
+  });
+
+  it('still aborts when the row was cleared from the store before completion failed', async () => {
+    // A consumer calling clear() (or a navigation that resets the list) mid-upload
+    // makes the terminal status write throw. The teardown must not be collateral:
+    // the session is open regardless of whether a row is left to update.
+    vi.stubGlobal('fetch', makeFetch(1));
+    completeStatus = 503;
+    onCompleteRequest = () => useS3UploadStore.setState({ items: [] });
+
+    const result = await useS3UploadStore
+      .getState()
+      .upload({ file: makeFile(CHUNK), type: UploadType.Model });
+
+    expect(result).toBeUndefined();
+    expect(abortCalls).toEqual([expectedAbort]);
+  });
+
+  it('still aborts when the row was cleared from the store before a part failed', async () => {
+    vi.stubGlobal('fetch', makeFetch(1));
+    partHandler = () => {
+      useS3UploadStore.setState({ items: [] });
+      return { status: 400 };
+    };
+
+    const result = await useS3UploadStore
+      .getState()
+      .upload({ file: makeFile(CHUNK), type: UploadType.Model });
+
+    expect(result).toBeUndefined();
+    expect(abortCalls).toEqual([expectedAbort]);
+  });
+
+  it('does not let a failed abort mask the original failure', async () => {
+    // The teardown is best-effort cleanup, not part of the caller's outcome:
+    // raising here would replace the real cause with an incidental network error.
+    vi.stubGlobal('fetch', makeFetch(1));
+    completeStatus = 503;
+    abortShouldReject = true;
+
+    const result = await useS3UploadStore
+      .getState()
+      .upload({ file: makeFile(CHUNK), type: UploadType.Model });
+
+    expect(result).toBeUndefined();
+    expect(useS3UploadStore.getState().items[0].status).toBe('error');
+    expect(abortCalls).toHaveLength(1);
   });
 });

--- a/src/store/s3-upload.store.ts
+++ b/src/store/s3-upload.store.ts
@@ -301,6 +301,47 @@ export const useS3UploadStore = create<StoreProps>()(
               }),
             });
 
+          // Best-effort teardown of the server-side multipart session. EVERY failure
+          // path that gives up after the session was created has to run this, or the
+          // upload stays open indefinitely and the parts already transferred keep
+          // accruing storage with nothing left to finalize them.
+          //
+          // The rejection is deliberately swallowed rather than surfaced: this is
+          // cleanup, not part of the caller's outcome. Both callers' contract is to
+          // return undefined with a terminal row already written, so raising here
+          // would replace the real cause (the part error, or the failed completion)
+          // with an incidental teardown error at every call site. The abort endpoint
+          // also treats an already-gone upload as success, so a throw on this path is
+          // genuinely exceptional — it gets logged, not raised.
+          const abortUploadQuietly = async () => {
+            try {
+              await abortUpload();
+            } catch (err) {
+              console.error('Failed to abort upload');
+              console.error(err);
+            }
+          };
+
+          // Write a terminal row state without letting a failure here pre-empt the
+          // teardown above. updateFile() throws 'index out of bounds' when the row has
+          // already been dropped from the store (clear(), or a navigation that reset
+          // the list) — and that is precisely a case where the session still needs
+          // aborting, so the two must not share a try block.
+          const setTerminalStatus = (status: UploadStatus) => {
+            try {
+              updateFile(pendingItem.uuid, {
+                status,
+                progress: 0,
+                speed: 0,
+                timeRemaining: 0,
+                uploaded: 0,
+              });
+            } catch (err) {
+              console.error('Failed to write terminal upload status');
+              console.error(err);
+            }
+          };
+
           const completeUpload = () =>
             withRetries(
               async (remainingAttempts) => {
@@ -483,19 +524,8 @@ export const useS3UploadStore = create<StoreProps>()(
           cancelProgress();
 
           if (failureStatus) {
-            try {
-              updateFile(pendingItem.uuid, {
-                status: failureStatus,
-                progress: 0,
-                speed: 0,
-                timeRemaining: 0,
-                uploaded: 0,
-              });
-              await abortUpload();
-            } catch (err) {
-              console.error('Failed to abort upload');
-              console.error(err);
-            }
+            setTerminalStatus(failureStatus);
+            await abortUploadQuietly();
             return;
           }
 
@@ -511,14 +541,18 @@ export const useS3UploadStore = create<StoreProps>()(
           // Every bailout here has to leave a terminal 'error' behind: the bytes are in
           // the bucket but no file record exists, and a row left mid-progress reads to
           // the user as a finished upload that silently never got added.
+          //
+          // It also has to tear the multipart session down. A failed completion leaves
+          // the session open with every transferred part still stored and billable, and
+          // nothing else ever closes it — the part-failure branch above has always
+          // aborted, but this sibling path returned without doing so, so each failed
+          // completion leaked one upload permanently. Both terminal outcomes need it:
+          // 422 (invalid/incomplete parts) leaves a live session holding every part,
+          // and 409 (already finalized or aborted) is harmless because the abort
+          // endpoint treats an upload that is already gone as success.
           if (!completeResult?.ok) {
-            updateFile(pendingItem.uuid, {
-              status: 'error',
-              progress: 0,
-              speed: 0,
-              timeRemaining: 0,
-              uploaded: 0,
-            });
+            setTerminalStatus('error');
+            await abortUploadQuietly();
             return;
           }
 


### PR DESCRIPTION
## The bug

`src/store/s3-upload.store.ts` has two sibling give-up paths after a multipart upload session has been created. The part-failure branch tears the session down before returning. The completion-failure branch — taken when `/api/upload/complete` never succeeds — wrote a terminal `'error'` row and returned **without** aborting.

Nothing else ever closes that session. It stays open indefinitely, and the parts already transferred keep occupying storage with no way left to finalize them. Every failed completion leaked exactly one upload, permanently. The asymmetry is the tell: the sibling path already knew to abort, so this was a missing call rather than a design question.

## Every exit path in the flow, audited

Rather than fixing only the reported branch, here is the full set of exits after the `/api/upload` response is parsed:

| Exit | Aborts? | Verdict |
|---|---|---|
| `'error' in data` throw | no | **Correct.** Runs before an upload id exists — there is nothing to abort, and no identity to abort it with. |
| `await res.json()` throwing on a non-JSON body | no | **Not fixable here.** The server may have created a session, but the client never learns its id. Pre-existing `TODO` on that line; left alone. |
| part-failure branch | yes | Already correct — but see the second bug below. |
| **completion-failure branch** | **no → now yes** | **The leak.** Fixed. |
| success path | no | **Correct.** Completion succeeded, so there is no session left to tear down. |

## A second instance of the same omission, on the path that supposedly handled it

The part-failure branch shared **one `try` block** between the terminal status write and the abort. `updateFile()` throws `index out of bounds` when the row has already been dropped from the store — `clear()`, or a navigation that reset the list. When that happened the abort was **skipped entirely**, and the `catch` logged `Failed to abort upload`: true, but for the wrong reason, since no abort had been attempted.

So the path credited with handling teardown had a conditional leak of its own. The status write and the teardown are now independent, and this is covered by its own test.

## Should a failing abort be surfaced or swallowed?

**Swallowed, and logged.** Reasoning:

- It is cleanup, not part of the caller's outcome. Both paths' contract is to return `undefined` with a terminal row already written; raising here would replace the real cause — the part error, or the failed completion — with an incidental teardown error at every call site. A throw inside error handling that masks the original error is its own bug.
- The abort endpoint already treats an upload that is already gone as success, so a rejection on this path is genuinely exceptional rather than routine.
- Consistency with the sibling path, whose divergence is what produced this bug class in the first place.

Critically, swallowing must not mean the abort failure can eat the *status write*, nor the reverse — which was the second bug. The two are now separately isolated, in that order.

## Tests

Extended the existing `s3-upload.store.test.ts` harness (its fake already models the `/api/upload/*` contract) to record abort requests and their body.

The assertions check that the abort is **issued, and issued for the right upload** — a test that only looked at the return value or the row status passes with the leak fully intact. The pre-existing `marks the file errored when complete never succeeds` test is exactly that shape, which is why the leak survived it.

New cases:

- completion fails terminally (retries exhausted) → aborts
- completion returns terminal 422 → aborts *(invalid/incomplete parts: the session is still live and holding every part, so this leaks the most)*
- completion returns terminal 409 → aborts *(already finalized/aborted; idempotent server-side, so nothing is lost by trying)*
- part fails terminally → aborts *(invariant guard, not regression cover — this path already worked)*
- **successful upload does not abort** *(negative control: proves the assertions can distinguish abort from no-abort, rather than passing because something always records a call)*
- row cleared from the store before completion failed → still aborts
- row cleared from the store before a part failed → still aborts
- a failing abort does not mask the original failure

### Evidence

- **Red at `6bf01a274d`** (base, new tests against the unmodified store): `6 failed | 9 passed (15)`. The three completion cases failed with `expected [] to deeply equal [{…}]` — zero abort calls. The cleared-row cases failed with `index out of bounds` traced to the shared `try` block, which is what confirmed the second bug empirically rather than by inspection.
- **Green at HEAD:** `15 passed (15)` (7 pre-existing + 8 new).
- **Mutation check:** changing the abort body's `uploadId` to a wrong value kills 6 of the new tests, with the mutant value named in the assertion diff — so the identity assertion is load-bearing, not merely "a call happened".
- **Wider regression run:** `src/store` plus the three upload endpoint suites — `132 passed (132)`, 10 files.
- `pnpm typecheck`: **12 errors, identical at base and at HEAD** (byte-identical error lines). All in `src/pages/api/internal/bitdex-stats.ts` and `src/server/services/image.service.ts`, from an unresolvable `event-engine-common` sibling path. Pre-existing and unrelated; none in the touched files.
- `prettier --check` clean on both changed files, verified against a known-bad control file so the pass is not a zero-files pass.

## Scope

This stops new leaks. It does **not** clean up sessions already orphaned by the old behaviour — that needs a separate sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
