### PR TITLE
fix(telemetry): make the OTel logs bridge reach every logToAxiom call site

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,24 @@ ENV SOURCE_COMMIT=$SOURCE_COMMIT
 RUN --mount=type=cache,target=/app/.next/cache \
     SKIP_ENV_VALIDATION=1 IS_BUILD=true NODE_OPTIONS="--max_old_space_size=${NODE_BUILD_MEM}" pnpm run build
 
+# Server-graph module identity — a HARD gate, deliberately unlike the report-only
+# bundle budget below.
+#
+# A module's top-level state is per RUNTIME module, and the bundler decides how many
+# runtime modules a source file becomes: Turbopack inlines `src/server/logging/client.ts`
+# into 14 of them in this build. Anything that must be a process-wide singleton therefore
+# has to be reached through `globalThis`. Nothing else we run can see a violation — `tsc`
+# checks one source file, eslint reads source, and Vitest loads a module once, so a
+# module-scope singleton looks like a singleton everywhere except in the emitted output.
+# That is how the OTel logs bridge shipped delivering 1.3% of its records with a green
+# typecheck, a green lint and a green suite.
+#
+# Runs here for the same reason the budget does: `.next` exists in this stage, so there is
+# no second build. It reads the emitted `.js.map` `sources` to attribute code to source
+# modules, and exits 2 (not 0) if it finds no maps — a scan that can see nothing must not
+# report health. Cheap: a few seconds of file reads.
+RUN node scripts/check-server-graph-singletons.mjs
+
 # Bundle-size budget (report-only during the soak). Next 16 (Turbopack) emits
 # opaque hashed chunks and removed per-route build stats, so scripts/bundle-budget.mjs
 # parses .next/build-manifest.json to reconstruct per-page First Load JS (brotli)

--- a/packages/civitai-telemetry/src/__tests__/otel-logs-metrics.test.ts
+++ b/packages/civitai-telemetry/src/__tests__/otel-logs-metrics.test.ts
@@ -2,7 +2,11 @@ import client from 'prom-client';
 import { describe, expect, it } from 'vitest';
 
 import { instrumentationRegistry, PROM_PREFIX } from '../client';
-import { emitOtelLog, otelLogRecordsEmittedCounter, otelLogRecordsSkippedCounter } from '../otel-logs';
+import {
+  emitOtelLog,
+  otelLogRecordsEmittedCounter,
+  otelLogRecordsSkippedCounter,
+} from '../otel-logs';
 
 /**
  * WHERE the bridge's counters are registered, which is the whole reason they were absent

--- a/packages/civitai-telemetry/src/__tests__/otel-logs-metrics.test.ts
+++ b/packages/civitai-telemetry/src/__tests__/otel-logs-metrics.test.ts
@@ -1,0 +1,77 @@
+import client from 'prom-client';
+import { describe, expect, it } from 'vitest';
+
+import { instrumentationRegistry, PROM_PREFIX } from '../client';
+import { emitOtelLog, otelLogRecordsEmittedCounter, otelLogRecordsSkippedCounter } from '../otel-logs';
+
+/**
+ * WHERE the bridge's counters are registered, which is the whole reason they were absent
+ * from production.
+ *
+ * The counters shipped on prom-client's DEFAULT registry. This module is only ever loaded
+ * from `src/instrumentation.node.ts`, and `/api/metrics` is an API route — a different
+ * bundler graph with a different default registry — so the counters incremented into a
+ * registry nothing scrapes. Measured on a live pod: `/metrics` returned HTTP 200 with
+ * 1,758 lines, 90 of them `nodejs_*` (so the endpoint was healthy and the scrape worked)
+ * and ZERO `otel_log*`. The one instrument built to make the bridge's silence legible was
+ * itself silent, which is why the 1.3% delivery rate had to be found by reconciling log
+ * volumes by hand.
+ *
+ * `instrumentationRegistry` is pinned on `globalThis`, so it is the same object in every
+ * graph, and `src/pages/api/metrics.ts` already merges it into the scrape response.
+ *
+ * These cases assert the WIRING (which registry), not the arithmetic. A test that only
+ * checked `counter.inc()` moves a number would have passed throughout the outage.
+ */
+
+const EMITTED = `${PROM_PREFIX}otel_log_records_emitted_total`;
+const SKIPPED = `${PROM_PREFIX}otel_log_records_skipped_total`;
+
+/** Render exactly what a scrape of a registry would contain. */
+const scrape = (registry: client.Registry) => registry.metrics();
+
+describe('otel-logs counters — registry wiring', () => {
+  it('registers BOTH counters on the cross-graph instrumentationRegistry', () => {
+    expect(instrumentationRegistry.getSingleMetric(EMITTED)).toBe(otelLogRecordsEmittedCounter);
+    expect(instrumentationRegistry.getSingleMetric(SKIPPED)).toBe(otelLogRecordsSkippedCounter);
+  });
+
+  it('THE REGRESSION: does NOT register them on the per-graph default registry', () => {
+    // This is the assertion that would have failed on the shipped code. The default
+    // registry is the one `/api/metrics` scrapes from the REQUEST graph; a counter that
+    // lands there from the instrumentation graph is unreachable.
+    expect(client.register.getSingleMetric(EMITTED)).toBeUndefined();
+    expect(client.register.getSingleMetric(SKIPPED)).toBeUndefined();
+  });
+
+  it('POSITIVE CONTROL: an increment is visible in a scrape of the shared registry', async () => {
+    // Proves the assertions above are about a LIVE instrument, not merely a registered
+    // name: without this, a counter wired to a registry that renders nothing would still
+    // satisfy every `getSingleMetric` check.
+    const before = await scrape(instrumentationRegistry);
+    expect(before).toContain(EMITTED);
+
+    // The dark-launch path is the cheapest way to move a counter without a provider:
+    // OTEL_LOGS_ENABLED is unset here, so this counts one `disabled` skip.
+    delete process.env.OTEL_LOGS_ENABLED;
+    const emitted = emitOtelLog('{"name":"registry-probe"}', { name: 'registry-probe' });
+    expect(emitted).toBe(false);
+
+    const after = await scrape(instrumentationRegistry);
+    expect(after).toContain(`${SKIPPED}{reason="disabled"}`);
+
+    // ...and the value actually moved, so this is not matching a zero-valued stub series.
+    const value = Number(
+      /^civitai_app_otel_log_records_skipped_total\{reason="disabled"\} (\d+)/m.exec(after)?.[1]
+    );
+    expect(value).toBeGreaterThan(0);
+  });
+
+  it('carries the civitai_app_ prefix, so the series name matches its siblings', () => {
+    // Named explicitly because the fix moved the registration call, and a hand-rolled
+    // `new Counter({name: 'otel_log_...'})` at the new site would silently drop the prefix
+    // and rename the series out from under any dashboard or alert written against it.
+    expect(EMITTED).toBe('civitai_app_otel_log_records_emitted_total');
+    expect(SKIPPED).toBe('civitai_app_otel_log_records_skipped_total');
+  });
+});

--- a/packages/civitai-telemetry/src/otel-logs.ts
+++ b/packages/civitai-telemetry/src/otel-logs.ts
@@ -21,7 +21,8 @@ import {
   type LogRecordProcessor,
 } from '@opentelemetry/sdk-logs';
 import type { Resource } from '@opentelemetry/resources';
