### PR TITLE
feat(app-blocks): extend App Listing Collaborators to OFF-SITE listings (re-key seats to app_listings)

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260811160000_rekey_app_collaborators_step_a_drop_block_keyed/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260811160000_rekey_app_collaborators_step_a_drop_block_keyed/migration.sql
@@ -1,0 +1,125 @@
+-- ============================================================
+-- App Listing COLLABORATORS — RE-KEY, **STEP A of 2**: DROP the block-keyed tables.
+-- ============================================================
+-- 🔴 RUN THIS **BEFORE** THE CODE DEPLOY. Its partner, STEP B
+-- (`20260811170000_rekey_app_collaborators_step_b_create_listing_keyed`), runs
+-- **AFTER**. The order is the whole point of the split — see "WHY TWO FILES" below.
+--
+-- SUPERSEDES 20260810140000_app_listing_collaborators, which created these same three
+-- tables keyed on `app_blocks(id)`:
+--   1. app_collaborators        — the consent-gated editor seat (+ byline opt-in)
+--   2. app_ownership_events     — append-only audit trail of every seat/ownership action
+--   3. app_ownership_transfers  — an in-flight owner→recipient ownership transfer
+--
+-- WHY RE-KEY. `app_blocks` is the ON-SITE runtime record. An OFF-SITE listing
+-- (external-link / OAuth-connect) has NO backing AppBlock in production today — every
+-- off-site row carries `app_listings.app_block_id IS NULL` — so a block-keyed seat was
+-- structurally unable to exist for one of the store's two kinds. `app_listings` is the
+-- store-facing parent of BOTH kinds, so keying the seat there is what makes
+-- collaborators reach off-site listings.
+--
+-- ------------------------------------------------------------
+-- 🔴 WHY TWO FILES — the DEPLOY WINDOW this ordering removes
+-- ------------------------------------------------------------
+-- A single DROP+CREATE migration cannot be applied atomically with a code deploy, so
+-- there is always a window in which one side is ahead of the other. The question is only
+-- WHICH error the code in that window sees:
+--
+--   * OLD (block-keyed) tables PRESENT + NEW code deployed
+--       → a seat read asks for `app_listing_id` on a table that has `app_block_id`
+--       → PG **42703** `column "app_listing_id" does not exist`
+--       → `isMissingTableError` (app-access.service.ts) deliberately REFUSES column
+--         errors — a half-applied schema must surface, not degrade to a silent zero —
+--         so `safeCollaboratorQuery` RETHROWS. It reaches `getListingDetail` →
+--         `loadDisplayedCollaboratorChips` with no try/catch above it, and the public
+--         listing-detail read 500s. 🔴 THIS IS THE WINDOW WE ARE REMOVING.
+--
+--   * NO collaborator tables at all + EITHER code version deployed
+--       → PG **42P01** `relation ... does not exist`
+--       → `isMissingTableError` returns true → `safeCollaboratorQuery` degrades to
+--         "no collaborators", i.e. exactly today's owner-only behaviour. No error
+--         surfaces anywhere.
+--
+-- So the safe sequence is to spend the whole deploy window in the SECOND state:
+--
+--     1. apply STEP A (this file)  → tables gone; the CURRENTLY DEPLOYED code degrades
+--                                    cleanly to owner-only (42P01, swallowed)
+--     2. deploy the code           → new code, still no tables; still 42P01, still
+--                                    swallowed. The feature is INERT, not broken.
+--     3. apply STEP B              → listing-keyed tables appear; the feature turns on
+--
+-- Every intermediate state is a 42P01 state. There is no instant at which any deployed
+-- code can raise 42703, which is what made the single-file version unsafe in BOTH
+-- directions (the reverse order — SQL first, deploy later — broke the OLD code the same
+-- way).
+--
+-- ⚠️ MANUAL APPLY — per datapacket-talos CLAUDE.md DB rule #8 the main civitai CNPG
+-- nvme0 DB does NOT auto-apply migrations (there is no `prisma migrate deploy` in any
+-- deploy path). This file is committed for HISTORY ONLY; a HUMAN applies the SQL below
+-- per environment (psql / retool). CI and deploy do NOT run it. Apply to BOTH:
+--   1. prod nvme0   (the live civitai DB)
+--   2. the dev clone (cnpg-cluster-dev, ns cnpg-database-dev, db civitai)
+--
+-- ------------------------------------------------------------
+-- 🔴 ROLLBACK DIRECTION
+-- ------------------------------------------------------------
+-- To undo STEP A: re-apply `20260810140000_app_listing_collaborators` verbatim. It is
+-- the file that created the block-keyed tables and every statement in it is
+-- `IF NOT EXISTS`, so re-running it restores the pre-STEP-A schema exactly. Nothing is
+-- lost, because the guard below refuses to run at all unless the tables are EMPTY.
+-- Undoing the whole re-key = roll back the code deploy, then re-apply
+-- `20260810140000_app_listing_collaborators`, then drop the STEP B tables (STEP B's own
+-- file documents that direction).
+--
+-- Idempotent: the guard tolerates already-absent tables and every DROP is IF EXISTS, so
+-- a re-run on an already-dropped schema is a no-op.
+
+-- ------------------------------------------------------------
+-- 0. 🔴 THE EMPTINESS GUARD — executable, not prose.
+-- ------------------------------------------------------------
+-- This whole migration is a DROP + re-CREATE rather than an ALTER + backfill, and that
+-- is safe for exactly ONE reason: all three tables are EMPTY in every environment
+-- (measured 2026-08-11: prod 0/0/0, dev clone 0/0/0). The predecessor migration is
+-- applied but the feature has never been exercised, so there is nothing to preserve.
+--
+-- 🔴 That fact is a MEASUREMENT, and a measurement decays. If a row appears between the
+-- measurement and the apply, this file would destroy it silently — so the precondition
+-- is RE-CHECKED AT APPLY TIME, by the database, and the apply ABORTS if it no longer
+-- holds. A comment saying "these are empty" cannot do that; this can. If it fires, the
+-- correct shape is an ALTER + backfill, not this file.
+--
+-- `to_regclass` + EXECUTE so a table that is already gone is skipped rather than being
+-- a parse-time failure.
+DO $$
+DECLARE
+  t     text;
+  n     bigint;
+  found text[] := ARRAY[]::text[];
+BEGIN
+  FOREACH t IN ARRAY ARRAY['app_collaborators', 'app_ownership_events', 'app_ownership_transfers']
+  LOOP
+    IF to_regclass('public.' || quote_ident(t)) IS NOT NULL THEN
+      EXECUTE format('SELECT count(*) FROM %I', t) INTO n;
+      IF n > 0 THEN
+        found := found || format('%s=%s', t, n);
+      END IF;
+    END IF;
+  END LOOP;
+
+  IF array_length(found, 1) IS NOT NULL THEN
+    RAISE EXCEPTION
+      'REFUSING TO DROP: the block-keyed collaborator tables are NOT empty (%). This migration is a DROP + re-CREATE and would destroy those rows. Use an ALTER + backfill instead.',
+      array_to_string(found, ', ');
+  END IF;
+END $$;
+
+-- ------------------------------------------------------------
+-- 1. Drop the block-keyed predecessors.
+-- ------------------------------------------------------------
+-- Order is irrelevant (no FK points at these three), but they are dropped together so a
+-- partial apply cannot leave a block-keyed table beside a listing-keyed one. CASCADE is
+-- deliberately NOT used: nothing should depend on these, and if something does, the
+-- apply must fail loudly rather than silently drop it.
+DROP TABLE IF EXISTS "app_ownership_transfers";
+DROP TABLE IF EXISTS "app_ownership_events";
+DROP TABLE IF EXISTS "app_collaborators";

--- a/packages/civitai-db-schema/prisma/migrations/20260811160000_rekey_app_collaborators_step_a_drop_block_keyed/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260811160000_rekey_app_collaborators_step_a_drop_block_keyed/migration.sql
@@ -67,9 +67,21 @@
 -- the file that created the block-keyed tables and every statement in it is
 -- `IF NOT EXISTS`, so re-running it restores the pre-STEP-A schema exactly. Nothing is
 -- lost, because the guard below refuses to run at all unless the tables are EMPTY.
--- Undoing the whole re-key = roll back the code deploy, then re-apply
--- `20260810140000_app_listing_collaborators`, then drop the STEP B tables (STEP B's own
--- file documents that direction).
+-- 🔴 Undoing the WHOLE re-key — THE ORDER IS LOAD-BEARING, and it is the reverse of the
+-- intuitive one. Do it in exactly this order:
+--   1. DROP the STEP B (listing-keyed) tables. Both code versions now see 42P01, which
+--      `safeCollaboratorQuery` swallows — inert for old AND new code.
+--   2. Roll back the code deploy.
+--   3. Re-apply `20260810140000_app_listing_collaborators` to restore the block-keyed
+--      tables.
+-- Rolling the CODE back first (step 2 before step 1) re-opens the exact window this
+-- split exists to eliminate: block-keyed code against STEP B's `app_listing_id` column
+-- raises 42703, which `isMissingTableError` deliberately refuses, so the public
+-- listing-detail read 500s.
+-- 🔴 And it does NOT self-correct: every statement in `20260810140000` is
+-- `IF NOT EXISTS`, so re-applying it over STEP B's tables emits "already exists,
+-- skipping" and leaves the key column as `app_listing_id`. The DROP in step 1 is what
+-- makes step 3 do anything at all.
 --
 -- Idempotent: the guard tolerates already-absent tables and every DROP is IF EXISTS, so
 -- a re-run on an already-dropped schema is a no-op.
@@ -90,6 +102,16 @@
 --
 -- `to_regclass` + EXECUTE so a table that is already gone is skipped rather than being
 -- a parse-time failure.
+--
+-- 🔴 THE `BEGIN;`/`COMMIT;` WRAPPER BELOW IS LOAD-BEARING — DO NOT REMOVE IT.
+-- psql's default is `ON_ERROR_STOP` **off**. Without the wrapper, the guard raises, psql
+-- PRINTS the error, and then runs the DROPs anyway — destroying the very rows the guard
+-- exists to protect, with its message scrolled off the top. Measured on PostgreSQL 18
+-- (2026-08-11): seeded one row, ran the file as a plain `psql -f`, and the table was
+-- gone. Inside a transaction the failed statement aborts the whole block and all three
+-- tables survive. Both controls were re-run after adding the wrapper.
+BEGIN;
+
 DO $$
 DECLARE
   t     text;
@@ -123,3 +145,5 @@ END $$;
 DROP TABLE IF EXISTS "app_ownership_transfers";
 DROP TABLE IF EXISTS "app_ownership_events";
 DROP TABLE IF EXISTS "app_collaborators";
+
+COMMIT;

--- a/packages/civitai-db-schema/prisma/migrations/20260811160000_rekey_app_collaborators_to_listings/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260811160000_rekey_app_collaborators_to_listings/migration.sql
@@ -1,0 +1,183 @@
+-- ============================================================
+-- App Listing COLLABORATORS — RE-KEY from app_blocks to app_listings
+-- ============================================================
+-- SUPERSEDES 20260810140000_app_listing_collaborators. That migration created the
+-- same three tables keyed on `app_blocks(id)`:
+--   1. app_collaborators        — the consent-gated editor seat (+ byline opt-in)
+--   2. app_ownership_events     — append-only audit trail of every seat/ownership action
+--   3. app_ownership_transfers  — an in-flight owner→recipient ownership transfer
+--
+-- WHY RE-KEY. `app_blocks` is the ON-SITE runtime record. An OFF-SITE listing
+-- (external-link / OAuth-connect) has NO backing AppBlock at all — every off-site row
+-- in production carries `app_listings.app_block_id IS NULL` — so a block-keyed seat is
+-- structurally unable to exist for one of the store's two kinds. `app_listings` is the
+-- store-facing parent of BOTH kinds, so keying the seat there is what makes
+-- collaborators reach off-site listings. It also removes a hop: every gate in this
+-- feature is a listing-shaped question that previously had to walk back to the block.
+--
+-- ⚠️ THIS IS A DROP + CREATE, NOT A DATA MIGRATION — and that is SAFE for exactly one
+-- reason: all three tables are EMPTY in every environment (verified 2026-08-11: prod
+-- 0/0/0, dev clone 0/0/0). The predecessor migration is applied but the feature has
+-- never been exercised, so there is nothing to preserve and nothing to back-fill. If a
+-- row ever appears before this is applied, STOP — this file would destroy it, and the
+-- correct shape is then an ALTER + backfill, not this.
+--
+-- ⚠️ MANUAL APPLY — per datapacket-talos CLAUDE.md DB rule #8 the main civitai
+-- CNPG nvme0 DB does NOT auto-apply migrations (there is no `prisma migrate
+-- deploy` in any deploy path). This file is committed for HISTORY ONLY; a HUMAN
+-- applies the SQL below per environment (psql / retool). CI and deploy do NOT
+-- run it. Apply to BOTH:
+--   1. prod nvme0   (the live civitai DB)
+--   2. the dev clone (cnpg-cluster-dev, ns cnpg-database-dev, db civitai)
+--
+-- 🔴 THE FEATURE IS INERT UNTIL THIS IS APPLIED, BY CONSTRUCTION. Every read of
+-- these tables is wrapped in `safeCollaboratorQuery` (app-access.service.ts),
+-- which catches the Postgres "relation does not exist" error (Prisma P2021 /
+-- PG 42P01) and degrades to "no collaborators" — i.e. exactly today's
+-- owner-only behaviour. The WRITE paths (invite / transfer) surface a friendly
+-- error instead. 🔴 NOTE THE WINDOW THIS MIGRATION OPENS THAT THE PREDECESSOR DID
+-- NOT: between deploying this code and applying this SQL, the OLD (block-keyed)
+-- tables still exist, so a read does NOT hit 42P01 — it hits `column
+-- "app_listing_id" does not exist` (42703), which `isMissingTableError`
+-- deliberately does NOT swallow (a column error is a HALF-APPLIED schema and must
+-- surface). Apply this migration in the SAME maintenance step as the deploy.
+--
+-- Idempotent: the DROPs are IF EXISTS and every CREATE is IF NOT EXISTS, so a manual
+-- re-run is a no-op on an already-re-keyed schema.
+
+-- ------------------------------------------------------------
+-- 0. Drop the block-keyed predecessors.
+-- ------------------------------------------------------------
+-- Order is irrelevant (no FK points at these three), but they are dropped together so
+-- a partial apply cannot leave a block-keyed table beside a listing-keyed one. CASCADE
+-- is deliberately NOT used: nothing should depend on these, and if something does, the
+-- apply must fail loudly rather than silently drop it.
+DROP TABLE IF EXISTS "app_ownership_transfers";
+DROP TABLE IF EXISTS "app_ownership_events";
+DROP TABLE IF EXISTS "app_collaborators";
+
+-- ------------------------------------------------------------
+-- 1. app_collaborators
+-- ------------------------------------------------------------
+-- Keyed to app_listings — the store-facing parent of BOTH kinds.
+--
+-- 🔴 A SEAT BELONGS TO A **PARENT** LISTING, NEVER TO A SHADOW REVISION
+-- (`revision_of_id IS NOT NULL`). `applyApprovedRevision` DELETES the shadow on
+-- approve, and this FK is ON DELETE CASCADE — so a seat that landed on a shadow would
+-- vanish the moment a moderator approved the revision, silently and with no error. A
+-- SQL CHECK cannot express this (a row-level CHECK cannot see another row's
+-- `revision_of_id`), so it is enforced in the service: `inviteCollaborator` refuses a
+-- shadow outright, and `resolveListingAccess` resolves a shadow to its parent before
+-- ever looking a seat up. Both directions are pinned in
+-- `app-collaborator.shadow-hazard.test.ts`.
+--
+-- CASCADE on both FKs (unlike the audit table below): a seat is a live capability, not
+-- a historical record. If the listing is deleted there is nothing to edit; if the user
+-- is deleted the seat must not survive as a dangling grant.
+CREATE TABLE IF NOT EXISTS "app_collaborators" (
+  "app_listing_id"   TEXT    NOT NULL REFERENCES "app_listings"("id") ON DELETE CASCADE,
+  "user_id"          INTEGER NOT NULL REFERENCES "User"("id")         ON DELETE CASCADE,
+  -- Capability role. 'editor' is the only value written today; TEXT (not an enum)
+  -- so adding a role needs no migration. What an 'editor' may actually DO is derived
+  -- from the listing's KIND, not stored here — see `capabilitiesForKind`.
+  "role"             TEXT    NOT NULL DEFAULT 'editor',
+  -- 🔴 CONSENT: only 'accepted' confers ANY capability and only 'accepted' is ever
+  -- publicly visible. 'pending'/'rejected' are inert.
+  "status"           TEXT    NOT NULL DEFAULT 'pending',
+  -- Public-byline opt-in (immediate-apply, no mod review). Safe to apply
+  -- immediately BECAUSE it lives here: applyApprovedRevision's offsite branch
+  -- copies app_listings scalars from the shadow onto the parent, so the same flag
+  -- stored as an app_listings column would be clobbered by a later approve. This row
+  -- is outside both branches' copy sets.
+  "displayed"        BOOLEAN NOT NULL DEFAULT true,
+  "invited_by"       INTEGER NOT NULL REFERENCES "User"("id")         ON DELETE CASCADE,
+  -- Re-invite notification throttle key. NULL = never notified.
+  "last_notified_at" TIMESTAMPTZ,
+  "created_at"       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  "responded_at"     TIMESTAMPTZ,
+
+  PRIMARY KEY ("app_listing_id", "user_id"),
+
+  CONSTRAINT "app_collaborators_status_check"
+    CHECK ("status" IN ('pending', 'accepted', 'rejected')),
+  CONSTRAINT "app_collaborators_role_check"
+    CHECK ("role" IN ('editor'))
+);
+
+-- "which listings may this user edit" — the hot path (resolveAccessibleListingIds,
+-- run on every gated proc for a non-owner).
+CREATE INDEX IF NOT EXISTS "app_collaborators_user_status_idx"
+  ON "app_collaborators" ("user_id", "status");
+-- "who is on this listing" — the owner roster + the public byline read.
+CREATE INDEX IF NOT EXISTS "app_collaborators_listing_status_idx"
+  ON "app_collaborators" ("app_listing_id", "status");
+-- FK index so a User delete (hot path) does not seq-scan on the inviter side.
+CREATE INDEX IF NOT EXISTS "app_collaborators_invited_by_idx"
+  ON "app_collaborators" ("invited_by");
+
+-- ------------------------------------------------------------
+-- 2. app_ownership_events  (append-only audit trail)
+-- ------------------------------------------------------------
+-- Mirrors app_listing_moderation_events' survivability posture: EVERY FK is
+-- NULLABLE + SET NULL so an event outlives the listing, the actor and the target. The
+-- denormalized "slug" keeps the row self-describing once the listing is gone.
+CREATE TABLE IF NOT EXISTS "app_ownership_events" (
+  "id"             TEXT PRIMARY KEY,                                            -- aoe_<ULID>
+  "app_listing_id" TEXT    REFERENCES "app_listings"("id") ON DELETE SET NULL,
+  "slug"           TEXT    NOT NULL,
+  "action"         TEXT    NOT NULL,
+  "actor_user_id"  INTEGER REFERENCES "User"("id")         ON DELETE SET NULL,
+  "target_user_id" INTEGER REFERENCES "User"("id")         ON DELETE SET NULL,
+  "metadata"       JSONB,
+  "created_at"     TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CONSTRAINT "app_ownership_events_action_check"
+    CHECK ("action" IN (
+      'invite', 'accept', 'reject', 'remove', 'leave', 'display',
+      'transfer_initiated', 'transfer_accepted', 'transfer_cancelled'
+    ))
+);
+
+CREATE INDEX IF NOT EXISTS "app_ownership_events_listing_idx"
+  ON "app_ownership_events" ("app_listing_id", "created_at" DESC);
+CREATE INDEX IF NOT EXISTS "app_ownership_events_actor_idx"
+  ON "app_ownership_events" ("actor_user_id", "created_at" DESC);
+
+-- ------------------------------------------------------------
+-- 3. app_ownership_transfers
+-- ------------------------------------------------------------
+-- One in-flight transfer per LISTING, enforced by the PARTIAL UNIQUE index below.
+CREATE TABLE IF NOT EXISTS "app_ownership_transfers" (
+  "id"             TEXT PRIMARY KEY,                                        -- aot_<ULID>
+  "app_listing_id" TEXT    NOT NULL REFERENCES "app_listings"("id") ON DELETE CASCADE,
+  -- Snapshot of the owner at initiate time. Re-asserted in-tx at accept, so a
+  -- transfer initiated by someone who has since lost the listing cannot complete.
+  "from_user_id"   INTEGER NOT NULL REFERENCES "User"("id")         ON DELETE CASCADE,
+  "to_user_id"     INTEGER NOT NULL REFERENCES "User"("id")         ON DELETE CASCADE,
+  "status"         TEXT    NOT NULL DEFAULT 'pending',
+  -- Hard expiry, enforced as a read-time predicate in the ACCEPT path — no
+  -- sweeper job is required for CORRECTNESS (a sweeper would only tidy rows).
+  "expires_at"     TIMESTAMPTZ NOT NULL,
+  "created_at"     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  "responded_at"   TIMESTAMPTZ,
+
+  CONSTRAINT "app_ownership_transfers_status_check"
+    CHECK ("status" IN ('pending', 'accepted', 'rejected', 'cancelled', 'expired')),
+  -- A self-transfer is meaningless and would make the accept path a no-op that
+  -- still emits an audit event.
+  CONSTRAINT "app_ownership_transfers_not_self_check"
+    CHECK ("from_user_id" <> "to_user_id")
+);
+
+-- 🔴 THE one-in-flight-transfer GUARD. Prisma cannot express a partial unique
+-- index, so this lives ONLY here — the service relies on its P2002 to close the
+-- read-then-write race between two concurrent initiateTransfer calls.
+CREATE UNIQUE INDEX IF NOT EXISTS "app_ownership_transfers_one_pending_per_listing"
+  ON "app_ownership_transfers" ("app_listing_id")
+  WHERE "status" = 'pending';
+
+CREATE INDEX IF NOT EXISTS "app_ownership_transfers_listing_status_idx"
+  ON "app_ownership_transfers" ("app_listing_id", "status");
+-- "transfers awaiting MY acceptance" — the recipient's inbox read.
+CREATE INDEX IF NOT EXISTS "app_ownership_transfers_to_status_idx"
+  ON "app_ownership_transfers" ("to_user_id", "status");

--- a/packages/civitai-db-schema/prisma/migrations/20260811170000_rekey_app_collaborators_step_b_create_listing_keyed/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260811170000_rekey_app_collaborators_step_b_create_listing_keyed/migration.sql
@@ -1,60 +1,43 @@
 -- ============================================================
--- App Listing COLLABORATORS — RE-KEY from app_blocks to app_listings
+-- App Listing COLLABORATORS — RE-KEY, **STEP B of 2**: CREATE the listing-keyed tables.
 -- ============================================================
--- SUPERSEDES 20260810140000_app_listing_collaborators. That migration created the
--- same three tables keyed on `app_blocks(id)`:
---   1. app_collaborators        — the consent-gated editor seat (+ byline opt-in)
---   2. app_ownership_events     — append-only audit trail of every seat/ownership action
---   3. app_ownership_transfers  — an in-flight owner→recipient ownership transfer
+-- 🔴 RUN THIS **AFTER** THE CODE DEPLOY. Its partner, STEP A
+-- (`20260811160000_rekey_app_collaborators_step_a_drop_block_keyed`), runs **BEFORE**.
 --
--- WHY RE-KEY. `app_blocks` is the ON-SITE runtime record. An OFF-SITE listing
--- (external-link / OAuth-connect) has NO backing AppBlock at all — every off-site row
--- in production carries `app_listings.app_block_id IS NULL` — so a block-keyed seat is
--- structurally unable to exist for one of the store's two kinds. `app_listings` is the
--- store-facing parent of BOTH kinds, so keying the seat there is what makes
--- collaborators reach off-site listings. It also removes a hop: every gate in this
--- feature is a listing-shaped question that previously had to walk back to the block.
+-- THE SEQUENCE, in full (STEP A's banner carries the reasoning):
+--     1. apply STEP A  → the block-keyed tables are dropped; the CURRENTLY DEPLOYED code
+--                        sees PG 42P01 and degrades to owner-only (swallowed by
+--                        `safeCollaboratorQuery`). Nothing surfaces.
+--     2. deploy        → the new listing-keyed code goes out. Still no tables, still
+--                        42P01, still swallowed. The feature is INERT, not broken.
+--     3. apply STEP B  → this file. The tables appear and the feature turns on.
 --
--- ⚠️ THIS IS A DROP + CREATE, NOT A DATA MIGRATION — and that is SAFE for exactly one
--- reason: all three tables are EMPTY in every environment (verified 2026-08-11: prod
--- 0/0/0, dev clone 0/0/0). The predecessor migration is applied but the feature has
--- never been exercised, so there is nothing to preserve and nothing to back-fill. If a
--- row ever appears before this is applied, STOP — this file would destroy it, and the
--- correct shape is then an ALTER + backfill, not this.
+-- 🔴 APPLYING THIS FILE **BEFORE** THE DEPLOY RE-OPENS THE WINDOW THE SPLIT CLOSED, in
+-- mirror image: the OLD deployed code would then read `app_block_id` off a table that
+-- only has `app_listing_id` → PG 42703 `column ... does not exist` → `isMissingTableError`
+-- refuses column errors on purpose → the error propagates and the public listing-detail
+-- read 500s. Order is not a nicety here; it is the entire reason there are two files.
 --
--- ⚠️ MANUAL APPLY — per datapacket-talos CLAUDE.md DB rule #8 the main civitai
--- CNPG nvme0 DB does NOT auto-apply migrations (there is no `prisma migrate
--- deploy` in any deploy path). This file is committed for HISTORY ONLY; a HUMAN
--- applies the SQL below per environment (psql / retool). CI and deploy do NOT
--- run it. Apply to BOTH:
+-- ⚠️ MANUAL APPLY — per datapacket-talos CLAUDE.md DB rule #8 the main civitai CNPG
+-- nvme0 DB does NOT auto-apply migrations (there is no `prisma migrate deploy` in any
+-- deploy path). This file is committed for HISTORY ONLY; a HUMAN applies the SQL below
+-- per environment (psql / retool). CI and deploy do NOT run it. Apply to BOTH:
 --   1. prod nvme0   (the live civitai DB)
 --   2. the dev clone (cnpg-cluster-dev, ns cnpg-database-dev, db civitai)
 --
--- 🔴 THE FEATURE IS INERT UNTIL THIS IS APPLIED, BY CONSTRUCTION. Every read of
--- these tables is wrapped in `safeCollaboratorQuery` (app-access.service.ts),
--- which catches the Postgres "relation does not exist" error (Prisma P2021 /
--- PG 42P01) and degrades to "no collaborators" — i.e. exactly today's
--- owner-only behaviour. The WRITE paths (invite / transfer) surface a friendly
--- error instead. 🔴 NOTE THE WINDOW THIS MIGRATION OPENS THAT THE PREDECESSOR DID
--- NOT: between deploying this code and applying this SQL, the OLD (block-keyed)
--- tables still exist, so a read does NOT hit 42P01 — it hits `column
--- "app_listing_id" does not exist` (42703), which `isMissingTableError`
--- deliberately does NOT swallow (a column error is a HALF-APPLIED schema and must
--- surface). Apply this migration in the SAME maintenance step as the deploy.
+-- ------------------------------------------------------------
+-- 🔴 ROLLBACK DIRECTION
+-- ------------------------------------------------------------
+-- To undo STEP B: `DROP TABLE IF EXISTS "app_ownership_transfers", "app_ownership_events",
+-- "app_collaborators";` — safe ONLY while they are still empty, which is the case for as
+-- long as no invite has been sent. Once a seat exists, dropping destroys it; take a dump
+-- of the three tables first. Dropping them returns the deployed code to the 42P01 path,
+-- i.e. inert-and-owner-only, NOT broken — so this rollback does not require a code
+-- rollback. To go all the way back to the block-keyed world, roll the code back and
+-- re-apply `20260810140000_app_listing_collaborators`.
 --
--- Idempotent: the DROPs are IF EXISTS and every CREATE is IF NOT EXISTS, so a manual
--- re-run is a no-op on an already-re-keyed schema.
-
--- ------------------------------------------------------------
--- 0. Drop the block-keyed predecessors.
--- ------------------------------------------------------------
--- Order is irrelevant (no FK points at these three), but they are dropped together so
--- a partial apply cannot leave a block-keyed table beside a listing-keyed one. CASCADE
--- is deliberately NOT used: nothing should depend on these, and if something does, the
--- apply must fail loudly rather than silently drop it.
-DROP TABLE IF EXISTS "app_ownership_transfers";
-DROP TABLE IF EXISTS "app_ownership_events";
-DROP TABLE IF EXISTS "app_collaborators";
+-- Idempotent: every CREATE is IF NOT EXISTS, so a re-run on an already-re-keyed schema
+-- is a no-op.
 
 -- ------------------------------------------------------------
 -- 1. app_collaborators

--- a/packages/civitai-db-schema/prisma/migrations/20260811170000_rekey_app_collaborators_step_b_create_listing_keyed/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260811170000_rekey_app_collaborators_step_b_create_listing_keyed/migration.sql
@@ -33,8 +33,21 @@
 -- long as no invite has been sent. Once a seat exists, dropping destroys it; take a dump
 -- of the three tables first. Dropping them returns the deployed code to the 42P01 path,
 -- i.e. inert-and-owner-only, NOT broken — so this rollback does not require a code
--- rollback. To go all the way back to the block-keyed world, roll the code back and
--- re-apply `20260810140000_app_listing_collaborators`.
+-- rollback.
+--
+-- 🔴 To go all the way back to the block-keyed world, THE ORDER IS LOAD-BEARING and is
+-- the reverse of the intuitive one:
+--   1. DROP these listing-keyed tables (the statement above). Both code versions then
+--      see 42P01, which `safeCollaboratorQuery` swallows — inert for old AND new code.
+--   2. Roll the code deploy back.
+--   3. Re-apply `20260810140000_app_listing_collaborators`.
+-- Rolling the CODE back FIRST re-opens the window this split exists to eliminate:
+-- block-keyed code against the `app_listing_id` column raises 42703, which
+-- `isMissingTableError` deliberately refuses, so the public listing-detail read 500s.
+-- 🔴 It also does not self-correct — every statement in `20260810140000` is
+-- `IF NOT EXISTS`, so re-applying it while these tables still exist emits "already
+-- exists, skipping" and leaves the key column as `app_listing_id`. Step 1 is what makes
+-- step 3 do anything at all.
 --
 -- Idempotent: every CREATE is IF NOT EXISTS, so a re-run on an already-re-keyed schema
 -- is a no-op.

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -2513,13 +2513,10 @@ model AppBlock {
   userScopeGrants    AppUserScopeGrant[]
   reviews            AppBlockReview[]
   appListing         AppListing?
-  // App Listing Collaborators — the editor seats + the append-only ownership
-  // audit trail + any in-flight ownership transfer. Keyed to the AppBlock (NOT
-  // the AppListing) because ownership is canonically the backing OauthClient's
-  // and the listing only carries a denormalized copy.
-  collaborators      AppCollaborator[]
-  ownershipEvents    AppOwnershipEvent[]
-  ownershipTransfers AppOwnershipTransfer[]
+  // NB: App Listing Collaborators (seats / ownership events / ownership transfers)
+  // are keyed to `AppListing`, NOT here — see the AppCollaborator model header. An
+  // off-site listing has no AppBlock at all, so a block-keyed seat could never exist
+  // for one of the store's two kinds.
 
   @@unique([appId, blockId], map: "app_blocks_app_block_uniq")
   // W1 audit C-3 fix: enforce one app per slug at the DB layer. The
@@ -2567,17 +2564,28 @@ model AppBlockReview {
   @@map("app_block_reviews")
 }
 
-/// App Listing COLLABORATORS — a consent-gated editor seat on an app.
+/// App Listing COLLABORATORS — a consent-gated editor seat on a STORE LISTING.
 ///
-/// 🔴 KEYED TO `AppBlock`, NOT `AppListing`. Ownership is canonically
-/// `OauthClient.userId` reached as `AppBlock.app.userId`; `AppListing.userId` is a
-/// DENORMALIZED COPY (written by `app-listing-mapper`). Keying the seat to the
-/// listing would make it a property of the copy, and a listing can be cloned into a
-/// shadow revision (`revisionOfId`) whose scalars are copied back onto the parent on
-/// approve — so a seat stored listing-side would be duplicated per shadow and could
-/// be silently reverted by `applyApprovedRevision`.
+/// 🔴 KEYED TO `AppListing`, NOT `AppBlock`. `AppBlock` is the ON-SITE runtime record;
+/// an OFF-SITE listing (external-link / OAuth-connect) has no AppBlock at all
+/// (`app_listings.app_block_id IS NULL`), so a block-keyed seat was structurally unable
+/// to exist for one of the store's two kinds. `AppListing` is the store-facing parent of
+/// BOTH, so the seat lives here. Ownership remains canonically `OauthClient.userId` for
+/// an on-site listing — the seat's KEY and the ownership COLUMN are different questions.
 ///
-/// 🔴 `displayed` (the public-byline opt-in) LIVES HERE FOR THE SAME REASON, and
+/// 🔴 A SEAT BELONGS TO A **PARENT** LISTING, NEVER TO A SHADOW REVISION
+/// (`revisionOfId != null`). `applyApprovedRevision` DELETES the shadow, and this FK
+/// CASCADEs — a seat on a shadow would silently vanish on approve. A SQL CHECK cannot
+/// express "parent only" (it cannot see another row), so it is enforced in the service:
+/// `inviteCollaborator` refuses a shadow, and `resolveListingAccess` resolves a shadow
+/// to its parent before any seat lookup.
+///
+/// 🔴 WHAT A SEAT UNLOCKS IS DERIVED FROM THE LISTING'S `kind`, not stored. An off-site
+/// editor gets content/media, submit-for-review and analytics, but NOT earnings
+/// (`BlockBuzzAttribution` is block-scoped) and NOT submit-version / git (there is no
+/// bundle and no repo). See `capabilitiesForKind` in `app-access.service.ts`.
+///
+/// 🔴 `displayed` (the public-byline opt-in) LIVES HERE FOR A LOAD-BEARING REASON, and
 /// this is load-bearing rather than incidental: `applyApprovedRevision`'s OFFSITE
 /// branch copies the shadow's `name/tagline/description/category/contentRating/
 /// externalUrl/connect*` straight onto the live parent. An `AppListing` column
@@ -2598,13 +2606,15 @@ model AppBlockReview {
 /// run `prisma migrate deploy`. The committed SQL is hand-applied per environment. All
 /// reads are NULL-safe / empty-safe, so the feature is INERT until it lands.
 model AppCollaborator {
-  appBlockId  String    @map("app_block_id")
-  appBlock    AppBlock  @relation(fields: [appBlockId], references: [id], onDelete: Cascade)
+  appListingId String   @map("app_listing_id")
+  appListing  AppListing @relation(fields: [appListingId], references: [id], onDelete: Cascade)
   userId      Int       @map("user_id")
   user        User      @relation("AppCollaboratorMember", fields: [userId], references: [id], onDelete: Cascade)
-  /// Capability role. 'editor' today (content + media + submit + app-scoped
-  /// analytics/earnings). Owner-only actions (managing collaborators, initiating a
-  /// transfer) are NOT a role — they are reserved to the OauthClient owner.
+  /// Capability role. 'editor' today. What it actually unlocks is DERIVED from the
+  /// listing's kind (`capabilitiesForKind`), not stored here: content + media + submit
+  /// for review + analytics on both kinds, plus earnings and submit-version/git on
+  /// on-site only. Owner-only actions (managing collaborators, initiating a transfer)
+  /// are NOT a role — they are reserved to the listing owner.
   role        String    @default("editor")
   /// 'pending' | 'accepted' | 'rejected'. Only 'accepted' confers capability, and
   /// only 'accepted' is ever visible publicly.
@@ -2623,25 +2633,25 @@ model AppCollaborator {
   createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
   respondedAt DateTime? @map("responded_at") @db.Timestamptz(6)
 
-  @@id([appBlockId, userId])
-  /// "which apps can this user edit" — the hot path (`resolveAccessibleAppBlockIds`).
+  @@id([appListingId, userId])
+  /// "which listings can this user edit" — the hot path (`resolveAccessibleListingIds`).
   @@index([userId, status], map: "app_collaborators_user_status_idx")
-  /// "who is on this app" — the roster + the public byline read.
-  @@index([appBlockId, status], map: "app_collaborators_app_status_idx")
+  /// "who is on this listing" — the roster + the public byline read.
+  @@index([appListingId, status], map: "app_collaborators_listing_status_idx")
   @@map("app_collaborators")
 }
 
-/// APPEND-ONLY audit trail of every collaborator/ownership action on an app.
+/// APPEND-ONLY audit trail of every collaborator/ownership action on a listing.
 ///
 /// Deliberately a separate table from `AppListingModerationEvent` (which is
-/// listing-scoped and mod-action-scoped): these are AUTHOR actions on the AppBlock.
-/// Mirrors that table's survivability posture — every FK is NULLABLE + SET NULL so an
-/// event outlives the app, the actor and the target.
+/// mod-ACTION-scoped): these are AUTHOR actions. Mirrors that table's survivability
+/// posture — every FK is NULLABLE + SET NULL so an event outlives the listing, the
+/// actor and the target.
 model AppOwnershipEvent {
-  id           String    @id // aoe_<ULID>
-  appBlockId   String?   @map("app_block_id")
-  appBlock     AppBlock? @relation(fields: [appBlockId], references: [id], onDelete: SetNull)
-  /// Denormalized so the event stays self-describing after the app is gone.
+  id           String      @id // aoe_<ULID>
+  appListingId String?     @map("app_listing_id")
+  appListing   AppListing? @relation(fields: [appListingId], references: [id], onDelete: SetNull)
+  /// Denormalized so the event stays self-describing after the listing is gone.
   slug         String
   /// invite | accept | reject | remove | leave | display | transfer_initiated |
   /// transfer_accepted | transfer_cancelled. Bounded by a CHECK in the migration.
@@ -2656,7 +2666,7 @@ model AppOwnershipEvent {
   metadata     Json?
   createdAt    DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
 
-  @@index([appBlockId, createdAt(sort: Desc)], map: "app_ownership_events_app_idx")
+  @@index([appListingId, createdAt(sort: Desc)], map: "app_ownership_events_listing_idx")
   @@index([actorUserId, createdAt(sort: Desc)], map: "app_ownership_events_actor_idx")
   @@map("app_ownership_events")
 }
@@ -2664,19 +2674,19 @@ model AppOwnershipEvent {
 /// An IN-FLIGHT ownership transfer (owner initiates → recipient accepts).
 ///
 /// 🔴 WHY A THIRD TABLE rather than folding this into `AppCollaborator` with a
-/// `role='owner_transfer'` row: `AppCollaborator`'s PK is `(appBlockId, userId)`, so a
+/// `role='owner_transfer'` row: `AppCollaborator`'s PK is `(appListingId, userId)`, so a
 /// transfer to someone who is ALREADY an editor would collide with their seat row and
 /// the two states would have to share one `status` column. And deriving the pending
 /// state from `AppOwnershipEvent` (the append-only log) cannot carry a UNIQUE, so two
 /// concurrent `initiateTransfer` calls could both "succeed". This table carries the
-/// real constraint: a PARTIAL UNIQUE on `app_block_id WHERE status='pending'` — at
-/// most one in-flight transfer per app, enforced at the DB.
+/// real constraint: a PARTIAL UNIQUE on `app_listing_id WHERE status='pending'` — at
+/// most one in-flight transfer per listing, enforced at the DB.
 model AppOwnershipTransfer {
-  id          String    @id // aot_<ULID>
-  appBlockId  String    @map("app_block_id")
-  appBlock    AppBlock  @relation(fields: [appBlockId], references: [id], onDelete: Cascade)
+  id           String     @id // aot_<ULID>
+  appListingId String     @map("app_listing_id")
+  appListing   AppListing @relation(fields: [appListingId], references: [id], onDelete: Cascade)
   /// Snapshot of the owner at initiate time — re-asserted in-tx at accept, so a
-  /// transfer initiated by an owner who has since lost the app cannot complete.
+  /// transfer initiated by an owner who has since lost the listing cannot complete.
   fromUserId  Int       @map("from_user_id")
   fromUser    User      @relation("AppOwnershipTransferFrom", fields: [fromUserId], references: [id], onDelete: Cascade)
   toUserId    Int       @map("to_user_id")
@@ -2691,10 +2701,10 @@ model AppOwnershipTransfer {
   respondedAt DateTime? @map("responded_at") @db.Timestamptz(6)
 
   /// NB: the migration ALSO creates a PARTIAL UNIQUE index
-  /// (`app_block_id WHERE status='pending'`) that Prisma cannot express. That partial
+  /// (`app_listing_id WHERE status='pending'`) that Prisma cannot express. That partial
   /// index — not this plain one — is the one-in-flight-transfer guard; the service
   /// relies on its P2002.
-  @@index([appBlockId, status], map: "app_ownership_transfers_app_status_idx")
+  @@index([appListingId, status], map: "app_ownership_transfers_listing_status_idx")
   @@index([toUserId, status], map: "app_ownership_transfers_to_status_idx")
   @@map("app_ownership_transfers")
 }
@@ -2854,6 +2864,12 @@ model AppListing {
   // P3b off-site moderation: user reports + the append-only mod audit trail.
   reports          AppListingReport[]
   moderationEvents AppListingModerationEvent[]
+  // App Listing Collaborators — the editor seats, the append-only ownership audit
+  // trail, and any in-flight ownership transfer. Keyed HERE (not to AppBlock) so an
+  // OFF-SITE listing, which has no AppBlock, can hold seats too.
+  collaborators      AppCollaborator[]
+  ownershipEvents    AppOwnershipEvent[]
+  ownershipTransfers AppOwnershipTransfer[]
 
   // Marketplace read-path indexes (future P2 read path).
   @@index([status, kind], map: "app_listings_status_kind_idx")

--- a/packages/civitai-db-schema/src/kysely/types.ts
+++ b/packages/civitai-db-schema/src/kysely/types.ts
@@ -327,9 +327,13 @@ export type AppCollaborator = {
   app_listing_id: string;
   user_id: number;
   /**
-   * Capability role. 'editor' today (content + media + submit + app-scoped
-   * analytics/earnings). Owner-only actions (managing collaborators, initiating a
-   * transfer) are NOT a role — they are reserved to the OauthClient owner.
+   * Capability role. 'editor' today. WHAT an editor may do is derived from the
+   * LISTING'S KIND, never stored here (`capabilitiesForKind`): content + media +
+   * submit-for-review + analytics for both kinds, plus earnings + submit-version for
+   * ONSITE only — an off-site listing has no AppBlock, so neither can exist for it.
+   * Owner-only actions (managing collaborators, initiating a transfer) are NOT a role —
+   * they are reserved to the listing OWNER, which is `AppBlock.app.userId` (the
+   * OauthClient) for an ONSITE listing and `app_listings.user_id` for an OFFSITE one.
    */
   role: Generated<string>;
   /**

--- a/packages/civitai-db-schema/src/kysely/types.ts
+++ b/packages/civitai-db-schema/src/kysely/types.ts
@@ -324,7 +324,7 @@ export type AppBlockReview = {
   updated_at: Timestamp;
 };
 export type AppCollaborator = {
-  app_block_id: string;
+  app_listing_id: string;
   user_id: number;
   /**
    * Capability role. 'editor' today (content + media + submit + app-scoped
@@ -478,9 +478,9 @@ export type AppListingScreenshot = {
 };
 export type AppOwnershipEvent = {
   id: string;
-  app_block_id: string | null;
+  app_listing_id: string | null;
   /**
-   * Denormalized so the event stays self-describing after the app is gone.
+   * Denormalized so the event stays self-describing after the listing is gone.
    */
   slug: string;
   /**
@@ -504,10 +504,10 @@ export type AppOwnershipEvent = {
 };
 export type AppOwnershipTransfer = {
   id: string;
-  app_block_id: string;
+  app_listing_id: string;
   /**
    * Snapshot of the owner at initiate time — re-asserted in-tx at accept, so a
-   * transfer initiated by an owner who has since lost the app cannot complete.
+   * transfer initiated by an owner who has since lost the listing cannot complete.
    */
   from_user_id: number;
   to_user_id: number;

--- a/packages/civitai-db-schema/src/models.ts
+++ b/packages/civitai-db-schema/src/models.ts
@@ -1891,9 +1891,6 @@ export interface AppBlock {
   userScopeGrants?: AppUserScopeGrant[];
   reviews?: AppBlockReview[];
   appListing?: AppListing | null;
-  collaborators?: AppCollaborator[];
-  ownershipEvents?: AppOwnershipEvent[];
-  ownershipTransfers?: AppOwnershipTransfer[];
 }
 
 export interface AppBlockReview {
@@ -1912,8 +1909,8 @@ export interface AppBlockReview {
 }
 
 export interface AppCollaborator {
-  appBlockId: string;
-  appBlock?: AppBlock;
+  appListingId: string;
+  appListing?: AppListing;
   userId: number;
   user?: User;
   role: string;
@@ -1928,8 +1925,8 @@ export interface AppCollaborator {
 
 export interface AppOwnershipEvent {
   id: string;
-  appBlockId: string | null;
-  appBlock?: AppBlock | null;
+  appListingId: string | null;
+  appListing?: AppListing | null;
   slug: string;
   action: string;
   actorUserId: number | null;
@@ -1942,8 +1939,8 @@ export interface AppOwnershipEvent {
 
 export interface AppOwnershipTransfer {
   id: string;
-  appBlockId: string;
-  appBlock?: AppBlock;
+  appListingId: string;
+  appListing?: AppListing;
   fromUserId: number;
   fromUser?: User;
   toUserId: number;
@@ -2021,6 +2018,9 @@ export interface AppListing {
   publishRequests?: AppListingPublishRequest[];
   reports?: AppListingReport[];
   moderationEvents?: AppListingModerationEvent[];
+  collaborators?: AppCollaborator[];
+  ownershipEvents?: AppOwnershipEvent[];
+  ownershipTransfers?: AppOwnershipTransfer[];
 }
 
 export interface AppListingScreenshot {

--- a/src/server/notifications/app-collaborator.notifications.ts
+++ b/src/server/notifications/app-collaborator.notifications.ts
@@ -22,15 +22,28 @@ import { createNotificationProcessor } from '~/server/notifications/base.notific
  */
 
 export type AppCollaboratorNotificationDetails = {
-  /** The app's public slug — identity + link target. */
+  /** The listing's public slug — identity + link target. */
   slug: string;
-  /** The backing AppBlock id (stable deep-link key). */
+  /** The store listing the seat/transfer belongs to (the stable key). */
+  appListingId?: string | null;
+  /**
+   * The backing AppBlock id, when there is one. 🔴 `null` for an OFF-SITE listing —
+   * seats are listing-keyed and off-site listings have no AppBlock, so this is a
+   * legitimately-absent value, not a missing one.
+   */
   appBlockId?: string | null;
   /** Best-effort display name for nicer copy; absent ⇒ terser message. */
   name?: string | null;
 };
 
-/** Where each notification points. Both audiences land on the app's own page. */
+/**
+ * Where each notification points.
+ *
+ * 🔴 The per-app authoring pages are BLOCK-keyed (`/apps/[appBlockId]/…`), so an
+ * off-site listing has no such page to deep-link to and falls back to `/apps`. That is
+ * the pre-existing behaviour for a null `appBlockId`, kept deliberately rather than
+ * inventing a route that does not exist.
+ */
 function appUrl(details: AppCollaboratorNotificationDetails): string {
   return details.appBlockId ? `/apps/${details.appBlockId}` : '/apps';
 }

--- a/src/server/routers/__tests__/blocks.router.getMyAppRepo.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getMyAppRepo.test.ts
@@ -81,6 +81,11 @@ vi.mock('~/server/db/client', () => ({
     // missing-TABLE error, so an absent mock surfaces as a TypeError rather than
     // being silently absorbed — which is why this fixture must declare it.
     appCollaborator: { findFirst: vi.fn(async () => null), findMany: vi.fn(async () => []) },
+    // 🔴 …and since seats were re-keyed from app_blocks to app_listings, the non-owner
+    // path first hops AppBlock -> AppListing to find the id the seat would live under.
+    // Default null = "this block has no store listing", which is the fail-closed answer
+    // these owner-gate cases assert.
+    appListing: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
   },
   dbWrite: {},
 }));

--- a/src/server/routers/__tests__/blocks.router.getMyForgejoCloneInfo.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getMyForgejoCloneInfo.test.ts
@@ -72,6 +72,11 @@ vi.mock('~/server/db/client', () => ({
     // missing-TABLE error, so an absent mock surfaces as a TypeError rather than
     // being silently absorbed — which is why this fixture must declare it.
     appCollaborator: { findFirst: vi.fn(async () => null), findMany: vi.fn(async () => []) },
+    // 🔴 …and since seats were re-keyed from app_blocks to app_listings, the non-owner
+    // path first hops AppBlock -> AppListing to find the id the seat would live under.
+    // Default null = "this block has no store listing", which is the fail-closed answer
+    // these owner-gate cases assert.
+    appListing: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
   },
   dbWrite: {},
 }));

--- a/src/server/routers/__tests__/blocks.router.updateManifest.test.ts
+++ b/src/server/routers/__tests__/blocks.router.updateManifest.test.ts
@@ -100,6 +100,11 @@ vi.mock('~/server/db/client', () => ({
     // missing-TABLE error, so an absent mock surfaces as a TypeError rather than
     // being silently absorbed — which is why this fixture must declare it.
     appCollaborator: { findFirst: vi.fn(async () => null), findMany: vi.fn(async () => []) },
+    // 🔴 …and since seats were re-keyed from app_blocks to app_listings, the non-owner
+    // path first hops AppBlock -> AppListing to find the id the seat would live under.
+    // Default null = "this block has no store listing", which is the fail-closed answer
+    // these owner-gate cases assert.
+    appListing: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
   },
   dbWrite: {},
 }));

--- a/src/server/routers/app-collaborators.router.ts
+++ b/src/server/routers/app-collaborators.router.ts
@@ -39,14 +39,27 @@ import type { SessionUser } from '~/types/session';
  * invite unacceptable. The author FLAG (a mod floor + the `app-dev-testers` cohort) is
  * the right gate; app ownership is not.
  *
- * ## No input-schema changes anywhere
+ * ## Keyed on the APP LISTING, so it serves BOTH store kinds
  *
- * Every proc here is NEW. No existing proc's input schema is touched by this feature,
- * so released `civitai` CLI versions driving the `AppBlocksSubmit`-scoped listing-media
- * procs are unaffected. None of these procs carries a CLI scope annotation: the CLI has
- * no collaborator commands, and an un-annotated proc implicitly requires
- * `TokenScope.Full`, which a session (or a Full personal key) satisfies via
- * `enforceTokenScope`'s early return. Annotate the day a CLI command needs one.
+ * Every proc takes `appListingId`. Seats are keyed to `AppListing` (see
+ * `app-access.service`'s header) precisely so an OFF-SITE listing — which has no
+ * AppBlock at all — can hold collaborators. What a seat then UNLOCKS is derived from
+ * the listing's kind, not from anything sent over the wire: `getAppEarnings` refuses an
+ * off-site listing with `unsupportedKind`, and the version/git surface is block-keyed
+ * so it is unreachable for one by construction.
+ *
+ * ## No PRE-EXISTING input schema is changed
+ *
+ * Every proc here is NEW AND UNCONSUMED, which is what makes re-keying their inputs
+ * from `appBlockId` to `appListingId` a non-event: no released `civitai` CLI version
+ * and no shipped client calls `appCollaborators.*`. The `AppBlocksSubmit`-scoped
+ * listing-media procs that the CLI DOES drive are untouched — `app-collaborator.cli-
+ * contract.test.ts` pins their schemas so the distinction is proven, not asserted.
+ *
+ * None of these procs carries a CLI scope annotation: the CLI has no collaborator
+ * commands, and an un-annotated proc implicitly requires `TokenScope.Full`, which a
+ * session (or a Full personal key) satisfies via `enforceTokenScope`'s early return.
+ * Annotate the day a CLI command needs one.
  */
 
 const enforceAppBlocksAuthorFlag = middleware(async ({ ctx, next }) => {
@@ -116,7 +129,7 @@ export const appCollaboratorsRouter = router({
       );
       return run(() =>
         inviteCollaborator({
-          appBlockId: input.appBlockId,
+          appListingId: input.appListingId,
           targetUserId: input.targetUserId,
           actorUserId: ctx.user!.id,
         })
@@ -132,7 +145,7 @@ export const appCollaboratorsRouter = router({
       );
       return run(() =>
         removeCollaborator({
-          appBlockId: input.appBlockId,
+          appListingId: input.appListingId,
           targetUserId: input.targetUserId,
           actorUserId: ctx.user!.id,
         })
@@ -157,7 +170,7 @@ export const appCollaboratorsRouter = router({
       const { respondToInvite } = await import('~/server/services/blocks/app-collaborator.service');
       return run(() =>
         respondToInvite({
-          appBlockId: input.appBlockId,
+          appListingId: input.appListingId,
           userId: ctx.user!.id,
           accept: input.accept,
         })
@@ -170,7 +183,7 @@ export const appCollaboratorsRouter = router({
     .input(leaveAppSchema)
     .mutation(async ({ ctx, input }) => {
       const { leaveApp } = await import('~/server/services/blocks/app-collaborator.service');
-      return run(() => leaveApp({ appBlockId: input.appBlockId, userId: ctx.user!.id }));
+      return run(() => leaveApp({ appListingId: input.appListingId, userId: ctx.user!.id }));
     }),
 
   /**
@@ -187,7 +200,7 @@ export const appCollaboratorsRouter = router({
       );
       return run(() =>
         setCollaboratorDisplayed({
-          appBlockId: input.appBlockId,
+          appListingId: input.appListingId,
           userId: ctx.user!.id,
           displayed: input.displayed,
         })
@@ -236,7 +249,7 @@ export const appCollaboratorsRouter = router({
       );
       return run(() =>
         listCollaborators({
-          appBlockId: input.appBlockId,
+          appListingId: input.appListingId,
           viewerUserId: ctx.user?.id ?? null,
           isModerator: !!ctx.user?.isModerator,
         })
@@ -249,9 +262,13 @@ export const appCollaboratorsRouter = router({
    * 🔴 NOT a widening of `blocks.getMyRevenue`. That proc is keyed on the snapshotted
    * `appOwnerUserId` and is USER-WIDE; reusing it for an editor (by passing the
    * owner's id) would return the owner's ENTIRE PORTFOLIO. This one resolves the
-   * caller's role on THIS app and filters by `appBlockId` + the app's CURRENT owner.
-   * Returns an explicit `notPermitted` rather than a zero, so a caller can never read
-   * "no access" as "earned nothing".
+   * caller's role on THIS listing and filters by its `appBlockId` + the app's CURRENT
+   * owner. Returns an explicit `notPermitted` rather than a zero, so a caller can never
+   * read "no access" as "earned nothing".
+   *
+   * 🔴 ON-SITE ONLY, returning `unsupportedKind` for an off-site listing.
+   * `BlockBuzzAttribution` is keyed on `appBlockId`, which an off-site listing does not
+   * have — so there is nothing to sum, and a zeroed summary would be a lie.
    */
   getAppEarnings: appDeveloperProcedure
     .input(getAppEarningsSchema)
@@ -261,7 +278,7 @@ export const appCollaboratorsRouter = router({
       );
       return run(() =>
         getAppEarnings({
-          appBlockId: input.appBlockId,
+          appListingId: input.appListingId,
           userId: ctx.user!.id,
           from: input.from ? new Date(input.from) : undefined,
           to: input.to ? new Date(input.to) : undefined,
@@ -293,7 +310,7 @@ export const appCollaboratorsRouter = router({
       );
       return run(() =>
         initiateTransfer({
-          appBlockId: input.appBlockId,
+          appListingId: input.appListingId,
           toUserId: input.toUserId,
           actorUserId: ctx.user!.id,
         })
@@ -341,7 +358,7 @@ export const appCollaboratorsRouter = router({
         '~/server/services/blocks/app-ownership-transfer.service'
       );
       return run(() =>
-        getPendingTransfer({ appBlockId: input.appBlockId, viewerUserId: ctx.user!.id })
+        getPendingTransfer({ appListingId: input.appListingId, viewerUserId: ctx.user!.id })
       );
     }),
 });

--- a/src/server/schema/blocks/app-collaborator.schema.ts
+++ b/src/server/schema/blocks/app-collaborator.schema.ts
@@ -12,46 +12,52 @@ import { z } from 'zod';
  * changing an INPUT SCHEMA breaks them. `app-collaborator.cli-contract.test.ts`
  * asserts every `listingMediaCliScope`-annotated proc's schema shape is unchanged.
  *
- * `appBlockId` bounds mirror the rest of the App Blocks surface (`min(1).max(64)`) so
+ * 🔴 THE KEY CHANGED FROM `appBlockId` TO `appListingId`, and that is only safe because
+ * every proc in `appCollaborators.*` is NEW AND UNCONSUMED — no released CLI version
+ * and no shipped client calls any of them. The pre-existing listing/media/submit
+ * schemas are NOT touched by this change; the cli-contract test is what proves the
+ * distinction rather than asserting it.
+ *
+ * `appListingId` bounds mirror the rest of the App Blocks surface (`min(1).max(64)`) so
  * a request-size guard is consistent across routers.
  */
 
-const appBlockId = z.string().min(1).max(64);
+const appListingId = z.string().min(1).max(64);
 /** A civitai `User.id`. Positive int — the FK would reject anything else anyway. */
 const userId = z.number().int().positive();
 
 export const inviteAppCollaboratorSchema = z.object({
-  appBlockId,
+  appListingId,
   targetUserId: userId,
 });
 export type InviteAppCollaboratorInput = z.infer<typeof inviteAppCollaboratorSchema>;
 
 export const respondToAppInviteSchema = z.object({
-  appBlockId,
+  appListingId,
   accept: z.boolean(),
 });
 export type RespondToAppInviteInput = z.infer<typeof respondToAppInviteSchema>;
 
 export const removeAppCollaboratorSchema = z.object({
-  appBlockId,
+  appListingId,
   targetUserId: userId,
 });
 export type RemoveAppCollaboratorInput = z.infer<typeof removeAppCollaboratorSchema>;
 
-export const leaveAppSchema = z.object({ appBlockId });
+export const leaveAppSchema = z.object({ appListingId });
 export type LeaveAppInput = z.infer<typeof leaveAppSchema>;
 
 export const setCollaboratorDisplayedSchema = z.object({
-  appBlockId,
+  appListingId,
   displayed: z.boolean(),
 });
 export type SetCollaboratorDisplayedInput = z.infer<typeof setCollaboratorDisplayedSchema>;
 
-export const listAppCollaboratorsSchema = z.object({ appBlockId });
+export const listAppCollaboratorsSchema = z.object({ appListingId });
 export type ListAppCollaboratorsInput = z.infer<typeof listAppCollaboratorsSchema>;
 
 export const initiateAppTransferSchema = z.object({
-  appBlockId,
+  appListingId,
   toUserId: userId,
 });
 export type InitiateAppTransferInput = z.infer<typeof initiateAppTransferSchema>;
@@ -61,11 +67,11 @@ export const transferIdSchema = z.object({
 });
 export type TransferIdInput = z.infer<typeof transferIdSchema>;
 
-export const getPendingAppTransferSchema = z.object({ appBlockId });
+export const getPendingAppTransferSchema = z.object({ appListingId });
 export type GetPendingAppTransferInput = z.infer<typeof getPendingAppTransferSchema>;
 
 export const getAppEarningsSchema = z.object({
-  appBlockId,
+  appListingId,
   from: z.string().datetime().optional(),
   to: z.string().datetime().optional(),
 });

--- a/src/server/services/__tests__/appBlockReview.collaborator-self-review.test.ts
+++ b/src/server/services/__tests__/appBlockReview.collaborator-self-review.test.ts
@@ -39,6 +39,11 @@ vi.mock('~/server/utils/cache-helpers', () => ({ bustCacheTag: vi.fn(async () =>
 const { upsertAppBlockReview } = await import('~/server/services/appBlockReview.service');
 
 const APP = 'ab_app1';
+/**
+ * 🔴 The block's STORE LISTING. Seats are keyed here since the block→listing re-key, so
+ * the insider read hops `AppBlock → AppListing → app_collaborators`.
+ */
+const LISTING = 'apl_live';
 const OWNER = 10;
 const ACCEPTED_EDITOR = 20;
 const HIDDEN_EDITOR = 21; // accepted, displayed:false
@@ -47,19 +52,26 @@ const REJECTED_INVITEE = 40;
 const OUTSIDER = 50;
 
 const SEATS = [
-  { userId: ACCEPTED_EDITOR, status: 'accepted', displayed: true },
-  { userId: HIDDEN_EDITOR, status: 'accepted', displayed: false },
-  { userId: PENDING_INVITEE, status: 'pending', displayed: true },
-  { userId: REJECTED_INVITEE, status: 'rejected', displayed: true },
+  { appListingId: LISTING, userId: ACCEPTED_EDITOR, status: 'accepted', displayed: true },
+  { appListingId: LISTING, userId: HIDDEN_EDITOR, status: 'accepted', displayed: false },
+  { appListingId: LISTING, userId: PENDING_INVITEE, status: 'pending', displayed: true },
+  { appListingId: LISTING, userId: REJECTED_INVITEE, status: 'rejected', displayed: true },
 ];
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockDb.appBlock.findUnique.mockResolvedValue({ app: { userId: OWNER } });
+  mockDb.appBlock.findUnique.mockResolvedValue({
+    app: { userId: OWNER },
+    appListing: { id: LISTING },
+  });
   mockDb.appCollaborator.findMany.mockImplementation(async (args: unknown) => {
-    const w = (args as { where: { status?: string; displayed?: boolean } }).where;
+    const w = (args as { where: { appListingId?: string; status?: string; displayed?: boolean } })
+      .where;
     return SEATS.filter(
       (r) =>
+        // 🔴 Honouring `appListingId` is load-bearing: without it the insider set would
+        // be satisfied by seats on ANY listing and the hop would be untested.
+        (w.appListingId === undefined || r.appListingId === w.appListingId) &&
         (w.status === undefined || r.status === w.status) &&
         (w.displayed === undefined || r.displayed === w.displayed)
     ).map((r) => ({ userId: r.userId }));
@@ -116,5 +128,24 @@ describe('upsertAppBlockReview — the insider set', () => {
     );
     await expect(review(OWNER)).rejects.toThrow('You cannot review your own app');
     await expect(review(ACCEPTED_EDITOR)).resolves.toBeTruthy();
+  });
+
+  it('🔴 a block with NO store listing has an OWNER-ONLY insider set (nothing to seat on)', async () => {
+    // A first-version app pending approval has no `AppListing` row yet, so there is no
+    // id under which a seat could exist. The gate must still refuse the owner, and must
+    // not throw trying to key a query on `undefined`.
+    mockDb.appBlock.findUnique.mockResolvedValue({ app: { userId: OWNER }, appListing: null });
+    await expect(review(OWNER)).rejects.toThrow('You cannot review your own app');
+    await expect(review(ACCEPTED_EDITOR)).resolves.toBeTruthy();
+    expect(mockDb.appCollaborator.findMany).not.toHaveBeenCalled();
+  });
+
+  it('🔴 the seat query is keyed on the block’s LISTING, not on the block', async () => {
+    // The hop, asserted directly. A query still keyed on `appBlockId` would match no
+    // fixture row and every insider would silently become a permitted reviewer.
+    await review(OUTSIDER);
+    expect(mockDb.appCollaborator.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { appListingId: LISTING, status: 'accepted' } })
+    );
   });
 });

--- a/src/server/services/blocks/__tests__/app-access.call-site-ledger.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.call-site-ledger.test.ts
@@ -113,7 +113,12 @@ const GATE_LEDGER: Record<string, string> = {
     'THE predicate itself — resolveAppAccess / resolveListingAccess / ' +
     'resolveAccessibleAppBlockIds — plus capabilitiesForKind, the derived per-KIND ' +
     'capability table. Every other site delegates here. Seats are keyed to AppListing ' +
-    'so an offsite listing can hold collaborators.',
+    'so an offsite listing can hold collaborators. 🔴 BOTH resolvers report the CANONICAL ' +
+    'owner (`appBlock.app.userId ?? listing.userId`), never the denormalized ' +
+    'AppListing.userId alone: acceptTransfer’s onsite step 3 is unguarded and treats a ' +
+    '0-count as an accepted desync, so the copy can be stale — and a stale copy inverts ' +
+    'every gate that delegates here, refusing the real owner while admitting the name ' +
+    'the row happens to carry.',
   'src/server/services/blocks/app-collaborator.service.ts':
     'assertOwner — seat management is OWNER-ONLY by product decision (an editor is a ' +
     'co-owner in every respect EXCEPT managing collaborators and initiating a ' +
@@ -193,7 +198,24 @@ const KIND_CAPABILITY_LEDGER: Record<string, string> = {
   'src/server/services/blocks/app-collaborator-earnings.service.ts':
     'CONSUMES `earnings`. Refuses an offsite listing with an explicit unsupportedKind ' +
     'before running any aggregate — never a zeroed summary, which would be ' +
-    'indistinguishable from "this app earned nothing".',
+    'indistinguishable from "this app earned nothing". The kind clause and the ' +
+    'appBlockId clause are OR-ed and each refuses alone: they disagree on an offsite ' +
+    'listing that HAS a block, and on an onsite listing that has none. Collaborators: ' +
+    'an accepted editor sees the same refusal as the owner — it is the KIND, not the seat.',
+  'src/server/services/blocks/app-collaborator.service.ts':
+    'CONSUMES `submitVersion` via `hasWritableRepo`, the ONE predicate behind the ' +
+    'Forgejo grant (accept) and both revokes (remove / leave). Gated on KIND rather ' +
+    'than on `blockSlug != null`, because `mapAppBlockToListing` can mint an OFFSITE ' +
+    'listing that carries a backing AppBlock and therefore a repo slug — a slug-only ' +
+    'gate would mint repo write for a collaborator on a listing whose kind declares no ' +
+    'version surface at all. Collaborators: an off-site seat decision never reaches ' +
+    'Forgejo, in either direction.',
+  'src/server/services/blocks/app-ownership-transfer.service.ts':
+    'CONSUMES `submitVersion` for acceptTransfer’s post-commit repo swap, so that gate ' +
+    'uses the SAME predicate as step (2)’s ownership write. They used to differ ' +
+    '(kind vs blockSlug nullness) and disagreed on an offsite-with-a-block listing, ' +
+    'where the function left the OauthClient alone while swapping Forgejo write. ' +
+    'Collaborators: seats are untouched by a transfer — the listing keeps its editors.',
 };
 
 /**
@@ -201,10 +223,15 @@ const KIND_CAPABILITY_LEDGER: Record<string, string> = {
  * runtime branch, and that is worth writing down because it looks like a missing entry:
  * the version/manifest/repo procs (`getMyAppRepo`, `getMyAppManifest`, `updateManifest`,
  * `getMyForgejoCloneInfo`) are keyed on an `appBlockId`, which an off-site listing does
- * not have. There is no id with which to call them. The seat-lifecycle service's Forgejo
- * grant/revoke is conditioned on the listing having a backing AppBlock for the same
- * reason, and that condition is pinned behaviourally in
- * `app-collaborator.service.test.ts` ("Forgejo is ON-SITE ONLY").
+ * not have. There is no id with which to call them.
+ *
+ * 🔴 The seat-lifecycle service's Forgejo grant/revoke is a RUNTIME branch, and it now
+ * appears in the ledger above because it asks `listingKindSupports(kind,'submitVersion')`
+ * rather than "is there a backing AppBlock". Those are not the same predicate — an
+ * OFFSITE listing can carry a block — and the difference is pinned behaviourally in
+ * `app-collaborator.service.test.ts` ("an OFF-SITE listing that HAS a repo slug still
+ * reaches Forgejo NEVER") and in `app-ownership-transfer.service.test.ts` for the accept
+ * path's repo swap.
  */
 
 /**
@@ -365,6 +392,12 @@ describe('app-ownership gate ledger', () => {
       // The seat-lifecycle service reads its OWN rows (roster + inbox + cap), which is
       // management, not an access decision — it must NOT filter on accepted.
       'src/server/services/blocks/app-collaborator.service.ts',
+      // 🔴 The MOD claim remedy reads every seat on the claimed listing in order to
+      // DELETE them all and audit each by user id. Deliberately UNFILTERED by status: a
+      // pending invite is as much of the impersonator's residue as an accepted seat, and
+      // leaving it would let them re-enter by having their invitee accept afterwards.
+      // This is the one legitimate seat read that must NOT carry the consent filter.
+      'src/server/services/blocks/offsite-moderation.service.ts',
     ]);
   });
 
@@ -385,7 +418,9 @@ describe('app-ownership gate ledger', () => {
       // A regex nobody has watched match is a claim, not a guard — and a zero here would
       // make every assertion below vacuously true.
       expect(SEAT_CALLS.length).toBeGreaterThan(8);
-      expect(new Set(SEAT_CALLS.map(([f]) => f)).size).toBe(2);
+      // THREE files now: the predicate, the seat lifecycle, and the mod claim remedy
+      // (which deletes an impersonator's seats in the same tx as the reassign).
+      expect(new Set(SEAT_CALLS.map(([f]) => f)).size).toBe(3);
     });
 
     it('every seat query/write names `appListingId`', () => {
@@ -408,7 +443,7 @@ describe('app-ownership gate ledger', () => {
       // `appBlockReview.service.ts` for a completely unrelated (and correct) selector —
       // an assertion that looks like a re-key regression and is not one.
       const seatFiles = [...new Set(SEAT_CALLS.map(([f]) => f))];
-      expect(seatFiles.length).toBe(2);
+      expect(seatFiles.length).toBe(3);
       for (const file of seatFiles) {
         expect(
           CODE.get(file)!,

--- a/src/server/services/blocks/__tests__/app-access.call-site-ledger.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.call-site-ledger.test.ts
@@ -25,6 +25,17 @@ import { describe, expect, it } from 'vitest';
  * Test files are OUT of scope on purpose: a test may legitimately compare a userId for
  * any reason.
  *
+ * ## 🔴 THE SECOND POPULATION, added with the block→listing re-key
+ *
+ * A gate answering "may this caller act?" is now only half the question. Since seats are
+ * keyed to `AppListing`, an OFF-SITE listing can hold them — and what a seat UNLOCKS is
+ * DERIVED from the listing's `kind` (`capabilitiesForKind`). That derivation is a second
+ * decayable set: a new site that hard-codes "editors get earnings" instead of consulting
+ * the table would hand an off-site editor a capability the schema cannot support, and no
+ * gate ledger would notice, because no gate would have changed. So {@link
+ * KIND_CAPABILITY_LEDGER} enumerates every consumer of the capability table with the
+ * same fails-on-GROWTH-and-SHRINK property.
+ *
  * ## The disagreements this ledger records rather than normalises
  *
  * Consolidating these predicates surfaced four genuine inconsistencies between sites
@@ -80,7 +91,10 @@ const GATE_LEDGER: Record<string, string> = {
   'src/server/services/blocks/app-analytics.service.ts':
     'getOwnedAppBlocks resolves the permitted-id SET (owned + seated) instead of ' +
     '`app: { userId }`. Safe to widen HERE because every downstream aggregate filters ' +
-    'appBlockId IN thatSet — unlike the appOwnerUserId-keyed earnings reads.',
+    'appBlockId IN thatSet — unlike the appOwnerUserId-keyed earnings reads. Since the ' +
+    'listing re-key an OFF-SITE seat contributes no block id to that set (it has no ' +
+    'block), so this read is unchanged for offsite: analytics for an offsite listing is ' +
+    'AppListingMetric, a different surface, not this block-scoped one.',
   'src/server/services/appBlockReview.service.ts':
     'The self-review exclusion is widened to the INSIDER set (owner + accepted ' +
     'collaborators, regardless of `displayed`) so a collaborator cannot 5-star the app ' +
@@ -89,10 +103,17 @@ const GATE_LEDGER: Record<string, string> = {
     'loadOwnedListingInTx (unpublish/republish own listing) and ' +
     'listMyListingModerationEvents are NOT widened: unpublishing a live listing and ' +
     'reading its moderation history are OWNER-scoped lifecycle actions, not content ' +
-    'editing. Kept strictly owner-only, no mod bypass (D1).',
+    'editing. Kept strictly owner-only, no mod bypass (D1). 🔴 claimListing ALSO lives ' +
+    'here and writes AppListing.userId for offsite — the same column acceptTransfer now ' +
+    'moves. They are reconciled, not merged: claim is a MOD remedy gated on ' +
+    'status IN (approved,removed); the transfer is owner-initiated + recipient-consented ' +
+    'and its offsite write is guarded on userId = the snapshotted fromUserId, so a claim ' +
+    'landing in the window makes the accept fail closed instead of undoing the remedy.',
   'src/server/services/blocks/app-access.service.ts':
     'THE predicate itself — resolveAppAccess / resolveListingAccess / ' +
-    'resolveAccessibleAppBlockIds. Every other site delegates here.',
+    'resolveAccessibleAppBlockIds — plus capabilitiesForKind, the derived per-KIND ' +
+    'capability table. Every other site delegates here. Seats are keyed to AppListing ' +
+    'so an offsite listing can hold collaborators.',
   'src/server/services/blocks/app-collaborator.service.ts':
     'assertOwner — seat management is OWNER-ONLY by product decision (an editor is a ' +
     'co-owner in every respect EXCEPT managing collaborators and initiating a ' +
@@ -102,15 +123,19 @@ const GATE_LEDGER: Record<string, string> = {
     'holder opted OUT of the public byline, plus invitedBy and timestamps, so it is not ' +
     'a public read. A pending invitee reads their own invite via listMyPendingInvites.',
   'src/server/services/blocks/app-ownership-transfer.service.ts':
-    'loadOwnedApp — initiating a transfer is OWNER-ONLY, same reasoning as seat ' +
+    'loadOwnedListing — initiating a transfer is OWNER-ONLY, same reasoning as seat ' +
     'management. Accept is gated on being the transfer’s ADDRESSEE, not on any role, ' +
     'and re-reads bannedAt in-tx on the primary. getPendingTransfer resolves the caller ' +
     'and returns the row only to the OWNER or the ADDRESSEE — null (never FORBIDDEN) to ' +
     'anyone else, so the read cannot become an existence oracle. Editors are excluded: ' +
-    'disposing of the app is the one capability a seat never carries.',
+    'disposing of the listing is the one capability a seat never carries. 🔴 KIND-AWARE: ' +
+    'onsite moves OauthClient.userId + AppListing.userId; offsite moves the listing ' +
+    'column ONLY and is REFUSED outright when the listing carries a connectClientId.',
   'src/server/services/blocks/app-collaborator-earnings.service.ts':
     'The app-scoped money read: resolves the role FIRST and filters by appBlockId + the ' +
-    'CURRENT owner. Never appOwnerUserId alone — that is the portfolio leak.',
+    'CURRENT owner. Never appOwnerUserId alone — that is the portfolio leak. 🔴 Also the ' +
+    'KIND gate: earnings are block-scoped, so an offsite listing is refused with an ' +
+    'explicit unsupportedKind rather than a zeroed summary.',
   'src/server/services/blocks/app-listing-mapper.ts':
     'Reads ab.app.userId to STAMP the listing’s denormalized owner at creation. Not an ' +
     'access gate — no caller identity is involved — but listed so the ownership-write ' +
@@ -147,6 +172,40 @@ const GATE_LEDGER: Record<string, string> = {
     'opened to non-mod authors it becomes a slug-hijack vector and needs an explicit ' +
     'owner (or collaborator) check.',
 };
+
+/**
+ * 🔴 THE KIND-CAPABILITY POPULATION — every production site that decides what a seat
+ * unlocks by consulting the derived table, mapped to WHICH capability it reads.
+ *
+ * Why a second ledger rather than more rows in the first: these are not access gates.
+ * They answer "can a listing of this KIND do X at all?", which is a question about the
+ * schema, not about the caller — and it is a question that did not exist before off-site
+ * listings could hold seats. A new consumer that hard-codes the answer instead of asking
+ * would be invisible to `GATE_LEDGER`, because it would open no new gate.
+ */
+const KIND_CAPABILITY_LEDGER: Record<string, string> = {
+  'src/server/services/blocks/app-access.service.ts':
+    'DEFINES the table (CAPABILITIES_BY_KIND / capabilitiesForKind / ' +
+    'listingKindSupports) and resolves each listing’s kind + appBlockId. The two false ' +
+    'cells — earnings and submitVersion on offsite — are STRUCTURAL: BlockBuzzAttribution ' +
+    'is keyed on appBlockId, and an offsite listing has no bundle and no Forgejo repo. An ' +
+    'unknown kind falls back to the NARROWER (offsite) row, i.e. fail closed.',
+  'src/server/services/blocks/app-collaborator-earnings.service.ts':
+    'CONSUMES `earnings`. Refuses an offsite listing with an explicit unsupportedKind ' +
+    'before running any aggregate — never a zeroed summary, which would be ' +
+    'indistinguishable from "this app earned nothing".',
+};
+
+/**
+ * The other half of `submitVersion: false` is enforced STRUCTURALLY rather than by a
+ * runtime branch, and that is worth writing down because it looks like a missing entry:
+ * the version/manifest/repo procs (`getMyAppRepo`, `getMyAppManifest`, `updateManifest`,
+ * `getMyForgejoCloneInfo`) are keyed on an `appBlockId`, which an off-site listing does
+ * not have. There is no id with which to call them. The seat-lifecycle service's Forgejo
+ * grant/revoke is conditioned on the listing having a backing AppBlock for the same
+ * reason, and that condition is pinned behaviourally in
+ * `app-collaborator.service.test.ts` ("Forgejo is ON-SITE ONLY").
+ */
 
 /**
  * The ownership predicates, in every spelling that appears in production.
@@ -307,5 +366,115 @@ describe('app-ownership gate ledger', () => {
       // management, not an access decision — it must NOT filter on accepted.
       'src/server/services/blocks/app-collaborator.service.ts',
     ]);
+  });
+
+  // -------------------------------------------------------------------------
+  // 🔴 THE RE-KEY, pinned structurally.
+  // -------------------------------------------------------------------------
+
+  describe('🔴 seats are keyed to the LISTING, everywhere', () => {
+    /** Every `appCollaborator.<op>(` occurrence in production, with its call text. */
+    const SEAT_CALLS: Array<[string, string]> = [];
+    for (const [file, src] of CODE) {
+      const re = /appCollaborator\.\w+\(/g;
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(src))) SEAT_CALLS.push([file, src.slice(m.index, m.index + 300)]);
+    }
+
+    it('POSITIVE CONTROL: the scan found the seat calls at all', () => {
+      // A regex nobody has watched match is a claim, not a guard — and a zero here would
+      // make every assertion below vacuously true.
+      expect(SEAT_CALLS.length).toBeGreaterThan(8);
+      expect(new Set(SEAT_CALLS.map(([f]) => f)).size).toBe(2);
+    });
+
+    it('every seat query/write names `appListingId`', () => {
+      // The one-line regression this change could suffer: a call left keyed on
+      // `appBlockId` would compile (both are strings) and would silently match NOTHING —
+      // demoting every editor to no-access with no error anywhere.
+      for (const [file, call] of SEAT_CALLS) {
+        expect(call, `${file}: a seat call must be keyed on appListingId`).toMatch(
+          /appListingId/
+        );
+      }
+    });
+
+    it('the OLD composite seat key `appBlockId_userId` is gone from the seat files', () => {
+      // The Prisma selector for the pre-re-key primary key `(appBlockId, userId)`.
+      //
+      // 🔴 SCOPED TO THE SEAT FILES ON PURPOSE, and the reason is a genuine collision:
+      // `AppBlockReview` carries its OWN `@@unique([appBlockId, userId])`, which Prisma
+      // ALSO names `appBlockId_userId`. A repo-wide ban on the string would fail on
+      // `appBlockReview.service.ts` for a completely unrelated (and correct) selector —
+      // an assertion that looks like a re-key regression and is not one.
+      const seatFiles = [...new Set(SEAT_CALLS.map(([f]) => f))];
+      expect(seatFiles.length).toBe(2);
+      for (const file of seatFiles) {
+        expect(
+          CODE.get(file)!,
+          `${file} still uses the pre-re-key composite seat key`
+        ).not.toContain('appBlockId_userId');
+      }
+    });
+
+    it('NEGATIVE CONTROL: the composite-key probe CAN match', () => {
+      // Proves the assertion above is testing a string that would be found if present.
+      expect('where: { appBlockId_userId: { appBlockId, userId } }').toContain(
+        'appBlockId_userId'
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 🔴 THE KIND-CAPABILITY POPULATION.
+  // -------------------------------------------------------------------------
+
+  describe('🔴 kind-derived capabilities — the second closed population', () => {
+    const CAP_RE = /listingKindSupports|capabilitiesForKind|CAPABILITIES_BY_KIND/;
+    const CAP_SITES = FILES.filter((f) => CAP_RE.test(CODE.get(f)!)).sort();
+
+    it('POSITIVE CONTROL: CAP_RE matches every spelling that appears in production', () => {
+      const SHAPES: Array<[string, string]> = [
+        ['the predicate', "if (!listingKindSupports(access.kind, 'earnings')) return x;"],
+        ['the whole row', 'const caps = capabilitiesForKind(listing.kind);'],
+        ['the table itself', 'CAPABILITIES_BY_KIND[kind] ?? CAPABILITIES_BY_KIND.offsite'],
+      ];
+      for (const [label, sample] of SHAPES) {
+        expect(CAP_RE.test(sample), `CAP_RE must recognise: ${label}`).toBe(true);
+      }
+      expect(CAP_SITES.length).toBeGreaterThan(0);
+    });
+
+    it('NEGATIVE CONTROL: an unrelated kind comparison is not a capability site', () => {
+      // `kind === 'offsite'` appears all over the listing services for reasons that have
+      // nothing to do with what a SEAT unlocks; sweeping those in would make the ledger
+      // unmaintainable noise.
+      expect(CAP_RE.test("if (row.kind === 'onsite' && row.appBlock == null) return null;")).toBe(
+        false
+      );
+    });
+
+    it('the set of capability consumers EXACTLY equals the ledger (GROWTH and SHRINK)', () => {
+      // A new site that hard-codes "editors get earnings" instead of asking the table
+      // would hand an off-site editor a capability the schema cannot support — and would
+      // open no gate, so GATE_LEDGER would stay green through it.
+      expect(CAP_SITES).toEqual(Object.keys(KIND_CAPABILITY_LEDGER).sort());
+    });
+
+    it('every capability-ledger entry names the capability it reads', () => {
+      for (const [file, rationale] of Object.entries(KIND_CAPABILITY_LEDGER)) {
+        expect(rationale.length, `${file} rationale is too terse`).toBeGreaterThan(80);
+        expect(
+          /earnings|submitVersion|analytics|listingContent|submitForReview/.test(rationale),
+          `${file} must name which capability it consumes`
+        ).toBe(true);
+      }
+    });
+
+    it('every capability-ledger entry names an actual file in the scanned population', () => {
+      for (const file of Object.keys(KIND_CAPABILITY_LEDGER)) {
+        expect(CODE.get(file), `${file} is not in the scanned population`).toBeDefined();
+      }
+    });
   });
 });

--- a/src/server/services/blocks/__tests__/app-access.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.service.test.ts
@@ -434,16 +434,163 @@ describe('resolveListingAccess — role × KIND', () => {
   });
 });
 
+/**
+ * 🔴 THE OWNER AXIS — `resolveListingAccess.ownerUserId` must be the CANONICAL owner.
+ *
+ * For an ON-SITE listing the owner is `OauthClient.userId`, reached as
+ * `AppListing.appBlock.app.userId`. `AppListing.userId` is a DENORMALIZED COPY, and this
+ * feature's own code can leave it stale on purpose: `acceptTransfer` step 3 is unguarded
+ * for onsite and treats a 0-count as an accepted desync
+ * (`app-ownership-transfer.service.ts`), so a listing whose OauthClient moved but whose
+ * column did not is a state the code can produce itself.
+ *
+ * Reading the copy inverts the gate in BOTH directions at once, which is why the fixture
+ * below pins both: the REAL owner is refused on their own listing, and the STALE user is
+ * admitted as owner — with the roster (including `displayed:false` seats, `invitedBy` and
+ * the timestamps) and the pending-transfer read behind that gate.
+ */
+describe('🔴 resolveListingAccess — ownerUserId is CANONICAL, not the denormalized column', () => {
+  /** The real owner (OauthClient.userId) and the stale name left in the column. */
+  const REAL_OWNER = 111;
+  const STALE_OWNER = 222;
+
+  /** An onsite listing whose denormalized `userId` DISAGREES with its OauthClient. */
+  function driftedOnsite(over: Record<string, unknown> = {}) {
+    return {
+      id: LISTING,
+      userId: STALE_OWNER,
+      kind: 'onsite',
+      appBlockId: APP,
+      revisionOfId: null,
+      revisionOf: null,
+      appBlock: { app: { userId: REAL_OWNER } },
+      ...over,
+    };
+  }
+
+  it('POSITIVE CONTROL: with no drift, both sources agree and the owner resolves', async () => {
+    // If this failed, every assertion below would be about a broken fixture rather than
+    // about the resolution rule.
+    mockDb.appListing.findUnique.mockResolvedValue({
+      ...driftedOnsite(),
+      userId: REAL_OWNER,
+    });
+    const res = await resolveListingAccess(LISTING, REAL_OWNER);
+    expect(res?.ownerUserId).toBe(REAL_OWNER);
+    expect(res?.role).toBe('owner');
+  });
+
+  it('🔴 the REAL owner is `owner` even though the column names someone else', async () => {
+    mockDb.appListing.findUnique.mockResolvedValue(driftedOnsite());
+    const res = await resolveListingAccess(LISTING, REAL_OWNER);
+    expect(res?.ownerUserId).toBe(REAL_OWNER);
+    expect(res?.role).toBe('owner');
+  });
+
+  it('🔴 the STALE user named by the column is NOT the owner', async () => {
+    // The other half, and the one that matters for the roster leak: whoever the stale
+    // row names must not be handed owner-level reads on someone else's listing.
+    mockDb.appListing.findUnique.mockResolvedValue(driftedOnsite());
+    const res = await resolveListingAccess(LISTING, STALE_OWNER);
+    expect(res?.ownerUserId).toBe(REAL_OWNER);
+    expect(res?.role).toBeNull();
+  });
+
+  it('an OFFSITE listing keeps using the column — there is no OauthClient in the chain', async () => {
+    // The fallback is not a lenience; for offsite the column IS the owner, so this pins
+    // that the fix did not quietly break the kind it does not apply to.
+    mockDb.appListing.findUnique.mockResolvedValue({ ...offsiteListing(), appBlock: null });
+    const res = await resolveListingAccess(OFFSITE, OWNER);
+    expect(res?.ownerUserId).toBe(OWNER);
+    expect(res?.role).toBe('owner');
+  });
+
+  it('an onsite block with a DANGLING app_id falls back to the column', async () => {
+    // `appBlock.app` is null when `app_id` points at nothing. Falling through to the
+    // column is the only owner signal left; the alternative (null) would lock the
+    // listing's real owner out of it entirely.
+    mockDb.appListing.findUnique.mockResolvedValue(driftedOnsite({ appBlock: { app: null } }));
+    const res = await resolveListingAccess(LISTING, STALE_OWNER);
+    expect(res?.ownerUserId).toBe(STALE_OWNER);
+    expect(res?.role).toBe('owner');
+  });
+
+  it('🔴 a SHADOW resolves the owner from its PARENT’s block, not from its own row', async () => {
+    // A shadow carries `appBlockId: null` by construction, so reading the block off the
+    // shadow would silently fall back to the column for every in-flight revision — i.e.
+    // re-introduce the whole defect on exactly the rows an editor is working on.
+    mockDb.appListing.findUnique.mockResolvedValue({
+      id: SHADOW,
+      userId: STALE_OWNER,
+      kind: 'onsite',
+      appBlockId: null,
+      revisionOfId: LISTING,
+      appBlock: null,
+      revisionOf: {
+        id: LISTING,
+        kind: 'onsite',
+        appBlockId: APP,
+        appBlock: { app: { userId: REAL_OWNER } },
+      },
+    });
+    const res = await resolveListingAccess(SHADOW, REAL_OWNER);
+    expect(res?.seatListingId).toBe(LISTING);
+    expect(res?.ownerUserId).toBe(REAL_OWNER);
+    expect(res?.role).toBe('owner');
+    expect((await resolveListingAccess(SHADOW, STALE_OWNER))?.role).toBeNull();
+  });
+
+  it('🔴 STRUCTURAL: the listing query SELECTS the canonical owner on both the row and its parent', async () => {
+    // A behavioural assertion alone cannot tell "resolved from the block" from "the fake
+    // happened to return the same number"; this pins that the column is actually asked
+    // for, on both sides of the shadow hop.
+    mockDb.appListing.findUnique.mockResolvedValue(driftedOnsite());
+    await resolveListingAccess(LISTING, REAL_OWNER);
+    const args = mockDb.appListing.findUnique.mock.calls[0][0] as {
+      select: {
+        appBlock?: { select: { app: { select: { userId: boolean } } } };
+        revisionOf?: {
+          select: { appBlock?: { select: { app: { select: { userId: boolean } } } } };
+        };
+      };
+    };
+    expect(args.select.appBlock?.select.app.select.userId).toBe(true);
+    expect(args.select.revisionOf?.select.appBlock?.select.app.select.userId).toBe(true);
+  });
+});
+
 describe('resolveAccessibleAppBlockIds', () => {
   const OTHER = 'ab_app2';
   const OTHER_LISTING = 'apl_other';
+  /**
+   * 🔴 THE SHAPE WHERE "offsite" AND "has no block" DISAGREE — an OFF-SITE listing that
+   * DOES carry a backing AppBlock. It is not hypothetical: `mapAppBlockToListing` mints
+   * exactly this whenever the source AppBlock has an `externalUrl`
+   * (`kind: isOffsite ? 'offsite' : 'onsite'` with `appBlockId: ab.id` unconditionally),
+   * and the mod proc `backfillAppListings` reaches it. `schema.full.prisma` says in as
+   * many words to discriminate on `kind`, never on `appBlockId` nullness.
+   *
+   * Production count today is 0 (measured 2026-08-11: offsite 5 rows, 0 with a block),
+   * so every assertion using this fixture is PREVENTION — but it guards the input to a
+   * money read, so a fixture that cannot express the shape cannot certify the gate.
+   */
+  const OFFSITE_WITH_BLOCK = 'apl_offsite_with_block';
+  const OFFSITE_BLOCK = 'ab_offsiteBlock';
 
-  /** Resolve seated LISTING ids → their backing blocks, honouring the not-null filter. */
-  function wireSeatListings(rows: Array<{ id: string; appBlockId: string | null }>) {
+  /**
+   * Resolve seated LISTING ids → their backing blocks, honouring BOTH filters the
+   * service sends: `kind` and the `appBlockId` not-null.
+   *
+   * 🔴 The fake must honour `kind` INDEPENDENTLY of `appBlockId`, or the two predicates
+   * collapse into one here and the disagreement case becomes untestable through it.
+   */
+  function wireSeatListings(rows: Array<{ id: string; kind: string; appBlockId: string | null }>) {
     mockDb.appListing.findMany.mockImplementation(async (args: unknown): Promise<unknown[]> => {
-      const w = (args as { where: { id: { in: string[] }; appBlockId?: unknown } }).where;
+      const w = (args as { where: { id: { in: string[] }; kind?: string; appBlockId?: unknown } })
+        .where;
       return rows
         .filter((r) => w.id.in.includes(r.id))
+        .filter((r) => (w.kind === undefined ? true : r.kind === w.kind))
         .filter((r) => (w.appBlockId === undefined ? true : r.appBlockId != null))
         .map((r) => ({ appBlockId: r.appBlockId }));
     });
@@ -451,10 +598,65 @@ describe('resolveAccessibleAppBlockIds', () => {
 
   beforeEach(() => {
     wireSeatListings([
-      { id: LISTING, appBlockId: APP },
-      { id: OTHER_LISTING, appBlockId: OTHER },
-      { id: OFFSITE, appBlockId: null },
+      { id: LISTING, kind: 'onsite', appBlockId: APP },
+      { id: OTHER_LISTING, kind: 'onsite', appBlockId: OTHER },
+      { id: OFFSITE, kind: 'offsite', appBlockId: null },
+      { id: OFFSITE_WITH_BLOCK, kind: 'offsite', appBlockId: OFFSITE_BLOCK },
     ]);
+  });
+
+  describe('🔴 the discriminator is `kind`, NOT `appBlockId IS NULL`', () => {
+    it('an OFFSITE seat on a listing that HAS a block still contributes NOTHING', async () => {
+      // The `appBlockId: { not: null }` predicate does not fire here — the row has a
+      // block. Only the `kind: 'onsite'` predicate can refuse it, so this case is the
+      // ONLY one that can kill a mutant which drops that predicate.
+      mockDb.appBlock.findMany.mockResolvedValue([]);
+      wireSeats([
+        { appListingId: OFFSITE_WITH_BLOCK, userId: EDITOR, status: 'accepted', displayed: true },
+      ]);
+      const res = await resolveAccessibleAppBlockIds(EDITOR);
+      expect(res.editorIds).toEqual([]);
+      expect(res.allIds).toEqual([]);
+      // Named explicitly so the failure message says WHICH id leaked.
+      expect(res.allIds).not.toContain(OFFSITE_BLOCK);
+    });
+
+    it('🔴 POSITIVE CONTROL: the SAME block id DOES flow through when the kind is onsite', async () => {
+      // Without this, "contributes nothing" is indistinguishable from a fixture whose
+      // block id was never reachable at all — the same zero, two causes.
+      mockDb.appBlock.findMany.mockResolvedValue([]);
+      wireSeatListings([{ id: OFFSITE_WITH_BLOCK, kind: 'onsite', appBlockId: OFFSITE_BLOCK }]);
+      wireSeats([
+        { appListingId: OFFSITE_WITH_BLOCK, userId: EDITOR, status: 'accepted', displayed: true },
+      ]);
+      expect((await resolveAccessibleAppBlockIds(EDITOR)).allIds).toEqual([OFFSITE_BLOCK]);
+    });
+
+    it('🔴 STRUCTURAL: the listing query carries `kind: onsite` as well as the not-null', async () => {
+      // The behavioural case above is served by a fake; this pins the predicate that is
+      // actually sent to Postgres, so a mutant that moves the filter into memory (where
+      // the next refactor drops it) is still visible.
+      mockDb.appBlock.findMany.mockResolvedValue([]);
+      wireSeats([{ appListingId: LISTING, userId: EDITOR, status: 'accepted', displayed: true }]);
+      await resolveAccessibleAppBlockIds(EDITOR);
+      const args = mockDb.appListing.findMany.mock.calls[0][0] as {
+        where: { kind?: unknown; appBlockId?: unknown };
+      };
+      expect(args.where.kind, 'the KIND discriminator must be in the WHERE').toBe('onsite');
+      expect(args.where.appBlockId).toEqual({ not: null });
+    });
+
+    it('a MIXED portfolio keeps only the onsite seat of THREE', async () => {
+      // onsite+block (kept), offsite+no-block (dropped by either predicate),
+      // offsite+block (dropped by KIND alone).
+      mockDb.appBlock.findMany.mockResolvedValue([]);
+      wireSeats([
+        { appListingId: LISTING, userId: EDITOR, status: 'accepted', displayed: true },
+        { appListingId: OFFSITE, userId: EDITOR, status: 'accepted', displayed: true },
+        { appListingId: OFFSITE_WITH_BLOCK, userId: EDITOR, status: 'accepted', displayed: true },
+      ]);
+      expect((await resolveAccessibleAppBlockIds(EDITOR)).allIds).toEqual([APP]);
+    });
   });
 
   it('an owner gets their owned ids and no editor ids', async () => {

--- a/src/server/services/blocks/__tests__/app-access.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.service.test.ts
@@ -4,7 +4,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  * App Listing COLLABORATORS — the consolidated access predicate.
  *
  * THE PERMISSION MATRIX lives here: role × subject × expected, across
- * owner / accepted editor / PENDING editor / REJECTED editor / stranger / anon.
+ * owner / accepted editor / PENDING editor / REJECTED editor / stranger / anon —
+ * and now, crossed with the listing KIND (onsite | offsite), which is the axis the
+ * block→listing re-key exists to open.
  *
  * All DB deps are mocked (no real Prisma), following the sibling block-service
  * convention: a `vi.hoisted` fake client handed to BOTH `dbRead` and `dbWrite`.
@@ -19,7 +21,10 @@ const { mockDb, mockWriteDb } = vi.hoisted(() => {
       // says nothing about this file and only an explicit test typecheck catches it.
       findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
     },
-    appListing: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    appListing: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    },
     appCollaborator: {
       findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
       findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
@@ -43,35 +48,43 @@ const {
   listAppInsiderUserIds,
   safeCollaboratorQuery,
   assertAppEditAccess,
+  capabilitiesForKind,
+  listingKindSupports,
+  CAPABILITIES_BY_KIND,
 } = await import('~/server/services/blocks/app-access.service');
 
 const APP = 'ab_app1';
+const LISTING = 'apl_live';
+const OFFSITE = 'apl_offsite';
+const SHADOW = 'apl_shadow';
 const OWNER = 10;
 const EDITOR = 20;
 const PENDING = 30;
 const REJECTED = 40;
 const STRANGER = 50;
 
-/** The seat table, as the fixture DB holds it. */
+/** The seat table, as the fixture DB holds it. 🔴 Keyed on the LISTING now. */
 const SEATS = [
-  { appBlockId: APP, userId: EDITOR, status: 'accepted', displayed: true },
-  { appBlockId: APP, userId: PENDING, status: 'pending', displayed: true },
-  { appBlockId: APP, userId: REJECTED, status: 'rejected', displayed: true },
+  { appListingId: LISTING, userId: EDITOR, status: 'accepted', displayed: true },
+  { appListingId: LISTING, userId: PENDING, status: 'pending', displayed: true },
+  { appListingId: LISTING, userId: REJECTED, status: 'rejected', displayed: true },
 ];
 
 /**
- * Drive `appCollaborator.findFirst` from the fixture, HONOURING the `status` filter.
+ * Drive `appCollaborator.findFirst`/`findMany` from the fixture, HONOURING the `status`
+ * filter.
  *
  * 🔴 Load-bearing: a mock that ignored `where.status` would make every consent test
  * pass vacuously — a pending seat would read as accepted and the suite would be green
- * against the exact bug it exists to catch.
+ * against the exact bug it exists to catch. The same goes for `appListingId`: ignoring
+ * it would make the shadow-hop and cross-listing tests meaningless.
  */
 function wireSeats(rows = SEATS) {
   mockDb.appCollaborator.findFirst.mockImplementation(async (args: unknown): Promise<unknown> => {
-    const w = (args as { where: { appBlockId: string; userId: number; status?: string } }).where;
+    const w = (args as { where: { appListingId: string; userId: number; status?: string } }).where;
     const hit = rows.find(
       (r) =>
-        r.appBlockId === w.appBlockId &&
+        r.appListingId === w.appListingId &&
         r.userId === w.userId &&
         (w.status === undefined || r.status === w.status)
     );
@@ -81,7 +94,7 @@ function wireSeats(rows = SEATS) {
     const w = (args as { where: Record<string, unknown> }).where;
     return rows.filter(
       (r) =>
-        (w.appBlockId === undefined || r.appBlockId === w.appBlockId) &&
+        (w.appListingId === undefined || r.appListingId === w.appListingId) &&
         (w.userId === undefined || r.userId === w.userId) &&
         (w.status === undefined || r.status === w.status) &&
         (w.displayed === undefined || r.displayed === w.displayed)
@@ -89,10 +102,93 @@ function wireSeats(rows = SEATS) {
   });
 }
 
+/** An onsite listing row as `resolveListingAccess` selects it. */
+function onsiteListing(over: Record<string, unknown> = {}) {
+  return {
+    id: LISTING,
+    userId: OWNER,
+    kind: 'onsite',
+    appBlockId: APP,
+    revisionOfId: null,
+    revisionOf: null,
+    ...over,
+  };
+}
+
+/** An OFF-SITE listing: no AppBlock anywhere in the chain, and that is normal. */
+function offsiteListing(over: Record<string, unknown> = {}) {
+  return {
+    id: OFFSITE,
+    userId: OWNER,
+    kind: 'offsite',
+    appBlockId: null,
+    revisionOfId: null,
+    revisionOf: null,
+    ...over,
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
-  mockDb.appBlock.findUnique.mockResolvedValue({ id: APP, app: { userId: OWNER } });
+  mockDb.appBlock.findUnique.mockResolvedValue({
+    id: APP,
+    app: { userId: OWNER },
+    appListing: { id: LISTING },
+  });
+  mockDb.appListing.findUnique.mockResolvedValue(onsiteListing());
   wireSeats();
+});
+
+// ---------------------------------------------------------------------------
+// CAPABILITIES — derived from kind, asserted as a table.
+// ---------------------------------------------------------------------------
+
+describe('capabilitiesForKind — capabilities are DERIVED, never configured', () => {
+  it('onsite supports everything', () => {
+    expect(capabilitiesForKind('onsite')).toEqual({
+      listingContent: true,
+      submitForReview: true,
+      analytics: true,
+      earnings: true,
+      submitVersion: true,
+    });
+  });
+
+  it('🔴 offsite supports content / review / analytics but NOT earnings or submit-version', () => {
+    // Both `false` cells are STRUCTURAL: BlockBuzzAttribution is keyed on appBlockId,
+    // and there is no bundle or Forgejo repo. They are not policy toggles.
+    expect(capabilitiesForKind('offsite')).toEqual({
+      listingContent: true,
+      submitForReview: true,
+      analytics: true,
+      earnings: false,
+      submitVersion: false,
+    });
+  });
+
+  it('POSITIVE CONTROL: the two rows genuinely DIFFER (so neither is vacuous)', () => {
+    // If both kinds mapped to the same object, every "offsite refuses X" assertion in
+    // this repo would be a fact about one shared row rather than about the kind axis.
+    expect(CAPABILITIES_BY_KIND.onsite).not.toEqual(CAPABILITIES_BY_KIND.offsite);
+    const differing = (
+      Object.keys(CAPABILITIES_BY_KIND.onsite) as Array<keyof typeof CAPABILITIES_BY_KIND.onsite>
+    ).filter((k) => CAPABILITIES_BY_KIND.onsite[k] !== CAPABILITIES_BY_KIND.offsite[k]);
+    expect(differing.sort()).toEqual(['earnings', 'submitVersion']);
+  });
+
+  it('🔴 an UNKNOWN kind falls back to the NARROWER (offsite) row — fail closed', () => {
+    // A kind this code does not recognise must never be handed the block-only
+    // capabilities. Asserted rather than assumed, because the natural mistake is to
+    // default to `onsite` (the "normal" case).
+    expect(listingKindSupports('something-new', 'earnings')).toBe(false);
+    expect(listingKindSupports('something-new', 'submitVersion')).toBe(false);
+    expect(listingKindSupports('something-new', 'listingContent')).toBe(true);
+  });
+
+  it('the table is frozen — a caller cannot mutate the capability set at runtime', () => {
+    expect(Object.isFrozen(CAPABILITIES_BY_KIND)).toBe(true);
+    expect(Object.isFrozen(CAPABILITIES_BY_KIND.offsite)).toBe(true);
+  });
 });
 
 describe('resolveAppAccess — the permission matrix', () => {
@@ -114,19 +210,45 @@ describe('resolveAppAccess — the permission matrix', () => {
       expect(access).not.toBeNull();
       expect(access!.role).toBe(expected);
       expect(access!.ownerUserId).toBe(OWNER);
+      expect(access!.appListingId).toBe(LISTING);
     });
   }
 
   it('POSITIVE CONTROL: the seat mock honours the status filter', async () => {
     // If this were not true, the PENDING/REJECTED rows above would pass vacuously.
     const asAccepted = await mockDb.appCollaborator.findFirst({
-      where: { appBlockId: APP, userId: PENDING, status: 'accepted' },
+      where: { appListingId: LISTING, userId: PENDING, status: 'accepted' },
     });
     const asAny = await mockDb.appCollaborator.findFirst({
-      where: { appBlockId: APP, userId: PENDING },
+      where: { appListingId: LISTING, userId: PENDING },
     });
     expect(asAccepted).toBeNull();
     expect(asAny).toEqual({ userId: PENDING });
+  });
+
+  it('🔴 the seat is looked up under the BLOCK’S LISTING id, not the block id', async () => {
+    // The whole re-key in one assertion. A resolver that kept passing `appBlockId` here
+    // would find nothing in the fixture and silently demote every editor to `null`.
+    await resolveAppAccess(APP, EDITOR);
+    expect(mockDb.appCollaborator.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { appListingId: LISTING, userId: EDITOR, status: 'accepted' },
+      })
+    );
+  });
+
+  it('a block with NO listing yet resolves owner-or-nothing (nothing to seat on)', async () => {
+    mockDb.appBlock.findUnique.mockResolvedValue({
+      id: APP,
+      app: { userId: OWNER },
+      appListing: null,
+    });
+    expect((await resolveAppAccess(APP, OWNER))!.role).toBe('owner');
+    const editor = await resolveAppAccess(APP, EDITOR);
+    expect(editor!.role).toBeNull();
+    expect(editor!.appListingId).toBeNull();
+    // …and it did not waste a seat query it could not key.
+    expect(mockDb.appCollaborator.findFirst).not.toHaveBeenCalled();
   });
 
   it('a missing AppBlock resolves null (not a role)', async () => {
@@ -136,80 +258,107 @@ describe('resolveAppAccess — the permission matrix', () => {
 
   it('an AppBlock with no resolvable owner resolves null — fail closed', async () => {
     // A dangling app_id: an app nobody owns is an app nobody may edit.
-    mockDb.appBlock.findUnique.mockResolvedValue({ id: APP, app: null });
+    mockDb.appBlock.findUnique.mockResolvedValue({ id: APP, app: null, appListing: null });
     expect(await resolveAppAccess(APP, OWNER)).toBeNull();
   });
 });
 
-describe('resolveListingAccess', () => {
-  const LISTING = 'apl_live';
-  const SHADOW = 'apl_shadow';
-
+describe('resolveListingAccess — role × KIND', () => {
   function wireListing(row: Record<string, unknown> | null) {
     mockDb.appListing.findUnique.mockResolvedValue(row);
   }
 
-  it('owner of the listing → owner', async () => {
-    wireListing({
-      id: LISTING,
-      userId: OWNER,
-      appBlockId: APP,
-      revisionOfId: null,
-      revisionOf: null,
-    });
-    expect((await resolveListingAccess(LISTING, OWNER))!.role).toBe('owner');
-  });
+  /**
+   * 🔴 THE KIND AXIS. Every cell is the same for onsite and offsite — that identity IS
+   * the feature. Before the re-key the offsite column was `owner`/`null` only, because a
+   * seat had nowhere to live.
+   */
+  const ROLES: Array<[string, number | null, 'owner' | 'editor' | null]> = [
+    ['owner', OWNER, 'owner'],
+    ['accepted editor', EDITOR, 'editor'],
+    ['PENDING editor', PENDING, null],
+    ['REJECTED editor', REJECTED, null],
+    ['stranger', STRANGER, null],
+    ['anonymous', null, null],
+  ];
 
-  it('accepted collaborator on the backing AppBlock → editor', async () => {
-    wireListing({
-      id: LISTING,
-      userId: OWNER,
-      appBlockId: APP,
-      revisionOfId: null,
-      revisionOf: null,
-    });
-    expect((await resolveListingAccess(LISTING, EDITOR))!.role).toBe('editor');
-  });
+  for (const [kind, listingId, row] of [
+    ['onsite', LISTING, onsiteListing] as const,
+    ['offsite', OFFSITE, offsiteListing] as const,
+  ]) {
+    describe(`kind=${kind}`, () => {
+      beforeEach(() => {
+        wireListing(row());
+        wireSeats(SEATS.map((s) => ({ ...s, appListingId: listingId })));
+      });
 
-  it('pending collaborator → null', async () => {
-    wireListing({
-      id: LISTING,
-      userId: OWNER,
-      appBlockId: APP,
-      revisionOfId: null,
-      revisionOf: null,
+      for (const [label, userId, expected] of ROLES) {
+        it(`${label} → role ${expected ?? 'null'}`, async () => {
+          const access = await resolveListingAccess(listingId, userId);
+          expect(access).not.toBeNull();
+          expect(access!.role).toBe(expected);
+          expect(access!.kind).toBe(kind);
+          expect(access!.seatListingId).toBe(listingId);
+        });
+      }
+
+      it(`reports appBlockId ${kind === 'onsite' ? 'APP' : 'null'}`, async () => {
+        const access = await resolveListingAccess(listingId, OWNER);
+        expect(access!.appBlockId).toBe(kind === 'onsite' ? APP : null);
+      });
     });
-    expect((await resolveListingAccess(LISTING, PENDING))!.role).toBeNull();
+  }
+
+  it('🔴 an OFFSITE listing can now hold an editor — the whole point of the re-key', async () => {
+    // Stated as its own case because the PRE-change behaviour was `null` here, for every
+    // offsite listing, unconditionally. This is the cell that flipped.
+    wireListing(offsiteListing());
+    wireSeats([{ appListingId: OFFSITE, userId: EDITOR, status: 'accepted', displayed: true }]);
+    expect((await resolveListingAccess(OFFSITE, EDITOR))!.role).toBe('editor');
   });
 
   it('🔴 SHADOW-AWARE: an editor keeps access to a shadow revision (appBlockId is NULL on it)', async () => {
     // A shadow carries appBlockId: null by construction (`appBlockId` is @unique and
     // stays on the parent). Without the revisionOf hop, an editor would LOSE access the
     // instant their first media edit minted the shadow — i.e. the feature would break
-    // on its own second click.
+    // on its own second click. Now it matters twice over: no seat can EXIST on a shadow.
     wireListing({
       id: SHADOW,
       userId: OWNER,
+      kind: 'onsite',
       appBlockId: null,
       revisionOfId: LISTING,
-      revisionOf: { appBlockId: APP },
+      revisionOf: { id: LISTING, kind: 'onsite', appBlockId: APP },
     });
     const access = await resolveListingAccess(SHADOW, EDITOR);
+    expect(access!.seatListingId).toBe(LISTING);
     expect(access!.appBlockId).toBe(APP);
     expect(access!.role).toBe('editor');
+    // 🔴 The seat was read under the PARENT id. A resolver that looked it up under the
+    // shadow id would find nothing — and would also be looking somewhere a seat can
+    // never legitimately exist.
+    expect(mockDb.appCollaborator.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { appListingId: LISTING, userId: EDITOR, status: 'accepted' },
+      })
+    );
   });
 
-  it('a listing with NO backing AppBlock anywhere resolves owner-or-nothing', async () => {
-    // A natively-created offsite listing: there is no AppBlock to seat anyone on.
+  it('🔴 a shadow of an OFFSITE parent reports the PARENT’s kind, not a guess', async () => {
+    // Reading kind/appBlockId off the shadow would make every in-flight revision look
+    // like a different kind than its parent.
     wireListing({
-      id: LISTING,
+      id: SHADOW,
       userId: OWNER,
+      kind: 'offsite',
       appBlockId: null,
-      revisionOfId: null,
-      revisionOf: null,
+      revisionOfId: OFFSITE,
+      revisionOf: { id: OFFSITE, kind: 'offsite', appBlockId: null },
     });
-    expect((await resolveListingAccess(LISTING, EDITOR))!.role).toBeNull();
-    expect((await resolveListingAccess(LISTING, OWNER))!.role).toBe('owner');
+    const access = await resolveListingAccess(SHADOW, OWNER);
+    expect(access!.kind).toBe('offsite');
+    expect(access!.seatListingId).toBe(OFFSITE);
+    expect(access!.appBlockId).toBeNull();
   });
 
   it('a missing listing resolves null', async () => {
@@ -246,9 +395,10 @@ describe('resolveListingAccess', () => {
       mockWriteDb.appListing.findUnique.mockResolvedValue({
         id: SHADOW,
         userId: OWNER,
+        kind: 'onsite',
         appBlockId: null,
         revisionOfId: LISTING,
-        revisionOf: { appBlockId: APP },
+        revisionOf: { id: LISTING, kind: 'onsite', appBlockId: APP },
       });
       mockWriteDb.appCollaborator.findFirst.mockImplementation(async (args: unknown) => {
         const w = (args as { where: { userId: number; status?: string } }).where;
@@ -286,9 +436,25 @@ describe('resolveListingAccess', () => {
 
 describe('resolveAccessibleAppBlockIds', () => {
   const OTHER = 'ab_app2';
+  const OTHER_LISTING = 'apl_other';
+
+  /** Resolve seated LISTING ids → their backing blocks, honouring the not-null filter. */
+  function wireSeatListings(rows: Array<{ id: string; appBlockId: string | null }>) {
+    mockDb.appListing.findMany.mockImplementation(async (args: unknown): Promise<unknown[]> => {
+      const w = (args as { where: { id: { in: string[] }; appBlockId?: unknown } }).where;
+      return rows
+        .filter((r) => w.id.in.includes(r.id))
+        .filter((r) => (w.appBlockId === undefined ? true : r.appBlockId != null))
+        .map((r) => ({ appBlockId: r.appBlockId }));
+    });
+  }
 
   beforeEach(() => {
-    mockDb.appBlock.findUnique.mockResolvedValue({ id: APP, app: { userId: OWNER } });
+    wireSeatListings([
+      { id: LISTING, appBlockId: APP },
+      { id: OTHER_LISTING, appBlockId: OTHER },
+      { id: OFFSITE, appBlockId: null },
+    ]);
   });
 
   it('an owner gets their owned ids and no editor ids', async () => {
@@ -301,9 +467,10 @@ describe('resolveAccessibleAppBlockIds', () => {
   });
 
   it('an editor gets ONLY the seated app — never the owner’s other apps', async () => {
-    // The editor owns nothing; their seat is on APP only. OTHER must not appear.
+    // The editor owns nothing; their seat is on LISTING (→ APP) only. OTHER must not
+    // appear.
     mockDb.appBlock.findMany.mockResolvedValue([]);
-    wireSeats([{ appBlockId: APP, userId: EDITOR, status: 'accepted', displayed: true }]);
+    wireSeats([{ appListingId: LISTING, userId: EDITOR, status: 'accepted', displayed: true }]);
     const res = await resolveAccessibleAppBlockIds(EDITOR);
     expect(res.ownedIds).toEqual([]);
     expect(res.editorIds).toEqual([APP]);
@@ -313,16 +480,92 @@ describe('resolveAccessibleAppBlockIds', () => {
 
   it('a PENDING seat contributes nothing', async () => {
     mockDb.appBlock.findMany.mockResolvedValue([]);
-    wireSeats([{ appBlockId: APP, userId: PENDING, status: 'pending', displayed: true }]);
+    wireSeats([{ appListingId: LISTING, userId: PENDING, status: 'pending', displayed: true }]);
     expect((await resolveAccessibleAppBlockIds(PENDING)).allIds).toEqual([]);
+  });
+
+  it('🔴 an OFFSITE seat contributes NOTHING to a BLOCK-id set — it has no block', async () => {
+    // This is the `earnings: false` capability cell expressed as data: an offsite seat
+    // must not widen a block-keyed money/analytics query by even one id.
+    mockDb.appBlock.findMany.mockResolvedValue([]);
+    wireSeats([{ appListingId: OFFSITE, userId: EDITOR, status: 'accepted', displayed: true }]);
+    const res = await resolveAccessibleAppBlockIds(EDITOR);
+    expect(res.editorIds).toEqual([]);
+    expect(res.allIds).toEqual([]);
+    expect(res.allIds).not.toContain(null);
+  });
+
+  /**
+   * 🔴 TWO REDUNDANT GUARDS, SO EACH NEEDS ITS OWN KILLING CASE.
+   *
+   * The null-block exclusion is written twice: once as `appBlockId: { not: null }` in
+   * the LISTING QUERY, and once as `!!id` in the mapping that follows. A mutation sweep
+   * found the pair out — removing the query filter changed NOTHING observable, because
+   * the `!!id` filter caught the nulls anyway, and the mutant SURVIVED. That is exactly
+   * the redundant-guard trap: "a test went red" is not the same as "this guard is
+   * tested", and with two guards protecting one property, an output-only assertion can
+   * only ever be evidence about whichever one happens to run last.
+   *
+   * So the two are pinned separately: the query filter STRUCTURALLY (it must be in the
+   * WHERE), and the mapping filter BEHAVIOURALLY (against a fake that deliberately
+   * ignores the WHERE, i.e. a DB that hands back a null).
+   */
+  it('🔴 GUARD 1/2 (structural): the listing query itself excludes null-block rows', async () => {
+    mockDb.appBlock.findMany.mockResolvedValue([]);
+    wireSeats([{ appListingId: LISTING, userId: EDITOR, status: 'accepted', displayed: true }]);
+    await resolveAccessibleAppBlockIds(EDITOR);
+    const args = mockDb.appListing.findMany.mock.calls[0][0] as {
+      where: { id: { in: string[] }; appBlockId?: unknown };
+    };
+    expect(args.where.id.in).toEqual([LISTING]);
+    // Not merely "some filter": the exact predicate. Dropping it makes the query pull
+    // rows it must then throw away, and leaves the null-exclusion resting on one
+    // in-memory `!!id` that a later refactor has no reason to keep.
+    expect(args.where.appBlockId, 'the null-block exclusion must be in the WHERE').toEqual({
+      not: null,
+    });
+  });
+
+  it('🔴 GUARD 2/2 (behavioural): a null that reaches memory anyway is still dropped', async () => {
+    // The fake here IGNORES the `appBlockId: { not: null }` filter on purpose — it is
+    // standing in for a DB that returned a null row. Only the in-memory `!!id` can save
+    // this case, so a mutant that removes THAT guard dies here and nowhere else.
+    mockDb.appBlock.findMany.mockResolvedValue([]);
+    wireSeats([
+      { appListingId: LISTING, userId: EDITOR, status: 'accepted', displayed: true },
+      { appListingId: OFFSITE, userId: EDITOR, status: 'accepted', displayed: true },
+    ]);
+    mockDb.appListing.findMany.mockResolvedValue([{ appBlockId: APP }, { appBlockId: null }]);
+    const res = await resolveAccessibleAppBlockIds(EDITOR);
+    expect(res.allIds).toEqual([APP]);
+    expect(res.allIds).not.toContain(null);
+    expect(res.editorIds).not.toContain(null);
+  });
+
+  it('🔴 a MIXED portfolio keeps the onsite seat and drops only the offsite one', async () => {
+    // The positive half of the case above: proving the filter removes the offsite id
+    // WITHOUT removing everything (which a broken filter would also do, silently).
+    mockDb.appBlock.findMany.mockResolvedValue([]);
+    wireSeats([
+      { appListingId: LISTING, userId: EDITOR, status: 'accepted', displayed: true },
+      { appListingId: OFFSITE, userId: EDITOR, status: 'accepted', displayed: true },
+    ]);
+    expect((await resolveAccessibleAppBlockIds(EDITOR)).allIds).toEqual([APP]);
   });
 
   it('owned and editor sets are disjoint — an owner who also holds a seat counts once', async () => {
     mockDb.appBlock.findMany.mockResolvedValue([{ id: APP }]);
-    wireSeats([{ appBlockId: APP, userId: OWNER, status: 'accepted', displayed: true }]);
+    wireSeats([{ appListingId: LISTING, userId: OWNER, status: 'accepted', displayed: true }]);
     const res = await resolveAccessibleAppBlockIds(OWNER);
     expect(res.editorIds).toEqual([]);
     expect(res.allIds).toEqual([APP]);
+  });
+
+  it('no seats at all ⇒ no listing round trip', async () => {
+    mockDb.appBlock.findMany.mockResolvedValue([{ id: APP }]);
+    wireSeats([]);
+    await resolveAccessibleAppBlockIds(OWNER);
+    expect(mockDb.appListing.findMany).not.toHaveBeenCalled();
   });
 });
 
@@ -330,17 +573,31 @@ describe('listDisplayedCollaboratorUserIds vs listAppInsiderUserIds — the disp
   const HIDDEN = 60;
 
   beforeEach(() => {
-    mockDb.appBlock.findUnique.mockResolvedValue({ id: APP, app: { userId: OWNER } });
+    mockDb.appBlock.findUnique.mockResolvedValue({
+      id: APP,
+      app: { userId: OWNER },
+      appListing: { id: LISTING },
+    });
     wireSeats([
-      { appBlockId: APP, userId: EDITOR, status: 'accepted', displayed: true },
-      { appBlockId: APP, userId: HIDDEN, status: 'accepted', displayed: false },
-      { appBlockId: APP, userId: PENDING, status: 'pending', displayed: true },
-      { appBlockId: APP, userId: REJECTED, status: 'rejected', displayed: true },
+      { appListingId: LISTING, userId: EDITOR, status: 'accepted', displayed: true },
+      { appListingId: LISTING, userId: HIDDEN, status: 'accepted', displayed: false },
+      { appListingId: LISTING, userId: PENDING, status: 'pending', displayed: true },
+      { appListingId: LISTING, userId: REJECTED, status: 'rejected', displayed: true },
     ]);
   });
 
   it('the PUBLIC byline is accepted AND displayed only', async () => {
-    expect(await listDisplayedCollaboratorUserIds(APP)).toEqual([EDITOR]);
+    expect(await listDisplayedCollaboratorUserIds(LISTING)).toEqual([EDITOR]);
+  });
+
+  it('🔴 the PUBLIC byline works for an OFFSITE listing — it is listing-keyed', async () => {
+    // Before the re-key this read took an appBlockId, so an offsite listing's byline was
+    // structurally always empty. Nothing about the query mentions a block now.
+    wireSeats([
+      { appListingId: OFFSITE, userId: EDITOR, status: 'accepted', displayed: true },
+      { appListingId: OFFSITE, userId: HIDDEN, status: 'accepted', displayed: false },
+    ]);
+    expect(await listDisplayedCollaboratorUserIds(OFFSITE)).toEqual([EDITOR]);
   });
 
   it('🔴 the INSIDER set ignores `displayed` — hiding your byline is not a self-review bypass', async () => {
@@ -354,6 +611,15 @@ describe('listDisplayedCollaboratorUserIds vs listAppInsiderUserIds — the disp
     expect(insiders).not.toContain(PENDING);
     expect(insiders).not.toContain(REJECTED);
   });
+
+  it('the insider set is the OWNER alone when the block has no listing', async () => {
+    mockDb.appBlock.findUnique.mockResolvedValue({
+      id: APP,
+      app: { userId: OWNER },
+      appListing: null,
+    });
+    expect(await listAppInsiderUserIds(APP)).toEqual([OWNER]);
+  });
 });
 
 describe('assertAppEditAccess — the blocks.router gate', () => {
@@ -364,6 +630,11 @@ describe('assertAppEditAccess — the blocks.router gate', () => {
   const gate = (userId: number, ownerUserId: number | null = OWNER) =>
     assertAppEditAccess({ appBlockId: APP, ownerUserId, userId });
 
+  beforeEach(() => {
+    // The block→listing hop the non-owner path now makes.
+    mockDb.appListing.findUnique.mockResolvedValue({ id: LISTING });
+  });
+
   it('the OWNER passes', async () => {
     await expect(gate(OWNER)).resolves.toBeUndefined();
   });
@@ -372,10 +643,29 @@ describe('assertAppEditAccess — the blocks.router gate', () => {
     await gate(OWNER);
     expect(mockDb.appCollaborator.findFirst).not.toHaveBeenCalled();
     expect(mockDb.appBlock.findUnique).not.toHaveBeenCalled();
+    // …including the block→listing hop, which is paid only when a seat could matter.
+    expect(mockDb.appListing.findUnique).not.toHaveBeenCalled();
   });
 
   it('an ACCEPTED collaborator passes', async () => {
     await expect(gate(EDITOR)).resolves.toBeUndefined();
+  });
+
+  it('🔴 the seat is resolved via the block’s LISTING', async () => {
+    await gate(EDITOR);
+    expect(mockDb.appListing.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { appBlockId: APP } })
+    );
+    expect(mockDb.appCollaborator.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { appListingId: LISTING, userId: EDITOR, status: 'accepted' },
+      })
+    );
+  });
+
+  it('a block with NO listing refuses even a would-be editor — fail closed', async () => {
+    mockDb.appListing.findUnique.mockResolvedValue(null);
+    await expect(gate(EDITOR)).rejects.toMatchObject({ message: 'Not the app owner' });
   });
 
   it('a PENDING invitee is refused with THIS guard’s exact message', async () => {
@@ -467,7 +757,16 @@ describe('safeCollaboratorQuery — INERT until the manual-apply migration lands
     // — and it is the one state where degrading to "no collaborators" is worst, because
     // it is silent and permanent. A `/does not exist/` message test cannot tell the two
     // apart; these cases are the mutants that prove it no longer tries.
+    //
+    // 🔴 THE RE-KEY MAKES THIS CASE ROUTINE RATHER THAN THEORETICAL. Between deploying
+    // this code and applying the re-key migration, the OLD block-keyed tables still
+    // exist, so every read fails with `column "app_listing_id" does not exist` — the
+    // FIRST case below, verbatim. It must surface, not degrade.
     const COLUMN_ERRORS: Array<[string, string]> = [
+      [
+        '🔴 the re-key deploy window: the table exists, the new column does not',
+        'column "app_listing_id" does not exist',
+      ],
       ['a bare missing column', 'column "displayed" does not exist'],
       [
         'PG 42703, which NAMES a relation and would match a relation-only regex',
@@ -558,7 +857,11 @@ describe('safeCollaboratorQuery — INERT until the manual-apply migration lands
   });
 
   it('resolveAppAccess degrades to owner-only when the seat table is absent', async () => {
-    mockDb.appBlock.findUnique.mockResolvedValue({ id: APP, app: { userId: OWNER } });
+    mockDb.appBlock.findUnique.mockResolvedValue({
+      id: APP,
+      app: { userId: OWNER },
+      appListing: { id: LISTING },
+    });
     mockDb.appCollaborator.findFirst.mockRejectedValue(
       Object.assign(new Error('does not exist'), { code: 'P2021' })
     );

--- a/src/server/services/blocks/__tests__/app-collaborator-earnings.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator-earnings.service.test.ts
@@ -24,6 +24,10 @@ const { mockDb } = vi.hoisted(() => ({
       findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
       findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
     },
+    appListing: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    },
     appCollaborator: {
       findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
       findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
@@ -43,9 +47,48 @@ const { getAppEarnings, getMyAppsEarnings } = await import(
 
 const APP_A = 'ab_appA'; // shared with the editor
 const APP_B = 'ab_appB'; // 🔴 the owner's OTHER app — must never surface to the editor
+/** The store listings that BACK those blocks — the seat key since the re-key. */
+const LISTING_A = 'apl_listingA';
+const LISTING_B = 'apl_listingB';
+/** 🔴 An OFF-SITE listing the editor is ALSO seated on. It has no block, so no earnings. */
+const LISTING_OFF = 'apl_offsite';
 const OWNER = 100;
 const EDITOR = 200;
 const STRANGER = 300;
+
+/**
+ * The listing table. Each row is what `resolveListingAccess` selects.
+ *
+ * 🔴 The OFF-SITE row is the new axis: the editor holds a real, accepted seat on it, so
+ * every "the editor cannot see earnings here" assertion is about the KIND and not about
+ * a missing seat.
+ */
+const LISTINGS: Record<string, Record<string, unknown>> = {
+  [LISTING_A]: {
+    id: LISTING_A,
+    userId: OWNER,
+    kind: 'onsite',
+    appBlockId: APP_A,
+    revisionOfId: null,
+    revisionOf: null,
+  },
+  [LISTING_B]: {
+    id: LISTING_B,
+    userId: OWNER,
+    kind: 'onsite',
+    appBlockId: APP_B,
+    revisionOfId: null,
+    revisionOf: null,
+  },
+  [LISTING_OFF]: {
+    id: LISTING_OFF,
+    userId: OWNER,
+    kind: 'offsite',
+    appBlockId: null,
+    revisionOfId: null,
+    revisionOf: null,
+  },
+};
 
 /** Every attribution row in the fixture DB, per app. */
 const LEDGER = [
@@ -148,14 +191,30 @@ function wireAccess() {
     const ids = (w as { id?: { in: string[] } }).id?.in ?? [];
     return ids.map((id) => ({ id, app: { userId: OWNER } }));
   });
+  mockDb.appListing.findUnique.mockImplementation(async (args: unknown) => {
+    const id = (args as { where: { id: string } }).where.id;
+    return LISTINGS[id] ?? null;
+  });
+  // The seated-LISTINGS → backing-BLOCKS hop, honouring the `appBlockId: { not: null }`
+  // filter that drops off-site seats from a block-id set.
+  mockDb.appListing.findMany.mockImplementation(async (args: unknown) => {
+    const w = (args as { where: { id: { in: string[] }; appBlockId?: unknown } }).where;
+    return Object.values(LISTINGS)
+      .filter((l) => w.id.in.includes(l.id as string))
+      .filter((l) => (w.appBlockId === undefined ? true : l.appBlockId != null))
+      .map((l) => ({ appBlockId: l.appBlockId }));
+  });
+  // 🔴 The editor is seated on the on-site LISTING_A *and* on the off-site LISTING_OFF.
   mockDb.appCollaborator.findFirst.mockImplementation(async (args: unknown) => {
-    const w = (args as { where: { appBlockId: string; userId: number; status?: string } }).where;
-    const ok = w.appBlockId === APP_A && w.userId === EDITOR && w.status === 'accepted';
-    return ok ? { userId: EDITOR } : null;
+    const w = (args as { where: { appListingId: string; userId: number; status?: string } }).where;
+    const seated = w.appListingId === LISTING_A || w.appListingId === LISTING_OFF;
+    return seated && w.userId === EDITOR && w.status === 'accepted' ? { userId: EDITOR } : null;
   });
   mockDb.appCollaborator.findMany.mockImplementation(async (args: unknown) => {
     const w = (args as { where: { userId?: number; status?: string } }).where;
-    return w.userId === EDITOR && w.status === 'accepted' ? [{ appBlockId: APP_A }] : [];
+    return w.userId === EDITOR && w.status === 'accepted'
+      ? [{ appListingId: LISTING_A }, { appListingId: LISTING_OFF }]
+      : [];
   });
 }
 
@@ -245,27 +304,28 @@ describe('getMyAppsEarnings — 🔴 the editor must never see the owner’s oth
   });
 });
 
-describe('getAppEarnings — per-app, fail-closed', () => {
-  it('the owner reads the app’s summary', async () => {
-    const res = await getAppEarnings({ appBlockId: APP_A, userId: OWNER });
+describe('getAppEarnings — per-listing, fail-closed', () => {
+  it('the owner reads the listing’s summary', async () => {
+    const res = await getAppEarnings({ appListingId: LISTING_A, userId: OWNER });
     expect(res.ok).toBe(true);
     if (!res.ok) throw new Error('unreachable');
     expect(res.role).toBe('owner');
+    expect(res.appBlockId).toBe(APP_A);
     expect(res.summary.confirmed.shareCents).toBe(500);
     expect(res.summary.paidOut.shareCents).toBe(250);
   });
 
-  it('the accepted editor reads the SHARED app’s summary', async () => {
-    const res = await getAppEarnings({ appBlockId: APP_A, userId: EDITOR });
+  it('the accepted editor reads the SHARED listing’s summary', async () => {
+    const res = await getAppEarnings({ appListingId: LISTING_A, userId: EDITOR });
     expect(res.ok).toBe(true);
     if (!res.ok) throw new Error('unreachable');
     expect(res.role).toBe('editor');
     expect(res.summary.confirmed.shareCents).toBe(500);
   });
 
-  it('🔴 the editor is REFUSED on the owner’s other app — and no aggregate is run', async () => {
-    const res = await getAppEarnings({ appBlockId: APP_B, userId: EDITOR });
-    expect(res).toEqual({ ok: false, appBlockId: APP_B, reason: 'notPermitted' });
+  it('🔴 the editor is REFUSED on the owner’s other listing — and no aggregate is run', async () => {
+    const res = await getAppEarnings({ appListingId: LISTING_B, userId: EDITOR });
+    expect(res).toEqual({ ok: false, appListingId: LISTING_B, reason: 'notPermitted' });
     // Fail-closed means fail EARLY: refusing after running the query would still have
     // put the owner's numbers in memory on this request.
     expect(mockDb.blockBuzzAttribution.aggregate).not.toHaveBeenCalled();
@@ -274,20 +334,20 @@ describe('getAppEarnings — per-app, fail-closed', () => {
   it('🔴 refusal is `notPermitted`, NOT a zeroed summary', async () => {
     // A zero here would be indistinguishable from "this app earned nothing" — the
     // fabricated-zero trap. The discriminated union makes that unrepresentable.
-    const res = await getAppEarnings({ appBlockId: APP_B, userId: STRANGER });
+    const res = await getAppEarnings({ appListingId: LISTING_B, userId: STRANGER });
     expect(res.ok).toBe(false);
     expect(res).not.toHaveProperty('summary');
   });
 
-  it('a missing app is `notFound`, distinct from `notPermitted`', async () => {
-    const res = await getAppEarnings({ appBlockId: 'ab_nope', userId: OWNER });
-    expect(res).toEqual({ ok: false, appBlockId: 'ab_nope', reason: 'notFound' });
+  it('a missing listing is `notFound`, distinct from `notPermitted`', async () => {
+    const res = await getAppEarnings({ appListingId: 'apl_nope', userId: OWNER });
+    expect(res).toEqual({ ok: false, appListingId: 'apl_nope', reason: 'notFound' });
   });
 
   it('🔴 the query carries BOTH scopes (appBlockId AND the current owner)', async () => {
     // A structural assertion on the WHERE clause, because dropping either axis is the
     // leak and a numeric assertion alone would not localise which axis went missing.
-    await getAppEarnings({ appBlockId: APP_A, userId: EDITOR });
+    await getAppEarnings({ appListingId: LISTING_A, userId: EDITOR });
     const calls = mockDb.blockBuzzAttribution.aggregate.mock.calls as Array<
       [{ where: Record<string, unknown> }]
     >;
@@ -296,5 +356,72 @@ describe('getAppEarnings — per-app, fail-closed', () => {
       expect(args.where.appBlockId).toBe(APP_A);
       expect(args.where.appOwnerUserId).toBe(OWNER);
     }
+  });
+
+  // -------------------------------------------------------------------------
+  // 🔴 THE KIND AXIS — earnings are structurally ON-SITE ONLY.
+  // -------------------------------------------------------------------------
+
+  describe('🔴 OFF-SITE: the capability is ABSENT, not erroring and not a zero', () => {
+    /**
+     * `BlockBuzzAttribution` is keyed on `appBlockId`. An off-site listing has no
+     * AppBlock, so no attribution row can ever belong to it — the `earnings: false` cell
+     * of `CAPABILITIES_BY_KIND`. The refusal has to be an explicit `unsupportedKind`:
+     *
+     *   - a THROW would read to the client as "something went wrong", and an off-site
+     *     developer would file a bug about their broken earnings page; and
+     *   - a ZEROED SUMMARY would read as "your app earned nothing", which is worse — it
+     *     is a plausible number for a claim the schema cannot support at all.
+     */
+    it('the OWNER of an off-site listing gets `unsupportedKind`', async () => {
+      const res = await getAppEarnings({ appListingId: LISTING_OFF, userId: OWNER });
+      expect(res).toEqual({ ok: false, appListingId: LISTING_OFF, reason: 'unsupportedKind' });
+    });
+
+    it('🔴 a genuinely SEATED off-site editor gets `unsupportedKind` too — it is the KIND, not the seat', async () => {
+      // The fixture seats EDITOR on LISTING_OFF for real, so this cannot be confused
+      // with `notPermitted`.
+      const res = await getAppEarnings({ appListingId: LISTING_OFF, userId: EDITOR });
+      expect(res).toEqual({ ok: false, appListingId: LISTING_OFF, reason: 'unsupportedKind' });
+    });
+
+    it('🔴 the two refusals are DISTINGUISHABLE — a stranger still gets `notPermitted`', async () => {
+      // Collapsing the two would tell an off-site owner they lack permission on their
+      // own listing.
+      const stranger = await getAppEarnings({ appListingId: LISTING_OFF, userId: STRANGER });
+      expect(stranger).toMatchObject({ reason: 'notPermitted' });
+      const owner = await getAppEarnings({ appListingId: LISTING_OFF, userId: OWNER });
+      expect(owner).toMatchObject({ reason: 'unsupportedKind' });
+    });
+
+    it('NO aggregate is run — there is no id to aggregate on', async () => {
+      await getAppEarnings({ appListingId: LISTING_OFF, userId: OWNER });
+      expect(mockDb.blockBuzzAttribution.aggregate).not.toHaveBeenCalled();
+    });
+
+    it('🔴 POSITIVE CONTROL: the SAME owner on the ON-SITE listing does get a summary', async () => {
+      // Without this, "no aggregate ran" is indistinguishable from an aggregate mock
+      // nothing ever calls.
+      const res = await getAppEarnings({ appListingId: LISTING_A, userId: OWNER });
+      expect(res.ok).toBe(true);
+      expect(mockDb.blockBuzzAttribution.aggregate).toHaveBeenCalled();
+    });
+  });
+
+  describe('🔴 getMyAppsEarnings drops the off-site seat entirely', () => {
+    it('the editor’s rows name only the ON-SITE app, though they hold TWO accepted seats', async () => {
+      // The off-site seat is real and accepted; it contributes no block id, so it cannot
+      // widen a block-keyed money query — and it must not appear as a zeroed row either,
+      // which would invite the same "earned nothing" misreading.
+      const rows = await getMyAppsEarnings({ userId: EDITOR });
+      expect(rows.map((r) => r.appBlockId)).toEqual([APP_A]);
+    });
+
+    it('POSITIVE CONTROL: the fixture really does give the editor two accepted seats', async () => {
+      const seats = (await mockDb.appCollaborator.findMany({
+        where: { userId: EDITOR, status: 'accepted' },
+      })) as Array<{ appListingId: string }>;
+      expect(seats.map((s) => s.appListingId).sort()).toEqual([LISTING_A, LISTING_OFF].sort());
+    });
   });
 });

--- a/src/server/services/blocks/__tests__/app-collaborator-earnings.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator-earnings.service.test.ts
@@ -52,6 +52,26 @@ const LISTING_A = 'apl_listingA';
 const LISTING_B = 'apl_listingB';
 /** 🔴 An OFF-SITE listing the editor is ALSO seated on. It has no block, so no earnings. */
 const LISTING_OFF = 'apl_offsite';
+/**
+ * 🔴 THE TWO SHAPES WHERE THE KIND GATE'S TWO CLAUSES DISAGREE.
+ *
+ * `getAppEarnings` refuses on `!listingKindSupports(kind,'earnings') || !appBlockId`. On
+ * every ordinary row the two clauses agree (onsite⇒block, offsite⇒no block), so a
+ * fixture built only from ordinary rows leaves the SECOND clause dead — and the
+ * `||`→`&&` mutant SURVIVES the whole suite, which is exactly what a mutation sweep
+ * found. These two rows are what make each clause independently load-bearing:
+ *
+ *   - OFFSITE **with** a block. Not hypothetical: `mapAppBlockToListing` sets
+ *     `kind: 'offsite'` while assigning `appBlockId: ab.id` unconditionally whenever the
+ *     source AppBlock has an `externalUrl` (reachable via the mod proc
+ *     `backfillAppListings`), and `schema.full.prisma` says to discriminate on `kind`,
+ *     never on `appBlockId` nullness. Only the KIND clause refuses it — and it is
+ *     pointed at APP_B, the lucrative app, so under the mutant the leak is a number.
+ *   - ONSITE **without** a block — a listing whose backing AppBlock is missing or not
+ *     yet linked. Only the BLOCK clause refuses it.
+ */
+const LISTING_OFF_WITH_BLOCK = 'apl_offsite_with_block';
+const LISTING_ON_NO_BLOCK = 'apl_onsite_no_block';
 const OWNER = 100;
 const EDITOR = 200;
 const STRANGER = 300;
@@ -84,6 +104,24 @@ const LISTINGS: Record<string, Record<string, unknown>> = {
     id: LISTING_OFF,
     userId: OWNER,
     kind: 'offsite',
+    appBlockId: null,
+    revisionOfId: null,
+    revisionOf: null,
+  },
+  // 🔴 offsite BUT carrying APP_B — the 999,999-cent app. Only the KIND clause refuses.
+  [LISTING_OFF_WITH_BLOCK]: {
+    id: LISTING_OFF_WITH_BLOCK,
+    userId: OWNER,
+    kind: 'offsite',
+    appBlockId: APP_B,
+    revisionOfId: null,
+    revisionOf: null,
+  },
+  // 🔴 onsite BUT with no block. Only the BLOCK clause refuses.
+  [LISTING_ON_NO_BLOCK]: {
+    id: LISTING_ON_NO_BLOCK,
+    userId: OWNER,
+    kind: 'onsite',
     appBlockId: null,
     revisionOfId: null,
     revisionOf: null,
@@ -195,25 +233,35 @@ function wireAccess() {
     const id = (args as { where: { id: string } }).where.id;
     return LISTINGS[id] ?? null;
   });
-  // The seated-LISTINGS → backing-BLOCKS hop, honouring the `appBlockId: { not: null }`
-  // filter that drops off-site seats from a block-id set.
+  // The seated-LISTINGS → backing-BLOCKS hop, honouring BOTH filters the service sends:
+  // `kind` and `appBlockId: { not: null }`.
+  //
+  // 🔴 The two are applied INDEPENDENTLY here on purpose. Collapsing them (e.g. treating
+  // "offsite" as implying "no block") would make LISTING_OFF_WITH_BLOCK unrepresentable
+  // through this fake, and the kind gate would then be certified by a fixture that
+  // cannot express the case it exists for.
   mockDb.appListing.findMany.mockImplementation(async (args: unknown) => {
-    const w = (args as { where: { id: { in: string[] }; appBlockId?: unknown } }).where;
+    const w = (args as { where: { id: { in: string[] }; kind?: string; appBlockId?: unknown } })
+      .where;
     return Object.values(LISTINGS)
       .filter((l) => w.id.in.includes(l.id as string))
+      .filter((l) => (w.kind === undefined ? true : l.kind === w.kind))
       .filter((l) => (w.appBlockId === undefined ? true : l.appBlockId != null))
       .map((l) => ({ appBlockId: l.appBlockId }));
   });
-  // 🔴 The editor is seated on the on-site LISTING_A *and* on the off-site LISTING_OFF.
+  // 🔴 The editor holds THREE accepted seats: the on-site LISTING_A, the off-site
+  // LISTING_OFF, and the off-site-WITH-A-BLOCK LISTING_OFF_WITH_BLOCK. The third is the
+  // one that can leak a block id — and therefore money — into a block-keyed query.
+  const SEATED = new Set([LISTING_A, LISTING_OFF, LISTING_OFF_WITH_BLOCK]);
   mockDb.appCollaborator.findFirst.mockImplementation(async (args: unknown) => {
     const w = (args as { where: { appListingId: string; userId: number; status?: string } }).where;
-    const seated = w.appListingId === LISTING_A || w.appListingId === LISTING_OFF;
+    const seated = SEATED.has(w.appListingId);
     return seated && w.userId === EDITOR && w.status === 'accepted' ? { userId: EDITOR } : null;
   });
   mockDb.appCollaborator.findMany.mockImplementation(async (args: unknown) => {
     const w = (args as { where: { userId?: number; status?: string } }).where;
     return w.userId === EDITOR && w.status === 'accepted'
-      ? [{ appListingId: LISTING_A }, { appListingId: LISTING_OFF }]
+      ? [...SEATED].map((appListingId) => ({ appListingId }))
       : [];
   });
 }
@@ -406,6 +454,71 @@ describe('getAppEarnings — per-listing, fail-closed', () => {
       expect(res.ok).toBe(true);
       expect(mockDb.blockBuzzAttribution.aggregate).toHaveBeenCalled();
     });
+
+    /**
+     * 🔴 THE TWO CLAUSES OF THE KIND GATE, MADE INDEPENDENTLY LOAD-BEARING.
+     *
+     * The guard is `!listingKindSupports(kind,'earnings') || !appBlockId`. Every fixture
+     * above satisfies BOTH clauses at once (offsite AND blockless), so each one alone is
+     * sufficient there — and the `||`→`&&` mutant, which only refuses when both fire,
+     * behaves identically on every one of them. It survived the full suite for exactly
+     * that reason: the second clause was never observed, and the comment claiming it was
+     * "asserted TWO ways" described an intention, not a fixture.
+     *
+     * Each test below satisfies EXACTLY ONE clause, so it is red under `&&` and green
+     * under `||` — and neither can be satisfied by the other clause's guard, which is
+     * what makes the kill attributable rather than a neighbour's.
+     */
+    describe('🔴 the `||` is not decorative — one clause fires per case', () => {
+      it('CLAUSE 1 ONLY (kind): an OFF-SITE listing that HAS a block is refused', async () => {
+        // `appBlockId` is APP_B (truthy), so `!access.appBlockId` is FALSE here — the
+        // kind clause is the only thing that can refuse.
+        const res = await getAppEarnings({ appListingId: LISTING_OFF_WITH_BLOCK, userId: OWNER });
+        expect(res).toEqual({
+          ok: false,
+          appListingId: LISTING_OFF_WITH_BLOCK,
+          reason: 'unsupportedKind',
+        });
+        // BEHAVIOURAL, not just the label: under `&&` this call reaches the aggregate and
+        // returns APP_B's 999,999 cents on a listing whose kind says it cannot earn.
+        expect(mockDb.blockBuzzAttribution.aggregate).not.toHaveBeenCalled();
+      });
+
+      it('CLAUSE 2 ONLY (block): an ON-SITE listing with NO block is refused', async () => {
+        // `listingKindSupports('onsite','earnings')` is TRUE here, so the kind clause is
+        // FALSE — the block clause is the only thing that can refuse.
+        const res = await getAppEarnings({ appListingId: LISTING_ON_NO_BLOCK, userId: OWNER });
+        expect(res).toEqual({
+          ok: false,
+          appListingId: LISTING_ON_NO_BLOCK,
+          reason: 'unsupportedKind',
+        });
+        // Under `&&` this would run four aggregates with `appBlockId: null`.
+        expect(mockDb.blockBuzzAttribution.aggregate).not.toHaveBeenCalled();
+      });
+
+      it('🔴 POSITIVE CONTROL: the fixture rows really do have the disagreeing shapes', async () => {
+        // The instrument, not the code: if the LISTINGS table did not actually hold an
+        // offsite-with-block and an onsite-without-block row, both tests above would be
+        // green for the wrong reason (an ordinary offsite/blockless row refuses under
+        // `&&` too).
+        const off = (await mockDb.appListing.findUnique({
+          where: { id: LISTING_OFF_WITH_BLOCK },
+        })) as { kind: string; appBlockId: string | null };
+        expect(off.kind).toBe('offsite');
+        expect(off.appBlockId).toBe(APP_B);
+        const on = (await mockDb.appListing.findUnique({
+          where: { id: LISTING_ON_NO_BLOCK },
+        })) as { kind: string; appBlockId: string | null };
+        expect(on.kind).toBe('onsite');
+        expect(on.appBlockId).toBeNull();
+      });
+
+      it('a SEATED editor on the offsite-with-block listing is refused too — kind, not seat', async () => {
+        const res = await getAppEarnings({ appListingId: LISTING_OFF_WITH_BLOCK, userId: EDITOR });
+        expect(res).toMatchObject({ reason: 'unsupportedKind' });
+      });
+    });
   });
 
   describe('🔴 getMyAppsEarnings drops the off-site seat entirely', () => {
@@ -417,11 +530,40 @@ describe('getAppEarnings — per-listing, fail-closed', () => {
       expect(rows.map((r) => r.appBlockId)).toEqual([APP_A]);
     });
 
-    it('POSITIVE CONTROL: the fixture really does give the editor two accepted seats', async () => {
+    it('POSITIVE CONTROL: the fixture really does give the editor THREE accepted seats', async () => {
       const seats = (await mockDb.appCollaborator.findMany({
         where: { userId: EDITOR, status: 'accepted' },
       })) as Array<{ appListingId: string }>;
-      expect(seats.map((s) => s.appListingId).sort()).toEqual([LISTING_A, LISTING_OFF].sort());
+      expect(seats.map((s) => s.appListingId).sort()).toEqual(
+        [LISTING_A, LISTING_OFF, LISTING_OFF_WITH_BLOCK].sort()
+      );
+    });
+
+    /**
+     * 🔴 THE MONEY READ, on the shape where "offsite" and "has no block" disagree.
+     *
+     * `getMyAppsEarnings` has NO kind gate of its own — it trusts the id set
+     * `resolveAccessibleAppBlockIds` hands it. So an off-site listing that carries a
+     * block is the one input that can put a real, earning block id in front of a
+     * seat-only holder on a listing whose kind declares `earnings: false`.
+     */
+    it('🔴 an OFF-SITE seat on a listing that HAS a block yields NO row and NO money', async () => {
+      const rows = await getMyAppsEarnings({ userId: EDITOR });
+      expect(rows.map((r) => r.appBlockId)).toEqual([APP_A]);
+      expect(rows.map((r) => r.appBlockId)).not.toContain(APP_B);
+      // The number, not just the id list: APP_B is the 999,999-cent app, so a leak here
+      // is a money figure and the assertion should say so.
+      expect(rows.reduce((s, r) => s + r.lifetimeShareCents, 0)).toBe(750);
+    });
+
+    it('🔴 STRUCTURAL: the groupBy never even ASKS for the off-site listing’s block', async () => {
+      // The output-only assertion above can be satisfied by the final `allIds.map`
+      // barrier while the QUERY still fetched the row. Pin the WHERE too.
+      await getMyAppsEarnings({ userId: EDITOR });
+      const args = mockDb.blockBuzzAttribution.groupBy.mock.calls[0][0] as {
+        where: { appBlockId?: { in: string[] } };
+      };
+      expect(args.where.appBlockId!.in).toEqual([APP_A]);
     });
   });
 });

--- a/src/server/services/blocks/__tests__/app-collaborator.migration-shape.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator.migration-shape.test.ts
@@ -1,0 +1,220 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * 🔴 THE MIGRATION'S SHAPE, pinned against the committed SQL.
+ *
+ * ## Why a structural test at all
+ *
+ * This migration is MANUAL-APPLY (datapacket-talos DB rule #8: the main civitai DB does
+ * not run `prisma migrate deploy`), and no test in this repo talks to a Postgres. So
+ * every claim the SERVICES make about the DB is, in CI, an unverifiable assertion about
+ * a file. Three of those claims are load-bearing enough that "the file says so" is worth
+ * asserting rather than assuming:
+ *
+ *   1. THE PARTIAL UNIQUE INDEX. Prisma cannot express it, so it exists ONLY in this
+ *      SQL — and `initiateTransfer` depends on its P2002 to close the read-then-write
+ *      race between two concurrent offers. If the index is dropped or re-keyed, the
+ *      service's catch becomes dead code and two "pending" transfers can coexist, which
+ *      makes `acceptTransfer`'s guard reachable from two directions at once. Nothing
+ *      else in the suite can notice.
+ *   2. THE CASCADE POSTURE. Seats and transfers CASCADE (a live capability must not
+ *      outlive its listing); ownership EVENTS `SET NULL` (an append-only audit trail
+ *      must outlive everything it references). Getting these backwards is silent: the
+ *      audit trail simply loses rows, months later, with no error.
+ *   3. THE KEY ITSELF. Every column is `app_listing_id`; `app_block_id` appears nowhere.
+ *
+ * 🔴 STATED PLAINLY: this proves the committed SQL SAYS the right thing. It does NOT
+ * prove any database has it — that is a human apply step, and nothing in CI can verify
+ * it. Do not read a green run here as "the constraint is live".
+ */
+
+const ROOT = process.cwd();
+const MIGRATION = join(
+  ROOT,
+  'packages/civitai-db-schema/prisma/migrations/20260811160000_rekey_app_collaborators_to_listings/migration.sql'
+);
+const SQL = readFileSync(MIGRATION, 'utf8');
+/** Comment-stripped, so prose about a constraint can never satisfy an assertion. */
+const CODE = SQL.replace(/^\s*--.*$/gm, '');
+const norm = (s: string) => s.replace(/\s+/g, ' ');
+const NCODE = norm(CODE);
+
+describe('🔴 INSTRUMENT CONTROLS', () => {
+  it('the migration file exists and has real content after comment-stripping', () => {
+    // This file is ~70% commentary. If the strip ate everything, every `toContain`
+    // below would fail loudly — but every `not.toContain` would pass VACUOUSLY, which is
+    // the direction that matters.
+    expect(SQL.length).toBeGreaterThan(2000);
+    expect(CODE.length).toBeGreaterThan(1000);
+    expect(NCODE).toContain('CREATE TABLE IF NOT EXISTS "app_collaborators"');
+  });
+
+  it('NEGATIVE CONTROL: the strip really does remove commentary', () => {
+    // The header sentence lives only in a `--` comment. If it survives, the strip is
+    // inert and the "app_block_id appears nowhere" test below would be reading prose.
+    expect(SQL).toContain('SUPERSEDES 20260810140000_app_listing_collaborators');
+    expect(CODE).not.toContain('SUPERSEDES 20260810140000_app_listing_collaborators');
+  });
+});
+
+describe('the three tables are keyed on app_listings', () => {
+  const TABLES = ['app_collaborators', 'app_ownership_events', 'app_ownership_transfers'];
+
+  for (const t of TABLES) {
+    it(`${t} carries an app_listing_id referencing app_listings(id)`, () => {
+      expect(NCODE).toMatch(
+        new RegExp(`CREATE TABLE IF NOT EXISTS "${t}"[\\s\\S]*?"app_listing_id"`)
+      );
+    });
+  }
+
+  it('🔴 `app_block_id` appears NOWHERE in the executable SQL', () => {
+    // The single most likely half-done re-key: one table left on the old key.
+    expect(CODE).not.toContain('app_block_id');
+  });
+
+  it('the predecessor tables are DROPped first (this is a re-create, not an ALTER)', () => {
+    for (const t of TABLES) expect(NCODE).toContain(`DROP TABLE IF EXISTS "${t}"`);
+    // …and the drops precede the creates, or the creates would be no-ops against the
+    // OLD block-keyed tables (every CREATE is `IF NOT EXISTS`) — a silent non-migration.
+    expect(NCODE.indexOf('DROP TABLE IF EXISTS "app_collaborators"')).toBeLessThan(
+      NCODE.indexOf('CREATE TABLE IF NOT EXISTS "app_collaborators"')
+    );
+  });
+
+  it('the seat PK is the composite (app_listing_id, user_id)', () => {
+    expect(NCODE).toContain('PRIMARY KEY ("app_listing_id", "user_id")');
+  });
+});
+
+describe('🔴 the PARTIAL UNIQUE index — the one-in-flight-transfer guard', () => {
+  it('exists, is UNIQUE, is keyed on app_listing_id, and is filtered to pending', () => {
+    // `initiateTransfer` catches this index's P2002 and turns it into a friendly error.
+    // Without the index that catch is unreachable and two concurrent offers both win.
+    expect(NCODE).toMatch(
+      /CREATE UNIQUE INDEX IF NOT EXISTS "app_ownership_transfers_one_pending_per_listing" ON "app_ownership_transfers" \("app_listing_id"\) WHERE "status" = 'pending'/
+    );
+  });
+
+  it('the WHERE clause is present — a non-partial unique would break every re-transfer', () => {
+    // A UNIQUE on `app_listing_id` with no predicate would permit exactly ONE transfer
+    // per listing FOREVER: the accepted row would block every future offer. The
+    // predicate is what makes the constraint about IN-FLIGHT offers.
+    const idx = NCODE.slice(NCODE.indexOf('app_ownership_transfers_one_pending_per_listing'));
+    expect(idx.slice(0, 200)).toContain('WHERE "status" = \'pending\'');
+  });
+});
+
+describe('🔴 the CASCADE posture — live capability vs append-only audit', () => {
+  /** The body of one CREATE TABLE statement. */
+  function table(name: string): string {
+    const start = NCODE.indexOf(`CREATE TABLE IF NOT EXISTS "${name}"`);
+    expect(start, `${name} must exist`).toBeGreaterThan(-1);
+    const end = NCODE.indexOf('CREATE ', start + 10);
+    return NCODE.slice(start, end === -1 ? undefined : end);
+  }
+
+  it('SEATS cascade — a seat must not outlive its listing or its user', () => {
+    const t = table('app_collaborators');
+    expect(t).toContain('REFERENCES "app_listings"("id") ON DELETE CASCADE');
+    expect(t).not.toContain('"app_listings"("id") ON DELETE SET NULL');
+  });
+
+  it('TRANSFERS cascade — an offer on a deleted listing is meaningless', () => {
+    const t = table('app_ownership_transfers');
+    expect(t).toContain('REFERENCES "app_listings"("id") ON DELETE CASCADE');
+  });
+
+  it('🔴 EVENTS are SET NULL and every FK is NULLABLE — the trail outlives everything', () => {
+    // The asymmetry with the two tables above IS the design. An audit row that
+    // cascade-deleted with its listing would erase the record of who did what, which is
+    // exactly what an append-only trail exists to prevent.
+    const t = table('app_ownership_events');
+    expect(t).toContain('"app_listing_id" TEXT REFERENCES "app_listings"("id") ON DELETE SET NULL');
+    expect(t).toContain('ON DELETE SET NULL');
+    expect(t).not.toContain('"app_listings"("id") ON DELETE CASCADE');
+    // The denormalized slug is what keeps the row self-describing once the FK is null.
+    expect(t).toContain('"slug" TEXT NOT NULL');
+  });
+
+  it('POSITIVE CONTROL: the two postures are genuinely DIFFERENT in this file', () => {
+    // If one of the strings were absent, half the assertions above would be vacuous.
+    expect(CODE).toContain('ON DELETE CASCADE');
+    expect(CODE).toContain('ON DELETE SET NULL');
+  });
+});
+
+describe('the CHECK constraints that bound the TEXT columns', () => {
+  it('seat status is bounded to pending|accepted|rejected', () => {
+    expect(NCODE).toContain(
+      `CONSTRAINT "app_collaborators_status_check" CHECK ("status" IN ('pending', 'accepted', 'rejected'))`
+    );
+  });
+
+  it('seat role is bounded to editor', () => {
+    expect(NCODE).toContain(
+      `CONSTRAINT "app_collaborators_role_check" CHECK ("role" IN ('editor'))`
+    );
+  });
+
+  it('a transfer cannot be a self-transfer', () => {
+    expect(NCODE).toContain(
+      `CONSTRAINT "app_ownership_transfers_not_self_check" CHECK ("from_user_id" <> "to_user_id")`
+    );
+  });
+
+  it('every audit action the service can write is in the events CHECK', () => {
+    // Enumerated against the union in `recordOwnershipEvent`. A service that writes an
+    // action the CHECK rejects fails at runtime with a raw 23514 — after the seat write
+    // it was supposed to accompany.
+    const ACTIONS = [
+      'invite',
+      'accept',
+      'reject',
+      'remove',
+      'leave',
+      'display',
+      'transfer_initiated',
+      'transfer_accepted',
+      'transfer_cancelled',
+    ];
+    const check = NCODE.slice(NCODE.indexOf('app_ownership_events_action_check'));
+    for (const a of ACTIONS) expect(check.slice(0, 400)).toContain(`'${a}'`);
+  });
+});
+
+describe('the supporting indexes the hot paths depend on', () => {
+  const INDEXES = [
+    // "which listings may this user edit" — resolveAccessibleAppBlockIds' seat scan.
+    ['app_collaborators_user_status_idx', '"app_collaborators" ("user_id", "status")'],
+    // "who is on this listing" — the roster + the public byline read.
+    ['app_collaborators_listing_status_idx', '"app_collaborators" ("app_listing_id", "status")'],
+    // A User delete must not seq-scan the inviter side.
+    ['app_collaborators_invited_by_idx', '"app_collaborators" ("invited_by")'],
+    // "transfers awaiting MY acceptance" — the recipient's inbox.
+    ['app_ownership_transfers_to_status_idx', '"app_ownership_transfers" ("to_user_id", "status")'],
+  ];
+
+  for (const [name, on] of INDEXES) {
+    it(`${name} is created on ${on}`, () => {
+      expect(NCODE).toContain(`CREATE INDEX IF NOT EXISTS "${name}" ON ${on}`);
+    });
+  }
+});
+
+describe('the MANUAL-APPLY banner is present', () => {
+  it('the file states that no deploy path applies it', () => {
+    // A future reader who assumes `prisma migrate deploy` runs somewhere will ship a
+    // feature that is inert in production and cannot tell why.
+    expect(SQL).toMatch(/MANUAL APPLY/);
+    expect(SQL).toMatch(/does NOT auto-apply/);
+  });
+
+  it('🔴 it warns that the tables must be EMPTY for this drop-and-create to be safe', () => {
+    // The single fact this migration's safety rests on. If it is ever applied to an
+    // environment where a seat exists, it destroys it.
+    expect(SQL).toMatch(/EMPTY in every environment/i);
+  });
+});

--- a/src/server/services/blocks/__tests__/app-collaborator.migration-shape.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator.migration-shape.test.ts
@@ -176,6 +176,29 @@ describe('🔴 STEP A refuses to run against non-empty tables — in SQL, not in
     );
   });
 
+  /**
+   * 🔴 The guard is only load-bearing INSIDE a transaction.
+   *
+   * psql defaults to `ON_ERROR_STOP` OFF. Measured on PostgreSQL 18 (2026-08-11): with a
+   * row seeded and the file run as a plain `psql -f`, the guard RAISEd, psql printed the
+   * error, and then executed the DROPs anyway — the populated table was destroyed and the
+   * message scrolled away. Wrapped in BEGIN/COMMIT the failed statement aborts the whole
+   * transaction and all three tables survive.
+   *
+   * So this asserts the wrapper, not just the guard: without it the guard reports a
+   * refusal it does not enforce, which is worse than no guard because it reads as safe.
+   */
+  it('🔴 the guard runs inside a transaction, so the DROPs cannot outlive its refusal', () => {
+    expect(CODE_A).toMatch(/^\s*BEGIN;/m);
+    expect(CODE_A).toMatch(/^\s*COMMIT;/m);
+    // BEGIN must open before the guard, and COMMIT must close after the last DROP —
+    // a wrapper that starts after the guard, or ends before the drops, protects nothing.
+    expect(CODE_A.indexOf('BEGIN;')).toBeLessThan(CODE_A.indexOf('DO $$'));
+    expect(CODE_A.lastIndexOf('COMMIT;')).toBeGreaterThan(
+      CODE_A.indexOf('DROP TABLE IF EXISTS "app_collaborators"')
+    );
+  });
+
   it('🔴 it counts ALL THREE tables, not just the one that is easy to name', () => {
     // A guard that only checked `app_collaborators` would let the DROP destroy a
     // populated `app_ownership_events` — the append-only audit trail — in silence.

--- a/src/server/services/blocks/__tests__/app-collaborator.migration-shape.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator.migration-shape.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'fs';
+import { existsSync, readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
 import { describe, expect, it } from 'vitest';
 
@@ -7,85 +7,222 @@ import { describe, expect, it } from 'vitest';
  *
  * ## Why a structural test at all
  *
- * This migration is MANUAL-APPLY (datapacket-talos DB rule #8: the main civitai DB does
- * not run `prisma migrate deploy`), and no test in this repo talks to a Postgres. So
+ * These migrations are MANUAL-APPLY (datapacket-talos DB rule #8: the main civitai DB
+ * does not run `prisma migrate deploy`), and no test in this repo talks to a Postgres. So
  * every claim the SERVICES make about the DB is, in CI, an unverifiable assertion about
- * a file. Three of those claims are load-bearing enough that "the file says so" is worth
+ * a file. Four of those claims are load-bearing enough that "the file says so" is worth
  * asserting rather than assuming:
  *
- *   1. THE PARTIAL UNIQUE INDEX. Prisma cannot express it, so it exists ONLY in this
+ *   1. THE SPLIT AND ITS ORDER. The re-key is TWO migrations — DROP before the deploy,
+ *      CREATE after it — and that ordering is the only reason the deploy window is safe.
+ *      Re-merging them, or letting the CREATE sort first, silently reopens a window in
+ *      which the public listing-detail read 500s on PG 42703. See the ordering describe.
+ *   2. THE EMPTINESS GUARD. The DROP is only safe because the tables are empty, and that
+ *      is a MEASUREMENT that decays. The guard must be EXECUTABLE SQL that re-checks it
+ *      at apply time — a comment saying "these are empty" cannot abort anything.
+ *   3. THE PARTIAL UNIQUE INDEX. Prisma cannot express it, so it exists ONLY in this
  *      SQL — and `initiateTransfer` depends on its P2002 to close the read-then-write
  *      race between two concurrent offers. If the index is dropped or re-keyed, the
- *      service's catch becomes dead code and two "pending" transfers can coexist, which
- *      makes `acceptTransfer`'s guard reachable from two directions at once. Nothing
- *      else in the suite can notice.
- *   2. THE CASCADE POSTURE. Seats and transfers CASCADE (a live capability must not
- *      outlive its listing); ownership EVENTS `SET NULL` (an append-only audit trail
+ *      service's catch becomes dead code and two "pending" transfers can coexist.
+ *   4. THE CASCADE POSTURE + THE KEY. Seats and transfers CASCADE (a live capability must
+ *      not outlive its listing); ownership EVENTS `SET NULL` (an append-only audit trail
  *      must outlive everything it references). Getting these backwards is silent: the
- *      audit trail simply loses rows, months later, with no error.
- *   3. THE KEY ITSELF. Every column is `app_listing_id`; `app_block_id` appears nowhere.
+ *      audit trail simply loses rows, months later, with no error. And every column is
+ *      `app_listing_id`; `app_block_id` appears nowhere.
  *
  * 🔴 STATED PLAINLY: this proves the committed SQL SAYS the right thing. It does NOT
- * prove any database has it — that is a human apply step, and nothing in CI can verify
- * it. Do not read a green run here as "the constraint is live".
+ * prove any database has it, and it does NOT prove the SQL runs — that is a human apply
+ * step, and nothing in CI can verify it. Do not read a green run here as "the constraint
+ * is live".
  */
 
 const ROOT = process.cwd();
-const MIGRATION = join(
-  ROOT,
-  'packages/civitai-db-schema/prisma/migrations/20260811160000_rekey_app_collaborators_to_listings/migration.sql'
-);
-const SQL = readFileSync(MIGRATION, 'utf8');
+const MIGRATIONS = join(ROOT, 'packages/civitai-db-schema/prisma/migrations');
+
+const STEP_A_DIR = '20260811160000_rekey_app_collaborators_step_a_drop_block_keyed';
+const STEP_B_DIR = '20260811170000_rekey_app_collaborators_step_b_create_listing_keyed';
+
+function read(dir: string): string {
+  return readFileSync(join(MIGRATIONS, dir, 'migration.sql'), 'utf8');
+}
+
+const SQL_A = read(STEP_A_DIR);
+const SQL_B = read(STEP_B_DIR);
 /** Comment-stripped, so prose about a constraint can never satisfy an assertion. */
-const CODE = SQL.replace(/^\s*--.*$/gm, '');
+const strip = (s: string) => s.replace(/^\s*--.*$/gm, '');
 const norm = (s: string) => s.replace(/\s+/g, ' ');
-const NCODE = norm(CODE);
+const CODE_A = strip(SQL_A);
+const CODE_B = strip(SQL_B);
+const NCODE_A = norm(CODE_A);
+const NCODE_B = norm(CODE_B);
+
+const TABLES = ['app_collaborators', 'app_ownership_events', 'app_ownership_transfers'];
 
 describe('🔴 INSTRUMENT CONTROLS', () => {
-  it('the migration file exists and has real content after comment-stripping', () => {
-    // This file is ~70% commentary. If the strip ate everything, every `toContain`
+  it('both migration files exist and have real content after comment-stripping', () => {
+    // These files are ~70% commentary. If the strip ate everything, every `toContain`
     // below would fail loudly — but every `not.toContain` would pass VACUOUSLY, which is
     // the direction that matters.
-    expect(SQL.length).toBeGreaterThan(2000);
-    expect(CODE.length).toBeGreaterThan(1000);
-    expect(NCODE).toContain('CREATE TABLE IF NOT EXISTS "app_collaborators"');
+    expect(SQL_A.length).toBeGreaterThan(2000);
+    expect(SQL_B.length).toBeGreaterThan(2000);
+    expect(CODE_A.length).toBeGreaterThan(500);
+    expect(CODE_B.length).toBeGreaterThan(1000);
+    expect(NCODE_A).toContain('DROP TABLE IF EXISTS "app_collaborators"');
+    expect(NCODE_B).toContain('CREATE TABLE IF NOT EXISTS "app_collaborators"');
   });
 
   it('NEGATIVE CONTROL: the strip really does remove commentary', () => {
-    // The header sentence lives only in a `--` comment. If it survives, the strip is
-    // inert and the "app_block_id appears nowhere" test below would be reading prose.
-    expect(SQL).toContain('SUPERSEDES 20260810140000_app_listing_collaborators');
-    expect(CODE).not.toContain('SUPERSEDES 20260810140000_app_listing_collaborators');
+    // These sentences live only in `--` comments. If they survive, the strip is inert
+    // and every "appears nowhere in the executable SQL" test below reads prose.
+    expect(SQL_A).toContain('SUPERSEDES 20260810140000_app_listing_collaborators');
+    expect(CODE_A).not.toContain('SUPERSEDES 20260810140000_app_listing_collaborators');
+    expect(SQL_B).toContain('ROLLBACK DIRECTION');
+    expect(CODE_B).not.toContain('ROLLBACK DIRECTION');
   });
 });
 
-describe('the three tables are keyed on app_listings', () => {
-  const TABLES = ['app_collaborators', 'app_ownership_events', 'app_ownership_transfers'];
+// ---------------------------------------------------------------------------
+// 🔴 THE SPLIT — the deploy window this ordering exists to remove.
+// ---------------------------------------------------------------------------
 
+describe('🔴 the re-key is TWO migrations, and the order is the safety property', () => {
+  /**
+   * A single DROP+CREATE cannot be applied atomically with a code deploy, so one side is
+   * always ahead. The question is only WHICH error the code in that window raises:
+   *
+   *   - OLD block-keyed tables present + NEW code → PG 42703 (`column "app_listing_id"
+   *     does not exist`). `isMissingTableError` REFUSES column errors on purpose, so
+   *     `safeCollaboratorQuery` rethrows; it reaches `getListingDetail` →
+   *     `loadDisplayedCollaboratorChips` with no try/catch above it and the public
+   *     listing-detail read 500s.
+   *   - NO tables at all + EITHER code version → PG 42P01, which IS swallowed → clean
+   *     degrade to owner-only.
+   *
+   * Splitting DROP (before the deploy) from CREATE (after it) makes every intermediate
+   * state the second kind. That is why these two files may not be merged back together,
+   * and why the DROP must sort first.
+   */
+  it('STEP A contains the DROPs and NO CREATE TABLE', () => {
+    for (const t of TABLES) expect(NCODE_A).toContain(`DROP TABLE IF EXISTS "${t}"`);
+    expect(NCODE_A).not.toContain('CREATE TABLE');
+  });
+
+  it('STEP B contains the CREATEs and NO DROP TABLE', () => {
+    for (const t of TABLES) expect(NCODE_B).toContain(`CREATE TABLE IF NOT EXISTS "${t}"`);
+    // 🔴 A DROP here would collapse the split back into the single migration whose
+    // window this whole arrangement exists to remove.
+    expect(NCODE_B).not.toContain('DROP TABLE');
+  });
+
+  it('🔴 STEP A sorts BEFORE STEP B — prisma applies migrations in directory order', () => {
+    expect(STEP_A_DIR < STEP_B_DIR).toBe(true);
+    // And both are really on disk under `migrations/`, not just names in this file.
+    const dirs = readdirSync(MIGRATIONS);
+    expect(dirs).toContain(STEP_A_DIR);
+    expect(dirs).toContain(STEP_B_DIR);
+  });
+
+  it('🔴 the SINGLE-FILE predecessor is GONE — a stale copy would re-open the window', () => {
+    // The original `..._rekey_app_collaborators_to_listings` did DROP + CREATE in one
+    // file. Leaving it beside the split pair would mean a human applying "the re-key
+    // migration" could pick the unsafe one.
+    expect(existsSync(join(MIGRATIONS, '20260811160000_rekey_app_collaborators_to_listings'))).toBe(
+      false
+    );
+    const merged = readdirSync(MIGRATIONS).filter(
+      (d) => /rekey_app_collaborators/.test(d) && d !== STEP_A_DIR && d !== STEP_B_DIR
+    );
+    expect(merged).toEqual([]);
+  });
+
+  it('each file states WHICH side of the deploy it belongs on', () => {
+    // The ordering is only safe if the human applying it knows the order. Both banners
+    // must say so in the file itself, not in a handoff doc that will not be open.
+    expect(SQL_A).toMatch(/\*\*BEFORE\*\* THE CODE DEPLOY/);
+    expect(SQL_B).toMatch(/\*\*AFTER\*\* THE CODE DEPLOY/);
+    // …and each names the other, so neither can be applied as if it were the whole job.
+    expect(SQL_A).toContain(STEP_B_DIR);
+    expect(SQL_B).toContain(STEP_A_DIR);
+  });
+
+  it('each file documents its ROLLBACK direction', () => {
+    expect(SQL_A).toMatch(/ROLLBACK DIRECTION/);
+    // A rollback that names no concrete action is not a rollback direction.
+    expect(SQL_A).toContain('20260810140000_app_listing_collaborators');
+    expect(SQL_B).toMatch(/ROLLBACK DIRECTION/);
+    expect(SQL_B).toMatch(/DROP TABLE IF EXISTS/); // inside the rollback comment only
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 🔴 THE EMPTINESS GUARD — executable, not prose.
+// ---------------------------------------------------------------------------
+
+describe('🔴 STEP A refuses to run against non-empty tables — in SQL, not in a comment', () => {
+  /**
+   * The previous version of this suite asserted `/EMPTY in every environment/i` against
+   * the COMMENT-INCLUSIVE text. That is a token-presence check satisfied by the sentence
+   * merely existing: the DROP itself was unguarded, so the "safety" was a claim a reader
+   * had to act on rather than a precondition the database enforced. Every assertion here
+   * is against `CODE_A` (comments stripped) for that reason.
+   */
+  it('the guard is EXECUTABLE: a DO block that RAISEs', () => {
+    expect(CODE_A).toContain('DO $$');
+    expect(CODE_A).toMatch(/RAISE EXCEPTION/);
+    // The RAISE must be inside the DO block, i.e. before the first DROP — a check that
+    // ran after the drops would be decoration.
+    expect(CODE_A.indexOf('RAISE EXCEPTION')).toBeLessThan(
+      CODE_A.indexOf('DROP TABLE IF EXISTS "app_ownership_transfers"')
+    );
+  });
+
+  it('🔴 it counts ALL THREE tables, not just the one that is easy to name', () => {
+    // A guard that only checked `app_collaborators` would let the DROP destroy a
+    // populated `app_ownership_events` — the append-only audit trail — in silence.
+    const guard = CODE_A.slice(CODE_A.indexOf('DO $$'), CODE_A.indexOf('END $$;'));
+    expect(guard.length).toBeGreaterThan(100);
+    for (const t of TABLES) expect(guard).toContain(t);
+    // It must actually COUNT, not merely mention them.
+    expect(guard).toMatch(/count\(\*\)/i);
+  });
+
+  it('the guard tolerates an ALREADY-DROPPED table (re-run must be a no-op, not an error)', () => {
+    // Without an existence check, a re-run against the post-drop schema fails on a
+    // missing relation and looks like the guard firing.
+    const guard = CODE_A.slice(CODE_A.indexOf('DO $$'), CODE_A.indexOf('END $$;'));
+    expect(guard).toContain('to_regclass');
+  });
+
+  it('POSITIVE CONTROL: STEP B has NO such guard — it creates, it does not destroy', () => {
+    // If `CODE_A` and `CODE_B` were accidentally the same string (a copy-paste this
+    // suite would otherwise not notice), every assertion above would be about the wrong
+    // file. They must differ in exactly this way.
+    expect(CODE_B).not.toContain('RAISE EXCEPTION');
+    expect(CODE_A).not.toEqual(CODE_B);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The shape of the tables STEP B creates.
+// ---------------------------------------------------------------------------
+
+describe('the three tables are keyed on app_listings', () => {
   for (const t of TABLES) {
     it(`${t} carries an app_listing_id referencing app_listings(id)`, () => {
-      expect(NCODE).toMatch(
+      expect(NCODE_B).toMatch(
         new RegExp(`CREATE TABLE IF NOT EXISTS "${t}"[\\s\\S]*?"app_listing_id"`)
       );
     });
   }
 
-  it('🔴 `app_block_id` appears NOWHERE in the executable SQL', () => {
+  it('🔴 `app_block_id` appears NOWHERE in either file’s executable SQL', () => {
     // The single most likely half-done re-key: one table left on the old key.
-    expect(CODE).not.toContain('app_block_id');
-  });
-
-  it('the predecessor tables are DROPped first (this is a re-create, not an ALTER)', () => {
-    for (const t of TABLES) expect(NCODE).toContain(`DROP TABLE IF EXISTS "${t}"`);
-    // …and the drops precede the creates, or the creates would be no-ops against the
-    // OLD block-keyed tables (every CREATE is `IF NOT EXISTS`) — a silent non-migration.
-    expect(NCODE.indexOf('DROP TABLE IF EXISTS "app_collaborators"')).toBeLessThan(
-      NCODE.indexOf('CREATE TABLE IF NOT EXISTS "app_collaborators"')
-    );
+    expect(CODE_A).not.toContain('app_block_id');
+    expect(CODE_B).not.toContain('app_block_id');
   });
 
   it('the seat PK is the composite (app_listing_id, user_id)', () => {
-    expect(NCODE).toContain('PRIMARY KEY ("app_listing_id", "user_id")');
+    expect(NCODE_B).toContain('PRIMARY KEY ("app_listing_id", "user_id")');
   });
 });
 
@@ -93,7 +230,7 @@ describe('🔴 the PARTIAL UNIQUE index — the one-in-flight-transfer guard', (
   it('exists, is UNIQUE, is keyed on app_listing_id, and is filtered to pending', () => {
     // `initiateTransfer` catches this index's P2002 and turns it into a friendly error.
     // Without the index that catch is unreachable and two concurrent offers both win.
-    expect(NCODE).toMatch(
+    expect(NCODE_B).toMatch(
       /CREATE UNIQUE INDEX IF NOT EXISTS "app_ownership_transfers_one_pending_per_listing" ON "app_ownership_transfers" \("app_listing_id"\) WHERE "status" = 'pending'/
     );
   });
@@ -102,7 +239,7 @@ describe('🔴 the PARTIAL UNIQUE index — the one-in-flight-transfer guard', (
     // A UNIQUE on `app_listing_id` with no predicate would permit exactly ONE transfer
     // per listing FOREVER: the accepted row would block every future offer. The
     // predicate is what makes the constraint about IN-FLIGHT offers.
-    const idx = NCODE.slice(NCODE.indexOf('app_ownership_transfers_one_pending_per_listing'));
+    const idx = NCODE_B.slice(NCODE_B.indexOf('app_ownership_transfers_one_pending_per_listing'));
     expect(idx.slice(0, 200)).toContain('WHERE "status" = \'pending\'');
   });
 });
@@ -110,10 +247,10 @@ describe('🔴 the PARTIAL UNIQUE index — the one-in-flight-transfer guard', (
 describe('🔴 the CASCADE posture — live capability vs append-only audit', () => {
   /** The body of one CREATE TABLE statement. */
   function table(name: string): string {
-    const start = NCODE.indexOf(`CREATE TABLE IF NOT EXISTS "${name}"`);
+    const start = NCODE_B.indexOf(`CREATE TABLE IF NOT EXISTS "${name}"`);
     expect(start, `${name} must exist`).toBeGreaterThan(-1);
-    const end = NCODE.indexOf('CREATE ', start + 10);
-    return NCODE.slice(start, end === -1 ? undefined : end);
+    const end = NCODE_B.indexOf('CREATE ', start + 10);
+    return NCODE_B.slice(start, end === -1 ? undefined : end);
   }
 
   it('SEATS cascade — a seat must not outlive its listing or its user', () => {
@@ -141,26 +278,26 @@ describe('🔴 the CASCADE posture — live capability vs append-only audit', ()
 
   it('POSITIVE CONTROL: the two postures are genuinely DIFFERENT in this file', () => {
     // If one of the strings were absent, half the assertions above would be vacuous.
-    expect(CODE).toContain('ON DELETE CASCADE');
-    expect(CODE).toContain('ON DELETE SET NULL');
+    expect(CODE_B).toContain('ON DELETE CASCADE');
+    expect(CODE_B).toContain('ON DELETE SET NULL');
   });
 });
 
 describe('the CHECK constraints that bound the TEXT columns', () => {
   it('seat status is bounded to pending|accepted|rejected', () => {
-    expect(NCODE).toContain(
+    expect(NCODE_B).toContain(
       `CONSTRAINT "app_collaborators_status_check" CHECK ("status" IN ('pending', 'accepted', 'rejected'))`
     );
   });
 
   it('seat role is bounded to editor', () => {
-    expect(NCODE).toContain(
+    expect(NCODE_B).toContain(
       `CONSTRAINT "app_collaborators_role_check" CHECK ("role" IN ('editor'))`
     );
   });
 
   it('a transfer cannot be a self-transfer', () => {
-    expect(NCODE).toContain(
+    expect(NCODE_B).toContain(
       `CONSTRAINT "app_ownership_transfers_not_self_check" CHECK ("from_user_id" <> "to_user_id")`
     );
   });
@@ -168,7 +305,8 @@ describe('the CHECK constraints that bound the TEXT columns', () => {
   it('every audit action the service can write is in the events CHECK', () => {
     // Enumerated against the union in `recordOwnershipEvent`. A service that writes an
     // action the CHECK rejects fails at runtime with a raw 23514 — after the seat write
-    // it was supposed to accompany.
+    // it was supposed to accompany. 🔴 `remove` and `transfer_cancelled` are also what
+    // `claimListing`'s seat remediation writes, so this list covers that path too.
     const ACTIONS = [
       'invite',
       'accept',
@@ -180,7 +318,7 @@ describe('the CHECK constraints that bound the TEXT columns', () => {
       'transfer_accepted',
       'transfer_cancelled',
     ];
-    const check = NCODE.slice(NCODE.indexOf('app_ownership_events_action_check'));
+    const check = NCODE_B.slice(NCODE_B.indexOf('app_ownership_events_action_check'));
     for (const a of ACTIONS) expect(check.slice(0, 400)).toContain(`'${a}'`);
   });
 });
@@ -199,22 +337,18 @@ describe('the supporting indexes the hot paths depend on', () => {
 
   for (const [name, on] of INDEXES) {
     it(`${name} is created on ${on}`, () => {
-      expect(NCODE).toContain(`CREATE INDEX IF NOT EXISTS "${name}" ON ${on}`);
+      expect(NCODE_B).toContain(`CREATE INDEX IF NOT EXISTS "${name}" ON ${on}`);
     });
   }
 });
 
-describe('the MANUAL-APPLY banner is present', () => {
-  it('the file states that no deploy path applies it', () => {
+describe('the MANUAL-APPLY banner is present on BOTH files', () => {
+  it('each file states that no deploy path applies it', () => {
     // A future reader who assumes `prisma migrate deploy` runs somewhere will ship a
     // feature that is inert in production and cannot tell why.
-    expect(SQL).toMatch(/MANUAL APPLY/);
-    expect(SQL).toMatch(/does NOT auto-apply/);
-  });
-
-  it('🔴 it warns that the tables must be EMPTY for this drop-and-create to be safe', () => {
-    // The single fact this migration's safety rests on. If it is ever applied to an
-    // environment where a seat exists, it destroys it.
-    expect(SQL).toMatch(/EMPTY in every environment/i);
+    for (const sql of [SQL_A, SQL_B]) {
+      expect(sql).toMatch(/MANUAL APPLY/);
+      expect(sql).toMatch(/does NOT auto-apply/);
+    }
   });
 });

--- a/src/server/services/blocks/__tests__/app-collaborator.permission-matrix.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator.permission-matrix.test.ts
@@ -3,8 +3,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type * as AppBlockIds from '~/server/utils/app-block-ids';
 
 /**
- * 🔴 THE PERMISSION MATRIX — table-driven `role × entry-point × expected`, executed
- * against the REAL widened gates rather than against `resolveAppAccess` alone.
+ * 🔴 THE PERMISSION MATRIX — table-driven `KIND × role × entry-point × expected`,
+ * executed against the REAL widened gates rather than against `resolveListingAccess`
+ * alone.
  *
  * `app-access.service.test.ts` pins the predicate. This file pins that each gate
  * actually CONSULTS it: a structural check type-checks past a wrong argument, so every
@@ -14,6 +15,15 @@ import type * as AppBlockIds from '~/server/utils/app-block-ids';
  * moderator. The moderator column is where the pre-existing D1 divergence shows up and
  * is asserted AS IT IS, not as it "should" be — `app-listing-assets` bypasses for mods,
  * `offsite-listing` does not.
+ *
+ * 🔴 THE KIND AXIS is the new dimension, and running the SAME table twice is the point:
+ * every cell must come out identical for an OFF-SITE listing, because a seat confers the
+ * same CONTENT capabilities on both kinds. A config that is blind to a dimension passes
+ * every defect on that dimension vacuously, so the two kinds are enumerated rather than
+ * assumed equivalent. (The two capabilities that genuinely DIFFER by kind — earnings and
+ * submit-version — are absent from this table on purpose: they are not listing-content
+ * entry points, and their absence is pinned in
+ * `app-collaborator-earnings.service.test.ts` and `app-collaborator.service.test.ts`.)
  *
  * Also covers CONCURRENCY: two editors share ONE shadow revision per parent, via
  * `beginListingRevision`'s idempotent-reuse path.
@@ -37,7 +47,10 @@ const { mockDb } = vi.hoisted(() => {
       findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
       create: vi.fn(async (args: { data: unknown }) => args.data),
     },
-    appCollaborator: { findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    appCollaborator: {
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    },
     oauthClient: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
     image: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
     $transaction: vi.fn(),
@@ -82,18 +95,29 @@ const SEATS = [
   { userId: REJECTED, status: 'rejected' },
 ];
 
+/** The two store kinds, run through the identical table. */
+const KINDS = ['onsite', 'offsite'] as const;
+type Kind = (typeof KINDS)[number];
+
+/** Currently-staged kind — the fixture builders read it. */
+let KIND: Kind = 'onsite';
+
 /** A DRAFT listing (freely editable, so the edit-lock never masks the access gate). */
 function draftListing(over: Record<string, unknown> = {}) {
   return {
     id: LIVE,
-    kind: 'onsite',
+    kind: KIND,
+    // 🔴 An OFF-SITE listing has NO backing AppBlock and DOES have an externalUrl. Both
+    // are what make it a different row rather than a relabelled onsite one.
+    ...(KIND === 'offsite'
+      ? { appBlockId: null, externalUrl: 'https://example.com/' }
+      : { appBlockId: APP, externalUrl: null }),
     slug: 'my-app',
     name: 'My App',
     tagline: null,
     description: null,
     category: null,
     contentRating: 'g',
-    externalUrl: null,
     connectClientId: null,
     connectRequestedScopes: null,
     connectScopeJustifications: null,
@@ -102,7 +126,6 @@ function draftListing(over: Record<string, unknown> = {}) {
     coverId: null,
     status: 'draft',
     revisionOfId: null,
-    appBlockId: APP,
     revisionOf: null,
     // `loadListingEditView` selects these relations off the SAME row; without them its
     // `screenshots.map` throws and every ALLOW cell would fail for a reason that has
@@ -129,11 +152,27 @@ beforeEach(() => {
   mockDb.appListing.findUnique.mockResolvedValue(draftListing());
   mockDb.appListing.findFirst.mockResolvedValue(null);
   mockDb.appCollaborator.findFirst.mockImplementation(async (args: unknown) => {
-    const w = (args as { where: { userId: number; status?: string } }).where;
+    const w = (args as { where: { appListingId?: string; userId: number; status?: string } }).where;
+    // 🔴 The seat lives on the LIVE parent listing. Honouring `appListingId` is what
+    // makes the shadow-hop assertions meaningful rather than incidental.
+    if (w.appListingId !== undefined && w.appListingId !== LIVE) return null;
     const hit = SEATS.find(
       (r) => r.userId === w.userId && (w.status === undefined || r.status === w.status)
     );
     return hit ? { userId: hit.userId } : null;
+  });
+  mockDb.appCollaborator.findMany.mockImplementation(async (args: unknown) => {
+    const w = (args as { where: { appListingId?: string; status?: string } }).where;
+    if (w.appListingId !== undefined && w.appListingId !== LIVE) return [];
+    return SEATS.filter((r) => w.status === undefined || r.status === w.status).map((r) => ({
+      userId: r.userId,
+      role: 'editor',
+      status: r.status,
+      displayed: true,
+      invitedBy: OWNER,
+      createdAt: new Date('2026-08-01T00:00:00Z'),
+      respondedAt: null,
+    }));
   });
 });
 
@@ -169,7 +208,27 @@ const MATRIX: Record<string, Record<string, boolean>> = {
     stranger: false,
     moderator: false,
   },
-  // offsite-listing: getMyListingForApp (NO mod bypass)
+  // app-collaborators: listCollaborators — the ROSTER read. A moderator DOES pass here
+  // (the service takes an explicit isModerator), unlike the two author-edit gates above.
+  'collaborators.list': {
+    owner: true,
+    'accepted editor': true,
+    'PENDING editor': false,
+    'REJECTED editor': false,
+    stranger: false,
+    moderator: true,
+  },
+};
+
+/**
+ * Entry points that exist for ONE kind only, and why — so their absence from the
+ * kind-crossed run reads as a decision rather than an oversight.
+ *
+ * `getMyListingForApp` is keyed on an `appBlockId`. An off-site listing does not have
+ * one, so the proc is not "denied" for offsite — it is UNCALLABLE, which is the same
+ * structural mechanism that makes `submitVersion: false` real.
+ */
+const ONSITE_ONLY: Record<string, Record<string, boolean>> = {
   'offsite.getMyListingForApp': {
     owner: true,
     'accepted editor': true,
@@ -184,15 +243,23 @@ const { getListingAssets } = await import('~/server/services/blocks/app-listing-
 const { getMyListingForApp, getMyListingForEdit, beginListingRevision } = await import(
   '~/server/services/blocks/offsite-listing.service'
 );
+const { listCollaborators } = await import('~/server/services/blocks/app-collaborator.service');
 
 const RUNNERS: Record<string, (s: Subject) => Promise<unknown>> = {
   'assets.getListingAssets': (s) =>
     getListingAssets({ listingId: LIVE }, { id: s.id, isModerator: s.isModerator } as never),
   'offsite.getMyListingForEdit': (s) => getMyListingForEdit({ listingId: LIVE, userId: s.id }),
   'offsite.getMyListingForApp': (s) => getMyListingForApp({ appBlockId: APP, userId: s.id }),
+  'collaborators.list': (s) =>
+    listCollaborators({ appListingId: LIVE, viewerUserId: s.id, isModerator: s.isModerator }),
 };
 
-describe('permission matrix — role × entry point', () => {
+describe.each(KINDS)('permission matrix — kind=%s × role × entry point', (kind) => {
+  beforeEach(() => {
+    KIND = kind;
+    mockDb.appListing.findUnique.mockResolvedValue(draftListing());
+  });
+
   for (const [entry, row] of Object.entries(MATRIX)) {
     for (const subject of SUBJECTS) {
       const allowed = row[subject.label];
@@ -203,6 +270,41 @@ describe('permission matrix — role × entry point', () => {
       });
     }
   }
+
+  it('🔴 the staged fixture really IS this kind (the axis is not a no-op)', async () => {
+    // A `describe.each` whose two runs stage the SAME row would double the test count
+    // and measure nothing. Assert the discriminator each run actually put on the table.
+    const row = (await mockDb.appListing.findUnique({ where: { id: LIVE } })) as {
+      kind: string;
+      appBlockId: string | null;
+    };
+    expect(row.kind).toBe(kind);
+    expect(row.appBlockId).toBe(kind === 'onsite' ? APP : null);
+  });
+});
+
+describe('ONSITE-ONLY entry points (block-keyed, so structurally absent for offsite)', () => {
+  beforeEach(() => {
+    KIND = 'onsite';
+    mockDb.appListing.findUnique.mockResolvedValue(draftListing());
+  });
+
+  for (const [entry, row] of Object.entries(ONSITE_ONLY)) {
+    for (const subject of SUBJECTS) {
+      const allowed = row[subject.label];
+      it(`${entry} · ${subject.label} → ${allowed ? 'ALLOW' : 'DENY'}`, async () => {
+        const call = RUNNERS[entry](subject);
+        if (allowed) await expect(call).resolves.toBeTruthy();
+        else await expect(call).rejects.toBeTruthy();
+      });
+    }
+  }
+});
+
+describe('matrix hygiene', () => {
+  beforeEach(() => {
+    KIND = 'onsite';
+  });
 
   it('POSITIVE CONTROL: the matrix has both ALLOW and DENY cells per entry point', () => {
     // An all-true (or all-false) row would make its whole column vacuous.

--- a/src/server/services/blocks/__tests__/app-collaborator.public-byline-offsite.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator.public-byline-offsite.test.ts
@@ -1,0 +1,266 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * 🔴 THE PUBLIC BYLINE ON AN OFF-SITE LISTING — end to end, through the real read.
+ *
+ * This is the user-visible payoff of keying seats to `AppListing` instead of `AppBlock`.
+ * BEFORE the re-key the byline hydrator took an `appBlockId` and short-circuited on
+ * null, so an off-site listing's byline was **structurally always empty**: not a bug in
+ * the filter, not a missing seat — there was no id to query with. Nothing went red,
+ * because nothing asked.
+ *
+ * So this suite drives the actual public read (`getListingDetail`, the anon-capable
+ * store-detail path) against an OFF-SITE row and asserts the three properties that
+ * matter, in the same call:
+ *
+ *   1. an accepted + displayed collaborator APPEARS;
+ *   2. pending / rejected / accepted-but-undisplayed do NOT — consent and the byline
+ *      opt-out are both enforced on a read that anonymous users can reach; and
+ *   3. the projection is EXACTLY `{id, username, image}`, even when the user rows the
+ *      hydrator is handed carry more.
+ *
+ * `app-access.service.test.ts` pins the filter in isolation and
+ * `app-collaborator.public-projection.test.ts` pins the DTO in isolation. Neither can
+ * see the SEAM — which is precisely where the pre-re-key defect lived.
+ */
+
+const { mockDb } = vi.hoisted(() => ({
+  mockDb: {
+    appCollaborator: {
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    },
+    user: { findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []) },
+    $queryRaw: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    appListing: {
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+    },
+  },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
+vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (src: string) => src }));
+vi.mock('~/env/server', () => ({ env: { APPS_DOMAIN: 'civit.ai' } }));
+vi.mock('~/server/common/constants', () => ({ CacheTTL: { hour: 3600 } }));
+vi.mock('~/server/utils/cache-helpers', () => ({
+  queryCache:
+    () =>
+    async (sql: unknown): Promise<unknown[]> =>
+      mockDb.$queryRaw(sql),
+}));
+
+import { getListingDetail } from '../app-listing.service';
+
+const OFFSITE = 'apl_offsite';
+const OWNER = 7;
+const DISPLAYED = 20;
+const HIDDEN = 21;
+const PENDING = 30;
+const REJECTED = 40;
+
+/**
+ * The seat table. 🔴 KEYED ON THE LISTING and carrying no block anywhere — which is the
+ * whole point: an off-site listing has no `appBlockId` to key a seat with.
+ */
+const SEATS = [
+  { appListingId: OFFSITE, userId: DISPLAYED, status: 'accepted', displayed: true },
+  { appListingId: OFFSITE, userId: HIDDEN, status: 'accepted', displayed: false },
+  { appListingId: OFFSITE, userId: PENDING, status: 'pending', displayed: true },
+  { appListingId: OFFSITE, userId: REJECTED, status: 'rejected', displayed: true },
+];
+
+/**
+ * Realistic over-wide user rows — the shape a careless upstream `select` produces. The
+ * hydrator's own `select` narrows to three columns, so this fixture is deliberately
+ * WIDER than what production returns: it is the only way to prove the projection
+ * narrows rather than merely passing through an already-narrow row.
+ */
+const USERS: Record<number, Record<string, unknown>> = {
+  [DISPLAYED]: {
+    id: DISPLAYED,
+    username: 'editor-shown',
+    image: 'shown.png',
+    email: 'shown@example.com',
+    bannedAt: new Date('2026-01-01T00:00:00Z'),
+    isModerator: true,
+  },
+  [HIDDEN]: { id: HIDDEN, username: 'editor-hidden', image: null, email: 'hidden@example.com' },
+  [PENDING]: { id: PENDING, username: 'invitee', image: null },
+  [REJECTED]: { id: REJECTED, username: 'decliner', image: null },
+};
+
+/** An approved OFF-SITE external-link listing, as `listingHydrateSelect` returns it. */
+function offsiteRow(over: Record<string, unknown> = {}) {
+  return {
+    id: OFFSITE,
+    serialId: 2,
+    kind: 'offsite',
+    slug: 'ext-app',
+    name: 'External App',
+    tagline: 't',
+    description: 'body',
+    category: 'utility',
+    contentRating: 'pg',
+    externalUrl: 'https://example.com/',
+    connectClientId: null,
+    // 🔴 NO backing AppBlock — the state that made the byline unreachable before.
+    appBlockId: null,
+    appBlock: null,
+    icon: null,
+    cover: null,
+    user: { id: OWNER, username: 'dev', image: null },
+    metric: null,
+    screenshots: [],
+    status: 'approved',
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDb.appListing.findFirst.mockResolvedValue(offsiteRow());
+  // Honour `appListingId`, `status` AND `displayed` — a fake that ignored any of the
+  // three would make the corresponding assertion below vacuous.
+  mockDb.appCollaborator.findMany.mockImplementation(async (args: unknown) => {
+    const w = (args as { where: { appListingId?: string; status?: string; displayed?: boolean } })
+      .where;
+    return SEATS.filter(
+      (s) =>
+        (w.appListingId === undefined || s.appListingId === w.appListingId) &&
+        (w.status === undefined || s.status === w.status) &&
+        (w.displayed === undefined || s.displayed === w.displayed)
+    ).map((s) => ({ userId: s.userId }));
+  });
+  mockDb.user.findMany.mockImplementation(async (args: unknown) => {
+    const ids = (args as { where: { id: { in: number[] } } }).where.id.in;
+    return ids.map((id) => USERS[id]).filter(Boolean);
+  });
+});
+
+describe('🔴 INSTRUMENT CONTROLS', () => {
+  it('the seat fake honours appListingId, status AND displayed', async () => {
+    const all = (await mockDb.appCollaborator.findMany({
+      where: { appListingId: OFFSITE },
+    })) as Array<{ userId: number }>;
+    expect(all.map((r) => r.userId).sort()).toEqual([DISPLAYED, HIDDEN, PENDING, REJECTED].sort());
+
+    const byline = (await mockDb.appCollaborator.findMany({
+      where: { appListingId: OFFSITE, status: 'accepted', displayed: true },
+    })) as Array<{ userId: number }>;
+    expect(byline.map((r) => r.userId)).toEqual([DISPLAYED]);
+
+    // …and a DIFFERENT listing id returns nothing, so "it found rows" is a statement
+    // about the key and not about a fake that answers everything.
+    const other = await mockDb.appCollaborator.findMany({ where: { appListingId: 'apl_other' } });
+    expect(other).toEqual([]);
+  });
+
+  it('the user fake really does return over-wide rows', async () => {
+    const rows = (await mockDb.user.findMany({ where: { id: { in: [DISPLAYED] } } })) as Array<
+      Record<string, unknown>
+    >;
+    expect(Object.keys(rows[0])).toContain('email');
+    expect(Object.keys(rows[0])).toContain('bannedAt');
+  });
+});
+
+describe('🔴 an OFF-SITE listing carries a public collaborator byline', () => {
+  it('the accepted + displayed collaborator APPEARS on the public detail', async () => {
+    const detail = await getListingDetail({ slug: 'ext-app' }, { scope: 'public-external' });
+    expect(detail).not.toBeNull();
+    expect(detail!.collaborators.map((c) => c.id)).toEqual([DISPLAYED]);
+  });
+
+  it('🔴 the byline is read under the LISTING id — the assertion the re-key exists for', async () => {
+    await getListingDetail({ slug: 'ext-app' }, { scope: 'public-external' });
+    expect(mockDb.appCollaborator.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { appListingId: OFFSITE, status: 'accepted', displayed: true },
+      })
+    );
+  });
+
+  it('🔴 CONSENT: a PENDING invitee is absent — a listing cannot borrow a stranger’s name', async () => {
+    const detail = await getListingDetail({ slug: 'ext-app' }, { scope: 'public-external' });
+    expect(detail!.collaborators.map((c) => c.id)).not.toContain(PENDING);
+  });
+
+  it('🔴 a REJECTED invitee is absent', async () => {
+    const detail = await getListingDetail({ slug: 'ext-app' }, { scope: 'public-external' });
+    expect(detail!.collaborators.map((c) => c.id)).not.toContain(REJECTED);
+  });
+
+  it('🔴 OPT-OUT: an accepted collaborator with `displayed: false` is absent', async () => {
+    const detail = await getListingDetail({ slug: 'ext-app' }, { scope: 'public-external' });
+    expect(detail!.collaborators.map((c) => c.id)).not.toContain(HIDDEN);
+  });
+
+  it('🔴 THE ALLOWLIST survives the whole read: exactly {id, username, image}', async () => {
+    // The hydrator is handed a row carrying email/bannedAt/isModerator; an anon-capable
+    // read must emit none of them.
+    const detail = await getListingDetail({ slug: 'ext-app' }, { scope: 'public-external' });
+    const chip = detail!.collaborators[0];
+    expect(Object.keys(chip).sort()).toEqual(['id', 'image', 'username']);
+    expect(chip).not.toHaveProperty('email');
+    expect(chip).not.toHaveProperty('bannedAt');
+    expect(chip).not.toHaveProperty('isModerator');
+    expect(chip).toEqual({ id: DISPLAYED, username: 'editor-shown', image: 'shown.png' });
+  });
+
+  it('a listing with NO seats still projects an empty array, never undefined', async () => {
+    mockDb.appCollaborator.findMany.mockResolvedValue([]);
+    const detail = await getListingDetail({ slug: 'ext-app' }, { scope: 'public-external' });
+    expect(detail!.collaborators).toEqual([]);
+    // …and it does not go looking up users it has no ids for.
+    expect(mockDb.user.findMany).not.toHaveBeenCalled();
+  });
+
+  it('the byline degrades to EMPTY when the manual-apply migration has not landed', async () => {
+    // `safeCollaboratorQuery` swallows only the missing-TABLE error, so the public store
+    // page keeps rendering instead of 500ing for every visitor.
+    mockDb.appCollaborator.findMany.mockRejectedValue(
+      Object.assign(new Error('relation "app_collaborators" does not exist'), { code: 'P2021' })
+    );
+    const detail = await getListingDetail({ slug: 'ext-app' }, { scope: 'public-external' });
+    expect(detail!.collaborators).toEqual([]);
+  });
+
+  it('🔴 NEGATIVE CONTROL: a genuine query failure is NOT swallowed into an empty byline', async () => {
+    // Otherwise this read would be a permanent silent-zero generator and a broken byline
+    // would be indistinguishable from an app with no collaborators.
+    mockDb.appCollaborator.findMany.mockRejectedValue(
+      Object.assign(new Error('connection reset'), { code: 'P1001' })
+    );
+    await expect(
+      getListingDetail({ slug: 'ext-app' }, { scope: 'public-external' })
+    ).rejects.toThrow('connection reset');
+  });
+});
+
+describe('the ONSITE byline still works (regression guard)', () => {
+  it('an onsite listing reads its byline under its OWN listing id, not its block id', async () => {
+    // The re-key had to not break the case that already worked. `appBlockId` is present
+    // on this row and must NOT be what the seat query uses.
+    const ONSITE = 'apl_onsite';
+    mockDb.appListing.findFirst.mockResolvedValue(
+      offsiteRow({
+        id: ONSITE,
+        kind: 'onsite',
+        slug: 'cool-app',
+        externalUrl: null,
+        appBlockId: 'ab_1',
+        appBlock: { manifest: {}, currentVersionDeployedAt: new Date('2026-01-01T00:00:00Z') },
+      })
+    );
+    mockDb.appCollaborator.findMany.mockImplementation(async (args: unknown) => {
+      const w = (args as { where: { appListingId?: string } }).where;
+      return w.appListingId === ONSITE ? [{ userId: DISPLAYED }] : [];
+    });
+    const detail = await getListingDetail({ slug: 'cool-app' }, { scope: 'full' });
+    expect(detail!.collaborators.map((c) => c.id)).toEqual([DISPLAYED]);
+    expect(mockDb.appCollaborator.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ appListingId: ONSITE }) })
+    );
+  });
+});

--- a/src/server/services/blocks/__tests__/app-collaborator.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator.service.test.ts
@@ -78,9 +78,27 @@ const OFFSITE = 'apl_offsite';
 const OFFSITE_SLUG = 'cool-offsite';
 /** A shadow revision of the on-site parent. No seat may EVER live here. */
 const SHADOW = 'apl_shadow';
+/**
+ * 🔴 An OFF-SITE listing that DOES carry a backing AppBlock — the shape where "offsite"
+ * and "has no repo slug" disagree. `mapAppBlockToListing` mints exactly this for an
+ * AppBlock with an `externalUrl` (`kind: 'offsite'` + `appBlockId: ab.id`), reachable via
+ * the mod proc `backfillAppListings`. Every Forgejo gate that keys on the SLUG alone
+ * would fire on it.
+ */
+const OFFSITE_WITH_REPO = 'apl_offsite_with_repo';
+const OFFSITE_REPO_SLUG = 'offsite-repo';
+/**
+ * 🔴 An ON-SITE listing whose denormalized `AppListing.userId` DISAGREES with its
+ * canonical `OauthClient.userId`. `acceptTransfer` step 3 is deliberately unguarded for
+ * onsite and treats a 0-count as an accepted desync, so this state is one the feature's
+ * own code can produce.
+ */
+const DRIFTED = 'apl_drifted';
 const OWNER = 10;
 const TARGET = 20;
 const STRANGER = 50;
+/** The name left behind in a stale denormalized `AppListing.userId`. */
+const STALE_OWNER = 77;
 const NOW = new Date('2026-08-10T12:00:00Z');
 
 /**
@@ -122,6 +140,32 @@ function listingTable(): Record<string, Record<string, unknown>> {
       revisionOfId: LISTING,
       revisionOf: { id: LISTING, kind: 'onsite', appBlockId: APP },
       appBlock: null,
+    },
+    // 🔴 offsite, but WITH a block and therefore WITH a repo slug.
+    [OFFSITE_WITH_REPO]: {
+      id: OFFSITE_WITH_REPO,
+      slug: 'offsite-store-slug',
+      kind: 'offsite',
+      userId: OWNER,
+      appBlockId: 'ab_offsiteBlock',
+      revisionOfId: null,
+      revisionOf: null,
+      appBlock: {
+        appId: 'oc_offsite',
+        blockId: OFFSITE_REPO_SLUG,
+        app: { userId: OWNER },
+      },
+    },
+    // 🔴 onsite, with the canonical owner and the denormalized column DISAGREEING.
+    [DRIFTED]: {
+      id: DRIFTED,
+      slug: 'drifted-slug',
+      kind: 'onsite',
+      userId: STALE_OWNER,
+      appBlockId: 'ab_drifted',
+      revisionOfId: null,
+      revisionOf: null,
+      appBlock: { appId: 'oc_drifted', blockId: 'drifted-repo', app: { userId: OWNER } },
     },
   };
 }
@@ -653,6 +697,58 @@ describe('🔴 Forgejo is ON-SITE ONLY — the `submitVersion: false` capability
     expect(mockRepo.grantAppRepoWrite).toHaveBeenCalledWith({ slug: SLUG, userId: TARGET });
     await removeCollaborator({ appListingId: LISTING, targetUserId: TARGET, actorUserId: OWNER });
     expect(mockRepo.revokeAppRepoWrite).toHaveBeenCalledWith({ slug: SLUG, userId: TARGET });
+  });
+
+  /**
+   * 🔴 THE GATE IS THE **KIND**, NOT THE PRESENCE OF A SLUG.
+   *
+   * `hasWritableRepo` ANDs two predicates that agree on every ordinary row, so a fixture
+   * built only from ordinary rows can be satisfied by either one alone. These three
+   * cases put a REAL repo slug on an OFF-SITE listing, so `blockSlug != null` is TRUE and
+   * only `listingKindSupports(kind,'submitVersion')` can refuse — which makes them the
+   * only cases that can kill a slug-only mutant.
+   */
+  describe('🔴 an OFF-SITE listing that HAS a repo slug still reaches Forgejo NEVER', () => {
+    it('accept grants nothing, even though a slug is available', async () => {
+      const res = await respondToInvite({
+        appListingId: OFFSITE_WITH_REPO,
+        userId: TARGET,
+        accept: true,
+        now: NOW,
+      });
+      expect(res.status).toBe('accepted');
+      expect(mockRepo.grantAppRepoWrite).not.toHaveBeenCalled();
+    });
+
+    it('remove revokes nothing, even though a slug is available', async () => {
+      await removeCollaborator({
+        appListingId: OFFSITE_WITH_REPO,
+        targetUserId: TARGET,
+        actorUserId: OWNER,
+      });
+      expect(mockRepo.revokeAppRepoWrite).not.toHaveBeenCalled();
+    });
+
+    it('leave revokes nothing, even though a slug is available', async () => {
+      await leaveApp({ appListingId: OFFSITE_WITH_REPO, userId: TARGET });
+      expect(mockRepo.revokeAppRepoWrite).not.toHaveBeenCalled();
+    });
+
+    it('🔴 POSITIVE CONTROL: THAT EXACT SLUG does reach Forgejo once the kind is onsite', async () => {
+      // Without this, "not called" is indistinguishable from a fixture whose slug was
+      // never reachable — the same zero, two causes. Only `kind` changes here.
+      LISTINGS[OFFSITE_WITH_REPO] = { ...LISTINGS[OFFSITE_WITH_REPO], kind: 'onsite' };
+      await respondToInvite({
+        appListingId: OFFSITE_WITH_REPO,
+        userId: TARGET,
+        accept: true,
+        now: NOW,
+      });
+      expect(mockRepo.grantAppRepoWrite).toHaveBeenCalledWith({
+        slug: OFFSITE_REPO_SLUG,
+        userId: TARGET,
+      });
+    });
   });
 
   it('🔴 the repo slug is the BLOCK slug, not the store slug', async () => {
@@ -1217,6 +1313,46 @@ describe('listCollaborators — 🔴 the caller must hold a REAL role', () => {
     expect(mockDb.appCollaborator.findMany).toHaveBeenCalledWith(
       expect.objectContaining({ where: { appListingId: LISTING } })
     );
+  });
+
+  /**
+   * 🔴 THE ROSTER GATE MUST USE THE **CANONICAL** OWNER.
+   *
+   * `listCollaborators` routes through `resolveListingAccess`. On `origin/main` this
+   * gate went through `resolveAppAccess`, whose owner is the canonical
+   * `AppBlock.app.userId`; the re-key moved it to the listing resolver, and while that
+   * resolver read `AppListing.userId` the gate silently changed authority to a
+   * DENORMALIZED COPY the feature's own transfer path can leave stale.
+   *
+   * Both directions are pinned, because the regression inverts the gate rather than
+   * merely loosening it: the REAL owner is refused NOT_OWNER on their own roster, and
+   * whoever the stale row names reads the full roster — including `displayed:false`
+   * seats, `invitedBy` and the invite/response timestamps.
+   */
+  describe('🔴 the owner gate is CANONICAL, not the denormalized AppListing.userId', () => {
+    it('POSITIVE CONTROL: the DRIFTED fixture really does disagree with itself', async () => {
+      const row = (await mockDb.appListing.findUnique({ where: { id: DRIFTED } })) as {
+        userId: number;
+        appBlock: { app: { userId: number } };
+      };
+      expect(row.userId).toBe(STALE_OWNER);
+      expect(row.appBlock.app.userId).toBe(OWNER);
+      expect(row.userId).not.toBe(row.appBlock.app.userId);
+    });
+
+    it('🔴 the REAL owner reads their own roster on a drifted listing', async () => {
+      await expect(
+        listCollaborators({ appListingId: DRIFTED, viewerUserId: OWNER, isModerator: false })
+      ).resolves.toHaveLength(1);
+    });
+
+    it('🔴 the STALE user is refused NOT_OWNER — and the rows are never loaded', async () => {
+      await expect(
+        listCollaborators({ appListingId: DRIFTED, viewerUserId: STALE_OWNER, isModerator: false })
+      ).rejects.toMatchObject({ code: 'NOT_OWNER' });
+      // Fail BEFORE the read: the opted-out seats must not even be fetched.
+      expect(mockDb.appCollaborator.findMany).not.toHaveBeenCalled();
+    });
   });
 
   it('POSITIVE CONTROL: the roster fixture really carries an opted-OUT seat', async () => {

--- a/src/server/services/blocks/__tests__/app-collaborator.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator.service.test.ts
@@ -10,6 +10,11 @@ import { constants } from '~/server/common/constants';
  * reject with its status-guarded flip, remove / leave with the Forgejo revoke, the
  * byline opt-in, and the status-VISIBILITY filter.
  *
+ * 🔴 Since the block→listing re-key, two axes are new and are exercised throughout:
+ * the listing KIND (an OFF-SITE listing has no Forgejo repo, so every grant/revoke must
+ * be SKIPPED rather than called with a slug that names nothing), and the SHADOW
+ * REVISION hazard (a seat may only exist on a parent).
+ *
  * `dbWrite.$transaction` runs its callback against the SAME `dbWrite` mock (the tx
  * client), so a test asserts the exact writes made inside the transaction.
  * `dbRead`/`dbWrite` are the same object here — these paths do not depend on the
@@ -20,6 +25,7 @@ import { constants } from '~/server/common/constants';
 const { mockDb, mockRepo, mockNotify } = vi.hoisted(() => {
   const db = {
     appBlock: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    appListing: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
     user: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
     appCollaborator: {
       findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
@@ -54,6 +60,7 @@ const {
   inviteCollaborator,
   leaveApp,
   listCollaborators,
+  listMyPendingInvites,
   mapCollaboratorError,
   removeCollaborator,
   respondToInvite,
@@ -64,17 +71,83 @@ const { TRPCError } = await import('@trpc/server');
 
 const APP = 'ab_app1';
 const SLUG = 'my-app';
+/** The ON-SITE parent listing — has a backing AppBlock, so it has a Forgejo repo. */
+const LISTING = 'apl_live';
+/** The OFF-SITE parent listing — no AppBlock, no repo, no earnings. */
+const OFFSITE = 'apl_offsite';
+const OFFSITE_SLUG = 'cool-offsite';
+/** A shadow revision of the on-site parent. No seat may EVER live here. */
+const SHADOW = 'apl_shadow';
 const OWNER = 10;
 const TARGET = 20;
 const STRANGER = 50;
 const NOW = new Date('2026-08-10T12:00:00Z');
 
+/**
+ * The listing table the fixture serves, keyed by id.
+ *
+ * 🔴 PAIRWISE-DISTINCT VALUES on purpose: the on-site and off-site rows differ in id,
+ * slug, kind, appBlockId AND appBlock, so an assertion cannot be satisfied by the wrong
+ * row happening to look like the right one.
+ */
+function listingTable(): Record<string, Record<string, unknown>> {
+  return {
+    [LISTING]: {
+      id: LISTING,
+      slug: SLUG,
+      kind: 'onsite',
+      userId: OWNER,
+      appBlockId: APP,
+      revisionOfId: null,
+      revisionOf: null,
+      appBlock: { appId: 'oc_app1', blockId: SLUG, app: { userId: OWNER } },
+    },
+    [OFFSITE]: {
+      id: OFFSITE,
+      slug: OFFSITE_SLUG,
+      kind: 'offsite',
+      userId: OWNER,
+      appBlockId: null,
+      revisionOfId: null,
+      revisionOf: null,
+      appBlock: null,
+    },
+    [SHADOW]: {
+      id: SHADOW,
+      slug: SLUG,
+      kind: 'onsite',
+      userId: OWNER,
+      // A shadow carries appBlockId: null by construction (@unique stays on the parent).
+      appBlockId: null,
+      revisionOfId: LISTING,
+      revisionOf: { id: LISTING, kind: 'onsite', appBlockId: APP },
+      appBlock: null,
+    },
+  };
+}
+
+let LISTINGS: Record<string, Record<string, unknown>>;
+
 beforeEach(() => {
   vi.clearAllMocks();
+  LISTINGS = listingTable();
   mockDb.$transaction.mockImplementation(async (cb: (tx: typeof mockDb) => Promise<unknown>) =>
     cb(mockDb)
   );
-  mockDb.appBlock.findUnique.mockResolvedValue({ id: APP, blockId: SLUG, app: { userId: OWNER } });
+  mockDb.appListing.findUnique.mockImplementation(async (args: unknown): Promise<unknown> => {
+    const w = (args as { where: { id?: string; appBlockId?: string } }).where;
+    if (w.id) return LISTINGS[w.id] ?? null;
+    if (w.appBlockId) {
+      return Object.values(LISTINGS).find((l) => l.appBlockId === w.appBlockId) ?? null;
+    }
+    return null;
+  });
+  mockDb.appBlock.findUnique.mockResolvedValue({
+    id: APP,
+    blockId: SLUG,
+    app: { userId: OWNER },
+    appListing: { id: LISTING },
+  });
   mockDb.user.findUnique.mockResolvedValue({ id: TARGET, bannedAt: null });
   mockDb.appCollaborator.findUnique.mockResolvedValue(null);
   mockDb.appCollaborator.count.mockResolvedValue(0);
@@ -120,25 +193,90 @@ describe('shouldNotifyInvite — 🔴 the inverted-throttle guard', () => {
 describe('inviteCollaborator', () => {
   it('the OWNER can invite; the row is created PENDING and an event is written', async () => {
     const res = await inviteCollaborator({
-      appBlockId: APP,
+      appListingId: LISTING,
       targetUserId: TARGET,
       actorUserId: OWNER,
       now: NOW,
     });
     expect(res).toMatchObject({ status: 'pending', created: true, notified: true });
     const upsert = mockDb.appCollaborator.upsert.mock.calls[0][0] as {
-      create: { status: string; role: string };
+      create: { status: string; role: string; appListingId: string };
     };
     expect(upsert.create.status).toBe('pending');
     expect(upsert.create.role).toBe('editor');
-    const evt = mockDb.appOwnershipEvent.create.mock.calls[0][0] as { data: { action: string } };
+    // 🔴 The re-key, at the write side: the seat is stored under the LISTING id.
+    expect(upsert.create.appListingId).toBe(LISTING);
+    const evt = mockDb.appOwnershipEvent.create.mock.calls[0][0] as {
+      data: { action: string; appListingId: string };
+    };
     expect(evt.data.action).toBe('invite');
+    expect(evt.data.appListingId).toBe(LISTING);
     expect(mockNotify.notifyAppCollaborator).toHaveBeenCalledOnce();
+  });
+
+  it('🔴 an OFF-SITE listing can be seated — the whole point of the re-key', async () => {
+    const res = await inviteCollaborator({
+      appListingId: OFFSITE,
+      targetUserId: TARGET,
+      actorUserId: OWNER,
+      now: NOW,
+    });
+    expect(res).toMatchObject({ appListingId: OFFSITE, status: 'pending', created: true });
+    const upsert = mockDb.appCollaborator.upsert.mock.calls[0][0] as {
+      create: { appListingId: string };
+    };
+    expect(upsert.create.appListingId).toBe(OFFSITE);
+  });
+
+  it('🔴 the OFF-SITE owner is the LISTING’s userId — there is no OauthClient in that chain', async () => {
+    // The onsite owner comes from `appBlock.app.userId`; offsite has no appBlock, so the
+    // column IS the owner. A resolver that only ever read `appBlock.app.userId` would
+    // refuse every off-site owner with NOT_OWNER.
+    LISTINGS[OFFSITE] = { ...LISTINGS[OFFSITE], userId: 777 };
+    await expect(
+      inviteCollaborator({
+        appListingId: OFFSITE,
+        targetUserId: TARGET,
+        actorUserId: 777,
+        now: NOW,
+      })
+    ).resolves.toMatchObject({ status: 'pending' });
+  });
+
+  it('🔴 ONSITE ownership is the OauthClient’s, even when the listing’s copy is STALE', async () => {
+    // `AppListing.userId` is a DENORMALIZED copy for an on-site listing, and it can
+    // legitimately drift (a mod `claimListing`, a partial write, a backfill). The
+    // canonical owner is `AppBlock.app.userId`. Resolving from the copy would let a
+    // stale row lock the REAL owner out of managing their own collaborators — and would
+    // let whoever the stale row names in.
+    LISTINGS[LISTING] = { ...LISTINGS[LISTING], userId: 999 };
+    await expect(
+      inviteCollaborator({
+        appListingId: LISTING,
+        targetUserId: TARGET,
+        actorUserId: OWNER,
+        now: NOW,
+      })
+    ).resolves.toMatchObject({ status: 'pending' });
+    // …and the stale name does NOT get in.
+    await expect(
+      inviteCollaborator({
+        appListingId: LISTING,
+        targetUserId: TARGET,
+        actorUserId: 999,
+        now: NOW,
+      })
+    ).rejects.toMatchObject({ code: 'NOT_OWNER' });
   });
 
   it('🔴 a NON-OWNER (even an accepted editor) cannot invite — seats are owner-managed', async () => {
     await expect(
-      inviteCollaborator({ appBlockId: APP, targetUserId: TARGET, actorUserId: STRANGER, now: NOW })
+      inviteCollaborator({
+        appListingId: LISTING,
+        targetUserId: TARGET,
+        actorUserId: STRANGER,
+        now: NOW,
+      })
     ).rejects.toMatchObject({ code: 'NOT_OWNER' });
     expect(mockDb.appCollaborator.upsert).not.toHaveBeenCalled();
     expect(mockDb.appOwnershipEvent.create).not.toHaveBeenCalled();
@@ -146,21 +284,37 @@ describe('inviteCollaborator', () => {
 
   it('inviting the OWNER is INVALID_TARGET', async () => {
     await expect(
-      inviteCollaborator({ appBlockId: APP, targetUserId: OWNER, actorUserId: OWNER, now: NOW })
+      inviteCollaborator({ appListingId: LISTING, targetUserId: OWNER, actorUserId: OWNER, now: NOW })
     ).rejects.toMatchObject({ code: 'INVALID_TARGET' });
   });
 
   it('a nonexistent target is INVALID_TARGET (never a raw FK error)', async () => {
     mockDb.user.findUnique.mockResolvedValue(null);
     await expect(
-      inviteCollaborator({ appBlockId: APP, targetUserId: 999, actorUserId: OWNER, now: NOW })
+      inviteCollaborator({ appListingId: LISTING, targetUserId: 999, actorUserId: OWNER, now: NOW })
     ).rejects.toMatchObject({ code: 'INVALID_TARGET' });
+  });
+
+  it('a missing listing is NOT_FOUND', async () => {
+    await expect(
+      inviteCollaborator({
+        appListingId: 'apl_nope',
+        targetUserId: TARGET,
+        actorUserId: OWNER,
+        now: NOW,
+      })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
   });
 
   it('🔴 a BANNED target cannot be seated (the ban decision)', async () => {
     mockDb.user.findUnique.mockResolvedValue({ id: TARGET, bannedAt: new Date() });
     await expect(
-      inviteCollaborator({ appBlockId: APP, targetUserId: TARGET, actorUserId: OWNER, now: NOW })
+      inviteCollaborator({
+        appListingId: LISTING,
+        targetUserId: TARGET,
+        actorUserId: OWNER,
+        now: NOW,
+      })
     ).rejects.toMatchObject({ code: 'BANNED' });
     expect(mockDb.appCollaborator.upsert).not.toHaveBeenCalled();
   });
@@ -171,7 +325,12 @@ describe('inviteCollaborator', () => {
       lastNotifiedAt: null,
     });
     await expect(
-      inviteCollaborator({ appBlockId: APP, targetUserId: TARGET, actorUserId: OWNER, now: NOW })
+      inviteCollaborator({
+        appListingId: LISTING,
+        targetUserId: TARGET,
+        actorUserId: OWNER,
+        now: NOW,
+      })
     ).rejects.toMatchObject({ code: 'ALREADY_SEATED' });
   });
 
@@ -181,7 +340,7 @@ describe('inviteCollaborator', () => {
       lastNotifiedAt: null,
     });
     const res = await inviteCollaborator({
-      appBlockId: APP,
+      appListingId: LISTING,
       targetUserId: TARGET,
       actorUserId: OWNER,
       now: NOW,
@@ -200,7 +359,7 @@ describe('inviteCollaborator', () => {
       lastNotifiedAt: new Date(NOW.getTime() - 60_000),
     });
     const res = await inviteCollaborator({
-      appBlockId: APP,
+      appListingId: LISTING,
       targetUserId: TARGET,
       actorUserId: OWNER,
       now: NOW,
@@ -212,21 +371,28 @@ describe('inviteCollaborator', () => {
   it('the CAP blocks a NEW seat at the configured maximum', async () => {
     mockDb.appCollaborator.count.mockResolvedValue(constants.appCollaborators.maxCollaborators);
     await expect(
-      inviteCollaborator({ appBlockId: APP, targetUserId: TARGET, actorUserId: OWNER, now: NOW })
+      inviteCollaborator({
+        appListingId: LISTING,
+        targetUserId: TARGET,
+        actorUserId: OWNER,
+        now: NOW,
+      })
     ).rejects.toMatchObject({ code: 'CAP_REACHED' });
   });
 
   it('the cap counts PENDING + ACCEPTED only — a rejected row occupies no seat', async () => {
     await inviteCollaborator({
-      appBlockId: APP,
+      appListingId: LISTING,
       targetUserId: TARGET,
       actorUserId: OWNER,
       now: NOW,
     });
     const args = mockDb.appCollaborator.count.mock.calls[0][0] as {
-      where: { status: { in: string[] } };
+      where: { appListingId: string; status: { in: string[] } };
     };
     expect(args.where.status.in.sort()).toEqual(['accepted', 'pending']);
+    // …and the cap is per LISTING, not global.
+    expect(args.where.appListingId).toBe(LISTING);
   });
 
   it('the cap is NOT re-charged when re-touching an existing row', async () => {
@@ -236,16 +402,114 @@ describe('inviteCollaborator', () => {
     });
     mockDb.appCollaborator.count.mockResolvedValue(constants.appCollaborators.maxCollaborators);
     await expect(
-      inviteCollaborator({ appBlockId: APP, targetUserId: TARGET, actorUserId: OWNER, now: NOW })
+      inviteCollaborator({
+        appListingId: LISTING,
+        targetUserId: TARGET,
+        actorUserId: OWNER,
+        now: NOW,
+      })
     ).resolves.toMatchObject({ status: 'pending' });
   });
 
   it('a notification failure does NOT undo the invite (best-effort, post-commit)', async () => {
     mockNotify.notifyAppCollaborator.mockRejectedValueOnce(new Error('notifications down'));
     await expect(
-      inviteCollaborator({ appBlockId: APP, targetUserId: TARGET, actorUserId: OWNER, now: NOW })
+      inviteCollaborator({
+        appListingId: LISTING,
+        targetUserId: TARGET,
+        actorUserId: OWNER,
+        now: NOW,
+      })
     ).resolves.toMatchObject({ status: 'pending' });
     expect(mockDb.appCollaborator.upsert).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 🔴 THE SHADOW HAZARD — a seat may only ever exist on a PARENT listing.
+// ---------------------------------------------------------------------------
+
+describe('🔴 SHADOW HAZARD — a seat can never be created on a revision draft', () => {
+  /**
+   * WHY THIS IS A SAFETY GUARD AND NOT A NICETY.
+   *
+   * `applyApprovedRevision` DELETES the shadow when a moderator approves the revision,
+   * and `app_collaborators.app_listing_id` is `ON DELETE CASCADE`. So a seat that landed
+   * on a shadow would be destroyed by a routine approve — silently, with no error, and
+   * with the audit event still claiming the person was seated. A SQL CHECK cannot
+   * express "parent only" (a row-level CHECK cannot see another row's `revision_of_id`),
+   * so the invariant is held here and in `resolveListingAccess`'s parent hop.
+   *
+   * The sibling direction — a seat on the PARENT SURVIVING an approve — is pinned in
+   * `app-collaborator.revision-non-clobber.test.ts`.
+   */
+  it('inviting on a SHADOW is refused, and nothing is written', async () => {
+    await expect(
+      inviteCollaborator({
+        appListingId: SHADOW,
+        targetUserId: TARGET,
+        actorUserId: OWNER,
+        now: NOW,
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_TARGET' });
+    expect(mockDb.appCollaborator.upsert).not.toHaveBeenCalled();
+    expect(mockDb.appOwnershipEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('🔴 the refusal names the reason (it is a product statement, not an internal error)', async () => {
+    await expect(
+      inviteCollaborator({
+        appListingId: SHADOW,
+        targetUserId: TARGET,
+        actorUserId: OWNER,
+        now: NOW,
+      })
+    ).rejects.toMatchObject({
+      message: 'Collaborators are managed on the live listing, not on a revision draft',
+    });
+  });
+
+  it('🔴 the refusal fires BEFORE the owner check — the id as SUPPLIED is what is tested', async () => {
+    // The guard must not be reachable only via the parent-resolved row: `assertOwner`
+    // hops to the parent, so a check placed after it could never see the shadow at all.
+    // A STRANGER on a shadow must still get the shadow error, not NOT_OWNER.
+    await expect(
+      inviteCollaborator({
+        appListingId: SHADOW,
+        targetUserId: TARGET,
+        actorUserId: STRANGER,
+        now: NOW,
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_TARGET' });
+  });
+
+  it('POSITIVE CONTROL: the SAME invite on the shadow’s PARENT succeeds', async () => {
+    // Proves the refusal is about the shadow and not about some other fixture defect.
+    await expect(
+      inviteCollaborator({
+        appListingId: LISTING,
+        targetUserId: TARGET,
+        actorUserId: OWNER,
+        now: NOW,
+      })
+    ).resolves.toMatchObject({ appListingId: LISTING, created: true });
+  });
+
+  it('🔴 every OTHER seat mutation handed a shadow id acts on the PARENT’s seat', async () => {
+    // Refusing everywhere would break the editor mid-revision; the resolve-to-parent hop
+    // is the single path, so these land on the parent rather than on a doomed namespace.
+    await respondToInvite({ appListingId: SHADOW, userId: TARGET, accept: true, now: NOW });
+    const upd = mockDb.appCollaborator.updateMany.mock.calls[0][0] as {
+      where: { appListingId: string };
+    };
+    expect(upd.where.appListingId).toBe(LISTING);
+
+    mockDb.appCollaborator.deleteMany.mockClear();
+    await leaveApp({ appListingId: SHADOW, userId: TARGET });
+    const del = mockDb.appCollaborator.deleteMany.mock.calls[0][0] as {
+      where: { appListingId: string };
+    };
+    expect(del.where.appListingId).toBe(LISTING);
   });
 });
 
@@ -255,7 +519,12 @@ describe('inviteCollaborator', () => {
 
 describe('respondToInvite', () => {
   it('ACCEPT flips the row and GRANTS Forgejo write', async () => {
-    const res = await respondToInvite({ appBlockId: APP, userId: TARGET, accept: true, now: NOW });
+    const res = await respondToInvite({
+      appListingId: LISTING,
+      userId: TARGET,
+      accept: true,
+      now: NOW,
+    });
     expect(res.status).toBe('accepted');
     const upd = mockDb.appCollaborator.updateMany.mock.calls[0][0] as {
       where: { status: string };
@@ -269,7 +538,12 @@ describe('respondToInvite', () => {
   });
 
   it('REJECT flips the row and grants NOTHING', async () => {
-    const res = await respondToInvite({ appBlockId: APP, userId: TARGET, accept: false, now: NOW });
+    const res = await respondToInvite({
+      appListingId: LISTING,
+      userId: TARGET,
+      accept: false,
+      now: NOW,
+    });
     expect(res.status).toBe('rejected');
     expect(mockRepo.grantAppRepoWrite).not.toHaveBeenCalled();
   });
@@ -279,7 +553,7 @@ describe('respondToInvite', () => {
     // The real $transaction rolls back on throw; the fake runs inline, so assert on the
     // ORDER instead: the guard must throw BEFORE the event create is reached.
     await expect(
-      respondToInvite({ appBlockId: APP, userId: STRANGER, accept: true, now: NOW })
+      respondToInvite({ appListingId: LISTING, userId: STRANGER, accept: true, now: NOW })
     ).rejects.toMatchObject({ code: 'NO_INVITE' });
     expect(mockDb.appOwnershipEvent.create).not.toHaveBeenCalled();
     expect(mockRepo.grantAppRepoWrite).not.toHaveBeenCalled();
@@ -288,14 +562,14 @@ describe('respondToInvite', () => {
   it('🔴 a BANNED user cannot ACCEPT', async () => {
     mockDb.user.findUnique.mockResolvedValue({ bannedAt: new Date() });
     await expect(
-      respondToInvite({ appBlockId: APP, userId: TARGET, accept: true, now: NOW })
+      respondToInvite({ appListingId: LISTING, userId: TARGET, accept: true, now: NOW })
     ).rejects.toMatchObject({ code: 'BANNED' });
   });
 
   it('a BANNED user CAN decline (declining takes nothing away from anyone)', async () => {
     mockDb.user.findUnique.mockResolvedValue({ bannedAt: new Date() });
     await expect(
-      respondToInvite({ appBlockId: APP, userId: TARGET, accept: false, now: NOW })
+      respondToInvite({ appListingId: LISTING, userId: TARGET, accept: false, now: NOW })
     ).resolves.toMatchObject({ status: 'rejected' });
   });
 
@@ -306,7 +580,7 @@ describe('respondToInvite', () => {
   // misleading rather than merely incomplete, and nothing downstream would ever
   // contradict it.
   it('🔴 ACCEPT is recorded as `accept` in the audit trail', async () => {
-    await respondToInvite({ appBlockId: APP, userId: TARGET, accept: true, now: NOW });
+    await respondToInvite({ appListingId: LISTING, userId: TARGET, accept: true, now: NOW });
     const evt = mockDb.appOwnershipEvent.create.mock.calls[0][0] as {
       data: { action: string; actorUserId: number; targetUserId: number };
     };
@@ -316,21 +590,81 @@ describe('respondToInvite', () => {
   });
 
   it('🔴 REJECT is recorded as `reject` — the two are not interchangeable', async () => {
-    await respondToInvite({ appBlockId: APP, userId: TARGET, accept: false, now: NOW });
+    await respondToInvite({ appListingId: LISTING, userId: TARGET, accept: false, now: NOW });
     const evt = mockDb.appOwnershipEvent.create.mock.calls[0][0] as { data: { action: string } };
     expect(evt.data.action).toBe('reject');
   });
 
   it('POSITIVE CONTROL: the two branches really do write DIFFERENT actions', async () => {
     // Otherwise both assertions above could be satisfied by one constant string.
-    await respondToInvite({ appBlockId: APP, userId: TARGET, accept: true, now: NOW });
+    await respondToInvite({ appListingId: LISTING, userId: TARGET, accept: true, now: NOW });
     const a = (mockDb.appOwnershipEvent.create.mock.calls[0][0] as { data: { action: string } })
       .data.action;
     mockDb.appOwnershipEvent.create.mockClear();
-    await respondToInvite({ appBlockId: APP, userId: TARGET, accept: false, now: NOW });
+    await respondToInvite({ appListingId: LISTING, userId: TARGET, accept: false, now: NOW });
     const b = (mockDb.appOwnershipEvent.create.mock.calls[0][0] as { data: { action: string } })
       .data.action;
     expect(a).not.toBe(b);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 🔴 KIND × Forgejo — an off-site seat must never reach the repo service.
+// ---------------------------------------------------------------------------
+
+describe('🔴 Forgejo is ON-SITE ONLY — the `submitVersion: false` capability, enforced', () => {
+  /**
+   * An off-site listing has no bundle and no repo. Calling `grantAppRepoWrite` with a
+   * store slug that names no repository would be a guaranteed remote 404 on EVERY
+   * off-site accept — and because the grant is best-effort post-commit, it would fail
+   * silently forever rather than surface. The guard is "there is a backing AppBlock",
+   * which is the same fact the capability table encodes.
+   */
+  it('accepting a seat on an OFF-SITE listing grants NOTHING', async () => {
+    const res = await respondToInvite({
+      appListingId: OFFSITE,
+      userId: TARGET,
+      accept: true,
+      now: NOW,
+    });
+    expect(res.status).toBe('accepted');
+    expect(mockRepo.grantAppRepoWrite).not.toHaveBeenCalled();
+  });
+
+  it('removing an OFF-SITE seat revokes NOTHING', async () => {
+    const res = await removeCollaborator({
+      appListingId: OFFSITE,
+      targetUserId: TARGET,
+      actorUserId: OWNER,
+    });
+    expect(res.removed).toBe(true);
+    expect(mockRepo.revokeAppRepoWrite).not.toHaveBeenCalled();
+  });
+
+  it('leaving an OFF-SITE listing revokes NOTHING', async () => {
+    await leaveApp({ appListingId: OFFSITE, userId: TARGET });
+    expect(mockRepo.revokeAppRepoWrite).not.toHaveBeenCalled();
+  });
+
+  it('🔴 POSITIVE CONTROL: the SAME three actions on the ON-SITE listing DO reach Forgejo', async () => {
+    // Without this, "not called" is indistinguishable from a repo mock that is never
+    // called by anything — the classic reassuring zero.
+    await respondToInvite({ appListingId: LISTING, userId: TARGET, accept: true, now: NOW });
+    expect(mockRepo.grantAppRepoWrite).toHaveBeenCalledWith({ slug: SLUG, userId: TARGET });
+    await removeCollaborator({ appListingId: LISTING, targetUserId: TARGET, actorUserId: OWNER });
+    expect(mockRepo.revokeAppRepoWrite).toHaveBeenCalledWith({ slug: SLUG, userId: TARGET });
+  });
+
+  it('🔴 the repo slug is the BLOCK slug, not the store slug', async () => {
+    // They coincide for on-site listings today, so the fixture makes them differ to
+    // prove which one is actually read: the Forgejo repo is `civitai-apps/<blockId>`.
+    LISTINGS[LISTING] = {
+      ...LISTINGS[LISTING],
+      slug: 'store-facing-slug',
+      appBlock: { appId: 'oc_app1', blockId: 'repo-slug', app: { userId: OWNER } },
+    };
+    await respondToInvite({ appListingId: LISTING, userId: TARGET, accept: true, now: NOW });
+    expect(mockRepo.grantAppRepoWrite).toHaveBeenCalledWith({ slug: 'repo-slug', userId: TARGET });
   });
 });
 
@@ -341,7 +675,7 @@ describe('respondToInvite', () => {
 describe('removeCollaborator / leaveApp — the REVOKE half', () => {
   it('the owner removes a seat and the repo grant is REVOKED', async () => {
     const res = await removeCollaborator({
-      appBlockId: APP,
+      appListingId: LISTING,
       targetUserId: TARGET,
       actorUserId: OWNER,
     });
@@ -351,7 +685,7 @@ describe('removeCollaborator / leaveApp — the REVOKE half', () => {
 
   it('a NON-OWNER cannot remove someone else', async () => {
     await expect(
-      removeCollaborator({ appBlockId: APP, targetUserId: TARGET, actorUserId: STRANGER })
+      removeCollaborator({ appListingId: LISTING, targetUserId: TARGET, actorUserId: STRANGER })
     ).rejects.toMatchObject({ code: 'NOT_OWNER' });
     expect(mockRepo.revokeAppRepoWrite).not.toHaveBeenCalled();
   });
@@ -359,7 +693,7 @@ describe('removeCollaborator / leaveApp — the REVOKE half', () => {
   it('removing a seat that does not exist is a no-op and revokes nothing', async () => {
     mockDb.appCollaborator.deleteMany.mockResolvedValue({ count: 0 });
     const res = await removeCollaborator({
-      appBlockId: APP,
+      appListingId: LISTING,
       targetUserId: TARGET,
       actorUserId: OWNER,
     });
@@ -369,7 +703,7 @@ describe('removeCollaborator / leaveApp — the REVOKE half', () => {
   });
 
   it('a COLLABORATOR may leave without any owner check — and is revoked', async () => {
-    const res = await leaveApp({ appBlockId: APP, userId: TARGET });
+    const res = await leaveApp({ appListingId: LISTING, userId: TARGET });
     expect(res.removed).toBe(true);
     expect(mockRepo.revokeAppRepoWrite).toHaveBeenCalledWith({ slug: SLUG, userId: TARGET });
     const evt = mockDb.appOwnershipEvent.create.mock.calls[0][0] as { data: { action: string } };
@@ -384,7 +718,7 @@ describe('removeCollaborator / leaveApp — the REVOKE half', () => {
 describe('🔴 leaveApp / removeCollaborator delete EXACTLY ONE seat', () => {
   /**
    * THE WORST SURVIVING MUTANT. Dropping `userId` from `leaveApp`'s `where` turns "I
-   * give up my seat" into "every collaborator on this app is removed" — a one-word
+   * give up my seat" into "every collaborator on this listing is removed" — a one-word
    * deletion, performed by a NON-OWNER (leaving needs no owner check, correctly), that
    * no test noticed. The old fixture asserted only `deleteMany` returned `count: 1`,
    * which a table-wide delete satisfies just as well as a targeted one.
@@ -396,23 +730,23 @@ describe('🔴 leaveApp / removeCollaborator delete EXACTLY ONE seat', () => {
   const OTHER_SEAT = 21;
 
   /** The seat table, mutated for real by the fake `deleteMany`. */
-  let seats: Array<{ appBlockId: string; userId: number }>;
+  let seats: Array<{ appListingId: string; userId: number }>;
 
   beforeEach(() => {
     seats = [
-      { appBlockId: APP, userId: TARGET },
-      { appBlockId: APP, userId: OTHER_SEAT },
-      // A seat on a DIFFERENT app, so an over-broad `where` that keeps `userId` but
-      // drops `appBlockId` is caught too.
-      { appBlockId: 'ab_other', userId: TARGET },
+      { appListingId: LISTING, userId: TARGET },
+      { appListingId: LISTING, userId: OTHER_SEAT },
+      // A seat on a DIFFERENT listing, so an over-broad `where` that keeps `userId` but
+      // drops `appListingId` is caught too.
+      { appListingId: OFFSITE, userId: TARGET },
     ];
     mockDb.appCollaborator.deleteMany.mockImplementation(async (args: unknown) => {
-      const w = (args as { where: { appBlockId?: string; userId?: number } }).where;
+      const w = (args as { where: { appListingId?: string; userId?: number } }).where;
       const before = seats.length;
       seats = seats.filter(
         (s) =>
           !(
-            (w.appBlockId === undefined || s.appBlockId === w.appBlockId) &&
+            (w.appListingId === undefined || s.appListingId === w.appListingId) &&
             (w.userId === undefined || s.userId === w.userId)
           )
       );
@@ -427,32 +761,32 @@ describe('🔴 leaveApp / removeCollaborator delete EXACTLY ONE seat', () => {
     expect(seats).toEqual([]);
   });
 
-  it('🔴 leaveApp removes ONLY the caller’s seat on THIS app', async () => {
-    const res = await leaveApp({ appBlockId: APP, userId: TARGET });
+  it('🔴 leaveApp removes ONLY the caller’s seat on THIS listing', async () => {
+    const res = await leaveApp({ appListingId: LISTING, userId: TARGET });
     expect(res.removed).toBe(true);
     // The co-editor keeps their seat. A `where` missing `userId` deletes them too.
-    expect(seats).toContainEqual({ appBlockId: APP, userId: OTHER_SEAT });
-    // …and the caller's seat on an unrelated app survives. A `where` missing
-    // `appBlockId` takes that one.
-    expect(seats).toContainEqual({ appBlockId: 'ab_other', userId: TARGET });
-    expect(seats).not.toContainEqual({ appBlockId: APP, userId: TARGET });
+    expect(seats).toContainEqual({ appListingId: LISTING, userId: OTHER_SEAT });
+    // …and the caller's seat on an unrelated listing survives. A `where` missing
+    // `appListingId` takes that one.
+    expect(seats).toContainEqual({ appListingId: OFFSITE, userId: TARGET });
+    expect(seats).not.toContainEqual({ appListingId: LISTING, userId: TARGET });
     expect(seats).toHaveLength(2);
   });
 
   it('🔴 leaveApp revokes repo write for the LEAVER only', async () => {
-    await leaveApp({ appBlockId: APP, userId: TARGET });
+    await leaveApp({ appListingId: LISTING, userId: TARGET });
     expect(mockRepo.revokeAppRepoWrite).toHaveBeenCalledOnce();
     expect(mockRepo.revokeAppRepoWrite).toHaveBeenCalledWith({ slug: SLUG, userId: TARGET });
   });
 
   it('🔴 removeCollaborator removes ONLY the named target', async () => {
-    await removeCollaborator({ appBlockId: APP, targetUserId: TARGET, actorUserId: OWNER });
-    expect(seats).toContainEqual({ appBlockId: APP, userId: OTHER_SEAT });
-    expect(seats).not.toContainEqual({ appBlockId: APP, userId: TARGET });
+    await removeCollaborator({ appListingId: LISTING, targetUserId: TARGET, actorUserId: OWNER });
+    expect(seats).toContainEqual({ appListingId: LISTING, userId: OTHER_SEAT });
+    expect(seats).not.toContainEqual({ appListingId: LISTING, userId: TARGET });
   });
 
-  it('leaving an app you hold no seat on removes nothing and revokes nothing', async () => {
-    const res = await leaveApp({ appBlockId: APP, userId: STRANGER });
+  it('leaving a listing you hold no seat on removes nothing and revokes nothing', async () => {
+    const res = await leaveApp({ appListingId: LISTING, userId: STRANGER });
     expect(res.removed).toBe(false);
     expect(seats).toHaveLength(3);
     expect(mockRepo.revokeAppRepoWrite).not.toHaveBeenCalled();
@@ -506,23 +840,28 @@ describe('🔴 recordOwnershipEvent writes through the `tx`, not `dbWrite`', () 
     [
       'inviteCollaborator',
       () =>
-        inviteCollaborator({ appBlockId: APP, targetUserId: TARGET, actorUserId: OWNER, now: NOW }),
+        inviteCollaborator({
+          appListingId: LISTING,
+          targetUserId: TARGET,
+          actorUserId: OWNER,
+          now: NOW,
+        }),
       'invite',
     ],
     [
       'respondToInvite',
-      () => respondToInvite({ appBlockId: APP, userId: TARGET, accept: true, now: NOW }),
+      () => respondToInvite({ appListingId: LISTING, userId: TARGET, accept: true, now: NOW }),
       'accept',
     ],
     [
       'removeCollaborator',
-      () => removeCollaborator({ appBlockId: APP, targetUserId: TARGET, actorUserId: OWNER }),
+      () => removeCollaborator({ appListingId: LISTING, targetUserId: TARGET, actorUserId: OWNER }),
       'remove',
     ],
-    ['leaveApp', () => leaveApp({ appBlockId: APP, userId: TARGET }), 'leave'],
+    ['leaveApp', () => leaveApp({ appListingId: LISTING, userId: TARGET }), 'leave'],
     [
       'setCollaboratorDisplayed',
-      () => setCollaboratorDisplayed({ appBlockId: APP, userId: TARGET, displayed: true }),
+      () => setCollaboratorDisplayed({ appListingId: LISTING, userId: TARGET, displayed: true }),
       'display',
     ],
   ];
@@ -540,7 +879,7 @@ describe('🔴 recordOwnershipEvent writes through the `tx`, not `dbWrite`', () 
   }
 
   it('the seat WRITE goes through the tx too, not just the event', async () => {
-    await respondToInvite({ appBlockId: APP, userId: TARGET, accept: true, now: NOW });
+    await respondToInvite({ appListingId: LISTING, userId: TARGET, accept: true, now: NOW });
     expect(tx.appCollaborator.updateMany).toHaveBeenCalledOnce();
     expect(mockDb.appCollaborator.updateMany).not.toHaveBeenCalled();
   });
@@ -553,26 +892,35 @@ describe('🔴 recordOwnershipEvent writes through the `tx`, not `dbWrite`', () 
 describe('setCollaboratorDisplayed', () => {
   it('an ACCEPTED collaborator can toggle their byline', async () => {
     const res = await setCollaboratorDisplayed({
-      appBlockId: APP,
+      appListingId: LISTING,
       userId: TARGET,
       displayed: false,
     });
     expect(res.displayed).toBe(false);
     const upd = mockDb.appCollaborator.updateMany.mock.calls[0][0] as {
-      where: { status: string };
+      where: { status: string; appListingId: string };
       data: { displayed: boolean };
     };
     // 🔴 Guarded on ACCEPTED: a pending invitee must not be able to pre-arrange public
     // credit for a seat they have not taken.
     expect(upd.where.status).toBe('accepted');
+    expect(upd.where.appListingId).toBe(LISTING);
     expect(upd.data.displayed).toBe(false);
   });
 
   it('a non-accepted (or absent) row is refused', async () => {
     mockDb.appCollaborator.updateMany.mockResolvedValue({ count: 0 });
     await expect(
-      setCollaboratorDisplayed({ appBlockId: APP, userId: STRANGER, displayed: true })
+      setCollaboratorDisplayed({ appListingId: LISTING, userId: STRANGER, displayed: true })
     ).rejects.toMatchObject({ code: 'NO_INVITE' });
+  });
+
+  it('an OFF-SITE collaborator can toggle their byline too', async () => {
+    // The byline is the one collaborator surface that is fully public, and it is
+    // kind-agnostic — an off-site listing's detail page carries the same chips.
+    await expect(
+      setCollaboratorDisplayed({ appListingId: OFFSITE, userId: TARGET, displayed: false })
+    ).resolves.toMatchObject({ appListingId: OFFSITE, displayed: false });
   });
 });
 
@@ -780,10 +1128,10 @@ describe('mapCollaboratorError — the router’s status-code contract', () => {
 
 describe('listCollaborators — 🔴 the caller must hold a REAL role', () => {
   /**
-   * `resolveAppAccess` was consulted here only for `ownerUserId`; its `role` was never
-   * required non-null. The status filter governs which ROWS a viewer sees, not whether
-   * the viewer may read the app at all — so any account with the author flag could
-   * enumerate ANY app's accepted roster, INCLUDING seats whose holder set
+   * `resolveListingAccess` was consulted here only for `ownerUserId`; its `role` was
+   * never required non-null. The status filter governs which ROWS a viewer sees, not
+   * whether the viewer may read the listing at all — so any account with the author flag
+   * could enumerate ANY listing's accepted roster, INCLUDING seats whose holder set
    * `displayed: false` precisely so as not to be listed publicly, plus `invitedBy` and
    * the invite/response timestamps.
    */
@@ -807,26 +1155,26 @@ describe('listCollaborators — 🔴 the caller must hold a REAL role', () => {
 
   it('the OWNER may read the roster', async () => {
     await expect(
-      listCollaborators({ appBlockId: APP, viewerUserId: OWNER, isModerator: false })
+      listCollaborators({ appListingId: LISTING, viewerUserId: OWNER, isModerator: false })
     ).resolves.toHaveLength(1);
   });
 
   it('an ACCEPTED editor may read the roster', async () => {
     mockDb.appCollaborator.findFirst.mockResolvedValue({ userId: TARGET });
     await expect(
-      listCollaborators({ appBlockId: APP, viewerUserId: TARGET, isModerator: false })
+      listCollaborators({ appListingId: LISTING, viewerUserId: TARGET, isModerator: false })
     ).resolves.toHaveLength(1);
   });
 
   it('a MODERATOR may read the roster', async () => {
     await expect(
-      listCollaborators({ appBlockId: APP, viewerUserId: STRANGER, isModerator: true })
+      listCollaborators({ appListingId: LISTING, viewerUserId: STRANGER, isModerator: true })
     ).resolves.toHaveLength(1);
   });
 
   it('🔴 a STRANGER is refused — and the query never runs', async () => {
     await expect(
-      listCollaborators({ appBlockId: APP, viewerUserId: STRANGER, isModerator: false })
+      listCollaborators({ appListingId: LISTING, viewerUserId: STRANGER, isModerator: false })
     ).rejects.toMatchObject({ code: 'NOT_OWNER' });
     // Fail BEFORE the read, not after it: the rows must never be loaded, let alone
     // filtered.
@@ -835,38 +1183,100 @@ describe('listCollaborators — 🔴 the caller must hold a REAL role', () => {
 
   it('🔴 an ANONYMOUS caller is refused', async () => {
     await expect(
-      listCollaborators({ appBlockId: APP, viewerUserId: null, isModerator: false })
+      listCollaborators({ appListingId: LISTING, viewerUserId: null, isModerator: false })
     ).rejects.toMatchObject({ code: 'NOT_OWNER' });
   });
 
   it('🔴 a PENDING invitee is refused (they read their own invite via listMyPendingInvites)', async () => {
-    // `resolveAppAccess` returns role null for a pending seat — the consent rule. So a
-    // pending invitee does not get the app's roster as a side effect of being invited.
+    // `resolveListingAccess` returns role null for a pending seat — the consent rule. So
+    // a pending invitee does not get the listing's roster as a side effect of being
+    // invited.
     mockDb.appCollaborator.findFirst.mockImplementation(async (args: unknown) => {
       const w = (args as { where: { status?: string } }).where;
       return w.status === 'accepted' ? null : { userId: TARGET };
     });
     await expect(
-      listCollaborators({ appBlockId: APP, viewerUserId: TARGET, isModerator: false })
+      listCollaborators({ appListingId: LISTING, viewerUserId: TARGET, isModerator: false })
     ).rejects.toMatchObject({ code: 'NOT_OWNER' });
   });
 
-  it('a missing app is NOT_FOUND, distinct from a refusal', async () => {
-    mockDb.appBlock.findUnique.mockResolvedValue(null);
+  it('a missing listing is NOT_FOUND, distinct from a refusal', async () => {
     await expect(
-      listCollaborators({ appBlockId: APP, viewerUserId: OWNER, isModerator: false })
+      listCollaborators({ appListingId: 'apl_nope', viewerUserId: OWNER, isModerator: false })
     ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('the OFF-SITE owner may read their roster', async () => {
+    await expect(
+      listCollaborators({ appListingId: OFFSITE, viewerUserId: OWNER, isModerator: false })
+    ).resolves.toHaveLength(1);
+  });
+
+  it('🔴 opening the roster from a SHADOW reads the PARENT’s seats, not an empty set', async () => {
+    await listCollaborators({ appListingId: SHADOW, viewerUserId: OWNER, isModerator: false });
+    expect(mockDb.appCollaborator.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { appListingId: LISTING } })
+    );
   });
 
   it('POSITIVE CONTROL: the roster fixture really carries an opted-OUT seat', async () => {
     // The stake of the leak, stated as data: `displayed: false` is exactly the row a
     // stranger must not be able to read back.
     const rows = await listCollaborators({
-      appBlockId: APP,
+      appListingId: LISTING,
       viewerUserId: OWNER,
       isModerator: false,
     });
     expect(rows[0].displayed).toBe(false);
     expect(rows[0].invitedBy).toBe(OWNER);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The invitee's inbox.
+// ---------------------------------------------------------------------------
+
+describe('listMyPendingInvites', () => {
+  it('carries the listing identity AND its kind, so the client can render both kinds', async () => {
+    mockDb.appCollaborator.findMany.mockResolvedValue([
+      {
+        appListingId: LISTING,
+        invitedBy: OWNER,
+        createdAt: NOW,
+        appListing: { slug: SLUG, kind: 'onsite', appBlockId: APP },
+      },
+      {
+        appListingId: OFFSITE,
+        invitedBy: OWNER,
+        createdAt: NOW,
+        appListing: { slug: OFFSITE_SLUG, kind: 'offsite', appBlockId: null },
+      },
+    ]);
+    expect(await listMyPendingInvites(TARGET)).toEqual([
+      {
+        appListingId: LISTING,
+        slug: SLUG,
+        kind: 'onsite',
+        appBlockId: APP,
+        invitedBy: OWNER,
+        createdAt: NOW,
+      },
+      {
+        appListingId: OFFSITE,
+        slug: OFFSITE_SLUG,
+        kind: 'offsite',
+        appBlockId: null,
+        invitedBy: OWNER,
+        createdAt: NOW,
+      },
+    ]);
+  });
+
+  it('only PENDING rows are read', async () => {
+    mockDb.appCollaborator.findMany.mockResolvedValue([]);
+    await listMyPendingInvites(TARGET);
+    expect(mockDb.appCollaborator.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: TARGET, status: 'pending' } })
+    );
   });
 });

--- a/src/server/services/blocks/__tests__/app-collaborator.shadow-hazard.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator.shadow-hazard.test.ts
@@ -1,0 +1,393 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type * as AppBlockIds from '~/server/utils/app-block-ids';
+
+/**
+ * 🔴 THE SHADOW HAZARD — a collaborator seat may live ONLY on a PARENT listing.
+ *
+ * ## The defect this file exists to keep out
+ *
+ * Seats are keyed to `AppListing` (the block→listing re-key), and a listing can be
+ * CLONED into a hidden shadow revision (`revisionOfId != null`) while its owner edits.
+ * `applyApprovedRevision` DELETES that shadow when a moderator approves the revision,
+ * and `app_collaborators.app_listing_id` is `ON DELETE CASCADE`. So a seat that landed
+ * on a shadow would be destroyed by an ordinary approve — silently, with no error, and
+ * with the invite's audit event still on record claiming the person was seated.
+ *
+ * A SQL CHECK cannot express "parent only": a row-level CHECK cannot see another row's
+ * `revision_of_id`. So the invariant is held in code, from both ends, and this file
+ * pins BOTH — against ONE shared fake seat table, so the two halves cannot be true of
+ * different worlds:
+ *
+ *   A. a seat on the PARENT SURVIVES an approve (the cascade never reaches it); and
+ *   B. a seat CANNOT BE CREATED on a shadow in the first place.
+ *
+ * 🔴 THE CASCADE IS MODELLED, NOT ASSUMED. The fake `appListing.deleteMany` deletes the
+ * seats of the listing it removes, exactly as the FK would. Without that, (A) would be a
+ * fact about a mock that never deletes anything — a reassuring zero. The negative
+ * control below hand-plants a seat ON the shadow and watches the same approve destroy
+ * it, which is what proves the cascade fake bites AND demonstrates the precise hazard
+ * that (B) prevents.
+ */
+
+const PARENT = 'apl_parent';
+const SHADOW = 'apl_shadow';
+const SLUG = 'my-app';
+const APP = 'ab_app1';
+const OWNER = 10;
+const EDITOR = 20;
+const MOD = 7;
+
+type Seat = { appListingId: string; userId: number; status: string; displayed: boolean };
+
+const { store, mockRead, mockWrite, mockNotifyListing, mockRepo, mockNotifyCollab, seq } =
+  vi.hoisted(() => {
+    const store: { seats: Seat[] } = { seats: [] };
+
+    /**
+     * The seat-table delegate. SHARED by the read and write clients, so an invite issued
+     * through `dbWrite` is visible to a later read through `dbRead` — the two halves of
+     * this file must operate on ONE table or the seam is untested.
+     */
+    const appCollaborator = {
+      findUnique: vi.fn(async (args: unknown) => {
+        const k = (
+          args as { where: { appListingId_userId: { appListingId: string; userId: number } } }
+        ).where.appListingId_userId;
+        return (
+          store.seats.find((s) => s.appListingId === k.appListingId && s.userId === k.userId) ??
+          null
+        );
+      }),
+      findFirst: vi.fn(async (args: unknown) => {
+        const w = (args as { where: { appListingId?: string; userId?: number; status?: string } })
+          .where;
+        return (
+          store.seats.find(
+            (s) =>
+              (w.appListingId === undefined || s.appListingId === w.appListingId) &&
+              (w.userId === undefined || s.userId === w.userId) &&
+              (w.status === undefined || s.status === w.status)
+          ) ?? null
+        );
+      }),
+      findMany: vi.fn(async (args: unknown) => {
+        const w = (args as { where: { appListingId?: string; userId?: number; status?: unknown } })
+          .where;
+        return store.seats.filter(
+          (s) =>
+            (w.appListingId === undefined || s.appListingId === w.appListingId) &&
+            (w.userId === undefined || s.userId === w.userId) &&
+            (w.status === undefined ||
+              (typeof w.status === 'string'
+                ? s.status === w.status
+                : (w.status as { in: string[] }).in.includes(s.status)))
+        );
+      }),
+      count: vi.fn(async (args: unknown) => {
+        const w = (args as { where: { appListingId?: string; status?: { in: string[] } } }).where;
+        return store.seats.filter(
+          (s) =>
+            (w.appListingId === undefined || s.appListingId === w.appListingId) &&
+            (w.status === undefined || w.status.in.includes(s.status))
+        ).length;
+      }),
+      upsert: vi.fn(async (args: unknown) => {
+        const a = args as {
+          where: { appListingId_userId: { appListingId: string; userId: number } };
+          create: Seat;
+        };
+        const k = a.where.appListingId_userId;
+        const existing = store.seats.find(
+          (s) => s.appListingId === k.appListingId && s.userId === k.userId
+        );
+        if (existing) return existing;
+        const row: Seat = {
+          appListingId: a.create.appListingId,
+          userId: a.create.userId,
+          status: a.create.status,
+          displayed: true,
+        };
+        store.seats.push(row);
+        return row;
+      }),
+      updateMany: vi.fn(async (args: unknown) => {
+        const a = args as {
+          where: { appListingId?: string; userId?: number; status?: string };
+          data: Partial<Seat>;
+        };
+        let n = 0;
+        for (const s of store.seats) {
+          if (a.where.appListingId !== undefined && s.appListingId !== a.where.appListingId)
+            continue;
+          if (a.where.userId !== undefined && s.userId !== a.where.userId) continue;
+          if (a.where.status !== undefined && s.status !== a.where.status) continue;
+          Object.assign(s, a.data);
+          n += 1;
+        }
+        return { count: n };
+      }),
+      deleteMany: vi.fn(async (args: unknown) => {
+        const w = (args as { where: { appListingId?: string; userId?: number } }).where;
+        const before = store.seats.length;
+        store.seats = store.seats.filter(
+          (s) =>
+            !(
+              (w.appListingId === undefined || s.appListingId === w.appListingId) &&
+              (w.userId === undefined || s.userId === w.userId)
+            )
+        );
+        return { count: before - store.seats.length };
+      }),
+    };
+
+    const makeClient = () => ({
+      appCollaborator,
+      appOwnershipEvent: { create: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({})) },
+      user: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+      appBlock: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+      appListing: {
+        findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+        findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+        create: vi.fn(async (args: { data: unknown }) => args.data),
+        update: vi.fn(async (args: { data: unknown }) => args.data),
+        updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
+        /**
+         * 🔴 THE FK CASCADE, modelled. Deleting a listing deletes its seats, exactly as
+         * `ON DELETE CASCADE` would. This is the whole instrument.
+         */
+        deleteMany: vi.fn(async (args: unknown) => {
+          const id = (args as { where: { id?: string } }).where.id;
+          if (id) store.seats = store.seats.filter((s) => s.appListingId !== id);
+          return { count: 1 };
+        }),
+      },
+      appListingScreenshot: {
+        count: vi.fn(async (..._a: unknown[]) => 1),
+        findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+        createMany: vi.fn(async (..._a: unknown[]) => ({ count: 0 })),
+        deleteMany: vi.fn(async (..._a: unknown[]) => ({ count: 0 })),
+        updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 0 })),
+      },
+      appListingModerationEvent: { create: vi.fn(async (args: { data: unknown }) => args.data) },
+      image: { findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []) },
+      appListingPublishRequest: {
+        findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+        findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+        findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+        create: vi.fn(async (args: { data: unknown }) => args.data),
+        updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
+      },
+    });
+
+    const mockRead = makeClient();
+    const mockWrite = makeClient() as ReturnType<typeof makeClient> & {
+      $transaction: ReturnType<typeof vi.fn>;
+    };
+    mockWrite.$transaction = vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb(mockWrite));
+
+    return {
+      store,
+      mockRead,
+      mockWrite,
+      mockNotifyListing: vi.fn(async () => undefined),
+      mockRepo: {
+        grantAppRepoWrite: vi.fn(async () => undefined),
+        revokeAppRepoWrite: vi.fn(async () => undefined),
+      },
+      mockNotifyCollab: { notifyAppCollaborator: vi.fn(async () => undefined) },
+      seq: { n: 0 },
+    };
+  });
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockWrite }));
+vi.mock('~/server/services/blocks/app-listing-notify', () => ({
+  notifyAppListingOwner: mockNotifyListing,
+}));
+vi.mock('~/server/services/blocks/app-repo-access', () => mockRepo);
+vi.mock('~/server/services/blocks/app-collaborator-notify', () => mockNotifyCollab);
+vi.mock('~/server/utils/app-block-ids', async (importOriginal) => {
+  const actual = await importOriginal<typeof AppBlockIds>();
+  return { ...actual, newAppListingModerationEventId: () => `alme_${++seq.n}` };
+});
+
+const { approveExternalRequest } = await import('~/server/services/blocks/offsite-listing.service');
+const { inviteCollaborator } = await import('~/server/services/blocks/app-collaborator.service');
+
+/** The listing rows both the read and the write client serve. */
+function listingRow(id: string) {
+  if (id === SHADOW) {
+    return {
+      id: SHADOW,
+      slug: SLUG,
+      kind: 'offsite',
+      status: 'draft',
+      userId: OWNER,
+      appBlockId: null,
+      revisionOfId: PARENT,
+      revisionOf: { id: PARENT, kind: 'offsite', appBlockId: null },
+      appBlock: null,
+      externalUrl: 'https://example.com/',
+      connectClientId: null,
+      connectRequestedScopes: null,
+      connectScopeJustifications: null,
+      connectClient: null,
+      name: 'Edited Name',
+      tagline: 'Edited tagline',
+      description: 'Edited description',
+      category: 'games',
+      contentRating: 'pg',
+      iconId: 99,
+      coverId: 88,
+    };
+  }
+  if (id === PARENT) {
+    return {
+      id: PARENT,
+      slug: SLUG,
+      kind: 'offsite',
+      status: 'approved',
+      userId: OWNER,
+      appBlockId: null,
+      revisionOfId: null,
+      revisionOf: null,
+      appBlock: null,
+      externalUrl: 'https://example.com/',
+      connectClientId: null,
+      connectRequestedScopes: null,
+      connectScopeJustifications: null,
+      connectClient: null,
+      iconId: 1,
+      coverId: 2,
+    };
+  }
+  return null;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  seq.n = 0;
+  store.seats = [];
+  mockWrite.$transaction.mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) =>
+    cb(mockWrite)
+  );
+  for (const c of [mockRead, mockWrite]) {
+    c.appListing.findUnique.mockImplementation(async (args: unknown) =>
+      listingRow((args as { where: { id: string } }).where.id)
+    );
+    c.appListing.deleteMany.mockImplementation(async (args: unknown) => {
+      const id = (args as { where: { id?: string } }).where.id;
+      if (id) store.seats = store.seats.filter((s) => s.appListingId !== id);
+      return { count: 1 };
+    });
+    c.appListingScreenshot.findMany.mockResolvedValue([]);
+    c.appListingPublishRequest.updateMany.mockResolvedValue({ count: 1 });
+    c.image.findMany.mockImplementation(async (...a: unknown[]) => {
+      const ids = (a[0] as { where?: { id?: { in?: number[] } } })?.where?.id?.in ?? [];
+      return ids.map((id) => ({ id, ingestion: 'Scanned' }));
+    });
+    c.user.findUnique.mockResolvedValue({ id: EDITOR, bannedAt: null });
+    c.appBlock.findUnique.mockResolvedValue({
+      id: APP,
+      blockId: SLUG,
+      app: { userId: OWNER },
+      appListing: { id: PARENT },
+    });
+  }
+  // The pending revision request the moderator is approving.
+  mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
+    id: 'alpr_rev',
+    status: 'pending',
+    kind: 'offsite',
+    slug: SLUG,
+    appListingId: SHADOW,
+  });
+});
+
+/** Seat `userId` on `listingId` directly, bypassing the invite guard. */
+function plantSeat(listingId: string, userId: number, status = 'accepted') {
+  store.seats.push({ appListingId: listingId, userId, status, displayed: true });
+}
+
+const approve = () => approveExternalRequest({ publishRequestId: 'alpr_rev', reviewerUserId: MOD });
+
+describe('🔴 INSTRUMENT CONTROLS — the cascade fake must actually bite', () => {
+  it('the approve really does delete the shadow', async () => {
+    await approve();
+    expect(mockWrite.appListing.deleteMany).toHaveBeenCalledWith({
+      where: { id: SHADOW, revisionOfId: { not: null } },
+    });
+  });
+
+  it('🔴 NEGATIVE CONTROL: a seat planted ON THE SHADOW is DESTROYED by that same approve', async () => {
+    // This is the hazard, demonstrated. It is also the proof that the "survives"
+    // assertion below is not a fact about a mock that never deletes anything: the exact
+    // same approve, on the exact same fake, annihilates a shadow-keyed seat.
+    plantSeat(SHADOW, EDITOR);
+    expect(store.seats).toHaveLength(1);
+    await approve();
+    expect(store.seats).toEqual([]);
+  });
+});
+
+describe('🔴 DIRECTION A — a seat on the PARENT survives a revision approve', () => {
+  it('the parent’s accepted seat is still there afterwards', async () => {
+    plantSeat(PARENT, EDITOR);
+    await approve();
+    expect(store.seats).toEqual([
+      { appListingId: PARENT, userId: EDITOR, status: 'accepted', displayed: true },
+    ]);
+  });
+
+  it('…and the approve never issues a seat delete of its own', async () => {
+    // Belt and braces: the cascade is one way to lose the seat; an explicit cleanup
+    // added to `applyApprovedRevision` would be another, and it would not show up as a
+    // cascade at all.
+    plantSeat(PARENT, EDITOR);
+    await approve();
+    expect(mockWrite.appCollaborator.deleteMany).not.toHaveBeenCalled();
+    expect(mockWrite.appCollaborator.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('🔴 MIXED: a parent seat survives while a (hand-planted) shadow seat does not', async () => {
+    // Both rows go through the SAME cascade in the SAME call, so the survivor set is
+    // decided by the KEY and nothing else — which is exactly the claim.
+    plantSeat(PARENT, EDITOR);
+    plantSeat(SHADOW, 999);
+    await approve();
+    expect(store.seats.map((s) => s.appListingId)).toEqual([PARENT]);
+  });
+});
+
+describe('🔴 DIRECTION B — a seat cannot be created on a shadow', () => {
+  it('inviting on the shadow is refused and the seat table stays empty', async () => {
+    await expect(
+      inviteCollaborator({ appListingId: SHADOW, targetUserId: EDITOR, actorUserId: OWNER })
+    ).rejects.toMatchObject({
+      code: 'INVALID_TARGET',
+      message: 'Collaborators are managed on the live listing, not on a revision draft',
+    });
+    expect(store.seats).toEqual([]);
+  });
+
+  it('POSITIVE CONTROL: the same invite on the PARENT does seat them', async () => {
+    // Without this, "the table stayed empty" is indistinguishable from an invite path
+    // that never writes at all.
+    await inviteCollaborator({ appListingId: PARENT, targetUserId: EDITOR, actorUserId: OWNER });
+    expect(store.seats).toEqual([
+      { appListingId: PARENT, userId: EDITOR, status: 'pending', displayed: true },
+    ]);
+  });
+
+  it('🔴 THE SEAM, end to end: invite on the parent → approve the shadow → the seat is still there', async () => {
+    // The two halves joined. This is the property the feature actually promises: an
+    // editor invited while a revision is in flight does not lose their seat when a
+    // moderator approves that revision.
+    await inviteCollaborator({ appListingId: PARENT, targetUserId: EDITOR, actorUserId: OWNER });
+    expect(store.seats).toHaveLength(1);
+    await approve();
+    expect(store.seats).toEqual([
+      { appListingId: PARENT, userId: EDITOR, status: 'pending', displayed: true },
+    ]);
+  });
+});

--- a/src/server/services/blocks/__tests__/app-listing-assets.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-assets.service.test.ts
@@ -32,6 +32,10 @@ const { mockDb, ids } = vi.hoisted(() => ({
       create: vi.fn(async (args: { data: unknown }) => args.data),
       update: vi.fn(async (args: { data: unknown }) => ({ ...(args as object) })),
     },
+    // 🔴 SEATS ARE LISTING-KEYED, so EVERY non-owner path now consults this table —
+    // there is no longer an "this listing has no AppBlock" short-circuit to skip it.
+    // Default: no seat, i.e. exactly the owner-only behaviour these cases assert.
+    appCollaborator: { findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
     image: {
       findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
       findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),

--- a/src/server/services/blocks/__tests__/app-ownership-transfer.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-ownership-transfer.service.test.ts
@@ -102,9 +102,26 @@ const OFFSITE_SLUG = 'cool-offsite';
 const CONNECT_LISTING = 'apl_connect';
 const CONNECT_CLIENT = 'oc_connect9';
 const SHADOW = 'apl_shadow';
+/**
+ * 🔴 An OFF-SITE listing that DOES carry a backing AppBlock — and therefore a Forgejo
+ * repo slug. `mapAppBlockToListing` mints exactly this shape for an AppBlock with an
+ * `externalUrl`. It is the row on which `kind === 'onsite'` and `blockSlug != null`
+ * DISAGREE, and `acceptTransfer` used to branch on each of them in different places:
+ * step (2) on the kind, the post-commit Forgejo swap on the slug.
+ */
+const OFFSITE_WITH_REPO = 'apl_offsite_with_repo';
+const OFFSITE_REPO_SLUG = 'offsite-repo';
+/**
+ * 🔴 An ON-SITE listing whose denormalized `AppListing.userId` DISAGREES with its
+ * canonical `OauthClient.userId` — the state this very service's step (3) can leave
+ * behind (unguarded for onsite, a 0-count is an accepted desync).
+ */
+const DRIFTED = 'apl_drifted';
 const OLD_OWNER = 10;
 const NEW_OWNER = 20;
 const STRANGER = 50;
+/** The name left behind in a stale denormalized `AppListing.userId`. */
+const STALE_OWNER = 77;
 const TRANSFER = 'aot_t1';
 const NOW = new Date('2026-08-10T12:00:00Z');
 const FUTURE = new Date('2026-08-17T12:00:00Z');
@@ -160,6 +177,34 @@ function listingTable(): Record<string, Record<string, unknown>> {
       revisionOf: { id: LISTING, kind: 'onsite', appBlockId: APP },
       appBlock: null,
     },
+    // 🔴 offsite, but WITH a block and therefore WITH a repo slug.
+    [OFFSITE_WITH_REPO]: {
+      id: OFFSITE_WITH_REPO,
+      slug: 'offsite-store-slug',
+      kind: 'offsite',
+      userId: OLD_OWNER,
+      appBlockId: 'ab_offsiteBlock',
+      connectClientId: null,
+      revisionOfId: null,
+      revisionOf: null,
+      appBlock: {
+        appId: 'oc_offsite',
+        blockId: OFFSITE_REPO_SLUG,
+        app: { userId: OLD_OWNER },
+      },
+    },
+    // 🔴 onsite, with the canonical owner and the denormalized column DISAGREEING.
+    [DRIFTED]: {
+      id: DRIFTED,
+      slug: 'drifted-slug',
+      kind: 'onsite',
+      userId: STALE_OWNER,
+      appBlockId: 'ab_drifted',
+      connectClientId: null,
+      revisionOfId: null,
+      revisionOf: null,
+      appBlock: { appId: 'oc_drifted', blockId: 'drifted-repo', app: { userId: OLD_OWNER } },
+    },
   };
 }
 
@@ -183,7 +228,16 @@ function liveTransfer(over: Record<string, unknown> = {}) {
       kind: l.kind,
       connectClientId: l.connectClientId,
       appBlockId: l.appBlockId,
-      appBlock: l.appBlock ? { appId: CLIENT, blockId: SLUG } : null,
+      // 🔴 Taken FROM THE ROW, not hardcoded: the offsite-with-a-repo fixture carries a
+      // different `blockId`, and a hardcoded `SLUG` here would make every Forgejo
+      // assertion in this suite about the same string regardless of which listing was
+      // transferred.
+      appBlock: l.appBlock
+        ? {
+            appId: (l.appBlock as { appId: string }).appId,
+            blockId: (l.appBlock as { blockId: string }).blockId,
+          }
+        : null,
     },
     ...over,
   };
@@ -787,6 +841,70 @@ describe('🔴 acceptTransfer re-reads bannedAt — the 7-day window', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// 🔴 acceptTransfer's post-commit Forgejo swap is gated on KIND, like step (2).
+// ---------------------------------------------------------------------------
+
+describe('🔴 the Forgejo swap and the ownership write agree about what "on-site" means', () => {
+  /**
+   * `acceptTransfer` makes two kind-shaped decisions and used to make them with two
+   * different predicates: step (2) (move `OauthClient.userId`) branched on
+   * `kind === 'onsite'`, while the post-commit repo swap branched on `blockSlug != null`.
+   * On every ordinary row those agree. On an OFF-SITE listing that carries a backing
+   * AppBlock they do not — and there the function did the WORSE half of both: it left the
+   * OauthClient alone (correctly, per its kind) while swapping Forgejo `write` on the
+   * app's repo from one user to another.
+   *
+   * This case is the only one that can distinguish the two predicates, so it is the only
+   * one that can kill a slug-only mutant.
+   */
+  beforeEach(() => {
+    mockDb.appOwnershipTransfer.findUnique.mockImplementation(async () =>
+      liveTransfer({ appListingId: OFFSITE_WITH_REPO })
+    );
+  });
+
+  it('POSITIVE CONTROL: the fixture really is offsite AND really does carry a repo slug', async () => {
+    const t = liveTransfer({ appListingId: OFFSITE_WITH_REPO }) as {
+      appListing: { kind: string; appBlock: { blockId: string } | null };
+    };
+    expect(t.appListing.kind).toBe('offsite');
+    expect(t.appListing.appBlock?.blockId).toBe(OFFSITE_REPO_SLUG);
+  });
+
+  it('🔴 no repo grant and no repo revoke fire for an OFF-SITE listing that has a slug', async () => {
+    await acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW });
+    expect(mockRepo.revokeAppRepoWrite).not.toHaveBeenCalled();
+    expect(mockRepo.grantAppRepoWrite).not.toHaveBeenCalled();
+  });
+
+  it('the OauthClient is still left alone, as its kind requires — the two agree now', async () => {
+    // The structural half: both decisions must land on the same side for this row.
+    await acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW });
+    expect(mockDb.oauthClient.updateMany).not.toHaveBeenCalled();
+    // …and the transfer itself still completes: this is a gate on the repo call, not a
+    // refusal of the transfer.
+    expect(mockDb.appListing.updateMany).toHaveBeenCalled();
+  });
+
+  it('🔴 POSITIVE CONTROL: THAT EXACT SLUG is swapped once the kind is onsite', async () => {
+    // Without this, "not called" is indistinguishable from a repo mock nothing reaches.
+    LISTINGS[OFFSITE_WITH_REPO] = { ...LISTINGS[OFFSITE_WITH_REPO], kind: 'onsite' };
+    mockDb.appOwnershipTransfer.findUnique.mockImplementation(async () =>
+      liveTransfer({ appListingId: OFFSITE_WITH_REPO })
+    );
+    await acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW });
+    expect(mockRepo.revokeAppRepoWrite).toHaveBeenCalledWith({
+      slug: OFFSITE_REPO_SLUG,
+      userId: OLD_OWNER,
+    });
+    expect(mockRepo.grantAppRepoWrite).toHaveBeenCalledWith({
+      slug: OFFSITE_REPO_SLUG,
+      userId: NEW_OWNER,
+    });
+  });
+});
+
 describe('🔴 MONEY INVARIANCE — attribution and payout grouping are untouched', () => {
   it('accept never writes BlockBuzzAttribution', async () => {
     await acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW });
@@ -946,6 +1064,45 @@ describe('🔴 getPendingTransfer — who may read the offer', () => {
     expect(mockDb.appOwnershipTransfer.findFirst).toHaveBeenCalledWith(
       expect.objectContaining({ where: { appListingId: LISTING, status: 'pending' } })
     );
+  });
+
+  /**
+   * 🔴 THE OWNER SIDE OF THIS GATE IS `resolveListingAccess(...).role === 'owner'`, so
+   * it inherits whatever that resolver calls the owner.
+   *
+   * On `origin/main` this read did not exist in this shape; the re-key routed it through
+   * the listing resolver, and while that resolver returned the DENORMALIZED
+   * `AppListing.userId` the gate answered a different question than every sibling
+   * (`initiateTransfer`/`loadOwnedListing` resolve `appBlock.app.userId ?? userId`).
+   * The consequence is specific and inverted: the REAL owner gets `null` for their own
+   * outgoing offer — which reads as "there is no transfer", the one answer that is
+   * indistinguishable from safety — while the stale name reads both parties and the
+   * deadline.
+   */
+  describe('🔴 the owner half of the gate is the CANONICAL owner', () => {
+    beforeEach(() => {
+      mockDb.appOwnershipTransfer.findFirst.mockImplementation(async () =>
+        liveTransfer({ appListingId: DRIFTED, fromUserId: OLD_OWNER })
+      );
+    });
+
+    it('POSITIVE CONTROL: the DRIFTED fixture disagrees with itself', () => {
+      const l = LISTINGS[DRIFTED] as { userId: number; appBlock: { app: { userId: number } } };
+      expect(l.userId).toBe(STALE_OWNER);
+      expect(l.appBlock.app.userId).toBe(OLD_OWNER);
+    });
+
+    it('🔴 the REAL owner sees their own outgoing offer', async () => {
+      await expect(
+        getPendingTransfer({ appListingId: DRIFTED, viewerUserId: OLD_OWNER, now: NOW })
+      ).resolves.toMatchObject({ id: TRANSFER, toUserId: NEW_OWNER });
+    });
+
+    it('🔴 the STALE user named by the column sees NOTHING', async () => {
+      await expect(
+        getPendingTransfer({ appListingId: DRIFTED, viewerUserId: STALE_OWNER, now: NOW })
+      ).resolves.toBeNull();
+    });
   });
 
   it('an EXPIRED offer is null for the owner too (expiry still wins over authorization)', async () => {

--- a/src/server/services/blocks/__tests__/app-ownership-transfer.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-ownership-transfer.service.test.ts
@@ -4,8 +4,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  * App Listing COLLABORATORS — OWNERSHIP TRANSFER.
  *
  * The load-bearing properties, each with its own describe:
- *   - ATOMICITY: both ownership columns move together; a failure on the SECOND write
- *     rolls the FIRST back.
+ *   - ATOMICITY: on an ON-SITE listing both ownership columns move together; a failure
+ *     on the SECOND write rolls the FIRST back.
+ *   - KIND: an OFF-SITE listing moves `AppListing.userId` ONLY — and one carrying a
+ *     `connectClientId` is REFUSED outright, at initiate AND again in-tx at accept.
  *   - A PENDING transfer confers NOTHING.
  *   - MONEY INVARIANCE: `BlockBuzzAttribution` is never touched, so payout grouping by
  *     `(app_owner_user_id, period_key)` cannot collide and the old owner keeps their
@@ -28,7 +30,10 @@ const { mockDb, mockRepo, mockNotify, calls } = vi.hoisted(() => {
     appBlock: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
     user: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
     oauthClient: { updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })) },
-    appListing: { updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })) },
+    appListing: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
+    },
     appOwnershipTransfer: {
       create: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({})),
       findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
@@ -75,14 +80,28 @@ vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
 vi.mock('~/server/services/blocks/app-repo-access', () => mockRepo);
 vi.mock('~/server/services/blocks/app-collaborator-notify', () => mockNotify);
 
-const { acceptTransfer, cancelTransfer, getPendingTransfer, initiateTransfer } = await import(
-  '~/server/services/blocks/app-ownership-transfer.service'
-);
-const { resolveAppAccess } = await import('~/server/services/blocks/app-access.service');
+const {
+  acceptTransfer,
+  cancelTransfer,
+  getPendingTransfer,
+  initiateTransfer,
+  refusesTransferForConnectClient,
+  CONNECT_CLIENT_TRANSFER_REFUSAL,
+} = await import('~/server/services/blocks/app-ownership-transfer.service');
+const { resolveListingAccess } = await import('~/server/services/blocks/app-access.service');
 
 const APP = 'ab_app1';
 const CLIENT = 'oc_client1';
 const SLUG = 'my-app';
+/** The ON-SITE listing: an AppBlock, an OauthClient, a Forgejo repo. */
+const LISTING = 'apl_live';
+/** A plain external-link OFF-SITE listing: no block, no client. Transferable. */
+const OFFSITE = 'apl_offsite';
+const OFFSITE_SLUG = 'cool-offsite';
+/** An OAuth-CONNECT off-site listing. 🔴 NOT transferable in v1. */
+const CONNECT_LISTING = 'apl_connect';
+const CONNECT_CLIENT = 'oc_connect9';
+const SHADOW = 'apl_shadow';
 const OLD_OWNER = 10;
 const NEW_OWNER = 20;
 const STRANGER = 50;
@@ -91,16 +110,81 @@ const NOW = new Date('2026-08-10T12:00:00Z');
 const FUTURE = new Date('2026-08-17T12:00:00Z');
 const PAST = new Date('2026-08-03T12:00:00Z');
 
+/**
+ * The listing table, keyed by id. Every row differs from every other in id, slug, kind,
+ * appBlockId AND connectClientId, so no assertion can be satisfied by the wrong row.
+ */
+function listingTable(): Record<string, Record<string, unknown>> {
+  return {
+    [LISTING]: {
+      id: LISTING,
+      slug: SLUG,
+      kind: 'onsite',
+      userId: OLD_OWNER,
+      appBlockId: APP,
+      connectClientId: null,
+      revisionOfId: null,
+      revisionOf: null,
+      appBlock: { appId: CLIENT, blockId: SLUG, app: { userId: OLD_OWNER } },
+    },
+    [OFFSITE]: {
+      id: OFFSITE,
+      slug: OFFSITE_SLUG,
+      kind: 'offsite',
+      userId: OLD_OWNER,
+      appBlockId: null,
+      connectClientId: null,
+      revisionOfId: null,
+      revisionOf: null,
+      appBlock: null,
+    },
+    [CONNECT_LISTING]: {
+      id: CONNECT_LISTING,
+      slug: 'connected-thing',
+      kind: 'offsite',
+      userId: OLD_OWNER,
+      appBlockId: null,
+      connectClientId: CONNECT_CLIENT,
+      revisionOfId: null,
+      revisionOf: null,
+      appBlock: null,
+    },
+    [SHADOW]: {
+      id: SHADOW,
+      slug: SLUG,
+      kind: 'onsite',
+      userId: OLD_OWNER,
+      appBlockId: null,
+      connectClientId: null,
+      revisionOfId: LISTING,
+      revisionOf: { id: LISTING, kind: 'onsite', appBlockId: APP },
+      appBlock: null,
+    },
+  };
+}
+
+let LISTINGS: Record<string, Record<string, unknown>>;
+
+/** A live pending transfer whose `appListing` relation is taken from the table. */
 function liveTransfer(over: Record<string, unknown> = {}) {
+  const listingId = (over.appListingId as string) ?? LISTING;
+  const l = LISTINGS[listingId];
   return {
     id: TRANSFER,
-    appBlockId: APP,
+    appListingId: listingId,
     fromUserId: OLD_OWNER,
     toUserId: NEW_OWNER,
     status: 'pending',
     expiresAt: FUTURE,
     createdAt: NOW,
-    appBlock: { appId: CLIENT, blockId: SLUG },
+    appListing: {
+      id: l.id,
+      slug: l.slug,
+      kind: l.kind,
+      connectClientId: l.connectClientId,
+      appBlockId: l.appBlockId,
+      appBlock: l.appBlock ? { appId: CLIENT, blockId: SLUG } : null,
+    },
     ...over,
   };
 }
@@ -108,6 +192,7 @@ function liveTransfer(over: Record<string, unknown> = {}) {
 beforeEach(() => {
   vi.clearAllMocks();
   calls.length = 0;
+  LISTINGS = listingTable();
   mockDb.$transaction.mockImplementation(async (cb: (tx: typeof mockDb) => Promise<unknown>) => {
     calls.push('tx:begin');
     try {
@@ -119,11 +204,16 @@ beforeEach(() => {
       throw e;
     }
   });
+  mockDb.appListing.findUnique.mockImplementation(async (args: unknown): Promise<unknown> => {
+    const w = (args as { where: { id?: string } }).where;
+    return w.id ? LISTINGS[w.id] ?? null : null;
+  });
   mockDb.appBlock.findUnique.mockResolvedValue({
     id: APP,
     appId: CLIENT,
     blockId: SLUG,
     app: { userId: OLD_OWNER },
+    appListing: { id: LISTING },
   });
   // 🔴 The user read is LOGGED into `calls`, so its POSITION relative to `tx:begin` is
   // observable. `dbRead` and `dbWrite` are the same fake here, so "was the ban read on
@@ -137,7 +227,7 @@ beforeEach(() => {
   mockDb.oauthClient.updateMany.mockResolvedValue({ count: 1 });
   mockDb.appListing.updateMany.mockResolvedValue({ count: 1 });
   mockDb.appOwnershipTransfer.updateMany.mockResolvedValue({ count: 1 });
-  mockDb.appOwnershipTransfer.findUnique.mockResolvedValue(liveTransfer());
+  mockDb.appOwnershipTransfer.findUnique.mockImplementation(async () => liveTransfer());
   mockDb.appOwnershipTransfer.create.mockImplementation(async (args: unknown) => ({
     ...(args as { data: Record<string, unknown> }).data,
     createdAt: NOW,
@@ -147,7 +237,7 @@ beforeEach(() => {
 describe('initiateTransfer', () => {
   it('the OWNER can offer; the row is pending with an expiry and an event is written', async () => {
     const t = await initiateTransfer({
-      appBlockId: APP,
+      appListingId: LISTING,
       toUserId: NEW_OWNER,
       actorUserId: OLD_OWNER,
       now: NOW,
@@ -161,7 +251,7 @@ describe('initiateTransfer', () => {
 
   it('🔴 NOTHING moves at initiate — neither ownership column is written', async () => {
     await initiateTransfer({
-      appBlockId: APP,
+      appListingId: LISTING,
       toUserId: NEW_OWNER,
       actorUserId: OLD_OWNER,
       now: NOW,
@@ -172,21 +262,38 @@ describe('initiateTransfer', () => {
 
   it('a NON-OWNER cannot initiate', async () => {
     await expect(
-      initiateTransfer({ appBlockId: APP, toUserId: NEW_OWNER, actorUserId: STRANGER, now: NOW })
+      initiateTransfer({ appListingId: LISTING, toUserId: NEW_OWNER, actorUserId: STRANGER, now: NOW })
     ).rejects.toMatchObject({ code: 'NOT_OWNER' });
   });
 
   it('transferring to yourself is INVALID_TARGET', async () => {
     await expect(
-      initiateTransfer({ appBlockId: APP, toUserId: OLD_OWNER, actorUserId: OLD_OWNER, now: NOW })
+      initiateTransfer({
+        appListingId: LISTING,
+        toUserId: OLD_OWNER,
+        actorUserId: OLD_OWNER,
+        now: NOW,
+      })
     ).rejects.toMatchObject({ code: 'INVALID_TARGET' });
   });
 
   it('🔴 a BANNED recipient cannot receive ownership', async () => {
     mockDb.user.findUnique.mockResolvedValue({ id: NEW_OWNER, bannedAt: new Date() });
     await expect(
-      initiateTransfer({ appBlockId: APP, toUserId: NEW_OWNER, actorUserId: OLD_OWNER, now: NOW })
+      initiateTransfer({
+        appListingId: LISTING,
+        toUserId: NEW_OWNER,
+        actorUserId: OLD_OWNER,
+        now: NOW,
+      })
     ).rejects.toMatchObject({ code: 'BANNED' });
+  });
+
+  it('a SHADOW revision cannot be transferred — there is nothing to own', async () => {
+    await expect(
+      initiateTransfer({ appListingId: SHADOW, toUserId: NEW_OWNER, actorUserId: OLD_OWNER, now: NOW })
+    ).rejects.toMatchObject({ code: 'INVALID_TARGET' });
+    expect(mockDb.appOwnershipTransfer.create).not.toHaveBeenCalled();
   });
 
   // 🔴 THE TWO PARTY COLUMNS, asserted as VALUES. A mutant that swapped them survived:
@@ -198,17 +305,17 @@ describe('initiateTransfer', () => {
   // wrong party. Fixture ids are deliberately distinct so the two cannot alias.
   it('🔴 the offer records fromUserId = CURRENT OWNER and toUserId = RECIPIENT, not the reverse', async () => {
     const t = await initiateTransfer({
-      appBlockId: APP,
+      appListingId: LISTING,
       toUserId: NEW_OWNER,
       actorUserId: OLD_OWNER,
       now: NOW,
     });
     const created = mockDb.appOwnershipTransfer.create.mock.calls[0][0] as {
-      data: { fromUserId: number; toUserId: number; appBlockId: string; status: string };
+      data: { fromUserId: number; toUserId: number; appListingId: string; status: string };
     };
     expect(created.data.fromUserId).toBe(OLD_OWNER);
     expect(created.data.toUserId).toBe(NEW_OWNER);
-    expect(created.data.appBlockId).toBe(APP);
+    expect(created.data.appListingId).toBe(LISTING);
     expect(created.data.status).toBe('pending');
     // …and the returned view carries the same orientation the client will render.
     expect(t.fromUserId).toBe(OLD_OWNER);
@@ -217,10 +324,10 @@ describe('initiateTransfer', () => {
     expect(OLD_OWNER).not.toBe(NEW_OWNER);
   });
 
-  it('🔴 `fromUserId` is the app’s CURRENT owner, not merely the actor', async () => {
+  it('🔴 `fromUserId` is the listing’s CURRENT owner, not merely the actor', async () => {
     // The audit event names the target; the row must name the owner it is moving FROM.
     await initiateTransfer({
-      appBlockId: APP,
+      appListingId: LISTING,
       toUserId: NEW_OWNER,
       actorUserId: OLD_OWNER,
       now: NOW,
@@ -232,17 +339,18 @@ describe('initiateTransfer', () => {
     expect(evt.data.targetUserId).toBe(NEW_OWNER);
   });
 
-  it('EXPIRED pending rows are reclaimed first, so one lapsed offer cannot wedge the app forever', async () => {
+  it('EXPIRED pending rows are reclaimed first, so one lapsed offer cannot wedge the listing forever', async () => {
     await initiateTransfer({
-      appBlockId: APP,
+      appListingId: LISTING,
       toUserId: NEW_OWNER,
       actorUserId: OLD_OWNER,
       now: NOW,
     });
     const reclaim = mockDb.appOwnershipTransfer.updateMany.mock.calls[0][0] as {
-      where: { status: string; expiresAt: { lte: Date } };
+      where: { appListingId: string; status: string; expiresAt: { lte: Date } };
       data: { status: string };
     };
+    expect(reclaim.where.appListingId).toBe(LISTING);
     expect(reclaim.where.status).toBe('pending');
     expect(reclaim.where.expiresAt.lte).toEqual(NOW);
     expect(reclaim.data.status).toBe('expired');
@@ -253,7 +361,12 @@ describe('initiateTransfer', () => {
       Object.assign(new Error('Unique constraint failed'), { code: 'P2002' })
     );
     await expect(
-      initiateTransfer({ appBlockId: APP, toUserId: NEW_OWNER, actorUserId: OLD_OWNER, now: NOW })
+      initiateTransfer({
+        appListingId: LISTING,
+        toUserId: NEW_OWNER,
+        actorUserId: OLD_OWNER,
+        now: NOW,
+      })
     ).rejects.toMatchObject({ code: 'ALREADY_SEATED' });
   });
 
@@ -263,26 +376,113 @@ describe('initiateTransfer', () => {
       Object.assign(new Error('connection reset'), { code: 'P1001' })
     );
     await expect(
-      initiateTransfer({ appBlockId: APP, toUserId: NEW_OWNER, actorUserId: OLD_OWNER, now: NOW })
+      initiateTransfer({
+        appListingId: LISTING,
+        toUserId: NEW_OWNER,
+        actorUserId: OLD_OWNER,
+        now: NOW,
+      })
     ).rejects.toThrow('connection reset');
   });
 });
 
+// ---------------------------------------------------------------------------
+// 🔴 THE CONNECT-CLIENT REFUSAL — the v1 scope decision, enforced at BOTH ends.
+// ---------------------------------------------------------------------------
+
+describe('🔴 an OFF-SITE listing with a connectClientId is REFUSED', () => {
+  /**
+   * THE DECISION. v1 moves `AppListing.userId` and nothing else. A connect listing
+   * carries an `OauthClient` with a SECRET, redirect URIs and allowed origins, and both
+   * silent options are bad: moving it hands over live credentials nobody agreed to
+   * transfer; NOT moving it leaves ownership SPLIT between the listing and the client.
+   * So the transfer is refused, with an error that says why.
+   *
+   * Enforced twice — at initiate (fail fast) and IN-TX at accept — because an offer
+   * stays open for `transferExpiryDays` and a revision approve can LINK a client inside
+   * that window. An initiate-only check is simply false for the whole window.
+   */
+  it('the predicate is exported and states the rule in one place', () => {
+    expect(refusesTransferForConnectClient({ kind: 'offsite', connectClientId: CONNECT_CLIENT })).toBe(
+      true
+    );
+    expect(refusesTransferForConnectClient({ kind: 'offsite', connectClientId: null })).toBe(false);
+    // 🔴 ON-SITE IS UNAFFECTED — its OauthClient is reached through the AppBlock, and
+    // THAT one does move. A predicate that dropped the kind check would block every
+    // on-site transfer the moment the column were ever populated.
+    expect(refusesTransferForConnectClient({ kind: 'onsite', connectClientId: CONNECT_CLIENT })).toBe(
+      false
+    );
+  });
+
+  it('initiate REFUSES, and no transfer row is created', async () => {
+    await expect(
+      initiateTransfer({
+        appListingId: CONNECT_LISTING,
+        toUserId: NEW_OWNER,
+        actorUserId: OLD_OWNER,
+        now: NOW,
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_TARGET', message: CONNECT_CLIENT_TRANSFER_REFUSAL });
+    expect(mockDb.appOwnershipTransfer.create).not.toHaveBeenCalled();
+    expect(mockDb.appOwnershipEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('🔴 the message NAMES the reason — "unlink the OAuth client first" is actionable', async () => {
+    // A bare FORBIDDEN would leave the owner with no idea what to do, and the whole
+    // point of refusing rather than guessing is that the human makes the call.
+    expect(CONNECT_CLIENT_TRANSFER_REFUSAL).toMatch(/OAuth application/i);
+    expect(CONNECT_CLIENT_TRANSFER_REFUSAL).toMatch(/Unlink the OAuth client first/i);
+  });
+
+  it('🔴 ACCEPT re-asserts it: a client LINKED after the offer was made blocks the accept', async () => {
+    // The window this closes. The offer was created against a clean listing; a revision
+    // approve then linked a client. Nothing about the transfer row changed — only the
+    // listing did — so an initiate-time-only check would let it through.
+    mockDb.appOwnershipTransfer.findUnique.mockImplementation(async () => {
+      const t = liveTransfer();
+      return {
+        ...t,
+        appListing: { ...t.appListing, kind: 'offsite', connectClientId: CONNECT_CLIENT },
+      };
+    });
+    await expect(
+      acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW })
+    ).rejects.toMatchObject({ code: 'INVALID_TARGET', message: CONNECT_CLIENT_TRANSFER_REFUSAL });
+    // Nothing moved, and the transaction aborted.
+    expect(mockDb.appListing.updateMany).not.toHaveBeenCalled();
+    expect(mockDb.oauthClient.updateMany).not.toHaveBeenCalled();
+    expect(mockDb.appOwnershipEvent.create).not.toHaveBeenCalled();
+    expect(calls).toContain('tx:rollback');
+  });
+
+  it('POSITIVE CONTROL: the SAME off-site listing WITHOUT a client transfers fine', async () => {
+    // Otherwise "it threw" is indistinguishable from off-site transfers being broken.
+    await expect(
+      initiateTransfer({
+        appListingId: OFFSITE,
+        toUserId: NEW_OWNER,
+        actorUserId: OLD_OWNER,
+        now: NOW,
+      })
+    ).resolves.toMatchObject({ appListingId: OFFSITE, status: 'pending' });
+  });
+});
+
 describe('a PENDING transfer confers NOTHING on the recipient', () => {
-  it('resolveAppAccess gives the recipient no role while the offer is open', async () => {
+  it('resolveListingAccess gives the recipient no role while the offer is open', async () => {
     // The access predicate does not consult the transfer table at all — asserted by
     // observing the resolved role, which is the property that matters.
-    mockDb.appBlock.findUnique.mockResolvedValue({ id: APP, app: { userId: OLD_OWNER } });
     // No SEAT exists for the recipient — the open offer is the only thing linking them
-    // to the app, and it must count for nothing.
+    // to the listing, and it must count for nothing.
     mockDb.appCollaborator.findFirst.mockResolvedValue(null);
-    const access = await resolveAppAccess(APP, NEW_OWNER);
+    const access = await resolveListingAccess(LISTING, NEW_OWNER);
     expect(access!.role).toBeNull();
     expect(access!.ownerUserId).toBe(OLD_OWNER);
   });
 });
 
-describe('acceptTransfer — 🔴 ATOMICITY of the two ownership columns', () => {
+describe('acceptTransfer — 🔴 ATOMICITY of the two ownership columns (ONSITE)', () => {
   it('moves BOTH OauthClient.userId and AppListing.userId', async () => {
     const res = await acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW });
     expect(res).toMatchObject({ fromUserId: OLD_OWNER, toUserId: NEW_OWNER });
@@ -295,10 +495,10 @@ describe('acceptTransfer — 🔴 ATOMICITY of the two ownership columns', () =>
     expect(client.data.userId).toBe(NEW_OWNER);
 
     const listing = mockDb.appListing.updateMany.mock.calls[0][0] as {
-      where: { appBlockId: string };
+      where: { id: string };
       data: { userId: number };
     };
-    expect(listing.where.appBlockId).toBe(APP);
+    expect(listing.where.id).toBe(LISTING);
     expect(listing.data.userId).toBe(NEW_OWNER);
   });
 
@@ -356,13 +556,19 @@ describe('acceptTransfer — 🔴 ATOMICITY of the two ownership columns', () =>
     expect(mockDb.appOwnershipEvent.create).not.toHaveBeenCalled();
   });
 
-  it('an app with NO listing yet still transfers (a 0-count on the listing is legitimate)', async () => {
-    // A first-version app pending approval has no AppListing row; that must not fail
-    // the transfer, which is why the listing write is deliberately NOT status-guarded.
+  it('🔴 ONSITE: the listing write is deliberately NOT owner-guarded, so a desync cannot fail it', async () => {
+    // `AppListing.userId` is a DENORMALIZED copy on an on-site listing; the canonical
+    // column is the OauthClient's, already guarded above. A 0-count here is a legitimate
+    // desync (or a claimListing that moved the copy), and must not fail a transfer whose
+    // authority already succeeded.
     mockDb.appListing.updateMany.mockResolvedValue({ count: 0 });
     await expect(
       acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW })
     ).resolves.toMatchObject({ toUserId: NEW_OWNER });
+    const listing = mockDb.appListing.updateMany.mock.calls[0][0] as {
+      where: Record<string, unknown>;
+    };
+    expect(listing.where).toEqual({ id: LISTING });
   });
 
   it('only the ADDRESSEE can accept', async () => {
@@ -373,7 +579,9 @@ describe('acceptTransfer — 🔴 ATOMICITY of the two ownership columns', () =>
   });
 
   it('🔴 an EXPIRED offer cannot be accepted', async () => {
-    mockDb.appOwnershipTransfer.findUnique.mockResolvedValue(liveTransfer({ expiresAt: PAST }));
+    mockDb.appOwnershipTransfer.findUnique.mockImplementation(async () =>
+      liveTransfer({ expiresAt: PAST })
+    );
     await expect(
       acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW })
     ).rejects.toMatchObject({ code: 'NO_INVITE' });
@@ -381,7 +589,9 @@ describe('acceptTransfer — 🔴 ATOMICITY of the two ownership columns', () =>
   });
 
   it('a CANCELLED offer cannot be accepted', async () => {
-    mockDb.appOwnershipTransfer.findUnique.mockResolvedValue(liveTransfer({ status: 'cancelled' }));
+    mockDb.appOwnershipTransfer.findUnique.mockImplementation(async () =>
+      liveTransfer({ status: 'cancelled' })
+    );
     await expect(
       acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW })
     ).rejects.toMatchObject({ code: 'NO_INVITE' });
@@ -391,6 +601,79 @@ describe('acceptTransfer — 🔴 ATOMICITY of the two ownership columns', () =>
     await acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW });
     expect(mockRepo.revokeAppRepoWrite).toHaveBeenCalledWith({ slug: SLUG, userId: OLD_OWNER });
     expect(mockRepo.grantAppRepoWrite).toHaveBeenCalledWith({ slug: SLUG, userId: NEW_OWNER });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 🔴 OFF-SITE accept: one column, GUARDED, and no OauthClient / Forgejo anywhere.
+// ---------------------------------------------------------------------------
+
+describe('🔴 acceptTransfer — OFF-SITE moves ONE column, and that column IS the authority', () => {
+  beforeEach(() => {
+    mockDb.appOwnershipTransfer.findUnique.mockImplementation(async () =>
+      liveTransfer({ appListingId: OFFSITE })
+    );
+  });
+
+  it('moves AppListing.userId and NEVER touches OauthClient', async () => {
+    const res = await acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW });
+    expect(res).toMatchObject({ appListingId: OFFSITE, toUserId: NEW_OWNER });
+    expect(mockDb.oauthClient.updateMany).not.toHaveBeenCalled();
+    const listing = mockDb.appListing.updateMany.mock.calls[0][0] as {
+      where: { id: string; userId: number };
+      data: { userId: number };
+    };
+    expect(listing.data.userId).toBe(NEW_OWNER);
+    // 🔴 STATUS-GUARDED on the snapshotted previous owner. Off-site has no OauthClient
+    // write to guard, so this predicate is the ONLY TOCTOU protection that exists.
+    expect(listing.where).toEqual({ id: OFFSITE, userId: OLD_OWNER });
+  });
+
+  it('🔴 a mod `claimListing` in the window makes the accept fail closed, not silently undo it', async () => {
+    // This is the reconciliation with `offsite-moderation::claimListing`, which also
+    // writes `AppListing.userId` for off-site listings. If a moderator reassigned the
+    // listing after the offer was made, the guarded update matches 0 rows and the accept
+    // is refused — moderator authority is final, and the pending offer becomes
+    // permanently unacceptable rather than reverting the remedy.
+    mockDb.appListing.updateMany.mockResolvedValue({ count: 0 });
+    await expect(
+      acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW })
+    ).rejects.toMatchObject({ code: 'NO_INVITE' });
+    expect(mockDb.appOwnershipEvent.create).not.toHaveBeenCalled();
+    expect(calls).toContain('tx:rollback');
+  });
+
+  it('touches NO Forgejo repo — there is none', async () => {
+    await acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW });
+    expect(mockRepo.revokeAppRepoWrite).not.toHaveBeenCalled();
+    expect(mockRepo.grantAppRepoWrite).not.toHaveBeenCalled();
+  });
+
+  it('records the kind on the audit event, so the trail says WHICH shape of move happened', async () => {
+    await acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW });
+    const evt = mockDb.appOwnershipEvent.create.mock.calls[0][0] as {
+      data: { action: string; metadata: { kind: string } };
+    };
+    expect(evt.data.action).toBe('transfer_accepted');
+    expect(evt.data.metadata.kind).toBe('offsite');
+  });
+
+  it('🔴 POSITIVE CONTROL: the ONSITE path DOES call both, so these zeroes mean something', async () => {
+    mockDb.appOwnershipTransfer.findUnique.mockImplementation(async () => liveTransfer());
+    await acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW });
+    expect(mockDb.oauthClient.updateMany).toHaveBeenCalledOnce();
+    expect(mockRepo.grantAppRepoWrite).toHaveBeenCalledOnce();
+  });
+
+  it('an ONSITE transfer whose block record vanished is refused rather than half-applied', async () => {
+    mockDb.appOwnershipTransfer.findUnique.mockImplementation(async () => {
+      const t = liveTransfer();
+      return { ...t, appListing: { ...t.appListing, appBlock: null } };
+    });
+    await expect(
+      acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    expect(mockDb.appListing.updateMany).not.toHaveBeenCalled();
   });
 });
 
@@ -519,7 +802,7 @@ describe('🔴 MONEY INVARIANCE — attribution and payout grouping are untouche
     expect(mockDb.appBlockPublishRequest.updateMany).not.toHaveBeenCalled();
   });
 
-  it('accept never removes collaborator seats — the app keeps its editors', async () => {
+  it('accept never removes collaborator seats — the listing keeps its editors', async () => {
     await acceptTransfer({ transferId: TRANSFER, userId: NEW_OWNER, now: NOW });
     expect(mockDb.appCollaborator.deleteMany).not.toHaveBeenCalled();
   });
@@ -563,17 +846,30 @@ describe('cancelTransfer / getPendingTransfer', () => {
     expect(mockDb.appOwnershipEvent.create).not.toHaveBeenCalled();
   });
 
+  it('a CONNECT listing’s stale offer can still be CANCELLED — refusing to move is not refusing to tidy', async () => {
+    // The refusal is about MOVING ownership. An offer created before a client was linked
+    // must still be withdrawable, or the partial-unique index wedges the listing.
+    mockDb.appOwnershipTransfer.findUnique.mockImplementation(async () =>
+      liveTransfer({ appListingId: CONNECT_LISTING })
+    );
+    await expect(
+      cancelTransfer({ transferId: TRANSFER, actorUserId: OLD_OWNER, now: NOW })
+    ).resolves.toMatchObject({ cancelled: true });
+  });
+
   it('getPendingTransfer returns a LIVE offer', async () => {
-    mockDb.appOwnershipTransfer.findFirst.mockResolvedValue(liveTransfer());
+    mockDb.appOwnershipTransfer.findFirst.mockImplementation(async () => liveTransfer());
     expect(
-      await getPendingTransfer({ appBlockId: APP, viewerUserId: OLD_OWNER, now: NOW })
+      await getPendingTransfer({ appListingId: LISTING, viewerUserId: OLD_OWNER, now: NOW })
     ).toMatchObject({ id: TRANSFER });
   });
 
   it('🔴 getPendingTransfer treats an EXPIRED row as ABSENT (read-time predicate, no sweeper needed)', async () => {
-    mockDb.appOwnershipTransfer.findFirst.mockResolvedValue(liveTransfer({ expiresAt: PAST }));
+    mockDb.appOwnershipTransfer.findFirst.mockImplementation(async () =>
+      liveTransfer({ expiresAt: PAST })
+    );
     expect(
-      await getPendingTransfer({ appBlockId: APP, viewerUserId: OLD_OWNER, now: NOW })
+      await getPendingTransfer({ appListingId: LISTING, viewerUserId: OLD_OWNER, now: NOW })
     ).toBeNull();
   });
 });
@@ -587,23 +883,17 @@ describe('🔴 getPendingTransfer — who may read the offer', () => {
    * This read had NO authorization at all: the proc destructured `{ input }` and never
    * touched `ctx`, while all three sibling transfer procs gate. The row it returns names
    * both parties (`fromUserId`, `toUserId`) and the deadline, so any account with the
-   * author flag could ask, for any app id, who is handing it to whom and by when —
+   * author flag could ask, for any listing id, who is handing it to whom and by when —
    * a pre-announcement of an acquisition, readable by the whole flagged cohort.
    *
-   * Permitted: the app OWNER (the offer's `fromUserId`) and the ADDRESSEE. That is
+   * Permitted: the listing OWNER (the offer's `fromUserId`) and the ADDRESSEE. That is
    * exactly the set that may ACT on the transfer, which is what makes it consistent
    * rather than arbitrary.
    */
   const EDITOR = 30;
 
   beforeEach(() => {
-    mockDb.appOwnershipTransfer.findFirst.mockResolvedValue(liveTransfer());
-    mockDb.appBlock.findUnique.mockResolvedValue({
-      id: APP,
-      appId: CLIENT,
-      blockId: SLUG,
-      app: { userId: OLD_OWNER },
-    });
+    mockDb.appOwnershipTransfer.findFirst.mockImplementation(async () => liveTransfer());
     mockDb.appCollaborator.findFirst.mockImplementation(async (args: unknown) => {
       const w = (args as { where: { userId: number; status?: string } }).where;
       return w.userId === EDITOR && w.status === 'accepted' ? { userId: EDITOR } : null;
@@ -612,53 +902,58 @@ describe('🔴 getPendingTransfer — who may read the offer', () => {
 
   it('the OWNER sees the offer', async () => {
     await expect(
-      getPendingTransfer({ appBlockId: APP, viewerUserId: OLD_OWNER, now: NOW })
+      getPendingTransfer({ appListingId: LISTING, viewerUserId: OLD_OWNER, now: NOW })
     ).resolves.toMatchObject({ id: TRANSFER, toUserId: NEW_OWNER });
   });
 
   it('the ADDRESSEE sees the offer they must accept', async () => {
     await expect(
-      getPendingTransfer({ appBlockId: APP, viewerUserId: NEW_OWNER, now: NOW })
+      getPendingTransfer({ appListingId: LISTING, viewerUserId: NEW_OWNER, now: NOW })
     ).resolves.toMatchObject({ id: TRANSFER });
   });
 
   it('🔴 a STRANGER gets null — not the row, and not a FORBIDDEN either', async () => {
     // `null`, deliberately: a throw would make this proc an EXISTENCE ORACLE, and "this
-    // app has a pending transfer" is itself the private fact. The refusal has to be
+    // listing has a pending transfer" is itself the private fact. The refusal has to be
     // indistinguishable from "there is no offer".
     await expect(
-      getPendingTransfer({ appBlockId: APP, viewerUserId: STRANGER, now: NOW })
+      getPendingTransfer({ appListingId: LISTING, viewerUserId: STRANGER, now: NOW })
     ).resolves.toBeNull();
   });
 
-  it('🔴 an ACCEPTED EDITOR gets null — a seat is not a claim on the app’s disposal', async () => {
+  it('🔴 an ACCEPTED EDITOR gets null — a seat is not a claim on the listing’s disposal', async () => {
     // An editor is a co-owner for CONTENT. Initiating a transfer is one of the two
     // owner-reserved actions, so watching one is not theirs either.
     await expect(
-      getPendingTransfer({ appBlockId: APP, viewerUserId: EDITOR, now: NOW })
+      getPendingTransfer({ appListingId: LISTING, viewerUserId: EDITOR, now: NOW })
     ).resolves.toBeNull();
   });
 
   it('POSITIVE CONTROL: that same editor really does resolve as an editor', async () => {
     // Otherwise the null above proves nothing — it could be a seat lookup wired to
     // nothing rather than a deliberate exclusion.
-    const { resolveAppAccess: resolve } = await import(
-      '~/server/services/blocks/app-access.service'
-    );
-    expect((await resolve(APP, EDITOR))!.role).toBe('editor');
+    expect((await resolveListingAccess(LISTING, EDITOR))!.role).toBe('editor');
   });
 
-  it('a missing app is NOT_FOUND', async () => {
-    mockDb.appBlock.findUnique.mockResolvedValue(null);
+  it('a missing listing is NOT_FOUND', async () => {
     await expect(
-      getPendingTransfer({ appBlockId: APP, viewerUserId: OLD_OWNER, now: NOW })
+      getPendingTransfer({ appListingId: 'apl_nope', viewerUserId: OLD_OWNER, now: NOW })
     ).rejects.toMatchObject({ code: 'NOT_FOUND' });
   });
 
+  it('the offer is looked up under the PARENT listing when asked from a shadow', async () => {
+    await getPendingTransfer({ appListingId: SHADOW, viewerUserId: OLD_OWNER, now: NOW });
+    expect(mockDb.appOwnershipTransfer.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { appListingId: LISTING, status: 'pending' } })
+    );
+  });
+
   it('an EXPIRED offer is null for the owner too (expiry still wins over authorization)', async () => {
-    mockDb.appOwnershipTransfer.findFirst.mockResolvedValue(liveTransfer({ expiresAt: PAST }));
+    mockDb.appOwnershipTransfer.findFirst.mockImplementation(async () =>
+      liveTransfer({ expiresAt: PAST })
+    );
     await expect(
-      getPendingTransfer({ appBlockId: APP, viewerUserId: OLD_OWNER, now: NOW })
+      getPendingTransfer({ appListingId: LISTING, viewerUserId: OLD_OWNER, now: NOW })
     ).resolves.toBeNull();
   });
 });

--- a/src/server/services/blocks/__tests__/offsite-listing.edit-consolidate.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.edit-consolidate.service.test.ts
@@ -28,6 +28,10 @@ const { mockRead, mockWrite, seq } = vi.hoisted(() => {
       create: vi.fn(async (args: { data: unknown }) => args.data),
       update: vi.fn(async (args: { data: unknown }) => args.data),
     },
+    // 🔴 SEATS ARE LISTING-KEYED, so EVERY non-owner path now consults this table —
+    // there is no longer an "this listing has no AppBlock" short-circuit to skip it.
+    // Default: no seat, i.e. exactly the owner-only behaviour these cases assert.
+    appCollaborator: { findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
     appListingScreenshot: {
       findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
       createMany: vi.fn(async (..._a: unknown[]) => ({ count: 0 })),

--- a/src/server/services/blocks/__tests__/offsite-listing.edit.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.edit.service.test.ts
@@ -46,6 +46,10 @@ const { mockRead, mockWrite, seq } = vi.hoisted(() => {
       updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
       deleteMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
     },
+    // 🔴 SEATS ARE LISTING-KEYED, so EVERY non-owner path now consults this table —
+    // there is no longer an "this listing has no AppBlock" short-circuit to skip it.
+    // Default: no seat, i.e. exactly the owner-only behaviour these cases assert.
+    appCollaborator: { findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
     appListingScreenshot: {
       count: vi.fn(async (..._a: unknown[]) => 0),
       findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
@@ -52,11 +52,20 @@ type WriteMock = {
   // scan-clean gate (assertAssetsScanClean).
   appListingScreenshot: { findMany: ReturnType<typeof vi.fn> };
   image: { findMany: ReturnType<typeof vi.fn> };
+  // 🔴 claim's SEAT REMEDIATION, in the same tx as the reassign: the impersonator's
+  // seats/invites are deleted and their pending transfer is cancelled, each recorded as
+  // an AppOwnershipEvent.
+  appCollaborator: { findMany: ReturnType<typeof vi.fn>; deleteMany: ReturnType<typeof vi.fn> };
+  appOwnershipTransfer: { updateMany: ReturnType<typeof vi.fn> };
+  appOwnershipEvent: { create: ReturnType<typeof vi.fn> };
 };
 type ReadMock = {
   appListing: { findUnique: ReturnType<typeof vi.fn> };
   appListingReport: { findUnique: ReturnType<typeof vi.fn> };
   appListingModerationEvent: { findMany: ReturnType<typeof vi.fn> };
+  // The OUT-OF-TX table-presence probe. A missing-table error here means the
+  // manual-apply migration has not landed, and the remediation is skipped entirely.
+  appCollaborator: { count: ReturnType<typeof vi.fn> };
 };
 
 const { mockRead, mockWrite, mockNotify, mockLogToAxiom, ids } = vi.hoisted(() => {
@@ -86,6 +95,13 @@ const { mockRead, mockWrite, mockNotify, mockLogToAxiom, ids } = vi.hoisted(() =
         (args?.where?.id?.in ?? []).map((id) => ({ id, ingestion: 'Scanned' }))
       ),
     },
+    // claim's seat remediation, in the same tx as the reassign.
+    appCollaborator: {
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+      deleteMany: vi.fn(async () => ({ count: 0 })),
+    },
+    appOwnershipTransfer: { updateMany: vi.fn(async () => ({ count: 0 })) },
+    appOwnershipEvent: { create: vi.fn(async (a: { data: unknown }) => a.data) },
   };
   // The tx client is the write mock itself, so tx.* calls land on the same spies.
   write.$transaction.mockImplementation(async (cb: (tx: WriteMock) => Promise<unknown>) => cb(write));
@@ -93,6 +109,7 @@ const { mockRead, mockWrite, mockNotify, mockLogToAxiom, ids } = vi.hoisted(() =
     appListing: { findUnique: vi.fn(async () => null) },
     appListingReport: { findUnique: vi.fn(async () => null) },
     appListingModerationEvent: { findMany: vi.fn(async () => []) },
+    appCollaborator: { count: vi.fn(async () => 0) },
   };
   return {
     mockRead: read,
@@ -110,6 +127,8 @@ vi.mock('~/server/utils/app-block-ids', () => ({
   newAppListingReportId: () => `alrp_test_${++ids.n}`,
   newAppListingModerationEventId: () => `alme_test_${++ids.n}`,
   newAppListingPublishRequestId: () => `alpr_test_${++ids.n}`,
+  // claim's seat remediation writes AppOwnershipEvents through `recordOwnershipEvent`.
+  newAppOwnershipEventId: () => `aoe_test_${++ids.n}`,
 }));
 // Assert owner-notification emission without pulling the notifications client graph.
 vi.mock('~/server/services/blocks/app-listing-notify', () => ({ notifyAppListingOwner: mockNotify }));
@@ -186,6 +205,12 @@ beforeEach(() => {
   mockRead.appListing.findUnique.mockResolvedValue(null);
   mockRead.appListingReport.findUnique.mockResolvedValue(null);
   mockRead.appListingModerationEvent.findMany.mockResolvedValue([]);
+  // Default: the collaborator tables EXIST (post-migration) and hold nothing.
+  mockRead.appCollaborator.count.mockResolvedValue(0);
+  mockWrite.appCollaborator.findMany.mockResolvedValue([]);
+  mockWrite.appCollaborator.deleteMany.mockResolvedValue({ count: 0 });
+  mockWrite.appOwnershipTransfer.updateMany.mockResolvedValue({ count: 0 });
+  mockWrite.appOwnershipEvent.create.mockImplementation(async (a: { data: unknown }) => a.data);
   mockNotify.mockResolvedValue(undefined);
   mockLogToAxiom.mockResolvedValue(undefined);
 });
@@ -731,6 +756,233 @@ describe('claimListing', () => {
       })
     ).rejects.toBeInstanceOf(TRPCError);
     expect(mockRead.appListing.findUnique).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // 🔴 SEAT REMEDIATION — new, and only necessary since seats became listing-keyed.
+  // -------------------------------------------------------------------------
+
+  /**
+   * 🔴 WHY THIS EXISTS AT ALL. Before the block→listing re-key an OFF-SITE listing could
+   * hold NO collaborator seats — `app_collaborators` was keyed on `app_blocks(id)` and an
+   * off-site listing has no AppBlock — so "reassign `AppListing.userId`" WAS the complete
+   * remediation and this gap did not exist. It does now.
+   *
+   * claim is the IMPERSONATION remedy (report → delist → claim → ban). Everything the
+   * impersonator attached to the listing is part of what is being taken away. Left
+   * behind, their seats survive as live editor capability on the REAL owner's listing,
+   * their pending invites stay acceptable, their accepted-and-displayed seats keep
+   * appearing in the PUBLIC BYLINE under the new owner's name, and a pending ownership
+   * TRANSFER they had already offered stays acceptable — handing the listing straight
+   * back out.
+   */
+  describe('🔴 claim clears the impersonator’s seats, invites and pending transfer', () => {
+    /** Two seats: one accepted-and-displayed (the byline), one still pending. */
+    const SEATS = [
+      { userId: 901, status: 'accepted' },
+      { userId: 902, status: 'pending' },
+    ];
+
+    function armClaim() {
+      mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('approved'));
+      mockWrite.appListing.findUnique.mockResolvedValueOnce(primarySnapshot('approved'));
+    }
+
+    it('POSITIVE CONTROL: with no seats and no transfer, nothing is deleted or cancelled', async () => {
+      // The baseline. If this failed, every "was deleted" assertion below could be
+      // satisfied by a fixture that deletes unconditionally.
+      armClaim();
+      await claimListing({
+        input: { appListingId: APP_ID, targetUserId: TARGET, reason: GOOD_REASON },
+        reviewerUserId: REVIEWER,
+      });
+      expect(mockWrite.appCollaborator.deleteMany).not.toHaveBeenCalled();
+      expect(mockWrite.appOwnershipEvent.create).not.toHaveBeenCalled();
+      // The transfer sweep is unconditional (a status-guarded updateMany is cheap and
+      // cannot damage a terminal row), but it must record NOTHING when it matches none.
+      expect(mockWrite.appOwnershipTransfer.updateMany).toHaveBeenCalledTimes(1);
+    });
+
+    it('🔴 every seat on the listing is DELETED — scoped to this listing', async () => {
+      armClaim();
+      mockWrite.appCollaborator.findMany.mockResolvedValue(SEATS);
+      mockWrite.appCollaborator.deleteMany.mockResolvedValue({ count: 2 });
+      await claimListing({
+        input: { appListingId: APP_ID, targetUserId: TARGET, reason: GOOD_REASON },
+        reviewerUserId: REVIEWER,
+      });
+      expect(mockWrite.appCollaborator.deleteMany).toHaveBeenCalledWith({
+        where: { appListingId: APP_ID },
+      });
+      // 🔴 No `status` filter: a PENDING invite is exactly as much of the impersonator's
+      // residue as an accepted seat, and leaving it would let them re-enter by having
+      // their invitee simply accept afterwards.
+      const where = mockWrite.appCollaborator.deleteMany.mock.calls[0][0].where;
+      expect(where).not.toHaveProperty('status');
+    });
+
+    it('🔴 each removed seat is AUDITED by user id — a count cannot name who lost access', async () => {
+      armClaim();
+      mockWrite.appCollaborator.findMany.mockResolvedValue(SEATS);
+      mockWrite.appCollaborator.deleteMany.mockResolvedValue({ count: 2 });
+      await claimListing({
+        input: { appListingId: APP_ID, targetUserId: TARGET, reason: GOOD_REASON },
+        reviewerUserId: REVIEWER,
+      });
+      const events = (
+        mockWrite.appOwnershipEvent.create.mock.calls as Array<[{ data: Record<string, unknown> }]>
+      ).map((c) => c[0].data);
+      expect(events).toHaveLength(2);
+      expect(events.map((e) => e.targetUserId).sort()).toEqual([901, 902]);
+      for (const e of events) {
+        expect(e.action).toBe('remove');
+        expect(e.actorUserId).toBe(REVIEWER);
+        expect(e.appListingId).toBe(APP_ID);
+        expect(e.slug).toBe(SLUG);
+      }
+      // The ids must be READ BEFORE the delete, or they cannot be recorded at all.
+      expect(mockWrite.appCollaborator.findMany).toHaveBeenCalledWith({
+        where: { appListingId: APP_ID },
+        select: { userId: true, status: true },
+      });
+    });
+
+    it('🔴 a PENDING ownership transfer is CANCELLED (guarded on pending) and audited', async () => {
+      armClaim();
+      mockWrite.appOwnershipTransfer.updateMany.mockResolvedValue({ count: 1 });
+      await claimListing({
+        input: { appListingId: APP_ID, targetUserId: TARGET, reason: GOOD_REASON },
+        reviewerUserId: REVIEWER,
+      });
+      const call = mockWrite.appOwnershipTransfer.updateMany.mock.calls[0][0];
+      expect(call.where).toMatchObject({ appListingId: APP_ID, status: 'pending' });
+      expect(call.data.status).toBe('cancelled');
+      const events = (
+        mockWrite.appOwnershipEvent.create.mock.calls as Array<[{ data: Record<string, unknown> }]>
+      ).map((c) => c[0].data);
+      expect(events).toHaveLength(1);
+      expect(events[0].action).toBe('transfer_cancelled');
+      expect(events[0].actorUserId).toBe(REVIEWER);
+    });
+
+    it('🔴 the cleanup happens INSIDE the claim transaction', async () => {
+      // A cleanup issued outside the tx would survive a rolled-back claim — the listing
+      // would keep its impersonating owner AND lose its seats. Same discipline the
+      // "zero events on a guarded claim" tests already hold for the audit write.
+      const order: string[] = [];
+      mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('approved'));
+      mockWrite.appListing.findUnique.mockResolvedValueOnce(primarySnapshot('approved'));
+      mockWrite.appCollaborator.findMany.mockResolvedValue(SEATS);
+      mockWrite.appCollaborator.deleteMany.mockImplementation(async () => {
+        order.push('delete');
+        return { count: 2 };
+      });
+      mockWrite.$transaction.mockImplementation(async (cb: (tx: WriteMock) => Promise<unknown>) => {
+        order.push('tx:begin');
+        const r = await cb(mockWrite);
+        order.push('tx:commit');
+        return r;
+      });
+      await claimListing({
+        input: { appListingId: APP_ID, targetUserId: TARGET, reason: GOOD_REASON },
+        reviewerUserId: REVIEWER,
+      });
+      expect(order).toEqual(['tx:begin', 'delete', 'tx:commit']);
+    });
+
+    it('🔴 a GUARDED (0-row) claim deletes NOTHING — the rollback covers the seats too', async () => {
+      // The reassign matches 0 rows (a concurrent action moved the listing), so the whole
+      // tx throws before any cleanup. The seats belong to a listing that was not claimed.
+      mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('approved'));
+      mockWrite.appListing.findUnique.mockResolvedValueOnce(primarySnapshot('approved'));
+      mockWrite.appListing.updateMany.mockResolvedValue({ count: 0 });
+      mockWrite.appCollaborator.findMany.mockResolvedValue(SEATS);
+      await expect(
+        claimListing({
+          input: { appListingId: APP_ID, targetUserId: TARGET, reason: GOOD_REASON },
+          reviewerUserId: REVIEWER,
+        })
+      ).rejects.toMatchObject({ code: 'NOT_TRANSITIONABLE' });
+      expect(mockWrite.appCollaborator.deleteMany).not.toHaveBeenCalled();
+      expect(mockWrite.appOwnershipTransfer.updateMany).not.toHaveBeenCalled();
+    });
+
+    /**
+     * 🔴 THE PRE-MIGRATION WINDOW. These tables are manual-apply (DB rule #8). A
+     * statement against a missing relation ABORTS the surrounding Postgres transaction
+     * and no `catch` can undo that — every later statement fails 25P02 — so the
+     * degrade-to-fallback CANNOT live inside the tx. It is a probe issued BEFORE one is
+     * opened, and a missing table must leave the claim behaving exactly as it did before
+     * this feature existed.
+     */
+    describe('the tables may not exist yet', () => {
+      /** What Prisma raises for a missing relation. */
+      const MISSING = Object.assign(new Error('relation "app_collaborators" does not exist'), {
+        code: 'P2021',
+      });
+
+      it('🔴 a missing table SKIPS the remediation and the claim still succeeds', async () => {
+        armClaim();
+        mockRead.appCollaborator.count.mockRejectedValue(MISSING);
+        const res = await claimListing({
+          input: { appListingId: APP_ID, targetUserId: TARGET, reason: GOOD_REASON },
+          reviewerUserId: REVIEWER,
+        });
+        expect(res).toEqual({ appListingId: APP_ID, userId: TARGET });
+        // Nothing collaborator-shaped is issued INSIDE the tx — which is the point: any
+        // one of these would have aborted it.
+        expect(mockWrite.appCollaborator.findMany).not.toHaveBeenCalled();
+        expect(mockWrite.appCollaborator.deleteMany).not.toHaveBeenCalled();
+        expect(mockWrite.appOwnershipTransfer.updateMany).not.toHaveBeenCalled();
+        // …and the claim's own audit event is still written.
+        expect(mockWrite.appListingModerationEvent.create).toHaveBeenCalledTimes(1);
+      });
+
+      it('🔴 the probe is issued BEFORE the transaction opens', async () => {
+        // If it ran inside, the missing-table error would abort the tx and the `catch`
+        // would be decorative — the whole reason it is out here.
+        const order: string[] = [];
+        mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('approved'));
+        mockWrite.appListing.findUnique.mockResolvedValueOnce(primarySnapshot('approved'));
+        mockRead.appCollaborator.count.mockImplementation(async () => {
+          order.push('probe');
+          return 0;
+        });
+        mockWrite.$transaction.mockImplementation(
+          async (cb: (tx: WriteMock) => Promise<unknown>) => {
+            order.push('tx:begin');
+            return cb(mockWrite);
+          }
+        );
+        await claimListing({
+          input: { appListingId: APP_ID, targetUserId: TARGET, reason: GOOD_REASON },
+          reviewerUserId: REVIEWER,
+        });
+        expect(order).toEqual(['probe', 'tx:begin']);
+      });
+
+      it('🔴 a NON-missing-table error still propagates — this is not a blanket swallow', async () => {
+        // The degrade is narrow by design. A connection failure or a genuine query bug
+        // must not be turned into "no seats to clean", which would silently skip the
+        // remediation on every claim.
+        //
+        // 🔴 Only the REPLICA read is armed here, deliberately: this call throws at the
+        // probe, BEFORE the transaction opens, so an `armClaim()` would leave an
+        // unconsumed `mockResolvedValueOnce` on `mockWrite.appListing.findUnique`.
+        // `vi.clearAllMocks()` clears recorded calls but NOT the once-queue, so that
+        // value would be handed to the NEXT suite's first in-tx primary read — which is
+        // how one leaked `Once` cascaded into 14 unrelated failures while this file was
+        // being written.
+        mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('approved'));
+        mockRead.appCollaborator.count.mockRejectedValue(new Error('connection reset'));
+        await expect(
+          claimListing({
+            input: { appListingId: APP_ID, targetUserId: TARGET, reason: GOOD_REASON },
+            reviewerUserId: REVIEWER,
+          })
+        ).rejects.toThrow('connection reset');
+      });
+    });
   });
 });
 

--- a/src/server/services/blocks/app-access.service.ts
+++ b/src/server/services/blocks/app-access.service.ts
@@ -58,22 +58,33 @@ import { dbRead } from '~/server/db/client';
  *   - `inviteCollaborator` REFUSES to create a seat on a shadow.
  * `app-collaborator.shadow-hazard.test.ts` pins both directions.
  *
- * ## INERT UNTIL THE MIGRATION IS APPLIED
+ * ## INERT WHILE THE COLLABORATOR TABLES ARE ABSENT — AND THE MIGRATION IS SPLIT IN TWO
+ *   SO THAT "ABSENT" IS THE ONLY STATE THE DEPLOY WINDOW CAN BE IN
  *
- * 🔴 The `app_collaborators` table is MANUAL-APPLY (datapacket-talos DB rule #8) — no
- * deploy path runs `prisma migrate deploy`. Every read of it therefore goes through
- * {@link safeCollaboratorQuery}, which catches "relation does not exist" and degrades
- * to "no collaborators". With the table absent, `resolveAppAccess` returns exactly
- * `owner`/`null` — byte-identical to the pre-change owner-only behaviour — instead of
- * 500ing every app page. The WRITE paths do not swallow it (an invite that silently
- * did nothing would be worse than an error).
+ * 🔴 THE SAFETY NET IS KEYED TO **42P01 ONLY**, so it is a claim about a MISSING TABLE
+ * and NOT about a mismatched one. {@link safeCollaboratorQuery} degrades to "no
+ * collaborators" when the table does not exist (P2021 / 42P01); {@link
+ * isMissingTableError} deliberately REFUSES a column error (42703), because a
+ * half-applied schema must surface rather than become a permanent silent zero. A 42703
+ * therefore PROPAGATES — through `getListingDetail` → `loadDisplayedCollaboratorChips`,
+ * which has no try/catch above it — and 500s the public listing-detail read.
  *
- * 🔴 THE RE-KEY NARROWS THAT SAFETY NET, DELIBERATELY. Between deploying this code and
- * applying `20260811160000_rekey_app_collaborators_to_listings`, the OLD block-keyed
- * tables still EXIST, so a read fails with `column "app_listing_id" does not exist`
- * (42703), NOT 42P01 — and {@link isMissingTableError} refuses column errors on
- * purpose (a half-applied schema must surface, not degrade to a permanent silent
- * zero). Apply the migration in the same maintenance step as the deploy.
+ * 🔴 SO THE RE-KEY IS APPLIED AS TWO MIGRATIONS, AND THE ORDER IS LOAD-BEARING:
+ *
+ *   1. `20260811160000_rekey_app_collaborators_step_a_drop_block_keyed` — apply BEFORE
+ *      the deploy. Drops the block-keyed tables. The code that is live at that moment
+ *      then reads a table that is GONE → 42P01 → swallowed → owner-only. No error.
+ *   2. the code deploy — this code, still with no tables → 42P01 → swallowed. Inert.
+ *   3. `20260811170000_rekey_app_collaborators_step_b_create_listing_keyed` — apply
+ *      AFTER the deploy. Creates the listing-keyed tables; the feature turns on.
+ *
+ * Every intermediate state is a MISSING-TABLE state, which is the state this module's
+ * fallback actually covers. There is no instant at which any deployed code reads a
+ * table whose KEY COLUMN it disagrees about, which is the 42703 case — the one the
+ * single DROP+CREATE migration created, in BOTH orderings.
+ *
+ * The WRITE paths do not swallow the missing table at all (an invite that silently did
+ * nothing would be worse than an error).
  */
 
 /** The two capability roles. `null` (no access) is modelled as the absence of one. */
@@ -105,7 +116,21 @@ export type ListingAccess = {
    * seat is ever read or written under.
    */
   seatListingId: string;
-  /** The listing's owner column (canonical for offsite, denormalized for onsite). */
+  /**
+   * 🔴 THE CANONICAL OWNER, resolved KIND-AWARE — **not** `AppListing.userId`.
+   *
+   * For an ON-SITE listing ownership lives on `OauthClient.userId`, reached as
+   * `AppListing.appBlock.app.userId`; `AppListing.userId` is a DENORMALIZED COPY that
+   * this feature's own code can leave stale (`acceptTransfer` step 3 is deliberately
+   * unguarded for onsite and treats a 0-count as an accepted desync). Reading the copy
+   * would hand the roster — including `displayed:false` seats, `invitedBy` and the
+   * timestamps — to whoever the stale row names, while refusing the REAL owner
+   * `NOT_OWNER` on their own app. For an OFF-SITE listing there is no OauthClient in
+   * the ownership chain, so the column IS the owner and the fallback is exact.
+   *
+   * This matches `toSeatListing` / `loadOwnedListing`, which already resolve it this
+   * way; `app-access.call-site-ledger.test.ts` pins that every consumer agrees.
+   */
   ownerUserId: number;
   /** The PARENT's kind — what the caller may do is derived from it, never from a seat. */
   kind: ListingKind;
@@ -347,27 +372,45 @@ export async function resolveListingAccess(
       kind: true,
       appBlockId: true,
       revisionOfId: true,
-      revisionOf: { select: { id: true, kind: true, appBlockId: true } },
+      // 🔴 The CANONICAL onsite owner. See {@link ListingAccess.ownerUserId}: the
+      // listing's own `userId` is a denormalized copy for onsite and must not be the
+      // authority here.
+      appBlock: { select: { app: { select: { userId: true } } } },
+      revisionOf: {
+        select: {
+          id: true,
+          kind: true,
+          appBlockId: true,
+          appBlock: { select: { app: { select: { userId: true } } } },
+        },
+      },
     },
   });
   if (!listing) return null;
-  // A shadow's seat lives on its PARENT (see the note above), and so do the kind and
-  // the backing block. `revisionOfId` is the authoritative "am I a shadow" signal; the
-  // `revisionOf` relation may be absent from a narrow fixture, so fall back to the
-  // id — never to the shadow's own (always-null) appBlockId.
+  // A shadow's seat lives on its PARENT (see the note above), and so do the kind, the
+  // backing block and the canonical owner. `revisionOfId` is the authoritative "am I a
+  // shadow" signal; the `revisionOf` relation may be absent from a narrow fixture, so
+  // fall back to the id — never to the shadow's own (always-null) appBlockId.
   const parent = listing.revisionOfId ? listing.revisionOf : null;
   const seatListingId = listing.revisionOfId ?? listing.id;
   const kind = ((listing.revisionOfId ? parent?.kind : listing.kind) ?? listing.kind) as ListingKind;
   const appBlockId = (listing.revisionOfId ? parent?.appBlockId : listing.appBlockId) ?? null;
+  // 🔴 `AppBlock.app.userId` FIRST, the column only as the fallback — which is exact for
+  // offsite (no OauthClient in the chain) and covers an onsite block with a dangling
+  // `app_id`. Identical resolution to `toSeatListing` and `loadOwnedListing`, so the
+  // read side and the write side cannot disagree about who the owner is.
+  const ownerUserId =
+    (listing.revisionOfId ? parent?.appBlock?.app?.userId : listing.appBlock?.app?.userId) ??
+    listing.userId;
   const base = {
     appListingId: listing.id,
     seatListingId,
-    ownerUserId: listing.userId,
+    ownerUserId,
     kind,
     appBlockId,
   };
   if (typeof userId !== 'number') return { ...base, role: null };
-  if (listing.userId === userId) return { ...base, role: 'owner' };
+  if (ownerUserId === userId) return { ...base, role: 'owner' };
   const editor = await hasAcceptedSeat(seatListingId, userId, db);
   return { ...base, role: editor ? 'editor' : null };
 }
@@ -449,12 +492,21 @@ export type AccessibleAppBlocks = {
  * `app-collaborator-earnings.service.test.ts`, which fixtures an owner with 2 apps and
  * an editor on 1 and asserts the second never appears.
  *
- * 🔴 SEATS ARE LISTING-KEYED, SO OFF-SITE SEATS DROP OUT HERE — BY DESIGN, NOT BY
- * ACCIDENT. An off-site listing has no `appBlockId`, so it contributes nothing to a
- * BLOCK-id set. That is precisely the `earnings: false` cell of
- * {@link CAPABILITIES_BY_KIND} expressed as data: there is no attribution row that
- * could ever belong to an off-site listing, so an off-site seat must not widen a
- * block-keyed money query by even one id.
+ * 🔴 SEATS ARE LISTING-KEYED, SO OFF-SITE SEATS DROP OUT HERE — AND THE DISCRIMINATOR IS
+ * `kind`, NEVER `appBlockId IS NULL`. Those two are not the same predicate:
+ * `mapAppBlockToListing` mints `kind:'offsite'` WITH a non-null `appBlockId` whenever the
+ * source AppBlock carries an `externalUrl` (reachable through the mod proc
+ * `backfillAppListings`), and `schema.full.prisma` says in as many words to discriminate
+ * on `kind` and never on `appBlockId` nullness. Filtering on nullness alone would let
+ * such a row's seat contribute a REAL block id to this set — and this set is the input to
+ * `getMyAppsEarnings`, which has no kind gate of its own, so a seat-only holder would be
+ * handed real `lifetimeShareCents` on a listing whose kind declares `earnings: false`.
+ * The count of such rows is 0 in production today (measured 2026-08-11: offsite 5 rows,
+ * 0 with a block), so this gate is PREVENTION — but it guards a money read, which is not
+ * where a latent hazard is worth leaving open.
+ *
+ * The `earnings: false` cell of {@link CAPABILITIES_BY_KIND} is the declared form of the
+ * same rule; this is it expressed as a query predicate.
  */
 export async function resolveAccessibleAppBlockIds(userId: number): Promise<AccessibleAppBlocks> {
   const [owned, seats] = await Promise.all([
@@ -471,13 +523,14 @@ export async function resolveAccessibleAppBlockIds(userId: number): Promise<Acce
   const ownedIds = owned.map((b: { id: string }) => b.id);
   const ownedSet = new Set(ownedIds);
 
-  // Seated LISTINGS → their backing blocks. `appBlockId: { not: null }` drops every
-  // off-site seat (see the note above); it is a filter on the DATA, so a listing that
-  // later gains a block is picked up automatically.
+  // Seated LISTINGS → their backing blocks. BOTH predicates, and they are not
+  // redundant (see the note above): `kind: 'onsite'` is the authoritative capability
+  // discriminator, `appBlockId: { not: null }` is the physical one. An OFFSITE row that
+  // carries a block is exactly the case where they disagree, and it must drop out.
   const seatListingIds = seats.map((s: { appListingId: string }) => s.appListingId);
   const seatBlocks = seatListingIds.length
     ? await dbRead.appListing.findMany({
-        where: { id: { in: seatListingIds }, appBlockId: { not: null } },
+        where: { id: { in: seatListingIds }, kind: 'onsite', appBlockId: { not: null } },
         select: { appBlockId: true },
       })
     : [];

--- a/src/server/services/blocks/app-access.service.ts
+++ b/src/server/services/blocks/app-access.service.ts
@@ -21,16 +21,22 @@ import { dbRead } from '~/server/db/client';
  *
  * ## The model
  *
- * Ownership is canonically `OauthClient.userId`, reached as `AppBlock.app.userId`.
- * `AppListing.userId` is a DENORMALIZED COPY. A collaborator seat (`AppCollaborator`)
- * is keyed to the `AppBlock`, so this module resolves listing-shaped questions by
- * walking back to the AppBlock.
+ * 🔴 A SEAT IS KEYED TO THE **APP LISTING**, not to the AppBlock. `AppBlock` is the
+ * ON-SITE runtime record; an OFF-SITE listing (external-link / OAuth-connect) has no
+ * AppBlock at all, so a block-keyed seat was structurally unable to exist for one of
+ * the store's two kinds. `AppListing` is the store-facing parent of BOTH.
  *
- *   role 'owner'  → the OauthClient owner. Everything an editor can do, PLUS managing
+ * Ownership is a SEPARATE question from the seat key, and that distinction is
+ * load-bearing: for an ON-SITE listing ownership is canonically `OauthClient.userId`
+ * (reached as `AppBlock.app.userId`) and `AppListing.userId` is a denormalized copy;
+ * for an OFF-SITE listing `AppListing.userId` IS the owner (there is no OauthClient in
+ * the ownership chain — a connect client is a linked credential, not the owner).
+ *
+ *   role 'owner'  → the listing owner. Everything an editor can do, PLUS managing
  *                   collaborators and initiating an ownership transfer.
- *   role 'editor' → an ACCEPTED `AppCollaborator`. Listing content + media + submit a
- *                   new version + app-scoped analytics AND earnings. Effectively a
- *                   co-owner minus the two owner-only actions above.
+ *   role 'editor' → an ACCEPTED `AppCollaborator`. What that unlocks is DERIVED from
+ *                   the listing's KIND — see {@link capabilitiesForKind}. It is never
+ *                   configured per seat, so there is no new surface to get wrong.
  *   role null     → no access. This INCLUDES a `pending` and a `rejected` seat:
  *                   🔴 an unaccepted invite must confer ZERO capability, or anyone
  *                   could attach a stranger's identity to their app by inviting them.
@@ -39,6 +45,18 @@ import { dbRead } from '~/server/db/client';
  * the existing sites disagree about it (see the ledger); each call site keeps its own
  * `user.isModerator` handling exactly as before, so this consolidation cannot silently
  * grant or revoke a mod bypass anywhere.
+ *
+ * ## 🔴 SHADOW REVISIONS: the resolve-to-parent hop is THE single path
+ *
+ * `applyApprovedRevision` DELETES the shadow on approve and the seat FK CASCADEs, so a
+ * seat that landed on a shadow (`revisionOfId != null`) would vanish silently the
+ * moment a moderator approved the revision. A SQL CHECK cannot express "parent only"
+ * (a row-level CHECK cannot see another row), so the invariant is held in code, from
+ * both ends:
+ *   - {@link resolveListingAccess} resolves a shadow to its PARENT before any seat
+ *     lookup — the only place a seat is ever read by listing id; and
+ *   - `inviteCollaborator` REFUSES to create a seat on a shadow.
+ * `app-collaborator.shadow-hazard.test.ts` pins both directions.
  *
  * ## INERT UNTIL THE MIGRATION IS APPLIED
  *
@@ -49,13 +67,29 @@ import { dbRead } from '~/server/db/client';
  * `owner`/`null` — byte-identical to the pre-change owner-only behaviour — instead of
  * 500ing every app page. The WRITE paths do not swallow it (an invite that silently
  * did nothing would be worse than an error).
+ *
+ * 🔴 THE RE-KEY NARROWS THAT SAFETY NET, DELIBERATELY. Between deploying this code and
+ * applying `20260811160000_rekey_app_collaborators_to_listings`, the OLD block-keyed
+ * tables still EXIST, so a read fails with `column "app_listing_id" does not exist`
+ * (42703), NOT 42P01 — and {@link isMissingTableError} refuses column errors on
+ * purpose (a half-applied schema must surface, not degrade to a permanent silent
+ * zero). Apply the migration in the same maintenance step as the deploy.
  */
 
 /** The two capability roles. `null` (no access) is modelled as the absence of one. */
 export type AppRole = 'owner' | 'editor';
 
+/** The store's two listing kinds. Mirrors `AppListing.kind`'s DB CHECK. */
+export type ListingKind = 'onsite' | 'offsite';
+
 export type AppAccess = {
   appBlockId: string;
+  /**
+   * The `AppListing` that backs this block and therefore holds its seats. `null` when
+   * the block has no listing yet (a first-version app pending approval), in which case
+   * only the owner has access — there is nothing to seat anyone on.
+   */
+  appListingId: string | null;
   /** The canonical owner (`OauthClient.userId`). */
   ownerUserId: number;
   /** `null` = the caller has NO access (stranger, or a pending/rejected invite). */
@@ -63,13 +97,22 @@ export type AppAccess = {
 };
 
 export type ListingAccess = {
+  /** The listing id that was ASKED about. May be a shadow revision. */
   appListingId: string;
-  /** The listing's denormalized owner column. */
-  ownerUserId: number;
   /**
-   * The AppBlock a collaborator seat could be keyed to. `null` for a natively-created
-   * OFFSITE listing (it has no backing AppBlock at all), in which case only the owner
-   * has access — there is nothing to collaborate on.
+   * The PARENT listing that actually holds the seats. Equals `appListingId` for a
+   * top-level listing; for a shadow it is `revisionOfId`. 🔴 This is the ONLY id a
+   * seat is ever read or written under.
+   */
+  seatListingId: string;
+  /** The listing's owner column (canonical for offsite, denormalized for onsite). */
+  ownerUserId: number;
+  /** The PARENT's kind — what the caller may do is derived from it, never from a seat. */
+  kind: ListingKind;
+  /**
+   * The PARENT's backing AppBlock, or `null` for an off-site listing. The two
+   * BLOCK-ONLY capabilities (earnings, submit-version/git) key on this and must refuse
+   * cleanly — not error confusingly — when it is null.
    */
   appBlockId: string | null;
   role: AppRole | null;
@@ -77,6 +120,81 @@ export type ListingAccess = {
 
 /** The one status that confers capability. Nothing else does. */
 export const ACCEPTED = 'accepted' as const;
+
+// ---------------------------------------------------------------------------
+// CAPABILITIES — derived from the listing KIND. No per-seat configuration.
+// ---------------------------------------------------------------------------
+
+/**
+ * What an editor seat can unlock. An editor gets their declared role ∩ what the
+ * listing's KIND supports; there is no third input, and deliberately no stored
+ * per-seat capability set — a config surface here would be a new thing to get wrong on
+ * every invite, and would drift from what the kind can physically do.
+ */
+export type ListingCapability =
+  /** Listing content + media (name/tagline/description/icon/cover/screenshots). */
+  | 'listingContent'
+  /** Submit the listing for moderator review (`AppListingPublishRequest` + changelog). */
+  | 'submitForReview'
+  /** Listing analytics (`AppListingMetric` connect/visit, app views). */
+  | 'analytics'
+  /** Buzz earnings + payout figures. */
+  | 'earnings'
+  /** Ship a new app VERSION: the bundle submit path and Forgejo repo write. */
+  | 'submitVersion';
+
+/**
+ * 🔴 THE CAPABILITY TABLE, and the two `false` cells are STRUCTURAL, not policy:
+ *
+ *   - `earnings` — `BlockBuzzAttribution` is keyed on `appBlockId` + a snapshotted
+ *     `appOwnerUserId`. An off-site listing has no AppBlock, so there is no row that
+ *     could ever be attributed to it. Returning a zeroed summary would be a lie
+ *     indistinguishable from "earned nothing"; the read refuses instead.
+ *   - `submitVersion` — an off-site listing has no bundle and no Forgejo repo. There
+ *     is nothing to push to and no credential to mint.
+ *
+ * Everything else is identical across kinds, because an off-site listing carries the
+ * same content, the same review flow (`AppListingPublishRequest`) and the same metric
+ * rows as an on-site one.
+ */
+export const CAPABILITIES_BY_KIND: Readonly<
+  Record<ListingKind, Readonly<Record<ListingCapability, boolean>>>
+> = Object.freeze({
+  onsite: Object.freeze({
+    listingContent: true,
+    submitForReview: true,
+    analytics: true,
+    earnings: true,
+    submitVersion: true,
+  }),
+  offsite: Object.freeze({
+    listingContent: true,
+    submitForReview: true,
+    analytics: true,
+    // Block-scoped money. No AppBlock ⇒ no attribution rows can exist.
+    earnings: false,
+    // No bundle, no repo.
+    submitVersion: false,
+  }),
+});
+
+/** The capability set a listing of this kind can support at all. */
+export function capabilitiesForKind(
+  kind: ListingKind
+): Readonly<Record<ListingCapability, boolean>> {
+  return CAPABILITIES_BY_KIND[kind] ?? CAPABILITIES_BY_KIND.offsite;
+}
+
+/**
+ * Does a listing of this kind support `capability`?
+ *
+ * 🔴 An UNKNOWN kind falls back to the OFFSITE (narrower) row, not the onsite one —
+ * fail-closed. A kind this code does not recognise must never be handed the two
+ * block-only capabilities.
+ */
+export function listingKindSupports(kind: string, capability: ListingCapability): boolean {
+  return capabilitiesForKind(kind as ListingKind)[capability] === true;
+}
 
 /**
  * Postgres/Prisma "the table isn't there yet" signals.
@@ -134,20 +252,25 @@ export async function safeCollaboratorQuery<T>(fn: () => Promise<T>, fallback: T
 export type AccessDb = typeof dbRead;
 
 /**
- * Is `userId` an ACCEPTED collaborator on `appBlockId`?
+ * Is `userId` an ACCEPTED collaborator on `appListingId`?
+ *
+ * 🔴 `appListingId` MUST already be a PARENT listing id. Every caller reaches this
+ * through {@link resolveListingAccess}'s shadow→parent hop or through an explicit
+ * block→listing hop; nothing looks a seat up under a shadow id, because no seat can
+ * exist there (see the module header).
  *
  * The `status: ACCEPTED` filter is the consent gate and is NOT optional — see the
  * module header. Callers must never widen this to "a row exists".
  */
 async function hasAcceptedSeat(
-  appBlockId: string,
+  appListingId: string,
   userId: number,
   db: AccessDb = dbRead
 ): Promise<boolean> {
   const row = await safeCollaboratorQuery(
     () =>
       db.appCollaborator.findFirst({
-        where: { appBlockId, userId, status: ACCEPTED },
+        where: { appListingId, userId, status: ACCEPTED },
         select: { userId: true },
       }),
     null
@@ -161,6 +284,12 @@ async function hasAcceptedSeat(
  * Returns `null` when the AppBlock does not exist, or when it has no resolvable owner
  * (a dangling `app_id`) — an app nobody owns is an app nobody may edit, which is the
  * fail-closed reading.
+ *
+ * 🔴 THE SEAT LIVES ON THE BLOCK'S LISTING, so this hops `AppBlock → AppListing`
+ * (1:1 via the UNIQUE `app_block_id`). A block with no listing yet resolves
+ * `appListingId: null` and therefore only ever `owner`/`null` — correct, because there
+ * is nothing to seat anyone on. The hop costs one query and is paid ONLY on the
+ * non-owner path.
  */
 export async function resolveAppAccess(
   appBlockId: string,
@@ -168,31 +297,33 @@ export async function resolveAppAccess(
 ): Promise<AppAccess | null> {
   const block = await dbRead.appBlock.findUnique({
     where: { id: appBlockId },
-    select: { id: true, app: { select: { userId: true } } },
+    select: { id: true, app: { select: { userId: true } }, appListing: { select: { id: true } } },
   });
   if (!block?.app) return null;
   const ownerUserId = block.app.userId;
-  if (typeof userId !== 'number') {
-    return { appBlockId: block.id, ownerUserId, role: null };
-  }
-  if (ownerUserId === userId) {
-    return { appBlockId: block.id, ownerUserId, role: 'owner' };
-  }
-  const editor = await hasAcceptedSeat(block.id, userId);
-  return { appBlockId: block.id, ownerUserId, role: editor ? 'editor' : null };
+  const appListingId = block.appListing?.id ?? null;
+  const base = { appBlockId: block.id, appListingId, ownerUserId };
+  if (typeof userId !== 'number') return { ...base, role: null };
+  if (ownerUserId === userId) return { ...base, role: 'owner' };
+  if (!appListingId) return { ...base, role: null };
+  const editor = await hasAcceptedSeat(appListingId, userId);
+  return { ...base, role: editor ? 'editor' : null };
 }
 
 /**
- * Resolve the caller's role on an App LISTING.
+ * Resolve the caller's role on an App LISTING. 🔴 THE primary resolver — every
+ * listing-shaped gate in the feature goes through here.
  *
- * 🔴 SHADOW-AWARE. A shadow revision (`revisionOfId != null`) carries
- * `appBlockId: null` by construction — `appBlockId` is `@unique` and stays on the
- * parent. So resolving a shadow's collaborator seat MUST walk to its parent, or every
- * editor would lose access the moment their first media edit minted the shadow. That
- * is one hop only: `beginListingRevision` refuses to open a revision of a revision.
+ * 🔴 SHADOW-AWARE, and that hop is a SAFETY invariant rather than an ergonomic. A
+ * shadow revision's seats do not exist (nothing may create one — see the module
+ * header), so resolving a shadow MUST walk to its parent or every editor would lose
+ * access the moment their first media edit minted the shadow. That is one hop only:
+ * `beginListingRevision` refuses to open a revision of a revision.
  *
- * A natively-created offsite listing (no backing AppBlock anywhere in the chain)
- * resolves `appBlockId: null` and therefore only ever `owner`/`null`.
+ * `kind` and `appBlockId` are taken from the PARENT for the same reason — a shadow
+ * carries `appBlockId: null` by construction (the column is `@unique` and stays on the
+ * parent), so reading them off the shadow would make every editor's in-flight revision
+ * look like an off-site listing and silently strip the block-only capabilities.
  *
  * 🔴 `db` IS LOAD-BEARING, NOT AN ERGONOMIC. The asset gates in
  * `app-listing-assets.service.ts` already carry a `dbWrite` pool override so the OWNER's
@@ -213,19 +344,31 @@ export async function resolveListingAccess(
     select: {
       id: true,
       userId: true,
+      kind: true,
       appBlockId: true,
       revisionOfId: true,
-      revisionOf: { select: { appBlockId: true } },
+      revisionOf: { select: { id: true, kind: true, appBlockId: true } },
     },
   });
   if (!listing) return null;
-  // A shadow's seat lives on its PARENT's AppBlock (see the note above).
-  const appBlockId = listing.appBlockId ?? listing.revisionOf?.appBlockId ?? null;
-  const base = { appListingId: listing.id, ownerUserId: listing.userId, appBlockId };
+  // A shadow's seat lives on its PARENT (see the note above), and so do the kind and
+  // the backing block. `revisionOfId` is the authoritative "am I a shadow" signal; the
+  // `revisionOf` relation may be absent from a narrow fixture, so fall back to the
+  // id — never to the shadow's own (always-null) appBlockId.
+  const parent = listing.revisionOfId ? listing.revisionOf : null;
+  const seatListingId = listing.revisionOfId ?? listing.id;
+  const kind = ((listing.revisionOfId ? parent?.kind : listing.kind) ?? listing.kind) as ListingKind;
+  const appBlockId = (listing.revisionOfId ? parent?.appBlockId : listing.appBlockId) ?? null;
+  const base = {
+    appListingId: listing.id,
+    seatListingId,
+    ownerUserId: listing.userId,
+    kind,
+    appBlockId,
+  };
   if (typeof userId !== 'number') return { ...base, role: null };
   if (listing.userId === userId) return { ...base, role: 'owner' };
-  if (!appBlockId) return { ...base, role: null };
-  const editor = await hasAcceptedSeat(appBlockId, userId, db);
+  const editor = await hasAcceptedSeat(seatListingId, userId, db);
   return { ...base, role: editor ? 'editor' : null };
 }
 
@@ -242,6 +385,11 @@ export async function resolveListingAccess(
  * collaborators: a moderator who does not personally own the app was refused, unlike
  * the App Listing asset gates which do bypass. That divergence is PRE-EXISTING and is
  * recorded in `app-access.call-site-ledger.test.ts` rather than silently changed here.
+ *
+ * 🔴 These four are BLOCK-ONLY procs by construction (a repo, a manifest, a clone URL),
+ * so they are unreachable for an off-site listing — there is no AppBlock to name. The
+ * `submitVersion` capability's `false` cell for offsite is therefore enforced by the
+ * shape of the surface, not by a runtime branch here.
  *
  * The message is `'Not the app owner'` VERBATIM — it is what callers see today, and the
  * mutation checks assert this exact string so a mutant that breaks this guard dies to
@@ -267,9 +415,15 @@ export async function assertAppEditAccess(args: {
   };
   if (typeof args.ownerUserId !== 'number') deny();
   if (args.ownerUserId === args.userId) return;
-  // Not the owner — the only remaining route in is an ACCEPTED seat. Costs one query,
-  // and ONLY on the non-owner path, so the common case is unchanged.
-  if (!(await hasAcceptedSeat(args.appBlockId, args.userId))) deny();
+  // Not the owner — the only remaining route in is an ACCEPTED seat on the block's
+  // LISTING. Costs two queries, and ONLY on the non-owner path, so the common case is
+  // unchanged. A block with no listing has no seats and falls straight through to deny.
+  const listing = await dbRead.appListing.findUnique({
+    where: { appBlockId: args.appBlockId },
+    select: { id: true },
+  });
+  const seated = listing ? await hasAcceptedSeat(listing.id, args.userId) : false;
+  if (!seated) deny();
 }
 
 export type AccessibleAppBlocks = {
@@ -294,6 +448,13 @@ export type AccessibleAppBlocks = {
  * `app-collaborator-earnings.service.ts`, and the regression test
  * `app-collaborator-earnings.service.test.ts`, which fixtures an owner with 2 apps and
  * an editor on 1 and asserts the second never appears.
+ *
+ * 🔴 SEATS ARE LISTING-KEYED, SO OFF-SITE SEATS DROP OUT HERE — BY DESIGN, NOT BY
+ * ACCIDENT. An off-site listing has no `appBlockId`, so it contributes nothing to a
+ * BLOCK-id set. That is precisely the `earnings: false` cell of
+ * {@link CAPABILITIES_BY_KIND} expressed as data: there is no attribution row that
+ * could ever belong to an off-site listing, so an off-site seat must not widen a
+ * block-keyed money query by even one id.
  */
 export async function resolveAccessibleAppBlockIds(userId: number): Promise<AccessibleAppBlocks> {
   const [owned, seats] = await Promise.all([
@@ -302,25 +463,44 @@ export async function resolveAccessibleAppBlockIds(userId: number): Promise<Acce
       () =>
         dbRead.appCollaborator.findMany({
           where: { userId, status: ACCEPTED },
-          select: { appBlockId: true },
+          select: { appListingId: true },
         }),
-      [] as { appBlockId: string }[]
+      [] as { appListingId: string }[]
     ),
   ]);
   const ownedIds = owned.map((b: { id: string }) => b.id);
   const ownedSet = new Set(ownedIds);
+
+  // Seated LISTINGS → their backing blocks. `appBlockId: { not: null }` drops every
+  // off-site seat (see the note above); it is a filter on the DATA, so a listing that
+  // later gains a block is picked up automatically.
+  const seatListingIds = seats.map((s: { appListingId: string }) => s.appListingId);
+  const seatBlocks = seatListingIds.length
+    ? await dbRead.appListing.findMany({
+        where: { id: { in: seatListingIds }, appBlockId: { not: null } },
+        select: { appBlockId: true },
+      })
+    : [];
+
   // Disjoint by construction: an owner who somehow also holds a seat on their own app
   // counts once, as an owner. (The invite path refuses to seat the owner, so this is
   // defence against a hand-written row, not an expected state.)
-  const editorIds = seats
-    .map((s: { appBlockId: string }) => s.appBlockId)
-    .filter((id: string) => !ownedSet.has(id));
+  const editorIds = [
+    ...new Set(
+      seatBlocks
+        .map((l: { appBlockId: string | null }) => l.appBlockId)
+        .filter((id: string | null): id is string => !!id && !ownedSet.has(id))
+    ),
+  ];
   return { ownedIds, editorIds, allIds: [...ownedIds, ...editorIds] };
 }
 
 /**
- * The PUBLIC byline set for an app: the user ids of its ACCEPTED **and** `displayed`
+ * The PUBLIC byline set for a LISTING: the user ids of its ACCEPTED **and** `displayed`
  * collaborators.
+ *
+ * 🔴 Takes the PARENT listing id. Works identically for both kinds — this is the read
+ * the re-key exists to make possible for off-site listings.
  *
  * 🔴 BOTH predicates are load-bearing and neither may be dropped:
  *   - `status = accepted` is CONSENT (a pending invitee never appears publicly, so an
@@ -332,11 +512,11 @@ export async function resolveAccessibleAppBlockIds(userId: number): Promise<Acce
  * this set. The DTO half — that the projection adds nothing to what it is handed — is
  * pinned separately in `app-collaborator.public-projection.test.ts`.
  */
-export async function listDisplayedCollaboratorUserIds(appBlockId: string): Promise<number[]> {
+export async function listDisplayedCollaboratorUserIds(appListingId: string): Promise<number[]> {
   const rows = await safeCollaboratorQuery(
     () =>
       dbRead.appCollaborator.findMany({
-        where: { appBlockId, status: ACCEPTED, displayed: true },
+        where: { appListingId, status: ACCEPTED, displayed: true },
         select: { userId: true },
         orderBy: { createdAt: 'asc' },
       }),
@@ -349,6 +529,9 @@ export async function listDisplayedCollaboratorUserIds(appBlockId: string): Prom
  * The user ids that must be treated as "the app's own people" for ANTI-ABUSE
  * purposes — the owner plus every ACCEPTED collaborator, REGARDLESS of `displayed`.
  *
+ * Keyed on the APP BLOCK because its only caller is the `AppBlockReview` self-review
+ * gate, which is block-scoped; the seats are reached via the block's listing.
+ *
  * 🔴 `displayed` is deliberately NOT filtered here, and the asymmetry with
  * {@link listDisplayedCollaboratorUserIds} is the whole point: `displayed` is a
  * PUBLIC-CREDIT preference, not a capability. An editor who opted out of the byline is
@@ -358,18 +541,20 @@ export async function listDisplayedCollaboratorUserIds(appBlockId: string): Prom
 export async function listAppInsiderUserIds(appBlockId: string): Promise<number[]> {
   const block = await dbRead.appBlock.findUnique({
     where: { id: appBlockId },
-    select: { app: { select: { userId: true } } },
+    select: { app: { select: { userId: true } }, appListing: { select: { id: true } } },
   });
   if (!block?.app) return [];
+  const ids = new Set<number>([block.app.userId]);
+  const appListingId = block.appListing?.id;
+  if (!appListingId) return [...ids];
   const seats = await safeCollaboratorQuery(
     () =>
       dbRead.appCollaborator.findMany({
-        where: { appBlockId, status: ACCEPTED },
+        where: { appListingId, status: ACCEPTED },
         select: { userId: true },
       }),
     [] as { userId: number }[]
   );
-  const ids = new Set<number>([block.app.userId]);
   for (const s of seats) ids.add(s.userId);
   return [...ids];
 }

--- a/src/server/services/blocks/app-collaborator-earnings.service.ts
+++ b/src/server/services/blocks/app-collaborator-earnings.service.ts
@@ -1,6 +1,7 @@
 import { dbRead } from '~/server/db/client';
 import {
-  resolveAppAccess,
+  listingKindSupports,
+  resolveListingAccess,
   resolveAccessibleAppBlockIds,
 } from '~/server/services/blocks/app-access.service';
 import type { RevenueSummary } from '~/server/services/blocks/buzz-attribution.service';
@@ -50,6 +51,18 @@ import type { RevenueSummary } from '~/server/services/blocks/buzz-attribution.s
  * Both scopes are therefore applied: the app must be one the caller may see, AND the
  * rows must belong to the app's CURRENT owner. That is the same forward-cut the
  * transfer decision describes, enforced on the read side.
+ *
+ * ## The third scope: KIND
+ *
+ * 🔴 EARNINGS ARE BLOCK-SCOPED AND THEREFORE ON-SITE ONLY. `BlockBuzzAttribution` keys
+ * on `appBlockId`; an OFF-SITE listing has no AppBlock, so no attribution row can ever
+ * belong to it. That is a structural fact, not a policy toggle, and it is the
+ * `earnings: false` cell of `CAPABILITIES_BY_KIND`.
+ *
+ * The refusal is EXPLICIT (`unsupportedKind`), never a zeroed summary. A zero here
+ * would be indistinguishable from "this app earned nothing" — the exact silent-zero
+ * shape this codebase keeps paying for — and would teach an off-site developer that
+ * their listing earns and simply has not yet.
  */
 
 export type AppScopedRevenue = {
@@ -66,35 +79,57 @@ const EMPTY_SUMMARY: RevenueSummary = {
 };
 
 export type AppEarningsResult =
-  | { ok: true; appBlockId: string; role: 'owner' | 'editor'; summary: RevenueSummary }
+  | {
+      ok: true;
+      appListingId: string;
+      appBlockId: string;
+      role: 'owner' | 'editor';
+      summary: RevenueSummary;
+    }
   /**
    * `notPermitted` is a REAL, reachable state (unlike revenue's deliberately-absent
    * `notOwned`): a collaborator-reachable read genuinely does compute access, so the
    * caller can be told "you may not see this" rather than handed a zero that is
    * indistinguishable from "this app earned nothing".
+   *
+   * `unsupportedKind` is the OFF-SITE refusal — the listing exists and the caller may
+   * well be its owner, but earnings are structurally block-scoped. Also explicit, for
+   * the same never-a-silent-zero reason.
    */
-  | { ok: false; appBlockId: string; reason: 'notPermitted' | 'notFound' };
+  | {
+      ok: false;
+      appListingId: string;
+      reason: 'notPermitted' | 'notFound' | 'unsupportedKind';
+    };
 
 /**
- * Earnings for ONE app, readable by its owner OR an accepted collaborator.
+ * Earnings for ONE listing, readable by its owner OR an accepted collaborator.
  *
- * Fail-closed: an app the caller has no role on returns `notPermitted` WITHOUT running
- * any aggregate — the caller never learns anything about a stranger's app, not even
- * its totals.
+ * Fail-closed: a listing the caller has no role on returns `notPermitted` WITHOUT
+ * running any aggregate — the caller never learns anything about a stranger's app, not
+ * even its totals. An OFF-SITE listing returns `unsupportedKind`, also without an
+ * aggregate (there is no id to aggregate on).
  */
 export async function getAppEarnings(opts: {
-  appBlockId: string;
+  appListingId: string;
   userId: number;
   from?: Date;
   to?: Date;
 }): Promise<AppEarningsResult> {
-  const access = await resolveAppAccess(opts.appBlockId, opts.userId);
-  if (!access) return { ok: false, appBlockId: opts.appBlockId, reason: 'notFound' };
-  if (!access.role) return { ok: false, appBlockId: opts.appBlockId, reason: 'notPermitted' };
+  const access = await resolveListingAccess(opts.appListingId, opts.userId);
+  if (!access) return { ok: false, appListingId: opts.appListingId, reason: 'notFound' };
+  if (!access.role) return { ok: false, appListingId: opts.appListingId, reason: 'notPermitted' };
+  // 🔴 KIND GATE, and it is asserted TWO ways so neither alone is load-bearing: the
+  // declared capability table says off-site has no earnings, and the resolved
+  // `appBlockId` is the physical reason it cannot. If they ever disagree, refuse.
+  if (!listingKindSupports(access.kind, 'earnings') || !access.appBlockId) {
+    return { ok: false, appListingId: opts.appListingId, reason: 'unsupportedKind' };
+  }
+  const appBlockId = access.appBlockId;
 
   const where = {
     // 🔴 BOTH scopes. See the module header — dropping either one is the leak.
-    appBlockId: opts.appBlockId,
+    appBlockId,
     appOwnerUserId: access.ownerUserId,
     ...(opts.from || opts.to
       ? {
@@ -141,7 +176,8 @@ export async function getAppEarnings(opts: {
 
   return {
     ok: true,
-    appBlockId: opts.appBlockId,
+    appListingId: opts.appListingId,
+    appBlockId,
     role: access.role,
     summary: {
       pending: bucket(pending as Agg),

--- a/src/server/services/blocks/app-collaborator-earnings.service.ts
+++ b/src/server/services/blocks/app-collaborator-earnings.service.ts
@@ -119,9 +119,21 @@ export async function getAppEarnings(opts: {
   const access = await resolveListingAccess(opts.appListingId, opts.userId);
   if (!access) return { ok: false, appListingId: opts.appListingId, reason: 'notFound' };
   if (!access.role) return { ok: false, appListingId: opts.appListingId, reason: 'notPermitted' };
-  // 🔴 KIND GATE, and it is asserted TWO ways so neither alone is load-bearing: the
-  // declared capability table says off-site has no earnings, and the resolved
-  // `appBlockId` is the physical reason it cannot. If they ever disagree, refuse.
+  // 🔴 KIND GATE. TWO INDEPENDENT clauses, OR-ed so that EITHER ONE refuses on its own:
+  // the declared capability table says off-site has no earnings, and the resolved
+  // `appBlockId` is the physical reason it cannot. They agree on the common shapes and
+  // DISAGREE on two that are both reachable, which is why neither clause may be dropped:
+  //
+  //   - kind 'offsite' WITH a block — `mapAppBlockToListing` mints this for any AppBlock
+  //     carrying an `externalUrl` (reachable via the mod proc `backfillAppListings`).
+  //     Only the KIND clause refuses it, and dropping it would return REAL money figures
+  //     for a listing whose kind declares `earnings: false`.
+  //   - kind 'onsite' WITHOUT a block — a listing whose backing AppBlock row is missing
+  //     or not yet linked. Only the BLOCK clause refuses it; dropping it would run the
+  //     aggregate with `appBlockId: null`.
+  //
+  // `app-collaborator-earnings.service.test.ts` fixtures BOTH shapes, so the `||`→`&&`
+  // mutant (which requires both clauses to fire before refusing) dies on each of them.
   if (!listingKindSupports(access.kind, 'earnings') || !access.appBlockId) {
     return { ok: false, appListingId: opts.appListingId, reason: 'unsupportedKind' };
   }

--- a/src/server/services/blocks/app-collaborator.service.ts
+++ b/src/server/services/blocks/app-collaborator.service.ts
@@ -3,7 +3,11 @@ import type { Prisma } from '@prisma/client';
 
 import { constants } from '~/server/common/constants';
 import { dbRead, dbWrite } from '~/server/db/client';
-import { ACCEPTED, resolveAppAccess } from '~/server/services/blocks/app-access.service';
+import {
+  ACCEPTED,
+  resolveListingAccess,
+  type ListingKind,
+} from '~/server/services/blocks/app-access.service';
 import { notifyAppCollaborator } from '~/server/services/blocks/app-collaborator-notify';
 import { grantAppRepoWrite, revokeAppRepoWrite } from '~/server/services/blocks/app-repo-access';
 import { newAppOwnershipEventId } from '~/server/utils/app-block-ids';
@@ -11,6 +15,10 @@ import { newAppOwnershipEventId } from '~/server/utils/app-block-ids';
 /**
  * App Listing COLLABORATORS — the SEAT lifecycle (invite / accept / reject / remove /
  * leave / byline opt-in).
+ *
+ * 🔴 SEATS ARE KEYED TO THE APP **LISTING**. See `app-access.service`'s header for why
+ * (an off-site listing has no AppBlock, so a block-keyed seat could not exist for one
+ * of the store's two kinds).
  *
  * ## What is copied from `EntityCollaborator`, and what deliberately is not
  *
@@ -36,6 +44,14 @@ import { newAppOwnershipEventId } from '~/server/utils/app-block-ids';
  * a co-owner, but may not seat or unseat anyone (that plus initiating a transfer are
  * the only two owner-reserved actions). An editor MAY remove themselves ({@link
  * leaveApp}) — that is consent, not management.
+ *
+ * ## Forgejo is ON-SITE ONLY
+ *
+ * The repo grant/revoke that rides along with accept / remove / leave fires ONLY when
+ * the listing has a backing AppBlock. An off-site listing has no bundle and no repo —
+ * the `submitVersion: false` capability cell — so there is nothing to grant, and
+ * calling Forgejo with a store slug that names no repo would be a guaranteed 404 on
+ * every off-site seat decision.
  */
 
 export type AppCollaboratorErrorCode =
@@ -69,7 +85,7 @@ export function mapCollaboratorError(err: unknown): unknown {
 }
 
 export type CollaboratorRow = {
-  appBlockId: string;
+  appListingId: string;
   userId: number;
   role: string;
   status: string;
@@ -94,7 +110,7 @@ export async function recordOwnershipEvent(
    */
   tx: Prisma.TransactionClient,
   args: {
-    appBlockId: string;
+    appListingId: string;
     slug: string;
     action:
       | 'invite'
@@ -114,7 +130,7 @@ export async function recordOwnershipEvent(
   await tx.appOwnershipEvent.create({
     data: {
       id: newAppOwnershipEventId(),
-      appBlockId: args.appBlockId,
+      appListingId: args.appListingId,
       slug: args.slug,
       action: args.action,
       actorUserId: args.actorUserId,
@@ -140,24 +156,102 @@ export function shouldNotifyInvite(lastNotifiedAt: Date | null, now: Date): bool
   return lastNotifiedAt.getTime() <= cutoff.getTime();
 }
 
-/** Load the app + assert the caller OWNS it. Editors are refused: seats are owner-managed. */
-async function assertOwner(
-  appBlockId: string,
-  actorUserId: number
-): Promise<{ appBlockId: string; slug: string; ownerUserId: number }> {
-  const block = await dbRead.appBlock.findUnique({
-    where: { id: appBlockId },
-    select: { id: true, blockId: true, app: { select: { userId: true } } },
-  });
-  if (!block?.app) throw new AppCollaboratorError('NOT_FOUND', 'App not found');
-  if (block.app.userId !== actorUserId) {
+/**
+ * The listing a seat operation acts on, already resolved to the SEAT-BEARING PARENT.
+ *
+ * `blockSlug` is the Forgejo repo name and is `null` for an off-site listing — every
+ * repo call is conditioned on it, so an off-site seat decision never reaches Forgejo.
+ */
+type SeatListing = {
+  /** The PARENT listing id — the seat key. */
+  appListingId: string;
+  /** The store slug (audit-event identity, notification copy). */
+  slug: string;
+  kind: ListingKind;
+  /** Backing AppBlock id, or null for off-site. */
+  appBlockId: string | null;
+  /** The AppBlock's `blockId` — the Forgejo repo slug. Null for off-site. */
+  blockSlug: string | null;
+  /** Canonical owner: the OauthClient owner for onsite, the listing column for offsite. */
+  ownerUserId: number;
+  /** True when the id handed in was a SHADOW revision (already hopped to the parent). */
+  wasShadow: boolean;
+};
+
+const seatListingSelect = {
+  id: true,
+  slug: true,
+  kind: true,
+  userId: true,
+  appBlockId: true,
+  revisionOfId: true,
+  appBlock: { select: { blockId: true, app: { select: { userId: true } } } },
+} as const;
+
+type RawSeatListing = {
+  id: string;
+  slug: string;
+  kind: string;
+  userId: number;
+  appBlockId: string | null;
+  revisionOfId: string | null;
+  appBlock: { blockId: string; app: { userId: number } | null } | null;
+};
+
+function toSeatListing(row: RawSeatListing, wasShadow: boolean): SeatListing {
+  return {
+    appListingId: row.id,
+    slug: row.slug,
+    kind: row.kind as ListingKind,
+    appBlockId: row.appBlockId,
+    blockSlug: row.appBlock?.blockId ?? null,
+    // 🔴 ONSITE OWNERSHIP IS CANONICALLY THE OauthClient's. `AppListing.userId` is a
+    // denormalized copy there; for OFFSITE it IS the owner (a connect client is a
+    // linked credential, never the owner). Falling back to the column also covers an
+    // onsite listing whose block has a dangling `app_id`.
+    ownerUserId: row.appBlock?.app?.userId ?? row.userId,
+    wasShadow,
+  };
+}
+
+/**
+ * Load the SEAT-BEARING listing for `appListingId`, hopping a shadow revision to its
+ * parent.
+ *
+ * 🔴 THE SINGLE RESOLVE-TO-PARENT PATH for the write side (the read side is
+ * `resolveListingAccess`). A seat may only ever exist on a parent — see
+ * `app-access.service`'s header — so every seat mutation must land there, and handing
+ * one a shadow id must NOT silently create a second, doomed seat namespace.
+ */
+async function loadSeatListing(appListingId: string): Promise<SeatListing> {
+  const row = (await dbRead.appListing.findUnique({
+    where: { id: appListingId },
+    select: seatListingSelect,
+  })) as RawSeatListing | null;
+  if (!row) throw new AppCollaboratorError('NOT_FOUND', 'App listing not found');
+  if (!row.revisionOfId) return toSeatListing(row, false);
+  const parent = (await dbRead.appListing.findUnique({
+    where: { id: row.revisionOfId },
+    select: seatListingSelect,
+  })) as RawSeatListing | null;
+  if (!parent) throw new AppCollaboratorError('NOT_FOUND', 'App listing not found');
+  return toSeatListing(parent, true);
+}
+
+/**
+ * Load the listing + assert the caller OWNS it. Editors are refused: seats are
+ * owner-managed.
+ */
+async function assertOwner(appListingId: string, actorUserId: number): Promise<SeatListing> {
+  const listing = await loadSeatListing(appListingId);
+  if (listing.ownerUserId !== actorUserId) {
     throw new AppCollaboratorError('NOT_OWNER', 'Only the app owner can manage collaborators');
   }
-  return { appBlockId: block.id, slug: block.blockId, ownerUserId: block.app.userId };
+  return listing;
 }
 
 export type InviteCollaboratorResult = {
-  appBlockId: string;
+  appListingId: string;
   userId: number;
   status: string;
   /** True when this call created the row (vs re-touching a standing invite). */
@@ -174,25 +268,50 @@ export type InviteCollaboratorResult = {
  * ALREADY_SEATED. A repeat invite for a `rejected` row RE-OPENS it as `pending` —
  * declining is not permanent, and the invitee must consent again.
  *
+ * 🔴 A SHADOW REVISION IS REFUSED OUTRIGHT — the seat-creation half of the
+ * parent-only invariant. Silently hopping to the parent here would be *safe* but
+ * *wrong to teach*: an owner who thinks they are seating "the revision" would be
+ * seating the live listing, and the UI would have to explain a hop the product does
+ * not have. Refusing names the truth: collaborators are a property of the LISTING.
+ * The other direction — a seat that landed on a shadow being destroyed by
+ * `applyApprovedRevision`'s CASCADE delete — is what makes this a safety guard and not
+ * a nicety.
+ *
  * 🔴 BAN POLICY (decided, and applied consistently across this feature): a BANNED user
- * may neither be invited nor accept. Rationale: a seat grants Forgejo `write` on the
- * app repo plus visibility of the app's earnings, and `getMyAppRepo` already refuses
- * to issue a push credential to a banned account (`blocks.router.ts:5579`). Seating a
- * banned user would mint exactly the credential that gate exists to withhold. An
- * EXISTING seat is NOT auto-revoked on ban (that would need a ban-hook this PR does
- * not add) — but every capability the seat unlocks re-checks `bannedAt` at the proc,
- * so a banned editor can hold an inert row and do nothing with it.
+ * may neither be invited nor accept. Rationale: on an on-site listing a seat grants
+ * Forgejo `write` on the app repo plus visibility of the app's earnings, and
+ * `getMyAppRepo` already refuses to issue a push credential to a banned account
+ * (`blocks.router.ts:5579`). Seating a banned user would mint exactly the credential
+ * that gate exists to withhold. An EXISTING seat is NOT auto-revoked on ban (that
+ * would need a ban-hook this PR does not add) — but every capability the seat unlocks
+ * re-checks `bannedAt` at the proc, so a banned editor can hold an inert row and do
+ * nothing with it.
  */
 export async function inviteCollaborator(opts: {
-  appBlockId: string;
+  appListingId: string;
   targetUserId: number;
   actorUserId: number;
   now?: Date;
 }): Promise<InviteCollaboratorResult> {
   const now = opts.now ?? new Date();
-  const app = await assertOwner(opts.appBlockId, opts.actorUserId);
 
-  if (opts.targetUserId === app.ownerUserId) {
+  // 🔴 SHADOW CHECK FIRST, and on the id AS SUPPLIED — `assertOwner` resolves to the
+  // parent, so asking it afterwards could never see the shadow.
+  const asked = await dbRead.appListing.findUnique({
+    where: { id: opts.appListingId },
+    select: { id: true, revisionOfId: true },
+  });
+  if (!asked) throw new AppCollaboratorError('NOT_FOUND', 'App listing not found');
+  if (asked.revisionOfId != null) {
+    throw new AppCollaboratorError(
+      'INVALID_TARGET',
+      'Collaborators are managed on the live listing, not on a revision draft'
+    );
+  }
+
+  const listing = await assertOwner(opts.appListingId, opts.actorUserId);
+
+  if (opts.targetUserId === listing.ownerUserId) {
     throw new AppCollaboratorError(
       'INVALID_TARGET',
       'The app owner already has full access and cannot be invited as a collaborator'
@@ -213,7 +332,9 @@ export async function inviteCollaborator(opts: {
   }
 
   const existing = await dbRead.appCollaborator.findUnique({
-    where: { appBlockId_userId: { appBlockId: app.appBlockId, userId: opts.targetUserId } },
+    where: {
+      appListingId_userId: { appListingId: listing.appListingId, userId: opts.targetUserId },
+    },
     select: { status: true, lastNotifiedAt: true },
   });
 
@@ -225,7 +346,7 @@ export async function inviteCollaborator(opts: {
   // Skipped when re-touching a row that already exists, since that consumes no new seat.
   if (!existing) {
     const seated = await dbWrite.appCollaborator.count({
-      where: { appBlockId: app.appBlockId, status: { in: ['pending', ACCEPTED] } },
+      where: { appListingId: listing.appListingId, status: { in: ['pending', ACCEPTED] } },
     });
     if (seated >= constants.appCollaborators.maxCollaborators) {
       throw new AppCollaboratorError(
@@ -239,9 +360,11 @@ export async function inviteCollaborator(opts: {
 
   await dbWrite.$transaction(async (tx) => {
     await tx.appCollaborator.upsert({
-      where: { appBlockId_userId: { appBlockId: app.appBlockId, userId: opts.targetUserId } },
+      where: {
+        appListingId_userId: { appListingId: listing.appListingId, userId: opts.targetUserId },
+      },
       create: {
-        appBlockId: app.appBlockId,
+        appListingId: listing.appListingId,
         userId: opts.targetUserId,
         role: 'editor',
         status: 'pending',
@@ -257,12 +380,12 @@ export async function inviteCollaborator(opts: {
       },
     });
     await recordOwnershipEvent(tx, {
-      appBlockId: app.appBlockId,
-      slug: app.slug,
+      appListingId: listing.appListingId,
+      slug: listing.slug,
       action: 'invite',
       actorUserId: opts.actorUserId,
       targetUserId: opts.targetUserId,
-      metadata: { role: 'editor', reopened: existing?.status === 'rejected' },
+      metadata: { role: 'editor', kind: listing.kind, reopened: existing?.status === 'rejected' },
     });
   });
 
@@ -272,8 +395,14 @@ export async function inviteCollaborator(opts: {
       await notifyAppCollaborator({
         type: 'app-collaborator-invited',
         userId: opts.targetUserId,
-        key: `app-collaborator-invited:${app.appBlockId}:${opts.targetUserId}:${now.getTime()}`,
-        details: { slug: app.slug, appBlockId: app.appBlockId },
+        key: `app-collaborator-invited:${listing.appListingId}:${
+          opts.targetUserId
+        }:${now.getTime()}`,
+        details: {
+          slug: listing.slug,
+          appListingId: listing.appListingId,
+          appBlockId: listing.appBlockId,
+        },
       });
     } catch {
       /* best-effort */
@@ -281,7 +410,7 @@ export async function inviteCollaborator(opts: {
   }
 
   return {
-    appBlockId: app.appBlockId,
+    appListingId: listing.appListingId,
     userId: opts.targetUserId,
     status: 'pending',
     created: !existing,
@@ -289,7 +418,7 @@ export async function inviteCollaborator(opts: {
   };
 }
 
-export type RespondToInviteResult = { appBlockId: string; userId: number; status: string };
+export type RespondToInviteResult = { appListingId: string; userId: number; status: string };
 
 /**
  * INVITEE: accept or decline a pending seat.
@@ -300,22 +429,20 @@ export type RespondToInviteResult = { appBlockId: string; userId: number; status
  *
  * On ACCEPT this also grants the collaborator Forgejo `write` on `civitai-apps/<slug>`
  * — the seat is worthless without push access, and the grant is part of accepting, not
- * a follow-up. The grant runs POST-COMMIT and is best-effort-logged: it is an external
- * system, and a Forgejo outage must not roll back a consent decision the user made.
- * `getMyAppRepo` re-grants on demand, so a dropped grant self-heals on first use.
+ * a follow-up. 🔴 ON-SITE ONLY: an off-site listing has no repo, so the grant is
+ * skipped entirely rather than called with a slug that names nothing. The grant runs
+ * POST-COMMIT and is best-effort-logged: it is an external system, and a Forgejo
+ * outage must not roll back a consent decision the user made. `getMyAppRepo` re-grants
+ * on demand, so a dropped grant self-heals on first use.
  */
 export async function respondToInvite(opts: {
-  appBlockId: string;
+  appListingId: string;
   userId: number;
   accept: boolean;
   now?: Date;
 }): Promise<RespondToInviteResult> {
   const now = opts.now ?? new Date();
-  const block = await dbRead.appBlock.findUnique({
-    where: { id: opts.appBlockId },
-    select: { id: true, blockId: true },
-  });
-  if (!block) throw new AppCollaboratorError('NOT_FOUND', 'App not found');
+  const listing = await loadSeatListing(opts.appListingId);
 
   if (opts.accept) {
     const user = await dbRead.user.findUnique({
@@ -334,26 +461,26 @@ export async function respondToInvite(opts: {
 
   await dbWrite.$transaction(async (tx) => {
     const flipped = await tx.appCollaborator.updateMany({
-      where: { appBlockId: block.id, userId: opts.userId, status: 'pending' },
+      where: { appListingId: listing.appListingId, userId: opts.userId, status: 'pending' },
       data: { status: nextStatus, respondedAt: now },
     });
     if (flipped.count === 0) {
       throw new AppCollaboratorError('NO_INVITE', 'There is no pending invitation to respond to');
     }
     await recordOwnershipEvent(tx, {
-      appBlockId: block.id,
-      slug: block.blockId,
+      appListingId: listing.appListingId,
+      slug: listing.slug,
       action: opts.accept ? 'accept' : 'reject',
       actorUserId: opts.userId,
       targetUserId: opts.userId,
     });
   });
 
-  if (opts.accept) {
-    await grantAppRepoWrite({ slug: block.blockId, userId: opts.userId });
+  if (opts.accept && listing.blockSlug) {
+    await grantAppRepoWrite({ slug: listing.blockSlug, userId: opts.userId });
   }
 
-  return { appBlockId: block.id, userId: opts.userId, status: nextStatus };
+  return { appListingId: listing.appListingId, userId: opts.userId, status: nextStatus };
 }
 
 /**
@@ -363,25 +490,26 @@ export async function respondToInvite(opts: {
  * `AppOwnershipEvent`, and leaving a `rejected`-like tombstone would keep occupying
  * conceptual space in the roster read for no benefit.
  *
- * REVOKES Forgejo write. This is the half with no prior art in the codebase: there was
- * no revoke path at all before this PR (`forgejo.service.ts` had `addCollaborator` and
- * nothing to undo it), which meant a dev who was granted push access kept it forever.
+ * REVOKES Forgejo write (on-site only). This is the half with no prior art in the
+ * codebase: there was no revoke path at all before this feature
+ * (`forgejo.service.ts` had `addCollaborator` and nothing to undo it), which meant a
+ * dev who was granted push access kept it forever.
  */
 export async function removeCollaborator(opts: {
-  appBlockId: string;
+  appListingId: string;
   targetUserId: number;
   actorUserId: number;
-}): Promise<{ appBlockId: string; userId: number; removed: boolean }> {
-  const app = await assertOwner(opts.appBlockId, opts.actorUserId);
+}): Promise<{ appListingId: string; userId: number; removed: boolean }> {
+  const listing = await assertOwner(opts.appListingId, opts.actorUserId);
 
   const removed = await dbWrite.$transaction(async (tx) => {
     const del = await tx.appCollaborator.deleteMany({
-      where: { appBlockId: app.appBlockId, userId: opts.targetUserId },
+      where: { appListingId: listing.appListingId, userId: opts.targetUserId },
     });
     if (del.count === 0) return false;
     await recordOwnershipEvent(tx, {
-      appBlockId: app.appBlockId,
-      slug: app.slug,
+      appListingId: listing.appListingId,
+      slug: listing.slug,
       action: 'remove',
       actorUserId: opts.actorUserId,
       targetUserId: opts.targetUserId,
@@ -389,10 +517,10 @@ export async function removeCollaborator(opts: {
     return true;
   });
 
-  if (removed) {
-    await revokeAppRepoWrite({ slug: app.slug, userId: opts.targetUserId });
+  if (removed && listing.blockSlug) {
+    await revokeAppRepoWrite({ slug: listing.blockSlug, userId: opts.targetUserId });
   }
-  return { appBlockId: app.appBlockId, userId: opts.targetUserId, removed };
+  return { appListingId: listing.appListingId, userId: opts.targetUserId, removed };
 }
 
 /**
@@ -400,23 +528,19 @@ export async function removeCollaborator(opts: {
  * seat mutation an editor may perform, and it needs no owner check.
  */
 export async function leaveApp(opts: {
-  appBlockId: string;
+  appListingId: string;
   userId: number;
-}): Promise<{ appBlockId: string; userId: number; removed: boolean }> {
-  const block = await dbRead.appBlock.findUnique({
-    where: { id: opts.appBlockId },
-    select: { id: true, blockId: true },
-  });
-  if (!block) throw new AppCollaboratorError('NOT_FOUND', 'App not found');
+}): Promise<{ appListingId: string; userId: number; removed: boolean }> {
+  const listing = await loadSeatListing(opts.appListingId);
 
   const removed = await dbWrite.$transaction(async (tx) => {
     const del = await tx.appCollaborator.deleteMany({
-      where: { appBlockId: block.id, userId: opts.userId },
+      where: { appListingId: listing.appListingId, userId: opts.userId },
     });
     if (del.count === 0) return false;
     await recordOwnershipEvent(tx, {
-      appBlockId: block.id,
-      slug: block.blockId,
+      appListingId: listing.appListingId,
+      slug: listing.slug,
       action: 'leave',
       actorUserId: opts.userId,
       targetUserId: opts.userId,
@@ -424,10 +548,10 @@ export async function leaveApp(opts: {
     return true;
   });
 
-  if (removed) {
-    await revokeAppRepoWrite({ slug: block.blockId, userId: opts.userId });
+  if (removed && listing.blockSlug) {
+    await revokeAppRepoWrite({ slug: listing.blockSlug, userId: opts.userId });
   }
-  return { appBlockId: block.id, userId: opts.userId, removed };
+  return { appListingId: listing.appListingId, userId: opts.userId, removed };
 }
 
 /**
@@ -444,27 +568,23 @@ export async function leaveApp(opts: {
  * must not be able to pre-arrange public credit for a seat they have not taken.
  */
 export async function setCollaboratorDisplayed(opts: {
-  appBlockId: string;
+  appListingId: string;
   userId: number;
   displayed: boolean;
-}): Promise<{ appBlockId: string; userId: number; displayed: boolean }> {
-  const block = await dbRead.appBlock.findUnique({
-    where: { id: opts.appBlockId },
-    select: { id: true, blockId: true },
-  });
-  if (!block) throw new AppCollaboratorError('NOT_FOUND', 'App not found');
+}): Promise<{ appListingId: string; userId: number; displayed: boolean }> {
+  const listing = await loadSeatListing(opts.appListingId);
 
   await dbWrite.$transaction(async (tx) => {
     const updated = await tx.appCollaborator.updateMany({
-      where: { appBlockId: block.id, userId: opts.userId, status: ACCEPTED },
+      where: { appListingId: listing.appListingId, userId: opts.userId, status: ACCEPTED },
       data: { displayed: opts.displayed },
     });
     if (updated.count === 0) {
       throw new AppCollaboratorError('NO_INVITE', 'You are not an active collaborator on this app');
     }
     await recordOwnershipEvent(tx, {
-      appBlockId: block.id,
-      slug: block.blockId,
+      appListingId: listing.appListingId,
+      slug: listing.slug,
       action: 'display',
       actorUserId: opts.userId,
       targetUserId: opts.userId,
@@ -472,7 +592,11 @@ export async function setCollaboratorDisplayed(opts: {
     });
   });
 
-  return { appBlockId: block.id, userId: opts.userId, displayed: opts.displayed };
+  return {
+    appListingId: listing.appListingId,
+    userId: opts.userId,
+    displayed: opts.displayed,
+  };
 }
 
 export type CollaboratorView = {
@@ -523,27 +647,28 @@ export function filterCollaboratorsForViewer(
 }
 
 /**
- * 🔴 THE ROSTER IS NOT A PUBLIC READ, and `resolveAppAccess` is consulted for its ROLE,
- * not merely for `ownerUserId`.
+ * 🔴 THE ROSTER IS NOT A PUBLIC READ, and `resolveListingAccess` is consulted for its
+ * ROLE, not merely for `ownerUserId`.
  *
- * Reading it back leaks, for any app on the platform: the full ACCEPTED roster
+ * Reading it back leaks, for any listing on the platform: the full ACCEPTED roster
  * INCLUDING seats whose holder opted OUT of the public byline (`displayed: false` — the
  * whole point of that flag is that those people are not listed publicly), plus
  * `invitedBy` and the invite/response timestamps. The status filter below governs
- * pending/rejected ROWS; it never governed whether the CALLER may read the app at all,
- * so without this gate every flagged account could enumerate every app's collaborators.
+ * pending/rejected ROWS; it never governed whether the CALLER may read the listing at
+ * all, so without this gate every flagged account could enumerate every listing's
+ * collaborators.
  *
- * Permitted: the app OWNER, an ACCEPTED editor, or a moderator. A PENDING invitee is
+ * Permitted: the listing OWNER, an ACCEPTED editor, or a moderator. A PENDING invitee is
  * NOT — they read their own standing invitation through `listMyPendingInvites`, which
- * is keyed to their own user id and needs no app-scoped access.
+ * is keyed to their own user id and needs no listing-scoped access.
  */
 export async function listCollaborators(opts: {
-  appBlockId: string;
+  appListingId: string;
   viewerUserId: number | null;
   isModerator: boolean;
 }): Promise<CollaboratorView[]> {
-  const access = await resolveAppAccess(opts.appBlockId, opts.viewerUserId);
-  if (!access) throw new AppCollaboratorError('NOT_FOUND', 'App not found');
+  const access = await resolveListingAccess(opts.appListingId, opts.viewerUserId);
+  if (!access) throw new AppCollaboratorError('NOT_FOUND', 'App listing not found');
   if (!access.role && !opts.isModerator) {
     throw new AppCollaboratorError(
       'NOT_OWNER',
@@ -551,7 +676,9 @@ export async function listCollaborators(opts: {
     );
   }
   const rows = (await dbRead.appCollaborator.findMany({
-    where: { appBlockId: opts.appBlockId },
+    // 🔴 `seatListingId`, not the id asked for: a caller who opened the roster from a
+    // shadow revision must see the parent's seats, not an empty list.
+    where: { appListingId: access.seatListingId },
     select: {
       userId: true,
       role: true,
@@ -571,28 +698,37 @@ export async function listCollaborators(opts: {
 }
 
 /** The caller's own PENDING invitations, for an inbox surface. */
-export async function listMyPendingInvites(
-  userId: number
-): Promise<Array<{ appBlockId: string; slug: string; invitedBy: number; createdAt: Date }>> {
+export async function listMyPendingInvites(userId: number): Promise<
+  Array<{
+    appListingId: string;
+    slug: string;
+    kind: ListingKind;
+    appBlockId: string | null;
+    invitedBy: number;
+    createdAt: Date;
+  }>
+> {
   const rows = await dbRead.appCollaborator.findMany({
     where: { userId, status: 'pending' },
     select: {
-      appBlockId: true,
+      appListingId: true,
       invitedBy: true,
       createdAt: true,
-      appBlock: { select: { blockId: true } },
+      appListing: { select: { slug: true, kind: true, appBlockId: true } },
     },
     orderBy: { createdAt: 'desc' },
   });
   return rows.map(
     (r: {
-      appBlockId: string;
+      appListingId: string;
       invitedBy: number;
       createdAt: Date;
-      appBlock: { blockId: string } | null;
+      appListing: { slug: string; kind: string; appBlockId: string | null } | null;
     }) => ({
-      appBlockId: r.appBlockId,
-      slug: r.appBlock?.blockId ?? '',
+      appListingId: r.appListingId,
+      slug: r.appListing?.slug ?? '',
+      kind: (r.appListing?.kind ?? 'offsite') as ListingKind,
+      appBlockId: r.appListing?.appBlockId ?? null,
       invitedBy: r.invitedBy,
       createdAt: r.createdAt,
     })

--- a/src/server/services/blocks/app-collaborator.service.ts
+++ b/src/server/services/blocks/app-collaborator.service.ts
@@ -5,6 +5,7 @@ import { constants } from '~/server/common/constants';
 import { dbRead, dbWrite } from '~/server/db/client';
 import {
   ACCEPTED,
+  listingKindSupports,
   resolveListingAccess,
   type ListingKind,
 } from '~/server/services/blocks/app-access.service';
@@ -48,10 +49,16 @@ import { newAppOwnershipEventId } from '~/server/utils/app-block-ids';
  * ## Forgejo is ON-SITE ONLY
  *
  * The repo grant/revoke that rides along with accept / remove / leave fires ONLY when
- * the listing has a backing AppBlock. An off-site listing has no bundle and no repo —
- * the `submitVersion: false` capability cell — so there is nothing to grant, and
- * calling Forgejo with a store slug that names no repo would be a guaranteed 404 on
- * every off-site seat decision.
+ * the listing's KIND supports `submitVersion` AND a repo slug exists. An off-site
+ * listing has no bundle and no repo — the `submitVersion: false` capability cell — so
+ * there is nothing to grant, and calling Forgejo with a store slug that names no repo
+ * would be a guaranteed 404 on every off-site seat decision.
+ *
+ * 🔴 THE KIND IS THE AUTHORITY AND THE SLUG IS ONLY THE PHYSICAL CHECK — see
+ * {@link hasWritableRepo}. Gating on the slug ALONE looks equivalent and is not: an
+ * `offsite` listing CAN carry a backing AppBlock (and therefore a `blockId` slug), so a
+ * slug-only gate would mint repo write on a listing whose kind declares it has no
+ * version surface at all.
  */
 
 export type AppCollaboratorErrorCode =
@@ -212,6 +219,26 @@ function toSeatListing(row: RawSeatListing, wasShadow: boolean): SeatListing {
     ownerUserId: row.appBlock?.app?.userId ?? row.userId,
     wasShadow,
   };
+}
+
+/**
+ * 🔴 THE ONE PREDICATE for "may a Forgejo repo call fire for this listing?", written
+ * once so the grant (accept) and the two revokes (remove / leave) cannot drift apart.
+ *
+ * BOTH clauses are load-bearing and they are NOT redundant:
+ *   - `listingKindSupports(kind, 'submitVersion')` is the DECLARED capability, and it is
+ *     the authority. `CAPABILITIES_BY_KIND` fails closed on an unrecognised kind, so a
+ *     kind this code does not know is refused rather than granted.
+ *   - `blockSlug != null` is the PHYSICAL check — there must be a repo name to call.
+ *
+ * They disagree on exactly one shape, and it is reachable: `mapAppBlockToListing` mints
+ * `kind:'offsite'` with a non-null `appBlockId` whenever the source AppBlock has an
+ * `externalUrl`, so such a listing HAS a `blockId` slug while declaring
+ * `submitVersion: false`. A slug-only gate would hand that listing's collaborator
+ * Forgejo `write`.
+ */
+function hasWritableRepo(listing: { kind: string; blockSlug: string | null }): boolean {
+  return listingKindSupports(listing.kind, 'submitVersion') && listing.blockSlug != null;
 }
 
 /**
@@ -476,8 +503,10 @@ export async function respondToInvite(opts: {
     });
   });
 
-  if (opts.accept && listing.blockSlug) {
-    await grantAppRepoWrite({ slug: listing.blockSlug, userId: opts.userId });
+  // 🔴 KIND-GATED, not slug-gated — see {@link hasWritableRepo}. The non-null assertion
+  // is safe: `hasWritableRepo` is precisely the null check.
+  if (opts.accept && hasWritableRepo(listing)) {
+    await grantAppRepoWrite({ slug: listing.blockSlug!, userId: opts.userId });
   }
 
   return { appListingId: listing.appListingId, userId: opts.userId, status: nextStatus };
@@ -517,8 +546,8 @@ export async function removeCollaborator(opts: {
     return true;
   });
 
-  if (removed && listing.blockSlug) {
-    await revokeAppRepoWrite({ slug: listing.blockSlug, userId: opts.targetUserId });
+  if (removed && hasWritableRepo(listing)) {
+    await revokeAppRepoWrite({ slug: listing.blockSlug!, userId: opts.targetUserId });
   }
   return { appListingId: listing.appListingId, userId: opts.targetUserId, removed };
 }
@@ -548,8 +577,8 @@ export async function leaveApp(opts: {
     return true;
   });
 
-  if (removed && listing.blockSlug) {
-    await revokeAppRepoWrite({ slug: listing.blockSlug, userId: opts.userId });
+  if (removed && hasWritableRepo(listing)) {
+    await revokeAppRepoWrite({ slug: listing.blockSlug!, userId: opts.userId });
   }
   return { appListingId: listing.appListingId, userId: opts.userId, removed };
 }

--- a/src/server/services/blocks/app-listing-assets.service.ts
+++ b/src/server/services/blocks/app-listing-assets.service.ts
@@ -323,8 +323,10 @@ export { nsfwLevelFromContentRating };
  * Load a listing and assert the caller may edit it. Throws NOT_FOUND for a missing
  * listing, FORBIDDEN otherwise.
  *
- * PERMITTED: the listing owner, an ACCEPTED collaborator on the backing AppBlock, or a
- * moderator. The mod bypass is UNCHANGED from before collaborators existed — this
+ * PERMITTED: the listing owner, an ACCEPTED collaborator ON THE LISTING (seats are
+ * listing-keyed since the re-key — the backing AppBlock is not the seat key and an
+ * off-site listing has none), or a moderator. The mod bypass is UNCHANGED from before
+ * collaborators existed — this
  * file's gate always had one, unlike `offsite-listing.service`'s
  * `loadOwnedEditableListing`, which deliberately has none. That divergence is
  * pre-existing and is recorded in `app-access.call-site-ledger.test.ts` rather than

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -687,31 +687,36 @@ export async function getListingDetail(
   // a missing one (mirrors the AppBlock detail's red-only 404).
   if (!redCapable && isMatureContentRating(row.contentRating)) return null;
 
-  return projectListingDetail(row, await loadDisplayedCollaboratorChips(row.appBlockId));
+  return projectListingDetail(row, await loadDisplayedCollaboratorChips(row.id));
 }
 
 /**
- * Hydrate the PUBLIC collaborator byline for a listing: the ACCEPTED **and**
- * `displayed` collaborators of its backing AppBlock, projected to the same
- * `{id, username, image}` allowlist as the creator chip.
+ * Hydrate the PUBLIC collaborator byline for a listing: its ACCEPTED **and**
+ * `displayed` collaborators, projected to the same `{id, username, image}` allowlist as
+ * the creator chip.
+ *
+ * 🔴 KEYED ON THE LISTING, so it works for BOTH kinds. This read is the whole point of
+ * the block→listing re-key: an OFF-SITE listing has no AppBlock, so while seats were
+ * block-keyed its byline could only ever be empty.
  *
  * 🔴 CONSENT + OPT-IN, both load-bearing (enforced in `listDisplayedCollaboratorUserIds`):
  * a PENDING invitee must never appear publicly — otherwise anyone could attach a
  * stranger's name to their listing simply by inviting them — and an accepted
  * collaborator who opted out of the byline must not appear either.
  *
- * Returns `[]` for a listing with no backing AppBlock (a natively-created offsite
- * listing), and `[]` when the manual-apply migration has not landed — so the public
- * read is byte-identical to today until both the table and a seat exist.
+ * Returns `[]` when the manual-apply migration has not landed — so the public read is
+ * byte-identical to today until both the table and a seat exist. The caller only ever
+ * passes a PARENT listing id (shadow revisions are filtered out of every public read),
+ * which is also the only id a seat can exist under.
  */
 async function loadDisplayedCollaboratorChips(
-  appBlockId: string | null
+  appListingId: string | null
 ): Promise<Array<{ id: number; username: string | null; image: string | null }>> {
-  if (!appBlockId) return [];
+  if (!appListingId) return [];
   const { listDisplayedCollaboratorUserIds } = await import(
     '~/server/services/blocks/app-access.service'
   );
-  const userIds = await listDisplayedCollaboratorUserIds(appBlockId);
+  const userIds = await listDisplayedCollaboratorUserIds(appListingId);
   if (userIds.length === 0) return [];
   // 🔴 EXPLICIT ALLOWLIST at the SELECT, not only at the projection. Two independent
   // narrowings: nothing but these three columns ever leaves the DB, and `creatorChip`

--- a/src/server/services/blocks/app-ownership-transfer.service.ts
+++ b/src/server/services/blocks/app-ownership-transfer.service.ts
@@ -1,6 +1,6 @@
 import { constants } from '~/server/common/constants';
 import { dbRead, dbWrite } from '~/server/db/client';
-import type { ListingKind } from '~/server/services/blocks/app-access.service';
+import { listingKindSupports, type ListingKind } from '~/server/services/blocks/app-access.service';
 import {
   AppCollaboratorError,
   recordOwnershipEvent,
@@ -87,6 +87,13 @@ import { newAppOwnershipTransferId } from '~/server/utils/app-block-ids';
  * On accept of an ON-SITE listing: revoke the OLD owner's repo write, grant the NEW
  * owner's. An OFF-SITE listing has no repo, so neither call fires. Collaborator seats
  * are untouched by a transfer — the listing keeps its editors.
+ *
+ * 🔴 THAT GATE READS `kind`, THE SAME PREDICATE STEP (2) USES — not `blockSlug != null`.
+ * The two look interchangeable and are not: an `offsite` listing CAN carry a backing
+ * AppBlock (`mapAppBlockToListing` mints `kind:'offsite'` with `appBlockId: ab.id` for any
+ * AppBlock with an `externalUrl`), and on such a row a slug-only gate made this one
+ * function disagree with itself — leaving the OauthClient alone, per its kind, while
+ * swapping repo write on the app's Forgejo repo.
  */
 
 export type TransferView = {
@@ -400,7 +407,23 @@ export async function acceptTransfer(opts: {
       where: { id: opts.userId },
       select: { bannedAt: true },
     })) as { bannedAt: Date | null } | null;
-    if (recipient?.bannedAt) {
+    // 🔴 A MISSING RECIPIENT ROW PASSES, AND THAT IS A DECISION, not an artefact of the
+    // `?.` — it is written out here because "no row ⇒ not banned ⇒ proceed" is exactly
+    // the shape that usually IS an accident. Three reasons it is deliberate:
+    //   1. This guard asks ONE question — "is the recipient BANNED?" — and `null` is not
+    //      an answer of "yes". Refusing here would fail the transfer for a reason this
+    //      read cannot establish.
+    //   2. The case is UNREACHABLE by construction: `app_ownership_transfers.to_user_id`
+    //      is `REFERENCES "User"("id") ON DELETE CASCADE`, so a deleted recipient takes
+    //      the transfer row with them and step (1) above would already have thrown
+    //      NOT_FOUND. A null here means the row was deleted between two statements of
+    //      the SAME transaction, which a snapshot cannot show.
+    //   3. Recipient EXISTENCE is not otherwise this function's business — `toUserId` was
+    //      validated against a real `User` at initiate.
+    // `app-ownership-transfer.service.test.ts` pins this direction, so a later drift into
+    // `if (!recipient) throw` is a visible change of decision rather than a tidy-up.
+    const recipientBannedAt = recipient?.bannedAt ?? null;
+    if (recipientBannedAt) {
       throw new AppCollaboratorError('BANNED', 'That account cannot receive app ownership');
     }
 
@@ -482,15 +505,23 @@ export async function acceptTransfer(opts: {
       fromUserId: transfer.fromUserId,
       toUserId: transfer.toUserId,
       slug: transfer.appListing.slug,
+      kind: transfer.appListing.kind,
       appBlockId: transfer.appListing.appBlockId,
       blockSlug: transfer.appListing.appBlock?.blockId ?? null,
     };
   });
 
   // POST-COMMIT external effects. Swap the repo grants: the old owner loses write, the
-  // new owner gains it. ON-SITE ONLY — an off-site listing has no repo. Collaborator
-  // seats are unaffected either way: the listing keeps its editors.
-  if (result.blockSlug) {
+  // new owner gains it. Collaborator seats are unaffected either way: the listing keeps
+  // its editors.
+  //
+  // 🔴 GATED ON **KIND**, matching step (2) above — this used to branch on `blockSlug`
+  // nullness alone while step (2) branched on `kind`, so the one function disagreed with
+  // itself about what "on-site" means. An `offsite` listing CAN carry a backing AppBlock
+  // (`mapAppBlockToListing` mints exactly that shape for an AppBlock with an
+  // `externalUrl`), and on such a row the slug-only gate would swap Forgejo write on a
+  // listing whose ownership chain step (2) had deliberately left alone.
+  if (listingKindSupports(result.kind, 'submitVersion') && result.blockSlug) {
     await revokeAppRepoWrite({ slug: result.blockSlug, userId: result.fromUserId });
     await grantAppRepoWrite({ slug: result.blockSlug, userId: result.toUserId });
   }

--- a/src/server/services/blocks/app-ownership-transfer.service.ts
+++ b/src/server/services/blocks/app-ownership-transfer.service.ts
@@ -1,5 +1,6 @@
 import { constants } from '~/server/common/constants';
 import { dbRead, dbWrite } from '~/server/db/client';
+import type { ListingKind } from '~/server/services/blocks/app-access.service';
 import {
   AppCollaboratorError,
   recordOwnershipEvent,
@@ -11,26 +12,64 @@ import { newAppOwnershipTransferId } from '~/server/utils/app-block-ids';
 /**
  * App Listing COLLABORATORS — OWNERSHIP TRANSFER (owner initiates → recipient accepts).
  *
+ * 🔴 LISTING-KEYED, so it works for BOTH store kinds. See `app-access.service`'s header.
+ *
  * ## Authorization: no moderator in the loop
  *
- * The prior art, `offsite-moderation.service.ts::claimListing:623`, is MOD-ONLY,
+ * The prior art, `offsite-moderation.service.ts::claimListing`, is MOD-ONLY,
  * OFFSITE-ONLY and reassigns `AppListing.userId` alone. That guard SHAPE is extended
  * here (status-guarded `updateMany`, in-tx primary snapshot, an audit event written in
  * the same transaction so a rolled-back transfer leaves ZERO events, submission
  * history untouched), but the authorization model is different by product decision:
  * the owner initiates and the recipient accepts. Nobody else is involved.
  *
- * 🔴 And `claimListing`'s single write is INSUFFICIENT for an ONSITE app. Ownership is
+ * ## 🔴 HOW THIS RELATES TO `claimListing` — they cannot race or disagree
+ *
+ * Both paths write `AppListing.userId` on an off-site listing, so the relationship is
+ * stated rather than assumed:
+ *
+ *   - DIFFERENT AUTHORITY. `claimListing` is a MODERATOR remedy (the impersonation
+ *     workflow: report → delist → claim → ban) requiring a mod reason and gated on
+ *     `status IN (approved, removed)`. This is an OWNER-initiated, recipient-consented
+ *     hand-over. Neither is a substitute for the other and neither calls the other.
+ *   - THEY CANNOT INTERLEAVE INTO A WRONG STATE. `acceptTransfer`'s off-site write is
+ *     status-guarded on `userId = <the snapshotted fromUserId>`. So if a mod claims the
+ *     listing after the offer was made, the accept matches 0 rows and is refused with
+ *     "ownership has changed" — the pending offer becomes permanently unacceptable
+ *     (fail-closed), rather than silently undoing the mod's remedy. In the other order,
+ *     a mod claim over an already-accepted transfer simply wins, which is the intended
+ *     precedence: moderator authority is final.
+ *   - SEPARATE AUDIT TRAILS, both written. `claimListing` writes an
+ *     `AppListingModerationEvent`; this writes an `AppOwnershipEvent`. Neither is
+ *     derived from the other, so a listing whose owner moved twice shows both.
+ *
+ * 🔴 `claimListing`'s single write is INSUFFICIENT for an ONSITE listing. Ownership is
  * canonically `OauthClient.userId` (`AppBlock.app.userId`); `AppListing.userId` is a
  * DENORMALIZED COPY. Moving only the listing column would leave the app's real owner
  * unchanged — the old owner would keep `getMyAppRepo`/`updateManifest`/`getMyApps`
- * while the new owner got the store listing. So accept writes BOTH columns in ONE
- * transaction. `app-ownership-transfer.service.test.ts` injects a failure on the second
- * write and asserts a full rollback.
+ * while the new owner got the store listing. So an ONSITE accept writes BOTH columns in
+ * ONE transaction. `app-ownership-transfer.service.test.ts` injects a failure on the
+ * second write and asserts a full rollback.
+ *
+ * ## 🔴 OFF-SITE + a linked OAuth client: REFUSED, at both ends
+ *
+ * v1 moves `AppListing.userId` and nothing else. An off-site listing may carry a
+ * `connectClientId` — an `OauthClient` with a SECRET, redirect URIs and allowed
+ * origins. Moving those is a materially different act from handing over a store
+ * listing, and both silent options are bad:
+ *   - silently moving the client hands over live credentials the recipient never asked
+ *     for and the initiator may not have meant to include; and
+ *   - silently NOT moving it leaves ownership SPLIT — the listing says one user, the
+ *     credential says another — which is the state that produces "why can't I rotate my
+ *     own app's secret?" months later.
+ * So the transfer is refused with an error that names the reason. Enforced at INITIATE
+ * (fail fast) AND re-asserted in-tx at ACCEPT — an offer stays open for
+ * `transferExpiryDays`, and a revision approve can LINK a client in that window, so an
+ * initiate-time check alone would be false for the whole window.
  *
  * ## What deliberately does NOT move
  *
- *   - `AppBlockPublishRequest.submittedByUserId` — historical submission record,
+ *   - `AppListingPublishRequest.submittedByUserId` — historical submission record,
  *     preserved for audit fidelity. Same locked decision as `claimListing`.
  *   - 🔴 `BlockBuzzAttribution.appOwnerUserId` — NOT rewritten. Product decision: Buzz
  *     accrued before the transfer stays with the OLD owner; the transfer is a clean
@@ -45,19 +84,26 @@ import { newAppOwnershipTransferId } from '~/server/utils/app-block-ids';
  *
  * ## Forgejo
  *
- * On accept: revoke the OLD owner's repo write, grant the NEW owner's. Collaborator
- * seats are untouched by a transfer — the app keeps its editors.
+ * On accept of an ON-SITE listing: revoke the OLD owner's repo write, grant the NEW
+ * owner's. An OFF-SITE listing has no repo, so neither call fires. Collaborator seats
+ * are untouched by a transfer — the listing keeps its editors.
  */
 
 export type TransferView = {
   id: string;
-  appBlockId: string;
+  appListingId: string;
   fromUserId: number;
   toUserId: number;
   status: string;
   expiresAt: Date;
   createdAt: Date;
 };
+
+/** The message a connect-linked off-site listing is refused with. Asserted verbatim. */
+export const CONNECT_CLIENT_TRANSFER_REFUSAL =
+  'This listing is linked to an OAuth application. Ownership transfer would either hand ' +
+  'over that application’s credentials or split ownership between the listing and the ' +
+  'client, so it is not available for connect listings. Unlink the OAuth client first.';
 
 /**
  * A pending transfer that has passed `expiresAt` is treated as ABSENT everywhere.
@@ -70,23 +116,79 @@ function isLive(t: { status: string; expiresAt: Date }, now: Date): boolean {
   return t.status === 'pending' && t.expiresAt.getTime() > now.getTime();
 }
 
-async function loadOwnedApp(
-  appBlockId: string,
-  actorUserId: number
-): Promise<{ appBlockId: string; appId: string; slug: string; ownerUserId: number }> {
-  const block = await dbRead.appBlock.findUnique({
-    where: { id: appBlockId },
-    select: { id: true, appId: true, blockId: true, app: { select: { userId: true } } },
-  });
-  if (!block?.app) throw new AppCollaboratorError('NOT_FOUND', 'App not found');
-  if (block.app.userId !== actorUserId) {
+/**
+ * 🔴 THE ONE PREDICATE for "may this listing's ownership move?", written once so the
+ * initiate-time check and the in-tx accept-time re-assert cannot drift apart.
+ *
+ * On-site listings are unaffected: their connect column is always null (an on-site
+ * listing's OauthClient is reached through the AppBlock, and THAT one does move).
+ */
+export function refusesTransferForConnectClient(listing: {
+  kind: string;
+  connectClientId: string | null;
+}): boolean {
+  return listing.kind === 'offsite' && listing.connectClientId != null;
+}
+
+type OwnedListing = {
+  appListingId: string;
+  slug: string;
+  kind: ListingKind;
+  /** Backing AppBlock id — null for off-site. */
+  appBlockId: string | null;
+  /** The AppBlock's OauthClient id (the CANONICAL onsite owner column). Null offsite. */
+  appId: string | null;
+  /** The AppBlock's `blockId` — the Forgejo repo slug. Null offsite. */
+  blockSlug: string | null;
+  connectClientId: string | null;
+  ownerUserId: number;
+};
+
+async function loadOwnedListing(appListingId: string, actorUserId: number): Promise<OwnedListing> {
+  const row = (await dbRead.appListing.findUnique({
+    where: { id: appListingId },
+    select: {
+      id: true,
+      slug: true,
+      kind: true,
+      userId: true,
+      appBlockId: true,
+      connectClientId: true,
+      revisionOfId: true,
+      appBlock: { select: { appId: true, blockId: true, app: { select: { userId: true } } } },
+    },
+  })) as {
+    id: string;
+    slug: string;
+    kind: string;
+    userId: number;
+    appBlockId: string | null;
+    connectClientId: string | null;
+    revisionOfId: string | null;
+    appBlock: { appId: string; blockId: string; app: { userId: number } | null } | null;
+  } | null;
+  if (!row) throw new AppCollaboratorError('NOT_FOUND', 'App listing not found');
+  // A shadow revision is an internal draft, not a thing anyone can own or hand over.
+  // Refused rather than hopped to the parent: "transfer this draft" has no meaning.
+  if (row.revisionOfId != null) {
+    throw new AppCollaboratorError(
+      'INVALID_TARGET',
+      'Ownership is transferred on the live listing, not on a revision draft'
+    );
+  }
+  const ownerUserId = row.appBlock?.app?.userId ?? row.userId;
+  if (ownerUserId !== actorUserId) {
     throw new AppCollaboratorError('NOT_OWNER', 'Only the app owner can transfer ownership');
   }
   return {
-    appBlockId: block.id,
-    appId: block.appId,
-    slug: block.blockId,
-    ownerUserId: block.app.userId,
+    appListingId: row.id,
+    slug: row.slug,
+    kind: row.kind as ListingKind,
+    appBlockId: row.appBlockId,
+    appId: row.appBlock?.appId ?? null,
+    blockSlug: row.appBlock?.blockId ?? null,
+    connectClientId: row.connectClientId,
+    ownerUserId,
   };
 }
 
@@ -95,24 +197,31 @@ async function loadOwnedApp(
  * until the recipient accepts.
  *
  * 🔴 A PENDING TRANSFER CONFERS ZERO CAPABILITY on the recipient — it is not a seat,
- * it does not appear in `resolveAppAccess`, and it grants no repo access. Same consent
- * principle as a pending invite.
+ * it does not appear in `resolveListingAccess`, and it grants no repo access. Same
+ * consent principle as a pending invite.
  *
- * One in-flight transfer per app, enforced by the migration's PARTIAL UNIQUE index
- * (`app_block_id WHERE status='pending'`), which Prisma cannot express. A concurrent
+ * One in-flight transfer per listing, enforced by the migration's PARTIAL UNIQUE index
+ * (`app_listing_id WHERE status='pending'`), which Prisma cannot express. A concurrent
  * second initiate loses on P2002 and is surfaced as a friendly error rather than a
  * raw constraint violation.
  */
 export async function initiateTransfer(opts: {
-  appBlockId: string;
+  appListingId: string;
   toUserId: number;
   actorUserId: number;
   now?: Date;
 }): Promise<TransferView> {
   const now = opts.now ?? new Date();
-  const app = await loadOwnedApp(opts.appBlockId, opts.actorUserId);
+  const listing = await loadOwnedListing(opts.appListingId, opts.actorUserId);
 
-  if (opts.toUserId === app.ownerUserId) {
+  // 🔴 FAIL FAST on a connect-linked off-site listing — see the module header. The
+  // same predicate is re-asserted in-tx at accept, because a revision approve can link
+  // a client while the offer sits open.
+  if (refusesTransferForConnectClient(listing)) {
+    throw new AppCollaboratorError('INVALID_TARGET', CONNECT_CLIENT_TRANSFER_REFUSAL);
+  }
+
+  if (opts.toUserId === listing.ownerUserId) {
     throw new AppCollaboratorError('INVALID_TARGET', 'You already own this app');
   }
   const target = await dbRead.user.findUnique({
@@ -125,9 +234,9 @@ export async function initiateTransfer(opts: {
   }
 
   // Reclaim an EXPIRED pending row first — otherwise the partial unique index would
-  // block every future transfer for this app once one invitation lapsed.
+  // block every future transfer for this listing once one invitation lapsed.
   await dbWrite.appOwnershipTransfer.updateMany({
-    where: { appBlockId: app.appBlockId, status: 'pending', expiresAt: { lte: now } },
+    where: { appListingId: listing.appListingId, status: 'pending', expiresAt: { lte: now } },
     data: { status: 'expired', respondedAt: now },
   });
 
@@ -142,15 +251,15 @@ export async function initiateTransfer(opts: {
       const row = (await tx.appOwnershipTransfer.create({
         data: {
           id,
-          appBlockId: app.appBlockId,
-          fromUserId: app.ownerUserId,
+          appListingId: listing.appListingId,
+          fromUserId: listing.ownerUserId,
           toUserId: opts.toUserId,
           status: 'pending',
           expiresAt,
         },
         select: {
           id: true,
-          appBlockId: true,
+          appListingId: true,
           fromUserId: true,
           toUserId: true,
           status: true,
@@ -159,12 +268,12 @@ export async function initiateTransfer(opts: {
         },
       })) as TransferView;
       await recordOwnershipEvent(tx, {
-        appBlockId: app.appBlockId,
-        slug: app.slug,
+        appListingId: listing.appListingId,
+        slug: listing.slug,
         action: 'transfer_initiated',
         actorUserId: opts.actorUserId,
         targetUserId: opts.toUserId,
-        metadata: { transferId: id, expiresAt: expiresAt.toISOString() },
+        metadata: { transferId: id, kind: listing.kind, expiresAt: expiresAt.toISOString() },
       });
       return row;
     });
@@ -186,7 +295,11 @@ export async function initiateTransfer(opts: {
       type: 'app-ownership-transfer-offered',
       userId: opts.toUserId,
       key: `app-ownership-transfer-offered:${id}`,
-      details: { slug: app.slug, appBlockId: app.appBlockId },
+      details: {
+        slug: listing.slug,
+        appListingId: listing.appListingId,
+        appBlockId: listing.appBlockId,
+      },
     });
   } catch {
     /* best-effort, post-commit */
@@ -207,25 +320,32 @@ export async function initiateTransfer(opts: {
  *      is simply false anywhere inside that window. `respondToInvite` re-reads the user
  *      row for exactly this reason; this one goes further and reads in-transaction on
  *      the primary, because unlike a seat an ownership move is not cheap to unwind;
- *   2. re-assert `OauthClient.userId` STILL equals the transfer's `fromUserId` — a
- *      status-guarded `updateMany` whose 0-count means the owner changed since the
- *      offer (a second transfer landed first), rolling everything back;
- *   3. move `AppListing.userId` for the backing listing — the denormalized copy;
+ *   1c. 🔴 re-assert the CONNECT-CLIENT refusal against the listing AS IT IS NOW. A
+ *      revision approve can link an OAuth client after the offer was made, so the
+ *      initiate-time check says nothing about this instant;
+ *   2. ONSITE ONLY — re-assert `OauthClient.userId` STILL equals the transfer's
+ *      `fromUserId` via a status-guarded `updateMany` whose 0-count means the owner
+ *      changed since the offer, rolling everything back;
+ *   3. move `AppListing.userId`;
  *   4. flip the transfer to `accepted`;
  *   5. write the audit event.
  *
- * Steps 2 and 3 are the two ownership columns; a failure in either rolls back BOTH.
- * That is asserted directly (inject a throw on the second write; assert the first is
- * not observable).
+ * 🔴 STEP 3 IS GUARDED FOR OFFSITE AND UNGUARDED FOR ONSITE, and the asymmetry is the
+ * point. Onsite: step 2 is the authority (the canonical column) and step 3 is the
+ * denormalized follow-up, where a 0-count is a legitimate desync that must not fail the
+ * transfer. Offsite: step 2 does not run at all, so step 3's `userId = fromUserId`
+ * predicate is the ONLY TOCTOU protection there is — a mod `claimListing` landing in
+ * the window makes it match 0 rows, and the accept is refused rather than silently
+ * undoing the moderator's remedy.
  *
- * NOT touched, by design: `AppBlockPublishRequest.submittedByUserId`,
+ * NOT touched, by design: `AppListingPublishRequest.submittedByUserId`,
  * `BlockBuzzAttribution.appOwnerUserId`, collaborator seats. See the module header.
  */
 export async function acceptTransfer(opts: {
   transferId: string;
   userId: number;
   now?: Date;
-}): Promise<{ transferId: string; appBlockId: string; fromUserId: number; toUserId: number }> {
+}): Promise<{ transferId: string; appListingId: string; fromUserId: number; toUserId: number }> {
   const now = opts.now ?? new Date();
 
   const result = await dbWrite.$transaction(async (tx) => {
@@ -233,16 +353,36 @@ export async function acceptTransfer(opts: {
       where: { id: opts.transferId },
       select: {
         id: true,
-        appBlockId: true,
+        appListingId: true,
         fromUserId: true,
         toUserId: true,
         status: true,
         expiresAt: true,
-        appBlock: { select: { appId: true, blockId: true } },
+        appListing: {
+          select: {
+            id: true,
+            slug: true,
+            kind: true,
+            connectClientId: true,
+            appBlockId: true,
+            appBlock: { select: { appId: true, blockId: true } },
+          },
+        },
       },
-    })) as (TransferView & { appBlock: { appId: string; blockId: string } | null }) | null;
+    })) as
+      | (TransferView & {
+          appListing: {
+            id: string;
+            slug: string;
+            kind: string;
+            connectClientId: string | null;
+            appBlockId: string | null;
+            appBlock: { appId: string; blockId: string } | null;
+          } | null;
+        })
+      | null;
 
-    if (!transfer || !transfer.appBlock) {
+    if (!transfer || !transfer.appListing) {
       throw new AppCollaboratorError('NOT_FOUND', 'That ownership transfer no longer exists');
     }
     if (transfer.toUserId !== opts.userId) {
@@ -264,26 +404,53 @@ export async function acceptTransfer(opts: {
       throw new AppCollaboratorError('BANNED', 'That account cannot receive app ownership');
     }
 
-    // (2) CANONICAL owner column, status-guarded on the snapshotted previous owner.
-    const movedClient = await tx.oauthClient.updateMany({
-      where: { id: transfer.appBlock.appId, userId: transfer.fromUserId },
-      data: { userId: transfer.toUserId },
-    });
-    if (movedClient.count === 0) {
-      throw new AppCollaboratorError(
-        'NO_INVITE',
-        'Ownership of this app has changed; this transfer can no longer be accepted'
-      );
+    // (1c) 🔴 RE-ASSERT the connect-client refusal on the CURRENT listing row. Same
+    // reasoning as (1b): a revision approve can link an OAuth client while the offer is
+    // open, and moving a listing out from under live credentials is the outcome this
+    // whole decision exists to prevent.
+    if (refusesTransferForConnectClient(transfer.appListing)) {
+      throw new AppCollaboratorError('INVALID_TARGET', CONNECT_CLIENT_TRANSFER_REFUSAL);
     }
 
-    // (3) DENORMALIZED copy. `updateMany` (not `update`) because an app need not have a
-    // listing yet — a first-version app pending approval has no `AppListing` row. A
-    // 0-count is therefore LEGITIMATE here and must not fail the transfer, which is
-    // exactly why this is not status-guarded the way (2) is.
-    await tx.appListing.updateMany({
-      where: { appBlockId: transfer.appBlockId },
+    const isOnsite = transfer.appListing.kind === 'onsite';
+    const appId = transfer.appListing.appBlock?.appId ?? null;
+
+    // (2) CANONICAL owner column — ONSITE ONLY, status-guarded on the snapshotted
+    // previous owner. An off-site listing has no OauthClient in its ownership chain.
+    if (isOnsite) {
+      if (!appId) {
+        throw new AppCollaboratorError(
+          'NOT_FOUND',
+          'This listing’s app record is missing; ownership cannot be transferred'
+        );
+      }
+      const movedClient = await tx.oauthClient.updateMany({
+        where: { id: appId, userId: transfer.fromUserId },
+        data: { userId: transfer.toUserId },
+      });
+      if (movedClient.count === 0) {
+        throw new AppCollaboratorError(
+          'NO_INVITE',
+          'Ownership of this app has changed; this transfer can no longer be accepted'
+        );
+      }
+    }
+
+    // (3) The listing's owner column. See the asymmetry note in the header: guarded
+    // for offsite (it is the ONLY ownership write there), unguarded for onsite (a
+    // denormalized copy whose 0-count is a legitimate desync).
+    const movedListing = await tx.appListing.updateMany({
+      where: isOnsite
+        ? { id: transfer.appListingId }
+        : { id: transfer.appListingId, userId: transfer.fromUserId },
       data: { userId: transfer.toUserId },
     });
+    if (!isOnsite && movedListing.count === 0) {
+      throw new AppCollaboratorError(
+        'NO_INVITE',
+        'Ownership of this listing has changed; this transfer can no longer be accepted'
+      );
+    }
 
     // (4) Close the transfer, guarded so a concurrent cancel cannot be overwritten.
     const closed = await tx.appOwnershipTransfer.updateMany({
@@ -296,13 +463,14 @@ export async function acceptTransfer(opts: {
 
     // (5) Audit — in-tx, so a rollback leaves ZERO events.
     await recordOwnershipEvent(tx, {
-      appBlockId: transfer.appBlockId,
-      slug: transfer.appBlock.blockId,
+      appListingId: transfer.appListingId,
+      slug: transfer.appListing.slug,
       action: 'transfer_accepted',
       actorUserId: opts.userId,
       targetUserId: opts.userId,
       metadata: {
         transferId: transfer.id,
+        kind: transfer.appListing.kind,
         before: { userId: transfer.fromUserId },
         after: { userId: transfer.toUserId },
       },
@@ -310,24 +478,33 @@ export async function acceptTransfer(opts: {
 
     return {
       transferId: transfer.id,
-      appBlockId: transfer.appBlockId,
+      appListingId: transfer.appListingId,
       fromUserId: transfer.fromUserId,
       toUserId: transfer.toUserId,
-      slug: transfer.appBlock.blockId,
+      slug: transfer.appListing.slug,
+      appBlockId: transfer.appListing.appBlockId,
+      blockSlug: transfer.appListing.appBlock?.blockId ?? null,
     };
   });
 
   // POST-COMMIT external effects. Swap the repo grants: the old owner loses write, the
-  // new owner gains it. Collaborator seats are unaffected — the app keeps its editors.
-  await revokeAppRepoWrite({ slug: result.slug, userId: result.fromUserId });
-  await grantAppRepoWrite({ slug: result.slug, userId: result.toUserId });
+  // new owner gains it. ON-SITE ONLY — an off-site listing has no repo. Collaborator
+  // seats are unaffected either way: the listing keeps its editors.
+  if (result.blockSlug) {
+    await revokeAppRepoWrite({ slug: result.blockSlug, userId: result.fromUserId });
+    await grantAppRepoWrite({ slug: result.blockSlug, userId: result.toUserId });
+  }
 
   try {
     await notifyAppCollaborator({
       type: 'app-ownership-transfer-accepted',
       userId: result.fromUserId,
       key: `app-ownership-transfer-accepted:${result.transferId}`,
-      details: { slug: result.slug, appBlockId: result.appBlockId },
+      details: {
+        slug: result.slug,
+        appListingId: result.appListingId,
+        appBlockId: result.appBlockId,
+      },
     });
   } catch {
     /* best-effort, post-commit */
@@ -335,7 +512,7 @@ export async function acceptTransfer(opts: {
 
   return {
     transferId: result.transferId,
-    appBlockId: result.appBlockId,
+    appListingId: result.appListingId,
     fromUserId: result.fromUserId,
     toUserId: result.toUserId,
   };
@@ -358,16 +535,16 @@ export async function cancelTransfer(opts: {
       where: { id: opts.transferId },
       select: {
         id: true,
-        appBlockId: true,
+        appListingId: true,
         fromUserId: true,
         toUserId: true,
         status: true,
         expiresAt: true,
-        appBlock: { select: { blockId: true } },
+        appListing: { select: { slug: true } },
       },
-    })) as (TransferView & { appBlock: { blockId: string } | null }) | null;
+    })) as (TransferView & { appListing: { slug: string } | null }) | null;
 
-    if (!transfer || !transfer.appBlock) {
+    if (!transfer || !transfer.appListing) {
       throw new AppCollaboratorError('NOT_FOUND', 'That ownership transfer no longer exists');
     }
     if (transfer.fromUserId !== opts.actorUserId && transfer.toUserId !== opts.actorUserId) {
@@ -381,8 +558,8 @@ export async function cancelTransfer(opts: {
     if (closed.count === 0) return { transferId: transfer.id, cancelled: false };
 
     await recordOwnershipEvent(tx, {
-      appBlockId: transfer.appBlockId,
-      slug: transfer.appBlock.blockId,
+      appListingId: transfer.appListingId,
+      slug: transfer.appListing.slug,
       action: 'transfer_cancelled',
       actorUserId: opts.actorUserId,
       targetUserId: transfer.toUserId,
@@ -393,7 +570,7 @@ export async function cancelTransfer(opts: {
 }
 
 /**
- * The LIVE pending transfer for an app, or `null`. Expiry is applied as a read-time
+ * The LIVE pending transfer for a listing, or `null`. Expiry is applied as a read-time
  * predicate (see {@link isLive}) so an expired row never surfaces as pending, whether
  * or not anything has swept it.
  *
@@ -401,29 +578,29 @@ export async function cancelTransfer(opts: {
  * `toUserId`) and the offer's deadline; every other transfer proc gates
  * (`initiateTransfer` → owner, `acceptTransfer` → addressee, `cancelTransfer` → either
  * party), and this one took no caller at all, so any flagged account could read who is
- * handing which app to whom. Permitted: the app OWNER (who is the offer's `fromUserId`)
- * and the ADDRESSEE, matching exactly the set that may act on the transfer.
+ * handing which app to whom. Permitted: the listing OWNER (who is the offer's
+ * `fromUserId`) and the ADDRESSEE, matching exactly the set that may act on the transfer.
  *
  * An unauthorized caller gets `null`, NOT a FORBIDDEN. Throwing would make this proc an
- * existence ORACLE — "this app has a pending transfer" is itself the private fact — so
- * the refusal is made indistinguishable from "there is no offer". (`NOT_FOUND` for a
- * missing app is fine: app existence is already public.)
+ * existence ORACLE — "this listing has a pending transfer" is itself the private fact —
+ * so the refusal is made indistinguishable from "there is no offer". (`NOT_FOUND` for a
+ * missing listing is fine: listing existence is already public.)
  */
 export async function getPendingTransfer(opts: {
-  appBlockId: string;
+  appListingId: string;
   /** The caller. Required — this is not a public read; see above. */
   viewerUserId: number;
   now?: Date;
 }): Promise<TransferView | null> {
   const now = opts.now ?? new Date();
-  const { resolveAppAccess } = await import('~/server/services/blocks/app-access.service');
-  const access = await resolveAppAccess(opts.appBlockId, opts.viewerUserId);
-  if (!access) throw new AppCollaboratorError('NOT_FOUND', 'App not found');
+  const { resolveListingAccess } = await import('~/server/services/blocks/app-access.service');
+  const access = await resolveListingAccess(opts.appListingId, opts.viewerUserId);
+  if (!access) throw new AppCollaboratorError('NOT_FOUND', 'App listing not found');
   const row = (await dbRead.appOwnershipTransfer.findFirst({
-    where: { appBlockId: opts.appBlockId, status: 'pending' },
+    where: { appListingId: access.seatListingId, status: 'pending' },
     select: {
       id: true,
-      appBlockId: true,
+      appListingId: true,
       fromUserId: true,
       toUserId: true,
       status: true,
@@ -433,7 +610,7 @@ export async function getPendingTransfer(opts: {
   })) as TransferView | null;
   if (!row || !isLive(row, now)) return null;
   // Owner or addressee only. An EDITOR is deliberately excluded: a seat is a content
-  // capability, and disposing of the app is the one thing an editor may not do or
+  // capability, and disposing of the listing is the one thing an editor may not do or
   // initiate — so it is not theirs to watch either.
   if (access.role !== 'owner' && row.toUserId !== opts.viewerUserId) return null;
   return row;

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -856,7 +856,8 @@ async function isAcceptedListingEditor(listingId: string, userId: number): Promi
 
 /**
  * Load a listing and assert the caller may edit it: its OWNER or an ACCEPTED
- * collaborator on the backing AppBlock.
+ * collaborator ON THE LISTING (seats are listing-keyed since the re-key; the backing
+ * AppBlock is not the seat key, and an off-site listing has none).
  *
  * 🔴 STILL NO MODERATOR OVERRIDE — unchanged, and deliberately different from
  * `app-listing-assets.service::loadOwnedListing`, which does bypass for mods. That
@@ -1651,8 +1652,9 @@ export async function getMyListingForApp(opts: {
       `no listing found for app ${appBlockId ?? slug ?? '(unspecified)'}`
     );
   }
-  // Owner OR an ACCEPTED collaborator on the backing AppBlock. This is the media
-  // editor's entry read; an editor who cannot reach it cannot edit anything.
+  // Owner OR an ACCEPTED collaborator ON THE LISTING (the seat key since the re-key).
+  // This is the media editor's entry read; an editor who cannot reach it cannot edit
+  // anything.
   if (listing.userId !== userId && !(await isAcceptedListingEditor(listing.id, userId))) {
     throw new OffsiteRequestError('NOT_OWNED', 'you can only manage your own listings');
   }

--- a/src/server/services/blocks/offsite-moderation.service.ts
+++ b/src/server/services/blocks/offsite-moderation.service.ts
@@ -19,6 +19,8 @@ import {
   type ResolveReportInput,
   type UnpublishOwnListingInput,
 } from '~/server/schema/blocks/offsite-moderation.schema';
+import { safeCollaboratorQuery } from '~/server/services/blocks/app-access.service';
+import { recordOwnershipEvent } from '~/server/services/blocks/app-collaborator.service';
 import { notifyAppListingOwner } from '~/server/services/blocks/app-listing-notify';
 import { assertListingAssetsScanCleanInTx } from '~/server/services/blocks/app-listing-assets.service';
 import { assertOffsiteListingActionableInTx } from '~/server/services/blocks/app-listing-actionable.service';
@@ -614,6 +616,28 @@ export type ClaimListingResult = { appListingId: string; userId: number };
  * is preserved for audit fidelity (who actually submitted it). This fn NEVER touches
  * the publish request. The audit event's before/after userId captures the transfer.
  *
+ * 🔴 IT DOES, HOWEVER, CLEAR THE COLLABORATOR SEATS — and that is NEW, because until
+ * seats were re-keyed to `app_listings` an off-site listing could not hold one, so
+ * "reassign `userId`" WAS the complete remediation. It no longer is. This is the
+ * IMPERSONATION remedy (report → delist → claim → ban): the row being claimed was set up
+ * by someone pretending to be the rightful owner, and everything that impersonator
+ * attached to it is part of what is being taken away. Left behind, their seats would
+ * survive the claim as live editor capability on the REAL owner's listing —
+ * `listingContent`, `submitForReview` and `analytics` — their PENDING invites would stay
+ * acceptable, their accepted-and-displayed seats would keep appearing in the PUBLIC
+ * BYLINE under the new owner's name, and a pending ownership TRANSFER they had already
+ * offered would stay acceptable, handing the listing straight back out. So, in the SAME
+ * transaction as the reassign: every seat is deleted (any status), every pending
+ * transfer is cancelled, and each is recorded as an `AppOwnershipEvent` so the removal
+ * is auditable rather than silent. The new owner re-invites whoever they actually want.
+ *
+ * 🔴 That cleanup is CONDITIONAL on the collaborator tables existing, checked ONCE
+ * before the transaction opens. They are manual-apply (DB rule #8), and a statement
+ * against a missing relation ABORTS the surrounding Postgres transaction — a `catch`
+ * cannot undo that (every later statement fails 25P02), so `safeCollaboratorQuery`'s
+ * degrade-to-fallback CANNOT be used inside a tx. Probing outside it keeps the claim
+ * working unchanged in the pre-migration window, where no seat can exist anyway.
+ *
  * Optionally links + resolves the triggering `reportId` in the SAME tx (mirrors
  * delist EXACTLY, listing-scoped): in the impersonation workflow (report → delist →
  * claim → ban) the claim is the substantive resolution, so it ties to and closes the
@@ -626,10 +650,20 @@ export async function claimListing(opts: {
 }): Promise<ClaimListingResult> {
   const { input, reviewerUserId } = opts;
   const reason = requireModReason(input.reason);
+  const now = new Date();
   // Fail-fast + info-leak parity (replica): a missing OR on-site listing throws the
   // same generic NOT_FOUND before any tx is opened. The authoritative snapshot is
   // re-read on the primary inside the tx below.
   await classifyOffsiteListing(input.appListingId);
+
+  // 🔴 OUTSIDE THE TX ON PURPOSE — see the header. A query against a missing relation
+  // aborts the whole Postgres transaction, so the missing-table degrade has to happen
+  // before one is opened. `false` ⇒ the manual-apply migration has not landed ⇒ no seat
+  // can exist ⇒ the claim behaves exactly as it did before this feature.
+  const seatsTableLive = await safeCollaboratorQuery(async () => {
+    await dbRead.appCollaborator.count({ where: { appListingId: input.appListingId } });
+    return true;
+  }, false);
 
   await dbWrite.$transaction(async (tx) => {
     // Authoritative pre-state snapshot from the PRIMARY (not the replica classify),
@@ -693,6 +727,49 @@ export async function claimListing(opts: {
         after: { userId: input.targetUserId },
       },
     });
+
+    // 🔴 SEAT REMEDIATION — in the SAME tx as the reassign, so a rolled-back claim
+    // leaves the seats untouched exactly as it leaves zero moderation events. See the
+    // header for why "reassign userId" stopped being the whole remedy.
+    if (seatsTableLive) {
+      // Read the ids BEFORE deleting: `deleteMany` returns a count, and a count cannot
+      // name who lost what. An impersonation remedy that cannot say whose access it
+      // revoked is not an audit trail.
+      const seats = (await tx.appCollaborator.findMany({
+        where: { appListingId: input.appListingId },
+        select: { userId: true, status: true },
+      })) as Array<{ userId: number; status: string }>;
+      if (seats.length > 0) {
+        await tx.appCollaborator.deleteMany({ where: { appListingId: input.appListingId } });
+        for (const seat of seats) {
+          await recordOwnershipEvent(tx, {
+            appListingId: input.appListingId,
+            slug: current.slug,
+            action: 'remove',
+            actorUserId: reviewerUserId,
+            targetUserId: seat.userId,
+            metadata: { via: 'claim', previousStatus: seat.status },
+          });
+        }
+      }
+      // A pending transfer the previous (impersonating) owner had already offered would
+      // otherwise stay acceptable and hand the listing straight back out. Guarded on
+      // `status:'pending'` so a terminal row is never re-written.
+      const cancelled = await tx.appOwnershipTransfer.updateMany({
+        where: { appListingId: input.appListingId, status: 'pending' },
+        data: { status: 'cancelled', respondedAt: now },
+      });
+      if (cancelled.count > 0) {
+        await recordOwnershipEvent(tx, {
+          appListingId: input.appListingId,
+          slug: current.slug,
+          action: 'transfer_cancelled',
+          actorUserId: reviewerUserId,
+          metadata: { via: 'claim', cancelled: cancelled.count },
+        });
+      }
+    }
+
     if (input.reportId) {
       // Resolve the triggering report in the same tx — mirrors delist EXACTLY. In the
       // impersonation flow (report → delist → claim → ban) the claim is the substantive


### PR DESCRIPTION
Extends App Listing Collaborators (#3805) to **off-site listings** by re-keying seats from `app_blocks` to `app_listings`.

## Why

#3805 shipped seats keyed to `app_blocks`. Every off-site listing has `app_block_id IS NULL`, and `resolveListingAccess` returns `role: null` when there is no block — so **all 4 off-site listings were structurally excluded**, despite the feature being called "App Listing Collaborators". Found by trying to add a collaborator to `radio` and discovering there is no row that could be inserted.

`app_listings` is the superset: **21 on-site + 4 off-site = 25 parents**, against 22 `app_blocks`. Re-keying excludes exactly one thing — `who-am-i`, a **suspended** block with no listing, which should not be gaining collaborators.

The alternative (nullable `app_block_id` **plus** `app_listing_id` + a CHECK that exactly one is set) was rejected: it breaks the composite PK and forks every query path and gate into two branches, permanently, to avoid a migration that currently costs nothing.

## Why now

**All three tables are EMPTY in prod and dev (0/0/0, re-verified immediately before this PR).** So this is a `DROP` + `CREATE`, not a backfill. The moment anyone seats a collaborator, that window closes and the same change becomes an ALTER + data migration with live capability grants in flight.

## What changed

- **New migration** `20260811160000_rekey_app_collaborators_to_listings` — supersedes `20260810140000_app_listing_collaborators` (already applied to prod + dev). Keyed on `app_listings(id)`; preserves every validated property: CHECK constraints, CASCADE on seats/transfers vs SET NULL on events, and the partial unique `… (app_listing_id) WHERE status='pending'` that the service's P2002 race-close depends on.
- **Capabilities derived by listing kind**, no new config surface. Listing content/media, submit-for-review and analytics work for both kinds; **earnings** and **submit-version/Forgejo git** are on-site only (block-scoped by nature) and are asserted *absent* rather than erroring.
- **Seats attach to the PARENT listing, never a shadow revision.** `applyApprovedRevision` deletes the shadow, so a seat there would silently vanish on approve. SQL cannot express "parent only", so it is a service guard, pinned both directions.
- **Transfer refuses on a connect client.** 3 of the 4 off-site listings carry a `connect_client_id` (an OauthClient with secrets + allowed origins). Moving OAuth credentials is a materially different act from handing over a listing; silently moving them is the worst outcome and silently not moving them leaves ownership split, so v1 refuses with a clear error. On-site keeps today's behaviour (both userId columns in one transaction).

## Reconciliation with the mod-only `claimListing`

Both write `AppListing.userId` for off-site. Reconciled, not merged — different authority (mod remedy vs owner-initiated + recipient-consented), separate audit trails, neither derived from the other. `acceptTransfer`'s off-site write is `updateMany({ where: { id, userId: fromUserId } })`, so a mod claim in the window makes it match 0 rows → fail closed rather than silently undoing the remedy. Pinned by a test.

## 🔴 Deploy-order hazard — read before merging

This migration is **not** inert the way its predecessor was. Between the code deploying and the SQL applying, the tables carry the *old* shape, so a seat read raises `column "app_listing_id" does not exist` (**42703**, not 42P01) — and `isMissingTableError` deliberately refuses column errors so a half-applied schema surfaces rather than silently degrading.

The exposure is symmetric (either order breaks the same `resolveAppAccess` path) and bounded: **zero seats exist, no collaborator UI ships, and the affected procs are author/mod-flag gated**, so the blast radius is a small population of authoring calls, with no data at risk.

Recommended sequence — **apply the SQL immediately before the release cut**, then verify author-gated procs are healthy once the deploy converges. Do not leave a long gap in either direction.

## Verification

- `pnpm typecheck` 0 errors; test files type-checked separately (0 errors in any file this branch authored).
- Full unit project: 945 files / 14692 passed / 0 failed.
- 31 mutants across **two independently-constructed sweeps**, all killed, each to its own assertion.
- One mutant **survived** the first pass and produced a real fix: a redundant in-memory `!!id` filter meant an output-only assertion could never attribute the kill on `resolveAccessibleAppBlockIds`' null-block exclusion. Split into a structural assertion (the predicate is in the `WHERE`) plus a behavioural one against a fake that ignores the `WHERE`.

## Not verified

- **Nothing here touched a Postgres.** The migration's shape is asserted against the committed file only. Applying it is a manual human step per environment (prod nvme0 + dev clone), per DB rule #8.
- **No UI.** Off-site listings have no per-app authoring page (`/apps/[appBlockId]/…` is block-keyed), so an off-site owner still has no surface to manage collaborators from. Procs exist and are tested; the page does not.
