### PR TITLE
fix(build): bring release-build peak memory back under the 40Gi builder limit

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -224,6 +224,10 @@ export default defineNextConfig(
       // Off because the builder's memory ceiling is now enforced and that ~+33% peak RSS is
       // what puts the release build over it. Re-enable only with a measured peak-RSS margin.
       turbopackServerSideNestedAsyncChunking: false,
+      // Not the same as omitting it: Next 16.3.0 defaults this to true, and turbopack-build
+      // derives `dependencyTracking` from it, so the flag governs what turbo-tasks retains in
+      // memory and not just what lands on disk.
+      turbopackFileSystemCacheForBuild: false,
       optimizePackageImports: [
         '@civitai/client',
         './src/libs/form',

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -221,9 +221,9 @@ export default defineNextConfig(
       // in exchange for ~+8% CI build time and ~+33% peak builder RSS. Measurements live
       // in the PR rather than here, so they don't rot when Next's chunker changes.
       //
-      // Build only. It buys nothing in dev — chunk size is irrelevant to a dev server — and
-      // the walk over dynamic-import paths is paid on a graph that `_app` already makes large.
-      turbopackServerSideNestedAsyncChunking: isProd,
+      // Off because the builder's memory ceiling is now enforced and that ~+33% peak RSS is
+      // what puts the release build over it. Re-enable only with a measured peak-RSS margin.
+      turbopackServerSideNestedAsyncChunking: false,
       optimizePackageImports: [
         '@civitai/client',
         './src/libs/form',


### PR DESCRIPTION
Bring the release build's peak memory back under the builder's 40Gi cgroup limit, so no infra accommodation is needed to ship.

## What broke, and when

An infra-side change made a previously-unenforced 40Gi cgroup limit on the build pod real. The release build then OOMKilled three times, peaking at **37-39 GiB**. Lowering the build heap cap is being handled separately, infra-side, to unblock deploys tonight. That is a bridge. This PR is the repair: two `next.config.mjs` flags that the build did not need to be paying.

Deliberately **not** in this PR, because they collide with work in flight: `NODE_BUILD_MEM` / the Dockerfile heap arg (infra, separate), and the `@mantine/core` `optimizePackageImports` addition + dead `refresh-sessions` import removal (`perf/bundle-dep-chains`, #3802).

Two commits, so either can be reverted on its own.

## Change 1 — `turbopackServerSideNestedAsyncChunking: isProd` -> `false`

This flag was turned on for the production build in #3458. The comment it replaced records the trade in the repo's own words:

> ~72% fewer emitted server chunks and roughly half the server chunk bytes, in exchange for ~+8% CI build time and ~+33% peak builder RSS.

**This is a real trade, not a free win.** Turning it off costs roughly +332 MB of server chunks and roughly doubles server chunk bytes. That is a regression in the emitted output and should be read as one.

The argument for flipping it anyway: the trade was accepted when nothing measured build RSS and nothing enforced a ceiling. Both are now true. On a 39 GiB peak, +33% is roughly 10 GiB — 39 / 1.33 is about 29 GiB, which fits under 40Gi with room. A build that cannot complete is worth less than smaller chunks.

If someone later wants the chunks back, the way to do it is to re-enable this flag *with* a peak-RSS measurement showing the headroom, not to re-enable it and hope.

## Change 2 — `turbopackFileSystemCacheForBuild: false` (was unset)

It was unset, so it took Next 16.3.0's new default of `true`. Verified in the installed Next 16.3.0:

- `next/dist/server/config-shared.js` sets `turbopackFileSystemCacheForBuild: true` in `defaultConfig`.
- `next/dist/build/turbopack-build/impl.js` reads it into `persistentCaching`, then sets `dependencyTracking: persistentCaching || hasDeferredEntries`.

So this flag governs what turbo-tasks retains **in memory**, not just what lands on disk. Setting it explicitly to `false` restores pre-16.3.0 behaviour. It is *not* redundant with omitting it, which is why it carries a comment.

The 16.3.0 upgrade (`d1b3241814`, 2026-08-07) was justified solely on the turbo-tasks lock-order fix for the dev server (vercel/next.js#93788). This build-side default flip came along with it and was never evaluated.

**A second, independent reason to set it**, which stands even if it turns out to cost nothing in memory: this default is reported upstream to cause a correctness bug where a production build serves pre-change renders from restored cache. A build that can silently serve stale output is worth turning off on its own merits.

## Measured vs. inferred

**I measured none of the memory numbers in this PR.** The thing that OOMs *is* the production build, so I did not run `pnpm run build`.

| Claim | Source | Status |
|---|---|---|
| ~72% fewer server chunks, ~half the server chunk bytes, ~+8% build time, ~+33% peak RSS | the `next.config.mjs` comment from #3458 | quoted, **not re-measured here** |
| Release build peaked 37-39 GiB, OOMKilled 3x | the infra-side incident that prompted this PR | reported to me, **not re-measured here** |
| 40Gi cgroup limit now enforced | same | reported to me, **not verified here** |
| 39 / 1.33 ~= 29 GiB | arithmetic on the two numbers above | **inference**, and only as good as the +33% figure |
| `turbopackFileSystemCacheForBuild` defaults to `true` on 16.3.0 and drives `dependencyTracking` | read out of `node_modules/next` at 16.3.0 | **verified by reading the source** |
| The FS-cache default causes stale renders | reported upstream | **not reproduced here** |

The +33% figure is the load-bearing one, and it is a single prior measurement of a different quantity (RSS delta of enabling the flag) being applied to a peak recorded on a different commit. It is the best number available, not a prediction.

## What to measure to confirm this worked

**Peak builder RSS on the next release build**, against the 40Gi ceiling. Two things that will otherwise make the comparison meaningless:

- **Control cache warmth.** `.next/cache` is a node-local BuildKit cache mount, so a cold build on one builder and a warm build on another are not comparable — and change 2 alters what is in that cache. Compare cold-to-cold, or warm-to-warm on the same builder.
- **Read peak, not final.** An OOMKill is a peak event; a final-RSS or average number will not tell you whether the headroom is real.

If peak lands near 29 GiB, change 1 is doing what the #3458 comment predicts and the infra heap-cap bridge can be reverted. If it lands much higher, the +33% figure does not transfer and change 2 (or something else) is carrying more of the 39 GiB than assumed.

## Dockerfile `.next/cache` mount — checked, left alone

`--mount=type=cache,target=/app/.next/cache` (Dockerfile ~L56) is **not** dead weight after change 2, as far as I can tell without a build. `getCacheDir(distDir)` in `next/dist/build/index.js` returns `.next/cache` unconditionally — it is not owned solely by the Turbopack FS cache, and Next explicitly warns in CI when the directory is missing. I could not enumerate what still lands there without running a build, so I have not touched it. Worth a second look by someone who can watch a real build, but not in this PR — a third change would muddy the attribution of the RSS measurement above.

## Verification

- `pnpm run typecheck` — 43 errors, **identical on `origin/main`** at the same base (`018c376321`). Pre-existing, from a stale generated Prisma client in this environment; unrelated to a `next.config.mjs` change.
- `pnpm run test:unit:run` — `18 failed | 14077 passed | 2 skipped (14097)` on this branch, and **exactly the same on `origin/main`**. Pre-existing (Windows path-separator assertions in the App Blocks privilege guards).
- `src/server/routers/__tests__/blocks.router.workflow.test.ts` collected **347 tests, all passing** — the worktree's submodule is present and the run is meaningful.
- `npx eslint next.config.mjs` — clean (the file is eslint-ignored by default; no errors).
- **Not run:** `pnpm run build`. Running it is the thing that OOMs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
