### PR TITLE
fix(api): pin per-file downloadUrl to its own fileId on /api/v1/models/[id] and /api/v1/model-versions/[id]

### DIFF
--- a/src/pages/api/v1/model-versions/[id].ts
+++ b/src/pages/api/v1/model-versions/[id].ts
@@ -7,7 +7,10 @@ import * as z from 'zod';
 import { getEdgeUrl } from '~/client-utils/cf-images-utils';
 import { isProd } from '~/env/other';
 import { getDownloadFilename } from '~/server/services/file.service';
-import { createModelFileDownloadUrl } from '~/server/common/model-helpers';
+import {
+  createModelFileDownloadUrl,
+  createSerializedFileDownloadUrl,
+} from '~/server/common/model-helpers';
 import { dbRead } from '~/server/db/client';
 import type { ModelVersionApiReturn } from '~/server/selectors/modelVersion.selector';
 import { getImagesForModelVersion } from '~/server/services/image.service';
@@ -257,9 +260,17 @@ export async function prepareModelVersionResponse(
             // route re-resolves the file from the caller's filePreferences, so
             // the advertised `hashes`/`sizeKB`/`name` and the bytes actually
             // served can disagree on a multi-file version.
-            downloadUrl: `${baseUrl.origin}${createModelFileDownloadUrl({
-              versionId: version.id,
-              fileId: file.id,
+            //
+            // `castedFiles` is NOT all this version's own files: the `vaeId`
+            // splice above pushes files that live on the LINKED VAE version.
+            // createSerializedFileDownloadUrl pins ONLY a file this version
+            // owns; a spliced one keeps its original discriminator URL, which
+            // the download route resolves through the linked-component
+            // fallback. See the invariant note on that helper.
+            downloadUrl: `${baseUrl.origin}${createSerializedFileDownloadUrl({
+              file: { id: file.id, modelVersionId, type: file.type, metadata },
+              hostVersionId: version.id,
+              primary: primaryFile.id === file.id,
             })}`,
           }))
       : [],

--- a/src/pages/api/v1/model-versions/[id].ts
+++ b/src/pages/api/v1/model-versions/[id].ts
@@ -252,11 +252,14 @@ export async function prepareModelVersionResponse(
               getDownloadFilename({ model, modelVersion: version, file })
             ),
             primary: primaryFile.id === file.id,
+            // Pin the URL to THIS file — see the matching note in
+            // src/pages/api/v1/models/[id].ts. Without `fileId` the download
+            // route re-resolves the file from the caller's filePreferences, so
+            // the advertised `hashes`/`sizeKB`/`name` and the bytes actually
+            // served can disagree on a multi-file version.
             downloadUrl: `${baseUrl.origin}${createModelFileDownloadUrl({
               versionId: version.id,
-              type: file.type,
-              meta: metadata,
-              primary: primaryFile.id === file.id,
+              fileId: file.id,
             })}`,
           }))
       : [],

--- a/src/pages/api/v1/models/[id].ts
+++ b/src/pages/api/v1/models/[id].ts
@@ -5,7 +5,10 @@ import { ModelFileVisibility, ModelModifier } from '~/shared/utils/prisma/enums'
 
 import { getEdgeUrl } from '~/client-utils/cf-images-utils';
 import { ModelSort } from '~/server/common/enums';
-import { createModelFileDownloadUrl } from '~/server/common/model-helpers';
+import {
+  createModelFileDownloadUrl,
+  createSerializedFileDownloadUrl,
+} from '~/server/common/model-helpers';
 import { getDownloadFilename } from '~/server/services/file.service';
 import { getModelsWithVersions } from '~/server/services/model.service';
 import { publicModelResponseKey } from '~/server/services/model-version.service';
@@ -115,7 +118,7 @@ async function buildPublicModelResponse(
           files: includeDownloadUrl
             ? castedFiles
                 .filter((file) => file.visibility === ModelFileVisibility.Public)
-                .map(({ hashes, metadata, ...file }) => ({
+                .map(({ hashes, metadata, modelVersionId, ...file }) => ({
                   ...file,
                   metadata: removeEmpty(metadata),
                   name: safeDecodeURIComponent(
@@ -132,9 +135,16 @@ async function buildPublicModelResponse(
                   // discriminator in createModelFileDownloadUrl, and the
                   // download route skips its metadata-misalignment check
                   // because the file is already exact.
-                  downloadUrl: `${baseUrl}${createModelFileDownloadUrl({
-                    versionId: version.id,
-                    fileId: file.id,
+                  //
+                  // `version.files` is NOT all this version's own files:
+                  // getModelsWithVersions splices in the linked VAE version's
+                  // files (`files.push(...vaeFile)`), which keep their own
+                  // `modelVersionId`. createSerializedFileDownloadUrl pins ONLY
+                  // a file this version owns — see the invariant note there.
+                  downloadUrl: `${baseUrl}${createSerializedFileDownloadUrl({
+                    file: { id: file.id, modelVersionId, type: file.type, metadata },
+                    hostVersionId: version.id,
+                    primary: primaryFile.id === file.id,
                   })}`,
                   primary: primaryFile.id === file.id ? true : undefined,
                   url: undefined,

--- a/src/pages/api/v1/models/[id].ts
+++ b/src/pages/api/v1/models/[id].ts
@@ -122,11 +122,19 @@ async function buildPublicModelResponse(
                     getDownloadFilename({ model, modelVersion: version, file })
                   ),
                   hashes: hashesAsObject(hashes),
+                  // Pin the URL to THIS file. Passing `type`/`meta`/`primary`
+                  // instead makes the download route re-resolve the file on its
+                  // own (caller's filePreferences + its own scoring) — and for
+                  // the elected primary it emits a bare, entirely unqualified
+                  // URL — so on a multi-file version the URL could serve a file
+                  // other than the one whose `hashes`/`sizeKB`/`name` are
+                  // serialized right here. `fileId` suppresses every soft
+                  // discriminator in createModelFileDownloadUrl, and the
+                  // download route skips its metadata-misalignment check
+                  // because the file is already exact.
                   downloadUrl: `${baseUrl}${createModelFileDownloadUrl({
                     versionId: version.id,
-                    type: file.type,
-                    meta: metadata,
-                    primary: primaryFile.id === file.id,
+                    fileId: file.id,
                   })}`,
                   primary: primaryFile.id === file.id ? true : undefined,
                   url: undefined,

--- a/src/server/common/__tests__/serialized-file-download-url.test.ts
+++ b/src/server/common/__tests__/serialized-file-download-url.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createModelFileDownloadUrl,
+  createSerializedFileDownloadUrl,
+  toApiModelFile,
+} from '~/server/common/model-helpers';
+
+/**
+ * The invariant, pinned at the one place that can violate it:
+ *
+ *   a `fileId` is emitted ONLY alongside the version that file belongs to.
+ *
+ * Both public v1 shapers splice CROSS-VERSION files into a version's file list
+ * (`getVaeFiles` → `files.push(...vae)`), so "every file in this array belongs
+ * to this version" is false. The download route resolves a pinned URL as
+ * `findFirst({ id: fileId, modelVersionId })` — a pair that disagrees is a hard
+ * 404 on a URL that resolved fine before pinning existed.
+ *
+ * Nothing is mocked here: the helper and the URL string it produces ARE the
+ * contract. Values are pairwise distinct so a mutant that binds the wrong id
+ * (or swaps the two version operands) cannot coincidentally emit the right URL.
+ */
+
+const HOST_VERSION_ID = 4242;
+const LINKED_VAE_VERSION_ID = 9999;
+
+const OWNED_FILE = {
+  id: 21,
+  modelVersionId: HOST_VERSION_ID,
+  type: 'Model',
+  metadata: { format: 'SafeTensor', size: 'pruned', fp: 'fp16' },
+} as const;
+
+// Exactly what getVaeFiles emits: a file selected off the LINKED version
+// (its own id, its own modelVersionId) with `type` rewritten to 'VAE'.
+const SPLICED_VAE_FILE = {
+  id: 91,
+  modelVersionId: LINKED_VAE_VERSION_ID,
+  type: 'VAE',
+  metadata: { format: 'SafeTensor', size: 'full', fp: 'fp32' },
+} as const;
+
+describe('createSerializedFileDownloadUrl — a fileId never pairs with a foreign version', () => {
+  it('pins a file the host version OWNS', () => {
+    const url = new URL(
+      `https://x.test${createSerializedFileDownloadUrl({
+        file: OWNED_FILE,
+        hostVersionId: HOST_VERSION_ID,
+        primary: false,
+      })}`
+    );
+    expect(url.pathname).toBe('/api/download/models/4242');
+    expect([...url.searchParams.keys()]).toEqual(['fileId']);
+    expect(url.searchParams.get('fileId')).toBe('21');
+  });
+
+  it('pins the elected primary too (a bare, re-resolvable URL is what #3861 fixed)', () => {
+    const url = new URL(
+      `https://x.test${createSerializedFileDownloadUrl({
+        file: OWNED_FILE,
+        hostVersionId: HOST_VERSION_ID,
+        primary: true,
+      })}`
+    );
+    expect(url.search).toBe('?fileId=21');
+  });
+
+  it('does NOT pin a file spliced in from a LINKED version', () => {
+    const path = createSerializedFileDownloadUrl({
+      file: SPLICED_VAE_FILE,
+      hostVersionId: HOST_VERSION_ID,
+      primary: false,
+    });
+    const url = new URL(`https://x.test${path}`);
+    // The 404 shape this guards against: fileId=91 on version 4242, a pair
+    // `findFirst({ id: 91, modelVersionId: 4242 })` resolves to null.
+    expect(url.searchParams.get('fileId')).toBeNull();
+    // …and it must not silently redirect the download at the OTHER version
+    // either: that would move access gating and download attribution.
+    expect(url.pathname).toBe('/api/download/models/4242');
+    expect(url.pathname).not.toBe(`/api/download/models/${LINKED_VAE_VERSION_ID}`);
+  });
+
+  it('falls back to EXACTLY the pre-pin discriminator URL for a spliced file', () => {
+    // Byte-identical to what the endpoints emitted before pinning existed —
+    // the download route's linked-component fallback keys off `type`.
+    const expected = createModelFileDownloadUrl({
+      versionId: HOST_VERSION_ID,
+      type: SPLICED_VAE_FILE.type,
+      meta: SPLICED_VAE_FILE.metadata,
+      primary: false,
+    });
+    expect(
+      createSerializedFileDownloadUrl({
+        file: SPLICED_VAE_FILE,
+        hostVersionId: HOST_VERSION_ID,
+        primary: false,
+      })
+    ).toBe(expected);
+    // Positive control: that fallback URL is not empty of discriminators, so
+    // the equality above is not two blank strings agreeing.
+    expect(new URL(`https://x.test${expected}`).searchParams.get('type')).toBe('VAE');
+  });
+
+  it.each([
+    ['missing', {}],
+    ['null', { modelVersionId: null }],
+  ])('does NOT pin when modelVersionId is %s (cannot prove the pair)', (_label, extra) => {
+    const url = new URL(
+      `https://x.test${createSerializedFileDownloadUrl({
+        file: { id: 77, type: 'Model', metadata: { format: 'GGUF' }, ...extra },
+        hostVersionId: HOST_VERSION_ID,
+        primary: false,
+      })}`
+    );
+    expect(url.searchParams.get('fileId')).toBeNull();
+    expect(url.pathname).toBe('/api/download/models/4242');
+  });
+
+  it('over a matrix of (file version, host version) pairs, a fileId appears IFF they match', () => {
+    const versionIds = [4242, 9999, 1, 4243];
+    let pinned = 0;
+    for (const fileVersionId of versionIds) {
+      for (const hostVersionId of versionIds) {
+        const url = new URL(
+          `https://x.test${createSerializedFileDownloadUrl({
+            file: { id: 500 + fileVersionId, modelVersionId: fileVersionId, type: 'Model' },
+            hostVersionId,
+            primary: false,
+          })}`
+        );
+        const fileId = url.searchParams.get('fileId');
+        // The path segment is ALWAYS the host version — never the file's.
+        expect(url.pathname).toBe(`/api/download/models/${hostVersionId}`);
+        if (fileVersionId === hostVersionId) {
+          expect(fileId, `${fileVersionId} vs ${hostVersionId}`).toBe(String(500 + fileVersionId));
+          pinned++;
+        } else {
+          expect(fileId, `${fileVersionId} vs ${hostVersionId}`).toBeNull();
+        }
+      }
+    }
+    // Positive control: the matrix really did exercise both branches.
+    expect(pinned).toBe(versionIds.length);
+  });
+});
+
+/**
+ * The other half of the invariant: the file has to still HAVE its owning
+ * version id by the time the URL is built. `getModelsWithVersions` reduces every
+ * file through `toApiModelFile` before handing it to its two public consumers,
+ * and that reduction used to destructure `modelVersionId` away — which is what
+ * made a spliced VAE file indistinguishable from a local one at the shaper.
+ */
+describe('toApiModelFile — the owning version id survives the reduction', () => {
+  const row = {
+    id: 91,
+    modelVersionId: 9999,
+    type: 'VAE',
+    visibility: 'Public',
+    sizeKB: 5555,
+    metadata: {
+      format: 'SafeTensor',
+      size: 'full',
+      fp: 'fp32',
+      quantType: 'Q8_0',
+      isRequired: true,
+      // Not published on the v1 wire body — must be dropped.
+      selectedEpochUrl: 's3://internal',
+    },
+  };
+
+  it('keeps modelVersionId (a spliced file is only identifiable by it)', () => {
+    expect(toApiModelFile({ ...row }).modelVersionId).toBe(9999);
+  });
+
+  it('passes every other non-metadata field through untouched', () => {
+    const out = toApiModelFile({ ...row });
+    expect(out.id).toBe(91);
+    expect(out.type).toBe('VAE');
+    expect(out.visibility).toBe('Public');
+    expect(out.sizeKB).toBe(5555);
+  });
+
+  it('narrows metadata to exactly the five published fields', () => {
+    const out = toApiModelFile({ ...row });
+    expect(Object.keys(out.metadata).sort()).toEqual([
+      'format',
+      'fp',
+      'isRequired',
+      'quantType',
+      'size',
+    ]);
+    expect(out.metadata.format).toBe('SafeTensor');
+    expect(out.metadata.fp).toBe('fp32');
+    expect(out.metadata.quantType).toBe('Q8_0');
+    expect(out.metadata.isRequired).toBe(true);
+  });
+
+  it('tolerates a missing metadata blob', () => {
+    const out = toApiModelFile({ id: 5, modelVersionId: 4242 });
+    expect(out.modelVersionId).toBe(4242);
+    expect(out.metadata.format).toBeUndefined();
+  });
+
+  it('a reduced file still pins correctly end-to-end', () => {
+    // The two helpers composed the way production composes them.
+    const reduced = toApiModelFile({ ...row });
+    expect(createSerializedFileDownloadUrl({ file: reduced, hostVersionId: 9999 })).toBe(
+      '/api/download/models/9999?fileId=91'
+    );
+    expect(
+      new URL(
+        `https://x.test${createSerializedFileDownloadUrl({ file: reduced, hostVersionId: 4242 })}`
+      ).searchParams.get('fileId')
+    ).toBeNull();
+  });
+});

--- a/src/server/common/model-helpers.ts
+++ b/src/server/common/model-helpers.ts
@@ -31,6 +31,92 @@ export const createModelFileDownloadUrl = ({
   return `/api/download/models/${versionId}${queryString ? '?' + queryString : ''}`;
 };
 
+/**
+ * The ONE place a per-file `downloadUrl` is built for a serialized file list.
+ *
+ * INVARIANT: a `fileId` is only ever emitted next to the version that file
+ * actually belongs to. That is not automatic, because both public shapers
+ * splice CROSS-VERSION files into a version's file list: `getVaeFiles`
+ * (model.service) reads the primary `Model` files off a LINKED component
+ * version, relabels them `VAE`, and pushes them into the HOST version's array
+ * carrying their own ids. Pinning such a file's id to the host version emits a
+ * pair the download route resolves as `findFirst({ id: fileId, modelVersionId })`
+ * (file.service) → null → a hard 404 on a URL that used to work.
+ *
+ * So the pin is gated on an identity comparison — `hostVersionId` is the only
+ * version id this function will ever put in the path, and `fileId` rides along
+ * ONLY when the file says it belongs to that same version.
+ *
+ * A file the host version does NOT own keeps the pre-pin, discriminator-based
+ * URL: the download route re-resolves it and, for a component type
+ * (`isComponentFileType` — VAE/Text Encoder/UNet/…), satisfies it through the
+ * linked-component fallback. That is byte-identical to the URL those files
+ * carried before pinning existed, which is deliberate — it keeps their access
+ * gating (evaluated against the HOST version) and their download attribution
+ * exactly where they were. Re-pointing the URL at the file's own version would
+ * silently move both, so it is not done here.
+ *
+ * A file with a missing/null `modelVersionId` takes the same unpinned branch:
+ * we cannot prove the pair is consistent, and an unpinned URL cannot 404. Both
+ * production sources select `modelVersionId` explicitly (`modelFileSelect`, and
+ * `getVaeFiles`' own select), so this is a deliberate fail-safe, not a path
+ * production is expected to take.
+ */
+export const createSerializedFileDownloadUrl = ({
+  file,
+  hostVersionId,
+  primary = false,
+}: {
+  file: {
+    id: number;
+    modelVersionId?: number | null;
+    type?: ModelFileType | string;
+    metadata?: BasicFileMetadata | null;
+  };
+  hostVersionId: number;
+  primary?: boolean;
+}) => {
+  const owned = file.modelVersionId != null && file.modelVersionId === hostVersionId;
+  if (owned) return createModelFileDownloadUrl({ versionId: hostVersionId, fileId: file.id });
+
+  return createModelFileDownloadUrl({
+    versionId: hostVersionId,
+    type: file.type,
+    meta: file.metadata ?? undefined,
+    primary,
+  });
+};
+
+/**
+ * Reduce a DB model file to the shape `getModelsWithVersions` hands its two
+ * public consumers: the raw `metadata` JSON narrowed to the five published
+ * fields, everything else passed through UNTOUCHED.
+ *
+ * "Everything else" is load-bearing and is why this is a named function rather
+ * than an inline map: it must keep `modelVersionId`. A version's file list can
+ * contain files spliced in from a LINKED version (`files.push(...vaeFile)`), so
+ * that field is the ONLY thing telling a consumer which version owns a given
+ * file — and `createSerializedFileDownloadUrl` needs it to decide whether the
+ * file's id may be pinned into a download URL. Dropping it here silently pairs
+ * a foreign file id with the host version, i.e. a 404.
+ */
+export function toApiModelFile<T extends { metadata?: unknown }>({
+  metadata: metadataRaw,
+  ...file
+}: T) {
+  const metadata = metadataRaw as FileMetadata | undefined;
+  return {
+    ...file,
+    metadata: {
+      format: metadata?.format,
+      size: metadata?.size,
+      fp: metadata?.fp,
+      quantType: metadata?.quantType,
+      isRequired: metadata?.isRequired,
+    },
+  };
+}
+
 export function getImageGenerationProcess(meta: MixedObject): ImageGenerationProcess {
   // if (meta['comfy'] != null) return ImageGenerationProcess.comfy; // Enable this after the search migration is complete
 

--- a/src/server/services/__tests__/file-download-lookup.test.ts
+++ b/src/server/services/__tests__/file-download-lookup.test.ts
@@ -150,7 +150,7 @@ describe('getFileForModelVersion — orphan model relation + unresolvable URL', 
   // box that transform can exceed a per-test timeout (a 30s describe override
   // flaked here under contention). Pay it ONCE in beforeAll with a generous hook
   // timeout, then every test uses the warm reference — no per-test import race.
-  let getFileForModelVersion: (typeof import('../file.service'))['getFileForModelVersion'];
+  let getFileForModelVersion: typeof import('../file.service')['getFileForModelVersion'];
   beforeAll(async () => {
     ({ getFileForModelVersion } = await import('../file.service'));
   }, 60000);
@@ -368,5 +368,198 @@ describe('getFileForModelVersion — orphan model relation + unresolvable URL', 
 
       expect(result.status).toBe('not-found');
     });
+  });
+});
+
+/**
+ * THE SEAM: a serialized `downloadUrl` is a CLAIM that the download route will
+ * resolve it. Nothing tested that claim — the endpoint suites assert URL
+ * strings, and this file's other cases never touch `fileId` or the
+ * linked-component fallback. So a URL pairing a spliced VAE file's id with the
+ * HOST version passed every assertion in the repo and 404s in production.
+ *
+ * These cases build the URL with the REAL helper the endpoints use, parse it the
+ * way `/api/download/models/[modelVersionId]` does, and feed it to the REAL
+ * `getFileForModelVersion` over a Prisma stub that enforces the actual `where`
+ * clauses. `not-found` here IS the production 404.
+ */
+describe('serialized downloadUrl → getFileForModelVersion (the pair actually resolves)', () => {
+  let getFileForModelVersion: typeof import('../file.service')['getFileForModelVersion'];
+  let createSerializedFileDownloadUrl: typeof import('~/server/common/model-helpers')['createSerializedFileDownloadUrl'];
+  beforeAll(async () => {
+    ({ getFileForModelVersion } = await import('../file.service'));
+    ({ createSerializedFileDownloadUrl } = await import('~/server/common/model-helpers'));
+  }, 60000);
+
+  const HOST_VERSION_ID = 4242;
+  const LINKED_VAE_VERSION_ID = 9999;
+  const PUBLIC_REQUESTER = { id: 1234, isModerator: false };
+
+  // The whole file universe, with the version each file REALLY belongs to.
+  const OWNED_PRIMARY = {
+    id: 21,
+    modelVersionId: HOST_VERSION_ID,
+    url: 'https://r2/host-primary.safetensors',
+    name: 'host-primary.safetensors',
+    overrideName: null,
+    type: 'Model',
+    visibility: 'Public',
+    metadata: { format: 'SafeTensor', size: 'pruned', fp: 'fp16' },
+    hashes: [{ hash: 'aaaa1111' }],
+  };
+  const OWNED_SECOND = {
+    id: 22,
+    modelVersionId: HOST_VERSION_ID,
+    url: 'https://r2/host-second.ckpt',
+    name: 'host-second.ckpt',
+    overrideName: null,
+    type: 'Model',
+    visibility: 'Public',
+    metadata: { format: 'PickleTensor', size: 'full', fp: 'fp32' },
+    hashes: [{ hash: 'bbbb2222' }],
+  };
+  // Lives on the LINKED version. `getVaeFiles` relabels its `type` to 'VAE'
+  // when splicing it into the host response; in the DB it is still 'Model'.
+  const LINKED_VAE = {
+    id: 91,
+    modelVersionId: LINKED_VAE_VERSION_ID,
+    url: 'https://r2/linked-vae.safetensors',
+    name: 'linked-vae.safetensors',
+    overrideName: null,
+    type: 'Model',
+    visibility: 'Public',
+    metadata: { format: 'SafeTensor', size: 'full', fp: 'fp32' },
+    hashes: [{ hash: 'eeee5555' }],
+  };
+  const UNIVERSE = [OWNED_PRIMARY, OWNED_SECOND, LINKED_VAE];
+
+  const matches = (f: (typeof UNIVERSE)[number], where: Record<string, unknown>) =>
+    (where.id === undefined || f.id === where.id) &&
+    (where.modelVersionId === undefined || f.modelVersionId === where.modelVersionId) &&
+    (where.type === undefined || f.type === where.type) &&
+    (where.visibility === undefined || f.visibility === where.visibility);
+
+  beforeEach(() => {
+    modelVersionFindFirst.mockReset();
+    modelFileFindMany.mockReset();
+    modelFileFindFirst.mockReset();
+    recommendedResourceFindFirst.mockReset();
+    hasEntityAccessMock.mockReset();
+    resolveDownloadUrlMock.mockReset();
+    getPaidAccessMock.mockReset();
+
+    hasEntityAccessMock.mockResolvedValue([{ hasAccess: true, permissions: 0 }]);
+    getPaidAccessMock.mockResolvedValue({});
+    modelVersionFindFirst.mockImplementation(async () =>
+      publishedModelVersion({ id: HOST_VERSION_ID })
+    );
+    resolveDownloadUrlMock.mockImplementation(async (_id: number, url: string) => ({
+      url,
+      urlExpiryDate: new Date(),
+    }));
+
+    // Prisma stubs that ENFORCE the where clause — this is what makes a
+    // mismatched (versionId, fileId) pair come back empty, exactly as in prod.
+    modelFileFindFirst.mockImplementation(async ({ where }: any) => {
+      const found = UNIVERSE.filter((f) => matches(f, where)).sort((a, b) => a.id - b.id);
+      return found[0] ?? null;
+    });
+    modelFileFindMany.mockImplementation(async ({ where }: any) =>
+      UNIVERSE.filter((f) => matches(f, where))
+    );
+    // The host version links the VAE version as a component.
+    recommendedResourceFindFirst.mockImplementation(async ({ where }: any) =>
+      where.sourceId === HOST_VERSION_ID
+        ? {
+            resourceId: LINKED_VAE_VERSION_ID,
+            settings: { isLinkedComponent: true, componentType: 'VAE' },
+          }
+        : null
+    );
+  });
+
+  /** Parse an emitted URL into the route's handler input (schema at
+   * src/pages/api/download/models/[modelVersionId].ts). */
+  function toRouteInput(path: string) {
+    const url = new URL(`https://civitai.com${path}`);
+    const modelVersionId = Number(url.pathname.split('/').pop());
+    const q = url.searchParams;
+    const fileIdParam = q.get('fileId');
+    return {
+      modelVersionId,
+      fileId: fileIdParam ? Number(fileIdParam) : undefined,
+      type: q.get('type') ?? undefined,
+      format: q.get('format') ?? undefined,
+      size: q.get('size') ?? undefined,
+      fp: q.get('fp') ?? undefined,
+      quantType: q.get('quantType') ?? undefined,
+    } as never;
+  }
+
+  it('a pinned URL for a file the version OWNS resolves to exactly that file', async () => {
+    const path = createSerializedFileDownloadUrl({
+      file: OWNED_SECOND,
+      hostVersionId: HOST_VERSION_ID,
+    });
+    // Positive control: this URL really is the pinned shape.
+    expect(path).toBe('/api/download/models/4242?fileId=22');
+
+    const result = (await getFileForModelVersion({
+      ...toRouteInput(path),
+      noAuth: true,
+      // A plain signed-in, non-owner, non-mod requester: `requireAuth` is
+      // satisfied (UNAUTHENTICATED_DOWNLOAD is off in the test env) while the
+      // Public visibility filter still applies, i.e. the public download path.
+      user: PUBLIC_REQUESTER,
+    })) as { status: string; fileId?: number; url?: string };
+    expect(result.status).toBe('success');
+    expect(result.fileId).toBe(22);
+    expect(result.url).toBe(OWNED_SECOND.url);
+  });
+
+  it('the URL emitted for a SPLICED VAE file resolves (it is not pinned to the host version)', async () => {
+    const path = createSerializedFileDownloadUrl({
+      // `type: 'VAE'` is the relabel getVaeFiles applies.
+      file: { ...LINKED_VAE, type: 'VAE' },
+      hostVersionId: HOST_VERSION_ID,
+    });
+    expect(new URL(`https://x.test${path}`).searchParams.get('fileId')).toBeNull();
+
+    const result = (await getFileForModelVersion({
+      ...toRouteInput(path),
+      noAuth: true,
+      // A plain signed-in, non-owner, non-mod requester: `requireAuth` is
+      // satisfied (UNAUTHENTICATED_DOWNLOAD is off in the test env) while the
+      // Public visibility filter still applies, i.e. the public download path.
+      user: PUBLIC_REQUESTER,
+    })) as { status: string; fileId?: number };
+    // Resolved through the linked-component fallback, to the VAE file itself.
+    expect(result.status).toBe('success');
+    expect(result.fileId).toBe(91);
+  });
+
+  it('NEGATIVE CONTROL: the pair the bug emitted (fileId=91 on version 4242) is a 404', async () => {
+    // Built by hand, NOT by the helper — this is the URL the unguarded pin
+    // produced, and it must be observably not-found, or the two tests above
+    // prove nothing about the seam.
+    const result = (await getFileForModelVersion({
+      ...toRouteInput('/api/download/models/4242?fileId=91'),
+      noAuth: true,
+      // A plain signed-in, non-owner, non-mod requester: `requireAuth` is
+      // satisfied (UNAUTHENTICATED_DOWNLOAD is off in the test env) while the
+      // Public visibility filter still applies, i.e. the public download path.
+      user: PUBLIC_REQUESTER,
+    })) as { status: string };
+    expect(result.status).toBe('not-found');
+  });
+
+  it('a pinned URL respects the version boundary in the DB query itself', async () => {
+    await getFileForModelVersion({
+      ...toRouteInput('/api/download/models/4242?fileId=21'),
+      noAuth: true,
+      user: PUBLIC_REQUESTER,
+    });
+    const where = modelFileFindFirst.mock.calls[0][0].where;
+    expect(where).toMatchObject({ id: 21, modelVersionId: 4242 });
   });
 });

--- a/src/server/services/__tests__/model-search-file-shape.test.ts
+++ b/src/server/services/__tests__/model-search-file-shape.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { allBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constants';
+
+/**
+ * `/api/v1/models` (the LIST endpoint) is the SECOND consumer of
+ * `getModelsWithVersions`, which now PRESERVES `modelVersionId` on every file so
+ * the by-id shaper can tell an owned file from one spliced in off a linked VAE
+ * version. This shaper spreads `...file` straight onto the wire body, so it has
+ * to strip that field again or an internal column appears on a public response.
+ *
+ * Nothing else pinned the list endpoint's per-file shape, so a mutation that
+ * removed the strip survived the whole suite. This is the guard for it.
+ *
+ * `createModelFileDownloadUrl` and `getPrimaryFile` are REAL — the emitted URL
+ * is asserted too, because this endpoint does NOT pin `fileId` (it still builds
+ * discriminator URLs) and that difference should be visible, not incidental.
+ */
+
+const { mockGetModelsWithVersions } = vi.hoisted(() => ({
+  mockGetModelsWithVersions: vi.fn(),
+}));
+
+vi.mock('~/server/services/model.service', () => ({
+  getModelsWithVersions: mockGetModelsWithVersions,
+}));
+vi.mock('~/server/meilisearch/client', () => ({
+  searchClient: undefined,
+  withMeili: (_label: string, fn: () => unknown) => fn(),
+  MeiliCallTimeoutError: class extends Error {},
+  isTransientMeiliError: () => false,
+}));
+vi.mock('~/server/services/file.service', () => ({
+  getDownloadFilename: ({ file }: any) => `${file.id}.safetensors`,
+}));
+vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (url: string) => url }));
+
+import { runModelSearch } from '~/server/services/model-search.service';
+
+const HOST_VERSION_ID = 4242;
+const LINKED_VAE_VERSION_ID = 9999;
+
+const FILES = [
+  {
+    id: 11,
+    modelVersionId: HOST_VERSION_ID,
+    type: 'Model',
+    visibility: 'Public',
+    sizeKB: 1111,
+    hashes: [{ type: 'SHA256', hash: 'aaaa1111' }],
+    metadata: { format: 'SafeTensor', size: 'pruned', fp: 'fp16' },
+  },
+  {
+    id: 12,
+    modelVersionId: HOST_VERSION_ID,
+    type: 'Model',
+    visibility: 'Public',
+    sizeKB: 2222,
+    hashes: [{ type: 'SHA256', hash: 'bbbb2222' }],
+    metadata: { format: 'PickleTensor', size: 'full', fp: 'fp32' },
+  },
+  // Spliced off the linked VAE version by getModelsWithVersions.
+  {
+    id: 91,
+    modelVersionId: LINKED_VAE_VERSION_ID,
+    type: 'VAE',
+    visibility: 'Public',
+    sizeKB: 5555,
+    hashes: [{ type: 'SHA256', hash: 'eeee5555' }],
+    metadata: { format: 'SafeTensor', size: 'full', fp: 'fp32' },
+  },
+];
+
+function shapedItem() {
+  return {
+    id: 7,
+    name: 'Model 7',
+    mode: null,
+    tagsOnModels: [],
+    user: { username: 'creator', image: null, profilePicture: null },
+    modelVersions: [
+      {
+        id: HOST_VERSION_ID,
+        name: 'v1',
+        status: 'Published',
+        covered: true,
+        createdAt: new Date(),
+        files: FILES,
+        images: [],
+      },
+    ],
+  };
+}
+
+async function run() {
+  const result = await runModelSearch(
+    { limit: 10 },
+    {
+      browsingLevel: allBrowsingLevelsFlag,
+      nsfwImagePassthrough: true,
+      baseUrlOrigin: 'https://civitai.com',
+    }
+  );
+  return (result.items[0] as any).modelVersions[0].files as any[];
+}
+
+describe('runModelSearch (GET /api/v1/models) — per-file wire shape', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetModelsWithVersions.mockResolvedValue({ items: [shapedItem()], nextCursor: undefined });
+  });
+
+  it('serializes every Public file', async () => {
+    const files = await run();
+    expect(files.map((f) => f.id).sort((a, b) => a - b)).toEqual([11, 12, 91]);
+  });
+
+  it('does NOT leak the internal modelVersionId onto the public list body', async () => {
+    const files = await run();
+    // Positive control: the loop has entries to inspect.
+    expect(files.length).toBeGreaterThan(0);
+    for (const entry of files)
+      expect(
+        Object.prototype.hasOwnProperty.call(entry, 'modelVersionId'),
+        `file ${entry.id} leaked modelVersionId`
+      ).toBe(false);
+  });
+
+  it('still strips url/visibility, as before', async () => {
+    const files = await run();
+    for (const entry of files) {
+      expect(entry.url).toBeUndefined();
+      expect(entry.visibility).toBeUndefined();
+    }
+  });
+
+  it('emits discriminator URLs, not fileId pins (this endpoint was NOT changed)', async () => {
+    const files = await run();
+    for (const entry of files) {
+      const url = new URL(entry.downloadUrl);
+      expect(url.pathname).toBe(`/api/download/models/${HOST_VERSION_ID}`);
+      expect(url.searchParams.get('fileId'), `file ${entry.id}`).toBeNull();
+    }
+  });
+});

