### PR TITLE
fix(memberships): block perks-only purchase when any membership is ac…

### DIFF
--- a/src/components/Stripe/memberships.util.ts
+++ b/src/components/Stripe/memberships.util.ts
@@ -8,7 +8,19 @@ import { trpc } from '~/utils/trpc';
 import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
 import { usePaymentProvider } from '~/components/Payments/usePaymentProvider';
 import { useAvailableBuzz } from '~/components/Buzz/useAvailableBuzz';
-import { BUZZ_MEMBERSHIP_SUBSCRIPTION_TYPE } from '~/shared/utils/buzz-membership';
+import {
+  BUZZ_MEMBERSHIP_SUBSCRIPTION_TYPE,
+  isMembershipActive,
+} from '~/shared/utils/buzz-membership';
+import type { AllUserSubscriptions } from '~/server/services/subscriptions.service';
+
+// getAllUserSubscriptions leaves product.metadata as raw JSON and exposes the parsed copy as
+// productMeta; getUserSubscription puts the parsed copy on product.metadata. Reshape so
+// consumers read parsed metadata regardless of which query answered.
+const withParsedProductMeta = (subscription: AllUserSubscriptions[number]) => ({
+  ...subscription,
+  product: { ...subscription.product, metadata: subscription.productMeta },
+});
 
 export const useActiveSubscription = ({
   checkWhenInBadState,
@@ -59,17 +71,8 @@ export const useActiveSubscription = ({
     ? allSubscriptions?.find((s) => s.buzzType === BUZZ_MEMBERSHIP_SUBSCRIPTION_TYPE)
     : undefined;
 
-  // getAllUserSubscriptions leaves product.metadata as raw JSON and exposes the parsed copy
-  // as productMeta; getUserSubscription puts the parsed copy on product.metadata. Reshape so
-  // consumers of this hook read parsed metadata regardless of which query answered.
   const activeSubscription =
-    subscription ??
-    (buzzMembership
-      ? {
-          ...buzzMembership,
-          product: { ...buzzMembership.product, metadata: buzzMembership.productMeta },
-        }
-      : null);
+    subscription ?? (buzzMembership ? withParsedProductMeta(buzzMembership) : null);
 
   const meta = activeSubscription?.product?.metadata as SubscriptionProductMetadata;
 
@@ -85,6 +88,38 @@ export const useActiveSubscription = ({
     isFreeTier: (meta?.tier ?? currentUser?.tier ?? 'free') === 'free',
     tier: meta?.tier ?? currentUser?.tier ?? 'free',
     meta,
+  };
+};
+
+/**
+ * The membership the user currently holds in ANY slot — every colour plus the perks one.
+ * `useActiveSubscription` reads a single colour slot (plus an opt-in perks fallback), so on
+ * green it answers "no membership" for someone holding a yellow one. Use this where the
+ * question is "does this user hold a membership at all", such as gating a perks purchase.
+ */
+export const useAnyActiveMembership = () => {
+  const currentUser = useCurrentUser();
+  const { data, isLoading, isFetching } = trpc.subscriptions.getAllUserSubscriptions.useQuery(
+    undefined,
+    { enabled: !!currentUser }
+  );
+
+  const active = (data ?? []).filter((s) => isMembershipActive(s));
+  // Green and yellow can both be active at once, and a perks purchase has to wait out the
+  // LAST of them, so the latest expiry is the one worth reporting. The perks row wins when
+  // present: nothing else can be active alongside it, and picking it lets the card the user
+  // already holds read as theirs rather than as a blocked purchase.
+  const subscription =
+    active.find((s) => s.buzzType === BUZZ_MEMBERSHIP_SUBSCRIPTION_TYPE) ??
+    active.reduce<(typeof active)[number] | undefined>(
+      (latest, current) =>
+        !latest || current.currentPeriodEnd > latest.currentPeriodEnd ? current : latest,
+      undefined
+    );
+
+  return {
+    subscription: subscription ? withParsedProductMeta(subscription) : null,
+    subscriptionLoading: !currentUser ? false : isLoading || isFetching,
   };
 };
 

--- a/src/components/Subscriptions/PlanCard.tsx
+++ b/src/components/Subscriptions/PlanCard.tsx
@@ -19,7 +19,7 @@ import type { SubscriptionPlan, UserSubscription } from '~/server/services/subsc
 import { capitalize, getStripeCurrencyDisplay } from '~/utils/string-helpers';
 import { getPlanDetails } from '~/components/Subscriptions/getPlanDetails';
 import { PaymentProvider } from '~/shared/utils/prisma/enums';
-import { getBuzzMembershipPrice } from '~/shared/utils/buzz-membership';
+import { getBuzzMembershipPrice, isMembershipActive } from '~/shared/utils/buzz-membership';
 import { numberWithCommas } from '~/utils/number-helpers';
 import Router from 'next/router';
 import { BuzzTransactionButton } from '~/components/Buzz/BuzzTransactionButton';
@@ -56,6 +56,14 @@ export function PlanCard({ product, subscription }: PlanCardProps) {
   const meta = (product.metadata ?? {}) as SubscriptionProductMetadata;
   const subscriptionMeta = (subscription?.product.metadata ?? {}) as SubscriptionProductMetadata;
   const isBuzzPurchase = !!meta.buzzPurchase;
+  // Green and yellow memberships can be held at the same time; a Buzz-purchased one cannot
+  // live alongside either. So holding any membership blocks the BUZZ card's button and
+  // nothing else — cash cards keep their own upgrade/downgrade rules.
+  //
+  // Not `hasActiveSubscription`, which reads a status: a lapsed row keeps `status = 'active'`
+  // until something reconciles it, and trialing/other non-'active' states are still rejected
+  // by the purchase guard.
+  const buzzPurchaseBlocked = isBuzzPurchase && !!subscription && isMembershipActive(subscription);
   const subscriptionIsBuzzPurchase = !!subscriptionMeta.buzzPurchase;
   // Tier-matching would let a Buzz membership claim the CASH card of the same tier, showing
   // "Manage your Membership" on a plan the user hasn't bought and hiding the upgrade they're
@@ -272,7 +280,7 @@ export function PlanCard({ product, subscription }: PlanCardProps) {
                         </Button>
                       ) : // A disabled Mantine Button still navigates when rendered as an
                       // anchor, so drop the link entirely while a membership is active.
-                      hasActiveSubscription ? (
+                      buzzPurchaseBlocked ? (
                         <Button radius="xl" {...subscribeBtnProps.subscribe} disabled>
                           Membership already active
                         </Button>

--- a/src/pages/pricing/buzz.tsx
+++ b/src/pages/pricing/buzz.tsx
@@ -1,12 +1,15 @@
-import { Alert, Center, Container, Loader, Stack, Text, Title } from '@mantine/core';
+import { Alert, Anchor, Center, Container, Loader, Stack, Text, Title } from '@mantine/core';
 import { IconInfoCircle } from '@tabler/icons-react';
 import { ContainerGrid2 } from '~/components/ContainerGrid/ContainerGrid';
 import { Meta } from '~/components/Meta/Meta';
-import { useActiveSubscription } from '~/components/Stripe/memberships.util';
+import { NextLink as Link } from '~/components/NextLink/NextLink';
+import { useAnyActiveMembership } from '~/components/Stripe/memberships.util';
 import { BuzzMembershipCallout } from '~/components/Subscriptions/BuzzMembershipCallout';
 import { PlanCard } from '~/components/Subscriptions/PlanCard';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
+import { formatDate } from '~/utils/date-helpers';
 import { getLoginLink } from '~/utils/login-helpers';
+import { capitalize } from '~/utils/string-helpers';
 import { trpc } from '~/utils/trpc';
 
 export const getServerSideProps = createServerSideProps({
@@ -32,10 +35,18 @@ export default function BuzzMembershipPurchasePage() {
     paymentProvider: 'Civitai',
   });
 
-  const { subscription } = useActiveSubscription({
-    checkWhenInBadState: true,
-    includeBuzzPurchase: true,
-  });
+  // Every slot, not just this site's colour: a perks membership requires no membership at
+  // all, so a yellow one held while browsing green has to block the purchase here the same
+  // way the server guard blocks it.
+  const { subscription, subscriptionLoading } = useAnyActiveMembership();
+  const heldMembership = subscription
+    ? [
+        capitalize(subscription.productMeta.tier ?? ''),
+        subscription.productMeta.buzzPurchase ? 'perks membership' : 'membership',
+      ]
+        .filter(Boolean)
+        .join(' ')
+    : null;
 
   return (
     <>
@@ -53,7 +64,20 @@ export default function BuzzMembershipPurchasePage() {
 
           <BuzzMembershipCallout />
 
-          {isLoading ? (
+          {subscription && (
+            <Alert color="yellow" icon={<IconInfoCircle size={20} />}>
+              <Text size="sm">
+                Your {heldMembership} runs through {formatDate(subscription.currentPeriodEnd)}. A
+                perks membership can only be bought with no membership active — including one held
+                on the other site — so you can buy one once this lapses.{' '}
+                <Anchor component={Link} href="/user/membership">
+                  Manage your membership
+                </Anchor>
+              </Text>
+            </Alert>
+          )}
+
+          {isLoading || subscriptionLoading ? (
             <Center p="xl">
               <Loader />
             </Center>

--- a/src/server/services/subscriptions.service.ts
+++ b/src/server/services/subscriptions.service.ts
@@ -30,6 +30,7 @@ import {
 import {
   BUZZ_MEMBERSHIP_SUBSCRIPTION_TYPE,
   getBuzzMembershipPrice,
+  isMembershipActive,
 } from '~/shared/utils/buzz-membership';
 
 // const baseUrl = getBaseUrl();
@@ -532,7 +533,7 @@ export const purchaseMembershipWithBuzz = async ({
     throw new Error('Memberships can only be purchased with Green or Yellow Buzz');
 
   const existing = await getAllUserSubscriptions(userId);
-  if (existing.some((s) => !s.isBadState && s.currentPeriodEnd > new Date()))
+  if (existing.some((s) => isMembershipActive(s)))
     throw new Error(
       'You already have an active membership. Let it lapse before purchasing one with Buzz.'
     );

--- a/src/shared/utils/__tests__/buzz-membership.test.ts
+++ b/src/shared/utils/__tests__/buzz-membership.test.ts
@@ -3,6 +3,7 @@ import {
   BUZZ_MEMBERSHIP_SUBSCRIPTION_TYPE,
   getBuzzMembershipPrice,
   getSubscriptionDisplayBuzzType,
+  isMembershipActive,
 } from '~/shared/utils/buzz-membership';
 import { getBuzzCurrencyConfig } from '~/shared/constants/currency.constants';
 import { buzzAccountTypes } from '~/shared/constants/buzz.constants';
@@ -34,6 +35,28 @@ describe('getBuzzMembershipPrice', () => {
     expect(getBuzzMembershipPrice({ unitAmount: 1000 })).toBe(12_500); // bronze $10
     expect(getBuzzMembershipPrice({ unitAmount: 2500 })).toBe(31_250); // silver $25
     expect(getBuzzMembershipPrice({ unitAmount: 5000 })).toBe(62_500); // gold $50
+  });
+});
+
+describe('isMembershipActive', () => {
+  const now = new Date('2026-08-10T00:00:00Z');
+  const future = new Date('2026-09-10T00:00:00Z');
+  const past = new Date('2026-07-10T00:00:00Z');
+
+  it('holds while the paid-for period is still running', () => {
+    expect(isMembershipActive({ isBadState: false, currentPeriodEnd: future }, now)).toBe(true);
+  });
+
+  it('lapses once the period ends', () => {
+    expect(isMembershipActive({ isBadState: false, currentPeriodEnd: past }, now)).toBe(false);
+  });
+
+  it('does not count a subscription in a bad state', () => {
+    expect(isMembershipActive({ isBadState: true, currentPeriodEnd: future }, now)).toBe(false);
+  });
+
+  it('treats a missing bad-state flag as good standing', () => {
+    expect(isMembershipActive({ currentPeriodEnd: future }, now)).toBe(true);
   });
 });
 

--- a/src/shared/utils/buzz-membership.ts
+++ b/src/shared/utils/buzz-membership.ts
@@ -17,6 +17,21 @@ export const BUZZ_MEMBERSHIP_PREMIUM_MULTIPLIER = 1.25;
  */
 export const BUZZ_MEMBERSHIP_SUBSCRIPTION_TYPE = 'buzzPurchase';
 
+type MembershipStanding = {
+  isBadState?: boolean;
+  currentPeriodEnd: Date;
+};
+
+/**
+ * Whether a subscription row still grants perks, and so blocks buying a perks-only
+ * membership with Buzz. Shared with the client because the purchase page has to answer the
+ * same question the purchase guard does, and a row's status alone doesn't answer it — a
+ * lapsed row keeps `status = 'active'` until something reconciles it.
+ */
+export function isMembershipActive(subscription: MembershipStanding, now = new Date()) {
+  return !subscription.isBadState && subscription.currentPeriodEnd > now;
+}
+
 type BuzzMembershipPriceInput = {
   /** Price amount in the smallest currency unit (cents), as stored on `Price.unitAmount`. */
   unitAmount: number;


### PR DESCRIPTION
…tive

Perks-only memberships require no active membership in any slot, but the buzz pricing page and plan card only checked the current site's colour, so a user on green holding a yellow membership saw a live purchase button and hit the server guard. Added `useAnyActiveMembership` plus a shared `isMembershipActive` helper (used by the client and the purchase guard), and the page now explains which membership is blocking the purchase and when it lapses.