### PR TITLE
fix(image-search): stop logging the session user object on search-error

### DIFF
--- a/src/server/services/__tests__/search-error-log-pii.test.ts
+++ b/src/server/services/__tests__/search-error-log-pii.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// `getInfiniteImagesHandler` spreads the whole `ctx.user` session object into the
+// image search input for business logic. Both `search-error` catch blocks in
+// image.service used to log that input verbatim, which shipped `email`,
+// `emailVerified`, `username` and `createdAt` for every erroring search —
+// measured at 331,164 records/day in production, each naming a real account.
+//
+// Two levels of coverage here, because they fail independently:
+//   1. `redactSearchInputForLog` actually removes the session user (behaviour).
+//   2. The two catch blocks CALL it (the seam). A correct redactor that nothing
+//      invokes is exactly the shape this bug already had — a unit test of the
+//      helper alone would stay green through a revert of either call site, so
+//      the seam cases drive the real catch path and inspect what was logged.
+//
+// Mock preamble mirrors image-metrics-timeout.test.ts: the smallest set of
+// stubs that lets image.service import without booting real infra.
+
+import type * as LoggingClient from '~/server/logging/client';
+import type * as MeilisearchClient from '~/server/meilisearch/client';
+
+const { logToAxiomMock, fetchDocumentsAbortableMock } = vi.hoisted(() => ({
+  logToAxiomMock: vi.fn(() => Promise.resolve()),
+  fetchDocumentsAbortableMock: vi.fn(),
+}));
+
+vi.mock('~/server/logging/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof LoggingClient>();
+  return { ...actual, logToAxiom: logToAxiomMock };
+});
+
+// metricsSearchClient must be TRUTHY or both functions early-return before the
+// try/catch we are testing. fetchDocumentsAbortable is the throw seam.
+vi.mock('~/server/meilisearch/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof MeilisearchClient>();
+  return {
+    ...actual,
+    metricsSearchClient: {},
+    getMetricsSearchClient: () => ({}),
+    fetchDocumentsAbortable: fetchDocumentsAbortableMock,
+  };
+});
+
+vi.mock('~/env/server', () => ({
+  env: new Proxy({ LOGGING: [] as string[] } as Record<string, unknown>, {
+    get: (target, prop) => {
+      if (prop in target) return target[prop as string];
+      if (typeof prop === 'string' && (prop.endsWith('_URL') || prop.endsWith('_ENDPOINT')))
+        return 'https://test:test@localhost:5432/test';
+      if (
+        typeof prop === 'string' &&
+        /(_CONCURRENCY|_LIMIT|_MS|_PORT|_TIMEOUT|_MAX|_SIZE|_COUNT)$/.test(prop)
+      )
+        return 1;
+      return undefined;
+    },
+  }),
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/redis/client', () => {
+  const make = (): any => new Proxy(() => 'k', { get: () => make() });
+  const keyProxy = make();
+  return {
+    redis: { packed: { get: vi.fn(), set: vi.fn() } },
+    sysRedis: {},
+    REDIS_KEYS: keyProxy,
+    REDIS_SYS_KEYS: keyProxy,
+  };
+});
+vi.mock('../../../../event-engine-common/services/metrics', () => ({
+  MetricService: class {
+    fetch = vi.fn();
+  },
+}));
+vi.mock('../../../../event-engine-common/feeds', () => ({ ImagesFeed: class {} }));
+vi.mock('../../../../event-engine-common/services/cache', () => ({ CacheService: class {} }));
+
+import {
+  redactSearchInputForLog,
+  getImagesFromSearchPreFilter,
+  getImagesFromSearchPostFilter,
+} from '../image.service';
+
+/** The real shape observed in production logs, values substituted. */
+const sessionUser = {
+  id: 4321,
+  username: 'a-real-username',
+  email: 'someone@example.com',
+  emailVerified: '2024-01-02T03:04:05.000Z',
+  createdAt: '2023-05-06T07:08:09.000Z',
+  isModerator: false,
+  muted: false,
+  showNsfw: true,
+  browsingLevel: 31,
+  permissions: [],
+  roles: [],
+  meta: { scores: { total: 12, users: 3 } },
+  filePreferences: { fp: 'fp16', size: 'pruned', format: 'SafeTensor' },
+};
+
+/** Every field that must never reach a log sink, with a distinctive value. */
+const PII_VALUES = [
+  'someone@example.com',
+  'a-real-username',
+  '2024-01-02T03:04:05.000Z',
+  '2023-05-06T07:08:09.000Z',
+];
+
+const searchInput = {
+  user: sessionUser,
+  // `userId` is a SEARCH FILTER (feed-by-creator) and is NOT the session user.
+  // It must survive redaction intact — remapping user.id onto it would corrupt
+  // the logged query, so this doubles as the regression guard for that.
+  userId: 999,
+  currentUserId: 4321,
+  isModerator: false,
+  limit: 20,
+  period: 'AllTime',
+  sort: 'Newest',
+  browsingLevel: 31,
+  include: ['tagIds'],
+  headers: { src: 'getInfiniteImagesHandler' },
+};
+
+describe('redactSearchInputForLog', () => {
+  it('drops the session user object entirely', () => {
+    const out = redactSearchInputForLog(searchInput) as Record<string, unknown>;
+    expect(out).not.toHaveProperty('user');
+  });
+
+  it('carries no PII value anywhere in its serialized output', () => {
+    const serialized = JSON.stringify(redactSearchInputForLog(searchInput));
+    for (const v of PII_VALUES) expect(serialized).not.toContain(v);
+    // positive control: the un-redacted input DOES contain every one of them,
+    // so the assertions above are capable of failing.
+    const raw = JSON.stringify(searchInput);
+    for (const v of PII_VALUES) expect(raw).toContain(v);
+  });
+
+  it('preserves the diagnostic fields, including the userId SEARCH FILTER', () => {
+    const out = redactSearchInputForLog(searchInput) as Record<string, unknown>;
+    expect(out.userId).toBe(999); // NOT overwritten with the session user's 4321
+    expect(out.currentUserId).toBe(4321); // session id still available for triage
+    expect(out.isModerator).toBe(false);
+    expect(out.limit).toBe(20);
+    expect(out.period).toBe('AllTime');
+    expect(out.sort).toBe('Newest');
+  });
+
+  it('is a denylist of exactly the user key — an unknown future PII field on the session user cannot leak', () => {
+    const out = redactSearchInputForLog({
+      ...searchInput,
+      user: { ...sessionUser, someFieldAddedLater: 'phone:+15551234567' },
+    }) as Record<string, unknown>;
+    expect(JSON.stringify(out)).not.toContain('+15551234567');
+  });
+
+  it('tolerates an input with no user at all', () => {
+    const { user, ...noUser } = searchInput;
+    expect(() => redactSearchInputForLog(noUser)).not.toThrow();
+    expect(redactSearchInputForLog(noUser)).toMatchObject({ userId: 999 });
+  });
+});
+
+// The seam: these drive the REAL catch block, so they go red if either call site
+// reverts to logging the raw input, which a helper-only unit test would not.
+describe.each([
+  ['getImagesFromSearchPreFilter', getImagesFromSearchPreFilter],
+  ['getImagesFromSearchPostFilter', getImagesFromSearchPostFilter],
+])('%s search-error log payload', (_name, fn) => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchDocumentsAbortableMock.mockRejectedValue(new Error('meili exploded'));
+  });
+
+  it('logs a search-error that contains NO session PII', async () => {
+    type SearchArg = Parameters<typeof getImagesFromSearchPreFilter>[0];
+    await expect(fn(searchInput as unknown as SearchArg)).rejects.toThrow('meili exploded');
+
+    type LoggedPayload = { type?: string; input?: Record<string, unknown> };
+    const searchErrorCalls = (logToAxiomMock.mock.calls as unknown as LoggedPayload[][]).filter(
+      (c) => c[0]?.type === 'search-error'
+    );
+    // positive control: the catch block we are asserting about actually ran.
+    expect(searchErrorCalls.length).toBeGreaterThan(0);
+
+    for (const call of searchErrorCalls) {
+      const payload = call[0];
+      expect(payload.input).not.toHaveProperty('user');
+      const serialized = JSON.stringify(payload);
+      for (const v of PII_VALUES) expect(serialized).not.toContain(v);
+    }
+  });
+});

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -2782,9 +2782,12 @@ type ImageSearchInput = GetInfiniteImagesOutput & {
  * `emailVerified`, `username` and `createdAt` for every erroring search — 331k
  * records/day in production, each naming a real account.
  *
- * Nothing diagnostic is lost: `getAllImagesIndex` already forwards the only two
- * fields the search path reads off the session user as `currentUserId`
- * (`user?.id`) and `isModerator`, and both survive this untouched.
+ * Nothing diagnostic is lost: of the session user, `getAllImagesIndex` forwards
+ * exactly `currentUserId` (= `user?.id`) and `isModerator` into this function as
+ * separate top-level keys, and both survive redaction untouched. (It also reads
+ * `user?.username` for `enforceBlockedBrowsingTags`, but that is consumed in the
+ * caller and never reaches this input — so the redacted payload still carries
+ * every session-user field the search path actually had.)
  *
  * The user object is dropped WHOLE rather than having its known PII keys
  * deleted. A denylist fails open — the next field added to the session user

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -2775,6 +2775,32 @@ type ImageSearchInput = GetInfiniteImagesOutput & {
 };
 
 /**
+ * Strip the session user off a search input before it reaches a log sink.
+ *
+ * `getInfiniteImagesHandler` spreads the whole `ctx.user` into the search input
+ * for business logic, so logging the input verbatim shipped `email`,
+ * `emailVerified`, `username` and `createdAt` for every erroring search — 331k
+ * records/day in production, each naming a real account.
+ *
+ * Nothing diagnostic is lost: `getAllImagesIndex` already forwards the only two
+ * fields the search path reads off the session user as `currentUserId`
+ * (`user?.id`) and `isModerator`, and both survive this untouched.
+ *
+ * The user object is dropped WHOLE rather than having its known PII keys
+ * deleted. A denylist fails open — the next field added to the session user
+ * would silently start shipping to logs again, which is exactly how this
+ * regressed. Do not "improve" this by re-adding `user` minus some keys.
+ *
+ * `user.id` is deliberately NOT remapped onto a `userId` key: `userId` is
+ * already a *search filter* on this input (feed-by-creator), and overwriting it
+ * would corrupt the logged query.
+ */
+export function redactSearchInputForLog<T extends Record<string, unknown>>(input: T) {
+  const { user: _sessionUser, ...rest } = input as T & { user?: unknown };
+  return removeEmpty(rest);
+}
+
+/**
  * Defense-in-depth post-filter for BitDex results. The main query uses strict
  * cacheable filters (no per-user clauses), so this rarely removes anything.
  * User's own excluded content is fetched in a separate second pass and merged.
@@ -3907,7 +3933,7 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
         type: 'search-error',
         error: err.message,
         cause: err.cause,
-        input: removeEmpty(input),
+        input: redactSearchInputForLog(input),
         request,
       },
       'temp-search'
@@ -4988,7 +5014,7 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
         type: 'search-error',
         error: err.message,
         cause: err.cause,
-        input: removeEmpty(input),
+        input: redactSearchInputForLog(input),
         request,
       },
       'temp-search'


### PR DESCRIPTION
## Problem

`getInfiniteImagesHandler` spreads the whole `ctx.user` session object into the image search input for business logic. Both `search-error` catch blocks in `image.service.ts` then logged that input verbatim via `removeEmpty(input)`, so **every erroring image search wrote the user's `email`, `emailVerified`, `username` and `createdAt` into the logs.**

Measured against the production logs immediately before this change:

| | |
|---|---:|
| records/day carrying a literal `"email":"<address>"` | **331,164** |
| records/hour | **17,107**, and rising |
| distinct addresses seen in a 5,000-line sample of **one** hour | **1,620** |
| share that are `type=search-error` on the `temp-search` datastream | **100%** |

Controls for those numbers: a bogus-token query over the same window returned 0, and the unfiltered namespace query returned 269,792 lines — so the match is meaningful, not a wiring artifact. The 1,620 figure is a **floor**, not a total: the query hit its 5,000-line limit exactly, so it is a truncated sample of that hour.

Fields exposed per record: `email`, `emailVerified`, `username`, `createdAt`, plus `meta.scores` and `filePreferences`.

## Fix

Both call sites now go through `redactSearchInputForLog`, which drops the session user object whole.

**Nothing diagnostic is lost.** `getAllImagesIndex` already forwards the only two fields the search path reads off the session user — `currentUserId` (= `user?.id`) and `isModerator` — as separate top-level keys, and both survive redaction untouched. Triage keeps the user id; it loses only the PII.

Two deliberate design choices, both documented at the function and pinned by tests:

- **The user object is dropped whole, not stripped of known PII keys.** A denylist of field names fails open — the next field added to the session user would silently start shipping again, which is how this regressed in the first place.
- **`user.id` is *not* remapped onto a `userId` key.** `userId` is already a *search filter* on this input (feed-by-creator); writing the session id over it would corrupt the logged query. There is a test for exactly this.

Not touched here: `input.actor` is already safe — `buildSearchActor` sha256-hashes IP+UA and emits `user:<id>` or `anon:<hash>`.

## Tests

`src/server/services/__tests__/search-error-log-pii.test.ts` — 7 cases, covering the redactor's behaviour **and** the two call sites.

The seam cases matter independently: a correct redactor that nothing invokes is the exact shape this bug already had, and a helper-only unit test would stay green through a revert of either call site. So those cases drive the real `catch` block (via a rejecting meili seam) and assert on what was actually handed to the log sink, with a positive control that the catch block ran at all.

Every guard was watched to fail, each for its own assertion:

| mutation | result |
|---|---|
| revert first call site to `removeEmpty(input)` | **only** the first seam test fails — `expected { user: {...} } to not have property "user"` |
| revert second call site | **only** the second seam test fails, same assertion |
| redactor becomes a pass-through | 5 of 7 fail |
| remap `user.id` onto `userId` | **only** the userId-filter test fails — `expected 4321 to be 999` |

Checks run: 7/7 new tests green · 196 files / 2,731 tests green across `src/server/services/__tests__/` + `src/server/meilisearch/__tests__/` · full-repo typecheck 0 errors · prettier clean (validated by watching it flag a deliberately misformatted copy) · eslint adds no new findings to `image.service.ts` vs the `origin/main` baseline.

## Deploy note

This is the fix for the PII half of the `temp-search` item. `temp-search` is a `temp-`-prefixed debug instrument that became permanent and is separately the single largest metered datastream — retiring or narrowing it is still worth doing, and is **not** attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
