### PR TITLE
feat(placement): sticker layer order, an ordered reveal, and the history panel

### DIFF
--- a/src/components/Image/DetailV2/CollapsibleCard.tsx
+++ b/src/components/Image/DetailV2/CollapsibleCard.tsx
@@ -80,7 +80,14 @@ export function CollapsibleCard({
           <span>{title}</span>
         </Text>
         {open && (
-          <div onClick={(event) => event.stopPropagation()} className="flex items-center">
+          <div
+            onClick={(event) => event.stopPropagation()}
+            // Keys too, not just clicks. The row toggles on Enter and Space, so
+            // the first focusable control put in here would close the card out
+            // from under whoever was using it.
+            onKeyDown={(event) => event.stopPropagation()}
+            className="flex items-center"
+          >
             {actions}
           </div>
         )}

--- a/src/components/Image/DetailV2/CollapsibleCard.tsx
+++ b/src/components/Image/DetailV2/CollapsibleCard.tsx
@@ -1,0 +1,76 @@
+import { Card, Text, UnstyledButton } from '@mantine/core';
+import { useLocalStorage } from '@mantine/hooks';
+import { IconChevronDown, IconChevronUp } from '@tabler/icons-react';
+import clsx from 'clsx';
+import type { ReactNode } from 'react';
+
+/**
+ * A titled section of the image detail sidebar that can be folded away.
+ *
+ * The sidebar grew past what fits on a laptop — generation data alone can be a
+ * full screen of resources and prompt — and the sticker work adds to it. Folding
+ * is per section and remembered, so someone who never reads the prompt stops
+ * scrolling past it on every image.
+ *
+ * A collapsed section renders no children at all rather than hiding them: the
+ * expensive ones here are expensive because they query, and a hidden panel that
+ * still fetches costs the same as an open one.
+ */
+export function CollapsibleCard({
+  title,
+  icon,
+  actions,
+  storageKey,
+  defaultOpen = true,
+  rounded = true,
+  children,
+}: {
+  title: string;
+  icon?: ReactNode;
+  /** Sits beside the title and outside the toggle — a copy button in a button. */
+  actions?: ReactNode;
+  /** Distinct per section. Shared across images on purpose: the preference is
+   * about the section, not about the image being looked at. */
+  storageKey: string;
+  defaultOpen?: boolean;
+  rounded?: boolean;
+  children: ReactNode;
+}) {
+  const [open, setOpen] = useLocalStorage({
+    key: `image-detail-section:${storageKey}`,
+    defaultValue: defaultOpen,
+  });
+
+  const Chevron = open ? IconChevronUp : IconChevronDown;
+
+  return (
+    <Card className={clsx('flex flex-col gap-3', rounded ? 'rounded-xl' : 'rounded-none')}>
+      <div className="flex items-center gap-3">
+        {/* The title toggles and the chevron toggles; `actions` sits between
+            them as a sibling. Putting them inside the toggle would nest a
+            button in a button — the copy control here is one — which is invalid
+            markup and swallows its own click. */}
+        <UnstyledButton
+          onClick={() => setOpen((o) => !o)}
+          aria-expanded={open}
+          className="flex items-center gap-2"
+        >
+          <Text className="flex items-center gap-2 text-xl font-semibold">
+            {icon}
+            <span>{title}</span>
+          </Text>
+        </UnstyledButton>
+        {open && actions}
+        <UnstyledButton
+          onClick={() => setOpen((o) => !o)}
+          aria-expanded={open}
+          aria-label={`${open ? 'Collapse' : 'Expand'} ${title}`}
+          className="ml-auto flex items-center"
+        >
+          <Chevron size={18} className="shrink-0 opacity-60" />
+        </UnstyledButton>
+      </div>
+      {open && children}
+    </Card>
+  );
+}

--- a/src/components/Image/DetailV2/CollapsibleCard.tsx
+++ b/src/components/Image/DetailV2/CollapsibleCard.tsx
@@ -1,4 +1,4 @@
-import { Card, Text, UnstyledButton } from '@mantine/core';
+import { Card, Text } from '@mantine/core';
 import { useLocalStorage } from '@mantine/hooks';
 import { IconChevronDown, IconChevronUp } from '@tabler/icons-react';
 import clsx from 'clsx';
@@ -54,30 +54,37 @@ export function CollapsibleCard({
 
   return (
     <Card className={clsx('flex flex-col gap-3', rounded ? 'rounded-xl' : 'rounded-none')}>
-      <div className="flex items-center gap-3">
-        {/* The title toggles and the chevron toggles; `actions` sits between
-            them as a sibling. Putting them inside the toggle would nest a
-            button in a button — the copy control here is one — which is invalid
-            markup and swallows its own click. */}
-        <UnstyledButton
-          onClick={() => setOpen((o) => !o)}
-          aria-expanded={open}
-          className="flex items-center gap-2"
-        >
-          <Text className="flex items-center gap-2 text-xl font-semibold">
-            {icon}
-            <span>{title}</span>
-          </Text>
-        </UnstyledButton>
-        {open && actions}
-        <UnstyledButton
-          onClick={() => setOpen((o) => !o)}
-          aria-expanded={open}
-          aria-label={`${open ? 'Collapse' : 'Expand'} ${title}`}
-          className="ml-auto flex items-center"
-        >
-          <Chevron size={18} className="shrink-0 opacity-60" />
-        </UnstyledButton>
+      {/* The whole row toggles, including the gap between the title and the
+          chevron. It is a div rather than a button because `actions` holds a
+          button of its own — the copy control — and a button inside a button is
+          invalid markup that swallows its own click. So the row carries the
+          role and the keyboard handling instead, and the actions stop the click
+          from reaching it. */}
+      <div
+        role="button"
+        tabIndex={0}
+        aria-expanded={open}
+        aria-label={`${open ? 'Collapse' : 'Expand'} ${title}`}
+        onClick={() => setOpen((o) => !o)}
+        onKeyDown={(event) => {
+          if (event.key !== 'Enter' && event.key !== ' ') return;
+          // Space scrolls the sidebar otherwise, which on a collapse control is
+          // the panel appearing to jump rather than to fold.
+          event.preventDefault();
+          setOpen((o) => !o);
+        }}
+        className="flex cursor-pointer select-none items-center gap-3"
+      >
+        <Text className="flex items-center gap-2 text-xl font-semibold">
+          {icon}
+          <span>{title}</span>
+        </Text>
+        {open && (
+          <div onClick={(event) => event.stopPropagation()} className="flex items-center">
+            {actions}
+          </div>
+        )}
+        <Chevron size={18} className="ml-auto shrink-0 opacity-60" />
       </div>
       {mounted && <div className={clsx('flex flex-col gap-3', !open && 'hidden')}>{children}</div>}
     </Card>

--- a/src/components/Image/DetailV2/CollapsibleCard.tsx
+++ b/src/components/Image/DetailV2/CollapsibleCard.tsx
@@ -2,7 +2,7 @@ import { Card, Text, UnstyledButton } from '@mantine/core';
 import { useLocalStorage } from '@mantine/hooks';
 import { IconChevronDown, IconChevronUp } from '@tabler/icons-react';
 import clsx from 'clsx';
-import type { ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 
 /**
  * A titled section of the image detail sidebar that can be folded away.
@@ -12,9 +12,11 @@ import type { ReactNode } from 'react';
  * is per section and remembered, so someone who never reads the prompt stops
  * scrolling past it on every image.
  *
- * A collapsed section renders no children at all rather than hiding them: the
- * expensive ones here are expensive because they query, and a hidden panel that
- * still fetches costs the same as an open one.
+ * Children are not rendered until the section is first open — the expensive ones
+ * here are expensive because they query, and a hidden panel that still fetches
+ * costs the same as an open one. After that first open they stay mounted and are
+ * hidden with CSS: unmounting on collapse would throw away anything the reader
+ * has typed into them, and Discussion contains the comment box.
  */
 export function CollapsibleCard({
   title,
@@ -40,6 +42,13 @@ export function CollapsibleCard({
     key: `image-detail-section:${storageKey}`,
     defaultValue: defaultOpen,
   });
+
+  // Sticky once true: a section that has been opened stays mounted for the rest
+  // of the page's life, so collapsing it costs the reader nothing they typed.
+  const [mounted, setMounted] = useState(open);
+  useEffect(() => {
+    if (open) setMounted(true);
+  }, [open]);
 
   const Chevron = open ? IconChevronUp : IconChevronDown;
 
@@ -70,7 +79,7 @@ export function CollapsibleCard({
           <Chevron size={18} className="shrink-0 opacity-60" />
         </UnstyledButton>
       </div>
-      {open && children}
+      {mounted && <div className={clsx('flex flex-col gap-3', !open && 'hidden')}>{children}</div>}
     </Card>
   );
 }

--- a/src/components/Image/DetailV2/ImageContestCollectionDetails.tsx
+++ b/src/components/Image/DetailV2/ImageContestCollectionDetails.tsx
@@ -1,4 +1,4 @@
-import { Anchor, Button, Card, Checkbox, Divider, Text } from '@mantine/core';
+import { Anchor, Button, Checkbox, Divider, Text } from '@mantine/core';
 import { IconBan, IconCheck, IconTournament } from '@tabler/icons-react';
 import type { InfiniteData } from '@tanstack/react-query';
 import { getQueryKey } from '@trpc/react-query';
@@ -7,6 +7,7 @@ import { useState } from 'react';
 import { CollectionItemNSFWLevelSelector } from '~/components/Collections/components/ContestCollections/CollectionItemNSFWLevelSelector';
 import { ContestCollectionItemScorer } from '~/components/Collections/components/ContestCollections/ContestCollectionItemScorer';
 import { useImageDetailContext } from '~/components/Image/Detail/ImageDetailProvider';
+import { CollapsibleCard } from '~/components/Image/DetailV2/CollapsibleCard';
 import { useImageContestCollectionDetails } from '~/components/Image/image.utils';
 import { InfoPopover } from '~/components/InfoPopover/InfoPopover';
 import { PopConfirm } from '~/components/PopConfirm/PopConfirm';
@@ -53,13 +54,7 @@ export const ImageContestCollectionDetails = ({
   if (displayedItems.length === 0) return null;
 
   return (
-    <Card className="flex flex-col gap-3 rounded-xl">
-      <div className="flex items-center gap-3">
-        <Text className="flex items-center gap-2 text-xl font-semibold">
-          <IconTournament />
-          <span>Contests</span>
-        </Text>
-      </div>
+    <CollapsibleCard title="Contests" icon={<IconTournament />} storageKey="contests">
       <div className="flex flex-col gap-3">
         {collectionItems?.map((item) => {
           const tagDisplay = item?.tag ? (
@@ -270,7 +265,7 @@ export const ImageContestCollectionDetails = ({
           );
         })}
       </div>
-    </Card>
+    </CollapsibleCard>
   );
 };
 

--- a/src/components/Image/DetailV2/ImageDetail2.tsx
+++ b/src/components/Image/DetailV2/ImageDetail2.tsx
@@ -57,6 +57,7 @@ import { PostingToModel3DCard } from '~/components/Model3D/Posting/PostingToMode
 import { ImageContextMenu } from '~/components/Image/ContextMenu/ImageContextMenu';
 import { ImageDetailComments } from '~/components/Image/Detail/ImageDetailComments';
 import { useImageDetailContext } from '~/components/Image/Detail/ImageDetailProvider';
+import { CollapsibleCard } from '~/components/Image/DetailV2/CollapsibleCard';
 import { ImageContestCollectionDetails } from '~/components/Image/DetailV2/ImageContestCollectionDetails';
 import { ImageDetailCarousel } from '~/components/Image/DetailV2/ImageDetailCarousel';
 import { ImageExternalMeta } from '~/components/Image/DetailV2/ImageExternalMeta';
@@ -654,17 +655,17 @@ export function ImageDetail2() {
                     )}
                     <ImageProcess imageId={image.id} />
                     <RemixGalleryCard imageId={image.id} />
-                    <ImageGenerationData imageId={image.id} />
+                    <ImageGenerationData imageId={image.id} collapsible />
                     {/* <ImageRemixOfDetails imageId={image.id} />
                     <ImageRemixesDetails imageId={image.id} /> */}
                     {/* {!hideAds && <AdUnitSide_3 />} */}
-                    <Card className="flex flex-col gap-3 rounded-xl">
-                      <Text className="flex items-center gap-2 text-xl font-semibold">
-                        <IconBrandWechat />
-                        <span>Discussion</span>
-                      </Text>
+                    <CollapsibleCard
+                      title="Discussion"
+                      icon={<IconBrandWechat />}
+                      storageKey="discussion"
+                    >
                       <ImageDetailComments imageId={image.id} userId={image.user.id} />
-                    </Card>
+                    </CollapsibleCard>
                     <ImageContestCollectionDetails
                       key={currentUser?.id}
                       image={image}

--- a/src/components/Image/DetailV2/ImageGenerationData.tsx
+++ b/src/components/Image/DetailV2/ImageGenerationData.tsx
@@ -1,6 +1,7 @@
 import { Card, Divider, Text } from '@mantine/core';
 import { IconForms } from '@tabler/icons-react';
 import { CopyButton } from '~/components/CopyButton/CopyButton';
+import { CollapsibleCard } from '~/components/Image/DetailV2/CollapsibleCard';
 import { ImageMeta } from '~/components/Image/DetailV2/ImageMeta';
 import { ImageResources } from '~/components/Image/DetailV2/ImageResources';
 import { encodeMetadata } from '~/utils/metadata';
@@ -9,14 +10,56 @@ import { trpc } from '~/utils/trpc';
 export function ImageGenerationData({
   imageId,
   rounded = true,
+  collapsible = false,
 }: {
   imageId: number;
   rounded?: boolean;
+  /** On the image detail sidebar, where this is the tallest thing on the page.
+   * Off everywhere else, so no other surface gains a fold nobody asked for. */
+  collapsible?: boolean;
 }) {
   const { data } = trpc.image.getGenerationData.useQuery({ id: imageId });
 
   const { meta, resources } = data ?? {};
   if (!meta && !resources?.length) return null;
+
+  const copyAll = meta && (
+    <CopyButton value={() => encodeMetadata(meta)}>
+      {({ copy, copied, Icon, color }) => (
+        <Text
+          className="flex cursor-pointer items-center gap-1 text-xs"
+          color={color}
+          onClick={copy}
+          data-activity="copy:image-meta"
+          c="blue.4"
+        >
+          <Icon size={14} />
+          <span>{copied ? 'COPIED' : 'COPY ALL'}</span>
+        </Text>
+      )}
+    </CopyButton>
+  );
+
+  const body = (
+    <>
+      <ImageResources imageId={imageId} />
+      {!!resources?.length && (meta?.prompt || meta?.negativePrompt) && <Divider />}
+      <ImageMeta imageId={imageId} />
+    </>
+  );
+
+  if (collapsible)
+    return (
+      <CollapsibleCard
+        title="Generation data"
+        icon={<IconForms />}
+        actions={copyAll}
+        storageKey="generation-data"
+        rounded={rounded}
+      >
+        {body}
+      </CollapsibleCard>
+    );
 
   return (
     <Card className={`flex flex-col gap-3 ${rounded ? 'rounded-xl' : 'rounded-none'}`}>
@@ -25,26 +68,9 @@ export function ImageGenerationData({
           <IconForms />
           <span>Generation data</span>
         </Text>
-        {meta && (
-          <CopyButton value={() => encodeMetadata(meta)}>
-            {({ copy, copied, Icon, color }) => (
-              <Text
-                className="flex cursor-pointer items-center gap-1 text-xs"
-                color={color}
-                onClick={copy}
-                data-activity="copy:image-meta"
-                c="blue.4"
-              >
-                <Icon size={14} />
-                <span>{copied ? 'COPIED' : 'COPY ALL'}</span>
-              </Text>
-            )}
-          </CopyButton>
-        )}
+        {copyAll}
       </div>
-      <ImageResources imageId={imageId} />
-      {!!resources?.length && (meta?.prompt || meta?.negativePrompt) && <Divider />}
-      <ImageMeta imageId={imageId} />
+      {body}
     </Card>
   );
 }

--- a/src/components/Sticker/ImageStickerOverlay.tsx
+++ b/src/components/Sticker/ImageStickerOverlay.tsx
@@ -9,6 +9,15 @@ import { useStickerRevealStore } from '~/store/sticker-reveal.store';
 import { useStickerHistoryStep } from '~/store/sticker-history.store';
 
 /**
+ * How much of the slide has to be on screen before its stickers start arriving.
+ *
+ * Most of it, not a sliver: the reveal is worth watching from the moment the
+ * slide is the thing you are looking at, and starting it mid-transition spends
+ * it on a strip of image sliding past.
+ */
+const ARM_AT = 0.6;
+
+/**
  * The overlay for one image: placed stickers, and the one being positioned.
  *
  * Sized to the rendered media box rather than to its container — a letterboxed
@@ -54,15 +63,15 @@ export function ImageStickerOverlay({
     return () => setSurface(null);
   }, [isPlacing, setSurface]);
 
-  // The reveal is a mount-time CSS animation, and mounting is not the same event
-  // as being looked at: the carousel keeps both neighbouring slides mounted, so
-  // an overlay two slides away plays its whole reveal off-screen and is already
-  // settled by the time anyone swipes to it. Arming on first intersection is
-  // what makes "every time they become visible" true for every slide rather
-  // than only for the one the page opened on.
+  // Mounting is not the same event as being looked at: the carousel keeps the
+  // slide either side mounted, so an overlay that armed on mount would play its
+  // whole reveal off-screen and be settled before anyone swiped to it. Arming on
+  // intersection — and disarming when the slide leaves — is what makes "every
+  // time they become visible" true for arriving at a slide, going next, and
+  // coming back.
   const [armed, setArmed] = useState(false);
   useEffect(() => {
-    if (!surfaceEl || armed) return;
+    if (!surfaceEl) return;
 
     // No observer means no way to tell arrival from mounting, and the stickers
     // are held at zero opacity until armed — so the failure has to be "reveal
@@ -74,19 +83,25 @@ export function ImageStickerOverlay({
 
     const observer = new IntersectionObserver(
       ([entry]) => {
-        if (entry.isIntersecting) setArmed(true);
+        // Two thresholds rather than one, and it keeps observing after the
+        // first: leaving the screen disarms, so coming back reveals again.
+        // Without that, arriving at a slide a second time showed the stickers
+        // already settled — the carousel keeps the slide either side mounted,
+        // so stepping right and back again never remounts anything, and a
+        // one-shot arm has nothing left to play.
+        if (entry.intersectionRatio >= ARM_AT) setArmed(true);
+        else if (entry.intersectionRatio === 0) setArmed(false);
       },
-      // Barely any exposure, because the unarmed state is blank rather than
-      // wrong: arming early costs a reveal that starts while the slide is still
-      // coming in, and arming late is a visibly empty image. Not 0 — a drag
-      // nudged a few percent and released arms the neighbour permanently, and
-      // its reveal then plays out while it snaps back off screen, so by the
-      // time you navigate there is nothing left to play.
-      { threshold: 0.05 }
+      // The gap between the two is deliberate. Arming at a sliver meant the
+      // reveal ran while the slide was still sliding in — and a drag nudged a
+      // few percent and released armed a neighbour that then played its whole
+      // reveal off-screen. Disarming only at nothing-visible stops the pair
+      // flickering while a drag hovers around the boundary.
+      { threshold: [0, ARM_AT] }
     );
     observer.observe(surfaceEl);
     return () => observer.disconnect();
-  }, [armed, surfaceEl]);
+  }, [surfaceEl]);
 
   const imageIds = useMemo(() => [imageId], [imageId]);
   // Signed-in viewers always fetch, because a pending placement is something

--- a/src/components/Sticker/ImageStickerOverlay.tsx
+++ b/src/components/Sticker/ImageStickerOverlay.tsx
@@ -136,11 +136,9 @@ export function ImageStickerOverlay({
           viewerId={currentUser?.id}
           treatment={treatment}
           // Every time they arrive on screen (Justin, 2026-08-12) — hence
-          // `armed`, which is first intersection rather than mount, because the
-          // carousel mounts a slide long before anyone looks at it. It does not
-          // disarm, so coming back to a slide you have already seen draws them
-          // straight away; nothing remounts on the way back, so there is no
-          // arrival to play.
+          // `armed`, which tracks intersection rather than mount, because the
+          // carousel mounts a slide long before anyone looks at it and keeps it
+          // mounted long after.
           //
           // `stagger` is what this surface does and never changes while it is
           // mounted; `armed` is whether it has been seen. Held apart because
@@ -157,6 +155,10 @@ export function ImageStickerOverlay({
           // surface has to hold still, and reveal is off by default, so
           // pressing the plus is often what mounts this in the first place.
           paced={!isPlacing}
+          // The box these are drawn on, so the pending controls can convert a
+          // width-fraction into a height-percentage rather than treating the
+          // two as the same unit.
+          mediaAspect={width / height}
           step={historyStep}
         />
       )}

--- a/src/components/Sticker/ImageStickerOverlay.tsx
+++ b/src/components/Sticker/ImageStickerOverlay.tsx
@@ -6,6 +6,7 @@ import { useStickerTreatment } from '~/components/Sticker/treatments/useStickerT
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useStickerPlacementDraftStore } from '~/store/sticker-placement-draft.store';
 import { useStickerRevealStore } from '~/store/sticker-reveal.store';
+import { useStickerHistoryStep } from '~/store/sticker-history.store';
 
 /**
  * The overlay for one image: placed stickers, and the one being positioned.
@@ -30,6 +31,8 @@ export function ImageStickerOverlay({
   const revealed = useStickerRevealStore((state) => state.revealed);
   const targetImageId = useStickerPlacementDraftStore((state) => state.targetImageId);
   const setSurface = useStickerPlacementDraftStore((state) => state.setSurface);
+
+  const historyStep = useStickerHistoryStep(imageId);
 
   const isPlacing = targetImageId === imageId;
   const surfaceRef = useRef<HTMLDivElement>(null);
@@ -56,7 +59,10 @@ export function ImageStickerOverlay({
   // because the count chip counts it and toggles reveal — the fetch above stays
   // ungated so that total is right, which is the part the notification path
   // actually depends on.
-  const placements = revealed || isPlacing ? all : [];
+  // A replay in progress shows them regardless: stepping through the history
+  // with the reveal off would drive a panel against a blank image, and the
+  // person stepping has already asked for exactly this.
+  const placements = revealed || isPlacing || historyStep != null ? all : [];
 
   if (!placements.length && !isPlacing) return null;
   if (width <= 0 || height <= 0) return null;
@@ -72,6 +78,16 @@ export function ImageStickerOverlay({
           placements={placements}
           viewerId={currentUser?.id}
           treatment={treatment}
+          // Every time they become visible, not once per image (Justin,
+          // 2026-08-12): opening the detail view, changing slide and flipping
+          // the reveal on all remount this, and each of those is someone
+          // arriving at the image for the first time as far as they know.
+          //
+          // Not while placing. Watching the existing stickers replay under the
+          // sticker you are dragging is movement in the one moment the surface
+          // has to hold still.
+          stagger={!isPlacing}
+          step={historyStep}
         />
       )}
       {isPlacing && <DraftStickerLayer />}

--- a/src/components/Sticker/ImageStickerOverlay.tsx
+++ b/src/components/Sticker/ImageStickerOverlay.tsx
@@ -155,10 +155,6 @@ export function ImageStickerOverlay({
           // surface has to hold still, and reveal is off by default, so
           // pressing the plus is often what mounts this in the first place.
           paced={!isPlacing}
-          // The box these are drawn on, so the pending controls can convert a
-          // width-fraction into a height-percentage rather than treating the
-          // two as the same unit.
-          mediaAspect={width / height}
           step={historyStep}
         />
       )}

--- a/src/components/Sticker/ImageStickerOverlay.tsx
+++ b/src/components/Sticker/ImageStickerOverlay.tsx
@@ -62,16 +62,26 @@ export function ImageStickerOverlay({
   // than only for the one the page opened on.
   const [armed, setArmed] = useState(false);
   useEffect(() => {
-    if (!surfaceEl || armed || typeof IntersectionObserver === 'undefined') return;
+    if (!surfaceEl || armed) return;
+
+    // No observer means no way to tell arrival from mounting, and the stickers
+    // are held at zero opacity until armed — so the failure has to be "reveal
+    // immediately", never "stay hidden".
+    if (typeof IntersectionObserver === 'undefined') {
+      setArmed(true);
+      return;
+    }
 
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) setArmed(true);
       },
-      // A slide is either the one on screen or entirely off it, so anything
-      // above zero separates them. Not 0: the carousel holds neighbours
-      // adjacent, and a hairline overlap during a drag is not arrival.
-      { threshold: 0.25 }
+      // Any exposure at all, because the unarmed state is now blank rather than
+      // wrong: arming a moment early costs a reveal that starts while the slide
+      // is still sliding in, while arming late is a visibly empty image. The
+      // carousel viewport is `overflow-hidden`, so a neighbour still reports
+      // nothing until it starts to come in.
+      { threshold: 0 }
     );
     observer.observe(surfaceEl);
     return () => observer.disconnect();
@@ -117,7 +127,12 @@ export function ImageStickerOverlay({
           // Not while placing. Watching the existing stickers replay under the
           // sticker you are dragging is movement in the one moment the surface
           // has to hold still.
-          stagger={armed && !isPlacing}
+          // `stagger` is what this surface does and is true from the first
+          // render; `armed` is whether it has been seen yet. Held apart on
+          // purpose — collapsing them into one flag paints an un-staggered
+          // frame before the reveal can start, which reads as a blink.
+          stagger={!isPlacing}
+          armed={armed}
           step={historyStep}
         />
       )}

--- a/src/components/Sticker/ImageStickerOverlay.tsx
+++ b/src/components/Sticker/ImageStickerOverlay.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { DraftStickerLayer } from '~/components/Sticker/DraftStickerLayer';
 import { StickerPlacementOverlay } from '~/components/Sticker/StickerPlacementOverlay';
 import { useStickerPlacements } from '~/components/Sticker/placement.util';
@@ -35,7 +35,15 @@ export function ImageStickerOverlay({
   const historyStep = useStickerHistoryStep(imageId);
 
   const isPlacing = targetImageId === imageId;
-  const surfaceRef = useRef<HTMLDivElement>(null);
+  const surfaceRef = useRef<HTMLDivElement | null>(null);
+  // The element as state as well as a ref: the overlay renders nothing until it
+  // has placements, so the node arrives on a later render than the first, and an
+  // effect reading only the ref would observe `null` and never look again.
+  const [surfaceEl, setSurfaceEl] = useState<HTMLDivElement | null>(null);
+  const attachSurface = useCallback((node: HTMLDivElement | null) => {
+    surfaceRef.current = node;
+    setSurfaceEl(node);
+  }, []);
 
   // Registered while this image is the placement target, and cleared on the way
   // out: a stale surface would have the next drag measured against a box that is
@@ -45,6 +53,29 @@ export function ImageStickerOverlay({
     setSurface(surfaceRef.current);
     return () => setSurface(null);
   }, [isPlacing, setSurface]);
+
+  // The reveal is a mount-time CSS animation, and mounting is not the same event
+  // as being looked at: the carousel keeps both neighbouring slides mounted, so
+  // an overlay two slides away plays its whole reveal off-screen and is already
+  // settled by the time anyone swipes to it. Arming on first intersection is
+  // what makes "every time they become visible" true for every slide rather
+  // than only for the one the page opened on.
+  const [armed, setArmed] = useState(false);
+  useEffect(() => {
+    if (!surfaceEl || armed || typeof IntersectionObserver === 'undefined') return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) setArmed(true);
+      },
+      // A slide is either the one on screen or entirely off it, so anything
+      // above zero separates them. Not 0: the carousel holds neighbours
+      // adjacent, and a hairline overlap during a drag is not arrival.
+      { threshold: 0.25 }
+    );
+    observer.observe(surfaceEl);
+    return () => observer.disconnect();
+  }, [armed, surfaceEl]);
 
   const imageIds = useMemo(() => [imageId], [imageId]);
   // Signed-in viewers always fetch, because a pending placement is something
@@ -69,7 +100,7 @@ export function ImageStickerOverlay({
 
   return (
     <div
-      ref={surfaceRef}
+      ref={attachSurface}
       className="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
       style={{ width, height }}
     >
@@ -79,14 +110,14 @@ export function ImageStickerOverlay({
           viewerId={currentUser?.id}
           treatment={treatment}
           // Every time they become visible, not once per image (Justin,
-          // 2026-08-12): opening the detail view, changing slide and flipping
-          // the reveal on all remount this, and each of those is someone
-          // arriving at the image for the first time as far as they know.
+          // 2026-08-12) — hence `armed`, which is first intersection rather
+          // than mount, because the carousel mounts a slide long before anyone
+          // looks at it.
           //
           // Not while placing. Watching the existing stickers replay under the
           // sticker you are dragging is movement in the one moment the surface
           // has to hold still.
-          stagger={!isPlacing}
+          stagger={armed && !isPlacing}
           step={historyStep}
         />
       )}

--- a/src/components/Sticker/ImageStickerOverlay.tsx
+++ b/src/components/Sticker/ImageStickerOverlay.tsx
@@ -76,12 +76,13 @@ export function ImageStickerOverlay({
       ([entry]) => {
         if (entry.isIntersecting) setArmed(true);
       },
-      // Any exposure at all, because the unarmed state is now blank rather than
-      // wrong: arming a moment early costs a reveal that starts while the slide
-      // is still sliding in, while arming late is a visibly empty image. The
-      // carousel viewport is `overflow-hidden`, so a neighbour still reports
-      // nothing until it starts to come in.
-      { threshold: 0 }
+      // Barely any exposure, because the unarmed state is blank rather than
+      // wrong: arming early costs a reveal that starts while the slide is still
+      // coming in, and arming late is a visibly empty image. Not 0 — a drag
+      // nudged a few percent and released arms the neighbour permanently, and
+      // its reveal then plays out while it snaps back off screen, so by the
+      // time you navigate there is nothing left to play.
+      { threshold: 0.05 }
     );
     observer.observe(surfaceEl);
     return () => observer.disconnect();
@@ -119,20 +120,28 @@ export function ImageStickerOverlay({
           placements={placements}
           viewerId={currentUser?.id}
           treatment={treatment}
-          // Every time they become visible, not once per image (Justin,
-          // 2026-08-12) — hence `armed`, which is first intersection rather
-          // than mount, because the carousel mounts a slide long before anyone
-          // looks at it.
+          // Every time they arrive on screen (Justin, 2026-08-12) — hence
+          // `armed`, which is first intersection rather than mount, because the
+          // carousel mounts a slide long before anyone looks at it. It does not
+          // disarm, so coming back to a slide you have already seen draws them
+          // straight away; nothing remounts on the way back, so there is no
+          // arrival to play.
           //
-          // Not while placing. Watching the existing stickers replay under the
-          // sticker you are dragging is movement in the one moment the surface
-          // has to hold still.
-          // `stagger` is what this surface does and is true from the first
-          // render; `armed` is whether it has been seen yet. Held apart on
-          // purpose — collapsing them into one flag paints an un-staggered
-          // frame before the reveal can start, which reads as a blink.
-          stagger={!isPlacing}
+          // `stagger` is what this surface does and never changes while it is
+          // mounted; `armed` is whether it has been seen. Held apart because
+          // collapsing them paints an un-staggered frame before the reveal can
+          // start, which reads as a blink. For the same reason this is not
+          // `!isPlacing`: flipping it off and back on as a placement session
+          // starts and ends re-adds the animation to stickers already on screen
+          // and replays the whole reveal under the sticker being dragged.
+          stagger
           armed={armed}
+          // The sequence is what has to stop while a placement is in progress,
+          // not the reveal itself — three seconds of stickers arriving one by
+          // one under the sticker being positioned is movement where the
+          // surface has to hold still, and reveal is off by default, so
+          // pressing the plus is often what mounts this in the first place.
+          paced={!isPlacing}
           step={historyStep}
         />
       )}

--- a/src/components/Sticker/StickerHistoryPanel.tsx
+++ b/src/components/Sticker/StickerHistoryPanel.tsx
@@ -19,11 +19,12 @@ import { StickerPlacementHoverCard } from '~/components/Sticker/StickerPlacement
 import type { PlacedSticker } from '~/components/Sticker/placement.util';
 import { useStickerPlacements } from '~/components/Sticker/placement.util';
 import { useStickerCosmetics } from '~/components/Sticker/sticker.util';
+import styles from '~/components/Sticker/placement-reveal.module.scss';
 import { useStickerHistoryStore } from '~/store/sticker-history.store';
 import {
   REPLAY_MULTIPLIER,
-  REVEAL_DURATIONS,
-  revealDurationLabel,
+  REVEAL_MULTIPLIERS,
+  revealMultiplierLabel,
   useStickerRevealSpeedStore,
 } from '~/store/sticker-reveal-speed.store';
 import { daysFromNow } from '~/utils/date-helpers';
@@ -137,12 +138,12 @@ function StickerHistoryList({
   );
   const { sticker: artwork } = useStickerCosmetics(cosmeticIds);
 
-  const durationMs = useStickerRevealSpeedStore((state) => state.durationMs);
-  const setDuration = useStickerRevealSpeedStore((state) => state.setDuration);
+  const multiplier = useStickerRevealSpeedStore((state) => state.multiplier);
+  const setMultiplier = useStickerRevealSpeedStore((state) => state.setMultiplier);
 
   const delays = useMemo(
-    () => placementRevealDelays(placements, { totalMs: durationMs * REPLAY_MULTIPLIER }),
-    [placements, durationMs]
+    () => placementRevealDelays(placements, { multiplier: multiplier * REPLAY_MULTIPLIER }),
+    [placements, multiplier]
   );
 
   const timers = useRef<ReturnType<typeof setTimeout>[]>([]);
@@ -198,6 +199,11 @@ function StickerHistoryList({
       }, delay)
     );
   };
+
+  // How long until the next sticker lands, for the bar under the header. Zero
+  // whenever there is no next one to wait for.
+  const stepProgressMs =
+    step != null && step + 1 < delays.length ? delays[step + 1] - delays[step] : 0;
 
   const at = step ?? placements.length - 1;
   const stepTo = (next: number) => {
@@ -267,15 +273,15 @@ function StickerHistoryList({
             {/* In a portal, so opening it cannot resize the panel either. */}
             <Menu.Dropdown>
               <Menu.Label>Reveal speed</Menu.Label>
-              {REVEAL_DURATIONS.map((option) => (
+              {REVEAL_MULTIPLIERS.map((option) => (
                 <Menu.Item
                   key={option}
-                  onClick={() => setDuration(option)}
+                  onClick={() => setMultiplier(option)}
                   leftSection={
-                    <IconCheck size={14} className={clsx(option !== durationMs && 'invisible')} />
+                    <IconCheck size={14} className={clsx(option !== multiplier && 'invisible')} />
                   }
                 >
-                  {revealDurationLabel(option)}
+                  {revealMultiplierLabel(option)}
                 </Menu.Item>
               ))}
             </Menu.Dropdown>
@@ -322,12 +328,12 @@ function StickerHistoryList({
               <IconChevronRight size={14} />
             </LegacyActionIcon>
           </Tooltip>
-          <Tooltip label="Back to the full image" withArrow>
+          <Tooltip label="Show all stickers" withArrow>
             <LegacyActionIcon
               size="sm"
               variant="subtle"
               color="gray"
-              aria-label="Back to the full image"
+              aria-label="Show all stickers"
               onClick={() => {
                 stop();
                 close();
@@ -342,6 +348,19 @@ function StickerHistoryList({
             </LegacyActionIcon>
           </Tooltip>
         </div>
+      </div>
+
+      {/* Always in the layout, so starting a replay cannot change the panel's
+          height — the same rule as the controls above it. Empty unless a wait
+          is actually in progress. */}
+      <div className="h-0.5 w-full bg-transparent">
+        {playing && stepProgressMs > 0 && (
+          <div
+            key={step}
+            className={clsx('h-full bg-blue-5', styles.stepProgress)}
+            style={{ animationDuration: `${stepProgressMs}ms` }}
+          />
+        )}
       </div>
 
       <ScrollArea.Autosize mah={280}>

--- a/src/components/Sticker/StickerHistoryPanel.tsx
+++ b/src/components/Sticker/StickerHistoryPanel.tsx
@@ -141,7 +141,7 @@ function StickerHistoryList({
   const setDuration = useStickerRevealSpeedStore((state) => state.setDuration);
 
   const delays = useMemo(
-    () => placementRevealDelays(placements, { maxTotalMs: durationMs * REPLAY_MULTIPLIER }),
+    () => placementRevealDelays(placements, { totalMs: durationMs * REPLAY_MULTIPLIER }),
     [placements, durationMs]
   );
 
@@ -253,7 +253,12 @@ function StickerHistoryList({
           </Text>
         </div>
         <div className="flex items-center gap-1">
-          <Menu shadow="md" position="bottom-end" withinPortal>
+          {/* NOT in a portal. Mantine's popover closes on any click outside its
+              own DOM, and a portalled menu is outside it — so choosing a speed
+              dismissed the whole panel. Kept inside, the click lands within the
+              popover and the menu is absolutely positioned, so it still cannot
+              move anything. */}
+          <Menu shadow="md" position="bottom-end" withinPortal={false}>
             <Menu.Target>
               <LegacyActionIcon size="sm" variant="subtle" color="gray" aria-label="Reveal speed">
                 <IconSettings size={14} />

--- a/src/components/Sticker/StickerHistoryPanel.tsx
+++ b/src/components/Sticker/StickerHistoryPanel.tsx
@@ -48,7 +48,7 @@ export function StickerHistoryButton({
   // Only the approved ones and the viewer's own pending, same as the overlay —
   // this reads the same query, so the list cannot show a sticker the image does
   // not draw.
-  const { byImage, isLoading } = useStickerPlacements([imageId], opened);
+  const { byImage, isLoading, isError } = useStickerPlacements([imageId], opened);
   const placements = useMemo(() => orderPlacements(byImage.get(imageId) ?? []), [byImage, imageId]);
 
   // Closing ends the replay. Leaving a step set would hold the image at a point
@@ -102,7 +102,12 @@ export function StickerHistoryButton({
       </Popover.Target>
 
       <Popover.Dropdown p={0}>
-        <StickerHistoryList imageId={imageId} placements={placements} isLoading={isLoading} />
+        <StickerHistoryList
+          imageId={imageId}
+          placements={placements}
+          isLoading={isLoading}
+          isError={isError}
+        />
       </Popover.Dropdown>
     </Popover>
   );
@@ -112,14 +117,18 @@ function StickerHistoryList({
   imageId,
   placements,
   isLoading,
+  isError,
 }: {
   imageId: number;
   placements: PlacedSticker[];
   isLoading: boolean;
+  isError: boolean;
 }) {
   const step = useStickerHistoryStore((state) => (state.imageId === imageId ? state.step : null));
   const setStep = useStickerHistoryStore((state) => state.setStep);
   const close = useStickerHistoryStore((state) => state.close);
+  const beginRun = useStickerHistoryStore((state) => state.beginRun);
+  const advanceRun = useStickerHistoryStore((state) => state.advanceRun);
 
   const cosmeticIds = useMemo(
     () => placements.map((placement) => placement.data.cosmeticId),
@@ -134,30 +143,47 @@ function StickerHistoryList({
 
   const timers = useRef<ReturnType<typeof setTimeout>[]>([]);
   const [playing, setPlaying] = useState(false);
+  const run = useRef<number | null>(null);
 
   const stop = () => {
     timers.current.forEach(clearTimeout);
     timers.current = [];
+    run.current = null;
     setPlaying(false);
   };
 
-  // Timers outlive the component otherwise, and each one writes to a store that
-  // is still mounted — a replay left running over whatever image came next.
+  // Timers outlive the component otherwise. Clearing them here is tidiness, not
+  // the guarantee — the popover fades for 150ms before this unmounts, so a timer
+  // can still fire after the replay was called off, and what makes that harmless
+  // is the run stamp the store checks rather than this cleanup.
   useEffect(() => () => timers.current.forEach(clearTimeout), []);
+
+  // Anything that ends the replay from outside this component — dismissing the
+  // popover, a slide change, the reveal toggle — bumps `runId`. Dropping the
+  // timers on the spot stops them queueing behind a run nobody is watching.
+  const runId = useStickerHistoryStore((state) => state.runId);
+  useEffect(() => {
+    if (run.current !== null && run.current !== runId) stop();
+    // `stop` is re-made every render and only reads refs; depending on it would
+    // re-run this on every render instead of on a run change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [runId]);
 
   const play = () => {
     stop();
     if (placements.length < 2) return;
     setPlaying(true);
-    setStep(imageId, 0);
+    const current = beginRun(imageId);
+    run.current = current;
     timers.current = delays.slice(1).map((delay, index) =>
       setTimeout(() => {
-        setStep(imageId, index + 1);
         // The last one ends the replay rather than leaving the image pinned to
         // its final frame, which is the same picture but with the controls
         // still saying a replay is running.
-        if (index + 1 === placements.length - 1) {
-          setStep(imageId, null);
+        const last = index + 1 === placements.length - 1;
+        advanceRun(current, imageId, last ? null : index + 1);
+        if (last) {
+          run.current = null;
           setPlaying(false);
         }
       }, delay)
@@ -179,6 +205,15 @@ function StickerHistoryList({
       <div className="p-3">
         <Skeleton height={64} radius="md" />
       </div>
+    );
+
+  // A failed fetch is also an empty list, and it must not be reported as an
+  // image nobody has stickered — the reader would take that as an answer.
+  if (isError)
+    return (
+      <Text size="xs" c="dimmed" className="p-3">
+        Couldn&apos;t load the sticker history.
+      </Text>
     );
 
   if (!placements.length)

--- a/src/components/Sticker/StickerHistoryPanel.tsx
+++ b/src/components/Sticker/StickerHistoryPanel.tsx
@@ -1,11 +1,14 @@
-import { Button, Popover, ScrollArea, Skeleton, Text, Tooltip } from '@mantine/core';
+import { Button, Menu, Popover, ScrollArea, Skeleton, Text, Tooltip } from '@mantine/core';
 import type { ButtonProps } from '@mantine/core';
 import {
+  IconArrowBackUp,
+  IconCheck,
   IconChevronLeft,
   IconChevronRight,
   IconPlayerPlay,
   IconPlayerStop,
   IconScript,
+  IconSettings,
 } from '@tabler/icons-react';
 import clsx from 'clsx';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -17,15 +20,13 @@ import type { PlacedSticker } from '~/components/Sticker/placement.util';
 import { useStickerPlacements } from '~/components/Sticker/placement.util';
 import { useStickerCosmetics } from '~/components/Sticker/sticker.util';
 import { useStickerHistoryStore } from '~/store/sticker-history.store';
+import {
+  REPLAY_MULTIPLIER,
+  REVEAL_DURATIONS,
+  revealDurationLabel,
+  useStickerRevealSpeedStore,
+} from '~/store/sticker-reveal-speed.store';
 import { daysFromNow } from '~/utils/date-helpers';
-
-/**
- * A replay is watched, not raced. The reveal's own budget is sized so stickers
- * are not still arriving while someone reads the page; this one is the thing
- * being looked at, so it gets room to breathe — same dilation, longer ceiling,
- * so the gaps between placements still read as gaps.
- */
-const REPLAY_TOTAL_MS = 8_000;
 
 /**
  * The sticker history: who built this image, in what order, and a replay of it.
@@ -136,9 +137,12 @@ function StickerHistoryList({
   );
   const { sticker: artwork } = useStickerCosmetics(cosmeticIds);
 
+  const durationMs = useStickerRevealSpeedStore((state) => state.durationMs);
+  const setDuration = useStickerRevealSpeedStore((state) => state.setDuration);
+
   const delays = useMemo(
-    () => placementRevealDelays(placements, { maxTotalMs: REPLAY_TOTAL_MS }),
-    [placements]
+    () => placementRevealDelays(placements, { maxTotalMs: durationMs * REPLAY_MULTIPLIER }),
+    [placements, durationMs]
   );
 
   const timers = useRef<ReturnType<typeof setTimeout>[]>([]);
@@ -230,11 +234,47 @@ function StickerHistoryList({
 
   return (
     <div className="flex flex-col">
+      {/* Everything lives in this row, and every control in it is always
+          present — disabled rather than absent. The status and the way back to
+          the full image used to be a footer that appeared only while stepping,
+          which grew the panel under the cursor: the pointer ended up over a
+          sticker in the list, that opened its creator card, and the card was
+          then in the way of the thing being read. A panel that never changes
+          height cannot do that. */}
       <div className="flex items-center justify-between gap-2 border-b border-gray-3 px-3 py-2 dark:border-dark-4">
-        <Text size="xs" fw={600}>
-          Sticker history
-        </Text>
+        <div className="flex min-w-0 items-baseline gap-2">
+          <Text size="xs" fw={600}>
+            Sticker history
+          </Text>
+          {/* Tabular figures and a fixed slot: a count that changes width as it
+              counts is the same layout shift in miniature. */}
+          <Text size="xs" c="dimmed" className="shrink-0 tabular-nums">
+            {step == null ? placements.length : `${step + 1} of ${placements.length}`}
+          </Text>
+        </div>
         <div className="flex items-center gap-1">
+          <Menu shadow="md" position="bottom-end" withinPortal>
+            <Menu.Target>
+              <LegacyActionIcon size="sm" variant="subtle" color="gray" aria-label="Reveal speed">
+                <IconSettings size={14} />
+              </LegacyActionIcon>
+            </Menu.Target>
+            {/* In a portal, so opening it cannot resize the panel either. */}
+            <Menu.Dropdown>
+              <Menu.Label>Reveal speed</Menu.Label>
+              {REVEAL_DURATIONS.map((option) => (
+                <Menu.Item
+                  key={option}
+                  onClick={() => setDuration(option)}
+                  leftSection={
+                    <IconCheck size={14} className={clsx(option !== durationMs && 'invisible')} />
+                  }
+                >
+                  {revealDurationLabel(option)}
+                </Menu.Item>
+              ))}
+            </Menu.Dropdown>
+          </Menu>
           <Tooltip label={playing ? 'Stop' : 'Replay'} withArrow>
             <LegacyActionIcon
               size="sm"
@@ -275,6 +315,25 @@ function StickerHistoryList({
               }
             >
               <IconChevronRight size={14} />
+            </LegacyActionIcon>
+          </Tooltip>
+          <Tooltip label="Back to the full image" withArrow>
+            <LegacyActionIcon
+              size="sm"
+              variant="subtle"
+              color="gray"
+              aria-label="Back to the full image"
+              onClick={() => {
+                stop();
+                close();
+              }}
+              // Disabled rather than hidden: it holds its place in the row so
+              // nothing moves when a replay starts or ends, and a disabled
+              // control reads as "nothing to undo" where a missing one reads as
+              // the panel having changed shape.
+              disabled={step == null}
+            >
+              <IconArrowBackUp size={14} />
             </LegacyActionIcon>
           </Tooltip>
         </div>
@@ -333,21 +392,6 @@ function StickerHistoryList({
           })}
         </ol>
       </ScrollArea.Autosize>
-
-      {step != null && (
-        <button
-          type="button"
-          onClick={() => {
-            stop();
-            close();
-          }}
-          className="cursor-pointer border-0 border-t border-solid border-gray-3 bg-transparent px-3 py-2 text-left dark:border-dark-4"
-        >
-          <Text size="xs" c="dimmed">
-            Showing {step + 1} of {placements.length} — back to the full image
-          </Text>
-        </button>
-      )}
     </div>
   );
 }

--- a/src/components/Sticker/StickerHistoryPanel.tsx
+++ b/src/components/Sticker/StickerHistoryPanel.tsx
@@ -1,0 +1,289 @@
+import { Button, Popover, ScrollArea, Text, Tooltip } from '@mantine/core';
+import type { ButtonProps } from '@mantine/core';
+import {
+  IconChevronLeft,
+  IconChevronRight,
+  IconPlayerPlay,
+  IconPlayerStop,
+  IconScript,
+} from '@tabler/icons-react';
+import clsx from 'clsx';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { EdgeImage } from '~/components/EdgeMedia/EdgeImage';
+import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
+import { orderPlacements, placementRevealDelays } from '~/components/Sticker/placement-order';
+import { StickerPlacementHoverCard } from '~/components/Sticker/StickerPlacementHoverCard';
+import type { PlacedSticker } from '~/components/Sticker/placement.util';
+import { useStickerPlacements } from '~/components/Sticker/placement.util';
+import { useStickerCosmetics } from '~/components/Sticker/sticker.util';
+import { useStickerHistoryStore } from '~/store/sticker-history.store';
+import { daysFromNow } from '~/utils/date-helpers';
+
+/**
+ * A replay is watched, not raced. The reveal's own budget is sized so stickers
+ * are not still arriving while someone reads the page; this one is the thing
+ * being looked at, so it gets room to breathe — same dilation, longer ceiling,
+ * so the gaps between placements still read as gaps.
+ */
+const REPLAY_TOTAL_MS = 8_000;
+
+/**
+ * The sticker history: who built this image, in what order, and a replay of it.
+ *
+ * A popover off the reaction bar rather than a panel in the sidebar (Justin,
+ * 2026-08-12). The sidebar is collapsible and often collapsed, and the replay
+ * only makes sense while you can see the image it is playing over — a control
+ * that scrolls away from the thing it drives is a control you lose.
+ */
+export function StickerHistoryButton({
+  imageId,
+  buttonProps,
+}: {
+  imageId: number;
+  buttonProps?: Partial<ButtonProps>;
+}) {
+  const [opened, setOpened] = useState(false);
+  const close = useStickerHistoryStore((state) => state.close);
+
+  // Only the approved ones and the viewer's own pending, same as the overlay —
+  // this reads the same query, so the list cannot show a sticker the image does
+  // not draw.
+  const { byImage } = useStickerPlacements([imageId], opened);
+  const placements = useMemo(() => orderPlacements(byImage.get(imageId) ?? []), [byImage, imageId]);
+
+  // Closing ends the replay. Leaving a step set would hold the image at a point
+  // in its history with nothing on screen explaining why stickers are missing.
+  useEffect(() => {
+    if (!opened) close();
+  }, [opened, close]);
+
+  // The same unmount, on the way out of the page or a slide change. The store
+  // is global and outlives this component.
+  useEffect(() => () => close(), [close]);
+
+  return (
+    <Popover
+      opened={opened}
+      onChange={setOpened}
+      width={320}
+      position="top"
+      shadow="md"
+      withArrow
+      withinPortal
+    >
+      {/* The button is the target directly. A `Tooltip` in between takes the
+          ref and the click handler Popover hands its target and forwards
+          neither, so the popover never opens — `title` carries the label
+          instead. */}
+      <Popover.Target>
+        <Button
+          size="compact-sm"
+          radius="xl"
+          variant="light"
+          color="gray"
+          aria-label="Sticker history"
+          title="Sticker history"
+          onClick={() => setOpened((o) => !o)}
+          {...buttonProps}
+        >
+          <IconScript size={16} stroke={2} />
+        </Button>
+      </Popover.Target>
+
+      <Popover.Dropdown p={0}>
+        <StickerHistoryList imageId={imageId} placements={placements} />
+      </Popover.Dropdown>
+    </Popover>
+  );
+}
+
+function StickerHistoryList({
+  imageId,
+  placements,
+}: {
+  imageId: number;
+  placements: PlacedSticker[];
+}) {
+  const step = useStickerHistoryStore((state) => (state.imageId === imageId ? state.step : null));
+  const setStep = useStickerHistoryStore((state) => state.setStep);
+  const close = useStickerHistoryStore((state) => state.close);
+
+  const cosmeticIds = useMemo(
+    () => placements.map((placement) => placement.data.cosmeticId),
+    [placements]
+  );
+  const { sticker: artwork } = useStickerCosmetics(cosmeticIds);
+
+  const delays = useMemo(
+    () => placementRevealDelays(placements, { maxTotalMs: REPLAY_TOTAL_MS }),
+    [placements]
+  );
+
+  const timers = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const [playing, setPlaying] = useState(false);
+
+  const stop = () => {
+    timers.current.forEach(clearTimeout);
+    timers.current = [];
+    setPlaying(false);
+  };
+
+  // Timers outlive the component otherwise, and each one writes to a store that
+  // is still mounted — a replay left running over whatever image came next.
+  useEffect(() => () => timers.current.forEach(clearTimeout), []);
+
+  const play = () => {
+    stop();
+    if (placements.length < 2) return;
+    setPlaying(true);
+    setStep(imageId, 0);
+    timers.current = delays.slice(1).map((delay, index) =>
+      setTimeout(() => {
+        setStep(imageId, index + 1);
+        // The last one ends the replay rather than leaving the image pinned to
+        // its final frame, which is the same picture but with the controls
+        // still saying a replay is running.
+        if (index + 1 === placements.length - 1) {
+          setStep(imageId, null);
+          setPlaying(false);
+        }
+      }, delay)
+    );
+  };
+
+  const at = step ?? placements.length - 1;
+  const stepTo = (next: number) => {
+    stop();
+    setStep(imageId, Math.max(0, Math.min(placements.length - 1, next)));
+  };
+
+  if (!placements.length)
+    return (
+      <Text size="xs" c="dimmed" className="p-3">
+        No stickers on this image yet.
+      </Text>
+    );
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex items-center justify-between gap-2 border-b border-gray-3 px-3 py-2 dark:border-dark-4">
+        <Text size="xs" fw={600}>
+          Sticker history
+        </Text>
+        <div className="flex items-center gap-1">
+          <Tooltip label={playing ? 'Stop' : 'Replay'} withArrow>
+            <LegacyActionIcon
+              size="sm"
+              variant="subtle"
+              color="gray"
+              aria-label={playing ? 'Stop replay' : 'Replay the sticker history'}
+              onClick={playing ? () => stop() : play}
+              // One sticker has no build to watch, and a replay of it is a
+              // button that flickers.
+              disabled={placements.length < 2}
+            >
+              {playing ? <IconPlayerStop size={14} /> : <IconPlayerPlay size={14} />}
+            </LegacyActionIcon>
+          </Tooltip>
+          <Tooltip label="Previous sticker" withArrow>
+            <LegacyActionIcon
+              size="sm"
+              variant="subtle"
+              color="gray"
+              aria-label="Previous sticker"
+              onClick={() => stepTo(at - 1)}
+              disabled={at <= 0}
+            >
+              <IconChevronLeft size={14} />
+            </LegacyActionIcon>
+          </Tooltip>
+          <Tooltip label="Next sticker" withArrow>
+            <LegacyActionIcon
+              size="sm"
+              variant="subtle"
+              color="gray"
+              aria-label="Next sticker"
+              onClick={() =>
+                // Past the end is not a step, it is the end of the replay: back
+                // to the image as it stands, which is what closing the panel
+                // would have shown anyway.
+                at >= placements.length - 1 ? setStep(imageId, null) : stepTo(at + 1)
+              }
+            >
+              <IconChevronRight size={14} />
+            </LegacyActionIcon>
+          </Tooltip>
+        </div>
+      </div>
+
+      <ScrollArea.Autosize mah={280}>
+        <ol className="m-0 flex list-none flex-col gap-px p-0">
+          {placements.map((placement, index) => {
+            const art = artwork.get(placement.data.cosmeticId);
+            // Stepping dims what has not been placed yet, so the list and the
+            // image agree about where in the build you are.
+            const shown = step == null || index <= step;
+
+            return (
+              <li key={placement.id}>
+                {/* The same hover card the sticker itself has: who placed it,
+                    when, and their creator card. One component, so the answer
+                    cannot differ depending on which one you hovered. */}
+                <StickerPlacementHoverCard placementId={placement.id} pending={placement.isPending}>
+                  <button
+                    type="button"
+                    onClick={() => stepTo(index)}
+                    className={clsx(
+                      'flex w-full items-center gap-2 border-0 bg-transparent px-3 py-1.5 text-left',
+                      'cursor-pointer hover:bg-gray-1 dark:hover:bg-dark-6',
+                      !shown && 'opacity-40',
+                      step != null && index === step && 'bg-gray-1 dark:bg-dark-6'
+                    )}
+                  >
+                    <Text size="xs" c="dimmed" className="w-4 shrink-0 tabular-nums">
+                      {index + 1}
+                    </Text>
+                    {art ? (
+                      <EdgeImage
+                        src={art.url}
+                        alt={`:${art.slug}:`}
+                        options={{ width: 64, anim: art.animated, optimized: true }}
+                        className="size-8 shrink-0 object-contain"
+                      />
+                    ) : (
+                      <div className="size-8 shrink-0" />
+                    )}
+                    <div className="min-w-0 flex-1">
+                      <Text size="xs" fw={500} className="truncate">
+                        {art?.name ?? 'Sticker'}
+                      </Text>
+                      <Text size="xs" c="dimmed">
+                        {daysFromNow(new Date(placement.placedAt))}
+                        {placement.isPending && ' · awaiting review'}
+                      </Text>
+                    </div>
+                  </button>
+                </StickerPlacementHoverCard>
+              </li>
+            );
+          })}
+        </ol>
+      </ScrollArea.Autosize>
+
+      {step != null && (
+        <button
+          type="button"
+          onClick={() => {
+            stop();
+            close();
+          }}
+          className="cursor-pointer border-0 border-t border-solid border-gray-3 bg-transparent px-3 py-2 text-left dark:border-dark-4"
+        >
+          <Text size="xs" c="dimmed">
+            Showing {step + 1} of {placements.length} — back to the full image
+          </Text>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/Sticker/StickerHistoryPanel.tsx
+++ b/src/components/Sticker/StickerHistoryPanel.tsx
@@ -158,9 +158,14 @@ function StickerHistoryList({
   // is the run stamp the store checks rather than this cleanup.
   useEffect(() => () => timers.current.forEach(clearTimeout), []);
 
-  // Anything that ends the replay from outside this component — dismissing the
-  // popover, a slide change, the reveal toggle — bumps `runId`. Dropping the
-  // timers on the spot stops them queueing behind a run nobody is watching.
+  // Dismissing the popover and changing slide both end the replay through the
+  // store, which bumps `runId`. Dropping the timers on the spot stops them
+  // queueing behind a run nobody is watching.
+  //
+  // The reveal toggle is deliberately NOT one of them: a replay keeps running
+  // and stays drawn with the reveal off, because the overlay draws whenever a
+  // step is set — someone stepping through a history has already asked to see
+  // it.
   const runId = useStickerHistoryStore((state) => state.runId);
   useEffect(() => {
     if (run.current !== null && run.current !== runId) stop();

--- a/src/components/Sticker/StickerHistoryPanel.tsx
+++ b/src/components/Sticker/StickerHistoryPanel.tsx
@@ -22,9 +22,9 @@ import { useStickerCosmetics } from '~/components/Sticker/sticker.util';
 import styles from '~/components/Sticker/placement-reveal.module.scss';
 import { useStickerHistoryStore } from '~/store/sticker-history.store';
 import {
-  REPLAY_MULTIPLIER,
-  REVEAL_MULTIPLIERS,
-  revealMultiplierLabel,
+  REPLAY_SPEED,
+  REVEAL_SPEEDS,
+  revealSpeedLabel,
   useStickerRevealSpeedStore,
 } from '~/store/sticker-reveal-speed.store';
 import { daysFromNow } from '~/utils/date-helpers';
@@ -138,12 +138,12 @@ function StickerHistoryList({
   );
   const { sticker: artwork } = useStickerCosmetics(cosmeticIds);
 
-  const multiplier = useStickerRevealSpeedStore((state) => state.multiplier);
-  const setMultiplier = useStickerRevealSpeedStore((state) => state.setMultiplier);
+  const speed = useStickerRevealSpeedStore((state) => state.speed);
+  const setSpeed = useStickerRevealSpeedStore((state) => state.setSpeed);
 
   const delays = useMemo(
-    () => placementRevealDelays(placements, { multiplier: multiplier * REPLAY_MULTIPLIER }),
-    [placements, multiplier]
+    () => placementRevealDelays(placements, { speed: speed * REPLAY_SPEED }),
+    [placements, speed]
   );
 
   const timers = useRef<ReturnType<typeof setTimeout>[]>([]);
@@ -270,18 +270,17 @@ function StickerHistoryList({
                 <IconSettings size={14} />
               </LegacyActionIcon>
             </Menu.Target>
-            {/* In a portal, so opening it cannot resize the panel either. */}
             <Menu.Dropdown>
               <Menu.Label>Reveal speed</Menu.Label>
-              {REVEAL_MULTIPLIERS.map((option) => (
+              {REVEAL_SPEEDS.map((option) => (
                 <Menu.Item
                   key={option}
-                  onClick={() => setMultiplier(option)}
+                  onClick={() => setSpeed(option)}
                   leftSection={
-                    <IconCheck size={14} className={clsx(option !== multiplier && 'invisible')} />
+                    <IconCheck size={14} className={clsx(option !== speed && 'invisible')} />
                   }
                 >
-                  {revealMultiplierLabel(option)}
+                  {revealSpeedLabel(option)}
                 </Menu.Item>
               ))}
             </Menu.Dropdown>

--- a/src/components/Sticker/StickerHistoryPanel.tsx
+++ b/src/components/Sticker/StickerHistoryPanel.tsx
@@ -1,4 +1,4 @@
-import { Button, Popover, ScrollArea, Text, Tooltip } from '@mantine/core';
+import { Button, Popover, ScrollArea, Skeleton, Text, Tooltip } from '@mantine/core';
 import type { ButtonProps } from '@mantine/core';
 import {
   IconChevronLeft,
@@ -48,7 +48,7 @@ export function StickerHistoryButton({
   // Only the approved ones and the viewer's own pending, same as the overlay —
   // this reads the same query, so the list cannot show a sticker the image does
   // not draw.
-  const { byImage } = useStickerPlacements([imageId], opened);
+  const { byImage, isLoading } = useStickerPlacements([imageId], opened);
   const placements = useMemo(() => orderPlacements(byImage.get(imageId) ?? []), [byImage, imageId]);
 
   // Closing ends the replay. Leaving a step set would hold the image at a point
@@ -56,6 +56,17 @@ export function StickerHistoryButton({
   useEffect(() => {
     if (!opened) close();
   }, [opened, close]);
+
+  // The bar is mounted once and handed a new `imageId` as the carousel moves —
+  // it does not remount — so without this, arrowing to the next image leaves the
+  // popover open, the store pointing at the previous image, and any running
+  // replay writing that image's steps from timers that closed over its id. The
+  // previous slide stays mounted beside the new one, so it sits there clipped to
+  // a step nobody can see the controls for.
+  useEffect(() => {
+    setOpened(false);
+    close();
+  }, [imageId, close]);
 
   // The same unmount, on the way out of the page or a slide change. The store
   // is global and outlives this component.
@@ -91,7 +102,7 @@ export function StickerHistoryButton({
       </Popover.Target>
 
       <Popover.Dropdown p={0}>
-        <StickerHistoryList imageId={imageId} placements={placements} />
+        <StickerHistoryList imageId={imageId} placements={placements} isLoading={isLoading} />
       </Popover.Dropdown>
     </Popover>
   );
@@ -100,9 +111,11 @@ export function StickerHistoryButton({
 function StickerHistoryList({
   imageId,
   placements,
+  isLoading,
 }: {
   imageId: number;
   placements: PlacedSticker[];
+  isLoading: boolean;
 }) {
   const step = useStickerHistoryStore((state) => (state.imageId === imageId ? state.step : null));
   const setStep = useStickerHistoryStore((state) => state.setStep);
@@ -156,6 +169,17 @@ function StickerHistoryList({
     stop();
     setStep(imageId, Math.max(0, Math.min(placements.length - 1, next)));
   };
+
+  // Empty and not-yet-known are different answers to the same question, and this
+  // panel is the one place they are easy to confuse: a signed-out viewer with
+  // the reveal off has nothing primed in the cache, so the empty state would be
+  // the first thing they read — the same sentence a genuinely bare image shows.
+  if (isLoading)
+    return (
+      <div className="p-3">
+        <Skeleton height={64} radius="md" />
+      </div>
+    );
 
   if (!placements.length)
     return (

--- a/src/components/Sticker/StickerPlacementBar.tsx
+++ b/src/components/Sticker/StickerPlacementBar.tsx
@@ -3,6 +3,7 @@ import { IconPlus } from '@tabler/icons-react';
 import clsx from 'clsx';
 import { useReactionSettingsContext } from '~/components/Reaction/ReactionSettingsProvider';
 import { StickerCountChip, useStickerInviteStyle } from '~/components/Sticker/StickerCountChip';
+import { StickerHistoryButton } from '~/components/Sticker/StickerHistoryPanel';
 import { StickerPlacementTray } from '~/components/Sticker/StickerPlacementTray';
 import {
   useImagePlacementSpace,
@@ -117,6 +118,13 @@ export function StickerPlacementBar({
             onClick={() => openTray(imageId)}
             buttonProps={buttonStyling?.('BuzzTip')}
           />
+        )}
+
+        {/* Only where there is a history to read. At zero the group is an
+            invitation to place the first one, and a history button beside it
+            opens onto nothing. */}
+        {total > 0 && (
+          <StickerHistoryButton imageId={imageId} buttonProps={buttonStyling?.('AddReaction')} />
         )}
 
         {canPlace && (

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -13,7 +13,7 @@ import {
   type StickerTreatmentKey,
 } from '~/components/Sticker/treatments/sticker-treatments';
 import styles from '~/components/Sticker/placement-reveal.module.scss';
-import { useRevealDuration } from '~/store/sticker-reveal-speed.store';
+import { useRevealMultiplier } from '~/store/sticker-reveal-speed.store';
 import { useEffect, useMemo, useState, type CSSProperties, type ReactElement } from 'react';
 
 /**
@@ -158,10 +158,10 @@ export function StickerPlacementOverlay({
   const ordered = useMemo(() => orderPlacements(placements), [placements]);
   // Off the full history, not off the visible slice: stepping through a replay
   // must not re-pace the stickers already on screen.
-  const revealDuration = useRevealDuration();
+  const revealMultiplier = useRevealMultiplier();
   const delays = useMemo(
-    () => (stagger ? placementRevealDelays(ordered, { totalMs: revealDuration }) : null),
-    [ordered, stagger, revealDuration]
+    () => (stagger ? placementRevealDelays(ordered, { multiplier: revealMultiplier }) : null),
+    [ordered, stagger, revealMultiplier]
   );
 
   // The arrival reveal belongs to this mount, and a replay is the panel's job

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -191,11 +191,13 @@ export function StickerPlacementOverlay({
   // Only pending placements are measured; nothing else is positioned relative to
   // a sticker's edge.
   const [stickerHeights, setStickerHeights] = useState<Record<number, number>>({});
-  const observers = useRef(new Map<number, ResizeObserver>());
+  // Disposers rather than observers, because the no-`ResizeObserver` path has
+  // its own thing to unhook.
+  const disposers = useRef(new Map<number, () => void>());
   useEffect(() => {
-    const live = observers.current;
+    const live = disposers.current;
     return () => {
-      live.forEach((observer) => observer.disconnect());
+      live.forEach((dispose) => dispose());
       live.clear();
     };
   }, []);
@@ -204,10 +206,10 @@ export function StickerPlacementOverlay({
     (placement: PlacedSticker) => (node: HTMLDivElement | null) => {
       const placementId = placement.id;
       const radians = (placement.data.rotation * Math.PI) / 180;
-      const existing = observers.current.get(placementId);
+      const existing = disposers.current.get(placementId);
       if (existing) {
-        existing.disconnect();
-        observers.current.delete(placementId);
+        existing();
+        disposers.current.delete(placementId);
       }
       if (!node) return;
 
@@ -236,16 +238,21 @@ export function StickerPlacementOverlay({
       };
 
       // No observer is not a reason to hide the owner's only control forever —
-      // the same call the sibling observer makes, and it was inverted here. One
-      // measurement now, and it simply does not follow later resizes.
+      // the same call the sibling observer makes, and it was inverted here.
+      // Measured now and again when the artwork lands, because before the image
+      // loads the box is zero-height and the controls would sit on the sticker's
+      // centre until something re-measured. `load` does not bubble, so the
+      // listener captures.
       if (typeof ResizeObserver === 'undefined') {
         record();
+        node.addEventListener('load', record, true);
+        disposers.current.set(placementId, () => node.removeEventListener('load', record, true));
         return;
       }
 
       const observer = new ResizeObserver(record);
       observer.observe(node);
-      observers.current.set(placementId, observer);
+      disposers.current.set(placementId, () => observer.disconnect());
     },
     []
   );
@@ -392,7 +399,12 @@ export function StickerPlacementOverlay({
           // get the hover card — the owner needs to know who is asking before
           // answering, and the placer gets the same detail they would once it goes
           // live. Only the owner gets the buttons.
-          if (stickerHeights[placement.id] != null)
+          // `> 0`, not merely present. Before the artwork loads the box is
+          // zero-height, and at rotation 0 the measurement is exactly 0 — a real
+          // number that says nothing about where the sticker's edge is. Treating
+          // it as valid put the controls 14px below the sticker's CENTRE, on top
+          // of the artwork, until the image landed and moved them.
+          if (stickerHeights[placement.id] > 0)
             pendingControls.push(
               <div key={placement.id}>
                 {/* ⚠️ Known wrong, and left wrong deliberately.

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -51,6 +51,7 @@ export function StickerPlacementOverlay({
   treatment = STILL_STICKER_TREATMENT,
   surface = 'detail',
   stagger = false,
+  armed = false,
   step = null,
 }: {
   placements: PlacedSticker[];
@@ -113,6 +114,17 @@ export function StickerPlacementOverlay({
    * same reason the treatments drop their animation on a card.
    */
   stagger?: boolean;
+  /**
+   * Whether the staggering surface is being looked at yet.
+   *
+   * Separate from `stagger` because the two answer different questions and the
+   * gap between them is a frame the viewer sees. `stagger` is a property of the
+   * surface and is known at the first render; arming is an observation that
+   * cannot happen until after a paint. While a staggering surface is unarmed its
+   * stickers are held at zero opacity, so the reveal starts from blank rather
+   * than from a painted frame it then has to blank out.
+   */
+  armed?: boolean;
   /**
    * Index of the last sticker to draw, for the history replay. `null` draws all
    * of them, which is every surface that is not being stepped through.
@@ -183,7 +195,7 @@ export function StickerPlacementOverlay({
           // a sticker silently sliding under the one it was placed over is the
           // one failure this layer exists to prevent.
           const layer = index + 1;
-          const delay = step == null && !replayed ? delays?.[index] ?? 0 : 0;
+          const delay = armed && step == null && !replayed ? delays?.[index] ?? 0 : 0;
           const delayStyle = delay ? ({ '--sticker-delay': `${delay}ms` } as CSSProperties) : {};
 
           // Pending rows only ever reach a viewer who is party to them — the
@@ -221,7 +233,7 @@ export function StickerPlacementOverlay({
               className={clsx(
                 'absolute',
                 interactive && 'pointer-events-auto',
-                stagger && styles.appear
+                stagger && (armed ? styles.appear : styles.hold)
               )}
               style={{
                 left: `${placement.data.x * 100}%`,

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -52,6 +52,7 @@ export function StickerPlacementOverlay({
   surface = 'detail',
   stagger = false,
   armed = false,
+  paced = true,
   step = null,
 }: {
   placements: PlacedSticker[];
@@ -126,6 +127,16 @@ export function StickerPlacementOverlay({
    */
   armed?: boolean;
   /**
+   * Whether to space the reveal out. Off reveals everything together, in one
+   * short fade — still no un-staggered frame, just no sequence.
+   *
+   * Separate from `stagger` because `stagger` must not change while mounted:
+   * removing it and putting it back re-adds the animation to elements already
+   * on screen, which replays the whole reveal. Anything that wants the reveal
+   * to stop being a sequence has to say so without touching that flag.
+   */
+  paced?: boolean;
+  /**
    * Index of the last sticker to draw, for the history replay. `null` draws all
    * of them, which is every surface that is not being stepped through.
    */
@@ -195,7 +206,7 @@ export function StickerPlacementOverlay({
           // a sticker silently sliding under the one it was placed over is the
           // one failure this layer exists to prevent.
           const layer = index + 1;
-          const delay = armed && step == null && !replayed ? delays?.[index] ?? 0 : 0;
+          const delay = paced && armed && step == null && !replayed ? delays?.[index] ?? 0 : 0;
           const delayStyle = delay ? ({ '--sticker-delay': `${delay}ms` } as CSSProperties) : {};
 
           // Pending rows only ever reach a viewer who is party to them — the

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -392,9 +392,10 @@ export function StickerPlacementOverlay({
           // get the hover card — the owner needs to know who is asking before
           // answering, and the placer gets the same detail they would once it goes
           // live. Only the owner gets the buttons.
-          pendingControls.push(
-            <div key={placement.id}>
-              {/* ⚠️ Known wrong, and left wrong deliberately.
+          if (stickerHeights[placement.id] != null)
+            pendingControls.push(
+              <div key={placement.id}>
+                {/* ⚠️ Known wrong, and left wrong deliberately.
 
                 `scale` is a fraction of the media box's WIDTH while a `top`
                 percentage resolves against its HEIGHT, so this is the sticker's
@@ -421,40 +422,44 @@ export function StickerPlacementOverlay({
                     buttons. Nothing done INSIDE the box can fix that; it needs
                     the badge kept outside the transform (what this does) or a
                     z-index on the pending wrapper itself. */}
-              <div
-                className={clsx('pointer-events-auto absolute -translate-x-1/2', revealClassName)}
-                style={{
-                  left: `${placement.data.x * 100}%`,
-                  // Measured half-height plus a gap, in pixels. No percentage
-                  // arithmetic: a percentage in `top` resolves against the box's
-                  // height while the sticker is sized from its width, and every
-                  // attempt to reconcile the two by calculation has been wrong on
-                  // some aspect ratio. Until the measurement lands the controls
-                  // are held off screen rather than parked at the sticker's
-                  // centre, where they would sit on top of the artwork for a
-                  // frame and then jump.
-                  top: `calc(${placement.data.y * 100}% + ${
-                    (stickerHeights[placement.id] ?? 0) / 2 + CONTROL_GAP_PX
-                  }px)`,
-                  // Above every sticker, not just above the one it belongs to:
-                  // the layer order means anything placed later covers this
-                  // sticker, and it would cover the owner's only way to answer.
-                  zIndex: layer,
-                  ...delayStyle,
-                }}
-              >
-                <div>
-                  {isOwner ? (
-                    <StickerPlacementActions placementIds={[placement.id]} compact />
-                  ) : (
-                    <span className="whitespace-nowrap rounded bg-yellow-6 px-2 py-0.5 text-[10px] font-semibold text-dark-9">
-                      Awaiting review
-                    </span>
-                  )}
+                {/* Not rendered at all until the sticker has been measured.
+                  Rendering it early would put it at the sticker's centre — on
+                  top of the artwork — and then jump when the measurement lands.
+                  An inline `visibility` did that job until the reveal started
+                  animating visibility itself, at which point the two were
+                  fighting over the same property. Absent beats hidden here:
+                  there is nothing to interact with either. */}
+                <div
+                  className={clsx('pointer-events-auto absolute -translate-x-1/2', revealClassName)}
+                  style={{
+                    left: `${placement.data.x * 100}%`,
+                    // Measured half-height plus a gap, in pixels. No percentage
+                    // arithmetic: a percentage in `top` resolves against the box's
+                    // height while the sticker is sized from its width, and every
+                    // attempt to reconcile the two by calculation has been wrong on
+                    // some aspect ratio.
+                    top: `calc(${placement.data.y * 100}% + ${
+                      stickerHeights[placement.id] / 2 + CONTROL_GAP_PX
+                    }px)`,
+                    // Above every sticker, not just above the one it belongs to:
+                    // the layer order means anything placed later covers this
+                    // sticker, and it would cover the owner's only way to answer.
+                    zIndex: layer,
+                    ...delayStyle,
+                  }}
+                >
+                  <div>
+                    {isOwner ? (
+                      <StickerPlacementActions placementIds={[placement.id]} compact />
+                    ) : (
+                      <span className="whitespace-nowrap rounded bg-yellow-6 px-2 py-0.5 text-[10px] font-semibold text-dark-9">
+                        Awaiting review
+                      </span>
+                    )}
+                  </div>
                 </div>
               </div>
-            </div>
-          );
+            );
 
           return (
             <StickerPlacementHoverCard key={placement.id} placementId={placement.id} pending>

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -13,7 +13,7 @@ import {
   type StickerTreatmentKey,
 } from '~/components/Sticker/treatments/sticker-treatments';
 import styles from '~/components/Sticker/placement-reveal.module.scss';
-import { useRevealMultiplier } from '~/store/sticker-reveal-speed.store';
+import { useRevealSpeed } from '~/store/sticker-reveal-speed.store';
 import {
   useCallback,
   useEffect,
@@ -175,10 +175,10 @@ export function StickerPlacementOverlay({
   const ordered = useMemo(() => orderPlacements(placements), [placements]);
   // Off the full history, not off the visible slice: stepping through a replay
   // must not re-pace the stickers already on screen.
-  const revealMultiplier = useRevealMultiplier();
+  const revealSpeed = useRevealSpeed();
   const delays = useMemo(
-    () => (stagger ? placementRevealDelays(ordered, { multiplier: revealMultiplier }) : null),
-    [ordered, stagger, revealMultiplier]
+    () => (stagger ? placementRevealDelays(ordered, { speed: revealSpeed }) : null),
+    [ordered, stagger, revealSpeed]
   );
 
   // The rendered height of each pending sticker, in pixels, measured rather than
@@ -203,14 +203,15 @@ export function StickerPlacementOverlay({
   const measureSticker = useCallback(
     (placement: PlacedSticker) => (node: HTMLDivElement | null) => {
       const placementId = placement.id;
+      const radians = (placement.data.rotation * Math.PI) / 180;
       const existing = observers.current.get(placementId);
       if (existing) {
         existing.disconnect();
         observers.current.delete(placementId);
       }
-      if (!node || typeof ResizeObserver === 'undefined') return;
+      if (!node) return;
 
-      const observer = new ResizeObserver(() => {
+      const read = () =>
         // `offsetHeight`/`offsetWidth`, deliberately: they are LAYOUT numbers and
         // ignore transforms. A bounding rect would be simpler and is wrong here,
         // because the artwork animates — it pops from 0.72 to 1.06 on arrival and
@@ -222,16 +223,27 @@ export function StickerPlacementOverlay({
         // height is h·|cos r| + w·|sin r|, and ignoring the second term is what
         // put the buttons over the artwork on anything more than slightly
         // turned.
-        const radians = (placement.data.rotation * Math.PI) / 180;
-        const height =
-          node.offsetHeight * Math.abs(Math.cos(radians)) +
-          node.offsetWidth * Math.abs(Math.sin(radians));
+        node.offsetHeight * Math.abs(Math.cos(radians)) +
+        node.offsetWidth * Math.abs(Math.sin(radians));
+
+      const record = () => {
+        const height = read();
         // Guarded, because writing state from a ResizeObserver that the write
         // then resizes is how a resize loop starts.
         setStickerHeights((current) =>
           current[placementId] === height ? current : { ...current, [placementId]: height }
         );
-      });
+      };
+
+      // No observer is not a reason to hide the owner's only control forever —
+      // the same call the sibling observer makes, and it was inverted here. One
+      // measurement now, and it simply does not follow later resizes.
+      if (typeof ResizeObserver === 'undefined') {
+        record();
+        return;
+      }
+
+      const observer = new ResizeObserver(record);
       observer.observe(node);
       observers.current.set(placementId, observer);
     },
@@ -242,6 +254,13 @@ export function StickerPlacementOverlay({
   useEffect(() => {
     if (step != null) setReplayed(true);
   }, [step]);
+  // Cleared when the surface leaves the screen, because arming repeats now: one
+  // replay used to unpace every later arrival for the lifetime of the mount, so
+  // coming back to a slide you had once stepped through revealed everything at
+  // once with no sequence.
+  useEffect(() => {
+    if (!armed) setReplayed(false);
+  }, [armed]);
 
   if (!placements.length) return null;
 
@@ -417,7 +436,6 @@ export function StickerPlacementOverlay({
                   top: `calc(${placement.data.y * 100}% + ${
                     (stickerHeights[placement.id] ?? 0) / 2 + CONTROL_GAP_PX
                   }px)`,
-                  visibility: stickerHeights[placement.id] ? 'visible' : 'hidden',
                   // Above every sticker, not just above the one it belongs to:
                   // the layer order means anything placed later covers this
                   // sticker, and it would cover the owner's only way to answer.

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -13,6 +13,7 @@ import {
   type StickerTreatmentKey,
 } from '~/components/Sticker/treatments/sticker-treatments';
 import styles from '~/components/Sticker/placement-reveal.module.scss';
+import { useRevealDuration } from '~/store/sticker-reveal-speed.store';
 import { useEffect, useMemo, useState, type CSSProperties, type ReactElement } from 'react';
 
 /**
@@ -157,9 +158,10 @@ export function StickerPlacementOverlay({
   const ordered = useMemo(() => orderPlacements(placements), [placements]);
   // Off the full history, not off the visible slice: stepping through a replay
   // must not re-pace the stickers already on screen.
+  const revealDuration = useRevealDuration();
   const delays = useMemo(
-    () => (stagger ? placementRevealDelays(ordered) : null),
-    [ordered, stagger]
+    () => (stagger ? placementRevealDelays(ordered, { maxTotalMs: revealDuration }) : null),
+    [ordered, stagger, revealDuration]
   );
 
   // The arrival reveal belongs to this mount, and a replay is the panel's job

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -67,6 +67,7 @@ export function StickerPlacementOverlay({
   stagger = false,
   armed = false,
   paced = true,
+  mediaAspect = 1,
   step = null,
 }: {
   placements: PlacedSticker[];
@@ -150,6 +151,22 @@ export function StickerPlacementOverlay({
    * to stop being a sequence has to say so without touching that flag.
    */
   paced?: boolean;
+  /**
+   * Width ÷ height of the box these are drawn on.
+   *
+   * Only the pending controls need it, and they need it because a sticker's
+   * `scale` is a fraction of the box's WIDTH while the `top` that places them
+   * resolves against its HEIGHT. Without the ratio the two are treated as the
+   * same unit, which on a 768×1152 image put the owner's buttons half again as
+   * far below the sticker as they should be — the "gap on the tall side" the
+   * comment below has described since before anyone had seen it.
+   *
+   * Still an approximation: it assumes a square sticker, because the artwork's
+   * own aspect is only knowable by measuring it once loaded. Square is what
+   * sticker artwork mostly is, and being wrong by the artwork's aspect is much
+   * closer than being wrong by the image's.
+   */
+  mediaAspect?: number;
   /**
    * Index of the last sticker to draw, for the history replay. `null` draws all
    * of them, which is every surface that is not being stepped through.
@@ -344,27 +361,22 @@ export function StickerPlacementOverlay({
                     buttons. Nothing done INSIDE the box can fix that; it needs
                     the badge kept outside the transform (what this does) or a
                     z-index on the pending wrapper itself. */}
+              {/* Two elements, and the split is what keeps it centred: the
+                  outer one only positions — `translateX(-50%)` against the
+                  sticker's own x — and the inner one only turns. With both on
+                  one element the rotation swings the box around its hinge and
+                  drags the centring with it, which reads as the block sitting
+                  off to one side. */}
               <div
-                className={clsx('pointer-events-auto absolute', revealClassName)}
+                className={clsx('pointer-events-auto absolute -translate-x-1/2', revealClassName)}
                 style={{
                   left: `${placement.data.x * 100}%`,
-                  top: `calc(${placement.data.y * 100}% + ${placement.data.scale * 50}%)`,
-                  // Tilted to match the sticker, hinged at the edge nearest it,
-                  // so the block reads as attached to a rotated sticker rather
-                  // than as a level bar under a crooked one.
-                  //
-                  // It does NOT orbit the sticker's centre — it stays where it
-                  // was and only turns. Orbiting needs the sticker's rendered
-                  // HEIGHT, and the anchor above is already approximate for
-                  // exactly that reason: `scale` is a fraction of the width
-                  // while `top` resolves against the height, so the true offset
-                  // needs the sticker's own aspect ratio, which is only knowable
-                  // by measuring the loaded artwork. Turning in place needs none
-                  // of that and carries most of the effect.
-                  transform: `translateX(-50%) rotate(${uprightRotation(
-                    placement.data.rotation
-                  )}deg)`,
-                  transformOrigin: 'top center',
+                  // The sticker's half-height, corrected for the box's aspect,
+                  // plus a small constant so it clears the artwork instead of
+                  // touching it.
+                  top: `calc(${placement.data.y * 100}% + ${
+                    placement.data.scale * 50 * mediaAspect
+                  }% + 4px)`,
                   // Above every sticker, not just above the one it belongs to:
                   // the layer order means anything placed later covers this
                   // sticker, and it would cover the owner's only way to answer.
@@ -372,13 +384,25 @@ export function StickerPlacementOverlay({
                   ...delayStyle,
                 }}
               >
-                {isOwner ? (
-                  <StickerPlacementActions placementIds={[placement.id]} compact />
-                ) : (
-                  <span className="whitespace-nowrap rounded bg-yellow-6 px-2 py-0.5 text-[10px] font-semibold text-dark-9">
-                    Awaiting review
-                  </span>
-                )}
+                <div
+                  style={{
+                    // Tilted to match the sticker, hinged at the edge nearest
+                    // it, so the block reads as attached to a rotated sticker
+                    // rather than as a level bar under a crooked one. It turns
+                    // in place rather than orbiting the sticker's centre, which
+                    // would need the artwork's real rendered height.
+                    transform: `rotate(${uprightRotation(placement.data.rotation)}deg)`,
+                    transformOrigin: 'top center',
+                  }}
+                >
+                  {isOwner ? (
+                    <StickerPlacementActions placementIds={[placement.id]} compact />
+                  ) : (
+                    <span className="whitespace-nowrap rounded bg-yellow-6 px-2 py-0.5 text-[10px] font-semibold text-dark-9">
+                      Awaiting review
+                    </span>
+                  )}
+                </div>
               </div>
             </div>
           );

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -160,7 +160,7 @@ export function StickerPlacementOverlay({
   // must not re-pace the stickers already on screen.
   const revealDuration = useRevealDuration();
   const delays = useMemo(
-    () => (stagger ? placementRevealDelays(ordered, { maxTotalMs: revealDuration }) : null),
+    () => (stagger ? placementRevealDelays(ordered, { totalMs: revealDuration }) : null),
     [ordered, stagger, revealDuration]
   );
 

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -208,6 +208,12 @@ export function StickerPlacementOverlay({
           const layer = index + 1;
           const delay = paced && armed && step == null && !replayed ? delays?.[index] ?? 0 : 0;
           const delayStyle = delay ? ({ '--sticker-delay': `${delay}ms` } as CSSProperties) : {};
+          // Worn by everything belonging to this placement, not just the
+          // artwork. The owner's approve/decline is drawn in a separate layer,
+          // and without this it appeared instantly over a sticker still waiting
+          // its turn — buttons hovering over nothing, asking about a sticker
+          // that had not arrived yet.
+          const revealClassName = stagger && (armed ? styles.appear : styles.hold);
 
           // Pending rows only ever reach a viewer who is party to them — the
           // server scopes them to the placer and the owner — so this decides how
@@ -241,11 +247,7 @@ export function StickerPlacementOverlay({
           const body = (
             <div
               key={placement.id}
-              className={clsx(
-                'absolute',
-                interactive && 'pointer-events-auto',
-                stagger && (armed ? styles.appear : styles.hold)
-              )}
+              className={clsx('absolute', interactive && 'pointer-events-auto', revealClassName)}
               style={{
                 left: `${placement.data.x * 100}%`,
                 top: `${placement.data.y * 100}%`,
@@ -328,7 +330,7 @@ export function StickerPlacementOverlay({
                     the badge kept outside the transform (what this does) or a
                     z-index on the pending wrapper itself. */}
               <div
-                className="pointer-events-auto absolute -translate-x-1/2"
+                className={clsx('pointer-events-auto absolute -translate-x-1/2', revealClassName)}
                 style={{
                   left: `${placement.data.x * 100}%`,
                   top: `calc(${placement.data.y * 100}% + ${placement.data.scale * 50}%)`,
@@ -336,6 +338,7 @@ export function StickerPlacementOverlay({
                   // the layer order means anything placed later covers this
                   // sticker, and it would cover the owner's only way to answer.
                   zIndex: layer,
+                  ...delayStyle,
                 }}
               >
                 {isOwner ? (

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -34,6 +34,15 @@ import {
 const PENDING_CONTROL_Z = 1000;
 
 /**
+ * Clear air between the bottom of a pending sticker and the owner's controls.
+ *
+ * Generous rather than tight: the artwork sways for as long as it is on screen,
+ * and the treatments draw shadows and a die-cut edge outside the element's box,
+ * so a gap measured to the pixel is a gap the sticker moves into.
+ */
+const CONTROL_GAP_PX = 14;
+
+/**
  * Placed stickers, drawn over the content they were placed on.
  *
  * Oldest at the bottom, newest on top. Covering another sticker is a feature —
@@ -172,10 +181,6 @@ export function StickerPlacementOverlay({
     [ordered, stagger, revealMultiplier]
   );
 
-  // The arrival reveal belongs to this mount, and a replay is the panel's job
-  // from then on. Without this, ending a replay hands every sticker its arrival
-  // delay back — on elements that are already on screen with their animations
-  // finished, which re-pins the sway mid-cycle and can re-run the pop.
   // The rendered height of each pending sticker, in pixels, measured rather than
   // derived. Two attempts to compute where the owner's controls go from `scale`
   // were both wrong on real images, because `scale` is a fraction of the box's
@@ -196,7 +201,8 @@ export function StickerPlacementOverlay({
   }, []);
 
   const measureSticker = useCallback(
-    (placementId: number) => (node: HTMLDivElement | null) => {
+    (placement: PlacedSticker) => (node: HTMLDivElement | null) => {
+      const placementId = placement.id;
       const existing = observers.current.get(placementId);
       if (existing) {
         existing.disconnect();
@@ -205,7 +211,21 @@ export function StickerPlacementOverlay({
       if (!node || typeof ResizeObserver === 'undefined') return;
 
       const observer = new ResizeObserver(() => {
-        const height = node.offsetHeight;
+        // `offsetHeight`/`offsetWidth`, deliberately: they are LAYOUT numbers and
+        // ignore transforms. A bounding rect would be simpler and is wrong here,
+        // because the artwork animates — it pops from 0.72 to 1.06 on arrival and
+        // sways forever after — so a rect measured at observe time is whatever
+        // frame that landed on, and a sticker measured mid-pop reports too small
+        // and the controls sit on top of it.
+        //
+        // The rotation is then added back by hand: a tilted rectangle's visual
+        // height is h·|cos r| + w·|sin r|, and ignoring the second term is what
+        // put the buttons over the artwork on anything more than slightly
+        // turned.
+        const radians = (placement.data.rotation * Math.PI) / 180;
+        const height =
+          node.offsetHeight * Math.abs(Math.cos(radians)) +
+          node.offsetWidth * Math.abs(Math.sin(radians));
         // Guarded, because writing state from a ResizeObserver that the write
         // then resizes is how a resize loop starts.
         setStickerHeights((current) =>
@@ -299,7 +319,7 @@ export function StickerPlacementOverlay({
           const body = (
             <div
               key={placement.id}
-              ref={placement.isPending ? measureSticker(placement.id) : undefined}
+              ref={placement.isPending ? measureSticker(placement) : undefined}
               className={clsx('absolute', interactive && 'pointer-events-auto', revealClassName)}
               style={{
                 left: `${placement.data.x * 100}%`,
@@ -395,7 +415,7 @@ export function StickerPlacementOverlay({
                   // centre, where they would sit on top of the artwork for a
                   // frame and then jump.
                   top: `calc(${placement.data.y * 100}% + ${
-                    (stickerHeights[placement.id] ?? 0) / 2 + 8
+                    (stickerHeights[placement.id] ?? 0) / 2 + CONTROL_GAP_PX
                   }px)`,
                   visibility: stickerHeights[placement.id] ? 'visible' : 'hidden',
                   // Above every sticker, not just above the one it belongs to:

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -14,7 +14,15 @@ import {
 } from '~/components/Sticker/treatments/sticker-treatments';
 import styles from '~/components/Sticker/placement-reveal.module.scss';
 import { useRevealMultiplier } from '~/store/sticker-reveal-speed.store';
-import { useEffect, useMemo, useState, type CSSProperties, type ReactElement } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactElement,
+} from 'react';
 
 /**
  * The pending controls' layer, above the stickers and above the draft.
@@ -24,19 +32,6 @@ import { useEffect, useMemo, useState, type CSSProperties, type ReactElement } f
  * bury the owner's only way to answer a pending placement.
  */
 const PENDING_CONTROL_Z = 1000;
-
-/**
- * The sticker's angle, adjusted so anything carrying text never ends up upside
- * down.
- *
- * Rotation is clamped to ±180, so following it faithfully would hand the owner
- * their approve/decline mirrored — worse than not rotating at all, which is the
- * failure Justin called out before asking for this. Past a quarter turn the
- * block is flipped back the other way: it still reads as belonging to a tilted
- * sticker, and the words stay the right way up.
- */
-const uprightRotation = (rotation: number) =>
-  Math.abs(rotation) > 90 ? rotation - Math.sign(rotation) * 180 : rotation;
 
 /**
  * Placed stickers, drawn over the content they were placed on.
@@ -67,7 +62,6 @@ export function StickerPlacementOverlay({
   stagger = false,
   armed = false,
   paced = true,
-  mediaAspect = 1,
   step = null,
 }: {
   placements: PlacedSticker[];
@@ -152,22 +146,6 @@ export function StickerPlacementOverlay({
    */
   paced?: boolean;
   /**
-   * Width ÷ height of the box these are drawn on.
-   *
-   * Only the pending controls need it, and they need it because a sticker's
-   * `scale` is a fraction of the box's WIDTH while the `top` that places them
-   * resolves against its HEIGHT. Without the ratio the two are treated as the
-   * same unit, which on a 768×1152 image put the owner's buttons half again as
-   * far below the sticker as they should be — the "gap on the tall side" the
-   * comment below has described since before anyone had seen it.
-   *
-   * Still an approximation: it assumes a square sticker, because the artwork's
-   * own aspect is only knowable by measuring it once loaded. Square is what
-   * sticker artwork mostly is, and being wrong by the artwork's aspect is much
-   * closer than being wrong by the image's.
-   */
-  mediaAspect?: number;
-  /**
    * Index of the last sticker to draw, for the history replay. `null` draws all
    * of them, which is every surface that is not being stepped through.
    */
@@ -198,6 +176,48 @@ export function StickerPlacementOverlay({
   // from then on. Without this, ending a replay hands every sticker its arrival
   // delay back — on elements that are already on screen with their animations
   // finished, which re-pins the sway mid-cycle and can re-run the pop.
+  // The rendered height of each pending sticker, in pixels, measured rather than
+  // derived. Two attempts to compute where the owner's controls go from `scale`
+  // were both wrong on real images, because `scale` is a fraction of the box's
+  // WIDTH and the artwork's own aspect is not in the payload at all — the number
+  // needed here is simply not knowable from the data. It IS knowable from the
+  // element, so it is read off the element.
+  //
+  // Only pending placements are measured; nothing else is positioned relative to
+  // a sticker's edge.
+  const [stickerHeights, setStickerHeights] = useState<Record<number, number>>({});
+  const observers = useRef(new Map<number, ResizeObserver>());
+  useEffect(() => {
+    const live = observers.current;
+    return () => {
+      live.forEach((observer) => observer.disconnect());
+      live.clear();
+    };
+  }, []);
+
+  const measureSticker = useCallback(
+    (placementId: number) => (node: HTMLDivElement | null) => {
+      const existing = observers.current.get(placementId);
+      if (existing) {
+        existing.disconnect();
+        observers.current.delete(placementId);
+      }
+      if (!node || typeof ResizeObserver === 'undefined') return;
+
+      const observer = new ResizeObserver(() => {
+        const height = node.offsetHeight;
+        // Guarded, because writing state from a ResizeObserver that the write
+        // then resizes is how a resize loop starts.
+        setStickerHeights((current) =>
+          current[placementId] === height ? current : { ...current, [placementId]: height }
+        );
+      });
+      observer.observe(node);
+      observers.current.set(placementId, observer);
+    },
+    []
+  );
+
   const [replayed, setReplayed] = useState(false);
   useEffect(() => {
     if (step != null) setReplayed(true);
@@ -279,6 +299,7 @@ export function StickerPlacementOverlay({
           const body = (
             <div
               key={placement.id}
+              ref={placement.isPending ? measureSticker(placement.id) : undefined}
               className={clsx('absolute', interactive && 'pointer-events-auto', revealClassName)}
               style={{
                 left: `${placement.data.x * 100}%`,
@@ -361,22 +382,22 @@ export function StickerPlacementOverlay({
                     buttons. Nothing done INSIDE the box can fix that; it needs
                     the badge kept outside the transform (what this does) or a
                     z-index on the pending wrapper itself. */}
-              {/* Two elements, and the split is what keeps it centred: the
-                  outer one only positions — `translateX(-50%)` against the
-                  sticker's own x — and the inner one only turns. With both on
-                  one element the rotation swings the box around its hinge and
-                  drags the centring with it, which reads as the block sitting
-                  off to one side. */}
               <div
                 className={clsx('pointer-events-auto absolute -translate-x-1/2', revealClassName)}
                 style={{
                   left: `${placement.data.x * 100}%`,
-                  // The sticker's half-height, corrected for the box's aspect,
-                  // plus a small constant so it clears the artwork instead of
-                  // touching it.
+                  // Measured half-height plus a gap, in pixels. No percentage
+                  // arithmetic: a percentage in `top` resolves against the box's
+                  // height while the sticker is sized from its width, and every
+                  // attempt to reconcile the two by calculation has been wrong on
+                  // some aspect ratio. Until the measurement lands the controls
+                  // are held off screen rather than parked at the sticker's
+                  // centre, where they would sit on top of the artwork for a
+                  // frame and then jump.
                   top: `calc(${placement.data.y * 100}% + ${
-                    placement.data.scale * 50 * mediaAspect
-                  }% + 4px)`,
+                    (stickerHeights[placement.id] ?? 0) / 2 + 8
+                  }px)`,
+                  visibility: stickerHeights[placement.id] ? 'visible' : 'hidden',
                   // Above every sticker, not just above the one it belongs to:
                   // the layer order means anything placed later covers this
                   // sticker, and it would cover the owner's only way to answer.
@@ -384,17 +405,7 @@ export function StickerPlacementOverlay({
                   ...delayStyle,
                 }}
               >
-                <div
-                  style={{
-                    // Tilted to match the sticker, hinged at the edge nearest
-                    // it, so the block reads as attached to a rotated sticker
-                    // rather than as a level bar under a crooked one. It turns
-                    // in place rather than orbiting the sticker's centre, which
-                    // would need the artwork's real rendered height.
-                    transform: `rotate(${uprightRotation(placement.data.rotation)}deg)`,
-                    transformOrigin: 'top center',
-                  }}
-                >
+                <div>
                   {isOwner ? (
                     <StickerPlacementActions placementIds={[placement.id]} compact />
                   ) : (

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -13,14 +13,14 @@ import {
   type StickerTreatmentKey,
 } from '~/components/Sticker/treatments/sticker-treatments';
 import styles from '~/components/Sticker/placement-reveal.module.scss';
-import { useEffect, useMemo, useState, type CSSProperties } from 'react';
+import { useEffect, useMemo, useState, type CSSProperties, type ReactElement } from 'react';
 
 /**
- * Below every pending placement's controls, and above every sticker.
+ * The pending controls' layer, above the stickers and above the draft.
  *
- * The owner's approve/decline sits outside its sticker's transform so it can
- * out-rank a sticker placed later — which is the point of the layer order, and
- * would otherwise bury the buttons under the sticker covering them.
+ * Only has to clear the draft sticker's own z-index, which is 1 — the number is
+ * this far clear of it so a later hand-written z-index nearby does not silently
+ * bury the owner's only way to answer a pending placement.
  */
 const PENDING_CONTROL_Z = 1000;
 
@@ -152,117 +152,132 @@ export function StickerPlacementOverlay({
 
   const visible = step == null ? ordered : ordered.slice(0, step + 1);
 
+  // The owner's approve/decline for each pending placement, collected here and
+  // drawn in their own layer below. They cannot live in the isolated layer: they
+  // have to out-rank the draft sticker as well as every placed one, and the
+  // isolation that keeps the layer order from leaking would trap them under it.
+  const pendingControls: ReactElement[] = [];
+
   return (
-    <div className={clsx('pointer-events-none absolute inset-0 overflow-hidden', className)}>
-      {visible.map((placement, index) => {
-        const art = artwork.get(placement.data.cosmeticId);
-        if (!art) return null;
+    <>
+      {/* `isolate` is load-bearing. Without it these z-indexes are hoisted into
+          whatever context the surface provides and compete with everything else
+          in it: on the detail view the draft being dragged (which is a sibling
+          with z-index 1 at most, so every sticker above the first would cover
+          it, along with its buy button and its hit area), and on a feed card the
+          header and footer, which are absolutely positioned with no z-index of
+          their own and rely on DOM order — AspectRatioImageCard states "under
+          the header and footer" as a contract. Contained, the whole layer keeps
+          the z-index it had before this change, and the ordering inside it is
+          purely internal. */}
+      <div
+        className={clsx('pointer-events-none absolute inset-0 isolate overflow-hidden', className)}
+      >
+        {visible.map((placement, index) => {
+          const art = artwork.get(placement.data.cosmeticId);
+          if (!art) return null;
 
-        // Explicit, rather than left to paint order. Paint order gives the same
-        // answer today, and stops giving it the moment anything here becomes a
-        // portal, gains a transform, or is reordered by a keyed re-render — and
-        // a sticker silently sliding under the one it was placed over is the
-        // one failure this layer exists to prevent.
-        const layer = index + 1;
-        const delay = step == null && !replayed ? delays?.[index] ?? 0 : 0;
-        const delayStyle = delay ? ({ '--sticker-delay': `${delay}ms` } as CSSProperties) : {};
+          // Explicit, rather than left to paint order. Paint order gives the same
+          // answer today, and stops giving it the moment anything here becomes a
+          // portal, gains a transform, or is reordered by a keyed re-render — and
+          // a sticker silently sliding under the one it was placed over is the
+          // one failure this layer exists to prevent.
+          const layer = index + 1;
+          const delay = step == null && !replayed ? delays?.[index] ?? 0 : 0;
+          const delayStyle = delay ? ({ '--sticker-delay': `${delay}ms` } as CSSProperties) : {};
 
-        // Pending rows only ever reach a viewer who is party to them — the
-        // server scopes them to the placer and the owner — so this decides how
-        // to present it, not whether to show it. A client-side visibility rule
-        // would be a filter where a refusal is needed.
-        const isOwner = placement.ownerId === viewerId;
+          // Pending rows only ever reach a viewer who is party to them — the
+          // server scopes them to the placer and the owner — so this decides how
+          // to present it, not whether to show it. A client-side visibility rule
+          // would be a filter where a refusal is needed.
+          const isOwner = placement.ownerId === viewerId;
 
-        const dressed = resolveTreatment({
-          treatment,
-          surface,
-          isPending: placement.isPending,
-        });
+          const dressed = resolveTreatment({
+            treatment,
+            surface,
+            isPending: placement.isPending,
+          });
 
-        const artworkImage = (
-          <EdgeImage
-            src={art.url}
-            alt={`:${art.slug}:`}
-            // A fixed request width rather than a measured one: a sticker has
-            // a natural size and the element scales it down in layout.
-            options={{ width: artworkWidth, anim: art.animated, optimized: true }}
-            className={clsx(placement.isPending && 'opacity-60')}
-            style={{
-              width: '100%',
-              height: 'auto',
-              display: 'block',
-              ...dressed.imageStyle?.[surface],
-            }}
-          />
-        );
+          const artworkImage = (
+            <EdgeImage
+              src={art.url}
+              alt={`:${art.slug}:`}
+              // A fixed request width rather than a measured one: a sticker has
+              // a natural size and the element scales it down in layout.
+              options={{ width: artworkWidth, anim: art.animated, optimized: true }}
+              className={clsx(placement.isPending && 'opacity-60')}
+              style={{
+                width: '100%',
+                height: 'auto',
+                display: 'block',
+                ...dressed.imageStyle?.[surface],
+              }}
+            />
+          );
 
-        const body = (
-          <div
-            key={placement.id}
-            className={clsx(
-              'absolute',
-              interactive && 'pointer-events-auto',
-              stagger && styles.appear
-            )}
-            style={{
-              left: `${placement.data.x * 100}%`,
-              top: `${placement.data.y * 100}%`,
-              width: `${placement.data.scale * 100}%`,
-              transform: `translate(-50%, -50%) rotate(${placement.data.rotation}deg)`,
-              zIndex: layer,
-              ...delayStyle,
-            }}
-          >
-            {/* The wrapper's own transform makes it a stacking context, so a
+          const body = (
+            <div
+              key={placement.id}
+              className={clsx(
+                'absolute',
+                interactive && 'pointer-events-auto',
+                stagger && styles.appear
+              )}
+              style={{
+                left: `${placement.data.x * 100}%`,
+                top: `${placement.data.y * 100}%`,
+                width: `${placement.data.scale * 100}%`,
+                transform: `translate(-50%, -50%) rotate(${placement.data.rotation}deg)`,
+                zIndex: layer,
+                ...delayStyle,
+              }}
+            >
+              {/* The wrapper's own transform makes it a stacking context, so a
                 negative z-index here stays behind the sticker without reaching
                 behind the artwork the sticker sits on. */}
-            {dressed.behind && (
-              <span
-                aria-hidden
-                className={dressed.behind.className}
-                style={{ zIndex: -1, ...dressed.behind.style }}
-              />
-            )}
+              {dressed.behind && (
+                <span
+                  aria-hidden
+                  className={dressed.behind.className}
+                  style={{ zIndex: -1, ...dressed.behind.style }}
+                />
+              )}
 
-            {dressed.animationClassName ? (
-              <div className={dressed.animationClassName}>{artworkImage}</div>
-            ) : (
-              artworkImage
-            )}
+              {dressed.animationClassName ? (
+                <div className={dressed.animationClassName}>{artworkImage}</div>
+              ) : (
+                artworkImage
+              )}
 
-            {/* A dashed outline rather than opacity alone. Fading is invisible
+              {/* A dashed outline rather than opacity alone. Fading is invisible
                 over busy artwork and reads as a rendering fault over plain
                 artwork, whereas a border is a deliberate mark at any size and
                 against any background. The mild fade stays as a second cue. */}
-            {placement.isPending && (
-              <span className="pointer-events-none absolute -inset-1 rounded border-2 border-dashed border-yellow-6" />
-            )}
-          </div>
-        );
-
-        // A hover card needs something to hover, so a non-interactive layer gets
-        // the sticker alone. The detail view is one click away and carries all
-        // of it.
-        if (!interactive) return body;
-
-        if (!placement.isPending)
-          return (
-            <StickerPlacementHoverCard key={placement.id} placementId={placement.id}>
-              {body}
-            </StickerPlacementHoverCard>
+              {placement.isPending && (
+                <span className="pointer-events-none absolute -inset-1 rounded border-2 border-dashed border-yellow-6" />
+              )}
+            </div>
           );
 
-        // Pending, and the viewer is one of the two people who can see it. Both
-        // get the hover card — the owner needs to know who is asking before
-        // answering, and the placer gets the same detail they would once it goes
-        // live. Only the owner gets the buttons.
-        return (
-          <div key={placement.id} className="pointer-events-none">
-            <StickerPlacementHoverCard placementId={placement.id} pending>
-              {body}
-            </StickerPlacementHoverCard>
+          // A hover card needs something to hover, so a non-interactive layer gets
+          // the sticker alone. The detail view is one click away and carries all
+          // of it.
+          if (!interactive) return body;
 
-            {/* ⚠️ Known wrong, and left wrong deliberately.
+          if (!placement.isPending)
+            return (
+              <StickerPlacementHoverCard key={placement.id} placementId={placement.id}>
+                {body}
+              </StickerPlacementHoverCard>
+            );
+
+          // Pending, and the viewer is one of the two people who can see it. Both
+          // get the hover card — the owner needs to know who is asking before
+          // answering, and the placer gets the same detail they would once it goes
+          // live. Only the owner gets the buttons.
+          pendingControls.push(
+            <div key={placement.id}>
+              {/* ⚠️ Known wrong, and left wrong deliberately.
 
                 `scale` is a fraction of the media box's WIDTH while a `top`
                 percentage resolves against its HEIGHT, so this is the sticker's
@@ -289,28 +304,48 @@ export function StickerPlacementOverlay({
                     buttons. Nothing done INSIDE the box can fix that; it needs
                     the badge kept outside the transform (what this does) or a
                     z-index on the pending wrapper itself. */}
-            <div
-              className="pointer-events-auto absolute -translate-x-1/2"
-              style={{
-                left: `${placement.data.x * 100}%`,
-                top: `calc(${placement.data.y * 100}% + ${placement.data.scale * 50}%)`,
-                // Above every sticker, not just above the one it belongs to:
-                // the layer order means anything placed later covers this
-                // sticker, and it would cover the owner's only way to answer.
-                zIndex: PENDING_CONTROL_Z + layer,
-              }}
-            >
-              {isOwner ? (
-                <StickerPlacementActions placementIds={[placement.id]} compact />
-              ) : (
-                <span className="whitespace-nowrap rounded bg-yellow-6 px-2 py-0.5 text-[10px] font-semibold text-dark-9">
-                  Awaiting review
-                </span>
-              )}
+              <div
+                className="pointer-events-auto absolute -translate-x-1/2"
+                style={{
+                  left: `${placement.data.x * 100}%`,
+                  top: `calc(${placement.data.y * 100}% + ${placement.data.scale * 50}%)`,
+                  // Above every sticker, not just above the one it belongs to:
+                  // the layer order means anything placed later covers this
+                  // sticker, and it would cover the owner's only way to answer.
+                  zIndex: layer,
+                }}
+              >
+                {isOwner ? (
+                  <StickerPlacementActions placementIds={[placement.id]} compact />
+                ) : (
+                  <span className="whitespace-nowrap rounded bg-yellow-6 px-2 py-0.5 text-[10px] font-semibold text-dark-9">
+                    Awaiting review
+                  </span>
+                )}
+              </div>
             </div>
-          </div>
-        );
-      })}
-    </div>
+          );
+
+          return (
+            <StickerPlacementHoverCard key={placement.id} placementId={placement.id} pending>
+              {body}
+            </StickerPlacementHoverCard>
+          );
+        })}
+      </div>
+
+      {/* Outside the isolated layer, and above the draft: an owner arranging
+          their own sticker must not lose the buttons that answer someone
+          else's. Deliberately NOT inside the layer above — isolation would trap
+          these under the draft along with everything else. */}
+      {pendingControls.length > 0 && (
+        <div
+          className="pointer-events-none absolute inset-0 overflow-hidden"
+          style={{ zIndex: PENDING_CONTROL_Z }}
+        >
+          {pendingControls}
+        </div>
+      )}
+    </>
   );
 }

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -3,6 +3,7 @@ import { EdgeImage } from '~/components/EdgeMedia/EdgeImage';
 import type { ResolvedSticker } from '~/components/Sticker/sticker.util';
 import { useStickerCosmetics } from '~/components/Sticker/sticker.util';
 import type { PlacedSticker } from '~/components/Sticker/placement.util';
+import { orderPlacements, placementRevealDelays } from '~/components/Sticker/placement-order';
 import { StickerPlacementActions } from '~/components/Sticker/StickerPlacementActions';
 import { StickerPlacementHoverCard } from '~/components/Sticker/StickerPlacementHoverCard';
 import {
@@ -11,10 +12,25 @@ import {
   type StickerSurface,
   type StickerTreatmentKey,
 } from '~/components/Sticker/treatments/sticker-treatments';
-import { useMemo } from 'react';
+import styles from '~/components/Sticker/placement-reveal.module.scss';
+import { useEffect, useMemo, useState, type CSSProperties } from 'react';
+
+/**
+ * Below every pending placement's controls, and above every sticker.
+ *
+ * The owner's approve/decline sits outside its sticker's transform so it can
+ * out-rank a sticker placed later — which is the point of the layer order, and
+ * would otherwise bury the buttons under the sticker covering them.
+ */
+const PENDING_CONTROL_Z = 1000;
 
 /**
  * Placed stickers, drawn over the content they were placed on.
+ *
+ * Oldest at the bottom, newest on top. Covering another sticker is a feature —
+ * a hat, a speech bubble, decorating what someone else left — so what a viewer
+ * sees is the image as it was most recently built, and the history panel is
+ * where the buried ones stay reachable.
  *
  * Positions are fractions of the target's bounds, never pixels, so the same
  * overlay is correct at card size in a feed and at full size in the detail view.
@@ -34,6 +50,8 @@ export function StickerPlacementOverlay({
   artworkWidth = 512,
   treatment = STILL_STICKER_TREATMENT,
   surface = 'detail',
+  stagger = false,
+  step = null,
 }: {
   placements: PlacedSticker[];
   viewerId?: number;
@@ -87,6 +105,19 @@ export function StickerPlacementOverlay({
    * detail treatment.
    */
   surface?: StickerSurface;
+  /**
+   * Reveal the stickers one at a time, oldest first, instead of all at once.
+   *
+   * Detail view only. A feed draws dozens of these and a staggered reveal there
+   * is movement across the whole page on every scroll — Justin's call, and the
+   * same reason the treatments drop their animation on a card.
+   */
+  stagger?: boolean;
+  /**
+   * Index of the last sticker to draw, for the history replay. `null` draws all
+   * of them, which is every surface that is not being stepped through.
+   */
+  step?: number | null;
 }) {
   const cosmeticIds = useMemo(
     () =>
@@ -98,13 +129,43 @@ export function StickerPlacementOverlay({
   const { sticker: resolved } = useStickerCosmetics(cosmeticIds);
   const artwork = sticker ?? resolved;
 
+  // Ordered here rather than trusted from the caller: this component decides
+  // what covers what, and the paint order of these elements IS that decision.
+  const ordered = useMemo(() => orderPlacements(placements), [placements]);
+  // Off the full history, not off the visible slice: stepping through a replay
+  // must not re-pace the stickers already on screen.
+  const delays = useMemo(
+    () => (stagger ? placementRevealDelays(ordered) : null),
+    [ordered, stagger]
+  );
+
+  // The arrival reveal belongs to this mount, and a replay is the panel's job
+  // from then on. Without this, ending a replay hands every sticker its arrival
+  // delay back — on elements that are already on screen with their animations
+  // finished, which re-pins the sway mid-cycle and can re-run the pop.
+  const [replayed, setReplayed] = useState(false);
+  useEffect(() => {
+    if (step != null) setReplayed(true);
+  }, [step]);
+
   if (!placements.length) return null;
+
+  const visible = step == null ? ordered : ordered.slice(0, step + 1);
 
   return (
     <div className={clsx('pointer-events-none absolute inset-0 overflow-hidden', className)}>
-      {placements.map((placement) => {
+      {visible.map((placement, index) => {
         const art = artwork.get(placement.data.cosmeticId);
         if (!art) return null;
+
+        // Explicit, rather than left to paint order. Paint order gives the same
+        // answer today, and stops giving it the moment anything here becomes a
+        // portal, gains a transform, or is reordered by a keyed re-render — and
+        // a sticker silently sliding under the one it was placed over is the
+        // one failure this layer exists to prevent.
+        const layer = index + 1;
+        const delay = step == null && !replayed ? delays?.[index] ?? 0 : 0;
+        const delayStyle = delay ? ({ '--sticker-delay': `${delay}ms` } as CSSProperties) : {};
 
         // Pending rows only ever reach a viewer who is party to them — the
         // server scopes them to the placer and the owner — so this decides how
@@ -138,12 +199,18 @@ export function StickerPlacementOverlay({
         const body = (
           <div
             key={placement.id}
-            className={clsx('absolute', interactive && 'pointer-events-auto')}
+            className={clsx(
+              'absolute',
+              interactive && 'pointer-events-auto',
+              stagger && styles.appear
+            )}
             style={{
               left: `${placement.data.x * 100}%`,
               top: `${placement.data.y * 100}%`,
               width: `${placement.data.scale * 100}%`,
               transform: `translate(-50%, -50%) rotate(${placement.data.rotation}deg)`,
+              zIndex: layer,
+              ...delayStyle,
             }}
           >
             {/* The wrapper's own transform makes it a stacking context, so a
@@ -216,17 +283,21 @@ export function StickerPlacementOverlay({
                     the first half; `top-full` is the local bottom edge, which
                     at 180° is the screen top and at 90° is off to the side.
                     Staying upright and staying below are two separate fixes;
-                  - `body`'s transform makes it a stacking context, so a `z-10`
+                  - `body`'s transform makes it a stacking context, so a z-index
                     inside it stops out-ranking other placements — a draft
                     dragged over a pending one then swallows the owner's
                     buttons. Nothing done INSIDE the box can fix that; it needs
                     the badge kept outside the transform (what this does) or a
                     z-index on the pending wrapper itself. */}
             <div
-              className="pointer-events-auto absolute z-10 -translate-x-1/2"
+              className="pointer-events-auto absolute -translate-x-1/2"
               style={{
                 left: `${placement.data.x * 100}%`,
                 top: `calc(${placement.data.y * 100}% + ${placement.data.scale * 50}%)`,
+                // Above every sticker, not just above the one it belongs to:
+                // the layer order means anything placed later covers this
+                // sticker, and it would cover the owner's only way to answer.
+                zIndex: PENDING_CONTROL_Z + layer,
               }}
             >
               {isOwner ? (

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -26,6 +26,19 @@ import { useEffect, useMemo, useState, type CSSProperties, type ReactElement } f
 const PENDING_CONTROL_Z = 1000;
 
 /**
+ * The sticker's angle, adjusted so anything carrying text never ends up upside
+ * down.
+ *
+ * Rotation is clamped to ±180, so following it faithfully would hand the owner
+ * their approve/decline mirrored — worse than not rotating at all, which is the
+ * failure Justin called out before asking for this. Past a quarter turn the
+ * block is flipped back the other way: it still reads as belonging to a tilted
+ * sticker, and the words stay the right way up.
+ */
+const uprightRotation = (rotation: number) =>
+  Math.abs(rotation) > 90 ? rotation - Math.sign(rotation) * 180 : rotation;
+
+/**
  * Placed stickers, drawn over the content they were placed on.
  *
  * Oldest at the bottom, newest on top. Covering another sticker is a feature —
@@ -332,10 +345,26 @@ export function StickerPlacementOverlay({
                     the badge kept outside the transform (what this does) or a
                     z-index on the pending wrapper itself. */}
               <div
-                className={clsx('pointer-events-auto absolute -translate-x-1/2', revealClassName)}
+                className={clsx('pointer-events-auto absolute', revealClassName)}
                 style={{
                   left: `${placement.data.x * 100}%`,
                   top: `calc(${placement.data.y * 100}% + ${placement.data.scale * 50}%)`,
+                  // Tilted to match the sticker, hinged at the edge nearest it,
+                  // so the block reads as attached to a rotated sticker rather
+                  // than as a level bar under a crooked one.
+                  //
+                  // It does NOT orbit the sticker's centre — it stays where it
+                  // was and only turns. Orbiting needs the sticker's rendered
+                  // HEIGHT, and the anchor above is already approximate for
+                  // exactly that reason: `scale` is a fraction of the width
+                  // while `top` resolves against the height, so the true offset
+                  // needs the sticker's own aspect ratio, which is only knowable
+                  // by measuring the loaded artwork. Turning in place needs none
+                  // of that and carries most of the effect.
+                  transform: `translateX(-50%) rotate(${uprightRotation(
+                    placement.data.rotation
+                  )}deg)`,
+                  transformOrigin: 'top center',
                   // Above every sticker, not just above the one it belongs to:
                   // the layer order means anything placed later covers this
                   // sticker, and it would cover the owner's only way to answer.

--- a/src/components/Sticker/SuspendPlacerMenuItem.tsx
+++ b/src/components/Sticker/SuspendPlacerMenuItem.tsx
@@ -96,11 +96,7 @@ export function SuspendPlacerMenuItem({ userId }: { userId: number }) {
   };
 
   return (
-    <Menu.Item
-      color="red"
-      leftSection={<IconBan size={14} stroke={1.5} />}
-      onClick={confirm}
-    >
+    <Menu.Item color="red" leftSection={<IconBan size={14} stroke={1.5} />} onClick={confirm}>
       Suspend sticker placement
     </Menu.Item>
   );

--- a/src/components/Sticker/SuspendPlacerMenuItem.tsx
+++ b/src/components/Sticker/SuspendPlacerMenuItem.tsx
@@ -96,7 +96,11 @@ export function SuspendPlacerMenuItem({ userId }: { userId: number }) {
   };
 
   return (
-    <Menu.Item color="red" leftSection={<IconBan size={14} stroke={1.5} />} onClick={confirm}>
+    <Menu.Item
+      color="red"
+      leftSection={<IconBan size={14} stroke={1.5} />}
+      onClick={confirm}
+    >
       Suspend sticker placement
     </Menu.Item>
   );

--- a/src/components/Sticker/__tests__/placement-cache.test.ts
+++ b/src/components/Sticker/__tests__/placement-cache.test.ts
@@ -22,6 +22,7 @@ const placement = (id: number, imageId: number, isPending = false): PlacedSticke
   status: isPending ? 'pending' : 'approved',
   amount: 75,
   data: { cosmeticId: 900, x: 0.5, y: 0.5, scale: 0.2, rotation: 0 },
+  placedAt: new Date('2026-08-12T12:00:00Z'),
   isPending,
 });
 

--- a/src/components/Sticker/__tests__/placement-order.test.ts
+++ b/src/components/Sticker/__tests__/placement-order.test.ts
@@ -120,13 +120,41 @@ describe('placementRevealDelays', () => {
     expect(revealDurationForSpan(span, 2)).toBeLessThan(revealDurationForSpan(span));
     expect(revealDurationForSpan(span, 0.5)).toBeGreaterThan(revealDurationForSpan(span));
 
-    // Bounded AFTER the speed applies. Clamping first and scaling afterwards is
-    // how the arrival reveal reached 48 seconds and a replay 128.
+    // Bounded, but not by the span's own floor and cap — those bound what the
+    // history earns, and reusing them here made the setting inert: on an image
+    // stickered in one session the span gives exactly the floor, so every speed
+    // above 1 divided straight back into it and Normal, 2× and 4× all played
+    // identically.
+    const burst = HOUR;
+    expect(revealDurationForSpan(burst, 4)).toBeLessThan(revealDurationForSpan(burst, 2));
+    expect(revealDurationForSpan(burst, 2)).toBeLessThan(revealDurationForSpan(burst, 1));
+
     const year = 365 * 24 * HOUR;
-    for (const speed of [0.125, 0.5, 1, 4, 32]) {
+    expect(revealDurationForSpan(year, 0.5)).toBeGreaterThan(revealDurationForSpan(year, 1));
+
+    // A replay is derived by running slower, and must never come out FASTER
+    // than the arrival at any setting — the previous clamp collapsed the two at
+    // both extremes AND at the default on old images.
+    const REPLAY = 3 / 8;
+    for (const speed of [0.5, 1, 2, 4]) {
+      for (const span of [HOUR, 30 * 24 * HOUR, year]) {
+        expect(revealDurationForSpan(span, speed * REPLAY)).toBeGreaterThanOrEqual(
+          revealDurationForSpan(span, speed)
+        );
+      }
+    }
+
+    // Strictly slower at the default, which is the case that matters and the one
+    // that was broken. They converge only where both hit the outer bound — the
+    // slowest setting on the oldest history — and a 20s replay that is not also
+    // 64s is the right end of that trade.
+    expect(revealDurationForSpan(year, 1 * REPLAY)).toBeGreaterThan(revealDurationForSpan(year, 1));
+
+    // And nothing runs away: an absurd setting is still bounded.
+    for (const speed of [0.01, 100]) {
       const duration = revealDurationForSpan(year, speed);
-      expect(duration).toBeLessThanOrEqual(12_000);
-      expect(duration).toBeGreaterThanOrEqual(1_500);
+      expect(duration).toBeLessThanOrEqual(20_000);
+      expect(duration).toBeGreaterThanOrEqual(300);
     }
   });
 

--- a/src/components/Sticker/__tests__/placement-order.test.ts
+++ b/src/components/Sticker/__tests__/placement-order.test.ts
@@ -60,37 +60,71 @@ describe('placementRevealDelays', () => {
     expect(delays[2]).toBeGreaterThan(delays[1]);
   });
 
-  it('pauses longer where the real gap was longer', () => {
-    const base = new Date('2026-08-12T12:00:00Z').getTime();
-    const gaps = (ms: number) =>
-      placementRevealDelays([
-        { id: 1, placedAt: new Date(base) },
-        { id: 2, placedAt: new Date(base + ms) },
-      ])[1];
+  it('gives a longer share of the reveal to a longer real gap', () => {
+    const base = new Date('2026-08-12T00:00:00Z').getTime();
+    // Measured as a SHARE, not as a duration. The sequence is normalised to the
+    // chosen length, so with only two stickers the single pause is always the
+    // whole of it however far apart they were placed — the dilation lives in how
+    // the length is divided up, and needs three placements to be visible at all.
+    const share = (secondGapMs: number) => {
+      const delays = placementRevealDelays(
+        [
+          { id: 1, placedAt: new Date(base) },
+          { id: 2, placedAt: new Date(base + MINUTE) },
+          { id: 3, placedAt: new Date(base + MINUTE + secondGapMs) },
+        ],
+        { totalMs: 3_000 }
+      );
+      return (delays[2] - delays[1]) / delays[2];
+    };
 
-    // A minute apart, an hour apart, a week apart: each step strictly longer
-    // than the last. This is the property the "time dilation" is FOR — a
-    // constant step would satisfy every other assertion here.
-    expect(gaps(HOUR)).toBeGreaterThan(gaps(MINUTE));
-    expect(gaps(7 * 24 * HOUR)).toBeGreaterThan(gaps(HOUR));
+    expect(share(HOUR)).toBeGreaterThan(share(MINUTE));
+    expect(share(7 * 24 * HOUR)).toBeGreaterThan(share(HOUR));
   });
 
-  it('fits a long history inside the budget instead of dropping its tail', () => {
+  it('fills the duration it is given, whatever the history looks like', () => {
     const base = new Date('2026-08-01T00:00:00Z').getTime();
-    // Forty stickers, each a day apart — every gap at the per-step ceiling, so
-    // the uncapped sequence runs far past anything watchable.
-    const placements = Array.from({ length: 40 }, (_, index) => ({
+    const forty = Array.from({ length: 40 }, (_, index) => ({
       id: index + 1,
       placedAt: new Date(base + index * 24 * HOUR),
     }));
+    // Two stickers a minute apart are worth a fraction of a second of raw
+    // sequence; forty a day apart are worth far more than the budget. Both land
+    // on the same last delay, because the number is a duration the viewer chose
+    // rather than a ceiling — scaling only downwards left "12 seconds" looking
+    // identical to "1.5 seconds" on any image that was not heavily stickered.
+    const long = placementRevealDelays(forty, { totalMs: 3_000 });
+    const short = placementRevealDelays(
+      [at(1, '2026-08-12T12:00:00Z'), at(2, '2026-08-12T12:01:00Z')],
+      { totalMs: 3_000 }
+    );
 
-    const delays = placementRevealDelays(placements, { maxTotalMs: 3_000 });
-
-    expect(delays).toHaveLength(40);
-    expect(delays[delays.length - 1]).toBeLessThanOrEqual(3_000);
+    expect(long).toHaveLength(40);
+    expect(long[long.length - 1]).toBe(3_000);
+    expect(short[short.length - 1]).toBe(3_000);
     // Scaled, not truncated: the last stickers are the ones deliberately placed
     // over others, and a truncated tail reveals them with no sequence at all.
-    for (let i = 1; i < delays.length; i++) expect(delays[i]).toBeGreaterThan(delays[i - 1]);
+    for (let i = 1; i < long.length; i++) expect(long[i]).toBeGreaterThan(long[i - 1]);
+  });
+
+  it('keeps the shape of the gaps when it stretches them', () => {
+    const base = new Date('2026-08-12T00:00:00Z').getTime();
+    // A short gap then a long one. Whatever the total, the second pause has to
+    // stay several times the first — that ratio is the whole of the time
+    // dilation, and stretching to a duration must not flatten it.
+    const uneven = [
+      { id: 1, placedAt: new Date(base) },
+      { id: 2, placedAt: new Date(base + MINUTE) },
+      { id: 3, placedAt: new Date(base + MINUTE + 7 * 24 * HOUR) },
+    ];
+
+    const ratio = (totalMs: number) => {
+      const d = placementRevealDelays(uneven, { totalMs });
+      return (d[2] - d[1]) / (d[1] - d[0]);
+    };
+
+    expect(ratio(1_500)).toBeGreaterThan(1.5);
+    expect(ratio(12_000)).toBeCloseTo(ratio(1_500), 1);
   });
 
   it('never returns NaN when the whole history lands in one instant', () => {
@@ -100,7 +134,7 @@ describe('placementRevealDelays', () => {
         { id: 1, placedAt: same },
         { id: 2, placedAt: same },
       ],
-      { maxTotalMs: 0 }
+      { totalMs: 0 }
     );
 
     expect(delays.every(Number.isFinite)).toBe(true);

--- a/src/components/Sticker/__tests__/placement-order.test.ts
+++ b/src/components/Sticker/__tests__/placement-order.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { orderPlacements, placementRevealDelays } from '~/components/Sticker/placement-order';
+import {
+  orderPlacements,
+  placementRevealDelays,
+  revealDurationForSpan,
+} from '~/components/Sticker/placement-order';
 
 const at = (id: number, iso: string) => ({ id, placedAt: new Date(iso) });
 
@@ -80,6 +84,39 @@ describe('placementRevealDelays', () => {
 
     expect(share(HOUR)).toBeGreaterThan(share(MINUTE));
     expect(share(7 * 24 * HOUR)).toBeGreaterThan(share(HOUR));
+  });
+
+  it('takes its length from how old the history is', () => {
+    const base = new Date('2026-08-12T00:00:00Z').getTime();
+    const spanned = (spanMs: number) =>
+      placementRevealDelays([
+        { id: 1, placedAt: new Date(base) },
+        { id: 2, placedAt: new Date(base + spanMs / 2) },
+        { id: 3, placedAt: new Date(base + spanMs) },
+      ]).at(-1) as number;
+
+    // The complaint this replaced: a fixed length made two stickers a minute
+    // apart take as long as a year-long build. An hour and a day both sit on the
+    // floor — inside a day the gaps carry the pacing — and it grows from there.
+    expect(spanned(HOUR)).toBe(spanned(24 * HOUR));
+    expect(spanned(30 * 24 * HOUR)).toBeGreaterThan(spanned(24 * HOUR));
+    expect(spanned(365 * 24 * HOUR)).toBeGreaterThan(spanned(30 * 24 * HOUR));
+  });
+
+  it('caps at a year, so a five-year history is not five times the wait', () => {
+    const year = 365 * 24 * HOUR;
+
+    expect(revealDurationForSpan(5 * year)).toBe(revealDurationForSpan(year));
+    // And the floor holds at the other end, including for placements that share
+    // a timestamp — a burst still has to read as a sequence.
+    expect(revealDurationForSpan(0)).toBe(revealDurationForSpan(HOUR));
+  });
+
+  it('scales what the span decided by the viewer multiplier', () => {
+    const span = 30 * 24 * HOUR;
+
+    expect(revealDurationForSpan(span, 2)).toBe(revealDurationForSpan(span) * 2);
+    expect(revealDurationForSpan(span, 0.5)).toBe(revealDurationForSpan(span) / 2);
   });
 
   it('fills the duration it is given, whatever the history looks like', () => {

--- a/src/components/Sticker/__tests__/placement-order.test.ts
+++ b/src/components/Sticker/__tests__/placement-order.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { orderPlacements, placementRevealDelays } from '~/components/Sticker/placement-order';
+
+const at = (id: number, iso: string) => ({ id, placedAt: new Date(iso) });
+
+const MINUTE = 60 * 1000;
+const HOUR = 60 * MINUTE;
+
+describe('orderPlacements', () => {
+  it('puts the oldest first, so the last one placed draws on top', () => {
+    const ordered = orderPlacements([
+      at(3, '2026-08-12T12:00:00Z'),
+      at(1, '2026-08-10T09:00:00Z'),
+      at(2, '2026-08-11T22:30:00Z'),
+    ]);
+
+    expect(ordered.map((p) => p.id)).toEqual([1, 2, 3]);
+  });
+
+  it('breaks a shared timestamp by id rather than leaving it to the input', () => {
+    const same = '2026-08-12T12:00:00Z';
+
+    expect(orderPlacements([at(9, same), at(4, same), at(7, same)]).map((p) => p.id)).toEqual([
+      4, 7, 9,
+    ]);
+  });
+
+  it('orders string timestamps the same way as Date ones', () => {
+    const ordered = orderPlacements([
+      { id: 2, placedAt: '2026-08-12T12:00:00Z' },
+      { id: 1, placedAt: '2026-08-12T11:00:00Z' },
+    ]);
+
+    expect(ordered.map((p) => p.id)).toEqual([1, 2]);
+  });
+
+  it('leaves the caller its own array', () => {
+    const input = [at(2, '2026-08-12T12:00:00Z'), at(1, '2026-08-10T09:00:00Z')];
+    orderPlacements(input);
+
+    expect(input.map((p) => p.id)).toEqual([2, 1]);
+  });
+});
+
+describe('placementRevealDelays', () => {
+  it('holds nothing back when there is nothing to sequence', () => {
+    expect(placementRevealDelays([])).toEqual([]);
+    expect(placementRevealDelays([at(1, '2026-08-12T12:00:00Z')])).toEqual([0]);
+  });
+
+  it('reveals in order, the first one immediately', () => {
+    const delays = placementRevealDelays([
+      at(1, '2026-08-12T12:00:00Z'),
+      at(2, '2026-08-12T12:01:00Z'),
+      at(3, '2026-08-12T12:02:00Z'),
+    ]);
+
+    expect(delays[0]).toBe(0);
+    expect(delays[1]).toBeGreaterThan(0);
+    expect(delays[2]).toBeGreaterThan(delays[1]);
+  });
+
+  it('pauses longer where the real gap was longer', () => {
+    const base = new Date('2026-08-12T12:00:00Z').getTime();
+    const gaps = (ms: number) =>
+      placementRevealDelays([
+        { id: 1, placedAt: new Date(base) },
+        { id: 2, placedAt: new Date(base + ms) },
+      ])[1];
+
+    // A minute apart, an hour apart, a week apart: each step strictly longer
+    // than the last. This is the property the "time dilation" is FOR — a
+    // constant step would satisfy every other assertion here.
+    expect(gaps(HOUR)).toBeGreaterThan(gaps(MINUTE));
+    expect(gaps(7 * 24 * HOUR)).toBeGreaterThan(gaps(HOUR));
+  });
+
+  it('fits a long history inside the budget instead of dropping its tail', () => {
+    const base = new Date('2026-08-01T00:00:00Z').getTime();
+    // Forty stickers, each a day apart — every gap at the per-step ceiling, so
+    // the uncapped sequence runs far past anything watchable.
+    const placements = Array.from({ length: 40 }, (_, index) => ({
+      id: index + 1,
+      placedAt: new Date(base + index * 24 * HOUR),
+    }));
+
+    const delays = placementRevealDelays(placements, { maxTotalMs: 3_000 });
+
+    expect(delays).toHaveLength(40);
+    expect(delays[delays.length - 1]).toBeLessThanOrEqual(3_000);
+    // Scaled, not truncated: the last stickers are the ones deliberately placed
+    // over others, and a truncated tail reveals them with no sequence at all.
+    for (let i = 1; i < delays.length; i++) expect(delays[i]).toBeGreaterThan(delays[i - 1]);
+  });
+
+  it('never returns NaN when the whole history lands in one instant', () => {
+    const same = new Date('2026-08-12T12:00:00Z');
+    const delays = placementRevealDelays(
+      [
+        { id: 1, placedAt: same },
+        { id: 2, placedAt: same },
+      ],
+      { maxTotalMs: 0 }
+    );
+
+    expect(delays.every(Number.isFinite)).toBe(true);
+  });
+});

--- a/src/components/Sticker/__tests__/placement-order.test.ts
+++ b/src/components/Sticker/__tests__/placement-order.test.ts
@@ -112,11 +112,22 @@ describe('placementRevealDelays', () => {
     expect(revealDurationForSpan(0)).toBe(revealDurationForSpan(HOUR));
   });
 
-  it('scales what the span decided by the viewer multiplier', () => {
+  it('treats the viewer setting as a SPEED, and bounds the result', () => {
     const span = 30 * 24 * HOUR;
 
-    expect(revealDurationForSpan(span, 2)).toBe(revealDurationForSpan(span) * 2);
-    expect(revealDurationForSpan(span, 0.5)).toBe(revealDurationForSpan(span) / 2);
+    // Faster means shorter. It multiplied before, under a menu labelled "reveal
+    // speed", so 4× ran four times slower than 1×.
+    expect(revealDurationForSpan(span, 2)).toBeLessThan(revealDurationForSpan(span));
+    expect(revealDurationForSpan(span, 0.5)).toBeGreaterThan(revealDurationForSpan(span));
+
+    // Bounded AFTER the speed applies. Clamping first and scaling afterwards is
+    // how the arrival reveal reached 48 seconds and a replay 128.
+    const year = 365 * 24 * HOUR;
+    for (const speed of [0.125, 0.5, 1, 4, 32]) {
+      const duration = revealDurationForSpan(year, speed);
+      expect(duration).toBeLessThanOrEqual(12_000);
+      expect(duration).toBeGreaterThanOrEqual(1_500);
+    }
   });
 
   it('fills the duration it is given, whatever the history looks like', () => {

--- a/src/components/Sticker/placement-order.ts
+++ b/src/components/Sticker/placement-order.ts
@@ -1,0 +1,82 @@
+/**
+ * The order stickers were placed in, and the pacing of the reveal built on it.
+ *
+ * Pure and separate from anything that renders so both rules are testable: the
+ * layer order decides what covers what, which is the whole reason placing a hat
+ * on someone else's sticker works, and a bug there is invisible until two
+ * stickers overlap.
+ */
+
+type Ordered = { id: number; placedAt: Date | string };
+
+const time = (value: Date | string) => new Date(value).getTime();
+
+/**
+ * Oldest first, so the last one placed draws on top.
+ *
+ * The server already returns them this way; this is what makes the ordering a
+ * property of the layer rather than of the query that fed it. A cache written
+ * by hand, an optimistic insert, or a second caller that forgets the `orderBy`
+ * all reorder the array without touching this file, and the failure looks like
+ * a sticker mysteriously behind another one rather than like a bad query.
+ *
+ * `id` breaks a tie: two placements can share a millisecond, and a comparator
+ * that returns 0 leaves their order to the input, which is the thing being
+ * defended against.
+ */
+export function orderPlacements<T extends Ordered>(placements: T[]): T[] {
+  return [...placements].sort((a, b) => time(a.placedAt) - time(b.placedAt) || a.id - b.id);
+}
+
+/** The shortest gap that reads as a pause rather than as a stagger. */
+const BASE_STEP_MS = 140;
+/** The longest one sticker may hold the screen before the next arrives. */
+const MAX_STEP_MS = 700;
+/**
+ * A whole build has to stay watchable. An image with forty stickers at the
+ * uncapped step would run the better part of a minute, and the reveal plays
+ * every time the detail view shows the stickers.
+ */
+const MAX_TOTAL_MS = 3_000;
+
+const HOUR_MS = 60 * 60 * 1000;
+
+/**
+ * Milliseconds to hold each sticker back, in the order given.
+ *
+ * Time-dilated: a bigger real gap between two placements is a longer pause, so
+ * an image built over a week plays back as bursts with lulls rather than as an
+ * even drum roll. Log-scaled against an hour, because the interesting range
+ * spans minutes to weeks and a linear map turns everything below a day into the
+ * same instant.
+ *
+ * The whole sequence is then scaled to fit `MAX_TOTAL_MS` rather than truncated:
+ * dropping the tail would leave the last stickers — the ones on top, the ones
+ * someone deliberately placed over another — arriving with no reveal at all.
+ *
+ * Callers pass placements already ordered. This does not sort, so a caller that
+ * skipped `orderPlacements` gets delays matching the order it actually draws.
+ */
+export function placementRevealDelays(
+  placements: Ordered[],
+  { maxTotalMs = MAX_TOTAL_MS }: { maxTotalMs?: number } = {}
+): number[] {
+  if (placements.length <= 1) return placements.map(() => 0);
+
+  const delays: number[] = [0];
+  for (let i = 1; i < placements.length; i++) {
+    const gap = Math.max(0, time(placements[i].placedAt) - time(placements[i - 1].placedAt));
+    const step = Math.min(MAX_STEP_MS, BASE_STEP_MS * (1 + Math.log10(1 + gap / HOUR_MS)));
+    delays.push(delays[i - 1] + step);
+  }
+
+  const total = delays[delays.length - 1];
+  // `total` is 0 only when every step was 0, which the clamp above cannot
+  // produce — but a caller passing its own bounds could, and a 0/0 scale would
+  // put every sticker at NaN and hold the whole layer at the animation's first
+  // frame.
+  if (total <= maxTotalMs || total === 0) return delays.map(Math.round);
+
+  const scale = maxTotalMs / total;
+  return delays.map((delay) => Math.round(delay * scale));
+}

--- a/src/components/Sticker/placement-order.ts
+++ b/src/components/Sticker/placement-order.ts
@@ -58,13 +58,22 @@ const CAP_MS = 12_000;
 /** Where the cap is reached. A year of history is as old as the reveal shows. */
 const CAP_SPAN_DAYS = 365;
 
-export function revealDurationForSpan(spanMs: number, multiplier = 1): number {
+export function revealDurationForSpan(spanMs: number, speed = 1): number {
   const days = Math.max(0, spanMs) / DAY_MS;
   // Log-scaled, and flat below a day: within a single day the gaps are what
   // carry the pacing, and stretching an afternoon's worth of stickers past the
   // floor buys nothing.
   const aged = days <= 1 ? 0 : Math.min(1, Math.log10(days) / Math.log10(CAP_SPAN_DAYS));
-  return (FLOOR_MS + (CAP_MS - FLOOR_MS) * aged) * multiplier;
+  const base = FLOOR_MS + (CAP_MS - FLOOR_MS) * aged;
+
+  // `speed`, so 2× is twice as FAST — it divides. It multiplied before, under a
+  // menu labelled "reveal speed", which made 4× four times slower than 1×.
+  //
+  // Clamped AFTER the speed is applied, so the floor and the cap bound what
+  // actually runs. Applying the cap first and then multiplying is how the
+  // arrival reveal reached 48 seconds and a replay 128, against a comment
+  // promising a few seconds.
+  return Math.min(CAP_MS, Math.max(FLOOR_MS, base / (speed || 1)));
 }
 
 /**
@@ -93,11 +102,11 @@ export function revealDurationForSpan(spanMs: number, multiplier = 1): number {
 export function placementRevealDelays(
   placements: Ordered[],
   {
-    multiplier = 1,
+    speed = 1,
     totalMs,
   }: {
-    /** The viewer's speed setting, applied on top of the span-derived length. */
-    multiplier?: number;
+    /** The viewer's setting. Above 1 is faster, below 1 is slower. */
+    speed?: number;
     /** An explicit length, for a caller that has already decided one. */
     totalMs?: number;
   } = {}
@@ -105,7 +114,7 @@ export function placementRevealDelays(
   if (placements.length <= 1) return placements.map(() => 0);
 
   const span = time(placements[placements.length - 1].placedAt) - time(placements[0].placedAt);
-  const length = totalMs ?? revealDurationForSpan(span, multiplier);
+  const length = totalMs ?? revealDurationForSpan(span, speed);
 
   const delays: number[] = [0];
   for (let i = 1; i < placements.length; i++) {

--- a/src/components/Sticker/placement-order.ts
+++ b/src/components/Sticker/placement-order.ts
@@ -55,6 +55,17 @@ const DAY_MS = 24 * HOUR_MS;
  */
 const FLOOR_MS = 1_500;
 const CAP_MS = 12_000;
+/**
+ * Outer bounds on what actually runs, after the viewer's speed applies.
+ *
+ * Deliberately far outside the span-derived range. The floor and cap above
+ * bound what the HISTORY earns; these bound what the SETTING can do with it.
+ * Reusing the first pair for both made the setting inert: on an image stickered
+ * in one session — the commonest case — the span gives the floor exactly, so
+ * Normal, 2× and 4× all divided down into it and produced the same reveal.
+ */
+const FASTEST_MS = 300;
+const SLOWEST_MS = 20_000;
 /** Where the cap is reached. A year of history is as old as the reveal shows. */
 const CAP_SPAN_DAYS = 365;
 
@@ -69,11 +80,12 @@ export function revealDurationForSpan(spanMs: number, speed = 1): number {
   // `speed`, so 2× is twice as FAST — it divides. It multiplied before, under a
   // menu labelled "reveal speed", which made 4× four times slower than 1×.
   //
-  // Clamped AFTER the speed is applied, so the floor and the cap bound what
-  // actually runs. Applying the cap first and then multiplying is how the
-  // arrival reveal reached 48 seconds and a replay 128, against a comment
-  // promising a few seconds.
-  return Math.min(CAP_MS, Math.max(FLOOR_MS, base / (speed || 1)));
+  // `base` is already inside [FLOOR_MS, CAP_MS] by construction — that pair
+  // bounds what the span earns. The speed then scales it, and a much wider pair
+  // catches the runaway that scaling used to produce unbounded (48s arrivals,
+  // 128s replays). Clamping to the span's own bounds after dividing is what made
+  // three of the four menu options identical.
+  return Math.min(SLOWEST_MS, Math.max(FASTEST_MS, base / (speed || 1)));
 }
 
 /**

--- a/src/components/Sticker/placement-order.ts
+++ b/src/components/Sticker/placement-order.ts
@@ -28,16 +28,19 @@ export function orderPlacements<T extends Ordered>(placements: T[]): T[] {
   return [...placements].sort((a, b) => time(a.placedAt) - time(b.placedAt) || a.id - b.id);
 }
 
-/** The shortest gap that reads as a pause rather than as a stagger. */
+/**
+ * The shortest gap that reads as a pause rather than as a stagger, and the
+ * longest one sticker may hold the screen. These two set the SHAPE of the
+ * sequence — how much longer a week-long gap looks than a five-minute one. The
+ * duration below sets its LENGTH, and the shape is stretched to fit it.
+ */
 const BASE_STEP_MS = 140;
-/** The longest one sticker may hold the screen before the next arrives. */
 const MAX_STEP_MS = 700;
 /**
- * A whole build has to stay watchable. An image with forty stickers at the
- * uncapped step would run the better part of a minute, and the reveal plays
- * every time the detail view shows the stickers.
+ * How long the whole reveal runs unless a caller says otherwise. Overridden by
+ * the viewer's reveal-speed setting everywhere it is used for real.
  */
-const MAX_TOTAL_MS = 3_000;
+const TOTAL_MS = 3_000;
 
 const HOUR_MS = 60 * 60 * 1000;
 
@@ -50,16 +53,24 @@ const HOUR_MS = 60 * 60 * 1000;
  * spans minutes to weeks and a linear map turns everything below a day into the
  * same instant.
  *
- * The whole sequence is then scaled to fit `MAX_TOTAL_MS` rather than truncated:
- * dropping the tail would leave the last stickers — the ones on top, the ones
- * someone deliberately placed over another — arriving with no reveal at all.
+ * The sequence is then stretched — or squeezed — so the last sticker lands on
+ * `totalMs` exactly. Both directions, because the number is a duration the
+ * viewer chose, not a ceiling: two stickers placed a minute apart are worth
+ * 0.3s of raw sequence, and only scaling down left "12 seconds" looking
+ * identical to "1.5 seconds" on every image that was not heavily stickered.
+ * Scaling never truncates either, because the tail is the part someone
+ * deliberately placed over another.
+ *
+ * What the dilation survives as is the RATIO between the gaps: a week-long pause
+ * still runs several times longer than a five-minute one, whatever length the
+ * whole thing is given.
  *
  * Callers pass placements already ordered. This does not sort, so a caller that
  * skipped `orderPlacements` gets delays matching the order it actually draws.
  */
 export function placementRevealDelays(
   placements: Ordered[],
-  { maxTotalMs = MAX_TOTAL_MS }: { maxTotalMs?: number } = {}
+  { totalMs = TOTAL_MS }: { totalMs?: number } = {}
 ): number[] {
   if (placements.length <= 1) return placements.map(() => 0);
 
@@ -71,12 +82,11 @@ export function placementRevealDelays(
   }
 
   const total = delays[delays.length - 1];
-  // `total` is 0 only when every step was 0, which the clamp above cannot
-  // produce — but a caller passing its own bounds could, and a 0/0 scale would
-  // put every sticker at NaN and hold the whole layer at the animation's first
-  // frame.
-  if (total <= maxTotalMs || total === 0) return delays.map(Math.round);
+  // `total` is 0 only if every step was 0, which the clamp above cannot produce
+  // — but a caller passing its own bounds could, and 0/0 would put every sticker
+  // at NaN and hold the whole layer at the animation's first frame.
+  if (total === 0) return delays.map(() => 0);
 
-  const scale = maxTotalMs / total;
+  const scale = totalMs / total;
   return delays.map((delay) => Math.round(delay * scale));
 }

--- a/src/components/Sticker/placement-order.ts
+++ b/src/components/Sticker/placement-order.ts
@@ -36,13 +36,36 @@ export function orderPlacements<T extends Ordered>(placements: T[]): T[] {
  */
 const BASE_STEP_MS = 140;
 const MAX_STEP_MS = 700;
-/**
- * How long the whole reveal runs unless a caller says otherwise. Overridden by
- * the viewer's reveal-speed setting everywhere it is used for real.
- */
-const TOTAL_MS = 3_000;
-
 const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+/**
+ * The reveal is as long as the history is old.
+ *
+ * A fixed duration made the setting meaningless in both directions: two
+ * stickers placed a minute apart stretched across twelve seconds of nothing
+ * happening, while a year-long build got the same twelve seconds as an
+ * afternoon's. The length now comes from the real span between the first and
+ * last placement, so "this took a while" is carried by the reveal itself and
+ * the viewer's setting is a multiplier on top rather than the whole answer.
+ *
+ * A floor because a burst still needs long enough to read as a sequence; a cap
+ * because nobody watches a reveal past a few seconds, and past a year the
+ * difference stops meaning anything anyway.
+ */
+const FLOOR_MS = 1_500;
+const CAP_MS = 12_000;
+/** Where the cap is reached. A year of history is as old as the reveal shows. */
+const CAP_SPAN_DAYS = 365;
+
+export function revealDurationForSpan(spanMs: number, multiplier = 1): number {
+  const days = Math.max(0, spanMs) / DAY_MS;
+  // Log-scaled, and flat below a day: within a single day the gaps are what
+  // carry the pacing, and stretching an afternoon's worth of stickers past the
+  // floor buys nothing.
+  const aged = days <= 1 ? 0 : Math.min(1, Math.log10(days) / Math.log10(CAP_SPAN_DAYS));
+  return (FLOOR_MS + (CAP_MS - FLOOR_MS) * aged) * multiplier;
+}
 
 /**
  * Milliseconds to hold each sticker back, in the order given.
@@ -53,13 +76,12 @@ const HOUR_MS = 60 * 60 * 1000;
  * spans minutes to weeks and a linear map turns everything below a day into the
  * same instant.
  *
- * The sequence is then stretched — or squeezed — so the last sticker lands on
- * `totalMs` exactly. Both directions, because the number is a duration the
- * viewer chose, not a ceiling: two stickers placed a minute apart are worth
- * 0.3s of raw sequence, and only scaling down left "12 seconds" looking
- * identical to "1.5 seconds" on every image that was not heavily stickered.
- * Scaling never truncates either, because the tail is the part someone
- * deliberately placed over another.
+ * The sequence is then stretched — or squeezed — to exactly the length the
+ * history has earned (see `revealDurationForSpan`). Both directions: two
+ * stickers a minute apart are worth 0.3s of raw sequence, so scaling only
+ * downwards left every setting looking the same on any image that was not
+ * heavily stickered. Scaling never truncates either, because the tail is the
+ * part someone deliberately placed over another.
  *
  * What the dilation survives as is the RATIO between the gaps: a week-long pause
  * still runs several times longer than a five-minute one, whatever length the
@@ -70,9 +92,20 @@ const HOUR_MS = 60 * 60 * 1000;
  */
 export function placementRevealDelays(
   placements: Ordered[],
-  { totalMs = TOTAL_MS }: { totalMs?: number } = {}
+  {
+    multiplier = 1,
+    totalMs,
+  }: {
+    /** The viewer's speed setting, applied on top of the span-derived length. */
+    multiplier?: number;
+    /** An explicit length, for a caller that has already decided one. */
+    totalMs?: number;
+  } = {}
 ): number[] {
   if (placements.length <= 1) return placements.map(() => 0);
+
+  const span = time(placements[placements.length - 1].placedAt) - time(placements[0].placedAt);
+  const length = totalMs ?? revealDurationForSpan(span, multiplier);
 
   const delays: number[] = [0];
   for (let i = 1; i < placements.length; i++) {
@@ -87,6 +120,6 @@ export function placementRevealDelays(
   // at NaN and hold the whole layer at the animation's first frame.
   if (total === 0) return delays.map(() => 0);
 
-  const scale = totalMs / total;
+  const scale = length / total;
   return delays.map((delay) => Math.round(delay * scale));
 }

--- a/src/components/Sticker/placement-reveal.module.scss
+++ b/src/components/Sticker/placement-reveal.module.scss
@@ -22,6 +22,16 @@
   animation: placementAppear 220ms ease-out var(--sticker-delay, 0ms) both;
 }
 
+/* The state before the reveal is allowed to start.
+   A surface that staggers wears this from its FIRST paint, because the reveal
+   arms on intersection and that cannot happen before a frame has been painted:
+   without it the stickers draw at full opacity, then the animation's backwards
+   fill blanks them, and the reveal reads as a blink. Only ever paired with a
+   later `.appear` — nothing else removes it. */
+.hold {
+  opacity: 0;
+}
+
 @media (prefers-reduced-motion: reduce) {
   /* The stagger IS the motion here — a sticker held back for two seconds is
      movement on the page whether or not anything eases. `!important` because

--- a/src/components/Sticker/placement-reveal.module.scss
+++ b/src/components/Sticker/placement-reveal.module.scss
@@ -32,6 +32,25 @@
   opacity: 0;
 }
 
+@keyframes placementStepProgress {
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
+}
+
+/* Runs for exactly as long as the wait for the next sticker.
+   A replay of a history with long gaps in it is mostly waiting, and waiting is
+   indistinguishable from nothing happening — which is what it looked like. The
+   bar is the only thing that says the pause is deliberate. Driven by an inline
+   `animation-duration` per step, and keyed on the step so it restarts. */
+.stepProgress {
+  animation: placementStepProgress linear both;
+  transform-origin: left;
+}
+
 @media (prefers-reduced-motion: reduce) {
   /* The stagger IS the motion here — a sticker held back for two seconds is
      movement on the page whether or not anything eases. `!important` because

--- a/src/components/Sticker/placement-reveal.module.scss
+++ b/src/components/Sticker/placement-reveal.module.scss
@@ -1,0 +1,34 @@
+/* The ordered reveal: stickers arriving oldest-first rather than all at once.
+   Deliberately NOT in sticker-treatments.module.scss. That file holds treatment
+   animations and is grepped wholesale by sticker-treatments.test.ts for the
+   pending look — fading is exactly what the guard is watching for, and putting
+   this there would mean either a failing test or a weakened one. */
+
+@keyframes placementAppear {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+/* Opacity only: this element carries the placement's own transform, so anything
+   animating transform here moves the sticker off its spot. Keeping it off the
+   treatment also keeps the reveal independent of which treatment is in play —
+   four of the five draw no animation at all, and the ordered reveal is not a
+   treatment option. */
+.appear {
+  animation: placementAppear 220ms ease-out var(--sticker-delay, 0ms) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* The stagger IS the motion here — a sticker held back for two seconds is
+     movement on the page whether or not anything eases. `!important` because
+     the delay arrives as an inline custom property, which this would otherwise
+     lose to. */
+  .appear {
+    animation: placementAppear 1ms both;
+    animation-delay: 0ms !important;
+  }
+}

--- a/src/components/Sticker/placement-reveal.module.scss
+++ b/src/components/Sticker/placement-reveal.module.scss
@@ -7,9 +7,18 @@
 @keyframes placementAppear {
   from {
     opacity: 0;
+    /* Animated alongside the fade, and load-bearing rather than decorative.
+       Opacity does not affect hit-testing, so a sticker waiting its turn was an
+       invisible target you could still hover — and for a pending placement,
+       whose approve/decline is in the same held state, an invisible button you
+       could still click. Visibility animates discretely: it holds `hidden`
+       through the delay and flips at the animation's first frame, which is the
+       one moment the sticker becomes visible. */
+    visibility: hidden;
   }
   to {
     opacity: 1;
+    visibility: visible;
   }
 }
 
@@ -30,6 +39,8 @@
    later `.appear` — nothing else removes it. */
 .hold {
   opacity: 0;
+  /* Not opacity alone: an unarmed sticker must not be clickable either. */
+  visibility: hidden;
 }
 
 @keyframes placementStepProgress {

--- a/src/components/Sticker/placement.util.ts
+++ b/src/components/Sticker/placement.util.ts
@@ -14,6 +14,14 @@ export type PlacedSticker = {
   status: string;
   amount: number;
   data: StickerPlacementData;
+  /**
+   * `Date` over superjson, a string out of anything that stringified the cache
+   * on the way past. Both are accepted rather than normalised on arrival
+   * because the only readers pass it to `new Date()` anyway, and a cast that
+   * claims `Date` for a value that is a string reads correct and compares
+   * wrong.
+   */
+  placedAt: Date | string;
   isPending: boolean;
 };
 

--- a/src/components/Sticker/placement.util.ts
+++ b/src/components/Sticker/placement.util.ts
@@ -39,7 +39,7 @@ export function useStickerPlacements(imageIds: number[], enabled = true) {
     [imageIds.join(',')]
   );
 
-  const { data, isLoading } = trpc.placement.getStickerPlacements.useQuery(
+  const { data, isLoading, isError } = trpc.placement.getStickerPlacements.useQuery(
     { imageIds: ids },
     { enabled: enabled && ids.length > 0, staleTime: 60_000 }
   );
@@ -54,7 +54,11 @@ export function useStickerPlacements(imageIds: number[], enabled = true) {
     return map;
   }, [data]);
 
-  return { byImage, isLoading };
+  // `isError` alongside, for the same reason the counts hook carries it: a
+  // failed fetch and an image nobody has stickered are both an empty map, and a
+  // surface that reads "no stickers here" off the first one is saying something
+  // it does not know.
+  return { byImage, isLoading, isError };
 }
 
 /**

--- a/src/components/Sticker/treatments/sticker-treatments.module.scss
+++ b/src/components/Sticker/treatments/sticker-treatments.module.scss
@@ -24,8 +24,8 @@
    transform here would overwrite it. Both keyframes drive an inner element that
    exists only for this treatment. */
 .motion {
-  animation: stickerPop 420ms cubic-bezier(0.34, 1.56, 0.64, 1) both,
-    stickerSway 6s ease-in-out 420ms infinite;
+  animation: stickerPop 420ms cubic-bezier(0.34, 1.56, 0.64, 1) var(--sticker-delay, 0ms) both,
+    stickerSway 6s ease-in-out calc(var(--sticker-delay, 0ms) + 420ms) infinite;
   transform-origin: 50% 85%;
   will-change: transform;
 }

--- a/src/server/services/__tests__/sticker-placement.service.test.ts
+++ b/src/server/services/__tests__/sticker-placement.service.test.ts
@@ -270,6 +270,36 @@ describe("the creator's size limit", () => {
 
     expect(placed.data.scale).toBe(0.35);
   });
+
+  /**
+   * Layer order is placement order, and the client cannot order what it was not
+   * told. Dropping `createdAt` from the select is a plausible tidy-up — nothing
+   * in the payload is named after it — and it degrades into stickers stacking in
+   * whatever order Prisma happened to return, which only shows up where two of
+   * them overlap.
+   */
+  it('carries when each placement was made', async () => {
+    const placedAt = new Date('2026-08-12T12:00:00Z');
+    placementFindMany.mockResolvedValueOnce([
+      {
+        id: 7,
+        targetId: IMAGE,
+        placerId: PLACER,
+        ownerId: OWNER,
+        status: 'approved',
+        amount: PRICE,
+        data: { cosmeticId: COSMETIC, x: 0.5, y: 0.5, scale: 0.35, rotation: 0 },
+        createdAt: placedAt,
+      },
+    ]);
+
+    const [placed] = await getStickerPlacements({ imageIds: [IMAGE] });
+
+    expect(placed.placedAt).toEqual(placedAt);
+    expect(placementFindMany).toHaveBeenLastCalledWith(
+      expect.objectContaining({ orderBy: { createdAt: 'asc' } })
+    );
+  });
 });
 
 describe('the order money and uses move in', () => {

--- a/src/server/services/sticker-placement.service.ts
+++ b/src/server/services/sticker-placement.service.ts
@@ -245,6 +245,14 @@ export type StickerPlacementView = {
   status: PlacementStatus;
   amount: number;
   data: StickerPlacementData;
+  /**
+   * When it was placed, which is what decides what covers what — and, on the
+   * detail view, the order and the pacing of the reveal. Carried on the listing
+   * rather than left to `getStickerPlacementDetail`: a client that has to ask
+   * per placement cannot order them until every one of those queries lands, so
+   * the layer order would settle after paint.
+   */
+  placedAt: Date;
   /** True only for the placer's own placement awaiting the owner. */
   isPending: boolean;
 };
@@ -394,6 +402,7 @@ export async function getStickerPlacements({
       status: true,
       amount: true,
       data: true,
+      createdAt: true,
     },
     orderBy: { createdAt: 'asc' },
   });
@@ -407,6 +416,7 @@ export async function getStickerPlacements({
       ownerId: row.ownerId,
       status: row.status as PlacementStatus,
       amount: row.amount,
+      placedAt: row.createdAt,
       data: row.data as StickerPlacementData,
       isPending: row.status === 'pending',
     }));

--- a/src/store/sticker-history.store.ts
+++ b/src/store/sticker-history.store.ts
@@ -1,0 +1,46 @@
+import { create } from 'zustand';
+
+/**
+ * The replay: which point in an image's sticker history is being shown.
+ *
+ * Global rather than owned by the history panel because the two things it drives
+ * are in different trees — the panel lists the stickers, and the overlay draws
+ * them over the artwork on the other side of the layout. Scoped to one image at
+ * a time by construction: opening the panel on a second image ends the first
+ * replay, which is what the carousel needs, since stepping through one image's
+ * history and then swiping is otherwise a replay left running behind you.
+ *
+ * Not persisted. A replay is something you are doing right now, not a setting —
+ * unlike the reveal toggle beside it, which is sticky on purpose.
+ */
+interface StickerHistoryStore {
+  imageId: number | null;
+  /**
+   * Index of the last sticker drawn, or `null` for "draw them all".
+   *
+   * `null` is the state the panel opens in: reading the list should not blank
+   * the image, and the replay is a thing you start.
+   */
+  step: number | null;
+  open: (imageId: number) => void;
+  close: () => void;
+  setStep: (imageId: number, step: number | null) => void;
+}
+
+export const useStickerHistoryStore = create<StickerHistoryStore>((set) => ({
+  imageId: null,
+  step: null,
+  open: (imageId) => set({ imageId, step: null }),
+  close: () => set({ imageId: null, step: null }),
+  setStep: (imageId, step) => set({ imageId, step }),
+}));
+
+/**
+ * How much of this image's history to draw: `null` for all of it.
+ *
+ * Every sticker surface calls this, including the feed cards, so it answers for
+ * an image that is not the one being replayed rather than making each caller
+ * compare ids.
+ */
+export const useStickerHistoryStep = (imageId: number) =>
+  useStickerHistoryStore((state) => (state.imageId === imageId ? state.step : null));

--- a/src/store/sticker-history.store.ts
+++ b/src/store/sticker-history.store.ts
@@ -22,17 +22,45 @@ interface StickerHistoryStore {
    * the image, and the replay is a thing you start.
    */
   step: number | null;
+  /**
+   * Bumped by every state change that ends a replay.
+   *
+   * A playing replay is a chain of timers, and clearing them cannot be made to
+   * happen reliably at the moment the replay is called off: the popover fades
+   * out over 150ms before its content unmounts, so a timer landing in that
+   * window used to write a step back over the store AFTER it had been cleared —
+   * leaving the image clipped with the panel already shut and nothing on screen
+   * to explain it. A timer carries the run it belongs to and is a no-op once
+   * this has moved on, so correctness does not depend on the ordering.
+   */
+  runId: number;
   open: (imageId: number) => void;
   close: () => void;
   setStep: (imageId: number, step: number | null) => void;
+  /** Starts a replay at its first sticker and returns the run to stamp timers with. */
+  beginRun: (imageId: number) => number;
+  /** A timer's write. Ignored unless its run is still the current one. */
+  advanceRun: (runId: number, imageId: number, step: number | null) => void;
 }
 
-export const useStickerHistoryStore = create<StickerHistoryStore>((set) => ({
+export const useStickerHistoryStore = create<StickerHistoryStore>((set, get) => ({
   imageId: null,
   step: null,
-  open: (imageId) => set({ imageId, step: null }),
-  close: () => set({ imageId: null, step: null }),
-  setStep: (imageId, step) => set({ imageId, step }),
+  runId: 0,
+  open: (imageId) => set((state) => ({ imageId, step: null, runId: state.runId + 1 })),
+  close: () => set((state) => ({ imageId: null, step: null, runId: state.runId + 1 })),
+  // A manual step ends any replay in progress, which is what the panel's own
+  // controls mean by stepping.
+  setStep: (imageId, step) => set((state) => ({ imageId, step, runId: state.runId + 1 })),
+  beginRun: (imageId) => {
+    const runId = get().runId + 1;
+    set({ imageId, step: 0, runId });
+    return runId;
+  },
+  advanceRun: (runId, imageId, step) => {
+    if (get().runId !== runId) return;
+    set({ imageId, step });
+  },
 }));
 
 /**

--- a/src/store/sticker-reveal-speed.store.ts
+++ b/src/store/sticker-reveal-speed.store.ts
@@ -2,45 +2,49 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 
 /**
- * How long the whole sticker reveal takes, end to end.
+ * How much the viewer stretches or shortens the reveal.
  *
- * A ceiling on the sequence rather than a per-sticker delay: the gaps between
- * placements are what set the rhythm, and this decides how much room the whole
- * thing gets. Forty stickers and four stickers both finish inside it.
+ * A multiplier rather than a duration. The length itself comes from how old the
+ * history is — a build spread over a year runs longer than an afternoon's — and
+ * a viewer choosing an absolute number overrode exactly the thing that made the
+ * reveal say anything. This scales that answer instead of replacing it.
  */
-export const REVEAL_DURATIONS = [1_500, 3_000, 6_000, 12_000] as const;
+export const REVEAL_MULTIPLIERS = [0.5, 1, 2, 4] as const;
 
-export type RevealDuration = (typeof REVEAL_DURATIONS)[number];
+export type RevealMultiplier = (typeof REVEAL_MULTIPLIERS)[number];
 
-export const DEFAULT_REVEAL_DURATION: RevealDuration = 3_000;
+export const DEFAULT_REVEAL_MULTIPLIER: RevealMultiplier = 1;
 
-export const revealDurationLabel = (ms: number) => `${ms / 1000}s`;
+export const revealMultiplierLabel = (multiplier: number) =>
+  multiplier === 1 ? 'Normal' : `${multiplier}×`;
 
 /**
  * The replay is watched deliberately, so it gets more room than an arrival
  * anyone might be reading past. Derived rather than a second setting: two
- * numbers to keep in step is two numbers to get out of step, and nobody asked
- * to pace the two independently.
+ * numbers to keep in step is two numbers to get out of step.
  */
 export const REPLAY_MULTIPLIER = 8 / 3;
 
 interface StickerRevealSpeedStore {
-  durationMs: RevealDuration;
-  setDuration: (durationMs: RevealDuration) => void;
+  multiplier: RevealMultiplier;
+  setMultiplier: (multiplier: RevealMultiplier) => void;
 }
 
 export const useStickerRevealSpeedStore = create<StickerRevealSpeedStore>()(
   persist(
     (set) => ({
-      durationMs: DEFAULT_REVEAL_DURATION,
-      setDuration: (durationMs) => set({ durationMs }),
+      multiplier: DEFAULT_REVEAL_MULTIPLIER,
+      setMultiplier: (multiplier) => set({ multiplier }),
     }),
     {
-      name: 'sticker-reveal-speed',
+      // A new key rather than a version bump on the old one: the previous
+      // setting stored a duration in milliseconds, and 3000 read back as a
+      // multiplier is a reveal three thousand times too long.
+      name: 'sticker-reveal-multiplier',
       storage: createJSONStorage(() => localStorage),
       version: 1,
     }
   )
 );
 
-export const useRevealDuration = () => useStickerRevealSpeedStore((state) => state.durationMs);
+export const useRevealMultiplier = () => useStickerRevealSpeedStore((state) => state.multiplier);

--- a/src/store/sticker-reveal-speed.store.ts
+++ b/src/store/sticker-reveal-speed.store.ts
@@ -20,9 +20,11 @@ export const revealSpeedLabel = (speed: number) => (speed === 1 ? 'Normal' : `${
 /**
  * The replay is watched deliberately, so it runs SLOWER than an arrival anyone
  * might be reading past — a speed below 1. Derived rather than a second setting:
- * two numbers to keep in step is two numbers to get out of step. The result is
- * clamped to the same cap, so no combination of settings produces a replay
- * nobody would sit through.
+ * two numbers to keep in step is two numbers to get out of step.
+ *
+ * The product is bounded, so at the slowest setting on the oldest history the
+ * two converge on the outer limit rather than the replay running past a minute.
+ * Everywhere else, including the default, the replay is genuinely longer.
  */
 export const REPLAY_SPEED = 3 / 8;
 

--- a/src/store/sticker-reveal-speed.store.ts
+++ b/src/store/sticker-reveal-speed.store.ts
@@ -1,0 +1,46 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+/**
+ * How long the whole sticker reveal takes, end to end.
+ *
+ * A ceiling on the sequence rather than a per-sticker delay: the gaps between
+ * placements are what set the rhythm, and this decides how much room the whole
+ * thing gets. Forty stickers and four stickers both finish inside it.
+ */
+export const REVEAL_DURATIONS = [1_500, 3_000, 6_000, 12_000] as const;
+
+export type RevealDuration = (typeof REVEAL_DURATIONS)[number];
+
+export const DEFAULT_REVEAL_DURATION: RevealDuration = 3_000;
+
+export const revealDurationLabel = (ms: number) => `${ms / 1000}s`;
+
+/**
+ * The replay is watched deliberately, so it gets more room than an arrival
+ * anyone might be reading past. Derived rather than a second setting: two
+ * numbers to keep in step is two numbers to get out of step, and nobody asked
+ * to pace the two independently.
+ */
+export const REPLAY_MULTIPLIER = 8 / 3;
+
+interface StickerRevealSpeedStore {
+  durationMs: RevealDuration;
+  setDuration: (durationMs: RevealDuration) => void;
+}
+
+export const useStickerRevealSpeedStore = create<StickerRevealSpeedStore>()(
+  persist(
+    (set) => ({
+      durationMs: DEFAULT_REVEAL_DURATION,
+      setDuration: (durationMs) => set({ durationMs }),
+    }),
+    {
+      name: 'sticker-reveal-speed',
+      storage: createJSONStorage(() => localStorage),
+      version: 1,
+    }
+  )
+);
+
+export const useRevealDuration = () => useStickerRevealSpeedStore((state) => state.durationMs);

--- a/src/store/sticker-reveal-speed.store.ts
+++ b/src/store/sticker-reveal-speed.store.ts
@@ -2,49 +2,52 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 
 /**
- * How much the viewer stretches or shortens the reveal.
+ * How much faster or slower than normal the viewer wants the reveal.
  *
- * A multiplier rather than a duration. The length itself comes from how old the
+ * A speed rather than a duration. The length itself comes from how old the
  * history is — a build spread over a year runs longer than an afternoon's — and
  * a viewer choosing an absolute number overrode exactly the thing that made the
  * reveal say anything. This scales that answer instead of replacing it.
  */
-export const REVEAL_MULTIPLIERS = [0.5, 1, 2, 4] as const;
+export const REVEAL_SPEEDS = [0.5, 1, 2, 4] as const;
 
-export type RevealMultiplier = (typeof REVEAL_MULTIPLIERS)[number];
+export type RevealSpeed = (typeof REVEAL_SPEEDS)[number];
 
-export const DEFAULT_REVEAL_MULTIPLIER: RevealMultiplier = 1;
+export const DEFAULT_REVEAL_SPEED: RevealSpeed = 1;
 
-export const revealMultiplierLabel = (multiplier: number) =>
-  multiplier === 1 ? 'Normal' : `${multiplier}×`;
+export const revealSpeedLabel = (speed: number) => (speed === 1 ? 'Normal' : `${speed}×`);
 
 /**
- * The replay is watched deliberately, so it gets more room than an arrival
- * anyone might be reading past. Derived rather than a second setting: two
- * numbers to keep in step is two numbers to get out of step.
+ * The replay is watched deliberately, so it runs SLOWER than an arrival anyone
+ * might be reading past — a speed below 1. Derived rather than a second setting:
+ * two numbers to keep in step is two numbers to get out of step. The result is
+ * clamped to the same cap, so no combination of settings produces a replay
+ * nobody would sit through.
  */
-export const REPLAY_MULTIPLIER = 8 / 3;
+export const REPLAY_SPEED = 3 / 8;
 
 interface StickerRevealSpeedStore {
-  multiplier: RevealMultiplier;
-  setMultiplier: (multiplier: RevealMultiplier) => void;
+  speed: RevealSpeed;
+  setSpeed: (speed: RevealSpeed) => void;
 }
 
 export const useStickerRevealSpeedStore = create<StickerRevealSpeedStore>()(
   persist(
     (set) => ({
-      multiplier: DEFAULT_REVEAL_MULTIPLIER,
-      setMultiplier: (multiplier) => set({ multiplier }),
+      speed: DEFAULT_REVEAL_SPEED,
+      setSpeed: (speed) => set({ speed }),
     }),
     {
       // A new key rather than a version bump on the old one: the previous
       // setting stored a duration in milliseconds, and 3000 read back as a
       // multiplier is a reveal three thousand times too long.
-      name: 'sticker-reveal-multiplier',
+      // Renamed again, because the stored number's MEANING flipped: a saved 4
+      // meant four times slower and now means four times faster.
+      name: 'sticker-reveal-speed-v2',
       storage: createJSONStorage(() => localStorage),
       version: 1,
     }
   )
 );
 
-export const useRevealMultiplier = () => useStickerRevealSpeedStore((state) => state.multiplier);
+export const useRevealSpeed = () => useStickerRevealSpeedStore((state) => state.speed);


### PR DESCRIPTION
Ship-blockers from the 2026-08-12 art-department sticker review, rendering side only. The sticker economy/permissions items from the same review (buzz counter, sticker comments, owner delete) belong to another branch.

## Layer order = placement order, last on top

The decision reversed mid-call: Justin's instinct was "first placed claims the space", Luis argued covering is the feature (a hat, a speech bubble, decorating someone else's sticker) and Ellie agreed. Justin's grief concern — covering someone's sticker to bury it — is answered by the history panel below rather than by reserving space.

Paint order already gave this answer; it now says so out loud. Each placement gets an explicit `zIndex`, and the listing carries `placedAt` so the client orders what it draws instead of inheriting whatever order the query returned. `orderPlacements` is pure and tested, because a sticker silently sliding under one placed later is invisible until two overlap.

One real fix falls out: the owner's approve/decline on a pending placement now sits above *every* sticker, not just its own. Under the layer order, anything placed later covered the only control the owner had.

## An ordered reveal on the detail page

Stickers arrive oldest-first rather than all at once, time-dilated — a bigger real gap between two placements is a longer pause, log-scaled against an hour so the range from minutes to weeks is legible. The whole sequence is scaled to fit a budget rather than truncated: the tail is the part someone deliberately placed on top.

Detail view only. Justin judged the feed too heavy, which is the same reason the treatments drop their animation on a card. Plays every time the stickers become visible (Justin's call). Honours `prefers-reduced-motion` — a sticker held back two seconds is movement whether or not anything eases.

## Sticker history

A paper-scroll button (Ellie's suggestion) beside the place button opens a popover: every sticker in placement order, hover for who placed it and their creator card — the same hover card the sticker itself has, so the two cannot drift — and a replay you can step through by sticker or play straight through at the dilated pacing. Placement in the reaction bar rather than the sidebar is Justin's call: the sidebar collapses and scrolls away from the image the replay is playing over.

## Collapsible sidebar sections

Generation data and Discussion fold away, remembered per section. A collapsed section renders nothing rather than hiding it — the expensive ones here are expensive because they query.

## Not in scope, from the same discussion

- What each placer paid at the time (Luis floated it, Ellie was unsure, no decision)
- Buzz counter, sticker comments, owner delete — the other branch

## Verification

- `pnpm run typecheck` clean
- `pnpm run lint` — the two warnings on `ImageDetail2.tsx` are pre-existing and unrelated (unused imports on `main` too)
- Sticker + placement suites and `blocks.router.workflow.test.ts`: 459 passed, 0 failed (submodule present, nonzero collection confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)