### PR TITLE
fix(collections): request video collection covers as transcoded stills

### DIFF
--- a/src/components/Cards/CollectionCard.browser.test.tsx
+++ b/src/components/Cards/CollectionCard.browser.test.tsx
@@ -1,0 +1,99 @@
+import type { ComponentProps, ReactNode } from 'react';
+import { describe, expect, test, vi } from 'vitest';
+
+// =============================================================================
+// CollectionCard covers — a video cover must be requested as a transcoded still.
+// =============================================================================
+//
+// `ImageCover` pins `type="image"` so the card never mounts EdgeVideo.
+// `getInferredMediaType` returns `options.type` when it is supplied, so that pin
+// also makes `useEdgeUrl`'s `inferredType === 'video' && type === 'image'` branch
+// — the one that would otherwise set `transcode` for us — unreachable. Without an
+// explicit `transcode`, the delivery URL asks the CDN for a video asset as a
+// plain image.
+//
+// EdgeMedia/EdgeImage/getEdgeUrl are REAL here; the assertion is on the emitted
+// `img[src]`. Only the card's non-media surroundings are stubbed.
+
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ id: 1, isModerator: false, filePreferences: {} }),
+}));
+vi.mock('~/providers/BrowserSettingsProvider', () => ({
+  useBrowsingSettings: <T,>(selector: (state: { autoplayGifs: boolean }) => T) =>
+    selector({ autoplayGifs: false }),
+}));
+vi.mock('~/components/ImageGuard/ImageGuard2', () => {
+  function ImageGuard2({ children }: { children: (safe: boolean) => ReactNode }) {
+    return <>{children(true)}</>;
+  }
+  ImageGuard2.BlurToggle = function BlurToggle() {
+    return null;
+  };
+  return { ImageGuard2 };
+});
+vi.mock('~/components/Collections/components/CollectionContextMenu', () => ({
+  CollectionContextMenu: function CollectionContextMenu({ children }: { children: ReactNode }) {
+    return <>{children}</>;
+  },
+}));
+
+import { ImageCover } from './CollectionCard';
+import { renderWithProviders } from '../../../test/component-setup';
+import { MediaType } from '~/shared/utils/prisma/enums';
+import { NsfwLevel } from '~/server/common/enums';
+
+type CoverImage = ComponentProps<typeof ImageCover>['coverImages'][number];
+
+const headerData: ComponentProps<typeof ImageCover>['data'] = {
+  id: 1,
+  userId: 2,
+  type: null,
+  mode: null,
+};
+
+function coverImage(overrides: Partial<CoverImage> = {}): CoverImage {
+  return {
+    id: 10,
+    nsfwLevel: NsfwLevel.PG,
+    url: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    type: MediaType.image,
+    name: 'cover.jpeg',
+    ...overrides,
+  };
+}
+
+// The cover count is fixed by the props, and an <img> never leaves the tree once
+// mounted, so waiting on it is waiting on an absorbing state.
+async function renderedSrcs(ui: React.ReactElement, expected: number) {
+  renderWithProviders(ui);
+  return vi.waitFor(() => {
+    const srcs = Array.from(document.body.querySelectorAll('img')).map(
+      (img) => img.getAttribute('src') ?? ''
+    );
+    expect(srcs).toHaveLength(expected);
+    return srcs;
+  });
+}
+
+describe('CollectionCard covers', () => {
+  test('ImageCover requests a transcoded still for a video cover', async () => {
+    const srcs = await renderedSrcs(
+      <ImageCover
+        data={headerData}
+        coverImages={[coverImage({ type: MediaType.video, name: 'cover.mp4' })]}
+      />,
+      1
+    );
+
+    expect(srcs[0]).toContain('transcode=true');
+  });
+
+  test('ImageCover leaves a still image untranscoded', async () => {
+    const srcs = await renderedSrcs(
+      <ImageCover data={headerData} coverImages={[coverImage()]} />,
+      1
+    );
+
+    expect(srcs[0]).not.toContain('transcode=true');
+  });
+});

