### PR TITLE
fix(remix-gallery): cap submissions to a minor-flagged host, and show the submitter their pending entries

### DIFF
--- a/src/components/RemixGallery/RemixGalleryCard.tsx
+++ b/src/components/RemixGallery/RemixGalleryCard.tsx
@@ -1,5 +1,6 @@
 import {
   ActionIcon,
+  Anchor,
   Button,
   Card,
   Center,
@@ -11,7 +12,13 @@ import {
   ThemeIcon,
   Tooltip,
 } from '@mantine/core';
-import { IconHierarchy, IconPlus, IconSettings, IconShieldCheck } from '@tabler/icons-react';
+import {
+  IconClock,
+  IconHierarchy,
+  IconPlus,
+  IconSettings,
+  IconShieldCheck,
+} from '@tabler/icons-react';
 import clsx from 'clsx';
 import dynamic from 'next/dynamic';
 import { useState } from 'react';
@@ -21,6 +28,7 @@ import { CurrencyIcon } from '~/components/Currency/CurrencyIcon';
 import { InfoPopover } from '~/components/InfoPopover/InfoPopover';
 import { RemixGalleryManageModal } from '~/components/RemixGallery/RemixGalleryManageModal';
 import { RemixGallerySubmitModal } from '~/components/RemixGallery/RemixGallerySubmitModal';
+import { SubmissionThumb } from '~/components/RemixGallery/SubmissionThumb';
 import {
   dedupeGalleryItems,
   galleryDialogImages,
@@ -174,6 +182,8 @@ export function RemixGalleryCard({ imageId }: { imageId: number }) {
   const isModerator = currentUser?.isModerator ?? false;
   // Server-side, and zero for anyone who is not the owner.
   const pendingCount = visibility.pendingCount ?? 0;
+  // Server-side, and empty for the owner and for signed-out viewers.
+  const viewerPending = visibility.viewerPending ?? [];
 
   return (
     <Card className="flex flex-col gap-3 rounded-xl">
@@ -329,6 +339,39 @@ export function RemixGalleryCard({ imageId }: { imageId: number }) {
             )}
           </Stack>
         </Group>
+      )}
+
+      {/* Answers "did that work?". Submitting charged Buzz and changed nothing
+          on the image it was sent to, so the submitter's only evidence was the
+          notification they get when the owner eventually decides. Shown to the
+          submitter alone — the owner has the review queue, and everyone else has
+          no business seeing what is waiting. */}
+      {viewerPending.length > 0 && (
+        <Stack gap={6} className="rounded-md bg-gray-1 p-2 dark:bg-dark-6">
+          <Group gap={6} wrap="nowrap">
+            <IconClock size={14} className="shrink-0 text-yellow-6" />
+            <Text size="xs" fw={600}>
+              {viewerPending.length === 1
+                ? 'Your remix is pending review'
+                : `${viewerPending.length} of your remixes are pending review`}
+            </Text>
+          </Group>
+          <Group gap={6} wrap="nowrap" className="overflow-x-auto">
+            {viewerPending.map((pending) =>
+              pending.image ? (
+                <SubmissionThumb key={pending.placementId} image={pending.image} />
+              ) : null
+            )}
+          </Group>
+          <Text size="xs" c="dimmed">
+            {visibility.ownerUsername ? `@${visibility.ownerUsername}` : 'The creator'} decides
+            whether it appears here. You can{' '}
+            <Anchor href="/user/remix-submissions" size="xs">
+              withdraw it
+            </Anchor>{' '}
+            until they do.
+          </Text>
+        </Stack>
       )}
 
       {hasNextPage && (

--- a/src/components/RemixGallery/RemixGalleryCard.tsx
+++ b/src/components/RemixGallery/RemixGalleryCard.tsx
@@ -26,6 +26,7 @@ import { AspectRatioImageCard } from '~/components/CardTemplates/AspectRatioImag
 import { dialogStore } from '~/components/Dialog/dialogStore';
 import { CurrencyIcon } from '~/components/Currency/CurrencyIcon';
 import { InfoPopover } from '~/components/InfoPopover/InfoPopover';
+import { LoginRedirect } from '~/components/LoginRedirect/LoginRedirect';
 import { RemixGalleryExplainer } from '~/components/RemixGallery/RemixGalleryExplainer';
 import { RemixGalleryManageModal } from '~/components/RemixGallery/RemixGalleryManageModal';
 import { RemixGallerySubmitModal } from '~/components/RemixGallery/RemixGallerySubmitModal';
@@ -388,28 +389,33 @@ export function RemixGalleryCard({ imageId }: { imageId: number }) {
         </Button>
       )}
 
+      {/* Wrapped rather than hidden. A signed-out visitor could open the modal
+          and be told the gallery was closed — it is open, they are signed out,
+          and nothing said so. */}
       {visibility.open && !isOwner && (
-        <Button
-          variant="light"
-          radius="md"
-          leftSection={<IconPlus size={16} />}
-          onClick={() =>
-            dialogStore.trigger({
-              component: RemixGallerySubmitModal,
-              props: { hostImageId: imageId },
-            })
-          }
-        >
-          <Group gap={4} wrap="nowrap">
-            <span>Submit your remix</span>
-            {visibility.price != null && (
-              <>
-                <CurrencyIcon currency={Currency.BUZZ} size={14} />
-                <span>{visibility.price}</span>
-              </>
-            )}
-          </Group>
-        </Button>
+        <LoginRedirect reason="perform-action">
+          <Button
+            variant="light"
+            radius="md"
+            leftSection={<IconPlus size={16} />}
+            onClick={() =>
+              dialogStore.trigger({
+                component: RemixGallerySubmitModal,
+                props: { hostImageId: imageId },
+              })
+            }
+          >
+            <Group gap={4} wrap="nowrap">
+              <span>Submit your remix</span>
+              {visibility.price != null && (
+                <>
+                  <CurrencyIcon currency={Currency.BUZZ} size={14} />
+                  <span>{visibility.price}</span>
+                </>
+              )}
+            </Group>
+          </Button>
+        </LoginRedirect>
       )}
 
       {/* Derived from the owner's actual share rather than asserting one. The

--- a/src/components/RemixGallery/RemixGalleryCard.tsx
+++ b/src/components/RemixGallery/RemixGalleryCard.tsx
@@ -26,6 +26,7 @@ import { AspectRatioImageCard } from '~/components/CardTemplates/AspectRatioImag
 import { dialogStore } from '~/components/Dialog/dialogStore';
 import { CurrencyIcon } from '~/components/Currency/CurrencyIcon';
 import { InfoPopover } from '~/components/InfoPopover/InfoPopover';
+import { RemixGalleryExplainer } from '~/components/RemixGallery/RemixGalleryExplainer';
 import { RemixGalleryManageModal } from '~/components/RemixGallery/RemixGalleryManageModal';
 import { RemixGallerySubmitModal } from '~/components/RemixGallery/RemixGallerySubmitModal';
 import { SubmissionThumb } from '~/components/RemixGallery/SubmissionThumb';
@@ -245,6 +246,8 @@ export function RemixGalleryCard({ imageId }: { imageId: number }) {
             </Tooltip>
           ))}
       </Group>
+
+      <RemixGalleryExplainer />
 
       {isLoading ? (
         // A skeleton row rather than a spinner: it occupies the shape the

--- a/src/components/RemixGallery/RemixGalleryExplainer.tsx
+++ b/src/components/RemixGallery/RemixGalleryExplainer.tsx
@@ -5,9 +5,14 @@ import { trpc } from '~/utils/trpc';
 
 const ALERT_ID = 'remix-gallery-explainer';
 
-/** Where the reasoning lives in full, for anyone who wants it. */
+/**
+ * Where the reasoning lives in full, for anyone who wants it.
+ *
+ * Relative, so a reader on civitai.red stays on civitai.red. An absolute
+ * civitai.com URL would move them off the domain they chose.
+ */
 const EARNINGS_ARTICLE =
-  'https://civitai.com/articles/33568/how-image-creators-earn-what-we-heard-and-what-were-building';
+  '/articles/33568/how-image-creators-earn-what-we-heard-and-what-were-building';
 
 /**
  * What the gallery is for, inside the gallery.
@@ -57,8 +62,8 @@ export function RemixGalleryExplainer() {
   if (!currentUser || !settings || isDismissed) return null;
 
   return (
-    <div className="flex gap-2 rounded-md bg-blue-0 p-2 dark:bg-dark-6">
-      <IconHierarchy size={16} className="mt-0.5 shrink-0 text-blue-6" />
+    <div className="flex gap-2 rounded-md border border-blue-2 bg-blue-0 p-2 dark:border-blue-9/30 dark:bg-blue-9/20">
+      <IconHierarchy size={16} className="mt-0.5 shrink-0 text-blue-6 dark:text-blue-4" />
       <div className="flex flex-col gap-1">
         <Text size="xs" fw={600}>
           What&apos;s a remix gallery?

--- a/src/components/RemixGallery/RemixGalleryExplainer.tsx
+++ b/src/components/RemixGallery/RemixGalleryExplainer.tsx
@@ -1,0 +1,86 @@
+import { Anchor, CloseButton, Text } from '@mantine/core';
+import { IconHierarchy } from '@tabler/icons-react';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { trpc } from '~/utils/trpc';
+
+const ALERT_ID = 'remix-gallery-explainer';
+
+/** Where the reasoning lives in full, for anyone who wants it. */
+const EARNINGS_ARTICLE =
+  'https://civitai.com/articles/33568/how-image-creators-earn-what-we-heard-and-what-were-building';
+
+/**
+ * What the gallery is for, inside the gallery.
+ *
+ * Testers read the panel and asked what the point was and what counts as a
+ * remix. The reasoning was already published, but nobody reads an article
+ * before pressing a button, so it has to be where the feature is.
+ *
+ * Dismissal goes to user settings rather than `localStorage`, which is what
+ * `DismissibleAlert` would have given us: this explains a feature, not a
+ * one-off event, and someone who has read it should not meet it again on their
+ * phone. Same pattern as {@link ../Alerts/NavTidyNotice}, down to the
+ * optimistic update and the `!!settings` guard.
+ */
+export function RemixGalleryExplainer() {
+  const currentUser = useCurrentUser();
+  const utils = trpc.useUtils();
+
+  const { data: settings } = trpc.user.getSettings.useQuery(undefined, {
+    enabled: !!currentUser,
+  });
+
+  const dismiss = trpc.user.dismissAlert.useMutation({
+    onMutate: async () => {
+      await utils.user.getSettings.cancel();
+      const prev = utils.user.getSettings.getData();
+      utils.user.getSettings.setData(undefined, (old) => ({
+        ...old,
+        dismissedAlerts: [...(old?.dismissedAlerts ?? []), ALERT_ID],
+      }));
+      return { prev };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.prev) utils.user.getSettings.setData(undefined, ctx.prev);
+    },
+    // The optimistic write spreads `...old`, so a cache seeded from a failed SSR
+    // snapshot could persist a truncated settings object. One refetch per
+    // dismiss, which is rare — not one per mount.
+    onSettled: () => {
+      utils.user.getSettings.invalidate();
+    },
+  });
+
+  const isDismissed = (settings?.dismissedAlerts ?? []).includes(ALERT_ID);
+  // Signed out there is nowhere to record a dismissal, so showing it would mean
+  // showing it forever.
+  if (!currentUser || !settings || isDismissed) return null;
+
+  return (
+    <div className="flex gap-2 rounded-md bg-blue-0 p-2 dark:bg-dark-6">
+      <IconHierarchy size={16} className="mt-0.5 shrink-0 text-blue-6" />
+      <div className="flex flex-col gap-1">
+        <Text size="xs" fw={600}>
+          What&apos;s a remix gallery?
+        </Text>
+        <Text size="xs" c="dimmed" lh={1.4}>
+          Any creator can appear on a popular image, and you get to see other takes on work you
+          liked. Iterate on it, restyle it, edit it, or turn it into a video — the creator reviews
+          every submission.{' '}
+          <Anchor href={EARNINGS_ARTICLE} target="_blank" rel="noreferrer" size="xs">
+            Why we built this
+          </Anchor>
+        </Text>
+      </div>
+      <CloseButton
+        size="xs"
+        variant="subtle"
+        color="gray"
+        radius="xl"
+        className="ml-auto shrink-0"
+        aria-label="Dismiss"
+        onClick={() => dismiss.mutate({ alertId: ALERT_ID })}
+      />
+    </div>
+  );
+}

--- a/src/components/RemixGallery/RemixGalleryManageModal.tsx
+++ b/src/components/RemixGallery/RemixGalleryManageModal.tsx
@@ -145,7 +145,7 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
     },
   });
 
-  const forThisImage = (pending ?? []).filter((row) => row.targetId === imageId);
+  const forThisImage = (pending?.items ?? []).filter((row) => row.targetId === imageId);
   const byId = new Map(items.map((item) => [item.placementId, item]));
   const pinnedItems = pinnedIds.map((id) => byId.get(id)).filter((x): x is RemixGalleryItem => !!x);
   const unpinned = items.filter((item) => !pinnedIds.includes(item.placementId));
@@ -259,7 +259,7 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
                     sees a full list that looks complete and never learns the
                     rest exist — and the escrow behind those sits until it
                     expires. */}