--- a/src/server/services/__tests__/vae-files-cross-version.test.ts
+++ b/src/server/services/__tests__/vae-files-cross-version.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+// 🔴 STATIC import, deliberately — see the note in get-models-raw.transient-503.test.ts:
+// `model.service` is a ~4900-line module whose cold transform dominates this
+// file's runtime. Hoisted to module scope that cost lands in Vitest's COLLECTION
+// phase, which no `testTimeout` bounds. `vi.mock` calls below are hoisted above
+// it by Vitest's transform, so the stubs still apply.
+import { getVaeFiles } from '~/server/services/model.service';
+import type * as RedisClient from '~/server/redis/client';
+
+/**
+ * `getVaeFiles` is the PRODUCER of the cross-version files that both public v1
+ * shapers splice into a host version's file list. Everything downstream — the
+ * `fileId` pin decision in `createSerializedFileDownloadUrl`, the download
+ * route's `findFirst({ id, modelVersionId })` — rests on two properties of its
+ * output that no other test pinned:
+ *
+ *   1. each returned file carries the LINKED version's id in `modelVersionId`,
+ *      NOT the host version's (the host id is never even passed in);
+ *   2. `type` is rewritten to 'VAE', so the file passes the shapers' Public
+ *      filter and is serialized exactly like a local file — i.e. it is
+ *      indistinguishable from one EXCEPT by `modelVersionId`.
+ *
+ * Only the Prisma call is stubbed; the selection + relabel are the real code.
+ */
+
+const { modelFileFindMany } = vi.hoisted(() => ({ modelFileFindMany: vi.fn() }));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { modelFile: { findMany: modelFileFindMany } },
+  dbWrite: {},
+}));
+vi.mock('~/server/db/pgDb', () => ({ pgDbRead: {}, pgDbWrite: {}, pgDbReadLong: {} }));
+// Breaks the `event-engine-common` submodule chain that otherwise blocks
+// importing model.service in the unit env; nothing here is reached by getVaeFiles.
+vi.mock('~/server/services/image.service', () => ({
+  getImagesForModelVersion: vi.fn(),
+  getImagesForModelVersionCache: vi.fn(),
+  queueImageSearchIndexUpdate: vi.fn(),
+}));
+vi.mock('~/server/flipt/client', () => ({ isFlipt: vi.fn().mockResolvedValue(false) }));
+vi.mock('~/server/redis/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof RedisClient>();
+  return {
+    ...actual,
+    redis: { packed: { get: async () => null, set: async () => undefined } },
+    sysRedis: {},
+  };
+});
+
+const HOST_VERSION_ID = 4242;
+const LINKED_VAE_VERSION_ID = 9999;
+
+describe('getVaeFiles — returns files owned by the LINKED version, relabelled VAE', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    modelFileFindMany.mockResolvedValue([
+      {
+        id: 91,
+        modelVersionId: LINKED_VAE_VERSION_ID,
+        type: 'Model',
+        visibility: 'Public',
+        sizeKB: 5555,
+        metadata: { format: 'SafeTensor', size: 'full', fp: 'fp32' },
+        hashes: [{ type: 'SHA256', hash: 'eeee5555' }],
+      },
+    ]);
+  });
+
+  it('selects on the LINKED version ids and asks for modelVersionId explicitly', async () => {
+    await getVaeFiles({ vaeIds: [LINKED_VAE_VERSION_ID] });
+    expect(modelFileFindMany).toHaveBeenCalledTimes(1);
+    const args = modelFileFindMany.mock.calls[0][0];
+    expect(args.where.modelVersionId).toEqual({ in: [LINKED_VAE_VERSION_ID] });
+    expect(args.where.type).toBe('Model');
+    // Without this the owning version is unknowable downstream and the shaper
+    // has to fall back to the host version — the bug.
+    expect(args.select.modelVersionId).toBe(true);
+  });
+
+  it('the returned file belongs to the LINKED version, not the host', async () => {
+    const [file] = await getVaeFiles({ vaeIds: [LINKED_VAE_VERSION_ID] });
+    expect(file.modelVersionId).toBe(LINKED_VAE_VERSION_ID);
+    expect(file.modelVersionId).not.toBe(HOST_VERSION_ID);
+    // It keeps its OWN id — this is the id that gets pinned into a URL.
+    expect(file.id).toBe(91);
+  });
+
+  it('rewrites type Model → VAE (which is why it passes the Public file filter)', async () => {
+    const [file] = await getVaeFiles({ vaeIds: [LINKED_VAE_VERSION_ID] });
+    expect(file.type).toBe('VAE');
+    expect(file.visibility).toBe('Public');
+  });
+});

