### PR TITLE
perf(db): port the hottest per-user read lookups to Kysely over pg

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -304,9 +304,12 @@ jobs:
     # tests with no browser, no database and no Next module graph — ~15s locally.
     #
     # DB-backed tiers self-skip: `@civitai/db-queries` sources DATABASE_URL from the root
-    # `.env`, which does not exist on a runner, so its 4 DB-backed tests across two files
-    # (3 in tag.db.explain, 1 in enum-array-parsers.explain) report as skipped. They are
-    # visible as skips in the summary rather than as a silent absence.
+    # `.env`, which does not exist on a runner, so its 8 DB-backed tests across three files
+    # (6 in tag.db.explain, 1 in model.db.explain, 1 in enum-array-parsers.explain) report
+    # as skipped. They are visible as skips in the summary rather than as a silent absence.
+    # Those EXPLAIN checks therefore have NEVER run in CI — they are laptop-only evidence.
+    # The same is true of the 16-case Kysely/Prisma parity suite, which lives in the app's
+    # `unit` project and self-skips without KYSELY_PARITY_DATABASE_URL.
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4

--- a/packages/civitai-db-queries/README.md
+++ b/packages/civitai-db-queries/README.md
@@ -10,8 +10,16 @@ See [`docs/db-queries-kysely-plan.md`](../../docs/db-queries-kysely-plan.md) for
 
 - `src/infra/helpers.ts` — shared query helpers (`jsonArrayFrom`/`jsonObjectFrom` reads, `toJson` writes).
 - `src/<domain>.db.ts` — one query module per domain, exported at the subpath `@civitai/db-queries/<domain>`.
-  Only the `tag.db.ts` **exemplar** exists today; domain modules are (re)ported on demand, per cutover, from
-  current `main` (see the migration plan) rather than kept ahead of their consumers where they'd drift.
+  Domain modules are (re)ported on demand, per cutover, from current `main` (see the migration plan) rather
+  than kept ahead of their consumers where they'd drift. Today: `tag.db.ts` (the original **exemplar**, plus
+  the votable-tag vote lookups) and `model.db.ts`.
+
+  The first ported **hot read paths** are the per-user vote lookups behind the votable-tag endpoint
+  (`listImageTagVotes` / `listImageTagVotesMany` / `listModelTagVotes`) and the per-visible-set engagement
+  membership read (`listModelEngagements`). These went to Kysely specifically to keep the highest-volume
+  read statements off the Prisma query engine, whose in-process CPU cost scales with call volume. Their
+  behaviour parity with the Prisma originals is pinned against a real database by
+  `<civitai>/src/server/db/__tests__/kysely-prisma-parity.test.ts` — see Testing below.
 
 ## Client access — executor injection
 
@@ -202,6 +210,19 @@ the root `.env` `DATABASE_URL` locally); the suite `describe.skipIf(!h.hasDb)`-s
 Wrap it and destroy the client in `afterAll`. See [`src/tag.db.explain.test.ts`](src/tag.db.explain.test.ts).
 Stricter plan-regression assertions (no seq-scan on a hot path) need a prod-like dataset — dev-DB planner
 choices vary with table size — so keep those against real data, not this suite.
+
+### 3. Prisma-vs-Kysely behaviour parity (for a query ported off Prisma)
+
+Tiers 1 and 2 prove what SQL runs and that it plans. Neither proves the **caller sees the same thing it saw
+before**, which is the whole risk of porting a live read path. For that, run BOTH implementations against the
+SAME rows in the SAME database and deep-compare the results, rather than asserting the Kysely result against
+a hand-written expectation (which only re-states what the new code does). This lives in the consuming app,
+since the package itself must stay Prisma-free: `<civitai>/src/server/db/__tests__/kysely-prisma-parity.test.ts`,
+with its schema fixture alongside. Cover the empty result, an empty input array (the `IN ()` guard), and
+cross-user/cross-entity isolation — a dropped predicate shows up as extra rows, not as an empty diff.
+
+It is opt-in via `KYSELY_PARITY_DATABASE_URL` and deliberately does NOT fall back to `DATABASE_URL`: it
+writes fixtures, so it needs a throwaway database. The test header has the one-line docker command.
 
 ## Example
 

--- a/packages/civitai-db-queries/package.json
+++ b/packages/civitai-db-queries/package.json
@@ -7,6 +7,7 @@
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./model": "./src/model.db.ts",
     "./tag": "./src/tag.db.ts"
   },
   "scripts": {

--- a/packages/civitai-db-queries/package.json
+++ b/packages/civitai-db-queries/package.json
@@ -9,7 +9,7 @@
     ".": "./src/index.ts",
     "./model": "./src/model.db.ts",
     "./tag": "./src/tag.db.ts",
-    "./test-harness": "./src/test/harness.ts"
+    "./test-harness": "./src/test/compile-harness.ts"
   },
   "scripts": {
     "test": "vitest run",

--- a/packages/civitai-db-queries/package.json
+++ b/packages/civitai-db-queries/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./model": "./src/model.db.ts",
-    "./tag": "./src/tag.db.ts"
+    "./tag": "./src/tag.db.ts",
+    "./test-harness": "./src/test/harness.ts"
   },
   "scripts": {
     "test": "vitest run",

--- a/packages/civitai-db-queries/src/model.db.explain.test.ts
+++ b/packages/civitai-db-queries/src/model.db.explain.test.ts
@@ -1,0 +1,17 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import { explainHarness } from './test/harness';
+import { listModelEngagements } from './model.db';
+
+const h = explainHarness();
+
+afterAll(() => h.destroy());
+
+// DB-backed tier: EXPLAIN (no ANALYZE) parses + plans against the live schema without executing, so a
+// column, type or enum that doesn't resolve fails here even though the compile test passed. Skips when
+// no DB is reachable.
+describe.skipIf(!h.hasDb)('model.db queries EXPLAIN against the real schema', () => {
+  it('listModelEngagements plans', async () => {
+    await listModelEngagements(h.db, { userId: 1, modelIds: [1, 2] });
+    expect(await h.explainLast()).toBeTruthy();
+  });
+});

--- a/packages/civitai-db-queries/src/model.db.test.ts
+++ b/packages/civitai-db-queries/src/model.db.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { listModelEngagements } from './model.db';
+import { compileHarness } from './test/harness';
+
+const harness = compileHarness();
+
+beforeEach(() => {
+  harness.queries.length = 0;
+});
+
+// Pins the EXACT SQL because the port's premise is that the statement is unchanged. Behaviour parity
+// against the Prisma original is covered against a real database by
+// src/server/db/__tests__/kysely-prisma-parity.test.ts.
+describe('model.db', () => {
+  it('listModelEngagements filters by userId AND the model id list, selecting modelId + type', async () => {
+    await listModelEngagements(harness.db, { userId: 7, modelIds: [1, 2, 3] });
+    const { sql, parameters } = harness.lastQuery();
+    expect(sql).toBe(
+      'select "modelId", "type" from "ModelEngagement" ' +
+        'where "userId" = $1 and "modelId" in ($2, $3, $4)'
+    );
+    expect(parameters).toEqual([7, 1, 2, 3]);
+    expect(sql).not.toContain('in ()');
+    expect(sql).not.toContain('order by'); // the source query had none
+  });
+
+  it('listModelEngagements short-circuits an empty id list without touching the DB', async () => {
+    const rows = await listModelEngagements(harness.db, { userId: 7, modelIds: [] });
+    expect(rows).toEqual([]);
+    expect(harness.queries).toHaveLength(0); // `in ([])` would compile to the syntax error `IN ()`
+  });
+
+  it('listModelEngagements keeps the userId predicate for a single-id lookup', async () => {
+    // The narrowest input a caller can pass; dropping userId here would return every user's
+    // engagement with that model.
+    await listModelEngagements(harness.db, { userId: 7, modelIds: [1] });
+    const { sql, parameters } = harness.lastQuery();
+    expect(sql).toContain('"userId" = $1');
+    expect(parameters).toEqual([7, 1]);
+  });
+});

--- a/packages/civitai-db-queries/src/model.db.ts
+++ b/packages/civitai-db-queries/src/model.db.ts
@@ -1,0 +1,31 @@
+import type { Kysely } from 'kysely';
+import type { DB } from '@civitai/db-schema/kysely';
+
+/**
+ * A user's engagements with a bounded set of models — the membership read behind the
+ * per-visible-set engagement lookup, and one of the highest-volume statements the app issues.
+ *
+ * `type` is a SCALAR Postgres enum (`ModelEngagementType`), which pg reads back as plain text and
+ * Kysely types as the enum union — the same string Prisma returned. It is NOT an enum ARRAY, which
+ * is the shape that needs `registerEnumArrayTypeParsers` (a `SomeEnum[]` column has a dynamic oid
+ * and would otherwise arrive as the raw `{a,b}` literal). Both selected columns are int4/text with
+ * built-in pg parsers, so this query depends on no type-parser registration at all.
+ *
+ * No `orderBy`, matching the source query: the caller buckets rows by `type` into arrays it uses as
+ * sets, so row order is not observable.
+ */
+export async function listModelEngagements(
+  db: Kysely<DB>,
+  input: { userId: number; modelIds: number[] }
+) {
+  // Kysely compiles `in ([])` to the Postgres syntax error `IN ()`; Prisma returned []. The tRPC input
+  // schema bounds `modelIds` to 1..200, but this function is also reachable from server-side callers
+  // that don't go through it.
+  if (!input.modelIds.length) return [];
+  return db
+    .selectFrom('ModelEngagement')
+    .select(['modelId', 'type'])
+    .where('userId', '=', input.userId)
+    .where('modelId', 'in', input.modelIds)
+    .execute();
+}

--- a/packages/civitai-db-queries/src/tag.db.explain.test.ts
+++ b/packages/civitai-db-queries/src/tag.db.explain.test.ts
@@ -1,6 +1,13 @@
 import { afterAll, describe, expect, it } from 'vitest';
 import { explainHarness } from './test/harness';
-import { createTag, getTagById, upsertTagsByName } from './tag.db';
+import {
+  createTag,
+  getTagById,
+  listImageTagVotes,
+  listImageTagVotesMany,
+  listModelTagVotes,
+  upsertTagsByName,
+} from './tag.db';
 
 const h = explainHarness();
 
@@ -21,5 +28,20 @@ describe.skipIf(!h.hasDb)('tag.db queries EXPLAIN against the real schema', () =
   it('upsertTagsByName plans (batch insert + id lookup)', async () => {
     await upsertTagsByName(h.db, ['x', 'y'], ['Model']);
     expect((await h.explainAll()).length).toBeGreaterThan(0);
+  });
+
+  it('listImageTagVotes plans', async () => {
+    await listImageTagVotes(h.db, { imageId: 1, userId: 1 });
+    expect(await h.explainLast()).toBeTruthy();
+  });
+
+  it('listImageTagVotesMany plans', async () => {
+    await listImageTagVotesMany(h.db, { imageIds: [1, 2], userId: 1 });
+    expect(await h.explainLast()).toBeTruthy();
+  });
+
+  it('listModelTagVotes plans', async () => {
+    await listModelTagVotes(h.db, { modelId: 1, userId: 1 });
+    expect(await h.explainLast()).toBeTruthy();
   });
 });

--- a/packages/civitai-db-queries/src/tag.db.test.ts
+++ b/packages/civitai-db-queries/src/tag.db.test.ts
@@ -1,5 +1,14 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { createTag, deleteTag, getTagById, updateTag, upsertTagsByName } from './tag.db';
+import {
+  createTag,
+  deleteTag,
+  getTagById,
+  listImageTagVotes,
+  listImageTagVotesMany,
+  listModelTagVotes,
+  updateTag,
+  upsertTagsByName,
+} from './tag.db';
 import { compileHarness } from './test/harness';
 
 const harness = compileHarness();
@@ -73,5 +82,55 @@ describe('tag.db', () => {
     const ids = await upsertTagsByName(harness.db, [], ['Model']);
     expect(ids).toEqual([]);
     expect(harness.queries).toHaveLength(0);
+  });
+});
+
+// The votable-tag vote lookups. These pin the EXACT SQL because the whole point of the port is that
+// the statement is unchanged: a dropped `userId` predicate here would leak other users' votes, and
+// the compiled SQL is the cheapest place to catch it. Behaviour parity against the Prisma originals
+// is covered separately, against a real database, by
+// src/server/db/__tests__/kysely-prisma-parity.test.ts.
+describe('tag.db votable-tag vote lookups', () => {
+  it('listImageTagVotes filters by BOTH imageId and userId, selecting only tagId + vote', async () => {
+    await listImageTagVotes(harness.db, { imageId: 42, userId: 7 });
+    const { sql, parameters } = harness.lastQuery();
+    expect(sql).toBe(
+      'select "tagId", "vote" from "TagsOnImageVote" where "imageId" = $1 and "userId" = $2'
+    );
+    expect(parameters).toEqual([42, 7]);
+    expect(sql).not.toContain('order by'); // the source query had none; adding one changes the plan
+  });
+
+  it('listModelTagVotes filters by BOTH modelId and userId, selecting only tagId + vote', async () => {
+    await listModelTagVotes(harness.db, { modelId: 42, userId: 7 });
+    const { sql, parameters } = harness.lastQuery();
+    expect(sql).toBe(
+      'select "tagId", "vote" from "TagsOnModelsVote" where "modelId" = $1 and "userId" = $2'
+    );
+    expect(parameters).toEqual([42, 7]);
+  });
+
+  it('listImageTagVotesMany expands the id list and keeps the userId predicate', async () => {
+    await listImageTagVotesMany(harness.db, { imageIds: [1, 2, 3], userId: 7 });
+    const { sql, parameters } = harness.lastQuery();
+    expect(sql).toBe(
+      'select "tagId", "vote" from "TagsOnImageVote" ' +
+        'where "imageId" in ($1, $2, $3) and "userId" = $4'
+    );
+    expect(parameters).toEqual([1, 2, 3, 7]);
+    expect(sql).not.toContain('in ()');
+  });
+
+  it('listImageTagVotesMany short-circuits an empty id list without touching the DB', async () => {
+    const rows = await listImageTagVotesMany(harness.db, { imageIds: [], userId: 7 });
+    expect(rows).toEqual([]);
+    expect(harness.queries).toHaveLength(0); // `in ([])` would compile to the syntax error `IN ()`
+  });
+
+  it('listImageTagVotesMany does not select imageId — the caller keys votes by tagId alone', async () => {
+    // Preserved from the source query verbatim. Widening the select would change what the
+    // votable-tag endpoint returns, which is a behaviour change, not a fix.
+    await listImageTagVotesMany(harness.db, { imageIds: [1], userId: 7 });
+    expect(harness.lastQuery().sql).not.toContain('"imageId",');
   });
 });

