### PR TITLE
fix(monetization): disclose the version fee UI in steps, and seed no fee behind it

### DIFF
--- a/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
@@ -52,6 +52,9 @@ vi.mock('~/components/UserSettings/hooks', () => ({
   useCurrentUserSettings: () => ({ hideDonationGoals: false }),
   useMutateUserSettings: () => ({ mutate: vi.fn(), isPending: false }),
 }));
+// The paid-access section opens with a DismissibleAlert, whose `useIsClient()` throws rather than
+// defaulting when the provider isn't mounted — unmocked it takes the whole render down.
+vi.mock('~/providers/IsClientProvider', () => ({ useIsClient: () => true }));
 // The description field mounts the whole rich-text editor (tiptap + sticker cosmetics queries), none
 // of which this test drives.
 vi.mock('~/components/RichTextEditor/RichTextEditorComponent', () => ({
@@ -114,9 +117,18 @@ const feeInput = () => page.getByLabelText('Licensing fee (Buzz)');
 
 // A version that already charges, with an affirmation on record — so the disclosure opens straight onto
 // the pricing controls, which is how a creator who already priced this version meets the form.
+// Published with a permanent gate: that is what makes the paid-access section configurable (and so the
+// early-access-loss warning reachable) without an early-access score.
 const chargingVersion = {
   ...(version as object),
+  status: 'Published',
   licensingFee: 2,
+  licensingFeeSettlementCurrency: 'Buzz',
+  paidAccess: {
+    endsAt: null,
+    timeframeDays: null,
+    terms: { download: { price: 5000 } },
+  },
   meta: {
     rightsAffirmation: {
       userId: 1,
@@ -128,6 +140,7 @@ const chargingVersion = {
 } as unknown as React.ComponentProps<typeof ModelVersionUpsertForm>['version'];
 
 function renderChargingForm() {
+  flags.current = { licensingFee: true, earlyAccessModel: true };
   renderWithProviders(
     <ModelVersionUpsertForm model={model} version={chargingVersion} onSubmit={vi.fn()}>
       {() => <button type="submit">Save</button>}
@@ -188,8 +201,9 @@ describe('ModelVersionUpsertForm — monetization disclosure', () => {
   });
 
   // Closing the section on a version that already charges is a removal, and it happens with the priced
-  // controls off screen — so both the warning and the undo have to live outside them.
-  test('warns before removing an existing charge, and puts it back when reopened', async () => {
+  // controls off screen — so the warning, the irreversible-early-access note and the undo all have to live
+  // outside them.
+  test('warns before removing an existing charge, and restores it on request', async () => {
     renderChargingForm();
 
     await expect.element(chargeSwitch()).toBeChecked();
@@ -198,11 +212,55 @@ describe('ModelVersionUpsertForm — monetization disclosure', () => {
 
     await userEvent.click(chargeSwitch());
     expect(feeInput().elements()).toHaveLength(0);
-    await expect.element(page.getByText(/Saving now removes this version/)).toBeInTheDocument();
+    expect(
+      page.getByText(/Saving now removes this version's license fee and paid access/).elements()
+    ).toHaveLength(1);
+    expect(page.getByText(/your payment for early access will be lost/).elements()).toHaveLength(1);
 
-    await userEvent.click(chargeSwitch());
+    await userEvent.click(page.getByRole('button', { name: 'Restore the stored settings' }));
+    await expect.element(chargeSwitch()).toBeChecked();
     await expect.element(feeInput()).toBeInTheDocument();
     expect((feeInput().element() as HTMLInputElement).value).toBe(stored);
+  });
+
+  // The alarm is keyed to the values, not the switch: clearing the fee with the section OPEN loses just as
+  // much, and a switch-position check cannot see it (`hasExistingCharge` forces the section open).
+  test('warns when a stored fee is cleared with the section still open', async () => {
+    renderChargingForm();
+
+    await expect.element(feeInput()).toBeInTheDocument();
+    await userEvent.fill(feeInput(), '0');
+    // Read synchronously right after the edit: the warning is absorbing, so if it isn't here now it is
+    // not coming, and a poll would only turn a one-second failure into a fifteen-second one.
+    expect(page.getByText(/Saving now removes this version/).elements()).toHaveLength(1);
+    // Still open — this is an edit in a labelled field, not a collapse.
+    await expect.element(chargeSwitch()).toBeChecked();
+  });
+
+  // A grandfathered version — priced before the affirmation existed — has to tick the box to save at all.
+  // Clearing that tick on a switch round-trip that changed nothing puts the creator back in front of
+  // "Confirmation required", which is the error this ticket was filed about.
+  test('keeps the affirmation through a switch round-trip on a version that already charges', async () => {
+    renderWithProviders(
+      <ModelVersionUpsertForm
+        model={model}
+        version={
+          { ...(version as object), licensingFee: 2 } as React.ComponentProps<
+            typeof ModelVersionUpsertForm
+          >['version']
+        }
+        onSubmit={vi.fn()}
+      >
+        {() => <button type="submit">Save</button>}
+      </ModelVersionUpsertForm>
+    );
+
+    await userEvent.click(rightsCheckbox());
+    await expect.element(rightsCheckbox()).toBeChecked();
+
+    await userEvent.click(chargeSwitch());
+    await userEvent.click(chargeSwitch());
+    await expect.element(rightsCheckbox()).toBeChecked();
   });
 
   // A pristine edit short-circuits the mutation, so the observable is the form's own onSubmit: it fires

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
@@ -11,7 +11,6 @@ import { renderWithProviders } from '../../../../test/component-setup';
  */
 
 import type * as TrpcModule from '~/utils/trpc';
-import type * as IsClientModule from '~/providers/IsClientProvider';
 
 const mutateAsync = vi.hoisted(() =>
   vi.fn(async (input: unknown) => ({ id: 456, ...(input as object) }))
@@ -52,13 +51,6 @@ vi.mock('~/components/Buzz/CreatorProgramV2/CreatorProgram.util', () => ({
 vi.mock('~/components/UserSettings/hooks', () => ({
   useCurrentUserSettings: () => ({ hideDonationGoals: false }),
   useMutateUserSettings: () => ({ mutate: vi.fn(), isPending: false }),
-}));
-// The paid-access section opens with a DismissibleAlert, whose `useIsClient()` throws rather than
-// defaulting when the provider isn't mounted — unmocked it takes the whole render down. Spread the real
-// module so the provider export stays intact if anything in the graph starts using it.
-vi.mock('~/providers/IsClientProvider', async (importOriginal) => ({
-  ...(await importOriginal<typeof IsClientModule>()),
-  useIsClient: () => true,
 }));
 // The description field mounts the whole rich-text editor (tiptap + sticker cosmetics queries), none
 // of which this test drives.

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
@@ -33,10 +33,14 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
     }),
   },
 }));
+const flags = vi.hoisted(() => ({
+  // earlyAccessModel off keeps the Paid Access sub-section out of the way for the disclosure tests; the
+  // removal test turns it on, because that section is what holds the irreversible warning.
+  current: { licensingFee: true, earlyAccessModel: false } as Record<string, boolean>,
+}));
+
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
-  // earlyAccessModel off keeps the Paid Access sub-section out of the way; this test is about the
-  // licensing fee, which is the control that used to render unasked.
-  useFeatureFlags: () => ({ licensingFee: true, earlyAccessModel: false }),
+  useFeatureFlags: () => flags.current,
 }));
 vi.mock('~/hooks/useCurrentUser', () => ({
   useCurrentUser: () => ({ id: 1, tier: 'free', isModerator: false, meta: {} }),
@@ -108,8 +112,32 @@ const chargeSwitch = () => page.getByRole('switch', { name: /I want to charge fo
 const rightsCheckbox = () => page.getByRole('checkbox', { name: /I hold the rights to monetize/ });
 const feeInput = () => page.getByLabelText('Licensing fee (Buzz)');
 
+// A version that already charges, with an affirmation on record — so the disclosure opens straight onto
+// the pricing controls, which is how a creator who already priced this version meets the form.
+const chargingVersion = {
+  ...(version as object),
+  licensingFee: 2,
+  meta: {
+    rightsAffirmation: {
+      userId: 1,
+      affirmedAt: '2026-08-01T00:00:00.000Z',
+      version: 1,
+      statement: 'x',
+    },
+  },
+} as unknown as React.ComponentProps<typeof ModelVersionUpsertForm>['version'];
+
+function renderChargingForm() {
+  renderWithProviders(
+    <ModelVersionUpsertForm model={model} version={chargingVersion} onSubmit={vi.fn()}>
+      {() => <button type="submit">Save</button>}
+    </ModelVersionUpsertForm>
+  );
+}
+
 beforeEach(() => {
   mutateAsync.mockClear();
+  flags.current = { licensingFee: true, earlyAccessModel: false };
 });
 
 describe('ModelVersionUpsertForm — monetization disclosure', () => {
@@ -157,6 +185,24 @@ describe('ModelVersionUpsertForm — monetization disclosure', () => {
     await userEvent.click(page.getByRole('button', { name: 'Save' }));
     await vi.waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
     expect(mutateAsync.mock.calls[0][0]).toMatchObject({ licensingFee: 0 });
+  });
+
+  // Closing the section on a version that already charges is a removal, and it happens with the priced
+  // controls off screen — so both the warning and the undo have to live outside them.
+  test('warns before removing an existing charge, and puts it back when reopened', async () => {
+    renderChargingForm();
+
+    await expect.element(chargeSwitch()).toBeChecked();
+    const stored = (feeInput().element() as HTMLInputElement).value;
+    expect(Number(stored)).toBeGreaterThan(0);
+
+    await userEvent.click(chargeSwitch());
+    expect(feeInput().elements()).toHaveLength(0);
+    await expect.element(page.getByText(/Saving now removes this version/)).toBeInTheDocument();
+
+    await userEvent.click(chargeSwitch());
+    await expect.element(feeInput()).toBeInTheDocument();
+    expect((feeInput().element() as HTMLInputElement).value).toBe(stored);
   });
 
   // A pristine edit short-circuits the mutation, so the observable is the form's own onSubmit: it fires

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
@@ -273,6 +273,8 @@ describe('ModelVersionUpsertForm — monetization disclosure', () => {
     expect(
       page.getByRole('button', { name: 'Restore the stored settings' }).elements()
     ).toHaveLength(0);
+    // The reason replaces it, rather than the line simply vanishing.
+    expect(page.getByText(/A private model can't have paid access/).elements()).toHaveLength(1);
   });
 
   // A grandfathered version — priced before the affirmation existed — has to tick the box to save at all.

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
@@ -118,6 +118,8 @@ function renderNewVersionForm(onSubmit: (v?: unknown) => void = vi.fn()) {
 
 const chargeSwitch = () => page.getByRole('switch', { name: /I want to charge for this version/ });
 const accessSwitch = () => page.getByRole('switch', { name: /Charge for access to this version/ });
+const feeSwitch = () =>
+  page.getByRole('switch', { name: /Charge a fee to generate with this version/ });
 const rightsCheckbox = () => page.getByRole('checkbox', { name: /I hold the rights to monetize/ });
 const feeInput = () => page.getByLabelText('Licensing fee (Buzz)');
 
@@ -177,6 +179,9 @@ describe('ModelVersionUpsertForm — monetization disclosure', () => {
     expect(feeInput().elements()).toHaveLength(0);
 
     await userEvent.click(rightsCheckbox());
+    // Each way to charge has its own opt-in: the fee editor waits on its own switch.
+    expect(feeInput().elements()).toHaveLength(0);
+    await userEvent.click(feeSwitch());
     await expect.element(feeInput()).toBeInTheDocument();
     // Seeded on reveal — the suggestion is why the field isn't simply blank.
     expect(Number((feeInput().element() as HTMLInputElement).value)).toBeGreaterThan(0);
@@ -187,6 +192,7 @@ describe('ModelVersionUpsertForm — monetization disclosure', () => {
 
     await userEvent.click(chargeSwitch());
     await userEvent.click(rightsCheckbox());
+    await userEvent.click(feeSwitch());
     await expect.element(feeInput()).toBeInTheDocument();
 
     await userEvent.click(chargeSwitch());
@@ -245,6 +251,24 @@ describe('ModelVersionUpsertForm — monetization disclosure', () => {
     expect(page.getByText(/Saving now removes this version/).elements()).toHaveLength(1);
     // Still open — this is an edit in a labelled field, not a collapse.
     await expect.element(chargeSwitch()).toBeChecked();
+  });
+
+  // The fee switch owns the fee the way the access switch owns the gate: closing it takes the value with
+  // it, or the card would hide a charge that still submits.
+  test('closing the fee switch clears the fee it revealed', async () => {
+    renderForm();
+
+    await userEvent.click(chargeSwitch());
+    await userEvent.click(rightsCheckbox());
+    await userEvent.click(feeSwitch());
+    await expect.element(feeInput()).toBeInTheDocument();
+
+    await userEvent.click(feeSwitch());
+    expect(feeInput().elements()).toHaveLength(0);
+
+    await userEvent.click(page.getByRole('button', { name: 'Save' }));
+    await vi.waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+    expect(mutateAsync.mock.calls[0][0]).toMatchObject({ licensingFee: 0 });
   });
 
   // A private model drops its gate on save (handleSubmit substitutes null), while the form's config still

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
@@ -1,0 +1,172 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../../test/component-setup';
+
+/**
+ * The monetization section is disclosed in three steps — charge intent, then the rights affirmation,
+ * then the pricing controls — and each step must leave nothing behind when it closes. A fee sitting
+ * behind a collapsed editor is both an unasked-for charge and a submit the creator can't unblock,
+ * which is what shipped before (CU 868kq69rv).
+ */
+
+import type * as TrpcModule from '~/utils/trpc';
+
+const mutateAsync = vi.hoisted(() =>
+  vi.fn(async (input: unknown) => ({ id: 456, ...(input as object) }))
+);
+
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcModule>()),
+  trpc: {
+    modelVersion: {
+      getLicensingRoots: { useQuery: () => ({ data: undefined }) },
+      getUserEarlyAccessVersions: { useQuery: () => ({ data: [] }) },
+      upsert: { useMutation: () => ({ mutateAsync, isPending: false }) },
+    },
+    useUtils: () => ({
+      modelVersion: {
+        getById: { invalidate: vi.fn() },
+        getByIdForEdit: { invalidate: vi.fn() },
+      },
+      model: { getById: { invalidate: vi.fn() } },
+    }),
+  },
+}));
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  // earlyAccessModel off keeps the Paid Access sub-section out of the way; this test is about the
+  // licensing fee, which is the control that used to render unasked.
+  useFeatureFlags: () => ({ licensingFee: true, earlyAccessModel: false }),
+}));
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ id: 1, tier: 'free', isModerator: false, meta: {} }),
+}));
+vi.mock('~/components/Buzz/CreatorProgramV2/CreatorProgram.util', () => ({
+  useCreatorProgramRequirements: () => ({ requirements: undefined }),
+}));
+vi.mock('~/components/UserSettings/hooks', () => ({
+  useCurrentUserSettings: () => ({ hideDonationGoals: false }),
+  useMutateUserSettings: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+// The description field mounts the whole rich-text editor (tiptap + sticker cosmetics queries), none
+// of which this test drives.
+vi.mock('~/components/RichTextEditor/RichTextEditorComponent', () => ({
+  RichTextEditor: () => <div data-testid="rte" />,
+  default: () => <div data-testid="rte" />,
+}));
+
+import { ModelVersionUpsertForm } from '~/components/Resource/Forms/ModelVersionUpsertForm';
+
+const model = {
+  id: 123,
+  name: 'Test model',
+  type: 'LORA',
+  status: 'Draft',
+  availability: 'Public',
+  nsfw: false,
+  poi: false,
+  user: { id: 1 },
+} as unknown as React.ComponentProps<typeof ModelVersionUpsertForm>['model'];
+
+const version = {
+  id: 456,
+  modelId: 123,
+  name: 'v1.0',
+  baseModel: 'SDXL 1.0',
+  trainedWords: ['sks'],
+  status: 'Draft',
+  licensingFee: 0,
+  paidAccess: null,
+  donationGoal: null,
+  createdAt: null,
+  meta: {},
+} as unknown as React.ComponentProps<typeof ModelVersionUpsertForm>['version'];
+
+function renderForm(onSubmit: (v?: unknown) => void = vi.fn()) {
+  renderWithProviders(
+    <ModelVersionUpsertForm model={model} version={version} onSubmit={onSubmit}>
+      {() => <button type="submit">Save</button>}
+    </ModelVersionUpsertForm>
+  );
+}
+
+// Koen's case: a first version, where the suggested fee used to be seeded into a visible editor.
+// Hypernetwork so the form doesn't also demand trained words, which would block the save for an
+// unrelated reason and hide the thing under test.
+function renderNewVersionForm(onSubmit: (v?: unknown) => void = vi.fn()) {
+  renderWithProviders(
+    <ModelVersionUpsertForm
+      model={{ ...model, type: 'Hypernetwork' } as typeof model}
+      onSubmit={onSubmit}
+    >
+      {() => <button type="submit">Save</button>}
+    </ModelVersionUpsertForm>
+  );
+}
+
+const chargeSwitch = () => page.getByRole('switch', { name: /I want to charge for this version/ });
+const rightsCheckbox = () => page.getByRole('checkbox', { name: /I hold the rights to monetize/ });
+const feeInput = () => page.getByLabelText('Licensing fee (Buzz)');
+
+beforeEach(() => {
+  mutateAsync.mockClear();
+});
+
+describe('ModelVersionUpsertForm — monetization disclosure', () => {
+  test('opens with the charge switch alone: no affirmation, no fee editor', async () => {
+    renderForm();
+
+    await expect.element(chargeSwitch()).not.toBeChecked();
+    expect(rightsCheckbox().elements()).toHaveLength(0);
+    expect(feeInput().elements()).toHaveLength(0);
+  });
+
+  test('reveals the affirmation first, and the fee editor only after it', async () => {
+    renderForm();
+
+    await userEvent.click(chargeSwitch());
+    await expect.element(rightsCheckbox()).toBeInTheDocument();
+    // The whole point of the ordering: pricing is still not on screen at this step.
+    expect(feeInput().elements()).toHaveLength(0);
+
+    await userEvent.click(rightsCheckbox());
+    await expect.element(feeInput()).toBeInTheDocument();
+    // Seeded on reveal — the suggestion is why the field isn't simply blank.
+    expect(Number((feeInput().element() as HTMLInputElement).value)).toBeGreaterThan(0);
+  });
+
+  test('leaves no fee behind when the section is closed again', async () => {
+    renderForm();
+
+    await userEvent.click(chargeSwitch());
+    await userEvent.click(rightsCheckbox());
+    await expect.element(feeInput()).toBeInTheDocument();
+
+    await userEvent.click(chargeSwitch());
+    expect(feeInput().elements()).toHaveLength(0);
+
+    await userEvent.click(page.getByRole('button', { name: 'Save' }));
+    await vi.waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+    expect(mutateAsync.mock.calls[0][0]).toMatchObject({ licensingFee: 0 });
+  });
+
+  test('a first version saves at no charge without the creator touching monetization', async () => {
+    renderNewVersionForm();
+
+    expect(feeInput().elements()).toHaveLength(0);
+    await userEvent.click(page.getByRole('button', { name: 'Save' }));
+    await vi.waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+    expect(mutateAsync.mock.calls[0][0]).toMatchObject({ licensingFee: 0 });
+  });
+
+  // A pristine edit short-circuits the mutation, so the observable is the form's own onSubmit: it fires
+  // only once validation passed, which is what the unasked-for fee used to block.
+  test('saves without ever opening the section', async () => {
+    const onSubmit = vi.fn();
+    renderForm(onSubmit);
+
+    await userEvent.click(page.getByRole('button', { name: 'Save' }));
+    await vi.waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(mutateAsync).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
@@ -261,9 +261,18 @@ describe('ModelVersionUpsertForm — monetization disclosure', () => {
       </ModelVersionUpsertForm>
     );
 
-    await expect
-      .element(page.getByText(/Saving now removes this version's paid access/))
-      .toBeInTheDocument();
+    // Present at first render (no user action), so read it synchronously behind a stable anchor.
+    await expect.element(chargeSwitch()).toBeChecked();
+    expect(page.getByText(/Saving now removes this version's paid access/).elements()).toHaveLength(
+      1
+    );
+    // The warning is doing the work precisely BECAUSE the gate editor isn't on screen for a private
+    // model — without this the test would still pass if that editor came back.
+    expect(accessSwitch().elements()).toHaveLength(0);
+    // And no restore affordance: handleSubmit substitutes null for a private model whatever we write.
+    expect(
+      page.getByRole('button', { name: 'Restore the stored settings' }).elements()
+    ).toHaveLength(0);
   });
 
   // A grandfathered version — priced before the affirmation existed — has to tick the box to save at all.

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
@@ -11,6 +11,7 @@ import { renderWithProviders } from '../../../../test/component-setup';
  */
 
 import type * as TrpcModule from '~/utils/trpc';
+import type * as IsClientModule from '~/providers/IsClientProvider';
 
 const mutateAsync = vi.hoisted(() =>
   vi.fn(async (input: unknown) => ({ id: 456, ...(input as object) }))
@@ -53,8 +54,12 @@ vi.mock('~/components/UserSettings/hooks', () => ({
   useMutateUserSettings: () => ({ mutate: vi.fn(), isPending: false }),
 }));
 // The paid-access section opens with a DismissibleAlert, whose `useIsClient()` throws rather than
-// defaulting when the provider isn't mounted — unmocked it takes the whole render down.
-vi.mock('~/providers/IsClientProvider', () => ({ useIsClient: () => true }));
+// defaulting when the provider isn't mounted — unmocked it takes the whole render down. Spread the real
+// module so the provider export stays intact if anything in the graph starts using it.
+vi.mock('~/providers/IsClientProvider', async (importOriginal) => ({
+  ...(await importOriginal<typeof IsClientModule>()),
+  useIsClient: () => true,
+}));
 // The description field mounts the whole rich-text editor (tiptap + sticker cosmetics queries), none
 // of which this test drives.
 vi.mock('~/components/RichTextEditor/RichTextEditorComponent', () => ({
@@ -112,6 +117,7 @@ function renderNewVersionForm(onSubmit: (v?: unknown) => void = vi.fn()) {
 }
 
 const chargeSwitch = () => page.getByRole('switch', { name: /I want to charge for this version/ });
+const accessSwitch = () => page.getByRole('switch', { name: /Charge for access to this version/ });
 const rightsCheckbox = () => page.getByRole('checkbox', { name: /I hold the rights to monetize/ });
 const feeInput = () => page.getByLabelText('Licensing fee (Buzz)');
 
@@ -221,6 +227,10 @@ describe('ModelVersionUpsertForm — monetization disclosure', () => {
     await expect.element(chargeSwitch()).toBeChecked();
     await expect.element(feeInput()).toBeInTheDocument();
     expect((feeInput().element() as HTMLInputElement).value).toBe(stored);
+    // The gate half of the restore, which the fee assertions above can't see.
+    await expect.element(accessSwitch()).toBeChecked();
+    const price = page.getByLabelText('Price for access').element() as HTMLInputElement;
+    expect(price.value.replace(/\D/g, '')).toBe('5000');
   });
 
   // The alarm is keyed to the values, not the switch: clearing the fee with the section OPEN loses just as
@@ -235,6 +245,25 @@ describe('ModelVersionUpsertForm — monetization disclosure', () => {
     expect(page.getByText(/Saving now removes this version/).elements()).toHaveLength(1);
     // Still open — this is an edit in a labelled field, not a collapse.
     await expect.element(chargeSwitch()).toBeChecked();
+  });
+
+  // A private model drops its gate on save (handleSubmit substitutes null), while the form's config still
+  // reads non-null — so a warning keyed to the raw config is silent on the one save that removes it.
+  test('warns that a private model is about to lose its stored gate', async () => {
+    flags.current = { licensingFee: true, earlyAccessModel: true };
+    renderWithProviders(
+      <ModelVersionUpsertForm
+        model={{ ...model, availability: 'Private' } as typeof model}
+        version={chargingVersion}
+        onSubmit={vi.fn()}
+      >
+        {() => <button type="submit">Save</button>}
+      </ModelVersionUpsertForm>
+    );
+
+    await expect
+      .element(page.getByText(/Saving now removes this version's paid access/))
+      .toBeInTheDocument();
   });
 
   // A grandfathered version — priced before the affirmation existed — has to tick the box to save at all.
@@ -260,7 +289,10 @@ describe('ModelVersionUpsertForm — monetization disclosure', () => {
 
     await userEvent.click(chargeSwitch());
     await userEvent.click(chargeSwitch());
-    await expect.element(rightsCheckbox()).toBeChecked();
+    // Synchronous: the tick is absorbing once the section is back, so polling would only stretch a
+    // one-second failure into a fifteen-second one.
+    await expect.element(rightsCheckbox()).toBeInTheDocument();
+    expect((rightsCheckbox().element() as HTMLInputElement).checked).toBe(true);
   });
 
   // A pristine edit short-circuits the mutation, so the observable is the form's own onSubmit: it fires

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -505,6 +505,9 @@ export function ModelVersionUpsertForm({
   // the requirement) keeps them visible, so it can still be edited or turned off.
   const showChargeSettings =
     chargeEnabled && (alreadyAffirmed || rightsAffirmed || hasExistingCharge);
+  // Closing the section on a version that already charges IS the removal, and it happens without the
+  // creator seeing the priced controls at all — so the consequence has to be stated outside them.
+  const removingStoredCharge = hasExistingCharge && !showChargeSettings;
 
   const licensingSourceVersionId = form.watch('licensingSourceVersionId') ?? null;
   const { data: licensingRootsData } = trpc.modelVersion.getLicensingRoots.useQuery(
@@ -565,21 +568,35 @@ export function ModelVersionUpsertForm({
   // Nothing may survive behind a collapsed section: `shouldUnregister` is false, so a hidden value is
   // still submitted, and a fee the creator can no longer see is both a charge they didn't make and (via
   // `requiresRightsAffirmation`) a submit blocked by a control that isn't on screen.
-  //
-  // An ended Early Access window is exempt: that config is locked, and clearing it here would let the
-  // master switch remove what the disabled paid-access switch refuses to.
   const feeSeededRef = useRef(false);
   const clearCharges = () => {
     if ((form.getValues('licensingFee') ?? 0) > 0) {
       form.setValue('licensingFee', 0, { shouldDirty: true });
       setFeeRatio((r) => ({ buzz: 0, images: r.images }));
     }
-    if (!isEarlyAccessOver && form.getValues('paidAccessConfig')) {
+    if (form.getValues('paidAccessConfig')) {
       form.setValue('paidAccessConfig', null, { shouldDirty: true });
       setGenMode(generationModeOf(null));
     }
+    if (form.getValues('licensingFeeSettlementCurrency'))
+      form.setValue('licensingFeeSettlementCurrency', null, { shouldDirty: true });
     if (form.getValues('rightsAffirmed')) form.setValue('rightsAffirmed', false);
-    feeSeededRef.current = false;
+  };
+
+  // Closing the section on a version that already charges is a removal, and it must be undoable from the
+  // UI — nothing else on screen holds the stored price, so without this a stray click on the switch loses
+  // it with no way back short of reloading the page.
+  const restoreStoredCharges = () => {
+    if (hasExistingLicensingFee) applyFeeRatio(feeToRatio(Number(version?.licensingFee ?? 0)));
+    if (version?.paidAccess) {
+      const stored = toFormPaidAccessConfig(version.paidAccess, version.donationGoal);
+      form.setValue('paidAccessConfig', stored, { shouldDirty: true });
+      setGenMode(generationModeOf(stored));
+    }
+    if (version?.licensingFeeSettlementCurrency)
+      form.setValue('licensingFeeSettlementCurrency', version.licensingFeeSettlementCurrency, {
+        shouldDirty: true,
+      });
   };
 
   // Unticking the affirmation withdraws the permission the pricing controls depend on, so it clears them
@@ -592,9 +609,9 @@ export function ModelVersionUpsertForm({
     if (withdrawn && !hasExistingCharge && !alreadyAffirmed) clearCharges();
   }, [rightsAffirmed]);
 
-  // The suggested fee lands when the editor opens, not when the form loads. Re-armed by `clearCharges`,
-  // so re-opening the section suggests again — but a 0 the creator typed while the editor was open is
-  // theirs to keep.
+  // The suggested fee lands when the editor first opens, not when the form loads, and once per version:
+  // re-suggesting on a second visit would re-price a creator who had already set the fee to 0 and closed
+  // the section.
   useEffect(() => {
     if (!showChargeSettings || !showLicensingFeeBlock || feeSeededRef.current) return;
     feeSeededRef.current = true;
@@ -616,9 +633,9 @@ export function ModelVersionUpsertForm({
     if (form.getValues('monetization')) form.setValue('monetization', null);
     if (form.getValues('paidAccessConfig')) form.setValue('paidAccessConfig', null);
     if (form.getValues('useMonetization')) form.setValue('useMonetization', false);
-    if (form.getValues('rightsAffirmed')) form.setValue('rightsAffirmed', false);
-    setChargeEnabled(false);
-    feeSeededRef.current = false;
+    // `chargeEnabled` is deliberately left alone. A non-commercial base model hides the whole section
+    // anyway, and turning the switch off here would mean switching back to a commercial base model shows
+    // a collapsed section with no sign that the version's charges were just cleared.
   }, [isNonCommercial]);
 
   const upsertVersionMutation = trpc.modelVersion.upsert.useMutation({
@@ -1168,9 +1185,29 @@ export function ModelVersionUpsertForm({
                       const checked = e.target.checked;
                       setChargeEnabled(checked);
                       if (!checked) clearCharges();
+                      else if (hasExistingCharge) restoreStoredCharges();
                     }}
                     disabled={isEarlyAccessOver && !!version?.paidAccess}
                   />
+                )}
+                {removingStoredCharge && (
+                  <Stack gap={4} mt="sm">
+                    <Text size="xs" c="red">
+                      Saving now removes this version&apos;s{' '}
+                      {hasExistingLicensingFee && version?.paidAccess
+                        ? 'license fee and paid access'
+                        : hasExistingLicensingFee
+                        ? 'license fee'
+                        : 'paid access'}
+                      . Switch it back on to keep the stored settings.
+                    </Text>
+                    {!!version?.paidAccess && (
+                      <Text size="xs" c="red">
+                        You will not be able to add this model to early access again after removing
+                        it. Also, your payment for early access will be lost.
+                      </Text>
+                    )}
+                  </Stack>
                 )}
                 {(showRightsAffirmation || requiresRightsAffirmation) && (
                   <InputCheckbox

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -511,7 +511,10 @@ export function ModelVersionUpsertForm({
   // instead reduces to `!chargeEnabled` — `hasExistingCharge` forces the `showChargeSettings` OR-arm
   // true — and misses every one of them.
   const removingStoredFee = hasExistingLicensingFee && (currentLicensingFee ?? 0) <= 0;
-  const removingStoredGate = !!version?.paidAccess && !paidAccessConfig;
+  // Read through `gateCharges` — what the submit actually sends — for the same reason it exists: the raw
+  // config survives behind a hidden editor, so a version that went private, or whose usage control can no
+  // longer be gated, drops its gate on save while the config still reads non-null.
+  const removingStoredGate = !!version?.paidAccess && !gateCharges;
   const removingStoredCharge = removingStoredFee || removingStoredGate;
 
   const licensingSourceVersionId = form.watch('licensingSourceVersionId') ?? null;
@@ -1202,7 +1205,9 @@ export function ModelVersionUpsertForm({
                 )}
                 {removingStoredCharge && (
                   <Stack gap={4} mt="sm" align="flex-start">
-                    <Text size="xs" c="red">
+                    {/* Red only when the priced controls are off screen — that's the case the creator
+                        can't see. With them open this is a note about an edit they just made. */}
+                    <Text size="xs" c={showChargeSettings ? 'yellow.5' : 'red'}>
                       Saving now removes this version&apos;s{' '}
                       {removingStoredFee && removingStoredGate
                         ? 'license fee and paid access'

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -414,6 +414,11 @@ export function ModelVersionUpsertForm({
   // collapsed behind the master switch below.
   const hasExistingCharge = !!version?.paidAccess || hasExistingLicensingFee;
   const [chargeEnabled, setChargeEnabled] = useState(hasExistingCharge);
+  // The generation fee gets its own opt-in beside paid access, so each of the two ways to charge opens
+  // its own card. Paid access tracks `paidAccessConfig != null`; the fee has no such object, so it needs
+  // state of its own rather than reading `licensingFee > 0` (which would collapse the card the moment a
+  // creator cleared the field to retype it).
+  const [feeEnabled, setFeeEnabled] = useState(hasExistingLicensingFee);
   const rightsAffirmed = form.watch('rightsAffirmed') ?? false;
   // The fee is edited as a whole-number "buzz per N images" ratio; the stored `licensingFee` stays per-image.
   const [feeRatio, setFeeRatio] = useState(() => feeToRatio(initialLicensingFee));
@@ -510,6 +515,9 @@ export function ModelVersionUpsertForm({
   // model), and those lose exactly as much as closing the section does. Reading the switch position
   // instead reduces to `!chargeEnabled` — `hasExistingCharge` forces the `showChargeSettings` OR-arm
   // true — and misses every one of them.
+  // Step 4 for the fee: its own opt-in, so the fee editor is reached by saying you want to charge per
+  // generation rather than by the section being open at all.
+  const feeEditorOpen = showChargeSettings && showLicensingFeeBlock && feeEnabled;
   const removingStoredFee = hasExistingLicensingFee && (currentLicensingFee ?? 0) <= 0;
   // Read through `gateCharges` — what the submit actually sends — for the same reason it exists: the raw
   // config survives behind a hidden editor, so a version that went private, or whose usage control can no
@@ -582,6 +590,7 @@ export function ModelVersionUpsertForm({
   // `requiresRightsAffirmation`) a submit blocked by a control that isn't on screen.
   const feeSeededRef = useRef(false);
   const clearCharges = () => {
+    setFeeEnabled(false);
     if ((form.getValues('licensingFee') ?? 0) > 0) {
       form.setValue('licensingFee', 0, { shouldDirty: true });
       setFeeRatio((r) => ({ buzz: 0, images: r.images }));
@@ -605,7 +614,10 @@ export function ModelVersionUpsertForm({
   // clear. Re-opens the section too — a restored price behind a collapsed switch is the original bug.
   const restoreStoredCharges = () => {
     setChargeEnabled(true);
-    if (hasExistingLicensingFee) applyFeeRatio(feeToRatio(Number(version?.licensingFee ?? 0)));
+    if (hasExistingLicensingFee) {
+      setFeeEnabled(true);
+      applyFeeRatio(feeToRatio(Number(version?.licensingFee ?? 0)));
+    }
     if (version?.paidAccess) {
       const stored = toFormPaidAccessConfig(version.paidAccess, version.donationGoal);
       form.setValue('paidAccessConfig', stored, { shouldDirty: true });
@@ -631,12 +643,12 @@ export function ModelVersionUpsertForm({
   // re-suggesting on a second visit would re-price a creator who had already set the fee to 0 and closed
   // the section.
   useEffect(() => {
-    if (!showChargeSettings || !showLicensingFeeBlock || feeSeededRef.current) return;
+    if (!feeEditorOpen || feeSeededRef.current) return;
     feeSeededRef.current = true;
     if (hasExistingCharge || (form.getValues('licensingFee') ?? 0) > 0) return;
     const suggestion = suggestedFee({ modelType: model?.type, baseModel });
     if (suggestion > 0) applyFeeRatio(feeToRatio(suggestion));
-  }, [showChargeSettings, showLicensingFeeBlock]);
+  }, [feeEditorOpen]);
 
   // Non-commercial base models can't be monetized. The monetization controls are
   // hidden (shouldUnregister is false, so their values would otherwise persist and
@@ -794,6 +806,7 @@ export function ModelVersionUpsertForm({
       // And for the master switch, for the same reason: `reset` restores the stored fee/gate, so the
       // switch has to follow what was actually restored rather than its mount-time value.
       setChargeEnabled(!!version.paidAccess || Number(version.licensingFee ?? 0) > 0);
+      setFeeEnabled(Number(version.licensingFee ?? 0) > 0);
       feeSeededRef.current = false;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -876,6 +889,9 @@ export function ModelVersionUpsertForm({
     model?.nsfw && baseModel && nsfwRestrictedBaseModels.includes(baseModel as BaseModel);
 
   const canSave = !hasNsfwBaseModelViolation;
+
+  // A card header carrying its own toggle needs to read as a header, not as another row of fields.
+  const cardHeaderBg = colorScheme === 'dark' ? 'dark.6' : 'gray.1';
 
   // A private model, or a usage control that can't be gated, loses its gate on save no matter what the
   // creator does — the submit substitutes null either way. Nothing to offer them, so say why instead.
@@ -1263,9 +1279,7 @@ export function ModelVersionUpsertForm({
                   />
                 )}
                 {showChargeSettings && showPaidAccessInput && (
-                  <Stack gap={0}>
-                    <Divider label="Paid Access Set Up" mb="md" mt="md" />
-
+                  <Stack gap={0} mt="md">
                     <DismissibleAlert
                       id="ea-info"
                       size="sm"
@@ -1321,454 +1335,526 @@ export function ModelVersionUpsertForm({
                         </Text>
                       </Alert>
                     )}
-                    <Alert color="blue" icon={<IconInfoCircle size={18} />} my="sm">
-                      <Text size="xs">
-                        Charge a fee for access to this version — a timed{' '}
-                        <Text span fw={600}>
-                          Early Access
-                        </Text>{' '}
-                        window that becomes free when it ends, or ongoing{' '}
-                        <Text span fw={600}>
-                          Paid Access
-                        </Text>{' '}
-                        that always requires purchase. Buyers unlock download and generation.
-                      </Text>
-                    </Alert>
-                    <Switch
-                      my="sm"
-                      label="Charge for access to this version"
-                      checked={paidAccessConfig !== null}
-                      onChange={(e) =>
-                        form.setValue(
-                          'paidAccessConfig',
-                          e.target.checked
-                            ? {
-                                permanent: !canChooseTimed,
-                                timeframe: EARLY_ACCESS_CONFIG.timeframeValues[0],
-                                accessPrice: 5000,
-                                generationPrice: undefined,
-                                freePreviewGenerations: DEFAULT_GENERATION_TRIAL_LIMIT,
-                                donationGoalEnabled: false,
-                                donationGoal: undefined,
-                              }
-                            : null
-                        )
-                      }
-                      disabled={
-                        isEarlyAccessOver || (atEarlyAccessModelCap && paidAccessConfig === null)
-                      }
-                    />
-                    {paidAccessConfig && (
-                      <Stack>
-                        <Input.Wrapper
-                          label={<Text fw="bold">Access mode</Text>}
-                          description={
-                            paidAccessConfig.permanent
-                              ? 'Always requires purchase — this version never becomes free.'
-                              : 'A timed Early Access window; the version becomes free when it ends.'
-                          }
-                        >
-                          <SegmentedControl
-                            value={paidAccessConfig.permanent ? 'permanent' : 'timed'}
-                            onChange={(value) =>
-                              form.setValue('paidAccessConfig.permanent', value === 'permanent')
-                            }
-                            data={[
-                              {
-                                label: 'Early Access (timed)',
-                                value: 'timed',
-                                // A timed window can't be started after publish (permanent stays available).
-                                disabled: !canChooseTimed,
-                              },
-                              {
-                                label: 'Paid Access (permanent)',
-                                value: 'permanent',
-                              },
-                            ]}
-                            color="blue"
-                            size="xs"
-                            fullWidth
-                            disabled={isEarlyAccessOver}
-                            styles={{
-                              root: {
-                                border: `1px solid ${
-                                  colorScheme === 'dark'
-                                    ? theme.colors.dark[4]
-                                    : theme.colors.gray[4]
-                                }`,
-                                background: 'none',
-                                marginTop: 'calc(var(--mantine-spacing-xs) * 0.5)',
-                              },
-                            }}
-                          />
-                        </Input.Wrapper>
-                        {!paidAccessConfig.permanent && (
-                          <Input.Wrapper
-                            label={
-                              <Group gap="xs">
-                                <Text fw="bold">Early access time frame</Text>
-                                <Popover width={300} withArrow withinPortal shadow="sm">
-                                  <Popover.Target>
-                                    <IconInfoCircle size={16} />
-                                  </Popover.Target>
-                                  <Popover.Dropdown>
-                                    <Stack gap="xs">
-                                      <Text size="sm">
-                                        The amount of resources you can have in early access and for
-                                        how long is determined by actions you&rsquo;ve taken on the
-                                        site. Increase your limits by posting more free models that
-                                        people want, being kind, and generally doing good within the
-                                        community.
-                                      </Text>
-                                    </Stack>
-                                  </Popover.Dropdown>
-                                </Popover>
-                              </Group>
-                            }
-                            description="When the window ends the version becomes free. Up to 30 days at your current Creator Program score."
-                            error={form.formState.errors.paidAccessConfig?.message}
-                          >
-                            <SegmentedControl
-                              onChange={(value) =>
-                                form.setValue('paidAccessConfig.timeframe', parseInt(value, 10))
-                              }
-                              value={
-                                paidAccessConfig?.timeframe?.toString() ??
-                                EARLY_ACCESS_CONFIG.timeframeValues[0]
-                              }
-                              data={earlyAccessUnlockedDays.map((v) => ({
-                                label: `${v} days`,
-                                value: v.toString(),
-                                disabled: maxEarlyAccessValue < v,
-                              }))}
-                              color="blue"
-                              size="xs"
-                              styles={{
-                                root: {
-                                  border: `1px solid ${
-                                    colorScheme === 'dark'
-                                      ? theme.colors.dark[4]
-                                      : theme.colors.gray[4]
-                                  }`,
-                                  background: 'none',
-                                  marginTop: 'calc(var(--mantine-spacing-xs) * 0.5)', // 5px
-                                },
-                              }}
-                              fullWidth
-                              disabled={isEarlyAccessOver}
-                            />
-                            {earlyAccessUnlockedDays.length !==
-                              EARLY_ACCESS_CONFIG.timeframeValues.length && (
-                              <Group wrap="nowrap">
-                                <Text size="xs" c="yellow">
-                                  You will unlock more early access day over time by posting models
-                                  to the site.
-                                </Text>
-                              </Group>
-                            )}
-                            {!canIncreaseEarlyAccess && (
-                              <Text size="xs" c="dimmed" mt="sm">
-                                You cannot increase early access value after a model has been
-                                published
-                              </Text>
-                            )}
-                          </Input.Wrapper>
-                        )}
-                        <Stack mt="sm">
-                          <Card withBorder>
-                            <Card.Section withBorder inheritPadding py="sm">
-                              <Text fw={600} size="sm">
-                                Pricing
-                              </Text>
-                            </Card.Section>
-                            <Card.Section inheritPadding py="sm">
-                              <Stack>
-                                <InputNumber
-                                  name="paidAccessConfig.accessPrice"
-                                  label="Price for access"
-                                  description={
-                                    isGenOnly
-                                      ? 'What buyers pay to generate with this version on-site.'
-                                      : 'Buyers unlock download + generation.'
-                                  }
-                                  min={100}
-                                  max={accessPriceMax}
-                                  step={100}
-                                  leftSection={<CurrencyIcon currency="BUZZ" size={16} />}
-                                  withAsterisk
-                                  disabled={isEarlyAccessOver}
-                                />
-                                {(paidAccessConfig?.accessPrice ?? 0) > paidAccessCap && (
-                                  <Text size="xs" c="yellow.5">
-                                    This price is above your membership&apos;s{' '}
-                                    {paidAccessCap.toLocaleString()} Buzz cap. You can keep or lower
-                                    it, but not raise it.
-                                  </Text>
-                                )}
-                                {!currentUser?.isModerator && (
-                                  <CapUpsell
-                                    value={paidAccessConfig?.accessPrice}
-                                    cap={limits.access.maxPrice ?? Infinity}
-                                    capTier={feeCapTier}
-                                    capFor={(t) =>
-                                      monetizationLimits({ tier: t, baseModel, permanent: true })
-                                        .access.maxPrice ?? Infinity
+                    <Card withBorder mt="sm">
+                      <Card.Section withBorder inheritPadding py="xs" bg={cardHeaderBg}>
+                        <Group justify="space-between" wrap="nowrap">
+                          <div>
+                            <Text fw={600} size="sm">
+                              Charge for access to this version
+                            </Text>
+                            <Text size="xs" c="dimmed">
+                              Buyers unlock download and generation — for a timed Early Access
+                              window, or ongoing.
+                            </Text>
+                          </div>
+                          <Switch
+                            aria-label="Charge for access to this version"
+                            checked={paidAccessConfig !== null}
+                            onChange={(e) =>
+                              form.setValue(
+                                'paidAccessConfig',
+                                e.target.checked
+                                  ? {
+                                      permanent: !canChooseTimed,
+                                      timeframe: EARLY_ACCESS_CONFIG.timeframeValues[0],
+                                      accessPrice: 5000,
+                                      generationPrice: undefined,
+                                      freePreviewGenerations: DEFAULT_GENERATION_TRIAL_LIMIT,
+                                      donationGoalEnabled: false,
+                                      donationGoal: undefined,
                                     }
-                                    title="Price for access"
+                                  : null
+                              )
+                            }
+                            disabled={
+                              isEarlyAccessOver ||
+                              (atEarlyAccessModelCap && paidAccessConfig === null)
+                            }
+                          />
+                        </Group>
+                      </Card.Section>
+                      {paidAccessConfig && (
+                        <>
+                          <Card.Section inheritPadding py="sm">
+                            <Stack>
+                              <Input.Wrapper
+                                label={
+                                  <Text fw={500} size="sm">
+                                    Access mode
+                                  </Text>
+                                }
+                                description={
+                                  paidAccessConfig.permanent
+                                    ? 'Always requires purchase — this version never becomes free.'
+                                    : 'A timed Early Access window; the version becomes free when it ends.'
+                                }
+                              >
+                                <SegmentedControl
+                                  value={paidAccessConfig.permanent ? 'permanent' : 'timed'}
+                                  onChange={(value) =>
+                                    form.setValue(
+                                      'paidAccessConfig.permanent',
+                                      value === 'permanent'
+                                    )
+                                  }
+                                  data={[
+                                    {
+                                      label: 'Early Access (timed)',
+                                      value: 'timed',
+                                      // A timed window can't be started after publish (permanent stays available).
+                                      disabled: !canChooseTimed,
+                                    },
+                                    {
+                                      label: 'Paid Access (permanent)',
+                                      value: 'permanent',
+                                    },
+                                  ]}
+                                  color="blue"
+                                  size="xs"
+                                  fullWidth
+                                  disabled={isEarlyAccessOver}
+                                  styles={{
+                                    root: {
+                                      border: `1px solid ${
+                                        colorScheme === 'dark'
+                                          ? theme.colors.dark[4]
+                                          : theme.colors.gray[4]
+                                      }`,
+                                      background: 'none',
+                                      marginTop: 'calc(var(--mantine-spacing-xs) * 0.5)',
+                                    },
+                                  }}
+                                />
+                              </Input.Wrapper>
+                              {!paidAccessConfig.permanent && (
+                                <Input.Wrapper
+                                  label={
+                                    <Group gap="xs">
+                                      <Text fw="bold">Early access time frame</Text>
+                                      <Popover width={300} withArrow withinPortal shadow="sm">
+                                        <Popover.Target>
+                                          <IconInfoCircle size={16} />
+                                        </Popover.Target>
+                                        <Popover.Dropdown>
+                                          <Stack gap="xs">
+                                            <Text size="sm">
+                                              The amount of resources you can have in early access
+                                              and for how long is determined by actions you&rsquo;ve
+                                              taken on the site. Increase your limits by posting
+                                              more free models that people want, being kind, and
+                                              generally doing good within the community.
+                                            </Text>
+                                          </Stack>
+                                        </Popover.Dropdown>
+                                      </Popover>
+                                    </Group>
+                                  }
+                                  description="When the window ends the version becomes free. Up to 30 days at your current Creator Program score."
+                                  error={form.formState.errors.paidAccessConfig?.message}
+                                >
+                                  <SegmentedControl
+                                    onChange={(value) =>
+                                      form.setValue(
+                                        'paidAccessConfig.timeframe',
+                                        parseInt(value, 10)
+                                      )
+                                    }
+                                    value={
+                                      paidAccessConfig?.timeframe?.toString() ??
+                                      EARLY_ACCESS_CONFIG.timeframeValues[0]
+                                    }
+                                    data={earlyAccessUnlockedDays.map((v) => ({
+                                      label: `${v} days`,
+                                      value: v.toString(),
+                                      disabled: maxEarlyAccessValue < v,
+                                    }))}
+                                    color="blue"
+                                    size="xs"
+                                    styles={{
+                                      root: {
+                                        border: `1px solid ${
+                                          colorScheme === 'dark'
+                                            ? theme.colors.dark[4]
+                                            : theme.colors.gray[4]
+                                        }`,
+                                        background: 'none',
+                                        marginTop: 'calc(var(--mantine-spacing-xs) * 0.5)', // 5px
+                                      },
+                                    }}
+                                    fullWidth
+                                    disabled={isEarlyAccessOver}
                                   />
-                                )}
-                                {!isGenOnly && (
-                                  <>
-                                    <Radio.Group
-                                      label="Generating on-site"
-                                      value={genMode}
-                                      onChange={(next) => {
-                                        const mode = next as GenerationMode;
-                                        setGenMode(mode);
-                                        // Only `separate` carries a price — the other two must clear it, or a
-                                        // stale value would keep the cheaper tier alive underneath the choice.
-                                        if (mode !== 'separate')
-                                          form.setValue(
-                                            'paidAccessConfig.generationPrice',
-                                            undefined as never
-                                          );
+                                  {earlyAccessUnlockedDays.length !==
+                                    EARLY_ACCESS_CONFIG.timeframeValues.length && (
+                                    <Group wrap="nowrap">
+                                      <Text size="xs" c="yellow">
+                                        You will unlock more early access day over time by posting
+                                        models to the site.
+                                      </Text>
+                                    </Group>
+                                  )}
+                                  {!canIncreaseEarlyAccess && (
+                                    <Text size="xs" c="dimmed" mt="sm">
+                                      You cannot increase early access value after a model has been
+                                      published
+                                    </Text>
+                                  )}
+                                </Input.Wrapper>
+                              )}
+                            </Stack>
+                          </Card.Section>
+                          <Card.Section inheritPadding py="sm" withBorder>
+                            <Stack>
+                              <InputNumber
+                                name="paidAccessConfig.accessPrice"
+                                label="Price for access"
+                                description={
+                                  isGenOnly
+                                    ? 'What buyers pay to generate with this version on-site.'
+                                    : 'Buyers unlock download + generation.'
+                                }
+                                min={100}
+                                max={accessPriceMax}
+                                step={100}
+                                leftSection={<CurrencyIcon currency="BUZZ" size={16} />}
+                                withAsterisk
+                                disabled={isEarlyAccessOver}
+                              />
+                              {(paidAccessConfig?.accessPrice ?? 0) > paidAccessCap && (
+                                <Text size="xs" c="yellow.5">
+                                  This price is above your membership&apos;s{' '}
+                                  {paidAccessCap.toLocaleString()} Buzz cap. You can keep or lower
+                                  it, but not raise it.
+                                </Text>
+                              )}
+                              {!currentUser?.isModerator && (
+                                <CapUpsell
+                                  value={paidAccessConfig?.accessPrice}
+                                  cap={limits.access.maxPrice ?? Infinity}
+                                  capTier={feeCapTier}
+                                  capFor={(t) =>
+                                    monetizationLimits({ tier: t, baseModel, permanent: true })
+                                      .access.maxPrice ?? Infinity
+                                  }
+                                  title="Price for access"
+                                />
+                              )}
+                              {!isGenOnly && (
+                                <>
+                                  <Radio.Group
+                                    label="Generating on-site"
+                                    value={genMode}
+                                    onChange={(next) => {
+                                      const mode = next as GenerationMode;
+                                      setGenMode(mode);
+                                      // Only `separate` carries a price — the other two must clear it, or a
+                                      // stale value would keep the cheaper tier alive underneath the choice.
+                                      if (mode !== 'separate')
                                         form.setValue(
-                                          'paidAccessConfig.freeGeneration',
-                                          mode === 'free'
+                                          'paidAccessConfig.generationPrice',
+                                          undefined as never
                                         );
-                                      }}
-                                    >
-                                      <Stack gap={4} mt={4}>
-                                        <Radio
-                                          value="bundled"
-                                          label="Same as the access price"
-                                          disabled={isEarlyAccessOver}
-                                        />
-                                        <Radio
-                                          value="separate"
-                                          label="A cheaper generation-only price"
-                                          disabled={isEarlyAccessOver}
-                                        />
-                                        <Radio
-                                          value="free"
-                                          label="Free for everyone"
-                                          description="Anyone can generate on-site without buying; only the download is gated. Earn per generation with a licensing fee instead."
-                                          disabled={isEarlyAccessOver}
-                                        />
-                                      </Stack>
-                                    </Radio.Group>
-                                    {genMode === 'separate' && (
-                                      <InputNumber
-                                        name="paidAccessConfig.generationPrice"
-                                        label="Generation-only price"
-                                        description="What buyers pay to generate on-site without unlocking the download. Can't exceed the access price."
-                                        min={50}
-                                        // Grandfather floor, as on the access price — generation is capped
-                                        // per-component and increase-only.
-                                        max={Math.max(
-                                          Math.min(
-                                            paidAccessConfig?.accessPrice ?? paidAccessCap,
-                                            paidAccessCap
-                                          ),
-                                          storedPaidGen?.price ?? 0
-                                        )}
-                                        step={100}
-                                        leftSection={<CurrencyIcon currency="BUZZ" size={16} />}
+                                      form.setValue(
+                                        'paidAccessConfig.freeGeneration',
+                                        mode === 'free'
+                                      );
+                                    }}
+                                  >
+                                    <Stack gap={4} mt={4}>
+                                      <Radio
+                                        value="bundled"
+                                        label="Same as the access price"
                                         disabled={isEarlyAccessOver}
                                       />
-                                    )}
-                                  </>
-                                )}
-                                {/* A free grant has no trial to run out, so there's nothing to sample toward. */}
-                                {!(genMode === 'free' && !isGenOnly) && (
-                                  <InputNumber
-                                    name="paidAccessConfig.freePreviewGenerations"
-                                    label="Free preview generations"
-                                    description={`How many free test generations a user can do before purchasing the ${resourceLabel}.`}
-                                    min={0}
-                                    max={1000}
-                                    disabled={isEarlyAccessOver}
-                                    withAsterisk
-                                  />
-                                )}
-                                <InputSwitch
-                                  name="paidAccessConfig.acceptsBlueBuzz"
-                                  label="Also accept Blue Buzz"
-                                  description={ACCEPTS_BLUE_BUZZ_HINT}
-                                  disabled={isEarlyAccessOver}
-                                />
-                              </Stack>
-                            </Card.Section>
-                          </Card>
-
-                          {!paidAccessConfig.permanent &&
-                            (version?.status !== 'Published' || version?.donationGoal) &&
-                            features.donationGoals && (
-                              <Card withBorder>
-                                <Card.Section withBorder>
-                                  <Group py="sm" px="md" justify="space-between" wrap="nowrap">
-                                    <div>
-                                      <Text fw={500} size="sm">
-                                        Let the community unlock this early
-                                      </Text>
-                                      <Text size="xs">
-                                        If the goal is met before the window ends, early access ends
-                                        immediately and the version becomes free for everyone. After
-                                        the model is published, you cannot change this value.
-                                      </Text>
-                                    </div>
-                                    <InputSwitch
-                                      name="paidAccessConfig.donationGoalEnabled"
-                                      disabled={donationGoalLocked}
-                                      onChange={(e) => {
-                                        if (e.target.checked) {
-                                          form.setValue('paidAccessConfig.donationGoal', 50000);
-                                        } else {
-                                          form.setValue('paidAccessConfig.donationGoal', undefined);
-                                        }
-                                      }}
-                                    />
-                                  </Group>
-                                </Card.Section>
-                                {paidAccessConfig?.donationGoalEnabled && (
-                                  <Card.Section py="sm" px="md">
-                                    <Stack>
-                                      <InputNumber
-                                        name="paidAccessConfig.donationGoal"
-                                        label="Goal amount"
-                                        description="Early access purchases count toward this goal. After publishing, you cannot change this value."
-                                        min={MIN_DONATION_GOAL}
-                                        max={MAX_DONATION_GOAL}
-                                        step={100}
-                                        leftSection={<CurrencyIcon currency="BUZZ" size={16} />}
-                                        disabled={donationGoalLocked}
+                                      <Radio
+                                        value="separate"
+                                        label="A cheaper generation-only price"
+                                        disabled={isEarlyAccessOver}
                                       />
-                                      <Switch
-                                        label="Hide donation goals from public view"
-                                        description="Others won't see the progress bar or collected amount. The goal still works, and you and moderators can still see it. This applies to all of your donation goals."
-                                        checked={hideDonationGoals ?? false}
-                                        onChange={(e) =>
-                                          mutateUserSettings({
-                                            hideDonationGoals: e.target.checked,
-                                          })
-                                        }
-                                        disabled={hideDonationGoalsUpdating}
+                                      <Radio
+                                        value="free"
+                                        label="Free for everyone"
+                                        description="Anyone can generate on-site without buying; only the download is gated. Earn per generation with a licensing fee instead."
+                                        disabled={isEarlyAccessOver}
                                       />
                                     </Stack>
-                                  </Card.Section>
-                                )}
-                              </Card>
-                            )}
-                        </Stack>
+                                  </Radio.Group>
+                                  {genMode === 'separate' && (
+                                    <InputNumber
+                                      name="paidAccessConfig.generationPrice"
+                                      label="Generation-only price"
+                                      description="What buyers pay to generate on-site without unlocking the download. Can't exceed the access price."
+                                      min={50}
+                                      // Grandfather floor, as on the access price — generation is capped
+                                      // per-component and increase-only.
+                                      max={Math.max(
+                                        Math.min(
+                                          paidAccessConfig?.accessPrice ?? paidAccessCap,
+                                          paidAccessCap
+                                        ),
+                                        storedPaidGen?.price ?? 0
+                                      )}
+                                      step={100}
+                                      leftSection={<CurrencyIcon currency="BUZZ" size={16} />}
+                                      disabled={isEarlyAccessOver}
+                                    />
+                                  )}
+                                </>
+                              )}
+                              {/* A free grant has no trial to run out, so there's nothing to sample toward. */}
+                              {!(genMode === 'free' && !isGenOnly) && (
+                                <InputNumber
+                                  name="paidAccessConfig.freePreviewGenerations"
+                                  label="Free preview generations"
+                                  description={`How many free test generations a user can do before purchasing the ${resourceLabel}.`}
+                                  min={0}
+                                  max={1000}
+                                  disabled={isEarlyAccessOver}
+                                  withAsterisk
+                                />
+                              )}
+                              <InputSwitch
+                                name="paidAccessConfig.acceptsBlueBuzz"
+                                label="Also accept Blue Buzz"
+                                description={ACCEPTS_BLUE_BUZZ_HINT}
+                                disabled={isEarlyAccessOver}
+                              />
+                            </Stack>
+                          </Card.Section>
+                        </>
+                      )}
+                    </Card>
+                    {paidAccessConfig && (
+                      <Stack mt="sm">
+                        {!paidAccessConfig.permanent &&
+                          (version?.status !== 'Published' || version?.donationGoal) &&
+                          features.donationGoals && (
+                            <Card withBorder>
+                              <Card.Section withBorder>
+                                <Group py="sm" px="md" justify="space-between" wrap="nowrap">
+                                  <div>
+                                    <Text fw={500} size="sm">
+                                      Let the community unlock this early
+                                    </Text>
+                                    <Text size="xs">
+                                      If the goal is met before the window ends, early access ends
+                                      immediately and the version becomes free for everyone. After
+                                      the model is published, you cannot change this value.
+                                    </Text>
+                                  </div>
+                                  <InputSwitch
+                                    name="paidAccessConfig.donationGoalEnabled"
+                                    disabled={donationGoalLocked}
+                                    onChange={(e) => {
+                                      if (e.target.checked) {
+                                        form.setValue('paidAccessConfig.donationGoal', 50000);
+                                      } else {
+                                        form.setValue('paidAccessConfig.donationGoal', undefined);
+                                      }
+                                    }}
+                                  />
+                                </Group>
+                              </Card.Section>
+                              {paidAccessConfig?.donationGoalEnabled && (
+                                <Card.Section py="sm" px="md">
+                                  <Stack>
+                                    <InputNumber
+                                      name="paidAccessConfig.donationGoal"
+                                      label="Goal amount"
+                                      description="Early access purchases count toward this goal. After publishing, you cannot change this value."
+                                      min={MIN_DONATION_GOAL}
+                                      max={MAX_DONATION_GOAL}
+                                      step={100}
+                                      leftSection={<CurrencyIcon currency="BUZZ" size={16} />}
+                                      disabled={donationGoalLocked}
+                                    />
+                                    <Switch
+                                      label="Hide donation goals from public view"
+                                      description="Others won't see the progress bar or collected amount. The goal still works, and you and moderators can still see it. This applies to all of your donation goals."
+                                      checked={hideDonationGoals ?? false}
+                                      onChange={(e) =>
+                                        mutateUserSettings({
+                                          hideDonationGoals: e.target.checked,
+                                        })
+                                      }
+                                      disabled={hideDonationGoalsUpdating}
+                                    />
+                                  </Stack>
+                                </Card.Section>
+                              )}
+                            </Card>
+                          )}
                       </Stack>
                     )}
-
-                    {showLicensingFeeBlock && <Divider my="md" />}
                   </Stack>
                 )}
                 {showChargeSettings && showLicensingFeeBlock && (
-                  <Stack gap="xs" mt={showPaidAccessInput ? undefined : 'md'}>
-                    <Input.Wrapper
-                      label="License Fee"
-                      description={`Charge for generations using this version, as Buzz per number of generations. If this is a derivative of a base model that already charges a licensing fee, your fee is added on top of it. Set 0 to disable. Your membership allows up to ${licensingFeeCap} Buzz per generation for this model type.`}
-                    >
-                      <Group gap="xs" wrap="nowrap" mt={4}>
-                        <NumberInput
-                          aria-label="Licensing fee (Buzz)"
-                          value={feeRatio.buzz}
-                          onChange={(v) =>
-                            applyFeeRatio({
-                              buzz: typeof v === 'number' ? v : 0,
-                              images: feeRatio.images,
-                            })
-                          }
-                          min={0}
-                          max={feeMaxFor(licensingFeeCeilingLimits, feeRatio.images)}
-                          step={1}
-                          allowDecimal={false}
-                          leftSection={<CurrencyIcon currency="BUZZ" size={16} />}
-                          w={140}
-                        />
-                        <Text size="sm" c="dimmed">
-                          per
-                        </Text>
-                        <Select
-                          aria-label="Number of generations"
-                          value={String(feeRatio.images)}
-                          onChange={(v) => {
-                            const images = Number(v) || DEFAULT_FEE_IMAGES;
-                            // Clamp to the absolute ceiling only, in the RATIO domain: the cap is
-                            // per-image and can be fractional, so `cap * images` would put a decimal
-                            // into a whole-number field the schema rejects. floor() keeps it valid.
-                            applyFeeRatio({
-                              buzz: Math.min(
-                                feeRatio.buzz,
-                                feeMaxFor(licensingFeeCeilingLimits, images)
-                              ),
-                              images,
-                            });
-                          }}
-                          data={feeImageOptions.map((n) => ({
-                            value: String(n),
-                            label: String(n),
-                          }))}
-                          allowDeselect={false}
-                          w={90}
-                        />
-                        <Text size="sm" c="dimmed">
-                          {feeRatio.images === 1 ? 'generation' : 'generations'}
-                        </Text>
-                      </Group>
-                    </Input.Wrapper>
-                    {!currentUser?.isModerator && (
-                      <CapUpsell
-                        value={feeRatio.buzz}
-                        cap={feeMaxFor(limits, feeRatio.images)}
-                        capTier={feeCapTier}
-                        capFor={(t) =>
-                          feeMaxFor(
-                            monetizationLimits({ tier: t, modelType: model?.type, baseModel }),
-                            feeRatio.images
-                          )
-                        }
-                        title="Licensing fee"
-                        expanded={currentLicensingFee > licensingFeeCap}
-                        perLabel={`${feeRatio.images} generation${
-                          feeRatio.images === 1 ? '' : 's'
-                        }`}
-                      />
-                    )}
-                    {currentLicensingFee > licensingFeeCap && (
-                      <Text size="xs" c="yellow.5">
-                        This fee is above your membership&apos;s {licensingFeeCap} Buzz cap for this
-                        model type. You can keep or lower it, but not raise it.
-                      </Text>
-                    )}
-                    {showLicensingFeeSettlementCurrency && (
-                      <InputSelect
-                        name="licensingFeeSettlementCurrency"
-                        label="Settlement Currency"
-                        description="Currency used to pay you out for license fees. Cash settlement is restricted; contact support to enable."
-                        data={[
-                          { value: LicensingFeeSettlementCurrency.Buzz, label: 'Buzz' },
-                          { value: LicensingFeeSettlementCurrency.Cash, label: 'Cash' },
-                        ]}
-                        allowDeselect={false}
-                      />
-                    )}
-                    {currentLicensingFee > 0 && (
-                      <Group gap="xs" wrap="nowrap" align="flex-start">
-                        <IconAlertTriangle
-                          size={14}
-                          className="text-yellow-500"
-                          style={{ flexShrink: 0, marginTop: 2 }}
-                        />
-                        <Text size="xs" c="yellow">
-                          With a license fee set, this version stops earning creator compensation
-                          and tips — you earn through the license fee instead.
-                        </Text>
-                      </Group>
-                    )}
+                  <Stack gap={0} mt="md">
+                    <Card withBorder>
+                      <Card.Section withBorder inheritPadding py="xs" bg={cardHeaderBg}>
+                        <Group justify="space-between" wrap="nowrap">
+                          <div>
+                            <Text fw={600} size="sm">
+                              Charge a fee to generate with this version
+                            </Text>
+                            <Text size="xs" c="dimmed">
+                              Earn Buzz every time someone generates with it, whether or not they
+                              bought access.
+                            </Text>
+                          </div>
+                          <Switch
+                            aria-label="Charge a fee to generate with this version"
+                            checked={feeEnabled}
+                            onChange={(e) => {
+                              const checked = e.target.checked;
+                              setFeeEnabled(checked);
+                              if (!checked && (form.getValues('licensingFee') ?? 0) > 0) {
+                                form.setValue('licensingFee', 0, { shouldDirty: true });
+                                setFeeRatio((r) => ({ buzz: 0, images: r.images }));
+                              }
+                            }}
+                          />
+                        </Group>
+                      </Card.Section>
+                      {feeEditorOpen && (
+                        <Card.Section inheritPadding py="sm">
+                          <Stack gap="xs">
+                            <Input.Wrapper
+                              label={
+                                <Group gap="xs">
+                                  <Text fw={500} size="sm">
+                                    Fee per generation
+                                  </Text>
+                                  <Popover width={320} withArrow withinPortal shadow="sm">
+                                    <Popover.Target>
+                                      <IconInfoCircle size={16} />
+                                    </Popover.Target>
+                                    <Popover.Dropdown>
+                                      <Stack gap="xs">
+                                        <Text size="sm">
+                                          You earn this in Buzz each time someone generates with
+                                          this version on-site, set as Buzz per number of
+                                          generations.
+                                        </Text>
+                                        <Text size="sm">
+                                          If this is a derivative of a base model that already
+                                          charges a licensing fee, yours is added on top of it.
+                                        </Text>
+                                        <Text size="sm">
+                                          Your membership allows up to {licensingFeeCap} Buzz per
+                                          generation for this model type.
+                                        </Text>
+                                      </Stack>
+                                    </Popover.Dropdown>
+                                  </Popover>
+                                </Group>
+                              }
+                            >
+                              <Group gap="xs" wrap="nowrap" mt={4}>
+                                <NumberInput
+                                  aria-label="Licensing fee (Buzz)"
+                                  value={feeRatio.buzz}
+                                  onChange={(v) =>
+                                    applyFeeRatio({
+                                      buzz: typeof v === 'number' ? v : 0,
+                                      images: feeRatio.images,
+                                    })
+                                  }
+                                  min={0}
+                                  max={feeMaxFor(licensingFeeCeilingLimits, feeRatio.images)}
+                                  step={1}
+                                  allowDecimal={false}
+                                  leftSection={<CurrencyIcon currency="BUZZ" size={16} />}
+                                  w={140}
+                                />
+                                <Text size="sm" c="dimmed">
+                                  per
+                                </Text>
+                                <Select
+                                  aria-label="Number of generations"
+                                  value={String(feeRatio.images)}
+                                  onChange={(v) => {
+                                    const images = Number(v) || DEFAULT_FEE_IMAGES;
+                                    // Clamp to the absolute ceiling only, in the RATIO domain: the cap is
+                                    // per-image and can be fractional, so `cap * images` would put a decimal
+                                    // into a whole-number field the schema rejects. floor() keeps it valid.
+                                    applyFeeRatio({
+                                      buzz: Math.min(
+                                        feeRatio.buzz,
+                                        feeMaxFor(licensingFeeCeilingLimits, images)
+                                      ),
+                                      images,
+                                    });
+                                  }}
+                                  data={feeImageOptions.map((n) => ({
+                                    value: String(n),
+                                    label: String(n),
+                                  }))}
+                                  allowDeselect={false}
+                                  w={90}
+                                />
+                                <Text size="sm" c="dimmed">
+                                  {feeRatio.images === 1 ? 'generation' : 'generations'}
+                                </Text>
+                              </Group>
+                            </Input.Wrapper>
+                            {!currentUser?.isModerator && (
+                              <CapUpsell
+                                value={feeRatio.buzz}
+                                cap={feeMaxFor(limits, feeRatio.images)}
+                                capTier={feeCapTier}
+                                capFor={(t) =>
+                                  feeMaxFor(
+                                    monetizationLimits({
+                                      tier: t,
+                                      modelType: model?.type,
+                                      baseModel,
+                                    }),
+                                    feeRatio.images
+                                  )
+                                }
+                                title="Licensing fee"
+                                expanded={currentLicensingFee > licensingFeeCap}
+                                perLabel={`${feeRatio.images} generation${
+                                  feeRatio.images === 1 ? '' : 's'
+                                }`}
+                              />
+                            )}
+                            {currentLicensingFee > licensingFeeCap && (
+                              <Text size="xs" c="yellow.5">
+                                This fee is above your membership&apos;s {licensingFeeCap} Buzz cap
+                                for this model type. You can keep or lower it, but not raise it.
+                              </Text>
+                            )}
+                            {showLicensingFeeSettlementCurrency && (
+                              <InputSelect
+                                name="licensingFeeSettlementCurrency"
+                                label="Settlement Currency"
+                                description="Currency used to pay you out for license fees. Cash settlement is restricted; contact support to enable."
+                                data={[
+                                  { value: LicensingFeeSettlementCurrency.Buzz, label: 'Buzz' },
+                                  { value: LicensingFeeSettlementCurrency.Cash, label: 'Cash' },
+                                ]}
+                                allowDeselect={false}
+                              />
+                            )}
+                            {currentLicensingFee > 0 && (
+                              <Group gap="xs" wrap="nowrap" align="flex-start">
+                                <IconAlertTriangle
+                                  size={14}
+                                  className="text-yellow-500"
+                                  style={{ flexShrink: 0, marginTop: 2 }}
+                                />
+                                <Text size="xs" c="yellow">
+                                  With a license fee set, this version stops earning creator
+                                  compensation and tips — you earn through the license fee instead.
+                                </Text>
+                              </Group>
+                            )}
+                          </Stack>
+                        </Card.Section>
+                      )}
+                    </Card>
                   </Stack>
                 )}
               </Stack>

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -505,9 +505,14 @@ export function ModelVersionUpsertForm({
   // the requirement) keeps them visible, so it can still be edited or turned off.
   const showChargeSettings =
     chargeEnabled && (alreadyAffirmed || rightsAffirmed || hasExistingCharge);
-  // Closing the section on a version that already charges IS the removal, and it happens without the
-  // creator seeing the priced controls at all — so the consequence has to be stated outside them.
-  const removingStoredCharge = hasExistingCharge && !showChargeSettings;
+  // Keyed to the VALUES, not to the switch: a stored charge can also be cleared with the section open (a
+  // hand-typed 0, the inner paid-access switch) or with it unmounted entirely (a non-commercial base
+  // model), and those lose exactly as much as closing the section does. Reading the switch position
+  // instead reduces to `!chargeEnabled` — `hasExistingCharge` forces the `showChargeSettings` OR-arm
+  // true — and misses every one of them.
+  const removingStoredFee = hasExistingLicensingFee && (currentLicensingFee ?? 0) <= 0;
+  const removingStoredGate = !!version?.paidAccess && !paidAccessConfig;
+  const removingStoredCharge = removingStoredFee || removingStoredGate;
 
   const licensingSourceVersionId = form.watch('licensingSourceVersionId') ?? null;
   const { data: licensingRootsData } = trpc.modelVersion.getLicensingRoots.useQuery(
@@ -580,13 +585,19 @@ export function ModelVersionUpsertForm({
     }
     if (form.getValues('licensingFeeSettlementCurrency'))
       form.setValue('licensingFeeSettlementCurrency', null, { shouldDirty: true });
-    if (form.getValues('rightsAffirmed')) form.setValue('rightsAffirmed', false);
+    // A version that already charges keeps its tick: it's the answer to a question the creator was asked
+    // about THIS version, and clearing it turns a switch round-trip that changed nothing into the
+    // "Confirmation required" save this ticket is about.
+    if (!hasExistingCharge && form.getValues('rightsAffirmed'))
+      form.setValue('rightsAffirmed', false);
   };
 
-  // Closing the section on a version that already charges is a removal, and it must be undoable from the
-  // UI — nothing else on screen holds the stored price, so without this a stray click on the switch loses
-  // it with no way back short of reloading the page.
+  // Restoring is an explicit action next to the warning, not a side effect of switching back on: the
+  // switch's job is disclosure, and having it silently re-apply the stored price would undo edits the
+  // creator made on purpose (dropping the gate but keeping the fee, or lowering the fee) as well as the
+  // clear. Re-opens the section too — a restored price behind a collapsed switch is the original bug.
   const restoreStoredCharges = () => {
+    setChargeEnabled(true);
     if (hasExistingLicensingFee) applyFeeRatio(feeToRatio(Number(version?.licensingFee ?? 0)));
     if (version?.paidAccess) {
       const stored = toFormPaidAccessConfig(version.paidAccess, version.donationGoal);
@@ -1185,28 +1196,35 @@ export function ModelVersionUpsertForm({
                       const checked = e.target.checked;
                       setChargeEnabled(checked);
                       if (!checked) clearCharges();
-                      else if (hasExistingCharge) restoreStoredCharges();
                     }}
                     disabled={isEarlyAccessOver && !!version?.paidAccess}
                   />
                 )}
                 {removingStoredCharge && (
-                  <Stack gap={4} mt="sm">
+                  <Stack gap={4} mt="sm" align="flex-start">
                     <Text size="xs" c="red">
                       Saving now removes this version&apos;s{' '}
-                      {hasExistingLicensingFee && version?.paidAccess
+                      {removingStoredFee && removingStoredGate
                         ? 'license fee and paid access'
-                        : hasExistingLicensingFee
+                        : removingStoredFee
                         ? 'license fee'
                         : 'paid access'}
-                      . Switch it back on to keep the stored settings.
+                      .
                     </Text>
-                    {!!version?.paidAccess && (
+                    {removingStoredGate && (
                       <Text size="xs" c="red">
                         You will not be able to add this model to early access again after removing
                         it. Also, your payment for early access will be lost.
                       </Text>
                     )}
+                    <Anchor
+                      component="button"
+                      type="button"
+                      size="xs"
+                      onClick={restoreStoredCharges}
+                    >
+                      Restore the stored settings
+                    </Anchor>
                   </Stack>
                 )}
                 {(showRightsAffirmation || requiresRightsAffirmation) && (
@@ -1617,13 +1635,6 @@ export function ModelVersionUpsertForm({
                       </Stack>
                     )}
 
-                    {version?.paidAccess && !paidAccessConfig && (
-                      <Text size="xs" c="red">
-                        You will not be able to add this model to early access again after removing
-                        it. Also, your payment for early access will be lost. Please consider this
-                        before removing early access.
-                      </Text>
-                    )}
                     {showLicensingFeeBlock && <Divider my="md" />}
                   </Stack>
                 )}

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -514,6 +514,10 @@ export function ModelVersionUpsertForm({
   // Read through `gateCharges` — what the submit actually sends — for the same reason it exists: the raw
   // config survives behind a hidden editor, so a version that went private, or whose usage control can no
   // longer be gated, drops its gate on save while the config still reads non-null.
+  //
+  // "charges nothing" stands in for "sends no gate" because `buildModelVersionTerms` has no branch that
+  // emits a gate charging nothing (and the server rejects that shape). Add one and this starts lying —
+  // switch it to the nullness of `toPaidAccessInput` then.
   const removingStoredGate = !!version?.paidAccess && !gateCharges;
   const removingStoredCharge = removingStoredFee || removingStoredGate;
 
@@ -873,6 +877,14 @@ export function ModelVersionUpsertForm({
 
   const canSave = !hasNsfwBaseModelViolation;
 
+  // A private model, or a usage control that can't be gated, loses its gate on save no matter what the
+  // creator does — the submit substitutes null either way. Nothing to offer them, so say why instead.
+  const gateRemovalIsStructural = removingStoredGate && (isPrivateModel || !paidAccessUsageOk);
+  // Whether the control each sentence is about is actually on screen (see the colour rule below).
+  const removalControlsVisible =
+    (!removingStoredFee || (showChargeSettings && showLicensingFeeBlock)) &&
+    (!removingStoredGate || (showChargeSettings && showPaidAccessInput));
+
   return (
     <>
       <Form id={id} form={form} onSubmit={handleSubmit}>
@@ -1205,9 +1217,9 @@ export function ModelVersionUpsertForm({
                 )}
                 {removingStoredCharge && (
                   <Stack gap={4} mt="sm" align="flex-start">
-                    {/* Red only when the priced controls are off screen — that's the case the creator
-                        can't see. With them open this is a note about an edit they just made. */}
-                    <Text size="xs" c={showChargeSettings ? 'yellow.5' : 'red'}>
+                    {/* Red only when the control the sentence is about is off screen — that's the case
+                        the creator can't see. On screen, this describes an edit they just made. */}
+                    <Text size="xs" c={removalControlsVisible ? 'yellow.5' : 'red'}>
                       Saving now removes this version&apos;s{' '}
                       {removingStoredFee && removingStoredGate
                         ? 'license fee and paid access'
@@ -1216,20 +1228,31 @@ export function ModelVersionUpsertForm({
                         : 'paid access'}
                       .
                     </Text>
-                    {removingStoredGate && (
-                      <Text size="xs" c="red">
-                        You will not be able to add this model to early access again after removing
-                        it. Also, your payment for early access will be lost.
-                      </Text>
+                    {removingStoredGate &&
+                      (gateRemovalIsStructural ? (
+                        <Text size="xs" c="red">
+                          {isPrivateModel
+                            ? "A private model can't have paid access, so this can't be kept."
+                            : "This version's usage control can't be gated, so this can't be kept."}
+                        </Text>
+                      ) : (
+                        <Text size="xs" c="red">
+                          You will not be able to add this model to early access again after
+                          removing it. Also, your payment for early access will be lost.
+                        </Text>
+                      ))}
+                    {/* No affordance for a removal the creator cannot prevent: the submit substitutes
+                        null for these regardless, so restoring would clear nothing and read as broken. */}
+                    {(removingStoredFee || !gateRemovalIsStructural) && (
+                      <Anchor
+                        component="button"
+                        type="button"
+                        size="xs"
+                        onClick={restoreStoredCharges}
+                      >
+                        Restore the stored settings
+                      </Anchor>
                     )}
-                    <Anchor
-                      component="button"
-                      type="button"
-                      size="xs"
-                      onClick={restoreStoredCharges}
-                    >
-                      Restore the stored settings
-                    </Anchor>
                   </Stack>
                 )}
                 {(showRightsAffirmation || requiresRightsAffirmation) && (

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -26,7 +26,6 @@ import * as z from 'zod';
 
 import { CapUpsell } from '~/components/Buzz/CapUpsell';
 import { CurrencyIcon } from '~/components/Currency/CurrencyIcon';
-import { DismissibleAlert } from '~/components/DismissibleAlert/DismissibleAlert';
 import InputResourceSelectMultiple from '~/components/ImageGeneration/GenerationForm/ResourceSelectMultiple';
 import {
   MAX_DONATION_GOAL,
@@ -1280,46 +1279,6 @@ export function ModelVersionUpsertForm({
                 )}
                 {showChargeSettings && showPaidAccessInput && (
                   <Stack gap={0} mt="md">
-                    <DismissibleAlert
-                      id="ea-info"
-                      size="sm"
-                      color="yellow"
-                      title={
-                        <Group gap="xs">
-                          <Text>Earn Buzz with early access! </Text>
-                          <Popover width={300} withArrow withinPortal shadow="sm">
-                            <Popover.Target>
-                              <IconInfoCircle size={16} />
-                            </Popover.Target>
-                            <Popover.Dropdown>
-                              <Stack gap="xs">
-                                <Text size="sm">
-                                  Early Access helps creators monetize, learn more{' '}
-                                  <Anchor href="/articles/6341">here</Anchor>
-                                </Text>
-                              </Stack>
-                            </Popover.Dropdown>
-                          </Popover>
-                        </Group>
-                      }
-                      content={
-                        <Stack>
-                          <Text size="xs">
-                            Early access allows you to charge a fee for early access to your model.
-                            Once the early access period ends, your model will be available to
-                            everyone for free.
-                          </Text>
-                          {!currentUser?.isModerator && maxEarlyAccessModels > 0 && (
-                            <Text size="xs">
-                              You have {activeEarlyAccessCount} of {maxEarlyAccessModels} early
-                              access {maxEarlyAccessModels === 1 ? 'slot' : 'slots'} in use. This
-                              limit increases as you post more models on the site.
-                            </Text>
-                          )}
-                        </Stack>
-                      }
-                      mb="xs"
-                    />
                     {isEarlyAccessOver && (
                       <Text size="xs" c="red">
                         Early access has ended for this model version. You cannot make changes to

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -337,14 +337,10 @@ export function ModelVersionUpsertForm({
 
   const MAX_EARLY_ACCCESS = 30;
 
-  // A NEW version seeds the type-based suggested licensing fee (non-checkpoints = 1 ⚡ per 10 images), but only
-  // when the fee editor is actually shown — never seed a fee the creator can't see. Existing versions keep their
-  // stored value (0 = off).
-  const initialLicensingFee = version?.id
-    ? Number(version.licensingFee ?? 0)
-    : features.licensingFee
-    ? suggestedFee({ modelType: model?.type, baseModel: initialBaseModel })
-    : 0;
+  // The form never LOADS with a fee: the type-based suggestion (non-checkpoints = 1 ⚡ per 10 images) is
+  // applied when the creator opens the fee editor, not before — a fee seeded behind a closed editor is a
+  // charge nobody asked for, and it tripped the rights affirmation at submit (CU 868kq69rv).
+  const initialLicensingFee = Number(version?.licensingFee ?? 0);
 
   const defaultValues: Schema = {
     ...version,
@@ -414,6 +410,11 @@ export function ModelVersionUpsertForm({
   const currentLicensingFee = form.watch('licensingFee') ?? 0;
   const existingSettlementCurrency = version?.licensingFeeSettlementCurrency ?? null;
   const hasExistingLicensingFee = Number(version?.licensingFee ?? 0) > 0;
+  // A version that already charges opens with the monetization section expanded; everything else starts
+  // collapsed behind the master switch below.
+  const hasExistingCharge = !!version?.paidAccess || hasExistingLicensingFee;
+  const [chargeEnabled, setChargeEnabled] = useState(hasExistingCharge);
+  const rightsAffirmed = form.watch('rightsAffirmed') ?? false;
   // The fee is edited as a whole-number "buzz per N images" ratio; the stored `licensingFee` stays per-image.
   const [feeRatio, setFeeRatio] = useState(() => feeToRatio(initialLicensingFee));
   const applyFeeRatio = (next: { buzz: number; images: number }) => {
@@ -493,8 +494,17 @@ export function ModelVersionUpsertForm({
   // from staff monetizing their own, and exempting on the role alone let every staff creator skip it.
   // The server applies the real ownership-scoped rule and simply ignores a moderator's tick on a model
   // they don't own.
-  const requiresRightsAffirmation =
-    !hasCurrentRightsAffirmation(version?.meta) && (currentLicensingFee > 0 || gateCharges);
+  const alreadyAffirmed = hasCurrentRightsAffirmation(version?.meta);
+  const requiresRightsAffirmation = !alreadyAffirmed && (currentLicensingFee > 0 || gateCharges);
+  // Step 2 of the disclosure: asked as soon as the creator says they want to charge, so the pricing
+  // controls never appear before the affirmation. Distinct from `requiresRightsAffirmation`, which is the
+  // submit gate and stays keyed to an actual charge — toggling the switch and changing your mind must not
+  // block a save.
+  const showRightsAffirmation = !alreadyAffirmed && chargeEnabled;
+  // Step 3: the pricing controls. A version already charging without an affirmation on record (predates
+  // the requirement) keeps them visible, so it can still be edited or turned off.
+  const showChargeSettings =
+    chargeEnabled && (alreadyAffirmed || rightsAffirmed || hasExistingCharge);
 
   const licensingSourceVersionId = form.watch('licensingSourceVersionId') ?? null;
   const { data: licensingRootsData } = trpc.modelVersion.getLicensingRoots.useQuery(
@@ -552,6 +562,47 @@ export function ModelVersionUpsertForm({
     }
   }, [baseModel]);
 
+  // Nothing may survive behind a collapsed section: `shouldUnregister` is false, so a hidden value is
+  // still submitted, and a fee the creator can no longer see is both a charge they didn't make and (via
+  // `requiresRightsAffirmation`) a submit blocked by a control that isn't on screen.
+  //
+  // An ended Early Access window is exempt: that config is locked, and clearing it here would let the
+  // master switch remove what the disabled paid-access switch refuses to.
+  const feeSeededRef = useRef(false);
+  const clearCharges = () => {
+    if ((form.getValues('licensingFee') ?? 0) > 0) {
+      form.setValue('licensingFee', 0, { shouldDirty: true });
+      setFeeRatio((r) => ({ buzz: 0, images: r.images }));
+    }
+    if (!isEarlyAccessOver && form.getValues('paidAccessConfig')) {
+      form.setValue('paidAccessConfig', null, { shouldDirty: true });
+      setGenMode(generationModeOf(null));
+    }
+    if (form.getValues('rightsAffirmed')) form.setValue('rightsAffirmed', false);
+    feeSeededRef.current = false;
+  };
+
+  // Unticking the affirmation withdraws the permission the pricing controls depend on, so it clears them
+  // too — leaving a fee behind a hidden editor is the bug this whole change is about. A version that was
+  // already charging is left alone: it has a stored price the creator didn't touch.
+  const prevRightsAffirmedRef = useRef(rightsAffirmed);
+  useEffect(() => {
+    const withdrawn = prevRightsAffirmedRef.current && !rightsAffirmed;
+    prevRightsAffirmedRef.current = rightsAffirmed;
+    if (withdrawn && !hasExistingCharge && !alreadyAffirmed) clearCharges();
+  }, [rightsAffirmed]);
+
+  // The suggested fee lands when the editor opens, not when the form loads. Re-armed by `clearCharges`,
+  // so re-opening the section suggests again — but a 0 the creator typed while the editor was open is
+  // theirs to keep.
+  useEffect(() => {
+    if (!showChargeSettings || !showLicensingFeeBlock || feeSeededRef.current) return;
+    feeSeededRef.current = true;
+    if (hasExistingCharge || (form.getValues('licensingFee') ?? 0) > 0) return;
+    const suggestion = suggestedFee({ modelType: model?.type, baseModel });
+    if (suggestion > 0) applyFeeRatio(feeToRatio(suggestion));
+  }, [showChargeSettings, showLicensingFeeBlock]);
+
   // Non-commercial base models can't be monetized. The monetization controls are
   // hidden (shouldUnregister is false, so their values would otherwise persist and
   // be re-submitted, then rejected server-side with a confusing error). Clear them
@@ -565,6 +616,9 @@ export function ModelVersionUpsertForm({
     if (form.getValues('monetization')) form.setValue('monetization', null);
     if (form.getValues('paidAccessConfig')) form.setValue('paidAccessConfig', null);
     if (form.getValues('useMonetization')) form.setValue('useMonetization', false);
+    if (form.getValues('rightsAffirmed')) form.setValue('rightsAffirmed', false);
+    setChargeEnabled(false);
+    feeSeededRef.current = false;
   }, [isNonCommercial]);
 
   const upsertVersionMutation = trpc.modelVersion.upsert.useMutation({
@@ -702,6 +756,10 @@ export function ModelVersionUpsertForm({
       setGenMode(
         generationModeOf(toFormPaidAccessConfig(version.paidAccess, version.donationGoal))
       );
+      // And for the master switch, for the same reason: `reset` restores the stored fee/gate, so the
+      // switch has to follow what was actually restored rather than its mount-time value.
+      setChargeEnabled(!!version.paidAccess || Number(version.licensingFee ?? 0) > 0);
+      feeSeededRef.current = false;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [acceptsTrainedWords, isTextualInversion, model?.id, version]);
@@ -1101,9 +1159,29 @@ export function ModelVersionUpsertForm({
                 <Text fw={600} mb="sm">
                   Monetization
                 </Text>
-                {showPaidAccessInput && (
+                {(showPaidAccessInput || showLicensingFeeBlock) && (
+                  <Switch
+                    label="I want to charge for this version"
+                    description="Sell access to the version, charge a fee per generation, or both."
+                    checked={chargeEnabled}
+                    onChange={(e) => {
+                      const checked = e.target.checked;
+                      setChargeEnabled(checked);
+                      if (!checked) clearCharges();
+                    }}
+                    disabled={isEarlyAccessOver && !!version?.paidAccess}
+                  />
+                )}
+                {(showRightsAffirmation || requiresRightsAffirmation) && (
+                  <InputCheckbox
+                    name="rightsAffirmed"
+                    label={MONETIZATION_RIGHTS_AFFIRMATION_STATEMENT}
+                    mt="sm"
+                  />
+                )}
+                {showChargeSettings && showPaidAccessInput && (
                   <Stack gap={0}>
-                    <Divider label="Paid Access Set Up" mb="md" />
+                    <Divider label="Paid Access Set Up" mb="md" mt="md" />
 
                     <DismissibleAlert
                       id="ea-info"
@@ -1175,7 +1253,7 @@ export function ModelVersionUpsertForm({
                     </Alert>
                     <Switch
                       my="sm"
-                      label="I want to charge for access to this version"
+                      label="Charge for access to this version"
                       checked={paidAccessConfig !== null}
                       onChange={(e) =>
                         form.setValue(
@@ -1509,11 +1587,11 @@ export function ModelVersionUpsertForm({
                         before removing early access.
                       </Text>
                     )}
-                    {(showLicensingFeeBlock || requiresRightsAffirmation) && <Divider my="md" />}
+                    {showLicensingFeeBlock && <Divider my="md" />}
                   </Stack>
                 )}
-                {showLicensingFeeBlock && (
-                  <Stack gap="xs">
+                {showChargeSettings && showLicensingFeeBlock && (
+                  <Stack gap="xs" mt={showPaidAccessInput ? undefined : 'md'}>
                     <Input.Wrapper
                       label="License Fee"
                       description={`Charge for generations using this version, as Buzz per number of generations. If this is a derivative of a base model that already charges a licensing fee, your fee is added on top of it. Set 0 to disable. Your membership allows up to ${licensingFeeCap} Buzz per generation for this model type.`}
@@ -1615,14 +1693,7 @@ export function ModelVersionUpsertForm({
                         </Text>
                       </Group>
                     )}
-                    {requiresRightsAffirmation && <Divider my="md" />}
                   </Stack>
-                )}
-                {requiresRightsAffirmation && (
-                  <InputCheckbox
-                    name="rightsAffirmed"
-                    label={MONETIZATION_RIGHTS_AFFIRMATION_STATEMENT}
-                  />
                 )}
               </Stack>
             </Card>

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -1389,7 +1389,9 @@ export function ModelVersionUpsertForm({
                                 <Input.Wrapper
                                   label={
                                     <Group gap="xs">
-                                      <Text fw="bold">Early access time frame</Text>
+                                      <Text fw={500} size="sm">
+                                        Early access time frame
+                                      </Text>
                                       <Popover width={300} withArrow withinPortal shadow="sm">
                                         <Popover.Target>
                                           <IconInfoCircle size={16} />
@@ -1583,68 +1585,67 @@ export function ModelVersionUpsertForm({
                         </>
                       )}
                     </Card>
-                    {paidAccessConfig && (
-                      <Stack mt="sm">
-                        {!paidAccessConfig.permanent &&
-                          (version?.status !== 'Published' || version?.donationGoal) &&
-                          features.donationGoals && (
-                            <Card withBorder>
-                              <Card.Section withBorder>
-                                <Group py="sm" px="md" justify="space-between" wrap="nowrap">
-                                  <div>
-                                    <Text fw={500} size="sm">
-                                      Let the community unlock this early
-                                    </Text>
-                                    <Text size="xs">
-                                      If the goal is met before the window ends, early access ends
-                                      immediately and the version becomes free for everyone. After
-                                      the model is published, you cannot change this value.
-                                    </Text>
-                                  </div>
-                                  <InputSwitch
-                                    name="paidAccessConfig.donationGoalEnabled"
+                    {!!paidAccessConfig &&
+                      !paidAccessConfig.permanent &&
+                      (version?.status !== 'Published' || version?.donationGoal) &&
+                      features.donationGoals && (
+                        <Stack mt="sm">
+                          <Card withBorder>
+                            <Card.Section withBorder bg={cardHeaderBg}>
+                              <Group py="xs" px="md" justify="space-between" wrap="nowrap">
+                                <div>
+                                  <Text fw={600} size="sm">
+                                    Let the community unlock this early
+                                  </Text>
+                                  <Text size="xs" c="dimmed">
+                                    If the goal is met before the window ends, early access ends
+                                    immediately and the version becomes free for everyone. After the
+                                    model is published, you cannot change this value.
+                                  </Text>
+                                </div>
+                                <InputSwitch
+                                  name="paidAccessConfig.donationGoalEnabled"
+                                  disabled={donationGoalLocked}
+                                  onChange={(e) => {
+                                    if (e.target.checked) {
+                                      form.setValue('paidAccessConfig.donationGoal', 50000);
+                                    } else {
+                                      form.setValue('paidAccessConfig.donationGoal', undefined);
+                                    }
+                                  }}
+                                />
+                              </Group>
+                            </Card.Section>
+                            {paidAccessConfig?.donationGoalEnabled && (
+                              <Card.Section py="sm" px="md">
+                                <Stack>
+                                  <InputNumber
+                                    name="paidAccessConfig.donationGoal"
+                                    label="Goal amount"
+                                    description="Early access purchases count toward this goal. After publishing, you cannot change this value."
+                                    min={MIN_DONATION_GOAL}
+                                    max={MAX_DONATION_GOAL}
+                                    step={100}
+                                    leftSection={<CurrencyIcon currency="BUZZ" size={16} />}
                                     disabled={donationGoalLocked}
-                                    onChange={(e) => {
-                                      if (e.target.checked) {
-                                        form.setValue('paidAccessConfig.donationGoal', 50000);
-                                      } else {
-                                        form.setValue('paidAccessConfig.donationGoal', undefined);
-                                      }
-                                    }}
                                   />
-                                </Group>
+                                  <Switch
+                                    label="Hide donation goals from public view"
+                                    description="Others won't see the progress bar or collected amount. The goal still works, and you and moderators can still see it. This applies to all of your donation goals."
+                                    checked={hideDonationGoals ?? false}
+                                    onChange={(e) =>
+                                      mutateUserSettings({
+                                        hideDonationGoals: e.target.checked,
+                                      })
+                                    }
+                                    disabled={hideDonationGoalsUpdating}
+                                  />
+                                </Stack>
                               </Card.Section>
-                              {paidAccessConfig?.donationGoalEnabled && (
-                                <Card.Section py="sm" px="md">
-                                  <Stack>
-                                    <InputNumber
-                                      name="paidAccessConfig.donationGoal"
-                                      label="Goal amount"
-                                      description="Early access purchases count toward this goal. After publishing, you cannot change this value."
-                                      min={MIN_DONATION_GOAL}
-                                      max={MAX_DONATION_GOAL}
-                                      step={100}
-                                      leftSection={<CurrencyIcon currency="BUZZ" size={16} />}
-                                      disabled={donationGoalLocked}
-                                    />
-                                    <Switch
-                                      label="Hide donation goals from public view"
-                                      description="Others won't see the progress bar or collected amount. The goal still works, and you and moderators can still see it. This applies to all of your donation goals."
-                                      checked={hideDonationGoals ?? false}
-                                      onChange={(e) =>
-                                        mutateUserSettings({
-                                          hideDonationGoals: e.target.checked,
-                                        })
-                                      }
-                                      disabled={hideDonationGoalsUpdating}
-                                    />
-                                  </Stack>
-                                </Card.Section>
-                              )}
-                            </Card>
-                          )}
-                      </Stack>
-                    )}
+                            )}
+                          </Card>
+                        </Stack>
+                      )}
                   </Stack>
                 )}
                 {showChargeSettings && showLicensingFeeBlock && (


### PR DESCRIPTION
@
Fixes the uploader feedback in [CU 868kq69rv](https://app.clickup.com/t/868kq69rv) (reported by Koen).

## The problem

The **License Fee** editor rendered whenever the `licensingFee` flag was on, pre-filled with the type-based suggested fee. So a creator who never asked to charge anything saw a price they had no context for — and then hit `You must confirm you hold the rights to monetize this model` at save, with the only ways out being to tick an affirmation they did not need or to type `0`.

## What changed

Monetization now discloses in three steps:

1. `I want to charge for this version` (master switch, off unless the version already charges)
2. the rights affirmation
3. the pricing controls — Paid Access setup and the License Fee editor

The suggested fee is applied when the fee editor **opens**, not when the form loads. Closing either step clears what it revealed (`clearCharges`): `shouldUnregister` is false on this form, so anything left behind a collapsed control is still submitted, and a fee behind a hidden editor is both an unasked-for charge and a save the creator cannot unblock.

The submit gate is deliberately unchanged — `requiresRightsAffirmation` stays keyed to an *actual* charge, so toggling the switch and changing your mind never blocks a save. An ended Early Access window is exempt from clearing: that config is locked, and the master switch must not remove what the disabled paid-access switch refuses to.

The inner paid-access switch is relabelled `Charge for access to this version` so it does not read as a duplicate of the master switch.

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm run lint` — no new errors (2 new `react-hooks/exhaustive-deps` warnings, same intentional-narrow-deps pattern as the four already in this file)
- `pnpm run test:unit:run` — 14,928 passed; the 6 failing files are the pre-existing app-blocks convention scans, untouched here
- 5 new browser tests in `ModelVersionUpsertForm.browser.test.tsx`, mutation-tested: restoring the old always-visible seeded fee fails 4 of them (including `expected "vi.fn()" to be called 1 times, but got 0 times` — the save Koen could not complete), and dropping the clear-on-close fails the stale-fee assertion. Both fail in under a second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@