### PR TITLE
feat(skills): add feature-walkthrough, for demoing a feature you cannot demo live

### DIFF
--- a/.claude/skills/feature-walkthrough/.env.example
+++ b/.claude/skills/feature-walkthrough/.env.example
@@ -1,0 +1,9 @@
+# Copy to `.env` in this directory. Gitignored — every developer supplies their own.
+# Nothing here is a secret; it is all local wiring.
+
+# The browser-automation server (see the browser-automation skill).
+BROWSER_API=http://localhost:9222
+
+# Where capture scripts write screenshots. Relative paths resolve from your working directory.
+# Use a scratch directory, not somewhere inside the repo.
+SHOTS_DIR=shots

--- a/.claude/skills/feature-walkthrough/.env.example
+++ b/.claude/skills/feature-walkthrough/.env.example
@@ -4,6 +4,7 @@
 # The browser-automation server (see the browser-automation skill).
 BROWSER_API=http://localhost:9222
 
-# Where capture scripts write screenshots. Relative paths resolve from your working directory.
-# Use a scratch directory, not somewhere inside the repo.
-SHOTS_DIR=shots
+# Where capture scripts write screenshots. Defaults to a temp directory when unset.
+# Keep it OUTSIDE the repo: these are screenshots of dev accounts and their content, and this
+# repo is public. A relative value resolves from wherever you ran the command.
+# SHOTS_DIR=/absolute/path/to/scratch/shots

