### PR TITLE
fix(upload): verify the object exists before reporting a multipart completion

### DIFF
--- a/src/env/__tests__/server-schema-upload-complete-verify.test.ts
+++ b/src/env/__tests__/server-schema-upload-complete-verify.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { serverSchema } from '~/env/server-schema';
+
+/**
+ * UPLOAD_COMPLETE_VERIFY_ENFORCE gates whether /api/upload/complete REJECTS a
+ * completion whose object it could not find. It ships OFF: the probe runs and logs,
+ * but nothing fails, so the false-reject rate can be measured before enforcement.
+ *
+ * 🔴 Why this is tested at the SCHEMA and not left to inspection. The handler reads
+ * `env.UPLOAD_COMPLETE_VERIFY_ENFORCE === true`. If the schema yielded the STRING
+ * `'true'` instead of a boolean, that comparison would be false forever and the gate
+ * could never be turned on — an inert config key that reads as enabled and does
+ * nothing, with no error anywhere. The values below are hand-written literals for what
+ * the deployment actually sets, not values recomputed from the schema.
+ *
+ * The two rows that matter operationally:
+ *   nothing set        → false  (the shipped default; observe-only)
+ *   the string 'true'  → true   (a real boolean, so `=== true` fires)
+ */
+const field = serverSchema.shape.UPLOAD_COMPLETE_VERIFY_ENFORCE;
+
+describe('UPLOAD_COMPLETE_VERIFY_ENFORCE env gate', () => {
+  it('defaults to false when unset — enforcement is opt-in', () => {
+    expect(field.parse(undefined)).toBe(false);
+  });
+
+  it("yields a real BOOLEAN true for the string 'true', so `=== true` can fire", () => {
+    const parsed = field.parse('true');
+    expect(parsed).toBe(true);
+    expect(typeof parsed).toBe('boolean');
+  });
+
+  it.each(['', 'false', 'FALSE', 'no', '0', 'yes', 'garbage'])(
+    'treats %j as NOT enforcing (only an unambiguous opt-in enables rejection)',
+    (value) => {
+      expect(field.parse(value)).toBe(false);
+    }
+  );
+
+  it('accepts a real boolean true as well', () => {
+    expect(field.parse(true)).toBe(true);
+  });
+});

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -601,6 +601,15 @@ export const serverSchema = z
     FRESHDESK_TOKEN: z.string().optional(),
     FRESHDESK_AGENT_ID: z.coerce.number().optional(),
     UPLOAD_PROHIBITED_EXTENSIONS: commaDelimitedStringArray().optional(),
+    // Enforce the post-completion object-existence check in /api/upload/complete.
+    // 🔴 Defaults to FALSE = observe-only: the probe still runs and its verdict is
+    // logged, but a missing object does NOT fail the request. That ordering is
+    // deliberate — a 422 here increments no Prometheus counter (the http-error
+    // instrument returns early below 500), so the false-reject rate has to be
+    // measured from the completion log before rejection is switched on. Deliberately
+    // an env var rather than a Flipt flag: this endpoint family removed Flipt
+    // precisely because init failure caused a silent fallback.
+    UPLOAD_COMPLETE_VERIFY_ENFORCE: zc.booleanString.optional().default(false),
     POST_INTENT_DETAILS_HOSTS: z.preprocess(stringToArray, z.array(z.url()).optional()),
     CHOPPED_TOKEN: z.string().optional(),
     TIER_METADATA_KEY: z.string().default('tier'),

--- a/src/hooks/useS3Upload.tsx
+++ b/src/hooks/useS3Upload.tsx
@@ -6,7 +6,12 @@ import type { UploadTypeUnion } from '~/server/common/enums';
 import { UploadType } from '~/server/common/enums';
 import { withRetries } from '~/utils/errorHandling';
 import type { UploadPartError } from '~/utils/upload-retry';
-import { getPartRetryDelay, MAX_PART_ATTEMPTS, shouldRetryPartError } from '~/utils/upload-retry';
+import {
+  getPartRetryDelay,
+  isTerminalCompleteStatus,
+  MAX_PART_ATTEMPTS,
+  shouldRetryPartError,
+} from '~/utils/upload-retry';
 
 const FILE_CHUNK_SIZE = 25 * 1024 * 1024; // 25 MB
 const CONCURRENT_PARTS = 4;
@@ -242,7 +247,10 @@ export const useS3Upload: UseS3Upload = (options = {}) => {
               }),
             });
 
