### PR TITLE
feat(comments): copy link & copy comment ID from comment menu

### DIFF
--- a/src/components/CommentsV2/Comment/Comment.tsx
+++ b/src/components/CommentsV2/Comment/Comment.tsx
@@ -19,10 +19,13 @@ import {
   IconEye,
   IconEyeOff,
   IconFlag,
+  IconId,
+  IconLink,
   IconPinned,
   IconPinnedOff,
   IconTrash,
 } from '@tabler/icons-react';
+import { useClipboard } from '@mantine/hooks';
 import clsx from 'clsx';
 import React, { useEffect, useState } from 'react';
 import { create } from 'zustand';
@@ -41,8 +44,10 @@ import { LineClamp } from '~/components/LineClamp/LineClamp';
 import { LoginRedirect } from '~/components/LoginRedirect/LoginRedirect';
 import { RenderHtml } from '~/components/RenderHtml/RenderHtml';
 import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { ReportEntity } from '~/shared/utils/report-helpers';
 import { type Comment } from '~/server/services/commentsv2.service';
+import { showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 import { constants } from '../../../server/common/constants';
 import { useMutateComment } from '../commentv2.utils';
@@ -99,7 +104,22 @@ export function CommentContent({
   const id = useStore((state) => state.id);
   const setId = useStore((state) => state.setId);
 
+  const currentUser = useCurrentUser();
+  const clipboard = useClipboard();
+
   const { toggleHide, togglePinned } = useMutateComment();
+
+  const handleCopyLink = () => {
+    const url = new URL(window.location.href);
+    url.searchParams.set('highlight', String(comment.id));
+    clipboard.copy(url.toString());
+    showSuccessNotification({ message: 'Comment link copied to clipboard' });
+  };
+
+  const handleCopyId = () => {
+    clipboard.copy(String(comment.id));
+    showSuccessNotification({ message: 'Comment ID copied to clipboard' });
+  };
 
   const editing = id === comment.id;
   const [replying, setReplying] = useState(false);
@@ -259,6 +279,14 @@ export function CommentContent({
                     Report
                   </Menu.Item>
                 </LoginRedirect>
+              )}
+              <Menu.Item leftSection={<IconLink size={14} stroke={1.5} />} onClick={handleCopyLink}>
+                Copy link
+              </Menu.Item>
+              {currentUser?.isModerator && (
+                <Menu.Item leftSection={<IconId size={14} stroke={1.5} />} onClick={handleCopyId}>
+                  Copy comment ID
+                </Menu.Item>
               )}
             </Menu.Dropdown>
           </Menu>


### PR DESCRIPTION
## What this does

Adds two actions to the CommentsV2 comment context menu (the `⋮` dropdown):

- **Copy link** — available to everyone. Copies a direct URL to that comment. It reuses the existing `?highlight=<commentId>` deep-link mechanism (the same param notifications use to scroll/highlight a comment) by taking the current page URL and setting/replacing the `highlight` query param, so it works on every surface a comment renders on (model dialogs, images, posts, articles, bounties, reviews, etc.) without per-page routing logic. Shows a success toast.
- **Copy comment ID** — moderator-only. Copies the numeric comment ID. Shows a success toast.

Primary use case is moderation: a mod handed a reported/suspicious comment can grab the ID for audit or copy a link to jump straight into the full conversation.

## Where the actions live

`src/components/CommentsV2/Comment/Comment.tsx` — appended to the existing `Menu.Dropdown` after the Report item, matching the surrounding `Menu.Item` structure (tabler `leftSection` icon + `onClick`).

## Moderator-gating decision

Followed the "Copy link everyone / Copy comment ID mod-only" split suggested in the task. Comments are already publicly linkable, so exposing "Copy link" broadly matches existing behavior and is low-risk. The raw numeric ID is an internal identifier only useful for moderation/audit, so it's gated behind `useCurrentUser()?.isModerator` — the same flag the nearby hide/pin/delete actions already key off of via the comment context.

## How I verified

- `pnpm run typecheck` — OK, 0 type errors.
- `eslint` on the touched file — 0 errors (the one pre-existing `no-unused-vars` warning on `CommentReplies`' `userId` is unrelated to this change).

## Notes for review

- The link is built client-side from `window.location.href` inside the click handler, so it always reflects the page the menu is opened on. This includes any other query params already on the URL (e.g. an open dialog's params), which is generally desirable for model-dialog threads but means the copied URL is not always the minimal canonical path.
- Reused Mantine `useClipboard` + `showSuccessNotification` (the repo's standard copy + toast utilities). No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)