--- a/src/components/Cards/CollectionCard.tsx
+++ b/src/components/Cards/CollectionCard.tsx
@@ -14,7 +14,7 @@ import { DEFAULT_EDGE_IMAGE_WIDTH, constants } from '~/server/common/constants';
 import type { NsfwLevel } from '~/server/common/enums';
 import type { ImageMetaProps } from '~/server/schema/image.schema';
 import type { SimpleUser } from '~/server/selectors/user.selector';
-import type { MediaType } from '~/shared/utils/prisma/enums';
+import { MediaType } from '~/shared/utils/prisma/enums';
 import type { CollectionGetInfinite } from '~/types/router';
 import { abbreviateNumber } from '~/utils/number-helpers';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
@@ -187,6 +187,7 @@ export function ImageCover({ data, coverImages }: { data: HeaderData; coverImage
                 <EdgeMedia
                   src={image.url}
                   type="image"
+                  transcode={image.type === MediaType.video}
                   className={cardClasses.image}
                   name={image.name ?? image.id.toString()}
                   alt={


### PR DESCRIPTION
## Problem

`CollectionCard`'s `ImageCover` pins `type="image"` on `EdgeMedia` so the card never mounts `EdgeVideo`. That pin has a second, unintended effect:

```ts
// client-utils/edge-url.ts
export function getInferredMediaType(src, options) {
  return options?.type ?? (videoTypeExtensions.some(...) ? 'video' : 'image');
}
```

`options.type` wins, so `inferredType` is `'image'` too — and this branch in `useEdgeUrl` never runs:

```ts
if (inferredType === 'video' && type === 'image') {
  transcode = true;   // <- the CDN hint that would have saved us
  anim = false;
}
```

Predates the collaborative-collections work; the same bug was found and fixed in the new invite card during #3719 (`CollectionInviteList.tsx:155`), and this is that fix carried back to the shared card. Split out per our scope-isolation rule.

## Measured impact

Same image, same card params, only `transcode` differs (collection 1158581's cover):

| | content-type | bytes | resolves to |
|---|---|---|---|
| without | `video/mp4` | 2,977,754 | `/original` |
| with | `image/jpeg` | 75,651 | `450x<auto>_.webp` |

An `<img>` cannot render an mp4, so today these covers are **blank** — and the browser downloads the full 3 MB original in order to fail with it. With `transcode` it's a 75 KB still that renders. 39x fewer bytes.

How many cards are affected:

- **195 collections** have `Collection.imageId` pointing at an `Image` with `type = 'video'` (the single-cover path).
- **~25% of the mosaic path**: of the 5,000 most recent public collections with `imageId IS NULL`, 896 have accepted image items, and **224 of those have a video among their first 4** — the tiles `ImageCover` renders. A card there can ship up to 4 originals.

## Fix

One line: pass `transcode={image.type === MediaType.video}`, matching the invite card.

**`ImageSrcCover` is deliberately left alone.** An earlier revision of this PR also sniffed the extension there. That was dead code: `coverSrcs` is populated only from `Article.cover` (in `getCollectionCoverImages`, `imageItemImage`/`postItemImage`/`modelItemImage` all feed `image`, and only `articleItemImage` feeds `src`), and all 2,551 non-null `Article.cover` values on prod are extensionless storage keys — so an extension sniff there can never return anything but `'image'`.

## Tests

New `src/components/Cards/CollectionCard.browser.test.tsx`, 2 cases. `EdgeMedia` / `EdgeImage` / `getEdgeUrl` are real — only the card's non-media surroundings are stubbed — so the assertion is on the actual emitted `img[src]`.

Verified the revert fails, and fails legibly: dropping the prop takes the suite to 1 failed / 1 passed with `expected 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/…' to contain 'transcode=true'`. The still-image case is a negative control and stays green, so the failure points at the video path specifically rather than at the render harness.

## Verification

- `pnpm vitest run --project component src/components/Cards/CollectionCard.browser.test.tsx` — 2 passed
- `pnpm run typecheck` — 0 errors
- `pnpm run test:lint-rules` — 215 passed
- `npx eslint` on both changed files — clean apart from a pre-existing unused-`ActionIcon` warning

No migration. No feature flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)