-import { registerCounter, registerCounterWithLabels } from './client';
+import promClient from 'prom-client';
+import { instrumentationRegistry, registerInstrumentationMetric, PROM_PREFIX } from './client';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type MixedObject = Record<string, any>;
@@ -31,22 +32,55 @@ type MixedObject = Record<string, any>;
 // ---------------------------------------------------------------------------
 // A count of zero records arriving at the far end is indistinguishable from a bridge
 // that never runs. These make the difference observable in-process, before the record
-// ever leaves it. `skipped{reason="no_provider"}` in particular is the ONLY runtime
-// signal for the module-identity/bundling failure described on `resolveLogger` below —
-// a unit test structurally cannot see that one.
-export const otelLogRecordsEmittedCounter = registerCounter({
-  name: 'otel_log_records_emitted_total',
-  help: 'Structured log records handed to the OTel Logs API by the Axiom bridge',
-});
+// ever leaves it.
+//
+// 🔴 REGISTERED ON `instrumentationRegistry`, NOT on prom-client's default registry.
+// This module is only ever loaded from `src/instrumentation.node.ts`, i.e. from the
+// INSTRUMENTATION graph, and `/api/metrics` scrapes prom-client's default registry as it
+// exists in the REQUEST graph. A metric created here with `registerCounter` therefore
+// lands in a registry nothing scrapes: it is registered, it increments, and it is absent
+// from every `/metrics` response. That is not a theory — it is what shipped: the first
+// production window of this bridge had a live `/metrics` returning 1,758 lines (90 of them
+// `nodejs_*`, so the endpoint itself was healthy) and ZERO `otel_log*` series, which left
+// the one instrument designed to make the bridge's failure legible completely mute.
+//
+// `instrumentationRegistry` is pinned on `globalThis` precisely so it crosses that
+// boundary, and `src/pages/api/metrics.ts` already merges it into the scrape. This is the
+// same trap, and the same cure, as the event-loop long-task metrics (PR #2451); see the
+// WHY note on `instrumentationRegistry` above.
+//
+// `registerInstrumentationMetric` is get-or-create, so a second evaluation of this module
+// (another graph, or HMR) adopts the existing counter instead of throwing "already
+// registered" inside the constructor.
+const EMITTED_METRIC = PROM_PREFIX + 'otel_log_records_emitted_total';
+const SKIPPED_METRIC = PROM_PREFIX + 'otel_log_records_skipped_total';
+
+export const otelLogRecordsEmittedCounter = registerInstrumentationMetric(
+  EMITTED_METRIC,
+  () =>
+    new promClient.Counter({
+      name: EMITTED_METRIC,
+      help: 'Structured log records handed to the OTel Logs API by the Axiom bridge',
+      registers: [instrumentationRegistry],
+    })
+);
 
 export const OTEL_LOG_SKIP_REASONS = ['disabled', 'no_provider', 'emit_threw'] as const;
 export type OtelLogSkipReason = (typeof OTEL_LOG_SKIP_REASONS)[number];
 
-export const otelLogRecordsSkippedCounter = registerCounterWithLabels({
-  name: 'otel_log_records_skipped_total',
-  help: 'Structured log records NOT emitted over OTLP, by reason',
-  labelNames: ['reason'] as const,
-});
+export const otelLogRecordsSkippedCounter = registerInstrumentationMetric(
+  SKIPPED_METRIC,
+  () =>
+    // `Counter<T>`'s type parameter is the LABEL NAME union, not the label VALUE union —
+    // so it is `'reason'`, matching `labelNames` below. (`OtelLogSkipReason` is the set of
+    // values that label may take; putting it here type-checks the call sites backwards.)
+    new promClient.Counter<'reason'>({
+      name: SKIPPED_METRIC,
+      help: 'Structured log records NOT emitted over OTLP, by reason',
+      labelNames: ['reason'] as const,
+      registers: [instrumentationRegistry],
+    })
+);
 
 // ---------------------------------------------------------------------------
 // Severity
@@ -151,11 +185,28 @@ let cachedLogger: Logger | undefined;
  * exception. A module-scope `getLogger()` is therefore not a style question; it is the
  * bug.
  *
- * This is a TIMING problem, not a bundling-identity one: every installed copy of the
- * logs API shares the same `Symbol.for` key and the same backwards-compatibility
- * version, so a second bundled copy still reads the same global. Checking the global
+ * This is a TIMING problem, and the guard below is the fix for it. Checking the global
  * first makes the permanently-silent state unreachable, and makes the not-yet-registered
  * state OBSERVABLE (counted as `no_provider`) rather than invisible.
