### PR TITLE
perf(server): narrow three read-path selects to cut per-row deserialization

### DIFF
--- a/src/components/CommentSection/CommentSectionItem.tsx
+++ b/src/components/CommentSection/CommentSectionItem.tsx
@@ -123,10 +123,7 @@ export function CommentSectionItem({ comment, modelId, onReplyClick }: Props) {
           reaction,
           user: {
             id: currentUser.id,
-            deletedAt: null,
             username: currentUser.username ?? '',
-            image: currentUser.image ?? '',
-            profilePicture: null, // not really necessary for reactions
           },
         };
         const reacted = previousReactions.find(

--- a/src/components/Model/Discussion/CommentThreadModal.tsx
+++ b/src/components/Model/Discussion/CommentThreadModal.tsx
@@ -55,10 +55,7 @@ export default function CommentThreadModal({
           reaction,
           user: {
             id: currentUser.id,
-            deletedAt: null,
             username: currentUser.username ?? '',
-            image: currentUser.image ?? '',
-            profilePicture: null, // Not really necessary for reactions
           },
         };
         const reacted = previousReactions.find(

--- a/src/components/Model/ModelDiscussion/CommentDiscussionItem.tsx
+++ b/src/components/Model/ModelDiscussion/CommentDiscussionItem.tsx
@@ -48,10 +48,7 @@ export function CommentDiscussionItem({ data: comment, modelUserId }: Props) {
           reaction,
           user: {
             id: currentUser.id,
-            deletedAt: null,
             username: currentUser.username ?? '',
-            image: currentUser.image ?? '',
-            profilePicture: null,
           },
         };
         const reacted = previousReactions.find(

--- a/src/server/selectors/reaction.selector.ts
+++ b/src/server/selectors/reaction.selector.ts
@@ -21,12 +21,14 @@ import { Prisma } from '@prisma/client';
  *    round-trip rather than a widened one. Selecting it meant one `Image`
  *    SELECT per call — not per row — whenever AT LEAST ONE reactor in the batch
  *    has a profile picture; when the collected FK set is empty Prisma skips the
- *    child query entirely. Measured on this exact shape (Prisma 6.13.0, PG16,
- *    SQL captured via `$on('query')`): a batch of 5 reactors issues 0 `Image`
- *    SELECTs with none of them carrying a picture, and 1 (`WHERE "Image"."id"
- *    IN (…)`) whether one carries one or all five do. That query is on top of
- *    the `User` SELECT the `user` relation still costs; dropping
- *    `profilePicture` removes it, rather than just a column.
+ *    child query entirely. Measured on a minimal MIRROR of this shape
+ *    (`CommentReaction -> User -> Image` via a nullable FK; Prisma 6.13.0, SQL
+ *    captured via `$on('query')`; reproduced on SQLite, and once on PG16): a
+ *    batch of 5 reactors issues 0 `Image` SELECTs with none of them carrying a
+ *    picture, and 1 (`WHERE "Image"."id" IN (…)`) whether one carries one or
+ *    all five do. That query is on top of the `User` SELECT the `user` relation
+ *    still costs; dropping `profilePicture` removes it, rather than just a
+ *    column.
  *
  * 2. Per-row decoding, but only CONDITIONALLY. Prisma converts tagged values
  *    on the JS main thread (`DateTime` -> `new Date`, `Json` -> `JSON.parse`),

--- a/src/server/selectors/reaction.selector.ts
+++ b/src/server/selectors/reaction.selector.ts
@@ -14,12 +14,19 @@ import { Prisma } from '@prisma/client';
  * Two distinct costs, and they are not the same size:
  *
  * 1. An EXTRA QUERY — plausibly the larger cost, and per call rather than per
- *    row. `profilePicture` is a relation, and the schema's generator block
- *    enables only `previewFeatures = ["metrics"]` — no `relationJoins` — so
- *    Prisma has no join strategy available and resolves a nested relation with
- *    an additional round-trip rather than a widened one. Selecting it meant an
- *    `Image` SELECT per call, on top of the `User` SELECT that the `user`
- *    relation still costs. Dropping it removes that query, not just a column.
+ *    row, but CONDITIONAL like the decode below. `profilePicture` is a
+ *    relation, and the schema's generator block enables only
+ *    `previewFeatures = ["metrics"]` — no `relationJoins` — so Prisma has no
+ *    join strategy available and resolves a nested relation with an additional
+ *    round-trip rather than a widened one. Selecting it meant one `Image`
+ *    SELECT per call — not per row — whenever AT LEAST ONE reactor in the batch
+ *    has a profile picture; when the collected FK set is empty Prisma skips the
+ *    child query entirely. Measured on this exact shape (Prisma 6.13.0, PG16,
+ *    SQL captured via `$on('query')`): a batch of 5 reactors issues 0 `Image`
+ *    SELECTs with none of them carrying a picture, and 1 (`WHERE "Image"."id"
+ *    IN (…)`) whether one carries one or all five do. That query is on top of
+ *    the `User` SELECT the `user` relation still costs; dropping
+ *    `profilePicture` removes it, rather than just a column.
  *
  * 2. Per-row decoding, but only CONDITIONALLY. Prisma converts tagged values
  *    on the JS main thread (`DateTime` -> `new Date`, `Json` -> `JSON.parse`),

--- a/src/server/selectors/reaction.selector.ts
+++ b/src/server/selectors/reaction.selector.ts
@@ -3,17 +3,38 @@ import { Prisma } from '@prisma/client';
 /**
  * Comment reactions only ever need to name the reactor.
  *
- * The renderer (`ReactionPicker`) reads `user.username` for the "who reacted"
- * tooltip and `user.id` to decide whether the viewer already reacted — nothing
- * else. Selecting the full `simpleUserSelect` here dragged in `deletedAt` and,
- * worse, the whole `profilePicture` Image relation, whose `metadata` is a
- * non-null `Json` column. Prisma decodes tagged values on the JS main thread,
- * so that was a `JSON.parse` plus a `new Date()` for every reaction on every
- * comment of every page — for two strings that are never rendered.
+ * Two fields are read, and nothing else. `ReactionPicker` reads
+ * `user.username` — for the "who reacted" tooltip, and for its own "have I
+ * reacted" comparison against the current user's username. Its three callers
+ * (`CommentSectionItem`, `CommentDiscussionItem`, `CommentThreadModal`) read
+ * `user.id`, to find the viewer's existing reaction before toggling it.
  *
- * The deleted-user case still works: `deleteUser` nulls `username`, and the
- * renderer already falls back on `username ?? '<deleted user>'`, so it reads
- * the null rather than the timestamp.
+ * This used to select the full `simpleUserSelect`, which additionally
+ * pulled `deletedAt`, `image` and the whole `profilePicture` Image relation.
+ * Two distinct costs, and they are not the same size:
+ *
+ * 1. An EXTRA QUERY — plausibly the larger cost, and per call rather than per
+ *    row. `profilePicture` is a relation, and the schema's generator block
+ *    enables only `previewFeatures = ["metrics"]` — no `relationJoins` — so
+ *    Prisma has no join strategy available and resolves a nested relation with
+ *    an additional round-trip rather than a widened one. Selecting it meant an
+ *    `Image` SELECT per call, on top of the `User` SELECT that the `user`
+ *    relation still costs. Dropping it removes that query, not just a column.
+ *
+ * 2. Per-row decoding, but only CONDITIONALLY. Prisma converts tagged values
+ *    on the JS main thread (`DateTime` -> `new Date`, `Json` -> `JSON.parse`),
+ *    and both dropped columns are nullable — `User.deletedAt` is `DateTime?`
+ *    and `User.profilePictureId` is `Int?` — so a live user with no profile
+ *    picture (the common case) paid neither. The decode cost landed only on
+ *    rows where the value was actually non-null: a `new Date()` per deleted
+ *    reactor, and, for each reactor who has one, a `JSON.parse` of that
+ *    Image's `metadata` (which is a non-null `Json` column, so it is always
+ *    parsed once the row is fetched at all).
+ *
+ * The deleted-user case still renders correctly: `deleteUser` nulls
+ * `username`, and the renderer already falls back on
+ * `username ?? '<deleted user>'`, so it reads the null rather than the
+ * timestamp.
  */
 export const getReactionsSelect = Prisma.validator<Prisma.CommentReactionSelect>()({
   id: true,

--- a/src/server/selectors/reaction.selector.ts
+++ b/src/server/selectors/reaction.selector.ts
@@ -1,11 +1,25 @@
 import { Prisma } from '@prisma/client';
-import { simpleUserSelect } from '~/server/selectors/user.selector';
 
+/**
+ * Comment reactions only ever need to name the reactor.
+ *
+ * The renderer (`ReactionPicker`) reads `user.username` for the "who reacted"
+ * tooltip and `user.id` to decide whether the viewer already reacted — nothing
+ * else. Selecting the full `simpleUserSelect` here dragged in `deletedAt` and,
+ * worse, the whole `profilePicture` Image relation, whose `metadata` is a
+ * non-null `Json` column. Prisma decodes tagged values on the JS main thread,
+ * so that was a `JSON.parse` plus a `new Date()` for every reaction on every
+ * comment of every page — for two strings that are never rendered.
+ *
+ * The deleted-user case still works: `deleteUser` nulls `username`, and the
+ * renderer already falls back on `username ?? '<deleted user>'`, so it reads
+ * the null rather than the timestamp.
+ */
 export const getReactionsSelect = Prisma.validator<Prisma.CommentReactionSelect>()({
   id: true,
   reaction: true,
   user: {
-    select: simpleUserSelect,
+    select: { id: true, username: true },
   },
 });
 

--- a/src/server/services/__tests__/hot-path-select-narrowing.image.test.ts
+++ b/src/server/services/__tests__/hot-path-select-narrowing.image.test.ts
@@ -28,9 +28,13 @@ import type * as PromClient from '~/server/prom/client';
  * absence assertion over `Object.keys(undefined ?? {})` passes on precisely
  * the shape being rejected; `toEqual` fails on `undefined` by itself. An
  * earlier revision followed the `toEqual` with a loop asserting each tagged
- * `Post` column was absent — unreachable, since any select containing one had
- * already failed the line above — and it has been removed. The `toBeDefined`
- * that remains is for its failure message, not for coverage.
+ * `Post` column was absent, and it has been removed. Given a FIXED `expected`
+ * that loop was redundant — any select containing one of those columns had
+ * already failed the line above — but it also went red when `expected` was
+ * widened ALONGSIDE the source, which a `toEqual` against the widened
+ * `expected` cannot catch, so removing it accepts the loss of that narrow
+ * ratchet against a test-file edit. The `toBeDefined` that remains is for its
+ * failure message, not for coverage.
  *
  * The mock block mirrors the established recipe from
  * `getAllImages-prioritized-guards.test.ts`, with one difference: `isFlipt`

--- a/src/server/services/__tests__/hot-path-select-narrowing.image.test.ts
+++ b/src/server/services/__tests__/hot-path-select-narrowing.image.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Type-only namespace imports rather than `typeof import('…')` inside the
+// factories: @typescript-eslint/consistent-type-imports forbids `import()` type
+// annotations, and this is the spelling the repo's own no-wholesale-module-mock
+// rule documents as the alternative.
+import type * as FliptClient from '../../flipt/client';
+import type * as PromClient from '~/server/prom/client';
+
+/**
+ * Sibling of `hot-path-select-narrowing.test.ts`, which pins the two
+ * `entity-collaborator.service` projections and the reaction selector.
+ *
+ * This one pins the third narrowed path: the `hasSystemPosts` existence check
+ * inside `getAllImages`. It lives in its own file because importing
+ * `image.service` requires a whole env / redis / clickhouse / submodule mock
+ * block, and `vi.mock` is file-scoped — dropping that block into the sibling
+ * would change what the collaborator tests import.
+ *
+ * The guarded defect: the check reads its result ONLY as a boolean
+ * (`if (prioritizseIsSystemUser && !hasSystemPosts)`), so a bare
+ * `findFirst({ where })` decodes an entire `Post` row — three DateTimes and the
+ * `metadata` Json — to answer yes/no. `select: { id: true }` is what keeps it
+ * from doing that, and nothing else in the suite would notice it regrowing.
+ *
+ * 🔴 The `toBeDefined` assertion below is load-bearing. Without it the check is
+ * vacuous: an unnarrowed call has no `select` key at all, and every "does not
+ * contain <column>" assertion over `Object.keys(undefined ?? {})` passes on
+ * precisely the shape being rejected.
+ *
+ * The mock block mirrors the established recipe from
+ * `getAllImages-prioritized-guards.test.ts`, with one difference: `isFlipt`
+ * resolves FALSE here, because `hasSystemPosts` sits in the
+ * `prioritizeUser && !useModelVersionCache` branch — the opposite side of the
+ * flag from the branch that file exercises.
+ */
+
+vi.mock('~/server/prom/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof PromClient>();
+  return { ...actual, registerCounter: () => ({ inc: vi.fn() }) };
+});
+
+// event-engine-common is a git submodule — stub the value imports image.service
+// pulls from it so this suite does not depend on it being checked out.
+vi.mock('../../../../event-engine-common/services/metrics', () => ({
+  MetricService: class {
+    fetch = vi.fn();
+  },
+}));
+vi.mock('../../../../event-engine-common/feeds', () => ({ ImagesFeed: class {} }));
+vi.mock('../../../../event-engine-common/services/cache', () => ({ CacheService: class {} }));
+
+// Importing the real `~/env/server` validates ALL prod env vars and throws in
+// test. A Proxy returns safe values for anything read at module load.
+vi.mock('~/env/server', () => ({
+  env: new Proxy({ LOGGING: [] as string[] } as Record<string, unknown>, {
+    get: (target, prop) => {
+      if (prop in target) return target[prop as string];
+      if (typeof prop === 'string' && (prop.endsWith('_URL') || prop.endsWith('_ENDPOINT')))
+        return 'https://test:test@localhost:5432/test';
+      if (
+        typeof prop === 'string' &&
+        /(_CONCURRENCY|_LIMIT|_MS|_PORT|_TIMEOUT|_MAX|_SIZE|_COUNT)$/.test(prop)
+      )
+        return 1;
+      return undefined;
+    },
+  }),
+}));
+
+// A sentinel thrown from the mocked `post.findFirst` so the test stops exactly
+// at the call under inspection. Everything after it in `getAllImages` is a raw
+// SQL feed query whose mocking would add nothing to what is being pinned.
+const STOP = new Error('__stop_after_hasSystemPosts__');
+const postFindFirst = vi.fn();
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: {
+    post: {
+      findFirst: (...args: unknown[]) => postFindFirst(...args),
+    },
+  },
+  dbWrite: {},
+}));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/redis/client', () => {
+  // A self-returning Proxy: every key lookup yields another one, so any depth of
+  // `REDIS_KEYS.A.B.C` read at module load resolves without enumerating them.
+  const make = (): unknown => new Proxy(() => 'k', { get: () => make() });
+  const keyProxy = make();
+  return {
+    redis: { packed: { get: vi.fn(), set: vi.fn() } },
+    sysRedis: {},
+    REDIS_KEYS: keyProxy,
+    REDIS_SYS_KEYS: keyProxy,
+  };
+});
+
+// The branch under test sits after this — stub it so `getAllImages` proceeds.
+vi.mock('~/server/services/blocked-browsing-tags.service', () => ({
+  enforceBlockedBrowsingTags: vi.fn().mockResolvedValue({ emptyResult: false }),
+}));
+
+// FALSE, so `useModelVersionCache` is false and the `prioritizeUser &&
+// !useModelVersionCache` branch (the one holding `hasSystemPosts`) is taken.
+vi.mock('../../flipt/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof FliptClient>();
+  return { ...actual, isFlipt: vi.fn().mockResolvedValue(false) };
+});
+
+import { getAllImages } from '../image.service';
+
+const SYSTEM_USER_ID = -1;
+const MODEL_VERSION_ID = 456;
+
+const systemUserInput = {
+  browsingLevel: 1,
+  // Exactly one prioritized id, and it is the system user — that is what makes
+  // `prioritizseIsSystemUser` true and issues the existence check.
+  prioritizedUserIds: [SYSTEM_USER_ID],
+  modelVersionId: MODEL_VERSION_ID,
+  include: [],
+} as unknown as Parameters<typeof getAllImages>[0];
+
+/** Drives `getAllImages` to the existence check and returns that call's args. */
+async function captureHasSystemPostsCall() {
+  postFindFirst.mockImplementation(() => {
+    throw STOP;
+  });
+
+  let caught: unknown;
+  try {
+    await getAllImages(systemUserInput);
+  } catch (e) {
+    caught = e;
+  }
+
+  // Positive control on the harness itself: if `getAllImages` returned early or
+  // threw somewhere else, the query never ran and any assertion below would be
+  // a statement about nothing.
+  expect(caught, 'getAllImages did not reach the hasSystemPosts check').toBe(STOP);
+  expect(postFindFirst).toHaveBeenCalledTimes(1);
+
+  return postFindFirst.mock.calls[0][0] as {
+    where?: Record<string, unknown>;
+    select?: Record<string, boolean>;
+  };
+}
+
+describe('getAllImages hasSystemPosts — an existence check, projected to one column', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('projects the existence check instead of decoding a whole Post row', async () => {
+    const args = await captureHasSystemPostsCall();
+
+    // Assert the projection EXISTS before asserting its contents — see the
+    // header. A bare `findFirst({ where })` has no `select` key, and the
+    // absence-checks below would pass on it.
+    expect(args.select, 'a bare findFirst fetches every Post column').toBeDefined();
+
+    expect(args.select).toEqual({ id: true });
+
+    const selected = Object.keys(args.select as Record<string, boolean>);
+    // Json + DateTime columns on Post — each one is a client-side decode.
+    for (const tagged of ['metadata', 'createdAt', 'updatedAt', 'publishedAt']) {
+      expect(selected, `re-added the tagged column \`${tagged}\``).not.toContain(tagged);
+    }
+  });
+
+  it('still asks the question it was asking — system user, this model version', async () => {
+    // Behavioural pair: narrowing the projection must not have touched the
+    // predicate. A `select` pinned over a `where` that no longer identifies the
+    // system user's posts would be a green shape check over broken logic.
+    const args = await captureHasSystemPostsCall();
+
+    expect(args.where).toEqual({ userId: SYSTEM_USER_ID, modelVersionId: MODEL_VERSION_ID });
+  });
+});

