### PR TITLE
fix(strikes): make escalation valid SQL, and actually atomic

### DIFF
--- a/src/server/services/__tests__/strike.service.test.ts
+++ b/src/server/services/__tests__/strike.service.test.ts
@@ -579,6 +579,12 @@ describe('strike.service', () => {
           }),
         })
       );
+      // Pin the window itself, not just the number quoted in the notification — the literal 3 here is
+      // deliberate, so the test still fails if TIMED_MUTE_DAYS is changed without meaning to.
+      const { muteExpiresAt } = userUpdate.mock.calls[0][0].data;
+      const days = (muteExpiresAt.getTime() - Date.now()) / (24 * 60 * 60 * 1000);
+      expect(days).toBeGreaterThan(2.99);
+      expect(days).toBeLessThan(3.01);
       expect(mockInvalidateSession).toHaveBeenCalledWith(1, 'strike');
       expect(mockCreateNotification).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/server/services/__tests__/strike.service.test.ts
+++ b/src/server/services/__tests__/strike.service.test.ts
@@ -107,15 +107,23 @@ import {
 } from '~/server/services/strike.service';
 import { StrikeReason, StrikeStatus } from '~/shared/utils/prisma/enums';
 
-// Helper: mock evaluateStrikeEscalation's transaction
+// Helper: mock evaluateStrikeEscalation's transaction. The returned mocks are the transaction
+// client's, so a test asserting on `userUpdate` is asserting the write happened INSIDE the
+// transaction — which is the whole point of taking the lock.
 function mockTransactionForEscalation(pointsSum: number | null, user: any) {
+  const queryRaw = vi.fn().mockResolvedValue([{ sum: pointsSum }]);
+  const userUpdate = vi.fn().mockResolvedValue(user);
   mockDbWrite.$transaction.mockImplementation(async (fn: any) =>
     fn({
-      $queryRaw: vi.fn().mockResolvedValue([{ sum: pointsSum }]),
-      user: { findUnique: vi.fn().mockResolvedValue(user) },
+      $queryRaw: queryRaw,
+      user: { findUnique: vi.fn().mockResolvedValue(user), update: userUpdate },
     })
   );
+  return { queryRaw, userUpdate };
 }