+ *
+ * 🔴 It is NOT the whole story, and the note that used to stand here was read as if it
+ * were. It argued that a second BUNDLED copy of the logs API would still read the same
+ * global, so identity could not matter. Both halves of that have now been measured on a
+ * real production build, and the conclusion drawn from them was wrong:
+ *
+ *   - The premise is true but idle. `@opentelemetry/api-logs` is not bundled AT ALL —
+ *     Next externalizes node_modules for the server build, and a scan of the emitted
+ *     server source maps finds ZERO copies of it. There is one instance, from the require
+ *     cache. Externalizing it via `serverExternalPackages` would change nothing.
+ *   - The conclusion is false. Identity DID sink the bridge — just not this module's.
+ *     The duplicated module was the app's own logger shim, `src/server/logging/client.ts`
+ *     (14 emitted copies), whose module-scope sink object the boot-time registration
+ *     could only ever arm in one of them. Fixed by pinning that object on `globalThis`;
+ *     see `src/server/logging/structured-log-sink.ts`.
+ *
+ * The lesson worth keeping: "which module instance holds this state" is a question about
+ * the BUNDLER's output, and reasoning about `Symbol.for` keys cannot answer it. Read the
+ * build.
  */
 function resolveLogger(): Logger | undefined {
   if (cachedLogger) return cachedLogger;

--- a/scripts/__tests__/check-server-graph-singletons.test.ts
+++ b/scripts/__tests__/check-server-graph-singletons.test.ts
@@ -1,0 +1,153 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+/**
+ * `scripts/check-server-graph-singletons.mjs` is a BUILD gate: it reads the emitted
+ * server source maps to count how many runtime modules a source file became, and fails
+ * when a module that must be a process-wide singleton is emitted with private state.
+ *
+ * These cases drive it against synthetic `.next/server` trees. That is deliberate — the
+ * only alternative is a real `next build` (minutes), so nobody would run one per case,
+ * and the branches that matter (a copy missing its globalThis pin, a singleton emitted
+ * twice, a scan that observed nothing) are exactly the ones a healthy real build cannot
+ * produce on demand.
+ *
+ * 🔴 Each case must fail for ITS OWN reason, so every expectation below asserts the
+ * specific message that branch emits, not merely a non-zero exit. A gate with three
+ * failure branches and one generic assertion is a gate with one tested branch.
+ */
+
+const GATE = path.resolve(__dirname, '../check-server-graph-singletons.mjs');
+
+const SINK_MODULE = 'src/server/logging/structured-log-sink.ts';
+const SINK_KEY = '__civitaiStructuredLogSink';
+const OTEL_MODULE = 'packages/civitai-telemetry/src/otel-logs.ts';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), 'graph-gate-'));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+/**
+ * Write one emitted chunk + its source map into the fake `.next/server`.
+ * `sources` are the source modules the bundler inlined into that chunk; `code` is the
+ * emitted JS the gate greps for a globalThis pin.
+ */
+function chunk(name: string, sources: string[], code: string) {
+  const serverDir = path.join(dir, 'server', path.dirname(name));
+  mkdirSync(serverDir, { recursive: true });
+  const base = path.join(dir, 'server', name);
+  writeFileSync(base, code);
+  writeFileSync(
+    `${base}.map`,
+    JSON.stringify({ version: 3, sources, names: [], mappings: '' })
+  );
+}
+
+/** The healthy baseline every case starts from: a singleton otel-logs, emitted once. */
+function healthyOtelLogs() {
+  chunk('chunks/instrumentation.js', [`../../${OTEL_MODULE}`], 'module.exports=[1,()=>{}]');
+}
+
+const run = () =>
+  spawnSync(process.execPath, [GATE, '--next-dir', dir], { encoding: 'utf8' });
+
+const output = (r: ReturnType<typeof run>) => `${r.stdout}${r.stderr}`;
+
+describe('check-server-graph-singletons', () => {
+  // -------------------------------------------------------------------------
+  // The gate can PASS. Without this, every assertion below is satisfied by a
+  // gate that is simply always red, which detects nothing.
+  // -------------------------------------------------------------------------
+  it('POSITIVE CONTROL: passes when every copy carries the pin and the singleton is emitted once', () => {
+    healthyOtelLogs();
+    chunk('chunks/a.js', [`../../${SINK_MODULE}`], `globalThis.${SINK_KEY}??={}`);
+    chunk('chunks/ssr/b.js', [`../../../${SINK_MODULE}`], `globalThis.${SINK_KEY}??={}`);
+
+    const r = run();
+    expect(output(r)).toContain('PASS');
+    expect(r.status).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // SHARED_STATE — the branch that catches the bug this gate was built for.
+  // -------------------------------------------------------------------------
+  it('FAILS when one emitted copy does not reference the globalThis pin', () => {
+    healthyOtelLogs();
+    chunk('chunks/a.js', [`../../${SINK_MODULE}`], `globalThis.${SINK_KEY}??={}`);
+    // The regression: this copy holds a private module-scope object instead.
+    chunk('chunks/ssr/b.js', [`../../../${SINK_MODULE}`], 'const sink={}');
+
+    const r = run();
+    expect(r.status).toBe(1);
+    expect(output(r)).toContain(`1 of 2 emitted copies do NOT reference \`globalThis.${SINK_KEY}\``);
+    // Names the offending chunk, so the failure is actionable rather than just red.
+    expect(output(r)).toContain('chunks/ssr/b.js');
+  });
+
+  it('counts EVERY unpinned copy, not just the first', () => {
+    healthyOtelLogs();
+    chunk('chunks/a.js', [`../../${SINK_MODULE}`], 'const sink={}');
+    chunk('chunks/b.js', [`../../${SINK_MODULE}`], 'const sink={}');
+    chunk('chunks/c.js', [`../../${SINK_MODULE}`], `globalThis.${SINK_KEY}??={}`);
+
+    const r = run();
+    expect(r.status).toBe(1);
+    expect(output(r)).toContain('2 of 3 emitted copies');
+  });
+
+  // -------------------------------------------------------------------------
+  // The wired-to-nothing branch. A rule whose subject it cannot find must FAIL,
+  // never quietly pass — that is the whole premise of the gate.
+  // -------------------------------------------------------------------------
+  it('FAILS when a watched module matches no emitted chunk (rule examined nothing)', () => {
+    healthyOtelLogs();
+    // No chunk mentions the sink module at all — e.g. it was renamed and the
+    // watchlist path went stale.
+    const r = run();
+    expect(r.status).toBe(1);
+    expect(output(r)).toContain('matched 0 emitted chunks');
+    expect(output(r)).toContain('examined NOTHING');
+  });
+
+  // -------------------------------------------------------------------------
+  // SINGLETON
+  // -------------------------------------------------------------------------
+  it('FAILS when a SINGLETON module is emitted more than once', () => {
+    chunk('chunks/a.js', [`../../${SINK_MODULE}`], `globalThis.${SINK_KEY}??={}`);
+    chunk('chunks/instrumentation.js', [`../../${OTEL_MODULE}`], 'module.exports=[1,()=>{}]');
+    // A second copy: something in the request graph pulled the bridge in.
+    chunk('chunks/ssr/page.js', [`../../../${OTEL_MODULE}`], 'module.exports=[2,()=>{}]');
+
+    const r = run();
+    expect(r.status).toBe(1);
+    expect(output(r)).toContain('emitted 2 times, expected exactly 1');
+  });
+
+  // -------------------------------------------------------------------------
+  // "The gate could not run" must be distinguishable from "the gate passed".
+  // Exit 2, not 0 — a scan that sees nothing is not evidence of health.
+  // -------------------------------------------------------------------------
+  it('EXITS 2 (not 0) when the build emitted no source maps', () => {
+    const serverDir = path.join(dir, 'server', 'chunks');
+    mkdirSync(serverDir, { recursive: true });
+    writeFileSync(path.join(serverDir, 'a.js'), 'module.exports=[1,()=>{}]');
+
+    const r = run();
+    expect(r.status).toBe(2);
+    expect(output(r)).toContain('found 0 source maps');
+  });
+
+  it('EXITS 2 (not 0) when there is no server build output at all', () => {
+    const r = run();
+    expect(r.status).toBe(2);
+    expect(output(r)).toContain('was `next build` run first?');
+  });
+});

--- a/scripts/__tests__/check-server-graph-singletons.test.ts
+++ b/scripts/__tests__/check-server-graph-singletons.test.ts
@@ -45,10 +45,7 @@ function chunk(name: string, sources: string[], code: string) {
   mkdirSync(serverDir, { recursive: true });
   const base = path.join(dir, 'server', name);
   writeFileSync(base, code);
-  writeFileSync(
-    `${base}.map`,
-    JSON.stringify({ version: 3, sources, names: [], mappings: '' })
-  );
+  writeFileSync(`${base}.map`, JSON.stringify({ version: 3, sources, names: [], mappings: '' }));
 }
 
 /** The healthy baseline every case starts from: a singleton otel-logs, emitted once. */
@@ -56,8 +53,7 @@ function healthyOtelLogs() {
   chunk('chunks/instrumentation.js', [`../../${OTEL_MODULE}`], 'module.exports=[1,()=>{}]');
 }
 
-const run = () =>
-  spawnSync(process.execPath, [GATE, '--next-dir', dir], { encoding: 'utf8' });
+const run = () => spawnSync(process.execPath, [GATE, '--next-dir', dir], { encoding: 'utf8' });
 
 const output = (r: ReturnType<typeof run>) => `${r.stdout}${r.stderr}`;
 
@@ -87,7 +83,9 @@ describe('check-server-graph-singletons', () => {
 
     const r = run();
     expect(r.status).toBe(1);
-    expect(output(r)).toContain(`1 of 2 emitted copies do NOT reference \`globalThis.${SINK_KEY}\``);
+    expect(output(r)).toContain(
+      `1 of 2 emitted copies do NOT reference \`globalThis.${SINK_KEY}\``
+    );
     // Names the offending chunk, so the failure is actionable rather than just red.
     expect(output(r)).toContain('chunks/ssr/b.js');
   });

--- a/scripts/check-server-graph-singletons.mjs
+++ b/scripts/check-server-graph-singletons.mjs
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+/**
+ * Server-graph module-identity gate.
+ *
+ * ---------------------------------------------------------------------------
+ * What this exists to catch
+ * ---------------------------------------------------------------------------
+ * A module's top-level bindings are per RUNTIME MODULE, and the bundler decides how many
+ * runtime modules a source file becomes. Turbopack merges source modules into larger
+ * runtime modules, so one `.ts` file is routinely INLINED into many of them: on a
+ * production build of this repo `src/server/logging/client.ts` is emitted 14 times.
+ *
+ * Anything that has to be a process-wide singleton therefore cannot live in a
+ * module-scope `const`. It has to be reached through `globalThis`, which is the only
+ * thing every copy shares.
+ *
+ * This failure is STRUCTURALLY INVISIBLE to every other gate we run. `tsc` type-checks
+ * one source file, not N emitted copies of it. ESLint reads source. Vitest loads each
+ * module exactly once, so a module-scope singleton looks like a singleton. Only the
+ * bundler knows, and it does not complain — it just quietly hands each copy its own
+ * object. That is how the OTel logs bridge shipped delivering 1.3% of records with a
+ * green typecheck, a green lint and a green suite: `setStructuredLogSink()` armed one of
+ * 14 sink objects, and nothing anywhere could see it.
+ *
+ * ---------------------------------------------------------------------------
+ * How it measures
+ * ---------------------------------------------------------------------------
+ * Turbopack's production output uses opaque NUMERIC module ids, so the emitted JS cannot
+ * be attributed to a source file by reading it. The source maps can: each emitted chunk
+ * ships a `.js.map` whose `sources` array names every source module inlined into it. A
+ * source file that appears in N chunks' `sources` is N runtime modules.
+ *
+ * This needs server source maps, which this repo emits in production
+ * (`productionBrowserSourceMaps: true` → Turbopack's `turbopackSourceMaps`, which covers
+ * `.next/server/**` too). If no maps are found the gate EXITS NON-ZERO rather than
+ * passing: a scan that cannot see anything must never be reported as "nothing wrong".
+ *
+ * ---------------------------------------------------------------------------
+ * Rules
+ * ---------------------------------------------------------------------------
+ *  SHARED_STATE — the module may be emitted any number of times, but every emitted copy
+ *                 must reference the named `globalThis` key. A copy without it owns
+ *                 private state that the registration path can never reach.
+ *
+ *  SINGLETON    — the module must be emitted EXACTLY once. Its module scope is
+ *                 deliberately graph-local (a memoized handle, a set of counters), so a
+ *                 second copy is a second, silently-unregistered instance.
+ *
+ * Usage:  node scripts/check-server-graph-singletons.mjs [--next-dir .next] [--json]
+ * Exit:   0 = pass · 1 = violation · 2 = the gate could not run (env/usage)
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { readdir } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Watchlist
+// ---------------------------------------------------------------------------
+// Keep this SMALL and justified. Every entry must name a real cross-graph invariant and
+// say what breaks when it is violated — an entry nobody can explain becomes an entry
+// nobody dares delete.
+const WATCHLIST = [
+  {
+    rule: 'SHARED_STATE',
+    module: 'src/server/logging/structured-log-sink.ts',
+    globalKey: '__civitaiStructuredLogSink',
+    why: 'The one AxiomDeps object every emitted copy of the logger shim hands to createAxiomLogger. `src/instrumentation.node.ts` calls setStructuredLogSink() ONCE at boot; a copy holding a private object is a log call site whose additional sinks (the OTel logs bridge) are permanently dark, with no error and no counter.',
+  },
+  {
+    rule: 'SINGLETON',
+    module: 'packages/civitai-telemetry/src/otel-logs.ts',
+    why: 'Holds the memoized OTel Logger and the bridge counters in module scope, and is loaded only from the instrumentation entry, which is also what registers the LoggerProvider. A second copy would be a second bridge that never sees that registration — and whose counters register into a registry nothing scrapes.',
+  },
+];
+
+// ---------------------------------------------------------------------------
+const args = process.argv.slice(2);
+function argValue(flag, fallback) {
+  const i = args.indexOf(flag);
+  return i !== -1 && args[i + 1] ? args[i + 1] : fallback;
+}
+const NEXT_DIR = argValue('--next-dir', process.env.NEXT_DIR || '.next');
+const SERVER_DIR = join(NEXT_DIR, 'server');
+const AS_JSON = args.includes('--json');
+
+function die(code, message) {
+  console.error(`server-graph-singletons: ${message}`);
+  process.exit(code);
+}
+
+if (!existsSync(SERVER_DIR)) {
+  die(2, `no server output at ${SERVER_DIR} — was \`next build\` run first?`);
+}
+
+async function walk(dir, out = []) {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) await walk(p, out);
+    else out.push(p);
+  }
+  return out;
+}
+
+const files = await walk(SERVER_DIR);
+const mapFiles = files.filter((f) => f.endsWith('.js.map'));
+
+if (mapFiles.length === 0) {
+  // A zero here is indistinguishable from "everything is fine" unless we refuse it.
+  die(
+    2,
+    `found 0 source maps under ${SERVER_DIR}. This gate reads \`.js.map\` \`sources\` to attribute emitted code to source modules; without them it can see nothing. Server maps come from \`productionBrowserSourceMaps: true\` in next.config.mjs (Turbopack maps both client and server chunks from that flag).`
+  );
+}
+
+// chunk (relative .js path) -> Set(source modules inlined into it)
+const chunkSources = new Map();
+for (const m of mapFiles) {
+  let sources;
+  try {
+    sources = JSON.parse(readFileSync(m, 'utf8')).sources;
+  } catch {
+    continue; // an unparseable map is not evidence of a violation
+  }
+  if (!Array.isArray(sources)) continue;
+  chunkSources.set(relative(SERVER_DIR, m).replace(/\.map$/, ''), sources);
+}
+
+const readChunk = (rel) => {
+  try {
+    return readFileSync(join(SERVER_DIR, rel), 'utf8');
+  } catch {
+    return '';
+  }
+};
+
+// ---------------------------------------------------------------------------
+const results = [];
+let failed = 0;
+
+for (const entry of WATCHLIST) {
+  const copies = [];
+  for (const [chunk, sources] of chunkSources) {
+    if (sources.some((s) => typeof s === 'string' && s.endsWith(entry.module))) copies.push(chunk);
+  }
+
+  const result = { ...entry, copies: copies.length, violations: [] };
+
+  // POSITIVE CONTROL, always. A watchlist entry that matches nothing means the path was
+  // renamed/deleted or the scan is looking in the wrong place — either way the rule below
+  // would "pass" without having examined anything, which is the failure mode this whole
+  // gate exists to prevent. Refuse it.
+  if (copies.length === 0) {
+    result.violations.push(
+      `matched 0 emitted chunks — this rule examined NOTHING. Either \`${entry.module}\` no longer exists / is no longer reachable from the server build, or its path in this watchlist is stale. Fix the path or drop the entry; do not leave a rule that cannot observe its subject.`
+    );
+  } else if (entry.rule === 'SINGLETON') {
+    if (copies.length > 1) {
+      result.violations.push(
+        `emitted ${copies.length} times, expected exactly 1. ${entry.why}\n    copies: ${copies.slice(0, 10).join(', ')}${copies.length > 10 ? `, +${copies.length - 10} more` : ''}`
+      );
+    }
+  } else if (entry.rule === 'SHARED_STATE') {
+    const unpinned = copies.filter((c) => !readChunk(c).includes(entry.globalKey));
+    result.pinned = copies.length - unpinned.length;
+    if (unpinned.length > 0) {
+      result.violations.push(
+        `${unpinned.length} of ${copies.length} emitted copies do NOT reference \`globalThis.${entry.globalKey}\`, so each of those holds PRIVATE module-scope state. ${entry.why}\n    unpinned copies: ${unpinned.slice(0, 10).join(', ')}${unpinned.length > 10 ? `, +${unpinned.length - 10} more` : ''}`
+      );
+    }
+  } else {
+    result.violations.push(`unknown rule \`${entry.rule}\` — the gate cannot evaluate it.`);
+  }
+
+  if (result.violations.length) failed++;
+  results.push(result);
+}
+
+// ---------------------------------------------------------------------------
+if (AS_JSON) {
+  console.log(JSON.stringify({ serverDir: SERVER_DIR, maps: mapFiles.length, results }, null, 2));
+} else {
+  console.log('===== server-graph module identity =====');
+  console.log(`scanned ${chunkSources.size} emitted chunks (${mapFiles.length} source maps) under ${SERVER_DIR}`);
+  console.log('');
+  for (const r of results) {
+    const detail =
+      r.rule === 'SHARED_STATE'
+        ? `${r.copies} emitted cop${r.copies === 1 ? 'y' : 'ies'}, ${r.pinned ?? 0} referencing globalThis.${r.globalKey}`
+        : `${r.copies} emitted cop${r.copies === 1 ? 'y' : 'ies'}`;
+    console.log(`  ${r.violations.length ? 'FAIL' : ' OK '}  ${r.rule.padEnd(12)} ${r.module}`);
+    console.log(`        ${detail}`);
+    for (const v of r.violations) console.log(`        ✗ ${v}`);
+  }
+  console.log('');
+}
+
+if (failed) {
+  console.error(`server-graph-singletons: ${failed} violation(s) — FAIL`);
+  process.exit(1);
+}
+console.log('server-graph-singletons: PASS');
+process.exit(0);

--- a/scripts/check-server-graph-singletons.mjs
+++ b/scripts/check-server-graph-singletons.mjs
@@ -162,7 +162,9 @@ for (const entry of WATCHLIST) {
   } else if (entry.rule === 'SINGLETON') {
     if (copies.length > 1) {
       result.violations.push(
-        `emitted ${copies.length} times, expected exactly 1. ${entry.why}\n    copies: ${copies.slice(0, 10).join(', ')}${copies.length > 10 ? `, +${copies.length - 10} more` : ''}`
+        `emitted ${copies.length} times, expected exactly 1. ${entry.why}\n    copies: ${copies
+          .slice(0, 10)
+          .join(', ')}${copies.length > 10 ? `, +${copies.length - 10} more` : ''}`
       );
     }
   } else if (entry.rule === 'SHARED_STATE') {
@@ -170,7 +172,13 @@ for (const entry of WATCHLIST) {
     result.pinned = copies.length - unpinned.length;
     if (unpinned.length > 0) {
       result.violations.push(
-        `${unpinned.length} of ${copies.length} emitted copies do NOT reference \`globalThis.${entry.globalKey}\`, so each of those holds PRIVATE module-scope state. ${entry.why}\n    unpinned copies: ${unpinned.slice(0, 10).join(', ')}${unpinned.length > 10 ? `, +${unpinned.length - 10} more` : ''}`
+        `${unpinned.length} of ${copies.length} emitted copies do NOT reference \`globalThis.${
+          entry.globalKey
+        }\`, so each of those holds PRIVATE module-scope state. ${
+          entry.why
+        }\n    unpinned copies: ${unpinned.slice(0, 10).join(', ')}${
+          unpinned.length > 10 ? `, +${unpinned.length - 10} more` : ''
+        }`
       );
     }
   } else {
@@ -186,12 +194,16 @@ if (AS_JSON) {
   console.log(JSON.stringify({ serverDir: SERVER_DIR, maps: mapFiles.length, results }, null, 2));
 } else {
   console.log('===== server-graph module identity =====');
-  console.log(`scanned ${chunkSources.size} emitted chunks (${mapFiles.length} source maps) under ${SERVER_DIR}`);
+  console.log(
+    `scanned ${chunkSources.size} emitted chunks (${mapFiles.length} source maps) under ${SERVER_DIR}`
+  );
   console.log('');
   for (const r of results) {
     const detail =
       r.rule === 'SHARED_STATE'
-        ? `${r.copies} emitted cop${r.copies === 1 ? 'y' : 'ies'}, ${r.pinned ?? 0} referencing globalThis.${r.globalKey}`
+        ? `${r.copies} emitted cop${r.copies === 1 ? 'y' : 'ies'}, ${
+            r.pinned ?? 0
+          } referencing globalThis.${r.globalKey}`
         : `${r.copies} emitted cop${r.copies === 1 ? 'y' : 'ies'}`;
     console.log(`  ${r.violations.length ? 'FAIL' : ' OK '}  ${r.rule.padEnd(12)} ${r.module}`);
     console.log(`        ${detail}`);

--- a/src/instrumentation.node.ts
+++ b/src/instrumentation.node.ts
@@ -16,7 +16,7 @@ import {
   emitOtelLog,
   registerOtelShutdown,
 } from '@civitai/telemetry/otel-logs';
-import { setStructuredLogSink } from '~/server/logging/client';
+import { setStructuredLogSink } from '~/server/logging/structured-log-sink';
 import { trace } from '@opentelemetry/api';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { registerCpuProfiler, registerEventLoopStallProfiler } from '~/server/cpu-profiler';
@@ -131,6 +131,15 @@ void import('~/server/warmup')
 // module is reachable from the client entry point — importing the bridge there bundles
 // prom-client for the browser and fails the build. This file only ever runs on the
 // server, so it is the correct place for the edge. See the note in that module.
+//
+// 🔴 This call reaches every log call site ONLY because the sink object it mutates lives
+// on `globalThis`. This file is compiled into ONE merged runtime module; the logger shim
+// is compiled into 14 of them. When the sink was a module-scope object in the shim, this
+// single call armed the one copy that happened to be merged alongside this file (which is
+// why `eventloop-longtask`, merged into this same runtime module, was the ONLY call site
+// that ever emitted) and left the other 13 permanently dark. See the header of
+// `~/server/logging/structured-log-sink`, and `scripts/check-server-graph-singletons.mjs`,
+// which fails the build if a copy of that module ever loses the globalThis pin.
 //
 // Unconditional on purpose: `emitOtelLog` is itself gated on OTEL_LOGS_ENABLED (default
 // off), so wiring it here keeps ONE gate rather than two, and its skip counter is then a

--- a/src/server/logging/__tests__/structured-log-sink.test.ts
+++ b/src/server/logging/__tests__/structured-log-sink.test.ts
@@ -1,0 +1,165 @@
+import { createAxiomLogger } from '@civitai/axiom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The seam nobody owned.
+ *
+ * `@civitai/axiom` has its own tests proving `createAxiomLogger` reads `deps.emitLog` per
+ * call, so a sink registered AFTER the logger is built still fires. `@civitai/telemetry`
+ * has its own tests proving `emitOtelLog` hands a record to a registered provider. Both
+ * suites were green, both were audited, and the bridge still delivered 1.3% of records in
+ * production — because the defect was in neither component but in the JOIN between them:
+ * the object the app hands to `createAxiomLogger` was a module-scope `const` in
+ * `~/server/logging/client`, and the bundler emits that module 14 times into one server
+ * build. `setStructuredLogSink()` runs once, at boot, and armed exactly one of them.
+ *
+ * These cases pin the RELATIONSHIP: a registration made through one module instance must
+ * be observable through a DIFFERENT instance of the same module. `vi.resetModules()` is
+ * what makes that expressible — it gives a second, genuinely separate module registry
+ * inside one process that shares one `globalThis`, which is structurally the relationship
+ * the bundler creates between two emitted copies.
+ *
+ * 🔴 What this CANNOT prove is how many copies the bundler actually emits — a test loads a
+ * module as many times as it is told to. That half is gated at build time by
+ * `scripts/check-server-graph-singletons.mjs`, which reads the real emitted source maps.
+ * Neither check subsumes the other: this one pins the invariant, that one pins the fact.
+ *
+ * No `vi.mock` of the logger or the OTel packages anywhere below — a wholesale mock would
+ * make the assertions statements about the mock, and the module under test has no runtime
+ * imports at all, so there is nothing that would need stubbing.
+ */
+
+// The module holds process-wide state on `globalThis` BY DESIGN, so it leaks between test
+// files unless each case starts from a known global. Clearing it here (not just resetting
+// modules) is what makes the `??=` adoption case below meaningful.
+const GLOBAL_KEY = '__civitaiStructuredLogSink' as const;
+type SinkGlobal = typeof globalThis & {
+  [GLOBAL_KEY]?: { emitLog?: (body: string, data: object, ds?: string) => void };
+};
+
+beforeEach(() => {
+  delete (globalThis as SinkGlobal)[GLOBAL_KEY];
+  vi.resetModules();
+});
+
+afterEach(() => {
+  delete (globalThis as SinkGlobal)[GLOBAL_KEY];
+});
+
+/** Load a fresh, genuinely separate instance of the module under test. */
+async function loadInstance() {
+  vi.resetModules();
+  return import('~/server/logging/structured-log-sink');
+}
+
+describe('structuredLogSink — cross-module-instance identity', () => {
+  it('gives two SEPARATE module instances the SAME sink object', async () => {
+    const a = await loadInstance();
+    const b = await loadInstance();
+
+    // Guard the premise: if these were the same module instance the test would pass
+    // trivially and prove nothing about the bug.
+    expect(a).not.toBe(b);
+    expect(a.setStructuredLogSink).not.toBe(b.setStructuredLogSink);
+
+    // ...and yet exactly one sink object, because it comes from globalThis.
+    expect(a.structuredLogSink).toBe(b.structuredLogSink);
+  });
+
+  it('THE REGRESSION: a sink registered via instance A is visible to instance B', async () => {
+    const a = await loadInstance();
+    const b = await loadInstance();
+
+    const emit = vi.fn();
+    a.setStructuredLogSink(emit);
+
+    // With a module-scope `const sink = {}` this reads `undefined` — which is precisely
+    // the production failure: 13 of 14 emitted copies of the logger shim never saw the
+    // boot-time registration.
+    expect(b.structuredLogSink.emitLog).toBe(emit);
+  });
+
+  it('ADOPTS a pre-existing global object rather than replacing it', async () => {
+    // A logger built by an earlier-evaluated copy has already closed over the object that
+    // is on the global. If a later copy assigned a FRESH object, that logger would be
+    // orphaned — the same bug in a different costume. `??=` is what prevents it.
+    const preexisting = { emitLog: vi.fn() };
+    (globalThis as SinkGlobal)[GLOBAL_KEY] = preexisting;
+
+    const a = await loadInstance();
+
+    expect(a.structuredLogSink).toBe(preexisting);
+    expect(a.structuredLogSink.emitLog).toBe(preexisting.emitLog);
+  });
+});
+
+describe('structuredLogSink — composed with the real logger', () => {
+  // The end-to-end shape of the production bug, with a REAL createAxiomLogger (no mock):
+  // register through one module instance, log through a logger built from another.
+  //
+  // `isProd: true` is required because the structured line (and therefore the injected
+  // sink) is only written on the production branch; the rest is overridden so the logger
+  // never constructs an Axiom client or touches the network.
+  const PROD_NO_AXIOM = {
+    token: undefined,
+    orgId: undefined,
+    datastream: 'test-stream',
+    podName: 'test-pod',
+    logErrorsToStdout: true,
+    isProd: true,
+  };
+
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let stderrLines: string[];
+  beforeEach(() => {
+    // logToAxiom writes the structured line to stderr unconditionally; capture instead of
+    // printing so the suite output stays readable. Capturing (rather than discarding) is
+    // what lets the case below assert that the sink got the SAME string stderr did.
+    stderrLines = [];
+    errorSpy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      stderrLines.push(String(args[0]));
+    });
+  });
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it('a logger built from instance B fires a sink registered through instance A', async () => {
+    const a = await loadInstance();
+    const b = await loadInstance();
+
+    const received: string[] = [];
+    a.setStructuredLogSink((body) => {
+      received.push(body);
+    });
+
+    // Built from B's view of the sink — a different module instance than the registrar.
+    const { logToAxiom } = createAxiomLogger(PROD_NO_AXIOM, b.structuredLogSink);
+    await logToAxiom({ type: 'error', name: 'seam-check' });
+
+    expect(received).toHaveLength(1);
+    // The sink's body is the SAME string the stderr write got — one serialization, N
+    // sinks. Asserting the content (not just the call count) keeps this from passing on a
+    // sink that fires with the wrong payload.
+    expect(received[0]).toContain('"name":"seam-check"');
+    expect(stderrLines).toEqual([received[0]]);
+  });
+
+  it('registration ORDER does not matter: a logger built BEFORE the registration still fires', async () => {
+    const a = await loadInstance();
+    const b = await loadInstance();
+
+    // This is the real boot order: the shim's module-scope `logToAxiom` is constructed
+    // when the module is first evaluated, and `src/instrumentation.node.ts` registers the
+    // OTel sink afterwards.
+    const { logToAxiom } = createAxiomLogger(PROD_NO_AXIOM, b.structuredLogSink);
+
+    const received: string[] = [];
+    a.setStructuredLogSink((body) => {
+      received.push(body);
+    });
+
+    await logToAxiom({ type: 'info', name: 'late-registration' });
+    expect(received).toHaveLength(1);
+  });
+});

