### PR TITLE
feat(users): creator card on hover for avatars, usernames and @mentions

### DIFF
--- a/src/components/AppLayout/AppHeader/UserMenu.tsx
+++ b/src/components/AppLayout/AppHeader/UserMenu.tsx
@@ -85,7 +85,7 @@ export function UserMenu() {
               ['hidden']: !currentUser,
             })}
           >
-            <UserAvatar user={creator ?? currentUser} size="md" />
+            <UserAvatar user={creator ?? currentUser} size="md" withHoverCard={false} />
             {features.buzz && currentUser && <UserBuzz pr="sm" />}
           </div>
           <Burger opened={open} className={clsx({ ['@md:hidden']: !!currentUser })} />
@@ -163,7 +163,7 @@ function UserMenuContent({ onAccountClick }: { onAccountClick: () => void }) {
       <div className="flex flex-1 flex-col overflow-y-auto overflow-x-hidden p-1 scrollbar-thin">
         {currentUser && (
           <MenuItemButton className="flex items-center justify-between" onClick={onAccountClick}>
-            <UserAvatar user={creator ?? currentUser} withUsername />
+            <UserAvatar user={creator ?? currentUser} withUsername withHoverCard={false} />
             <IconChevronRight />
           </MenuItemButton>
         )}

--- a/src/components/CommentSection/CommentSectionItem.tsx
+++ b/src/components/CommentSection/CommentSectionItem.tsx
@@ -15,6 +15,7 @@ import { LoginRedirect } from '~/components/LoginRedirect/LoginRedirect';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
 import { ReactionPicker } from '~/components/ReactionPicker/ReactionPicker';
 import { RenderHtml } from '~/components/RenderHtml/RenderHtml';
+import { UserHoverCard } from '~/components/UserAvatar/UserHoverCard';
 import { RichTextEditor } from '~/components/RichTextEditor/RichTextEditor';
 import type { EditorCommandsRef } from '~/components/RichTextEditor/RichTextEditorComponent';
 import { StickerPicker } from '~/components/Sticker/StickerPicker';
@@ -159,9 +160,16 @@ export function CommentSectionItem({ comment, modelId, onReplyClick }: Props) {
           <Stack gap={0}>
             <Group gap={8} align="center">
               {!comment.user.deletedAt ? (
-                <Text component={Link} href={`/user/${comment.user.username}`} size="sm" fw="bold">
-                  <Username {...comment.user} />
-                </Text>
+                <UserHoverCard user={comment.user}>
+                  <Text
+                    component={Link}
+                    href={`/user/${comment.user.username}`}
+                    size="sm"
+                    fw="bold"
+                  >
+                    <Username {...comment.user} />
+                  </Text>
+                </UserHoverCard>
               ) : (
                 <Username {...comment.user} />
               )}

--- a/src/components/CreatorCard/CreatorCard.tsx
+++ b/src/components/CreatorCard/CreatorCard.tsx
@@ -75,6 +75,7 @@ export function CreatorCard({
               }
               withUsername
               linkToProfile
+              withHoverCard={false}
             />
             {withActions && (
               <Group gap={8} wrap="nowrap">

--- a/src/components/CreatorCard/CreatorCardSimple.tsx
+++ b/src/components/CreatorCard/CreatorCardSimple.tsx
@@ -192,6 +192,7 @@ const CreatorCardSimpleContent = ({
                             },
                           }}
                           user={creatorWithCosmetics}
+                          withHoverCard={false}
                         />
                       </Box>
                       <Stack gap={0} ml={70} style={{ minWidth: 0 }}>

--- a/src/components/RenderHtml/RenderHtml.tsx
+++ b/src/components/RenderHtml/RenderHtml.tsx
@@ -14,6 +14,7 @@ import { useBrowsingSettings } from '~/providers/BrowserSettingsProvider';
 import { useStickerCosmetics } from '~/components/Sticker/sticker.util';
 import { STICKER_JUMBO_LIMIT, stickerMaxWidth, STICKER_SIZE } from '~/shared/utils/sticker-token';
 import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { MentionHoverCard } from '~/components/UserAvatar/MentionHoverCard';
 
 // Match host exactly or as a subdomain (e.g. "www.youtube.com"), never as a
 // substring elsewhere in the URL — `url.includes('youtube.com')` would let
@@ -98,6 +99,10 @@ export function RenderHtml({
       allowedAttributes: {
         ...DEFAULT_ALLOWED_ATTRIBUTES,
         div: ['data-youtube-video', 'data-type', 'style', 'data-consent-blocked'],
+        // Attributes are filtered against the tag a transform produced, so the
+        // mention span's data attributes are dropped once it becomes a link
+        // unless `a` allows them too. The hover card reads the user from them.
+        a: [...DEFAULT_ALLOWED_ATTRIBUTES.a, 'data-type', 'data-id', 'data-label'],
       },
       allowedStyles: allowCustomStyles
         ? {
@@ -275,6 +280,9 @@ export function RenderHtml({
   return (
     <TypographyStylesWrapper {...props} className={clsx(classes.htmlRenderer, className)}>
       <div ref={contentRef} dangerouslySetInnerHTML={{ __html: html }} />
+      {/* Not gated on `withMentions` — that prop only decides whether a mention
+          becomes a link. The span carries the user either way. */}
+      <MentionHoverCard containerRef={contentRef} />
     </TypographyStylesWrapper>
   );
 }

--- a/src/components/RichTextEditor/RenderRichText.tsx
+++ b/src/components/RichTextEditor/RenderRichText.tsx
@@ -1,7 +1,7 @@
 // import { generateJSON } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import { renderToReactElement } from '@tiptap/static-renderer';
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef } from 'react';
 import { TypographyStylesWrapper } from '~/components/TypographyStylesWrapper/TypographyStylesWrapper';
 import { TextStyleKit } from '@tiptap/extension-text-style';
 import ImageExtension from '@tiptap/extension-image';
@@ -18,6 +18,7 @@ import { StrawPollNode } from '~/components/TipTap/StrawPollNode';
 import { CustomYoutubeNode } from '~/shared/tiptap/custom-youtube-node';
 import { TimestampNode } from '~/shared/tiptap/timestamp.node';
 import { LocalTimestamp } from '~/components/LocalTimestamp/LocalTimestamp';
+import { MentionHoverCard } from '~/components/UserAvatar/MentionHoverCard';
 
 const extensions = [
   StarterKit.configure({ heading: false }),
@@ -40,6 +41,7 @@ export function RenderRichText({
   fallbackHtml?: string;
 }) {
   const { allowed } = useThirdPartyConsent();
+  const contentRef = useRef<HTMLDivElement>(null);
   const memoized = useMemo(() => {
     try {
       const el = renderToReactElement({
@@ -77,7 +79,8 @@ export function RenderRichText({
 
   return (
     <TypographyStylesWrapper className={classes.htmlRenderer}>
-      <div>{memoized.el}</div>
+      <div ref={contentRef}>{memoized.el}</div>
+      <MentionHoverCard containerRef={contentRef} />
     </TypographyStylesWrapper>
   );
 }

--- a/src/components/UserAvatar/MentionHoverCard.tsx
+++ b/src/components/UserAvatar/MentionHoverCard.tsx
@@ -2,21 +2,28 @@ import { Popover } from '@mantine/core';
 import type { RefObject } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import {
+  CREATOR_HOVER_DROPDOWN_CLASS,
+  CreatorHoverDropdown,
   HOVER_CARD_WIDTH,
+  HOVER_CARD_Z_INDEX,
+  HOVER_CLOSE_DELAY_MS,
   HOVER_DELAY_MS,
   HoverCreatorCard,
+  useHoverCapable,
+  useNestedHoverCard,
 } from '~/components/UserAvatar/UserHoverCard';
-
-// Long enough to cross the gap between the mention and the dropdown, short
-// enough that the card doesn't linger over what you moved on to read.
-const CLOSE_DELAY_MS = 150;
 
 type Mention = { userId: number | null; username: string | null; rect: DOMRect };
 
 /**
- * A mention inside rendered comment HTML resolves to `mention:<userId>`; older
- * content stored the username instead, and the link is built from `data-label`
- * either way.
+ * The user a mention element claims to be, or null if the claim can't be trusted.
+ *
+ * `data-type="mention"` is storable on a span by anyone who can post — it always
+ * has been, since the write sanitizer allows it. Styled text making that claim
+ * was harmless; a card showing a real creator's avatar, badges and stats is a
+ * credential, so a mention wrapped in a link somewhere else would let a comment
+ * vouch for someone it is not sending you to. Where there is a link, its target
+ * has to be that user's profile.
  */
 function readMention(el: HTMLElement): Omit<Mention, 'rect'> | null {
   const raw = el.getAttribute('data-id')?.replace(/^mention:/, '') ?? '';
@@ -24,7 +31,21 @@ function readMention(el: HTMLElement): Omit<Mention, 'rect'> | null {
   const userId = /^\d+$/.test(raw) ? Number(raw) : null;
   const username = label ?? (userId ? null : raw || null);
   if (!userId && !username) return null;
+
+  const anchor = el.closest('a');
+  if (anchor && !linksToProfile(anchor, label ?? username)) return null;
+
   return { userId, username };
+}
+
+function linksToProfile(anchor: HTMLAnchorElement, username: string | null) {
+  if (!username) return false;
+  try {
+    const { pathname } = new URL(anchor.getAttribute('href') ?? '', window.location.origin);
+    return decodeURIComponent(pathname).replace(/\/$/, '') === `/user/${username}`;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -40,20 +61,20 @@ export function MentionHoverCard({
 }: {
   containerRef: RefObject<HTMLElement | null>;
 }) {
+  const nested = useNestedHoverCard();
+  const hoverCapable = useHoverCapable();
+  const enabled = hoverCapable && !nested;
+
   const [mention, setMention] = useState<Mention | null>(null);
   const openTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const closeTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   useEffect(() => {
     const container = containerRef.current;
-    if (!container) return;
+    if (!container || !enabled) return;
 
     const cancelOpen = () => clearTimeout(openTimer.current);
     const cancelClose = () => clearTimeout(closeTimer.current);
-    const scheduleClose = () => {
-      cancelClose();
-      closeTimer.current = setTimeout(() => setMention(null), CLOSE_DELAY_MS);
-    };
 
     const onOver = (e: MouseEvent) => {
       const el = (e.target as HTMLElement | null)?.closest<HTMLElement>('[data-type="mention"]');
@@ -62,37 +83,50 @@ export function MentionHoverCard({
       cancelOpen();
       const parsed = readMention(el);
       if (!parsed) return;
-      openTimer.current = setTimeout(
-        () => setMention({ ...parsed, rect: el.getBoundingClientRect() }),
-        HOVER_DELAY_MS
-      );
+      openTimer.current = setTimeout(() => {
+        // The container swaps its whole innerHTML when the html prop changes, so
+        // the element captured a delay ago may be detached — and a detached
+        // element measures as all zeros, which would pin the card to the corner
+        // of the viewport.
+        if (!el.isConnected) return;
+        setMention({ ...parsed, rect: el.getBoundingClientRect() });
+      }, HOVER_DELAY_MS);
     };
 
     const onOut = (e: MouseEvent) => {
       const el = (e.target as HTMLElement | null)?.closest('[data-type="mention"]');
       if (!el) return;
       cancelOpen();
-      scheduleClose();
+      cancelClose();
+      closeTimer.current = setTimeout(() => setMention(null), HOVER_CLOSE_DELAY_MS);
     };
 
     container.addEventListener('mouseover', onOver);
     container.addEventListener('mouseout', onOut);
-    // The anchor is a fixed-position box over the mention, so it goes stale the
-    // moment the page moves under it. Closing beats chasing the rect.
-    const onScroll = () => {
-      cancelOpen();
-      setMention(null);
-    };
-    window.addEventListener('scroll', onScroll, true);
 
     return () => {
       container.removeEventListener('mouseover', onOver);
       container.removeEventListener('mouseout', onOut);
-      window.removeEventListener('scroll', onScroll, true);
       cancelOpen();
       cancelClose();
     };
-  }, [containerRef]);
+  }, [containerRef, enabled]);
+
+  // Only while a card is open: the anchor is a fixed box over the mention, so it
+  // goes stale the moment the page moves under it, and closing beats chasing the
+  // rect. Subscribing unconditionally would put one capture-phase window
+  // listener per rendered comment on every scroll frame.
+  useEffect(() => {
+    if (!mention) return;
+    const onScroll = (e: Event) => {
+      // Scrolling inside the card itself shouldn't dismiss it.
+      if (e.target instanceof Element && e.target.closest(`.${CREATOR_HOVER_DROPDOWN_CLASS}`))
+        return;
+      setMention(null);
+    };
+    window.addEventListener('scroll', onScroll, true);
+    return () => window.removeEventListener('scroll', onScroll, true);
+  }, [mention]);
 
   if (!mention) return null;
 
@@ -101,10 +135,15 @@ export function MentionHoverCard({
   return (
     <Popover
       opened
+      // Controlled, so Mantine's own dismissals (outside click, Escape) come
+      // back through here rather than being swallowed.
+      onChange={(opened) => !opened && setMention(null)}
       width={HOVER_CARD_WIDTH}
       shadow="sm"
       withArrow
       withinPortal
+      withRoles={false}
+      zIndex={HOVER_CARD_Z_INDEX}
       position="bottom-start"
       offset={4}
     >
@@ -114,14 +153,13 @@ export function MentionHoverCard({
           style={{ left: rect.left, top: rect.top, width: rect.width, height: rect.height }}
         />
       </Popover.Target>
-      <Popover.Dropdown
-        p={0}
-        className="overflow-hidden"
+      <CreatorHoverDropdown
+        component={Popover.Dropdown}
         onMouseEnter={() => clearTimeout(closeTimer.current)}
         onMouseLeave={() => setMention(null)}
       >
         <HoverCreatorCard userId={mention.userId} username={mention.username} />
-      </Popover.Dropdown>
+      </CreatorHoverDropdown>
     </Popover>
   );
 }

--- a/src/components/UserAvatar/MentionHoverCard.tsx
+++ b/src/components/UserAvatar/MentionHoverCard.tsx
@@ -1,0 +1,127 @@
+import { Popover } from '@mantine/core';
+import type { RefObject } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import {
+  HOVER_CARD_WIDTH,
+  HOVER_DELAY_MS,
+  HoverCreatorCard,
+} from '~/components/UserAvatar/UserHoverCard';
+
+// Long enough to cross the gap between the mention and the dropdown, short
+// enough that the card doesn't linger over what you moved on to read.
+const CLOSE_DELAY_MS = 150;
+
+type Mention = { userId: number | null; username: string | null; rect: DOMRect };
+
+/**
+ * A mention inside rendered comment HTML resolves to `mention:<userId>`; older
+ * content stored the username instead, and the link is built from `data-label`
+ * either way.
+ */
+function readMention(el: HTMLElement): Omit<Mention, 'rect'> | null {
+  const raw = el.getAttribute('data-id')?.replace(/^mention:/, '') ?? '';
+  const label = el.getAttribute('data-label');
+  const userId = /^\d+$/.test(raw) ? Number(raw) : null;
+  const username = label ?? (userId ? null : raw || null);
+  if (!userId && !username) return null;
+  return { userId, username };
+}
+
+/**
+ * Creator cards for @mentions in rendered HTML.
+ *
+ * The mentions are markup inside `dangerouslySetInnerHTML`, not React nodes, so
+ * there is nothing to wrap in a `HoverCard`. Hover is delegated from the
+ * container instead and the card is anchored to a zero-size element parked over
+ * the mention's bounding box.
+ */
+export function MentionHoverCard({
+  containerRef,
+}: {
+  containerRef: RefObject<HTMLElement | null>;
+}) {
+  const [mention, setMention] = useState<Mention | null>(null);
+  const openTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const cancelOpen = () => clearTimeout(openTimer.current);
+    const cancelClose = () => clearTimeout(closeTimer.current);
+    const scheduleClose = () => {
+      cancelClose();
+      closeTimer.current = setTimeout(() => setMention(null), CLOSE_DELAY_MS);
+    };
+
+    const onOver = (e: MouseEvent) => {
+      const el = (e.target as HTMLElement | null)?.closest<HTMLElement>('[data-type="mention"]');
+      if (!el) return;
+      cancelClose();
+      cancelOpen();
+      const parsed = readMention(el);
+      if (!parsed) return;
+      openTimer.current = setTimeout(
+        () => setMention({ ...parsed, rect: el.getBoundingClientRect() }),
+        HOVER_DELAY_MS
+      );
+    };
+
+    const onOut = (e: MouseEvent) => {
+      const el = (e.target as HTMLElement | null)?.closest('[data-type="mention"]');
+      if (!el) return;
+      cancelOpen();
+      scheduleClose();
+    };
+
+    container.addEventListener('mouseover', onOver);
+    container.addEventListener('mouseout', onOut);
+    // The anchor is a fixed-position box over the mention, so it goes stale the
+    // moment the page moves under it. Closing beats chasing the rect.
+    const onScroll = () => {
+      cancelOpen();
+      setMention(null);
+    };
+    window.addEventListener('scroll', onScroll, true);
+
+    return () => {
+      container.removeEventListener('mouseover', onOver);
+      container.removeEventListener('mouseout', onOut);
+      window.removeEventListener('scroll', onScroll, true);
+      cancelOpen();
+      cancelClose();
+    };
+  }, [containerRef]);
+
+  if (!mention) return null;
+
+  const { rect } = mention;
+
+  return (
+    <Popover
+      opened
+      width={HOVER_CARD_WIDTH}
+      shadow="sm"
+      withArrow
+      withinPortal
+      position="bottom-start"
+      offset={4}
+    >
+      <Popover.Target>
+        <div
+          className="pointer-events-none fixed"
+          style={{ left: rect.left, top: rect.top, width: rect.width, height: rect.height }}
+        />
+      </Popover.Target>
+      <Popover.Dropdown
+        p={0}
+        className="overflow-hidden"
+        onMouseEnter={() => clearTimeout(closeTimer.current)}
+        onMouseLeave={() => setMention(null)}
+      >
+        <HoverCreatorCard userId={mention.userId} username={mention.username} />
+      </Popover.Dropdown>
+    </Popover>
+  );
+}

--- a/src/components/UserAvatar/MentionHoverCard.tsx
+++ b/src/components/UserAvatar/MentionHoverCard.tsx
@@ -13,7 +13,12 @@ import {
   useNestedHoverCard,
 } from '~/components/UserAvatar/UserHoverCard';
 
-type Mention = { userId: number | null; username: string | null; rect: DOMRect };
+type Mention = {
+  userId: number | null;
+  username: string | null;
+  linked: boolean;
+  rect: DOMRect;
+};
 
 /**
  * The user a mention element claims to be, or null if the claim can't be trusted.
@@ -26,23 +31,39 @@ type Mention = { userId: number | null; username: string | null; rect: DOMRect }
  * has to be that user's profile.
  */
 function readMention(el: HTMLElement): Omit<Mention, 'rect'> | null {
-  const raw = el.getAttribute('data-id')?.replace(/^mention:/, '') ?? '';
+  const idAttr = el.getAttribute('data-id') ?? '';
+  const raw = idAttr.replace(/^mention:/, '');
   const label = el.getAttribute('data-label');
   const userId = /^\d+$/.test(raw) ? Number(raw) : null;
   const username = label ?? (userId ? null : raw || null);
   if (!userId && !username) return null;
 
-  const anchor = el.closest('a');
-  if (anchor && !linksToProfile(anchor, label ?? username)) return null;
+  // `closest` walks ancestors only, so a link *inside* the mention would never
+  // be checked — and the renderer never produces one.
+  if (el.querySelector('a')) return null;
 
-  return { userId, username };
+  const anchor = el.closest('a');
+  // The profile the renderer would have linked to. `data-label` is what it uses
+  // when present, falling back to the raw id attribute — so a mention stored
+  // without a label still validates instead of silently losing its card.
+  if (anchor && !linksToProfile(anchor, label ?? idAttr)) return null;
+
+  return { userId, username, linked: !!anchor };
 }
 
-function linksToProfile(anchor: HTMLAnchorElement, username: string | null) {
-  if (!username) return false;
+/**
+ * Same-origin and same profile. Comparing only the path would accept
+ * `https://evil.example/user/Justin`, which is the whole attack.
+ */
+function linksToProfile(anchor: HTMLAnchorElement, expected: string) {
   try {
-    const { pathname } = new URL(anchor.getAttribute('href') ?? '', window.location.origin);
-    return decodeURIComponent(pathname).replace(/\/$/, '') === `/user/${username}`;
+    const url = new URL(anchor.getAttribute('href') ?? '', window.location.href);
+    if (url.origin !== window.location.origin) return false;
+    // Usernames resolve case-insensitively, so a link that works must pass.
+    return (
+      decodeURIComponent(url.pathname).replace(/\/$/, '').toLowerCase() ===
+      `/user/${expected}`.toLowerCase()
+    );
   } catch {
     return false;
   }
@@ -124,8 +145,17 @@ export function MentionHoverCard({
         return;
       setMention(null);
     };
+    // Mantine's own Escape handling is a React prop on the dropdown, which only
+    // sees keys pressed inside it — and nothing ever focuses a hover card.
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setMention(null);
+    };
     window.addEventListener('scroll', onScroll, true);
-    return () => window.removeEventListener('scroll', onScroll, true);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      window.removeEventListener('scroll', onScroll, true);
+      document.removeEventListener('keydown', onKeyDown);
+    };
   }, [mention]);
 
   if (!mention) return null;
@@ -158,7 +188,15 @@ export function MentionHoverCard({
         onMouseEnter={() => clearTimeout(closeTimer.current)}
         onMouseLeave={() => setMention(null)}
       >
-        <HoverCreatorCard userId={mention.userId} username={mention.username} />
+        <HoverCreatorCard
+          userId={mention.userId}
+          username={mention.username}
+          // The href was validated against the label, but the card is keyed on
+          // the id — independent attributes, so they can disagree. A link and a
+          // card that name different people is the same borrowed identity in a
+          // quieter form.
+          expectUsername={mention.linked ? mention.username : undefined}
+        />
       </CreatorHoverDropdown>
     </Popover>
   );

--- a/src/components/UserAvatar/UserAvatar.tsx
+++ b/src/components/UserAvatar/UserAvatar.tsx
@@ -34,6 +34,7 @@ import { NextLink as Link } from '~/components/NextLink/NextLink';
 import { useBrowsingLevelDebounced } from '~/components/BrowsingLevel/BrowsingLevelProvider';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { decorationFrameStyle } from '~/components/UserAvatar/decoration-frame.util';
+import { UserHoverCard } from '~/components/UserAvatar/UserHoverCard';
 import { isBlobUrl } from '~/utils/type-guards';
 
 const mapAvatarTextSize: Record<MantineSize, { textSize: MantineSize; subTextSize: MantineSize }> =
@@ -98,6 +99,7 @@ export function UserAvatar({
   badgeSize,
   withDecorations = true,
   withOverlay = false,
+  withHoverCard = true,
   className,
 }: Props) {
   const theme = useMantineTheme();
@@ -159,7 +161,7 @@ export function UserAvatar({
           ?.cosmetic as Omit<ContentDecorationCosmetic, 'description' | 'obtainedAt' | 'name'>)
       : undefined;
 
-  return (
+  const content = (
     <Group
       className={className}
       align="center"
@@ -273,6 +275,10 @@ export function UserAvatar({
       ) : null}
     </Group>
   );
+
+  if (!withHoverCard) return content;
+
+  return <UserHoverCard user={avatarUser}>{content}</UserHoverCard>;
 }
 
 type Props = {
@@ -296,6 +302,7 @@ type Props = {
   badgeSize?: number;
   withDecorations?: boolean;
   withOverlay?: boolean;
+  withHoverCard?: boolean;
   className?: string;
 };
 

--- a/src/components/UserAvatar/UserAvatarSimple.tsx
+++ b/src/components/UserAvatar/UserAvatarSimple.tsx
@@ -20,6 +20,7 @@ import { Flags } from '~/shared/utils/flags';
 import { getInitials } from '~/utils/string-helpers';
 import classes from './UserAvatarSimple.module.scss';
 import { decorationFrameStyle } from '~/components/UserAvatar/decoration-frame.util';
+import { UserHoverCard } from '~/components/UserAvatar/UserHoverCard';
 import { useBrowsingSettings } from '~/providers/BrowserSettingsProvider';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 
@@ -62,76 +63,78 @@ export function UserAvatarSimple({
   const anim = !autoplayGifs || autoplayAnimations === false ? false : undefined;
 
   return (
-    <UnstyledButton
-      onClick={() => router.push(username ? `/user/${username}` : `/user?id=${id}`)}
-      className="flex w-fit items-center gap-2"
-    >
-      {displayProfilePicture && (
-        <div className="relative ">
-          <div className="flex size-8 items-center justify-center overflow-hidden rounded-full bg-white/30 dark:bg-black/30">
-            {profilePicture &&
-            (!features.canViewNsfw
-              ? currentUser
-                ? hasSafeBrowsingLevel(profilePicture.nsfwLevel)
-                : hasPublicBrowsingLevel(profilePicture.nsfwLevel)
-              : Flags.hasFlag(browsingLevel, profilePicture.nsfwLevel)) ? (
-              <UserAvatarProfilePicture id={id} username={username} image={profilePicture} />
-            ) : (
-              <span className="text-sm font-semibold text-dark-8 dark:text-gray-0">
-                {username ? getInitials(username) : <IconUser size={32} />}
-              </span>
+    <UserHoverCard user={{ id, deletedAt }}>
+      <UnstyledButton
+        onClick={() => router.push(username ? `/user/${username}` : `/user?id=${id}`)}
+        className="flex w-fit items-center gap-2"
+      >
+        {displayProfilePicture && (
+          <div className="relative ">
+            <div className="flex size-8 items-center justify-center overflow-hidden rounded-full bg-white/30 dark:bg-black/30">
+              {profilePicture &&
+              (!features.canViewNsfw
+                ? currentUser
+                  ? hasSafeBrowsingLevel(profilePicture.nsfwLevel)
+                  : hasPublicBrowsingLevel(profilePicture.nsfwLevel)
+                : Flags.hasFlag(browsingLevel, profilePicture.nsfwLevel)) ? (
+                <UserAvatarProfilePicture id={id} username={username} image={profilePicture} />
+              ) : (
+                <span className="text-sm font-semibold text-dark-8 dark:text-gray-0">
+                  {username ? getInitials(username) : <IconUser size={32} />}
+                </span>
+              )}
+            </div>
+
+            {decoration && decoration.data.url && (
+              <EdgeMedia
+                src={decoration.data.url}
+                anim={anim}
+                // original={anim === false ? false : undefined}
+                type="image"
+                name="user avatar decoration"
+                alt=""
+                className="z-[2]"
+                loading="lazy"
+                style={decorationFrameStyle(decoration.data)}
+                optimized
+                width={96}
+                original={false}
+              />
             )}
           </div>
-
-          {decoration && decoration.data.url && (
-            <EdgeMedia
-              src={decoration.data.url}
-              anim={anim}
-              // original={anim === false ? false : undefined}
-              type="image"
-              name="user avatar decoration"
-              alt=""
-              className="z-[2]"
-              loading="lazy"
-              style={decorationFrameStyle(decoration.data)}
-              optimized
-              width={96}
-              original={false}
-            />
-          )}
-        </div>
-      )}
-      {deletedAt ? (
-        <Text size="sm">[deleted]</Text>
-      ) : (
-        <>
-          <Text
-            size="sm"
-            fw={500}
-            lineClamp={1}
-            color="white"
-            className={classes.username}
-            {...additionalTextProps}
-          >
-            {username}
-          </Text>
-          {badge?.data.url && (
-            <Tooltip label={badge.name} withArrow withinPortal>
-              <div style={{ display: 'flex', width: 28 }}>
-                <EdgeMedia
-                  src={badge.data.url}
-                  anim={badge.data.animated && anim}
-                  original={false}
-                  alt={badge.name}
-                  optimized
-                  loading="lazy"
-                  width={96}
-                />
-              </div>
-            </Tooltip>
-          )}
-        </>
-      )}
-    </UnstyledButton>
+        )}
+        {deletedAt ? (
+          <Text size="sm">[deleted]</Text>
+        ) : (
+          <>
+            <Text
+              size="sm"
+              fw={500}
+              lineClamp={1}
+              color="white"
+              className={classes.username}
+              {...additionalTextProps}
+            >
+              {username}
+            </Text>
+            {badge?.data.url && (
+              <Tooltip label={badge.name} withArrow withinPortal>
+                <div style={{ display: 'flex', width: 28 }}>
+                  <EdgeMedia
+                    src={badge.data.url}
+                    anim={badge.data.animated && anim}
+                    original={false}
+                    alt={badge.name}
+                    optimized
+                    loading="lazy"
+                    width={96}
+                  />
+                </div>
+              </Tooltip>
+            )}
+          </>
+        )}
+      </UnstyledButton>
+    </UserHoverCard>
   );
 }

--- a/src/components/UserAvatar/UserAvatarSimple.tsx
+++ b/src/components/UserAvatar/UserAvatarSimple.tsx
@@ -31,6 +31,7 @@ export function UserAvatarSimple({
   deletedAt,
   cosmetics,
   autoplayAnimations,
+  withHoverCard = true,
 }: {
   id: number;
   profilePicture?: ProfileImage | null;
@@ -38,6 +39,7 @@ export function UserAvatarSimple({
   deletedAt?: Date | null;
   cosmetics?: UserWithCosmetics['cosmetics'] | null;
   autoplayAnimations?: boolean;
+  withHoverCard?: boolean;
 }) {
   const features = useFeatureFlags();
   const currentUser = useCurrentUser();
@@ -63,7 +65,7 @@ export function UserAvatarSimple({
   const anim = !autoplayGifs || autoplayAnimations === false ? false : undefined;
 
   return (
-    <UserHoverCard user={{ id, deletedAt }}>
+    <UserHoverCard user={{ id, deletedAt }} disabled={!withHoverCard}>
       <UnstyledButton
         onClick={() => router.push(username ? `/user/${username}` : `/user?id=${id}`)}
         className="flex w-fit items-center gap-2"

--- a/src/components/UserAvatar/UserHoverCard.tsx
+++ b/src/components/UserAvatar/UserHoverCard.tsx
@@ -2,7 +2,7 @@ import type { Popover } from '@mantine/core';
 import { HoverCard, Skeleton, Stack, Text } from '@mantine/core';
 import dynamic from 'next/dynamic';
 import type { ReactElement, ReactNode } from 'react';
-import { createContext, useContext, useEffect, useState } from 'react';
+import { createContext, useContext, useSyncExternalStore } from 'react';
 import type { UserWithCosmetics } from '~/server/selectors/user.selector';
 import { trpc } from '~/utils/trpc';
 
@@ -38,21 +38,31 @@ const NestedContext = createContext(false);
 /** Suppresses hover cards inside a hover card. Read by `UserHoverCard`. */
 export const useNestedHoverCard = () => useContext(NestedContext);
 
+let hoverQuery: MediaQueryList | undefined;
+const getHoverQuery = () => {
+  hoverQuery ??= window.matchMedia('(hover: hover) and (pointer: fine)');
+  return hoverQuery;
+};
+
+// One MediaQueryList and one subscription for the whole page, not one per
+// avatar — a feed renders these by the hundred.
+const subscribeHover = (onChange: () => void) => {
+  const query = getHoverQuery();
+  query.addEventListener('change', onChange);
+  return () => query.removeEventListener('change', onChange);
+};
+
 /**
  * Hover cards are for pointers that hover. A touch tap synthesises `mouseover`
  * with no reliable `mouseout`, so on a phone the card opens on a tap meant for
  * the link underneath and then has no gesture that dismisses it.
  */
 export function useHoverCapable() {
-  const [capable, setCapable] = useState(false);
-  useEffect(() => {
-    const query = window.matchMedia('(hover: hover) and (pointer: fine)');
-    setCapable(query.matches);
-    const onChange = (e: MediaQueryListEvent) => setCapable(e.matches);
-    query.addEventListener('change', onChange);
-    return () => query.removeEventListener('change', onChange);
-  }, []);
-  return capable;
+  return useSyncExternalStore(
+    subscribeHover,
+    () => getHoverQuery().matches,
+    () => false
+  );
 }
 
 /**
@@ -143,18 +153,29 @@ export function CreatorHoverDropdown({
 export function HoverCreatorCard({
   userId,
   username,
+  expectUsername,
 }: {
   userId?: number | null;
   username?: string | null;
+  /**
+   * Refuse to show a creator other than this one. Set where the identity that
+   * was verified (a mention's link target) isn't the one the query is keyed on.
+   */
+  expectUsername?: string | null;
 }) {
   const { data, isLoading, isError } = trpc.user.getCreator.useQuery(
     userId ? { id: userId } : { username: username as string },
     { enabled: !!userId || !!username, staleTime: 5 * 60_000 }
   );
 
+  const mismatched =
+    !!expectUsername &&
+    !!data?.username &&
+    data.username.toLowerCase() !== expectUsername.toLowerCase();
+
   // Falling through on failure would show the zeroed `[deleted]` card the
   // skeleton exists to hide, which reads as an answer rather than a failure.
-  if (isError || (!isLoading && !userId && !data))
+  if (isError || mismatched || (!isLoading && !userId && !data))
     return (
       <Text size="sm" c="dimmed" p="md">
         Couldn&apos;t load this creator.

--- a/src/components/UserAvatar/UserHoverCard.tsx
+++ b/src/components/UserAvatar/UserHoverCard.tsx
@@ -1,0 +1,115 @@
+import { HoverCard, Skeleton, Stack } from '@mantine/core';
+import dynamic from 'next/dynamic';
+import type { ReactElement } from 'react';
+import { createContext, useContext } from 'react';
+import type { UserWithCosmetics } from '~/server/selectors/user.selector';
+import { trpc } from '~/utils/trpc';
+
+// Loaded with the hover, not with the page. The creator card drags in profile
+// cosmetics, live metrics and edge media, and a feed renders dozens of avatars
+// that nobody hovers.
+const SmartCreatorCard = dynamic(() =>
+  import('~/components/CreatorCard/CreatorCard').then((m) => m.SmartCreatorCard)
+);
+
+/**
+ * Wide enough that the creator card's top row never wraps — rank badge, up to
+ * three stat badges and the cosmetic badge need about 385px. Matches the width
+ * the sticker placement hover card settled on.
+ */
+export const HOVER_CARD_WIDTH = 400;
+
+export const HOVER_DELAY_MS = 500;
+
+const NestedContext = createContext(false);
+
+/**
+ * Peek at a creator without leaving the page.
+ *
+ * The dropdown suppresses hover cards rendered inside it, because the creator
+ * card renders a `UserAvatar` of its own and would otherwise offer to open the
+ * same card again on top of itself.
+ */
+export function UserHoverCard({
+  user,
+  children,
+}: {
+  user: Pick<Partial<UserWithCosmetics>, 'id' | 'deletedAt'>;
+  children: ReactElement;
+}) {
+  const nested = useContext(NestedContext);
+  const userId = user.id;
+
+  if (nested || !userId || userId < 1 || !!user.deletedAt) return children;
+
+  return (
+    <HoverCard
+      width={HOVER_CARD_WIDTH}
+      shadow="sm"
+      withArrow
+      withinPortal
+      openDelay={HOVER_DELAY_MS}
+      closeDelay={100}
+      position="bottom-start"
+      offset={4}
+    >
+      <HoverCard.Target>{children}</HoverCard.Target>
+      {/* The creator card carries its own padding and fills the dropdown edge to
+          edge. Its border is dropped rather than the dropdown's, so there is one
+          outline instead of two nested ones a pixel apart. */}
+      <HoverCard.Dropdown p={0} className="overflow-hidden">
+        <NestedContext.Provider value={true}>
+          <HoverCreatorCard userId={userId} />
+        </NestedContext.Provider>
+      </HoverCard.Dropdown>
+    </HoverCard>
+  );
+}
+
+/**
+ * The creator card with its empty state held back.
+ *
+ * Given only an id it renders zeroed stats and a `[deleted]` name until its own
+ * `getCreator` query lands — fine on a page, wrong in a dropdown that opens
+ * already populated. This runs the same query first (so the card's is a cache
+ * hit) and shows the card only once there is something to show.
+ *
+ * A username-only mention costs the id lookup here too.
+ */
+export function HoverCreatorCard({
+  userId,
+  username,
+}: {
+  userId?: number | null;
+  username?: string | null;
+}) {
+  const { data, isLoading } = trpc.user.getCreator.useQuery(
+    userId ? { id: userId } : { username: username as string },
+    { enabled: !!userId || !!username, staleTime: 5 * 60_000 }
+  );
+
+  const id = userId ?? data?.id;
+  if (isLoading || !id) return <CreatorCardSkeleton />;
+
+  return <SmartCreatorCard user={{ id }} withBorder={false} />;
+}
+
+/**
+ * Shaped like the card it stands in for — banner, avatar, name, stat row — so
+ * the dropdown doesn't resize under the cursor when the data lands, which on a
+ * hover card can move the target out from under you.
+ */
+function CreatorCardSkeleton() {
+  return (
+    <Stack gap={0}>
+      <Skeleton height={80} radius={0} />
+      <div className="flex items-center gap-3 p-3">
+        <Skeleton height={60} circle />
+        <Stack gap={6} className="flex-1">
+          <Skeleton height={14} width="55%" />
+          <Skeleton height={10} width="35%" />
+        </Stack>
+      </div>
+    </Stack>
+  );
+}

--- a/src/components/UserAvatar/UserHoverCard.tsx
+++ b/src/components/UserAvatar/UserHoverCard.tsx
@@ -1,7 +1,8 @@
-import { HoverCard, Skeleton, Stack } from '@mantine/core';
+import type { Popover } from '@mantine/core';
+import { HoverCard, Skeleton, Stack, Text } from '@mantine/core';
 import dynamic from 'next/dynamic';
-import type { ReactElement } from 'react';
-import { createContext, useContext } from 'react';
+import type { ReactElement, ReactNode } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 import type { UserWithCosmetics } from '~/server/selectors/user.selector';
 import { trpc } from '~/utils/trpc';
 
@@ -14,33 +15,68 @@ const SmartCreatorCard = dynamic(() =>
 
 /**
  * Wide enough that the creator card's top row never wraps — rank badge, up to
- * three stat badges and the cosmetic badge need about 385px. Matches the width
- * the sticker placement hover card settled on.
+ * three stat badges and the cosmetic badge need about 385px.
  */
 export const HOVER_CARD_WIDTH = 400;
 
 export const HOVER_DELAY_MS = 500;
+export const HOVER_CLOSE_DELAY_MS = 150;
+
+/**
+ * Above Mantine's default popover layer. A hover card is frequently rendered
+ * inside another popover's target — the collection collaborator stack, for one
+ * — and at equal z-index the portal mounted first loses, which put the creator
+ * card behind the popover it was opened from.
+ */
+export const HOVER_CARD_Z_INDEX = 305;
+
+/** Lets a scroll handler tell scrolling inside the card from scrolling the page. */
+export const CREATOR_HOVER_DROPDOWN_CLASS = 'creator-hover-dropdown';
 
 const NestedContext = createContext(false);
+
+/** Suppresses hover cards inside a hover card. Read by `UserHoverCard`. */
+export const useNestedHoverCard = () => useContext(NestedContext);
+
+/**
+ * Hover cards are for pointers that hover. A touch tap synthesises `mouseover`
+ * with no reliable `mouseout`, so on a phone the card opens on a tap meant for
+ * the link underneath and then has no gesture that dismisses it.
+ */
+export function useHoverCapable() {
+  const [capable, setCapable] = useState(false);
+  useEffect(() => {
+    const query = window.matchMedia('(hover: hover) and (pointer: fine)');
+    setCapable(query.matches);
+    const onChange = (e: MediaQueryListEvent) => setCapable(e.matches);
+    query.addEventListener('change', onChange);
+    return () => query.removeEventListener('change', onChange);
+  }, []);
+  return capable;
+}
 
 /**
  * Peek at a creator without leaving the page.
  *
- * The dropdown suppresses hover cards rendered inside it, because the creator
- * card renders a `UserAvatar` of its own and would otherwise offer to open the
- * same card again on top of itself.
+ * `withRoles` is off because the target is frequently a plain div, and even
+ * where it is a button the dialog it would announce cannot be opened from the
+ * keyboard — a hover card has no focus trigger.
  */
 export function UserHoverCard({
   user,
+  disabled,
   children,
 }: {
   user: Pick<Partial<UserWithCosmetics>, 'id' | 'deletedAt'>;
+  disabled?: boolean;
   children: ReactElement;
 }) {
-  const nested = useContext(NestedContext);
+  const nested = useNestedHoverCard();
+  const hoverCapable = useHoverCapable();
   const userId = user.id;
 
-  if (nested || !userId || userId < 1 || !!user.deletedAt) return children;
+  if (disabled || nested || !hoverCapable || !userId || userId < 1 || !!user.deletedAt)
+    return children;
 
   return (
     <HoverCard
@@ -48,21 +84,49 @@ export function UserHoverCard({
       shadow="sm"
       withArrow
       withinPortal
+      withRoles={false}
+      zIndex={HOVER_CARD_Z_INDEX}
       openDelay={HOVER_DELAY_MS}
-      closeDelay={100}
+      closeDelay={HOVER_CLOSE_DELAY_MS}
       position="bottom-start"
       offset={4}
     >
       <HoverCard.Target>{children}</HoverCard.Target>
-      {/* The creator card carries its own padding and fills the dropdown edge to
-          edge. Its border is dropped rather than the dropdown's, so there is one
-          outline instead of two nested ones a pixel apart. */}
-      <HoverCard.Dropdown p={0} className="overflow-hidden">
-        <NestedContext.Provider value={true}>
-          <HoverCreatorCard userId={userId} />
-        </NestedContext.Provider>
-      </HoverCard.Dropdown>
+      <CreatorHoverDropdown component={HoverCard.Dropdown}>
+        <HoverCreatorCard userId={userId} />
+      </CreatorHoverDropdown>
     </HoverCard>
+  );
+}
+
+/**
+ * The dropdown shared by the avatar and mention hover cards, so the two can't
+ * drift on chrome or on nesting.
+ *
+ * The creator card carries its own padding and fills the dropdown edge to edge.
+ * Its border is dropped rather than the dropdown's, so there is one outline
+ * instead of two nested ones a pixel apart.
+ */
+export function CreatorHoverDropdown({
+  component: Dropdown,
+  children,
+  onMouseEnter,
+  onMouseLeave,
+}: {
+  component: typeof HoverCard.Dropdown | typeof Popover.Dropdown;
+  children: ReactNode;
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
+}) {
+  return (
+    <Dropdown
+      p={0}
+      className={`${CREATOR_HOVER_DROPDOWN_CLASS} max-w-[calc(100vw-2rem)] overflow-hidden`}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
+      <NestedContext.Provider value={true}>{children}</NestedContext.Provider>
+    </Dropdown>
   );
 }
 
@@ -71,8 +135,8 @@ export function UserHoverCard({
  *
  * Given only an id it renders zeroed stats and a `[deleted]` name until its own
  * `getCreator` query lands — fine on a page, wrong in a dropdown that opens
- * already populated. This runs the same query first (so the card's is a cache
- * hit) and shows the card only once there is something to show.
+ * already populated. This runs the same query first (same key, so the card's is
+ * a cache hit) and shows the card only once there is something to show.
  *
  * A username-only mention costs the id lookup here too.
  */
@@ -83,10 +147,19 @@ export function HoverCreatorCard({
   userId?: number | null;
   username?: string | null;
 }) {
-  const { data, isLoading } = trpc.user.getCreator.useQuery(
+  const { data, isLoading, isError } = trpc.user.getCreator.useQuery(
     userId ? { id: userId } : { username: username as string },
     { enabled: !!userId || !!username, staleTime: 5 * 60_000 }
   );
+
+  // Falling through on failure would show the zeroed `[deleted]` card the
+  // skeleton exists to hide, which reads as an answer rather than a failure.
+  if (isError || (!isLoading && !userId && !data))
+    return (
+      <Text size="sm" c="dimmed" p="md">
+        Couldn&apos;t load this creator.
+      </Text>
+    );
 
   const id = userId ?? data?.id;
   if (isLoading || !id) return <CreatorCardSkeleton />;


### PR DESCRIPTION
Hovering a user anywhere on the site peeks at their creator card after 500ms, instead of costing a navigation away from what you were reading.

## What's covered

- **`UserAvatar`** — comment headers, sidebars, chat lists, profile links, ~87 call sites.
- **`UserAvatarSimple`** — every feed card (model, image, article, collection, bounty, comic, 3D).
- **`@mentions`** — comments and post/model/bounty/challenge descriptions (`RenderHtml`), plus article bodies (`RenderRichText`).
- The username link in the legacy model comment section, which renders `Username` outside the avatar.

Opt-out via `withHoverCard={false}`, used where a hover card would fight an existing menu (header account popover) or offer the card you are already looking at (`CreatorCard`, `CreatorCardSimple`). A context inside the dropdown suppresses nested hover cards, so the creator card's own avatar can't spawn another.

## Notes for review

- **Mentions are markup, not React nodes.** Hover is delegated from the container and the card anchored to a fixed box over the mention's rect; it closes on scroll rather than chasing the rect.
- **Sanitization dropped the mention's data attributes.** `sanitize-html` filters attributes against the tag a transform *produced*, so `withMentions` rewriting `span` → `a` stripped `data-id`/`data-label` — `a` now allows them. This is why mentions did nothing on first pass.
- **Skeleton while loading.** Given only an id, `CreatorCardSimple` renders zeroed stats and a `[deleted]` name until its own `getCreator` lands. The hover card runs that query first and shows a shaped skeleton until it resolves, so the card's own query is a cache hit.
- **Cost on render is nil.** The creator card is `next/dynamic`, dropdowns don't mount until open, so a feed of 50 avatars fetches nothing.

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm exec eslint` on touched files — 0 errors (2 pre-existing `any` warnings in `RenderRichText`)
- Manual: comments, mentions and feed cards on a local dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)