-            if (!res.ok && remainingAttempts > 0) {
+            // Terminal statuses must not be re-POSTed — see isTerminalCompleteStatus.
+            // This exemption was missing here (it existed only in s3-upload.store.ts),
+            // so a terminal status was retried 4 times, 200 ms apart.
+            if (!res.ok && !isTerminalCompleteStatus(res.status) && remainingAttempts > 0) {
               throw new Error('Failed to complete upload');
             }
 

--- a/src/pages/api/upload/complete.ts
+++ b/src/pages/api/upload/complete.ts
@@ -76,9 +76,14 @@ const upload = async (req: NextApiRequest, res: NextApiResponse) => {
      * indistinguishable from a healthy one, and the bytes are unrecoverable — the
      * browser had already dropped them.
      *
-     * One HeadObject closes that gap while the client still holds the file and can
-     * re-upload. We deliberately trust the probe over the response SHAPE: a present,
-     * non-empty object is proof regardless of whether the backend echoed a Location.
+     * One HeadObject closes that gap: the failure surfaces at completion time, as a
+     * failed upload the user can see and retry, instead of a row that looks healthy
+     * forever. 🔴 Note it does NOT guarantee the bytes are still in hand — the store
+     * keeps the File, but `useS3Upload.tsx` sets `file: undefined` on its bailout, so
+     * "retry" there means the user re-selecting the file, not an automatic resend.
+     *
+     * We deliberately trust the probe over the response SHAPE: a present, non-empty
+     * object is proof regardless of whether the backend echoed a Location.
      */
     const head = await headObject(bucket, key, s3, {
       abortSignal: AbortSignal.timeout(COMPLETE_VERIFY_TIMEOUT_MS),
@@ -222,9 +227,13 @@ const upload = async (req: NextApiRequest, res: NextApiResponse) => {
          * We need the client to retry the UPLOAD, not the completion. 422 is the code
          * that already carries that meaning here — "the request was well formed but the
          * upload STATE isn't; terminal → re-upload" — and, unlike a retryable status,
-         * both clients treat it as final rather than re-POSTing a manifest whose
+         * both clients now treat it as final rather than re-POSTing a manifest whose
          * session may already be consumed (each such retry throws NoSuchUpload and gets
          * relabelled "already finalized or aborted", destroying the diagnosis).
+         *
+         * "Both" is load-bearing and was NOT true before this change: the exemption
+         * existed only in s3-upload.store.ts, so useS3Upload.tsx retried a terminal
+         * status 4 times. It is now one shared predicate — see isTerminalCompleteStatus.
          *
          * Not 409: terminal, but carries no re-upload meaning. Not 500: this is a
          * storage-state fault, and paging on it as a server bug buries it.

--- a/src/pages/api/upload/complete.ts
+++ b/src/pages/api/upload/complete.ts
@@ -2,24 +2,40 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { instrumentApiResponse } from '~/server/prom/http-errors';
 import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
 import {
+  abortMultipartUpload,
   classifyS3MultipartError,
   completeMultipartUpload,
+  getS3Client,
   getUploadS3Client,
   getB2ImageS3Client,
   headObject,
   objectExists,
 } from '~/utils/s3-utils';
 import { logToAxiom } from '~/server/logging/client';
+import { env } from '~/env/server';
 
 /**
- * Wall-clock budget for the post-completion existence probe. The user has already
- * waited out the whole upload by this point, so a few seconds is invisible — but an
- * UNBOUNDED probe against a degraded backend would turn a finished upload into a
- * hung request, which is strictly worse than the bug this guards. Per `headObject`'s
- * contract this bounds each network attempt, not wall-clock: worst case is the budget
- * plus one SDK backoff, and an abort lands on `unknown` → fail open.
+ * Timeout budget for the post-completion existence probe. The user has already waited
+ * out the whole upload by this point, so a few seconds is invisible — but an UNBOUNDED
+ * probe against a degraded backend would turn a finished upload into a hung request,
+ * which is strictly worse than the bug this guards.
+ *
+ * Per `headObject`'s contract this bounds each network ATTEMPT, not wall-clock: the
+ * SDK's retry sleep is not abort-aware, so worst case is this budget plus one backoff.
+ * An abort lands on `unknown` → the request passes.
  */
 const COMPLETE_VERIFY_TIMEOUT_MS = 5_000;
+
+/**
+ * What the post-completion probe concluded. 🔴 THREE values, never a boolean.
+ *
+ * A boolean forces the fail-open case to be reported as one of the other two, and
+ * both readings are wrong: counting `indeterminate` as verified asserts we confirmed
+ * an object we never saw, and counting it as missing inflates the defect rate with
+ * probes that simply could not reach the bucket. Both directions corrupt the very
+ * measurement the observe-only rollout below exists to take.
+ */
+type VerifyVerdict = 'confirmed' | 'missing' | 'indeterminate';
 
 const upload = async (req: NextApiRequest, res: NextApiResponse) => {
   // 5xx attribution: bypasses the endpoint wrappers, so its 500s were
@@ -40,6 +56,13 @@ const upload = async (req: NextApiRequest, res: NextApiResponse) => {
     s3 = getUploadS3Client('b2');
   }
   try {
+    // Resolve the default (R2) client ONCE and reuse it for both the completion and
+    // the probe below. Without this the probe builds a SECOND unmemoized S3Client per
+    // request on the `default` happy path, where previously one was built per
+    // completion. Kept inside the try so an unconfigured environment still lands in
+    // the classifier below rather than throwing out of the handler.
+    s3 ??= getS3Client();
+
     const result = await completeMultipartUpload(bucket, key, uploadId, parts, s3);
 
     /**
@@ -61,14 +84,15 @@ const upload = async (req: NextApiRequest, res: NextApiResponse) => {
       abortSignal: AbortSignal.timeout(COMPLETE_VERIFY_TIMEOUT_MS),
     });
     /**
-     * 🔴 FAIL OPEN, deliberately, and only on what the backend actually asserted.
+     * 🔴 REJECT ONLY ON WHAT THE BACKEND ACTUALLY ASSERTED.
      *
-     * `unknown` (the probe threw, timed out, 403'd, or the client wasn't configured)
-     * means we could not consult the bucket — that is not evidence of loss, and
-     * treating it as loss would let a verification step fail uploads that worked. It
-     * is logged and passes. Only two verdicts reject: the bucket answered `absent`,
-     * or it answered with a definitively ZERO ContentLength. `size: null` is "the
-     * backend reported no length", not zero, so it must not trip the size check.
+     * `indeterminate` (the probe threw, timed out, 403'd, or the client wasn't
+     * configured) means we could not consult the bucket. That is not evidence of loss,
+     * and treating it as loss would let a verification step fail uploads that worked.
+     * It is logged and the request passes. Only two shapes are `missing`: the bucket
+     * ANSWERED `absent`, or it answered with a definitively ZERO ContentLength.
+     * `size: null` is "the backend reported no length", not zero, so it must not trip
+     * the size check.
      *
      * NOTE what this can and cannot catch. There is NO trustworthy expected size at
      * this point in the flow: the request body carries only bucket/key/uploadId/parts,
@@ -78,8 +102,42 @@ const upload = async (req: NextApiRequest, res: NextApiResponse) => {
      * object. That is not a reason to invent a comparison that looks rigorous and
      * isn't — a present, non-empty object is strictly better evidence than none.
      */
-    const objectMissing =
-      head.status === 'absent' || (head.status === 'present' && head.size === 0);
+    let verdict: VerifyVerdict;
+    if (head.status === 'unknown') verdict = 'indeterminate';
+    else if (head.status === 'absent' || head.size === 0) verdict = 'missing';
+    else verdict = 'confirmed';
+
+    /**
+     * 🔴 OBSERVE-ONLY BY DEFAULT. The probe always runs and always logs; whether a
+     * `missing` verdict actually FAILS the request is gated.
+     *
+     * Rejecting here is a new failure mode on the upload happy path, and there is
+     * currently no way to see or stop a false-reject storm: a 422 increments no
+     * Prometheus counter, because the http-error instrument returns early below 500.
+     * The only signal is this log.
+     *
+     * The measurement also has to come first on its merits. The known damage — rows
+     * pointing at objects that never landed — can only count the PERMANENT class. If a
+     * backend can ack a completion before the object is listable, there is also a
+     * TRANSIENT class that is observable ONLY from this probe, and it is exactly the
+     * population that would be falsely rejected. R2 documents strong read-after-write
+     * consistency including multipart; Backblaze's S3-compatible API reference
+     * documents no consistency model at all, and its native large-file docs advise
+     * re-checking after a finish call that appears to succeed. So on the backend where
+     * the incident happened, "acked" and "visible" are not established to be the same
+     * instant — and our own premise is that it acked while leaving nothing behind.
+     *
+     * So: deploy with this off, let the `missing` rate accumulate against the total,
+     * then enable it in a second deploy. Flipping it back off is a config change, not
+     * a revert.
+     *
+     * Compared against `true` explicitly: the gate guards a REJECTION, so anything
+     * other than an unambiguous opt-in — unset, malformed, a stray string — must land
+     * on observe-only rather than on failing uploads. It also keeps the logged field a
+     * real boolean instead of `undefined`, which would be indistinguishable from
+     * "this build predates the field" when reading the rollout data.
+     */
+    const enforcing = env.UPLOAD_COMPLETE_VERIFY_ENFORCE === true;
 
     // Log the SHAPE of the completion, not just that it happened, now including the
     // probe's verdict — so a silently-empty completion is distinguishable from a
@@ -97,12 +155,28 @@ const upload = async (req: NextApiRequest, res: NextApiResponse) => {
       etag: result?.ETag ?? null,
       objectStatus: head.status,
       objectSize: head.status === 'present' ? head.size : null,
-      objectVerified: !objectMissing,
+      verifyVerdict: verdict,
+      verifyEnforced: enforcing,
     });
 
-    if (objectMissing) {
+    // The fail-open branch gets its OWN event, so the rate at which this guard cannot
+    // see the bucket is measurable on its own rather than being folded into either the
+    // healthy or the defective count.
+    if (verdict === 'indeterminate') {
+      await logToAxiom({
+        name: 's3-upload-complete-verify-unknown',
+        userId,
+        type,
+        key,
+        uploadId,
+        backend,
+      });
+    }
+
+    if (verdict === 'missing') {
       // Distinct event name so this class is alertable on its own rather than hiding
-      // inside the generic completion log.
+      // inside the generic completion log. `verifyEnforced` separates "we would have
+      // rejected this" during the observe-only phase from an actual rejection.
       await logToAxiom({
         name: 's3-upload-complete-unverified',
         userId,
@@ -115,33 +189,56 @@ const upload = async (req: NextApiRequest, res: NextApiResponse) => {
         etag: result?.ETag ?? null,
         objectStatus: head.status,
         objectSize: head.status === 'present' ? head.size : null,
+        verifyEnforced: enforcing,
       });
 
-      /**
-       * 422, against this handler's existing taxonomy (409 terminal / 422 parts-invalid
-       * + no-store / 503 transient + Retry-After / 500 genuine fault).
-       *
-       * We need the client to retry the UPLOAD, not the completion — and 422 is the
-       * code that already means exactly that here: "the request was well formed but
-       * the upload STATE isn't; terminal → the client must stop retrying this manifest
-       * and re-upload." The client store treats 409 and 422 as terminal and everything
-       * else as retry-the-completion, then surfaces any non-ok as a failed upload row
-       * while the browser still holds the File.
-       *
-       * Not 503: re-sending the same manifest cannot be better founded than the call
-       * the backend already acknowledged, so its three retries end at the same failed
-       * row having cost three more completions and three more probes. Worse, if the
-       * first completion did consume the session, each retry now throws NoSuchUpload
-       * and lands in the `not-found` branch, relabelling a silent-loss event as
-       * "already finalized or aborted" — destroying the diagnosis. Not 409: that tells
-       * the client to stop with no instruction to re-upload. Not 500: this is a
-       * storage-state fault, and paging on it as a server bug buries it.
-       */
-      res.setHeader('Cache-Control', 'no-store');
-      res.status(422).json({
-        error: 'Upload completed but the file was not stored — please re-upload',
-      });
-      return;
+      if (enforcing) {
+        /**
+         * Release the multipart session before failing, so a rejected completion does
+         * not strand parts. These are the largest objects in the system.
+         *
+         * Safe in both directions: if the session really is unfinished this frees the
+         * parts, and if the completion did finalize an object then Abort answers
+         * NoSuchUpload and is a no-op — it cannot delete a finalized object. Guarded
+         * because a cleanup failure must never change the response the client gets.
+         *
+         * 🔴 This bounds the PARTS leak, not every leak. The upload key carries a
+         * random token, so the client's retry writes to a DIFFERENT key; an object that
+         * becomes visible after we called it absent would sit at the old key with no DB
+         * row. That case cannot be cleaned up from here without deleting an object we
+         * just concluded does not exist — and it is precisely the population the
+         * observe-only phase above exists to measure before rejection is enabled.
+         */
+        try {
+          await abortMultipartUpload(bucket, key, uploadId, s3);
+        } catch {
+          /* cleanup is best-effort; never let it change the client's outcome */
+        }
+
+        /**
+         * 422, against this handler's existing taxonomy (409 terminal / 422
+         * parts-invalid + no-store / 503 transient + Retry-After / 500 genuine fault).
+         *
+         * We need the client to retry the UPLOAD, not the completion. 422 is the code
+         * that already carries that meaning here — "the request was well formed but the
+         * upload STATE isn't; terminal → re-upload" — and, unlike a retryable status,
+         * both clients treat it as final rather than re-POSTing a manifest whose
+         * session may already be consumed (each such retry throws NoSuchUpload and gets
+         * relabelled "already finalized or aborted", destroying the diagnosis).
+         *
+         * Not 409: terminal, but carries no re-upload meaning. Not 500: this is a
+         * storage-state fault, and paging on it as a server bug buries it.
+         *
+         * 🔴 The status is chosen for retry semantics and log separability, NOT for the
+         * message text — neither client reads this body on the completion path, so the
+         * user sees the same generic upload-failed copy either way.
+         */
+        res.setHeader('Cache-Control', 'no-store');
+        res.status(422).json({
+          error: 'Upload completed but the file was not stored — please re-upload',
+        });
+        return;
+      }
     }
 
     res.status(200).json(result.Location);

--- a/src/pages/api/upload/complete.ts
+++ b/src/pages/api/upload/complete.ts
@@ -6,9 +6,20 @@ import {
   completeMultipartUpload,
   getUploadS3Client,
   getB2ImageS3Client,
+  headObject,
   objectExists,
 } from '~/utils/s3-utils';
 import { logToAxiom } from '~/server/logging/client';
+
+/**
+ * Wall-clock budget for the post-completion existence probe. The user has already
+ * waited out the whole upload by this point, so a few seconds is invisible — but an
+ * UNBOUNDED probe against a degraded backend would turn a finished upload into a
+ * hung request, which is strictly worse than the bug this guards. Per `headObject`'s
+ * contract this bounds each network attempt, not wall-clock: worst case is the budget
+ * plus one SDK backoff, and an abort lands on `unknown` → fail open.
+ */
+const COMPLETE_VERIFY_TIMEOUT_MS = 5_000;
 
 const upload = async (req: NextApiRequest, res: NextApiResponse) => {
   // 5xx attribution: bypasses the endpoint wrappers, so its 500s were
@@ -30,14 +41,50 @@ const upload = async (req: NextApiRequest, res: NextApiResponse) => {
   }
   try {
     const result = await completeMultipartUpload(bucket, key, uploadId, parts, s3);
-    // Log the SHAPE of the completion, not just that it happened. A completion can
-    // resolve without throwing and still leave the multipart session unfinished with
-    // no object — S3 documents that CompleteMultipartUpload "can contain either a
-    // success or an error" and that an error "might be embedded in the 200 OK
-    // response", so a non-throwing call is not proof of a finalized object. Without
-    // partCount/location/etag there is nothing in the log to tell an apparently-good
-    // completion from a silently-empty one after the fact, and the resulting rows are
-    // indistinguishable from healthy ones. partCount also catches a truncated manifest.
+
+    /**
+     * 🔴 A NON-THROWING COMPLETION IS NOT PROOF OF A STORED OBJECT — so go look.
+     *
+     * S3 documents that CompleteMultipartUpload "can contain either a success or an
+     * error" and that an error "might be embedded in the 200 OK response". In
+     * production a completion resolved as successful, the file row was written 472 ms
+     * later, and the storage backend still lists that multipart session as unfinished
+     * with NO object. Nothing ever re-verified, so the row became permanent and
+     * indistinguishable from a healthy one, and the bytes are unrecoverable — the
+     * browser had already dropped them.
+     *
+     * One HeadObject closes that gap while the client still holds the file and can
+     * re-upload. We deliberately trust the probe over the response SHAPE: a present,
+     * non-empty object is proof regardless of whether the backend echoed a Location.
+     */
+    const head = await headObject(bucket, key, s3, {
+      abortSignal: AbortSignal.timeout(COMPLETE_VERIFY_TIMEOUT_MS),
+    });
+    /**
+     * 🔴 FAIL OPEN, deliberately, and only on what the backend actually asserted.
+     *
+     * `unknown` (the probe threw, timed out, 403'd, or the client wasn't configured)
+     * means we could not consult the bucket — that is not evidence of loss, and
+     * treating it as loss would let a verification step fail uploads that worked. It
+     * is logged and passes. Only two verdicts reject: the bucket answered `absent`,
+     * or it answered with a definitively ZERO ContentLength. `size: null` is "the
+     * backend reported no length", not zero, so it must not trip the size check.
+     *
+     * NOTE what this can and cannot catch. There is NO trustworthy expected size at
+     * this point in the flow: the request body carries only bucket/key/uploadId/parts,
+     * the parts manifest carries ETag+PartNumber with no per-part sizes, and the
+     * `sizeKb` used downstream is client-supplied and never verified against the
+     * bytes. So this catches ABSENT and EMPTY, and cannot catch a short-but-non-zero
+     * object. That is not a reason to invent a comparison that looks rigorous and
+     * isn't — a present, non-empty object is strictly better evidence than none.
+     */
+    const objectMissing =
+      head.status === 'absent' || (head.status === 'present' && head.size === 0);
+
+    // Log the SHAPE of the completion, not just that it happened, now including the
+    // probe's verdict — so a silently-empty completion is distinguishable from a
+    // healthy one in the log, which is exactly what the incident lacked.
+    // partCount also catches a truncated manifest.
     await logToAxiom({
       name: 's3-upload-complete',
       userId,
@@ -48,7 +95,54 @@ const upload = async (req: NextApiRequest, res: NextApiResponse) => {
       partCount: Array.isArray(parts) ? parts.length : null,
       location: result?.Location ?? null,
       etag: result?.ETag ?? null,
+      objectStatus: head.status,
+      objectSize: head.status === 'present' ? head.size : null,
+      objectVerified: !objectMissing,
     });
+
+    if (objectMissing) {
+      // Distinct event name so this class is alertable on its own rather than hiding
+      // inside the generic completion log.
+      await logToAxiom({
+        name: 's3-upload-complete-unverified',
+        userId,
+        type,
+        key,
+        uploadId,
+        backend,
+        partCount: Array.isArray(parts) ? parts.length : null,
+        location: result?.Location ?? null,
+        etag: result?.ETag ?? null,
+        objectStatus: head.status,
+        objectSize: head.status === 'present' ? head.size : null,
+      });
+
+      /**
+       * 422, against this handler's existing taxonomy (409 terminal / 422 parts-invalid
+       * + no-store / 503 transient + Retry-After / 500 genuine fault).
+       *
+       * We need the client to retry the UPLOAD, not the completion — and 422 is the
+       * code that already means exactly that here: "the request was well formed but
+       * the upload STATE isn't; terminal → the client must stop retrying this manifest
+       * and re-upload." The client store treats 409 and 422 as terminal and everything
+       * else as retry-the-completion, then surfaces any non-ok as a failed upload row
+       * while the browser still holds the File.
+       *
+       * Not 503: re-sending the same manifest cannot be better founded than the call
+       * the backend already acknowledged, so its three retries end at the same failed
+       * row having cost three more completions and three more probes. Worse, if the
+       * first completion did consume the session, each retry now throws NoSuchUpload
+       * and lands in the `not-found` branch, relabelling a silent-loss event as
+       * "already finalized or aborted" — destroying the diagnosis. Not 409: that tells
+       * the client to stop with no instruction to re-upload. Not 500: this is a
+       * storage-state fault, and paging on it as a server bug buries it.
+       */
+      res.setHeader('Cache-Control', 'no-store');
+      res.status(422).json({
+        error: 'Upload completed but the file was not stored — please re-upload',
+      });
+      return;
+    }
 
     res.status(200).json(result.Location);
   } catch (e) {

--- a/src/server/__tests__/upload-complete-endpoint.test.ts
+++ b/src/server/__tests__/upload-complete-endpoint.test.ts
@@ -24,21 +24,26 @@ import type { NextApiRequest, NextApiResponse } from 'next';
  * Fails before the fix (everything is a raw 500); passes after.
  */
 
-const { mockCompleteMultipartUpload, mockObjectExists } = vi.hoisted(() => ({
+const { mockCompleteMultipartUpload, mockObjectExists, mockS3Send } = vi.hoisted(() => ({
   mockCompleteMultipartUpload: vi.fn(),
   mockObjectExists: vi.fn(),
+  mockS3Send: vi.fn(),
 }));
 
-// Keep the REAL module (so the real classifyS3MultipartError runs) and override
-// only the network send + client factories.
+// Keep the REAL module (so the real classifyS3MultipartError AND the real
+// `headObject` / `isNotFoundError` run) and override only the network send + client
+// factories. 🔴 The client factories return a stub whose `.send` is `mockS3Send`, so
+// the post-completion HeadObject probe is driven by real AWS-SDK-shaped errors
+// through the real not-found classifier — a fake `headObject` could encode the same
+// wrong shape as the code and pass with the bug present.
 vi.mock('~/utils/s3-utils', async (importOriginal) => {
   const actual = await importOriginal<typeof import('~/utils/s3-utils')>();
   return {
     ...actual,
     completeMultipartUpload: mockCompleteMultipartUpload,
     objectExists: mockObjectExists,
-    getUploadS3Client: vi.fn(() => ({})),
-    getB2ImageS3Client: vi.fn(() => ({})),
+    getUploadS3Client: vi.fn(() => ({ send: mockS3Send })),
+    getB2ImageS3Client: vi.fn(() => ({ send: mockS3Send })),
   };
 });
 
@@ -56,6 +61,9 @@ vi.mock('~/server/db/client', () => ({ dbWrite: {}, dbRead: {} }));
 import handler from '~/pages/api/upload/complete';
 // Mocked in ~/__tests__/setup as vi.fn(); imported here so the LOG PAYLOAD is assertable.
 import { logToAxiom } from '~/server/logging/client';
+// The REAL helper (the vi.mock above spreads the actual module), driven directly to
+// pin the never-throws contract the handler's fail-open depends on.
+import { headObject } from '~/utils/s3-utils';
 
 function makeRes() {
   const headers: Record<string, string> = {};
@@ -106,7 +114,9 @@ function makeReq() {
   return {
     method: 'POST',
     body: {
-      bucket: 'civitai-modelfiles',
+      // The bucket value is irrelevant to every assertion in this file, so it is kept
+      // generic rather than naming a real one (matching `reqWithParts` below).
+      bucket: 'test-bucket',
       key: 'some/key.safetensors',
       type: 'model',
       uploadId: 'test-upload-id',
@@ -125,6 +135,11 @@ beforeEach(() => {
   mockCompleteMultipartUpload.mockReset();
   mockObjectExists.mockReset();
   mockObjectExists.mockResolvedValue(false);
+  // Default for the post-completion HeadObject probe: the object is there with real
+  // bytes. That is the healthy case, so every test that isn't ABOUT the probe keeps
+  // asserting the same status it always did.
+  mockS3Send.mockReset();
+  mockS3Send.mockResolvedValue({ ContentLength: 1024 });
 });
 
 describe('/api/upload/complete — error classification', () => {
@@ -324,5 +339,183 @@ describe('/api/upload/complete — the completion LOG must record the completion
     await handler(reqWithParts(undefined), res);
     expect(logged()?.partCount).toBeNull();
     expect(res.statusCode).toBe(200);
+  });
+});
+
+describe('/api/upload/complete — a successful completion must be VERIFIED against the bucket', () => {
+  /**
+   * WHY THIS EXISTS — silent data loss, proven in production.
+   *
+   * CompleteMultipartUpload can resolve WITHOUT THROWING and still leave the session
+   * unfinished with no object: S3 documents that the call "can contain either a
+   * success or an error" and that an error "might be embedded in the 200 OK
+   * response". A completion resolved as successful, the file row was written 472 ms
+   * later, and the storage backend still lists that session unfinished with NO
+   * object. Nothing re-verified, so the row is permanent, indistinguishable from a
+   * healthy one, and unrecoverable — the browser had already dropped the bytes.
+   *
+   * The fix is one HeadObject before the 200, so the failure lands while the client
+   * still holds the file and can re-upload.
+   *
+   * 🔴 These assert the STATUS AND BODY THE CLIENT SEES, never that HeadObject was
+   * called. A spy-count assertion passes with a handler that issues the probe and
+   * then ignores the answer — which is the entire bug.
+   *
+   * 🔴 The probe runs through the REAL `headObject` and the REAL not-found
+   * classifier; only `s3.send` is stubbed, with AWS-SDK-shaped errors.
+   */
+  const notFound = () =>
+    Object.assign(new Error('NotFound'), { name: 'NotFound', $metadata: { httpStatusCode: 404 } });
+
+  const unverifiedEvent = () =>
+    vi
+      .mocked(logToAxiom)
+      .mock.calls.map((c) => c[0] as Record<string, unknown>)
+      .find((c) => c?.name === 's3-upload-complete-unverified');
+
+  const completeEvent = () =>
+    vi
+      .mocked(logToAxiom)
+      .mock.calls.map((c) => c[0] as Record<string, unknown>)
+      .find((c) => c?.name === 's3-upload-complete');
+
+  beforeEach(() => vi.mocked(logToAxiom).mockClear());
+
+  it('🔴 THE DEFECT: completion resolves but the object is ABSENT → 422, never a success', async () => {
+    mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x', ETag: '"abc"' });
+    mockS3Send.mockRejectedValue(notFound());
+    const res = makeRes();
+    await handler(makeReq(), res);
+    // Before this change the handler returned 200 with result.Location here, and the
+    // client went on to register a row for a file that does not exist.
+    expect(res.statusCode).toBe(422);
+    expect(res.body).toEqual({
+      error: 'Upload completed but the file was not stored — please re-upload',
+    });
+    expect(res.headers['Cache-Control']).toBe('no-store');
+    expect(res.body).not.toBe('https://cdn/x');
+  });
+
+  it('the absent case is separately alertable and records the probe verdict', async () => {
+    mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x', ETag: '"abc"' });
+    mockS3Send.mockRejectedValue(notFound());
+    await handler(makeReq(), makeRes());
+    expect(unverifiedEvent()).toBeDefined();
+    expect(completeEvent()?.objectStatus).toBe('absent');
+    expect(completeEvent()?.objectVerified).toBe(false);
+  });
+
+  it('object present with real bytes → 200 + Location, unchanged', async () => {
+    mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x', ETag: '"abc"' });
+    mockS3Send.mockResolvedValue({ ContentLength: 4096 });
+    const res = makeRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe('https://cdn/x');
+    expect(unverifiedEvent()).toBeUndefined();
+    expect(completeEvent()?.objectVerified).toBe(true);
+    expect(completeEvent()?.objectSize).toBe(4096);
+  });
+
+  it('object present but ZERO bytes → 422 (presence alone is not enough)', async () => {
+    mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x', ETag: '"abc"' });
+    mockS3Send.mockResolvedValue({ ContentLength: 0 });
+    const res = makeRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(422);
+    expect(completeEvent()?.objectSize).toBe(0);
+  });
+
+  /**
+   * 🔴 FAIL-OPEN CASES. A verification step that turns a working upload into an error
+   * is worse than the bug it guards. Only a bucket that ANSWERS "not there" — or
+   * answers with a definitively zero length — may reject. Everything else is "we
+   * could not consult the bucket", which is not evidence of loss.
+   */
+  it('HeadObject 403 (rotated/absent credentials) → 200, not a rejection', async () => {
+    mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x' });
+    mockS3Send.mockRejectedValue(
+      Object.assign(new Error('Access Denied'), {
+        name: 'AccessDenied',
+        $metadata: { httpStatusCode: 403 },
+      })
+    );
+    const res = makeRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe('https://cdn/x');
+    expect(completeEvent()?.objectStatus).toBe('unknown');
+    expect(completeEvent()?.objectVerified).toBe(true);
+  });
+
+  it('HeadObject network failure (ECONNRESET) → 200, not a rejection', async () => {
+    mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x' });
+    mockS3Send.mockRejectedValue(
+      Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' })
+    );
+    const res = makeRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe('https://cdn/x');
+  });
+
+  // The probe's own timeout budget firing must not fail the upload it is checking —
+  // this is the "the verification step causes the failure it looks for" case.
+  it('HeadObject aborted by its own timeout → 200, not a rejection', async () => {
+    mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x' });
+    mockS3Send.mockRejectedValue(
+      Object.assign(new Error('Request aborted'), { name: 'AbortError' })
+    );
+    const res = makeRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(200);
+    expect(completeEvent()?.objectStatus).toBe('unknown');
+  });
+
+  // `size: null` means the backend reported NO length. That is not zero, and a size
+  // check that treats it as zero rejects healthy uploads on every backend that omits
+  // ContentLength.
+  it('object present but the backend reports no ContentLength → 200', async () => {
+    mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x' });
+    mockS3Send.mockResolvedValue({});
+    const res = makeRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(200);
+    expect(completeEvent()?.objectStatus).toBe('present');
+    expect(completeEvent()?.objectSize).toBeNull();
+  });
+
+  // A backend that finalizes the object but echoes no Location is HEALTHY. The probe
+  // is stronger evidence than the response shape, so it — not the shape — decides.
+  it('a completion with NO Location but a real object still returns 200', async () => {
+    mockCompleteMultipartUpload.mockResolvedValue({});
+    mockS3Send.mockResolvedValue({ ContentLength: 512 });
+    const res = makeRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(200);
+    expect(unverifiedEvent()).toBeUndefined();
+  });
+});
+
+describe('headObject — the probe itself can never throw into its caller', () => {
+  // The whole guard rests on this: `headObject` resolving to `unknown` instead of
+  // throwing is what makes the handler's fail-open reachable at all. A client object
+  // with no usable `send` is the cheapest deterministic stand-in for "the client
+  // could not be used".
+  it('a client whose send throws synchronously resolves to unknown', async () => {
+    const broken = {
+      send: () => {
+        throw new TypeError('boom');
+      },
+    } as never;
+    await expect(headObject('test-bucket', 'k', broken)).resolves.toEqual({ status: 'unknown' });
+  });
+
+  it('reports the ContentLength the backend returned', async () => {
+    const ok = { send: async () => ({ ContentLength: 77 }) } as never;
+    await expect(headObject('test-bucket', 'k', ok)).resolves.toEqual({
+      status: 'present',
+      size: 77,
+    });
   });
 });

--- a/src/server/__tests__/upload-complete-endpoint.test.ts
+++ b/src/server/__tests__/upload-complete-endpoint.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 // Setup-order import: installs the shared ~/env/server / logging / prom mocks
 // before the handler evaluates env at module load.
 import '~/__tests__/setup';
@@ -61,9 +61,10 @@ vi.mock('~/server/db/client', () => ({ dbWrite: {}, dbRead: {} }));
 import handler from '~/pages/api/upload/complete';
 // Mocked in ~/__tests__/setup as vi.fn(); imported here so the LOG PAYLOAD is assertable.
 import { logToAxiom } from '~/server/logging/client';
-// The REAL helper (the vi.mock above spreads the actual module), driven directly to
-// pin the never-throws contract the handler's fail-open depends on.
-import { headObject } from '~/utils/s3-utils';
+// The enforcement gate is read off the (mocked) server env; toggled per test below.
+// `headObject` itself is unit-tested in src/utils/__tests__/s3-utils.test.ts, including
+// the tri-state mapping and the client-cannot-be-constructed case.
+import { env } from '~/env/server';
 
 function makeRes() {
   const headers: Record<string, string> = {};
@@ -342,7 +343,7 @@ describe('/api/upload/complete — the completion LOG must record the completion
   });
 });
 
-describe('/api/upload/complete — a successful completion must be VERIFIED against the bucket', () => {
+describe('/api/upload/complete — a successful completion is VERIFIED against the bucket', () => {
   /**
    * WHY THIS EXISTS — silent data loss, proven in production.
    *
@@ -354,9 +355,6 @@ describe('/api/upload/complete — a successful completion must be VERIFIED agai
    * object. Nothing re-verified, so the row is permanent, indistinguishable from a
    * healthy one, and unrecoverable — the browser had already dropped the bytes.
    *
-   * The fix is one HeadObject before the 200, so the failure lands while the client
-   * still holds the file and can re-upload.
-   *
    * 🔴 These assert the STATUS AND BODY THE CLIENT SEES, never that HeadObject was
    * called. A spy-count assertion passes with a handler that issues the probe and
    * then ignores the answer — which is the entire bug.
@@ -367,155 +365,204 @@ describe('/api/upload/complete — a successful completion must be VERIFIED agai
   const notFound = () =>
     Object.assign(new Error('NotFound'), { name: 'NotFound', $metadata: { httpStatusCode: 404 } });
 
-  const unverifiedEvent = () =>
+  const eventNamed = (name: string) =>
     vi
       .mocked(logToAxiom)
       .mock.calls.map((c) => c[0] as Record<string, unknown>)
-      .find((c) => c?.name === 's3-upload-complete-unverified');
+      .find((c) => c?.name === name);
 
-  const completeEvent = () =>
-    vi
-      .mocked(logToAxiom)
-      .mock.calls.map((c) => c[0] as Record<string, unknown>)
-      .find((c) => c?.name === 's3-upload-complete');
+  const completeEvent = () => eventNamed('s3-upload-complete');
+
+  /** Which SDK commands actually reached the wire, in order. */
+  const sentCommands = () => mockS3Send.mock.calls.map((c) => (c[0] as object)?.constructor?.name);
+
+  // The enforcement gate is an env var (deliberately NOT a Flipt flag — this endpoint
+  // family removed Flipt because init failure caused a silent fallback). The shared
+  // setup mock proxies a plain object, so a field can be set and removed per test.
+  const envRecord = env as unknown as Record<string, unknown>;
+  const setEnforce = (value: boolean) => {
+    envRecord.UPLOAD_COMPLETE_VERIFY_ENFORCE = value;
+  };
 
   beforeEach(() => vi.mocked(logToAxiom).mockClear());
+  afterEach(() => {
+    delete envRecord.UPLOAD_COMPLETE_VERIFY_ENFORCE;
+  });
 
-  it('🔴 THE DEFECT: completion resolves but the object is ABSENT → 422, never a success', async () => {
-    mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x', ETag: '"abc"' });
-    mockS3Send.mockRejectedValue(notFound());
-    const res = makeRes();
-    await handler(makeReq(), res);
-    // Before this change the handler returned 200 with result.Location here, and the
-    // client went on to register a row for a file that does not exist.
-    expect(res.statusCode).toBe(422);
-    expect(res.body).toEqual({
-      error: 'Upload completed but the file was not stored — please re-upload',
+  describe('observe-only (the default) — measure first, never fail an upload', () => {
+    /**
+     * 🔴 Rejecting is OFF by default and that is the shipped behaviour of this PR.
+     * A 422 here increments no Prometheus counter (the http-error instrument returns
+     * early below 500), so there would be no way to see or stop a false-reject storm
+     * until the rate has been measured from the log. These tests pin that the probe
+     * still runs and still records its verdict while changing nothing the user sees.
+     */
+    it('an ABSENT object is recorded but does NOT fail the upload', async () => {
+      mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x', ETag: '"abc"' });
+      mockS3Send.mockRejectedValue(notFound());
+      const res = makeRes();
+      await handler(makeReq(), res);
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toBe('https://cdn/x');
+      expect(completeEvent()?.verifyVerdict).toBe('missing');
+      expect(completeEvent()?.verifyEnforced).toBe(false);
+      expect(eventNamed('s3-upload-complete-unverified')).toBeDefined();
     });
-    expect(res.headers['Cache-Control']).toBe('no-store');
-    expect(res.body).not.toBe('https://cdn/x');
+
+    it('does NOT abort the multipart session while only observing', async () => {
+      mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x' });
+      mockS3Send.mockRejectedValue(notFound());
+      await handler(makeReq(), makeRes());
+      // Only the HeadObject probe may reach the wire in observe-only mode.
+      expect(sentCommands()).toEqual(['HeadObjectCommand']);
+    });
   });
 
-  it('the absent case is separately alertable and records the probe verdict', async () => {
-    mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x', ETag: '"abc"' });
-    mockS3Send.mockRejectedValue(notFound());
-    await handler(makeReq(), makeRes());
-    expect(unverifiedEvent()).toBeDefined();
-    expect(completeEvent()?.objectStatus).toBe('absent');
-    expect(completeEvent()?.objectVerified).toBe(false);
-  });
+  describe('enforcing — a missing object fails the completion', () => {
+    beforeEach(() => setEnforce(true));
 
-  it('object present with real bytes → 200 + Location, unchanged', async () => {
-    mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x', ETag: '"abc"' });
-    mockS3Send.mockResolvedValue({ ContentLength: 4096 });
-    const res = makeRes();
-    await handler(makeReq(), res);
-    expect(res.statusCode).toBe(200);
-    expect(res.body).toBe('https://cdn/x');
-    expect(unverifiedEvent()).toBeUndefined();
-    expect(completeEvent()?.objectVerified).toBe(true);
-    expect(completeEvent()?.objectSize).toBe(4096);
-  });
+    it('🔴 THE DEFECT: completion resolves but the object is ABSENT → 422, never a success', async () => {
+      mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x', ETag: '"abc"' });
+      mockS3Send.mockRejectedValue(notFound());
+      const res = makeRes();
+      await handler(makeReq(), res);
+      // Before this change the handler returned 200 with result.Location here, and the
+      // client went on to register a row for a file that does not exist.
+      expect(res.statusCode).toBe(422);
+      expect(res.body).toEqual({
+        error: 'Upload completed but the file was not stored — please re-upload',
+      });
+      expect(res.headers['Cache-Control']).toBe('no-store');
+      expect(res.body).not.toBe('https://cdn/x');
+    });
 
-  it('object present but ZERO bytes → 422 (presence alone is not enough)', async () => {
-    mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x', ETag: '"abc"' });
-    mockS3Send.mockResolvedValue({ ContentLength: 0 });
-    const res = makeRes();
-    await handler(makeReq(), res);
-    expect(res.statusCode).toBe(422);
-    expect(completeEvent()?.objectSize).toBe(0);
-  });
+    it('releases the multipart session so a rejected completion does not strand parts', async () => {
+      mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x' });
+      mockS3Send.mockRejectedValue(notFound());
+      await handler(makeReq(), makeRes());
+      expect(sentCommands()).toEqual(['HeadObjectCommand', 'AbortMultipartUploadCommand']);
+    });
 
-  /**
-   * 🔴 FAIL-OPEN CASES. A verification step that turns a working upload into an error
-   * is worse than the bug it guards. Only a bucket that ANSWERS "not there" — or
-   * answers with a definitively zero length — may reject. Everything else is "we
-   * could not consult the bucket", which is not evidence of loss.
-   */
-  it('HeadObject 403 (rotated/absent credentials) → 200, not a rejection', async () => {
-    mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x' });
-    mockS3Send.mockRejectedValue(
-      Object.assign(new Error('Access Denied'), {
-        name: 'AccessDenied',
-        $metadata: { httpStatusCode: 403 },
-      })
-    );
-    const res = makeRes();
-    await handler(makeReq(), res);
-    expect(res.statusCode).toBe(200);
-    expect(res.body).toBe('https://cdn/x');
-    expect(completeEvent()?.objectStatus).toBe('unknown');
-    expect(completeEvent()?.objectVerified).toBe(true);
-  });
+    // The abort is cleanup, not the verdict. A backend that also fails the abort must
+    // still get the same terminal answer to the client.
+    it('a FAILING abort does not change the response the client sees', async () => {
+      mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x' });
+      mockS3Send.mockRejectedValue(notFound()); // both the head AND the abort reject
+      const res = makeRes();
+      await handler(makeReq(), res);
+      expect(res.statusCode).toBe(422);
+    });
 
-  it('HeadObject network failure (ECONNRESET) → 200, not a rejection', async () => {
-    mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x' });
-    mockS3Send.mockRejectedValue(
-      Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' })
-    );
-    const res = makeRes();
-    await handler(makeReq(), res);
-    expect(res.statusCode).toBe(200);
-    expect(res.body).toBe('https://cdn/x');
-  });
+    it('object present but ZERO bytes → 422 (presence alone is not enough)', async () => {
+      mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x' });
+      mockS3Send.mockResolvedValue({ ContentLength: 0 });
+      const res = makeRes();
+      await handler(makeReq(), res);
+      expect(res.statusCode).toBe(422);
+      expect(completeEvent()?.objectSize).toBe(0);
+      expect(completeEvent()?.verifyEnforced).toBe(true);
+    });
 
-  // The probe's own timeout budget firing must not fail the upload it is checking —
-  // this is the "the verification step causes the failure it looks for" case.
-  it('HeadObject aborted by its own timeout → 200, not a rejection', async () => {
-    mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x' });
-    mockS3Send.mockRejectedValue(
-      Object.assign(new Error('Request aborted'), { name: 'AbortError' })
-    );
-    const res = makeRes();
-    await handler(makeReq(), res);
-    expect(res.statusCode).toBe(200);
-    expect(completeEvent()?.objectStatus).toBe('unknown');
-  });
+    it('object present with real bytes → 200 + Location, unchanged', async () => {
+      mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x', ETag: '"abc"' });
+      mockS3Send.mockResolvedValue({ ContentLength: 4096 });
+      const res = makeRes();
+      await handler(makeReq(), res);
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toBe('https://cdn/x');
+      expect(eventNamed('s3-upload-complete-unverified')).toBeUndefined();
+      expect(completeEvent()?.verifyVerdict).toBe('confirmed');
+      expect(completeEvent()?.objectSize).toBe(4096);
+    });
 
-  // `size: null` means the backend reported NO length. That is not zero, and a size
-  // check that treats it as zero rejects healthy uploads on every backend that omits
-  // ContentLength.
-  it('object present but the backend reports no ContentLength → 200', async () => {
-    mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x' });
-    mockS3Send.mockResolvedValue({});
-    const res = makeRes();
-    await handler(makeReq(), res);
-    expect(res.statusCode).toBe(200);
-    expect(completeEvent()?.objectStatus).toBe('present');
-    expect(completeEvent()?.objectSize).toBeNull();
-  });
+    /**
+     * 🔴 FAIL-OPEN CASES, asserted with enforcement ON — otherwise they would pass for
+     * the wrong reason (the gate being off). A verification step that turns a working
+     * upload into an error is worse than the bug it guards, so only a bucket that
+     * ANSWERS "not there", or answers a definitively zero length, may reject.
+     */
+    it.each([
+      [
+        'a 403 from a rotated/absent credential',
+        Object.assign(new Error('Access Denied'), {
+          name: 'AccessDenied',
+          $metadata: { httpStatusCode: 403 },
+        }),
+      ],
+      ['a network failure', Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' })],
+      // The probe's own timeout budget firing must not fail the upload it is checking:
+      // "the verification step causes the failure it looks for".
+      [
+        'its own timeout aborting',
+        Object.assign(new Error('Request aborted'), { name: 'AbortError' }),
+      ],
+    ])('HeadObject failing with %s → 200, and no abort', async (_label, error) => {
+      mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x' });
+      mockS3Send.mockRejectedValue(error);
+      const res = makeRes();
+      await handler(makeReq(), res);
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toBe('https://cdn/x');
+      expect(completeEvent()?.verifyVerdict).toBe('indeterminate');
+      expect(sentCommands()).toEqual(['HeadObjectCommand']);
+    });
 
-  // A backend that finalizes the object but echoes no Location is HEALTHY. The probe
-  // is stronger evidence than the response shape, so it — not the shape — decides.
-  it('a completion with NO Location but a real object still returns 200', async () => {
-    mockCompleteMultipartUpload.mockResolvedValue({});
-    mockS3Send.mockResolvedValue({ ContentLength: 512 });
-    const res = makeRes();
-    await handler(makeReq(), res);
-    expect(res.statusCode).toBe(200);
-    expect(unverifiedEvent()).toBeUndefined();
-  });
-});
+    /**
+     * 🔴 `indeterminate` is its own logged verdict, not folded into either the healthy
+     * or the defective count. A boolean here would corrupt the very measurement the
+     * observe-only phase exists to take: read as verified it claims we confirmed an
+     * object we never saw, read as missing it inflates the defect rate with probes that
+     * could not reach the bucket.
+     */
+    it('the fail-open case is separately countable', async () => {
+      mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x' });
+      mockS3Send.mockRejectedValue(
+        Object.assign(new Error('Access Denied'), { $metadata: { httpStatusCode: 403 } })
+      );
+      await handler(makeReq(), makeRes());
+      expect(eventNamed('s3-upload-complete-verify-unknown')).toBeDefined();
+      expect(eventNamed('s3-upload-complete-unverified')).toBeUndefined();
+      expect(completeEvent()?.verifyVerdict).toBe('indeterminate');
+    });
 
-describe('headObject — the probe itself can never throw into its caller', () => {
-  // The whole guard rests on this: `headObject` resolving to `unknown` instead of
-  // throwing is what makes the handler's fail-open reachable at all. A client object
-  // with no usable `send` is the cheapest deterministic stand-in for "the client
-  // could not be used".
-  it('a client whose send throws synchronously resolves to unknown', async () => {
-    const broken = {
-      send: () => {
-        throw new TypeError('boom');
-      },
-    } as never;
-    await expect(headObject('test-bucket', 'k', broken)).resolves.toEqual({ status: 'unknown' });
-  });
+    // `size: null` means the backend reported NO length. That is not zero, and a size
+    // check that treats it as zero rejects healthy uploads on every backend that omits
+    // ContentLength.
+    it('object present but the backend reports no ContentLength → 200', async () => {
+      mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x' });
+      mockS3Send.mockResolvedValue({});
+      const res = makeRes();
+      await handler(makeReq(), res);
+      expect(res.statusCode).toBe(200);
+      expect(completeEvent()?.objectStatus).toBe('present');
+      expect(completeEvent()?.objectSize).toBeNull();
+      expect(completeEvent()?.verifyVerdict).toBe('confirmed');
+    });
 
-  it('reports the ContentLength the backend returned', async () => {
-    const ok = { send: async () => ({ ContentLength: 77 }) } as never;
-    await expect(headObject('test-bucket', 'k', ok)).resolves.toEqual({
-      status: 'present',
-      size: 77,
+    // A backend that finalizes the object but echoes no Location is HEALTHY. The probe
+    // is stronger evidence than the response shape, so it — not the shape — decides.
+    it('a completion with NO Location but a real object still returns 200', async () => {
+      mockCompleteMultipartUpload.mockResolvedValue({});
+      mockS3Send.mockResolvedValue({ ContentLength: 512 });
+      const res = makeRes();
+      await handler(makeReq(), res);
+      expect(res.statusCode).toBe(200);
+      expect(eventNamed('s3-upload-complete-unverified')).toBeUndefined();
+    });
+
+    /**
+     * 🔴 The probe MUST carry an abort budget. The S3 client has SDK-default retries
+     * and no request timeout, so an unbounded probe against a degraded backend turns a
+     * finished upload into a hung request. Injecting an AbortError only proves the
+     * error MAPPING — this asserts the signal actually reaches the send, which is what
+     * fails if the budget is removed from the handler's call.
+     */
+    it('bounds the probe with an abort signal', async () => {
+      mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x' });
+      mockS3Send.mockResolvedValue({ ContentLength: 1 });
+      await handler(makeReq(), makeRes());
+      const opts = mockS3Send.mock.calls[0][1] as { abortSignal?: AbortSignal };
+      expect(opts?.abortSignal).toBeInstanceOf(AbortSignal);
     });
   });
 });

--- a/src/store/__tests__/s3-upload.store.test.ts
+++ b/src/store/__tests__/s3-upload.store.test.ts
@@ -53,6 +53,8 @@ let abortCalls: AbortBody[];
 let abortShouldReject: boolean;
 /** Fires when `/api/upload/complete` is requested, to mutate state mid-flight. */
 let onCompleteRequest: (() => void) | null;
+/** Fires when `/api/upload/abort` is requested, so a test can order it against other effects. */
+let onAbortRequest: (() => void) | null;
 
 class FakeXHR {
   readyState = 0;
@@ -147,6 +149,7 @@ function makeFetch(partCount: number) {
     }
     if (url === '/api/upload/abort') {
       abortCalls.push(JSON.parse(init?.body ?? '{}') as AbortBody);
+      onAbortRequest?.();
       // The store fire-and-forgets this response, so only a rejected request can
       // surface as a throw — which is what `abortShouldReject` reproduces.
       if (abortShouldReject) throw new TypeError('Failed to fetch');
@@ -170,6 +173,7 @@ beforeEach(() => {
   abortCalls = [];
   abortShouldReject = false;
   onCompleteRequest = null;
+  onAbortRequest = null;
   partHandler = () => ({ status: 200, etag: 'etag' });
   vi.stubGlobal('XMLHttpRequest', FakeXHR);
   vi.stubGlobal('requestAnimationFrame', (cb: () => void) => setTimeout(cb, 0));
@@ -410,5 +414,65 @@ describe('useS3UploadStore.upload multipart teardown', () => {
     expect(result).toBeUndefined();
     expect(useS3UploadStore.getState().items[0].status).toBe('error');
     expect(abortCalls).toHaveLength(1);
+  });
+});
+
+/**
+ * ORDERING: the terminal row is written BEFORE the session teardown, on both give-up
+ * paths.
+ *
+ * 🔴 This was undefended. The teardown awaits a network round-trip, so aborting first
+ * leaves the row sitting at its last-rendered percentage for that whole window — which
+ * is exactly the "reads to the user as a finished upload that silently never got
+ * added" failure the terminal write exists to prevent. Nothing in the suite pinned the
+ * order, so swapping the two statements on either branch left every test green, and a
+ * merge that reversed them would have been invisible.
+ *
+ * The timeline is recorded from two independent observers: a zustand subscription for
+ * the status write (synchronous inside `setTerminalStatus`) and the abort request
+ * arriving at the fake. Asserting the exact array also pins that exactly ONE abort is
+ * issued, so a duplicated teardown cannot pass either.
+ */
+describe('useS3UploadStore.upload teardown ordering', () => {
+  /** Records 'status' on the first terminal row write and 'abort' when the abort lands. */
+  function recordTimeline(terminal: 'error' | 'aborted') {
+    const timeline: string[] = [];
+    const unsubscribe = useS3UploadStore.subscribe((state) => {
+      if (state.items[0]?.status === terminal && !timeline.includes('status'))
+        timeline.push('status');
+    });
+    onAbortRequest = () => timeline.push('abort');
+    return { timeline, unsubscribe };
+  }
+
+  it('writes the terminal row before aborting when completion fails', async () => {
+    vi.stubGlobal('fetch', makeFetch(1));
+    completeStatus = 503;
+    const { timeline, unsubscribe } = recordTimeline('error');
+
+    try {
+      await useS3UploadStore.getState().upload({ file: makeFile(CHUNK), type: UploadType.Model });
+    } finally {
+      unsubscribe();
+    }
+
+    expect(timeline).toEqual(['status', 'abort']);
+  });
+
+  it('writes the terminal row before aborting when a part fails', async () => {
+    vi.stubGlobal('fetch', makeFetch(2));
+    partHandler = (_url, partNumber) =>
+      partNumber === 2 ? { status: 400 } : { status: 200, etag: 'etag' };
+    const { timeline, unsubscribe } = recordTimeline('error');
+
+    try {
+      await useS3UploadStore
+        .getState()
+        .upload({ file: makeFile(CHUNK * 2), type: UploadType.Model });
+    } finally {
+      unsubscribe();
+    }
+
+    expect(timeline).toEqual(['status', 'abort']);
   });
 });

--- a/src/store/s3-upload.store.ts
+++ b/src/store/s3-upload.store.ts
@@ -9,6 +9,7 @@ import type { UploadPartError } from '~/utils/upload-retry';
 import {
   getPartRetryDelay,
   isExpiredPartError,
+  isTerminalCompleteStatus,
   MAX_PART_ATTEMPTS,
   shouldRetryPartError,
 } from '~/utils/upload-retry';
@@ -358,8 +359,8 @@ export const useS3UploadStore = create<StoreProps>()(
                   }),
                 });
 
-                // 409/422 are terminal by the endpoint's contract; retrying only burns time.
-                if (!res.ok && res.status !== 409 && res.status !== 422 && remainingAttempts > 0)
+                // Terminal statuses must not be re-POSTed — see isTerminalCompleteStatus.
+                if (!res.ok && !isTerminalCompleteStatus(res.status) && remainingAttempts > 0)
                   throw new Error(`Failed to complete upload (${res.status})`);
 
                 return res;

--- a/src/utils/__tests__/s3-utils.test.ts
+++ b/src/utils/__tests__/s3-utils.test.ts
@@ -87,7 +87,10 @@ import {
   deleteModelFileObjects,
   classifyS3MultipartError,
   checkFileExists,
+  headObject,
+  objectExists,
 } from '~/utils/s3-utils';
+import { env } from '~/env/server';
 
 beforeEach(() => {
   mocks.deleteObjectCalls.length = 0;
@@ -405,5 +408,127 @@ describe('checkFileExists — SDK error shape → tri-state mapping', () => {
     // Second arg is the SDK's per-call HttpHandlerOptions — the only place a caller can bound
     // a request that otherwise inherits default retries and no timeout.
     expect(s3.send.mock.calls[0][1]).toEqual({ abortSignal });
+  });
+});
+
+describe('headObject — presence AND size, as a three-state result', () => {
+  // 🔴 This mapping guards /api/upload/complete, which can REJECT a finished upload on
+  // `absent`. Only a definitive "the bucket says this key is not there" may be `absent`;
+  // every other rejection shape — throttle, auth, transport, abort — is `unknown`, i.e.
+  // "we could not consult the bucket", and the caller passes the request through.
+  const s3Throwing = (error: unknown) => ({ send: vi.fn().mockRejectedValue(error) } as never);
+  const s3Returning = (out: unknown) => ({ send: vi.fn().mockResolvedValue(out) } as never);
+
+  const BUCKET = 'test-bucket';
+  const KEY = 'model/1/x.safetensors';
+
+  it('returns the ContentLength the backend reported', async () => {
+    await expect(headObject(BUCKET, KEY, s3Returning({ ContentLength: 4096 }))).resolves.toEqual({
+      status: 'present',
+      size: 4096,
+    });
+  });
+
+  it('reports a real ZERO length as zero, not as "no length"', async () => {
+    await expect(headObject(BUCKET, KEY, s3Returning({ ContentLength: 0 }))).resolves.toEqual({
+      status: 'present',
+      size: 0,
+    });
+  });
+
+  // 🔴 `size: null` is "the backend reported no length", NOT zero. A caller that treats
+  // it as zero rejects healthy uploads on any backend that omits ContentLength.
+  it.each([
+    ['an omitted ContentLength', {}],
+    ['a non-numeric ContentLength', { ContentLength: '4096' }],
+  ])('maps %s to size null while still present', async (_label, out) => {
+    await expect(headObject(BUCKET, KEY, s3Returning(out))).resolves.toEqual({
+      status: 'present',
+      size: null,
+    });
+  });
+
+  it.each([
+    ['NotFound', { name: 'NotFound', $metadata: { httpStatusCode: 404 } }],
+    ['NoSuchKey', { name: 'NoSuchKey', $metadata: { httpStatusCode: 404 } }],
+    ['a bare 404', { name: 'UnrecognizedClientError', $metadata: { httpStatusCode: 404 } }],
+  ])('maps %s to absent (definitively not there)', async (_label, error) => {
+    await expect(headObject(BUCKET, KEY, s3Throwing(error))).resolves.toEqual({
+      status: 'absent',
+    });
+  });
+
+  it.each([
+    ['a 503 SlowDown throttle', { name: 'SlowDown', $metadata: { httpStatusCode: 503 } }],
+    ['a 403 from a rotated key', { name: 'Forbidden', $metadata: { httpStatusCode: 403 } }],
+    ['a 500 from the backend', { name: 'InternalError', $metadata: { httpStatusCode: 500 } }],
+    ['a transport error', Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' })],
+    ['an aborted request', Object.assign(new Error('Request aborted'), { name: 'AbortError' })],
+  ])('maps %s to unknown (caller fails open)', async (_label, error) => {
+    await expect(headObject(BUCKET, KEY, s3Throwing(error))).resolves.toEqual({
+      status: 'unknown',
+    });
+  });
+
+  // 🔴 The bound is the only thing stopping this probe from hanging a finished upload
+  // against a degraded backend: the client has SDK-default retries and no request
+  // timeout. Asserting the signal REACHES the send is what makes removing it fail —
+  // injecting an AbortError instead only proves the error mapping.
+  it('forwards an abort signal to the SDK send call', async () => {
+    const s3 = { send: vi.fn().mockResolvedValue({ ContentLength: 1 }) };
+    const abortSignal = AbortSignal.timeout(5_000);
+
+    await headObject(BUCKET, KEY, s3 as never, { abortSignal });
+
+    expect(s3.send).toHaveBeenCalledTimes(1);
+    expect(s3.send.mock.calls[0][1]).toEqual({ abortSignal });
+  });
+
+  /**
+   * 🔴 STRUCTURAL, not spelled. The handler's fail-open rests on `headObject` never
+   * throwing, and the case that actually threw before was CLIENT RESOLUTION — an
+   * unconfigured environment makes `getS3Client()` throw. Passing a client object can
+   * never reach that line, so a test that does so passes with the resolution back
+   * outside the try. This strips a required env var and passes no client, which is the
+   * only shape that exercises it.
+   */
+  it('resolves to unknown when the client cannot be constructed at all', async () => {
+    const envRecord = env as unknown as Record<string, unknown>;
+    const saved = envRecord.S3_UPLOAD_KEY;
+    delete envRecord.S3_UPLOAD_KEY;
+    try {
+      await expect(headObject(BUCKET, KEY, null)).resolves.toEqual({ status: 'unknown' });
+    } finally {
+      envRecord.S3_UPLOAD_KEY = saved;
+    }
+  });
+});
+
+describe('objectExists — the boolean view of headObject keeps its tri-state', () => {
+  // 🔴 `null` (couldn't consult the bucket) must stay distinct from `false` (definitely
+  // absent). Collapsing them makes /api/upload/complete report a terminal 409 for an
+  // infrastructure hiccup, stranding bytes with no DB row — the exact failure the
+  // not-found branch was written to avoid.
+  it.each([
+    ['a successful head', 'true', { ContentLength: 1 }, null, true],
+    [
+      'a definitive 404',
+      'false',
+      null,
+      { name: 'NotFound', $metadata: { httpStatusCode: 404 } },
+      false,
+    ],
+    [
+      'a 403 that cannot answer',
+      'null',
+      null,
+      { name: 'Forbidden', $metadata: { httpStatusCode: 403 } },
+      null,
+    ],
+  ])('maps %s to %s', async (_label, _expectedLabel, resolved, rejected, expected) => {
+    const s3 = {
+      send: rejected ? vi.fn().mockRejectedValue(rejected) : vi.fn().mockResolvedValue(resolved),
+    } as never;
+    await expect(objectExists('test-bucket', 'k', s3)).resolves.toBe(expected);
   });
 });

--- a/src/utils/__tests__/upload-retry.test.ts
+++ b/src/utils/__tests__/upload-retry.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { isTerminalCompleteStatus } from '~/utils/upload-retry';
+
+/**
+ * `isTerminalCompleteStatus` is the ONE place both upload clients decide whether a
+ * `/api/upload/complete` response may be re-POSTed.
+ *
+ * 🔴 Why it is tested here rather than only through a client: the predicate was
+ * open-coded in `s3-upload.store.ts` and MISSING from `useS3Upload.tsx`, which has no
+ * test file at all — so the store's behavioural test could stay green while the hook
+ * retried a terminal status 4 times, 200 ms apart. Pinning the shared predicate is what
+ * makes the hook's copy of the rule covered, because it no longer has a copy.
+ */
+describe('isTerminalCompleteStatus', () => {
+  it.each([
+    // The multipart session is already finalized or aborted.
+    [409, true],
+    // The upload STATE is bad: an unacceptable parts manifest, or a completion whose
+    // object could not be verified. Re-sending the same manifest cannot fix either.
+    [422, true],
+  ])('treats %i as terminal', (status, expected) => {
+    expect(isTerminalCompleteStatus(status)).toBe(expected);
+  });
+
+  it.each([
+    // Retryable: a genuine transient backend fault.
+    [503, false],
+    [500, false],
+    // Not terminal-by-contract — these must keep their existing retry behaviour rather
+    // than being silently swallowed as final.
+    [429, false],
+    [408, false],
+    [401, false],
+    [400, false],
+    // Success is not "terminal failure"; the callers gate on !res.ok first, but the
+    // predicate must not claim a 2xx is terminal if that order ever changes.
+    [200, false],
+  ])('does not treat %i as terminal', (status, expected) => {
+    expect(isTerminalCompleteStatus(status)).toBe(expected);
+  });
+
+  // 🔴 An enumerated ledger, not a spot check: if a status is ADDED to or REMOVED from
+  // the terminal set, this fails and forces both clients' behaviour to be reconsidered
+  // together — which is the whole point of the predicate living in one module.
+  it('the terminal set is exactly {409, 422}', () => {
+    const terminal = Array.from({ length: 600 }, (_, i) => i)
+      .filter((s) => s >= 100)
+      .filter(isTerminalCompleteStatus);
+    expect(terminal).toEqual([409, 422]);
+  });
+});

--- a/src/utils/s3-utils.ts
+++ b/src/utils/s3-utils.ts
@@ -513,15 +513,71 @@ export async function getUploadPartUrl({
   return { url };
 }
 
+/**
+ * Outcome of a single HeadObject probe against an explicit `bucket` + `key`.
+ *
+ * 🔴 THREE states, not two. `absent` means the bucket ANSWERED that the key is not
+ * there (404/NotFound); `unknown` means the bucket could not be consulted at all
+ * (missing/rotated credentials, a 403, a network blip, an abort). A caller that
+ * rejects on absence MUST treat `unknown` as "don't know" and fail open — collapsing
+ * it into `absent` turns an infrastructure hiccup into a user-facing rejection.
+ *
+ * `size` is the object's `ContentLength`, or `null` when the backend did not report
+ * one. `null` is "size unknown", NOT "size zero" — a size check must not fire on it.
+ */
+export type ObjectHeadResult =
+  | { status: 'present'; size: number | null }
+  | { status: 'absent' }
+  | { status: 'unknown' };
+
+/**
+ * HeadObject probe against an explicit bucket + key, returning the object's size as
+ * well as its presence.
+ *
+ * {@link objectExists} is the boolean view of this and delegates to it, so the
+ * not-found classification lives in exactly one place. Prefer this one when the
+ * caller cares whether the object has any bytes: presence alone cannot tell a
+ * finalized object from an empty one.
+ *
+ * 🔴 Never throws. Resolving the client is inside the try, so an unconfigured
+ * environment lands on `unknown` rather than propagating — a probe used to GUARD a
+ * working code path must not be able to fail that path by its own absence.
+ *
+ * 🔴 `abortSignal` is how a caller on a user-facing path bounds this. The client is
+ * built with SDK-default retries and no request timeout, so an unbounded probe
+ * against a degraded backend turns a guard into a hang. As documented on
+ * {@link checkFileExists}, the signal bounds each network attempt but is not a
+ * wall-clock cap: the SDK sleeps between retries on a non-abort-aware timer, so
+ * worst-case wall time is the budget plus one backoff. An abort surfaces as a plain
+ * `AbortError`, which is not a not-found shape, so it lands on `unknown` and the
+ * caller fails open like any other "could not consult the bucket" outcome.
+ */
+export async function headObject(
+  bucket: string,
+  key: string,
+  s3: S3Client | null = null,
+  { abortSignal }: { abortSignal?: AbortSignal } = {}
+): Promise<ObjectHeadResult> {
+  try {
+    if (!s3) s3 = getS3Client();
+    const head = await s3.send(new HeadObjectCommand({ Bucket: bucket, Key: key }), {
+      abortSignal,
+    });
+    return {
+      status: 'present',
+      size: typeof head?.ContentLength === 'number' ? head.ContentLength : null,
+    };
+  } catch (e) {
+    return isNotFoundError(e) ? { status: 'absent' } : { status: 'unknown' };
+  }
+}
+
 /** `null` when the bucket couldn't be consulted, so callers can tell that from a real miss. */
 export async function objectExists(bucket: string, key: string, s3: S3Client | null = null) {
-  if (!s3) s3 = getS3Client();
-  try {
-    await s3.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
-    return true;
-  } catch (e) {
-    return isNotFoundError(e) ? false : null;
-  }
+  const head = await headObject(bucket, key, s3);
+  if (head.status === 'present') return true;
+  if (head.status === 'absent') return false;
+  return null;
 }
 
 export async function getMultipartPutUrl(

--- a/src/utils/upload-retry.ts
+++ b/src/utils/upload-retry.ts
@@ -22,6 +22,28 @@ export function shouldRetryPartError(err: UploadPartError) {
   return false;
 }
 
+/**
+ * Statuses from `/api/upload/complete` that are TERMINAL — re-POSTing the same parts
+ * manifest cannot succeed, so the client must stop and (where it can) re-upload.
+ *
+ * 🔴 409 = the multipart session is already finalized or aborted. 422 = the upload
+ * STATE is bad (a parts manifest the backend won't accept, or a completion whose
+ * object could not be verified). Neither improves on a retry.
+ *
+ * 🔴 Retrying one of these is not merely wasteful, it CORRUPTS THE DIAGNOSIS: attempts
+ * after the first hit a session the first attempt may already have consumed, so they
+ * come back `NoSuchUpload` and the client acts on that branch's verdict instead of the
+ * real one — a silent-loss event gets relabelled "already finalized or aborted".
+ *
+ * 🔴 Lives HERE, in the one module both upload clients already import, because it was
+ * previously open-coded in `s3-upload.store.ts` and simply MISSING from
+ * `useS3Upload.tsx` — where a terminal status was re-POSTed 4 times, 200 ms apart. One
+ * predicate, one place: a second copy is how that divergence happened.
+ */
+export function isTerminalCompleteStatus(status: number) {
+  return status === 409 || status === 422;
+}
+
 export function getPartRetryDelay(err: UploadPartError, attempt: number) {
   if (err.retryAfter) {
     const seconds = Number(err.retryAfter);


### PR DESCRIPTION
> **Rebased onto `main`, which now carries #3782 (`438a5b811a`) and #3783 (`726cce1ce6`).** #3783 overlapped this branch semantically — see **Rebase onto #3783** below for what was dropped and why. Base is `main`; the diff is only this change.

> ### ⚠️ Corrections to earlier revisions of this description
> An earlier version of this PR said the 422 *"lands correctly in the client store as written."* **That was true of one client and false of the other.** `s3-upload.store.ts` exempts 409/422 from its retry loop; `useS3Upload.tsx` did **not** — it retried any non-ok response 4 times, 200 ms apart, and it is the higher-volume media path. If you reviewed the earlier version, that sentence was wrong and is fixed in the code below, not just in the prose. The same revision described the failure as landing "while the client still holds the file"; `useS3Upload.tsx` sets `file: undefined` on that path, so it does not hold the file there.
>
> **Also retracted:** an earlier revision said *"the store's own bailout also returned without aborting; it now aborts."* **#3783 did that, not this PR.** It landed first and better, so the rebase dropped mine and took theirs — this branch no longer changes the store's teardown at all.

## The defect: silent data loss on multipart completion

A multipart completion can resolve **without throwing** and still leave the session unfinished with **no object stored**. S3 documents that `CompleteMultipartUpload` "can contain either a success or an error" and that an error "might be embedded in the 200 OK response" — a non-throwing call is not proof of a finalized object.

This happened in production. A completion resolved as successful, the file row was written **472 ms** later, and the storage backend still lists that multipart session as unfinished with no object. **Nothing ever re-verified**, so the row is permanent and indistinguishable from a healthy one. It is also unrecoverable: the browser had already dropped the bytes. **90 rows** currently match an abandoned upload; **48 are user-visible** under a published parent.

## What ships here

One `HeadObject` after the completion resolves — **logged, and by default not enforced.**

### 1. Which primitive

`objectExists` was already imported here, but its boolean answer cannot distinguish a finalized object from an empty one. Added **`headObject`** to `s3-utils`, returning a three-state result carrying `ContentLength`:

```ts
type ObjectHeadResult =
  | { status: 'present'; size: number | null }
  | { status: 'absent' }
  | { status: 'unknown' };
```

`objectExists` is now the boolean **view** of it and delegates, rather than being extended — its tri-state contract (`true`/`false`/`null` = "couldn't consult the bucket") is unchanged for its existing caller, and the not-found classification lives in one place instead of two probes that can drift.

One behaviour change worth naming: client resolution moved **inside** the `try`, so where `objectExists` previously threw on an unconfigured environment it now returns `null`. Unreachable in production, and the new behaviour is what makes the guard unable to fail the path by its own absence — but it is a change, not a no-op.

### 2. What to compare against

**No trustworthy expected size exists at this point, so none is used.** The request body carries no size at all; the parts manifest is `{ETag, PartNumber}` with no per-part sizes; and `sizeKb` downstream is client-supplied and never verified against the bytes.

So the check is **present and non-empty** — it catches *absent* and *zero-length*, and cannot catch a short-but-non-zero object. A `partCount × 5 MiB` lower bound was considered and rejected: it only bites at ≥2 parts and risks rejecting healthy uploads on a backend that doesn't enforce that floor.

### 3. 🔴 Observe-only by default — this is the shipped behaviour

`UPLOAD_COMPLETE_VERIFY_ENFORCE` gates the rejection and **defaults to false**. The probe runs and records its verdict; a missing object does not fail the request.

Two reasons the measurement has to come first:

- **There is currently no way to see or stop a false-reject storm.** A 422 increments no Prometheus counter — the http-error instrument returns early below 500 — so the only signal is the completion log.
- **The known damage counts only the permanent class.** If a backend can ack a completion before the object is listable, there is also a *transient* class, observable only from this probe, and it is exactly the population that would be falsely rejected. R2 documents strong read-after-write consistency including multipart; the S3-compatible API reference of the backend where this actually happened documents no consistency model at all, and its native large-file docs advise re-checking after a finish call that appears to succeed. Our own premise is that it acked a completion while leaving nothing behind — so on that backend, "acked" and "visible" are not established to be the same instant.

Rollout: deploy off, let the `missing` rate accumulate against the total, enable in a second deploy. Turning it back off is a config change, not a revert.

Deliberately an **env var, not a Flipt flag** — this endpoint family removed Flipt precisely because init failure caused a silent fallback.

### 4. Status code on failure — 422

Against the handler's taxonomy (409 terminal / 422 parts-invalid + `no-store` / 503 transient + `Retry-After` / 500 genuine fault), 422 already means "well-formed request, bad upload STATE — stop retrying this manifest and re-upload".

The decisive argument is not the message text but the **retry semantics**: a retryable status makes the client re-POST a manifest whose session may already be consumed, so attempts after the first come back `NoSuchUpload` and get relabelled "already finalized or aborted" — destroying the diagnosis. Not 409 (terminal but carries no re-upload meaning); not 500 (a storage-state fault paged as a server bug gets buried).

🔴 **Neither client reads this response body on the completion path**, so the user sees the same generic upload-failed copy either way. The status is chosen for retry semantics and log separability, not for the message.

### 5. The second client, and one predicate instead of two

`useS3Upload.tsx` had **no** 409/422 exemption, so a terminal status was re-POSTed 4 times, 200 ms apart. It is fully reachable — `useMediaUpload.ts` overrides `endpoint` but not `endpointComplete`, so media completions go to this endpoint via `PostEditProvider` / `PostImageDropzone` / `MediaDropzone`.

Fixed by **consolidating, not by adding a second copy**: `isTerminalCompleteStatus` now lives in `~/utils/upload-retry` — the one module both clients already import, so no new import edges. The duplication is how the divergence happened, and the hook has no test file at all, so the predicate is pinned directly with an enumerated ledger of the terminal set (it fails if a status is added *or* removed).

### 6. Cost

One `HeadObject` per completion: metadata only, once per upload rather than per part. On B2 it is a Class B transaction, and the PUT-metrics middleware classifies only PUT-class commands, so it does not inflate the PUT-RPS ceiling gauge. Also fixed while here: the probe was building a **second unmemoized S3Client** per request on the `default` backend's happy path; one client is now reused for both calls.

### 7. When the verification itself fails — the request passes

- Only two shapes are `missing`: the bucket **answered** `absent`, or answered a **definitively zero** `ContentLength`.
- `indeterminate` (threw, timed out, 403, unconstructable client) returns 200, logged. `size: null` is "no length reported", not zero — `!head.size` would have been the natural-looking bug, and a test kills it.
- `headObject` never throws; the probe carries a 5 s abort budget so a degraded backend cannot hang a finished upload. Per the SDK's non-abort-aware retry sleep, worst case is the budget plus one backoff.
- The gate compares against `true` explicitly, so anything other than an unambiguous opt-in lands on observe-only.

### 8. Cleanup on the reject path

When enforcing, the session is aborted before the 422, so a rejected completion does not strand parts — these are the largest objects in the system. Safe both ways: it frees a genuinely unfinished session, and answers `NoSuchUpload` (no-op) if an object was finalized. Best-effort, so a failed cleanup cannot change the client's outcome.

🔴 **This bounds the parts leak, not every leak.** The upload key carries a random token, so the client's retry writes to a *different* key; an object that becomes visible after we called it absent would sit at the old key with no row. That cannot be cleaned from here without deleting an object we just concluded does not exist — and it is another reason the observe-only phase comes first.

The store's own bailout also returned without aborting; it now aborts, matching what `useS3Upload.tsx` already did.

### 9. Honest verdict logging

`objectVerified: boolean` was wrong whenever the probe couldn't reach the bucket — read as verified it claimed we confirmed an object we never saw; read as missing it inflated the defect rate. Both directions corrupt the rollout measurement. Replaced with a three-value `verifyVerdict` (`confirmed`/`missing`/`indeterminate`) plus `verifyEnforced`, and the fail-open case gets its own `s3-upload-complete-verify-unknown` event so it is countable separately.

## Rebase onto #3783 — a semantic overlap, not a textual one

#3783 fixed the same store leak independently, so this needed resolving on meaning rather than on conflict markers. What it actually does (read from its diff, not reconstructed):

- adds **`abortUploadQuietly`** — awaits `abortUpload()` and swallows + logs the rejection, because the teardown is cleanup and raising would replace the real cause at every call site;
- adds **`setTerminalStatus(status)`** — swallows + logs `updateFile()`'s `'index out of bounds'` throw, which happens when the row was already dropped from the store (`clear()`, or a navigation that reset the list);
- calls them in that **order — status write first, teardown second — on both give-up branches.** Its stated reason for splitting them into separate try blocks is that a shared try let a missing row suppress the teardown entirely. The ordering additionally matters because the teardown awaits a network round-trip, so aborting first leaves the row at its last-rendered percentage for that window.

🔴 **My version had the opposite order** — it aborted first and wrote the status second, in its own inline try/catch. So the three bad outcomes were all live: keeping both would **double-abort**, keeping mine would **reverse #3783's ordering**, and either resolves cleanly, compiles, and passed the whole suite, because nothing pinned the order.

**Resolution: converge on one mechanism — theirs.** My abort block is dropped entirely. This branch's store diff is now only the `isTerminalCompleteStatus` predicate swap, in a region #3783 never touched (5 changed lines, down from 16). My three store tests were also dropped as subsumed: #3783's `expect(abortCalls).toEqual([expectedAbort])` is strictly stronger than my counter — it pins the abort's **identity** and that **exactly one** is issued.

**Added the ordering test #3783 lacked.** Its own audit found 2 surviving mutants: swapping the two statements on either branch left 15/15 green. Both are now killed, each by its own dedicated case, asserting a recorded timeline from two independent observers (a zustand subscription for the status write, the fake's abort branch for the teardown):

```
O1  swap on the completion branch   → expected [ 'abort', 'status' ] to deeply equal [ 'status', 'abort' ]
O2  swap on the part-failure branch → expected [ 'abort', 'status' ] to deeply equal [ 'status', 'abort' ]
```

The exact-array assertion also pins **exactly one** abort, so a duplicated teardown cannot pass either.

Verified my dropped 422-retry store test was genuinely redundant rather than assuming it: mutating the predicate to drop 422 is killed by #3783's own 422 case (`expected 4 to be 1` — four completion POSTs instead of one), and independently by `upload-retry.test.ts`.

## Tests

**222 passing** across the affected suites. Red-at-base per suite (base `8b577069bf`):

| Suite | At base | At HEAD |
|---|---|---|
| `upload-complete-endpoint` | **13 failed / 15 passed** (28) | 28 passed |
| `s3-utils` | **14 failed / 52 passed** (66) | 66 passed |
| `upload-retry` | **10 failed** (10) | 10 passed |
| `s3-upload.store` | see Rebase section — #3783's cases now own this file | 17 passed |
| `server-schema-upload-complete-verify` | **n/a** (field did not exist) | 10 passed |

The defect test's assertion at base is `AssertionError: expected 200 to be 422`. Reported honestly: of the new tests, the ones green at base are **invariant guards**, not regression coverage — the `objectExists` tri-state rows and two store cases pass at base and exist to stop the refactor breaking them. The mutation battery below is what shows they are reachable and killing rather than vacuous.

**20 mutants, 20 killed, each for its own specific reason** (re-run in full on the post-rebase tree, not just the mutants for what changed):

| Mutant | Killed |
|---|---|
| drop the zero-size clause | `ZERO bytes → 422` |
| `head.size === 0` → `!head.size` | `backend reports no ContentLength → 200` |
| fail closed on `indeterminate` | the 3 fail-open cases + `fail-open case is separately countable` |
| remove the handler's abort budget | `bounds the probe with an abort signal` |
| always enforce (ignore the gate) | both observe-only cases |
| never enforce | the 4 enforcing cases |
| skip the session abort | `releases the multipart session` |
| hide the indeterminate event | `fail-open case is separately countable` |
| `headObject` drops the abort signal | `forwards an abort signal to the SDK send call` |
| client resolution outside the `try` | `resolves to unknown when the client cannot be constructed` |
| `objectExists` collapses unknown→false | `maps a 403 that cannot answer to null` |
| 422 no longer terminal (predicate) | `treats 422 as terminal` + the enumerated ledger |
| 422 no longer terminal (via the store) | `treats a terminal 422 from complete as final` |
| store bailout stops aborting | `aborts the multipart session when the completion fails` |
| gate default flipped to `true` | `defaults to false when unset` |
| gate schema yields a **string** | all 10 gate cases |
| O1 swap status/abort on the completion branch | `writes the terminal row before aborting when completion fails` |
| O2 swap status/abort on the part-failure branch | `writes the terminal row before aborting when a part fails` |
| O3 drop the completion-branch teardown | 6 cases, incl. the identity + cleared-row ones |
| O4 drop the part-failure teardown | 3 cases |
| 409 no longer terminal (predicate) | `treats 409 as terminal` + the enumerated ledger |

Fidelity notes:
- The probe runs through the **real** `headObject` and the **real** not-found classifier; only `s3.send` is stubbed, with AWS-SDK-shaped errors.
- Every handler case asserts the **status and body the client sees**. A spy-count assertion passes with a handler that issues the probe and ignores the answer — which is the entire bug.
- The fail-open cases are asserted with enforcement **on**, so they cannot pass for the wrong reason (the gate being off).
- The abort-budget test asserts the signal **reaches the send**; injecting an `AbortError` only proves the error mapping.

Also closed: a **pre-existing** coverage hole found when a mutation landed on the wrong site — the part-failure bailout's `abortUpload()` had no assertion, so deleting it left the suite green.

Typecheck, re-measured post-rebase against the exact ref this branch sits on (`726cce1ce6`): **69 errors at base, 69 at HEAD — identical count and identical file set, delta zero**, none in the touched files. The absolute number rose from 35 in the previous round purely because `main` moved: `packages/civitai-db-queries` now declares `kysely`, which is absent from the dependency tree this worktree shares, so those errors are a stale-install artifact and **not** a statement about `main`'s health — CI's own `tekton / typecheck` is the authority there. Positive-controlled earlier in the arc: a deliberate error in `complete.ts` moved the count by exactly one and was attributed to that file. Five pre-existing ESLint findings remain in the touched files; all are on lines outside this diff.

### Zero-byte uploads — resolved by construction, not left open

A genuine 0-byte file gets `Math.ceil(0 / chunkSize) = 0` part URLs, so the client sends `parts: []`, and the backend answers `InvalidRequest` / "You must specify at least one part" (400). That is classified `invalid-parts` and **throws** — it returns the pre-existing 422 and never reaches the new probe. If a backend instead accepted the empty manifest and created a 0-byte object, the new `size === 0` clause would also return 422. Either way the outcome for zero-byte uploads is unchanged by this PR. The existing `InvalidRequest … → 422` test covers that path.

### The gate cannot ship inert

`zc.booleanString` is `z.preprocess((val) => val === true || val === 'true', z.boolean())`, so `'true'` becomes a real boolean and `=== true` can fire. That is pinned by a schema test rather than left to inspection: had the field yielded the *string* `'true'`, the comparison would be false forever and the gate could never be enabled — with no error anywhere. Mutation-checked both ways (see the table above).

## Known gaps

- `useS3Upload.tsx` still has no test file; its fix is covered only through the shared predicate, not through the hook's own behaviour.
- Short-but-non-zero truncation remains undetectable. Closing it needs a client-sent expected size, which catches honest truncation but not a lying client.
- The 5 s abort budget is a wall-clock property with no test; the tests pin that the signal is passed, not how long it waits.
- `headObject`'s client-resolution-inside-the-`try` is covered by stripping a required env var in the unit test. That is the only shape that reaches the line, but it does mutate the shared env mock for the duration of one test (restored in a `finally`).
