### PR TITLE
fix(generation): strip hidden prompts from getGenerationData

### DIFF
--- a/src/server/services/generation/__tests__/generation.service.hidden-prompt.test.ts
+++ b/src/server/services/generation/__tests__/generation.service.hidden-prompt.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `generation.getGenerationData` is a publicProcedure keyed on an image id, so an
+ * image with `hideMeta` set is only protected if the READ refuses. `hasMeta`
+ * (`meta IS NOT NULL AND NOT hideMeta`) decides whether a remix button renders and
+ * nothing more — a caller that skips the listing still gets a payload.
+ *
+ * This pins the refusal on the read: hidden prompt text is absent from the remix
+ * params for everyone except the uploader and moderators, while the rest of the
+ * payload (resources, seed, dimensions) still seeds a remix.
+ */
+
+vi.mock('~/server/redis/client', () => {
+  const make = (): any => new Proxy(() => 'k', { get: () => make() });
+  const keyProxy = make();
+  return {
+    redis: { packed: { get: vi.fn(), set: vi.fn(), mGet: vi.fn() }, get: vi.fn(), set: vi.fn() },
+    sysRedis: { hGet: vi.fn() },
+    REDIS_KEYS: keyProxy,
+    REDIS_SYS_KEYS: keyProxy,
+    REDIS_SUB_KEYS: keyProxy,
+    withSysReadDeadline: vi.fn((p: Promise<unknown>) => p),
+  };
+});
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: vi.fn() }));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/db/db-lag-helpers', () => ({
+  getDbWithoutLag: vi.fn(),
+  getDbWithoutLagBatch: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/ecosystems/wan.handler', () => ({
+  wanBaseModelGroupIdMap: {},
+}));
+vi.mock('~/server/search-index', () => ({ modelsSearchIndex: {} }));
+vi.mock('~/server/services/common.service', () => ({ hasEntityAccess: vi.fn() }));
+vi.mock('~/server/services/model-file.service', () => ({ getFilesForModelVersionCache: vi.fn() }));
+vi.mock('~/server/redis/resource-data.redis', () => ({ resourceDataCache: {} }));
+vi.mock('~/server/services/model.service', () => ({ getFeaturedModels: vi.fn() }));
+vi.mock('~/server/services/model-version.service', () => ({
+  getLinkedVaeIds: vi.fn(),
+  bustMvCache: vi.fn(),
+}));
+vi.mock('~/server/services/image.service', () => ({ imagesForModelVersionsCache: {} }));
+vi.mock('~/server/services/generation/version-generation-state.service', () => ({
+  getVisibleSystemWildcardSetIdsByVersionId: vi.fn(),
+}));
+vi.mock('~/server/utils/otel-helpers', () => ({
+  withSpan: (_name: string, fn: () => unknown) => fn(),
+}));
+
+const findUnique = vi.fn();
+vi.mock('~/server/db/client', () => ({
+  dbRead: {
+    image: { findUnique: (...args: unknown[]) => findUnique(...args) },
+    // No stored resource rows: `getResourceData([])` short-circuits, so the whole
+    // resource-enrichment path stays out of this test.
+    imageResourceNew: { findMany: vi.fn().mockResolvedValue([]) },
+  },
+  dbWrite: {},
+}));
+
+import { getGenerationData } from '~/server/services/generation/generation.service';
+import type { SessionUser } from '~/types/session';
+
+const OWNER_ID = 555;
+
+const PROMPT = 'a very secret prompt';
+const NEGATIVE_PROMPT = 'a very secret negative prompt';
+
+const baseMeta = {
+  prompt: PROMPT,
+  negativePrompt: NEGATIVE_PROMPT,
+  steps: 30,
+  cfgScale: 7,
+  seed: 12345,
+  sampler: 'Euler a',
+};
+
+function mockImage(meta: Record<string, unknown>, hideMeta: boolean) {
+  findUnique.mockResolvedValue({
+    id: 1,
+    type: 'image',
+    url: 'some-url',
+    meta,
+    hideMeta,
+    userId: OWNER_ID,
+    height: 1024,
+    width: 1024,
+    createdAt: new Date('2026-01-01'),
+  });
+}
+
+const getParams = async (user?: { id: number; isModerator: boolean }) => {
+  const data = await getGenerationData({
+    query: { type: 'image', id: 1, generation: false },
+    user: user as SessionUser | undefined,
+  });
+  return data.params;
+};
+
+const owner = { id: OWNER_ID, isModerator: false };
+const moderator = { id: 999, isModerator: true };
+const otherUser = { id: 999, isModerator: false };
+
+describe('getGenerationData - hidden prompt', () => {
+  beforeEach(() => {
+    findUnique.mockReset();
+  });
+
+  it('strips prompt and negativePrompt for an anonymous caller when hideMeta is set', async () => {
+    mockImage(baseMeta, true);
+
+    const params = await getParams();
+
+    expect(params.prompt).toBeUndefined();
+    expect(params.negativePrompt).toBeUndefined();
+    expect(JSON.stringify(params)).not.toContain(PROMPT);
+    expect(JSON.stringify(params)).not.toContain(NEGATIVE_PROMPT);
+  });
+
+  it('strips prompt and negativePrompt for a signed-in non-owner when hideMeta is set', async () => {
+    mockImage(baseMeta, true);
+
+    const params = await getParams(otherUser);
+
+    expect(params.prompt).toBeUndefined();
+    expect(params.negativePrompt).toBeUndefined();
+  });
+
+  it('keeps the non-prompt params so the remix is still seeded', async () => {
+    mockImage(baseMeta, true);
+
+    const params = await getParams();
+
+    expect(params.steps).toBe(30);
+    expect(params.cfgScale).toBe(7);
+    expect(params.seed).toBe(12345);
+    expect(params.sampler).toBe('Euler a');
+  });
+
+  it('drops the raw comfy blob, which carries the prompt in its nodes', async () => {
+    mockImage({ ...baseMeta, comfy: `{"prompt": {"6": {"inputs": {"text": "${PROMPT}"}}}}` }, true);
+
+    const params = await getParams();
+
+    expect(params.comfy).toBeUndefined();
+    expect(JSON.stringify(params)).not.toContain(PROMPT);
+  });
+
+  it('drops unknown string fields whose key mentions prompt, but keeps non-string settings', async () => {
+    mockImage(
+      { ...baseMeta, positivePrompt: PROMPT, enablePromptEnhancer: true, promptStrength: 0.8 },
+      true
+    );
+
+    const params = await getParams();
+
+    expect(params.positivePrompt).toBeUndefined();
+    expect(params.enablePromptEnhancer).toBe(true);
+    expect(params.promptStrength).toBe(0.8);
+  });
+
+  it('returns the prompt to the uploader', async () => {
+    mockImage(baseMeta, true);
+
+    const params = await getParams(owner);
+
+    expect(params.prompt).toBe(PROMPT);
+    expect(params.negativePrompt).toBe(NEGATIVE_PROMPT);
+  });
+
+  it('returns the prompt to a moderator', async () => {
+    mockImage(baseMeta, true);
+
+    const params = await getParams(moderator);
+
+    expect(params.prompt).toBe(PROMPT);
+    expect(params.negativePrompt).toBe(NEGATIVE_PROMPT);
+  });
+
+  it('returns the prompt to anyone when hideMeta is not set', async () => {
+    mockImage(baseMeta, false);
+
+    const params = await getParams();
+
+    expect(params.prompt).toBe(PROMPT);
+    expect(params.negativePrompt).toBe(NEGATIVE_PROMPT);
+  });
+});

