### PR TITLE
chore(renovate): add Renovate config scoped to Docker base images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", "docker:pinDigests"],
+  "enabledManagers": ["dockerfile"],
+  "schedule": ["before 6am on monday"]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "docker:pinDigests"],
-  "enabledManagers": ["dockerfile"],
-  "schedule": ["before 6am on monday"]
+  "enabledManagers": ["dockerfile", "nvm"],
+  "schedule": ["before 6am on monday"],
+  "packageRules": [
+    {
+      "description": "Keep the root Dockerfile's node tag and .nvmrc in ONE pull request. src/__tests__/node-version-consistency.test.ts asserts the two agree, so a bump that moves only one of them reds that guard. Scoped to the two files that guard actually reads: the per-service images under apps/ and containers/ are on their own cadence and must not be dragged into this group.",
+      "matchDepNames": ["node"],
+      "matchFileNames": ["Dockerfile", ".nvmrc"],
+      "groupName": "node runtime pin"
+    }
+  ]
 }


### PR DESCRIPTION
## What this adds

A single new file, `renovate.json`:

```json
{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": ["config:recommended", "docker:pinDigests"],
  "enabledManagers": ["dockerfile", "nvm"],
  "schedule": ["before 6am on monday"],
  "packageRules": [
    {
      "description": "Keep the root Dockerfile's node tag and .nvmrc in ONE pull request…",
      "matchDepNames": ["node"],
      "matchFileNames": ["Dockerfile", ".nvmrc"],
      "groupName": "node runtime pin"
    }
  ]
}
```

No workflow changes, no Dockerfile changes, no dependency changes.

---

## 🔴 Read this first: merging this does not, by itself, do anything

**A `renovate.json` that the Renovate App is not reading is inert. It fails silently and it reads as done.** That is the main risk this PR carries, so it goes at the top rather than in a footnote.

**The prerequisite is smaller and more specific than "install the app".** Verified against the API:

- The Renovate App **is already installed on the `civitai` org** — the installation was created 2026-01-12 and its `repository_selection` is **`selected`**.
- **`civitai/civitai` is simply not among the selected repositories.**

Evidence that it is not selected: **0 Renovate-authored PRs in this repo all-time**, and **0 "Configure Renovate" onboarding PRs in any state** (`is:pr author:app/renovate` → 0; `"Configure Renovate" in:title` → 0).

So the action an org admin needs to take is **add `civitai/civitai` to the existing Renovate installation's repository list** — not install an app. Saying "install the app" would send someone looking for the wrong thing, and would probably end with them concluding it was already done and stopping.

**The behavioural check after merge:** because a config file is already present, an onboarded install skips onboarding and starts opening dependency PRs on the next scheduled run.

> **If no Renovate PR appears within ~1 day of the repo being added, this file is decoration.** Do not treat a merged config as coverage.

**Fallback if changing the org installation is unwanted:** self-host Renovate as a scheduled GitHub Action (`renovatebot/github-action`), which needs a token rather than an installation change. This repo already runs Actions, so that path is open. It is more moving parts and a token to own, which is why the installation change is the first choice rather than the only one.

---

## Why now

#3779 pinned the root `Dockerfile`'s Node base image from the floating `node:24-alpine3.24` to the exact `node:24.19.0-alpine3.24` in both the `deps` and `runner` stages.

That was the right call for reproducibility, and it **gave up patch flow** as the price:

- Docker rebuilds a *floating* tag when its contents get security fixes. The same tag string quietly starts resolving to a patched image.
- An *exact patch* tag is never rebuilt. `node:24.19.0-alpine3.24` will resolve to the same bytes in a year, CVEs and all.

So as of #3779, base-image security patches stop arriving, and nothing in the repo closes that gap. A digest pin managed by a bot gives reproducibility **and** patch flow; the tag pin alone gives only the first.

### This repo has already paid for the failure mode — and already asked for this fix

I read #3371 rather than working from a summary. What it actually documents:

| Claim in #3371 | Verified in its body |
|---|---|
| `node:22-alpine3.20` pinned in both `deps` and `runner` | ✅ |
| That tag last pushed **2025-05-21** (Docker Hub `tag_last_pushed`) | ✅ |
| Node frozen at **22.16.0** | ✅ |
| Alpine 3.20 EOL **2026-04-01** — already expired | ✅ |
| "roughly 14 months of unpatched Node **and** OS CVEs" in production | ✅ — that is its wording, not a paraphrase |