-                {(pending?.length ?? 0) >= REMIX_GALLERY_QUEUE_LIMIT && (
+                {pending?.truncated && (
                   <Text size="xs" c="dimmed">
                     Showing the first {REMIX_GALLERY_QUEUE_LIMIT}. Answer some to see the rest.
                   </Text>

--- a/src/components/RemixGallery/RemixGalleryManageModal.tsx
+++ b/src/components/RemixGallery/RemixGalleryManageModal.tsx
@@ -37,7 +37,11 @@ import { dedupeGalleryItems } from '~/components/RemixGallery/remix-gallery.util
 import { SubmissionThumb } from '~/components/RemixGallery/SubmissionThumb';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { Currency } from '~/shared/utils/prisma/enums';
-import { REMIX_GALLERY_MAX_PINNED, remixGalleryRemovableAt } from '~/shared/utils/remix-gallery';
+import {
+  REMIX_GALLERY_MAX_PINNED,
+  REMIX_GALLERY_QUEUE_LIMIT,
+  remixGalleryRemovableAt,
+} from '~/shared/utils/remix-gallery';
 import { daysFromNow, formatDateMin } from '~/utils/date-helpers';
 import { showErrorNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
@@ -251,6 +255,15 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
                     </Group>
                   </Card>
                 ))}
+                {/* The queue does not page. Without this line a busy owner
+                    sees a full list that looks complete and never learns the
+                    rest exist — and the escrow behind those sits until it
+                    expires. */}
+                {(pending?.length ?? 0) >= REMIX_GALLERY_QUEUE_LIMIT && (
+                  <Text size="xs" c="dimmed">
+                    Showing the first {REMIX_GALLERY_QUEUE_LIMIT}. Answer some to see the rest.
+                  </Text>
+                )}
               </Stack>
             ) : (
               <Text size="sm" c="dimmed" mt="sm">

--- a/src/components/RemixGallery/RemixGallerySettings.tsx
+++ b/src/components/RemixGallery/RemixGallerySettings.tsx
@@ -81,7 +81,7 @@ export function RemixGallerySettings() {
   const overCap = typeof price === 'number' && cap > 0 && price > cap;
   // Waiting on the owner, and waiting on someone else. Only the first is a
   // to-do, which is why it is the one badged in yellow.
-  const receivedCount = pending?.length ?? 0;
+  const receivedCount = pending?.items.length ?? 0;
   const sentCount = (sent ?? []).filter((row) => row.status === 'pending').length;
   const caption = placementPriceCaption(
     'remixGallery',

--- a/src/components/RemixGallery/RemixGallerySubmitModal.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, Divider, Group, Loader, Modal, Stack, Text } from '@mantine/core';
+import { Alert, Anchor, Button, Divider, Group, Loader, Modal, Stack, Text } from '@mantine/core';
 import { IconAlertTriangle } from '@tabler/icons-react';
 import clsx from 'clsx';
 import { useState } from 'react';
@@ -52,6 +52,16 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
 
   const price = visibility?.price ?? null;
 
+  // Filtered rather than shown-and-refused. Until the ceiling arrives nothing is
+  // offered: rendering the whole grid first and removing images a moment later
+  // invites a click on one that is about to disappear.
+  const maxLevel = visibility?.maxSubmissionLevel;
+  const eligible =
+    maxLevel == null
+      ? []
+      : images.filter((image) => !!image.nsfwLevel && image.nsfwLevel <= maxLevel);
+  const hidden = images.length - eligible.length;
+
   return (
     // `padding={0}` would strip the header's padding too, putting the title and
     // the close button against the edges. Only the body needs to lose it, so the
@@ -74,6 +84,30 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
             The creator reviews every submission and decides what belongs in their gallery.
           </Text>
 
+          {/* The picker lists published images because that is all the mutation
+              accepts, and a freshly generated image is not one. Said here rather
+              than only in the empty state: the case that confuses people is
+              having images in the grid and not the one they just made. */}
+          <Text size="xs" c="dimmed">
+            Only images you have posted appear below.{' '}
+            <Anchor href="/posts/create" target="_blank" rel="noreferrer" size="xs">
+              Post your remix first
+            </Anchor>{' '}
+            if you don&apos;t see it.
+          </Text>
+
+          {/* Says why the grid is short. Without it a submitter whose work is
+              mostly mature sees a picker missing their best images and no
+              reason, which reads as a bug rather than a rule. The reason is not
+              named: which rule bit is the host's business, not the
+              submitter's. */}
+          {hidden > 0 && (
+            <Text size="xs" c="dimmed">
+              {hidden === 1 ? '1 of your images is' : `${hidden} of your images are`} rated above
+              what this gallery accepts, so {hidden === 1 ? 'it is' : 'they are'} not shown.
+            </Text>
+          )}
+
           {visibility && !visibility.open && (
             <Alert color="yellow" icon={<IconAlertTriangle />}>
               This creator has stopped accepting submissions.
@@ -87,14 +121,17 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
             fires on viewport intersection, so it has to live inside here — it
             is reached by scrolling this box, not the page. */}
         <div className="flex-1 overflow-y-auto px-4 py-3">
-          {isLoading ? (
+          {/* Waits on the ceiling as well as the images: without it the picker
+              renders "you have nothing to submit" for a beat while the rule is
+              still in flight. */}
+          {isLoading || !visibility ? (
             <Group justify="center" py="xl">
               <Loader />
             </Group>
-          ) : images.length ? (
+          ) : eligible.length ? (
             <>
               <div className="grid grid-cols-4 gap-3">
-                {images.map((image) => (
+                {eligible.map((image) => (
                   <AspectRatioImageCard
                     key={image.id}
                     aspectRatio="square"
@@ -117,7 +154,13 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
               )}
             </>
           ) : (
-            <NoContent message="You don't have any published images to submit yet." />
+            <NoContent
+              message={
+                hidden > 0
+                  ? 'None of your posted images are rated low enough for this gallery.'
+                  : "You don't have any posted images to submit yet. Post your remix first, then submit it here."
+              }
+            />
           )}
         </div>
 

--- a/src/components/RemixGallery/RemixGallerySubmitModal.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.tsx
@@ -156,7 +156,9 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
           ) : (
             <NoContent
               message={
-                hidden > 0
+                maxLevel === 0
+                  ? 'This image has no rating yet, so nothing can be submitted to it.'
+                  : hidden > 0
                   ? 'None of your posted images are rated low enough for this gallery.'
                   : "You don't have any posted images to submit yet. Post your remix first, then submit it here."
               }

--- a/src/components/RemixGallery/RemixGallerySubmitModal.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.tsx
@@ -25,9 +25,8 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
   const utils = trpc.useUtils();
   const [selected, setSelected] = useState<number | null>(null);
 
-  const { data: visibility } = trpc.placement.getRemixGalleryVisibility.useQuery({
-    imageId: hostImageId,
-  });
+  const { data: visibility, isError: visibilityFailed } =
+    trpc.placement.getRemixGalleryVisibility.useQuery({ imageId: hostImageId });
 
   const { images, isLoading, fetchNextPage, hasNextPage, isRefetching } = useQueryImages(
     { userId: currentUser?.id, period: 'AllTime', limit: 50 },
@@ -60,7 +59,15 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
     maxLevel == null
       ? []
       : images.filter((image) => !!image.nsfwLevel && image.nsfwLevel <= maxLevel);
-  const hidden = images.length - eligible.length;
+  // Counted apart, because they are hidden for different reasons and only one of
+  // them is about the gallery's ceiling. An unrated image is not "too spicy for
+  // this gallery", it has no rating yet — telling someone otherwise sends them
+  // looking for a rating that is not there.
+  const overRated =
+    maxLevel == null
+      ? 0
+      : images.filter((image) => !!image.nsfwLevel && image.nsfwLevel > maxLevel).length;
+  const unrated = images.filter((image) => !image.nsfwLevel).length;
 
   return (
     // `padding={0}` would strip the header's padding too, putting the title and
@@ -101,10 +108,24 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
               reason, which reads as a bug rather than a rule. The reason is not
               named: which rule bit is the host's business, not the
               submitter's. */}
-          {hidden > 0 && (
+          {maxLevel === 0 ? (
             <Text size="xs" c="dimmed">
-              {hidden === 1 ? '1 of your images is' : `${hidden} of your images are`} rated above
-              what this gallery accepts, so {hidden === 1 ? 'it is' : 'they are'} not shown.
+              This image has no rating yet, so nothing can be submitted to it.
+            </Text>
+          ) : (
+            overRated > 0 && (
+              <Text size="xs" c="dimmed">
+                {overRated === 1 ? '1 of your images is' : `${overRated} of your images are`} rated
+                above what this gallery accepts, so {overRated === 1 ? 'it is' : 'they are'} not
+                shown.
+              </Text>
+            )
+          )}
+
+          {unrated > 0 && (
+            <Text size="xs" c="dimmed">
+              {unrated === 1 ? '1 of your images is' : `${unrated} of your images are`} still being
+              rated and cannot be submitted yet.
             </Text>
           )}
 
@@ -124,7 +145,14 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
           {/* Waits on the ceiling as well as the images: without it the picker
               renders "you have nothing to submit" for a beat while the rule is
               still in flight. */}
-          {isLoading || !visibility ? (
+          {visibilityFailed ? (
+            // An errored query settles with no data and isLoading false, so
+            // waiting on `visibility` alone spins here forever with nothing to
+            // read and nothing to press.
+            <Alert color="red" icon={<IconAlertTriangle />}>
+              Couldn&apos;t load this gallery. Close this and try again.
+            </Alert>
+          ) : isLoading || !visibility ? (
             <Group justify="center" py="xl">
               <Loader />
             </Group>
@@ -158,7 +186,7 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
               message={
                 maxLevel === 0
                   ? 'This image has no rating yet, so nothing can be submitted to it.'
-                  : hidden > 0
+                  : overRated > 0
                   ? 'None of your posted images are rated low enough for this gallery.'
                   : "You don't have any posted images to submit yet. Post your remix first, then submit it here."
               }

--- a/src/components/RemixGallery/RemixGallerySubmitModal.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.tsx
@@ -59,18 +59,13 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
     maxLevel == null
       ? []
       : images.filter((image) => !!image.nsfwLevel && image.nsfwLevel <= maxLevel);
-  // Counted apart, because they are hidden for different reasons and only one of
-  // them is about the gallery's ceiling. An unrated image is not "too spicy for
-  // this gallery", it has no rating yet — telling someone otherwise sends them
-  // looking for a rating that is not there.
+  // The picker's query backfills `browsingLevel`, which forces the
+  // `nsfwLevel != 0` branch server-side, so an unrated image never arrives here
+  // and every hidden one is genuinely over the ceiling.
   const overRated =
     maxLevel == null
       ? 0
       : images.filter((image) => !!image.nsfwLevel && image.nsfwLevel > maxLevel).length;
-  // Gated on the ceiling like the other two, so a closed gallery — where
-  // nothing is submittable for a reason that has nothing to do with the user's
-  // library — does not explain itself by naming some of their images.
-  const unrated = maxLevel == null ? 0 : images.filter((image) => !image.nsfwLevel).length;
 
   return (
     // `padding={0}` would strip the header's padding too, putting the title and
@@ -123,13 +118,6 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
                 shown.
               </Text>
             )
-          )}
-
-          {unrated > 0 && (
-            <Text size="xs" c="dimmed">
-              {unrated === 1 ? '1 of your images is' : `${unrated} of your images are`} still being
-              rated and cannot be submitted yet.
-            </Text>
           )}
 
           {visibility && !visibility.open && (
@@ -208,10 +196,6 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
                     // rather than an active one: nothing is fetching now, the
                     // button below is the action.
                     'Nothing so far in the images loaded.'
-                  : unrated > 0 && !overRated
-                  ? // Sending them to post images they have already posted is the
-                    // one wrong answer here; they are waiting on a rating.
-                    'Your posted images are still being rated. Try again once they have finished.'
                   : overRated > 0
                   ? 'None of your posted images are rated low enough for this gallery.'
                   : "You don't have any posted images to submit yet. Post your remix first, then submit it here."

--- a/src/components/RemixGallery/RemixGallerySubmitModal.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.tsx
@@ -204,10 +204,10 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
                   ? 'This image has no rating yet, so nothing can be submitted to it.'
                   : hasNextPage
                   ? // Hedged while pages remain, because every count here is
-                    // computed from what has loaded. The loader below keeps
-                    // fetching, so this is a statement about progress rather
-                    // than a verdict on the library.
-                    'Still looking through your images…'
+                    // computed from what has loaded. Phrased as a paused state
+                    // rather than an active one: nothing is fetching now, the
+                    // button below is the action.
+                    'Nothing so far in the images loaded.'
                   : unrated > 0 && !overRated
                   ? // Sending them to post images they have already posted is the
                     // one wrong answer here; they are waiting on a rating.
@@ -226,7 +226,7 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
               of requests, in exactly the case where nothing will be found.
               Paging past the first page is worth doing, but on intent. */}
           {!eligible.length && hasNextPage && !isLoading && visibility && (
-            <Group justify="center" pb="sm">
+            <Group justify="center" mt={-12} pb="sm">
               <Button
                 variant="subtle"
                 size="compact-sm"

--- a/src/components/RemixGallery/RemixGallerySubmitModal.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.tsx
@@ -162,30 +162,17 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
               <Loader />
             </Group>
           ) : eligible.length ? (
-            <>
-              <div className="grid grid-cols-4 gap-3">
-                {eligible.map((image) => (
-                  <AspectRatioImageCard
-                    key={image.id}
-                    aspectRatio="square"
-                    image={image}
-                    onClick={() => setSelected(image.id)}
-                    className={clsx(
-                      'cursor-pointer',
-                      selected === image.id && 'ring-2 ring-blue-5'
-                    )}
-                  />
-                ))}
-              </div>
-
-              {hasNextPage && (
-                <InViewLoader loadFn={fetchNextPage} loadCondition={!isRefetching}>
-                  <Group justify="center" py="md">
-                    <Loader size="sm" />
-                  </Group>
-                </InViewLoader>
-              )}
-            </>
+            <div className="grid grid-cols-4 gap-3">
+              {eligible.map((image) => (
+                <AspectRatioImageCard
+                  key={image.id}
+                  aspectRatio="square"
+                  image={image}
+                  onClick={() => setSelected(image.id)}
+                  className={clsx('cursor-pointer', selected === image.id && 'ring-2 ring-blue-5')}
+                />
+              ))}
+            </div>
           ) : (
             <NoContent
               message={
@@ -201,6 +188,12 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
                     : 'This gallery is not open for submissions.'
                   : maxLevel === 0
                   ? 'This image has no rating yet, so nothing can be submitted to it.'
+                  : hasNextPage
+                  ? // Hedged while pages remain, because every count here is
+                    // computed from what has loaded. The loader below keeps
+                    // fetching, so this is a statement about progress rather
+                    // than a verdict on the library.
+                    'Still looking through your images…'
                   : unrated > 0 && !overRated
                   ? // Sending them to post images they have already posted is the
                     // one wrong answer here; they are waiting on a rating.
@@ -210,6 +203,19 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
                   : "You don't have any posted images to submit yet. Post your remix first, then submit it here."
               }
             />
+          )}
+
+          {/* Outside the branches above. Inside the populated one it could only
+              page while something was already eligible — so a creator whose 50
+              most recent posts are all above the ceiling got a terminal "none of
+              your images qualify" over a library it had never finished
+              reading. */}
+          {hasNextPage && !isLoading && visibility && (
+            <InViewLoader loadFn={fetchNextPage} loadCondition={!isRefetching}>
+              <Group justify="center" py="md">
+                <Loader size="sm" />
+              </Group>
+            </InViewLoader>
           )}
         </div>
 

--- a/src/components/RemixGallery/RemixGallerySubmitModal.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.tsx
@@ -190,7 +190,15 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
             <NoContent
               message={
                 maxLevel == null
-                  ? 'This gallery is not open for submissions.'
+                  ? // Three different reasons collapse into a null ceiling, and
+                    // naming the wrong one is worse than saying less: signed
+                    // out, gallery closed, or a host that cannot show a gallery
+                    // at all (mid-rescan, blocked, under review).
+                    !currentUser
+                    ? 'Sign in to submit a remix to this gallery.'
+                    : visibility?.open
+                    ? 'This image cannot show a gallery right now.'
+                    : 'This gallery is not open for submissions.'
                   : maxLevel === 0
                   ? 'This image has no rating yet, so nothing can be submitted to it.'
                   : unrated > 0 && !overRated

--- a/src/components/RemixGallery/RemixGallerySubmitModal.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.tsx
@@ -162,17 +162,31 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
               <Loader />
             </Group>
           ) : eligible.length ? (
-            <div className="grid grid-cols-4 gap-3">
-              {eligible.map((image) => (
-                <AspectRatioImageCard
-                  key={image.id}
-                  aspectRatio="square"
-                  image={image}
-                  onClick={() => setSelected(image.id)}
-                  className={clsx('cursor-pointer', selected === image.id && 'ring-2 ring-blue-5')}
-                />
-              ))}
-            </div>
+            <>
+              <div className="grid grid-cols-4 gap-3">
+                {eligible.map((image) => (
+                  <AspectRatioImageCard
+                    key={image.id}
+                    aspectRatio="square"
+                    image={image}
+                    onClick={() => setSelected(image.id)}
+                    className={clsx(
+                      'cursor-pointer',
+                      selected === image.id && 'ring-2 ring-blue-5'
+                    )}
+                  />
+                ))}
+              </div>
+
+              {/* Scroll-to-load, which is what a populated grid should do. */}
+              {hasNextPage && (
+                <InViewLoader loadFn={fetchNextPage} loadCondition={!isRefetching}>
+                  <Group justify="center" py="md">
+                    <Loader size="sm" />
+                  </Group>
+                </InViewLoader>
+              )}
+            </>
           ) : (
             <NoContent
               message={
@@ -205,17 +219,23 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
             />
           )}
 
-          {/* Outside the branches above. Inside the populated one it could only
-              page while something was already eligible — so a creator whose 50
-              most recent posts are all above the ceiling got a terminal "none of
-              your images qualify" over a library it had never finished
-              reading. */}
-          {hasNextPage && !isLoading && visibility && (
-            <InViewLoader loadFn={fetchNextPage} loadCondition={!isRefetching}>
-              <Group justify="center" py="md">
-                <Loader size="sm" />
-              </Group>
-            </InViewLoader>
+          {/* A button rather than the in-view loader used above. With nothing
+              eligible there is no content between the loader and the top of the
+              scroll box, so it would sit permanently in view: fire, load 50,
+              still be in view, fire again — walking the whole library in a burst
+              of requests, in exactly the case where nothing will be found.
+              Paging past the first page is worth doing, but on intent. */}
+          {!eligible.length && hasNextPage && !isLoading && visibility && (
+            <Group justify="center" pb="sm">
+              <Button
+                variant="subtle"
+                size="compact-sm"
+                loading={isRefetching}
+                onClick={() => fetchNextPage()}
+              >
+                Keep looking through your images
+              </Button>
+            </Group>
           )}
         </div>
 

--- a/src/components/RemixGallery/RemixGallerySubmitModal.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.tsx
@@ -67,7 +67,10 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
     maxLevel == null
       ? 0
       : images.filter((image) => !!image.nsfwLevel && image.nsfwLevel > maxLevel).length;
-  const unrated = images.filter((image) => !image.nsfwLevel).length;
+  // Gated on the ceiling like the other two, so a closed gallery — where
+  // nothing is submittable for a reason that has nothing to do with the user's
+  // library — does not explain itself by naming some of their images.
+  const unrated = maxLevel == null ? 0 : images.filter((image) => !image.nsfwLevel).length;
 
   return (
     // `padding={0}` would strip the header's padding too, putting the title and
@@ -145,10 +148,12 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
           {/* Waits on the ceiling as well as the images: without it the picker
               renders "you have nothing to submit" for a beat while the rule is
               still in flight. */}
-          {visibilityFailed ? (
+          {visibilityFailed && !visibility ? (
             // An errored query settles with no data and isLoading false, so
             // waiting on `visibility` alone spins here forever with nothing to
-            // read and nothing to press.
+            // read and nothing to press. Gated on `!visibility` as well, because
+            // React Query keeps the previous data through a failed refetch — the
+            // error alone would replace a working, already-populated picker.
             <Alert color="red" icon={<IconAlertTriangle />}>
               Couldn&apos;t load this gallery. Close this and try again.
             </Alert>
@@ -184,8 +189,14 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
           ) : (
             <NoContent
               message={
-                maxLevel === 0
+                maxLevel == null
+                  ? 'This gallery is not open for submissions.'
+                  : maxLevel === 0
                   ? 'This image has no rating yet, so nothing can be submitted to it.'
+                  : unrated > 0 && !overRated
+                  ? // Sending them to post images they have already posted is the
+                    // one wrong answer here; they are waiting on a rating.
+                    'Your posted images are still being rated. Try again once they have finished.'
                   : overRated > 0
                   ? 'None of your posted images are rated low enough for this gallery.'
                   : "You don't have any posted images to submit yet. Post your remix first, then submit it here."

--- a/src/components/RemixGallery/SubmissionThumb.tsx
+++ b/src/components/RemixGallery/SubmissionThumb.tsx
@@ -3,7 +3,8 @@ import { IconExternalLink } from '@tabler/icons-react';
 import { AspectRatioImageCard } from '~/components/CardTemplates/AspectRatioImageCard';
 import type { RouterOutput } from '~/types/router';
 
-type PendingSubmission = RouterOutput['placement']['getPendingRemixGallerySubmissions'][number];
+type PendingSubmission =
+  RouterOutput['placement']['getPendingRemixGallerySubmissions']['items'][number];
 
 /**
  * The submitted image, openable.

--- a/src/pages/user/remix-submissions.tsx
+++ b/src/pages/user/remix-submissions.tsx
@@ -75,7 +75,7 @@ export default function RemixSubmissions() {
   const { data: sent, isLoading: sentLoading } =
     trpc.placement.getMyRemixGallerySubmissions.useQuery();
 
-  const waiting = received?.length ?? 0;
+  const waiting = received?.items.length ?? 0;
 
   return (
     <>
@@ -107,7 +107,11 @@ export default function RemixSubmissions() {
             </Tabs.List>
 
             <Tabs.Panel value="received" pt="md">
-              <ReceivedTab rows={received ?? []} isLoading={receivedLoading} />
+              <ReceivedTab
+                rows={received?.items ?? []}
+                truncated={!!received?.truncated}
+                isLoading={receivedLoading}
+              />
             </Tabs.Panel>
 
             <Tabs.Panel value="sent" pt="md">
@@ -120,9 +124,17 @@ export default function RemixSubmissions() {
   );
 }
 
-type ReceivedRow = RouterOutput['placement']['getPendingRemixGallerySubmissions'][number];
+type ReceivedRow = RouterOutput['placement']['getPendingRemixGallerySubmissions']['items'][number];
 
-function ReceivedTab({ rows, isLoading }: { rows: ReceivedRow[]; isLoading: boolean }) {
+function ReceivedTab({
+  rows,
+  truncated,
+  isLoading,
+}: {
+  rows: ReceivedRow[];
+  truncated: boolean;
+  isLoading: boolean;
+}) {
   const utils = trpc.useUtils();
 
   const act = trpc.placement.actOnRemixGallerySubmission.useMutation({
@@ -173,7 +185,7 @@ function ReceivedTab({ rows, isLoading }: { rows: ReceivedRow[]; isLoading: bool
     <Stack gap="md">
       {/* Neither queue pages. A list that stops at the cap and says nothing
           reads as complete. */}
-      {rows.length >= REMIX_GALLERY_QUEUE_LIMIT && (
+      {truncated && (
         <Text size="xs" c="dimmed">
           Showing the first {REMIX_GALLERY_QUEUE_LIMIT}.
         </Text>

--- a/src/pages/user/remix-submissions.tsx
+++ b/src/pages/user/remix-submissions.tsx
@@ -27,6 +27,7 @@ import { Currency } from '~/shared/utils/prisma/enums';
 import type { RouterOutput } from '~/types/router';
 import { daysFromNow, formatDate } from '~/utils/date-helpers';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
+import { REMIX_GALLERY_QUEUE_LIMIT } from '~/shared/utils/remix-gallery';
 import { trpc } from '~/utils/trpc';
 
 const TABS = ['received', 'sent'] as const;
@@ -170,6 +171,14 @@ function ReceivedTab({ rows, isLoading }: { rows: ReceivedRow[]; isLoading: bool
 
   return (
     <Stack gap="md">
+      {/* Neither queue pages. A list that stops at the cap and says nothing
+          reads as complete. */}
+      {rows.length >= REMIX_GALLERY_QUEUE_LIMIT && (
+        <Text size="xs" c="dimmed">
+          Showing the first {REMIX_GALLERY_QUEUE_LIMIT}.
+        </Text>
+      )}
+
       {rows.map((row) => (
         <Card key={row.id} withBorder>
           <Group justify="space-between" wrap="nowrap" align="flex-start">
@@ -281,6 +290,14 @@ function SentTab({ rows, isLoading }: { rows: SentRow[]; isLoading: boolean }) {
         You can withdraw a submission any time before the creator reviews it and get your Buzz back
         in full. Once it has been accepted there is nothing to withdraw.
       </Text>
+
+      {/* Neither queue pages. A list that stops at the cap and says nothing
+          reads as complete. */}
+      {rows.length >= REMIX_GALLERY_QUEUE_LIMIT && (
+        <Text size="xs" c="dimmed">
+          Showing the first {REMIX_GALLERY_QUEUE_LIMIT}.
+        </Text>
+      )}
 
       {rows.map((row) => (
         <Card key={row.id} withBorder>

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -73,6 +73,7 @@ const {
   retractRemixGallerySubmission,
   setRemixGalleryPins,
   parseGalleryCursor,
+  getRemixGallery,
 } = await import('~/server/services/remix-gallery.service');
 
 const {
@@ -320,6 +321,37 @@ describe('minor-flagged host ceiling', () => {
       actOnRemixGallerySubmission({ placementId: PLACEMENT, action: 'approve', userId: OWNER })
     ).rejects.toThrow(/PG-13 or below/i);
     expect(settlePlacement).not.toHaveBeenCalled();
+  });
+});
+
+describe('the ceiling is applied on read, not only on the mutation', () => {
+  // Without this the display-side half is a silent revert: delete the predicate
+  // from the gallery query and every other test in this file still passes,
+  // while entries approved before a host was flagged keep rendering — and the
+  // owner cannot take them down for a week.
+  it('carries the minor-host predicate in the gallery read', async () => {
+    queryRaw.mockImplementation(async () => []);
+
+    await getRemixGallery({ hostImageId: HOST_IMAGE, browsingLevel: 1 });
+
+    // Nested `Prisma.sql` fragments arrive as VALUES, not as part of the
+    // template's string array, so flattening them is what makes this test see
+    // the predicate at all.
+    const flatten = (value: unknown): string => {
+      if (Array.isArray(value)) return value.map(flatten).join(' ');
+      if (value && typeof value === 'object' && 'strings' in value)
+        return [
+          flatten((value as { strings: unknown }).strings),
+          flatten((value as { values?: unknown }).values ?? []),
+        ].join(' ');
+      return typeof value === 'string' ? value : '';
+    };
+
+    const sql = queryRaw.mock.calls.map(flatten).join(' ');
+
+    for (const column of ['minor', 'acceptableMinor', 'needsReview']) expect(sql).toContain(column);
+    // The bound itself, so widening the ceiling silently is also caught.
+    expect(sql).toMatch(/nsfwLevel"\s*<=/);
   });
 });
 

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -75,8 +75,12 @@ const {
   parseGalleryCursor,
 } = await import('~/server/services/remix-gallery.service');
 
-const { remixGalleryLevelAllowed, REMIX_GALLERY_MAX_PINNED, REMIX_GALLERY_REMOVAL_LOCK_HOURS } =
-  await import('~/shared/utils/remix-gallery');
+const {
+  remixGalleryLevelAllowed,
+  remixGalleryMaxSubmissionLevel,
+  REMIX_GALLERY_MAX_PINNED,
+  REMIX_GALLERY_REMOVAL_LOCK_HOURS,
+} = await import('~/shared/utils/remix-gallery');
 
 /** A submission that passes every check, so each test breaks exactly one thing. */
 const goodSubmission = {
@@ -109,12 +113,17 @@ const openSpace = {
 function primeQueries({
   submission = goodSubmission,
   hostLevel = NsfwLevel.PG,
-}: { submission?: typeof goodSubmission | null; hostLevel?: number | null } = {}) {
+  hostMinor = false,
+}: {
+  submission?: typeof goodSubmission | null;
+  hostLevel?: number | null;
+  hostMinor?: boolean;
+} = {}) {
   let call = 0;
   queryRaw.mockImplementation(async () => {
     call += 1;
     if (call === 1) return submission ? [submission] : [];
-    if (call === 2) return hostLevel == null ? [] : [{ nsfwLevel: hostLevel }];
+    if (call === 2) return hostLevel == null ? [] : [{ nsfwLevel: hostLevel, minor: hostMinor }];
     return [];
   });
 }
@@ -147,9 +156,14 @@ describe('content level rules', () => {
     // safe, and admitting it under `any` is how an unscanned image lands on
     // someone else's page.
     for (const rule of ['atOrBelow', 'any'] as const)
-      expect(remixGalleryLevelAllowed({ rule, submissionLevel: 0, hostLevel: NsfwLevel.XXX })).toBe(
-        false
-      );
+      expect(
+        remixGalleryLevelAllowed({
+          rule,
+          submissionLevel: 0,
+          hostLevel: NsfwLevel.XXX,
+          hostMinor: false,
+        })
+      ).toBe(false);
   });
 
   it('refuses a Blocked submission under both rules', () => {
@@ -159,6 +173,7 @@ describe('content level rules', () => {
           rule,
           submissionLevel: NsfwLevel.Blocked,
           hostLevel: NsfwLevel.XXX,
+          hostMinor: false,
         })
       ).toBe(false);
   });
@@ -169,6 +184,7 @@ describe('content level rules', () => {
         rule: 'atOrBelow',
         submissionLevel: NsfwLevel.R,
         hostLevel: NsfwLevel.X,
+        hostMinor: false,
       })
     ).toBe(true);
     expect(
@@ -176,6 +192,7 @@ describe('content level rules', () => {
         rule: 'atOrBelow',
         submissionLevel: NsfwLevel.X,
         hostLevel: NsfwLevel.R,
+        hostMinor: false,
       })
     ).toBe(false);
   });
@@ -186,6 +203,7 @@ describe('content level rules', () => {
         rule: 'atOrBelow',
         submissionLevel: NsfwLevel.PG,
         hostLevel: 0,
+        hostMinor: false,
       })
     ).toBe(false);
   });
@@ -209,6 +227,99 @@ describe('content level rules', () => {
       hostLevel: NsfwLevel.PG,
     });
     await expect(submit()).resolves.toEqual({ id: PLACEMENT });
+  });
+});
+
+describe('minor-flagged host ceiling', () => {
+  // The gap this closes: the submitted image's own `minor` flag was refused, the
+  // host's was never read. A remix can come from an external generation, so the
+  // generator's refusals are not in this path.
+  const ABOVE_PG13 = [NsfwLevel.R, NsfwLevel.X, NsfwLevel.XXX];
+
+  it('refuses anything above PG-13 under BOTH content rules', () => {
+    for (const rule of ['atOrBelow', 'any'] as const)
+      for (const submissionLevel of ABOVE_PG13)
+        expect(
+          remixGalleryLevelAllowed({
+            rule,
+            submissionLevel,
+            // An XXX host is the case that matters: `atOrBelow` alone would
+            // admit every one of these.
+            hostLevel: NsfwLevel.XXX,
+            hostMinor: true,
+          })
+        ).toBe(false);
+  });
+
+  it('caps the ceiling the picker filters on, under both rules', () => {
+    // The picker and the mutation have to agree, or a submitter is offered an
+    // image they will then be refused for — after paying.
+    expect(
+      remixGalleryMaxSubmissionLevel({ rule: 'any', hostLevel: NsfwLevel.XXX, hostMinor: true })
+    ).toBe(NsfwLevel.PG13);
+    expect(
+      remixGalleryMaxSubmissionLevel({ rule: 'atOrBelow', hostLevel: NsfwLevel.X, hostMinor: true })
+    ).toBe(NsfwLevel.PG13);
+    expect(
+      remixGalleryMaxSubmissionLevel({ rule: 'any', hostLevel: NsfwLevel.PG, hostMinor: false })
+    ).toBe(NsfwLevel.XXX);
+    // Nothing is submittable to an unrated host under `atOrBelow`.
+    expect(
+      remixGalleryMaxSubmissionLevel({ rule: 'atOrBelow', hostLevel: 0, hostMinor: false })
+    ).toBe(0);
+  });
+
+  it('still allows PG and PG-13 into a minor-flagged host', () => {
+    for (const submissionLevel of [NsfwLevel.PG, NsfwLevel.PG13])
+      expect(
+        remixGalleryLevelAllowed({
+          rule: 'any',
+          submissionLevel,
+          hostLevel: NsfwLevel.PG13,
+          hostMinor: true,
+        })
+      ).toBe(true);
+  });
+
+  it('refuses through the mutation even when the owner opted into any rating', async () => {
+    resolvePlacementSpaceFor.mockResolvedValue({ ...openSpace, settings: { contentRule: 'any' } });
+    primeQueries({
+      submission: { ...goodSubmission, nsfwLevel: NsfwLevel.XXX },
+      hostLevel: NsfwLevel.XXX,
+      hostMinor: true,
+    });
+
+    await expect(submit()).rejects.toThrow(/PG-13 or below/i);
+    expect(placementCreate).not.toHaveBeenCalled();
+    expect(holdPlacementEscrow).not.toHaveBeenCalled();
+  });
+
+  it('refuses on approval when the host is flagged after the submission was sent', async () => {
+    // Approval is the moment the entry becomes public, and a host can be flagged
+    // between the two. Without the re-check the escrow settles and an XXX entry
+    // goes live on a minor-flagged image.
+    placementFindUnique
+      .mockResolvedValueOnce({
+        id: PLACEMENT,
+        ownerId: OWNER,
+        status: 'pending',
+        surface: 'remixGallery',
+        data: { imageId: REMIX_IMAGE },
+        resolvedAt: null,
+        createdAt: new Date('2026-01-01'),
+      })
+      .mockResolvedValueOnce({ targetId: HOST_IMAGE });
+    primeQueries({
+      submission: { ...goodSubmission, nsfwLevel: NsfwLevel.XXX },
+      hostLevel: NsfwLevel.XXX,
+      hostMinor: true,
+    });
+    resolvePlacementSpaceFor.mockResolvedValue({ ...openSpace, settings: { contentRule: 'any' } });
+
+    await expect(
+      actOnRemixGallerySubmission({ placementId: PLACEMENT, action: 'approve', userId: OWNER })
+    ).rejects.toThrow(/PG-13 or below/i);
+    expect(settlePlacement).not.toHaveBeenCalled();
   });
 });
 

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -350,6 +350,46 @@ it('refuses a submission to a host that cannot show a gallery', async () => {
   expect(holdPlacementEscrow).not.toHaveBeenCalled();
 });
 
+describe('declining on a host that cannot show a gallery', () => {
+  const pending = {
+    id: PLACEMENT,
+    ownerId: OWNER,
+    status: 'pending',
+    surface: 'remixGallery',
+    targetId: HOST_IMAGE,
+    data: { imageId: REMIX_IMAGE },
+    resolvedAt: null,
+    createdAt: new Date('2026-01-01'),
+  };
+
+  const declineWithHost = async (showable: boolean) => {
+    placementFindUnique.mockResolvedValue(pending);
+    // Only `loadHostImage` runs on this path, so the fake answers with the host
+    // row rather than the submission-then-host pair the submit path expects.
+    queryRaw.mockImplementation(async () => [{ nsfwLevel: NsfwLevel.PG, minor: false, showable }]);
+    await actOnRemixGallerySubmission({ placementId: PLACEMENT, action: 'decline', userId: OWNER });
+  };
+
+  it('refunds in full instead of charging the decline fee', async () => {
+    // The fee prices the owner's attention. An unshowable host refuses approval,
+    // so the owner was never offered a choice — and without this the outcome
+    // fair to the submitter was the one where the owner ignored their queue.
+    await declineWithHost(false);
+
+    expect(settlePlacement).toHaveBeenCalledWith(
+      expect.objectContaining({ placementId: PLACEMENT, action: 'expire' })
+    );
+  });
+
+  it('still charges the fee on a normal host', async () => {
+    await declineWithHost(true);
+
+    expect(settlePlacement).toHaveBeenCalledWith(
+      expect.objectContaining({ placementId: PLACEMENT, action: 'decline' })
+    );
+  });
+});
+
 describe('the ceiling is applied on read, not only on the mutation', () => {
   // Without this the display-side half is a silent revert: delete the predicate
   // from a read query and every other test in this file still passes, while

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -14,9 +14,11 @@ const PLACEMENT = 96;
 const PRICE = 700;
 
 const holdPlacementEscrow = vi.fn(async () => ({ fee: 210, principal: 490 }));
-const settlePlacement = vi.fn(async (_args?: { placementId: number; action: string }) => ({
-  settled: true,
-}));
+const settlePlacement = vi.fn(async () => ({ settled: true }));
+
+/** What the refund tests below read back off the last settle call. */
+type SettleArgs = { placementId: number; action: string };
+const lastSettleArgs = () => settlePlacement.mock.calls.at(-1)?.[0] as SettleArgs | undefined;
 const FEE_WAIVING_ACTIONS = ['declineByBlock', 'declineUnshowableHost'];
 vi.mock('~/server/services/placement-escrow.service', () => ({
   holdPlacementEscrow,
@@ -386,7 +388,7 @@ describe('declining on a host that cannot show a gallery', () => {
     // choice; "the submitter is not charged" is the thing that must hold, and an
     // assertion on the string would go green against any future action that
     // happens to be spelled the same and charges the fee.
-    const [call] = settlePlacement.mock.calls.at(-1) ?? [];
+    const call = lastSettleArgs();
     expect(FEE_WAIVING_ACTIONS).toContain(call?.action);
     expect(call?.placementId).toBe(PLACEMENT);
   });
@@ -394,8 +396,7 @@ describe('declining on a host that cannot show a gallery', () => {
   it('still charges the fee on a normal host', async () => {
     await declineWithHost(true);
 
-    const [call] = settlePlacement.mock.calls.at(-1) ?? [];
-    expect(FEE_WAIVING_ACTIONS).not.toContain(call?.action);
+    expect(FEE_WAIVING_ACTIONS).not.toContain(lastSettleArgs()?.action);
   });
 });
 

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -377,7 +377,7 @@ describe('declining on a host that cannot show a gallery', () => {
     await declineWithHost(false);
 
     expect(settlePlacement).toHaveBeenCalledWith(
-      expect.objectContaining({ placementId: PLACEMENT, action: 'expire' })
+      expect.objectContaining({ placementId: PLACEMENT, action: 'declineUnshowableHost' })
     );
   });
 

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -14,10 +14,16 @@ const PLACEMENT = 96;
 const PRICE = 700;
 
 const holdPlacementEscrow = vi.fn(async () => ({ fee: 210, principal: 490 }));
-const settlePlacement = vi.fn(async () => ({ settled: true }));
+const settlePlacement = vi.fn(async (_args?: { placementId: number; action: string }) => ({
+  settled: true,
+}));
+const FEE_WAIVING_ACTIONS = ['declineByBlock', 'declineUnshowableHost'];
 vi.mock('~/server/services/placement-escrow.service', () => ({
   holdPlacementEscrow,
   settlePlacement,
+  // Real, not a stand-in. The refund test asserts membership of this list, so a
+  // fake one would let the test pass against an action that charges the fee.
+  FEE_WAIVING_ACTIONS: ['declineByBlock', 'declineUnshowableHost'],
 }));
 
 const assertCanPlace = vi.fn(async () => undefined);
@@ -376,17 +382,20 @@ describe('declining on a host that cannot show a gallery', () => {
     // fair to the submitter was the one where the owner ignored their queue.
     await declineWithHost(false);
 
-    expect(settlePlacement).toHaveBeenCalledWith(
-      expect.objectContaining({ placementId: PLACEMENT, action: 'declineUnshowableHost' })
-    );
+    // Asserted as a property rather than as the action name. The name is a
+    // choice; "the submitter is not charged" is the thing that must hold, and an
+    // assertion on the string would go green against any future action that
+    // happens to be spelled the same and charges the fee.
+    const [call] = settlePlacement.mock.calls.at(-1) ?? [];
+    expect(FEE_WAIVING_ACTIONS).toContain(call?.action);
+    expect(call?.placementId).toBe(PLACEMENT);
   });
 
   it('still charges the fee on a normal host', async () => {
     await declineWithHost(true);
 
-    expect(settlePlacement).toHaveBeenCalledWith(
-      expect.objectContaining({ placementId: PLACEMENT, action: 'decline' })
-    );
+    const [call] = settlePlacement.mock.calls.at(-1) ?? [];
+    expect(FEE_WAIVING_ACTIONS).not.toContain(call?.action);
   });
 });
 

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -28,6 +28,10 @@ vi.mock('~/server/services/placement-space.service', () => ({ resolvePlacementSp
 
 vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn().mockResolvedValue(undefined) }));
 
+vi.mock('~/server/services/placement.service', () => ({
+  getPlacementConfig: async () => ({ declineFeeRate: () => 0.3 }),
+}));
+
 /**
  * The mutation's ordering is its design — the row must exist before the escrow
  * can reference it — and that cannot be read off assertions about final state.
@@ -63,7 +67,12 @@ vi.mock('~/server/db/client', () => ({
   },
   dbRead: {
     $queryRaw: (...args: unknown[]) => queryRaw(...args),
-    placement: { findMany: placementFindMany, findUnique: placementFindUnique },
+    placement: {
+      findMany: placementFindMany,
+      findUnique: placementFindUnique,
+      count: placementCount,
+    },
+    user: { findUnique: async () => ({ username: 'someone' }) },
   },
 }));
 
@@ -74,6 +83,7 @@ const {
   setRemixGalleryPins,
   parseGalleryCursor,
   getRemixGallery,
+  getRemixGalleryVisibility,
 } = await import('~/server/services/remix-gallery.service');
 
 const {
@@ -115,16 +125,21 @@ function primeQueries({
   submission = goodSubmission,
   hostLevel = NsfwLevel.PG,
   hostMinor = false,
+  hostShowable = true,
 }: {
   submission?: typeof goodSubmission | null;
   hostLevel?: number | null;
   hostMinor?: boolean;
+  hostShowable?: boolean;
 } = {}) {
   let call = 0;
   queryRaw.mockImplementation(async () => {
     call += 1;
     if (call === 1) return submission ? [submission] : [];
-    if (call === 2) return hostLevel == null ? [] : [{ nsfwLevel: hostLevel, minor: hostMinor }];
+    if (call === 2)
+      return hostLevel == null
+        ? []
+        : [{ nsfwLevel: hostLevel, minor: hostMinor, showable: hostShowable }];
     return [];
   });
 }
@@ -324,34 +339,67 @@ describe('minor-flagged host ceiling', () => {
   });
 });
 
+it('refuses a submission to a host that cannot show a gallery', async () => {
+  // The host was never checked for anything but its rating. A blocked or
+  // unscanned host is hidden from everyone but its owner, so this took Buzz for
+  // a placement that could never render.
+  primeQueries({ hostShowable: false });
+
+  await expect(submit()).rejects.toThrow(/cannot show a gallery/i);
+  expect(placementCreate).not.toHaveBeenCalled();
+  expect(holdPlacementEscrow).not.toHaveBeenCalled();
+});
+
 describe('the ceiling is applied on read, not only on the mutation', () => {
   // Without this the display-side half is a silent revert: delete the predicate
-  // from the gallery query and every other test in this file still passes,
-  // while entries approved before a host was flagged keep rendering — and the
-  // owner cannot take them down for a week.
-  it('carries the minor-host predicate in the gallery read', async () => {
-    queryRaw.mockImplementation(async () => []);
+  // from a read query and every other test in this file still passes, while
+  // entries approved before a host was flagged keep rendering — and the owner
+  // cannot take them down for a week.
+  //
+  // Nested `Prisma.sql` fragments arrive as VALUES rather than as part of the
+  // template's string array, so flattening them is what makes this see the
+  // predicate at all.
+  const flatten = (value: unknown): string => {
+    if (Array.isArray(value)) return value.map(flatten).join(' ');
+    if (value && typeof value === 'object' && 'strings' in value)
+      return [
+        flatten((value as { strings: unknown }).strings),
+        flatten((value as { values?: unknown }).values ?? []),
+      ].join(' ');
+    return typeof value === 'string' ? value : '';
+  };
 
-    await getRemixGallery({ hostImageId: HOST_IMAGE, browsingLevel: 1 });
+  const sqlFrom = () => queryRaw.mock.calls.map(flatten).join(' ');
 
-    // Nested `Prisma.sql` fragments arrive as VALUES, not as part of the
-    // template's string array, so flattening them is what makes this test see
-    // the predicate at all.
-    const flatten = (value: unknown): string => {
-      if (Array.isArray(value)) return value.map(flatten).join(' ');
-      if (value && typeof value === 'object' && 'strings' in value)
-        return [
-          flatten((value as { strings: unknown }).strings),
-          flatten((value as { values?: unknown }).values ?? []),
-        ].join(' ');
-      return typeof value === 'string' ? value : '';
-    };
-
-    const sql = queryRaw.mock.calls.map(flatten).join(' ');
-
-    for (const column of ['minor', 'acceptableMinor', 'needsReview']) expect(sql).toContain(column);
-    // The bound itself, so widening the ceiling silently is also caught.
+  /**
+   * Asserted on rather than `minor` or `needsReview`, both of which the gallery
+   * CTE already contains as filters on the *entry* — so asserting those would
+   * hold with the host ceiling deleted entirely. These two strings appear only
+   * inside `minorHostCeiling`.
+   */
+  const expectCeiling = (sql: string) => {
+    expect(sql).toContain('acceptableMinor');
+    expect(sql).toContain('NOT EXISTS');
     expect(sql).toMatch(/nsfwLevel"\s*<=/);
+  };
+
+  beforeEach(() => {
+    queryRaw.mockImplementation(async () => []);
+  });
+
+  it('carries it in the gallery read', async () => {
+    await getRemixGallery({ hostImageId: HOST_IMAGE, browsingLevel: 1 });
+    expectCeiling(sqlFrom());
+  });
+
+  // Its own case, because the two readers are separate queries and the earlier
+  // version of this test only reached the first. Deleting the predicate from
+  // `galleryHasEntries` alone left the owner shown a card for entries the
+  // gallery query will not return.
+  it('carries it in the has-entries read', async () => {
+    resolvePlacementSpaceFor.mockResolvedValue(openSpace);
+    await getRemixGalleryVisibility({ hostImageId: HOST_IMAGE, browsingLevel: 1 });
+    expectCeiling(sqlFrom());
   });
 });
 

--- a/src/server/services/placement-escrow.service.ts
+++ b/src/server/services/placement-escrow.service.ts
@@ -212,7 +212,7 @@ type SettleAction =
  * a member added to one but not the other would refund in full while recording
  * a fee that was never taken.
  */
-const FEE_WAIVING_ACTIONS: SettleAction[] = ['declineByBlock', 'declineUnshowableHost'];
+export const FEE_WAIVING_ACTIONS: SettleAction[] = ['declineByBlock', 'declineUnshowableHost'];
 
 const STATUS_FOR_ACTION: Record<SettleAction, 'approved' | 'declined' | 'expired' | 'removed'> = {
   approve: 'approved',

--- a/src/server/services/placement-escrow.service.ts
+++ b/src/server/services/placement-escrow.service.ts
@@ -185,6 +185,17 @@ type SettleAction =
    * fee later is additive, refunding one taken wrongly is not.
    */
   | 'declineByBlock'
+  /**
+   * The owner declined, but the host could not have shown the placement anyway —
+   * it is blocked, unscanned or under review, so approval was refused and the
+   * owner was never offered a choice. Same reasoning as a block: the fee prices
+   * the owner's *attention*, and there was no judgement here to charge for.
+   *
+   * Recorded as a decline rather than an expiry, though the money is identical.
+   * An expiry says the hold timed out with nobody acting, which is not what
+   * happened and is the only thing the row would say afterwards.
+   */
+  | 'declineUnshowableHost'
   | 'expire'
   | 'removeByOwner'
   | 'removeByModerator'
@@ -195,10 +206,19 @@ type SettleAction =
    */
   | 'removeByCosmeticTakedown';
 
+/**
+ * Actions that return the whole escrow, fee included. Named once because the
+ * waive is read in two places — computing the payout and writing the row — and
+ * a member added to one but not the other would refund in full while recording
+ * a fee that was never taken.
+ */
+const FEE_WAIVING_ACTIONS: SettleAction[] = ['declineByBlock', 'declineUnshowableHost'];
+
 const STATUS_FOR_ACTION: Record<SettleAction, 'approved' | 'declined' | 'expired' | 'removed'> = {
   approve: 'approved',
   decline: 'declined',
   declineByBlock: 'declined',
+  declineUnshowableHost: 'declined',
   expire: 'expired',
   removeByOwner: 'removed',
   removeByModerator: 'removed',
@@ -467,7 +487,7 @@ export async function settlePlacement({
   const before = await dbWrite.placement.findUnique({ where: { id: placementId } });
   if (!before) throw new Error(`placement escrow: placement ${placementId} not found`);
 
-  const feeWaived = action === 'declineByBlock' ? true : before.feeWaived;
+  const feeWaived = FEE_WAIVING_ACTIONS.includes(action) ? true : before.feeWaived;
   const held = await heldAmountsFor(placementId);
   // Computed against the status this settle is *about to* write, since the row
   // still says `pending` and a pending placement has no settled outcome.
@@ -488,7 +508,7 @@ export async function settlePlacement({
         removedBy,
         resolvedAt: new Date(),
         resolvedById: actorId ?? null,
-        ...(action === 'declineByBlock' ? { feeWaived: true } : {}),
+        ...(FEE_WAIVING_ACTIONS.includes(action) ? { feeWaived: true } : {}),
       },
     });
 

--- a/src/server/services/remix-gallery.service.ts
+++ b/src/server/services/remix-gallery.service.ts
@@ -1,7 +1,7 @@
 import { Prisma } from '@prisma/client';
 import type { MediaType } from '~/shared/utils/prisma/enums';
 import { MetricTimeframe } from '~/shared/utils/prisma/enums';
-import { ImageSort } from '~/server/common/enums';
+import { ImageSort, NsfwLevel } from '~/server/common/enums';
 import type { SessionUser } from '~/types/session';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
@@ -82,13 +82,32 @@ const MINOR_HOST_REFUSAL =
  * can decide a rating without it — `remixGalleryLevelAllowed` requires it.
  */
 async function loadHostImage(hostImageId: number) {
-  const [row] = await dbWrite.$queryRaw<{ nsfwLevel: number; minor: boolean }[]>`
-    SELECT "nsfwLevel", ${HOST_IS_MINOR} AS minor FROM "Image" WHERE id = ${hostImageId}
+  const [row] = await dbWrite.$queryRaw<{ nsfwLevel: number; minor: boolean; showable: boolean }[]>`
+    SELECT "nsfwLevel", ${HOST_IS_MINOR} AS minor, ${HOST_IS_SHOWABLE} AS showable
+    FROM "Image" WHERE id = ${hostImageId}
   `;
 
   if (!row) throw throwBadRequestError('remix gallery: that image no longer exists');
   return row;
 }
+
+/**
+ * Whether the host can display a gallery at all.
+ *
+ * Every check on this surface asked what the *submission* was, and none asked
+ * whether the host could show it. A blocked or unscanned host is hidden from
+ * everyone but its owner, yet nothing required the submitter to be able to see
+ * it — so Buzz went into escrow for a placement that could never render, and
+ * the submitter's only ways out were withdrawing or being charged the decline
+ * fee. Not a safety hole, since display is gated either way; it is money taken
+ * for something structurally unshowable.
+ */
+const HOST_IS_SHOWABLE = Prisma.sql`(
+  ingestion = 'Scanned'
+  AND "needsReview" IS NULL
+  AND NOT "tosViolation"
+  AND "nsfwLevel" != ${NsfwLevel.Blocked}
+)`;
 
 export type CreateRemixGallerySubmission = {
   placerId: number;
@@ -172,6 +191,8 @@ export async function createRemixGallerySubmission({
     throw throwBadRequestError('remix gallery: that image cannot be submitted');
 
   const host = await loadHostImage(hostImageId);
+  if (!host.showable)
+    throw throwBadRequestError('remix gallery: this image cannot show a gallery right now');
 
   const rule = remixGalleryContentRule(space.settings);
   if (
@@ -433,6 +454,11 @@ async function assertStillAcceptable({
   });
 
   const host = await loadHostImage(placement.targetId);
+  // Refused rather than approved into a gallery that cannot render. The escrow
+  // is released by expiry, which refunds in full, so waiting costs the submitter
+  // nothing — approving costs them everything.
+  if (!host.showable)
+    throw throwBadRequestError('remix gallery: this image cannot show a gallery right now');
 
   if (
     !remixGalleryLevelAllowed({
@@ -819,8 +845,9 @@ const HOST_IS_MINOR_H = Prisma.sql`(h.minor OR h."acceptableMinor" OR h."needsRe
  * cost of that window is a picker offering an image that is then declined.
  */
 async function readHostImage(hostImageId: number) {
-  const [row] = await dbRead.$queryRaw<{ nsfwLevel: number; minor: boolean }[]>`
-    SELECT "nsfwLevel", ${HOST_IS_MINOR} AS minor FROM "Image" WHERE id = ${hostImageId}
+  const [row] = await dbRead.$queryRaw<{ nsfwLevel: number; minor: boolean; showable: boolean }[]>`
+    SELECT "nsfwLevel", ${HOST_IS_MINOR} AS minor, ${HOST_IS_SHOWABLE} AS showable
+    FROM "Image" WHERE id = ${hostImageId}
   `;
   return row ?? null;
 }
@@ -1020,7 +1047,8 @@ export async function getRemixGalleryVisibility({
   // for exactly that reason; this would have shipped the same fact as a number.
   // Signed in, gallery open, not your own: the case the picker needs and nothing
   // wider.
-  const canSubmitHere = !!viewerId && space.mode !== 'off' && viewerId !== space.ownerId;
+  const canSubmitHere =
+    !!viewerId && space.mode !== 'off' && viewerId !== space.ownerId && !!host?.showable;
   const maxSubmissionLevel = canSubmitHere
     ? remixGalleryMaxSubmissionLevel({
         rule: remixGalleryContentRule(space.settings),

--- a/src/server/services/remix-gallery.service.ts
+++ b/src/server/services/remix-gallery.service.ts
@@ -83,7 +83,7 @@ const MINOR_HOST_REFUSAL =
  */
 async function loadHostImage(hostImageId: number) {
   const [row] = await dbWrite.$queryRaw<{ nsfwLevel: number; minor: boolean }[]>`
-    SELECT "nsfwLevel", minor FROM "Image" WHERE id = ${hostImageId}
+    SELECT "nsfwLevel", ${HOST_IS_MINOR} AS minor FROM "Image" WHERE id = ${hostImageId}
   `;
 
   if (!row) throw throwBadRequestError('remix gallery: that image no longer exists');
@@ -778,6 +778,27 @@ export async function getRemixGallery({
 }
 
 /**
+ * What counts as a host depicting a minor.
+ *
+ * `needsReview = 'minor'` is included because it is the *unresolved* case, and
+ * the resolution can go either way: clearing it without ticking `removeMinorFlag`
+ * sets `minor = TRUE` (`handleUnblockImages`). Reading only the settled column
+ * would leave the window between the scanner raising it and a moderator
+ * answering it as the one moment the ceiling does not apply.
+ */
+const HOST_IS_MINOR = Prisma.sql`((minor OR "needsReview" = 'minor') IS TRUE)`;
+
+/**
+ * The same predicate, qualified for the `h` alias in the gallery read.
+ *
+ * The trailing `IS TRUE` is load-bearing in both. `needsReview` is nullable, so
+ * `"needsReview" = 'minor'` is NULL rather than FALSE on the ordinary image, and
+ * `FALSE OR NULL` is NULL — which `?? true` in the visibility path would then
+ * read as fail-closed and cap *every* gallery at PG-13.
+ */
+const HOST_IS_MINOR_H = Prisma.sql`(h.minor OR h."needsReview" = 'minor') IS TRUE`;
+
+/**
  * The display-side half of the minor-host ceiling.
  *
  * The mutation refuses an over-rating submission, but a host can be flagged as
@@ -788,7 +809,9 @@ export async function getRemixGallery({
 const minorHostCeiling = (hostImageId: number) => Prisma.sql`
         AND (
           i."nsfwLevel" <= ${REMIX_GALLERY_MINOR_HOST_MAX_LEVEL}
-          OR NOT EXISTS (SELECT 1 FROM "Image" h WHERE h.id = ${hostImageId} AND h.minor)
+          OR NOT EXISTS (
+            SELECT 1 FROM "Image" h WHERE h.id = ${hostImageId} AND (${HOST_IS_MINOR_H})
+          )
         )`;
 
 export function parseGalleryCursor(cursor?: string | null) {
@@ -966,7 +989,7 @@ export async function getRemixGalleryVisibility({
   // the mutation will refuse — and, for a minor-flagged host, is not shown a
   // grid of their own mature work next to a Submit button.
   const [host] = await dbRead.$queryRaw<{ nsfwLevel: number; minor: boolean }[]>`
-    SELECT "nsfwLevel", minor FROM "Image" WHERE id = ${hostImageId}
+    SELECT "nsfwLevel", ${HOST_IS_MINOR} AS minor FROM "Image" WHERE id = ${hostImageId}
   `;
   const maxSubmissionLevel = remixGalleryMaxSubmissionLevel({
     rule: remixGalleryContentRule(space.settings),

--- a/src/server/services/remix-gallery.service.ts
+++ b/src/server/services/remix-gallery.service.ts
@@ -10,6 +10,7 @@ import { holdPlacementEscrow, settlePlacement } from '~/server/services/placemen
 import { assertCanPlace } from '~/server/services/placement-moderation.service';
 import { getPlacementConfig } from '~/server/services/placement.service';
 import { resolvePlacementSpaceFor } from '~/server/services/placement-space.service';
+import { imageReviewedSql } from '~/server/common/image-visibility';
 import { throwAuthorizationError, throwBadRequestError } from '~/server/utils/errorHandling';
 import { onlySelectableLevels } from '~/shared/constants/browsingLevel.constants';
 import { declineFeeAmount, PLACEMENT_SURFACES } from '~/shared/utils/placement';
@@ -83,31 +84,13 @@ const MINOR_HOST_REFUSAL =
  */
 async function loadHostImage(hostImageId: number) {
   const [row] = await dbWrite.$queryRaw<{ nsfwLevel: number; minor: boolean; showable: boolean }[]>`
-    SELECT "nsfwLevel", ${HOST_IS_MINOR} AS minor, ${HOST_IS_SHOWABLE} AS showable
-    FROM "Image" WHERE id = ${hostImageId}
+    SELECT i."nsfwLevel", ${hostIsMinor()} AS minor, ${hostIsShowable()} AS showable
+    FROM "Image" i WHERE i.id = ${hostImageId}
   `;
 
   if (!row) throw throwBadRequestError('remix gallery: that image no longer exists');
   return row;
 }
-
-/**
- * Whether the host can display a gallery at all.
- *
- * Every check on this surface asked what the *submission* was, and none asked
- * whether the host could show it. A blocked or unscanned host is hidden from
- * everyone but its owner, yet nothing required the submitter to be able to see
- * it — so Buzz went into escrow for a placement that could never render, and
- * the submitter's only ways out were withdrawing or being charged the decline
- * fee. Not a safety hole, since display is gated either way; it is money taken
- * for something structurally unshowable.
- */
-const HOST_IS_SHOWABLE = Prisma.sql`(
-  ingestion = 'Scanned'
-  AND "needsReview" IS NULL
-  AND NOT "tosViolation"
-  AND "nsfwLevel" != ${NsfwLevel.Blocked}
-)`;
 
 export type CreateRemixGallerySubmission = {
   placerId: number;
@@ -811,43 +794,67 @@ export async function getRemixGallery({
  * and it is the load-bearing one. It is written by a function that touches no
  * other column, so it is independent of `minor` — and every other minor-related
  * gate in this codebase checks it, several without checking `minor` at all.
- * Omitting it here would have left the durably-marked population unguarded at
- * any rating.
  *
- * `minor` alone is also narrower than it looks: resolving a minor review without
+ * `minor` alone is narrower than it looks: resolving a minor review without
  * `removeMinorFlag` writes `CASE WHEN "nsfwLevel" >= 4 THEN FALSE ELSE TRUE`, so
- * a set `minor` is nearly always a PG/PG-13 image that this ceiling would not
- * have moved anyway. The R-and-above host the cap exists for lands in
- * `acceptableMinor`.
+ * a set `minor` is nearly always a PG/PG-13 image already under this ceiling.
+ * The R-and-above host the cap exists for lands in `acceptableMinor`.
  *
  * `needsReview = 'minor'` is the unresolved case, included because the
  * resolution can go either way and fail-closed is the posture everywhere else.
- */
-const HOST_IS_MINOR = Prisma.sql`((minor OR "acceptableMinor" OR "needsReview" = 'minor') IS TRUE)`;
-
-/**
- * The same predicate, qualified for the `h` alias in the gallery read.
  *
- * The trailing `IS TRUE` is load-bearing in both. `needsReview` is nullable, so
- * `"needsReview" = 'minor'` is NULL rather than FALSE on the ordinary image, and
- * `FALSE OR NULL` is NULL — which `?? true` in the visibility path would then
- * read as fail-closed and cap *every* gallery at PG-13.
+ * Parameterised by alias rather than written twice. The second copy — one for
+ * the `h` alias in the gallery read — was a hand-written duplicate, which is
+ * exactly the shape that drifts silently and fails open.
  */
-const HOST_IS_MINOR_H = Prisma.sql`(h.minor OR h."acceptableMinor" OR h."needsReview" = 'minor') IS TRUE`;
+const hostIsMinor = (alias = 'i') => {
+  const t = Prisma.raw(`"${alias}"`);
+  return Prisma.sql`((${t}.minor OR ${t}."acceptableMinor" OR ${t}."needsReview" = 'minor') IS TRUE)`;
+};
 
 /**
- * The host's rating and minor flag from the replica, for display decisions.
+ * Whether the host can display a gallery at all.
+ *
+ * Every check on this surface asked what the *submission* was, and none asked
+ * whether the host could show it. A blocked or unscanned host is hidden from
+ * everyone but its owner, yet nothing required the submitter to be able to see
+ * it — so Buzz went into escrow for a placement that could never render, and
+ * the submitter's only ways out were withdrawing or being charged the decline
+ * fee. Not a safety hole, since display is gated either way; it is money taken
+ * for something structurally unshowable.
+ *
+ * Built on `imageReviewedSql` rather than on `ingestion = 'Scanned'`, which is
+ * what this originally said. That is *stricter* than the rule it claims to
+ * track, and stricter in the direction that costs a creator revenue: a stalled
+ * scan that a moderator rated, or a routine `Rescan` of a published image, is
+ * visible to every viewer through that helper's second arm and would have been
+ * refused here. Same mistake as reading `minor` alone — a hand-rolled predicate
+ * where the repo already has the canonical one.
+ */
+const hostIsShowable = (alias = 'i') => {
+  const t = Prisma.raw(`"${alias}"`);
+  return Prisma.sql`(
+    ${t}."needsReview" IS NULL
+    AND ${imageReviewedSql(alias)}
+    AND NOT ${t}."tosViolation"
+    AND ${t}."nsfwLevel" != ${NsfwLevel.Blocked}
+  )`;
+};
+
+/**
+ * The host's rating and flags from the replica, for display decisions.
  *
  * Deliberately not `loadHostImage`: that reads the primary because it decides a
- * mutation, and this runs on every image-detail view. The predicate is shared,
- * so the two cannot disagree about *what* a minor host is — only, under replica
- * lag, about a flag set in the last moment. The mutation still refuses, so the
- * cost of that window is a picker offering an image that is then declined.
+ * mutation, and this runs on every image-detail view. The predicates are shared,
+ * so the two cannot disagree about *what* a minor or showable host is — only,
+ * under replica lag, about a flag set in the last moment. The mutation still
+ * refuses, so the cost of that window is a picker offering an image that is then
+ * declined.
  */
 async function readHostImage(hostImageId: number) {
   const [row] = await dbRead.$queryRaw<{ nsfwLevel: number; minor: boolean; showable: boolean }[]>`
-    SELECT "nsfwLevel", ${HOST_IS_MINOR} AS minor, ${HOST_IS_SHOWABLE} AS showable
-    FROM "Image" WHERE id = ${hostImageId}
+    SELECT i."nsfwLevel", ${hostIsMinor()} AS minor, ${hostIsShowable()} AS showable
+    FROM "Image" i WHERE i.id = ${hostImageId}
   `;
   return row ?? null;
 }
@@ -864,7 +871,7 @@ const minorHostCeiling = (hostImageId: number) => Prisma.sql`
         AND (
           i."nsfwLevel" <= ${REMIX_GALLERY_MINOR_HOST_MAX_LEVEL}
           OR NOT EXISTS (
-            SELECT 1 FROM "Image" h WHERE h.id = ${hostImageId} AND (${HOST_IS_MINOR_H})
+            SELECT 1 FROM "Image" h WHERE h.id = ${hostImageId} AND ${hostIsMinor('h')}
           )
         )`;
 

--- a/src/server/services/remix-gallery.service.ts
+++ b/src/server/services/remix-gallery.service.ts
@@ -392,7 +392,9 @@ export async function actOnRemixGallerySubmission({
   // prices the owner's attention: a spammer costs them a review. When the host
   // cannot show a gallery the owner was never offered a choice — approve is
   // refused above — so there is no judgement to charge for, and the submitter is
-  // refunded in full through the same path expiry and retraction use.
+  // refunded in full — but recorded as a decline, because that is what happened.
+  // Settling it as an expiry would have written the same money and then told
+  // every later reader that the hold timed out with nobody acting.
   //
   // Without this, the fair outcome for the submitter was the one where the owner
   // ignored their queue: doing nothing expires the hold and returns everything,
@@ -402,7 +404,8 @@ export async function actOnRemixGallerySubmission({
 
   const result = await settlePlacement({
     placementId,
-    action: action === 'approve' ? 'approve' : declineRefundsInFull ? 'expire' : 'decline',
+    action:
+      action === 'approve' ? 'approve' : declineRefundsInFull ? 'declineUnshowableHost' : 'decline',
     actorId: userId,
   });
 

--- a/src/server/services/remix-gallery.service.ts
+++ b/src/server/services/remix-gallery.service.ts
@@ -301,6 +301,7 @@ export async function actOnRemixGallerySubmission({
       ownerId: true,
       status: true,
       surface: true,
+      targetId: true,
       data: true,
       resolvedAt: true,
       createdAt: true,
@@ -387,9 +388,21 @@ export async function actOnRemixGallerySubmission({
     return { settled: true, removed: true };
   }
 
+  // A decline charges the submitter the non-refundable share, and that share
+  // prices the owner's attention: a spammer costs them a review. When the host
+  // cannot show a gallery the owner was never offered a choice — approve is
+  // refused above — so there is no judgement to charge for, and the submitter is
+  // refunded in full through the same path expiry and retraction use.
+  //
+  // Without this, the fair outcome for the submitter was the one where the owner
+  // ignored their queue: doing nothing expires the hold and returns everything,
+  // while tidying up took 30% for a refusal caused entirely by the host's state.
+  const declineRefundsInFull =
+    action === 'decline' && !(await loadHostImage(placement.targetId)).showable;
+
   const result = await settlePlacement({
     placementId,
-    action: action === 'approve' ? 'approve' : 'decline',
+    action: action === 'approve' ? 'approve' : declineRefundsInFull ? 'expire' : 'decline',
     actorId: userId,
   });
 

--- a/src/server/services/remix-gallery.service.ts
+++ b/src/server/services/remix-gallery.service.ts
@@ -18,9 +18,13 @@ import {
   isRemixGalleryPlacementData,
   REMIX_GALLERY_MAX_PENDING_PER_OWNER,
   REMIX_GALLERY_MAX_PINNED,
+  REMIX_GALLERY_MINOR_HOST_MAX_LEVEL,
   REMIX_GALLERY_PAGE_SIZE,
+  REMIX_GALLERY_QUEUE_LIMIT,
+  remixGalleryBlockedByMinorHost,
   remixGalleryContentRule,
   remixGalleryLevelAllowed,
+  remixGalleryMaxSubmissionLevel,
   remixGalleryRemovableAt,
   remixGalleryShuffleSeed,
 } from '~/shared/utils/remix-gallery';
@@ -57,6 +61,29 @@ async function loadSubmissionImage(imageId: number): Promise<SubmissionImage> {
     FROM "Image" i
     LEFT JOIN "Post" p ON p.id = i."postId"
     WHERE i.id = ${imageId}
+  `;
+
+  if (!row) throw throwBadRequestError('remix gallery: that image no longer exists');
+  return row;
+}
+
+/**
+ * Names a ceiling rather than the host's flag. The flag is a moderation state of
+ * someone else's image and the submitter has no business reading it off an error.
+ */
+const MINOR_HOST_REFUSAL =
+  'remix gallery: this image only accepts submissions rated PG-13 or below';
+
+/**
+ * The host image's rating and minor flag, from the primary for the same reason
+ * `loadSubmissionImage` is.
+ *
+ * The flag is loaded here rather than at the call sites so no submission path
+ * can decide a rating without it — `remixGalleryLevelAllowed` requires it.
+ */
+async function loadHostImage(hostImageId: number) {
+  const [row] = await dbWrite.$queryRaw<{ nsfwLevel: number; minor: boolean }[]>`
+    SELECT "nsfwLevel", minor FROM "Image" WHERE id = ${hostImageId}
   `;
 
   if (!row) throw throwBadRequestError('remix gallery: that image no longer exists');
@@ -144,10 +171,7 @@ export async function createRemixGallerySubmission({
   if (submission.tosViolation || submission.minor || submission.poi)
     throw throwBadRequestError('remix gallery: that image cannot be submitted');
 
-  const [host] = await dbWrite.$queryRaw<{ nsfwLevel: number }[]>`
-    SELECT "nsfwLevel" FROM "Image" WHERE id = ${hostImageId}
-  `;
-  if (!host) throw throwBadRequestError('remix gallery: that image no longer exists');
+  const host = await loadHostImage(hostImageId);
 
   const rule = remixGalleryContentRule(space.settings);
   if (
@@ -155,10 +179,16 @@ export async function createRemixGallerySubmission({
       rule,
       submissionLevel: submission.nsfwLevel,
       hostLevel: host.nsfwLevel,
+      hostMinor: host.minor,
     })
   )
     throw throwBadRequestError(
-      rule === 'any'
+      remixGalleryBlockedByMinorHost({
+        submissionLevel: submission.nsfwLevel,
+        hostMinor: host.minor,
+      })
+        ? MINOR_HOST_REFUSAL
+        : rule === 'any'
         ? 'remix gallery: that image has no rating yet'
         : "remix gallery: this creator only accepts submissions rated at or below their image's rating"
     );
@@ -402,16 +432,14 @@ async function assertStillAcceptable({
     targetId: placement.targetId,
   });
 
-  const [host] = await dbWrite.$queryRaw<{ nsfwLevel: number }[]>`
-    SELECT "nsfwLevel" FROM "Image" WHERE id = ${placement.targetId}
-  `;
-  if (!host) throw throwBadRequestError('remix gallery: that image no longer exists');
+  const host = await loadHostImage(placement.targetId);
 
   if (
     !remixGalleryLevelAllowed({
       rule: remixGalleryContentRule(space.settings),
       submissionLevel: submission.nsfwLevel,
       hostLevel: host.nsfwLevel,
+      hostMinor: host.minor,
     })
   )
     // Names both possibilities, because the rule is as likely to have moved as
@@ -419,7 +447,12 @@ async function assertStillAcceptable({
     // arrive gets this on approval, and blaming the image would send them
     // looking at the wrong thing.
     throw throwBadRequestError(
-      "remix gallery: that image's rating no longer fits this gallery's content rule"
+      remixGalleryBlockedByMinorHost({
+        submissionLevel: submission.nsfwLevel,
+        hostMinor: host.minor,
+      })
+        ? MINOR_HOST_REFUSAL
+        : "remix gallery: that image's rating no longer fits this gallery's content rule"
     );
 }
 
@@ -702,7 +735,7 @@ export async function getRemixGallery({
         AND NOT i.minor
         AND NOT i.poi
         AND (i."nsfwLevel" & ${levels}) != 0
-        AND i."nsfwLevel" != 0
+        AND i."nsfwLevel" != 0${minorHostCeiling(hostImageId)}
     )
     SELECT * FROM e
     WHERE TRUE ${keyset}
@@ -743,6 +776,20 @@ export async function getRemixGallery({
         : null,
   };
 }
+
+/**
+ * The display-side half of the minor-host ceiling.
+ *
+ * The mutation refuses an over-rating submission, but a host can be flagged as
+ * depicting a minor *after* entries were approved, and approval is irreversible
+ * for a week. So the ceiling is applied on read too — an entry that becomes
+ * inadmissible stops rendering rather than waiting on a takedown.
+ */
+const minorHostCeiling = (hostImageId: number) => Prisma.sql`
+        AND (
+          i."nsfwLevel" <= ${REMIX_GALLERY_MINOR_HOST_MAX_LEVEL}
+          OR NOT EXISTS (SELECT 1 FROM "Image" h WHERE h.id = ${hostImageId} AND h.minor)
+        )`;
 
 export function parseGalleryCursor(cursor?: string | null) {
   if (!cursor) return null;
@@ -804,12 +851,71 @@ async function galleryHasEntries({
         AND NOT i.minor
         AND NOT i.poi
         AND (i."nsfwLevel" & ${levels}) != 0
-        AND i."nsfwLevel" != 0
+        AND i."nsfwLevel" != 0${minorHostCeiling(hostImageId)}
     ) AS "exists"
   `;
 
   return row?.exists ?? false;
 }
+
+/**
+ * What the viewer has waiting on this gallery, so submitting is not a button
+ * that appears to do nothing.
+ *
+ * Scoped to the viewer's own rows: how many submissions an owner is sitting on
+ * is the owner's business, and `pendingCount` above is the owner-only number.
+ * Rows whose image no longer resolves are kept — an unpublished or re-flagged
+ * image is exactly when the submitter needs to see the row and withdraw it.
+ */
+async function getViewerPendingSubmissions({
+  hostImageId,
+  viewerId,
+}: {
+  hostImageId: number;
+  viewerId: number;
+}) {
+  const rows = await dbRead.placement.findMany({
+    where: {
+      surface: SURFACE,
+      targetType: TARGET_TYPE,
+      targetId: hostImageId,
+      placerId: viewerId,
+      status: 'pending',
+    },
+    select: { id: true, amount: true, data: true, createdAt: true, expiresAt: true },
+    orderBy: { createdAt: 'asc' },
+    take: REMIX_GALLERY_MAX_PENDING_PER_OWNER,
+  });
+
+  const entries = rows.filter((row) => isRemixGalleryPlacementData(row.data));
+  const imageIds = entries.map((row) => (row.data as RemixGalleryPlacementData).imageId);
+  if (!imageIds.length) return [];
+
+  const images = await dbRead.$queryRaw<GalleryThumbImage[]>`
+    SELECT i.id, i.url, i.width, i.height, i.type, i.metadata, i."nsfwLevel"
+    FROM "Image" i
+    WHERE i.id IN (${Prisma.join(imageIds)})
+  `;
+  const byId = new Map(images.map((image) => [image.id, image]));
+
+  return entries.map((row) => ({
+    placementId: row.id,
+    amount: row.amount,
+    createdAt: row.createdAt,
+    expiresAt: row.expiresAt,
+    image: byId.get((row.data as RemixGalleryPlacementData).imageId) ?? null,
+  }));
+}
+
+type GalleryThumbImage = {
+  id: number;
+  url: string;
+  width: number | null;
+  height: number | null;
+  type: MediaType;
+  metadata: MixedObject | null;
+  nsfwLevel: number;
+};
 
 export async function getRemixGalleryVisibility({
   hostImageId,
@@ -848,6 +954,26 @@ export async function getRemixGalleryVisibility({
   // so a string compiled against today's split is a claim about money that can
   // quietly stop being true — the same reason `ResolvedPlacementSpace` carries
   // `ownerShare` at all.
+  // The submitter's own pending rows. Without this, submitting shows nothing at
+  // all on the image it was sent to — the money left and the page looked
+  // unchanged. Skipped for the owner, whose pending view is the queue above.
+  const viewerPending =
+    viewerId && viewerId !== space.ownerId
+      ? await getViewerPendingSubmissions({ hostImageId, viewerId })
+      : [];
+
+  // The ceiling the picker filters on, so a submitter is not offered an image
+  // the mutation will refuse — and, for a minor-flagged host, is not shown a
+  // grid of their own mature work next to a Submit button.
+  const [host] = await dbRead.$queryRaw<{ nsfwLevel: number; minor: boolean }[]>`
+    SELECT "nsfwLevel", minor FROM "Image" WHERE id = ${hostImageId}
+  `;
+  const maxSubmissionLevel = remixGalleryMaxSubmissionLevel({
+    rule: remixGalleryContentRule(space.settings),
+    hostLevel: host?.nsfwLevel ?? 0,
+    hostMinor: host?.minor ?? true,
+  });
+
   const owner = await dbRead.user.findUnique({
     where: { id: space.ownerId },
     select: { username: true },
@@ -870,6 +996,8 @@ export async function getRemixGalleryVisibility({
     ownerShare: space.ownerShare,
     declineFee,
     pendingCount,
+    viewerPending,
+    maxSubmissionLevel,
   };
 }
 
@@ -883,7 +1011,7 @@ export async function getRemixGalleryVisibility({
 export async function getPendingRemixGallerySubmissions({
   ownerId,
   hostImageId,
-  limit = 50,
+  limit = REMIX_GALLERY_QUEUE_LIMIT,
 }: {
   ownerId: number;
   /**
@@ -963,7 +1091,7 @@ export async function getPendingRemixGallerySubmissions({
  */
 export async function getMyRemixGallerySubmissions({
   placerId,
-  limit = 50,
+  limit = REMIX_GALLERY_QUEUE_LIMIT,
 }: {
   placerId: number;
   limit?: number;

--- a/src/server/services/remix-gallery.service.ts
+++ b/src/server/services/remix-gallery.service.ts
@@ -830,15 +830,20 @@ const hostIsMinor = (alias = 'i') => {
  * visible to every viewer through that helper's second arm and would have been
  * refused here. Same mistake as reading `minor` alone — a hand-rolled predicate
  * where the repo already has the canonical one.
+ *
+ * The trailing `IS TRUE` matches its sibling. Every input here is NOT NULL
+ * today, so it changes nothing — but that is a property of four column
+ * defaults rather than of this expression, and a NULL leaking through a future
+ * `NOT` would drop rows silently instead of keeping them.
  */
 const hostIsShowable = (alias = 'i') => {
   const t = Prisma.raw(`"${alias}"`);
-  return Prisma.sql`(
+  return Prisma.sql`((
     ${t}."needsReview" IS NULL
     AND ${imageReviewedSql(alias)}
     AND NOT ${t}."tosViolation"
     AND ${t}."nsfwLevel" != ${NsfwLevel.Blocked}
-  )`;
+  ) IS TRUE)`;
 };
 
 /**

--- a/src/server/services/remix-gallery.service.ts
+++ b/src/server/services/remix-gallery.service.ts
@@ -778,15 +778,26 @@ export async function getRemixGallery({
 }
 
 /**
- * What counts as a host depicting a minor.
+ * What counts as a host depicting a minor. Three columns, because each catches a
+ * population the others miss.
  *
- * `needsReview = 'minor'` is included because it is the *unresolved* case, and
- * the resolution can go either way: clearing it without ticking `removeMinorFlag`
- * sets `minor = TRUE` (`handleUnblockImages`). Reading only the settled column
- * would leave the window between the scanner raising it and a moderator
- * answering it as the one moment the ceiling does not apply.
+ * `acceptableMinor` is the moderator checkbox "Realistic depiction of a minor",
+ * and it is the load-bearing one. It is written by a function that touches no
+ * other column, so it is independent of `minor` — and every other minor-related
+ * gate in this codebase checks it, several without checking `minor` at all.
+ * Omitting it here would have left the durably-marked population unguarded at
+ * any rating.
+ *
+ * `minor` alone is also narrower than it looks: resolving a minor review without
+ * `removeMinorFlag` writes `CASE WHEN "nsfwLevel" >= 4 THEN FALSE ELSE TRUE`, so
+ * a set `minor` is nearly always a PG/PG-13 image that this ceiling would not
+ * have moved anyway. The R-and-above host the cap exists for lands in
+ * `acceptableMinor`.
+ *
+ * `needsReview = 'minor'` is the unresolved case, included because the
+ * resolution can go either way and fail-closed is the posture everywhere else.
  */
-const HOST_IS_MINOR = Prisma.sql`((minor OR "needsReview" = 'minor') IS TRUE)`;
+const HOST_IS_MINOR = Prisma.sql`((minor OR "acceptableMinor" OR "needsReview" = 'minor') IS TRUE)`;
 
 /**
  * The same predicate, qualified for the `h` alias in the gallery read.
@@ -796,7 +807,23 @@ const HOST_IS_MINOR = Prisma.sql`((minor OR "needsReview" = 'minor') IS TRUE)`;
  * `FALSE OR NULL` is NULL — which `?? true` in the visibility path would then
  * read as fail-closed and cap *every* gallery at PG-13.
  */
-const HOST_IS_MINOR_H = Prisma.sql`(h.minor OR h."needsReview" = 'minor') IS TRUE`;
+const HOST_IS_MINOR_H = Prisma.sql`(h.minor OR h."acceptableMinor" OR h."needsReview" = 'minor') IS TRUE`;
+
+/**
+ * The host's rating and minor flag from the replica, for display decisions.
+ *
+ * Deliberately not `loadHostImage`: that reads the primary because it decides a
+ * mutation, and this runs on every image-detail view. The predicate is shared,
+ * so the two cannot disagree about *what* a minor host is — only, under replica
+ * lag, about a flag set in the last moment. The mutation still refuses, so the
+ * cost of that window is a picker offering an image that is then declined.
+ */
+async function readHostImage(hostImageId: number) {
+  const [row] = await dbRead.$queryRaw<{ nsfwLevel: number; minor: boolean }[]>`
+    SELECT "nsfwLevel", ${HOST_IS_MINOR} AS minor FROM "Image" WHERE id = ${hostImageId}
+  `;
+  return row ?? null;
+}
 
 /**
  * The display-side half of the minor-host ceiling.
@@ -950,9 +977,10 @@ export async function getRemixGalleryVisibility({
   /** Decides whether the pending count is computed at all. */
   viewerId?: number;
 }) {
-  const [space, hasEntries] = await Promise.all([
+  const [space, hasEntries, host] = await Promise.all([
     resolvePlacementSpaceFor({ surface: SURFACE, targetType: TARGET_TYPE, targetId: hostImageId }),
     galleryHasEntries({ hostImageId, browsingLevel }),
+    readHostImage(hostImageId),
   ]);
 
   // Counted here rather than by a second round trip from the card, and only for
@@ -972,11 +1000,6 @@ export async function getRemixGalleryVisibility({
         })
       : 0;
 
-  // The owner's name and cut, so the submit button can say where the money goes
-  // without the copy asserting it. The shares are operator-tunable at runtime,
-  // so a string compiled against today's split is a claim about money that can
-  // quietly stop being true — the same reason `ResolvedPlacementSpace` carries
-  // `ownerShare` at all.
   // The submitter's own pending rows. Without this, submitting shows nothing at
   // all on the image it was sent to — the money left and the page looked
   // unchanged. Skipped for the owner, whose pending view is the queue above.
@@ -985,18 +1008,34 @@ export async function getRemixGalleryVisibility({
       ? await getViewerPendingSubmissions({ hostImageId, viewerId })
       : [];
 
-  // The ceiling the picker filters on, so a submitter is not offered an image
-  // the mutation will refuse — and, for a minor-flagged host, is not shown a
-  // grid of their own mature work next to a Submit button.
-  const [host] = await dbRead.$queryRaw<{ nsfwLevel: number; minor: boolean }[]>`
-    SELECT "nsfwLevel", ${HOST_IS_MINOR} AS minor FROM "Image" WHERE id = ${hostImageId}
-  `;
-  const maxSubmissionLevel = remixGalleryMaxSubmissionLevel({
-    rule: remixGalleryContentRule(space.settings),
-    hostLevel: host?.nsfwLevel ?? 0,
-    hostMinor: host?.minor ?? true,
-  });
+  // The ceiling the picker filters on, so a submitter is not offered an image the
+  // mutation will refuse — and, for a minor-flagged host, is not shown a grid of
+  // their own mature work next to a Submit button.
+  //
+  // Withheld from anyone who cannot act on it. Under the `any` rule this number
+  // is 2 only when the host carries a minor flag, so returning it unconditionally
+  // from a public query turned every image id into a one-call oracle for another
+  // user's moderation state — including an *unresolved* review on an image the
+  // caller cannot even view. The refusal message on the mutation is anonymised
+  // for exactly that reason; this would have shipped the same fact as a number.
+  // Signed in, gallery open, not your own: the case the picker needs and nothing
+  // wider.
+  const canSubmitHere = !!viewerId && space.mode !== 'off' && viewerId !== space.ownerId;
+  const maxSubmissionLevel = canSubmitHere
+    ? remixGalleryMaxSubmissionLevel({
+        rule: remixGalleryContentRule(space.settings),
+        hostLevel: host?.nsfwLevel ?? 0,
+        // A host row that no longer resolves fails closed rather than lifting the
+        // ceiling.
+        hostMinor: host?.minor ?? true,
+      })
+    : null;
 
+  // The owner's name and cut, so the submit button can say where the money goes
+  // without the copy asserting it. The shares are operator-tunable at runtime,
+  // so a string compiled against today's split is a claim about money that can
+  // quietly stop being true — the same reason `ResolvedPlacementSpace` carries
+  // `ownerShare` at all.
   const owner = await dbRead.user.findUnique({
     where: { id: space.ownerId },
     select: { username: true },
@@ -1066,9 +1105,15 @@ export async function getPendingRemixGallerySubmissions({
     take: limit,
   });
 
+  // Measured before the image filter below, not after. A queue that hit the cap
+  // and then dropped rows whose image was deleted returns fewer than `limit`, so
+  // a caller counting the returned rows concludes it saw everything — precisely
+  // when it did not, and the escrow behind the rest sits until it expires.
+  const truncated = rows.length >= limit;
+
   const entries = rows.filter((row) => isRemixGalleryPlacementData(row.data));
   const imageIds = entries.map((row) => (row.data as RemixGalleryPlacementData).imageId);
-  if (!imageIds.length) return [];
+  if (!imageIds.length) return { items: [], truncated };
 
   const images = await dbRead.$queryRaw<
     {
@@ -1095,13 +1140,16 @@ export async function getPendingRemixGallerySubmissions({
   `;
   const byId = new Map(images.map((image) => [image.id, image]));
 
-  return entries
-    .map((row) => ({
-      ...row,
-      data: row.data as RemixGalleryPlacementData,
-      image: byId.get((row.data as RemixGalleryPlacementData).imageId) ?? null,
-    }))
-    .filter((row) => row.image);
+  return {
+    items: entries
+      .map((row) => ({
+        ...row,
+        data: row.data as RemixGalleryPlacementData,
+        image: byId.get((row.data as RemixGalleryPlacementData).imageId) ?? null,
+      }))
+      .filter((row) => row.image),
+    truncated,
+  };
 }
 
 /**

--- a/src/shared/utils/remix-gallery.ts
+++ b/src/shared/utils/remix-gallery.ts
@@ -33,6 +33,14 @@ export const REMIX_GALLERY_MAX_PINNED = 4;
 /** Entries per page. The rest arrive on scroll against the same seed. */
 export const REMIX_GALLERY_PAGE_SIZE = 12;
 
+/**
+ * How many rows either review queue returns in one request.
+ *
+ * Neither queue pages, so this is also the point at which a busy owner stops
+ * being shown everything — the queues say so rather than looking complete.
+ */
+export const REMIX_GALLERY_QUEUE_LIMIT = 50;
+
 /** Cards per row, used to trim a page to a whole number of rows. */
 export const REMIX_GALLERY_ROW_WIDTH = 4;
 
@@ -76,6 +84,12 @@ export const remixGalleryContentRule = (
   settings?.contentRule === 'any' ? 'any' : REMIX_GALLERY_DEFAULT_CONTENT_RULE;
 
 /**
+ * The hard ceiling on what may be submitted into a host image flagged as
+ * depicting a minor. Not a creator preference and not overridable by one.
+ */
+export const REMIX_GALLERY_MINOR_HOST_MAX_LEVEL = NsfwLevel.PG13;
+
+/**
  * Whether a submission's rating is acceptable for a host under a rule.
  *
  * `nsfwLevel` is a single bitwise flag per image and the levels are ordered
@@ -85,23 +99,62 @@ export const remixGalleryContentRule = (
  * A level of 0 means unscanned or unrated and is refused under **both** rules.
  * It is not a safe value, it is an absent one, and treating it as PG is how an
  * unscanned image lands on someone else's page.
+ *
+ * `hostMinor` is required rather than optional so a caller cannot reach this
+ * without having loaded the flag: the submitted image being clean says nothing
+ * about the host, and a remix can arrive from an external generation, so the
+ * generator's own refusals are not in the path.
  */
 export function remixGalleryLevelAllowed({
   rule,
   submissionLevel,
   hostLevel,
+  hostMinor,
 }: {
   rule: RemixGalleryContentRule;
   submissionLevel: number;
   hostLevel: number;
+  hostMinor: boolean;
 }) {
   if (!submissionLevel || submissionLevel === NsfwLevel.Blocked) return false;
-  if (rule === 'any') return true;
-  // An unrated host cannot ceiling anything, so it fails closed rather than
-  // admitting everything.
-  if (!hostLevel) return false;
-  return submissionLevel <= hostLevel;
+  return submissionLevel <= remixGalleryMaxSubmissionLevel({ rule, hostLevel, hostMinor });
 }
+
+/**
+ * The highest rating this gallery will take, as a number the picker can filter
+ * on before anyone pays.
+ *
+ * Expressed as the ceiling rather than as a second copy of the rules, because
+ * `remixGalleryLevelAllowed` is defined in terms of it — a picker that filtered
+ * on its own reading of the rules would drift from what the mutation refuses,
+ * and the direction it drifts in decides whether someone is charged for a
+ * submission that was never going to be accepted.
+ *
+ * Zero means nothing may be submitted: an unrated host cannot ceiling anything,
+ * so `atOrBelow` fails closed rather than admitting everything.
+ */
+export function remixGalleryMaxSubmissionLevel({
+  rule,
+  hostLevel,
+  hostMinor,
+}: {
+  rule: RemixGalleryContentRule;
+  hostLevel: number;
+  hostMinor: boolean;
+}) {
+  const ceiling = rule === 'any' ? NsfwLevel.XXX : hostLevel;
+  // The one ceiling `any` does not lift.
+  return hostMinor ? Math.min(ceiling, REMIX_GALLERY_MINOR_HOST_MAX_LEVEL) : ceiling;
+}
+
+/** Whether a refusal from `remixGalleryLevelAllowed` was the minor-host cap. */
+export const remixGalleryBlockedByMinorHost = ({
+  submissionLevel,
+  hostMinor,
+}: {
+  submissionLevel: number;
+  hostMinor: boolean;
+}) => hostMinor && submissionLevel > REMIX_GALLERY_MINOR_HOST_MAX_LEVEL;
 
 /**
  * Hours since the epoch, the same value the contest-collection shuffle uses.


### PR DESCRIPTION
Pre-rollout fixes for the remix gallery (#3810), from the 2026-08-12 art-department review. Remix gallery is live for mods and about to open to testers.

## 1. Safety: a minor-flagged host caps submissions at PG-13

This is the item that must not ship late. The submission flow read the *submitted* image's `minor` flag and never the *host's*, so an image flagged as depicting a minor accepted whatever its owner's content rule allowed — under the `any` rule, that is XXX. A remix can be an external generation rather than something made through the remix entry point, so the generator's own refusals are not in this path.

The ceiling is expressed once, in `remixGalleryMaxSubmissionLevel`, and `remixGalleryLevelAllowed` is defined in terms of it. That is deliberate: the picker filters on the same number the mutation refuses on, rather than on a second reading of the rules that can drift — and the direction it would drift in decides whether someone is charged for a submission that was never going to be accepted. `hostMinor` is a **required** parameter, so no call site can decide a rating without having loaded the flag.

Applied at four moments, each for a different reason:

| Where | Why it is not covered by the others |
|---|---|
| `createRemixGallerySubmission` | Before any Buzz is held. |
| `assertStillAcceptable` (approval) | A host can be flagged *after* the submission was sent. |
| `getRemixGallery` / `galleryHasEntries` (read) | Approval is irreversible for a week, so an entry that becomes inadmissible must stop rendering rather than wait for a takedown. |
| `RemixGallerySubmitModal` (picker) | Nobody should be shown a grid of their own mature work next to a Submit button on a minor-flagged host. |

## 2. The submitter sees a pending state

Submitting charged Buzz and changed nothing on the image it was sent to; the only evidence it had worked was a notification whenever the owner eventually decided. `getRemixGalleryVisibility` now returns the viewer's own pending entries — their own rows only, since how many submissions an owner is sitting on is the owner's business — and the card shows the submitted thumbnails with the withdraw path.

## 3. "You have to post it first"

The picker lists published images because that is all the mutation accepts, and a freshly generated image is not one. It now says so, above the grid rather than only in the empty state — the confusing case is having images in the grid and not the one you just made — and links to posting.

I did **not** make the picker post the image for you. Publishing content on someone's behalf is a product decision, not a bug fix.

## 4. Volume

The gallery pages by keyset over a shuffled order and had never been run with enough entries. Verified against the dev database: **43 approved entries, 4 of them pinned, walked in 4 pages — 43/43 distinct, no duplicates, no omissions, cursor terminates.** With the host flagged as minor the 3 mature entries drop out (43 → 40) and paging still terminates. Seed data removed afterwards.

What that surfaced instead: **neither review queue pages at all.** Both are capped at 50 with no cursor, so a busy owner saw a full list that looked complete while the escrow behind everything past 50 sat until it expired. Both now say when they are showing only the first 50. Real paging for the queues is a follow-up, not a rollout blocker.

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm run lint` — clean on changed files (repo-wide baseline is dirty)
- `pnpm run test:unit:run` — 14936 passed, 16 failed. All 16 are pre-existing: `check-server-graph-singletons`, `typecheck`, `analytics-bucket-labels.drift`, `block-scope.normalize-endpoint`, `app-spend-tier-privilege`, `orchestrator-chat.wait-unit`. I ran the same files on untouched `main` and they fail identically there. **Zero** failures in remix or placement.
- `blocks.router.workflow.test.ts` collected **347 tests** (nonzero, so the run means something)
- Both halves of the guard are mutation-tested, including the partial revert: deleting the ceiling from `galleryHasEntries` *alone* now fails, which the first version of the drift guard missed. Nothing hangs.

  Known limit, stated rather than papered over: the drift guard asserts on SQL strings, so it catches deletion but cannot catch an inversion (`NOT EXISTS` → `EXISTS`). No assertion reachable without a database sees that.

## Adversarial review

Two independent reviewers over six rounds, both prompted to refute and to default to "broken". Between them they found 18 real defects, all fixed here. The ones worth reading:

- **`acceptableMinor` was missing from the host check** — the moderator's "Realistic depiction of a minor" checkbox, written independently of `Image.minor`, and checked by every other minor gate in the codebase. It was the column that mattered: `minor` is cleared to FALSE on anything R-and-above when a review is resolved, so without this the cap mostly guarded images already under it.
- **The host was checked with a stricter rule than the app's own.** `ingestion = 'Scanned'` refuses a stalled scan a moderator rated, and an image mid-`Rescan` — both publicly visible. Now built on `imageReviewedSql`, the helper `getImage` itself uses. Same mistake as the `minor` one: hand-rolled where the repo had the canonical predicate.
- **The host was never checked for being showable at all**, so a blocked or unscanned host took Buzz into escrow for a placement that could never render.
- **The drift guard was half decorative.** Two of its four assertions were satisfied by filters the CTE already carried, and it only exercised one of the two readers — so deleting the ceiling from `galleryHasEntries` alone passed clean.
- `maxSubmissionLevel` was readable from a public query, making every image id a one-call probe for another user's moderation state.
- The picker concluded from its first page of 50: a creator whose recent posts are all above the ceiling was told none of their images qualified, over a library it had never finished reading.

## What this session should teach us

Worth recording, because it is the most transferable output here:

**Every original fix held. Five of the hardening passes on top of them introduced new bugs** — a three-valued-logic SQL error that would have capped every gallery at PG-13, a code block edited into the wrong function, an infinite spinner, a vacuous test, and an unbounded fetch that walked a creator's whole library on modal open.

**None of them was caught by the test suite.** What caught them: a query against the dev database, the typechecker, and an adversarial reader. The suite was green for every one.

Two claims in earlier versions of this PR description were too strong and have been corrected in place: that the disclosure oracle was closed (it is narrowed), and that the read-side ceiling was covered by a mutation test (it was, but only against full deletion — the partial revert passed).

## Not fixed, deliberately

- **Replica lag.** Display ceilings read the replica, the mutation reads the primary. A just-flagged host has a lag-width window where the picker offers an image the mutation then refuses. Moving the gallery read to the primary would put every image-detail view on it.
- **Residual disclosure.** `hasEntries` and the gallery read are public and derived from the same predicate, so an entry disappearing when a host is flagged is observable by anyone on the page. Closing it means removing the feature. The position is that this bit is acceptable to leak to someone who can already see the gallery.
- **Paid placements suppressed by the read-side ceiling.** If a host is flagged after an entry was approved, the entry stops rendering: submitter paid, owner keeps the Buzz, nobody is told. Right safety call, wrong person to decide the money question.
- **Nothing.** The decline-fee asymmetry this guard created was decided by Justin and fixed: on an unshowable host a decline now settles as `declineUnshowableHost` — full refund, no fee, recorded as a decline. The fee prices the owner's attention, and an unshowable host refuses approval, so there was no judgement to charge for.

## Worth remembering

- `feeWaived` is now read from one `FEE_WAIVING_ACTIONS` list rather than two by-name comparisons. Those two are consulted in different places — one computes the payout, one writes the row — and a member added to one but not the other would refund in full while recording a fee that was never taken. Same shape as collapsing the duplicated host predicate into `hostIsMinor(alias)`: two hand-maintained copies became one definition, and both times that closed a class of bug rather than an instance.
- **An owner can waive their own decline fee** by appealing their own host image, which sets `needsReview = 'appeal'` and makes it unshowable. It costs them and gains them nothing today, so there is no abuse case. It would become one if the split ever changes so the platform takes a share of the decline fee.
- A declined placement disappears from the submitter's Sent tab (`getMyRemixGallerySubmissions` filters to `pending`/`approved`). That predates this branch and applies to every decline — but it means the resolved notification is the *only* signal a submitter ever gets that their submission was answered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