--- a/src/server/services/__tests__/hot-path-select-narrowing.image.test.ts
+++ b/src/server/services/__tests__/hot-path-select-narrowing.image.test.ts
@@ -23,10 +23,14 @@ import type * as PromClient from '~/server/prom/client';
  * `metadata` Json — to answer yes/no. `select: { id: true }` is what keeps it
  * from doing that, and nothing else in the suite would notice it regrowing.
  *
- * 🔴 The `toBeDefined` assertion below is load-bearing. Without it the check is
- * vacuous: an unnarrowed call has no `select` key at all, and every "does not
- * contain <column>" assertion over `Object.keys(undefined ?? {})` passes on
- * precisely the shape being rejected.
+ * 🔴 The shape is pinned by an exact-key-set `toEqual`, never by "does not
+ * contain <column>". An unnarrowed call has no `select` key at all, and every
+ * absence assertion over `Object.keys(undefined ?? {})` passes on precisely
+ * the shape being rejected; `toEqual` fails on `undefined` by itself. An
+ * earlier revision followed the `toEqual` with a loop asserting each tagged
+ * `Post` column was absent — unreachable, since any select containing one had
+ * already failed the line above — and it has been removed. The `toBeDefined`
+ * that remains is for its failure message, not for coverage.
  *
  * The mock block mirrors the established recipe from
  * `getAllImages-prioritized-guards.test.ts`, with one difference: `isFlipt`
