### PR TITLE
fix(licenses): correct LTX license URLs and LTXV2 license mapping

### DIFF
--- a/packages/civitai-shared/src/basemodel.constants.ts
+++ b/packages/civitai-shared/src/basemodel.constants.ts
@@ -2748,7 +2748,7 @@ export const baseModelRecords: BaseModelRecord[] = [
     description: "Lightricks' next-generation video generation model",
     type: 'video',
     ecosystemId: ECO.LTXV2,
-    licenseId: 16,
+    licenseId: 35,
   },
   {
     id: BM.LTXV23,

--- a/src/server/common/constants.ts
+++ b/src/server/common/constants.ts
@@ -628,7 +628,7 @@ const baseLicenses: Record<string, LicenseDetails> = {
     name: 'Illustrious License',
   },
   'ltxv license': {
-    url: 'https://huggingface.co/Lightricks/LTX-Video/blob/main/License.txt',
+    url: 'https://huggingface.co/Lightricks/LTX-Video/blob/main/LTX-Video-Open-Weights-License-0.X.txt',
     name: 'LTX Video License',
   },
   'cogvideox license': {
@@ -664,8 +664,10 @@ const baseLicenses: Record<string, LicenseDetails> = {
     name: 'Pony',
   },
   ltxv2: {
-    url: 'https://github.com/Lightricks/LTX-2/blob/main/LICENSE',
-    name: 'LTXV2',
+    // Not github.com/Lightricks/LTX-2 — that tracks the latest revision, which since
+    // Aug 2026 is scoped to 2.5+ and does not govern these weights.
+    url: 'https://huggingface.co/Lightricks/LTX-2.3/blob/main/LICENSE',
+    name: 'LTX-2 Community License Agreement',
   },
   anima: {
     url: 'https://huggingface.co/circlestone-labs/Anima/blob/main/LICENSE.md',


### PR DESCRIPTION
Three factual bugs in the LTX license records, bringing them in line with how the
other base-model licenses are already recorded. No behaviour or policy change.

## What was wrong

**Both LTX license URLs 404'd.** Every LTXV **and** LTXV2/2.3 model page linked to
a dead license.

- `ltxv license` → `.../LTX-Video/blob/main/License.txt` — 404. The file is
  `LTX-Video-Open-Weights-License-0.X.txt`, which is what `civitai-shared` already
  had right.
- `ltxv2` → `github.com/Lightricks/LTX-2/blob/main/LICENSE` — 404 (the file is
  `LICENSE.md`).

**`LTXV2` was mapped to the wrong license.** `civitai-shared` had it on
`licenseId: 16` — the 0.9.x LTX Video License — while `baseModelLicenses` served
the 2.x license for the same base model. The two license records disagreed with
each other. 16 → 35, matching `LTXV 2.3`.

**`ltxv2.name` was `'LTXV2'`**, a model name rather than a license name. Now
`'LTX-2 Community License Agreement'`, matching the name `civitai-shared` already
used for the same record.

## One judgement call worth flagging

The 2.x URLs pin to the **LTX-2.3 repo**, not `github.com/Lightricks/LTX-2`.

That path tracks the latest revision, and Lightricks published a new one on
2026-08-11. It is a different agreement: titled LTX-2.**x** Community License
Agreement, and scoped by its own §1.9 to "all LTX-**2.5** versions released since
August 11, 2026, and all future releases of LTX-2.x." HF's metadata for
`Lightricks/LTX-2.5` points its `license_link` at exactly that file.

Our 2.x weights ship under the **January 5, 2026** text, which the LTX-2.3 repo
still serves. Pointing at the tracking URL would have silently relabelled our
models under whichever agreement Lightricks publishes next — including one that is
materially stricter. Hence the pin, and the comment on it.

## Not in this PR

Reviewing the license surfaced two obligations that are not addressed here, one of
which is live today. Both are written up in the thread rather than bundled in — the
ToS one is a binding legal term and wants its own review.

## Testing

`pnpm run typecheck`: 0 errors. (If you see errors in the new collaborative-
collections code, run `pnpm run db:generate` — the local Prisma client goes stale
after #3719; the committed client is correct.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