**One correction worth making, because it changes how strong the analogy is.** #3371's tag was *floating*, not an exact patch pin. Its mechanism was "upstream stopped rebuilding this tag because the Alpine branch went EOL"; #3779's mechanism is "we chose a tag form that is never rebuilt by design." Those are different causes. They converge on the identical end state — **a base image that silently stops receiving patches, with no diff, no signal, and nobody's name on it** — which is the part that matters here, but they are not the same bug.

**And #3371 explicitly asked for what this PR does.** From its own Follow-ups section:

> `Dockerfile:3,113` use a floating tag. `node:24-alpine3.24` resolves to 24.18.0 today, but it will be rebuilt — the base can change with **no diff and no review** […] Suggest digest-pinning (`node:24-alpine3.24@sha256:4ba75f83…`) plus **an explicit bump cadence**.

#3779 delivered the pin. This PR delivers the **cadence** — the half that makes the pin safe to leave alone.

---

## The `.nvmrc` interaction, and how it was resolved

#3779 also added `src/__tests__/node-version-consistency.test.ts`, which asserts the root Dockerfile's Node tag, `.nvmrc` and `engines.node` agree. Renovate is about to start editing one of those.

**The first draft of this PR enabled only the `dockerfile` manager, and that was a real defect.** Renovate cannot edit `.nvmrc` through the `dockerfile` manager, so *every* future Node version bump would have landed with `.nvmrc` untouched and **red that guard** until someone hand-edited it. A bot that reliably opens a red PR is worse than no bot.

The fix is the `nvm` manager plus a `packageRules` group. **Verified by running Renovate's extractor and full dry-run, not by reading docs.**

### Method, and the gotcha that invalidates a careless run

Renovate 44.22.0, `--platform=local`, on Node 24. 🔴 **Local platform builds its file list from git, so an uncommitted `renovate.json` makes Renovate silently fall back to its default onboarding config and measure the wrong thing** — every measurement below was taken with the config committed.

Because `24.19.0` is currently the newest Node 24, there is **no live update to observe**. So the grouping test uses a constructed positive control: root `Dockerfile` → `node:24.17.0-alpine3.24` and `.nvmrc` → `24.17.0` on a throwaway local branch, which makes a real `24.19.0` update available on both sides.

### Result: one branch, therefore one PR

With the group rule, `--dry-run=full` puts these on branch **`renovate/node-runtime-pin`**:

| Manager | File | Change | Type |
|---|---|---|---|
| `dockerfile` | `Dockerfile` (`deps`) | `24.17.0-alpine3.24` → `24.19.0-alpine3.24` | minor |
| `dockerfile` | `Dockerfile` (`runner`) | `24.17.0-alpine3.24` → `24.19.0-alpine3.24` | minor |
| `nvm` | `.nvmrc` | `24.17.0` → `24.19.0` | minor |

**Both files move on one branch — so one PR, and the guard stays green.** (Two `pinDigest` entries for the already-superseded `24.17.0` also land in that branch and Renovate discards them itself, logging `Ignoring upgrade collision` and keeping `24.19.0`. That collision only exists in the transient "unpinned *and* behind" state; once the first digest pin lands there is no `pinDigest` update to collide.)

### Why the rule is scoped, and what it is actually buying

The honest version, because the control run changes the story. **Without** the `packageRules` entry, `.nvmrc` and the root Dockerfile still land together — but on `renovate/node-24.x` alongside **18 upgrades**, including major `22-alpine` → `24-alpine` bumps for all seven `apps/*` images and `20-bookworm` → `24-bookworm` for `containers/image-stub`.

So the rule is not what makes the two files co-locate in this particular case. It buys two things:

1. **Isolation — measured.** 5 upgrades on the group branch versus 18 without it. The runtime pin is no longer welded to major Node bumps for seven other services that are on their own release cadence; you can merge one without the other.
2. **Co-location by rule rather than by coincidence.** Ungrouped, the shared branch name comes from the branch topic `node-{{newMajor}}.x` — the two files sit together only *because both happen to resolve to major 24*. The `groupName` makes it structural instead of incidental.

`matchFileNames` scoping was verified rather than assumed: in the grouped run the `apps/*` and `containers/*` node images stayed **out** of the group, in `renovate/node-24.x`.

### Measured scope of enabling `nvm`

Enabling a second manager is exactly where scope creep hides, so it was counted:

| | Managers | Package files | Dependencies |
|---|---|---|---|
| Default onboarding config (no `enabledManagers`) | 7 — `npm`, `bun`, `dockerfile`, `docker-compose`, `github-actions`, `html`, `nvm` | 54 | **579** |
| Previous revision of this PR (`dockerfile` only) | 1 | 13 | **21** |
| **This config (`dockerfile` + `nvm`)** | 2 | 14 | **22** |

