### PR TITLE
fix(comments): stop the sanitizer stripping code and pre

### DIFF
--- a/src/server/schema/__tests__/comment-code-sanitize.test.ts
+++ b/src/server/schema/__tests__/comment-code-sanitize.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { commentUpsertInput } from '~/server/schema/comment.schema';
+import { upsertCommentv2Schema } from '~/server/schema/commentv2.schema';
+
+/**
+ * The comment editor ships the code-block control and StarterKit's inline `code`
+ * mark, so anything the toolbar can produce has to survive the save-side
+ * allowlist. It didn't: `code`/`pre` were missing from both comment schemas while
+ * every comparable surface allowed them, and a marked prompt snippet came back as
+ * plain body copy (Freshdesk #69083).
+ */
+const surfaces = [
+  [
+    'commentv2',
+    (content: string) =>
+      upsertCommentv2Schema.parse({ entityType: 'model', entityId: 1, content }).content,
+  ],
+  ['model comment', (content: string) => commentUpsertInput.parse({ modelId: 1, content }).content],
+] as const;
+
+describe.each(surfaces)('%s sanitization', (_label, parse) => {
+  it('keeps inline code', () => {
+    expect(parse('<p>use <code>score_8, score_7</code> in the prompt</p>')).toContain(
+      '<code>score_8, score_7</code>'
+    );
+  });
+
+  it('keeps code blocks', () => {
+    const clean = parse('<pre><code>highres, score_8, score_7</code></pre>');
+    expect(clean).toContain('<pre>');
+    expect(clean).toContain('highres, score_8, score_7');
+  });
+
+  it('still strips img — the list stays narrower than the default', () => {
+    expect(parse('<p>look <img src="https://example.com/x.png" /></p>')).not.toContain('<img');
+  });
+
+  it('still keeps sticker spans', () => {
+    expect(parse('<p><span data-type="sticker" data-id="12"></span></p>')).toContain(
+      'data-type="sticker"'
+    );
+  });
+});

--- a/src/server/schema/comment.schema.ts
+++ b/src/server/schema/comment.schema.ts
@@ -6,6 +6,7 @@ import { ReviewFilter, ReviewSort } from '~/server/common/enums';
 import type { RateLimit } from '~/server/middleware.trpc';
 import { getSanitizedStringSchema } from '~/server/schema/utils.schema';
 import { surfaceMayContainStickers } from '~/shared/utils/sticker-token';
