### PR TITLE
feat(moderation): add a pending-review mute path for the Orchestrator

### DIFF
--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -111,6 +111,14 @@ const TEST_ENV_DEFAULTS: Record<string, unknown> = {
   REDIS_SYS_COMMANDS_QUEUE_MAX_LENGTH: 10000,
   NEXTAUTH_URL: 'http://localhost:3000',
   NEXTAUTH_SECRET: 'test-secret',
+  // endpoint-helpers spreads TRPC_ORIGINS at module load, so an undefined value
+  // makes importing ANY api page throw "is not iterable" — which is why tests
+  // have been stubbing the endpoint wrappers instead of exercising them. The
+  // tokens are non-empty so a request that omits `?token=` genuinely fails the
+  // check rather than matching `undefined !== undefined`.
+  TRPC_ORIGINS: [] as string[],
+  WEBHOOK_TOKEN: 'test-webhook-token',
+  JOB_TOKEN: 'test-job-token',
   S3_UPLOAD_ENDPOINT: 'http://localhost:9000',
   S3_IMAGE_UPLOAD_ENDPOINT: 'http://localhost:9000',
   ORCHESTRATOR_ENDPOINT: 'http://localhost:8080',

--- a/src/pages/api/mod/mute-user-pending-review.ts
+++ b/src/pages/api/mod/mute-user-pending-review.ts
@@ -1,0 +1,93 @@
+/**
+ * Service-callable pending-review mute (Orchestrator strike escalation).
+ * =============================================================================
+ *
+ * Auth: WEBHOOK_TOKEN (`?token=`), the same control as `/api/mod/ban-user`.
+ *
+ * POST /api/mod/mute-user-pending-review?token=...
+ * Body/query: {
+ *   userId: number,
+ *   reason: string,          // surfaced to the moderator as the restriction trigger
+ *   source?: string,         // free-text caller detail, defaults to "orchestrator"
+ *   prompts?: string[]       // offending prompts, one trigger row each
+ * }
+ *
+ * Pauses the account and files a Pending UserRestriction for the review queue.
+ * It does NOT set `mutedAt`, so `confirm-mutes` leaves the user's memberships
+ * alone — only a moderator upholding the restriction cancels them.
+ *
+ * There is deliberately no unmute counterpart. Clearing a pending-review mute
+ * means judging the case, and the only path that may do that is a moderator
+ * overturning it via `userRestriction.resolve`, which also reinstates the
+ * subscription and resets the violation count.
+ *
+ * Responses:
+ *   200 { userId, muted: true, userRestrictionId }
+ *   200 { userId, muted: false, skipped: 'moderator' }
+ *   400 invalid payload
+ *   500 { error } — safe for the caller to retry
+ */
+import type { NextApiRequest, NextApiResponse } from 'next';
+import * as z from 'zod';
+import { Tracker } from '~/server/clickhouse/client';
+import { logToAxiom } from '~/server/logging/client';
+import { trackModActivity } from '~/server/services/moderator.service';
+import {
+  applyPendingReviewMute,
+  buildManualMuteTriggers,
+} from '~/server/services/user-restriction.service';
+import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
+
+const schema = z.object({
+  userId: z.coerce.number().int().positive(),
+  reason: z.string().trim().min(1).max(500),
+  source: z.string().trim().min(1).max(100).default('orchestrator'),
+  prompts: z.array(z.string().max(5000)).max(50).optional(),
+});
+
+// Fixed, not derived from the caller-supplied `source`: it labels a Prometheus
+// counter, so a free-text value would let the caller blow up its cardinality.
+const UPDATE_SOURCE = 'webhook:mutePendingReview';
+
+const SYSTEM_ACTOR_ID = -1;
+
+export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse) => {
+  const parsed = schema.safeParse({ ...req.query, ...(req.body ?? {}) });
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'Invalid request', issues: parsed.error.issues });
+  }
+  const { userId, reason, source, prompts } = parsed.data;
+
+  try {
+    const result = await applyPendingReviewMute({
+      userId,
+      triggers: buildManualMuteTriggers({ reason, source, prompts }),
+      updateSource: UPDATE_SOURCE,
+    });
+
+    if (result.muted) {
+      await trackModActivity(SYSTEM_ACTOR_ID, {
+        entityType: 'user',
+        entityId: userId,
+        activity: 'mutePendingReview',
+      });
+      const tracker = new Tracker(req, res);
+      await tracker.userActivity({
+        type: 'Muted',
+        targetUserId: userId,
+        source: `mute-pending-review (${source}: ${reason})`,
+      });
+    }
+
+    return res.status(200).json({ userId, ...result });
+  } catch (e) {
+    const err = e as Error;
+    logToAxiom({
+      type: 'error',
+      name: 'mod-mute-user-pending-review-error',
+      message: err.message,
+      details: { userId, source, reason },
+    });
+    return res.status(500).json({ error: err.message });
+  }
+});

--- a/src/pages/api/mod/overturn-user-mute.ts
+++ b/src/pages/api/mod/overturn-user-mute.ts
@@ -1,31 +1,24 @@
 /**
- * POST /api/mod/mute-user-pending-review
+ * POST /api/mod/overturn-user-mute
  *
- * Pauses an account and files a Pending UserRestriction for the moderator queue.
- * It does NOT set `mutedAt`, so `confirm-mutes` leaves the user's memberships
- * alone — only a moderator upholding the restriction cancels them.
+ * "They shouldn't have been muted." Overturns the user's open generation
+ * restriction rather than just clearing `muted`, so the review queue doesn't
+ * keep a stale Pending row — and picks up the subscription reinstate and the
+ * violation-count reset that come with an overturn.
  */
 import type { NextApiRequest, NextApiResponse } from 'next';
 import * as z from 'zod';
 import { Tracker } from '~/server/clickhouse/client';
 import { logToAxiom } from '~/server/logging/client';
 import { trackModActivity } from '~/server/services/moderator.service';
-import {
-  applyPendingReviewMute,
-  buildManualMuteTriggers,
-} from '~/server/services/user-restriction.service';
+import { overturnPendingReviewMute } from '~/server/services/user-restriction-resolve.service';
 import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
 
 const schema = z.object({
   userId: z.coerce.number().int().positive(),
   reason: z.string().trim().min(1).max(500),
   source: z.string().trim().min(1).max(100).default('orchestrator'),
-  prompts: z.array(z.string().max(5000)).max(50).optional(),
 });
-
-// Fixed, not derived from the caller-supplied `source`: it labels a Prometheus
-// counter, so a free-text value would let the caller blow up its cardinality.
-const UPDATE_SOURCE = 'webhook:mutePendingReview';
 
 const SYSTEM_ACTOR_ID = -1;
 
@@ -39,26 +32,26 @@ export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse)
   if (!parsed.success) {
     return res.status(400).json({ error: 'Invalid request', issues: parsed.error.issues });
   }