--- a/src/server/logging/client.ts
+++ b/src/server/logging/client.ts
@@ -5,7 +5,7 @@
 import { TRPCError } from '@trpc/server';
 import type { TRPC_ERROR_CODE_KEY } from '@trpc/server/rpc';
 import { createAxiomLogger, safeError } from '@civitai/axiom/client';
-import type { AxiomDeps, EmitLog } from '@civitai/axiom/client';
+import { structuredLogSink } from '~/server/logging/structured-log-sink';
 import { env } from '~/env/server';
 
 // The build guard is a Next.js concern, so it lives here in the app shim — not in
@@ -21,23 +21,22 @@ const noopLog = async (_data: MixedObject, _datastream?: string) => {};
 // and both vitest projects all stayed green, because only the bundler walks this edge.
 //
 // So the OTel sink is REGISTERED, not imported: `src/instrumentation.node.ts` (server-only
-// by construction) calls `setStructuredLogSink(emitOtelLog)` at boot. The type import
-// above is erased at compile time and adds no runtime edge.
+// by construction) calls `setStructuredLogSink(emitOtelLog)` at boot. (That import is
+// `~/server/logging/structured-log-sink`, which has no runtime imports of its own, so it
+// adds no edge to the client graph either.)
 //
-// The sink is read per call from this stable object, so registering it after the logger
+// 🔴 The sink object is NOT declared here, and must not be. The bundler emits THIS module
+// 14 times into one server build (measured; see the header of ./structured-log-sink), so a
+// module-scope `const sink = {}` here is 14 separate objects and the single boot-time
+// `setStructuredLogSink()` call reaches exactly one of them — which is precisely the bug
+// that made the OTel bridge deliver 1.3% of records. It is imported from the
+// globalThis-pinned singleton instead, which every copy shares by construction.
+//
+// The sink is read per call from that stable object, so registering it after the logger
 // is built still takes effect. Pinned by a test in @civitai/axiom.
