### PR TITLE
fix(reports): refuse self-profile reports and hide the menu entry

### DIFF
--- a/src/components/Profile/UserContextMenu.tsx
+++ b/src/components/Profile/UserContextMenu.tsx
@@ -386,19 +386,21 @@ export const UserContextMenu = ({ username }: { username: string }) => {
             </Menu.Item>
           )}
           <HideUserButton as="menu-item" userId={user.id} />
-          <LoginRedirect reason="report-user">
-            <Menu.Item
-              leftSection={<IconFlag size={14} stroke={1.5} />}
-              onClick={() =>
-                openReportModal({
-                  entityType: ReportEntity.User,
-                  entityId: user.id,
-                })
-              }
-            >
-              Report
-            </Menu.Item>
-          </LoginRedirect>
+          {user.id !== currentUser?.id && (
+            <LoginRedirect reason="report-user">
+              <Menu.Item
+                leftSection={<IconFlag size={14} stroke={1.5} />}
+                onClick={() =>
+                  openReportModal({
+                    entityType: ReportEntity.User,
+                    entityId: user.id,
+                  })
+                }
+              >
+                Report
+              </Menu.Item>
+            </LoginRedirect>
+          )}
         </>
       </Menu.Dropdown>
     </Menu>

--- a/src/server/__tests__/report-self-user.test.ts
+++ b/src/server/__tests__/report-self-user.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ReportEntity } from '~/shared/utils/report-helpers';
+import { ReportReason } from '~/shared/utils/prisma/enums';
+
+/**
+ * The guard is User-only on purpose, so the tests that matter most here are the
+ * ones that prove the OTHER entity types were left alone: reporting your own
+ * image or model is how a creator contests a rating, and a fix that closed the
+ * self-profile hole by closing that too would look identical from the User
+ * tests alone.
+ */
+const REPORTER = 41;
+const OTHER_USER = 52;
+const OWN_IMAGE = 63;
+const SYSTEM_USER = -1;
+
+const reportFindFirst = vi.fn();
+const reportCreate = vi.fn();
+const reportUpdate = vi.fn();
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { placement: { findFirst: vi.fn(async () => null) } },
+  dbWrite: {
+    report: {
+      findFirst: (...args: unknown[]) => reportFindFirst(...args),
+      update: (...args: unknown[]) => reportUpdate(...args),
+    },
+    $transaction: async (fn: (tx: unknown) => Promise<unknown>) =>
+      fn({
+        report: { create: (...args: unknown[]) => reportCreate(...args) },
+        image: { update: vi.fn(), findUnique: vi.fn(async () => null) },
+        model: { update: vi.fn() },
+      }),
+  },
+}));
+
+vi.mock('~/server/services/system-cache', () => ({ getModeratedTags: vi.fn(async () => []) }));
+
+const { createReport } = await import('~/server/services/report.service');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // No existing report to fold into, so every allowed case below reaches the
+  // write and `create` is a meaningful assertion.
+  reportFindFirst.mockResolvedValue(null);
+  reportCreate.mockResolvedValue({ id: 74, details: {} });
+});
+
+describe('a user cannot report their own profile', () => {
+  it('refuses the self-profile report before anything is written', async () => {
+    await expect(
+      createReport({
+        userId: REPORTER,
+        id: REPORTER,
+        type: ReportEntity.User,
+        reason: ReportReason.AdminAttention,
+        details: { comment: 'please look at my account' },
+      })
+    ).rejects.toThrow(/your own profile/);
+
+    expect(reportCreate).not.toHaveBeenCalled();
+    expect(reportUpdate).not.toHaveBeenCalled();
+    // The dedupe read must not run either — a refusal that still queries has
+    // moved the guard below the work it exists to skip.
+    expect(reportFindFirst).not.toHaveBeenCalled();
+  });
+
+  it('names a route that reaches a human', async () => {
+    // AdminAttention is the top reason people picked this for, so the refusal
+    // has to replace the dead end rather than just close it.
+    await expect(
+      createReport({
+        userId: REPORTER,
+        id: REPORTER,
+        type: ReportEntity.User,
+        reason: ReportReason.AdminAttention,
+        details: {},
+      })
+    ).rejects.toThrow(/support-portal/i);
+  });
+
+  it('refuses regardless of reason', async () => {
+    await expect(
+      createReport({
+        userId: REPORTER,
+        id: REPORTER,
+        type: ReportEntity.User,
+        reason: ReportReason.TOSViolation,
+        details: { violation: 'whatever' },
+      })
+    ).rejects.toThrow(/your own profile/);
+    expect(reportCreate).not.toHaveBeenCalled();
+  });
+
+  it('still reports someone else’s profile', async () => {
+    await createReport({
+      userId: REPORTER,
+      id: OTHER_USER,
+      type: ReportEntity.User,
+      reason: ReportReason.AdminAttention,
+      details: { comment: 'impersonating me' },
+    });
+
+    expect(reportCreate).toHaveBeenCalledOnce();
+  });
+
+  it('still lets the automated moderation pass file a profile report', async () => {
+    // entity-moderation files these as the system user against a real user id,
+    // so the two are never equal — pinned because a guard written as "reporter
+    // is a party to this" rather than "reporter IS the target" would kill it.
+    await createReport({
+      userId: SYSTEM_USER,
+      id: OTHER_USER,
+      type: ReportEntity.User,
+      isModerator: true,
+      reason: ReportReason.Automated,
+      details: { tags: ['whatever'] },
+    });
+
+    expect(reportCreate).toHaveBeenCalledOnce();
+  });
+});
+
+describe('reporting your own CONTENT is untouched', () => {
+  it('still files a report on your own image', async () => {
+    // This is how a creator contests a rating or a flag. Losing it is the one
+    // way this fix could do real damage.
+    await createReport({
+      userId: REPORTER,
+      id: OWN_IMAGE,
+      type: ReportEntity.Image,
+      reason: ReportReason.AdminAttention,
+      details: { comment: 'this was rated wrong' },
+    });
+
+    expect(reportCreate).toHaveBeenCalledOnce();
+  });
+
+  it('still files a report on a model whose id collides with the reporter’s user id', async () => {
+    // `id` is deliberately equal to `userId` here: the guard compares two ids
+    // drawn from different tables, so it has to be gated on the entity type as
+    // well. Without that gate this exact call is refused and model 41 becomes
+    // unreportable by user 41.
+    await createReport({
+      userId: REPORTER,
+      id: REPORTER,
+      type: ReportEntity.Model,
+      reason: ReportReason.AdminAttention,
+      details: { comment: 'this was flagged wrong' },
+    });
+
+    expect(reportCreate).toHaveBeenCalledOnce();
+  });
+});