`nvm` matched exactly **one file** (`.nvmrc`, via `/(^|/)\.nvmrc$/`) contributing **one dependency** — `depName: node`, `datasource: node-version`. Nothing unintended came with it.

`docker:pinDigests` still applies: the `dockerfile` half is byte-identical at 13 files / 21 deps, and `pinDigest` updates are present across the Dockerfiles in the dry-run.

---

## Known residual friction — stated rather than left to be discovered

**A Node *major* bump will still red the guard.** The guard also asserts `package.json` `engines.node` brackets the pinned major, and the `npm` manager is not enabled here, so Renovate cannot move it. That case needs a hand-edit.

It is not imminent: all 18 node dependencies resolve under Renovate's LTS-aware `versioning: node`, and the dry-run offered **no** Node 25/26 update despite 26.7.0 existing upstream. The only `26.x` candidate in the whole run was ClickHouse.

**A datasource-lag window could split the pair.** If nodejs.org publishes a version before the matching `node:<version>-alpine3.24` tag exists, one run could produce a group PR carrying `.nvmrc` alone, which reds the guard. Because the branch name is stable, Renovate would then add the Dockerfile change to the **same** PR on a later run rather than opening a second one.

**I could not measure how often that window is open, and I am not going to guess.** Docker Hub's `last_updated` reflects rebuilds rather than first push, so it cannot be used to derive the lag. The one clean data point: `24.19.0-alpine3.24` carries a timestamp on the same calendar day as the nodejs.org `v24.19.0` release.

**Either way it lands in the `unit` job, which is `continue-on-error`** — so a red guard here is *visible without blocking*.

---

## Which Dockerfiles this covers — measured, not assumed

`Matched 13 file(s) for manager dockerfile`. All 13 covered, no `managerFilePatterns` override needed:

| File | Base image today |
|---|---|
| `Dockerfile` (`deps` + `runner`) | `node:24.19.0-alpine3.24` |
| `apps/auth/Dockerfile` | `node:22-alpine` |
| `apps/creator-studio/Dockerfile` | `node:22-alpine` |
| `apps/event-engine/Dockerfile` | `node:22-alpine` |
| `apps/moderator/Dockerfile` | `node:22-alpine` |
| `apps/notifications/Dockerfile` | `node:22-alpine` |
| `apps/orchestrator-gateway/Dockerfile` | `node:22-alpine` |
| `apps/storage/Dockerfile` | `node:22-alpine` |
| `containers/clickhouse/Dockerfile` | `clickhouse/clickhouse-server:24.8.4` |
| `containers/db/Dockerfile` | `postgres:17` |
| `containers/image-stub/Dockerfile` | `node:20-bookworm` |
| `containers/logical-db/Dockerfile` | `postgres:15-bookworm` |
| `containers/notification-db/Dockerfile` | `postgres:15-bookworm` |

The first run is more than one PR — the `apps/*` images are on floating `node:22-alpine` and the `containers/*` ones are local-dev/test images that have never been pinned. From the dry-run, the natural split is roughly: the node runtime pin, a `node-24.x` major group, `postgres-18.x`, two ClickHouse branches, and a `pin-dependencies` branch. Worth knowing before it runs, not after.

`containers/image-stub/Dockerfile` on `node:20-bookworm` is picked up. #3371 flagged Node 20 as EOL since 2026-04 and out of scope there; Renovate will now surface it.

### Explicitly out of scope

**`docker-compose` is a separate Renovate manager and is NOT enabled here.** These 5 files are *not* covered, and I would rather say so than let the table above imply full Docker coverage:

`docker-compose.yml`, `docker-compose.base.yml`, `apps/event-engine/docker-compose.yml`, `.devcontainer/internal/docker-compose.yml`, `.devcontainer/public/docker-compose.yml`

They are local-dev/CI compose stacks, not production runtimes, which is why I left them out of the first step rather than widening scope on day one. Adding `"docker-compose"` to `enabledManagers` covers them when wanted.

---

## Design decisions

### Narrow `enabledManagers` — deliberate and load-bearing

579 dependencies in scope is not 579 PRs — `config:recommended` groups and rate-limits. But it is the size of the surface, and the predictable week-one outcome of turning that on cold is that somebody switches Renovate off. Then the repo has an inert config *plus* a false belief in coverage, which is worse than having nothing, because nothing at least looks like nothing.

Land Docker (plus the one file needed to keep it consistent), prove it works, widen deliberately later. `npm`, `github-actions` and `docker-compose` are all one line each when someone wants them.

### `docker:pinDigests` — the actual mechanism