-  const { userId, reason, source, prompts } = parsed.data;
+  const { userId, reason, source } = parsed.data;
 
   try {
-    const result = await applyPendingReviewMute({
+    const result = await overturnPendingReviewMute({
       userId,
-      triggers: buildManualMuteTriggers({ reason, source, prompts }),
-      updateSource: UPDATE_SOURCE,
+      resolvedMessage: reason,
+      moderatorId: SYSTEM_ACTOR_ID,
     });
 
-    if (result.muted && !result.deduped) {
+    if (result.unmuted) {
       await trackModActivity(SYSTEM_ACTOR_ID, {
         entityType: 'user',
         entityId: userId,
-        activity: 'mutePendingReview',
+        activity: 'overturnPendingReviewMute',
       });
       const tracker = new Tracker(req, res, null);
       await tracker.userActivity({
-        type: 'Muted',
+        type: 'Unmuted',
         targetUserId: userId,
-        source: `mute-pending-review (${source}: ${reason})`,
+        source: `overturn-pending-review-mute (${source}: ${reason})`,
       });
     }
 
@@ -67,7 +60,7 @@ export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse)
     const err = e as Error;
     logToAxiom({
       type: 'error',
-      name: 'mod-mute-user-pending-review-error',
+      name: 'mod-overturn-user-mute-error',
       message: err.message,
       details: { userId, source, reason },
     });

--- a/src/server/__tests__/pending-review-mute.test.ts
+++ b/src/server/__tests__/pending-review-mute.test.ts
@@ -39,6 +39,7 @@ const {
   trackUserActivity,
   userUpdateCounterInc,
   refreshSession,
+  createNotification,
 } = vi.hoisted(() => {
   const store = {
     users: new Map<number, UserRow>(),
@@ -135,6 +136,7 @@ const {
     trackUserActivity: vi.fn(async () => undefined),
     userUpdateCounterInc: vi.fn(),
     refreshSession: vi.fn(async () => undefined),
+    createNotification: vi.fn(async () => undefined),
   };
 });
 
@@ -148,7 +150,7 @@ vi.mock('~/server/auth/session-invalidation', async (importOriginal) => ({
 }));
 vi.mock('~/server/services/notification.service', async (importOriginal) => ({
   ...(await importOriginal<typeof NotificationService>()),
-  createNotification: vi.fn(async () => undefined),
+  createNotification,
 }));
 vi.mock('~/server/services/moderator.service', async (importOriginal) => ({
   ...(await importOriginal<typeof ModeratorService>()),
@@ -171,11 +173,6 @@ vi.mock('~/server/clickhouse/client', () => ({
     userActivity = trackUserActivity;
   },
 }));
-
-// `~/server/utils/endpoint-helpers` is deliberately NOT mocked. The token check
-// is the endpoint's only access control, so stubbing the wrapper out would make
-// deleting it a silent, green-passing change. The env defaults it needs at
-// module load live in src/__tests__/setup.ts.
 
 import muteHandler from '~/pages/api/mod/mute-user-pending-review';
 import overturnHandler from '~/pages/api/mod/overturn-user-mute';
@@ -525,6 +522,61 @@ describe('POST /api/mod/overturn-user-mute', () => {
     expect(trackUserActivity).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'Unmuted', targetUserId: USER_ID })
     );
+  });
+
+  it('audits the overturn even when the notification fails', async () => {
+    await applyPendingReviewMute({ userId: USER_ID, triggers, updateSource: 'test' });
+    createNotification.mockRejectedValueOnce(new Error('notification service down'));
+
+    const { status, body } = await call(overturnHandler, {
+      body: { userId: USER_ID, reason: 'mistake' },
+    });
+
+    expect(status).toBe(200);
+    expect(body).toMatchObject({ userId: USER_ID, unmuted: true });
+    expect(trackModActivity).toHaveBeenCalledOnce();
+    expect(trackUserActivity).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ['the system actor', constants.system.user.id, 'protected'],
+    ['the official brand account', constants.system.officialUserId, 'protected'],
+    ['a moderator', MOD_ID, 'moderator'],
+  ])('refuses to overturn %s', async (_label, userId, skipped) => {
+    store.users.set(userId, makeUser(userId, { isModerator: userId === MOD_ID, muted: true }));
+    store.restrictions.push({
+      id: 1,
+      userId,
+      type: 'generation',
+      status: 'Pending',
+      triggers: [],
+      createdAt: new Date(),
+    });
+
+    const result = await overturnPendingReviewMute({ userId, moderatorId: -1 });
+
+    expect(result).toEqual({ unmuted: false, skipped });
+    expect(store.restrictions[0].status).toBe('Pending');
+    expect(store.users.get(userId)).toMatchObject({ muted: true });
+  });
+
+  it('refuses to overturn a mute a moderator made by hand, which mutedAt marks', async () => {
+    await setUserMuted({ userId: USER_ID, muted: true });
+    store.restrictions.push({
+      id: 1,
+      userId: USER_ID,
+      type: 'generation',
+      status: 'Pending',
+      triggers: [],
+      createdAt: new Date(),
+    });
+
+    const result = await overturnPendingReviewMute({ userId: USER_ID, moderatorId: -1 });
+
+    expect(result).toEqual({ unmuted: false, skipped: 'manually-muted' });
+    expect(store.restrictions[0].status).toBe('Pending');
+    expect(store.users.get(USER_ID)).toMatchObject({ muted: true });
+    expect(reinstateSubscription).not.toHaveBeenCalled();
   });
 
   it('is a no-op when there is nothing open to overturn', async () => {

--- a/src/server/__tests__/pending-review-mute.test.ts
+++ b/src/server/__tests__/pending-review-mute.test.ts
@@ -1,0 +1,310 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as NotificationService from '~/server/services/notification.service';
+import type * as SessionInvalidation from '~/server/auth/session-invalidation';
+import type * as ModeratorService from '~/server/services/moderator.service';
+import type * as PromClient from '~/server/prom/client';
+
+type UserRow = { id: number; isModerator: boolean; muted: boolean; mutedAt: Date | null };
+type RestrictionRow = {
+  id: number;
+  userId: number;
+  type: string;
+  status: string;
+  triggers: unknown;
+};
+
+const {
+  store,
+  dbRead,
+  dbWrite,
+  cancelSubscription,
+  cancelSubscriptionPlan,
+  lastQuery,
+  trackModActivity,
+  trackUserActivity,
+  userUpdateCounterInc,
+} = vi.hoisted(() => {
+  const store = {
+    users: new Map<number, UserRow>(),
+    restrictions: [] as RestrictionRow[],
+    jobDate: new Date(0),
+  };
+  const lastQuery = { sql: '' };
+
+  const dbRead = {
+    user: {
+      findUnique: vi.fn(async ({ where }: { where: { id: number } }) => {
+        const user = store.users.get(where.id);
+        return user ? { ...user } : null;
+      }),
+    },
+  };
+
+  const dbWrite = {
+    user: {
+      findFirst: vi.fn(async () => null),
+      update: vi.fn(
+        async ({ where, data }: { where: { id: number }; data: Record<string, unknown> }) => {
+          const user = store.users.get(where.id);
+          if (!user) throw new Error(`no user ${where.id}`);
+          if ('muted' in data) user.muted = data.muted as boolean;
+          if ('mutedAt' in data) user.mutedAt = (data.mutedAt as Date | null) ?? null;
+          return { ...user };
+        }
+      ),
+    },
+    userRestriction: {
+      create: vi.fn(async ({ data }: { data: Omit<RestrictionRow, 'id' | 'status'> }) => {
+        const row: RestrictionRow = {
+          id: store.restrictions.length + 1,
+          status: 'Pending',
+          ...data,
+        };
+        store.restrictions.push(row);
+        return { id: row.id };
+      }),
+    },
+    keyValue: {
+      findUnique: vi.fn(async () => ({ value: store.jobDate.getTime() })),
+      upsert: vi.fn(async () => undefined),
+    },
+    // confirm-mutes' only query. Mirrors `WHERE "muted" AND "mutedAt" > $lastRan`;
+    // the shape assertion below is what keeps this in step with the real SQL.
+    $queryRaw: vi.fn(async (strings: TemplateStringsArray, lastRan: Date) => {
+      lastQuery.sql = strings.join('?');
+      return [...store.users.values()]
+        .filter((u) => u.muted && u.mutedAt && u.mutedAt > lastRan)
+        .map((u) => ({ id: u.id }));
+    }),
+  };
+
+  return {
+    store,
+    dbRead,
+    dbWrite,
+    cancelSubscription: vi.fn(async () => undefined),
+    cancelSubscriptionPlan: vi.fn(async () => undefined),
+    lastQuery,
+    trackModActivity: vi.fn(async () => undefined),
+    trackUserActivity: vi.fn(async () => undefined),
+    userUpdateCounterInc: vi.fn(),
+  };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead, dbWrite, dbKV: dbWrite }));
+vi.mock('~/server/services/stripe.service', () => ({ cancelSubscription }));
+vi.mock('~/server/services/paddle.service', () => ({ cancelSubscriptionPlan }));
+vi.mock('~/server/auth/session-invalidation', async (importOriginal) => ({
+  ...(await importOriginal<typeof SessionInvalidation>()),
+  refreshSession: vi.fn(async () => undefined),
+  invalidateSession: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/services/notification.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof NotificationService>()),
+  createNotification: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/services/moderator.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof ModeratorService>()),
+  trackModActivity,
+}));
+vi.mock('~/server/prom/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof PromClient>()),
+  userUpdateCounter: { inc: userUpdateCounterInc },
+}));
+// endpoint-helpers spreads `env.TRPC_ORIGINS` at module load, so an unmocked
+// import pulls the whole env + axiom chain into a unit test.
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  WebhookEndpoint: (handler: unknown) => handler,
+}));
+vi.mock('~/server/clickhouse/client', () => ({
+  Tracker: class {
+    userActivity = trackUserActivity;
+  },
+}));
+
+import muteUserPendingReviewHandler from '~/pages/api/mod/mute-user-pending-review';
+import { confirmMutes } from '~/server/jobs/confirm-mutes';
+import { setUserMuted } from '~/server/services/user.service';
+import {
+  applyPendingReviewMute,
+  buildManualMuteTriggers,
+} from '~/server/services/user-restriction.service';
+
+const USER_ID = 101;
+const MOD_ID = 102;
+
+function seed() {
+  store.users.clear();
+  store.restrictions.length = 0;
+  store.jobDate = new Date(Date.now() - 60 * 60 * 1000);
+  store.users.set(USER_ID, { id: USER_ID, isModerator: false, muted: false, mutedAt: null });
+  store.users.set(MOD_ID, { id: MOD_ID, isModerator: true, muted: false, mutedAt: null });
+}
+
+async function runConfirmMutes() {
+  const { result } = confirmMutes.run({});
+  await result;
+}
+
+const triggers = buildManualMuteTriggers({ reason: 'csam-block strike threshold', source: 'test' });
+
+describe('pending-review mute', () => {
+  beforeEach(() => {
+    seed();
+    vi.clearAllMocks();
+  });
+
+  it('mutes without writing mutedAt', async () => {
+    await applyPendingReviewMute({ userId: USER_ID, triggers, updateSource: 'test' });
+
+    const [{ data }] = dbWrite.user.update.mock.calls.map(([arg]) => arg);
+    expect(data).toEqual({ muted: true });
+    expect(data).not.toHaveProperty('mutedAt');
+    expect(store.users.get(USER_ID)).toMatchObject({ muted: true, mutedAt: null });
+  });
+
+  it('files a Pending generation restriction so the review queue sees it', async () => {
+    await applyPendingReviewMute({ userId: USER_ID, triggers, updateSource: 'test' });
+
+    expect(store.restrictions).toHaveLength(1);
+    expect(store.restrictions[0]).toMatchObject({
+      userId: USER_ID,
+      type: 'generation',
+      status: 'Pending',
+    });
+    expect(store.restrictions[0].triggers).toEqual(triggers);
+  });
+
+  it('is not picked up by confirm-mutes, so no subscription is cancelled', async () => {
+    await applyPendingReviewMute({ userId: USER_ID, triggers, updateSource: 'test' });
+
+    await runConfirmMutes();
+
+    expect(cancelSubscription).not.toHaveBeenCalled();
+    expect(cancelSubscriptionPlan).not.toHaveBeenCalled();
+  });
+
+  it('skips moderators', async () => {
+    const result = await applyPendingReviewMute({ userId: MOD_ID, triggers, updateSource: 'test' });
+
+    expect(result).toEqual({ muted: false, skipped: 'moderator' });
+    expect(store.restrictions).toHaveLength(0);
+    expect(store.users.get(MOD_ID)).toMatchObject({ muted: false, mutedAt: null });
+  });
+});
+
+describe('POST /api/mod/mute-user-pending-review', () => {
+  const REASON = 'csam-block strike threshold';
+
+  function createRes() {
+    const state: { status: number; body: unknown } = { status: 0, body: undefined };
+    const res = {
+      status(code: number) {
+        state.status = code;
+        return res;
+      },
+      json(body: unknown) {
+        state.body = body;
+        return res;
+      },
+      setHeader() {},
+      state,
+    };
+    return res;
+  }
+
+  async function post(body: unknown) {
+    const res = createRes();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (muteUserPendingReviewHandler as any)(
+      { method: 'POST', query: {}, body, headers: {} },
+      res
+    );
+    return res.state;
+  }
+
+  beforeEach(() => {
+    seed();
+    vi.clearAllMocks();
+  });
+
+  it('mutes pending review and leaves mutedAt unset', async () => {
+    const { status, body } = await post({ userId: USER_ID, reason: REASON });
+
+    expect(status).toBe(200);
+    expect(body).toMatchObject({ userId: USER_ID, muted: true });
+    expect(store.users.get(USER_ID)).toMatchObject({ muted: true, mutedAt: null });
+  });
+
+  it('records the reason on the restriction the moderator reviews', async () => {
+    await post({ userId: USER_ID, reason: REASON, prompts: ['bad prompt'] });
+
+    expect(store.restrictions).toHaveLength(1);
+    expect(store.restrictions[0].triggers).toEqual([
+      expect.objectContaining({
+        prompt: 'bad prompt',
+        matchedWord: REASON,
+        source: 'orchestrator',
+      }),
+    ]);
+  });
+
+  it('attributes the mute to the system actor in ModActivity', async () => {
+    await post({ userId: USER_ID, reason: REASON });
+
+    expect(trackModActivity).toHaveBeenCalledWith(-1, {
+      entityType: 'user',
+      entityId: USER_ID,
+      activity: 'mutePendingReview',
+    });
+    expect(trackUserActivity).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'Muted', targetUserId: USER_ID })
+    );
+  });
+
+  it('tags the user write with a fixed, caller-independent updateSource', async () => {
+    await post({ userId: USER_ID, reason: REASON, source: 'anything-the-caller-likes' });
+
+    expect(userUpdateCounterInc).toHaveBeenCalledWith({
+      location: 'user.service:updateUserById:webhook:mutePendingReview',
+    });
+  });
+
+  it('rejects a payload with no reason and mutes nobody', async () => {
+    const { status } = await post({ userId: USER_ID });
+
+    expect(status).toBe(400);
+    expect(store.users.get(USER_ID)).toMatchObject({ muted: false });
+    expect(trackModActivity).not.toHaveBeenCalled();
+  });
+});
+
+describe('confirmed mute', () => {
+  beforeEach(() => {
+    seed();
+    vi.clearAllMocks();
+  });
+
+  it('writes mutedAt', async () => {
+    await setUserMuted({ userId: USER_ID, muted: true });
+
+    expect(store.users.get(USER_ID)?.mutedAt).toBeInstanceOf(Date);
+  });
+
+  it('is picked up by confirm-mutes, which cancels the subscription', async () => {
+    await setUserMuted({ userId: USER_ID, muted: true });
+
+    await runConfirmMutes();
+
+    expect(cancelSubscriptionPlan).toHaveBeenCalledWith({ userId: USER_ID });
+    expect(cancelSubscription).toHaveBeenCalledWith({ userId: USER_ID, atPeriodEnd: true });
+  });
+
+  // The two jobs above read through a hand-written stand-in for confirm-mutes'
+  // raw SQL. Pin the shape so the stand-in cannot silently diverge from it.
+  it('selects on muted AND a mutedAt newer than the last run', async () => {
+    await runConfirmMutes();
+
+    expect(lastQuery.sql.replace(/\s+/g, ' ')).toContain('WHERE "muted" AND "mutedAt" > ?');
+  });
+});

