### PR TITLE
fix(shop): add top pagination and keep section pages across purchases

### DIFF
--- a/packages/civitai-db-schema/src/kysely/types.ts
+++ b/packages/civitai-db-schema/src/kysely/types.ts
@@ -327,13 +327,11 @@ export type AppCollaborator = {
   app_listing_id: string;
   user_id: number;
   /**
-   * Capability role. 'editor' today. WHAT an editor may do is derived from the
-   * LISTING'S KIND, never stored here (`capabilitiesForKind`): content + media +
-   * submit-for-review + analytics for both kinds, plus earnings + submit-version for
-   * ONSITE only — an off-site listing has no AppBlock, so neither can exist for it.
-   * Owner-only actions (managing collaborators, initiating a transfer) are NOT a role —
-   * they are reserved to the listing OWNER, which is `AppBlock.app.userId` (the
-   * OauthClient) for an ONSITE listing and `app_listings.user_id` for an OFFSITE one.
+   * Capability role. 'editor' today. What it actually unlocks is DERIVED from the
+   * listing's kind (`capabilitiesForKind`), not stored here: content + media + submit
+   * for review + analytics on both kinds, plus earnings and submit-version/git on
+   * on-site only. Owner-only actions (managing collaborators, initiating a transfer)
+   * are NOT a role — they are reserved to the listing owner.
    */
   role: Generated<string>;
   /**

--- a/src/components/CosmeticShop/CommunityCosmeticsSection.tsx
+++ b/src/components/CosmeticShop/CommunityCosmeticsSection.tsx
@@ -85,6 +85,7 @@ export function CommunityCosmeticsSection({
           </Center>
         ) : items.length ? (
           <>
+            <ShopBrowsePagination page={page} onChange={setPage} totalPages={totalPages} />
             <div className="relative">
               <LoadingOverlay visible={isFetching} zIndex={9} />
               <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(280px,1fr))]">

--- a/src/components/CreatorShop/Storefront/CosmeticsSection.tsx
+++ b/src/components/CreatorShop/Storefront/CosmeticsSection.tsx
@@ -65,6 +65,7 @@ export function CosmeticsSection({
       />
       {matched.length ? (
         <>
+          <ShopBrowsePagination page={page} onChange={setPage} totalPages={totalPages} />
           <ShopItemGrid
             items={cosmetics}
             ownedCosmeticIds={ownedCosmeticIds}

--- a/src/components/CreatorShop/Storefront/ResoldSection.tsx
+++ b/src/components/CreatorShop/Storefront/ResoldSection.tsx
@@ -69,6 +69,7 @@ export function ResoldSection({
       />
       {matched.length ? (
         <>
+          <ShopBrowsePagination page={page} onChange={setPage} totalPages={totalPages} />
           {/* viaShopUserId credits this shop owner with the reseller share on purchase. */}
           <ShopItemGrid
             items={filtered}

--- a/src/components/Shop/OfficialShopSection.tsx
+++ b/src/components/Shop/OfficialShopSection.tsx
@@ -65,6 +65,7 @@ export function OfficialShopSection({
       hideTitle={meta.hideTitle}
       className={className}
     >
+      <ShopBrowsePagination page={page} onChange={setPage} totalPages={totalPages} />
       <ShopSection.Items>
         {items.map(({ shopItem, createdAt }) => (
           <ShopItem

--- a/src/pages/shop/index.tsx
+++ b/src/pages/shop/index.tsx
@@ -83,7 +83,9 @@ export default function CosmeticShopMain() {
   const [pageSize, setPageSize] = useState<number>(COSMETIC_SHOP_DEFAULT_PAGE_SIZE);
   const [debouncedFilters] = useDebouncedValue({ cosmeticTypes: filters.cosmeticTypes }, 500);
   const { cosmeticShopSections, isLoading } = useQueryShop(debouncedFilters);
-  const { isFetching: loadingOwnedCosmetics } = useQueryUserCosmetics();
+  // Initial load only: a purchase invalidates `user.getCosmetics`, and gating on
+  // the refetch would unmount every section and lose each one's page.
+  const { isLoading: loadingOwnedCosmetics } = useQueryUserCosmetics();
   const ownedCosmeticIds = useOwnedCosmeticIds();
   const { wishlistedIds } = useQueryWishlistedShopItems();
   const features = useFeatureFlags();


### PR DESCRIPTION
Renders `ShopBrowsePagination` above the item grid in the official, community, creator cosmetics, and resold sections so long lists can be paged without scrolling to the bottom. On the shop page, the owned-cosmetics gate now uses `isLoading` instead of `isFetching`, so the `user.getCosmetics` invalidation a purchase triggers no longer unmounts every section and resets each one's page.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
Implemented by the local ticket agent (task `cosmetic-shop-f1`). Reviewed locally before push.