### PR TITLE
fix(home): cap one creator's share of every featured collection

### DIFF
--- a/src/components/HomeBlocks/CollectionHomeBlock.tsx
+++ b/src/components/HomeBlocks/CollectionHomeBlock.tsx
@@ -24,6 +24,7 @@ import { NextLink as Link } from '~/components/NextLink/NextLink';
 import { ImageCard } from '~/components/Cards/ImageCard';
 import { ModelCard } from '~/components/Cards/ModelCard';
 import { HomeBlockWrapper } from '~/components/HomeBlocks/HomeBlockWrapper';
+import { ITEMS_PER_ROW, useCappedItems } from '~/components/HomeBlocks/homeBlockItems';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { PostCard } from '~/components/Cards/PostCard';
 import { ArticleCard } from '~/components/Cards/ArticleCard';
@@ -59,7 +60,6 @@ export const CollectionHomeBlock = ({ showAds, ...props }: Props) => {
   );
 };
 
-const ITEMS_PER_ROW = 7;
 const CollectionHomeBlockContent = ({ homeBlockId, metadata }: Props) => {
   const { data: homeBlock, isLoading } = trpc.homeBlock.getHomeBlock.useQuery(
     { id: homeBlockId },
@@ -87,26 +87,11 @@ const CollectionHomeBlockContent = ({ homeBlockId, metadata }: Props) => {
   });
 
   const maxPerUser = metadata.collection?.maxPerUser;
-  const items = useMemo(() => {
-    const itemsToShow = ITEMS_PER_ROW * rows;
-    if (!maxPerUser) return filtered.slice(0, itemsToShow);
-
-    const perUserCount = new Map<number, number>();
-    const capped: typeof filtered = [];
-    for (const item of filtered) {
-      if (capped.length >= itemsToShow) break;
-      const userId = (item as any)?.user?.id as number | undefined;
-      if (userId == null) {
-        capped.push(item);
-        continue;
-      }
-      const count = perUserCount.get(userId) ?? 0;
-      if (count >= maxPerUser) continue;
-      perUserCount.set(userId, count + 1);
-      capped.push(item);
-    }
-    return capped;
-  }, [filtered, rows, maxPerUser]);
+  const items = useCappedItems(
+    filtered as { user?: { id: number } | null }[],
+    rows,
+    maxPerUser
+  ) as typeof filtered;
 
   // useEffect(() => console.log({ homeBlock, filtered, items }), [homeBlock, filtered, items]);
 

--- a/src/components/HomeBlocks/FeaturedCollectionsHomeBlock.tsx
+++ b/src/components/HomeBlocks/FeaturedCollectionsHomeBlock.tsx
@@ -9,6 +9,7 @@ import { useApplyHiddenPreferences } from '~/components/HiddenPreferences/useApp
 import { ImagesProvider } from '~/components/Image/Providers/ImagesProvider';
 import { ReactionSettingsProvider } from '~/components/Reaction/ReactionSettingsProvider';
 import { FeaturedCollectionHeader } from '~/components/HomeBlocks/FeaturedCollectionHeader';
+import { ITEMS_PER_ROW, useCappedItems } from '~/components/HomeBlocks/homeBlockItems';
 import { contestCollectionReactionsHidden } from '~/components/Collections/collection.utils';
 import classes from '~/components/HomeBlocks/HomeBlock.module.scss';
 import type { HomeBlockMetaSchema } from '~/server/schema/home-block.schema';
@@ -16,8 +17,6 @@ import type { PickedFeaturedCollection } from '~/server/services/home-block.serv
 import { CollectionMode } from '~/shared/utils/prisma/enums';
 import { shuffle } from '~/utils/array-helpers';
 import { trpc } from '~/utils/trpc';
-
-const ITEMS_PER_ROW = 7;
 
 type Props = { homeBlockId: number; metadata: HomeBlockMetaSchema };
 
@@ -58,13 +57,14 @@ export const FeaturedCollectionsHomeBlock = ({ homeBlockId }: Props) => {
 type SectionProps =
   | { pick: PickedFeaturedCollection; isLoading?: false }
   | {
-      pick: { collection: null; items: []; rows: number; limit: number };
+      pick: { collection: null; items: []; rows: number; limit: number; maxPerUser?: number };
       isLoading: true;
     };
 
 function FeaturedCollectionSection({ pick, isLoading }: SectionProps) {
   const { collection, items: rawItems } = pick;
   const rows = pick.rows;
+  const maxPerUser = pick.maxPerUser;
 
   const shuffled = useMemo(() => shuffle(rawItems ?? []), [rawItems]);
   const shuffledData = useMemo(() => shuffled.map((x: { data: unknown }) => x.data), [shuffled]);
@@ -76,7 +76,7 @@ function FeaturedCollectionSection({ pick, isLoading }: SectionProps) {
     data: shuffledData as any,
   });
 
-  const items = useMemo(() => filtered.slice(0, ITEMS_PER_ROW * rows), [filtered, rows]);
+  const items = useCappedItems(filtered as { user?: { id: number } | null }[], rows, maxPerUser);
 
   const title = collection?.name ?? 'Collection';
   const link = collection ? `/collections/${collection.id}` : '#';

--- a/src/components/HomeBlocks/FeedHomeBlock.tsx
+++ b/src/components/HomeBlocks/FeedHomeBlock.tsx
@@ -16,6 +16,7 @@ import { ImageCard } from '~/components/Cards/ImageCard';
 import { ModelCard } from '~/components/Cards/ModelCard';
 import { HomeBlockWrapper } from '~/components/HomeBlocks/HomeBlockWrapper';
 import { useApplyHiddenPreferences } from '~/components/HiddenPreferences/useApplyHiddenPreferences';
+import { ITEMS_PER_ROW, useCappedItems } from '~/components/HomeBlocks/homeBlockItems';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { ImagesProvider } from '~/components/Image/Providers/ImagesProvider';
 import { CustomMarkdown } from '~/components/Markdown/CustomMarkdown';
@@ -25,8 +26,6 @@ import type { FeedBlockItems } from '~/server/services/home-block.service';
 import { shuffle } from '~/utils/array-helpers';
 import { trpc } from '~/utils/trpc';
 import classes from '~/components/HomeBlocks/HomeBlock.module.scss';
-
-const ITEMS_PER_ROW = 7;
 
 type Props = { homeBlockId: number; metadata: HomeBlockMetaSchema };
 
@@ -169,34 +168,6 @@ const FeedSkeleton = ({ rows }: { rows: number }) => (
  */
 function useShuffled<T>(items: T[]) {
   return useMemo(() => shuffle([...items]), [items]);
-}
-
-/** Trim to the visible slice, capping how many items one creator can contribute. */
-function useCappedItems<T extends { id: number; user?: { id: number } }>(
-  items: T[],
-  rows: number,
-  maxPerUser?: number
-) {
-  return useMemo(() => {
-    const itemsToShow = ITEMS_PER_ROW * rows;
-    if (!maxPerUser) return items.slice(0, itemsToShow);
-
-    const perUserCount = new Map<number, number>();
-    const capped: T[] = [];
-    for (const item of items) {
-      if (capped.length >= itemsToShow) break;
-      const userId = item.user?.id;
-      if (userId == null) {
-        capped.push(item);
-        continue;
-      }
-      const count = perUserCount.get(userId) ?? 0;
-      if (count >= maxPerUser) continue;
-      perUserCount.set(userId, count + 1);
-      capped.push(item);
-    }
-    return capped;
-  }, [items, rows, maxPerUser]);
 }
 
 type GridProps<T> = { items: T; rows: number; maxPerUser?: number };

--- a/src/components/HomeBlocks/__tests__/homeBlockItems.test.ts
+++ b/src/components/HomeBlocks/__tests__/homeBlockItems.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { capPerUser } from '~/components/HomeBlocks/homeBlockItems';
+
+type Item = { id: number; user?: { id: number } | null };
+
+// Item ids start at 100 so a test can mix these with hand-built items without an id collision
+// silently making an assertion pass for the wrong item.
+const byUser = (userIds: number[]): Item[] =>
+  userIds.map((userId, index) => ({ id: 100 + index, user: { id: userId } }));
+
+describe('capPerUser', () => {
+  it('caps one creator and backfills the slice from the rest of the pool', () => {
+    // A curator's own work first in the pool — the shape Demian reported on the home page.
+    const pool = byUser([1, 1, 1, 1, 1, 2, 3, 4]);
+
+    const result = capPerUser(pool, 5, 2);
+
+    expect(result.filter((i) => i.user?.id === 1)).toHaveLength(2);
+    // Backfilled rather than left short: a naive slice-then-cap would return 2 items here.
+    expect(result).toHaveLength(5);
+    expect(result.map((i) => i.user?.id)).toEqual([1, 1, 2, 3, 4]);
+  });
+
+  it('returns fewer than the slice when the pool cannot fill it under the cap', () => {
+    const result = capPerUser(byUser([1, 1, 1, 1]), 5, 2);
+
+    expect(result).toHaveLength(2);
+  });
+
+  it('keeps items with no resolvable creator', () => {
+    const pool: Item[] = [{ id: 1 }, { id: 2, user: null }, ...byUser([1, 1, 1])];
+
+    const result = capPerUser(pool, 4, 1);
+
+    expect(result.map((i) => i.id)).toEqual([1, 2, 100]);
+  });
+
+  it('only slices when no cap is set', () => {
+    const pool = byUser([1, 1, 1, 1]);
+
+    expect(capPerUser(pool, 3)).toHaveLength(3);
+    expect(capPerUser(pool, 3, 0)).toHaveLength(3);
+  });
+
+  it('never exceeds the visible slice', () => {
+    const result = capPerUser(byUser([1, 2, 3, 4, 5, 6]), 3, 2);
+
+    expect(result).toHaveLength(3);
+  });
+});

--- a/src/components/HomeBlocks/homeBlockItems.ts
+++ b/src/components/HomeBlocks/homeBlockItems.ts
@@ -1,0 +1,48 @@
+import { useMemo } from 'react';
+
+export const ITEMS_PER_ROW = 7;
+
+type CappableItem = { user?: { id: number } | null };
+
+/**
+ * Trim to the visible slice, capping how many items one creator can contribute.
+ *
+ * Fed the whole fetched pool rather than the visible slice, so a capped-out creator's
+ * items are replaced by other creators' rather than leaving holes in the grid — which
+ * is why every caller pairs this with a fetch `limit` well above `rows * ITEMS_PER_ROW`.
+ * Items with no resolvable creator are always kept; they can't be attributed.
+ */
+export function capPerUser<T extends CappableItem>(
+  items: T[],
+  itemsToShow: number,
+  maxPerUser?: number
+) {
+  if (!maxPerUser) return items.slice(0, itemsToShow);
+
+  const perUserCount = new Map<number, number>();
+  const capped: T[] = [];
+  for (const item of items) {
+    if (capped.length >= itemsToShow) break;
+    const userId = item.user?.id;
+    if (userId == null) {
+      capped.push(item);
+      continue;
+    }
+    const count = perUserCount.get(userId) ?? 0;
+    if (count >= maxPerUser) continue;
+    perUserCount.set(userId, count + 1);
+    capped.push(item);
+  }
+  return capped;
+}
+
+export function useCappedItems<T extends CappableItem>(
+  items: T[],
+  rows: number,
+  maxPerUser?: number
+) {
+  return useMemo(
+    () => capPerUser(items, ITEMS_PER_ROW * rows, maxPerUser),
+    [items, rows, maxPerUser]
+  );
+}

--- a/src/server/schema/home-block.schema.ts
+++ b/src/server/schema/home-block.schema.ts
@@ -81,9 +81,13 @@ export const homeBlockMetaSchema = z
     cosmeticShopSection: cosmeticShopSectionSchema,
     featuredCollections: z.object({
       collectionIds: z.array(z.number()).default([]),
-      limit: z.number().int().min(1).max(50).default(8),
+      // Fetch pool per rendered collection, ceilinged at getAllCollectionItemsSchema's max.
+      limit: z.number().int().min(1).max(100).default(100),
       rows: z.number().int().min(1).max(4).default(2),
       renderCount: z.number().int().min(1).max(10).default(3),
+      // Per-curator cap inside each rendered collection, same knob Collection blocks have.
+      // 0 opts a block out; unset falls back to FEATURED_COLLECTIONS_DEFAULTS.maxPerUser.
+      maxPerUser: z.number().int().min(0).max(50).optional(),
       maxStaleDays: z.number().int().min(1).max(365).optional(),
       minRecentItems: z.number().int().min(1).max(100).optional(),
       nameSnapshots: z.record(z.string(), z.string()).default({}),

--- a/src/server/services/home-block.service.ts
+++ b/src/server/services/home-block.service.ts
@@ -191,6 +191,9 @@ export type PickedFeaturedCollection = {
   items: AsyncReturnType<typeof getCollectionItemsByCollectionId>['items'];
   rows: number;
   limit: number;
+  // Optional because a Redis entry written before this field existed still deserializes
+  // into this type; those render uncapped until the 3-minute block cache turns over.
+  maxPerUser?: number;
 };
 
 export type HomeBlockWithData = {
@@ -302,7 +305,10 @@ export const getHomeBlockData = async ({
             user,
             input: {
               collectionId: collection.id,
-              limit: input.limit || metadata.collection.limit,
+              // Whichever pool is larger. `input.limit` used to win outright, which made a
+              // block's own `limit` unreachable — so raising it to give `maxPerUser` more
+              // creators to pick from had no effect. 100 is getAllCollectionItemsSchema's max.
+              limit: Math.min(100, Math.max(input.limit ?? 0, metadata.collection.limit ?? 0)),
               browsingLevel: sfwBrowsingLevelsFlag,
               collectionTagId: metadata.collection.tagId,
             },
@@ -435,8 +441,14 @@ export const getHomeBlockData = async ({
       }
 
       // Clamp to sane bounds — metadata is mutable JSON, don't trust blindly.
-      const limit = Math.min(50, Math.max(1, input.limit || effectivePool.limit || 8));
+      // Deliberately not `input.limit`: the by-id cache path passes one fixed number for
+      // every block type, and letting it win made this block's own `limit` dead config.
+      const limit = Math.min(
+        100,
+        Math.max(1, effectivePool.limit || FEATURED_COLLECTIONS_DEFAULTS.limit)
+      );
       const rows = Math.min(4, Math.max(1, effectivePool.rows || 2));
+      const maxPerUser = effectivePool.maxPerUser ?? FEATURED_COLLECTIONS_DEFAULTS.maxPerUser;
       const renderCount = Math.min(
         10,
         Math.max(1, effectivePool.renderCount ?? 3),
@@ -468,7 +480,7 @@ export const getHomeBlockData = async ({
           // Drop picks with zero items post-SFW filter — don't render an empty grid block
           // (e.g. a curator whose collection is all R/X would show a ghost section otherwise).
           if (!input.withCoreData && result.items.length === 0) return null;
-          return { collection: col, items: result.items, rows, limit };
+          return { collection: col, items: result.items, rows, limit, maxPerUser };
         })
       );
 
@@ -653,10 +665,13 @@ export const deleteHomeBlockById = async ({
   }
 };
 
-const FEATURED_COLLECTIONS_DEFAULTS = {
-  limit: 8,
+export const FEATURED_COLLECTIONS_DEFAULTS = {
+  // The fetch pool, not the visible count (rows * 7 of these render). Sized well above the
+  // visible slice so `maxPerUser` has other creators to promote instead of leaving holes.
+  limit: 100,
   rows: 2,
   renderCount: 3,
+  maxPerUser: 2,
   title: 'Featured Collection',
 };
 
@@ -678,6 +693,7 @@ async function getOrCreateFeaturedCollectionsSystemBlock() {
           limit: FEATURED_COLLECTIONS_DEFAULTS.limit,
           rows: FEATURED_COLLECTIONS_DEFAULTS.rows,
           renderCount: FEATURED_COLLECTIONS_DEFAULTS.renderCount,
+          maxPerUser: FEATURED_COLLECTIONS_DEFAULTS.maxPerUser,
           nameSnapshots: {},
         },
       },
@@ -730,6 +746,8 @@ async function updateFeaturedPool(
       rows: metadata.featuredCollections?.rows ?? FEATURED_COLLECTIONS_DEFAULTS.rows,
       renderCount:
         metadata.featuredCollections?.renderCount ?? FEATURED_COLLECTIONS_DEFAULTS.renderCount,
+      maxPerUser:
+        metadata.featuredCollections?.maxPerUser ?? FEATURED_COLLECTIONS_DEFAULTS.maxPerUser,
       maxStaleDays: metadata.featuredCollections?.maxStaleDays,
       minRecentItems: metadata.featuredCollections?.minRecentItems,
       nameSnapshots: nextNameSnaps,


### PR DESCRIPTION
Demian reported a featured collection on the home page where five of the fourteen visible slots were the curator's own images, expecting the "max 2 per creator" rule to apply there.

## What was actually wrong

That rule only ever existed on **Collection** blocks, which read `metadata.collection.maxPerUser` (Featured Images has `maxPerUser: 2`). `FeaturedCollections` sections have neither the metadata knob nor the capping logic — `FeaturedCollectionsHomeBlock` just sliced to `rows * 7`.

Raising the fetch limit would not have fixed it on its own: with no cap, a bigger pool only changes the odds. And the limit was unreachable anyway — the by-id cache path passes one fixed `limit` (`14 * 4`) for every block type, and it won a `||` against the block's own `limit`. So `FeaturedCollections` was pinned at the old `Math.min(50, …)` clamp regardless of metadata, and Featured Images' `limit: 40` was dead config.

## Changes

- `featuredCollections.maxPerUser` in the metadata schema, default **2**, `0` opts a block out. No DB write needed to get the cap — the default applies to blocks whose metadata predates the field.
- Cap applied in the render path, via `capPerUser`/`useCappedItems` in a new `homeBlockItems.ts` now shared by Feed, Collection and FeaturedCollections blocks (Feed and Collection each carried their own copy).
- Fetch pool made reachable: featured collections use their own `limit` (default **100**), Collection blocks use whichever of the two pools is larger. Both ceilinged at 100, which is `getAllCollectionItemsSchema`'s max.

The cap is fed the whole pool, not the visible slice, so a capped-out creator's items are replaced by other creators' rather than leaving holes.

## Verification

- `pnpm run typecheck` clean (the one remaining error, a missing `@opentelemetry/context-async-hooks` in a package test, is pre-existing and unrelated).
- New unit suite `src/components/HomeBlocks/__tests__/homeBlockItems.test.ts` — 5 tests. The backfill test fails legibly on a revert to slice-then-cap (`[1,1,1,1,1]` vs `[1,1,2,3,4]`) rather than just going short.
- `pnpm run test:lint-rules` 220 passed; HomeBlocks + collection service suites 100 passed.
- Prettier + eslint clean on touched files (the 9 `no-explicit-any` warnings are pre-existing; this removes one).

## Follow-ups, not in this PR

- **One DB edit after merge**, optional and tunable: Featured Images (`HomeBlock` id 3) `collection.limit` 40 → 100, so its cap has a deeper pool too. Nothing breaks without it.
- Cache footprint: three featured collections × up to 100 items per entry instead of 50, on a 3-minute TTL. Worth a glance at the Redis entry size after this lands.
- Demian also asked whether the same image can be prevented from appearing in two featured collections at once. Not addressed here — deduping across picks would need a render order and can empty a section, so it deserves its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
