### PR TITLE
feat(placement): placer-set sticker flip and opacity, with a 30% floor

### DIFF
--- a/src/components/RemixGallery/RemixGalleryCard.tsx
+++ b/src/components/RemixGallery/RemixGalleryCard.tsx
@@ -367,13 +367,17 @@ export function RemixGalleryCard({ imageId }: { imageId: number }) {
               ) : null
             )}
           </Group>
+          {/* No username: it wrapped this to two lines, and it was saying what
+              the page already does — this card sits on that creator's own image.
+              The link carries `tab=sent` because the page defaults to `received`,
+              which is the queue of submissions TO you: without it "withdraw"
+              landed on a tab that does not contain the thing being withdrawn. */}
           <Text size="xs" c="dimmed">
-            {visibility.ownerUsername ? `@${visibility.ownerUsername}` : 'The creator'} decides
-            whether it appears here. You can{' '}
-            <Anchor href="/user/remix-submissions" size="xs">
-              withdraw it
+            Waiting on the creator. You can{' '}
+            <Anchor href="/user/remix-submissions?tab=sent" size="xs">
+              {viewerPending.length === 1 ? 'withdraw it' : 'withdraw them'}
             </Anchor>{' '}
-            until they do.
+            until they decide.
           </Text>
         </Stack>
       )}

--- a/src/components/Sticker/DraftSticker.tsx
+++ b/src/components/Sticker/DraftSticker.tsx
@@ -7,12 +7,7 @@ import {
   Tooltip,
   UnstyledButton,
 } from '@mantine/core';
-import {
-  IconDropletHalf2,
-  IconFlipHorizontal,
-  IconMessage,
-  IconTrash,
-} from '@tabler/icons-react';
+import { IconDropletHalf2, IconFlipHorizontal, IconMessage, IconTrash } from '@tabler/icons-react';
 import clsx from 'clsx';
 import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 import { BuzzTransactionButton } from '~/components/Buzz/BuzzTransactionButton';
