### PR TITLE
fix(collections): gate getPermissionDetails on read permission

### DIFF
--- a/src/server/controllers/__tests__/collection.controller.permission-details.test.ts
+++ b/src/server/controllers/__tests__/collection.controller.permission-details.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as CollectionService from '~/server/services/collection.service';
+
+/**
+ * `collection.getPermissionDetails` is a `protectedProcedure` taking arbitrary ids, so the
+ * handler's own filtering is the only read gate on the name/metadata/mode/tags it returns.
+ */
+
+const { mockCollectionFindMany } = vi.hoisted(() => ({
+  mockCollectionFindMany: vi.fn(),
+}));
+
+const { mockGetUserCollectionPermissionsById } = vi.hoisted(() => ({
+  mockGetUserCollectionPermissionsById: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { collection: { findMany: mockCollectionFindMany } },
+  dbWrite: {},
+}));
+vi.mock('~/server/services/collection.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof CollectionService>()),
+  getUserCollectionPermissionsById: mockGetUserCollectionPermissionsById,
+}));
+
+import { getPermissionDetailsHandler } from '../collection.controller';
+
+function collectionRow(id: number, name: string) {
+  return { id, name, metadata: null, mode: null, tags: [] };
+}
+
+function permissions(collectionId: number, read: boolean) {
+  return {
+    collectionId,
+    read,
+    write: false,
+    writeReview: false,
+    manage: false,
+    follow: false,
+    isContributor: false,
+    isOwner: false,
+    publicCollection: read,
+    followPermissions: [],
+    collectionType: null,
+    collectionMode: null,
+  };
+}
+
+const ctx = { user: { id: 1, isModerator: false } } as never;
+
+describe('getPermissionDetailsHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('omits collections the user cannot read', async () => {
+    mockCollectionFindMany.mockResolvedValue([
+      collectionRow(10, 'public one'),
+      collectionRow(11, "someone else's private one"),
+    ]);
+    mockGetUserCollectionPermissionsById.mockImplementation(async ({ id }: { id: number }) =>
+      permissions(id, id === 10)
+    );
+
+    const result = await getPermissionDetailsHandler({ input: { ids: [10, 11] }, ctx });
+
+    expect(result.map((c) => c.id)).toEqual([10]);
+    expect(JSON.stringify(result)).not.toContain("someone else's private one");
+  });
+
+  it('returns the readable collection with its permissions attached', async () => {
+    mockCollectionFindMany.mockResolvedValue([collectionRow(10, 'public one')]);
+    mockGetUserCollectionPermissionsById.mockResolvedValue(permissions(10, true));
+
+    const result = await getPermissionDetailsHandler({ input: { ids: [10] }, ctx });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('public one');
+    expect(result[0].permissions.read).toBe(true);
+  });
+
+  it('short-circuits an empty id list without touching the db', async () => {
+    const result = await getPermissionDetailsHandler({ input: { ids: [] }, ctx });
+
+    expect(result).toEqual([]);
+    expect(mockCollectionFindMany).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/controllers/collection.controller.ts
+++ b/src/server/controllers/collection.controller.ts
@@ -605,16 +605,22 @@ export const getPermissionDetailsHandler = async ({
       })
     )
   );
+  const permissionsByCollectionId = new Map(permissions.map((p) => [p.collectionId, p]));
 
-  return collections.map((c) => ({
-    ...c,
-    tags: c.tags.map((t) => ({
-      ...t.tag,
-      filterableOnly: t.filterableOnly,
-    })),
-    metadata: (c.metadata ?? {}) as CollectionMetadataSchema,
-    permissions: permissions.find((p) => p.collectionId === c.id),
-  }));
+  return collections.flatMap((c) => {
+    const permission = permissionsByCollectionId.get(c.id);
+    if (!permission?.read) return [];
+
+    return {
+      ...c,
+      tags: c.tags.map((t) => ({
+        ...t.tag,
+        filterableOnly: t.filterableOnly,
+      })),
+      metadata: (c.metadata ?? {}) as CollectionMetadataSchema,
+      permissions: permission,
+    };
+  });
 };
 
 export const removeCollectionItemHandler = async ({


### PR DESCRIPTION
## Problem

`collection.getPermissionDetails` is a `protectedProcedure` that accepts an arbitrary list of collection ids:

```ts
const collections = await dbRead.collection.findMany({
  where: { id: { in: ids } },
  select: { id, name, metadata, mode, tags },
});
```

There is no read gate. Any logged-in user could enumerate collection ids and read back the name, metadata, mode and tags of collections they have no access to — including private ones belonging to other users.

The handler already resolves permissions for every collection in the same request, so the information needed to filter was sitting right there, unused for that purpose.

Predates the collaborative-collections work; found while reviewing #3719 and split out per our scope-isolation rule.

## Fix

Filter the response down to collections whose resolved permission has `read`.

Both consumers key by collection id and already tolerate a missing entry:
- `useCollectionsForPostCreation` — passes ids the user is posting to
- `useCollectionsPermissionsMap` — builds `new Map(data.map((c) => [c.id, c.permissions]))`

`permissions` is now non-optional on the returned rows, since a row is only emitted when its permission record exists. Removing `undefined` from a field's type is safe for readers, so existing optional chaining still compiles — confirmed by a clean `pnpm run typecheck`.

## Tests

New `src/server/controllers/__tests__/collection.controller.permission-details.test.ts`, 3 cases: unreadable collection omitted, readable collection returned with permissions attached, empty id list short-circuits without a db call.

Reverting the fix fails the first case with `expected [ 10, 11 ] to deeply equal [ 10 ]` — verified by writing the test against the unfixed handler before changing it.

## Verification

- `pnpm vitest run --project unit src/server/controllers/__tests__/collection.controller.permission-details.test.ts` — 3 passed
- `pnpm run typecheck` — 0 errors

No migration. No feature flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)