--- a/packages/civitai-db-queries/src/tag.db.ts
+++ b/packages/civitai-db-queries/src/tag.db.ts
@@ -58,3 +58,58 @@ export function updateTag(db: Kysely<DB>, input: Updateable<DB['Tag']> & { id: n
 export function deleteTag(db: Kysely<DB>, id: number) {
   return db.deleteFrom('Tag').where('id', '=', id).execute();
 }
+
+// --- Votable-tag vote lookups -------------------------------------------------------------------
+//
+// The per-user vote overlay on the votable-tag read path. The tag rows themselves come from a cache;
+// only the caller's own votes are read per request, which makes these among the highest-volume
+// statements the app issues. They select two int4 columns off a hash-indexed key and are read-only
+// with no transaction, so they port to Kysely 1:1.
+//
+// Deliberately NOT ordered: the source queries had no `orderBy`, and each table's primary key makes
+// (tag, entity, user) unique, so callers resolve a vote by `find(v => v.tagId === tag.id)` — at most
+// one row can match and row order is not observable. Adding an ORDER BY would change the plan, not
+// the semantics.
+
+/** One image's votes for the given user. */
+export function listImageTagVotes(db: Kysely<DB>, input: { imageId: number; userId: number }) {
+  return db
+    .selectFrom('TagsOnImageVote')
+    .select(['tagId', 'vote'])
+    .where('imageId', '=', input.imageId)
+    .where('userId', '=', input.userId)
+    .execute();
+}
+
+/**
+ * Bulk variant across several images.
+ *
+ * Returns `tagId`/`vote` only — NOT `imageId` — matching the source query. The caller folds these
+ * into a flat tag list keyed by tagId alone, so a vote is applied per tag rather than per
+ * (image, tag) pair. That is existing behaviour and is preserved here verbatim; widening the select
+ * would change what the endpoint returns.
+ */
+export async function listImageTagVotesMany(
+  db: Kysely<DB>,
+  input: { imageIds: number[]; userId: number }
+) {
+  // Kysely compiles `in ([])` to the Postgres syntax error `IN ()`; Prisma returned []. The votable-tag
+  // input schema accepts an empty `ids` array, so this guard is reachable from a real request.
+  if (!input.imageIds.length) return [];
+  return db
+    .selectFrom('TagsOnImageVote')
+    .select(['tagId', 'vote'])
+    .where('imageId', 'in', input.imageIds)
+    .where('userId', '=', input.userId)
+    .execute();
+}
+
+/** One model's votes for the given user. */
+export function listModelTagVotes(db: Kysely<DB>, input: { modelId: number; userId: number }) {
+  return db
+    .selectFrom('TagsOnModelsVote')
+    .select(['tagId', 'vote'])
+    .where('modelId', '=', input.modelId)
+    .where('userId', '=', input.userId)
+    .execute();
+}

--- a/packages/civitai-db-queries/src/test/compile-harness.ts
+++ b/packages/civitai-db-queries/src/test/compile-harness.ts
@@ -1,0 +1,57 @@
+import {
+  type CompiledQuery,
+  DummyDriver,
+  Kysely,
+  PostgresAdapter,
+  PostgresIntrospector,
+  PostgresQueryCompiler,
+} from 'kysely';
+import type { DB } from '@civitai/db-schema/kysely';
+import { UPDATED_AT_TABLES } from '@civitai/db-schema/kysely/updated-at-tables';
+import { updatedAtPlugin } from '../infra/updated-at-plugin';
+
+// This module is the ONLY thing the package's public `./test-harness` subpath exports, and it is
+// deliberately kept in its own file rather than living beside `explainHarness`/`testDbUrl` in
+// `harness.ts`. Those two resolve a connection string, falling back to `process.env.DATABASE_URL` —
+// a REAL environment's writer in any checkout that has one — so exporting them across a package
+// boundary would let a non-test importer open a second pool against production by calling one
+// function. Nothing reachable from here touches a connection string or opens a socket; the parity
+// suite's refusal to fall back to `DATABASE_URL` is a property of the whole module graph it imports,
+// not just of its own code. Pinned by `harness-exports.test.ts`.
+
+// Query functions take a Kysely client as their first argument (executor injection). This harness builds
+// the client a test passes in — no global wiring.
+
+// An offline Kysely wired to DummyDriver: pass its `db` to a query function and the function's SQL COMPILES to
+// real Postgres SQL and `.execute()` resolves to an empty result WITHOUT a database (safe for writes). A `log`
+// hook captures each compiled query so a test can assert the exact SQL + parameters.
+//
+// The `@updatedAt` plugin is installed here exactly as the app installs it (kyselyDb.ts), so the compiled SQL a
+// test sees matches production: an UPDATE to an `@updatedAt` table auto-stamps `updatedAt` unless the write
+// opts out (self-reference `keepUpdatedAt`) or is raw `sql`. Ported writes therefore don't set `updatedAt` by
+// hand, and the tests assert the plugin-stamped result.
+export function compileHarness() {
+  const queries: CompiledQuery[] = [];
+
+  const db = new Kysely<DB>({
+    dialect: {
+      createAdapter: () => new PostgresAdapter(),
+      createDriver: () => new DummyDriver(),
+      createIntrospector: (kysely) => new PostgresIntrospector(kysely),
+      createQueryCompiler: () => new PostgresQueryCompiler(),
+    },
+    plugins: [updatedAtPlugin(UPDATED_AT_TABLES)],
+    log: (event) => {
+      if (event.level === 'query') queries.push(event.query);
+    },
+  });
+
+  return {
+    db,
+    // The most recently compiled query — `{ sql, parameters }`. A caller that must not miss a
+    // statement should read `queries` instead: a function may issue several, and reading only the
+    // last one is how a guard over this harness silently stopped seeing the earlier ones.
+    lastQuery: () => queries[queries.length - 1],
+    queries,
+  };
+}

--- a/packages/civitai-db-queries/src/test/compile-harness.ts
+++ b/packages/civitai-db-queries/src/test/compile-harness.ts
@@ -15,9 +15,16 @@ import { updatedAtPlugin } from '../infra/updated-at-plugin';
 // `harness.ts`. Those two resolve a connection string, falling back to `process.env.DATABASE_URL` —
 // a REAL environment's writer in any checkout that has one — so exporting them across a package
 // boundary would let a non-test importer open a second pool against production by calling one
-// function. Nothing reachable from here touches a connection string or opens a socket; the parity
-// suite's refusal to fall back to `DATABASE_URL` is a property of the whole module graph it imports,
-// not just of its own code. Pinned by `harness-exports.test.ts`.
+// function.
+//
+// `harness-exports.test.ts` pins that, and pins the IMPORT GRAPH as well as the export names: it
+// walks every import reachable from this file, asserts the resulting first-party files and
+// third-party packages against an exact ledger (`pg` is not in it), and scans each first-party file
+// for pool/connection-string tokens. So the parity suite's refusal to fall back to `DATABASE_URL`
+// is a checked property of what this module pulls in, not only of its own body — a
+// `process.env.DATABASE_URL` added to the function below fails that scan even though it changes no
+// export name and no subpath. Scope, exactly: first-party sources are read; `kysely` is ledgered by
+// name, its own sources are not scanned.
 
 // Query functions take a Kysely client as their first argument (executor injection). This harness builds
 // the client a test passes in — no global wiring.

--- a/packages/civitai-db-queries/src/test/harness-exports.test.ts
+++ b/packages/civitai-db-queries/src/test/harness-exports.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import * as publicSubpath from './compile-harness';
+import * as internal from './harness';
+
+/**
+ * What the package's public `./test-harness` subpath is allowed to expose.
+ *
+ * `explainHarness` and `testDbUrl` resolve a connection string and fall back to
+ * `process.env.DATABASE_URL` — a real environment's WRITER in any checkout that has one. The
+ * Kysely/Prisma parity suite deliberately refuses that fallback (it demands
+ * `KYSELY_PARITY_DATABASE_URL`, because it writes fixtures), and that refusal is only a real
+ * property if nothing else the suite imports can reach `DATABASE_URL` either. So the subpath
+ * exports the offline compile-only harness and nothing else: calling anything on it cannot open a
+ * pool.
+ *
+ * This is a SEAM guard — it pins the relationship between two files, which is why it asserts an
+ * exact ledger rather than "compileHarness is present". It fails if the surface GROWS (a
+ * DB-reaching helper is moved or re-exported into the public module) and if it SHRINKS (the
+ * harness is renamed and the parity suite's import silently starts resolving to something else).
+ */
+const PUBLIC_SUBPATH_EXPORTS = ['compileHarness'];
+
+// The helpers that must stay package-internal, asserted below to actually EXIST. Without this the
+// exclusion above is unfalsifiable: a test that lists what is absent passes just as well when the
+// excluded names were never real.
+const MUST_STAY_INTERNAL = ['explainHarness', 'testDbUrl'];
+
+const packageJson = JSON.parse(
+  readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), '../../package.json'), 'utf-8')
+) as { exports: Record<string, string> };
+
+describe('the ./test-harness subpath cannot reach DATABASE_URL', () => {
+  it('exports exactly the offline compile harness', () => {
+    expect(Object.keys(publicSubpath).sort()).toEqual(PUBLIC_SUBPATH_EXPORTS);
+  });
+
+  it('routes the subpath at that module, not at the DB-backed harness', () => {
+    expect(packageJson.exports['./test-harness']).toBe('./src/test/compile-harness.ts');
+  });
+
+  it('keeps the DB-reaching helpers internal — and they exist, so the exclusion is real', () => {
+    // Positive control on the exclusion: these are importable package-internally...
+    expect(Object.keys(internal).sort()).toEqual(
+      [...MUST_STAY_INTERNAL, ...PUBLIC_SUBPATH_EXPORTS].sort()
+    );
+    // ...and absent from the public module.
+    for (const name of MUST_STAY_INTERNAL) expect(Object.keys(publicSubpath)).not.toContain(name);
+  });
+});