-const sink: AxiomDeps = {};
-
-/**
- * Attach an additional sink for every structured log record. Server-only callers.
- * Additive: it cannot change or break the stderr write or the Axiom dual-write, and a
- * sink that throws is contained by the logger.
- */
-export function setStructuredLogSink(emitLog: EmitLog): void {
-  sink.emitLog = emitLog;
-}
-
-export const logToAxiom = env.IS_BUILD ? noopLog : createAxiomLogger({}, sink).logToAxiom;
+export const logToAxiom = env.IS_BUILD
+  ? noopLog
+  : createAxiomLogger({}, structuredLogSink).logToAxiom;
 export { safeError };
 
 /**

--- a/src/server/logging/structured-log-sink.ts
+++ b/src/server/logging/structured-log-sink.ts
@@ -1,0 +1,71 @@
+// The registration seam between the app's structured logger and any additional sink
+// (today: the OTel logs bridge). It exists as its own module for ONE reason — the object
+// below must be a process-wide singleton, and that is not something a module-scope
+// `const` can give you here.
+//
+// ---------------------------------------------------------------------------
+// 🔴 WHY globalThis, and not a module-scope object
+// ---------------------------------------------------------------------------
+// The bundler emits `src/server/logging/client.ts` MANY times into the server build. It
+// is not one module at runtime: Turbopack merges source modules into larger runtime
+// modules, and `logging/client.ts` is inlined into every merged module that reaches it.
+// Measured on a production build of this repo (`next build`, reading the emitted server
+// source maps): **14 distinct emitted copies** — 7 under `.next/server/chunks/` and 7
+// under `.next/server/chunks/ssr/`.
+//
+// Each copy carries its own top-level bindings, so a module-scope `const sink = {}` is
+// FOURTEEN independent objects, and `setStructuredLogSink()` — called once, from
+// `src/instrumentation.node.ts` at boot — mutates exactly one of them. Every log call
+// resolved through any other copy sees a permanently empty sink: no error, no counter, no
+// symptom other than the records not being there.
+//
+// That is not a hypothesis. It is what the first production window of the bridge
+// measured: `eventloop-longtask` — the one call site the build merges into the SAME
+// runtime module as `instrumentation.node.ts` — delivered 8 of 8 records, while every
+// other call site delivered 0. Same `emitOtelLog` function, same registered provider,
+// different `sink` object.
+//
+// `globalThis` is the one thing all of those copies genuinely share: it is the real V8
+// global of the single Node process, so it is indifferent to how the bundler splits,
+// merges or duplicates modules. The same reasoning (and the same idiom) is why
+// `__civitaiInstrumentationRegistry` exists in `@civitai/telemetry`'s prom helpers, and
+// why `global.collectMetricsInitialized` guards the default-metrics collector — this is
+// the established cross-graph pattern in this codebase, not a new trick.
+//
+// ---------------------------------------------------------------------------
+// Why this is a separate file from `./client`
+// ---------------------------------------------------------------------------
+// `./client` is reachable from the CLIENT bundle (`src/pages/_app.tsx` → system-cache →
+// fail-open-log → here), so it must stay free of server-only imports. This module has NO
+// runtime imports at all — the `AxiomDeps`/`EmitLog` imports are `import type`, erased at
+// compile time — so it adds no edge to any graph, and `src/instrumentation.node.ts` can
+// depend on it without dragging `./client`'s dependencies anywhere new.
+import type { AxiomDeps, EmitLog } from '@civitai/axiom/client';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __civitaiStructuredLogSink: AxiomDeps | undefined;
+}
+
+/**
+ * The ONE `AxiomDeps` object handed to `createAxiomLogger`, shared by every emitted copy
+ * of the logger shim in the process.
+ *
+ * `??=` rather than a plain assignment: the second (third, fourteenth) copy of this
+ * module to evaluate must ADOPT the existing object, not replace it — replacing it would
+ * orphan the logger instances that already closed over the previous one, which is the
+ * original bug wearing a different hat.
+ */
+export const structuredLogSink: AxiomDeps = (globalThis.__civitaiStructuredLogSink ??= {});
+
+/**
+ * Attach an additional sink for every structured log record. Server-only callers.
+ *
+ * Additive: it cannot change or break the stderr write or the Axiom dual-write, and a
+ * sink that throws is contained by the logger. Mutates the shared object in place — the
+ * logger reads `deps.emitLog` per call, so registering after the logger is built still
+ * takes effect (pinned by a test in `@civitai/axiom`).
+ */
+export function setStructuredLogSink(emitLog: EmitLog): void {
+  structuredLogSink.emitLog = emitLog;
+}