--- a/src/server/__tests__/pending-review-mute.test.ts
+++ b/src/server/__tests__/pending-review-mute.test.ts
@@ -234,8 +234,8 @@ function createRes() {
       state.body = body;
       return res;
     },
-    setHeader() {},
-    on() {},
+    setHeader: () => undefined,
+    on: () => undefined,
     state,
   };
   return res;

--- a/src/server/__tests__/pending-review-mute.test.ts
+++ b/src/server/__tests__/pending-review-mute.test.ts
@@ -3,26 +3,42 @@ import type * as NotificationService from '~/server/services/notification.servic
 import type * as SessionInvalidation from '~/server/auth/session-invalidation';
 import type * as ModeratorService from '~/server/services/moderator.service';
 import type * as PromClient from '~/server/prom/client';
+import type * as EmailTemplates from '~/server/email/templates';
+import type * as PromptAuditing from '~/server/services/orchestrator/promptAuditing';
 
-type UserRow = { id: number; isModerator: boolean; muted: boolean; mutedAt: Date | null };
+type UserRow = {
+  id: number;
+  isModerator: boolean;
+  muted: boolean;
+  mutedAt: Date | null;
+  bannedAt: Date | null;
+  deletedAt: Date | null;
+  email: string | null;
+  username: string;
+};
 type RestrictionRow = {
   id: number;
   userId: number;
   type: string;
   status: string;
   triggers: unknown;
+  createdAt: Date;
+  resolvedBy?: number;
+  resolvedMessage?: string;
 };
 
 const {
   store,
-  dbRead,
   dbWrite,
   cancelSubscription,
+  reinstateSubscription,
   cancelSubscriptionPlan,
+  resetProhibitedRequestCount,
   lastQuery,
   trackModActivity,
   trackUserActivity,
   userUpdateCounterInc,
+  refreshSession,
 } = vi.hoisted(() => {
   const store = {
     users: new Map<number, UserRow>(),
@@ -31,17 +47,15 @@ const {
   };
   const lastQuery = { sql: '' };
 
-  const dbRead = {
+  const findRestriction = (predicate: (r: RestrictionRow) => boolean) =>
+    [...store.restrictions].sort((a, b) => +b.createdAt - +a.createdAt).find(predicate) ?? null;
+
+  const dbWrite = {
     user: {
       findUnique: vi.fn(async ({ where }: { where: { id: number } }) => {
         const user = store.users.get(where.id);
         return user ? { ...user } : null;
       }),
-    },
-  };
-
-  const dbWrite = {
-    user: {
       findFirst: vi.fn(async () => null),
       update: vi.fn(
         async ({ where, data }: { where: { id: number }; data: Record<string, unknown> }) => {
@@ -54,22 +68,53 @@ const {
       ),
     },
     userRestriction: {
-      create: vi.fn(async ({ data }: { data: Omit<RestrictionRow, 'id' | 'status'> }) => {
-        const row: RestrictionRow = {
-          id: store.restrictions.length + 1,
-          status: 'Pending',
-          ...data,
+      create: vi.fn(
+        async ({ data }: { data: Omit<RestrictionRow, 'id' | 'status' | 'createdAt'> }) => {
+          const row: RestrictionRow = {
+            id: store.restrictions.length + 1,
+            status: 'Pending',
+            createdAt: new Date(),
+            ...data,
+          };
+          store.restrictions.push(row);
+          return { id: row.id };
+        }
+      ),
+      findFirst: vi.fn(
+        async ({ where }: { where: { userId: number; type: string; status: string } }) => {
+          const row = findRestriction(
+            (r) => r.userId === where.userId && r.type === where.type && r.status === where.status
+          );
+          return row ? { id: row.id } : null;
+        }
+      ),
+      findUnique: vi.fn(async ({ where }: { where: { id: number } }) => {
+        const row = store.restrictions.find((r) => r.id === where.id);
+        if (!row) return null;
+        const user = store.users.get(row.userId);
+        return {
+          id: row.id,
+          userId: row.userId,
+          status: row.status,
+          user: user ? { email: user.email, username: user.username } : null,
         };
-        store.restrictions.push(row);
-        return { id: row.id };
       }),
+      update: vi.fn(
+        async ({ where, data }: { where: { id: number }; data: Record<string, unknown> }) => {
+          const row = store.restrictions.find((r) => r.id === where.id);
+          if (!row) throw new Error(`no restriction ${where.id}`);
+          Object.assign(row, data);
+          return { ...row };
+        }
+      ),
     },
     keyValue: {
       findUnique: vi.fn(async () => ({ value: store.jobDate.getTime() })),
       upsert: vi.fn(async () => undefined),
     },
+    $transaction: vi.fn(async (ops: Promise<unknown>[]) => Promise.all(ops)),
     // confirm-mutes' only query. Mirrors `WHERE "muted" AND "mutedAt" > $lastRan`;
-    // the shape assertion below is what keeps this in step with the real SQL.
+    // the equality assertion below is what keeps this in step with the real SQL.
     $queryRaw: vi.fn(async (strings: TemplateStringsArray, lastRan: Date) => {
       lastQuery.sql = strings.join('?');
       return [...store.users.values()]
@@ -80,23 +125,25 @@ const {
 
   return {
     store,
-    dbRead,
     dbWrite,
     cancelSubscription: vi.fn(async () => undefined),
+    reinstateSubscription: vi.fn(async () => undefined),
     cancelSubscriptionPlan: vi.fn(async () => undefined),
+    resetProhibitedRequestCount: vi.fn(async () => undefined),
     lastQuery,
     trackModActivity: vi.fn(async () => undefined),
     trackUserActivity: vi.fn(async () => undefined),
     userUpdateCounterInc: vi.fn(),
+    refreshSession: vi.fn(async () => undefined),
   };
 });
 
-vi.mock('~/server/db/client', () => ({ dbRead, dbWrite, dbKV: dbWrite }));
-vi.mock('~/server/services/stripe.service', () => ({ cancelSubscription }));
+vi.mock('~/server/db/client', () => ({ dbRead: dbWrite, dbWrite, dbKV: dbWrite }));
+vi.mock('~/server/services/stripe.service', () => ({ cancelSubscription, reinstateSubscription }));
 vi.mock('~/server/services/paddle.service', () => ({ cancelSubscriptionPlan }));
 vi.mock('~/server/auth/session-invalidation', async (importOriginal) => ({
   ...(await importOriginal<typeof SessionInvalidation>()),
-  refreshSession: vi.fn(async () => undefined),
+  refreshSession,
   invalidateSession: vi.fn(async () => undefined),
 }));
 vi.mock('~/server/services/notification.service', async (importOriginal) => ({
@@ -111,10 +158,13 @@ vi.mock('~/server/prom/client', async (importOriginal) => ({
   ...(await importOriginal<typeof PromClient>()),
   userUpdateCounter: { inc: userUpdateCounterInc },
 }));
-// endpoint-helpers spreads `env.TRPC_ORIGINS` at module load, so an unmocked
-// import pulls the whole env + axiom chain into a unit test.
-vi.mock('~/server/utils/endpoint-helpers', () => ({
-  WebhookEndpoint: (handler: unknown) => handler,
+vi.mock('~/server/email/templates', async (importOriginal) => ({
+  ...(await importOriginal<typeof EmailTemplates>()),
+  moderationActionEmail: { send: vi.fn(async () => undefined) },
+}));
+vi.mock('~/server/services/orchestrator/promptAuditing', async (importOriginal) => ({
+  ...(await importOriginal<typeof PromptAuditing>()),
+  resetProhibitedRequestCount,
 }));
 vi.mock('~/server/clickhouse/client', () => ({
   Tracker: class {
@@ -122,23 +172,53 @@ vi.mock('~/server/clickhouse/client', () => ({
   },
 }));
 
-import muteUserPendingReviewHandler from '~/pages/api/mod/mute-user-pending-review';
+// `~/server/utils/endpoint-helpers` is deliberately NOT mocked. The token check
+// is the endpoint's only access control, so stubbing the wrapper out would make
+// deleting it a silent, green-passing change. The env defaults it needs at
+// module load live in src/__tests__/setup.ts.
+
+import muteHandler from '~/pages/api/mod/mute-user-pending-review';
+import overturnHandler from '~/pages/api/mod/overturn-user-mute';
 import { confirmMutes } from '~/server/jobs/confirm-mutes';
+import { constants } from '~/server/common/constants';
+import { env } from '~/env/server';
 import { setUserMuted } from '~/server/services/user.service';
 import {
   applyPendingReviewMute,
   buildManualMuteTriggers,
 } from '~/server/services/user-restriction.service';
+import { overturnPendingReviewMute } from '~/server/services/user-restriction-resolve.service';
 
 const USER_ID = 101;
 const MOD_ID = 102;
+const BANNED_ID = 103;
+const DELETED_ID = 104;
+const REASON = 'csam-block strike threshold';
+
+function makeUser(id: number, over: Partial<UserRow> = {}): UserRow {
+  return {
+    id,
+    isModerator: false,
+    muted: false,
+    mutedAt: null,
+    bannedAt: null,
+    deletedAt: null,
+    email: `u${id}@example.com`,
+    username: `user${id}`,
+    ...over,
+  };
+}
 
 function seed() {
   store.users.clear();
   store.restrictions.length = 0;
   store.jobDate = new Date(Date.now() - 60 * 60 * 1000);
-  store.users.set(USER_ID, { id: USER_ID, isModerator: false, muted: false, mutedAt: null });
-  store.users.set(MOD_ID, { id: MOD_ID, isModerator: true, muted: false, mutedAt: null });
+  store.users.set(USER_ID, makeUser(USER_ID));
+  store.users.set(MOD_ID, makeUser(MOD_ID, { isModerator: true }));
+  store.users.set(BANNED_ID, makeUser(BANNED_ID, { bannedAt: new Date() }));
+  store.users.set(DELETED_ID, makeUser(DELETED_ID, { deletedAt: new Date() }));
+  store.users.set(constants.system.officialUserId, makeUser(constants.system.officialUserId));
+  vi.clearAllMocks();
 }
 
 async function runConfirmMutes() {
@@ -146,20 +226,54 @@ async function runConfirmMutes() {
   await result;
 }
 
-const triggers = buildManualMuteTriggers({ reason: 'csam-block strike threshold', source: 'test' });
+function createRes() {
+  const state: { status: number; body: unknown } = { status: 0, body: undefined };
+  const res = {
+    status(code: number) {
+      state.status = code;
+      return res;
+    },
+    json(body: unknown) {
+      state.body = body;
+      return res;
+    },
+    setHeader() {},
+    on() {},
+    state,
+  };
+  return res;
+}
+
+type Handler = (req: unknown, res: unknown) => Promise<unknown>;
+
+// `token: null` means OMIT it. A `token?: string` default would silently send the
+// valid token for an explicit `undefined`, making the no-token test vacuous.
+async function call(
+  handler: unknown,
+  opts: { method?: string; token?: string | null; body?: unknown } = {}
+) {
+  const { method = 'POST', body = {} } = opts;
+  const token = 'token' in opts ? opts.token : env.WEBHOOK_TOKEN;
+  const res = createRes();
+  const query: Record<string, unknown> = {};
+  if (token !== null) query.token = token;
+  await (handler as Handler)(
+    { method, query, body, headers: {}, url: '/api/mod/test', socket: {} },
+    res
+  );
+  return res.state;
+}
+
+const triggers = buildManualMuteTriggers({ reason: REASON, source: 'test' });
 
 describe('pending-review mute', () => {
-  beforeEach(() => {
-    seed();
-    vi.clearAllMocks();
-  });
+  beforeEach(seed);
 
   it('mutes without writing mutedAt', async () => {
     await applyPendingReviewMute({ userId: USER_ID, triggers, updateSource: 'test' });
 
-    const [{ data }] = dbWrite.user.update.mock.calls.map(([arg]) => arg);
-    expect(data).toEqual({ muted: true });
-    expect(data).not.toHaveProperty('mutedAt');
+    const dataArgs = dbWrite.user.update.mock.calls.map(([arg]) => arg.data);
+    expect(dataArgs).toEqual([{ muted: true }]);
     expect(store.users.get(USER_ID)).toMatchObject({ muted: true, mutedAt: null });
   });
 
@@ -175,6 +289,13 @@ describe('pending-review mute', () => {
     expect(store.restrictions[0].triggers).toEqual(triggers);
   });
 
+  it('writes the mute and the restriction in one transaction', async () => {
+    await applyPendingReviewMute({ userId: USER_ID, triggers, updateSource: 'test' });
+
+    expect(dbWrite.$transaction).toHaveBeenCalledOnce();
+    expect(dbWrite.$transaction.mock.calls[0][0]).toHaveLength(2);
+  });
+
   it('is not picked up by confirm-mutes, so no subscription is cancelled', async () => {
     await applyPendingReviewMute({ userId: USER_ID, triggers, updateSource: 'test' });
 
@@ -184,60 +305,110 @@ describe('pending-review mute', () => {
     expect(cancelSubscriptionPlan).not.toHaveBeenCalled();
   });
 
-  it('skips moderators', async () => {
-    const result = await applyPendingReviewMute({ userId: MOD_ID, triggers, updateSource: 'test' });
+  it('is idempotent — a retry reuses the open restriction instead of filing another', async () => {
+    const first = await applyPendingReviewMute({ userId: USER_ID, triggers, updateSource: 'test' });
+    const second = await applyPendingReviewMute({
+      userId: USER_ID,
+      triggers,
+      updateSource: 'test',
+    });
 
-    expect(result).toEqual({ muted: false, skipped: 'moderator' });
+    expect(store.restrictions).toHaveLength(1);
+    expect(second).toEqual({
+      muted: true,
+      userRestrictionId: (first as { userRestrictionId: number }).userRestrictionId,
+      deduped: true,
+    });
+  });
+
+  it('repairs a Pending restriction left on an unmuted user', async () => {
+    store.restrictions.push({
+      id: 99,
+      userId: USER_ID,
+      type: 'generation',
+      status: 'Pending',
+      triggers: [],
+      createdAt: new Date(),
+    });
+
+    const result = await applyPendingReviewMute({
+      userId: USER_ID,
+      triggers,
+      updateSource: 'test',
+    });
+
+    expect(result).toEqual({ muted: true, userRestrictionId: 99, deduped: true });
+    expect(store.users.get(USER_ID)).toMatchObject({ muted: true, mutedAt: null });
+    expect(store.restrictions).toHaveLength(1);
+  });
+
+  it.each([
+    ['moderator', MOD_ID, 'moderator'],
+    ['banned user', BANNED_ID, 'banned'],
+    ['deleted user', DELETED_ID, 'deleted'],
+    ['the official brand account', constants.system.officialUserId, 'protected'],
+    ['the system actor', constants.system.user.id, 'protected'],
+  ])('refuses to mute a %s', async (_label, userId, skipped) => {
+    const result = await applyPendingReviewMute({ userId, triggers, updateSource: 'test' });
+
+    expect(result).toEqual({ muted: false, skipped });
     expect(store.restrictions).toHaveLength(0);
-    expect(store.users.get(MOD_ID)).toMatchObject({ muted: false, mutedAt: null });
+    expect(store.users.get(userId)?.muted ?? false).toBe(false);
+  });
+
+  it('still reports success when the session refresh fails', async () => {
+    refreshSession.mockRejectedValueOnce(new Error('redis down'));
+
+    const result = await applyPendingReviewMute({
+      userId: USER_ID,
+      triggers,
+      updateSource: 'test',
+    });
+
+    expect(result).toMatchObject({ muted: true });
+    expect(store.users.get(USER_ID)).toMatchObject({ muted: true });
   });
 });
 
 describe('POST /api/mod/mute-user-pending-review', () => {
-  const REASON = 'csam-block strike threshold';
+  beforeEach(seed);
 
-  function createRes() {
-    const state: { status: number; body: unknown } = { status: 0, body: undefined };
-    const res = {
-      status(code: number) {
-        state.status = code;
-        return res;
-      },
-      json(body: unknown) {
-        state.body = body;
-        return res;
-      },
-      setHeader() {},
-      state,
-    };
-    return res;
-  }
+  it.each([
+    ['no token', null],
+    ['a wrong token', 'not-the-webhook-token'],
+  ])('rejects a request with %s and mutes nobody', async (_label, token) => {
+    const { status } = await call(muteHandler, {
+      token,
+      body: { userId: USER_ID, reason: REASON },
+    });
 
-  async function post(body: unknown) {
-    const res = createRes();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await (muteUserPendingReviewHandler as any)(
-      { method: 'POST', query: {}, body, headers: {} },
-      res
-    );
-    return res.state;
-  }
+    expect(status).toBe(401);
+    expect(store.users.get(USER_ID)).toMatchObject({ muted: false });
+    expect(store.restrictions).toHaveLength(0);
+  });
 
-  beforeEach(() => {
-    seed();
-    vi.clearAllMocks();
+  it('rejects a GET even with a valid token, so the token cannot ride in a URL', async () => {
+    const { status } = await call(muteHandler, {
+      method: 'GET',
+      body: { userId: USER_ID, reason: REASON },
+    });
+
+    expect(status).toBe(405);
+    expect(store.users.get(USER_ID)).toMatchObject({ muted: false });
   });
 
   it('mutes pending review and leaves mutedAt unset', async () => {
-    const { status, body } = await post({ userId: USER_ID, reason: REASON });
+    const { status, body } = await call(muteHandler, { body: { userId: USER_ID, reason: REASON } });
 
     expect(status).toBe(200);
-    expect(body).toMatchObject({ userId: USER_ID, muted: true });
+    expect(body).toMatchObject({ userId: USER_ID, muted: true, deduped: false });
     expect(store.users.get(USER_ID)).toMatchObject({ muted: true, mutedAt: null });
   });
 
   it('records the reason on the restriction the moderator reviews', async () => {
-    await post({ userId: USER_ID, reason: REASON, prompts: ['bad prompt'] });
+    await call(muteHandler, {
+      body: { userId: USER_ID, reason: REASON, prompts: ['bad prompt'] },
+    });
 
     expect(store.restrictions).toHaveLength(1);
     expect(store.restrictions[0].triggers).toEqual([
@@ -249,8 +420,8 @@ describe('POST /api/mod/mute-user-pending-review', () => {
     ]);
   });
 
-  it('attributes the mute to the system actor in ModActivity', async () => {
-    await post({ userId: USER_ID, reason: REASON });
+  it('attributes the mute to the system actor', async () => {
+    await call(muteHandler, { body: { userId: USER_ID, reason: REASON } });
 
     expect(trackModActivity).toHaveBeenCalledWith(-1, {
       entityType: 'user',
@@ -262,16 +433,28 @@ describe('POST /api/mod/mute-user-pending-review', () => {
     );
   });
 
+  it('audits the mute even when the session refresh fails', async () => {
+    refreshSession.mockRejectedValueOnce(new Error('redis down'));
+
+    const { status } = await call(muteHandler, { body: { userId: USER_ID, reason: REASON } });
+
+    expect(status).toBe(200);
+    expect(trackModActivity).toHaveBeenCalledOnce();
+    expect(trackUserActivity).toHaveBeenCalledOnce();
+  });
+
   it('tags the user write with a fixed, caller-independent updateSource', async () => {
-    await post({ userId: USER_ID, reason: REASON, source: 'anything-the-caller-likes' });
+    await call(muteHandler, {
+      body: { userId: USER_ID, reason: REASON, source: 'anything-the-caller-likes' },
+    });
 
     expect(userUpdateCounterInc).toHaveBeenCalledWith({
-      location: 'user.service:updateUserById:webhook:mutePendingReview',
+      location: 'user-restriction.service:webhook:mutePendingReview',
     });
   });
 
   it('rejects a payload with no reason and mutes nobody', async () => {
-    const { status } = await post({ userId: USER_ID });
+    const { status } = await call(muteHandler, { body: { userId: USER_ID } });
 
     expect(status).toBe(400);
     expect(store.users.get(USER_ID)).toMatchObject({ muted: false });
@@ -279,11 +462,81 @@ describe('POST /api/mod/mute-user-pending-review', () => {
   });
 });
 
-describe('confirmed mute', () => {
-  beforeEach(() => {
-    seed();
-    vi.clearAllMocks();
+describe('POST /api/mod/overturn-user-mute', () => {
+  beforeEach(seed);
+
+  it.each([
+    ['no token', null],
+    ['a wrong token', 'not-the-webhook-token'],
+  ])('rejects a request with %s', async (_label, token) => {
+    await applyPendingReviewMute({ userId: USER_ID, triggers, updateSource: 'test' });
+
+    const { status } = await call(overturnHandler, {
+      token,
+      body: { userId: USER_ID, reason: 'mistake' },
+    });
+
+    expect(status).toBe(401);
+    expect(store.restrictions[0].status).toBe('Pending');
+    expect(store.users.get(USER_ID)).toMatchObject({ muted: true });
   });
+
+  it('rejects a GET even with a valid token', async () => {
+    const { status } = await call(overturnHandler, {
+      method: 'GET',
+      body: { userId: USER_ID, reason: 'mistake' },
+    });
+
+    expect(status).toBe(405);
+  });
+
+  it('unmutes and overturns the open restriction so the queue is cleared', async () => {
+    await applyPendingReviewMute({ userId: USER_ID, triggers, updateSource: 'test' });
+
+    const { status, body } = await call(overturnHandler, {
+      body: { userId: USER_ID, reason: 'mistake' },
+    });
+
+    expect(status).toBe(200);
+    expect(body).toMatchObject({ userId: USER_ID, unmuted: true });
+    expect(store.users.get(USER_ID)).toMatchObject({ muted: false });
+    expect(store.restrictions[0]).toMatchObject({ status: 'Overturned', resolvedBy: -1 });
+  });
+
+  it('reinstates the subscription and resets the violation count', async () => {
+    await applyPendingReviewMute({ userId: USER_ID, triggers, updateSource: 'test' });
+
+    await call(overturnHandler, { body: { userId: USER_ID, reason: 'mistake' } });
+
+    expect(reinstateSubscription).toHaveBeenCalledWith({ userId: USER_ID });
+    expect(resetProhibitedRequestCount).toHaveBeenCalledWith(USER_ID);
+  });
+
+  it('audits the overturn', async () => {
+    await applyPendingReviewMute({ userId: USER_ID, triggers, updateSource: 'test' });
+
+    await call(overturnHandler, { body: { userId: USER_ID, reason: 'mistake' } });
+
+    expect(trackModActivity).toHaveBeenCalledWith(-1, {
+      entityType: 'user',
+      entityId: USER_ID,
+      activity: 'overturnPendingReviewMute',
+    });
+    expect(trackUserActivity).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'Unmuted', targetUserId: USER_ID })
+    );
+  });
+
+  it('is a no-op when there is nothing open to overturn', async () => {
+    const result = await overturnPendingReviewMute({ userId: USER_ID, moderatorId: -1 });
+
+    expect(result).toEqual({ unmuted: false, skipped: 'no-pending-restriction' });
+    expect(reinstateSubscription).not.toHaveBeenCalled();
+  });
+});
+
+describe('confirmed mute', () => {
+  beforeEach(seed);
 
   it('writes mutedAt', async () => {
     await setUserMuted({ userId: USER_ID, muted: true });
@@ -300,11 +553,14 @@ describe('confirmed mute', () => {
     expect(cancelSubscription).toHaveBeenCalledWith({ userId: USER_ID, atPeriodEnd: true });
   });
 
-  // The two jobs above read through a hand-written stand-in for confirm-mutes'
-  // raw SQL. Pin the shape so the stand-in cannot silently diverge from it.
-  it('selects on muted AND a mutedAt newer than the last run', async () => {
+  // The confirm-mutes tests above read through a hand-written stand-in for the
+  // job's raw SQL. Pin the predicate EXACTLY: `toContain` would still pass if the
+  // job were widened to `OR "mutedAt" IS NULL`, which is the regression that
+  // would start cancelling pending-review-muted users' subscriptions.
+  it('selects on muted AND a mutedAt newer than the last run, and nothing else', async () => {
     await runConfirmMutes();
 
-    expect(lastQuery.sql.replace(/\s+/g, ' ')).toContain('WHERE "muted" AND "mutedAt" > ?');
+    const sql = lastQuery.sql.replace(/\s+/g, ' ').trim();
+    expect(sql).toBe('SELECT id FROM "User" WHERE "muted" AND "mutedAt" > ?');
   });
 });

--- a/src/server/__tests__/warmup.test.ts
+++ b/src/server/__tests__/warmup.test.ts
@@ -53,9 +53,8 @@ vi.mock('~/server/prom/client', () => {
   };
 });
 
-// env.NEXTAUTH_URL / env.WEBHOOK_TOKEN are read by warmup.ts. The global setup
-// proxy already supplies NEXTAUTH_URL='http://localhost:3000'; WEBHOOK_TOKEN
-// falls through to undefined which is fine for these tests.
+// env.NEXTAUTH_URL / env.WEBHOOK_TOKEN are read by warmup.ts; both come from the
+// defaults in src/__tests__/setup.ts.
 
 // Helper: a deferred promise that never resolves on its own — used to simulate a
 // hung fetch. We expose resolve so a test can release it if needed.

--- a/src/server/routers/user-restriction.router.ts
+++ b/src/server/routers/user-restriction.router.ts
@@ -1,4 +1,3 @@
-import { NotificationCategory } from '~/server/common/enums';
 import { clickhouse } from '~/server/clickhouse/client';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
@@ -14,17 +13,9 @@ import {
 } from '~/server/schema/user-restriction.schema';
 import type { BlockedPromptEntry } from '~/server/services/orchestrator/promptAuditing';
 import { debugAuditPrompt, type DebugAuditMatch } from '~/utils/metadata/audit';
-import { moderationActionEmail } from '~/server/email/templates';
-import { createNotification } from '~/server/services/notification.service';
-import {
-  bustPromptAllowlistCache,
-  resetProhibitedRequestCount,
-} from '~/server/services/orchestrator/promptAuditing';
-import { updateUserById } from '~/server/services/user.service';
-import { cancelSubscription, reinstateSubscription } from '~/server/services/stripe.service';
+import { bustPromptAllowlistCache } from '~/server/services/orchestrator/promptAuditing';
+import { resolveUserRestriction } from '~/server/services/user-restriction-resolve.service';
 import { moderatorProcedure, protectedProcedure, router } from '~/server/trpc';
-import { UserRestrictionStatus } from '~/shared/utils/prisma/enums';
-import { refreshSession } from '~/server/auth/session-invalidation';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const userRestrictionRouter = router({
@@ -96,115 +87,7 @@ export const userRestrictionRouter = router({
 
   /** Moderator resolves a restriction — uphold or overturn. */
   resolve: moderatorProcedure.input(resolveRestrictionSchema).mutation(async ({ ctx, input }) => {
-    const { userRestrictionId, status, resolvedMessage } = input;
-    const moderatorId = ctx.user.id;
-
-    const restriction = await dbRead.userRestriction.findUnique({
-      where: { id: userRestrictionId },
-      select: {
-        id: true,
-        userId: true,
-        status: true,
-        user: { select: { email: true, username: true } },
-      },
-    });
-
-    if (!restriction) throw new Error('Restriction record not found');
-    if (restriction.status !== UserRestrictionStatus.Pending)
-      throw new Error('Restriction has already been resolved');
-
-    await dbWrite.userRestriction.update({
-      where: { id: userRestrictionId },
-      data: {
-        status,
-        resolvedAt: new Date(),
-        resolvedBy: moderatorId,
-        resolvedMessage,
-      },
-    });
-
-    if (status === UserRestrictionStatus.Upheld) {
-      // Set mutedAt to confirm the restriction (moderator review)
-      await updateUserById({
-        id: restriction.userId,
-        data: { mutedAt: new Date() },
-        updateSource: 'moderator:generationRestrictionUpheld',
-      });
-      // Stop the recurring membership from auto-renewing for the restricted
-      // user. Cancel at period end (reversible) rather than waiting for the
-      // daily confirm-mutes safety-net job.
-      await cancelSubscription({ userId: restriction.userId, atPeriodEnd: true }).catch((error) =>
-        logToAxiom({
-          name: 'cancel-stripe-subscription-restriction-upheld',
-          type: 'error',
-          message: (error as Error).message,
-        })
-      );
-      await refreshSession(restriction.userId, { caller: 'moderation' });
-    } else if (status === UserRestrictionStatus.Overturned) {
-      // Unmute the user and reset their violation count
-      await updateUserById({
-        id: restriction.userId,
-        data: { muted: false },
-        updateSource: 'moderator:generationRestrictionOverturned',
-      });
-      // Reverse the at-period-end cancellation if the membership is still live.
-      await reinstateSubscription({ userId: restriction.userId }).catch((error) =>
-        logToAxiom({
-          name: 'reinstate-stripe-subscription-restriction-overturned',
-          type: 'error',
-          message: (error as Error).message,
-        })
-      );
-      await resetProhibitedRequestCount(restriction.userId);
-      await refreshSession(restriction.userId, { caller: 'moderation' });
-    }
-
-    // Send notification to the user
-    const notifType =
-      status === UserRestrictionStatus.Upheld
-        ? 'generation-restriction-upheld'
-        : 'generation-restriction-overturned';
-
-    await createNotification({
-      type: notifType,
-      key: `${notifType}:${restriction.userId}:${userRestrictionId}`,
-      category: NotificationCategory.System,
-      userId: restriction.userId,
-      details: { resolvedMessage: resolvedMessage ?? '' },
-    }).catch();
-
-    // Send transactional email mirroring the in-app notification
-    try {
-      if (restriction.user?.email) {
-        // Intentionally omit `resolvedMessage` from the email — moderator
-        // free-text is shown only in-app (notification above), never emailed,
-        // to avoid exposing potentially explicit/targeted prose. The TOS link
-        // in the email template provides the policy reference for upheld cases.
-        await moderationActionEmail.send({
-          to: restriction.user.email,
-          username: restriction.user.username ?? 'User',
-          kind:
-            status === UserRestrictionStatus.Upheld
-              ? 'restriction-upheld'
-              : 'restriction-overturned',
-        });
-      }
-    } catch (error) {
-      logToAxiom({
-        type: 'error',
-        name: 'restriction-email-failed',
-        message: (error as Error).message,
-        error,
-      });
-    }
-
-    logToAxiom({
-      name: 'user-restriction-resolved',
-      type: 'info',
-      details: { userRestrictionId, status, moderatorId, userId: restriction.userId },
-    });
-
+    await resolveUserRestriction({ ...input, moderatorId: ctx.user.id });
     return { success: true };
   }),
 

--- a/src/server/services/moderator.service.ts
+++ b/src/server/services/moderator.service.ts
@@ -47,7 +47,12 @@ type ImpersonateModActivity = {
 
 type UserModActivity = {
   entityType: 'user';
-  activity: 'setRewardsEligibility' | 'removeContent' | 'autoMuteScam' | 'mutePendingReview';
+  activity:
+    | 'setRewardsEligibility'
+    | 'removeContent'
+    | 'autoMuteScam'
+    | 'mutePendingReview'
+    | 'overturnPendingReviewMute';
 };
 
 type ComicProjectModActivity = {

--- a/src/server/services/moderator.service.ts
+++ b/src/server/services/moderator.service.ts
@@ -47,7 +47,7 @@ type ImpersonateModActivity = {
 
 type UserModActivity = {
   entityType: 'user';
-  activity: 'setRewardsEligibility' | 'removeContent' | 'autoMuteScam';
+  activity: 'setRewardsEligibility' | 'removeContent' | 'autoMuteScam' | 'mutePendingReview';
 };
 
 type ComicProjectModActivity = {

--- a/src/server/services/orchestrator/__tests__/promptAuditing.sysredis-soft.test.ts
+++ b/src/server/services/orchestrator/__tests__/promptAuditing.sysredis-soft.test.ts
@@ -149,7 +149,7 @@ describe('auditPromptServer → addBlockedPrompt — sysRedis reads (fail-CLOSED
 describe('auditPromptServer → reportProhibitedRequest → getBlockedPrompts (mute path, fail-CAUGHT)', () => {
   // Drive count > muted (constants.imageGeneration.requestBlocking.muted = 8) so
   // reportProhibitedRequest enters the auto-mute branch and calls getBlockedPrompts.
-  // The downstream dbWrite.userRestriction.create throws (dbWrite is mocked {}),
+  // The downstream applyPendingReviewMute throws (dbWrite is mocked {}),
   // absorbed by the existing `catch (banError)` — so no heavy mute-path scaffolding
   // is needed. Unlike addBlockedPrompt (fail-PROPAGATED), a sysRedis error in
   // getBlockedPrompts is fail-CAUGHT: the auto-mute is skipped, and the current

--- a/src/server/services/orchestrator/promptAuditing.ts
+++ b/src/server/services/orchestrator/promptAuditing.ts
@@ -1,13 +1,12 @@
 import { CacheTTL, constants } from '~/server/common/constants';
-import { BlocklistType, NotificationCategory } from '~/server/common/enums';
-import { dbRead, dbWrite } from '~/server/db/client';
+import { BlocklistType } from '~/server/common/enums';
+import { dbRead } from '~/server/db/client';
 import { extModeration } from '~/server/integrations/moderation';
 import { logToAxiom } from '~/server/logging/client';
 import { REDIS_KEYS, REDIS_SYS_KEYS, sysRedis, withSysReadDeadline } from '~/server/redis/client';
 import { decodeRedisString } from '~/server/redis/buffer-decode';
 import { stripBenignPhrases } from '~/server/services/blocklist.service';
-import { createNotification } from '~/server/services/notification.service';
-import { updateUserById } from '~/server/services/user.service';
+import { applyPendingReviewMute } from '~/server/services/user-restriction.service';
 import { fetchThroughCache, bustFetchThroughCache } from '~/server/utils/cache-helpers';
 import { throwBadRequestError } from '~/server/utils/errorHandling';
 import {
@@ -16,7 +15,6 @@ import {
   type PromptTrigger,
   type PromptTriggerCategory,
 } from '~/utils/metadata/audit';
-import { refreshSession } from '~/server/auth/session-invalidation';
 
 // --- Blocked Prompt Store ---
 // Single Redis list stores both count (list length) and prompt data.
@@ -511,41 +509,16 @@ async function reportProhibitedRequest(options: {
   // Auto-mute when count exceeds the muted threshold
   if (count > constants.imageGeneration.requestBlocking.muted) {
     try {
-      // Retrieve all blocked prompts from Redis for the UserRestriction record
       const allBlockedPrompts = await getBlockedPrompts(userId);
 
-      // Create a UserRestriction record with ALL trigger data for moderator review
-      await dbWrite.userRestriction.create({
-        data: {
-          userId,
-          type: 'generation',
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          triggers: allBlockedPrompts as any,
-        },
-      });
-
-      // Only gate the user via `muted`. `mutedAt` is reserved for moderator
-      // confirmation (uphold) — setting it here would make a Pending restriction
-      // display as "Upheld" and trip the confirm-mutes cron.
-      await updateUserById({
-        id: userId,
-        data: { muted: true },
+      await applyPendingReviewMute({
+        userId,
+        triggers: allBlockedPrompts,
         updateSource: 'promptAuditing:autoMute',
       });
 
-      await refreshSession(userId, { caller: 'moderation' });
-
       // Clear the blocked prompts from Redis now that they're stored in the DB
       await clearBlockedPromptsAfterMute(userId);
-
-      // Notify the user about the restriction
-      await createNotification({
-        type: 'generation-muted',
-        key: `generation-muted:${userId}:${Date.now()}`,
-        category: NotificationCategory.System,
-        userId,
-        details: {},
-      }).catch();
     } catch (banError) {
       logToAxiom({
         name: 'user-ban-creation-error',

--- a/src/server/services/user-restriction-resolve.service.ts
+++ b/src/server/services/user-restriction-resolve.service.ts
@@ -1,0 +1,155 @@
+import { refreshSession } from '~/server/auth/session-invalidation';
+import { NotificationCategory } from '~/server/common/enums';
+import { dbWrite } from '~/server/db/client';
+import { moderationActionEmail } from '~/server/email/templates';
+import { logToAxiom } from '~/server/logging/client';
+import { createNotification } from '~/server/services/notification.service';
+import { resetProhibitedRequestCount } from '~/server/services/orchestrator/promptAuditing';
+import { cancelSubscription, reinstateSubscription } from '~/server/services/stripe.service';
+import { updateUserById } from '~/server/services/user.service';
+import { UserRestrictionStatus } from '~/shared/utils/prisma/enums';
+
+/**
+ * Uphold or overturn a generation restriction. The single write path for a
+ * verdict — the moderator router and the service-facing overturn endpoint both
+ * go through here so the membership and violation-count side effects can't drift.
+ */
+export async function resolveUserRestriction({
+  userRestrictionId,
+  status,
+  resolvedMessage,
+  moderatorId,
+}: {
+  userRestrictionId: number;
+  status: UserRestrictionStatus;
+  resolvedMessage?: string;
+  moderatorId: number;
+}) {
+  const restriction = await dbWrite.userRestriction.findUnique({
+    where: { id: userRestrictionId },
+    select: {
+      id: true,
+      userId: true,
+      status: true,
+      user: { select: { email: true, username: true } },
+    },
+  });
+
+  if (!restriction) throw new Error('Restriction record not found');
+  if (restriction.status !== UserRestrictionStatus.Pending)
+    throw new Error('Restriction has already been resolved');
+
+  await dbWrite.userRestriction.update({
+    where: { id: userRestrictionId },
+    data: { status, resolvedAt: new Date(), resolvedBy: moderatorId, resolvedMessage },
+  });
+
+  if (status === UserRestrictionStatus.Upheld) {
+    await updateUserById({
+      id: restriction.userId,
+      data: { mutedAt: new Date() },
+      updateSource: 'moderator:generationRestrictionUpheld',
+    });
+    // Cancel at period end (reversible) rather than waiting for the daily
+    // confirm-mutes safety-net job.
+    await cancelSubscription({ userId: restriction.userId, atPeriodEnd: true }).catch((error) =>
+      logToAxiom({
+        name: 'cancel-stripe-subscription-restriction-upheld',
+        type: 'error',
+        message: (error as Error).message,
+      })
+    );
+    await refreshSession(restriction.userId, { caller: 'moderation' });
+  } else if (status === UserRestrictionStatus.Overturned) {
+    await updateUserById({
+      id: restriction.userId,
+      data: { muted: false },
+      updateSource: 'moderator:generationRestrictionOverturned',
+    });
+    await reinstateSubscription({ userId: restriction.userId }).catch((error) =>
+      logToAxiom({
+        name: 'reinstate-stripe-subscription-restriction-overturned',
+        type: 'error',
+        message: (error as Error).message,
+      })
+    );
+    await resetProhibitedRequestCount(restriction.userId);
+    await refreshSession(restriction.userId, { caller: 'moderation' });
+  }
+
+  const notifType =
+    status === UserRestrictionStatus.Upheld
+      ? 'generation-restriction-upheld'
+      : 'generation-restriction-overturned';
+
+  await createNotification({
+    type: notifType,
+    key: `${notifType}:${restriction.userId}:${userRestrictionId}`,
+    category: NotificationCategory.System,
+    userId: restriction.userId,
+    details: { resolvedMessage: resolvedMessage ?? '' },
+  }).catch();
+
+  try {
+    if (restriction.user?.email) {
+      // Moderator free-text is shown only in-app, never emailed, to avoid
+      // forwarding potentially explicit or targeted prose.
+      await moderationActionEmail.send({
+        to: restriction.user.email,
+        username: restriction.user.username ?? 'User',
+        kind:
+          status === UserRestrictionStatus.Upheld ? 'restriction-upheld' : 'restriction-overturned',
+      });
+    }
+  } catch (error) {
+    logToAxiom({
+      type: 'error',
+      name: 'restriction-email-failed',
+      message: (error as Error).message,
+      error,
+    });
+  }
+
+  logToAxiom({
+    name: 'user-restriction-resolved',
+    type: 'info',
+    details: { userRestrictionId, status, moderatorId, userId: restriction.userId },
+  });
+
+  return { userId: restriction.userId };
+}
+
+export type OverturnPendingReviewMuteResult =
+  | { unmuted: true; userRestrictionId: number }
+  | { unmuted: false; skipped: 'no-pending-restriction' };
+
+/**
+ * Service-facing "they shouldn't have been muted": overturns the user's open
+ * generation restriction so the review queue doesn't keep a stale Pending row,
+ * and picks up the reinstate-subscription and violation-count reset with it.
+ */
+export async function overturnPendingReviewMute({
+  userId,
+  resolvedMessage,
+  moderatorId,
+}: {
+  userId: number;
+  resolvedMessage?: string;
+  moderatorId: number;
+}): Promise<OverturnPendingReviewMuteResult> {
+  const restriction = await dbWrite.userRestriction.findFirst({
+    where: { userId, type: 'generation', status: UserRestrictionStatus.Pending },
+    orderBy: { createdAt: 'desc' },
+    select: { id: true },
+  });
+  if (!restriction) return { unmuted: false, skipped: 'no-pending-restriction' };
+
+  await resolveUserRestriction({
+    userRestrictionId: restriction.id,
+    status: UserRestrictionStatus.Overturned,
+    resolvedMessage,
+    moderatorId,
+  });
+
+  return { unmuted: true, userRestrictionId: restriction.id };
+}

--- a/src/server/services/user-restriction-resolve.service.ts
+++ b/src/server/services/user-restriction-resolve.service.ts
@@ -7,6 +7,7 @@ import { createNotification } from '~/server/services/notification.service';
 import { resetProhibitedRequestCount } from '~/server/services/orchestrator/promptAuditing';
 import { cancelSubscription, reinstateSubscription } from '~/server/services/stripe.service';
 import { updateUserById } from '~/server/services/user.service';
+import { PROTECTED_USER_IDS } from '~/server/services/user-restriction.service';
 import { UserRestrictionStatus } from '~/shared/utils/prisma/enums';
 
 /**
@@ -88,7 +89,13 @@ export async function resolveUserRestriction({
     category: NotificationCategory.System,
     userId: restriction.userId,
     details: { resolvedMessage: resolvedMessage ?? '' },
-  }).catch();
+  }).catch((error) =>
+    logToAxiom({
+      name: 'restriction-resolved-notify-failed',
+      type: 'error',
+      message: (error as Error).message,
+    })
+  );
 
   try {
     if (restriction.user?.email) {
@@ -121,7 +128,10 @@ export async function resolveUserRestriction({
 
 export type OverturnPendingReviewMuteResult =
   | { unmuted: true; userRestrictionId: number }
-  | { unmuted: false; skipped: 'no-pending-restriction' };
+  | {
+      unmuted: false;
+      skipped: 'protected' | 'moderator' | 'manually-muted' | 'no-pending-restriction';
+    };
 
 /**
  * Service-facing "they shouldn't have been muted": overturns the user's open
@@ -137,6 +147,18 @@ export async function overturnPendingReviewMute({
   resolvedMessage?: string;
   moderatorId: number;
 }): Promise<OverturnPendingReviewMuteResult> {
+  if (PROTECTED_USER_IDS.has(userId)) return { unmuted: false, skipped: 'protected' };
+
+  const user = await dbWrite.user.findUnique({
+    where: { id: userId },
+    select: { isModerator: true, mutedAt: true },
+  });
+  if (!user) throw new Error(`No user with id ${userId}`);
+  if (user.isModerator) return { unmuted: false, skipped: 'moderator' };
+  // Only a moderator's verdict writes `mutedAt`, so a non-null value is a human
+  // decision that no service caller may reverse.
+  if (user.mutedAt) return { unmuted: false, skipped: 'manually-muted' };
+
   const restriction = await dbWrite.userRestriction.findFirst({
     where: { userId, type: 'generation', status: UserRestrictionStatus.Pending },
     orderBy: { createdAt: 'desc' },

--- a/src/server/services/user-restriction.service.ts
+++ b/src/server/services/user-restriction.service.ts
@@ -11,7 +11,7 @@ import { userUpdateCounter } from '~/server/prom/client';
 import { createNotification } from '~/server/services/notification.service';
 import { UserRestrictionStatus } from '~/shared/utils/prisma/enums';
 
-const PROTECTED_USER_IDS = new Set<number>([
+export const PROTECTED_USER_IDS = new Set<number>([
   constants.system.user.id,
   constants.system.officialUserId,
 ]);
@@ -35,9 +35,6 @@ async function bestEffort(name: string, userId: number, fn: () => Promise<unknow
  * `mutedAt` is deliberately not written. It marks a moderator's uphold, and
  * `confirm-mutes` cancels the user's memberships off a recent non-null value —
  * so setting it here would bill-punish an unreviewed account.
- *
- * Resolving means the mute landed; the session refresh and notification after it
- * are best-effort, so a caller that gets a result can always trust it and audit it.
  */
 export async function applyPendingReviewMute({
   userId,

--- a/src/server/services/user-restriction.service.ts
+++ b/src/server/services/user-restriction.service.ts
@@ -1,12 +1,32 @@
+// Keep this module's import graph light. `promptAuditing` imports it on the
+// generation hot path, and pulling stripe/email in here made three of its
+// suites fail to collect. Verdict handling lives in
+// `user-restriction-resolve.service.ts` for that reason.
 import { refreshSession } from '~/server/auth/session-invalidation';
+import { constants } from '~/server/common/constants';
 import { NotificationCategory } from '~/server/common/enums';
-import { dbRead, dbWrite } from '~/server/db/client';
+import { dbWrite } from '~/server/db/client';
+import { logToAxiom } from '~/server/logging/client';
+import { userUpdateCounter } from '~/server/prom/client';
 import { createNotification } from '~/server/services/notification.service';
-import { updateUserById } from '~/server/services/user.service';
+import { UserRestrictionStatus } from '~/shared/utils/prisma/enums';
+
+const PROTECTED_USER_IDS = new Set<number>([
+  constants.system.user.id,
+  constants.system.officialUserId,
+]);
 
 export type PendingReviewMuteResult =
-  | { muted: true; userRestrictionId: number }
-  | { muted: false; skipped: 'moderator' };
+  | { muted: true; userRestrictionId: number; deduped: boolean }
+  | { muted: false; skipped: 'protected' | 'moderator' | 'banned' | 'deleted' };
+
+async function bestEffort(name: string, userId: number, fn: () => Promise<unknown>) {
+  try {
+    await fn();
+  } catch (e) {
+    logToAxiom({ type: 'error', name, message: (e as Error).message, details: { userId } });
+  }
+}
 
 /**
  * Mute a user *pending moderator review*: the account is paused and the case is
@@ -15,6 +35,9 @@ export type PendingReviewMuteResult =
  * `mutedAt` is deliberately not written. It marks a moderator's uphold, and
  * `confirm-mutes` cancels the user's memberships off a recent non-null value —
  * so setting it here would bill-punish an unreviewed account.
+ *
+ * Resolving means the mute landed; the session refresh and notification after it
+ * are best-effort, so a caller that gets a result can always trust it and audit it.
  */
 export async function applyPendingReviewMute({
   userId,
@@ -25,36 +48,66 @@ export async function applyPendingReviewMute({
   triggers: unknown[];
   updateSource: string;
 }): Promise<PendingReviewMuteResult> {
-  const user = await dbRead.user.findUnique({
+  if (PROTECTED_USER_IDS.has(userId)) return { muted: false, skipped: 'protected' };
+
+  // Primary, not the replica: this is a security gate, and replica lag would let
+  // a just-promoted moderator or a just-banned account through the wrong branch.
+  const user = await dbWrite.user.findUnique({
     where: { id: userId },
-    select: { isModerator: true },
+    select: { isModerator: true, muted: true, bannedAt: true, deletedAt: true },
   });
   if (!user) throw new Error(`No user with id ${userId}`);
   if (user.isModerator) return { muted: false, skipped: 'moderator' };
+  if (user.deletedAt) return { muted: false, skipped: 'deleted' };
+  if (user.bannedAt) return { muted: false, skipped: 'banned' };
 
-  const restriction = await dbWrite.userRestriction.create({
-    data: {
-      userId,
-      type: 'generation',
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      triggers: triggers as any,
-    },
+  const existing = await dbWrite.userRestriction.findFirst({
+    where: { userId, type: 'generation', status: UserRestrictionStatus.Pending },
+    orderBy: { createdAt: 'desc' },
     select: { id: true },
   });
 
-  await updateUserById({ id: userId, data: { muted: true }, updateSource });
+  let userRestrictionId: number;
+  const deduped = !!existing;
 
-  await refreshSession(userId, { caller: 'moderation' });
+  if (existing) {
+    userRestrictionId = existing.id;
+    // Repairs the one state a Pending row must never be left in: queued against
+    // an unmuted account, where an uphold sets `mutedAt` without `muted` and the
+    // user keeps generating while confirm-mutes acts on them.
+    if (!user.muted) await dbWrite.user.update({ where: { id: userId }, data: { muted: true } });
+  } else {
+    const [, restriction] = await dbWrite.$transaction([
+      dbWrite.user.update({ where: { id: userId }, data: { muted: true } }),
+      dbWrite.userRestriction.create({
+        data: {
+          userId,
+          type: 'generation',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          triggers: triggers as any,
+        },
+        select: { id: true },
+      }),
+    ]);
+    userRestrictionId = restriction.id;
+  }
 
-  await createNotification({
-    type: 'generation-muted',
-    key: `generation-muted:${userId}:${Date.now()}`,
-    category: NotificationCategory.System,
-    userId,
-    details: {},
-  }).catch();
+  userUpdateCounter?.inc({ location: `user-restriction.service:${updateSource}` });
 
-  return { muted: true, userRestrictionId: restriction.id };
+  await bestEffort('pending-review-mute-refresh-session-failed', userId, () =>
+    refreshSession(userId, { caller: 'moderation' })
+  );
+  await bestEffort('pending-review-mute-notify-failed', userId, () =>
+    createNotification({
+      type: 'generation-muted',
+      key: `generation-muted:${userId}:${userRestrictionId}`,
+      category: NotificationCategory.System,
+      userId,
+      details: {},
+    })
+  );
+
+  return { muted: true, userRestrictionId, deduped };
 }
 
 /**

--- a/src/server/services/user-restriction.service.ts
+++ b/src/server/services/user-restriction.service.ts
@@ -1,0 +1,83 @@
+import { refreshSession } from '~/server/auth/session-invalidation';
+import { NotificationCategory } from '~/server/common/enums';
+import { dbRead, dbWrite } from '~/server/db/client';
+import { createNotification } from '~/server/services/notification.service';
+import { updateUserById } from '~/server/services/user.service';
+
+export type PendingReviewMuteResult =
+  | { muted: true; userRestrictionId: number }
+  | { muted: false; skipped: 'moderator' };
+
+/**
+ * Mute a user *pending moderator review*: the account is paused and the case is
+ * queued, but no verdict has been reached.
+ *
+ * `mutedAt` is deliberately not written. It marks a moderator's uphold, and
+ * `confirm-mutes` cancels the user's memberships off a recent non-null value —
+ * so setting it here would bill-punish an unreviewed account.
+ */
+export async function applyPendingReviewMute({
+  userId,
+  triggers,
+  updateSource,
+}: {
+  userId: number;
+  triggers: unknown[];
+  updateSource: string;
+}): Promise<PendingReviewMuteResult> {
+  const user = await dbRead.user.findUnique({
+    where: { id: userId },
+    select: { isModerator: true },
+  });
+  if (!user) throw new Error(`No user with id ${userId}`);
+  if (user.isModerator) return { muted: false, skipped: 'moderator' };
+
+  const restriction = await dbWrite.userRestriction.create({
+    data: {
+      userId,
+      type: 'generation',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      triggers: triggers as any,
+    },
+    select: { id: true },
+  });
+
+  await updateUserById({ id: userId, data: { muted: true }, updateSource });
+
+  await refreshSession(userId, { caller: 'moderation' });
+
+  await createNotification({
+    type: 'generation-muted',
+    key: `generation-muted:${userId}:${Date.now()}`,
+    category: NotificationCategory.System,
+    userId,
+    details: {},
+  }).catch();
+
+  return { muted: true, userRestrictionId: restriction.id };
+}
+
+/**
+ * Shapes a free-text reason into the trigger entries the moderator review UI
+ * renders, so a mute raised by a service or by hand isn't reviewed blind.
+ */
+export function buildManualMuteTriggers({
+  reason,
+  source,
+  prompts,
+}: {
+  reason: string;
+  source: string;
+  prompts?: string[];
+}) {
+  const time = new Date().toISOString();
+  return (prompts?.length ? prompts : [reason]).map((prompt) => ({
+    prompt,
+    negativePrompt: '',
+    source,
+    matchedWord: reason,
+    imageId: null,
+    remixOfId: null,
+    time,
+  }));
+}


### PR DESCRIPTION
## Problem

The Orchestrator will call us to mute a user when they hit a CSAM-block strike threshold. That mute must **pause** the account for review — it is not a verdict.

The only exposed mute today is wrong for it. `retool/user`'s `mute` action calls `setUserMuted`, which writes both `muted` **and** `mutedAt`. `confirm-mutes` selects `WHERE "muted" AND "mutedAt" > lastRan` and cancels the user's Stripe and Paddle subscriptions. Wiring the Orchestrator to it would cancel a paying customer's membership within 24h with no moderator involved. A bare `muted` flag with no `UserRestriction` row is also invisible to the review queue, which reads `UserRestriction` rows with status `Pending`.

The correctly-shaped mute already existed, but inline and module-private inside `reportProhibitedRequest`.

## What this does

**Extracts** that sequence into `applyPendingReviewMute` (`src/server/services/user-restriction.service.ts`): file a Pending `UserRestriction{type:'generation'}` with the triggers, set **only** `muted`, refresh the session, notify. `promptAuditing.ts` now calls it instead of duplicating it.

**Exposes two service endpoints**, both guarded by `WebhookEndpoint` — the same wrapper as `/api/mod/ban-user`, the existing precedent for a service-driven moderation action:

| Endpoint | Does |
|---|---|
| `POST /api/mod/mute-user-pending-review` | Pauses the account, files a Pending restriction carrying the caller's reason |
| `POST /api/mod/overturn-user-mute` | "They shouldn't have been muted" — **overturns** the open restriction rather than just clearing `muted`, so the queue keeps no stale Pending row and the subscription reinstate + violation-count reset come with it |

Why webhooks rather than Retool actions: the Retool wrapper's only gate is `isModerator`, so a bot key for these two capabilities would also unlock every other Retool domain (profile clears, force-logout, comment bulk-delete, cosmetic grants, home blocks). Its per-actor `60/60s` limit is also a single bucket for one bot identity, so a strike burst would 429 and silently drop mutes.

The verdict path is **extracted and shared**, not duplicated: `resolveUserRestriction` moves out of `user-restriction.router.ts` into `user-restriction-resolve.service.ts`, and the tRPC `resolve` mutation and the overturn endpoint both call it. That is a separate module from `user-restriction.service.ts` deliberately — `promptAuditing` imports the latter on the generation path, and co-locating the stripe and email imports made three of its suites fail to collect.

**Purely additive on existing surfaces.** `mute`, `unmute` and `setUserMuted` are untouched; nothing an existing Retool panel calls changes behaviour or starts returning 400.

## Safety properties

- **One transaction.** The `muted` write and the restriction `create` go in a single `$transaction`, so neither of the half-applied states is reachable. The dangerous one was a Pending row on an *unmuted* user: upholding it sets `mutedAt` without `muted`, so the user keeps generating **and** `confirm-mutes` cancels their subscription.
- **Idempotent.** A retry finds the open Pending restriction and reuses it (`deduped: true`) rather than filing a second row — `UserRestriction` has only non-unique indexes. If it finds one on an unmuted user it repairs the mute instead of duplicating. Two genuinely concurrent calls can still race to create two rows; that needs a partial unique index and is not attempted here.
- **Refuses** the system actor, the official brand account, moderators, and already-banned or deleted users. The gate reads the primary, not the replica, because replica lag decides the wrong branch for a just-promoted moderator or just-banned account.
- **POST only**, so the token cannot ride in a URL into access and proxy logs.
- **The audit rows are written straight after the atomic write**, and the session refresh and notification are best-effort. A late failure can no longer leave a muted user with no audit trail.

## Audit trail

| Where | What it records |
|---|---|
| `userActivities` (ClickHouse) | **The per-incident record.** `type='Muted'` / `'Unmuted'`, `targetUserId`, `source` carrying the caller and its reason |
| `UserRestriction.triggers` | The reason and any offending prompts — what the moderator actually reads on review |
| `ModActivity` (Postgres) | `userId=-1` (system actor, matching `entity-moderation.ts` and `ban-user.ts`), `activity='mutePendingReview'` / `'overturnPendingReviewMute'` |

⚠️ **Correction to an earlier version of this description.** `ModActivity` still carries `@@unique([activity, entityType, entityId])` and `trackModActivity` inserts `ON CONFLICT DO NOTHING`, so it records only the **first** mute of a given user under a given activity — a re-offender leaves no new Postgres row, and the surviving row's `createdAt` points at the first incident. Making it per-incident needs the migration that drops that index (already anticipated in `moderator.service.ts`'s own comment) and is not attempted here. The ClickHouse row is the per-incident record; treat `ModActivity` as "this has happened at least once".

`updateSource` is **not** attribution either — it only labels a Prometheus counter, with no user id, actor, or timestamp. A distinct fixed value is set for metrics, and deliberately not derived from the caller-supplied `source`, which would let a caller blow up label cardinality.

The auto-mute path in `promptAuditing` still writes no `ModActivity` row. Unchanged by this PR, not fixed by it.

## Tests

`src/server/__tests__/pending-review-mute.test.ts`, 31 tests. Every one was checked by reverting the thing it protects and reading what it prints:

| Mutation | Output |
|---|---|
| **strip `WebhookEndpoint(...)` off the export** | 2 failures, `expected 200 to be 401` |
| service writes `mutedAt` again | `expected [ { muted: true, mutedAt: … } ] to deeply equal [ { muted: true } ]`, plus the confirm-mutes cancel spy firing |
| `setUserMuted` stops writing `mutedAt` | `expected null to be an instance of Date` |
| widen confirm-mutes to `OR "mutedAt" IS NULL` | `expected 'SELECT id … OR "mutedAt" IS NULL)' to be 'SELECT id … "mutedAt" > ?'` |
| `ModActivity` activity value changed | `expected "vi.fn()" to be called with arguments: [ -1, { entityType: 'user', …(2) } ]` |
| `updateSource` changed | assertion on the counter label |

All fail in under 50ms. The endpoints are exercised **through the real `WebhookEndpoint` wrapper** — `endpoint-helpers` is not mocked. The env defaults that made stubbing it seem necessary (`TRPC_ORIGINS`, and non-empty tokens so an omitted `?token=` genuinely fails rather than matching `undefined !== undefined`) now live in `src/__tests__/setup.ts`, so the next webhook test doesn't have to stub its own auth away either.

Two honest limits on the fakes: the transaction is pinned **structurally** (`$transaction` called once with both ops) rather than by simulating rollback, since Prisma owns the atomicity; and the confirm-mutes tests read through a hand-written stand-in for the job's raw SQL, which is why the predicate is pinned by equality.

While writing the auth tests, the first version of the "no token" case was itself vacuous — a `token = env.WEBHOOK_TOKEN` default parameter meant passing `undefined` sent the *valid* token. It only surfaced because the real wrapper was in the path. The helper now uses an explicit `null` sentinel.

## Verification

Run in a worktree with `node_modules` junctioned from the primary checkout, so environment caveats are listed rather than glossed.

- `pnpm test:unit:run` — **7 failed files / 16 failed tests / 13836 passed** against **7 / 16 / 13817** on the same base without this diff: the identical failure set, plus this PR's tests. The 16 are Windows-only (drift guards that shell out to `grep` → `spawnSync grep ENOENT`, and one path-resolution case in `no-wholesale-module-mock`). `blocks.router.workflow.test.ts` collected **347** tests, so the run is valid.
  - That comparison earned its keep: an intermediate version of this change quietly took **three `promptAuditing` suites from passing to zero-collected** by widening that module's import graph. The fix was to split the module, not to widen the mocks.
- `pnpm typecheck` — **35 errors with the change, 35 without it**, none in the changed files. They are `creator-shop.service.ts` against a stale generated Prisma client in the shared `node_modules`, plus one missing `@opentelemetry/context-async-hooks`; CI regenerates the client. Output was not filtered.
- `pnpm lint` **could not be run whole** — ESLint 8 crashes on an unrelated file (`src/components/Comics/PanelCard.tsx`, `consistent-type-imports` internal `TypeError`) in this environment. Every changed file was linted individually: 0 errors, and the 4 remaining `no-unused-vars` warnings in `user-restriction.router.ts` are byte-identical to the base.
- Prettier run on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
