### PR TITLE
fix(api): stop /api/v1 500s leaking Prisma table+column text; unify the apps error envelope

### DIFF
--- a/src/pages/api/v1/apps/[slug].ts
+++ b/src/pages/api/v1/apps/[slug].ts
@@ -67,16 +67,25 @@ export default MixedAuthEndpoint(async function handler(req, res, user) {
       .json(restErrorBody(REST_ERROR_CODE.BAD_REQUEST, 'Invalid slug', parsed.error.flatten()));
   }
 
-  const limited = await enforceAppsCatalogRateLimit({ req, res, user, log: req.log });
-  if (limited) return;
-
-  // DEFAULT-CLOSED scope gate — pass the resolved scope EXPLICITLY to the service.
-  const scope = await resolveStoreVisibilityScope({ user });
-  if (scope === 'none') {
-    return res.status(404).json(restErrorBody(REST_ERROR_CODE.NOT_FOUND, 'App not found'));
-  }
-
+  // Everything that can throw lives INSIDE the try. The rate limiter and the
+  // scope gate used to sit outside it: both are `await`ed calls into Redis / the
+  // Flipt client, and a throw from either would escape `handleEndpointError`
+  // entirely — no envelope, no `code`, no fault log, just Next.js's default 500.
+  // Neither has a known throw path today (the limiter catches its own Redis
+  // errors and fails open; `isFlipt` swallows init + eval failures and returns
+  // false), so this closes a STRUCTURAL gap rather than an observed bug — but
+  // "no envelope on this path" should not depend on a dependency's internals
+  // staying that defensive.
   try {
+    const limited = await enforceAppsCatalogRateLimit({ req, res, user, log: req.log });
+    if (limited) return;
+
+    // DEFAULT-CLOSED scope gate — pass the resolved scope EXPLICITLY to the service.
+    const scope = await resolveStoreVisibilityScope({ user });
+    if (scope === 'none') {
+      return res.status(404).json(restErrorBody(REST_ERROR_CODE.NOT_FOUND, 'App not found'));
+    }
+
     const detail = await getListingDetail(
       { slug: parsed.data.slug },
       { redCapable: isRedCapableRequest(req.headers.host), scope }

--- a/src/pages/api/v1/apps/[slug].ts
+++ b/src/pages/api/v1/apps/[slug].ts
@@ -4,6 +4,7 @@ import { getListingDetail } from '~/server/services/blocks/app-listing.service';
 import { MixedAuthEndpoint, handleEndpointError } from '~/server/utils/endpoint-helpers';
 import { enforceAppsCatalogRateLimit } from '~/server/utils/apps-catalog-rate-limit';
 import { isHostForColor } from '~/server/utils/server-domain';
+import { REST_ERROR_CODE, restErrorBody } from '~/server/utils/rest-error-envelope';
 
 /**
  * GET /api/v1/apps/{slug}
@@ -28,6 +29,19 @@ import { isHostForColor } from '~/server/utils/server-domain';
  * A missing slug, a non-approved listing, an onsite listing under
  * `public-external` scope, or a mature listing off a non-red host all resolve to
  * the SAME 404 as a genuinely absent app — no existence oracle.
+ *
+ * ## Error envelope — ONE shape for every non-2xx (civitai#3845)
+ * 400 / 404 / 429 / 500 all carry `{ error, message, code }`:
+ *   - `code` is the stable machine-readable discriminator a client branches on
+ *     (`BAD_REQUEST` | `NOT_FOUND` | `TOO_MANY_REQUESTS` | `INTERNAL_SERVER_ERROR`),
+ *     and is NEVER present on a 2xx.
+ *   - `message` is always a string.
+ *   - `error` is RETAINED with its historical per-status value — including the
+ *     zod `.flatten()` OBJECT on 400, which the shipped Go CLI special-cases to
+ *     render per-field errors. See `~/server/utils/rest-error-envelope`.
+ * The 500 body is generic BY DESIGN: `handleEndpointError` must never place
+ * driver text on this public, unauthenticated surface (#3845 leaked a Prisma
+ * invocation with the table and column name). Attribution lives in the log.
  */
 
 /** Single query-param value (Next gives `string | string[] | undefined`); '' → undefined. */
@@ -46,7 +60,11 @@ const slugSchema = z.object({ slug: z.string().min(1).max(64) });
 export default MixedAuthEndpoint(async function handler(req, res, user) {
   const parsed = slugSchema.safeParse({ slug: firstQuery(req.query.slug) });
   if (!parsed.success) {
-    return res.status(400).json({ error: parsed.error.flatten() });
+    // `error` stays the zod flatten OBJECT — the shipped Go CLI special-cases
+    // that exact shape (`{formErrors, fieldErrors}`) to render per-field errors.
+    return res
+      .status(400)
+      .json(restErrorBody(REST_ERROR_CODE.BAD_REQUEST, 'Invalid slug', parsed.error.flatten()));
   }
 
   const limited = await enforceAppsCatalogRateLimit({ req, res, user, log: req.log });
@@ -55,7 +73,7 @@ export default MixedAuthEndpoint(async function handler(req, res, user) {
   // DEFAULT-CLOSED scope gate — pass the resolved scope EXPLICITLY to the service.
   const scope = await resolveStoreVisibilityScope({ user });
   if (scope === 'none') {
-    return res.status(404).json({ error: 'App not found' });
+    return res.status(404).json(restErrorBody(REST_ERROR_CODE.NOT_FOUND, 'App not found'));
   }
 
   try {
@@ -64,7 +82,7 @@ export default MixedAuthEndpoint(async function handler(req, res, user) {
       { redCapable: isRedCapableRequest(req.headers.host), scope }
     );
     if (!detail) {
-      return res.status(404).json({ error: 'App not found' });
+      return res.status(404).json(restErrorBody(REST_ERROR_CODE.NOT_FOUND, 'App not found'));
     }
     return res.status(200).json(detail);
   } catch (e) {

--- a/src/pages/api/v1/apps/index.ts
+++ b/src/pages/api/v1/apps/index.ts
@@ -76,17 +76,24 @@ export default MixedAuthEndpoint(async function handler(req, res, user) {
       .json(restErrorBody(REST_ERROR_CODE.BAD_REQUEST, 'Invalid query', parsed.error.flatten()));
   }
 
-  const limited = await enforceAppsCatalogRateLimit({ req, res, user, log: req.log });
-  if (limited) return;
-
-  // DEFAULT-CLOSED scope gate — pass the resolved scope EXPLICITLY to the service.
-  const scope = await resolveStoreVisibilityScope({ user });
-  if (scope === 'none') {
-    // Anon / non-privileged pre-launch → empty page, NEVER the full catalog.
-    return res.status(200).json({ items: [], metadata: { nextCursor: undefined, nextPage: undefined } });
-  }
-
+  // Same try-scope discipline as the sibling `[slug].ts`: the rate limiter and the
+  // scope gate are `await`ed calls into Redis / the Flipt client, so a throw from
+  // either must land in `handleEndpointError` rather than escaping to Next.js's
+  // default 500 (no envelope, no fault log). Structural — neither has a known
+  // throw path today.
   try {
+    const limited = await enforceAppsCatalogRateLimit({ req, res, user, log: req.log });
+    if (limited) return;
+
+    // DEFAULT-CLOSED scope gate — pass the resolved scope EXPLICITLY to the service.
+    const scope = await resolveStoreVisibilityScope({ user });
+    if (scope === 'none') {
+      // Anon / non-privileged pre-launch → empty page, NEVER the full catalog.
+      return res
+        .status(200)
+        .json({ items: [], metadata: { nextCursor: undefined, nextPage: undefined } });
+    }
+
     const { items, nextCursor } = await listAvailableListings(parsed.data, {
       redCapable: isRedCapableRequest(req.headers.host),
       scope,

--- a/src/pages/api/v1/apps/index.ts
+++ b/src/pages/api/v1/apps/index.ts
@@ -6,6 +6,7 @@ import { MixedAuthEndpoint, handleEndpointError } from '~/server/utils/endpoint-
 import { enforceAppsCatalogRateLimit } from '~/server/utils/apps-catalog-rate-limit';
 import { getNextPage } from '~/server/utils/pagination-helpers';
 import { isHostForColor } from '~/server/utils/server-domain';
+import { REST_ERROR_CODE, restErrorBody } from '~/server/utils/rest-error-envelope';
 
 /**
  * GET /api/v1/apps
@@ -68,7 +69,11 @@ export default MixedAuthEndpoint(async function handler(req, res, user) {
     limit: firstQuery(req.query.limit),
   });
   if (!parsed.success) {
-    return res.status(400).json({ error: parsed.error.flatten() });
+    // Sibling of `[slug].ts` — same shared envelope (civitai#3845). `error`
+    // stays the zod flatten OBJECT, which the shipped Go CLI special-cases.
+    return res
+      .status(400)
+      .json(restErrorBody(REST_ERROR_CODE.BAD_REQUEST, 'Invalid query', parsed.error.flatten()));
   }
 
   const limited = await enforceAppsCatalogRateLimit({ req, res, user, log: req.log });

--- a/src/server/utils/__tests__/endpoint-helpers-error-envelope.test.ts
+++ b/src/server/utils/__tests__/endpoint-helpers-error-envelope.test.ts
@@ -11,11 +11,16 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
  *               The column `app_collaborators.app_listing_id` does not exist
  *               in the current database." }
  *
- * `handleEndpointError` is the shared 500 chokepoint for 14 REST routes, so the
- * leak is a property of the HELPER, not of that one route — which is why the
- * guard lives here rather than only in the route suite. The route-level
- * counterpart (driving the real handler end to end) is in
- * `src/tests/api/v1/apps/apps-error-envelope.test.ts`.
+ * `handleEndpointError` is the shared 500 chokepoint for 14 REST routes (10 on
+ * the public `/api/v1` surface), so the leak is a property of the HELPER, not of
+ * that one route — which is why the guard lives here rather than only in the
+ * route suite. The route-level counterpart (driving the real handler end to end)
+ * is in `src/tests/api/v1/apps/apps-error-envelope.test.ts`.
+ *
+ * 🔴 The helper has TWO 500-producing branches. This first `describe` covers the
+ * non-`TRPCError` one; the second covers the `TRPCError` one, which is where a
+ * `throwDbError`-wrapped driver error actually lands and which the original fix
+ * left leaking.
  *
  * This suite exercises the REAL `handleEndpointError` — `src/__tests__/setup.ts`
  * seeds `TRPC_ORIGINS` precisely so `endpoint-helpers` is importable — and mocks
@@ -36,13 +41,23 @@ const { mockLogToAxiom, mockBuildCentralErrorLog, mockWasServerFaultLogged } = v
   mockWasServerFaultLogged: vi.fn(() => false),
 }));
 
-vi.mock('~/server/logging/client', () => ({
+// Spread the ORIGINAL and override only the three exports this suite drives.
+// `~/server/logging/client` has 7 exports; replacing it wholesale with a 3-key
+// object makes the mock go stale the moment `endpoint-helpers` (or anything it
+// pulls in) reaches for a fourth — a failure that surfaces as an unrelated
+// "not a function" far from here.
+vi.mock('~/server/logging/client', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   logToAxiom: mockLogToAxiom,
   buildCentralErrorLog: mockBuildCentralErrorLog,
   wasServerFaultLogged: mockWasServerFaultLogged,
 }));
 
+import { Prisma } from '@prisma/client';
+import { TRPCError } from '@trpc/server';
 import { handleEndpointError } from '~/server/utils/endpoint-helpers';
+import { throwDbError } from '~/server/utils/errorHandling';
+import { GENERIC_SERVER_ERROR_MESSAGE } from '~/server/utils/rest-error-envelope';
 
 // The exact internals the incident disclosed. Kept as named constants so the
 // assertions below read as "this identifier must not appear", not as a wall of
@@ -193,5 +208,264 @@ describe('handleEndpointError — non-TRPCError branch', () => {
 
     expect(res._status()).toBe(500);
     expect(mockLogToAxiom).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The SECOND 500-producing branch of the same helper.
+ *
+ * `handleEndpointError` has two: the `else` (non-`TRPCError`) branch above, and
+ * this one. The original #3845 fix changed only the former, which left the leak
+ * fully live — because the dominant way a driver error reaches a REST route is
+ * NOT as a bare `Error` but as a `TRPCError` built by `throwDbError`
+ * (`errorHandling.ts`), whose Prisma map sends `P2022` — the exact code from the
+ * incident — to `INTERNAL_SERVER_ERROR`. That TRPCError carries `error.message`
+ * verbatim and this branch served it as `{ message: <driver text> }`.
+ *
+ * The two things this branch must NOT lose, both pinned below:
+ *   - 4xx bodies pass through BYTE-IDENTICALLY (the `JSON.parse` exists because
+ *     older zod-validation TRPCErrors JSON-encode an issue ARRAY into `message`,
+ *     and the shipped Go CLI renders that shape per-field), and
+ *   - 503 keeps its message verbatim — see `isRestServerFault`.
+ */
+describe('handleEndpointError — TRPCError branch', () => {
+  /** Exactly what `throwDbError` builds from the #3845 driver error. */
+  function dbTrpcError() {
+    return new TRPCError({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: driverError().message,
+      cause: driverError(),
+    });
+  }
+
+  // ── Guard 5: the #3845 disclosure, on the OTHER 500 branch ─────────────────
+  it('does NOT disclose driver, table or column detail on a 500 TRPCError', () => {
+    const res = createRes();
+
+    handleEndpointError(res as never, dbTrpcError());
+
+    expect(res._status()).toBe(500);
+    const serialized = JSON.stringify(res._json());
+    for (const secret of MUST_NOT_DISCLOSE) {
+      expect(
+        serialized,
+        `#3845 (TRPCError branch): the public 500 body must not disclose ${JSON.stringify(
+          secret
+        )} — full body was ${serialized}`
+      ).not.toContain(secret);
+    }
+  });
+
+  // ── Guard 6: SEAM — the real throwDbError → handleEndpointError chain ──────
+  // Neither component's own suite builds this combined state: `throwDbError` is
+  // only ever tested on the code it PRODUCES, and the helper is only ever tested
+  // on errors a test fabricated. This drives a genuine
+  // `PrismaClientKnownRequestError` (code P2022, the incident's) through the real
+  // `throwDbError` and into the real helper.
+  it('SEAM: a real P2022 driver error through throwDbError does not reach the wire', () => {
+    const res = createRes();
+    const prismaError = new Prisma.PrismaClientKnownRequestError(driverError().message, {
+      code: 'P2022',
+      clientVersion: '6.13.0',
+      meta: { column: `${LEAKED_TABLE}.${LEAKED_COLUMN}` },
+    });
+
+    let thrown: unknown;
+    try {
+      throwDbError(prismaError);
+    } catch (e) {
+      thrown = e;
+    }
+
+    // Positive control on the FIXTURE: if throwDbError stopped mapping P2022 to a
+    // 500 this test would silently be exercising some other status.
+    expect(thrown, 'throwDbError must produce a TRPCError').toBeInstanceOf(TRPCError);
+    expect((thrown as TRPCError).code, 'P2022 must map to INTERNAL_SERVER_ERROR').toBe(
+      'INTERNAL_SERVER_ERROR'
+    );
+    expect(
+      (thrown as TRPCError).message,
+      'the fixture must actually carry the leaked text, or the guard below is vacuous'
+    ).toContain(`${LEAKED_TABLE}.${LEAKED_COLUMN}`);
+
+    handleEndpointError(res as never, thrown);
+
+    expect(res._status()).toBe(500);
+    const serialized = JSON.stringify(res._json());
+    for (const secret of MUST_NOT_DISCLOSE) {
+      expect(
+        serialized,
+        `#3845 seam: the public 500 body must not disclose ${JSON.stringify(
+          secret
+        )} — full body was ${serialized}`
+      ).not.toContain(secret);
+    }
+  });
+
+  // ── Guard 7: the envelope, by VALUE not by key presence ───────────────────
+  it('serves the shared envelope with the generic text in BOTH `message` and `error`', () => {
+    const res = createRes();
+
+    handleEndpointError(res as never, dbTrpcError());
+
+    const body = res._json() as Record<string, unknown>;
+    expect(body.code, 'the 500 envelope must carry the `code` discriminator').toBe(
+      'INTERNAL_SERVER_ERROR'
+    );
+    expect(body.message, '`message` must be the generic text').toBe(GENERIC_SERVER_ERROR_MESSAGE);
+    // Asserted by VALUE: the shipped CLI renders `error` in PREFERENCE to
+    // `message`, so an `error` that were blank (or still the driver text) is the
+    // whole ballgame and key-presence would not notice either.
+    expect(body.error, '`error` must be the generic text too — the CLI prefers it').toBe(
+      GENERIC_SERVER_ERROR_MESSAGE
+    );
+  });
+
+  // ── Guard 8: observability preserved on THIS branch too ───────────────────
+  it('INVARIANT: still logs the UN-redacted TRPCError (observability preserved)', () => {
+    const err = dbTrpcError();
+    const res = createRes();
+
+    handleEndpointError(res as never, err);
+
+    expect(mockBuildCentralErrorLog).toHaveBeenCalledTimes(1);
+    expect(mockBuildCentralErrorLog).toHaveBeenCalledWith(err);
+    const [payload] = mockLogToAxiom.mock.calls[0] as [Record<string, unknown>];
+    expect(
+      String(payload.message),
+      'the LOG must keep the un-redacted driver text even though the RESPONSE drops it'
+    ).toContain(`${LEAKED_TABLE}.${LEAKED_COLUMN}`);
+  });
+
+  // ── Guard 9: the 4xx pass-through, EXECUTED rather than reasoned about ────
+  it('INVARIANT: a zod-issue-ARRAY 400 still produces the identical parsed body', () => {
+    // The shape older zod-validation TRPCErrors carry: the issue array
+    // JSON-encoded into `message`. Field values are pairwise distinct so a body
+    // assembled from the wrong part of the payload cannot coincidentally match.
+    const issues = [
+      {
+        code: 'invalid_type',
+        expected: 'string',
+        received: 'undefined',
+        path: ['slug'],
+        message: 'Required',
+      },
+      {
+        code: 'too_big',
+        maximum: 64,
+        type: 'string',
+        inclusive: true,
+        path: ['slug'],
+        message: 'String must contain at most 64 character(s)',
+      },
+    ];
+    const res = createRes();
+
+    handleEndpointError(
+      res as never,
+      new TRPCError({ code: 'BAD_REQUEST', message: JSON.stringify(issues) })
+    );
+
+    expect(res._status(), 'a 400 must NOT be swept into the server-fault branch').toBe(400);
+    // BYTE-IDENTICAL: the parsed array itself, not an object wrapping it, and
+    // with no `code`/`message`/`error` envelope grafted on.
+    expect(
+      res._json(),
+      'the 400 body must stay the parsed zod issue array, unchanged'
+    ).toStrictEqual(issues);
+    expect(mockLogToAxiom, 'a 4xx is client feedback, never a logged fault').not.toHaveBeenCalled();
+  });
+
+  it('INVARIANT: a plain-string 4xx still produces the identical `{ message }` body', () => {
+    const res = createRes();
+
+    handleEndpointError(res as never, new TRPCError({ code: 'NOT_FOUND', message: 'No article' }));
+
+    expect(res._status()).toBe(404);
+    expect(res._json(), 'the fallback 4xx body must stay exactly `{ message }`').toStrictEqual({
+      message: 'No article',
+    });
+    expect(mockLogToAxiom).not.toHaveBeenCalled();
+  });
+
+  // ── Guard 10: the deliberate 503 carve-out ────────────────────────────────
+  it('503 keeps its retry hint VERBATIM and is still not logged (deliberate)', () => {
+    const hint = 'Image search is temporarily overloaded — please retry.';
+    const res = createRes();
+
+    handleEndpointError(
+      res as never,
+      new TRPCError({ code: 'SERVICE_UNAVAILABLE', message: hint })
+    );
+
+    expect(res._status()).toBe(503);
+    // 503 is excluded from the fault log, so the response is the ONLY copy of
+    // this message — genericizing it would destroy it rather than relocate it.
+    expect(res._json(), '503 must pass through unchanged').toStrictEqual({ message: hint });
+    expect(mockLogToAxiom, '503 stays out of the error stream').not.toHaveBeenCalled();
+  });
+
+  // ── Guard 11: the COUPLING invariant, over every 5xx status ───────────────
+  // One predicate governs both logging and genericizing, so the property that
+  // matters is not "500 is generic" but "the text is dropped from the wire
+  // EXACTLY when it is preserved in the log". Asserted per status, in ONE test,
+  // so it cannot pass by only ever exercising the agreeing half.
+  it('INVARIANT: across every 5xx, genericized ⟺ logged (text is never destroyed)', () => {
+    const cases = [
+      { code: 'INTERNAL_SERVER_ERROR', status: 500 },
+      { code: 'NOT_IMPLEMENTED', status: 501 },
+      { code: 'BAD_GATEWAY', status: 502 },
+      { code: 'SERVICE_UNAVAILABLE', status: 503 },
+      { code: 'GATEWAY_TIMEOUT', status: 504 },
+    ] as const;
+
+    for (const { code, status } of cases) {
+      vi.clearAllMocks();
+      mockWasServerFaultLogged.mockReturnValue(false);
+      const marker = `distinct-text-for-${status}`;
+      const res = createRes();
+
+      handleEndpointError(res as never, new TRPCError({ code, message: marker }));
+
+      expect(res._status(), `${code} must map to ${status}`).toBe(status);
+      const serialized = JSON.stringify(res._json());
+      const genericized = !serialized.includes(marker);
+      const logged = mockLogToAxiom.mock.calls.length > 0;
+      expect(
+        genericized,
+        `${code} (${status}): dropped-from-the-wire (${genericized}) must equal ` +
+          `kept-in-the-log (${logged}) — otherwise the only copy of the message is destroyed`
+      ).toBe(logged);
+    }
+  });
+
+  // ── Guard 12: the threshold boundaries ────────────────────────────────────
+  // Pins BOTH sides of `status >= 500`: a 499 must pass through and a 500 must
+  // not, so neither `> 500` nor `>= 400` can survive.
+  it('INVARIANT: the server-fault threshold sits exactly at 500', () => {
+    const belowRes = createRes();
+    handleEndpointError(
+      belowRes as never,
+      new TRPCError({ code: 'CLIENT_CLOSED_REQUEST', message: 'below-threshold-text' })
+    );
+    expect(belowRes._status()).toBe(499);
+    expect(
+      JSON.stringify(belowRes._json()),
+      '499 is below the threshold — its message must pass through'
+    ).toContain('below-threshold-text');
+
+    vi.clearAllMocks();
+    mockWasServerFaultLogged.mockReturnValue(false);
+
+    const atRes = createRes();
+    handleEndpointError(
+      atRes as never,
+      new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'at-threshold-text' })
+    );
+    expect(atRes._status()).toBe(500);
+    expect(
+      JSON.stringify(atRes._json()),
+      '500 is AT the threshold — its message must be genericized'
+    ).not.toContain('at-threshold-text');
   });
 });

--- a/src/server/utils/__tests__/endpoint-helpers-error-envelope.test.ts
+++ b/src/server/utils/__tests__/endpoint-helpers-error-envelope.test.ts
@@ -405,12 +405,24 @@ describe('handleEndpointError — TRPCError branch', () => {
     expect(mockLogToAxiom, '503 stays out of the error stream').not.toHaveBeenCalled();
   });
 
-  // ── Guard 11: the COUPLING invariant, over every 5xx status ───────────────
+  // ── Guard 11: BOTH halves pinned ABSOLUTELY, over every 5xx status ─────────
   // One predicate governs both logging and genericizing, so the property that
-  // matters is not "500 is generic" but "the text is dropped from the wire
-  // EXACTLY when it is preserved in the log". Asserted per status, in ONE test,
-  // so it cannot pass by only ever exercising the agreeing half.
-  it('INVARIANT: across every 5xx, genericized ⟺ logged (text is never destroyed)', () => {
+  // matters is "the text is dropped from the wire EXACTLY when it is preserved
+  // in the log". But pinning only that RELATIONSHIP (`genericized === logged`)
+  // is far too weak: NEITHER satisfies a biconditional exactly as well as BOTH.
+  // A narrowed `isRestServerFault` — e.g. `status === 500` — makes 501/502/504
+  // neither genericized nor logged, which simultaneously RE-OPENS the #3845
+  // disclosure on those statuses and silently stops logging those faults, while
+  // a biconditional stays green throughout. (Verified: that mutant left this
+  // suite at 30/30 before this guard was strengthened.)
+  //
+  // So each side is pinned to its expected VALUE per status instead. That
+  // SUBSUMES the coupling — both equal the same constant, therefore equal each
+  // other — and additionally fixes WHICH statuses are server faults, which the
+  // biconditional never constrained. 503 is the sole carve-out (see
+  // `isRestServerFault`): it alone passes through verbatim and stays out of the
+  // error stream. Every other 5xx must be both genericized and logged.
+  it('INVARIANT: every 5xx except 503 is BOTH genericized AND logged (each pinned absolutely)', () => {
     const cases = [
       { code: 'INTERNAL_SERVER_ERROR', status: 500 },
       { code: 'NOT_IMPLEMENTED', status: 501 },
@@ -431,11 +443,27 @@ describe('handleEndpointError — TRPCError branch', () => {
       const serialized = JSON.stringify(res._json());
       const genericized = !serialized.includes(marker);
       const logged = mockLogToAxiom.mock.calls.length > 0;
+
+      // 503 is the ONLY 5xx that is not a server fault.
+      const isServerFault = status !== 503;
+
       expect(
         genericized,
-        `${code} (${status}): dropped-from-the-wire (${genericized}) must equal ` +
-          `kept-in-the-log (${logged}) — otherwise the only copy of the message is destroyed`
-      ).toBe(logged);
+        isServerFault
+          ? `${code} (${status}): the message must be DROPPED from the wire — it was served ` +
+              `verbatim as ${serialized}, which is the #3845 disclosure re-opened on this status`
+          : `${code} (${status}): the retry hint must pass through VERBATIM — genericizing it ` +
+              `destroys the only copy, since 503 is deliberately excluded from the error stream`
+      ).toBe(isServerFault);
+
+      expect(
+        logged,
+        isServerFault
+          ? `${code} (${status}): the fault must be KEPT in the log — genericizing the response ` +
+              `without logging destroys the only copy of the message`
+          : `${code} (${status}): 503 must stay OUT of the error stream (high-volume transient ` +
+              `upstream waves) — it was logged instead`
+      ).toBe(isServerFault);
     }
   });
 

--- a/src/server/utils/__tests__/endpoint-helpers-error-envelope.test.ts
+++ b/src/server/utils/__tests__/endpoint-helpers-error-envelope.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Regression coverage for civitai#3845 — the unauthenticated internal-detail
+ * DISCLOSURE on the non-`TRPCError` branch of `handleEndpointError`.
+ *
+ * The incident body served to anonymous callers on `GET /api/v1/apps/{slug}`:
+ *
+ *   { "message": "An unexpected error occurred",
+ *     "error": "\nInvalid `prisma.appCollaborator.findMany()` invocation:\n\n\n
+ *               The column `app_collaborators.app_listing_id` does not exist
+ *               in the current database." }
+ *
+ * `handleEndpointError` is the shared 500 chokepoint for 14 REST routes, so the
+ * leak is a property of the HELPER, not of that one route — which is why the
+ * guard lives here rather than only in the route suite. The route-level
+ * counterpart (driving the real handler end to end) is in
+ * `src/tests/api/v1/apps/apps-error-envelope.test.ts`.
+ *
+ * This suite exercises the REAL `handleEndpointError` — `src/__tests__/setup.ts`
+ * seeds `TRPC_ORIGINS` precisely so `endpoint-helpers` is importable — and mocks
+ * ONLY the logging client, because one of the guards below is about what that
+ * client receives.
+ */
+
+const { mockLogToAxiom, mockBuildCentralErrorLog, mockWasServerFaultLogged } = vi.hoisted(() => ({
+  mockLogToAxiom: vi.fn().mockResolvedValue(undefined),
+  // Deliberately message-FAITHFUL: the real builder walks the cause chain and
+  // carries `.message` through verbatim. Keeping that one field real is what
+  // lets the observability guard below detect a future "fix" that stops the
+  // leak by redacting the LOG instead of the RESPONSE.
+  mockBuildCentralErrorLog: vi.fn((e: unknown) => ({
+    name: (e as Error)?.name,
+    message: (e as Error)?.message,
+  })),
+  mockWasServerFaultLogged: vi.fn(() => false),
+}));
+
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: mockLogToAxiom,
+  buildCentralErrorLog: mockBuildCentralErrorLog,
+  wasServerFaultLogged: mockWasServerFaultLogged,
+}));
+
+import { handleEndpointError } from '~/server/utils/endpoint-helpers';
+
+// The exact internals the incident disclosed. Kept as named constants so the
+// assertions below read as "this identifier must not appear", not as a wall of
+// string literals.
+const LEAKED_TABLE = 'app_collaborators';
+const LEAKED_COLUMN = 'app_listing_id';
+const LEAKED_MODEL = 'appCollaborator';
+const LEAKED_METHOD = 'findMany';
+
+/** Verbatim reproduction of the driver text served in the #3845 incident. */
+function driverError() {
+  return new Error(
+    `\nInvalid \`prisma.${LEAKED_MODEL}.${LEAKED_METHOD}()\` invocation:\n\n\n` +
+      `The column \`${LEAKED_TABLE}.${LEAKED_COLUMN}\` does not exist in the current database.`
+  );
+}
+
+/**
+ * Every token that must NOT reach an unauthenticated caller. Asserted against
+ * the FULL SERIALIZED BODY rather than a single field, so a leak that merely
+ * relocates to another key still fails.
+ */
+const MUST_NOT_DISCLOSE = [
+  LEAKED_TABLE,
+  LEAKED_COLUMN,
+  LEAKED_MODEL,
+  LEAKED_METHOD,
+  'prisma.',
+  'invocation',
+  'does not exist in the current database',
+];
+
+function createRes() {
+  let statusCode = 200;
+  let payload: unknown;
+  let headersSent = false;
+  const res = {
+    status(c: number) {
+      statusCode = c;
+      return res;
+    },
+    json(b: unknown) {
+      payload = b;
+      headersSent = true;
+      return res;
+    },
+    setHeader() {
+      /* noop */
+    },
+    end() {
+      headersSent = true;
+      return res;
+    },
+    get headersSent() {
+      return headersSent;
+    },
+    _status: () => statusCode,
+    _json: () => payload,
+  };
+  return res;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWasServerFaultLogged.mockReturnValue(false);
+});
+
+describe('handleEndpointError — non-TRPCError branch', () => {
+  // ── Guard 1: the disclosure regression (civitai#3845) ──────────────────────
+  it('does NOT disclose driver, table or column detail in the 500 response body', () => {
+    const res = createRes();
+
+    handleEndpointError(res as never, driverError());
+
+    expect(res._status()).toBe(500);
+    const serialized = JSON.stringify(res._json());
+    for (const secret of MUST_NOT_DISCLOSE) {
+      expect(
+        serialized,
+        `#3845: the public 500 body must not disclose ${JSON.stringify(
+          secret
+        )} — full body was ${serialized}`
+      ).not.toContain(secret);
+    }
+  });
+
+  // ── Guard 2: the machine-readable discriminator ────────────────────────────
+  it('carries the stable `code` discriminator and string `message`/`error` fields', () => {
+    const res = createRes();
+
+    handleEndpointError(res as never, driverError());
+
+    const body = res._json() as Record<string, unknown>;
+    expect(body.code, 'the 500 envelope must carry the `code` discriminator').toBe(
+      'INTERNAL_SERVER_ERROR'
+    );
+    // `message` MUST stay a string: the Go CLI's readError decodes it into a
+    // `Message string`, and a non-string fails the whole unmarshal.
+    expect(typeof body.message, '`message` must remain a string for the CLI decoder').toBe(
+      'string'
+    );
+    // `error` is retained (not deleted) for backwards compatibility — the CLI
+    // prefers it over `message` when rendering.
+    expect(typeof body.error, '`error` must be retained as a string').toBe('string');
+  });
+
+  // ── Guard 3: INVARIANT GUARD (green before the fix, by construction) ───────
+  // Not regression coverage: it pins behaviour the fix must PRESERVE. Without
+  // it, a future "fix" that stops the leak by deleting the log would pass
+  // guards 1-2 while silently destroying 500 attribution.
+  it('INVARIANT: still logs the UN-redacted error (observability preserved)', () => {
+    const err = driverError();
+    const res = createRes();
+
+    handleEndpointError(res as never, err);
+
+    expect(mockBuildCentralErrorLog).toHaveBeenCalledTimes(1);
+    // The IDENTICAL error instance — not a copy, not a redacted clone.
+    expect(mockBuildCentralErrorLog).toHaveBeenCalledWith(err);
+
+    expect(mockLogToAxiom).toHaveBeenCalledTimes(1);
+    const [payload] = mockLogToAxiom.mock.calls[0] as [Record<string, unknown>];
+    expect(payload.source).toBe('handleEndpointError');
+    expect(
+      String(payload.message),
+      'the LOG must keep the un-redacted driver text even though the RESPONSE drops it'
+    ).toContain(`${LEAKED_TABLE}.${LEAKED_COLUMN}`);
+    expect(String(payload.message)).toContain(`prisma.${LEAKED_MODEL}.${LEAKED_METHOD}()`);
+  });
+
+  // ── Guard 4: the un-related branches must be untouched ────────────────────
+  it('INVARIANT: a client-abort still short-circuits to 499 with no body', () => {
+    const res = createRes();
+    const abort = Object.assign(new Error('aborted'), { name: 'AbortError' });
+
+    handleEndpointError(res as never, abort);
+
+    expect(res._status()).toBe(499);
+    expect(res._json()).toBeUndefined();
+    expect(mockLogToAxiom).not.toHaveBeenCalled();
+  });
+
+  it('INVARIANT: a fault already logged upstream is not double-logged', () => {
+    mockWasServerFaultLogged.mockReturnValue(true);
+    const res = createRes();
+
+    handleEndpointError(res as never, driverError());
+
+    expect(res._status()).toBe(500);
+    expect(mockLogToAxiom).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/utils/__tests__/rest-error-envelope.test.ts
+++ b/src/server/utils/__tests__/rest-error-envelope.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Unit coverage for the envelope BUILDER itself (civitai#3845).
+ *
+ * Why a separate suite from the route/helper ones: at every real emit site the
+ * `message` and `error` fields carry the SAME string (`restErrorBody(code, msg)`
+ * defaults `error` to `msg`), so a route-level assertion cannot tell the two
+ * apart — a mutation that blanks one, swaps them, or wires both to the same
+ * source survives. Here they are given DELIBERATELY DISTINCT values, which is
+ * what makes each field's placement independently observable.
+ */
+
+import {
+  GENERIC_SERVER_ERROR_MESSAGE,
+  REST_ERROR_CODE,
+  restErrorBody,
+} from '~/server/utils/rest-error-envelope';
+
+describe('restErrorBody', () => {
+  it('places DISTINCT `message` and `error` values in their own fields (no aliasing)', () => {
+    const body = restErrorBody(REST_ERROR_CODE.NOT_FOUND, 'message-value', 'error-value');
+
+    // Distinct on purpose: a swap, an alias, or a blanked field all fail here and
+    // are indistinguishable at any real call site (where the two are equal).
+    expect(body.message, '`message` must be the 2nd argument, verbatim').toBe('message-value');
+    expect(body.error, '`error` must be the 3rd argument, verbatim').toBe('error-value');
+    expect(body.code, '`code` must be the 1st argument, verbatim').toBe('NOT_FOUND');
+  });
+
+  it('defaults `error` to `message` — the retained-legacy-value rule', () => {
+    const body = restErrorBody(REST_ERROR_CODE.NOT_FOUND, 'App not found');
+
+    // The shipped Go CLI renders `error` IN PREFERENCE to `message`, so an empty
+    // or omitted `error` blanks every CLI-visible error string. Assert the VALUE,
+    // never mere key presence.
+    expect(body.error, '`error` must default to the message, not to empty/undefined').toBe(
+      'App not found'
+    );
+    expect(body.message).toBe('App not found');
+  });
+
+  it('accepts a NON-STRING `error` (the zod flatten object) while `message` stays a string', () => {
+    const flattened = { formErrors: [], fieldErrors: { slug: ['Required'] } };
+    const body = restErrorBody(REST_ERROR_CODE.BAD_REQUEST, 'Invalid slug', flattened);
+
+    // The CLI's `badRequestDetail` special-cases this exact `{formErrors,
+    // fieldErrors}` shape to render per-field errors; retyping it to a string
+    // silently degrades every 400 the CLI prints.
+    expect(body.error, '`error` must carry the flatten OBJECT through unchanged').toEqual(
+      flattened
+    );
+    expect(typeof body.message, '`message` must remain a string for the CLI decoder').toBe(
+      'string'
+    );
+  });
+
+  it('emits EXACTLY the three contract keys — nothing more', () => {
+    const body = restErrorBody(REST_ERROR_CODE.INTERNAL_SERVER_ERROR, GENERIC_SERVER_ERROR_MESSAGE);
+
+    expect(Object.keys(body).sort(), 'the envelope is exactly {code, error, message}').toEqual([
+      'code',
+      'error',
+      'message',
+    ]);
+  });
+
+  it('the generic 500 text discloses NOTHING about the failure', () => {
+    // Not a tautology on the constant's spelling: this asserts the PROPERTY the
+    // constant exists for — no driver/table/column/stack vocabulary — so a future
+    // edit that makes it "helpfully" specific fails here.
+    for (const token of ['prisma', 'invocation', 'column', 'table', 'sql', 'database', 'stack']) {
+      expect(
+        GENERIC_SERVER_ERROR_MESSAGE.toLowerCase(),
+        `the generic 500 text must not mention ${JSON.stringify(token)}`
+      ).not.toContain(token);
+    }
+  });
+});

--- a/src/server/utils/apps-catalog-rate-limit.ts
+++ b/src/server/utils/apps-catalog-rate-limit.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import type { SessionUser } from '~/types/session';
 import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
+import { REST_ERROR_CODE, restErrorBody } from '~/server/utils/rest-error-envelope';
 
 /**
  * Abuse-control rate limiter for the PUBLIC app-catalog read endpoints
@@ -78,8 +79,11 @@ export async function enforceAppsCatalogRateLimit({
   if (count > RATE_LIMIT.max) {
     const retryAfter = await sysRedis.ttl(rateKey).catch(() => RATE_LIMIT.windowSeconds);
     res.setHeader('Retry-After', String(Math.max(retryAfter, 1)));
+    // Conforms to the shared REST error envelope (civitai#3845) — `code` +
+    // string `message` + the retained `error` key — with the pre-existing
+    // informational fields kept alongside it.
     res.status(429).json({
-      message: 'Rate limit exceeded',
+      ...restErrorBody(REST_ERROR_CODE.TOO_MANY_REQUESTS, 'Rate limit exceeded'),
       retryAfterSeconds: retryAfter,
       limit: RATE_LIMIT.max,
       windowSeconds: RATE_LIMIT.windowSeconds,

--- a/src/server/utils/endpoint-helpers.ts
+++ b/src/server/utils/endpoint-helpers.ts
@@ -39,6 +39,42 @@ function logRestServerFault(e: unknown) {
   );
 }
 
+/**
+ * Is this REST status a SERVER FAULT — i.e. one whose error text is OURS, never a
+ * message written for the caller?
+ *
+ * 🔴 ONE predicate, deliberately governing BOTH sides of `handleEndpointError`:
+ * whether the fault is LOGGED in full, and whether the response body is
+ * GENERICIZED. Keeping them on one rule buys an invariant that is worth more than
+ * either half alone, and that `endpoint-helpers-error-envelope.test.ts` pins over
+ * every 5xx status:
+ *
+ *   the un-redacted text is dropped from the wire EXACTLY when it is preserved in
+ *   the log — so genericizing can never destroy the only copy of a message.
+ *
+ * Two exclusions, both load-bearing:
+ *   - **4xx** is client feedback the caller is meant to read (zod issues, "not
+ *     found", rate-limit hints). Never logged as a fault, never genericized.
+ *   - **503** is the retryable transient-upstream mapping
+ *     (`throwServiceUnavailableError`, the Meili/ClickHouse/orchestrator brownout
+ *     guards). It fires in high-volume waves, so it is excluded from the error
+ *     stream — which means the response is the ONLY copy of its message. Its
+ *     messages are hand-authored retry hints ("… is temporarily overloaded —
+ *     please retry."), and no Prisma code maps to SERVICE_UNAVAILABLE in
+ *     `prismaErrorToTrpcCode`, so the #3845 disclosure class cannot arrive as a
+ *     503. Genericizing it would therefore destroy an actionable hint (the
+ *     shipped Go CLI renders it verbatim on its 503 branch) to redact text that
+ *     is never driver-derived. Kept verbatim, on purpose.
+ *
+ * NB `TIMEOUT` maps to **408**, not a 5xx (`@trpc/server` JSONRPC2_TO_HTTP_CODE),
+ * so it takes the 4xx pass-through. The 5xx codes reachable here are
+ * INTERNAL_SERVER_ERROR (500), NOT_IMPLEMENTED (501), BAD_GATEWAY (502),
+ * SERVICE_UNAVAILABLE (503) and GATEWAY_TIMEOUT (504).
+ */
+function isRestServerFault(status: number): boolean {
+  return status >= 500 && status !== 503;
+}
+
 type AxiomAPIRequest = NextApiRequest & { log: Logger };
 
 // Single chokepoint every endpoint wrapper funnels through (in place of a bare
@@ -251,15 +287,37 @@ export function handleEndpointError(res: NextApiResponse, e: unknown) {
   if (e instanceof TRPCError) {
     const apiError = e as TRPCError;
     const status = getHTTPStatusCodeFromError(apiError);
-    // A TRPCError that maps to a 5xx (INTERNAL_SERVER_ERROR / TIMEOUT) is a genuine
-    // server fault that previously reached the client as a 500 with NOTHING logged
-    // structurally — invisible in `_axiom`. Emit the un-masked cause-walked error
-    // log so it's queryable. Sub-500 (4xx) TRPCErrors are normal client feedback,
-    // and SERVICE_UNAVAILABLE (503) is the retryable transient-upstream mapping
-    // (transient CH/Meili/orchestrator) that fires in high-volume waves — both are
-    // excluded so they don't flood the error stream (mirrors the tRPC onError
-    // early-return for 503).
-    if (status >= 500 && status !== 503) logRestServerFault(apiError);
+    // ── SERVER FAULT (500/501/502/504) — log in full, genericize on the wire ────
+    // A TRPCError that maps to one of these is a genuine server fault that
+    // previously reached the client as a 5xx with NOTHING logged structurally —
+    // invisible in `_axiom`. Emit the un-masked cause-walked error log so it's
+    // queryable. See `isRestServerFault` for why 4xx and 503 are excluded.
+    //
+    // 🔴 civitai#3845 — this branch produces 500s TOO, and its body was the SAME
+    // leak the else-branch below had. `throwDbError` (~310 call sites) turns a
+    // driver error straight into
+    //   `new TRPCError({ code: prismaErrorToTrpcCode[e.code] ?? 'INTERNAL_SERVER_ERROR',
+    //                    message: e.message, cause: e })`
+    // and `P2022` — the exact code from the #3845 incident — maps to
+    // INTERNAL_SERVER_ERROR, so the raw invocation text carrying the TABLE and
+    // COLUMN name arrived here and was served verbatim (the fallback body below
+    // is `{ message: apiError.message }`). Reachable unauthenticated: e.g.
+    // `GET /api/v1/articles/{id}` (a public MixedAuthEndpoint) → `getArticleById`
+    // → `throwDbError`. Genericizing here is what makes "no driver-derived text on
+    // any 500" a property of the HELPER rather than of one branch of it.
+    //
+    // The `code` is deliberately UNIFORM across every genericized 5xx: the HTTP
+    // status already distinguishes 500/501/502/504, and a per-sub-kind code would
+    // hand back a fault-classification oracle that genericizing exists to remove.
+    // The un-redacted error is fully preserved by `logRestServerFault` above —
+    // this genericizes the RESPONSE only, never the LOG.
+    if (isRestServerFault(status)) {
+      logRestServerFault(apiError);
+      return res
+        .status(status)
+        .json(restErrorBody(REST_ERROR_CODE.INTERNAL_SERVER_ERROR, GENERIC_SERVER_ERROR_MESSAGE));
+    }
+    // ── CLIENT FEEDBACK (4xx) + 503 — passed through BYTE-IDENTICALLY ──────────
     // Older Zod-validation TRPCErrors stuff a JSON-encoded issue array into
     // `message`; many newer call sites (incl. `withMeili`'s
     // MeiliCallTimeoutError → TRPCError mapping) pass a plain string. Falling
@@ -285,10 +343,13 @@ export function handleEndpointError(res: NextApiResponse, e: unknown) {
     // from Loki the normal way. safeError keeps it PII-light (primitive fields only).
     logRestServerFault(error);
     // 🔴 civitai#3845 — do NOT put `error.message` (or any other driver-derived
-    // text) in this body. This branch is the 500 chokepoint for 14 PUBLIC REST
-    // routes, so `.message` here is whatever the driver produced. In the #3845
-    // incident that was a raw Prisma invocation carrying the TABLE and COLUMN
-    // name, served to unauthenticated callers on `GET /api/v1/apps/{slug}`:
+    // text) in this body. `handleEndpointError` is the shared 500 chokepoint for
+    // 14 REST routes — 10 on the public `/api/v1` surface, plus 3 `mod/*` and
+    // `user/orchestrator-key`, which are authenticated — and this is ONE of its
+    // two 500-producing branches (the TRPCError branch above is the other, and
+    // had the same leak). `.message` here is whatever the driver produced. In the
+    // #3845 incident that was a raw Prisma invocation carrying the TABLE and
+    // COLUMN name, served to unauthenticated callers on `GET /api/v1/apps/{slug}`:
     //   "Invalid `prisma.appCollaborator.findMany()` invocation: The column
     //    `app_collaborators.app_listing_id` does not exist in the current database."
     // The un-redacted error is still fully preserved by `logRestServerFault`

--- a/src/server/utils/endpoint-helpers.ts
+++ b/src/server/utils/endpoint-helpers.ts
@@ -18,6 +18,11 @@ import { instrumentApiResponse } from '~/server/prom/http-errors';
 import { isClientAbortError } from '~/server/utils/errorHandling';
 import { isDefined } from '~/utils/type-guards';
 import { logToAxiom, buildCentralErrorLog, wasServerFaultLogged } from '~/server/logging/client';
+import {
+  GENERIC_SERVER_ERROR_MESSAGE,
+  REST_ERROR_CODE,
+  restErrorBody,
+} from '~/server/utils/rest-error-envelope';
 
 // Fire-and-forget structured, cause-walked error log for a REST 500 produced by
 // `handleEndpointError`. logToAxiom's stderr write is synchronous (→ Alloy → Loki),
@@ -279,7 +284,20 @@ export function handleEndpointError(res: NextApiResponse, e: unknown) {
     // log (name + message + stack, un-masked cause) so the next one is attributable
     // from Loki the normal way. safeError keeps it PII-light (primitive fields only).
     logRestServerFault(error);
-    return res.status(500).json({ message: 'An unexpected error occurred', error: error.message });
+    // 🔴 civitai#3845 — do NOT put `error.message` (or any other driver-derived
+    // text) in this body. This branch is the 500 chokepoint for 14 PUBLIC REST
+    // routes, so `.message` here is whatever the driver produced. In the #3845
+    // incident that was a raw Prisma invocation carrying the TABLE and COLUMN
+    // name, served to unauthenticated callers on `GET /api/v1/apps/{slug}`:
+    //   "Invalid `prisma.appCollaborator.findMany()` invocation: The column
+    //    `app_collaborators.app_listing_id` does not exist in the current database."
+    // The un-redacted error is still fully preserved by `logRestServerFault`
+    // above (structured, cause-walked, queryable in `_axiom`) — this genericizes
+    // the RESPONSE only, never the LOG. Pinned by
+    // `src/server/utils/__tests__/endpoint-helpers-error-envelope.test.ts`.
+    return res
+      .status(500)
+      .json(restErrorBody(REST_ERROR_CODE.INTERNAL_SERVER_ERROR, GENERIC_SERVER_ERROR_MESSAGE));
   }
 }
 

--- a/src/server/utils/rest-error-envelope.ts
+++ b/src/server/utils/rest-error-envelope.ts
@@ -11,7 +11,12 @@
  * Every non-2xx body carries all three of:
  *   - `code`    — stable, machine-readable discriminator (never on a 2xx)
  *   - `message` — human-readable summary, ALWAYS a string
- *   - `error`   — RETAINED legacy field, value unchanged per status
+ *   - `error`   — RETAINED legacy field. Its KEY and its TYPE are unchanged at
+ *     every status; its VALUE is unchanged at every status EXCEPT a genericized
+ *     5xx, where it stops being the driver-derived text and becomes
+ *     {@link GENERIC_SERVER_ERROR_MESSAGE}. That single value change IS the
+ *     #3845 fix — the shipped CLI renders `error` in preference to `message`, so
+ *     leaving it verbatim would have left the disclosure fully visible.
  *
  * Nothing is removed or retyped, so both shipped consumers keep working:
  *   - the Go CLI (`civitai app view`) decodes `error` as a `json.RawMessage`
@@ -33,9 +38,14 @@
  * vocabulary.
  */
 
+/**
+ * Only codes an emitter in this repo actually uses. Deliberately NOT the full
+ * tRPC vocabulary: an unused member is an unverified claim about the wire (the
+ * 401s on this surface are still bare `{ error: 'Unauthorized' }` from the shared
+ * endpoint wrappers, not this envelope). Add one WITH its emitter.
+ */
 export const REST_ERROR_CODE = {
   BAD_REQUEST: 'BAD_REQUEST',
-  UNAUTHORIZED: 'UNAUTHORIZED',
   NOT_FOUND: 'NOT_FOUND',
   TOO_MANY_REQUESTS: 'TOO_MANY_REQUESTS',
   INTERNAL_SERVER_ERROR: 'INTERNAL_SERVER_ERROR',
@@ -44,9 +54,11 @@ export const REST_ERROR_CODE = {
 export type RestErrorCode = (typeof REST_ERROR_CODE)[keyof typeof REST_ERROR_CODE];
 
 /**
- * The generic 500 text. Deliberately content-free: it is the ONLY thing a
- * non-`TRPCError` throw is allowed to put on the wire (see the comment on
- * `handleEndpointError`'s else-branch).
+ * The generic server-fault text. Deliberately content-free: it is the ONLY thing
+ * a genericized 5xx is allowed to put on the wire, on BOTH of
+ * `handleEndpointError`'s 500-producing branches (the `TRPCError` one — which is
+ * where a `throwDbError`-wrapped driver error arrives — and the else-branch). See
+ * `isRestServerFault` for which statuses that covers and why 503 is excluded.
  */
 export const GENERIC_SERVER_ERROR_MESSAGE = 'An unexpected error occurred';
 

--- a/src/server/utils/rest-error-envelope.ts
+++ b/src/server/utils/rest-error-envelope.ts
@@ -1,0 +1,74 @@
+/**
+ * The ONE error-envelope contract for the public `/api/v1/*` REST surface.
+ *
+ * Motivated by civitai#3845: `GET /api/v1/apps/{slug}` emitted three different
+ * non-2xx body shapes (`{error: <object>}` on 400, `{error: <string>}` on 404,
+ * `{message, error}` on 500, and `{message, …}` on 429 from the rate limiter),
+ * so a client could not branch on body shape alone. This module is the single
+ * place that decides what a non-2xx body looks like.
+ *
+ * ## The contract — ADDITIVE, so it does not break shipped consumers
+ * Every non-2xx body carries all three of:
+ *   - `code`    — stable, machine-readable discriminator (never on a 2xx)
+ *   - `message` — human-readable summary, ALWAYS a string
+ *   - `error`   — RETAINED legacy field, value unchanged per status
+ *
+ * Nothing is removed or retyped, so both shipped consumers keep working:
+ *   - the Go CLI (`civitai app view`) decodes `error` as a `json.RawMessage`
+ *     (tolerant of string OR object) and `message` as a plain `string`, and
+ *     ignores keys it does not know — so `code` is inert for it today and
+ *     available the moment it wants to stop substring-matching error text.
+ *     🔴 Two things would break it, and neither is done here: making `message`
+ *     a non-string (fails the whole envelope unmarshal), and changing the 400's
+ *     `error` away from the zod `.flatten()` object (the CLI special-cases that
+ *     exact shape to render per-field errors).
+ *   - `@civitai/app-sdk` parses error bodies as opaque `unknown`.
+ *
+ * ## Why `code` and not `errorCode`/`type`/`kind`
+ * `{ error, code }` is the existing house shape — see `/api/v1/images`,
+ * `/api/v1/blocks/images` and `/api/v1/users`, the last of which names it "the
+ * /api/v1/images error shape" in its own comment. The VALUES are tRPC error-code
+ * strings for the same reason: those three sites take theirs straight off
+ * `TRPCError.code`, so the two surfaces agree instead of inventing a second
+ * vocabulary.
+ */
+
+export const REST_ERROR_CODE = {
+  BAD_REQUEST: 'BAD_REQUEST',
+  UNAUTHORIZED: 'UNAUTHORIZED',
+  NOT_FOUND: 'NOT_FOUND',
+  TOO_MANY_REQUESTS: 'TOO_MANY_REQUESTS',
+  INTERNAL_SERVER_ERROR: 'INTERNAL_SERVER_ERROR',
+} as const;
+
+export type RestErrorCode = (typeof REST_ERROR_CODE)[keyof typeof REST_ERROR_CODE];
+
+/**
+ * The generic 500 text. Deliberately content-free: it is the ONLY thing a
+ * non-`TRPCError` throw is allowed to put on the wire (see the comment on
+ * `handleEndpointError`'s else-branch).
+ */
+export const GENERIC_SERVER_ERROR_MESSAGE = 'An unexpected error occurred';
+
+export type RestErrorBody = {
+  error: unknown;
+  message: string;
+  code: RestErrorCode;
+};
+
+/**
+ * Build a conformant non-2xx body.
+ *
+ * @param code    the stable discriminator
+ * @param message human-readable summary — MUST stay a string (CLI decoder)
+ * @param error   the legacy `error` value for this status; defaults to
+ *                `message` so string-valued cases stay byte-identical to what
+ *                they emitted before.
+ */
+export function restErrorBody(
+  code: RestErrorCode,
+  message: string,
+  error: unknown = message
+): RestErrorBody {
+  return { error, message, code };
+}

--- a/src/tests/api/v1/apps/apps-error-envelope.test.ts
+++ b/src/tests/api/v1/apps/apps-error-envelope.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * ROUTE-level coverage for civitai#3845 on `GET /api/v1/apps/{slug}`.
+ *
+ * Distinct from the sibling suite `apps.test.ts`, which stubs
+ * `handleEndpointError` wholesale and therefore pins only status codes: this
+ * suite keeps the **REAL** `handleEndpointError` (stubbing only the
+ * `MixedAuthEndpoint` wrapper, which needs a live session/db) so the assertions
+ * below pin the ACTUAL public response bytes an anonymous caller receives —
+ * not a test double's idea of them.
+ *
+ * Two things are pinned:
+ *   1. DISCLOSURE — a driver throw must not put table/column/Prisma text on the
+ *      wire (the #3845 incident).
+ *   2. ENVELOPE — 400 / 404 / 500 all conform to ONE shape carrying a stable
+ *      machine-readable `code`, and a real 200 does NOT carry it.
+ */
+
+const { mockResolveScope, mockDetail, mockRateLimit, mockIsHostForColor, mockLogToAxiom } =
+  vi.hoisted(() => ({
+    mockResolveScope: vi.fn(),
+    mockDetail: vi.fn(),
+    mockRateLimit: vi.fn(),
+    mockIsHostForColor: vi.fn(),
+    mockLogToAxiom: vi.fn().mockResolvedValue(undefined),
+  }));
+
+// Keep the REAL handleEndpointError — that is the whole point of this suite.
+// Only the auth wrapper is stubbed (it would need a live session + db).
+vi.mock('~/server/utils/endpoint-helpers', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  MixedAuthEndpoint: (handler: unknown) => handler,
+}));
+// `endpoint-helpers` imports `getAllServerHosts` from this module, so spread the
+// original rather than replacing it wholesale.
+vi.mock('~/server/utils/server-domain', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  isHostForColor: mockIsHostForColor,
+}));
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: mockLogToAxiom,
+  buildCentralErrorLog: vi.fn((e: unknown) => ({
+    name: (e as Error)?.name,
+    message: (e as Error)?.message,
+  })),
+  wasServerFaultLogged: vi.fn(() => false),
+}));
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  resolveStoreVisibilityScope: mockResolveScope,
+}));
+vi.mock('~/server/services/blocks/app-listing.service', () => ({
+  listAvailableListings: vi.fn(),
+  getListingDetail: mockDetail,
+}));
+vi.mock('~/server/utils/apps-catalog-rate-limit', () => ({
+  enforceAppsCatalogRateLimit: mockRateLimit,
+}));
+
+import detailHandler from '~/pages/api/v1/apps/[slug]';
+
+type Handler = (req: unknown, res: unknown, user: unknown) => Promise<unknown>;
+
+const LEAKED_TABLE = 'app_collaborators';
+const LEAKED_COLUMN = 'app_listing_id';
+const MUST_NOT_DISCLOSE = [
+  LEAKED_TABLE,
+  LEAKED_COLUMN,
+  'appCollaborator',
+  'findMany',
+  'prisma.',
+  'invocation',
+  'does not exist in the current database',
+];
+
+/** Verbatim reproduction of the driver text served in the #3845 incident. */
+function driverError() {
+  return new Error(
+    '\nInvalid `prisma.appCollaborator.findMany()` invocation:\n\n\n' +
+      `The column \`${LEAKED_TABLE}.${LEAKED_COLUMN}\` does not exist in the current database.`
+  );
+}
+
+function createMocks({ query = {} }: { query?: Record<string, string> } = {}) {
+  const req = {
+    method: 'GET',
+    url: '/api/v1/apps/x',
+    query,
+    headers: {},
+    socket: { remoteAddress: '203.0.113.7' },
+    log: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+  };
+  let statusCode = 200;
+  let payload: unknown;
+  let headersSent = false;
+  const res = {
+    status(c: number) {
+      statusCode = c;
+      return res;
+    },
+    json(b: unknown) {
+      payload = b;
+      headersSent = true;
+      return res;
+    },
+    setHeader() {
+      /* noop */
+    },
+    end() {
+      headersSent = true;
+      return res;
+    },
+    get headersSent() {
+      return headersSent;
+    },
+    _status: () => statusCode,
+    _json: () => payload,
+  };
+  return { req, res };
+}
+
+const MOD = { id: 7, isModerator: true };
+
+/**
+ * The envelope contract, asserted STRUCTURALLY (key presence + type of each key
+ * + the discriminator's exact value) — never a substring match on a word some
+ * other response could also spell.
+ */
+function expectErrorEnvelope(body: unknown, label: string, expectedCode: string) {
+  expect(body, `${label}: body must be a non-null JSON object`).toBeTypeOf('object');
+  expect(body, `${label}: body must be a non-null JSON object`).not.toBeNull();
+  const b = body as Record<string, unknown>;
+  expect(b.code, `${label}: must carry the \`code\` discriminator`).toBe(expectedCode);
+  // Must stay a string: the Go CLI decodes `message` into a `Message string`,
+  // and a non-string value fails the whole envelope unmarshal.
+  expect(typeof b.message, `${label}: \`message\` must be a string`).toBe('string');
+  // Retained for backwards compatibility — the shipped CLI prefers `error`.
+  expect(
+    Object.prototype.hasOwnProperty.call(b, 'error'),
+    `${label}: must retain the legacy \`error\` key`
+  ).toBe(true);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRateLimit.mockResolvedValue(false);
+  mockIsHostForColor.mockReturnValue(false);
+  mockResolveScope.mockImplementation(async ({ user }: { user?: { isModerator?: boolean } }) =>
+    user?.isModerator ? 'full' : 'none'
+  );
+  mockDetail.mockResolvedValue({ id: 'al_a', serialId: 1, slug: 'a', kind: 'onsite', name: 'a' });
+});
+
+describe('GET /api/v1/apps/{slug} — error envelope + disclosure', () => {
+  // ── Guard: the #3845 disclosure, through the REAL handler ──────────────────
+  it('a driver throw does NOT disclose table/column/Prisma detail on the wire', async () => {
+    mockDetail.mockRejectedValueOnce(driverError());
+    const { req, res } = createMocks({ query: { slug: 'sensei' } });
+
+    await (detailHandler as unknown as Handler)(req, res, MOD);
+
+    expect(res._status()).toBe(500);
+    const serialized = JSON.stringify(res._json());
+    for (const secret of MUST_NOT_DISCLOSE) {
+      expect(
+        serialized,
+        `#3845: the public 500 body must not disclose ${JSON.stringify(
+          secret
+        )} — full body was ${serialized}`
+      ).not.toContain(secret);
+    }
+  });
+
+  // ── Guard: one envelope across every non-2xx status this route emits ───────
+  it('400, 404 and 500 all conform to ONE envelope carrying the discriminator', async () => {
+    // 400 — invalid/absent slug (zod). `error` stays the zod flatten OBJECT:
+    // the shipped Go CLI special-cases that shape to render field errors.
+    const bad = createMocks({ query: {} });
+    await (detailHandler as unknown as Handler)(bad.req, bad.res, MOD);
+    expect(bad.res._status()).toBe(400);
+    expectErrorEnvelope(bad.res._json(), '400', 'BAD_REQUEST');
+
+    // 404 — out-of-scope caller (the default-closed scope gate).
+    const scoped = createMocks({ query: { slug: 'secret-app' } });
+    await (detailHandler as unknown as Handler)(scoped.req, scoped.res, undefined);
+    expect(scoped.res._status()).toBe(404);
+    expectErrorEnvelope(scoped.res._json(), '404 (scope gate)', 'NOT_FOUND');
+
+    // 404 — the OTHER 404 site: service resolved nothing.
+    mockDetail.mockResolvedValueOnce(null);
+    const absent = createMocks({ query: { slug: 'ghost' } });
+    await (detailHandler as unknown as Handler)(absent.req, absent.res, MOD);
+    expect(absent.res._status()).toBe(404);
+    expectErrorEnvelope(absent.res._json(), '404 (absent listing)', 'NOT_FOUND');
+
+    // 500 — unhandled throw via the shared helper.
+    mockDetail.mockRejectedValueOnce(driverError());
+    const boom = createMocks({ query: { slug: 'sensei' } });
+    await (detailHandler as unknown as Handler)(boom.req, boom.res, MOD);
+    expect(boom.res._status()).toBe(500);
+    expectErrorEnvelope(boom.res._json(), '500', 'INTERNAL_SERVER_ERROR');
+  });
+
+  // ── Positive control: the discriminator actually DISCRIMINATES ─────────────
+  // Asserts BOTH sides in one test so it cannot pass vacuously: a `code` that
+  // were present on every response (or on none) fails here.
+  it('the `code` discriminator is present on an error and ABSENT from a real 200', async () => {
+    // Negative side — a genuine success.
+    const ok = createMocks({ query: { slug: 'my-app' } });
+    await (detailHandler as unknown as Handler)(ok.req, ok.res, MOD);
+    expect(ok.res._status()).toBe(200);
+    const okBody = ok.res._json() as Record<string, unknown>;
+    expect(
+      Object.prototype.hasOwnProperty.call(okBody, 'code'),
+      'a 200 must NOT carry the error discriminator — otherwise it discriminates nothing'
+    ).toBe(false);
+
+    // Positive side — the same key IS present on an error from the same route.
+    const err = createMocks({ query: { slug: 'ghost' } });
+    mockDetail.mockResolvedValueOnce(null);
+    await (detailHandler as unknown as Handler)(err.req, err.res, MOD);
+    expect(err.res._status()).toBe(404);
+    expect(
+      Object.prototype.hasOwnProperty.call(err.res._json() as object, 'code'),
+      'the discriminator must be present on error responses'
+    ).toBe(true);
+  });
+
+  // ── Invariant: the 200 payload is untouched by this change ────────────────
+  it('INVARIANT: a 200 still returns the listing detail unchanged', async () => {
+    const { req, res } = createMocks({ query: { slug: 'my-app' } });
+    await (detailHandler as unknown as Handler)(req, res, MOD);
+    expect(res._status()).toBe(200);
+    expect(res._json()).toEqual({
+      id: 'al_a',
+      serialId: 1,
+      slug: 'a',
+      kind: 'onsite',
+      name: 'a',
+    });
+  });
+});

--- a/src/tests/api/v1/apps/apps-error-envelope.test.ts
+++ b/src/tests/api/v1/apps/apps-error-envelope.test.ts
@@ -38,7 +38,11 @@ vi.mock('~/server/utils/server-domain', async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   isHostForColor: mockIsHostForColor,
 }));
-vi.mock('~/server/logging/client', () => ({
+// Spread the ORIGINAL: `~/server/logging/client` exports 7 symbols and this suite
+// only needs to intercept 3. Replacing it wholesale makes the mock silently stale
+// the moment anything in the import graph reaches for a fourth export.
+vi.mock('~/server/logging/client', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   logToAxiom: mockLogToAxiom,
   buildCentralErrorLog: vi.fn((e: unknown) => ({
     name: (e as Error)?.name,
@@ -57,7 +61,9 @@ vi.mock('~/server/utils/apps-catalog-rate-limit', () => ({
   enforceAppsCatalogRateLimit: mockRateLimit,
 }));
 
+import { TRPCError } from '@trpc/server';
 import detailHandler from '~/pages/api/v1/apps/[slug]';
+import { GENERIC_SERVER_ERROR_MESSAGE as GENERIC_MESSAGE } from '~/server/utils/rest-error-envelope';
 
 type Handler = (req: unknown, res: unknown, user: unknown) => Promise<unknown>;
 
@@ -125,8 +131,26 @@ const MOD = { id: 7, isModerator: true };
  * The envelope contract, asserted STRUCTURALLY (key presence + type of each key
  * + the discriminator's exact value) — never a substring match on a word some
  * other response could also spell.
+ *
+ * 🔴 `error` is asserted BY VALUE, not by key presence. Key presence is the
+ * weakest possible check on the one field the shipped Go CLI renders in
+ * PREFERENCE to `message` (`readError` in `pkg/civitai/read.go` takes `error`
+ * whenever it is non-empty and only falls back to `message`): a build that
+ * blanked `error`, or retyped the 400's away from the zod flatten object the CLI
+ * special-cases, would keep the key and pass a presence check while every
+ * CLI-visible error string went blank or lost its per-field detail.
+ *
+ * `expectedError` is either a literal to match exactly, or the sentinel
+ * `ZOD_FLATTEN` meaning "the `{formErrors, fieldErrors}` object".
  */
-function expectErrorEnvelope(body: unknown, label: string, expectedCode: string) {
+const ZOD_FLATTEN = Symbol('zod-flatten-object');
+
+function expectErrorEnvelope(
+  body: unknown,
+  label: string,
+  expectedCode: string,
+  expectedError: string | typeof ZOD_FLATTEN
+) {
   expect(body, `${label}: body must be a non-null JSON object`).toBeTypeOf('object');
   expect(body, `${label}: body must be a non-null JSON object`).not.toBeNull();
   const b = body as Record<string, unknown>;
@@ -134,11 +158,33 @@ function expectErrorEnvelope(body: unknown, label: string, expectedCode: string)
   // Must stay a string: the Go CLI decodes `message` into a `Message string`,
   // and a non-string value fails the whole envelope unmarshal.
   expect(typeof b.message, `${label}: \`message\` must be a string`).toBe('string');
-  // Retained for backwards compatibility — the shipped CLI prefers `error`.
   expect(
     Object.prototype.hasOwnProperty.call(b, 'error'),
     `${label}: must retain the legacy \`error\` key`
   ).toBe(true);
+
+  if (expectedError === ZOD_FLATTEN) {
+    // The exact shape `badRequestDetail` special-cases to render per-field
+    // errors. A `parsed.error.message` (a STRING) fails the first assertion; a
+    // partially-shaped object fails the next two.
+    expect(
+      typeof b.error,
+      `${label}: \`error\` must be the zod flatten OBJECT the CLI special-cases, not a string`
+    ).toBe('object');
+    const flat = b.error as Record<string, unknown>;
+    expect(Array.isArray(flat?.formErrors), `${label}: \`error.formErrors\` must be an array`).toBe(
+      true
+    );
+    expect(typeof flat?.fieldErrors, `${label}: \`error.fieldErrors\` must be an object`).toBe(
+      'object'
+    );
+  } else {
+    expect(
+      b.error,
+      `${label}: \`error\` must carry the human text VERBATIM — the CLI renders it in ` +
+        `preference to \`message\`, so a blank/renamed value silently empties every CLI error`
+    ).toBe(expectedError);
+  }
 }
 
 beforeEach(() => {
@@ -178,27 +224,73 @@ describe('GET /api/v1/apps/{slug} — error envelope + disclosure', () => {
     const bad = createMocks({ query: {} });
     await (detailHandler as unknown as Handler)(bad.req, bad.res, MOD);
     expect(bad.res._status()).toBe(400);
-    expectErrorEnvelope(bad.res._json(), '400', 'BAD_REQUEST');
+    expectErrorEnvelope(bad.res._json(), '400', 'BAD_REQUEST', ZOD_FLATTEN);
 
     // 404 — out-of-scope caller (the default-closed scope gate).
     const scoped = createMocks({ query: { slug: 'secret-app' } });
     await (detailHandler as unknown as Handler)(scoped.req, scoped.res, undefined);
     expect(scoped.res._status()).toBe(404);
-    expectErrorEnvelope(scoped.res._json(), '404 (scope gate)', 'NOT_FOUND');
+    expectErrorEnvelope(scoped.res._json(), '404 (scope gate)', 'NOT_FOUND', 'App not found');
 
     // 404 — the OTHER 404 site: service resolved nothing.
     mockDetail.mockResolvedValueOnce(null);
     const absent = createMocks({ query: { slug: 'ghost' } });
     await (detailHandler as unknown as Handler)(absent.req, absent.res, MOD);
     expect(absent.res._status()).toBe(404);
-    expectErrorEnvelope(absent.res._json(), '404 (absent listing)', 'NOT_FOUND');
+    expectErrorEnvelope(absent.res._json(), '404 (absent listing)', 'NOT_FOUND', 'App not found');
 
     // 500 — unhandled throw via the shared helper.
     mockDetail.mockRejectedValueOnce(driverError());
     const boom = createMocks({ query: { slug: 'sensei' } });
     await (detailHandler as unknown as Handler)(boom.req, boom.res, MOD);
     expect(boom.res._status()).toBe(500);
-    expectErrorEnvelope(boom.res._json(), '500', 'INTERNAL_SERVER_ERROR');
+    expectErrorEnvelope(boom.res._json(), '500', 'INTERNAL_SERVER_ERROR', GENERIC_MESSAGE);
+  });
+
+  // ── Guard: the OTHER 500 branch, through the SAME real route ───────────────
+  // `getListingDetail` reaches its data through services that funnel driver
+  // failures into `throwDbError` → a `TRPCError`, which takes the helper's
+  // TRPCError branch, not the else-branch the two tests above exercise. Same
+  // route, same public caller, different code path — and it leaked identically
+  // until this round.
+  it('a TRPCError-wrapped driver throw is ALSO generic on the wire (both fields)', async () => {
+    mockDetail.mockRejectedValueOnce(
+      new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: driverError().message,
+        cause: driverError(),
+      })
+    );
+    const { req, res } = createMocks({ query: { slug: 'sensei' } });
+
+    await (detailHandler as unknown as Handler)(req, res, MOD);
+
+    expect(res._status()).toBe(500);
+    const serialized = JSON.stringify(res._json());
+    for (const secret of MUST_NOT_DISCLOSE) {
+      expect(
+        serialized,
+        `#3845 (TRPCError branch, route level): must not disclose ${JSON.stringify(
+          secret
+        )} — full body was ${serialized}`
+      ).not.toContain(secret);
+    }
+    expectErrorEnvelope(res._json(), '500 (TRPCError)', 'INTERNAL_SERVER_ERROR', GENERIC_MESSAGE);
+  });
+
+  // ── Guard: the 4xx pass-through is UNCHANGED on the same route ─────────────
+  it('INVARIANT: a 4xx TRPCError still passes its body through untouched', async () => {
+    mockDetail.mockRejectedValueOnce(
+      new TRPCError({ code: 'NOT_FOUND', message: 'That app was removed' })
+    );
+    const { req, res } = createMocks({ query: { slug: 'gone' } });
+
+    await (detailHandler as unknown as Handler)(req, res, MOD);
+
+    expect(res._status(), 'a 4xx must not be swept into the server-fault branch').toBe(404);
+    expect(res._json(), 'the 4xx body must stay exactly what the helper always produced').toEqual({
+      message: 'That app was removed',
+    });
   });
 
   // ── Positive control: the discriminator actually DISCRIMINATES ─────────────
@@ -224,6 +316,49 @@ describe('GET /api/v1/apps/{slug} — error envelope + disclosure', () => {
       Object.prototype.hasOwnProperty.call(err.res._json() as object, 'code'),
       'the discriminator must be present on error responses'
     ).toBe(true);
+  });
+
+  // ── Guard: nothing on the request path throws OUTSIDE the try ─────────────
+  // The rate limiter and the scope gate used to sit before the `try`, so a throw
+  // from either escaped `handleEndpointError` entirely — Next.js's default 500,
+  // no envelope, no `code`, no fault log. Neither has a KNOWN throw path today
+  // (the limiter catches its own Redis errors; `isFlipt` swallows init/eval
+  // failures), so this pins the STRUCTURE: wherever the throw comes from on this
+  // route, the response is the envelope.
+  it('a throw from the SCOPE GATE still produces the envelope, not an escaped throw', async () => {
+    mockResolveScope.mockRejectedValueOnce(new Error('flipt exploded'));
+    const { req, res } = createMocks({ query: { slug: 'my-app' } });
+
+    await expect(
+      (detailHandler as unknown as Handler)(req, res, MOD),
+      'the handler must not reject — the throw belongs to handleEndpointError'
+    ).resolves.not.toThrow();
+
+    expect(res._status()).toBe(500);
+    expectErrorEnvelope(
+      res._json(),
+      '500 (scope gate throw)',
+      'INTERNAL_SERVER_ERROR',
+      GENERIC_MESSAGE
+    );
+  });
+
+  it('a throw from the RATE LIMITER still produces the envelope, not an escaped throw', async () => {
+    mockRateLimit.mockRejectedValueOnce(new Error('redis exploded'));
+    const { req, res } = createMocks({ query: { slug: 'my-app' } });
+
+    await expect(
+      (detailHandler as unknown as Handler)(req, res, MOD),
+      'the handler must not reject — the throw belongs to handleEndpointError'
+    ).resolves.not.toThrow();
+
+    expect(res._status()).toBe(500);
+    expectErrorEnvelope(
+      res._json(),
+      '500 (limiter throw)',
+      'INTERNAL_SERVER_ERROR',
+      GENERIC_MESSAGE
+    );
   });
 
   // ── Invariant: the 200 payload is untouched by this change ────────────────

--- a/src/tests/api/v1/collections/collections-error-envelope.test.ts
+++ b/src/tests/api/v1/collections/collections-error-envelope.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * SECOND route through the shared `handleEndpointError` (civitai#3845).
+ *
+ * `handleEndpointError` is the 500 chokepoint for 14 REST routes. The apps
+ * suite alone would pin only that one route's behaviour, so this suite drives
+ * the same non-disclosure assertion through an unrelated consumer —
+ * `GET /api/v1/collections/{id}` — which makes the guard a claim about the
+ * HELPER's contract rather than about `/api/v1/apps/{slug}`.
+ *
+ * As in the apps envelope suite, the REAL `handleEndpointError` is kept and only
+ * the `MixedAuthEndpoint` wrapper is stubbed.
+ */
+
+const { mockGetPermissions, mockGetCollectionById, mockRateLimit, mockLogToAxiom } = vi.hoisted(
+  () => ({
+    mockGetPermissions: vi.fn(),
+    mockGetCollectionById: vi.fn(),
+    mockRateLimit: vi.fn(),
+    mockLogToAxiom: vi.fn().mockResolvedValue(undefined),
+  })
+);
+
+vi.mock('~/server/utils/endpoint-helpers', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  MixedAuthEndpoint: (handler: unknown) => handler,
+}));
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: mockLogToAxiom,
+  buildCentralErrorLog: vi.fn((e: unknown) => ({
+    name: (e as Error)?.name,
+    message: (e as Error)?.message,
+  })),
+  wasServerFaultLogged: vi.fn(() => false),
+}));
+vi.mock('~/server/services/collection.service', () => ({
+  getUserCollectionPermissionsById: mockGetPermissions,
+  getCollectionById: mockGetCollectionById,
+}));
+vi.mock('~/server/utils/public-api-rate-limit', () => ({
+  checkPublicApiRateLimit: mockRateLimit,
+}));
+
+import collectionHandler from '~/pages/api/v1/collections/[id]';
+
+type Handler = (req: unknown, res: unknown, user: unknown) => Promise<unknown>;
+
+const LEAKED_TABLE = 'CollectionItem';
+const LEAKED_COLUMN = 'collection_owner_id';
+const MUST_NOT_DISCLOSE = [
+  LEAKED_TABLE,
+  LEAKED_COLUMN,
+  'collectionItem',
+  'findMany',
+  'prisma.',
+  'invocation',
+  'does not exist in the current database',
+];
+
+function driverError() {
+  return new Error(
+    '\nInvalid `prisma.collectionItem.findMany()` invocation:\n\n\n' +
+      `The column \`${LEAKED_TABLE}.${LEAKED_COLUMN}\` does not exist in the current database.`
+  );
+}
+
+function createMocks(query: Record<string, string> = { id: '42' }) {
+  const req = { method: 'GET', url: '/api/v1/collections/42', query, headers: {} };
+  let statusCode = 200;
+  let payload: unknown;
+  let headersSent = false;
+  const res = {
+    status(c: number) {
+      statusCode = c;
+      return res;
+    },
+    json(b: unknown) {
+      payload = b;
+      headersSent = true;
+      return res;
+    },
+    setHeader() {
+      /* noop */
+    },
+    end() {
+      headersSent = true;
+      return res;
+    },
+    get headersSent() {
+      return headersSent;
+    },
+    _status: () => statusCode,
+    _json: () => payload,
+  };
+  return { req, res };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRateLimit.mockResolvedValue({ allowed: true });
+  mockGetPermissions.mockResolvedValue({ read: true });
+});
+
+describe('GET /api/v1/collections/{id} — shared-helper non-disclosure', () => {
+  it('a driver throw does NOT disclose table/column/Prisma detail on the wire', async () => {
+    mockGetCollectionById.mockRejectedValueOnce(driverError());
+    const { req, res } = createMocks();
+
+    await (collectionHandler as unknown as Handler)(req, res, undefined);
+
+    expect(res._status()).toBe(500);
+    const serialized = JSON.stringify(res._json());
+    for (const secret of MUST_NOT_DISCLOSE) {
+      expect(
+        serialized,
+        `#3845: the public 500 body must not disclose ${JSON.stringify(
+          secret
+        )} — full body was ${serialized}`
+      ).not.toContain(secret);
+    }
+  });
+
+  it('the shared 500 envelope carries the `code` discriminator here too', async () => {
+    mockGetCollectionById.mockRejectedValueOnce(driverError());
+    const { req, res } = createMocks();
+
+    await (collectionHandler as unknown as Handler)(req, res, undefined);
+
+    const body = res._json() as Record<string, unknown>;
+    expect(body.code).toBe('INTERNAL_SERVER_ERROR');
+    expect(typeof body.message).toBe('string');
+    expect(typeof body.error).toBe('string');
+  });
+});

--- a/src/tests/api/v1/collections/collections-error-envelope.test.ts
+++ b/src/tests/api/v1/collections/collections-error-envelope.test.ts
@@ -3,11 +3,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 /**
  * SECOND route through the shared `handleEndpointError` (civitai#3845).
  *
- * `handleEndpointError` is the 500 chokepoint for 14 REST routes. The apps
- * suite alone would pin only that one route's behaviour, so this suite drives
- * the same non-disclosure assertion through an unrelated consumer —
- * `GET /api/v1/collections/{id}` — which makes the guard a claim about the
- * HELPER's contract rather than about `/api/v1/apps/{slug}`.
+ * `handleEndpointError` is the 500 chokepoint for 14 REST routes (10 on the
+ * public `/api/v1` surface). The apps suite alone would pin only that one
+ * route's behaviour, so this suite drives the same non-disclosure assertion
+ * through an unrelated consumer — `GET /api/v1/collections/{id}` — which makes
+ * the guard a claim about the HELPER's contract rather than about
+ * `/api/v1/apps/{slug}`. Both of the helper's 500-producing branches are driven
+ * here, since a driver failure in `getCollectionById` normally arrives as a
+ * `throwDbError`-built TRPCError, not as a bare `Error`.
  *
  * As in the apps envelope suite, the REAL `handleEndpointError` is kept and only
  * the `MixedAuthEndpoint` wrapper is stubbed.
@@ -26,7 +29,10 @@ vi.mock('~/server/utils/endpoint-helpers', async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   MixedAuthEndpoint: (handler: unknown) => handler,
 }));
-vi.mock('~/server/logging/client', () => ({
+// Spread the ORIGINAL (7 exports) rather than replacing it with a 3-key object —
+// same reason as the `endpoint-helpers` mock above.
+vi.mock('~/server/logging/client', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   logToAxiom: mockLogToAxiom,
   buildCentralErrorLog: vi.fn((e: unknown) => ({
     name: (e as Error)?.name,
@@ -42,7 +48,9 @@ vi.mock('~/server/utils/public-api-rate-limit', () => ({
   checkPublicApiRateLimit: mockRateLimit,
 }));
 
+import { TRPCError } from '@trpc/server';
 import collectionHandler from '~/pages/api/v1/collections/[id]';
+import { GENERIC_SERVER_ERROR_MESSAGE as GENERIC_MESSAGE } from '~/server/utils/rest-error-envelope';
 
 type Handler = (req: unknown, res: unknown, user: unknown) => Promise<unknown>;
 
@@ -128,8 +136,46 @@ describe('GET /api/v1/collections/{id} — shared-helper non-disclosure', () => 
     await (collectionHandler as unknown as Handler)(req, res, undefined);
 
     const body = res._json() as Record<string, unknown>;
-    expect(body.code).toBe('INTERNAL_SERVER_ERROR');
-    expect(typeof body.message).toBe('string');
-    expect(typeof body.error).toBe('string');
+    expect(body.code, 'the 500 envelope must carry the `code` discriminator').toBe(
+      'INTERNAL_SERVER_ERROR'
+    );
+    expect(body.message, '`message` must be the generic server-fault text').toBe(GENERIC_MESSAGE);
+    // BY VALUE, not by type: the shipped CLI renders `error` in preference to
+    // `message`, so a blanked `error` would keep `typeof === 'string'` and empty
+    // every CLI-visible error string.
+    expect(body.error, '`error` must carry the generic text too — the CLI prefers it').toBe(
+      GENERIC_MESSAGE
+    );
+  });
+
+  // The route's OTHER 500 path: `getCollectionById` funnels driver failures
+  // through `throwDbError`, so they arrive as a TRPCError and take the helper's
+  // other branch. Same disclosure, different branch — this is a second consumer
+  // proving that fix is a property of the HELPER, not of `/api/v1/apps`.
+  it('a TRPCError-wrapped driver throw is generic here too', async () => {
+    mockGetCollectionById.mockRejectedValueOnce(
+      new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: driverError().message,
+        cause: driverError(),
+      })
+    );
+    const { req, res } = createMocks();
+
+    await (collectionHandler as unknown as Handler)(req, res, undefined);
+
+    expect(res._status()).toBe(500);
+    const serialized = JSON.stringify(res._json());
+    for (const secret of MUST_NOT_DISCLOSE) {
+      expect(
+        serialized,
+        `#3845 (TRPCError branch): the public 500 body must not disclose ${JSON.stringify(
+          secret
+        )} — full body was ${serialized}`
+      ).not.toContain(secret);
+    }
+    expect((res._json() as Record<string, unknown>).error, '`error` must be genericized').toBe(
+      GENERIC_MESSAGE
+    );
   });
 });

--- a/src/tests/server/utils/apps-catalog-rate-limit.test.ts
+++ b/src/tests/server/utils/apps-catalog-rate-limit.test.ts
@@ -117,6 +117,21 @@ describe('enforceAppsCatalogRateLimit', () => {
     expect((res as { _headers: () => Record<string, string> })._headers()['Retry-After']).toBeDefined();
   });
 
+  it('the 429 body conforms to the shared app-catalog error envelope (civitai#3845)', async () => {
+    mockMulti.value = 61; // > 60
+    const { req, res } = makeReqRes();
+    await enforceAppsCatalogRateLimit({ req, res, user: MOD });
+    const body = (res as { _json: () => unknown })._json() as Record<string, unknown>;
+    // Structural: the same {code, message, error} contract every other non-2xx
+    // on `GET /api/v1/apps{,/{slug}}` carries, so a client can branch on shape.
+    expect(body.code, '429 must carry the `code` discriminator').toBe('TOO_MANY_REQUESTS');
+    expect(typeof body.message, '429 `message` must be a string').toBe('string');
+    expect(typeof body.error, '429 `error` must be a string (the CLI prefers it)').toBe('string');
+    // The pre-existing informational fields are retained, not replaced.
+    expect(body.limit).toBe(60);
+    expect(body.windowSeconds).toBe(60);
+  });
+
   it('FAILS OPEN (proceeds, no 503) when the limiter exec throws — public-read divergence', async () => {
     mockMulti.throwExec = true;
     const warn = vi.fn();


### PR DESCRIPTION
Fixes #3845.

Two independent error-handling defects reachable via `GET /api/v1/apps/{slug}` — a public, unauthenticated endpoint. Both are independent of the outage that surfaced them (that root cause is already fixed); these would recur on the next unhandled error on this route whatever its cause.

> **Round 2 (commit `3ba1cf5888`) — read this first if you reviewed the earlier version.** An adversarial audit found the first pass fixed only **one of the two** 500-producing branches of `handleEndpointError`, and that the leak stayed **fully live** via the other one — the branch a driver error actually takes in practice. That is fixed here, the completeness claims below are corrected, and the consumer-compat property that had **no** coverage now has it. Details in [§1b](#1b-the-other-500-branch--the-actual-live-path-round-2) and [§4](#round-2-changes-in-full).

---

## 1. The 500 response leaked internal query + schema detail to unauthenticated callers

`handleEndpointError`'s non-`TRPCError` branch put the raw driver text on the wire:

```js
return res.status(500).json({ message: 'An unexpected error occurred', error: error.message });
```

which served anonymous callers the Prisma invocation, the **table** name and the **column** name:

```json
{ "message": "An unexpected error occurred",
  "error": "\nInvalid `prisma.appCollaborator.findMany()` invocation:\n\n\nThe column `app_collaborators.app_listing_id` does not exist in the current database." }
```

The response is now generic. **Observability is unchanged** — `logRestServerFault` on the same branch still receives the identical, un-redacted error object, so `_axiom` attribution is untouched. That is pinned by its own test, precisely so a future "fix" cannot stop the leak by deleting the log.

### 1b. The OTHER 500 branch — the actual live path (round 2)

`handleEndpointError` has **two** branches that produce a 500. The first pass changed only the `else` one, and the earlier version of this PR asserted the `TRPCError` branch "is not reachable for the #3845 leak". **That was wrong**, and it was the more important half:

`throwDbError` (`src/server/utils/errorHandling.ts`, ~310 call sites) turns a driver error straight into

```ts
new TRPCError({
  code: prismaErrorToTrpcCode[error.code] ?? 'INTERNAL_SERVER_ERROR',
  message: error.message,   // ← the raw driver text
  cause: error,
});
```

and **`P2022` — the exact code from the #3845 incident — maps to `INTERNAL_SERVER_ERROR`**. Its generic tail does the same for any `Error`. That TRPCError hit the other branch, whose `JSON.parse(apiError.message)` fails on non-JSON text and falls back to `{ message: <raw driver text> }`, served at a 500. Reachable **unauthenticated** on, among others, `GET /api/v1/articles/{id}` (a public `MixedAuthEndpoint`) → `getArticleById` → `throwDbError`.

Both branches now genericize through **one predicate**, `isRestServerFault(status)`, which governs whether the fault is **logged in full** *and* whether the body is **genericized**. Coupling them buys an invariant worth more than either half alone, asserted per-status over every 5xx:

> the un-redacted text is dropped from the wire **exactly when** it is preserved in the log — so genericizing can never destroy the only copy of a message.

**What this deliberately does NOT change:**

- **4xx passes through byte-identically.** That branch's `JSON.parse` exists because older zod-validation TRPCErrors JSON-encode an issue **array** into `message`, and the shipped Go CLI renders that shape per-field. Proven by **executing** it, not by reading: a zod-issue-array `BAD_REQUEST` still yields the identical parsed array (`toStrictEqual`), a plain-string 4xx the identical `{ message }`, and neither is logged.
- **503 keeps its message verbatim.** Reasoning below.
- **`message` stays a string** at every status (the CLI's envelope unmarshal depends on it).

### Why 503 is excluded — a deliberate decision

503 (`SERVICE_UNAVAILABLE`) is the retryable transient-upstream mapping (`throwServiceUnavailableError`; the Meili / ClickHouse / orchestrator brownout guards). It is genericized **nowhere** — the same predicate leaves it alone on both sides. Four reasons, in order of weight:

1. **It is excluded from the fault log, so the response is the ONLY copy of its message.** On a 500 the un-redacted text goes to `_axiom`, so genericizing *relocates* information. On a 503 nothing is logged, so genericizing would *destroy* it.
2. **Its messages are never driver-derived.** Every 503 message in the repo is a hand-authored retry hint — "Image search is temporarily overloaded — please retry.", "Model search is temporarily overloaded — please retry.", the orchestrator-unavailable constant. And no Prisma code maps to `SERVICE_UNAVAILABLE` in `prismaErrorToTrpcCode`, so the #3845 disclosure class **cannot arrive as a 503**.
3. **The message is functionally load-bearing for a retryable condition.** The Go CLI renders it on its 503 branch; "An unexpected error occurred" would tell a user not to retry something they should retry.
4. **Consumer retry behaviour is unaffected either way.** The CLI's `getWithRetry` keys retry on `isRetriableStatus(status)` and the `Retry-After` header, never on 5xx body text. (It *does* key on body text for a 429 deep-paging cap — that path is untouched.)

`isRestServerFault` states all of this in a comment at the definition, so the exclusion cannot be "cleaned up" as an oddity.

### Which population this fixes — and which it does not

There are two populations, and this PR fixes **A only**.

**A. Via the shared helper — 14 routes, on BOTH of its 500 branches.**
`v1/apps/{index,[slug]}`, `v1/articles/{index,[id]}`, `v1/collections/{index,[id]}`, `v1/models/{index,[id]}`, `v1/blocks/{models,generation-resources}` — **10 on the public `/api/v1` surface** — plus `mod/{delete-user-images,mod-rules,restore-images}` and `user/orchestrator-key`, which are authenticated. (The earlier version of this table said "14 PUBLIC" and "FIXED by the one-line change"; both were wrong — hence round 2.)

**B. ~11 hand-rolled duplicates of the same envelope that do NOT use the helper — NOT fixed here.**
`v1/users/index.ts:81` (`error: err.message` — a verbatim-identical `.message` leak), `v1/creators.ts:69`, `v1/tags.ts:59`, `v1/permissions/check.ts:59`, `v1/vault/{all,get,check-vault,toggle-version}.tsx`, `notification/getDetails.ts:19`, and the retool endpoint wrapper.

**Why A only:** this is a one-rule-one-place problem. The right fix for B is to *route those sites through the helper*, deleting the copy-pasted envelope rather than patching it in 11 places — a refactor across 11 files with its own review and test surface, which does not belong in a security fix for #3845. Leaving them patched-in-place would keep the pattern alive to regrow.

**But B is not benign, and I measured it rather than reasoned about it.** Most B sites pass the whole `Error` object rather than `.message`. A *plain* `Error` serializes to `{}` (non-enumerable props), which is why this has looked safe. A **real Prisma driver error does not**:

```
new Error(...)                        → {"error":{}}
PrismaClientKnownRequestError(...)    → {"error":{"code":"P2022",
                                          "meta":{"column":"app_collaborators.app_listing_id"},
                                          "clientVersion":"6.13.0",
                                          "name":"PrismaClientKnownRequestError"}}
```

So for **exactly the error class in this incident**, the "passes the object" sites leak the column name *and* the Prisma client version. Recommend a follow-up issue to consolidate B onto the helper; I did not open one.

---

## 2. One consistent error envelope, with a stable discriminator

The route emitted three shapes with no discriminator a client could branch on — `error` was sometimes a string and sometimes an object, and `message` appeared only on 5xx. (In fact **four** shapes: the 429 from the shared app-catalog rate limiter had no `error` key at all. That one is included here too.)

### Wire format: nothing removed, nothing retyped

Every non-2xx body on `GET /api/v1/apps{,/{slug}}` now carries all three of:

| key | | |
|---|---|---|
| `code` | **new** | stable machine-readable discriminator; **never present on a 2xx** |
| `message` | now always present | human-readable, **always a string** |
| `error` | **retained** — key and type unchanged at every status | incl. the zod `.flatten()` **object** on 400. Its **value** is unchanged everywhere except a genericized 5xx, where it stops being the driver text — **that value change is the fix**, since the CLI renders `error` in preference to `message` |

Codes are tRPC error-code strings: `BAD_REQUEST` (400), `NOT_FOUND` (404), `TOO_MANY_REQUESTS` (429), `INTERNAL_SERVER_ERROR` (500). The code is **uniform across every genericized 5xx** (500/501/502/504): the HTTP status already distinguishes them, and a per-sub-kind code would hand back the fault-classification oracle that genericizing exists to remove.

**This is not an invented shape.** `{ error, code }` is the existing house convention — `/api/v1/images`, `/api/v1/blocks/images` and `/api/v1/users`, the last of which calls it "the /api/v1/images error shape" in its own comment. The values come off `TRPCError.code` at those sites, so the two surfaces now share one vocabulary. The contract lives in one new file, `src/server/utils/rest-error-envelope.ts`.

### Consumers checked — no break

- **Go CLI `civitai app view`** (`civitai/cli`) — the single decoder on that path is `pkg/civitai/read.go` `readError`, which unmarshals into `struct { Error json.RawMessage; Message string }` and **ignores unknown keys**, so `code` is inert for the shipped CLI today. Three things would break it and none is done here: making `message` a non-string (fails the whole envelope unmarshal); changing the 400's `error` away from the zod flatten object — `badRequestDetail` special-cases that exact `{formErrors, fieldErrors}` shape, with a comment naming this endpoint; and **blanking `error`**, because `readError` takes `error` whenever it is non-empty and only falls back to `message`, so an empty `error` empties every rendered CLI error string. All three are now asserted (see the mutation table — two of them were live survivors before this round).
- **`@civitai/app-sdk`** — does not call `/api/v1/apps` at all; its error paths parse the body as opaque `unknown`. Immune.
- **In-repo** — no consumer reads these error fields; no docs describe the shape.

**No breaking change.** Existing keys and their types are preserved at every status.

---

## 3. Everything on the request path now throws INSIDE the try

On both apps routes the rate limiter and the visibility-scope gate sat **before** the `try`, so a throw from either escaped `handleEndpointError` entirely — Next.js's default 500, no envelope, no `code`, no fault log.

I traced both and **neither has a known throw path today**: `enforceAppsCatalogRateLimit` catches its own Redis errors and fails open (and its remaining `ttl`/`expire` calls each carry a `.catch`), and `isFlipt` swallows init failures behind a circuit breaker and eval failures behind a try, returning `false`. So this closes a **structural** gap, not an observed bug — but "this route always answers with the envelope" should not depend on a dependency's internals staying that defensive. Two tests drive a throw from each and assert the envelope comes back.

---

## Round 2 changes in full

| | |
|---|---|
| **Fix** | Genericize the `TRPCError` branch's 5xx bodies via the shared `isRestServerFault` predicate (§1b) |
| **Fix** | Rate limiter + scope gate moved inside the `try` on `apps/[slug].ts` and `apps/index.ts` (§3) |
| **Claims** | Corrected "14 PUBLIC REST routes" → 14 routes, 10 public; corrected "this branch is *the* 500 chokepoint" → one of two; corrected "the TRPCError branch is not reachable for the #3845 leak" → it is the main path |
| **Claims** | Corrected the envelope doc's "`error` … value unchanged per status" — the 500's value *did* change, and that is the fix |
| **Coverage** | `expectErrorEnvelope` asserted only that the `error` **key** existed. Two mutants survived 18/18 green: `parsed.error.flatten()` → `.message` (the 400 stops being the object the CLI special-cases) and `error: unknown = message` → `= ''` (blanks the field the CLI prefers). `error` is now asserted by **value/shape** at every status |
| **Coverage** | New `rest-error-envelope.test.ts` — at every real call site `message` and `error` carry the **same string**, so no route-level test can tell them apart (fixture collapse). The builder suite gives them **distinct** values, which is what makes each field's placement independently observable |
| **Hygiene** | Three suites replaced the 7-export `~/server/logging/client` with a 3-key object; all now spread `importOriginal` (the pattern those same files already used for other modules) |
| **Hygiene** | Two bare assertions in the collections suite given messages; removed `REST_ERROR_CODE.UNAUTHORIZED`, which had no emitter |

---

## Test coverage

**31 tests** across the five suites this PR touches (12 from round 1, **19 added in round 2**). Red→green matrix for the round-2 additions, measured by reverting the round's source files to `b5705b8d30` and re-running:

| # | test | pre-fix | at HEAD |
|---|---|---|---|
| 1 | helper/TRPCError: does NOT disclose driver/table/column on a 500 | 🔴 RED | ✅ |
| 2 | helper/TRPCError: **SEAM** — a real `P2022` `PrismaClientKnownRequestError` through the real `throwDbError` into the real helper | 🔴 RED | ✅ |
| 3 | helper/TRPCError: envelope carries the generic text in **both** `message` and `error` | 🔴 RED | ✅ |
| 4 | helper/TRPCError: **INVARIANT** every 5xx except 503 is BOTH genericized AND logged — **each half pinned absolutely** (round 3; was a biconditional) | 🔴 RED | ✅ |
| 5 | helper/TRPCError: **INVARIANT** the threshold sits exactly at 500 (499 passes through, 500 does not) | 🔴 RED | ✅ |
| 6 | route (apps): a TRPCError-wrapped driver throw is ALSO generic | 🔴 RED | ✅ |
| 7 | route (collections): same, through a second consumer | 🔴 RED | ✅ |
| 8 | route (apps): a throw from the **scope gate** still produces the envelope | 🔴 RED | ✅ |
| 9 | route (apps): a throw from the **rate limiter** still produces the envelope | 🔴 RED | ✅ |
| 10 | helper/TRPCError: **INVARIANT** still logs the UN-redacted TRPCError | 🟢 green | ✅ |
| 11 | helper/TRPCError: **INVARIANT** a zod-issue-**array** 400 produces the identical parsed body | 🟢 green | ✅ |
| 12 | helper/TRPCError: **INVARIANT** a plain-string 4xx produces the identical `{ message }` | 🟢 green | ✅ |
| 13 | helper/TRPCError: 503 keeps its retry hint verbatim and is still not logged | 🟢 green | ✅ |
| 14 | route (apps): **INVARIANT** a 4xx TRPCError passes its body through untouched | 🟢 green | ✅ |
| 15–19 | `restErrorBody`: distinct `message`/`error` placement · the `error`-defaults-to-`message` rule · a non-string `error` (flatten object) survives while `message` stays a string · exactly the three contract keys · the generic text discloses nothing | 🟢 green | ✅ |

Tests 10–19 are **invariant guards, not regression coverage** — they pin behaviour the fix must preserve (4xx byte-identity, 503, observability, the builder contract) and are green on both sides by construction. They are labeled `INVARIANT:` in the source where applicable and are not counted as proof a bug existed. Tests 1–9 were each observed failing against the pre-fix source with the assertion shown in the suite.

The disclosure guards assert against the **full serialized body string**, not a single field, so a leak that relocates to another key still fails. The envelope guard is **structural** (key presence, type of each key, exact discriminator value, and now the `error` value/shape) — never a substring match on a word another response could spell.

### Mutation check — full battery re-run, 28/28 killed (round 3)

A fix round resets the gate, so the whole battery was re-run (not only mutants for what changed), and again after the round's one Prettier reformat. Each mutant is an exact string replacement into one source file, with the six affected suites re-run and the tree checksummed back to a pristine copy afterwards. **Every mutant died with its own assertion message.**

| mutation | guard(s) killed | assertion that caught it |
|---|---|---|
| M1 restore `error: error.message` on the else-branch 500 | 8 | `the public 500 body must not disclose "app_collaborators"` |
| M2 drop `code` from the else-branch 500 | 5 | `the 500 envelope must carry the \`code\` discriminator` |
| M3 log a *different* error object | **1** | `expected "vi.fn()" to be called with arguments` (identity of the logged error) |
| M3b log the same object but scrub the payload text | 2 | `the LOG must keep the un-redacted driver text even though the RESPONSE drops it` |
| M4 drop `code` from the 400 | **1** | `400: must carry the \`code\` discriminator` |
| M5 drop `code` from the scope-gate 404 only | **1** | `404 (scope gate): must carry the \`code\` discriminator` — proves the 404 assertion is reached, not pre-empted by the 400's |
| M6 add `code` to the **200** | 2 | `a 200 must NOT carry the error discriminator — otherwise it discriminates nothing` |
| M7 drop `code` from the 429 | **1** | `429 must carry the \`code\` discriminator` |
| M8 make `message` a non-string | 11 | each at its own `message must be a string` assertion |
| **X1 blank the `error` default (`= message` → `= ''`)** — *survived the previous round* | 8 | `` `error` must default to the message, not to empty/undefined: expected '' to be 'App not found' `` |
| **X4 400 `error`: `flatten()` → `.message`** — *survived the previous round* | **1** | `` 400: `error` must be the zod flatten OBJECT the CLI special-cases, not a string: expected 'string' to be 'object' `` |
| X5 alias `error` to `message`, ignoring the 3rd argument | 3 | `` `message` must be the 2nd argument, verbatim `` |
| X6 hardcode `code` instead of using the argument | 3 | `` `code` must be the 1st argument, verbatim `` |
| X7 swap the `message` and `error` fields | **1** | `` `message` must be the 2nd argument, verbatim: expected 'error-value' to be 'message-value' `` — only the distinct-value builder test can see this |
| N1 threshold `>= 500` → `> 500` | 7 | `500 is AT the threshold — its message must be genericized` |
| N2 threshold `>= 500` → `>= 400` | 4 | `the 400 body must stay the parsed zod issue array, unchanged` |
| N3 drop the 503 carve-out entirely | **1** | `503 must pass through unchanged` |
| N9 rebind the carve-out to a stale status (503 → 502) | **1** | `503 must pass through unchanged` — the coupling invariant alone cannot see this; the explicit 503 guard can |
| N4 comment the new guard out (text still matches every regex, clause dead) | 7 | `#3845 (TRPCError branch): must not disclose "app_collaborators"` |
| N13 **invert** the guard (`if (!isRestServerFault(status))`) | 11 | 4xx bodies genericized *and* 5xx leaked — both halves fail |
| N5 genericize but do **not** log | 2 | `INTERNAL_SERVER_ERROR (500): the fault must be KEPT in the log — genericizing the response without logging destroys the only copy of the message` |
| **N14 `isRestServerFault` → `status === 500`** — *survived until round 3* | **1** | `NOT_IMPLEMENTED (501): the message must be DROPPED from the wire … which is the #3845 disclosure re-opened on this status` |
| **N15 `isRestServerFault` → exclude 502 as well as 503** — *survived until round 3* | **1** | `BAD_GATEWAY (502): the message must be DROPPED from the wire …` |
| N16 drop only `logRestServerFault(apiError)`, genericizing intact (reachability of the *logged* half) | 2 | `INTERNAL_SERVER_ERROR (500): the fault must be KEPT in the log …` |
| N17 **invert the round-3 guard itself** (`status !== 503` → `status === 503`) | **1** | `INTERNAL_SERVER_ERROR (500): the retry hint must pass through VERBATIM …` |
| N7 genericize into the envelope but leak via `message` | 7 | `#3845 seam: the public 500 body must not disclose …` |
| N8 rebind the response status to a literal 500 | **1** | `NOT_IMPLEMENTED must map to 501: expected 500 to be 501` |
| N12 blank the 4xx `{ message }` fallback body | 5 | `the fallback 4xx body must stay exactly \`{ message }\`` |
| T1 move the scope gate back **outside** the try (the pre-round file) | 2 | `promise rejected "Error: flipt exploded" instead of resolving` |

M3/M4/M5/M7/X4/X7/N3/N8/N9 each killed **exactly one** guard, so those guards are reachable and are not dying to a neighbour's check.

### Suite results

- Targeted suites (the 6 this PR touches + the two 503 suites + `retool-endpoint` + `metrics-endpoint-prisma-failure`): **87 tests, all passing**.
- **Full unit project, base vs HEAD, run twice:** `25 failed / 13608 passed` at HEAD vs `25 failed / 13589 passed` at base (`b5705b8d30`) — the **failing sets are byte-identical** (118 identical `FAIL` lines, `diff` clean). All are environment failures in this checkout (an unpopulated `event-engine-common` submodule, a missing `sharp` native binding, DB-backed suites). **Zero introduced; +19 passing.**
- `pnpm typecheck`: **12 errors at base, the same 12 at HEAD** — all in `bitdex-stats.ts` / `image.service.ts`, from the same absent submodule. **Zero introduced.**
- Prettier: **all 8 changed files clean**. ESLint on the same 8: 1 warning, `'z' is defined but never used` in `apps/index.ts` line 1 — **pre-existing on `origin/main`**, left alone to avoid unrelated churn.

---

---

## Round 3 — the 5xx invariant guard was too weak to see a narrowed predicate

Test-only change (`96e6c39f78`); **no source behaviour changed.**

Guard #4 asserted a **biconditional**, `expect(genericized).toBe(logged)`. "Neither
genericized nor logged" satisfies that exactly as well as "both", so it could not see a
**narrowing** of `isRestServerFault`. Measured: mutating the predicate to
`return status === 500;` left the four envelope suites at **30/30 green**, while that
mutant re-opens the #3845 disclosure at **501/502/504** *and* silently stops logging
those faults. Only 500 and 503 were pinned absolutely; 501/502/504 were pinned by nothing.

Each side is now pinned to its expected **value** per status:

```js
expect(genericized, …).toBe(status !== 503);
expect(logged,      …).toBe(status !== 503);
```

That **subsumes** the coupling (both equal the same constant, therefore equal each other)
and additionally fixes *which* statuses are server faults — the thing the biconditional
never constrained. 503 remains the sole carve-out. The test name, its leading comment and
both assertion messages were rewritten to describe what is now asserted.

Both halves have been watched fail **independently**: dropping only
`logRestServerFault(apiError)` (genericizing left intact) fires the `logged` assertion at
500, so it is reachable and not pre-empted by the `genericized` one. Inverting the new
condition to `status === 503` also goes red, so the guard itself has been watched fail.

Full battery re-run over the six affected suites: **28/28 killed**, each with its own
assertion message. Unmutated: **55/55** across those six suites (30/30 over the four
envelope suites). `pnpm typecheck` unchanged at the pre-existing 12 errors, none in this file.

## Deliberately NOT done

- **A request/trace correlation id in the 500 body.** Raised as a gap in review: genericizing removes the caller's only handle on their own failure, so they cannot quote anything back to support. It is a real gap, but it is a **product/design decision for this repo** (which id, which header, whether it is exposed to anonymous callers at all) rather than part of a security fix. Flagging it as a follow-up, not silently shipping a shape.
- **`isMissingTableError` is untouched.** Its refusal of column errors (`app-access.service.ts:276`) is load-bearing: it makes a half-applied migration surface instead of degrading to a silent "no collaborators". Widening it would convert a half-applied schema into a permanent silent zero — strictly worse than the bug being fixed.
- **4xx bodies are unchanged**, including the ones that pass a driver-derived `message` through at, say, a `P2025`→404. Making 4xx generic would break the CLI's zod-issue rendering and is a distinct decision from "no server-fault text on the wire". Called out rather than quietly folded in.
- **The 405 from the shared `MixedAuthEndpoint` wrapper** (`POST /api/v1/apps/foo`) still returns bare `{ error: 'Method not allowed' }`. It is emitted by a wrapper shared well beyond this route, so bringing it into the envelope would change unrelated endpoints.
- **Population B** — see above.
- **The try-scope fix on `src/pages/api/v1/apps/index.ts` is UNTESTED.** §3 moved the rate limiter and scope gate inside the `try` on **both** apps routes, but the two tests that drive a throw from each (`500 (scope gate throw)` / `500 (limiter throw)`) import **only** `~/pages/api/v1/apps/[slug]`. The list route's copy of the same fix therefore has no coverage — mutating it back out is not caught. Tracked as a follow-up; no code changed for it in round 3.
- **The residual 4xx driver-text disclosure.** A driver-derived `message` still reaches the wire on 4xx (e.g. a `P2025`→404 through `throwDbError`), and the comment at `endpoint-helpers.ts` justifying the 4xx exclusion asserts it is client feedback the caller is meant to read — which is true of hand-authored 4xx text but **not** of driver-derived text that arrives at a 4xx. Distinct from #3845's 5xx class and a separate decision (genericizing 4xx would break the CLI's zod-issue rendering). Tracked as a follow-up.
- **A 200 on the LIST route is not pinned against carrying `code`.** Found in round 3: the `a 200 must NOT carry the error discriminator` guard exercises `[slug]` only, so adding `code` to `index.ts`'s 200 body **survives** the battery. The detail route's 200 is guarded. Coverage gap, not a live defect; noted rather than fixed in a test-only round.

## Live probe against the PR preview

Anonymous `curl` against `pr-3850.civitaic.com`, confirming the wire bytes rather than the tests' idea of them:

```
GET /api/v1/apps/<70 chars>   → 400 {"error":{"formErrors":[],"fieldErrors":{"slug":["Too big: expected string to have <=64 characters"]}},"message":"Invalid slug","code":"BAD_REQUEST"}
GET /api/v1/apps?sort=bogus   → 400 {"error":{"formErrors":[],"fieldErrors":{"sort":["Invalid option: expected one of …"]}},"message":"Invalid query","code":"BAD_REQUEST"}
GET /api/v1/apps/<missing>    → 404 {"error":"App not found","message":"App not found","code":"NOT_FOUND"}
GET /api/v1/apps              → 200 {"items":[…],"metadata":{…}}          ← no `code` on a 2xx
POST /api/v1/apps/foo         → 405 {"error":"Method not allowed"}        ← the known-remaining wrapper 405
```

The 400's `error` is confirmed live as the zod `.flatten()` **object** — the one shape the shipped CLI special-cases — so the round-2 `X4` mutant is guarding a property that is real on the wire, not just in a fixture.

## Not verified

- **The 500 genericization has no live probe.** Inducing a genuine driver failure on the preview is not something I can do safely, so "an anonymous `curl` no longer sees the column name" rests on the route-level tests through the real `handleEndpointError` (both branches, plus the real `throwDbError` seam), not on a live 500.
- The 503 carve-out's *consumer* reasoning was read out of the Go CLI's source (`pkg/civitai/read.go`, `retry.go`), not observed against a live 503.
- The claim that `resolveStoreVisibilityScope` / `enforceAppsCatalogRateLimit` have **no** throw path today is from reading every branch of `isFlipt` and the limiter, not from fuzzing them. The fix in §3 is structural precisely because that reading could go stale.

