### PR TITLE
fix(app-listings): cap listing asset dimensions on the full-res upload path

### DIFF
--- a/src/server/schema/blocks/app-listing.schema.ts
+++ b/src/server/schema/blocks/app-listing.schema.ts
@@ -65,6 +65,10 @@ export const LISTING_SCREENSHOT_MIN_PX = 320;
  * (`INLINE_ICON_MAX_INPUT_PIXELS`, 16.7 Mpx in `listing-meta.service.ts`), which is
  * the metric that threat actually calls for. Bounding area on the upload path is a
  * known gap, not something this constant covers.
+ *
+ * (8192 is retained because it is the value the OG-pull path already enforced, so
+ * this makes the paths agree. It is ~2× a 4K width, not 4× — 4× is the AREA ratio
+ * against 4096².)
  */
 export const LISTING_ASSET_MAX_DIMENSION_PX = 8192;
 
@@ -82,13 +86,19 @@ export const LISTING_ASSET_MAX_DIMENSION_PX = 8192;
  *
  * 🔴 SCOPE — the attach check is a BACKSTOP, not a chokepoint. Two things it does
  * not cover, so nobody builds on a guarantee that isn't here:
- *   1. `backfillListingAssets` / `migrateBlockScreenshots`
- *      (`app-listing-assets.service.ts`) write listing assets via direct `dbWrite`
- *      calls and never call {@link validateListingImage} at all.
+ *   1. The backfill route, in `app-listing-assets.service.ts`, never calls
+ *      {@link validateListingImage} at all: `backfillListingAssets` writes the
+ *      listing's own rows (`appListingScreenshot.createMany`, `appListing.update`
+ *      of `coverId` / `iconId`) with direct `dbWrite` calls, and the
+ *      `migrateBlockScreenshots` dep it uses creates the backing `Image` rows at
+ *      whatever dimensions the decoder reports.
  *   2. At attach the dimensions are read off the `Image` row, and some creation