### PR DESCRIPTION
## What shipped broken

#3736 added an OTel logs bridge at the single `logToAxiom` chokepoint. Enabled on one
low-traffic workload, one 5-minute window measured:

| path | records |
|---|---:|
| stderr `_axiom` write (pre-existing, unchanged) | **383** |
| OTel bridge | **5** |

**1.3% delivery**, and reconciling by event name shows it is not a sampling loss — it is a
clean partition:

- `eventloop-longtask`: **8 via the bridge, 8 via stderr**, bodies byte-identical.
- `model-file-scan` (66), `scan-files-fallback` (66), `resource-training-v2-cron` (19),
  `Notification cursor stale` (12) and ~984 unnamed records: **stderr only, zero bridged**.

`eventloop-longtask` is registered from `src/instrumentation.node.ts` — the same module
that constructs the `LoggerProvider` and calls `setStructuredLogSink()`. Call sites
co-located with the registration worked; every other call site was a permanent, silent
no-op.

The counters #3736 added specifically to make this legible — `otel_log_records_emitted_total`,
`otel_log_records_skipped_total` — **were not exposed either**. A live `/metrics` returned
HTTP 200 with 1,758 lines, 90 of them `nodejs_*` (so the endpoint and scrape were healthy)
and **zero** `otel_log*` series. The instrument built to detect the failure had the same
failure.