Rewrites `node:24.19.0-alpine3.24` to `node:24.19.0-alpine3.24@sha256:…` and then keeps that digest current. Reproducibility *and* patch flow. The preset resolves to `{ matchDatasources: ["docker"], pinDigests: true }`.

A digest pin **does not** break the #3779 guard — its version extractor still reads `24.19.0` out of a tag with `@sha256:…` appended. That was checked against the guard's own regexes.

### No automerge — deliberately deferred, not overlooked

I explicitly did not enable it, because **this repo cannot currently fail a bot's PR:**

- `.github/workflows/lint.yml` → the `unit` job carries `continue-on-error: true` (its own comment says: *"FLIP TO BLOCKING once a couple of weeks of runs show a clean pass rate. Remove `continue-on-error` and this comment together."*), so ~8,900 unit tests cannot red a check.
- `main`'s branch protection has **no `required_status_checks`** and no required reviews at all (verified via the API — pushes are restricted to five named users, but nothing gates on CI).

A bot merging base-image changes into a repo where tests cannot block is strictly worse than a human glancing at a one-line digest diff. Automerge should be reconsidered **once the `unit` job is blocking and `main` requires it** — tracked separately, not in this PR.

The `packages` and `apps` test jobs are *not* `continue-on-error`, to be precise about it — but with no required status checks they still cannot prevent a merge.

### `schedule: ["before 6am on monday"]`

One batch a week, landing before the week starts, rather than PRs trickling in continuously.

---

## Validation

Run against **renovate 44.22.0** (current latest) on Node 24 — a bare `npx` on Node 26 silently falls back to renovate 37, so the version was pinned and confirmed:

```
INFO: Validating renovate.json
INFO: Config validated successfully against 1 file(s)
```

I also validated the **instrument**, because a validator that cannot go red proves nothing. A deliberately broken config fed to the same invocation:

```
ERROR: Found errors in configuration
       "errors": [
         { "message": "Configuration option `packageRules` should be a list (Array)" },
         { "message": "Invalid configuration option: notARealOption" }
       ]
```

Exit 1 as it should, exit 0 for the real config. Both the file-argument and the in-repo auto-detect invocations were run, and they agree. So the pass above is a real pass.

---

## What automation exists today — verified independently

- **No other bot config file anywhere in the tree.** Searched all tracked files on `main` for `renovate`/`dependabot` in any path: **0 matches** before this PR. That covers `.github/renovate.json`, `.renovaterc*`, `.github/dependabot.yml` and every other supported location.
- **No bot has ever opened a PR here.** Across the last 200 PRs every author is a human; **0 bot-authored PRs**, and 0 Renovate-authored PRs all-time.

**Dependabot is partly on, and the earlier revision of this PR said "no Dependabot", which was imprecise.** Corrected, from the API:

| Feature | State | Effect |
|---|---|---|
| Dependabot **alerts** | **enabled** (`/vulnerability-alerts` → 204) | detects and reports — **153 open: 6 critical, 74 high, 59 moderate, 14 low** |
| Dependabot **security-update PRs** | **disabled** (`/automated-security-fixes` → `{"enabled": false}`) | opens nothing |
| Dependabot **version updates** | not configured (no `.github/dependabot.yml` — 404) | opens nothing |

So the repo **detects** vulnerabilities and **fixes none automatically** — 153 alerts and zero PRs is that gap made visible. Two things follow. Those alerts are npm/lockfile-derived, so **the Docker base-image gap this PR addresses is not covered even by the alerting that does exist.** And it is a concrete argument for widening `enabledManagers` to `npm` after Docker is proven — deliberately a later step, not this one.

---

## Stated plainly as unverified

- **How often the datasource-lag window is actually open** — see above; Docker Hub's `last_updated` cannot answer it, and I did not build a longitudinal measurement.
- **The exact number of PRs the first run opens.** The dry-run shows the branch split, but rate limits and `prConcurrentLimit` shape how many appear in week one; I neutralised those limits to make the branch computation observable, so the branch count is not a PR-count prediction.
- **The vitest suite itself** was not executed — there is no `node_modules` in my worktree. The guard's regexes were read from source and driven directly rather than transcribed, but the real suite was not run.
- **The end-to-end file writes.** `--platform=local` stops after branch assignment, so the measurements above are of *which branch each update lands on*, not of the resulting file contents.

## Not doing in this PR

- Enabling `npm` / `github-actions` / `docker-compose` managers
- Automerge (see above — gated on the `unit` job becoming blocking)
- Updating the `apps/*` floating `node:22-alpine` tags by hand — Renovate will propose them

🤖 Generated with [Claude Code](https://claude.com/claude-code)
