### PR TITLE
fix(app-listings): check the per-KIND listing-asset geometry before uploading too

### DIFF
--- a/src/components/Apps/ListingAssetStep.browser.test.tsx
+++ b/src/components/Apps/ListingAssetStep.browser.test.tsx
@@ -14,9 +14,15 @@ import {
   LISTING_SCREENSHOT_ASPECT_MAX,
   LISTING_SCREENSHOT_ASPECT_MIN,
   LISTING_SCREENSHOT_MIN_PX,
+  MAX_LISTING_COVER_SIZE_BYTES,
 } from '~/server/schema/blocks/app-listing.schema';
+import type * as AppListingSchema from '~/server/schema/blocks/app-listing.schema';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
+import {
+  jpegWithExifOrientation,
+  webpWithExifOrientation,
+} from '../../../test/fixtures/exif-image';
 
 /**
  * W13 — the shared listing ASSET step, focused on the OG-image AUTO-FILL path
@@ -64,7 +70,35 @@ const mocks = vi.hoisted(() => ({
   // badge, so for screenshots this notification is the ONLY channel the rejection
   // reason travels on.
   showErrorNotification: vi.fn(),
+  // A pass-through spy over the server's own predicate, so a test can read the
+  // ARGUMENTS the component hands it — see the exclusions ledger below.
+  validateListingImage: vi.fn(),
 }));
+
+/**
+ * Wrap `validateListingImage` in a recording pass-through. The real implementation
+ * still decides every verdict (so no behaviour is mocked away); the spy exists only
+ * so the exclusions ledger can assert WHICH FIELDS the component supplies.
+ *
+ * 🔴 That ledger is the guard the PR body's two "deliberately left server-only"
+ * exclusions did not have: adding `sizeBytes: file.size` or
+ * `mimeType: file.type || undefined` to the call survived the whole suite at 34/34,
+ * even though the PR body itself argues those would refuse images the server
+ * accepts. A prose warning is not a guard.
+ */
+vi.mock('~/server/schema/blocks/app-listing.schema', async (importOriginal) => {
+  // Type-only NAMESPACE import, not `typeof import('…')` — the latter is an
+  // `import()` type annotation, which `@typescript-eslint/consistent-type-imports`
+  // rejects.
+  const actual = await importOriginal<typeof AppListingSchema>();
+  return {
+    ...actual,
+    validateListingImage: (...args: Parameters<typeof actual.validateListingImage>) => {
+      mocks.validateListingImage(...args);
+      return actual.validateListingImage(...args);
+    },
+  };
+});
 
 vi.mock('~/utils/trpc', () => {
   return {
@@ -220,6 +254,117 @@ function fileInputEl(which: 'icon' | 'cover' | 'screenshots'): Promise<HTMLInput
   });
 }
 