--- a/.claude/skills/feature-walkthrough/SKILL.md
+++ b/.claude/skills/feature-walkthrough/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: feature-walkthrough
+description: Capture a finished feature as live screenshots and assemble them into a shareable walkthrough page for review. Use when someone needs to see a feature working but a live demo isn't possible — a reviewer in another timezone, a stakeholder who wants to look before a rollout, a PR whose value doesn't survive a diff. Produces a published artifact, not a slide deck.
+---
+
+# Feature walkthrough
+
+Drive a feature through every state that matters, screenshot each one from the real app, and
+assemble them into one page a reviewer can read start to finish. The output is a published
+Artifact — a private URL the author can share.
+
+This is a **demo substitute**, not a test report. If the question is "does it work", run the
+tests. If the question is "is this the right product", this is the shape that answers it, because
+the reviewer sees the screens rather than a description of them.
+
+## ⚠️ Dev database only — never production
+
+Every step below **writes**: seeding a scenario needs contributor rows, invites, lapsed flags and
+half-finished states that no real account should ever be put into, and the restore at the end
+deletes rows. Doing that against production would corrupt real users' data.
+
+Before the first write:
+
+1. Confirm the app you are driving points at a **dev database**, and that the query tool you seed
+   with points at the same one. Check the connection your `.env` actually resolves to — do not
+   trust a log line that says which database it is.
+2. Re-check after any long gap. The `postgres-query` skill's target can be re-pointed between
+   sessions, and a "dev" fingerprint taken an hour ago is not evidence about the query you are
+   about to run.
+3. Never pass a writable flag to a production target. If you cannot tell which target you have,
+   stop and ask.
+
+Also assume the screenshots are **going to be shared**. Anything on screen — usernames, avatars,
+collection names, item thumbnails — leaves with the report. Prefer dev accounts whose content is
+unremarkable, and read the captures before publishing rather than after.
+
+## Setup
+
+Copy `.env.example` to `.env` in this directory and adjust if your ports differ. It is gitignored;
+every developer supplies their own. Nothing in it is secret.
+
+You need three things running:
+
+- the app and, for anything behind sign-in, the auth hub — see the **`dev-server`** skill
+- the **`browser-automation`** server, which gives you one session per user so you can hold
+  several signed-in accounts at once
+- the **`postgres-query`** skill for seeding and for verifying the restore
+
+Signing a session in as a given user is covered by `browser-automation` and the dev-login notes in
+memory; it is deliberately not restated here.
+
+## The loop
+
+**1. List the states before you touch anything.** Write them down. Every state a screenshot has to
+prove, including the empty, blocked and refused ones — those are usually the interesting half and
+the easiest to forget. Note which are one-way.
+
+**2. Seed the scenario.** Multi-user features need states the UI cannot reach on its own (someone
+already holding a role, an invite sent six days ago, a lapsed subscription). Seed those directly,
+and keep a note of every row you create — that note is your restore script.
+
+**3. Capture, in dependency order.** This is the step people redo. A pending state has to be shot
+*before* it is accepted; a blocked state before the block is lifted. Get the order wrong and you
+re-seed the whole scenario. Sequence the one-way transitions first, then everything reversible.
+
+**4. Build the page.** A template with `{{shot-name.png}}` placeholders, then:
+
+```bash
+node .claude/skills/feature-walkthrough/build-report.mjs report.template.html shots/ report.html
+```
+
+**5. Publish and hand it over.** See below — the sharing step has an order to it.
+
+**6. Restore, and verify the restore.** Delete what you seeded, put changed columns back, then
+**query for the rows again** and confirm they are gone. Report anything you deliberately left
+behind and why.
+
+## Publishing, and the sharing handshake
+
+Publish the built file with the **Artifact** tool. It is the right vehicle for this: one scrollable
+page, screenshots inline, a URL that keeps working, and it updates in place.
+
+```
+Artifact(file_path: "report.html", favicon: "🤝", description: "<one line for the gallery card>")
+```
+
+Keep the **file path and favicon stable** across redeploys. Same path means the same URL, so a
+reviewer who already has the link keeps seeing the current version; a changed favicon reads as a
+different page to anyone who kept the tab open.
+
+**Artifacts are private until the author shares them**, and an agent cannot share on their behalf.
+That ordering catches people out, so do it deliberately:
+
+1. Publish, and give the author the link.
+2. Say plainly that it is private until they open it and use the page's share menu.
+3. Only **after** they confirm it is shared, send the link onward.
+
+Announcing the link to a reviewer before that step gives them a URL they cannot open. If you are
+sending the message yourself, wait for the confirmation.
+
+To update a walkthrough from a later session, pass the existing artifact's `url` — publishing
+without it creates a second artifact rather than updating the first, and the reviewer's link goes
+stale. Use `action: "list"` to find the URL if you do not have it.
+
+## If an artifact isn't the right vehicle
+
+It usually is, but the alternatives have real trade-offs:
+
+| Instead | Worth it when | Costs |
+| --- | --- | --- |
+| **Link it from the PR** | Reviewers live there, and it outlives the chat | Screenshots can't be embedded from the CLI, so this is a link *to* the artifact, not a replacement |
+| **Chat with attachments** | One person, one nudge, no sharing step — the `discord-bridge` skill uploads files directly | Images arrive as a pile with no order or captions; useless as a durable reference |
+| **A tracker doc** | It has to be findable months later next to the ticket | Another surface to keep current, and image support varies |
+
+The strongest combination is the artifact as the canonical page, **linked from the PR**, with a
+short chat message pointing at it.
+
+**Do not commit the report or its screenshots to this repo.** It is public and permanent: the
+screenshots carry dev usernames, avatars and content, and the images bloat the tree. Publish them,
+don't check them in.
+
+## Writing capture scripts
+
+Run them with:
+
+```bash
+node .claude/skills/feature-walkthrough/capture.mjs <session> script.js
+```
+
+The browser-automation server executes a chunk and **throws away its return value**, so a script
+that inspects the page has no way to tell you what it saw. `capture.mjs` wraps the script, writes
+its return value to `script.js.out.json` and prints it. Return whatever you want to assert on.
+
+Scripts get `page` plus these, already defined:
+
+| Helper | Does |
+| --- | --- |
+| `SHOTS` | absolute screenshot directory |
+| `dismissOverlays()` | removes sticky banners and the chat widget |
+| `shot(name, clip?)` | viewport screenshot, optional `{x,y,width,height}` |
+| `shotOf(selector, name)` | element screenshot |
+| `shotModal(name)` | shortcut for the open modal |
+| `mainText(n?)` / `modalText(n?)` | text of `main` / the open modal |
+
+**Call `dismissOverlays()` after every navigation, before clicking anything.** A sticky
+announcement sits above the page and swallows clicks; Playwright retries for 30 seconds and then
+fails with `subtree intercepts pointer events`, which reads like a broken selector and is not one.
+
+Two more that cost time:
+
+- **Assert what the screenshot is supposed to show.** Return the text alongside the shot. A
+  screenshot of the wrong state looks fine until someone reads it.
+- **Re-running a script does not reset the page.** The session keeps its position from the last
+  chunk, so a script that assumed a starting URL will capture whatever is on screen instead —
+  which is how the wrong modal ends up in a report. Navigate explicitly at the top of each script.
+
+## Screenshot craft
+
+- **Element shots beat viewport shots** wherever the DOM can scope it: no clip maths, and the
+  framing survives a layout change. Reach for a clip only for composites the DOM does not group,
+  like a sidebar plus its header.
+- Set a **fixed viewport** for the whole run so shots share a scale.
+- Keep them **tight**. The artifact ceiling is 16 MB with images inlined as base64, and a page of
+  full-page screenshots hits it fast. `build-report.mjs` fails the build rather than letting a
+  rejected publish surprise you.
+- **Pair the before and after** for anything you changed. Two narrow shots side by side carry a
+  permission split better than a paragraph.
+
+## The page itself
+
+Load the `artifact-design` skill before writing the template.
+
+What makes these read well:
+
+- **Lead with what the feature is** in two sentences, then the walkthrough in order. A reviewer
+  should be able to stop after the first screen and still know what it does.
+- **Caption every screenshot** with whose view it is. "Manager's edit form" beats "edit form" —
+  half the value of a permissions walkthrough is who is looking.
+- **Explain the non-obvious rule, not the mechanics.** Say why a row counts as shared; don't
+  narrate that there is a sidebar.
+- **Put the open questions in their own section** and make them answerable. A reviewer who can
+  reply "option B" is worth more than one who has to write an essay.
+- **State the deploy prerequisites** — anything that has to be done by hand before it ships.
+
+## Writing the message that carries it
+
+A link with no framing gets opened last. Say what it is in one line, then what you want back —
+"three things I'd like your call on, last section" beats "let me know your thoughts".
+
+If it goes out over chat, use the **`discord-bridge`** skill and read its `voice.md` first, so the
+message sounds like the person sending it rather than like a release note. A walkthrough written in
+memo voice under someone's own name is worse than one they wrote in a hurry. If no `voice.md`
+exists, read a few of their own messages in that thread before drafting — and weight organic
+messages over any an agent already sent, which otherwise trains the profile on itself.
+
+Sending on someone's behalf is outward-facing: confirm the recipient before sending, and report
+exactly who received it.