--- a/src/server/services/model-search.service.ts
+++ b/src/server/services/model-search.service.ts
@@ -258,7 +258,13 @@ export async function runModelSearch(
           files: includeDownloadUrl
             ? castedFiles
                 .filter((file) => file.visibility === ModelFileVisibility.Public)
-                .map(({ hashes, ...file }) => ({
+                // `modelVersionId` is stripped, not used: getModelsWithVersions
+                // now preserves it (a spliced VAE file belongs to the LINKED
+                // version, not this one), and the `...file` spread would
+                // otherwise put it on the public wire body. This endpoint does
+                // not pin `fileId` at all, so it needs the value only to keep
+                // it out of the response.
+                .map(({ hashes, modelVersionId: _ownerVersionId, ...file }) => ({
                   ...file,
                   name: safeDecodeURIComponent(
                     getDownloadFilename({ model, modelVersion: version, file })

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -22,6 +22,7 @@ import {
   isBaseModelGenerationSupported,
 } from '~/shared/constants/basemodel.constants';
 import { ModelSort, SearchIndexUpdateQueueAction } from '~/server/common/enums';
+import { toApiModelFile } from '~/server/common/model-helpers';
 import type { Context } from '~/server/createContext';
 import { dbRead, dbWrite } from '~/server/db/client';
 import {
@@ -3872,20 +3873,18 @@ export async function getModelsWithVersions({
 
               return {
                 ...version,
-                files: files.map(({ metadata: metadataRaw, modelVersionId, ...file }) => {
-                  const metadata = metadataRaw as FileMetadata | undefined;
-
-                  return {
-                    ...file,
-                    metadata: {
-                      format: metadata?.format,
-                      size: metadata?.size,
-                      fp: metadata?.fp,
-                      quantType: metadata?.quantType,
-                      isRequired: metadata?.isRequired,
-                    },
-                  };
-                }),
+                // `modelVersionId` is deliberately PRESERVED on each file. The
+                // `files.push(...vaeFile)` above splices in files that live on
+                // the LINKED VAE version, so "which version owns this file" is
+                // not derivable from the enclosing `version.id` — and the v1
+                // response shapers need it to decide whether a per-file
+                // `downloadUrl` may be pinned with `fileId` (see
+                // createSerializedFileDownloadUrl). Dropping it here is what let
+                // a VAE file's id be paired with the host version, producing a
+                // 404 on a previously-working URL. Both public consumers
+                // (api/v1/models/[id], model-search.service) strip it from the
+                // wire body, so the public shape is unchanged.
+                files: files.map(toApiModelFile),
                 earlyAccessDeadline,
                 paidAccess,
                 stats,

--- a/src/tests/api/v1/download-url-seam.helper.ts
+++ b/src/tests/api/v1/download-url-seam.helper.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared assertion for the URL → download-route SEAM.
+ *
+ * A per-file `downloadUrl` is a claim that `/api/download/models/<versionId>`
+ * plus `?fileId=<n>` will actually resolve. The download route resolves a
+ * pinned URL with `dbRead.modelFile.findFirst({ where: { id: fileId,
+ * modelVersionId } })` (src/server/services/file.service.ts) — so a pair whose
+ * two halves disagree is a hard 404, and the URL string alone cannot show it.
+ *
+ * `assertDownloadUrlsResolve` replays that exact lookup against a universe of
+ * files (local + spliced), and is deliberately NOT satisfied by "the URL looks
+ * right": it fails on a pair that would 404, and it fails on an empty run.
+ */
+
+export type SeamFile = { id: number; modelVersionId: number };
+
+export function assertDownloadUrlsResolve({
+  urls,
+  universe,
+  expect,
+}: {
+  /** every per-file downloadUrl the response emitted */
+  urls: string[];
+  /** every file that exists, with the version it really belongs to */
+  universe: SeamFile[];
+  expect: (
+    actual: unknown,
+    message?: string
+  ) => {
+    toBe(expected: unknown): void;
+    toBeGreaterThan(expected: number): void;
+  };
+}) {
+  // Positive control: an empty list would pass every loop below vacuously.
+  expect(urls.length, 'no downloadUrls to check').toBeGreaterThan(0);
+
+  for (const raw of urls) {
+    const url = new URL(raw);
+    const versionId = Number(url.pathname.split('/').pop());
+    const fileIdParam = url.searchParams.get('fileId');
+    if (fileIdParam === null) continue; // unpinned — the route re-resolves it
+
+    const fileId = Number(fileIdParam);
+    // The download route's `fileId` branch, replayed literally.
+    const resolved = universe.find((f) => f.id === fileId && f.modelVersionId === versionId);
+    expect(
+      resolved === undefined ? `404: no file ${fileId} on version ${versionId}` : 'resolved',
+      `${raw} — the (versionId, fileId) pair this URL encodes does not exist`
+    ).toBe('resolved');
+  }
+}

--- a/src/tests/api/v1/model-versions/id-file-download-url.test.ts
+++ b/src/tests/api/v1/model-versions/id-file-download-url.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Regression coverage for GET /api/v1/model-versions/[id] — per-file
+ * `downloadUrl` must resolve to the SAME file whose `hashes` / `sizeKB` /
+ * `name` were serialized next to it.
+ *
+ * Same defect and same fix as the sibling `/api/v1/models/[id]` suite: the
+ * response built each file's URL with
+ * `createModelFileDownloadUrl({ versionId, type, meta, primary: primaryFile.id === file.id })`,
+ * which for the elected primary emits a BARE `/api/download/models/<versionId>`
+ * that the download route re-resolves on its own (requesting user's
+ * filePreferences + its own scoring). On a multi-file version the advertised
+ * SHA256 and the file actually served can then disagree.
+ *
+ * Exercised through the exported `prepareModelVersionResponse`, which is the
+ * whole body-shaping path the handler delegates to (the handler above it is one
+ * raw SQL read). `createModelFileDownloadUrl` and `getPrimaryFile` are REAL —
+ * the URL string and the primary election are the contract under test.
+ */
+
+const { mockGetVaeFiles, mockGetImages, mockGetPaidAccess, mockFindUnique } = vi.hoisted(() => ({
+  mockGetVaeFiles: vi.fn(),
+  mockGetImages: vi.fn(),
+  mockGetPaidAccess: vi.fn(),
+  mockFindUnique: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => {
+  const stub = {
+    modelVersion: { findUnique: mockFindUnique },
+    $queryRaw: vi.fn(),
+  };
+  // The page module's transitive graph reaches for several named exports of this
+  // client; a partial mock makes Vitest throw on the first one it can't find.
+  return { dbRead: stub, dbWrite: stub, dbKV: stub, dbReadLong: stub, dbReadReplica: stub };
+});
+vi.mock('~/server/services/model.service', () => ({ getVaeFiles: mockGetVaeFiles }));
+vi.mock('~/server/services/image.service', () => ({
+  getImagesForModelVersion: mockGetImages,
+}));
+vi.mock('~/server/services/paid-access.service', () => ({
+  getPaidAccess: mockGetPaidAccess,
+  toPublicPaidAccessDto: () => null,
+}));
+vi.mock('~/server/services/creator-program.service', () => ({
+  hasValidCreatorMembershipCached: async () => false,
+}));
+vi.mock('~/server/services/file.service', () => ({
+  getDownloadFilename: ({ file }: any) => `${file.id}.safetensors`,
+}));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn() }));
+vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (url: string) => url }));
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  MixedAuthEndpoint: (handler: any) => handler,
+}));
+vi.mock('~/server/utils/region-blocking', () => ({
+  getRegion: () => 'US',
+  isRegionRestricted: () => false,
+}));
+
+/**
+ * Four files on ONE version, PAIRWISE DISTINCT on every axis the implementation
+ * could key off (id, type, format, size, fp, sizeKB, hash) so a mutant binding
+ * the wrong file cannot coincidentally emit the right URL.
+ *
+ * File 21 is the one real `getPrimaryFile` elects (type 'Model' +
+ * SafeTensor/pruned/fp16 = the default preference) — the exact file the defect
+ * emitted a bare, re-resolvable URL for. File 24 is non-Public.
+ */
+const FILES = [
+  {
+    id: 21,
+    type: 'Model',
+    visibility: 'Public',
+    sizeKB: 1111,
+    modelVersionId: 4242,
+    url: 's3://a',
+    name: 'a.safetensors',
+    hashes: [{ type: 'SHA256', hash: 'aaaa1111' }],
+    metadata: { format: 'SafeTensor', size: 'pruned', fp: 'fp16' },
+  },
+  {
+    id: 22,
+    type: 'Model',
+    visibility: 'Public',
+    sizeKB: 2222,
+    modelVersionId: 4242,
+    url: 's3://b',
+    name: 'b.ckpt',
+    hashes: [{ type: 'SHA256', hash: 'bbbb2222' }],
+    metadata: { format: 'PickleTensor', size: 'full', fp: 'fp32' },
+  },
+  {
+    id: 23,
+    type: 'Config',
+    visibility: 'Public',
+    sizeKB: 3333,
+    modelVersionId: 4242,
+    url: 's3://c',
+    name: 'c.yaml',
+    hashes: [{ type: 'SHA256', hash: 'cccc3333' }],
+    metadata: { format: 'Other' },
+  },
+  {
+    id: 24,
+    type: 'Model',
+    visibility: 'Private',
+    sizeKB: 4444,
+    modelVersionId: 4242,
+    url: 's3://d',
+    name: 'd.gguf',
+    hashes: [{ type: 'SHA256', hash: 'dddd4444' }],
+    metadata: { format: 'GGUF', quantType: 'Q8_0' },
+  },
+];
+
+const BY_HASH = new Map(FILES.map((f) => [f.hashes[0].hash, f]));
+
+function modelVersion() {
+  return {
+    id: 4242,
+    modelId: 77,
+    name: 'v1',
+    baseModel: 'SD 1.5',
+    status: 'Published',
+    nsfwLevel: 1,
+    licensingFee: null,
+    // getVaeFiles pushes into this array, so hand over a fresh copy per call.
+    files: FILES.map((f) => ({ ...f })),
+    metrics: [{ downloadCount: 5, thumbsUpCount: 2 }],
+    model: { name: 'Model 77', type: 'Checkpoint', nsfw: false, poi: false, mode: null },
+  } as any;
+}
+
+async function prepare() {
+  const mod = await import('~/pages/api/v1/model-versions/[id]');
+  return mod.prepareModelVersionResponse(modelVersion(), new URL('https://civitai.com'), [], null);
+}
+
+describe('GET /api/v1/model-versions/[id] — per-file downloadUrl is pinned to that file', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetVaeFiles.mockResolvedValue([]);
+    mockGetImages.mockResolvedValue([]);
+    mockGetPaidAccess.mockResolvedValue({});
+    mockFindUnique.mockResolvedValue(null);
+  });
+
+  it('serializes only the Public files', async () => {
+    const body = await prepare();
+    expect(body!.files.map((f: any) => f.id).sort((a: number, b: number) => a - b)).toEqual([
+      21, 22, 23,
+    ]);
+  });
+
+  it('every file downloadUrl carries the fileId of the file serialized alongside it', async () => {
+    const body = await prepare();
+    const files = body!.files as any[];
+    // Positive control: the loop below must actually run over entries.
+    expect(files).toHaveLength(3);
+
+    for (const entry of files) {
+      const source = BY_HASH.get(entry.hashes.SHA256);
+      expect(source, `unknown SHA256 ${entry.hashes.SHA256}`).toBeDefined();
+      expect(entry.sizeKB).toBe(source!.sizeKB);
+
+      const url = new URL(entry.downloadUrl);
+      expect(url.pathname).toBe('/api/download/models/4242');
+      // THE CONTRACT: the URL resolves to the file whose hash/size were advertised.
+      expect(
+        url.searchParams.get('fileId'),
+        `file ${source!.id} (sha ${source!.hashes[0].hash}) url=${entry.downloadUrl}`
+      ).toBe(String(source!.id));
+    }
+  });
+
+  it('the primary file gets a fileId-pinned URL too, not a bare re-resolvable one', async () => {
+    const body = await prepare();
+    const files = body!.files as any[];
+    const primaryEntry = files.find((f) => f.primary === true);
+    expect(primaryEntry).toBeDefined();
+    expect(primaryEntry.id).toBe(21);
+    expect(primaryEntry.hashes.SHA256).toBe('aaaa1111');
+    expect(primaryEntry.downloadUrl).toBe('https://civitai.com/api/download/models/4242?fileId=21');
+  });
+
+  it('does not leak type/format/size/fp discriminators into the pinned URL', async () => {
+    const body = await prepare();
+    for (const entry of body!.files as any[]) {
+      const url = new URL(entry.downloadUrl);
+      expect([...url.searchParams.keys()]).toEqual(['fileId']);
+    }
+  });
+
+  it('the version-level downloadUrl remains the unpinned default download', async () => {
+    const body = await prepare();
+    expect(body!.downloadUrl).toBe('https://civitai.com/api/download/models/4242');
+  });
+});

--- a/src/tests/api/v1/model-versions/id-file-download-url.test.ts
+++ b/src/tests/api/v1/model-versions/id-file-download-url.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { assertDownloadUrlsResolve } from '~/tests/api/v1/download-url-seam.helper';
 
 /**
  * Regression coverage for GET /api/v1/model-versions/[id] — per-file
@@ -19,16 +20,20 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
  * the URL string and the primary election are the contract under test.
  */
 
-const { mockGetVaeFiles, mockGetImages, mockGetPaidAccess, mockFindUnique } = vi.hoisted(() => ({
-  mockGetVaeFiles: vi.fn(),
-  mockGetImages: vi.fn(),
-  mockGetPaidAccess: vi.fn(),
-  mockFindUnique: vi.fn(),
-}));
+const { mockGetVaeFiles, mockGetImages, mockGetPaidAccess, mockFindUnique, mockFileFindFirst } =
+  vi.hoisted(() => ({
+    mockGetVaeFiles: vi.fn(),
+    mockGetImages: vi.fn(),
+    mockGetPaidAccess: vi.fn(),
+    mockFindUnique: vi.fn(),
+    mockFileFindFirst: vi.fn(),
+  }));
 
 vi.mock('~/server/db/client', () => {
   const stub = {
     modelVersion: { findUnique: mockFindUnique },
+    // by-hash/[hash] resolves the version through modelFile.findFirst.
+    modelFile: { findFirst: mockFileFindFirst },
     $queryRaw: vi.fn(),
   };
   // The page module's transitive graph reaches for several named exports of this
@@ -53,6 +58,8 @@ vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn() }));
 vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (url: string) => url }));
 vi.mock('~/server/utils/endpoint-helpers', () => ({
   MixedAuthEndpoint: (handler: any) => handler,
+  // by-hash/[hash] is wrapped in PublicEndpoint(handler, ['GET'], {maxAge}).
+  PublicEndpoint: (handler: any) => handler,
 }));
 vi.mock('~/server/utils/region-blocking', () => ({
   getRegion: () => 'US',
@@ -133,9 +140,34 @@ function modelVersion() {
   } as any;
 }
 
-async function prepare() {
+/**
+ * A file that lives on the LINKED VAE version, shaped exactly as `getVaeFiles`
+ * emits it: selected off version 9999 (`modelVersionId: 9999`, its own id), with
+ * `type` rewritten from 'Model' to 'VAE' and a real Public `visibility`, so it
+ * passes the Public filter and is serialized like any other file. Distinct on
+ * every axis from the four host files above.
+ */
+const LINKED_VAE_VERSION_ID = 9999;
+const VAE_FILE = {
+  id: 91,
+  type: 'VAE',
+  visibility: 'Public',
+  sizeKB: 5555,
+  modelVersionId: LINKED_VAE_VERSION_ID,
+  url: 's3://vae',
+  name: 'vae.safetensors',
+  hashes: [{ type: 'SHA256', hash: 'eeee5555' }],
+  metadata: { format: 'SafeTensor', size: 'full', fp: 'fp32' },
+};
+
+async function prepare(vaeId?: number) {
   const mod = await import('~/pages/api/v1/model-versions/[id]');
-  return mod.prepareModelVersionResponse(modelVersion(), new URL('https://civitai.com'), [], null);
+  return mod.prepareModelVersionResponse(
+    { ...modelVersion(), vaeId } as any,
+    new URL('https://civitai.com'),
+    [],
+    null
+  );
 }
 
 describe('GET /api/v1/model-versions/[id] — per-file downloadUrl is pinned to that file', () => {
@@ -196,5 +228,139 @@ describe('GET /api/v1/model-versions/[id] — per-file downloadUrl is pinned to 
   it('the version-level downloadUrl remains the unpinned default download', async () => {
     const body = await prepare();
     expect(body!.downloadUrl).toBe('https://civitai.com/api/download/models/4242');
+  });
+
+  /**
+   * The CROSS-VERSION case the pin got wrong.
+   *
+   * `prepareModelVersionResponse` itself does `files.push(...vae)` — the real
+   * splice, exercised here for real; only the DB read behind `getVaeFiles` is
+   * mocked. The spliced file belongs to version 9999, so pinning its id to the
+   * host version 4242 emits `?fileId=91` on `/api/download/models/4242`, a pair
+   * `findFirst({ id: 91, modelVersionId: 4242 })` resolves to null → 404 on a
+   * URL that resolved fine before pinning existed.
+   */
+  describe('with a VAE file spliced in from a LINKED version', () => {
+    beforeEach(() => {
+      mockGetVaeFiles.mockResolvedValue([{ ...VAE_FILE }]);
+    });
+
+    it('serializes the spliced VAE file alongside the host version files', async () => {
+      const body = await prepare(LINKED_VAE_VERSION_ID);
+      expect(mockGetVaeFiles).toHaveBeenCalledWith({ vaeIds: [LINKED_VAE_VERSION_ID] });
+      expect(body!.files.map((f: any) => f.id).sort((a: number, b: number) => a - b)).toEqual([
+        21, 22, 23, 91,
+      ]);
+    });
+
+    it('does NOT pin the foreign file id to the host version', async () => {
+      const body = await prepare(LINKED_VAE_VERSION_ID);
+      const vaeEntry = (body!.files as any[]).find((f) => f.id === 91);
+      expect(vaeEntry, 'the spliced VAE file was not serialized').toBeDefined();
+      const url = new URL(vaeEntry.downloadUrl);
+      expect(url.pathname).toBe('/api/download/models/4242');
+      expect(
+        url.searchParams.get('fileId'),
+        `fileId=91 on version 4242 is the 404 pair — url=${vaeEntry.downloadUrl}`
+      ).toBeNull();
+      // It keeps the discriminator URL the download route's linked-component
+      // fallback resolves (`isComponentFileType('VAE')`).
+      expect(url.searchParams.get('type')).toBe('VAE');
+    });
+
+    it('still pins every file the host version DOES own', async () => {
+      const body = await prepare(LINKED_VAE_VERSION_ID);
+      const owned = (body!.files as any[]).filter((f) => f.id !== 91);
+      expect(owned).toHaveLength(3);
+      for (const entry of owned)
+        expect(
+          new URL(entry.downloadUrl).searchParams.get('fileId'),
+          `owned file ${entry.id} lost its pin`
+        ).toBe(String(entry.id));
+    });
+
+    it('every emitted (versionId, fileId) pair resolves at the download route', async () => {
+      const body = await prepare(LINKED_VAE_VERSION_ID);
+      assertDownloadUrlsResolve({
+        urls: (body!.files as any[]).map((f) => f.downloadUrl),
+        universe: [
+          ...FILES.map((f) => ({ id: f.id, modelVersionId: f.modelVersionId })),
+          { id: VAE_FILE.id, modelVersionId: VAE_FILE.modelVersionId },
+        ],
+        expect: expect as never,
+      });
+    });
+  });
+});
+
+/**
+ * BLAST RADIUS: `prepareModelVersionResponse` / `resModelVersionDetails` also
+ * shape the bodies of the by-hash endpoints — the ones SD-WebUI helper
+ * extensions call. They therefore inherit the `fileId` pin, and nothing covered
+ * them.
+ *
+ * They do NOT inherit the cross-version splice: both select the version through
+ * `getModelVersionApiSelect`, which carries no `vaeId`, so `prepareModelVersionResponse`
+ * takes the `!!vaeId ? … : []` false branch and never calls `getVaeFiles`. That
+ * is asserted below rather than assumed — it is the difference between "these
+ * endpoints were also 404ing" and "these endpoints changed shape only".
+ */
+describe('GET /api/v1/model-versions/by-hash/[hash] — same shaper, same pin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetVaeFiles.mockResolvedValue([]);
+    mockGetImages.mockResolvedValue([]);
+    mockGetPaidAccess.mockResolvedValue({});
+    mockFindUnique.mockResolvedValue(null);
+    mockFileFindFirst.mockResolvedValue({ modelVersion: modelVersion() });
+  });
+
+  async function invokeByHash() {
+    const mod = await import('~/pages/api/v1/model-versions/by-hash/[hash]');
+    const handler = mod.default as (req: any, res: any) => Promise<void>;
+    const res: any = {
+      setHeader() {
+        return this;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(b: unknown) {
+        this.body = b;
+        return this;
+      },
+    };
+    await handler(
+      { method: 'GET', query: { hash: 'a'.repeat(64) }, headers: { host: 'civitai.com' } },
+      res
+    );
+    return res;
+  }
+
+  it('pins every serialized file to its own id', async () => {
+    const res = await invokeByHash();
+    expect(res.statusCode).toBe(200);
+    const files = res.body.files as any[];
+    expect(files).toHaveLength(3);
+    for (const entry of files) {
+      const url = new URL(entry.downloadUrl);
+      expect(url.searchParams.get('fileId'), `file ${entry.id}`).toBe(String(entry.id));
+      expect(url.pathname).toBe('/api/download/models/4242');
+    }
+  });
+
+  it('never splices a cross-version file (no vaeId in the by-hash select)', async () => {
+    await invokeByHash();
+    expect(mockGetVaeFiles).not.toHaveBeenCalled();
+  });
+
+  it('every emitted (versionId, fileId) pair resolves at the download route', async () => {
+    const res = await invokeByHash();
+    assertDownloadUrlsResolve({
+      urls: (res.body.files as any[]).map((f) => f.downloadUrl),
+      universe: FILES.map((f) => ({ id: f.id, modelVersionId: f.modelVersionId })),
+      expect: expect as never,
+    });
   });
 });

--- a/src/tests/api/v1/models/id-file-download-url.test.ts
+++ b/src/tests/api/v1/models/id-file-download-url.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { assertDownloadUrlsResolve } from '~/tests/api/v1/download-url-seam.helper';
 
 /**
  * Regression coverage for GET /api/v1/models/[id] — per-file `downloadUrl`
@@ -85,6 +86,7 @@ vi.mock('~/server/utils/url-helpers', () => ({ getBaseUrl: () => 'https://civita
 const FILES = [
   {
     id: 11,
+    modelVersionId: 4242,
     type: 'Model',
     visibility: 'Public',
     sizeKB: 1111,
@@ -93,6 +95,7 @@ const FILES = [
   },
   {
     id: 12,
+    modelVersionId: 4242,
     type: 'Model',
     visibility: 'Public',
     sizeKB: 2222,
@@ -101,6 +104,7 @@ const FILES = [
   },
   {
     id: 13,
+    modelVersionId: 4242,
     type: 'Config',
     visibility: 'Public',
     sizeKB: 3333,
@@ -109,6 +113,7 @@ const FILES = [
   },
   {
     id: 14,
+    modelVersionId: 4242,
     type: 'Model',
     visibility: 'Private',
     sizeKB: 4444,
@@ -117,12 +122,36 @@ const FILES = [
   },
 ];
 
+/**
+ * A file spliced in from the LINKED VAE version. `getModelsWithVersions` does
+ * `files.push(...vaeFile)` on the HOST version's array, where `vaeFile` came
+ * from `getVaeFiles` — which selects `type: 'Model'` rows on the LINKED version,
+ * rewrites `type` to 'VAE', and keeps each row's own `id` AND `modelVersionId`
+ * (that select is pinned by
+ * src/server/services/__tests__/vae-files-cross-version.test.ts, so this shape
+ * is derived from the real producer, not invented here).
+ *
+ * So `version.files` is NOT "the files of version 4242": entry 91 belongs to
+ * 9999. Pinning its id to 4242 emits a pair the download route resolves as
+ * `findFirst({ id: 91, modelVersionId: 4242 })` → null → 404.
+ */
+const LINKED_VAE_VERSION_ID = 9999;
+const VAE_FILE = {
+  id: 91,
+  modelVersionId: LINKED_VAE_VERSION_ID,
+  type: 'VAE',
+  visibility: 'Public',
+  sizeKB: 5555,
+  hashes: [{ type: 'SHA256', hash: 'eeee5555' }],
+  metadata: { format: 'SafeTensor', size: 'full', fp: 'fp32' },
+};
+
 // hash → the fixture file that hash belongs to. The assertion walks the RESPONSE
 // and uses the advertised hash to recover which file the response claims each
 // entry is, then checks the URL points at THAT file.
 const BY_HASH = new Map(FILES.map((f) => [f.hashes[0].hash, f]));
 
-function modelItem(id: number) {
+function modelItem(id: number, { withVae = false }: { withVae?: boolean } = {}) {
   return {
     id,
     name: `Model ${id}`,
@@ -134,7 +163,8 @@ function modelItem(id: number) {
         id: 4242,
         name: 'v1',
         status: 'Published',
-        files: FILES,
+        // The literal splice getModelsWithVersions performs.
+        files: withVae ? [...FILES, { ...VAE_FILE }] : FILES,
         images: [],
       },
     ],
@@ -270,6 +300,73 @@ describe('GET /api/v1/models/[id] — per-file downloadUrl is pinned to that fil
     expect(res.body.modelVersions[0].downloadUrl).toBe(
       'https://civitai.com/api/download/models/4242'
     );
+  });
+
+  it('does not leak the internal modelVersionId onto the wire body', async () => {
+    // getModelsWithVersions now PRESERVES `modelVersionId` on each file so the
+    // shaper can tell owned files from spliced ones; the endpoint must strip it
+    // again or the public response shape changes.
+    const res = await invoke('7');
+    for (const entry of res.body.modelVersions[0].files)
+      expect(Object.prototype.hasOwnProperty.call(entry, 'modelVersionId')).toBe(false);
+  });
+
+  /**
+   * The CROSS-VERSION case the pin got wrong: a VAE file belonging to version
+   * 9999 sitting in version 4242's file list.
+   */
+  describe('with a VAE file spliced in from a LINKED version', () => {
+    beforeEach(() => {
+      mockGetModelsWithVersions.mockImplementation(async ({ input }: any) => ({
+        items: [modelItem(input.ids[0], { withVae: true })],
+      }));
+    });
+
+    it('serializes the spliced VAE file alongside the host version files', async () => {
+      const res = await invoke('7');
+      const files = res.body.modelVersions[0].files;
+      expect(files.map((f: any) => f.id).sort((a: number, b: number) => a - b)).toEqual([
+        11, 12, 13, 91,
+      ]);
+    });
+
+    it('does NOT pin the foreign file id to the host version', async () => {
+      const res = await invoke('7');
+      const vaeEntry = res.body.modelVersions[0].files.find((f: any) => f.id === 91);
+      expect(vaeEntry, 'the spliced VAE file was not serialized').toBeDefined();
+      const url = new URL(vaeEntry.downloadUrl);
+      expect(url.pathname).toBe('/api/download/models/4242');
+      expect(
+        url.searchParams.get('fileId'),
+        `fileId=91 on version 4242 is the 404 pair — url=${vaeEntry.downloadUrl}`
+      ).toBeNull();
+      // Keeps the discriminator URL the download route's linked-component
+      // fallback resolves (`isComponentFileType('VAE')`).
+      expect(url.searchParams.get('type')).toBe('VAE');
+    });
+
+    it('still pins every file the host version DOES own', async () => {
+      const res = await invoke('7');
+      const owned = res.body.modelVersions[0].files.filter((f: any) => f.id !== 91);
+      expect(owned).toHaveLength(3);
+      for (const entry of owned)
+        expect(
+          new URL(entry.downloadUrl).searchParams.get('fileId'),
+          `owned file ${entry.id} lost its pin`
+        ).toBe(String(entry.id));
+    });
+
+    it('every emitted (versionId, fileId) pair resolves at the download route', async () => {
+      const res = await invoke('7');
+      assertDownloadUrlsResolve({
+        urls: res.body.modelVersions[0].files.map((f: any) => f.downloadUrl),
+        universe: [
+          ...FILES.map((f) => ({ id: f.id, modelVersionId: f.modelVersionId })),
+          { id: VAE_FILE.id, modelVersionId: VAE_FILE.modelVersionId },
+        ],
+        expect: expect as never,
+      });
+    });
   });
 });
 

--- a/src/tests/api/v1/models/id-file-download-url.test.ts
+++ b/src/tests/api/v1/models/id-file-download-url.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+/**
+ * Regression coverage for GET /api/v1/models/[id] — per-file `downloadUrl`
+ * must resolve to the SAME file whose `hashes` / `sizeKB` / `name` were
+ * serialized next to it.
+ *
+ * The defect: the handler built each file's URL with
+ * `createModelFileDownloadUrl({ versionId, type, meta, primary: primaryFile.id === file.id })`.
+ * For the file that happened to be primary that emits a BARE
+ * `/api/download/models/<versionId>` with no query string at all, which the
+ * download route then re-resolves independently (requesting user's
+ * filePreferences + its own scoring). On a multi-file version that can land on
+ * a DIFFERENT file than the one whose SHA256 the response advertised — an API
+ * contract violation for any consumer that verifies the hash.
+ *
+ * The fix pins each URL to its own file: `{ versionId, fileId: file.id }`.
+ *
+ * `createModelFileDownloadUrl` is deliberately NOT mocked here (the sibling
+ * origin-cache suite stubs it to a constant) — the URL string it produces IS
+ * the contract under test. `getPrimaryFile` is also real, so the primary
+ * election is the production one.
+ */
+
+const { mockGetModelsWithVersions } = vi.hoisted(() => ({
+  mockGetModelsWithVersions: vi.fn(),
+}));
+
+vi.mock('~/server/services/model.service', () => ({
+  getModelsWithVersions: mockGetModelsWithVersions,
+}));
+
+vi.mock('~/server/services/model-version.service', () => ({
+  publicModelResponseKey: (id: number, browsingLevel: number) =>
+    `packed:caches:public-model-response:${id}:${browsingLevel}`,
+}));
+
+// Origin cache is disabled for this suite (IS_DATAPACKET false below), so these
+// are never exercised; stubbed only to keep the redis graph out of the suite.
+vi.mock('~/server/utils/cache-helpers', () => ({ fetchThroughCache: vi.fn() }));
+vi.mock('~/server/redis/client', () => ({
+  redis: { packed: { get: vi.fn(), set: vi.fn() }, del: vi.fn() },
+  REDIS_KEYS: { CACHES: { PUBLIC_MODEL_RESPONSE: 'packed:caches:public-model-response' } },
+}));
+
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  withBlockScope: (handler: any) => (req: any, res: any) => handler(req, res),
+}));
+
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  PublicEndpoint: (handler: any) => (req: any, res: any) => handler(req, res),
+  handleEndpointError: (res: any, e: any) => res.status(500).json({ error: String(e) }),
+}));
+
+vi.mock('~/server/utils/region-blocking', () => ({
+  getRegion: () => 'US',
+  isRegionRestricted: () => false,
+}));
+
+// IS_DATAPACKET false ⇒ PUBLIC_MODEL_RESPONSE_TTL = 0 ⇒ every request builds
+// directly (no cache), which is what we want to observe.
+vi.mock('~/env/server', () => ({
+  env: { IS_DATAPACKET: false, LOGGING: '', IS_BUILD: true },
+}));
+
+vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (url: string) => url }));
+// The serialized `name` is not the subject here; a per-file deterministic name
+// keeps the fixture readable while staying distinct per file.
+vi.mock('~/server/services/file.service', () => ({
+  getDownloadFilename: ({ file }: any) => `${file.id}.safetensors`,
+}));
+vi.mock('~/server/utils/url-helpers', () => ({ getBaseUrl: () => 'https://civitai.com' }));
+
+/**
+ * Four files on ONE version, values PAIRWISE DISTINCT on every axis the
+ * implementation could key off (id, type, format, size, fp, sizeKB, hash) so a
+ * mutant that binds the wrong file cannot coincidentally produce the right URL.
+ *
+ * File 11 is deliberately the one `getPrimaryFile` elects (type 'Model' +
+ * SafeTensor/pruned/fp16 = the default preference, highest score) — that is the
+ * exact file the old `primary: true` branch emitted a bare, re-resolvable URL for.
+ * File 14 is non-Public and must not be serialized at all.
+ */
+const FILES = [
+  {
+    id: 11,
+    type: 'Model',
+    visibility: 'Public',
+    sizeKB: 1111,
+    hashes: [{ type: 'SHA256', hash: 'aaaa1111' }],
+    metadata: { format: 'SafeTensor', size: 'pruned', fp: 'fp16' },
+  },
+  {
+    id: 12,
+    type: 'Model',
+    visibility: 'Public',
+    sizeKB: 2222,
+    hashes: [{ type: 'SHA256', hash: 'bbbb2222' }],
+    metadata: { format: 'PickleTensor', size: 'full', fp: 'fp32' },
+  },
+  {
+    id: 13,
+    type: 'Config',
+    visibility: 'Public',
+    sizeKB: 3333,
+    hashes: [{ type: 'SHA256', hash: 'cccc3333' }],
+    metadata: { format: 'Other' },
+  },
+  {
+    id: 14,
+    type: 'Model',
+    visibility: 'Private',
+    sizeKB: 4444,
+    hashes: [{ type: 'SHA256', hash: 'dddd4444' }],
+    metadata: { format: 'GGUF', quantType: 'Q8_0' },
+  },
+];
+
+// hash → the fixture file that hash belongs to. The assertion walks the RESPONSE
+// and uses the advertised hash to recover which file the response claims each
+// entry is, then checks the URL points at THAT file.
+const BY_HASH = new Map(FILES.map((f) => [f.hashes[0].hash, f]));
+
+function modelItem(id: number) {
+  return {
+    id,
+    name: `Model ${id}`,
+    mode: null,
+    tagsOnModels: [],
+    user: { username: 'creator', image: null, profilePicture: null },
+    modelVersions: [
+      {
+        id: 4242,
+        name: 'v1',
+        status: 'Published',
+        files: FILES,
+        images: [],
+      },
+    ],
+  };
+}
+
+function fakeRes() {
+  const res: any = {
+    headers: {},
+    setHeader(k: string, v: unknown) {
+      this.headers[k] = v;
+      return this;
+    },
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(b: unknown) {
+      this.body = b;
+      return this;
+    },
+  };
+  return res as NextApiResponse & { statusCode?: number; body?: any };
+}
+
+async function invoke(id: string) {
+  const mod = await import('~/pages/api/v1/models/[id]');
+  const handler = mod.default as (req: NextApiRequest, res: NextApiResponse) => Promise<void>;
+  const req = {
+    method: 'GET',
+    query: { id },
+    headers: { host: 'civitai.com' },
+    url: `/api/v1/models/${id}`,
+  } as unknown as NextApiRequest;
+  const res = fakeRes();
+  await handler(req, res);
+  return res;
+}
+
+describe('GET /api/v1/models/[id] — per-file downloadUrl is pinned to that file', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetModelsWithVersions.mockImplementation(async ({ input }: any) => ({
+      items: [modelItem(input.ids[0])],
+    }));
+  });
+
+  it('serializes only the Public files', async () => {
+    const res = await invoke('7');
+    expect(res.statusCode).toBe(200);
+    const files = res.body.modelVersions[0].files;
+    expect(files.map((f: any) => f.id).sort((a: number, b: number) => a - b)).toEqual([11, 12, 13]);
+  });
+
+  it('every file downloadUrl carries the fileId of the file serialized alongside it', async () => {
+    const res = await invoke('7');
+    expect(res.statusCode).toBe(200);
+    const files = res.body.modelVersions[0].files;
+    // Positive control: the assertion loop below must actually run over entries.
+    expect(files).toHaveLength(3);
+
+    for (const entry of files) {
+      const source = BY_HASH.get(entry.hashes.SHA256);
+      // The advertised hash must belong to a real fixture file (guards against a
+      // mutant that shuffles hashes rather than URLs).
+      expect(source, `unknown SHA256 ${entry.hashes.SHA256}`).toBeDefined();
+      // The metadata really is this file's metadata (sizeKB is pairwise distinct).
+      expect(entry.sizeKB).toBe(source!.sizeKB);
+
+      const url = new URL(entry.downloadUrl);
+      expect(url.pathname).toBe('/api/download/models/4242');
+      // THE CONTRACT: the URL resolves to the file whose hash/size were advertised.
+      expect(
+        url.searchParams.get('fileId'),
+        `file ${source!.id} (sha ${source!.hashes[0].hash}) url=${entry.downloadUrl}`
+      ).toBe(String(source!.id));
+    }
+  });
+
+  it('the primary file gets a fileId-pinned URL too, not a bare re-resolvable one', async () => {
+    const res = await invoke('7');
+    const files = res.body.modelVersions[0].files;
+    // EXACTLY ONE entry may claim `primary` — a mutant that hardcodes the flag
+    // (dropping the `primaryFile.id === file.id` identity comparison) marks all
+    // three, which is a lie about which file the version's bare default URL
+    // resolves to.
+    const primaryIds = files.filter((f: any) => f.primary === true).map((f: any) => f.id);
+    expect(primaryIds).toEqual([11]);
+    const primaryEntry = files.find((f: any) => f.primary === true);
+    // File 11 is the elected primary (real getPrimaryFile, default preferences).
+    expect(primaryEntry).toBeDefined();
+    expect(primaryEntry.id).toBe(11);
+    // …and every other entry must explicitly NOT claim it.
+    for (const other of files.filter((f: any) => f.id !== 11))
+      expect(other.primary, `file ${other.id}`).toBeUndefined();
+    expect(primaryEntry.hashes.SHA256).toBe('aaaa1111');
+    // This is the file the defect emitted `/api/download/models/4242` for, with
+    // NO query string — free to re-resolve to file 12 or 13 at download time.
+    expect(primaryEntry.downloadUrl).toBe('https://civitai.com/api/download/models/4242?fileId=11');
+  });
+
+  it('does not leak type/format/size/fp discriminators into the pinned URL', async () => {
+    // `createModelFileDownloadUrl` suppresses every soft discriminator once
+    // `fileId` is supplied; a URL still carrying them would mean the pin is not
+    // actually taking the fileId branch.
+    const res = await invoke('7');
+    for (const entry of res.body.modelVersions[0].files) {
+      const url = new URL(entry.downloadUrl);
+      expect([...url.searchParams.keys()]).toEqual(['fileId']);
+    }
+  });
+
+  it('a pinned URL survives a round trip through the download route contract', async () => {
+    // The pin is only worth anything if the download route's `fileId` branch
+    // treats it as authoritative. Pin what that branch depends on: the URL is a
+    // plain `?fileId=<n>` on the version path, i.e. exactly the shape
+    // `/api/download/models/[modelVersionId]` parses into `input.fileId` — the
+    // input that both selects the file directly (bypassing filePreferences
+    // scoring) and skips the metadata-misalignment check.
+    const res = await invoke('7');
+    for (const entry of res.body.modelVersions[0].files) {
+      const url = new URL(entry.downloadUrl);
+      const fileId = url.searchParams.get('fileId');
+      expect(fileId).toMatch(/^\d+$/);
+      expect(Number(fileId)).toBe(entry.id);
+    }
+  });
+
+  it('the version-level downloadUrl remains the unpinned default download', async () => {
+    // Not part of the fix: the version-level URL is the "give me the default
+    // file" entry point and advertises no per-file hash, so it stays bare.
+    const res = await invoke('7');
+    expect(res.body.modelVersions[0].downloadUrl).toBe(
+      'https://civitai.com/api/download/models/4242'
+    );
+  });
+});
+
+/**
+ * The pin above is only correct because `createModelFileDownloadUrl` treats
+ * `fileId` as exclusive: it must emit ONLY `fileId` and suppress every soft
+ * discriminator, otherwise a stale `type`/`format`/`size`/`fp`/`quantType` would
+ * ride along and the download route's misalignment check could 404 a URL we
+ * just advertised. The endpoint suites can't observe this (they no longer pass
+ * type/meta at all), so it is pinned here directly.
+ */
+describe('createModelFileDownloadUrl — `fileId` is exclusive', () => {
+  it('suppresses type/format/size/fp/quantType even when they are supplied', async () => {
+    const { createModelFileDownloadUrl } = await import('~/server/common/model-helpers');
+    const url = new URL(
+      `https://x.test${createModelFileDownloadUrl({
+        versionId: 4242,
+        fileId: 11,
+        type: 'Model',
+        meta: { format: 'GGUF', size: 'full', fp: 'fp32', quantType: 'Q8_0' },
+      })}`
+    );
+    expect(url.pathname).toBe('/api/download/models/4242');
+    expect([...url.searchParams.keys()]).toEqual(['fileId']);
+    expect(url.searchParams.get('fileId')).toBe('11');
+  });
+
+  it('still emits the discriminators when NO fileId is given (unchanged behavior)', async () => {
+    // Positive control for the test above: the suppression really is keyed on
+    // `fileId`, not on the helper ignoring these fields outright.
+    const { createModelFileDownloadUrl } = await import('~/server/common/model-helpers');
+    const url = new URL(
+      `https://x.test${createModelFileDownloadUrl({
+        versionId: 4242,
+        type: 'Model',
+        meta: { format: 'GGUF', size: 'full', fp: 'fp32', quantType: 'Q8_0' },
+      })}`
+    );
+    expect([...url.searchParams.keys()].sort()).toEqual([
+      'format',
+      'fp',
+      'quantType',
+      'size',
+      'type',
+    ]);
+  });
+});

