### PR TITLE
fix(rewards, comics): stop the sweep re-awarding paid posts, and query the real engagement table

### DIFF
--- a/src/server/jobs/__tests__/process-scheduled-publishing.rewards.test.ts
+++ b/src/server/jobs/__tests__/process-scheduled-publishing.rewards.test.ts
@@ -8,6 +8,7 @@ const {
   mockSetLastRun,
   mockLogToAxiom,
   mockProcessEngagement,
+  mockCreateNotification,
   jobDate,
 } = vi.hoisted(() => ({
   mockDbWrite: {
@@ -22,6 +23,7 @@ const {
   mockSetLastRun: vi.fn(),
   mockLogToAxiom: vi.fn(() => Promise.resolve()),
   mockProcessEngagement: vi.fn(),
+  mockCreateNotification: vi.fn(),
   jobDate: { lastRun: new Date(0) },
 }));
 
@@ -46,8 +48,12 @@ vi.mock('~/server/services/model-version.service', () => ({
   bustMvCache: vi.fn(),
   publishModelVersionsWithEarlyAccess: vi.fn(),
 }));
-vi.mock('~/server/services/notification.service', () => ({ createNotification: vi.fn() }));
-vi.mock('~/server/services/nsfwLevels.service', () => ({ updateComicNsfwLevels: vi.fn() }));
+vi.mock('~/server/services/notification.service', () => ({
+  createNotification: mockCreateNotification,
+}));
+vi.mock('~/server/services/nsfwLevels.service', () => ({
+  updateComicNsfwLevels: vi.fn(async () => undefined),
+}));
 vi.mock('~/server/jobs/job', () => ({
   createJob: (_n: string, _c: string, fn: unknown) => fn,
   getJobDate: async () => [jobDate.lastRun, mockSetLastRun] as const,
@@ -56,18 +62,36 @@ vi.mock('~/server/jobs/job', () => ({
 import { processScheduledPublishing } from '~/server/jobs/process-scheduled-publishing';
 
 type Row = { id: number; userId: number };
+type Chapter = {
+  projectId: number;
+  position: number;
+  userId: number;
+  projectName: string;
+  chapterName: string;
+  username: string | null;
+};
+type Follower = { projectId: number; userId: number };
 
 // Routed on SQL text rather than call order so adding a read doesn't shift these.
 const stubReads = ({
   scheduled = [],
   newlyLive = [],
+  chapters = [],
+  followers = [],
 }: {
   scheduled?: Row[];
   newlyLive?: Row[];
+  chapters?: Chapter[];
+  followers?: Follower[];
 }) => {
   mockDbWrite.$queryRaw.mockImplementation(async (...args: unknown[]) => {
     const sql = (args[0] as string[]).join(' ');
-    if (sql.includes('"ComicChapter"')) return [];
+    // There is no "ComicEngagement" table — prod answers 42P01. Throwing rather than
+    // returning [] keeps a revert from reading as "this project has no followers".
+    if (sql.includes('"ComicEngagement"'))
+      throw new Error('relation "ComicEngagement" does not exist');
+    if (sql.includes('"ComicProjectEngagement"')) return followers;
+    if (sql.includes('"ComicChapter"')) return chapters;
     if (sql.includes('JOIN "ModelVersion" mv ON mv.id = p."modelVersionId"')) return scheduled;
     if (sql.includes('FROM "Post" p')) return newlyLive;
     return [];
@@ -184,6 +208,49 @@ describe('processScheduledPublishing :: first daily post reward', () => {
     expect(mockLogToAxiom).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'warning', message: expect.stringContaining('row limit') })
     );
+  });
+});
+
+describe('processScheduledPublishing :: comic chapter notifications', () => {
+  const chapter: Chapter = {
+    projectId: 5,
+    position: 2,
+    userId: 50,
+    projectName: 'Proj',
+    chapterName: 'Ch2',
+    username: 'author',
+  };
+
+  it('notifies the project followers when a scheduled chapter goes live', async () => {
+    stubReads({
+      chapters: [chapter],
+      followers: [
+        { projectId: 5, userId: 101 },
+        { projectId: 5, userId: 102 },
+      ],
+    });
+    await runJob();
+    expect(mockCreateNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'new-comic-chapter',
+        key: 'new-comic-chapter:5:2',
+        userIds: [101, 102],
+      })
+    );
+  });
+
+  // The follower read sits ahead of every publish side effect and outside the
+  // transaction, so a failure there takes down the whole run — after the chapters
+  // have already flipped to Published, which is what makes the loss permanent.
+  it('completes the rest of the run once a chapter batch is handled', async () => {
+    stubReads({
+      chapters: [chapter],
+      followers: [{ projectId: 5, userId: 101 }],
+      newlyLive: [{ id: 9, userId: 90 }],
+    });
+    await runJob();
+    expect(mockApply).toHaveBeenCalledWith({ postId: 9, posterId: 90 });
+    expect(mockSetLastRun).toHaveBeenCalled();
   });
 });
 

--- a/src/server/jobs/__tests__/process-scheduled-publishing.rewards.test.ts
+++ b/src/server/jobs/__tests__/process-scheduled-publishing.rewards.test.ts
@@ -1,21 +1,29 @@
 import type { Prisma } from '@prisma/client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockDbWrite, mockApply, mockSetLastRun, mockLogToAxiom, mockProcessEngagement, jobDate } =
-  vi.hoisted(() => ({
-    mockDbWrite: {
-      $queryRaw: vi.fn(),
-      $executeRaw: vi.fn(),
-      $transaction: vi.fn(),
-      image: { findMany: vi.fn() },
-      comicProject: { updateMany: vi.fn() },
-    },
-    mockApply: vi.fn(),
-    mockSetLastRun: vi.fn(),
-    mockLogToAxiom: vi.fn(() => Promise.resolve()),
-    mockProcessEngagement: vi.fn(),
-    jobDate: { lastRun: new Date(0) },
-  }));
+const {
+  mockDbWrite,
+  mockApply,
+  mockRewardedIds,
+  mockSetLastRun,
+  mockLogToAxiom,
+  mockProcessEngagement,
+  jobDate,
+} = vi.hoisted(() => ({
+  mockDbWrite: {
+    $queryRaw: vi.fn(),
+    $executeRaw: vi.fn(),
+    $transaction: vi.fn(),
+    image: { findMany: vi.fn() },
+    comicProject: { updateMany: vi.fn() },
+  },
+  mockApply: vi.fn(),
+  mockRewardedIds: vi.fn(),
+  mockSetLastRun: vi.fn(),
+  mockLogToAxiom: vi.fn(() => Promise.resolve()),
+  mockProcessEngagement: vi.fn(),
+  jobDate: { lastRun: new Date(0) },
+}));
 
 vi.mock('~/server/logging/client', () => ({ logToAxiom: mockLogToAxiom }));
 
@@ -24,6 +32,9 @@ vi.mock('~/server/db/client', () => ({ dbWrite: mockDbWrite }));
 // modules that build query caches from the db client at import time, so pulling the
 // real one in drops this suite to zero collected tests.
 vi.mock('~/server/rewards', () => ({ firstDailyPostReward: { apply: mockApply } }));
+vi.mock('~/server/rewards/active/firstDailyPost.reward', () => ({
+  getFirstDailyPostRewardedIds: mockRewardedIds,
+}));
 vi.mock('~/server/events', () => ({ eventEngine: { processEngagement: mockProcessEngagement } }));
 vi.mock('~/server/redis/caches', () => ({
   dataForModelsCache: { refresh: vi.fn() },
@@ -76,6 +87,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   jobDate.lastRun = new Date(0);
   mockApply.mockResolvedValue(undefined);
+  mockRewardedIds.mockResolvedValue(new Set<number>());
   mockDbWrite.$transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) =>
     fn({ $executeRaw: vi.fn(), $queryRaw: vi.fn().mockResolvedValue([]) })
   );
@@ -130,6 +142,40 @@ describe('processScheduledPublishing :: first daily post reward', () => {
       expect.objectContaining({ type: 'error', postId: 4 })
     );
     expect(mockSetLastRun).toHaveBeenCalled();
+  });
+
+  // The ledger keys this reward on the post id and never expires it, so re-applying
+  // to a post it already paid for spends the user's daily cap and then gets refused
+  // as a duplicate — 25 Buzz never moves and the day's real post is capped.
+  it('skips posts the reward has already been granted for', async () => {
+    mockRewardedIds.mockResolvedValue(new Set([2]));
+    stubReads({
+      newlyLive: [
+        { id: 2, userId: 20 },
+        { id: 3, userId: 30 },
+      ],
+    });
+    await runJob();
+    expect(mockApply).toHaveBeenCalledTimes(1);
+    expect(mockApply).toHaveBeenCalledWith({ postId: 3, posterId: 30 });
+  });
+
+  it('checks both publish paths against the prior grants, deduped', async () => {
+    stubReads({ scheduled: [{ id: 7, userId: 70 }], newlyLive: [{ id: 7, userId: 70 }] });
+    await runJob();
+    expect(mockRewardedIds).toHaveBeenCalledWith([{ id: 7, userId: 70 }]);
+  });
+
+  // Dropping the sweep's rewards on a ClickHouse blip would lose them for good: the
+  // window only advances forward, so these posts are never reconsidered.
+  it('keeps granting, and says so, when the prior-grant lookup fails', async () => {
+    mockRewardedIds.mockRejectedValue(new Error('clickhouse down'));
+    stubReads({ newlyLive: [{ id: 8, userId: 80 }] });
+    await runJob();
+    expect(mockApply).toHaveBeenCalledWith({ postId: 8, posterId: 80 });
+    expect(mockLogToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error', message: expect.stringContaining('unfiltered') })
+    );
   });
 
   it('warns instead of silently truncating when the sweep hits its row limit', async () => {

--- a/src/server/jobs/process-scheduled-publishing.ts
+++ b/src/server/jobs/process-scheduled-publishing.ts
@@ -7,6 +7,7 @@ import { uniq, uniqBy } from 'lodash-es';
 import { logToAxiom } from '~/server/logging/client';
 import { dataForModelsCache, userImageVideoCountCaches } from '~/server/redis/caches';
 import { firstDailyPostReward } from '~/server/rewards';
+import { getFirstDailyPostRewardedIds } from '~/server/rewards/active/firstDailyPost.reward';
 import { queueImageSearchIndexUpdate } from '~/server/services/image.service';
 import { modelsSearchIndex } from '~/server/search-index';
 import {
@@ -324,7 +325,24 @@ export const processScheduledPublishing = createJob(
         windowStart: rewardWindowStart.toISOString(),
       }).catch(() => undefined);
     }
+    // A post can reach this sweep already paid for: anything scheduled before the
+    // reward moved to publish time was granted at schedule time, and an
+    // unpublish/republish crosses the window a second time. The ledger refuses those
+    // as duplicates — but only after the reward has spent the user's daily cap on
+    // them — so they have to be dropped before apply rather than after.
+    const alreadyRewarded = await getFirstDailyPostRewardedIds(publishedPosts).catch((error) => {
+      logToAxiom({
+        name: 'process-scheduled-publishing',
+        type: 'error',
+        message: 'Failed to read prior first daily post rewards; granting unfiltered',
+        error: (error as Error)?.message,
+      }).catch(() => undefined);
+      return new Set<number>();
+    });
+
     for (const post of publishedPosts) {
+      if (alreadyRewarded.has(post.id)) continue;
+
       // Caught per post so one failure can't abort the job — but routed to Axiom
       // rather than swallowed, since base.reward rethrows genuine ClickHouse schema
       // breaks precisely so they stay visible.

--- a/src/server/jobs/process-scheduled-publishing.ts
+++ b/src/server/jobs/process-scheduled-publishing.ts
@@ -166,7 +166,7 @@ export const processScheduledPublishing = createJob(
 
       // Batch-fetch all followers for affected projects in a single query
       const allFollowers = await dbWrite.$queryRaw<{ projectId: number; userId: number }[]>`
-        SELECT "projectId", "userId" FROM "ComicEngagement"
+        SELECT "projectId", "userId" FROM "ComicProjectEngagement"
         WHERE "projectId" IN (${Prisma.join(projectIds)}) AND "type" = 'Notify'
       `;
       const followersByProject = new Map<number, number[]>();

--- a/src/server/rewards/__tests__/firstDailyPost.reward.test.ts
+++ b/src/server/rewards/__tests__/firstDailyPost.reward.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The reward module loads `../base.reward`, which builds a buzz client, redis
+// handles and prom collectors at import time. Mocked to the surface base.reward
+// touches so this suite can collect; only `$query` is under test.
+const h = vi.hoisted(() => ({ query: vi.fn() }));
+
+vi.mock('~/server/clickhouse/client', () => ({
+  clickhouse: { $query: (...args: unknown[]) => h.query(...args) },
+}));
+vi.mock('~/server/redis/client', () => ({ redis: {}, REDIS_KEYS: { BUZZ_EVENTS: 'buzz-events' } }));
+vi.mock('~/server/db/client', () => ({ dbWrite: {}, dbRead: {} }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn(async () => undefined) }));
+vi.mock('~/server/prom/client', () => ({
+  rewardFailedCounter: { inc: vi.fn() },
+  rewardGivenCounter: { inc: vi.fn() },
+  clickhouseFailSoftCounter: { inc: vi.fn() },
+}));
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransactionMany: vi.fn(),
+  getMultipliersForUser: vi.fn(async () => ({ rewardsMultiplier: 1 })),
+}));
+
+import { getFirstDailyPostRewardedIds } from '~/server/rewards/active/firstDailyPost.reward';
+
+// `$query` is a tagged template, so the mock sees (parts, ...values).
+const lastQuery = () => {
+  const [parts, ...values] = h.query.mock.calls.at(-1) as unknown as [string[], ...unknown[]];
+  return parts.reduce((acc, part, i) => acc + part + (values[i] ?? ''), '');
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.query.mockResolvedValue([]);
+});
+
+describe('getFirstDailyPostRewardedIds', () => {
+  it('returns the post ids ClickHouse reports an award for', async () => {
+    h.query.mockResolvedValue([{ forId: 2 }, { forId: 2 }]);
+    const rewarded = await getFirstDailyPostRewardedIds([
+      { id: 1, userId: 10 },
+      { id: 2, userId: 20 },
+    ]);
+    expect([...rewarded]).toEqual([2]);
+  });
+
+  // buzzEvents is ordered by (type, toUserId, forId, byUserId), so matching on
+  // forId alone drops the index: measured 124MiB read against 24MiB for the pair.
+  it('matches on the (user, post) pair so the primary key still applies', async () => {
+    await getFirstDailyPostRewardedIds([
+      { id: 1, userId: 10 },
+      { id: 2, userId: 20 },
+    ]);
+    expect(lastQuery()).toContain('(toUserId, forId) IN ((10,1),(20,2))');
+  });
+
+  // A capped event means the user's cap was already spent that day by another
+  // post; it is not a payment, and treating it as one would skip a legitimate grant.
+  it('counts awarded events only', async () => {
+    await getFirstDailyPostRewardedIds([{ id: 1, userId: 10 }]);
+    expect(lastQuery()).toContain("status = 'awarded'");
+  });
+
+  it('does not query for an empty post set', async () => {
+    expect([...(await getFirstDailyPostRewardedIds([]))]).toEqual([]);
+    expect(h.query).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/rewards/active/firstDailyPost.reward.ts
+++ b/src/server/rewards/active/firstDailyPost.reward.ts
@@ -1,3 +1,4 @@
+import { clickhouse } from '~/server/clickhouse/client';
 import { createBuzzEvent } from '../base.reward';
 
 export const firstDailyPostReward = createBuzzEvent({
@@ -18,7 +19,43 @@ export const firstDailyPostReward = createBuzzEvent({
   },
 });
 
+/**
+ * Of the given posts, the ids that have already been granted this reward on some
+ * earlier day.
+ *
+ * The Buzz ledger keys this reward on the post — `firstDailyPost:<postId>-<userId>-<userId>`
+ * — and that key never expires, while the grant itself is capped per user per UTC
+ * day in Redis. So re-applying to a post on a later day passes the daily cap,
+ * spends it, and is then refused by the ledger as a duplicate: the user's day is
+ * burned and no Buzz moves, silently. Any caller that can hand the reward a post
+ * it already paid for has to filter with this first.
+ */
+export async function getFirstDailyPostRewardedIds(posts: PostOwner[]) {
+  const rewarded = new Set<number>();
+  if (!clickhouse || !posts.length) return rewarded;
+
+  // Matched on (toUserId, forId), not forId alone: buzzEvents is ordered by
+  // (type, toUserId, forId, byUserId), so dropping the user costs the index and
+  // turns this into a full read of every firstDailyPost row ever written.
+  const pairs = posts.map(({ id, userId }) => `(${userId},${id})`).join(',');
+  const rows = await clickhouse.$query<{ forId: number }>`
+    SELECT DISTINCT forId
+    FROM buzzEvents
+    WHERE type = 'firstDailyPost'
+      AND status = 'awarded'
+      AND (toUserId, forId) IN (${pairs})
+  `;
+  for (const { forId } of rows) rewarded.add(forId);
+
+  return rewarded;
+}
+
 type PostEvent = {
   postId: number;
   posterId: number;
+};
+
+type PostOwner = {
+  id: number;
+  userId: number;
 };

--- a/src/server/rewards/index.ts
+++ b/src/server/rewards/index.ts
@@ -1,3 +1,5 @@
+// process-rewards and user.controller iterate this module's values and treat every
+// one as a BuzzEvent, so only rewards belong here — import helpers from their file.
 export { imagePostedToModelReward } from './passive/imagePostedToModel.reward';
 export { encouragementReward } from './active/encouragement.reward';
 export { firstDailyPostReward } from './active/firstDailyPost.reward';


### PR DESCRIPTION
Fixes [CU-868knwakx](https://app.clickup.com/t/8459928/868knwakx). Follow-up to #3656.

Two independent bugs in `process-scheduled-publishing`, both found while investigating the ticket. Commit 1 is the reported one; commit 2 is a wrong table name that has been killing the job outright.

---

# 1. The first-daily-post re-award

## The report, and why it was inverted

The ticket reads: `firstDailyPost` events are written `status: awarded / awardAmount: 25` with no matching `buzzTransactions` row, so 25 Blue Buzz never arrives — and because the day's award now shows as claimed, the user's genuine post later that day is recorded `capped`.

The events and the cap burn are real. The missing credit is not. **The Buzz was paid — weeks earlier.**

```
truly_missing        0
paid_on_earlier_day  200
paid_same_day        2246
```
(all sweep-path `awarded` events since 2026-08-07, joined to `buzzTransactions` with **no** date filter)

Every one of the 200 has a `firstDailyPost:<postId>-<userId>-<userId>` transaction dated the day the post was **scheduled** — from 2026-02-18 through 2026-08-06. The ticket's detection query bounded the transaction subquery at `date >= '2026-08-01'`, so the earlier payment fell outside the join and read as absent.

## Root cause

The reward has two dedup layers at two different granularities, and they only agreed while a post could be rewarded once:

| Layer | Key | Lifetime |
|---|---|---|
| Redis (`ON_DEMAND_REWARD_SCRIPT`) | `<userId>:firstDailyPost` → hash of the event key | expires at UTC midnight |
| Buzz ledger (`sendAward`, `base.reward.ts:181`) | `firstDailyPost:<postId>-<userId>-<userId>` | **never expires** |

Before #3656, standalone scheduled posts were rewarded at schedule time. #3656 correctly moved that grant to publish time — but a post scheduled *before* it shipped had already been paid, and the new sweep hands it to `apply` again days or weeks later:

1. Redis cache is fresh on the go-live day → the Lua script returns 25.
2. `apply` writes an `awarded` buzzEvent and **spends the user's daily cap**.
3. `sendAward` submits the same `externalTransactionId` from step 0 → the buzz service returns it as a **conflict**.
4. `createBuzzTransactionMany` treats conflicts as benign ("the money already moved") and excludes them from its `unaccounted` reconciliation — so there is **no throw, no Axiom log, no metric**.
5. The user's real post that day hits the spent cap and is recorded `capped`.

Confirmed end to end on post `30158785` (user `2288868`): `awarded` inline on 2026-08-03 with a matching transaction at `05:08:05`, then `awarded` again by the sweep on 2026-08-10 at `03:07:15` with no new transaction.

An unpublish/republish across a day boundary reaches the same state, independent of the #3656 transition.

## The fix

Filter the sweep's post set against the awards ClickHouse has already recorded, before `apply` — so an already-paid post never spends the day's cap.

**Invariant: a post earns this reward at most once, ever.** The affected users are not paid a second time; their day is freed, so a genuine post still earns the 25.

The lookup matches on `(toUserId, forId)` rather than `forId` alone. `buzzEvents` is `ORDER BY (type, toUserId, forId, byUserId)`, so dropping the user drops the index — measured on prod for the same 14-post batch:

| Predicate | rows read | bytes | duration |
|---|---|---|---|
| `(toUserId, forId) IN (...)` | 2,515,141 | 24.01 MiB | 40 ms |
| `forId IN (...)` | 25,638,938 | 124.26 MiB | 178 ms |

It fails **open**: a ClickHouse error logs to Axiom and grants unfiltered. Failing closed would drop those rewards permanently — the sweep window only advances forward, so a skipped post is never reconsidered.

`~/server/rewards`'s exports are iterated as BuzzEvents by `process-rewards.ts` and `user.controller.ts`, so the helper is imported from its own module rather than the barrel (typecheck catches the alternative; a comment now says so).

## Tests

New guards, each verified to fail legibly when the fix is reverted:

- **`skips posts the reward has already been granted for`** → on revert: `expected "vi.fn()" to be called 1 times, but got 2 times`
- **`matches on the (user, post) pair so the primary key still applies`** → on revert to `forId IN`: `expected '...' to contain '(toUserId, forId) IN ((10,1),(20,2))'`
- `counts awarded events only` — a `capped` event means the cap was spent by another post, not that this one was paid
- `checks both publish paths against the prior grants, deduped`
- `keeps granting, and says so, when the prior-grant lookup fails`
- `does not query for an empty post set`

---

# 2. The comic-chapter follower query names a table that doesn't exist

Found while reading the job for bug 1. `process-scheduled-publishing.ts:169` reads followers from `"ComicEngagement"`. **There is no such table** — and there never was. The model is `ComicProjectEngagement` (`schema.full.prisma:6988`, created in migration `20260205200000_add_comics`); prod has it with 129,900 rows, 1,806 of them `type = 'Notify'`, and exactly the columns the query wants. Not a missing migration — a wrong name.

Prod answers `42P01` every time a scheduled chapter comes due. Three runs died this way in the last 7 days, each at the exact minute a chapter published:

| job died | chapter that published that minute |
|---|---|
| 2026-08-04 16:00:02 | project 2988 ch.4 @ 16:00:00 |
| 2026-08-07 04:51:02 | project 3178 ch.0 @ 04:51:00 |
| 2026-08-08 17:00:15 | project 3279 ch.1 @ 17:00:00 |

## What it actually costs

The read sits ahead of every publish side effect and **outside** the `$transaction`, so the throw aborts the whole run — but only after `UPDATE "ComicChapter" SET status = 'Published'` has already committed.

- **Publishing is fine.** The chapters go live; the next minute's run finds nothing `Scheduled` and proceeds normally. The missed minute is recovered because `setLastRun()` never fired, so the reward window doesn't advance past it. Verified against prod: 0 overdue models, and all 42 overdue `ModelVersion`s are held by the job's own no-`ModelFile` guard, not by this.
- **The follower notification is lost for good.** Those chapters aren't `Scheduled` anymore, so no later run re-selects them. Three chapters' `new-comic-chapter` notifications were never sent and can't be replayed by this fix.
- **Latent, worse:** a crash spanning UTC midnight would drop that window's rewards permanently — `rewardWindowStart` clamps to the start of day, so the missed posts fall out of range. All three crashes so far were mid-day.

## Tests

The suite's db stub now **throws 42P01 for the old name** rather than returning no rows, so a revert fails with the production error instead of quietly reading as "this project has no followers":

- **`notifies the project followers when a scheduled chapter goes live`** → on revert: `Error: relation "ComicEngagement" does not exist`
- **`completes the rest of the run once a chapter batch is handled`** → same; pins that a chapter batch no longer takes the reward sweep and `setLastRun` down with it

---

Verification (both commits): `pnpm run typecheck` 0 errors · `eslint` clean on changed files · `pnpm run test:unit:run` **897 files / 13,836 passed / 0 failed** · `pnpm run test:lint-rules` 204 passed.

## Not in this PR

**Backfill.** No Buzz is owed for the 200 events — each was paid on its schedule day. What those users lost is the *day* the phantom award consumed. If we want to make that whole, it is a separate grant decision; this PR only stops it recurring. Support's hold on manual grants can be lifted for anyone whose "missing" award resolves to a prior payment.

**The three lost chapter notifications.** Replaying them means re-deriving the follower set and posting `new-comic-chapter` for projects 2988/3178/3279 — a one-off, not something this job should do on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