+/**
+ * Drive one slot with one fixture and assert nothing reached the object store —
+ * and that the author was told WHY, in the server's exact words.
+ *
+ * The message is asserted on the channel that actually carries it for that slot:
+ * icon/cover rows render `state.message` inline, a screenshot slot renders only a
+ * status badge. `showErrorNotification` carries it for all three, so it is the
+ * assertion every kind shares; without it the screenshot cases would be asserting
+ * on an element the component never renders.
+ */
+async function expectRefused(which: 'icon' | 'cover' | 'screenshots', file: File, message: string) {
+  const kind = which === 'screenshots' ? 'screenshot' : which;
+  await userEvent.upload(await fileInputEl(which), file);
+  await vi.waitFor(() =>
+    expect(mocks.showErrorNotification).toHaveBeenCalledWith({
+      title: `Could not add ${kind}`,
+      // The Error the author sees, matched on its whole message — not a substring,
+      // so a guard that fired for a different bound cannot satisfy it.
+      error: expect.objectContaining({ message }),
+    })
+  );
+  if (which !== 'screenshots') {
+    await expect.element(page.getByText(message)).toBeInTheDocument();
+  }
+  expect(mocks.uploadToCF).not.toHaveBeenCalled();
+  expect(mocks.persistAsync).not.toHaveBeenCalled();
+}
+
+/** Drive one slot with one fixture and assert it DID reach the object store. */
+async function expectUploaded(
+  which: 'icon' | 'cover' | 'screenshots',
+  file: File,
+  width: number,
+  height: number
+) {
+  await userEvent.upload(await fileInputEl(which), file);
+  await vi.waitFor(() => expect(mocks.uploadToCF).toHaveBeenCalledTimes(1));
+  await vi.waitFor(() =>
+    expect(mocks.persistAsync).toHaveBeenCalledWith(expect.objectContaining({ width, height }))
+  );
+}
+
+/** Encode a solid raster of a known STORED size in the requested container. */
+async function raster(mime: 'image/webp' | 'image/jpeg', width: number, height: number) {
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('no 2d context');
+  // JPEG has no alpha, so an unpainted canvas encodes as black — fine either way,
+  // but painting keeps the three fixture builders producing comparable bytes.
+  ctx.fillStyle = '#4488cc';
+  ctx.fillRect(0, 0, width, height);
+  const blob = await new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob((b) => (b ? resolve(b) : reject(new Error('toBlob null'))), mime);
+  });
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  if (blob.type !== mime) throw new Error(`canvas encoded ${blob.type}, asked for ${mime}`);
+  return bytes;
+}
+
+/**
+ * A REAL image file carrying a REAL EXIF orientation — the fixture class every
+ * other one in this file lacks.
+ *
+ * 🔴 Why it has to exist: `makeImageFile` produces a fresh canvas PNG, which has
+ * no EXIF at all, so a suite built only from those cannot observe whether the
+ * component's dimension read honours orientation — mutating `readImageDimensions`
+ * from `'from-image'` to `'none'` left the file 34/34 GREEN. Whether the browser
+ * and the server agree about which axis is which is the entire premise the
+ * per-kind aspect precheck rests on, and only a fixture with an orientation tag
+ * can make a test fail when that premise is wrong.
+ *
+ * `expectClient` is asserted here rather than in the tests, so every fixture
+ * carries its own premise: the browser's reading is a MEASURED fact about this
+ * Chromium (149: it applies EXIF to JPEG, and does not to WebP), not something the
+ * component under test gets to decide. If a future engine changes its mind, these
+ * fail with "browser read X, expected Y" instead of the suite quietly going green
+ * for a new reason. `src/server/utils/__tests__/listing-asset-exif-fixture.test.ts`
+ * pins the other side: what `sharp` — and so the server — makes of the same bytes.
+ */
+async function makeExifOrientedFile(opts: {
+  name: string;
+  mime: 'image/webp' | 'image/jpeg';
+  /** The STORED raster's size, i.e. what the encoder is handed. */
+  width: number;
+  height: number;
+  orientation: number;
+  /** What THIS browser is expected to report for the finished file. */
+  expectClient: { width: number; height: number };
+}): Promise<File> {
+  const { name, mime, width, height, orientation, expectClient } = opts;
+  const encoded = await raster(mime, width, height);
+  const bytes =
+    mime === 'image/webp'
+      ? webpWithExifOrientation(encoded, width, height, orientation)
+      : jpegWithExifOrientation(encoded, orientation);
+  const file = new File([bytes as BlobPart], name, { type: mime });
+  const bitmap = await createImageBitmap(file, { imageOrientation: 'from-image' });
+  try {
+    if (bitmap.width !== expectClient.width || bitmap.height !== expectClient.height) {
+      throw new Error(
+        `browser read ${bitmap.width}×${bitmap.height} for ${name}, expected ${expectClient.width}×${expectClient.height}`
+      );
+    }
+  } finally {
+    bitmap.close();
+  }
+  return file;
+}
+
 beforeEach(() => {
   mocks.ingestAsync.mockReset();
   mocks.setIconAsync.mockReset();
@@ -230,6 +375,7 @@ beforeEach(() => {
   mocks.uploadToCF.mockReset();
   mocks.scanStatusFetch.mockReset();
   mocks.showErrorNotification.mockReset();
+  mocks.validateListingImage.mockReset();
   // Default upload pipeline: CF upload + persist resolve so the row can reach
   // the attached+scanning state.
   mocks.uploadToCF.mockResolvedValue({ id: 'cf-image-id' });
@@ -630,52 +776,6 @@ describe('ListingAssetStep — per-KIND geometry precheck (issue #3772)', () => 
    * named a different number — cannot satisfy it.
    */
 
-  /**
-   * Drive one slot with one fixture and assert nothing reached the object store —
-   * and that the author was told WHY, in the server's exact words.
-   *
-   * The message is asserted on the channel that actually carries it for that slot:
-   * icon/cover rows render `state.message` inline, a screenshot slot renders only a
-   * status badge. `showErrorNotification` carries it for all three, so it is the
-   * assertion every kind shares; without it the screenshot cases would be asserting
-   * on an element the component never renders.
-   */
-  async function expectRefused(
-    which: 'icon' | 'cover' | 'screenshots',
-    file: File,
-    message: string
-  ) {
-    const kind = which === 'screenshots' ? 'screenshot' : which;
-    await userEvent.upload(await fileInputEl(which), file);
-    await vi.waitFor(() =>
-      expect(mocks.showErrorNotification).toHaveBeenCalledWith({
-        title: `Could not add ${kind}`,
-        // The Error the author sees, matched on its whole message — not a substring,
-        // so a guard that fired for a different bound cannot satisfy it.
-        error: expect.objectContaining({ message }),
-      })
-    );
-    if (which !== 'screenshots') {
-      await expect.element(page.getByText(message)).toBeInTheDocument();
-    }
-    expect(mocks.uploadToCF).not.toHaveBeenCalled();
-    expect(mocks.persistAsync).not.toHaveBeenCalled();
-  }
-
-  /** Drive one slot with one fixture and assert it DID reach the object store. */
-  async function expectUploaded(
-    which: 'icon' | 'cover' | 'screenshots',
-    file: File,
-    width: number,
-    height: number
-  ) {
-    await userEvent.upload(await fileInputEl(which), file);
-    await vi.waitFor(() => expect(mocks.uploadToCF).toHaveBeenCalledTimes(1));
-    await vi.waitFor(() =>
-      expect(mocks.persistAsync).toHaveBeenCalledWith(expect.objectContaining({ width, height }))
-    );
-  }
-
   beforeEach(() => {
     // The accept cases run past the upload into the attach proc; without a resolved
     // result the row would error for a reason unrelated to the bound under test.
@@ -886,5 +986,313 @@ describe('ListingAssetStep — per-KIND geometry precheck (issue #3772)', () => 
       await square(),
       `screenshot must be at least ${LISTING_SCREENSHOT_MIN_PX}px on its shorter side`
     );
+  });
+});
+
+describe('ListingAssetStep — EXIF orientation: the axes only agree for some containers', () => {
+  /**
+   * The per-kind precheck above is only honest while the browser and the server
+   * read the SAME width/height pair. They do not, universally — and the exception
+   * is a format the file inputs explicitly `accept`.
+   *
+   * Measured on Chromium 149 (and pinned per-fixture by `makeExifOrientedFile`):
+   *
+   *   JPEG   EXIF orientation applied → the pair matches the server's.
+   *   WEBP   EXIF orientation NOT applied → the pair arrives TRANSPOSED relative
+   *          to the server's. `imageOrientation: 'from-image'` does not change
+   *          this; neither does `'none'`. The option is inert for WebP here.
+   *
+   * A transposition maps an aspect `a` to `1/a`, so it inverts the verdict of any
+   * bound naming an axis. For a COVER — whose band 1.3–2.4 lies entirely above 1 —
+   * that means EVERY EXIF-rotated WebP cover the server would store was refused at
+   * the picker. So the client now prechecks only the bounds a quarter-turn cannot
+   * change (`Math.min`/`Math.max` ones) whenever the file's own bytes say WebP,
+   * and leaves the rest to the server.
+   *
+   * 🔴 The direction matters: skipping a client check restores a LATE rejection,
+   * which is the cost this PR set out to reduce. Refusing something the server
+   * would accept has no recovery at all — the author simply cannot upload a valid
+   * image. The two are not symmetric, which is why the sniff errs toward skipping.
+   */
+
+  beforeEach(() => {
+    mocks.setIconAsync.mockResolvedValue({ status: 'attached', iconId: 501, scanPending: false });
+    mocks.setCoverAsync.mockResolvedValue({ status: 'attached', coverId: 501, scanPending: false });
+    mocks.addScreenshotAsync.mockResolvedValue({
+      status: 'attached',
+      screenshotId: 77,
+      imageId: 501,
+      scanPending: false,
+    });
+  });
+
+  /** Stored 640×1280 + orientation 6 → the server measures a 1280×640 landscape. */
+  const exifCover = (
+    mime: 'image/webp' | 'image/jpeg',
+    client: { width: number; height: number }
+  ) =>
+    makeExifOrientedFile({
+      name: mime === 'image/webp' ? 'rotated-cover.webp' : 'rotated-cover.jpg',
+      mime,
+      width: 640,
+      height: 1280,
+      orientation: 6,
+      expectClient: client,
+    });
+
+  test('🔴 an EXIF-rotated WEBP cover the server accepts is UPLOADED, not refused at the picker', async () => {
+    renderStep();
+
+    // The regression case, end to end. The server reads this file as 1280×640 —
+    // aspect 2.00, inside the cover band — and stores it. Chromium reads the stored
+    // 640×1280, aspect 0.50, which is outside the band on the far side; a precheck
+    // that applied the band to THAT pair refuses a perfectly valid cover before a
+    // byte is sent, and no server round-trip ever gets to overrule it.
+    await expectUploaded(
+      'cover',
+      await exifCover('image/webp', { width: 640, height: 1280 }),
+      640,
+      1280
+    );
+
+    // Nothing was reported to the author either — a refusal that also uploaded
+    // would be a different bug wearing this test's green.
+    expect(mocks.showErrorNotification).not.toHaveBeenCalled();
+  });
+
+  test('the WEBP skip is NARROW — the orientation-invariant ceiling still refuses before upload', async () => {
+    renderStep();
+
+    // `Math.max(width, height)` is what the ceiling reads, and a quarter turn cannot
+    // change it, so this bound is as trustworthy for WebP as for anything else and
+    // is still prechecked. Without this, "skip the aspect check for WebP" and "skip
+    // ALL checks for WebP" would be indistinguishable — and the second is a real
+    // regression against #3824, the PR this one builds on.
+    const over = LISTING_ASSET_MAX_DIMENSION_PX + 1;
+    await expectRefused(
+      'cover',
+      await makeExifOrientedFile({
+        name: 'huge-rotated.webp',
+        mime: 'image/webp',
+        width: 512,
+        height: over,
+        orientation: 6,
+        expectClient: { width: 512, height: over },
+      }),
+      `That image is too large (max ${LISTING_ASSET_MAX_DIMENSION_PX}px per side, got ${over}px).`
+    );
+  });
+
+  test('the WEBP skip is NARROW — the orientation-invariant icon minimum still refuses before upload', async () => {
+    renderStep();
+
+    // The icon's minimum is stated over `Math.min(width, height)`: invariant, so it
+    // stays on for WebP too. A square keeps this test about the minimum rather than
+    // about the aspect band that is skipped here.
+    const under = LISTING_ICON_MIN_PX - 1;
+    await expectRefused(
+      'icon',
+      await makeExifOrientedFile({
+        name: 'tiny-rotated.webp',
+        mime: 'image/webp',
+        width: under,
+        height: under,
+        orientation: 6,
+        expectClient: { width: under, height: under },
+      }),
+      `icon must be at least ${LISTING_ICON_MIN_PX}px on its shorter side (got ${under}px)`
+    );
+  });
+
+  test('🔴 the skipped set is not just the ASPECT bands — the cover minimum WIDTH names an axis too', async () => {
+    renderStep();
+
+    // The cover's minimum is stated over `width`, not over the shorter side, so a
+    // transposed reading flips it exactly the way an aspect band does — it is
+    // orientation-SENSITIVE despite not being an aspect. Stored 400×800 + orientation
+    // 6 is a 800×400 landscape to the server: aspect 2.00, width 800, a perfectly
+    // valid cover. Chromium reads 400×800, whose width (400) is under the 640
+    // minimum. Skip the aspect band alone and this valid cover is STILL refused at
+    // the picker — the same user-facing failure, one bound further down.
+    expect(400).toBeLessThan(LISTING_COVER_MIN_WIDTH_PX);
+    await expectUploaded(
+      'cover',
+      await makeExifOrientedFile({
+        name: 'narrow-rotated.webp',
+        mime: 'image/webp',
+        width: 400,
+        height: 800,
+        orientation: 6,
+        expectClient: { width: 400, height: 800 },
+      }),
+      400,
+      800
+    );
+    expect(mocks.showErrorNotification).not.toHaveBeenCalled();
+  });
+
+  test('a WEBP whose aspect is genuinely wrong is now left to the SERVER (the accepted cost)', async () => {
+    renderStep();
+
+    // Stated as an expectation rather than left implicit: for WebP the aspect band
+    // is no longer a picker-time verdict, so a square WebP cover — which the server
+    // still refuses — now costs the upload it used to be spared. That is the price
+    // of not being able to tell a rotated WebP from an unrotated one, and it is the
+    // cheap direction: a late rejection, not an impossible upload.
+    await expectUploaded(
+      'cover',
+      new File([(await raster('image/webp', 640, 640)) as BlobPart], 'square.webp', {
+        type: 'image/webp',
+      }),
+      640,
+      640
+    );
+  });
+
+  // --- the JPEG control: same EXIF, same server reading, agreeing browser ---------
+
+  test('an EXIF-rotated JPEG cover uploads — the axes agree, so nothing changed for it', async () => {
+    renderStep();
+
+    // The same 640×1280-stored, orientation-6 file in the container Chromium DOES
+    // rotate: the browser reports 1280×640, the server measures 1280×640, and the
+    // cover band is applied to a pair both sides agree on. This is what the WebP
+    // case was assumed to look like.
+    await expectUploaded(
+      'cover',
+      await exifCover('image/jpeg', { width: 1280, height: 640 }),
+      1280,
+      640
+    );
+    expect(mocks.showErrorNotification).not.toHaveBeenCalled();
+  });
+
+  test('🔴 an EXIF-rotated JPEG whose DISPLAYED aspect is wrong is still refused before upload', async () => {
+    renderStep();
+
+    // The discriminating case for the sniff's polarity. Stored 1280×640 + orientation
+    // 6 displays as a 640×1280 PORTRAIT — invalid as a cover on both sides. A sniff
+    // that skipped the aspect band for everything EXCEPT WebP (inverted), or that
+    // skipped it unconditionally, lets this reach the object store.
+    await expectRefused(
+      'cover',
+      await makeExifOrientedFile({
+        name: 'rotated-portrait.jpg',
+        mime: 'image/jpeg',
+        width: 1280,
+        height: 640,
+        orientation: 6,
+        expectClient: { width: 640, height: 1280 },
+      }),
+      `cover must be landscape (aspect 0.50 outside ${LISTING_COVER_ASPECT_MIN}–${LISTING_COVER_ASPECT_MAX})`
+    );
+  });
+
+  // --- the sniff reads BYTES, not the filename ------------------------------------
+
+  test('🔴 a WEBP named ".png" is still treated as a WEBP — the sniff reads the file, not its name', async () => {
+    renderStep();
+
+    // `file.type` comes from the file NAME. This fixture is a real EXIF-rotated WebP
+    // announcing itself as `image/png`, which is exactly the mislabelling the PR body
+    // gives as its reason for leaving the MIME check server-only — so a gate on
+    // `file.type` here would land back in the over-strict direction the whole change
+    // exists to fix, and would do it silently.
+    const bytes = webpWithExifOrientation(await raster('image/webp', 640, 1280), 640, 1280, 6);
+    const mislabelled = new File([bytes as BlobPart], 'actually-a-webp.png', { type: 'image/png' });
+    expect(mislabelled.type).toBe('image/png');
+
+    await expectUploaded('cover', mislabelled, 640, 1280);
+    expect(mocks.showErrorNotification).not.toHaveBeenCalled();
+  });
+
+  test('a PNG is NOT sniffed as WebP — the aspect band still applies to it', async () => {
+    renderStep();
+
+    // The positive control for the test above: if `isWebpContainer` answered true for
+    // everything (or its offsets were wrong in a way that matched anything), the band
+    // would be off for PNG too and this square cover would upload.
+    await expectRefused(
+      'cover',
+      await makeImageFile('square-cover.png', 640, 640),
+      `cover must be landscape (aspect 1.00 outside ${LISTING_COVER_ASPECT_MIN}–${LISTING_COVER_ASPECT_MAX})`
+    );
+  });
+});
+
+describe('ListingAssetStep — the precheck supplies GEOMETRY only (exclusions ledger)', () => {
+  /**
+   * 🔴 The PR body declares two fields deliberately withheld from
+   * `validateListingImage` — `sizeBytes` and `mimeType` — because this side cannot
+   * evaluate either faithfully and a wrong verdict would refuse an image the server
+   * accepts. Both were unguarded: adding either survived the entire suite. These
+   * make the exclusion a test rather than a paragraph, structurally (the exact set
+   * of keys handed over) and behaviourally (a file that WOULD trip each one still
+   * reaches the object store).
+   */
+
+  beforeEach(() => {
+    mocks.setCoverAsync.mockResolvedValue({ status: 'attached', coverId: 501, scanPending: false });
+  });
+
+  test('the meta handed to validateListingImage carries EXACTLY type/width/height', async () => {
+    renderStep();
+
+    await expectUploaded('cover', await makeImageFile('ok-cover.png', 1280, 640), 1280, 640);
+
+    expect(mocks.validateListingImage).toHaveBeenCalledTimes(1);
+    const [meta, kind] = mocks.validateListingImage.mock.calls[0];
+    // An asserted LEDGER, not a subset match: this fails when the set GROWS (a
+    // future `sizeBytes`/`mimeType`) and when it SHRINKS (a field the predicate
+    // needs going missing).
+    expect(Object.keys(meta).sort()).toEqual(['height', 'type', 'width']);
+    expect(meta).toEqual({ type: 'image', width: 1280, height: 640 });
+    expect(kind).toBe('cover');
+  });
+
+  test('the sniff verdict is passed through as the third argument (PNG → axis-aware)', async () => {
+    renderStep();
+
+    // Kept separate from the ledger above so the two claims stay separable: the
+    // ledger is an INVARIANT guard (it held before this change too), while this
+    // asserts the option the change introduced actually reaches the predicate — and
+    // that a PNG resolves to `false`, i.e. every bound stays on for it.
+    await expectUploaded('cover', await makeImageFile('ok-cover.png', 1280, 640), 1280, 640);
+
+    const [, , opts] = mocks.validateListingImage.mock.calls[0];
+    expect(opts).toEqual({ skipOrientationSensitive: false });
+  });
+
+  test('a cover over the per-kind BYTE cap still uploads — size stays a server verdict', async () => {
+    renderStep();
+
+    // Padding after `IEND` leaves the PNG decodable while pushing the file past the
+    // 4 MiB cover cap. Were `sizeBytes: file.size` passed, `validateListingImage`
+    // would refuse this at the picker naming the wrong gate (the whole-asset ceiling
+    // at persist is reached first on the server).
+    const png = await makeImageFile('padded.png', 1280, 640);
+    const padded = new File(
+      [png, new Uint8Array(MAX_LISTING_COVER_SIZE_BYTES) as BlobPart],
+      'padded.png',
+      { type: 'image/png' }
+    );
+    expect(padded.size).toBeGreaterThan(MAX_LISTING_COVER_SIZE_BYTES);
+
+    await expectUploaded('cover', padded, 1280, 640);
+    expect(mocks.showErrorNotification).not.toHaveBeenCalled();
+  });
+
+  test('a cover whose file.type is an UNSUPPORTED mime still uploads — MIME stays a server verdict', async () => {
+    renderStep();
+
+    // Real PNG bytes wearing a `image/gif` label, which `LISTING_ASSET_ALLOWED_MIME`
+    // does not contain. The server reads the DECODED format and accepts it; a
+    // `mimeType: file.type` passed here would not.
+    const png = await makeImageFile('mislabelled.png', 1280, 640);
+    const mislabelled = new File([png], 'mislabelled.gif', { type: 'image/gif' });
+    expect(mislabelled.type).toBe('image/gif');
+
+    await expectUploaded('cover', mislabelled, 1280, 640);
+    expect(mocks.showErrorNotification).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Apps/ListingAssetStep.browser.test.tsx
+++ b/src/components/Apps/ListingAssetStep.browser.test.tsx
@@ -1104,6 +1104,66 @@ describe('ListingAssetStep — EXIF orientation: the axes only agree for some co
     );
   });
 
+  test('the WEBP skip is NARROW — the orientation-invariant icon MAXIMUM still refuses before upload', async () => {
+    renderStep();
+
+    // The icon's own maximum is `Math.max(width, height)` — invariant under a
+    // quarter turn, so it stays on for WebP like the minimum above.
+    //
+    // 🔴 It needs its own case because it is NOT covered by the ceiling guard two
+    // tests up: 4096 is HALF the 8192 kind-agnostic ceiling, so a fixture that trips
+    // the icon maximum is comfortably under the ceiling and reaches this bound with
+    // nothing having fired earlier. Widening the skip to cover it therefore changes
+    // real behaviour — a 4097px icon that used to be refused at the picker would be
+    // uploaded and refused by the server — while leaving every other test green.
+    //
+    // The strip shape is deliberate: its aspect (20.49) is far outside the icon
+    // band, which for a WebP is exactly the bound that is skipped, so what remains
+    // to refuse it is the maximum and nothing else. `expectRefused` matches the
+    // WHOLE message, so a run where the aspect band fired instead would fail here
+    // rather than pass for the wrong reason.
+    const over = LISTING_ICON_MAX_PX + 1;
+    expect(over).toBeLessThan(LISTING_ASSET_MAX_DIMENSION_PX);
+    await expectRefused(
+      'icon',
+      await makeExifOrientedFile({
+        name: 'over-max-rotated.webp',
+        mime: 'image/webp',
+        width: over,
+        height: 200,
+        orientation: 6,
+        expectClient: { width: over, height: 200 },
+      }),
+      `icon must be at most ${LISTING_ICON_MAX_PX}px on its longer side (got ${over}px)`
+    );
+  });
+
+  test('the WEBP skip is NARROW — the screenshot MINIMUM shorter side still refuses before upload', async () => {
+    renderStep();
+
+    // The third kind's invariant bound, and the last of the four kept ones without a
+    // case of its own. `Math.min(width, height)` cannot be changed by a quarter turn,
+    // so a WebP screenshot under it is refused at the picker exactly as a PNG one is.
+    //
+    // Square on purpose: aspect 1.00 sits inside the screenshot band (0.4–2.6), so
+    // this fixture would be accepted by every bound EXCEPT the minimum — the test
+    // does not lean on the aspect skip in either direction, and a run in which the
+    // minimum stopped applying has nothing else left to refuse it.
+    const under = LISTING_SCREENSHOT_MIN_PX - 20;
+    await expectRefused(
+      'screenshots',
+      await makeExifOrientedFile({
+        name: 'small-rotated.webp',
+        mime: 'image/webp',
+        width: under,
+        height: under,
+        orientation: 6,
+        expectClient: { width: under, height: under },
+      }),
+      `screenshot must be at least ${LISTING_SCREENSHOT_MIN_PX}px on its shorter side`
+    );
+  });
+
   test('🔴 the skipped set is not just the ASPECT bands — the cover minimum WIDTH names an axis too', async () => {
     renderStep();
 

--- a/src/components/Apps/ListingAssetStep.browser.test.tsx
+++ b/src/components/Apps/ListingAssetStep.browser.test.tsx
@@ -1,8 +1,20 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
-// The bound the precheck applies, IMPORTED rather than spelled: a literal here
+// The bounds the prechecks apply, IMPORTED rather than spelled: a literal here
 // would agree with a precheck that hard-coded a different number.
-import { LISTING_ASSET_MAX_DIMENSION_PX } from '~/server/schema/blocks/app-listing.schema';
+import {
+  LISTING_ASSET_MAX_DIMENSION_PX,
+  LISTING_COVER_ASPECT_MAX,
+  LISTING_COVER_ASPECT_MIN,
+  LISTING_COVER_MIN_WIDTH_PX,
+  LISTING_ICON_ASPECT_MAX,
+  LISTING_ICON_ASPECT_MIN,
+  LISTING_ICON_MAX_PX,
+  LISTING_ICON_MIN_PX,
+  LISTING_SCREENSHOT_ASPECT_MAX,
+  LISTING_SCREENSHOT_ASPECT_MIN,
+  LISTING_SCREENSHOT_MIN_PX,
+} from '~/server/schema/blocks/app-listing.schema';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
 
@@ -46,6 +58,12 @@ const mocks = vi.hoisted(() => ({
   uploadToCF: vi.fn(),
   // Item 1: the per-asset scan-status poll (utils.appListings.getAssetScanStatuses.fetch).
   scanStatusFetch: vi.fn(),
+  // Hoisted (rather than an inline `vi.fn()` in the factory) so the per-kind
+  // precheck tests can read what the author was actually told: the icon/cover rows
+  // render `state.message` inline, but a SCREENSHOT slot renders only a status
+  // badge, so for screenshots this notification is the ONLY channel the rejection
+  // reason travels on.
+  showErrorNotification: vi.fn(),
 }));
 
 vi.mock('~/utils/trpc', () => {
@@ -58,10 +76,18 @@ vi.mock('~/utils/trpc', () => {
       }),
       appListings: {
         persistAssetImage: {
-          useMutation: () => ({ mutate: vi.fn(), mutateAsync: mocks.persistAsync, isPending: false }),
+          useMutation: () => ({
+            mutate: vi.fn(),
+            mutateAsync: mocks.persistAsync,
+            isPending: false,
+          }),
         },
         ingestAssetFromUrl: {
-          useMutation: () => ({ mutate: vi.fn(), mutateAsync: mocks.ingestAsync, isPending: false }),
+          useMutation: () => ({
+            mutate: vi.fn(),
+            mutateAsync: mocks.ingestAsync,
+            isPending: false,
+          }),
         },
         // `ListingAssetStep` calls `trpc.appListings.ingestAssetFromDataUri.useMutation()`
         // unconditionally at the top of the component. A wholesale `vi.mock` of
@@ -76,10 +102,18 @@ vi.mock('~/utils/trpc', () => {
           }),
         },
         setIcon: {
-          useMutation: () => ({ mutate: vi.fn(), mutateAsync: mocks.setIconAsync, isPending: false }),
+          useMutation: () => ({
+            mutate: vi.fn(),
+            mutateAsync: mocks.setIconAsync,
+            isPending: false,
+          }),
         },
         setCover: {
-          useMutation: () => ({ mutate: vi.fn(), mutateAsync: mocks.setCoverAsync, isPending: false }),
+          useMutation: () => ({
+            mutate: vi.fn(),
+            mutateAsync: mocks.setCoverAsync,
+            isPending: false,
+          }),
         },
         addScreenshot: {
           useMutation: () => ({
@@ -89,7 +123,11 @@ vi.mock('~/utils/trpc', () => {
           }),
         },
         removeScreenshot: {
-          useMutation: () => ({ mutate: vi.fn(), mutateAsync: mocks.removeAsync, isPending: false }),
+          useMutation: () => ({
+            mutate: vi.fn(),
+            mutateAsync: mocks.removeAsync,
+            isPending: false,
+          }),
         },
       },
     },
@@ -107,7 +145,7 @@ vi.mock('~/hooks/useCFImageUpload', () => ({
 
 vi.mock('~/utils/notifications', () => ({
   showSuccessNotification: vi.fn(),
-  showErrorNotification: vi.fn(),
+  showErrorNotification: mocks.showErrorNotification,
 }));
 
 const { ListingAssetStep } = await import('./ListingAssetStep');
@@ -132,8 +170,13 @@ function renderStep(props: Partial<Parameters<typeof ListingAssetStep>[0]> = {})
  * Generate a REAL png File (via canvas → toBlob) — an arbitrary-bytes File would
  * fail `createImageBitmap` in the upload path (readImageDimensions), so the row
  * would never reach the scanning state we assert on.
+ *
+ * The default 640×480 is a VALID SCREENSHOT (aspect 1.33 inside 0.4–2.6, shorter
+ * side 480 ≥ 320) because the client now applies the server's per-kind geometry
+ * rules before uploading: a fixture that merely decodes is no longer enough for a
+ * test whose subject is anything downstream of the picker.
  */
-async function makeImageFile(name = 'shot.png', width = 200, height = 150): Promise<File> {
+async function makeImageFile(name = 'shot.png', width = 640, height = 480): Promise<File> {
   const canvas = document.createElement('canvas');
   canvas.width = width;
   canvas.height = height;
@@ -186,24 +229,25 @@ beforeEach(() => {
   mocks.persistAsync.mockReset();
   mocks.uploadToCF.mockReset();
   mocks.scanStatusFetch.mockReset();
+  mocks.showErrorNotification.mockReset();
   // Default upload pipeline: CF upload + persist resolve so the row can reach
   // the attached+scanning state.
   mocks.uploadToCF.mockResolvedValue({ id: 'cf-image-id' });
   mocks.persistAsync.mockResolvedValue({ imageId: 501 });
   // Default scan poll: the image is still scanning (keeps the "Scanning…" badge).
   // A test that wants it to LAND overrides this to return 'scanned' / 'blocked'.
-  mocks.scanStatusFetch.mockImplementation(
-    async ({ imageIds }: { imageIds: number[] }) => ({
-      statuses: imageIds.map((imageId) => ({ imageId, status: 'pending' as const })),
-    })
-  );
+  mocks.scanStatusFetch.mockImplementation(async ({ imageIds }: { imageIds: number[] }) => ({
+    statuses: imageIds.map((imageId) => ({ imageId, status: 'pending' as const })),
+  }));
 });
 
 describe('ListingAssetStep — OG-image auto-fill', () => {
   test('renders the suggested-icon accept affordance from the server suggestion', async () => {
     renderStep();
     await expect.element(page.getByTestId('apps-offsite-accept-icon')).toBeInTheDocument();
-    await expect.element(page.getByTestId('apps-offsite-suggested-icon-preview')).toBeInTheDocument();
+    await expect
+      .element(page.getByTestId('apps-offsite-suggested-icon-preview'))
+      .toBeInTheDocument();
     // The "re-scan it just like an upload" reassurance is shown (icon + cover
     // both render it → scope with .first()).
     await expect
@@ -232,9 +276,7 @@ describe('ListingAssetStep — OG-image auto-fill', () => {
     expect(mocks.setIconAsync).toHaveBeenCalledWith({ listingId: 'listing-1', imageId: 777 });
 
     // The scan-status poll lands → the badge flips to "Scanned".
-    await expect
-      .element(page.getByTestId('apps-asset-scan-scanned'))
-      .toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-asset-scan-scanned')).toBeInTheDocument();
     expect(mocks.scanStatusFetch).toHaveBeenCalledWith({ imageIds: [777] });
   });
 
@@ -258,10 +300,7 @@ describe('ListingAssetStep — OG-image auto-fill', () => {
     // the client classifies it as a terminal error instead of polling forever, and
     // shows the human message for display.
     mocks.setIconAsync.mockRejectedValue(
-      trpcAttachError(
-        'BAD_REQUEST',
-        "that image couldn't be imported — upload it manually instead"
-      )
+      trpcAttachError('BAD_REQUEST', "that image couldn't be imported — upload it manually instead")
     );
 
     renderStep();
@@ -305,7 +344,8 @@ describe('ListingAssetStep — uploaded-asset preview + cancel mid-scan', () => 
     mocks.setIconAsync.mockResolvedValue({ status: 'attached', iconId: 501, scanPending: true });
     renderStep();
 
-    await userEvent.upload(await fileInputEl('icon'), await makeImageFile('icon.png'));
+    // Square + comfortably inside the icon bounds — see `makeImageFile`.
+    await userEvent.upload(await fileInputEl('icon'), await makeImageFile('icon.png', 256, 256));
 
     const preview = page.getByTestId('apps-offsite-current-icon-preview');
     await expect.element(preview).toBeInTheDocument();
@@ -342,7 +382,9 @@ describe('ListingAssetStep — uploaded-asset preview + cancel mid-scan', () => 
     await cancel.click();
 
     // The committed row was removed on the server …
-    await vi.waitFor(() => expect(mocks.removeAsync).toHaveBeenCalledWith({ screenshotId: 'row-1' }));
+    await vi.waitFor(() =>
+      expect(mocks.removeAsync).toHaveBeenCalledWith({ screenshotId: 'row-1' })
+    );
     // … the slot is gone (no preview, no "Screenshot 1" row) …
     await expect.element(page.getByText('Screenshot 1')).not.toBeInTheDocument();
     expect(page.getByTestId('apps-offsite-screenshot-preview-0').elements()).toHaveLength(0);
@@ -354,7 +396,9 @@ describe('ListingAssetStep — uploaded-asset preview + cancel mid-scan', () => 
   const prefill = {
     icon: { imageId: 1, url: 'https://edge/icon.png' },
     cover: { imageId: 2, url: 'https://edge/cover.png' },
-    screenshots: [{ id: 'row-9', imageId: 3, url: 'https://edge/shot.png', caption: null, order: 0 }],
+    screenshots: [
+      { id: 'row-9', imageId: 3, url: 'https://edge/shot.png', caption: null, order: 0 },
+    ],
   };
 
   test('an attached prefilled screenshot offers NO remove/cancel when allowRemove=false', async () => {
@@ -411,9 +455,7 @@ describe('ListingAssetStep — uploaded-asset preview + cancel mid-scan', () => 
       },
     });
     const alert = page.getByTestId('apps-listing-assets-completeness');
-    await expect
-      .element(alert)
-      .toHaveTextContent(/Screenshots are recommended but optional/i);
+    await expect.element(alert).toHaveTextContent(/Screenshots are recommended but optional/i);
     await vi.waitFor(() => expect(state.meetsFloor).toBe(true));
     expect(state.complete).toBe(false);
   });
@@ -538,9 +580,13 @@ describe('ListingAssetStep — per-side dimension precheck (issue #3772)', () =>
     mocks.setCoverAsync.mockResolvedValue({ status: 'attached', coverId: 501, scanPending: true });
     renderStep();
 
+    // Half the long side, so the aspect (2.0) also sits inside the COVER's own
+    // 1.3–2.4 band: the fixture has to clear every rule the client now applies, or
+    // this would fail for a reason that has nothing to do with the bound it guards.
+    const atBoundHeight = LISTING_ASSET_MAX_DIMENSION_PX / 2;
     await userEvent.upload(
       await fileInputEl('cover'),
-      await makeImageFile('at-bound.png', LISTING_ASSET_MAX_DIMENSION_PX, 512)
+      await makeImageFile('at-bound.png', LISTING_ASSET_MAX_DIMENSION_PX, atBoundHeight)
     );
 
     // The positive control for the test above: the SAME code path and the same
@@ -550,8 +596,295 @@ describe('ListingAssetStep — per-side dimension precheck (issue #3772)', () =>
     await vi.waitFor(() => expect(mocks.uploadToCF).toHaveBeenCalledTimes(1));
     await vi.waitFor(() =>
       expect(mocks.persistAsync).toHaveBeenCalledWith(
-        expect.objectContaining({ width: LISTING_ASSET_MAX_DIMENSION_PX, height: 512 })
+        expect.objectContaining({
+          width: LISTING_ASSET_MAX_DIMENSION_PX,
+          height: atBoundHeight,
+        })
       )
+    );
+  });
+});
+
+describe('ListingAssetStep — per-KIND geometry precheck (issue #3772)', () => {
+  /**
+   * The per-side ceiling above is kind-AGNOSTIC. Every other geometry rule the
+   * server applies is per-kind and lives at ATTACH (`validateListingImage`, reached
+   * through `setIcon`/`setCover`/`addScreenshot`) — which the client only gets to
+   * AFTER the upload AND the persist. So a 5000px icon, or a merely wrongly-shaped
+   * one, still cost a full transfer before being refused, and a wrongly-shaped icon
+   * is far easier to produce by accident than an 8192px one.
+   *
+   * Each bound is asserted in BOTH directions: a fixture the server would refuse is
+   * refused before `uploadToCF`, and a fixture at the boundary the server ACCEPTS
+   * still uploads. The accept half is not decoration — over-rejection at the picker
+   * is a worse failure than the wasted upload this is fixing, and only the accept
+   * cases can catch it.
+   *
+   * 🔴 As with the block above, these prove the UPLOAD IS SKIPPED, not that the
+   * image is rejected. The server re-derives the pair from the stored bytes and
+   * re-applies `validateListingImage`; that remains the enforcement point, and it is
+   * covered by `src/server/services/blocks/__tests__/app-listing-assets.service.test.ts`.
+   *
+   * Every expected message is BUILT FROM THE IMPORTED CONSTANTS and asserted whole,
+   * including the offending value, so a guard that fired for a different reason — or
+   * named a different number — cannot satisfy it.
+   */
+
+  /**
+   * Drive one slot with one fixture and assert nothing reached the object store —
+   * and that the author was told WHY, in the server's exact words.
+   *
+   * The message is asserted on the channel that actually carries it for that slot:
+   * icon/cover rows render `state.message` inline, a screenshot slot renders only a
+   * status badge. `showErrorNotification` carries it for all three, so it is the
+   * assertion every kind shares; without it the screenshot cases would be asserting
+   * on an element the component never renders.
+   */
+  async function expectRefused(
+    which: 'icon' | 'cover' | 'screenshots',
+    file: File,
+    message: string
+  ) {
+    const kind = which === 'screenshots' ? 'screenshot' : which;
+    await userEvent.upload(await fileInputEl(which), file);
+    await vi.waitFor(() =>
+      expect(mocks.showErrorNotification).toHaveBeenCalledWith({
+        title: `Could not add ${kind}`,
+        // The Error the author sees, matched on its whole message — not a substring,
+        // so a guard that fired for a different bound cannot satisfy it.
+        error: expect.objectContaining({ message }),
+      })
+    );
+    if (which !== 'screenshots') {
+      await expect.element(page.getByText(message)).toBeInTheDocument();
+    }
+    expect(mocks.uploadToCF).not.toHaveBeenCalled();
+    expect(mocks.persistAsync).not.toHaveBeenCalled();
+  }
+
+  /** Drive one slot with one fixture and assert it DID reach the object store. */
+  async function expectUploaded(
+    which: 'icon' | 'cover' | 'screenshots',
+    file: File,
+    width: number,
+    height: number
+  ) {
+    await userEvent.upload(await fileInputEl(which), file);
+    await vi.waitFor(() => expect(mocks.uploadToCF).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() =>
+      expect(mocks.persistAsync).toHaveBeenCalledWith(expect.objectContaining({ width, height }))
+    );
+  }
+
+  beforeEach(() => {
+    // The accept cases run past the upload into the attach proc; without a resolved
+    // result the row would error for a reason unrelated to the bound under test.
+    mocks.setIconAsync.mockResolvedValue({ status: 'attached', iconId: 501, scanPending: false });
+    mocks.setCoverAsync.mockResolvedValue({ status: 'attached', coverId: 501, scanPending: false });
+    mocks.addScreenshotAsync.mockResolvedValue({
+      status: 'attached',
+      id: 'row-1',
+      order: 0,
+      scanPending: false,
+    });
+  });
+
+  // --- icon: longer side (the bound the kind-agnostic ceiling is DOUBLE of) ------
+
+  test('an icon over the ICON pixel cap is refused before the upload — at half the kind-agnostic ceiling', async () => {
+    renderStep();
+    // 🔴 The discriminating case for this whole block: this is UNDER
+    // LISTING_ASSET_MAX_DIMENSION_PX, so the pre-existing per-side precheck passes
+    // it. Only a check that knows the asset is an ICON refuses it.
+    expect(LISTING_ICON_MAX_PX).toBeLessThan(LISTING_ASSET_MAX_DIMENSION_PX);
+    const over = LISTING_ICON_MAX_PX + 1;
+    await expectRefused(
+      'icon',
+      await makeImageFile('big-icon.png', over, over),
+      `icon must be at most ${LISTING_ICON_MAX_PX}px on its longer side (got ${over}px)`
+    );
+  });
+
+  test('an icon EXACTLY at the ICON pixel cap still uploads', async () => {
+    renderStep();
+    await expectUploaded(
+      'icon',
+      await makeImageFile('max-icon.png', LISTING_ICON_MAX_PX, LISTING_ICON_MAX_PX),
+      LISTING_ICON_MAX_PX,
+      LISTING_ICON_MAX_PX
+    );
+  });
+
+  // --- icon: aspect (both sides of the band) ------------------------------------
+
+  test('a WIDE icon is refused before the upload', async () => {
+    renderStep();
+    await expectRefused(
+      'icon',
+      await makeImageFile('wide-icon.png', 242, 200),
+      `icon must be square-ish (aspect 1.21 outside ${LISTING_ICON_ASPECT_MIN}–${LISTING_ICON_ASPECT_MAX})`
+    );
+  });
+
+  test('a TALL icon is refused before the upload — the band is two-sided', async () => {
+    renderStep();
+    // The wide case above cannot tell a two-sided band from a bare upper bound.
+    await expectRefused(
+      'icon',
+      await makeImageFile('tall-icon.png', 200, 242),
+      `icon must be square-ish (aspect 0.83 outside ${LISTING_ICON_ASPECT_MIN}–${LISTING_ICON_ASPECT_MAX})`
+    );
+  });
+
+  test('an icon at the aspect band EDGE still uploads', async () => {
+    renderStep();
+    // 220/200 = 1.1 exactly — the boundary the two refusals bracket.
+    await expectUploaded('icon', await makeImageFile('edge-icon.png', 220, 200), 220, 200);
+  });
+
+  // --- icon: minimum shorter side ----------------------------------------------
+
+  test('an under-size icon is refused before the upload', async () => {
+    renderStep();
+    const under = LISTING_ICON_MIN_PX - 1;
+    await expectRefused(
+      'icon',
+      await makeImageFile('small-icon.png', under, under),
+      `icon must be at least ${LISTING_ICON_MIN_PX}px on its shorter side (got ${under}px)`
+    );
+  });
+
+  test('an icon EXACTLY at the minimum still uploads', async () => {
+    renderStep();
+    await expectUploaded(
+      'icon',
+      await makeImageFile('min-icon.png', LISTING_ICON_MIN_PX, LISTING_ICON_MIN_PX),
+      LISTING_ICON_MIN_PX,
+      LISTING_ICON_MIN_PX
+    );
+  });
+
+  // --- cover: aspect + minimum width -------------------------------------------
+
+  test('a SQUARE cover is refused before the upload', async () => {
+    renderStep();
+    // Width is kept above the cover minimum so the ASPECT rule is what fires.
+    await expectRefused(
+      'cover',
+      await makeImageFile('square-cover.png', 640, 640),
+      `cover must be landscape (aspect 1.00 outside ${LISTING_COVER_ASPECT_MIN}–${LISTING_COVER_ASPECT_MAX})`
+    );
+  });
+
+  test('an over-wide cover is refused before the upload', async () => {
+    renderStep();
+    await expectRefused(
+      'cover',
+      await makeImageFile('panorama.png', 1600, 640),
+      `cover must be landscape (aspect 2.50 outside ${LISTING_COVER_ASPECT_MIN}–${LISTING_COVER_ASPECT_MAX})`
+    );
+  });
+
+  test('a cover at the widest ACCEPTED aspect still uploads', async () => {
+    renderStep();
+    // 1536/640 = 2.4 exactly — one step inside the refusal above.
+    await expectUploaded('cover', await makeImageFile('wide-cover.png', 1536, 640), 1536, 640);
+  });
+
+  test('a too-narrow cover is refused before the upload', async () => {
+    renderStep();
+    const under = LISTING_COVER_MIN_WIDTH_PX - 1;
+    // Aspect 1.5 — inside the band, so WIDTH is unambiguously what fires.
+    await expectRefused(
+      'cover',
+      await makeImageFile('narrow-cover.png', under, 426),
+      `cover must be at least ${LISTING_COVER_MIN_WIDTH_PX}px wide (got ${under}px)`
+    );
+  });
+
+  test('a cover EXACTLY at the minimum width still uploads', async () => {
+    renderStep();
+    await expectUploaded(
+      'cover',
+      await makeImageFile('min-cover.png', LISTING_COVER_MIN_WIDTH_PX, 427),
+      LISTING_COVER_MIN_WIDTH_PX,
+      427
+    );
+  });
+
+  // --- screenshot: aspect + minimum shorter side --------------------------------
+
+  test('an over-wide screenshot is refused before the upload', async () => {
+    renderStep();
+    await expectRefused(
+      'screenshots',
+      await makeImageFile('wide-shot.png', 1080, 400),
+      `screenshot aspect 2.70 is outside ${LISTING_SCREENSHOT_ASPECT_MIN}–${LISTING_SCREENSHOT_ASPECT_MAX}`
+    );
+  });
+
+  test('an over-tall screenshot is refused before the upload — the band is two-sided', async () => {
+    renderStep();
+    await expectRefused(
+      'screenshots',
+      await makeImageFile('tall-shot.png', 400, 1080),
+      `screenshot aspect 0.37 is outside ${LISTING_SCREENSHOT_ASPECT_MIN}–${LISTING_SCREENSHOT_ASPECT_MAX}`
+    );
+  });
+
+  test('a screenshot at the widest ACCEPTED aspect still uploads', async () => {
+    renderStep();
+    // 1040/400 = 2.6 exactly.
+    await expectUploaded('screenshots', await makeImageFile('edge-shot.png', 1040, 400), 1040, 400);
+  });
+
+  test('an under-size screenshot is refused before the upload', async () => {
+    renderStep();
+    const under = LISTING_SCREENSHOT_MIN_PX - 1;
+    // Aspect 2.5 — inside the band, so the SHORTER SIDE is what fires.
+    await expectRefused(
+      'screenshots',
+      await makeImageFile('small-shot.png', 800, under),
+      `screenshot must be at least ${LISTING_SCREENSHOT_MIN_PX}px on its shorter side`
+    );
+  });
+
+  test('a screenshot EXACTLY at the minimum shorter side still uploads', async () => {
+    renderStep();
+    await expectUploaded(
+      'screenshots',
+      await makeImageFile('min-shot.png', 800, LISTING_SCREENSHOT_MIN_PX),
+      800,
+      LISTING_SCREENSHOT_MIN_PX
+    );
+  });
+
+  // --- the kind is actually THREADED, not assumed --------------------------------
+
+  test('ONE fixture, three verdicts — the slot decides which rules apply', async () => {
+    // 🔴 The guard against the kind being hardcoded or mis-threaded. A 256×256 square
+    // is a VALID icon, but too square for a cover (aspect 1.00 < 1.3) and too small
+    // for a screenshot (256 < 320). Any implementation that validates every upload
+    // as one fixed kind gets at least one of these three wrong, and a `kind`
+    // threaded from the wrong place gets the accept and the refusals inconsistent.
+    const square = () => makeImageFile('square.png', 256, 256);
+
+    renderStep();
+    await expectUploaded('icon', await square(), 256, 256);
+
+    mocks.uploadToCF.mockClear();
+    mocks.persistAsync.mockClear();
+    mocks.showErrorNotification.mockClear();
+    await expectRefused(
+      'cover',
+      await square(),
+      `cover must be landscape (aspect 1.00 outside ${LISTING_COVER_ASPECT_MIN}–${LISTING_COVER_ASPECT_MAX})`
+    );
+
+    await expectRefused(
+      'screenshots',
+      await square(),
+      `screenshot must be at least ${LISTING_SCREENSHOT_MIN_PX}px on its shorter side`
     );
   });
 });

--- a/src/components/Apps/ListingAssetStep.tsx
+++ b/src/components/Apps/ListingAssetStep.tsx
@@ -123,15 +123,26 @@ function mergePreview(prev: AssetState, next: AssetState): AssetState {
 }
 
 /**
- * Read the DISPLAYED pixel dimensions of an image File (the attach proc rejects
- * zero/unknown).
+ * Read the pixel dimensions of an image File as the BROWSER presents them (the
+ * attach proc rejects zero/unknown).
  *
- * `imageOrientation: 'from-image'` is the spec default, and is passed EXPLICITLY
- * because the prechecks in `uploadAndPersist` depend on it: the server measures
- * the displayed pair too (`probeStoredImage` transposes width/height for the EXIF
- * quarter-turns, orientations 5–8), and only if this side does the same do the two
- * agree on the individual axes rather than merely on `Math.max`. Spelling it out
- * keeps that agreement from resting on a default a browser could differ on.
+ * 🔴 "As the browser presents them" is not the same as the server's pair for every
+ * container, and the prechecks in `uploadAndPersist` are split along exactly that
+ * line. Measured on Chromium 149:
+ *
+ *   JPEG, PNG  the browser applies EXIF orientation, and so does the server
+ *              (`probeStoredImage` transposes for orientations 5–8) — the two
+ *              agree on BOTH AXES, not merely on `Math.max`.
+ *   WEBP       the browser does NOT apply it. An EXIF-oriented WebP stored 640×1280
+ *              reads 640×1280 here and 1280×640 on the server. The axes are
+ *              transposed relative to each other, so any bound naming an axis (an
+ *              aspect band, the cover's minimum width) gets the OPPOSITE verdict.
+ *
+ * `imageOrientation: 'from-image'` is the spec default and is passed explicitly to
+ * state the intent, but it does NOT buy the agreement: in this Chromium the option
+ * is inert for WebP — `'from-image'`, `'none'` and no options all return the stored
+ * pair — which is why `uploadAndPersist` sniffs the container instead of trusting
+ * it. WebP is offered by the file inputs' own `accept`, so this is a live path.
  */
 async function readImageDimensions(file: File): Promise<{ width: number; height: number }> {
   const bitmap = await createImageBitmap(file, { imageOrientation: 'from-image' });
@@ -140,6 +151,32 @@ async function readImageDimensions(file: File): Promise<{ width: number; height:
   } finally {
     bitmap.close();
   }
+}
+
+/** `RIFF` at offset 0 and `WEBP` at offset 8 — the WebP container's signature. */
+const WEBP_RIFF = [0x52, 0x49, 0x46, 0x46];
+const WEBP_FORM = [0x57, 0x45, 0x42, 0x50];
+
+/**
+ * Is this file a WEBP, judged from its own first bytes?
+ *
+ * 🔴 Deliberately NOT `file.type`. That is derived from the file NAME, which is
+ * precisely why the MIME check is left server-only a few lines below — and a
+ * mislabelled file is the case this has to get right: reading `.png` off a WebP
+ * would re-enable the axis-sensitive bounds on the one container whose axes this
+ * side cannot trust, which is the over-strict failure being fixed. The bytes are
+ * the thing the server's decoder will also go on.
+ *
+ * Reads the first 12 bytes only (`File.slice` is a view; nothing else is pulled
+ * into memory). A file too short to hold a signature is not a WebP — and is not a
+ * decodable image either, so `createImageBitmap` has already thrown for it.
+ */
+async function isWebpContainer(file: File): Promise<boolean> {
+  const header = new Uint8Array(await file.slice(0, 12).arrayBuffer());
+  if (header.length < 12) return false;
+  return (
+    WEBP_RIFF.every((b, i) => header[i] === b) && WEBP_FORM.every((b, i) => header[8 + i] === b)
+  );
 }
 
 export function ListingAssetStep({
@@ -352,10 +389,18 @@ export function ListingAssetStep({
     // Both predicates are IMPORTED, never restated: a vendored copy of a bound is
     // exactly what goes stale and starts refusing valid input (civitai/cli#270).
     //
-    // Evaluating them on the BROWSER's reading is sound because both sides read the
-    // DISPLAYED pixel pair — see `readImageDimensions`. They agree on BOTH AXES, not
-    // merely on `Math.max`, and that is precisely what licenses prechecking the
-    // orientation-SENSITIVE aspect bounds here at all.
+    // 🔴 How much of (2) may be evaluated here depends on the CONTAINER, because
+    // that decides whether this side and the server agree about which axis is which
+    // — see `readImageDimensions` for the measurement. For JPEG and PNG both apply
+    // EXIF orientation and agree on both axes, so every bound is fair game. For
+    // WEBP the browser does not, so the pair arrives transposed relative to the
+    // server's and any bound naming an axis would be evaluated against the wrong
+    // one: an EXIF-rotated WebP cover the server stores happily (aspect 2.00) reads
+    // as 0.50 here, i.e. EVERY such cover would be refused at the picker. So for
+    // WebP the axis-sensitive bounds are skipped and left to the server, and only
+    // the transposition-INVARIANT ones — which a quarter-turn cannot change — are
+    // prechecked. Skipping restores a late rejection; refusing something the server
+    // would accept is the failure that has no recovery.
     const tooLarge = listingAssetTooLargeReason('That image', width, height);
     if (tooLarge) throw new Error(`${tooLarge}.`);
     // `validateListingImage` is handed only what this side knows FAITHFULLY; it
@@ -369,7 +414,9 @@ export function ListingAssetStep({
     //     name the wrong gate for files above the ceiling. Left server-side whole.
     // `type` is not a claim: `createImageBitmap` has already thrown above for
     // anything that is not a decodable image.
-    const perKind = validateListingImage({ type: 'image', width, height }, kind);
+    const perKind = validateListingImage({ type: 'image', width, height }, kind, {
+      skipOrientationSensitive: await isWebpContainer(file),
+    });
     // No trailing period — the attach proc surfaces `reason` verbatim, and this has
     // to read identically wherever the rejection lands.
     if (!perKind.ok) throw new Error(perKind.reason);

--- a/src/components/Apps/ListingAssetStep.tsx
+++ b/src/components/Apps/ListingAssetStep.tsx
@@ -1,4 +1,15 @@
-import { Alert, Badge, Button, Card, FileInput, Group, Image, Loader, Stack, Text } from '@mantine/core';
+import {
+  Alert,
+  Badge,
+  Button,
+  Card,
+  FileInput,
+  Group,
+  Image,
+  Loader,
+  Stack,
+  Text,
+} from '@mantine/core';
 import {
   IconAlertTriangle,
   IconCheck,
@@ -27,7 +38,11 @@ import {
   type ScreenshotSlot,
 } from '~/components/Apps/screenshotSlots';
 import type { EditAsset, EditScreenshot } from '~/components/Apps/offsiteEditConfig';
-import { listingAssetTooLargeReason } from '~/server/schema/blocks/app-listing.schema';
+import {
+  listingAssetTooLargeReason,
+  validateListingImage,
+  type ListingAssetKind,
+} from '~/server/schema/blocks/app-listing.schema';
 import type { OffsiteContentRating } from '~/server/schema/blocks/offsite-listing.schema';
 import { showErrorNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
@@ -60,7 +75,13 @@ export type MetaSuggestions = {
   iconDataUri?: string;
 };
 
-type AssetKind = 'icon' | 'cover' | 'screenshot';
+/**
+ * ALIASED to the server's kind union rather than respelled, because this value is
+ * now handed to the server's own per-kind validator (`uploadAndPersist`): if the
+ * two ever diverge the compiler says so here, instead of a kind silently missing
+ * its bounds at the picker.
+ */
+type AssetKind = ListingAssetKind;
 
 /** Per-asset attach lifecycle (see the create wizard's doc for the full state map). */
 export type AssetStatus = 'idle' | 'working' | 'scanning' | 'attached' | 'timeout' | 'error';
@@ -101,9 +122,19 @@ function mergePreview(prev: AssetState, next: AssetState): AssetState {
   return { ...next, previewUrl: prev.previewUrl };
 }
 
-/** Read the intrinsic pixel dimensions of an image File (the attach proc rejects zero/unknown). */
+/**
+ * Read the DISPLAYED pixel dimensions of an image File (the attach proc rejects
+ * zero/unknown).
+ *
+ * `imageOrientation: 'from-image'` is the spec default, and is passed EXPLICITLY
+ * because the prechecks in `uploadAndPersist` depend on it: the server measures
+ * the displayed pair too (`probeStoredImage` transposes width/height for the EXIF
+ * quarter-turns, orientations 5–8), and only if this side does the same do the two
+ * agree on the individual axes rather than merely on `Math.max`. Spelling it out
+ * keeps that agreement from resting on a default a browser could differ on.
+ */
 async function readImageDimensions(file: File): Promise<{ width: number; height: number }> {
-  const bitmap = await createImageBitmap(file);
+  const bitmap = await createImageBitmap(file, { imageOrientation: 'from-image' });
   try {
     return { width: bitmap.width, height: bitmap.height };
   } finally {
@@ -156,7 +187,12 @@ export function ListingAssetStep({
   const [screenshots, setScreenshots] = useState<ScreenshotSlot[]>(() =>
     (initial?.screenshots ?? [])
       .filter((s) => s.imageId != null)
-      .map((s) => ({ id: `pre_${s.id}`, status: 'attached' as const, imageId: s.imageId, message: null }))
+      .map((s) => ({
+        id: `pre_${s.id}`,
+        status: 'attached' as const,
+        imageId: s.imageId,
+        message: null,
+      }))
   );
   const screenshotIdRef = useRef(0);
   // Slot id → { rowId (AppListingScreenshot.id, for removal), previewUrl }. Kept
@@ -291,28 +327,52 @@ export function ListingAssetStep({
     scanTimersRef.current.set(key, timer);
   }
 
-  async function uploadAndPersist(file: File): Promise<number> {
+  async function uploadAndPersist(file: File, kind: AssetKind): Promise<number> {
     const { width, height } = await readImageDimensions(file);
     // Fail fast, BEFORE a byte leaves the browser. The dimensions are already in
-    // hand here and the server applies this same predicate to `persistAssetImage`
-    // — but only after the upload to the object store has completed, so without
-    // this mirror the author waits out a full upload to be told something that was
-    // knowable from the file picker.
+    // hand here, but every rule expressed over them lives further down the wire, so
+    // without this mirror the author waits out a full upload to be told something
+    // that was knowable from the file picker.
     //
-    // 🔴 This is a UX mirror, NOT the enforcement point. The server re-derives the
-    // pair from the STORED BYTES (`measureListingAssetUpload`) and re-applies the
-    // bound there; anything decided here is a client claim. Deleting this check
-    // costs a wasted upload, never a bypass.
+    // TWO checks, applied in the order the SERVER reaches them, so the author is
+    // shown the message that would actually have landed:
+    //   1. the kind-AGNOSTIC per-side ceiling, which `persistAssetImage` applies to
+    //      the measured bytes as soon as the upload completes ("That image …");
+    //   2. the per-KIND geometry rules (aspect + minimum sides + the icon's own,
+    //      tighter, maximum), which the attach procs apply one step later via
+    //      `validateListingImage` ("icon must be …").
+    // An image failing (1) never reaches (2) — here or on the server — so the
+    // ordering is what keeps the two messages from swapping places.
     //
-    // The predicate is IMPORTED, never restated: a vendored copy of the bound is
+    // 🔴 A UX MIRROR, NOT THE ENFORCEMENT POINT. The server re-derives the pair from
+    // the STORED BYTES (`measureListingAssetUpload`) and re-applies both; anything
+    // decided here is a client claim. Deleting either check costs a wasted upload,
+    // never a bypass, and nothing downstream may become conditional on it running.
+    //
+    // Both predicates are IMPORTED, never restated: a vendored copy of a bound is
     // exactly what goes stale and starts refusing valid input (civitai/cli#270).
-    // It is also safe to evaluate on the browser's reading of the file even though
-    // the server reads EXIF orientation and the browser does not — the bound is
-    // over `Math.max(width, height)`, which a quarter-turn cannot change, so the
-    // two readings cannot disagree about this verdict. The subject string matches
-    // the server's so the author sees ONE message wherever the rejection lands.
+    //
+    // Evaluating them on the BROWSER's reading is sound because both sides read the
+    // DISPLAYED pixel pair — see `readImageDimensions`. They agree on BOTH AXES, not
+    // merely on `Math.max`, and that is precisely what licenses prechecking the
+    // orientation-SENSITIVE aspect bounds here at all.
     const tooLarge = listingAssetTooLargeReason('That image', width, height);
     if (tooLarge) throw new Error(`${tooLarge}.`);
+    // `validateListingImage` is handed only what this side knows FAITHFULLY; it
+    // skips `sizeBytes` / `mimeType` when absent, and both are omitted on purpose:
+    //   • `mimeType` — `file.type` comes from the file NAME, while the server reads
+    //     the DECODED container format. A mislabelled extension (or an empty
+    //     `file.type`) would refuse an image the server accepts, and refusing valid
+    //     input at the picker is worse than the wasted upload this is fixing.
+    //   • `sizeBytes` — the byte caps are split across two server gates (a 4 MiB
+    //     ceiling at persist, the per-kind cap at attach), so one verdict here would
+    //     name the wrong gate for files above the ceiling. Left server-side whole.
+    // `type` is not a claim: `createImageBitmap` has already thrown above for
+    // anything that is not a decodable image.
+    const perKind = validateListingImage({ type: 'image', width, height }, kind);
+    // No trailing period — the attach proc surfaces `reason` verbatim, and this has
+    // to read identically wherever the rejection lands.
+    if (!perKind.ok) throw new Error(perKind.reason);
     const result = await uploadToCF(file);
     const { imageId } = await persistMutation.mutateAsync({
       url: result.id,
@@ -378,7 +438,10 @@ export function ListingAssetStep({
       // Promote a captured row id into screenshotMeta so the Remove button appears.
       const rowId = rowIdRef.current.get(key);
       if (rowId) {
-        setScreenshotMeta((prev) => ({ ...prev, [key]: { rowId, previewUrl: prev[key]?.previewUrl ?? null } }));
+        setScreenshotMeta((prev) => ({
+          ...prev,
+          [key]: { rowId, previewUrl: prev[key]?.previewUrl ?? null },
+        }));
       }
       onAssetMutated?.();
       // Kick off the scan-status poll only while the scan is still in-flight. Updates
@@ -432,7 +495,7 @@ export function ListingAssetStep({
       apply({ status: 'working', imageId: null, message: null, previewUrl });
     }
     try {
-      const imageId = await uploadAndPersist(file);
+      const imageId = await uploadAndPersist(file, kind);
       if (!isCurrentEpoch(key, epoch)) return;
       await drive(key, kind, imageId, 0, epoch, apply);
     } catch (err) {
@@ -740,7 +803,9 @@ export function ListingAssetStep({
                             // A scanning-but-committed row (has a server row) must be
                             // removed on the server; a not-yet-committed (working) row is
                             // a local-only cancel.
-                            onClick={() => (hasRow ? void removeScreenshot(s.id) : cancelScreenshot(s.id))}
+                            onClick={() =>
+                              hasRow ? void removeScreenshot(s.id) : cancelScreenshot(s.id)
+                            }
                             data-testid={`apps-offsite-screenshot-cancel-${i}`}
                           >
                             Cancel

--- a/src/server/schema/blocks/app-listing.schema.ts
+++ b/src/server/schema/blocks/app-listing.schema.ts
@@ -146,6 +146,40 @@ export type ListingImageMeta = {
 
 export type ValidateListingImageResult = { ok: true } | { ok: false; reason: string };
 
+export type ValidateListingImageOptions = {
+  /**
+   * Skip the bounds whose verdict is NOT invariant under transposing width and
+   * height, keeping the ones that are. Defaults to `false`; the SERVER never
+   * passes it, so enforcement is unchanged.
+   *
+   * 🔴 This exists for exactly one caller — a CLIENT-side precheck that has only
+   * the browser's reading of the file — and it is a narrowing, never a widening:
+   * every bound it skips is still applied by the server to the stored bytes, so
+   * setting it can only move a rejection later, never let one through.
+   *
+   * Which bounds are which, and why the split falls where it does. Transposition
+   * maps an aspect `a` to `1/a`, so a bound stated over `width / height` — or
+   * over one NAMED axis — can flip its verdict, while one stated over
+   * `Math.min` / `Math.max` of the pair cannot:
+   *
+   *   SENSITIVE (skipped)    icon/cover/screenshot aspect bands; the cover's
+   *                          minimum WIDTH, which names an axis rather than the
+   *                          shorter side.
+   *   INVARIANT (kept)       the kind-agnostic per-side ceiling (`Math.max`),
+   *                          the icon's minimum and maximum side (`Math.min` /
+   *                          `Math.max`), the screenshot's minimum shorter side
+   *                          (`Math.min`), and everything above the geometry
+   *                          block — type, MIME, byte cap, non-positive dims.
+   *
+   * The caller needing this is `ListingAssetStep`: `createImageBitmap` in
+   * Chromium does not apply EXIF orientation to WEBP, while the server's
+   * `probeStoredImage` transposes for orientations 5–8, so for that one
+   * container the two sides disagree about which axis is which and only the
+   * invariant bounds can be honestly prechecked.
+   */
+  skipOrientationSensitive?: boolean;
+};
+
 const KIND_SIZE_CAP: Record<ListingAssetKind, number> = {
   icon: MAX_LISTING_ICON_SIZE_BYTES,
   cover: MAX_LISTING_COVER_SIZE_BYTES,
@@ -159,10 +193,15 @@ const KIND_SIZE_CAP: Record<ListingAssetKind, number> = {
  * result (the caller maps `!ok` → a 400) rather than throwing so it's trivially
  * unit-testable. Size/MIME checks are SKIPPED only when the field is absent
  * (an older Image row may not carry `metadata.size` / `mimeType`) — never faked.
+ *
+ * `opts.skipOrientationSensitive` narrows this to the transposition-invariant
+ * subset for a caller that cannot trust which axis is which; see
+ * {@link ValidateListingImageOptions}. The server passes no options.
  */
 export function validateListingImage(
   meta: ListingImageMeta,
-  kind: ListingAssetKind
+  kind: ListingAssetKind,
+  opts?: ValidateListingImageOptions
 ): ValidateListingImageResult {
   if (meta.type !== 'image') {
     return { ok: false, reason: `asset must be an image (got type "${meta.type}")` };
@@ -189,10 +228,13 @@ export function validateListingImage(
   const tooLarge = listingAssetTooLargeReason(kind, width, height);
   if (tooLarge) return { ok: false, reason: tooLarge };
   const aspect = width / height;
+  // See ValidateListingImageOptions: `true` drops exactly the bounds a
+  // width/height transposition can flip, and nothing else.
+  const axisAware = opts?.skipOrientationSensitive !== true;
   if (kind === 'icon') {
     const minSide = Math.min(width, height);
     const maxSide = Math.max(width, height);
-    if (aspect < LISTING_ICON_ASPECT_MIN || aspect > LISTING_ICON_ASPECT_MAX) {
+    if (axisAware && (aspect < LISTING_ICON_ASPECT_MIN || aspect > LISTING_ICON_ASPECT_MAX)) {
       return { ok: false, reason: `icon must be square-ish (aspect ${aspect.toFixed(2)} outside ${LISTING_ICON_ASPECT_MIN}–${LISTING_ICON_ASPECT_MAX})` };
     }
     if (minSide < LISTING_ICON_MIN_PX) {
@@ -202,14 +244,20 @@ export function validateListingImage(
       return { ok: false, reason: `icon must be at most ${LISTING_ICON_MAX_PX}px on its longer side (got ${maxSide}px)` };
     }
   } else if (kind === 'cover') {
-    if (aspect < LISTING_COVER_ASPECT_MIN || aspect > LISTING_COVER_ASPECT_MAX) {
+    if (axisAware && (aspect < LISTING_COVER_ASPECT_MIN || aspect > LISTING_COVER_ASPECT_MAX)) {
       return { ok: false, reason: `cover must be landscape (aspect ${aspect.toFixed(2)} outside ${LISTING_COVER_ASPECT_MIN}–${LISTING_COVER_ASPECT_MAX})` };
     }
-    if (width < LISTING_COVER_MIN_WIDTH_PX) {
+    // Stated over the WIDTH specifically, not the shorter side, so a transposed
+    // reading can flip it either way — orientation-sensitive despite not being an
+    // aspect band.
+    if (axisAware && width < LISTING_COVER_MIN_WIDTH_PX) {
       return { ok: false, reason: `cover must be at least ${LISTING_COVER_MIN_WIDTH_PX}px wide (got ${width}px)` };
     }
   } else {
-    if (aspect < LISTING_SCREENSHOT_ASPECT_MIN || aspect > LISTING_SCREENSHOT_ASPECT_MAX) {
+    if (
+      axisAware &&
+      (aspect < LISTING_SCREENSHOT_ASPECT_MIN || aspect > LISTING_SCREENSHOT_ASPECT_MAX)
+    ) {
       return { ok: false, reason: `screenshot aspect ${aspect.toFixed(2)} is outside ${LISTING_SCREENSHOT_ASPECT_MIN}–${LISTING_SCREENSHOT_ASPECT_MAX}` };
     }
     if (Math.min(width, height) < LISTING_SCREENSHOT_MIN_PX) {

--- a/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
@@ -1573,6 +1573,33 @@ describe('persistListingAssetImage (measures the uploaded bytes)', () => {
     expect(validateListingImage(persistedRow(), 'cover')).toEqual({ ok: true });
   });
 
+  it('reports a quarter-turned WEBP the way a renderer shows it', async () => {
+    // 🔴 The container the whole client-side skip exists for, EXECUTED rather than
+    // restated. The JPEG case above and this one differ in exactly one variable —
+    // `.jpeg()` vs `.webp()` — so this pins that the server transposes for WebP too.
+    //
+    // That is the half of the disagreement this side owns: Chromium does NOT apply
+    // EXIF orientation to WebP (asserted against the browser in
+    // `src/components/Apps/ListingAssetStep.browser.test.tsx`), while the server
+    // does — which is precisely why the axis-naming bounds cannot be prechecked for
+    // this container. If sharp ever stopped honouring orientation on WebP, the two
+    // sides would agree again and the skip would become unnecessary; this test is
+    // what would notice.
+    storeObject(
+      await sharp({
+        create: { width: 450, height: 800, channels: 3, background: { r: 8, g: 8, b: 8 } },
+      })
+        .withMetadata({ orientation: 6 })
+        .webp()
+        .toBuffer()
+    );
+
+    await persistListingAssetImage({ input: HONEST_COVER, userId: CALLER });
+
+    expect(persistedRow()).toMatchObject({ width: 800, height: 450, mimeType: 'image/webp' });
+    expect(validateListingImage(persistedRow(), 'cover')).toEqual({ ok: true });
+  });
+
   it('leaves an upright JPEG alone — the transpose is conditional, not per-format', async () => {
     storeObject(
       await sharp({

--- a/src/server/utils/__tests__/listing-asset-exif-fixture.test.ts
+++ b/src/server/utils/__tests__/listing-asset-exif-fixture.test.ts
@@ -18,11 +18,21 @@ import {
  * it reproduced the bug, and nothing would have shown that the server ever saw an
  * orientation at all. That is the failure this file exists to make impossible.
  *
- * What is asserted is the two INPUTS `probeStoredImage` consumes —
- * `sharp().metadata()`'s stored dimensions and its `orientation` — plus the rule
- * that function states over them (orientations 5–8 are quarter turns, so the
- * displayed pair is the stored one transposed). Runs in the `unit` project, which
- * keeps the real `sharp`.
+ * Scope is deliberately ONE claim: that these fixtures' BYTES carry a readable
+ * EXIF orientation, i.e. the two INPUTS `probeStoredImage` consumes —
+ * `sharp().metadata()`'s stored dimensions and its `orientation`.
+ *
+ * 🔴 It stops there on purpose. An earlier revision also asserted what the server
+ * MAKES of those inputs, using a local helper that re-stated `probeStoredImage`'s
+ * orientation-5–8 transposition — a vendored copy of a rule, which is the exact
+ * anti-pattern this PR exists to remove (civitai/cli#270): it agrees with itself
+ * whatever the real function does, so it could not detect the two diverging. The
+ * rule is now EXECUTED instead, by `persistListingAssetImage` running end to end
+ * against the real `probeStoredImage` in
+ * `src/server/services/blocks/__tests__/offsite-listing.service.test.ts`
+ * ("reports a quarter-turned JPEG/WEBP the way a renderer shows it").
+ *
+ * Runs in the `unit` project, which keeps the real `sharp`.
  */
 
 /** A solid raster of a known STORED size, in the container under test. */
@@ -30,14 +40,6 @@ async function raster(format: 'webp' | 'jpeg', width: number, height: number) {
   const img = sharp({ create: { width, height, channels: 3, background: '#4488cc' } });
   const buf = format === 'webp' ? await img.webp().toBuffer() : await img.jpeg().toBuffer();
   return new Uint8Array(buf);
-}
-
-/** Exactly the transposition rule `probeStoredImage` applies. */
-function displayed(m: { width?: number; height?: number; orientation?: number }) {
-  const quarterTurned = m.orientation != null && m.orientation >= 5 && m.orientation <= 8;
-  return quarterTurned
-    ? { width: m.height, height: m.width }
-    : { width: m.width, height: m.height };
 }
 
 describe('EXIF fixture builders are faithful to the server-side reader', () => {
@@ -54,10 +56,10 @@ describe('EXIF fixture builders are faithful to the server-side reader', () => {
     // leave this undefined, and the browser-side WebP test would then be asserting
     // nothing about a disagreement.
     expect(meta.orientation).toBe(6);
-    // …so the server measures a LANDSCAPE 1280×640 (cover aspect 2.00) from bytes
-    // Chromium reports as a portrait 640×1280 (aspect 0.50). That inversion is the
-    // entire regression the client-side sniff exists to avoid.
-    expect(displayed(meta)).toEqual({ width: 1280, height: 640 });
+    // …which is what makes the server measure a LANDSCAPE 1280×640 (cover aspect
+    // 2.00) from bytes Chromium reports as a portrait 640×1280 (aspect 0.50). That
+    // inversion is the entire regression the client-side sniff exists to avoid, and
+    // the consequence is asserted where the real transposition RUNS — see the header.
   });
 
   test('jpegWithExifOrientation produces a JPEG sharp reads as quarter-turned', async () => {
@@ -68,10 +70,9 @@ describe('EXIF fixture builders are faithful to the server-side reader', () => {
     expect(meta.format).toBe('jpeg');
     expect({ width: meta.width, height: meta.height }).toEqual({ width: 640, height: 1280 });
     expect(meta.orientation).toBe(6);
-    // Same server-side reading as the WebP above — which is what makes the JPEG the
-    // CONTROL: the browser agrees here and disagrees there, so the two fixtures
-    // differ in exactly one variable, the container.
-    expect(displayed(meta)).toEqual({ width: 1280, height: 640 });
+    // Same stored pair and same orientation as the WebP above — which is what makes
+    // the JPEG the CONTROL: the browser agrees here and disagrees there, so the two
+    // fixtures differ in exactly one variable, the container.
   });
 
   test('an untouched raster carries no orientation (the builders are what add it)', async () => {
@@ -81,7 +82,7 @@ describe('EXIF fixture builders are faithful to the server-side reader', () => {
     for (const format of ['webp', 'jpeg'] as const) {
       const meta = await sharp(Buffer.from(await raster(format, 640, 1280))).metadata();
       expect(meta.orientation).toBeUndefined();
-      expect(displayed(meta)).toEqual({ width: 640, height: 1280 });
+      expect({ width: meta.width, height: meta.height }).toEqual({ width: 640, height: 1280 });
     }
   });
 });

--- a/src/server/utils/__tests__/listing-asset-exif-fixture.test.ts
+++ b/src/server/utils/__tests__/listing-asset-exif-fixture.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from 'vitest';
+import sharp from 'sharp';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import {
+  jpegWithExifOrientation,
+  webpWithExifOrientation,
+} from '../../../../test/fixtures/exif-image';
+
+/**
+ * The listing-asset browser suite proves its EXIF claims against CHROMIUM. This
+ * proves the other half — that those same fixtures are what the SERVER thinks
+ * they are — because the whole point of the WebP case is that the two readers
+ * DISAGREE, and a disagreement is only evidence if both sides were measured.
+ *
+ * Without this, a hand-built container that simply carried no readable EXIF would
+ * make the browser assertion pass for the wrong reason: the browser would report
+ * the stored pair (as it does for a real EXIF WebP), the fixture would look like
+ * it reproduced the bug, and nothing would have shown that the server ever saw an
+ * orientation at all. That is the failure this file exists to make impossible.
+ *
+ * What is asserted is the two INPUTS `probeStoredImage` consumes —
+ * `sharp().metadata()`'s stored dimensions and its `orientation` — plus the rule
+ * that function states over them (orientations 5–8 are quarter turns, so the
+ * displayed pair is the stored one transposed). Runs in the `unit` project, which
+ * keeps the real `sharp`.
+ */
+
+/** A solid raster of a known STORED size, in the container under test. */
+async function raster(format: 'webp' | 'jpeg', width: number, height: number) {
+  const img = sharp({ create: { width, height, channels: 3, background: '#4488cc' } });
+  const buf = format === 'webp' ? await img.webp().toBuffer() : await img.jpeg().toBuffer();
+  return new Uint8Array(buf);
+}
+
+/** Exactly the transposition rule `probeStoredImage` applies. */
+function displayed(m: { width?: number; height?: number; orientation?: number }) {
+  const quarterTurned = m.orientation != null && m.orientation >= 5 && m.orientation <= 8;
+  return quarterTurned
+    ? { width: m.height, height: m.width }
+    : { width: m.width, height: m.height };
+}
+
+describe('EXIF fixture builders are faithful to the server-side reader', () => {
+  test('webpWithExifOrientation produces a WebP sharp reads as quarter-turned', async () => {
+    const bytes = webpWithExifOrientation(await raster('webp', 640, 1280), 640, 1280, 6);
+
+    const meta = await sharp(Buffer.from(bytes)).metadata();
+
+    expect(meta.format).toBe('webp');
+    // The raster is unchanged — only the container gained an EXIF chunk.
+    expect({ width: meta.width, height: meta.height }).toEqual({ width: 640, height: 1280 });
+    // 🔴 The load-bearing assertion: the orientation actually survives the byte
+    // surgery and is READ. A builder that produced a malformed EXIF chunk would
+    // leave this undefined, and the browser-side WebP test would then be asserting
+    // nothing about a disagreement.
+    expect(meta.orientation).toBe(6);
+    // …so the server measures a LANDSCAPE 1280×640 (cover aspect 2.00) from bytes
+    // Chromium reports as a portrait 640×1280 (aspect 0.50). That inversion is the
+    // entire regression the client-side sniff exists to avoid.
+    expect(displayed(meta)).toEqual({ width: 1280, height: 640 });
+  });
+
+  test('jpegWithExifOrientation produces a JPEG sharp reads as quarter-turned', async () => {
+    const bytes = jpegWithExifOrientation(await raster('jpeg', 640, 1280), 6);
+
+    const meta = await sharp(Buffer.from(bytes)).metadata();
+
+    expect(meta.format).toBe('jpeg');
+    expect({ width: meta.width, height: meta.height }).toEqual({ width: 640, height: 1280 });
+    expect(meta.orientation).toBe(6);
+    // Same server-side reading as the WebP above — which is what makes the JPEG the
+    // CONTROL: the browser agrees here and disagrees there, so the two fixtures
+    // differ in exactly one variable, the container.
+    expect(displayed(meta)).toEqual({ width: 1280, height: 640 });
+  });
+
+  test('an untouched raster carries no orientation (the builders are what add it)', async () => {
+    // The negative control for both assertions above: if `orientation` were somehow
+    // truthy on a plain encode, `toBe(6)` would be evidence about sharp's defaults
+    // rather than about the builder.
+    for (const format of ['webp', 'jpeg'] as const) {
+      const meta = await sharp(Buffer.from(await raster(format, 640, 1280))).metadata();
+      expect(meta.orientation).toBeUndefined();
+      expect(displayed(meta)).toEqual({ width: 640, height: 1280 });
+    }
+  });
+});

--- a/test/fixtures/exif-image.ts
+++ b/test/fixtures/exif-image.ts
@@ -1,0 +1,154 @@
+/**
+ * Build image containers that actually CARRY an EXIF orientation tag.
+ *
+ * Why this exists: `ListingAssetStep` prechecks the server's per-kind geometry
+ * bounds on the pair `createImageBitmap` reports, and whether that pair matches
+ * the server's depends entirely on EXIF orientation. Every other fixture in the
+ * listing-asset suite is a fresh canvas raster, which carries no EXIF at all — so
+ * a suite built only from those is STRUCTURALLY BLIND to the dimension the
+ * precheck's correctness rests on (mutating the `imageOrientation` option left it
+ * 34/34 green). These builders are what let a test observe that dimension.
+ *
+ * Both are pure byte surgery over an already-encoded image, so the same helper
+ * serves the browser suite (raster from `canvas.toBlob`) and the node suite
+ * (raster from `sharp`) — which is what lets ONE fixture be proven faithful to
+ * BOTH readers: `stored-image-probe-exif-fixture.test.ts` asserts sharp reads
+ * these exact containers the way the server's probe needs, and the browser suite
+ * asserts what Chromium makes of them.
+ */
+
+function u32le(n: number): number[] {
+  return [n & 0xff, (n >>> 8) & 0xff, (n >>> 16) & 0xff, (n >>> 24) & 0xff];
+}
+
+function u24le(n: number): number[] {
+  return [n & 0xff, (n >>> 8) & 0xff, (n >>> 16) & 0xff];
+}
+
+function ascii(s: string): number[] {
+  return Array.from(s, (c) => c.charCodeAt(0));
+}
+
+/**
+ * The smallest legal little-endian TIFF block that says one thing: Orientation.
+ * Header (8 bytes: "II", magic 42, offset-to-IFD0 = 8) + an IFD0 holding exactly
+ * one 12-byte entry (tag 0x0112, type SHORT, count 1, value inline) + a null
+ * next-IFD pointer.
+ */
+function tiffOrientation(orientation: number): Uint8Array {
+  return Uint8Array.from([
+    ...ascii('II'),
+    0x2a,
+    0x00,
+    ...u32le(8),
+    // IFD0: one entry.
+    0x01,
+    0x00,
+    // tag 0x0112 = Orientation, type 3 = SHORT, count 1.
+    0x12,
+    0x01,
+    0x03,
+    0x00,
+    ...u32le(1),
+    // A SHORT occupies the first 2 of the entry's 4 value bytes.
+    orientation & 0xff,
+    0x00,
+    0x00,
+    0x00,
+    // No next IFD.
+    ...u32le(0),
+  ]);
+}
+
+/** One RIFF chunk: FourCC + LE payload length + payload, padded to even. */
+function riffChunk(fourCC: string, payload: Uint8Array): Uint8Array {
+  const out = new Uint8Array(8 + payload.length + (payload.length % 2));
+  out.set(ascii(fourCC), 0);
+  out.set(u32le(payload.length), 4);
+  out.set(payload, 8);
+  return out;
+}
+
+/** The VP8X flags bit that declares "this file carries an EXIF chunk". */
+const VP8X_EXIF_FLAG = 0x08;
+
+/**
+ * Re-wrap an encoded WebP as an EXTENDED WebP carrying an EXIF chunk: a leading
+ * `VP8X` chunk whose flags byte has bit 0x08 set, the original image data, and
+ * the `EXIF` chunk last.
+ *
+ * 🔴 The two encoders this suite uses do NOT agree on the input shape, and
+ * getting that wrong produces a file no decoder will touch rather than a wrong
+ * answer. `sharp().webp()` emits the simple form (`VP8 ` alone), so a `VP8X` has
+ * to be synthesised; Chromium's `canvas.toBlob('image/webp')` ALREADY emits an
+ * extended file (`VP8X` + `ICCP` + `VP8 `), and prepending a second `VP8X` to
+ * that made every `createImageBitmap` call fail `InvalidStateError`. So: reuse
+ * an existing `VP8X` and just set its EXIF bit; synthesise one only when there
+ * is none.
+ *
+ * `width`/`height` are the STORED raster's — what the encoder was handed. They
+ * are used only for a synthesised `VP8X`; a reader honouring the orientation
+ * reports them transposed either way.
+ */
+export function webpWithExifOrientation(
+  webp: Uint8Array,
+  width: number,
+  height: number,
+  orientation: number
+): Uint8Array {
+  if (String.fromCharCode(...webp.subarray(0, 4)) !== 'RIFF') throw new Error('not a RIFF file');
+  if (String.fromCharCode(...webp.subarray(8, 12)) !== 'WEBP') throw new Error('not a WebP file');
+  // Everything after the 12-byte RIFF/WEBP preamble is the existing chunk list.
+  const rest = webp.subarray(12);
+  const hasVp8x = String.fromCharCode(...rest.subarray(0, 4)) === 'VP8X';
+  let head: Uint8Array;
+  if (hasVp8x) {
+    head = Uint8Array.from(rest);
+    // Byte 8 is the first byte of the VP8X payload: the flags.
+    head[8] |= VP8X_EXIF_FLAG;
+  } else {
+    const vp8x = riffChunk(
+      'VP8X',
+      Uint8Array.from([VP8X_EXIF_FLAG, 0, 0, 0, ...u24le(width - 1), ...u24le(height - 1)])
+    );
+    head = new Uint8Array(vp8x.length + rest.length);
+    head.set(vp8x, 0);
+    head.set(rest, vp8x.length);
+  }
+  const exif = riffChunk('EXIF', tiffOrientation(orientation));
+  const body = new Uint8Array(head.length + exif.length);
+  body.set(head, 0);
+  body.set(exif, head.length);
+  const out = new Uint8Array(12 + body.length);
+  out.set(ascii('RIFF'), 0);
+  out.set(u32le(4 + body.length), 4);
+  out.set(ascii('WEBP'), 8);
+  out.set(body, 12);
+  return out;
+}
+
+/**
+ * Splice an EXIF `APP1` segment in immediately after the JPEG `SOI`, which is
+ * where every EXIF reader looks for it.
+ */
+export function jpegWithExifOrientation(jpeg: Uint8Array, orientation: number): Uint8Array {
+  if (jpeg[0] !== 0xff || jpeg[1] !== 0xd8) throw new Error('not a JPEG file');
+  const tiff = tiffOrientation(orientation);
+  // Segment length counts its own 2 bytes + the "Exif\0\0" introducer + the TIFF.
+  const len = 2 + 6 + tiff.length;
+  const app1 = Uint8Array.from([
+    0xff,
+    0xe1,
+    (len >>> 8) & 0xff,
+    len & 0xff,
+    ...ascii('Exif'),
+    0,
+    0,
+    ...tiff,
+  ]);
+  const out = new Uint8Array(jpeg.length + app1.length);
+  out.set(jpeg.subarray(0, 2), 0);
+  out.set(app1, 2);
+  out.set(jpeg.subarray(2), 2 + app1.length);
+  return out;
+}

--- a/test/fixtures/exif-image.ts
+++ b/test/fixtures/exif-image.ts
@@ -12,9 +12,9 @@
  * Both are pure byte surgery over an already-encoded image, so the same helper
  * serves the browser suite (raster from `canvas.toBlob`) and the node suite
  * (raster from `sharp`) — which is what lets ONE fixture be proven faithful to
- * BOTH readers: `stored-image-probe-exif-fixture.test.ts` asserts sharp reads
- * these exact containers the way the server's probe needs, and the browser suite
- * asserts what Chromium makes of them.
+ * BOTH readers: `src/server/utils/__tests__/listing-asset-exif-fixture.test.ts`
+ * asserts sharp reads these exact containers the way the server's probe needs, and
+ * the browser suite asserts what Chromium makes of them.
  */
 
 function u32le(n: number): number[] {


### PR DESCRIPTION
#3824 moved the kind-agnostic per-side ceiling to the point the dimensions are first known, before the upload. It only half-closed #3772: every *per-kind* rule still lived at attach, which the client reaches only after the upload **and** the persist.

So these all still cost a full transfer before the rejection:

- the icon's own longer-side maximum — **half** the ceiling #3824 prechecks
- the icon / cover / screenshot aspect bands
- the icon / cover / screenshot minimum dimensions

A wrongly-shaped icon is far easier to produce by accident than an over-ceiling one, so this is plausibly the more common rejection — and late geometry validation is the original complaint behind civitai/cli#270.

## What changed

`startAttach` already holds the kind; `uploadAndPersist` now takes it and applies `validateListingImage` — the server's own predicate, **imported, not restated** — right after the existing ceiling check.

The order mirrors the server's, so the author is shown the message that would actually have landed: the kind-agnostic ceiling is what `persistAssetImage` applies (subject "That image …"), and the per-kind rules are what the attach procs apply one step later (`reason` passed through verbatim, no trailing period). An image failing the first never reaches the second — here or on the server — so the two messages cannot swap places.

**Prechecked:** every geometry bound `validateListingImage` expresses — the per-side ceiling, the per-kind aspect bands, the per-kind minimums, and the icon's own maximum — **except on WebP**, where this side cannot tell which axis is which; see the next section.

**Deliberately left server-only,** because this side cannot evaluate them faithfully:

- **MIME** — `file.type` comes from the file *name*, while the server reads the *decoded* container format. A mislabelled extension, or an empty `file.type`, would refuse an image the server accepts. Refusing valid input at the picker is a worse failure than the wasted upload this is fixing.
- **Byte size** — the caps are split across two server gates (a whole-asset ceiling at persist, the per-kind cap at attach), so one verdict here would name the wrong gate for anything above the ceiling.
- `type` is not a claim: `createImageBitmap` has already thrown for anything that is not a decodable image.

Both exclusions are now **guarded rather than only described**: an asserted ledger of the exact fields handed to `validateListingImage` (which fails if the set grows *or* shrinks), plus one behavioural case each — a cover past the byte cap, and a cover whose `file.type` is an unsupported MIME — that must still reach the object store. Adding either field previously survived the entire suite.

The server remains the enforcement point and re-derives everything from the stored bytes. Nothing became conditional on the client having run — deleting the check costs a wasted upload, never a bypass.

## The orientation premise, measured

#3824 said the precheck was safe "even though the server reads EXIF orientation and the browser does not". That was wrong — but so was this PR's first revision, which claimed the two agree on both axes. **The truth is per-container.** Measured on Chromium 149:

| container | browser applies EXIF orientation | agrees with the server |
| --- | --- | --- |
| JPEG, PNG | yes | yes, on **both axes** |
| **WEBP** | **no** | **no — the axes arrive transposed** |

A transposition maps an aspect `a` to `1/a`, so it *inverts* the verdict of any bound naming an axis. The cover band (1.3–2.4) lies entirely above 1, so **every EXIF-rotated WebP cover the server would happily store was refused at the file picker** — no upload, and therefore no server verdict able to overrule it. Measured end to end on a stored 640×1280 WebP with `Orientation=6`: the server reads 1280×640 (aspect 2.00, accepted), the browser reads 640×1280 (aspect 0.50, refused). WebP is offered by the file inputs' own `accept`, so this was a live path.

The precheck now applies only the bounds a quarter turn cannot change, whenever the file is a WebP:

- **skipped** — the icon / cover / screenshot aspect bands, *and* the cover's minimum **width**, which names an axis rather than the shorter side. That last one is easy to miss: skipping the aspect band alone still refuses a valid rotated cover, one bound further down.
- **kept** — the kind-agnostic per-side ceiling, the icon's minimum and maximum side, the screenshot's minimum shorter side. All are stated over `Math.min` / `Math.max`, which a transposition leaves alone.

The container is detected from the **file's own first 12 bytes** (`RIFF`…`WEBP`), never from `file.type` — gating on a filename-derived MIME would land straight back in the over-strict direction this fixes, and would do it silently. The narrowing itself lives in `validateListingImage`, as an option beside the bounds it governs, so no bound is vendored into the component. The server passes no options and is unchanged; the 182 existing server-side tests across the three suites that exercise the predicate still pass.

Direction matters: skipping a client check restores a *late* rejection, which is merely the cost this PR set out to reduce. Refusing something the server would accept has no recovery at all.

`imageOrientation: 'from-image'` is still passed explicitly to state the intent, but it is **not** what buys the agreement — in this Chromium the option is inert: `'from-image'`, `'none'`, and no options at all return the same pair for both containers.

## Message fidelity — one honest caveat

"The author is shown the message that would actually have landed" holds for **geometry**, not universally. The server reaches byte size and format *before* geometry (`measureListingAssetUpload` → `measureUploadedImage`, then the format→MIME map), and the per-kind byte cap before geometry inside `validateListingImage`. So for a file over 4 MiB, an icon over 1 MiB, or a GIF/SVG, the client now names a *geometry* reason where the server would have named size or format. Both still reject, and the rejection is still correct — only the wording differs.

## Tests

`ListingAssetStep.browser.test.tsx` — **47 pass** (13 new this round), plus **3 new node-project tests**. Every number below was re-measured against both baselines rather than carried over:

| | count |
| --- | --- |
| red at `main` (8da95972bf) | **16** |
| red at this PR's previous revision (442dcb727e) | **5** |
| distinct tests red on at least one baseline | **20** |
| green on both baselines | **27** |

The two red sets overlap in exactly one test, and the split is meaningful rather than bookkeeping: the 16 are regression coverage for the PR's *original* subject (per-kind rules reaching the picker at all), while 4 of the 5 are green at `main` precisely because `main` never had the WebP defect — the PR introduced it, so only the PR's own previous revision is the baseline that can show it.

Of the 13 new tests: 4 red only at the previous revision (the orientation defect), 1 red at both, 4 red only at `main`, and 4 green on both — the last group being mutation guards, each justified by the specific mutant it kills below, and none counted as regression coverage.

The 27 green-on-both are the accept half at each boundary plus those guards. Not regression coverage, and labelled as such in the file. They exist because over-rejection at the picker is the worse failure and only an accept case can catch it — which is not hypothetical: the aspect-band swap mutant is caught **only** by them, and the WebP defect itself was an over-rejection that a suite of refusals could not see.

Also: pre-existing fixtures were resized to be valid listing media (the client now applies the real predicate, so "it decodes" is no longer enough), and a screenshot slot renders only a status badge, so for that kind the rejection reason is asserted on `showErrorNotification` — the channel that actually carries it.

### Fixtures that carry real EXIF

The suite could not previously observe orientation **at all**: every fixture was a fresh canvas raster with no EXIF, so mutating the dimension read from `'from-image'` to `'none'` left it 34/34 green. `test/fixtures/exif-image.ts` builds real EXIF-oriented WebP and JPEG containers by byte surgery, and both readers are pinned:

- the **browser's**, per fixture — the expected client pair is asserted at construction, so an engine that changes its mind fails loudly instead of the suite going green for a new reason;
- the **server's**, in `listing-asset-exif-fixture.test.ts` — `sharp` must read `orientation: 6` off the same bytes, with an untouched raster as the negative control. Without that half, a container carrying no *readable* EXIF would make the browser assertion pass for the wrong reason.

## Mutation results

### This round — 14 mutants, re-run against the final 49-test suite

🔴 **Corrected.** Four rows below were each **one kill low** in the first version of this table: the counts were computed before the `a WEBP whose aspect is genuinely wrong is now left to the SERVER` test landed, despite this heading previously claiming they were all re-run. The corrected numbers, and the like-for-like 47-test figures, are in [this comment](https://github.com/civitai/civitai/pull/3826#issuecomment-5262090590). Counts below are a full re-run against the final suite (49 tests: 47 plus the two guards added in `f54e07c9db`), read off vitest's `Tests` summary line, with the unmutated baseline (`0 failed`) and a known-killed mutant (`1 failed`) as controls.

| mutant | killed by |
| --- | --- |
| WebP sniff deleted | 5 |
| WebP sniff inverted | 16 |
| WebP sniff always true | 11 |
| sniff offsets wrong (`WEBP` sought at byte 4) | 5 |
| **sniff gated on `file.type` instead of the bytes** | exactly **1** — the mislabelled-`.png` case, the only test that can tell the two apart |
| `skipOrientationSensitive` inverted in the schema | 15 |
| skip widened to cover the icon minimum | exactly **1** — the narrowness guard |
| skip widened to cover the icon **maximum** | exactly **1** — the narrowness guard added in `f54e07c9db`. **Survived all 47 tests before it.** Not covered by the ceiling guard: 4096 is *half* the 8192 kind-agnostic ceiling, so a fixture that trips the icon maximum never reaches the ceiling check |
| skip widened to cover the screenshot **minimum** shorter side | exactly **1** — the other narrowness guard added in `f54e07c9db`. **Survived all 47 tests before it.** |
| skip widened to cover the per-side ceiling in `validateListingImage` | **equivalent — survives.** The client reaches the identical ceiling through `listingAssetTooLargeReason` first (which is what the refusal message names), and the server passes no options, so no reachable input distinguishes it |
| `sizeBytes: file.size` added to the call | 2 — the ledger, and the byte-cap behavioural case |
| `mimeType: file.type` added to the call | 2 — the ledger, and the unsupported-MIME behavioural case |
| skip **not** applied to the cover minimum width | **survived the first pass** — a real gap in the new code. A test was added; it now kills it, and nothing else does |
| `'from-image'` → `'none'` | **survives, and cannot be killed on this engine.** Chromium 149 returns the same pair for both values and for no options at all — the option is inert here. Reported rather than papered over: no fixture can make a test observe a difference the browser does not make |

The two rows marked "survived all 47 tests" were the property's real gap: `the skip is NARROW` was pinned at **1 of the 4 bounds the skip keeps**. Both mutants are genuine behaviour changes, not equivalent mutants — a 4097px WebP icon, or a 300px WebP screenshot, would have gone from refused-at-the-picker to uploaded. Each was re-applied and watched to fail its own new test on `showErrorNotification` "Number of calls: 0" — no refusal produced at all. Neither is regression coverage; both pass on unmodified code and are labelled as guards.

Each killing test was checked to fail for *its own* reason — the behavioural ones on "upload expected once, called 0 times" or a missing rejection notification, the ledger on the key set itself — not incidentally.

### Previous round, carried over — **not re-run against the final suite**

Listed for continuity only; treat the counts as claims from that round, not as re-verified here.

| mutant | killed by |
| --- | --- |
| guard deleted | the 11 refusals, and no accept case |
| guard moved after the upload call | the same 11 — they assert the upload never started |
| kind hardcoded to icon / cover / screenshot | 14 / 14 / 11 — every test of the *other* kinds |
| kind rotated to the wrong slot | 19 |
| dimensions transposed (aspect inverted) | 11 |
| reason replaced with house prose | the 11 refusals, on message mismatch |
| icon maximum widened to the kind-agnostic ceiling | exactly 1 — the icon-cap refusal, and nothing else |
| icon aspect band min/max swapped | 7, all icon — the two aspect refusals survive; only the accept cases catch it |

Refs #3772. Follows #3824.

