### PR TITLE
fix(app-listings): bound the ranged read too, and pin what #3804 left unpinned

### DIFF
--- a/src/server/services/blocks/__tests__/listing-asset-integrity-logging.test.ts
+++ b/src/server/services/blocks/__tests__/listing-asset-integrity-logging.test.ts
@@ -1,0 +1,210 @@
+import { HeadObjectCommand } from '@aws-sdk/client-s3';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type * as LoggingClient from '~/server/logging/client';
+import type * as S3Utils from '~/utils/s3-utils';
+
+/**
+ * Pins the `.catch()` on the best-effort `logToAxiom(...)` in the listing-media
+ * integrity re-check.
+ *
+ * The call is fire-and-forget: nothing awaits it, because an operational event must
+ * never be on the critical path of the attach it is describing. That is exactly what
+ * makes a rejecting sink dangerous — `logToAxiom` awaits an ingest that rejects when
+ * Axiom is degraded, and an unawaited rejection with no handler goes to
+ * `unhandledRejection`, i.e. the observation takes down the request it was only
+ * watching. The `.catch()` is the whole defence, and deleting it changes nothing
+ * anywhere else in the suite.
+ *
+ * ## Why this is a separate file
+ *
+ * 🔴 The sink below is a PLAIN FUNCTION, not a `vi.fn()`, and that is the entire
+ * reason this test can fail. A `vi.fn()` records settled results by attaching
+ * `returnValue.then(onFulfilled, onRejected)` to whatever the implementation
+ * returns, which MARKS a returned rejected promise as handled — so through a
+ * `vi.fn()` mock Node never emits `unhandledRejection`, with or without the
+ * production `.catch()`, and the assertion passes either way. Unfalsifiable, which
+ * is worse than no test. `vi.mock` is per-file and the sibling
+ * `listing-asset-upload-integrity.test.ts` deliberately uses `vi.fn()` there so it
+ * can assert on payloads; the two shapes cannot coexist in one file. (Same split,
+ * same reason, as `~/server/services/__tests__/cover-image.service.logging.test.ts`.)
+ */
+
+const { mockRead, mockWrite, mockS3Send } = vi.hoisted(() => {
+  const db = {
+    appListing: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      update: vi.fn(async (..._a: unknown[]) => ({})),
+    },
+    appListingScreenshot: {
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+      count: vi.fn(async (..._a: unknown[]) => 0),
+      create: vi.fn(async (..._a: unknown[]) => ({})),
+    },
+    image: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    },
+    $transaction: vi.fn(async (arg: unknown) => {
+      if (typeof arg === 'function') return (arg as (tx: unknown) => unknown)(db);
+      return Promise.all(arg as Promise<unknown>[]);
+    }),
+  };
+  return { mockRead: db, mockWrite: db, mockS3Send: vi.fn() };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockWrite }));
+vi.mock('~/server/services/image.service', () => ({ createImage: vi.fn() }));
+vi.mock('~/server/utils/app-block-ids', () => ({
+  newAppListingId: () => 'apl_test_1',
+  newAppListingPublishRequestId: () => 'alpr_test_1',
+  newAppListingModerationEventId: () => 'alme_test_1',
+  newAppListingScreenshotId: () => 'apls_test_1',
+}));
+vi.mock('~/utils/s3-utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof S3Utils>()),
+  getImageUploadBackend: async () => ({
+    s3: { send: mockS3Send },
+    bucket: 'test-image-bucket',
+    backend: 'backblaze' as const,
+  }),
+}));
+
+/**
+ * A degraded sink. Everything else in the logging module stays REAL, so this test
+ * is not also asserting a hand-built module shape.
+ */
+vi.mock('~/server/logging/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof LoggingClient>()),
+  logToAxiom: () => Promise.reject(new Error('axiom is unreachable')),
+}));
+
+const OWNER = 42;
+const KEY = '44444444-4444-4444-8444-444444444444';
+/** The tag the row records; the store's answer is varied against it per case. */
+const RECORDED_ETAG = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const owner = { id: OWNER, isModerator: false } as never;
+
+const LISTING = {
+  id: 'apl_1',
+  kind: 'onsite',
+  slug: 's',
+  name: 'n',
+  category: null,
+  contentRating: null,
+  userId: OWNER,
+  iconId: null,
+  coverId: null,
+};
+
+/** A square icon row that satisfies every column rule, carrying a recorded tag. */
+function iconRow() {
+  return {
+    id: 500,
+    userId: OWNER,
+    url: KEY,
+    type: 'image',
+    width: 512,
+    height: 512,
+    mimeType: 'image/png',
+    metadata: { size: 1234, storedEtag: RECORDED_ETAG },
+    ingestion: 'Scanned',
+    nsfwLevel: 1,
+  };
+}
+
+async function attachAsIcon() {
+  const { setListingIcon } = await import('../app-listing-assets.service');
+  return setListingIcon({ listingId: 'apl_1', imageId: 500 }, owner);
+}
+
+/**
+ * Run `act` and report every rejection Node considered unhandled while it settled.
+ *
+ * `unhandledRejection` is emitted at the END of the turn in which a promise rejects
+ * with no handler attached, so a macrotask wait — not just a microtask flush — is
+ * required before reading the result. Vitest's own listener stays installed; Node
+ * fans the event out to every listener, so ours still sees it.
+ */
+async function unhandledRejectionsDuring(act: () => void | Promise<unknown>) {
+  const seen: unknown[] = [];
+  const listener = (reason: unknown) => seen.push(reason);
+  process.on('unhandledRejection', listener);
+  try {
+    await act();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  } finally {
+    process.off('unhandledRejection', listener);
+  }
+  return seen;
+}
+
+beforeEach(() => {
+  mockS3Send.mockReset();
+  mockRead.appListing.findUnique.mockReset().mockResolvedValue(LISTING);
+  mockRead.appListing.findFirst.mockReset().mockResolvedValue(null);
+  mockRead.appListing.update.mockReset().mockResolvedValue({});
+  mockRead.image.findUnique.mockReset().mockResolvedValue(iconRow());
+  mockRead.image.findMany.mockReset().mockResolvedValue([]);
+  mockWrite.appListingScreenshot.findMany.mockReset().mockResolvedValue([]);
+  mockWrite.appListingScreenshot.count.mockReset().mockResolvedValue(0);
+  mockWrite.appListingScreenshot.create.mockReset().mockResolvedValue({});
+});
+
+describe('listing media — a degraded log sink cannot break the attach it observes', () => {
+  /**
+   * The fail-OPEN branch. The verdict is `unverifiable`, the attach is supposed to
+   * proceed, and the only thing between "proceeds" and "the whole request dies" is
+   * the `.catch()` on an event nobody awaits.
+   */
+  it('still attaches when the sink rejects on an unverifiable verdict', async () => {
+    mockS3Send.mockRejectedValue(
+      Object.assign(new Error('boom'), { $metadata: { httpStatusCode: 503 } })
+    );
+
+    let result: unknown;
+    const seen = await unhandledRejectionsDuring(async () => {
+      result = await attachAsIcon();
+    });
+
+    expect(result).toMatchObject({ status: 'attached' });
+    expect(seen).toEqual([]);
+  });
+
+  /**
+   * The fail-CLOSED branch. The rejection the caller receives must still be the
+   * integrity refusal — a sink failure must not replace, mask or precede it.
+   */
+  it('still refuses with the integrity message when the sink rejects on a mismatch', async () => {
+    mockS3Send.mockResolvedValue({ ETag: '"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"' });
+
+    let error: unknown;
+    const seen = await unhandledRejectionsDuring(async () => {
+      error = await attachAsIcon().catch((e) => e);
+    });
+
+    expect(error).toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'that image has changed since it was uploaded — upload it again',
+    });
+    expect(seen).toEqual([]);
+  });
+
+  /**
+   * POSITIVE CONTROL. Both cases above are claims about a request that was actually
+   * made and a verdict that was actually reached — without this, a build where the
+   * re-check never ran would satisfy them for the wrong reason, and `seen` would be
+   * empty because nothing ever logged.
+   */
+  it('reached the store — the cases above are not passing on a skipped check', async () => {
+    mockS3Send.mockResolvedValue({ ETag: `"${RECORDED_ETAG}"` });
+
+    await expect(attachAsIcon()).resolves.toMatchObject({ status: 'attached' });
+
+    const heads = mockS3Send.mock.calls.filter(
+      ([cmd]) => cmd instanceof HeadObjectCommand && (cmd as HeadObjectCommand).input.Key === KEY
+    );
+    expect(heads).toHaveLength(1);
+  });
+});