+import { COMMENT_ALLOWED_TAGS } from '~/utils/html-sanitize-helpers';
 
 export const commentRateLimits: RateLimit[] = [
   { limit: 10, period: CacheTTL.hour },
@@ -40,7 +41,7 @@ export const commentUpsertInput = z.object({
   reviewId: z.number().nullish(),
   parentId: z.number().nullish(),
   content: getSanitizedStringSchema({
-    allowedTags: ['div', 'strong', 'p', 'em', 'u', 's', 'a', 'br', 'span'],
+    allowedTags: COMMENT_ALLOWED_TAGS,
     // Read from STICKER_SURFACES rather than hardcoded, so "may contain a
     // sticker" and "charges for one" can't drift apart — that split is what let
     // sticker markup be containable on surfaces that never charged.

--- a/src/server/schema/commentv2.schema.ts
+++ b/src/server/schema/commentv2.schema.ts
@@ -3,6 +3,7 @@ import { constants } from '~/server/common/constants';
 import { ThreadSort } from '~/server/common/enums';
 import { getSanitizedStringSchema } from '~/server/schema/utils.schema';
 import { surfaceMayContainStickers } from '~/shared/utils/sticker-token';
+import { COMMENT_ALLOWED_TAGS } from '~/utils/html-sanitize-helpers';
 
 export type CommentConnectorInput = z.infer<typeof commentConnectorSchema>;
 export const commentConnectorSchema = z.object({
@@ -33,7 +34,7 @@ export type UpsertCommentV2Input = z.infer<typeof upsertCommentv2Schema>;
 export const upsertCommentv2Schema = commentConnectorSchema.extend({
   id: z.number().optional(),
   content: getSanitizedStringSchema({
-    allowedTags: ['div', 'strong', 'p', 'em', 'u', 's', 'a', 'br', 'span'],
+    allowedTags: COMMENT_ALLOWED_TAGS,
     // Read from STICKER_SURFACES rather than hardcoded, so "may contain a
     // sticker" and "charges for one" can't drift apart — that split is what let
     // sticker markup be containable on surfaces that never charged.

--- a/src/shared/utils/__tests__/sticker-comment-sanitize.test.ts
+++ b/src/shared/utils/__tests__/sticker-comment-sanitize.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { sanitizeHtml } from '~/utils/html-sanitize-helpers';
+import { COMMENT_ALLOWED_TAGS, sanitizeHtml } from '~/utils/html-sanitize-helpers';
 
 // The comment schemas override `allowedTags` to a list that excludes `img`, so a
 // sticker rides through as `<span data-type="sticker" data-id>` — the same
 // mechanism @mentions use. If someone "simplifies" the node to an <img>, or
 // trims DEFAULT_ALLOWED_ATTRIBUTES, stickers silently vanish from every comment
 // at submit time with no error. These pin that contract.
-const COMMENT_ALLOWED_TAGS = ['div', 'strong', 'p', 'em', 'u', 's', 'a', 'br', 'span'];
 const sanitizeAsComment = (html: string) =>
   sanitizeHtml(html, { allowedTags: COMMENT_ALLOWED_TAGS, allowStickers: true });
 

--- a/src/utils/html-sanitize-helpers.ts
+++ b/src/utils/html-sanitize-helpers.ts
@@ -28,6 +28,22 @@ const DEFAULT_ALLOWED_TAGS = [
   'edge-media',
 ];
 
+// Must cover everything the comment editor's toolbar can produce: a tag missing
+// here is stripped at save with no error, so the markup just vanishes.
+export const COMMENT_ALLOWED_TAGS = [
+  'div',
+  'strong',
+  'p',
+  'em',
+  'u',
+  's',
+  'a',
+  'br',
+  'span',
+  'code',
+  'pre',
+];
+
 const DEFAULT_ALLOWED_IFRAME_HOSTNAMES = [
   'www.youtube.com',
   'www.instagram.com',


### PR DESCRIPTION
Closes [868kq9aw4](https://app.clickup.com/t/868kq9aw4).

`comment.schema.ts` and `commentv2.schema.ts` each hardcoded their own copy of the sanitizer's `allowedTags`, and both had fallen behind `model-version.schema.ts` / `resourceReview.schema.ts`: neither listed `code` or `pre`. So anything the comment editor's code button produced was stripped at save with no error. The render path already allowed both (`DEFAULT_ALLOWED_TAGS`) — only the save-side allowlist was dropping them.

### Shape of the fix

The ticket's candidate fix was "add `code` and `pre` to the two lists". This does that, but puts the list in one exported `COMMENT_ALLOWED_TAGS` instead of editing two literals — the bug *is* drift, and two literals can drift again. `sticker-comment-sanitize.test.ts` had made a third hand-copy of the same list; it now imports the real one, so it doubles as a drift guard.

`COMMENT_ALLOWED_TAGS` is a plain `string[]`, not `as const` — `sanitize.IOptions['allowedTags']` is mutable `string[]` and a readonly tuple fails to assign.

New test `src/server/schema/__tests__/comment-code-sanitize.test.ts` parses through both real zod schemas: inline `code` kept, `pre` block kept, `img` still stripped (the list stays narrower than the default), sticker spans still survive.

### Verified end to end

Browser-driven through the real editor → tRPC → Postgres on the dev DB (fingerprinted `inet_server_addr() = 10.244.18.86`, dev cnpg), both schemas, read back with tags intact and rendering monospaced. All test comments deleted afterwards through the app's own delete flow and confirmed gone.

Styling needed no change: comments render through `RenderHtml` → `TypographyStylesWrapper`, which already styles `pre`/`code` — the same styles model descriptions and resource reviews use.

### Deliberately not included

- **`blockquote` has exactly the same bug.** The comment editor enables it off the same `formatting` flag (`RichTextEditorComponent.tsx`), typing `> ` produces `<blockquote><p>…</p></blockquote>`, and it is stripped on save just like `code` was. Left out because the ticket scopes to code tags and blockquote is a visible layout change, not a lost monospace run. It is a one-word addition to `COMMENT_ALLOWED_TAGS` if you want it here.
- **`ul`/`ol`/`li`** (which `model-version.schema.ts` allows) — the comment editor does not pass the `list` control, so they are unreachable there.

### Pre-existing, not from this diff

Submitting any comment whose content ends in a trailing empty paragraph white-screens the page: `TypeError: Cannot assign to read only property 'content' of object '#<Object>'` at `CommentContent`. `Comment.tsx` mutates `comment.content` in place to trim `<p></p>` and the freshly-inserted store item is frozen. Reproduced with a plain-text comment containing no code tags at all, and ~23.7K CommentV2 rows already end in `<p></p>` (oldest from 2022). Untouched here — worth its own ticket, since it fires on the most ordinary thing a user can do.

### Checks

`pnpm run typecheck` exit 0. `pnpm run test:unit:run` → 960 files passed / 1 skipped, 14991 passed / 18 skipped, exit 0. eslint clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
