### PR TITLE
perf: sever client→server import bridges in the _app graph

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,7 +10,6 @@ const isProd = process.env.NODE_ENV === 'production';
 const isDev = process.env.NODE_ENV === 'development';
 const analyze = process.env.ANALYZE === 'true';
 const includeCircularDependencyPlugin = process.env.CIRCULAR_DEPENDENCY_PLUGIN === 'true';
-const shouldOptimizeImports = (isDev && analyze) || isProd;
 
 const withBundleAnalyzer = bundlAnalyzer({
   enabled: analyze,
@@ -228,12 +227,16 @@ export default defineNextConfig(
       // derives `dependencyTracking` from it, so the flag governs what turbo-tasks retains in
       // memory and not just what lands on disk.
       turbopackFileSystemCacheForBuild: false,
+      // NB: `lodash-es`, `@tabler/icons-react` and `@headlessui/react` are already in Next's
+      // built-in default list (config.js merges ours into it) — kept here only as intent.
+      // `@mantine/core` is NOT a Next default and is the widest barrel we import.
       optimizePackageImports: [
         '@civitai/client',
         './src/libs/form',
         'lodash-es',
         '@tabler/icons-react',
         '@headlessui/react',
+        '@mantine/core',
       ],
     },
     headers: async () => {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -35,8 +35,7 @@ export default defineNextConfig(
       // by exposing it to the client bundle as NEXT_PUBLIC_AUTH_HUB_URL — so there's no separate var to set. An
       // explicit NEXT_PUBLIC_AUTH_HUB_URL still wins if provided. (AUTH_JWT_ISSUER is public: the JWT `iss` /
       // JWKS origin.)
-      NEXT_PUBLIC_AUTH_HUB_URL:
-        process.env.NEXT_PUBLIC_AUTH_HUB_URL ?? process.env.AUTH_JWT_ISSUER,
+      NEXT_PUBLIC_AUTH_HUB_URL: process.env.NEXT_PUBLIC_AUTH_HUB_URL ?? process.env.AUTH_JWT_ISSUER,
     },
     // webpack: (config, options) => {
     //   if (isDev && !options.isServer) {
@@ -157,9 +156,17 @@ export default defineNextConfig(
     ],
     // Renamed from experimental.serverComponentsExternalPackages → top-level serverExternalPackages in Next 15
     serverExternalPackages: [
-      'redis', '@redis/client', '@redis/bloom', '@redis/json', '@redis/search', '@redis/time-series',
-      '@opentelemetry/sdk-node', '@opentelemetry/instrumentation', '@opentelemetry/instrumentation-http',
-      '@opentelemetry/instrumentation-redis', '@prisma/instrumentation',
+      'redis',
+      '@redis/client',
+      '@redis/bloom',
+      '@redis/json',
+      '@redis/search',
+      '@redis/time-series',
+      '@opentelemetry/sdk-node',
+      '@opentelemetry/instrumentation',
+      '@opentelemetry/instrumentation-http',
+      '@opentelemetry/instrumentation-redis',
+      '@prisma/instrumentation',
       // Bundling this gives the app layer its own copy of the Prisma runtime while
       // `dbRead`/`dbWrite` (reached through the transpiled `@civitai/db-schema`) hold a
       // second one. `$queryRaw` identifies its template argument with `instanceof Sql`,
@@ -172,7 +179,8 @@ export default defineNextConfig(
       // gate. The logs bridge does not depend on it: it binds to the Logs API lazily, so
       // a second bundled module copy is survivable, and `no_provider` on its skip counter
       // is the runtime signal if one ever appears.
-      '@pyroscope/nodejs', '@datadog/pprof',
+      '@pyroscope/nodejs',
+      '@datadog/pprof',
     ],
     // Several entry points read markdown from src/static-content at runtime via fs
     // (dynamic string paths that @vercel/nft can't trace). With output:'standalone'
@@ -229,14 +237,20 @@ export default defineNextConfig(
       turbopackFileSystemCacheForBuild: false,
       // NB: `lodash-es`, `@tabler/icons-react` and `@headlessui/react` are already in Next's
       // built-in default list (config.js merges ours into it) — kept here only as intent.
-      // `@mantine/core` is NOT a Next default and is the widest barrel we import.
+      //
+      // 🔴 Do NOT add a package that creates React context — `@mantine/core`, `@mantine/modals`,
+      // `@mantine/notifications`. This rewrites barrel imports into deep per-component imports,
+      // which can put the provider and its consumers on DIFFERENT module instances: the provider
+      // is in the tree, but consumers read a context object created by another copy. Adding
+      // `@mantine/core` here 500'd every Mantine-heavy route in preview with "MantineProvider was
+      // not found in component tree" (PR #3802). Nothing local catches it — typecheck, lint and
+      // both vitest projects stayed green; only a real build renders the provider.
       optimizePackageImports: [
         '@civitai/client',
         './src/libs/form',
         'lodash-es',
         '@tabler/icons-react',
         '@headlessui/react',
-        '@mantine/core',
       ],
     },
     headers: async () => {
@@ -271,8 +285,9 @@ export default defineNextConfig(
         headers: [
           {
             key: 'Content-Security-Policy',
-            value: "frame-src 'self' https://www.kinguin.net https://sandbox.kinguin.net https://gateway.kinguin.net https://*.kinguin.net;"
-          }
+            value:
+              "frame-src 'self' https://www.kinguin.net https://sandbox.kinguin.net https://gateway.kinguin.net https://*.kinguin.net;",
+          },
           // NOTE: Intentionally NO X-Frame-Options header as per Kinguin's documentation
           // NOTE: Only setting frame-src, letting other resources use browser defaults
         ],

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "test:packages:run": "vitest run --project '@civitai/*'",
     "test:apps": "vitest --project 'app:*'",
     "test:apps:run": "vitest run --project 'app:*'",
-    "test:lint-rules": "vitest run --project unit src/server/services/__tests__/no-io-in-transaction.test.ts src/server/services/__tests__/no-module-scope-cache.test.ts src/server/services/__tests__/no-unbounded-paging-fake.test.ts src/server/services/__tests__/no-unloadable-image-fixture.test.ts src/server/services/__tests__/no-wholesale-module-mock.test.ts",
+    "test:lint-rules": "vitest run --project unit src/server/services/__tests__/no-io-in-transaction.test.ts src/server/services/__tests__/no-module-scope-cache.test.ts src/server/services/__tests__/no-server-infra-in-app-graph.test.ts src/server/services/__tests__/no-unbounded-paging-fake.test.ts src/server/services/__tests__/no-unloadable-image-fixture.test.ts src/server/services/__tests__/no-wholesale-module-mock.test.ts",
     "test:component": "vitest run --project component",
     "test:component:watch": "vitest --project component",
     "meilisearch:migrate": "NODE_ENV=development tsx scripts/oneoffs/meilisearch-migration.ts",

--- a/src/components/Stripe/memberships.util.ts
+++ b/src/components/Stripe/memberships.util.ts
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
-import refreshSessions from '~/pages/api/admin/refresh-sessions';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { constants } from '~/server/common/constants';
 import type { SubscriptionProductMetadata } from '~/server/schema/subscriptions.schema';

--- a/src/env/is-build.ts
+++ b/src/env/is-build.ts
@@ -1,0 +1,9 @@
+// Split out of `~/env/server` so modules needing only this flag don't pull the
+// 958-line server env schema into their import graph — `_app`'s client graph
+// reaches several of them, and zod-validating every server var is a large,
+// entirely unused cost there. `env.IS_BUILD` still re-exports this, so existing
+// callsites are unchanged.
+const isNextBuild =
+  process.argv.some((arg) => arg.includes('next')) && process.argv.some((arg) => arg === 'build');
+
+export const IS_BUILD = process.env.IS_BUILD === 'true' || isNextBuild;

--- a/src/env/is-build.ts
+++ b/src/env/is-build.ts
@@ -3,7 +3,11 @@
 // reaches several of them, and zod-validating every server var is a large,
 // entirely unused cost there. `env.IS_BUILD` still re-exports this, so existing
 // callsites are unchanged.
-const isNextBuild =
-  process.argv.some((arg) => arg.includes('next')) && process.argv.some((arg) => arg === 'build');
+// `process.argv` is Node-only and this module sits in `_app`'s client chunk graph
+// (via server/logging/client). Nothing evaluates it in a browser today, but an
+// unguarded read would throw TypeError the moment something imports IS_BUILD from
+// a component — with the graph guard and typecheck both still green.
+const argv = typeof process !== 'undefined' && Array.isArray(process.argv) ? process.argv : [];
+const isNextBuild = argv.some((arg) => arg.includes('next')) && argv.some((arg) => arg === 'build');
 
 export const IS_BUILD = process.env.IS_BUILD === 'true' || isNextBuild;

--- a/src/env/server.ts
+++ b/src/env/server.ts
@@ -5,6 +5,7 @@
  */
 import * as dotenv from 'dotenv';
 import { env as clientEnv, formatErrors } from './client';
+import { IS_BUILD } from './is-build';
 import { serverSchema } from './server-schema';
 
 if (process.env.NODE_ENV === 'development') {
@@ -49,11 +50,5 @@ if (process.env.NODE_ENV === 'development') {
     }
   } catch {}
 }
-
-// Detect if we're in a Next.js build process
-// This is useful for skipping runtime-only operations like database/redis connections
-const isNextBuild =
-  process.argv.some((arg) => arg.includes('next')) && process.argv.some((arg) => arg === 'build');
-const IS_BUILD = process.env.IS_BUILD === 'true' || isNextBuild;
 
 export const env = { ..._serverEnv.data, ...clientEnv, IS_BUILD };

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -490,9 +490,10 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
     announcements,
     following,
     browsingSettingsAddons,
-    // Fail closed to "not live": the endpoint already swallows a degraded
-    // sysRedis into `false`, and this covers the case where the bootstrap fetch
-    // itself failed. The client query self-heals on its 5-minute refetch.
+    // Fail closed to "not live". `getLiveNow` reads the main redis with no internal
+    // catch and no deadline race, so the endpoint's own `.catch` is what turns a
+    // degraded read into `false`; this default covers the bootstrap fetch failing
+    // outright. The client query self-heals on its 5-minute refetch.
     liveNow = false,
   } = settingsBootstrap;
   const { getFeatureFlagsAsync, computeUserFeatureFlagsOverlay } = await import(

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -117,7 +117,7 @@ type CustomAppProps = {
   following?: number[];
   seed: number;
   settings: UserContentSettings;
-  browsingSettingsAddons: BrowsingSettingsAddon[];
+  browsingSettingsAddons?: BrowsingSettingsAddon[];
   liveNow: boolean;
   // SSR-seeded `chat.getUserSettings` (logged-in only) — the per-user chat
   // settings (mute sounds / bad-word filter / acknowledged). Derived from the
@@ -421,6 +421,11 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
     tosMeta?: TosMeta;
     announcements?: AnnouncementsSeed;
     following?: number[];
+    // Absent on the degraded path. `browsingSettingsAddons` must stay possibly-
+    // undefined all the way to the provider — see the endpoint for why `[]` is
+    // not a safe substitute.
+    browsingSettingsAddons?: BrowsingSettingsAddon[];
+    liveNow?: boolean;
     session: Session | null;
   };
   let settingsBootstrap: SettingsBootstrap;
@@ -473,49 +478,31 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
       tosMeta: undefined,
       announcements: undefined,
       following: undefined,
+      browsingSettingsAddons: undefined,
+      liveNow: undefined,
       session: null,
     };
   }
-  const { settings, session, tosMeta, announcements, following } = settingsBootstrap;
-  // Pass these via the request so we can use them in SSR. Resolve the per-user
-  // feature flags and the global (redis-cached, identical-for-all-users) browsing
-  // setting addons in PARALLEL — neither depends on the other and both sit on
-  // every full render's critical path. SSR-injecting the addons keeps the
-  // `system.getBrowsingSettingAddons` round-trip off api-primary (it becomes
-  // `initialData` for the client provider).
-  const [
-    { getFeatureFlagsAsync, computeUserFeatureFlagsOverlay },
-    { getBrowsingSettingAddons, getLiveNow },
-  ] = await Promise.all([
-    import('~/server/services/feature-flags.service'),
-    import('~/server/services/system-cache'),
-  ]);
-  const [flags, browsingSettingsAddons] = await Promise.all([
-    getFeatureFlagsAsync({
-      user: session?.user,
-      host: request?.headers.host,
-      req: request,
-    }),
-    getBrowsingSettingAddons(),
-  ]);
-
-  // SSR-seed the global `system.getLiveNow` boolean (a single `redis.get`,
-  // identical for every user) so the ambient `useIsLive` client query reads a
-  // primed cache and never fires on bootstrap (~26 req/s off api-primary).
-  // Fail open to `false` (the "not live" default): `getLiveNow` has no internal
-  // try/catch, and an uncaught redis throw here would 500 every page render —
-  // so a degraded sysRedis must degrade to "not live", never to an error. The
-  // client query still self-heals on its 5-minute refetch interval.
-  let liveNow = false;
-  try {
-    liveNow = await getLiveNow();
-  } catch (e) {
-    console.warn(
-      `[_app] getLiveNow bootstrap failed, defaulting to not-live: ${
-        e instanceof Error ? e.message : String(e)
-      }`
-    );
-  }
+  const {
+    settings,
+    session,
+    tosMeta,
+    announcements,
+    following,
+    browsingSettingsAddons,
+    // Fail closed to "not live": the endpoint already swallows a degraded
+    // sysRedis into `false`, and this covers the case where the bootstrap fetch
+    // itself failed. The client query self-heals on its 5-minute refetch.
+    liveNow = false,
+  } = settingsBootstrap;
+  const { getFeatureFlagsAsync, computeUserFeatureFlagsOverlay } = await import(
+    '~/server/services/feature-flags.service'
+  );
+  const flags = await getFeatureFlagsAsync({
+    user: session?.user,
+    host: request?.headers.host,
+    req: request,
+  });
 
   const domain = getRequestDomainColor(request);
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -521,7 +521,7 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
   //   ToS content only changes on a deploy (never mid-session). The show/hide
   //   decision is computed client-side in `useToSUpdateModal` against the seeded
   //   `user.getSettings`, so there is no tRPC query to seed here — `tosMeta` just
-  //   rides down through pageProps to AppProvider (its `lastmod` is revived there).
+  //   rides down through pageProps to AppProvider as-is.
   let userFeatureFlags: FeatureAccess | undefined;
   if (session?.user && settings) {
     userFeatureFlags = computeUserFeatureFlagsOverlay(settings.features, flags);

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -428,11 +428,10 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
     session: Session | null;
   };
   let settingsBootstrap: SettingsBootstrap;
-  // True only on the DEGRADED fallback path (we couldn't reach/parse the
-  // settings endpoint). Distinct from a SUCCESSFUL fetch that returned
-  // `session: null` (genuinely expired/invalid token). The two look identical in
-  // the destructured shape below (both have `session: null`) but must be treated
-  // differently for the auth cookie — see the cookie carve-out near the return.
+  // True only on the DEGRADED fallback path (we couldn't reach/parse the settings
+  // endpoint). A SUCCESSFUL fetch returning `session: null` looks identical in the
+  // destructured shape below, but the two drive `hasAuthCookie` differently — see the
+  // carve-out near the return.
   let settingsDegraded = false;
   try {
     const res = await fetch(`${baseUrl as string}/api/user/settings`, {
@@ -441,15 +440,12 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
     });
     if (!res.ok) throw new Error(`settings fetch returned ${res.status}`);
     const data = (await res.json()) as SettingsBootstrap;
-    // The endpoint's OWN internal catch swallows transient errors (e.g. a DB
-    // blip on a draining pod mid-roll) into a SUCCESSFUL `200 {}` — a body with
-    // NO `session` key. That sails past the `!res.ok` guard but carries no
-    // authoritative session, so treating it as a real result would delete the
-    // auth cookie (key absent ≠ `session: null`) and log the user out — the exact
-    // vector this fix exists to kill. Distinguish on KEY PRESENCE: a genuinely
-    // logged-out user gets `session: null` (key present → not degraded, cookie
-    // cleanup is correct); an internal swallow gets `{}` (key absent → degrade,
-    // preserve the cookie). `'session' in data` is the precise discriminator.
+    // The endpoint's OWN internal catch swallows transient errors (e.g. a DB blip on a
+    // draining pod mid-roll) into a SUCCESSFUL `200 {}` — a body with NO `session` key.
+    // That sails past the `!res.ok` guard but carries no authoritative session, so
+    // treating it as a real result would render a logged-in user as signed out. Key
+    // ABSENT (`{}`) ⇒ degraded; key PRESENT (`session: null`) ⇒ render anonymous.
+    // `'session' in data` is the discriminator — a truthiness check erases it.
     if (!data || typeof data !== 'object' || !('session' in data)) {
       throw new Error('settings fetch returned no session payload (endpoint-swallowed error)');
     }
@@ -546,16 +542,16 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
   if (session) {
     (appContext.ctx.req as any)['session'] = session;
   } else if (hasAuthCookie && !settingsDegraded) {
-    // Render anonymous, but DO NOT delete the cookie. A successful fetch returning
-    // `session: null` is ambiguous: `getServerAuthSession` fail-softs to null on a hub
-    // outage (`.catch(() => null)` on both the hub and legacy lookups), so this means
-    // EITHER an expired token OR a degraded lookup, and nothing on the wire separates
-    // them. Deleting on the second case logs a valid user out durably, during the exact
-    // incident that caused it — and a logout storm lands on an auth hub that is already
-    // struggling. Keeping the cookie makes an outage a transient logged-out *appearance*
-    // that recovers on the next successful bootstrap; the cost is that a genuinely dead
-    // cookie lingers until it expires. Deleting it safely needs the endpoint to signal a
-    // degraded lookup distinctly from "no session".
+    // Render anonymous, but DO NOT delete the cookie. `session: null` is ambiguous:
+    // `getServerAuthSession` fail-softs to null (`.catch(() => null)` at
+    // get-server-auth-session.ts:92,102), so a hub outage is indistinguishable on the
+    // wire from an expired token — and deleting on the outage durably logs out a valid
+    // user. Scope: the delete this replaces named the LEGACY `civitai-token` family only,
+    // so only legacy holders were ever affected either way. Cost of keeping it is near
+    // zero: a civ-token's Max-Age comes from its own `exp` (civ-cookie.ts:163), so an
+    // expired one is never in the jar to linger; a stale legacy cookie costs one failed
+    // jose decode per request. Deleting safely needs the endpoint to signal a degraded
+    // lookup distinctly from "no session".
     hasAuthCookie = false;
   }
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,7 +4,7 @@ import dynamic from 'next/dynamic';
 // Side-effect import: globally disables next/link route prefetching. Must run
 // before any <Link> mounts — see the file for rationale.
 import '~/utils/disable-router-prefetch';
-import { getCookie, getCookies, deleteCookie } from 'cookies-next';
+import { getCookie, getCookies } from 'cookies-next';
 import type { Session } from '~/types/session';
 import { SessionProvider } from '~/providers/SessionProvider';
 import { resolveAuthGuard } from '~/server/auth/route-guard';
@@ -41,7 +41,6 @@ import { TrackPageView } from '~/components/TrackView/TrackPageView';
 import { UpdateRequiredWatcher } from '~/components/UpdateRequiredWatcher/UpdateRequiredWatcher';
 import { env } from '~/env/client';
 import { isDev, isPreview, isProd } from '~/env/other';
-import { civitaiTokenCookieName } from '~/libs/auth';
 import { ActivityReportingProvider } from '~/providers/ActivityReportingProvider';
 import { AppProvider } from '~/providers/AppProvider';
 import { BrowserSettingsProvider } from '~/providers/BrowserSettingsProvider';
@@ -547,15 +546,16 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
   if (session) {
     (appContext.ctx.req as any)['session'] = session;
   } else if (hasAuthCookie && !settingsDegraded) {
-    // Only clear the auth cookie when the settings fetch SUCCEEDED and authoritatively
-    // returned no session — i.e. the token is genuinely expired/invalid, so cleaning up
-    // the stale cookie is correct. On the DEGRADED path we never reached the endpoint, so
-    // we DON'T KNOW the session: deleting the cookie here would durably log out a
-    // valid user (worse than the retryable failure this fix exists to soften). Don't
-    // conflate "couldn't reach settings" with "token invalid" — preserve the cookie and
-    // let the client refetch (the SessionProvider seed below already yields `undefined`
-    // → client refetch when hasAuthCookie is true and session is null).
-    deleteCookie(civitaiTokenCookieName, appContext.ctx);
+    // Render anonymous, but DO NOT delete the cookie. A successful fetch returning
+    // `session: null` is ambiguous: `getServerAuthSession` fail-softs to null on a hub
+    // outage (`.catch(() => null)` on both the hub and legacy lookups), so this means
+    // EITHER an expired token OR a degraded lookup, and nothing on the wire separates
+    // them. Deleting on the second case logs a valid user out durably, during the exact
+    // incident that caused it — and a logout storm lands on an auth hub that is already
+    // struggling. Keeping the cookie makes an outage a transient logged-out *appearance*
+    // that recovers on the next successful bootstrap; the cost is that a genuinely dead
+    // cookie lingers until it expires. Deleting it safely needs the endpoint to signal a
+    // degraded lookup distinctly from "no session".
     hasAuthCookie = false;
   }
 

--- a/src/pages/api/user/settings.ts
+++ b/src/pages/api/user/settings.ts
@@ -5,6 +5,7 @@ import { getTosMeta } from '~/server/services/content.service';
 import { getCurrentAnnouncements } from '~/server/services/announcement.service';
 import { getUserFollows } from '~/server/redis/caches';
 import { getRequestDomainColor } from '~/server/utils/server-domain';
+import { getBrowsingSettingAddons, getLiveNow } from '~/server/services/system-cache';
 
 export default PublicEndpoint(
   async function handler(req, res) {
@@ -19,40 +20,56 @@ export default PublicEndpoint(
       // and drop the critical settings/session payload; tosMeta (static, no user
       // input) can still throw to the outer catch (preserving prior behaviour).
       const domainColor = getRequestDomainColor(req);
-      const [tosMeta, announcements, following] = await Promise.all([
-        // Resolve the static per-domain ToS metadata here (server-only API route)
-        // so `_app` getInitialProps can deliver it WITHOUT importing
-        // `content.service` — which pulls `fs/promises` into `_app`'s client-bundled
-        // graph and breaks the build. The show/hide decision is computed client-side
-        // against the seeded `user.getSettings`, so this is user-independent and we
-        // can resolve it for everyone (it's cheap + cached). Domain fallback matches
-        // createContext's `getRequestDomainColor(req) ?? 'blue'`.
-        getTosMeta({ domainColor: domainColor ?? 'blue' }),
-        // SSR-seed the ambient `announcement.getAnnouncements` query (fires on every
-        // bootstrap, anon + authed). Computed here — NOT in `_app` getInitialProps —
-        // because `announcement.service` is server-only and importing it into `_app`
-        // leaks it into the client bundle. Match the resolver byte-for-byte: its
-        // `applyRequestDomainColor` middleware overrides the client input with
-        // `getRequestDomainColor(req)` (NO 'blue' fallback), so we pass the same raw
-        // value here. On failure fall back to undefined and let the client self-heal
-        // via a live fetch.
-        getCurrentAnnouncements({ domain: domainColor, userId: session?.user?.id }).catch(
-          () => undefined
-        ),
-        // SSR-seed the ambient, auth-gated `user.getFollowingUsers` query (fires
-        // on every logged-in bootstrap wherever a follow/notify button mounts).
-        // `getUserFollows` is the same redis-cached fn the resolver calls, so the
-        // seed is byte-identical (a `number[]` of followed userIds). Anon never
-        // fires this query (`enabled: !!currentUser`), so seed authed-only.
-        session?.user
-          ? getUserFollows(session.user.id).catch(() => undefined)
-          : Promise.resolve(undefined),
-      ]);
+      const [tosMeta, announcements, following, browsingSettingsAddons, liveNow] =
+        await Promise.all([
+          // Resolve the static per-domain ToS metadata here (server-only API route)
+          // so `_app` getInitialProps can deliver it WITHOUT importing
+          // `content.service` — which pulls `fs/promises` into `_app`'s client-bundled
+          // graph and breaks the build. The show/hide decision is computed client-side
+          // against the seeded `user.getSettings`, so this is user-independent and we
+          // can resolve it for everyone (it's cheap + cached). Domain fallback matches
+          // createContext's `getRequestDomainColor(req) ?? 'blue'`.
+          getTosMeta({ domainColor: domainColor ?? 'blue' }),
+          // SSR-seed the ambient `announcement.getAnnouncements` query (fires on every
+          // bootstrap, anon + authed). Computed here — NOT in `_app` getInitialProps —
+          // because `announcement.service` is server-only and importing it into `_app`
+          // leaks it into the client bundle. Match the resolver byte-for-byte: its
+          // `applyRequestDomainColor` middleware overrides the client input with
+          // `getRequestDomainColor(req)` (NO 'blue' fallback), so we pass the same raw
+          // value here. On failure fall back to undefined and let the client self-heal
+          // via a live fetch.
+          getCurrentAnnouncements({ domain: domainColor, userId: session?.user?.id }).catch(
+            () => undefined
+          ),
+          // SSR-seed the ambient, auth-gated `user.getFollowingUsers` query (fires
+          // on every logged-in bootstrap wherever a follow/notify button mounts).
+          // `getUserFollows` is the same redis-cached fn the resolver calls, so the
+          // seed is byte-identical (a `number[]` of followed userIds). Anon never
+          // fires this query (`enabled: !!currentUser`), so seed authed-only.
+          session?.user
+            ? getUserFollows(session.user.id).catch(() => undefined)
+            : Promise.resolve(undefined),
+          // Global, user-independent sysRedis reads moved off `_app` getInitialProps:
+          // importing `system-cache` there pulled `~/server/db/client` (Prisma) and
+          // `~/server/redis/client` into `_app`'s CLIENT-bundled module graph, since
+          // getInitialProps also runs in the browser on client-side transitions.
+          //
+          // `undefined` — NOT `[]` — is the failure value. The client provider passes
+          // this straight to `useQuery({ initialData, staleTime: Infinity })`: an empty
+          // array is VALID seed data, so it would pin the browsing-settings addons to
+          // "no restrictions" for the whole session and never refetch. `undefined`
+          // leaves the query unseeded, so it falls back to
+          // DEFAULT_BROWSING_SETTINGS_ADDONS and self-heals on the next fetch.
+          getBrowsingSettingAddons().catch(() => undefined),
+          getLiveNow().catch(() => false),
+        ]);
       res.status(200).json({
         settings,
         tosMeta,
         announcements,
         following,
+        browsingSettingsAddons,
+        liveNow,
         session: session?.user && Object.keys(session.user).length > 0 ? session : null,
       });
     } catch (e) {

--- a/src/pages/api/user/settings.ts
+++ b/src/pages/api/user/settings.ts
@@ -14,11 +14,10 @@ export default PublicEndpoint(
       // Use the content-settings view so SSR initialData matches the tRPC
       // getSettings response shape (JSON settings + User-column toggles).
       const settings = await getUserContentSettings(session?.user?.id ?? -1);
-      // tosMeta + announcements + following are computed concurrently to keep this
-      // hot per-bootstrap route off the critical path. announcements + following
-      // swallow their own errors (`.catch`) so they can never reject the Promise.all
-      // and drop the critical settings/session payload; tosMeta (static, no user
-      // input) can still throw to the outer catch (preserving prior behaviour).
+      // Concurrent, to keep this hot per-bootstrap route off the critical path.
+      // EVERY member swallows its own errors: a single rejection diverts the whole
+      // payload to the outer catch, which `_app` reads as "endpoint degraded" — so
+      // one blip would drop the session seed and the browsing-settings addons too.
       const domainColor = getRequestDomainColor(req);
       const [tosMeta, announcements, following, browsingSettingsAddons, liveNow] =
         await Promise.all([
@@ -29,7 +28,9 @@ export default PublicEndpoint(
           // against the seeded `user.getSettings`, so this is user-independent and we
           // can resolve it for everyone (it's cheap + cached). Domain fallback matches
           // createContext's `getRequestDomainColor(req) ?? 'blue'`.
-          getTosMeta({ domainColor: domainColor ?? 'blue' }),
+          // `undefined` on failure: `useToSUpdateModal` guards on it and simply
+          // doesn't prompt, which beats degrading the whole payload.
+          getTosMeta({ domainColor: domainColor ?? 'blue' }).catch(() => undefined),
           // SSR-seed the ambient `announcement.getAnnouncements` query (fires on every
           // bootstrap, anon + authed). Computed here — NOT in `_app` getInitialProps —
           // because `announcement.service` is server-only and importing it into `_app`
@@ -54,12 +55,16 @@ export default PublicEndpoint(
           // `~/server/redis/client` into `_app`'s CLIENT-bundled module graph, since
           // getInitialProps also runs in the browser on client-side transitions.
           //
-          // `undefined` — NOT `[]` — is the failure value. The client provider passes
-          // this straight to `useQuery({ initialData, staleTime: Infinity })`: an empty
-          // array is VALID seed data, so it would pin the browsing-settings addons to
-          // "no restrictions" for the whole session and never refetch. `undefined`
-          // leaves the query unseeded, so it falls back to
-          // DEFAULT_BROWSING_SETTINGS_ADDONS and self-heals on the next fetch.
+          // `getBrowsingSettingAddons` fails OPEN internally — a redis reject, a
+          // `withSysReadDeadline` timeout and corrupt JSON all RETURN
+          // DEFAULT_BROWSING_SETTINGS_ADDONS rather than throwing. So on degraded
+          // sysRedis the client is seeded with the defaults, and because the provider
+          // passes this to `useQuery({ initialData, staleTime: Infinity })` they are
+          // pinned for the session; the live config is only picked up on the next
+          // bootstrap. Telling "live config" apart from "failed open" would need a
+          // sentinel out of system-cache. The `.catch` below is unreachable today and
+          // kept only so a future refactor that lets this reject can't seed `[]` —
+          // which react-query would treat as valid data and pin as "no restrictions".
           getBrowsingSettingAddons().catch(() => undefined),
           getLiveNow().catch(() => false),
         ]);

--- a/src/server/__tests__/app-settings-bootstrap.test.ts
+++ b/src/server/__tests__/app-settings-bootstrap.test.ts
@@ -3,19 +3,21 @@
  *
  * `'session' in data` is a key-presence check that reads as an ordinary null-guard, so
  * collapsing it into a truthiness check looks harmless. It isn't: a response carrying NO
- * `session` key came from the endpoint's own outer catch and is NOT authoritative, and
- * clearing the cookie there durably logs out a valid user. This file makes that collapse
+ * `session` key came from the endpoint's own outer catch and is NOT authoritative, so
+ * treating it as "logged out" throws away a valid session. This file makes that collapse
  * fail loudly.
  *
- * What the discriminator ACTUALLY covers: the endpoint's outer catch (`200 {}`), a fetch
- * that rejects or aborts, and a non-OK status.
+ * Its only observable is `pageProps.hasAuthCookie` (false ⇒ render anonymous). The cookie
+ * itself is never deleted on any path — `session: null` cannot distinguish an expired token
+ * from a fail-soft session lookup (`get-server-auth-session.ts:92,102` `.catch(() => null)`
+ * on both the hub and legacy lookups), so a hub outage would otherwise durably log out
+ * valid users. The `deleteCookie` assertions below pin that: reintroducing a delete fails
+ * them. A dead cookie now lingers until it expires, which is the deliberate trade.
  *
- * What it does NOT cover, and no test here should be read as claiming otherwise: an
- * authoritative-looking `session: null`. `getServerAuthSession` fails SOFT —
- * `get-server-auth-session.ts:92,102` do `.catch(() => null)` on both the hub and legacy
- * lookups — so a hub outage produces `session: null` with the key PRESENT, which `_app`
- * then treats as "token genuinely expired" and clears the cookie. Closing that needs an
- * explicit "session lookup degraded" signal from the endpoint; tracked separately.
+ * What the discriminator covers: the endpoint's outer catch (`200 {}`), a fetch that rejects
+ * or aborts, and a non-OK status. What it still cannot see is a fail-soft lookup — that
+ * yields an anonymous render rather than a logout, and closing it properly needs an explicit
+ * "session lookup degraded" signal from the endpoint. Tracked separately.
  *
  * Lives outside `src/pages` deliberately: Next treats every file under there as a route
  * and `next build` rejects a test file, which only that build catches.
@@ -23,7 +25,6 @@
 import type * as CookiesNext from 'cookies-next';
 import type { AppContext } from 'next/app';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { civitaiTokenCookieName } from '~/libs/auth';
 import type * as FeatureFlagsService from '~/server/services/feature-flags.service';
 
 const h = vi.hoisted(() => ({
@@ -99,23 +100,19 @@ beforeEach(() => {
 });
 
 describe('_app settings bootstrap — auth cookie discriminator', () => {
-  it('DELETES the cookie when the fetch succeeds and authoritatively returns session: null', async () => {
+  it('renders anonymous but PRESERVES the cookie when the fetch returns session: null', async () => {
     h.respond = async () => json({ session: null, settings: { features: {} } });
 
     const { pageProps } = await getInitialProps(makeCtx());
 
+    // `hasAuthCookie` — NOT a deleteCookie spy — is the discriminator's only observable now.
+    expect(pageProps.hasAuthCookie, 'an authoritative session: null must render anonymous').toBe(
+      false
+    );
     expect(
       h.deleteCookie,
-      'an authoritative session: null means the token is genuinely expired — the stale cookie must be cleared'
-    ).toHaveBeenCalledTimes(1);
-    // Pins WHICH cookie, not just that one was cleared — without this the argument is
-    // unconstrained and pointing it at a nonexistent name keeps every test green.
-    // NB this pins CURRENT behaviour, and current behaviour is narrower than the jar:
-    // `civitaiTokenCookieName` is the LEGACY `civitai-token` family, while `hasAuthCookie`
-    // above matches `civ-token` too. A session holding only a modern `civ-token` therefore
-    // gets a delete for a name that isn't present. Pre-existing; tracked separately.
-    expect(h.deleteCookie).toHaveBeenCalledWith(civitaiTokenCookieName, expect.anything());
-    expect(pageProps.hasAuthCookie).toBe(false);
+      'the cookie must never be deleted here: session: null is ambiguous between an expired token and a fail-soft session lookup, and deleting on the latter logs out a valid user'
+    ).not.toHaveBeenCalled();
   });
 
   it('PRESERVES the cookie when the endpoint swallowed an error into 200 {} (no session key)', async () => {

--- a/src/server/__tests__/app-settings-bootstrap.test.ts
+++ b/src/server/__tests__/app-settings-bootstrap.test.ts
@@ -199,4 +199,21 @@ describe('_app settings bootstrap — auth cookie discriminator', () => {
     ).not.toHaveBeenCalled();
     expect(pageProps.hasAuthCookie).toBe(false);
   });
+
+  // The LEGACY family is the only population the cookie behaviour ever reached — the
+  // delete removed here named `civitai-token`, never `civ-token`. Without this case,
+  // dropping `|| x.endsWith('civitai-token')` from the matcher passes the whole file:
+  // every other fixture uses a modern cookie.
+  it('recognises a legacy civitai-token as an auth cookie', async () => {
+    h.jar = { '__Secure-civitai-token': 'legacy-token-value' };
+    h.respond = async () => json({});
+
+    const { pageProps } = await getInitialProps(makeCtx());
+
+    expect(
+      pageProps.hasAuthCookie,
+      'a legacy-cookie session must survive a degraded settings response too'
+    ).toBe(true);
+    expect(h.deleteCookie).not.toHaveBeenCalled();
+  });
 });

--- a/src/server/__tests__/app-settings-bootstrap.test.ts
+++ b/src/server/__tests__/app-settings-bootstrap.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Pins the auth-cookie discriminator in `_app.getInitialProps`.
+ *
+ * A SUCCESSFUL settings fetch returning `session: null` means the token is genuinely
+ * expired, so the stale cookie is cleared. An endpoint that swallowed an internal error
+ * into `200 {}` carries NO `session` key and is NOT authoritative — clearing the cookie
+ * there durably logs out a valid user. The two are told apart ONLY by `'session' in data`,
+ * which is a key-presence check that reads as an ordinary null-guard; this file exists so
+ * that collapsing it into a truthiness check fails loudly instead of silently logging
+ * people out.
+ *
+ * Lives outside `src/pages` deliberately: Next treats every file under there as a route
+ * and `next build` rejects a test file, which only that build catches.
+ */
+import type { AppContext } from 'next/app';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as FeatureFlagsService from '~/server/services/feature-flags.service';
+
+const h = vi.hoisted(() => ({
+  deleteCookie: vi.fn(),
+  jar: {} as Record<string, string>,
+  respond: null as null | (() => Promise<Response>),
+}));
+
+vi.mock('cookies-next', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('cookies-next')>()),
+  getCookie: vi.fn(() => 'dark'),
+  getCookies: vi.fn(() => h.jar),
+  deleteCookie: h.deleteCookie,
+}));
+
+// The real `getFeatureFlagsAsync` awaits a Flipt module load + client init, which opens a
+// network client under a node test env. The flag values are irrelevant to the cookie
+// decision, so only this one export is replaced.
+vi.mock('~/server/services/feature-flags.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof FeatureFlagsService>()),
+  getFeatureFlagsAsync: vi.fn(async () => ({})),
+}));
+
+// Module scope on purpose: this graph is ~1200 modules and a `await import()` from a test
+// body would charge its whole transform to that one test's timeout.
+import AppWithTRPC from '~/pages/_app';
+
+const getInitialProps = (
+  AppWithTRPC as unknown as {
+    getInitialProps: (c: AppContext) => Promise<{ pageProps: Record<string, unknown> }>;
+  }
+).getInitialProps;
+
+const AUTH_COOKIE = '__Secure-civ-token';
+const SETTINGS_PATH = '/api/user/settings';
+
+function makeCtx(): AppContext {
+  const noop = () => null;
+  return {
+    Component: noop,
+    AppTree: noop,
+    router: {},
+    ctx: {
+      req: { headers: { host: 'civitai.com' }, url: '/' },
+      pathname: '/',
+      query: {},
+      AppTree: noop,
+    },
+  } as unknown as AppContext;
+}
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  h.deleteCookie.mockClear();
+  h.jar = { [AUTH_COOKIE]: 'token-value' };
+  h.respond = async () => json({ session: null });
+  // URL-aware: only the settings self-fetch is scripted. Anything else the bootstrap
+  // happens to call (e.g. the hub provider list) gets a benign failure so it fails open
+  // rather than silently consuming the scripted settings response.
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes(SETTINGS_PATH)) return h.respond!();
+      return new Response(null, { status: 503 });
+    })
+  );
+});
+
+describe('_app settings bootstrap — auth cookie discriminator', () => {
+  it('DELETES the cookie when the fetch succeeds and authoritatively returns session: null', async () => {
+    h.respond = async () => json({ session: null, settings: { features: {} } });
+
+    const { pageProps } = await getInitialProps(makeCtx());
+
+    expect(
+      h.deleteCookie,
+      'an authoritative session: null means the token is genuinely expired — the stale cookie must be cleared'
+    ).toHaveBeenCalledTimes(1);
+    expect(pageProps.hasAuthCookie).toBe(false);
+  });
+
+  it('PRESERVES the cookie when the endpoint swallowed an error into 200 {} (no session key)', async () => {
+    h.respond = async () => json({});
+
+    const { pageProps } = await getInitialProps(makeCtx());
+
+    expect(
+      h.deleteCookie,
+      'auth cookie must survive a non-authoritative settings response — deleting it here logs out a valid user'
+    ).not.toHaveBeenCalled();
+    expect(pageProps.hasAuthCookie).toBe(true);
+    expect(pageProps.session).toBeNull();
+    // Degraded shape: no snapshot is seeded, so the client queries self-heal.
+    expect(pageProps.settings).toBeUndefined();
+    expect(pageProps.browsingSettingsAddons).toBeUndefined();
+  });
+
+  it('PRESERVES the cookie and threads the session through on a real session', async () => {
+    const session = { user: { id: 1, username: 'someone' } };
+    h.respond = async () => json({ session, settings: { features: {} } });
+
+    const { pageProps } = await getInitialProps(makeCtx());
+
+    expect(
+      h.deleteCookie,
+      'auth cookie must survive a non-authoritative settings response — deleting it here logs out a valid user'
+    ).not.toHaveBeenCalled();
+    expect(pageProps.hasAuthCookie).toBe(true);
+    expect(pageProps.session).toMatchObject(session);
+  });
+
+  it('PRESERVES the cookie when the fetch rejects outright', async () => {
+    h.respond = async () => {
+      throw new TypeError('fetch failed');
+    };
+
+    const { pageProps } = await getInitialProps(makeCtx());
+
+    expect(
+      h.deleteCookie,
+      'auth cookie must survive a non-authoritative settings response — deleting it here logs out a valid user'
+    ).not.toHaveBeenCalled();
+    expect(pageProps.hasAuthCookie).toBe(true);
+  });
+
+  it('PRESERVES the cookie when the fetch aborts on the timeout', async () => {
+    // Models what `AbortSignal.timeout(SETTINGS_FETCH_TIMEOUT_MS)` throws, without
+    // spending the real 8s — a test that waited would be timing-dependent for no gain.
+    h.respond = async () => {
+      throw new DOMException('The operation was aborted due to timeout', 'TimeoutError');
+    };
+
+    const { pageProps } = await getInitialProps(makeCtx());
+
+    expect(
+      h.deleteCookie,
+      'auth cookie must survive a non-authoritative settings response — deleting it here logs out a valid user'
+    ).not.toHaveBeenCalled();
+    expect(pageProps.hasAuthCookie).toBe(true);
+  });
+
+  it('PRESERVES the cookie on a non-OK status', async () => {
+    h.respond = async () => json({ session: null }, 500);
+
+    const { pageProps } = await getInitialProps(makeCtx());
+
+    expect(
+      h.deleteCookie,
+      'auth cookie must survive a non-authoritative settings response — deleting it here logs out a valid user'
+    ).not.toHaveBeenCalled();
+    expect(pageProps.hasAuthCookie).toBe(true);
+  });
+
+  it('does not touch the cookie when there was no auth cookie to begin with', async () => {
+    h.jar = {};
+    h.respond = async () => json({ session: null, settings: { features: {} } });
+
+    const { pageProps } = await getInitialProps(makeCtx());
+
+    expect(
+      h.deleteCookie,
+      'nothing to clear when the request carried no auth cookie'
+    ).not.toHaveBeenCalled();
+    expect(pageProps.hasAuthCookie).toBe(false);
+  });
+});

--- a/src/server/__tests__/app-settings-bootstrap.test.ts
+++ b/src/server/__tests__/app-settings-bootstrap.test.ts
@@ -1,19 +1,29 @@
 /**
  * Pins the auth-cookie discriminator in `_app.getInitialProps`.
  *
- * A SUCCESSFUL settings fetch returning `session: null` means the token is genuinely
- * expired, so the stale cookie is cleared. An endpoint that swallowed an internal error
- * into `200 {}` carries NO `session` key and is NOT authoritative — clearing the cookie
- * there durably logs out a valid user. The two are told apart ONLY by `'session' in data`,
- * which is a key-presence check that reads as an ordinary null-guard; this file exists so
- * that collapsing it into a truthiness check fails loudly instead of silently logging
- * people out.
+ * `'session' in data` is a key-presence check that reads as an ordinary null-guard, so
+ * collapsing it into a truthiness check looks harmless. It isn't: a response carrying NO
+ * `session` key came from the endpoint's own outer catch and is NOT authoritative, and
+ * clearing the cookie there durably logs out a valid user. This file makes that collapse
+ * fail loudly.
+ *
+ * What the discriminator ACTUALLY covers: the endpoint's outer catch (`200 {}`), a fetch
+ * that rejects or aborts, and a non-OK status.
+ *
+ * What it does NOT cover, and no test here should be read as claiming otherwise: an
+ * authoritative-looking `session: null`. `getServerAuthSession` fails SOFT —
+ * `get-server-auth-session.ts:92,102` do `.catch(() => null)` on both the hub and legacy
+ * lookups — so a hub outage produces `session: null` with the key PRESENT, which `_app`
+ * then treats as "token genuinely expired" and clears the cookie. Closing that needs an
+ * explicit "session lookup degraded" signal from the endpoint; tracked separately.
  *
  * Lives outside `src/pages` deliberately: Next treats every file under there as a route
  * and `next build` rejects a test file, which only that build catches.
  */
+import type * as CookiesNext from 'cookies-next';
 import type { AppContext } from 'next/app';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { civitaiTokenCookieName } from '~/libs/auth';
 import type * as FeatureFlagsService from '~/server/services/feature-flags.service';
 
 const h = vi.hoisted(() => ({
@@ -23,7 +33,7 @@ const h = vi.hoisted(() => ({
 }));
 
 vi.mock('cookies-next', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('cookies-next')>()),
+  ...(await importOriginal<typeof CookiesNext>()),
   getCookie: vi.fn(() => 'dark'),
   getCookies: vi.fn(() => h.jar),
   deleteCookie: h.deleteCookie,
@@ -98,6 +108,13 @@ describe('_app settings bootstrap — auth cookie discriminator', () => {
       h.deleteCookie,
       'an authoritative session: null means the token is genuinely expired — the stale cookie must be cleared'
     ).toHaveBeenCalledTimes(1);
+    // Pins WHICH cookie, not just that one was cleared — without this the argument is
+    // unconstrained and pointing it at a nonexistent name keeps every test green.
+    // NB this pins CURRENT behaviour, and current behaviour is narrower than the jar:
+    // `civitaiTokenCookieName` is the LEGACY `civitai-token` family, while `hasAuthCookie`
+    // above matches `civ-token` too. A session holding only a modern `civ-token` therefore
+    // gets a delete for a name that isn't present. Pre-existing; tracked separately.
+    expect(h.deleteCookie).toHaveBeenCalledWith(civitaiTokenCookieName, expect.anything());
     expect(pageProps.hasAuthCookie).toBe(false);
   });
 

--- a/src/server/common/enums.ts
+++ b/src/server/common/enums.ts
@@ -302,7 +302,9 @@ export enum EntityAccessPermission {
 // domain now). Re-exported here so the ~90 existing `~/server/common/enums` importers are unchanged and
 // there is ONE definition shared with the package — no enum-vs-union mismatch across the seam.
 // nb: when updating the values, similar updates must be made to the notification DB.
-export { NotificationCategory } from '@civitai/notifications';
+// Deep path, not the package barrel: the barrel re-exports `./client`, an HTTP client for the
+// internal notifications service, and this module has 56 client-side importers.
+export { NotificationCategory } from '@civitai/notifications/constants';
 
 export enum BanReasonCode {
   SexualMinor = 'SexualMinor',

--- a/src/server/logging/client.ts
+++ b/src/server/logging/client.ts
@@ -24,8 +24,9 @@ const noopLog = async (_data: MixedObject, _datastream?: string) => {};
 //
 // So the OTel sink is REGISTERED, not imported: `src/instrumentation.node.ts` (server-only
 // by construction) calls `setStructuredLogSink(emitOtelLog)` at boot. (That import is
-// `~/server/logging/structured-log-sink`, which has no runtime imports of its own, so it
-// adds no edge to the client graph either.)
+// `~/server/logging/structured-log-sink`, whose only import is an `import type`, so it adds
+// no FURTHER edges — though the module itself is still compiled into the client graph, and
+// `no-server-infra-in-app-graph.test.ts` records it as such.)
 //
 // 🔴 The sink object is NOT declared here, and must not be. The bundler emits THIS module
 // 14 times into one server build (measured; see the header of ./structured-log-sink), so a
@@ -36,9 +37,7 @@ const noopLog = async (_data: MixedObject, _datastream?: string) => {};
 //
 // The sink is read per call from that stable object, so registering it after the logger
 // is built still takes effect. Pinned by a test in @civitai/axiom.
-export const logToAxiom = IS_BUILD
-  ? noopLog
-  : createAxiomLogger({}, structuredLogSink).logToAxiom;
+export const logToAxiom = IS_BUILD ? noopLog : createAxiomLogger({}, structuredLogSink).logToAxiom;
 export { safeError };
 
 /**

--- a/src/server/logging/client.ts
+++ b/src/server/logging/client.ts
@@ -6,15 +6,17 @@ import { TRPCError } from '@trpc/server';
 import type { TRPC_ERROR_CODE_KEY } from '@trpc/server/rpc';
 import { createAxiomLogger, safeError } from '@civitai/axiom/client';
 import { structuredLogSink } from '~/server/logging/structured-log-sink';
-import { env } from '~/env/server';
+import { IS_BUILD } from '~/env/is-build';
 
 // The build guard is a Next.js concern, so it lives here in the app shim — not in
 // the app-agnostic @civitai/axiom package. Skip the client during `next build`.
 const noopLog = async (_data: MixedObject, _datastream?: string) => {};
 
 // 🔴 THIS MODULE IS IN THE **CLIENT** BUNDLE. It looks server-only and is not:
-// `src/pages/_app.tsx` → `~/server/services/system-cache` → `~/server/redis/fail-open-log`
+// `src/pages/_app.tsx` → `~/server/services/feature-flags.service` → `~/server/flipt/client`
 // reaches it, so anything imported here at module scope is bundled for the browser too.
+// (A dynamic `import()` does not exempt a module — the chunk is compiled, just not fetched.
+// `no-server-infra-in-app-graph.test.ts` tracks this edge in `KNOWN_REACHABLE`.)
 // A static `import { emitOtelLog } from '@civitai/telemetry/otel-logs'` here pulled
 // prom-client into the browser graph and broke `next build` with
 // `Can't resolve 'cluster' / 'fs' / 'v8'`. Nothing else catches that — typecheck, eslint
@@ -34,7 +36,7 @@ const noopLog = async (_data: MixedObject, _datastream?: string) => {};
 //
 // The sink is read per call from that stable object, so registering it after the logger
 // is built still takes effect. Pinned by a test in @civitai/axiom.
-export const logToAxiom = env.IS_BUILD
+export const logToAxiom = IS_BUILD
   ? noopLog
   : createAxiomLogger({}, structuredLogSink).logToAxiom;
 export { safeError };

--- a/src/server/services/__tests__/no-server-infra-in-app-graph.test.ts
+++ b/src/server/services/__tests__/no-server-infra-in-app-graph.test.ts
@@ -90,7 +90,7 @@ const KNOWN_REACHABLE: { file: string; reason: string }[] = [
   },
 ];
 
-const EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'];
+const EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.svelte'];
 
 function readAliasMap(): [string, string][] {
   // tsconfig is JSONC (comments + trailing commas). Use TypeScript's own parser rather than
@@ -126,7 +126,10 @@ type ExportTarget = string | Record<string, unknown> | undefined;
 function exportTargetToPath(target: ExportTarget): string | null {
   if (typeof target === 'string') return target;
   if (!target || typeof target !== 'object') return null;
-  for (const condition of ['default', 'import', 'require', 'node']) {
+  // `import` before `default`: this walks SOURCE. The conventional manifest is
+  // `{ import: './src/x.ts', default: './dist/x.cjs' }`, and preferring `default` would walk a
+  // bundled artifact whose imports are invisible — blindness, dressed as a resolution.
+  for (const condition of ['import', 'node', 'default', 'require']) {
     const value = target[condition];
     if (typeof value === 'string') return value;
   }
@@ -183,7 +186,13 @@ function resolveWorkspace(spec: string): string | null {
       best = target.replace('*', subpath.slice(prefix.length, subpath.length - suffix.length));
       bestPrefix = prefix.length;
     }
-    if (best) return resolveFile(path.join(pkg.dir, best));
+    // Fall THROUGH when a wildcard matched but its target doesn't exist. Returning here
+    // would make a wildcard key strictly worse than no map at all, since the layout
+    // fallback below would never get its turn.
+    if (best) {
+      const resolved = resolveFile(path.join(pkg.dir, best));
+      if (resolved) return resolved;
+    }
 
     // Six packages ship no `exports` map at all (buzz, redis, axiom, ...); use their layout.
     return resolveFile(path.join(pkg.dir, 'src', rest || 'index'));
@@ -193,6 +202,16 @@ function resolveWorkspace(spec: string): string | null {
 
 function resolveFile(candidate: string): string | null {
   if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) return candidate;
+  // ESM specifiers name the EMITTED file, so TS/Svelte sources are imported as `./x.js`
+  // (and Svelte 5 rune modules as `./x.svelte.js`). Every real `@civitai/ui` subpath in
+  // apps/ is spelled that way; without this swap they all resolve to nothing and the
+  // package becomes a silent external leaf.
+  if (candidate.endsWith('.js')) {
+    const stem = candidate.slice(0, -'.js'.length);
+    for (const ext of EXTENSIONS) {
+      if (fs.existsSync(stem + ext)) return stem + ext;
+    }
+  }
   for (const ext of EXTENSIONS) {
     if (fs.existsSync(candidate + ext)) return candidate + ext;
   }
@@ -333,18 +352,34 @@ describe('workspace export resolution', () => {
     expect(exportTargetToPath({ import: './src/a.ts', require: './dist/a.cjs' })).toBe(
       './src/a.ts'
     );
-    expect(exportTargetToPath({ default: './src/b.ts', import: './src/c.ts' })).toBe('./src/b.ts');
+    // `import` wins over `default`: `default` conventionally points at a built artifact, and
+    // walking that instead of source is how a resolver goes blind while looking successful.
+    expect(exportTargetToPath({ default: './dist/b.cjs', import: './src/b.ts' })).toBe(
+      './src/b.ts'
+    );
     expect(exportTargetToPath('./src/d.ts')).toBe('./src/d.ts');
     expect(exportTargetToPath(undefined)).toBeNull();
     expect(exportTargetToPath({ types: './a.d.ts' })).toBeNull();
   });
 
-  it('resolves a wildcard subpath to the package layout it actually declares', () => {
-    // `@civitai/ui` maps `./components/*` at `./src/lib/components/*`. Exact-key lookup misses,
-    // and the source-layout fallback would guess `src/components/*` and resolve nothing.
-    const resolved = resolveWorkspace('@civitai/ui/utils');
-    expect(resolved, '@civitai/ui/utils should resolve via its exports map').not.toBeNull();
-    expect(resolved!.replace(/\\/g, '/')).toContain('packages/civitai-ui/src/lib/utils.ts');
+  it('resolves a wildcard-only subpath, spelled the way the repo actually spells it', () => {
+    // Must be a subpath with NO exact key, or this passes on the exact branch and never
+    // reaches the wildcard code — `./utils` has one, so it proved nothing.
+    // `@civitai/ui` maps `./hooks/*` at `./src/lib/hooks/*`, and every real call site writes
+    // the EMITTED name (`.svelte.js`) against a `.svelte.ts` source.
+    expect(
+      Object.keys(WORKSPACE_PACKAGES.find((p) => p.name === '@civitai/ui')!.exports),
+      'pick a subpath with no exact key or this test is vacuous'
+    ).not.toContain('./hooks/is-mobile.svelte.js');
+
+    const resolved = resolveWorkspace('@civitai/ui/hooks/is-mobile.svelte.js');
+    expect(
+      resolved,
+      'a wildcard subpath must resolve, not become a silent external leaf'
+    ).not.toBeNull();
+    expect(resolved!.replace(/\\/g, '/')).toContain(
+      'packages/civitai-ui/src/lib/hooks/is-mobile.svelte.ts'
+    );
   });
 });
 

--- a/src/server/services/__tests__/no-server-infra-in-app-graph.test.ts
+++ b/src/server/services/__tests__/no-server-infra-in-app-graph.test.ts
@@ -1,0 +1,261 @@
+import fs from 'fs';
+import path from 'path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * `_app`'s module graph must not reach server infrastructure.
+ *
+ * `_app.getInitialProps` runs in the BROWSER on client-side route transitions
+ * (`node_modules/next/dist/docs/02-pages/04-api-reference/03-functions/get-initial-props.md`
+ * lines 8 and 39). The `if (!request) return initialProps;` early return makes it
+ * behaviourally server-only at RUNTIME, but the module graph is still compiled into the
+ * client bundle. A `dynamic import()` does not exempt a module either — the chunk is
+ * compiled, merely not fetched.
+ *
+ * That distinction is not intuitive, and getting it wrong is what put a Prisma client and a
+ * redis client into the browser graph. Nothing reported it: the leaves were externalised by
+ * `serverExternalPackages`, so the build stayed green. Only an `fs/promises` import ever
+ * failed loudly enough to notice.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const ENTRY = 'src/pages/_app.tsx';
+
+/**
+ * Server infrastructure: modules that open connections, read the server env, or talk to
+ * another service. Deliberately a denylist of INFRA rather than a snapshot of the current
+ * file list — a snapshot rots into churn, and the invariant we actually care about is
+ * "no infra", not "exactly these 1198 files".
+ */
+const DENIED_PREFIXES = [
+  'src/server/db/',
+  'src/server/redis/',
+  'src/server/flipt/',
+  'src/server/logging/',
+  'src/env/server.ts',
+  'src/env/server-schema.ts',
+  'src/utils/logging.ts',
+  'packages/civitai-db/',
+  'packages/civitai-redis/',
+  'packages/civitai-clickhouse/',
+  'packages/civitai-axiom/',
+];
+
+/**
+ * Violations that exist today. Each must be REMOVED from this list when fixed — the second
+ * test fails on a stale entry, so the list can shrink but never silently grow. An allowlist
+ * that keeps permitting a fixed violation is worse than no guard at all.
+ */
+const KNOWN_REACHABLE: { file: string; reason: string }[] = [
+  {
+    file: 'src/server/flipt/client.ts',
+    reason:
+      'via _app -> [dyn] feature-flags.service. Drops with the feature-flag evaluator move to ~/shared/.',
+  },
+  {
+    file: 'src/env/server.ts',
+    reason: 'sole importer in this graph is flipt/client.ts:294; drops with it.',
+  },
+  {
+    file: 'src/env/server-schema.ts',
+    reason: 'sole importer is env/server.ts; drops with it.',
+  },
+  {
+    file: 'src/server/logging/client.ts',
+    reason:
+      'TWO live paths — flipt/client.ts:3 AND audit-slow-log.ts:176 (guarded, deliberate, out of scope). Evicting flipt alone does NOT clear this one.',
+  },
+  {
+    file: 'packages/civitai-axiom/src/client.ts',
+    reason: 'via logging/client.ts:7; drops only when logging/client does.',
+  },
+  {
+    file: 'packages/civitai-axiom/src/env.ts',
+    reason: 'via civitai-axiom/src/client.ts; drops with it.',
+  },
+];
+
+const EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'];
+
+function readAliasMap(): [string, string][] {
+  // tsconfig is JSONC (comments + trailing commas). Use TypeScript's own parser rather than
+  // hand-rolled stripping, so a future edit to tsconfig can't quietly yield an empty alias
+  // map — which would resolve nothing and make this whole guard vacuously pass.
+  const file = path.join(REPO_ROOT, 'tsconfig.json');
+  const { config, error } = ts.parseConfigFileTextToJson(file, fs.readFileSync(file, 'utf8'));
+  if (error) throw new Error(`could not parse tsconfig.json: ${JSON.stringify(error.messageText)}`);
+  const paths = config?.compilerOptions?.paths as Record<string, string[]> | undefined;
+  if (!paths || !Object.keys(paths).length)
+    throw new Error('tsconfig.json has no compilerOptions.paths');
+  return Object.entries(paths).map(([k, v]) => [k, v[0]!]);
+}
+
+const ALIASES = readAliasMap();
+
+function resolveFile(candidate: string): string | null {
+  if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) return candidate;
+  for (const ext of EXTENSIONS) {
+    if (fs.existsSync(candidate + ext)) return candidate + ext;
+  }
+  for (const ext of EXTENSIONS) {
+    const index = path.join(candidate, 'index' + ext);
+    if (fs.existsSync(index)) return index;
+  }
+  return null;
+}
+
+function resolveSpecifier(spec: string, fromFile: string): string | null {
+  if (spec.startsWith('.')) {
+    return resolveFile(path.resolve(path.dirname(fromFile), spec));
+  }
+  for (const [pattern, target] of ALIASES) {
+    if (pattern.endsWith('/*')) {
+      const prefix = pattern.slice(0, -1);
+      if (spec.startsWith(prefix)) {
+        return resolveFile(path.join(REPO_ROOT, target.slice(0, -1) + spec.slice(prefix.length)));
+      }
+    } else if (spec === pattern) {
+      return resolveFile(path.join(REPO_ROOT, target));
+    }
+  }
+  return null; // node_modules / unresolvable -> external leaf
+}
+
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+}
+
+/**
+ * A named-import clause erases entirely when every specifier is type-only. Both spellings
+ * count: `import type { A }` and the inline `import { type A, type B }`. Missing the inline
+ * form makes a pure type reference look like a value edge, which mis-attributes megabytes
+ * of unrelated graph to whichever file happens to use it.
+ */
+function isTypeOnlyClause(clause: string): boolean {
+  if (/^\s*type[\s{*]/.test(clause)) return true;
+  const braces = clause.match(/\{([\s\S]*)\}/);
+  if (!braces) return false;
+  const outside = clause.slice(0, clause.indexOf('{'));
+  if (/[A-Za-z_$*]/.test(outside)) return false; // default or namespace binding present
+  const specifiers = braces[1]!
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return specifiers.length > 0 && specifiers.every((s) => /^type\s/.test(s));
+}
+
+type Edge = { spec: string; dynamic: boolean };
+
+function parseImports(source: string): Edge[] {
+  const code = stripComments(source);
+  const edges: Edge[] = [];
+  let match: RegExpExecArray | null;
+
+  const fromRe = /(?:^|[\n;}])\s*(?:import|export)\s+([\s\S]*?)from\s*['"]([^'"]+)['"]/g;
+  while ((match = fromRe.exec(code))) {
+    if (!isTypeOnlyClause(match[1]!)) edges.push({ spec: match[2]!, dynamic: false });
+  }
+  const bareRe = /(?:^|[\n;}])\s*import\s*['"]([^'"]+)['"]/g;
+  while ((match = bareRe.exec(code))) edges.push({ spec: match[1]!, dynamic: false });
+  const requireRe = /\brequire\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+  while ((match = requireRe.exec(code))) edges.push({ spec: match[1]!, dynamic: false });
+  // Followed deliberately: a lazily-fetched chunk is still a compiled chunk.
+  const dynamicRe = /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+  while ((match = dynamicRe.exec(code))) edges.push({ spec: match[1]!, dynamic: true });
+
+  return edges;
+}
+
+const rel = (abs: string) => path.relative(REPO_ROOT, abs).replace(/\\/g, '/');
+
+/**
+ * Breadth-first so a reported chain is the SHORTEST one, and `visited` bounds the walk to
+ * one visit per file — the import graph has cycles, and an unbounded walk would hang rather
+ * than fail.
+ */
+function walkGraph() {
+  const entryAbs = path.join(REPO_ROOT, ENTRY);
+  const parent = new Map<string, { from: string; dynamic: boolean } | null>([[entryAbs, null]]);
+  const queue = [entryAbs];
+  const parsed = new Map<string, Edge[]>();
+
+  while (queue.length) {
+    const file = queue.shift()!;
+    let edges = parsed.get(file);
+    if (!edges) {
+      let source = '';
+      try {
+        source = fs.readFileSync(file, 'utf8');
+      } catch {
+        continue; // unreadable -> leaf
+      }
+      edges = parseImports(source);
+      parsed.set(file, edges);
+    }
+    for (const edge of edges) {
+      const target = resolveSpecifier(edge.spec, file);
+      if (!target || parent.has(target)) continue;
+      parent.set(target, { from: file, dynamic: edge.dynamic });
+      queue.push(target);
+    }
+  }
+
+  const chainTo = (abs: string) => {
+    const hops: string[] = [];
+    let cursor: string | null = abs;
+    while (cursor) {
+      const link = parent.get(cursor);
+      hops.push(rel(cursor) + (link?.dynamic ? '   [dynamic import]' : ''));
+      cursor = link ? link.from : null;
+    }
+    return hops.reverse();
+  };
+
+  return { reachable: new Set([...parent.keys()].map(rel)), chainTo, parent };
+}
+
+const { reachable, chainTo } = walkGraph();
+const isDenied = (file: string) => DENIED_PREFIXES.some((p) => file === p || file.startsWith(p));
+const known = new Set(KNOWN_REACHABLE.map((k) => k.file));
+
+function formatViolation(file: string): string {
+  const chain = chainTo(path.join(REPO_ROOT, file));
+  const lines = chain.map((hop, i) => (i === 0 ? `    ${hop}` : `      -> ${hop}`));
+  return `  ${file}\n${lines.join('\n')}`;
+}
+
+describe('no server infrastructure in the _app client graph', () => {
+  it('walks a non-trivial graph', () => {
+    // Guards the guard: an alias-resolution or entry-path breakage would empty the graph and
+    // make every assertion below pass vacuously.
+    expect(reachable.size).toBeGreaterThan(500);
+  });
+
+  it('does not reach server infrastructure', () => {
+    const violations = [...reachable].filter((f) => isDenied(f) && !known.has(f)).sort();
+    if (violations.length) {
+      throw new Error(
+        `${violations.length} server-infrastructure module(s) reachable from ${ENTRY}.\n\n` +
+          `A dynamic import() does NOT exempt a module — the chunk is still compiled into the\n` +
+          `client bundle. Move the work behind an API route, or import the value from ~/shared/.\n\n` +
+          violations.map(formatViolation).join('\n\n') +
+          `\n`
+      );
+    }
+  });
+
+  it('has no stale KNOWN_REACHABLE entries', () => {
+    const fixed = KNOWN_REACHABLE.filter((k) => !reachable.has(k.file));
+    if (fixed.length) {
+      throw new Error(
+        `${fixed.length} KNOWN_REACHABLE entr(ies) are no longer reachable — delete them from\n` +
+          `${path.basename(
+            __filename
+          )} so the guard tightens instead of silently re-permitting them:\n\n` +
+          fixed.map((k) => `  ${k.file}\n    (${k.reason})`).join('\n\n') +
+          `\n`
+      );
+    }
+  });
+});

--- a/src/server/services/__tests__/no-server-infra-in-app-graph.test.ts
+++ b/src/server/services/__tests__/no-server-infra-in-app-graph.test.ts
@@ -72,6 +72,11 @@ const KNOWN_REACHABLE: { file: string; reason: string }[] = [
       'TWO live paths — flipt/client.ts:3 AND audit-slow-log.ts:176 (guarded, deliberate, out of scope). Evicting flipt alone does NOT clear this one.',
   },
   {
+    file: 'src/server/logging/structured-log-sink.ts',
+    reason:
+      'via logging/client.ts; a leaf (its only import is `import type`), so it adds itself and no further edges. Drops with logging/client.',
+  },
+  {
     file: 'packages/civitai-axiom/src/client.ts',
     reason: 'via logging/client.ts:7; drops only when logging/client does.',
   },

--- a/src/server/services/__tests__/no-server-infra-in-app-graph.test.ts
+++ b/src/server/services/__tests__/no-server-infra-in-app-graph.test.ts
@@ -40,6 +40,11 @@ const DENIED_PREFIXES = [
   'packages/civitai-redis/',
   'packages/civitai-clickhouse/',
   'packages/civitai-axiom/',
+  'packages/civitai-telemetry/',
+  // Not the whole package: most of @civitai/buzz is pure pricing/limits constants that client
+  // code legitimately uses. Only the service transport and its env slice are infra.
+  'packages/civitai-buzz/src/client.ts',
+  'packages/civitai-buzz/src/env.ts',
 ];
 
 /**
@@ -74,6 +79,15 @@ const KNOWN_REACHABLE: { file: string; reason: string }[] = [
     file: 'packages/civitai-axiom/src/env.ts',
     reason: 'via civitai-axiom/src/client.ts; drops with it.',
   },
+  {
+    file: 'packages/civitai-buzz/src/client.ts',
+    reason:
+      'PRE-EXISTING, invisible until this guard learned to resolve unaliased workspace packages. Static chain: _app -> SignalsProviderStack -> SignalsNotifications -> shared/constants/buzz.constants.ts -> the @civitai/buzz BARREL, which `export * from ./client`. buzz.constants only needs ./account-types. Fix needs an `exports` map on @civitai/buzz (it ships none) so the import can go deep.',
+  },
+  {
+    file: 'packages/civitai-buzz/src/env.ts',
+    reason: 'same barrel chain as civitai-buzz/src/client.ts; drops with the same fix.',
+  },
 ];
 
 const EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'];
@@ -92,6 +106,47 @@ function readAliasMap(): [string, string][] {
 }
 
 const ALIASES = readAliasMap();
+
+/**
+ * Workspace packages resolved from each `package.json` `exports` map — the real contract, and
+ * the only thing that covers deep subpaths. tsconfig aliases only 8 of the 15 packages, so
+ * alias-only resolution silently treated `@civitai/auth`, `buzz`, `shared`, `ui`, `email`,
+ * `storage` and `db-queries` as external leaves and stopped walking there. That mattered:
+ * `@civitai/auth`'s barrel reaches `redis.ts`, which imports `@civitai/redis` — so the
+ * invariant held only because call sites happen to spell it `@civitai/auth/client`, something
+ * the guard could not see and a one-word edit would undo.
+ */
+function readWorkspacePackages(): { name: string; dir: string; exports: Record<string, string> }[] {
+  const packagesDir = path.join(REPO_ROOT, 'packages');
+  const out: { name: string; dir: string; exports: Record<string, string> }[] = [];
+  for (const entry of fs.readdirSync(packagesDir)) {
+    const manifest = path.join(packagesDir, entry, 'package.json');
+    if (!fs.existsSync(manifest)) continue;
+    const json = JSON.parse(fs.readFileSync(manifest, 'utf8')) as {
+      name?: string;
+      exports?: Record<string, string>;
+    };
+    if (!json.name) continue;
+    out.push({ name: json.name, dir: path.join(packagesDir, entry), exports: json.exports ?? {} });
+  }
+  if (!out.length) throw new Error('no workspace packages found under packages/');
+  return out;
+}
+
+const WORKSPACE_PACKAGES = readWorkspacePackages();
+
+function resolveWorkspace(spec: string): string | null {
+  for (const pkg of WORKSPACE_PACKAGES) {
+    if (spec !== pkg.name && !spec.startsWith(pkg.name + '/')) continue;
+    const rest = spec === pkg.name ? '' : spec.slice(pkg.name.length + 1);
+    const subpath = rest ? `./${rest}` : '.';
+    const target = pkg.exports[subpath];
+    if (target) return resolveFile(path.join(pkg.dir, target));
+    // `@civitai/buzz` ships no exports map at all; fall back to the source layout.
+    return resolveFile(path.join(pkg.dir, 'src', rest || 'index'));
+  }
+  return null;
+}
 
 function resolveFile(candidate: string): string | null {
   if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) return candidate;
@@ -119,7 +174,7 @@ function resolveSpecifier(spec: string, fromFile: string): string | null {
       return resolveFile(path.join(REPO_ROOT, target));
     }
   }
-  return null; // node_modules / unresolvable -> external leaf
+  return resolveWorkspace(spec); // null -> node_modules / unresolvable -> external leaf
 }
 
 function stripComments(source: string): string {
@@ -229,7 +284,7 @@ describe('no server infrastructure in the _app client graph', () => {
   it('walks a non-trivial graph', () => {
     // Guards the guard: an alias-resolution or entry-path breakage would empty the graph and
     // make every assertion below pass vacuously.
-    expect(reachable.size).toBeGreaterThan(500);
+    expect(reachable.size).toBeGreaterThan(1000);
   });
 
   it('does not reach server infrastructure', () => {

--- a/src/server/services/__tests__/no-server-infra-in-app-graph.test.ts
+++ b/src/server/services/__tests__/no-server-infra-in-app-graph.test.ts
@@ -116,15 +116,36 @@ const ALIASES = readAliasMap();
  * invariant held only because call sites happen to spell it `@civitai/auth/client`, something
  * the guard could not see and a one-word edit would undo.
  */
-function readWorkspacePackages(): { name: string; dir: string; exports: Record<string, string> }[] {
+/**
+ * An `exports` value is a path, or a conditions object (`{ import, require, default }`).
+ * Returning null rather than throwing on an unrecognised shape matters: this runs at module
+ * scope, so a throw here fails COLLECTION, and a file that collects nothing reads as a pass.
+ */
+type ExportTarget = string | Record<string, unknown> | undefined;
+
+function exportTargetToPath(target: ExportTarget): string | null {
+  if (typeof target === 'string') return target;
+  if (!target || typeof target !== 'object') return null;
+  for (const condition of ['default', 'import', 'require', 'node']) {
+    const value = target[condition];
+    if (typeof value === 'string') return value;
+  }
+  return null;
+}
+
+function readWorkspacePackages(): {
+  name: string;
+  dir: string;
+  exports: Record<string, ExportTarget>;
+}[] {
   const packagesDir = path.join(REPO_ROOT, 'packages');
-  const out: { name: string; dir: string; exports: Record<string, string> }[] = [];
+  const out: { name: string; dir: string; exports: Record<string, ExportTarget> }[] = [];
   for (const entry of fs.readdirSync(packagesDir)) {
     const manifest = path.join(packagesDir, entry, 'package.json');
     if (!fs.existsSync(manifest)) continue;
     const json = JSON.parse(fs.readFileSync(manifest, 'utf8')) as {
       name?: string;
-      exports?: Record<string, string>;
+      exports?: Record<string, ExportTarget>;
     };
     if (!json.name) continue;
     out.push({ name: json.name, dir: path.join(packagesDir, entry), exports: json.exports ?? {} });
@@ -140,9 +161,31 @@ function resolveWorkspace(spec: string): string | null {
     if (spec !== pkg.name && !spec.startsWith(pkg.name + '/')) continue;
     const rest = spec === pkg.name ? '' : spec.slice(pkg.name.length + 1);
     const subpath = rest ? `./${rest}` : '.';
-    const target = pkg.exports[subpath];
-    if (target) return resolveFile(path.join(pkg.dir, target));
-    // `@civitai/buzz` ships no exports map at all; fall back to the source layout.
+
+    const exact = exportTargetToPath(pkg.exports[subpath]);
+    if (exact) return resolveFile(path.join(pkg.dir, exact));
+
+    // Wildcard keys, longest-prefix-wins per the exports spec. `@civitai/ui` maps
+    // `./components/*` at `./src/lib/components/*` — without this the subpath misses the map
+    // and the source-layout fallback guesses `src/components/*`, which does not exist, so the
+    // module becomes a silent external leaf: the exact blindness this guard exists to prevent.
+    let best: string | null = null;
+    let bestPrefix = -1;
+    for (const [key, value] of Object.entries(pkg.exports)) {
+      const star = key.indexOf('*');
+      if (star === -1) continue;
+      const prefix = key.slice(0, star);
+      const suffix = key.slice(star + 1);
+      if (!subpath.startsWith(prefix) || !subpath.endsWith(suffix)) continue;
+      if (prefix.length <= bestPrefix) continue;
+      const target = exportTargetToPath(value);
+      if (!target) continue;
+      best = target.replace('*', subpath.slice(prefix.length, subpath.length - suffix.length));
+      bestPrefix = prefix.length;
+    }
+    if (best) return resolveFile(path.join(pkg.dir, best));
+
+    // Six packages ship no `exports` map at all (buzz, redis, axiom, ...); use their layout.
     return resolveFile(path.join(pkg.dir, 'src', rest || 'index'));
   }
   return null;
@@ -279,6 +322,31 @@ function formatViolation(file: string): string {
   const lines = chain.map((hop, i) => (i === 0 ? `    ${hop}` : `      -> ${hop}`));
   return `  ${file}\n${lines.join('\n')}`;
 }
+
+describe('workspace export resolution', () => {
+  // Every manifest ships flat string targets today, so the conditions form is unexercised by
+  // the walk above. It still has to be handled here rather than in review: `path.join` throws
+  // on a non-string, and this resolver runs at MODULE SCOPE, so the first package to adopt
+  // `{ "import": ..., "require": ... }` would fail COLLECTION — which reports as no tests
+  // rather than as red.
+  it('reads a path out of a conditional export instead of throwing', () => {
+    expect(exportTargetToPath({ import: './src/a.ts', require: './dist/a.cjs' })).toBe(
+      './src/a.ts'
+    );
+    expect(exportTargetToPath({ default: './src/b.ts', import: './src/c.ts' })).toBe('./src/b.ts');
+    expect(exportTargetToPath('./src/d.ts')).toBe('./src/d.ts');
+    expect(exportTargetToPath(undefined)).toBeNull();
+    expect(exportTargetToPath({ types: './a.d.ts' })).toBeNull();
+  });
+
+  it('resolves a wildcard subpath to the package layout it actually declares', () => {
+    // `@civitai/ui` maps `./components/*` at `./src/lib/components/*`. Exact-key lookup misses,
+    // and the source-layout fallback would guess `src/components/*` and resolve nothing.
+    const resolved = resolveWorkspace('@civitai/ui/utils');
+    expect(resolved, '@civitai/ui/utils should resolve via its exports map').not.toBeNull();
+    expect(resolved!.replace(/\\/g, '/')).toContain('packages/civitai-ui/src/lib/utils.ts');
+  });
+});
 
 describe('no server infrastructure in the _app client graph', () => {
   it('walks a non-trivial graph', () => {

--- a/src/server/utils/__tests__/server-domain.board-color.test.ts
+++ b/src/server/utils/__tests__/server-domain.board-color.test.ts
@@ -10,19 +10,18 @@ import { describe, expect, it, vi } from 'vitest';
  * `getRequestDomainColor` would be hidden on every host rather than moved to .red.
  * These tests pin the escape hatch so that regression can't come back a third time
  * (App Blocks hit it first).
+ *
+ * `serverDomainMap` is built from `process.env` at module load, so the stubs must be
+ * in place before the `await import('../server-domain')` inside each test.
  */
-vi.mock('~/env/server', () => ({
-  env: {
-    SERVER_DOMAIN_GREEN: 'civitai.com',
-    SERVER_DOMAIN_GREEN_ALIASES: '',
-    // Mirrors prod exactly, including the blue alias — `civitaired.com` is a live
-    // front door configured ONLY as a blue alias, while red has no aliases at all.
-    SERVER_DOMAIN_BLUE: 'civitai.red',
-    SERVER_DOMAIN_BLUE_ALIASES: 'civitaired.com',
-    SERVER_DOMAIN_RED: 'civitai.red',
-    SERVER_DOMAIN_RED_ALIASES: 'www.civitai.red',
-  },
-}));
+vi.stubEnv('SERVER_DOMAIN_GREEN', 'civitai.com');
+vi.stubEnv('SERVER_DOMAIN_GREEN_ALIASES', '');
+// Mirrors prod exactly, including the blue alias — `civitaired.com` is a live
+// front door configured ONLY as a blue alias, while red has no aliases at all.
+vi.stubEnv('SERVER_DOMAIN_BLUE', 'civitai.red');
+vi.stubEnv('SERVER_DOMAIN_BLUE_ALIASES', 'civitaired.com');
+vi.stubEnv('SERVER_DOMAIN_RED', 'civitai.red');
+vi.stubEnv('SERVER_DOMAIN_RED_ALIASES', 'www.civitai.red');
 
 const req = (host?: string) => ({ headers: { host } });
 

--- a/src/server/utils/__tests__/server-domain.nsfw-rating.test.ts
+++ b/src/server/utils/__tests__/server-domain.nsfw-rating.test.ts
@@ -4,25 +4,21 @@ import { describe, expect, it, vi } from 'vitest';
  * NSFW-APP-RED-ONLY helper tests — `isMatureContentRating` + `ratingAllowedOnHost`
  * (src/server/utils/server-domain.ts).
  *
- * server-domain.ts builds `serverDomainMap` from the validated server env AT
- * IMPORT, so we stub `~/env/server` with a realistic multi-color config that
- * mirrors production: civitai.red is configured as BOTH a blue and a red domain
- * (the exact shape that makes `getRequestDomainColor('civitai.red')` return
- * `blue` while `isHostForColor('civitai.red', 'red')` returns true). The host
- * gate must key off RED capability, not the color walk.
+ * server-domain.ts builds `serverDomainMap` from `process.env` AT IMPORT, so we
+ * stub a realistic multi-color config that mirrors production: civitai.red is
+ * configured as BOTH a blue and a red domain (the exact shape that makes
+ * `getRequestDomainColor('civitai.red')` return `blue` while
+ * `isHostForColor('civitai.red', 'red')` returns true). The host gate must key off
+ * RED capability, not the color walk.
  */
-vi.mock('~/env/server', () => ({
-  env: {
-    SERVER_DOMAIN_GREEN: 'civitai.green',
-    SERVER_DOMAIN_GREEN_ALIASES: '',
-    // blue's primary is civitai.com, and civitai.red is also a blue alias — this
-    // is what makes the color-walk return blue for .red.
-    SERVER_DOMAIN_BLUE: 'civitai.com',
-    SERVER_DOMAIN_BLUE_ALIASES: 'civitai.red',
-    SERVER_DOMAIN_RED: 'civitai.red',
-    SERVER_DOMAIN_RED_ALIASES: 'www.civitai.red',
-  },
-}));
+vi.stubEnv('SERVER_DOMAIN_GREEN', 'civitai.green');
+vi.stubEnv('SERVER_DOMAIN_GREEN_ALIASES', '');
+// blue's primary is civitai.com, and civitai.red is also a blue alias — this
+// is what makes the color-walk return blue for .red.
+vi.stubEnv('SERVER_DOMAIN_BLUE', 'civitai.com');
+vi.stubEnv('SERVER_DOMAIN_BLUE_ALIASES', 'civitai.red');
+vi.stubEnv('SERVER_DOMAIN_RED', 'civitai.red');
+vi.stubEnv('SERVER_DOMAIN_RED_ALIASES', 'www.civitai.red');
 
 const RED_HOST = 'civitai.red';
 const RED_ALIAS = 'www.civitai.red';

--- a/src/server/utils/server-domain.ts
+++ b/src/server/utils/server-domain.ts
@@ -1,4 +1,3 @@
-import { env } from '~/env/server';
 import {
   colorDomainNames,
   type ColorDomain,
@@ -29,10 +28,24 @@ function buildConfig(primary: string | undefined, aliases: string[]): DomainConf
   return { primary: primary.toLowerCase(), aliases };
 }
 
+// Read from `process.env` rather than `~/env/server`: these are the only vars this
+// module needs, they are declared `z.string().optional()` with no default or
+// transform (server-schema.ts:738-743), so the value is identical — and importing
+// the validated `env` object would drag the whole server env schema into every
+// graph that touches domain resolution, including `_app`'s client graph.
 export const serverDomainMap: ServerDomains = {
-  green: buildConfig(env.SERVER_DOMAIN_GREEN, parseAliases(env.SERVER_DOMAIN_GREEN_ALIASES)),
-  blue: buildConfig(env.SERVER_DOMAIN_BLUE, parseAliases(env.SERVER_DOMAIN_BLUE_ALIASES)),
-  red: buildConfig(env.SERVER_DOMAIN_RED, parseAliases(env.SERVER_DOMAIN_RED_ALIASES)),
+  green: buildConfig(
+    process.env.SERVER_DOMAIN_GREEN,
+    parseAliases(process.env.SERVER_DOMAIN_GREEN_ALIASES)
+  ),
+  blue: buildConfig(
+    process.env.SERVER_DOMAIN_BLUE,
+    parseAliases(process.env.SERVER_DOMAIN_BLUE_ALIASES)
+  ),
+  red: buildConfig(
+    process.env.SERVER_DOMAIN_RED,
+    parseAliases(process.env.SERVER_DOMAIN_RED_ALIASES)
+  ),
 };
 
 /** Canonical-only projection. Used by client and outbound URL helpers. */

--- a/src/utils/metadata/audit-slow-log.ts
+++ b/src/utils/metadata/audit-slow-log.ts
@@ -170,7 +170,9 @@ function emitSlowLog(input: SlowLogInput): void {
         if (negativePrompt) payload.rawNegativePrompt = truncateMiddle(negativePrompt, rawMax);
       }
 
-      // Dynamic server-only import (code-split, never in the client bundle).
+      // Deferred so the module is never EVALUATED on the client — the callers above
+      // guard on `typeof window !== 'undefined'`. It is still compiled into the client
+      // chunk graph: a dynamic import splits the chunk, it does not remove the edge.
       const { logToAxiom } = await import('~/server/logging/client');
       await logToAxiom(payload);
     } catch {


### PR DESCRIPTION
## What

Removes **95 modules** from `src/pages/_app.tsx`'s client module graph (1306 → 1211), including all of
`@civitai/db`, all of `@civitai/redis`, nine `src/server/auth/*` files, `prom/client`, and `system-cache`.
Adds a convention guard so it can't silently come back.

## Why this was possible

`_app.getInitialProps` runs **in the browser** on client-side route transitions
([Next 16 docs](https://nextjs.org/docs/pages/api-reference/functions/get-initial-props)). The
`if (!request) return initialProps;` early-return makes it behaviourally server-only at *runtime*, but the
module graph is still compiled into the client bundle — and **a `dynamic import()` doesn't exempt a module
either**; the chunk is compiled, just never fetched.

That misconception is why a Prisma client and a redis client were reachable from `_app`. It was also written
into the tree as fact at `src/utils/metadata/audit-slow-log.ts` ("never in the client bundle"), corrected here.

We'd already half-fixed this once — `src/pages/api/user/settings.ts` carries a comment explaining that
`content.service` was moved into the endpoint because `fs/promises` broke the client build. The migration
stalled where the build stopped complaining: `redis` and `@prisma/client` are in `serverExternalPackages`, so
Turbopack externalises them and the build stays green while the first-party server tree keeps getting compiled.

## Changes

| Commit | |
|---|---|
| `c25f958a89` | Delete a dead import of `~/pages/api/admin/refresh-sessions` from `memberships.util.ts` |
| `3325751c66` | Move the `system-cache` bootstrap (`getBrowsingSettingAddons`, `getLiveNow`) into `/api/user/settings` |
| `14cb44a2f4` | Stop `logging/client` and `server-domain` pulling the 958-line server env schema for three values |
| `193c1bbcbd` | Import `NotificationCategory` from `@civitai/notifications/constants`, not the barrel |
| `cd3fba3358`, `99c8a3a2a5`, `a41fdf82ab` | Convention guard: fail if `_app`'s graph reaches server infrastructure |
| `3b6a64bb63` | `.catch` on `getTosMeta`; correct two comments that described guards which don't exist |
| `271dcaa567` | Guard `process.argv` in `is-build.ts` |
| `4e0e88a319`, `3cb2c4186d` | Regression test pinning the auth-cookie discriminator |
| `178339669c` | Guard resolver: conditional + wildcard `exports`, `.js`→source extension |
| `83432a7f17` | **Stop deleting the auth cookie on an ambiguous `session: null`** (see below) |
| `2b8094df66` | Drop a stale comment |

**The single biggest win is the one-line deletion in `c25f958a89`**, not the refactor. That dead import was
dragging `refresh-sessions → endpoint-helpers → auth/db/redis/prom/orchestrator` in through a *statically*
imported component chain (`AppLayout → RewardsBonusBanner → dialog-registry2 → PaddleTransacionModal →
memberships.util`). Worth knowing when weighing the rest of the diff's risk against its payoff.

## Auth fix included (pre-existing bug, found by review of this branch)

`_app` deleted the auth cookie whenever a **successful** settings fetch returned `session: null`, on the
reasoning that an authoritative "no session" means the token is expired. That reasoning doesn't hold:
`getServerAuthSession` fails *soft* — `.catch(() => null)` on both the hub and legacy lookups — so a hub
outage produces `session: null` with the key present and is indistinguishable on the wire from a genuinely
expired token. The result was that a hub blip logged valid users out **durably**, putting a logout storm on
an auth hub that was already degraded.

`83432a7f17` stops deleting the cookie on that signal. The render still goes anonymous
(`hasAuthCookie = false`), so an expired token behaves as before from the user's point of view, and an outage
becomes a transient logged-out *appearance* that recovers on the next successful bootstrap. Cost: a genuinely
dead cookie now lingers until it expires.

This also moots a second pre-existing bug found alongside it — the delete only covered the legacy
`civitai-token` family while `hasAuthCookie` matches `civ-token` too, so modern sessions were getting a
delete for a name that wasn't there.

Deleting safely (rather than not at all) needs the endpoint to signal a degraded lookup distinctly from "no
session". That changes `getServerAuthSession`'s contract, which has 58 callers, so it's tracked as a
follow-up rather than bundled here.

## Incidental fix

`_app` previously ran a **serial** `await getLiveNow()` after two `Promise.all` waves. `getLiveNow` has no
deadline race (unlike `getBrowsingSettingAddons`, which uses `withSysReadDeadline`), so a half-open redis
parked every page render indefinitely. It now sits behind the settings fetch's `AbortSignal.timeout`.

## Behaviour change — please read

`browsingSettingsAddons` used to be computed independently in `_app` and **survived** a settings-endpoint
failure. It now rides the same fetch. Two degraded states result, and only one self-heals:

- **Settings fetch fails** (8s timeout, non-OK, or the endpoint's outer catch) → addons arrive `undefined` →
  the provider is unseeded → the tRPC query fires → defaults for the first paint, live config one round trip
  later. Rare, self-healing.
- **sysRedis degraded but the endpoint succeeds** → `getBrowsingSettingAddons` fails open and *returns* the
  DEFAULT array → seeded as `initialData` under `staleTime`/`gcTime: Infinity` → **pinned for the session**,
  live config only on the next full page load. **Not self-healing.**

The second is pre-existing in shape (base behaves identically) but is now the documented path. Closing it
properly needs `system-cache` to signal its fail-open with a sentinel so callers can choose to seed nothing —
tracked as follow-up, not attempted here.

The `.catch` on `getTosMeta` removes one degradation trigger, not all: `getServerAuthSession` and
`getUserContentSettings` remain uncaught above the `Promise.all`.

## The guard

`src/server/services/__tests__/no-server-infra-in-app-graph.test.ts`, wired into `pnpm run test:lint-rules`.
Walks `_app`'s graph (static **and** dynamic imports, erasing type-only imports including the all-inline
`{ type X }` form) and fails if it reaches `src/server/{db,redis,flipt,logging}`, `src/env/server*`,
`src/utils/logging`, or `@civitai/{db,redis,clickhouse,axiom,telemetry}`.

Denylist, not a snapshot. `KNOWN_REACHABLE` must **shrink but never grow** — the test also fails if a listed
entry becomes unreachable, so fixing one forces deleting it. Two entries today
(`@civitai/buzz`'s `client.ts`/`env.ts`, pre-existing, see below).

On violation it prints the full import chain, one hop per line, marking dynamic hops. Mutation-tested.

## Known-reachable, not fixed here

`packages/civitai-buzz/src/index.ts` does `export * from './client'`, and `client.ts` is a 17 KB server-side
HTTP client for the buzz service. It reaches `_app` **statically** via
`SignalsProviderStack → SignalsNotifications → shared/constants/buzz.constants.ts → @civitai/buzz`.
`buzz.constants.ts` only needs `./account-types`; its own comment calls the import "browser-safe", which is
true of `account-types` and false of the barrel.

Pre-existing — confirmed reachable at the base commit with the same resolver. Not fixed because 38 files
import the bare barrel, nothing uses a deep path, and the real fix is adding an `exports` map to the package
and dropping `./client` from the barrel, which has cross-app blast radius.

## Testing

- `pnpm run typecheck` — 0 errors
- `pnpm run test:unit:run` — 13,726 collected, 16 failed / 13,708 passed / 2 skipped. All 16 failures verified
  pre-existing against a byte-identical base tree; passes went 13,699 → 13,708, exactly the 9 added.
- `pnpm run test:lint-rules` — 208 passed / 1 failed; the single failure is the pre-existing
  `no-wholesale-module-mock` fixture
- New: 7 tests pinning the auth-cookie discriminator, which had **zero** coverage. Its observable is
  `pageProps.hasAuthCookie`; the `deleteCookie` assertions pin that no path deletes the cookie, so
  reintroducing a delete fails them. Mutation-tested: dropping `!settingsDegraded` fails 4 cases, dropping
  `hasAuthCookie = false` fails 1, both in under a second with assertion messages naming the consequence.

Note on the failure counts: the *set* of failing files shifted between runs while the count stayed at 16
(`warmup` appeared; `eventloop-watchdog.capture` and `scripts/typecheck` dropped out). Some are flaky or
host-dependent, so treat "16 pre-existing" as a count, not a fixed list. `pnpm run lint` does not pass on
`main` either (`src/server/logging/client.ts` has a pre-existing `no-empty-function` error, plus untouched
`apps/` files) — the accurate claim here is that this branch **adds no lint errors**.

## Measured: build memory. It's a negative result.

Peak builder RSS, same node (`ve7-5mi`), same preview pipeline, same `NODE_BUILD_MEM=16384`:

```
pr-preview-3807-5w96n   17.9 GiB   #3807's flags only
pr-preview-3802-fkwlh   17.4 GiB   + this PR's 95 removed modules
```

**−2.8% for ~7% of the graph removed.** So module-graph size is **not** a meaningful lever on peak
builder RSS, and this PR does **not** buy back headroom for the `turbopackServerSideNestedAsyncChunking`
regression taken in #3807. If that flag goes back on, the headroom has to come from somewhere else.

Caveat: the two builds ran ~2.5h apart so cache warmth differed, which makes 0.5 GiB more likely an
overstatement than an understatement. Measurements by @ivy.

This was a falsifiable prediction and it failed. The case for this PR is the correctness one below —
no Prisma client, no redis client, no server env schema compiled into the browser graph — not build memory.

## `@mantine/core` was removed from this PR after preview caught it 500ing

An earlier revision added `@mantine/core` to `optimizePackageImports`. It **500'd every Mantine-heavy
route**: `⨯ @mantine/core: MantineProvider was not found in component tree`. Preview smoke went
31 passed / 34 failed, against 65/65 on three control PRs the same day.

`optimizePackageImports` rewrites barrel imports into deep per-component imports, and for a package that
creates React **context** that can put the provider and its consumers on different module instances — the
provider is in the tree, but consumers read a context object created by another copy. The error message
says "not found" when the truth is "found a different one", so it sends you debugging the provider.

Reverted in `4855a377d9`, with a comment at the callsite so nobody re-adds it or adds
`@mantine/modals` / `@mantine/notifications`, which are the same hazard class. **Nothing local catches
this** — typecheck, lint and both vitest projects stayed green; the flag only takes effect in a real build.

## Not measured: actual downloaded bytes

Every number above is **modules in the import graph**, not First Load JS. Source size counts code behind
`dynamic()` boundaries that users never download — that proxy produced three wrong calls during this work
before tooling caught them.

`next build` currently segfaults locally (native crash during page-data collection, plus an "Invalid media
query" Lightning CSS parse error in `src/pages/models/[id]/review.module.scss`) — reproduced on a commit
predating this branch, so pre-existing and unrelated. The real number should come from the preview build's
`scripts/bundle-budget.mjs` output against the recorded baseline (shared 425.9 kB).

**Please check that before merging.** If First Load JS hasn't moved, the correctness and guard changes still
stand on their own, but the perf framing should be dropped.

## Review

Adversarially reviewed twice by an agent with no prior context, which found 5 issues (all fixed) and verified
the fixes. Security and auth-discriminator paths came back clean: both new endpoint fields are already
anonymously readable via `system.router.ts`'s `publicProcedure`s, and no server env var is inlined into a
client bundle.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