- *      paths accept width/height from the client (see the note in
- *      `measure-uploaded-image.ts`) — so for a row this feature did not measure,
- *      the bound is only as honest as the path that made it.
+ *      paths accept width/height from the client — see
+ *      `src/server/utils/stored-image-probe.ts`, which states it outright ("a
+ *      CLIENT CLAIM about bytes the server never looked at"); the sibling note in
+ *      `services/blocks/measure-uploaded-image.ts` draws the consequence. So for a row
+ *      this feature did not measure, the bound is only as honest as the path that
+ *      made it.
  */
 export function listingAssetTooLargeReason(
   subject: string,

--- a/src/server/schema/blocks/app-listing.schema.ts
+++ b/src/server/schema/blocks/app-listing.schema.ts
@@ -54,11 +54,17 @@ export const LISTING_SCREENSHOT_ASPECT_MAX = 2.6;
 export const LISTING_SCREENSHOT_MIN_PX = 320;
 
 /**
- * Absolute upper bound on either side of ANY listing asset. A ceiling (the
- * per-kind checks above only enforce MINIMUMS / aspect) that stops a
- * decompression-bomb / absurd-dimension image (e.g. 100000×100000) from being
- * stored and rendered as store media. 8192px is comfortably above any real store
- * icon/cover/screenshot.
+ * Absolute upper bound on EITHER SIDE of any listing asset. A ceiling (the
+ * per-kind checks above only enforce MINIMUMS / aspect) that keeps an
+ * absurdly-dimensioned image (e.g. 100000×100000) from being stored and rendered
+ * as store media. 8192px is comfortably above any real store icon/cover/screenshot.
+ *
+ * 🔴 It bounds SHAPE, not AREA — do not cite it as the decompression-bomb defence.
+ * 8192×8192 is 67 Mpx and passes this check; so does 8192×4000 (33 Mpx). The
+ * inline-icon ingest path bounds decoded PIXEL COUNT separately
+ * (`INLINE_ICON_MAX_INPUT_PIXELS`, 16.7 Mpx in `listing-meta.service.ts`), which is
+ * the metric that threat actually calls for. Bounding area on the upload path is a
+ * known gap, not something this constant covers.
  */
 export const LISTING_ASSET_MAX_DIMENSION_PX = 8192;
 
@@ -71,10 +77,18 @@ export const LISTING_ASSET_MAX_DIMENSION_PX = 8192;
  * Single-sourced because the bound is applied at more than one layer, and an
  * open-coded copy at each would let them drift: the ingest paths reject early
  * (before the bytes reach `createImage` + the scan pipeline), while
- * {@link validateListingImage} is the gate EVERY asset passes at attach whatever
- * created its `Image` row — the attach gate is ownership-based, so it cannot tell
- * how a row was made, and an ingest-side check alone is bypassable by attaching
- * an image uploaded through some other path.
+ * {@link validateListingImage} re-applies it at attach, which catches rows the
+ * measured ingest paths did not create.
+ *
+ * 🔴 SCOPE — the attach check is a BACKSTOP, not a chokepoint. Two things it does
+ * not cover, so nobody builds on a guarantee that isn't here:
+ *   1. `backfillListingAssets` / `migrateBlockScreenshots`
+ *      (`app-listing-assets.service.ts`) write listing assets via direct `dbWrite`
+ *      calls and never call {@link validateListingImage} at all.
+ *   2. At attach the dimensions are read off the `Image` row, and some creation
+ *      paths accept width/height from the client (see the note in
+ *      `measure-uploaded-image.ts`) — so for a row this feature did not measure,
+ *      the bound is only as honest as the path that made it.
  */
 export function listingAssetTooLargeReason(
   subject: string,
@@ -157,9 +171,11 @@ export function validateListingImage(
   if (!width || !height || width <= 0 || height <= 0) {
     return { ok: false, reason: `${kind} has unknown or non-positive dimensions` };
   }
-  // The ceiling applies to EVERY kind (the per-kind rules below are minimums +
-  // aspect; only `icon` carries its own, tighter, maximum). Checked here rather
-  // than only at ingest because this is the one gate every asset passes.
+  // The ceiling applies to every kind validated here (the per-kind rules below are
+  // minimums + aspect; only `icon` carries its own, tighter, maximum). Checked at
+  // attach as well as at ingest so a row the measured ingest paths did not create
+  // is still bounded — see the SCOPE note on `listingAssetTooLargeReason` for what
+  // this does NOT cover.
   const tooLarge = listingAssetTooLargeReason(kind, width, height);
   if (tooLarge) return { ok: false, reason: tooLarge };
   const aspect = width / height;

--- a/src/server/schema/blocks/app-listing.schema.ts
+++ b/src/server/schema/blocks/app-listing.schema.ts
@@ -54,13 +54,37 @@ export const LISTING_SCREENSHOT_ASPECT_MAX = 2.6;
 export const LISTING_SCREENSHOT_MIN_PX = 320;
 
 /**
- * Absolute upper bound on either side of ANY ingested listing asset. A ceiling
- * (the per-kind checks above only enforce MINIMUMS / aspect) that stops a
- * decompression-bomb / absurd-dimension image (e.g. 100000×100000) from reaching
- * the CF upload + `createImage` scan pipeline on the OG-pull path. 8192px is
- * comfortably above any real store icon/cover/screenshot.
+ * Absolute upper bound on either side of ANY listing asset. A ceiling (the
+ * per-kind checks above only enforce MINIMUMS / aspect) that stops a
+ * decompression-bomb / absurd-dimension image (e.g. 100000×100000) from being
+ * stored and rendered as store media. 8192px is comfortably above any real store
+ * icon/cover/screenshot.
  */
 export const LISTING_ASSET_MAX_DIMENSION_PX = 8192;
+
+/**
+ * The ONE expression of the {@link LISTING_ASSET_MAX_DIMENSION_PX} ceiling:
+ * returns the house-style rejection text naming the bound and the offending side,
+ * or `null` when the image is within it. `subject` is what the message calls the
+ * image ("cover", "That image", …).
+ *
+ * Single-sourced because the bound is applied at more than one layer, and an
+ * open-coded copy at each would let them drift: the ingest paths reject early
+ * (before the bytes reach `createImage` + the scan pipeline), while
+ * {@link validateListingImage} is the gate EVERY asset passes at attach whatever
+ * created its `Image` row — the attach gate is ownership-based, so it cannot tell
+ * how a row was made, and an ingest-side check alone is bypassable by attaching
+ * an image uploaded through some other path.
+ */
+export function listingAssetTooLargeReason(
+  subject: string,
+  width: number,
+  height: number
+): string | null {
+  const maxSide = Math.max(width, height);
+  if (maxSide <= LISTING_ASSET_MAX_DIMENSION_PX) return null;
+  return `${subject} is too large (max ${LISTING_ASSET_MAX_DIMENSION_PX}px per side, got ${maxSide}px)`;
+}
 
 /** Only real raster image MIME types (mirrors E5 SCREENSHOT_EXTENSIONS). */
 export const LISTING_ASSET_ALLOWED_MIME = ['image/png', 'image/jpeg', 'image/webp'] as const;
@@ -133,6 +157,11 @@ export function validateListingImage(
   if (!width || !height || width <= 0 || height <= 0) {
     return { ok: false, reason: `${kind} has unknown or non-positive dimensions` };
   }
+  // The ceiling applies to EVERY kind (the per-kind rules below are minimums +
+  // aspect; only `icon` carries its own, tighter, maximum). Checked here rather
+  // than only at ingest because this is the one gate every asset passes.
+  const tooLarge = listingAssetTooLargeReason(kind, width, height);
+  if (tooLarge) return { ok: false, reason: tooLarge };
   const aspect = width / height;
   if (kind === 'icon') {
     const minSide = Math.min(width, height);

--- a/src/server/services/blocks/__tests__/app-listing-assets.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-assets.service.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  LISTING_ASSET_MAX_DIMENSION_PX,
+  LISTING_ICON_MAX_PX,
   validateListingImage,
   type ListingImageMeta,
 } from '~/server/schema/blocks/app-listing.schema';
@@ -151,6 +153,97 @@ describe('validateListingImage', () => {
   it('skips size/mime checks when those fields are absent (older Image rows)', () => {
     const r = validateListingImage({ type: 'image', width: 512, height: 512 }, 'icon');
     expect(r.ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateListingImage — the per-side CEILING
+// ---------------------------------------------------------------------------
+
+/**
+ * The cover / screenshot rules are MINIMUMS + aspect; before this there was no
+ * maximum on either kind at all, and the attach gate is the one place every asset
+ * passes whatever created its `Image` row (`loadValidatedImage` gates on
+ * ownership, not provenance). So a full-resolution upload far above the ceiling —
+ * a 9000×4000 cover was accepted in production and stored at full size — cleared
+ * every rule that existed.
+ *
+ * The fixtures vary DIMENSIONS ONLY: `sizeBytes` is held at the same small value
+ * on both sides of the boundary, so a byte cap cannot account for either verdict.
+ */
+describe('validateListingImage (LISTING_ASSET_MAX_DIMENSION_PX ceiling)', () => {
+  const base: ListingImageMeta = {
+    type: 'image',
+    width: 512,
+    height: 512,
+    mimeType: 'image/png',
+    // Well under every per-kind byte cap (the tightest is the 1 MiB icon cap), so
+    // no size rule can fire on any fixture below.
+    sizeBytes: 100_000,
+  };
+
+  it('accepts a cover AT the ceiling and rejects one a single pixel over', () => {
+    // Aspect 2.0 and far above the 640px floor either side of the boundary — the
+    // only thing that changes across these two cases is one pixel of width.
+    expect(
+      validateListingImage(
+        { ...base, width: LISTING_ASSET_MAX_DIMENSION_PX, height: 4096 },
+        'cover'
+      )
+    ).toEqual({ ok: true });
+
+    const over = validateListingImage(
+      { ...base, width: LISTING_ASSET_MAX_DIMENSION_PX + 1, height: 4096 },
+      'cover'
+    );
+    expect(over).toEqual({
+      ok: false,
+      reason: `cover is too large (max ${LISTING_ASSET_MAX_DIMENSION_PX}px per side, got ${
+        LISTING_ASSET_MAX_DIMENSION_PX + 1
+      }px)`,
+    });
+  });
+
+  it('rejects the 9000×4000 cover shape that was accepted in production', () => {
+    // Aspect 2.25 (inside 1.3–2.4) and 9000px wide (above the 640px floor): every
+    // pre-existing cover rule passes, so ONLY the ceiling can reject it.
+    const r = validateListingImage({ ...base, width: 9000, height: 4000 }, 'cover');
+    expect(r).toEqual({
+      ok: false,
+      reason: `cover is too large (max ${LISTING_ASSET_MAX_DIMENSION_PX}px per side, got 9000px)`,
+    });
+  });
+
+  it('applies the ceiling to the TALLER side too, not just width', () => {
+    // Aspect 0.55 — a valid screenshot aspect, above the 320px floor, over the
+    // ceiling on height only.
+    const r = validateListingImage(
+      { ...base, width: 4500, height: LISTING_ASSET_MAX_DIMENSION_PX + 1 },
+      'screenshot'
+    );
+    expect(r).toEqual({
+      ok: false,
+      reason: `screenshot is too large (max ${LISTING_ASSET_MAX_DIMENSION_PX}px per side, got ${
+        LISTING_ASSET_MAX_DIMENSION_PX + 1
+      }px)`,
+    });
+    // Same aspect, same bytes, under the ceiling → accepted.
+    expect(
+      validateListingImage(
+        { ...base, width: 4500, height: LISTING_ASSET_MAX_DIMENSION_PX },
+        'screenshot'
+      )
+    ).toEqual({ ok: true });
+  });
+
+  it('keeps the icon on its own TIGHTER maximum', () => {
+    // The shared ceiling must not loosen the icon: 5000px square is inside 8192
+    // but outside LISTING_ICON_MAX_PX, and must still be rejected for that reason.
+    const r = validateListingImage({ ...base, width: 5000, height: 5000 }, 'icon');
+    expect(r).toEqual({
+      ok: false,
+      reason: expect.stringContaining(`${LISTING_ICON_MAX_PX}px on its longer side`),
+    });
   });
 });
 

--- a/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
@@ -3,6 +3,7 @@ import { TRPCError } from '@trpc/server';
 import sharp from 'sharp';
 
 import {
+  LISTING_ASSET_MAX_DIMENSION_PX,
   MAX_LISTING_ASSET_SIZE_BYTES,
   validateListingImage,
 } from '~/server/schema/blocks/app-listing.schema';
@@ -1526,5 +1527,68 @@ describe('persistListingAssetImage (measures the uploaded bytes)', () => {
       persistListingAssetImage({ input: HONEST_COVER, userId: CALLER })
     ).rejects.toMatchObject({ code: 'INTERNAL_SERVER_ERROR' });
     expect(mockCreateImage).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// persistListingAssetImage — the per-side DIMENSION CEILING
+// ---------------------------------------------------------------------------
+
+/**
+ * The presigned full-resolution upload path (`/api/v1/image-upload` PUT →
+ * `persistAssetImage`) — the one the CLI's `set-cover` / `add-screenshot` and the
+ * web uploader use — enforced NO maximum on either side, while the other two
+ * ingest paths did. A 9000×4000 cover was accepted in production and stored at
+ * full dimensions.
+ *
+ * These vary DIMENSIONS ONLY. Both fixtures are flat PNGs of a few tens of KB —
+ * orders of magnitude under the 4 MiB byte cap — so the byte rule cannot be what
+ * separates the accepted case from the rejected one, and the accepted case proves
+ * the guard is a CEILING rather than a blanket reject.
+ */
+describe('persistListingAssetImage (per-side dimension ceiling)', () => {
+  const KEY = '33333333-3333-4333-8333-333333333333';
+  const COVER = { url: KEY, width: 800, height: 450, mimeType: 'image/png' as const };
+
+  it('rejects the 9000×4000 upload before it reaches the scan pipeline', async () => {
+    storeObject(await flatPng(9000, 4000));
+
+    await expect(persistListingAssetImage({ input: COVER, userId: CALLER })).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: `That image is too large (max ${LISTING_ASSET_MAX_DIMENSION_PX}px per side, got 9000px).`,
+    });
+    // No `Image` row, so nothing is scanned, stored or attachable.
+    expect(mockCreateImage).not.toHaveBeenCalled();
+  });
+
+  it('rejects an upload one pixel over the ceiling on its TALLER side', async () => {
+    storeObject(await flatPng(4000, LISTING_ASSET_MAX_DIMENSION_PX + 1));
+
+    await expect(persistListingAssetImage({ input: COVER, userId: CALLER })).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: `That image is too large (max ${LISTING_ASSET_MAX_DIMENSION_PX}px per side, got ${
+        LISTING_ASSET_MAX_DIMENSION_PX + 1
+      }px).`,
+    });
+    expect(mockCreateImage).not.toHaveBeenCalled();
+  });
+
+  it('NEGATIVE CONTROL: an upload AT the ceiling still persists at full size', async () => {
+    const bytes = await flatPng(LISTING_ASSET_MAX_DIMENSION_PX, 4096);
+    storeObject(bytes);
+
+    await expect(persistListingAssetImage({ input: COVER, userId: CALLER })).resolves.toEqual({
+      imageId: 12345,
+    });
+
+    const arg = mockCreateImage.mock.calls[0][0] as {
+      width?: number;
+      height?: number;
+      metadata?: { size?: number };
+    };
+    expect(arg).toMatchObject({ width: LISTING_ASSET_MAX_DIMENSION_PX, height: 4096 });
+    // The rejected fixtures above are the same KIND of object as this accepted
+    // one — a flat PNG well inside the byte cap. Only the dimensions differ.
+    expect(arg.metadata?.size).toBeLessThan(MAX_LISTING_ASSET_SIZE_BYTES);
   });
 });

--- a/src/server/services/blocks/listing-meta.service.ts
+++ b/src/server/services/blocks/listing-meta.service.ts
@@ -1,6 +1,6 @@
 import { TRPCError } from '@trpc/server';
 
-import { LISTING_ASSET_MAX_DIMENSION_PX } from '~/server/schema/blocks/app-listing.schema';
+import { listingAssetTooLargeReason } from '~/server/schema/blocks/app-listing.schema';
 import { validateExternalUrl } from '~/server/schema/blocks/external-app.schema';
 import type {
   FetchListingMetaInput,
@@ -184,11 +184,13 @@ export async function ingestListingAssetFromUrl(opts: {
 
   // Ceiling on either side — the byte cap alone doesn't bound decoded dimensions
   // (a tiny highly-compressed file can decode to an enormous canvas / bomb). Reject
-  // before the CF upload + createImage scan pipeline.
-  if (width > LISTING_ASSET_MAX_DIMENSION_PX || height > LISTING_ASSET_MAX_DIMENSION_PX) {
+  // before the CF upload + createImage scan pipeline. Shared predicate + text, so
+  // this path and the upload paths name the same bound.
+  const tooLarge = listingAssetTooLargeReason('That image', width, height);
+  if (tooLarge) {
     throw new TRPCError({
       code: 'BAD_REQUEST',
-      message: `That image is too large (max ${LISTING_ASSET_MAX_DIMENSION_PX}px per side). Try uploading a smaller one manually.`,
+      message: `${tooLarge}. Try uploading a smaller one manually.`,
     });
   }
 

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -5,7 +5,10 @@ import { TRPCError } from '@trpc/server';
 import { Prisma } from '@prisma/client';
 
 import { dbRead, dbWrite } from '~/server/db/client';
-import { MAX_LISTING_ASSET_SIZE_BYTES } from '~/server/schema/blocks/app-listing.schema';
+import {
+  listingAssetTooLargeReason,
+  MAX_LISTING_ASSET_SIZE_BYTES,
+} from '~/server/schema/blocks/app-listing.schema';
 import {
   assertNoOnPlatformSurface,
   validateExternalUrl,
@@ -2644,12 +2647,25 @@ export async function rejectExternalRequest(opts: {
  * The byte cap is the LOOSEST per-kind cap: bytes above it satisfy no kind, and the
  * kind is not known until attach, so it is the only size rejection that can happen
  * this early.
+ *
+ * The DIMENSION ceiling does not need the kind either — it is the same for all of
+ * them — so it is applied here too, on the measured (never the declared) pair. A
+ * byte cap does not bound decoded dimensions: a small, highly-compressed file can
+ * decode to an enormous canvas, and the presigned-upload path had no ceiling at
+ * all, so an image far above the bound was stored at full size and only its
+ * MINIMUMS were ever checked. Rejecting here keeps the bytes out of `createImage`
+ * + the scan pipeline; {@link validateListingImage} re-applies the same bound at
+ * attach for rows this path did not create.
  */
-const measureListingAssetUpload = (key: string) =>
-  measureUploadedImage(key, {
+const measureListingAssetUpload = async (key: string) => {
+  const measured = await measureUploadedImage(key, {
     maxBytes: MAX_LISTING_ASSET_SIZE_BYTES,
     subject: 'listing media',
   });
+  const tooLarge = listingAssetTooLargeReason('That image', measured.width, measured.height);
+  if (tooLarge) throw new TRPCError({ code: 'BAD_REQUEST', message: `${tooLarge}.` });
+  return measured;
+};
 
 /**
  * Materialise an uploaded image into an `Image` row (owned by the caller) and


### PR DESCRIPTION
## The defect

`LISTING_ASSET_MAX_DIMENSION_PX = 8192` is declared in `src/server/schema/blocks/app-listing.schema.ts` as the absolute per-side ceiling for **any** listing asset, and its docstring says it exists to stop a decompression-bomb / absurd-dimension image being stored and rendered as store media. It was referenced by exactly one file.

App-listing media has three ingest paths. Two applied a ceiling; the third — the one that carries user cover/screenshot uploads — applied none:

| ingest path | used by | per-side ceiling (before) |
|---|---|---|
| `ingestListingAssetFromDataUri` (inline icon) | `set-icon` | 4096 at attach (`LISTING_ICON_MAX_PX`) |
| presigned upload → `persistAssetImage` (full-res) | **`set-cover`, `add-screenshot`, the web uploader** | **none** |
| `ingestListingAssetFromUrl` (OG pull) | listing-meta | 8192 |

And the attach validator did not close the gap either: `validateListingImage`'s cover branch enforces aspect (1.3–2.4) and a 640px minimum width; the screenshot branch enforces aspect and a minimum side. Neither had a maximum — only `icon` did.

**Observed in production**: a 9000×4000 (36 Mpx) PNG cover was accepted through `civitai app listing set-cover` and stored at full dimensions (`Image` row `width=9000, height=4000`, 234,792 bytes). A 6144×3456 (21 Mpx) cover was accepted too. Aspect 2.25 is inside the cover band and 9000px is far above the 640px floor, so every rule that existed passed — nothing was misconfigured, there simply was no maximum.

Note the byte caps cannot substitute: that 36 Mpx image was 229 KiB, ~6% of the 4 MiB cover cap. Compression ratio is not a bound on decoded dimensions.

## The fix

Applies the **existing** bound — no new constant, no changed value, no new pixel-count cap — through a single shared predicate, `listingAssetTooLargeReason(subject, width, height)`, declared next to the constant it enforces. It returns the house-style rejection text (`cover is too large (max 8192px per side, got 9000px)`) or `null`.

It is called at two layers, deliberately:

1. **`measureListingAssetUpload`** (the presigned persist path) rejects on the **measured** dimensions — never the declared ones — *before* `createImage`. So oversize bytes never reach the scan pipeline and no `Image` row is created. This is the same point in the flow at which the other two ingest paths already reject.
2. **`validateListingImage`** applies the ceiling to every kind at attach. This is the choke point: it is the one gate every listing asset passes *whatever created its `Image` row*. `loadValidatedImage` gates on ownership, not provenance, so it cannot tell how a row was made — which means an ingest-side check alone is bypassable by attaching an image that reached the account through some other upload path. Layer 1 is the early reject; layer 2 is the one that makes the bound actually hold.

The rule, the bound and the message text live in one function, so the two layers cannot drift. The OG-pull path in `listing-meta.service.ts` now calls that helper instead of open-coding the same comparison and message — a de-duplication, not a third copy.

The icon keeps its own tighter 4096px maximum; the shared ceiling does not loosen it, and there is a test pinning that.

Errors are `TRPCError` `BAD_REQUEST`, so the `civitai` CLI relays them verbatim. The CLI vendors no bounds of its own and needs no change.

## ⚠️ This is a behaviour change

**Uploads that succeed today will start being refused.** Any listing icon/cover/screenshot over 8192px on either side now gets a 400 naming the bound, where it previously succeeded and was stored at full resolution.

**The guard applies to NEW uploads only.** Existing stored assets above the bound are unaffected — nothing is migrated, re-encoded or deleted, and no backfill runs. An already-attached oversize cover keeps working; it would only be refused if it were re-attached.

8192px is retained rather than repointed: it is comfortably above any real store icon/cover/screenshot (the largest legitimate asset shape here is a hero cover, and 8192px is 4× a 4K width), it is the number the constant's docstring already promised, and adopting a different bound on one path would recreate the inconsistency this PR removes.

## Tests

Added next to the existing suites, matching their mocking style. Fixtures vary **dimensions only** — every one is a flat PNG far under the 4 MiB byte cap, so the byte rule cannot account for any verdict — and both sides of the boundary are covered.

`src/server/services/blocks/__tests__/app-listing-assets.service.test.ts` (pure attach validator):
- cover at exactly 8192 passes; 8193 is refused with the bound-naming reason
- the 9000×4000 shape observed in production is refused
- the ceiling applies to the taller side, not just width (screenshot at 4500×8193 refused, 4500×8192 accepted)
- invariant guard: the icon still fails on its own tighter 4096px maximum

`src/server/services/blocks/__tests__/offsite-listing.service.test.ts` (presigned persist path, real bytes through real `sharp`, only the store accessor mocked):
- a 9000×4000 upload is refused and **`createImage` is never called**
- one pixel over the ceiling on the taller side is refused
- negative control: an upload at exactly 8192×4096 still persists at full size

### Red at base / green at HEAD

Run with the new test files applied to an otherwise-unmodified checkout of the branch base (`670cc946b4`):

```
base   →  Tests  5 failed | 162 passed (167)
HEAD   →  Tests  203 passed (203)   [5 suites: the 2 above + listing-meta ×2 + block-image-upload.persist]
```

The 5 red-at-base failures are the regression tests; e.g. the 9000×4000 cover case fails with `expected { ok: true } to deeply equal { ok: false, reason: "cover is too large (max 8192px per side, got 9000px)" }` — the base genuinely accepted it. The other 2 new cases (icon tighter-max, at-the-ceiling negative control) pass on both sides and are labelled as an invariant guard and a negative control, not as regression coverage.

### Mutation checks

Each guard was broken on purpose and attributed by the **specific** failing message, not merely by "a test went red":

| mutation | result |
|---|---|
| delete the ceiling check in `validateListingImage` | 3 attach tests fail with *this* guard's text (`"cover is too large (max 8192px per side, got 9000px)"` vs received `{ ok: true }`); the 2 persist tests still pass, so the failure is attributable to that guard alone. Received `{ ok: true }` also proves the check is **reachable** — no earlier rule intercepts these fixtures |
| delete the throw in `measureListingAssetUpload` | 2 persist tests fail with `promise resolved "{ imageId: 12345 }" instead of rejecting` — i.e. the mutant reproduces the exact defect (row created, sent to scan); the 3 attach tests still pass |
| raise the bound in the shared predicate (`<= MAX` → `<= MAX * 2`) | all 5 regression tests fail — both call sites do depend on the single predicate, not on a local copy |
| keep the guard but stop it naming the bound (`message: 'That image is too large.'`) | 2 persist tests fail on the **message**, proving the assertions pin the bound-naming text so an adjacent guard's error could not produce a false green |

### Other verification

- `node scripts/typecheck.mjs`: 77 errors at base, 77 at HEAD, **identical error sets** (pre-existing, all in unrelated files — generated-client and workspace-build artifacts of a fresh checkout). Zero reference the touched files.
- The repo's lint-rule suites (`no-unloadable-image-fixture`, `no-wholesale-module-mock`, `no-io-in-transaction`, `no-module-scope-cache`, `no-unbounded-paging-fake`): 215 passed.
- Wider sweep of `src/server/services/blocks/__tests__`, `src/server/routers/__tests__`, `src/server/schema`: 2995 passed, 2 failed — both in `manifest-schema-endpoint.test.ts`, and both fail identically on an unmodified base checkout, so they are pre-existing and unrelated. (26 further files fail to *collect* in my local worktree for environment reasons — an unbuilt workspace package and the Prisma engine — equally at base; CI resolves those.)
- Prettier: the touched files are flagged identically at base and at HEAD, so no new formatting violation is introduced (these files carry substantial pre-existing drift and were left alone rather than reformatted, to keep the diff readable).

No Prisma migration is needed and none is included.