## Diagnosis

Both problems are one mechanism: **a module's top-level state is per *runtime* module, and
the bundler decides how many runtime modules a source file becomes.**

Measured by building this repo and reading the emitted server source maps (`sources`
attributes emitted code back to source modules; Turbopack's numeric module ids cannot):

| module | emitted copies in `.next/server` |
|---|---:|
| `src/server/logging/client.ts` | **14** (7 under `chunks/`, 7 under `chunks/ssr/`) |
| `packages/civitai-telemetry/src/otel-logs.ts` | **1** |
| `@opentelemetry/api-logs` | **0** (not bundled at all) |

`logging/client.ts` held the sink as a module-scope `const sink: AxiomDeps = {}`. Fourteen
emitted copies means fourteen independent objects; `setStructuredLogSink()` runs **once**,
at boot, from the instrumentation entry, and armed exactly one of them.

Which one is also measurable, and it matches the production split exactly. One merged
runtime module (`chunks/[root-of-the-server]__0lu0oox._.js`, 184 inlined sources) contains
`src/instrumentation.node.ts`, `src/server/eventloop-longtask.ts` **and** the only copy of
`otel-logs.ts`. `eventloop-longtask` resolves the logger shim through the same import
binding as the registrar, so it got the armed copy. Nothing else did.

The counters are the same story one layer down: they were registered on prom-client's
**default** registry from the instrumentation graph, while `/api/metrics` scrapes the
request graph's default registry. This repo already hit this exact trap (PR #2451) and
already carries the cure — `instrumentationRegistry`, pinned on `globalThis`, which
`src/pages/api/metrics.ts` merges into every scrape. `otel-logs.ts` simply did not use it.

### On #3736's timing-vs-identity call

It was wrong, and interestingly so. Its premise checks out: every installed `api-logs`
copy does share the `Symbol.for('io.opentelemetry.js.api.logs')` key and
`API_BACKWARDS_COMPATIBILITY_VERSION = 1` (verified in the installed sources). Its
conclusion does not.

- **The premise is idle.** `@opentelemetry/api-logs` is not bundled at all — Next
  externalizes node_modules for the server build, and the emitted maps contain zero copies
  of it. There is one instance, from the require cache. Adding it to
  `serverExternalPackages` would change nothing, so that deferred follow-up is moot for
  this bug. **This PR does not touch `serverExternalPackages`.**
- **Hypothesis (c) — a cached dead ProxyLogger — is refuted by the observation itself.**
  There is only one copy of `emitOtelLog` in the whole build, so the working and
  non-working call sites ran the *same* closure with the *same* `cachedLogger`. A dead
  logger would have broken both.
- **It was an identity problem — of the app's own shim**, not of any OTel package. Both
  of #3736's hypotheses were about the wrong module.

The lazy per-emit bind #3736 added is still correct and is kept; it just was not
sufficient, and could not have been.

## The fix

1. **`src/server/logging/structured-log-sink.ts` (new)** — the sink object, pinned on
   `globalThis` via `??=`, which is the one thing all emitted copies share. `??=` rather
   than `=` so a later-evaluated copy *adopts* the object instead of orphaning loggers that
   already closed over it. The module has no runtime imports (its `AxiomDeps`/`EmitLog`
   imports are `import type`), so it adds no edge to any graph — including the client
   graph that `logging/client.ts` is reachable from, which is what broke the original
   build attempt.
2. **`otel-logs.ts` counters** move to `registerInstrumentationMetric(...)` with
   `registers: [instrumentationRegistry]` — the established cross-graph pattern here.
   Series names are unchanged (`civitai_app_otel_log_records_{emitted,skipped}_total`).

No bundler config change, so there is no risk of reintroducing the client-bundle
resolution failure (`cluster`/`fs`/`v8`) that forced the original revert.

**Unchanged, deliberately:** the stderr `_axiom` write, the Axiom ingest path, and
`OTEL_LOGS_ENABLED`'s default. Both sinks still coexist; the ramp stays operator-controlled
in config.

## The build gate

`scripts/check-server-graph-singletons.mjs`, wired into the Dockerfile builder stage
(hard gate, unlike the report-only bundle budget). It reads the emitted server source maps
and enforces two rules:

- `SHARED_STATE` — every emitted copy of a module must reference its `globalThis` key.
- `SINGLETON` — `otel-logs.ts` must be emitted exactly once (a second copy would be a
  second bridge that never sees the provider registration).

Both rules **fail** when they match nothing, and the script exits **2** (not 0) when it
finds no source maps — a scan that can see nothing must never report health.

This class is structurally invisible to everything else we run: `tsc` checks one source
file, ESLint reads source, and Vitest loads a module once, so a module-scope singleton
looks like a singleton everywhere except in the emitted output.

**Watched red before trusted green**, on real build output:

```
# pre-fix build, gate pointed at the module that actually held the defect
FAIL  SHARED_STATE src/server/logging/client.ts
      14 emitted copies, 0 referencing globalThis.__civitaiStructuredLogSink
      ✗ 14 of 14 emitted copies do NOT reference `globalThis....`
```
```
# full build of this branch
 OK   SHARED_STATE src/server/logging/structured-log-sink.ts
      11 emitted copies, 11 referencing globalThis.__civitaiStructuredLogSink
 OK   SINGLETON    packages/civitai-telemetry/src/otel-logs.ts
      1 emitted copy
```

Plus a real rebuild with the pin removed (see the comment below) and 7 fixture-driven unit
cases covering each failure branch separately.

## Tests

No `vi.mock` of the OTel or prom packages anywhere — the SDKs expose everything needed to
run this for real.

- `src/server/logging/__tests__/structured-log-sink.test.ts` (5) — the seam. Two genuinely
  separate module instances (`vi.resetModules()`) sharing one `globalThis`, which is
  structurally the relationship the bundler creates between two emitted copies. Registering
  through instance A must be observable through instance B, including composed with a real
  `createAxiomLogger`. Killing mutation (revert to a module-scope object): **all 5 fail**,
  each with its own message — the headline one is `expected undefined to be [Function Mock]`,
  which is the production failure exactly.
- `packages/civitai-telemetry/src/__tests__/otel-logs-metrics.test.ts` (4) — *which*
  registry, not arithmetic. Killing mutation (counters back on the default registry):
  **3 of 4 fail**, distinctly (`expected undefined to be Counter`, `expected Counter to be
  undefined`, and the positive control finding an empty scrape). The 4th is a naming
  invariant and correctly survives — it is not regression coverage and is not counted as
  such. Notably the pre-existing 24 bridge tests stay **green** under that mutation, which
  is precisely why this needed a new instrument rather than a new assertion.
- `scripts/__tests__/check-server-graph-singletons.test.ts` (7) — the gate's own negative
  controls: unpinned copy, multiple unpinned copies, watched module absent, singleton
  duplicated, no source maps (exit 2), no build output (exit 2), plus a positive control
  that it can pass at all.

## Not verified here

- **Runtime counter values.** The build and boot are verified; `emitted ≈ logToAxiom call
  rate` and `skipped{reason="no_provider"} ≈ 0` can only be read from a running deployment
  with the flag on. That is the acceptance check to run after this reaches an environment
  with the bridge enabled.
- **Production timing.** Production deploys from the **`release`** branch, not `main` — so
  merging this does not reach production until a release promotion. The ramp sequencing is
  unaffected by the merge itself.
- One consequence worth expecting: with the sink now reaching every call site,
  `skipped{reason="disabled"}` will count the *full* log rate wherever the flag is off.
  That is intended — it is the live positive control that the wiring exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
