### PR TITLE
fix(app-listings): check the listing-asset dimension bound before uploading, not after

### DIFF
--- a/src/components/Apps/ListingAssetStep.browser.test.tsx
+++ b/src/components/Apps/ListingAssetStep.browser.test.tsx
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
+// The bound the precheck applies, IMPORTED rather than spelled: a literal here
+// would agree with a precheck that hard-coded a different number.
+import { LISTING_ASSET_MAX_DIMENSION_PX } from '~/server/schema/blocks/app-listing.schema';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
 
@@ -130,14 +133,27 @@ function renderStep(props: Partial<Parameters<typeof ListingAssetStep>[0]> = {})
  * fail `createImageBitmap` in the upload path (readImageDimensions), so the row
  * would never reach the scanning state we assert on.
  */
-async function makeImageFile(name = 'shot.png'): Promise<File> {
+async function makeImageFile(name = 'shot.png', width = 200, height = 150): Promise<File> {
   const canvas = document.createElement('canvas');
-  canvas.width = 200;
-  canvas.height = 150;
+  canvas.width = width;
+  canvas.height = height;
   const blob = await new Promise<Blob>((resolve, reject) => {
     canvas.toBlob((b) => (b ? resolve(b) : reject(new Error('toBlob null'))), 'image/png');
   });
-  return new File([blob], name, { type: 'image/png' });
+  const file = new File([blob], name, { type: 'image/png' });
+  // The dimension precheck below is the whole point of the oversize fixtures, so
+  // assert the fixture actually HAS the dimensions asked for before any test
+  // reasons about which side of the bound it falls on — a canvas that silently
+  // clamped would make an "under the bound" result a fact about the fixture.
+  const bitmap = await createImageBitmap(file);
+  try {
+    if (bitmap.width !== width || bitmap.height !== height) {
+      throw new Error(`fixture is ${bitmap.width}×${bitmap.height}, asked for ${width}×${height}`);
+    }
+  } finally {
+    bitmap.close();
+  }
+  return file;
 }
 
 /**
@@ -446,5 +462,96 @@ describe('ListingAssetStep — uploaded-asset preview + cancel mid-scan', () => 
     // One revoke per cancelled cycle (no leak, no crash).
     expect(revokeSpy.mock.calls.length).toBeGreaterThanOrEqual(3);
     revokeSpy.mockRestore();
+  });
+});
+
+describe('ListingAssetStep — per-side dimension precheck (issue #3772)', () => {
+  /**
+   * The server has applied `listingAssetTooLargeReason` to listing uploads since
+   * #3801 — but only in `persistAssetImage`, i.e. AFTER the object-store upload
+   * has finished. `uploadAndPersist` already reads the file's intrinsic dimensions
+   * before it uploads, so the rejection is knowable from the file picker; these
+   * assert it is actually taken there.
+   *
+   * The two fixtures differ by exactly ONE pixel on the side the bound is over
+   * (`LISTING_ASSET_MAX_DIMENSION_PX` and `+ 1`), which is what makes the pair
+   * able to cross the bound rather than merely sit on one side of it. The bound
+   * is imported, not spelled — a literal here would pass just as happily against
+   * a precheck that hard-coded a different number.
+   *
+   * 🔴 These prove the UPLOAD IS SKIPPED, not that the image is rejected: the
+   * server re-derives the dimensions from the stored bytes and re-applies the
+   * same predicate, and that is the enforcement point. A green run here says
+   * nothing about the server-side bound, which
+   * `__tests__/offsite-listing.service.test.ts` covers.
+   */
+  test('an over-bound cover is refused BEFORE the upload starts', async () => {
+    renderStep();
+
+    await userEvent.upload(
+      await fileInputEl('cover'),
+      await makeImageFile('huge.png', LISTING_ASSET_MAX_DIMENSION_PX + 1, 512)
+    );
+
+    // The author is told why, in the server's own words — asserted as the whole
+    // rendered string INCLUDING the offending value, so a guard that fired for a
+    // different reason (or named a different number) cannot satisfy it.
+    await expect
+      .element(
+        page.getByText(
+          `That image is too large (max ${LISTING_ASSET_MAX_DIMENSION_PX}px per side, got ${
+            LISTING_ASSET_MAX_DIMENSION_PX + 1
+          }px).`
+        )
+      )
+      .toBeInTheDocument();
+    // … and not one byte was sent to the object store, nor a row persisted.
+    expect(mocks.uploadToCF).not.toHaveBeenCalled();
+    expect(mocks.persistAsync).not.toHaveBeenCalled();
+  });
+
+  test('the bound is caught on EITHER axis — a tall icon is refused too', async () => {
+    renderStep();
+
+    // The landscape case above cannot tell `max(w, h)` apart from a check that
+    // only ever looks at the width; this one crosses the bound on the OTHER axis,
+    // so a single-axis precheck fails here even though it passes there.
+    await userEvent.upload(
+      await fileInputEl('icon'),
+      await makeImageFile('tall.png', 512, LISTING_ASSET_MAX_DIMENSION_PX + 1)
+    );
+
+    await expect
+      .element(
+        page.getByText(
+          `That image is too large (max ${LISTING_ASSET_MAX_DIMENSION_PX}px per side, got ${
+            LISTING_ASSET_MAX_DIMENSION_PX + 1
+          }px).`
+        )
+      )
+      .toBeInTheDocument();
+    expect(mocks.uploadToCF).not.toHaveBeenCalled();
+    expect(mocks.persistAsync).not.toHaveBeenCalled();
+  });
+
+  test('a cover EXACTLY at the bound still uploads (the check is >, not >=)', async () => {
+    mocks.setCoverAsync.mockResolvedValue({ status: 'attached', coverId: 501, scanPending: true });
+    renderStep();
+
+    await userEvent.upload(
+      await fileInputEl('cover'),
+      await makeImageFile('at-bound.png', LISTING_ASSET_MAX_DIMENSION_PX, 512)
+    );
+
+    // The positive control for the test above: the SAME code path and the same
+    // slot, one pixel narrower, reaches the store. Without this a precheck that
+    // rejected everything — or one whose comparison was inverted at the boundary —
+    // would look correct.
+    await vi.waitFor(() => expect(mocks.uploadToCF).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() =>
+      expect(mocks.persistAsync).toHaveBeenCalledWith(
+        expect.objectContaining({ width: LISTING_ASSET_MAX_DIMENSION_PX, height: 512 })
+      )
+    );
   });
 });

