### PR TITLE
fix(app-blocks): route the last five listing-ownership gates through the canonical owner

### DIFF
--- a/src/server/services/blocks/__tests__/app-access.call-site-ledger.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.call-site-ledger.test.ts
@@ -133,10 +133,14 @@ const GATE_LEDGER: Record<string, string> = {
     'capability table. Every other site delegates here. Seats are keyed to AppListing ' +
     'so an offsite listing can hold collaborators. 🔴 BOTH resolvers report the CANONICAL ' +
     'owner (`appBlock.app.userId ?? listing.userId`), never the denormalized ' +
-    'AppListing.userId alone: acceptTransfer’s onsite step 3 is unguarded and treats a ' +
-    '0-count as an accepted desync, so the copy can be stale — and a stale copy inverts ' +
+    'AppListing.userId alone: a SHADOW REVISION clones that column and no ownership ' +
+    'write ever revisits the clone, so the copy can be stale — and a stale copy inverts ' +
     'every gate that delegates here, refusing the real owner while admitting the name ' +
-    'the row happens to carry.',
+    'the row happens to carry. (NOT acceptTransfer’s onsite listing write, which is ' +
+    'unconditional and heals the parent; see app-access.denormalized-owner-drift.test.ts ' +
+    'for the mechanism in full.) 🔴 The resolution is BLOCK-FIRST, not kind-branching, ' +
+    'and on an offsite-listing-that-carries-a-block it names the wrong owner after a ' +
+    'transfer or a mod claim — 0 rows and unmintable today, tracked as issue #3844.',
   'src/server/services/blocks/app-collaborator.service.ts':
     'assertOwner — seat management is OWNER-ONLY by product decision (an editor is a ' +
     'co-owner in every respect EXCEPT managing collaborators and initiating a ' +
@@ -276,9 +280,17 @@ const KIND_CAPABILITY_LEDGER: Record<string, string> = {
  * a fresh copy of the same inversion. Every shape is probed in the POSITIVE CONTROL test,
  * because a regex nobody has watched match is a claim, not a guard — and that matters
  * more, not less, now that the live corpus no longer exercises them.
+ *
+ * 🔴 AND IT IS A SPELLING GUARD, NOT A STRUCTURAL ONE. Read {@link DENORM_OWNER_RE}'s
+ * KNOWN EVASIONS block before quoting either regex as protection: both are anchored on
+ * the RECEIVER NAME (`*listing` / `*shadow` / `<x>.appListing`), so a gate written
+ * against a differently-named local evades them entirely. The listing-owner alternatives
+ * here accept either operand order, optional chaining and `!=` — but they are a
+ * naming-convention lint over this feature's own conventions, and the guard that
+ * actually holds the BEHAVIOUR is `app-access.denormalized-owner-drift.test.ts`.
  */
 const GATE_RE =
-  /app\??\.userId|app:\s*\{\s*userId|(?:\w*[Ll]isting|\w*[Ss]hadow)\.userId\s*!==|\w+\.appListing\.userId\s*!==|resolveAppAccess|resolveListingAccess|resolveAccessibleAppBlockIds|assertAppEditAccess|listAppInsiderUserIds|loadOwnedListingInTx/;
+  /app\??\.userId|app:\s*\{\s*userId|(?:\w*[Ll]isting|\w*[Ss]hadow)\??\.userId\s*(?:!==|!=)|(?:!==|!=)\s*(?:\w*[Ll]isting|\w*[Ss]hadow)\??\.userId|\w+\??\.appListing\??\.userId\s*(?:!==|!=)|(?:!==|!=)\s*\w+\??\.appListing\??\.userId|resolveAppAccess|resolveListingAccess|resolveAccessibleAppBlockIds|assertAppEditAccess|listAppInsiderUserIds|loadOwnedListingInTx/;
 
 /**
  * 🔴 THE DENORMALIZED-OWNER GATE CLASS (D5) — every spelling of "compare the caller
@@ -289,9 +301,38 @@ const GATE_RE =
  * exclusion is) and that form is just as stale-able. Kept as a separate regex rather than
  * widened into `GATE_RE` so that the gate POPULATION and the column-read CLASS can be
  * asserted independently — a site can legitimately be in one and not the other.
+ *
+ * 🔴 KNOWN EVASIONS — READ THIS BEFORE CITING THIS REGEX AS A GUARD. It is a SPELLED
+ * check, not a structural one: it is anchored on the RECEIVER NAME. Measured over the
+ * whole non-test `src/` corpus, of eleven realistic spellings of the exact D5 regression
+ * it catches eight and MISSES three, and the three it misses are ordinary code:
+ *
+ *   - a HOISTED LOCAL  — `const ownerId = listing.userId; if (ownerId !== userId) …`
+ *   - a DESTRUCTURE    — `const { userId: ownerId } = listing; if (ownerId !== …)`
+ *   - ANY OTHER NAME   — `row.userId !== userId`, `parent.…`, `draft.…`
+ *
+ * The three newly-covered spellings (reversed operands, `listing?.userId`, `!=`) were
+ * added because they cost nothing: they changed NEITHER matched file set — `GATES` stayed
+ * at 16 files and this class stayed at exactly the three holdouts below — so the widening
+ * is strictly additive. Going further is not free and was REJECTED with a measurement: a
+ * pattern over an ARBITRARY receiver (`(?:\w+\.)*\w+\.userId <op>`) matches **127 files
+ * repo-wide and 15 under `src/server/services/blocks/` alone**, almost all of them
+ * correct and unrelated (`image.userId`, `session.userId`, `client.userId`,
+ * `sub.userId`, `metadata.userId`). As an enumerated-equality assertion that is a
+ * permanently-noisy allowlist that decays on every unrelated edit — a gate people learn
+ * to click through — and it STILL would not see the hoisted-local or destructured forms.
+ *
+ * 🔴 SO THE HONEST STATEMENT OF WHAT THIS HOLDS: it is a NAMING-CONVENTION LINT. It keeps
+ * a gate written in this feature's own idiom from being reintroduced silently, and it
+ * keeps the holdout record from going stale. It is NOT a guarantee that no gate compares
+ * against `AppListing.userId`. The guard that actually holds the BEHAVIOUR — for any
+ * spelling, because it never reads the source at all — is
+ * `app-access.denormalized-owner-drift.test.ts`, which drives all five sites against a
+ * drifted fixture and asserts both directions. If you are deciding whether this class is
+ * safe, that suite is the evidence; this one is bookkeeping.
  */
 const DENORM_OWNER_RE =
-  /(?:\w*[Ll]isting|\w*[Ss]hadow)\.userId\s*(?:!==|===)|\w+\.appListing\.userId\s*(?:!==|===)/;
+  /(?:\w*[Ll]isting|\w*[Ss]hadow)\??\.userId\s*(?:!==|===|!=|==)|(?:!==|===|!=|==)\s*(?:\w*[Ll]isting|\w*[Ss]hadow)\??\.userId|\w+\??\.appListing\??\.userId\s*(?:!==|===|!=|==)|(?:!==|===|!=|==)\s*\w+\??\.appListing\??\.userId/;
 
 /**
  * 🔴 THE CLASS IS NOT DELETED, IT IS EMPTY-EXCEPT-FOR-THESE — and this table is the
@@ -305,9 +346,11 @@ const DENORM_OWNER_RE =
  * different verdicts and the table states which is which, because a reader who assumes
  * the first means the second is exactly how this class gets forgotten again.
  *
- * The assertion below fails on GROWTH (a new site reads the column)
- * and on SHRINK (one of these was fixed and this record went stale) — the same property
- * the two ledgers above have, applied to a class rather than to a population.
+ * The assertion below fails on GROWTH (a new site reads the column IN ONE OF THE
+ * SPELLINGS {@link DENORM_OWNER_RE} CAN SEE — read its KNOWN EVASIONS block, this is a
+ * naming-convention lint, not a structural guarantee) and on SHRINK (one of these was
+ * fixed and this record went stale) — the same property the two ledgers above have,
+ * applied to a class rather than to a population.
  */
 const DENORM_OWNER_HOLDOUTS: Record<string, string> = {
   'src/server/services/blocks/offsite-moderation.service.ts':
@@ -408,6 +451,11 @@ describe('app-ownership gate ledger', () => {
         'screenshot listing-owner gate (app-listing-assets::resolveOwnerScreenshotTarget)',
         'if (shot.appListing.userId !== user.id && !user.isModerator) {',
       ],
+      // The three spellings the widening added. Each is a one-token rewrite of a shape
+      // above, and each used to walk straight past this regex.
+      ['reversed operands', 'if (userId !== listing.userId) throw e;'],
+      ['optional chaining', 'if (listing?.userId !== userId) throw e;'],
+      ['loose inequality', 'if (listing.userId != userId) throw e;'],
     ];
     for (const [label, sample] of SHAPES) {
       expect(GATE_RE.test(sample), `GATE_RE must recognise: ${label}`).toBe(true);
@@ -499,11 +547,53 @@ describe('app-ownership gate ledger', () => {
           'the ALLOW-branch form (app-listing-review)',
           'if (listing.userId === userId) { throw throwAuthorizationError(...); }',
         ],
+        // Widened spellings — a one-token rewrite of the shapes above, each of which
+        // used to evade this regex completely.
+        [
+          'reversed operands',
+          "if (userId !== listing.userId && (await resolveListingRole(id, userId)) !== 'editor') {",
+        ],
+        ['reversed ALLOW-branch', 'if (userId === listing.userId) { throw e; }'],
+        ['optional chaining', 'if (listing?.userId !== userId) throw e;'],
+        ['loose inequality', 'if (listing.userId != userId) throw e;'],
+        ['shadow, reversed', 'if (userId !== shadow.userId) throw e;'],
+        ['nested member, optional', 'if (shot.appListing?.userId !== user.id) throw e;'],
       ];
       for (const [label, sample] of REMOVED) {
         expect(DENORM_OWNER_RE.test(sample), `DENORM_OWNER_RE must recognise: ${label}`).toBe(
           true
         );
+      }
+    });
+
+    it('🔴 KNOWN EVASIONS: the spellings this regex CANNOT see, pinned as measured', () => {
+      // 🔴 THIS TEST ASSERTS A LIMIT, NOT A CAPABILITY, and it is here so the limit is a
+      // measured fact in the suite rather than a sentence in a comment nobody re-derives.
+      // `DENORM_OWNER_RE` is anchored on the RECEIVER NAME, so a gate written against a
+      // differently-named local is invisible to it — including the exact D5 regression,
+      // restored verbatim under another name.
+      //
+      // Do NOT "fix" this by widening the regex to an arbitrary receiver. That was
+      // measured: `(?:\w+\.)*\w+\.userId <op>` matches 127 files repo-wide and 15 under
+      // `src/server/services/blocks/` alone, nearly all correct and unrelated, which
+      // turns the enumerated-equality assertion above into a permanently-noisy
+      // allowlist. If one of these forms is what you want caught, the guard is
+      // `app-access.denormalized-owner-drift.test.ts` — it asserts BEHAVIOUR and is
+      // blind to spelling by construction.
+      const EVADES: Array<[string, string]> = [
+        ['a hoisted local', 'const ownerId = listing.userId;\nif (ownerId !== userId) throw e;'],
+        [
+          'a destructure',
+          'const { userId: ownerId } = listing;\nif (ownerId !== callerId) throw e;',
+        ],
+        ['any other receiver name', 'if (row.userId !== userId) throw e;'],
+      ];
+      for (const [label, sample] of EVADES) {
+        expect(
+          DENORM_OWNER_RE.test(sample),
+          `${label} is a KNOWN evasion — if this now matches, the regex was widened; ` +
+            'update the KNOWN EVASIONS comment and re-measure the false-positive count'
+        ).toBe(false);
       }
     });
 
@@ -524,6 +614,11 @@ describe('app-ownership gate ledger', () => {
       // comparing against AppListing.userId — the two-sided inversion D5 describes.
       // SHRINK means one of the holdouts was finally fixed and DENORM_OWNER_HOLDOUTS is
       // now lying about the state of the codebase.
+      //
+      // 🔴 GREEN HERE IS NOT "no gate compares against the column". It is "no gate
+      // compares against it in a spelling this regex can see" — see the KNOWN EVASIONS
+      // test below and the note on DENORM_OWNER_RE. The behavioural claim belongs to
+      // `app-access.denormalized-owner-drift.test.ts`.
       expect(DENORM_SITES).toEqual(Object.keys(DENORM_OWNER_HOLDOUTS).sort());
     });
 

--- a/src/server/services/blocks/__tests__/app-access.call-site-ledger.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.call-site-ledger.test.ts
@@ -62,6 +62,18 @@ import { describe, expect, it } from 'vitest';
  *       `appOwnerUserId` and is user-wide. Left as-is, deliberately — see the note on
  *       `getMyRevenue`, which must keep showing an ex-owner the money they accrued
  *       before transferring an app away.
+ *   D5. THE OWNER HALF OF A GATE READ A DIFFERENT COLUMN FROM ITS SEAT HALF. Five gates
+ *       spelled the owner question as `<row>.userId !== callerId` against
+ *       `AppListing.userId` — a DENORMALIZED copy for an on-site listing, whose canonical
+ *       owner is `AppBlock.app.userId` — while their seat half delegated to
+ *       `resolveListingAccess`, which resolves the canonical owner. On a drifted onsite
+ *       row those two halves disagree, and the disagreement is two-sided: the REAL owner
+ *       resolves as `owner` (not `editor`) and is refused, and whoever the stale column
+ *       names walks straight through the first comparison. FIXED (not merely recorded):
+ *       all five now ask `resolveListingAccess`. The class this ledger used to record is
+ *       consequently EMPTY for every collaborator-reachable gate, and
+ *       {@link DENORM_OWNER_HOLDOUTS} keeps it that way while naming the owner-only
+ *       holdouts that are NOT fixed.
  */
 
 const ROOT = process.cwd();
@@ -79,15 +91,21 @@ const GATE_LEDGER: Record<string, string> = {
     'widened to owned+seated via getMyAppsEarnings; getMyRevenue is deliberately NOT ' +
     'widened (D4).',
   'src/server/services/blocks/app-listing-assets.service.ts':
-    'loadOwnedListing + resolveOwnerScreenshotTarget widened to owner | ACCEPTED ' +
-    'collaborator | moderator via resolveListingAccess. Keeps its pre-existing mod ' +
-    'bypass (D1). loadValidatedImage is NOT widened: it gates IMAGE ownership, and an ' +
-    'editor attaches their OWN uploads.',
+    'loadOwnedListing is THE gate: owner | ACCEPTED collaborator | moderator, with BOTH ' +
+    'the owner half and the seat half resolved by resolveListingAccess — never the ' +
+    'denormalized AppListing.userId (D5). Keeps its pre-existing mod bypass (D1), which ' +
+    'still short-circuits first so a mod pays no extra read. resolveOwnerScreenshotTarget ' +
+    'no longer runs its own early copy of the gate: it called loadOwnedListing on the ' +
+    'same listing one line later, so the copy was pure drift surface. loadValidatedImage ' +
+    'is NOT widened: it gates IMAGE ownership, and an editor attaches their OWN uploads.',
   'src/server/services/blocks/offsite-listing.service.ts':
-    'loadOwnedEditableListing, getMyListingForApp and submitListingRevision widened to ' +
-    'owner | ACCEPTED collaborator. Still NO mod bypass (D1). submitListingRevision ' +
-    'needed the seat check specifically because beginListingRevision clones the shadow ' +
-    'with the PARENT OWNER’s userId, so an editor’s own shadow reads as not-theirs.',
+    'loadOwnedEditableListing, getMyListingForApp and submitListingRevision are owner | ' +
+    'ACCEPTED collaborator, all three via the one resolveListingRole helper (a thin read ' +
+    'of resolveListingAccess) — the owner half included, so a stale denormalized column ' +
+    'cannot invert them (D5). Still NO mod bypass (D1). submitListingRevision needed the ' +
+    'seat check specifically because beginListingRevision clones the shadow with the ' +
+    'PARENT OWNER’s userId, so an editor’s own shadow reads as not-theirs — and that ' +
+    'clone is a copy of a copy, which is why reading it directly was doubly wrong.',
   'src/server/services/blocks/app-analytics.service.ts':
     'getOwnedAppBlocks resolves the permitted-id SET (owned + seated) instead of ' +
     '`app: { userId }`. Safe to widen HERE because every downstream aggregate filters ' +
@@ -243,19 +261,84 @@ const KIND_CAPABILITY_LEDGER: Record<string, string> = {
  * `assertAppEditAccess` — the blocks.router wrapper.
  *
  * 🔴 THE LISTING-OWNER CLASS IS MATCHED EXPLICITLY, and that is the point of the third
- * and fourth alternatives. This PR widened three gates spelled
- * `listing.userId !== user.id`, `shadow.userId !== userId` and
- * `shot.appListing.userId !== user.id` — the DENORMALIZED owner column, not
- * `app.userId`. Before they were listed here the regex could not see any of them: their
- * three files were in the ledger only INCIDENTALLY, matched by an unrelated token
- * (`resolveListingAccess`, `loadOwnedListingInTx`), so a new file opening a fresh
- * `listing.userId !== callerId` gate would have grown the population WITHOUT growing
- * `GATES` — the "fails on GROWTH" assertion below would have stayed green through
- * exactly the event it exists to catch. Every shape is probed in the POSITIVE CONTROL
- * test, because a regex nobody has watched match is a claim, not a guard.
+ * and fourth alternatives. The gates spelled `listing.userId !== user.id`,
+ * `shadow.userId !== userId` and `shot.appListing.userId !== user.id` read the
+ * DENORMALIZED owner column, not `app.userId`. Before they were listed here the regex
+ * could not see any of them: their files were in the ledger only INCIDENTALLY, matched by
+ * an unrelated token (`resolveListingAccess`, `loadOwnedListingInTx`), so a new file
+ * opening a fresh `listing.userId !== callerId` gate would have grown the population
+ * WITHOUT growing `GATES` — the "fails on GROWTH" assertion below would have stayed green
+ * through exactly the event it exists to catch.
+ *
+ * 🔴 THOSE ALTERNATIVES NOW MATCH NOTHING IN PRODUCTION, AND THEY STAY. All five sites of
+ * that class were routed through `resolveListingAccess` (D5), so keeping the alternatives
+ * here is what makes a REINTRODUCTION grow `GATES` and fail loudly instead of shipping as
+ * a fresh copy of the same inversion. Every shape is probed in the POSITIVE CONTROL test,
+ * because a regex nobody has watched match is a claim, not a guard — and that matters
+ * more, not less, now that the live corpus no longer exercises them.
  */
 const GATE_RE =
   /app\??\.userId|app:\s*\{\s*userId|(?:\w*[Ll]isting|\w*[Ss]hadow)\.userId\s*!==|\w+\.appListing\.userId\s*!==|resolveAppAccess|resolveListingAccess|resolveAccessibleAppBlockIds|assertAppEditAccess|listAppInsiderUserIds|loadOwnedListingInTx/;
+
+/**
+ * 🔴 THE DENORMALIZED-OWNER GATE CLASS (D5) — every spelling of "compare the caller
+ * against `AppListing.userId`", including the positive-branch form.
+ *
+ * Broader than the corresponding alternatives in {@link GATE_RE} on purpose: this one
+ * also matches `===`, because a gate can be written as an ALLOW branch (the self-review
+ * exclusion is) and that form is just as stale-able. Kept as a separate regex rather than
+ * widened into `GATE_RE` so that the gate POPULATION and the column-read CLASS can be
+ * asserted independently — a site can legitimately be in one and not the other.
+ */
+const DENORM_OWNER_RE =
+  /(?:\w*[Ll]isting|\w*[Ss]hadow)\.userId\s*(?:!==|===)|\w+\.appListing\.userId\s*(?:!==|===)/;
+
+/**
+ * 🔴 THE CLASS IS NOT DELETED, IT IS EMPTY-EXCEPT-FOR-THESE — and this table is the
+ * difference between "we fixed it" and "we stopped looking".
+ *
+ * Every collaborator-reachable gate now resolves the owner canonically. What is left is
+ * three NON-collaborator sites that still compare against the column, listed with why
+ * each was not swept along — two owner-only lifecycle gates that carry the same latent
+ * inversion, and one that is in the class by SHAPE but safe by CONTEXT (it matches on
+ * `appBlockId IS NULL`, where the column IS canonical). "Left as-is" and "safe" are
+ * different verdicts and the table states which is which, because a reader who assumes
+ * the first means the second is exactly how this class gets forgotten again.
+ *
+ * The assertion below fails on GROWTH (a new site reads the column)
+ * and on SHRINK (one of these was fixed and this record went stale) — the same property
+ * the two ledgers above have, applied to a class rather than to a population.
+ */
+const DENORM_OWNER_HOLDOUTS: Record<string, string> = {
+  'src/server/services/blocks/offsite-moderation.service.ts':
+    'TWO owner-only gates: loadOwnedListingInTx (unpublish/republish your own listing, ' +
+    'DUAL-KIND so an onsite listing reaches it) and listMyListingModerationEvents. Both ' +
+    'carry the same latent inversion as D5 — on a drifted onsite row the real owner is ' +
+    'refused and the stale name is admitted — and neither is fixed here. The reason is ' +
+    'mechanical, not a judgement that they are safe: loadOwnedListingInTx runs INSIDE an ' +
+    'interactive transaction and would need resolveListingAccess to accept a ' +
+    'Prisma.TransactionClient, i.e. a widening of the shared AccessDb type that changes ' +
+    'the resolver for every caller. That deserves its own PR, not a ride-along.',
+  'src/server/services/blocks/publish-request.service.ts':
+    'The orphan-draft REUSE check in submitVersion’s first-version branch ' +
+    '(`existingSlugListing.userId === submittedByUserId`) — reuse a same-slug ' +
+    'pre-approval draft only if it is the submitter’s own, else treat the slug as taken. ' +
+    'NOT a stale-copy hazard and NOT scheduled for change: the row it reads is matched on ' +
+    '`kind = onsite AND status = draft AND appBlockId IS NULL` in the same condition, and ' +
+    'a listing with no backing AppBlock has no OauthClient in its ownership chain, so the ' +
+    'column IS the canonical owner there — resolveListingAccess would return the exact ' +
+    'same number by its own fallback. Recorded so the class stays enumerated rather than ' +
+    'sampled: it is in the class by SHAPE, and safe by CONTEXT.',
+  'src/server/services/blocks/app-listing-review.service.ts':
+    'The self-review exclusion in upsertAppListingReview, written as an ALLOW branch ' +
+    '(`listing.userId === userId` → refuse). Not a collaborator gate at all — it is ' +
+    'anti-abuse — but it reads the same denormalized column, so on a drifted onsite ' +
+    'listing the REAL owner could review their own app while a stranger named by the ' +
+    'stale row could not. NOT fixed here: the block-side equivalent already resolves the ' +
+    'insider set (listAppInsiderUserIds), so the right fix is to route this at the same ' +
+    'insider seam rather than to swap one column read for another, and widening an ' +
+    'anti-abuse rule is a product decision.',
+};
 
 function walk(dir: string, out: string[] = []): string[] {
   for (const entry of readdirSync(dir)) {
@@ -378,6 +461,97 @@ describe('app-ownership gate ledger', () => {
         `${file} rationale must state what it decided about collaborators`
       ).toBe(true);
     }
+  });
+
+  // -------------------------------------------------------------------------
+  // 🔴 D5 — the denormalized-owner gate CLASS, pinned as (almost) empty.
+  // -------------------------------------------------------------------------
+
+  describe('🔴 the denormalized-owner gate class (D5)', () => {
+    const DENORM_SITES = FILES.filter((f) => DENORM_OWNER_RE.test(CODE.get(f)!)).sort();
+
+    it('POSITIVE CONTROL: DENORM_OWNER_RE matches every spelling the fix removed', () => {
+      // These five lines are copied verbatim from the pre-fix source. A regex asserting a
+      // class is EMPTY is worthless unless it has been watched to match that class — an
+      // empty result is otherwise indistinguishable from a typo in the pattern.
+      const REMOVED: Array<[string, string]> = [
+        [
+          'offsite-listing::loadOwnedEditableListing',
+          'if (listing.userId !== userId && !(await isAcceptedListingEditor(listingId, userId))) {',
+        ],
+        [
+          'offsite-listing::submitListingRevision',
+          'if (shadow.userId !== userId && !(await isAcceptedListingEditor(shadowId, userId))) {',
+        ],
+        [
+          'offsite-listing::getMyListingForApp',
+          'if (listing.userId !== userId && !(await isAcceptedListingEditor(listing.id, userId))) {',
+        ],
+        [
+          'app-listing-assets::loadOwnedListing',
+          'if (listing.userId !== user.id && !user.isModerator) {',
+        ],
+        [
+          'app-listing-assets::resolveOwnerScreenshotTarget',
+          'if (shot.appListing.userId !== user.id && !user.isModerator) {',
+        ],
+        [
+          'the ALLOW-branch form (app-listing-review)',
+          'if (listing.userId === userId) { throw throwAuthorizationError(...); }',
+        ],
+      ];
+      for (const [label, sample] of REMOVED) {
+        expect(DENORM_OWNER_RE.test(sample), `DENORM_OWNER_RE must recognise: ${label}`).toBe(
+          true
+        );
+      }
+    });
+
+    it('NEGATIVE CONTROL: it does not match the canonical resolution or an unrelated owner', () => {
+      // The replacement must NOT itself count as a member of the class, or the assertion
+      // below could never go green; and an Image/Post owner check is a different subject.
+      expect(DENORM_OWNER_RE.test('const role = await resolveListingRole(listingId, userId);')).toBe(
+        false
+      );
+      expect(
+        DENORM_OWNER_RE.test('const ownerUserId = row.appBlock?.app?.userId ?? row.userId;')
+      ).toBe(false);
+      expect(DENORM_OWNER_RE.test('if (image.userId !== user.id) return null;')).toBe(false);
+    });
+
+    it('the class is EMPTY except for the recorded owner-only holdouts (GROWTH and SHRINK)', () => {
+      // 🔴 Read the failure message before "fixing" it. GROWTH means a gate went back to
+      // comparing against AppListing.userId — the two-sided inversion D5 describes.
+      // SHRINK means one of the holdouts was finally fixed and DENORM_OWNER_HOLDOUTS is
+      // now lying about the state of the codebase.
+      expect(DENORM_SITES).toEqual(Object.keys(DENORM_OWNER_HOLDOUTS).sort());
+    });
+
+    it('no file that gates on collaborator ACCESS is in the class', () => {
+      // The narrower, behaviour-facing half of the same claim: whatever the holdout list
+      // says, a file that consults a seat must not ALSO be comparing against the column —
+      // that is exactly the split-brain gate D5 is about (seat half canonical, owner half
+      // denormalized), and it is what all five fixed sites looked like.
+      const seatAware = FILES.filter((f) =>
+        /resolveListingAccess|resolveAppAccess|resolveListingRole/.test(CODE.get(f)!)
+      );
+      expect(seatAware.length).toBeGreaterThan(2); // positive control: the scan found some
+      for (const file of seatAware) {
+        expect(
+          DENORM_OWNER_RE.test(CODE.get(file)!),
+          `${file} resolves a seat canonically but still compares against AppListing.userId`
+        ).toBe(false);
+      }
+    });
+
+    it('every holdout entry names a real file and states why it was left', () => {
+      for (const [file, rationale] of Object.entries(DENORM_OWNER_HOLDOUTS)) {
+        expect(CODE.get(file), `${file} is not in the scanned population`).toBeDefined();
+        expect(rationale.length, `${file} rationale is too terse to be a decision`).toBeGreaterThan(
+          80
+        );
+      }
+    });
   });
 
   it('🔴 the consolidated predicate is the ONLY place the accepted-status filter is written', () => {

--- a/src/server/services/blocks/__tests__/app-access.denormalized-owner-drift.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.denormalized-owner-drift.test.ts
@@ -5,10 +5,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  *
  * `AppListing.userId` is the CANONICAL owner for an OFF-SITE listing and a DENORMALIZED
  * COPY for an ON-SITE one, whose real owner is `OauthClient.userId` reached as
- * `AppListing.appBlock.app.userId`. The copy can go stale: `acceptTransfer`'s onsite
- * step 3 is deliberately unguarded and treats a 0-count as an accepted desync. Five
- * production gates used to compare the caller against that copy, and on a drifted row a
- * comparison like that fails in BOTH directions at once:
+ * `AppListing.appBlock.app.userId`. Five production gates used to compare the caller
+ * against that copy, and on a drifted row a comparison like that fails in BOTH directions
+ * at once:
  *
  *   - the REAL owner is refused on their own listing — and refused twice over, because
  *     the collaborator fallback resolves them as `owner`, which is not `editor`; and
@@ -22,10 +21,39 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  * reason — the fix must move the OWNER half onto the canonical resolution without
  * touching the seat half in either direction.
  *
+ * 🔴 WHERE A DRIFTED ROW ACTUALLY COMES FROM — stated exactly, because the first version
+ * of this file named the wrong mechanism and a wrong mechanism sends the next reader to
+ * the wrong file. It is a SHADOW REVISION:
+ *
+ *   - `beginListingRevision` clones the approved parent into a hidden draft with
+ *     `userId: parent.userId` (a copy of a copy) and `appBlockId: null`;
+ *   - `acceptTransfer` step 3 updates only `{ id: <the transferred listing> }` — it never
+ *     touches that listing's shadows — and `applyApprovedRevision` copies assets back to
+ *     the parent, never `userId`;
+ *   - so a shadow that outlives a transfer of its parent keeps the OLD owner FROZEN,
+ *     while the parent and the `OauthClient` both name the new one. A gate that reads the
+ *     shadow's own column reads that frozen value.
+ *
+ * 🔴 It is NOT `acceptTransfer`'s onsite listing write "being deliberately unguarded, a
+ * 0-count an accepted desync" — that write is `where: { id }`, i.e. UNCONDITIONAL, issued
+ * in the same transaction as the `OauthClient` move and after an in-tx read of the same
+ * row through its own FK. It HEALS the parent's copy; a 0-count there needs the row to be
+ * absent, which the pre-read precludes. And `app-ownership-transfer.service.ts` holds the
+ * only in-app write to `OauthClient.userId`. So the top-level row's copy has no drift
+ * mechanism; only clones of it do.
+ *
+ * The fixture below is therefore built as a parent PLUS its shadow, and both directions
+ * are asserted on each. The parent is given the drifted value anyway — it costs nothing
+ * and it is what makes each case measurable against the pre-fix code, which read the
+ * column on both rows.
+ *
  * 🔴 MEASURED STATE, so the stakes are stated honestly: 0 drifted rows across all 21
- * onsite listings in production on 2026-08-11, because the only mechanism that creates
- * drift (an onsite ownership transfer) has never run. This is LATENT, not live. It goes
- * live on the first onsite transfer.
+ * onsite listings in production on 2026-08-11, because no onsite ownership transfer has
+ * ever run. This is LATENT, not live. It goes live on the first onsite transfer of a
+ * listing that has an in-flight revision draft. (The rate of approved onsite parents
+ * carrying a shadow is NOT measured here — `getMyListingForApp` stopped minting one per
+ * page view, so the old 78% figure in `app-listing-assets.service.ts` describes the
+ * pre-change world and must not be re-quoted as current.)
  *
  * The last describe block is the control that keeps the fix from over-reaching: on an
  * OFF-SITE listing the column IS the owner, so "always use the block owner" would be a
@@ -276,6 +304,85 @@ describe('offsite-listing::loadOwnedEditableListing (via updateListing)', () => 
   });
 });
 
+describe('🔴 D1: offsite-listing has NO moderator bypass — behaviourally, not as a string', () => {
+  /**
+   * D1 is the decision that `offsite-listing.service`'s author gates admit ONLY the
+   * owner and an accepted editor, while its sibling `app-listing-assets.service` also
+   * lets a moderator through. Until now that decision existed as prose in
+   * `app-access.call-site-ledger.test.ts` and as a comment on `loadOwnedEditableListing`
+   * — and a LEDGER STRING IS NOT A GUARD. A mutant that threads `isModerator` into
+   * `loadOwnedEditableListing` and short-circuits on it leaves the entire blocks suite
+   * green, and the comments there explicitly anticipate a future "make the mod bypass
+   * consistent" edit — which would silently widen an AUTHOR edit path to every moderator.
+   *
+   * `updateListing` already accepts `isModerator` (it is threaded into `deriveScopePatch`
+   * so a mod editing a listing that links a foreign OAuth client is not blocked by the
+   * client re-assertion), so the flag reaching the function is not hypothetical: it is
+   * already in the signature, one line away from the gate. These cases pin that it does
+   * NOT reach the gate.
+   */
+  it('a moderator who is not the owner is REFUSED on an ON-SITE listing', async () => {
+    await expect(
+      updateListing({
+        listingId: LIVE,
+        patch: { name: 'Renamed' },
+        userId: STRANGER,
+        isModerator: true,
+      })
+    ).rejects.toMatchObject({ code: 'NOT_OWNED', message: 'you can only edit your own listings' });
+    expect(mockWrite.appListing.update).not.toHaveBeenCalled();
+  });
+
+  it('a moderator who is not the owner is REFUSED on an OFF-SITE listing', async () => {
+    // The kind D1 is named for. Same refusal, so the decision is not an artefact of the
+    // drifted onsite fixture.
+    wireListings({
+      [LIVE]: liveRow({
+        kind: 'offsite',
+        userId: REAL_OWNER,
+        externalUrl: 'https://example.com/',
+        appBlockId: null,
+        appBlock: null,
+      }),
+    });
+    await expect(
+      updateListing({
+        listingId: LIVE,
+        patch: { name: 'Renamed' },
+        userId: STRANGER,
+        isModerator: true,
+      })
+    ).rejects.toMatchObject({ code: 'NOT_OWNED' });
+    expect(mockWrite.appListing.update).not.toHaveBeenCalled();
+  });
+
+  it('🔴 POSITIVE CONTROL: the flag is accepted and the owner still gets through with it', async () => {
+    // Without this, the two refusals above are indistinguishable from `isModerator` being
+    // an unknown key that never reaches anything — a reassuring zero. This proves the
+    // same call shape SUCCEEDS when the caller is the owner, so the refusals are the
+    // gate's verdict on the CALLER, not on the argument.
+    await expect(
+      updateListing({
+        listingId: LIVE,
+        patch: { name: 'Renamed' },
+        userId: REAL_OWNER,
+        isModerator: true,
+      })
+    ).resolves.toMatchObject({ listingId: LIVE });
+    expect(mockWrite.appListing.update).toHaveBeenCalledOnce();
+  });
+
+  it('🔴 CROSS-FILE CONTROL: the SAME non-owner moderator IS admitted by the assets gate', async () => {
+    // D1 is a claim about a DIVERGENCE between two sibling gates, so asserting only the
+    // refusal would leave "mods are refused everywhere" indistinguishable from it. The
+    // asset path's bypass is live and must stay live; that is what makes the offsite
+    // refusal above a decision rather than an oversight.
+    await expect(
+      getListingAssets({ listingId: LIVE }, { id: STRANGER, isModerator: true } as never)
+    ).resolves.toMatchObject({ listingId: LIVE });
+  });
+});
+
 describe('offsite-listing::submitListingRevision', () => {
   it('ADMITS the real owner (resolved through the shadow’s PARENT)', async () => {
     await expect(
@@ -309,6 +416,13 @@ describe('offsite-listing::submitListingRevision', () => {
 });
 
 describe('offsite-listing::getMyListingForApp', () => {
+  // 🔴 SCOPE NOTE, so this block is not read as more than it is. Unlike the other four
+  // sites, this one cannot be handed a shadow id — it resolves its row by `appBlockId` or
+  // `slug`, so it only ever sees a top-level parent, and a parent's copy has no drift
+  // mechanism (see the file header). The fixture below is therefore a state production
+  // cannot reach on THIS path. The cases still earn their place: they pin WHICH FIELD the
+  // gate reads, which is what keeps the fifth site from being the one that quietly keeps
+  // its own spelling of the predicate.
   it('ADMITS the real owner', async () => {
     await expect(
       getMyListingForApp({ appBlockId: BLOCK, userId: REAL_OWNER })
@@ -349,19 +463,39 @@ describe('app-listing-assets::loadOwnedListing (via getListingAssets)', () => {
     });
   });
 
-  it('still admits an ACCEPTED editor and a moderator, and still refuses a stranger', async () => {
+  it('still admits an ACCEPTED editor, and still refuses a stranger', async () => {
     seatFor(EDITOR);
     await expect(getListingAssets({ listingId: LIVE }, user(EDITOR))).resolves.toMatchObject({
       listingId: LIVE,
     });
-    // The mod bypass (D1) is this file's alone and must survive the consolidation — and
-    // it must still short-circuit BEFORE the resolve, so a mod pays no seat lookup.
-    await expect(
-      getListingAssets({ listingId: LIVE }, { id: STRANGER, isModerator: true } as never)
-    ).resolves.toMatchObject({ listingId: LIVE });
     await expect(getListingAssets({ listingId: LIVE }, user(STRANGER))).rejects.toMatchObject({
       code: 'FORBIDDEN',
     });
+  });
+
+  it('🔴 the mod bypass survives AND still short-circuits before the resolve', async () => {
+    // The mod bypass (D1) is this file's alone and must survive the consolidation. The
+    // second half of that sentence used to be an unasserted claim — "a mod pays no extra
+    // query" appeared in the comment while nothing counted the calls, so a mutant that
+    // moved the `isModerator` check AFTER the resolve would have kept this green.
+    // Counting it is the whole point, so it is counted, with a positive control.
+    seatFor(EDITOR);
+    await expect(
+      getListingAssets({ listingId: LIVE }, { id: STRANGER, isModerator: true } as never)
+    ).resolves.toMatchObject({ listingId: LIVE });
+    expect(mockRead.appCollaborator.findFirst).not.toHaveBeenCalled();
+    expect(mockWrite.appCollaborator.findFirst).not.toHaveBeenCalled();
+
+    // POSITIVE CONTROL: the seat lookup is reachable from this very call shape — the only
+    // thing that changed is who is asking. Without it, "0 calls" is indistinguishable
+    // from a seat lookup this path never performs for anyone.
+    await expect(getListingAssets({ listingId: LIVE }, user(EDITOR))).resolves.toMatchObject({
+      listingId: LIVE,
+    });
+    expect(
+      mockRead.appCollaborator.findFirst.mock.calls.length +
+        mockWrite.appCollaborator.findFirst.mock.calls.length
+    ).toBe(1);
   });
 });
 
@@ -418,27 +552,37 @@ describe('🔴 THE OTHER DIRECTION: an OFF-SITE listing’s column IS the owner'
     ).rejects.toMatchObject({ code: 'NOT_OWNED' });
   });
 
-  it('🔴 RECORDED DISAGREEMENT (not an endorsement): offsite + a block ⇒ the BLOCK wins', async () => {
-    // 🔴 This pins what the shared resolver DOES today, and it is NOT what its own prose
-    // says. `resolveListingAccess` computes `appBlock.app.userId ?? listing.userId` —
+  it('🔴 KNOWN REGRESSION on an unreachable shape (issue #3844): offsite + a block ⇒ the BLOCK wins', async () => {
+    // 🔴 CALLED WHAT IT IS. An earlier version of this comment (and of the PR body)
+    // framed this as a "neutral recorded disagreement". It is not neutral: PRE-PR these
+    // five gates compared against `AppListing.userId` and were therefore CORRECT on this
+    // shape; routing them through the resolver makes them wrong on it. That is a
+    // regression — on a shape that cannot currently occur, but a regression.
+    //
+    // `resolveListingAccess` computes `appBlock.app.userId ?? listing.userId` —
     // BLOCK-FIRST, with no branch on `kind`. That reads as "kind-aware" only because an
     // ordinary off-site listing has no block, so the fallback is the only branch reached.
+    // On an OFFSITE listing that carries one, the block decides — and BOTH off-site
+    // ownership writers move only the column, so the block keeps naming the old owner:
+    //   - `acceptTransfer` — its step (2) OauthClient move is `if (isOnsite)`-guarded;
+    //   - `claimListing` — the mod impersonation remedy (report → delist → claim → ban),
+    //     which refuses a non-offsite listing outright and writes only the column.
+    // So on this shape the ex-owner (or the impersonator the claim was meant to
+    // dispossess) keeps edit access and the rightful owner is refused.
     //
-    // On the one shape where the two rules differ — an OFFSITE listing that carries a
-    // block, which `mapAppBlockToListing` mints from any AppBlock with an `externalUrl`
-    // and which the mod proc `backfillAppListings` can reach — the block wins, so the
-    // listing's own `userId` does NOT decide. That matters because
-    // `app-ownership-transfer` moves ONLY the column for an offsite listing: transfer
-    // such a listing and this resolver keeps naming the OLD owner. It is the same
-    // stale-copy inversion, one shape over.
+    // 🔴 WHY IT IS PINNED RATHER THAN FIXED: measured against production 2026-08-12 the
+    // shape is not merely 0-row, it is UNMINTABLE. `kind='offsite' AND app_block_id IS
+    // NOT NULL` → 0 rows; 0 of 22 `app_blocks` carry an `external_url`; and a grep of
+    // `src/server` finds NO writer of that column — every hit is a read, a projection or
+    // a test fixture. `mapAppBlockToListing` mints the shape only from an AppBlock that
+    // has one. Changing the resolver moves the primary listing-access predicate for every
+    // caller, so it belongs in its own PR: https://github.com/civitai/civitai/issues/3844
+    // (which also notes that `resolveAccessibleAppBlockIds`, in the same module, already
+    // discriminates on `kind` rather than on block-nullness — the two halves disagree
+    // about which discriminator is authoritative).
     //
-    // 0 rows of this shape in production (measured 2026-08-11: 5 offsite listings, 0 with
-    // a block), and `resolveAccessibleAppBlockIds` already discriminates on `kind` rather
-    // than on block-nullness for exactly this reason — so the two halves of one module
-    // disagree about which discriminator is authoritative. Changing the resolver is a
-    // decision for whoever owns that call, not a side effect of consolidating five gates,
-    // so it is RECORDED here (and in the ledger's D5 note) and pinned, not silently
-    // altered. This test failing means someone changed it — read this comment first.
+    // This test failing means someone changed the resolver — read the issue first, and
+    // update this case deliberately rather than deleting it.
     wireListings({
       [LIVE]: offsite({ appBlockId: BLOCK, appBlock: { app: { userId: STRANGER } } }),
     });

--- a/src/server/services/blocks/__tests__/app-access.denormalized-owner-drift.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.denormalized-owner-drift.test.ts
@@ -1,0 +1,452 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * 🔴 THE DRIFTED ON-SITE LISTING — one fixture, five gates, both directions.
+ *
+ * `AppListing.userId` is the CANONICAL owner for an OFF-SITE listing and a DENORMALIZED
+ * COPY for an ON-SITE one, whose real owner is `OauthClient.userId` reached as
+ * `AppListing.appBlock.app.userId`. The copy can go stale: `acceptTransfer`'s onsite
+ * step 3 is deliberately unguarded and treats a 0-count as an accepted desync. Five
+ * production gates used to compare the caller against that copy, and on a drifted row a
+ * comparison like that fails in BOTH directions at once:
+ *
+ *   - the REAL owner is refused on their own listing — and refused twice over, because
+ *     the collaborator fallback resolves them as `owner`, which is not `editor`; and
+ *   - whoever the stale row happens to name walks straight through the first comparison,
+ *     reaching the listing's media, its revision submit and (via the roster) the
+ *     `displayed:false` seats.
+ *
+ * Every case below therefore asserts the PAIR. Asserting only the refusal would leave a
+ * "deny everyone" mutant alive; asserting only the admission would leave "allow
+ * everyone" alive. The seated EDITOR and the STRANGER cases are here for the same
+ * reason — the fix must move the OWNER half onto the canonical resolution without
+ * touching the seat half in either direction.
+ *
+ * 🔴 MEASURED STATE, so the stakes are stated honestly: 0 drifted rows across all 21
+ * onsite listings in production on 2026-08-11, because the only mechanism that creates
+ * drift (an onsite ownership transfer) has never run. This is LATENT, not live. It goes
+ * live on the first onsite transfer.
+ *
+ * The last describe block is the control that keeps the fix from over-reaching: on an
+ * OFF-SITE listing the column IS the owner, so "always use the block owner" would be a
+ * new bug. The kind-aware resolution has to keep admitting the column's owner there.
+ */
+
+const { mockRead, mockWrite, seq } = vi.hoisted(() => {
+  const make = () => ({
+    appListing: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      create: vi.fn(async (args: { data: unknown }) => args.data),
+      update: vi.fn(async (args: { data: unknown }) => args.data),
+    },
+    appListingScreenshot: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+      count: vi.fn(async (..._a: unknown[]): Promise<number> => 0),
+      createMany: vi.fn(async (..._a: unknown[]) => ({ count: 0 })),
+      updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
+    },
+    appListingPublishRequest: {
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      create: vi.fn(async (args: { data: unknown }) => args.data),
+    },
+    appCollaborator: { findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    image: { findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []) },
+    oauthClient: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    $transaction: vi.fn(async (arg: unknown) =>
+      typeof arg === 'function'
+        ? (arg as (tx: unknown) => Promise<unknown>)(null)
+        : Promise.all(arg as Promise<unknown>[])
+    ),
+  });
+  // 🔴 TWO OBJECTS, never one shared fake. A single client makes "which pool answered?"
+  // unanswerable, and the asset gates carry a pool override whose loss is a 403 for an
+  // editor (see `app-collaborator.editor-read-after-write.test.ts`).
+  return { mockRead: make(), mockWrite: make(), seq: { n: 0 } };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockWrite }));
+vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (url: string) => `edge:${url}` }));
+vi.mock('~/server/utils/app-block-ids', () => ({
+  newAppListingId: () => `apl_new_${++seq.n}`,
+  newAppListingPublishRequestId: () => `alpr_new_${++seq.n}`,
+  newAppListingScreenshotId: () => `apls_new_${++seq.n}`,
+  newUlid: () => `ULID${++seq.n}`,
+}));
+
+const { getMyListingForApp, submitListingRevision, updateListing } = await import(
+  '~/server/services/blocks/offsite-listing.service'
+);
+const { getListingAssets, updateListingScreenshotCaption } = await import(
+  '~/server/services/blocks/app-listing-assets.service'
+);
+
+// 🔴 PAIRWISE-DISTINCT ids. Two roles sharing a number is how a fixture "proves" a gate
+// that is actually reading the wrong field.
+const REAL_OWNER = 42; // OauthClient.userId — the canonical owner
+const STALE_NAME = 99; // what the drifted AppListing.userId column still says
+const EDITOR = 77; // holds an ACCEPTED seat on the parent
+const STRANGER = 13; // no relationship to the listing at all
+
+const LIVE = 'apl_live';
+const SHADOW = 'apl_shadow';
+const SHOT = 'apls_1';
+const BLOCK = 'ab_1';
+
+const user = (id: number) => ({ id, isModerator: false } as never);
+
+/**
+ * The drifted ON-SITE parent: the column says {@link STALE_NAME}, the OauthClient says
+ * {@link REAL_OWNER}. Every select this fixture serves is a subset of these fields, so
+ * one row can answer both the gate's load and the resolver's.
+ */
+function liveRow(over: Record<string, unknown> = {}) {
+  return {
+    id: LIVE,
+    kind: 'onsite',
+    slug: 'my-app',
+    status: 'draft',
+    userId: STALE_NAME,
+    revisionOfId: null,
+    appBlockId: BLOCK,
+    appBlock: { app: { userId: REAL_OWNER } },
+    name: 'My App',
+    tagline: null,
+    description: null,
+    category: null,
+    contentRating: 'g',
+    externalUrl: null,
+    connectClientId: null,
+    connectRequestedScopes: null,
+    connectScopeJustifications: null,
+    iconId: 101,
+    coverId: 202,
+    ...over,
+  };
+}
+
+/**
+ * The shadow revision of that parent — a COPY OF THE COPY. `beginListingRevision` clones
+ * with `userId: parent.userId`, so the shadow carries the drifted value frozen at clone
+ * time, and its own `appBlockId` is null by construction. Its `revisionOf` therefore has
+ * to supply both what the submit path reads (`slug`, `status`) and what the resolver
+ * reads (`appBlock.app.userId`).
+ */
+function shadowRow(over: Record<string, unknown> = {}) {
+  return {
+    id: SHADOW,
+    kind: 'onsite',
+    slug: 'rev-ulid',
+    status: 'draft',
+    userId: STALE_NAME,
+    revisionOfId: LIVE,
+    appBlockId: null,
+    appBlock: null,
+    externalUrl: null,
+    iconId: 101,
+    coverId: 202,
+    revisionOf: {
+      id: LIVE,
+      slug: 'my-app',
+      status: 'approved',
+      kind: 'onsite',
+      appBlockId: BLOCK,
+      appBlock: { app: { userId: REAL_OWNER } },
+    },
+    ...over,
+  };
+}
+
+/** The `loadListingEditView` projection (`getMyListingForApp`'s asset half). */
+const editView = {
+  name: 'My App',
+  tagline: null,
+  description: null,
+  category: null,
+  contentRating: 'g',
+  externalUrl: null,
+  connectRequestedScopes: null,
+  connectScopeJustifications: null,
+  iconId: 101,
+  coverId: 202,
+  icon: { url: 'icon-key' },
+  cover: { url: 'cover-key' },
+  screenshots: [],
+};
+
+/**
+ * Route `appListing.findUnique` by call shape on BOTH pools:
+ *   - `select` has `icon`  → the edit-view projection
+ *   - `where.appBlockId`   → the by-block entry resolve
+ *   - `where.id`           → the parent or the shadow
+ */
+function wireListings(rows: Record<string, unknown>) {
+  const impl = async (args: unknown) => {
+    const a = args as {
+      select?: Record<string, unknown>;
+      where?: { id?: string; appBlockId?: string };
+    };
+    if ('icon' in (a.select ?? {})) return editView;
+    if (a.where?.appBlockId != null) return rows[LIVE] ?? null;
+    return rows[a.where?.id ?? ''] ?? null;
+  };
+  mockRead.appListing.findUnique.mockImplementation(impl);
+  mockWrite.appListing.findUnique.mockImplementation(impl);
+}
+
+/** Give `userId` an ACCEPTED seat on every listing, on both pools. */
+function seatFor(userId: number) {
+  const impl = async (args: unknown) => {
+    const w = (args as { where: { userId: number; status?: string } }).where;
+    return w.userId === userId && w.status === 'accepted' ? { userId } : null;
+  };
+  mockRead.appCollaborator.findFirst.mockImplementation(impl);
+  mockWrite.appCollaborator.findFirst.mockImplementation(impl);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  seq.n = 0;
+  for (const db of [mockRead, mockWrite]) {
+    db.appListing.findFirst.mockResolvedValue(null);
+    db.appListing.update.mockImplementation(async (a: { data: unknown }) => a.data);
+    db.appListingScreenshot.findMany.mockResolvedValue([]);
+    db.appListingScreenshot.count.mockResolvedValue(0);
+    db.appListingScreenshot.updateMany.mockResolvedValue({ count: 1 });
+    db.appListingPublishRequest.findFirst.mockResolvedValue(null);
+    db.appCollaborator.findFirst.mockResolvedValue(null);
+    db.image.findMany.mockResolvedValue([]);
+    db.$transaction.mockImplementation(async (arg: unknown) =>
+      typeof arg === 'function'
+        ? (arg as (tx: unknown) => Promise<unknown>)(mockWrite)
+        : Promise.all(arg as Promise<unknown>[])
+    );
+  }
+  // `appListing.userId` is no longer SELECTED by the screenshot resolve (the gate that
+  // read it is gone), but the relation still exists on the real row and the fixture keeps
+  // it: it is what makes this suite measurable against the PRE-FIX code, where the same
+  // call reads it and admits the stale name. Without it the pre-fix run dies on a
+  // TypeError — a failure that proves nothing about the gate.
+  const shot = { id: SHOT, appListingId: LIVE, appListing: { userId: STALE_NAME } };
+  mockRead.appListingScreenshot.findUnique.mockResolvedValue(shot);
+  mockWrite.appListingScreenshot.findUnique.mockResolvedValue(shot);
+  wireListings({ [LIVE]: liveRow(), [SHADOW]: shadowRow() });
+});
+
+describe('🔴 POSITIVE CONTROL: the fixture really is drifted', () => {
+  it('the column and the OauthClient name DIFFERENT users', () => {
+    // Without this, every assertion below could be passing because the two ids happen to
+    // agree — the fixture would prove nothing about which one is being read.
+    expect(liveRow().userId).toBe(STALE_NAME);
+    expect(liveRow().appBlock.app.userId).toBe(REAL_OWNER);
+    expect(STALE_NAME).not.toBe(REAL_OWNER);
+    // The shadow inherited the drift rather than fixing it.
+    expect(shadowRow().userId).toBe(STALE_NAME);
+    expect(shadowRow().appBlockId).toBeNull();
+  });
+});
+
+describe('offsite-listing::loadOwnedEditableListing (via updateListing)', () => {
+  it('ADMITS the real owner', async () => {
+    await expect(
+      updateListing({ listingId: LIVE, patch: { name: 'Renamed' }, userId: REAL_OWNER })
+    ).resolves.toMatchObject({ listingId: LIVE, status: 'draft', requiresReview: false });
+    expect(mockWrite.appListing.update).toHaveBeenCalledOnce();
+  });
+
+  it('REFUSES the stale name the column still carries', async () => {
+    await expect(
+      updateListing({ listingId: LIVE, patch: { name: 'Renamed' }, userId: STALE_NAME })
+    ).rejects.toMatchObject({
+      code: 'NOT_OWNED',
+      message: 'you can only edit your own listings',
+    });
+    expect(mockWrite.appListing.update).not.toHaveBeenCalled();
+  });
+
+  it('still admits an ACCEPTED editor, and still refuses a stranger', async () => {
+    seatFor(EDITOR);
+    await expect(
+      updateListing({ listingId: LIVE, patch: { name: 'Renamed' }, userId: EDITOR })
+    ).resolves.toMatchObject({ listingId: LIVE });
+    await expect(
+      updateListing({ listingId: LIVE, patch: { name: 'Renamed' }, userId: STRANGER })
+    ).rejects.toMatchObject({ code: 'NOT_OWNED' });
+  });
+});
+
+describe('offsite-listing::submitListingRevision', () => {
+  it('ADMITS the real owner (resolved through the shadow’s PARENT)', async () => {
+    await expect(
+      submitListingRevision({ shadowId: SHADOW, userId: REAL_OWNER })
+    ).resolves.toMatchObject({ shadowId: SHADOW, slug: 'my-app' });
+    expect(mockWrite.appListingPublishRequest.create).toHaveBeenCalledOnce();
+  });
+
+  it('REFUSES the stale name', async () => {
+    await expect(
+      submitListingRevision({ shadowId: SHADOW, userId: STALE_NAME })
+    ).rejects.toMatchObject({
+      code: 'NOT_OWNED',
+      message: 'you can only submit your own revision',
+    });
+    expect(mockWrite.appListingPublishRequest.create).not.toHaveBeenCalled();
+  });
+
+  it('still admits an ACCEPTED editor on the parent, and still refuses a stranger', async () => {
+    // The seat lives on the PARENT — the resolver hops there. This is the case the bare
+    // comparison could never serve: the shadow's column names the (stale) parent owner,
+    // never the editor.
+    seatFor(EDITOR);
+    await expect(
+      submitListingRevision({ shadowId: SHADOW, userId: EDITOR })
+    ).resolves.toMatchObject({ shadowId: SHADOW });
+    await expect(
+      submitListingRevision({ shadowId: SHADOW, userId: STRANGER })
+    ).rejects.toMatchObject({ code: 'NOT_OWNED' });
+  });
+});
+
+describe('offsite-listing::getMyListingForApp', () => {
+  it('ADMITS the real owner', async () => {
+    await expect(
+      getMyListingForApp({ appBlockId: BLOCK, userId: REAL_OWNER })
+    ).resolves.toMatchObject({ appListingId: LIVE, status: 'draft' });
+  });
+
+  it('REFUSES the stale name', async () => {
+    await expect(
+      getMyListingForApp({ appBlockId: BLOCK, userId: STALE_NAME })
+    ).rejects.toMatchObject({
+      code: 'NOT_OWNED',
+      message: 'you can only manage your own listings',
+    });
+  });
+
+  it('still admits an ACCEPTED editor, and still refuses a stranger', async () => {
+    seatFor(EDITOR);
+    await expect(getMyListingForApp({ appBlockId: BLOCK, userId: EDITOR })).resolves.toMatchObject({
+      appListingId: LIVE,
+    });
+    await expect(getMyListingForApp({ appBlockId: BLOCK, userId: STRANGER })).rejects.toMatchObject(
+      { code: 'NOT_OWNED' }
+    );
+  });
+});
+
+describe('app-listing-assets::loadOwnedListing (via getListingAssets)', () => {
+  it('ADMITS the real owner', async () => {
+    await expect(getListingAssets({ listingId: LIVE }, user(REAL_OWNER))).resolves.toMatchObject({
+      listingId: LIVE,
+    });
+  });
+
+  it('REFUSES the stale name', async () => {
+    await expect(getListingAssets({ listingId: LIVE }, user(STALE_NAME))).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'You do not own this listing',
+    });
+  });
+
+  it('still admits an ACCEPTED editor and a moderator, and still refuses a stranger', async () => {
+    seatFor(EDITOR);
+    await expect(getListingAssets({ listingId: LIVE }, user(EDITOR))).resolves.toMatchObject({
+      listingId: LIVE,
+    });
+    // The mod bypass (D1) is this file's alone and must survive the consolidation — and
+    // it must still short-circuit BEFORE the resolve, so a mod pays no seat lookup.
+    await expect(
+      getListingAssets({ listingId: LIVE }, { id: STRANGER, isModerator: true } as never)
+    ).resolves.toMatchObject({ listingId: LIVE });
+    await expect(getListingAssets({ listingId: LIVE }, user(STRANGER))).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
+  });
+});
+
+describe('app-listing-assets::resolveOwnerScreenshotTarget (via updateListingScreenshotCaption)', () => {
+  // The fifth site. Its own early gate — a second, denormalized-column copy of
+  // `loadOwnedListing`'s question about the same listing — is gone; these cases pin that
+  // its removal left the path GATED, and gated CORRECTLY, rather than merely quieter.
+  it('ADMITS the real owner', async () => {
+    await expect(
+      updateListingScreenshotCaption({ screenshotId: SHOT, caption: 'hi' }, user(REAL_OWNER))
+    ).resolves.toEqual({ id: SHOT });
+    expect(mockWrite.appListingScreenshot.updateMany).toHaveBeenCalledOnce();
+  });
+
+  it('REFUSES the stale name — and writes nothing', async () => {
+    await expect(
+      updateListingScreenshotCaption({ screenshotId: SHOT, caption: 'hi' }, user(STALE_NAME))
+    ).rejects.toMatchObject({ code: 'FORBIDDEN', message: 'You do not own this listing' });
+    expect(mockWrite.appListingScreenshot.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('still refuses a stranger', async () => {
+    await expect(
+      updateListingScreenshotCaption({ screenshotId: SHOT, caption: 'hi' }, user(STRANGER))
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(mockWrite.appListingScreenshot.updateMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('🔴 THE OTHER DIRECTION: an OFF-SITE listing’s column IS the owner', () => {
+  // The control on the fix itself. "Always take the block owner" would be a NEW inversion
+  // — an off-site listing has no OauthClient in its ownership chain, so `AppListing.userId`
+  // is canonical there and the fallback must be exact. An off-site row that nonetheless
+  // carries a block (`mapAppBlockToListing` mints exactly that shape from an AppBlock with
+  // an externalUrl) is the sharpest case: the block is present and must still not decide
+  // ownership.
+  const offsite = (over: Record<string, unknown> = {}) =>
+    liveRow({
+      kind: 'offsite',
+      userId: REAL_OWNER,
+      externalUrl: 'https://example.com/',
+      appBlockId: null,
+      appBlock: null,
+      ...over,
+    });
+
+  it('the column’s owner is admitted; a stranger is refused', async () => {
+    wireListings({ [LIVE]: offsite() });
+    await expect(
+      updateListing({ listingId: LIVE, patch: { name: 'Renamed' }, userId: REAL_OWNER })
+    ).resolves.toMatchObject({ listingId: LIVE });
+    await expect(
+      updateListing({ listingId: LIVE, patch: { name: 'Renamed' }, userId: STRANGER })
+    ).rejects.toMatchObject({ code: 'NOT_OWNED' });
+  });
+
+  it('🔴 RECORDED DISAGREEMENT (not an endorsement): offsite + a block ⇒ the BLOCK wins', async () => {
+    // 🔴 This pins what the shared resolver DOES today, and it is NOT what its own prose
+    // says. `resolveListingAccess` computes `appBlock.app.userId ?? listing.userId` —
+    // BLOCK-FIRST, with no branch on `kind`. That reads as "kind-aware" only because an
+    // ordinary off-site listing has no block, so the fallback is the only branch reached.
+    //
+    // On the one shape where the two rules differ — an OFFSITE listing that carries a
+    // block, which `mapAppBlockToListing` mints from any AppBlock with an `externalUrl`
+    // and which the mod proc `backfillAppListings` can reach — the block wins, so the
+    // listing's own `userId` does NOT decide. That matters because
+    // `app-ownership-transfer` moves ONLY the column for an offsite listing: transfer
+    // such a listing and this resolver keeps naming the OLD owner. It is the same
+    // stale-copy inversion, one shape over.
+    //
+    // 0 rows of this shape in production (measured 2026-08-11: 5 offsite listings, 0 with
+    // a block), and `resolveAccessibleAppBlockIds` already discriminates on `kind` rather
+    // than on block-nullness for exactly this reason — so the two halves of one module
+    // disagree about which discriminator is authoritative. Changing the resolver is a
+    // decision for whoever owns that call, not a side effect of consolidating five gates,
+    // so it is RECORDED here (and in the ledger's D5 note) and pinned, not silently
+    // altered. This test failing means someone changed it — read this comment first.
+    wireListings({
+      [LIVE]: offsite({ appBlockId: BLOCK, appBlock: { app: { userId: STRANGER } } }),
+    });
+    await expect(getListingAssets({ listingId: LIVE }, user(STRANGER))).resolves.toMatchObject({
+      listingId: LIVE,
+    });
+    await expect(getListingAssets({ listingId: LIVE }, user(REAL_OWNER))).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
+  });
+});

--- a/src/server/services/blocks/__tests__/app-access.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.service.test.ts
@@ -439,10 +439,13 @@ describe('resolveListingAccess — role × KIND', () => {
  *
  * For an ON-SITE listing the owner is `OauthClient.userId`, reached as
  * `AppListing.appBlock.app.userId`. `AppListing.userId` is a DENORMALIZED COPY, and this
- * feature's own code can leave it stale on purpose: `acceptTransfer` step 3 is unguarded
- * for onsite and treats a 0-count as an accepted desync
- * (`app-ownership-transfer.service.ts`), so a listing whose OauthClient moved but whose
- * column did not is a state the code can produce itself.
+ * feature's own code leaves it stale on a SHADOW REVISION: `beginListingRevision` clones
+ * the parent with `userId: parent.userId`, and no ownership write ever revisits the clone
+ * (`acceptTransfer` step 3 updates only the parent row; the revision-apply copies assets
+ * back, never `userId`). So a shadow whose parent's OauthClient moved, but whose own
+ * column did not, is a state the code produces itself. It is NOT the transfer's listing
+ * write that drifts — that one is unconditional and heals the parent; the mechanism is
+ * laid out in full in `app-access.denormalized-owner-drift.test.ts`.
  *
  * Reading the copy inverts the gate in BOTH directions at once, which is why the fixture
  * below pins both: the REAL owner is refused on their own listing, and the STALE user is

--- a/src/server/services/blocks/__tests__/app-collaborator.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator.service.test.ts
@@ -88,10 +88,25 @@ const SHADOW = 'apl_shadow';
 const OFFSITE_WITH_REPO = 'apl_offsite_with_repo';
 const OFFSITE_REPO_SLUG = 'offsite-repo';
 /**
+ * 🔴 An ON-SITE listing with NO backing AppBlock — the OTHER shape where the two clauses
+ * of `hasWritableRepo` disagree, and the mirror image of {@link OFFSITE_WITH_REPO}. Here
+ * the KIND says `submitVersion: true` and only `blockSlug != null` can refuse.
+ *
+ * It is a real row, not a hypothetical: `publish-request.service::submitVersion`'s
+ * first-version branch matches a pre-approval draft on
+ * `kind = 'onsite' AND status = 'draft' AND appBlockId IS NULL`, so an on-site listing
+ * exists without a block for the whole window before its first approval.
+ */
+const ONSITE_NO_BLOCK = 'apl_onsite_no_block';
+/**
  * 🔴 An ON-SITE listing whose denormalized `AppListing.userId` DISAGREES with its
- * canonical `OauthClient.userId`. `acceptTransfer` step 3 is deliberately unguarded for
- * onsite and treats a 0-count as an accepted desync, so this state is one the feature's
- * own code can produce.
+ * canonical `OauthClient.userId`. This state is one the feature's own code produces, via
+ * a SHADOW REVISION: `beginListingRevision` clones the column and no ownership write ever
+ * revisits the clone, so a shadow that outlives a transfer names the old owner forever.
+ * (NOT via `acceptTransfer`'s onsite listing write — that one is `where: { id }`,
+ * unconditional and in the same tx as the OauthClient move, so it heals the parent rather
+ * than drifting it. The full mechanism is in
+ * `app-access.denormalized-owner-drift.test.ts`.)
  */
 const DRIFTED = 'apl_drifted';
 const OWNER = 10;
@@ -155,6 +170,17 @@ function listingTable(): Record<string, Record<string, unknown>> {
         blockId: OFFSITE_REPO_SLUG,
         app: { userId: OWNER },
       },
+    },
+    // 🔴 onsite, but with NO block and therefore NO repo slug.
+    [ONSITE_NO_BLOCK]: {
+      id: ONSITE_NO_BLOCK,
+      slug: 'onsite-no-block-slug',
+      kind: 'onsite',
+      userId: OWNER,
+      appBlockId: null,
+      revisionOfId: null,
+      revisionOf: null,
+      appBlock: null,
     },
     // 🔴 onsite, with the canonical owner and the denormalized column DISAGREEING.
     [DRIFTED]: {
@@ -746,6 +772,71 @@ describe('🔴 Forgejo is ON-SITE ONLY — the `submitVersion: false` capability
       });
       expect(mockRepo.grantAppRepoWrite).toHaveBeenCalledWith({
         slug: OFFSITE_REPO_SLUG,
+        userId: TARGET,
+      });
+    });
+  });
+
+  /**
+   * 🔴 THE NULL-SLUG HALF — the clause the COMPILER cannot hold.
+   *
+   * `hasWritableRepo` is a type PREDICATE, and an earlier comment on it claimed that
+   * relaxing its body to a kind-only check "is a type error at every call site instead".
+   * It is not: TypeScript never checks a user-defined predicate's body against the
+   * declared predicate. Measured with `pnpm typecheck` on this tree — the relaxed body
+   * emits 0 errors; the positive control (same body, return type demoted to `boolean`)
+   * emits exactly 3 `TS2322: Type 'string | null' is not assignable to type 'string'`,
+   * one per call site.
+   *
+   * So the null half is held HERE or nowhere. Every other on-site fixture in this file
+   * carries a slug, which means both clauses agree on it and either alone satisfies it;
+   * this row is the only one that can kill a body relaxed to `listingKindSupports(...)`
+   * — the kind says `submitVersion: true`, so only `blockSlug != null` can refuse, and
+   * a mutant would call Forgejo with `null` as the repository name.
+   */
+  describe('🔴 an ON-SITE listing with NO backing block reaches Forgejo NEVER', () => {
+    it('accept grants nothing — there is no repo to grant on', async () => {
+      const res = await respondToInvite({
+        appListingId: ONSITE_NO_BLOCK,
+        userId: TARGET,
+        accept: true,
+        now: NOW,
+      });
+      expect(res.status).toBe('accepted');
+      expect(mockRepo.grantAppRepoWrite).not.toHaveBeenCalled();
+    });
+
+    it('remove revokes nothing', async () => {
+      await removeCollaborator({
+        appListingId: ONSITE_NO_BLOCK,
+        targetUserId: TARGET,
+        actorUserId: OWNER,
+      });
+      expect(mockRepo.revokeAppRepoWrite).not.toHaveBeenCalled();
+    });
+
+    it('leave revokes nothing', async () => {
+      await leaveApp({ appListingId: ONSITE_NO_BLOCK, userId: TARGET });
+      expect(mockRepo.revokeAppRepoWrite).not.toHaveBeenCalled();
+    });
+
+    it('🔴 POSITIVE CONTROL: the SAME row reaches Forgejo once it has a block', async () => {
+      // Without this, "not called" is indistinguishable from a fixture this path never
+      // reaches at all — the reassuring zero. Only the block changes here; the kind was
+      // already `onsite`, so this also proves the kind clause was never what refused.
+      LISTINGS[ONSITE_NO_BLOCK] = {
+        ...LISTINGS[ONSITE_NO_BLOCK],
+        appBlockId: 'ab_late',
+        appBlock: { appId: 'oc_late', blockId: 'late-repo', app: { userId: OWNER } },
+      };
+      await respondToInvite({
+        appListingId: ONSITE_NO_BLOCK,
+        userId: TARGET,
+        accept: true,
+        now: NOW,
+      });
+      expect(mockRepo.grantAppRepoWrite).toHaveBeenCalledWith({
+        slug: 'late-repo',
         userId: TARGET,
       });
     });

--- a/src/server/services/blocks/__tests__/app-listing-assets.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-assets.service.test.ts
@@ -941,6 +941,12 @@ describe('screenshot CRUD', () => {
   });
 
   it('removeScreenshot rejects a non-owner of the parent listing', async () => {
+    // The parent listing must be wired: ownership is decided by `loadOwnedListing`, which
+    // LOADS the listing and resolves its canonical owner. (This case used to pass off an
+    // earlier, denormalized-column copy of the same check that read `appListing.userId`
+    // straight off the screenshot row; that copy is gone — see
+    // `app-access.denormalized-owner-drift.test.ts`.)
+    mockDb.appListing.findUnique.mockResolvedValue(listingRow);
     mockDb.appListingScreenshot.findUnique.mockResolvedValue({
       id: 'b', appListingId: 'apl_1', appListing: { userId: 42 },
     });

--- a/src/server/services/blocks/__tests__/app-ownership-transfer.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-ownership-transfer.service.test.ts
@@ -113,8 +113,15 @@ const OFFSITE_WITH_REPO = 'apl_offsite_with_repo';
 const OFFSITE_REPO_SLUG = 'offsite-repo';
 /**
  * 🔴 An ON-SITE listing whose denormalized `AppListing.userId` DISAGREES with its
- * canonical `OauthClient.userId` — the state this very service's step (3) can leave
- * behind (unguarded for onsite, a 0-count is an accepted desync).
+ * canonical `OauthClient.userId`.
+ *
+ * 🔴 Step (3) does NOT leave this behind on the row it writes, despite being unguarded
+ * for onsite: `where: { id }` is unconditional, runs in the same tx as the step-(2)
+ * `OauthClient` move, and follows an in-tx read of the same row through its own FK — so
+ * it HEALS the copy. What it leaves behind is any SHADOW REVISION of that listing, which
+ * it never addresses and which froze `userId` at clone time. This fixture is the
+ * resulting state, whichever row you imagine it on. Full mechanism:
+ * `app-access.denormalized-owner-drift.test.ts`.
  */
 const DRIFTED = 'apl_drifted';
 const OLD_OWNER = 10;

--- a/src/server/services/blocks/__tests__/offsite-listing.get-my-listing-for-app.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.get-my-listing-for-app.service.test.ts
@@ -48,6 +48,11 @@ const { mockRead, mockWrite, seq } = vi.hoisted(() => {
     appListingPublishRequest: {
       findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
     },
+    // 🔴 SEATS ARE LISTING-KEYED, so every non-owner path consults this table — and since
+    // the owner half of the gate is resolved too (never compared against the
+    // denormalized AppListing.userId), the resolver is on EVERY path. Default: no seat,
+    // i.e. exactly the owner-only behaviour these cases assert.
+    appCollaborator: { findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
   });
   const mockRead = makeClient();
   const mockWrite = makeClient() as ReturnType<typeof makeClient> & {
@@ -119,7 +124,13 @@ function editViewRow(ssRowId: string, overrides: Record<string, unknown> = {}) {
  * Route `appListing.findUnique` by call shape, on BOTH pools:
  *   - `where.appBlockId`   → the entry resolve (id/userId/status/contentRating)
  *   - `select` has `icon`  → `loadListingEditView`, keyed by `where.id`
- *   - otherwise            → the owner/editable load (`beginListingRevision`)
+ *   - otherwise            → the owner/editable load (`beginListingRevision`), AND the
+ *     ownership resolve. The gate no longer compares the caller against the entry row's
+ *     denormalized `userId`; it re-reads the listing BY ID through `resolveListingAccess`
+ *     so the canonical (`appBlock.app.userId`) owner decides. `owned` therefore defaults
+ *     to `entry`: a case that does not care about the editable load still has to serve
+ *     the ownership read, and serving the same row is what "these are the same listing"
+ *     means here.
  *
  * `replicaLagsOn` makes the REPLICA miss on the given ids while the PRIMARY still
  * serves them — i.e. real replication lag, the condition that decides whether a
@@ -143,7 +154,7 @@ function wireFindUnique(opts: {
       if (isReplica && (opts.replicaLagsOn ?? []).includes(id)) return null;
       return opts.viewByListingId?.[id] ?? null;
     }
-    return opts.owned ?? null;
+    return opts.owned ?? opts.entry ?? null;
   };
   mockRead.appListing.findUnique.mockImplementation(impl(true));
   mockWrite.appListing.findUnique.mockImplementation(impl(false));
@@ -180,6 +191,8 @@ beforeEach(() => {
   mockRead.appListing.findFirst.mockResolvedValue(null);
   mockRead.appListingScreenshot.findMany.mockResolvedValue([]);
   mockRead.appListingPublishRequest.findFirst.mockResolvedValue(null);
+  mockRead.appCollaborator.findFirst.mockResolvedValue(null);
+  mockWrite.appCollaborator.findFirst.mockResolvedValue(null);
   mockWrite.appListing.findFirst.mockResolvedValue(null);
   mockWrite.appListingScreenshot.findMany.mockResolvedValue([]);
 });
@@ -505,15 +518,27 @@ describe('getMyListingForApp', () => {
 // slug fallback: the owner reaches their pending draft; ownership is still enforced.
 describe('getMyListingForApp — pre-approval DRAFT slug resolver (pending, no AppBlock)', () => {
   it('resolves the pending draft BY SLUG when only a slug is given (no appBlockId lookup)', async () => {
-    mockRead.appListing.findFirst.mockResolvedValue({
+    // 🔴 The pre-approval draft carries `appBlockId: null`, so it has no OauthClient in
+    // its ownership chain and `AppListing.userId` IS its canonical owner — the resolver's
+    // fallback. The row is served on `findUnique` too because the gate resolves the
+    // listing BY ID rather than trusting the row the slug lookup handed it.
+    const draft = {
       id: 'apl_draft',
       userId: OWNER,
+      kind: 'onsite',
+      appBlockId: null,
+      revisionOfId: null,
       status: 'draft',
       contentRating: 'g',
-    });
+    };
+    mockRead.appListing.findFirst.mockResolvedValue(draft);
     // A draft is NOT approved → no shadow revision; it is its own EFFECTIVE edit target,
     // so the edit-view assets are read straight off `apl_draft` (#3476 projection).
-    wireFindUnique({ entry: null, viewByListingId: { apl_draft: editViewRow('apls_draft') } });
+    wireFindUnique({
+      entry: null,
+      owned: draft,
+      viewByListingId: { apl_draft: editViewRow('apls_draft') },
+    });
 
     const res = await getMyListingForApp({ slug: 'my-app', userId: OWNER });
 
@@ -544,14 +569,22 @@ describe('getMyListingForApp — pre-approval DRAFT slug resolver (pending, no A
   });
 
   it('falls back to the slug draft when the appBlockId lookup misses', async () => {
-    // Entry resolve by appBlockId MISSES (no approved listing yet) → slug fallback wins.
-    wireFindUnique({ entry: null, viewByListingId: { apl_draft: editViewRow('apls_draft') } });
-    mockRead.appListing.findFirst.mockResolvedValue({
+    const draft = {
       id: 'apl_draft',
       userId: OWNER,
+      kind: 'onsite',
+      appBlockId: null,
+      revisionOfId: null,
       status: 'draft',
       contentRating: 'pg',
+    };
+    // Entry resolve by appBlockId MISSES (no approved listing yet) → slug fallback wins.
+    wireFindUnique({
+      entry: null,
+      owned: draft,
+      viewByListingId: { apl_draft: editViewRow('apls_draft') },
     });
+    mockRead.appListing.findFirst.mockResolvedValue(draft);
 
     const res = await getMyListingForApp({ appBlockId: 'maybe', slug: 'my-app', userId: OWNER });
 
@@ -561,12 +594,21 @@ describe('getMyListingForApp — pre-approval DRAFT slug resolver (pending, no A
   });
 
   it('a draft owned by ANOTHER user → NOT_OWNED (ownership still enforced on the slug path)', async () => {
-    mockRead.appListing.findFirst.mockResolvedValue({
+    // The row is wired on BOTH lookups so the refusal is attributable to OWNERSHIP. With
+    // only the slug lookup wired, the ownership resolve finds nothing and denies for
+    // "listing not found" — the right verdict for the wrong reason, which would survive a
+    // mutant that deleted the owner comparison entirely.
+    const draft = {
       id: 'apl_draft',
       userId: OTHER,
+      kind: 'onsite',
+      appBlockId: null,
+      revisionOfId: null,
       status: 'draft',
       contentRating: 'g',
-    });
+    };
+    mockRead.appListing.findFirst.mockResolvedValue(draft);
+    wireFindUnique({ entry: null, owned: draft });
 
     await expect(getMyListingForApp({ slug: 'my-app', userId: OWNER })).rejects.toMatchObject({
       name: 'OffsiteRequestError',

--- a/src/server/services/blocks/app-access.service.ts
+++ b/src/server/services/blocks/app-access.service.ts
@@ -121,28 +121,42 @@ export type ListingAccess = {
    *
    * For an ON-SITE listing ownership lives on `OauthClient.userId`, reached as
    * `AppListing.appBlock.app.userId`; `AppListing.userId` is a DENORMALIZED COPY that
-   * this feature's own code can leave stale (`acceptTransfer` step 3 is deliberately
-   * unguarded for onsite and treats a 0-count as an accepted desync). Reading the copy
-   * would hand the roster — including `displayed:false` seats, `invitedBy` and the
-   * timestamps — to whoever the stale row names, while refusing the REAL owner
-   * `NOT_OWNER` on their own app. For an OFF-SITE listing there is no OauthClient in
-   * the ownership chain, so the column IS the owner and the fallback is exact.
+   * this feature's own code can leave stale — see {@link resolveListingAccess} for the
+   * mechanism that actually does it (a SHADOW REVISION freezes the column at clone
+   * time and no ownership write ever revisits it). Reading the copy would hand the
+   * roster — including `displayed:false` seats, `invitedBy` and the timestamps — to
+   * whoever the stale row names, while refusing the REAL owner `NOT_OWNER` on their own
+   * app. For an OFF-SITE listing there is no OauthClient in the ownership chain, so the
+   * column IS the owner and the fallback is exact.
+   *
+   * 🔴 …WITH ONE MEASURED EXCEPTION TO "kind-aware", tracked as
+   * https://github.com/civitai/civitai/issues/3844. The implementation is BLOCK-FIRST
+   * (`appBlock.app.userId ?? listing.userId`) and never branches on `kind`, which reads
+   * as kind-aware only because an ordinary off-site listing has no block. On an OFF-SITE
+   * listing that DOES carry one, the block decides — and both off-site ownership writers
+   * (`acceptTransfer`'s offsite path and `claimListing`) move only the column, so this
+   * function keeps naming the OLD owner. 0 rows of that shape in production and no code
+   * path can mint one today (see the issue for the measurement). Do not fix it here; the
+   * behaviour is pinned in `app-access.denormalized-owner-drift.test.ts`.
    *
    * The same resolution is written in `app-collaborator.service::toSeatListing` and in
    * `app-ownership-transfer.service::loadOwnedListing`, the two WRITE-side seat/transfer
    * loaders; every other consumer delegates to THIS function rather than re-deriving it.
    *
-   * 🔴 WHAT THE LEDGER ACTUALLY PINS, stated exactly, because an earlier version of this
-   * sentence claimed "`app-access.call-site-ledger.test.ts` pins that every consumer
-   * agrees" and it did not — the ledger enumerates the POPULATION of gate sites, and it
-   * separately RECORDED a class of gate that read the denormalized column directly. That
-   * class is now empty for every collaborator-reachable gate, and the ledger's
-   * `DENORM_OWNER_RE` assertion is what holds it empty: it fails if a new gate compares
-   * against `AppListing.userId`, and it fails if the two remaining owner-only holdouts
-   * (`offsite-moderation.service.ts`, `app-listing-review.service.ts`, both listed there
-   * with their reasons) are fixed without updating the record. Agreement between the two
-   * write-side loaders and this function is pinned BEHAVIOURALLY instead, by
-   * `app-access.denormalized-owner-drift.test.ts` and the transfer/seat suites.
+   * 🔴 WHAT THE LEDGER ACTUALLY PINS, stated exactly, because two earlier versions of
+   * this paragraph overstated it. The ledger enumerates the POPULATION of gate sites, and
+   * it separately RECORDS a class of gate that reads the denormalized column directly.
+   * That class is now empty for every collaborator-reachable gate. But its
+   * `DENORM_OWNER_RE` assertion is a **naming-convention lint, not a structural guard**:
+   * it is anchored on the receiver name (`*listing` / `*shadow` / `<x>.appListing`), so
+   * it catches a reintroduction written in this feature's idiom — in either operand
+   * order, with optional chaining, with `!=` — and is BLIND to the same gate written
+   * against a hoisted local, a destructure, or any other variable name. Its own KNOWN
+   * EVASIONS test pins that limit as a measured fact. It also fails if the three recorded
+   * holdouts are fixed without updating the record. The claim that no gate anywhere reads
+   * the column is NOT what it holds; the behaviour is held instead by
+   * `app-access.denormalized-owner-drift.test.ts` (spelling-blind by construction) and
+   * the transfer/seat suites.
    */
   ownerUserId: number;
   /** The PARENT's kind — what the caller may do is derived from it, never from a seat. */

--- a/src/server/services/blocks/app-access.service.ts
+++ b/src/server/services/blocks/app-access.service.ts
@@ -128,8 +128,21 @@ export type ListingAccess = {
    * `NOT_OWNER` on their own app. For an OFF-SITE listing there is no OauthClient in
    * the ownership chain, so the column IS the owner and the fallback is exact.
    *
-   * This matches `toSeatListing` / `loadOwnedListing`, which already resolve it this
-   * way; `app-access.call-site-ledger.test.ts` pins that every consumer agrees.
+   * The same resolution is written in `app-collaborator.service::toSeatListing` and in
+   * `app-ownership-transfer.service::loadOwnedListing`, the two WRITE-side seat/transfer
+   * loaders; every other consumer delegates to THIS function rather than re-deriving it.
+   *
+   * 🔴 WHAT THE LEDGER ACTUALLY PINS, stated exactly, because an earlier version of this
+   * sentence claimed "`app-access.call-site-ledger.test.ts` pins that every consumer
+   * agrees" and it did not — the ledger enumerates the POPULATION of gate sites, and it
+   * separately RECORDED a class of gate that read the denormalized column directly. That
+   * class is now empty for every collaborator-reachable gate, and the ledger's
+   * `DENORM_OWNER_RE` assertion is what holds it empty: it fails if a new gate compares
+   * against `AppListing.userId`, and it fails if the two remaining owner-only holdouts
+   * (`offsite-moderation.service.ts`, `app-listing-review.service.ts`, both listed there
+   * with their reasons) are fixed without updating the record. Agreement between the two
+   * write-side loaders and this function is pinned BEHAVIOURALLY instead, by
+   * `app-access.denormalized-owner-drift.test.ts` and the transfer/seat suites.
    */
   ownerUserId: number;
   /** The PARENT's kind — what the caller may do is derived from it, never from a seat. */
@@ -507,6 +520,27 @@ export type AccessibleAppBlocks = {
  *
  * The `earnings: false` cell of {@link CAPABILITIES_BY_KIND} is the declared form of the
  * same rule; this is it expressed as a query predicate.
+ *
+ * 🔴 IT IS NOT ONLY THE MONEY PATH, AND THE JUSTIFICATION ABOVE DOES NOT COVER THE OTHER
+ * CONSUMER ON ITS OWN. `app-analytics.service::getOwnedAppBlocks` reads the SAME set, and
+ * `CAPABILITIES_BY_KIND.offsite.analytics` is `true` — so read naively, `kind: 'onsite'`
+ * narrows a capability the table grants. It does not, for two independent reasons, and
+ * BOTH are needed:
+ *   1. This set is a set of APP BLOCK ids, and every downstream analytics aggregate is
+ *      `appBlockId IN thatSet` over block-scoped series (`AppBlockView`, install counts,
+ *      the manifest). An OFFSITE listing's analytics surface is `AppListingMetric` —
+ *      connect/visit counters on the LISTING — which this set does not address at all.
+ *      An ordinary offsite listing has no block, so it contributes nothing here whatever
+ *      the kind clause says; the `analytics: true` cell is honoured on a different read.
+ *   2. The only shape the clause actually removes is the odd one: an OFFSITE listing that
+ *      HAS a backing block (`mapAppBlockToListing` + `externalUrl`). Its block-scoped
+ *      series belong to a block whose listing declares itself off-site; feeding it here
+ *      would report app-block analytics for a listing the store presents as external.
+ *      0 rows of that shape in production (same measurement as above).
+ * DECISION: the predicate is left as-is and this comment is widened to cover both
+ * consumers, rather than splitting the resolver into a money set and an analytics set.
+ * Splitting would add a second decayable set and change a live read to fix a case with
+ * no rows, no user-visible difference (see 1), and no capability actually withheld.
  */
 export async function resolveAccessibleAppBlockIds(userId: number): Promise<AccessibleAppBlocks> {
   const [owned, seats] = await Promise.all([

--- a/src/server/services/blocks/app-collaborator.service.ts
+++ b/src/server/services/blocks/app-collaborator.service.ts
@@ -236,8 +236,21 @@ function toSeatListing(row: RawSeatListing, wasShadow: boolean): SeatListing {
  * `externalUrl`, so such a listing HAS a `blockId` slug while declaring
  * `submitVersion: false`. A slug-only gate would hand that listing's collaborator
  * Forgejo `write`.
+ *
+ * 🔴 A TYPE PREDICATE, not a `boolean`, and that is load-bearing rather than cosmetic.
+ * The three call sites pass `listing.blockSlug` to a Forgejo call that requires a
+ * `string`, and they used to do it through a `!` non-null assertion justified by a
+ * comment ("safe: `hasWritableRepo` is precisely the null check"). That comment was the
+ * only thing holding the invariant: relax this function to a kind-only check — a
+ * one-token edit that looks like a simplification — and all three assertions silently
+ * start asserting something false, passing `undefined` as a repo slug. As a predicate,
+ * the compiler does the narrowing, the `!`s are gone, and that same edit is a type
+ * error at every call site instead.
  */
-function hasWritableRepo(listing: { kind: string; blockSlug: string | null }): boolean {
+function hasWritableRepo(listing: {
+  kind: string;
+  blockSlug: string | null;
+}): listing is { kind: string; blockSlug: string } {
   return listingKindSupports(listing.kind, 'submitVersion') && listing.blockSlug != null;
 }
 
@@ -503,10 +516,10 @@ export async function respondToInvite(opts: {
     });
   });
 
-  // 🔴 KIND-GATED, not slug-gated — see {@link hasWritableRepo}. The non-null assertion
-  // is safe: `hasWritableRepo` is precisely the null check.
+  // 🔴 KIND-GATED, not slug-gated — see {@link hasWritableRepo}. It is a TYPE PREDICATE,
+  // so `blockSlug` narrows to `string` here; no non-null assertion is involved.
   if (opts.accept && hasWritableRepo(listing)) {
-    await grantAppRepoWrite({ slug: listing.blockSlug!, userId: opts.userId });
+    await grantAppRepoWrite({ slug: listing.blockSlug, userId: opts.userId });
   }
 
   return { appListingId: listing.appListingId, userId: opts.userId, status: nextStatus };
@@ -547,7 +560,7 @@ export async function removeCollaborator(opts: {
   });
 
   if (removed && hasWritableRepo(listing)) {
-    await revokeAppRepoWrite({ slug: listing.blockSlug!, userId: opts.targetUserId });
+    await revokeAppRepoWrite({ slug: listing.blockSlug, userId: opts.targetUserId });
   }
   return { appListingId: listing.appListingId, userId: opts.targetUserId, removed };
 }
@@ -578,7 +591,7 @@ export async function leaveApp(opts: {
   });
 
   if (removed && hasWritableRepo(listing)) {
-    await revokeAppRepoWrite({ slug: listing.blockSlug!, userId: opts.userId });
+    await revokeAppRepoWrite({ slug: listing.blockSlug, userId: opts.userId });
   }
   return { appListingId: listing.appListingId, userId: opts.userId, removed };
 }

--- a/src/server/services/blocks/app-collaborator.service.ts
+++ b/src/server/services/blocks/app-collaborator.service.ts
@@ -237,15 +237,29 @@ function toSeatListing(row: RawSeatListing, wasShadow: boolean): SeatListing {
  * `submitVersion: false`. A slug-only gate would hand that listing's collaborator
  * Forgejo `write`.
  *
- * 🔴 A TYPE PREDICATE, not a `boolean`, and that is load-bearing rather than cosmetic.
- * The three call sites pass `listing.blockSlug` to a Forgejo call that requires a
- * `string`, and they used to do it through a `!` non-null assertion justified by a
- * comment ("safe: `hasWritableRepo` is precisely the null check"). That comment was the
- * only thing holding the invariant: relax this function to a kind-only check — a
- * one-token edit that looks like a simplification — and all three assertions silently
- * start asserting something false, passing `undefined` as a repo slug. As a predicate,
- * the compiler does the narrowing, the `!`s are gone, and that same edit is a type
- * error at every call site instead.
+ * 🔴 A TYPE PREDICATE, not a `boolean` — and here is EXACTLY what that buys, because an
+ * earlier version of this comment claimed a safety property the compiler does not
+ * provide. The three call sites pass `listing.blockSlug` to a Forgejo call that requires
+ * a `string`, and they used to do it through a `!` non-null assertion justified by a
+ * comment ("safe: `hasWritableRepo` is precisely the null check"). The predicate replaces
+ * that comment with narrowing the compiler performs, so the three `!`s are gone and the
+ * three call sites can no longer be re-written to pass a nullable slug without tsc
+ * objecting.
+ *
+ * 🔴 WHAT IT DOES **NOT** BUY: TypeScript NEVER checks a user-defined predicate's BODY
+ * against the declared predicate. Relaxing this body to a kind-only check is a silent
+ * change — measured on this tree with `pnpm typecheck`: the relaxed body emits **0**
+ * errors, while the positive control (same relaxed body, return type demoted to
+ * `boolean`) emits exactly **3** — `TS2322: Type 'string | null' is not assignable to
+ * type 'string'`, one per call site (`respondToInvite`, `removeCollaborator`,
+ * `leaveApp`) as each loses the narrowing. So the predicate is checked at its CALLERS and
+ * unchecked at its DEFINITION, and the null-slug half of this function has no
+ * compile-time guard at all.
+ *
+ * That half is therefore pinned BEHAVIOURALLY, by `app-collaborator.service.test.ts` →
+ * "🔴 an ON-SITE listing with NO backing block reaches Forgejo NEVER". That case is the
+ * only one that can kill a body relaxed to `listingKindSupports(...)` alone: every other
+ * on-site fixture has a slug, so both clauses agree and either one alone satisfies them.
  */
 function hasWritableRepo(listing: {
   kind: string;

--- a/src/server/services/blocks/app-listing-assets.service.ts
+++ b/src/server/services/blocks/app-listing-assets.service.ts
@@ -379,11 +379,22 @@ async function loadOwnedListing(
     //
     // 🔴 THE OWNER HALF IS RESOLVED, NOT COMPARED. `listing.userId` (selected above) is
     // a DENORMALIZED copy of the owner for an ON-SITE listing — the canonical owner is
-    // `AppBlock.app.userId`, and `acceptTransfer`'s onsite step 3 is deliberately
-    // unguarded (a 0-count is an accepted desync), so the copy can go stale. Comparing
-    // against it inverts this gate in BOTH directions on a drifted row: the real owner
-    // is refused FORBIDDEN on their own listing, and whoever the stale row names is let
-    // in. `resolveListingAccess` is the one place that resolution lives.
+    // `AppBlock.app.userId`. Comparing against the copy inverts this gate in BOTH
+    // directions on a drifted row: the real owner is refused FORBIDDEN on their own
+    // listing, and whoever the stale row names is let in. `resolveListingAccess` is the
+    // one place that resolution lives.
+    //
+    // 🔴 THE DRIFT COMES FROM A SHADOW REVISION, not from the transfer's listing write —
+    // an earlier version of this comment blamed the latter and was wrong.
+    // `beginListingRevision` clones the parent with `userId: parent.userId` and nothing
+    // ever revisits the clone (`acceptTransfer` step 3 updates only `{ id: <parent> }`;
+    // the revision-apply copies assets back, never `userId`), so a shadow that outlives a
+    // transfer names the OLD owner forever. That matters HERE specifically: this gate is
+    // handed a shadow id on the whole approved-listing edit flow — see
+    // `resolveOwnerAssetEditTarget`, which calls `loadOwnedListing(shadowId, user,
+    // dbWrite)` directly. The transfer's own write to the parent is unconditional and in
+    // the same transaction as the OauthClient move, so it HEALS the parent rather than
+    // drifting it.
     //
     // 🔴 `db` IS THREADED THROUGH, not dropped. An EDITOR never resolves as the owner —
     // a shadow's canonical owner is the PARENT's — so this is the ONLY branch an editor

--- a/src/server/services/blocks/app-listing-assets.service.ts
+++ b/src/server/services/blocks/app-listing-assets.service.ts
@@ -17,6 +17,9 @@ import {
   type ListingAssetKind,
 } from '~/server/schema/blocks/app-listing.schema';
 import type { SessionUser } from '~/types/session';
+// TYPE-ONLY (erased at compile time) — the runtime reach into `app-access.service` stays
+// a dynamic import (it imports this module back). See `resolveListingRole`.
+import type { AppRole } from '~/server/services/blocks/app-access.service';
 import {
   classifyStoredObjectIntegrity,
   readRecordedEtag,
@@ -332,10 +335,15 @@ export { nsfwLevelFromContentRating };
  * pre-existing and is recorded in `app-access.call-site-ledger.test.ts` rather than
  * silently normalised here.
  *
- * The collaborator half routes through `resolveListingAccess`, which is SHADOW-AWARE:
- * a shadow revision carries `appBlockId: null`, so the seat is resolved via its parent.
- * Without that, an editor would lose access to their own in-flight revision the moment
- * their first media edit minted it.
+ * 🔴 BOTH halves route through `resolveListingAccess` — the owner one too, not just the
+ * collaborator fallback. It is SHADOW-AWARE (a shadow revision carries `appBlockId: null`, so both the seat and
+ * the canonical owner are resolved via its parent; without that an editor would lose
+ * access to their own in-flight revision the moment their first media edit minted it)
+ * and it is KIND-AWARE about ownership (`appBlock.app.userId ?? listing.userId`).
+ *
+ * 🔴 THIS IS THE ONLY OWNERSHIP GATE ON THE ASSET PATH. `resolveOwnerScreenshotTarget`
+ * used to run a second, denormalized-column copy of it one line before calling this;
+ * that copy is gone.
  */
 async function loadOwnedListing(
   listingId: string,
@@ -365,17 +373,25 @@ async function loadOwnedListing(
     },
   });
   if (!listing) throw new TRPCError({ code: 'NOT_FOUND', message: 'Listing not found' });
-  if (listing.userId !== user.id && !user.isModerator) {
-    // Not the owner and not a mod — the last chance is an ACCEPTED collaborator seat.
-    // Resolved lazily so the common owner/mod path costs no extra query.
+  if (!user.isModerator) {
+    // Not a mod — the way in is an owner or an ACCEPTED collaborator ROLE, resolved
+    // canonically. Mods short-circuit first, so their path still costs no extra query.
     //
-    // 🔴 `db` IS THREADED THROUGH, not dropped. An EDITOR never takes the owner
-    // short-circuit above — a shadow's `userId` is the PARENT OWNER's — so this is the
-    // ONLY branch an editor ever reaches. Resolving it off the replica while the caller
-    // handed us `dbWrite` would re-open, as a 403, the very read-after-write hole the
-    // override exists to close for the owner's 404.
-    const editor = await isAcceptedListingEditor(listingId, user.id, db);
-    if (!editor) {
+    // 🔴 THE OWNER HALF IS RESOLVED, NOT COMPARED. `listing.userId` (selected above) is
+    // a DENORMALIZED copy of the owner for an ON-SITE listing — the canonical owner is
+    // `AppBlock.app.userId`, and `acceptTransfer`'s onsite step 3 is deliberately
+    // unguarded (a 0-count is an accepted desync), so the copy can go stale. Comparing
+    // against it inverts this gate in BOTH directions on a drifted row: the real owner
+    // is refused FORBIDDEN on their own listing, and whoever the stale row names is let
+    // in. `resolveListingAccess` is the one place that resolution lives.
+    //
+    // 🔴 `db` IS THREADED THROUGH, not dropped. An EDITOR never resolves as the owner —
+    // a shadow's canonical owner is the PARENT's — so this is the ONLY branch an editor
+    // ever reaches. Resolving it off the replica while the caller handed us `dbWrite`
+    // would re-open, as a 403, the very read-after-write hole the override exists to
+    // close for the owner's 404.
+    const role = await resolveListingRole(listingId, user.id, db);
+    if (role === null) {
       throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not own this listing' });
     }
   }
@@ -383,23 +399,25 @@ async function loadOwnedListing(
 }
 
 /**
- * True when `userId` holds an ACCEPTED collaborator seat reachable from this listing.
+ * The caller's role on this listing — `'owner'`, `'editor'`, or `null` for no access.
  *
- * Extracted so every gate in this file asks the question the SAME way (`resolveAppAccess`
- * is the single predicate; this is a thin `role === 'editor'` read of it) and so the
- * seam has one name to mock in tests.
+ * Extracted so every gate in this file asks the question the SAME way
+ * (`resolveListingAccess` is the single predicate; this is a thin read of it) and so the
+ * seam has one name to mock in tests. It answers BOTH halves: the canonical owner
+ * (kind-aware — `appBlock.app.userId ?? listing.userId`, never the denormalized column
+ * alone) and the ACCEPTED seat, in one call.
  *
  * `db` defaults to the replica and MUST be passed on by any caller that itself received
  * a pool override — see the note at the `loadOwnedListing` call site.
  */
-async function isAcceptedListingEditor(
+async function resolveListingRole(
   listingId: string,
   userId: number,
   db: typeof dbRead = dbRead
-): Promise<boolean> {
+): Promise<AppRole | null> {
   const { resolveListingAccess } = await import('~/server/services/blocks/app-access.service');
   const access = await resolveListingAccess(listingId, userId, db);
-  return access?.role === 'editor';
+  return access?.role ?? null;
 }
 
 // ---------------------------------------------------------------------------
@@ -1253,11 +1271,9 @@ async function resolveOwnerScreenshotTarget(
   screenshotId: string,
   user: SessionUser
 ): Promise<{ screenshotId: string; listing: OwnedListing }> {
-  const select = {
-    id: true,
-    appListingId: true,
-    appListing: { select: { userId: true } },
-  } as const;
+  // 🔴 The listing's `userId` is deliberately NOT selected any more — see the note on
+  // the removed early gate below.
+  const select = { id: true, appListingId: true } as const;
   // 🔴 READ-AFTER-WRITE. The replica answers first, but a MISS off the replica is NOT
   // authoritative here: once the first mutation mints the shadow, `getMyListingForApp`
   // re-projects the SHADOW's row ids from the PRIMARY, so the very next call arrives
@@ -1274,17 +1290,18 @@ async function resolveOwnerScreenshotTarget(
     shot = await dbWrite.appListingScreenshot.findUnique({ where: { id: screenshotId }, select });
   }
   if (!shot) throw new TRPCError({ code: 'NOT_FOUND', message: 'Screenshot not found' });
-  // Owner / mod / ACCEPTED collaborator (see `loadOwnedListing`). This is an EARLY
-  // check on the screenshot's own listing; `loadOwnedListing` below re-asserts it on
-  // the resolved listing row, so widening here does not weaken the second gate.
-  if (shot.appListing.userId !== user.id && !user.isModerator) {
-    // Same pool discipline as `loadOwnedListing`: `db` is whichever pool actually
-    // answered for this screenshot, and an editor only ever reaches THIS branch.
-    const editor = await isAcceptedListingEditor(shot.appListingId, user.id, db);
-    if (!editor) {
-      throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not own this listing' });
-    }
-  }
+  // 🔴 THE EARLY OWNER CHECK THAT USED TO SIT HERE IS GONE, and its removal is the point
+  // rather than a shortcut. It read `shot.appListing.userId` — the DENORMALIZED owner
+  // column — and then asked `loadOwnedListing(shot.appListingId, user, db)` the SAME
+  // question about the SAME listing on the very next line. Two spellings of one
+  // predicate is how they drift: this copy was the stale-column spelling, so on a
+  // drifted onsite listing it refused the real owner (and admitted the stale name)
+  // BEFORE the correct gate below ever ran. A redundant guard also makes a mutation
+  // kill unattributable — whichever copy you break, the other one throws the same
+  // FORBIDDEN with the same message. One gate, one line: `loadOwnedListing`.
+  //
+  // Pool discipline is unchanged: `db` is whichever pool actually answered for this
+  // screenshot, and it is handed straight to the gate that now owns the decision.
   const sourceListing = await loadOwnedListing(shot.appListingId, user, db);
   const listing = await resolveOwnerAssetEditTarget(sourceListing, user);
   if (listing.id === shot.appListingId) return { screenshotId, listing };

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -848,13 +848,32 @@ const editableListingSelect = {
  *
  * 🔴 THE WHOLE GATE, not just its collaborator half. Every author gate in this file
  * asks THIS, never `listing.userId !== userId`, because that column is a DENORMALIZED
- * copy of the owner for an ON-SITE listing (the canonical owner is the backing
- * `AppBlock.app.userId`; `acceptTransfer`'s onsite step 3 is deliberately unguarded and
- * accepts a 0-count, so the copy can go stale). Comparing against the copy inverts the
- * gate in BOTH directions on a drifted row — it refuses the real owner and admits
- * whoever the stale row names. `resolveListingAccess` resolves the owner kind-aware
- * (`appBlock.app.userId ?? listing.userId`, exact for offsite, canonical for onsite),
- * hops a shadow revision to its parent, and answers the seat question in the same call.
+ * copy of the owner for an ON-SITE listing — the canonical owner is the backing
+ * `AppBlock.app.userId`. Comparing against the copy inverts the gate in BOTH directions
+ * on a drifted row: it refuses the real owner and admits whoever the stale row names.
+ * `resolveListingAccess` resolves the owner from the block, hops a shadow revision to its
+ * parent, and answers the seat question in the same call.
+ *
+ * 🔴 WHERE THE DRIFT ACTUALLY COMES FROM — a SHADOW REVISION, and this is worth stating
+ * precisely because an earlier version of this comment named the wrong mechanism and
+ * would have sent the next maintainer to the wrong file. {@link beginListingRevision}
+ * clones the parent with `userId: parent.userId`; `acceptTransfer` step 3 updates ONLY
+ * `{ id: <the transferred listing> }` and never that listing's shadows, and
+ * {@link applyApprovedRevision} never copies `userId` back onto the parent. So a shadow
+ * that outlives a transfer keeps the OLD owner FROZEN while its parent and the
+ * `OauthClient` both name the new one. That is reachable on every path in this file that
+ * can be handed a shadow id — `updateRevisionDraft` → {@link loadOwnedEditableListing},
+ * and {@link submitListingRevision}, which takes nothing else.
+ *
+ * 🔴 NOT via `acceptTransfer`'s onsite listing write, which is what that earlier comment
+ * claimed. That write is `where: { id }` — UNCONDITIONAL, in the same transaction as the
+ * `OauthClient` move and after an in-tx read of the row through its own FK — so it HEALS
+ * the parent's copy rather than drifting it, and a 0-count there would require the row to
+ * be absent, which the pre-read precludes. There is no other in-app writer of
+ * `OauthClient.userId`. The top-level row's copy therefore has no drift mechanism at all;
+ * only clones of it do. (`getMyListingForApp` resolves its row by `appBlockId`/`slug`, so
+ * it only ever sees a parent — it goes through this helper for uniformity, not because a
+ * stale copy can reach it.)
  *
  * 🔴 IT COSTS ONE EXTRA READ ON THE OWNER PATH, deliberately. The bare comparison was
  * free for the owner because the row was already in hand — but "already in hand" is
@@ -1180,12 +1199,14 @@ export async function submitListingRevision(opts: {
   // resolveListingRole} hops to the parent, which is where both the seat and the
   // canonical owner live.
   //
-  // 🔴 A shadow is the WORST row to read `userId` off. It carries a copy of a copy:
-  // `beginListingRevision` clones with `userId: parent.userId`, which for an onsite
-  // parent is itself the denormalized copy of `AppBlock.app.userId`. So the bare
-  // equality was wrong twice over — it refused an editor on their own shadow (the
-  // clone names the parent owner, not them) AND it inherited any drift the parent's
-  // column had at clone time, frozen.
+  // 🔴 A shadow is the WORST row to read `userId` off, and it is where the drift is
+  // actually MINTED rather than merely inherited. `beginListingRevision` clones with
+  // `userId: parent.userId`, and nothing ever revisits that clone: an ownership transfer
+  // updates only the parent row (`where: { id }`), and the revision-apply copies assets
+  // back, never `userId`. So the bare equality was wrong twice over — it refused an
+  // editor on their own shadow (the clone names the parent owner, not them) AND, on any
+  // shadow that outlives a transfer of its parent, it named an owner who had already
+  // been replaced, refusing the new owner and admitting the old one.
   if ((await resolveListingRole(shadowId, userId)) === null) {
     throw new OffsiteRequestError('NOT_OWNED', 'you can only submit your own revision');
   }
@@ -1684,9 +1705,20 @@ export async function getMyListingForApp(opts: {
   }
   // Owner OR an ACCEPTED collaborator ON THE LISTING (the seat key since the re-key).
   // This is the media editor's entry read; an editor who cannot reach it cannot edit
-  // anything — and neither can the real owner of a drifted onsite listing, which is why
-  // the owner half also goes through {@link resolveListingRole} rather than the
-  // denormalized column selected above.
+  // anything. The owner half goes through {@link resolveListingRole} too, for UNIFORMITY
+  // rather than because a stale copy can reach here: this read resolves its row by
+  // `appBlockId`/`slug`, so it only ever sees a top-level parent, and a parent's copy has
+  // no drift mechanism (see {@link resolveListingRole}). One spelling of the gate across
+  // the file is the point — a second spelling is what drifts.
+  //
+  // 🟡 KNOWN, ACCEPTED: this re-reads the same row on the same pool, so a listing DELETED
+  // between the two reads reports `NOT_OWNED` instead of `NOT_FOUND` (`resolveListingAccess`
+  // returns null for a missing row, and null role is the refusal here). It is cosmetic —
+  // the caller is refused either way, no capability turns on it — and the alternative is
+  // to distinguish "no row" from "no role" in the shared resolver's return, which widens
+  // it for every caller to improve one error string on a race with a moderator delete.
+  // Written down rather than left as a puzzle for whoever next reads a NOT_OWNED in the
+  // logs for a listing that no longer exists.
   if ((await resolveListingRole(listing.id, userId)) === null) {
     throw new OffsiteRequestError('NOT_OWNED', 'you can only manage your own listings');
   }

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -33,6 +33,9 @@ import {
   assertListingMeetsFloor,
 } from '~/server/services/blocks/app-listing-assets.service';
 import { assertOffsiteListingActionable } from '~/server/services/blocks/app-listing-actionable.service';
+// TYPE-ONLY (erased at compile time) — the runtime reach into `app-access.service` stays
+// a dynamic import, so this adds nothing to the module graph. See `resolveListingRole`.
+import type { AppRole } from '~/server/services/blocks/app-access.service';
 import { computeListingProblems } from '~/server/services/blocks/listing-problems';
 import { measureUploadedImage } from '~/server/services/blocks/measure-uploaded-image';
 import { storedObjectEtagMetadata } from '~/server/services/blocks/stored-object-integrity';
@@ -841,17 +844,33 @@ const editableListingSelect = {
 } as const;
 
 /**
- * True when `userId` holds an ACCEPTED collaborator seat reachable from this listing.
+ * The caller's role on this listing — `'owner'`, `'editor'`, or `null` for no access.
+ *
+ * 🔴 THE WHOLE GATE, not just its collaborator half. Every author gate in this file
+ * asks THIS, never `listing.userId !== userId`, because that column is a DENORMALIZED
+ * copy of the owner for an ON-SITE listing (the canonical owner is the backing
+ * `AppBlock.app.userId`; `acceptTransfer`'s onsite step 3 is deliberately unguarded and
+ * accepts a 0-count, so the copy can go stale). Comparing against the copy inverts the
+ * gate in BOTH directions on a drifted row — it refuses the real owner and admits
+ * whoever the stale row names. `resolveListingAccess` resolves the owner kind-aware
+ * (`appBlock.app.userId ?? listing.userId`, exact for offsite, canonical for onsite),
+ * hops a shadow revision to its parent, and answers the seat question in the same call.
+ *
+ * 🔴 IT COSTS ONE EXTRA READ ON THE OWNER PATH, deliberately. The bare comparison was
+ * free for the owner because the row was already in hand — but "already in hand" is
+ * exactly the stale copy. These are author EDIT paths (a handful of calls per editing
+ * session), not a hot read, so correctness wins. The non-owner path costs the same as
+ * before: it already resolved through here.
  *
  * Dynamic import: `app-access.service` is small and IO-only, but keeping the import
  * inside the body matches this file's existing discipline for cross-service reach
  * (`beginListingRevision`'s import of the asset service) and keeps the module graph of
  * a plain listing read unchanged.
  */
-async function isAcceptedListingEditor(listingId: string, userId: number): Promise<boolean> {
+async function resolveListingRole(listingId: string, userId: number): Promise<AppRole | null> {
   const { resolveListingAccess } = await import('~/server/services/blocks/app-access.service');
   const access = await resolveListingAccess(listingId, userId);
-  return access?.role === 'editor';
+  return access?.role ?? null;
 }
 
 /**
@@ -865,6 +884,10 @@ async function isAcceptedListingEditor(listingId: string, userId: number): Promi
  * consolidating the predicate and is recorded in `app-access.call-site-ledger.test.ts`
  * rather than quietly normalised, because "make the mod bypass consistent" is a
  * behaviour change to the author edit path that deserves its own decision.
+ *
+ * 🔴 THE OWNER HALF IS `resolveListingRole`, NOT `listing.userId` — the row loaded here
+ * carries the DENORMALIZED copy, which is stale-able for onsite. See
+ * {@link resolveListingRole}.
  */
 async function loadOwnedEditableListing(
   listingId: string,
@@ -877,7 +900,7 @@ async function loadOwnedEditableListing(
   if (!listing) {
     throw new OffsiteRequestError('NOT_FOUND', `listing ${listingId} not found`);
   }
-  if (listing.userId !== userId && !(await isAcceptedListingEditor(listingId, userId))) {
+  if ((await resolveListingRole(listingId, userId)) === null) {
     throw new OffsiteRequestError('NOT_OWNED', 'you can only edit your own listings');
   }
   return listing;
@@ -1153,12 +1176,17 @@ export async function submitListingRevision(opts: {
   if (!shadow) {
     throw new OffsiteRequestError('NOT_FOUND', `revision draft ${shadowId} not found`);
   }
-  // Owner OR an ACCEPTED collaborator. 🔴 Note the shadow's `userId` is the PARENT
-  // OWNER's, not the editor's — `beginListingRevision` clones with
-  // `userId: parent.userId` — so an editor's own shadow reads as owned by someone
-  // else and the bare equality refused it. Submitting a new version is an explicit
-  // editor capability, so the seat check is what admits them.
-  if (shadow.userId !== userId && !(await isAcceptedListingEditor(shadowId, userId))) {
+  // Owner OR an ACCEPTED collaborator, resolved from the SHADOW id — {@link
+  // resolveListingRole} hops to the parent, which is where both the seat and the
+  // canonical owner live.
+  //
+  // 🔴 A shadow is the WORST row to read `userId` off. It carries a copy of a copy:
+  // `beginListingRevision` clones with `userId: parent.userId`, which for an onsite
+  // parent is itself the denormalized copy of `AppBlock.app.userId`. So the bare
+  // equality was wrong twice over — it refused an editor on their own shadow (the
+  // clone names the parent owner, not them) AND it inherited any drift the parent's
+  // column had at clone time, frozen.
+  if ((await resolveListingRole(shadowId, userId)) === null) {
     throw new OffsiteRequestError('NOT_OWNED', 'you can only submit your own revision');
   }
   if (shadow.revisionOfId == null || !shadow.revisionOf) {
@@ -1620,9 +1648,11 @@ export async function getMyListingForApp(opts: {
   userId: number;
 }): Promise<GetMyListingForAppResult> {
   const { appBlockId, slug, userId } = opts;
+  // 🔴 `userId` is deliberately NOT selected. Nothing below reads it any more (the gate
+  // is `resolveListingRole`), and leaving the denormalized owner column sitting next to
+  // an access check is an invitation to compare against it again.
   const entrySelect = {
     id: true,
-    userId: true,
     status: true,
     contentRating: true,
     revisionOfId: true,
@@ -1654,8 +1684,10 @@ export async function getMyListingForApp(opts: {
   }
   // Owner OR an ACCEPTED collaborator ON THE LISTING (the seat key since the re-key).
   // This is the media editor's entry read; an editor who cannot reach it cannot edit
-  // anything.
-  if (listing.userId !== userId && !(await isAcceptedListingEditor(listing.id, userId))) {
+  // anything — and neither can the real owner of a drifted onsite listing, which is why
+  // the owner half also goes through {@link resolveListingRole} rather than the
+  // denormalized column selected above.
+  if ((await resolveListingRole(listing.id, userId)) === null) {
     throw new OffsiteRequestError('NOT_OWNED', 'you can only manage your own listings');
   }
   // A pending revision REQUEST (not mere shadow existence) drives the "already


### PR DESCRIPTION
# Consolidate the listing-ownership gates onto the canonical owner

#3834 made `resolveListingAccess` resolve ownership canonically — `appBlock.app.userId ?? listing.userId` — because for an **onsite** listing the canonical owner is the `OauthClient`'s and `AppListing.userId` is a denormalized copy that can drift. Several gates were left comparing the caller against the copy.

On a drifted onsite listing such a gate is wrong in **both** directions at once: the real owner is refused (their collaborator fallback resolves them as `owner`, which is not `editor`), and whoever the stale row names walks straight through. Same inversion #3834 fixed in `listCollaborators` / `getPendingTransfer`.

## 🔴 Where the drift actually comes from — corrected

An earlier version of this PR body, and of several code comments, said the drift comes from `acceptTransfer`'s onsite listing write being "deliberately unguarded, a 0-count an accepted desync". **That was wrong**, and it pointed maintainers at the wrong file. It is corrected here and in every comment that repeated it.

`app-ownership-transfer.service.ts:465-470` writes `where: { id: transfer.appListingId }` for onsite — **unconditional**, in the same transaction as the `OauthClient` move at `:450`, and after an in-tx read of the same row through its own FK. That write **heals** the parent's copy; a 0-count there would require the row to be absent, which the pre-read precludes. And `:450` is the only in-app write to `OauthClient.userId` (the two `publish-request.service.ts` `oauthClient.update` calls touch `grants`/`allowedScopes` only). **A top-level listing row's copy has no drift mechanism at all.**

The reachable mechanism is the **SHADOW REVISION**:

- `beginListingRevision` clones the approved parent into a hidden draft with `userId: parent.userId` (offsite-listing.service.ts:1081) and `appBlockId: null`;
- `acceptTransfer` step 3 updates only `{ id: <the transferred listing> }` — never that listing's shadows — and `applyApprovedRevision` copies assets back to the parent, never `userId`;
- so a shadow that outlives a transfer keeps the OLD owner **frozen**, while its parent and the `OauthClient` both name the new one.

Four of the five gates below can be handed a shadow id and therefore see that frozen value: `loadOwnedEditableListing` (via `updateRevisionDraft`), `submitListingRevision` (which takes nothing else), `loadOwnedListing` (via `resolveOwnerAssetEditTarget`, which calls it with the shadow id directly), and `resolveOwnerScreenshotTarget`. The fifth, `getMyListingForApp`, resolves its row by `appBlockId`/`slug`, so it only ever sees a parent — it is routed through the same helper for **uniformity**, not because a stale copy can reach it. That is stated as such in the code.

**Measured state: latent, not live.** 0 drift across all 21 onsite listings in prod (2026-08-11); no onsite ownership transfer has ever run. It goes live on the first onsite transfer of a listing that has an in-flight revision draft.

## What changed

Five gates now ask `resolveListingAccess` for the whole answer (owner **and** seat), instead of comparing against the column and using the resolver only as a collaborator fallback:

| # | Site | Gate |
|---|---|---|
| 1 | `offsite-listing::loadOwnedEditableListing` | `updateListing`, `getMyListingForEdit`, `updateRevisionDraft`, `beginListingRevision` |
| 2 | `offsite-listing::submitListingRevision` | submit a shadow revision |
| 3 | `offsite-listing::getMyListingForApp` | the media editor's entry read |
| 4 | `app-listing-assets::loadOwnedListing` | every asset mutator + `getListingAssets` |
| 5 | `app-listing-assets::resolveOwnerScreenshotTarget` | **the fifth site, not in the original four** — its redundant early copy of the gate is deleted |

Both files now have one helper, `resolveListingRole` (a thin read of `resolveListingAccess`); no second implementation of ownership was written. The mod bypass in the assets file (D1) still short-circuits **first**, so a moderator pays no extra read — and that is now **asserted by call count**, not just claimed in a comment. `offsite-listing` still has **no** mod bypass (D1 preserved), and that too is now a behavioural test rather than a ledger string.

Also in this PR:

- **`hasWritableRepo` is now a type predicate** (`listing is { kind: string; blockSlug: string }`), so the three `blockSlug!` non-null assertions are gone.
  🔴 **Its justification is corrected.** The old comment claimed that relaxing the body to a kind-only check "is a type error at every call site instead". It is not — TypeScript **never** checks a user-defined predicate's body against the declared predicate. Measured with `pnpm typecheck` on this tree: the relaxed body emits **0** errors; the positive control (same relaxed body, return type demoted to `boolean`) emits exactly **3** `TS2322: Type 'string | null' is not assignable to type 'string'`, one per call site. So the predicate is checked at its **callers** and unchecked at its **definition**. The null-slug half is now pinned behaviourally by a new fixture — an ON-SITE listing with **no** backing block, the only shape that can kill a kind-only body (every other on-site fixture has a slug, so both clauses agree). Against that mutant the three new cases go red with `expected "vi.fn()" to not be called at all, but actually been called 1 times` and the recorded call is `{ slug: null, userId: 20 }`.
- **`app-access.service`'s `ownerUserId` doc** no longer claims the ledger "pins that every consumer agrees", and no longer names the wrong drift mechanism.
- **`resolveAccessibleAppBlockIds`'s `kind:'onsite'` comment now covers analytics**, not only money. **Decision: comment widened, predicate unchanged.** The set is a set of *AppBlock* ids and every analytics aggregate is `appBlockId IN thatSet` over block-scoped series; an offsite listing's analytics surface is `AppListingMetric`, which this set does not address. The only shape the clause removes is offsite-with-a-block (0 rows).
- 🟡 A known, accepted wart is written down at `getMyListingForApp`: it re-reads the same row on the same pool, so a listing deleted between the two reads reports `NOT_OWNED` rather than `NOT_FOUND`. Cosmetic — the caller is refused either way — and the alternative widens the shared resolver's return type for every caller.

## The ledger — and an honest statement of what it holds

`app-access.call-site-ledger.test.ts` gains **D5** and a third population: `DENORM_OWNER_HOLDOUTS`, with the same fails-on-GROWTH-**and**-SHRINK property. The denormalized-column class is **empty for every collaborator-reachable gate**; three non-collaborator sites remain and are recorded with their reasons (`offsite-moderation.service.ts` — same latent inversion, needs `resolveListingAccess` to accept a `Prisma.TransactionClient`; `app-listing-review.service.ts` — anti-abuse, belongs at the `listAppInsiderUserIds` seam; `publish-request.service.ts` — in the class by SHAPE, safe by CONTEXT).

🔴 **`DENORM_OWNER_RE` is a SPELLED guard, not a structural one, and the PR now says so instead of overstating it.** `app-access.service.ts` used to claim "it fails if a new gate compares against `AppListing.userId`". Measured over the whole non-test `src/` corpus, the original regex caught **2 of 11** realistic spellings of the exact D5 regression — restoring it as `if (userId !== listing.userId && (await resolveListingRole(…)) !== 'editor')` passed the entire ledger suite.

**Chosen remedy: (b) — downgrade the claim to exactly what it holds, plus the widening that is free.** Both regexes now accept either operand order, optional chaining and `!=`/`==`, which lifts coverage to **8 of 11** and changed **neither matched file set** (`GATES` stayed at 16 files; the class stayed at exactly the 3 holdouts), so it is strictly additive. Going further was **rejected with a measurement**: a pattern over an arbitrary receiver (`(?:\w+\.)*\w+\.userId <op>`) matches **127 files repo-wide and 15 under `src/server/services/blocks/` alone** — `image.userId`, `session.userId`, `client.userId`, `sub.userId` — which turns the enumerated-equality assertion into a permanently-noisy allowlist that decays on every unrelated edit, i.e. a gate people learn to click through. And it still would not see a hoisted local or a destructure.

So the ledger is documented as a **naming-convention lint**: it stops a reintroduction written in this feature's own idiom and keeps the holdout record from going stale. It is **not** a guarantee that no gate reads the column. A new `🔴 KNOWN EVASIONS` test pins the three spellings it cannot see (hoisted local, destructure, any other receiver name) as a measured fact, with a comment saying not to "fix" it by widening. The guard that actually holds the behaviour — for any spelling, because it never reads the source — is `app-access.denormalized-owner-drift.test.ts`.

## 🔴 Known regression on a currently-unmintable shape — issue #3844

`resolveListingAccess` is **block-first, not kind-branching** (`appBlock.app.userId ?? listing.userId`, no branch on `kind`). On an **offsite listing that carries a backing AppBlock**, the block decides ownership — and both off-site ownership writers move only the column (`acceptTransfer`'s step (2) is `if (isOnsite)`-guarded; `claimListing`, the mod impersonation remedy, refuses a non-offsite listing outright and writes only the column). So on that shape the ex-owner, or the impersonator a claim was meant to dispossess, keeps edit access and the rightful owner is refused.

**Pre-PR these five gates were correct on that shape.** This is a regression, not a neutral recorded disagreement, and it is now labelled as one in the code and here.

It is filed rather than fixed because it is currently **unreachable**, measured against prod 2026-08-12:

- `kind='offsite' AND app_block_id IS NOT NULL` → **0 rows**;
- **0 of 22** `app_blocks` carry an `external_url`, and a grep of `src/server` finds **no writer** of that column — every hit is a read, a projection or a test fixture. `mapAppBlockToListing` mints the shape only from an AppBlock that has one, so it is not merely 0-row, it is not mintable by any current code path.

Tracked as **https://github.com/civitai/civitai/issues/3844** with the suggested fix (branch on `kind`), referenced from the code, and pinned by the drift suite's last case so a resolver change surfaces deliberately.

## Verification

- **`app-access.denormalized-owner-drift.test.ts`** — one drifted onsite fixture, all five sites, both directions each, plus editor/stranger/mod controls, the D1 no-mod-bypass cases and an offsite control.
  **Red at `662a47f334`: 12 failed / 11 passed (23). Green at HEAD: 23 / 23.**
- **Mutation-verified with non-deletion mutants**, each killed by its own assertion:
  - `hasWritableRepo` body → kind-only: **3 failures**, all three the new no-block cases, message `expected "vi.fn()" to not be called at all, but actually been called 1 times`, recorded call `{ slug: null, userId: 20 }`. `pnpm typecheck` on the same mutant: **0 errors** (the finding above).
  - `loadOwnedEditableListing` gains an `isModerator` short-circuit (threaded from `updateListing`): **2 failures across the whole 2820-test blocks suite**, both the new D1 cases, `promise resolved "{ listingId: 'apl_live', …(3) }" instead of rejecting`. Nothing else in the suite saw it — which is exactly the gap this test closes.
  - assets `loadOwnedListing` mod bypass moved AFTER the resolve (behaviour-preserving): killed by the new call-count case, `expected "vi.fn()" to not be called at all, but actually been called 1 times`. Two collateral failures in `app-listing-assets.lazy-revision.service.test.ts` are fixture artefacts (`TypeError: Cannot read properties of undefined (reading 'findFirst')` — that suite mocks no `appCollaborator`), not a second guard on the property.
  - `DENORM_OWNER_RE` reverted to its pre-widening form: killed by the positive control, `DENORM_OWNER_RE must recognise: reversed operands`.
  - `DENORM_OWNER_RE` widened to an arbitrary receiver: killed by `🔴 KNOWN EVASIONS` with its own message, and the class assertion independently reported `expected [ …(127) ] to deeply equal [ …(3) ]` — corroborating the 127-file false-positive count quoted above.
- Blocks dir: **125 files / 2820 tests, all passing** (2810 before these fixes; +10).
- `pnpm typecheck`: **0 errors** in 78 s. Changed test files type-check separately (tsconfig excludes `__tests__`) with **0 errors in all five**; the 3 in `app-listing-assets.service.test.ts` are byte-identical at the base.
- eslint 8.57.1 over all 9 changed files (absolute paths, count read): **0 errors, 54 warnings**, every one the pre-existing `'_a' is defined but never used` mock-signature shape, none in a source file. Instrument validated against a known-bad probe (1 `Error/no-var`).
- prettier: the one **added** file is clean. Four modified files report style issues — **byte-identical set at `HEAD` before these edits**, and none of the diffs touch a line this work added, so they are left alone rather than blanket-reformatted.