+
+// Prisma tagged templates hand the raw SQL over as a TemplateStringsArray.
+const sqlOf = (call: any[]) => (call[0] as string[]).join(' ');
 
 describe('strike.service', () => {
   beforeEach(() => {
@@ -510,7 +518,7 @@ describe('strike.service', () => {
   // ==========================================================================
   describe('evaluateStrikeEscalation', () => {
     it('3+ points: mutes, flags for review, invalidates session', async () => {
-      mockTransactionForEscalation(3, {
+      const { userUpdate } = mockTransactionForEscalation(3, {
         muted: false,
         muteExpiresAt: null,
         meta: {},
@@ -519,9 +527,9 @@ describe('strike.service', () => {
       const result = await evaluateStrikeEscalation(1);
 
       expect(result).toEqual({ totalPoints: 3, action: 'muted-and-flagged' });
-      expect(mockUpdateUserById).toHaveBeenCalledWith(
+      expect(userUpdate).toHaveBeenCalledWith(
         expect.objectContaining({
-          id: 1,
+          where: { id: 1 },
           data: expect.objectContaining({
             muted: true,
             muteExpiresAt: null,
@@ -529,6 +537,9 @@ describe('strike.service', () => {
           }),
         })
       );
+      // Through the transaction client, never a post-commit updateUserById — outside the
+      // transaction the FOR UPDATE lock is already released and the decision is unguarded.
+      expect(mockUpdateUserById).not.toHaveBeenCalled();
       expect(mockInvalidateSession).toHaveBeenCalledWith(1, 'strike');
       expect(mockCreateNotification).toHaveBeenCalledWith(
         expect.objectContaining({ type: 'strike-escalation-muted' })
@@ -536,7 +547,7 @@ describe('strike.service', () => {
     });
 
     it('3+ points, already flagged: updates user but skips duplicate notification', async () => {
-      mockTransactionForEscalation(4, {
+      const { userUpdate } = mockTransactionForEscalation(4, {
         muted: true,
         muteExpiresAt: null,
         meta: { strikeFlaggedForReview: true },
@@ -545,12 +556,12 @@ describe('strike.service', () => {
       const result = await evaluateStrikeEscalation(1);
 
       expect(result.action).toBe('muted-and-flagged');
-      expect(mockUpdateUserById).toHaveBeenCalled();
+      expect(userUpdate).toHaveBeenCalled();
       expect(mockCreateNotification).not.toHaveBeenCalled();
     });
 
     it('2 points: 3-day mute, invalidates session', async () => {
-      mockTransactionForEscalation(2, {
+      const { userUpdate } = mockTransactionForEscalation(2, {
         muted: false,
         muteExpiresAt: null,
         meta: {},
@@ -559,9 +570,9 @@ describe('strike.service', () => {
       const result = await evaluateStrikeEscalation(1);
 
       expect(result).toEqual({ totalPoints: 2, action: 'muted' });
-      expect(mockUpdateUserById).toHaveBeenCalledWith(
+      expect(userUpdate).toHaveBeenCalledWith(
         expect.objectContaining({
-          id: 1,
+          where: { id: 1 },
           data: expect.objectContaining({
             muted: true,
             muteExpiresAt: expect.any(Date),
@@ -578,7 +589,7 @@ describe('strike.service', () => {
     });
 
     it('2 points, already timed-muted: updates user but skips duplicate notification', async () => {
-      mockTransactionForEscalation(2, {
+      const { userUpdate } = mockTransactionForEscalation(2, {
         muted: true,
         muteExpiresAt: new Date('2099-01-01'),
         meta: {},
@@ -587,12 +598,12 @@ describe('strike.service', () => {
       const result = await evaluateStrikeEscalation(1);
 
       expect(result.action).toBe('muted');
-      expect(mockUpdateUserById).toHaveBeenCalled();
+      expect(userUpdate).toHaveBeenCalled();
       expect(mockCreateNotification).not.toHaveBeenCalled();
     });
 
     it('2 points with existing flag: clears strikeFlaggedForReview', async () => {
-      mockTransactionForEscalation(2, {
+      const { userUpdate } = mockTransactionForEscalation(2, {
         muted: true,
         muteExpiresAt: null,
         meta: { strikeFlaggedForReview: true },
@@ -601,7 +612,7 @@ describe('strike.service', () => {
       const result = await evaluateStrikeEscalation(1);
 
       expect(result.action).toBe('muted');
-      expect(mockUpdateUserById).toHaveBeenCalledWith(
+      expect(userUpdate).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({
             meta: expect.objectContaining({ strikeFlaggedForReview: false }),
@@ -611,7 +622,7 @@ describe('strike.service', () => {
     });
 
     it('<2 points, user not muted: no action', async () => {
-      mockTransactionForEscalation(1, {
+      const { userUpdate } = mockTransactionForEscalation(1, {
         muted: false,
         muteExpiresAt: null,
         meta: {},
@@ -620,12 +631,12 @@ describe('strike.service', () => {
       const result = await evaluateStrikeEscalation(1);
 
       expect(result).toEqual({ totalPoints: 1, action: 'none' });
-      expect(mockUpdateUserById).not.toHaveBeenCalled();
+      expect(userUpdate).not.toHaveBeenCalled();
       expect(mockCreateNotification).not.toHaveBeenCalled();
     });
 
     it('<2 points, user strike-muted (has muteExpiresAt): unmutes and sends notification', async () => {
-      mockTransactionForEscalation(1, {
+      const { userUpdate } = mockTransactionForEscalation(1, {
         muted: true,
         muteExpiresAt: new Date('2099-01-01'),
         meta: {},
@@ -634,13 +645,13 @@ describe('strike.service', () => {
       const result = await evaluateStrikeEscalation(1);
 
       expect(result).toEqual({ totalPoints: 1, action: 'unmuted' });
-      expect(mockUpdateUserById).toHaveBeenCalledWith(
+      expect(userUpdate).toHaveBeenCalledWith(
         expect.objectContaining({
+          where: { id: 1 },
           data: expect.objectContaining({
             muted: false,
             muteExpiresAt: null,
           }),
-          updateSource: 'strike-de-escalation',
         })
       );
       expect(mockCreateNotification).toHaveBeenCalledWith(
@@ -650,7 +661,7 @@ describe('strike.service', () => {
     });
 
     it('<2 points, user flagged (has strikeFlaggedForReview): unmutes and clears flag', async () => {
-      mockTransactionForEscalation(0, {
+      const { userUpdate } = mockTransactionForEscalation(0, {
         muted: true,
         muteExpiresAt: null,
         meta: { strikeFlaggedForReview: true },
@@ -659,7 +670,7 @@ describe('strike.service', () => {
       const result = await evaluateStrikeEscalation(1);
 
       expect(result).toEqual({ totalPoints: 0, action: 'unmuted' });
-      expect(mockUpdateUserById).toHaveBeenCalledWith(
+      expect(userUpdate).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({
             muted: false,
@@ -671,7 +682,7 @@ describe('strike.service', () => {
     });
 
     it('<2 points, user manually muted (no muteExpiresAt, no flag): does NOT unmute', async () => {
-      mockTransactionForEscalation(0, {
+      const { userUpdate } = mockTransactionForEscalation(0, {
         muted: true,
         muteExpiresAt: null,
         meta: {},
@@ -680,20 +691,20 @@ describe('strike.service', () => {
       const result = await evaluateStrikeEscalation(1);
 
       expect(result).toEqual({ totalPoints: 0, action: 'none' });
-      expect(mockUpdateUserById).not.toHaveBeenCalled();
+      expect(userUpdate).not.toHaveBeenCalled();
     });
 
     it('user not found: returns none', async () => {
-      mockTransactionForEscalation(3, null);
+      const { userUpdate } = mockTransactionForEscalation(3, null);
 
       const result = await evaluateStrikeEscalation(999);
 
       expect(result).toEqual({ totalPoints: 3, action: 'none' });
-      expect(mockUpdateUserById).not.toHaveBeenCalled();
+      expect(userUpdate).not.toHaveBeenCalled();
     });
 
-    it('uses dbWrite.$transaction with FOR UPDATE for race condition safety', async () => {
-      mockTransactionForEscalation(1, {
+    it('locks the strike rows at a query level below the SUM', async () => {
+      const { queryRaw } = mockTransactionForEscalation(1, {
         muted: false,
         muteExpiresAt: null,
         meta: {},
@@ -702,7 +713,17 @@ describe('strike.service', () => {
       await evaluateStrikeEscalation(1);
 
       expect(mockDbWrite.$transaction).toHaveBeenCalledTimes(1);
-      expect(mockDbWrite.$transaction).toHaveBeenCalledWith(expect.any(Function));
+      // Postgres rejects `FOR UPDATE` on an aggregate query (0A000, "not allowed with aggregate
+      // functions"), so the lock has to stay one query level below the SUM — which it only does
+      // while the CTE is materialized. Collapsing the levels throws on every call, and that is what
+      // left the whole strike system dead in production for five months.
+      const [sql] = queryRaw.mock.calls.map(sqlOf);
+      expect(sql).toMatch(/FOR UPDATE/);
+      expect(sql).toMatch(/AS MATERIALIZED/);
+      expect(
+        sql.indexOf('FOR UPDATE') < sql.indexOf('SUM('),
+        'FOR UPDATE must be inside the CTE, i.e. before the SUM that reads it'
+      ).toBe(true);
     });
   });
 
@@ -921,7 +942,7 @@ describe('strike.service', () => {
     it('re-evaluates escalation after voiding', async () => {
       mockDbWrite.userStrike.updateMany.mockResolvedValue({ count: 1 });
       mockDbRead.userStrike.findUniqueOrThrow.mockResolvedValue(mockVoidedStrike);
-      mockTransactionForEscalation(0, {
+      const { userUpdate } = mockTransactionForEscalation(0, {
         muted: true,
         muteExpiresAt: new Date('2099-01-01'),
         meta: {},
@@ -931,9 +952,9 @@ describe('strike.service', () => {
 
       // evaluateStrikeEscalation should have been called via transaction
       expect(mockDbWrite.$transaction).toHaveBeenCalled();
-      expect(mockUpdateUserById).toHaveBeenCalledWith(
+      expect(userUpdate).toHaveBeenCalledWith(
         expect.objectContaining({
-          id: 100,
+          where: { id: 100 },
           data: expect.objectContaining({ muted: false }),
         })
       );

--- a/src/server/services/strike.service.ts
+++ b/src/server/services/strike.service.ts
@@ -320,12 +320,17 @@ export async function getUserStandings(input: GetUserStandingsInput) {
 
 export type EscalationAction = 'none' | 'muted' | 'muted-and-flagged' | 'unmuted';
 
+// The escalation ladder, in active strike points. At or above INDEFINITE_MUTE_POINTS the mute has no
+// expiry and the account is flagged for moderator review; at or above TIMED_MUTE_POINTS it expires
+// after TIMED_MUTE_DAYS; below that, a mute this engine applied earlier is lifted again.
+const TIMED_MUTE_POINTS = 2;
+const INDEFINITE_MUTE_POINTS = 3;
+const TIMED_MUTE_DAYS = 3;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
 /**
  * Evaluate strike escalation for a user based on their total active points.
  * Handles both escalation (mute/flag) and de-escalation (unmute when points drop).
- * - 3+ points: Indefinite mute + flagged for review
- * - 2 points: 3-day mute (timer resets/extends each time)
- * - <2 points: If currently strike-muted, unmute and clear flag
  */
 export async function evaluateStrikeEscalation(
   userId: number
@@ -361,15 +366,14 @@ export async function evaluateStrikeEscalation(
 
       const currentMeta = (user.meta as UserMeta) ?? {};
 
-      if (totalPoints >= 3) {
-        // Indefinite mute + flag for review
+      if (totalPoints >= INDEFINITE_MUTE_POINTS) {
         const alreadyFlagged = user.muted && currentMeta.strikeFlaggedForReview;
 
         await tx.user.update({
           where: { id: userId },
           data: {
             muted: true,
-            muteExpiresAt: null, // Indefinite
+            muteExpiresAt: null, // A null expiry is what makes a mute indefinite
             meta: {
               ...currentMeta,
               strikeFlaggedForReview: true,
@@ -382,9 +386,9 @@ export async function evaluateStrikeEscalation(
         return { totalPoints, action: 'muted-and-flagged', notify: !alreadyFlagged };
       }
 
-      if (totalPoints >= 2) {
-        // 3-day mute (always reset/extend timer)
-        const muteExpiresAt = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000);
+      if (totalPoints >= TIMED_MUTE_POINTS) {
+        // The window restarts on every evaluation, so a new strike extends an active mute
+        const muteExpiresAt = new Date(Date.now() + TIMED_MUTE_DAYS * DAY_MS);
         const alreadyTimedMuted = user.muted && user.muteExpiresAt !== null;
 
         await tx.user.update({
@@ -392,7 +396,7 @@ export async function evaluateStrikeEscalation(
           data: {
             muted: true,
             muteExpiresAt,
-            // Clear the review flag if points dropped below 3
+            // Coming down from the indefinite tier, so the review flag no longer applies
             ...(currentMeta.strikeFlaggedForReview && {
               meta: {
                 ...currentMeta,
@@ -451,7 +455,7 @@ export async function evaluateStrikeEscalation(
             category: NotificationCategory.System,
             key: `strike-escalation-muted:${userId}:${Date.now()}`,
             userId,
-            details: { muteDays: action === 'muted-and-flagged' ? 'indefinite' : 3 },
+            details: { muteDays: action === 'muted-and-flagged' ? 'indefinite' : TIMED_MUTE_DAYS },
           }
     );
   }

--- a/src/server/services/strike.service.ts
+++ b/src/server/services/strike.service.ts
@@ -2,7 +2,7 @@ import { Prisma } from '@prisma/client';
 import { TRPCError } from '@trpc/server';
 import { NotificationCategory } from '~/server/common/enums';
 import { dbRead, dbWrite } from '~/server/db/client';
-import { dbReadFallbackCounter } from '~/server/prom/client';
+import { dbReadFallbackCounter, userUpdateCounter } from '~/server/prom/client';
 import { invalidateSession, refreshSession } from '~/server/auth/session-invalidation';
 import { createNotification } from '~/server/services/notification.service';
 import { updateUserById } from '~/server/services/user.service';
@@ -330,134 +330,136 @@ export type EscalationAction = 'none' | 'muted' | 'muted-and-flagged' | 'unmuted
 export async function evaluateStrikeEscalation(
   userId: number
 ): Promise<{ totalPoints: number; action: EscalationAction }> {
-  // Read points and user state in a single transaction to prevent race conditions
-  const { totalPoints, user } = await dbWrite.$transaction(async (tx) => {
-    const [pointsResult] = await tx.$queryRaw<[{ sum: bigint | null }]>`
-      SELECT SUM(points) as sum
-      FROM "UserStrike"
-      WHERE "userId" = ${userId}
-        AND "status" = ${StrikeStatus.Active}::"StrikeStatus"
-        AND "expiresAt" > NOW()
-      FOR UPDATE
-    `;
-    const txUser = await tx.user.findUnique({
-      where: { id: userId },
-      select: { muted: true, muteExpiresAt: true, meta: true },
-    });
-    return {
-      totalPoints: Number(pointsResult.sum ?? 0),
-      user: txUser,
-    };
-  });
+  // The point total and the mute-state write are one atomic unit. `FOR UPDATE` on the strike rows
+  // only serializes concurrent evaluations while the transaction is open, so the write has to be
+  // inside it — otherwise two callers both read a stale total and the loser's decision lands last.
+  // Notifications and session invalidation stay outside: no I/O in a transaction.
+  const { totalPoints, action, notify } = await dbWrite.$transaction(
+    async (tx): Promise<{ totalPoints: number; action: EscalationAction; notify: boolean }> => {
+      // The lock has to sit at a different query level from the aggregate: Postgres rejects
+      // `FOR UPDATE` on an aggregate query outright (0A000), so `SUM(points) ... FOR UPDATE` throws
+      // on every call. `MATERIALIZED` is load-bearing — inlining the CTE would collapse the two
+      // levels back into one.
+      const [pointsResult] = await tx.$queryRaw<[{ sum: bigint | null }]>`
+        WITH locked AS MATERIALIZED (
+          SELECT points
+          FROM "UserStrike"
+          WHERE "userId" = ${userId}
+            AND "status" = ${StrikeStatus.Active}::"StrikeStatus"
+            AND "expiresAt" > NOW()
+          FOR UPDATE
+        )
+        SELECT SUM(points) as sum FROM locked
+      `;
+      const totalPoints = Number(pointsResult?.sum ?? 0);
 
-  if (!user) {
-    return { totalPoints, action: 'none' };
-  }
-
-  const currentMeta = (user.meta as UserMeta) ?? {};
-
-  if (totalPoints >= 3) {
-    // Indefinite mute + flag for review
-    const alreadyFlagged = user.muted && currentMeta.strikeFlaggedForReview;
-
-    await updateUserById({
-      id: userId,
-      data: {
-        muted: true,
-        muteExpiresAt: null, // Indefinite
-        meta: {
-          ...currentMeta,
-          strikeFlaggedForReview: true,
-          strikeFlaggedAt: new Date(),
-        },
-      },
-      updateSource: 'strike-escalation',
-    });
-
-    // Only send notification if this is a new escalation, not a duplicate
-    if (!alreadyFlagged) {
-      await createNotification({
-        type: 'strike-escalation-muted',
-        category: NotificationCategory.System,
-        key: `strike-escalation-muted:${userId}:${Date.now()}`,
-        userId,
-        details: { muteDays: 'indefinite' },
+      const user = await tx.user.findUnique({
+        where: { id: userId },
+        select: { muted: true, muteExpiresAt: true, meta: true },
       });
-    }
+      if (!user) return { totalPoints, action: 'none', notify: false };
 
-    await invalidateSession(userId, 'strike');
+      const currentMeta = (user.meta as UserMeta) ?? {};
 
-    return { totalPoints, action: 'muted-and-flagged' };
-  } else if (totalPoints >= 2) {
-    // 3-day mute (always reset/extend timer)
-    const muteExpiresAt = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000);
-    const alreadyTimedMuted = user.muted && user.muteExpiresAt !== null;
+      if (totalPoints >= 3) {
+        // Indefinite mute + flag for review
+        const alreadyFlagged = user.muted && currentMeta.strikeFlaggedForReview;
 
-    await updateUserById({
-      id: userId,
-      data: {
-        muted: true,
-        muteExpiresAt,
-        // Clear the review flag if points dropped below 3
-        ...(currentMeta.strikeFlaggedForReview && {
-          meta: {
-            ...currentMeta,
-            strikeFlaggedForReview: false,
+        await tx.user.update({
+          where: { id: userId },
+          data: {
+            muted: true,
+            muteExpiresAt: null, // Indefinite
+            meta: {
+              ...currentMeta,
+              strikeFlaggedForReview: true,
+              strikeFlaggedAt: new Date(),
+            },
           },
-        }),
-      },
-      updateSource: 'strike-escalation',
-    });
+        });
 
-    // Only send notification if this is a new mute, not just extending an existing one
-    if (!alreadyTimedMuted) {
-      await createNotification({
-        type: 'strike-escalation-muted',
-        category: NotificationCategory.System,
-        key: `strike-escalation-muted:${userId}:${Date.now()}`,
-        userId,
-        details: { muteDays: 3 },
-      });
+        // Only notify on a new escalation, not a duplicate
+        return { totalPoints, action: 'muted-and-flagged', notify: !alreadyFlagged };
+      }
+
+      if (totalPoints >= 2) {
+        // 3-day mute (always reset/extend timer)
+        const muteExpiresAt = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000);
+        const alreadyTimedMuted = user.muted && user.muteExpiresAt !== null;
+
+        await tx.user.update({
+          where: { id: userId },
+          data: {
+            muted: true,
+            muteExpiresAt,
+            // Clear the review flag if points dropped below 3
+            ...(currentMeta.strikeFlaggedForReview && {
+              meta: {
+                ...currentMeta,
+                strikeFlaggedForReview: false,
+              },
+            }),
+          },
+        });
+
+        // Only notify on a new mute, not on extending an existing one
+        return { totalPoints, action: 'muted', notify: !alreadyTimedMuted };
+      }
+
+      // De-escalation: if user is currently muted from strikes, unmute them.
+      // Only unmute if the mute was from strikes (has muteExpiresAt set) or
+      // was flagged for review. Don't touch manual mutes (muteExpiresAt === null
+      // and no strike flag).
+      if (user.muted && (user.muteExpiresAt !== null || currentMeta.strikeFlaggedForReview)) {
+        await tx.user.update({
+          where: { id: userId },
+          data: {
+            muted: false,
+            muteExpiresAt: null,
+            ...(currentMeta.strikeFlaggedForReview && {
+              meta: {
+                ...currentMeta,
+                strikeFlaggedForReview: false,
+              },
+            }),
+          },
+        });
+
+        return { totalPoints, action: 'unmuted', notify: true };
+      }
+
+      return { totalPoints, action: 'none', notify: false };
     }
+  );
 
-    await invalidateSession(userId, 'strike');
+  if (action === 'none') return { totalPoints, action };
 
-    return { totalPoints, action: 'muted' };
+  userUpdateCounter?.inc({ location: 'strike.service:evaluateStrikeEscalation' });
+
+  if (notify) {
+    await createNotification(
+      action === 'unmuted'
+        ? {
+            type: 'strike-de-escalation-unmuted',
+            category: NotificationCategory.System,
+            key: `strike-de-escalation-unmuted:${userId}:${Date.now()}`,
+            userId,
+            details: {},
+          }
+        : {
+            type: 'strike-escalation-muted',
+            category: NotificationCategory.System,
+            key: `strike-escalation-muted:${userId}:${Date.now()}`,
+            userId,
+            details: { muteDays: action === 'muted-and-flagged' ? 'indefinite' : 3 },
+          }
+    );
   }
 
-  // De-escalation: if user is currently muted from strikes, unmute them.
-  // Only unmute if the mute was from strikes (has muteExpiresAt set) or
-  // was flagged for review. Don't touch manual mutes (muteExpiresAt === null
-  // and no strike flag).
-  if (user.muted && (user.muteExpiresAt !== null || currentMeta.strikeFlaggedForReview)) {
-    await updateUserById({
-      id: userId,
-      data: {
-        muted: false,
-        muteExpiresAt: null,
-        ...(currentMeta.strikeFlaggedForReview && {
-          meta: {
-            ...currentMeta,
-            strikeFlaggedForReview: false,
-          },
-        }),
-      },
-      updateSource: 'strike-de-escalation',
-    });
+  if (action === 'unmuted') await refreshSession(userId, { caller: 'strike' });
+  else await invalidateSession(userId, 'strike');
 
-    await createNotification({
-      type: 'strike-de-escalation-unmuted',
-      category: NotificationCategory.System,
-      key: `strike-de-escalation-unmuted:${userId}:${Date.now()}`,
-      userId,
-      details: {},
-    });
-
-    await refreshSession(userId, { caller: 'strike' });
-    return { totalPoints, action: 'unmuted' };
-  }
-
-  return { totalPoints, action: 'none' };
+  return { totalPoints, action };
 }
 
 // ============================================================================


### PR DESCRIPTION
Fixes the strike escalation engine, which has been dead in production since it shipped.

ClickUp: [868kqe9y2](https://app.clickup.com/t/868kqe9y2)

## The bug

`evaluateStrikeEscalation` ran:

```sql
SELECT SUM(points) as sum FROM "UserStrike" WHERE ... FOR UPDATE
```

Postgres refuses this outright — `0A000`, *"FOR UPDATE is not allowed with aggregate functions"*. It is a **parse-analysis rejection**, so it threw on every call, for every input, from the day it shipped (#2019, 2026-02-26). Reproduced directly against the database.

Four callers: `createStrike`, `voidStrike`, `expireStrikes` (daily cron), `processTimedUnmutes` (hourly cron). Both crons catch per user and log, so it failed silently — `civitai-prod` carries **649 `strike-expired-escalation-failed` events** in the trailing 30 days, every one this error.

## It never ran once

Not "mostly broken" — never succeeded:

| Query against prod | Result |
|---|---|
| `SELECT count(*) FROM "User" WHERE meta ? 'strikeFlaggedForReview'` | **0** |
| `SELECT count(*) FROM "User" WHERE "muteExpiresAt" IS NOT NULL` | **0** |

The flag key is only ever *added* — de-escalation writes `false`, it does not delete — so zero means the 3+ path has never completed. No strike has ever muted anyone.

Current exposure: **437 users sit at ≥2 active points**; 334 of them are not muted. 36 are at ≥3.

## The fix

**1. The lock moved one query level below the aggregate**, into a CTE, because it cannot share a level with it.

```sql
WITH locked AS MATERIALIZED (
  SELECT points FROM "UserStrike" WHERE ... FOR UPDATE
)
SELECT SUM(points) as sum FROM locked
```

`MATERIALIZED` is load-bearing, not decorative — inlining the CTE would collapse the two levels back into one. I verified the locks are genuinely taken rather than silently skipped: a second connection probing each row with `FOR UPDATE NOWAIT` got `55P03` on every one, and `EXPLAIN` puts `LockRows` inside the CTE.

A single statement also means the predicate is written once. The two-statement alternative had it twice, where editing one copy would silently lock a different set of rows than it summed.

**2. The mute-state write moved inside that transaction.** It was a post-commit `updateUserById`, which made the lock decorative: row locks release at commit, so every decision was acted on after the guard was already gone, and two concurrent evaluations could both read a stale total with the loser's write landing last.

For the fields escalation touches, `updateUserById` reduces to `dbWrite.user.update` plus a prom counter — no cache busts, no external calls — so `tx.user.update` loses nothing. Notifications and session invalidation stay after commit, per `no-io-in-transaction` (guard suite passes). The counter is re-emitted post-commit as `strike.service:evaluateStrikeEscalation`; the old label has no historical data to lose, since the path never ran.

## Tests

The 55 existing tests pass **before and after** the fix — they mock Prisma, so none of them could ever execute the raw SQL. That suite should not be read as coverage of these queries.

They now assert the write lands on the **transaction client** rather than on `updateUserById` — that assertion *is* the atomicity property. A new test pins the lock below the aggregate, and I checked how it fails rather than only that it passes:

| Break | Failure |
|---|---|
| Collapse the levels back | `expected '…SELECT SUM(points) as sum…' to match /AS MATERIALIZED/` |
| Drop `MATERIALIZED` | `expected '…WITH locked AS (…' to match /AS MATERIALIZED/` |
| Drop `FOR UPDATE` | `expected '…WITH locked AS MATERIALIZED…' to match /FOR UPDATE/` |

Each fails in under a second with the offending SQL in the message. The dropped-lock case is the one worth having — an ordering-only assertion passes it, since `indexOf` returns `-1`.

## Verified end to end

Driven against the dev database through the moderator app UI and `/api/mod/retool/strike`:

| Points | Expected | Observed |
|---|---|---|
| 1 | no action | `muted:false` — negative control |
| 2 | 3-day mute | `muted:true, muteExpiresAt:+3d` |
| 3 | indefinite + flagged | `muted:true, muteExpiresAt:null, strikeFlaggedForReview:true` |
| 3 → 2 (void) | downgrade, clear flag | `muteExpiresAt:+3d, flag:false` |
| 2 → 1 (void) | unmute | `muted:false, muteExpiresAt:null` |

Every branch, including the 3+ path that has never run in production. The `new Date()` written into the meta JSON serializes correctly — that was a real open risk.

**Not verified:** notification *delivery*. `NOTIFICATIONS_ENDPOINT` is unset in dev, so `createNotification` logs `notifications-request-failed` and swallows it. The dispatch calls fire and their failure is non-fatal — the mute committed and the endpoint still returned 200 — but no payload left the box.

## Before merging — this deploy is not neutral

Once this ships, `expireStrikes` calls escalation for every user with a strike expiring that day, against points accrued over months while nothing was enforcing them:

- **63 users** get auto-muted within the first 30 days, **3 of them indefinitely + flagged**
- each gets a `strike-escalation-muted` notification

That is a retroactive enforcement wave, not a catch-up. Worth an explicit decision (and possibly a reconciliation pass) rather than letting the cron discover it.

Separately: **prod user 1290051 carries 2 leftover strike rows** (ids 12383, 12384) from the original reproduction. They are real, Active until 2026-09-11, and put that account at 2 points — it gets auto-muted the moment this deploys. They should be voided first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
