### PR TITLE
chore(renovate): gate major updates behind dependency-dashboard approval

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,10 @@
   "extends": ["config:recommended", "docker:pinDigests"],
   "enabledManagers": ["dockerfile", "nvm"],
   "schedule": ["before 6am on monday"],
+  "major": {
+    "description": "A major bump is never opened unasked. Majors stay VISIBLE on the Dependency Dashboard (issue #3789) with an unticked checkbox, and a branch/PR is only created once a human ticks it. Digest pins and patch/minor updates are unaffected and keep flowing automatically — they are separate updateTypes. Motivation: the first scheduled run queued three majors at once, one of which (node v24) rewrites the base image of every service under apps/ plus containers/image-stub in a single PR.",
+    "dependencyDashboardApproval": true
+  },
   "packageRules": [
     {
       "description": "Keep the root Dockerfile's node tag and .nvmrc in ONE pull request. src/__tests__/node-version-consistency.test.ts asserts the two agree, so a bump that moves only one of them reds that guard. Scoped to the two files that guard actually reads: the per-service images under apps/ and containers/ are on their own cadence and must not be dragged into this group.",


### PR DESCRIPTION
Adds four lines to `renovate.json` so a **major** update never opens a PR unasked.

```json
"major": {
  "dependencyDashboardApproval": true
}
```

## Why now

Renovate's schedule (`before 6am on monday`) next fires **Monday 2026-08-17**. Three major bumps are already queued on the Dependency Dashboard (#3789) and would all open PRs on that run:

| Branch | Update |
|---|---|
| `renovate/node-24.x` | Node.js → **v24** |
| `renovate/postgres-18.x` | `postgres` → **v18** |
| `renovate/clickhouse-clickhouse-server-26.x` | `clickhouse/clickhouse-server` → **v26** |

`renovate/node-24.x` is the one that motivated this. It moves every service under `apps/` off `node:22-alpine` plus `containers/image-stub/Dockerfile` off `node:20-bookworm` — **eight Dockerfiles, seven of them production services** — in a single PR titled "Update Node.js to v24". A cross-major runtime bump of that blast radius should be a deliberate, scheduled piece of work that someone is watching, not something that lands over a weekend.

It also matters that our unit-test CI job currently cannot fail a check, so a green tick on a PR like that would not mean the suite passed. Until that is fixed, an unattended major merge has less of a safety net than it looks like it has.

## What changes

**Gated** — majors only. They stay fully visible on #3789, moved into a new **Pending Approval** section, each with an unticked checkbox. Nothing is hidden or dropped.

**Still automatic — unchanged:**

- digest pins (`renovate/node-runtime-pin`, the grouped root `Dockerfile` + `.nvmrc` rule)
- version pins (`renovate/pin-dependencies`)
- minor and patch updates (e.g. `renovate/clickhouse-clickhouse-server-24.x` → v24.12.6)

The nested `major` key is applied per-`updateType`, so `pin`, `pinDigest`, `minor` and `patch` are untouched. This is a policy change only — manager, file and dependency counts are identical before and after (2 managers, 14 files, 22 deps).

## How to opt a major in

Tick its checkbox on **#3789** under *Pending Approval*:

```
- [ ] Update Node.js to v24
```

Renovate creates the branch and PR on its next run. There is also a *Create all pending approval PRs at once* checkbox. Nothing else is needed — no config edit, and the gate stays in place for future majors.

## Verification

Measured with `renovate --platform=local --dry-run=full` (Renovate 44.22.0), running the real config against the real Dockerfiles, before and after.

Per-branch verdict:

| Branch | updateType | before | after |
|---|---|---|---|
| `renovate/pin-dependencies` | pin | proceeds | proceeds |
| `renovate/node-runtime-pin` | pinDigest | proceeds | proceeds |
| `renovate/clickhouse-clickhouse-server-24.x` | minor | proceeds | proceeds |
| `renovate/clickhouse-clickhouse-server-26.x` | **major** | proceeds | **needs-approval** |
| `renovate/node-24.x` | **major** | proceeds | **needs-approval** |
| `renovate/postgres-18.x` | **major** | proceeds | **needs-approval** |

The rendered Dependency Dashboard diff between the two runs is exactly:

```diff
+## Pending Approval
+
+The following branches are pending approval. To create them, click on a checkbox below.
+
+ - [ ] Update clickhouse/clickhouse-server Docker tag to v26
+ - [ ] Update Node.js to v24
+ - [ ] Update postgres Docker tag to v18
+ - [ ] Create all pending approval PRs at once
```

...with those three titles removed from the would-be-created list and the other three branches untouched.

Also checked:

- `renovate-config-validator --strict` passes. Validated against a deliberately broken config first, which exits 1 and names all three planted faults — including a wrong-typed `major.dependencyDashboardApproval` — so the pass is meaningful.
- Mutation control: swapping the gate to `"minor"` gates *only* the one minor branch and lets all three majors through, confirming the key is matched per-`updateType` rather than catching everything.

Not directly observed: no **patch**-type update happens to be available in the current dependency set, so patch behaviour is inferred from the same per-`updateType` keying that the minor control demonstrates, rather than measured.
