### PR TITLE
feat(app-blocks): App Listing Collaborators — editor seats, ownership transfer, display-author

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260810140000_app_listing_collaborators/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260810140000_app_listing_collaborators/migration.sql
@@ -1,0 +1,145 @@
+-- ============================================================
+-- App Listing COLLABORATORS — editor seats, ownership audit trail, transfers
+-- ============================================================
+-- Adds three ADDITIVE tables:
+--   1. app_collaborators        — the consent-gated editor seat (+ byline opt-in)
+--   2. app_ownership_events     — append-only audit trail of every seat/ownership action
+--   3. app_ownership_transfers  — an in-flight owner→recipient ownership transfer
+--
+-- Nothing existing is altered: no column is added to app_blocks, app_listings,
+-- oauth_clients or block_buzz_attributions, and no existing row is touched.
+--
+-- ⚠️ MANUAL APPLY — per datapacket-talos CLAUDE.md DB rule #8 the main civitai
+-- CNPG nvme0 DB does NOT auto-apply migrations (there is no `prisma migrate
+-- deploy` in any deploy path). This file is committed for HISTORY ONLY; a HUMAN
+-- applies the SQL below per environment (psql / retool). CI and deploy do NOT
+-- run it. Apply to BOTH:
+--   1. prod nvme0   (the live civitai DB)
+--   2. the dev clone (cnpg-cluster-dev, ns cnpg-database-dev, db civitai)
+--
+-- 🔴 THE FEATURE IS INERT UNTIL THIS IS APPLIED, BY CONSTRUCTION. Every read of
+-- these tables is wrapped in `safeCollaboratorQuery` (app-access.service.ts),
+-- which catches the Postgres "relation does not exist" error (Prisma P2021 /
+-- PG 42P01) and degrades to "no collaborators" — i.e. exactly today's
+-- owner-only behaviour. The WRITE paths (invite / transfer) surface a friendly
+-- error instead. So deploying the code before applying this migration changes
+-- nothing observable; it does not 500 the app-listing pages.
+--
+-- Idempotent: IF NOT EXISTS guards throughout, so a manual re-run is a no-op.
+-- All three tables are brand-new and EMPTY — no meaningful lock, no backfill.
+
+-- ------------------------------------------------------------
+-- 1. app_collaborators
+-- ------------------------------------------------------------
+-- Keyed to app_blocks (NOT app_listings): ownership is canonically
+-- oauth_clients.user_id reached via app_blocks.app_id, and app_listings.user_id
+-- is a denormalized copy that a shadow-revision approve can rewrite.
+--
+-- CASCADE on both FKs (unlike the audit table below): a seat is a live
+-- capability, not a historical record. If the app is deleted there is nothing
+-- to edit; if the user is deleted the seat must not survive as a dangling grant.
+CREATE TABLE IF NOT EXISTS "app_collaborators" (
+  "app_block_id"     TEXT    NOT NULL REFERENCES "app_blocks"("id") ON DELETE CASCADE,
+  "user_id"          INTEGER NOT NULL REFERENCES "User"("id")       ON DELETE CASCADE,
+  -- Capability role. 'editor' is the only value written today; TEXT (not an enum)
+  -- so adding a role needs no migration.
+  "role"             TEXT    NOT NULL DEFAULT 'editor',
+  -- 🔴 CONSENT: only 'accepted' confers ANY capability and only 'accepted' is ever
+  -- publicly visible. 'pending'/'rejected' are inert.
+  "status"           TEXT    NOT NULL DEFAULT 'pending',
+  -- Public-byline opt-in (immediate-apply, no mod review). Safe to apply
+  -- immediately BECAUSE it lives here: applyApprovedRevision's offsite branch
+  -- copies app_listings scalars from the shadow onto the parent, so the same flag
+  -- stored as an app_listings column would be clobbered by a later approve.
+  "displayed"        BOOLEAN NOT NULL DEFAULT true,
+  "invited_by"       INTEGER NOT NULL REFERENCES "User"("id")       ON DELETE CASCADE,
+  -- Re-invite notification throttle key. NULL = never notified.
+  "last_notified_at" TIMESTAMPTZ,
+  "created_at"       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  "responded_at"     TIMESTAMPTZ,
+
+  PRIMARY KEY ("app_block_id", "user_id"),
+
+  CONSTRAINT "app_collaborators_status_check"
+    CHECK ("status" IN ('pending', 'accepted', 'rejected')),
+  CONSTRAINT "app_collaborators_role_check"
+    CHECK ("role" IN ('editor'))
+);
+
+-- "which apps may this user edit" — the hot path (resolveAccessibleAppBlockIds,
+-- run on every gated proc for a non-owner).
+CREATE INDEX IF NOT EXISTS "app_collaborators_user_status_idx"
+  ON "app_collaborators" ("user_id", "status");
+-- "who is on this app" — the owner roster + the public byline read.
+CREATE INDEX IF NOT EXISTS "app_collaborators_app_status_idx"
+  ON "app_collaborators" ("app_block_id", "status");
+-- FK index so a User delete (hot path) does not seq-scan on the inviter side.
+CREATE INDEX IF NOT EXISTS "app_collaborators_invited_by_idx"
+  ON "app_collaborators" ("invited_by");
+
+-- ------------------------------------------------------------
+-- 2. app_ownership_events  (append-only audit trail)
+-- ------------------------------------------------------------
+-- Mirrors app_listing_moderation_events' survivability posture: EVERY FK is
+-- NULLABLE + SET NULL so an event outlives the app, the actor and the target. The
+-- denormalized "slug" keeps the row self-describing once the app is gone.
+CREATE TABLE IF NOT EXISTS "app_ownership_events" (
+  "id"             TEXT PRIMARY KEY,                                        -- aoe_<ULID>
+  "app_block_id"   TEXT    REFERENCES "app_blocks"("id") ON DELETE SET NULL,
+  "slug"           TEXT    NOT NULL,
+  "action"         TEXT    NOT NULL,
+  "actor_user_id"  INTEGER REFERENCES "User"("id")       ON DELETE SET NULL,
+  "target_user_id" INTEGER REFERENCES "User"("id")       ON DELETE SET NULL,
+  "metadata"       JSONB,
+  "created_at"     TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CONSTRAINT "app_ownership_events_action_check"
+    CHECK ("action" IN (
+      'invite', 'accept', 'reject', 'remove', 'leave', 'display',
+      'transfer_initiated', 'transfer_accepted', 'transfer_cancelled'
+    ))
+);
+
+CREATE INDEX IF NOT EXISTS "app_ownership_events_app_idx"
+  ON "app_ownership_events" ("app_block_id", "created_at" DESC);
+CREATE INDEX IF NOT EXISTS "app_ownership_events_actor_idx"
+  ON "app_ownership_events" ("actor_user_id", "created_at" DESC);
+
+-- ------------------------------------------------------------
+-- 3. app_ownership_transfers
+-- ------------------------------------------------------------
+-- One in-flight transfer per app, enforced by the PARTIAL UNIQUE index below.
+CREATE TABLE IF NOT EXISTS "app_ownership_transfers" (
+  "id"           TEXT PRIMARY KEY,                                    -- aot_<ULID>
+  "app_block_id" TEXT    NOT NULL REFERENCES "app_blocks"("id") ON DELETE CASCADE,
+  -- Snapshot of the owner at initiate time. Re-asserted in-tx at accept, so a
+  -- transfer initiated by someone who has since lost the app cannot complete.
+  "from_user_id" INTEGER NOT NULL REFERENCES "User"("id")       ON DELETE CASCADE,
+  "to_user_id"   INTEGER NOT NULL REFERENCES "User"("id")       ON DELETE CASCADE,
+  "status"       TEXT    NOT NULL DEFAULT 'pending',
+  -- Hard expiry, enforced as a read-time predicate in the ACCEPT path — no
+  -- sweeper job is required for CORRECTNESS (a sweeper would only tidy rows).
+  "expires_at"   TIMESTAMPTZ NOT NULL,
+  "created_at"   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  "responded_at" TIMESTAMPTZ,
+
+  CONSTRAINT "app_ownership_transfers_status_check"
+    CHECK ("status" IN ('pending', 'accepted', 'rejected', 'cancelled', 'expired')),
+  -- A self-transfer is meaningless and would make the accept path a no-op that
+  -- still emits an audit event.
+  CONSTRAINT "app_ownership_transfers_not_self_check"
+    CHECK ("from_user_id" <> "to_user_id")
+);
+
+-- 🔴 THE one-in-flight-transfer GUARD. Prisma cannot express a partial unique
+-- index, so this lives ONLY here — the service relies on its P2002 to close the
+-- read-then-write race between two concurrent initiateTransfer calls.
+CREATE UNIQUE INDEX IF NOT EXISTS "app_ownership_transfers_one_pending_per_app"
+  ON "app_ownership_transfers" ("app_block_id")
+  WHERE "status" = 'pending';
+
+CREATE INDEX IF NOT EXISTS "app_ownership_transfers_app_status_idx"
+  ON "app_ownership_transfers" ("app_block_id", "status");
+-- "transfers awaiting MY acceptance" — the recipient's inbox read.
+CREATE INDEX IF NOT EXISTS "app_ownership_transfers_to_status_idx"
+  ON "app_ownership_transfers" ("to_user_id", "status");

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -603,6 +603,14 @@ model User {
   appListingReportsReported          AppListingReport[]         @relation("AppListingReportReporter")
   appListingReportsResolved          AppListingReport[]         @relation("AppListingReportResolver")
   appListingModerationEvents         AppListingModerationEvent[] @relation("AppListingModEventActor")
+  // App Listing Collaborators — editor seats held / issued, the ownership audit
+  // trail this user acted in or was targeted by, and any transfer they are party to.
+  appCollaboratorSeats               AppCollaborator[]          @relation("AppCollaboratorMember")
+  appCollaboratorInvitesSent         AppCollaborator[]          @relation("AppCollaboratorInviter")
+  appOwnershipEventsActed            AppOwnershipEvent[]        @relation("AppOwnershipEventActor")
+  appOwnershipEventsTargeted         AppOwnershipEvent[]        @relation("AppOwnershipEventTarget")
+  appOwnershipTransfersFrom          AppOwnershipTransfer[]     @relation("AppOwnershipTransferFrom")
+  appOwnershipTransfersTo            AppOwnershipTransfer[]     @relation("AppOwnershipTransferTo")
   targetedAnnouncements              AnnouncementUser[]
   placementSuspension                PlacementSuspension?       @relation("PlacementSuspensionUser")
   placementsReceived                 Placement[]                @relation("PlacementOwner")
@@ -2503,6 +2511,13 @@ model AppBlock {
   userScopeGrants    AppUserScopeGrant[]
   reviews            AppBlockReview[]
   appListing         AppListing?
+  // App Listing Collaborators — the editor seats + the append-only ownership
+  // audit trail + any in-flight ownership transfer. Keyed to the AppBlock (NOT
+  // the AppListing) because ownership is canonically the backing OauthClient's
+  // and the listing only carries a denormalized copy.
+  collaborators      AppCollaborator[]
+  ownershipEvents    AppOwnershipEvent[]
+  ownershipTransfers AppOwnershipTransfer[]
 
   @@unique([appId, blockId], map: "app_blocks_app_block_uniq")
   // W1 audit C-3 fix: enforce one app per slug at the DB layer. The
@@ -2548,6 +2563,138 @@ model AppBlockReview {
   // Aggregate read path (AVG/COUNT WHERE NOT exclude).
   @@index([appBlockId, exclude], map: "app_block_reviews_app_agg_idx")
   @@map("app_block_reviews")
+}
+
+/// App Listing COLLABORATORS — a consent-gated editor seat on an app.
+///
+/// 🔴 KEYED TO `AppBlock`, NOT `AppListing`. Ownership is canonically
+/// `OauthClient.userId` reached as `AppBlock.app.userId`; `AppListing.userId` is a
+/// DENORMALIZED COPY (written by `app-listing-mapper`). Keying the seat to the
+/// listing would make it a property of the copy, and a listing can be cloned into a
+/// shadow revision (`revisionOfId`) whose scalars are copied back onto the parent on
+/// approve — so a seat stored listing-side would be duplicated per shadow and could
+/// be silently reverted by `applyApprovedRevision`.
+///
+/// 🔴 `displayed` (the public-byline opt-in) LIVES HERE FOR THE SAME REASON, and
+/// this is load-bearing rather than incidental: `applyApprovedRevision`'s OFFSITE
+/// branch copies the shadow's `name/tagline/description/category/contentRating/
+/// externalUrl/connect*` straight onto the live parent. An `AppListing` column
+/// holding a display-author flag would therefore be CLOBBERED by any later shadow
+/// approve — an immediate-apply product decision would silently revert on the next
+/// mod re-review. Collaborator rows are outside BOTH branches' copy sets, so
+/// immediate-apply is correct BY CONSTRUCTION, not by a promise to remember.
+///
+/// CONSENT MODEL (mirrors `EntityCollaborator`'s status-visibility rules, NOT its
+/// code — that model is hard-scoped to Posts): an invite starts `pending` and confers
+/// ZERO capability and ZERO public visibility. Only `accepted` grants anything.
+///
+/// `role` is TEXT (not an enum) so a future role needs no migration; `'editor'` is the
+/// only value the code writes today. `status` is TEXT for the same reason, bounded by
+/// a CHECK constraint in the migration.
+///
+/// MANUAL-APPLY (datapacket-talos rule #8): the main civitai DB (CNPG nvme0) does NOT
+/// run `prisma migrate deploy`. The committed SQL is hand-applied per environment. All
+/// reads are NULL-safe / empty-safe, so the feature is INERT until it lands.
+model AppCollaborator {
+  appBlockId  String    @map("app_block_id")
+  appBlock    AppBlock  @relation(fields: [appBlockId], references: [id], onDelete: Cascade)
+  userId      Int       @map("user_id")
+  user        User      @relation("AppCollaboratorMember", fields: [userId], references: [id], onDelete: Cascade)
+  /// Capability role. 'editor' today (content + media + submit + app-scoped
+  /// analytics/earnings). Owner-only actions (managing collaborators, initiating a
+  /// transfer) are NOT a role — they are reserved to the OauthClient owner.
+  role        String    @default("editor")
+  /// 'pending' | 'accepted' | 'rejected'. Only 'accepted' confers capability, and
+  /// only 'accepted' is ever visible publicly.
+  status      String    @default("pending")
+  /// Public-byline opt-in. Immediate-apply (no mod review) — safe because this row is
+  /// outside the revision copy sets (see the header). A collaborator is listed on the
+  /// public listing only when status='accepted' AND displayed=true.
+  displayed   Boolean   @default(true)
+  /// The OWNER who issued the invite (audit + the "invited by" chip).
+  invitedBy   Int       @map("invited_by")
+  inviter     User      @relation("AppCollaboratorInviter", fields: [invitedBy], references: [id], onDelete: Cascade)
+  /// Last time an invite NOTIFICATION was emitted for this row — the re-invite
+  /// throttle key. NB: the `EntityCollaborator` sibling has an inverted throttle
+  /// (`>=` where it means `<=`); this one is written correctly (see the service).
+  lastNotifiedAt DateTime? @map("last_notified_at") @db.Timestamptz(6)
+  createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  respondedAt DateTime? @map("responded_at") @db.Timestamptz(6)
+
+  @@id([appBlockId, userId])
+  /// "which apps can this user edit" — the hot path (`resolveAccessibleAppBlockIds`).
+  @@index([userId, status], map: "app_collaborators_user_status_idx")
+  /// "who is on this app" — the roster + the public byline read.
+  @@index([appBlockId, status], map: "app_collaborators_app_status_idx")
+  @@map("app_collaborators")
+}
+
+/// APPEND-ONLY audit trail of every collaborator/ownership action on an app.
+///
+/// Deliberately a separate table from `AppListingModerationEvent` (which is
+/// listing-scoped and mod-action-scoped): these are AUTHOR actions on the AppBlock.
+/// Mirrors that table's survivability posture — every FK is NULLABLE + SET NULL so an
+/// event outlives the app, the actor and the target.
+model AppOwnershipEvent {
+  id           String    @id // aoe_<ULID>
+  appBlockId   String?   @map("app_block_id")
+  appBlock     AppBlock? @relation(fields: [appBlockId], references: [id], onDelete: SetNull)
+  /// Denormalized so the event stays self-describing after the app is gone.
+  slug         String
+  /// invite | accept | reject | remove | leave | display | transfer_initiated |
+  /// transfer_accepted | transfer_cancelled. Bounded by a CHECK in the migration.
+  action       String
+  /// Who performed the action.
+  actorUserId  Int?      @map("actor_user_id")
+  actor        User?     @relation("AppOwnershipEventActor", fields: [actorUserId], references: [id], onDelete: SetNull)
+  /// Who it was performed ON (the invitee / removed editor / transfer recipient).
+  targetUserId Int?      @map("target_user_id")
+  target       User?     @relation("AppOwnershipEventTarget", fields: [targetUserId], references: [id], onDelete: SetNull)
+  /// Structured extras (role, before/after owner, expiry, …).
+  metadata     Json?
+  createdAt    DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+
+  @@index([appBlockId, createdAt(sort: Desc)], map: "app_ownership_events_app_idx")
+  @@index([actorUserId, createdAt(sort: Desc)], map: "app_ownership_events_actor_idx")
+  @@map("app_ownership_events")
+}
+
+/// An IN-FLIGHT ownership transfer (owner initiates → recipient accepts).
+///
+/// 🔴 WHY A THIRD TABLE rather than folding this into `AppCollaborator` with a
+/// `role='owner_transfer'` row: `AppCollaborator`'s PK is `(appBlockId, userId)`, so a
+/// transfer to someone who is ALREADY an editor would collide with their seat row and
+/// the two states would have to share one `status` column. And deriving the pending
+/// state from `AppOwnershipEvent` (the append-only log) cannot carry a UNIQUE, so two
+/// concurrent `initiateTransfer` calls could both "succeed". This table carries the
+/// real constraint: a PARTIAL UNIQUE on `app_block_id WHERE status='pending'` — at
+/// most one in-flight transfer per app, enforced at the DB.
+model AppOwnershipTransfer {
+  id          String    @id // aot_<ULID>
+  appBlockId  String    @map("app_block_id")
+  appBlock    AppBlock  @relation(fields: [appBlockId], references: [id], onDelete: Cascade)
+  /// Snapshot of the owner at initiate time — re-asserted in-tx at accept, so a
+  /// transfer initiated by an owner who has since lost the app cannot complete.
+  fromUserId  Int       @map("from_user_id")
+  fromUser    User      @relation("AppOwnershipTransferFrom", fields: [fromUserId], references: [id], onDelete: Cascade)
+  toUserId    Int       @map("to_user_id")
+  toUser      User      @relation("AppOwnershipTransferTo", fields: [toUserId], references: [id], onDelete: Cascade)
+  /// 'pending' | 'accepted' | 'cancelled' | 'rejected' | 'expired'. CHECK in the migration.
+  status      String    @default("pending")
+  /// Hard expiry — an unaccepted transfer stops being acceptable after this instant.
+  /// Enforced in the ACCEPT path (a read-time predicate), so no sweeper job is
+  /// required for correctness; a sweeper would only tidy the rows.
+  expiresAt   DateTime  @map("expires_at") @db.Timestamptz(6)
+  createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  respondedAt DateTime? @map("responded_at") @db.Timestamptz(6)
+
+  /// NB: the migration ALSO creates a PARTIAL UNIQUE index
+  /// (`app_block_id WHERE status='pending'`) that Prisma cannot express. That partial
+  /// index — not this plain one — is the one-in-flight-transfer guard; the service
+  /// relies on its P2002.
+  @@index([appBlockId, status], map: "app_ownership_transfers_app_status_idx")
+  @@index([toUserId, status], map: "app_ownership_transfers_to_status_idx")
+  @@map("app_ownership_transfers")
 }
 
 /// W1 v0 publish request — every version of every app goes through the

--- a/packages/civitai-db-schema/src/kysely/types.ts
+++ b/packages/civitai-db-schema/src/kysely/types.ts
@@ -321,6 +321,39 @@ export type AppBlockReview = {
   created_at: Generated<Timestamp>;
   updated_at: Timestamp;
 };
+export type AppCollaborator = {
+  app_block_id: string;
+  user_id: number;
+  /**
+   * Capability role. 'editor' today (content + media + submit + app-scoped
+   * analytics/earnings). Owner-only actions (managing collaborators, initiating a
+   * transfer) are NOT a role — they are reserved to the OauthClient owner.
+   */
+  role: Generated<string>;
+  /**
+   * 'pending' | 'accepted' | 'rejected'. Only 'accepted' confers capability, and
+   * only 'accepted' is ever visible publicly.
+   */
+  status: Generated<string>;
+  /**
+   * Public-byline opt-in. Immediate-apply (no mod review) — safe because this row is
+   * outside the revision copy sets (see the header). A collaborator is listed on the
+   * public listing only when status='accepted' AND displayed=true.
+   */
+  displayed: Generated<boolean>;
+  /**
+   * The OWNER who issued the invite (audit + the "invited by" chip).
+   */
+  invited_by: number;
+  /**
+   * Last time an invite NOTIFICATION was emitted for this row — the re-invite
+   * throttle key. NB: the `EntityCollaborator` sibling has an inverted throttle
+   * (`>=` where it means `<=`); this one is written correctly (see the service).
+   */
+  last_notified_at: Timestamp | null;
+  created_at: Generated<Timestamp>;
+  responded_at: Timestamp | null;
+};
 export type AppDevForgejoIdentity = {
   user_id: number;
   forgejo_username: string;
@@ -440,6 +473,54 @@ export type AppListingScreenshot = {
   caption: string | null;
   created_at: Generated<Timestamp>;
   updated_at: Generated<Timestamp>;
+};
+export type AppOwnershipEvent = {
+  id: string;
+  app_block_id: string | null;
+  /**
+   * Denormalized so the event stays self-describing after the app is gone.
+   */
+  slug: string;
+  /**
+   * invite | accept | reject | remove | leave | display | transfer_initiated |
+   * transfer_accepted | transfer_cancelled. Bounded by a CHECK in the migration.
+   */
+  action: string;
+  /**
+   * Who performed the action.
+   */
+  actor_user_id: number | null;
+  /**
+   * Who it was performed ON (the invitee / removed editor / transfer recipient).
+   */
+  target_user_id: number | null;
+  /**
+   * Structured extras (role, before/after owner, expiry, …).
+   */
+  metadata: unknown | null;
+  created_at: Generated<Timestamp>;
+};
+export type AppOwnershipTransfer = {
+  id: string;
+  app_block_id: string;
+  /**
+   * Snapshot of the owner at initiate time — re-asserted in-tx at accept, so a
+   * transfer initiated by an owner who has since lost the app cannot complete.
+   */
+  from_user_id: number;
+  to_user_id: number;
+  /**
+   * 'pending' | 'accepted' | 'cancelled' | 'rejected' | 'expired'. CHECK in the migration.
+   */
+  status: Generated<string>;
+  /**
+   * Hard expiry — an unaccepted transfer stops being acceptable after this instant.
+   * Enforced in the ACCEPT path (a read-time predicate), so no sweeper job is
+   * required for correctness; a sweeper would only tidy the rows.
+   */
+  expires_at: Timestamp;
+  created_at: Generated<Timestamp>;
+  responded_at: Timestamp | null;
 };
 export type AppReviewAgentReport = {
   id: string;
@@ -4051,6 +4132,7 @@ export type DB = {
   app_block_publish_requests: AppBlockPublishRequest;
   app_block_reviews: AppBlockReview;
   app_blocks: AppBlock;
+  app_collaborators: AppCollaborator;
   app_dev_forgejo_identity: AppDevForgejoIdentity;
   app_listing_metrics: AppListingMetric;
   app_listing_moderation_events: AppListingModerationEvent;
@@ -4059,6 +4141,8 @@ export type DB = {
   app_listing_reviews: AppListingReview;
   app_listing_screenshots: AppListingScreenshot;
   app_listings: AppListing;
+  app_ownership_events: AppOwnershipEvent;
+  app_ownership_transfers: AppOwnershipTransfer;
   app_review_agent_reports: AppReviewAgentReport;
   app_user_scope_grants: AppUserScopeGrant;
   Appeal: Appeal;

--- a/packages/civitai-db-schema/src/models.ts
+++ b/packages/civitai-db-schema/src/models.ts
@@ -656,6 +656,12 @@ export interface User {
   appListingReportsReported?: AppListingReport[];
   appListingReportsResolved?: AppListingReport[];
   appListingModerationEvents?: AppListingModerationEvent[];
+  appCollaboratorSeats?: AppCollaborator[];
+  appCollaboratorInvitesSent?: AppCollaborator[];
+  appOwnershipEventsActed?: AppOwnershipEvent[];
+  appOwnershipEventsTargeted?: AppOwnershipEvent[];
+  appOwnershipTransfersFrom?: AppOwnershipTransfer[];
+  appOwnershipTransfersTo?: AppOwnershipTransfer[];
   targetedAnnouncements?: AnnouncementUser[];
   placementSuspension?: PlacementSuspension | null;
   placementsReceived?: Placement[];
@@ -1879,6 +1885,9 @@ export interface AppBlock {
   userScopeGrants?: AppUserScopeGrant[];
   reviews?: AppBlockReview[];
   appListing?: AppListing | null;
+  collaborators?: AppCollaborator[];
+  ownershipEvents?: AppOwnershipEvent[];
+  ownershipTransfers?: AppOwnershipTransfer[];
 }
 
 export interface AppBlockReview {
@@ -1894,6 +1903,49 @@ export interface AppBlockReview {
   tosViolation: boolean;
   createdAt: Date;
   updatedAt: Date;
+}
+
+export interface AppCollaborator {
+  appBlockId: string;
+  appBlock?: AppBlock;
+  userId: number;
+  user?: User;
+  role: string;
+  status: string;
+  displayed: boolean;
+  invitedBy: number;
+  inviter?: User;
+  lastNotifiedAt: Date | null;
+  createdAt: Date;
+  respondedAt: Date | null;
+}
+
+export interface AppOwnershipEvent {
+  id: string;
+  appBlockId: string | null;
+  appBlock?: AppBlock | null;
+  slug: string;
+  action: string;
+  actorUserId: number | null;
+  actor?: User | null;
+  targetUserId: number | null;
+  target?: User | null;
+  metadata: JsonValue | null;
+  createdAt: Date;
+}
+
+export interface AppOwnershipTransfer {
+  id: string;
+  appBlockId: string;
+  appBlock?: AppBlock;
+  fromUserId: number;
+  fromUser?: User;
+  toUserId: number;
+  toUser?: User;
+  status: string;
+  expiresAt: Date;
+  createdAt: Date;
+  respondedAt: Date | null;
 }
 
 export interface AppBlockPublishRequest {

--- a/src/components/Apps/AppListingDetailBody.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.browser.test.tsx
@@ -96,6 +96,7 @@ function base(over: Partial<ListingDetail>): ListingDetail {
     serialId: 1,
     slug: 'my-app',
     kind: 'onsite',
+    collaborators: [],
     name: 'My App',
     tagline: 'A handy app',
     description: null,

--- a/src/components/Apps/reviewListingPreview.ts
+++ b/src/components/Apps/reviewListingPreview.ts
@@ -125,6 +125,11 @@ export function buildListingDetailPreview(
     serialId: 0,
     tagline: null,
     description: null,
+    // The mod REVIEW preview intentionally shows no collaborator byline: this row is
+    // built from an in-review publish request, not from a live listing, so there is no
+    // accepted-and-displayed set to read yet. An empty array is the honest answer, not
+    // a placeholder.
+    collaborators: [],
     screenshots: images?.screenshots ?? [],
     kindData: detailKindData(row),
   };

--- a/src/server/common/constants.ts
+++ b/src/server/common/constants.ts
@@ -444,6 +444,32 @@ export const constants = {
     maxCollaborators: 15,
   },
 
+  /**
+   * App Listing COLLABORATORS (editor seats on an App Block).
+   *
+   * Mirrors `entityCollaborators` deliberately, so the two collaborator surfaces
+   * stay comparable. The cap counts PENDING + ACCEPTED seats (a rejected seat is
+   * inert and does not occupy one) — see `app-collaborator.service.ts`.
+   */
+  appCollaborators: {
+    /** Max pending+accepted editor seats per app. */
+    maxCollaborators: 15,
+    /**
+     * Minimum gap between re-invite NOTIFICATIONS to the same (app, user).
+     *
+     * 🔴 The `EntityCollaborator` sibling's equivalent throttle is INVERTED —
+     * `entity-collaborator.service.ts` compares `lastMessageSentAt >= (now - 1d)`
+     * where the semantically identical `sendMessagesToCollaborators` correctly uses
+     * `lte`. As written it re-notifies precisely when it should stay silent. This
+     * one is written the correct way round (`lastNotifiedAt <= now - window`), and
+     * `app-collaborator.service.test.ts` pins BOTH sides of the boundary so the bug
+     * cannot be re-imported by copy-paste.
+     */
+    inviteNotifyThrottleHours: 24,
+    /** An unaccepted ownership transfer stops being acceptable after this. */
+    transferExpiryDays: 7,
+  },
+
   autoLabel: {
     labelTypes: ['tag', 'caption'] as const,
   },

--- a/src/server/notifications/app-collaborator.notifications.ts
+++ b/src/server/notifications/app-collaborator.notifications.ts
@@ -1,0 +1,105 @@
+import { NotificationCategory } from '~/server/common/enums';
+import { createNotificationProcessor } from '~/server/notifications/base.notifications';
+
+/**
+ * App Listing COLLABORATORS — seat + ownership-transfer notifications.
+ *
+ * IMPERATIVE types (emitted directly from the services POST-COMMIT via
+ * `createNotification`, behind the `notifyAppCollaborator` helper) — NOT scanned by a
+ * scheduled `prepareQuery`, so they carry only a `prepareMessage`. Same shape as the
+ * sibling `app-block.notifications` / `app-listing.notifications` families.
+ *
+ * 🔴 REUSING THIS PATH IS A DELIBERATE DIVERGENCE FROM THE PRIOR ART.
+ * `EntityCollaborator` delivers its invite as a SYSTEM CHAT MESSAGE (`upsertChat` +
+ * `createMessage` with `userId: -1`). That drags the whole chat subsystem into an
+ * App Blocks flow, has no idempotency key, and is not toggleable or dismissible like a
+ * notification. The App Blocks surface already has a notification path; using it keeps
+ * the seat lifecycle on the same rails as approve/reject.
+ *
+ * The `type` strings are free-form (the notifications app stores them as text, no DB
+ * enum), so adding these needs NO notifications-DB migration. Registered in
+ * `utils.notifications.ts`.
+ */
+
+export type AppCollaboratorNotificationDetails = {
+  /** The app's public slug — identity + link target. */
+  slug: string;
+  /** The backing AppBlock id (stable deep-link key). */
+  appBlockId?: string | null;
+  /** Best-effort display name for nicer copy; absent ⇒ terser message. */
+  name?: string | null;
+};
+
+/** Where each notification points. Both audiences land on the app's own page. */
+function appUrl(details: AppCollaboratorNotificationDetails): string {
+  return details.appBlockId ? `/apps/${details.appBlockId}` : '/apps';
+}
+
+/** `the app "Name"` when a name is present, else `the app <slug>`. */
+function appLabel(details: AppCollaboratorNotificationDetails): string {
+  const name = details.name?.trim();
+  return name ? `the app "${name}"` : `the app ${details.slug}`;
+}
+
+export const appCollaboratorNotifications = createNotificationProcessor({
+  'app-collaborator-invited': {
+    displayName: 'App collaborator invitation',
+    category: NotificationCategory.System,
+    toggleable: false,
+    prepareMessage: (notification) => {
+      const details = notification.details as AppCollaboratorNotificationDetails;
+      return {
+        message: `You were invited to collaborate on ${appLabel(details)}.`,
+        url: appUrl(details),
+      };
+    },
+  },
+  'app-collaborator-accepted': {
+    displayName: 'App collaborator accepted',
+    category: NotificationCategory.System,
+    toggleable: false,
+    prepareMessage: (notification) => {
+      const details = notification.details as AppCollaboratorNotificationDetails;
+      return {
+        message: `Your collaborator invitation for ${appLabel(details)} was accepted.`,
+        url: appUrl(details),
+      };
+    },
+  },
+  'app-collaborator-removed': {
+    displayName: 'App collaborator removed',
+    category: NotificationCategory.System,
+    toggleable: false,
+    prepareMessage: (notification) => {
+      const details = notification.details as AppCollaboratorNotificationDetails;
+      return {
+        message: `You are no longer a collaborator on ${appLabel(details)}.`,
+        url: '/apps',
+      };
+    },
+  },
+  'app-ownership-transfer-offered': {
+    displayName: 'App ownership transfer offered',
+    category: NotificationCategory.System,
+    toggleable: false,
+    prepareMessage: (notification) => {
+      const details = notification.details as AppCollaboratorNotificationDetails;
+      return {
+        message: `You were offered ownership of ${appLabel(details)}. Accept it to take over.`,
+        url: appUrl(details),
+      };
+    },
+  },
+  'app-ownership-transfer-accepted': {
+    displayName: 'App ownership transfer accepted',
+    category: NotificationCategory.System,
+    toggleable: false,
+    prepareMessage: (notification) => {
+      const details = notification.details as AppCollaboratorNotificationDetails;
+      return {
+        message: `Ownership of ${appLabel(details)} was transferred.`,
+        url: appUrl(details),
+      };
+    },
+  },
+});

--- a/src/server/notifications/utils.notifications.ts
+++ b/src/server/notifications/utils.notifications.ts
@@ -3,6 +3,7 @@ import { comicNotifications } from '~/server/notifications/comics.notifications'
 import { articleRatingReviewNotifications } from '~/server/notifications/article-rating-review.notifications';
 import { articleUnpublishNotifications } from '~/server/notifications/article-unpublish.notifications';
 import { appBlockNotifications } from '~/server/notifications/app-block.notifications';
+import { appCollaboratorNotifications } from '~/server/notifications/app-collaborator.notifications';
 import { appListingNotifications } from '~/server/notifications/app-listing.notifications';
 import { auctionNotifications } from '~/server/notifications/auction.notifications';
 import type { BareNotification } from '~/server/notifications/base.notifications';
@@ -46,6 +47,7 @@ export const notificationProcessors = {
   ...articleUnpublishNotifications,
   ...appListingNotifications,
   ...appBlockNotifications,
+  ...appCollaboratorNotifications,
   ...articleRatingReviewNotifications,
   ...reportNotifications,
   ...featuredNotifications,

--- a/src/server/routers/__tests__/blocks.router.getMyAppRepo.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getMyAppRepo.test.ts
@@ -74,7 +74,14 @@ vi.mock('~/server/services/orchestrator/promptAuditing', () => ({
 }));
 vi.mock('~/server/services/user.service', () => ({ getUserById: vi.fn() }));
 vi.mock('~/server/db/client', () => ({
-  dbRead: { appBlock: { findUnique: vi.fn() } },
+  dbRead: {
+    appBlock: { findUnique: vi.fn() },
+    // App Listing COLLABORATORS: the widened gates consult the seat table on the
+    // NON-owner path. `safeCollaboratorQuery` deliberately swallows ONLY the
+    // missing-TABLE error, so an absent mock surfaces as a TypeError rather than
+    // being silently absorbed — which is why this fixture must declare it.
+    appCollaborator: { findFirst: vi.fn(async () => null), findMany: vi.fn(async () => []) },
+  },
   dbWrite: {},
 }));
 vi.mock('~/server/redis/client', async () => {

--- a/src/server/routers/__tests__/blocks.router.getMyForgejoCloneInfo.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getMyForgejoCloneInfo.test.ts
@@ -65,7 +65,14 @@ vi.mock('~/server/services/orchestrator/workflows', () => ({
 vi.mock('~/server/services/orchestrator/promptAuditing', () => ({ auditPromptServer: vi.fn() }));
 vi.mock('~/server/services/user.service', () => ({ getUserById: vi.fn() }));
 vi.mock('~/server/db/client', () => ({
-  dbRead: { appBlock: { findUnique: vi.fn(), findFirst: vi.fn() } },
+  dbRead: {
+    appBlock: { findUnique: vi.fn(), findFirst: vi.fn() },
+    // App Listing COLLABORATORS: the widened gates consult the seat table on the
+    // NON-owner path. `safeCollaboratorQuery` deliberately swallows ONLY the
+    // missing-TABLE error, so an absent mock surfaces as a TypeError rather than
+    // being silently absorbed — which is why this fixture must declare it.
+    appCollaborator: { findFirst: vi.fn(async () => null), findMany: vi.fn(async () => []) },
+  },
   dbWrite: {},
 }));
 vi.mock('~/server/redis/client', async () => {

--- a/src/server/routers/__tests__/blocks.router.updateManifest.test.ts
+++ b/src/server/routers/__tests__/blocks.router.updateManifest.test.ts
@@ -93,7 +93,14 @@ vi.mock('~/server/services/orchestrator/workflows', () => ({
 vi.mock('~/server/services/orchestrator/promptAuditing', () => ({ auditPromptServer: vi.fn() }));
 vi.mock('~/server/services/user.service', () => ({ getUserById: vi.fn() }));
 vi.mock('~/server/db/client', () => ({
-  dbRead: { appBlock: { findUnique: vi.fn() } },
+  dbRead: {
+    appBlock: { findUnique: vi.fn() },
+    // App Listing COLLABORATORS: the widened gates consult the seat table on the
+    // NON-owner path. `safeCollaboratorQuery` deliberately swallows ONLY the
+    // missing-TABLE error, so an absent mock surfaces as a TypeError rather than
+    // being silently absorbed — which is why this fixture must declare it.
+    appCollaborator: { findFirst: vi.fn(async () => null), findMany: vi.fn(async () => []) },
+  },
   dbWrite: {},
 }));
 vi.mock('~/server/redis/client', async () => {

--- a/src/server/routers/app-collaborators.router.ts
+++ b/src/server/routers/app-collaborators.router.ts
@@ -313,13 +313,22 @@ export const appCollaboratorsRouter = router({
       return run(() => cancelTransfer({ transferId: input.transferId, actorUserId: ctx.user!.id }));
     }),
 
-  /** The LIVE pending transfer for an app (expiry applied as a read-time predicate). */
+  /**
+   * The LIVE pending transfer for an app (expiry applied as a read-time predicate).
+   *
+   * 🔴 Takes `ctx`, and passes the caller down. The transfer row names both parties and
+   * the deadline; the service restricts it to the app OWNER and the ADDRESSEE — the same
+   * set the three sibling transfer procs gate on — and returns `null` (never FORBIDDEN)
+   * to anyone else, so this read cannot be used as an existence oracle.
+   */
   getPendingTransfer: appDeveloperProcedure
     .input(getPendingAppTransferSchema)
-    .query(async ({ input }) => {
+    .query(async ({ ctx, input }) => {
       const { getPendingTransfer } = await import(
         '~/server/services/blocks/app-ownership-transfer.service'
       );
-      return run(() => getPendingTransfer({ appBlockId: input.appBlockId }));
+      return run(() =>
+        getPendingTransfer({ appBlockId: input.appBlockId, viewerUserId: ctx.user!.id })
+      );
     }),
 });

--- a/src/server/routers/app-collaborators.router.ts
+++ b/src/server/routers/app-collaborators.router.ts
@@ -209,10 +209,23 @@ export const appCollaboratorsRouter = router({
   // -------------------------------------------------------------------------
 
   /**
-   * The app's roster, filtered by the status-visibility rules `EntityCollaborator`
-   * established: accepted → everyone; pending → owner/invitee/mod; rejected →
-   * owner/mod. Enforced in the SERVICE, so the filter cannot be bypassed by a
-   * different caller.
+   * The app's roster. 🔴 NOT a public read — two gates apply, in this order:
+   *
+   *   1. ACCESS. The caller must be the app OWNER, an ACCEPTED editor, or a
+   *      moderator (`listCollaborators` throws NOT_OWNER otherwise). A PENDING
+   *      invitee is refused here — they read their own standing invitation via
+   *      `listMyPendingInvites`, which is keyed to their own user id.
+   *   2. STATUS. Within an app the caller may already read, rows are filtered by
+   *      the `EntityCollaborator` status rules (pending → owner/invitee/mod;
+   *      rejected → owner/mod).
+   *
+   * Gate 1 is the load-bearing one and is NEW: the status filter alone never
+   * governed whether the caller may read the app at all, so without it any
+   * flagged account could enumerate every app's roster — including seats whose
+   * holder opted OUT of the public byline (`displayed: false`).
+   *
+   * Both are enforced in the SERVICE, so neither can be bypassed by a different
+   * caller. See `listCollaborators`.
    */
   list: protectedProcedure
     .use(enforceAppBlocksAuthorFlag)

--- a/src/server/routers/app-collaborators.router.ts
+++ b/src/server/routers/app-collaborators.router.ts
@@ -124,18 +124,20 @@ export const appCollaboratorsRouter = router({
     }),
 
   /** OWNER: remove a collaborator (any status). Revokes their repo write. */
-  remove: appDeveloperProcedure.input(removeAppCollaboratorSchema).mutation(async ({ ctx, input }) => {
-    const { removeCollaborator } = await import(
-      '~/server/services/blocks/app-collaborator.service'
-    );
-    return run(() =>
-      removeCollaborator({
-        appBlockId: input.appBlockId,
-        targetUserId: input.targetUserId,
-        actorUserId: ctx.user!.id,
-      })
-    );
-  }),
+  remove: appDeveloperProcedure
+    .input(removeAppCollaboratorSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { removeCollaborator } = await import(
+        '~/server/services/blocks/app-collaborator.service'
+      );
+      return run(() =>
+        removeCollaborator({
+          appBlockId: input.appBlockId,
+          targetUserId: input.targetUserId,
+          actorUserId: ctx.user!.id,
+        })
+      );
+    }),
 
   // -------------------------------------------------------------------------
   // INVITEE / COLLABORATOR.
@@ -152,9 +154,7 @@ export const appCollaboratorsRouter = router({
     .input(respondToAppInviteSchema)
     .mutation(async ({ ctx, input }) => {
       if (input.accept) assertNotBanned(ctx.user as SessionUser);
-      const { respondToInvite } = await import(
-        '~/server/services/blocks/app-collaborator.service'
-      );
+      const { respondToInvite } = await import('~/server/services/blocks/app-collaborator.service');
       return run(() =>
         respondToInvite({
           appBlockId: input.appBlockId,
@@ -240,19 +240,21 @@ export const appCollaboratorsRouter = router({
    * Returns an explicit `notPermitted` rather than a zero, so a caller can never read
    * "no access" as "earned nothing".
    */
-  getAppEarnings: appDeveloperProcedure.input(getAppEarningsSchema).query(async ({ ctx, input }) => {
-    const { getAppEarnings } = await import(
-      '~/server/services/blocks/app-collaborator-earnings.service'
-    );
-    return run(() =>
-      getAppEarnings({
-        appBlockId: input.appBlockId,
-        userId: ctx.user!.id,
-        from: input.from ? new Date(input.from) : undefined,
-        to: input.to ? new Date(input.to) : undefined,
-      })
-    );
-  }),
+  getAppEarnings: appDeveloperProcedure
+    .input(getAppEarningsSchema)
+    .query(async ({ ctx, input }) => {
+      const { getAppEarnings } = await import(
+        '~/server/services/blocks/app-collaborator-earnings.service'
+      );
+      return run(() =>
+        getAppEarnings({
+          appBlockId: input.appBlockId,
+          userId: ctx.user!.id,
+          from: input.from ? new Date(input.from) : undefined,
+          to: input.to ? new Date(input.to) : undefined,
+        })
+      );
+    }),
 
   // -------------------------------------------------------------------------
   // OWNERSHIP TRANSFER.
@@ -308,9 +310,7 @@ export const appCollaboratorsRouter = router({
       const { cancelTransfer } = await import(
         '~/server/services/blocks/app-ownership-transfer.service'
       );
-      return run(() =>
-        cancelTransfer({ transferId: input.transferId, actorUserId: ctx.user!.id })
-      );
+      return run(() => cancelTransfer({ transferId: input.transferId, actorUserId: ctx.user!.id }));
     }),
 
   /** The LIVE pending transfer for an app (expiry applied as a read-time predicate). */

--- a/src/server/routers/app-collaborators.router.ts
+++ b/src/server/routers/app-collaborators.router.ts
@@ -1,0 +1,325 @@
+import { TRPCError } from '@trpc/server';
+
+import {
+  getAppEarningsSchema,
+  getPendingAppTransferSchema,
+  initiateAppTransferSchema,
+  inviteAppCollaboratorSchema,
+  leaveAppSchema,
+  listAppCollaboratorsSchema,
+  removeAppCollaboratorSchema,
+  respondToAppInviteSchema,
+  setCollaboratorDisplayedSchema,
+  transferIdSchema,
+} from '~/server/schema/blocks/app-collaborator.schema';
+import { isAppBlocksAuthorEnabled } from '~/server/services/app-blocks-flag';
+import { rateLimit } from '~/server/middleware.trpc';
+import { appDeveloperProcedure, middleware, protectedProcedure, router } from '~/server/trpc';
+import type { SessionUser } from '~/types/session';
+
+/**
+ * App Listing COLLABORATORS — seat management, ownership transfer, and the APP-SCOPED
+ * earnings read.
+ *
+ * A NEW router rather than an extension of `blocks.router`/`app-listings.router`,
+ * mirroring the locked decision that put the store-listing procs in their own router.
+ *
+ * ## Flag gating
+ *
+ * Everything here sits behind the SAME mod-segmented App Blocks author flag as the
+ * neighbouring authoring procs — `appDeveloperProcedure` (which composes
+ * `hasAppBlocksAuthor`) for owner/editor actions, plus `enforceAppBlocksAuthorFlag`
+ * on the invitee-facing procs.
+ *
+ * 🔴 The two INVITEE-facing procs (`respondToInvite`, `listMyPendingInvites`) and the
+ * transfer-recipient procs use `protectedProcedure + enforceAppBlocksAuthorFlag`
+ * rather than `appDeveloperProcedure`, which is the same composition — stated
+ * explicitly because the subtle alternative is wrong: an invitee is not yet an author
+ * of anything, so gating them on "do you already own an app" would make the very first
+ * invite unacceptable. The author FLAG (a mod floor + the `app-dev-testers` cohort) is
+ * the right gate; app ownership is not.
+ *
+ * ## No input-schema changes anywhere
+ *
+ * Every proc here is NEW. No existing proc's input schema is touched by this feature,
+ * so released `civitai` CLI versions driving the `AppBlocksSubmit`-scoped listing-media
+ * procs are unaffected. None of these procs carries a CLI scope annotation: the CLI has
+ * no collaborator commands, and an un-annotated proc implicitly requires
+ * `TokenScope.Full`, which a session (or a Full personal key) satisfies via
+ * `enforceTokenScope`'s early return. Annotate the day a CLI command needs one.
+ */
+
+const enforceAppBlocksAuthorFlag = middleware(async ({ ctx, next }) => {
+  if (await isAppBlocksAuthorEnabled({ user: ctx.user })) return next();
+  throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Apps authoring is not enabled' });
+});
+
+/** Map the service's typed errors onto tRPC codes; pass anything else through. */
+async function run<T>(fn: () => Promise<T>): Promise<T> {
+  const { mapCollaboratorError } = await import(
+    '~/server/services/blocks/app-collaborator.service'
+  );
+  try {
+    return await fn();
+  } catch (err) {
+    throw mapCollaboratorError(err);
+  }
+}
+
+/**
+ * A BANNED account may not take a seat-granting or ownership-granting action.
+ *
+ * 🔴 THE BAN DECISION, applied in one place so it cannot drift between procs:
+ * a banned user may NOT be invited, may NOT accept an invite, and may NOT receive an
+ * ownership transfer. Rationale: a seat mints Forgejo `write` on the app repo and
+ * exposes the app's earnings, and `getMyAppRepo` already refuses to issue a push
+ * credential to a banned account — seating a banned user would hand out exactly the
+ * credential that gate withholds.
+ *
+ * An EXISTING seat is NOT auto-revoked on ban (that needs a ban-hook this change does
+ * not add), but every capability it unlocks re-checks `bannedAt` at the proc, so a
+ * banned editor holds an inert row. `protectedProcedure`'s `isAuthed` already refuses
+ * banned sessions outright; these are defence-in-depth, matching the sibling
+ * `blocks.router` procs' explicit re-checks.
+ */
+function assertNotBanned(user: SessionUser | undefined): void {
+  if (user?.bannedAt) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Your account is not eligible for app collaboration',
+    });
+  }
+}
+
+export const appCollaboratorsRouter = router({
+  // -------------------------------------------------------------------------
+  // OWNER: seat management.
+  // -------------------------------------------------------------------------
+
+  /**
+   * OWNER: invite a user to an editor seat. Idempotent; re-invites are throttled
+   * (notification only). Rate-limited so an owner cannot spray invitations.
+   */
+  invite: appDeveloperProcedure
+    .use(
+      rateLimit({
+        limit: 30,
+        period: 3600,
+        errorMessage: 'Too many collaborator invitations — slow down.',
+      })
+    )
+    .input(inviteAppCollaboratorSchema)
+    .mutation(async ({ ctx, input }) => {
+      assertNotBanned(ctx.user as SessionUser);
+      const { inviteCollaborator } = await import(
+        '~/server/services/blocks/app-collaborator.service'
+      );
+      return run(() =>
+        inviteCollaborator({
+          appBlockId: input.appBlockId,
+          targetUserId: input.targetUserId,
+          actorUserId: ctx.user!.id,
+        })
+      );
+    }),
+
+  /** OWNER: remove a collaborator (any status). Revokes their repo write. */
+  remove: appDeveloperProcedure.input(removeAppCollaboratorSchema).mutation(async ({ ctx, input }) => {
+    const { removeCollaborator } = await import(
+      '~/server/services/blocks/app-collaborator.service'
+    );
+    return run(() =>
+      removeCollaborator({
+        appBlockId: input.appBlockId,
+        targetUserId: input.targetUserId,
+        actorUserId: ctx.user!.id,
+      })
+    );
+  }),
+
+  // -------------------------------------------------------------------------
+  // INVITEE / COLLABORATOR.
+  // -------------------------------------------------------------------------
+
+  /**
+   * INVITEE: accept or decline a pending seat.
+   *
+   * Gated on the author FLAG, not on `appDeveloperProcedure`'s ownership-flavoured
+   * read — see the router header. A banned account may not accept.
+   */
+  respondToInvite: protectedProcedure
+    .use(enforceAppBlocksAuthorFlag)
+    .input(respondToAppInviteSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (input.accept) assertNotBanned(ctx.user as SessionUser);
+      const { respondToInvite } = await import(
+        '~/server/services/blocks/app-collaborator.service'
+      );
+      return run(() =>
+        respondToInvite({
+          appBlockId: input.appBlockId,
+          userId: ctx.user!.id,
+          accept: input.accept,
+        })
+      );
+    }),
+
+  /** COLLABORATOR: give up your own seat. Consent, not management — no owner check. */
+  leave: protectedProcedure
+    .use(enforceAppBlocksAuthorFlag)
+    .input(leaveAppSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { leaveApp } = await import('~/server/services/blocks/app-collaborator.service');
+      return run(() => leaveApp({ appBlockId: input.appBlockId, userId: ctx.user!.id }));
+    }),
+
+  /**
+   * COLLABORATOR: opt in/out of the PUBLIC BYLINE. Applies immediately (no mod
+   * review) — safe by construction because the flag lives on the collaborator row,
+   * outside the shadow-revision copy sets. See the service.
+   */
+  setDisplayed: protectedProcedure
+    .use(enforceAppBlocksAuthorFlag)
+    .input(setCollaboratorDisplayedSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { setCollaboratorDisplayed } = await import(
+        '~/server/services/blocks/app-collaborator.service'
+      );
+      return run(() =>
+        setCollaboratorDisplayed({
+          appBlockId: input.appBlockId,
+          userId: ctx.user!.id,
+          displayed: input.displayed,
+        })
+      );
+    }),
+
+  /** The caller's own pending invitations (inbox). */
+  listMyPendingInvites: protectedProcedure
+    .use(enforceAppBlocksAuthorFlag)
+    .query(async ({ ctx }) => {
+      const { listMyPendingInvites } = await import(
+        '~/server/services/blocks/app-collaborator.service'
+      );
+      return run(() => listMyPendingInvites(ctx.user!.id));
+    }),
+
+  // -------------------------------------------------------------------------
+  // READ.
+  // -------------------------------------------------------------------------
+
+  /**
+   * The app's roster, filtered by the status-visibility rules `EntityCollaborator`
+   * established: accepted → everyone; pending → owner/invitee/mod; rejected →
+   * owner/mod. Enforced in the SERVICE, so the filter cannot be bypassed by a
+   * different caller.
+   */
+  list: protectedProcedure
+    .use(enforceAppBlocksAuthorFlag)
+    .input(listAppCollaboratorsSchema)
+    .query(async ({ ctx, input }) => {
+      const { listCollaborators } = await import(
+        '~/server/services/blocks/app-collaborator.service'
+      );
+      return run(() =>
+        listCollaborators({
+          appBlockId: input.appBlockId,
+          viewerUserId: ctx.user?.id ?? null,
+          isModerator: !!ctx.user?.isModerator,
+        })
+      );
+    }),
+
+  /**
+   * APP-SCOPED earnings — the collaborator money surface.
+   *
+   * 🔴 NOT a widening of `blocks.getMyRevenue`. That proc is keyed on the snapshotted
+   * `appOwnerUserId` and is USER-WIDE; reusing it for an editor (by passing the
+   * owner's id) would return the owner's ENTIRE PORTFOLIO. This one resolves the
+   * caller's role on THIS app and filters by `appBlockId` + the app's CURRENT owner.
+   * Returns an explicit `notPermitted` rather than a zero, so a caller can never read
+   * "no access" as "earned nothing".
+   */
+  getAppEarnings: appDeveloperProcedure.input(getAppEarningsSchema).query(async ({ ctx, input }) => {
+    const { getAppEarnings } = await import(
+      '~/server/services/blocks/app-collaborator-earnings.service'
+    );
+    return run(() =>
+      getAppEarnings({
+        appBlockId: input.appBlockId,
+        userId: ctx.user!.id,
+        from: input.from ? new Date(input.from) : undefined,
+        to: input.to ? new Date(input.to) : undefined,
+      })
+    );
+  }),
+
+  // -------------------------------------------------------------------------
+  // OWNERSHIP TRANSFER.
+  // -------------------------------------------------------------------------
+
+  /**
+   * OWNER: offer ownership to another user. NOTHING moves until they accept, and a
+   * pending offer confers ZERO capability on the recipient.
+   */
+  initiateTransfer: appDeveloperProcedure
+    .use(
+      rateLimit({
+        limit: 10,
+        period: 3600,
+        errorMessage: 'Too many ownership transfer attempts — slow down.',
+      })
+    )
+    .input(initiateAppTransferSchema)
+    .mutation(async ({ ctx, input }) => {
+      assertNotBanned(ctx.user as SessionUser);
+      const { initiateTransfer } = await import(
+        '~/server/services/blocks/app-ownership-transfer.service'
+      );
+      return run(() =>
+        initiateTransfer({
+          appBlockId: input.appBlockId,
+          toUserId: input.toUserId,
+          actorUserId: ctx.user!.id,
+        })
+      );
+    }),
+
+  /**
+   * RECIPIENT: accept. Moves `OauthClient.userId` AND `AppListing.userId` in ONE
+   * transaction; leaves submission history and Buzz attribution untouched.
+   */
+  acceptTransfer: protectedProcedure
+    .use(enforceAppBlocksAuthorFlag)
+    .input(transferIdSchema)
+    .mutation(async ({ ctx, input }) => {
+      assertNotBanned(ctx.user as SessionUser);
+      const { acceptTransfer } = await import(
+        '~/server/services/blocks/app-ownership-transfer.service'
+      );
+      return run(() => acceptTransfer({ transferId: input.transferId, userId: ctx.user!.id }));
+    }),
+
+  /** Either party cancels: the owner withdraws the offer, or the recipient declines. */
+  cancelTransfer: protectedProcedure
+    .use(enforceAppBlocksAuthorFlag)
+    .input(transferIdSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { cancelTransfer } = await import(
+        '~/server/services/blocks/app-ownership-transfer.service'
+      );
+      return run(() =>
+        cancelTransfer({ transferId: input.transferId, actorUserId: ctx.user!.id })
+      );
+    }),
+
+  /** The LIVE pending transfer for an app (expiry applied as a read-time predicate). */
+  getPendingTransfer: appDeveloperProcedure
+    .input(getPendingAppTransferSchema)
+    .query(async ({ input }) => {
+      const { getPendingTransfer } = await import(
+        '~/server/services/blocks/app-ownership-transfer.service'
+      );
+      return run(() => getPendingTransfer({ appBlockId: input.appBlockId }));
+    }),
+});

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -305,27 +305,22 @@ async function assertViewerIsAppDeveloper(userId: number): Promise<void> {
  * THE app-authoring access gate for this router's four owner-scoped procs
  * (`getMyAppRepo`, `getMyAppManifest`, `updateManifest`, `getMyForgejoCloneInfo`).
  *
- * Replaces four byte-identical open-codings of `block.app?.userId !== ctx.user!.id`,
- * routing them through the single `resolveAppAccess` predicate so an ACCEPTED
- * collaborator reaches them and a pending/rejected invitee does not.
- *
- * 🔴 NO MODERATOR BYPASS — deliberately preserved. All four of these gates were
- * strict before collaborators: a moderator who does not personally own the app was
- * refused, unlike the App Listing asset gates which do bypass for mods. That
- * divergence is PRE-EXISTING; consolidating surfaced it and
- * `app-access.call-site-ledger.test.ts` records it rather than this change silently
- * granting mods a new capability.
- *
- * The message stays `'Not the app owner'` verbatim: it is what a caller sees today and
- * the mutation checks pin this exact string, so a mutant that deletes this guard must
- * die to THIS error and not to a neighbouring one.
+ * A thin re-export of `app-access.service::assertAppEditAccess`, which replaced four
+ * byte-identical open-codings of `block.app?.userId !== ctx.user!.id`. The guard itself
+ * lives in the service so it has one home and can be unit-tested without importing this
+ * 7.9k-line router; this wrapper only keeps the import dynamic, matching the rest of
+ * the file's discipline for cross-service reach.
  */
-async function assertAppEditAccess(appBlockId: string, userId: number): Promise<void> {
-  const { resolveAppAccess } = await import('~/server/services/blocks/app-access.service');
-  const access = await resolveAppAccess(appBlockId, userId);
-  if (!access || !access.role) {
-    throw new TRPCError({ code: 'FORBIDDEN', message: 'Not the app owner' });
-  }
+async function assertAppEditAccess(
+  block: { id: string; app: { userId: number } | null },
+  userId: number
+): Promise<void> {
+  const { assertAppEditAccess: assertAccess } = await import(
+    '~/server/services/blocks/app-access.service'
+  );
+  // The owner is already in hand from the proc's own AppBlock select — passed through
+  // so the gate costs ZERO extra queries on the owner path.
+  await assertAccess({ appBlockId: block.id, ownerUserId: block.app?.userId, userId });
 }
 
 /**
@@ -5618,7 +5613,7 @@ export const blocksRouter = router({
       // ACCEPTED collaborator. A pending/rejected invitee is refused. FORBIDDEN
       // (authenticated but not permitted) rather than UNAUTHORIZED, to distinguish a
       // logged-in non-owner from an anon caller; mirrors the grantScopes ceiling gate.
-      await assertAppEditAccess(block.id, ctx.user!.id);
+      await assertAppEditAccess(block, ctx.user!.id);
       // A banned/suspended account must not be issued (or re-issued) a live push
       // credential. They still can't deploy (the mod gate holds), but we don't
       // hand out a fresh Forgejo token. Full revoke-on-ban is a follow-up.
@@ -5727,7 +5722,7 @@ export const blocksRouter = router({
       });
       if (!block) throw throwNotFoundError('App block not found');
       // Owner OR accepted collaborator (see `assertAppEditAccess`).
-      await assertAppEditAccess(block.id, ctx.user!.id);
+      await assertAppEditAccess(block, ctx.user!.id);
       // 🔴 BAN PARITY. The three sibling owner-scoped procs (getMyAppRepo,
       // updateManifest, getMyForgejoCloneInfo) each carry an explicit `bannedAt`
       // re-check; this read did NOT, which was a real inconsistency surfaced by
@@ -5876,7 +5871,7 @@ export const blocksRouter = router({
       // Access gate — owner OR accepted collaborator. Shipping a new version is an
       // explicit editor capability; the no-trust review gate downstream is unchanged
       // (the commit still parks a `pending` request a moderator must approve).
-      await assertAppEditAccess(block.id, ctx.user!.id);
+      await assertAppEditAccess(block, ctx.user!.id);
       // A banned/suspended account must not be able to mutate a live app.
       if (ctx.user!.bannedAt) {
         throw new TRPCError({
@@ -6112,7 +6107,7 @@ export const blocksRouter = router({
           });
       if (!block) throw throwNotFoundError('App block not found');
       // Owner OR accepted collaborator (see `assertAppEditAccess`).
-      await assertAppEditAccess(block.id, ctx.user!.id);
+      await assertAppEditAccess(block, ctx.user!.id);
       if (ctx.user!.bannedAt) {
         throw new TRPCError({
           code: 'FORBIDDEN',

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -302,6 +302,33 @@ async function assertViewerIsAppDeveloper(userId: number): Promise<void> {
 }
 
 /**
+ * THE app-authoring access gate for this router's four owner-scoped procs
+ * (`getMyAppRepo`, `getMyAppManifest`, `updateManifest`, `getMyForgejoCloneInfo`).
+ *
+ * Replaces four byte-identical open-codings of `block.app?.userId !== ctx.user!.id`,
+ * routing them through the single `resolveAppAccess` predicate so an ACCEPTED
+ * collaborator reaches them and a pending/rejected invitee does not.
+ *
+ * 🔴 NO MODERATOR BYPASS — deliberately preserved. All four of these gates were
+ * strict before collaborators: a moderator who does not personally own the app was
+ * refused, unlike the App Listing asset gates which do bypass for mods. That
+ * divergence is PRE-EXISTING; consolidating surfaced it and
+ * `app-access.call-site-ledger.test.ts` records it rather than this change silently
+ * granting mods a new capability.
+ *
+ * The message stays `'Not the app owner'` verbatim: it is what a caller sees today and
+ * the mutation checks pin this exact string, so a mutant that deletes this guard must
+ * die to THIS error and not to a neighbouring one.
+ */
+async function assertAppEditAccess(appBlockId: string, userId: number): Promise<void> {
+  const { resolveAppAccess } = await import('~/server/services/blocks/app-access.service');
+  const access = await resolveAppAccess(appBlockId, userId);
+  if (!access || !access.role) {
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'Not the app owner' });
+  }
+}
+
+/**
  * App-Blocks flag gate for the BLOCK-TOKEN-authed runtime procs
  * (estimate/submit/poll/cancelWorkflow, updateUserSettings).
  *
@@ -5310,6 +5337,24 @@ export const blocksRouter = router({
    * therefore takes enforceTokenScope's Full early-return regardless. Annotate it the
    * day something token-authed needs it — at which point AppBlocksSubmit is the
    * consistent choice, for the reasons spelled out on getMyAppAnalytics.
+   *
+   * 🔴 DELIBERATELY **NOT** WIDENED FOR COLLABORATORS. This proc answers "what have
+   * *I* accrued", keyed on the snapshotted `BlockBuzzAttribution.appOwnerUserId`, and
+   * that is exactly the right question for it to keep answering:
+   *   - an editor calling it sees THEIR OWN portfolio, and nothing of the owner's —
+   *     no leak, no change;
+   *   - an owner who TRANSFERRED an app away still sees the rows they accrued before
+   *     the cut, which is required: those rows are still theirs to be paid for
+   *     (`app-ownership-transfer.service` deliberately does not rewrite the column).
+   * Widening it — or app-scoping it — would break that second property.
+   *
+   * The collaborator surface is the SEPARATE app-scoped `getAppEarnings` below. Note
+   * the one rough edge left alone on purpose: an editor who calls THIS proc with the
+   * shared `appBlockId` gets zeros, because none of those rows are attributed to them.
+   * Making that case throw would create the ownership oracle this proc deliberately
+   * does not have (see `RevenueUnavailableReason`'s note on why there is no `notOwned`
+   * value). The client routes editors to `getAppEarnings`, which answers the question
+   * they actually mean and returns an explicit `notPermitted` rather than a zero.
    */
   getMyRevenue: appDeveloperProcedure
     .use(enforceAppBlocksFlag)
@@ -5462,14 +5507,41 @@ export const blocksRouter = router({
     }),
 
   /**
-   * The current user's owned apps + lifetime revenue per app. Drives
-   * the per-app dropdown on /apps/revenue. OauthClient.userId is the
-   * single source of truth for app ownership in v1.
+   * The apps the caller can act on (OWNED + apps they hold an ACCEPTED collaborator
+   * seat on) + lifetime revenue per app. Drives the per-app dropdown on /apps/revenue.
+   *
+   * 🔴 THE LIFETIME GROUPBY IS THE PORTFOLIO-LEAK SITE, so read this before editing it.
+   * It used to be `where: { appOwnerUserId: user.id }` with NO app filter — a
+   * USER-WIDE query, bucketed by app in JS afterwards. That is safe only while the
+   * caller owns everything they can see. The moment an editor is in scope, the
+   * "obvious" widening (pass the OWNER's id, since the editor has no attribution rows
+   * of their own) returns the OWNER'S ENTIRE PORTFOLIO — every app they ever published,
+   * including ones this editor was never invited to.
+   *
+   * It is now served by `getMyAppsEarnings`, which resolves the permitted app-id SET
+   * first and filters `appBlockId IN thatSet`. Never reintroduce an
+   * `appOwnerUserId`-only filter on a collaborator-reachable read.
+   *
+   * `role` is surfaced so the client can distinguish an owned app from a seat (only an
+   * owner sees the manage-collaborators / transfer controls).
    */
   getMyApps: appDeveloperProcedure.use(enforceAppBlocksFlag).query(async ({ ctx }) => {
     const user = ctx.user as SessionUser;
+    const { getMyAppsEarnings } = await import(
+      '~/server/services/blocks/app-collaborator-earnings.service'
+    );
+    const earnings = await getMyAppsEarnings({ userId: user.id });
+    if (earnings.length === 0) return [];
+    const roleByApp = new Map(earnings.map((e) => [e.appBlockId, e.role] as const));
+    const lifetimeMap = new Map(
+      earnings.map(
+        (e) => [e.appBlockId, { shareCents: e.lifetimeShareCents, count: e.lifetimeCount }] as const
+      )
+    );
+
     const apps = await dbRead.appBlock.findMany({
-      where: { app: { userId: user.id } },
+      // The permitted set, not `app: { userId }` — that would drop every seated app.
+      where: { id: { in: earnings.map((e) => e.appBlockId) } },
       select: {
         id: true,
         blockId: true,
@@ -5480,32 +5552,6 @@ export const blocksRouter = router({
       },
       orderBy: { createdAt: 'desc' },
     });
-
-    // One groupBy across all of the user's apps so the request
-    // doesn't N+1 against the attribution table. Skip when there
-    // are no apps — pointless query.
-    const lifetimeByApp = apps.length
-      ? await dbRead.blockBuzzAttribution.groupBy({
-          by: ['appBlockId'],
-          where: {
-            appOwnerUserId: user.id,
-            status: { in: ['confirmed', 'paid_out'] },
-          },
-          _sum: { appOwnerShareCents: true },
-          _count: true,
-        })
-      : [];
-    type LifetimeRow = {
-      appBlockId: string;
-      _sum: { appOwnerShareCents: number | null };
-      _count: number;
-    };
-    const lifetimeMap = new Map<string, { shareCents: number; count: number }>(
-      (lifetimeByApp as LifetimeRow[]).map((r) => [
-        r.appBlockId,
-        { shareCents: r._sum.appOwnerShareCents ?? 0, count: r._count },
-      ])
-    );
 
     type AppRow = {
       id: string;
@@ -5522,6 +5568,7 @@ export const blocksRouter = router({
       status: a.status,
       appName: a.app?.name ?? null,
       manifest: a.manifest as Record<string, unknown>,
+      role: roleByApp.get(a.id) ?? ('owner' as const),
       lifetimeShareCents: lifetimeMap.get(a.id)?.shareCents ?? 0,
       lifetimeCount: lifetimeMap.get(a.id)?.count ?? 0,
     }));
@@ -5560,19 +5607,18 @@ export const blocksRouter = router({
       const block = await dbRead.appBlock.findUnique({
         where: { id: input.appBlockId },
         select: {
+          id: true,
           blockId: true,
           status: true,
           app: { select: { userId: true } },
         },
       });
       if (!block) throw throwNotFoundError('App block not found');
-      // Owner gate — OauthClient.userId is the v1 app-ownership source of truth.
-      // FORBIDDEN (authenticated but not permitted) rather than UNAUTHORIZED, to
-      // distinguish a logged-in non-owner from an anon caller; mirrors the
-      // grantScopes ceiling gate above.
-      if (block.app?.userId !== ctx.user!.id) {
-        throw new TRPCError({ code: 'FORBIDDEN', message: 'Not the app owner' });
-      }
+      // Access gate — the OWNER (OauthClient.userId, the v1 source of truth) or an
+      // ACCEPTED collaborator. A pending/rejected invitee is refused. FORBIDDEN
+      // (authenticated but not permitted) rather than UNAUTHORIZED, to distinguish a
+      // logged-in non-owner from an anon caller; mirrors the grantScopes ceiling gate.
+      await assertAppEditAccess(block.id, ctx.user!.id);
       // A banned/suspended account must not be issued (or re-issued) a live push
       // credential. They still can't deploy (the mod gate holds), but we don't
       // hand out a fresh Forgejo token. Full revoke-on-ban is a follow-up.
@@ -5680,8 +5726,19 @@ export const blocksRouter = router({
         },
       });
       if (!block) throw throwNotFoundError('App block not found');
-      if (block.app?.userId !== ctx.user!.id) {
-        throw new TRPCError({ code: 'FORBIDDEN', message: 'Not the app owner' });
+      // Owner OR accepted collaborator (see `assertAppEditAccess`).
+      await assertAppEditAccess(block.id, ctx.user!.id);
+      // 🔴 BAN PARITY. The three sibling owner-scoped procs (getMyAppRepo,
+      // updateManifest, getMyForgejoCloneInfo) each carry an explicit `bannedAt`
+      // re-check; this read did NOT, which was a real inconsistency surfaced by
+      // consolidating these four gates. `protectedProcedure`'s `isAuthed` already
+      // refuses a banned session, so this is defence-in-depth exactly like its
+      // siblings rather than a new restriction.
+      if (ctx.user!.bannedAt) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'Account is not eligible to manage apps',
+        });
       }
       return {
         appBlockId: block.id,
@@ -5816,10 +5873,10 @@ export const blocksRouter = router({
         },
       });
       if (!block) throw throwNotFoundError('App block not found');
-      // Owner gate — OauthClient.userId is the v1 ownership source of truth.
-      if (block.app?.userId !== ctx.user!.id) {
-        throw new TRPCError({ code: 'FORBIDDEN', message: 'Not the app owner' });
-      }
+      // Access gate — owner OR accepted collaborator. Shipping a new version is an
+      // explicit editor capability; the no-trust review gate downstream is unchanged
+      // (the commit still parks a `pending` request a moderator must approve).
+      await assertAppEditAccess(block.id, ctx.user!.id);
       // A banned/suspended account must not be able to mutate a live app.
       if (ctx.user!.bannedAt) {
         throw new TRPCError({
@@ -6047,16 +6104,15 @@ export const blocksRouter = router({
       const block = input.appBlockId
         ? await dbRead.appBlock.findUnique({
             where: { id: input.appBlockId },
-            select: { blockId: true, status: true, app: { select: { userId: true } } },
+            select: { id: true, blockId: true, status: true, app: { select: { userId: true } } },
           })
         : await dbRead.appBlock.findFirst({
             where: { blockId: input.slug },
-            select: { blockId: true, status: true, app: { select: { userId: true } } },
+            select: { id: true, blockId: true, status: true, app: { select: { userId: true } } },
           });
       if (!block) throw throwNotFoundError('App block not found');
-      if (block.app?.userId !== ctx.user!.id) {
-        throw new TRPCError({ code: 'FORBIDDEN', message: 'Not the app owner' });
-      }
+      // Owner OR accepted collaborator (see `assertAppEditAccess`).
+      await assertAppEditAccess(block.id, ctx.user!.id);
       if (ctx.user!.bannedAt) {
         throw new TRPCError({
           code: 'FORBIDDEN',

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -6018,10 +6018,11 @@ export const blocksRouter = router({
 
   /**
    * App management (Phase 2) — return the caller's per-user Forgejo clone info
-   * for one of THEIR apps, for the read-only `civitai app pull` CLI command.
-   * Owner-gated identically to getMyAppRepo; lazily provisions the scoped,
-   * restricted per-user Forgejo identity (ensureForgejoIdentity) and grants it
-   * read on the app's own civitai-apps/<slug> repo.
+   * for an app they may EDIT, for the read-only `civitai app pull` CLI command.
+   * Access-gated identically to getMyAppRepo — which, since App Listing Collaborators,
+   * means OWNER **or** ACCEPTED collaborator (`assertAppEditAccess`), not owner-only.
+   * Lazily provisions the scoped, restricted per-user Forgejo identity
+   * (ensureForgejoIdentity) and grants it read on the app's own civitai-apps/<slug> repo.
    *
    * Close to getMyAppRepo but no longer identical to it — three differences, and the
    * first is easy to miss now that only one of them carries a scope annotation:
@@ -6032,7 +6033,7 @@ export const blocksRouter = router({
    *   - INTENT: pull/sync here vs push instructions there.
    *   - COLLABORATOR PERMISSION: `read` here vs `write` there (see the note at the
    *     addCollaborator call below).
-   * Ownership gating IS identical (owner check + bannedAt + `approved`). It returns the
+   * Access gating IS identical (assertAppEditAccess + bannedAt + `approved`). It returns the
    * raw { forgejoUsername, token, cloneUrl } the CLI assembles its git command from; the
    * token is embedded in the returned cloneUrl exactly as getMyAppRepo does (the CLI
    * documents the token-in-URL leakage caveat).
@@ -6057,8 +6058,10 @@ export const blocksRouter = router({
     // include the civitai-cli OAuth login token.
     //
     // Accepted, deliberately: AppBlocksSubmit is opt-in, excluded from `Full`, and
-    // carried only by the first-party civitai-cli client; the caller must still own the
-    // app, not be banned, and the app must be `approved`; the collaborator grant is
+    // carried only by the first-party civitai-cli client; the caller must still hold EDIT
+    // ACCESS to the app — owner OR an ACCEPTED collaborator seat, per assertAppEditAccess
+    // (a pending or rejected invitee is refused, and there is no moderator bypass) — must
+    // not be banned, and the app must be `approved`; the collaborator grant is
     // `read` on that one repo; and this is already the established meaning of the bit
     // for CLI-facing procs, several of which are outright mutations (see
     // `listingMediaCliScope` in app-listings.router.ts). A dedicated bit would be

--- a/src/server/routers/index.ts
+++ b/src/server/routers/index.ts
@@ -10,6 +10,9 @@ export const appRouter = router({
   appListings: lazy(() =>
     import('~/server/routers/app-listings.router').then((m) => m.appListingsRouter)
   ),
+  appCollaborators: lazy(() =>
+    import('~/server/routers/app-collaborators.router').then((m) => m.appCollaboratorsRouter)
+  ),
   blockImageUpload: lazy(() =>
     import('~/server/routers/block-image-upload.router').then((m) => m.blockImageUploadRouter)
   ),

--- a/src/server/schema/blocks/app-collaborator.schema.ts
+++ b/src/server/schema/blocks/app-collaborator.schema.ts
@@ -1,0 +1,72 @@
+import { z } from 'zod';
+
+/**
+ * App Listing COLLABORATORS — tRPC input schemas.
+ *
+ * 🔴 THESE ARE ALL NEW SCHEMAS ON NEW PROCS. No existing proc's input schema is
+ * touched anywhere in this feature, which is the CLI wire contract: released
+ * `civitai` CLI versions drive the listing-media procs
+ * (`setIcon`/`setCover`/`addScreenshot`/`removeScreenshot`/`reorderScreenshots`/
+ * `getMyListingForApp`/`beginListingRevision`/`submitListingRevision`, …) under the
+ * `AppBlocksSubmit` token scope. Widening a GATE is invisible to those clients;
+ * changing an INPUT SCHEMA breaks them. `app-collaborator.cli-contract.test.ts`
+ * asserts every `listingMediaCliScope`-annotated proc's schema shape is unchanged.
+ *
+ * `appBlockId` bounds mirror the rest of the App Blocks surface (`min(1).max(64)`) so
+ * a request-size guard is consistent across routers.
+ */
+
+const appBlockId = z.string().min(1).max(64);
+/** A civitai `User.id`. Positive int — the FK would reject anything else anyway. */
+const userId = z.number().int().positive();
+
+export const inviteAppCollaboratorSchema = z.object({
+  appBlockId,
+  targetUserId: userId,
+});
+export type InviteAppCollaboratorInput = z.infer<typeof inviteAppCollaboratorSchema>;
+
+export const respondToAppInviteSchema = z.object({
+  appBlockId,
+  accept: z.boolean(),
+});
+export type RespondToAppInviteInput = z.infer<typeof respondToAppInviteSchema>;
+
+export const removeAppCollaboratorSchema = z.object({
+  appBlockId,
+  targetUserId: userId,
+});
+export type RemoveAppCollaboratorInput = z.infer<typeof removeAppCollaboratorSchema>;
+
+export const leaveAppSchema = z.object({ appBlockId });
+export type LeaveAppInput = z.infer<typeof leaveAppSchema>;
+
+export const setCollaboratorDisplayedSchema = z.object({
+  appBlockId,
+  displayed: z.boolean(),
+});
+export type SetCollaboratorDisplayedInput = z.infer<typeof setCollaboratorDisplayedSchema>;
+
+export const listAppCollaboratorsSchema = z.object({ appBlockId });
+export type ListAppCollaboratorsInput = z.infer<typeof listAppCollaboratorsSchema>;
+
+export const initiateAppTransferSchema = z.object({
+  appBlockId,
+  toUserId: userId,
+});
+export type InitiateAppTransferInput = z.infer<typeof initiateAppTransferSchema>;
+
+export const transferIdSchema = z.object({
+  transferId: z.string().min(1).max(64),
+});
+export type TransferIdInput = z.infer<typeof transferIdSchema>;
+
+export const getPendingAppTransferSchema = z.object({ appBlockId });
+export type GetPendingAppTransferInput = z.infer<typeof getPendingAppTransferSchema>;
+
+export const getAppEarningsSchema = z.object({
+  appBlockId,
+  from: z.string().datetime().optional(),
+  to: z.string().datetime().optional(),
+});
+export type GetAppEarningsInput = z.infer<typeof getAppEarningsSchema>;

--- a/src/server/schema/blocks/app-listing-read.schema.ts
+++ b/src/server/schema/blocks/app-listing-read.schema.ts
@@ -236,6 +236,17 @@ export type ListingDetail = {
   iconUrl: string | null;
   coverUrl: string | null;
   creator: ListingCreatorChip | null;
+  /**
+   * PUBLIC BYLINE — the app's ACCEPTED collaborators who have opted IN to display
+   * (`AppCollaborator.status = 'accepted' AND displayed = true`). Same
+   * `{id, username, image}` allowlist as `creator`.
+   *
+   * 🔴 A PENDING OR REJECTED INVITE MUST NEVER APPEAR HERE. Otherwise an owner could
+   * attach any stranger's name and avatar to their listing just by inviting them.
+   * Empty for a listing with no backing AppBlock, and empty until the manual-apply
+   * collaborator migration lands.
+   */
+  collaborators: ListingCreatorChip[];
   recommend: ListingRecommendRollup;
   reviewCount: number;
   /** Ordered gallery — screenshots whose backing Image still exists (null-image rows dropped). */

--- a/src/server/services/__tests__/appBlockReview.collaborator-self-review.test.ts
+++ b/src/server/services/__tests__/appBlockReview.collaborator-self-review.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * 🔴 SELF-REVIEW, widened for collaborators.
+ *
+ * `upsertAppBlockReview`'s gate 2 used to compare the caller against the single
+ * `app.userId`. With editor seats an ACCEPTED collaborator — who can edit the listing,
+ * ship new versions and read the app's earnings — could 5-star the app they co-author.
+ * That is the same conflict of interest the owner check exists to prevent.
+ *
+ * The asymmetries this suite pins, each of which is a decision that could plausibly
+ * have gone the other way:
+ *   - an accepted collaborator IS an insider (blocked);
+ *   - an UNDISPLAYED accepted collaborator is STILL an insider — hiding your byline
+ *     must not be a self-review bypass;
+ *   - a PENDING or REJECTED invitee is NOT an insider — otherwise an owner could
+ *     silence a critic by inviting them.
+ */
+
+const { mockDb } = vi.hoisted(() => ({
+  mockDb: {
+    appBlock: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    appCollaborator: {
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+    },
+    blockUserSubscription: { findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    appBlockReview: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      create: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({})),
+      update: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({})),
+    },
+  },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
+vi.mock('~/server/utils/cache-helpers', () => ({ bustCacheTag: vi.fn(async () => undefined) }));
+
+const { upsertAppBlockReview } = await import('~/server/services/appBlockReview.service');
+
+const APP = 'ab_app1';
+const OWNER = 10;
+const ACCEPTED_EDITOR = 20;
+const HIDDEN_EDITOR = 21; // accepted, displayed:false
+const PENDING_INVITEE = 30;
+const REJECTED_INVITEE = 40;
+const OUTSIDER = 50;
+
+const SEATS = [
+  { userId: ACCEPTED_EDITOR, status: 'accepted', displayed: true },
+  { userId: HIDDEN_EDITOR, status: 'accepted', displayed: false },
+  { userId: PENDING_INVITEE, status: 'pending', displayed: true },
+  { userId: REJECTED_INVITEE, status: 'rejected', displayed: true },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDb.appBlock.findUnique.mockResolvedValue({ app: { userId: OWNER } });
+  mockDb.appCollaborator.findMany.mockImplementation(async (args: unknown) => {
+    const w = (args as { where: { status?: string; displayed?: boolean } }).where;
+    return SEATS.filter(
+      (r) =>
+        (w.status === undefined || r.status === w.status) &&
+        (w.displayed === undefined || r.displayed === w.displayed)
+    ).map((r) => ({ userId: r.userId }));
+  });
+  // Every caller below has an enabled install, so gate 3 never masks gate 2.
+  mockDb.blockUserSubscription.findFirst.mockResolvedValue({ id: 'bus_1' });
+});
+
+const review = (userId: number) => upsertAppBlockReview({ userId, appBlockId: APP, rating: 5 });
+
+describe('upsertAppBlockReview — the insider set', () => {
+  it('the OWNER cannot review (unchanged)', async () => {
+    await expect(review(OWNER)).rejects.toThrow('You cannot review your own app');
+  });
+
+  it('🔴 an ACCEPTED COLLABORATOR cannot review', async () => {
+    await expect(review(ACCEPTED_EDITOR)).rejects.toThrow('You cannot review your own app');
+    expect(mockDb.appBlockReview.create).not.toHaveBeenCalled();
+  });
+
+  it('🔴 an accepted collaborator with `displayed: false` STILL cannot review', async () => {
+    // Hiding your byline is a public-credit preference, not a capability change.
+    // Filtering the insider set on `displayed` would turn it into a bypass.
+    await expect(review(HIDDEN_EDITOR)).rejects.toThrow('You cannot review your own app');
+  });
+
+  it('a PENDING invitee CAN review — an invite must not silence a critic', async () => {
+    await expect(review(PENDING_INVITEE)).resolves.toBeTruthy();
+  });
+
+  it('a REJECTED invitee CAN review', async () => {
+    await expect(review(REJECTED_INVITEE)).resolves.toBeTruthy();
+  });
+
+  it('an ordinary user CAN review', async () => {
+    await expect(review(OUTSIDER)).resolves.toBeTruthy();
+  });
+
+  it('POSITIVE CONTROL: the happy path really does write a review', async () => {
+    // Otherwise the four "resolves" above could be passing for the wrong reason.
+    await review(OUTSIDER);
+    expect(mockDb.appBlockReview.create).toHaveBeenCalledOnce();
+  });
+
+  it('a missing app is a BAD_REQUEST, not a silent allow', async () => {
+    mockDb.appBlock.findUnique.mockResolvedValue(null);
+    await expect(review(OUTSIDER)).rejects.toThrow('App block not found');
+  });
+
+  it('the insider set degrades to OWNER-ONLY when the seat table is absent', async () => {
+    // Pre-migration: the review gate must keep working exactly as it did before.
+    mockDb.appCollaborator.findMany.mockRejectedValue(
+      Object.assign(new Error('does not exist'), { code: 'P2021' })
+    );
+    await expect(review(OWNER)).rejects.toThrow('You cannot review your own app');
+    await expect(review(ACCEPTED_EDITOR)).resolves.toBeTruthy();
+  });
+});

--- a/src/server/services/__tests__/appBlockReview.service.test.ts
+++ b/src/server/services/__tests__/appBlockReview.service.test.ts
@@ -20,6 +20,11 @@ import { Prisma } from '@prisma/client';
 const { mockDb, mockBust } = vi.hoisted(() => ({
   mockDb: {
     appBlock: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    // App Listing COLLABORATORS: the widened gates consult the seat table on the
+    // NON-owner path. `safeCollaboratorQuery` deliberately swallows ONLY the
+    // missing-TABLE error, so an absent mock surfaces as a TypeError rather than
+    // being silently absorbed — which is why this fixture must declare it.
+    appCollaborator: { findFirst: vi.fn(async () => null), findMany: vi.fn(async () => []) },
     blockUserSubscription: {
       findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
     },

--- a/src/server/services/appBlockReview.service.ts
+++ b/src/server/services/appBlockReview.service.ts
@@ -53,6 +53,29 @@ async function getAppOwnerUserId(appBlockId: string): Promise<number | null> {
   return row?.app.userId ?? null;
 }
 
+/**
+ * The app's INSIDERS for the self-review gate: the owner plus every ACCEPTED
+ * collaborator.
+ *
+ * 🔴 WIDENED FOR COLLABORATORS. The gate used to compare against the single
+ * `app.userId`; with editor seats, an accepted collaborator — who can edit the
+ * listing, ship versions and see the earnings — could otherwise 5-star the app they
+ * co-author. That is the same conflict of interest the owner check exists to stop.
+ *
+ * 🔴 `displayed` is deliberately NOT part of this set. It is a public-CREDIT
+ * preference, not a capability, so an editor who hid their byline is still an insider;
+ * filtering on it would turn "hide my name" into a self-review bypass. See
+ * `listAppInsiderUserIds`, which encodes that asymmetry against its public sibling.
+ *
+ * PENDING and REJECTED seats are NOT insiders — they hold no capability, so they have
+ * no conflict, and treating a mere invite as disqualifying would let an owner silence
+ * a critic by inviting them.
+ */
+async function getAppInsiderUserIds(appBlockId: string): Promise<number[]> {
+  const { listAppInsiderUserIds } = await import('~/server/services/blocks/app-access.service');
+  return listAppInsiderUserIds(appBlockId);
+}
+
 /** True when the viewer has an ENABLED subscription (install) for the app. */
 async function hasEnabledInstall(appBlockId: string, userId: number): Promise<boolean> {
   const row = await dbRead.blockUserSubscription.findFirst({
@@ -112,11 +135,13 @@ export const upsertAppBlockReview = async ({
   const createRecommended = recommended ?? true;
   const updateRecommended = recommended === undefined ? {} : { recommended };
 
-  // Gate 2: no self-review. Reject before any write so the owner can't seed
-  // their own (even though it's excluded from the aggregate too).
+  // Gate 2: no self-review. Reject before any write so an insider can't seed
+  // their own (even though it's excluded from the aggregate too). Covers the owner
+  // AND every accepted collaborator — see `getAppInsiderUserIds`.
   const ownerUserId = await getAppOwnerUserId(appBlockId);
   if (ownerUserId == null) throw throwBadRequestError('App block not found');
-  if (ownerUserId === userId) {
+  const insiders = await getAppInsiderUserIds(appBlockId);
+  if (insiders.includes(userId)) {
     throw throwAuthorizationError('You cannot review your own app');
   }
 

--- a/src/server/services/blocks/__tests__/app-access.call-site-ledger.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.call-site-ledger.test.ts
@@ -97,10 +97,17 @@ const GATE_LEDGER: Record<string, string> = {
     'assertOwner — seat management is OWNER-ONLY by product decision (an editor is a ' +
     'co-owner in every respect EXCEPT managing collaborators and initiating a ' +
     'transfer). Deliberately does NOT use resolveAppAccess, because "role !== null" is ' +
-    'the wrong question here; only `owner` may pass.',
+    'the wrong question here; only `owner` may pass. listCollaborators DOES use it, and ' +
+    'requires a non-null role (or a moderator): the roster exposes accepted seats whose ' +
+    'holder opted OUT of the public byline, plus invitedBy and timestamps, so it is not ' +
+    'a public read. A pending invitee reads their own invite via listMyPendingInvites.',
   'src/server/services/blocks/app-ownership-transfer.service.ts':
     'loadOwnedApp — initiating a transfer is OWNER-ONLY, same reasoning as seat ' +
-    'management. Accept is gated on being the transfer’s ADDRESSEE, not on any role.',
+    'management. Accept is gated on being the transfer’s ADDRESSEE, not on any role, ' +
+    'and re-reads bannedAt in-tx on the primary. getPendingTransfer resolves the caller ' +
+    'and returns the row only to the OWNER or the ADDRESSEE — null (never FORBIDDEN) to ' +
+    'anyone else, so the read cannot become an existence oracle. Editors are excluded: ' +
+    'disposing of the app is the one capability a seat never carries.',
   'src/server/services/blocks/app-collaborator-earnings.service.ts':
     'The app-scoped money read: resolves the role FIRST and filters by appBlockId + the ' +
     'CURRENT owner. Never appOwnerUserId alone — that is the portfolio leak.',
@@ -148,9 +155,21 @@ const GATE_LEDGER: Record<string, string> = {
  * `resolveAppAccess` / `resolveListingAccess` / `resolveAccessibleAppBlockIds` — the
  * consolidated predicate (a site that delegates must still be in the ledger).
  * `assertAppEditAccess` — the blocks.router wrapper.
+ *
+ * 🔴 THE LISTING-OWNER CLASS IS MATCHED EXPLICITLY, and that is the point of the third
+ * and fourth alternatives. This PR widened three gates spelled
+ * `listing.userId !== user.id`, `shadow.userId !== userId` and
+ * `shot.appListing.userId !== user.id` — the DENORMALIZED owner column, not
+ * `app.userId`. Before they were listed here the regex could not see any of them: their
+ * three files were in the ledger only INCIDENTALLY, matched by an unrelated token
+ * (`resolveListingAccess`, `loadOwnedListingInTx`), so a new file opening a fresh
+ * `listing.userId !== callerId` gate would have grown the population WITHOUT growing
+ * `GATES` — the "fails on GROWTH" assertion below would have stayed green through
+ * exactly the event it exists to catch. Every shape is probed in the POSITIVE CONTROL
+ * test, because a regex nobody has watched match is a claim, not a guard.
  */
 const GATE_RE =
-  /app\??\.userId|app:\s*\{\s*userId|resolveAppAccess|resolveListingAccess|resolveAccessibleAppBlockIds|assertAppEditAccess|listAppInsiderUserIds|loadOwnedListingInTx/;
+  /app\??\.userId|app:\s*\{\s*userId|(?:\w*[Ll]isting|\w*[Ss]hadow)\.userId\s*!==|\w+\.appListing\.userId\s*!==|resolveAppAccess|resolveListingAccess|resolveAccessibleAppBlockIds|assertAppEditAccess|listAppInsiderUserIds|loadOwnedListingInTx/;
 
 function walk(dir: string, out: string[] = []): string[] {
   for (const entry of readdirSync(dir)) {
@@ -196,6 +215,44 @@ describe('app-ownership gate ledger', () => {
   it('NEGATIVE CONTROL: a definitely-absent predicate matches nothing', () => {
     const bogus = FILES.filter((f) => /resolveAppAccessNoSuchFunction/.test(CODE.get(f)!));
     expect(bogus).toEqual([]);
+  });
+
+  it('🔴 POSITIVE CONTROL: GATE_RE matches EVERY gate shape, including the listing-owner class', () => {
+    // A regex is only a guard for the shapes it has been WATCHED to match. Each sample
+    // is copied from a real production line; the last three are the listing-owner class
+    // this PR widened, which GATE_RE was blind to — their files were in the ledger only
+    // incidentally, via a different token on an unrelated line.
+    const SHAPES: Array<[string, string]> = [
+      ['blocks.router hard throw', 'if (block.app?.userId !== ctx.user!.id) throw x;'],
+      ['analytics where-clause', 'where: { app: { userId } },'],
+      ['the consolidated predicate', 'const access = await resolveAppAccess(id, userId);'],
+      ['the router wrapper', 'await assertAppEditAccess(block, ctx.user!.id);'],
+      [
+        'listing-owner gate (app-listing-assets::loadOwnedListing)',
+        'if (listing.userId !== user.id && !user.isModerator) {',
+      ],
+      [
+        'shadow-owner gate (offsite-listing::submitListingRevision)',
+        'if (shadow.userId !== userId && !(await isAcceptedListingEditor(shadowId, userId))) {',
+      ],
+      [
+        'screenshot listing-owner gate (app-listing-assets::resolveOwnerScreenshotTarget)',
+        'if (shot.appListing.userId !== user.id && !user.isModerator) {',
+      ],
+    ];
+    for (const [label, sample] of SHAPES) {
+      expect(GATE_RE.test(sample), `GATE_RE must recognise: ${label}`).toBe(true);
+    }
+  });
+
+  it('NEGATIVE CONTROL: GATE_RE does not match an unrelated owner comparison or a plain read', () => {
+    // Otherwise the widening above would sweep half the codebase into the population and
+    // the equality assertion would become unmaintainable noise rather than a guard.
+    expect(GATE_RE.test('if (image.userId !== user.id) return null;')).toBe(false);
+    expect(GATE_RE.test('if (post.userId !== ctx.user.id) throw e;')).toBe(false);
+    expect(GATE_RE.test('const listing = await dbRead.appListing.findUnique({ where });')).toBe(
+      false
+    );
   });
 
   it('the set of production gate sites EXACTLY equals the ledger (fails on GROWTH and on SHRINK)', () => {

--- a/src/server/services/blocks/__tests__/app-access.call-site-ledger.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.call-site-ledger.test.ts
@@ -1,0 +1,248 @@
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join, relative, sep } from 'path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * 🔴 SEAM GUARD for app-ownership gating.
+ *
+ * The behavioural suites prove each gate is individually correct. What none of them can
+ * express is the property that decays: that the SET of production sites which decide
+ * "may this caller act on this app?" is CLOSED, and that every member of it made a
+ * deliberate COLLABORATOR decision.
+ *
+ * Nothing in the compiler notices when someone adds a thirteenth owner-gated proc with
+ * a fresh `block.app?.userId !== ctx.user!.id`. It would ship silently owner-only,
+ * quietly excluding every collaborator from a capability the product says they have —
+ * a defect that produces no error, only an inexplicable FORBIDDEN for one class of
+ * user. So this ledger names every site together with its collaborator decision, and
+ * FAILS when the set GROWS (someone added a gate without deciding) or SHRINKS (someone
+ * removed or renamed one and the reasoning here went stale).
+ *
+ * A structural check type-checks past a wrong argument, so this is deliberately NOT the
+ * only guard — `app-access.service.test.ts`'s role × subject matrix and the per-service
+ * behavioural suites pin the VALUES. This pins the POPULATION.
+ *
+ * Test files are OUT of scope on purpose: a test may legitimately compare a userId for
+ * any reason.
+ *
+ * ## The disagreements this ledger records rather than normalises
+ *
+ * Consolidating these predicates surfaced four genuine inconsistencies between sites
+ * that all claim to answer the same question. They are documented as data below,
+ * because silently "fixing" any of them is a behaviour change that deserves its own
+ * decision, not a side effect of a collaborators PR:
+ *
+ *   D1. MOD BYPASS IS INCONSISTENT. `app-listing-assets::loadOwnedListing` bypasses for
+ *       moderators; `offsite-listing::loadOwnedEditableListing` and
+ *       `offsite-moderation::loadOwnedListingInTx` deliberately do NOT ("no mod
+ *       override on the author edit path"); the four `blocks.router` gates also do not.
+ *       Three sibling gates on the same objects, two answers.
+ *   D2. BAN CHECKS WERE ASYMMETRIC. `getMyAppRepo`, `updateManifest` and
+ *       `getMyForgejoCloneInfo` each carried an explicit `bannedAt` re-check;
+ *       `getMyAppManifest` did not. FIXED in this change (added, matching its siblings)
+ *       because it was plainly an omission rather than a decision.
+ *   D3. THE OWNERSHIP KEY DIFFERS. Most sites key on `AppListing.userId` or
+ *       `AppBlock.app.userId`, but `withdrawExternalRequest` keys on
+ *       `AppBlockPublishRequest.submittedByUserId` — the SUBMITTER, which after an
+ *       ownership transfer is deliberately NOT the owner. Left as-is: withdrawing your
+ *       own submission is a different question from owning the app.
+ *   D4. EARNINGS SCOPING DIVERGES BETWEEN SIBLINGS. `getMyAppAnalytics` resolves a
+ *       permitted-id set and filters by it; `getMyRevenue` filters by
+ *       `appOwnerUserId` and is user-wide. Left as-is, deliberately — see the note on
+ *       `getMyRevenue`, which must keep showing an ex-owner the money they accrued
+ *       before transferring an app away.
+ */
+
+const ROOT = process.cwd();
+
+/**
+ * EVERY production site that gates on app ownership, mapped to its collaborator
+ * decision. Update this table in the same commit as any change to the set.
+ */
+const GATE_LEDGER: Record<string, string> = {
+  'src/server/routers/blocks.router.ts':
+    'FOUR owner-scoped procs (getMyAppRepo, getMyAppManifest, updateManifest, ' +
+    'getMyForgejoCloneInfo) now route through the shared assertAppEditAccess → ' +
+    'resolveAppAccess, so an ACCEPTED collaborator reaches them and a pending/rejected ' +
+    'invitee does not. NO mod bypass — preserved exactly as it was (D1). getMyApps is ' +
+    'widened to owned+seated via getMyAppsEarnings; getMyRevenue is deliberately NOT ' +
+    'widened (D4).',
+  'src/server/services/blocks/app-listing-assets.service.ts':
+    'loadOwnedListing + resolveOwnerScreenshotTarget widened to owner | ACCEPTED ' +
+    'collaborator | moderator via resolveListingAccess. Keeps its pre-existing mod ' +
+    'bypass (D1). loadValidatedImage is NOT widened: it gates IMAGE ownership, and an ' +
+    'editor attaches their OWN uploads.',
+  'src/server/services/blocks/offsite-listing.service.ts':
+    'loadOwnedEditableListing, getMyListingForApp and submitListingRevision widened to ' +
+    'owner | ACCEPTED collaborator. Still NO mod bypass (D1). submitListingRevision ' +
+    'needed the seat check specifically because beginListingRevision clones the shadow ' +
+    'with the PARENT OWNER’s userId, so an editor’s own shadow reads as not-theirs.',
+  'src/server/services/blocks/app-analytics.service.ts':
+    'getOwnedAppBlocks resolves the permitted-id SET (owned + seated) instead of ' +
+    '`app: { userId }`. Safe to widen HERE because every downstream aggregate filters ' +
+    'appBlockId IN thatSet — unlike the appOwnerUserId-keyed earnings reads.',
+  'src/server/services/appBlockReview.service.ts':
+    'The self-review exclusion is widened to the INSIDER set (owner + accepted ' +
+    'collaborators, regardless of `displayed`) so a collaborator cannot 5-star the app ' +
+    'they co-author. Pending/rejected invitees are NOT insiders.',
+  'src/server/services/blocks/offsite-moderation.service.ts':
+    'loadOwnedListingInTx (unpublish/republish own listing) and ' +
+    'listMyListingModerationEvents are NOT widened: unpublishing a live listing and ' +
+    'reading its moderation history are OWNER-scoped lifecycle actions, not content ' +
+    'editing. Kept strictly owner-only, no mod bypass (D1).',
+  'src/server/services/blocks/app-access.service.ts':
+    'THE predicate itself — resolveAppAccess / resolveListingAccess / ' +
+    'resolveAccessibleAppBlockIds. Every other site delegates here.',
+  'src/server/services/blocks/app-collaborator.service.ts':
+    'assertOwner — seat management is OWNER-ONLY by product decision (an editor is a ' +
+    'co-owner in every respect EXCEPT managing collaborators and initiating a ' +
+    'transfer). Deliberately does NOT use resolveAppAccess, because "role !== null" is ' +
+    'the wrong question here; only `owner` may pass.',
+  'src/server/services/blocks/app-ownership-transfer.service.ts':
+    'loadOwnedApp — initiating a transfer is OWNER-ONLY, same reasoning as seat ' +
+    'management. Accept is gated on being the transfer’s ADDRESSEE, not on any role.',
+  'src/server/services/blocks/app-collaborator-earnings.service.ts':
+    'The app-scoped money read: resolves the role FIRST and filters by appBlockId + the ' +
+    'CURRENT owner. Never appOwnerUserId alone — that is the portfolio leak.',
+  'src/server/services/blocks/app-listing-mapper.ts':
+    'Reads ab.app.userId to STAMP the listing’s denormalized owner at creation. Not an ' +
+    'access gate — no caller identity is involved — but listed so the ownership-write ' +
+    'sites stay enumerated alongside the ownership-read sites.',
+  'src/server/services/blocks/app-listing-backfill.service.ts':
+    'Same as the mapper: a mod-only backfill STAMPING the denormalized owner. Not a ' +
+    'caller-identity gate.',
+  'src/pages/api/v1/blocks/dev-token.ts':
+    'NOT widened, deliberately. This is a THIRD gate shape the ledger surfaced: a ' +
+    'positive-match BRANCH CONDITION (`block.app.userId === user.id`) rather than a ' +
+    'throw or a where-clause. A non-owner simply does not enter the owned-approved ' +
+    'branch and falls through to the same 404 a missing app produces — the file is ' +
+    'explicitly built to be ORACLE-FREE. Routing it through resolveAppAccess would ' +
+    'change externally-observable behaviour for an unrelated reason, so a collaborator ' +
+    'cannot mint a dev token today; that is a follow-up decision, not a silent one.',
+  'src/server/services/block-registry.service.ts':
+    'NOT widened. resolveOwnedNonApprovedPageBlock and resolveDevPageBlockForAuthor ' +
+    'gate the DEV TUNNEL / dev-page mint by pushing `app: { userId }` into the query ' +
+    'and failing closed to null. Dev-tunnel access mints a scoped SPEND-capable token, ' +
+    'which is a wider capability than listing editing and deserves its own decision ' +
+    'rather than riding along on an editor seat.',
+  'src/server/services/blocks/buzz-attribution.service.ts':
+    'NOT a gate — listed so the population stays closed. `app.userId` here is (a) the ' +
+    'value STAMPED into BlockBuzzAttribution.appOwnerUserId at attribution time and ' +
+    '(b) the isSelfPurchase / isSelfSpend business-logic branch for revenue share. No ' +
+    'caller is being authorised. 🔴 The stamp is deliberately never rewritten by an ' +
+    'ownership transfer — see the money-invariance decision.',
+  'src/server/services/blocks/publish-request.service.ts':
+    'NOT a caller-identity gate: both sites STAMP the owner (the approve path minting ' +
+    'the listing via mapAppBlockToListing, and the backfill attributing a synthetic ' +
+    'request). 🔴 KNOWN GAP recorded here rather than fixed in this PR: submitVersion’s ' +
+    'SUBSEQUENT-version branch never checks that the submitter owns the existing app — ' +
+    'it is masked today because both HTTP callers require isModerator. If that is ever ' +
+    'opened to non-mod authors it becomes a slug-hijack vector and needs an explicit ' +
+    'owner (or collaborator) check.',
+};
+
+/**
+ * The ownership predicates, in every spelling that appears in production.
+ *
+ * `app.userId` / `app?.userId` — the canonical OauthClient owner reached via AppBlock.
+ * `resolveAppAccess` / `resolveListingAccess` / `resolveAccessibleAppBlockIds` — the
+ * consolidated predicate (a site that delegates must still be in the ledger).
+ * `assertAppEditAccess` — the blocks.router wrapper.
+ */
+const GATE_RE =
+  /app\??\.userId|app:\s*\{\s*userId|resolveAppAccess|resolveListingAccess|resolveAccessibleAppBlockIds|assertAppEditAccess|listAppInsiderUserIds|loadOwnedListingInTx/;
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === '.next' || entry === '.git') continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) walk(full, out);
+    else if (/\.tsx?$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+/** Every non-test .ts/.tsx under src/, as repo-relative POSIX-ish paths. */
+function sourceFiles(): string[] {
+  return walk(join(ROOT, 'src'))
+    .map((f) => relative(ROOT, f).split(sep).join('/'))
+    .filter((f) => !/__tests__|\.test\.tsx?$|(^|\/)src\/tests\//.test(f));
+}
+
+const FILES = sourceFiles();
+
+/**
+ * Source with comments removed — there is a LOT of prose about ownership in this
+ * codebase, and only real code should count as a gate site.
+ */
+function code(file: string): string {
+  return readFileSync(join(ROOT, file), 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+const CODE = new Map(FILES.map((f) => [f, code(f)] as const));
+const GATES = FILES.filter((f) => GATE_RE.test(CODE.get(f)!)).sort();
+
+describe('app-ownership gate ledger', () => {
+  it('POSITIVE CONTROL: the scan enumerates a real population and can match', () => {
+    // A broken walk or a regex that matches nothing would make every assertion below
+    // vacuously true. Prove the instrument works before reading its verdict.
+    expect(FILES.length).toBeGreaterThan(500);
+    expect(FILES).toContain('src/server/services/blocks/app-access.service.ts');
+    expect(GATES.length).toBeGreaterThan(5);
+  });
+
+  it('NEGATIVE CONTROL: a definitely-absent predicate matches nothing', () => {
+    const bogus = FILES.filter((f) => /resolveAppAccessNoSuchFunction/.test(CODE.get(f)!));
+    expect(bogus).toEqual([]);
+  });
+
+  it('the set of production gate sites EXACTLY equals the ledger (fails on GROWTH and on SHRINK)', () => {
+    // Enumerated equality, not containment: a 13th gated file fails here, and so does
+    // deleting one. The message names the ledger so the fix is obvious — add the file
+    // WITH its collaborator decision, or remove the stale entry.
+    expect(GATES).toEqual(Object.keys(GATE_LEDGER).sort());
+  });
+
+  it('🔴 no site re-opens a bare owner comparison against ctx.user outside the shared helper', () => {
+    // The exact shape that was open-coded four times in blocks.router.ts. Anywhere it
+    // reappears, a collaborator is being silently excluded.
+    for (const [file, src] of CODE) {
+      if (file === 'src/server/services/blocks/app-access.service.ts') continue;
+      expect(src, `${file} must not re-open-code the router owner gate`).not.toContain(
+        'app?.userId !== ctx.user'
+      );
+    }
+  });
+
+  it('every ledger entry names an actual file in the scanned population', () => {
+    for (const file of Object.keys(GATE_LEDGER)) {
+      expect(CODE.get(file), `${file} is not in the scanned population`).toBeDefined();
+    }
+  });
+
+  it('every ledger entry carries a non-trivial collaborator decision', () => {
+    // Guards against an entry added purely to make the equality test pass.
+    for (const [file, rationale] of Object.entries(GATE_LEDGER)) {
+      expect(rationale.length, `${file} rationale is too terse to be a decision`).toBeGreaterThan(80);
+      expect(
+        /collaborat|owner|seat|insider|access|widen|NOT widened|stamp|denormalized/i.test(rationale),
+        `${file} rationale must state what it decided about collaborators`
+      ).toBe(true);
+    }
+  });
+
+  it('🔴 the consolidated predicate is the ONLY place the accepted-status filter is written', () => {
+    // The consent gate is `status: 'accepted'`. If a second site writes its own seat
+    // query, that site can drift — e.g. by forgetting the status filter, which would
+    // make a PENDING invite confer capability. One home, one filter.
+    const seatQueryFiles = FILES.filter((f) => /appCollaborator\.(findFirst|findMany)/.test(CODE.get(f)!));
+    expect(seatQueryFiles.sort()).toEqual([
+      'src/server/services/blocks/app-access.service.ts',
+      // The seat-lifecycle service reads its OWN rows (roster + inbox + cap), which is
+      // management, not an access decision — it must NOT filter on accepted.
+      'src/server/services/blocks/app-collaborator.service.ts',
+    ]);
+  });
+});

--- a/src/server/services/blocks/__tests__/app-access.call-site-ledger.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.call-site-ledger.test.ts
@@ -225,9 +225,13 @@ describe('app-ownership gate ledger', () => {
   it('every ledger entry carries a non-trivial collaborator decision', () => {
     // Guards against an entry added purely to make the equality test pass.
     for (const [file, rationale] of Object.entries(GATE_LEDGER)) {
-      expect(rationale.length, `${file} rationale is too terse to be a decision`).toBeGreaterThan(80);
+      expect(rationale.length, `${file} rationale is too terse to be a decision`).toBeGreaterThan(
+        80
+      );
       expect(
-        /collaborat|owner|seat|insider|access|widen|NOT widened|stamp|denormalized/i.test(rationale),
+        /collaborat|owner|seat|insider|access|widen|NOT widened|stamp|denormalized/i.test(
+          rationale
+        ),
         `${file} rationale must state what it decided about collaborators`
       ).toBe(true);
     }
@@ -237,7 +241,9 @@ describe('app-ownership gate ledger', () => {
     // The consent gate is `status: 'accepted'`. If a second site writes its own seat
     // query, that site can drift — e.g. by forgetting the status filter, which would
     // make a PENDING invite confer capability. One home, one filter.
-    const seatQueryFiles = FILES.filter((f) => /appCollaborator\.(findFirst|findMany)/.test(CODE.get(f)!));
+    const seatQueryFiles = FILES.filter((f) =>
+      /appCollaborator\.(findFirst|findMany)/.test(CODE.get(f)!)
+    );
     expect(seatQueryFiles.sort()).toEqual([
       'src/server/services/blocks/app-access.service.ts',
       // The seat-lifecycle service reads its OWN rows (roster + inbox + cap), which is

--- a/src/server/services/blocks/__tests__/app-access.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.service.test.ts
@@ -61,18 +61,16 @@ const SEATS = [
  * against the exact bug it exists to catch.
  */
 function wireSeats(rows = SEATS) {
-  mockDb.appCollaborator.findFirst.mockImplementation(
-    async (args: unknown): Promise<unknown> => {
-      const w = (args as { where: { appBlockId: string; userId: number; status?: string } }).where;
-      const hit = rows.find(
-        (r) =>
-          r.appBlockId === w.appBlockId &&
-          r.userId === w.userId &&
-          (w.status === undefined || r.status === w.status)
-      );
-      return hit ? { userId: hit.userId } : null;
-    }
-  );
+  mockDb.appCollaborator.findFirst.mockImplementation(async (args: unknown): Promise<unknown> => {
+    const w = (args as { where: { appBlockId: string; userId: number; status?: string } }).where;
+    const hit = rows.find(
+      (r) =>
+        r.appBlockId === w.appBlockId &&
+        r.userId === w.userId &&
+        (w.status === undefined || r.status === w.status)
+    );
+    return hit ? { userId: hit.userId } : null;
+  });
   mockDb.appCollaborator.findMany.mockImplementation(async (args: unknown): Promise<unknown[]> => {
     const w = (args as { where: Record<string, unknown> }).where;
     return rows.filter(
@@ -146,17 +144,35 @@ describe('resolveListingAccess', () => {
   }
 
   it('owner of the listing → owner', async () => {
-    wireListing({ id: LISTING, userId: OWNER, appBlockId: APP, revisionOfId: null, revisionOf: null });
+    wireListing({
+      id: LISTING,
+      userId: OWNER,
+      appBlockId: APP,
+      revisionOfId: null,
+      revisionOf: null,
+    });
     expect((await resolveListingAccess(LISTING, OWNER))!.role).toBe('owner');
   });
 
   it('accepted collaborator on the backing AppBlock → editor', async () => {
-    wireListing({ id: LISTING, userId: OWNER, appBlockId: APP, revisionOfId: null, revisionOf: null });
+    wireListing({
+      id: LISTING,
+      userId: OWNER,
+      appBlockId: APP,
+      revisionOfId: null,
+      revisionOf: null,
+    });
     expect((await resolveListingAccess(LISTING, EDITOR))!.role).toBe('editor');
   });
 
   it('pending collaborator → null', async () => {
-    wireListing({ id: LISTING, userId: OWNER, appBlockId: APP, revisionOfId: null, revisionOf: null });
+    wireListing({
+      id: LISTING,
+      userId: OWNER,
+      appBlockId: APP,
+      revisionOfId: null,
+      revisionOf: null,
+    });
     expect((await resolveListingAccess(LISTING, PENDING))!.role).toBeNull();
   });
 
@@ -179,7 +195,13 @@ describe('resolveListingAccess', () => {
 
   it('a listing with NO backing AppBlock anywhere resolves owner-or-nothing', async () => {
     // A natively-created offsite listing: there is no AppBlock to seat anyone on.
-    wireListing({ id: LISTING, userId: OWNER, appBlockId: null, revisionOfId: null, revisionOf: null });
+    wireListing({
+      id: LISTING,
+      userId: OWNER,
+      appBlockId: null,
+      revisionOfId: null,
+      revisionOf: null,
+    });
     expect((await resolveListingAccess(LISTING, EDITOR))!.role).toBeNull();
     expect((await resolveListingAccess(LISTING, OWNER))!.role).toBe('owner');
   });
@@ -316,7 +338,11 @@ describe('assertAppEditAccess — the blocks.router gate', () => {
 describe('safeCollaboratorQuery — INERT until the manual-apply migration lands', () => {
   it('degrades to the fallback on Prisma P2021 (table does not exist)', async () => {
     const err = Object.assign(new Error('The table does not exist'), { code: 'P2021' });
-    expect(await safeCollaboratorQuery(async () => { throw err; }, 'FALLBACK')).toBe('FALLBACK');
+    expect(
+      await safeCollaboratorQuery(async () => {
+        throw err;
+      }, 'FALLBACK')
+    ).toBe('FALLBACK');
   });
 
   it('degrades on the raw PG SQLSTATE 42P01 too', async () => {
@@ -324,15 +350,21 @@ describe('safeCollaboratorQuery — INERT until the manual-apply migration lands
     const err = Object.assign(new Error('relation "app_collaborators" does not exist'), {
       code: '42P01',
     });
-    expect(await safeCollaboratorQuery(async () => { throw err; }, 'FALLBACK')).toBe('FALLBACK');
+    expect(
+      await safeCollaboratorQuery(async () => {
+        throw err;
+      }, 'FALLBACK')
+    ).toBe('FALLBACK');
   });
 
   it('🔴 NEGATIVE CONTROL: it does NOT swallow an unrelated error', async () => {
     // A blanket catch here would be a permanent silent-zero generator. Prove it isn't.
     const err = Object.assign(new Error('connection refused'), { code: 'P1001' });
-    await expect(safeCollaboratorQuery(async () => { throw err; }, 'FALLBACK')).rejects.toThrow(
-      'connection refused'
-    );
+    await expect(
+      safeCollaboratorQuery(async () => {
+        throw err;
+      }, 'FALLBACK')
+    ).rejects.toThrow('connection refused');
   });
 
   it('resolveAppAccess degrades to owner-only when the seat table is absent', async () => {

--- a/src/server/services/blocks/__tests__/app-access.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.service.test.ts
@@ -10,8 +10,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  * convention: a `vi.hoisted` fake client handed to BOTH `dbRead` and `dbWrite`.
  */
 
-const { mockDb } = vi.hoisted(() => ({
-  mockDb: {
+const { mockDb, mockWriteDb } = vi.hoisted(() => {
+  const make = () => ({
     appBlock: {
       findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
       // Declared here (not assigned ad-hoc in a test) so the mock's TYPE carries it —
@@ -24,10 +24,16 @@ const { mockDb } = vi.hoisted(() => ({
       findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
       findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
     },
-  },
-}));
+  });
+  // 🔴 dbRead and dbWrite are DISTINCT objects here, deliberately. A shared fake would
+  // make "did this resolve read the primary?" unanswerable — the two spies would be one
+  // spy, and a pool override that silently got dropped would look identical to one that
+  // was honoured. Every replica-vs-primary assertion in this file depends on them being
+  // two objects.
+  return { mockDb: make(), mockWriteDb: make() };
+});
 
-vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
+vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockWriteDb }));
 
 const {
   resolveAppAccess,
@@ -210,6 +216,72 @@ describe('resolveListingAccess', () => {
     wireListing(null);
     expect(await resolveListingAccess(LISTING, OWNER)).toBeNull();
   });
+
+  // -------------------------------------------------------------------------
+  // 🔴 THE POOL OVERRIDE — the editor's first media edit under replica lag.
+  // -------------------------------------------------------------------------
+
+  describe('🔴 the `db` pool override reaches the SEAT lookup, not just the listing lookup', () => {
+    /**
+     * THE SCENARIO, stated so the assertions are readable as behaviour:
+     *
+     * `app-listing-assets::loadOwnedListing` takes a `dbWrite` override so the OWNER's
+     * FIRST edit does not 404 off a lagging replica — the shadow revision was INSERTed
+     * milliseconds earlier. An EDITOR cannot benefit from that on the owner branch,
+     * because a shadow's `userId` is the PARENT OWNER's: the editor ALWAYS falls through
+     * to the collaborator check. If that check reads the replica, the identical lag that
+     * used to 404 the owner now 403s the editor instead of resolving their seat.
+     *
+     * So the primary must answer BOTH reads. `dbRead` here is wired to know NOTHING —
+     * it is the lagging replica — which is what makes a dropped override observable as a
+     * denial rather than as an equivalent answer from a second identical fixture.
+     */
+    const LAGGING = () => {
+      mockDb.appListing.findUnique.mockResolvedValue(null);
+      mockDb.appCollaborator.findFirst.mockResolvedValue(null);
+    };
+
+    beforeEach(() => {
+      LAGGING();
+      mockWriteDb.appListing.findUnique.mockResolvedValue({
+        id: SHADOW,
+        userId: OWNER,
+        appBlockId: null,
+        revisionOfId: LISTING,
+        revisionOf: { appBlockId: APP },
+      });
+      mockWriteDb.appCollaborator.findFirst.mockImplementation(async (args: unknown) => {
+        const w = (args as { where: { userId: number; status?: string } }).where;
+        return w.userId === EDITOR && w.status === 'accepted' ? { userId: EDITOR } : null;
+      });
+    });
+
+    it('the editor resolves to `editor` when the PRIMARY is passed', async () => {
+      const access = await resolveListingAccess(SHADOW, EDITOR, mockWriteDb as never);
+      expect(access!.role).toBe('editor');
+      // Both reads went to the primary…
+      expect(mockWriteDb.appListing.findUnique).toHaveBeenCalledOnce();
+      expect(mockWriteDb.appCollaborator.findFirst).toHaveBeenCalledOnce();
+      // …and NEITHER touched the replica. This is the assertion that dies when the
+      // override is threaded to the listing load but dropped before the seat lookup —
+      // the exact shape of the bug.
+      expect(mockDb.appListing.findUnique).not.toHaveBeenCalled();
+      expect(mockDb.appCollaborator.findFirst).not.toHaveBeenCalled();
+    });
+
+    it('🔴 NEGATIVE CONTROL: the SAME call off the lagging replica denies', async () => {
+      // Without this, the test above is a fact about a mock that answers either way.
+      // The replica knows nothing, so the default (no override) must fail to resolve —
+      // which is precisely the 403 the override exists to prevent.
+      expect(await resolveListingAccess(SHADOW, EDITOR)).toBeNull();
+    });
+
+    it('POSITIVE CONTROL: the two pools are distinct objects with independent spies', () => {
+      // A shared fake would make every assertion above vacuous.
+      expect(mockWriteDb).not.toBe(mockDb);
+      expect(mockWriteDb.appCollaborator.findFirst).not.toBe(mockDb.appCollaborator.findFirst);
+    });
+  });
 });
 
 describe('resolveAccessibleAppBlockIds', () => {
@@ -365,6 +437,124 @@ describe('safeCollaboratorQuery — INERT until the manual-apply migration lands
         throw err;
       }, 'FALLBACK')
     ).rejects.toThrow('connection refused');
+  });
+
+  it('the message branch still degrades when the driver attached NO code (relation missing)', async () => {
+    // The reason the message branch exists at all: some driver paths surface the raw PG
+    // text with the SQLSTATE unclassified. This must keep working after the narrowing.
+    const err = new Error('relation "app_collaborators" does not exist');
+    expect(
+      await safeCollaboratorQuery(async () => {
+        throw err;
+      }, 'FALLBACK')
+    ).toBe('FALLBACK');
+  });
+
+  it('…and on Prisma’s own P2021 wording with no code attached', async () => {
+    const err = new Error(
+      'The table `public.app_collaborators` does not exist in the current database.'
+    );
+    expect(
+      await safeCollaboratorQuery(async () => {
+        throw err;
+      }, 'FALLBACK')
+    ).toBe('FALLBACK');
+  });
+
+  describe('🔴 a HALF-APPLIED manual migration must NOT be swallowed', () => {
+    // The blast radius: migrations here are applied BY HAND (datapacket-talos DB rule
+    // #8), so "the table exists but a column is missing" is a routine intermediate state
+    // — and it is the one state where degrading to "no collaborators" is worst, because
+    // it is silent and permanent. A `/does not exist/` message test cannot tell the two
+    // apart; these cases are the mutants that prove it no longer tries.
+    const COLUMN_ERRORS: Array<[string, string]> = [
+      ['a bare missing column', 'column "displayed" does not exist'],
+      [
+        'PG 42703, which NAMES a relation and would match a relation-only regex',
+        'column "invited_by" of relation "app_collaborators" does not exist',
+      ],
+      [
+        'the Prisma-wrapped form',
+        'Invalid `prisma.appCollaborator.findMany()` invocation: The column `app_collaborators.displayed` does not exist in the current database.',
+      ],
+    ];
+
+    for (const [label, message] of COLUMN_ERRORS) {
+      it(`propagates: ${label}`, async () => {
+        await expect(
+          safeCollaboratorQuery(async () => {
+            throw new Error(message);
+          }, 'FALLBACK')
+        ).rejects.toThrow(message);
+      });
+    }
+
+    /**
+     * 🔴 THESE EXIST BECAUSE OF REDUNDANT-GUARD COVERAGE, and finding that out is why
+     * they exist at all.
+     *
+     * The narrowing is TWO clauses: a `\bcolumns?\b` veto, and a final regex that
+     * requires the missing object to be named as a RELATION or TABLE. Every case above
+     * mentions a column, so the veto alone kills them — which means a mutant that
+     * broadened the FINAL regex straight back to `/does not exist/` SURVIVED the first
+     * sweep: the veto caught the column cases and nothing else was asking.
+     *
+     * A `does not exist` message can name plenty of objects that are not columns, and
+     * these two are the ones a hand-applied migration actually produces: the enum TYPE a
+     * migration creates before its table (42704), and the SCHEMA it was pointed at
+     * (3F000). Neither contains the word "column", so ONLY the object-name clause can
+     * refuse them — which is what makes these kills attributable to that clause rather
+     * than to its neighbour.
+     */
+    const NON_COLUMN_ERRORS: Array<[string, string]> = [
+      [
+        'PG 42704 — the enum TYPE a migration creates before its table',
+        'type "app_collaborator_status" does not exist',
+      ],
+      ['PG 3F000 — the schema itself', 'schema "public_v2" does not exist'],
+    ];
+
+    for (const [label, message] of NON_COLUMN_ERRORS) {
+      it(`🔴 propagates (object-name clause, no column word to lean on): ${label}`, async () => {
+        await expect(
+          safeCollaboratorQuery(async () => {
+            throw new Error(message);
+          }, 'FALLBACK')
+        ).rejects.toThrow(message);
+      });
+    }
+
+    it('POSITIVE CONTROL: those same messages differ from a real missing TABLE only in the object named', async () => {
+      // Proves the assertions above are about the OBJECT NAME and not about some other
+      // incidental difference in the string: swap `type`/`schema` for `relation` and the
+      // very same sentence shape IS degraded.
+      expect(
+        await safeCollaboratorQuery(async () => {
+          throw new Error('relation "app_collaborator_status" does not exist');
+        }, 'FALLBACK')
+      ).toBe('FALLBACK');
+    });
+
+    it('🔴 MUTANT: broadening the message test to `not found` must not swallow either', async () => {
+      // The surviving P5 mutant. `not found` is Prisma's wording for a missing RECORD
+      // (P2025) — a normal application-level failure that must never read as "the
+      // feature is not deployed yet".
+      await expect(
+        safeCollaboratorQuery(async () => {
+          throw new Error(
+            'An operation failed because it depends on one or more records that were required but not found.'
+          );
+        }, 'FALLBACK')
+      ).rejects.toThrow('not found');
+    });
+
+    it('a non-string message is not a missing table', async () => {
+      await expect(
+        safeCollaboratorQuery(async () => {
+          throw Object.assign(new Error('x'), { message: undefined, code: 'P1017' });
+        }, 'FALLBACK')
+      ).rejects.toBeTruthy();
+    });
   });
 
   it('resolveAppAccess degrades to owner-only when the seat table is absent', async () => {

--- a/src/server/services/blocks/__tests__/app-access.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.service.test.ts
@@ -1,0 +1,348 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * App Listing COLLABORATORS — the consolidated access predicate.
+ *
+ * THE PERMISSION MATRIX lives here: role × subject × expected, across
+ * owner / accepted editor / PENDING editor / REJECTED editor / stranger / anon.
+ *
+ * All DB deps are mocked (no real Prisma), following the sibling block-service
+ * convention: a `vi.hoisted` fake client handed to BOTH `dbRead` and `dbWrite`.
+ */
+
+const { mockDb } = vi.hoisted(() => ({
+  mockDb: {
+    appBlock: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      // Declared here (not assigned ad-hoc in a test) so the mock's TYPE carries it —
+      // `tsconfig.json` EXCLUDES `src/**/__tests__/**`, so a green `pnpm typecheck`
+      // says nothing about this file and only an explicit test typecheck catches it.
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    },
+    appListing: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    appCollaborator: {
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    },
+  },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
+
+const {
+  resolveAppAccess,
+  resolveListingAccess,
+  resolveAccessibleAppBlockIds,
+  listDisplayedCollaboratorUserIds,
+  listAppInsiderUserIds,
+  safeCollaboratorQuery,
+  assertAppEditAccess,
+} = await import('~/server/services/blocks/app-access.service');
+
+const APP = 'ab_app1';
+const OWNER = 10;
+const EDITOR = 20;
+const PENDING = 30;
+const REJECTED = 40;
+const STRANGER = 50;
+
+/** The seat table, as the fixture DB holds it. */
+const SEATS = [
+  { appBlockId: APP, userId: EDITOR, status: 'accepted', displayed: true },
+  { appBlockId: APP, userId: PENDING, status: 'pending', displayed: true },
+  { appBlockId: APP, userId: REJECTED, status: 'rejected', displayed: true },
+];
+
+/**
+ * Drive `appCollaborator.findFirst` from the fixture, HONOURING the `status` filter.
+ *
+ * 🔴 Load-bearing: a mock that ignored `where.status` would make every consent test
+ * pass vacuously — a pending seat would read as accepted and the suite would be green
+ * against the exact bug it exists to catch.
+ */
+function wireSeats(rows = SEATS) {
+  mockDb.appCollaborator.findFirst.mockImplementation(
+    async (args: unknown): Promise<unknown> => {
+      const w = (args as { where: { appBlockId: string; userId: number; status?: string } }).where;
+      const hit = rows.find(
+        (r) =>
+          r.appBlockId === w.appBlockId &&
+          r.userId === w.userId &&
+          (w.status === undefined || r.status === w.status)
+      );
+      return hit ? { userId: hit.userId } : null;
+    }
+  );
+  mockDb.appCollaborator.findMany.mockImplementation(async (args: unknown): Promise<unknown[]> => {
+    const w = (args as { where: Record<string, unknown> }).where;
+    return rows.filter(
+      (r) =>
+        (w.appBlockId === undefined || r.appBlockId === w.appBlockId) &&
+        (w.userId === undefined || r.userId === w.userId) &&
+        (w.status === undefined || r.status === w.status) &&
+        (w.displayed === undefined || r.displayed === w.displayed)
+    );
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDb.appBlock.findUnique.mockResolvedValue({ id: APP, app: { userId: OWNER } });
+  wireSeats();
+});
+
+describe('resolveAppAccess — the permission matrix', () => {
+  const CASES: Array<[string, number | null, 'owner' | 'editor' | null]> = [
+    ['owner', OWNER, 'owner'],
+    ['accepted editor', EDITOR, 'editor'],
+    // 🔴 THE CONSENT ROWS. A pending or rejected invite must confer ZERO capability —
+    // otherwise anyone's name can be attached to a listing, and worse, an uninvited
+    // stranger could be granted repo write by an owner unilaterally.
+    ['PENDING editor', PENDING, null],
+    ['REJECTED editor', REJECTED, null],
+    ['stranger', STRANGER, null],
+    ['anonymous', null, null],
+  ];
+
+  for (const [label, userId, expected] of CASES) {
+    it(`${label} → role ${expected ?? 'null'}`, async () => {
+      const access = await resolveAppAccess(APP, userId);
+      expect(access).not.toBeNull();
+      expect(access!.role).toBe(expected);
+      expect(access!.ownerUserId).toBe(OWNER);
+    });
+  }
+
+  it('POSITIVE CONTROL: the seat mock honours the status filter', async () => {
+    // If this were not true, the PENDING/REJECTED rows above would pass vacuously.
+    const asAccepted = await mockDb.appCollaborator.findFirst({
+      where: { appBlockId: APP, userId: PENDING, status: 'accepted' },
+    });
+    const asAny = await mockDb.appCollaborator.findFirst({
+      where: { appBlockId: APP, userId: PENDING },
+    });
+    expect(asAccepted).toBeNull();
+    expect(asAny).toEqual({ userId: PENDING });
+  });
+
+  it('a missing AppBlock resolves null (not a role)', async () => {
+    mockDb.appBlock.findUnique.mockResolvedValue(null);
+    expect(await resolveAppAccess(APP, OWNER)).toBeNull();
+  });
+
+  it('an AppBlock with no resolvable owner resolves null — fail closed', async () => {
+    // A dangling app_id: an app nobody owns is an app nobody may edit.
+    mockDb.appBlock.findUnique.mockResolvedValue({ id: APP, app: null });
+    expect(await resolveAppAccess(APP, OWNER)).toBeNull();
+  });
+});
+
+describe('resolveListingAccess', () => {
+  const LISTING = 'apl_live';
+  const SHADOW = 'apl_shadow';
+
+  function wireListing(row: Record<string, unknown> | null) {
+    mockDb.appListing.findUnique.mockResolvedValue(row);
+  }
+
+  it('owner of the listing → owner', async () => {
+    wireListing({ id: LISTING, userId: OWNER, appBlockId: APP, revisionOfId: null, revisionOf: null });
+    expect((await resolveListingAccess(LISTING, OWNER))!.role).toBe('owner');
+  });
+
+  it('accepted collaborator on the backing AppBlock → editor', async () => {
+    wireListing({ id: LISTING, userId: OWNER, appBlockId: APP, revisionOfId: null, revisionOf: null });
+    expect((await resolveListingAccess(LISTING, EDITOR))!.role).toBe('editor');
+  });
+
+  it('pending collaborator → null', async () => {
+    wireListing({ id: LISTING, userId: OWNER, appBlockId: APP, revisionOfId: null, revisionOf: null });
+    expect((await resolveListingAccess(LISTING, PENDING))!.role).toBeNull();
+  });
+
+  it('🔴 SHADOW-AWARE: an editor keeps access to a shadow revision (appBlockId is NULL on it)', async () => {
+    // A shadow carries appBlockId: null by construction (`appBlockId` is @unique and
+    // stays on the parent). Without the revisionOf hop, an editor would LOSE access the
+    // instant their first media edit minted the shadow — i.e. the feature would break
+    // on its own second click.
+    wireListing({
+      id: SHADOW,
+      userId: OWNER,
+      appBlockId: null,
+      revisionOfId: LISTING,
+      revisionOf: { appBlockId: APP },
+    });
+    const access = await resolveListingAccess(SHADOW, EDITOR);
+    expect(access!.appBlockId).toBe(APP);
+    expect(access!.role).toBe('editor');
+  });
+
+  it('a listing with NO backing AppBlock anywhere resolves owner-or-nothing', async () => {
+    // A natively-created offsite listing: there is no AppBlock to seat anyone on.
+    wireListing({ id: LISTING, userId: OWNER, appBlockId: null, revisionOfId: null, revisionOf: null });
+    expect((await resolveListingAccess(LISTING, EDITOR))!.role).toBeNull();
+    expect((await resolveListingAccess(LISTING, OWNER))!.role).toBe('owner');
+  });
+
+  it('a missing listing resolves null', async () => {
+    wireListing(null);
+    expect(await resolveListingAccess(LISTING, OWNER)).toBeNull();
+  });
+});
+
+describe('resolveAccessibleAppBlockIds', () => {
+  const OTHER = 'ab_app2';
+
+  beforeEach(() => {
+    mockDb.appBlock.findUnique.mockResolvedValue({ id: APP, app: { userId: OWNER } });
+  });
+
+  it('an owner gets their owned ids and no editor ids', async () => {
+    mockDb.appBlock.findMany.mockResolvedValue([{ id: APP }, { id: OTHER }]);
+    wireSeats([]);
+    const res = await resolveAccessibleAppBlockIds(OWNER);
+    expect(res.ownedIds.sort()).toEqual([APP, OTHER].sort());
+    expect(res.editorIds).toEqual([]);
+    expect(res.allIds.sort()).toEqual([APP, OTHER].sort());
+  });
+
+  it('an editor gets ONLY the seated app — never the owner’s other apps', async () => {
+    // The editor owns nothing; their seat is on APP only. OTHER must not appear.
+    mockDb.appBlock.findMany.mockResolvedValue([]);
+    wireSeats([{ appBlockId: APP, userId: EDITOR, status: 'accepted', displayed: true }]);
+    const res = await resolveAccessibleAppBlockIds(EDITOR);
+    expect(res.ownedIds).toEqual([]);
+    expect(res.editorIds).toEqual([APP]);
+    expect(res.allIds).toEqual([APP]);
+    expect(res.allIds).not.toContain(OTHER);
+  });
+
+  it('a PENDING seat contributes nothing', async () => {
+    mockDb.appBlock.findMany.mockResolvedValue([]);
+    wireSeats([{ appBlockId: APP, userId: PENDING, status: 'pending', displayed: true }]);
+    expect((await resolveAccessibleAppBlockIds(PENDING)).allIds).toEqual([]);
+  });
+
+  it('owned and editor sets are disjoint — an owner who also holds a seat counts once', async () => {
+    mockDb.appBlock.findMany.mockResolvedValue([{ id: APP }]);
+    wireSeats([{ appBlockId: APP, userId: OWNER, status: 'accepted', displayed: true }]);
+    const res = await resolveAccessibleAppBlockIds(OWNER);
+    expect(res.editorIds).toEqual([]);
+    expect(res.allIds).toEqual([APP]);
+  });
+});
+
+describe('listDisplayedCollaboratorUserIds vs listAppInsiderUserIds — the displayed asymmetry', () => {
+  const HIDDEN = 60;
+
+  beforeEach(() => {
+    mockDb.appBlock.findUnique.mockResolvedValue({ id: APP, app: { userId: OWNER } });
+    wireSeats([
+      { appBlockId: APP, userId: EDITOR, status: 'accepted', displayed: true },
+      { appBlockId: APP, userId: HIDDEN, status: 'accepted', displayed: false },
+      { appBlockId: APP, userId: PENDING, status: 'pending', displayed: true },
+      { appBlockId: APP, userId: REJECTED, status: 'rejected', displayed: true },
+    ]);
+  });
+
+  it('the PUBLIC byline is accepted AND displayed only', async () => {
+    expect(await listDisplayedCollaboratorUserIds(APP)).toEqual([EDITOR]);
+  });
+
+  it('🔴 the INSIDER set ignores `displayed` — hiding your byline is not a self-review bypass', async () => {
+    const insiders = await listAppInsiderUserIds(APP);
+    expect(insiders).toContain(OWNER);
+    expect(insiders).toContain(EDITOR);
+    // The whole point: HIDDEN is invisible publicly but is still an insider.
+    expect(insiders).toContain(HIDDEN);
+    // …and a mere invite is NOT an insider (an owner must not be able to silence a
+    // critic by inviting them).
+    expect(insiders).not.toContain(PENDING);
+    expect(insiders).not.toContain(REJECTED);
+  });
+});
+
+describe('assertAppEditAccess — the blocks.router gate', () => {
+  // 🔴 This guard had NO behavioural test until a mutation sweep surfaced it: deleting
+  // it left every suite green, because the only thing "covering" it was a structural
+  // ledger assertion that never executes the guard. That is the unreachable-guard trap
+  // in its purest form — a check whose coverage was a fact about a grep.
+  const gate = (userId: number, ownerUserId: number | null = OWNER) =>
+    assertAppEditAccess({ appBlockId: APP, ownerUserId, userId });
+
+  it('the OWNER passes', async () => {
+    await expect(gate(OWNER)).resolves.toBeUndefined();
+  });
+
+  it('the owner path costs NO extra query (the owner is passed in, not re-read)', async () => {
+    await gate(OWNER);
+    expect(mockDb.appCollaborator.findFirst).not.toHaveBeenCalled();
+    expect(mockDb.appBlock.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('an ACCEPTED collaborator passes', async () => {
+    await expect(gate(EDITOR)).resolves.toBeUndefined();
+  });
+
+  it('a PENDING invitee is refused with THIS guard’s exact message', async () => {
+    // The message is asserted verbatim so a mutant that breaks this guard dies to THIS
+    // error and cannot be confused with a neighbouring gate's.
+    await expect(gate(PENDING)).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'Not the app owner',
+    });
+  });
+
+  it('a REJECTED invitee is refused', async () => {
+    await expect(gate(REJECTED)).rejects.toMatchObject({ message: 'Not the app owner' });
+  });
+
+  it('a stranger is refused', async () => {
+    await expect(gate(STRANGER)).rejects.toMatchObject({ message: 'Not the app owner' });
+  });
+
+  it('🔴 NO MODERATOR BYPASS — preserved from before collaborators (ledger D1)', async () => {
+    // These four router procs always refused a non-owning moderator. This change must
+    // not quietly grant mods a capability they did not have; the gate takes no
+    // isModerator input at all, which is what makes that structural.
+    await expect(gate(STRANGER)).rejects.toBeTruthy();
+  });
+
+  it('an app with NO resolvable owner is refused (fail closed), not allowed', async () => {
+    await expect(gate(OWNER, null)).rejects.toMatchObject({ message: 'Not the app owner' });
+  });
+});
+
+describe('safeCollaboratorQuery — INERT until the manual-apply migration lands', () => {
+  it('degrades to the fallback on Prisma P2021 (table does not exist)', async () => {
+    const err = Object.assign(new Error('The table does not exist'), { code: 'P2021' });
+    expect(await safeCollaboratorQuery(async () => { throw err; }, 'FALLBACK')).toBe('FALLBACK');
+  });
+
+  it('degrades on the raw PG SQLSTATE 42P01 too', async () => {
+    // Matching P2021 alone let a raw-path failure through; both are handled.
+    const err = Object.assign(new Error('relation "app_collaborators" does not exist'), {
+      code: '42P01',
+    });
+    expect(await safeCollaboratorQuery(async () => { throw err; }, 'FALLBACK')).toBe('FALLBACK');
+  });
+
+  it('🔴 NEGATIVE CONTROL: it does NOT swallow an unrelated error', async () => {
+    // A blanket catch here would be a permanent silent-zero generator. Prove it isn't.
+    const err = Object.assign(new Error('connection refused'), { code: 'P1001' });
+    await expect(safeCollaboratorQuery(async () => { throw err; }, 'FALLBACK')).rejects.toThrow(
+      'connection refused'
+    );
+  });
+
+  it('resolveAppAccess degrades to owner-only when the seat table is absent', async () => {
+    mockDb.appBlock.findUnique.mockResolvedValue({ id: APP, app: { userId: OWNER } });
+    mockDb.appCollaborator.findFirst.mockRejectedValue(
+      Object.assign(new Error('does not exist'), { code: 'P2021' })
+    );
+    // Byte-identical to the pre-change behaviour: owner yes, everyone else no —
+    // and crucially NOT a 500 on every app page.
+    expect((await resolveAppAccess(APP, OWNER))!.role).toBe('owner');
+    expect((await resolveAppAccess(APP, EDITOR))!.role).toBeNull();
+  });
+});

--- a/src/server/services/blocks/__tests__/app-analytics.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-analytics.service.test.ts
@@ -15,6 +15,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const { mockDbRead } = vi.hoisted(() => ({
   mockDbRead: {
     appBlock: { findMany: vi.fn() },
+    // App Listing COLLABORATORS: the widened gates consult the seat table on the
+    // NON-owner path. `safeCollaboratorQuery` deliberately swallows ONLY the
+    // missing-TABLE error, so an absent mock surfaces as a TypeError rather than
+    // being silently absorbed — which is why this fixture must declare it.
+    appCollaborator: { findFirst: vi.fn(async () => null), findMany: vi.fn(async () => []) },
     blockUserSubscription: { count: vi.fn() },
     blockSpendAttribution: { aggregate: vi.fn() },
     blockBuzzAttribution: { aggregate: vi.fn() },
@@ -179,12 +184,21 @@ describe('getOwnedAppBlockIds (ownership resolution)', () => {
   it('returns all owned ids when no specific id is requested', async () => {
     const ids = await getOwnedAppBlockIds({ ownerUserId: OWNER_ID });
     expect(ids).toEqual([OWNED_ID, OWNED_ID_2]);
-    expect(mockDbRead.appBlock.findMany).toHaveBeenCalledWith({
-      where: { app: { userId: OWNER_ID } },
+    // App Listing COLLABORATORS: the final select is now filtered by the RESOLVED
+    // permitted-id set (owned + accepted seats), not by a bare `app: { userId }` —
+    // which would drop every app the caller holds a collaborator seat on. The
+    // ownership resolve itself is the FIRST findMany call; this asserts the SECOND.
+    expect(mockDbRead.appBlock.findMany).toHaveBeenLastCalledWith({
+      where: { id: { in: [OWNED_ID, OWNED_ID_2] } },
       // `manifest` rides along on this one query — the installs applicability
       // discriminator needs it, and getMyAppAnalytics is on a per-app fan-out
       // path where a second round trip would be paid N times per page load.
       select: { id: true, manifest: true },
+    });
+    // …and the resolve step really did ask the owner question.
+    expect(mockDbRead.appBlock.findMany).toHaveBeenNthCalledWith(1, {
+      where: { app: { userId: OWNER_ID } },
+      select: { id: true },
     });
   });
 

--- a/src/server/services/blocks/__tests__/app-collaborator-earnings.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator-earnings.service.test.ts
@@ -1,0 +1,283 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * 🔴 THE PORTFOLIO-LEAK REGRESSION TEST. This is the highest-risk item in the
+ * collaborators feature and this suite is its guard.
+ *
+ * THE FIXTURE IS THE POINT: the owner has TWO apps and the editor is seated on ONE.
+ * A one-app fixture cannot distinguish the correct implementation from the leaking one,
+ * because with a single app "everything the owner has" and "the shared app" are the
+ * same set. Every assertion below therefore names APP_B (the app the editor was never
+ * invited to) explicitly.
+ *
+ * 🔴 WATCHED TO FAIL FIRST. Before the real implementation existed, the same fixture
+ * was run against the NAIVE implementation — reusing the pre-existing
+ * `appOwnerUserId`-keyed filter with the OWNER's id, which is the obvious way to make
+ * an editor see any earnings at all. It returned BOTH apps, and this suite went red
+ * with `expected [ 'ab_appA', 'ab_appB' ] not to contain 'ab_appB'`. That is the
+ * defect this file exists to keep out.
+ */
+
+const { mockDb } = vi.hoisted(() => ({
+  mockDb: {
+    appBlock: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    },
+    appCollaborator: {
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    },
+    blockBuzzAttribution: {
+      aggregate: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({})),
+      groupBy: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    },
+  },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
+
+const { getAppEarnings, getMyAppsEarnings } = await import(
+  '~/server/services/blocks/app-collaborator-earnings.service'
+);
+
+const APP_A = 'ab_appA'; // shared with the editor
+const APP_B = 'ab_appB'; // 🔴 the owner's OTHER app — must never surface to the editor
+const OWNER = 100;
+const EDITOR = 200;
+const STRANGER = 300;
+
+/** Every attribution row in the fixture DB, per app. */
+const LEDGER = [
+  { appBlockId: APP_A, appOwnerUserId: OWNER, status: 'confirmed', share: 500, gross: 1000 },
+  { appBlockId: APP_A, appOwnerUserId: OWNER, status: 'paid_out', share: 250, gross: 500 },
+  // APP_B is far more lucrative — so a leak is unmissable in the numbers, not just
+  // in the id list.
+  { appBlockId: APP_B, appOwnerUserId: OWNER, status: 'confirmed', share: 999_999, gross: 1_999_999 },
+];
+
+/**
+ * A `groupBy` fake that HONOURS the `where` clause it is handed.
+ *
+ * 🔴 This is the instrument, so validate it before reading its verdict: a fake that
+ * ignored `where.appBlockId` would return everything to everybody and make the leak
+ * assertions fail even for a correct implementation — or, worse, a fake that returned
+ * a hardcoded single row would make them PASS for a leaking one. The positive/negative
+ * control test at the bottom of this describe exercises both directions.
+ */
+function wireGroupBy() {
+  mockDb.blockBuzzAttribution.groupBy.mockImplementation(async (args: unknown) => {
+    const w = (args as { where: { appBlockId?: { in?: string[] }; status?: { in?: string[] } } })
+      .where;
+    const allowed = w.appBlockId?.in;
+    const statuses = w.status?.in ?? ['confirmed', 'paid_out'];
+    const rows = LEDGER.filter(
+      (r) => (allowed === undefined || allowed.includes(r.appBlockId)) && statuses.includes(r.status)
+    );
+    const acc = new Map<string, { appBlockId: string; appOwnerUserId: number; share: number; n: number }>();
+    for (const r of rows) {
+      const k = `${r.appBlockId}:${r.appOwnerUserId}`;
+      const prev = acc.get(k) ?? {
+        appBlockId: r.appBlockId,
+        appOwnerUserId: r.appOwnerUserId,
+        share: 0,
+        n: 0,
+      };
+      acc.set(k, { ...prev, share: prev.share + r.share, n: prev.n + 1 });
+    }
+    return [...acc.values()].map((v) => ({
+      appBlockId: v.appBlockId,
+      appOwnerUserId: v.appOwnerUserId,
+      _sum: { appOwnerShareCents: v.share },
+      _count: v.n,
+    }));
+  });
+}
+
+/** An `aggregate` fake that honours appBlockId + appOwnerUserId + status. */
+function wireAggregate() {
+  mockDb.blockBuzzAttribution.aggregate.mockImplementation(async (args: unknown) => {
+    const w = (args as {
+      where: { appBlockId?: string; appOwnerUserId?: number; status?: string };
+    }).where;
+    const rows = LEDGER.filter(
+      (r) =>
+        (w.appBlockId === undefined || r.appBlockId === w.appBlockId) &&
+        (w.appOwnerUserId === undefined || r.appOwnerUserId === w.appOwnerUserId) &&
+        (w.status === undefined || r.status === w.status)
+    );
+    return {
+      _count: rows.length,
+      _sum: {
+        usdAmountCents: rows.reduce((s, r) => s + r.gross, 0),
+        appOwnerShareCents: rows.reduce((s, r) => s + r.share, 0),
+      },
+    };
+  });
+}
+
+/** Owner owns both apps; the editor holds an ACCEPTED seat on APP_A only. */
+function wireAccess() {
+  mockDb.appBlock.findUnique.mockImplementation(async (args: unknown) => {
+    const id = (args as { where: { id: string } }).where.id;
+    if (id !== APP_A && id !== APP_B) return null;
+    return { id, app: { userId: OWNER } };
+  });
+  mockDb.appBlock.findMany.mockImplementation(async (args: unknown) => {
+    const w = (args as { where: Record<string, unknown> }).where;
+    if ((w as { app?: { userId: number } }).app) {
+      return (w as { app: { userId: number } }).app.userId === OWNER
+        ? [{ id: APP_A, app: { userId: OWNER } }, { id: APP_B, app: { userId: OWNER } }]
+        : [];
+    }
+    const ids = (w as { id?: { in: string[] } }).id?.in ?? [];
+    return ids.map((id) => ({ id, app: { userId: OWNER } }));
+  });
+  mockDb.appCollaborator.findFirst.mockImplementation(async (args: unknown) => {
+    const w = (args as { where: { appBlockId: string; userId: number; status?: string } }).where;
+    const ok = w.appBlockId === APP_A && w.userId === EDITOR && w.status === 'accepted';
+    return ok ? { userId: EDITOR } : null;
+  });
+  mockDb.appCollaborator.findMany.mockImplementation(async (args: unknown) => {
+    const w = (args as { where: { userId?: number; status?: string } }).where;
+    return w.userId === EDITOR && w.status === 'accepted' ? [{ appBlockId: APP_A }] : [];
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  wireAccess();
+  wireGroupBy();
+  wireAggregate();
+});
+
+describe('getMyAppsEarnings — 🔴 the editor must never see the owner’s other app', () => {
+  it('INSTRUMENT CONTROLS: the groupBy fake both filters and can return multiple apps', async () => {
+    // POSITIVE — an unrestricted call sees BOTH apps (so a later "only APP_A" result is
+    // a fact about the code, not about a fake that can only ever return one row).
+    const all = (await mockDb.blockBuzzAttribution.groupBy({
+      where: { status: { in: ['confirmed', 'paid_out'] } },
+    })) as Array<{ appBlockId: string; _count: number }>;
+    // Grouped by (appBlockId, appOwnerUserId), so APP_A's two rows collapse to ONE
+    // group of count 2 — asserting the count too proves the fake really aggregates
+    // rather than returning a canned pair.
+    expect(all.map((r) => r.appBlockId).sort()).toEqual([APP_A, APP_B]);
+    expect(all.find((r) => r.appBlockId === APP_A)!._count).toBe(2);
+    // NEGATIVE — the filter genuinely bites: APP_B disappears when excluded.
+    const only = (await mockDb.blockBuzzAttribution.groupBy({
+      where: { appBlockId: { in: [APP_A] }, status: { in: ['confirmed', 'paid_out'] } },
+    })) as Array<{ appBlockId: string }>;
+    expect(only.map((r) => r.appBlockId)).toEqual([APP_A]);
+  });
+
+  it('the OWNER sees both of their apps', async () => {
+    const rows = await getMyAppsEarnings({ userId: OWNER });
+    expect(rows.map((r) => r.appBlockId).sort()).toEqual([APP_A, APP_B].sort());
+    expect(rows.every((r) => r.role === 'owner')).toBe(true);
+  });
+
+  it('🔴 the EDITOR sees ONLY the shared app — APP_B is absent', async () => {
+    const rows = await getMyAppsEarnings({ userId: EDITOR });
+    const ids = rows.map((r) => r.appBlockId);
+    expect(ids).toEqual([APP_A]);
+    // Stated as its own assertion so the failure message names the leak directly.
+    expect(ids).not.toContain(APP_B);
+  });
+
+  it('🔴 the EDITOR’s totals equal APP_A’s alone — not the portfolio total', async () => {
+    // A leak that returned the right id list but the wrong SUM would pass the id
+    // assertion above. Pin the number too.
+    const rows = await getMyAppsEarnings({ userId: EDITOR });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].lifetimeShareCents).toBe(750); // 500 confirmed + 250 paid_out
+    expect(rows[0].lifetimeShareCents).not.toBe(750 + 999_999);
+    expect(rows[0].role).toBe('editor');
+  });
+
+  it('a stranger sees nothing', async () => {
+    expect(await getMyAppsEarnings({ userId: STRANGER })).toEqual([]);
+  });
+
+  it('🔴 STRUCTURAL: the groupBy is filtered by `appBlockId IN <permitted set>`', async () => {
+    // A mutation sweep showed the id-list assertions alone SURVIVE removal of this
+    // filter, because the final `allIds.map` is a second, independent barrier that
+    // hides the leak in the OUTPUT while the QUERY still fetched the owner's whole
+    // portfolio. Defence in depth is good; relying on it to be the only guard is not —
+    // the rows are in memory either way, and the next refactor of that map re-opens it.
+    await getMyAppsEarnings({ userId: EDITOR });
+    const args = mockDb.blockBuzzAttribution.groupBy.mock.calls[0][0] as {
+      where: { appBlockId?: { in: string[] }; appOwnerUserId?: number };
+    };
+    expect(args.where.appBlockId, 'the app-scope filter must be present').toBeDefined();
+    expect(args.where.appBlockId!.in).toEqual([APP_A]);
+    expect(args.where.appBlockId!.in).not.toContain(APP_B);
+    // …and NEVER an appOwnerUserId-only filter, which is the user-wide axis.
+    expect(args.where.appOwnerUserId).toBeUndefined();
+  });
+
+  it('🔴 pre-transfer rows attributed to a PREVIOUS owner are excluded', async () => {
+    // The transfer decision leaves `appOwnerUserId` alone, so an app-scoped query on
+    // appBlockId ALONE would show the new owner the old owner's money. The second
+    // scope axis (current owner) is what stops that.
+    mockDb.blockBuzzAttribution.groupBy.mockResolvedValue([
+      { appBlockId: APP_A, appOwnerUserId: OWNER, _sum: { appOwnerShareCents: 750 }, _count: 2 },
+      // An OLD owner's rows on the same app.
+      { appBlockId: APP_A, appOwnerUserId: 999, _sum: { appOwnerShareCents: 424_242 }, _count: 7 },
+    ]);
+    const rows = await getMyAppsEarnings({ userId: EDITOR });
+    expect(rows[0].lifetimeShareCents).toBe(750);
+    expect(rows[0].lifetimeCount).toBe(2);
+  });
+});
+
+describe('getAppEarnings — per-app, fail-closed', () => {
+  it('the owner reads the app’s summary', async () => {
+    const res = await getAppEarnings({ appBlockId: APP_A, userId: OWNER });
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error('unreachable');
+    expect(res.role).toBe('owner');
+    expect(res.summary.confirmed.shareCents).toBe(500);
+    expect(res.summary.paidOut.shareCents).toBe(250);
+  });
+
+  it('the accepted editor reads the SHARED app’s summary', async () => {
+    const res = await getAppEarnings({ appBlockId: APP_A, userId: EDITOR });
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error('unreachable');
+    expect(res.role).toBe('editor');
+    expect(res.summary.confirmed.shareCents).toBe(500);
+  });
+
+  it('🔴 the editor is REFUSED on the owner’s other app — and no aggregate is run', async () => {
+    const res = await getAppEarnings({ appBlockId: APP_B, userId: EDITOR });
+    expect(res).toEqual({ ok: false, appBlockId: APP_B, reason: 'notPermitted' });
+    // Fail-closed means fail EARLY: refusing after running the query would still have
+    // put the owner's numbers in memory on this request.
+    expect(mockDb.blockBuzzAttribution.aggregate).not.toHaveBeenCalled();
+  });
+
+  it('🔴 refusal is `notPermitted`, NOT a zeroed summary', async () => {
+    // A zero here would be indistinguishable from "this app earned nothing" — the
+    // fabricated-zero trap. The discriminated union makes that unrepresentable.
+    const res = await getAppEarnings({ appBlockId: APP_B, userId: STRANGER });
+    expect(res.ok).toBe(false);
+    expect(res).not.toHaveProperty('summary');
+  });
+
+  it('a missing app is `notFound`, distinct from `notPermitted`', async () => {
+    const res = await getAppEarnings({ appBlockId: 'ab_nope', userId: OWNER });
+    expect(res).toEqual({ ok: false, appBlockId: 'ab_nope', reason: 'notFound' });
+  });
+
+  it('🔴 the query carries BOTH scopes (appBlockId AND the current owner)', async () => {
+    // A structural assertion on the WHERE clause, because dropping either axis is the
+    // leak and a numeric assertion alone would not localise which axis went missing.
+    await getAppEarnings({ appBlockId: APP_A, userId: EDITOR });
+    const calls = mockDb.blockBuzzAttribution.aggregate.mock.calls as Array<[{ where: Record<string, unknown> }]>;
+    expect(calls.length).toBeGreaterThan(0);
+    for (const [args] of calls) {
+      expect(args.where.appBlockId).toBe(APP_A);
+      expect(args.where.appOwnerUserId).toBe(OWNER);
+    }
+  });
+});

--- a/src/server/services/blocks/__tests__/app-collaborator-earnings.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator-earnings.service.test.ts
@@ -53,7 +53,13 @@ const LEDGER = [
   { appBlockId: APP_A, appOwnerUserId: OWNER, status: 'paid_out', share: 250, gross: 500 },
   // APP_B is far more lucrative — so a leak is unmissable in the numbers, not just
   // in the id list.
-  { appBlockId: APP_B, appOwnerUserId: OWNER, status: 'confirmed', share: 999_999, gross: 1_999_999 },
+  {
+    appBlockId: APP_B,
+    appOwnerUserId: OWNER,
+    status: 'confirmed',
+    share: 999_999,
+    gross: 1_999_999,
+  },
 ];
 
 /**
@@ -72,9 +78,13 @@ function wireGroupBy() {
     const allowed = w.appBlockId?.in;
     const statuses = w.status?.in ?? ['confirmed', 'paid_out'];
     const rows = LEDGER.filter(
-      (r) => (allowed === undefined || allowed.includes(r.appBlockId)) && statuses.includes(r.status)
+      (r) =>
+        (allowed === undefined || allowed.includes(r.appBlockId)) && statuses.includes(r.status)
     );
-    const acc = new Map<string, { appBlockId: string; appOwnerUserId: number; share: number; n: number }>();
+    const acc = new Map<
+      string,
+      { appBlockId: string; appOwnerUserId: number; share: number; n: number }
+    >();
     for (const r of rows) {
       const k = `${r.appBlockId}:${r.appOwnerUserId}`;
       const prev = acc.get(k) ?? {
@@ -97,9 +107,11 @@ function wireGroupBy() {
 /** An `aggregate` fake that honours appBlockId + appOwnerUserId + status. */
 function wireAggregate() {
   mockDb.blockBuzzAttribution.aggregate.mockImplementation(async (args: unknown) => {
-    const w = (args as {
-      where: { appBlockId?: string; appOwnerUserId?: number; status?: string };
-    }).where;
+    const w = (
+      args as {
+        where: { appBlockId?: string; appOwnerUserId?: number; status?: string };
+      }
+    ).where;
     const rows = LEDGER.filter(
       (r) =>
         (w.appBlockId === undefined || r.appBlockId === w.appBlockId) &&
@@ -127,7 +139,10 @@ function wireAccess() {
     const w = (args as { where: Record<string, unknown> }).where;
     if ((w as { app?: { userId: number } }).app) {
       return (w as { app: { userId: number } }).app.userId === OWNER
-        ? [{ id: APP_A, app: { userId: OWNER } }, { id: APP_B, app: { userId: OWNER } }]
+        ? [
+            { id: APP_A, app: { userId: OWNER } },
+            { id: APP_B, app: { userId: OWNER } },
+          ]
         : [];
     }
     const ids = (w as { id?: { in: string[] } }).id?.in ?? [];
@@ -273,7 +288,9 @@ describe('getAppEarnings — per-app, fail-closed', () => {
     // A structural assertion on the WHERE clause, because dropping either axis is the
     // leak and a numeric assertion alone would not localise which axis went missing.
     await getAppEarnings({ appBlockId: APP_A, userId: EDITOR });
-    const calls = mockDb.blockBuzzAttribution.aggregate.mock.calls as Array<[{ where: Record<string, unknown> }]>;
+    const calls = mockDb.blockBuzzAttribution.aggregate.mock.calls as Array<
+      [{ where: Record<string, unknown> }]
+    >;
     expect(calls.length).toBeGreaterThan(0);
     for (const [args] of calls) {
       expect(args.where.appBlockId).toBe(APP_A);

--- a/src/server/services/blocks/__tests__/app-collaborator.cli-contract.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator.cli-contract.test.ts
@@ -1,0 +1,164 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  addListingScreenshotSchema,
+  removeListingScreenshotSchema,
+  reorderListingScreenshotsSchema,
+  setListingCoverSchema,
+  setListingIconSchema,
+  updateListingScreenshotCaptionSchema,
+} from '~/server/schema/blocks/app-listing.schema';
+import {
+  beginListingRevisionSchema,
+  getMyListingForAppSchema,
+  submitListingRevisionSchema,
+} from '~/server/schema/blocks/offsite-listing.schema';
+
+/**
+ * 🔴 THE CLI WIRE CONTRACT.
+ *
+ * The listing-media procs are CLI-reachable: `civitai login` mints a SCOPED OAuth token
+ * (`UserRead | AppBlocksSubmit | AppBlocksDevTunnel`) and released CLI versions drive
+ * `civitai app listing set-icon / set-cover / add-screenshot / rm-screenshot / reorder /
+ * status` through the `listingMediaCliScope`-annotated procs.
+ *
+ * Widening a GATE is invisible to those clients — the request bytes are identical and
+ * only the server's answer changes. Changing an INPUT SCHEMA is not: an added required
+ * field, a tightened type or a renamed key breaks every already-released binary in the
+ * field, and there is no way to make an old binary send the new shape.
+ *
+ * This suite pins the two halves of that contract:
+ *   1. every media proc's input schema still ACCEPTS the exact payload a released CLI
+ *      sends (a behavioural parse, not a shape description); and
+ *   2. the set of `listingMediaCliScope`-annotated procs has not shrunk, so a proc
+ *      cannot quietly lose its CLI reachability.
+ */
+
+const ROOT = process.cwd();
+const ROUTER = readFileSync(join(ROOT, 'src/server/routers/app-listings.router.ts'), 'utf8');
+
+describe('listing-media input schemas — unchanged for released CLI clients', () => {
+  it('setIcon accepts { listingId, imageId }', () => {
+    const parsed = setListingIconSchema.parse({ listingId: 'apl_1', imageId: 5 });
+    expect(parsed).toMatchObject({ listingId: 'apl_1', imageId: 5 });
+  });
+
+  it('setCover accepts { listingId, imageId }', () => {
+    expect(setListingCoverSchema.parse({ listingId: 'apl_1', imageId: 5 })).toMatchObject({
+      listingId: 'apl_1',
+      imageId: 5,
+    });
+  });
+
+  it('addScreenshot accepts { listingId, imageId }', () => {
+    expect(addListingScreenshotSchema.parse({ listingId: 'apl_1', imageId: 5 })).toMatchObject({
+      listingId: 'apl_1',
+      imageId: 5,
+    });
+  });
+
+  it('removeScreenshot accepts { screenshotId }', () => {
+    expect(removeListingScreenshotSchema.parse({ screenshotId: 'apls_1' })).toMatchObject({
+      screenshotId: 'apls_1',
+    });
+  });
+
+  it('reorderScreenshots accepts { listingId, orderedIds }', () => {
+    // The field is `orderedIds` — asserted by PARSING a real payload rather than by
+    // describing the shape from memory, which is exactly how this test caught an
+    // author's wrong guess (`screenshotIds`) while it was being written.
+    expect(
+      reorderListingScreenshotsSchema.parse({ listingId: 'apl_1', orderedIds: ['apls_1'] })
+    ).toMatchObject({ listingId: 'apl_1', orderedIds: ['apls_1'] });
+  });
+
+  it('updateScreenshotCaption accepts { screenshotId, caption }', () => {
+    expect(
+      updateListingScreenshotCaptionSchema.parse({ screenshotId: 'apls_1', caption: 'hi' })
+    ).toMatchObject({ screenshotId: 'apls_1', caption: 'hi' });
+  });
+
+  it('getMyListingForApp accepts an appBlockId-only payload (the CLI’s shape)', () => {
+    expect(getMyListingForAppSchema.parse({ appBlockId: 'ab_1' })).toMatchObject({
+      appBlockId: 'ab_1',
+    });
+  });
+
+  it('beginListingRevision accepts { listingId }', () => {
+    expect(beginListingRevisionSchema.parse({ listingId: 'apl_1' })).toMatchObject({
+      listingId: 'apl_1',
+    });
+  });
+
+  it('submitListingRevision accepts { shadowId } with no changelog', () => {
+    // `changelog` must stay OPTIONAL — a released CLI does not send it.
+    expect(submitListingRevisionSchema.parse({ shadowId: 'apl_shadow' })).toMatchObject({
+      shadowId: 'apl_shadow',
+    });
+  });
+
+  it('🔴 NEGATIVE CONTROL: these schemas really do reject a wrong payload', () => {
+    // Otherwise every `parse` above could be passing against a permissive `z.any()`
+    // and would prove nothing about the contract.
+    expect(() => setListingIconSchema.parse({ listingId: 'apl_1' })).toThrow();
+    expect(() => removeListingScreenshotSchema.parse({})).toThrow();
+    expect(() => submitListingRevisionSchema.parse({})).toThrow();
+  });
+
+  it('🔴 no collaborator field leaked into a CLI-facing schema', () => {
+    // The temptation when widening a gate is to add "actingAs" / "collaboratorId" to
+    // the input. That would be a wire-contract break. Access is derived SERVER-SIDE
+    // from the session/token subject and never from the request body.
+    for (const schema of [
+      setListingIconSchema,
+      setListingCoverSchema,
+      addListingScreenshotSchema,
+      removeListingScreenshotSchema,
+      reorderListingScreenshotsSchema,
+      updateListingScreenshotCaptionSchema,
+      getMyListingForAppSchema,
+      beginListingRevisionSchema,
+      submitListingRevisionSchema,
+    ]) {
+      const keys = Object.keys((schema as unknown as { shape: Record<string, unknown> }).shape);
+      expect(keys).not.toContain('actingAs');
+      expect(keys).not.toContain('collaboratorId');
+      expect(keys).not.toContain('onBehalfOf');
+      expect(keys).not.toContain('appCollaboratorId');
+    }
+  });
+});
+
+describe('CLI scope annotations — the reachable set has not shrunk', () => {
+  const annotations = ROUTER.match(/\.meta\(listingMediaCliScope\)/g) ?? [];
+
+  it('POSITIVE CONTROL: the annotation really is found in the router source', () => {
+    expect(ROUTER).toContain('const listingMediaCliScope');
+    expect(annotations.length).toBeGreaterThan(0);
+  });
+
+  it('🔴 all 13 CLI-reachable listing-media procs remain annotated', () => {
+    // An exact count, not a floor: losing one silently 403s every released CLI on that
+    // command (an un-annotated proc implicitly requires TokenScope.Full, which the
+    // scoped CLI token is not).
+    expect(annotations).toHaveLength(13);
+  });
+
+  it('the annotation still requires AppBlocksSubmit — the bit the CLI token carries', () => {
+    expect(ROUTER).toContain(
+      'const listingMediaCliScope = { requiredScope: TokenScope.AppBlocksSubmit } as const;'
+    );
+  });
+
+  it('the new collaborator router does NOT annotate anything with a CLI scope', () => {
+    // The CLI has no collaborator commands. An un-annotated proc implicitly requires
+    // TokenScope.Full, which a session satisfies via enforceTokenScope's early return.
+    const collabRouter = readFileSync(
+      join(ROOT, 'src/server/routers/app-collaborators.router.ts'),
+      'utf8'
+    );
+    expect(collabRouter).not.toContain('requiredScope');
+  });
+});

--- a/src/server/services/blocks/__tests__/app-collaborator.editor-read-after-write.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator.editor-read-after-write.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * 🔴 THE EDITOR'S FIRST MEDIA EDIT, UNDER REPLICA LAG — a SEAM test, not a unit test.
+ *
+ * `app-access.service.test.ts` proves `resolveListingAccess` HONOURS a pool override.
+ * That is a fact about one function. This file proves the asset gates actually PASS one
+ * down, which is a different claim and the one that was false: `loadOwnedListing` and
+ * `resolveOwnerScreenshotTarget` both carried a `dbWrite` override, and both dropped it
+ * on the floor at the collaborator branch.
+ *
+ * WHY THE OWNER'S SUITE COULD NEVER CATCH IT. The override exists because a shadow
+ * revision is INSERTed milliseconds before the write that follows it, so a replica read
+ * 404s the OWNER's first edit. An EDITOR never reaches that code path at all — a
+ * shadow's `userId` is the PARENT OWNER's, so an editor always falls through the owner
+ * short-circuit into the seat lookup. The seat lookup was the one read still going to
+ * the replica, which converted the owner's fixed 404 into an editor's unfixed 403 on
+ * exactly the same lag. Neither surface's own tests build the combined state: the owner
+ * suite never has a seat, and the access suite never has a pool.
+ *
+ * The fixture therefore makes the replica know NOTHING — the strongest form of lag —
+ * so a dropped override is observable as a DENIAL rather than as the same answer
+ * arriving from a second identical fixture.
+ */
+
+const { mockRead, mockWrite } = vi.hoisted(() => {
+  const make = () => ({
+    appListing: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      update: vi.fn(async (args: unknown) => args),
+      create: vi.fn(async (args: { data: unknown }) => args.data),
+    },
+    appListingScreenshot: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+      updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
+    },
+    appCollaborator: { findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    appBlock: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    $transaction: vi.fn(async (cb: unknown) =>
+      typeof cb === 'function' ? (cb as (tx: unknown) => Promise<unknown>)(null) : cb
+    ),
+  });
+  // 🔴 TWO OBJECTS, not one. A shared fake makes "which pool answered?" unanswerable —
+  // the whole defect is a pool choice, so a fixture that cannot express the choice
+  // cannot express the bug either. (Same fixture-collapse trap as the tx double in
+  // `app-collaborator.service.test.ts`.)
+  return { mockRead: make(), mockWrite: make() };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockWrite }));
+
+const { updateListingScreenshotCaption } = await import(
+  '~/server/services/blocks/app-listing-assets.service'
+);
+
+const PARENT = 'apl_live';
+const SHADOW = 'apl_shadow';
+const SHOT = 'als_1';
+const OWNER = 10;
+const EDITOR = 20;
+const STRANGER = 50;
+
+/** The freshly-minted shadow: owned (denormalized) by the PARENT owner, not the editor. */
+function shadowRow() {
+  return {
+    id: SHADOW,
+    kind: 'onsite',
+    slug: 'my-app',
+    name: 'My App',
+    category: null,
+    contentRating: 'g',
+    userId: OWNER,
+    iconId: null,
+    coverId: null,
+    status: 'draft',
+    revisionOfId: PARENT,
+    appBlockId: null,
+    revisionOf: { appBlockId: 'ab_app1' },
+  };
+}
+
+const user = (id: number) => ({ id, isModerator: false } as never);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  // THE LAGGING REPLICA: it has seen none of it — not the screenshot, not the shadow,
+  // not the seat.
+  mockRead.appListingScreenshot.findUnique.mockResolvedValue(null);
+  mockRead.appListing.findUnique.mockResolvedValue(null);
+  mockRead.appCollaborator.findFirst.mockResolvedValue(null);
+
+  // THE PRIMARY: everything is there, committed microseconds ago.
+  mockWrite.appListingScreenshot.findUnique.mockResolvedValue({
+    id: SHOT,
+    appListingId: SHADOW,
+    appListing: { userId: OWNER },
+  });
+  mockWrite.appListing.findUnique.mockResolvedValue(shadowRow());
+  mockWrite.appCollaborator.findFirst.mockImplementation(async (args: unknown) => {
+    const w = (args as { where: { userId: number; status?: string } }).where;
+    return w.userId === EDITOR && w.status === 'accepted' ? { userId: EDITOR } : null;
+  });
+  mockWrite.appListingScreenshot.updateMany.mockResolvedValue({ count: 1 });
+});
+
+describe('🔴 an ACCEPTED editor’s first screenshot edit does not 403 under replica lag', () => {
+  it('the editor’s caption write succeeds — the seat is resolved on the pool that answered', async () => {
+    await expect(
+      updateListingScreenshotCaption({ screenshotId: SHOT, caption: 'hi' }, user(EDITOR))
+    ).resolves.toEqual({ id: SHOT });
+
+    // The seat lookup went to the PRIMARY…
+    expect(mockWrite.appCollaborator.findFirst).toHaveBeenCalled();
+    // …and never to the replica. That is the assertion the un-threaded code fails: it
+    // asks the replica, gets nothing, and throws FORBIDDEN.
+    expect(mockRead.appCollaborator.findFirst).not.toHaveBeenCalled();
+    expect(mockWrite.appListingScreenshot.updateMany).toHaveBeenCalledOnce();
+  });
+
+  it('🔴 NEGATIVE CONTROL: the same call against a replica that CAN see everything also passes', async () => {
+    // Proves the test above is measuring the POOL and not some unrelated denial: give
+    // the replica the full picture and the editor gets in without the primary's seat
+    // read mattering at all.
+    mockRead.appListingScreenshot.findUnique.mockResolvedValue({
+      id: SHOT,
+      appListingId: SHADOW,
+      appListing: { userId: OWNER },
+    });
+    mockRead.appListing.findUnique.mockResolvedValue(shadowRow());
+    mockRead.appCollaborator.findFirst.mockImplementation(async (args: unknown) => {
+      const w = (args as { where: { userId: number; status?: string } }).where;
+      return w.userId === EDITOR && w.status === 'accepted' ? { userId: EDITOR } : null;
+    });
+    await expect(
+      updateListingScreenshotCaption({ screenshotId: SHOT, caption: 'hi' }, user(EDITOR))
+    ).resolves.toEqual({ id: SHOT });
+  });
+
+  it('🔴 the widening does NOT open the gate: a stranger is still refused ON THE PRIMARY', async () => {
+    // The mutation this excludes is "thread the pool through AND stop checking the
+    // seat" — which would also make the test above pass. The stranger has no seat on
+    // either pool, so the only thing that can let them through is a missing check.
+    await expect(
+      updateListingScreenshotCaption({ screenshotId: SHOT, caption: 'hi' }, user(STRANGER))
+    ).rejects.toMatchObject({ code: 'FORBIDDEN', message: 'You do not own this listing' });
+    expect(mockWrite.appListingScreenshot.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('a PENDING invitee is refused even though the primary holds their row', async () => {
+    // The consent gate, re-asserted at this seam: `status: 'accepted'` is what the
+    // primary is being asked, so a pending row on the primary must not resolve.
+    mockWrite.appCollaborator.findFirst.mockImplementation(async (args: unknown) => {
+      const w = (args as { where: { userId: number; status?: string } }).where;
+      // A pending row exists, but never for `status: 'accepted'`.
+      return w.userId === 30 && w.status === undefined ? { userId: 30 } : null;
+    });
+    await expect(
+      updateListingScreenshotCaption({ screenshotId: SHOT, caption: 'hi' }, user(30))
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+
+  it('the OWNER still short-circuits without any seat lookup at all', async () => {
+    // The pre-existing behaviour this must not regress: the common path costs no extra
+    // query on either pool.
+    await expect(
+      updateListingScreenshotCaption({ screenshotId: SHOT, caption: 'hi' }, user(OWNER))
+    ).resolves.toEqual({ id: SHOT });
+    expect(mockWrite.appCollaborator.findFirst).not.toHaveBeenCalled();
+    expect(mockRead.appCollaborator.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('POSITIVE CONTROL: the two pools are distinct objects with independent spies', () => {
+    expect(mockWrite).not.toBe(mockRead);
+    expect(mockWrite.appCollaborator.findFirst).not.toBe(mockRead.appCollaborator.findFirst);
+  });
+});

--- a/src/server/services/blocks/__tests__/app-collaborator.permission-matrix.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator.permission-matrix.test.ts
@@ -43,7 +43,9 @@ const { mockDb } = vi.hoisted(() => {
     $transaction: vi.fn(),
   };
   db.$transaction.mockImplementation(async (cb: unknown) =>
-    typeof cb === 'function' ? (cb as (tx: typeof db) => Promise<unknown>)(db) : Promise.all(cb as unknown[])
+    typeof cb === 'function'
+      ? (cb as (tx: typeof db) => Promise<unknown>)(db)
+      : Promise.all(cb as unknown[])
   );
   return { mockDb: db };
 });
@@ -119,12 +121,18 @@ beforeEach(() => {
       ? (cb as (tx: typeof mockDb) => Promise<unknown>)(mockDb)
       : Promise.all(cb as unknown[])
   );
-  mockDb.appBlock.findUnique.mockResolvedValue({ id: APP, blockId: 'my-app', app: { userId: OWNER } });
+  mockDb.appBlock.findUnique.mockResolvedValue({
+    id: APP,
+    blockId: 'my-app',
+    app: { userId: OWNER },
+  });
   mockDb.appListing.findUnique.mockResolvedValue(draftListing());
   mockDb.appListing.findFirst.mockResolvedValue(null);
   mockDb.appCollaborator.findFirst.mockImplementation(async (args: unknown) => {
     const w = (args as { where: { userId: number; status?: string } }).where;
-    const hit = SEATS.find((r) => r.userId === w.userId && (w.status === undefined || r.status === w.status));
+    const hit = SEATS.find(
+      (r) => r.userId === w.userId && (w.status === undefined || r.status === w.status)
+    );
     return hit ? { userId: hit.userId } : null;
   });
 });
@@ -179,10 +187,7 @@ const { getMyListingForApp, getMyListingForEdit, beginListingRevision } = await 
 
 const RUNNERS: Record<string, (s: Subject) => Promise<unknown>> = {
   'assets.getListingAssets': (s) =>
-    getListingAssets(
-      { listingId: LIVE },
-      { id: s.id, isModerator: s.isModerator } as never
-    ),
+    getListingAssets({ listingId: LIVE }, { id: s.id, isModerator: s.isModerator } as never),
   'offsite.getMyListingForEdit': (s) => getMyListingForEdit({ listingId: LIVE, userId: s.id }),
   'offsite.getMyListingForApp': (s) => getMyListingForApp({ appBlockId: APP, userId: s.id }),
 };

--- a/src/server/services/blocks/__tests__/app-collaborator.permission-matrix.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator.permission-matrix.test.ts
@@ -1,0 +1,276 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type * as AppBlockIds from '~/server/utils/app-block-ids';
+
+/**
+ * 🔴 THE PERMISSION MATRIX — table-driven `role × entry-point × expected`, executed
+ * against the REAL widened gates rather than against `resolveAppAccess` alone.
+ *
+ * `app-access.service.test.ts` pins the predicate. This file pins that each gate
+ * actually CONSULTS it: a structural check type-checks past a wrong argument, so every
+ * cell here drives the real service function and asserts allow/deny.
+ *
+ * Subjects: owner · accepted editor · PENDING editor · REJECTED editor · stranger ·
+ * moderator. The moderator column is where the pre-existing D1 divergence shows up and
+ * is asserted AS IT IS, not as it "should" be — `app-listing-assets` bypasses for mods,
+ * `offsite-listing` does not.
+ *
+ * Also covers CONCURRENCY: two editors share ONE shadow revision per parent, via
+ * `beginListingRevision`'s idempotent-reuse path.
+ */
+
+const { mockDb } = vi.hoisted(() => {
+  const db = {
+    appBlock: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    appListing: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      create: vi.fn(async (args: { data: unknown }) => args.data),
+      update: vi.fn(async (args: unknown) => args),
+    },
+    appListingScreenshot: {
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+      createMany: vi.fn(async (..._a: unknown[]) => ({ count: 0 })),
+      count: vi.fn(async (..._a: unknown[]) => 0),
+    },
+    appListingPublishRequest: {
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      create: vi.fn(async (args: { data: unknown }) => args.data),
+    },
+    appCollaborator: { findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    oauthClient: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    image: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    $transaction: vi.fn(),
+  };
+  db.$transaction.mockImplementation(async (cb: unknown) =>
+    typeof cb === 'function' ? (cb as (tx: typeof db) => Promise<unknown>)(db) : Promise.all(cb as unknown[])
+  );
+  return { mockDb: db };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
+vi.mock('~/server/utils/app-block-ids', async (importOriginal) => {
+  const actual = await importOriginal<typeof AppBlockIds>();
+  return { ...actual };
+});
+
+const APP = 'ab_app1';
+const LIVE = 'apl_live';
+const SHADOW = 'apl_shadow';
+const OWNER = 10;
+const EDITOR = 20;
+const PENDING = 30;
+const REJECTED = 40;
+const STRANGER = 50;
+const MOD = 60;
+
+type Subject = { label: string; id: number; isModerator: boolean };
+const SUBJECTS: Subject[] = [
+  { label: 'owner', id: OWNER, isModerator: false },
+  { label: 'accepted editor', id: EDITOR, isModerator: false },
+  { label: 'PENDING editor', id: PENDING, isModerator: false },
+  { label: 'REJECTED editor', id: REJECTED, isModerator: false },
+  { label: 'stranger', id: STRANGER, isModerator: false },
+  { label: 'moderator', id: MOD, isModerator: true },
+];
+
+const SEATS = [
+  { userId: EDITOR, status: 'accepted' },
+  { userId: PENDING, status: 'pending' },
+  { userId: REJECTED, status: 'rejected' },
+];
+
+/** A DRAFT listing (freely editable, so the edit-lock never masks the access gate). */
+function draftListing(over: Record<string, unknown> = {}) {
+  return {
+    id: LIVE,
+    kind: 'onsite',
+    slug: 'my-app',
+    name: 'My App',
+    tagline: null,
+    description: null,
+    category: null,
+    contentRating: 'g',
+    externalUrl: null,
+    connectClientId: null,
+    connectRequestedScopes: null,
+    connectScopeJustifications: null,
+    userId: OWNER,
+    iconId: null,
+    coverId: null,
+    status: 'draft',
+    revisionOfId: null,
+    appBlockId: APP,
+    revisionOf: null,
+    // `loadListingEditView` selects these relations off the SAME row; without them its
+    // `screenshots.map` throws and every ALLOW cell would fail for a reason that has
+    // nothing to do with access.
+    icon: null,
+    cover: null,
+    screenshots: [],
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDb.$transaction.mockImplementation(async (cb: unknown) =>
+    typeof cb === 'function'
+      ? (cb as (tx: typeof mockDb) => Promise<unknown>)(mockDb)
+      : Promise.all(cb as unknown[])
+  );
+  mockDb.appBlock.findUnique.mockResolvedValue({ id: APP, blockId: 'my-app', app: { userId: OWNER } });
+  mockDb.appListing.findUnique.mockResolvedValue(draftListing());
+  mockDb.appListing.findFirst.mockResolvedValue(null);
+  mockDb.appCollaborator.findFirst.mockImplementation(async (args: unknown) => {
+    const w = (args as { where: { userId: number; status?: string } }).where;
+    const hit = SEATS.find((r) => r.userId === w.userId && (w.status === undefined || r.status === w.status));
+    return hit ? { userId: hit.userId } : null;
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The matrix.
+// ---------------------------------------------------------------------------
+
+/**
+ * `true` = the subject may reach the entry point.
+ *
+ * 🔴 The `moderator` column differs BY ENTRY POINT, and that is a faithful record of a
+ * PRE-EXISTING divergence (ledger D1), not a new inconsistency introduced here:
+ * `app-listing-assets::loadOwnedListing` has always bypassed for moderators, while
+ * `offsite-listing::loadOwnedEditableListing` has always refused them ("no mod override
+ * on the author edit path").
+ */
+const MATRIX: Record<string, Record<string, boolean>> = {
+  // app-listing-assets: getListingAssets (mod bypass)
+  'assets.getListingAssets': {
+    owner: true,
+    'accepted editor': true,
+    'PENDING editor': false,
+    'REJECTED editor': false,
+    stranger: false,
+    moderator: true,
+  },
+  // offsite-listing: getMyListingForEdit (NO mod bypass)
+  'offsite.getMyListingForEdit': {
+    owner: true,
+    'accepted editor': true,
+    'PENDING editor': false,
+    'REJECTED editor': false,
+    stranger: false,
+    moderator: false,
+  },
+  // offsite-listing: getMyListingForApp (NO mod bypass)
+  'offsite.getMyListingForApp': {
+    owner: true,
+    'accepted editor': true,
+    'PENDING editor': false,
+    'REJECTED editor': false,
+    stranger: false,
+    moderator: false,
+  },
+};
+
+const { getListingAssets } = await import('~/server/services/blocks/app-listing-assets.service');
+const { getMyListingForApp, getMyListingForEdit, beginListingRevision } = await import(
+  '~/server/services/blocks/offsite-listing.service'
+);
+
+const RUNNERS: Record<string, (s: Subject) => Promise<unknown>> = {
+  'assets.getListingAssets': (s) =>
+    getListingAssets(
+      { listingId: LIVE },
+      { id: s.id, isModerator: s.isModerator } as never
+    ),
+  'offsite.getMyListingForEdit': (s) => getMyListingForEdit({ listingId: LIVE, userId: s.id }),
+  'offsite.getMyListingForApp': (s) => getMyListingForApp({ appBlockId: APP, userId: s.id }),
+};
+
+describe('permission matrix — role × entry point', () => {
+  for (const [entry, row] of Object.entries(MATRIX)) {
+    for (const subject of SUBJECTS) {
+      const allowed = row[subject.label];
+      it(`${entry} · ${subject.label} → ${allowed ? 'ALLOW' : 'DENY'}`, async () => {
+        const call = RUNNERS[entry](subject);
+        if (allowed) await expect(call).resolves.toBeTruthy();
+        else await expect(call).rejects.toBeTruthy();
+      });
+    }
+  }
+
+  it('POSITIVE CONTROL: the matrix has both ALLOW and DENY cells per entry point', () => {
+    // An all-true (or all-false) row would make its whole column vacuous.
+    for (const [entry, row] of Object.entries(MATRIX)) {
+      const values = Object.values(row);
+      expect(values, `${entry} must have at least one ALLOW`).toContain(true);
+      expect(values, `${entry} must have at least one DENY`).toContain(false);
+    }
+  });
+
+  it('every subject appears in every row (no silently-unmeasured cell)', () => {
+    for (const [entry, row] of Object.entries(MATRIX)) {
+      expect(Object.keys(row).sort(), `${entry}`).toEqual(SUBJECTS.map((s) => s.label).sort());
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Concurrency: two editors, ONE shadow.
+// ---------------------------------------------------------------------------
+
+describe('🔴 SHARED SHADOW — two editors converge on one revision draft', () => {
+  const APPROVED = () => draftListing({ status: 'approved' });
+
+  beforeEach(() => {
+    mockDb.appListing.findUnique.mockResolvedValue(APPROVED());
+  });
+
+  it('a standing shadow is REUSED, not cloned again (created: false)', async () => {
+    mockDb.appListing.findFirst.mockResolvedValue({ id: SHADOW });
+    const a = await beginListingRevision({ listingId: LIVE, userId: OWNER });
+    const b = await beginListingRevision({ listingId: LIVE, userId: EDITOR });
+    expect(a).toEqual({ shadowId: SHADOW, created: false });
+    // 🔴 EDITOR B DELIBERATELY LANDS ON EDITOR A'S SHADOW. One parent has at most one
+    // in-flight shadow (a partial UNIQUE on revision_of_id), so collaborators SHARE a
+    // staged revision — B sees A's unsubmitted edits. That is intended: a revision is a
+    // property of the LISTING, not of whoever opened it. It is documented here because
+    // the alternative reading ("B lost their edits") is the natural first assumption.
+    expect(b).toEqual({ shadowId: SHADOW, created: false });
+    expect(mockDb.appListing.create).not.toHaveBeenCalled();
+  });
+
+  it('🔴 the P2002 race collapses to idempotent reuse rather than surfacing an error', async () => {
+    // Editor B's INSERT loses to editor A's committed shadow on the partial-unique
+    // index. B must receive A's shadow, not a 500.
+    let probe = 0;
+    mockDb.appListing.findFirst.mockImplementation(async () => {
+      // 1st: the pre-tx idempotency probe (miss). 2nd: the in-tx race re-check (miss).
+      // 3rd: the post-P2002 winner re-read (hit).
+      probe += 1;
+      return probe >= 3 ? { id: SHADOW } : null;
+    });
+    mockDb.appListing.create.mockRejectedValue(
+      Object.assign(new Error('Unique constraint failed'), { code: 'P2002' })
+    );
+    const res = await beginListingRevision({ listingId: LIVE, userId: EDITOR });
+    expect(res.shadowId).toBe(SHADOW);
+    expect(res.created).toBe(false);
+  });
+
+  it('🔴 NEGATIVE CONTROL: a non-P2002 failure is NOT collapsed into reuse', async () => {
+    // A broad catch would turn a genuine write failure into a silent "reused" answer.
+    mockDb.appListing.findFirst.mockResolvedValue(null);
+    mockDb.appListing.create.mockRejectedValue(
+      Object.assign(new Error('disk on fire'), { code: 'P1001' })
+    );
+    await expect(beginListingRevision({ listingId: LIVE, userId: EDITOR })).rejects.toThrow(
+      'disk on fire'
+    );
+  });
+
+  it('a PENDING invitee cannot open a revision at all', async () => {
+    mockDb.appListing.findFirst.mockResolvedValue({ id: SHADOW });
+    await expect(beginListingRevision({ listingId: LIVE, userId: PENDING })).rejects.toBeTruthy();
+  });
+});

--- a/src/server/services/blocks/__tests__/app-collaborator.public-projection.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator.public-projection.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+
+import { projectListingDetail } from '~/server/services/blocks/app-listing.service';
+import type { HydratedListing } from '~/server/services/blocks/app-listing.service';
+
+/**
+ * App Listing COLLABORATORS — the PUBLIC BYLINE projection.
+ *
+ * Two independent things are pinned here:
+ *   1. CONSENT — only accepted+displayed collaborators reach the DTO. (The
+ *      accepted/displayed filtering itself lives in `listDisplayedCollaboratorUserIds`
+ *      and is pinned in `app-access.service.test.ts`; this file pins that the DTO
+ *      carries exactly what it is handed and adds nothing.)
+ *   2. 🔴 THE ALLOWLIST — the chip is exactly `{id, username, image}` and NO EXTRA KEY
+ *      CAN APPEAR, even when the input row carries more. That is the property that
+ *      keeps an accidental widening of an upstream `select` from leaking PII through
+ *      an anon-capable read.
+ */
+
+/** A minimal hydrated row — only what `projectListingDetail` reads. */
+function row(over: Partial<HydratedListing> = {}): HydratedListing {
+  return {
+    id: 'apl_1',
+    serialId: 1,
+    kind: 'onsite',
+    slug: 'my-app',
+    name: 'My App',
+    tagline: null,
+    description: null,
+    category: null,
+    contentRating: 'g',
+    externalUrl: null,
+    connectClientId: null,
+    appBlockId: 'ab_1',
+    icon: null,
+    cover: null,
+    user: { id: 7, username: 'owner', image: null },
+    metric: null,
+    appBlock: { manifest: {}, currentVersionDeployedAt: new Date() },
+    screenshots: [],
+    ...over,
+  } as unknown as HydratedListing;
+}
+
+describe('projectListingDetail — the collaborator byline', () => {
+  it('with NO collaborators the field is an empty array (never undefined)', () => {
+    // A `undefined` here would make every consumer write `?? []` and one of them
+    // eventually would not.
+    expect(projectListingDetail(row()).collaborators).toEqual([]);
+  });
+
+  it('projects the supplied collaborators in order', () => {
+    const detail = projectListingDetail(row(), [
+      { id: 20, username: 'editor-a', image: 'a.png' },
+      { id: 21, username: 'editor-b', image: null },
+    ]);
+    expect(detail.collaborators).toEqual([
+      { id: 20, username: 'editor-a', image: 'a.png' },
+      { id: 21, username: 'editor-b', image: null },
+    ]);
+  });
+
+  it('🔴 THE ALLOWLIST: exactly {id, username, image} — no extra key can appear', () => {
+    // Feed a REALISTIC over-wide user row (the shape a careless `select: true` upstream
+    // would produce), not a textbook fixture. A projection that spread its input would
+    // pass this key set straight through.
+    const overWide = {
+      id: 20,
+      username: 'editor',
+      image: null,
+      email: 'secret@example.com',
+      bannedAt: new Date(),
+      isModerator: true,
+      settings: { anything: 1 },
+      muted: true,
+    } as unknown as { id: number; username: string | null; image: string | null };
+
+    const detail = projectListingDetail(row(), [overWide]);
+    expect(detail.collaborators).toHaveLength(1);
+    expect(Object.keys(detail.collaborators[0]).sort()).toEqual(['id', 'image', 'username']);
+    // Named explicitly so the failure message says WHICH field leaked.
+    expect(detail.collaborators[0]).not.toHaveProperty('email');
+    expect(detail.collaborators[0]).not.toHaveProperty('bannedAt');
+    expect(detail.collaborators[0]).not.toHaveProperty('isModerator');
+  });
+
+  it('POSITIVE CONTROL: the over-wide fixture really does carry the extra keys', () => {
+    // Otherwise the assertion above is a fact about the fixture, not about the code.
+    const overWide = { id: 20, username: 'e', image: null, email: 'x@y.z' };
+    expect(Object.keys(overWide)).toContain('email');
+  });
+
+  it('the `creator` chip uses the SAME allowlist (the two must not diverge)', () => {
+    const detail = projectListingDetail(
+      row({
+        user: {
+          id: 7,
+          username: 'owner',
+          image: null,
+          email: 'owner@example.com',
+        } as unknown as HydratedListing['user'],
+      })
+    );
+    expect(Object.keys(detail.creator!).sort()).toEqual(['id', 'image', 'username']);
+  });
+
+  it('a null username survives as null rather than being invented', () => {
+    const detail = projectListingDetail(row(), [{ id: 20, username: null, image: null }]);
+    expect(detail.collaborators[0].username).toBeNull();
+  });
+});

--- a/src/server/services/blocks/__tests__/app-collaborator.revision-non-clobber.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator.revision-non-clobber.test.ts
@@ -1,0 +1,119 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * 🔴 REVISION NON-CLOBBER — why `displayed` lives on the collaborator row and not on
+ * `AppListing`.
+ *
+ * `applyApprovedRevision` (offsite-listing.service.ts) copies a shadow's contents onto
+ * its live parent when a moderator approves a revision. It is KIND-AWARE:
+ *   - ONSITE  branch: copies ONLY `iconId` / `coverId`.
+ *   - OFFSITE branch: ALSO copies name / tagline / description / category /
+ *     contentRating / externalUrl / connect* .
+ *
+ * The product decision is that the display-author flag applies IMMEDIATELY, with no mod
+ * review. Had it been stored as an `AppListing` column, the offsite branch would
+ * overwrite it from the shadow on the next approved revision — an immediate-apply
+ * setting that silently reverts. Storing it on `AppCollaborator` puts it outside BOTH
+ * branches' copy sets, which makes immediate-apply correct BY CONSTRUCTION.
+ *
+ * This suite pins that structurally, against the real source, so the guarantee survives
+ * someone widening a copy set later. It is a RELATIONSHIP guard: the behavioural half
+ * (that a toggle actually persists) lives in `app-collaborator.service.test.ts`.
+ */
+
+const ROOT = process.cwd();
+const SRC = join(ROOT, 'src/server/services/blocks/offsite-listing.service.ts');
+const SOURCE = readFileSync(SRC, 'utf8');
+
+/** Slice out `applyApprovedRevision`'s body: from its declaration to the next top-level fn. */
+function applyApprovedRevisionBody(): string {
+  const start = SOURCE.indexOf('async function applyApprovedRevision(');
+  expect(start, 'applyApprovedRevision must exist — has it been renamed?').toBeGreaterThan(-1);
+  const after = SOURCE.indexOf('\nexport async function rejectExternalRequest', start);
+  expect(after, 'the slice end marker must exist').toBeGreaterThan(start);
+  return SOURCE.slice(start, after);
+}
+
+const BODY = applyApprovedRevisionBody();
+
+describe('applyApprovedRevision — the copy sets', () => {
+  it('POSITIVE CONTROL: the slice really contains both branches', () => {
+    // A slice that silently matched nothing would make every "does not contain"
+    // assertion below vacuously true — the classic reassuring zero.
+    expect(BODY.length).toBeGreaterThan(500);
+    expect(BODY).toContain("parent.kind === 'onsite'");
+    // The offsite branch's marker scalars.
+    expect(BODY).toContain('name: shadow.name');
+    expect(BODY).toContain('tagline: shadow.tagline');
+    expect(BODY).toContain('iconId: shadow.iconId');
+  });
+
+  it('🔴 NEITHER branch copies `userId` — a revision cannot change ownership', () => {
+    expect(BODY).not.toContain('userId: shadow.userId');
+    expect(BODY).not.toMatch(/data:\s*\{[^}]*\buserId\b/s);
+  });
+
+  it('🔴 NEITHER branch touches `AppCollaborator` — seats survive an approve', () => {
+    expect(BODY).not.toContain('appCollaborator');
+  });
+
+  it('🔴 NEITHER branch touches `displayed` — the byline opt-in survives an approve', () => {
+    // THE assertion this file exists for. If `displayed` ever appears in this function,
+    // the flag has been moved onto the listing and immediate-apply is no longer safe.
+    expect(BODY).not.toContain('displayed');
+  });
+
+  it('the ONSITE branch copies ASSETS ONLY (the scalars stay manifest-governed)', () => {
+    const onsiteStart = BODY.indexOf("parent.kind === 'onsite'");
+    const elseAt = BODY.indexOf('} else {', onsiteStart);
+    const onsite = BODY.slice(onsiteStart, elseAt);
+    expect(onsite).toContain('iconId: shadow.iconId');
+    expect(onsite).toContain('coverId: shadow.coverId');
+    expect(onsite).not.toContain('name: shadow.name');
+    expect(onsite).not.toContain('displayed');
+    expect(onsite).not.toContain('appCollaborator');
+  });
+
+  it('the OFFSITE branch copies the full scalar set — but still nothing collaborator-shaped', () => {
+    const elseAt = BODY.indexOf('} else {');
+    const offsite = BODY.slice(elseAt);
+    // Prove the branch is the wide one (so "not displayed" below is meaningful).
+    expect(offsite).toContain('name: shadow.name');
+    expect(offsite).toContain('description: shadow.description');
+    expect(offsite).toContain('category: shadow.category');
+    // 🔴 …and yet still carries neither.
+    expect(offsite).not.toContain('displayed');
+    expect(offsite).not.toContain('appCollaborator');
+    expect(offsite).not.toContain('userId: shadow.userId');
+  });
+
+  it('NEGATIVE CONTROL: the scan CAN find a token in this body', () => {
+    // Proves the "not.toContain" assertions above are answering about real content
+    // rather than about an empty string.
+    expect(BODY).toContain('appListingScreenshot');
+    expect(BODY).not.toContain('aTokenThatIsDefinitelyNotInThisFunction');
+  });
+});
+
+describe('beginListingRevision — the shadow clone set', () => {
+  it('🔴 clones with the PARENT OWNER’s userId, not the editing user’s', () => {
+    // Load-bearing for collaborators: the shadow is owner-owned, which is why
+    // `submitListingRevision`'s bare `shadow.userId !== userId` refused an editor and
+    // had to be widened with the seat check.
+    const start = SOURCE.indexOf('export async function beginListingRevision(');
+    const end = SOURCE.indexOf('export type SubmitListingRevisionResult', start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const body = SOURCE.slice(start, end);
+    expect(body).toContain('userId: parent.userId');
+  });
+
+  it('a shadow carries NO appBlockId — which is why listing access must walk to the parent', () => {
+    const start = SOURCE.indexOf('export async function beginListingRevision(');
+    const end = SOURCE.indexOf('export type SubmitListingRevisionResult', start);
+    const body = SOURCE.slice(start, end);
+    expect(body).toContain('appBlockId: null');
+  });
+});

--- a/src/server/services/blocks/__tests__/app-collaborator.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator.service.test.ts
@@ -36,7 +36,10 @@ const { mockDb, mockRepo, mockNotify } = vi.hoisted(() => {
   db.$transaction.mockImplementation(async (cb: (tx: typeof db) => Promise<unknown>) => cb(db));
   return {
     mockDb: db,
-    mockRepo: { grantAppRepoWrite: vi.fn(async () => undefined), revokeAppRepoWrite: vi.fn(async () => undefined) },
+    mockRepo: {
+      grantAppRepoWrite: vi.fn(async () => undefined),
+      revokeAppRepoWrite: vi.fn(async () => undefined),
+    },
     mockNotify: { notifyAppCollaborator: vi.fn(async () => undefined) },
   };
 });
@@ -211,7 +214,12 @@ describe('inviteCollaborator', () => {
   });
 
   it('the cap counts PENDING + ACCEPTED only — a rejected row occupies no seat', async () => {
-    await inviteCollaborator({ appBlockId: APP, targetUserId: TARGET, actorUserId: OWNER, now: NOW });
+    await inviteCollaborator({
+      appBlockId: APP,
+      targetUserId: TARGET,
+      actorUserId: OWNER,
+      now: NOW,
+    });
     const args = mockDb.appCollaborator.count.mock.calls[0][0] as {
       where: { status: { in: string[] } };
     };
@@ -219,7 +227,10 @@ describe('inviteCollaborator', () => {
   });
 
   it('the cap is NOT re-charged when re-touching an existing row', async () => {
-    mockDb.appCollaborator.findUnique.mockResolvedValue({ status: 'pending', lastNotifiedAt: null });
+    mockDb.appCollaborator.findUnique.mockResolvedValue({
+      status: 'pending',
+      lastNotifiedAt: null,
+    });
     mockDb.appCollaborator.count.mockResolvedValue(constants.appCollaborators.maxCollaborators);
     await expect(
       inviteCollaborator({ appBlockId: APP, targetUserId: TARGET, actorUserId: OWNER, now: NOW })
@@ -335,7 +346,11 @@ describe('removeCollaborator / leaveApp — the REVOKE half', () => {
 
 describe('setCollaboratorDisplayed', () => {
   it('an ACCEPTED collaborator can toggle their byline', async () => {
-    const res = await setCollaboratorDisplayed({ appBlockId: APP, userId: TARGET, displayed: false });
+    const res = await setCollaboratorDisplayed({
+      appBlockId: APP,
+      userId: TARGET,
+      displayed: false,
+    });
     expect(res.displayed).toBe(false);
     const upd = mockDb.appCollaborator.updateMany.mock.calls[0][0] as {
       where: { status: string };
@@ -361,49 +376,113 @@ describe('setCollaboratorDisplayed', () => {
 
 describe('filterCollaboratorsForViewer — status visibility', () => {
   const ROWS = [
-    { userId: 1, role: 'editor', status: 'accepted', displayed: true, invitedBy: OWNER, createdAt: NOW, respondedAt: NOW },
-    { userId: 2, role: 'editor', status: 'pending', displayed: true, invitedBy: OWNER, createdAt: NOW, respondedAt: null },
-    { userId: 3, role: 'editor', status: 'rejected', displayed: true, invitedBy: OWNER, createdAt: NOW, respondedAt: NOW },
+    {
+      userId: 1,
+      role: 'editor',
+      status: 'accepted',
+      displayed: true,
+      invitedBy: OWNER,
+      createdAt: NOW,
+      respondedAt: NOW,
+    },
+    {
+      userId: 2,
+      role: 'editor',
+      status: 'pending',
+      displayed: true,
+      invitedBy: OWNER,
+      createdAt: NOW,
+      respondedAt: null,
+    },
+    {
+      userId: 3,
+      role: 'editor',
+      status: 'rejected',
+      displayed: true,
+      invitedBy: OWNER,
+      createdAt: NOW,
+      respondedAt: NOW,
+    },
   ];
   const ids = (rows: typeof ROWS) => rows.map((r) => r.userId);
 
   it('anon sees ACCEPTED only', () => {
     expect(
-      ids(filterCollaboratorsForViewer(ROWS, { ownerUserId: OWNER, viewerUserId: null, isModerator: false }))
+      ids(
+        filterCollaboratorsForViewer(ROWS, {
+          ownerUserId: OWNER,
+          viewerUserId: null,
+          isModerator: false,
+        })
+      )
     ).toEqual([1]);
   });
 
   it('a stranger sees ACCEPTED only', () => {
     expect(
-      ids(filterCollaboratorsForViewer(ROWS, { ownerUserId: OWNER, viewerUserId: STRANGER, isModerator: false }))
+      ids(
+        filterCollaboratorsForViewer(ROWS, {
+          ownerUserId: OWNER,
+          viewerUserId: STRANGER,
+          isModerator: false,
+        })
+      )
     ).toEqual([1]);
   });
 
   it('the OWNER sees everything', () => {
     expect(
-      ids(filterCollaboratorsForViewer(ROWS, { ownerUserId: OWNER, viewerUserId: OWNER, isModerator: false }))
+      ids(
+        filterCollaboratorsForViewer(ROWS, {
+          ownerUserId: OWNER,
+          viewerUserId: OWNER,
+          isModerator: false,
+        })
+      )
     ).toEqual([1, 2, 3]);
   });
 
   it('a MODERATOR sees everything', () => {
     expect(
-      ids(filterCollaboratorsForViewer(ROWS, { ownerUserId: OWNER, viewerUserId: STRANGER, isModerator: true }))
+      ids(
+        filterCollaboratorsForViewer(ROWS, {
+          ownerUserId: OWNER,
+          viewerUserId: STRANGER,
+          isModerator: true,
+        })
+      )
     ).toEqual([1, 2, 3]);
   });
 
   it('the INVITEE sees their own pending row, but not someone else’s rejection', () => {
     expect(
-      ids(filterCollaboratorsForViewer(ROWS, { ownerUserId: OWNER, viewerUserId: 2, isModerator: false }))
+      ids(
+        filterCollaboratorsForViewer(ROWS, {
+          ownerUserId: OWNER,
+          viewerUserId: 2,
+          isModerator: false,
+        })
+      )
     ).toEqual([1, 2]);
     expect(
-      ids(filterCollaboratorsForViewer(ROWS, { ownerUserId: OWNER, viewerUserId: 3, isModerator: false }))
+      ids(
+        filterCollaboratorsForViewer(ROWS, {
+          ownerUserId: OWNER,
+          viewerUserId: 3,
+          isModerator: false,
+        })
+      )
     ).toEqual([1]);
   });
 
   it('an unknown status is filtered OUT — fail closed on a value the code does not know', () => {
     const weird = [{ ...ROWS[0], status: 'something-new' }];
     expect(
-      filterCollaboratorsForViewer(weird, { ownerUserId: OWNER, viewerUserId: null, isModerator: false })
+      filterCollaboratorsForViewer(weird, {
+        ownerUserId: OWNER,
+        viewerUserId: null,
+        isModerator: false,
+      })
     ).toEqual([]);
   });
 });

--- a/src/server/services/blocks/__tests__/app-collaborator.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator.service.test.ts
@@ -53,11 +53,14 @@ const {
   filterCollaboratorsForViewer,
   inviteCollaborator,
   leaveApp,
+  listCollaborators,
+  mapCollaboratorError,
   removeCollaborator,
   respondToInvite,
   setCollaboratorDisplayed,
   shouldNotifyInvite,
 } = await import('~/server/services/blocks/app-collaborator.service');
+const { TRPCError } = await import('@trpc/server');
 
 const APP = 'ab_app1';
 const SLUG = 'my-app';
@@ -295,6 +298,40 @@ describe('respondToInvite', () => {
       respondToInvite({ appBlockId: APP, userId: TARGET, accept: false, now: NOW })
     ).resolves.toMatchObject({ status: 'rejected' });
   });
+
+  // 🔴 The APPEND-ONLY TRAIL's `action` field. Untested until a mutation sweep swapped
+  // the ternary and nothing went red: an accept was recorded as a `reject`. The trail is
+  // the ONLY record of who consented to what — the seat row itself is deleted on
+  // remove/leave — so a silently-inverted action makes the audit history actively
+  // misleading rather than merely incomplete, and nothing downstream would ever
+  // contradict it.
+  it('🔴 ACCEPT is recorded as `accept` in the audit trail', async () => {
+    await respondToInvite({ appBlockId: APP, userId: TARGET, accept: true, now: NOW });
+    const evt = mockDb.appOwnershipEvent.create.mock.calls[0][0] as {
+      data: { action: string; actorUserId: number; targetUserId: number };
+    };
+    expect(evt.data.action).toBe('accept');
+    expect(evt.data.actorUserId).toBe(TARGET);
+    expect(evt.data.targetUserId).toBe(TARGET);
+  });
+
+  it('🔴 REJECT is recorded as `reject` — the two are not interchangeable', async () => {
+    await respondToInvite({ appBlockId: APP, userId: TARGET, accept: false, now: NOW });
+    const evt = mockDb.appOwnershipEvent.create.mock.calls[0][0] as { data: { action: string } };
+    expect(evt.data.action).toBe('reject');
+  });
+
+  it('POSITIVE CONTROL: the two branches really do write DIFFERENT actions', async () => {
+    // Otherwise both assertions above could be satisfied by one constant string.
+    await respondToInvite({ appBlockId: APP, userId: TARGET, accept: true, now: NOW });
+    const a = (mockDb.appOwnershipEvent.create.mock.calls[0][0] as { data: { action: string } })
+      .data.action;
+    mockDb.appOwnershipEvent.create.mockClear();
+    await respondToInvite({ appBlockId: APP, userId: TARGET, accept: false, now: NOW });
+    const b = (mockDb.appOwnershipEvent.create.mock.calls[0][0] as { data: { action: string } })
+      .data.action;
+    expect(a).not.toBe(b);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -337,6 +374,175 @@ describe('removeCollaborator / leaveApp — the REVOKE half', () => {
     expect(mockRepo.revokeAppRepoWrite).toHaveBeenCalledWith({ slug: SLUG, userId: TARGET });
     const evt = mockDb.appOwnershipEvent.create.mock.calls[0][0] as { data: { action: string } };
     expect(evt.data.action).toBe('leave');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 🔴 THE BLAST RADIUS of the two `deleteMany` calls.
+// ---------------------------------------------------------------------------
+
+describe('🔴 leaveApp / removeCollaborator delete EXACTLY ONE seat', () => {
+  /**
+   * THE WORST SURVIVING MUTANT. Dropping `userId` from `leaveApp`'s `where` turns "I
+   * give up my seat" into "every collaborator on this app is removed" — a one-word
+   * deletion, performed by a NON-OWNER (leaving needs no owner check, correctly), that
+   * no test noticed. The old fixture asserted only `deleteMany` returned `count: 1`,
+   * which a table-wide delete satisfies just as well as a targeted one.
+   *
+   * So this suite stops asserting the RETURN and starts asserting the TABLE: a real
+   * two-seat fixture, a `deleteMany` that honours its `where`, and an assertion on who
+   * SURVIVES. A predicate that is too broad now leaves the wrong survivors.
+   */
+  const OTHER_SEAT = 21;
+
+  /** The seat table, mutated for real by the fake `deleteMany`. */
+  let seats: Array<{ appBlockId: string; userId: number }>;
+
+  beforeEach(() => {
+    seats = [
+      { appBlockId: APP, userId: TARGET },
+      { appBlockId: APP, userId: OTHER_SEAT },
+      // A seat on a DIFFERENT app, so an over-broad `where` that keeps `userId` but
+      // drops `appBlockId` is caught too.
+      { appBlockId: 'ab_other', userId: TARGET },
+    ];
+    mockDb.appCollaborator.deleteMany.mockImplementation(async (args: unknown) => {
+      const w = (args as { where: { appBlockId?: string; userId?: number } }).where;
+      const before = seats.length;
+      seats = seats.filter(
+        (s) =>
+          !(
+            (w.appBlockId === undefined || s.appBlockId === w.appBlockId) &&
+            (w.userId === undefined || s.userId === w.userId)
+          )
+      );
+      return { count: before - seats.length };
+    });
+  });
+
+  it('POSITIVE CONTROL: the fake deleteMany really does honour its `where`', async () => {
+    // Without this the survivor assertions below are facts about an inert mock.
+    const wide = await mockDb.appCollaborator.deleteMany({ where: {} });
+    expect(wide).toEqual({ count: 3 });
+    expect(seats).toEqual([]);
+  });
+
+  it('🔴 leaveApp removes ONLY the caller’s seat on THIS app', async () => {
+    const res = await leaveApp({ appBlockId: APP, userId: TARGET });
+    expect(res.removed).toBe(true);
+    // The co-editor keeps their seat. A `where` missing `userId` deletes them too.
+    expect(seats).toContainEqual({ appBlockId: APP, userId: OTHER_SEAT });
+    // …and the caller's seat on an unrelated app survives. A `where` missing
+    // `appBlockId` takes that one.
+    expect(seats).toContainEqual({ appBlockId: 'ab_other', userId: TARGET });
+    expect(seats).not.toContainEqual({ appBlockId: APP, userId: TARGET });
+    expect(seats).toHaveLength(2);
+  });
+
+  it('🔴 leaveApp revokes repo write for the LEAVER only', async () => {
+    await leaveApp({ appBlockId: APP, userId: TARGET });
+    expect(mockRepo.revokeAppRepoWrite).toHaveBeenCalledOnce();
+    expect(mockRepo.revokeAppRepoWrite).toHaveBeenCalledWith({ slug: SLUG, userId: TARGET });
+  });
+
+  it('🔴 removeCollaborator removes ONLY the named target', async () => {
+    await removeCollaborator({ appBlockId: APP, targetUserId: TARGET, actorUserId: OWNER });
+    expect(seats).toContainEqual({ appBlockId: APP, userId: OTHER_SEAT });
+    expect(seats).not.toContainEqual({ appBlockId: APP, userId: TARGET });
+  });
+
+  it('leaving an app you hold no seat on removes nothing and revokes nothing', async () => {
+    const res = await leaveApp({ appBlockId: APP, userId: STRANGER });
+    expect(res.removed).toBe(false);
+    expect(seats).toHaveLength(3);
+    expect(mockRepo.revokeAppRepoWrite).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 🔴 The audit event must be written through the TRANSACTION, not the client.
+// ---------------------------------------------------------------------------
+
+describe('🔴 recordOwnershipEvent writes through the `tx`, not `dbWrite`', () => {
+  /**
+   * FIXTURE COLLAPSE, and why this needed its own describe.
+   *
+   * Every suite's `$transaction` fake calls back with the SAME object it was called on
+   * (`cb(db)`), so `tx.appOwnershipEvent.create` and `dbWrite.appOwnershipEvent.create`
+   * are literally the same spy. A mutant that swapped the transactional client for the
+   * bare `dbWrite` was therefore byte-identical to correct code under test — and it is
+   * the one difference that matters: an event written outside the transaction SURVIVES
+   * a rollback, so a seat change that never happened leaves a permanent audit row
+   * claiming it did.
+   *
+   * The cure is a DISTINCT tx double. Two objects make the choice observable; one
+   * object makes the assertion unwritable.
+   */
+  function txDouble() {
+    return {
+      appCollaborator: {
+        upsert: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({})),
+        updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
+        deleteMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
+      },
+      appOwnershipEvent: { create: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({})) },
+    };
+  }
+
+  let tx: ReturnType<typeof txDouble>;
+
+  beforeEach(() => {
+    tx = txDouble();
+    mockDb.$transaction.mockImplementation(async (cb: (t: unknown) => Promise<unknown>) => cb(tx));
+  });
+
+  it('POSITIVE CONTROL: the tx double is a DIFFERENT object from the client', () => {
+    // If these were the same object every assertion below would be vacuous — which is
+    // exactly the state that let the mutant survive.
+    expect(tx.appOwnershipEvent.create).not.toBe(mockDb.appOwnershipEvent.create);
+  });
+
+  const CASES: Array<[string, () => Promise<unknown>, string]> = [
+    [
+      'inviteCollaborator',
+      () =>
+        inviteCollaborator({ appBlockId: APP, targetUserId: TARGET, actorUserId: OWNER, now: NOW }),
+      'invite',
+    ],
+    [
+      'respondToInvite',
+      () => respondToInvite({ appBlockId: APP, userId: TARGET, accept: true, now: NOW }),
+      'accept',
+    ],
+    [
+      'removeCollaborator',
+      () => removeCollaborator({ appBlockId: APP, targetUserId: TARGET, actorUserId: OWNER }),
+      'remove',
+    ],
+    ['leaveApp', () => leaveApp({ appBlockId: APP, userId: TARGET }), 'leave'],
+    [
+      'setCollaboratorDisplayed',
+      () => setCollaboratorDisplayed({ appBlockId: APP, userId: TARGET, displayed: true }),
+      'display',
+    ],
+  ];
+
+  for (const [label, run, action] of CASES) {
+    it(`${label}: the \`${action}\` event lands on the tx and NOT on the client`, async () => {
+      await run();
+      expect(tx.appOwnershipEvent.create).toHaveBeenCalledOnce();
+      const evt = tx.appOwnershipEvent.create.mock.calls[0][0] as { data: { action: string } };
+      expect(evt.data.action).toBe(action);
+      // 🔴 The mutant's signature: the event written through the bare client, where a
+      // rollback cannot reach it.
+      expect(mockDb.appOwnershipEvent.create).not.toHaveBeenCalled();
+    });
+  }
+
+  it('the seat WRITE goes through the tx too, not just the event', async () => {
+    await respondToInvite({ appBlockId: APP, userId: TARGET, accept: true, now: NOW });
+    expect(tx.appCollaborator.updateMany).toHaveBeenCalledOnce();
+    expect(mockDb.appCollaborator.updateMany).not.toHaveBeenCalled();
   });
 });
 
@@ -492,5 +698,175 @@ describe('AppCollaboratorError', () => {
     const e = new AppCollaboratorError('CAP_REACHED', 'too many');
     expect(e.code).toBe('CAP_REACHED');
     expect(e.name).toBe('AppCollaboratorError');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 🔴 The tRPC STATUS-CODE contract for the whole new router.
+// ---------------------------------------------------------------------------
+
+describe('mapCollaboratorError — the router’s status-code contract', () => {
+  /**
+   * Every proc in `app-collaborators.router.ts` funnels through `run()` → this
+   * function, so this table IS the router's error contract. It was entirely untested:
+   * a mutant returning BAD_REQUEST for NOT_OWNER/BANNED survived, which would turn
+   * "you are not allowed" into "your request was malformed" for every authorization
+   * failure the feature can produce — the client cannot tell a permission problem from
+   * a bad payload, and neither can a support agent reading a ticket.
+   *
+   * Asserted as an exhaustive table over `AppCollaboratorErrorCode` (the codes are
+   * listed, not derived from the implementation) so a NEW code added without a decision
+   * shows up as an unlisted case in the union rather than silently defaulting.
+   */
+  const CONTRACT: Array<[string, string]> = [
+    ['NOT_FOUND', 'NOT_FOUND'],
+    // 🔴 The two authorization codes. FORBIDDEN, never BAD_REQUEST.
+    ['NOT_OWNER', 'FORBIDDEN'],
+    ['BANNED', 'FORBIDDEN'],
+    // Everything else is the caller asking for something the state does not allow.
+    ['INVALID_TARGET', 'BAD_REQUEST'],
+    ['ALREADY_SEATED', 'BAD_REQUEST'],
+    ['CAP_REACHED', 'BAD_REQUEST'],
+    ['NO_INVITE', 'BAD_REQUEST'],
+  ];
+
+  for (const [serviceCode, trpcCode] of CONTRACT) {
+    it(`${serviceCode} → tRPC ${trpcCode}`, () => {
+      const mapped = mapCollaboratorError(
+        new AppCollaboratorError(serviceCode as never, `msg-${serviceCode}`)
+      );
+      expect(mapped).toBeInstanceOf(TRPCError);
+      expect((mapped as InstanceType<typeof TRPCError>).code).toBe(trpcCode);
+      // The service message reaches the client verbatim — these strings are the UX.
+      expect((mapped as InstanceType<typeof TRPCError>).message).toBe(`msg-${serviceCode}`);
+    });
+  }
+
+  it('the table covers EVERY code the service can throw (no silently-unmapped case)', () => {
+    // A structural guard against the table drifting behind the union: the codes below
+    // are the ones `AppCollaboratorErrorCode` declares.
+    const DECLARED = [
+      'NOT_FOUND',
+      'NOT_OWNER',
+      'INVALID_TARGET',
+      'ALREADY_SEATED',
+      'CAP_REACHED',
+      'NO_INVITE',
+      'BANNED',
+    ];
+    expect(CONTRACT.map(([c]) => c).sort()).toEqual(DECLARED.sort());
+  });
+
+  it('🔴 NEGATIVE CONTROL: a non-service error passes through UNCHANGED', () => {
+    // Wrapping everything would relabel genuine 500s as client errors.
+    const raw = new Error('connection reset');
+    expect(mapCollaboratorError(raw)).toBe(raw);
+    expect(mapCollaboratorError(raw)).not.toBeInstanceOf(TRPCError);
+  });
+
+  it('POSITIVE CONTROL: FORBIDDEN and BAD_REQUEST are distinguishable values', () => {
+    // Otherwise the whole table could be satisfied by one constant.
+    const a = mapCollaboratorError(new AppCollaboratorError('NOT_OWNER', 'x'));
+    const b = mapCollaboratorError(new AppCollaboratorError('CAP_REACHED', 'x'));
+    expect((a as InstanceType<typeof TRPCError>).code).not.toBe(
+      (b as InstanceType<typeof TRPCError>).code
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 🔴 The ROSTER read is not public.
+// ---------------------------------------------------------------------------
+
+describe('listCollaborators — 🔴 the caller must hold a REAL role', () => {
+  /**
+   * `resolveAppAccess` was consulted here only for `ownerUserId`; its `role` was never
+   * required non-null. The status filter governs which ROWS a viewer sees, not whether
+   * the viewer may read the app at all — so any account with the author flag could
+   * enumerate ANY app's accepted roster, INCLUDING seats whose holder set
+   * `displayed: false` precisely so as not to be listed publicly, plus `invitedBy` and
+   * the invite/response timestamps.
+   */
+  const ROSTER = [
+    {
+      userId: 1,
+      role: 'editor',
+      status: 'accepted',
+      displayed: false,
+      invitedBy: OWNER,
+      createdAt: NOW,
+      respondedAt: NOW,
+    },
+  ];
+
+  beforeEach(() => {
+    mockDb.appCollaborator.findMany.mockResolvedValue(ROSTER);
+    // No seat for anyone unless a test says otherwise.
+    mockDb.appCollaborator.findFirst.mockResolvedValue(null);
+  });
+
+  it('the OWNER may read the roster', async () => {
+    await expect(
+      listCollaborators({ appBlockId: APP, viewerUserId: OWNER, isModerator: false })
+    ).resolves.toHaveLength(1);
+  });
+
+  it('an ACCEPTED editor may read the roster', async () => {
+    mockDb.appCollaborator.findFirst.mockResolvedValue({ userId: TARGET });
+    await expect(
+      listCollaborators({ appBlockId: APP, viewerUserId: TARGET, isModerator: false })
+    ).resolves.toHaveLength(1);
+  });
+
+  it('a MODERATOR may read the roster', async () => {
+    await expect(
+      listCollaborators({ appBlockId: APP, viewerUserId: STRANGER, isModerator: true })
+    ).resolves.toHaveLength(1);
+  });
+
+  it('🔴 a STRANGER is refused — and the query never runs', async () => {
+    await expect(
+      listCollaborators({ appBlockId: APP, viewerUserId: STRANGER, isModerator: false })
+    ).rejects.toMatchObject({ code: 'NOT_OWNER' });
+    // Fail BEFORE the read, not after it: the rows must never be loaded, let alone
+    // filtered.
+    expect(mockDb.appCollaborator.findMany).not.toHaveBeenCalled();
+  });
+
+  it('🔴 an ANONYMOUS caller is refused', async () => {
+    await expect(
+      listCollaborators({ appBlockId: APP, viewerUserId: null, isModerator: false })
+    ).rejects.toMatchObject({ code: 'NOT_OWNER' });
+  });
+
+  it('🔴 a PENDING invitee is refused (they read their own invite via listMyPendingInvites)', async () => {
+    // `resolveAppAccess` returns role null for a pending seat — the consent rule. So a
+    // pending invitee does not get the app's roster as a side effect of being invited.
+    mockDb.appCollaborator.findFirst.mockImplementation(async (args: unknown) => {
+      const w = (args as { where: { status?: string } }).where;
+      return w.status === 'accepted' ? null : { userId: TARGET };
+    });
+    await expect(
+      listCollaborators({ appBlockId: APP, viewerUserId: TARGET, isModerator: false })
+    ).rejects.toMatchObject({ code: 'NOT_OWNER' });
+  });
+
+  it('a missing app is NOT_FOUND, distinct from a refusal', async () => {
+    mockDb.appBlock.findUnique.mockResolvedValue(null);
+    await expect(
+      listCollaborators({ appBlockId: APP, viewerUserId: OWNER, isModerator: false })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('POSITIVE CONTROL: the roster fixture really carries an opted-OUT seat', async () => {
+    // The stake of the leak, stated as data: `displayed: false` is exactly the row a
+    // stranger must not be able to read back.
+    const rows = await listCollaborators({
+      appBlockId: APP,
+      viewerUserId: OWNER,
+      isModerator: false,
+    });
+    expect(rows[0].displayed).toBe(false);
+    expect(rows[0].invitedBy).toBe(OWNER);
   });
 });

--- a/src/server/services/blocks/__tests__/app-collaborator.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator.service.test.ts
@@ -1,0 +1,417 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { constants } from '~/server/common/constants';
+
+/**
+ * App Listing COLLABORATORS — the SEAT lifecycle.
+ *
+ * Covers invite (idempotency, cap, re-open a decline, ban, self-invite), the
+ * NOTIFY THROTTLE (both sides of the boundary — the inverted-sibling guard), accept /
+ * reject with its status-guarded flip, remove / leave with the Forgejo revoke, the
+ * byline opt-in, and the status-VISIBILITY filter.
+ *
+ * `dbWrite.$transaction` runs its callback against the SAME `dbWrite` mock (the tx
+ * client), so a test asserts the exact writes made inside the transaction.
+ * `dbRead`/`dbWrite` are the same object here — these paths do not depend on the
+ * replica/primary split, and pretending otherwise would add fixture noise for no
+ * assertion.
+ */
+
+const { mockDb, mockRepo, mockNotify } = vi.hoisted(() => {
+  const db = {
+    appBlock: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    user: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    appCollaborator: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      count: vi.fn(async (..._a: unknown[]): Promise<number> => 0),
+      upsert: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({})),
+      updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
+      deleteMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
+    },
+    appOwnershipEvent: { create: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({})) },
+    $transaction: vi.fn(),
+  };
+  db.$transaction.mockImplementation(async (cb: (tx: typeof db) => Promise<unknown>) => cb(db));
+  return {
+    mockDb: db,
+    mockRepo: { grantAppRepoWrite: vi.fn(async () => undefined), revokeAppRepoWrite: vi.fn(async () => undefined) },
+    mockNotify: { notifyAppCollaborator: vi.fn(async () => undefined) },
+  };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
+vi.mock('~/server/services/blocks/app-repo-access', () => mockRepo);
+vi.mock('~/server/services/blocks/app-collaborator-notify', () => mockNotify);
+
+const {
+  AppCollaboratorError,
+  filterCollaboratorsForViewer,
+  inviteCollaborator,
+  leaveApp,
+  removeCollaborator,
+  respondToInvite,
+  setCollaboratorDisplayed,
+  shouldNotifyInvite,
+} = await import('~/server/services/blocks/app-collaborator.service');
+
+const APP = 'ab_app1';
+const SLUG = 'my-app';
+const OWNER = 10;
+const TARGET = 20;
+const STRANGER = 50;
+const NOW = new Date('2026-08-10T12:00:00Z');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDb.$transaction.mockImplementation(async (cb: (tx: typeof mockDb) => Promise<unknown>) =>
+    cb(mockDb)
+  );
+  mockDb.appBlock.findUnique.mockResolvedValue({ id: APP, blockId: SLUG, app: { userId: OWNER } });
+  mockDb.user.findUnique.mockResolvedValue({ id: TARGET, bannedAt: null });
+  mockDb.appCollaborator.findUnique.mockResolvedValue(null);
+  mockDb.appCollaborator.count.mockResolvedValue(0);
+  mockDb.appCollaborator.updateMany.mockResolvedValue({ count: 1 });
+  mockDb.appCollaborator.deleteMany.mockResolvedValue({ count: 1 });
+});
+
+// ---------------------------------------------------------------------------
+// The throttle — the inverted-sibling guard.
+// ---------------------------------------------------------------------------
+
+describe('shouldNotifyInvite — 🔴 the inverted-throttle guard', () => {
+  const WINDOW_MS = constants.appCollaborators.inviteNotifyThrottleHours * 3600_000;
+
+  it('never notified → notify', () => {
+    expect(shouldNotifyInvite(null, NOW)).toBe(true);
+  });
+
+  it('notified LONGER ago than the window → notify', () => {
+    expect(shouldNotifyInvite(new Date(NOW.getTime() - WINDOW_MS - 1000), NOW)).toBe(true);
+  });
+
+  it('🔴 notified RECENTLY → stay silent (this is the direction EntityCollaborator gets wrong)', () => {
+    // `entity-collaborator.service.ts:94-95` uses `>=` here and therefore re-notifies
+    // exactly when it should suppress. Both sides of the boundary are pinned so a
+    // copy-paste of that comparison flips this test red.
+    expect(shouldNotifyInvite(new Date(NOW.getTime() - 60_000), NOW)).toBe(false);
+  });
+
+  it('exactly ON the boundary → notify (inclusive `<=`)', () => {
+    expect(shouldNotifyInvite(new Date(NOW.getTime() - WINDOW_MS), NOW)).toBe(true);
+  });
+
+  it('1 ms inside the boundary → silent', () => {
+    expect(shouldNotifyInvite(new Date(NOW.getTime() - WINDOW_MS + 1), NOW)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invite.
+// ---------------------------------------------------------------------------
+
+describe('inviteCollaborator', () => {
+  it('the OWNER can invite; the row is created PENDING and an event is written', async () => {
+    const res = await inviteCollaborator({
+      appBlockId: APP,
+      targetUserId: TARGET,
+      actorUserId: OWNER,
+      now: NOW,
+    });
+    expect(res).toMatchObject({ status: 'pending', created: true, notified: true });
+    const upsert = mockDb.appCollaborator.upsert.mock.calls[0][0] as {
+      create: { status: string; role: string };
+    };
+    expect(upsert.create.status).toBe('pending');
+    expect(upsert.create.role).toBe('editor');
+    const evt = mockDb.appOwnershipEvent.create.mock.calls[0][0] as { data: { action: string } };
+    expect(evt.data.action).toBe('invite');
+    expect(mockNotify.notifyAppCollaborator).toHaveBeenCalledOnce();
+  });
+
+  it('🔴 a NON-OWNER (even an accepted editor) cannot invite — seats are owner-managed', async () => {
+    await expect(
+      inviteCollaborator({ appBlockId: APP, targetUserId: TARGET, actorUserId: STRANGER, now: NOW })
+    ).rejects.toMatchObject({ code: 'NOT_OWNER' });
+    expect(mockDb.appCollaborator.upsert).not.toHaveBeenCalled();
+    expect(mockDb.appOwnershipEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('inviting the OWNER is INVALID_TARGET', async () => {
+    await expect(
+      inviteCollaborator({ appBlockId: APP, targetUserId: OWNER, actorUserId: OWNER, now: NOW })
+    ).rejects.toMatchObject({ code: 'INVALID_TARGET' });
+  });
+
+  it('a nonexistent target is INVALID_TARGET (never a raw FK error)', async () => {
+    mockDb.user.findUnique.mockResolvedValue(null);
+    await expect(
+      inviteCollaborator({ appBlockId: APP, targetUserId: 999, actorUserId: OWNER, now: NOW })
+    ).rejects.toMatchObject({ code: 'INVALID_TARGET' });
+  });
+
+  it('🔴 a BANNED target cannot be seated (the ban decision)', async () => {
+    mockDb.user.findUnique.mockResolvedValue({ id: TARGET, bannedAt: new Date() });
+    await expect(
+      inviteCollaborator({ appBlockId: APP, targetUserId: TARGET, actorUserId: OWNER, now: NOW })
+    ).rejects.toMatchObject({ code: 'BANNED' });
+    expect(mockDb.appCollaborator.upsert).not.toHaveBeenCalled();
+  });
+
+  it('re-inviting an ALREADY ACCEPTED collaborator is ALREADY_SEATED', async () => {
+    mockDb.appCollaborator.findUnique.mockResolvedValue({
+      status: 'accepted',
+      lastNotifiedAt: null,
+    });
+    await expect(
+      inviteCollaborator({ appBlockId: APP, targetUserId: TARGET, actorUserId: OWNER, now: NOW })
+    ).rejects.toMatchObject({ code: 'ALREADY_SEATED' });
+  });
+
+  it('re-inviting a REJECTED invitee RE-OPENS it as pending (they must consent again)', async () => {
+    mockDb.appCollaborator.findUnique.mockResolvedValue({
+      status: 'rejected',
+      lastNotifiedAt: null,
+    });
+    const res = await inviteCollaborator({
+      appBlockId: APP,
+      targetUserId: TARGET,
+      actorUserId: OWNER,
+      now: NOW,
+    });
+    expect(res.created).toBe(false);
+    const upsert = mockDb.appCollaborator.upsert.mock.calls[0][0] as {
+      update: { status: string; respondedAt: null };
+    };
+    expect(upsert.update.status).toBe('pending');
+    expect(upsert.update.respondedAt).toBeNull();
+  });
+
+  it('a repeat invite inside the throttle window writes the row but sends NO notification', async () => {
+    mockDb.appCollaborator.findUnique.mockResolvedValue({
+      status: 'pending',
+      lastNotifiedAt: new Date(NOW.getTime() - 60_000),
+    });
+    const res = await inviteCollaborator({
+      appBlockId: APP,
+      targetUserId: TARGET,
+      actorUserId: OWNER,
+      now: NOW,
+    });
+    expect(res.notified).toBe(false);
+    expect(mockNotify.notifyAppCollaborator).not.toHaveBeenCalled();
+  });
+
+  it('the CAP blocks a NEW seat at the configured maximum', async () => {
+    mockDb.appCollaborator.count.mockResolvedValue(constants.appCollaborators.maxCollaborators);
+    await expect(
+      inviteCollaborator({ appBlockId: APP, targetUserId: TARGET, actorUserId: OWNER, now: NOW })
+    ).rejects.toMatchObject({ code: 'CAP_REACHED' });
+  });
+
+  it('the cap counts PENDING + ACCEPTED only — a rejected row occupies no seat', async () => {
+    await inviteCollaborator({ appBlockId: APP, targetUserId: TARGET, actorUserId: OWNER, now: NOW });
+    const args = mockDb.appCollaborator.count.mock.calls[0][0] as {
+      where: { status: { in: string[] } };
+    };
+    expect(args.where.status.in.sort()).toEqual(['accepted', 'pending']);
+  });
+
+  it('the cap is NOT re-charged when re-touching an existing row', async () => {
+    mockDb.appCollaborator.findUnique.mockResolvedValue({ status: 'pending', lastNotifiedAt: null });
+    mockDb.appCollaborator.count.mockResolvedValue(constants.appCollaborators.maxCollaborators);
+    await expect(
+      inviteCollaborator({ appBlockId: APP, targetUserId: TARGET, actorUserId: OWNER, now: NOW })
+    ).resolves.toMatchObject({ status: 'pending' });
+  });
+
+  it('a notification failure does NOT undo the invite (best-effort, post-commit)', async () => {
+    mockNotify.notifyAppCollaborator.mockRejectedValueOnce(new Error('notifications down'));
+    await expect(
+      inviteCollaborator({ appBlockId: APP, targetUserId: TARGET, actorUserId: OWNER, now: NOW })
+    ).resolves.toMatchObject({ status: 'pending' });
+    expect(mockDb.appCollaborator.upsert).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Accept / reject.
+// ---------------------------------------------------------------------------
+
+describe('respondToInvite', () => {
+  it('ACCEPT flips the row and GRANTS Forgejo write', async () => {
+    const res = await respondToInvite({ appBlockId: APP, userId: TARGET, accept: true, now: NOW });
+    expect(res.status).toBe('accepted');
+    const upd = mockDb.appCollaborator.updateMany.mock.calls[0][0] as {
+      where: { status: string };
+      data: { status: string };
+    };
+    // 🔴 STATUS-GUARDED: only a PENDING row flips, so a concurrent remove/re-invite
+    // cannot be double-acted.
+    expect(upd.where.status).toBe('pending');
+    expect(upd.data.status).toBe('accepted');
+    expect(mockRepo.grantAppRepoWrite).toHaveBeenCalledWith({ slug: SLUG, userId: TARGET });
+  });
+
+  it('REJECT flips the row and grants NOTHING', async () => {
+    const res = await respondToInvite({ appBlockId: APP, userId: TARGET, accept: false, now: NOW });
+    expect(res.status).toBe('rejected');
+    expect(mockRepo.grantAppRepoWrite).not.toHaveBeenCalled();
+  });
+
+  it('🔴 no pending invite → NO_INVITE, and NO event is written (tx rolled back)', async () => {
+    mockDb.appCollaborator.updateMany.mockResolvedValue({ count: 0 });
+    // The real $transaction rolls back on throw; the fake runs inline, so assert on the
+    // ORDER instead: the guard must throw BEFORE the event create is reached.
+    await expect(
+      respondToInvite({ appBlockId: APP, userId: STRANGER, accept: true, now: NOW })
+    ).rejects.toMatchObject({ code: 'NO_INVITE' });
+    expect(mockDb.appOwnershipEvent.create).not.toHaveBeenCalled();
+    expect(mockRepo.grantAppRepoWrite).not.toHaveBeenCalled();
+  });
+
+  it('🔴 a BANNED user cannot ACCEPT', async () => {
+    mockDb.user.findUnique.mockResolvedValue({ bannedAt: new Date() });
+    await expect(
+      respondToInvite({ appBlockId: APP, userId: TARGET, accept: true, now: NOW })
+    ).rejects.toMatchObject({ code: 'BANNED' });
+  });
+
+  it('a BANNED user CAN decline (declining takes nothing away from anyone)', async () => {
+    mockDb.user.findUnique.mockResolvedValue({ bannedAt: new Date() });
+    await expect(
+      respondToInvite({ appBlockId: APP, userId: TARGET, accept: false, now: NOW })
+    ).resolves.toMatchObject({ status: 'rejected' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Remove / leave.
+// ---------------------------------------------------------------------------
+
+describe('removeCollaborator / leaveApp — the REVOKE half', () => {
+  it('the owner removes a seat and the repo grant is REVOKED', async () => {
+    const res = await removeCollaborator({
+      appBlockId: APP,
+      targetUserId: TARGET,
+      actorUserId: OWNER,
+    });
+    expect(res.removed).toBe(true);
+    expect(mockRepo.revokeAppRepoWrite).toHaveBeenCalledWith({ slug: SLUG, userId: TARGET });
+  });
+
+  it('a NON-OWNER cannot remove someone else', async () => {
+    await expect(
+      removeCollaborator({ appBlockId: APP, targetUserId: TARGET, actorUserId: STRANGER })
+    ).rejects.toMatchObject({ code: 'NOT_OWNER' });
+    expect(mockRepo.revokeAppRepoWrite).not.toHaveBeenCalled();
+  });
+
+  it('removing a seat that does not exist is a no-op and revokes nothing', async () => {
+    mockDb.appCollaborator.deleteMany.mockResolvedValue({ count: 0 });
+    const res = await removeCollaborator({
+      appBlockId: APP,
+      targetUserId: TARGET,
+      actorUserId: OWNER,
+    });
+    expect(res.removed).toBe(false);
+    expect(mockRepo.revokeAppRepoWrite).not.toHaveBeenCalled();
+    expect(mockDb.appOwnershipEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('a COLLABORATOR may leave without any owner check — and is revoked', async () => {
+    const res = await leaveApp({ appBlockId: APP, userId: TARGET });
+    expect(res.removed).toBe(true);
+    expect(mockRepo.revokeAppRepoWrite).toHaveBeenCalledWith({ slug: SLUG, userId: TARGET });
+    const evt = mockDb.appOwnershipEvent.create.mock.calls[0][0] as { data: { action: string } };
+    expect(evt.data.action).toBe('leave');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Byline opt-in.
+// ---------------------------------------------------------------------------
+
+describe('setCollaboratorDisplayed', () => {
+  it('an ACCEPTED collaborator can toggle their byline', async () => {
+    const res = await setCollaboratorDisplayed({ appBlockId: APP, userId: TARGET, displayed: false });
+    expect(res.displayed).toBe(false);
+    const upd = mockDb.appCollaborator.updateMany.mock.calls[0][0] as {
+      where: { status: string };
+      data: { displayed: boolean };
+    };
+    // 🔴 Guarded on ACCEPTED: a pending invitee must not be able to pre-arrange public
+    // credit for a seat they have not taken.
+    expect(upd.where.status).toBe('accepted');
+    expect(upd.data.displayed).toBe(false);
+  });
+
+  it('a non-accepted (or absent) row is refused', async () => {
+    mockDb.appCollaborator.updateMany.mockResolvedValue({ count: 0 });
+    await expect(
+      setCollaboratorDisplayed({ appBlockId: APP, userId: STRANGER, displayed: true })
+    ).rejects.toMatchObject({ code: 'NO_INVITE' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Status visibility (the consent model borrowed from EntityCollaborator).
+// ---------------------------------------------------------------------------
+
+describe('filterCollaboratorsForViewer — status visibility', () => {
+  const ROWS = [
+    { userId: 1, role: 'editor', status: 'accepted', displayed: true, invitedBy: OWNER, createdAt: NOW, respondedAt: NOW },
+    { userId: 2, role: 'editor', status: 'pending', displayed: true, invitedBy: OWNER, createdAt: NOW, respondedAt: null },
+    { userId: 3, role: 'editor', status: 'rejected', displayed: true, invitedBy: OWNER, createdAt: NOW, respondedAt: NOW },
+  ];
+  const ids = (rows: typeof ROWS) => rows.map((r) => r.userId);
+
+  it('anon sees ACCEPTED only', () => {
+    expect(
+      ids(filterCollaboratorsForViewer(ROWS, { ownerUserId: OWNER, viewerUserId: null, isModerator: false }))
+    ).toEqual([1]);
+  });
+
+  it('a stranger sees ACCEPTED only', () => {
+    expect(
+      ids(filterCollaboratorsForViewer(ROWS, { ownerUserId: OWNER, viewerUserId: STRANGER, isModerator: false }))
+    ).toEqual([1]);
+  });
+
+  it('the OWNER sees everything', () => {
+    expect(
+      ids(filterCollaboratorsForViewer(ROWS, { ownerUserId: OWNER, viewerUserId: OWNER, isModerator: false }))
+    ).toEqual([1, 2, 3]);
+  });
+
+  it('a MODERATOR sees everything', () => {
+    expect(
+      ids(filterCollaboratorsForViewer(ROWS, { ownerUserId: OWNER, viewerUserId: STRANGER, isModerator: true }))
+    ).toEqual([1, 2, 3]);
+  });
+
+  it('the INVITEE sees their own pending row, but not someone else’s rejection', () => {
+    expect(
+      ids(filterCollaboratorsForViewer(ROWS, { ownerUserId: OWNER, viewerUserId: 2, isModerator: false }))
+    ).toEqual([1, 2]);
+    expect(
+      ids(filterCollaboratorsForViewer(ROWS, { ownerUserId: OWNER, viewerUserId: 3, isModerator: false }))
+    ).toEqual([1]);
+  });
+
+  it('an unknown status is filtered OUT — fail closed on a value the code does not know', () => {
+    const weird = [{ ...ROWS[0], status: 'something-new' }];
+    expect(
+      filterCollaboratorsForViewer(weird, { ownerUserId: OWNER, viewerUserId: null, isModerator: false })
+    ).toEqual([]);
+  });
+});
+
+describe('AppCollaboratorError', () => {
+  it('carries its code (the router maps on it)', () => {
+    const e = new AppCollaboratorError('CAP_REACHED', 'too many');
+    expect(e.code).toBe('CAP_REACHED');
+    expect(e.name).toBe('AppCollaboratorError');
+  });
+});

--- a/src/server/services/blocks/__tests__/app-listing.deploy-gate.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.deploy-gate.test.ts
@@ -20,6 +20,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockDbRead } = vi.hoisted(() => ({
   mockDbRead: {
+    // App Listing COLLABORATORS: `getAppListingDetail` now hydrates the PUBLIC BYLINE
+    // (accepted + displayed collaborators) alongside the listing. Both reads go through
+    // `safeCollaboratorQuery`, which swallows ONLY the missing-TABLE error — so an
+    // absent mock surfaces as a TypeError instead of being silently absorbed. Empty
+    // here: these suites assert the pre-collaborator projection, which must be
+    // byte-identical when an app has no seats.
+    appCollaborator: { findFirst: vi.fn(async () => null), findMany: vi.fn(async () => []) },
+    user: { findMany: vi.fn(async () => []) },
     $queryRaw: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
     appListing: {
       findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),

--- a/src/server/services/blocks/__tests__/app-listing.public-scope.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.public-scope.test.ts
@@ -18,6 +18,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockDbRead } = vi.hoisted(() => ({
   mockDbRead: {
+    // App Listing COLLABORATORS: `getAppListingDetail` now hydrates the PUBLIC BYLINE
+    // (accepted + displayed collaborators) alongside the listing. Both reads go through
+    // `safeCollaboratorQuery`, which swallows ONLY the missing-TABLE error — so an
+    // absent mock surfaces as a TypeError instead of being silently absorbed. Empty
+    // here: these suites assert the pre-collaborator projection, which must be
+    // byte-identical when an app has no seats.
+    appCollaborator: { findFirst: vi.fn(async () => null), findMany: vi.fn(async () => []) },
+    user: { findMany: vi.fn(async () => []) },
     $queryRaw: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
     appListing: {
       findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),

--- a/src/server/services/blocks/__tests__/app-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.service.test.ts
@@ -14,6 +14,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockDbRead } = vi.hoisted(() => ({
   mockDbRead: {
+    // App Listing COLLABORATORS: `getAppListingDetail` now hydrates the PUBLIC BYLINE
+    // (accepted + displayed collaborators) alongside the listing. Both reads go through
+    // `safeCollaboratorQuery`, which swallows ONLY the missing-TABLE error — so an
+    // absent mock surfaces as a TypeError instead of being silently absorbed. Empty
+    // here: these suites assert the pre-collaborator projection, which must be
+    // byte-identical when an app has no seats.
+    appCollaborator: { findFirst: vi.fn(async () => null), findMany: vi.fn(async () => []) },
+    user: { findMany: vi.fn(async () => []) },
     $queryRaw: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
     appListing: {
       findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
@@ -356,6 +364,11 @@ describe('projectListingDetail — public allowlist + gallery', () => {
     expect(Object.keys(detail).sort()).toEqual(
       [
         'category',
+        // App Listing COLLABORATORS: the PUBLIC BYLINE (accepted + displayed seats),
+        // projected through the SAME {id, username, image} allowlist as `creator`.
+        // Empty here — this row has no seats — but the KEY must be present, so a
+        // consumer never has to write `?? []`.
+        'collaborators',
         'contentRating',
         'coverUrl',
         'creator',

--- a/src/server/services/blocks/__tests__/app-ownership-transfer.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-ownership-transfer.service.test.ts
@@ -125,7 +125,15 @@ beforeEach(() => {
     blockId: SLUG,
     app: { userId: OLD_OWNER },
   });
-  mockDb.user.findUnique.mockResolvedValue({ id: NEW_OWNER, bannedAt: null });
+  // 🔴 The user read is LOGGED into `calls`, so its POSITION relative to `tx:begin` is
+  // observable. `dbRead` and `dbWrite` are the same fake here, so "was the ban read on
+  // the primary?" cannot be asked by identity — only by ordering. Without this, a mutant
+  // that moves the read OUT of the transaction (back onto the replica, where a very
+  // recent ban may not be visible) is indistinguishable from correct code.
+  mockDb.user.findUnique.mockImplementation(async (..._a: unknown[]) => {
+    calls.push('read:user');
+    return { id: NEW_OWNER, bannedAt: null };
+  });
   mockDb.oauthClient.updateMany.mockResolvedValue({ count: 1 });
   mockDb.appListing.updateMany.mockResolvedValue({ count: 1 });
   mockDb.appOwnershipTransfer.updateMany.mockResolvedValue({ count: 1 });
@@ -179,6 +187,49 @@ describe('initiateTransfer', () => {
     await expect(
       initiateTransfer({ appBlockId: APP, toUserId: NEW_OWNER, actorUserId: OLD_OWNER, now: NOW })
     ).rejects.toMatchObject({ code: 'BANNED' });
+  });
+
+  // 🔴 THE TWO PARTY COLUMNS, asserted as VALUES. A mutant that swapped them survived:
+  // `fromUserId`/`toUserId` are both plain ints on the same row, so the create
+  // type-checks either way round and every downstream assertion in the old suite read
+  // the row back through the same swap. A swapped row makes `acceptTransfer`'s
+  // status-guarded `where: { userId: fromUserId }` match nobody — the offer becomes
+  // permanently unacceptable — while `cancelTransfer` hands the withdraw right to the
+  // wrong party. Fixture ids are deliberately distinct so the two cannot alias.
+  it('🔴 the offer records fromUserId = CURRENT OWNER and toUserId = RECIPIENT, not the reverse', async () => {
+    const t = await initiateTransfer({
+      appBlockId: APP,
+      toUserId: NEW_OWNER,
+      actorUserId: OLD_OWNER,
+      now: NOW,
+    });
+    const created = mockDb.appOwnershipTransfer.create.mock.calls[0][0] as {
+      data: { fromUserId: number; toUserId: number; appBlockId: string; status: string };
+    };
+    expect(created.data.fromUserId).toBe(OLD_OWNER);
+    expect(created.data.toUserId).toBe(NEW_OWNER);
+    expect(created.data.appBlockId).toBe(APP);
+    expect(created.data.status).toBe('pending');
+    // …and the returned view carries the same orientation the client will render.
+    expect(t.fromUserId).toBe(OLD_OWNER);
+    expect(t.toUserId).toBe(NEW_OWNER);
+    // POSITIVE CONTROL: the two ids are distinct, so a swap is observable at all.
+    expect(OLD_OWNER).not.toBe(NEW_OWNER);
+  });
+
+  it('🔴 `fromUserId` is the app’s CURRENT owner, not merely the actor', async () => {
+    // The audit event names the target; the row must name the owner it is moving FROM.
+    await initiateTransfer({
+      appBlockId: APP,
+      toUserId: NEW_OWNER,
+      actorUserId: OLD_OWNER,
+      now: NOW,
+    });
+    const evt = mockDb.appOwnershipEvent.create.mock.calls[0][0] as {
+      data: { actorUserId: number; targetUserId: number };
+    };
+    expect(evt.data.actorUserId).toBe(OLD_OWNER);
+    expect(evt.data.targetUserId).toBe(NEW_OWNER);
   });
 
   it('EXPIRED pending rows are reclaimed first, so one lapsed offer cannot wedge the app forever', async () => {
@@ -343,6 +394,116 @@ describe('acceptTransfer — 🔴 ATOMICITY of the two ownership columns', () =>
   });
 });
 
+// ---------------------------------------------------------------------------
+// 🔴 The BAN is re-read at ACCEPT, not inherited from the offer or the session.
+// ---------------------------------------------------------------------------
+
+describe('🔴 acceptTransfer re-reads bannedAt — the 7-day window', () => {
+  /**
+   * THE HOLE THIS CLOSES. The stated policy is "a banned user may not receive an
+   * ownership transfer". It was enforced at INITIATE (against the user row) and at the
+   * proc (against `ctx.user.bannedAt`, a SESSION value). An offer stays live for
+   * `transferExpiryDays`, so between those two points a recipient can be banned and the
+   * policy silently stops holding: `respondToInvite` re-reads the user row for exactly
+   * this reason, and this path — which hands over an entire app, its repo write and its
+   * earnings surface — did not.
+   *
+   * The read is issued through the TRANSACTION (the primary), not the replica, because
+   * an ownership move is not cheap to unwind and a ban is a deny signal you never want
+   * to read stale.
+   */
+  it('a recipient banned AFTER the offer was made cannot accept', async () => {
+    // The offer itself is untouched and still live — only the user row changed.
+    mockDb.user.findUnique.mockResolvedValue({ id: NEW_OWNER, bannedAt: new Date() });
+    await expect(
+      acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW })
+    ).rejects.toMatchObject({ code: 'BANNED' });
+  });
+
+  it('🔴 …and NOTHING moves: neither ownership column, no audit event, no repo grant', async () => {
+    mockDb.user.findUnique.mockResolvedValue({ id: NEW_OWNER, bannedAt: new Date() });
+    await expect(
+      acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW })
+    ).rejects.toMatchObject({ code: 'BANNED' });
+    expect(mockDb.oauthClient.updateMany).not.toHaveBeenCalled();
+    expect(mockDb.appListing.updateMany).not.toHaveBeenCalled();
+    expect(mockDb.appOwnershipEvent.create).not.toHaveBeenCalled();
+    expect(mockRepo.grantAppRepoWrite).not.toHaveBeenCalled();
+    // The whole transaction aborts, which is what makes the guard's position safe.
+    expect(calls).toContain('tx:rollback');
+  });
+
+  it('the ban is read for the ACCEPTING user, on the primary, inside the tx', async () => {
+    await acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW });
+    expect(mockDb.user.findUnique).toHaveBeenCalledWith({
+      where: { id: NEW_OWNER },
+      select: { bannedAt: true },
+    });
+    // 🔴 ORDERING, not just "it was called": the read must sit strictly BETWEEN
+    // `tx:begin` and `tx:commit`. A pre-tx read runs on the replica, where a ban applied
+    // seconds ago may not be visible yet — and since both pools are the same fake here,
+    // ordering is the ONLY thing that distinguishes the two.
+    expect(calls).toEqual(['tx:begin', 'read:user', 'tx:commit']);
+  });
+
+  it('🔴 NEGATIVE CONTROL: an UNBANNED recipient still completes the transfer', async () => {
+    // Otherwise "it threw" would be indistinguishable from a guard that refuses
+    // everyone — the fail-closed mutant.
+    mockDb.user.findUnique.mockResolvedValue({ id: NEW_OWNER, bannedAt: null });
+    await expect(
+      acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW })
+    ).resolves.toMatchObject({ toUserId: NEW_OWNER });
+    expect(mockDb.oauthClient.updateMany).toHaveBeenCalledOnce();
+  });
+
+  it('🔴 the read is issued on the TRANSACTION CLIENT, not on the bare `dbRead`', async () => {
+    /**
+     * WHY ORDERING WAS NOT ENOUGH. This suite hands the SAME fake to `dbRead` and
+     * `dbWrite`, so a mutant that changes `tx.user.findUnique` to `dbRead.user.findUnique`
+     * WITHOUT moving it out of the callback keeps the identical call ordering and
+     * SURVIVED the first sweep — it is the same fixture-collapse trap the audit flagged
+     * on `recordOwnershipEvent`. Yet the defect is real: inside a primary transaction,
+     * `dbRead` still goes to the REPLICA, which is exactly where a ban applied seconds
+     * ago is not yet visible — i.e. the mutant silently restores the hole this fix
+     * closes.
+     *
+     * Only a DISTINCT tx double can tell them apart, so this test builds one.
+     */
+    const tx = {
+      user: { findUnique: vi.fn(async (..._a: unknown[]) => ({ bannedAt: null })) },
+      appOwnershipTransfer: {
+        findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => liveTransfer()),
+        updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
+      },
+      oauthClient: { updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })) },
+      appListing: { updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })) },
+      appOwnershipEvent: { create: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({})) },
+    };
+    mockDb.$transaction.mockImplementation(async (cb: (t: unknown) => Promise<unknown>) => cb(tx));
+    // POSITIVE CONTROL: two objects, or every assertion below is vacuous.
+    expect(tx.user.findUnique).not.toBe(mockDb.user.findUnique);
+
+    await acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW });
+
+    expect(tx.user.findUnique).toHaveBeenCalledWith({
+      where: { id: NEW_OWNER },
+      select: { bannedAt: true },
+    });
+    // 🔴 The mutant's signature: the ban read routed through the replica handle.
+    expect(mockDb.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('a recipient row that has vanished does not block the transfer on a null read', async () => {
+    // `bannedAt` is the question; a missing row is not a ban. (The FK makes this
+    // unreachable in practice — pinned so the guard cannot drift into `if (!user) throw`,
+    // which would fail the transfer for the wrong reason.)
+    mockDb.user.findUnique.mockResolvedValue(null);
+    await expect(
+      acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW })
+    ).resolves.toMatchObject({ toUserId: NEW_OWNER });
+  });
+});
+
 describe('🔴 MONEY INVARIANCE — attribution and payout grouping are untouched', () => {
   it('accept never writes BlockBuzzAttribution', async () => {
     await acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW });
@@ -404,11 +565,100 @@ describe('cancelTransfer / getPendingTransfer', () => {
 
   it('getPendingTransfer returns a LIVE offer', async () => {
     mockDb.appOwnershipTransfer.findFirst.mockResolvedValue(liveTransfer());
-    expect(await getPendingTransfer({ appBlockId: APP, now: NOW })).toMatchObject({ id: TRANSFER });
+    expect(
+      await getPendingTransfer({ appBlockId: APP, viewerUserId: OLD_OWNER, now: NOW })
+    ).toMatchObject({ id: TRANSFER });
   });
 
   it('🔴 getPendingTransfer treats an EXPIRED row as ABSENT (read-time predicate, no sweeper needed)', async () => {
     mockDb.appOwnershipTransfer.findFirst.mockResolvedValue(liveTransfer({ expiresAt: PAST }));
-    expect(await getPendingTransfer({ appBlockId: APP, now: NOW })).toBeNull();
+    expect(
+      await getPendingTransfer({ appBlockId: APP, viewerUserId: OLD_OWNER, now: NOW })
+    ).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 🔴 getPendingTransfer is AUTHORIZED.
+// ---------------------------------------------------------------------------
+
+describe('🔴 getPendingTransfer — who may read the offer', () => {
+  /**
+   * This read had NO authorization at all: the proc destructured `{ input }` and never
+   * touched `ctx`, while all three sibling transfer procs gate. The row it returns names
+   * both parties (`fromUserId`, `toUserId`) and the deadline, so any account with the
+   * author flag could ask, for any app id, who is handing it to whom and by when —
+   * a pre-announcement of an acquisition, readable by the whole flagged cohort.
+   *
+   * Permitted: the app OWNER (the offer's `fromUserId`) and the ADDRESSEE. That is
+   * exactly the set that may ACT on the transfer, which is what makes it consistent
+   * rather than arbitrary.
+   */
+  const EDITOR = 30;
+
+  beforeEach(() => {
+    mockDb.appOwnershipTransfer.findFirst.mockResolvedValue(liveTransfer());
+    mockDb.appBlock.findUnique.mockResolvedValue({
+      id: APP,
+      appId: CLIENT,
+      blockId: SLUG,
+      app: { userId: OLD_OWNER },
+    });
+    mockDb.appCollaborator.findFirst.mockImplementation(async (args: unknown) => {
+      const w = (args as { where: { userId: number; status?: string } }).where;
+      return w.userId === EDITOR && w.status === 'accepted' ? { userId: EDITOR } : null;
+    });
+  });
+
+  it('the OWNER sees the offer', async () => {
+    await expect(
+      getPendingTransfer({ appBlockId: APP, viewerUserId: OLD_OWNER, now: NOW })
+    ).resolves.toMatchObject({ id: TRANSFER, toUserId: NEW_OWNER });
+  });
+
+  it('the ADDRESSEE sees the offer they must accept', async () => {
+    await expect(
+      getPendingTransfer({ appBlockId: APP, viewerUserId: NEW_OWNER, now: NOW })
+    ).resolves.toMatchObject({ id: TRANSFER });
+  });
+
+  it('🔴 a STRANGER gets null — not the row, and not a FORBIDDEN either', async () => {
+    // `null`, deliberately: a throw would make this proc an EXISTENCE ORACLE, and "this
+    // app has a pending transfer" is itself the private fact. The refusal has to be
+    // indistinguishable from "there is no offer".
+    await expect(
+      getPendingTransfer({ appBlockId: APP, viewerUserId: STRANGER, now: NOW })
+    ).resolves.toBeNull();
+  });
+
+  it('🔴 an ACCEPTED EDITOR gets null — a seat is not a claim on the app’s disposal', async () => {
+    // An editor is a co-owner for CONTENT. Initiating a transfer is one of the two
+    // owner-reserved actions, so watching one is not theirs either.
+    await expect(
+      getPendingTransfer({ appBlockId: APP, viewerUserId: EDITOR, now: NOW })
+    ).resolves.toBeNull();
+  });
+
+  it('POSITIVE CONTROL: that same editor really does resolve as an editor', async () => {
+    // Otherwise the null above proves nothing — it could be a seat lookup wired to
+    // nothing rather than a deliberate exclusion.
+    const { resolveAppAccess: resolve } = await import(
+      '~/server/services/blocks/app-access.service'
+    );
+    expect((await resolve(APP, EDITOR))!.role).toBe('editor');
+  });
+
+  it('a missing app is NOT_FOUND', async () => {
+    mockDb.appBlock.findUnique.mockResolvedValue(null);
+    await expect(
+      getPendingTransfer({ appBlockId: APP, viewerUserId: OLD_OWNER, now: NOW })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('an EXPIRED offer is null for the owner too (expiry still wins over authorization)', async () => {
+    mockDb.appOwnershipTransfer.findFirst.mockResolvedValue(liveTransfer({ expiresAt: PAST }));
+    await expect(
+      getPendingTransfer({ appBlockId: APP, viewerUserId: OLD_OWNER, now: NOW })
+    ).resolves.toBeNull();
   });
 });

--- a/src/server/services/blocks/__tests__/app-ownership-transfer.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-ownership-transfer.service.test.ts
@@ -152,7 +152,12 @@ describe('initiateTransfer', () => {
   });
 
   it('🔴 NOTHING moves at initiate — neither ownership column is written', async () => {
-    await initiateTransfer({ appBlockId: APP, toUserId: NEW_OWNER, actorUserId: OLD_OWNER, now: NOW });
+    await initiateTransfer({
+      appBlockId: APP,
+      toUserId: NEW_OWNER,
+      actorUserId: OLD_OWNER,
+      now: NOW,
+    });
     expect(mockDb.oauthClient.updateMany).not.toHaveBeenCalled();
     expect(mockDb.appListing.updateMany).not.toHaveBeenCalled();
   });
@@ -177,7 +182,12 @@ describe('initiateTransfer', () => {
   });
 
   it('EXPIRED pending rows are reclaimed first, so one lapsed offer cannot wedge the app forever', async () => {
-    await initiateTransfer({ appBlockId: APP, toUserId: NEW_OWNER, actorUserId: OLD_OWNER, now: NOW });
+    await initiateTransfer({
+      appBlockId: APP,
+      toUserId: NEW_OWNER,
+      actorUserId: OLD_OWNER,
+      now: NOW,
+    });
     const reclaim = mockDb.appOwnershipTransfer.updateMany.mock.calls[0][0] as {
       where: { status: string; expiresAt: { lte: Date } };
       data: { status: string };
@@ -282,11 +292,7 @@ describe('acceptTransfer — 🔴 ATOMICITY of the two ownership columns', () =>
     await acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW });
     expect(order[0]).toBe('tx:begin');
     expect(order[order.length - 1]).toBe('tx:end');
-    expect(order.slice(1, -1)).toEqual([
-      'write:oauthClient',
-      'write:appListing',
-      'write:event',
-    ]);
+    expect(order.slice(1, -1)).toEqual(['write:oauthClient', 'write:appListing', 'write:event']);
   });
 
   it('🔴 the client write is STATUS-GUARDED on the previous owner — a 0-count aborts', async () => {

--- a/src/server/services/blocks/__tests__/app-ownership-transfer.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-ownership-transfer.service.test.ts
@@ -1,0 +1,408 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * App Listing COLLABORATORS — OWNERSHIP TRANSFER.
+ *
+ * The load-bearing properties, each with its own describe:
+ *   - ATOMICITY: both ownership columns move together; a failure on the SECOND write
+ *     rolls the FIRST back.
+ *   - A PENDING transfer confers NOTHING.
+ *   - MONEY INVARIANCE: `BlockBuzzAttribution` is never touched, so payout grouping by
+ *     `(app_owner_user_id, period_key)` cannot collide and the old owner keeps their
+ *     accrual.
+ *   - Submission history is preserved.
+ *   - EXPIRY and cancellation.
+ *
+ * 🔴 The `$transaction` fake runs the callback inline against the SAME mock, so it
+ * cannot itself roll anything back. The atomicity test therefore asserts what a real
+ * rollback GUARANTEES and what this fake CAN observe: that the throw propagates out of
+ * `$transaction` (so the real client aborts), and that every write the service performs
+ * is issued INSIDE that callback rather than before it. A write issued outside the
+ * transaction would survive a rollback, and that is precisely the defect being
+ * excluded — see the `writes are all inside the tx` test, which is the structural half.
+ */
+
+const { mockDb, mockRepo, mockNotify, calls } = vi.hoisted(() => {
+  const calls: string[] = [];
+  const db = {
+    appBlock: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    user: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    oauthClient: { updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })) },
+    appListing: { updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })) },
+    appOwnershipTransfer: {
+      create: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({})),
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
+    },
+    appOwnershipEvent: { create: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({})) },
+    // 🔴 Present but NEVER expected to be called. Its absence from the call log is the
+    // money-invariance assertion.
+    blockBuzzAttribution: {
+      updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 0 })),
+      update: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({})),
+    },
+    appBlockPublishRequest: { updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 0 })) },
+    appCollaborator: {
+      deleteMany: vi.fn(async (..._a: unknown[]) => ({ count: 0 })),
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+    },
+    $transaction: vi.fn(),
+  };
+  db.$transaction.mockImplementation(async (cb: (tx: typeof db) => Promise<unknown>) => {
+    calls.push('tx:begin');
+    try {
+      const r = await cb(db);
+      calls.push('tx:commit');
+      return r;
+    } catch (e) {
+      calls.push('tx:rollback');
+      throw e;
+    }
+  });
+  return {
+    mockDb: db,
+    mockRepo: {
+      grantAppRepoWrite: vi.fn(async () => undefined),
+      revokeAppRepoWrite: vi.fn(async () => undefined),
+    },
+    mockNotify: { notifyAppCollaborator: vi.fn(async () => undefined) },
+    calls,
+  };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
+vi.mock('~/server/services/blocks/app-repo-access', () => mockRepo);
+vi.mock('~/server/services/blocks/app-collaborator-notify', () => mockNotify);
+
+const { acceptTransfer, cancelTransfer, getPendingTransfer, initiateTransfer } = await import(
+  '~/server/services/blocks/app-ownership-transfer.service'
+);
+const { resolveAppAccess } = await import('~/server/services/blocks/app-access.service');
+
+const APP = 'ab_app1';
+const CLIENT = 'oc_client1';
+const SLUG = 'my-app';
+const OLD_OWNER = 10;
+const NEW_OWNER = 20;
+const STRANGER = 50;
+const TRANSFER = 'aot_t1';
+const NOW = new Date('2026-08-10T12:00:00Z');
+const FUTURE = new Date('2026-08-17T12:00:00Z');
+const PAST = new Date('2026-08-03T12:00:00Z');
+
+function liveTransfer(over: Record<string, unknown> = {}) {
+  return {
+    id: TRANSFER,
+    appBlockId: APP,
+    fromUserId: OLD_OWNER,
+    toUserId: NEW_OWNER,
+    status: 'pending',
+    expiresAt: FUTURE,
+    createdAt: NOW,
+    appBlock: { appId: CLIENT, blockId: SLUG },
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  calls.length = 0;
+  mockDb.$transaction.mockImplementation(async (cb: (tx: typeof mockDb) => Promise<unknown>) => {
+    calls.push('tx:begin');
+    try {
+      const r = await cb(mockDb);
+      calls.push('tx:commit');
+      return r;
+    } catch (e) {
+      calls.push('tx:rollback');
+      throw e;
+    }
+  });
+  mockDb.appBlock.findUnique.mockResolvedValue({
+    id: APP,
+    appId: CLIENT,
+    blockId: SLUG,
+    app: { userId: OLD_OWNER },
+  });
+  mockDb.user.findUnique.mockResolvedValue({ id: NEW_OWNER, bannedAt: null });
+  mockDb.oauthClient.updateMany.mockResolvedValue({ count: 1 });
+  mockDb.appListing.updateMany.mockResolvedValue({ count: 1 });
+  mockDb.appOwnershipTransfer.updateMany.mockResolvedValue({ count: 1 });
+  mockDb.appOwnershipTransfer.findUnique.mockResolvedValue(liveTransfer());
+  mockDb.appOwnershipTransfer.create.mockImplementation(async (args: unknown) => ({
+    ...(args as { data: Record<string, unknown> }).data,
+    createdAt: NOW,
+  }));
+});
+
+describe('initiateTransfer', () => {
+  it('the OWNER can offer; the row is pending with an expiry and an event is written', async () => {
+    const t = await initiateTransfer({
+      appBlockId: APP,
+      toUserId: NEW_OWNER,
+      actorUserId: OLD_OWNER,
+      now: NOW,
+    });
+    expect(t.status).toBe('pending');
+    expect(t.expiresAt.getTime()).toBeGreaterThan(NOW.getTime());
+    const evt = mockDb.appOwnershipEvent.create.mock.calls[0][0] as { data: { action: string } };
+    expect(evt.data.action).toBe('transfer_initiated');
+    expect(mockNotify.notifyAppCollaborator).toHaveBeenCalledOnce();
+  });
+
+  it('🔴 NOTHING moves at initiate — neither ownership column is written', async () => {
+    await initiateTransfer({ appBlockId: APP, toUserId: NEW_OWNER, actorUserId: OLD_OWNER, now: NOW });
+    expect(mockDb.oauthClient.updateMany).not.toHaveBeenCalled();
+    expect(mockDb.appListing.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('a NON-OWNER cannot initiate', async () => {
+    await expect(
+      initiateTransfer({ appBlockId: APP, toUserId: NEW_OWNER, actorUserId: STRANGER, now: NOW })
+    ).rejects.toMatchObject({ code: 'NOT_OWNER' });
+  });
+
+  it('transferring to yourself is INVALID_TARGET', async () => {
+    await expect(
+      initiateTransfer({ appBlockId: APP, toUserId: OLD_OWNER, actorUserId: OLD_OWNER, now: NOW })
+    ).rejects.toMatchObject({ code: 'INVALID_TARGET' });
+  });
+
+  it('🔴 a BANNED recipient cannot receive ownership', async () => {
+    mockDb.user.findUnique.mockResolvedValue({ id: NEW_OWNER, bannedAt: new Date() });
+    await expect(
+      initiateTransfer({ appBlockId: APP, toUserId: NEW_OWNER, actorUserId: OLD_OWNER, now: NOW })
+    ).rejects.toMatchObject({ code: 'BANNED' });
+  });
+
+  it('EXPIRED pending rows are reclaimed first, so one lapsed offer cannot wedge the app forever', async () => {
+    await initiateTransfer({ appBlockId: APP, toUserId: NEW_OWNER, actorUserId: OLD_OWNER, now: NOW });
+    const reclaim = mockDb.appOwnershipTransfer.updateMany.mock.calls[0][0] as {
+      where: { status: string; expiresAt: { lte: Date } };
+      data: { status: string };
+    };
+    expect(reclaim.where.status).toBe('pending');
+    expect(reclaim.where.expiresAt.lte).toEqual(NOW);
+    expect(reclaim.data.status).toBe('expired');
+  });
+
+  it('a concurrent second offer loses on the partial-unique index (P2002) with a friendly error', async () => {
+    mockDb.appOwnershipTransfer.create.mockRejectedValue(
+      Object.assign(new Error('Unique constraint failed'), { code: 'P2002' })
+    );
+    await expect(
+      initiateTransfer({ appBlockId: APP, toUserId: NEW_OWNER, actorUserId: OLD_OWNER, now: NOW })
+    ).rejects.toMatchObject({ code: 'ALREADY_SEATED' });
+  });
+
+  it('🔴 NEGATIVE CONTROL: a non-P2002 error is NOT swallowed as "already pending"', async () => {
+    // A broad catch here would mask genuine write failures as a benign conflict.
+    mockDb.appOwnershipTransfer.create.mockRejectedValue(
+      Object.assign(new Error('connection reset'), { code: 'P1001' })
+    );
+    await expect(
+      initiateTransfer({ appBlockId: APP, toUserId: NEW_OWNER, actorUserId: OLD_OWNER, now: NOW })
+    ).rejects.toThrow('connection reset');
+  });
+});
+
+describe('a PENDING transfer confers NOTHING on the recipient', () => {
+  it('resolveAppAccess gives the recipient no role while the offer is open', async () => {
+    // The access predicate does not consult the transfer table at all — asserted by
+    // observing the resolved role, which is the property that matters.
+    mockDb.appBlock.findUnique.mockResolvedValue({ id: APP, app: { userId: OLD_OWNER } });
+    // No SEAT exists for the recipient — the open offer is the only thing linking them
+    // to the app, and it must count for nothing.
+    mockDb.appCollaborator.findFirst.mockResolvedValue(null);
+    const access = await resolveAppAccess(APP, NEW_OWNER);
+    expect(access!.role).toBeNull();
+    expect(access!.ownerUserId).toBe(OLD_OWNER);
+  });
+});
+
+describe('acceptTransfer — 🔴 ATOMICITY of the two ownership columns', () => {
+  it('moves BOTH OauthClient.userId and AppListing.userId', async () => {
+    const res = await acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW });
+    expect(res).toMatchObject({ fromUserId: OLD_OWNER, toUserId: NEW_OWNER });
+
+    const client = mockDb.oauthClient.updateMany.mock.calls[0][0] as {
+      where: { id: string; userId: number };
+      data: { userId: number };
+    };
+    expect(client.where).toEqual({ id: CLIENT, userId: OLD_OWNER });
+    expect(client.data.userId).toBe(NEW_OWNER);
+
+    const listing = mockDb.appListing.updateMany.mock.calls[0][0] as {
+      where: { appBlockId: string };
+      data: { userId: number };
+    };
+    expect(listing.where.appBlockId).toBe(APP);
+    expect(listing.data.userId).toBe(NEW_OWNER);
+  });
+
+  it('🔴 a failure on the SECOND write aborts the transaction (the first cannot commit alone)', async () => {
+    mockDb.appListing.updateMany.mockRejectedValue(new Error('listing write exploded'));
+    await expect(
+      acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW })
+    ).rejects.toThrow('listing write exploded');
+    // The throw must escape `$transaction` — that is what makes the real client roll
+    // the first write back.
+    expect(calls).toContain('tx:rollback');
+    expect(calls).not.toContain('tx:commit');
+    // …and no audit event is left behind by a transfer that did not happen.
+    expect(mockDb.appOwnershipEvent.create).not.toHaveBeenCalled();
+    // …nor any post-commit external effect.
+    expect(mockRepo.revokeAppRepoWrite).not.toHaveBeenCalled();
+    expect(mockRepo.grantAppRepoWrite).not.toHaveBeenCalled();
+  });
+
+  it('🔴 STRUCTURAL: every ownership write is issued INSIDE the transaction', async () => {
+    // A write issued before `$transaction` would survive a rollback, which the inline
+    // fake above cannot detect by outcome. Assert the ordering instead.
+    const order: string[] = [];
+    mockDb.$transaction.mockImplementation(async (cb: (tx: typeof mockDb) => Promise<unknown>) => {
+      order.push('tx:begin');
+      const r = await cb(mockDb);
+      order.push('tx:end');
+      return r;
+    });
+    mockDb.oauthClient.updateMany.mockImplementation(async () => {
+      order.push('write:oauthClient');
+      return { count: 1 };
+    });
+    mockDb.appListing.updateMany.mockImplementation(async () => {
+      order.push('write:appListing');
+      return { count: 1 };
+    });
+    mockDb.appOwnershipEvent.create.mockImplementation(async () => {
+      order.push('write:event');
+      return {};
+    });
+    await acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW });
+    expect(order[0]).toBe('tx:begin');
+    expect(order[order.length - 1]).toBe('tx:end');
+    expect(order.slice(1, -1)).toEqual([
+      'write:oauthClient',
+      'write:appListing',
+      'write:event',
+    ]);
+  });
+
+  it('🔴 the client write is STATUS-GUARDED on the previous owner — a 0-count aborts', async () => {
+    // Ownership changed since the offer (a second transfer landed first).
+    mockDb.oauthClient.updateMany.mockResolvedValue({ count: 0 });
+    await expect(
+      acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW })
+    ).rejects.toMatchObject({ code: 'NO_INVITE' });
+    expect(mockDb.appListing.updateMany).not.toHaveBeenCalled();
+    expect(mockDb.appOwnershipEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('an app with NO listing yet still transfers (a 0-count on the listing is legitimate)', async () => {
+    // A first-version app pending approval has no AppListing row; that must not fail
+    // the transfer, which is why the listing write is deliberately NOT status-guarded.
+    mockDb.appListing.updateMany.mockResolvedValue({ count: 0 });
+    await expect(
+      acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW })
+    ).resolves.toMatchObject({ toUserId: NEW_OWNER });
+  });
+
+  it('only the ADDRESSEE can accept', async () => {
+    await expect(
+      acceptTransfer({ transferId: TRANSFER, userId: STRANGER, now: NOW })
+    ).rejects.toMatchObject({ code: 'NOT_OWNER' });
+    expect(mockDb.oauthClient.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('🔴 an EXPIRED offer cannot be accepted', async () => {
+    mockDb.appOwnershipTransfer.findUnique.mockResolvedValue(liveTransfer({ expiresAt: PAST }));
+    await expect(
+      acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW })
+    ).rejects.toMatchObject({ code: 'NO_INVITE' });
+    expect(mockDb.oauthClient.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('a CANCELLED offer cannot be accepted', async () => {
+    mockDb.appOwnershipTransfer.findUnique.mockResolvedValue(liveTransfer({ status: 'cancelled' }));
+    await expect(
+      acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW })
+    ).rejects.toMatchObject({ code: 'NO_INVITE' });
+  });
+
+  it('swaps the Forgejo grants post-commit: OLD owner revoked, NEW owner granted', async () => {
+    await acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW });
+    expect(mockRepo.revokeAppRepoWrite).toHaveBeenCalledWith({ slug: SLUG, userId: OLD_OWNER });
+    expect(mockRepo.grantAppRepoWrite).toHaveBeenCalledWith({ slug: SLUG, userId: NEW_OWNER });
+  });
+});
+
+describe('🔴 MONEY INVARIANCE — attribution and payout grouping are untouched', () => {
+  it('accept never writes BlockBuzzAttribution', async () => {
+    await acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW });
+    // Rewriting `appOwnerUserId` mid-period would merge two owners' pending rows into
+    // ONE payout group and can collide on the (app_owner_user_id, period_key) UNIQUE.
+    // The old owner also stops being paid for what they already accrued.
+    expect(mockDb.blockBuzzAttribution.updateMany).not.toHaveBeenCalled();
+    expect(mockDb.blockBuzzAttribution.update).not.toHaveBeenCalled();
+  });
+
+  it('accept never rewrites submission history (AppBlockPublishRequest.submittedByUserId)', async () => {
+    await acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW });
+    expect(mockDb.appBlockPublishRequest.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('accept never removes collaborator seats — the app keeps its editors', async () => {
+    await acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW });
+    expect(mockDb.appCollaborator.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it('POSITIVE CONTROL: those mocks CAN record a call', async () => {
+    // Otherwise the three "not called" assertions above are indistinguishable from
+    // mocks wired to nothing.
+    await mockDb.blockBuzzAttribution.updateMany({ where: {}, data: {} });
+    await mockDb.appBlockPublishRequest.updateMany({ where: {}, data: {} });
+    await mockDb.appCollaborator.deleteMany({ where: {} });
+    expect(mockDb.blockBuzzAttribution.updateMany).toHaveBeenCalledOnce();
+    expect(mockDb.appBlockPublishRequest.updateMany).toHaveBeenCalledOnce();
+    expect(mockDb.appCollaborator.deleteMany).toHaveBeenCalledOnce();
+  });
+});
+
+describe('cancelTransfer / getPendingTransfer', () => {
+  it('the OWNER can withdraw the offer', async () => {
+    const res = await cancelTransfer({ transferId: TRANSFER, actorUserId: OLD_OWNER, now: NOW });
+    expect(res.cancelled).toBe(true);
+    const evt = mockDb.appOwnershipEvent.create.mock.calls[0][0] as { data: { action: string } };
+    expect(evt.data.action).toBe('transfer_cancelled');
+  });
+
+  it('the RECIPIENT can decline', async () => {
+    await expect(
+      cancelTransfer({ transferId: TRANSFER, actorUserId: NEW_OWNER, now: NOW })
+    ).resolves.toMatchObject({ cancelled: true });
+  });
+
+  it('a third party cannot cancel', async () => {
+    await expect(
+      cancelTransfer({ transferId: TRANSFER, actorUserId: STRANGER, now: NOW })
+    ).rejects.toMatchObject({ code: 'NOT_OWNER' });
+  });
+
+  it('cancelling an already-terminal transfer is a no-op, not an error', async () => {
+    mockDb.appOwnershipTransfer.updateMany.mockResolvedValue({ count: 0 });
+    const res = await cancelTransfer({ transferId: TRANSFER, actorUserId: OLD_OWNER, now: NOW });
+    expect(res.cancelled).toBe(false);
+    expect(mockDb.appOwnershipEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('getPendingTransfer returns a LIVE offer', async () => {
+    mockDb.appOwnershipTransfer.findFirst.mockResolvedValue(liveTransfer());
+    expect(await getPendingTransfer({ appBlockId: APP, now: NOW })).toMatchObject({ id: TRANSFER });
+  });
+
+  it('🔴 getPendingTransfer treats an EXPIRED row as ABSENT (read-time predicate, no sweeper needed)', async () => {
+    mockDb.appOwnershipTransfer.findFirst.mockResolvedValue(liveTransfer({ expiresAt: PAST }));
+    expect(await getPendingTransfer({ appBlockId: APP, now: NOW })).toBeNull();
+  });
+});

--- a/src/server/services/blocks/__tests__/app-repo-access.test.ts
+++ b/src/server/services/blocks/__tests__/app-repo-access.test.ts
@@ -28,7 +28,9 @@ const { forgejo, gitAccess, logs } = vi.hoisted(() => ({
   },
   // Typed args so `logToAxiom.mock.calls[0][0]` is indexable under an explicit
   // test typecheck (tsconfig excludes __tests__, so only that run catches it).
-  logs: { logToAxiom: vi.fn(async (_payload: Record<string, unknown>, _tag?: string) => undefined) },
+  logs: {
+    logToAxiom: vi.fn(async (_payload: Record<string, unknown>, _tag?: string) => undefined),
+  },
 }));
 
 vi.mock('~/server/services/blocks/forgejo.service', () => forgejo);
@@ -106,10 +108,9 @@ describe('the full lifecycle, as a sequence of Forgejo calls', () => {
     await revokeAppRepoWrite({ slug: SLUG, userId: OLD });
     await grantAppRepoWrite({ slug: SLUG, userId: NEW });
 
-    expect(forgejo.addCollaborator.mock.calls.map((c) => (c[0] as { username: string }).username)).toEqual([
-      `dev-${EDITOR}`,
-      `dev-${NEW}`,
-    ]);
+    expect(
+      forgejo.addCollaborator.mock.calls.map((c) => (c[0] as { username: string }).username)
+    ).toEqual([`dev-${EDITOR}`, `dev-${NEW}`]);
     expect(
       forgejo.removeCollaborator.mock.calls.map((c) => (c[0] as { username: string }).username)
     ).toEqual([`dev-${EDITOR}`, `dev-${OLD}`]);

--- a/src/server/services/blocks/__tests__/app-repo-access.test.ts
+++ b/src/server/services/blocks/__tests__/app-repo-access.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * App Listing COLLABORATORS — the FORGEJO grant/revoke lifecycle.
+ *
+ * A FAKE Forgejo client asserting the EXACT calls made on accept / remove / transfer.
+ * The `forgejo.service` and `dev-git-access.service` modules are mocked at the
+ * boundary (the convention `dev-git-access.service.test.ts` established), so no HTTP
+ * and no Prisma is booted.
+ *
+ * 🔴 The NEGATIVE case is the one with no prior art: before this change the repo could
+ * only ever GRANT — `forgejo.service` had `addCollaborator` and nothing to undo it, so
+ * a developer handed `write` kept it forever. "A removed editor no longer has write" is
+ * therefore a genuinely new assertion, not a restatement.
+ */
+
+const { forgejo, gitAccess, logs } = vi.hoisted(() => ({
+  forgejo: {
+    addCollaborator: vi.fn(async (..._a: unknown[]) => ({ outcome: 'granted' })),
+    removeCollaborator: vi.fn(async (..._a: unknown[]) => undefined),
+  },
+  gitAccess: {
+    ensureForgejoIdentity: vi.fn(async (userId: number) => ({
+      forgejoUsername: `dev-${userId}`,
+      token: 'tok',
+    })),
+    forgejoUsernameForUser: vi.fn((userId: number) => `dev-${userId}`),
+  },
+  // Typed args so `logToAxiom.mock.calls[0][0]` is indexable under an explicit
+  // test typecheck (tsconfig excludes __tests__, so only that run catches it).
+  logs: { logToAxiom: vi.fn(async (_payload: Record<string, unknown>, _tag?: string) => undefined) },
+}));
+
+vi.mock('~/server/services/blocks/forgejo.service', () => forgejo);
+vi.mock('~/server/services/blocks/dev-git-access.service', () => gitAccess);
+vi.mock('~/server/logging/client', () => logs);
+
+const { grantAppRepoWrite, revokeAppRepoWrite } = await import(
+  '~/server/services/blocks/app-repo-access'
+);
+
+const SLUG = 'my-app';
+const EDITOR = 20;
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('grantAppRepoWrite', () => {
+  it('provisions the identity and grants exactly `write` on civitai-apps/<slug>', async () => {
+    await grantAppRepoWrite({ slug: SLUG, userId: EDITOR });
+    expect(gitAccess.ensureForgejoIdentity).toHaveBeenCalledWith(EDITOR);
+    expect(forgejo.addCollaborator).toHaveBeenCalledExactlyOnceWith({
+      slug: SLUG,
+      username: `dev-${EDITOR}`,
+      permission: 'write',
+    });
+    expect(forgejo.removeCollaborator).not.toHaveBeenCalled();
+  });
+
+  it('a Forgejo outage does NOT propagate (a consent decision must not be rolled back)', async () => {
+    forgejo.addCollaborator.mockRejectedValue(new Error('forgejo 502'));
+    await expect(grantAppRepoWrite({ slug: SLUG, userId: EDITOR })).resolves.toBeUndefined();
+    const logged = logs.logToAxiom.mock.calls[0][0] as unknown as { name: string; message: string };
+    expect(logged.name).toBe('app-repo-access');
+    expect(logged.message).toBe('grant-failed');
+  });
+});
+
+describe('revokeAppRepoWrite — 🔴 the half that did not exist before', () => {
+  it('removes the collaborator row for the derived username', async () => {
+    await revokeAppRepoWrite({ slug: SLUG, userId: EDITOR });
+    expect(forgejo.removeCollaborator).toHaveBeenCalledExactlyOnceWith({
+      slug: SLUG,
+      username: `dev-${EDITOR}`,
+    });
+    expect(forgejo.addCollaborator).not.toHaveBeenCalled();
+  });
+
+  it('🔴 uses the PURE username derivation — revoking must never PROVISION an identity', async () => {
+    // `ensureForgejoIdentity` creates a Forgejo user and mints a push token on miss.
+    // Calling it here would mean revoking someone's access can bring their credential
+    // into existence — the exact inverse of the intent.
+    await revokeAppRepoWrite({ slug: SLUG, userId: EDITOR });
+    expect(gitAccess.forgejoUsernameForUser).toHaveBeenCalledWith(EDITOR);
+    expect(gitAccess.ensureForgejoIdentity).not.toHaveBeenCalled();
+  });
+
+  it('a Forgejo outage does NOT propagate, and is logged as revoke-failed', async () => {
+    forgejo.removeCollaborator.mockRejectedValue(new Error('forgejo 500'));
+    await expect(revokeAppRepoWrite({ slug: SLUG, userId: EDITOR })).resolves.toBeUndefined();
+    const logged = logs.logToAxiom.mock.calls[0][0] as unknown as { message: string };
+    // The ONLY signal that a revoke was dropped — a durable retry is a follow-up.
+    expect(logged.message).toBe('revoke-failed');
+  });
+});
+
+describe('the full lifecycle, as a sequence of Forgejo calls', () => {
+  it('accept → grant; remove → revoke; transfer → revoke(old) + grant(new)', async () => {
+    const OLD = 10;
+    const NEW = 30;
+
+    // 1. An invite is ACCEPTED.
+    await grantAppRepoWrite({ slug: SLUG, userId: EDITOR });
+    // 2. That editor is REMOVED.
+    await revokeAppRepoWrite({ slug: SLUG, userId: EDITOR });
+    // 3. Ownership is TRANSFERRED.
+    await revokeAppRepoWrite({ slug: SLUG, userId: OLD });
+    await grantAppRepoWrite({ slug: SLUG, userId: NEW });
+
+    expect(forgejo.addCollaborator.mock.calls.map((c) => (c[0] as { username: string }).username)).toEqual([
+      `dev-${EDITOR}`,
+      `dev-${NEW}`,
+    ]);
+    expect(
+      forgejo.removeCollaborator.mock.calls.map((c) => (c[0] as { username: string }).username)
+    ).toEqual([`dev-${EDITOR}`, `dev-${OLD}`]);
+  });
+
+  it('🔴 NEGATIVE: the removed editor is never re-granted anywhere in that sequence', async () => {
+    const NEW = 30;
+    await grantAppRepoWrite({ slug: SLUG, userId: EDITOR });
+    await revokeAppRepoWrite({ slug: SLUG, userId: EDITOR });
+    await grantAppRepoWrite({ slug: SLUG, userId: NEW });
+    const grantsAfterRevoke = forgejo.addCollaborator.mock.calls
+      .slice(1)
+      .map((c) => (c[0] as { username: string }).username);
+    expect(grantsAfterRevoke).not.toContain(`dev-${EDITOR}`);
+  });
+});

--- a/src/server/services/blocks/app-access.service.ts
+++ b/src/server/services/blocks/app-access.service.ts
@@ -1,3 +1,5 @@
+import { TRPCError } from '@trpc/server';
+
 import { dbRead } from '~/server/db/client';
 
 /**
@@ -190,6 +192,49 @@ export async function resolveListingAccess(
   if (!appBlockId) return { ...base, role: null };
   const editor = await hasAcceptedSeat(appBlockId, userId);
   return { ...base, role: editor ? 'editor' : null };
+}
+
+/**
+ * THE app-authoring gate for `blocks.router`'s four owner-scoped procs
+ * (`getMyAppRepo`, `getMyAppManifest`, `updateManifest`, `getMyForgejoCloneInfo`).
+ *
+ * Replaces four byte-identical open-codings of `block.app?.userId !== ctx.user!.id`.
+ * Lives HERE rather than in the router so it has exactly one home AND is directly
+ * unit-testable — importing the 7.9k-line router into a test to exercise one guard
+ * would drag in a module graph that has nothing to do with access.
+ *
+ * 🔴 NO MODERATOR BYPASS — deliberately preserved. All four gates were strict before
+ * collaborators: a moderator who does not personally own the app was refused, unlike
+ * the App Listing asset gates which do bypass. That divergence is PRE-EXISTING and is
+ * recorded in `app-access.call-site-ledger.test.ts` rather than silently changed here.
+ *
+ * The message is `'Not the app owner'` VERBATIM — it is what callers see today, and the
+ * mutation checks assert this exact string so a mutant that breaks this guard dies to
+ * THIS error rather than to a neighbouring one.
+ */
+export async function assertAppEditAccess(args: {
+  appBlockId: string;
+  /**
+   * The owner the CALLER already loaded (`block.app?.userId`).
+   *
+   * 🔴 Passed in rather than re-read. All four call sites have just selected the
+   * AppBlock with its `app: { select: { userId } }`, so re-resolving it here would be a
+   * second identical round trip on every one of those procs — and it would make the
+   * gate's answer depend on a row read at a DIFFERENT instant than the one the proc
+   * goes on to use. `undefined`/`null` (a missing app or a dangling `app_id`) is
+   * refused: an app with no resolvable owner is an app nobody may edit.
+   */
+  ownerUserId: number | null | undefined;
+  userId: number;
+}): Promise<void> {
+  const deny = () => {
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'Not the app owner' });
+  };
+  if (typeof args.ownerUserId !== 'number') deny();
+  if (args.ownerUserId === args.userId) return;
+  // Not the owner — the only remaining route in is an ACCEPTED seat. Costs one query,
+  // and ONLY on the non-owner path, so the common case is unchanged.
+  if (!(await hasAcceptedSeat(args.appBlockId, args.userId))) deny();
 }
 
 export type AccessibleAppBlocks = {

--- a/src/server/services/blocks/app-access.service.ts
+++ b/src/server/services/blocks/app-access.service.ts
@@ -1,0 +1,293 @@
+import { dbRead } from '~/server/db/client';
+
+/**
+ * App Listing COLLABORATORS — THE consolidated app-access predicate.
+ *
+ * ## Why this module exists
+ *
+ * Before it, "does this caller control this app?" was open-coded at ~14 production
+ * sites in four different shapes:
+ *
+ *   - `block.app?.userId !== ctx.user!.id`            (blocks.router, ×4, hard throw)
+ *   - `listing.userId !== user.id && !user.isModerator` (app-listing-assets, mod bypass)
+ *   - `listing.userId !== userId`                      (offsite-listing, NO mod bypass)
+ *   - `where: { app: { userId } }`                     (analytics/nav, silent empty)
+ *
+ * Consolidating them surfaced real disagreements between those sites — they are
+ * catalogued in `app-access.call-site-ledger.test.ts` (which also FAILS when the set
+ * of owner-gated sites grows or shrinks) rather than silently normalised here.
+ *
+ * ## The model
+ *
+ * Ownership is canonically `OauthClient.userId`, reached as `AppBlock.app.userId`.
+ * `AppListing.userId` is a DENORMALIZED COPY. A collaborator seat (`AppCollaborator`)
+ * is keyed to the `AppBlock`, so this module resolves listing-shaped questions by
+ * walking back to the AppBlock.
+ *
+ *   role 'owner'  → the OauthClient owner. Everything an editor can do, PLUS managing
+ *                   collaborators and initiating an ownership transfer.
+ *   role 'editor' → an ACCEPTED `AppCollaborator`. Listing content + media + submit a
+ *                   new version + app-scoped analytics AND earnings. Effectively a
+ *                   co-owner minus the two owner-only actions above.
+ *   role null     → no access. This INCLUDES a `pending` and a `rejected` seat:
+ *                   🔴 an unaccepted invite must confer ZERO capability, or anyone
+ *                   could attach a stranger's identity to their app by inviting them.
+ *
+ * Moderator status is deliberately NOT folded in here. It is an orthogonal axis and
+ * the existing sites disagree about it (see the ledger); each call site keeps its own
+ * `user.isModerator` handling exactly as before, so this consolidation cannot silently
+ * grant or revoke a mod bypass anywhere.
+ *
+ * ## INERT UNTIL THE MIGRATION IS APPLIED
+ *
+ * 🔴 The `app_collaborators` table is MANUAL-APPLY (datapacket-talos DB rule #8) — no
+ * deploy path runs `prisma migrate deploy`. Every read of it therefore goes through
+ * {@link safeCollaboratorQuery}, which catches "relation does not exist" and degrades
+ * to "no collaborators". With the table absent, `resolveAppAccess` returns exactly
+ * `owner`/`null` — byte-identical to the pre-change owner-only behaviour — instead of
+ * 500ing every app page. The WRITE paths do not swallow it (an invite that silently
+ * did nothing would be worse than an error).
+ */
+
+/** The two capability roles. `null` (no access) is modelled as the absence of one. */
+export type AppRole = 'owner' | 'editor';
+
+export type AppAccess = {
+  appBlockId: string;
+  /** The canonical owner (`OauthClient.userId`). */
+  ownerUserId: number;
+  /** `null` = the caller has NO access (stranger, or a pending/rejected invite). */
+  role: AppRole | null;
+};
+
+export type ListingAccess = {
+  appListingId: string;
+  /** The listing's denormalized owner column. */
+  ownerUserId: number;
+  /**
+   * The AppBlock a collaborator seat could be keyed to. `null` for a natively-created
+   * OFFSITE listing (it has no backing AppBlock at all), in which case only the owner
+   * has access — there is nothing to collaborate on.
+   */
+  appBlockId: string | null;
+  role: AppRole | null;
+};
+
+/** The one status that confers capability. Nothing else does. */
+export const ACCEPTED = 'accepted' as const;
+
+/**
+ * Postgres/Prisma "the table isn't there yet" signals.
+ *
+ * P2021 is Prisma's typed code; 42P01 is the raw PG SQLSTATE that surfaces through
+ * `$queryRaw` and through some driver paths where Prisma has not classified the error.
+ * Matching BOTH matters: a check on P2021 alone let a raw-path failure through in
+ * local testing.
+ */
+function isMissingTableError(err: unknown): boolean {
+  const code = (err as { code?: unknown })?.code;
+  if (code === 'P2021' || code === '42P01') return true;
+  // Prisma wraps the driver error; the SQLSTATE is only in the message on some paths.
+  const message = (err as { message?: unknown })?.message;
+  return typeof message === 'string' && /does not exist|42P01/i.test(message);
+}
+
+/**
+ * Run a collaborator-table READ, degrading to `fallback` when the manual-apply
+ * migration has not landed yet.
+ *
+ * 🔴 Deliberately narrow: it swallows ONLY the missing-table error. A genuine query
+ * bug, a connection failure or a constraint error still propagates — otherwise this
+ * would be a permanent silent-zero generator, which is exactly the failure mode the
+ * repo keeps paying for elsewhere.
+ */
+export async function safeCollaboratorQuery<T>(fn: () => Promise<T>, fallback: T): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (isMissingTableError(err)) return fallback;
+    throw err;
+  }
+}
+
+/**
+ * Is `userId` an ACCEPTED collaborator on `appBlockId`?
+ *
+ * The `status: ACCEPTED` filter is the consent gate and is NOT optional — see the
+ * module header. Callers must never widen this to "a row exists".
+ */
+async function hasAcceptedSeat(appBlockId: string, userId: number): Promise<boolean> {
+  const row = await safeCollaboratorQuery(
+    () =>
+      dbRead.appCollaborator.findFirst({
+        where: { appBlockId, userId, status: ACCEPTED },
+        select: { userId: true },
+      }),
+    null
+  );
+  return !!row;
+}
+
+/**
+ * Resolve the caller's role on an App Block.
+ *
+ * Returns `null` when the AppBlock does not exist, or when it has no resolvable owner
+ * (a dangling `app_id`) — an app nobody owns is an app nobody may edit, which is the
+ * fail-closed reading.
+ */
+export async function resolveAppAccess(
+  appBlockId: string,
+  userId: number | null | undefined
+): Promise<AppAccess | null> {
+  const block = await dbRead.appBlock.findUnique({
+    where: { id: appBlockId },
+    select: { id: true, app: { select: { userId: true } } },
+  });
+  if (!block?.app) return null;
+  const ownerUserId = block.app.userId;
+  if (typeof userId !== 'number') {
+    return { appBlockId: block.id, ownerUserId, role: null };
+  }
+  if (ownerUserId === userId) {
+    return { appBlockId: block.id, ownerUserId, role: 'owner' };
+  }
+  const editor = await hasAcceptedSeat(block.id, userId);
+  return { appBlockId: block.id, ownerUserId, role: editor ? 'editor' : null };
+}
+
+/**
+ * Resolve the caller's role on an App LISTING.
+ *
+ * 🔴 SHADOW-AWARE. A shadow revision (`revisionOfId != null`) carries
+ * `appBlockId: null` by construction — `appBlockId` is `@unique` and stays on the
+ * parent. So resolving a shadow's collaborator seat MUST walk to its parent, or every
+ * editor would lose access the moment their first media edit minted the shadow. That
+ * is one hop only: `beginListingRevision` refuses to open a revision of a revision.
+ *
+ * A natively-created offsite listing (no backing AppBlock anywhere in the chain)
+ * resolves `appBlockId: null` and therefore only ever `owner`/`null`.
+ */
+export async function resolveListingAccess(
+  appListingId: string,
+  userId: number | null | undefined
+): Promise<ListingAccess | null> {
+  const listing = await dbRead.appListing.findUnique({
+    where: { id: appListingId },
+    select: {
+      id: true,
+      userId: true,
+      appBlockId: true,
+      revisionOfId: true,
+      revisionOf: { select: { appBlockId: true } },
+    },
+  });
+  if (!listing) return null;
+  // A shadow's seat lives on its PARENT's AppBlock (see the note above).
+  const appBlockId = listing.appBlockId ?? listing.revisionOf?.appBlockId ?? null;
+  const base = { appListingId: listing.id, ownerUserId: listing.userId, appBlockId };
+  if (typeof userId !== 'number') return { ...base, role: null };
+  if (listing.userId === userId) return { ...base, role: 'owner' };
+  if (!appBlockId) return { ...base, role: null };
+  const editor = await hasAcceptedSeat(appBlockId, userId);
+  return { ...base, role: editor ? 'editor' : null };
+}
+
+export type AccessibleAppBlocks = {
+  /** AppBlock ids the caller OWNS (via `OauthClient.userId`). */
+  ownedIds: string[];
+  /** AppBlock ids the caller holds an ACCEPTED editor seat on. Disjoint from owned. */
+  editorIds: string[];
+  /** The union, de-duplicated. The scope every app-scoped read must filter by. */
+  allIds: string[];
+};
+
+/**
+ * Enumerate every AppBlock the caller may act on, split by how.
+ *
+ * 🔴 THIS IS THE ONLY SAFE INPUT TO AN EARNINGS OR ANALYTICS QUERY FOR A NON-OWNER.
+ * The pre-existing earnings reads (`getRevenueForOwner`,
+ * `getRecentAttributionsForOwner`, `getMyApps`' lifetime groupBy) key on
+ * `BlockBuzzAttribution.appOwnerUserId` — a USER-WIDE filter. "Widening" one of those
+ * for an editor by passing the OWNER's id would hand the editor the owner's ENTIRE
+ * PORTFOLIO, including apps they were never invited to. Every collaborator-reachable
+ * money/analytics read must instead filter `appBlockId IN allIds`. See
+ * `app-collaborator-earnings.service.ts`, and the regression test
+ * `app-collaborator-earnings.service.test.ts`, which fixtures an owner with 2 apps and
+ * an editor on 1 and asserts the second never appears.
+ */
+export async function resolveAccessibleAppBlockIds(userId: number): Promise<AccessibleAppBlocks> {
+  const [owned, seats] = await Promise.all([
+    dbRead.appBlock.findMany({ where: { app: { userId } }, select: { id: true } }),
+    safeCollaboratorQuery(
+      () =>
+        dbRead.appCollaborator.findMany({
+          where: { userId, status: ACCEPTED },
+          select: { appBlockId: true },
+        }),
+      [] as { appBlockId: string }[]
+    ),
+  ]);
+  const ownedIds = owned.map((b: { id: string }) => b.id);
+  const ownedSet = new Set(ownedIds);
+  // Disjoint by construction: an owner who somehow also holds a seat on their own app
+  // counts once, as an owner. (The invite path refuses to seat the owner, so this is
+  // defence against a hand-written row, not an expected state.)
+  const editorIds = seats
+    .map((s: { appBlockId: string }) => s.appBlockId)
+    .filter((id: string) => !ownedSet.has(id));
+  return { ownedIds, editorIds, allIds: [...ownedIds, ...editorIds] };
+}
+
+/**
+ * The PUBLIC byline set for an app: the user ids of its ACCEPTED **and** `displayed`
+ * collaborators.
+ *
+ * 🔴 BOTH predicates are load-bearing and neither may be dropped:
+ *   - `status = accepted` is CONSENT (a pending invitee never appears publicly, so an
+ *     app cannot borrow a stranger's name), and
+ *   - `displayed = true` is the byline OPT-OUT (an accepted editor who does not want
+ *     public credit).
+ * `app-listing.public-collaborators.test.ts` asserts a pending, a rejected and an
+ * accepted-but-undisplayed row are all absent from the public projection.
+ */
+export async function listDisplayedCollaboratorUserIds(appBlockId: string): Promise<number[]> {
+  const rows = await safeCollaboratorQuery(
+    () =>
+      dbRead.appCollaborator.findMany({
+        where: { appBlockId, status: ACCEPTED, displayed: true },
+        select: { userId: true },
+        orderBy: { createdAt: 'asc' },
+      }),
+    [] as { userId: number }[]
+  );
+  return rows.map((r: { userId: number }) => r.userId);
+}
+
+/**
+ * The user ids that must be treated as "the app's own people" for ANTI-ABUSE
+ * purposes — the owner plus every ACCEPTED collaborator, REGARDLESS of `displayed`.
+ *
+ * 🔴 `displayed` is deliberately NOT filtered here, and the asymmetry with
+ * {@link listDisplayedCollaboratorUserIds} is the whole point: `displayed` is a
+ * PUBLIC-CREDIT preference, not a capability. An editor who opted out of the byline is
+ * still an insider, so they still must not be able to 5-star the app they can edit.
+ * Filtering on `displayed` here would make "hide my name" a self-review bypass.
+ */
+export async function listAppInsiderUserIds(appBlockId: string): Promise<number[]> {
+  const block = await dbRead.appBlock.findUnique({
+    where: { id: appBlockId },
+    select: { app: { select: { userId: true } } },
+  });
+  if (!block?.app) return [];
+  const seats = await safeCollaboratorQuery(
+    () =>
+      dbRead.appCollaborator.findMany({
+        where: { appBlockId, status: ACCEPTED },
+        select: { userId: true },
+      }),
+    [] as { userId: number }[]
+  );
+  const ids = new Set<number>([block.app.userId]);
+  for (const s of seats) ids.add(s.userId);
+  return [...ids];
+}

--- a/src/server/services/blocks/app-access.service.ts
+++ b/src/server/services/blocks/app-access.service.ts
@@ -85,13 +85,26 @@ export const ACCEPTED = 'accepted' as const;
  * `$queryRaw` and through some driver paths where Prisma has not classified the error.
  * Matching BOTH matters: a check on P2021 alone let a raw-path failure through in
  * local testing.
+ *
+ * 🔴 THE MESSAGE BRANCH IS DELIBERATELY NARROWER THAN "does not exist". That substring
+ * also appears in `column "displayed" does not exist` and in
+ * `column "x" of relation "y" does not exist` (SQLSTATE 42703) — which is EXACTLY what a
+ * HALF-APPLIED manual migration produces, and this repo applies migrations by hand
+ * (datapacket-talos DB rule #8). Swallowing a column error would degrade a genuinely
+ * broken schema to a permanent silent "no collaborators" instead of surfacing it. So the
+ * message branch requires the missing object to be named as a RELATION or TABLE, and
+ * refuses anything that mentions a column at all. `app-access.service.test.ts` pins both
+ * directions, including the "broadened back to `does not exist` / `not found`" mutants.
  */
 function isMissingTableError(err: unknown): boolean {
   const code = (err as { code?: unknown })?.code;
   if (code === 'P2021' || code === '42P01') return true;
   // Prisma wraps the driver error; the SQLSTATE is only in the message on some paths.
   const message = (err as { message?: unknown })?.message;
-  return typeof message === 'string' && /does not exist|42P01/i.test(message);
+  if (typeof message !== 'string') return false;
+  // A column/attribute error is a HALF-APPLIED migration, not an absent table.
+  if (/\bcolumns?\b/i.test(message)) return false;
+  return /\b42P01\b/.test(message) || /\b(?:relation|table)\s+\S+\s+does not exist/i.test(message);
 }
 
 /**
@@ -113,15 +126,27 @@ export async function safeCollaboratorQuery<T>(fn: () => Promise<T>, fallback: T
 }
 
 /**
+ * The Prisma pool a resolve should read through.
+ *
+ * Defaults to the replica. Callers pass `dbWrite` when the rows in question may have
+ * been INSERTed milliseconds ago — see {@link resolveListingAccess}.
+ */
+export type AccessDb = typeof dbRead;
+
+/**
  * Is `userId` an ACCEPTED collaborator on `appBlockId`?
  *
  * The `status: ACCEPTED` filter is the consent gate and is NOT optional — see the
  * module header. Callers must never widen this to "a row exists".
  */
-async function hasAcceptedSeat(appBlockId: string, userId: number): Promise<boolean> {
+async function hasAcceptedSeat(
+  appBlockId: string,
+  userId: number,
+  db: AccessDb = dbRead
+): Promise<boolean> {
   const row = await safeCollaboratorQuery(
     () =>
-      dbRead.appCollaborator.findFirst({
+      db.appCollaborator.findFirst({
         where: { appBlockId, userId, status: ACCEPTED },
         select: { userId: true },
       }),
@@ -168,12 +193,22 @@ export async function resolveAppAccess(
  *
  * A natively-created offsite listing (no backing AppBlock anywhere in the chain)
  * resolves `appBlockId: null` and therefore only ever `owner`/`null`.
+ *
+ * 🔴 `db` IS LOAD-BEARING, NOT AN ERGONOMIC. The asset gates in
+ * `app-listing-assets.service.ts` already carry a `dbWrite` pool override so the OWNER's
+ * FIRST edit does not 404 off a lagging replica (the shadow was INSERTed milliseconds
+ * ago). An EDITOR never takes the owner short-circuit at all — a shadow's `userId` is
+ * the PARENT OWNER's — so the collaborator fallback is the ONE path that always reaches
+ * this function, and reading the replica here would turn that same lag into a 403 on an
+ * editor's first media edit. The override must therefore be threaded all the way down to
+ * the seat lookup, not just to the listing lookup.
  */
 export async function resolveListingAccess(
   appListingId: string,
-  userId: number | null | undefined
+  userId: number | null | undefined,
+  db: AccessDb = dbRead
 ): Promise<ListingAccess | null> {
-  const listing = await dbRead.appListing.findUnique({
+  const listing = await db.appListing.findUnique({
     where: { id: appListingId },
     select: {
       id: true,
@@ -190,7 +225,7 @@ export async function resolveListingAccess(
   if (typeof userId !== 'number') return { ...base, role: null };
   if (listing.userId === userId) return { ...base, role: 'owner' };
   if (!appBlockId) return { ...base, role: null };
-  const editor = await hasAcceptedSeat(appBlockId, userId);
+  const editor = await hasAcceptedSeat(appBlockId, userId, db);
   return { ...base, role: editor ? 'editor' : null };
 }
 
@@ -292,8 +327,10 @@ export async function resolveAccessibleAppBlockIds(userId: number): Promise<Acce
  *     app cannot borrow a stranger's name), and
  *   - `displayed = true` is the byline OPT-OUT (an accepted editor who does not want
  *     public credit).
- * `app-listing.public-collaborators.test.ts` asserts a pending, a rejected and an
- * accepted-but-undisplayed row are all absent from the public projection.
+ * `app-access.service.test.ts` ("the PUBLIC byline is accepted AND displayed only")
+ * asserts a pending, a rejected and an accepted-but-undisplayed row are all absent from
+ * this set. The DTO half — that the projection adds nothing to what it is handed — is
+ * pinned separately in `app-collaborator.public-projection.test.ts`.
  */
 export async function listDisplayedCollaboratorUserIds(appBlockId: string): Promise<number[]> {
   const rows = await safeCollaboratorQuery(

--- a/src/server/services/blocks/app-analytics.service.ts
+++ b/src/server/services/blocks/app-analytics.service.ts
@@ -232,9 +232,19 @@ export function resolveRange(input: { from?: Date; to?: Date; now?: Date }): App
 export type OwnedAppBlock = { id: string; manifest: unknown };
 
 /**
- * The app_blocks the caller owns, optionally narrowed to a single requested id.
- * Returns [] when the requested id isn't theirs (or they own nothing) — the
- * callers then fail closed to an empty result.
+ * The app_blocks the caller may see analytics for, optionally narrowed to a single
+ * requested id. Returns [] when the requested id isn't reachable by them (or they can
+ * see nothing) — the callers then fail closed to an empty result.
+ *
+ * 🔴 WIDENED FOR COLLABORATORS, and the widening is SAFE HERE for a reason that does
+ * NOT generalise to the earnings path. This function is app-scoped by construction:
+ * it resolves a permitted-id SET and `getMyAppAnalytics` filters every downstream
+ * aggregate by `appBlockId IN thatSet`. The earnings reads (`getRevenueForOwner`,
+ * `getRecentAttributionsForOwner`, `getMyApps`' groupBy) instead key on
+ * `BlockBuzzAttribution.appOwnerUserId`, which does not mention the app at all — the
+ * equivalent "widening" there would hand an editor the OWNER'S ENTIRE PORTFOLIO. Those
+ * are served by `app-collaborator-earnings.service` instead. Do not copy this pattern
+ * onto an `appOwnerUserId`-keyed query.
  *
  * The manifest rides along on this ONE query rather than a second round trip:
  * `getMyAppAnalytics` fans out per approved app row (see the note on
@@ -248,8 +258,15 @@ export async function getOwnedAppBlocks({
   ownerUserId: number;
   appBlockId?: string;
 }): Promise<OwnedAppBlock[]> {
+  const { resolveAccessibleAppBlockIds } = await import(
+    '~/server/services/blocks/app-access.service'
+  );
+  const { allIds } = await resolveAccessibleAppBlockIds(ownerUserId);
+  if (allIds.length === 0) return [];
   const owned = await dbRead.appBlock.findMany({
-    where: { app: { userId: ownerUserId } },
+    // Owner-held ids AND accepted-seat ids, resolved above. Never a bare
+    // `app: { userId }` — that would drop every collaborator's app.
+    where: { id: { in: allIds } },
     select: { id: true, manifest: true },
   });
   if (!appBlockId) return owned;

--- a/src/server/services/blocks/app-collaborator-earnings.service.ts
+++ b/src/server/services/blocks/app-collaborator-earnings.service.ts
@@ -1,5 +1,8 @@
 import { dbRead } from '~/server/db/client';
-import { resolveAppAccess, resolveAccessibleAppBlockIds } from '~/server/services/blocks/app-access.service';
+import {
+  resolveAppAccess,
+  resolveAccessibleAppBlockIds,
+} from '~/server/services/blocks/app-access.service';
 import type { RevenueSummary } from '~/server/services/blocks/buzz-attribution.service';
 
 /**
@@ -126,7 +129,10 @@ export async function getAppEarnings(opts: {
     }),
   ]);
 
-  type Agg = { _count?: number; _sum: { usdAmountCents?: number | null; appOwnerShareCents?: number | null } };
+  type Agg = {
+    _count?: number;
+    _sum: { usdAmountCents?: number | null; appOwnerShareCents?: number | null };
+  };
   const bucket = (a: Agg) => ({
     count: a._count ?? 0,
     grossCents: a._sum.usdAmountCents ?? 0,
@@ -214,7 +220,11 @@ export async function getMyAppsEarnings(opts: { userId: number }): Promise<MyApp
   const editorSet = new Set(editorIds);
   return allIds.map((id) => ({
     appBlockId: id,
-    role: ownedSet.has(id) ? ('owner' as const) : editorSet.has(id) ? ('editor' as const) : ('owner' as const),
+    role: ownedSet.has(id)
+      ? ('owner' as const)
+      : editorSet.has(id)
+      ? ('editor' as const)
+      : ('owner' as const),
     lifetimeShareCents: totals.get(id)?.shareCents ?? 0,
     lifetimeCount: totals.get(id)?.count ?? 0,
   }));

--- a/src/server/services/blocks/app-collaborator-earnings.service.ts
+++ b/src/server/services/blocks/app-collaborator-earnings.service.ts
@@ -1,0 +1,224 @@
+import { dbRead } from '~/server/db/client';
+import { resolveAppAccess, resolveAccessibleAppBlockIds } from '~/server/services/blocks/app-access.service';
+import type { RevenueSummary } from '~/server/services/blocks/buzz-attribution.service';
+
+/**
+ * App Listing COLLABORATORS — the APP-SCOPED earnings read.
+ *
+ * 🔴 THIS MODULE EXISTS BECAUSE THE OBVIOUS IMPLEMENTATION LEAKS THE OWNER'S WHOLE
+ * PORTFOLIO. Read this before touching it.
+ *
+ * Product decision: an editor is effectively a co-owner and DOES see earnings/payout
+ * data — but only for the app they were seated on.
+ *
+ * Every pre-existing earnings read is keyed on `BlockBuzzAttribution.appOwnerUserId`,
+ * a USER-WIDE filter:
+ *
+ *   `blocks.getMyApps`  (blocks.router.ts:5488-5496)
+ *       groupBy appBlockId WHERE appOwnerUserId = caller  — no app filter at all
+ *   `getRevenueForOwner` / `getRecentAttributionsForOwner`  (buzz-attribution.service)
+ *       WHERE appOwnerUserId = caller, with `appBlockId` an OPTIONAL narrowing filter
+ *       that is never checked against what the caller may actually see
+ *   `getOwnedAppBlocks`  (app-analytics.service.ts:252)
+ *       WHERE app.userId = caller
+ *
+ * The NAIVE way to serve an editor is to reuse one of those with the OWNER's id (the
+ * editor has no attribution rows of their own, so passing the editor's id returns
+ * nothing). That hands the editor **every app the owner has ever published**, because
+ * `appOwnerUserId` does not mention the app. It looks right in a one-app fixture and
+ * is catastrophic with two.
+ *
+ * So the rule here, with no exceptions:
+ *
+ *   🔴 RESOLVE THE PERMITTED APP IDS FIRST, THEN FILTER BY `appBlockId IN (thatSet)`.
+ *      Never filter a collaborator-reachable money query by `appOwnerUserId` alone.
+ *
+ * `app-collaborator-earnings.service.test.ts` fixtures an owner with TWO apps and an
+ * editor seated on ONE, and asserts the second never appears. That test was written
+ * against a deliberately naive implementation first and watched to FAIL before this
+ * one was written.
+ *
+ * ## The second scope: whose earnings, not just which app
+ *
+ * `appOwnerUserId` is SNAPSHOTTED at attribution time and is deliberately NOT rewritten
+ * by an ownership transfer (Buzz stays with the old owner — see
+ * `app-ownership-transfer.service`). So an app-scoped query on `appBlockId` ALONE would
+ * show a new owner (and their editors) the PREVIOUS owner's pre-transfer earnings.
+ * Both scopes are therefore applied: the app must be one the caller may see, AND the
+ * rows must belong to the app's CURRENT owner. That is the same forward-cut the
+ * transfer decision describes, enforced on the read side.
+ */
+
+export type AppScopedRevenue = {
+  appBlockId: string;
+  summary: RevenueSummary;
+};
+
+const EMPTY_BUCKET = { count: 0, grossCents: 0, shareCents: 0 };
+const EMPTY_SUMMARY: RevenueSummary = {
+  pending: EMPTY_BUCKET,
+  confirmed: EMPTY_BUCKET,
+  paidOut: EMPTY_BUCKET,
+  voided: { count: 0, grossCents: 0 },
+};
+
+export type AppEarningsResult =
+  | { ok: true; appBlockId: string; role: 'owner' | 'editor'; summary: RevenueSummary }
+  /**
+   * `notPermitted` is a REAL, reachable state (unlike revenue's deliberately-absent
+   * `notOwned`): a collaborator-reachable read genuinely does compute access, so the
+   * caller can be told "you may not see this" rather than handed a zero that is
+   * indistinguishable from "this app earned nothing".
+   */
+  | { ok: false; appBlockId: string; reason: 'notPermitted' | 'notFound' };
+
+/**
+ * Earnings for ONE app, readable by its owner OR an accepted collaborator.
+ *
+ * Fail-closed: an app the caller has no role on returns `notPermitted` WITHOUT running
+ * any aggregate — the caller never learns anything about a stranger's app, not even
+ * its totals.
+ */
+export async function getAppEarnings(opts: {
+  appBlockId: string;
+  userId: number;
+  from?: Date;
+  to?: Date;
+}): Promise<AppEarningsResult> {
+  const access = await resolveAppAccess(opts.appBlockId, opts.userId);
+  if (!access) return { ok: false, appBlockId: opts.appBlockId, reason: 'notFound' };
+  if (!access.role) return { ok: false, appBlockId: opts.appBlockId, reason: 'notPermitted' };
+
+  const where = {
+    // 🔴 BOTH scopes. See the module header — dropping either one is the leak.
+    appBlockId: opts.appBlockId,
+    appOwnerUserId: access.ownerUserId,
+    ...(opts.from || opts.to
+      ? {
+          attributedAt: {
+            ...(opts.from ? { gte: opts.from } : {}),
+            ...(opts.to ? { lte: opts.to } : {}),
+          },
+        }
+      : {}),
+  };
+
+  const [pending, confirmed, paidOut, voided] = await Promise.all([
+    dbRead.blockBuzzAttribution.aggregate({
+      where: { ...where, status: 'pending' },
+      _sum: { usdAmountCents: true, appOwnerShareCents: true },
+      _count: true,
+    }),
+    dbRead.blockBuzzAttribution.aggregate({
+      where: { ...where, status: 'confirmed' },
+      _sum: { usdAmountCents: true, appOwnerShareCents: true },
+      _count: true,
+    }),
+    dbRead.blockBuzzAttribution.aggregate({
+      where: { ...where, status: 'paid_out' },
+      _sum: { usdAmountCents: true, appOwnerShareCents: true },
+      _count: true,
+    }),
+    dbRead.blockBuzzAttribution.aggregate({
+      where: { ...where, status: 'voided' },
+      _sum: { usdAmountCents: true },
+      _count: true,
+    }),
+  ]);
+
+  type Agg = { _count?: number; _sum: { usdAmountCents?: number | null; appOwnerShareCents?: number | null } };
+  const bucket = (a: Agg) => ({
+    count: a._count ?? 0,
+    grossCents: a._sum.usdAmountCents ?? 0,
+    shareCents: a._sum.appOwnerShareCents ?? 0,
+  });
+
+  return {
+    ok: true,
+    appBlockId: opts.appBlockId,
+    role: access.role,
+    summary: {
+      pending: bucket(pending as Agg),
+      confirmed: bucket(confirmed as Agg),
+      paidOut: bucket(paidOut as Agg),
+      voided: {
+        count: (voided as Agg)._count ?? 0,
+        grossCents: (voided as Agg)._sum.usdAmountCents ?? 0,
+      },
+    },
+  };
+}
+
+export type MyAppsEarningsRow = {
+  appBlockId: string;
+  role: 'owner' | 'editor';
+  lifetimeShareCents: number;
+  lifetimeCount: number;
+};
+
+/**
+ * Lifetime per-app earnings across every app the caller may see (owned + seated) —
+ * the collaborator-aware replacement for `getMyApps`' portfolio-wide groupBy.
+ *
+ * 🔴 The groupBy is filtered by `appBlockId IN allIds`, NOT by `appOwnerUserId`. For
+ * an OWNER those two happen to coincide today, which is exactly why the distinction
+ * has to be written down: the moment an editor calls this, `appOwnerUserId` would be
+ * the wrong axis and would return either nothing (their own id) or everything (the
+ * owner's id). Neither is the answer.
+ *
+ * Ownership per row is resolved from the CURRENT owner, so a transferred app's
+ * pre-transfer rows are excluded for exactly the reason in the module header.
+ */
+export async function getMyAppsEarnings(opts: { userId: number }): Promise<MyAppsEarningsRow[]> {
+  const { ownedIds, editorIds, allIds } = await resolveAccessibleAppBlockIds(opts.userId);
+  if (allIds.length === 0) return [];
+
+  // Current owner per accessible app — the second scope axis.
+  const blocks = await dbRead.appBlock.findMany({
+    where: { id: { in: allIds } },
+    select: { id: true, app: { select: { userId: true } } },
+  });
+  const ownerByApp = new Map<string, number>(
+    blocks
+      .filter((b: { app: { userId: number } | null }) => !!b.app)
+      .map((b: { id: string; app: { userId: number } | null }) => [b.id, b.app!.userId])
+  );
+
+  // 🔴 GROUPED BY (appBlockId, appOwnerUserId), not appBlockId alone. The second key is
+  // what lets a transferred app's PRE-transfer rows be dropped below — grouping on the
+  // app alone would silently fold a previous owner's earnings into the current one's.
+  const rows = (await dbRead.blockBuzzAttribution.groupBy({
+    by: ['appBlockId', 'appOwnerUserId'] as const,
+    where: { appBlockId: { in: allIds }, status: { in: ['confirmed', 'paid_out'] } },
+    _sum: { appOwnerShareCents: true },
+    _count: true,
+  } as never)) as unknown as Array<{
+    appBlockId: string;
+    appOwnerUserId: number;
+    _sum: { appOwnerShareCents: number | null };
+    _count: number;
+  }>;
+
+  const totals = new Map<string, { shareCents: number; count: number }>();
+  for (const r of rows) {
+    // Drop rows attributed to a PREVIOUS owner of a transferred app.
+    if (ownerByApp.get(r.appBlockId) !== r.appOwnerUserId) continue;
+    const prev = totals.get(r.appBlockId) ?? { shareCents: 0, count: 0 };
+    totals.set(r.appBlockId, {
+      shareCents: prev.shareCents + (r._sum.appOwnerShareCents ?? 0),
+      count: prev.count + r._count,
+    });
+  }
+
+  const ownedSet = new Set(ownedIds);
+  const editorSet = new Set(editorIds);
+  return allIds.map((id) => ({
+    appBlockId: id,
+    role: ownedSet.has(id) ? ('owner' as const) : editorSet.has(id) ? ('editor' as const) : ('owner' as const),
+    lifetimeShareCents: totals.get(id)?.shareCents ?? 0,
+    lifetimeCount: totals.get(id)?.count ?? 0,
+  }));
+}
+
+/** Exposed for the empty/unavailable render path so a caller never invents a shape. */
+export const emptyAppRevenueSummary = EMPTY_SUMMARY;

--- a/src/server/services/blocks/app-collaborator-notify.ts
+++ b/src/server/services/blocks/app-collaborator-notify.ts
@@ -1,0 +1,43 @@
+import type { AppCollaboratorNotificationDetails } from '~/server/notifications/app-collaborator.notifications';
+
+/**
+ * App Listing COLLABORATORS — seat/transfer notification emit helper.
+ *
+ * Identical discipline to the sibling `app-block-notify` / `app-listing-notify`
+ * helpers: the ONLY static import is a TYPE (erased at compile), and
+ * `createNotification` + `NotificationCategory` are DYNAMICALLY imported inside the
+ * async body — so importing this adds ZERO runtime graph to a caller, and the
+ * collaborator service's unit tests never pull the notifications client. A test that
+ * asserts emission mocks THIS module; a test that asserts the swallow mocks
+ * `~/server/services/notification.service`.
+ *
+ * Every call site is POST-COMMIT and wrapped in the caller's own try/catch, so even a
+ * defect that made this throw cannot fail or roll back a seat decision.
+ */
+
+export type AppCollaboratorNotificationType =
+  | 'app-collaborator-invited'
+  | 'app-collaborator-accepted'
+  | 'app-collaborator-removed'
+  | 'app-ownership-transfer-offered'
+  | 'app-ownership-transfer-accepted';
+
+export async function notifyAppCollaborator(opts: {
+  type: AppCollaboratorNotificationType;
+  userId: number;
+  /** Idempotency key — dedups repeat emissions of the same event to the same user. */
+  key: string;
+  details: AppCollaboratorNotificationDetails;
+}): Promise<void> {
+  const [{ createNotification }, { NotificationCategory }] = await Promise.all([
+    import('~/server/services/notification.service'),
+    import('~/server/common/enums'),
+  ]);
+  await createNotification({
+    userId: opts.userId,
+    category: NotificationCategory.System,
+    type: opts.type,
+    key: opts.key,
+    details: opts.details,
+  });
+}

--- a/src/server/services/blocks/app-collaborator.service.ts
+++ b/src/server/services/blocks/app-collaborator.service.ts
@@ -1,0 +1,572 @@
+import { TRPCError } from '@trpc/server';
+import type { Prisma } from '@prisma/client';
+
+import { constants } from '~/server/common/constants';
+import { dbRead, dbWrite } from '~/server/db/client';
+import { ACCEPTED, resolveAppAccess } from '~/server/services/blocks/app-access.service';
+import { notifyAppCollaborator } from '~/server/services/blocks/app-collaborator-notify';
+import { grantAppRepoWrite, revokeAppRepoWrite } from '~/server/services/blocks/app-repo-access';
+import { newAppOwnershipEventId } from '~/server/utils/app-block-ids';
+
+/**
+ * App Listing COLLABORATORS — the SEAT lifecycle (invite / accept / reject / remove /
+ * leave / byline opt-in).
+ *
+ * ## What is copied from `EntityCollaborator`, and what deliberately is not
+ *
+ * COPIED — the CONSENT MODEL, which is the part worth reusing: an invite starts
+ * `pending`, confers nothing, and the status-visibility rules mirror
+ * `entity-collaborator.service.ts::getEntityCollaborators:181-199` (accepted → visible
+ * to everyone; pending → owner, invitee, mod; rejected → owner, mod).
+ *
+ * NOT COPIED:
+ *   - its CODE (hard-scoped to `EntityType.Post`; every function throws on anything else);
+ *   - its DELIVERY mechanism (a system chat message via `upsertChat`/`createMessage`).
+ *     We use the existing App Blocks notification path instead;
+ *   - 🔴 its THROTTLE, which is INVERTED. `entity-collaborator.service.ts:94-95` reads
+ *     `lastMessageSentAt >= dayjs().subtract(1,'day')` — i.e. "notify again when the
+ *     last notification was RECENT" — while its own sibling
+ *     `sendMessagesToCollaborators:312` correctly uses `lte`. Ours is written the
+ *     correct way round (see {@link shouldNotifyInvite}) and the test pins both sides
+ *     of the boundary so a future copy-paste cannot re-import the bug.
+ *
+ * ## Owner-only
+ *
+ * Managing collaborators is reserved to the OWNER. An editor is otherwise effectively
+ * a co-owner, but may not seat or unseat anyone (that plus initiating a transfer are
+ * the only two owner-reserved actions). An editor MAY remove themselves ({@link
+ * leaveApp}) — that is consent, not management.
+ */
+
+export type AppCollaboratorErrorCode =
+  | 'NOT_FOUND'
+  | 'NOT_OWNER'
+  | 'INVALID_TARGET'
+  | 'ALREADY_SEATED'
+  | 'CAP_REACHED'
+  | 'NO_INVITE'
+  | 'BANNED';
+
+export class AppCollaboratorError extends Error {
+  readonly code: AppCollaboratorErrorCode;
+  constructor(code: AppCollaboratorErrorCode, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'AppCollaboratorError';
+    this.code = code;
+  }
+}
+
+/** Map a typed service error onto the tRPC code the client should see. */
+export function mapCollaboratorError(err: unknown): unknown {
+  if (!(err instanceof AppCollaboratorError)) return err;
+  const code =
+    err.code === 'NOT_FOUND'
+      ? 'NOT_FOUND'
+      : err.code === 'NOT_OWNER' || err.code === 'BANNED'
+        ? 'FORBIDDEN'
+        : 'BAD_REQUEST';
+  return new TRPCError({ code, message: err.message, cause: err });
+}
+
+export type CollaboratorRow = {
+  appBlockId: string;
+  userId: number;
+  role: string;
+  status: string;
+  displayed: boolean;
+  invitedBy: number;
+  createdAt: Date;
+  respondedAt: Date | null;
+};
+
+/**
+ * Write an append-only ownership/collaboration audit event.
+ *
+ * Takes an explicit `tx` so a caller inside a transaction records the event in the
+ * SAME transaction — a rolled-back action must leave ZERO events (the discipline
+ * `claimListing` established for `AppListingModerationEvent`).
+ */
+export async function recordOwnershipEvent(
+  /**
+   * The transaction client. Typed as `Prisma.TransactionClient` (not a hand-rolled
+   * structural shape) so a schema change to `AppOwnershipEvent` breaks HERE at compile
+   * time rather than being absorbed by a `Record<string, unknown>` that types nothing.
+   */
+  tx: Prisma.TransactionClient,
+  args: {
+    appBlockId: string;
+    slug: string;
+    action:
+      | 'invite'
+      | 'accept'
+      | 'reject'
+      | 'remove'
+      | 'leave'
+      | 'display'
+      | 'transfer_initiated'
+      | 'transfer_accepted'
+      | 'transfer_cancelled';
+    actorUserId: number;
+    targetUserId?: number | null;
+    metadata?: Record<string, unknown> | null;
+  }
+): Promise<void> {
+  await tx.appOwnershipEvent.create({
+    data: {
+      id: newAppOwnershipEventId(),
+      appBlockId: args.appBlockId,
+      slug: args.slug,
+      action: args.action,
+      actorUserId: args.actorUserId,
+      targetUserId: args.targetUserId ?? null,
+      metadata: (args.metadata ?? undefined) as Prisma.InputJsonValue | undefined,
+    },
+  });
+}
+
+/**
+ * Re-notify throttle for a repeat invite.
+ *
+ * 🔴 WRITTEN THE OPPOSITE WAY ROUND FROM `entity-collaborator.service.ts:94-95`, which
+ * is the bug being avoided. The rule is: notify when we have NEVER notified, OR when
+ * the last notification is OLDER than the window. `lastNotifiedAt` newer than the
+ * cutoff ⇒ stay silent.
+ */
+export function shouldNotifyInvite(lastNotifiedAt: Date | null, now: Date): boolean {
+  if (!lastNotifiedAt) return true;
+  const cutoff = new Date(
+    now.getTime() - constants.appCollaborators.inviteNotifyThrottleHours * 3600_000
+  );
+  return lastNotifiedAt.getTime() <= cutoff.getTime();
+}
+
+/** Load the app + assert the caller OWNS it. Editors are refused: seats are owner-managed. */
+async function assertOwner(
+  appBlockId: string,
+  actorUserId: number
+): Promise<{ appBlockId: string; slug: string; ownerUserId: number }> {
+  const block = await dbRead.appBlock.findUnique({
+    where: { id: appBlockId },
+    select: { id: true, blockId: true, app: { select: { userId: true } } },
+  });
+  if (!block?.app) throw new AppCollaboratorError('NOT_FOUND', 'App not found');
+  if (block.app.userId !== actorUserId) {
+    throw new AppCollaboratorError(
+      'NOT_OWNER',
+      'Only the app owner can manage collaborators'
+    );
+  }
+  return { appBlockId: block.id, slug: block.blockId, ownerUserId: block.app.userId };
+}
+
+export type InviteCollaboratorResult = {
+  appBlockId: string;
+  userId: number;
+  status: string;
+  /** True when this call created the row (vs re-touching a standing invite). */
+  created: boolean;
+  /** True when a notification was actually emitted (the throttle may suppress it). */
+  notified: boolean;
+};
+
+/**
+ * OWNER: invite a user to an editor seat.
+ *
+ * Idempotent. A repeat invite for a standing `pending` row does NOT reset the row; it
+ * only (throttled) re-notifies. A repeat invite for an `accepted` row is
+ * ALREADY_SEATED. A repeat invite for a `rejected` row RE-OPENS it as `pending` —
+ * declining is not permanent, and the invitee must consent again.
+ *
+ * 🔴 BAN POLICY (decided, and applied consistently across this feature): a BANNED user
+ * may neither be invited nor accept. Rationale: a seat grants Forgejo `write` on the
+ * app repo plus visibility of the app's earnings, and `getMyAppRepo` already refuses
+ * to issue a push credential to a banned account (`blocks.router.ts:5579`). Seating a
+ * banned user would mint exactly the credential that gate exists to withhold. An
+ * EXISTING seat is NOT auto-revoked on ban (that would need a ban-hook this PR does
+ * not add) — but every capability the seat unlocks re-checks `bannedAt` at the proc,
+ * so a banned editor can hold an inert row and do nothing with it.
+ */
+export async function inviteCollaborator(opts: {
+  appBlockId: string;
+  targetUserId: number;
+  actorUserId: number;
+  now?: Date;
+}): Promise<InviteCollaboratorResult> {
+  const now = opts.now ?? new Date();
+  const app = await assertOwner(opts.appBlockId, opts.actorUserId);
+
+  if (opts.targetUserId === app.ownerUserId) {
+    throw new AppCollaboratorError(
+      'INVALID_TARGET',
+      'The app owner already has full access and cannot be invited as a collaborator'
+    );
+  }
+  const target = await dbRead.user.findUnique({
+    where: { id: opts.targetUserId },
+    select: { id: true, bannedAt: true },
+  });
+  if (!target) {
+    throw new AppCollaboratorError('INVALID_TARGET', 'That user could not be found');
+  }
+  if (target.bannedAt) {
+    throw new AppCollaboratorError('BANNED', 'That account is not eligible for a collaborator seat');
+  }
+
+  const existing = await dbRead.appCollaborator.findUnique({
+    where: { appBlockId_userId: { appBlockId: app.appBlockId, userId: opts.targetUserId } },
+    select: { status: true, lastNotifiedAt: true },
+  });
+
+  if (existing?.status === ACCEPTED) {
+    throw new AppCollaboratorError('ALREADY_SEATED', 'That user is already a collaborator');
+  }
+
+  // CAP — counts PENDING + ACCEPTED (a rejected row is inert and occupies no seat).
+  // Skipped when re-touching a row that already exists, since that consumes no new seat.
+  if (!existing) {
+    const seated = await dbWrite.appCollaborator.count({
+      where: { appBlockId: app.appBlockId, status: { in: ['pending', ACCEPTED] } },
+    });
+    if (seated >= constants.appCollaborators.maxCollaborators) {
+      throw new AppCollaboratorError(
+        'CAP_REACHED',
+        `An app can have at most ${constants.appCollaborators.maxCollaborators} collaborators`
+      );
+    }
+  }
+
+  const notify = shouldNotifyInvite(existing?.lastNotifiedAt ?? null, now);
+
+  await dbWrite.$transaction(async (tx) => {
+    await tx.appCollaborator.upsert({
+      where: { appBlockId_userId: { appBlockId: app.appBlockId, userId: opts.targetUserId } },
+      create: {
+        appBlockId: app.appBlockId,
+        userId: opts.targetUserId,
+        role: 'editor',
+        status: 'pending',
+        invitedBy: opts.actorUserId,
+        lastNotifiedAt: notify ? now : null,
+      },
+      update: {
+        // Re-open a declined invite; leave a standing pending row's createdAt alone.
+        status: 'pending',
+        respondedAt: null,
+        invitedBy: opts.actorUserId,
+        ...(notify ? { lastNotifiedAt: now } : {}),
+      },
+    });
+    await recordOwnershipEvent(tx, {
+      appBlockId: app.appBlockId,
+      slug: app.slug,
+      action: 'invite',
+      actorUserId: opts.actorUserId,
+      targetUserId: opts.targetUserId,
+      metadata: { role: 'editor', reopened: existing?.status === 'rejected' },
+    });
+  });
+
+  if (notify) {
+    // Post-commit + best-effort: a notification failure must never undo the invite.
+    try {
+      await notifyAppCollaborator({
+        type: 'app-collaborator-invited',
+        userId: opts.targetUserId,
+        key: `app-collaborator-invited:${app.appBlockId}:${opts.targetUserId}:${now.getTime()}`,
+        details: { slug: app.slug, appBlockId: app.appBlockId },
+      });
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  return {
+    appBlockId: app.appBlockId,
+    userId: opts.targetUserId,
+    status: 'pending',
+    created: !existing,
+    notified: notify,
+  };
+}
+
+export type RespondToInviteResult = { appBlockId: string; userId: number; status: string };
+
+/**
+ * INVITEE: accept or decline a pending seat.
+ *
+ * Status-guarded `updateMany` (`status:'pending'`), so a concurrent remove/re-invite
+ * cannot be double-acted: a 0-count means the invite is no longer pending → NO_INVITE,
+ * and the transaction rolls back before any audit event is written.
+ *
+ * On ACCEPT this also grants the collaborator Forgejo `write` on `civitai-apps/<slug>`
+ * — the seat is worthless without push access, and the grant is part of accepting, not
+ * a follow-up. The grant runs POST-COMMIT and is best-effort-logged: it is an external
+ * system, and a Forgejo outage must not roll back a consent decision the user made.
+ * `getMyAppRepo` re-grants on demand, so a dropped grant self-heals on first use.
+ */
+export async function respondToInvite(opts: {
+  appBlockId: string;
+  userId: number;
+  accept: boolean;
+  now?: Date;
+}): Promise<RespondToInviteResult> {
+  const now = opts.now ?? new Date();
+  const block = await dbRead.appBlock.findUnique({
+    where: { id: opts.appBlockId },
+    select: { id: true, blockId: true },
+  });
+  if (!block) throw new AppCollaboratorError('NOT_FOUND', 'App not found');
+
+  if (opts.accept) {
+    const user = await dbRead.user.findUnique({
+      where: { id: opts.userId },
+      select: { bannedAt: true },
+    });
+    if (user?.bannedAt) {
+      throw new AppCollaboratorError(
+        'BANNED',
+        'Your account is not eligible for a collaborator seat'
+      );
+    }
+  }
+
+  const nextStatus = opts.accept ? ACCEPTED : 'rejected';
+
+  await dbWrite.$transaction(async (tx) => {
+    const flipped = await tx.appCollaborator.updateMany({
+      where: { appBlockId: block.id, userId: opts.userId, status: 'pending' },
+      data: { status: nextStatus, respondedAt: now },
+    });
+    if (flipped.count === 0) {
+      throw new AppCollaboratorError('NO_INVITE', 'There is no pending invitation to respond to');
+    }
+    await recordOwnershipEvent(tx, {
+      appBlockId: block.id,
+      slug: block.blockId,
+      action: opts.accept ? 'accept' : 'reject',
+      actorUserId: opts.userId,
+      targetUserId: opts.userId,
+    });
+  });
+
+  if (opts.accept) {
+    await grantAppRepoWrite({ slug: block.blockId, userId: opts.userId });
+  }
+
+  return { appBlockId: block.id, userId: opts.userId, status: nextStatus };
+}
+
+/**
+ * OWNER: remove a collaborator (any status).
+ *
+ * Deletes the row rather than tombstoning it — the audit trail is the
+ * `AppOwnershipEvent`, and leaving a `rejected`-like tombstone would keep occupying
+ * conceptual space in the roster read for no benefit.
+ *
+ * REVOKES Forgejo write. This is the half with no prior art in the codebase: there was
+ * no revoke path at all before this PR (`forgejo.service.ts` had `addCollaborator` and
+ * nothing to undo it), which meant a dev who was granted push access kept it forever.
+ */
+export async function removeCollaborator(opts: {
+  appBlockId: string;
+  targetUserId: number;
+  actorUserId: number;
+}): Promise<{ appBlockId: string; userId: number; removed: boolean }> {
+  const app = await assertOwner(opts.appBlockId, opts.actorUserId);
+
+  const removed = await dbWrite.$transaction(async (tx) => {
+    const del = await tx.appCollaborator.deleteMany({
+      where: { appBlockId: app.appBlockId, userId: opts.targetUserId },
+    });
+    if (del.count === 0) return false;
+    await recordOwnershipEvent(tx, {
+      appBlockId: app.appBlockId,
+      slug: app.slug,
+      action: 'remove',
+      actorUserId: opts.actorUserId,
+      targetUserId: opts.targetUserId,
+    });
+    return true;
+  });
+
+  if (removed) {
+    await revokeAppRepoWrite({ slug: app.slug, userId: opts.targetUserId });
+  }
+  return { appBlockId: app.appBlockId, userId: opts.targetUserId, removed };
+}
+
+/**
+ * COLLABORATOR: give up your own seat. Consent, not management — so this is the one
+ * seat mutation an editor may perform, and it needs no owner check.
+ */
+export async function leaveApp(opts: {
+  appBlockId: string;
+  userId: number;
+}): Promise<{ appBlockId: string; userId: number; removed: boolean }> {
+  const block = await dbRead.appBlock.findUnique({
+    where: { id: opts.appBlockId },
+    select: { id: true, blockId: true },
+  });
+  if (!block) throw new AppCollaboratorError('NOT_FOUND', 'App not found');
+
+  const removed = await dbWrite.$transaction(async (tx) => {
+    const del = await tx.appCollaborator.deleteMany({
+      where: { appBlockId: block.id, userId: opts.userId },
+    });
+    if (del.count === 0) return false;
+    await recordOwnershipEvent(tx, {
+      appBlockId: block.id,
+      slug: block.blockId,
+      action: 'leave',
+      actorUserId: opts.userId,
+      targetUserId: opts.userId,
+    });
+    return true;
+  });
+
+  if (removed) {
+    await revokeAppRepoWrite({ slug: block.blockId, userId: opts.userId });
+  }
+  return { appBlockId: block.id, userId: opts.userId, removed };
+}
+
+/**
+ * COLLABORATOR: opt in/out of the public byline.
+ *
+ * 🔴 APPLIES IMMEDIATELY — no mod review, and no shadow revision. That is only safe
+ * because the flag lives on the collaborator row: `applyApprovedRevision`'s offsite
+ * branch copies the shadow's listing SCALARS onto the live parent, so the same flag
+ * held as an `AppListing` column would be silently reverted by the next approved
+ * revision. Being outside both branches' copy sets makes immediate-apply correct by
+ * construction. `app-collaborator.revision-non-clobber.test.ts` pins that.
+ *
+ * Only an ACCEPTED collaborator may set it — a pending invitee toggling `displayed`
+ * must not be able to pre-arrange public credit for a seat they have not taken.
+ */
+export async function setCollaboratorDisplayed(opts: {
+  appBlockId: string;
+  userId: number;
+  displayed: boolean;
+}): Promise<{ appBlockId: string; userId: number; displayed: boolean }> {
+  const block = await dbRead.appBlock.findUnique({
+    where: { id: opts.appBlockId },
+    select: { id: true, blockId: true },
+  });
+  if (!block) throw new AppCollaboratorError('NOT_FOUND', 'App not found');
+
+  await dbWrite.$transaction(async (tx) => {
+    const updated = await tx.appCollaborator.updateMany({
+      where: { appBlockId: block.id, userId: opts.userId, status: ACCEPTED },
+      data: { displayed: opts.displayed },
+    });
+    if (updated.count === 0) {
+      throw new AppCollaboratorError(
+        'NO_INVITE',
+        'You are not an active collaborator on this app'
+      );
+    }
+    await recordOwnershipEvent(tx, {
+      appBlockId: block.id,
+      slug: block.blockId,
+      action: 'display',
+      actorUserId: opts.userId,
+      targetUserId: opts.userId,
+      metadata: { displayed: opts.displayed },
+    });
+  });
+
+  return { appBlockId: block.id, userId: opts.userId, displayed: opts.displayed };
+}
+
+export type CollaboratorView = {
+  userId: number;
+  role: string;
+  status: string;
+  displayed: boolean;
+  invitedBy: number;
+  createdAt: Date;
+  respondedAt: Date | null;
+};
+
+/**
+ * List an app's collaborators, filtered by the SAME status-visibility rules
+ * `EntityCollaborator` established (the part of that prior art worth reusing):
+ *
+ *   accepted → visible to everyone
+ *   pending  → visible to the app owner, the invitee themselves, and moderators
+ *   rejected → visible to the app owner and moderators only
+ *
+ * Anything else is filtered out. An anonymous caller (`viewerUserId == null`) sees
+ * ACCEPTED only.
+ */
+export function filterCollaboratorsForViewer(
+  rows: CollaboratorView[],
+  ctx: { ownerUserId: number; viewerUserId: number | null; isModerator: boolean }
+): CollaboratorView[] {
+  return rows.filter((row) => {
+    if (row.status === ACCEPTED) return true;
+    if (ctx.isModerator) return true;
+    if (ctx.viewerUserId == null) return false;
+    if (row.status === 'pending') {
+      return ctx.ownerUserId === ctx.viewerUserId || row.userId === ctx.viewerUserId;
+    }
+    if (row.status === 'rejected') return ctx.ownerUserId === ctx.viewerUserId;
+    return false;
+  });
+}
+
+export async function listCollaborators(opts: {
+  appBlockId: string;
+  viewerUserId: number | null;
+  isModerator: boolean;
+}): Promise<CollaboratorView[]> {
+  const access = await resolveAppAccess(opts.appBlockId, opts.viewerUserId);
+  if (!access) throw new AppCollaboratorError('NOT_FOUND', 'App not found');
+  const rows = (await dbRead.appCollaborator.findMany({
+    where: { appBlockId: opts.appBlockId },
+    select: {
+      userId: true,
+      role: true,
+      status: true,
+      displayed: true,
+      invitedBy: true,
+      createdAt: true,
+      respondedAt: true,
+    },
+    orderBy: { createdAt: 'asc' },
+  })) as CollaboratorView[];
+  return filterCollaboratorsForViewer(rows, {
+    ownerUserId: access.ownerUserId,
+    viewerUserId: opts.viewerUserId,
+    isModerator: opts.isModerator,
+  });
+}
+
+/** The caller's own PENDING invitations, for an inbox surface. */
+export async function listMyPendingInvites(userId: number): Promise<
+  Array<{ appBlockId: string; slug: string; invitedBy: number; createdAt: Date }>
+> {
+  const rows = await dbRead.appCollaborator.findMany({
+    where: { userId, status: 'pending' },
+    select: {
+      appBlockId: true,
+      invitedBy: true,
+      createdAt: true,
+      appBlock: { select: { blockId: true } },
+    },
+    orderBy: { createdAt: 'desc' },
+  });
+  return rows.map(
+    (r: {
+      appBlockId: string;
+      invitedBy: number;
+      createdAt: Date;
+      appBlock: { blockId: string } | null;
+    }) => ({
+      appBlockId: r.appBlockId,
+      slug: r.appBlock?.blockId ?? '',
+      invitedBy: r.invitedBy,
+      createdAt: r.createdAt,
+    })
+  );
+}

--- a/src/server/services/blocks/app-collaborator.service.ts
+++ b/src/server/services/blocks/app-collaborator.service.ts
@@ -512,6 +512,21 @@ export function filterCollaboratorsForViewer(
   });
 }
 
+/**
+ * 🔴 THE ROSTER IS NOT A PUBLIC READ, and `resolveAppAccess` is consulted for its ROLE,
+ * not merely for `ownerUserId`.
+ *
+ * Reading it back leaks, for any app on the platform: the full ACCEPTED roster
+ * INCLUDING seats whose holder opted OUT of the public byline (`displayed: false` — the
+ * whole point of that flag is that those people are not listed publicly), plus
+ * `invitedBy` and the invite/response timestamps. The status filter below governs
+ * pending/rejected ROWS; it never governed whether the CALLER may read the app at all,
+ * so without this gate every flagged account could enumerate every app's collaborators.
+ *
+ * Permitted: the app OWNER, an ACCEPTED editor, or a moderator. A PENDING invitee is
+ * NOT — they read their own standing invitation through `listMyPendingInvites`, which
+ * is keyed to their own user id and needs no app-scoped access.
+ */
 export async function listCollaborators(opts: {
   appBlockId: string;
   viewerUserId: number | null;
@@ -519,6 +534,12 @@ export async function listCollaborators(opts: {
 }): Promise<CollaboratorView[]> {
   const access = await resolveAppAccess(opts.appBlockId, opts.viewerUserId);
   if (!access) throw new AppCollaboratorError('NOT_FOUND', 'App not found');
+  if (!access.role && !opts.isModerator) {
+    throw new AppCollaboratorError(
+      'NOT_OWNER',
+      'You do not have access to this app’s collaborators'
+    );
+  }
   const rows = (await dbRead.appCollaborator.findMany({
     where: { appBlockId: opts.appBlockId },
     select: {

--- a/src/server/services/blocks/app-collaborator.service.ts
+++ b/src/server/services/blocks/app-collaborator.service.ts
@@ -486,15 +486,25 @@ export type CollaboratorView = {
 };
 
 /**
- * List an app's collaborators, filtered by the SAME status-visibility rules
- * `EntityCollaborator` established (the part of that prior art worth reusing):
+ * Filter roster ROWS by the status-visibility rules `EntityCollaborator` established
+ * (the part of that prior art worth reusing):
  *
- *   accepted → visible to everyone
+ *   accepted → visible to any caller that reaches this function
  *   pending  → visible to the app owner, the invitee themselves, and moderators
  *   rejected → visible to the app owner and moderators only
  *
- * Anything else is filtered out. An anonymous caller (`viewerUserId == null`) sees
- * ACCEPTED only.
+ * 🔴 "Any caller that reaches this function" is NOT "everyone". This is a row filter,
+ * never an access check: its only production caller is `listCollaborators`, which
+ * ALREADY refused anyone who is not the owner, an ACCEPTED editor, or a moderator.
+ * Do not read the `accepted → everyone` line as a statement about who may call the
+ * proc — that gate lives in `listCollaborators` and is the load-bearing one.
+ *
+ * Consequently two branches below are unreachable from that caller and are retained
+ * only as defence-in-depth for a future second caller: the `viewerUserId == null`
+ * early return (a non-moderator caller must hold a role, so it is never anonymous),
+ * and the `row.userId === viewerUserId` disjunct in the `pending` arm (a role-holder
+ * cannot simultaneously hold a `pending` row). Their unit tests pin an invariant, not
+ * behaviour any current caller can reach.
  */
 export function filterCollaboratorsForViewer(
   rows: CollaboratorView[],

--- a/src/server/services/blocks/app-collaborator.service.ts
+++ b/src/server/services/blocks/app-collaborator.service.ts
@@ -63,8 +63,8 @@ export function mapCollaboratorError(err: unknown): unknown {
     err.code === 'NOT_FOUND'
       ? 'NOT_FOUND'
       : err.code === 'NOT_OWNER' || err.code === 'BANNED'
-        ? 'FORBIDDEN'
-        : 'BAD_REQUEST';
+      ? 'FORBIDDEN'
+      : 'BAD_REQUEST';
   return new TRPCError({ code, message: err.message, cause: err });
 }
 
@@ -151,10 +151,7 @@ async function assertOwner(
   });
   if (!block?.app) throw new AppCollaboratorError('NOT_FOUND', 'App not found');
   if (block.app.userId !== actorUserId) {
-    throw new AppCollaboratorError(
-      'NOT_OWNER',
-      'Only the app owner can manage collaborators'
-    );
+    throw new AppCollaboratorError('NOT_OWNER', 'Only the app owner can manage collaborators');
   }
   return { appBlockId: block.id, slug: block.blockId, ownerUserId: block.app.userId };
 }
@@ -209,7 +206,10 @@ export async function inviteCollaborator(opts: {
     throw new AppCollaboratorError('INVALID_TARGET', 'That user could not be found');
   }
   if (target.bannedAt) {
-    throw new AppCollaboratorError('BANNED', 'That account is not eligible for a collaborator seat');
+    throw new AppCollaboratorError(
+      'BANNED',
+      'That account is not eligible for a collaborator seat'
+    );
   }
 
   const existing = await dbRead.appCollaborator.findUnique({
@@ -460,10 +460,7 @@ export async function setCollaboratorDisplayed(opts: {
       data: { displayed: opts.displayed },
     });
     if (updated.count === 0) {
-      throw new AppCollaboratorError(
-        'NO_INVITE',
-        'You are not an active collaborator on this app'
-      );
+      throw new AppCollaboratorError('NO_INVITE', 'You are not an active collaborator on this app');
     }
     await recordOwnershipEvent(tx, {
       appBlockId: block.id,
@@ -543,9 +540,9 @@ export async function listCollaborators(opts: {
 }
 
 /** The caller's own PENDING invitations, for an inbox surface. */
-export async function listMyPendingInvites(userId: number): Promise<
-  Array<{ appBlockId: string; slug: string; invitedBy: number; createdAt: Date }>
-> {
+export async function listMyPendingInvites(
+  userId: number
+): Promise<Array<{ appBlockId: string; slug: string; invitedBy: number; createdAt: Date }>> {
   const rows = await dbRead.appCollaborator.findMany({
     where: { userId, status: 'pending' },
     select: {

--- a/src/server/services/blocks/app-listing-assets.service.ts
+++ b/src/server/services/blocks/app-listing-assets.service.ts
@@ -309,8 +309,20 @@ function assertOwnerAssetEditable(
 export { nsfwLevelFromContentRating };
 
 /**
- * Load a listing and assert the caller owns it (or is a moderator). Throws
- * NOT_FOUND for a missing listing, FORBIDDEN for a non-owner non-mod.
+ * Load a listing and assert the caller may edit it. Throws NOT_FOUND for a missing
+ * listing, FORBIDDEN otherwise.
+ *
+ * PERMITTED: the listing owner, an ACCEPTED collaborator on the backing AppBlock, or a
+ * moderator. The mod bypass is UNCHANGED from before collaborators existed — this
+ * file's gate always had one, unlike `offsite-listing.service`'s
+ * `loadOwnedEditableListing`, which deliberately has none. That divergence is
+ * pre-existing and is recorded in `app-access.call-site-ledger.test.ts` rather than
+ * silently normalised here.
+ *
+ * The collaborator half routes through `resolveListingAccess`, which is SHADOW-AWARE:
+ * a shadow revision carries `appBlockId: null`, so the seat is resolved via its parent.
+ * Without that, an editor would lose access to their own in-flight revision the moment
+ * their first media edit minted it.
  */
 async function loadOwnedListing(
   listingId: string,
@@ -341,9 +353,27 @@ async function loadOwnedListing(
   });
   if (!listing) throw new TRPCError({ code: 'NOT_FOUND', message: 'Listing not found' });
   if (listing.userId !== user.id && !user.isModerator) {
-    throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not own this listing' });
+    // Not the owner and not a mod — the last chance is an ACCEPTED collaborator seat.
+    // Resolved lazily so the common owner/mod path costs no extra query.
+    const editor = await isAcceptedListingEditor(listingId, user.id);
+    if (!editor) {
+      throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not own this listing' });
+    }
   }
   return listing;
+}
+
+/**
+ * True when `userId` holds an ACCEPTED collaborator seat reachable from this listing.
+ *
+ * Extracted so every gate in this file asks the question the SAME way (`resolveAppAccess`
+ * is the single predicate; this is a thin `role === 'editor'` read of it) and so the
+ * seam has one name to mock in tests.
+ */
+async function isAcceptedListingEditor(listingId: string, userId: number): Promise<boolean> {
+  const { resolveListingAccess } = await import('~/server/services/blocks/app-access.service');
+  const access = await resolveListingAccess(listingId, userId);
+  return access?.role === 'editor';
 }
 
 // ---------------------------------------------------------------------------
@@ -1098,8 +1128,14 @@ async function resolveOwnerScreenshotTarget(
     shot = await dbWrite.appListingScreenshot.findUnique({ where: { id: screenshotId }, select });
   }
   if (!shot) throw new TRPCError({ code: 'NOT_FOUND', message: 'Screenshot not found' });
+  // Owner / mod / ACCEPTED collaborator (see `loadOwnedListing`). This is an EARLY
+  // check on the screenshot's own listing; `loadOwnedListing` below re-asserts it on
+  // the resolved listing row, so widening here does not weaken the second gate.
   if (shot.appListing.userId !== user.id && !user.isModerator) {
-    throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not own this listing' });
+    const editor = await isAcceptedListingEditor(shot.appListingId, user.id);
+    if (!editor) {
+      throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not own this listing' });
+    }
   }
   const sourceListing = await loadOwnedListing(shot.appListingId, user, db);
   const listing = await resolveOwnerAssetEditTarget(sourceListing, user);

--- a/src/server/services/blocks/app-listing-assets.service.ts
+++ b/src/server/services/blocks/app-listing-assets.service.ts
@@ -355,7 +355,13 @@ async function loadOwnedListing(
   if (listing.userId !== user.id && !user.isModerator) {
     // Not the owner and not a mod — the last chance is an ACCEPTED collaborator seat.
     // Resolved lazily so the common owner/mod path costs no extra query.
-    const editor = await isAcceptedListingEditor(listingId, user.id);
+    //
+    // 🔴 `db` IS THREADED THROUGH, not dropped. An EDITOR never takes the owner
+    // short-circuit above — a shadow's `userId` is the PARENT OWNER's — so this is the
+    // ONLY branch an editor ever reaches. Resolving it off the replica while the caller
+    // handed us `dbWrite` would re-open, as a 403, the very read-after-write hole the
+    // override exists to close for the owner's 404.
+    const editor = await isAcceptedListingEditor(listingId, user.id, db);
     if (!editor) {
       throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not own this listing' });
     }
@@ -369,10 +375,17 @@ async function loadOwnedListing(
  * Extracted so every gate in this file asks the question the SAME way (`resolveAppAccess`
  * is the single predicate; this is a thin `role === 'editor'` read of it) and so the
  * seam has one name to mock in tests.
+ *
+ * `db` defaults to the replica and MUST be passed on by any caller that itself received
+ * a pool override — see the note at the `loadOwnedListing` call site.
  */
-async function isAcceptedListingEditor(listingId: string, userId: number): Promise<boolean> {
+async function isAcceptedListingEditor(
+  listingId: string,
+  userId: number,
+  db: typeof dbRead = dbRead
+): Promise<boolean> {
   const { resolveListingAccess } = await import('~/server/services/blocks/app-access.service');
-  const access = await resolveListingAccess(listingId, userId);
+  const access = await resolveListingAccess(listingId, userId, db);
   return access?.role === 'editor';
 }
 
@@ -1132,7 +1145,9 @@ async function resolveOwnerScreenshotTarget(
   // check on the screenshot's own listing; `loadOwnedListing` below re-asserts it on
   // the resolved listing row, so widening here does not weaken the second gate.
   if (shot.appListing.userId !== user.id && !user.isModerator) {
-    const editor = await isAcceptedListingEditor(shot.appListingId, user.id);
+    // Same pool discipline as `loadOwnedListing`: `db` is whichever pool actually
+    // answered for this screenshot, and an editor only ever reaches THIS branch.
+    const editor = await isAcceptedListingEditor(shot.appListingId, user.id, db);
     if (!editor) {
       throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not own this listing' });
     }

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -385,10 +385,10 @@ export async function getListingPreviewForReview(args: {
  *      unit-testable (which is how the public-projection allowlist is pinned).
  *
  * 🔴 The chips are built by the SAME `creatorChip` allowlist as `creator` — exactly
- * `{id, username, image}`, nothing else, ever. `app-listing.public-collaborators.test.ts`
- * asserts the projected key set is exactly those three even when the input user row
- * carries extra fields (email, bannedAt, …), so a wider `select` upstream cannot leak
- * through this seam.
+ * `{id, username, image}`, nothing else, ever.
+ * `app-collaborator.public-projection.test.ts` asserts the projected key set is exactly
+ * those three even when the input user row carries extra fields (email, bannedAt, …), so
+ * a wider `select` upstream cannot leak through this seam.
  */
 export function projectListingDetail(
   row: HydratedListing,

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -372,10 +372,33 @@ export async function getListingPreviewForReview(args: {
   return { card: projectListingCard(row), detail: projectListingDetail(row) };
 }
 
-/** Project a hydrated listing row → the PUBLIC detail DTO (allowlist). */
-export function projectListingDetail(row: HydratedListing): ListingDetail {
+/**
+ * Project a hydrated listing row → the PUBLIC detail DTO (allowlist).
+ *
+ * `collaborators` is passed IN rather than selected on `row`, and that is deliberate
+ * on two counts:
+ *   1. INERTNESS. `app_collaborators` is a MANUAL-APPLY table. A nested Prisma select
+ *      on it would make the whole public store-detail read fail with P2021 until a
+ *      human applies the migration — turning an additive feature into an outage. The
+ *      caller resolves them through `safeCollaboratorQuery`, which degrades to `[]`.
+ *   2. PURITY. This projection stays synchronous and IO-free, so it remains directly
+ *      unit-testable (which is how the public-projection allowlist is pinned).
+ *
+ * 🔴 The chips are built by the SAME `creatorChip` allowlist as `creator` — exactly
+ * `{id, username, image}`, nothing else, ever. `app-listing.public-collaborators.test.ts`
+ * asserts the projected key set is exactly those three even when the input user row
+ * carries extra fields (email, bannedAt, …), so a wider `select` upstream cannot leak
+ * through this seam.
+ */
+export function projectListingDetail(
+  row: HydratedListing,
+  collaborators: Array<{ id: number; username: string | null; image: string | null }> = []
+): ListingDetail {
   const recommend = recommendRollup(row.metric);
   return {
+    collaborators: collaborators
+      .map((u) => creatorChip(u))
+      .filter((c): c is ListingCreatorChip => c !== null),
     id: row.id,
     serialId: row.serialId,
     slug: row.slug,
@@ -664,7 +687,46 @@ export async function getListingDetail(
   // a missing one (mirrors the AppBlock detail's red-only 404).
   if (!redCapable && isMatureContentRating(row.contentRating)) return null;
 
-  return projectListingDetail(row);
+  return projectListingDetail(row, await loadDisplayedCollaboratorChips(row.appBlockId));
+}
+
+/**
+ * Hydrate the PUBLIC collaborator byline for a listing: the ACCEPTED **and**
+ * `displayed` collaborators of its backing AppBlock, projected to the same
+ * `{id, username, image}` allowlist as the creator chip.
+ *
+ * 🔴 CONSENT + OPT-IN, both load-bearing (enforced in `listDisplayedCollaboratorUserIds`):
+ * a PENDING invitee must never appear publicly — otherwise anyone could attach a
+ * stranger's name to their listing simply by inviting them — and an accepted
+ * collaborator who opted out of the byline must not appear either.
+ *
+ * Returns `[]` for a listing with no backing AppBlock (a natively-created offsite
+ * listing), and `[]` when the manual-apply migration has not landed — so the public
+ * read is byte-identical to today until both the table and a seat exist.
+ */
+async function loadDisplayedCollaboratorChips(
+  appBlockId: string | null
+): Promise<Array<{ id: number; username: string | null; image: string | null }>> {
+  if (!appBlockId) return [];
+  const { listDisplayedCollaboratorUserIds } = await import(
+    '~/server/services/blocks/app-access.service'
+  );
+  const userIds = await listDisplayedCollaboratorUserIds(appBlockId);
+  if (userIds.length === 0) return [];
+  // 🔴 EXPLICIT ALLOWLIST at the SELECT, not only at the projection. Two independent
+  // narrowings: nothing but these three columns ever leaves the DB, and `creatorChip`
+  // re-shapes them. Widening either alone cannot leak.
+  const users = await dbRead.user.findMany({
+    where: { id: { in: userIds } },
+    select: { id: true, username: true, image: true },
+  });
+  // Preserve the seat order (`createdAt asc`) rather than the DB's row order.
+  const byId = new Map(users.map((u: { id: number }) => [u.id, u]));
+  return userIds
+    .map((id) => byId.get(id))
+    .filter(
+      (u): u is { id: number; username: string | null; image: string | null } => u !== undefined
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/services/blocks/app-ownership-transfer.service.ts
+++ b/src/server/services/blocks/app-ownership-transfer.service.ts
@@ -79,10 +79,7 @@ async function loadOwnedApp(
   });
   if (!block?.app) throw new AppCollaboratorError('NOT_FOUND', 'App not found');
   if (block.app.userId !== actorUserId) {
-    throw new AppCollaboratorError(
-      'NOT_OWNER',
-      'Only the app owner can transfer ownership'
-    );
+    throw new AppCollaboratorError('NOT_OWNER', 'Only the app owner can transfer ownership');
   }
   return {
     appBlockId: block.id,
@@ -235,9 +232,7 @@ export async function acceptTransfer(opts: {
         expiresAt: true,
         appBlock: { select: { appId: true, blockId: true } },
       },
-    })) as
-      | (TransferView & { appBlock: { appId: string; blockId: string } | null })
-      | null;
+    })) as (TransferView & { appBlock: { appId: string; blockId: string } | null }) | null;
 
     if (!transfer || !transfer.appBlock) {
       throw new AppCollaboratorError('NOT_FOUND', 'That ownership transfer no longer exists');
@@ -246,10 +241,7 @@ export async function acceptTransfer(opts: {
       throw new AppCollaboratorError('NOT_OWNER', 'This transfer was not offered to you');
     }
     if (!isLive(transfer, now)) {
-      throw new AppCollaboratorError(
-        'NO_INVITE',
-        'This ownership transfer is no longer available'
-      );
+      throw new AppCollaboratorError('NO_INVITE', 'This ownership transfer is no longer available');
     }
 
     // (2) CANONICAL owner column, status-guarded on the snapshotted previous owner.
@@ -279,10 +271,7 @@ export async function acceptTransfer(opts: {
       data: { status: 'accepted', respondedAt: now },
     });
     if (closed.count === 0) {
-      throw new AppCollaboratorError(
-        'NO_INVITE',
-        'This ownership transfer is no longer available'
-      );
+      throw new AppCollaboratorError('NO_INVITE', 'This ownership transfer is no longer available');
     }
 
     // (5) Audit — in-tx, so a rollback leaves ZERO events.

--- a/src/server/services/blocks/app-ownership-transfer.service.ts
+++ b/src/server/services/blocks/app-ownership-transfer.service.ts
@@ -1,5 +1,3 @@
-import type { Prisma } from '@prisma/client';
-
 import { constants } from '~/server/common/constants';
 import { dbRead, dbWrite } from '~/server/db/client';
 import {

--- a/src/server/services/blocks/app-ownership-transfer.service.ts
+++ b/src/server/services/blocks/app-ownership-transfer.service.ts
@@ -40,7 +40,8 @@ import { newAppOwnershipTransferId } from '~/server/utils/app-block-ids';
  *     Rewriting the column mid-period would MERGE the two owners' pending rows into
  *     one payout group and could collide on that unique. Leaving them alone means the
  *     old owner is still paid for what they accrued and the new owner starts at zero.
- *     `app-ownership-transfer.money-invariance.test.ts` pins this.
+ *     `app-ownership-transfer.service.test.ts`'s "MONEY INVARIANCE" describe pins this
+ *     (including the positive control that proves those mocks CAN record a call).
  *
  * ## Forgejo
  *
@@ -199,6 +200,13 @@ export async function initiateTransfer(opts: {
  * 🔴 THE ATOMIC CORE. In ONE transaction:
  *   1. re-read the transfer on the PRIMARY and re-assert it is live + addressed to the
  *      caller (a replica read could accept an already-cancelled offer under lag);
+ *   1b. re-read the RECIPIENT's `bannedAt` on the PRIMARY. The ban was checked at
+ *      INITIATE and again from `ctx.user` at the proc, but a transfer stays open for
+ *      `transferExpiryDays` and a SESSION can be arbitrarily stale — so without this
+ *      read the stated policy ("a banned user may not receive an ownership transfer")
+ *      is simply false anywhere inside that window. `respondToInvite` re-reads the user
+ *      row for exactly this reason; this one goes further and reads in-transaction on
+ *      the primary, because unlike a seat an ownership move is not cheap to unwind;
  *   2. re-assert `OauthClient.userId` STILL equals the transfer's `fromUserId` — a
  *      status-guarded `updateMany` whose 0-count means the owner changed since the
  *      offer (a second transfer landed first), rolling everything back;
@@ -242,6 +250,18 @@ export async function acceptTransfer(opts: {
     }
     if (!isLive(transfer, now)) {
       throw new AppCollaboratorError('NO_INVITE', 'This ownership transfer is no longer available');
+    }
+
+    // (1b) 🔴 RE-READ THE BAN on the primary, in-transaction. `ctx.user.bannedAt` is a
+    // SESSION value and the offer may have been sitting open for days; the initiate-time
+    // check says nothing about now. Without this, "a banned user may not receive an
+    // ownership transfer" is false for the whole expiry window.
+    const recipient = (await tx.user.findUnique({
+      where: { id: opts.userId },
+      select: { bannedAt: true },
+    })) as { bannedAt: Date | null } | null;
+    if (recipient?.bannedAt) {
+      throw new AppCollaboratorError('BANNED', 'That account cannot receive app ownership');
     }
 
     // (2) CANONICAL owner column, status-guarded on the snapshotted previous owner.
@@ -376,12 +396,29 @@ export async function cancelTransfer(opts: {
  * The LIVE pending transfer for an app, or `null`. Expiry is applied as a read-time
  * predicate (see {@link isLive}) so an expired row never surfaces as pending, whether
  * or not anything has swept it.
+ *
+ * 🔴 AUTHORIZED, like its three siblings. The row names BOTH parties (`fromUserId`,
+ * `toUserId`) and the offer's deadline; every other transfer proc gates
+ * (`initiateTransfer` → owner, `acceptTransfer` → addressee, `cancelTransfer` → either
+ * party), and this one took no caller at all, so any flagged account could read who is
+ * handing which app to whom. Permitted: the app OWNER (who is the offer's `fromUserId`)
+ * and the ADDRESSEE, matching exactly the set that may act on the transfer.
+ *
+ * An unauthorized caller gets `null`, NOT a FORBIDDEN. Throwing would make this proc an
+ * existence ORACLE — "this app has a pending transfer" is itself the private fact — so
+ * the refusal is made indistinguishable from "there is no offer". (`NOT_FOUND` for a
+ * missing app is fine: app existence is already public.)
  */
 export async function getPendingTransfer(opts: {
   appBlockId: string;
+  /** The caller. Required — this is not a public read; see above. */
+  viewerUserId: number;
   now?: Date;
 }): Promise<TransferView | null> {
   const now = opts.now ?? new Date();
+  const { resolveAppAccess } = await import('~/server/services/blocks/app-access.service');
+  const access = await resolveAppAccess(opts.appBlockId, opts.viewerUserId);
+  if (!access) throw new AppCollaboratorError('NOT_FOUND', 'App not found');
   const row = (await dbRead.appOwnershipTransfer.findFirst({
     where: { appBlockId: opts.appBlockId, status: 'pending' },
     select: {
@@ -395,5 +432,9 @@ export async function getPendingTransfer(opts: {
     },
   })) as TransferView | null;
   if (!row || !isLive(row, now)) return null;
+  // Owner or addressee only. An EDITOR is deliberately excluded: a seat is a content
+  // capability, and disposing of the app is the one thing an editor may not do or
+  // initiate — so it is not theirs to watch either.
+  if (access.role !== 'owner' && row.toUserId !== opts.viewerUserId) return null;
   return row;
 }

--- a/src/server/services/blocks/app-ownership-transfer.service.ts
+++ b/src/server/services/blocks/app-ownership-transfer.service.ts
@@ -1,0 +1,412 @@
+import type { Prisma } from '@prisma/client';
+
+import { constants } from '~/server/common/constants';
+import { dbRead, dbWrite } from '~/server/db/client';
+import {
+  AppCollaboratorError,
+  recordOwnershipEvent,
+} from '~/server/services/blocks/app-collaborator.service';
+import { notifyAppCollaborator } from '~/server/services/blocks/app-collaborator-notify';
+import { grantAppRepoWrite, revokeAppRepoWrite } from '~/server/services/blocks/app-repo-access';
+import { newAppOwnershipTransferId } from '~/server/utils/app-block-ids';
+
+/**
+ * App Listing COLLABORATORS — OWNERSHIP TRANSFER (owner initiates → recipient accepts).
+ *
+ * ## Authorization: no moderator in the loop
+ *
+ * The prior art, `offsite-moderation.service.ts::claimListing:623`, is MOD-ONLY,
+ * OFFSITE-ONLY and reassigns `AppListing.userId` alone. That guard SHAPE is extended
+ * here (status-guarded `updateMany`, in-tx primary snapshot, an audit event written in
+ * the same transaction so a rolled-back transfer leaves ZERO events, submission
+ * history untouched), but the authorization model is different by product decision:
+ * the owner initiates and the recipient accepts. Nobody else is involved.
+ *
+ * 🔴 And `claimListing`'s single write is INSUFFICIENT for an ONSITE app. Ownership is
+ * canonically `OauthClient.userId` (`AppBlock.app.userId`); `AppListing.userId` is a
+ * DENORMALIZED COPY. Moving only the listing column would leave the app's real owner
+ * unchanged — the old owner would keep `getMyAppRepo`/`updateManifest`/`getMyApps`
+ * while the new owner got the store listing. So accept writes BOTH columns in ONE
+ * transaction. `app-ownership-transfer.service.test.ts` injects a failure on the second
+ * write and asserts a full rollback.
+ *
+ * ## What deliberately does NOT move
+ *
+ *   - `AppBlockPublishRequest.submittedByUserId` — historical submission record,
+ *     preserved for audit fidelity. Same locked decision as `claimListing`.
+ *   - 🔴 `BlockBuzzAttribution.appOwnerUserId` — NOT rewritten. Product decision: Buzz
+ *     accrued before the transfer stays with the OLD owner; the transfer is a clean
+ *     forward cut. This is also what keeps the money invariant safe: those rows are
+ *     grouped by `appOwnerUserId` in `bulk-payout-block-attributions.ts` and
+ *     `mintPayoutForOwner` carries a `(app_owner_user_id, period_key)` UNIQUE.
+ *     Rewriting the column mid-period would MERGE the two owners' pending rows into
+ *     one payout group and could collide on that unique. Leaving them alone means the
+ *     old owner is still paid for what they accrued and the new owner starts at zero.
+ *     `app-ownership-transfer.money-invariance.test.ts` pins this.
+ *
+ * ## Forgejo
+ *
+ * On accept: revoke the OLD owner's repo write, grant the NEW owner's. Collaborator
+ * seats are untouched by a transfer — the app keeps its editors.
+ */
+
+export type TransferView = {
+  id: string;
+  appBlockId: string;
+  fromUserId: number;
+  toUserId: number;
+  status: string;
+  expiresAt: Date;
+  createdAt: Date;
+};
+
+/**
+ * A pending transfer that has passed `expiresAt` is treated as ABSENT everywhere.
+ *
+ * Enforced as a READ-TIME predicate rather than by a sweeper job, so expiry is correct
+ * with no cron dependency: an expired row can never be accepted, and `initiateTransfer`
+ * reclaims it. A sweeper would only tidy rows.
+ */
+function isLive(t: { status: string; expiresAt: Date }, now: Date): boolean {
+  return t.status === 'pending' && t.expiresAt.getTime() > now.getTime();
+}
+
+async function loadOwnedApp(
+  appBlockId: string,
+  actorUserId: number
+): Promise<{ appBlockId: string; appId: string; slug: string; ownerUserId: number }> {
+  const block = await dbRead.appBlock.findUnique({
+    where: { id: appBlockId },
+    select: { id: true, appId: true, blockId: true, app: { select: { userId: true } } },
+  });
+  if (!block?.app) throw new AppCollaboratorError('NOT_FOUND', 'App not found');
+  if (block.app.userId !== actorUserId) {
+    throw new AppCollaboratorError(
+      'NOT_OWNER',
+      'Only the app owner can transfer ownership'
+    );
+  }
+  return {
+    appBlockId: block.id,
+    appId: block.appId,
+    slug: block.blockId,
+    ownerUserId: block.app.userId,
+  };
+}
+
+/**
+ * OWNER: offer ownership to another user. Creates a `pending` transfer; NOTHING moves
+ * until the recipient accepts.
+ *
+ * 🔴 A PENDING TRANSFER CONFERS ZERO CAPABILITY on the recipient — it is not a seat,
+ * it does not appear in `resolveAppAccess`, and it grants no repo access. Same consent
+ * principle as a pending invite.
+ *
+ * One in-flight transfer per app, enforced by the migration's PARTIAL UNIQUE index
+ * (`app_block_id WHERE status='pending'`), which Prisma cannot express. A concurrent
+ * second initiate loses on P2002 and is surfaced as a friendly error rather than a
+ * raw constraint violation.
+ */
+export async function initiateTransfer(opts: {
+  appBlockId: string;
+  toUserId: number;
+  actorUserId: number;
+  now?: Date;
+}): Promise<TransferView> {
+  const now = opts.now ?? new Date();
+  const app = await loadOwnedApp(opts.appBlockId, opts.actorUserId);
+
+  if (opts.toUserId === app.ownerUserId) {
+    throw new AppCollaboratorError('INVALID_TARGET', 'You already own this app');
+  }
+  const target = await dbRead.user.findUnique({
+    where: { id: opts.toUserId },
+    select: { id: true, bannedAt: true },
+  });
+  if (!target) throw new AppCollaboratorError('INVALID_TARGET', 'That user could not be found');
+  if (target.bannedAt) {
+    throw new AppCollaboratorError('BANNED', 'That account cannot receive app ownership');
+  }
+
+  // Reclaim an EXPIRED pending row first — otherwise the partial unique index would
+  // block every future transfer for this app once one invitation lapsed.
+  await dbWrite.appOwnershipTransfer.updateMany({
+    where: { appBlockId: app.appBlockId, status: 'pending', expiresAt: { lte: now } },
+    data: { status: 'expired', respondedAt: now },
+  });
+
+  const id = newAppOwnershipTransferId();
+  const expiresAt = new Date(
+    now.getTime() + constants.appCollaborators.transferExpiryDays * 86_400_000
+  );
+
+  let created: TransferView;
+  try {
+    created = await dbWrite.$transaction(async (tx) => {
+      const row = (await tx.appOwnershipTransfer.create({
+        data: {
+          id,
+          appBlockId: app.appBlockId,
+          fromUserId: app.ownerUserId,
+          toUserId: opts.toUserId,
+          status: 'pending',
+          expiresAt,
+        },
+        select: {
+          id: true,
+          appBlockId: true,
+          fromUserId: true,
+          toUserId: true,
+          status: true,
+          expiresAt: true,
+          createdAt: true,
+        },
+      })) as TransferView;
+      await recordOwnershipEvent(tx, {
+        appBlockId: app.appBlockId,
+        slug: app.slug,
+        action: 'transfer_initiated',
+        actorUserId: opts.actorUserId,
+        targetUserId: opts.toUserId,
+        metadata: { transferId: id, expiresAt: expiresAt.toISOString() },
+      });
+      return row;
+    });
+  } catch (err) {
+    // The partial-unique index rejected a second live transfer. Duck-type on `code`
+    // (the Prisma error class is not reliably constructible against a stale client) —
+    // the same technique `beginListingRevision` uses for its one-shadow index.
+    if ((err as { code?: unknown })?.code === 'P2002') {
+      throw new AppCollaboratorError(
+        'ALREADY_SEATED',
+        'This app already has a pending ownership transfer. Cancel it first.'
+      );
+    }
+    throw err;
+  }
+
+  try {
+    await notifyAppCollaborator({
+      type: 'app-ownership-transfer-offered',
+      userId: opts.toUserId,
+      key: `app-ownership-transfer-offered:${id}`,
+      details: { slug: app.slug, appBlockId: app.appBlockId },
+    });
+  } catch {
+    /* best-effort, post-commit */
+  }
+  return created;
+}
+
+/**
+ * RECIPIENT: accept a pending ownership transfer.
+ *
+ * 🔴 THE ATOMIC CORE. In ONE transaction:
+ *   1. re-read the transfer on the PRIMARY and re-assert it is live + addressed to the
+ *      caller (a replica read could accept an already-cancelled offer under lag);
+ *   2. re-assert `OauthClient.userId` STILL equals the transfer's `fromUserId` — a
+ *      status-guarded `updateMany` whose 0-count means the owner changed since the
+ *      offer (a second transfer landed first), rolling everything back;
+ *   3. move `AppListing.userId` for the backing listing — the denormalized copy;
+ *   4. flip the transfer to `accepted`;
+ *   5. write the audit event.
+ *
+ * Steps 2 and 3 are the two ownership columns; a failure in either rolls back BOTH.
+ * That is asserted directly (inject a throw on the second write; assert the first is
+ * not observable).
+ *
+ * NOT touched, by design: `AppBlockPublishRequest.submittedByUserId`,
+ * `BlockBuzzAttribution.appOwnerUserId`, collaborator seats. See the module header.
+ */
+export async function acceptTransfer(opts: {
+  transferId: string;
+  userId: number;
+  now?: Date;
+}): Promise<{ transferId: string; appBlockId: string; fromUserId: number; toUserId: number }> {
+  const now = opts.now ?? new Date();
+
+  const result = await dbWrite.$transaction(async (tx) => {
+    const transfer = (await tx.appOwnershipTransfer.findUnique({
+      where: { id: opts.transferId },
+      select: {
+        id: true,
+        appBlockId: true,
+        fromUserId: true,
+        toUserId: true,
+        status: true,
+        expiresAt: true,
+        appBlock: { select: { appId: true, blockId: true } },
+      },
+    })) as
+      | (TransferView & { appBlock: { appId: string; blockId: string } | null })
+      | null;
+
+    if (!transfer || !transfer.appBlock) {
+      throw new AppCollaboratorError('NOT_FOUND', 'That ownership transfer no longer exists');
+    }
+    if (transfer.toUserId !== opts.userId) {
+      throw new AppCollaboratorError('NOT_OWNER', 'This transfer was not offered to you');
+    }
+    if (!isLive(transfer, now)) {
+      throw new AppCollaboratorError(
+        'NO_INVITE',
+        'This ownership transfer is no longer available'
+      );
+    }
+
+    // (2) CANONICAL owner column, status-guarded on the snapshotted previous owner.
+    const movedClient = await tx.oauthClient.updateMany({
+      where: { id: transfer.appBlock.appId, userId: transfer.fromUserId },
+      data: { userId: transfer.toUserId },
+    });
+    if (movedClient.count === 0) {
+      throw new AppCollaboratorError(
+        'NO_INVITE',
+        'Ownership of this app has changed; this transfer can no longer be accepted'
+      );
+    }
+
+    // (3) DENORMALIZED copy. `updateMany` (not `update`) because an app need not have a
+    // listing yet — a first-version app pending approval has no `AppListing` row. A
+    // 0-count is therefore LEGITIMATE here and must not fail the transfer, which is
+    // exactly why this is not status-guarded the way (2) is.
+    await tx.appListing.updateMany({
+      where: { appBlockId: transfer.appBlockId },
+      data: { userId: transfer.toUserId },
+    });
+
+    // (4) Close the transfer, guarded so a concurrent cancel cannot be overwritten.
+    const closed = await tx.appOwnershipTransfer.updateMany({
+      where: { id: transfer.id, status: 'pending' },
+      data: { status: 'accepted', respondedAt: now },
+    });
+    if (closed.count === 0) {
+      throw new AppCollaboratorError(
+        'NO_INVITE',
+        'This ownership transfer is no longer available'
+      );
+    }
+
+    // (5) Audit — in-tx, so a rollback leaves ZERO events.
+    await recordOwnershipEvent(tx, {
+      appBlockId: transfer.appBlockId,
+      slug: transfer.appBlock.blockId,
+      action: 'transfer_accepted',
+      actorUserId: opts.userId,
+      targetUserId: opts.userId,
+      metadata: {
+        transferId: transfer.id,
+        before: { userId: transfer.fromUserId },
+        after: { userId: transfer.toUserId },
+      },
+    });
+
+    return {
+      transferId: transfer.id,
+      appBlockId: transfer.appBlockId,
+      fromUserId: transfer.fromUserId,
+      toUserId: transfer.toUserId,
+      slug: transfer.appBlock.blockId,
+    };
+  });
+
+  // POST-COMMIT external effects. Swap the repo grants: the old owner loses write, the
+  // new owner gains it. Collaborator seats are unaffected — the app keeps its editors.
+  await revokeAppRepoWrite({ slug: result.slug, userId: result.fromUserId });
+  await grantAppRepoWrite({ slug: result.slug, userId: result.toUserId });
+
+  try {
+    await notifyAppCollaborator({
+      type: 'app-ownership-transfer-accepted',
+      userId: result.fromUserId,
+      key: `app-ownership-transfer-accepted:${result.transferId}`,
+      details: { slug: result.slug, appBlockId: result.appBlockId },
+    });
+  } catch {
+    /* best-effort, post-commit */
+  }
+
+  return {
+    transferId: result.transferId,
+    appBlockId: result.appBlockId,
+    fromUserId: result.fromUserId,
+    toUserId: result.toUserId,
+  };
+}
+
+/**
+ * Cancel a pending transfer. Either party may: the OWNER withdraws the offer, or the
+ * RECIPIENT declines it. Both land on the same terminal state and the same audit
+ * action — the actor id on the event records which of the two it was.
+ */
+export async function cancelTransfer(opts: {
+  transferId: string;
+  actorUserId: number;
+  now?: Date;
+}): Promise<{ transferId: string; cancelled: boolean }> {
+  const now = opts.now ?? new Date();
+
+  return dbWrite.$transaction(async (tx) => {
+    const transfer = (await tx.appOwnershipTransfer.findUnique({
+      where: { id: opts.transferId },
+      select: {
+        id: true,
+        appBlockId: true,
+        fromUserId: true,
+        toUserId: true,
+        status: true,
+        expiresAt: true,
+        appBlock: { select: { blockId: true } },
+      },
+    })) as (TransferView & { appBlock: { blockId: string } | null }) | null;
+
+    if (!transfer || !transfer.appBlock) {
+      throw new AppCollaboratorError('NOT_FOUND', 'That ownership transfer no longer exists');
+    }
+    if (transfer.fromUserId !== opts.actorUserId && transfer.toUserId !== opts.actorUserId) {
+      throw new AppCollaboratorError('NOT_OWNER', 'You are not party to this transfer');
+    }
+
+    const closed = await tx.appOwnershipTransfer.updateMany({
+      where: { id: transfer.id, status: 'pending' },
+      data: { status: 'cancelled', respondedAt: now },
+    });
+    if (closed.count === 0) return { transferId: transfer.id, cancelled: false };
+
+    await recordOwnershipEvent(tx, {
+      appBlockId: transfer.appBlockId,
+      slug: transfer.appBlock.blockId,
+      action: 'transfer_cancelled',
+      actorUserId: opts.actorUserId,
+      targetUserId: transfer.toUserId,
+      metadata: { transferId: transfer.id },
+    });
+    return { transferId: transfer.id, cancelled: true };
+  });
+}
+
+/**
+ * The LIVE pending transfer for an app, or `null`. Expiry is applied as a read-time
+ * predicate (see {@link isLive}) so an expired row never surfaces as pending, whether
+ * or not anything has swept it.
+ */
+export async function getPendingTransfer(opts: {
+  appBlockId: string;
+  now?: Date;
+}): Promise<TransferView | null> {
+  const now = opts.now ?? new Date();
+  const row = (await dbRead.appOwnershipTransfer.findFirst({
+    where: { appBlockId: opts.appBlockId, status: 'pending' },
+    select: {
+      id: true,
+      appBlockId: true,
+      fromUserId: true,
+      toUserId: true,
+      status: true,
+      expiresAt: true,
+      createdAt: true,
+    },
+  })) as TransferView | null;
+  if (!row || !isLive(row, now)) return null;
+  return row;
+}

--- a/src/server/services/blocks/app-repo-access.ts
+++ b/src/server/services/blocks/app-repo-access.ts
@@ -1,0 +1,94 @@
+import { logToAxiom } from '~/server/logging/client';
+
+/**
+ * App Listing COLLABORATORS — the FORGEJO GRANT/REVOKE lifecycle for a seat.
+ *
+ * A thin seam over `forgejo.service` + `dev-git-access.service` whose only static
+ * import is the logger. Both Forgejo helpers are DYNAMICALLY imported inside the async
+ * bodies (mirroring `app-block-notify` / `app-listing-notify` and `getMyAppRepo`'s own
+ * discipline), so importing this module adds ZERO runtime graph to a caller and the
+ * seat-lifecycle unit tests can mock exactly this seam.
+ *
+ * ## The lifecycle this closes
+ *
+ *   accept an invite  → grant `write` on civitai-apps/<slug>
+ *   remove / leave    → REVOKE
+ *   transfer accepted → revoke the OLD owner, grant the NEW owner
+ *
+ * Before this, only the grant half existed anywhere in the repo.
+ *
+ * ## Best-effort, and why that is the right call here rather than a cop-out
+ *
+ * Both functions SWALLOW failures (logged to Axiom) instead of propagating. Forgejo is
+ * an external system; a 502 from it must not roll back a consent decision the user
+ * already made, nor block an owner from removing someone.
+ *
+ * The two directions have DIFFERENT residual risk and it is worth being precise:
+ *   - a failed GRANT is self-healing — `getMyAppRepo` calls `addCollaborator` on every
+ *     invocation, so the editor's first use of the repo re-grants;
+ *   - a failed REVOKE is NOT self-healing. Nothing re-runs it. The seat is gone from
+ *     the DB (so every civitai-side capability is closed immediately), but the removed
+ *     user may retain Forgejo push access until someone notices. That residue cannot
+ *     deploy anything on its own — a push only parks a `pending` publish request that
+ *     a moderator must approve — so it is a real but bounded gap. A durable
+ *     retry/reconcile job is the correct fix and is NOT in this PR; the log line
+ *     `app-repo-access` / `revoke-failed` is the only signal today.
+ */
+
+/** Grant `write` on the app's canonical repo to a collaborator's Forgejo identity. */
+export async function grantAppRepoWrite(opts: { slug: string; userId: number }): Promise<void> {
+  try {
+    const [{ ensureForgejoIdentity }, { addCollaborator }] = await Promise.all([
+      import('~/server/services/blocks/dev-git-access.service'),
+      import('~/server/services/blocks/forgejo.service'),
+    ]);
+    const { forgejoUsername } = await ensureForgejoIdentity(opts.userId);
+    await addCollaborator({ slug: opts.slug, username: forgejoUsername, permission: 'write' });
+  } catch (err) {
+    logToAxiom(
+      {
+        name: 'app-repo-access',
+        type: 'error',
+        message: 'grant-failed',
+        slug: opts.slug,
+        userId: opts.userId,
+        error: err instanceof Error ? err.message : String(err),
+      },
+      'webhooks'
+    ).catch(() => undefined);
+  }
+}
+
+/**
+ * Revoke a user's collaborator row on the app's canonical repo.
+ *
+ * 🔴 Uses `forgejoUsernameForUser` (the pure `dev-<userId>` derivation) rather than
+ * `ensureForgejoIdentity`. That is deliberate, not a shortcut: `ensureForgejoIdentity`
+ * PROVISIONS on miss — it would create a Forgejo user and mint them a push token as a
+ * side effect of REVOKING their access. Revocation must never be able to bring an
+ * identity into existence.
+ */
+export async function revokeAppRepoWrite(opts: { slug: string; userId: number }): Promise<void> {
+  try {
+    const [{ forgejoUsernameForUser }, { removeCollaborator }] = await Promise.all([
+      import('~/server/services/blocks/dev-git-access.service'),
+      import('~/server/services/blocks/forgejo.service'),
+    ]);
+    await removeCollaborator({
+      slug: opts.slug,
+      username: forgejoUsernameForUser(opts.userId),
+    });
+  } catch (err) {
+    logToAxiom(
+      {
+        name: 'app-repo-access',
+        type: 'error',
+        message: 'revoke-failed',
+        slug: opts.slug,
+        userId: opts.userId,
+        error: err instanceof Error ? err.message : String(err),
+      },
+      'webhooks'
+    ).catch(() => undefined);
+  }
+}

--- a/src/server/services/blocks/forgejo.service.ts
+++ b/src/server/services/blocks/forgejo.service.ts
@@ -405,6 +405,36 @@ export async function addCollaborator(opts: {
 }
 
 /**
+ * REVOKE a user's collaborator row on `civitai-apps/<slug>`.
+ *
+ * 🔴 THE MISSING HALF. Until App Listing Collaborators, this codebase could only ever
+ * GRANT (`addCollaborator`) — a developer handed `write` kept it forever, because no
+ * caller and no function existed to take it back. Removing a collaborator seat (or
+ * transferring ownership away) is the first operation with a genuine revoke
+ * requirement, so this is its counterpart.
+ *
+ * Gitea/Forgejo `DELETE /repos/{owner}/{repo}/collaborators/{user}` answers 204 on a
+ * successful removal AND on a user who was not a collaborator; 404 is the repo (or
+ * user) not existing. Both are treated as success, mirroring `deleteForgejoUser` /
+ * `deleteReviewRepo` — revocation is idempotent, and "they already do not have it" is
+ * the desired end state, not an error.
+ *
+ * 🔴 UNLIKE `addCollaborator` this does NOT read the current permission first. That
+ * read exists there only to implement grant-AT-LEAST (never downgrade); a revoke has
+ * no level to preserve. Deliberately NOT symmetric — do not "fix" it by adding one.
+ */
+export async function removeCollaborator(opts: { slug: string; username: string }): Promise<void> {
+  const res = await fjFetch(
+    `/api/v1/repos/${FORGEJO_ORG}/${opts.slug}/collaborators/${encodeURIComponent(opts.username)}`,
+    { method: 'DELETE' }
+  );
+  if (!res.ok && res.status !== 204 && res.status !== 404) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`Forgejo removeCollaborator ${res.status}: ${body.slice(0, 240)}`);
+  }
+}
+
+/**
  * Attach a push webhook pointing at our webhook handler. HMAC secret is
  * read from FORGEJO_WEBHOOK_SECRET so all repos share the same key (the
  * receiver doesn't need per-repo state to verify). If a webhook with the

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -839,7 +839,31 @@ const editableListingSelect = {
   coverId: true,
 } as const;
 
-/** Load a listing and assert the caller is its OWNER (strict — no mod override on the author edit path). */
+/**
+ * True when `userId` holds an ACCEPTED collaborator seat reachable from this listing.
+ *
+ * Dynamic import: `app-access.service` is small and IO-only, but keeping the import
+ * inside the body matches this file's existing discipline for cross-service reach
+ * (`beginListingRevision`'s import of the asset service) and keeps the module graph of
+ * a plain listing read unchanged.
+ */
+async function isAcceptedListingEditor(listingId: string, userId: number): Promise<boolean> {
+  const { resolveListingAccess } = await import('~/server/services/blocks/app-access.service');
+  const access = await resolveListingAccess(listingId, userId);
+  return access?.role === 'editor';
+}
+
+/**
+ * Load a listing and assert the caller may edit it: its OWNER or an ACCEPTED
+ * collaborator on the backing AppBlock.
+ *
+ * 🔴 STILL NO MODERATOR OVERRIDE — unchanged, and deliberately different from
+ * `app-listing-assets.service::loadOwnedListing`, which does bypass for mods. That
+ * divergence between two sibling gates PREDATES collaborators; it was surfaced by
+ * consolidating the predicate and is recorded in `app-access.call-site-ledger.test.ts`
+ * rather than quietly normalised, because "make the mod bypass consistent" is a
+ * behaviour change to the author edit path that deserves its own decision.
+ */
 async function loadOwnedEditableListing(
   listingId: string,
   userId: number
@@ -851,7 +875,7 @@ async function loadOwnedEditableListing(
   if (!listing) {
     throw new OffsiteRequestError('NOT_FOUND', `listing ${listingId} not found`);
   }
-  if (listing.userId !== userId) {
+  if (listing.userId !== userId && !(await isAcceptedListingEditor(listingId, userId))) {
     throw new OffsiteRequestError('NOT_OWNED', 'you can only edit your own listings');
   }
   return listing;
@@ -1130,7 +1154,12 @@ export async function submitListingRevision(opts: {
   if (!shadow) {
     throw new OffsiteRequestError('NOT_FOUND', `revision draft ${shadowId} not found`);
   }
-  if (shadow.userId !== userId) {
+  // Owner OR an ACCEPTED collaborator. 🔴 Note the shadow's `userId` is the PARENT
+  // OWNER's, not the editor's — `beginListingRevision` clones with
+  // `userId: parent.userId` — so an editor's own shadow reads as owned by someone
+  // else and the bare equality refused it. Submitting a new version is an explicit
+  // editor capability, so the seat check is what admits them.
+  if (shadow.userId !== userId && !(await isAcceptedListingEditor(shadowId, userId))) {
     throw new OffsiteRequestError('NOT_OWNED', 'you can only submit your own revision');
   }
   if (shadow.revisionOfId == null || !shadow.revisionOf) {
@@ -1624,7 +1653,9 @@ export async function getMyListingForApp(opts: {
       `no listing found for app ${appBlockId ?? slug ?? '(unspecified)'}`
     );
   }
-  if (listing.userId !== userId) {
+  // Owner OR an ACCEPTED collaborator on the backing AppBlock. This is the media
+  // editor's entry read; an editor who cannot reach it cannot edit anything.
+  if (listing.userId !== userId && !(await isAcceptedListingEditor(listing.id, userId))) {
     throw new OffsiteRequestError('NOT_OWNED', 'you can only manage your own listings');
   }
   // A pending revision REQUEST (not mere shadow existence) drives the "already

--- a/src/server/utils/app-block-ids.ts
+++ b/src/server/utils/app-block-ids.ts
@@ -133,3 +133,14 @@ export function newAppListingModerationEventId(): string {
 export function newAppReviewAgentReportId(): string {
   return `arar_${newUlid()}`;
 }
+
+// App Listing Collaborators — the append-only ownership audit trail + the
+// in-flight ownership transfer. (`AppCollaborator` itself has a COMPOSITE key
+// `(appBlockId, userId)` and needs no generated id.)
+export function newAppOwnershipEventId(): string {
+  return `aoe_${newUlid()}`;
+}
+
+export function newAppOwnershipTransferId(): string {
+  return `aot_${newUlid()}`;
+}


### PR DESCRIPTION
Adds **App Listing Collaborators**: a consent-gated *editor* seat on an App Block, an owner-initiated / recipient-accepted **ownership transfer**, and a public **display-author** byline opt-in.

An editor is effectively a co-owner — listing content + media, submit new versions, view analytics, and see earnings for the shared app. The only things reserved to the owner are **managing collaborators** and **initiating a transfer**.

---

## 🔴 Prisma migrations are NEVER auto-applied here

The main civitai DB (CNPG nvme0) does **not** run `prisma migrate deploy`; no deploy path applies migrations. The `.sql` below is committed **for history only** and must be **applied by a human** (psql/retool) per environment — prod nvme0 **and** the dev clone.

**The feature is INERT until then, by construction.** Every read of the new tables goes through `safeCollaboratorQuery` (`app-access.service.ts`), which catches the missing-relation error (Prisma `P2021` / PG `42P01`) and degrades to "no collaborators" — i.e. byte-identical to today's owner-only behaviour. It does **not** blanket-catch: a connection failure or a genuine query bug still propagates, so this cannot become a permanent silent-zero. Merging and deploying before the SQL is applied changes nothing observable and does not 500 the app pages.

### Raw SQL to apply

`packages/civitai-db-schema/prisma/migrations/20260810140000_app_listing_collaborators/migration.sql`

```sql
-- 1. app_collaborators — the consent-gated editor seat (+ byline opt-in)
CREATE TABLE IF NOT EXISTS "app_collaborators" (
  "app_block_id"     TEXT    NOT NULL REFERENCES "app_blocks"("id") ON DELETE CASCADE,
  "user_id"          INTEGER NOT NULL REFERENCES "User"("id")       ON DELETE CASCADE,
  "role"             TEXT    NOT NULL DEFAULT 'editor',
  "status"           TEXT    NOT NULL DEFAULT 'pending',
  "displayed"        BOOLEAN NOT NULL DEFAULT true,
  "invited_by"       INTEGER NOT NULL REFERENCES "User"("id")       ON DELETE CASCADE,
  "last_notified_at" TIMESTAMPTZ,
  "created_at"       TIMESTAMPTZ NOT NULL DEFAULT now(),
  "responded_at"     TIMESTAMPTZ,
  PRIMARY KEY ("app_block_id", "user_id"),
  CONSTRAINT "app_collaborators_status_check" CHECK ("status" IN ('pending','accepted','rejected')),
  CONSTRAINT "app_collaborators_role_check"   CHECK ("role" IN ('editor'))
);
CREATE INDEX IF NOT EXISTS "app_collaborators_user_status_idx" ON "app_collaborators" ("user_id","status");
CREATE INDEX IF NOT EXISTS "app_collaborators_app_status_idx"  ON "app_collaborators" ("app_block_id","status");
CREATE INDEX IF NOT EXISTS "app_collaborators_invited_by_idx"  ON "app_collaborators" ("invited_by");

-- 2. app_ownership_events — append-only audit trail (every FK nullable + SET NULL so
--    an event outlives the app, the actor and the target)
CREATE TABLE IF NOT EXISTS "app_ownership_events" (
  "id"             TEXT PRIMARY KEY,                                        -- aoe_<ULID>
  "app_block_id"   TEXT    REFERENCES "app_blocks"("id") ON DELETE SET NULL,
  "slug"           TEXT    NOT NULL,
  "action"         TEXT    NOT NULL,
  "actor_user_id"  INTEGER REFERENCES "User"("id")       ON DELETE SET NULL,
  "target_user_id" INTEGER REFERENCES "User"("id")       ON DELETE SET NULL,
  "metadata"       JSONB,
  "created_at"     TIMESTAMPTZ NOT NULL DEFAULT now(),
  CONSTRAINT "app_ownership_events_action_check" CHECK ("action" IN (
    'invite','accept','reject','remove','leave','display',
    'transfer_initiated','transfer_accepted','transfer_cancelled'))
);
CREATE INDEX IF NOT EXISTS "app_ownership_events_app_idx"   ON "app_ownership_events" ("app_block_id","created_at" DESC);
CREATE INDEX IF NOT EXISTS "app_ownership_events_actor_idx" ON "app_ownership_events" ("actor_user_id","created_at" DESC);

-- 3. app_ownership_transfers — an in-flight owner→recipient transfer
CREATE TABLE IF NOT EXISTS "app_ownership_transfers" (
  "id"           TEXT PRIMARY KEY,                                    -- aot_<ULID>
  "app_block_id" TEXT    NOT NULL REFERENCES "app_blocks"("id") ON DELETE CASCADE,
  "from_user_id" INTEGER NOT NULL REFERENCES "User"("id")       ON DELETE CASCADE,
  "to_user_id"   INTEGER NOT NULL REFERENCES "User"("id")       ON DELETE CASCADE,
  "status"       TEXT    NOT NULL DEFAULT 'pending',
  "expires_at"   TIMESTAMPTZ NOT NULL,
  "created_at"   TIMESTAMPTZ NOT NULL DEFAULT now(),
  "responded_at" TIMESTAMPTZ,
  CONSTRAINT "app_ownership_transfers_status_check"   CHECK ("status" IN ('pending','accepted','rejected','cancelled','expired')),
  CONSTRAINT "app_ownership_transfers_not_self_check" CHECK ("from_user_id" <> "to_user_id")
);
-- 🔴 The one-in-flight-transfer guard. Prisma cannot express a partial unique index,
-- so this lives ONLY here; the service relies on its P2002.
CREATE UNIQUE INDEX IF NOT EXISTS "app_ownership_transfers_one_pending_per_app"
  ON "app_ownership_transfers" ("app_block_id") WHERE "status" = 'pending';
CREATE INDEX IF NOT EXISTS "app_ownership_transfers_app_status_idx" ON "app_ownership_transfers" ("app_block_id","status");
CREATE INDEX IF NOT EXISTS "app_ownership_transfers_to_status_idx"  ON "app_ownership_transfers" ("to_user_id","status");
```

All three tables are brand-new and empty — no backfill, no meaningful lock, `IF NOT EXISTS` throughout so a re-run is a no-op.

---

## Why the seat is keyed to `AppBlock`, and why `displayed` lives on the seat row

Ownership is canonically `OauthClient.userId`, reached as `AppBlock.app.userId`; `AppListing.userId` is a **denormalized copy**.

`displayed` (the byline opt-in) is stored on `AppCollaborator`, **not** as an `AppListing` column, and that is load-bearing rather than incidental: `applyApprovedRevision`'s **offsite branch** copies the shadow's `name/tagline/description/category/contentRating/externalUrl/connect*` straight onto the live parent. The same flag held as a listing column would be silently **clobbered** by the next approved revision — an immediate-apply setting that reverts on the next mod re-review. Collaborator rows sit outside **both** branches' copy sets, which makes immediate-apply correct *by construction*. Pinned structurally in `app-collaborator.revision-non-clobber.test.ts`.

## 🔴 The earnings leak, and how it is avoided

Every pre-existing earnings read keys on `BlockBuzzAttribution.appOwnerUserId` — a **user-wide** filter that does not mention the app:

- `blocks.getMyApps` — `groupBy appBlockId WHERE appOwnerUserId = caller`, no app filter at all
- `getRevenueForOwner` / `getRecentAttributionsForOwner` — `appBlockId` is an *optional* narrowing filter, never checked against what the caller may see

The obvious way to serve an editor is to reuse one of those with the **owner's** id (the editor has no attribution rows of their own). That hands the editor **the owner's entire portfolio**. It looks correct in a one-app fixture and is catastrophic with two.

Instead there is a new app-scoped path (`app-collaborator-earnings.service.ts`) that resolves the permitted app-id set **first** and filters `appBlockId IN (thatSet)`, plus a second axis on the app's **current** owner so a transferred app's pre-transfer rows are excluded. `blocks.getMyApps` now routes through it.

`app-collaborator-earnings.service.test.ts` fixtures an owner with **2 apps** and an editor on **1**. It was written against a deliberately naive implementation first and **watched to fail** — `expected [ 'ab_appA', 'ab_appB' ] to deeply equal [ 'ab_appA' ]` — before the real one was written.

`blocks.getMyRevenue` is deliberately **not** widened: it answers "what have *I* accrued", and it must keep showing an ex-owner the money they accrued **before** transferring an app away.

## Consolidated permission predicate + the disagreements it surfaced

`resolveAppAccess(appBlockId, userId) → { role: 'owner' | 'editor' | null }` (plus `resolveListingAccess`, `resolveAccessibleAppBlockIds`, `assertAppEditAccess`) now backs every gate. `resolveListingAccess` is **shadow-aware**: a shadow revision carries `appBlockId: null`, so the seat is resolved via its parent — without that hop an editor would lose access the instant their first media edit minted the shadow.

Consolidating surfaced four genuine inconsistencies. They are recorded as data in the seam-guard ledger rather than silently normalised, because "fix" here means a behaviour change that deserves its own decision:

| | Finding | Disposition |
|---|---|---|
| **D1** | **Mod bypass is inconsistent.** `app-listing-assets::loadOwnedListing` bypasses for moderators; `offsite-listing::loadOwnedEditableListing` and `offsite-moderation::loadOwnedListingInTx` deliberately do not; the four `blocks.router` gates do not. | Left exactly as-is; asserted in the matrix as it *is*. |
| **D2** | **Ban checks were asymmetric.** `getMyAppRepo`, `updateManifest`, `getMyForgejoCloneInfo` each had an explicit `bannedAt` re-check; **`getMyAppManifest` did not.** | **Fixed** — plainly an omission, not a decision. |
| **D3** | **The ownership key differs.** `withdrawExternalRequest` keys on `AppBlockPublishRequest.submittedByUserId` (the *submitter*), which after a transfer is deliberately not the owner. | Left as-is — withdrawing your own submission is a different question. |
| **D4** | **Earnings scoping diverges between siblings.** `getMyAppAnalytics` resolves a permitted-id set; `getMyRevenue` is `appOwnerUserId`-keyed and user-wide. | Left as-is, deliberately (see above). |

Two further findings recorded in the ledger:

- **A third gate shape exists.** `src/pages/api/v1/blocks/dev-token.ts` uses a positive-match *branch condition* rather than a throw or a where-clause, and is explicitly built to be **oracle-free**. Not routed through the predicate — that would change externally-observable behaviour for an unrelated reason. A collaborator cannot mint a dev token today.
- 🔴 **KNOWN GAP (pre-existing, not introduced here).** `publish-request.service::submitVersion`'s **subsequent-version** branch never checks that the submitter owns the existing app. It is masked today because both HTTP callers require `isModerator`. If that is ever opened to non-mod authors it becomes a **slug-hijack vector**.

## Ban interaction — the decision

**A banned user may not be invited, may not accept an invite, and may not receive an ownership transfer.** A seat mints Forgejo `write` on the app repo and exposes the app's earnings, and `getMyAppRepo` already refuses to issue a push credential to a banned account — seating a banned user would hand out exactly the credential that gate withholds. A banned user **may** decline an invite (that takes nothing from anyone).

An **existing** seat is *not* auto-revoked on ban — that needs a ban-hook this PR does not add — but every capability the seat unlocks re-checks `bannedAt` at the proc, so a banned editor holds an inert row.

## Forgejo lifecycle (in scope, not a follow-up)

`forgejo.service` could previously only ever **grant**: `addCollaborator` existed with nothing to undo it, so a developer handed `write` kept it forever. This adds `removeCollaborator` and wires the full lifecycle — grant on invite-accept, revoke on remove/leave, revoke-old + grant-new on transfer-accept.

Both directions are best-effort (Forgejo is external; an outage must not roll back a consent decision). Being precise about the residual risk: a failed **grant** self-heals, because `getMyAppRepo` re-grants on every call. A failed **revoke** does **not** self-heal — the seat is gone from the DB so every civitai-side capability closes immediately, but the user may retain Forgejo push until someone notices. That residue cannot deploy anything (a push only parks a `pending` request a moderator must approve). A durable retry/reconcile job is the correct fix and is **not** in this PR; the `app-repo-access` / `revoke-failed` log line is the only signal today.

## Other notes

- **CLI wire contract intact.** No existing proc's input schema is touched. Widening a *gate* is invisible to released CLI binaries; changing an *input schema* is not. `app-collaborator.cli-contract.test.ts` parses each released-CLI payload and asserts all 13 `listingMediaCliScope` annotations remain.
- **Consent.** A pending or rejected invite confers **zero** capability and never appears in any public projection — otherwise anyone's name could be attached to a listing simply by inviting them.
- **Shared shadow.** Two editors converge on one revision draft per parent (partial UNIQUE on `revision_of_id`); the P2002 idempotent-reuse path is preserved. Editor B seeing editor A's staged edits is **deliberate** — a revision is a property of the listing, not of whoever opened it — and is commented as such.
- **Self-review** widened to the insider set (owner + accepted collaborators). `displayed` is deliberately **not** part of it: hiding your byline is a public-credit preference, not a capability, so it must not become a self-review bypass.
- **Throttle written correctly.** `EntityCollaborator`'s invite throttle is inverted (`>=` where its own sibling correctly uses `lte`), so it re-notifies precisely when it should stay silent. Ours is the right way round, with both sides of the boundary pinned so a copy-paste cannot re-import the bug.
- **Cap + rate limits.** 15 seats/app (mirrors `constants.entityCollaborators`), 30 invites/hr, 10 transfer attempts/hr.
- All new surfaces sit behind the existing mod-segmented App Blocks author flag, consistent with neighbouring procs.

---

## Verification

**Ran:**
- `pnpm typecheck` — **0 errors**.
- `pnpm vitest run --project unit` — **926 files, 14270 passed, 1 skipped, 0 failed** (counts read from the output, not an exit code; no timeout panics).
- Test files type-checked **explicitly** under a config that overrides `tsconfig.json`'s `src/**/__tests__/**` exclusion — a green `pnpm typecheck` says nothing about them. 0 errors in the 11 new suites.
- **Mutation sweep: 31 mutants, 31 killed.** Two classes — *delete the guard* (the operation must then succeed where it must not) and *change the guard's own code/message* (proving the test reads **this** guard's identity, not a neighbour's). Every mutant died to its own expected signal.

**Two harness bugs the sweep caught in itself, both worth stating** because either would have produced a confident wrong verdict: the verdict parser required a `passed` segment, but `vitest -t` prints `Tests 1 failed | 24 skipped` with no `passed` — so **every genuine kill initially read as SURVIVED**. And `-t` is a *regex*, so a filter containing parentheses matched nothing; that now reports `NO-TESTS-MATCHED` rather than being scored either way.

**Found by the sweep, in the code:**
- `assertAppEditAccess` had **no behavioural test** — deleting it left every suite green, because the only thing "covering" it was a structural ledger assertion that never executes the guard. It has since been relocated into `app-access.service` (one home, directly testable) and given a behavioural matrix.
- The `getMyAppsEarnings` app-scope filter **survived deletion**, because the final `allIds.map` is a second independent barrier that hides the leak in the *output* while the *query* still fetched the whole portfolio. A structural assertion on the WHERE clause now pins it.

**Not verified / needs a human:**
- **The migration has not been applied anywhere.** Nothing here was exercised against a real Postgres — no DB-level test of the CHECK constraints, the partial unique index, or the cascade behaviour. Every DB dep in these suites is a mock.
- **No live/e2e run.** There is no UI in this PR, and no click path was driven.
- **The transfer rollback is asserted structurally, not observed.** The `$transaction` fake runs its callback inline and cannot itself roll anything back; the test asserts what a real rollback guarantees and what the fake *can* observe — that the throw escapes `$transaction`, and that every ownership write is issued inside the callback rather than before it. A real two-column rollback should be confirmed against a live DB.
- **The Forgejo calls are asserted against a fake client**, not against a real Forgejo instance. `removeCollaborator`'s 204/404 handling is modelled on the documented Gitea/Forgejo behaviour and the existing `deleteForgejoUser`/`deleteReviewRepo` shape; it has not been measured against 15.0.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015w3tqf9DUTs8V7xGyDCcd3
