### PR TITLE
fix(discord): stop recording leaderboard roles Discord never granted

### DIFF
--- a/src/pages/api/auth/connect.ts
+++ b/src/pages/api/auth/connect.ts
@@ -1,6 +1,8 @@
+import crypto from 'crypto';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { hubLoginUrl } from '@civitai/auth';
 import { resolveSelfOrigin, safePath } from '~/server/auth/oauth-bridge';
+import { setLinkSyncCookie } from '~/server/auth/link-sync';
 
 // GET /api/auth/connect?provider=<id>&returnUrl=<same-origin path> — start the hub account-LINK flow from the
 // MAIN SERVER. Builds the hub link URL with the server's AUTH_JWT_ISSUER (no client-side hub env var) and 302s
@@ -35,5 +37,6 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   // `roles=true` opts into the provider's incremental scope (Discord Linked Roles) — only the /discord/link-role
   // flow passes it; a plain "Connect <provider>" never does, so normal linking can't trip the Linked-Roles scope.
   const linkRoles = req.query.roles === 'true';
+  setLinkSyncCookie(res, crypto.randomUUID());
   res.redirect(302, hubLoginUrl(HUB, { provider, link: true, linkRoles, returnUrl }));
 }

--- a/src/pages/api/auth/connect.ts
+++ b/src/pages/api/auth/connect.ts
@@ -26,8 +26,12 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   // Absolute, same-origin return target (the hub redirects back here cross-origin after linking). safePath
-  // keeps it a same-origin path — no open redirect through the query param.
-  const returnUrl = `${selfOrigin.replace(/\/+$/, '')}${safePath(req.query.returnUrl)}`;
+  // keeps it a same-origin path — no open redirect through the query param. The hub returns to /api/auth/linked
+  // so the main app can run post-link side effects it alone can do, which then forwards to the caller's path.
+  const linked = new URL('/api/auth/linked', selfOrigin);
+  linked.searchParams.set('provider', provider);
+  linked.searchParams.set('returnUrl', safePath(req.query.returnUrl));
+  const returnUrl = linked.toString();
   // `roles=true` opts into the provider's incremental scope (Discord Linked Roles) — only the /discord/link-role
   // flow passes it; a plain "Connect <provider>" never does, so normal linking can't trip the Linked-Roles scope.
   const linkRoles = req.query.roles === 'true';

--- a/src/pages/api/auth/connect.ts
+++ b/src/pages/api/auth/connect.ts
@@ -37,6 +37,6 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   // `roles=true` opts into the provider's incremental scope (Discord Linked Roles) — only the /discord/link-role
   // flow passes it; a plain "Connect <provider>" never does, so normal linking can't trip the Linked-Roles scope.
   const linkRoles = req.query.roles === 'true';
-  setLinkSyncCookie(res, crypto.randomUUID());
+  setLinkSyncCookie(req, res, crypto.randomUUID());
   res.redirect(302, hubLoginUrl(HUB, { provider, link: true, linkRoles, returnUrl }));
 }

