### PR TITLE
fix(profile): move sticker suspension below mute in the user menu

### DIFF
--- a/src/components/Profile/UserContextMenu.tsx
+++ b/src/components/Profile/UserContextMenu.tsx
@@ -276,7 +276,6 @@ export const UserContextMenu = ({ username }: { username: string }) => {
         <>
           {isMod && (
             <>
-              <SuspendPlacerMenuItem userId={user.id} />
               {env.NEXT_PUBLIC_USER_LOOKUP_URL && (
                 <Menu.Item
                   component="a"
@@ -350,6 +349,7 @@ export const UserContextMenu = ({ username }: { username: string }) => {
               >
                 {user.muted ? 'Unmute user' : 'Mute user'}
               </Menu.Item>
+              <SuspendPlacerMenuItem userId={user.id} />
               {canManageUserPayments && (
                 <>
                   <Menu.Item


### PR DESCRIPTION
Closes [CU-868kpe7by](https://app.clickup.com/t/868kpe7by).

## Problem

`SuspendPlacerMenuItem` was inserted at the very top of the moderator section of the user context menu on `/user/[name]`, pushing **Lookup User** — the item moderators reach for most, and the first item in this menu for years — down a row. Muscle memory now lands on a destructive red action instead.

## Change

Moved `<SuspendPlacerMenuItem />` to sit directly below **Mute user**, as requested. One line moved; no behavior change.

The component gates itself on `features.stickerPlacement` and renders no divider or label, so it has no dependency on its position in the list.

## Testing

Visual/ordering-only change to a moderator-gated menu — verified by reading the rendered order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)