--- a/packages/civitai-db-queries/src/test/harness-exports.test.ts
+++ b/packages/civitai-db-queries/src/test/harness-exports.test.ts
@@ -1,25 +1,34 @@
-import { readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import * as publicSubpath from './compile-harness';
 import * as internal from './harness';
 
 /**
- * What the package's public `./test-harness` subpath is allowed to expose.
+ * What the package's public `./test-harness` subpath is allowed to expose, and what it is allowed
+ * to IMPORT.
  *
  * `explainHarness` and `testDbUrl` resolve a connection string and fall back to
  * `process.env.DATABASE_URL` — a real environment's WRITER in any checkout that has one. The
  * Kysely/Prisma parity suite deliberately refuses that fallback (it demands
  * `KYSELY_PARITY_DATABASE_URL`, because it writes fixtures), and that refusal is only a real
  * property if nothing else the suite imports can reach `DATABASE_URL` either. So the subpath
- * exports the offline compile-only harness and nothing else: calling anything on it cannot open a
- * pool.
+ * exports the offline compile-only harness and nothing else.
  *
- * This is a SEAM guard — it pins the relationship between two files, which is why it asserts an
- * exact ledger rather than "compileHarness is present". It fails if the surface GROWS (a
- * DB-reaching helper is moved or re-exported into the public module) and if it SHRINKS (the
- * harness is renamed and the parity suite's import silently starts resolving to something else).
+ * "And nothing else" is two separate claims, and this file asserts both, because an export ledger
+ * on its own does not imply the second:
+ *
+ *   1. the EXPORT NAMES of the public module, and the package's whole `exports` map;
+ *   2. the IMPORT GRAPH reachable from the public module — an exact ledger of first-party files
+ *      plus third-party packages, and a scan of every first-party file in it for pool/connection
+ *      string tokens. Without (2), adding `process.env.DATABASE_URL` to the body of
+ *      `compileHarness` changes no export name and no subpath, so (1) alone stays green.
+ *
+ * The walk is a SUPERSET of what runs: it follows `import type` too, which TypeScript erases. That
+ * is deliberate — telling an erased import from a live one needs a real TS parse, and the coarser
+ * walk is the stricter guarantee. It is not a claim about third-party code: `kysely` is ledgered by
+ * name (so `pg` cannot slip into the graph) but its own sources are not scanned.
  */
 const PUBLIC_SUBPATH_EXPORTS = ['compileHarness'];
 
@@ -28,17 +37,189 @@ const PUBLIC_SUBPATH_EXPORTS = ['compileHarness'];
 // excluded names were never real.
 const MUST_STAY_INTERNAL = ['explainHarness', 'testDbUrl'];
 
-const packageJson = JSON.parse(
-  readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), '../../package.json'), 'utf-8')
-) as { exports: Record<string, string> };
+const here = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_DIR = resolve(here, '../..');
+const REPO_ROOT = resolve(PACKAGE_DIR, '../..');
+const rel = (absolute: string) => relative(REPO_ROOT, absolute).replace(/\\/g, '/');
+
+const COMPILE_HARNESS = resolve(here, 'compile-harness.ts');
+const DB_BACKED_HARNESS = resolve(here, 'harness.ts');
+
+const packageJson = JSON.parse(readFileSync(resolve(PACKAGE_DIR, 'package.json'), 'utf-8')) as {
+  exports: Record<string, string>;
+};
+
+// The package's whole `exports` map, not one entry of it. The previous version of this file
+// asserted `exports['./test-harness']` alone, which left the obvious hole open: adding a SECOND
+// subpath aimed at `./src/test/harness.ts` re-exposed `explainHarness` and `testDbUrl` across the
+// package boundary and every assertion still passed. Against the whole map that mutant now fails
+// here, and again in the reachability test at the bottom, which reads the map off disk.
+const PACKAGE_EXPORTS = {
+  '.': './src/index.ts',
+  './model': './src/model.db.ts',
+  './tag': './src/tag.db.ts',
+  './test-harness': './src/test/compile-harness.ts',
+};
+
+// Every first-party file reachable from `./src/test/compile-harness.ts`, repo-root-relative.
+const PUBLIC_GRAPH_FILES = [
+  'packages/civitai-db-queries/src/infra/updated-at-plugin.ts',
+  'packages/civitai-db-queries/src/test/compile-harness.ts',
+  'packages/civitai-db-schema/src/kysely/enums.ts',
+  'packages/civitai-db-schema/src/kysely/types.ts',
+  'packages/civitai-db-schema/src/kysely/updated-at-tables.ts',
+];
+
+// ...and every third-party package it reaches. `pg` being absent here is the point: the offline
+// harness compiles SQL with kysely's PostgresQueryCompiler and executes it against DummyDriver, so
+// no driver is involved.
+const PUBLIC_GRAPH_PACKAGES = ['kysely'];
+
+/**
+ * Source with comments blanked out, string and template literals kept.
+ *
+ * Necessary in both directions. The token scan below would otherwise fire on the docblocks that
+ * DESCRIBE the hazard — this file and `compile-harness.ts` both spell `DATABASE_URL` in prose — and
+ * the specifier scan would otherwise follow a commented-out import.
+ */
+function stripComments(source: string): string {
+  let out = '';
+  let i = 0;
+  while (i < source.length) {
+    const char = source[i];
+    const next = source[i + 1];
+    if (char === '/' && next === '/') {
+      while (i < source.length && source[i] !== '\n') i++;
+      continue;
+    }
+    if (char === '/' && next === '*') {
+      i += 2;
+      while (i < source.length && !(source[i] === '*' && source[i + 1] === '/')) i++;
+      i += 2;
+      continue;
+    }
+    if (char === '"' || char === "'" || char === '`') {
+      out += char;
+      i++;
+      while (i < source.length) {
+        if (source[i] === '\\') {
+          out += source[i] + (source[i + 1] ?? '');
+          i += 2;
+          continue;
+        }
+        out += source[i];
+        const closed = source[i] === char;
+        i++;
+        if (closed) break;
+      }
+      continue;
+    }
+    out += char;
+    i++;
+  }
+  return out;
+}
+
+// Module specifiers of one file. The `from` forms are anchored at the start of a line and may not
+// cross a `;` or `=`, so a `from "Table"` inside a multi-line `sql` template is not mistaken for an
+// import. Under-collection cannot pass silently: the graph is asserted as an EXACT ledger, so a
+// missed edge shrinks the set and fails.
+function moduleSpecifiers(source: string): string[] {
+  const code = stripComments(source);
+  const found: string[] = [];
+  const patterns = [
+    /^(?:import|export)\s[^;=]*?\bfrom\s*['"]([^'"]+)['"]/gm,
+    /^import\s*['"]([^'"]+)['"]/gm,
+    /\b(?:import|require)\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
+  ];
+  for (const pattern of patterns) for (const match of code.matchAll(pattern)) found.push(match[1]);
+  return [...new Set(found)];
+}
+
+type Resolved = { kind: 'first-party'; file: string } | { kind: 'third-party'; pkg: string };
+
+/**
+ * Resolve one specifier. THROWS on anything it cannot resolve rather than skipping it — an edge
+ * quietly dropped is an unwalked subtree, which is how this kind of guard becomes vacuous.
+ */
+function resolveSpecifier(fromFile: string, specifier: string): Resolved {
+  if (specifier.startsWith('.')) {
+    const base = resolve(dirname(fromFile), specifier);
+    for (const candidate of [base, `${base}.ts`, `${base}/index.ts`])
+      if (existsSync(candidate) && statSync(candidate).isFile())
+        return { kind: 'first-party', file: candidate };
+    throw new Error(`cannot resolve "${specifier}" from ${rel(fromFile)}`);
+  }
+  if (specifier.startsWith('@civitai/')) {
+    const [, name, ...subpath] = specifier.split('/');
+    const packageDir = resolve(REPO_ROOT, 'packages', `civitai-${name}`);
+    const manifest = resolve(packageDir, 'package.json');
+    if (!existsSync(manifest))
+      throw new Error(`cannot resolve "${specifier}" from ${rel(fromFile)}: no ${rel(manifest)}`);
+    const map = (
+      JSON.parse(readFileSync(manifest, 'utf-8')) as { exports?: Record<string, string> }
+    ).exports;
+    const key = subpath.length ? `./${subpath.join('/')}` : '.';
+    const target = map?.[key];
+    if (typeof target !== 'string')
+      throw new Error(
+        `cannot resolve "${specifier}" from ${rel(
+          fromFile
+        )}: @civitai/${name} has no "${key}" export`
+      );
+    return { kind: 'first-party', file: resolve(packageDir, target) };
+  }
+  const pkg = specifier.startsWith('@')
+    ? specifier.split('/').slice(0, 2).join('/')
+    : specifier.split('/')[0];
+  return { kind: 'third-party', pkg };
+}
+
+function importGraph(entry: string): { files: string[]; packages: string[] } {
+  const files = new Set<string>();
+  const packages = new Set<string>();
+  const queue = [entry];
+  while (queue.length) {
+    const file = queue.pop() as string;
+    if (files.has(file)) continue;
+    files.add(file);
+    for (const specifier of moduleSpecifiers(readFileSync(file, 'utf-8'))) {
+      const resolved = resolveSpecifier(file, specifier);
+      if (resolved.kind === 'third-party') packages.add(resolved.pkg);
+      else if (!files.has(resolved.file)) queue.push(resolved.file);
+    }
+  }
+  return { files: [...files].map(rel).sort(), packages: [...packages].sort() };
+}
+
+// Tokens that mean a module can name a database or hold a socket. `pg` itself is caught by the
+// package ledger, not here.
+const CONNECTION_TOKENS: Array<[label: string, pattern: RegExp]> = [
+  ['DATABASE_URL', /DATABASE_URL/],
+  ['connectionString', /\bconnectionString\b/],
+  ['new Pool', /\bnew\s+Pool\b/],
+  ['PostgresDialect', /\bPostgresDialect\b/],
+  ['createKyselyClients', /\bcreateKyselyClients\b/],
+];
+
+// `<file>: <token>, <token>` for each first-party file in the graph that names one.
+function connectionOffenders(files: string[]): string[] {
+  return files.flatMap((file) => {
+    const code = stripComments(readFileSync(resolve(REPO_ROOT, file), 'utf-8'));
+    const hits = CONNECTION_TOKENS.filter(([, pattern]) => pattern.test(code)).map(
+      ([label]) => label
+    );
+    return hits.length ? [`${file}: ${hits.join(', ')}`] : [];
+  });
+}
 
 describe('the ./test-harness subpath cannot reach DATABASE_URL', () => {
   it('exports exactly the offline compile harness', () => {
     expect(Object.keys(publicSubpath).sort()).toEqual(PUBLIC_SUBPATH_EXPORTS);
   });
 
-  it('routes the subpath at that module, not at the DB-backed harness', () => {
-    expect(packageJson.exports['./test-harness']).toBe('./src/test/compile-harness.ts');
+  it('routes every subpath in the exports map at a module that is allowed there', () => {
+    expect(packageJson.exports).toEqual(PACKAGE_EXPORTS);
   });
 
   it('keeps the DB-reaching helpers internal — and they exist, so the exclusion is real', () => {
@@ -48,5 +229,45 @@ describe('the ./test-harness subpath cannot reach DATABASE_URL', () => {
     );
     // ...and absent from the public module.
     for (const name of MUST_STAY_INTERNAL) expect(Object.keys(publicSubpath)).not.toContain(name);
+  });
+
+  // POSITIVE CONTROL for the two assertions that follow. A walker that resolves nothing, or a token
+  // scan that matches nothing, would certify every module in the repo as clean. Pointed at the
+  // DB-backed harness — one relative hop and one cross-package hop away from a real pool — both
+  // must fire. This runs FIRST so a broken instrument cannot be read as a clean result.
+  it('the walk and the token scan can both see a real pool (control: the DB-backed harness)', () => {
+    const control = importGraph(DB_BACKED_HARNESS);
+
+    // The cross-package hop: `@civitai/db/kysely` resolved through that package's exports map.
+    expect(control.files).toContain('packages/civitai-db/src/kysely.ts');
+    expect(control.packages).toContain('pg');
+
+    const offenders = connectionOffenders(control.files);
+    expect(offenders).toContain(
+      'packages/civitai-db/src/kysely.ts: connectionString, new Pool, PostgresDialect, createKyselyClients'
+    );
+    expect(offenders).toContain(
+      'packages/civitai-db-queries/src/test/harness.ts: DATABASE_URL, connectionString, createKyselyClients'
+    );
+  });
+
+  it('imports exactly these modules, transitively', () => {
+    const graph = importGraph(COMPILE_HARNESS);
+    expect(graph.files).toEqual(PUBLIC_GRAPH_FILES);
+    expect(graph.packages).toEqual(PUBLIC_GRAPH_PACKAGES);
+  });
+
+  // Driven off the manifest ON DISK, not off `PACKAGE_EXPORTS`. The ledger above is the only thing
+  // that notices a subpath being ADDED, but a ledger is satisfied by whoever updates it; this is the
+  // PROPERTY, and reading the real map is what makes it hold for a subpath nobody listed here.
+  it('no module reachable from any exported subpath names a pool or a connection string', () => {
+    const reachable = new Set<string>();
+    for (const target of Object.values(packageJson.exports))
+      for (const file of importGraph(resolve(PACKAGE_DIR, target)).files) reachable.add(file);
+
+    // Control on THIS test's own reach: the whole public graph is in scope, so a walk that
+    // collapsed to the entry files alone would be visible here.
+    expect([...reachable].sort()).toEqual(expect.arrayContaining(PUBLIC_GRAPH_FILES));
+    expect(connectionOffenders([...reachable].sort())).toEqual([]);
   });
 });

--- a/packages/civitai-db-queries/src/test/harness.ts
+++ b/packages/civitai-db-queries/src/test/harness.ts
@@ -1,51 +1,14 @@
-import {
-  type CompiledQuery,
-  DummyDriver,
-  Kysely,
-  PostgresAdapter,
-  PostgresIntrospector,
-  PostgresQueryCompiler,
-  CompiledQuery as CompiledQueryClass,
-} from 'kysely';
+import { type CompiledQuery, CompiledQuery as CompiledQueryClass } from 'kysely';
 import { createKyselyClients } from '@civitai/db/kysely';
 import type { DB } from '@civitai/db-schema/kysely';
-import { UPDATED_AT_TABLES } from '@civitai/db-schema/kysely/updated-at-tables';
-import { updatedAtPlugin } from '../infra/updated-at-plugin';
+import { compileHarness } from './compile-harness';
 
-// Query functions take a Kysely client as their first argument (executor injection). These harnesses build
-// the client a test passes in — no global wiring.
-
-// An offline Kysely wired to DummyDriver: pass its `db` to a query function and the function's SQL COMPILES to
-// real Postgres SQL and `.execute()` resolves to an empty result WITHOUT a database (safe for writes). A `log`
-// hook captures each compiled query so a test can assert the exact SQL + parameters.
-//
-// The `@updatedAt` plugin is installed here exactly as the app installs it (kyselyDb.ts), so the compiled SQL a
-// test sees matches production: an UPDATE to an `@updatedAt` table auto-stamps `updatedAt` unless the write
-// opts out (self-reference `keepUpdatedAt`) or is raw `sql`. Ported writes therefore don't set `updatedAt` by
-// hand, and the tests assert the plugin-stamped result.
-export function compileHarness() {
-  const queries: CompiledQuery[] = [];
-
-  const db = new Kysely<DB>({
-    dialect: {
-      createAdapter: () => new PostgresAdapter(),
-      createDriver: () => new DummyDriver(),
-      createIntrospector: (kysely) => new PostgresIntrospector(kysely),
-      createQueryCompiler: () => new PostgresQueryCompiler(),
-    },
-    plugins: [updatedAtPlugin(UPDATED_AT_TABLES)],
-    log: (event) => {
-      if (event.level === 'query') queries.push(event.query);
-    },
-  });
-
-  return {
-    db,
-    // The most recently compiled query — `{ sql, parameters }`.
-    lastQuery: () => queries[queries.length - 1],
-    queries,
-  };
-}
+// `compileHarness` lives in its own module and is re-exported here for the package's own tests,
+// which import it from `./test/harness` alongside the DB-backed helpers. Only that module — NOT
+// this one — is on the package's public `./test-harness` subpath: everything below resolves a
+// connection string and can fall back to `process.env.DATABASE_URL`, so it must stay
+// package-internal. See the note at the top of `compile-harness.ts`.
+export { compileHarness };
 
 // The DB URL for the DB-backed tier. Prefer a dedicated TEST_DATABASE_URL; fall back to DATABASE_URL for local
 // runs. Absent (e.g. plain CI with no Postgres) → the DB-backed suites skip via `describe.skipIf`.

--- a/src/server/db/__tests__/fixtures/kysely-parity-schema.sql
+++ b/src/server/db/__tests__/fixtures/kysely-parity-schema.sql
@@ -1,0 +1,51 @@
+-- Minimal schema for the Prisma-vs-Kysely parity suite (kysely-prisma-parity.test.ts).
+--
+-- Only the tables the ported read queries touch, mirroring schema.full.prisma: same column names,
+-- same types, same primary keys, same hash indexes. Foreign keys to Model/Image/User/Tag are
+-- deliberately omitted so the suite can seed rows without materialising half the schema — the
+-- queries under test never join those tables, so their absence cannot change a result.
+--
+-- Applied by the suite against KYSELY_PARITY_DATABASE_URL, which must be a THROWAWAY database:
+-- this drops and recreates everything below on every run.
+
+DROP TABLE IF EXISTS "TagsOnImageVote";
+DROP TABLE IF EXISTS "TagsOnModelsVote";
+DROP TABLE IF EXISTS "ModelEngagement";
+-- Created by the array-column seam guard's positive control. Dropped here, before the enum it
+-- depends on, so the suite is re-runnable against the same database.
+DROP TABLE IF EXISTS "_ParityArrayProbe";
+DROP TYPE IF EXISTS "ModelEngagementType";
+
+CREATE TYPE "ModelEngagementType" AS ENUM ('Favorite', 'Hide', 'Mute', 'Notify');
+
+CREATE TABLE "ModelEngagement" (
+  "userId"    INTEGER                NOT NULL,
+  "modelId"   INTEGER                NOT NULL,
+  "type"      "ModelEngagementType"  NOT NULL,
+  "createdAt" TIMESTAMP(3)           NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "ModelEngagement_pkey" PRIMARY KEY ("userId", "modelId")
+);
+CREATE INDEX "ModelEngagement_modelId_idx" ON "ModelEngagement" USING HASH ("modelId");
+
+CREATE TABLE "TagsOnModelsVote" (
+  "modelId"   INTEGER      NOT NULL,
+  "tagId"     INTEGER      NOT NULL,
+  "userId"    INTEGER      NOT NULL,
+  "vote"      INTEGER      NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "TagsOnModelsVote_pkey" PRIMARY KEY ("tagId", "modelId", "userId")
+);
+CREATE INDEX "TagsOnModelsVote_modelId_idx" ON "TagsOnModelsVote" USING HASH ("modelId");
+CREATE INDEX "TagsOnModelsVote_userId_idx" ON "TagsOnModelsVote" USING HASH ("userId");
+
+CREATE TABLE "TagsOnImageVote" (
+  "imageId"   INTEGER      NOT NULL,
+  "tagId"     INTEGER      NOT NULL,
+  "userId"    INTEGER      NOT NULL,
+  "vote"      INTEGER      NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "applied"   BOOLEAN      NOT NULL DEFAULT false,
+  CONSTRAINT "TagsOnImageVote_pkey" PRIMARY KEY ("tagId", "imageId", "userId")
+);
+CREATE INDEX "TagsOnImageVote_imageId_idx" ON "TagsOnImageVote" USING HASH ("imageId");
+CREATE INDEX "TagsOnImageVote_userId_idx" ON "TagsOnImageVote" USING HASH ("userId");

--- a/src/server/db/__tests__/kysely-prisma-parity.test.ts
+++ b/src/server/db/__tests__/kysely-prisma-parity.test.ts
@@ -1,0 +1,319 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PrismaClient } from '@prisma/client';
+import { createKyselyClients } from '@civitai/db/kysely';
+import type { DB } from '@civitai/db-schema/kysely';
+import { listModelEngagements } from '@civitai/db-queries/model';
+import {
+  listImageTagVotes,
+  listImageTagVotesMany,
+  listModelTagVotes,
+} from '@civitai/db-queries/tag';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+/**
+ * Behaviour-parity gate for the hot read queries ported from Prisma to Kysely-over-pg.
+ *
+ * The port exists to keep these statements off the Prisma query engine. That is only safe if the
+ * two paths are indistinguishable to the caller, so this suite runs BOTH against the SAME rows in
+ * the SAME database and deep-compares — rather than asserting the Kysely result against a hand
+ * written expectation, which would only re-state what the new code does.
+ *
+ * Opt-in via `KYSELY_PARITY_DATABASE_URL`, which must point at a THROWAWAY database: the suite
+ * drops and recreates its tables and writes fixture rows. It deliberately does NOT fall back to
+ * `DATABASE_URL` — that variable points at a real environment in every checkout that has one.
+ *
+ *   docker run -d --rm --name pg-parity -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=parity \
+ *     -p 54329:5432 postgres:17
+ *   KYSELY_PARITY_DATABASE_URL=postgresql://postgres:postgres@localhost:54329/parity \
+ *     pnpm vitest run --project unit src/server/db/__tests__/kysely-prisma-parity.test.ts
+ */
+const parityUrl = process.env.KYSELY_PARITY_DATABASE_URL;
+
+// `$executeRawUnsafe` sends one prepared statement, so the DDL script is applied statement by
+// statement. A naive split on `;` is safe for this fixture: it is plain DDL with no function bodies,
+// dollar-quoting or semicolons inside literals.
+const schemaStatements = readFileSync(
+  resolve(dirname(fileURLToPath(import.meta.url)), 'fixtures/kysely-parity-schema.sql'),
+  'utf-8'
+)
+  .split(';')
+  .map((statement) =>
+    statement
+      .split('\n')
+      .filter((line) => !line.trim().startsWith('--'))
+      .join('\n')
+      .trim()
+  )
+  .filter(Boolean);
+
+// Row order is unspecified on both paths (neither query has an ORDER BY, matching the source), so
+// parity is a multiset comparison: sort both sides by a total key before comparing.
+const sortRows = <T extends Record<string, unknown>>(rows: T[]): T[] =>
+  [...rows].sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+
+const expectParity = <T extends Record<string, unknown>>(kysely: T[], prisma: T[]) => {
+  expect(sortRows(kysely)).toEqual(sortRows(prisma));
+};
+
+describe.skipIf(!parityUrl)('Kysely ports return exactly what Prisma returned', () => {
+  const prisma = new PrismaClient({ datasourceUrl: parityUrl });
+  const { db: kysely } = createKyselyClients<DB>({
+    connectionString: parityUrl,
+    singleClient: true,
+  });
+
+  const USER = 1;
+  const OTHER_USER = 2;
+
+  beforeAll(async () => {
+    for (const statement of schemaStatements) await prisma.$executeRawUnsafe(statement);
+
+    // Two users, several images/models, both vote polarities, and every engagement type — so a
+    // filter dropped in the port shows up as extra rows rather than as an empty diff.
+    await prisma.tagsOnImageVote.createMany({
+      data: [
+        { imageId: 10, tagId: 100, userId: USER, vote: 1 },
+        { imageId: 10, tagId: 101, userId: USER, vote: -1 },
+        { imageId: 10, tagId: 102, userId: OTHER_USER, vote: 1 },
+        { imageId: 11, tagId: 103, userId: USER, vote: 1 },
+        { imageId: 12, tagId: 104, userId: USER, vote: -1 },
+      ],
+    });
+    await prisma.tagsOnModelsVote.createMany({
+      data: [
+        { modelId: 20, tagId: 200, userId: USER, vote: 1 },
+        { modelId: 20, tagId: 201, userId: USER, vote: -1 },
+        { modelId: 20, tagId: 202, userId: OTHER_USER, vote: 1 },
+        { modelId: 21, tagId: 203, userId: USER, vote: 1 },
+      ],
+    });
+    await prisma.modelEngagement.createMany({
+      data: [
+        { userId: USER, modelId: 30, type: 'Favorite' },
+        { userId: USER, modelId: 31, type: 'Hide' },
+        { userId: USER, modelId: 32, type: 'Mute' },
+        { userId: USER, modelId: 33, type: 'Notify' },
+        { userId: OTHER_USER, modelId: 30, type: 'Favorite' },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+    await kysely.destroy();
+  });
+
+  describe('listImageTagVotes', () => {
+    const viaPrisma = (imageId: number, userId: number) =>
+      prisma.tagsOnImageVote.findMany({
+        where: { imageId, userId },
+        select: { tagId: true, vote: true },
+      });
+
+    it('matches Prisma for an image the user voted on, including a negative vote', async () => {
+      const [k, p] = await Promise.all([
+        listImageTagVotes(kysely, { imageId: 10, userId: USER }),
+        viaPrisma(10, USER),
+      ]);
+      expect(k).toHaveLength(2); // positive control: the comparison is not two empty arrays
+      expectParity(k, p);
+    });
+
+    it('matches Prisma (empty) for an image the user has not voted on', async () => {
+      const [k, p] = await Promise.all([
+        listImageTagVotes(kysely, { imageId: 99, userId: USER }),
+        viaPrisma(99, USER),
+      ]);
+      expect(k).toEqual([]);
+      expectParity(k, p);
+    });
+
+    it('excludes other users votes on the same image, exactly as Prisma did', async () => {
+      const [k, p] = await Promise.all([
+        listImageTagVotes(kysely, { imageId: 10, userId: OTHER_USER }),
+        viaPrisma(10, OTHER_USER),
+      ]);
+      expect(k).toEqual([{ tagId: 102, vote: 1 }]);
+      expectParity(k, p);
+    });
+
+    it('returns vote as a JS number, not a string', async () => {
+      const [row] = await listImageTagVotes(kysely, { imageId: 10, userId: USER });
+      expect(typeof row.vote).toBe('number');
+      expect(typeof row.tagId).toBe('number');
+    });
+  });
+
+  describe('listImageTagVotesMany', () => {
+    const viaPrisma = (imageIds: number[], userId: number) =>
+      prisma.tagsOnImageVote.findMany({
+        where: { imageId: { in: imageIds }, userId },
+        select: { tagId: true, vote: true },
+      });
+
+    it('matches Prisma across several images', async () => {
+      const [k, p] = await Promise.all([
+        listImageTagVotesMany(kysely, { imageIds: [10, 11, 12], userId: USER }),
+        viaPrisma([10, 11, 12], USER),
+      ]);
+      expect(k).toHaveLength(4);
+      expectParity(k, p);
+    });
+
+    it('matches Prisma for a subset that excludes some seeded images', async () => {
+      const [k, p] = await Promise.all([
+        listImageTagVotesMany(kysely, { imageIds: [11], userId: USER }),
+        viaPrisma([11], USER),
+      ]);
+      expect(k).toEqual([{ tagId: 103, vote: 1 }]);
+      expectParity(k, p);
+    });
+
+    it('matches Prisma (empty) for an empty imageIds array instead of raising IN ()', async () => {
+      // Prisma compiled `{ in: [] }` to an empty result; Kysely would compile `IN ()`, a Postgres
+      // syntax error, without the guard. Reachable from a request: the votable-tag input schema
+      // accepts an empty `ids` array.
+      const [k, p] = await Promise.all([
+        listImageTagVotesMany(kysely, { imageIds: [], userId: USER }),
+        viaPrisma([], USER),
+      ]);
+      expect(k).toEqual([]);
+      expectParity(k, p);
+    });
+
+    it('matches Prisma (empty) for image ids that exist but hold no votes for this user', async () => {
+      const [k, p] = await Promise.all([
+        listImageTagVotesMany(kysely, { imageIds: [11, 12], userId: OTHER_USER }),
+        viaPrisma([11, 12], OTHER_USER),
+      ]);
+      expect(k).toEqual([]);
+      expectParity(k, p);
+    });
+  });
+
+  describe('listModelTagVotes', () => {
+    const viaPrisma = (modelId: number, userId: number) =>
+      prisma.tagsOnModelsVote.findMany({
+        where: { modelId, userId },
+        select: { tagId: true, vote: true },
+      });
+
+    it('matches Prisma for a model the user voted on', async () => {
+      const [k, p] = await Promise.all([
+        listModelTagVotes(kysely, { modelId: 20, userId: USER }),
+        viaPrisma(20, USER),
+      ]);
+      expect(k).toHaveLength(2);
+      expectParity(k, p);
+    });
+
+    it('matches Prisma (empty) for a model the user has not voted on', async () => {
+      const [k, p] = await Promise.all([
+        listModelTagVotes(kysely, { modelId: 99, userId: USER }),
+        viaPrisma(99, USER),
+      ]);
+      expect(k).toEqual([]);
+      expectParity(k, p);
+    });
+  });
+
+  describe('listModelEngagements', () => {
+    const viaPrisma = (userId: number, modelIds: number[]) =>
+      prisma.modelEngagement.findMany({
+        where: { userId, modelId: { in: modelIds } },
+        select: { modelId: true, type: true },
+      });
+
+    it('matches Prisma across every engagement type', async () => {
+      const [k, p] = await Promise.all([
+        listModelEngagements(kysely, { userId: USER, modelIds: [30, 31, 32, 33] }),
+        viaPrisma(USER, [30, 31, 32, 33]),
+      ]);
+      expect(k).toHaveLength(4);
+      expectParity(k, p);
+    });
+
+    it('returns the scalar enum as its string value, exactly as Prisma did', async () => {
+      // ModelEngagementType is a SCALAR enum: pg reads it back as plain text with no parser
+      // registration. The array-of-enum case is the one that arrives as a raw `{a,b}` literal —
+      // see the guard below, and @civitai/db/kysely's registerEnumArrayTypeParsers.
+      const rows = await listModelEngagements(kysely, { userId: USER, modelIds: [30] });
+      expect(rows).toEqual([{ modelId: 30, type: 'Favorite' }]);
+      expect(typeof rows[0].type).toBe('string');
+    });
+
+    it('matches Prisma (empty) for an empty modelIds array instead of raising IN ()', async () => {
+      const [k, p] = await Promise.all([
+        listModelEngagements(kysely, { userId: USER, modelIds: [] }),
+        viaPrisma(USER, []),
+      ]);
+      expect(k).toEqual([]);
+      expectParity(k, p);
+    });
+
+    it('matches Prisma (empty) for model ids the user has no engagement with', async () => {
+      const [k, p] = await Promise.all([
+        listModelEngagements(kysely, { userId: USER, modelIds: [900, 901] }),
+        viaPrisma(USER, [900, 901]),
+      ]);
+      expect(k).toEqual([]);
+      expectParity(k, p);
+    });
+
+    it('excludes another users engagement with the same model, exactly as Prisma did', async () => {
+      const [k, p] = await Promise.all([
+        listModelEngagements(kysely, { userId: OTHER_USER, modelIds: [30, 31, 32, 33] }),
+        viaPrisma(OTHER_USER, [30, 31, 32, 33]),
+      ]);
+      expect(k).toEqual([{ modelId: 30, type: 'Favorite' }]);
+      expectParity(k, p);
+    });
+  });
+
+  // Seam guard. The Kysely-over-pg path has no parser for an ARRAY of a user-defined enum unless
+  // registerEnumArrayTypeParsers has run, so such a column silently arrives as the raw Postgres
+  // literal `{a,b}` where the inferred type promises string[]. None of the columns selected above
+  // is an array type today, which is why these ports need no registration. This asserts that fact
+  // against the live catalog rather than against a reading of the schema: widening one of these
+  // selects to an enum-array column (Tag.target is the nearby example) fails here.
+  it('selects no array-typed column, so no enum-array parser is required', async () => {
+    const selected: Array<[table: string, column: string]> = [
+      ['TagsOnImageVote', 'tagId'],
+      ['TagsOnImageVote', 'vote'],
+      ['TagsOnModelsVote', 'tagId'],
+      ['TagsOnModelsVote', 'vote'],
+      ['ModelEngagement', 'modelId'],
+      ['ModelEngagement', 'type'],
+    ];
+
+    const rows = await prisma.$queryRawUnsafe<Array<{ table: string; column: string }>>(
+      `SELECT c.relname AS "table", a.attname AS "column"
+         FROM pg_attribute a
+         JOIN pg_class c ON c.oid = a.attrelid
+         JOIN pg_type t ON t.oid = a.atttypid
+        WHERE t.typcategory = 'A'
+          AND a.attnum > 0
+          AND c.relname IN ('TagsOnImageVote', 'TagsOnModelsVote', 'ModelEngagement')`
+    );
+
+    const arrayColumns = new Set(rows.map((r) => `${r.table}.${r.column}`));
+    // Positive control: the query CAN see an array column when one exists.
+    await prisma.$executeRawUnsafe(
+      `CREATE TABLE IF NOT EXISTS "_ParityArrayProbe" (x "ModelEngagementType"[])`
+    );
+    const probe = await prisma.$queryRawUnsafe<Array<{ column: string }>>(
+      `SELECT a.attname AS "column"
+         FROM pg_attribute a
+         JOIN pg_class c ON c.oid = a.attrelid
+         JOIN pg_type t ON t.oid = a.atttypid
+        WHERE t.typcategory = 'A' AND a.attnum > 0 AND c.relname = '_ParityArrayProbe'`
+    );
+    expect(probe.map((r) => r.column)).toEqual(['x']);
+
+    for (const [table, column] of selected) {
+      expect(arrayColumns.has(`${table}.${column}`)).toBe(false);
+    }
+  });
+});

--- a/src/server/db/__tests__/kysely-prisma-parity.test.ts
+++ b/src/server/db/__tests__/kysely-prisma-parity.test.ts
@@ -61,13 +61,29 @@ const expectParity = <T extends Record<string, unknown>>(kysely: T[], prisma: T[
 
 // Every query this PR ported, with arguments that reach the statement (a bulk query's empty-array
 // guard short-circuits before compiling anything). The array-column seam guard below runs each one
-// and reads the select list back off EVERY statement it compiles, so adding a port here is what
-// extends the check — there is no second list to keep in sync.
-const PORTED_QUERIES: Array<[name: string, run: (db: Kysely<DB>) => Promise<unknown>]> = [
-  ['listImageTagVotes', (db) => listImageTagVotes(db, { imageId: 1, userId: 1 })],
-  ['listImageTagVotesMany', (db) => listImageTagVotesMany(db, { imageIds: [1], userId: 1 })],
-  ['listModelTagVotes', (db) => listModelTagVotes(db, { modelId: 1, userId: 1 })],
-  ['listModelEngagements', (db) => listModelEngagements(db, { userId: 1, modelIds: [1] })],
+// and reads the select list back off every statement the call COMPILES, so adding a port here is
+// what extends the check — there is no second list to keep in sync. What it does not cover is a
+// statement that never compiles, which is what the count below is for.
+//
+// The middle field is how many statements that call is expected to COMPILE under the offline
+// harness, and it is the guard's blind spot made explicit. `DummyDriver` resolves every `.execute()`
+// to zero rows, so the common two-step read
+//
+//   const ids = await select(...);  if (!ids.length) return [];  return select(...).where('id','in',ids);
+//
+// compiles its FIRST statement only — the second is unreachable behind a guard the harness can never
+// satisfy. Nothing about that is visible in the compiled output, so a port whose second statement
+// silently stopped compiling would have gone unnoticed while the fleet-wide yield control below
+// still cleared on the other ports' rows. Declaring the count per port turns that into a failure:
+// a two-step port cannot be added here with `2` and pass, which is the intended outcome — this
+// harness cannot check its second statement, and the entry has to say so rather than look covered.
+const PORTED_QUERIES: Array<
+  [name: string, compiledStatements: number, run: (db: Kysely<DB>) => Promise<unknown>]
+> = [
+  ['listImageTagVotes', 1, (db) => listImageTagVotes(db, { imageId: 1, userId: 1 })],
+  ['listImageTagVotesMany', 1, (db) => listImageTagVotesMany(db, { imageIds: [1], userId: 1 })],
+  ['listModelTagVotes', 1, (db) => listModelTagVotes(db, { modelId: 1, userId: 1 })],
+  ['listModelEngagements', 1, (db) => listModelEngagements(db, { userId: 1, modelIds: [1] })],
 ];
 
 /**
@@ -328,21 +344,43 @@ describe.skipIf(!parityUrl)('Kysely ports return exactly what Prisma returned', 
     // Compiled offline against DummyDriver — the SQL is real, nothing executes.
     const harness = compileHarness();
     const selected: Array<[table: string, column: string]> = [];
-    for (const [name, run] of PORTED_QUERIES) {
+    for (const [name, compiledStatements, run] of PORTED_QUERIES) {
       harness.queries.length = 0;
       await run(harness.db);
-      if (!harness.queries.length)
-        throw new Error(`${name} compiled no query — the derivation saw nothing`);
+
+      // PER-PORT control, not a fleet-wide one. The floor below is a TOTAL, so it can only see a
+      // shortfall big enough to drop the total under it: with the four ports here it does catch one
+      // of them compiling nothing (6 < 8), but it cannot see a NEWLY ADDED port compiling fewer
+      // statements than intended — those four already satisfy the floor on their own, so the new
+      // port's shortfall is hidden. That is the case this assertion exists for.
+      expect(
+        harness.queries.length,
+        `${name} compiled ${harness.queries.length} statement(s), expected ${compiledStatements}. ` +
+          `A statement gated on a previous statement's ROWS never compiles here — DummyDriver ` +
+          `resolves every execute() to zero rows — so this port is not covered by the array-column ` +
+          `check below and the count must be corrected rather than the expectation lowered.`
+      ).toBe(compiledStatements);
+
       // EVERY statement the call compiled, not just the last one. Reading only `lastQuery()` meant
       // a port that issues two statements was checked on its final statement alone, so an
       // array-typed select in any earlier one passed unseen — the same silent green this guard
       // exists to remove. Verified by mutation: an enum-array select in the FIRST of two.
-      for (const compiled of harness.queries) selected.push(...selectedColumns(name, compiled.sql));
+      const derived = harness.queries.flatMap((compiled) => selectedColumns(name, compiled.sql));
+
+      // ...and the derivation must actually yield for THIS port. Belt-and-braces: `selectedColumns`
+      // THROWS on any statement it cannot parse (it never returns an empty list), and the count
+      // above already rejects zero statements, so with the entries as they stand today this cannot
+      // fire. It is here to catch a future entry that declares `0`.
+      expect(
+        derived.length,
+        `${name} contributed no (table, column) pair — the derivation saw nothing for this port`
+      ).toBeGreaterThanOrEqual(1);
+      selected.push(...derived);
     }
 
-    // Positive control on the derivation's YIELD. A parse that silently produced nothing would make
-    // every assertion below pass vacuously, which is the failure this guard replaced. 4 queries × 2
-    // columns today; widening a select, or a port growing a second statement, only ever raises it.
+    // Fleet-wide floor, kept as a coarse second net: 4 queries × 2 columns today. The per-port
+    // controls above are what make a single port's shortfall fail; this one only catches a
+    // collapse across all of them.
     expect(selected.length).toBeGreaterThanOrEqual(8);
 
     const tables = [...new Set(selected.map(([table]) => table))];

--- a/src/server/db/__tests__/kysely-prisma-parity.test.ts
+++ b/src/server/db/__tests__/kysely-prisma-parity.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { PrismaClient } from '@prisma/client';
+import type { Kysely } from 'kysely';
 import { createKyselyClients } from '@civitai/db/kysely';
 import type { DB } from '@civitai/db-schema/kysely';
 import { listModelEngagements } from '@civitai/db-queries/model';
@@ -10,6 +11,7 @@ import {
   listImageTagVotesMany,
   listModelTagVotes,
 } from '@civitai/db-queries/tag';
+import { compileHarness } from '@civitai/db-queries/test-harness';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 /**
@@ -56,6 +58,40 @@ const sortRows = <T extends Record<string, unknown>>(rows: T[]): T[] =>
 const expectParity = <T extends Record<string, unknown>>(kysely: T[], prisma: T[]) => {
   expect(sortRows(kysely)).toEqual(sortRows(prisma));
 };
+
+// Every query this PR ported, with arguments that reach the statement (a bulk query's empty-array
+// guard short-circuits before compiling anything). The array-column seam guard below compiles each
+// one and reads the select list back off the SQL, so adding a port here is what extends the check —
+// there is no second list to keep in sync.
+const PORTED_QUERIES: Array<[name: string, run: (db: Kysely<DB>) => Promise<unknown>]> = [
+  ['listImageTagVotes', (db) => listImageTagVotes(db, { imageId: 1, userId: 1 })],
+  ['listImageTagVotesMany', (db) => listImageTagVotesMany(db, { imageIds: [1], userId: 1 })],
+  ['listModelTagVotes', (db) => listModelTagVotes(db, { modelId: 1, userId: 1 })],
+  ['listModelEngagements', (db) => listModelEngagements(db, { userId: 1, modelIds: [1] })],
+];
+
+/**
+ * The (table, column) pairs a compiled single-table SELECT reads.
+ *
+ * THROWS rather than returning [] on anything it does not fully understand — a join, an alias, an
+ * expression, a `select *`. An unparsed statement returning an empty set is indistinguishable from
+ * a statement that selects nothing dangerous, and that silent zero is precisely how the previous
+ * version of this guard came to be vacuous. If a port outgrows this shape, this has to be taught
+ * the new shape; it may not degrade quietly.
+ */
+function selectedColumns(name: string, sql: string): Array<[table: string, column: string]> {
+  const match = /^select (.+?) from "([^"]+)"(?: where | order by |$)/.exec(sql);
+  if (!match)
+    throw new Error(`selectedColumns(${name}): not a simple single-table select — ${sql}`);
+  const [, list, table] = match;
+  const items = list.split(',').map((item) => item.trim());
+  const unrecognised = items.filter((item) => !/^"[^"]+"$/.test(item));
+  if (unrecognised.length)
+    throw new Error(
+      `selectedColumns(${name}): unrecognised select item(s) [${unrecognised.join(', ')}] — ${sql}`
+    );
+  return items.map((item) => [table, item.slice(1, -1)]);
+}
 
 describe.skipIf(!parityUrl)('Kysely ports return exactly what Prisma returned', () => {
   const prisma = new PrismaClient({ datasourceUrl: parityUrl });
@@ -274,46 +310,71 @@ describe.skipIf(!parityUrl)('Kysely ports return exactly what Prisma returned', 
 
   // Seam guard. The Kysely-over-pg path has no parser for an ARRAY of a user-defined enum unless
   // registerEnumArrayTypeParsers has run, so such a column silently arrives as the raw Postgres
-  // literal `{a,b}` where the inferred type promises string[]. None of the columns selected above
-  // is an array type today, which is why these ports need no registration. This asserts that fact
-  // against the live catalog rather than against a reading of the schema: widening one of these
-  // selects to an enum-array column (Tag.target is the nearby example) fails here.
-  it('selects no array-typed column, so no enum-array parser is required', async () => {
-    const selected: Array<[table: string, column: string]> = [
-      ['TagsOnImageVote', 'tagId'],
-      ['TagsOnImageVote', 'vote'],
-      ['TagsOnModelsVote', 'tagId'],
-      ['TagsOnModelsVote', 'vote'],
-      ['ModelEngagement', 'modelId'],
-      ['ModelEngagement', 'type'],
-    ];
+  // literal `{a,b}` where the inferred type promises string[]. None of the columns these ports
+  // select is an array type today, which is why they need no registration.
+  //
+  // The column set is DERIVED FROM THE COMPILED SQL of the real query functions, so it tracks the
+  // query rather than a maintainer's memory: widening a select onto an enum-array column
+  // (`Tag.target` is the nearby example) puts that column into the set below without anyone
+  // editing this test. The predecessor of this guard was a hand-written literal list, which is
+  // exactly the shape that cannot fail — an audit widened `listModelEngagements` onto a real
+  // `"ModelEngagementType"[]` column and the guard passed.
+  //
+  // What it is checked against is the catalog of the FIXTURE database this suite creates from
+  // `fixtures/kysely-parity-schema.sql` — not the production catalog. The fixture mirrors the
+  // real column types for these three tables, so it answers the array-vs-scalar question; it is
+  // not evidence about any column the fixture does not declare.
+  it('no ported query selects an array-typed column, so no enum-array parser is required', async () => {
+    // Compiled offline against DummyDriver — the SQL is real, nothing executes.
+    const harness = compileHarness();
+    const selected: Array<[table: string, column: string]> = [];
+    for (const [name, run] of PORTED_QUERIES) {
+      harness.queries.length = 0;
+      await run(harness.db);
+      const compiled = harness.lastQuery();
+      if (!compiled) throw new Error(`${name} compiled no query — the derivation saw nothing`);
+      selected.push(...selectedColumns(name, compiled.sql));
+    }
 
-    const rows = await prisma.$queryRawUnsafe<Array<{ table: string; column: string }>>(
-      `SELECT c.relname AS "table", a.attname AS "column"
-         FROM pg_attribute a
-         JOIN pg_class c ON c.oid = a.attrelid
-         JOIN pg_type t ON t.oid = a.atttypid
-        WHERE t.typcategory = 'A'
-          AND a.attnum > 0
-          AND c.relname IN ('TagsOnImageVote', 'TagsOnModelsVote', 'ModelEngagement')`
-    );
+    // Positive control on the DERIVATION. A parse that silently yielded nothing would make every
+    // assertion below pass vacuously, which is the failure this guard replaced. 4 queries × 2
+    // columns today; widening a select only ever raises this.
+    expect(selected.length).toBeGreaterThanOrEqual(8);
 
-    const arrayColumns = new Set(rows.map((r) => `${r.table}.${r.column}`));
-    // Positive control: the query CAN see an array column when one exists.
+    const tables = [...new Set(selected.map(([table]) => table))];
+    const arrayColumnsIn = async (relnames: string[]) => {
+      const rows = await prisma.$queryRawUnsafe<Array<{ table: string; column: string }>>(
+        `SELECT c.relname AS "table", a.attname AS "column"
+           FROM pg_attribute a
+           JOIN pg_class c ON c.oid = a.attrelid
+           JOIN pg_type t ON t.oid = a.atttypid
+          WHERE t.typcategory = 'A'
+            AND a.attnum > 0
+            AND c.relname = ANY($1::text[])`,
+        relnames
+      );
+      return new Set(rows.map((r) => `${r.table}.${r.column}`));
+    };
+
+    // Positive control on the CATALOG QUERY, run through the same helper the assertion uses: it
+    // CAN see an enum-array column when one exists.
     await prisma.$executeRawUnsafe(
       `CREATE TABLE IF NOT EXISTS "_ParityArrayProbe" (x "ModelEngagementType"[])`
     );
-    const probe = await prisma.$queryRawUnsafe<Array<{ column: string }>>(
-      `SELECT a.attname AS "column"
-         FROM pg_attribute a
-         JOIN pg_class c ON c.oid = a.attrelid
-         JOIN pg_type t ON t.oid = a.atttypid
-        WHERE t.typcategory = 'A' AND a.attnum > 0 AND c.relname = '_ParityArrayProbe'`
-    );
-    expect(probe.map((r) => r.column)).toEqual(['x']);
+    expect([...(await arrayColumnsIn(['_ParityArrayProbe']))]).toEqual(['_ParityArrayProbe.x']);
 
-    for (const [table, column] of selected) {
-      expect(arrayColumns.has(`${table}.${column}`)).toBe(false);
-    }
+    const arrayColumns = await arrayColumnsIn(tables);
+    const offenders = selected
+      .map(([table, column]) => `${table}.${column}`)
+      .filter((qualified) => arrayColumns.has(qualified));
+
+    expect(
+      offenders,
+      `ported query selects ARRAY-typed column(s) [${offenders.join(
+        ', '
+      )}] — pg returns an array ` +
+        `of a user-defined enum as the raw '{a,b}' literal unless registerEnumArrayTypeParsers ` +
+        `has run, and none of these ports registers one`
+    ).toEqual([]);
   });
 });

--- a/src/server/db/__tests__/kysely-prisma-parity.test.ts
+++ b/src/server/db/__tests__/kysely-prisma-parity.test.ts
@@ -60,9 +60,9 @@ const expectParity = <T extends Record<string, unknown>>(kysely: T[], prisma: T[
 };
 
 // Every query this PR ported, with arguments that reach the statement (a bulk query's empty-array
-// guard short-circuits before compiling anything). The array-column seam guard below compiles each
-// one and reads the select list back off the SQL, so adding a port here is what extends the check —
-// there is no second list to keep in sync.
+// guard short-circuits before compiling anything). The array-column seam guard below runs each one
+// and reads the select list back off EVERY statement it compiles, so adding a port here is what
+// extends the check — there is no second list to keep in sync.
 const PORTED_QUERIES: Array<[name: string, run: (db: Kysely<DB>) => Promise<unknown>]> = [
   ['listImageTagVotes', (db) => listImageTagVotes(db, { imageId: 1, userId: 1 })],
   ['listImageTagVotesMany', (db) => listImageTagVotesMany(db, { imageIds: [1], userId: 1 })],
@@ -331,29 +331,42 @@ describe.skipIf(!parityUrl)('Kysely ports return exactly what Prisma returned', 
     for (const [name, run] of PORTED_QUERIES) {
       harness.queries.length = 0;
       await run(harness.db);
-      const compiled = harness.lastQuery();
-      if (!compiled) throw new Error(`${name} compiled no query — the derivation saw nothing`);
-      selected.push(...selectedColumns(name, compiled.sql));
+      if (!harness.queries.length)
+        throw new Error(`${name} compiled no query — the derivation saw nothing`);
+      // EVERY statement the call compiled, not just the last one. Reading only `lastQuery()` meant
+      // a port that issues two statements was checked on its final statement alone, so an
+      // array-typed select in any earlier one passed unseen — the same silent green this guard
+      // exists to remove. Verified by mutation: an enum-array select in the FIRST of two.
+      for (const compiled of harness.queries) selected.push(...selectedColumns(name, compiled.sql));
     }
 
-    // Positive control on the DERIVATION. A parse that silently yielded nothing would make every
-    // assertion below pass vacuously, which is the failure this guard replaced. 4 queries × 2
-    // columns today; widening a select only ever raises this.
+    // Positive control on the derivation's YIELD. A parse that silently produced nothing would make
+    // every assertion below pass vacuously, which is the failure this guard replaced. 4 queries × 2
+    // columns today; widening a select, or a port growing a second statement, only ever raises it.
     expect(selected.length).toBeGreaterThanOrEqual(8);
 
     const tables = [...new Set(selected.map(([table]) => table))];
-    const arrayColumnsIn = async (relnames: string[]) => {
-      const rows = await prisma.$queryRawUnsafe<Array<{ table: string; column: string }>>(
-        `SELECT c.relname AS "table", a.attname AS "column"
+    // Every attribute of the named relations, with whether its type is an array (typcategory 'A').
+    // ONE query feeds both checks below, so the control cannot certify a path the assertion does
+    // not use.
+    const attributesIn = async (relnames: string[]) => {
+      const rows = await prisma.$queryRawUnsafe<
+        Array<{ table: string; column: string; isArray: boolean }>
+      >(
+        `SELECT c.relname AS "table", a.attname AS "column", (t.typcategory = 'A') AS "isArray"
            FROM pg_attribute a
            JOIN pg_class c ON c.oid = a.attrelid
            JOIN pg_type t ON t.oid = a.atttypid
-          WHERE t.typcategory = 'A'
-            AND a.attnum > 0
+          WHERE a.attnum > 0
+            AND NOT a.attisdropped
             AND c.relname = ANY($1::text[])`,
         relnames
       );
-      return new Set(rows.map((r) => `${r.table}.${r.column}`));
+      const qualify = (r: { table: string; column: string }) => `${r.table}.${r.column}`;
+      return {
+        all: new Set(rows.map(qualify)),
+        arrays: new Set(rows.filter((r) => r.isArray).map(qualify)),
+      };
     };
 
     // Positive control on the CATALOG QUERY, run through the same helper the assertion uses: it
@@ -361,13 +374,27 @@ describe.skipIf(!parityUrl)('Kysely ports return exactly what Prisma returned', 
     await prisma.$executeRawUnsafe(
       `CREATE TABLE IF NOT EXISTS "_ParityArrayProbe" (x "ModelEngagementType"[])`
     );
-    expect([...(await arrayColumnsIn(['_ParityArrayProbe']))]).toEqual(['_ParityArrayProbe.x']);
+    expect([...(await attributesIn(['_ParityArrayProbe'])).arrays]).toEqual([
+      '_ParityArrayProbe.x',
+    ]);
 
-    const arrayColumns = await arrayColumnsIn(tables);
-    const offenders = selected
-      .map(([table, column]) => `${table}.${column}`)
-      .filter((qualified) => arrayColumns.has(qualified));
+    const { all, arrays } = await attributesIn(tables);
+    const qualified = selected.map(([table, column]) => `${table}.${column}`);
 
+    // Positive control on the derivation's CONTENT — the seam between "a name was derived" and "the
+    // catalog can match it", which neither control above covers. Counting items cannot tell a real
+    // column name from a mangled one, and a mangled name matches NOTHING, so `offenders` would be
+    // permanently empty and the assertion below permanently green while the hazard existed.
+    // Verified by mutation: dropping one character from the unquoting in `selectedColumns`
+    // (`slice(1, -1)` → `slice(1)`) fires exactly this, and nothing else.
+    const unknown = qualified.filter((name) => !all.has(name));
+    expect(
+      unknown,
+      `derived column name(s) match no catalog column [${unknown.join(', ')}] — the select-list ` +
+        `derivation is broken, so the array check below cannot fail and would prove nothing`
+    ).toEqual([]);
+
+    const offenders = qualified.filter((name) => arrays.has(name));
     expect(
       offenders,
       `ported query selects ARRAY-typed column(s) [${offenders.join(

--- a/src/server/services/__tests__/get-engaged-models-by-ids.service.test.ts
+++ b/src/server/services/__tests__/get-engaged-models-by-ids.service.test.ts
@@ -108,6 +108,19 @@ vi.mock('~/server/services/user-preferences.service', () => ({
 
 import { getUserEngagedModelsByIds } from '~/server/services/user.service';
 import { getResourceReviewsByUserId } from '~/server/services/resourceReview.service';
+// NOT mocked: the real client the service passes to the ported query function. Before the port the
+// engagement read was `dbRead.modelEngagement.findMany`, so the mock's location pinned the tier and
+// a wrong-tier read blew up. Mocking the query-function seam moves that property out of the suite
+// unless the client argument is pinned with `toBe` — `expect.anything()` is satisfied by
+// `kyselyWrite` just as happily, and so is `toHaveBeenCalledWith(kyselyRead, …)`, because the two
+// clients are distinct objects that compare DEEP-EQUAL. Measured twice: routing every ported read
+// at `kyselyWrite` failed 1 test on pre-port code and passed the whole suite after the port; and
+// the first cut of this fix used `toHaveBeenCalledWith` and that same mutant survived it.
+import { kyselyRead, kyselyWrite } from '~/server/db/kyselyDb';
+
+const WRONG_TIER =
+  'ported read was handed a client other than kyselyRead (kyselyWrite / kyselyReadLong routes it ' +
+  'at the wrong tier); note kyselyRead and kyselyWrite are deep-equal, so only toBe catches this';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -145,7 +158,14 @@ describe('getUserEngagedModelsByIds — membership is scoped to (engagements ∩
 
   it('passes the bounded modelId filter down to both reads (Kysely + Prisma)', async () => {
     await getUserEngagedModelsByIds({ id: USER, modelIds: [A, B, Z] });
-    expect(listModelEngagementsMock).toHaveBeenCalledWith(expect.anything(), {
+    // The client is pinned with `toBe`, not `expect.anything()` and not
+    // `toHaveBeenCalledWith(kyselyRead, …)`: the client argument is the only thing left pinning
+    // this read to the read tier, and a STRUCTURAL matcher cannot pin it — `kyselyRead` and
+    // `kyselyWrite` are distinct objects that compare deep-equal, so the wrong-tier mutant
+    // survives `toHaveBeenCalledWith`. Measured; see the negative control below.
+    expect(listModelEngagementsMock).toHaveBeenCalledTimes(1);
+    expect(listModelEngagementsMock.mock.calls[0][0], WRONG_TIER).toBe(kyselyRead);
+    expect(listModelEngagementsMock.mock.calls[0][1]).toEqual({
       userId: USER,
       modelIds: [A, B, Z],
     });
@@ -156,6 +176,17 @@ describe('getUserEngagedModelsByIds — membership is scoped to (engagements ∩
         where: { userId: USER, recommended: true, modelId: { in: [A, B, Z] } },
       })
     );
+  });
+});
+
+describe('getUserEngagedModelsByIds — read-tier seam', () => {
+  // Negative control on the matcher used above: `kyselyWrite` is a DIFFERENT object, so `toBe`
+  // separates the tiers — but the two are deep-equal, so a structural matcher would not. This
+  // fails if they ever become the same object, at which point the pin above is inert and this
+  // seam needs a different one.
+  it('toBe separates the read and write clients even though toEqual does not', () => {
+    expect(kyselyRead).not.toBe(kyselyWrite);
+    expect(kyselyRead).toEqual(kyselyWrite);
   });
 });
 

--- a/src/server/services/__tests__/get-engaged-models-by-ids.service.test.ts
+++ b/src/server/services/__tests__/get-engaged-models-by-ids.service.test.ts
@@ -10,9 +10,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
  * These tests pin that the new path returns ONLY the intersection of (user's engagements ∩ input
  * modelIds), keyed by engagement type, so the response is bounded by |modelIds| × (#types).
  *
- * `~/server/db/client` is mocked with an in-memory fixture whose `findMany` applies the real
- * `where` clause — so the tests exercise the service's shaping AND that it passes the correct,
- * bounded filters down to Prisma (including through the reused `getResourceReviewsByUserId`).
+ * Both reads are mocked over one in-memory fixture that applies the real filters, so the tests
+ * exercise the service's shaping AND that it passes the correct, bounded filters down. They sit at
+ * two different seams because the two reads now take different paths: the engagement read goes
+ * through `@civitai/db-queries` (Kysely over the app's own pg pool, off the Prisma query engine),
+ * while `getResourceReviewsByUserId` is still Prisma via `~/server/db/client`.
  */
 
 // Model id fixtures (kept in sync with the hoisted mock below — plain numbers, safe to duplicate).
@@ -26,7 +28,7 @@ const E = 105; // Recommended only (outside input)
 const F = 106; // resource review but recommended:false (must never appear)
 const Z = 999; // in input but user has NO engagement
 
-const { mockDb } = vi.hoisted(() => {
+const { mockDb, listModelEngagementsMock } = vi.hoisted(() => {
   const U = 1;
   const OU = 2;
   type EngRow = { userId: number; modelId: number; type: string };
@@ -51,18 +53,21 @@ const { mockDb } = vi.hoisted(() => {
   const inArr = (where: any, field: string) => where?.[field]?.in as number[] | undefined;
 
   return {
+    // The engagement read is served by the Kysely query function, not Prisma. Same in-memory
+    // fixture and same filtering, applied to the ported signature `(db, { userId, modelIds })`.
+    listModelEngagementsMock: vi.fn(
+      async (_db: unknown, { userId, modelIds }: { userId: number; modelIds: number[] }) => {
+        if (!modelIds.length) return [];
+        return engagementRows
+          .filter((r) => r.userId === userId && modelIds.includes(r.modelId))
+          .map((r) => ({ modelId: r.modelId, type: r.type }));
+      }
+    ),
     mockDb: {
+      // Kept only to prove the engagement read NO LONGER goes through Prisma.
       modelEngagement: {
-        findMany: vi.fn(async ({ where }: any) => {
-          const ids = inArr(where, 'modelId');
-          return engagementRows
-            .filter(
-              (r) =>
-                r.userId === where.userId &&
-                (where.type === undefined || r.type === where.type) &&
-                (!ids || ids.includes(r.modelId))
-            )
-            .map((r) => ({ modelId: r.modelId, type: r.type }));
+        findMany: vi.fn(async () => {
+          throw new Error('modelEngagement.findMany must not be called — ported to Kysely');
         }),
       },
       resourceReview: {
@@ -83,6 +88,10 @@ const { mockDb } = vi.hoisted(() => {
 });
 
 vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
+// The engagement read runs through @civitai/db-queries over the app's own pg pool, bypassing the
+// Prisma query engine. Mocked at that seam so these tests keep exercising the service's shaping
+// and the bounded filters it passes down.
+vi.mock('@civitai/db-queries/model', () => ({ listModelEngagements: listModelEngagementsMock }));
 // user.service reaches into user-preferences.service at import time; stub the surface
 // (matches the proven recipe in engagement-toggle.idempotent.service.test.ts).
 vi.mock('~/server/services/user-preferences.service', () => ({
@@ -134,11 +143,14 @@ describe('getUserEngagedModelsByIds — membership is scoped to (engagements ∩
     expect(allIds).not.toContain(Z);
   });
 
-  it('passes the bounded modelId filter down to Prisma (both tables)', async () => {
+  it('passes the bounded modelId filter down to both reads (Kysely + Prisma)', async () => {
     await getUserEngagedModelsByIds({ id: USER, modelIds: [A, B, Z] });
-    expect(mockDb.modelEngagement.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { userId: USER, modelId: { in: [A, B, Z] } } })
-    );
+    expect(listModelEngagementsMock).toHaveBeenCalledWith(expect.anything(), {
+      userId: USER,
+      modelIds: [A, B, Z],
+    });
+    // The engagement read no longer touches the Prisma engine.
+    expect(mockDb.modelEngagement.findMany).not.toHaveBeenCalled();
     expect(mockDb.resourceReview.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { userId: USER, recommended: true, modelId: { in: [A, B, Z] } },
@@ -218,10 +230,10 @@ describe('getUserEngagedModelsByIds — freeze-safety bound', () => {
     const bigEng = modelIds.flatMap((modelId) => types.map((type) => ({ modelId, type })));
     const bigRev = modelIds.map((modelId, i) => ({ modelId, modelVersionId: 9000 + i }));
 
-    mockDb.modelEngagement.findMany.mockImplementationOnce(async ({ where }: any) => {
-      const ids = where.modelId.in as number[];
-      return bigEng.filter((r) => ids.includes(r.modelId));
-    });
+    listModelEngagementsMock.mockImplementationOnce(
+      async (_db: unknown, { modelIds: ids }: { userId: number; modelIds: number[] }) =>
+        bigEng.filter((r) => ids.includes(r.modelId))
+    );
     mockDb.resourceReview.findMany.mockImplementationOnce(async ({ where }: any) => {
       const ids = where.modelId.in as number[];
       return bigRev.filter((r) => ids.includes(r.modelId));

--- a/src/server/services/__tests__/tag.service.unlisted.test.ts
+++ b/src/server/services/__tests__/tag.service.unlisted.test.ts
@@ -7,6 +7,8 @@ const {
   imageVotes,
   modelTagFindMany,
   modelVotes,
+  prismaImageVotes,
+  prismaModelVotes,
   modelVotableTagsFetch,
   modelVotableTagsBust,
   executeRaw,
@@ -24,6 +26,12 @@ const {
   imageVotes: vi.fn().mockResolvedValue([]),
   modelTagFindMany: vi.fn(),
   modelVotes: vi.fn().mockResolvedValue([]),
+  prismaImageVotes: vi.fn(async () => {
+    throw new Error('tagsOnImageVote.findMany must not be called — ported to Kysely');
+  }),
+  prismaModelVotes: vi.fn(async () => {
+    throw new Error('tagsOnModelsVote.findMany must not be called — ported to Kysely');
+  }),
   modelVotableTagsFetch: vi.fn(),
   modelVotableTagsBust: vi.fn(),
   executeRaw: vi.fn().mockResolvedValue(undefined),
@@ -63,10 +71,18 @@ vi.mock('~/server/redis/client', async (importOriginal) => {
     },
   };
 });
+// The per-user vote reads run through @civitai/db-queries (Kysely over the app's own pg pool),
+// bypassing the Prisma query engine. Mocked at that seam; the Prisma spies below are kept only to
+// prove those reads no longer go through it.
+vi.mock('@civitai/db-queries/tag', () => ({
+  listImageTagVotes: imageVotes,
+  listImageTagVotesMany: imageVotes,
+  listModelTagVotes: modelVotes,
+}));
 vi.mock('~/server/db/client', () => ({
   dbRead: {
-    tagsOnImageVote: { findMany: imageVotes },
-    tagsOnModelsVote: { findMany: modelVotes },
+    tagsOnImageVote: { findMany: prismaImageVotes },
+    tagsOnModelsVote: { findMany: prismaModelVotes },
     // Kept only to prove the model path NO LONGER reads the ModelTag view directly.
     modelTag: { findMany: modelTagFindMany },
     model: { findFirst: modelFindFirst },
@@ -181,9 +197,9 @@ describe('getVotableTags — model tags', () => {
 
     it('merges each user OWN vote from their own tagsOnModelsVote read, uncached', async () => {
       // User A upvoted; user B downvoted the SAME tag on the SAME model.
-      modelVotes.mockImplementation(async ({ where }: { where: { userId: number } }) => {
-        if (where.userId === 111) return [{ tagId: NUDE, vote: 1 }];
-        if (where.userId === 222) return [{ tagId: NUDE, vote: -1 }];
+      modelVotes.mockImplementation(async (_db: unknown, { userId }: { userId: number }) => {
+        if (userId === 111) return [{ tagId: NUDE, vote: 1 }];
+        if (userId === 222) return [{ tagId: NUDE, vote: -1 }];
         return [];
       });
 
@@ -195,14 +211,16 @@ describe('getVotableTags — model tags', () => {
       expect(bTags.find((t) => t.id === NUDE)?.vote).toBe(-1);
 
       // The per-user vote read is scoped to that user + this model (uncached path).
-      expect(modelVotes).toHaveBeenNthCalledWith(1, {
-        where: { modelId: 1, userId: 111 },
-        select: { tagId: true, vote: true },
+      expect(modelVotes).toHaveBeenNthCalledWith(1, expect.anything(), {
+        modelId: 1,
+        userId: 111,
       });
-      expect(modelVotes).toHaveBeenNthCalledWith(2, {
-        where: { modelId: 1, userId: 222 },
-        select: { tagId: true, vote: true },
+      expect(modelVotes).toHaveBeenNthCalledWith(2, expect.anything(), {
+        modelId: 1,
+        userId: 222,
       });
+      // The vote read no longer touches the Prisma engine.
+      expect(prismaModelVotes).not.toHaveBeenCalled();
     });
 
     it('an anonymous request never reads per-user votes', async () => {

--- a/src/server/services/__tests__/tag.service.unlisted.test.ts
+++ b/src/server/services/__tests__/tag.service.unlisted.test.ts
@@ -107,9 +107,19 @@ import {
   addTags,
   deleteTags,
   disableTags,
+  getVotableImageTags,
   getVotableTags,
   removeTagVotes,
 } from '~/server/services/tag.service';
+// NOT mocked: the real client the service passes to the ported query functions. Asserting it with
+// `toBe` is what keeps these reads pinned to the read tier — see the read-tier describe at the
+// bottom of this file for why `toBe` and not a structural matcher.
+import { kyselyRead, kyselyWrite } from '~/server/db/kyselyDb';
+import type { SessionUser } from '~/types/session';
+
+const WRONG_TIER =
+  'ported read was handed a client other than kyselyRead (kyselyWrite / kyselyReadLong routes it ' +
+  'at the wrong tier); note kyselyRead and kyselyWrite are deep-equal, so only toBe catches this';
 
 const LOLI = 114467;
 const NUDE = 304;
@@ -210,15 +220,14 @@ describe('getVotableTags — model tags', () => {
       expect(aTags.find((t) => t.id === NUDE)?.vote).toBe(1);
       expect(bTags.find((t) => t.id === NUDE)?.vote).toBe(-1);
 
-      // The per-user vote read is scoped to that user + this model (uncached path).
-      expect(modelVotes).toHaveBeenNthCalledWith(1, expect.anything(), {
-        modelId: 1,
-        userId: 111,
-      });
-      expect(modelVotes).toHaveBeenNthCalledWith(2, expect.anything(), {
-        modelId: 1,
-        userId: 222,
-      });
+      // The per-user vote read is scoped to that user + this model (uncached path), and runs on
+      // the READ tier. The client is asserted with `toBe` — see the read-tier describe at the
+      // bottom of this file for why matcher choice is load-bearing here.
+      expect(modelVotes.mock.calls[0][0], WRONG_TIER).toBe(kyselyRead);
+      expect(modelVotes.mock.calls[0][1]).toEqual({ modelId: 1, userId: 111 });
+      expect(modelVotes.mock.calls[1][0], WRONG_TIER).toBe(kyselyRead);
+      expect(modelVotes.mock.calls[1][1]).toEqual({ modelId: 1, userId: 222 });
+      expect(modelVotes).toHaveBeenCalledTimes(2);
       // The vote read no longer touches the Prisma engine.
       expect(prismaModelVotes).not.toHaveBeenCalled();
     });
@@ -353,5 +362,65 @@ describe('getVotableTags — model votable-tags cache invalidation contract', ()
   it('a model vote does NOT bust the getTags listing cache (join-table only)', async () => {
     await addTagVotes({ userId: 111, type: 'model', id: 1, tags: [304], vote: 1 });
     expect(bustCacheTagSpy).not.toHaveBeenCalledWith('getTags');
+  });
+});
+
+/**
+ * Read-tier seam.
+ *
+ * Before the Kysely port these reads were `dbRead.tagsOn*Vote.findMany`, and the mock lived on
+ * `dbRead` SPECIFICALLY — so a read routed at the writer had no mock to hit and blew up. Mocking
+ * the query-function seam instead moves that property out of the suite unless the client argument
+ * is pinned: `expect.anything()` is satisfied by `kyselyWrite`, `kyselyReadLong` or anything else.
+ * That loss was measured, not assumed — routing every ported read at `kyselyWrite` failed 1 test
+ * on pre-port code and passed the whole suite after the port.
+ *
+ * 🔴 The matcher matters as much as the argument. `kyselyRead` and `kyselyWrite` are DISTINCT
+ * objects but they are `toEqual`-DEEP-EQUAL (same Kysely shape, and in a single-DB environment the
+ * same underlying pool), so `toHaveBeenCalledWith(kyselyRead, …)` — which compares structurally —
+ * still passes when the read is routed at the writer. Measured, again: the first cut of this fix
+ * used `toHaveBeenCalledWith` and the wrong-tier mutant survived it. Only `toBe` discriminates.
+ *
+ * These pin the tier for the two image-side ports; the model-side port is pinned inline in the
+ * per-user vote merge test above.
+ */
+describe('ported vote reads run on the kyselyRead tier, not the writer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    imageVotes.mockResolvedValue([]);
+    modelVotes.mockResolvedValue([]);
+    imageTagsFetch.mockResolvedValue({ 1: { imageId: 1, tags: [] } });
+    primeModelCache(1, [modelTag(NUDE, 'nude')]);
+    tagCacheFetch.mockResolvedValue({ [NUDE]: { id: NUDE, name: 'nude' } });
+  });
+
+  it('getVotableTags(image) reads one image’s votes through kyselyRead', async () => {
+    await getVotableTags({ type: 'image', id: 1, userId: 111, isModerator: true });
+    expect(imageVotes).toHaveBeenCalledTimes(1);
+    expect(imageVotes.mock.calls[0][0], WRONG_TIER).toBe(kyselyRead);
+    expect(imageVotes.mock.calls[0][1]).toEqual({ imageId: 1, userId: 111 });
+  });
+
+  it('getVotableTags(model) reads one model’s votes through kyselyRead', async () => {
+    await getVotableTags({ type: 'model', id: 1, userId: 111, isModerator: true });
+    expect(modelVotes).toHaveBeenCalledTimes(1);
+    expect(modelVotes.mock.calls[0][0], WRONG_TIER).toBe(kyselyRead);
+    expect(modelVotes.mock.calls[0][1]).toEqual({ modelId: 1, userId: 111 });
+  });
+
+  it('getVotableImageTags reads the bulk vote overlay through kyselyRead', async () => {
+    await getVotableImageTags({ ids: [1], user: { id: 111 } as SessionUser });
+    expect(imageVotes).toHaveBeenCalledTimes(1);
+    expect(imageVotes.mock.calls[0][0], WRONG_TIER).toBe(kyselyRead);
+    expect(imageVotes.mock.calls[0][1]).toEqual({ imageIds: [1], userId: 111 });
+  });
+
+  // Negative control on the matcher above: `kyselyWrite` is a DIFFERENT object, so `toBe`
+  // separates the tiers — but it is deep-equal, so a structural matcher would not. This pins the
+  // reason `toBe` is used, and fails if the two clients ever become the same object (at which
+  // point the assertions above would be inert and this seam needs a different pin).
+  it('toBe separates the read and write clients even though toEqual does not', () => {
+    expect(kyselyRead).not.toBe(kyselyWrite);
+    expect(kyselyRead).toEqual(kyselyWrite);
   });
 });

--- a/src/server/services/tag.service.ts
+++ b/src/server/services/tag.service.ts
@@ -8,9 +8,15 @@ import {
   type TagVotableEntityType,
   type VotableTagModel,
 } from '~/libs/tags';
+import {
+  listImageTagVotes,
+  listImageTagVotesMany,
+  listModelTagVotes,
+} from '@civitai/db-queries/tag';
 import { CacheTTL, constants } from '~/server/common/constants';
 import { NsfwLevel, TagSort } from '~/server/common/enums';
 import { dbRead, dbWrite } from '~/server/db/client';
+import { kyselyRead } from '~/server/db/kyselyDb';
 import {
   imageTagsCache,
   modelVotableTagsCache,
@@ -464,10 +470,7 @@ export const getVotableTags = async ({
       }))
     );
     if (userId) {
-      const userVotes = await dbRead.tagsOnModelsVote.findMany({
-        where: { modelId: id, userId },
-        select: { tagId: true, vote: true },
-      });
+      const userVotes = await listModelTagVotes(kyselyRead, { modelId: id, userId });
 
       for (const tag of results) {
         const userVote = userVotes.find((vote) => vote.tagId === tag.id);
@@ -505,10 +508,7 @@ export const getVotableTags = async ({
       );
     }
     if (userId) {
-      const userVotes = await dbRead.tagsOnImageVote.findMany({
-        where: { imageId: id, userId },
-        select: { tagId: true, vote: true },
-      });
+      const userVotes = await listImageTagVotes(kyselyRead, { imageId: id, userId });
 
       for (const tag of results) {
         const userVote = userVotes.find((vote) => vote.tagId === tag.id);
@@ -573,10 +573,7 @@ export async function getVotableImageTags({
     allImageTags.push(...filteredTags);
   }
 
-  const userVotes = await dbRead.tagsOnImageVote.findMany({
-    where: { imageId: { in: ids }, userId: user.id },
-    select: { tagId: true, vote: true },
-  });
+  const userVotes = await listImageTagVotesMany(kyselyRead, { imageIds: ids, userId: user.id });
 
   for (const tag of allImageTags) {
     const userVote = userVotes.find((vote) => vote.tagId === tag.id);

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -18,7 +18,9 @@ import {
   SearchIndexUpdateQueueAction,
 } from '~/server/common/enums';
 import { clickhouse } from '~/server/clickhouse/client';
+import { listModelEngagements } from '@civitai/db-queries/model';
 import { dbRead, dbWrite } from '~/server/db/client';
+import { kyselyRead } from '~/server/db/kyselyDb';
 
 import { preventReplicationLag } from '~/server/db/db-lag-helpers';
 import { withSpan } from '~/server/utils/otel-helpers';
@@ -635,10 +637,7 @@ export const getUserEngagedModelsByIds = async ({
   modelIds: number[];
 }) => {
   const [engagements, recommendedReviews] = await Promise.all([
-    dbRead.modelEngagement.findMany({
-      where: { userId: id, modelId: { in: modelIds } },
-      select: { modelId: true, type: true },
-    }),
+    listModelEngagements(kyselyRead, { userId: id, modelIds }),
     getResourceReviewsByUserId({ userId: id, recommended: true, modelIds }),
   ]);
 


### PR DESCRIPTION
## Why

The Prisma query engine runs in-process, and its CPU cost scales with call volume — so the highest-frequency read statements pay the most for it. Going through Kysely over the app's own `pg.Pool` bypasses the engine entirely for that query.

Worth stating explicitly, because it is the obvious wrong turn: **`$queryRaw` on the `PrismaClient` does not achieve this.** It still goes through the engine. Only the separate-pool path removes it.

This is the first cutover of real call sites onto the existing `@civitai/db-queries` escape hatch — the package, the `prisma-kysely` generator, `kyselyDb.ts` and the harnesses were already in place; nothing new was built.

## What was ported, and why these

The two highest-volume read paths that are read-only, transaction-free and stable in shape:

| Query | Path | Notes |
|---|---|---|
| `listImageTagVotes`, `listImageTagVotesMany`, `listModelTagVotes` | the per-user vote overlay behind the votable-tag endpoint | the tag rows already come from a cache; only the caller's own votes are read per request |
| `listModelEngagements` | the per-visible-set engagement membership read | bounded input, buckets rows by type |

Each is a 1:1 swap onto the **same read tier**: `dbRead` (Prisma) and `kyselyRead` ride the same underlying pool, so there is no routing, pagination or ordering change. Both services already reached `kyselyDb` transitively via `db-lag-helpers`, so this adds no new module edges.

Two candidates were deliberately left alone: `getGenerationData` (a large branching graph — a much bigger surface than one statement) and `getResourceReviewsByUserId` (shared with whole-history callers whose optional-filter semantics differ; a separate, riskier change).

## How equivalence was verified

Behaviour equivalence is the whole point, so it is not left to review. `src/server/db/__tests__/kysely-prisma-parity.test.ts` runs **both** implementations against the **same rows in the same database** and deep-compares — rather than asserting the Kysely result against a hand-written expectation, which would only re-state what the new code does. 16 cases: empty results, empty input arrays, cross-user and cross-entity isolation, both vote polarities, every engagement type, and column typing.

It is opt-in via `KYSELY_PARITY_DATABASE_URL` and deliberately does **not** fall back to `DATABASE_URL` — it writes fixtures, so it needs a throwaway database. One-line docker command is in the test header.

Underneath that, the package tiers: exact compiled-SQL assertions (no DB, runs in CI) and `EXPLAIN` against a real schema. There are **4** new `EXPLAIN` checks (3 tag-vote + 1 engagement).

### 🔴 Which of that evidence runs in CI, and which does not

The table further down is a **laptop** run against a throwaway Postgres. Splitting it honestly, because it does not read that way at a glance:

| Evidence | Runs in CI? |
|---|---|
| `pnpm typecheck` | ✅ yes |
| full `unit` project (14k tests) | ✅ yes — report-only, `continue-on-error` |
| `@civitai/db-queries` compiled-SQL + plugin tests (26) | ✅ yes, in "Package unit tests" |
| eslint on changed files | ✅ yes |
| the 16-case **parity suite** | ❌ **never** — self-skips without `KYSELY_PARITY_DATABASE_URL` |
| the 4 new **`EXPLAIN`** checks | ❌ **never** — self-skip without a DB |
| the enum-array **seam guard** | ❌ **never** — it lives inside the parity suite |

Measured with no DB present: the package suite reports **26 passed, 8 skipped**, and those 8 DB-backed tests span three files (6 `tag.db.explain`, 1 `model.db.explain`, 1 `enum-array-parsers.explain`). `.github/workflows/lint.yml` said "4 across two files"; this PR corrects that comment and adds the never-run-in-CI statement to it.

So the strongest evidence in this PR — the behaviour-parity comparison — is **operator-run, not gated**. Wiring a CI database is deliberately out of scope here.

## The two guards the audit found, and what they are now

An adversarial audit confirmed the ported queries are behaviourally correct and found **two guards that were claimed to work and did not**. Both are fixed in the second commit, and both were re-verified with the exact mutant that had survived.

**1. The enum-array seam guard could not fail for the hazard it advertised.** Its column set was a hand-written literal, disconnected from the actual `.select()` calls. The audit added a real `"ModelEngagementType"[]` column and widened `listModelEngagements` onto it — and the guard **passed**. An earlier revision of this PR body, the commit message and the test's own comment all said such a widening "fails loudly"; that was false, and worse than saying nothing, because it invites a maintainer to skip the check that matters.

It is now **structural**: each ported query is compiled through the package's `compileHarness` and the select list is read back off the **compiled SQL**, so the checked set tracks the real query instead of somebody's memory. `selectedColumns()` throws on any statement shape it does not fully understand rather than returning an empty set — a silent zero is exactly how the old version became vacuous — and a positive control asserts the derivation produced at least the 8 columns the four ports select today.

Also corrected: it checks the catalog of the **fixture database this suite creates**, not "the live catalog".

**2. The moved test seam no longer pinned the read tier.** Before the port these reads were `dbRead.<table>.findMany` and the mock lived on `dbRead` *specifically*, so a wrong-tier read blew up. Mocking the query-function seam moved that property out of the suites, which asserted the client as `expect.anything()`. Measured by the audit: routing all four ported reads at `kyselyWrite` failed 1 test on pre-port code and passed all 35 after.

The client is now pinned to `kyselyRead` — with a matcher caveat worth reading, because the obvious fix is also inert: **`kyselyRead` and `kyselyWrite` are distinct objects that compare deep-equal**, so `toHaveBeenCalledWith(kyselyRead, …)` *still* passes under the wrong-tier mutant. The first cut of the fix used it and the mutant survived. Only `toBe` discriminates, and each file carries a negative control (`not.toBe` + `toEqual`) that pins that reason and fails if the two clients ever become one object. Coverage also widened from 2 of the 4 ported reads to all 4.

## Round 2 — the replacement guard had two silent-degradation paths of its own

A delta re-audit confirmed both round-1 fixes land, and found that the new seam guard could still
report green while the hazard it exists to catch was present. Both were reproduced end to end
before being fixed.

**a. It inspected only the LAST compiled statement.** It read `harness.lastQuery()`, so a ported
query issuing more than one statement was checked on its final statement alone. Reproduced: give
`listModelEngagements` a first statement selecting a real `"ModelEngagementType"[]` column and the
suite passes **16/16**, seam guard included. The *same* column as the last statement fails 4 tests
— which is what makes this a blind spot rather than a dead test. It also contradicted the guard's
own docblock, which promises it "may not degrade quietly". It now iterates `harness.queries`.

**b. Neither positive control covered the derivation → catalog NAME seam.**
`expect(selected.length).toBeGreaterThanOrEqual(8)` proves 8 *items* were derived, not that any is
a name the catalog can match; the catalog control asserted a hardcoded `_ParityArrayProbe.x`, never
a derived name. Reproduced with a **one-character** edit — `item.slice(1, -1)` → `item.slice(1)` —
after which every derived name carries a trailing quote, matches nothing, leaves `offenders`
permanently `[]`, and **both** controls stay green. Stacked with a genuine enum-array widening the
seam guard drops out of the failure set entirely (4 failures become 3). The guard now asserts every
derived `(table, column)` pair exists in `pg_attribute`, and one catalog query feeds both checks so
a control cannot certify a path the assertion does not use.

**c. The `./test-harness` subpath exposed the DB-backed helpers.** It pointed at `test/harness.ts`,
which also exports `explainHarness()` / `testDbUrl()` — and the latter falls back to
`DATABASE_URL`, exactly the fallback this suite refuses on purpose. Nothing imports it today, but a
production import of `explainHarness()` would open a second pool against the real database.
`compileHarness` moved to its own module, which is what the subpath now points at, so the refusal
to fall back is a property of the suite's whole import graph rather than just its own code.

## Post-fix mutant battery

Every mutant applied to a freshly restored tree, tiers run per mutant, with a no-mutant control
first *and* again at the end so a red tier is attributable. Each result is quoted by its **own**
reason — a mutant killed by a different guard's error would still be green with the intended guard
deleted.

| Mutant | Result |
|---|---|
| *(control — no mutant)* | parity 16 pass · package 26 pass / 8 skip · services 40 pass |
| drop the `userId` predicate from `listImageTagVotes` | parity **2 fail** (`to have a length of 2 but got 3`) **+** the compiled-SQL test |
| comment out the `listModelEngagements` empty-array guard | parity **1 fail**: `syntax error at or near ")"` |
| comment out the `listImageTagVotesMany` empty-array guard | parity **1 fail**: `syntax error at or near ")"` |
| off-by-one on the bulk id list (`imageIds.slice(1)`) | parity **2 fail** (`length of 4 but got 2`) **+** the compiled-SQL test |
| route all four ported reads at `kyselyWrite` | services **5 fail**, all `ported read was handed a client other than kyselyRead` |
| widen onto an enum-array column, **as the LAST statement** | parity **4 fail**, incl. the seam guard by its own `selects ARRAY-typed column(s) [ModelEngagement.types]` |
| widen onto an enum-array column, **as the FIRST of two** | parity **1 fail** — the seam guard *alone*, same message. **Was 16/16 green before this round** |
| one-character break in the guard's own derivation | parity **1 fail**: `derived column name(s) match no catalog column`. **Was 16/16 green before this round**; the `>= 8` control does *not* fire |
| repoint the subpath at the DB-backed harness | package **1 fail**: `expected './src/test/harness.ts' to be './src/test/compile-harness.ts'` |
| add `testDbUrl` to the public module | package **2 fail**: `expected [ 'compileHarness', 'testDbUrl' ] to deeply equal [ 'compileHarness' ]` |

**typecheck** 0 errors — but note `tsconfig.json` excludes `src/**/__tests__/**`, so `pnpm
typecheck` does **not** see the parity suite at all (`--listFilesOnly`: 0 of 11,552 program files).
It was checked separately under a scoped config; both instruments were validated by watching a
deliberate error get reported by file and line. The other four changed files *are* in the root
program.

**eslint** unchanged: 6 errors / 0 warnings in the `packages` scope, 0/0 on the changed `src` file
— measured at base and at head **in one tree**, so a single plugin resolution applies. Both scopes
carry a positive control (an added `~/...` import raises packages 6 → 7 naming the new file; an
unused local raises the src file 0 → 1 warning), because `packages/.eslintrc.cjs` is `root: true`
and enables only two rules, so a bare "0 problems" there is unreadable. **prettier** clean.

Recorded, deliberately not fixed: the statement-shape docblock slightly overstates what the regex
rejects; the structural half of the guard is gated behind a DB it does not need; two service
functions share one mock; `PORTED_QUERIES` is still hand-maintained.

## Behaviour preserved deliberately

`listImageTagVotesMany` keeps the source query's narrow select (`tagId`/`vote`, **no** `imageId`). The caller keys votes by tagId alone, so a vote is applied per tag rather than per (image, tag) pair. That is existing behaviour; widening the select would change what the endpoint returns, which is a behaviour change, not a fix. It is pinned by its own test.

Neither query gained an `ORDER BY` — the sources had none, and the primary keys make the rows unique per lookup key, so row order is not observable to the callers.

## The two documented gotchas

- **`setTypeParser` is a process-global mutation.** Not newly exercised here: the numeric parsers are registered lazily inside the client factory, and this change adds no new registration.
- **Enum arrays.** pg has no parser for an array of a user-defined enum (dynamic oid), so such a column arrives as the raw `{a,b}` literal unless `registerEnumArrayTypeParsers` has run. **None of the columns selected here is an array type** — `ModelEngagement.type` is a *scalar* enum, which pg reads back as plain text with no registration. The seam guard above is what keeps that true as the selects change.

## Test-seam change worth a look

The two existing suites that mocked the Prisma client for these tables now mock the query-function seam instead, and **additionally assert the Prisma path is no longer called**, so a regression back onto the engine fails the test. This was found the honest way: those 14 tests went red on the first full run because the service no longer hit their mocks. See the read-tier caveat above for what that move cost and how it is now pinned back.

## Gate

Laptop run unless the CI column above says otherwise.

| Check | Result |
|---|---|
| `pnpm typecheck` | 0 errors (positive control: a deliberate error in `model.db.ts` is reported by file and line) |
| `pnpm test:unit:run` | 14139 passed, 17 skipped, 15 failed in 2 files — `hiddenBlocks` and `recent-source-images`, which fail **identically on the merge-base**; a local jsdom/environment break, not this PR |
| `@civitai/db-queries` (no DB, the CI condition) | 26 passed, 8 skipped, 0 failed |
| `@civitai/db-queries` (against a real Postgres) | all 4 new `EXPLAIN` checks pass; the pre-existing failures needing `Tag` + the `CommercialUse` enum remain, since the minimal parity fixture does not create them |
| parity suite | 16 passed |
| `eslint` on changed files | **0 new errors, 0 new warnings.** All three revisions measured inside ONE tree, because two checkouts of this repo can resolve different `@typescript-eslint` versions and silently disagree on severity: merge-base 12 problems (2 errors) → PR head 10 (2 errors) → here 10 (2 errors) |
| `prettier --check` on changed files | clean |

`tag.service.ts` is left unformatted where it already was on `main` (one pre-existing line, unrelated to this change) rather than mixing a reformat into the diff; the added files are Prettier-clean.

## Not verified

This is a CPU-efficiency change whose effect is only observable under real traffic. Nothing here measures that — the claim being made is **equivalence**, which is tested, and which (see above) is tested **outside** CI. Draft on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## `preview / deploy` is red — measured NOT to be this PR

The `build-image` step fails with `Turbopack build failed`, every error being
`TypeError: __turbopack_context__.a is not a function` at
`postcss.config.js_.loader.mjs`, with CSS-only import traces (`@mantine/*` styles,
`src/styles/utils.module.scss` via `src/pages/product/odor.tsx`) — files this PR does not touch.
`typecheck` and `unit-tests` passed in the same run.

It looked attributable: the original head `1bef7dff25` built clean, the current head failed, and
all three heads involved share the same merge base (`a9e9ddf533`), so main moving underneath is
excluded. It reproduces locally on a cold cache, so it is not the builder's shared
`--mount=type=cache,target=/app/.next/cache` either.

**It is a nondeterministic pre-existing failure. Repeated cold production builds
(`SKIP_ENV_VALIDATION=1 IS_BUILD=true pnpm run build`, `.next` removed each time, tree fingerprint
asserted identical on every run):**

| Tree | Cold builds | FAIL | PASS |
|---|---|---|---|
| this PR's head | 4 | 2 | 2 |
| merge base `a9e9ddf533` (none of this PR's changes) | 5 | 2 | 3 |

The base fails with the identical error, so the break is not caused by this PR. The count of
`context.a` errors also varies run to run (107, 2, 2), which is what a race looks like rather than
a property of the source.

Mechanism, as far as it was traced: Turbopack always emits the postcss config loader as an async
module (`__turbopack_context__.a(async ...)`), but the Node.js build runtime it is instantiated in
(`[turbopack]_runtime.js`) defines `.A`, `.y`, `.i`, `.s` and **not** `.a` — so whether a build
survives depends on which runtime variant gets emitted for that chunk group. Next 16.3.0 /
Turbopack; `turbopackFileSystemCacheForBuild` is already `false` in `next.config.mjs`, so this is
not the persistent FS cache.

Not fixed here — it is upstream of this change and wants its own issue. Flagged rather than
retried-until-green: re-running the check until it passes would hide a real intermittent build
failure affecting every PR and `main`.

**A caveat on the earlier rows in this PR's verification table: they were all `tsc` and Vitest.
Neither exercises the bundler. The numbers above are the first real `next build` evidence on this
branch.**
