### PR TITLE
feat(placement): image buzz counter for paid placements, sticker notes, one-week removal lock

### DIFF
--- a/src/components/Report/StickerPlacementForm.tsx
+++ b/src/components/Report/StickerPlacementForm.tsx
@@ -70,6 +70,20 @@ function StickerPlacementFields() {
         </Stack>
       </InputRadioGroup>
 
+      {/* Offered only where a note exists to report. The two are separately
+          objectionable — a fine sticker can carry an abusive note — and they
+          have different remedies, since the owner can hide a note without the
+          sticker coming off. Hidden entirely when no placement here has one,
+          rather than asked and ignored. */}
+      {placements.some((placement) => placement.hasComment) && (
+        <InputRadioGroup name="target" label="What are you reporting?">
+          <Stack gap={4}>
+            <Radio value="sticker" label="The sticker itself" />
+            <Radio value="comment" label="The note attached to it" />
+          </Stack>
+        </InputRadioGroup>
+      )}
+
       <InputTextArea
         name="comment"
         label="What's wrong with it? (optional)"

--- a/src/components/Sticker/DraftSticker.tsx
+++ b/src/components/Sticker/DraftSticker.tsx
@@ -1,5 +1,5 @@
-import { Text } from '@mantine/core';
-import { IconX } from '@tabler/icons-react';
+import { Text, Textarea, UnstyledButton } from '@mantine/core';
+import { IconMessage, IconX } from '@tabler/icons-react';
 import clsx from 'clsx';
 import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 import { BuzzTransactionButton } from '~/components/Buzz/BuzzTransactionButton';
@@ -17,6 +17,7 @@ import { useCreateStickerPlacement } from '~/components/Sticker/placement.util';
 import type { ResolvedSticker } from '~/components/Sticker/sticker.util';
 import type { StickerTreatment } from '~/components/Sticker/treatments/sticker-treatments';
 import { PLACEMENT_SPEND_TYPES } from '~/shared/constants/placement.constants';
+import { STICKER_COMMENT_MAX_LENGTH } from '~/shared/utils/sticker-placement';
 import type { StickerDraft } from '~/store/sticker-placement-draft.store';
 import {
   pointerToSurfaceFraction,
@@ -25,6 +26,13 @@ import {
 
 /** Enough for the label and the currency badge at the smallest allowed sticker. */
 const BUY_BUTTON_MIN_WIDTH = 132;
+
+/**
+ * Fixed, because the cluster is `w-max` and sized by its widest child — an
+ * autosizing field would widen the whole thing as you type, and the cluster's
+ * width feeds the overlap test that decides which side the button sits on.
+ */
+const NOTE_WIDTH = 220;
 
 /** `mt-2`, in pixels, and the clearance the flipped side is built from. */
 const BUY_BUTTON_GAP = 8;
@@ -91,6 +99,12 @@ export function DraftSticker({
   const select = useStickerPlacementDraftStore((state) => state.select);
   const cancelDraft = useStickerPlacementDraftStore((state) => state.cancelDraft);
   const place = useCreateStickerPlacement(draft.id);
+
+  // Local to the draft rather than in the store: it is written once, read once
+  // at purchase, and putting it in the store would make every keystroke a
+  // store write that re-renders the layer mid-arrangement.
+  const [note, setNote] = useState('');
+  const [writingNote, setWritingNote] = useState(false);
 
   const rootRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLDivElement>(null);
@@ -396,6 +410,33 @@ export function DraftSticker({
         // on it would also start a move and the click would land mid-drag.
         onPointerDown={(event) => event.stopPropagation()}
       >
+        {/* Optional, and folded away until asked for: a field on every draft
+            would sit over the artwork through the whole arrangement, which is
+            the one thing this overlay is trying not to do. */}
+        {writingNote ? (
+          <Textarea
+            autoFocus
+            size="xs"
+            autosize
+            minRows={2}
+            maxRows={4}
+            w={NOTE_WIDTH}
+            className="whitespace-normal"
+            placeholder="Say something with it (optional)"
+            maxLength={STICKER_COMMENT_MAX_LENGTH}
+            value={note}
+            onChange={(event) => setNote(event.currentTarget.value)}
+          />
+        ) : (
+          <UnstyledButton
+            className="flex items-center gap-1 rounded-full bg-black/80 px-2 py-0.5 text-xs text-white"
+            onClick={() => setWritingNote(true)}
+          >
+            <IconMessage size={12} />
+            Add a note
+          </UnstyledButton>
+        )}
+
         <BuzzTransactionButton
           size="sm"
           style={{ minWidth: BUY_BUTTON_MIN_WIDTH }}
@@ -415,6 +456,9 @@ export function DraftSticker({
                 y: draft.y,
                 scale: draft.scale,
                 rotation: draft.rotation,
+                // Sent only when there is something to send, so an opened-then-
+                // abandoned field is the same as never opening it.
+                ...(note.trim() ? { comment: note } : {}),
               },
             })
           }

--- a/src/components/Sticker/StickerPlacementActions.tsx
+++ b/src/components/Sticker/StickerPlacementActions.tsx
@@ -1,4 +1,5 @@
 import { Button, Group, Popover, Skeleton, Stack, Text } from '@mantine/core';
+import { IconMessage } from '@tabler/icons-react';
 import clsx from 'clsx';
 import { useState } from 'react';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
@@ -93,7 +94,10 @@ export function StickerPlacementActions({
       {asksAboutNote ? (
         <Popover opened={approving} onChange={setApproving} withArrow position="top" width={280}>
           <Popover.Target>{approveButton}</Popover.Target>
-          <Popover.Dropdown>
+          {/* Unpadded so the header's divider can run the full width of the
+              panel. Same reason, and the same shape, as the sticker hover
+              card's dropdown. */}
+          <Popover.Dropdown p={0}>
             <NoteDecision
               placementId={placementIds[0]}
               pending={act.isPending}
@@ -178,32 +182,55 @@ function NoteDecision({
   );
 
   return (
-    <Stack gap="xs">
-      <Text size="xs" c="dimmed">
-        They left a note with this sticker:
-      </Text>
-
-      {isLoading ? (
-        <Skeleton height={32} radius="sm" />
-      ) : (
-        <Text size="sm" className="whitespace-pre-wrap break-words">
-          {data?.comment ?? 'The note is no longer available.'}
+    <>
+      {/* A panel header, divider across the full width, styled like the sticker
+          hover card's — the two are the same kind of object seen from two
+          places, and matching them is what stops the sticker UI reading as
+          several unrelated widgets. */}
+      <Group
+        gap={6}
+        px="sm"
+        py={6}
+        wrap="nowrap"
+        className="border-b border-gray-3 dark:border-dark-4"
+      >
+        <IconMessage size={14} className="shrink-0 text-yellow-6" />
+        <Text size="xs" c="dimmed" className="min-w-0 truncate">
+          They left a note with this sticker
         </Text>
-      )}
+      </Group>
 
-      <Text size="xs" c="dimmed">
-        Approving without it keeps the sticker and leaves the note private — only you, the person
-        who placed it, and moderators can read it.
-      </Text>
+      <Stack gap="xs" p="sm">
+        {/* Its own surface rather than a rule beside it. The note is the subject
+            of the question and everything else in the panel is instructions
+            about it, so it has to read as quoted content at a glance. */}
+        {isLoading ? (
+          <Skeleton height={40} radius="sm" />
+        ) : (
+          <div className="rounded-md bg-gray-2 px-2 py-1.5 dark:bg-dark-5">
+            <Text size="sm" className="whitespace-pre-wrap break-words">
+              {data?.comment ?? 'The note is no longer available.'}
+            </Text>
+          </div>
+        )}
 
-      <Stack gap={4}>
-        <Button size="compact-xs" color="green" loading={pending} onClick={onInclude}>
-          Approve with the note
-        </Button>
-        <Button size="compact-xs" variant="default" loading={pending} onClick={onOmit}>
-          Approve without it
-        </Button>
+        <Stack gap={4}>
+          <Button size="compact-xs" color="green" loading={pending} onClick={onInclude}>
+            Approve with the note
+          </Button>
+          <Button size="compact-xs" variant="default" loading={pending} onClick={onOmit}>
+            Approve without it
+          </Button>
+        </Stack>
+
+        {/* Under the buttons, not above them. It explains what the second button
+            does, and between the note and the choice it pushed the note far
+            enough from the buttons to be skipped. */}
+        <Text size="xs" c="dimmed">
+          Approving without it keeps the sticker and leaves the note private — only you, the person
+          who placed it, and moderators can read it.
+        </Text>
       </Stack>
-    </Stack>
+    </>
   );
 }

--- a/src/components/Sticker/StickerPlacementActions.tsx
+++ b/src/components/Sticker/StickerPlacementActions.tsx
@@ -157,10 +157,19 @@ export function StickerPlacementActions({
 /**
  * The note, and the two ways to accept the sticker carrying it.
  *
- * The text is shown here because this is the only place the decision is made
- * with the words in front of you — on the image there is no indication a note
- * exists at all until the sticker is already live. Fetched on open rather than
- * carried by the listing, which runs for every image on a feed page.
+ * On the image there is nothing to say a note exists at all until the sticker
+ * is live, so this is where the owner first reads it. The queue renders it
+ * beside the row as well, which makes this a second copy there — worth it to
+ * keep one component asking one question in both places. Fetched on open rather
+ * than carried by the listing, which runs for every image on a feed page.
+ *
+ * **It also has to say what the owner already decided.** They can hide a note
+ * from the hover card while the placement is still pending, and the approve
+ * that follows is the only thing that can undo that. Showing two buttons with
+ * no mention of the earlier decision would make the primary one silently
+ * publish a note they had refused — which is the same defect this feature has
+ * now produced twice, once by defaulting the flag and once by removing the
+ * option to leave it alone.
  *
  * Closing the popover is the third answer and needs no button: it leaves the
  * placement pending, so Decline is still available.
@@ -181,6 +190,12 @@ function NoteDecision({
     { staleTime: 60_000 }
   );
 
+  // Read from the same query that supplies the text, rather than threaded down
+  // from a listing: `getPendingStickerPlacements` and the feed listing both
+  // report only whether a note exists, so a caller could not pass this even if
+  // it wanted to.
+  const alreadyHidden = !!data?.commentHidden;
+
   return (
     <>
       {/* A panel header, divider across the full width, styled like the sticker
@@ -196,7 +211,7 @@ function NoteDecision({
       >
         <IconMessage size={14} className="shrink-0 text-yellow-6" />
         <Text size="xs" c="dimmed" className="min-w-0 truncate">
-          They left a note with this sticker
+          {alreadyHidden ? 'You hid this note earlier' : 'They left a note with this sticker'}
         </Text>
       </Group>
 
@@ -214,21 +229,37 @@ function NoteDecision({
           </div>
         )}
 
+        {/* Order follows what the owner already chose, so the primary button is
+            never the one that reverses it. Publishing is the answer that cannot
+            be taken back, so it is never the default for a note they refused. */}
         <Stack gap={4}>
-          <Button size="compact-xs" color="green" loading={pending} onClick={onInclude}>
-            Approve with the note
-          </Button>
-          <Button size="compact-xs" variant="default" loading={pending} onClick={onOmit}>
-            Approve without it
-          </Button>
+          {alreadyHidden ? (
+            <>
+              <Button size="compact-xs" color="green" loading={pending} onClick={onOmit}>
+                Approve, keep it hidden
+              </Button>
+              <Button size="compact-xs" variant="default" loading={pending} onClick={onInclude}>
+                Approve and show it after all
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button size="compact-xs" color="green" loading={pending} onClick={onInclude}>
+                Approve with the note
+              </Button>
+              <Button size="compact-xs" variant="default" loading={pending} onClick={onOmit}>
+                Approve without it
+              </Button>
+            </>
+          )}
         </Stack>
 
         {/* Under the buttons, not above them. It explains what the second button
             does, and between the note and the choice it pushed the note far
             enough from the buttons to be skipped. */}
         <Text size="xs" c="dimmed">
-          Approving without it keeps the sticker and leaves the note private — only you, the person
-          who placed it, and moderators can read it.
+          A hidden note stays private — only you, the person who placed it, and moderators can read
+          it. You can change your mind from the sticker at any time.
         </Text>
       </Stack>
     </>

--- a/src/components/Sticker/StickerPlacementActions.tsx
+++ b/src/components/Sticker/StickerPlacementActions.tsx
@@ -9,18 +9,27 @@ import { trpc } from '~/utils/trpc';
  * One component for the image and the queue, so the two cannot end up asking
  * different questions before taking someone's money.
  *
- * **Decline confirms; approve does not.** Approving is reversible — the owner
- * can remove an approved placement afterwards and it refunds in full. Declining
- * keeps 30% of what the placer paid and cannot be undone, so it gets the extra
- * press. That asymmetry is the point rather than an inconsistency.
+ * **Decline confirms; approve does not.** Declining keeps 30% of what the placer
+ * paid and cannot be undone. Approving pays the owner and is not undone either —
+ * an approved sticker can be removed after a week, and that removes it without
+ * returning anyone's Buzz — but it takes nothing from the placer that they did
+ * not choose to spend, so it does not get the extra press.
  */
 export function StickerPlacementActions({
   placementIds,
   compact = false,
+  hasComment = false,
   onDone,
 }: {
   placementIds: number[];
   compact?: boolean;
+  /**
+   * Whether any of these carries a note, which is what makes partial approval
+   * meaningful. Offered only then rather than always: "Approve without note" on
+   * a placement with no note is a button that does nothing, in the one place an
+   * owner is deciding what to accept.
+   */
+  hasComment?: boolean;
   onDone?: () => void;
 }) {
   const [confirming, setConfirming] = useState(false);
@@ -58,6 +67,18 @@ export function StickerPlacementActions({
       >
         Approve{placementIds.length > 1 ? ` ${placementIds.length}` : ''}
       </Button>
+
+      {hasComment && (
+        <Button
+          size={size}
+          color="green"
+          variant="light"
+          disabled={disabled}
+          onClick={() => act.mutate({ placementIds, action: 'approve', hideComment: true })}
+        >
+          Approve without note
+        </Button>
+      )}
 
       <Popover opened={confirming} onChange={setConfirming} withArrow position="top" width={260}>
         <Popover.Target>

--- a/src/components/Sticker/StickerPlacementActions.tsx
+++ b/src/components/Sticker/StickerPlacementActions.tsx
@@ -1,4 +1,5 @@
-import { Button, Group, Popover, Stack, Text } from '@mantine/core';
+import { Button, Group, Popover, Skeleton, Stack, Text } from '@mantine/core';
+import clsx from 'clsx';
 import { useState } from 'react';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
@@ -9,30 +10,37 @@ import { trpc } from '~/utils/trpc';
  * One component for the image and the queue, so the two cannot end up asking
  * different questions before taking someone's money.
  *
- * **Decline confirms; approve does not.** Declining keeps 30% of what the placer
- * paid and cannot be undone. Approving pays the owner and is not undone either —
- * an approved sticker can be removed after a week, and that removes it without
- * returning anyone's Buzz — but it takes nothing from the placer that they did
- * not choose to spend, so it does not get the extra press.
+ * **Decline confirms; approve confirms only when there is a note.** Declining
+ * keeps 30% of what the placer paid and cannot be undone. A plain approve takes
+ * nothing from the placer they did not choose to spend, so it goes straight
+ * through — but an approve that would publish someone's words is a second
+ * decision, and it is the one the owner cannot see the subject of otherwise.
  */
 export function StickerPlacementActions({
   placementIds,
   compact = false,
   hasComment = false,
+  stacked = false,
   onDone,
 }: {
   placementIds: number[];
   compact?: boolean;
   /**
-   * Whether any of these carries a note, which is what makes partial approval
-   * meaningful. Offered only then rather than always: "Approve without note" on
-   * a placement with no note is a button that does nothing, in the one place an
-   * owner is deciding what to accept.
+   * Whether this carries a note. Only meaningful for a single placement — a bulk
+   * action deliberately does not offer the choice, so a mixed selection cannot
+   * silently apply one answer to all of them.
    */
   hasComment?: boolean;
+  /**
+   * Stack the buttons instead of sitting them in a row. The queue gives each row
+   * a narrow column; the overlay floats over artwork where a tall stack would
+   * cover more of the image than a wide one.
+   */
+  stacked?: boolean;
   onDone?: () => void;
 }) {
   const [confirming, setConfirming] = useState(false);
+  const [approving, setApproving] = useState(false);
   const utils = trpc.useUtils();
 
   const act = trpc.placement.actOnStickers.useMutation({
@@ -48,6 +56,7 @@ export function StickerPlacementActions({
       });
       await utils.placement.invalidate();
       setConfirming(false);
+      setApproving(false);
       onDone?.();
     },
     onError: (error) =>
@@ -56,28 +65,45 @@ export function StickerPlacementActions({
 
   const size = compact ? 'compact-xs' : 'compact-sm';
   const disabled = !placementIds.length || act.isPending;
+  // A bulk action never asks about notes, so the question can only be about one
+  // placement — which is also the only case where the note can be shown.
+  const asksAboutNote = hasComment && placementIds.length === 1;
+
+  const approve = (hideComment?: boolean) =>
+    act.mutate({
+      placementIds,
+      action: 'approve',
+      ...(hideComment === undefined ? {} : { hideComment }),
+    });
+
+  const approveButton = (
+    <Button
+      size={size}
+      color="green"
+      disabled={disabled}
+      fullWidth={stacked}
+      onClick={() => (asksAboutNote ? setApproving((open) => !open) : approve())}
+    >
+      Approve{placementIds.length > 1 ? ` ${placementIds.length}` : ''}
+    </Button>
+  );
 
   return (
-    <Group gap={4} wrap="nowrap">
-      <Button
-        size={size}
-        color="green"
-        disabled={disabled}
-        onClick={() => act.mutate({ placementIds, action: 'approve' })}
-      >
-        Approve{placementIds.length > 1 ? ` ${placementIds.length}` : ''}
-      </Button>
-
-      {hasComment && (
-        <Button
-          size={size}
-          color="green"
-          variant="light"
-          disabled={disabled}
-          onClick={() => act.mutate({ placementIds, action: 'approve', hideComment: true })}
-        >
-          Approve without note
-        </Button>
+    <Group gap={4} wrap="nowrap" className={clsx(stacked && 'flex-col items-stretch')}>
+      {asksAboutNote ? (
+        <Popover opened={approving} onChange={setApproving} withArrow position="top" width={280}>
+          <Popover.Target>{approveButton}</Popover.Target>
+          <Popover.Dropdown>
+            <NoteDecision
+              placementId={placementIds[0]}
+              pending={act.isPending}
+              onInclude={() => approve(false)}
+              onOmit={() => approve(true)}
+            />
+          </Popover.Dropdown>
+        </Popover>
+      ) : (
+        approveButton
       )}
 
       <Popover opened={confirming} onChange={setConfirming} withArrow position="top" width={260}>
@@ -85,6 +111,7 @@ export function StickerPlacementActions({
           <Button
             size={size}
             color="red"
+            fullWidth={stacked}
             // Filled, not light. `light` is a tinted background at low contrast,
             // which sits on top of arbitrary artwork on the image overlay and
             // becomes unreadable against anything busy or red.
@@ -120,5 +147,63 @@ export function StickerPlacementActions({
         </Popover.Dropdown>
       </Popover>
     </Group>
+  );
+}
+
+/**
+ * The note, and the two ways to accept the sticker carrying it.
+ *
+ * The text is shown here because this is the only place the decision is made
+ * with the words in front of you — on the image there is no indication a note
+ * exists at all until the sticker is already live. Fetched on open rather than
+ * carried by the listing, which runs for every image on a feed page.
+ *
+ * Closing the popover is the third answer and needs no button: it leaves the
+ * placement pending, so Decline is still available.
+ */
+function NoteDecision({
+  placementId,
+  pending,
+  onInclude,
+  onOmit,
+}: {
+  placementId: number;
+  pending: boolean;
+  onInclude: () => void;
+  onOmit: () => void;
+}) {
+  const { data, isLoading } = trpc.placement.getStickerPlacementDetail.useQuery(
+    { placementId },
+    { staleTime: 60_000 }
+  );
+
+  return (
+    <Stack gap="xs">
+      <Text size="xs" c="dimmed">
+        They left a note with this sticker:
+      </Text>
+
+      {isLoading ? (
+        <Skeleton height={32} radius="sm" />
+      ) : (
+        <Text size="sm" className="whitespace-pre-wrap break-words">
+          {data?.comment ?? 'The note is no longer available.'}
+        </Text>
+      )}
+
+      <Text size="xs" c="dimmed">
+        Approving without it keeps the sticker and leaves the note private — only you, the person
+        who placed it, and moderators can read it.
+      </Text>
+
+      <Stack gap={4}>
+        <Button size="compact-xs" color="green" loading={pending} onClick={onInclude}>
+          Approve with the note
+        </Button>
+        <Button size="compact-xs" variant="default" loading={pending} onClick={onOmit}>
+          Approve without it
+        </Button>
+      </Stack>
+    </Stack>
   );
 }

--- a/src/components/Sticker/StickerPlacementHoverCard.tsx
+++ b/src/components/Sticker/StickerPlacementHoverCard.tsx
@@ -1,6 +1,6 @@
 import { Anchor, Badge, Group, HoverCard, Skeleton, Text, Tooltip } from '@mantine/core';
 import { openConfirmModal } from '@mantine/modals';
-import { IconSticker, IconTrash } from '@tabler/icons-react';
+import { IconEye, IconEyeOff, IconSticker, IconTrash } from '@tabler/icons-react';
 import dynamic from 'next/dynamic';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
@@ -150,10 +150,155 @@ export function StickerPlacementHoverCard({
             <Skeleton height={92} radius="md" />
           </div>
         ) : (
-          <SmartCreatorCard user={data.placer} withActions={false} withBorder={false} />
+          <>
+            {/* Above the creator card rather than below it: the note is the
+                thing the placer said, and the card is who said it. */}
+            {data.comment && (
+              <div className="border-b border-gray-3 px-3 py-2 dark:border-dark-4">
+                <Text size="sm" className="whitespace-pre-wrap break-words">
+                  {data.comment}
+                </Text>
+                {data.commentHidden && (
+                  <Text size="xs" c="dimmed" mt={4}>
+                    Hidden — only you, the person who placed it, and moderators can see this.
+                  </Text>
+                )}
+              </div>
+            )}
+            <SmartCreatorCard user={data.placer} withActions={false} withBorder={false} />
+            {data.viewerIsOwner && (
+              <OwnerControls
+                placementId={placementId}
+                hasComment={!!data.comment}
+                commentHidden={data.commentHidden}
+                isLive={data.status === 'approved'}
+                removableAt={data.removableAt}
+              />
+            )}
+          </>
         )}
       </HoverCard.Dropdown>
     </HoverCard>
+  );
+}
+
+/**
+ * What the content owner can do about a sticker already on their image.
+ *
+ * The two controls are deliberately unequal. Hiding the note is unlocked — it
+ * came free with the placement and is the owner's to refuse at any time, and
+ * being able to put it back is what makes hiding a safe first move. Removing
+ * the sticker waits a week from approval, because approval already paid the
+ * owner and nothing is refunded: without the wait an owner could take the Buzz
+ * and wipe the sticker before anyone saw it.
+ *
+ * Both refusals live on the server. The disabled button and its date are what
+ * the card *says*, not what decides it.
+ */
+function OwnerControls({
+  placementId,
+  hasComment,
+  commentHidden,
+  isLive,
+  removableAt,
+}: {
+  placementId: number;
+  hasComment: boolean;
+  commentHidden: boolean;
+  isLive: boolean;
+  removableAt: Date | string | null;
+}) {
+  const utils = trpc.useUtils();
+  const forget = useForgetStickerPlacement();
+
+  const setHidden = trpc.placement.setStickerCommentHidden.useMutation({
+    onSuccess: () => utils.placement.getStickerPlacementDetail.invalidate({ placementId }),
+    onError: (error) =>
+      showErrorNotification({ title: "Couldn't change the note", error: new Error(error.message) }),
+  });
+
+  const remove = trpc.placement.actOnStickers.useMutation({
+    onSuccess: async () => {
+      showSuccessNotification({ message: 'Sticker removed.' });
+      await forget(placementId);
+    },
+    onError: (error) =>
+      showErrorNotification({ title: "Couldn't remove it", error: new Error(error.message) }),
+  });
+
+  if (!hasComment && !isLive) return null;
+
+  const locked = !!removableAt;
+
+  return (
+    <Group
+      gap="xs"
+      px="sm"
+      py={6}
+      justify="flex-end"
+      className="border-t border-gray-3 dark:border-dark-4"
+    >
+      {hasComment && (
+        <Anchor
+          component="button"
+          type="button"
+          size="xs"
+          onClick={() => setHidden.mutate({ placementId, hidden: !commentHidden })}
+        >
+          <Group gap={4} wrap="nowrap">
+            {commentHidden ? <IconEye size={14} /> : <IconEyeOff size={14} />}
+            {commentHidden ? 'Show the note' : 'Hide the note'}
+          </Group>
+        </Anchor>
+      )}
+
+      {isLive && (
+        <Tooltip
+          withArrow
+          multiline
+          w={240}
+          label={
+            locked
+              ? `Someone paid to place this, so it stays up for a week. You can remove it from ${formatDate(
+                  removableAt as Date
+                )}.`
+              : 'Takes the sticker off your image. No Buzz moves.'
+          }
+        >
+          {/* Wrapped, because a disabled control fires no pointer events and a
+              tooltip on it never opens — which would leave the date explaining
+              the button visible only to people who did not need it. */}
+          <span>
+            <Anchor
+              component="button"
+              type="button"
+              size="xs"
+              c={locked ? 'dimmed' : 'red'}
+              disabled={locked}
+              onClick={() =>
+                openConfirmModal({
+                  title: 'Remove this sticker',
+                  children: (
+                    <Text size="sm">
+                      It comes off your image for everyone. The Buzz you were paid for it stays with
+                      you, and nobody is notified.
+                    </Text>
+                  ),
+                  labels: { confirm: 'Remove', cancel: 'Cancel' },
+                  confirmProps: { color: 'red' },
+                  onConfirm: () => remove.mutate({ placementIds: [placementId], action: 'remove' }),
+                })
+              }
+            >
+              <Group gap={4} wrap="nowrap">
+                <IconTrash size={14} />
+                Remove
+              </Group>
+            </Anchor>
+          </span>
+        </Tooltip>
+      )}
+    </Group>
   );
 }
 

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -462,7 +462,11 @@ export function StickerPlacementOverlay({
                 >
                   <div>
                     {isOwner ? (
-                      <StickerPlacementActions placementIds={[placement.id]} compact />
+                      <StickerPlacementActions
+                        placementIds={[placement.id]}
+                        hasComment={placement.hasComment}
+                        compact
+                      />
                     ) : (
                       <span className="whitespace-nowrap rounded bg-yellow-6 px-2 py-0.5 text-[10px] font-semibold text-dark-9">
                         Awaiting review

--- a/src/components/Sticker/placement.util.ts
+++ b/src/components/Sticker/placement.util.ts
@@ -23,6 +23,12 @@ export type PlacedSticker = {
    */
   placedAt: Date | string;
   isPending: boolean;
+  /**
+   * Whether this placement carries a note the viewer may read. The text itself
+   * is not in the listing — that runs for every image on a feed page — and comes
+   * with the hover card instead.
+   */
+  hasComment: boolean;
 };
 
 /**

--- a/src/pages/user/sticker-placements.tsx
+++ b/src/pages/user/sticker-placements.tsx
@@ -125,6 +125,14 @@ export default function StickerPlacements() {
                       Placed {formatDate(row.createdAt)}
                       {row.expiresAt ? ` · expires ${formatDate(row.expiresAt)}` : ''}
                     </Text>
+                    {/* Shown here because this is where the note is decided on.
+                        An owner choosing "Approve without note" needs to have
+                        read the note in the same glance as the sticker. */}
+                    {row.data.comment && (
+                      <Text size="sm" className="whitespace-pre-wrap break-words">
+                        &ldquo;{row.data.comment}&rdquo;
+                      </Text>
+                    )}
                     <Anchor
                       component={Link}
                       href={`/images/${row.targetId}`}
@@ -138,7 +146,11 @@ export default function StickerPlacements() {
                     </Anchor>
                   </Stack>
 
-                  <StickerPlacementActions placementIds={[row.id]} compact />
+                  <StickerPlacementActions
+                    placementIds={[row.id]}
+                    hasComment={!!row.data.comment}
+                    compact
+                  />
                 </Group>
               </Card>
             );

--- a/src/pages/user/sticker-placements.tsx
+++ b/src/pages/user/sticker-placements.tsx
@@ -149,6 +149,7 @@ export default function StickerPlacements() {
                   <StickerPlacementActions
                     placementIds={[row.id]}
                     hasComment={!!row.data.comment}
+                    stacked
                     compact
                   />
                 </Group>

--- a/src/server/__tests__/report-sticker-dedupe.test.ts
+++ b/src/server/__tests__/report-sticker-dedupe.test.ts
@@ -73,7 +73,9 @@ describe('a sticker report is deduped by placement, not by image', () => {
     // The query must carry the placement, or it would match the existing report
     // about PLACEMENT_ONE and return it instead.
     const [query] = reportFindFirst.mock.calls[0] as [{ where: MixedObject }];
-    expect(query.where.details).toEqual({ path: ['placementId'], equals: PLACEMENT_TWO });
+    expect(query.where.AND).toContainEqual({
+      details: { path: ['placementId'], equals: PLACEMENT_TWO },
+    });
 
     // The row that gets written has to carry the NEW placement. Asserting only
     // that create ran proves nothing here — `findFirst` is mocked to null, so it
@@ -97,6 +99,36 @@ describe('a sticker report is deduped by placement, not by image', () => {
         data: expect.objectContaining({ alsoReportedBy: [REPORTER_A, REPORTER_B] }),
       })
     );
+  });
+
+  /**
+   * A sticker and the note hanging off it are separately objectionable, and the
+   * discrimination has to run in BOTH directions. Matching on the placement
+   * alone for either one is not a weaker filter — it is a fold: the second
+   * report is appended to the first as "also reported by", its reason text
+   * discarded, and a moderator is shown a complaint about one while the
+   * complaint about the other is invisible.
+   */
+  it('asks for the note and the sticker separately, whichever is reported', async () => {
+    reportFindFirst.mockResolvedValue(null);
+
+    await createReport({
+      ...stickerReport(PLACEMENT_ONE, REPORTER_A),
+      details: { placementId: PLACEMENT_ONE, target: 'comment', comment: 'nope' },
+    });
+    const [noteQuery] = reportFindFirst.mock.calls[0] as [{ where: MixedObject }];
+    expect(noteQuery.where.AND).toContainEqual({
+      details: { path: ['target'], equals: 'comment' },
+    });
+
+    reportFindFirst.mockClear();
+    await createReport(stickerReport(PLACEMENT_ONE, REPORTER_B));
+    const [artQuery] = reportFindFirst.mock.calls[0] as [{ where: MixedObject }];
+    // Not merely "no comment predicate" — the sticker arm has to assert its own
+    // value, or it matches the note report about the same placement.
+    expect(artQuery.where.AND).toContainEqual({
+      details: { path: ['target'], equals: 'sticker' },
+    });
   });
 
   it('leaves every other reason deduping exactly as it did', async () => {

--- a/src/server/routers/placement.router.ts
+++ b/src/server/routers/placement.router.ts
@@ -17,6 +17,7 @@ import {
   removePlacementSchema,
   retractRemixGallerySubmissionSchema,
   setRemixGalleryPinsSchema,
+  setStickerCommentHiddenSchema,
   submitToRemixGallerySchema,
   suspendPlacerSchema,
 } from '~/server/schema/placement.schema';
@@ -44,6 +45,7 @@ import {
   getPlacementSettlementStates,
   getStickerPlacementCounts,
   getStickerPlacements,
+  setStickerCommentHidden,
 } from '~/server/services/sticker-placement.service';
 import {
   actOnRemixGallerySubmission,
@@ -199,6 +201,21 @@ export const placementRouter = router({
     .input(actOnStickerPlacementsSchema)
     .mutation(({ input, ctx }) =>
       actOnStickerPlacements({ ...input, userId: ctx.user.id, isModerator: ctx.user.isModerator })
+    ),
+
+  /**
+   * Hiding or restoring the note on a sticker. Ungated for the same reason
+   * `actOnStickers` is: turning the flag off must not leave an owner holding a
+   * note on their own image with no way to refuse it.
+   */
+  setStickerCommentHidden: protectedProcedure
+    .input(setStickerCommentHiddenSchema)
+    .mutation(({ input, ctx }) =>
+      setStickerCommentHidden({
+        ...input,
+        userId: ctx.user.id,
+        isModerator: ctx.user.isModerator,
+      })
     ),
 
   isSuspended: moderatorProcedure

--- a/src/server/schema/placement.schema.ts
+++ b/src/server/schema/placement.schema.ts
@@ -3,6 +3,7 @@ import { allBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constant
 import { placementSurfaces } from '~/shared/utils/placement';
 import { REMIX_GALLERY_MAX_PINNED } from '~/shared/utils/remix-gallery';
 import {
+  STICKER_COMMENT_MAX_LENGTH,
   STICKER_PLACEMENT_MAX_ROTATION,
   STICKER_PLACEMENT_MAX_SCALE,
   STICKER_PLACEMENT_MIN_SCALE,
@@ -25,6 +26,13 @@ export const stickerPlacementDataSchema = z.object({
   y: finite.min(0).max(1),
   scale: finite.min(STICKER_PLACEMENT_MIN_SCALE).max(STICKER_PLACEMENT_MAX_SCALE),
   rotation: finite.min(-STICKER_PLACEMENT_MAX_ROTATION).max(STICKER_PLACEMENT_MAX_ROTATION),
+  // Bounded well above what the field allows, because the service trims and
+  // truncates. The limit here is what stops a megabyte of text reaching a JSON
+  // column; the normaliser is what decides the stored value.
+  comment: z
+    .string()
+    .max(STICKER_COMMENT_MAX_LENGTH * 4)
+    .optional(),
 });
 
 export const createStickerPlacementSchema = z.object({
@@ -100,6 +108,13 @@ export const getStickerPlacementDetailSchema = z.object({
 export const actOnStickerPlacementsSchema = z.object({
   placementIds: z.array(z.number().int().positive()).min(1).max(50),
   action: z.enum(['approve', 'decline', 'remove']),
+  /** Partial approval — take the sticker, refuse the note it came with. */
+  hideComment: z.boolean().optional(),
+});
+
+export const setStickerCommentHiddenSchema = z.object({
+  placementId: z.number().int().positive(),
+  hidden: z.boolean(),
 });
 
 export const getPlacementSpaceRowSchema = z.object({

--- a/src/server/schema/report.schema.ts
+++ b/src/server/schema/report.schema.ts
@@ -55,6 +55,20 @@ export const reportStickerPlacementDetailsSchema = baseDetailSchema.extend({
     .number({ error: 'Choose which sticker you are reporting.' })
     .int()
     .positive(),
+  /**
+   * Which half of the placement is being reported.
+   *
+   * A sticker and the note attached to it are separately objectionable — the
+   * artwork can be fine and the note abusive, which is the griefing case Ellie
+   * raised — and a moderator needs to know which one they are being sent to
+   * look at, because the remedies differ: the owner can hide a note without the
+   * sticker coming off.
+   *
+   * Carried in the details rather than as its own `ReportReason` so this needs
+   * no enum migration, and so both reports still land on the image with the
+   * same placement id a moderator acts on.
+   */
+  target: z.enum(['sticker', 'comment']).default('sticker'),
 });
 
 export const reportAutomatedDetailsSchema = baseDetailSchema.extend({

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -980,6 +980,7 @@ describe('an approved submission counts toward the host image buzz counter', () 
   const pending = {
     id: PLACEMENT,
     ownerId: OWNER,
+    placerId: PLACER,
     status: 'pending',
     surface: 'remixGallery',
     data: { imageId: REMIX_IMAGE },
@@ -1001,6 +1002,8 @@ describe('an approved submission counts toward the host image buzz counter', () 
       entityId: HOST_IMAGE,
       metricType: 'Buzz',
       amount: PRICE,
+      // The submitter, not the host's owner: attribution follows who paid.
+      userId: PLACER,
     });
     // Exactly once, which the payload assertion above cannot see. The two
     // negative tests in this block would both pass against a full revert, so

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -1,5 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NsfwLevel } from '~/server/common/enums';
+import type * as MetricHelpers from '~/server/utils/metric-helpers';
+
+const updateEntityMetricDetached = vi.fn(async () => undefined);
+vi.mock('~/server/utils/metric-helpers', async (importOriginal) => ({
+  ...(await importOriginal<typeof MetricHelpers>()),
+  updateEntityMetricDetached,
+}));
 
 /**
  * Every quantity distinct, so a value reaching the wrong place cannot pass by
@@ -960,5 +967,63 @@ describe('gallery cursor', () => {
     // expression, which selects a different but stable permutation and looks
     // like nothing is wrong.
     expect(parseGalleryCursor(cursor as string | undefined)).toBeNull();
+  });
+});
+
+/**
+ * A gallery entry is a paid placement on the host image, so it counts toward the
+ * same Buzz counter a sticker does (Justin, 2026-08-12). Same rule on both
+ * surfaces, because a single counter that means different things depending on
+ * which surface you asked has lost the only property it needs.
+ */
+describe('an approved submission counts toward the host image buzz counter', () => {
+  const pending = {
+    id: PLACEMENT,
+    ownerId: OWNER,
+    status: 'pending',
+    surface: 'remixGallery',
+    data: { imageId: REMIX_IMAGE },
+    targetId: HOST_IMAGE,
+    amount: PRICE,
+    resolvedAt: null,
+    createdAt: new Date(0),
+  };
+
+  it('counts what the submitter paid, against the host image', async () => {
+    placementFindUnique.mockResolvedValue(pending);
+
+    await actOnRemixGallerySubmission({ placementId: PLACEMENT, action: 'approve', userId: OWNER });
+
+    expect(updateEntityMetricDetached).toHaveBeenCalledWith({
+      entityType: 'Image',
+      // The HOST, not the submitted image. The submitter's own image gained
+      // nothing; the creator was paid to have it shown on theirs.
+      entityId: HOST_IMAGE,
+      metricType: 'Buzz',
+      amount: PRICE,
+    });
+  });
+
+  /**
+   * A decline still moves 30% of the fee to the owner and still counts nothing
+   * (Justin, 2026-08-12). Counting it would grow the counter fastest for a
+   * creator who refuses everything.
+   */
+  it('counts nothing when the owner declines, though the fee is kept', async () => {
+    placementFindUnique.mockResolvedValue(pending);
+
+    await actOnRemixGallerySubmission({ placementId: PLACEMENT, action: 'decline', userId: OWNER });
+
+    expect(updateEntityMetricDetached).not.toHaveBeenCalled();
+  });
+
+  it('counts nothing when the settle lost the race', async () => {
+    placementFindUnique.mockResolvedValue(pending);
+    settlePlacement.mockResolvedValue({ settled: false });
+
+    await expect(
+      actOnRemixGallerySubmission({ placementId: PLACEMENT, action: 'approve', userId: OWNER })
+    ).rejects.toThrow(/already resolved/i);
+    expect(updateEntityMetricDetached).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -1002,6 +1002,11 @@ describe('an approved submission counts toward the host image buzz counter', () 
       metricType: 'Buzz',
       amount: PRICE,
     });
+    // Exactly once, which the payload assertion above cannot see. The two
+    // negative tests in this block would both pass against a full revert, so
+    // without this the whole commit rests on an assertion that a second,
+    // duplicate emission would satisfy just as happily.
+    expect(updateEntityMetricDetached).toHaveBeenCalledTimes(1);
   });
 
   /**

--- a/src/server/services/__tests__/sticker-placement.service.test.ts
+++ b/src/server/services/__tests__/sticker-placement.service.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as MetricHelpers from '~/server/utils/metric-helpers';
+import { STICKER_REMOVAL_LOCK_HOURS } from '~/shared/utils/sticker-placement';
 
 /**
  * Fixture discipline: every quantity in scope is a distinct number, so a value
@@ -61,10 +63,20 @@ const transactionFindMany = vi.fn(async () => [] as unknown[]);
 const placementFindFirst = vi.fn(async () => null as unknown);
 const cosmeticFindUnique = vi.fn(async () => null as unknown);
 
+const placementFindUnique = vi.fn(async () => null as unknown);
+const placementUpdate = vi.fn(async () => ({}));
+const placementUpdateMany = vi.fn(async () => ({ count: 1 }));
+
 vi.mock('~/server/db/client', () => ({
   dbWrite: {
     $queryRaw: (...args: unknown[]) => queryRaw(...args),
-    placement: { create: placementCreate, count: placementCount, findUnique: vi.fn() },
+    placement: {
+      create: placementCreate,
+      count: placementCount,
+      findUnique: placementFindUnique,
+      update: placementUpdate,
+      updateMany: placementUpdateMany,
+    },
   },
   dbRead: {
     placement: {
@@ -77,7 +89,14 @@ vi.mock('~/server/db/client', () => ({
   },
 }));
 
+const updateEntityMetricDetached = vi.fn(async () => undefined);
+vi.mock('~/server/utils/metric-helpers', async (importOriginal) => ({
+  ...(await importOriginal<typeof MetricHelpers>()),
+  updateEntityMetricDetached,
+}));
+
 const {
+  actOnStickerPlacement,
   createStickerPlacement,
   getStickerPlacements,
   getPlacementSettlementStates,
@@ -117,6 +136,7 @@ beforeEach(() => {
   queryRaw.mockResolvedValue([]);
   resolvePlacementSpaceFor.mockResolvedValue({ ...OPEN_SPACE });
   placementCount.mockResolvedValue(0);
+  placementUpdateMany.mockResolvedValue({ count: 1 });
   holdPlacementEscrow.mockImplementation(async () => {
     calls.push('hold');
     return { fee: 210, principal: 490 };
@@ -660,5 +680,309 @@ describe('the hover-card detail', () => {
 
     const [query] = placementFindFirst.mock.calls[0] as [{ where: { OR: MixedObject[] } }];
     expect(query.where.OR.map((clause) => clause.status)).toEqual(['approved']);
+  });
+});
+
+/**
+ * The image's Buzz counter, which the 2026-08-12 review agreed a sticker should
+ * move: a placement reads as a pseudo-tip, so it counts toward the number people
+ * already look at.
+ */
+describe("a placement counts toward the image's Buzz counter", () => {
+  const givenApprovable = () =>
+    placementFindUnique.mockResolvedValue({
+      id: PLACEMENT,
+      ownerId: OWNER,
+      targetId: IMAGE,
+      amount: PRICE,
+      status: 'pending',
+      surface: 'sticker',
+      data: { cosmeticId: COSMETIC, x: 0.5, y: 0.5, scale: 0.2, rotation: 0 },
+      createdAt: new Date(0),
+      resolvedAt: null,
+    });
+
+  it('counts what the placer paid when an auto space approves on placement', async () => {
+    resolvePlacementSpaceFor.mockResolvedValue({ ...OPEN_SPACE, mode: 'auto' });
+    givenStickerAndBalance();
+
+    await createStickerPlacement(placeInput);
+
+    expect(updateEntityMetricDetached).toHaveBeenCalledWith({
+      entityType: 'Image',
+      entityId: IMAGE,
+      metricType: 'Buzz',
+      // `price`, not `setPrice`: the cap is what was actually charged.
+      amount: PRICE,
+    });
+  });
+
+  /**
+   * The guard that stops one payment being counted twice. `settlePlacement`
+   * returns `settled: false` when something else claimed the transition first —
+   * a double-submitted approve, a retried call — so counting on the action asked
+   * for rather than on the transition won would add the Buzz again with no
+   * second payment behind it.
+   */
+  it('does not count a settle that lost the race', async () => {
+    resolvePlacementSpaceFor.mockResolvedValue({ ...OPEN_SPACE, mode: 'auto' });
+    givenStickerAndBalance();
+    settlePlacement.mockImplementation(async () => ({ settled: false }));
+
+    await createStickerPlacement(placeInput);
+
+    expect(updateEntityMetricDetached).not.toHaveBeenCalled();
+  });
+
+  it('counts when the owner approves from the queue', async () => {
+    givenApprovable();
+
+    await actOnStickerPlacement({ placementId: PLACEMENT, action: 'approve', userId: OWNER });
+
+    expect(updateEntityMetricDetached).toHaveBeenCalledWith(
+      expect.objectContaining({ entityId: IMAGE, amount: PRICE })
+    );
+  });
+
+  it('counts nothing when the owner declines', async () => {
+    givenApprovable();
+
+    await actOnStickerPlacement({ placementId: PLACEMENT, action: 'decline', userId: OWNER });
+
+    expect(updateEntityMetricDetached).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The week an approved sticker stays up.
+ *
+ * Approval pays the owner and removal refunds nothing, so without the lock an
+ * owner could accept a sticker, bank the Buzz and wipe it before anyone saw it.
+ */
+describe('the owner cannot remove a sticker for a week after approving it', () => {
+  const HOUR_MS = 60 * 60 * 1000;
+
+  const givenApproved = (approvedHoursAgo: number, resolved = true) => {
+    const at = new Date(Date.now() - approvedHoursAgo * HOUR_MS);
+    placementFindUnique.mockResolvedValue({
+      id: PLACEMENT,
+      ownerId: OWNER,
+      targetId: IMAGE,
+      amount: PRICE,
+      status: 'approved',
+      surface: 'sticker',
+      data: { cosmeticId: COSMETIC, x: 0.5, y: 0.5, scale: 0.2, rotation: 0 },
+      createdAt: at,
+      resolvedAt: resolved ? at : null,
+    });
+  };
+
+  it('refuses inside the week, and says when it opens', async () => {
+    givenApproved(STICKER_REMOVAL_LOCK_HOURS - 1);
+
+    await expect(
+      actOnStickerPlacement({ placementId: PLACEMENT, action: 'remove', userId: OWNER })
+    ).rejects.toThrow(/stays up for a week/);
+    expect(placementUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it('allows it once the week is up, and moves no money', async () => {
+    givenApproved(STICKER_REMOVAL_LOCK_HOURS + 1);
+
+    await actOnStickerPlacement({ placementId: PLACEMENT, action: 'remove', userId: OWNER });
+
+    const [write] = placementUpdateMany.mock.calls[0] as [{ data: Record<string, unknown> }];
+    expect(write.data).toMatchObject({ status: 'removed', removedBy: 'owner' });
+    // `settlePlacement` claims `WHERE status = 'pending'`, so routing a live row
+    // through it would report success and change nothing.
+    expect(settlePlacement).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Fails CLOSED on a row with no `resolvedAt`. Skipping the check when the
+   * column is absent would let a hand-seeded row — or anything predating the
+   * approval path writing it — be removed immediately, which is the exact case
+   * the lock exists for.
+   */
+  it('measures from createdAt when the approval time is missing', async () => {
+    givenApproved(0, false);
+
+    await expect(
+      actOnStickerPlacement({ placementId: PLACEMENT, action: 'remove', userId: OWNER })
+    ).rejects.toThrow(/stays up for a week/);
+  });
+
+  /**
+   * A takedown is a moderation record, not an owner decision, and the abusive
+   * cases are the ones that must not wait. The exemption follows the role being
+   * exercised — an owner who is also a moderator is still the owner here.
+   */
+  it('does not bind a moderator acting on content that is not theirs', async () => {
+    givenApproved(1);
+
+    await actOnStickerPlacement({
+      placementId: PLACEMENT,
+      action: 'remove',
+      userId: STRANGER,
+      isModerator: true,
+    });
+
+    const [write] = placementUpdateMany.mock.calls[0] as [{ data: Record<string, unknown> }];
+    expect(write.data).toMatchObject({ removedBy: 'moderator' });
+  });
+
+  it('still binds an owner who happens to be a moderator', async () => {
+    givenApproved(1);
+
+    await expect(
+      actOnStickerPlacement({
+        placementId: PLACEMENT,
+        action: 'remove',
+        userId: OWNER,
+        isModerator: true,
+      })
+    ).rejects.toThrow(/stays up for a week/);
+  });
+});
+
+/** The optional note, and the partial approval that refuses it. */
+describe('the note on a placement', () => {
+  const withComment = (comment?: string) =>
+    placementFindUnique.mockResolvedValue({
+      id: PLACEMENT,
+      ownerId: OWNER,
+      targetId: IMAGE,
+      amount: PRICE,
+      status: 'pending',
+      surface: 'sticker',
+      data: {
+        cosmeticId: COSMETIC,
+        x: 0.5,
+        y: 0.5,
+        scale: 0.2,
+        rotation: 0,
+        ...(comment ? { comment } : {}),
+      },
+      createdAt: new Date(0),
+      resolvedAt: null,
+    });
+
+  it('is stored with the placement, trimmed and collapsed', async () => {
+    givenStickerAndBalance();
+
+    await createStickerPlacement({
+      ...placeInput,
+      data: { ...placeInput.data, comment: '  love   this\n\none  ' },
+    });
+
+    const [write] = placementCreate.mock.calls[0] as [{ data: { data: { comment?: string } } }];
+    expect(write.data.data.comment).toBe('love this one');
+  });
+
+  it('stores no comment key at all when the field was left blank', async () => {
+    givenStickerAndBalance();
+
+    await createStickerPlacement({ ...placeInput, data: { ...placeInput.data, comment: '   ' } });
+
+    const [write] = placementCreate.mock.calls[0] as [{ data: { data: Record<string, unknown> } }];
+    expect(write.data.data).not.toHaveProperty('comment');
+  });
+
+  it('is hidden by an approve that refuses it, before the placement goes live', async () => {
+    withComment('nice hat');
+
+    await actOnStickerPlacement({
+      placementId: PLACEMENT,
+      action: 'approve',
+      userId: OWNER,
+      hideComment: true,
+    });
+
+    const [write] = placementUpdate.mock.calls[0] as [{ data: { data: Record<string, unknown> } }];
+    expect(write.data.data).toMatchObject({ comment: 'nice hat', commentHidden: true });
+    // The rest of the payload survives: refusing a note must not be a way to
+    // move the sticker it was attached to.
+    expect(write.data.data).toMatchObject({ cosmeticId: COSMETIC, x: 0.5, scale: 0.2 });
+  });
+
+  /**
+   * Hiding is the owner's judgement about their own image, not a deletion. The
+   * three parties with a reason to see it keep seeing it — the owner who hid it,
+   * the placer who wrote and paid for it, and a moderator acting on a report,
+   * which is about text nobody else can read.
+   */
+  describe('once hidden', () => {
+    const givenHidden = () =>
+      placementFindFirst.mockResolvedValue({
+        id: PLACEMENT,
+        createdAt: new Date(0),
+        resolvedAt: new Date(0),
+        status: 'approved',
+        ownerId: OWNER,
+        placerId: PLACER,
+        data: {
+          cosmeticId: COSMETIC,
+          x: 0.5,
+          y: 0.5,
+          scale: 0.2,
+          rotation: 0,
+          comment: 'nice hat',
+          commentHidden: true,
+        },
+        placer: { id: PLACER, username: 'placer' },
+      });
+
+    beforeEach(() => {
+      placementFindFirst.mockReset();
+      cosmeticFindUnique.mockReset();
+      cosmeticFindUnique.mockResolvedValue(null);
+    });
+
+    it('is withheld from everyone else', async () => {
+      givenHidden();
+
+      const detail = await getStickerPlacementDetail({
+        placementId: PLACEMENT,
+        viewerId: STRANGER,
+      });
+
+      expect(detail.comment).toBeNull();
+      // Still stated, so the placer is never told their note is live when it is
+      // not — and so the owner's control knows which way it points.
+      expect(detail.commentHidden).toBe(true);
+    });
+
+    it('stays readable to the placer who paid for it', async () => {
+      givenHidden();
+
+      const detail = await getStickerPlacementDetail({ placementId: PLACEMENT, viewerId: PLACER });
+
+      expect(detail.comment).toBe('nice hat');
+    });
+
+    it('stays readable to a moderator acting on a report about it', async () => {
+      givenHidden();
+
+      const detail = await getStickerPlacementDetail({
+        placementId: PLACEMENT,
+        viewerId: STRANGER,
+        isModerator: true,
+      });
+
+      expect(detail.comment).toBe('nice hat');
+    });
+  });
+
+  it('writes no flag onto a placement that never carried one', async () => {
+    withComment();
+
+    await actOnStickerPlacement({
+      placementId: PLACEMENT,
+      action: 'approve',
+      userId: OWNER,
+      hideComment: true,
+    });
+
+    expect(placementUpdate).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/__tests__/sticker-placement.service.test.ts
+++ b/src/server/services/__tests__/sticker-placement.service.test.ts
@@ -698,6 +698,7 @@ describe("a placement counts toward the image's Buzz counter", () => {
     placementFindUnique.mockResolvedValue({
       id: PLACEMENT,
       ownerId: OWNER,
+      placerId: PLACER,
       targetId: IMAGE,
       amount: PRICE,
       status: 'pending',
@@ -719,6 +720,9 @@ describe("a placement counts toward the image's Buzz counter", () => {
       metricType: 'Buzz',
       // `price`, not `setPrice`: the cap is what was actually charged.
       amount: PRICE,
+      // Attributed to the placer, the way a tip is attributed to its tipper —
+      // and load-bearing, because `userId` is part of the pipeline's dedupe key.
+      userId: PLACER,
     });
   });
 
@@ -745,7 +749,7 @@ describe("a placement counts toward the image's Buzz counter", () => {
     await actOnStickerPlacement({ placementId: PLACEMENT, action: 'approve', userId: OWNER });
 
     expect(updateEntityMetricDetached).toHaveBeenCalledWith(
-      expect.objectContaining({ entityId: IMAGE, amount: PRICE })
+      expect.objectContaining({ entityId: IMAGE, amount: PRICE, userId: PLACER })
     );
   });
 
@@ -772,6 +776,7 @@ describe('the owner cannot remove a sticker for a week after approving it', () =
     placementFindUnique.mockResolvedValue({
       id: PLACEMENT,
       ownerId: OWNER,
+      placerId: PLACER,
       targetId: IMAGE,
       amount: PRICE,
       status: 'approved',
@@ -856,6 +861,7 @@ describe('the note on a placement', () => {
     placementFindUnique.mockResolvedValue({
       id: PLACEMENT,
       ownerId: OWNER,
+      placerId: PLACER,
       targetId: IMAGE,
       amount: PRICE,
       status: 'pending',
@@ -924,6 +930,7 @@ describe('the note on a placement', () => {
     placementFindUnique.mockResolvedValue({
       id: PLACEMENT,
       ownerId: OWNER,
+      placerId: PLACER,
       targetId: IMAGE,
       amount: PRICE,
       status: 'pending',

--- a/src/server/services/__tests__/sticker-placement.service.test.ts
+++ b/src/server/services/__tests__/sticker-placement.service.test.ts
@@ -97,6 +97,7 @@ vi.mock('~/server/utils/metric-helpers', async (importOriginal) => ({
 
 const {
   actOnStickerPlacement,
+  setStickerCommentHidden,
   createStickerPlacement,
   getStickerPlacements,
   getPlacementSettlementStates,
@@ -137,6 +138,10 @@ beforeEach(() => {
   resolvePlacementSpaceFor.mockResolvedValue({ ...OPEN_SPACE });
   placementCount.mockResolvedValue(0);
   placementUpdateMany.mockResolvedValue({ count: 1 });
+  placementUpdate.mockImplementation(async () => {
+    calls.push('hideComment');
+    return {};
+  });
   holdPlacementEscrow.mockImplementation(async () => {
     calls.push('hold');
     return { fee: 210, principal: 490 };
@@ -903,6 +908,68 @@ describe('the note on a placement', () => {
     // The rest of the payload survives: refusing a note must not be a way to
     // move the sticker it was attached to.
     expect(write.data.data).toMatchObject({ cosmeticId: COSMETIC, x: 0.5, scale: 0.2 });
+    // "Before it goes live" is the property the name claims, and it is the one
+    // an assertion about the payload alone cannot see. Move the hide after the
+    // settle and only this line fails.
+    expect(calls).toEqual(['hideComment', 'settle:approve']);
+  });
+
+  /**
+   * The owner can refuse a note from the hover card while the placement is
+   * still pending. A plain Approve must leave that decision alone — treating
+   * "no opinion" as "show it" publishes text the owner explicitly refused, and
+   * publishing is the direction that cannot be taken back.
+   */
+  it('is left alone by a plain approve, rather than being un-hidden', async () => {
+    placementFindUnique.mockResolvedValue({
+      id: PLACEMENT,
+      ownerId: OWNER,
+      targetId: IMAGE,
+      amount: PRICE,
+      status: 'pending',
+      surface: 'sticker',
+      data: {
+        cosmeticId: COSMETIC,
+        x: 0.5,
+        y: 0.5,
+        scale: 0.2,
+        rotation: 0,
+        comment: 'nice hat',
+        commentHidden: true,
+      },
+      createdAt: new Date(0),
+      resolvedAt: null,
+    });
+
+    await actOnStickerPlacement({ placementId: PLACEMENT, action: 'approve', userId: OWNER });
+
+    expect(placementUpdate).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The only thing stopping a stranger flipping the flag on someone else's
+   * placement. Delete the ownership check and this is what fails.
+   */
+  it('cannot be hidden by someone who does not own the content', async () => {
+    withComment('nice hat');
+
+    await expect(
+      setStickerCommentHidden({ placementId: PLACEMENT, hidden: true, userId: STRANGER })
+    ).rejects.toThrow(/not on your content/);
+    expect(placementUpdate).not.toHaveBeenCalled();
+  });
+
+  it('can be hidden by a moderator', async () => {
+    withComment('nice hat');
+
+    await setStickerCommentHidden({
+      placementId: PLACEMENT,
+      hidden: true,
+      userId: STRANGER,
+      isModerator: true,
+    });
+
+    expect(placementUpdate).toHaveBeenCalled();
   });
 
   /**
@@ -947,8 +1014,25 @@ describe('the note on a placement', () => {
       });
 
       expect(detail.comment).toBeNull();
-      // Still stated, so the placer is never told their note is live when it is
-      // not — and so the owner's control knows which way it points.
+      // Not merely textless. Saying a note was refused tells a stranger one
+      // existed and how the owner judged it — the fact withholding the text was
+      // protecting.
+      expect(detail.commentHidden).toBe(false);
+    });
+
+    it('tells the placer their note is not live, so they are not left guessing', async () => {
+      givenHidden();
+
+      const detail = await getStickerPlacementDetail({ placementId: PLACEMENT, viewerId: PLACER });
+
+      expect(detail.commentHidden).toBe(true);
+    });
+
+    it('tells the owner, whose control it labels', async () => {
+      givenHidden();
+
+      const detail = await getStickerPlacementDetail({ placementId: PLACEMENT, viewerId: OWNER });
+
       expect(detail.commentHidden).toBe(true);
     });
 
@@ -970,6 +1054,69 @@ describe('the note on a placement', () => {
       });
 
       expect(detail.comment).toBe('nice hat');
+    });
+  });
+
+  /**
+   * `getStickerPlacements` is a public procedure that runs for every image on a
+   * feed page. Stripping the text out of it is the entire control keeping notes
+   * — hidden ones above all — from being serialised to anonymous viewers, and
+   * the whole rest of this file stays green if that strip is removed.
+   */
+  describe('is never carried by the feed listing', () => {
+    const givenListed = (data: Record<string, unknown>) =>
+      placementFindMany.mockResolvedValueOnce([
+        {
+          id: PLACEMENT,
+          targetId: IMAGE,
+          placerId: PLACER,
+          ownerId: OWNER,
+          status: 'approved',
+          amount: PRICE,
+          data: { cosmeticId: COSMETIC, x: 0.5, y: 0.5, scale: 0.2, rotation: 0, ...data },
+        },
+      ]);
+
+    it('withholds the text even from the placer, who is allowed to read it', async () => {
+      givenListed({ comment: 'nice hat' });
+
+      const [placed] = await getStickerPlacements({ imageIds: [IMAGE], viewerId: PLACER });
+
+      expect(placed.data.comment).toBeUndefined();
+      // The flag has to travel, because the sticker needs a marker before
+      // anyone hovers it — but the flag is not the text.
+      expect(placed.hasComment).toBe(true);
+    });
+
+    it('does not even admit a hidden note exists, to a stranger', async () => {
+      givenListed({ comment: 'nice hat', commentHidden: true });
+
+      const [placed] = await getStickerPlacements({ imageIds: [IMAGE], viewerId: STRANGER });
+
+      expect(placed.data.comment).toBeUndefined();
+      expect(placed.data.commentHidden).toBeUndefined();
+      expect(placed.hasComment).toBe(false);
+    });
+
+    it('still marks a hidden note for the owner, who can act on it', async () => {
+      givenListed({ comment: 'nice hat', commentHidden: true });
+
+      const [placed] = await getStickerPlacements({ imageIds: [IMAGE], viewerId: OWNER });
+
+      expect(placed.hasComment).toBe(true);
+    });
+
+    /**
+     * `isStickerPlacementData` validates the geometry and stops there, which is
+     * right — a malformed note should not stop the sticker drawing. So the read
+     * is where the note has to prove it is a string.
+     */
+    it('treats a non-string note on the row as no note at all', async () => {
+      givenListed({ comment: 42 });
+
+      const [placed] = await getStickerPlacements({ imageIds: [IMAGE], viewerId: PLACER });
+
+      expect(placed.hasComment).toBe(false);
     });
   });
 

--- a/src/server/services/placement-metrics.service.ts
+++ b/src/server/services/placement-metrics.service.ts
@@ -16,12 +16,13 @@ import type { PlacementSurface } from '~/shared/utils/placement';
  * number would then mean something different depending on which surface you
  * asked — the one property a single counter cannot afford to lose.
  *
- * **Accepted placements only** (Justin, 2026-08-12). A declined placement pays
- * the owner a non-refundable fee and still counts nothing, which is deliberate
- * and is the one place this number is not "Buzz the creator received": counting
- * declines would grow the counter fastest for a creator who refuses everything.
- * What it means instead is *what people paid to be on this image*, which is also
- * what makes it legible next to the content it labels.
+ * **Accepted placements only** (Justin, 2026-08-12). A decline counts nothing
+ * whatever it pays: most leave a non-refundable fee with the owner, some waive
+ * it entirely, and neither moves this number. That is the one place the counter
+ * is not "Buzz the creator received", and it is deliberate — counting declines
+ * would grow it fastest for a creator who refuses everything. What it means
+ * instead is *what people paid to be on this image*, which is also what makes
+ * it legible next to the content it labels.
  *
  * **Never reversed.** Every path that takes a live placement down — owner
  * removal past its lock, a moderator takedown, a cosmetic takedown — moves no

--- a/src/server/services/placement-metrics.service.ts
+++ b/src/server/services/placement-metrics.service.ts
@@ -61,11 +61,24 @@ export async function recordPlacementTip({
   surface,
   imageId,
   amount,
+  placerId,
 }: {
   /** For the log only — the counter does not distinguish them. */
   surface: PlacementSurface;
   imageId: number;
   amount: number;
+  /**
+   * Who paid, attributed the way a tip attributes its tipper.
+   *
+   * Not cosmetic: `userId` is part of the key the metric pipeline dedupes on
+   * — `(entityType, entityId, metricType, userId, createdAt)`, with no
+   * `metricValue` in it — so two placements landing on the same image, under
+   * the same attribution, in the same millisecond would replace one another
+   * and the second payment would vanish from the counter. A request-less
+   * `Tracker` attributes everything to 0, which is exactly the collision this
+   * avoids; a bulk approval loop is the shape that would hit it.
+   */
+  placerId: number;
 }) {
   if (amount <= 0) return;
 
@@ -75,6 +88,7 @@ export async function recordPlacementTip({
       entityId: imageId,
       metricType: 'Buzz',
       amount,
+      userId: placerId,
     });
   } catch (error) {
     await logToAxiom({

--- a/src/server/services/placement-metrics.service.ts
+++ b/src/server/services/placement-metrics.service.ts
@@ -43,6 +43,19 @@ import type { PlacementSurface } from '~/shared/utils/placement';
  * the module load, the tracker construction and the flag read sit outside that,
  * so the whole call is wrapped rather than trusting where that boundary happens
  * to fall today.
+ *
+ * **The consequence, stated rather than left implied: this counter is
+ * best-effort and permanently lossy.** The emission is a separate step after a
+ * committed settle, outside any transaction, and nothing reconciles it. A
+ * failure loses that placement's Buzz from the number for good, and a pod
+ * killed between the two loses it without even the log line above. There is no
+ * backfill, and a lost emit is indistinguishable from a placement that was
+ * never approved.
+ *
+ * That is the right trade — a counter must not be able to fail a payment — but
+ * it means the number is a display total and not a ledger. Anything that has to
+ * be *right* about money reads `PlacementTransaction`, which is the record that
+ * is written in the same transaction as the status.
  */
 export async function recordPlacementTip({
   surface,

--- a/src/server/services/placement-metrics.service.ts
+++ b/src/server/services/placement-metrics.service.ts
@@ -1,0 +1,77 @@
+import { logToAxiom } from '~/server/logging/client';
+import { updateEntityMetricDetached } from '~/server/utils/metric-helpers';
+import type { PlacementSurface } from '~/shared/utils/placement';
+
+/**
+ * A paid placement counts toward the Buzz counter on the content it sits on.
+ *
+ * Agreed by Justin, Ellie and Luis in the 2026-08-12 review for stickers — a
+ * placement reads as a pseudo-tip, and the counter people already look at should
+ * say so — and widened by Justin the same day to every surface. A sticker and a
+ * remix entry are the same act from the counter's point of view: someone paid to
+ * be on this image. The whole `amount` counts, not the owner's share of it;
+ * Justin's own example was two 200⚡ stickers taking a counter from 13 to 413.
+ *
+ * Shared rather than one copy per surface, because the two would drift and the
+ * number would then mean something different depending on which surface you
+ * asked — the one property a single counter cannot afford to lose.
+ *
+ * **Accepted placements only** (Justin, 2026-08-12). A declined placement pays
+ * the owner a non-refundable fee and still counts nothing, which is deliberate
+ * and is the one place this number is not "Buzz the creator received": counting
+ * declines would grow the counter fastest for a creator who refuses everything.
+ * What it means instead is *what people paid to be on this image*, which is also
+ * what makes it legible next to the content it labels.
+ *
+ * **Never reversed.** Every path that takes a live placement down — owner
+ * removal past its lock, a moderator takedown, a cosmetic takedown — moves no
+ * money back, so there is nothing to take off the counter; and a counter that
+ * fell would read as the creator losing Buzz they still hold.
+ *
+ * The same event the tip button emits (`Image`/`Buzz`), so this arrives through
+ * the metric pipeline the feed, the detail page and the search index already
+ * read, rather than as a second number each of them has to learn to add.
+ *
+ * Detached from any request context on purpose: approval happens from a review
+ * queue, from an auto-approving space and from a bulk action, and the counter
+ * has to move the same way in all three.
+ *
+ * **Nothing here may throw.** It runs after the settle has already claimed the
+ * transition and paid the owner, so a throw would report a live, paid placement
+ * as failed — and in a bulk path would put its id in `failed`, inviting the
+ * owner to action it again. `updateEntityMetric` catches its own emission, but
+ * the module load, the tracker construction and the flag read sit outside that,
+ * so the whole call is wrapped rather than trusting where that boundary happens
+ * to fall today.
+ */
+export async function recordPlacementTip({
+  surface,
+  imageId,
+  amount,
+}: {
+  /** For the log only — the counter does not distinguish them. */
+  surface: PlacementSurface;
+  imageId: number;
+  amount: number;
+}) {
+  if (amount <= 0) return;
+
+  try {
+    await updateEntityMetricDetached({
+      entityType: 'Image',
+      entityId: imageId,
+      metricType: 'Buzz',
+      amount,
+    });
+  } catch (error) {
+    await logToAxiom({
+      name: 'placement-metrics',
+      type: 'error',
+      message: 'could not count an approved placement toward the image buzz counter',
+      surface,
+      imageId,
+      amount,
+      error: (error as Error).message,
+    }).catch(() => null);
+  }
+}

--- a/src/server/services/remix-gallery.service.ts
+++ b/src/server/services/remix-gallery.service.ts
@@ -300,6 +300,7 @@ export async function actOnRemixGallerySubmission({
     select: {
       id: true,
       ownerId: true,
+      placerId: true,
       targetId: true,
       amount: true,
       status: true,
@@ -435,6 +436,7 @@ export async function actOnRemixGallerySubmission({
       surface: SURFACE,
       imageId: placement.targetId,
       amount: placement.amount,
+      placerId: placement.placerId,
     });
 
   return result;

--- a/src/server/services/remix-gallery.service.ts
+++ b/src/server/services/remix-gallery.service.ts
@@ -7,6 +7,7 @@ import { dbRead, dbWrite } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
 import { getAllImages } from '~/server/services/image.service';
 import { holdPlacementEscrow, settlePlacement } from '~/server/services/placement-escrow.service';
+import { recordPlacementTip } from '~/server/services/placement-metrics.service';
 import { assertCanPlace } from '~/server/services/placement-moderation.service';
 import { getPlacementConfig } from '~/server/services/placement.service';
 import { resolvePlacementSpaceFor } from '~/server/services/placement-space.service';
@@ -299,6 +300,8 @@ export async function actOnRemixGallerySubmission({
     select: {
       id: true,
       ownerId: true,
+      targetId: true,
+      amount: true,
       status: true,
       surface: true,
       targetId: true,
@@ -415,6 +418,18 @@ export async function actOnRemixGallerySubmission({
   // appeared to work and did not is what this cost us on chunk D.
   if (!result.settled)
     throw throwBadRequestError('remix gallery: that submission was already resolved elsewhere');
+
+  // A gallery entry is a paid placement on this image, so it counts toward the
+  // same Buzz counter a sticker does (Justin, 2026-08-12). Gated on `settled`
+  // rather than on the action asked for, so a double-submitted approve counts
+  // one payment once. A decline counts nothing even though its fee reaches the
+  // owner — see `recordPlacementTip` for why.
+  if (action === 'approve')
+    await recordPlacementTip({
+      surface: SURFACE,
+      imageId: placement.targetId,
+      amount: placement.amount,
+    });
 
   return result;
 }

--- a/src/server/services/remix-gallery.service.ts
+++ b/src/server/services/remix-gallery.service.ts
@@ -305,7 +305,6 @@ export async function actOnRemixGallerySubmission({
       amount: true,
       status: true,
       surface: true,
-      targetId: true,
       data: true,
       resolvedAt: true,
       createdAt: true,

--- a/src/server/services/remix-gallery.service.ts
+++ b/src/server/services/remix-gallery.service.ts
@@ -420,11 +420,17 @@ export async function actOnRemixGallerySubmission({
     throw throwBadRequestError('remix gallery: that submission was already resolved elsewhere');
 
   // A gallery entry is a paid placement on this image, so it counts toward the
-  // same Buzz counter a sticker does (Justin, 2026-08-12). Gated on `settled`
-  // rather than on the action asked for, so a double-submitted approve counts
-  // one payment once. A decline counts nothing even though its fee reaches the
-  // owner — see `recordPlacementTip` for why.
-  if (action === 'approve')
+  // same Buzz counter a sticker does (Justin, 2026-08-12). A decline counts
+  // nothing even though its fee reaches the owner — see `recordPlacementTip`.
+  //
+  // `result.settled` is re-checked even though the throw above already covers
+  // it, and not as belt and braces: it is the gate the sticker twin actually
+  // uses, so writing it here keeps the two surfaces the same shape. The throw
+  // is the kind of thing that gets softened into a returned value — the
+  // moderator removal path already made exactly that change — and whoever does
+  // that would otherwise be introducing a double count with nothing beside it
+  // to say so.
+  if (action === 'approve' && result.settled)
     await recordPlacementTip({
       surface: SURFACE,
       imageId: placement.targetId,

--- a/src/server/services/report.service.ts
+++ b/src/server/services/report.service.ts
@@ -99,22 +99,26 @@ const reportedPlacementFilter = ({
   if (typeof placementId !== 'number' || !Number.isFinite(placementId))
     throw throwBadRequestError('report: a sticker placement report must name a placement');
 
-  // A note is reported separately from the sticker it hangs off, and folding the
-  // two together would hide one behind the other: a moderator who cleared the
-  // artwork would never see that someone also complained about the text.
+  // A note is reported separately from the sticker it hangs off, and the
+  // discrimination has to run in BOTH directions. Matching on the placement
+  // alone for one of them is not a weaker filter, it is a fold: report the note
+  // on placement 5, then report the artwork on placement 5, and the second
+  // report is appended to the first as "also reported by" — its reason text
+  // discarded, and a moderator shown a complaint about a note while the
+  // complaint about the artwork is invisible.
   //
-  // Only ever added for `comment`, never for `sticker`. Reports filed before
-  // this field existed carry no `target` key at all, and `equals: 'sticker'`
-  // does not match a missing one — so asserting the default here would stop
-  // every new sticker report deduping against the history it should dedupe
-  // against, which is the same fold this predicate exists to prevent.
-  const target = (details as { target?: string } | undefined)?.target;
-  if (target !== 'comment') return { details: { path: ['placementId'], equals: placementId } };
+  // The cost is that reports filed before this field existed carry no `target`
+  // key, and `equals: 'sticker'` does not match a missing one, so a new sticker
+  // report will not dedupe against that history. That is a duplicate in the
+  // queue, on a fixed and shrinking set of rows — strictly better than dropping
+  // a complaint, which is what the asymmetric version did.
+  const target =
+    (details as { target?: string } | undefined)?.target === 'comment' ? 'comment' : 'sticker';
 
   return {
     AND: [
       { details: { path: ['placementId'], equals: placementId } },
-      { details: { path: ['target'], equals: 'comment' } },
+      { details: { path: ['target'], equals: target } },
     ],
   };
 };

--- a/src/server/services/report.service.ts
+++ b/src/server/services/report.service.ts
@@ -99,7 +99,24 @@ const reportedPlacementFilter = ({
   if (typeof placementId !== 'number' || !Number.isFinite(placementId))
     throw throwBadRequestError('report: a sticker placement report must name a placement');
 
-  return { details: { path: ['placementId'], equals: placementId } };
+  // A note is reported separately from the sticker it hangs off, and folding the
+  // two together would hide one behind the other: a moderator who cleared the
+  // artwork would never see that someone also complained about the text.
+  //
+  // Only ever added for `comment`, never for `sticker`. Reports filed before
+  // this field existed carry no `target` key at all, and `equals: 'sticker'`
+  // does not match a missing one — so asserting the default here would stop
+  // every new sticker report deduping against the history it should dedupe
+  // against, which is the same fold this predicate exists to prevent.
+  const target = (details as { target?: string } | undefined)?.target;
+  if (target !== 'comment') return { details: { path: ['placementId'], equals: placementId } };
+
+  return {
+    AND: [
+      { details: { path: ['placementId'], equals: placementId } },
+      { details: { path: ['target'], equals: 'comment' } },
+    ],
+  };
 };
 
 const validateReportCreation = async ({

--- a/src/server/services/sticker-placement.service.ts
+++ b/src/server/services/sticker-placement.service.ts
@@ -446,11 +446,13 @@ export async function getStickerPlacementDetail({
     /**
      * When the owner may take this off, so the button can be disabled with a
      * date rather than refusing after the click. `null` once the lock has run
-     * out, and for anything not live. The server refuses independently — this
+     * out, for anything not live, and for anyone but the owner — nobody else has
+     * a control it explains, and it is the only field here that would tell a
+     * stranger when the owner approved. The server refuses independently: this
      * is what the UI says, not what decides it.
      */
     removableAt:
-      placement.status === 'approved'
+      placement.status === 'approved' && viewerId === placement.ownerId
         ? nextRemovableAt(placement.resolvedAt ?? placement.createdAt)
         : null,
     sticker: cosmetic
@@ -680,7 +682,11 @@ export async function actOnStickerPlacement({
 
   if (action === 'remove') return removeApprovedSticker({ placement, userId, isModerator });
 
-  if (action === 'approve' && hideComment) await hideStickerComment(placement, true);
+  // Written with the approve's actual intent, not only when it is `true`. An
+  // approve that failed after hiding would otherwise leave the flag set, and a
+  // second, plain approve would silently keep refusing a note the owner just
+  // chose to accept.
+  if (action === 'approve') await hideStickerComment(placement, hideComment);
 
   const { settled } = await settlePlacement({
     placementId,

--- a/src/server/services/sticker-placement.service.ts
+++ b/src/server/services/sticker-placement.service.ts
@@ -265,7 +265,8 @@ export async function createStickerPlacement({
     // line: `settlePlacement` returns `settled: false` when something else got
     // there first, and counting then would add the placement's Buzz to the image
     // twice for one payment.
-    if (settled) await recordPlacementTip({ surface: SURFACE, imageId, amount: space.price });
+    if (settled)
+      await recordPlacementTip({ surface: SURFACE, imageId, amount: space.price, placerId });
   }
 
   return { placementId: placement.id, status: space.mode === 'auto' ? 'approved' : 'pending' };
@@ -649,6 +650,7 @@ export async function actOnStickerPlacement({
     select: {
       id: true,
       ownerId: true,
+      placerId: true,
       targetId: true,
       amount: true,
       status: true,
@@ -690,6 +692,7 @@ export async function actOnStickerPlacement({
       surface: SURFACE,
       imageId: placement.targetId,
       amount: placement.amount,
+      placerId: placement.placerId,
     });
 
   return { settled };

--- a/src/server/services/sticker-placement.service.ts
+++ b/src/server/services/sticker-placement.service.ts
@@ -14,6 +14,7 @@ import {
   throwBadRequestError,
   throwNotFoundError,
 } from '~/server/utils/errorHandling';
+import { updateEntityMetricDetached } from '~/server/utils/metric-helpers';
 import type { PlacementStatus } from '~/shared/utils/placement';
 import type {
   PlacementSettlementState,
@@ -21,8 +22,10 @@ import type {
 } from '~/shared/utils/sticker-placement';
 import {
   isStickerPlacementData,
+  normalizeStickerComment,
   normalizeStickerPlacement,
   stickerMaxScale,
+  stickerRemovableAt,
 } from '~/shared/utils/sticker-placement';
 
 const SURFACE = 'sticker' as const;
@@ -36,6 +39,59 @@ const TARGET_TYPE = 'image' as const;
  * through. Their remedy for the rest is block, which declines all of them.
  */
 const MAX_PENDING_PER_OWNER = 10;
+
+/**
+ * A sticker counts toward the image's Buzz counter, because it is a tip.
+ *
+ * Agreed by Justin, Ellie and Luis in the 2026-08-12 review: a placement reads as
+ * a pseudo-tip, and the counter people already look at should say so. The whole
+ * `amount` counts, not the owner's share of it — Justin's own example was two
+ * 200⚡ stickers taking a counter from 13 to 413.
+ *
+ * **Emitted only on approval, and never reversed.** The counter measures Buzz
+ * that reached the owner, and every path that takes a live sticker down —
+ * owner removal past the lock, a moderator takedown, a cosmetic takedown —
+ * deliberately moves no money back. A placement that is declined or expires is
+ * refunded and never counted here, because it never approved.
+ *
+ * The same event the tip button emits (`Image`/`Buzz`), so this arrives through
+ * the metric pipeline everything else already reads rather than as a second
+ * number the feed, the detail page and the search index each have to learn to
+ * add. Failures are swallowed inside `updateEntityMetric`: a settlement that
+ * moved real Buzz must not be reported as failed because a counter did not move.
+ *
+ * Detached from any request context on purpose — approval happens from the
+ * review queue, from an auto-approving space and from a bulk action, and the
+ * counter has to move the same way in all three.
+ */
+async function recordStickerTip({ imageId, amount }: { imageId: number; amount: number }) {
+  if (amount <= 0) return;
+
+  await updateEntityMetricDetached({
+    entityType: 'Image',
+    entityId: imageId,
+    metricType: 'Buzz',
+    amount,
+  });
+}
+
+/**
+ * The note on a placement, if this viewer may read it.
+ *
+ * A hidden note stays readable to the three parties who have a reason to see it
+ * — the owner who hid it, the placer who wrote and paid for it, and a moderator
+ * acting on a report about it — and to nobody else. Hiding is the owner's
+ * judgement about their own image, not a deletion: the text is what a report is
+ * about, so a moderator opening one must be able to see what was said.
+ */
+const visibleStickerComment = (data: StickerPlacementData, isParty: boolean) =>
+  data.comment && (!data.commentHidden || isParty) ? data.comment : undefined;
+
+/** The lock's expiry, or `null` once it has already passed. */
+const nextRemovableAt = (approvedAt: Date) => {
+  const removableAt = stickerRemovableAt(approvedAt);
+  return removableAt > new Date() ? removableAt : null;
+};
 
 /**
  * The sticker the placer chose, from the primary, with ownership resolved.
@@ -78,6 +134,17 @@ export type CreateStickerPlacement = {
   /** Moderators may exceed a creator's size limit. Justin's call. */
   isModerator?: boolean;
 };
+
+/**
+ * A placer's optional note travels with the placement it belongs to.
+ *
+ * Not a `CommentV2` thread: this is one immutable line bought with the
+ * placement, and giving it the comment system's identity would give it that
+ * system's edit, reply and notification behaviour — none of which anyone asked
+ * for, all of which would then need their own answer to "the owner accepted the
+ * sticker and refused the note".
+ */
+const commentFrom = (data: { comment?: string | null }) => normalizeStickerComment(data.comment);
 
 /**
  * Places a sticker on an image, charging a use and the owner's price.
@@ -161,6 +228,8 @@ export async function createStickerPlacement({
   const sticker = await loadPlaceableSticker({ cosmeticId: data.cosmeticId, placerId });
   await assertHasUse({ userId: placerId, cosmeticId: sticker.id });
 
+  const comment = commentFrom(data);
+
   const placement = await dbWrite.placement.create({
     data: {
       surface: SURFACE,
@@ -177,6 +246,9 @@ export async function createStickerPlacement({
       data: {
         cosmeticId: sticker.id,
         ...normalizeStickerPlacement(data),
+        // Omitted rather than stored as an empty string, so "left the field
+        // blank" and "wrote nothing but spaces" are the same row.
+        ...(comment ? { comment } : {}),
       },
     },
     select: { id: true },
@@ -209,8 +281,18 @@ export async function createStickerPlacement({
 
   // `auto` settles immediately, which is what makes the placement live. `review`
   // leaves it pending, visible only to its placer, until the owner acts.
-  if (space.mode === 'auto')
-    await settlePlacement({ placementId: placement.id, action: 'approve', actorId: space.ownerId });
+  if (space.mode === 'auto') {
+    const { settled } = await settlePlacement({
+      placementId: placement.id,
+      action: 'approve',
+      actorId: space.ownerId,
+    });
+    // Gated on the settle actually claiming the transition, not on reaching this
+    // line: `settlePlacement` returns `settled: false` when something else got
+    // there first, and counting then would add the placement's Buzz to the image
+    // twice for one payment.
+    if (settled) await recordStickerTip({ imageId, amount: space.price });
+  }
 
   return { placementId: placement.id, status: space.mode === 'auto' ? 'approved' : 'pending' };
 }
@@ -255,6 +337,8 @@ export type StickerPlacementView = {
   placedAt: Date;
   /** True only for the placer's own placement awaiting the owner. */
   isPending: boolean;
+  /** Whether this placement carries a note the viewer may read. */
+  hasComment: boolean;
 };
 
 /**
@@ -312,8 +396,11 @@ export async function getStickerPlacementDetail({
     select: {
       id: true,
       createdAt: true,
+      resolvedAt: true,
       status: true,
       data: true,
+      ownerId: true,
+      placerId: true,
       placer: { select: userWithCosmeticsSelect },
     },
   });
@@ -322,9 +409,14 @@ export async function getStickerPlacementDetail({
 
   // Read off the placement's own payload rather than joined in the query above:
   // `data` is JSON, so the cosmetic id is not a relation Prisma can follow.
-  const cosmeticId = isStickerPlacementData(placement.data)
-    ? (placement.data as StickerPlacementData).cosmeticId
+  const data = isStickerPlacementData(placement.data)
+    ? (placement.data as StickerPlacementData)
     : null;
+  const cosmeticId = data?.cosmeticId ?? null;
+
+  const isParty =
+    isModerator ||
+    (!!viewerId && (viewerId === placement.ownerId || viewerId === placement.placerId));
 
   const cosmetic = cosmeticId
     ? await dbRead.cosmetic.findUnique({
@@ -341,6 +433,26 @@ export async function getStickerPlacementDetail({
     placedAt: placement.createdAt,
     status: placement.status as PlacementStatus,
     placer: placement.placer,
+    comment: data ? visibleStickerComment(data, isParty) ?? null : null,
+    /**
+     * Whether this viewer owns the content, so the card can offer the controls
+     * that belong to the owner. Emitted as the answer rather than as `ownerId`
+     * for the caller to compare: the id is not otherwise on this card, and a
+     * page that has it will eventually compare it somewhere the server does not.
+     */
+    viewerIsOwner: !!viewerId && viewerId === placement.ownerId,
+    /** Whether the note is currently refused, so the owner's control can say so. */
+    commentHidden: !!data?.commentHidden,
+    /**
+     * When the owner may take this off, so the button can be disabled with a
+     * date rather than refusing after the click. `null` once the lock has run
+     * out, and for anything not live. The server refuses independently — this
+     * is what the UI says, not what decides it.
+     */
+    removableAt:
+      placement.status === 'approved'
+        ? nextRemovableAt(placement.resolvedAt ?? placement.createdAt)
+        : null,
     sticker: cosmetic
       ? {
           id: cosmetic.id,
@@ -409,17 +521,27 @@ export async function getStickerPlacements({
 
   return rows
     .filter((row) => isStickerPlacementData(row.data))
-    .map((row) => ({
-      id: row.id,
-      imageId: row.targetId,
-      placerId: row.placerId,
-      ownerId: row.ownerId,
-      status: row.status as PlacementStatus,
-      amount: row.amount,
-      placedAt: row.createdAt,
-      data: row.data as StickerPlacementData,
-      isPending: row.status === 'pending',
-    }));
+    .map((row) => {
+      const data = row.data as StickerPlacementData;
+      const isParty = !!viewerId && (viewerId === row.ownerId || viewerId === row.placerId);
+
+      return {
+        id: row.id,
+        imageId: row.targetId,
+        placerId: row.placerId,
+        ownerId: row.ownerId,
+        status: row.status as PlacementStatus,
+        amount: row.amount,
+        placedAt: row.createdAt,
+        // The note's text is deliberately NOT in the listing, which runs for
+        // every image on a feed page — only whether there is one, so an overlay
+        // can mark the sticker without the page carrying everyone's comments.
+        // The text comes with the hover, from `getStickerPlacementDetail`.
+        data: { ...data, comment: undefined, commentHidden: undefined },
+        isPending: row.status === 'pending',
+        hasComment: !!visibleStickerComment(data, isParty),
+      };
+    });
 }
 
 /** Approved placements per image, for the reaction-bar count. */
@@ -509,25 +631,41 @@ type OwnerAction = 'approve' | 'decline' | 'remove';
 /**
  * The owner acting on a placement on their own content.
  *
- * `remove` maps to `removeByOwner`, which refunds the placer in full and pays
- * the owner nothing. That asymmetry with decline is deliberate: a fee for
- * after-the-fact removal would pay creators to accept placements, bank the
- * money, and sweep them off later.
+ * `approve` and `decline` settle a pending placement. `remove` is a different
+ * operation on a different state — a live placement whose money is already
+ * paid — and goes through `removeApprovedSticker`, which explains why.
  */
 export async function actOnStickerPlacement({
   placementId,
   action,
   userId,
   isModerator = false,
+  hideComment = false,
 }: {
   placementId: number;
   action: OwnerAction;
   userId: number;
   isModerator?: boolean;
+  /**
+   * Partial approval: take the sticker, refuse the note (Justin's call in the
+   * 2026-08-12 review). Carried on the approve rather than left to a second
+   * call, so an owner who refuses a note never has a moment where it is live.
+   */
+  hideComment?: boolean;
 }) {
   const placement = await dbWrite.placement.findUnique({
     where: { id: placementId },
-    select: { id: true, ownerId: true, status: true, surface: true },
+    select: {
+      id: true,
+      ownerId: true,
+      targetId: true,
+      amount: true,
+      status: true,
+      surface: true,
+      data: true,
+      createdAt: true,
+      resolvedAt: true,
+    },
   });
 
   if (!placement || placement.surface !== SURFACE)
@@ -540,10 +678,147 @@ export async function actOnStickerPlacement({
   if (action !== 'remove' && placement.status !== 'pending')
     throw throwBadRequestError('placement: that placement has already been actioned');
 
-  const settleAction =
-    action === 'approve' ? 'approve' : action === 'decline' ? 'decline' : 'removeByOwner';
+  if (action === 'remove') return removeApprovedSticker({ placement, userId, isModerator });
 
-  return settlePlacement({ placementId, action: settleAction, actorId: userId });
+  if (action === 'approve' && hideComment) await hideStickerComment(placement, true);
+
+  const { settled } = await settlePlacement({
+    placementId,
+    action: action === 'approve' ? 'approve' : 'decline',
+    actorId: userId,
+  });
+
+  // Gated on the settle claiming the transition rather than on the action asked
+  // for: two owners' tabs both pressing approve would otherwise count the same
+  // payment on the image twice.
+  if (action === 'approve' && settled)
+    await recordStickerTip({ imageId: placement.targetId, amount: placement.amount });
+
+  return { settled };
+}
+
+type ActionablePlacement = {
+  id: number;
+  ownerId: number;
+  status: string;
+  data: unknown;
+  createdAt: Date;
+  resolvedAt: Date | null;
+};
+
+/**
+ * The owner taking a live sticker off, once it has been up for its week.
+ *
+ * **Not `settlePlacement`, which cannot do this.** That claims its transition
+ * with `WHERE status = 'pending'`, so an approved row matches nothing: the
+ * removal reported success, moved no money and left the sticker exactly where it
+ * was. The direct write is the same one `removePlacementByModerator` and the
+ * remix gallery already use for a live row, and reusing their shape is what
+ * stops a third meaning of "removed" existing.
+ *
+ * No money moves, which is the whole reason for the lock. Approval already paid
+ * the owner, and a removal that refunded would let them bank the Buzz and wipe
+ * the sticker before anyone saw it — indistinguishable from an honest removal,
+ * and it costs the placer everything they paid. So the sticker stays up for a
+ * week and then comes off for free, rather than coming off at once for a refund
+ * the owner controls the timing of.
+ */
+async function removeApprovedSticker({
+  placement,
+  userId,
+  isModerator,
+}: {
+  placement: ActionablePlacement;
+  userId: number;
+  isModerator: boolean;
+}) {
+  // A moderator acting on someone else's content is a takedown, not an owner
+  // decision. An owner who also happens to be a moderator is still the owner —
+  // the exemption follows the role being exercised, not the account.
+  const isModeratorTakedown = isModerator && placement.ownerId !== userId;
+
+  if (!isModeratorTakedown) {
+    // Falls back to `createdAt` rather than skipping the check when `resolvedAt`
+    // is absent. Gating on the column being set fails OPEN: a hand-seeded row,
+    // or anything predating the approval path writing it, could be removed
+    // immediately — the exact case the lock exists to prevent. `createdAt` is
+    // never null, so there is always a time to measure from.
+    const removableAt = stickerRemovableAt(placement.resolvedAt ?? placement.createdAt);
+    if (removableAt > new Date())
+      throw throwBadRequestError(
+        `placement: this sticker can be removed from ${removableAt.toISOString()}. Someone paid to place it, so it stays up for a week after you accept it.`
+      );
+  }
+
+  const { count } = await dbWrite.placement.updateMany({
+    where: { id: placement.id, status: 'approved' },
+    data: {
+      status: 'removed',
+      removedBy: isModeratorTakedown ? 'moderator' : 'owner',
+      // Not `resolvedAt`/`resolvedById`: those record who approved it, and
+      // overwriting them here would destroy the approval trail.
+      takenDownAt: new Date(),
+      takenDownById: userId,
+    },
+  });
+
+  return { settled: count > 0 };
+}
+
+/**
+ * Writes the note's hidden flag, preserving the rest of the payload.
+ *
+ * Read-modify-write rather than a JSON path update because `data` is the
+ * surface's whole payload — position, scale, rotation, the cosmetic id — and a
+ * client-supplied replacement would let an owner move someone's sticker while
+ * refusing their note.
+ */
+async function hideStickerComment(placement: { id: number; data: unknown }, hidden: boolean) {
+  if (!isStickerPlacementData(placement.data)) return;
+  const data = placement.data as StickerPlacementData;
+  // Nothing to hide and nothing to say about it. Writing the flag anyway would
+  // put `commentHidden` on placements that never carried a note, which reads as
+  // a refusal that never happened.
+  if (!data.comment) return;
+
+  await dbWrite.placement.update({
+    where: { id: placement.id },
+    data: { data: { ...data, commentHidden: hidden } },
+  });
+}
+
+/**
+ * The owner changing their mind about a note after the fact, either way.
+ *
+ * Unlocked, unlike removing the sticker: the week protects what the placer paid
+ * for, which is the placement. The note came with it and is the owner's to
+ * refuse at any time — and being able to put one back is what makes hiding a
+ * safe first move on something ambiguous.
+ */
+export async function setStickerCommentHidden({
+  placementId,
+  hidden,
+  userId,
+  isModerator = false,
+}: {
+  placementId: number;
+  hidden: boolean;
+  userId: number;
+  isModerator?: boolean;
+}) {
+  const placement = await dbWrite.placement.findUnique({
+    where: { id: placementId },
+    select: { id: true, ownerId: true, surface: true, data: true },
+  });
+
+  if (!placement || placement.surface !== SURFACE)
+    throw throwBadRequestError('placement: that placement no longer exists');
+  if (placement.ownerId !== userId && !isModerator)
+    throw throwAuthorizationError('placement: that placement is not on your content');
+
+  await hideStickerComment(placement, hidden);
+
+  return { hidden };
 }
 
 /**
@@ -608,18 +883,26 @@ export async function actOnStickerPlacements({
   action,
   userId,
   isModerator = false,
+  hideComment = false,
 }: {
   placementIds: number[];
   action: OwnerAction;
   userId: number;
   isModerator?: boolean;
+  hideComment?: boolean;
 }) {
   const failed: number[] = [];
   let settled = 0;
 
   for (const placementId of placementIds) {
     try {
-      const result = await actOnStickerPlacement({ placementId, action, userId, isModerator });
+      const result = await actOnStickerPlacement({
+        placementId,
+        action,
+        userId,
+        isModerator,
+        hideComment,
+      });
       if (result.settled) settled++;
     } catch (error) {
       failed.push(placementId);

--- a/src/server/services/sticker-placement.service.ts
+++ b/src/server/services/sticker-placement.service.ts
@@ -57,22 +57,40 @@ const MAX_PENDING_PER_OWNER = 10;
  * The same event the tip button emits (`Image`/`Buzz`), so this arrives through
  * the metric pipeline everything else already reads rather than as a second
  * number the feed, the detail page and the search index each have to learn to
- * add. Failures are swallowed inside `updateEntityMetric`: a settlement that
- * moved real Buzz must not be reported as failed because a counter did not move.
+ * add.
  *
  * Detached from any request context on purpose — approval happens from the
  * review queue, from an auto-approving space and from a bulk action, and the
  * counter has to move the same way in all three.
+ *
+ * **Nothing here may throw.** It runs after the settle has already claimed the
+ * transition and paid the owner, so a throw would report a live, paid placement
+ * as failed — and in the bulk path would put its id in `failed`, inviting the
+ * owner to action it again. `updateEntityMetric` catches its own emission, but
+ * the module load, the tracker construction and the flag read sit outside that,
+ * so the whole call is wrapped rather than trusting where the boundary happens
+ * to fall today.
  */
 async function recordStickerTip({ imageId, amount }: { imageId: number; amount: number }) {
   if (amount <= 0) return;
 
-  await updateEntityMetricDetached({
-    entityType: 'Image',
-    entityId: imageId,
-    metricType: 'Buzz',
-    amount,
-  });
+  try {
+    await updateEntityMetricDetached({
+      entityType: 'Image',
+      entityId: imageId,
+      metricType: 'Buzz',
+      amount,
+    });
+  } catch (error) {
+    await logToAxiom({
+      name: 'sticker-placement',
+      type: 'error',
+      message: 'could not count an approved placement toward the image buzz counter',
+      imageId,
+      amount,
+      error: (error as Error).message,
+    }).catch(() => null);
+  }
 }
 
 /**
@@ -83,9 +101,18 @@ async function recordStickerTip({ imageId, amount }: { imageId: number; amount: 
  * acting on a report about it — and to nobody else. Hiding is the owner's
  * judgement about their own image, not a deletion: the text is what a report is
  * about, so a moderator opening one must be able to see what was said.
+ *
+ * Both fields are re-checked here rather than trusted from the payload.
+ * `isStickerPlacementData` validates the geometry and stops there, which is
+ * right — a row with a malformed note should still draw its sticker — so this
+ * is the boundary where the note has to prove it is a string. `commentHidden`
+ * is compared against `true` for the same reason: a hand-edited `"false"` is
+ * truthy, and would hide a note nobody refused.
  */
-const visibleStickerComment = (data: StickerPlacementData, isParty: boolean) =>
-  data.comment && (!data.commentHidden || isParty) ? data.comment : undefined;
+const visibleStickerComment = (data: StickerPlacementData, isParty: boolean) => {
+  if (typeof data.comment !== 'string' || !data.comment) return undefined;
+  return data.commentHidden === true && !isParty ? undefined : data.comment;
+};
 
 /** The lock's expiry, or `null` once it has already passed. */
 const nextRemovableAt = (approvedAt: Date) => {
@@ -441,8 +468,16 @@ export async function getStickerPlacementDetail({
      * page that has it will eventually compare it somewhere the server does not.
      */
     viewerIsOwner: !!viewerId && viewerId === placement.ownerId,
-    /** Whether the note is currently refused, so the owner's control can say so. */
-    commentHidden: !!data?.commentHidden,
+    /**
+     * Whether the note is currently refused — for the owner whose control it
+     * labels and the placer who would otherwise think their note was live.
+     *
+     * `false` for everyone else rather than the truth. A stranger has nothing to
+     * do with the answer, and a hover card that draws no text but says a note
+     * was refused tells them a note existed and how the owner judged it, which
+     * is the fact withholding the text was protecting.
+     */
+    commentHidden: isParty && !!data?.commentHidden,
     /**
      * When the owner may take this off, so the button can be disabled with a
      * date rather than refusing after the click. `null` once the lock has run
@@ -642,7 +677,7 @@ export async function actOnStickerPlacement({
   action,
   userId,
   isModerator = false,
-  hideComment = false,
+  hideComment,
 }: {
   placementId: number;
   action: OwnerAction;
@@ -652,6 +687,13 @@ export async function actOnStickerPlacement({
    * Partial approval: take the sticker, refuse the note (Justin's call in the
    * 2026-08-12 review). Carried on the approve rather than left to a second
    * call, so an owner who refuses a note never has a moment where it is live.
+   *
+   * **`undefined` means "don't touch it", and that is load-bearing.** An owner
+   * can already have hidden the note from the hover card while the placement
+   * sat pending; defaulting this to `false` would make the ordinary Approve
+   * button publish a note they had explicitly refused. Where the two readings
+   * disagree, the safe one is the note staying hidden — it is someone else's
+   * text on the owner's image, and the owner can put it back in one click.
    */
   hideComment?: boolean;
 }) {
@@ -682,11 +724,10 @@ export async function actOnStickerPlacement({
 
   if (action === 'remove') return removeApprovedSticker({ placement, userId, isModerator });
 
-  // Written with the approve's actual intent, not only when it is `true`. An
-  // approve that failed after hiding would otherwise leave the flag set, and a
-  // second, plain approve would silently keep refusing a note the owner just
-  // chose to accept.
-  if (action === 'approve') await hideStickerComment(placement, hideComment);
+  // Before the settle, so a refused note is never live for the window between
+  // the two writes.
+  if (action === 'approve' && hideComment !== undefined)
+    await hideStickerComment(placement, hideComment);
 
   const { settled } = await settlePlacement({
     placementId,
@@ -889,12 +930,13 @@ export async function actOnStickerPlacements({
   action,
   userId,
   isModerator = false,
-  hideComment = false,
+  hideComment,
 }: {
   placementIds: number[];
   action: OwnerAction;
   userId: number;
   isModerator?: boolean;
+  /** `undefined` leaves each note as it is — see `actOnStickerPlacement`. */
   hideComment?: boolean;
 }) {
   const failed: number[] = [];

--- a/src/server/services/sticker-placement.service.ts
+++ b/src/server/services/sticker-placement.service.ts
@@ -5,6 +5,7 @@ import {
   settlePlacement,
   MAX_LEG_ATTEMPTS,
 } from '~/server/services/placement-escrow.service';
+import { recordPlacementTip } from '~/server/services/placement-metrics.service';
 import { assertCanPlace } from '~/server/services/placement-moderation.service';
 import { resolvePlacementSpaceFor } from '~/server/services/placement-space.service';
 import { spendStickerUsesFor } from '~/server/services/sticker.service';
@@ -14,7 +15,6 @@ import {
   throwBadRequestError,
   throwNotFoundError,
 } from '~/server/utils/errorHandling';
-import { updateEntityMetricDetached } from '~/server/utils/metric-helpers';
 import type { PlacementStatus } from '~/shared/utils/placement';
 import type {
   PlacementSettlementState,
@@ -39,59 +39,6 @@ const TARGET_TYPE = 'image' as const;
  * through. Their remedy for the rest is block, which declines all of them.
  */
 const MAX_PENDING_PER_OWNER = 10;
-
-/**
- * A sticker counts toward the image's Buzz counter, because it is a tip.
- *
- * Agreed by Justin, Ellie and Luis in the 2026-08-12 review: a placement reads as
- * a pseudo-tip, and the counter people already look at should say so. The whole
- * `amount` counts, not the owner's share of it — Justin's own example was two
- * 200⚡ stickers taking a counter from 13 to 413.
- *
- * **Emitted only on approval, and never reversed.** The counter measures Buzz
- * that reached the owner, and every path that takes a live sticker down —
- * owner removal past the lock, a moderator takedown, a cosmetic takedown —
- * deliberately moves no money back. A placement that is declined or expires is
- * refunded and never counted here, because it never approved.
- *
- * The same event the tip button emits (`Image`/`Buzz`), so this arrives through
- * the metric pipeline everything else already reads rather than as a second
- * number the feed, the detail page and the search index each have to learn to
- * add.
- *
- * Detached from any request context on purpose — approval happens from the
- * review queue, from an auto-approving space and from a bulk action, and the
- * counter has to move the same way in all three.
- *
- * **Nothing here may throw.** It runs after the settle has already claimed the
- * transition and paid the owner, so a throw would report a live, paid placement
- * as failed — and in the bulk path would put its id in `failed`, inviting the
- * owner to action it again. `updateEntityMetric` catches its own emission, but
- * the module load, the tracker construction and the flag read sit outside that,
- * so the whole call is wrapped rather than trusting where the boundary happens
- * to fall today.
- */
-async function recordStickerTip({ imageId, amount }: { imageId: number; amount: number }) {
-  if (amount <= 0) return;
-
-  try {
-    await updateEntityMetricDetached({
-      entityType: 'Image',
-      entityId: imageId,
-      metricType: 'Buzz',
-      amount,
-    });
-  } catch (error) {
-    await logToAxiom({
-      name: 'sticker-placement',
-      type: 'error',
-      message: 'could not count an approved placement toward the image buzz counter',
-      imageId,
-      amount,
-      error: (error as Error).message,
-    }).catch(() => null);
-  }
-}
 
 /**
  * The note on a placement, if this viewer may read it.
@@ -318,7 +265,7 @@ export async function createStickerPlacement({
     // line: `settlePlacement` returns `settled: false` when something else got
     // there first, and counting then would add the placement's Buzz to the image
     // twice for one payment.
-    if (settled) await recordStickerTip({ imageId, amount: space.price });
+    if (settled) await recordPlacementTip({ surface: SURFACE, imageId, amount: space.price });
   }
 
   return { placementId: placement.id, status: space.mode === 'auto' ? 'approved' : 'pending' };
@@ -739,7 +686,11 @@ export async function actOnStickerPlacement({
   // for: two owners' tabs both pressing approve would otherwise count the same
   // payment on the image twice.
   if (action === 'approve' && settled)
-    await recordStickerTip({ imageId: placement.targetId, amount: placement.amount });
+    await recordPlacementTip({
+      surface: SURFACE,
+      imageId: placement.targetId,
+      amount: placement.amount,
+    });
 
   return { settled };
 }

--- a/src/server/utils/metric-helpers.ts
+++ b/src/server/utils/metric-helpers.ts
@@ -10,6 +10,19 @@ const logError = (name: string, details: Record<string, unknown>) => {
   });
 };
 
+/**
+ * What this helper actually needs, which is the tracker and — for the error log
+ * only — who did it.
+ *
+ * Widened from `ProtectedContext` so a metric can be emitted from a settlement
+ * that no request is waiting on: a sticker placement is approved from a review
+ * queue, from an auto-approving space, and from a bulk action, and the money it
+ * moves is the same money in each. Narrowing to a request context would mean
+ * emitting the metric at three call sites that happen to have one, and silently
+ * not emitting it wherever a job settles the same placement.
+ */
+type EntityMetricContext = { track: ProtectedContext['track']; user?: { id: number } | null };
+
 export const updateEntityMetric = async ({
   ctx,
   entityType = 'Image',
@@ -17,7 +30,7 @@ export const updateEntityMetric = async ({
   metricType,
   amount = 1,
 }: {
-  ctx: ProtectedContext;
+  ctx: EntityMetricContext;
   entityType?: EntityMetric_EntityType_Type;
   entityId: number;
   metricType: EntityMetric_MetricType_Type;
@@ -58,6 +71,22 @@ export const updateEntityMetric = async ({
       stack: error.stack,
     });
   }
+};
+
+/**
+ * The same emission, for a caller with no request behind it.
+ *
+ * The tracker is pulled in dynamically rather than imported at the top of this
+ * module: `~/server/clickhouse/client` is a heavy graph to attach to every
+ * module that only wants to move a counter, and importing it statically from a
+ * service drags it into that service's tests, where it is neither mocked nor
+ * wanted. Loaded once by the module cache on first use.
+ */
+export const updateEntityMetricDetached = async (
+  input: Omit<Parameters<typeof updateEntityMetric>[0], 'ctx'>
+) => {
+  const { Tracker } = await import('~/server/clickhouse/client');
+  await updateEntityMetric({ ...input, ctx: { track: new Tracker() } });
 };
 
 export const incrementEntityMetric = async ({

--- a/src/server/utils/metric-helpers.ts
+++ b/src/server/utils/metric-helpers.ts
@@ -82,11 +82,27 @@ export const updateEntityMetric = async ({
  * service drags it into that service's tests, where it is neither mocked nor
  * wanted. Loaded once by the module cache on first use.
  */
-export const updateEntityMetricDetached = async (
-  input: Omit<Parameters<typeof updateEntityMetric>[0], 'ctx'>
-) => {
+export const updateEntityMetricDetached = async ({
+  userId,
+  ...input
+}: Omit<Parameters<typeof updateEntityMetric>[0], 'ctx'> & {
+  /**
+   * Who caused it. Worth threading through rather than letting a request-less
+   * `Tracker` default to 0: `userId` is part of the dedupe key the metric
+   * pipeline replaces rows on, so several events attributed to the same
+   * non-user, on the same entity and metric, within the same millisecond
+   * collapse into one and silently undercount. A real id makes them distinct
+   * for the same reason a tip's does.
+   */
+  userId?: number;
+}) => {
   const { Tracker } = await import('~/server/clickhouse/client');
-  await updateEntityMetric({ ...input, ctx: { track: new Tracker() } });
+  const track = new Tracker(
+    undefined,
+    undefined,
+    userId ? ({ user: { id: userId } } as ConstructorParameters<typeof Tracker>[2]) : undefined
+  );
+  await updateEntityMetric({ ...input, ctx: { track } });
 };
 
 export const incrementEntityMetric = async ({

--- a/src/shared/utils/sticker-placement.ts
+++ b/src/shared/utils/sticker-placement.ts
@@ -21,6 +21,17 @@ export type StickerPlacementData = {
   scale: number;
   /** Degrees, for a sticker placed at an angle. */
   rotation: number;
+  /** Optional note from the placer, shown beside their creator card on hover. */
+  comment?: string;
+  /**
+   * The owner took the sticker and refused the note.
+   *
+   * A flag rather than deleting the text, because the placer paid for the
+   * placement the note came with and a report has to be able to reach what was
+   * actually written. Absent means never hidden, so an existing row needs no
+   * backfill.
+   */
+  commentHidden?: boolean;
 };
 
 /**
@@ -81,6 +92,47 @@ export const normalizeStickerPlacement = (
   scale: clamp(data.scale, STICKER_PLACEMENT_MIN_SCALE, STICKER_PLACEMENT_MAX_SCALE),
   rotation: clamp(data.rotation, -STICKER_PLACEMENT_MAX_ROTATION, STICKER_PLACEMENT_MAX_ROTATION),
 });
+
+/**
+ * Long enough for a joke or a compliment, short enough that it cannot become a
+ * comment thread nobody can moderate. It sits on a hover card beside a creator
+ * card, so anything longer stops fitting before it stops being allowed.
+ */
+export const STICKER_COMMENT_MAX_LENGTH = 300;
+
+/**
+ * Truncated rather than refused, and whitespace-collapsed on the way through.
+ *
+ * A note is optional decoration on a payment that has already been quoted, so
+ * failing the placement over a long one would cost the placer a round trip
+ * through a Buzz charge for something the field can simply hold less of. The
+ * schema still bounds it; this is what makes the stored value canonical however
+ * it arrived — a hand-written API call, a paste with newlines in it, an
+ * all-spaces string that would otherwise render as an empty comment bubble.
+ */
+export const normalizeStickerComment = (comment?: string | null): string | undefined => {
+  if (typeof comment !== 'string') return undefined;
+  const collapsed = comment.replace(/\s+/g, ' ').trim();
+  return collapsed ? collapsed.slice(0, STICKER_COMMENT_MAX_LENGTH) : undefined;
+};
+
+/**
+ * How long an approved sticker is protected from the owner removing it.
+ *
+ * Approval pays the owner immediately and nothing is refunded on removal, so
+ * without this an owner could accept a sticker, bank the Buzz and wipe it before
+ * anyone saw it — which is indistinguishable from an honest removal and costs
+ * the placer everything they paid. Deliberately the same week the remix gallery
+ * uses; they are the same bargain on two surfaces, and two numbers would drift.
+ *
+ * A moderator is not bound by it: a takedown is a moderation record, not an
+ * owner decision, and the abusive cases are the ones that must not wait.
+ */
+export const STICKER_REMOVAL_LOCK_HOURS = 24 * 7;
+
+/** When a sticker approved at `approvedAt` may be removed by the content owner. */
+export const stickerRemovableAt = (approvedAt: Date | string) =>
+  new Date(new Date(approvedAt).getTime() + STICKER_REMOVAL_LOCK_HOURS * 60 * 60 * 1000);
 
 export const isStickerPlacementData = (value: unknown): value is StickerPlacementData => {
   if (!value || typeof value !== 'object') return false;


### PR DESCRIPTION
Section 1 of the 2026-08-12 punch list, economy and permissions half. Sticker rendering, layer order and the history panel are someone else's branch.

## The image's Buzz counter counts paid placements — both surfaces

Agreed by Justin, Ellie and Luis in the review: a placement reads as a pseudo-tip, so it belongs in the number people already look at (Justin's example: two 200⚡ stickers taking a counter from 13 to 413).

It is emitted as the same `Image` / `Buzz` entity metric the tip button emits, so the feed, the detail page and the search index all pick it up without learning about stickers. The whole `amount` counts, not the owner's share.

**Only on approval, and never reversed.** The counter measures Buzz that reached the owner, and no path that takes a live sticker down returns any of it — owner removal, moderator takedown and cosmetic takedown all move no money by existing design. A declined or expired placement is refunded and was never counted, because it never approved. Emission is gated on `settlePlacement` actually claiming the transition, so a double-submitted approve cannot count one payment twice.

**Remix gallery entries count too** (Justin widened this mid-build): the counter is the value of *paid placements on this image*, not of stickers specifically. Both surfaces share one emitter, `recordPlacementTip` in the new `placement-metrics.service.ts` — two copies would drift, and a counter that means something different depending on which surface you asked has lost the only property it needs. The remix surface has no auto-approve path to instrument; the schema, the space service and the submission path each refuse `auto`, so `actOnRemixGallerySubmission` is the only site (confirmed with the agent who owns that surface).

**Accepted placements only** (Justin's call, asked because it is not derivable from the code). A declined placement pays the owner a 30% non-refundable fee and still counts nothing. This is the one place the number is deliberately *not* "Buzz the creator received" — counting declines would grow the counter fastest for a creator who refuses everything. What it means instead is *what people paid to be on this image*, which is also what makes it legible next to the content it labels.

**It never decrements.** A moderator takedown therefore leaves the count standing. Intended: the money was paid and never clawed back, and a counter that fell would read as the creator losing Buzz they still hold.

`updateEntityMetric` was widened from `ProtectedContext` to what it uses, and a `updateEntityMetricDetached` added, because approval happens from the review queue, from an auto-approving space and from a bulk action — only some of which have a request behind them.

## An optional note, with partial approval

The placer can attach one line to a placement, shown on the hover card beside their creator card. The owner can accept the sticker and refuse the note — "Approve without note" in the review queue, and a hide/show toggle on the hover card afterwards.

Hiding is not deletion: the text stays readable to the owner, the placer who paid for it, and a moderator, because that is what a report about it is about. Everyone else sees nothing.

The note lives in the placement's own JSON payload, so **no migration**. It is deliberately not a `CommentV2` thread — that would bring edit, reply and notification behaviour nobody asked for, each of which would then need its own answer to "accepted the sticker, refused the note".

Reporting a note reuses the existing `StickerPlacement` reason with a `target: 'sticker' | 'comment'` discriminator rather than a new `ReportReason`, which avoids an enum migration and still stops the two report kinds folding into each other in dedupe. The discriminator is only added to the dedupe predicate for `comment` — asserting the `'sticker'` default would stop new reports deduping against the history from before the field existed, which is the same fold the predicate exists to prevent.

## The owner cannot remove a sticker for a week

Same bargain as the remix gallery, and the same constant. Approval pays the owner and removal refunds nothing, so without the lock an owner could accept a sticker, bank the Buzz and wipe it before anyone saw it. A moderator acting on someone else's content is exempt; an owner who happens to be a moderator is not.

**This also fixes owner removal, which did not work.** `actOnStickerPlacement`'s `remove` routed an approved row through `settlePlacement`, which claims its transition with `WHERE status = 'pending'` — it matched nothing, moved no money, returned `settled: false` and left the sticker exactly where it was. Live rows now take the same direct write `removePlacementByModerator` and the remix gallery already use.

The lock falls back to `createdAt` when `resolvedAt` is absent, so a hand-seeded row fails closed rather than being removable immediately.

## Two investigations, both reported rather than coded

**The 10,000 Buzz sticker price is not a bug.** It is the creator-shop *submission* fee (`SUBMISSION_FEE_DEFAULT`), not the placement price — placement defaults to 100 with a floor of 50 and no 10,000 anywhere near it. The fee is DB-editable through the `creatorShopFees` KeyValue row, and prod already reads **5000 for `Sticker`** (the other cosmetic types are still 10000). Ellie's 10:29 screenshot predates Justin's change. No code touched.

**Blocked users already cannot place.** `assertCanPlace` runs on the mutation, reads the **primary** rather than the cached `getBlockedPairIds`, and checks both directions — so a block committed seconds earlier refuses rather than merely filtering an affordance. Blocking also auto-declines everything pending from that user. Seeing a sticker made or placed by someone you blocked is unchanged, per the decision. No code touched.

## Two adversarial reviews, eight fixes

Both reviewers were prompted to refute and to default to "broken". Between them they cleared authorisation, lock bypass, metric double/miss-counting, `data` clobbering, and vacuous tests (the second checked all ten new tests against a revert and found none vacuous). Eight real defects, all fixed in `9b9d43c`:

1. **A regression I introduced mid-review.** Making the hidden-note write unconditional meant a plain Approve wrote `commentHidden: false`, **publishing a note the owner had already refused** from the hover card while the placement sat pending. `hideComment` is now `boolean | undefined`; undefined leaves the decision alone. Where the readings disagree the safe one is the note staying hidden.
2. **The report dedupe folded in one direction.** The sticker arm matched on `placementId` alone, so a complaint about the artwork was appended to an existing complaint about the *note* and its text discarded — a moderator would see one and never the other. Both arms now assert their own `target`.
3. **The listing's note-strip had no test** — reverting the one line that keeps notes off anonymous feed pages left the whole suite green. Four tests now; reverting it fails two.
4. **`commentHidden` was sent to strangers.** Text was withheld but the card still said a note existed and was refused, which is the fact withholding the text protected. Scoped to the owner and the placer.
5. **`recordStickerTip` could throw** after the settle had paid the owner — the module load, tracker construction and flag read sit outside `updateEntityMetric`'s own swallow — reporting a live, paid placement as failed. Wrapped.
6. **`visibleStickerComment` trusted the JSON.** `isStickerPlacementData` validates geometry only, so the read now requires a string and compares `commentHidden === true` (a hand-edited `"false"` is truthy and would hide a note nobody refused).
7. **Partial approval was missing on the main surface** — `hasComment` was not forwarded in `StickerPlacementOverlay`, so "Approve without note" only rendered on `/user/sticker-placements`.
8. **A test asserted less than its name.** "before the placement goes live" checked only the payload; it now asserts the call order. Added the missing authorisation tests for `setStickerCommentHidden`.

Two findings acknowledged and not fixed: `hideStickerComment` is an unguarded read-modify-write of `data` (nothing else writes that column after creation, so the only race is hide-vs-hide where last-write-wins is the user's own intent, and geometry comes off the DB row rather than the client); and `actOnStickerPlacements`' `settled` counter counts takedowns that moved no money, which the UI reports as "Actioned N".

## Verification

- `pnpm run typecheck` — 0 errors.
- `pnpm run lint` on the touched files — clean. `report.service.ts` carries 3 `no-unused-vars` warnings that are identical on clean `main`.
- 34 new/changed tests across `sticker-placement.service.test.ts`, `remix-gallery.service.test.ts` and `report-sticker-dedupe.test.ts`. Four mutation checks, each reverting one production line: the listing strip fails 2, the un-hide guard fails 1, the sticker emission fails 1, the remix emission fails 1.
- `blocks.router.workflow.test.ts` collected 347 tests, so the run is real rather than silently empty.
- `pnpm run test:unit:run` — my suites pass; the failures are all repo-*scanning* drift guards (`app-spend-tier-privilege`, `block-scope.normalize-endpoint`, `orchestrator-chat.wait-unit`, the apps page tests). **Their count is not stable run to run on this machine** — 16, 16, then 37 across three runs of identical code — so I compared the subset directly instead: run in isolation, that set is **3 files / 13 tests failing on this branch and 3 files / 13 tests failing on clean `main`**. None touch stickers. A CI run is the number to trust here, not mine.

**No migration.** Everything new is in the existing `Placement.data` JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