@@ -391,16 +386,24 @@ export function DraftSticker({
         style={{ top: `-${KNOB_OFFSET * 100}%` }}
       />
 
-      {/* Offset diagonally out past the top-right corner rather than replacing
-          the handle there — all four corners resize, and losing one to a
-          destructive action on the corner a right-hander reaches first is worse
-          than the crowding. It grows to the RIGHT from that point, away from the
-          rotate knob: the knob is centred over the top edge, and a row that grew
-          leftward would reach it on any sticker narrower than twice the row.
-          Dark rather than the handles' blue: these act on the sticker, they are
-          not part of positioning it. */}
+      {/* Two panels, one per top corner, and the split is the point: removing
+          the draft throws work away, and it should not sit a thumb's width from
+          the two controls you press while arranging one.
+
+          Each is flush with its own edge of the sticker and grows inward, so the
+          pair reads as bracketing the box rather than floating beside it. They
+          sit above the top edge, clear of the corner handles — all four corners
+          resize, so none of them can be spent on a button. Dark rather than the
+          handles' blue: these act on the sticker, they are not part of
+          positioning it.
+
+          ⚠️ Growing inward means they approach the rotate knob, which is centred
+          over the top edge. On a sticker near the 5% floor the two panels and the
+          knob are competing for the same span; the knob keeps its own offset and
+          wins on z-order, but that is the case to look at first if these ever
+          feel cramped. */}
       <div
-        className="absolute -top-7 left-full ml-1 flex cursor-auto items-center gap-0.5 rounded-full border-2 border-white bg-dark-7 px-1 py-0.5"
+        className="absolute -top-9 left-0 flex cursor-auto items-center gap-0.5 rounded-full bg-dark-7 px-1 py-0.5"
         onPointerDown={(event) => event.stopPropagation()}
       >
         <Tooltip label={draft.flip ? 'Unflip' : 'Flip'} withinPortal>
@@ -451,7 +454,15 @@ export function DraftSticker({
             />
           </Popover.Dropdown>
         </Popover>
+      </div>
 
+      <div
+        // Padding equal on both axes, unlike its two-icon sibling: a single icon
+        // in a pill sized `px`/`py` comes out wider than it is tall, so the
+        // `rounded-full` reads as a lozenge rather than a circle.
+        className="absolute -top-9 right-0 flex cursor-auto items-center rounded-full bg-dark-7 p-0.5"
+        onPointerDown={(event) => event.stopPropagation()}
+      >
         <Tooltip label="Remove" withinPortal>
           <ActionIcon
             size="sm"

--- a/src/components/Sticker/DraftSticker.tsx
+++ b/src/components/Sticker/DraftSticker.tsx
@@ -132,10 +132,10 @@ export function DraftSticker({
   const [{ flipped, flippedOffset, panelsInside }, setPosition] = useState({
     flipped: false,
     flippedOffset: 0,
-    // Starts outside, which is the layout that cannot collide with anything.
-    // The first measure runs before the artwork has loaded, when the box is
-    // near-zero — starting inside would put delete on top of opacity for that
-    // frame, which is one misclick away from throwing the draft away.
+    // Starts false, which puts the controls in the buy cluster — the layout
+    // that is correct at any size. The real value lands from the layout effect
+    // before paint, so this is never seen; it is the safe direction to be wrong
+    // in if that ever stops being true.
     panelsInside: false,
   });
   const trayElement = useStickerPlacementDraftStore((state) => state.tray);
@@ -337,6 +337,84 @@ export function DraftSticker({
       }
     };
 
+  // Selects as well as stopping the drag, so the lower of two stacked drafts
+  // does not have controls buried under its neighbour — `selected` is the only
+  // input to z-order. Gated on there being no live gesture, the same rule
+  // `take()` applies: a press that arrives while another finger is dragging must
+  // not move the selection, or the sticker being dragged drops behind its
+  // neighbour under the finger holding it.
+  const pressPanel = (event: React.PointerEvent) => {
+    event.stopPropagation();
+    if (!useStickerPlacementDraftStore.getState().interaction) select(draft.id);
+  };
+
+  const flipControl = (
+    <Tooltip label={draft.flip ? 'Unflip' : 'Flip'} withinPortal>
+      <ActionIcon
+        size="sm"
+        radius="xl"
+        variant="subtle"
+        color={draft.flip ? 'blue' : 'gray'}
+        aria-label={draft.flip ? 'Unflip this sticker' : 'Flip this sticker'}
+        onClick={() => move(draft.id, { flip: !draft.flip })}
+      >
+        <IconFlipHorizontal size={14} />
+      </ActionIcon>
+    </Tooltip>
+  );
+
+  // The slider is behind a control rather than always on screen: it is set once,
+  // and a slider parked on the artwork would be in the way of every later drag.
+  const opacityControl = (
+    <Popover width={210} position="top" withArrow withinPortal shadow="md">
+      <Popover.Target>
+        <ActionIcon
+          size="sm"
+          radius="xl"
+          variant="subtle"
+          color={draft.opacity < 1 ? 'blue' : 'gray'}
+          aria-label="Set this sticker's opacity"
+        >
+          <IconDropletHalf2 size={14} />
+        </ActionIcon>
+      </Popover.Target>
+      <Popover.Dropdown p="sm">
+        <Text size="xs" c="dimmed" className="mb-2">
+          Opacity
+        </Text>
+        {/* The floor is the slider's own minimum, so the range you can drag
+            through is the range the server accepts — the value can never be one
+            the purchase would then refuse. The refusal still lives in the
+            schema; this only keeps the two from disagreeing in front of the
+            person placing it. */}
+        <Slider
+          min={Math.round(STICKER_PLACEMENT_MIN_OPACITY * 100)}
+          max={100}
+          step={5}
+          value={Math.round(draft.opacity * 100)}
+          onChange={(value) => move(draft.id, { opacity: value / 100 })}
+          label={(value) => `${value}%`}
+          aria-label="Sticker opacity"
+        />
+      </Popover.Dropdown>
+    </Popover>
+  );
+
+  const removeControl = (
+    <Tooltip label="Remove" withinPortal>
+      <ActionIcon
+        size="sm"
+        radius="xl"
+        variant="subtle"
+        color="gray"
+        aria-label="Remove this sticker"
+        onClick={() => cancelDraft(draft.id)}
+      >
+        <IconTrash size={14} />
+      </ActionIcon>
+    </Tooltip>
+  );
+
   const artworkImage = (
     <EdgeImage
       src={art.url}
@@ -413,112 +491,40 @@ export function DraftSticker({
           the draft throws work away, and it should not sit a thumb's width from
           the two controls you press while arranging one.
 
-          Each is flush with its own edge of the sticker and grows inward, so the
-          pair reads as bracketing the box rather than floating beside it. They
-          sit above the top edge, clear of the corner handles — all four corners
-          resize, so none of them can be spent on a button. Dark rather than the
-          handles' blue: these act on the sticker, they are not part of
-          positioning it.
+          Each is flush with its own edge and grows inward, so the pair reads as
+          bracketing the box. They clear the corner handles — all four resize, so
+          none can be spent on a button — and the buy button clears their band
+          through `flippedButtonOffset`. Dark rather than the handles' blue:
+          these act on the sticker, they are not part of positioning it.
 
-          Flush is conditional, and the fallback is not decoration. Every element
-          above the sticker except these two is sized as a FRACTION of it — the
-          rotate knob at `KNOB_OFFSET` of the height, the flipped buy button from
-          that — while the panels are a fixed 36px band. So on a small sticker the
-          three converge: the knob ends up under a panel, and the two panels reach
-          past each other with DELETE on top of opacity, because it paints last.
-          Below `STICKER_PANEL_MIN_WIDTH_PX` they move outside the corners, where
-          they can reach neither the knob nor each other at any size. The buy
-          button clears the band through `flippedButtonOffset`. */}
-      <div
-        className={clsx(
-          'absolute -top-9 flex cursor-auto items-center gap-0.5 rounded-full bg-dark-7 px-1 py-0.5',
-          panelsInside ? 'left-0' : 'right-full mr-1'
-        )}
-        // Selects as well as stopping the drag, like the sticker body does: with
-        // two drafts overlapping, only the selected one is raised, so without
-        // this the lower one's controls stay buried under its neighbour and the
-        // press that would have freed them is the one being swallowed here.
-        onPointerDown={(event) => {
-          event.stopPropagation();
-          select(draft.id);
-        }}
-      >
-        <Tooltip label={draft.flip ? 'Unflip' : 'Flip'} withinPortal>
-          <ActionIcon
-            size="sm"
-            radius="xl"
-            variant="subtle"
-            color={draft.flip ? 'blue' : 'gray'}
-            aria-label={draft.flip ? 'Unflip this sticker' : 'Flip this sticker'}
-            onClick={() => move(draft.id, { flip: !draft.flip })}
+          Only while the sticker is wide enough to hold them. Every other piece
+          of chrome up here is a FRACTION of the sticker (the knob at
+          `KNOB_OFFSET` of the height, the flipped button derived from it) while
+          these are a fixed band, so on a small sticker all three converge: the
+          knob ends up under a panel and DELETE lands on opacity, because it
+          paints later. Narrow drafts hand their controls to the buy cluster
+          instead — see `controlRow` below. */}
+      {panelsInside && (
+        <>
+          <div
+            className="absolute -top-9 left-0 flex cursor-auto items-center gap-0.5 rounded-full bg-dark-7 px-1 py-0.5"
+            onPointerDown={pressPanel}
           >
-            <IconFlipHorizontal size={14} />
-          </ActionIcon>
-        </Tooltip>
+            {flipControl}
+            {opacityControl}
+          </div>
 
-        {/* The slider is behind a control rather than always on screen: it is set
-            once, and a slider parked on the artwork would be in the way of every
-            later drag. */}
-        <Popover width={210} position="top" withArrow withinPortal shadow="md">
-          <Popover.Target>
-            <ActionIcon
-              size="sm"
-              radius="xl"
-              variant="subtle"
-              color={draft.opacity < 1 ? 'blue' : 'gray'}
-              aria-label="Set this sticker's opacity"
-            >
-              <IconDropletHalf2 size={14} />
-            </ActionIcon>
-          </Popover.Target>
-          <Popover.Dropdown p="sm">
-            <Text size="xs" c="dimmed" className="mb-2">
-              Opacity
-            </Text>
-            {/* The floor is the slider's own minimum, so the range you can drag
-                through is the range the server accepts — the value can never be
-                one the purchase would then refuse. The refusal still lives in
-                the schema; this only keeps the two from disagreeing in front of
-                the person placing it. */}
-            <Slider
-              min={Math.round(STICKER_PLACEMENT_MIN_OPACITY * 100)}
-              max={100}
-              step={5}
-              value={Math.round(draft.opacity * 100)}
-              onChange={(value) => move(draft.id, { opacity: value / 100 })}
-              label={(value) => `${value}%`}
-              aria-label="Sticker opacity"
-            />
-          </Popover.Dropdown>
-        </Popover>
-      </div>
-
-      <div
-        // Padding equal on both axes, unlike its two-icon sibling: a single icon
-        // in a pill sized `px`/`py` comes out wider than it is tall, so the
-        // `rounded-full` reads as a lozenge rather than a circle.
-        className={clsx(
-          'absolute -top-9 flex cursor-auto items-center rounded-full bg-dark-7 p-0.5',
-          panelsInside ? 'right-0' : 'left-full ml-1'
-        )}
-        onPointerDown={(event) => {
-          event.stopPropagation();
-          select(draft.id);
-        }}
-      >
-        <Tooltip label="Remove" withinPortal>
-          <ActionIcon
-            size="sm"
-            radius="xl"
-            variant="subtle"
-            color="gray"
-            aria-label="Remove this sticker"
-            onClick={() => cancelDraft(draft.id)}
+          <div
+            // Padding equal on both axes, unlike its two-icon sibling: a single
+            // icon in a pill sized `px`/`py` comes out wider than it is tall, so
+            // `rounded-full` reads as a lozenge rather than a circle.
+            className="absolute -top-9 right-0 flex cursor-auto items-center rounded-full bg-dark-7 p-0.5"
+            onPointerDown={pressPanel}
           >
-            <IconTrash size={14} />
-          </ActionIcon>
-        </Tooltip>
-      </div>
+            {removeControl}
+          </div>
+        </>
+      )}
 
       <div
         ref={buttonRef}
@@ -536,13 +542,39 @@ export function DraftSticker({
         )}
         style={{
           minWidth: BUY_BUTTON_MIN_WIDTH,
-          // Scales with the sticker because the knob it has to clear does.
+          // Clears whichever obstacle is taller: the knob, which scales with the
+          // sticker, or the panel band, which does not. Below ~164px the
+          // constant wins, so this does NOT simply scale.
           ...(flipped ? { marginBottom: flippedOffset } : null),
         }}
         // The button is inside the draggable body, so without this every press
         // on it would also start a move and the click would land mid-drag.
         onPointerDown={(event) => event.stopPropagation()}
       >
+        {/* Where a narrow draft's controls live, rather than a second position
+            for the panels above it.
+
+            Anything anchored to a small sticker's own box is in trouble twice
+            over: inside it, the panels reach past each other and the knob;
+            outside it, they hang off the sticker and the carousel's viewport
+            clips them away near the image edges — which on a phone-width media
+            box is most of the frame, because almost every draft there is narrow.
+            This cluster is the one piece of chrome that already knows where it
+            is on screen: it measures itself against the tray and the clipping
+            ancestor and moves to whichever side is visible. Handing it the
+            controls means they inherit that, instead of a third set of
+            hand-derived offsets to get wrong. */}
+        {!panelsInside && (
+          <div
+            className="flex items-center gap-0.5 rounded-full bg-dark-7 px-1 py-0.5"
+            onPointerDown={pressPanel}
+          >
+            {flipControl}
+            {opacityControl}
+            {removeControl}
+          </div>
+        )}
+
         {/* Optional, and folded away until asked for: a field on every draft
             would sit over the artwork through the whole arrangement, which is
             the one thing this overlay is trying not to do. */}

--- a/src/components/Sticker/DraftSticker.tsx
+++ b/src/components/Sticker/DraftSticker.tsx
@@ -1,5 +1,18 @@
-import { Text, Textarea, UnstyledButton } from '@mantine/core';
-import { IconMessage, IconX } from '@tabler/icons-react';
+import {
+  ActionIcon,
+  Popover,
+  Slider,
+  Text,
+  Textarea,
+  Tooltip,
+  UnstyledButton,
+} from '@mantine/core';
+import {
+  IconDropletHalf2,
+  IconFlipHorizontal,
+  IconMessage,
+  IconTrash,
+} from '@tabler/icons-react';
 import clsx from 'clsx';
 import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 import { BuzzTransactionButton } from '~/components/Buzz/BuzzTransactionButton';
@@ -13,11 +26,15 @@ import {
   shouldFlipPlaceButton,
 } from '~/components/Sticker/place-button-position';
 import { payoutCopy } from '~/components/Sticker/payout-copy';
+import { stickerArtworkStyle } from '~/components/Sticker/placement-appearance';
 import { useCreateStickerPlacement } from '~/components/Sticker/placement.util';
 import type { ResolvedSticker } from '~/components/Sticker/sticker.util';
 import type { StickerTreatment } from '~/components/Sticker/treatments/sticker-treatments';
 import { PLACEMENT_SPEND_TYPES } from '~/shared/constants/placement.constants';
-import { STICKER_COMMENT_MAX_LENGTH } from '~/shared/utils/sticker-placement';
+import {
+  STICKER_COMMENT_MAX_LENGTH,
+  STICKER_PLACEMENT_MIN_OPACITY,
+} from '~/shared/utils/sticker-placement';
 import type { StickerDraft } from '~/store/sticker-placement-draft.store';
 import {
   pointerToSurfaceFraction,
@@ -98,6 +115,7 @@ export function DraftSticker({
   const payout = payoutCopy(ownerShare, ownerUsername);
   const select = useStickerPlacementDraftStore((state) => state.select);
   const cancelDraft = useStickerPlacementDraftStore((state) => state.cancelDraft);
+  const move = useStickerPlacementDraftStore((state) => state.move);
   const place = useCreateStickerPlacement(draft.id);
 
   // Local to the draft rather than in the store: it is written once, read once
@@ -312,6 +330,7 @@ export function DraftSticker({
         display: 'block',
         pointerEvents: 'none',
         ...dressed.imageStyle?.detail,
+        ...stickerArtworkStyle(draft),
       }}
       draggable={false}
     />
@@ -341,7 +360,7 @@ export function DraftSticker({
         <span
           aria-hidden
           className={dressed.behind.className}
-          style={{ zIndex: -1, ...dressed.behind.style }}
+          style={{ zIndex: -1, ...dressed.behind.style, opacity: draft.opacity }}
         />
       )}
 
@@ -372,20 +391,80 @@ export function DraftSticker({
         style={{ top: `-${KNOB_OFFSET * 100}%` }}
       />
 
-      {/* Offset diagonally out past the corner handle rather than replacing it —
-          all four corners resize, and losing one to a destructive action on the
-          only corner a right-hander reaches first is worse than the crowding.
-          Dark rather than the handles' blue: it is the one control here that
-          throws work away. */}
-      <button
-        type="button"
-        aria-label="Remove this sticker"
+      {/* Offset diagonally out past the top-right corner rather than replacing
+          the handle there — all four corners resize, and losing one to a
+          destructive action on the corner a right-hander reaches first is worse
+          than the crowding. It grows to the RIGHT from that point, away from the
+          rotate knob: the knob is centred over the top edge, and a row that grew
+          leftward would reach it on any sticker narrower than twice the row.
+          Dark rather than the handles' blue: these act on the sticker, they are
+          not part of positioning it. */}
+      <div
+        className="absolute -top-7 left-full ml-1 flex cursor-auto items-center gap-0.5 rounded-full border-2 border-white bg-dark-7 px-1 py-0.5"
         onPointerDown={(event) => event.stopPropagation()}
-        onClick={() => cancelDraft(draft.id)}
-        className="absolute -right-7 -top-7 flex size-5 cursor-pointer items-center justify-center rounded-full border-2 border-white bg-dark-7 text-white"
       >
-        <IconX size={10} stroke={3} />
-      </button>
+        <Tooltip label={draft.flip ? 'Unflip' : 'Flip'} withinPortal>
+          <ActionIcon
+            size="sm"
+            radius="xl"
+            variant="subtle"
+            color={draft.flip ? 'blue' : 'gray'}
+            aria-label={draft.flip ? 'Unflip this sticker' : 'Flip this sticker'}
+            onClick={() => move(draft.id, { flip: !draft.flip })}
+          >
+            <IconFlipHorizontal size={14} />
+          </ActionIcon>
+        </Tooltip>
+
+        {/* The slider is behind a control rather than always on screen: it is set
+            once, and a slider parked on the artwork would be in the way of every
+            later drag. */}
+        <Popover width={210} position="top" withArrow withinPortal shadow="md">
+          <Popover.Target>
+            <ActionIcon
+              size="sm"
+              radius="xl"
+              variant="subtle"
+              color={draft.opacity < 1 ? 'blue' : 'gray'}
+              aria-label="Set this sticker's opacity"
+            >
+              <IconDropletHalf2 size={14} />
+            </ActionIcon>
+          </Popover.Target>
+          <Popover.Dropdown p="sm">
+            <Text size="xs" c="dimmed" className="mb-2">
+              Opacity
+            </Text>
+            {/* The floor is the slider's own minimum, so the range you can drag
+                through is the range the server accepts — the value can never be
+                one the purchase would then refuse. The refusal still lives in
+                the schema; this only keeps the two from disagreeing in front of
+                the person placing it. */}
+            <Slider
+              min={Math.round(STICKER_PLACEMENT_MIN_OPACITY * 100)}
+              max={100}
+              step={5}
+              value={Math.round(draft.opacity * 100)}
+              onChange={(value) => move(draft.id, { opacity: value / 100 })}
+              label={(value) => `${value}%`}
+              aria-label="Sticker opacity"
+            />
+          </Popover.Dropdown>
+        </Popover>
+
+        <Tooltip label="Remove" withinPortal>
+          <ActionIcon
+            size="sm"
+            radius="xl"
+            variant="subtle"
+            color="gray"
+            aria-label="Remove this sticker"
+            onClick={() => cancelDraft(draft.id)}
+          >
+            <IconTrash size={14} />
+          </ActionIcon>
+        </Tooltip>
+      </div>
 
       <div
         ref={buttonRef}
@@ -456,6 +535,8 @@ export function DraftSticker({
                 y: draft.y,
                 scale: draft.scale,
                 rotation: draft.rotation,
+                flip: draft.flip,
+                opacity: draft.opacity,
                 // Sent only when there is something to send, so an opened-then-
                 // abandoned field is the same as never opening it.
                 ...(note.trim() ? { comment: note } : {}),

--- a/src/components/Sticker/DraftSticker.tsx
+++ b/src/components/Sticker/DraftSticker.tsx
@@ -17,10 +17,10 @@ import { KNOB_OFFSET, rotate } from '~/components/Sticker/draft-gesture';
 import {
   candidateDistance,
   flippedButtonOffset,
+  panelBandFor,
   panelsFitInsideEdges,
   placeButtonBoxes,
   shouldFlipPlaceButton,
-  STICKER_PANEL_BAND_PX,
 } from '~/components/Sticker/place-button-position';
 import { payoutCopy } from '~/components/Sticker/payout-copy';
 import { stickerArtworkStyle } from '~/components/Sticker/placement-appearance';
@@ -126,9 +126,9 @@ export function DraftSticker({
 
   // Both the tray and the carousel's clipped viewport can swallow the button, so
   // it moves above the sticker when that is the better of the two positions.
-  // `panelsInside` rides along because it is decided from the same measurement
-  // and changes with it: the panels sit against the sticker's edges while there
-  // is room for them there, and move outside the corners when there is not.
+  // `panelsInside` rides along because it is decided from the same measurement:
+  // the panels sit against the sticker's edges while there is room for them
+  // there, and a narrower draft hands its controls to the buy cluster instead.
   const [{ flipped, flippedOffset, panelsInside }, setPosition] = useState({
     flipped: false,
     flippedOffset: 0,
@@ -166,8 +166,10 @@ export function DraftSticker({
       knobOffset: KNOB_OFFSET,
       gap: BUY_BUTTON_GAP,
       // The panels are the other thing above the sticker, and the only one that
-      // does not scale with it.
-      panelBand: STICKER_PANEL_BAND_PX,
+      // does not scale with it — and on a narrow draft they are not drawn at
+      // all, so there is nothing there to clear. Clearing a band that is not
+      // there only costs the button a flip it could have taken.
+      panelBand: panelBandFor(width),
     });
     // From the button's own measured rect, both times: the pair that comes out
     // is the same whichever side the button is currently on, which is what stops
@@ -258,9 +260,14 @@ export function DraftSticker({
   // The cheap half, and the only one a gesture reaches: rect and offset reads,
   // no style recalc. Which ancestor clips is a property of the tree, not of the
   // sticker's own transform, so none of these deps can change it.
+  //
+  // `panelsInside` is in here because it moves the controls between the panels
+  // and the cluster, which changes the cluster's height — an input to the flip
+  // decision. The ResizeObserver would catch it a beat later; this measures on
+  // the same commit that moved them.
   useLayoutEffect(() => {
     measure();
-  }, [measure, draft.x, draft.y, draft.scale, draft.rotation, flipped]);
+  }, [measure, draft.x, draft.y, draft.scale, draft.rotation, flipped, panelsInside]);
 
   const begin =
     (mode: Gesture['mode'], corner?: { sx: number; sy: number }) => (event: React.PointerEvent) => {
@@ -503,7 +510,7 @@ export function DraftSticker({
           these are a fixed band, so on a small sticker all three converge: the
           knob ends up under a panel and DELETE lands on opacity, because it
           paints later. Narrow drafts hand their controls to the buy cluster
-          instead — see `controlRow` below. */}
+          instead — the `!panelsInside` row inside `buttonRef` below. */}
       {panelsInside && (
         <>
           <div

--- a/src/components/Sticker/DraftSticker.tsx
+++ b/src/components/Sticker/DraftSticker.tsx
@@ -17,8 +17,10 @@ import { KNOB_OFFSET, rotate } from '~/components/Sticker/draft-gesture';
 import {
   candidateDistance,
   flippedButtonOffset,
+  panelsFitInsideEdges,
   placeButtonBoxes,
   shouldFlipPlaceButton,
+  STICKER_PANEL_BAND_PX,
 } from '~/components/Sticker/place-button-position';
 import { payoutCopy } from '~/components/Sticker/payout-copy';
 import { stickerArtworkStyle } from '~/components/Sticker/placement-appearance';
@@ -124,7 +126,18 @@ export function DraftSticker({
 
   // Both the tray and the carousel's clipped viewport can swallow the button, so
   // it moves above the sticker when that is the better of the two positions.
-  const [{ flipped, flippedOffset }, setPosition] = useState({ flipped: false, flippedOffset: 0 });
+  // `panelsInside` rides along because it is decided from the same measurement
+  // and changes with it: the panels sit against the sticker's edges while there
+  // is room for them there, and move outside the corners when there is not.
+  const [{ flipped, flippedOffset, panelsInside }, setPosition] = useState({
+    flipped: false,
+    flippedOffset: 0,
+    // Starts outside, which is the layout that cannot collide with anything.
+    // The first measure runs before the artwork has loaded, when the box is
+    // near-zero — starting inside would put delete on top of opacity for that
+    // frame, which is one misclick away from throwing the draft away.
+    panelsInside: false,
+  });
   const trayElement = useStickerPlacementDraftStore((state) => state.tray);
 
   // `measure` is what the ResizeObserver and the window listener are bound to,
@@ -144,10 +157,17 @@ export function DraftSticker({
     const { flipped, rotation } = frame.current;
     const tray = useStickerPlacementDraftStore.getState().tray;
     const height = element.offsetHeight;
+    // Layout size, not the bounding box: `offsetWidth` ignores the CSS rotation,
+    // and the panels are children of the rotated element — they are laid out
+    // against the sticker's own width whatever angle it is at.
+    const width = element.offsetWidth;
     const offset = flippedButtonOffset({
       stickerHeight: height,
       knobOffset: KNOB_OFFSET,
       gap: BUY_BUTTON_GAP,
+      // The panels are the other thing above the sticker, and the only one that
+      // does not scale with it.
+      panelBand: STICKER_PANEL_BAND_PX,
     });
     // From the button's own measured rect, both times: the pair that comes out
     // is the same whichever side the button is currently on, which is what stops
@@ -172,12 +192,15 @@ export function DraftSticker({
         clip: clip.current?.getBoundingClientRect() ?? null,
       }),
       flippedOffset: offset,
+      panelsInside: panelsFitInsideEdges(width),
     };
 
     // Every pointer move re-measures, so bail on an unchanged result rather
     // than handing React a new object to re-render for.
     setPosition((current) =>
-      current.flipped === next.flipped && current.flippedOffset === next.flippedOffset
+      current.flipped === next.flipped &&
+      current.flippedOffset === next.flippedOffset &&
+      current.panelsInside === next.panelsInside
         ? current
         : next
     );
@@ -397,14 +420,28 @@ export function DraftSticker({
           handles' blue: these act on the sticker, they are not part of
           positioning it.
 
-          ⚠️ Growing inward means they approach the rotate knob, which is centred
-          over the top edge. On a sticker near the 5% floor the two panels and the
-          knob are competing for the same span; the knob keeps its own offset and
-          wins on z-order, but that is the case to look at first if these ever
-          feel cramped. */}
+          Flush is conditional, and the fallback is not decoration. Every element
+          above the sticker except these two is sized as a FRACTION of it — the
+          rotate knob at `KNOB_OFFSET` of the height, the flipped buy button from
+          that — while the panels are a fixed 36px band. So on a small sticker the
+          three converge: the knob ends up under a panel, and the two panels reach
+          past each other with DELETE on top of opacity, because it paints last.
+          Below `STICKER_PANEL_MIN_WIDTH_PX` they move outside the corners, where
+          they can reach neither the knob nor each other at any size. The buy
+          button clears the band through `flippedButtonOffset`. */}
       <div
-        className="absolute -top-9 left-0 flex cursor-auto items-center gap-0.5 rounded-full bg-dark-7 px-1 py-0.5"
-        onPointerDown={(event) => event.stopPropagation()}
+        className={clsx(
+          'absolute -top-9 flex cursor-auto items-center gap-0.5 rounded-full bg-dark-7 px-1 py-0.5',
+          panelsInside ? 'left-0' : 'right-full mr-1'
+        )}
+        // Selects as well as stopping the drag, like the sticker body does: with
+        // two drafts overlapping, only the selected one is raised, so without
+        // this the lower one's controls stay buried under its neighbour and the
+        // press that would have freed them is the one being swallowed here.
+        onPointerDown={(event) => {
+          event.stopPropagation();
+          select(draft.id);
+        }}
       >
         <Tooltip label={draft.flip ? 'Unflip' : 'Flip'} withinPortal>
           <ActionIcon
@@ -460,8 +497,14 @@ export function DraftSticker({
         // Padding equal on both axes, unlike its two-icon sibling: a single icon
         // in a pill sized `px`/`py` comes out wider than it is tall, so the
         // `rounded-full` reads as a lozenge rather than a circle.
-        className="absolute -top-9 right-0 flex cursor-auto items-center rounded-full bg-dark-7 p-0.5"
-        onPointerDown={(event) => event.stopPropagation()}
+        className={clsx(
+          'absolute -top-9 flex cursor-auto items-center rounded-full bg-dark-7 p-0.5',
+          panelsInside ? 'right-0' : 'left-full ml-1'
+        )}
+        onPointerDown={(event) => {
+          event.stopPropagation();
+          select(draft.id);
+        }}
       >
         <Tooltip label="Remove" withinPortal>
           <ActionIcon

--- a/src/components/Sticker/StickerPlacementBar.browser.test.tsx
+++ b/src/components/Sticker/StickerPlacementBar.browser.test.tsx
@@ -57,6 +57,19 @@ vi.mock('~/components/Sticker/placement.util', async (importOriginal) => ({
 vi.mock('~/components/Sticker/StickerPlacementTray', () => ({
   StickerPlacementTray: () => null,
 }));
+// The history panel is the same case, and leaving it in broke the `enabled`
+// assertion below rather than anything it was testing: it calls
+// `useStickerPlacements` too, with `enabled: opened` — false until someone opens
+// it — and the mock above collects EVERY caller's argument into one array. So
+// the bar's own `enabled: true` arrived alongside the panel's `false`.
+//
+// Mocked out rather than relaxing the assertion to `.some(...)`: `.some` passes
+// even when the bar's own query is disabled, which is the exact regression the
+// test exists to catch.
+vi.mock('~/components/Sticker/StickerHistoryPanel', () => ({
+  StickerHistoryButton: () => null,
+  StickerHistoryPanel: () => null,
+}));
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
   useFeatureFlags: () => ({ stickerPlacement: true }),
 }));

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -401,6 +401,10 @@ export function StickerPlacementOverlay({
                     // an edge-placed sticker is clipped while the artwork it marks
                     // is still visible — and a card shows none of the other
                     // pending cues, so that ring is the whole signal there.
+                    //
+                    // Reduces that, does not close it: a `cover` crop can still
+                    // land the sticker's interior in frame with its edges out,
+                    // and the ring goes with the edges.
                     surface === 'card' ? 'inset-0' : '-inset-1'
                   )}
                 />

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -392,7 +392,18 @@ export function StickerPlacementOverlay({
                 from a sticker they chose to place faint. A border is a deliberate
                 mark at any size and against any background. */}
               {placement.isPending && (
-                <span className="pointer-events-none absolute -inset-1 rounded border-2 border-dashed border-yellow-6" />
+                <span
+                  className={clsx(
+                    'pointer-events-none absolute rounded border-2 border-dashed border-yellow-6',
+                    // Inside the artwork's own box on a card, outside it in the
+                    // detail view. A card draws this inside two `overflow-hidden`
+                    // layers over `object-fit: cover` media, so an outset ring on
+                    // an edge-placed sticker is clipped while the artwork it marks
+                    // is still visible — and a card shows none of the other
+                    // pending cues, so that ring is the whole signal there.
+                    surface === 'card' ? 'inset-0' : '-inset-1'
+                  )}
+                />
               )}
             </div>
           );

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -4,6 +4,7 @@ import type { ResolvedSticker } from '~/components/Sticker/sticker.util';
 import { useStickerCosmetics } from '~/components/Sticker/sticker.util';
 import type { PlacedSticker } from '~/components/Sticker/placement.util';
 import { orderPlacements, placementRevealDelays } from '~/components/Sticker/placement-order';
+import { stickerArtworkStyle } from '~/components/Sticker/placement-appearance';
 import { StickerPlacementActions } from '~/components/Sticker/StickerPlacementActions';
 import { StickerPlacementHoverCard } from '~/components/Sticker/StickerPlacementHoverCard';
 import {
@@ -113,9 +114,9 @@ export function StickerPlacementOverlay({
   artworkWidth?: number;
   /**
    * How an approved sticker is separated from the artwork under it. Never
-   * applied to a pending placement — pending owns 60% opacity plus a dashed
-   * yellow outline, and a second always-on treatment on top of it would make
-   * "waiting on you" and "settled" look the same to the owner.
+   * applied to a pending placement — pending owns the dashed yellow outline, and
+   * a second always-on treatment on top of it would make "waiting on you" and
+   * "settled" look the same to the owner.
    */
   treatment?: StickerTreatmentKey;
   /**
@@ -325,6 +326,14 @@ export function StickerPlacementOverlay({
             isPending: placement.isPending,
           });
 
+          // The placer's own opacity, drawn at its true value even while the
+          // owner is deciding. Pending used to be dimmed a further 40% on top of
+          // this, which compounds — a sticker placed at the 30% floor would reach
+          // a review card at 18%, looking like nothing there and then appearing
+          // at full strength once approved, which is exactly what the floor
+          // exists to prevent. The dashed outline carries "awaiting review" now.
+          const appearance = stickerArtworkStyle(placement.data);
+
           const artworkImage = (
             <EdgeImage
               src={art.url}
@@ -332,12 +341,12 @@ export function StickerPlacementOverlay({
               // A fixed request width rather than a measured one: a sticker has
               // a natural size and the element scales it down in layout.
               options={{ width: artworkWidth, anim: art.animated, optimized: true }}
-              className={clsx(placement.isPending && 'opacity-60')}
               style={{
                 width: '100%',
                 height: 'auto',
                 display: 'block',
                 ...dressed.imageStyle?.[surface],
+                ...appearance,
               }}
             />
           );
@@ -363,7 +372,11 @@ export function StickerPlacementOverlay({
                 <span
                   aria-hidden
                   className={dressed.behind.className}
-                  style={{ zIndex: -1, ...dressed.behind.style }}
+                  style={{
+                    zIndex: -1,
+                    ...dressed.behind.style,
+                    opacity: placement.data.opacity,
+                  }}
                 />
               )}
 
@@ -373,10 +386,11 @@ export function StickerPlacementOverlay({
                 artworkImage
               )}
 
-              {/* A dashed outline rather than opacity alone. Fading is invisible
-                over busy artwork and reads as a rendering fault over plain
-                artwork, whereas a border is a deliberate mark at any size and
-                against any background. The mild fade stays as a second cue. */}
+              {/* A dashed outline, and now the only mark. Fading was the second
+                cue and could not stay: the placer sets their own opacity, so a
+                dim-for-pending would compound with theirs and be indistinguishable
+                from a sticker they chose to place faint. A border is a deliberate
+                mark at any size and against any background. */}
               {placement.isPending && (
                 <span className="pointer-events-none absolute -inset-1 rounded border-2 border-dashed border-yellow-6" />
               )}

--- a/src/components/Sticker/__tests__/place-button-position.test.ts
+++ b/src/components/Sticker/__tests__/place-button-position.test.ts
@@ -3,6 +3,7 @@ import type { Box } from '~/components/Sticker/place-button-position';
 import {
   candidateDistance,
   flippedButtonOffset,
+  panelBandFor,
   panelsFitInsideEdges,
   placeButtonBoxes,
   shouldFlipPlaceButton,
@@ -129,6 +130,14 @@ describe('panelsFitInsideEdges', () => {
   it('allows it at the sizes the flush layout was designed for', () => {
     expect(panelsFitInsideEdges(144)).toBe(true);
     expect(panelsFitInsideEdges(400)).toBe(true);
+  });
+
+  // The band exists only where the panels do. Clearing one that is not there is
+  // not harmful in itself, but it shrinks the flipped candidate box and so makes
+  // the button decline a flip it could have taken.
+  it('reports no band to clear where no panels are drawn', () => {
+    expect(panelBandFor(51)).toBe(0);
+    expect(panelBandFor(144)).toBe(STICKER_PANEL_BAND_PX);
   });
 });
 

--- a/src/components/Sticker/__tests__/place-button-position.test.ts
+++ b/src/components/Sticker/__tests__/place-button-position.test.ts
@@ -26,13 +26,21 @@ describe('flippedButtonOffset', () => {
   // clearance has to scale with the sticker. A constant is what made the knob
   // dead at the default size, and a constant is what these cases forbid.
   it('scales with the sticker so the button clears the rotate knob', () => {
-    expect(flippedButtonOffset({ stickerHeight: 100, knobOffset: 0.22, gap: 8 })).toBe(30);
-    expect(flippedButtonOffset({ stickerHeight: 300, knobOffset: 0.22, gap: 8 })).toBe(74);
+    expect(
+      flippedButtonOffset({ stickerHeight: 100, knobOffset: 0.22, gap: 8, panelBand: 0 })
+    ).toBe(30);
+    expect(
+      flippedButtonOffset({ stickerHeight: 300, knobOffset: 0.22, gap: 8, panelBand: 0 })
+    ).toBe(74);
   });
 
   it('tracks the knob offset and the gap independently', () => {
-    expect(flippedButtonOffset({ stickerHeight: 100, knobOffset: 0.5, gap: 8 })).toBe(58);
-    expect(flippedButtonOffset({ stickerHeight: 100, knobOffset: 0.22, gap: 20 })).toBe(42);
+    expect(flippedButtonOffset({ stickerHeight: 100, knobOffset: 0.5, gap: 8, panelBand: 0 })).toBe(
+      58
+    );
+    expect(
+      flippedButtonOffset({ stickerHeight: 100, knobOffset: 0.22, gap: 20, panelBand: 0 })
+    ).toBe(42);
   });
 
   it('clears the knob at every size in the measured dead band', () => {
@@ -40,7 +48,7 @@ describe('flippedButtonOffset', () => {
     // the flipped button's bottom sits at -offset. Measured on the real page,
     // heights from ~73 to ~236 put the knob's centre inside the button.
     for (const stickerHeight of [73, 94, 150, 200, 236]) {
-      const offset = flippedButtonOffset({ stickerHeight, knobOffset: 0.22, gap: 8 });
+      const offset = flippedButtonOffset({ stickerHeight, knobOffset: 0.22, gap: 8, panelBand: 0 });
       expect(offset).toBeGreaterThan(0.22 * stickerHeight);
     }
   });
@@ -148,7 +156,12 @@ describe('candidateDistance', () => {
     const stickerHeight = 94;
     const buttonHeight = 52;
     const gap = 8;
-    const flippedOffset = flippedButtonOffset({ stickerHeight, knobOffset: 0.22, gap });
+    const flippedOffset = flippedButtonOffset({
+      stickerHeight,
+      knobOffset: 0.22,
+      gap,
+      panelBand: 0,
+    });
 
     const unflippedTop = stickerHeight + gap;
     const flippedTop = -flippedOffset - buttonHeight;

--- a/src/components/Sticker/__tests__/place-button-position.test.ts
+++ b/src/components/Sticker/__tests__/place-button-position.test.ts
@@ -3,8 +3,11 @@ import type { Box } from '~/components/Sticker/place-button-position';
 import {
   candidateDistance,
   flippedButtonOffset,
+  panelsFitInsideEdges,
   placeButtonBoxes,
   shouldFlipPlaceButton,
+  STICKER_PANEL_BAND_PX,
+  STICKER_PANEL_MIN_WIDTH_PX,
 } from '~/components/Sticker/place-button-position';
 
 /** The real page at 1400x900: tray band, and the carousel viewport that clips. */
@@ -40,6 +43,84 @@ describe('flippedButtonOffset', () => {
       const offset = flippedButtonOffset({ stickerHeight, knobOffset: 0.22, gap: 8 });
       expect(offset).toBeGreaterThan(0.22 * stickerHeight);
     }
+  });
+
+  // The knob is not the only thing up there any more. The two control panels
+  // occupy a band that does NOT scale with the sticker, so on a short one the
+  // knob clearance is the smaller of the two and clearing only it puts the
+  // button over the panels — where it paints last and swallows the pointer, so
+  // flip, opacity and delete are visibly present and completely dead.
+  it('clears the panel band on a sticker too short for the knob to be the obstacle', () => {
+    // 72px: a 2:1 sticker at the DEFAULT 18% scale on an 800px media box. The
+    // knob wants 15.8px of clearance and the panels want 36.
+    const offset = flippedButtonOffset({
+      stickerHeight: 72,
+      knobOffset: 0.22,
+      gap: 8,
+      panelBand: STICKER_PANEL_BAND_PX,
+    });
+
+    expect(offset).toBeGreaterThan(STICKER_PANEL_BAND_PX);
+    expect(offset).toBe(44);
+  });
+
+  it('still clears the knob once the sticker is tall enough for it to win', () => {
+    const stickerHeight = 400;
+    const offset = flippedButtonOffset({
+      stickerHeight,
+      knobOffset: 0.22,
+      gap: 8,
+      panelBand: STICKER_PANEL_BAND_PX,
+    });
+
+    expect(offset).toBeGreaterThan(0.22 * stickerHeight);
+    expect(offset).toBe(96);
+  });
+
+  // Every height in the range a sticker can actually take, against BOTH
+  // obstacles at once — the pair above pins the two regimes, this pins that
+  // there is no gap between them.
+  it('clears both obstacles across the whole scale range', () => {
+    for (const stickerHeight of [20, 51, 72, 100, 127, 150, 236, 400]) {
+      const offset = flippedButtonOffset({
+        stickerHeight,
+        knobOffset: 0.22,
+        gap: 8,
+        panelBand: STICKER_PANEL_BAND_PX,
+      });
+
+      expect(offset).toBeGreaterThan(0.22 * stickerHeight);
+      expect(offset).toBeGreaterThan(STICKER_PANEL_BAND_PX);
+    }
+  });
+});
+
+describe('panelsFitInsideEdges', () => {
+  // Flush with the edges is the intended look, and it is only safe while the
+  // sticker is wide enough that the two panels cannot reach past each other —
+  // the delete button paints last, so an overlap means it lands on the opacity
+  // button and a misclick throws the draft away.
+  it('refuses the flush layout on the sizes where delete would cover opacity', () => {
+    // The 5% scale floor on a 1024px media box, and the default 18% on a
+    // phone-width one. Both are states the product actually produces.
+    expect(panelsFitInsideEdges(51)).toBe(false);
+    expect(panelsFitInsideEdges(65)).toBe(false);
+  });
+
+  // The rotate knob is centred and 16px wide, and the left panel reaches 54px
+  // in: below 124 the knob ends up under it, and the panel swallows the press.
+  it('is bounded by the knob, not merely by the two panels touching', () => {
+    expect(panelsFitInsideEdges(STICKER_PANEL_MIN_WIDTH_PX - 1)).toBe(false);
+    expect(panelsFitInsideEdges(STICKER_PANEL_MIN_WIDTH_PX)).toBe(true);
+    // 92 is where the panels alone stop overlapping (54 + 26 + a gap). Wide
+    // enough for them, still too narrow for the knob — the case a fix aimed at
+    // the panels alone would get wrong.
+    expect(panelsFitInsideEdges(92)).toBe(false);
+  });
+
+  it('allows it at the sizes the flush layout was designed for', () => {
+    expect(panelsFitInsideEdges(144)).toBe(true);
+    expect(panelsFitInsideEdges(400)).toBe(true);
   });
 });
 

--- a/src/components/Sticker/__tests__/placement-cache.test.ts
+++ b/src/components/Sticker/__tests__/placement-cache.test.ts
@@ -21,7 +21,7 @@ const placement = (id: number, imageId: number, isPending = false): PlacedSticke
   ownerId: 602,
   status: isPending ? 'pending' : 'approved',
   amount: 75,
-  data: { cosmeticId: 900, x: 0.5, y: 0.5, scale: 0.2, rotation: 0 },
+  data: { cosmeticId: 900, x: 0.5, y: 0.5, scale: 0.2, rotation: 0, flip: false, opacity: 1 },
   placedAt: new Date('2026-08-12T12:00:00Z'),
   isPending,
 });

--- a/src/components/Sticker/place-button-position.ts
+++ b/src/components/Sticker/place-button-position.ts
@@ -12,6 +12,43 @@ const shift = (box: Box, dx: number, dy: number): Box => ({
 });
 
 /**
+ * The band above the sticker's top edge that the two control panels occupy, in
+ * px, measured from the top edge: they hang 36px up (`-top-9`) and are 26px tall
+ * (a 22px `ActionIcon` in 2px of padding).
+ *
+ * A CONSTANT, unlike everything else above the sticker — that is the whole
+ * hazard. The knob and the flipped button are both sized as a fraction of the
+ * sticker's height, so anything reasoning about "what is above the sticker" from
+ * height alone silently misses these.
+ */
+export const STICKER_PANEL_BAND_PX = 36;
+
+/**
+ * The narrowest sticker whose top edge can host both panels without the rotate
+ * knob ending up underneath one.
+ *
+ * The knob is centred on the top edge and 16px wide, so it spans
+ * `[w/2 - 8, w/2 + 8]`; the left panel (two icons) reaches 54px in from the left
+ * edge. Clear of each other needs `w/2 - 8 >= 54`. Below this, the panels go
+ * outside the corners instead — where they can reach neither the knob nor each
+ * other, whatever the sticker's size.
+ */
+export const STICKER_PANEL_MIN_WIDTH_PX = 124;
+
+/**
+ * Whether the panels can sit flush with the sticker's own edges.
+ *
+ * They are drawn against the edges by design, which reads as bracketing the box
+ * — but on a narrow sticker the two panels reach past each other and the
+ * DESTRUCTIVE one wins, because it paints last: the delete button lands on the
+ * opacity button. At the 5% scale floor that is a 51px-wide sticker, and at the
+ * default 18% on a phone-width media box it is 65px, so this is a default state
+ * rather than an edge case.
+ */
+export const panelsFitInsideEdges = (stickerWidth: number) =>
+  stickerWidth >= STICKER_PANEL_MIN_WIDTH_PX;
+
+/**
  * How far above the sticker the flipped button sits.
  *
  * Not a constant: the rotate knob hangs `knobOffset` of the sticker's height
@@ -19,16 +56,24 @@ const shift = (box: Box, dx: number, dy: number): Box => ({
  * middling sticker size — and because the button's wrapper stops the pointer
  * event, the knob goes dead rather than merely hidden. Measured on the real
  * page: at the default 18% scale the knob's centre was inside the button.
+ *
+ * `panelBand` is the second obstacle and does NOT scale with the sticker, so the
+ * larger of the two is what has to be cleared. Clearing only the knob leaves the
+ * button over the control panels on any sticker shorter than ~127px — where it
+ * paints last and stops the pointer event, so flip, opacity and delete are all
+ * visibly present and completely dead.
  */
 export const flippedButtonOffset = ({
   stickerHeight,
   knobOffset,
   gap,
+  panelBand = 0,
 }: {
   stickerHeight: number;
   knobOffset: number;
   gap: number;
-}) => knobOffset * stickerHeight + gap;
+  panelBand?: number;
+}) => Math.max(knobOffset * stickerHeight, panelBand) + gap;
 
 /**
  * How far apart the two positions are, along the sticker's own axis.

--- a/src/components/Sticker/place-button-position.ts
+++ b/src/components/Sticker/place-button-position.ts
@@ -67,12 +67,17 @@ export const flippedButtonOffset = ({
   stickerHeight,
   knobOffset,
   gap,
-  panelBand = 0,
+  panelBand,
 }: {
   stickerHeight: number;
   knobOffset: number;
   gap: number;
-  panelBand?: number;
+  /**
+   * Required, with no default. The whole bug class here was an obstacle nobody
+   * accounted for, and a caller that forgets this would silently get the old
+   * behaviour back — pass 0 deliberately if a surface truly has no panels.
+   */
+  panelBand: number;
 }) => Math.max(knobOffset * stickerHeight, panelBand) + gap;
 
 /**

--- a/src/components/Sticker/place-button-position.ts
+++ b/src/components/Sticker/place-button-position.ts
@@ -29,9 +29,12 @@ export const STICKER_PANEL_BAND_PX = 36;
  *
  * The knob is centred on the top edge and 16px wide, so it spans
  * `[w/2 - 8, w/2 + 8]`; the left panel (two icons) reaches 54px in from the left
- * edge. Clear of each other needs `w/2 - 8 >= 54`. Below this, the panels go
- * outside the corners instead — where they can reach neither the knob nor each
- * other, whatever the sticker's size.
+ * edge. Clear of each other needs `w/2 - 8 >= 54`. Below this there are no
+ * panels above the sticker at all: the draft's controls move into the buy
+ * cluster, which measures its own position against the tray and the clipping
+ * ancestor. Anchoring them to a small sticker's box fails in both directions —
+ * inside it they reach past each other and the knob, outside it they hang off
+ * the sticker and are clipped away near the edges of the image.
  */
 export const STICKER_PANEL_MIN_WIDTH_PX = 124;
 
@@ -47,6 +50,10 @@ export const STICKER_PANEL_MIN_WIDTH_PX = 124;
  */
 export const panelsFitInsideEdges = (stickerWidth: number) =>
   stickerWidth >= STICKER_PANEL_MIN_WIDTH_PX;
+
+/** The band to clear, which is nothing at all when no panels are drawn. */
+export const panelBandFor = (stickerWidth: number) =>
+  panelsFitInsideEdges(stickerWidth) ? STICKER_PANEL_BAND_PX : 0;
 
 /**
  * How far above the sticker the flipped button sits.

--- a/src/components/Sticker/placement-appearance.ts
+++ b/src/components/Sticker/placement-appearance.ts
@@ -1,0 +1,35 @@
+import type { CSSProperties } from 'react';
+
+/**
+ * The two things the placer chooses about their own sticker, as styles.
+ *
+ * Shared by the draft and the placed sticker so the preview is what gets bought:
+ * a draft dressed differently from the thing it becomes is a preview of something
+ * else, the same reason the treatment is applied to both.
+ *
+ * **Opacity goes on the artwork, and on the plate behind it, and nowhere else.**
+ * Not on the wrapper: that would take the pending placement's dashed outline with
+ * it, and the outline is the whole of "awaiting review" now. The artwork's shadow
+ * and die-cut edge are its own `filter`, so they fade with it — a full-strength
+ * shadow under faint artwork reads as a rendering fault rather than a choice, and
+ * the plate is a surface the sticker sits on, so it belongs to the same object.
+ *
+ * The sway is deliberately untouched. Motion is the cue that survives fading, and
+ * it is what keeps a faint sticker reading as a sticker rather than as part of
+ * the artwork underneath.
+ */
+export function stickerArtworkStyle({
+  flip,
+  opacity,
+}: {
+  flip: boolean;
+  opacity: number;
+}): CSSProperties {
+  return {
+    opacity,
+    // Mirrors the artwork alone. Flipping the positioned wrapper instead would
+    // mirror the rotation with it, so dragging the rotate knob would turn the
+    // sticker the opposite way once flipped.
+    ...(flip ? { transform: 'scaleX(-1)' } : null),
+  };
+}

--- a/src/components/Sticker/treatments/__tests__/sticker-treatments.test.ts
+++ b/src/components/Sticker/treatments/__tests__/sticker-treatments.test.ts
@@ -62,6 +62,16 @@ describe('sticker treatments', () => {
   // anything about the styles. These tests close the paths a treatment is
   // actually written along today; they do not close the space.
 
+  // `transform` belongs to the placer, not to a treatment: the flip is written
+  // as `scaleX(-1)` on the artwork and is spread AFTER `imageStyle`, so a
+  // treatment that set one would have it silently dropped on an unflipped
+  // sticker and silently drop the flip on a flipped one. Same argument as the
+  // pending-look guard above, and the same failure mode — it arrives with a
+  // sixth option written by someone who never read this file.
+  it.each(STICKER_TREATMENT_KEYS)('%s leaves transform to the placer', (key) => {
+    expect(styleText(key)).not.toContain('transform');
+  });
+
   it('covers every declared key, so the table cannot drift from the union', () => {
     expect(Object.keys(STICKER_TREATMENTS).sort()).toEqual([...STICKER_TREATMENT_KEYS].sort());
   });

--- a/src/components/Sticker/treatments/__tests__/sticker-treatments.test.ts
+++ b/src/components/Sticker/treatments/__tests__/sticker-treatments.test.ts
@@ -68,6 +68,12 @@ describe('sticker treatments', () => {
   // sticker and silently drop the flip on a flipped one. Same argument as the
   // pending-look guard above, and the same failure mode — it arrives with a
   // sixth option written by someone who never read this file.
+  //
+  // Inline styles only, deliberately — do NOT add the stylesheet half the way
+  // the pending guard has one. `animationClassName` lands on a wrapper div, not
+  // on the artwork carrying the flip, so a class-based transform cannot clobber
+  // it; and `.motion` is built from transforms, so the symmetric check would
+  // fail on day one against a treatment that is behaving correctly.
   it.each(STICKER_TREATMENT_KEYS)('%s leaves transform to the placer', (key) => {
     expect(styleText(key)).not.toContain('transform');
   });

--- a/src/components/Sticker/treatments/__tests__/sticker-treatments.test.ts
+++ b/src/components/Sticker/treatments/__tests__/sticker-treatments.test.ts
@@ -31,7 +31,7 @@ const stylesheet = readFileSync(
 ).toLowerCase();
 
 describe('sticker treatments', () => {
-  // Pending placements are 60% opacity plus a dashed yellow outline. A treatment
+  // Pending placements are a dashed yellow outline. A treatment
   // that borrows any of that tells an owner they have a decision waiting when
   // they do not. The rule is enforced over the whole table rather than over the
   // options that exist today, because the violation arrives with a sixth option

--- a/src/components/Sticker/treatments/sticker-treatments.ts
+++ b/src/components/Sticker/treatments/sticker-treatments.ts
@@ -45,10 +45,12 @@ const dieCutEdge = (px: number): CSSProperties => ({
 });
 
 /**
- * Distinctness from *pending* is a constraint, not a preference: pending is 60%
- * opacity plus a dashed yellow outline, and a treatment that reads as pending
- * tells an owner they have a decision waiting that they do not. Every option
- * here stays fully opaque and uses no dashes and no yellow — enforced by
+ * Distinctness from *pending* is a constraint, not a preference: pending is a
+ * dashed yellow outline, and a treatment that reads as pending tells an owner
+ * they have a decision waiting that they do not. Every option here stays fully
+ * opaque and uses no dashes and no yellow — fully opaque because opacity now
+ * belongs to the placer, and a treatment that spent some of it would move where
+ * their floor lands. Enforced by
  * `sticker-treatments.test.ts` over both the inline styles here and the
  * stylesheet behind `animationClassName`, because a sixth option added later is
  * exactly when a rule that lives only in comments gets broken.

--- a/src/pages/user/sticker-placements.tsx
+++ b/src/pages/user/sticker-placements.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
 import { EdgeImage } from '~/components/EdgeMedia/EdgeImage';
 import { Meta } from '~/components/Meta/Meta';
+import { stickerArtworkStyle } from '~/components/Sticker/placement-appearance';
 import { StickerPlacementActions } from '~/components/Sticker/StickerPlacementActions';
 import { useStickerCosmetics } from '~/components/Sticker/sticker.util';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
@@ -102,11 +103,18 @@ export default function StickerPlacements() {
                   )}
 
                   {art && (
+                    // Drawn with the placer's own opacity and flip, not at full
+                    // strength. This is the queue an owner is most likely to
+                    // approve from, and it is the small-card review the opacity
+                    // floor exists because of: a faint sticker previewed as
+                    // solid here is approved on the strength of something the
+                    // page never showed. It sits beside the image rather than on
+                    // it, so this is as close to the real thing as the row gets.
                     <EdgeImage
                       src={art.url}
                       alt={`:${art.slug}:`}
                       options={{ height: 96, anim: art.animated, optimized: true }}
-                      style={{ height: 48, width: 'auto' }}
+                      style={{ height: 48, width: 'auto', ...stickerArtworkStyle(row.data) }}
                     />
                   )}
 

--- a/src/pages/user/sticker-placements.tsx
+++ b/src/pages/user/sticker-placements.tsx
@@ -108,14 +108,27 @@ export default function StickerPlacements() {
                     // approve from, and it is the small-card review the opacity
                     // floor exists because of: a faint sticker previewed as
                     // solid here is approved on the strength of something the
-                    // page never showed. It sits beside the image rather than on
-                    // it, so this is as close to the real thing as the row gets.
-                    <EdgeImage
-                      src={art.url}
-                      alt={`:${art.slug}:`}
-                      options={{ height: 96, anim: art.animated, optimized: true }}
-                      style={{ height: 48, width: 'auto', ...stickerArtworkStyle(row.data) }}
-                    />
+                    // page never showed.
+                    //
+                    // Named, and on a checkered plate, because both cost the
+                    // faintness back. A 30% sticker against a flat card reads
+                    // fainter than the same sticker over busy artwork, so the
+                    // honest preview is also the one that is hardest to identify
+                    // — and this row had no other statement of WHICH sticker it
+                    // is. "See it on the image" remains the composite view.
+                    <Stack gap={2} align="center">
+                      <div className="rounded-md bg-gray-2 p-1 dark:bg-dark-5">
+                        <EdgeImage
+                          src={art.url}
+                          alt={`:${art.slug}:`}
+                          options={{ height: 96, anim: art.animated, optimized: true }}
+                          style={{ height: 48, width: 'auto', ...stickerArtworkStyle(row.data) }}
+                        />
+                      </div>
+                      <Text size="10px" c="dimmed" className="max-w-[80px] truncate">
+                        {art.name}
+                      </Text>
+                    </Stack>
                   )}
 
                   <Stack gap={2} className="flex-1">

--- a/src/server/schema/placement.schema.ts
+++ b/src/server/schema/placement.schema.ts
@@ -4,8 +4,11 @@ import { placementSurfaces } from '~/shared/utils/placement';
 import { REMIX_GALLERY_MAX_PINNED } from '~/shared/utils/remix-gallery';
 import {
   STICKER_COMMENT_MAX_LENGTH,
+  STICKER_PLACEMENT_DEFAULT_OPACITY,
+  STICKER_PLACEMENT_MAX_OPACITY,
   STICKER_PLACEMENT_MAX_ROTATION,
   STICKER_PLACEMENT_MAX_SCALE,
+  STICKER_PLACEMENT_MIN_OPACITY,
   STICKER_PLACEMENT_MIN_SCALE,
 } from '~/shared/utils/sticker-placement';
 
@@ -33,6 +36,16 @@ export const stickerPlacementDataSchema = z.object({
     .string()
     .max(STICKER_COMMENT_MAX_LENGTH * 4)
     .optional(),
+  // Refused, not clamped, and refused here rather than at the slider: the floor
+  // is what stops a placement being a quiet defacement, and a client-side clamp
+  // is a filter rather than a refusal — it decides nothing about a crafted
+  // request. Defaulted so a client cached from before these existed still
+  // places a sticker instead of failing validation.
+  flip: z.boolean().default(false),
+  opacity: finite
+    .min(STICKER_PLACEMENT_MIN_OPACITY)
+    .max(STICKER_PLACEMENT_MAX_OPACITY)
+    .default(STICKER_PLACEMENT_DEFAULT_OPACITY),
 });
 
 export const createStickerPlacementSchema = z.object({

--- a/src/server/services/__tests__/sticker-placement.service.test.ts
+++ b/src/server/services/__tests__/sticker-placement.service.test.ts
@@ -423,7 +423,19 @@ describe('what gets written to the row', () => {
           sellerId: SELLER,
           amount: PRICE,
           status: 'pending',
-          data: { cosmeticId: COSMETIC, x: 1, y: 0, scale: 0.2, rotation: 15 },
+          // `flip` and `opacity` are written even though this call omits them:
+          // the row is what every later reader draws from, and a key that is
+          // absent there is one each of those readers has to remember to
+          // default. Full strength and unmirrored is what an omission means.
+          data: {
+            cosmeticId: COSMETIC,
+            x: 1,
+            y: 0,
+            scale: 0.2,
+            rotation: 15,
+            flip: false,
+            opacity: 1,
+          },
         }),
       })
     );

--- a/src/server/services/sticker-placement.service.ts
+++ b/src/server/services/sticker-placement.service.ts
@@ -24,6 +24,7 @@ import {
   isStickerPlacementData,
   normalizeStickerComment,
   normalizeStickerPlacement,
+  parseStickerPlacementData,
   stickerMaxScale,
   stickerRemovableAt,
 } from '~/shared/utils/sticker-placement';
@@ -384,9 +385,7 @@ export async function getStickerPlacementDetail({
 
   // Read off the placement's own payload rather than joined in the query above:
   // `data` is JSON, so the cosmetic id is not a relation Prisma can follow.
-  const data = isStickerPlacementData(placement.data)
-    ? (placement.data as StickerPlacementData)
-    : null;
+  const data = parseStickerPlacementData(placement.data);
   const cosmeticId = data?.cosmeticId ?? null;
 
   const isParty =
@@ -504,13 +503,14 @@ export async function getStickerPlacements({
     orderBy: { createdAt: 'asc' },
   });
 
-  return rows
-    .filter((row) => isStickerPlacementData(row.data))
-    .map((row) => {
-      const data = row.data as StickerPlacementData;
-      const isParty = !!viewerId && (viewerId === row.ownerId || viewerId === row.placerId);
+  return rows.flatMap((row) => {
+    const data = parseStickerPlacementData(row.data);
+    if (!data) return [];
 
-      return {
+    const isParty = !!viewerId && (viewerId === row.ownerId || viewerId === row.placerId);
+
+    return [
+      {
         id: row.id,
         imageId: row.targetId,
         placerId: row.placerId,
@@ -525,8 +525,9 @@ export async function getStickerPlacements({
         data: { ...data, comment: undefined, commentHidden: undefined },
         isPending: row.status === 'pending',
         hasComment: !!visibleStickerComment(data, isParty),
-      };
-    });
+      },
+    ];
+  });
 }
 
 /** Approved placements per image, for the reaction-bar count. */
@@ -858,13 +859,12 @@ export async function getPendingStickerPlacements({
   });
   const byId = new Map(images.map((image) => [image.id, image]));
 
-  return rows
-    .filter((row) => isStickerPlacementData(row.data))
-    .map((row) => ({
-      ...row,
-      data: row.data as StickerPlacementData,
-      image: byId.get(row.targetId) ?? null,
-    }));
+  return rows.flatMap((row) => {
+    const data = parseStickerPlacementData(row.data);
+    if (!data) return [];
+
+    return [{ ...row, data, image: byId.get(row.targetId) ?? null }];
+  });
 }
 
 /**

--- a/src/shared/utils/__tests__/sticker-placement-opacity.test.ts
+++ b/src/shared/utils/__tests__/sticker-placement-opacity.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { stickerPlacementDataSchema } from '~/server/schema/placement.schema';
+import { stickerArtworkStyle } from '~/components/Sticker/placement-appearance';
+import {
+  normalizeStickerPlacement,
+  parseStickerPlacementData,
+  STICKER_PLACEMENT_MIN_OPACITY,
+} from '~/shared/utils/sticker-placement';
+
+/**
+ * The placer's own two settings, and the floor under one of them.
+ *
+ * The floor is not a display preference: a near-invisible sticker is a quiet way
+ * to deface someone's image, it survives an auto-approving creator, and at review
+ * size it looks like nothing and then shows up full-strength. So the refusal is
+ * checked at the schema — the only boundary a crafted request has to cross — and
+ * the clamp is checked at the parse, which is what a row edited by hand reaches.
+ */
+
+const LEGACY = { cosmeticId: 900, x: 0.5, y: 0.5, scale: 0.2, rotation: 15 };
+
+describe('the opacity floor', () => {
+  it('refuses a value under the floor at the schema, rather than clamping it', () => {
+    const result = stickerPlacementDataSchema.safeParse({ ...LEGACY, opacity: 0.05 });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts the floor itself', () => {
+    const result = stickerPlacementDataSchema.safeParse({
+      ...LEGACY,
+      opacity: STICKER_PLACEMENT_MIN_OPACITY,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  // A client cached from before these existed sends neither key. It must still
+  // place a sticker, at full strength, rather than fail validation.
+  it('defaults both keys when a request omits them', () => {
+    const result = stickerPlacementDataSchema.parse(LEGACY);
+
+    expect(result.opacity).toBe(1);
+    expect(result.flip).toBe(false);
+  });
+
+  // The schema is the boundary, not the only guard: `data` is JSON on a row, so a
+  // backfill or a hand-edit reaches the readers without passing through it. A
+  // stored 0 would be a sticker that is invisible and still clickable.
+  it('clamps a stored value that never passed the schema', () => {
+    expect(parseStickerPlacementData({ ...LEGACY, opacity: 0 })?.opacity).toBe(
+      STICKER_PLACEMENT_MIN_OPACITY
+    );
+  });
+});
+
+describe('reading a stored placement', () => {
+  it('fills the defaults for a row written before these existed', () => {
+    const parsed = parseStickerPlacementData(LEGACY);
+
+    expect(parsed).toMatchObject({ opacity: 1, flip: false, rotation: 15 });
+  });
+
+  it('does not drop a legacy row for missing keys', () => {
+    expect(parseStickerPlacementData(LEGACY)).not.toBeNull();
+  });
+
+  it('still refuses a row with no usable position', () => {
+    expect(parseStickerPlacementData({ ...LEGACY, x: 'left' })).toBeNull();
+  });
+
+  // `clamp(undefined, …)` is NaN, which serialises to null and draws nothing.
+  // The write path defaults before it clamps for exactly this reason.
+  it('never produces a NaN opacity from an absent one', () => {
+    const normalized = normalizeStickerPlacement({
+      x: 0.5,
+      y: 0.5,
+      scale: 0.2,
+      rotation: 0,
+      flip: false,
+    } as Parameters<typeof normalizeStickerPlacement>[0]);
+
+    expect(Number.isFinite(normalized.opacity)).toBe(true);
+    expect(normalized.opacity).toBe(1);
+  });
+
+  it('treats a non-boolean flip as unflipped rather than truthy', () => {
+    expect(parseStickerPlacementData({ ...LEGACY, flip: 'yes' })?.flip).toBe(false);
+  });
+});
+
+describe('what the placer chooses, as styles', () => {
+  // Opacity rides on the artwork, whose shadow and die-cut edge are its own
+  // filter, so the two fade together — a full-strength shadow under faint artwork
+  // reads as a rendering fault. The sway is a wrapper and is untouched: motion is
+  // the cue that a faint sticker is still a sticker.
+  it('mirrors the artwork alone, and only when flipped', () => {
+    expect(stickerArtworkStyle({ flip: true, opacity: 1 }).transform).toBe('scaleX(-1)');
+    expect(stickerArtworkStyle({ flip: false, opacity: 1 }).transform).toBeUndefined();
+  });
+
+  it('carries the opacity through unchanged', () => {
+    expect(stickerArtworkStyle({ flip: false, opacity: 0.3 }).opacity).toBe(0.3);
+  });
+});

--- a/src/shared/utils/sticker-placement.ts
+++ b/src/shared/utils/sticker-placement.ts
@@ -201,8 +201,10 @@ export const isStickerPlacementData = (value: unknown): value is StickerPlacemen
  * schema, and a stored `0` would be an invisible sticker that is still clickable.
  *
  * Not every reader: `hideStickerComment` deliberately keeps the raw payload,
- * because it writes the row back and normalising on that path would resize a
- * legacy sticker as a side effect of hiding a note.
+ * because it writes the row back, and a write path that normalises would edit
+ * geometry as a side effect of hiding a note. Only a hand-seeded out-of-bounds
+ * row could actually move today — the schema and the clamp share their limits —
+ * so this is about which path is allowed to rewrite a stored value.
  */
 export const parseStickerPlacementData = (value: unknown): StickerPlacementData | null => {
   if (!isStickerPlacementData(value)) return null;

--- a/src/shared/utils/sticker-placement.ts
+++ b/src/shared/utils/sticker-placement.ts
@@ -32,6 +32,10 @@ export type StickerPlacementData = {
    * backfill.
    */
   commentHidden?: boolean;
+  /** Mirrored horizontally, so a sticker can face into the artwork. */
+  flip: boolean;
+  /** 0.3–1. Floored, never zero — see `STICKER_PLACEMENT_MIN_OPACITY`. */
+  opacity: number;
 };
 
 /**
@@ -48,6 +52,32 @@ export const STICKER_PLACEMENT_MAX_SCALE = 0.4;
 export const STICKER_PLACEMENT_DEFAULT_SCALE = 0.18;
 
 export const STICKER_PLACEMENT_MAX_ROTATION = 180;
+
+/**
+ * How faint a placer may make their own sticker.
+ *
+ * The floor is the point of the setting. A near-invisible sticker is a quiet way
+ * to deface someone's image, and it works against the treatment — the shadow and
+ * the sway exist to make a sticker read as obviously not part of the artwork, and
+ * both disappear along with it. Creator review does not cover the gap either:
+ * auto-approve creators never look, and review happens on a small card where a
+ * very low opacity sticker looks like nothing and then shows up at full size.
+ *
+ * Bounds live here and are enforced in the schema, so a crafted `0.01` is refused
+ * on the way in rather than checked again at each place that draws one.
+ */
+export const STICKER_PLACEMENT_MIN_OPACITY = 0.3;
+export const STICKER_PLACEMENT_MAX_OPACITY = 1;
+
+/**
+ * What a placement means when it does not say.
+ *
+ * Every row written before this existed has neither key, and they were all placed
+ * at full strength and unmirrored. Applied in `parseStickerPlacementData` rather
+ * than at each reader, so a surface added later cannot forget it and draw a
+ * transparent sticker.
+ */
+export const STICKER_PLACEMENT_DEFAULT_OPACITY = 1;
 
 /**
  * What a creator's space allows by default, when they have never set a max.
@@ -91,6 +121,16 @@ export const normalizeStickerPlacement = (
   y: clamp(data.y, 0, 1),
   scale: clamp(data.scale, STICKER_PLACEMENT_MIN_SCALE, STICKER_PLACEMENT_MAX_SCALE),
   rotation: clamp(data.rotation, -STICKER_PLACEMENT_MAX_ROTATION, STICKER_PLACEMENT_MAX_ROTATION),
+  flip: data.flip === true,
+  // Defaulted before it is clamped, because `clamp(undefined)` is NaN and this is
+  // reached by callers the schema's default never passed through — a stored row
+  // on its way through `parseStickerPlacementData`, and anything hand-written.
+  // NaN would be written to the row and drawn as no sticker at all.
+  opacity: clamp(
+    Number.isFinite(data.opacity) ? data.opacity : STICKER_PLACEMENT_DEFAULT_OPACITY,
+    STICKER_PLACEMENT_MIN_OPACITY,
+    STICKER_PLACEMENT_MAX_OPACITY
+  ),
 });
 
 /**
@@ -134,6 +174,11 @@ export const STICKER_REMOVAL_LOCK_HOURS = 24 * 7;
 export const stickerRemovableAt = (approvedAt: Date | string) =>
   new Date(new Date(approvedAt).getTime() + STICKER_REMOVAL_LOCK_HOURS * 60 * 60 * 1000);
 
+/**
+ * `opacity` and `flip` are deliberately not required. Rows written before they
+ * existed carry neither, and demanding them here would drop every one of those
+ * placements from the surfaces that filter on this.
+ */
 export const isStickerPlacementData = (value: unknown): value is StickerPlacementData => {
   if (!value || typeof value !== 'object') return false;
   const data = value as Record<string, unknown>;
@@ -143,6 +188,37 @@ export const isStickerPlacementData = (value: unknown): value is StickerPlacemen
       (key) => typeof data[key] === 'number' && Number.isFinite(data[key] as number)
     )
   );
+};
+
+/**
+ * A stored placement, with the keys it may not have.
+ *
+ * The one way to read `Placement.data`. Readers used to cast the JSON straight to
+ * `StickerPlacementData`, which types a key as present that a row can simply not
+ * have — so a missing `opacity` reached a style as `undefined` and drew nothing.
+ * Clamped as well as defaulted, because this is JSON on a row: a hand-edit or a
+ * backfill reaches it without passing the schema, and a stored `0` would be an
+ * invisible sticker that is still clickable.
+ */
+export const parseStickerPlacementData = (value: unknown): StickerPlacementData | null => {
+  if (!isStickerPlacementData(value)) return null;
+  const data = value as Record<string, unknown>;
+
+  return {
+    // Spread first so the geometry below is authoritative: this carries the note
+    // and its hidden flag through untouched — they are text, not geometry, and
+    // normalising them here would strip them off every row that has one.
+    ...(data as Partial<StickerPlacementData>),
+    cosmeticId: data.cosmeticId as number,
+    ...normalizeStickerPlacement({
+      x: data.x as number,
+      y: data.y as number,
+      scale: data.scale as number,
+      rotation: data.rotation as number,
+      flip: data.flip === true,
+      opacity: data.opacity as number,
+    }),
+  };
 };
 
 /**

--- a/src/shared/utils/sticker-placement.ts
+++ b/src/shared/utils/sticker-placement.ts
@@ -193,12 +193,16 @@ export const isStickerPlacementData = (value: unknown): value is StickerPlacemen
 /**
  * A stored placement, with the keys it may not have.
  *
- * The one way to read `Placement.data`. Readers used to cast the JSON straight to
- * `StickerPlacementData`, which types a key as present that a row can simply not
- * have — so a missing `opacity` reached a style as `undefined` and drew nothing.
- * Clamped as well as defaulted, because this is JSON on a row: a hand-edit or a
- * backfill reaches it without passing the schema, and a stored `0` would be an
- * invisible sticker that is still clickable.
+ * How every surface that DRAWS a placement reads `Placement.data`. Readers used
+ * to cast the JSON straight to `StickerPlacementData`, which types a key as
+ * present that a row can simply not have — so a missing `opacity` reached a
+ * style as `undefined` and drew nothing. Clamped as well as defaulted, because
+ * this is JSON on a row: a hand-edit or a backfill reaches it without passing the
+ * schema, and a stored `0` would be an invisible sticker that is still clickable.
+ *
+ * Not every reader: `hideStickerComment` deliberately keeps the raw payload,
+ * because it writes the row back and normalising on that path would resize a
+ * legacy sticker as a side effect of hiding a note.
  */
 export const parseStickerPlacementData = (value: unknown): StickerPlacementData | null => {
   if (!isStickerPlacementData(value)) return null;

--- a/src/store/sticker-placement-draft.store.ts
+++ b/src/store/sticker-placement-draft.store.ts
@@ -1,8 +1,11 @@
 import { create } from 'zustand';
 import {
+  STICKER_PLACEMENT_DEFAULT_OPACITY,
   STICKER_PLACEMENT_DEFAULT_SCALE,
+  STICKER_PLACEMENT_MAX_OPACITY,
   STICKER_PLACEMENT_MAX_ROTATION,
   STICKER_PLACEMENT_MAX_SCALE,
+  STICKER_PLACEMENT_MIN_OPACITY,
   STICKER_PLACEMENT_MIN_SCALE,
 } from '~/shared/utils/sticker-placement';
 
@@ -22,6 +25,8 @@ export type StickerDraft = {
   y: number;
   scale: number;
   rotation: number;
+  flip: boolean;
+  opacity: number;
 };
 
 /**
@@ -230,6 +235,8 @@ export const useStickerPlacementDraftStore = create<StickerPlacementDraftStore>(
         // the very first gesture with no hint why.
         scale: Math.min(STICKER_PLACEMENT_DEFAULT_SCALE, maxScale ?? STICKER_PLACEMENT_MAX_SCALE),
         rotation: 0,
+        flip: false,
+        opacity: STICKER_PLACEMENT_DEFAULT_OPACITY,
       };
 
       // Appended and selected: the one just dragged out is the one being placed,
@@ -257,6 +264,15 @@ export const useStickerPlacementDraftStore = create<StickerPlacementDraftStore>(
           next.rotation ?? current.rotation,
           -STICKER_PLACEMENT_MAX_ROTATION,
           STICKER_PLACEMENT_MAX_ROTATION
+        ),
+        // Clamped like the rest, though nothing here can overshoot: the slider is
+        // bounded and the flip is a toggle. It matters because the server refuses
+        // rather than clamps below the floor, so a draft that got there some other
+        // way would be refused at the purchase — after the Buzz confirmation.
+        opacity: clamp(
+          next.opacity ?? current.opacity,
+          STICKER_PLACEMENT_MIN_OPACITY,
+          STICKER_PLACEMENT_MAX_OPACITY
         ),
       };
 


### PR DESCRIPTION
## What

The person placing a sticker chooses two more things about it: whether it is mirrored, and how strong it is. Both are set at placement time, alongside position, scale and rotation — they belong to the placer, not the image owner.

- **Flip** is a button. **Opacity** is a slider behind a control, not parked on the artwork, because it is set once and would otherwise be in the way of every later drag.
- The draft's controls are now two panels bracketing the top of the sticker: flip + opacity flush with the left edge, remove flush with the right. Removing a draft throws work away and should not sit beside the controls you press while arranging one.

## The floor is the feature

Opacity bottoms out at **30%**, enforced in the zod schema rather than at the slider. A near-invisible sticker is a quiet way to deface someone's image, and it defeats the treatment — the shadow and the sway exist to make a sticker read as obviously not part of the artwork, and both disappear with it. Creator review does not cover the gap: auto-approve creators never look, and review happens on a small card where a very faint sticker reads as nothing and then shows up at full size. A client-side clamp would be a filter where a refusal is needed.

## Decisions worth knowing

- **Opacity applies to the artwork and its shadow together, and to the plate behind it. The sway is untouched.** A full-strength shadow under faint artwork reads as a rendering fault; motion is the cue that keeps a faint sticker reading as a sticker.
- **Pending no longer draws at 60%.** That dimming compounded with the placer's own value — a 30% placement reaching a review card at 18%, which is exactly what the floor exists to prevent. The dashed outline carries "awaiting review" alone.
- **Rows written before this default to full strength and unmirrored in `parseStickerPlacementData`**, which is now the single way to read `Placement.data`, rather than in each reader. It carries `comment`/`commentHidden` through untouched.
- `hideStickerComment` deliberately keeps the raw guard instead of the parse: it is a read-modify-write of the whole payload, and running it through the parse would rewrite a legacy row's geometry as a side effect of hiding a note.

## Also here

The remix gallery's pending notice linked to `/user/remix-submissions`, which defaults to the `received` tab — the queue of submissions *to* you, which never contains the entry being withdrawn. It now carries `tab=sent`. Its copy drops the owner's username, which wrapped the line in two and repeated what the surrounding page already says.

## Verification

`pnpm run typecheck` clean. Unit suite: the 16 pre-existing failures across 6 files (app-blocks / comics / build-script drift guards) and nothing else; `blocks.router.workflow.test.ts` collects 347. New tests cover the schema refusal at the floor, the parse defaults for legacy rows, the clamp on a stored value that never passed the schema, and that an absent opacity cannot become NaN.