### PR TITLE
fix(app-listings): re-verify listing media at attach, not only at upload

### DIFF
--- a/src/server/services/blocks/__tests__/listing-asset-upload-integrity.test.ts
+++ b/src/server/services/blocks/__tests__/listing-asset-upload-integrity.test.ts
@@ -3,6 +3,7 @@ import { GetObjectCommand, HeadObjectCommand } from '@aws-sdk/client-s3';
 import sharp from 'sharp';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type * as LoggingClient from '~/server/logging/client';
 import type * as S3Utils from '~/utils/s3-utils';
 
 /**
@@ -27,14 +28,27 @@ import type * as S3Utils from '~/utils/s3-utils';
  * The dimension every case varies is the identity of the stored object, and the
  * fixtures cross it in both directions: an untouched object attaches (proving the
  * guard is not a blanket reject), a replaced one does not.
+ *
+ * 🔴 SECOND DIMENSION: THE ASSET KIND. The guard is placed ONCE, in the shared
+ * `loadValidatedImage`, precisely so all three attach procs inherit it rather than
+ * re-deriving it — which means "it is placed once" is a claim about all three, and
+ * covering only `icon` leaves it pinned for none of the others. A guard narrowed to
+ * a single kind is a one-word edit away and, covered from one kind only, is
+ * INVISIBLE. So the accept/refuse pair below is run across icon, cover AND
+ * screenshot, each through its own real proc.
  */
 