--- a/src/pages/api/auth/linked.ts
+++ b/src/pages/api/auth/linked.ts
@@ -1,0 +1,34 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
+import { safePath } from '~/server/auth/oauth-bridge';
+import { syncUserDiscordLeaderboardRoles } from '~/server/jobs/apply-discord-roles';
+import { logToAxiom } from '~/server/logging/client';
+
+// GET /api/auth/linked?provider=<id>&returnUrl=<same-origin path> — the hub's return target for the account-LINK
+// flow started by /api/auth/connect. Runs the main app's post-link side effects (the hub has neither the main DB
+// nor the Discord bot token) and then forwards to where the user was actually headed, preserving the hub's
+// ?error. Side effects are best-effort: linking has already succeeded by the time we get here, so nothing in
+// here may keep the user on this endpoint.
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const provider = typeof req.query.provider === 'string' ? req.query.provider : undefined;
+  const error = typeof req.query.error === 'string' ? req.query.error : undefined;
+
+  if (provider === 'discord' && !error) {
+    try {
+      const session = await getServerAuthSession({ req, res });
+      const userId = session?.user?.id;
+      if (userId) await syncUserDiscordLeaderboardRoles(userId);
+    } catch (e) {
+      logToAxiom({
+        type: 'discord-link-sync-error',
+        name: 'auth-linked',
+        message: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
+  const destination = new URL(safePath(req.query.returnUrl), 'https://placeholder.invalid');
+  if (error) destination.searchParams.set('error', error);
+
+  res.redirect(302, `${destination.pathname}${destination.search}${destination.hash}`);
+}

--- a/src/pages/api/auth/linked.ts
+++ b/src/pages/api/auth/linked.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
+import { takeLinkSyncCookie } from '~/server/auth/link-sync';
 import { safePath } from '~/server/auth/oauth-bridge';
 import { syncUserDiscordLeaderboardRoles } from '~/server/jobs/apply-discord-roles';
 import { logToAxiom } from '~/server/logging/client';
@@ -7,17 +8,26 @@ import { logToAxiom } from '~/server/logging/client';
 // GET /api/auth/linked?provider=<id>&returnUrl=<same-origin path> — the hub's return target for the account-LINK
 // flow started by /api/auth/connect. Runs the main app's post-link side effects (the hub has neither the main DB
 // nor the Discord bot token) and then forwards to where the user was actually headed, preserving the hub's
-// ?error. Side effects are best-effort: linking has already succeeded by the time we get here, so nothing in
-// here may keep the user on this endpoint.
+// ?error.
+//
+// The user is already linked by the time we get here, so nothing in here may keep them on this endpoint: the
+// side effect is capped and its failure only ever costs a log line.
+const SYNC_TIMEOUT = 5000;
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const provider = typeof req.query.provider === 'string' ? req.query.provider : undefined;
   const error = typeof req.query.error === 'string' ? req.query.error : undefined;
+  const initiatedHere = takeLinkSyncCookie(req, res);
 
-  if (provider === 'discord' && !error) {
+  if (provider === 'discord' && !error && initiatedHere) {
     try {
       const session = await getServerAuthSession({ req, res });
       const userId = session?.user?.id;
-      if (userId) await syncUserDiscordLeaderboardRoles(userId);
+      if (userId)
+        await Promise.race([
+          syncUserDiscordLeaderboardRoles(userId),
+          new Promise((resolve) => setTimeout(resolve, SYNC_TIMEOUT)),
+        ]);
     } catch (e) {
       logToAxiom({
         type: 'discord-link-sync-error',

--- a/src/pages/api/auth/linked.ts
+++ b/src/pages/api/auth/linked.ts
@@ -23,15 +23,29 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     try {
       const session = await getServerAuthSession({ req, res });
       const userId = session?.user?.id;
-      if (userId)
-        await Promise.race([
-          syncUserDiscordLeaderboardRoles(userId),
-          new Promise((resolve) => setTimeout(resolve, SYNC_TIMEOUT)),
+      if (userId) {
+        // The redirect wins the race on a slow Discord, so without this the sync a user is waiting on can fail
+        // to finish every single time and look exactly like a sync that never ran.
+        let timer: NodeJS.Timeout | undefined;
+        const timedOut = await Promise.race([
+          syncUserDiscordLeaderboardRoles(userId).then(() => false),
+          new Promise<boolean>((resolve) => {
+            timer = setTimeout(() => resolve(true), SYNC_TIMEOUT);
+          }),
         ]);
+        clearTimeout(timer);
+
+        if (timedOut)
+          logToAxiom({
+            type: 'warn',
+            name: 'discord-link-sync-timeout',
+            error: { userId, timeout: SYNC_TIMEOUT },
+          });
+      }
     } catch (e) {
       logToAxiom({
-        type: 'discord-link-sync-error',
-        name: 'auth-linked',
+        type: 'error',
+        name: 'discord-link-sync-error',
         message: e instanceof Error ? e.message : String(e),
       });
     }

--- a/src/server/__tests__/connect-endpoint.test.ts
+++ b/src/server/__tests__/connect-endpoint.test.ts
@@ -12,6 +12,14 @@ function mockReqRes(query: Record<string, string>, host = 'civitai.com') {
     statusCode: 200 as number,
     body: undefined as unknown,
     location: undefined as string | undefined,
+    headers: {} as Record<string, unknown>,
+    getHeader(name: string) {
+      return this.headers[name];
+    },
+    setHeader(name: string, value: unknown) {
+      this.headers[name] = value;
+      return this;
+    },
     status(code: number) {
       this.statusCode = code;
       return this;

--- a/src/server/__tests__/connect-endpoint.test.ts
+++ b/src/server/__tests__/connect-endpoint.test.ts
@@ -48,17 +48,23 @@ describe('/api/auth/connect', () => {
     const url = new URL(res.location as string);
     expect(url.origin + url.pathname).toBe('https://auth.test/login/discord');
     expect(url.searchParams.get('link')).toBe('true');
-    // returnUrl is made absolute + same-origin from the request host (the hub returns here after linking).
-    expect(url.searchParams.get('returnUrl')).toBe('https://civitai.com/user/account#accounts');
+    // The hub returns to /api/auth/linked (absolute + same-origin from the request host) so the main app can run
+    // its post-link side effects, carrying the caller's path along for the forward.
+    const returned = new URL(url.searchParams.get('returnUrl') as string);
+    expect(returned.origin + returned.pathname).toBe('https://civitai.com/api/auth/linked');
+    expect(returned.searchParams.get('provider')).toBe('discord');
+    expect(returned.searchParams.get('returnUrl')).toBe('/user/account#accounts');
   });
 
   it('collapses an unsafe returnUrl to the origin root (no open redirect)', async () => {
     const handler = (await import('~/pages/api/auth/connect')).default;
     const { req, res } = mockReqRes({ provider: 'github', returnUrl: 'https://evil.com' });
     handler(req, res as unknown as NextApiResponse);
-    expect(new URL(res.location as string).searchParams.get('returnUrl')).toBe(
-      'https://civitai.com/'
+    const returned = new URL(
+      new URL(res.location as string).searchParams.get('returnUrl') as string
     );
+    expect(returned.origin + returned.pathname).toBe('https://civitai.com/api/auth/linked');
+    expect(returned.searchParams.get('returnUrl')).toBe('/');
   });
 
   it('400 when provider is missing', async () => {

--- a/src/server/__tests__/connect-endpoint.test.ts
+++ b/src/server/__tests__/connect-endpoint.test.ts
@@ -75,6 +75,38 @@ describe('/api/auth/connect', () => {
     expect(returned.searchParams.get('returnUrl')).toBe('/');
   });
 
+  // The other half of the one-shot protocol /api/auth/linked gates on. Asserted here by NAME and PATH, because
+  // the linked-endpoint test supplies its own cookie fixture — without this, deleting the call below leaves
+  // every test in both files green while the post-link sync is dead in production.
+  it('sets the one-shot link cookie that /api/auth/linked consumes', async () => {
+    const handler = (await import('~/pages/api/auth/connect')).default;
+    const { req, res } = mockReqRes({ provider: 'discord', returnUrl: '/user/account' });
+    handler(req, res as unknown as NextApiResponse);
+
+    const cookies = res.headers['Set-Cookie'] as string[];
+    const cookie = cookies.find((c) => c.startsWith('civ-link-sync='));
+    expect(cookie).toBeDefined();
+    expect(cookie).toContain('Path=/api/auth/linked');
+    expect(cookie).toContain('HttpOnly');
+  });
+
+  // Plain http in tests means the dev branch: None-without-Secure is browser-rejected, so it has to be Lax.
+  // On https the cookie rides a cross-registrable-domain return (civitai.red → hub → civitai.red), where Lax
+  // and host-only scoping are both known to drop it — see the bridge cookie this mirrors.
+  it('scopes the cookie for the cross-site return when the request is https', async () => {
+    const handler = (await import('~/pages/api/auth/connect')).default;
+    const { req, res } = mockReqRes({ provider: 'discord', returnUrl: '/' }, 'www.civitai.red');
+    (req.headers as Record<string, string>)['x-forwarded-proto'] = 'https';
+    handler(req, res as unknown as NextApiResponse);
+
+    const cookie = (res.headers['Set-Cookie'] as string[]).find((c) =>
+      c.startsWith('civ-link-sync=')
+    ) as string;
+    expect(cookie).toContain('SameSite=None');
+    expect(cookie).toContain('Secure');
+    expect(cookie).toContain('Domain=civitai.red');
+  });
+
   it('400 when provider is missing', async () => {
     const handler = (await import('~/pages/api/auth/connect')).default;
     const { req, res } = mockReqRes({});

--- a/src/server/__tests__/linked-endpoint.test.ts
+++ b/src/server/__tests__/linked-endpoint.test.ts
@@ -35,7 +35,7 @@ function mockReqRes(query: Record<string, string>, cookies: Record<string, strin
       return this;
     },
   };
-  const req = { query, cookies } as unknown as NextApiRequest;
+  const req = { query, cookies, headers: { host: 'civitai.com' } } as unknown as NextApiRequest;
   return { req, res };
 }
 

--- a/src/server/__tests__/linked-endpoint.test.ts
+++ b/src/server/__tests__/linked-endpoint.test.ts
@@ -6,14 +6,15 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 // effect is gated on the one-shot cookie /api/auth/connect sets — otherwise any page could fire it in a
 // logged-in visitor's browser and spend our Discord rate limit.
 
-const { mockSync, mockSession } = vi.hoisted(() => ({
+const { mockSync, mockSession, mockLog } = vi.hoisted(() => ({
   mockSync: vi.fn(),
   mockSession: vi.fn(),
+  mockLog: vi.fn(),
 }));
 
 vi.mock('~/server/jobs/apply-discord-roles', () => ({ syncUserDiscordLeaderboardRoles: mockSync }));
 vi.mock('~/server/auth/get-server-auth-session', () => ({ getServerAuthSession: mockSession }));
-vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn() }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: mockLog }));
 
 import handler from '~/pages/api/auth/linked';
 
@@ -107,5 +108,28 @@ describe('/api/auth/linked', () => {
 
     expect(res.statusCode).toBe(302);
     vi.useRealTimers();
+  });
+
+  // A sync that loses the race every time looks identical to one that never ran, so the timeout has to say so.
+  it('logs when the sync loses the race', async () => {
+    vi.useFakeTimers();
+    mockSync.mockReturnValue(new Promise(() => undefined));
+    const { req, res } = mockReqRes({ provider: 'discord', returnUrl: '/' }, linkStarted);
+
+    const pending = handler(req, res as unknown as NextApiResponse);
+    await vi.advanceTimersByTimeAsync(5000);
+    await pending;
+
+    expect(mockLog).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'discord-link-sync-timeout' })
+    );
+    vi.useRealTimers();
+  });
+
+  it('does not log a timeout when the sync finishes in time', async () => {
+    const { req, res } = mockReqRes({ provider: 'discord', returnUrl: '/' }, linkStarted);
+    await handler(req, res as unknown as NextApiResponse);
+
+    expect(mockLog).not.toHaveBeenCalled();
   });
 });

--- a/src/server/__tests__/linked-endpoint.test.ts
+++ b/src/server/__tests__/linked-endpoint.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+// Handler test lives OUTSIDE src/pages (Next would treat it as a route) and imports via the ~/pages alias.
+// /api/auth/linked runs the main app's post-link side effects and forwards on. It is a plain GET, so the side
+// effect is gated on the one-shot cookie /api/auth/connect sets — otherwise any page could fire it in a
+// logged-in visitor's browser and spend our Discord rate limit.
+
+const { mockSync, mockSession } = vi.hoisted(() => ({
+  mockSync: vi.fn(),
+  mockSession: vi.fn(),
+}));
+
+vi.mock('~/server/jobs/apply-discord-roles', () => ({ syncUserDiscordLeaderboardRoles: mockSync }));
+vi.mock('~/server/auth/get-server-auth-session', () => ({ getServerAuthSession: mockSession }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn() }));
+
+import handler from '~/pages/api/auth/linked';
+
+function mockReqRes(query: Record<string, string>, cookies: Record<string, string> = {}) {
+  const res = {
+    statusCode: 200 as number,
+    location: undefined as string | undefined,
+    headers: {} as Record<string, unknown>,
+    getHeader(name: string) {
+      return this.headers[name];
+    },
+    setHeader(name: string, value: unknown) {
+      this.headers[name] = value;
+      return this;
+    },
+    redirect(code: number, loc: string) {
+      this.statusCode = code;
+      this.location = loc;
+      return this;
+    },
+  };
+  const req = { query, cookies } as unknown as NextApiRequest;
+  return { req, res };
+}
+
+const linkStarted = { 'civ-link-sync': 'nonce' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSession.mockResolvedValue({ user: { id: 42 } });
+  mockSync.mockResolvedValue(undefined);
+});
+
+describe('/api/auth/linked', () => {
+  it('syncs and forwards to the caller path when the link started here', async () => {
+    const { req, res } = mockReqRes(
+      { provider: 'discord', returnUrl: '/user/account#accounts' },
+      linkStarted
+    );
+    await handler(req, res as unknown as NextApiResponse);
+
+    expect(mockSync).toHaveBeenCalledWith(42);
+    expect(res.statusCode).toBe(302);
+    expect(res.location).toBe('/user/account#accounts');
+  });
+
+  it('forwards without syncing when no link was started in this browser', async () => {
+    const { req, res } = mockReqRes({ provider: 'discord', returnUrl: '/user/account' });
+    await handler(req, res as unknown as NextApiResponse);
+
+    expect(mockSync).not.toHaveBeenCalled();
+    expect(res.location).toBe('/user/account');
+  });
+
+  it('consumes the cookie, so a replay of the same URL does not sync again', async () => {
+    const { req, res } = mockReqRes({ provider: 'discord', returnUrl: '/' }, linkStarted);
+    await handler(req, res as unknown as NextApiResponse);
+
+    const cookies = res.getHeader('Set-Cookie') as string[];
+    expect(cookies.some((c) => c.startsWith('civ-link-sync=;') && c.includes('Max-Age=0'))).toBe(
+      true
+    );
+  });
+
+  it('carries the hub error through and skips the sync', async () => {
+    const { req, res } = mockReqRes(
+      { provider: 'discord', returnUrl: '/user/account#accounts', error: 'AccountNotLinked' },
+      linkStarted
+    );
+    await handler(req, res as unknown as NextApiResponse);
+
+    expect(mockSync).not.toHaveBeenCalled();
+    expect(res.location).toBe('/user/account?error=AccountNotLinked#accounts');
+  });
+
+  it('collapses an unsafe returnUrl instead of redirecting off-site', async () => {
+    const { req, res } = mockReqRes({ provider: 'discord', returnUrl: 'https://evil.com' });
+    await handler(req, res as unknown as NextApiResponse);
+
+    expect(res.location).toBe('/');
+  });
+
+  it('still redirects when the sync hangs', async () => {
+    vi.useFakeTimers();
+    mockSync.mockReturnValue(new Promise(() => undefined));
+    const { req, res } = mockReqRes({ provider: 'discord', returnUrl: '/' }, linkStarted);
+
+    const pending = handler(req, res as unknown as NextApiResponse);
+    await vi.advanceTimersByTimeAsync(5000);
+    await pending;
+
+    expect(res.statusCode).toBe(302);
+    vi.useRealTimers();
+  });
+});

--- a/src/server/auth/link-sync.ts
+++ b/src/server/auth/link-sync.ts
@@ -1,11 +1,31 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { cookieDomainForHost } from '~/server/auth/civ-cookie';
 
 // One-shot marker proving THIS browser started an account link through /api/auth/connect, so /api/auth/linked
 // will only run post-link side effects for a link it actually initiated. Without it the endpoint is a plain GET
 // with a third-party side effect: any page could fire it in a logged-in visitor's browser and spend our Discord
 // rate limit. Not a security boundary — linking already happened at the hub — just a cost one.
 export const LINK_SYNC_COOKIE = 'civ-link-sync';
-const MAX_AGE = 10 * 60;
+const MAX_AGE = 15 * 60;
+
+// Same round trip as the OAuth bridge cookie (spoke → hub → spoke), so it needs the same two properties that
+// prod telemetry forced there: SameSite=None to ride a cross-registrable-domain return (civitai.red → the hub
+// is cross-site; Lax would drop it), and Domain=<registrable> to survive a www↔apex host variation between the
+// set and the read. Lax + host-only in dev, where None-without-Secure is browser-rejected.
+function build(value: string, maxAge: number, req: NextApiRequest) {
+  const secure = (req.headers?.['x-forwarded-proto'] ?? '').toString().split(',')[0] === 'https';
+  const domain = secure ? cookieDomainForHost(req.headers?.host) : undefined;
+
+  return [
+    `${LINK_SYNC_COOKIE}=${value}`,
+    'Path=/api/auth/linked',
+    'HttpOnly',
+    secure ? 'SameSite=None' : 'SameSite=Lax',
+    ...(secure ? ['Secure'] : []),
+    ...(domain ? [`Domain=${domain}`] : []),
+    `Max-Age=${maxAge}`,
+  ].join('; ');
+}
 
 function appendCookie(res: NextApiResponse, cookie: string) {
   const existing = res.getHeader('Set-Cookie');
@@ -13,21 +33,17 @@ function appendCookie(res: NextApiResponse, cookie: string) {
   res.setHeader('Set-Cookie', [...cookies, cookie]);
 }
 
-function attributes() {
-  const secure = process.env.NODE_ENV === 'production' ? '; Secure' : '';
-  return `Path=/api/auth/linked; HttpOnly; SameSite=Lax${secure}`;
-}
-
-export function setLinkSyncCookie(res: NextApiResponse, value: string) {
-  appendCookie(res, `${LINK_SYNC_COOKIE}=${value}; Max-Age=${MAX_AGE}; ${attributes()}`);
+export function setLinkSyncCookie(req: NextApiRequest, res: NextApiResponse, value: string) {
+  appendCookie(res, build(value, MAX_AGE, req));
 }
 
 // Reading it consumes it: the expiry header goes out with the redirect, so a replay of the same URL finds no
-// cookie and skips the side effect.
+// cookie and skips the side effect. Cleared with the same attributes it was set with — a Domain-scoped cookie
+// can only be cleared by a matching Domain.
 export function takeLinkSyncCookie(req: NextApiRequest, res: NextApiResponse) {
   const value = req.cookies?.[LINK_SYNC_COOKIE];
   if (!value) return false;
 
-  appendCookie(res, `${LINK_SYNC_COOKIE}=; Max-Age=0; ${attributes()}`);
+  appendCookie(res, build('', 0, req));
   return true;
 }

--- a/src/server/auth/link-sync.ts
+++ b/src/server/auth/link-sync.ts
@@ -1,0 +1,33 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+// One-shot marker proving THIS browser started an account link through /api/auth/connect, so /api/auth/linked
+// will only run post-link side effects for a link it actually initiated. Without it the endpoint is a plain GET
+// with a third-party side effect: any page could fire it in a logged-in visitor's browser and spend our Discord
+// rate limit. Not a security boundary — linking already happened at the hub — just a cost one.
+export const LINK_SYNC_COOKIE = 'civ-link-sync';
+const MAX_AGE = 10 * 60;
+
+function appendCookie(res: NextApiResponse, cookie: string) {
+  const existing = res.getHeader('Set-Cookie');
+  const cookies = Array.isArray(existing) ? existing : existing ? [String(existing)] : [];
+  res.setHeader('Set-Cookie', [...cookies, cookie]);
+}
+
+function attributes() {
+  const secure = process.env.NODE_ENV === 'production' ? '; Secure' : '';
+  return `Path=/api/auth/linked; HttpOnly; SameSite=Lax${secure}`;
+}
+
+export function setLinkSyncCookie(res: NextApiResponse, value: string) {
+  appendCookie(res, `${LINK_SYNC_COOKIE}=${value}; Max-Age=${MAX_AGE}; ${attributes()}`);
+}
+
+// Reading it consumes it: the expiry header goes out with the redirect, so a replay of the same URL finds no
+// cookie and skips the side effect.
+export function takeLinkSyncCookie(req: NextApiRequest, res: NextApiResponse) {
+  const value = req.cookies?.[LINK_SYNC_COOKIE];
+  if (!value) return false;
+
+  appendCookie(res, `${LINK_SYNC_COOKIE}=; Max-Age=0; ${attributes()}`);
+  return true;
+}

--- a/src/server/integrations/discord.ts
+++ b/src/server/integrations/discord.ts
@@ -234,13 +234,19 @@ const getAllRoles = async () => {
   return res as DiscordRole[];
 };
 
+const UNKNOWN_MEMBER = 10007;
+
+// Returns false when the role could not be granted because the user isn't in the guild yet.
+// Callers must not record the role as granted in that case, or it will never be retried.
 const addRoleToUser = async (user_id: string, role_id: string) => {
   const discord = getDiscordClient();
   if (!env.DISCORD_GUILD_ID) throw new Error('DISCORD_GUILD_ID not set');
   try {
     await discord.put(Routes.guildMemberRole(env.DISCORD_GUILD_ID, user_id, role_id));
+    return true;
   } catch (e: any) {
-    if (e.code !== 10007) throw e;
+    if (e.code !== UNKNOWN_MEMBER) throw e;
+    return false;
   }
 };
 
@@ -250,8 +256,9 @@ const removeRoleFromUser = async (user_id: string, role_id: string) => {
   try {
     await discord.delete(Routes.guildMemberRole(env.DISCORD_GUILD_ID, user_id, role_id));
   } catch (e: any) {
-    if (e.code !== 10007) throw e;
+    if (e.code !== UNKNOWN_MEMBER) throw e;
   }
+  return true;
 };
 
 export const getDiscordId = async (userId: number) => {

--- a/src/server/jobs/__tests__/apply-discord-roles.test.ts
+++ b/src/server/jobs/__tests__/apply-discord-roles.test.ts
@@ -70,8 +70,9 @@ beforeEach(() => {
   mockDiscord.getAllRoles.mockResolvedValue([TOP_10, TOP_100]);
   mockDiscord.addRoleToUser.mockResolvedValue(true);
   mockDiscord.removeRoleFromUser.mockResolvedValue(true);
-  // getAccountsInRole: Top 100 first, then Top 10.
+  // $queryRaw order: the UserRank board-spread check, then getAccountsInRole for Top 100 and Top 10.
   mockDbWrite.$queryRaw.mockResolvedValue([]);
+  mockDbWrite.$queryRaw.mockResolvedValueOnce([{ boards: 31 }]);
   mockDbWrite.user.findMany.mockResolvedValue([]);
 });
 
@@ -181,6 +182,37 @@ describe('applyDiscordLeaderboardRoles — Top 10 removal', () => {
   });
 });
 
+describe('applyDiscordLeaderboardRoles — UserRank has to be diffable', () => {
+  // updateLeaderboardRank({ leaderboardIds }) truncates UserRank and refills it from one event's boards. The
+  // table is populated and the rows are real, so only the spread of boards separates that from a full rebuild.
+  it('aborts when UserRank covers only one board', async () => {
+    mockDbWrite.$queryRaw.mockReset();
+    mockDbWrite.$queryRaw.mockResolvedValue([]);
+    mockDbWrite.$queryRaw.mockResolvedValueOnce([{ boards: 1 }]);
+    mockDbWrite.user.findMany.mockResolvedValue([topUser(5, '111')]);
+
+    await applyDiscordLeaderboardRoles();
+
+    expect(mockDbWrite.user.findMany).not.toHaveBeenCalled();
+    expect(mockDiscord.removeRoleFromUser).not.toHaveBeenCalled();
+    expect(mockDiscord.addRoleToUser).not.toHaveBeenCalled();
+  });
+
+  // The guards above all assert a negative, so this pins that an ordinary revoke still gets through them —
+  // a guard that blocks everything would satisfy every other test in this file.
+  it('still revokes an ordinary share of holders', async () => {
+    const holders = Array.from({ length: 20 }, (_, i) => ({ providerAccountId: `${100 + i}` }));
+    mockDbWrite.user.findMany.mockResolvedValue(
+      holders.slice(0, 15).map((h, i) => topUser(50 + i, h.providerAccountId))
+    );
+    mockDbWrite.$queryRaw.mockResolvedValueOnce(holders).mockResolvedValueOnce([]);
+
+    await applyDiscordLeaderboardRoles();
+
+    expect(idsWritten('revoke', 'Top 100').sort()).toEqual(['115', '116', '117', '118', '119']);
+  });
+});
+
 describe('syncUserDiscordLeaderboardRoles', () => {
   it('grants both roles to a top-10 user without revoking anything', async () => {
     mockDbWrite.user.findUnique.mockResolvedValue({
@@ -193,6 +225,40 @@ describe('syncUserDiscordLeaderboardRoles', () => {
     expect(idsWritten('grant', 'Top 100')).toEqual(['111']);
     expect(idsWritten('grant', 'Top 10')).toEqual(['111']);
     expect(mockDiscord.removeRoleFromUser).not.toHaveBeenCalled();
+  });
+
+  it('grants only Top 100 to a user ranked outside the top 10', async () => {
+    mockDbWrite.user.findUnique.mockResolvedValue({
+      rank: { leaderboardRank: 50 },
+      accounts: [{ providerAccountId: '111' }],
+    });
+
+    await syncUserDiscordLeaderboardRoles(1);
+
+    expect(idsWritten('grant', 'Top 100')).toEqual(['111']);
+    expect(idsWritten('grant', 'Top 10')).toEqual([]);
+  });
+
+  it('touches nothing for a user ranked outside the top 100', async () => {
+    mockDbWrite.user.findUnique.mockResolvedValue({
+      rank: { leaderboardRank: 101 },
+      accounts: [{ providerAccountId: '111' }],
+    });
+
+    await syncUserDiscordLeaderboardRoles(1);
+
+    expect(mockDiscord.addRoleToUser).not.toHaveBeenCalled();
+  });
+
+  it('touches nothing for a user with no linked Discord account', async () => {
+    mockDbWrite.user.findUnique.mockResolvedValue({
+      rank: { leaderboardRank: 3 },
+      accounts: [],
+    });
+
+    await syncUserDiscordLeaderboardRoles(1);
+
+    expect(mockDiscord.addRoleToUser).not.toHaveBeenCalled();
   });
 
   it('touches nothing for an unranked user', async () => {

--- a/src/server/jobs/__tests__/apply-discord-roles.test.ts
+++ b/src/server/jobs/__tests__/apply-discord-roles.test.ts
@@ -32,7 +32,10 @@ vi.mock('~/server/jobs/job', () => ({
   getJobDate: vi.fn().mockResolvedValue([new Date(0), vi.fn()]),
 }));
 
-import { applyDiscordLeaderboardRoles } from '~/server/jobs/apply-discord-roles';
+import {
+  applyDiscordLeaderboardRoles,
+  syncUserDiscordLeaderboardRoles,
+} from '~/server/jobs/apply-discord-roles';
 
 const TOP_10 = { id: 'role-10', name: 'Top 10' };
 const TOP_100 = { id: 'role-100', name: 'Top 100' };
@@ -40,15 +43,20 @@ const TOP_100 = { id: 'role-100', name: 'Top 100' };
 type RawCall = [TemplateStringsArray, ...unknown[]];
 
 // The metadata writes are tagged templates, so recover each one's bound params and read back the
-// providerAccountIds it touched. Grants append to the array (`||`); revokes only subtract.
+// providerAccountIds it touched. Only a grant binds the role as a JSON array (the value it appends); both bind
+// the bare name (the value they subtract), so that pair identifies the direction without reading the SQL text.
 function idsWritten(kind: 'grant' | 'revoke', roleName: string) {
+  const appended = JSON.stringify([roleName]);
   return (mockDbWrite.$executeRaw.mock.calls as RawCall[])
     .map(([strings, ...values]) => Prisma.sql(strings, ...values))
     .filter(
-      (query) => query.values.includes(roleName) && query.sql.includes('||') === (kind === 'grant')
+      (query) =>
+        query.values.includes(roleName) && query.values.includes(appended) === (kind === 'grant')
     )
     .flatMap((query) =>
-      query.values.filter((v): v is string => typeof v === 'string' && /^\d+$/.test(v))
+      query.values.filter(
+        (v): v is string => typeof v === 'string' && v !== roleName && v !== appended
+      )
     );
 }
 
@@ -141,6 +149,61 @@ describe('applyDiscordLeaderboardRoles — Top 10 removal', () => {
     await applyDiscordLeaderboardRoles();
 
     expect(mockDiscord.removeRoleFromUser).not.toHaveBeenCalled();
+    expect(mockDbWrite.$executeRaw).not.toHaveBeenCalled();
+  });
+
+  // Taking a role away from someone who has it is worse than failing to grant one, so the revoke direction gets
+  // the same treatment: metadata follows Discord's answer per account.
+  it('keeps the role recorded for an account whose revoke Discord rejected', async () => {
+    const holders = [{ providerAccountId: '111' }, { providerAccountId: '222' }];
+    mockDbWrite.user.findMany.mockResolvedValue([topUser(5, '333')]);
+    mockDbWrite.$queryRaw.mockResolvedValueOnce(holders).mockResolvedValueOnce([]);
+    mockDiscord.removeRoleFromUser.mockImplementation(async (providerAccountId: string) => {
+      if (providerAccountId === '222') throw new Error('Missing Permissions');
+      return true;
+    });
+
+    await applyDiscordLeaderboardRoles();
+
+    expect(idsWritten('revoke', 'Top 100')).toEqual(['111']);
+  });
+
+  // updateLeaderboardRank({ leaderboardIds }) truncates UserRank and refills it with one event's users, so a
+  // near-total revoke list means our view of who is ranked collapsed, not that the leaderboard emptied out.
+  it('refuses to revoke in bulk when most holders would lose the role at once', async () => {
+    const holders = Array.from({ length: 20 }, (_, i) => ({ providerAccountId: `${100 + i}` }));
+    mockDbWrite.user.findMany.mockResolvedValue([topUser(5, '100')]);
+    mockDbWrite.$queryRaw.mockResolvedValueOnce(holders).mockResolvedValueOnce([]);
+
+    await applyDiscordLeaderboardRoles();
+
+    expect(mockDiscord.removeRoleFromUser).not.toHaveBeenCalled();
+  });
+});
+
+describe('syncUserDiscordLeaderboardRoles', () => {
+  it('grants both roles to a top-10 user without revoking anything', async () => {
+    mockDbWrite.user.findUnique.mockResolvedValue({
+      rank: { leaderboardRank: 3 },
+      accounts: [{ providerAccountId: '111' }],
+    });
+
+    await syncUserDiscordLeaderboardRoles(1);
+
+    expect(idsWritten('grant', 'Top 100')).toEqual(['111']);
+    expect(idsWritten('grant', 'Top 10')).toEqual(['111']);
+    expect(mockDiscord.removeRoleFromUser).not.toHaveBeenCalled();
+  });
+
+  it('touches nothing for an unranked user', async () => {
+    mockDbWrite.user.findUnique.mockResolvedValue({
+      rank: null,
+      accounts: [{ providerAccountId: '111' }],
+    });
+
+    await syncUserDiscordLeaderboardRoles(1);
+
+    expect(mockDiscord.addRoleToUser).not.toHaveBeenCalled();
     expect(mockDbWrite.$executeRaw).not.toHaveBeenCalled();
   });
 });

--- a/src/server/jobs/__tests__/apply-discord-roles.test.ts
+++ b/src/server/jobs/__tests__/apply-discord-roles.test.ts
@@ -1,0 +1,131 @@
+import { Prisma } from '@prisma/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Account.metadata->'roles' is our only record of what Discord has, and it is also the skip list for the next
+ * run. So writing it for an account Discord rejected is unrecoverable: the user never gets the role and we
+ * never try again. These pin that the write follows Discord's answer, per account.
+ */
+
+const { mockDbWrite, mockDiscord } = vi.hoisted(() => ({
+  mockDbWrite: {
+    $queryRaw: vi.fn(),
+    $executeRaw: vi.fn().mockResolvedValue(undefined),
+    user: { findMany: vi.fn(), findUnique: vi.fn() },
+  },
+  mockDiscord: {
+    getAllRoles: vi.fn(),
+    addRoleToUser: vi.fn(),
+    removeRoleFromUser: vi.fn(),
+  },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbWrite: mockDbWrite }));
+vi.mock('~/server/integrations/discord', () => ({ discord: mockDiscord }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn() }));
+vi.mock('~/server/jobs/job', () => ({
+  createJob: (name: string, cron: string, fn: (e: unknown) => Promise<unknown>) => ({
+    name,
+    cron,
+    run: () => fn(undefined),
+  }),
+  getJobDate: vi.fn().mockResolvedValue([new Date(0), vi.fn()]),
+}));
+
+import { applyDiscordLeaderboardRoles } from '~/server/jobs/apply-discord-roles';
+
+const TOP_10 = { id: 'role-10', name: 'Top 10' };
+const TOP_100 = { id: 'role-100', name: 'Top 100' };
+
+type RawCall = [TemplateStringsArray, ...unknown[]];
+
+// The metadata writes are tagged templates, so recover each one's bound params and read back the
+// providerAccountIds it touched. Grants append to the array (`||`); revokes only subtract.
+function idsWritten(kind: 'grant' | 'revoke', roleName: string) {
+  return (mockDbWrite.$executeRaw.mock.calls as RawCall[])
+    .map(([strings, ...values]) => Prisma.sql(strings, ...values))
+    .filter(
+      (query) => query.values.includes(roleName) && query.sql.includes('||') === (kind === 'grant')
+    )
+    .flatMap((query) =>
+      query.values.filter((v): v is string => typeof v === 'string' && /^\d+$/.test(v))
+    );
+}
+
+function topUser(rank: number, providerAccountId: string) {
+  return { rank: { leaderboardRank: rank }, accounts: [{ providerAccountId }] };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDbWrite.$executeRaw.mockResolvedValue(undefined);
+  mockDiscord.getAllRoles.mockResolvedValue([TOP_10, TOP_100]);
+  mockDiscord.addRoleToUser.mockResolvedValue(true);
+  mockDiscord.removeRoleFromUser.mockResolvedValue(true);
+  // getAccountsInRole: Top 100 first, then Top 10.
+  mockDbWrite.$queryRaw.mockResolvedValue([]);
+  mockDbWrite.user.findMany.mockResolvedValue([]);
+});
+
+describe('applyDiscordLeaderboardRoles — metadata must follow Discord', () => {
+  it('does not record the role for an account Discord rejected', async () => {
+    mockDbWrite.user.findMany.mockResolvedValue([topUser(5, '111'), topUser(50, '222')]);
+    mockDiscord.addRoleToUser.mockImplementation(async (providerAccountId: string) => {
+      if (providerAccountId === '222') throw new Error('Missing Access');
+      return true;
+    });
+
+    await applyDiscordLeaderboardRoles();
+
+    expect(idsWritten('grant', 'Top 100')).toEqual(['111']);
+  });
+
+  it('does not record the role for a user who has not joined the guild', async () => {
+    mockDbWrite.user.findMany.mockResolvedValue([topUser(5, '111'), topUser(50, '222')]);
+    // addRoleToUser resolves false for an unknown member — nothing was granted, so it must stay retryable.
+    mockDiscord.addRoleToUser.mockImplementation(async (providerAccountId: string) => {
+      return providerAccountId !== '222';
+    });
+
+    await applyDiscordLeaderboardRoles();
+
+    expect(idsWritten('grant', 'Top 100')).toEqual(['111']);
+  });
+
+  it('writes nothing when every Discord call fails', async () => {
+    mockDbWrite.user.findMany.mockResolvedValue([topUser(5, '111')]);
+    mockDiscord.addRoleToUser.mockRejectedValue(new Error('Service Unavailable'));
+
+    await applyDiscordLeaderboardRoles();
+
+    expect(mockDbWrite.$executeRaw).not.toHaveBeenCalled();
+  });
+
+  it('keeps every account of a user with more than one linked Discord row', async () => {
+    mockDbWrite.user.findMany.mockResolvedValue([
+      {
+        rank: { leaderboardRank: 5 },
+        accounts: [{ providerAccountId: '111' }, { providerAccountId: '333' }],
+      },
+    ]);
+
+    await applyDiscordLeaderboardRoles();
+
+    expect(idsWritten('grant', 'Top 100').sort()).toEqual(['111', '333']);
+  });
+});
+
+describe('applyDiscordLeaderboardRoles — Top 10 removal', () => {
+  it('revokes Top 10 from a user who fell out of the top 10 but is still in the top 100', async () => {
+    mockDbWrite.user.findMany.mockResolvedValue([topUser(50, '222')]);
+    mockDbWrite.$queryRaw
+      .mockResolvedValueOnce([{ providerAccountId: '222' }]) // already has Top 100
+      .mockResolvedValueOnce([{ providerAccountId: '222' }]); // and still has Top 10
+
+    await applyDiscordLeaderboardRoles();
+
+    expect(mockDiscord.removeRoleFromUser).toHaveBeenCalledWith('222', TOP_10.id);
+    expect(idsWritten('revoke', 'Top 10')).toEqual(['222']);
+    expect(mockDiscord.removeRoleFromUser).not.toHaveBeenCalledWith('222', TOP_100.id);
+  });
+});

--- a/src/server/jobs/__tests__/apply-discord-roles.test.ts
+++ b/src/server/jobs/__tests__/apply-discord-roles.test.ts
@@ -128,4 +128,19 @@ describe('applyDiscordLeaderboardRoles — Top 10 removal', () => {
     expect(idsWritten('revoke', 'Top 10')).toEqual(['222']);
     expect(mockDiscord.removeRoleFromUser).not.toHaveBeenCalledWith('222', TOP_100.id);
   });
+
+  // The job no longer refuses to run on a partially populated leaderboard, so an empty UserRank reaches this
+  // code instead of being filtered out upstream. Reading it as "everyone left the top 100" would strip the role
+  // from every holder in one run.
+  it('strips nobody when no ranked user has a linked Discord account', async () => {
+    mockDbWrite.user.findMany.mockResolvedValue([]);
+    mockDbWrite.$queryRaw
+      .mockResolvedValueOnce([{ providerAccountId: '111' }, { providerAccountId: '222' }])
+      .mockResolvedValueOnce([{ providerAccountId: '111' }]);
+
+    await applyDiscordLeaderboardRoles();
+
+    expect(mockDiscord.removeRoleFromUser).not.toHaveBeenCalled();
+    expect(mockDbWrite.$executeRaw).not.toHaveBeenCalled();
+  });
 });

--- a/src/server/jobs/apply-discord-roles.ts
+++ b/src/server/jobs/apply-discord-roles.ts
@@ -1,8 +1,10 @@
+import { Prisma } from '@prisma/client';
 import dayjs from '~/shared/utils/dayjs';
 import { env } from '~/env/server';
 import { dbWrite } from '~/server/db/client';
 import type { DiscordRole } from '~/server/integrations/discord';
 import { discord } from '~/server/integrations/discord';
+import { logToAxiom } from '~/server/logging/client';
 import { limitConcurrency } from '~/server/utils/concurrency-helpers';
 import { createJob } from './job';
 
@@ -84,65 +86,104 @@ const applyDiscordActivityRoles = createJob(
   }
 );
 
-export const applyDiscordLeaderboardRoles = async () => {
+const getLeaderboardRoles = async () => {
   const discordRoles = await discord.getAllRoles();
 
   const top10Role = discordRoles.find((r) => r.name === 'Top 10');
   const top100Role = discordRoles.find((r) => r.name === 'Top 100');
-  if (!top100Role || !top10Role) return;
+  if (!top100Role || !top10Role) {
+    logToAxiom({
+      type: 'discord-role-sync-aborted',
+      name: 'apply-discord-leaderboard-roles',
+      reason: 'leaderboard roles not found in guild',
+      missing: [!top10Role && 'Top 10', !top100Role && 'Top 100'].filter(Boolean),
+    });
+    return null;
+  }
+
+  return { top10Role, top100Role };
+};
+
+export const applyDiscordLeaderboardRoles = async () => {
+  const roles = await getLeaderboardRoles();
+  if (!roles) return;
+  const { top10Role, top100Role } = roles;
 
   const existingTop100 = await getAccountsInRole(top100Role);
   const existingTop10 = await getAccountsInRole(top10Role);
 
   // Get the top 100 users with a discord account
-  const top100 =
-    (
-      await dbWrite.user.findMany({
-        where: {
-          rank: { leaderboardRank: { lte: 100 } },
-          accounts: {
-            some: { provider: 'discord' },
+  const top100 = (
+    await dbWrite.user.findMany({
+      where: {
+        rank: { leaderboardRank: { lte: 100 } },
+        accounts: {
+          some: { provider: 'discord' },
+        },
+      },
+      select: {
+        rank: {
+          select: {
+            leaderboardRank: true,
           },
         },
-        select: {
-          rank: {
-            select: {
-              leaderboardRank: true,
-            },
-          },
-          accounts: {
-            select: { providerAccountId: true },
-            where: { provider: 'discord' },
-          },
+        accounts: {
+          select: { providerAccountId: true },
+          where: { provider: 'discord' },
         },
-      })
-    )?.map((s) => ({
+      },
+    })
+  ).flatMap((s) =>
+    s.accounts.map((account) => ({
       rank: s.rank?.leaderboardRank,
-      providerAccountId: s.accounts[0].providerAccountId,
-    })) ?? [];
+      providerAccountId: account.providerAccountId,
+    }))
+  );
+
+  const top100Ids = new Set(top100.map((u) => u.providerAccountId));
+  const top10Ids = new Set(
+    top100.filter((u) => u.rank && u.rank <= 10).map((u) => u.providerAccountId)
+  );
 
   // Get the new users in the top 100 and the users that are no longer in the top 100
-  const newTop100 = top100
-    .filter((u) => !existingTop100.includes(u.providerAccountId))
-    .map((u) => u.providerAccountId);
+  const newTop100 = [...top100Ids].filter((id) => !existingTop100.includes(id));
   await addRoleToAccounts(top100Role, newTop100);
 
-  const removedTop100 = existingTop100.filter(
-    (u) => !top100.map((u) => u.providerAccountId).includes(u)
-  );
+  const removedTop100 = existingTop100.filter((id) => !top100Ids.has(id));
   await removeRoleFromAccounts(top100Role, removedTop100);
 
   // Get the new users in the top 10 and the users that are no longer in the top 10
-  const newTop10 = top100
-    .filter((u) => u.rank && u.rank <= 10)
-    .filter((u) => !existingTop10.includes(u.providerAccountId))
-    .map((u) => u.providerAccountId);
+  const newTop10 = [...top10Ids].filter((id) => !existingTop10.includes(id));
   await addRoleToAccounts(top10Role, newTop10);
 
-  const removedTop10 = existingTop10.filter(
-    (u) => !top100.map((u) => u.providerAccountId).includes(u)
-  );
+  const removedTop10 = existingTop10.filter((id) => !top10Ids.has(id));
   await removeRoleFromAccounts(top10Role, removedTop10);
+};
+
+// Grant-only sync for a single user, so linking Discord doesn't mean waiting for the nightly cron. Removals stay
+// with the cron: a link should never strip a role because our rank data happens to be mid-refresh.
+export const syncUserDiscordLeaderboardRoles = async (userId: number) => {
+  const roles = await getLeaderboardRoles();
+  if (!roles) return;
+  const { top10Role, top100Role } = roles;
+
+  const user = await dbWrite.user.findUnique({
+    where: { id: userId },
+    select: {
+      rank: { select: { leaderboardRank: true } },
+      accounts: {
+        select: { providerAccountId: true },
+        where: { provider: 'discord' },
+      },
+    },
+  });
+
+  const rank = user?.rank?.leaderboardRank;
+  const providerAccountIds = user?.accounts.map((a) => a.providerAccountId) ?? [];
+  if (!providerAccountIds.length || !rank || rank > 100) return;
+
+  await addRoleToAccounts(top100Role, providerAccountIds);
+  if (rank <= 10) await addRoleToAccounts(top10Role, providerAccountIds);
 };
 
 const applyDiscordPaidRoles = createJob('apply-discord-paid-roles', '*/10 * * * *', async () => {
@@ -211,67 +252,93 @@ export const applyDiscordRoles = [applyDiscordActivityRoles, applyDiscordPaidRol
 
 // #region [utilities]
 const getAccountsInRole = async (role: DiscordRole) => {
+  const roleValue = JSON.stringify([role.name]);
   return (
     (
-      await dbWrite.$queryRawUnsafe<{ providerAccountId: string }[]>(`
+      await dbWrite.$queryRaw<{ providerAccountId: string }[]>`
       SELECT
         "providerAccountId"
       FROM "Account"
       WHERE
           provider = 'discord'
-      AND metadata -> 'roles' @> '["${role.name}"]';`)
+      AND metadata -> 'roles' @> ${roleValue}::jsonb`
     )?.map((x) => x.providerAccountId) ?? []
   );
 };
 
-const addRoleToAccounts = async (role: DiscordRole, providerAccountIds: string[]) => {
-  // Update discord
+// Our metadata is a record of what Discord accepted, so only the accounts Discord actually accepted may be
+// written. Recording a role we failed to apply is unrecoverable: the next run reads it back as already-granted
+// and never retries.
+const applyToDiscord = async (
+  role: DiscordRole,
+  providerAccountIds: string[],
+  action: 'add' | 'remove'
+) => {
+  const applied: string[] = [];
+  let notInGuild = 0;
+  const errors: string[] = [];
+
   const tasks = providerAccountIds.map((providerAccountId) => async () => {
     try {
-      await discord.addRoleToUser(providerAccountId, role.id);
+      const ok =
+        action === 'add'
+          ? await discord.addRoleToUser(providerAccountId, role.id)
+          : await discord.removeRoleFromUser(providerAccountId, role.id);
+      if (ok) applied.push(providerAccountId);
+      else notInGuild++;
     } catch (e) {
-      console.error(e);
+      errors.push(e instanceof Error ? e.message : String(e));
     }
   });
   await limitConcurrency(tasks, 10);
 
-  // Update the accounts in the database
+  if (notInGuild || errors.length) {
+    logToAxiom({
+      type: 'discord-role-sync',
+      name: 'apply-discord-roles',
+      role: role.name,
+      action,
+      requested: providerAccountIds.length,
+      applied: applied.length,
+      notInGuild,
+      failed: errors.length,
+      errors: [...new Set(errors)].slice(0, 5),
+    });
+  }
+
+  return applied;
+};
+
+const addRoleToAccounts = async (role: DiscordRole, providerAccountIds: string[]) => {
+  if (providerAccountIds.length === 0) return;
+  const granted = await applyToDiscord(role, providerAccountIds, 'add');
+  if (granted.length === 0) return;
+
   const roleValue = JSON.stringify([role.name]);
-  const ids = providerAccountIds.map((id) => `'${id}'`).join(',');
-  if (ids.length === 0) return;
-  await dbWrite.$executeRawUnsafe(`
+  await dbWrite.$executeRaw`
     UPDATE "Account"
     SET metadata = jsonb_set(
       metadata,
       '{roles}',
-      COALESCE(metadata->'roles', '[]'::jsonb) || '${roleValue}'::jsonb,
+      (COALESCE(metadata->'roles', '[]'::jsonb) - ${role.name}::text) || ${roleValue}::jsonb,
       true
     )
-    WHERE "providerAccountId" IN (${ids})`);
+    WHERE "providerAccountId" IN (${Prisma.join(granted)})`;
 };
 
 const removeRoleFromAccounts = async (role: DiscordRole, providerAccountIds: string[]) => {
-  // Update discord
-  const tasks = providerAccountIds.map((providerAccountId) => async () => {
-    try {
-      await discord.removeRoleFromUser(providerAccountId, role.id);
-    } catch (e) {
-      console.error(e);
-    }
-  });
-  await limitConcurrency(tasks, 10);
+  if (providerAccountIds.length === 0) return;
+  const revoked = await applyToDiscord(role, providerAccountIds, 'remove');
+  if (revoked.length === 0) return;
 
-  // Update the accounts in the database
-  const ids = providerAccountIds.map((id) => `'${id}'`).join(',');
-  if (ids.length === 0) return;
-  await dbWrite.$executeRawUnsafe(`
+  await dbWrite.$executeRaw`
     UPDATE "Account"
     SET metadata = jsonb_set(
       metadata,
       '{roles}',
-      COALESCE(metadata->'roles', '[]'::jsonb) - '${role.name}',
+      COALESCE(metadata->'roles', '[]'::jsonb) - ${role.name}::text,
       true
     )
-    WHERE "providerAccountId" IN (${ids})`);
+    WHERE "providerAccountId" IN (${Prisma.join(revoked)})`;
 };
 // #endregion

--- a/src/server/jobs/apply-discord-roles.ts
+++ b/src/server/jobs/apply-discord-roles.ts
@@ -86,6 +86,30 @@ const applyDiscordActivityRoles = createJob(
   }
 );
 
+// Nobody sheds half the leaderboard overnight, so a revoke list that size means our view of who is ranked
+// collapsed. UserRank is rebuilt by TRUNCATE + INSERT, and updateLeaderboardRank({ leaderboardIds }) — the
+// hourly event path — legitimately leaves it holding only that event's users until the next nightly rebuild.
+// Before this job ran unguarded that could not reach us; now it can, and it would strip the roles for real.
+const REVOKE_SHARE_LIMIT = 0.5;
+const REVOKE_FLOOR = 10;
+
+const withinBlastRadius = (role: DiscordRole, revoking: string[], holders: string[]) => {
+  if (holders.length < REVOKE_FLOOR) return true;
+  if (revoking.length <= holders.length * REVOKE_SHARE_LIMIT) return true;
+
+  logToAxiom({
+    type: 'discord-role-sync-aborted',
+    name: 'apply-discord-leaderboard-roles',
+    error: {
+      reason: 'revoke list too large — refusing to strip the role in bulk',
+      role: role.name,
+      revoking: revoking.length,
+      holders: holders.length,
+    },
+  });
+  return false;
+};
+
 const getLeaderboardRoles = async () => {
   const discordRoles = await discord.getAllRoles();
 
@@ -95,8 +119,10 @@ const getLeaderboardRoles = async () => {
     logToAxiom({
       type: 'discord-role-sync-aborted',
       name: 'apply-discord-leaderboard-roles',
-      reason: 'leaderboard roles not found in guild',
-      missing: [!top10Role && 'Top 10', !top100Role && 'Top 100'].filter(Boolean),
+      error: {
+        reason: 'leaderboard roles not found in guild',
+        missing: [!top10Role && 'Top 10', !top100Role && 'Top 100'].filter(Boolean),
+      },
     });
     return null;
   }
@@ -146,8 +172,10 @@ export const applyDiscordLeaderboardRoles = async () => {
     logToAxiom({
       type: 'discord-role-sync-aborted',
       name: 'apply-discord-leaderboard-roles',
-      reason: 'no ranked users with a linked discord account',
-      holders: existingTop100.length,
+      error: {
+        reason: 'no ranked users with a linked discord account',
+        holders: existingTop100.length,
+      },
     });
     return;
   }
@@ -162,14 +190,16 @@ export const applyDiscordLeaderboardRoles = async () => {
   await addRoleToAccounts(top100Role, newTop100);
 
   const removedTop100 = existingTop100.filter((id) => !top100Ids.has(id));
-  await removeRoleFromAccounts(top100Role, removedTop100);
+  if (withinBlastRadius(top100Role, removedTop100, existingTop100))
+    await removeRoleFromAccounts(top100Role, removedTop100);
 
   // Get the new users in the top 10 and the users that are no longer in the top 10
   const newTop10 = [...top10Ids].filter((id) => !existingTop10.includes(id));
   await addRoleToAccounts(top10Role, newTop10);
 
   const removedTop10 = existingTop10.filter((id) => !top10Ids.has(id));
-  await removeRoleFromAccounts(top10Role, removedTop10);
+  if (withinBlastRadius(top10Role, removedTop10, existingTop10))
+    await removeRoleFromAccounts(top10Role, removedTop10);
 };
 
 // Grant-only sync for a single user, so linking Discord doesn't mean waiting for the nightly cron. Removals stay
@@ -308,13 +338,16 @@ const applyToDiscord = async (
     logToAxiom({
       type: 'discord-role-sync',
       name: 'apply-discord-roles',
-      role: role.name,
-      action,
-      requested: providerAccountIds.length,
-      applied: applied.length,
-      notInGuild,
-      failed: errors.length,
-      errors: [...new Set(errors)].slice(0, 5),
+      // civitai-prod is at its column cap, so `error` is the only top-level container new fields can go in.
+      error: {
+        role: role.name,
+        action,
+        requested: providerAccountIds.length,
+        applied: applied.length,
+        notInGuild,
+        failed: errors.length,
+        errors: [...new Set(errors)].slice(0, 5),
+      },
     });
   }
 
@@ -335,7 +368,7 @@ const addRoleToAccounts = async (role: DiscordRole, providerAccountIds: string[]
       (COALESCE(metadata->'roles', '[]'::jsonb) - ${role.name}::text) || ${roleValue}::jsonb,
       true
     )
-    WHERE "providerAccountId" IN (${Prisma.join(granted)})`;
+    WHERE provider = 'discord' AND "providerAccountId" IN (${Prisma.join(granted)})`;
 };
 
 const removeRoleFromAccounts = async (role: DiscordRole, providerAccountIds: string[]) => {
@@ -351,6 +384,6 @@ const removeRoleFromAccounts = async (role: DiscordRole, providerAccountIds: str
       COALESCE(metadata->'roles', '[]'::jsonb) - ${role.name}::text,
       true
     )
-    WHERE "providerAccountId" IN (${Prisma.join(revoked)})`;
+    WHERE provider = 'discord' AND "providerAccountId" IN (${Prisma.join(revoked)})`;
 };
 // #endregion

--- a/src/server/jobs/apply-discord-roles.ts
+++ b/src/server/jobs/apply-discord-roles.ts
@@ -86,10 +86,28 @@ const applyDiscordActivityRoles = createJob(
   }
 );
 
-// Nobody sheds half the leaderboard overnight, so a revoke list that size means our view of who is ranked
-// collapsed. UserRank is rebuilt by TRUNCATE + INSERT, and updateLeaderboardRank({ leaderboardIds }) — the
-// hourly event path — legitimately leaves it holding only that event's users until the next nightly rebuild.
-// Before this job ran unguarded that could not reach us; now it can, and it would strip the roles for real.
+// UserRank is rebuilt from every public board, but updateLeaderboardRank({ leaderboardIds }) — the hourly event
+// path — truncates it and refills it from that event's boards alone. Both leave a populated table, so row count
+// can't tell them apart; the spread of boards can (31 in prod today, 1 for an event). isLeaderboardPopulated
+// used to keep this job away from that state by accident, since it also gated the rebuild.
+const MIN_RANK_BOARDS = 3;
+
+const userRankIsNarrowed = async () => {
+  const [{ boards }] = await dbWrite.$queryRaw<{ boards: number }[]>`
+    SELECT count(DISTINCT "leaderboardId")::int AS boards FROM "UserRank"`;
+  if (boards >= MIN_RANK_BOARDS) return false;
+
+  logToAxiom({
+    type: 'error',
+    name: 'discord-role-sync-aborted',
+    error: { reason: 'UserRank covers too few boards to diff against', boards },
+  });
+  return true;
+};
+
+// Second line, for a collapse that still spans boards. Deliberately loose: the real cleanup this ships with
+// revokes 33 of 83 Top 10 holders (40%), and `leaderboardRank` is the best position across all 31 boards, so
+// the ranked-under-10 population is ~196 users — not 10.
 const REVOKE_SHARE_LIMIT = 0.5;
 const REVOKE_FLOOR = 10;
 
@@ -98,8 +116,8 @@ const withinBlastRadius = (role: DiscordRole, revoking: string[], holders: strin
   if (revoking.length <= holders.length * REVOKE_SHARE_LIMIT) return true;
 
   logToAxiom({
-    type: 'discord-role-sync-aborted',
-    name: 'apply-discord-leaderboard-roles',
+    type: 'error',
+    name: 'discord-role-sync-aborted',
     error: {
       reason: 'revoke list too large — refusing to strip the role in bulk',
       role: role.name,
@@ -117,8 +135,8 @@ const getLeaderboardRoles = async () => {
   const top100Role = discordRoles.find((r) => r.name === 'Top 100');
   if (!top100Role || !top10Role) {
     logToAxiom({
-      type: 'discord-role-sync-aborted',
-      name: 'apply-discord-leaderboard-roles',
+      type: 'error',
+      name: 'discord-role-sync-aborted',
       error: {
         reason: 'leaderboard roles not found in guild',
         missing: [!top10Role && 'Top 10', !top100Role && 'Top 100'].filter(Boolean),
@@ -133,6 +151,7 @@ const getLeaderboardRoles = async () => {
 export const applyDiscordLeaderboardRoles = async () => {
   const roles = await getLeaderboardRoles();
   if (!roles) return;
+  if (await userRankIsNarrowed()) return;
   const { top10Role, top100Role } = roles;
 
   const existingTop100 = await getAccountsInRole(top100Role);
@@ -170,8 +189,8 @@ export const applyDiscordLeaderboardRoles = async () => {
   // Continuing would read that as "everyone left the top 100" and strip the roles from every holder.
   if (!top100.length) {
     logToAxiom({
-      type: 'discord-role-sync-aborted',
-      name: 'apply-discord-leaderboard-roles',
+      type: 'error',
+      name: 'discord-role-sync-aborted',
       error: {
         reason: 'no ranked users with a linked discord account',
         holders: existingTop100.length,
@@ -336,8 +355,8 @@ const applyToDiscord = async (
 
   if (notInGuild || errors.length) {
     logToAxiom({
-      type: 'discord-role-sync',
-      name: 'apply-discord-roles',
+      type: 'warn',
+      name: 'discord-role-sync',
       // civitai-prod is at its column cap, so `error` is the only top-level container new fields can go in.
       error: {
         role: role.name,

--- a/src/server/jobs/apply-discord-roles.ts
+++ b/src/server/jobs/apply-discord-roles.ts
@@ -140,6 +140,18 @@ export const applyDiscordLeaderboardRoles = async () => {
     }))
   );
 
+  // Nobody ranked with a linked Discord account is not a real state — it means UserRank is empty or mid-rebuild.
+  // Continuing would read that as "everyone left the top 100" and strip the roles from every holder.
+  if (!top100.length) {
+    logToAxiom({
+      type: 'discord-role-sync-aborted',
+      name: 'apply-discord-leaderboard-roles',
+      reason: 'no ranked users with a linked discord account',
+      holders: existingTop100.length,
+    });
+    return;
+  }
+
   const top100Ids = new Set(top100.map((u) => u.providerAccountId));
   const top10Ids = new Set(
     top100.filter((u) => u.rank && u.rank <= 10).map((u) => u.providerAccountId)

--- a/src/server/jobs/prepare-leaderboard.ts
+++ b/src/server/jobs/prepare-leaderboard.ts
@@ -7,7 +7,10 @@ import { pgDbReadLong, pgDbWrite } from '~/server/db/pgDb';
 import { applyDiscordLeaderboardRoles } from '~/server/jobs/apply-discord-roles';
 import { logToAxiom } from '~/server/logging/client';
 import { redis } from '~/server/redis/client';
-import { isLeaderboardPopulated } from '~/server/services/leaderboard.service';
+import {
+  getUnpopulatedLeaderboards,
+  isLeaderboardPopulated,
+} from '~/server/services/leaderboard.service';
 import { leaderboardPopulatedKey } from '~/server/services/new-creators.service';
 import { updateLeaderboardRank } from '~/server/services/user.service';
 import type { Task } from '~/server/utils/concurrency-helpers';
@@ -231,7 +234,16 @@ const updateUserDiscordLeaderboardRoles = createJob(
   'update-user-discord-leaderboard-roles',
   '10 0 * * *',
   async () => {
-    if (!(await isLeaderboardPopulated())) throw new Error('Leaderboard not populated');
+    // Roles are driven by UserRank, not by any single board, so an unpopulated board only means the ranks may
+    // lag a day. Skipping the run instead costs the whole day's role sync, with no retry.
+    const unpopulated = await getUnpopulatedLeaderboards();
+    if (unpopulated.length)
+      logToAxiom({
+        type: 'leaderboard-partially-populated',
+        name: 'update-user-discord-leaderboard-roles',
+        unpopulated,
+      });
+
     await applyDiscordLeaderboardRoles();
   }
 );

--- a/src/server/jobs/prepare-leaderboard.ts
+++ b/src/server/jobs/prepare-leaderboard.ts
@@ -239,8 +239,8 @@ const updateUserDiscordLeaderboardRoles = createJob(
     const unpopulated = await getUnpopulatedLeaderboards();
     if (unpopulated.length)
       logToAxiom({
-        type: 'leaderboard-partially-populated',
-        name: 'update-user-discord-leaderboard-roles',
+        type: 'warn',
+        name: 'leaderboard-partially-populated',
         // civitai-prod is at its column cap, so `error` is the only top-level container new fields can go in.
         error: { unpopulated },
       });

--- a/src/server/jobs/prepare-leaderboard.ts
+++ b/src/server/jobs/prepare-leaderboard.ts
@@ -241,7 +241,8 @@ const updateUserDiscordLeaderboardRoles = createJob(
       logToAxiom({
         type: 'leaderboard-partially-populated',
         name: 'update-user-discord-leaderboard-roles',
-        unpopulated,
+        // civitai-prod is at its column cap, so `error` is the only top-level container new fields can go in.
+        error: { unpopulated },
       });
 
     await applyDiscordLeaderboardRoles();

--- a/src/server/services/leaderboard.service.ts
+++ b/src/server/services/leaderboard.service.ts
@@ -26,6 +26,21 @@ export async function isLeaderboardPopulated() {
   return populated;
 }
 
+export async function getUnpopulatedLeaderboards() {
+  const rows = await dbWrite.$queryRaw<{ id: string }[]>`
+      SELECT l.id
+      FROM "Leaderboard" l
+      WHERE l.query != '' AND l.active
+        AND NOT EXISTS (
+          SELECT 1
+          FROM "LeaderboardResult" lr
+          WHERE lr."leaderboardId" = l.id AND lr.date = current_date::date
+        )
+    `;
+
+  return rows.map((x) => x.id);
+}
+
 // A board is visible on a domain when its `domain` array contains that color or
 // `all`.
 //


### PR DESCRIPTION
Fixes the recurring support complaint (ClickUp [868kq6vqv](https://app.clickup.com/t/868kq6vqv), reported by Ellie): users place on the leaderboard, link Discord, and never receive the Top 10 / Top 100 role.

## The bug

`addRoleToAccounts` called Discord, swallowed any failure with `console.error`, then ran the `Account.metadata->'roles'` UPDATE unconditionally for the whole batch. That metadata is also the skip list for the next run (`getAccountsInRole`), so a rejected grant was **permanent**: the user never got the role, and the next night saw them in `existingTop100` and skipped them. Same drift in the other direction on removal.

Worse, `discord.addRoleToUser` swallowed error `10007` (unknown member) entirely and returned as if it had worked. A user who links Discord before joining the guild — a normal order of operations — was marked granted forever.

The metadata write now follows Discord's answer per account, and `addRoleToUser` reports the unknown-member case so it stays retryable.

## The abort

Axiom (60 days) shows `update-user-discord-leaderboard-roles` threw `Leaderboard not populated` on 3 days, losing the entire day's sync with no retry. Twice the boards were fine and the job simply ran at 00:10 before prep had finished; once (2026-06-24) prep died on ClickHouse (`memory limit exceeded: 14.42 GiB`, `Too many simultaneous queries: 1000`) and only 29 of 33 boards populated.

Roles are driven by `UserRank`, not by any single board, so an unpopulated board only means ranks may lag a day. The job now logs which boards are missing and proceeds. Guard against the failure mode that opens up: zero ranked users with a linked account is not a real state, and reading it as "everyone left the top 100" would strip the role from every holder in one run — so that case aborts and logs instead.

## Sync on link

Linking no longer means waiting up to 24h. The hub (`apps/auth`) owns the `Account` insert but has neither the main DB nor the bot token, so `/api/auth/connect` now points the hub's return at `/api/auth/linked`, which runs main-app post-link effects and forwards to where the user was headed (preserving the hub's `?error`). Grant-only — removals stay with the cron, so a link can never strip a role because rank data happens to be mid-refresh.

## Also

- Top 10 removal compared against the top-**100** list, so a drop from rank 5 to rank 50 kept the Top 10 role until the user left the top 100 entirely.
- `accounts[0]` only — a user with more than one linked Discord row had the others silently ignored.
- The `if (!top100Role || !top10Role) return;` abort was silent; it logs now.
- `getAccountsInRole` and the metadata writes are parameterized instead of interpolating the guild role name into raw SQL.

## Verification

- `pnpm run typecheck` — 0 errors.
- `pnpm exec eslint` on the changed files — 0 errors (4 warnings, all pre-existing).
- `pnpm run test:unit:run` — 14,932 passed. 7 files fail, and the same 7 fail on an unmodified `main` (verified by running them there): blocks, comics, middleware, scripts. None are touched by this PR.
- Mutation-tested: reverting the metadata fix, the Top 10 filter, or the empty-rank guard each fails an assertion in about a second. No hangs.

Nothing here needs a migration or a manual SQL step.