--- a/src/server/services/generation/generation.service.ts
+++ b/src/server/services/generation/generation.service.ts
@@ -394,6 +394,25 @@ function resolveGraphParamsFromImageMeta({
   return { resources, params };
 }
 
+/**
+ * Removes prompt text from image meta for `hideMeta` images. `hasMeta` only decides
+ * whether a remix button renders; it does not gate this read, which is reachable by
+ * image id from a public procedure — so the refusal has to happen here.
+ *
+ * Beyond the named fields: `comfy` carries the prompt verbatim in its text-encoder
+ * nodes, and meta is a passthrough object, so foreign tools can land prompt text
+ * under keys this file doesn't know. Non-string values under prompt-ish keys
+ * (`enablePromptEnhancer`, `promptStrength`) are settings, not prompt text.
+ */
+function stripHiddenPrompt(meta: ImageMetaProps): ImageMetaProps {
+  const { prompt: _prompt, negativePrompt: _negativePrompt, comfy: _comfy, ...rest } = meta;
+  for (const [key, value] of Object.entries(rest)) {
+    if (typeof value === 'string' && key.toLowerCase().includes('prompt'))
+      delete (rest as Record<string, unknown>)[key];
+  }
+  return rest as ImageMetaProps;
+}
+
 async function getMediaGenerationData({
   id,
   user,
@@ -414,6 +433,8 @@ async function getMediaGenerationData({
       type: true,
       url: true,
       meta: true,
+      hideMeta: true,
+      userId: true,
       height: true,
       width: true,
       createdAt: true,
@@ -431,7 +452,10 @@ async function getMediaGenerationData({
     createdAt: media.createdAt,
   };
 
-  const initialMeta = (media.meta ?? {}) as ImageMetaProps;
+  const storedMeta = (media.meta ?? {}) as ImageMetaProps;
+  const canSeeHiddenPrompt = !!user && (user.isModerator || user.id === media.userId);
+  const initialMeta =
+    media.hideMeta && !canSeeHiddenPrompt ? stripHiddenPrompt(storedMeta) : storedMeta;
   const imageResources = getMetaResources(initialMeta);
 
   await dbRead.imageResourceNew


### PR DESCRIPTION
`getGenerationData` is a public procedure keyed on an image id, and it returned the stored meta verbatim, so prompt text on `hideMeta` images was readable by anyone who knew the id. The read now strips prompt-bearing fields (`prompt`, `negativePrompt`, `comfy`, and any string field with a prompt-ish key) unless the caller is the uploader or a moderator, leaving the rest of the remix payload intact.