### PR TITLE
fix(users): stop a mention card's Escape from closing the modal around it

### DIFF
--- a/src/components/UserAvatar/MentionHoverCard.tsx
+++ b/src/components/UserAvatar/MentionHoverCard.tsx
@@ -164,8 +164,8 @@ export function MentionHoverCard({
   return (
     <Popover
       opened
-      // Controlled, so Mantine's own dismissals (outside click, Escape) come
-      // back through here rather than being swallowed.
+      // Controlled, so an outside click comes back through here rather than
+      // being swallowed.
       onChange={(opened) => !opened && setMention(null)}
       width={HOVER_CARD_WIDTH}
       shadow="sm"

--- a/src/components/UserAvatar/MentionHoverCard.tsx
+++ b/src/components/UserAvatar/MentionHoverCard.tsx
@@ -56,8 +56,12 @@ function readMention(el: HTMLElement): Omit<Mention, 'rect'> | null {
  * `https://evil.example/user/Justin`, which is the whole attack.
  */
 function linksToProfile(anchor: HTMLAnchorElement, expected: string) {
+  const href = anchor.getAttribute('href');
+  // An empty href resolves to the current page, which would pass the check for
+  // any reader who happened to be standing on that profile.
+  if (!href) return false;
   try {
-    const url = new URL(anchor.getAttribute('href') ?? '', window.location.href);
+    const url = new URL(href, window.location.href);
     if (url.origin !== window.location.origin) return false;
     // Usernames resolve case-insensitively, so a link that works must pass.
     return (
@@ -145,17 +149,12 @@ export function MentionHoverCard({
         return;
       setMention(null);
     };
-    // Mantine's own Escape handling is a React prop on the dropdown, which only
-    // sees keys pressed inside it — and nothing ever focuses a hover card.
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setMention(null);
-    };
+    // No Escape handler here on purpose. A modal binds Escape as a capturing
+    // window listener, which runs before anything on document, so a card opened
+    // inside one — a comment thread modal, say — would take the modal down with
+    // it. Mouseleave, scroll and outside-click already dismiss it.
     window.addEventListener('scroll', onScroll, true);
-    document.addEventListener('keydown', onKeyDown);
-    return () => {
-      window.removeEventListener('scroll', onScroll, true);
-      document.removeEventListener('keydown', onKeyDown);
-    };
+    return () => window.removeEventListener('scroll', onScroll, true);
   }, [mention]);
 
   if (!mention) return null;


### PR DESCRIPTION
Follow-up to #3846, from the same adversarial review.

**The regression.** Mantine binds a modal's Escape as a *capturing window* listener; the hover card's was a *bubble* listener on document. Capture-on-window runs first, so both fired: pressing Escape to dismiss a mention card inside a comment thread modal (`CommentThreadModal.tsx:119` renders `RenderHtml withMentions` inside one) closed the whole modal.

Registration order can't rescue it — among same-phase listeners the modal wins, because it binds on mount and the card binds on open. Mantine's `data-mantine-stop-propagation` opt-out doesn't apply either: for a body-focused keypress the target is `<body>`.

So the listener is **removed** rather than repaired. The card already closes on mouseleave, scroll, and outside click (the controlled `onChange` routes that correctly). Making Escape safe would mean no-opping while any modal is open, which means reaching into dialog state — more machinery than the gesture is worth. The trade-off is now written down where the listener used to be.

**Also**: `linksToProfile` treated a missing href as `''`, which `new URL` resolves to the *current page* — so the identity check passed for a reader standing on the profile the mention named. Not exploitable (no href means no destination, and the write path rejects href-less anchors) but the guard shouldn't pass by coincidence.

**Verification**: `pnpm run typecheck` 0 errors; eslint clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)