### PR TITLE
docs(blocks): scope the cancel "non-refundable" clause to customComfy

### DIFF
--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -3351,10 +3351,23 @@ export const blocksRouter = router({
         }
       );
       // customComfy post-paid SETTLE (plan §5.3): a mid-run cancel BILLS the
-      // accrued cost (orchestrator-side, non-refundable), so settle refunds the
-      // reserved CEILING down to that accrued `cost.total` on BOTH reservation
-      // keys. Self-scoping + idempotent + best-effort — a txt2img / non-customComfy
-      // cancel has no settle record and no-ops.
+      // accrued cost, and that accrued portion is non-refundable — post-billing
+      // handlers recompute the authoritative cost from measured RUNTIME, so the
+      // orchestrator exempts them from the blob-delivery proration below
+      // (WorkflowStepManager.GetUndeliveredFractionAsync) to avoid double-refunding.
+      // Settle therefore refunds the reserved CEILING down to that accrued
+      // `cost.total` on BOTH reservation keys. Self-scoping + idempotent +
+      // best-effort — a txt2img / non-customComfy cancel has no settle record and
+      // no-ops here.
+      //
+      // 🔴 DO NOT QUOTE THE "non-refundable" CLAUSE AS A GENERAL CANCEL RULE.
+      // It scopes to customComfy post-paid only. A NON-customComfy cancel IS
+      // prorated by the orchestrator: the workflow is re-priced by the share of
+      // each job's output blobs that never landed and the difference is refunded
+      // (a job that delivered nothing refunds in full). civitai/cli read this
+      // comment as universal and shipped "cancel does not undo the charge" to
+      // users for months — wrong, and wrong in the direction that costs them.
+      // Retracted in civitai/cli#336; see civitai/cli#307 for the trace.
       await settleCustomComfySpend({
         workflowId: input.workflowId,
         actualCost: snapshot.cost?.total ?? 0,


### PR DESCRIPTION
The comment on the customComfy post-paid settle path (`blocks.router.ts`) says a mid-run cancel *"BILLS the accrued cost (orchestrator-side, non-refundable)"*.

**That is correct for customComfy**, and the comment already scoped itself on its first line (`customComfy post-paid SETTLE`) and its last (`a txt2img / non-customComfy cancel has no settle record and no-ops`). This is not a correctness fix.

**But the middle clause reads as a general statement about cancelling, and it was quoted as one.** `civitai/cli` lifted it out of scope and shipped *"cancel does not undo the charge"* to users — wrong, and wrong in the direction that costs them.

## What actually happens on a non-customComfy cancel

The orchestrator prorates. `WorkflowStepManager.cs:470-509` does `cost -= job.Cost * undeliveredFraction`, where `GetUndeliveredFractionAsync` (`:641-663`) is `(expected blobs − delivered) / expected` and returns `1.0` when the blob set is unknown. The workflow is then re-priced and the difference refunded via `WorkflowGrain.EnsureCorrectBuzzChargedAsync` → `RefundChargedBuzzAsync` (`:308-377`), as `TransactionType.Refund`. A job that delivered nothing refunds in full.

## Why customComfy is genuinely exempt

From the orchestrator's own comment at `WorkflowStepManager.cs:475-476`: post-billing handlers recompute the authoritative cost from measured **runtime**, so applying blob-delivery proration on top would **double-refund**. The accrued runtime cost is billed and not refunded; `settle` refunds the reserved ceiling down to it. Exactly what this code does.

## Change

Comment-only. Adds the *why* behind the exemption and marks the clause customComfy-only so the next reader cannot repeat the generalisation.

- No behaviour change — diff is comment lines only
- `prettier --check` clean on the file (validated with a positive control: a deliberately misformatted file reports `rc=1`, this file `rc=0`)
- A second settle comment at `blocks.router.ts:3230` was checked and left alone — it carries no "non-refundable" claim and is correctly scoped already

Retracted CLI-side in civitai/cli#336; orchestrator trace in civitai/cli#307.