--- a/.claude/skills/feature-walkthrough/SKILL.md
+++ b/.claude/skills/feature-walkthrough/SKILL.md
@@ -39,6 +39,11 @@ unremarkable, and read the captures before publishing rather than after.
 Copy `.env.example` to `.env` in this directory and adjust if your ports differ. It is gitignored;
 every developer supplies their own. Nothing in it is secret.
 
+Screenshots default to a temp directory, outside the repo. If you point `SHOTS_DIR` somewhere
+else, keep it outside the checkout — the captures show dev accounts and their content, and this
+repo is public. `/shots/` and `**/walkthrough-shots/` are gitignored as a backstop, not as
+permission to write there.
+
 You need three things running:
 
 - the app and, for anything behind sign-in, the auth hub — see the **`dev-server`** skill

--- a/.claude/skills/feature-walkthrough/build-report.mjs
+++ b/.claude/skills/feature-walkthrough/build-report.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+// Inline captured screenshots into a report template, ready to publish as an Artifact.
+//
+//   node .claude/skills/feature-walkthrough/build-report.mjs <template.html> <shots-dir> <out.html>
+//
+// Artifacts run under a CSP that blocks every external host, so a page that references
+// screenshots by path or URL renders as a column of broken images. Each `{{name.png}}` in the
+// template becomes a base64 data: URI of `<shots-dir>/name.png`.
+//
+// A missing image is a hard error. Publishing a walkthrough with a silently absent screenshot is
+// worse than not publishing it — the reader cannot tell the difference between "no screenshot"
+// and "this state does not exist".
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { join, extname } from 'node:path';
+
+const [template, shotsDir, outFile] = process.argv.slice(2);
+if (!template || !shotsDir || !outFile) {
+  console.error('usage: build-report.mjs <template.html> <shots-dir> <out.html>');
+  process.exit(1);
+}
+
+const MIME = { '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg', '.webp': 'image/webp' };
+const ARTIFACT_LIMIT = 16 * 1024 * 1024;
+
+const src = readFileSync(template, 'utf8');
+const missing = [];
+const used = new Set();
+
+const out = src.replace(/\{\{([^}]+)\}\}/g, (match, name) => {
+  const file = join(shotsDir, name.trim());
+  const mime = MIME[extname(file).toLowerCase()];
+  if (!mime) {
+    missing.push(`${name} (unsupported extension)`);
+    return match;
+  }
+  if (!existsSync(file)) {
+    missing.push(name);
+    return match;
+  }
+  used.add(name.trim());
+  return `data:${mime};base64,${readFileSync(file).toString('base64')}`;
+});
+
+if (missing.length) {
+  console.error(`Missing ${missing.length} image(s) referenced by the template:`);
+  for (const name of missing) console.error(`  - ${name}`);
+  process.exit(1);
+}
+
+writeFileSync(outFile, out);
+
+const bytes = Buffer.byteLength(out);
+const mb = (bytes / 1024 / 1024).toFixed(2);
+console.log(`Wrote ${outFile}`);
+console.log(`  images inlined : ${used.size}`);
+console.log(`  size           : ${mb} MB`);
+
+if (bytes > ARTIFACT_LIMIT) {
+  console.error(`  OVER the ${ARTIFACT_LIMIT / 1024 / 1024} MB artifact limit — the publish will be rejected.`);
+  console.error('  Capture tighter regions, or drop the screenshots that repeat a state.');
+  process.exit(1);
+}
+if (bytes > ARTIFACT_LIMIT * 0.75) {
+  console.warn('  Close to the artifact limit. Prefer element shots over full-page ones.');
+}