@@ -155,18 +159,15 @@ describe('getAllImages hasSystemPosts — an existence check, projected to one c
   it('projects the existence check instead of decoding a whole Post row', async () => {
     const args = await captureHasSystemPostsCall();
 
-    // Assert the projection EXISTS before asserting its contents — see the
-    // header. A bare `findFirst({ where })` has no `select` key, and the
-    // absence-checks below would pass on it.
+    // Named first so a bare `findFirst({ where })` reports the real defect
+    // rather than an `undefined` mismatch. The `toEqual` below would catch it
+    // regardless — see the header.
     expect(args.select, 'a bare findFirst fetches every Post column').toBeDefined();
 
+    // The exact key set: re-adding any Post column — the tagged ones
+    // (`metadata`, `createdAt`, `updatedAt`, `publishedAt`) above all, since
+    // each is a client-side decode — fails here.
     expect(args.select).toEqual({ id: true });
-
-    const selected = Object.keys(args.select as Record<string, boolean>);
-    // Json + DateTime columns on Post — each one is a client-side decode.
-    for (const tagged of ['metadata', 'createdAt', 'updatedAt', 'publishedAt']) {
-      expect(selected, `re-added the tagged column \`${tagged}\``).not.toContain(tagged);
-    }
   });
 
   it('still asks the question it was asking — system user, this model version', async () => {

--- a/src/server/services/__tests__/hot-path-select-narrowing.test.ts
+++ b/src/server/services/__tests__/hot-path-select-narrowing.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * These pin the SELECT SHAPE of three read paths that are hot enough for
+ * Prisma's client-side row decoding to show up on the main thread.
+ *
+ * Prisma walks the engine response in JS and converts every tagged value per
+ * row — `DateTime` -> `new Date`, `Json` -> `JSON.parse`, `Decimal` ->
+ * `new Decimal`, `BigInt`, `Bytes` -> `Buffer.from`. So a column that is
+ * fetched and never read is not free: it is an allocation per row per request.
+ * Each assertion below fails against the pre-narrowing code, and each is
+ * paired with a behavioural case so the shape check cannot pass while the
+ * logic that consumes the remaining fields is broken.
+ */
+
+const postFindUnique = vi.fn();
+const entityCollaboratorFindMany = vi.fn();
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: {
+    post: {
+      findUnique: (...args: unknown[]) => postFindUnique(...args),
+    },
+    entityCollaborator: {
+      findMany: (...args: unknown[]) => entityCollaboratorFindMany(...args),
+    },
+  },
+  dbWrite: {},
+}));
+
+// Reached transitively by the service under test; instantiating the real chat
+// stack here would pull in Redis. Nothing below exercises messaging.
+vi.mock('~/server/services/chat.service', () => ({
+  createMessage: vi.fn(),
+  upsertChat: vi.fn(),
+}));
+
+import { getEntityCollaborators } from '~/server/services/entity-collaborator.service';
+import { getReactionsSelect } from '~/server/selectors/reaction.selector';
+import { EntityType, EntityCollaboratorStatus } from '~/shared/utils/prisma/enums';
+
+const OWNER_ID = 101;
+const COLLABORATOR_ID = 202;
+const STRANGER_ID = 303;
+const POST_ID = 5150;
+
+describe('getEntityCollaborators — Post owner lookup is projected, not a full row', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    postFindUnique.mockResolvedValue({ userId: OWNER_ID });
+    entityCollaboratorFindMany.mockResolvedValue([]);
+  });
+
+  it('asks Postgres for ONLY the owner id', async () => {
+    await getEntityCollaborators({
+      entityId: POST_ID,
+      entityType: EntityType.Post,
+      userId: OWNER_ID,
+    });
+
+    expect(postFindUnique).toHaveBeenCalledTimes(1);
+    const [args] = postFindUnique.mock.calls[0] as [{ select?: Record<string, boolean> }];
+
+    // A bare `findUnique` has no `select` at all — that is the shape this
+    // guards against, and it is what shipped before. Asserting the exact key
+    // set (rather than just "userId is present") means re-adding `metadata`,
+    // `createdAt`, `publishedAt` or `detail` fails here too.
+    expect(args.select).toEqual({ userId: true });
+  });
+
+  it('does not select any of the Post columns that cost a decode per row', async () => {
+    await getEntityCollaborators({
+      entityId: POST_ID,
+      entityType: EntityType.Post,
+      userId: OWNER_ID,
+    });
+
+    const [args] = postFindUnique.mock.calls[0] as [{ select?: Record<string, boolean> }];
+
+    // Assert the projection EXISTS before asserting what is missing from it.
+    // Without this line the loop below is vacuous — an absent `select` means
+    // Prisma returns every column, yet `Object.keys(undefined ?? {})` is empty
+    // and every `not.toContain` passes. That is the shape this whole file is
+    // guarding against, so it has to be the first thing checked.
+    expect(args.select, 'a bare findUnique fetches every column').toBeDefined();
+
+    const selected = Object.keys(args.select as Record<string, boolean>);
+    // Json + DateTime columns on Post — each one is a decode per row.
+    for (const tagged of ['metadata', 'createdAt', 'updatedAt', 'publishedAt']) {
+      expect(selected).not.toContain(tagged);
+    }
+  });
+
+  it('still gates pending collaborators on the owner id it fetched', async () => {
+    entityCollaboratorFindMany.mockResolvedValue([
+      {
+        user: { id: COLLABORATOR_ID },
+        entityId: POST_ID,
+        entityType: EntityType.Post,
+        status: EntityCollaboratorStatus.Pending,
+      },
+    ]);
+
+    const asOwner = await getEntityCollaborators({
+      entityId: POST_ID,
+      entityType: EntityType.Post,
+      userId: OWNER_ID,
+    });
+    expect(asOwner).toHaveLength(1);
+
+    const asStranger = await getEntityCollaborators({
+      entityId: POST_ID,
+      entityType: EntityType.Post,
+      userId: STRANGER_ID,
+    });
+    expect(asStranger).toHaveLength(0);
+  });
+
+  it('returns [] when the post is missing, without reading further columns', async () => {
+    postFindUnique.mockResolvedValue(null);
+
+    const result = await getEntityCollaborators({
+      entityId: POST_ID,
+      entityType: EntityType.Post,
+      userId: OWNER_ID,
+    });
+
+    expect(result).toEqual([]);
+    expect(entityCollaboratorFindMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('getReactionsSelect — a reaction names its reactor and nothing more', () => {
+  it('selects exactly the two user fields the renderer reads', () => {
+    // `ReactionPicker` reads `user.username` (tooltip / "did I react") and its
+    // callers read `user.id`. Pinning the exact set is the point: this used to
+    // be `simpleUserSelect`, which additionally pulled `deletedAt`, `image`
+    // and the whole `profilePicture` relation.
+    expect(getReactionsSelect.user.select).toEqual({ id: true, username: true });
+  });
+
+  it('does not pull the profilePicture relation (its `metadata` is a non-null Json)', () => {
+    const userSelect = getReactionsSelect.user.select as Record<string, unknown>;
+    expect(userSelect).not.toHaveProperty('profilePicture');
+    expect(userSelect).not.toHaveProperty('deletedAt');
+    expect(userSelect).not.toHaveProperty('image');
+  });
+
+  it('keeps the reaction fields the grouping and optimistic update depend on', () => {
+    expect(getReactionsSelect).toHaveProperty('id', true);
+    expect(getReactionsSelect).toHaveProperty('reaction', true);
+  });
+});

--- a/src/server/services/__tests__/hot-path-select-narrowing.test.ts
+++ b/src/server/services/__tests__/hot-path-select-narrowing.test.ts
@@ -1,20 +1,40 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
- * These pin the SELECT SHAPE of three read paths that are hot enough for
- * Prisma's client-side row decoding to show up on the main thread.
+ * These pin the SELECT SHAPE of read paths that are hot enough for Prisma's
+ * client-side row decoding to show up on the main thread: all three `Post`
+ * owner lookups in `entity-collaborator.service`, plus the comment-reaction
+ * selector.
  *
  * Prisma walks the engine response in JS and converts every tagged value per
  * row — `DateTime` -> `new Date`, `Json` -> `JSON.parse`, `Decimal` ->
  * `new Decimal`, `BigInt`, `Bytes` -> `Buffer.from`. So a column that is
  * fetched and never read is not free: it is an allocation per row per request.
- * Each assertion below fails against the pre-narrowing code, and each is
- * paired with a behavioural case so the shape check cannot pass while the
- * logic that consumes the remaining fields is broken.
+ *
+ * Each shape assertion fails against the pre-narrowing code, and each is paired
+ * with a behavioural case so the shape check cannot pass while the logic that
+ * consumes the remaining fields is broken. The behavioural cases are invariant
+ * guards — they pass on both sides of the narrowing by design, and are not
+ * counted as regression coverage.
+ *
+ * 🔴 Every shape assertion asserts `select` is DEFINED before asserting
+ * anything about its contents. Without that, a "does not contain <column>"
+ * check is vacuous: an unnarrowed `findUnique` has no `select` at all, and
+ * `Object.keys(undefined ?? {})` is empty, so every `not.toContain` passes on
+ * exactly the shape this file exists to reject.
+ *
+ * The remaining narrowed path — `hasSystemPosts` in `getAllImages` — is pinned
+ * in the sibling file `hot-path-select-narrowing.image.test.ts`. It lives apart
+ * because importing `image.service` needs a whole env/redis/submodule mock
+ * block, and `vi.mock` is file-scoped.
  */
 
 const postFindUnique = vi.fn();
 const entityCollaboratorFindMany = vi.fn();
+const entityCollaboratorFindFirst = vi.fn();
+const entityCollaboratorCount = vi.fn();
+const entityCollaboratorUpsert = vi.fn();
+const entityCollaboratorDelete = vi.fn();
 
 vi.mock('~/server/db/client', () => ({
   dbRead: {
@@ -23,9 +43,16 @@ vi.mock('~/server/db/client', () => ({
     },
     entityCollaborator: {
       findMany: (...args: unknown[]) => entityCollaboratorFindMany(...args),
+      findFirst: (...args: unknown[]) => entityCollaboratorFindFirst(...args),
+      count: (...args: unknown[]) => entityCollaboratorCount(...args),
     },
   },
-  dbWrite: {},
+  dbWrite: {
+    entityCollaborator: {
+      upsert: (...args: unknown[]) => entityCollaboratorUpsert(...args),
+      delete: (...args: unknown[]) => entityCollaboratorDelete(...args),
+    },
+  },
 }));
 
 // Reached transitively by the service under test; instantiating the real chat
@@ -35,7 +62,11 @@ vi.mock('~/server/services/chat.service', () => ({
   upsertChat: vi.fn(),
 }));
 
-import { getEntityCollaborators } from '~/server/services/entity-collaborator.service';
+import {
+  getEntityCollaborators,
+  removeEntityCollaborator,
+  upsertEntityCollaborator,
+} from '~/server/services/entity-collaborator.service';
 import { getReactionsSelect } from '~/server/selectors/reaction.selector';
 import { EntityType, EntityCollaboratorStatus } from '~/shared/utils/prisma/enums';
 
@@ -43,6 +74,41 @@ const OWNER_ID = 101;
 const COLLABORATOR_ID = 202;
 const STRANGER_ID = 303;
 const POST_ID = 5150;
+const TARGET_USER_ID = 404;
+
+/**
+ * The Post columns that cost a client-side decode per row. Each of the three
+ * `Post` narrowings is checked against this same list, so adding a tagged
+ * column to `Post` is a one-line change here rather than three.
+ */
+const TAGGED_POST_COLUMNS = ['metadata', 'createdAt', 'updatedAt', 'publishedAt'];
+
+/**
+ * Asserts a Prisma call argument carries a projection, and that the projection
+ * is exactly `expected`.
+ *
+ * The `toBeDefined` line is load-bearing, not defensive noise — see the file
+ * header. It also names the real defect ("a bare Prisma call fetches every
+ * column") rather than leaving a bare `undefined` mismatch for the reader to
+ * decode.
+ */
+function expectProjection(
+  args: { select?: Record<string, boolean> } | undefined,
+  expected: Record<string, boolean>,
+  label: string
+) {
+  expect(args, `${label}: the query was never issued`).toBeDefined();
+  expect(
+    args?.select,
+    `${label}: no \`select\` — a bare Prisma call fetches every column`
+  ).toBeDefined();
+  expect(args?.select).toEqual(expected);
+
+  const selected = Object.keys(args?.select as Record<string, boolean>);
+  for (const tagged of TAGGED_POST_COLUMNS) {
+    expect(selected, `${label}: re-added the tagged column \`${tagged}\``).not.toContain(tagged);
+  }
+}
 
 describe('getEntityCollaborators — Post owner lookup is projected, not a full row', () => {
   beforeEach(() => {
@@ -86,7 +152,7 @@ describe('getEntityCollaborators — Post owner lookup is projected, not a full 
 
     const selected = Object.keys(args.select as Record<string, boolean>);
     // Json + DateTime columns on Post — each one is a decode per row.
-    for (const tagged of ['metadata', 'createdAt', 'updatedAt', 'publishedAt']) {
+    for (const tagged of TAGGED_POST_COLUMNS) {
       expect(selected).not.toContain(tagged);
     }
   });
@@ -127,6 +193,108 @@ describe('getEntityCollaborators — Post owner lookup is projected, not a full 
 
     expect(result).toEqual([]);
     expect(entityCollaboratorFindMany).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * `upsertEntityCollaborator` and `removeEntityCollaborator` do the SAME
+ * full-row-for-one-field lookup that `getEntityCollaborators` did, in the same
+ * file. They are ratcheted here for the same reason: each is one careless
+ * `findUnique({ where })` away from regrowing, and nothing else in the suite
+ * would notice.
+ */
+describe('upsertEntityCollaborator — Post owner lookup is projected, not a full row', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    postFindUnique.mockResolvedValue({ userId: OWNER_ID });
+    entityCollaboratorFindFirst.mockResolvedValue(null);
+    entityCollaboratorCount.mockResolvedValue(0);
+    entityCollaboratorUpsert.mockResolvedValue({ id: 1 });
+  });
+
+  it('asks Postgres for ONLY the owner id', async () => {
+    await upsertEntityCollaborator({
+      entityId: POST_ID,
+      entityType: EntityType.Post,
+      targetUserId: TARGET_USER_ID,
+      userId: OWNER_ID,
+    } as Parameters<typeof upsertEntityCollaborator>[0]);
+
+    expect(postFindUnique).toHaveBeenCalledTimes(1);
+    const [args] = postFindUnique.mock.calls[0] as [{ select?: Record<string, boolean> }];
+    expectProjection(args, { userId: true }, 'upsertEntityCollaborator');
+  });
+
+  it('still refuses a non-owner using the owner id it fetched', async () => {
+    // Behavioural pair for the shape check above: proves the surviving field is
+    // the one the authorization branch actually consults, so the projection
+    // cannot be narrowed to something the logic no longer reads.
+    await expect(
+      upsertEntityCollaborator({
+        entityId: POST_ID,
+        entityType: EntityType.Post,
+        targetUserId: TARGET_USER_ID,
+        userId: STRANGER_ID,
+      } as Parameters<typeof upsertEntityCollaborator>[0])
+    ).rejects.toThrow(/Only the owner of the post can add collaborators/);
+
+    expect(entityCollaboratorUpsert).not.toHaveBeenCalled();
+
+    // …and the owner still gets through.
+    await expect(
+      upsertEntityCollaborator({
+        entityId: POST_ID,
+        entityType: EntityType.Post,
+        targetUserId: TARGET_USER_ID,
+        userId: OWNER_ID,
+      } as Parameters<typeof upsertEntityCollaborator>[0])
+    ).resolves.toBeTruthy();
+    expect(entityCollaboratorUpsert).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('removeEntityCollaborator — Post owner lookup is projected, not a full row', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    postFindUnique.mockResolvedValue({ userId: OWNER_ID });
+    entityCollaboratorFindFirst.mockResolvedValue({ id: 1, userId: TARGET_USER_ID });
+    entityCollaboratorDelete.mockResolvedValue({ id: 1 });
+  });
+
+  it('asks Postgres for ONLY the owner id', async () => {
+    await removeEntityCollaborator({
+      entityId: POST_ID,
+      entityType: EntityType.Post,
+      targetUserId: TARGET_USER_ID,
+      userId: OWNER_ID,
+    } as Parameters<typeof removeEntityCollaborator>[0]);
+
+    expect(postFindUnique).toHaveBeenCalledTimes(1);
+    const [args] = postFindUnique.mock.calls[0] as [{ select?: Record<string, boolean> }];
+    expectProjection(args, { userId: true }, 'removeEntityCollaborator');
+  });
+
+  it('still refuses a non-owner using the owner id it fetched', async () => {
+    await expect(
+      removeEntityCollaborator({
+        entityId: POST_ID,
+        entityType: EntityType.Post,
+        targetUserId: TARGET_USER_ID,
+        userId: STRANGER_ID,
+      } as Parameters<typeof removeEntityCollaborator>[0])
+    ).rejects.toThrow(/Only the owner of the post can remove collaborators/);
+
+    expect(entityCollaboratorDelete).not.toHaveBeenCalled();
+
+    await expect(
+      removeEntityCollaborator({
+        entityId: POST_ID,
+        entityType: EntityType.Post,
+        targetUserId: TARGET_USER_ID,
+        userId: OWNER_ID,
+      } as Parameters<typeof removeEntityCollaborator>[0])
+    ).resolves.toBe(true);
+    expect(entityCollaboratorDelete).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/server/services/__tests__/hot-path-select-narrowing.test.ts
+++ b/src/server/services/__tests__/hot-path-select-narrowing.test.ts
@@ -17,11 +17,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  * guards — they pass on both sides of the narrowing by design, and are not
  * counted as regression coverage.
  *
- * 🔴 Every shape assertion asserts `select` is DEFINED before asserting
- * anything about its contents. Without that, a "does not contain <column>"
- * check is vacuous: an unnarrowed `findUnique` has no `select` at all, and
- * `Object.keys(undefined ?? {})` is empty, so every `not.toContain` passes on
- * exactly the shape this file exists to reject.
+ * 🔴 Every shape assertion pins the projection's EXACT key set with `toEqual`,
+ * never "does not contain <column>". That distinction is the whole reason this
+ * file looks the way it does: an unnarrowed `findUnique` has no `select` at
+ * all, and `Object.keys(undefined ?? {})` is empty, so an absence-check passes
+ * on precisely the shape being rejected. `toEqual` has no such hole — it fails
+ * on `undefined` by itself — so it is the only shape assertion here, and there
+ * are no absence-checks left to be vacuous. The `toBeDefined` line inside
+ * `expectProjection` survives for its FAILURE MESSAGE, not for coverage: it
+ * names the real defect ("a bare Prisma call fetches every column") instead of
+ * leaving a bare `undefined` mismatch for the reader to decode.
  *
  * The remaining narrowed path — `hasSystemPosts` in `getAllImages` — is pinned
  * in the sibling file `hot-path-select-narrowing.image.test.ts`. It lives apart
@@ -77,20 +82,20 @@ const POST_ID = 5150;
 const TARGET_USER_ID = 404;
 
 /**
- * The Post columns that cost a client-side decode per row. Each of the three
- * `Post` narrowings is checked against this same list, so adding a tagged
- * column to `Post` is a one-line change here rather than three.
- */
-const TAGGED_POST_COLUMNS = ['metadata', 'createdAt', 'updatedAt', 'publishedAt'];
-
-/**
  * Asserts a Prisma call argument carries a projection, and that the projection
  * is exactly `expected`.
  *
- * The `toBeDefined` line is load-bearing, not defensive noise — see the file
- * header. It also names the real defect ("a bare Prisma call fetches every
- * column") rather than leaving a bare `undefined` mismatch for the reader to
- * decode.
+ * `toEqual` on the exact key set is the entire shape guard. Re-adding any of
+ * the `Post` columns that cost a client-side decode per row — `metadata`,
+ * `createdAt`, `updatedAt`, `publishedAt` — fails it, as does dropping to a
+ * bare call with no `select`. An earlier revision also looped over those four
+ * column names asserting each was absent; that loop sat AFTER the `toEqual`
+ * and could therefore never report, since any select containing one of them
+ * already failed above it. It was removed rather than reordered: `toEqual` is
+ * strictly stronger, so the loop had nothing to add in either position.
+ *
+ * The two `toBeDefined` lines are for the failure message only — see the file
+ * header.
  */
 function expectProjection(
   args: { select?: Record<string, boolean> } | undefined,
@@ -103,11 +108,6 @@ function expectProjection(
     `${label}: no \`select\` — a bare Prisma call fetches every column`
   ).toBeDefined();
   expect(args?.select).toEqual(expected);
-
-  const selected = Object.keys(args?.select as Record<string, boolean>);
-  for (const tagged of TAGGED_POST_COLUMNS) {
-    expect(selected, `${label}: re-added the tagged column \`${tagged}\``).not.toContain(tagged);
-  }
 }
 
 describe('getEntityCollaborators — Post owner lookup is projected, not a full row', () => {
@@ -131,30 +131,13 @@ describe('getEntityCollaborators — Post owner lookup is projected, not a full 
     // guards against, and it is what shipped before. Asserting the exact key
     // set (rather than just "userId is present") means re-adding `metadata`,
     // `createdAt`, `publishedAt` or `detail` fails here too.
-    expect(args.select).toEqual({ userId: true });
-  });
-
-  it('does not select any of the Post columns that cost a decode per row', async () => {
-    await getEntityCollaborators({
-      entityId: POST_ID,
-      entityType: EntityType.Post,
-      userId: OWNER_ID,
-    });
-
-    const [args] = postFindUnique.mock.calls[0] as [{ select?: Record<string, boolean> }];
-
-    // Assert the projection EXISTS before asserting what is missing from it.
-    // Without this line the loop below is vacuous — an absent `select` means
-    // Prisma returns every column, yet `Object.keys(undefined ?? {})` is empty
-    // and every `not.toContain` passes. That is the shape this whole file is
-    // guarding against, so it has to be the first thing checked.
-    expect(args.select, 'a bare findUnique fetches every column').toBeDefined();
-
-    const selected = Object.keys(args.select as Record<string, boolean>);
-    // Json + DateTime columns on Post — each one is a decode per row.
-    for (const tagged of TAGGED_POST_COLUMNS) {
-      expect(selected).not.toContain(tagged);
-    }
+    //
+    // This went through the shared helper along with the other two `Post`
+    // narrowings when its former companion case — a separate `it` looping over
+    // the tagged column names — was deleted. That case asserted strictly less
+    // than this line does about every possible implementation, so it could not
+    // fail on any mutant this one survives.
+    expectProjection(args, { userId: true }, 'getEntityCollaborators');
   });
 
   it('still gates pending collaborators on the owner id it fetched', async () => {

--- a/src/server/services/__tests__/hot-path-select-narrowing.test.ts
+++ b/src/server/services/__tests__/hot-path-select-narrowing.test.ts
@@ -17,16 +17,28 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  * guards — they pass on both sides of the narrowing by design, and are not
  * counted as regression coverage.
  *
- * 🔴 Every shape assertion pins the projection's EXACT key set with `toEqual`,
- * never "does not contain <column>". That distinction is the whole reason this
- * file looks the way it does: an unnarrowed `findUnique` has no `select` at
- * all, and `Object.keys(undefined ?? {})` is empty, so an absence-check passes
- * on precisely the shape being rejected. `toEqual` has no such hole — it fails
- * on `undefined` by itself — so it is the only shape assertion here, and there
- * are no absence-checks left to be vacuous. The `toBeDefined` line inside
- * `expectProjection` survives for its FAILURE MESSAGE, not for coverage: it
- * names the real defect ("a bare Prisma call fetches every column") instead of
- * leaving a bare `undefined` mismatch for the reader to decode.
+ * 🔴 Wherever the thing under test is a Prisma call ARGUMENT, the shape is
+ * pinned by its EXACT key set with `toEqual`, never "does not contain
+ * <column>". That distinction is the whole reason those assertions look the way
+ * they do: an unnarrowed `findUnique` has no `select` at all, and
+ * `Object.keys(undefined ?? {})` is empty, so an absence-check passes on
+ * precisely the shape being rejected. `toEqual` has no such hole — it fails on
+ * `undefined` by itself. The two `toBeDefined` lines inside `expectProjection`
+ * survive for their FAILURE MESSAGE, not for coverage: they name the real
+ * defect ("a bare Prisma call fetches every column") instead of leaving a bare
+ * `undefined` mismatch for the reader to decode.
+ *
+ * The `getReactionsSelect` cases are the deliberate exception, and they do use
+ * targeted presence/absence checks. That selector is a module-level object
+ * literal rather than a call argument, so it has no "no `select` key at all"
+ * shape for an absence-check to pass vacuously on. Its `user` projection is
+ * still pinned by exact key set with `toEqual`, and the `not.toHaveProperty`
+ * trio beside it is reachable rather than vacuous: deleting `user.select` does
+ * not quietly satisfy it, it fails it with `TypeError: Cannot convert undefined
+ * or null to object`, and re-adding `profilePicture` fails it by name. The two
+ * `toHaveProperty(…, true)` reaction-field checks are presence checks on the
+ * top-level selector; like the behavioural cases above they hold on both sides
+ * of the narrowing and are not counted as regression coverage.
  *
  * The remaining narrowed path — `hasSystemPosts` in `getAllImages` — is pinned
  * in the sibling file `hot-path-select-narrowing.image.test.ts`. It lives apart
@@ -89,10 +101,14 @@ const TARGET_USER_ID = 404;
  * the `Post` columns that cost a client-side decode per row — `metadata`,
  * `createdAt`, `updatedAt`, `publishedAt` — fails it, as does dropping to a
  * bare call with no `select`. An earlier revision also looped over those four
- * column names asserting each was absent; that loop sat AFTER the `toEqual`
- * and could therefore never report, since any select containing one of them
- * already failed above it. It was removed rather than reordered: `toEqual` is
- * strictly stronger, so the loop had nothing to add in either position.
+ * column names asserting each was absent. Given a FIXED `expected`, that loop
+ * was redundant: it sat AFTER the `toEqual`, and any select containing one of
+ * those columns had already failed there. It was not redundant in every
+ * scenario, though — it also went red when `expected` was widened ALONGSIDE the
+ * source (the ordinary "developer updates the failing expectation" edit),
+ * naming the re-added column, and a `toEqual` against a widened `expected` by
+ * construction cannot catch that. Removing the loop accepts the loss of that
+ * narrow ratchet against a test-file edit.
  *
  * The two `toBeDefined` lines are for the failure message only — see the file
  * header.
@@ -134,9 +150,10 @@ describe('getEntityCollaborators — Post owner lookup is projected, not a full 
     //
     // This went through the shared helper along with the other two `Post`
     // narrowings when its former companion case — a separate `it` looping over
-    // the tagged column names — was deleted. That case asserted strictly less
-    // than this line does about every possible implementation, so it could not
-    // fail on any mutant this one survives.
+    // the tagged column names — was deleted. Against a fixed `expected` that
+    // case asserted less than this line does, so it could not fail on a SOURCE
+    // mutant this one survives; the one edit it did still catch is described on
+    // `expectProjection`.
     expectProjection(args, { userId: true }, 'getEntityCollaborators');
   });
 

--- a/src/server/services/entity-collaborator.service.ts
+++ b/src/server/services/entity-collaborator.service.ts
@@ -74,7 +74,10 @@ export const upsertEntityCollaborator = async ({
     throw throwBadRequestError('Only posts are currently supported for entity collaborators');
   }
 
-  const entity = await dbRead.post.findUnique({ where: { id: entityId } });
+  const entity = await dbRead.post.findUnique({
+    where: { id: entityId },
+    select: { userId: true },
+  });
   if (!entity) {
     throw throwBadRequestError('Entity not found');
   }
@@ -161,7 +164,14 @@ export const getEntityCollaborators = async ({
 
   switch (entityType) {
     case EntityType.Post:
-      const entity = await dbRead.post.findUnique({ where: { id: entityId } });
+      // Only the owner id is consulted below (the pending/rejected visibility
+      // checks). A bare `findUnique` fetched every Post column, which on this
+      // read path meant three `new Date()` and a `JSON.parse` of `metadata`
+      // per call, all discarded.
+      const entity = await dbRead.post.findUnique({
+        where: { id: entityId },
+        select: { userId: true },
+      });
       if (!entity) {
         return [];
       }
@@ -214,7 +224,10 @@ export const removeEntityCollaborator = async ({
     throw throwBadRequestError('Only posts are currently supported for entity collaborators');
   }
 
-  const entity = await dbRead.post.findUnique({ where: { id: entityId } });
+  const entity = await dbRead.post.findUnique({
+    where: { id: entityId },
+    select: { userId: true },
+  });
 
   if (!entity) {
     throw throwBadRequestError('Entity not found');

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -1956,9 +1956,15 @@ export const getAllImages = async (
     const prioritizseIsSystemUser = prioritizedUserIds.length === 1 && prioritizedUserIds[0] === -1;
 
     // Confirm system user has posts:
+    // Existence check only — `select: { id }` keeps this from decoding the
+    // whole Post row (three DateTimes plus the `metadata` Json) to answer a
+    // boolean.
     const hasSystemPosts =
       prioritizseIsSystemUser && modelVersionId
-        ? await dbRead.post.findFirst({ where: { userId: -1, modelVersionId } })
+        ? await dbRead.post.findFirst({
+            where: { userId: -1, modelVersionId },
+            select: { id: true },
+          })
         : false;
 
     if (prioritizseIsSystemUser && !hasSystemPosts)


### PR DESCRIPTION
## Why

Prisma Client walks the engine response **in JS, on the main thread**, and converts every tagged value per row: `DateTime` → `new Date`, `Json` → `JSON.parse`, `Decimal` → `new Decimal`, `BigInt`, `Bytes` → `Buffer.from` (plus a `JSON.parse` of the whole engine response).

So a column that a query selects but no consumer reads is **not** a free ride on a round-trip that was happening anyway — it is an allocation per row per request. Narrowing `select` is a direct main-thread CPU reduction with no architecture change and no behaviour change.

I ranked candidate read paths by request volume × rows-per-call × wasted tagged columns, then traced every field to its consumers before removing it. Most of the hot paths turned out to be **already narrow** (the big feed queries are raw SQL + Redis, and their satellite Prisma calls select Int/enum only). These three are what was left.

## What changed

### 1. Comment reactions no longer hydrate a whole user + profile picture

`getReactionsSelect` selected `simpleUserSelect` for the `user` on every comment reaction. The renderer reads **two fields**:

- `ReactionPicker` → `reaction.user.username` (the "who reacted" tooltip, and the "have I reacted" check)
- its three callers → `r.user.id`

Everything else was fetched and dropped. `simpleUserSelect` pulls `deletedAt` (a `DateTime`) and the entire **`profilePicture` Image relation**, whose `metadata` is a non-null `Json`. Both of those costs are **conditional**, and an earlier revision of this description overstated them as unconditional — the corrected version:

- **An extra query, per call, whenever at least one reactor in the batch has a profile picture.** `profilePicture` is a relation and the schema's generator block enables only `previewFeatures = ["metrics"]` — no `relationJoins` — so Prisma has no join strategy available and resolves it with a second round-trip rather than a widened one. When the collected FK set is empty it skips that child query entirely. Measured on a minimal mirror of this shape (`CommentReaction → User → Image` via a nullable FK), Prisma 6.13.0, SQL captured via `$on('query')`, on SQLite and again on PostgreSQL 16:

  | reactors in the batch with a profile picture | `Image` SELECTs |
  |---|---|
  | 0 of 5 | **0** |
  | 1 of 5 | 1 — `WHERE "Image"."id" IN ($1)` |
  | 5 of 5 | 1 — `WHERE "Image"."id" IN ($1..$5)` |

  So it is one query per call, not per row, and only when the batch has at least one picture to fetch. This is plausibly the larger of the two costs.

- **A decode, per row, only where the value is non-null.** `User.deletedAt` is `DateTime?` and `User.profilePictureId` is `Int?`, so a live reactor with no profile picture paid neither. The cost landed as a `new Date()` per *deleted* reactor and a `JSON.parse` of the Image `metadata` per reactor who *has* a picture (that column is non-null `Json`, so it is always parsed once its row is fetched at all).

Narrowed to `{ id: true, username: true }`.

The deleted-user case is unaffected: `deleteUser` nulls `username`, and the renderer already falls back on `username ?? '<deleted user>'` — it reads the null, not the timestamp. Notably the three optimistic-update sites that hand-build a `ReactionDetails` were **already** passing `profilePicture: null` with a comment saying it wasn't needed; they now simply match the select.

This selector feeds both `comment.getAll` (the reactions arrive as `initialData`) and `comment.getReactions`, so the shapes stay identical on both sides of the hydration boundary.

### 2. Three full-row `Post` fetches for an ownership check

`entity-collaborator.service.ts` did `dbRead.post.findUnique({ where: { id } })` — no `select` — in `upsertEntityCollaborator`, `getEntityCollaborators` and `removeEntityCollaborator`, and read exactly one field off the result: `userId`. A full `Post` row is three DateTimes plus a `metadata` `Json`, plus the `title`/`detail` text. Narrowed to `select: { userId: true }`.

`getEntityCollaborators` is the one on a read path; the other two are the same defect in the same file and were fixed together rather than left to regrow.

### 3. A full `Post` row fetched to answer a boolean

`getAllImages` did `dbRead.post.findFirst({ where: { userId: -1, modelVersionId } })` and used the result only as a truthiness check (`hasSystemPosts`). Narrowed to `select: { id: true }`.

## Safety

A field that exists on a returned object can be read anywhere, so every dropped field was grepped across the repo — including client components and the `select`-derived types (`ReactionDetails`, `CommentGetReactions`) — before removal. The only reads of `reaction.user.*` anywhere are `.id` and `.username`. Nothing reads `deletedAt`, `image` or `profilePicture` off a reaction.

The only response-shape change is that reaction `user` object. Paths 2 and 3 change no response shape at all — the narrowed rows never leave their functions.

🔴 **That one response-shape change is reachable by third-party OAuth clients, and that is an accepted risk rather than a non-issue.** `comment.getAll`, `comment.getById` and `comment.getReactions` are `.meta({ requiredScope: TokenScope.MediaRead })`, and `MediaRead` is a grantable scope in both the `ReadOnly` and `Creator` presets — so an external app holding a user token can observe the object going from `{ id, username, deletedAt, image, profilePicture }` to `{ id, username }`. Concretely: an app rendering reactor avatars off `user.image` gets `undefined` and shows no avatar. The request still succeeds; this is a degraded render, not a server error. There is no compile-time contract with any external consumer to check against (nothing under `packages/` imports or re-exports `AppRouter`), and nothing in this repo is evidence about what third-party clients actually field. My read is that it is worth taking — the fields were fetched for an avatar this codebase never renders on a reaction, and re-adding a narrower `profilePicture` projection later is a one-line change — but that is a reviewer's call to make with the fact in front of them.

## Tests

Two files pin the projected shapes, and pair each shape assertion with a **behavioural** case so the guard cannot pass while the logic reading the surviving fields is broken:

- `src/server/services/__tests__/hot-path-select-narrowing.test.ts` — the three `entity-collaborator.service` owner lookups and the reaction selector
- `src/server/services/__tests__/hot-path-select-narrowing.image.test.ts` — the `hasSystemPosts` existence check (its own file because importing `image.service` needs an env/redis/submodule mock block and `vi.mock` is file-scoped)

**12 tests. Red at base, green at HEAD: 6 fail with the three source files reverted to `a9e9ddf533`, all 12 pass at HEAD** (measured in one tree, swapping only the source files). The 6 red are the shape assertions — one per narrowed call site, plus two on the reaction selector:

| Red at base | |
|---|---|
| `getEntityCollaborators › asks Postgres for ONLY the owner id` | `removeEntityCollaborator › asks Postgres for ONLY the owner id` |
| `upsertEntityCollaborator › asks Postgres for ONLY the owner id` | `getAllImages hasSystemPosts › projects the existence check…` |
| `getReactionsSelect › selects exactly the two user fields the renderer reads` | `getReactionsSelect › does not pull the profilePicture relation` |

The other 6 pass on both sides by design — they are behavioural **invariant guards** (owner-vs-stranger authorization on upsert and remove, pending-collaborator gating, the missing-post short-circuit, the surviving reaction fields, the `where` predicate) and are not counted as regression coverage.

Every shape assertion **on a Prisma call argument** pins the projection's **exact key set** with `toEqual`. It is deliberately never spelled as "does not contain `metadata`": an unnarrowed call has no `select` key at all, `Object.keys(undefined ?? {})` is empty, and an absence-check therefore passes on precisely the shape being rejected. `toEqual` fails on `undefined` by itself. The `getReactionsSelect` assertions are the exception, and they do use targeted presence/absence checks: that selector is a module-level object literal, not a call argument, so it has no "no `select` key at all" shape to pass vacuously on. Alongside its exact-key-set `toEqual`, the `not.toHaveProperty` trio there is reachable rather than vacuous — deleting `user.select` fails it with `TypeError: Cannot convert undefined or null to object` instead of passing it.

**Mutation matrix** — 14 mutants, each applied alone. Twelve kill exactly one test, by that test's own labelled assertion; the two rows marked **both** kill a pair, unavoidably, for the reason stated in the row.

| Mutation | Test that failed | Failure |
|---|---|---|
| `getEntityCollaborators` → bare `findUnique` | `getEntityCollaborators › asks Postgres for ONLY the owner id` | ``getEntityCollaborators: no `select` — a bare Prisma call fetches every column`` |
| `upsertEntityCollaborator` → bare `findUnique` | `upsertEntityCollaborator › asks Postgres for ONLY the owner id` | ``upsertEntityCollaborator: no `select` — a bare Prisma call fetches every column`` |
| `removeEntityCollaborator` → bare `findUnique` | `removeEntityCollaborator › asks Postgres for ONLY the owner id` | ``removeEntityCollaborator: no `select` — a bare Prisma call fetches every column`` |
| `hasSystemPosts` → bare `findFirst` | `getAllImages hasSystemPosts › projects the existence check…` | ``a bare findFirst fetches every Post column`` |
| `where: { userId: -1 }` → `-2` | `getAllImages hasSystemPosts › still asks the question it was asking` | `expected { userId: -2, … } to deeply equal { userId: -1, … }` |
| the `hasSystemPosts` branch made unreachable | **both** `getAllImages hasSystemPosts` cases | `getAllImages did not reach the hasSystemPosts check` — the harness positive control, which both cases run before asserting anything, so removing the call necessarily fails both |
| upsert owner check disabled | `upsertEntityCollaborator › still refuses a non-owner…` | `promise resolved "{ id: 1 }" instead of rejecting` |
| remove owner check disabled | `removeEntityCollaborator › still refuses a non-owner…` | `promise resolved "true" instead of rejecting` |
| `select: { id: true }` → `{ metadata: true }` | `getAllImages hasSystemPosts › projects the existence check…` | `expected { metadata: true } to deeply equal { id: true }` |
| `{ userId }` → `{ userId, metadata }`, at each of the 3 sites | that site's `asks Postgres for ONLY the owner id` | `expected { userId: true, metadata: true } to deeply equal { userId: true }` |
| `user.select` + `email: true` | `getReactionsSelect › selects exactly the two user fields…` | `expected { id: true, username: true, …(1) } to deeply equal { id: true, username: true }` |
| `user.select` + `profilePicture: true` | **both** `getReactionsSelect` shape cases | `expected { id: true, username: true, …(1) } to not have property "profilePicture"`, plus the exact-key-set `toEqual` beside it — any key added to `user.select` fails that too, so this assertion cannot be killed on its own |

Coverage of the 12 tests: those 14 mutants target **9 distinct tests**. The three with no mutant — `getEntityCollaborators › still gates pending collaborators…`, `getEntityCollaborators › returns [] when the post is missing…` and `getReactionsSelect › keeps the reaction fields…` — are invariant guards that hold on both sides of the narrowing, and are not counted as regression coverage above.

The shape and behavioural checks are independent: the `where`-clause mutation killed the behavioural test while the shape test stayed green.

## Gates

Measured on `1cad65e484`, all in one tree.

| Gate | Result |
|---|---|
| `pnpm typecheck` | **0 errors** in 66s (heap cap 8192 MB) |
| typecheck of the **test files themselves** | **0 new errors.** 🔴 `tsconfig.json` excludes `src/**/__tests__/**`, so `pnpm typecheck` does not see either test file in this PR — its "0 errors" says nothing about them. Re-run under a scoped config (`include` = the two test files + `src/**/*.d.ts`; without the `.d.ts` glob you get ~336 phantom ambient errors): 1 error, in `src/utils/signals/useSignalsWorker.ts`, a file this PR does not touch — **byte-identical count at `4df72dbb53`**, so the delta is 0. Instrument validated: planting `const x: number = 'not a number'` in the test file made the scoped run report it. |
| `pnpm test:unit:run` | 921 files, **14146 passed, 15 failed, 1 skipped**. All 15 are in `hiddenBlocks.test.ts` and `recent-source-images.store.test.ts` — neither in this PR's diff — and all are `localStorage is not available because --localstorage-file was not provided` on Node 26. Reproduced identically running those two files alone. |
| the two guard suites | 12 passed, 0 failed |
| `eslint` (all 8 changed files, `-f json`, 8 files confirmed processed) | 3 errors / 25 warnings, **all in `image.service.ts` and all pre-existing**: same three rules at base, the two line numbers shifted only by the 6 comment lines added (`prefer-const` 3705→3711, `no-module-scope-cache` 5568→5574). Base measured in the **same** tree by swapping the file, never across checkouts. The selector and both test files are 0/0. |
| `prettier --check` | clean on all three changed files. `pnpm prettier:check` only inspects *uncommitted* files and reports "no uncommitted .ts/.tsx files" on a committed branch — a zero about the file list, not the code — so the files were named explicitly, with a deliberately misformatted probe in the same invocation confirming the check can go red. |

## Not measured

This is a mechanism-level argument plus a volume ranking. I have **not** measured a CPU delta in a running environment — the per-row saving is real and arithmetic, but its share of total CPU is unquantified here. Worth watching after it ships rather than claiming a number now.

## Follow-ups deliberately left out

- Six `isOwnerOrModerator` middlewares (`image`, `comment`, `commentV2`, `answer`, `question`, `collection` routers) repeat the same full-row-for-`userId` pattern. Correct to fix, but they sit on mutations measuring well under 3 req/s combined, so the CPU case is not there — hygiene, not a perf win, and better as its own PR.
- Two paths do `select: { settings: true }` on `User` (a large accumulating `Json` blob) purely to read one boolean. Eliminating those parses needs a raw projection (`settings->>'…'`) rather than a `select` narrowing, which is a bigger change than this PR's premise.