--- a/src/server/services/report.service.ts
+++ b/src/server/services/report.service.ts
@@ -258,6 +258,13 @@ export const createReport = async ({
   // only mods can create csam reports
   if (data.reason === ReportReason.CSAM && !isModerator) throw throwAuthorizationError();
 
+  // User-only on purpose: reporting your own content is how a creator contests a
+  // rating, so this must not widen to other entity types.
+  if (type === ReportEntity.User && id === userId)
+    throw throwBadRequestError(
+      'You cannot report your own profile. To reach a moderator about your own account, use the Support Portal at /support-portal.'
+    );
+
   await assertReportedPlacementIsOnEntity({ type, entityId: id, details: data.details });
 
   const validReport =


### PR DESCRIPTION
Closes [868kq76xj](https://app.clickup.com/t/868kq76xj).

`createReport` now refuses `type === ReportEntity.User && id === userId`, placed right after the CSAM authorization check — before the placement assertion, before the dedupe read, and outside the transaction. So it costs no queries and writes nothing.

The message points at `/support-portal` rather than just closing the door: `AdminAttention` was the majority of the existing self-reports, i.e. people looking for a human. It is a `BAD_REQUEST`, and `ReportModal`'s `onError` passes `error.message` straight into the notification, so a stale client or a direct API caller sees the route verbatim.

The Report entry in `UserContextMenu` is hidden on your own profile, gated on `user.id !== currentUser?.id`. The file's existing `isSameUser` is username-slug based and goes stale after a rename, which would show a Report button that then 400s. `handleImpersonate` next to it already compares ids this way. Anonymous viewers still see Report (`currentUser` is undefined → ids differ) and `LoginRedirect` handles them as before.

**Scoped to `ReportEntity.User` on purpose.** Reporting your own image/model/comment is the contest-a-rating path and is untouched — two tests pin it, including one where the model id deliberately equals the reporter's user id, since the guard compares ids drawn from two different tables. A third pins that `entity-moderation` still files profile reports (it uses `userId: -1`, so the ids are never equal).

No moderator exemption — a moderator reporting their own profile is refused like anyone else.

### Not included, deliberately

- The optional `reportAcceptedReward` actor-is-not-target guard. Doing it properly needs a per-entity ownership lookup inside the entity-agnostic `bulkSetReportStatus` — own change, own review. The volume behind it is small and shows no farming. The general hole (any reporter who owns the reported entity) stays open and is still worth a ticket.
- No backfill of the existing self-profile reports; they are real moderation history.
- `ProfileLayout2`'s `BlockedByThemPanel` report item — that panel only renders for a user who has blocked you, which you cannot be.
- A "contact support" affordance in the product. Hiding the button removes the misuse; it does not give people the route. That is a product call, not something to slip into this diff.

### Worth confirming before merge

`/support-portal` is a rewrite in `next.config.mjs`, not a page under `src/pages` — confirm it resolves where you expect on both hosts. Error copy is user-facing; change it freely.

### Checks

`pnpm run typecheck` 0 errors. `pnpm run test:unit:run` 14990 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