--- a/.claude/skills/feature-walkthrough/capture.mjs
+++ b/.claude/skills/feature-walkthrough/capture.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+// Run a capture script against a browser-automation session and keep its return value.
+//
+//   node .claude/skills/feature-walkthrough/capture.mjs <session> <script.js>
+//
+// The browser-automation server executes a chunk and DISCARDS whatever it returns, so a script
+// that inspects the page has no way to report what it found. This wraps the script so its return
+// value (or its stack, if it throws) lands in `<script.js>.out.json` and gets printed.
+//
+// Scripts run with `page` plus the helpers below already defined — see SKILL.md.
+
+import { readFileSync, existsSync, unlinkSync, mkdirSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function readEnv(key, fallback) {
+  if (process.env[key]) return process.env[key];
+  try {
+    const line = readFileSync(join(here, '.env'), 'utf8')
+      .split('\n')
+      .find((l) => l.startsWith(`${key}=`));
+    if (line) return line.slice(key.length + 1).trim().replace(/^["']|["']$/g, '');
+  } catch {
+    /* no .env is fine — the defaults cover a stock setup */
+  }
+  return fallback;
+}
+
+const [session, file] = process.argv.slice(2);
+if (!session || !file) {
+  console.error('usage: capture.mjs <session> <script.js>');
+  process.exit(1);
+}
+
+const api = readEnv('BROWSER_API', 'http://localhost:9222');
+const shotsDir = resolve(readEnv('SHOTS_DIR', 'shots'));
+mkdirSync(shotsDir, { recursive: true });
+
+const outPath = resolve(`${file}.out.json`);
+if (existsSync(outPath)) unlinkSync(outPath);
+
+// Everything the capture scripts would otherwise re-solve every time.
+const preamble = `
+const SHOTS = ${JSON.stringify(shotsDir)};
+
+// Overlays that sit above the page and swallow clicks. Without this, clicking anything below a
+// sticky announcement fails with "<div ...> subtree intercepts pointer events" after a 30s retry.
+const dismissOverlays = async () => {
+  await page.evaluate(() => {
+    document.querySelectorAll('div.sticky.inset-x-0.top-0.z-50').forEach((el) => el.remove());
+    document.querySelectorAll('[data-testid="open-chat"]').forEach((el) => el.remove());
+  });
+  await page.waitForTimeout(200);
+};
+
+// clip is optional {x,y,width,height}; omit it for the full viewport.
+const shot = async (name, clip) => {
+  await page.screenshot({ path: SHOTS + '/' + name, ...(clip ? { clip } : {}) });
+  return name;
+};
+
+// Element shots beat viewport shots for anything the DOM can scope — no clip maths, and the
+// framing survives a layout change.
+const shotOf = async (selector, name) => {
+  await page.locator(selector).first().screenshot({ path: SHOTS + '/' + name });
+  return name;
+};
+
+const shotModal = (name) => shotOf('.mantine-Modal-content', name);
+
+const mainText = (max = 800) =>
+  page.evaluate((n) => (document.querySelector('main')?.innerText || '').slice(0, n), max);
+
+const modalText = (max = 1200) =>
+  page
+    .locator('.mantine-Modal-content')
+    .first()
+    .innerText()
+    .then((t) => t.slice(0, max))
+    .catch(() => null);
+`;
+
+const inner = readFileSync(file, 'utf8');
+const code = `
+const __fs = await import('node:fs');
+${preamble}
+let __r;
+try {
+  __r = await (async () => { ${inner}
+  })();
+} catch (e) {
+  __r = { __error: String((e && e.stack) || e).slice(0, 3000) };
+}
+__fs.writeFileSync(${JSON.stringify(outPath)}, JSON.stringify(__r ?? null, null, 1));
+`;
+
+const res = await fetch(`${api}/chunk?session=${encodeURIComponent(session)}`, {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ label: file, code }),
+});
+
+const text = await res.text();
+let data;
+try {
+  data = JSON.parse(text);
+} catch {
+  console.log(text.slice(0, 2000));
+  process.exit(1);
+}
+
+if (data.type === 'chunk_failed') console.log('CHUNK FAILED:', data.error);
+if (existsSync(outPath)) console.log('RESULT:', readFileSync(outPath, 'utf8').slice(0, 8000));
+console.log('URL:', data.inspection?.url);
+console.log('SHOT:', data.inspection?.screenshot);

--- a/.claude/skills/feature-walkthrough/capture.mjs
+++ b/.claude/skills/feature-walkthrough/capture.mjs
@@ -11,6 +11,7 @@
 
 import { readFileSync, existsSync, unlinkSync, mkdirSync } from 'node:fs';
 import { resolve, dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -35,7 +36,10 @@ if (!session || !file) {
 }
 
 const api = readEnv('BROWSER_API', 'http://localhost:9222');
-const shotsDir = resolve(readEnv('SHOTS_DIR', 'shots'));
+// Defaults outside the repo on purpose: these are screenshots of dev accounts and their content,
+// and a relative default lands in whatever directory the run started from — which is usually a
+// checkout of a public repo.
+const shotsDir = resolve(readEnv('SHOTS_DIR', join(tmpdir(), 'feature-walkthrough-shots')));
 mkdirSync(shotsDir, { recursive: true });
 
 const outPath = resolve(`${file}.out.json`);

--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,12 @@ src/pages/api/dev-local/*
 # Vitest browser-mode failure screenshots (written next to *.browser.test.tsx)
 **/__screenshots__/
 
+# feature-walkthrough captures. The skill defaults to a temp dir, but SHOTS_DIR is configurable
+# and a relative value lands here — these are screenshots of dev accounts and their content, and
+# this repo is public and permanent.
+/shots/
+**/walkthrough-shots/
+
 # Ladle (local dev artifacts)
 .ladle/stubs/
 


### PR DESCRIPTION
Adds a `feature-walkthrough` skill: drive a finished feature through every state that matters, screenshot each one from the real app, and assemble them into one page a reviewer can read start to finish.

Came out of demoing collaborative collections (#3719) to a reviewer we couldn't get a meeting with. The page itself was the easy half — most of the cost was rediscovering the same friction, so this puts that in code rather than in a doc nobody reads twice.

## What's in it

- **`capture.mjs`** — runs a script against a browser-automation session and **keeps its return value**. The server executes a chunk and discards whatever it returns, so an inspection script otherwise has no way to report what it saw. It also injects the helpers every capture script would rewrite: `dismissOverlays`, `shot`, `shotOf`, `shotModal`, `mainText`, `modalText`.
- **`build-report.mjs`** — inlines the screenshots as data URIs and **fails the build** on a missing image or an oversized page.
- **`SKILL.md`** — the procedure and the judgment calls: capture order, screenshot craft, what makes the page readable, publishing and sharing.

## The friction it removes

Each of these cost real time on the first run:

- The chunk runner discards return values, so nothing you inspect comes back.
- A sticky announcement banner sits above the page and swallows clicks. Playwright retries for 30s and then fails with `subtree intercepts pointer events`, which reads exactly like a bad selector and isn't one.
- Artifacts run under a CSP that blocks every external host, so screenshots must be inlined as base64 under a 16 MB ceiling. A page of full-page shots blows it.
- Captures have a dependency order: a pending state has to be shot *before* it's accepted, a blocked state before the block is lifted. Get it wrong and you re-seed the whole scenario.
- Artifacts are private until the author shares them, and an agent can't share on their behalf — so announcing the link before that step hands the reviewer a URL they can't open.

## Safety

The skill **writes** — seeding needs roles, invites and lapsed states no real account should be put into, and the restore deletes rows. So it opens with a dev-database-only rule, says to re-verify the target rather than trusting a stale fingerprint, and notes that screenshots leave with whatever is on screen (usernames, avatars, content), so pick unremarkable dev accounts.

It deliberately carries **no sign-in-as-any-user recipe** — that stays in the existing skills and memory. No hosts, IPs, account names or tokens. Its `.env` is gitignored with an `.env.example` to copy, matching `postgres-query`. It also states the rule that the report and its screenshots must never be committed to this repo, which is public and permanent.

It leans on `dev-server`, `browser-automation` and `postgres-query` rather than restating them, so it doesn't rot when they change.

## Testing

Both scripts exercised end to end, including their failure paths:

- `build-report.mjs` inlines correctly, and exits 1 naming the file when an image is missing.
- `capture.mjs` ran against a live session — return value captured, `SHOTS` honoured the env override, `dismissOverlays` left 0 banners, both screenshot helpers wrote files, and a deliberately failing script reported its stack instead of passing silently.

No app code touched; nothing here runs in CI or at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