--- a/src/components/Apps/ListingAssetStep.tsx
+++ b/src/components/Apps/ListingAssetStep.tsx
@@ -27,6 +27,7 @@ import {
   type ScreenshotSlot,
 } from '~/components/Apps/screenshotSlots';
 import type { EditAsset, EditScreenshot } from '~/components/Apps/offsiteEditConfig';
+import { listingAssetTooLargeReason } from '~/server/schema/blocks/app-listing.schema';
 import type { OffsiteContentRating } from '~/server/schema/blocks/offsite-listing.schema';
 import { showErrorNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
@@ -292,6 +293,26 @@ export function ListingAssetStep({
 
   async function uploadAndPersist(file: File): Promise<number> {
     const { width, height } = await readImageDimensions(file);
+    // Fail fast, BEFORE a byte leaves the browser. The dimensions are already in
+    // hand here and the server applies this same predicate to `persistAssetImage`
+    // — but only after the upload to the object store has completed, so without
+    // this mirror the author waits out a full upload to be told something that was
+    // knowable from the file picker.
+    //
+    // 🔴 This is a UX mirror, NOT the enforcement point. The server re-derives the
+    // pair from the STORED BYTES (`measureListingAssetUpload`) and re-applies the
+    // bound there; anything decided here is a client claim. Deleting this check
+    // costs a wasted upload, never a bypass.
+    //
+    // The predicate is IMPORTED, never restated: a vendored copy of the bound is
+    // exactly what goes stale and starts refusing valid input (civitai/cli#270).
+    // It is also safe to evaluate on the browser's reading of the file even though
+    // the server reads EXIF orientation and the browser does not — the bound is
+    // over `Math.max(width, height)`, which a quarter-turn cannot change, so the
+    // two readings cannot disagree about this verdict. The subject string matches
+    // the server's so the author sees ONE message wherever the rejection lands.
+    const tooLarge = listingAssetTooLargeReason('That image', width, height);
+    if (tooLarge) throw new Error(`${tooLarge}.`);
     const result = await uploadToCF(file);
     const { imageId } = await persistMutation.mutateAsync({
       url: result.id,


### PR DESCRIPTION
Follow-up to #3801. Refs #3772 — **does not close it**; see below.

## The gap

#3801 applied `listingAssetTooLargeReason` to listing media on the upload path, but the only place it runs there is `persistAssetImage`, which the client calls **after** the file has finished uploading. `uploadAndPersist` in `ListingAssetStep.tsx` already reads the image's intrinsic dimensions immediately before it uploads, and then does nothing with them — so an author picks a file, waits out the whole transfer, and is then refused for something that was knowable from the file picker.

Issue #3772 called this out as the blocking half of adding the ceiling at all. The ceiling shipped in #3801; this is the other half.

## The change

Take the same predicate at the point the dimensions are first known:

```ts
const { width, height } = await readImageDimensions(file);
const tooLarge = listingAssetTooLargeReason('That image', width, height);
if (tooLarge) throw new Error(`${tooLarge}.`);
const result = await uploadToCF(file);
```

Three properties worth stating explicitly, because each is a way this could have gone wrong:

- **Imported, not restated.** No constant is copied to the client. A vendored bound is exactly what goes stale and starts refusing valid input — `civitai/cli#270`.
- **Not the enforcement point.** The server still re-derives the dimensions from the stored bytes and re-applies the bound; nothing here is trusted. Deleting this check costs a wasted upload, never a bypass. That is written into the comment so a later reader does not mistake it for a gate.
- **Cannot disagree with the server.** The bound is over `Math.max(width, height)`, which is invariant under the EXIF quarter-turn the server applies and the browser does not. The subject string matches the server's, so the author sees one message wherever the rejection lands.

`ListingAssetStep` is the single client surface for listing media — the create wizard, the edit form and the media editor all embed it — so this is one call site, not a predicate spread across three.

**No behaviour change to what is accepted.** This rejects exactly the set the server already rejects, and it rejects it sooner.

## Tests

`src/components/Apps/ListingAssetStep.browser.test.tsx` (component project). Matrix, measured — not asserted:

| test | at `origin/main` | here | what it is |
|---|---|---|---|
| over-bound cover refused **before** the upload starts | **RED** | green | regression coverage |
| over-bound on the **other** axis (tall icon) | **RED** | green | regression coverage |
| a cover **exactly** at the bound still uploads | green | green | invariant guard + positive control |

Two of the three are regression coverage; the third is not, and is labelled as such in the file. 16/16 green here, 14/16 at `origin/main`.

The fixture helper now takes explicit dimensions and **asserts the canvas actually produced them** before any test reasons about which side of the bound it falls on — otherwise an "under the bound" result could be a fact about the fixture rather than about the code.

### Mutation results

Each mutation applied to the shipped code, suite re-run, failure message read to confirm it attributes to this guard:

| mutation | outcome |
|---|---|
| guard deleted (i.e. `origin/main`) | killed — over-bound tests fail |
| guard kept, specific message replaced with a generic one | killed — the message locator, so the wording is pinned |
| check moved to **after** `uploadToCF` | killed — and by the `not.toHaveBeenCalled()` assertion, not the message, so "before the upload" is genuinely pinned rather than incidental |
| comparison inverted (`if (!tooLarge)`) | killed — 5 tests, including the at-bound one, which is what makes that test non-vacuous |
| single-axis (`width, width`) | killed — **only** by the tall-icon test, which is why that test exists |
| arguments swapped (`height, width`) | **survived.** Honest result, not a gap: the predicate is `Math.max(width, height)`, so the swap is semantically identical and no test can distinguish it. |

## Checks

- `pnpm typecheck`: sorted error sets at `origin/main` and at this branch are **identical** (12 either side, all pre-existing and unrelated to these files). Zero introduced.
- `prettier`: both files are already non-conformant on `main`; this branch adds **zero** new formatting deltas to either (29→29 and 63→63 changed lines). Left alone rather than reformatted, to keep the diff readable.

## What this deliberately does not do

#3772 also asks whether listing media should carry an **area** bound — covers and screenshots have none today, so `8192×4096` (33 Mpx) is accepted while an icon path enforces a 16.7 Mpx decode budget.

I did not pick a number. Every candidate that actually constrains anything rejects images a real author could plausibly produce, and the "just unify with the icon path" framing does not survive reading what that constant is for. The analysis, the options and a recommendation are in a comment on #3772 — it is a product decision, and guessing at it here to have something to ship would have been the wrong call.
