### PR TITLE
fix(gallery): filter pinned posts to the pinned model version

### DIFF
--- a/src/components/Image/AsPosts/ImagesAsPostsCard.tsx
+++ b/src/components/Image/AsPosts/ImagesAsPostsCard.tsx
@@ -134,7 +134,7 @@ function PinnedIndicator({
   return (
     <HoverCard width={300} withArrow withinPortal>
       <HoverCard.Target>
-        <ThemeIcon {...themeIconProps} className="absolute -right-2.5 -top-2.5 z-10">
+        <ThemeIcon {...themeIconProps} className="absolute -right-1.5 -top-1.5 z-10">
           <IconPinFilled {...iconProps} />
         </ThemeIcon>
       </HoverCard.Target>

--- a/src/components/MasonryColumns/MasonryColumnsVirtual.browser.test.tsx
+++ b/src/components/MasonryColumns/MasonryColumnsVirtual.browser.test.tsx
@@ -42,8 +42,24 @@ const ITEM_HEIGHT = 200;
 type Item = { id: number };
 const items: Item[] = Array.from({ length: 60 }, (_, i) => ({ id: i }));
 
+const BADGE_SIZE = 12;
+const BADGE_OFFSET = 6;
+
 function Card({ data }: { data: Item }) {
-  return <div data-testid="card" data-id={data.id} style={{ height: ITEM_HEIGHT }} />;
+  return (
+    <div data-testid="card" data-id={data.id} style={{ height: ITEM_HEIGHT, position: 'relative' }}>
+      <div
+        data-testid="badge"
+        style={{
+          position: 'absolute',
+          right: -BADGE_OFFSET,
+          top: -BADGE_OFFSET,
+          width: BADGE_SIZE,
+          height: BADGE_SIZE,
+        }}
+      />
+    </div>
+  );
 }
 
 function Gallery() {
@@ -120,11 +136,36 @@ async function expectGalleryTopOnScreen() {
   });
 }
 
+// A card badge that hangs off the card's corner (the pinned-post indicator) is painted, not
+// laid out, outside the card. `contentVisibility: 'auto'` on each virtual item implies
+// `contain: paint`, which clips descendants to the item's border box regardless of `overflow`
+// — so the badge lost its outer half with nothing in the computed styles to point at. The item
+// is padded outward by ITEM_BLEED to give that overhang somewhere to land.
+
 describe('MasonryColumnsVirtual', () => {
   beforeEach(async () => {
     renderWithProviders(<Gallery />);
     await vi.waitFor(() => expect(columns().length).toBe(2));
     await vi.waitFor(() => expect(renderedIds().length).toBeGreaterThan(0));
+  });
+
+  test('does not clip a badge that overhangs the top-right of its card', async () => {
+    // Deliberately NOT scrolled to the gallery: the first row has to sit clear of the window's
+    // top edge, or the probe lands outside the viewport and elementFromPoint returns null for
+    // a reason that has nothing to do with clipping.
+    const badge = document.querySelector('[data-testid="badge"]') as HTMLElement;
+    const card = badge.closest('[data-testid="card"]') as HTMLElement;
+    const badgeRect = badge.getBoundingClientRect();
+    const cardRect = card.getBoundingClientRect();
+    const probe = { x: badgeRect.right - 2, y: badgeRect.top + 2 };
+
+    expect(badgeRect.right).toBeGreaterThan(cardRect.right);
+    expect(badgeRect.top).toBeLessThan(cardRect.top);
+    expect(probe.y).toBeGreaterThan(0);
+
+    // The probe is outside the card on BOTH axes, so it can only be the badge if the overhang
+    // survives paint containment. Read synchronously — nothing here is transient.
+    expect(document.elementFromPoint(probe.x, probe.y)).toBe(badge);
   });
 
   test('fills the viewport when scrolled to the gallery', async () => {

--- a/src/components/MasonryColumns/MasonryColumnsVirtual.tsx
+++ b/src/components/MasonryColumns/MasonryColumnsVirtual.tsx
@@ -15,6 +15,14 @@ import { useScrollAreaRef } from '~/components/ScrollArea/ScrollAreaContext';
 import { useScrollMargin } from '~/hooks/useScrollMargin';
 import type { AdFeedItem } from '~/components/Ads/ads.utils';
 
+// `contentVisibility: 'auto'` below implies `contain: paint`, which clips every
+// descendant to the item's border box no matter what `overflow` says — so a card's
+// corner badge gets sliced in half. Padding the item outward by this much (and
+// pulling its origin back by the same) gives that overflow somewhere to land while
+// leaving the card's own box untouched. Must stay <= half the 16px row/column gap,
+// or a later sibling's bleed paints over the badge and undoes the whole thing.
+const ITEM_BLEED = 8;
+
 type Props<TData> = {
   data: TData[];
   render: React.ComponentType<MasonryRenderItemProps<TData>>;
@@ -135,15 +143,18 @@ function VirtualColumn<TData>({
           style={{
             position: 'absolute',
             top: 0,
-            left: 0,
-            width: '100%',
-            height: items[item.index].height,
-            transform: `translateY(${item.start - rowVirtualizer.options.scrollMargin}px)`,
+            left: -ITEM_BLEED,
+            width: `calc(100% + ${ITEM_BLEED * 2}px)`,
+            height: items[item.index].height + ITEM_BLEED * 2,
+            padding: ITEM_BLEED,
+            transform: `translateY(${
+              item.start - rowVirtualizer.options.scrollMargin - ITEM_BLEED
+            }px)`,
             // Skip layout/paint for offscreen overscan rows; the explicit
             // `height` above keeps layout space reserved so the virtualizer's
             // scroll math stays correct.
             contentVisibility: 'auto',
-            containIntrinsicSize: `0 ${items[item.index].height}px`,
+            containIntrinsicSize: `0 ${items[item.index].height + ITEM_BLEED * 2}px`,
           }}
         >
           <VirtualItem index={item.index} item={items[item.index]} {...rest} />

--- a/src/server/controllers/image.controller.ts
+++ b/src/server/controllers/image.controller.ts
@@ -78,6 +78,7 @@ import {
   getImageResources,
   getReportViolationDetailsForImages,
   getResourceIdsForImages,
+  filterPinnedImagesToVersion,
   getTagNamesForImages,
   moderateImages,
 } from './../services/image.service';
@@ -435,10 +436,10 @@ export const getImagesAsPostsInfiniteHandler = async ({
       const { items: pinnedPostsImages } = await getAllImages({
         ...input,
         domain: getRequestBoardDomainColor(ctx.req),
-        // Don't filter by model version/model for pinned posts â€” we already have
-        // exact postIds. The ImageResourceNew join that modelVersionId triggers
-        // excludes videos and other media that lack resource-detection entries,
-        // causing pinned posts with videos to silently disappear from the gallery.
+        // Fetch the posts whole and narrow them with filterPinnedImagesToVersion
+        // below. The ImageResourceNew join that modelVersionId triggers is an
+        // inner join, so filtering it here drops media with no resource-detection
+        // entries, which is what made pinned posts with videos disappear.
         modelVersionId: undefined,
         modelId: undefined,
         reviewId: undefined,
@@ -453,17 +454,14 @@ export const getImagesAsPostsInfiniteHandler = async ({
         dbTarget: 'datapacket',
       });
 
-      for (const image of pinnedPostsImages) {
+      const versionPinnedImages = input.modelVersionId
+        ? await filterPinnedImagesToVersion(pinnedPostsImages, input.modelVersionId)
+        : pinnedPostsImages;
+
+      for (const image of versionPinnedImages) {
         if (!image?.postId) continue;
         if (!pinned[image.postId]) pinned[image.postId] = [];
         pinned[image.postId].push(image);
-      }
-
-      // Build per-post image count map to see which posts got partial vs zero results
-      const imagesPerPost: Record<number, number> = {};
-      for (const id of versionPinnedPosts) imagesPerPost[id] = 0;
-      for (const img of pinnedPostsImages) {
-        if (img.postId) imagesPerPost[img.postId] = (imagesPerPost[img.postId] ?? 0) + 1;
       }
     }
 

--- a/src/server/services/__tests__/pinned-posts-version-filter.test.ts
+++ b/src/server/services/__tests__/pinned-posts-version-filter.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type * as PromClient from '~/server/prom/client';
+
+// Pinning is per model version, so a pinned post must contribute only the media that version made.
+// The carve-out for media carrying no resource rows is the whole point of the function and is what a
+// naive "just filter on the resource row" rewrite drops -- which is how pinned posts with videos
+// vanished from model galleries. A post left with nothing is meant to drop out.
+//
+// Mock recipe follows image-hide-challenges-exclusion.test.ts: stub env + infra clients + the
+// event-engine-common submodule so importing image.service boots no real infra.
+
+vi.mock('~/server/prom/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof PromClient>();
+  return { ...actual, registerCounter: () => ({ inc: vi.fn() }) };
+});
+
+vi.mock('../../../../event-engine-common/services/metrics', () => ({
+  MetricService: class {
+    fetch = vi.fn();
+  },
+}));
+vi.mock('../../../../event-engine-common/feeds', () => ({ ImagesFeed: class {} }));
+vi.mock('../../../../event-engine-common/services/cache', () => ({ CacheService: class {} }));
+
+vi.mock('~/env/server', () => ({
+  env: new Proxy({ LOGGING: [] as string[] } as Record<string, unknown>, {
+    get: (target, prop) => {
+      if (prop in target) return target[prop as string];
+      if (typeof prop === 'string' && (prop.endsWith('_URL') || prop.endsWith('_ENDPOINT')))
+        return 'https://test:test@localhost:5432/test';
+      if (
+        typeof prop === 'string' &&
+        /(_CONCURRENCY|_LIMIT|_MS|_PORT|_TIMEOUT|_MAX|_SIZE|_COUNT)$/.test(prop)
+      )
+        return 1;
+      return undefined;
+    },
+  }),
+}));
+
+const queryRaw = vi.fn();
+vi.mock('~/server/db/client', () => ({
+  dbRead: {
+    get $queryRaw() {
+      return queryRaw;
+    },
+  },
+  dbWrite: {
+    get $queryRaw() {
+      return queryRaw;
+    },
+  },
+}));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/redis/client', () => {
+  type KeyProxy = (() => string) & { [key: string]: KeyProxy };
+  const make = (): KeyProxy => new Proxy((() => 'k') as KeyProxy, { get: () => make() });
+  const keyProxy = make();
+  return {
+    redis: { packed: { get: vi.fn(), set: vi.fn() } },
+    sysRedis: {},
+    REDIS_KEYS: keyProxy,
+    REDIS_SYS_KEYS: keyProxy,
+  };
+});
+
+vi.mock('../../flipt/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../flipt/client')>()),
+  isFlipt: vi.fn().mockResolvedValue(false),
+  getFliptBoolean: vi.fn().mockResolvedValue(false),
+  getFliptVariant: vi.fn().mockResolvedValue(null),
+}));
+
+import { filterPinnedImagesToVersion } from '../image.service';
+
+const PINNED_VERSION = 280515;
+const OTHER_VERSION = 274522;
+
+type Row = { imageId: number; modelVersionId: number };
+const image = (id: number, postId: number) => ({ id, postId });
+const resourceRows = (...rows: [number, number][]): Row[] =>
+  rows.map(([imageId, modelVersionId]) => ({ imageId, modelVersionId }));
+
+describe('filterPinnedImagesToVersion', () => {
+  beforeEach(() => {
+    queryRaw.mockReset();
+  });
+
+  it('drops images in a pinned post that were made with a different version', async () => {
+    queryRaw.mockResolvedValue(
+      resourceRows([1, PINNED_VERSION], [2, OTHER_VERSION], [3, OTHER_VERSION])
+    );
+
+    const result = await filterPinnedImagesToVersion(
+      [image(1, 900), image(2, 900), image(3, 900)],
+      PINNED_VERSION
+    );
+
+    expect(result.map((x) => x.id)).toEqual([1]);
+  });
+
+  it('keeps media that has no resource rows at all', async () => {
+    // The video case: resource detection never wrote a row, so the media can't be attributed
+    // either way. Dropping it is what made pinned posts with videos disappear.
+    queryRaw.mockResolvedValue(resourceRows([1, PINNED_VERSION], [2, OTHER_VERSION]));
+
+    const result = await filterPinnedImagesToVersion(
+      [image(1, 900), image(2, 900), image(3, 900)],
+      PINNED_VERSION
+    );
+
+    expect(result.map((x) => x.id)).toEqual([1, 3]);
+  });
+
+  it('drops a pinned post entirely when every image in it belongs to another version', async () => {
+    // The post can only reappear here by being unpinned-and-repinned or re-attributed. Keeping it
+    // whole instead would put images the version never made back on the gallery, which is the bug.
+    queryRaw.mockResolvedValue(resourceRows([1, OTHER_VERSION], [2, OTHER_VERSION]));
+
+    const result = await filterPinnedImagesToVersion(
+      [image(1, 900), image(2, 900)],
+      PINNED_VERSION
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it('applies the same rule across posts in one batch', async () => {
+    queryRaw.mockResolvedValue(
+      resourceRows([1, PINNED_VERSION], [2, OTHER_VERSION], [3, OTHER_VERSION])
+    );
+
+    const result = await filterPinnedImagesToVersion(
+      [image(1, 900), image(2, 900), image(3, 901), image(4, 901)],
+      PINNED_VERSION
+    );
+
+    // Post 900 narrows to its match; post 901 keeps only image 4, which carries no rows at all.
+    expect(result.map((x) => x.id)).toEqual([1, 4]);
+  });
+
+  it('keeps an image carrying rows for both the pinned version and others', async () => {
+    queryRaw.mockResolvedValue(resourceRows([1, OTHER_VERSION], [1, PINNED_VERSION]));
+
+    const result = await filterPinnedImagesToVersion([image(1, 900)], PINNED_VERSION);
+
+    expect(result.map((x) => x.id)).toEqual([1]);
+  });
+
+  it('does not query when there is nothing to filter', async () => {
+    const result = await filterPinnedImagesToVersion([], PINNED_VERSION);
+
+    expect(result).toEqual([]);
+    expect(queryRaw).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/__tests__/pinned-posts-version-filter.test.ts
+++ b/src/server/services/__tests__/pinned-posts-version-filter.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type * as PromClient from '~/server/prom/client';
+import type * as FliptClient from '~/server/flipt/client';
 
 // Pinning is per model version, so a pinned post must contribute only the media that version made.
 // The carve-out for media carrying no resource rows is the whole point of the function and is what a
@@ -65,7 +66,7 @@ vi.mock('~/server/redis/client', () => {
 });
 
 vi.mock('../../flipt/client', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('../../flipt/client')>()),
+  ...(await importOriginal<typeof FliptClient>()),
   isFlipt: vi.fn().mockResolvedValue(false),
   getFliptBoolean: vi.fn().mockResolvedValue(false),
   getFliptVariant: vi.fn().mockResolvedValue(null),

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -5092,6 +5092,25 @@ export async function getResourceIdsForImages(imageIds: number[]) {
   return imageResources;
 }
 
+/**
+ * Narrow a pinned post's media down to what the pinned model version made.
+ *
+ * Media with no resource rows at all is kept: it can't be attributed either way, and
+ * dropping it is what made pinned posts with videos vanish before 7518ca4f54.
+ */
+export async function filterPinnedImagesToVersion<T extends { id: number }>(
+  images: T[],
+  modelVersionId: number
+) {
+  if (!images.length) return images;
+
+  const resources = await getResourceIdsForImages(images.map((x) => x.id));
+  return images.filter((image) => {
+    const imageResources = resources[image.id];
+    return !imageResources?.length || imageResources.includes(modelVersionId);
+  });
+}
+
 type GetImageRaw = GetAllImagesRaw & {
   reactions?: ReviewReactions[];
   postId?: number | null;


### PR DESCRIPTION
Fixes [CU-868kngqqb](https://app.clickup.com/t/8459928/868kngqqb) (Freshdesk #68136).

## 1. Pinned posts bypassed the model-version filter

The model gallery filters per image via `ImageResourceNew`, so an ordinary post contributes only the images actually generated with that version. Pinned posts were fetched through a separate `getAllImages` call with `modelVersionId: undefined`, so no filter ran and the entire post was pulled in.

Creators pin a community post for the one good showcase image in it; pinning then dragged in every other image in that post, publicly, on their model page. On the reported model, seven pinned posts advertised 14-20 images each while only 1-3 in each were made with the version.

That call was deliberately unfiltered (`7518ca4f54`) because the `ImageResourceNew` join is an **inner** join, so it dropped pinned posts whose media had no resource-detection rows — the "pinned posts with videos disappear" bug. The premise was half right: the join drops *any* media lacking a row, not just video.

**Fix:** keep fetching the posts whole, then filter in JS (`filterPinnedImagesToVersion`). An image stays if it has a resource row for the pinned version, **or** if it has no resource rows at all. The second clause covers the video case; the filter runs only on the pinned path, so the shared feed query, its cache tags, and the BitDex path are untouched.

There is **no whole-post fallback**. If the filter empties a post then every image in it has rows and none match — we *know* they belong elsewhere — so keeping the post whole can only fire in the case it must not. I built one first and production killed it: post 10119101 came back showing two images belonging to other versions.

### Measured on production

Model 227403 / version 280515, per-post image counts through the real tRPC endpoint, against `ImageResourceNew` truth:

| post | before | after | rows matching 280515 |
|---|---|---|---|
| 26509247 | 20 | **1** | 1 |
| 19968101 | 20 | **1** | 1 |
| 19986417 | 20 | **1** | 1 |
| 10116638 | 16 | **1** | 1 |
| 9872935 | 16 | **1** | 1 |
| 11168532 | 14 | **3** | 3 |
| 5867947 | 6 | **6** | 6 |

Every pinned post now matches per-image DB truth.

Blast radius across the 6000 newest pin entries: 60,169 pinned images -> 54,941 kept. **~8.9% were being shown on a version that never made them.** 145 images (0.24%) survive only via the no-rows carve-out, and 17 posts (0.29%) drop out entirely because every image in them belongs to another version.

The carousel's lazy tail fetch (`image.getInfinite({ postId })`) already forwards `modelVersionId`, so `imageCount` and the tail stay consistent with the filtered seed.

## 2. Pinned badge was clipped by paint containment

The badge hangs off the card's top-right corner and rendered as a half circle. Nothing in the computed styles explains it — every ancestor is `overflow: visible`. The cause is `contentVisibility: 'auto'` on each `MasonryColumnsVirtual` item, which implies `contain: paint` and clips descendants to the item's border box. The item box *is* the card box, so the overhang had nowhere to go. `overflow-clip-margin` does not relieve it (Chromium ignores it under paint containment).

Pixel-scan: the badge was hit-testable only within the item's border box, losing exactly 8px on each axis.

**Fix:** pad each item outward by `ITEM_BLEED = 8` and pull its origin back by the same, so the card's own box is unchanged but the overhang has room. 8 is the ceiling — half the 16px row/column gap, beyond which a later sibling's bleed paints over the badge again. The badge offset moves `-right-2.5` -> `-right-1.5` to sit inside that budget.

This touches the virtualizer shared by `/images`, `/posts`, `/search/images`, the resource-select modal and the as-posts gallery. Verified geometry-neutral on `/images` and `/posts`: inner content sits at exactly item+8 on both axes, column width still 320, gaps unchanged. `contentVisibility` is kept, so the overscan-row perf win from `6320cfe6b4` stands.

## Testing

- `src/server/services/__tests__/pinned-posts-version-filter.test.ts` — 6 tests. Mutation-verified both ways: dropping the no-rows carve-out gives `expected [ 1 ] to deeply equal [ 1, 3 ]`; passthrough (today's behaviour) fails 4 of 6. All under 6s.
- `MasonryColumnsVirtual.browser.test.tsx` — probes a point outside the card on both axes and asserts it hits the badge. At `ITEM_BLEED = 0` it fails in 199ms. It deliberately does not scroll to the gallery: flush against the window top, the probe lands outside the viewport and `elementFromPoint` returns null for a reason unrelated to clipping.
- `pnpm run typecheck` 0 errors; `test:lint-rules` 204/204; component suite 3/3.
- Verified end to end in a dev server against the production database, signed in as a moderator at full browsing level.

No migration, no config, no flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