--- a/src/server/services/blocks/__tests__/listing-asset-upload-integrity.test.ts
+++ b/src/server/services/blocks/__tests__/listing-asset-upload-integrity.test.ts
@@ -477,6 +477,37 @@ describe('listing media — every non-match verdict is reported with its reason'
     ]);
   });
 
+  /**
+   * 🔴 SEVERITY, and it is not cosmetic. `type` is the field the Alloy→Loki pipeline
+   * reads as the log LEVEL (see the SEVERITY FIELD note in `~/server/logging/client`),
+   * and that same module states the rule: a BAD_REQUEST-class fault is normal user
+   * feedback and must never land at error severity or it drowns out the real
+   * server-side failures. A `mismatch` ends in exactly such a rejection AND any
+   * author can produce one at will, so at `error` this event is an author-controlled
+   * tap on the error board.
+   *
+   * The distinction operators need is carried by `status` / `reason`, which are
+   * asserted above — a query on `status="mismatch"` is narrower than one on a level
+   * shared with every other error in the app, so nothing is lost here except the
+   * flooding.
+   */
+  it('emits below error severity — mismatch included, since a user can trigger it', async () => {
+    await attachWithMetadata();
+    putObject(KEY, await flatPng(160, 120, 200));
+    await expect(attachAsIcon()).rejects.toThrow();
+    const [mismatch] = integrityEvents();
+
+    await attachWithMetadata();
+    storeOutage = Object.assign(new Error('boom'), { $metadata: { httpStatusCode: 503 } });
+    await expect(attachAsIcon()).resolves.toMatchObject({ status: 'attached' });
+    const [unverifiable] = integrityEvents();
+
+    // Named explicitly rather than `not.toBe('error')`: "some other level" would
+    // satisfy a negative assertion, including a level the pipeline does not know.
+    expect(mismatch).toMatchObject({ status: 'mismatch', type: 'warning' });
+    expect(unverifiable).toMatchObject({ status: 'unverifiable', type: 'warning' });
+  });
+
   it('carries the asset KIND, so the three procs are separable in the data', async () => {
     putObject(KEY, await flatPng(1280, 720, 8));
     const metadata = await persistAndCaptureMetadata();

--- a/src/server/services/blocks/app-listing-assets.service.ts
+++ b/src/server/services/blocks/app-listing-assets.service.ts
@@ -540,15 +540,17 @@ async function remapScreenshotRowIds(args: {
  * cannot be checked cost no extra round trip — and `stored-image-probe` (and the
  * S3 client graph behind it) stays out of this module's static import graph.
  *
- * 🔴 EVERY OUTCOME THAT IS NOT `match` IS LOGGED, and the four `unverifiable`
- * reasons are kept apart on the way out. Without that, a guard that is firing and a
- * guard that is inert produce exactly the same observable — nothing — and the four
- * reasons are operationally different signals rather than one blob: a rising
- * `store-unreachable` is an infrastructure incident, a rising `no-current-etag` is a
- * backend that stopped returning tags (which quietly disarms this check for every
- * row), and `mismatch` is the case the guard exists for. A steady trickle of any of
- * them is the only way to notice that the fail-open branch has become the ONLY
- * branch.
+ * 🔴 EVERY OUTCOME THAT IS NOT `match` IS LOGGED, and the three `unverifiable`
+ * reasons reachable from here are kept apart on the way out. (Three, not the
+ * classifier's four: `no-recorded-etag` is short-circuited above and can never be
+ * emitted from this consumer — see the note at the end of this block.) Without that,
+ * a guard that is firing and a guard that is inert produce exactly the same
+ * observable — nothing — and the reasons are operationally different signals rather
+ * than one blob: a rising `store-unreachable` is an infrastructure incident, a rising
+ * `no-current-etag` is a backend that stopped returning tags (which quietly disarms
+ * this check for every row), and `mismatch` is the case the guard exists for. A
+ * steady trickle of any of them is the only way to notice that the fail-open branch
+ * has become the ONLY branch.
  *
  * 🔴 The event carries NO storage key, bucket, URL or caller identity — the reason
  * plus the asset kind plus the row id is everything an operator needs to tell these
@@ -572,12 +574,38 @@ async function assertStoredObjectUnchanged(
 
   logToAxiom({
     name: 'listing-asset-integrity',
-    type: verdict.status === 'mismatch' ? 'error' : 'warning',
+    /**
+     * 🔴 `warning`, INCLUDING for `mismatch`, and deliberately so.
+     *
+     * `type` is what the Alloy→Loki pipeline reads as the log level (see the
+     * SEVERITY FIELD note in `~/server/logging/client`), and that same file states
+     * the rule this obeys: a BAD_REQUEST-class fault is normal user feedback and
+     * "must never be logged at error severity, or they drown out the real
+     * server-side failures on the error board". A `mismatch` ends in exactly such a
+     * rejection, and any author can produce one at will simply by replacing the
+     * object behind a key they own — so at `error` this is an author-controlled tap
+     * on the error board, which is the failure mode that rule exists to prevent.
+     *
+     * The severity was never the discriminator anyway: `status` and `reason` are
+     * emitted as their own fields precisely so these outcomes are separable, and a
+     * query or alert on `status="mismatch"` is both narrower and more stable than
+     * one on a level shared with every other error in the app. Nothing is lost by
+     * dropping to `warning` except the flooding.
+     */
+    type: 'warning',
     status: verdict.status,
     reason: verdict.status === 'unverifiable' ? verdict.reason : null,
     kind,
     imageId: image.id,
   }).catch(() => null);
+  // 🔴 That `.catch(() => null)` is LOAD-BEARING, not tidiness. Nothing awaits the
+  // call above, so a rejecting sink — `logToAxiom` awaits an ingest that rejects
+  // when Axiom itself is degraded — has nowhere to go but `unhandledRejection`, and
+  // the attach it is merely OBSERVING would be taken down by the observation. Same
+  // reasoning as `~/server/redis/fail-open-log`, `~/server/meilisearch/client` and
+  // `~/server/signals/wrapper`. Pinned by
+  // `./__tests__/listing-asset-integrity-logging.test.ts`, which needs a file of its
+  // own to be falsifiable at all — a `vi.fn()` sink marks the rejection handled.
 
   if (verdict.status !== 'mismatch') return;
 

--- a/src/server/utils/__tests__/stored-image-probe.test.ts
+++ b/src/server/utils/__tests__/stored-image-probe.test.ts
@@ -1,15 +1,17 @@
-import { HeadObjectCommand } from '@aws-sdk/client-s3';
+import { GetObjectCommand, HeadObjectCommand } from '@aws-sdk/client-s3';
+import sharp from 'sharp';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type * as S3Utils from '~/utils/s3-utils';
 
 /**
- * `headStoredImage` — the entity-tag re-read the listing attach gate depends on.
+ * `headStoredImage` and `probeStoredImage` — the two requests this module makes
+ * against the image store, BOTH of them inline on a user-facing mutation.
  *
- * The property under test is that it is BOUNDED. Its three-state result already
- * fails open on an error, and that is the state everything downstream reasons
+ * The property under test is that they are BOUNDED. Their failure handling already
+ * covers a store that ERRORS, and that is the state everything downstream reasons
  * about; what an error-shaped test cannot show is the other way a store fails,
- * which is by not answering at all. An unbounded head does not fail open — it
+ * which is by not answering at all. An unbounded request does not fail open — it
  * holds the caller open — and because a healthy backend answers with or without a
  * timeout, nothing about a missing bound is observable until production is the
  * thing that is degraded.
@@ -49,6 +51,46 @@ function hangUntilAborted() {
       );
     });
 }
+
+/**
+ * A store that ANSWERS and then stops mid-body — headers back, bytes never
+ * arriving. A distinct failure from "no response at all", and the one a ranged GET
+ * is actually exposed to, since it is the only request here that transfers bytes.
+ *
+ * The abort is wired into the body read as well as the response, which is what the
+ * AWS SDK really does: the signal destroys the underlying request, so a stream still
+ * being read off that socket errors rather than idling forever.
+ */
+function answerThenStallBody() {
+  return async (_command: unknown, options?: { abortSignal?: AbortSignal }) => ({
+    ContentRange: 'bytes 0-15/16',
+    ETag: '"abc123"',
+    Body: {
+      transformToByteArray: () =>
+        new Promise((_resolve, reject) => {
+          const signal = options?.abortSignal;
+          if (!signal) return; // unbounded → the read never ends, which is the bug
+          signal.addEventListener('abort', () =>
+            reject(Object.assign(new Error('aborted'), { name: 'TimeoutError' }))
+          );
+        }),
+    },
+  });
+}
+
+/** Real, decodable bytes, so a happy-path probe is not a fixture-shaped assertion. */
+async function flatPng() {
+  return sharp({ create: { width: 8, height: 8, channels: 3, background: { r: 1, g: 1, b: 1 } } })
+    .png()
+    .toBuffer();
+}
+
+/**
+ * Every hang case below must settle in MILLISECONDS — the injected budget is the
+ * thing under test. The suite-wide 60s ceiling would let a regression cost a minute
+ * per case before reporting, so bound them explicitly.
+ */
+const HANG_CASE_TIMEOUT_MS = 10_000;
 
 beforeEach(() => {
   mockS3Send.mockReset();
@@ -138,4 +180,148 @@ describe('headStoredImage', () => {
     mockS3Send.mockResolvedValue({ ContentLength: 10 });
     await expect(headStoredImage(KEY)).resolves.toEqual({ status: 'present', etag: null });
   });
+});
+
+/**
+ * 🔴 THE INJECTED BUDGET HAS TO BE THE ONE THAT IS USED.
+ *
+ * `timeoutMs` exists so the abort path is reachable in milliseconds instead of
+ * seconds. Nothing else observes it: a version that accepts the parameter and then
+ * bounds every request with the module constant behaves IDENTICALLY in production
+ * and passes every hang case above — they would simply take five seconds each
+ * instead of five milliseconds, which no assertion reads. So the value handed to the
+ * bound is asserted directly.
+ *
+ * Asserted through a spy on `AbortSignal.timeout` rather than by timing the call:
+ * a wall-clock assertion would pin the same property with a race attached, and a
+ * flaky guard is one that gets re-run rather than believed.
+ */
+describe('the timeout budget that is applied is the one the caller passed', () => {
+  it.each([
+    {
+      what: 'headStoredImage',
+      call: async (opts?: { timeoutMs?: number }) => {
+        const { headStoredImage } = await import('~/server/utils/stored-image-probe');
+        mockS3Send.mockResolvedValue({ ETag: '"abc123"' });
+        await headStoredImage(KEY, opts);
+      },
+      constant: 'STORED_IMAGE_HEAD_TIMEOUT_MS' as const,
+    },
+    {
+      what: 'probeStoredImage',
+      call: async (opts?: { timeoutMs?: number }) => {
+        const { probeStoredImage } = await import('~/server/utils/stored-image-probe');
+        const bytes = await flatPng();
+        mockS3Send.mockResolvedValue({
+          Body: { transformToByteArray: async () => new Uint8Array(bytes) },
+          ContentRange: `bytes 0-${bytes.byteLength - 1}/${bytes.byteLength}`,
+          ETag: '"abc123"',
+        });
+        await probeStoredImage(KEY, { maxBytes: 1024 * 1024, ...opts });
+      },
+      constant: 'STORED_IMAGE_READ_TIMEOUT_MS' as const,
+    },
+  ])('$what', async ({ call, constant }) => {
+    const probeModule = await import('~/server/utils/stored-image-probe');
+    const spy = vi.spyOn(AbortSignal, 'timeout');
+    try {
+      // A value that is not the constant and not any other number in this module,
+      // so "the parameter was read" and "a default was applied" cannot look alike.
+      await call({ timeoutMs: 37 });
+      await call();
+
+      expect(spy.mock.calls.map(([ms]) => ms)).toEqual([37, probeModule[constant]]);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+/**
+ * `probeStoredImage` — the RANGED READ, and the request that actually transfers
+ * bytes.
+ *
+ * It sits on the same user-facing mutation as the head above (the listing persist
+ * proc, via `measureUploadedImage`), so the same argument applies to it and applies
+ * harder: a head exchanges a round trip, this streams up to `maxBytes + 1` off the
+ * socket, so there are two ways for it to stall rather than one.
+ */
+describe('probeStoredImage is bounded too', () => {
+  it('hands the ranged read an abort signal that has not already fired', async () => {
+    const bytes = await flatPng();
+    mockS3Send.mockResolvedValue({
+      Body: { transformToByteArray: async () => new Uint8Array(bytes) },
+      ContentRange: `bytes 0-${bytes.byteLength - 1}/${bytes.byteLength}`,
+      ETag: '"abc123"',
+    });
+    const { probeStoredImage, STORED_IMAGE_READ_TIMEOUT_MS } = await import(
+      '~/server/utils/stored-image-probe'
+    );
+
+    await expect(probeStoredImage(KEY, { maxBytes: 1024 * 1024 })).resolves.toMatchObject({
+      width: 8,
+      height: 8,
+      format: 'png',
+    });
+
+    // POSITIVE CONTROL: the assertions below are about a request that really happened.
+    expect(mockS3Send).toHaveBeenCalledTimes(1);
+    expect(mockS3Send.mock.calls[0][0]).toBeInstanceOf(GetObjectCommand);
+    const signal = (mockS3Send.mock.calls[0][1] as { abortSignal?: AbortSignal })?.abortSignal;
+    expect(signal).toBeInstanceOf(AbortSignal);
+    // An expired budget would abort every read before it left, turning every upload
+    // into "we could not read that back" — the failure a bare "a signal was passed"
+    // assertion waves through.
+    expect(signal?.aborted).toBe(false);
+    expect(STORED_IMAGE_READ_TIMEOUT_MS).toBeGreaterThan(0);
+    expect(Number.isFinite(STORED_IMAGE_READ_TIMEOUT_MS)).toBe(true);
+  });
+
+  /**
+   * 🔴 THE POINT, first shape: no response at all. Unbounded, this call never
+   * returns and the persist mutation holding it never returns either.
+   */
+  it(
+    'fails as store-unavailable (rather than hanging) when the store never responds',
+    async () => {
+      mockS3Send.mockImplementation(hangUntilAborted());
+      const { probeStoredImage, StoredImageProbeError } = await import(
+        '~/server/utils/stored-image-probe'
+      );
+
+      const err = await probeStoredImage(KEY, { maxBytes: 1024 * 1024, timeoutMs: 5 }).catch(
+        (e) => e
+      );
+
+      expect(err).toBeInstanceOf(StoredImageProbeError);
+      // The classification matters as much as the bound: an aborted read is "we could
+      // not consult the store", which is the caller's retryable branch — NOT `missing`
+      // or `unreadable`, both of which tell the uploader their file is at fault.
+      expect(err).toMatchObject({ reason: 'store-unavailable' });
+    },
+    HANG_CASE_TIMEOUT_MS
+  );
+
+  /**
+   * 🔴 THE POINT, second shape, and the one only a byte-transferring request has:
+   * headers arrive and the body then stalls. A bound applied to the response alone
+   * would leave this case unbounded while the case above passes.
+   */
+  it(
+    'fails as store-unavailable when the response arrives but the bytes never do',
+    async () => {
+      mockS3Send.mockImplementation(answerThenStallBody());
+      const { probeStoredImage, StoredImageProbeError } = await import(
+        '~/server/utils/stored-image-probe'
+      );
+
+      const err = await probeStoredImage(KEY, { maxBytes: 1024 * 1024, timeoutMs: 5 }).catch(
+        (e) => e
+      );
+
+      expect(err).toBeInstanceOf(StoredImageProbeError);
+      expect(err).toMatchObject({ reason: 'store-unavailable' });
+    },
+    HANG_CASE_TIMEOUT_MS
+  );
 });

--- a/src/server/utils/stored-image-probe.ts
+++ b/src/server/utils/stored-image-probe.ts
@@ -97,6 +97,38 @@ export type StoredImageHead =
 export const STORED_IMAGE_HEAD_TIMEOUT_MS = 5_000;
 
 /**
+ * Timeout budget for the ranged read in {@link probeStoredImage}.
+ *
+ * 🔴 THE SAME ARGUMENT AS ABOVE, AND IT APPLIES HARDER HERE. This read is on the
+ * same user-facing mutation, and unlike the head it TRANSFERS BYTES, so it has two
+ * ways to stall rather than one: no response, or a response whose body stops
+ * arriving. Unbounded, either one holds a persist request open for as long as the
+ * backend feels like it.
+ *
+ * 🔴 DELIBERATELY NOT {@link STORED_IMAGE_HEAD_TIMEOUT_MS}, and the difference is
+ * the point rather than an oversight. 5s is a ROUND-TRIP budget for a request that
+ * moves no bytes; this one moves up to `maxBytes + 1` — 4 MiB for listing media,
+ * 40 MiB for block images — so the same number would abort a perfectly legitimate
+ * large upload on a slow link, and `measureUploadedImage` surfaces an aborted read
+ * as "We couldn't read that upload back to check it". A hardening change that
+ * invents a new rejection for images that are fine is not a hardening change.
+ *
+ * Taken from the sibling bounded transfer in
+ * `~/server/services/blocks/block-image-upload.service` — the workflow-output blob
+ * fetch, which streams under the same 40 MiB cap for the same block-media surface —
+ * rather than picked afresh, so the two byte-moving bounds in this area cannot drift
+ * apart the way a locally-chosen number would.
+ *
+ * What this buys is NOT a tight latency target; at 60s a stalled read is still a bad
+ * request. It buys the difference between bounded and unbounded, which is the
+ * difference between an eventual error and a request that never ends. An abort lands
+ * in the generic catch below as `store-unavailable` — "we could not consult the
+ * store", the caller's retryable branch — which is the correct class for it and the
+ * exact counterpart of the head's `unknown`.
+ */
+export const STORED_IMAGE_READ_TIMEOUT_MS = 60_000;
+
+/**
  * Cheap HeadObject re-read of the entity tag at `key`, for a consumer that holds a
  * tag recorded by {@link probeStoredImage} and needs to know whether the object is
  * STILL the one that was measured. No bytes are transferred and nothing is decoded.
@@ -157,10 +189,18 @@ function parseTotalSize(contentRange: string | undefined, readBytes: number): nu
  * Throws {@link StoredImageProbeError} — callers map `reason` to their own
  * client-facing error (`store-unavailable` is the only one that is not the
  * caller's fault).
+ *
+ * BOUNDED by {@link STORED_IMAGE_READ_TIMEOUT_MS}; see that constant for why the
+ * budget is its own and not the head's. One signal covers the whole read — the
+ * response AND the body being streamed off it — because the SDK aborts the
+ * underlying request, so a body that stops arriving errors instead of idling.
+ *
+ * `timeoutMs` exists so the abort path is testable in milliseconds rather than
+ * minutes. Production callers pass nothing.
  */
 export async function probeStoredImage(
   key: string,
-  { maxBytes }: { maxBytes: number }
+  { maxBytes, timeoutMs = STORED_IMAGE_READ_TIMEOUT_MS }: { maxBytes: number; timeoutMs?: number }
 ): Promise<StoredImageProbe> {
   let bytes: Buffer;
   let sizeBytes: number;
@@ -168,7 +208,8 @@ export async function probeStoredImage(
   try {
     const { s3, bucket } = await getImageUploadBackend();
     const object = await s3.send(
-      new GetObjectCommand({ Bucket: bucket, Key: key, Range: `bytes=0-${maxBytes}` })
+      new GetObjectCommand({ Bucket: bucket, Key: key, Range: `bytes=0-${maxBytes}` }),
+      { abortSignal: AbortSignal.timeout(timeoutMs) }
     );
     if (!object.Body) throw new StoredImageProbeError('unreadable', 'stored image has no body');
     bytes = Buffer.from(await object.Body.transformToByteArray());

--- a/src/server/utils/stored-image-probe.ts
+++ b/src/server/utils/stored-image-probe.ts
@@ -89,17 +89,22 @@ export type StoredImageHead =
  *
  * Same budget, and the same reasoning, as the post-completion probe in
  * `~/pages/api/upload/complete.ts`; taken from there rather than picked afresh so
- * the two probes against this store cannot drift apart. Per the AWS SDK's contract
- * this bounds each network ATTEMPT, not wall-clock — the retry sleep is not
- * abort-aware, so the worst case is this budget plus one backoff. An abort lands on
- * `unknown`, i.e. the check could not run.
+ * the two probes against this store cannot drift apart. `AbortSignal.timeout` is
+ * constructed ONCE per `send()` and shared across the SDK's retries, so this is a
+ * single WALL-CLOCK deadline for the whole operation, not a per-attempt budget —
+ * and an aborted attempt is not retried at all, because `AbortError` is absent from
+ * smithy's `TRANSIENT_ERROR_CODES`. The worst case is therefore this budget, not
+ * this budget plus a backoff. An abort lands on `unknown`, i.e. the check could not
+ * run.
  */
 export const STORED_IMAGE_HEAD_TIMEOUT_MS = 5_000;
 
 /**
  * Timeout budget for the ranged read in {@link probeStoredImage}.
  *
- * 🔴 THE SAME ARGUMENT AS ABOVE, AND IT APPLIES HARDER HERE. This read is on the
+ * 🔴 THE SAME BOUNDED-VS-UNBOUNDED ARGUMENT AS ABOVE, AND IT APPLIES HARDER HERE.
+ * (The wall-clock note above applies verbatim: one deadline for the whole
+ * operation, no retry multiplication.) This read is on the
  * same user-facing mutation, and unlike the head it TRANSFERS BYTES, so it has two
  * ways to stall rather than one: no response, or a response whose body stops
  * arriving. Unbounded, either one holds a persist request open for as long as the
@@ -108,8 +113,10 @@ export const STORED_IMAGE_HEAD_TIMEOUT_MS = 5_000;
  * 🔴 DELIBERATELY NOT {@link STORED_IMAGE_HEAD_TIMEOUT_MS}, and the difference is
  * the point rather than an oversight. 5s is a ROUND-TRIP budget for a request that
  * moves no bytes; this one moves up to `maxBytes + 1` — 4 MiB for listing media,
- * 40 MiB for block images — so the same number would abort a perfectly legitimate
- * large upload on a slow link, and `measureUploadedImage` surfaces an aborted read
+ * 40 MiB for block images. Note the transfer being bounded is SERVER→STORE, read
+ * back after the author's own upload has already completed; the author's link is
+ * not in this path, so what 5s would abort is a slow or distant STORE, not a slow
+ * uploader. `measureUploadedImage` surfaces an aborted read
  * as "We couldn't read that upload back to check it". A hardening change that
  * invents a new rejection for images that are fine is not a hardening change.
  *


### PR DESCRIPTION
Follow-ups to #3804 — hardening and internal consistency, no product behaviour change for a healthy store. Based directly on `main` (which already contains #3804); not stacked on anything.

## 1. The ranged read is bounded too (the substantive one)

#3804 bounded the entity-tag `HeadObject` and argued, in a comment, that a bound is not optional for a store request sitting inline on a user-facing mutation. That argument applies at least as strongly to the *other* request on the same mutation — the ranged read that measures an upload — which was left unbounded and, unlike the head, actually transfers bytes. It therefore has two ways to stall rather than one: never responding, or responding and then not delivering the body. Either held the request open indefinitely.

**Deliberately not the head's budget, and the comment says why** rather than leaving a bare number:

* 5s is a *round-trip* allowance for a request that moves nothing. This one moves up to the caller's whole byte cap, so reusing 5s would abort legitimate large uploads on a slow link and surface them to the author as "we couldn't read that back" — a hardening change that invents a new rejection for images that are fine is not a hardening change.
* The value is taken from the **sibling bounded transfer under the same byte cap** in the block-media path rather than picked afresh, so the two byte-moving bounds in this area cannot drift apart.
* What it buys is not a latency target — it is the difference between *bounded* and *unbounded*. An abort lands on the existing "could not consult the store" state, so the classification the caller acts on is unchanged.

## 2. The injected timeout parameter is pinned

Both entry points take a `timeoutMs` so the abort path is reachable in milliseconds. A version that accepted the parameter and then applied the module constant behaved *identically* in production and passed every existing case — those cases would simply have taken seconds instead of milliseconds, which nothing asserted. The value handed to the bound is now asserted directly, via a spy rather than a stopwatch so the guard carries no race.

## 3. The fail-open `.catch` on the integrity event is pinned

The event is fire-and-forget by design — an operational log must not sit on the critical path of the attach it describes — which is exactly what makes a rejecting sink dangerous: the rejection has nowhere to go but `unhandledRejection`, so the observation takes down the request it was only watching. Deleting the clause previously left the whole suite green.

Its test needs a **file of its own** to be falsifiable at all: a `vi.fn()` sink attaches its own handler to the returned promise and marks the rejection handled, so an assertion written against one passes with or without the production `.catch()`. Same split, and the same reason, as the existing cover-image logging test.

## 4. Severity lowered to `warning`, mismatch included

`type` is what the log pipeline reads as the level, and `src/server/logging/client.ts` states the rule plainly: a BAD_REQUEST-class fault is normal user feedback and "must never be logged at error severity, or they drown out the real server-side failures". A mismatch ends in exactly such a rejection *and* any author can produce one at will, so at `error` this event was an author-controlled tap on the error board.

The severity was never the discriminator anyway — `status` and `reason` are emitted as their own fields precisely so these outcomes are separable, and a query or alert on `status="mismatch"` is both narrower and more stable than one on a level shared with every other error in the app. **Called out explicitly for review**: the alternative was to keep `error` and document a security-event exception. I chose the file's own rule, because the trigger is author-controlled and the discrimination is already available in a better field.

## 5. Comment correction

A comment claimed four `unverifiable` reasons are reachable from that consumer where three are — the fourth is short-circuited a few lines above. The block reconciled itself further down, but the headline sentence was wrong read alone.

---

## Test matrix — honestly

9 new cases. **5 are RED at `a7a96e7cd3` and green here**; 4 are green at base by construction.

| Case | At base | Kind |
|---|---|---|
| ranged read is handed a live abort signal | ✗ red | new-code coverage |
| ranged read fails `store-unavailable` when the store never responds | ✗ red (times out) | new-code coverage |
| ranged read fails `store-unavailable` when the body never arrives | ✗ red (times out) | new-code coverage |
| injected budget is the one applied — read side | ✗ red | new-code coverage |
| every outcome emits below error severity | ✗ red (was `error`) | new-code coverage |
| injected budget is the one applied — head side | ✓ green | **invariant guard** on #3804 behaviour |
| degraded sink: unverifiable verdict still attaches | ✓ green | **invariant guard** |
| degraded sink: mismatch still refuses with its own message | ✓ green | **invariant guard** |
| positive control: the re-check actually reached the store | ✓ green | positive control |

Base run: **5 failed / 56 passed of 61**. HEAD run: **61 passed**. Wider sweep over the whole blocks + server-utils tree at HEAD: **172 files / 3426 tests, all green**.

None of the four green-at-base cases is regression coverage and none is counted as such — they pin behaviour #3804 already shipped, and their worth is the mutation result below rather than the base run.

## Mutation results — every guard, beyond deletion

Each mutation was applied to the real source, the suite re-run, and the *failing message* read to confirm it attributes to the guard under test rather than an adjacent one.

| Mutation | Killed by | Failing assertion |
|---|---|---|
| bound deleted from the ranged read | 4 cases | `expected [] to deeply equal [ 37, 60000 ]`, `expected undefined to be an instance of AbortSignal`, 2× timeout |
| bound built from the **wrong constant** (head's) | budget pin **only** | `expected [ 5000, 5000 ] to deeply equal [ 37, 60000 ]` |
| read accepts `timeoutMs` then ignores it | budget pin + both hang cases | `expected [ 60000, 60000 ] to deeply equal [ 37, 60000 ]` |
| head accepts `timeoutMs` then ignores it | budget pin **only** | `expected [ 5000, 5000 ] to deeply equal [ 37, 5000 ]` |
| budget set to a degenerate `0` | bound case | `expected 0 to be greater than 0` |
| severity restored to `error` on mismatch | severity case | `to match object { status: 'mismatch', type: 'warning' }` |
| `.catch(() => null)` deleted | both sink cases | `expected [ Error: axiom is unreachable ] to deeply equal []` |
| whole re-check made unreachable (positive control) | 15 cases incl. the new positive control | `expected [] to have a length of 1 but got +0` |

Two of these matter more than the rest. The **wrong-constant** mutation is killed *only* by the injected-budget pin — the hang cases pass at 5s, so without that pin a silently-wrong-but-finite bound ships. And the **unreachable** mutation kills the new positive control, which is what stops the two sink cases passing for the wrong reason: with the check skipped nothing logs, so "no unhandled rejection" would be vacuously true.

## Deliberately not done

* **No Prisma migration**, and none is needed — nothing here touches a column or a schema.
* **No new event fields, no renames.** The event's key set is unchanged (a pre-existing test pins it), so existing queries keep working; only the level moved.
* **No change to the head's 5s budget.** It is correct for a request that transfers nothing, and #3804's reasoning for it still holds.
* **No test for item 5's comment correction** — it is a comment, and a test asserting comment text would pin the wrong thing.
* **The "body never arrives" case is a fidelity choice, stated as one.** The fixture wires the abort into the body read because that is what the SDK does — it destroys the underlying request, so a stream still being read off that socket errors rather than idling. That behaviour is the SDK's, not something this PR can assert against a real backend from a unit test.

## Pre-existing, not attributable here

* Typecheck is red at base and at HEAD with the **identical 12-error set** (verified by diffing both runs: `event-engine-common` module resolution + implicit-`any` in `image.service.ts`). Nothing in a touched file. Note this is 12, not the ~34 quoted to me — reporting what I measured.
* The first `preview / deploy` run failed, and it is worth saying exactly how rather than waving at "the pool is busy": the image step was **OOM-killed**, which is a different signature from the scheduling failures the pool had been showing, so it got a control rather than an assumption. The failed run took 28 minutes where comparable ones took 9–17, overlapping a concurrent memory experiment that had been holding an unschedulable claim against the same pool for over an hour; a build of the base branch on the same pool succeeded two minutes after this branch's failed. That was suggestive but not decisive either way, so the branch was rebuilt on an **identical tree** (the empty commit here) — and it passed in 18 minutes. Same code, same pool, opposite outcome: the OOM was environmental.

  Worth noting for anyone reading the failed run later: nothing in this branch adds a module to the production graph. The three test files are not reachable from any entry point, and the two source files gain an exported number, an optional parameter and one argument — no new imports. So there was no mechanism by which it could move build memory, but "no mechanism I can see" is not a measurement, which is why the re-run happened.

Refs #3804