--- a/src/tests/api/v1/models/id-origin-cache.test.ts
+++ b/src/tests/api/v1/models/id-origin-cache.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { pack, unpack } from 'msgpackr';
 import type { NextApiRequest, NextApiResponse } from 'next';
+import type * as ModelHelpers from '~/server/common/model-helpers';
 
 import {
   allBrowsingLevelsFlag,
@@ -112,8 +113,14 @@ vi.mock('~/env/server', () => ({
 // Trim the serialization helper graph so the handler body is deterministic and
 // no Prisma client loads through them.
 vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (url: string) => url }));
-vi.mock('~/server/common/model-helpers', () => ({
+// Keep the REAL module and override only the URL builders. A wholesale factory
+// here silently drops any export the handler later starts using — which is
+// exactly what happened when `createSerializedFileDownloadUrl` was added: the
+// handler called `undefined` and every case in this file 500'd.
+vi.mock('~/server/common/model-helpers', async (importOriginal) => ({
+  ...(await importOriginal<typeof ModelHelpers>()),
   createModelFileDownloadUrl: () => '/download',
+  createSerializedFileDownloadUrl: () => '/download',
 }));
 vi.mock('~/server/services/file.service', () => ({
   getDownloadFilename: () => 'file.safetensors',


### PR DESCRIPTION
Refs #3861. Sibling-endpoint follow-up to #3863 (which fixed the same class on `/api/v1/model-versions/mini/[id]`); this PR is branched off `main`, not off that PR.

## The defect — an API contract violation

`GET /api/v1/models/[id]` and `GET /api/v1/model-versions/[id]` both serialize, per model file, that file's `hashes`, `name` and `sizeKB` — and next to them a `downloadUrl` that was **not** pinned to that file:

```ts
createModelFileDownloadUrl({
  versionId: version.id,
  type: file.type,
  meta: metadata,
  primary: primaryFile.id === file.id,
})
```

Two problems follow from that:

1. `QS.stringify` drops the `primary` key entirely, and `createModelFileDownloadUrl` nulls out `type`/`format`/`size`/`fp`/`quantType` when `primary` is true. So **for the file elected primary the URL is a bare `/api/download/models/<versionId>` with no query string at all.**
2. That URL is re-resolved from scratch by `/api/download/models/[modelVersionId]` → `getFileForModelVersion`, whose `else` branch re-picks the file using **the requesting user's `filePreferences`** merged with any query params, scored by `getPrimaryFile`. `getPrimaryFile` has no tiebreak and neither query has an `ORDER BY`, so equal-scoring files resolve by raw row order.

Net effect: on a version with more than one public file, the response can advertise file A's SHA256, name and size beside a URL that serves file B — and *which* file it serves depends on who is asking. Any consumer that verifies the advertised hash against the downloaded bytes fails, permanently and non-deterministically.

**3,587 Published versions** currently have more than one `Public` primary-type file with more than one distinct `metadata.format` — the population where the two picks can diverge.

## The change

Pin each file's URL to that file:

```ts
createModelFileDownloadUrl({ versionId: version.id, fileId: file.id })
```

Verified against `createModelFileDownloadUrl` rather than assumed: supplying `fileId` suppresses `type`, `format`, `size`, `fp` and `quantType` (each is gated on `!primary && !fileId`), so the emitted URL is exactly `/api/download/models/<versionId>?fileId=<n>` — pinned in a direct unit test in this PR, with a positive control showing the discriminators *are* still emitted when no `fileId` is given.

On the download side, `getFileForModelVersion`'s `fileId` branch does a direct `findFirst({ id: fileId, modelVersionId })`, bypassing preference scoring entirely, and `/api/download/models/[modelVersionId]` explicitly **skips** its metadata-misalignment check when `input.fileId` is set (the file is already exact), so the new query string cannot cause a spurious 404.

The **version-level** `downloadUrl` on both endpoints is deliberately unchanged. It advertises no per-file metadata and is the "just give me the default file" entry point, so re-resolution there is the intended behaviour, not a mismatch.

### On consolidating into a shared helper

I considered extracting a `downloadUrlForFile(versionId, file)` wrapper, since three or four call sites need the same "pin the URL to the file whose metadata I just serialized" rule. I did not, and deliberately: `createModelFileDownloadUrl({ versionId, fileId })` **is** already the single place that rule lives, and the fix is precisely to stop passing the ambiguous arguments. A wrapper would add a name and an indirection without removing any duplicated logic — the call is one line either way. The smaller change wins here.

## Behaviour changes

- The primary file's URL gains `?fileId=N` where it previously had none; the other files' URLs swap `?type=…&format=…&size=…&fp=…` for `?fileId=N`. Both still point at `/api/download/models/<versionId>`, which is `Cache-Control: no-store` / `private, no-store` — so no CDN or edge caching behaviour changes.
- **The caller's `filePreferences` no longer influence which file a per-file URL serves.** That is the point of the fix — the URL must match the hash printed beside it — and the preference-driven "give me my preferred variant" behaviour is still available through the unchanged version-level `downloadUrl`.
- These are unauthenticated, shared-cache public responses (`/api/v1/models/[id]` in particular is served from an origin cache keyed only by `(modelId, browsingLevel)` behind an edge cache), so selecting per-caller preference at serialization time is not a viable alternative here — it would be both wrong for a shared cache entry and still leave the advertised hash and the served bytes free to disagree.

## Visibility

Checked rather than assumed: **both** endpoints already filter the serialized file list to `visibility === ModelFileVisibility.Public` before mapping. So every file that gets a pinned URL is one the download route's non-owner path (`if (!isOwner && !isMod) → visibility: Public`) will also serve. Pinning `fileId` therefore cannot turn a previously-working URL into a 404 for anonymous callers. Regression tests assert the Public-only filter on both endpoints so a future change can't quietly widen it under a pinned URL.

(Separate, pre-existing, not touched here: `getPrimaryFile` is called over the *unfiltered* file list on both endpoints, so if the elected primary happens to be non-Public, no serialized file carries `primary: true`. That is a labelling oddity in the response, not a hash/URL mismatch.)

## Other consumers of `createModelFileDownloadUrl`

Enumerated exhaustively (every call site in `src/`), not sampled:

**Same defect, not fixed in this PR** (each serializes per-file metadata next to a `primary`-derived URL):
- `src/server/services/model-search.service.ts:267` — backs the `/api/v1/models` list endpoint. Same shape, same `Public`-only filter. The best candidate for a follow-up.
- `src/server/webhooks/model.webooks.ts:63` and `:129` — the `new-model` / `updated-model` webhook payloads. Same shape, and notably these have **no visibility filter at all**, so a fix there needs the visibility question settled first.

**Already correct** (pass `fileId`):
- `src/pages/api/v1/model-versions/mini/[id].ts:241`
- `src/components/Model/ModelVersions/RequiredComponentsSection.tsx` (5 sites)

**Not affected** — version-level "default download" URLs that advertise no per-file metadata: `models/[id].ts:147`, `model-versions/[id].ts:274`, `model-search.service.ts:297`, `model.webooks.ts:76`/`:142`.

**Not affected** — UI call sites that build a URL for a file the user explicitly picked in the same interaction, or for a single known file: `DownloadVariantDropdown.tsx`, `ModelVersionDetails.tsx`, `ModelFileAlert.tsx`, `UserTrainingModels.tsx`, `Training/Form/{trainingSamplePrompts.ts,TrainingImages.tsx,ImageSelectModal.tsx}`.

## Tests

Two new suites (13 tests), both using the **real** `createModelFileDownloadUrl` and the **real** `getPrimaryFile` — the URL string and the primary election are the contract under test, so neither is stubbed. Fixtures use four files with pairwise-distinct `id`/`type`/`format`/`size`/`fp`/`sizeKB`/`hash`, so a wrong-file binding cannot coincidentally produce a correct URL. Each assertion recovers which file the response *claims* an entry is (via the advertised SHA256) and then checks the URL points at **that** file.

- `src/tests/api/v1/models/id-file-download-url.test.ts` (8)
- `src/tests/api/v1/model-versions/id-file-download-url.test.ts` (5)

Red/green matrix, same tests both sides:

| | at `origin/main` source | with the fix |
|---|---|---|
| both suites | **7 failed / 6 passed (13)** | **13 passed (13)** |

Mutation battery — 13 mutants plus an unmutated control, run on an isolated copy of the tree:

| mutant | result |
|---|---|
| `fileId: file.id` → `primaryFile.id` (models) | killed (2 failed) |
| `fileId: file.id` → `file.id + 1` (models) | killed (3 failed) |
| full revert to the pre-fix call (models) | killed (4 failed) |
| drop the `fileId` key entirely (models) | killed (4 failed) |
| `primary: primaryFile.id === file.id ? true : undefined` → `primary: true` | killed (1 failed) |
| delete the `Public` visibility filter (models) | killed (2 failed) |
| `fileId: file.id` → `primaryFile.id` (model-versions) | killed (1 failed) |
| `fileId: file.id` → `file.id - 1` (model-versions) | killed (2 failed) |
| full revert to the pre-fix call (model-versions) | killed (3 failed) |
| `primary: … === …` → `!==` (model-versions) | killed (1 failed) |
| delete the `Public` visibility filter (model-versions) | killed (2 failed) |
| helper: `fileId: fileId ?? null` → `null` (branch present but dead) | killed (8 failed) |
| helper: drop `&& !fileId` from all five suppression gates | killed (1 failed) |
| **control: unmutated** | **13 passed** |

**No survivors.** Two mutants survived the first pass and drove real test changes: `primary: true` (the suite only looked up the first entry claiming primary — now it asserts the *exact set*), and the helper-suppression mutant (unobservable from the endpoints, which no longer pass `type`/`meta` at all — hence the direct `createModelFileDownloadUrl` contract test).

## Gates

- `pnpm typecheck` — **0 type errors**. Instrument validated: a deliberately planted type error in `src/pages/api/v1/models/[id].ts` produced `1 type error(s)` / exit 2, then reverted.
- `vitest --project unit` over the touched areas (`src/tests/api/v1/{models,model-versions,model-files}`, `src/__tests__/pages/api/download`, the four `model-search` suites): **17 files, 161 tests, 161 passed, 0 failed**.
- `eslint` on the four changed files: 0 errors, 24 `no-explicit-any` **warnings** in the two new test files, matching the style of the existing sibling suite (`id-origin-cache.test.ts`).
- `prettier --check` on the four changed files: clean.