-const { mockRead, mockWrite, mockCreateImage, mockS3Send } = vi.hoisted(() => {
+const { mockRead, mockWrite, mockCreateImage, mockS3Send, mockLogToAxiom } = vi.hoisted(() => {
   const db = {
     appListing: {
       findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
       findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
       update: vi.fn(async (..._a: unknown[]) => ({})),
+    },
+    appListingScreenshot: {
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+      count: vi.fn(async (..._a: unknown[]) => 0),
+      create: vi.fn(async (..._a: unknown[]) => ({})),
     },
     image: {
       findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
@@ -50,10 +64,17 @@ const { mockRead, mockWrite, mockCreateImage, mockS3Send } = vi.hoisted(() => {
     mockWrite: db,
     mockCreateImage: vi.fn(async (..._a: unknown[]) => ({ id: 777 })),
     mockS3Send: vi.fn(),
+    mockLogToAxiom: vi.fn(async (..._a: unknown[]) => undefined),
   };
 });
 
 vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockWrite }));
+// Only the SINK is replaced — every field the service decides to emit is the real
+// one, so an assertion here is about what an operator would actually receive.
+vi.mock('~/server/logging/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof LoggingClient>()),
+  logToAxiom: mockLogToAxiom,
+}));
 vi.mock('~/server/services/image.service', () => ({ createImage: mockCreateImage }));
 vi.mock('~/server/utils/app-block-ids', () => ({
   newAppListingId: () => 'apl_test_1',
@@ -185,6 +206,49 @@ async function attachAsIcon() {
   return setListingIcon({ listingId: 'apl_1', imageId: 500 }, owner);
 }
 
+/**
+ * One entry per asset kind, so the accept/refuse pair below runs through the REAL
+ * proc a client would call rather than through `loadValidatedImage` directly.
+ *
+ * `measured` is a geometry that satisfies THAT kind's own bounds (icon square,
+ * cover landscape ≥640px wide, screenshot ≥320px on its short side), so a case that
+ * fails does so for the integrity reason and not because the fixture tripped an
+ * unrelated rule. `assertNoWrite` names the write each proc would have made, so
+ * "refused" means nothing landed rather than just "it threw".
+ */
+const KIND_FIXTURES = [
+  {
+    kind: 'icon' as const,
+    measured: { width: 512, height: 512 },
+    sameShape: { width: 512, height: 512, shade: 200 },
+    attach: attachAsIcon,
+    attached: { status: 'attached', iconId: 500 },
+    assertNoWrite: () => expect(mockWrite.appListing.update).not.toHaveBeenCalled(),
+  },
+  {
+    kind: 'cover' as const,
+    measured: { width: 1280, height: 720 },
+    sameShape: { width: 1280, height: 720, shade: 200 },
+    attach: async () => {
+      const { setListingCover } = await import('../app-listing-assets.service');
+      return setListingCover({ listingId: 'apl_1', imageId: 500 }, owner);
+    },
+    attached: { status: 'attached', coverId: 500 },
+    assertNoWrite: () => expect(mockWrite.appListing.update).not.toHaveBeenCalled(),
+  },
+  {
+    kind: 'screenshot' as const,
+    measured: { width: 1280, height: 720 },
+    sameShape: { width: 1280, height: 720, shade: 200 },
+    attach: async () => {
+      const { addListingScreenshot } = await import('../app-listing-assets.service');
+      return addListingScreenshot({ listingId: 'apl_1', imageId: 500 }, owner);
+    },
+    attached: { status: 'attached', id: 'apls_test_1', order: 0 },
+    assertNoWrite: () => expect(mockWrite.appListingScreenshot.create).not.toHaveBeenCalled(),
+  },
+];
+
 beforeEach(() => {
   store.clear();
   fixtureCache.clear();
@@ -194,7 +258,11 @@ beforeEach(() => {
   mockRead.appListing.update.mockReset().mockResolvedValue({});
   mockRead.image.findUnique.mockReset().mockResolvedValue(null);
   mockRead.image.findMany.mockReset().mockResolvedValue([]);
+  mockWrite.appListingScreenshot.findMany.mockReset().mockResolvedValue([]);
+  mockWrite.appListingScreenshot.count.mockReset().mockResolvedValue(0);
+  mockWrite.appListingScreenshot.create.mockReset().mockResolvedValue({});
   mockCreateImage.mockReset().mockResolvedValue({ id: 777 });
+  mockLogToAxiom.mockReset().mockResolvedValue(undefined);
 });
 
 describe('listing media — the persisted measurement is re-verified at attach', () => {
@@ -211,69 +279,80 @@ describe('listing media — the persisted measurement is re-verified at attach',
     expect(readRecordedEtag(metadata)).toBe(etagOf(original).replaceAll('"', ''));
   });
 
-  it('attaches normally while the stored object is still the measured one', async () => {
-    const original = await flatPng(512, 512, 8);
-    putObject(KEY, original);
-    const metadata = await persistAndCaptureMetadata();
-    mockRead.image.findUnique.mockResolvedValue(rowWith(metadata, { width: 512, height: 512 }));
-    mockS3Send.mockClear();
-
-    await expect(attachAsIcon()).resolves.toMatchObject({ status: 'attached', iconId: 500 });
-    expect(mockRead.appListing.update).toHaveBeenCalled();
-
-    // 🔴 POSITIVE CONTROL for REACHABILITY. The accept above must be the guard
-    // running and agreeing, not the guard being skipped — those are the same
-    // observable from the outside. So assert the head request was actually issued
-    // against this key: with the check short-circuited, this count is 0.
-    const heads = mockS3Send.mock.calls.filter(
-      ([cmd]) => cmd instanceof HeadObjectCommand && (cmd as HeadObjectCommand).input.Key === KEY
-    );
-    expect(heads).toHaveLength(1);
-  });
-
   /**
-   * 🔴 THE REGRESSION. Same row, same columns, same caller — only the bytes behind
-   * the key differ from the ones those columns were measured from. Before this
-   * guard the attach succeeded and the listing was validated against geometry that
-   * was no longer in the store.
+   * 🔴 RUN PER KIND, NOT ONCE. The guard lives in the shared loader, so narrowing
+   * it to one kind (`if (kind === 'icon') …`) leaves the other two attach procs
+   * silently unguarded while every icon case still passes. These three cases are
+   * what makes that edit visible: each drives the REAL proc for its own kind.
    */
-  it('REFUSES the attach once the stored object is no longer the measured one', async () => {
-    const original = await flatPng(512, 512, 8);
-    putObject(KEY, original);
-    const metadata = await persistAndCaptureMetadata();
-    const row = rowWith(metadata, { width: 512, height: 512 });
-    mockRead.image.findUnique.mockResolvedValue(row);
+  describe.each(KIND_FIXTURES)(
+    '$kind',
+    ({ measured, sameShape, attach, attached, assertNoWrite }) => {
+      it('attaches normally while the stored object is still the measured one', async () => {
+        const original = await flatPng(measured.width, measured.height, 8);
+        putObject(KEY, original);
+        const metadata = await persistAndCaptureMetadata();
+        mockRead.image.findUnique.mockResolvedValue(rowWith(metadata, measured));
+        mockS3Send.mockClear();
 
-    // The object is replaced; the row is NOT touched, so it still advertises the
-    // original geometry and would satisfy every column rule unchanged.
-    const replacement = await flatPng(160, 120, 200);
-    putObject(KEY, replacement);
-    expect(etagOf(replacement)).not.toBe(etagOf(original));
+        await expect(attach()).resolves.toMatchObject(attached);
 
-    await expect(attachAsIcon()).rejects.toMatchObject({
-      code: 'BAD_REQUEST',
-      message: 'that image has changed since it was uploaded — upload it again',
-    });
-    // Nothing was written — the listing never references the swapped object.
-    expect(mockRead.appListing.update).not.toHaveBeenCalled();
-  });
+        // 🔴 POSITIVE CONTROL for REACHABILITY. The accept above must be the guard
+        // running and agreeing, not the guard being skipped — those are the same
+        // observable from the outside. So assert the head request was actually
+        // issued against this key: with the check short-circuited for this kind,
+        // this count is 0.
+        const heads = mockS3Send.mock.calls.filter(
+          ([cmd]) =>
+            cmd instanceof HeadObjectCommand && (cmd as HeadObjectCommand).input.Key === KEY
+        );
+        expect(heads).toHaveLength(1);
+      });
 
-  it('refuses even when the replacement decodes to the SAME geometry', async () => {
-    const original = await flatPng(512, 512, 8);
-    putObject(KEY, original);
-    const metadata = await persistAndCaptureMetadata();
-    mockRead.image.findUnique.mockResolvedValue(rowWith(metadata, { width: 512, height: 512 }));
+      /**
+       * 🔴 THE REGRESSION. Same row, same columns, same caller — only the bytes
+       * behind the key differ from the ones those columns were measured from.
+       * Before this guard the attach succeeded and the listing was validated
+       * against geometry that was no longer in the store.
+       */
+      it('REFUSES the attach once the stored object is no longer the measured one', async () => {
+        const original = await flatPng(measured.width, measured.height, 8);
+        putObject(KEY, original);
+        const metadata = await persistAndCaptureMetadata();
+        mockRead.image.findUnique.mockResolvedValue(rowWith(metadata, measured));
 
-    // Identical dimensions, different content. A geometry re-probe would say this
-    // is fine; the question the gate asks is "are these the same bytes", not "do
-    // they still measure the same".
-    const sameShape = await flatPng(512, 512, 200);
-    putObject(KEY, sameShape);
+        // The object is replaced; the row is NOT touched, so it still advertises
+        // the original geometry and would satisfy every column rule unchanged.
+        const replacement = await flatPng(160, 120, 200);
+        putObject(KEY, replacement);
+        expect(etagOf(replacement)).not.toBe(etagOf(original));
 
-    await expect(attachAsIcon()).rejects.toMatchObject({
-      message: 'that image has changed since it was uploaded — upload it again',
-    });
-  });
+        await expect(attach()).rejects.toMatchObject({
+          code: 'BAD_REQUEST',
+          message: 'that image has changed since it was uploaded — upload it again',
+        });
+        // Nothing was written — the listing never references the swapped object.
+        assertNoWrite();
+      });
+
+      it('refuses even when the replacement decodes to the SAME geometry', async () => {
+        const original = await flatPng(measured.width, measured.height, 8);
+        putObject(KEY, original);
+        const metadata = await persistAndCaptureMetadata();
+        mockRead.image.findUnique.mockResolvedValue(rowWith(metadata, measured));
+
+        // Identical dimensions, different content. A geometry re-probe would say
+        // this is fine; the question the gate asks is "are these the same bytes",
+        // not "do they still measure the same".
+        putObject(KEY, await flatPng(sameShape.width, sameShape.height, sameShape.shade));
+
+        await expect(attach()).rejects.toMatchObject({
+          message: 'that image has changed since it was uploaded — upload it again',
+        });
+        assertNoWrite();
+      });
+    }
+  );
 });
 
 describe('listing media — the re-check fails CLOSED only on disagreement', () => {
@@ -332,6 +411,140 @@ describe('listing media — the re-check fails CLOSED only on disagreement', () 
   });
 });
 
+/**
+ * 🔴 A GUARD THAT ONLY EVER FAILS OPEN IS INDISTINGUISHABLE FROM A GUARD THAT IS
+ * NOT THERE — from the outside both simply attach. The four `unverifiable` reasons
+ * are kept apart by the classifier precisely because they are different operational
+ * signals, so the consumer has to actually emit which one it hit; otherwise the
+ * distinction exists only in a type.
+ */
+describe('listing media — every non-match verdict is reported with its reason', () => {
+  /** The events this guard emitted, in order. */
+  function integrityEvents() {
+    return mockLogToAxiom.mock.calls
+      .map(([event]) => event as Record<string, unknown>)
+      .filter((e) => e?.name === 'listing-asset-integrity');
+  }
+
+  async function attachWithMetadata() {
+    putObject(KEY, await flatPng(512, 512, 8));
+    const metadata = await persistAndCaptureMetadata();
+    mockRead.image.findUnique.mockResolvedValue(rowWith(metadata, { width: 512, height: 512 }));
+    mockLogToAxiom.mockClear();
+  }
+
+  it('reports MISMATCH — the verdict the guard exists for', async () => {
+    await attachWithMetadata();
+    putObject(KEY, await flatPng(160, 120, 200));
+
+    await expect(attachAsIcon()).rejects.toThrow();
+    expect(integrityEvents()).toEqual([
+      expect.objectContaining({ status: 'mismatch', reason: null, kind: 'icon', imageId: 500 }),
+    ]);
+  });
+
+  it('reports store-unreachable rather than swallowing an infrastructure event', async () => {
+    await attachWithMetadata();
+    storeOutage = Object.assign(new Error('boom'), { $metadata: { httpStatusCode: 503 } });
+
+    await expect(attachAsIcon()).resolves.toMatchObject({ status: 'attached' });
+    expect(integrityEvents()).toEqual([
+      expect.objectContaining({ status: 'unverifiable', reason: 'store-unreachable' }),
+    ]);
+  });
+
+  it('reports object-absent separately from store-unreachable', async () => {
+    await attachWithMetadata();
+    store.delete(KEY);
+
+    await expect(attachAsIcon()).resolves.toMatchObject({ status: 'attached' });
+    expect(integrityEvents()).toEqual([
+      expect.objectContaining({ status: 'unverifiable', reason: 'object-absent' }),
+    ]);
+  });
+
+  /**
+   * The quietest failure of the lot: a backend that stops returning tags disarms
+   * this check for EVERY row while nothing rejects and nothing errors.
+   */
+  it('reports no-current-etag — the shape that silently disarms the check', async () => {
+    await attachWithMetadata();
+    putObject(KEY, await flatPng(160, 120, 200), { etag: null });
+
+    await expect(attachAsIcon()).resolves.toMatchObject({ status: 'attached' });
+    expect(integrityEvents()).toEqual([
+      expect.objectContaining({ status: 'unverifiable', reason: 'no-current-etag' }),
+    ]);
+  });
+
+  it('carries the asset KIND, so the three procs are separable in the data', async () => {
+    putObject(KEY, await flatPng(1280, 720, 8));
+    const metadata = await persistAndCaptureMetadata();
+    mockRead.image.findUnique.mockResolvedValue(rowWith(metadata, { width: 1280, height: 720 }));
+    mockLogToAxiom.mockClear();
+    putObject(KEY, await flatPng(160, 120, 200));
+
+    const { setListingCover } = await import('../app-listing-assets.service');
+    await expect(setListingCover({ listingId: 'apl_1', imageId: 500 }, owner)).rejects.toThrow();
+    expect(integrityEvents()).toEqual([expect.objectContaining({ kind: 'cover' })]);
+  });
+
+  it('says NOTHING on a match — the healthy path is not an event stream', async () => {
+    await attachWithMetadata();
+
+    await expect(attachAsIcon()).resolves.toMatchObject({ status: 'attached' });
+    expect(integrityEvents()).toEqual([]);
+  });
+
+  /**
+   * 🔴 The event is an OPERATIONAL signal, not an audit trail of what was uploaded
+   * where. A storage key in a log is an upload location in a log, and the reason +
+   * kind + row id are already enough to tell these classes apart.
+   */
+  it('never carries the storage key, the bucket, or the caller', async () => {
+    await attachWithMetadata();
+    putObject(KEY, await flatPng(160, 120, 200));
+
+    await expect(attachAsIcon()).rejects.toThrow();
+    const [event] = integrityEvents();
+    expect(event).toBeDefined();
+    const serialized = JSON.stringify(event);
+    for (const secret of [KEY, 'test-image-bucket', String(OWNER)]) {
+      expect(serialized).not.toContain(secret);
+    }
+    expect(Object.keys(event).sort()).toEqual(
+      ['imageId', 'kind', 'name', 'reason', 'status', 'type'].sort()
+    );
+  });
+});
+
+describe('listing media — the re-read is BOUNDED, and a timeout fails open', () => {
+  /**
+   * The fail-open argument covers a store that ERRORS. It does not cover a store
+   * that never answers: an unbounded head would hold the attach mutation open for
+   * as long as the backend feels like, which is a worse outcome than the tampering
+   * this check catches. So the wiring itself is asserted — a removed `abortSignal`
+   * is otherwise invisible, because a healthy store answers either way.
+   */
+  it('hands the head request an abort signal that has not already fired', async () => {
+    putObject(KEY, await flatPng(512, 512, 8));
+    const metadata = await persistAndCaptureMetadata();
+    mockRead.image.findUnique.mockResolvedValue(rowWith(metadata, { width: 512, height: 512 }));
+    mockS3Send.mockClear();
+
+    await expect(attachAsIcon()).resolves.toMatchObject({ status: 'attached' });
+
+    const head = mockS3Send.mock.calls.find(([cmd]) => cmd instanceof HeadObjectCommand);
+    expect(head).toBeDefined();
+    const signal = (head?.[1] as { abortSignal?: AbortSignal } | undefined)?.abortSignal;
+    expect(signal).toBeInstanceOf(AbortSignal);
+    // A zero/expired budget would abort every head before it is sent, turning the
+    // guard permanently unverifiable — the failure a bare "a signal was passed"
+    // assertion would wave through.
+    expect(signal?.aborted).toBe(false);
+  });
+});
+
 describe('listing media — the pre-existing attach rules are unchanged', () => {
   /**
    * NEGATIVE CONTROL for the guard's placement. It runs before the column
@@ -347,6 +560,26 @@ describe('listing media — the pre-existing attach rules are unchanged', () => 
     const err = await attachAsIcon().catch((e: { message: string }) => e);
     expect((err as { message: string }).message).not.toContain('changed since it was uploaded');
     expect(mockRead.appListing.update).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The ORDER is a documented claim, not an accident: the column rules are
+   * expressed over the persisted measurements, so "are these still the bytes those
+   * measurements describe" is a precondition for the bounds meaning anything. With
+   * the check moved after the validation, a swapped object whose row also happens
+   * to be out of bounds is reported as a geometry problem — advice to re-crop an
+   * image that is not the one in the store.
+   */
+  it('reports the INTEGRITY failure first when the row is ALSO out of bounds', async () => {
+    const original = await flatPng(512, 200, 8);
+    putObject(KEY, original);
+    const metadata = await persistAndCaptureMetadata();
+    mockRead.image.findUnique.mockResolvedValue(rowWith(metadata, { width: 512, height: 200 }));
+    putObject(KEY, await flatPng(160, 120, 200));
+
+    await expect(attachAsIcon()).rejects.toMatchObject({
+      message: 'that image has changed since it was uploaded — upload it again',
+    });
   });
 
   it('still rejects an image the caller does not own, before any store call', async () => {

--- a/src/server/services/blocks/__tests__/listing-asset-upload-integrity.test.ts
+++ b/src/server/services/blocks/__tests__/listing-asset-upload-integrity.test.ts
@@ -1,0 +1,364 @@
+import { createHash } from 'crypto';
+import { GetObjectCommand, HeadObjectCommand } from '@aws-sdk/client-s3';
+import sharp from 'sharp';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type * as S3Utils from '~/utils/s3-utils';
+
+/**
+ * Listing media — the upload measurement must still describe the stored object at
+ * the moment it is RELIED UPON, not merely at the moment it was taken.
+ *
+ * `persistListingAssetImage` derives an `Image` row's width / height / MIME / byte
+ * size from the bytes it reads back out of the store, precisely so those columns
+ * are not a client claim. Every listing attach rule is expressed over exactly those
+ * columns. But the upload grant for a key outlives that measurement, so between
+ * persist and attach the object at the key can become different bytes while the row
+ * keeps describing the old ones — at which point the attach gate is validating a
+ * description rather than the media it is about.
+ *
+ * 🔴 THIS IS A SEAM TEST, and deliberately not two isolated ones. Persist WRITES an
+ * integrity token into `Image.metadata` and attach READS it back; each half is
+ * trivially "correct" on its own while the pair does nothing at all, if they
+ * disagree about the metadata key or the comparison. So every case below runs the
+ * REAL persist proc, takes the metadata blob it actually produced, puts THAT on the
+ * row the REAL attach proc loads, and only then varies the store.
+ *
+ * The dimension every case varies is the identity of the stored object, and the
+ * fixtures cross it in both directions: an untouched object attaches (proving the
+ * guard is not a blanket reject), a replaced one does not.
+ */
+
+const { mockRead, mockWrite, mockCreateImage, mockS3Send } = vi.hoisted(() => {
+  const db = {
+    appListing: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      update: vi.fn(async (..._a: unknown[]) => ({})),
+    },
+    image: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    },
+    $transaction: vi.fn(async (arg: unknown) => {
+      if (typeof arg === 'function') return (arg as (tx: unknown) => unknown)(db);
+      return Promise.all(arg as Promise<unknown>[]);
+    }),
+  };
+  return {
+    mockRead: db,
+    mockWrite: db,
+    mockCreateImage: vi.fn(async (..._a: unknown[]) => ({ id: 777 })),
+    mockS3Send: vi.fn(),
+  };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockWrite }));
+vi.mock('~/server/services/image.service', () => ({ createImage: mockCreateImage }));
+vi.mock('~/server/utils/app-block-ids', () => ({
+  newAppListingId: () => 'apl_test_1',
+  newAppListingPublishRequestId: () => 'alpr_test_1',
+  newAppListingModerationEventId: () => 'alme_test_1',
+  newAppListingScreenshotId: () => 'apls_test_1',
+}));
+// Only the backend ACCESSOR is replaced. The probe, the `sharp` decode inside it,
+// the head re-read and the comparison all run for real against real bytes.
+vi.mock('~/utils/s3-utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof S3Utils>()),
+  getImageUploadBackend: async () => ({
+    s3: { send: mockS3Send },
+    bucket: 'test-image-bucket',
+    backend: 'backblaze' as const,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// A minimal object store the real probe + the real head both talk to.
+// ---------------------------------------------------------------------------
+
+type StoredObject = { bytes: Buffer; etag: string | null };
+const store = new Map<string, StoredObject>();
+/** Set when a request should fail as infrastructure rather than as a miss. */
+let storeOutage: Error | null = null;
+
+/**
+ * Entity tags are derived from the bytes, exactly as a real store derives them —
+ * so two different fixtures cannot accidentally share one, and an "unchanged"
+ * case cannot pass because both sides were handed the same literal.
+ */
+function etagOf(bytes: Buffer) {
+  return `"${createHash('md5').update(bytes).digest('hex')}"`;
+}
+
+function putObject(key: string, bytes: Buffer, opts: { etag?: string | null } = {}) {
+  store.set(key, { bytes, etag: opts.etag === undefined ? etagOf(bytes) : opts.etag });
+}
+
+function notFound() {
+  return Object.assign(new Error('NoSuchKey'), {
+    name: 'NoSuchKey',
+    $metadata: { httpStatusCode: 404 },
+  });
+}
+
+mockS3Send.mockImplementation(async (command: unknown) => {
+  if (storeOutage) throw storeOutage;
+  const key = (command as { input: { Key: string } }).input.Key;
+  const object = store.get(key);
+  if (!object) throw notFound();
+  if (command instanceof HeadObjectCommand) {
+    return { ETag: object.etag, ContentLength: object.bytes.byteLength };
+  }
+  if (command instanceof GetObjectCommand) {
+    return {
+      Body: { transformToByteArray: async () => new Uint8Array(object.bytes) },
+      ContentRange: `bytes 0-${object.bytes.byteLength - 1}/${object.bytes.byteLength}`,
+      ETag: object.etag,
+    };
+  }
+  throw new Error(`unexpected S3 command: ${(command as object)?.constructor?.name}`);
+});
+
+const fixtureCache = new Map<string, Buffer>();
+/** Real, decodable bytes — nothing about these images is declared. */
+async function flatPng(width: number, height: number, shade: number) {
+  const cacheKey = `${width}x${height}:${shade}`;
+  const hit = fixtureCache.get(cacheKey);
+  if (hit) return hit;
+  const made = await sharp({
+    create: { width, height, channels: 3, background: { r: shade, g: shade, b: shade } },
+  })
+    .png()
+    .toBuffer();
+  fixtureCache.set(cacheKey, made);
+  return made;
+}
+
+const OWNER = 42;
+const KEY = '44444444-4444-4444-8444-444444444444';
+const LISTING = {
+  id: 'apl_1',
+  kind: 'onsite',
+  slug: 's',
+  name: 'n',
+  category: null,
+  contentRating: null,
+  userId: OWNER,
+  iconId: null,
+  coverId: null,
+};
+const owner = { id: OWNER, isModerator: false } as never;
+
+/**
+ * Run the REAL persist proc over the object currently at `KEY` and return the
+ * `Image.metadata` blob it produced — the seam's write side, unedited.
+ */
+async function persistAndCaptureMetadata() {
+  mockCreateImage.mockClear();
+  const { persistListingAssetImage } = await import('../offsite-listing.service');
+  await persistListingAssetImage({
+    input: { url: KEY, name: 'icon.png', width: 1, height: 1, mimeType: 'image/png' },
+    userId: OWNER,
+  } as never);
+  expect(mockCreateImage).toHaveBeenCalledTimes(1);
+  return (mockCreateImage.mock.calls[0][0] as { metadata: Record<string, unknown> }).metadata;
+}
+
+/** The row the attach gate loads, carrying persist's own metadata verbatim. */
+function rowWith(metadata: unknown, measured: { width: number; height: number }) {
+  return {
+    id: 500,
+    userId: OWNER,
+    url: KEY,
+    type: 'image',
+    width: measured.width,
+    height: measured.height,
+    mimeType: 'image/png',
+    metadata,
+    ingestion: 'Scanned',
+    nsfwLevel: 1,
+  };
+}
+
+async function attachAsIcon() {
+  const { setListingIcon } = await import('../app-listing-assets.service');
+  return setListingIcon({ listingId: 'apl_1', imageId: 500 }, owner);
+}
+
+beforeEach(() => {
+  store.clear();
+  fixtureCache.clear();
+  storeOutage = null;
+  mockRead.appListing.findUnique.mockReset().mockResolvedValue(LISTING);
+  mockRead.appListing.findFirst.mockReset().mockResolvedValue(null);
+  mockRead.appListing.update.mockReset().mockResolvedValue({});
+  mockRead.image.findUnique.mockReset().mockResolvedValue(null);
+  mockRead.image.findMany.mockReset().mockResolvedValue([]);
+  mockCreateImage.mockReset().mockResolvedValue({ id: 777 });
+});
+
+describe('listing media — the persisted measurement is re-verified at attach', () => {
+  it('records an integrity token derived from the bytes it measured', async () => {
+    const original = await flatPng(512, 512, 8);
+    putObject(KEY, original);
+
+    const metadata = await persistAndCaptureMetadata();
+
+    // Recorded, and recorded as the store's own token for THESE bytes — not some
+    // value the caller supplied and not a constant.
+    expect(metadata).toMatchObject({ size: original.byteLength });
+    const { readRecordedEtag } = await import('../stored-object-integrity');
+    expect(readRecordedEtag(metadata)).toBe(etagOf(original).replaceAll('"', ''));
+  });
+
+  it('attaches normally while the stored object is still the measured one', async () => {
+    const original = await flatPng(512, 512, 8);
+    putObject(KEY, original);
+    const metadata = await persistAndCaptureMetadata();
+    mockRead.image.findUnique.mockResolvedValue(rowWith(metadata, { width: 512, height: 512 }));
+    mockS3Send.mockClear();
+
+    await expect(attachAsIcon()).resolves.toMatchObject({ status: 'attached', iconId: 500 });
+    expect(mockRead.appListing.update).toHaveBeenCalled();
+
+    // 🔴 POSITIVE CONTROL for REACHABILITY. The accept above must be the guard
+    // running and agreeing, not the guard being skipped — those are the same
+    // observable from the outside. So assert the head request was actually issued
+    // against this key: with the check short-circuited, this count is 0.
+    const heads = mockS3Send.mock.calls.filter(
+      ([cmd]) => cmd instanceof HeadObjectCommand && (cmd as HeadObjectCommand).input.Key === KEY
+    );
+    expect(heads).toHaveLength(1);
+  });
+
+  /**
+   * 🔴 THE REGRESSION. Same row, same columns, same caller — only the bytes behind
+   * the key differ from the ones those columns were measured from. Before this
+   * guard the attach succeeded and the listing was validated against geometry that
+   * was no longer in the store.
+   */
+  it('REFUSES the attach once the stored object is no longer the measured one', async () => {
+    const original = await flatPng(512, 512, 8);
+    putObject(KEY, original);
+    const metadata = await persistAndCaptureMetadata();
+    const row = rowWith(metadata, { width: 512, height: 512 });
+    mockRead.image.findUnique.mockResolvedValue(row);
+
+    // The object is replaced; the row is NOT touched, so it still advertises the
+    // original geometry and would satisfy every column rule unchanged.
+    const replacement = await flatPng(160, 120, 200);
+    putObject(KEY, replacement);
+    expect(etagOf(replacement)).not.toBe(etagOf(original));
+
+    await expect(attachAsIcon()).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'that image has changed since it was uploaded — upload it again',
+    });
+    // Nothing was written — the listing never references the swapped object.
+    expect(mockRead.appListing.update).not.toHaveBeenCalled();
+  });
+
+  it('refuses even when the replacement decodes to the SAME geometry', async () => {
+    const original = await flatPng(512, 512, 8);
+    putObject(KEY, original);
+    const metadata = await persistAndCaptureMetadata();
+    mockRead.image.findUnique.mockResolvedValue(rowWith(metadata, { width: 512, height: 512 }));
+
+    // Identical dimensions, different content. A geometry re-probe would say this
+    // is fine; the question the gate asks is "are these the same bytes", not "do
+    // they still measure the same".
+    const sameShape = await flatPng(512, 512, 200);
+    putObject(KEY, sameShape);
+
+    await expect(attachAsIcon()).rejects.toMatchObject({
+      message: 'that image has changed since it was uploaded — upload it again',
+    });
+  });
+});
+
+describe('listing media — the re-check fails CLOSED only on disagreement', () => {
+  it('allows a row that carries no recorded token (written before this existed)', async () => {
+    const original = await flatPng(512, 512, 8);
+    putObject(KEY, original);
+    // A legacy row: measured columns, but only the byte size in metadata.
+    mockRead.image.findUnique.mockResolvedValue(
+      rowWith({ size: original.byteLength }, { width: 512, height: 512 })
+    );
+    // …and the object behind it has since been replaced. With nothing recorded
+    // there is no evidence of that, and an absence must not become a rejection.
+    putObject(KEY, await flatPng(160, 120, 200));
+
+    await expect(attachAsIcon()).resolves.toMatchObject({ status: 'attached' });
+  });
+
+  it('allows the attach when the store cannot be consulted at all', async () => {
+    putObject(KEY, await flatPng(512, 512, 8));
+    const metadata = await persistAndCaptureMetadata();
+    mockRead.image.findUnique.mockResolvedValue(rowWith(metadata, { width: 512, height: 512 }));
+
+    storeOutage = Object.assign(new Error('boom'), { $metadata: { httpStatusCode: 503 } });
+
+    await expect(attachAsIcon()).resolves.toMatchObject({ status: 'attached' });
+  });
+
+  it('allows the attach when the store reports the object missing', async () => {
+    putObject(KEY, await flatPng(512, 512, 8));
+    const metadata = await persistAndCaptureMetadata();
+    mockRead.image.findUnique.mockResolvedValue(rowWith(metadata, { width: 512, height: 512 }));
+
+    store.delete(KEY);
+
+    await expect(attachAsIcon()).resolves.toMatchObject({ status: 'attached' });
+  });
+
+  it('allows the attach when the store returns no token for the object', async () => {
+    putObject(KEY, await flatPng(512, 512, 8));
+    const metadata = await persistAndCaptureMetadata();
+    mockRead.image.findUnique.mockResolvedValue(rowWith(metadata, { width: 512, height: 512 }));
+
+    // Present, but the backend answered without one — nothing to compare.
+    putObject(KEY, await flatPng(160, 120, 200), { etag: null });
+
+    await expect(attachAsIcon()).resolves.toMatchObject({ status: 'attached' });
+  });
+
+  it('does NOT spend a head request on a row that carries no token', async () => {
+    putObject(KEY, await flatPng(512, 512, 8));
+    mockRead.image.findUnique.mockResolvedValue(rowWith({ size: 1 }, { width: 512, height: 512 }));
+    mockS3Send.mockClear();
+
+    await expect(attachAsIcon()).resolves.toMatchObject({ status: 'attached' });
+    expect(mockS3Send).not.toHaveBeenCalled();
+  });
+});
+
+describe('listing media — the pre-existing attach rules are unchanged', () => {
+  /**
+   * NEGATIVE CONTROL for the guard's placement. It runs before the column
+   * validation, so a bad-geometry image must still be rejected for ITS OWN reason
+   * — not silently swallowed by, or shadowed into, the integrity message.
+   */
+  it('still rejects a non-square icon, with the geometry message', async () => {
+    const original = await flatPng(512, 200, 8);
+    putObject(KEY, original);
+    const metadata = await persistAndCaptureMetadata();
+    mockRead.image.findUnique.mockResolvedValue(rowWith(metadata, { width: 512, height: 200 }));
+
+    const err = await attachAsIcon().catch((e: { message: string }) => e);
+    expect((err as { message: string }).message).not.toContain('changed since it was uploaded');
+    expect(mockRead.appListing.update).not.toHaveBeenCalled();
+  });
+
+  it('still rejects an image the caller does not own, before any store call', async () => {
+    putObject(KEY, await flatPng(512, 512, 8));
+    const metadata = await persistAndCaptureMetadata();
+    mockRead.image.findUnique.mockResolvedValue({
+      ...rowWith(metadata, { width: 512, height: 512 }),
+      userId: 99,
+    });
+    mockS3Send.mockClear();
+
+    await expect(attachAsIcon()).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(mockS3Send).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TRPCError } from '@trpc/server';
 import sharp from 'sharp';
@@ -135,7 +136,9 @@ vi.mock('~/server/utils/app-block-ids', () => ({
 }));
 // approve/reject emit an owner notification post-commit; assert it without pulling
 // the notifications client graph.
-vi.mock('~/server/services/blocks/app-listing-notify', () => ({ notifyAppListingOwner: mockNotify }));
+vi.mock('~/server/services/blocks/app-listing-notify', () => ({
+  notifyAppListingOwner: mockNotify,
+}));
 vi.mock('~/utils/s3-utils', async (importOriginal) => ({
   ...(await importOriginal<typeof S3Utils>()),
   getImageUploadBackend: async () => ({
@@ -170,12 +173,26 @@ function flatGif(width: number, height: number) {
   );
 }
 
-/** Put `bytes` at the key the probe will read, answering its ranged GET. */
-function storeObject(bytes: Buffer, opts: { totalSize?: number } = {}) {
+/** The entity tag a real store derives for these bytes — quoted, as on the wire. */
+function etagOf(bytes: Buffer) {
+  return `"${createHash('md5').update(bytes).digest('hex')}"`;
+}
+
+/**
+ * Put `bytes` at the key the probe will read, answering its ranged GET.
+ *
+ * 🔴 The response carries an `ETag`, because the real one does. A fake that omits
+ * it does not merely under-test the tag — it makes every assertion about the
+ * persisted metadata hold for the WRONG reason (the absent-tag branch), so the
+ * recorded-tag path would look covered while never running. `etag: null` is
+ * available for the case that genuinely needs a backend that reports none.
+ */
+function storeObject(bytes: Buffer, opts: { totalSize?: number; etag?: string | null } = {}) {
   const totalSize = opts.totalSize ?? bytes.byteLength;
   mockS3Send.mockResolvedValue({
     Body: { transformToByteArray: async () => new Uint8Array(bytes) },
     ContentRange: `bytes 0-${bytes.byteLength - 1}/${totalSize}`,
+    ETag: opts.etag === undefined ? etagOf(bytes) : opts.etag,
   });
 }
 
@@ -254,7 +271,10 @@ describe('submitExternalListing', () => {
     expect(res.publishRequestId).toMatch(/^alpr_test_/);
 
     // Rows are created on the PRIMARY (inside the tx).
-    const listingData = mockWrite.appListing.create.mock.calls[0][0].data as Record<string, unknown>;
+    const listingData = mockWrite.appListing.create.mock.calls[0][0].data as Record<
+      string,
+      unknown
+    >;
     expect(listingData).toMatchObject({
       kind: 'offsite',
       status: 'draft',
@@ -271,8 +291,10 @@ describe('submitExternalListing', () => {
       userId: CALLER,
     });
 
-    const reqData = mockWrite.appListingPublishRequest.create.mock.calls[0][0]
-      .data as Record<string, unknown>;
+    const reqData = mockWrite.appListingPublishRequest.create.mock.calls[0][0].data as Record<
+      string,
+      unknown
+    >;
     expect(reqData).toMatchObject({
       kind: 'offsite',
       status: 'pending',
@@ -297,9 +319,9 @@ describe('submitExternalListing', () => {
 
   it('REQUIRES an OAuth client: a missing client → NOT_FOUND, no write', async () => {
     mockRead.oauthClient.findUnique.mockResolvedValue(null);
-    await expect(submitExternalListing({ input: validInput, userId: CALLER })).rejects.toMatchObject(
-      { code: 'NOT_FOUND' }
-    );
+    await expect(
+      submitExternalListing({ input: validInput, userId: CALLER })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
     expect(mockWrite.$transaction).not.toHaveBeenCalled();
   });
 
@@ -310,26 +332,33 @@ describe('submitExternalListing', () => {
     mockRead.oauthClient.findUnique.mockResolvedValue(ownedClient({ userId: OTHER }));
     await submitExternalListing({ input: validInput, userId: OTHER });
     const listingData = mockWrite.appListing.create.mock.calls[0][0].data as { userId: number };
-    const reqData = mockWrite.appListingPublishRequest.create.mock.calls[0][0]
-      .data as { submittedByUserId: number };
+    const reqData = mockWrite.appListingPublishRequest.create.mock.calls[0][0].data as {
+      submittedByUserId: number;
+    };
     expect(listingData.userId).toBe(OTHER);
     expect(reqData.submittedByUserId).toBe(OTHER);
   });
 
   it('slug already taken (existing AppListing pre-check on the replica) → friendly BAD_REQUEST, no write', async () => {
     mockRead.appListing.findUnique.mockResolvedValue({ id: 'apl_existing' });
-    await expect(submitExternalListing({ input: validInput, userId: CALLER })).rejects.toMatchObject(
-      { code: 'BAD_REQUEST', message: expect.stringContaining('already taken') }
-    );
+    await expect(
+      submitExternalListing({ input: validInput, userId: CALLER })
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('already taken'),
+    });
     expect(mockWrite.$transaction).not.toHaveBeenCalled();
   });
 
   it('slug taken via the P2002 create RACE → same friendly error', async () => {
     // Pre-checks pass (null), but the unique constraint fires inside the tx.
     mockWrite.$transaction.mockRejectedValue({ code: 'P2002' });
-    await expect(submitExternalListing({ input: validInput, userId: CALLER })).rejects.toMatchObject(
-      { code: 'BAD_REQUEST', message: expect.stringContaining('already taken') }
-    );
+    await expect(
+      submitExternalListing({ input: validInput, userId: CALLER })
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('already taken'),
+    });
   });
 
   it('a non-P2002 tx error is NOT masked as a slug collision', async () => {
@@ -341,9 +370,12 @@ describe('submitExternalListing', () => {
 
   it('cross-kind: a slug equal to an existing AppBlock.block_id (replica pre-check) is rejected', async () => {
     mockRead.appBlock.findFirst.mockResolvedValue({ id: 'block_x' });
-    await expect(submitExternalListing({ input: validInput, userId: CALLER })).rejects.toMatchObject(
-      { code: 'BAD_REQUEST', message: expect.stringContaining('already taken') }
-    );
+    await expect(
+      submitExternalListing({ input: validInput, userId: CALLER })
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('already taken'),
+    });
     expect(mockWrite.$transaction).not.toHaveBeenCalled();
   });
 
@@ -353,9 +385,12 @@ describe('submitExternalListing', () => {
     // AppListing is never created.
     mockRead.appBlock.findFirst.mockResolvedValue(null);
     mockWrite.appBlock.findFirst.mockResolvedValue({ id: 'block_lagged' });
-    await expect(submitExternalListing({ input: validInput, userId: CALLER })).rejects.toMatchObject(
-      { code: 'BAD_REQUEST', message: expect.stringContaining('already taken') }
-    );
+    await expect(
+      submitExternalListing({ input: validInput, userId: CALLER })
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('already taken'),
+    });
     // The tx opened (primary re-check runs inside it) but no rows were created.
     expect(mockWrite.$transaction).toHaveBeenCalledTimes(1);
     expect(mockWrite.appListing.create).not.toHaveBeenCalled();
@@ -364,9 +399,12 @@ describe('submitExternalListing', () => {
 
   it('per-user pending cap: AT the cap → TOO_MANY_REQUESTS, no write', async () => {
     mockRead.appListingPublishRequest.count.mockResolvedValue(MAX_PENDING_OFFSITE_SUBMISSIONS);
-    await expect(submitExternalListing({ input: validInput, userId: CALLER })).rejects.toMatchObject(
-      { code: 'TOO_MANY_REQUESTS', message: expect.stringContaining('pending') }
-    );
+    await expect(
+      submitExternalListing({ input: validInput, userId: CALLER })
+    ).rejects.toMatchObject({
+      code: 'TOO_MANY_REQUESTS',
+      message: expect.stringContaining('pending'),
+    });
     // The count is scoped to the caller's pending offsite requests (on the replica).
     expect(mockRead.appListingPublishRequest.count).toHaveBeenCalledWith({
       where: { submittedByUserId: CALLER, kind: 'offsite', status: 'pending' },
@@ -642,7 +680,8 @@ function stageApproveScenario(listing: {
   const listingRow = {
     id: 'apl_1',
     status: listing.status ?? 'draft',
-    externalUrl: listing.externalUrl === undefined ? 'https://cool.example.com/app' : listing.externalUrl,
+    externalUrl:
+      listing.externalUrl === undefined ? 'https://cool.example.com/app' : listing.externalUrl,
     iconId: listing.iconId === undefined ? 1 : listing.iconId,
     coverId: listing.coverId === undefined ? 2 : listing.coverId,
     // Owner fields the approve path reads for the post-commit owner notification.
@@ -879,7 +918,10 @@ describe('approveExternalRequest', () => {
     });
     await expect(
       approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD })
-    ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: expect.stringContaining('missing: cover') });
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('missing: cover'),
+    });
     // We DID open the tx (the authoritative gate runs inside it) but bailed BEFORE
     // any flip — neither the request nor the listing status changed.
     expect(mockWrite.$transaction).toHaveBeenCalledTimes(1);
@@ -982,7 +1024,10 @@ describe('approveExternalRequest', () => {
     stageApproveScenario({ iconId: null, coverId: 2, screenshotCount: 1 });
     await expect(
       approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD })
-    ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: expect.stringContaining('missing: icon') });
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('missing: icon'),
+    });
     // Missing on the replica too → fail-fast before the tx even opens.
     expect(mockWrite.$transaction).not.toHaveBeenCalled();
     expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
@@ -992,7 +1037,10 @@ describe('approveExternalRequest', () => {
     stageApproveScenario({ iconId: 1, coverId: null, screenshotCount: 1 });
     await expect(
       approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD })
-    ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: expect.stringContaining('missing: cover') });
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('missing: cover'),
+    });
     expect(mockWrite.$transaction).not.toHaveBeenCalled();
   });
 
@@ -1174,7 +1222,11 @@ describe('rejectExternalRequest', () => {
 
   it('reason shorter than the shared min (3) → BAD_REQUEST, no DB read/write', async () => {
     await expect(
-      rejectExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD, rejectionReason: 'no' })
+      rejectExternalRequest({
+        publishRequestId: 'alpr_1',
+        reviewerUserId: MOD,
+        rejectionReason: 'no',
+      })
     ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: expect.stringContaining('at least') });
     expect(mockRead.appListingPublishRequest.findUnique).not.toHaveBeenCalled();
     expect(mockWrite.appListingPublishRequest.updateMany).not.toHaveBeenCalled();
@@ -1189,7 +1241,11 @@ describe('rejectExternalRequest', () => {
     });
     // The in-tx close reads the listing status → a first-time DRAFT is deleted (regression).
     mockWrite.appListing.findUnique.mockResolvedValue({ status: 'draft', slug: 'cool-app' });
-    await rejectExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD, rejectionReason: REASON });
+    await rejectExternalRequest({
+      publishRequestId: 'alpr_1',
+      reviewerUserId: MOD,
+      rejectionReason: REASON,
+    });
 
     // The flip + close run inside ONE transaction on the primary (tx client).
     expect(mockWrite.$transaction).toHaveBeenCalledTimes(1);
@@ -1221,7 +1277,11 @@ describe('rejectExternalRequest', () => {
     });
     // The in-tx close reads status → `pending` = a reset-to-pending, formerly-live listing.
     mockWrite.appListing.findUnique.mockResolvedValue({ status: 'pending', slug: 'cool-app' });
-    await rejectExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD, rejectionReason: REASON });
+    await rejectExternalRequest({
+      publishRequestId: 'alpr_1',
+      reviewerUserId: MOD,
+      rejectionReason: REASON,
+    });
 
     // NOT hard-deleted — transitioned to `removed` (recoverable via mod relist).
     expect(mockWrite.appListing.deleteMany).not.toHaveBeenCalled();
@@ -1255,7 +1315,11 @@ describe('rejectExternalRequest', () => {
       slug: 'cool-app',
       revisionOfId: null,
     });
-    await rejectExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD, rejectionReason: REASON });
+    await rejectExternalRequest({
+      publishRequestId: 'alpr_1',
+      reviewerUserId: MOD,
+      rejectionReason: REASON,
+    });
     expect(mockNotify).toHaveBeenCalledWith(
       expect.objectContaining({
         type: 'app-listing-rejected',
@@ -1279,7 +1343,11 @@ describe('rejectExternalRequest', () => {
       slug: 'cool-app',
       revisionOfId: 'apl_parent',
     });
-    await rejectExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD, rejectionReason: REASON });
+    await rejectExternalRequest({
+      publishRequestId: 'alpr_1',
+      reviewerUserId: MOD,
+      rejectionReason: REASON,
+    });
     expect(mockNotify).not.toHaveBeenCalled();
   });
 
@@ -1291,7 +1359,11 @@ describe('rejectExternalRequest', () => {
       appListingId: 'apl_1',
     });
     await expect(
-      rejectExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD, rejectionReason: REASON })
+      rejectExternalRequest({
+        publishRequestId: 'alpr_1',
+        reviewerUserId: MOD,
+        rejectionReason: REASON,
+      })
     ).rejects.toMatchObject({ code: 'NOT_PENDING' });
     expect(mockWrite.appListingPublishRequest.updateMany).not.toHaveBeenCalled();
     expect(mockWrite.appListing.deleteMany).not.toHaveBeenCalled();
@@ -1300,7 +1372,11 @@ describe('rejectExternalRequest', () => {
   it('NOT_FOUND when the request does not exist', async () => {
     mockRead.appListingPublishRequest.findUnique.mockResolvedValue(null);
     await expect(
-      rejectExternalRequest({ publishRequestId: 'nope', reviewerUserId: MOD, rejectionReason: REASON })
+      rejectExternalRequest({
+        publishRequestId: 'nope',
+        reviewerUserId: MOD,
+        rejectionReason: REASON,
+      })
     ).rejects.toMatchObject({ code: 'NOT_FOUND' });
   });
 
@@ -1313,7 +1389,11 @@ describe('rejectExternalRequest', () => {
     });
     mockWrite.appListingPublishRequest.updateMany.mockResolvedValue({ count: 0 });
     await expect(
-      rejectExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD, rejectionReason: REASON })
+      rejectExternalRequest({
+        publishRequestId: 'alpr_1',
+        reviewerUserId: MOD,
+        rejectionReason: REASON,
+      })
     ).rejects.toMatchObject({ code: 'NOT_PENDING' });
     // Lost the flip → the tx rolls back and we never delete the draft.
     expect(mockWrite.appListing.deleteMany).not.toHaveBeenCalled();
@@ -1357,7 +1437,14 @@ describe('persistListingAssetImage (scan invariant)', () => {
     expect('skipIngestion' in arg && arg.skipIngestion === true).toBe(false);
     // Sanity: the persisted row carries the byte size the P1 validator reads.
     expect(arg).toMatchObject({ url: persistInput.url, type: 'image', userId: CALLER });
-    expect(arg.metadata).toEqual({ size: (await flatPng(512, 512)).byteLength });
+    // Sanity: the persisted row carries the byte size the P1 validator reads, PLUS
+    // the store's tag for the object those measurements came from — the evidence the
+    // attach gate re-checks so a row cannot outlive the bytes it describes.
+    const bytes = await flatPng(512, 512);
+    expect(arg.metadata).toEqual({
+      size: bytes.byteLength,
+      storedEtag: etagOf(bytes).replaceAll('"', ''),
+    });
   });
 
   it('binds the owner to the caller even for a different user id', async () => {
@@ -1365,6 +1452,22 @@ describe('persistListingAssetImage (scan invariant)', () => {
     const arg = mockCreateImage.mock.calls[0][0] as Record<string, unknown>;
     expect(arg.userId).toBe(OTHER);
     expect(arg.skipIngestion).toBeFalsy();
+  });
+
+  /**
+   * A backend that reports no tag records NOTHING rather than a null entry, so the
+   * attach gate reads one representation of "no evidence". The persist itself is
+   * unaffected — an unverifiable row is still a perfectly good row.
+   */
+  it('records no tag at all when the store returns none', async () => {
+    storeObject(await flatPng(512, 512), { etag: null });
+
+    await expect(
+      persistListingAssetImage({ input: persistInput, userId: CALLER })
+    ).resolves.toEqual({ imageId: 12345 });
+
+    const arg = mockCreateImage.mock.calls[0][0] as Record<string, unknown>;
+    expect(arg.metadata).toEqual({ size: (await flatPng(512, 512)).byteLength });
   });
 });
 
@@ -1487,7 +1590,10 @@ describe('persistListingAssetImage (measures the uploaded bytes)', () => {
 
   it('rejects an upload whose bytes are not there', async () => {
     mockS3Send.mockRejectedValue(
-      Object.assign(new Error('NoSuchKey'), { name: 'NoSuchKey', $metadata: { httpStatusCode: 404 } })
+      Object.assign(new Error('NoSuchKey'), {
+        name: 'NoSuchKey',
+        $metadata: { httpStatusCode: 404 },
+      })
     );
 
     await expect(

--- a/src/server/services/blocks/__tests__/stored-object-integrity.test.ts
+++ b/src/server/services/blocks/__tests__/stored-object-integrity.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  STORED_OBJECT_ETAG_META_KEY,
+  classifyStoredObjectIntegrity,
+  normalizeEtag,
+  readRecordedEtag,
+  storedObjectEtagMetadata,
+} from '~/server/services/blocks/stored-object-integrity';
+import type { StoredImageHead } from '~/server/utils/stored-image-probe';
+
+/**
+ * The pure rule behind the listing-media integrity re-check.
+ *
+ * The property under test is asymmetric and easy to get subtly wrong in the
+ * permissive direction: exactly ONE combination may say "this changed", and every
+ * other combination must say "I could not tell" — never "this is fine" and never
+ * "this changed". So the cases below enumerate the whole cross-product of
+ * (recorded tag present/absent) × (head present/absent/unknown) × (current tag
+ * present/absent) rather than sampling the interesting ones.
+ */
+
+const present = (etag: string | null): StoredImageHead => ({ status: 'present', etag });
+
+describe('normalizeEtag', () => {
+  it('strips one layer of surrounding quotes so the two wire forms compare equal', () => {
+    expect(normalizeEtag('"abc123"')).toBe('abc123');
+    expect(normalizeEtag('abc123')).toBe('abc123');
+    // POSITIVE CONTROL for the stripping step: it must actually change something,
+    // or an assertion that quoted and bare forms agree would hold vacuously.
+    expect(normalizeEtag('"abc123"')).not.toBe('"abc123"');
+  });
+
+  it('trims surrounding whitespace, inside and outside the quotes', () => {
+    expect(normalizeEtag('  "abc123"  ')).toBe('abc123');
+    expect(normalizeEtag('" abc123 "')).toBe('abc123');
+  });
+
+  it('does NOT strip a second layer of quotes (the tag is opaque, not parsed)', () => {
+    expect(normalizeEtag('""abc123""')).toBe('"abc123"');
+  });
+
+  it('returns null for every shape that is not a usable tag', () => {
+    for (const bad of [null, undefined, 42, {}, [], true, '', '   ', '""', '"   "']) {
+      expect(normalizeEtag(bad)).toBeNull();
+    }
+  });
+
+  it('rejects a WEAK validator — a weak tag cannot certify byte identity', () => {
+    expect(normalizeEtag('W/"abc123"')).toBeNull();
+  });
+});
+
+describe('readRecordedEtag', () => {
+  it('reads the tag out of an Image.metadata blob', () => {
+    expect(readRecordedEtag({ size: 10, [STORED_OBJECT_ETAG_META_KEY]: '"abc"' })).toBe('abc');
+  });
+
+  it('returns null for a metadata blob that does not carry one', () => {
+    for (const meta of [null, undefined, {}, { size: 10 }, 'nope', 7, []]) {
+      expect(readRecordedEtag(meta)).toBeNull();
+    }
+  });
+
+  it('returns null when the key holds a non-string (an untyped JSON column)', () => {
+    expect(readRecordedEtag({ [STORED_OBJECT_ETAG_META_KEY]: 12345 })).toBeNull();
+    expect(readRecordedEtag({ [STORED_OBJECT_ETAG_META_KEY]: { v: 'abc' } })).toBeNull();
+    expect(readRecordedEtag({ [STORED_OBJECT_ETAG_META_KEY]: '' })).toBeNull();
+  });
+});
+
+describe('storedObjectEtagMetadata', () => {
+  it('contributes the tag under the shared key when there is one', () => {
+    expect(storedObjectEtagMetadata('"abc"')).toEqual({ [STORED_OBJECT_ETAG_META_KEY]: 'abc' });
+  });
+
+  it('contributes NOTHING when there is no usable tag — never a null entry', () => {
+    for (const bad of [null, '', '   ', 'W/"abc"']) {
+      expect(storedObjectEtagMetadata(bad)).toEqual({});
+    }
+  });
+
+  /**
+   * The round trip the two services actually depend on: what persist merges into
+   * `Image.metadata` is what the attach gate reads back out. A drift in the key
+   * name would leave both halves individually correct and the pair inert.
+   */
+  it('round-trips through readRecordedEtag', () => {
+    expect(readRecordedEtag({ size: 1, ...storedObjectEtagMetadata('"round-trip"') })).toBe(
+      'round-trip'
+    );
+    expect(readRecordedEtag({ size: 1, ...storedObjectEtagMetadata(null) })).toBeNull();
+  });
+});
+
+describe('classifyStoredObjectIntegrity', () => {
+  it('MATCH: the live object carries the tag that was recorded', () => {
+    expect(classifyStoredObjectIntegrity('"abc"', present('"abc"'))).toEqual({ status: 'match' });
+  });
+
+  it('MATCH across the quoted/bare wire forms', () => {
+    expect(classifyStoredObjectIntegrity('abc', present('"abc"'))).toEqual({ status: 'match' });
+    expect(classifyStoredObjectIntegrity('"abc"', present('abc'))).toEqual({ status: 'match' });
+  });
+
+  it('MISMATCH: the live object carries a DIFFERENT tag — the only asserting verdict', () => {
+    expect(classifyStoredObjectIntegrity('"abc"', present('"def"'))).toEqual({
+      status: 'mismatch',
+    });
+  });
+
+  it('UNVERIFIABLE (no-recorded-etag): a row written before the tag was recorded', () => {
+    expect(classifyStoredObjectIntegrity(null, present('"def"'))).toEqual({
+      status: 'unverifiable',
+      reason: 'no-recorded-etag',
+    });
+  });
+
+  it('UNVERIFIABLE (object-absent): the store says the key is gone', () => {
+    expect(classifyStoredObjectIntegrity('"abc"', { status: 'absent' })).toEqual({
+      status: 'unverifiable',
+      reason: 'object-absent',
+    });
+  });
+
+  it('UNVERIFIABLE (store-unreachable): the store could not be consulted', () => {
+    expect(classifyStoredObjectIntegrity('"abc"', { status: 'unknown' })).toEqual({
+      status: 'unverifiable',
+      reason: 'store-unreachable',
+    });
+  });
+
+  it('UNVERIFIABLE (no-current-etag): the object is there but the store returned no tag', () => {
+    expect(classifyStoredObjectIntegrity('"abc"', present(null))).toEqual({
+      status: 'unverifiable',
+      reason: 'no-current-etag',
+    });
+    expect(classifyStoredObjectIntegrity('"abc"', present('  '))).toEqual({
+      status: 'unverifiable',
+      reason: 'no-current-etag',
+    });
+  });
+
+  /**
+   * 🔴 The failure that would make the guard worse than useless: two ABSENT tags
+   * comparing equal and reading as agreement. `null === null` is true, so this is a
+   * one-character mistake away at all times.
+   */
+  it('never reports MATCH when either side has no tag', () => {
+    expect(classifyStoredObjectIntegrity(null, present(null)).status).toBe('unverifiable');
+    expect(classifyStoredObjectIntegrity('', present('')).status).toBe('unverifiable');
+  });
+
+  it('never reports MISMATCH from an absence — that would reject healthy images', () => {
+    const absences: [string | null, StoredImageHead][] = [
+      [null, present('"def"')],
+      ['"abc"', present(null)],
+      ['"abc"', { status: 'absent' }],
+      ['"abc"', { status: 'unknown' }],
+      [null, { status: 'absent' }],
+      [null, { status: 'unknown' }],
+      [null, present(null)],
+    ];
+    for (const [recorded, head] of absences) {
+      expect(classifyStoredObjectIntegrity(recorded, head).status).toBe('unverifiable');
+    }
+  });
+});

--- a/src/server/services/blocks/app-listing-assets.service.ts
+++ b/src/server/services/blocks/app-listing-assets.service.ts
@@ -3,6 +3,7 @@ import type { Prisma } from '@prisma/client';
 import { randomUUID } from 'crypto';
 
 import { dbRead, dbWrite } from '~/server/db/client';
+import { logToAxiom } from '~/server/logging/client';
 import { NsfwLevel } from '~/server/common/enums';
 import {
   deriveContentRatingFromAssets,
@@ -538,13 +539,46 @@ async function remapScreenshotRowIds(args: {
  * The head request is issued ONLY when the row actually carries a tag, so rows that
  * cannot be checked cost no extra round trip — and `stored-image-probe` (and the
  * S3 client graph behind it) stays out of this module's static import graph.
+ *
+ * 🔴 EVERY OUTCOME THAT IS NOT `match` IS LOGGED, and the four `unverifiable`
+ * reasons are kept apart on the way out. Without that, a guard that is firing and a
+ * guard that is inert produce exactly the same observable — nothing — and the four
+ * reasons are operationally different signals rather than one blob: a rising
+ * `store-unreachable` is an infrastructure incident, a rising `no-current-etag` is a
+ * backend that stopped returning tags (which quietly disarms this check for every
+ * row), and `mismatch` is the case the guard exists for. A steady trickle of any of
+ * them is the only way to notice that the fail-open branch has become the ONLY
+ * branch.
+ *
+ * 🔴 The event carries NO storage key, bucket, URL or caller identity — the reason
+ * plus the asset kind plus the row id is everything an operator needs to tell these
+ * classes apart, and an object key in a log is an upload location in a log.
+ *
+ * `no-recorded-etag` is deliberately unreachable from here: the early return above
+ * skips the head entirely for a row that has nothing recorded, which is the expected
+ * steady state for every row written before this existed and is not worth an event
+ * each. It stays in the classifier's vocabulary for callers that do not short-circuit.
  */
-async function assertStoredObjectUnchanged(image: { url: string; metadata: unknown }) {
+async function assertStoredObjectUnchanged(
+  image: { id: number; url: string; metadata: unknown },
+  kind: ListingAssetKind
+) {
   const recordedEtag = readRecordedEtag(image.metadata);
   if (recordedEtag === null) return;
 
   const { headStoredImage } = await import('~/server/utils/stored-image-probe');
   const verdict = classifyStoredObjectIntegrity(recordedEtag, await headStoredImage(image.url));
+  if (verdict.status === 'match') return;
+
+  logToAxiom({
+    name: 'listing-asset-integrity',
+    type: verdict.status === 'mismatch' ? 'error' : 'warning',
+    status: verdict.status,
+    reason: verdict.status === 'unverifiable' ? verdict.reason : null,
+    kind,
+    imageId: image.id,
+  }).catch(() => null);
+
   if (verdict.status !== 'mismatch') return;
 
   throw new TRPCError({
@@ -630,7 +664,7 @@ async function loadValidatedImage(
   if (image.userId !== user.id && !user.isModerator) {
     throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not own this image' });
   }
-  await assertStoredObjectUnchanged(image);
+  await assertStoredObjectUnchanged(image, kind);
   const size = (image.metadata as { size?: unknown } | null)?.size;
   const result = validateListingImage(
     {

--- a/src/server/services/blocks/app-listing-assets.service.ts
+++ b/src/server/services/blocks/app-listing-assets.service.ts
@@ -17,6 +17,10 @@ import {
 } from '~/server/schema/blocks/app-listing.schema';
 import type { SessionUser } from '~/types/session';
 import {
+  classifyStoredObjectIntegrity,
+  readRecordedEtag,
+} from '~/server/services/blocks/stored-object-integrity';
+import {
   appInitial,
   categoryGlyph,
   listingPlaceholderSeed,
@@ -222,7 +226,9 @@ export function buildPlaceholderIconSvg(args: {
     `<stop offset="100%" stop-color="${placeholderStop('icon', 'to', hue2)}"/>`,
     `</linearGradient></defs>`,
     `<rect width="${size}" height="${size}" rx="${Math.round(size * 0.18)}" fill="url(#g)"/>`,
-    `<text x="50%" y="50%" dy="0.35em" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-weight="700" font-size="${Math.round(size * 0.5)}" fill="#ffffff" fill-opacity="0.92">${initial}</text>`,
+    `<text x="50%" y="50%" dy="0.35em" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-weight="700" font-size="${Math.round(
+      size * 0.5
+    )}" fill="#ffffff" fill-opacity="0.92">${initial}</text>`,
     `</svg>`,
   ].join('');
 }
@@ -252,8 +258,12 @@ export function buildPlaceholderCoverSvg(args: {
     `<stop offset="100%" stop-color="${placeholderStop('cover', 'to', hue2)}"/>`,
     `</linearGradient></defs>`,
     `<rect width="${width}" height="${height}" fill="url(#g)"/>`,
-    `<text x="50%" y="44%" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="${Math.round(height * 0.22)}" fill="#ffffff" fill-opacity="0.85">${glyph}</text>`,
-    `<text x="50%" y="66%" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-weight="600" font-size="${Math.round(height * 0.07)}" fill="#ffffff" fill-opacity="0.9">${name}</text>`,
+    `<text x="50%" y="44%" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="${Math.round(
+      height * 0.22
+    )}" fill="#ffffff" fill-opacity="0.85">${glyph}</text>`,
+    `<text x="50%" y="66%" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-weight="600" font-size="${Math.round(
+      height * 0.07
+    )}" fill="#ffffff" fill-opacity="0.9">${name}</text>`,
     `</svg>`,
   ].join('');
 }
@@ -500,6 +510,50 @@ async function remapScreenshotRowIds(args: {
 }
 
 /**
+ * Re-check that the stored object an `Image` row was MEASURED from is still the
+ * object at that key, and refuse the attach if it demonstrably is not.
+ *
+ * WHY THIS EXISTS. Every rule {@link loadValidatedImage} applies — the per-kind
+ * dimension bounds, the aspect ratio, the MIME allowlist, the byte cap — reads the
+ * `Image` row's own columns. Those columns are trustworthy at the moment they are
+ * written, because the persist procs derive them from the stored bytes rather than
+ * from anything the client said. They are not automatically trustworthy LATER: the
+ * upload grant for a key outlives the measurement, so an object can be replaced
+ * after its row was written, leaving the row describing bytes that are no longer
+ * there. Validating the columns then validates a description, not the media.
+ *
+ * Persist records the store's entity tag next to the measurement; this compares it
+ * to the live one at the point the measurement is relied upon, which is the only
+ * place the guarantee actually has to hold.
+ *
+ * 🔴 FAILS CLOSED ON DISAGREEMENT ONLY. A row with no recorded tag (written before
+ * this existed, or by a path that never measures an uploaded object), an object the
+ * store says is gone, or a store that cannot be consulted all classify as
+ * `unverifiable` — and are ALLOWED through, because none of them is evidence that
+ * anything changed, and rejecting on them would turn a store hiccup into a blocked
+ * attach for images that are perfectly fine. See
+ * {@link classifyStoredObjectIntegrity}, which owns that distinction, and the same
+ * three-state posture on `headObject` in `~/utils/s3-utils`.
+ *
+ * The head request is issued ONLY when the row actually carries a tag, so rows that
+ * cannot be checked cost no extra round trip — and `stored-image-probe` (and the
+ * S3 client graph behind it) stays out of this module's static import graph.
+ */
+async function assertStoredObjectUnchanged(image: { url: string; metadata: unknown }) {
+  const recordedEtag = readRecordedEtag(image.metadata);
+  if (recordedEtag === null) return;
+
+  const { headStoredImage } = await import('~/server/utils/stored-image-probe');
+  const verdict = classifyStoredObjectIntegrity(recordedEtag, await headStoredImage(image.url));
+  if (verdict.status !== 'mismatch') return;
+
+  throw new TRPCError({
+    code: 'BAD_REQUEST',
+    message: 'that image has changed since it was uploaded — upload it again',
+  });
+}
+
+/**
  * The result of {@link loadValidatedImage}: a discriminated union.
  *
  *   - `{ pending: true }`  — the Image exists, is owned + format-valid, but its
@@ -533,10 +587,15 @@ type LoadValidatedImageResult =
  *
  * TERMINAL failures ALWAYS THROW regardless of `allowPending` (real errors the
  * client surfaces + stops polling on): missing → NOT_FOUND; not owned → FORBIDDEN;
- * bad format → BAD_REQUEST; `ImageIngestionStatus.NotFound` (scanner couldn't fetch
- * the bytes) → BAD_REQUEST; `Blocked` (prohibited content) → BAD_REQUEST. A
- * `Blocked` / `NotFound` image is terminal-bad and is NEVER written, even under
- * `allowPending`.
+ * the stored object no longer being the one the row was measured from
+ * ({@link assertStoredObjectUnchanged}) → BAD_REQUEST; bad format → BAD_REQUEST;
+ * `ImageIngestionStatus.NotFound` (scanner couldn't fetch the bytes) → BAD_REQUEST;
+ * `Blocked` (prohibited content) → BAD_REQUEST. A `Blocked` / `NotFound` image is
+ * terminal-bad and is NEVER written, even under `allowPending`.
+ *
+ * 🔴 The integrity re-check runs BEFORE the column validation deliberately: the
+ * validation's inputs are the persisted measurements, so confirming they still
+ * describe the stored object is a precondition for the bounds meaning anything.
  *
  * Content RATING is deliberately NOT gated here (W13): the scanner's per-image
  * level is imprecise, every off-site listing is mod-reviewed before it is visible,
@@ -555,6 +614,9 @@ async function loadValidatedImage(
     select: {
       id: true,
       userId: true,
+      // The storage key the row's measurements were taken from — the integrity
+      // re-check below needs it; nothing else here reads it.
+      url: true,
       type: true,
       width: true,
       height: true,
@@ -568,6 +630,7 @@ async function loadValidatedImage(
   if (image.userId !== user.id && !user.isModerator) {
     throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not own this image' });
   }
+  await assertStoredObjectUnchanged(image);
   const size = (image.metadata as { size?: unknown } | null)?.size;
   const result = validateListingImage(
     {
@@ -838,7 +901,12 @@ export async function getAssetScanStatuses(
  */
 async function reDeriveContentRatingForModLiveEdit(
   tx: Prisma.TransactionClient,
-  listing: { id: string; status: string; revisionOfId: string | null; contentRating: string | null },
+  listing: {
+    id: string;
+    status: string;
+    revisionOfId: string | null;
+    contentRating: string | null;
+  },
   user: SessionUser
 ): Promise<void> {
   if (!user.isModerator) return;
@@ -863,7 +931,8 @@ async function reDeriveContentRatingForModLiveEdit(
   // RAISE-ONLY floor: bump the stored rating up to `derived` only if derived's
   // ceiling is strictly higher (never auto-lower). `nsfwLevelFromContentRating`
   // maps null → the SFW floor, so a null stored rating is raised by any mature asset.
-  if (nsfwLevelFromContentRating(derived) <= nsfwLevelFromContentRating(current.contentRating)) return;
+  if (nsfwLevelFromContentRating(derived) <= nsfwLevelFromContentRating(current.contentRating))
+    return;
   await tx.appListing.update({ where: { id: listing.id }, data: { contentRating: derived } });
 }
 
@@ -1267,20 +1336,16 @@ export async function getListingAssets(
   });
 
   // Resolve the detected nsfwLevel of every backing Image in ONE query.
-  const imageIds = [
-    listing.iconId,
-    listing.coverId,
-    ...screenshots.map((s) => s.imageId),
-  ].filter((v): v is number => v != null);
+  const imageIds = [listing.iconId, listing.coverId, ...screenshots.map((s) => s.imageId)].filter(
+    (v): v is number => v != null
+  );
   const images = imageIds.length
     ? await dbRead.image.findMany({
         where: { id: { in: imageIds } },
         select: { id: true, nsfwLevel: true, ingestion: true },
       })
     : [];
-  const levelById = new Map<number, number | null>(
-    images.map((i) => [i.id, i.nsfwLevel ?? null])
-  );
+  const levelById = new Map<number, number | null>(images.map((i) => [i.id, i.nsfwLevel ?? null]));
   const ingestionById = new Map<number, string | null>(
     images.map((i) => [i.id, i.ingestion ?? null])
   );
@@ -1532,8 +1597,7 @@ export async function backfillListingAssets(
     // A screenshot row whose Image was deleted (imageId → null) does NOT count
     // as a present screenshot — it must be re-filled, not treated as complete.
     const hasScreenshots = candidate.screenshots.some((s) => s.imageId != null);
-    const complete =
-      candidate.iconId != null && candidate.coverId != null && hasScreenshots;
+    const complete = candidate.iconId != null && candidate.coverId != null && hasScreenshots;
     if (complete) {
       result.skippedComplete += 1;
       continue;

--- a/src/server/services/blocks/block-image-upload.service.ts
+++ b/src/server/services/blocks/block-image-upload.service.ts
@@ -10,6 +10,7 @@ import {
 import type { OffsiteRatingValue } from '~/shared/constants/browsingLevel.constants';
 import type { PersistBlockUploadImageInput } from '~/server/schema/blocks/block-image-upload.schema';
 import { measureUploadedImage } from '~/server/services/blocks/measure-uploaded-image';
+import { storedObjectEtagMetadata } from '~/server/services/blocks/stored-object-integrity';
 import type { SessionUser } from '~/types/session';
 import { uploadImageBufferToStore } from '~/utils/s3-utils';
 
@@ -64,8 +65,11 @@ export async function persistBlockUploadImage(opts: {
     width: measured.width,
     height: measured.height,
     mimeType: measured.mimeType,
-    // Byte size is read from `Image.metadata.size` by the image validators.
-    metadata: { size: measured.sizeBytes },
+    // Byte size is read from `Image.metadata.size` by the image validators. The
+    // entity tag records which stored object they were measured from — a row from
+    // here is attachable as listing media, so it must carry the same evidence the
+    // listing attach gate re-checks.
+    metadata: { size: measured.sizeBytes, ...storedObjectEtagMetadata(measured.etag) },
     userId,
   });
   return { imageId: image.id };
@@ -102,8 +106,14 @@ function sniffSupportedImage(b: Buffer): string | null {
   if (b[0] === 0x89 && b[1] === 0x50 && b[2] === 0x4e && b[3] === 0x47) return 'image/png';
   if (b[0] === 0x47 && b[1] === 0x49 && b[2] === 0x46 && b[3] === 0x38) return 'image/gif';
   if (
-    b[0] === 0x52 && b[1] === 0x49 && b[2] === 0x46 && b[3] === 0x46 && // 'RIFF'
-    b[8] === 0x57 && b[9] === 0x45 && b[10] === 0x42 && b[11] === 0x50 // 'WEBP'
+    b[0] === 0x52 &&
+    b[1] === 0x49 &&
+    b[2] === 0x46 &&
+    b[3] === 0x46 && // 'RIFF'
+    b[8] === 0x57 &&
+    b[9] === 0x45 &&
+    b[10] === 0x42 &&
+    b[11] === 0x50 // 'WEBP'
   ) {
     return 'image/webp';
   }

--- a/src/server/services/blocks/measure-uploaded-image.ts
+++ b/src/server/services/blocks/measure-uploaded-image.ts
@@ -10,6 +10,13 @@ export type MeasuredUploadedImage = {
   height: number;
   mimeType: (typeof LISTING_ASSET_ALLOWED_MIME)[number];
   sizeBytes: number;
+  /**
+   * The store's entity tag for the object these values were measured from — the
+   * evidence that lets a later consumer tell "still those bytes" from "was those
+   * bytes once". `null` when the backend returned none; see
+   * {@link classifyStoredObjectIntegrity}, which treats that as unverifiable.
+   */
+  etag: string | null;
 };
 
 /**
@@ -26,6 +33,12 @@ export type MeasuredUploadedImage = {
  * The guarantee is narrower than "the columns match the object": the presigned PUT
  * stays usable for its full expiry, so the same key can be overwritten after this
  * read. It says the values were true of real bytes AT PROBE TIME.
+ *
+ * `etag` is what a consumer needs to close that distance at ITS end: persisted
+ * beside the measurement (under {@link STORED_OBJECT_ETAG_META_KEY}) it can be
+ * re-checked against the live object at the point the measurement is actually
+ * relied upon, so a row whose bytes were replaced afterwards is recognisable
+ * rather than merely caveated.
  *
  * `maxBytes` bounds the read back out of the store AND rejects an object above it
  * (`subject` names the caller's media in that message). A decoded format outside
@@ -69,5 +82,11 @@ export async function measureUploadedImage(
       }" (allowed: ${LISTING_ASSET_ALLOWED_MIME.join(', ')})`,
     });
   }
-  return { width: probe.width, height: probe.height, mimeType, sizeBytes: probe.sizeBytes };
+  return {
+    width: probe.width,
+    height: probe.height,
+    mimeType,
+    sizeBytes: probe.sizeBytes,
+    etag: probe.etag,
+  };
 }

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -35,6 +35,7 @@ import {
 import { assertOffsiteListingActionable } from '~/server/services/blocks/app-listing-actionable.service';
 import { computeListingProblems } from '~/server/services/blocks/listing-problems';
 import { measureUploadedImage } from '~/server/services/blocks/measure-uploaded-image';
+import { storedObjectEtagMetadata } from '~/server/services/blocks/stored-object-integrity';
 import { notifyAppListingOwner } from '~/server/services/blocks/app-listing-notify';
 import {
   deriveContentRatingFromAssets,
@@ -973,10 +974,7 @@ export async function beginListingRevision(opts: {
   const parent = await loadOwnedEditableListing(listingId, userId);
 
   if (parent.revisionOfId != null) {
-    throw new OffsiteRequestError(
-      'INVALID_REVISION',
-      'cannot open a revision of a revision draft'
-    );
+    throw new OffsiteRequestError('INVALID_REVISION', 'cannot open a revision of a revision draft');
   }
   if (parent.status !== 'approved') {
     throw new OffsiteRequestError(
@@ -1042,13 +1040,15 @@ export async function beginListingRevision(opts: {
       });
       if (shots.length > 0) {
         await tx.appListingScreenshot.createMany({
-          data: shots.map((s: { imageId: number | null; order: number; caption: string | null }) => ({
-            id: newAppListingScreenshotId(),
-            appListingId: shadowId,
-            imageId: s.imageId,
-            order: s.order,
-            caption: s.caption,
-          })),
+          data: shots.map(
+            (s: { imageId: number | null; order: number; caption: string | null }) => ({
+              id: newAppListingScreenshotId(),
+              appListingId: shadowId,
+              imageId: s.imageId,
+              order: s.order,
+              caption: s.caption,
+            })
+          ),
         });
       }
     });
@@ -1113,19 +1113,17 @@ export async function submitListingRevision(opts: {
       coverId: true,
       revisionOf: { select: { slug: true, status: true } },
     },
-  })) as
-    | {
-        id: string;
-        kind: string;
-        status: string;
-        userId: number;
-        revisionOfId: string | null;
-        externalUrl: string | null;
-        iconId: number | null;
-        coverId: number | null;
-        revisionOf: { slug: string; status: string } | null;
-      }
-    | null;
+  })) as {
+    id: string;
+    kind: string;
+    status: string;
+    userId: number;
+    revisionOfId: string | null;
+    externalUrl: string | null;
+    iconId: number | null;
+    coverId: number | null;
+    revisionOf: { slug: string; status: string } | null;
+  } | null;
 
   if (!shadow) {
     throw new OffsiteRequestError('NOT_FOUND', `revision draft ${shadowId} not found`);
@@ -2163,7 +2161,9 @@ export async function approveExternalRequest(opts: {
       // submit/edit time). A connect listing always has a `connectClient` row here
       // (FK-backed by the non-null `connectClientId`); treat a null ceiling as 0.
       const allowedScopes = primaryListing.connectClient?.allowedScopes ?? 0;
-      if (!connectScopesSubsetOfCeiling(primaryListing.connectRequestedScopes ?? 0, allowedScopes)) {
+      if (
+        !connectScopesSubsetOfCeiling(primaryListing.connectRequestedScopes ?? 0, allowedScopes)
+      ) {
         throw new TRPCError({
           code: 'BAD_REQUEST',
           message: 'requested scopes exceed the OAuth client’s allowed scopes',
@@ -2695,8 +2695,11 @@ export async function persistListingAssetImage(opts: {
     width: measured.width,
     height: measured.height,
     mimeType: measured.mimeType,
-    // The P1 image validator reads the byte size from `Image.metadata.size`.
-    metadata: { size: measured.sizeBytes },
+    // The P1 image validator reads the byte size from `Image.metadata.size`. The
+    // entity tag alongside it records WHICH stored object those measurements came
+    // from, so the attach gate can re-check that the object still is that one
+    // instead of trusting a reading taken before the upload grant expired.
+    metadata: { size: measured.sizeBytes, ...storedObjectEtagMetadata(measured.etag) },
     userId,
   });
   return { imageId: image.id };
@@ -2802,9 +2805,7 @@ export type ListOffsiteRequestsOptions = { limit?: number; cursor?: string };
  * a rejected/withdrawn submission — is still shown.) The shape is otherwise
  * backward-compatible: `hasPendingRevision` is purely additive.
  */
-export async function listMySubmissions(
-  opts: { userId: number } & ListOffsiteRequestsOptions
-) {
+export async function listMySubmissions(opts: { userId: number } & ListOffsiteRequestsOptions) {
   const limit = Math.min(opts.limit ?? 25, 100);
   const rows = await dbRead.appListingPublishRequest.findMany({
     where: {
@@ -2819,11 +2820,7 @@ export async function listMySubmissions(
       // request (all onsite requests are shadow revisions, per the invariant). Include
       // them directly via the `{ kind: 'onsite' }` OR branch so onsite media revisions
       // appear on my-submissions (decision: yes).
-      OR: [
-        { appListingId: null },
-        { appListing: { revisionOfId: null } },
-        { kind: 'onsite' },
-      ],
+      OR: [{ appListingId: null }, { appListing: { revisionOfId: null } }, { kind: 'onsite' }],
     },
     orderBy: { submittedAt: 'desc' },
     take: limit + 1,
@@ -2839,9 +2836,7 @@ export async function listMySubmissions(
   // existence. An abandoned shadow (opened via beginListingRevision but never
   // submitListingRevision-ed → no pending request) must NOT falsely badge the
   // parent "revision in review".
-  const parentIds = page
-    .map((r) => r.appListingId)
-    .filter((id): id is string => id != null);
+  const parentIds = page.map((r) => r.appListingId).filter((id): id is string => id != null);
   const pendingRevisionReqs =
     parentIds.length > 0
       ? await dbRead.appListingPublishRequest.findMany({
@@ -2913,9 +2908,7 @@ export async function listMySubmissions(
       })
     : [];
   const ingestionByImageId = new Map(ingestionRows.map((i) => [i.id, i.ingestion ?? null]));
-  const scanStatusOf = (
-    ingestion: string | null | undefined
-  ): 'scanned' | 'pending' | 'blocked' =>
+  const scanStatusOf = (ingestion: string | null | undefined): 'scanned' | 'pending' | 'blocked' =>
     ingestion === 'Scanned' ? 'scanned' : ingestion === 'Blocked' ? 'blocked' : 'pending';
   const assetScansFor = (listing: {
     iconId: number | null;

--- a/src/server/services/blocks/stored-object-integrity.ts
+++ b/src/server/services/blocks/stored-object-integrity.ts
@@ -1,0 +1,120 @@
+import type { StoredImageHead } from '~/server/utils/stored-image-probe';
+
+/**
+ * The measurement a persist proc takes of an uploaded object describes the bytes
+ * that were there AT PROBE TIME — the upload grant outlives the probe, so the
+ * object at that key can differ later while the row still describes the old bytes
+ * (see the header of `~/server/utils/stored-image-probe`). Every consumer that
+ * makes a DECISION from those persisted columns is therefore trusting a claim
+ * about a moment that has passed.
+ *
+ * This module is the pure half of closing that gap: the persist procs record the
+ * store's entity tag next to the measurement, and a consumer re-reads the tag and
+ * compares. No db, no network, no `sharp` — so the RULE that decides whether an
+ * attach may proceed is unit-testable on its own, and lives in exactly one place
+ * rather than being re-derived at each of the three attach procs.
+ */
+
+/**
+ * Key under `Image.metadata` holding the entity tag of the object the row's
+ * dimensions / MIME / byte size were measured from.
+ *
+ * 🔴 Additive and OPTIONAL by construction. Rows written before this existed, and
+ * rows created by paths that never measure an uploaded object, simply do not carry
+ * it — {@link classifyStoredObjectIntegrity} reports those `unverifiable`, never
+ * `mismatch`. Absence is the absence of EVIDENCE, and must never be read as
+ * evidence of tampering.
+ */
+export const STORED_OBJECT_ETAG_META_KEY = 'storedEtag' as const;
+
+/**
+ * Why a comparison could not be made. Kept distinct rather than collapsed into one
+ * `unverifiable`, because they are operationally different signals: a store that
+ * cannot be reached is an infrastructure event, while a row with no recorded tag is
+ * just an older row.
+ */
+export type StoredObjectIntegrityUnverifiableReason =
+  /** The row carries no recorded tag — created before this existed, or by a path that does not measure. */
+  | 'no-recorded-etag'
+  /** The store answered that the key is gone. Nothing to compare against. */
+  | 'object-absent'
+  /** The store could not be consulted at all. */
+  | 'store-unreachable'
+  /** The object is there, but the store returned no tag for it. */
+  | 'no-current-etag';
+
+export type StoredObjectIntegrity =
+  | { status: 'match' }
+  | { status: 'mismatch' }
+  | { status: 'unverifiable'; reason: StoredObjectIntegrityUnverifiableReason };
+
+/**
+ * Entity tags are quoted by the S3 wire format (`"d41d8…"`), and a backend may or
+ * may not preserve the quoting across a `GetObject` vs a `HeadObject`. Compare the
+ * token, not its punctuation: strip surrounding whitespace and at most one layer of
+ * double quotes.
+ *
+ * Returns `null` for anything that is not a non-empty token afterwards, so an empty
+ * or whitespace-only tag can never compare equal to another empty one and be read
+ * as agreement.
+ */
+export function normalizeEtag(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null;
+  let value = raw.trim();
+  // Weak-validator prefix (`W/"…"`) — a byte-for-byte comparison is what we want,
+  // so a weak tag is deliberately NOT accepted as a strong one.
+  if (value.startsWith('W/')) return null;
+  if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+    value = value.slice(1, -1).trim();
+  }
+  return value.length > 0 ? value : null;
+}
+
+/**
+ * Read the recorded entity tag out of an `Image.metadata` blob. `metadata` is an
+ * untyped JSON column, so every shape that is not a usable tag — `null`, a number,
+ * an object, an empty string — returns `null` ("nothing recorded").
+ */
+export function readRecordedEtag(metadata: unknown): string | null {
+  if (typeof metadata !== 'object' || metadata === null) return null;
+  return normalizeEtag((metadata as Record<string, unknown>)[STORED_OBJECT_ETAG_META_KEY]);
+}
+
+/**
+ * The `Image.metadata` fragment a persist proc merges in to record the tag it
+ * measured from. An unusable tag contributes NOTHING rather than a `null` entry, so
+ * "no evidence" has one representation on the read side.
+ *
+ * Shared by every persist path rather than open-coded at each, so the key and the
+ * omit-when-absent rule cannot drift between them.
+ */
+export function storedObjectEtagMetadata(
+  etag: string | null
+): Record<string, string> | Record<string, never> {
+  const normalized = normalizeEtag(etag);
+  return normalized === null ? {} : { [STORED_OBJECT_ETAG_META_KEY]: normalized };
+}
+
+/**
+ * Compare a recorded tag against a fresh head of the same key.
+ *
+ * 🔴 `mismatch` is the ONLY verdict that asserts anything. It requires two tags
+ * that both exist and disagree — i.e. the store is holding an object that is
+ * demonstrably not the one that was measured. Every other combination is
+ * `unverifiable`: a missing tag on either side, an absent object, an unreachable
+ * store. A consumer must fail CLOSED on `mismatch` and must NOT fail closed on
+ * `unverifiable`, or an unrelated store hiccup becomes a user-facing rejection —
+ * the same posture `headObject`'s three-state result documents in `~/utils/s3-utils`.
+ */
+export function classifyStoredObjectIntegrity(
+  recordedEtag: string | null,
+  head: StoredImageHead
+): StoredObjectIntegrity {
+  const recorded = normalizeEtag(recordedEtag);
+  if (recorded === null) return { status: 'unverifiable', reason: 'no-recorded-etag' };
+  if (head.status === 'absent') return { status: 'unverifiable', reason: 'object-absent' };
+  if (head.status === 'unknown') return { status: 'unverifiable', reason: 'store-unreachable' };
+  const current = normalizeEtag(head.etag);
+  if (current === null) return { status: 'unverifiable', reason: 'no-current-etag' };
+  return current === recorded ? { status: 'match' } : { status: 'mismatch' };
+}

--- a/src/server/utils/__tests__/stored-image-probe.test.ts
+++ b/src/server/utils/__tests__/stored-image-probe.test.ts
@@ -1,0 +1,141 @@
+import { HeadObjectCommand } from '@aws-sdk/client-s3';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type * as S3Utils from '~/utils/s3-utils';
+
+/**
+ * `headStoredImage` — the entity-tag re-read the listing attach gate depends on.
+ *
+ * The property under test is that it is BOUNDED. Its three-state result already
+ * fails open on an error, and that is the state everything downstream reasons
+ * about; what an error-shaped test cannot show is the other way a store fails,
+ * which is by not answering at all. An unbounded head does not fail open — it
+ * holds the caller open — and because a healthy backend answers with or without a
+ * timeout, nothing about a missing bound is observable until production is the
+ * thing that is degraded.
+ */
+
+const { mockS3Send } = vi.hoisted(() => ({ mockS3Send: vi.fn() }));
+
+// Nothing here talks to the database, but the module graph reaches a Prisma client
+// that cannot initialise in a unit environment — and it fails as an UNHANDLED
+// REJECTION, i.e. a red run with every test green. Stubbed so the run's verdict is
+// about this module.
+vi.mock('~/server/db/client', () => ({
+  dbRead: {},
+  dbWrite: {},
+  dbKV: {},
+}));
+
+vi.mock('~/utils/s3-utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof S3Utils>()),
+  getImageUploadBackend: async () => ({
+    s3: { send: mockS3Send },
+    bucket: 'test-image-bucket',
+    backend: 'backblaze' as const,
+  }),
+}));
+
+const KEY = '44444444-4444-4444-8444-444444444444';
+
+/** A store that never answers — it settles only when the caller gives up on it. */
+function hangUntilAborted() {
+  return (_command: unknown, options?: { abortSignal?: AbortSignal }) =>
+    new Promise((_resolve, reject) => {
+      const signal = options?.abortSignal;
+      if (!signal) return; // no bound handed down → hangs forever, which is the bug
+      signal.addEventListener('abort', () =>
+        reject(Object.assign(new Error('aborted'), { name: 'TimeoutError' }))
+      );
+    });
+}
+
+beforeEach(() => {
+  mockS3Send.mockReset();
+});
+
+describe('headStoredImage', () => {
+  it('reads back the entity tag the store reports', async () => {
+    mockS3Send.mockResolvedValue({ ETag: '"abc123"' });
+    const { headStoredImage } = await import('~/server/utils/stored-image-probe');
+
+    await expect(headStoredImage(KEY)).resolves.toEqual({ status: 'present', etag: '"abc123"' });
+    // POSITIVE CONTROL: the assertions below are about a call that really happens.
+    expect(mockS3Send).toHaveBeenCalledTimes(1);
+    expect(mockS3Send.mock.calls[0][0]).toBeInstanceOf(HeadObjectCommand);
+  });
+
+  it('bounds the request with an abort signal derived from the timeout budget', async () => {
+    mockS3Send.mockResolvedValue({ ETag: '"abc123"' });
+    const { headStoredImage, STORED_IMAGE_HEAD_TIMEOUT_MS } = await import(
+      '~/server/utils/stored-image-probe'
+    );
+
+    await headStoredImage(KEY);
+
+    const signal = (mockS3Send.mock.calls[0][1] as { abortSignal?: AbortSignal })?.abortSignal;
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(signal?.aborted).toBe(false);
+    // The budget is a real, finite, non-zero one: a 0 would abort every head before
+    // it left, and an Infinity would be the unbounded case wearing a signal.
+    expect(STORED_IMAGE_HEAD_TIMEOUT_MS).toBeGreaterThan(0);
+    expect(Number.isFinite(STORED_IMAGE_HEAD_TIMEOUT_MS)).toBe(true);
+  });
+
+  /**
+   * 🔴 THE POINT. A store that hangs must resolve to `unknown` — the same "we could
+   * not consult it" the caller already fails open on — and must NOT reject, because
+   * a rejection out of here would propagate as a 500 from an attach whose image is
+   * perfectly fine.
+   */
+  it('resolves UNKNOWN (never rejects) when the store does not answer in time', async () => {
+    mockS3Send.mockImplementation(hangUntilAborted());
+    const { headStoredImage } = await import('~/server/utils/stored-image-probe');
+
+    await expect(headStoredImage(KEY, { timeoutMs: 5 })).resolves.toEqual({ status: 'unknown' });
+  });
+
+  /**
+   * And the verdict a hung store produces at the consumer's end is `unverifiable`,
+   * i.e. the attach proceeds. Composed here rather than asserted in two places, so
+   * a change that made a timeout look like a MISMATCH — a rejected upload for a
+   * slow bucket — cannot pass both halves separately.
+   */
+  it('a timed-out head classifies as unverifiable, not as tampering', async () => {
+    mockS3Send.mockImplementation(hangUntilAborted());
+    const { headStoredImage } = await import('~/server/utils/stored-image-probe');
+    const { classifyStoredObjectIntegrity } = await import(
+      '~/server/services/blocks/stored-object-integrity'
+    );
+
+    const head = await headStoredImage(KEY, { timeoutMs: 5 });
+    expect(classifyStoredObjectIntegrity('"abc123"', head)).toEqual({
+      status: 'unverifiable',
+      reason: 'store-unreachable',
+    });
+  });
+
+  it('still distinguishes an ANSWERED miss from a store that could not be consulted', async () => {
+    const { headStoredImage } = await import('~/server/utils/stored-image-probe');
+
+    mockS3Send.mockRejectedValue(
+      Object.assign(new Error('NoSuchKey'), {
+        name: 'NoSuchKey',
+        $metadata: { httpStatusCode: 404 },
+      })
+    );
+    await expect(headStoredImage(KEY)).resolves.toEqual({ status: 'absent' });
+
+    mockS3Send.mockRejectedValue(
+      Object.assign(new Error('boom'), { $metadata: { httpStatusCode: 503 } })
+    );
+    await expect(headStoredImage(KEY)).resolves.toEqual({ status: 'unknown' });
+  });
+
+  it('reports no tag as null rather than inventing one', async () => {
+    const { headStoredImage } = await import('~/server/utils/stored-image-probe');
+
+    mockS3Send.mockResolvedValue({ ContentLength: 10 });
+    await expect(headStoredImage(KEY)).resolves.toEqual({ status: 'present', etag: null });
+  });
+});

--- a/src/server/utils/stored-image-probe.ts
+++ b/src/server/utils/stored-image-probe.ts
@@ -1,4 +1,4 @@
-import { GetObjectCommand } from '@aws-sdk/client-s3';
+import { GetObjectCommand, HeadObjectCommand } from '@aws-sdk/client-s3';
 
 import { logToAxiom } from '~/server/logging/client';
 import { getImageUploadBackend } from '~/utils/s3-utils';
@@ -18,6 +18,11 @@ import { getImageUploadBackend } from '~/utils/s3-utils';
  * remains usable for its whole expiry window, so the object can be replaced after
  * this returns. Callers may record "these values were measured from real bytes",
  * never "these values describe the object".
+ *
+ * {@link StoredImageProbe.etag} is what lets a later consumer tell those two apart:
+ * recorded alongside the measurement, it turns "true at probe time" into a claim
+ * that can be RE-CHECKED at the point of use via {@link headStoredImage}, without
+ * re-reading (or re-decoding) the bytes.
  */
 
 export type StoredImageProbeReason =
@@ -49,7 +54,48 @@ export type StoredImageProbe = {
   format: string;
   /** The object's true byte length in the store. */
   sizeBytes: number;
+  /**
+   * The store's entity tag for the object these values were read from, or `null`
+   * when the backend did not return one. An OPAQUE token — never parsed, only
+   * compared for equality against a later {@link headStoredImage} of the same key.
+   * `null` is "the store said nothing", NOT "no object": it can never be treated
+   * as evidence of anything.
+   */
+  etag: string | null;
 };
+
+/**
+ * Outcome of re-reading the entity tag of an already-measured key.
+ *
+ * 🔴 THREE states, mirroring `headObject` in `~/utils/s3-utils`. `absent` = the
+ * bucket ANSWERED that the key is gone; `unknown` = the bucket could not be
+ * consulted at all, or answered without an `ETag`. Only `present` carries a token
+ * that may be compared; the other two mean "we do not know", and a caller must
+ * not read them as either agreement or disagreement.
+ */
+export type StoredImageHead =
+  | { status: 'present'; etag: string | null }
+  | { status: 'absent' }
+  | { status: 'unknown' };
+
+/**
+ * Cheap HeadObject re-read of the entity tag at `key`, for a consumer that holds a
+ * tag recorded by {@link probeStoredImage} and needs to know whether the object is
+ * STILL the one that was measured. No bytes are transferred and nothing is decoded.
+ *
+ * 🔴 Never throws, and never converts a failure into a verdict: an unreachable or
+ * unconfigured store lands on `unknown`, which is the caller's cue that the check
+ * could not run — not that it failed.
+ */
+export async function headStoredImage(key: string): Promise<StoredImageHead> {
+  try {
+    const { s3, bucket } = await getImageUploadBackend();
+    const head = await s3.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
+    return { status: 'present', etag: typeof head?.ETag === 'string' ? head.ETag : null };
+  } catch (err) {
+    return isNotFoundError(err) ? { status: 'absent' } : { status: 'unknown' };
+  }
+}
 
 function isNotFoundError(e: unknown) {
   const err = e as { name?: string; Code?: string; $metadata?: { httpStatusCode?: number } };
@@ -90,6 +136,7 @@ export async function probeStoredImage(
 ): Promise<StoredImageProbe> {
   let bytes: Buffer;
   let sizeBytes: number;
+  let etag: string | null;
   try {
     const { s3, bucket } = await getImageUploadBackend();
     const object = await s3.send(
@@ -98,6 +145,10 @@ export async function probeStoredImage(
     if (!object.Body) throw new StoredImageProbeError('unreadable', 'stored image has no body');
     bytes = Buffer.from(await object.Body.transformToByteArray());
     sizeBytes = parseTotalSize(object.ContentRange, bytes.byteLength);
+    // A ranged GET still reports the WHOLE object's entity tag, so this costs no
+    // extra request: it identifies the very bytes the measurement below is taken
+    // from, which is exactly what a later re-check needs.
+    etag = typeof object.ETag === 'string' ? object.ETag : null;
   } catch (err) {
     if (err instanceof StoredImageProbeError) throw err;
     if (isNotFoundError(err)) {
@@ -157,5 +208,6 @@ export async function probeStoredImage(
     height: quarterTurned ? width : height,
     format,
     sizeBytes,
+    etag,
   };
 }

--- a/src/server/utils/stored-image-probe.ts
+++ b/src/server/utils/stored-image-probe.ts
@@ -79,18 +79,46 @@ export type StoredImageHead =
   | { status: 'unknown' };
 
 /**
+ * Timeout budget for the entity-tag re-read.
+ *
+ * 🔴 A BOUND IS NOT OPTIONAL HERE. `headStoredImage` sits inline on a user-facing
+ * mutation, and "the store errors" and "the store never answers" are different
+ * failures: the fail-open posture below only covers the first. An unbounded head
+ * against a degraded backend does not fail open, it HANGS the request holding it —
+ * strictly worse than the tampering this check exists to catch.
+ *
+ * Same budget, and the same reasoning, as the post-completion probe in
+ * `~/pages/api/upload/complete.ts`; taken from there rather than picked afresh so
+ * the two probes against this store cannot drift apart. Per the AWS SDK's contract
+ * this bounds each network ATTEMPT, not wall-clock — the retry sleep is not
+ * abort-aware, so the worst case is this budget plus one backoff. An abort lands on
+ * `unknown`, i.e. the check could not run.
+ */
+export const STORED_IMAGE_HEAD_TIMEOUT_MS = 5_000;
+
+/**
  * Cheap HeadObject re-read of the entity tag at `key`, for a consumer that holds a
  * tag recorded by {@link probeStoredImage} and needs to know whether the object is
  * STILL the one that was measured. No bytes are transferred and nothing is decoded.
  *
  * 🔴 Never throws, and never converts a failure into a verdict: an unreachable or
  * unconfigured store lands on `unknown`, which is the caller's cue that the check
- * could not run — not that it failed.
+ * could not run — not that it failed. A timeout is one of those failures, not a
+ * separate outcome: an aborted head is indistinguishable from an unreachable one
+ * as far as what we know about the object.
+ *
+ * `timeoutMs` exists so the abort path is testable in milliseconds rather than
+ * seconds. Production callers pass nothing.
  */
-export async function headStoredImage(key: string): Promise<StoredImageHead> {
+export async function headStoredImage(
+  key: string,
+  { timeoutMs = STORED_IMAGE_HEAD_TIMEOUT_MS }: { timeoutMs?: number } = {}
+): Promise<StoredImageHead> {
   try {
     const { s3, bucket } = await getImageUploadBackend();
-    const head = await s3.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
+    const head = await s3.send(new HeadObjectCommand({ Bucket: bucket, Key: key }), {
+      abortSignal: AbortSignal.timeout(timeoutMs),
+    });
     return { status: 'present', etag: typeof head?.ETag === 'string' ? head.ETag : null };
   } catch (err) {
     return isNotFoundError(err) ? { status: 'absent' } : { status: 'unknown' };


### PR DESCRIPTION
Closes the gap described in #3771, for the listing-media path.

## The problem

A listing asset's `width` / `height` / `mimeType` / byte size are derived server-side from the bytes read back out of the store, so that the attach rules expressed over those columns are not self-reported. That derivation is **point-in-time**, and the measurement module says so in its own header:

> 🔴 A POINT-IN-TIME reading, not a durable property of the key. […] Callers may record "these values were measured from real bytes", never "these values describe the object".

Nothing acted on that caveat. The attach gate validates the persisted columns and never re-checks the object, so a row can end up describing bytes that are no longer the ones stored at that key — and the gate then validates a description rather than the media it is about.

## The change

Persist records the store's entity tag alongside the measurement; the listing attach gate re-reads it and refuses the attach when the two disagree.

**Fails closed on disagreement only.** A row with no recorded tag (written before this existed, or by a path that never measures an uploaded object), an object the store reports as gone, or a store that cannot be consulted are all classified `unverifiable` and pass through. None of them is evidence that anything changed, and rejecting on them would turn a transient store problem into a blocked attach for images that are perfectly fine — the same three-state posture already documented on the existing head-object helper. The extra request is issued **only** for rows that actually carry a tag, so anything that cannot be checked pays nothing.

The comparison rule is a pure module, so it is unit-testable on its own and lives in one place rather than being re-derived at each of the three attach procs.

**No schema change** — the tag rides in the existing `metadata` column beside the byte size.

## Why this scope

The broader alternative — re-keying each object server-side after persist and relying only on the copy — was scoped first and rejected. The presigned-upload endpoint and its presign helpers back the general site-wide media path (the shared upload hooks across dozens of components, plus vault and training assets), and the stored key is what CDN URLs, existing rows and the scan pipeline all resolve against. Changing it site-wide to fix a listing-media guarantee is the wrong trade. This PR closes the path where the measurement guarantee is load-bearing and leaves the general upload path untouched.

Worth noting separately, and **not** addressed here: the same staleness window exists for as long as an upload grant remains valid, which is a knob on the shared upload path rather than something this gate can shorten.

## Tests

`red at 1264c8e1e4 (origin/main) → green at HEAD`, measured by running the new suite against a clean checkout of the base commit:

| | base | HEAD |
|---|---|---|
| new integrity suites | **3 failed** / 8 passed | 31 passed |
| whole `blocks` service suite | 2291 passed / 2293 | 2323 passed / 2325 |

The 2 failures in both columns are pre-existing and unrelated (`manifest-schema-endpoint`). The base failure for the core case reads `promise resolved "{ status: 'attached', … }" instead of rejecting` — the gap itself, reproduced.

The main suite is a **seam test**, deliberately not two isolated ones: persist *writes* the token and attach *reads* it back, and each half is trivially "correct" alone while the pair does nothing at all if they disagree about the metadata key or the comparison. So every case runs the real persist proc, takes the metadata blob it actually produced, puts that on the row the real attach proc loads, and only then varies the store. Entity tags in the fixtures are derived from the fixture bytes, as a real store derives them, so two fixtures cannot accidentally share one.

Also included: full cross-product coverage of the pure rule (recorded tag present/absent × store present/absent/unreachable × live tag present/absent), a positive control that the accept path actually issues the check rather than skipping it, and a case proving the refusal fires even when the replacement decodes to identical geometry.

The existing fixture was additionally made faithful to the real store response, which omitted the tag entirely — so every assertion about persisted metadata there had been holding via the absent-tag branch, and the recorded-tag path looked covered while never running.

## Mutation results

10 mutants, all killed; baseline restored green afterwards.

| Mutant | Killed by |
|---|---|
| remove the guard's call site | reachability control (`expected [] to have length 1`) + the regression case |
| invert the verdict (throw on agreement) | 7 tests, both directions |
| keep the call, make the body unreachable | reachability control — the accept path stops issuing the check |
| **keep the guard, drop its specific error** | regression case fails on the message, so it is bound to *this* guard's error and not an adjacent one |
| also reject when the check could not run | the three fail-open cases |
| classifier can never disagree | pure case + both refusal cases |
| compare the live tag against itself | pure case + both refusal cases |
| read the neighbouring metadata field | 6 tests across both suites |
| drop the quote-normalisation step | 9 tests — the positive control on that text-stripping step |
| let two absent tags compare equal | the "never MATCH when either side has no tag" case |

## Checks

- No existing validation weakened or removed; two cases pin that the ownership and geometry rejections still fire for their own reasons, with their own messages.
- `pnpm typecheck`: applying this diff to a clean base checkout produces a **byte-identical error set** to that checkout without it (34, all pre-existing: an unbuilt workspace package and stub modules). Zero added.
- `pnpm prettier:check` green — validated against a known-bad input first, since its pass message is also what a zero-file run prints.
- `pnpm test:lint-rules` 215 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Known limits of this gate — please read before merging

It re-checks **at attach**, which is where the persisted measurement is first relied upon. Two things it therefore does **not** cover, stated plainly rather than implied:

1. **A change that happens after the last attach.** Nothing re-verifies at the go-live gate, which reads scan state only. An asset attached while intact and altered afterwards would not be caught by this PR.
2. **Scan freshness.** The content scan is performed against the bytes as they were at ingestion time, so the same staleness argument applies to the scan verdict independently of geometry.

3. **Coverage is bounded by provenance, and the gate does not establish provenance.** The re-check compares against a token recorded at measurement time. The attach gate selects the row by id and confirms ownership; it does not determine which path created the row or where its recorded values came from. So a row can reach the gate with no recorded token and classify as `unverifiable` (allowed through, exactly as an older row is), **or** carrying a token the measuring paths did not produce, in which case the comparison can return an affirmative `match` — and `match` is the silent outcome. The gate therefore raises the floor for rows the measuring procs minted; it is not a guarantee about every row that can be attached, and it should not be read as one. Making the token a precondition rather than evidence is a separate decision, and would need a story for rows that predate it.

Items 1 and 2 are the same underlying class as #3771 and both close naturally if the recorded token is also re-checked at the go-live gate. I did not extend it there in this PR because that gate is on the publish path and deserves its own scoping decision about what an `unverifiable` verdict should do when a listing is about to become visible — the fail-open posture that is clearly right at attach is not obviously right there.

