### PR TITLE
fix(model-file): give each caller its own `files` array from the version-file cache

### DIFF
--- a/src/server/services/__tests__/bust-public-model-response-cache.service.test.ts
+++ b/src/server/services/__tests__/bust-public-model-response-cache.service.test.ts
@@ -88,7 +88,9 @@ vi.mock('~/server/services/model.service', () => ({
   ingestModelById: vi.fn(),
   updateModelLastVersionAt: vi.fn(),
 }));
-vi.mock('~/server/services/model-file.service', () => ({ filesForModelVersionCache: {} }));
+vi.mock('~/server/services/model-file.service', () => ({
+  deleteFilesForModelVersionCache: vi.fn(),
+}));
 vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn() }));
 
 import { bustPublicModelResponseCache } from '~/server/services/model-version.service';

--- a/src/server/services/__tests__/model-file.service.test.ts
+++ b/src/server/services/__tests__/model-file.service.test.ts
@@ -18,8 +18,11 @@ vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbRead }
 // live redis connection — these official-file helpers only touch dbRead.
 // `lookupFn` isn't reachable through this stub, so the cache-filter test below calls
 // the exported `fetchModelFilesForCache` directly instead of going through the cache object.
+// `mockCacheFetch` is hoisted so the getFilesForModelVersionCache tests below can drive what
+// the cache hands back (the point of those tests is what the ACCESSOR does to that value).
+const { mockCacheFetch } = vi.hoisted(() => ({ mockCacheFetch: vi.fn() }));
 vi.mock('~/server/utils/cache-helpers', () => ({
-  createCachedObject: () => ({ bust: vi.fn(), fetch: vi.fn(), lookupFn: undefined }),
+  createCachedObject: () => ({ bust: vi.fn(), fetch: mockCacheFetch, lookupFn: undefined }),
 }));
 vi.mock('~/server/cloudflare/client', () => ({ purgeCache: vi.fn() }));
 vi.mock('~/server/redis/client', () => ({
@@ -32,6 +35,7 @@ import {
   markFileReplaced,
   restoreReplacedFile,
   fetchModelFilesForCache,
+  getFilesForModelVersionCache,
 } from '~/server/services/model-file.service';
 import { constants } from '~/server/common/constants';
 import { ModelFileVisibility } from '~/shared/utils/prisma/enums';
@@ -234,5 +238,112 @@ describe('fetchModelFilesForCache', () => {
     await fetchModelFilesForCache([10]);
     const arg = mockDbRead.modelFile.findMany.mock.calls[0][0];
     expect(arg.where).toMatchObject({ modelVersionId: { in: [10] }, replacedAt: null });
+  });
+});
+
+/**
+ * REGRESSION — the accessor must not hand a caller a `files` array that is shared with the
+ * cache layer.
+ *
+ * `createCachedArray` (packages/civitai-redis/src/cached-array.ts) only ever SHALLOW-clones a
+ * record before handing it out, and documents that nested refs stay shared: "shallow only
+ * protects TOP-LEVEL fields … consumers MUST treat returned values as read-only for nested
+ * fields". The healthy Redis path is fine — each hit msgpack-decodes a fresh object. The live
+ * sharing path is the FAIL-OPEN DEGRADED fetch: its per-id single-flight resolves ONE record
+ * for every caller that joins the in-flight lookup, so all of them end up holding the same
+ * `files` array. (An L1 hit would share it too, but this cache sets no `localTtl`.)
+ * `getModelsWithVersions` does `files.push(...vaeFile)` on that array, so without a copy one
+ * request's VAE append is visible to every other request sharing the flight.
+ *
+ * These tests drive the cache mock to return records that share ONE nested array — exactly
+ * what the degraded path produces — and assert the accessor isolates the caller from it.
+ * Before the fix the accessor returned `filesForModelVersionCache.fetch(...)` verbatim.
+ */
+describe('getFilesForModelVersionCache — nested files array is caller-owned', () => {
+  beforeEach(() => mockCacheFetch.mockReset());
+
+  // One record object reused across fetches, as an L1 hit / degraded single-flight would.
+  function sharedCacheSource() {
+    const cached = {
+      '42': { modelVersionId: 42, files: [{ id: 1, name: 'base.safetensors' }] },
+    };
+    mockCacheFetch.mockImplementation(async () => ({ '42': { ...cached['42'] } }));
+    return cached;
+  }
+
+  it('returns a files array that is NOT the cached record’s array', async () => {
+    const cached = sharedCacheSource();
+    const result = await getFilesForModelVersionCache([42]);
+    expect(result['42'].files).toEqual(cached['42'].files);
+    expect(result['42'].files).not.toBe(cached['42'].files);
+  });
+
+  it('appending a VAE file does not leak into a later read (the getModelsWithVersions path)', async () => {
+    const cached = sharedCacheSource();
+
+    const first = await getFilesForModelVersionCache([42]);
+    expect(first['42'].files).toHaveLength(1);
+    // exactly what model.service.ts getModelsWithVersions does with the linked VAE
+    first['42'].files.push({ id: 999, name: 'linked.vae.safetensors' });
+
+    const second = await getFilesForModelVersionCache([42]);
+    expect(second['42'].files).toHaveLength(1);
+    expect(second['42'].files.map((f) => f.name)).toEqual(['base.safetensors']);
+    expect(cached['42'].files).toHaveLength(1);
+  });
+
+  it('isolates two concurrent callers from each other (degraded single-flight shape)', async () => {
+    const shared = { modelVersionId: 42, files: [{ id: 1, name: 'base.safetensors' }] };
+    // The degraded path awaits ONE promise per id and shallow-clones it per caller, so every
+    // caller's record carries the SAME nested array. Model that exactly.
+    mockCacheFetch.mockImplementation(async () => ({ '42': { ...shared } }));
+
+    const [a, b] = await Promise.all([
+      getFilesForModelVersionCache([42]),
+      getFilesForModelVersionCache([42]),
+    ]);
+    expect(a['42'].files).not.toBe(b['42'].files);
+
+    a['42'].files.push({ id: 999, name: 'linked.vae.safetensors' });
+    expect(b['42'].files).toHaveLength(1);
+  });
+
+  it('preserves the record shape and the file contents', async () => {
+    sharedCacheSource();
+    const result = await getFilesForModelVersionCache([42]);
+    expect(Object.keys(result)).toEqual(['42']);
+    expect(result['42']).toEqual({
+      modelVersionId: 42,
+      files: [{ id: 1, name: 'base.safetensors' }],
+    });
+  });
+
+  // EVERY record must be isolated, not just the first one the map happens to visit — a
+  // batched fetch is the normal shape here (a feed page hydrates ~100 version ids at once).
+  it('isolates every record in a multi-id batch, not only the first', async () => {
+    const cached = {
+      '42': { modelVersionId: 42, files: [{ id: 1, name: 'a.safetensors' }] },
+      '43': { modelVersionId: 43, files: [{ id: 2, name: 'b.safetensors' }] },
+      '44': { modelVersionId: 44, files: [{ id: 3, name: 'c.safetensors' }] },
+    };
+    mockCacheFetch.mockImplementation(async () =>
+      Object.fromEntries(Object.entries(cached).map(([k, v]) => [k, { ...v }]))
+    );
+
+    const result = await getFilesForModelVersionCache([42, 43, 44]);
+    expect(Object.keys(result)).toEqual(['42', '43', '44']);
+    for (const id of ['42', '43', '44'] as const) {
+      expect(result[id].files).not.toBe(cached[id].files);
+      result[id].files.push({ id: 999, name: 'linked.vae.safetensors' });
+      expect(cached[id].files).toHaveLength(1);
+    }
+  });
+
+  // The copy is guarded so a record that somehow carries no `files` array keeps its shape
+  // rather than throwing on a public-API read path.
+  it('passes through a record with no files array instead of throwing', async () => {
+    mockCacheFetch.mockImplementation(async () => ({ '42': { modelVersionId: 42 } }));
+    const result = await getFilesForModelVersionCache([42]);
+    expect(result['42']).toEqual({ modelVersionId: 42 });
   });
 });

--- a/src/server/services/__tests__/model-file.service.test.ts
+++ b/src/server/services/__tests__/model-file.service.test.ts
@@ -306,8 +306,13 @@ describe('getFilesForModelVersionCache — nested files array is caller-owned', 
 
     const first = await getFilesForModelVersionCache([42]);
     expect(first['42'].files).toHaveLength(1);
-    // exactly what model.service.ts getModelsWithVersions does with the linked VAE
-    first['42'].files.push({ id: 999, name: 'linked.vae.safetensors' });
+    // exactly what model.service.ts getModelsWithVersions does with the linked VAE.
+    // 🔴 `as unknown[]` on the ARRAY, not `as never` on the element and not `any`: `files` is
+    // typed as the full Prisma-derived model-file row, and these fixtures are deliberately
+    // two-field stubs — identity is all these tests read. Widening the receiver keeps the cast
+    // to the push call alone, so every other read of `files` in this file stays fully typed
+    // (same pattern as the H2b block in `cache-helpers-failopen.test.ts`).
+    (first['42'].files as unknown[]).push({ id: 999, name: 'linked.vae.safetensors' });
 
     const second = await getFilesForModelVersionCache([42]);
     expect(second['42'].files).toHaveLength(1);
@@ -327,7 +332,7 @@ describe('getFilesForModelVersionCache — nested files array is caller-owned', 
     ]);
     expect(a['42'].files).not.toBe(b['42'].files);
 
-    a['42'].files.push({ id: 999, name: 'linked.vae.safetensors' });
+    (a['42'].files as unknown[]).push({ id: 999, name: 'linked.vae.safetensors' });
     expect(b['42'].files).toHaveLength(1);
   });
 
@@ -357,7 +362,7 @@ describe('getFilesForModelVersionCache — nested files array is caller-owned', 
     expect(Object.keys(result)).toEqual(['42', '43', '44']);
     for (const id of ['42', '43', '44'] as const) {
       expect(result[id].files).not.toBe(cached[id].files);
-      result[id].files.push({ id: 999, name: 'linked.vae.safetensors' });
+      (result[id].files as unknown[]).push({ id: 999, name: 'linked.vae.safetensors' });
       expect(cached[id].files).toHaveLength(1);
     }
   });

--- a/src/server/services/__tests__/model-file.service.test.ts
+++ b/src/server/services/__tests__/model-file.service.test.ts
@@ -29,6 +29,7 @@ vi.mock('~/server/redis/client', () => ({
   REDIS_KEYS: { CACHES: { FILES_FOR_MODEL_VERSION: 'files-for-model-version' } },
 }));
 
+import * as modelFileService from '~/server/services/model-file.service';
 import {
   hasOfficialFileOfSize,
   findOfficialFileByHash,
@@ -242,23 +243,45 @@ describe('fetchModelFilesForCache', () => {
 });
 
 /**
- * REGRESSION — the accessor must not hand a caller a `files` array that is shared with the
- * cache layer.
+ * ACCESSOR CONTRACT — the accessor must not hand a caller a `files` array that is shared with
+ * the cache layer.
  *
- * `createCachedArray` (packages/civitai-redis/src/cached-array.ts) only ever SHALLOW-clones a
- * record before handing it out, and documents that nested refs stay shared: "shallow only
- * protects TOP-LEVEL fields … consumers MUST treat returned values as read-only for nested
- * fields". The healthy Redis path is fine — each hit msgpack-decodes a fresh object. The live
- * sharing path is the FAIL-OPEN DEGRADED fetch: its per-id single-flight resolves ONE record
- * for every caller that joins the in-flight lookup, so all of them end up holding the same
- * `files` array. (An L1 hit would share it too, but this cache sets no `localTtl`.)
- * `getModelsWithVersions` does `files.push(...vaeFile)` on that array, so without a copy one
- * request's VAE append is visible to every other request sharing the flight.
+ * 🔴 READ THIS BEFORE TRUSTING THE COVERAGE BELOW. These tests drive a MOCKED
+ * `createCachedObject` (see the wholesale `~/server/utils/cache-helpers` mock at the top of this
+ * file) and hand-construct the aliasing they then assert against. That makes them a contract test
+ * for THIS FUNCTION — they would pass against a completely broken cache layer and fail against a
+ * fixed one, because the cache layer is not present.
  *
- * These tests drive the cache mock to return records that share ONE nested array — exactly
- * what the degraded path produces — and assert the accessor isolates the caller from it.
- * Before the fix the accessor returned `filesForModelVersionCache.fetch(...)` verbatim.
+ * The REAL degraded window — rejecting `mGet` → genuine fail-open → genuine per-id single-flight
+ * joined by two callers → the real `lookupFn` → the real accessor — is driven in the "H2b" block
+ * of `src/server/utils/__tests__/cache-helpers-failopen.test.ts`. That is where the hazard is
+ * OBSERVED; this block only pins the accessor's own behaviour.
+ *
+ * Why the accessor copies at all: `createCachedArray`
+ * (`packages/civitai-redis/src/cached-array.ts`) only ever SHALLOW-clones a record before handing
+ * it out, and documents that nested refs stay shared — "shallow only protects TOP-LEVEL fields …
+ * consumers MUST treat returned values as read-only for nested fields". The one consumer that
+ * mutated the array (`getModelsWithVersions` doing `files.push(...vaeFile)`) has been fixed to
+ * build a new array instead, so the copy here is FORWARD-PROTECTION for the next consumer, not a
+ * fix for a live mutator.
  */
+/**
+ * The cache object itself must stay module-private, so the caller-owned-`files` contract cannot be
+ * bypassed by reaching past the accessor. This reads the module's ACTUAL export namespace (not the
+ * source text), so it fails the moment an `export` keyword is put back on it — which is the only
+ * way the bypass can reappear.
+ */
+describe('module export surface', () => {
+  it('does NOT export the raw filesForModelVersionCache — reads go through the accessor', () => {
+    const exports = Object.keys(modelFileService);
+    // positive control: the accessor/wrapper pair IS exported, so an empty/undefined namespace
+    // cannot make the negative assertion below pass vacuously.
+    expect(exports).toContain('getFilesForModelVersionCache');
+    expect(exports).toContain('deleteFilesForModelVersionCache');
+    expect(exports).not.toContain('filesForModelVersionCache');
+  });
+});
+
 describe('getFilesForModelVersionCache — nested files array is caller-owned', () => {
   beforeEach(() => mockCacheFetch.mockReset());
 
@@ -339,9 +362,16 @@ describe('getFilesForModelVersionCache — nested files array is caller-owned', 
     }
   });
 
-  // The copy is guarded so a record that somehow carries no `files` array keeps its shape
-  // rather than throwing on a public-API read path.
-  it('passes through a record with no files array instead of throwing', async () => {
+  // 🔴 INVARIANT GUARD, NOT REGRESSION COVERAGE. With the real cache this state is UNREACHABLE:
+  // `lookupFn` always initialises `files: []` (model-file.service.ts), and marker records
+  // (`notFound`/`debounce`) are `continue`d inside the cache layer before they can be returned
+  // (packages/civitai-redis/src/cached-array.ts). So the `Array.isArray` guard cannot fire in
+  // production, and this test only pins a shape the MOCK above can produce. It is kept because a
+  // future cache-layer or lookupFn change could make the state reachable, and because throwing on
+  // a hot public-API read path is a worse failure than passing the record through — but it must
+  // not be counted as evidence of a demonstrated hazard, and in a mutation battery it is the sole
+  // kill for the guard-removal mutant, i.e. that arm scores against an unreachable state.
+  it('INVARIANT GUARD (unreachable with the real cache): passes through a record with no files array instead of throwing', async () => {
     mockCacheFetch.mockImplementation(async () => ({ '42': { modelVersionId: 42 } }));
     const result = await getFilesForModelVersionCache([42]);
     expect(result['42']).toEqual({ modelVersionId: 42 });

--- a/src/server/services/__tests__/model-version.blue-buzz-purchase.service.test.ts
+++ b/src/server/services/__tests__/model-version.blue-buzz-purchase.service.test.ts
@@ -82,7 +82,7 @@ vi.mock('~/server/services/model.service', () => ({
   updateModelLastVersionAt: vi.fn(),
 }));
 vi.mock('~/server/services/model-file.service', () => ({
-  filesForModelVersionCache: {},
+  deleteFilesForModelVersionCache: vi.fn(),
   findOfficialFileByHash: vi.fn(),
 }));
 vi.mock('~/server/services/monetization-rights.service', () => ({

--- a/src/server/services/__tests__/model-version.deregister.service.test.ts
+++ b/src/server/services/__tests__/model-version.deregister.service.test.ts
@@ -79,7 +79,9 @@ vi.mock('~/server/services/paid-access.service', () => ({
   earlyAccessDonationGoalFromLegacyConfig: vi.fn(() => null),
   earlyAccessConfigFromPaidAccess: vi.fn(),
 }));
-vi.mock('~/server/services/model-file.service', () => ({ filesForModelVersionCache: {} }));
+vi.mock('~/server/services/model-file.service', () => ({
+  deleteFilesForModelVersionCache: vi.fn(),
+}));
 vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn() }));
 vi.mock('~/server/db/db-lag-helpers', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();

--- a/src/server/services/__tests__/model-version.donation-goals-cache.service.test.ts
+++ b/src/server/services/__tests__/model-version.donation-goals-cache.service.test.ts
@@ -75,7 +75,9 @@ vi.mock('~/server/services/model.service', () => ({
   ingestModelById: vi.fn(),
   updateModelLastVersionAt: vi.fn(),
 }));
-vi.mock('~/server/services/model-file.service', () => ({ filesForModelVersionCache: {} }));
+vi.mock('~/server/services/model-file.service', () => ({
+  deleteFilesForModelVersionCache: vi.fn(),
+}));
 vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn() }));
 
 import { modelVersionDonationGoal } from '~/server/services/model-version.service';

--- a/src/server/services/__tests__/model-version.idempotent.service.test.ts
+++ b/src/server/services/__tests__/model-version.idempotent.service.test.ts
@@ -117,7 +117,9 @@ vi.mock('~/server/services/model.service', () => ({
   ingestModelById: vi.fn(),
   updateModelLastVersionAt: vi.fn(),
 }));
-vi.mock('~/server/services/model-file.service', () => ({ filesForModelVersionCache: {} }));
+vi.mock('~/server/services/model-file.service', () => ({
+  deleteFilesForModelVersionCache: vi.fn(),
+}));
 vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn() }));
 
 import {

--- a/src/server/services/__tests__/model-version.linked-component.service.test.ts
+++ b/src/server/services/__tests__/model-version.linked-component.service.test.ts
@@ -53,7 +53,7 @@ vi.mock('~/server/services/model.service', () => ({
   updateModelLastVersionAt: vi.fn(),
 }));
 vi.mock('~/server/services/model-file.service', () => ({
-  filesForModelVersionCache: {},
+  deleteFilesForModelVersionCache: vi.fn(),
   markFileReplaced: mockMarkReplaced,
 }));
 // Keep the real paid-access module (which reads REDIS_KEYS.CACHES.PAID_ACCESS at import) out of the graph.

--- a/src/server/services/__tests__/model-version.purge-by-hash.service.test.ts
+++ b/src/server/services/__tests__/model-version.purge-by-hash.service.test.ts
@@ -95,7 +95,7 @@ vi.mock('~/server/services/model.service', () => ({
   updateModelLastVersionAt: vi.fn(),
 }));
 vi.mock('~/server/services/model-file.service', () => ({
-  filesForModelVersionCache: {},
+  deleteFilesForModelVersionCache: vi.fn(),
   findOfficialFileByHash: vi.fn(),
   markFileReplaced: vi.fn(),
 }));

--- a/src/server/services/__tests__/model.service.vae-append-no-mutation.test.ts
+++ b/src/server/services/__tests__/model.service.vae-append-no-mutation.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type * as RedisClient from '~/server/redis/client';
+
+/**
+ * 🔴 CALL-SITE coverage for the VAE-append mutation — the half of this fix that the
+ * accessor tests structurally CANNOT see.
+ *
+ * `getModelsWithVersions` used to do `groupedFiles[version.id].files.push(...vaeFile)` on an
+ * array owned by the version-file cache layer. Two independent things now stop that leaking:
+ *
+ *   (a) the call site builds a NEW array (`model.service.ts`), and
+ *   (b) `getFilesForModelVersionCache` hands every caller its own copy
+ *       (`model-file.service.ts`).
+ *
+ * Either one alone is sufficient, which is exactly the problem: with (b) in place, reverting
+ * (a) is unobservable to every other test in the tree, so nothing pins the call site. Whoever
+ * later concludes the accessor copy is redundant — e.g. while landing the deep-clone proposed
+ * in issue #3872 — would delete (b) and silently restore the bug.
+ *
+ * This suite closes that circle. It mocks `getFilesForModelVersionCache` to return the RAW,
+ * cache-owned array with no copy at all — i.e. it removes (b) — so the only thing that can keep
+ * the caller's array intact is (a). Restoring the `push` at the call site turns the last
+ * assertion red.
+ *
+ * It drives the REAL `getModelsWithVersions`; only its I/O surfaces are stubbed. See
+ * `get-models-raw.transient-503.test.ts` for the same import-the-real-model.service scaffold
+ * and why these particular modules must be stubbed (Prisma/redis clients instantiate at module
+ * load; `image.service` breaks the `event-engine-common` submodule chain).
+ *
+ * 🔴 STATIC import, deliberately — `model.service` is a ~5000-line module whose cold transform
+ * would otherwise be charged to one test's `testTimeout`. See that file's header.
+ */
+
+const VERSION_ID = 42;
+const VAE_VERSION_ID = 77;
+const MODEL_ID = 7;
+const USER_ID = 5;
+
+const { mockDbRead, mockGetFilesForModelVersionCache, mockCancellableQuery } = vi.hoisted(() => ({
+  mockDbRead: {
+    recommendedResource: { findMany: vi.fn() },
+    modelFile: { findMany: vi.fn() },
+    modelMetric: { findMany: vi.fn() },
+    modelVersionMetric: { findMany: vi.fn() },
+    modelVersion: { findMany: vi.fn() },
+    $queryRaw: vi.fn(),
+  },
+  mockGetFilesForModelVersionCache: vi.fn(),
+  mockCancellableQuery: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbRead }));
+vi.mock('~/server/db/pgDb', () => ({
+  pgDbRead: { cancellableQuery: mockCancellableQuery },
+  pgDbWrite: {},
+  pgDbReadLong: {},
+}));
+
+// THE SEAM. Returning the cache's own array (no copy) is the whole point — it models the
+// accessor with its forward-protection removed, so this suite grades the CALL SITE alone.
+vi.mock('~/server/services/model-file.service', () => ({
+  getFilesForModelVersionCache: mockGetFilesForModelVersionCache,
+  deleteFilesForModelVersionCache: vi.fn(),
+}));
+
+vi.mock('~/server/services/image.service', () => ({
+  getImagesForModelVersion: vi.fn(),
+  getImagesForModelVersionCache: vi.fn().mockResolvedValue({}),
+  queueImageSearchIndexUpdate: vi.fn(),
+}));
+vi.mock('~/server/flipt/client', () => ({ isFlipt: vi.fn().mockResolvedValue(false) }));
+vi.mock('~/server/services/blocked-browsing-tags.service', () => ({
+  enforceBlockedBrowsingTagsForModels: vi.fn().mockResolvedValue({ emptyResult: false }),
+}));
+vi.mock('~/server/services/paid-access.service', () => ({
+  getPaidAccess: vi.fn(),
+  getPublicPaidAccessForModelVersions: vi.fn().mockResolvedValue({}),
+}));
+vi.mock('~/server/services/creator-program.service', () => ({
+  getValidCreatorMembershipMap: vi.fn().mockResolvedValue(new Map()),
+  getUserMetricPrivacyDefaultsMap: vi.fn().mockResolvedValue(new Map()),
+}));
+vi.mock('~/server/services/user.service', () => ({
+  deleteBasicDataForUser: vi.fn(),
+  getCosmeticsForUsers: vi.fn().mockResolvedValue({}),
+  getProfilePicturesForUsers: vi.fn().mockResolvedValue({}),
+}));
+vi.mock('~/server/services/cosmetic.service', () => ({ getCosmeticsForEntity: vi.fn() }));
+vi.mock('~/server/redis/caches', () => ({
+  dataForModelsCache: { fetch: vi.fn() },
+  modelTagCache: { fetch: vi.fn(), bust: vi.fn() },
+  modelVotableTagsCache: { fetch: vi.fn(), bust: vi.fn() },
+  userBasicCache: { fetch: vi.fn().mockResolvedValue({}), bust: vi.fn() },
+  userModelCountCache: { fetch: vi.fn(), bust: vi.fn() },
+}));
+vi.mock('~/server/redis/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof RedisClient>();
+  return {
+    ...actual,
+    redis: { packed: { get: async () => null, set: async () => undefined } },
+    sysRedis: {},
+  };
+});
+
+import { getModelsWithVersions } from '~/server/services/model.service';
+import { dataForModelsCache } from '~/server/redis/caches';
+
+/** One primary file, as the version-file cache stores it. */
+function baseFile() {
+  return {
+    id: 1,
+    name: 'base.safetensors',
+    type: 'Model',
+    modelVersionId: VERSION_ID,
+    metadata: {},
+    hashes: [],
+  };
+}
+
+/** The linked VAE, which `getVaeFiles` reads straight from the DB (NOT from the cache). */
+function vaeFileRow() {
+  return {
+    id: 900,
+    name: 'linked.vae.safetensors',
+    type: 'Model',
+    modelVersionId: VAE_VERSION_ID,
+    metadata: {},
+    hashes: [],
+  };
+}
+
+/**
+ * Wire every I/O surface `getModelsWithVersions` touches for a one-model / one-version read
+ * whose version has a linked VAE. Returns the array handed to the service as the cached
+ * record's `files` — the object whose identity the assertions are about.
+ */
+function primeOneModelWithALinkedVae() {
+  const cacheOwnedFiles = [baseFile()];
+
+  mockCancellableQuery.mockResolvedValue({
+    result: async () => [
+      {
+        id: MODEL_ID,
+        userId: USER_ID,
+        name: 'Boogu',
+        cursorId: null,
+        meta: null,
+        rank: {
+          downloadCount: 0,
+          thumbsUpCount: 0,
+          thumbsDownCount: 0,
+          commentCount: 0,
+          collectedCount: 0,
+          tippedAmountCount: 0,
+        },
+      },
+    ],
+  });
+
+  vi.mocked(dataForModelsCache.fetch).mockResolvedValue({
+    [MODEL_ID]: {
+      hashes: [],
+      tags: [],
+      versions: [
+        {
+          id: VERSION_ID,
+          name: 'v1',
+          status: 'Published',
+          baseModel: 'SD 1.5',
+          nsfwLevel: 1,
+          availability: 'Public',
+          covered: true,
+          trainingStatus: null,
+          earlyAccessTimeFrame: 0,
+        },
+      ],
+    },
+  } as never);
+
+  mockDbRead.$queryRaw.mockResolvedValue([]); // getModelEarlyAccessDeadlines
+  mockDbRead.modelMetric.findMany.mockResolvedValue([]);
+  mockDbRead.modelVersionMetric.findMany.mockResolvedValue([]);
+  mockDbRead.modelVersion.findMany.mockResolvedValue([{ id: VERSION_ID, meta: null }]);
+
+  // The linked-component row that makes this version resolve a VAE.
+  mockDbRead.recommendedResource.findMany.mockResolvedValue([
+    {
+      sourceId: VERSION_ID,
+      resourceId: VAE_VERSION_ID,
+      settings: { isLinkedComponent: true, componentType: 'VAE' },
+    },
+  ]);
+  // getVaeFiles' own read.
+  mockDbRead.modelFile.findMany.mockResolvedValue([vaeFileRow()]);
+
+  mockGetFilesForModelVersionCache.mockResolvedValue({
+    [VERSION_ID]: { modelVersionId: VERSION_ID, files: cacheOwnedFiles },
+  });
+
+  return cacheOwnedFiles;
+}
+
+function callGetModelsWithVersions() {
+  return getModelsWithVersions({
+    input: { browsingLevel: 1, take: 10, period: 'AllTime' } as never,
+    user: { id: USER_ID, isModerator: true },
+  });
+}
+
+describe('getModelsWithVersions — the linked-VAE append does NOT mutate the cache-owned files array', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('POSITIVE CONTROL: the linked VAE really is appended to the returned version', async () => {
+    primeOneModelWithALinkedVae();
+    const { items } = await callGetModelsWithVersions();
+
+    // Without this, the isolation assertion below could pass simply because no VAE was ever
+    // resolved (a broken mock chain reads exactly like a correct call site).
+    expect(items).toHaveLength(1);
+    expect(items[0].modelVersions[0].files.map((f) => f.name)).toEqual([
+      'base.safetensors',
+      'linked.vae.safetensors',
+    ]);
+  });
+
+  it('leaves the array it was handed UNCHANGED (kills the `files.push(...vaeFile)` mutant)', async () => {
+    const cacheOwnedFiles = primeOneModelWithALinkedVae();
+    expect(cacheOwnedFiles).toHaveLength(1); // sanity: one file before the call
+
+    await callGetModelsWithVersions();
+
+    // 🔴 The regression. `getFilesForModelVersionCache` is stubbed here to hand back the
+    // cache's OWN array, so the accessor's defensive copy is out of the picture: if this array
+    // grew, the call site mutated a value it does not own. In production that array is shared
+    // by every caller joined to the same degraded single-flight, so the VAE would leak into
+    // `generation.service` and `modelFile.getByVersionId`, and — via the 180s origin response
+    // cache on the v1 models endpoint — into every later reader of that model id.
+    expect(cacheOwnedFiles.map((f) => f.name)).toEqual(['base.safetensors']);
+    expect(cacheOwnedFiles).toHaveLength(1);
+  });
+
+  // NOTE: there is deliberately NO `expect(items[0].modelVersions[0].files).not.toBe(cached)`
+  // assertion here. The returned `files` is the output of a `.map()` over the list, so it is a
+  // freshly allocated array on every path — that assertion passes even with the `push` mutant
+  // restored (measured), i.e. it is vacuous. The array identity that matters is the INPUT one,
+  // which is what the test above pins.
+});

--- a/src/server/services/model-file.service.ts
+++ b/src/server/services/model-file.service.ts
@@ -93,6 +93,13 @@ export function reduceToBasicFileMetadata(
  * now builds a new array (`model.service.ts`). So no caller in the tree mutates the returned
  * `files` today, and this copy is deliberately kept as belt-and-braces for the NEXT one.
  *
+ * 🔴 That does NOT make the two halves circular. The call site is pinned INDEPENDENTLY of this
+ * copy by `model.service.vae-append-no-mutation.test.ts`, which stubs this accessor to hand back
+ * the raw cache-owned array — the copy removed — so restoring the `push` turns it red on its own.
+ * Deleting this copy is therefore a real decision, not a no-op, and one that must be argued
+ * against the cache layer's own contract below (relevant if the deep-clone in issue #3872 lands:
+ * a clone THERE would make this copy redundant, but only once it is actually in place).
+ *
  * What it protects against is the shared cache layer, whose contract is genuinely unsafe here:
  * `createCachedArray` only ever SHALLOW-clones a record before handing it out, and says so —
  * "shallow only protects TOP-LEVEL fields — nested refs are shared … consumers MUST treat

--- a/src/server/services/model-file.service.ts
+++ b/src/server/services/model-file.service.ts
@@ -49,7 +49,13 @@ export async function fetchModelFilesForCache(ids: number[]) {
     );
 }
 
-export const filesForModelVersionCache = createCachedObject({
+/**
+ * NOT EXPORTED — on purpose. Every read must go through `getFilesForModelVersionCache` (which
+ * hands back a caller-owned `files` array) and every bust through
+ * `deleteFilesForModelVersionCache`. Keeping the cache object module-private makes bypassing
+ * the accessor structurally impossible rather than merely discouraged by a comment.
+ */
+const filesForModelVersionCache = createCachedObject({
   key: REDIS_KEYS.CACHES.FILES_FOR_MODEL_VERSION,
   idKey: 'modelVersionId',
   ttl: CacheTTL.day,
@@ -82,35 +88,44 @@ export function reduceToBasicFileMetadata(
  * Read the per-version file lists, returning records whose nested `files` array is the
  * CALLER'S OWN — safe to append to, sort, or splice.
  *
- * 🔴 WHY THE COPY. `createCachedArray` only ever SHALLOW-clones a record before handing it
- * out, and says so: "shallow only protects TOP-LEVEL fields — nested refs are shared …
- * consumers MUST treat returned values as read-only for nested fields"
- * (`packages/civitai-redis/src/cached-array.ts`). So the contract the cache offers is
- * read-only-for-`files`, while `getModelsWithVersions` appends the linked VAE file to
- * exactly that array. This function is the seam that converts one contract into the other.
+ * 🔴 THE COPY IS FORWARD-PROTECTION, NOT A FIX FOR A LIVE MUTATOR. The one mutator that
+ * existed — `getModelsWithVersions` doing `files.push(...vaeFile)` — is gone; that call site
+ * now builds a new array (`model.service.ts`). So no caller in the tree mutates the returned
+ * `files` today, and this copy is deliberately kept as belt-and-braces for the NEXT one.
  *
- * The healthy Redis path is NOT the concern — every hit msgpack-decodes a fresh object per
- * read, so nothing is shared there. The live sharing path is the FAIL-OPEN DEGRADED fetch
- * (taken whenever a cluster read rejects): its per-id single-flight resolves ONE record for
- * every caller that joins the in-flight lookup, and the shallow clone it then makes leaves
- * every one of those callers holding the SAME `files` array. Without this copy, one
- * request's VAE append is visible to every other request sharing that flight — including
- * `generation.service` and the `modelFile.getByVersionId` handler, which never expected a
- * VAE file in the list at all. (An in-process L1 hit would share it too, but this cache
- * sets no `localTtl`, so that path is latent rather than live.)
+ * What it protects against is the shared cache layer, whose contract is genuinely unsafe here:
+ * `createCachedArray` only ever SHALLOW-clones a record before handing it out, and says so —
+ * "shallow only protects TOP-LEVEL fields — nested refs are shared … consumers MUST treat
+ * returned values as read-only for nested fields"
+ * (`packages/civitai-redis/src/cached-array.ts`). Its FAIL-OPEN DEGRADED fetch (taken whenever
+ * a cluster read rejects) resolves ONE record per id for every caller that joins the in-flight
+ * lookup, so the shallow clone leaves all of them holding the SAME `files` array. An in-process
+ * L1 hit shares it the same way; this cache sets no `localTtl`, so that path is latent.
  *
- * Array-level is the right DEPTH: no consumer mutates an individual file object, only the
- * list. Guarded rather than unconditional so a record without a `files` array keeps its
- * pre-existing shape instead of throwing on a hot public-API path.
+ * Because `filesForModelVersionCache` is module-private, EVERY read routes through here, which
+ * is what makes this the single place a future appender can be made safe. Cost is one array
+ * copy per record (~a few hundred short-lived allocations per feed hydration) — negligible
+ * against the msgpack unpack already done on the same path.
+ *
+ * Array-level is the right DEPTH: no consumer mutates an individual file object, only the list.
+ * Guarded rather than unconditional so a record without a `files` array keeps its pre-existing
+ * shape instead of throwing on a hot public-API path. NOTE: with the real cache that guard is
+ * not reachable — `lookupFn` above always initialises `files: []`, and marker records are
+ * skipped inside the cache layer — so its test is an invariant guard, not regression coverage.
+ *
+ * The result is built into a `typeof records`-annotated object rather than cast: the annotation
+ * is the only thing that makes dropping a field from the returned shape a type error.
  */
 export async function getFilesForModelVersionCache(modelVersionIds: number[]) {
   const records = await filesForModelVersionCache.fetch(modelVersionIds);
-  return Object.fromEntries(
-    Object.entries(records).map(([id, record]) => [
-      id,
-      { ...record, files: Array.isArray(record.files) ? [...record.files] : record.files },
-    ])
-  ) as typeof records;
+  const isolated: typeof records = {};
+  for (const [id, record] of Object.entries(records)) {
+    isolated[id] = {
+      ...record,
+      files: Array.isArray(record.files) ? [...record.files] : record.files,
+    };
+  }
+  return isolated;
 }
 export async function deleteFilesForModelVersionCache(modelVersionId: number) {
   await filesForModelVersionCache.bust(modelVersionId);

--- a/src/server/services/model-file.service.ts
+++ b/src/server/services/model-file.service.ts
@@ -78,8 +78,39 @@ export function reduceToBasicFileMetadata(
   };
 }
 
+/**
+ * Read the per-version file lists, returning records whose nested `files` array is the
+ * CALLER'S OWN — safe to append to, sort, or splice.
+ *
+ * 🔴 WHY THE COPY. `createCachedArray` only ever SHALLOW-clones a record before handing it
+ * out, and says so: "shallow only protects TOP-LEVEL fields — nested refs are shared …
+ * consumers MUST treat returned values as read-only for nested fields"
+ * (`packages/civitai-redis/src/cached-array.ts`). So the contract the cache offers is
+ * read-only-for-`files`, while `getModelsWithVersions` appends the linked VAE file to
+ * exactly that array. This function is the seam that converts one contract into the other.
+ *
+ * The healthy Redis path is NOT the concern — every hit msgpack-decodes a fresh object per
+ * read, so nothing is shared there. The live sharing path is the FAIL-OPEN DEGRADED fetch
+ * (taken whenever a cluster read rejects): its per-id single-flight resolves ONE record for
+ * every caller that joins the in-flight lookup, and the shallow clone it then makes leaves
+ * every one of those callers holding the SAME `files` array. Without this copy, one
+ * request's VAE append is visible to every other request sharing that flight — including
+ * `generation.service` and the `modelFile.getByVersionId` handler, which never expected a
+ * VAE file in the list at all. (An in-process L1 hit would share it too, but this cache
+ * sets no `localTtl`, so that path is latent rather than live.)
+ *
+ * Array-level is the right DEPTH: no consumer mutates an individual file object, only the
+ * list. Guarded rather than unconditional so a record without a `files` array keeps its
+ * pre-existing shape instead of throwing on a hot public-API path.
+ */
 export async function getFilesForModelVersionCache(modelVersionIds: number[]) {
-  return await filesForModelVersionCache.fetch(modelVersionIds);
+  const records = await filesForModelVersionCache.fetch(modelVersionIds);
+  return Object.fromEntries(
+    Object.entries(records).map(([id, record]) => [
+      id,
+      { ...record, files: Array.isArray(record.files) ? [...record.files] : record.files },
+    ])
+  ) as typeof records;
 }
 export async function deleteFilesForModelVersionCache(modelVersionId: number) {
   await filesForModelVersionCache.bust(modelVersionId);

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -137,7 +137,7 @@ import {
 import type { LicensingFeeSettlementCurrency, LicensingFeeType } from '~/shared/utils/prisma/enums';
 import { isDefined } from '~/utils/type-guards';
 import { ingestModelById, updateModelLastVersionAt } from './model.service';
-import { markFileReplaced, filesForModelVersionCache } from './model-file.service';
+import { markFileReplaced, deleteFilesForModelVersionCache } from './model-file.service';
 import { getBuzzTransactionSupportedAccountTypes } from '~/utils/buzz';
 import { deleteModelFileObjects } from '~/utils/s3-utils';
 import { deregisterFileLocations } from '~/utils/storage-resolver';
@@ -3198,8 +3198,8 @@ export const mergeVersions = async ({
   await Promise.all([
     bustMvCache(allVersionIds2, modelId, userId),
     dataForModelsCache.bust(modelId),
-    filesForModelVersionCache.bust(targetVersionId),
-    ...sourceVersionIds.map((id) => filesForModelVersionCache.bust(id)),
+    deleteFilesForModelVersionCache(targetVersionId),
+    ...sourceVersionIds.map((id) => deleteFilesForModelVersionCache(id)),
     preventReplicationLag('model', modelId),
     preventReplicationLag('modelVersion', targetVersionId),
   ]);

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -3862,6 +3862,12 @@ export async function getModelsWithVersions({
               const vaeFile = vaeVersionId
                 ? vaeFiles.filter((x) => x.modelVersionId === vaeVersionId)
                 : [];
+              // This append is safe ONLY because getFilesForModelVersionCache hands back a
+              // per-caller copy of `files`. The cache layer shallow-clones records and
+              // documents nested fields as read-only, and its fail-open degraded path gives
+              // one shared `files` array to every concurrent reader of that version — so a
+              // push straight onto `filesForModelVersionCache.fetch(...)` output leaks this
+              // VAE into other in-flight requests. Don't bypass the accessor.
               const files = groupedFiles[version.id]?.files ?? [];
               files.push(...vaeFile);
 

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -3862,14 +3862,15 @@ export async function getModelsWithVersions({
               const vaeFile = vaeVersionId
                 ? vaeFiles.filter((x) => x.modelVersionId === vaeVersionId)
                 : [];
-              // This append is safe ONLY because getFilesForModelVersionCache hands back a
-              // per-caller copy of `files`. The cache layer shallow-clones records and
-              // documents nested fields as read-only, and its fail-open degraded path gives
-              // one shared `files` array to every concurrent reader of that version — so a
-              // push straight onto `filesForModelVersionCache.fetch(...)` output leaks this
-              // VAE into other in-flight requests. Don't bypass the accessor.
-              const files = groupedFiles[version.id]?.files ?? [];
-              files.push(...vaeFile);
+              // Build a NEW array rather than pushing onto the cached record's own. The cache
+              // layer shallow-clones records and documents nested fields as read-only, and its
+              // fail-open degraded path hands one shared `files` array to every concurrent
+              // reader of that version — a `push` here would leak this VAE into other in-flight
+              // requests (and, via the 180s origin response cache on
+              // `src/pages/api/v1/models/[id].ts`, into every later reader of that model id).
+              // The next statement rebuilds the list with `.map()` anyway, so nothing downstream
+              // wanted the mutation.
+              const files = [...(groupedFiles[version.id]?.files ?? []), ...vaeFile];
 
               // `earlyAccessTimeFrame` is dead — no write path has touched it since the PaidAccess
               // cutover, so the deadline has to come from PaidAccess.

--- a/src/server/utils/__tests__/cache-helpers-failopen.test.ts
+++ b/src/server/utils/__tests__/cache-helpers-failopen.test.ts
@@ -34,8 +34,25 @@ vi.mock('~/server/redis/client', () => ({
     del: (...args: unknown[]) => delMock(...args),
   },
   sysRedis: {},
-  REDIS_KEYS: { CACHE_LOCKS: 'caches:lock', TAG: 'caches:tag' },
+  REDIS_KEYS: {
+    CACHE_LOCKS: 'caches:lock',
+    TAG: 'caches:tag',
+    // model-file.service dereferences this at MODULE scope to build
+    // filesForModelVersionCache; the H2b block below drives that real cache.
+    CACHES: { FILES_FOR_MODEL_VERSION: 'caches:files-for-model-version' },
+  },
 }));
+
+// --- H2b support: import the REAL model-file.service accessor -----------------------------------
+// The H2b block drives the genuine seam — real createCachedObject + real degraded single-flight +
+// real lookupFn + real getFilesForModelVersionCache — so only the leaves it cannot reach in a unit
+// test (prisma, cloudflare) are stubbed. `cache-helpers` is deliberately NOT mocked here: the whole
+// point is that the cache layer is real.
+const { mockDbRead } = vi.hoisted(() => ({
+  mockDbRead: { modelFile: { findMany: vi.fn() } },
+}));
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbRead }));
+vi.mock('~/server/cloudflare/client', () => ({ purgeCache: vi.fn() }));
 
 // Keep the fail-open logger inert (fire-and-forget Axiom/Loki, not under test).
 vi.mock('~/server/redis/fail-open-log', () => ({
@@ -58,6 +75,7 @@ vi.mock('~/server/prom/client', () => ({
 }));
 
 import { createCachedArray, createCachedObject } from '~/server/utils/cache-helpers';
+import { getFilesForModelVersionCache } from '~/server/services/model-file.service';
 
 type Row = { id: number; name: string };
 
@@ -255,6 +273,126 @@ describe('createCachedArray.fetch — degraded shared-object isolation (H2)', ()
     // Without the clone, id 2's shared object would be appended TWICE ("db-2-appended-appended").
     expect(r1.find((r) => r.id === 2)?.name).toBe('db-2-appended');
     expect(r2.find((r) => r.id === 2)?.name).toBe('db-2-appended');
+  });
+});
+
+/**
+ * H2b — the degraded window OBSERVED, not inferred.
+ *
+ * H2 above pins the TOP-LEVEL clone. This block pins what that clone does NOT do: the record it
+ * hands each caller is `{ ...r }`, so every NESTED field is still one shared reference across
+ * every caller that joined the same degraded single-flight
+ * (`packages/civitai-redis/src/cached-array.ts`, the `degraded.add({ ...r })` loop).
+ *
+ * Nothing is hand-constructed here. A rejecting `mGet` forces the real fail-open path, a gated
+ * `dbRead.modelFile.findMany` holds the real `lookupFn` open so a second caller joins the same
+ * in-flight promise, and the assertions read what the real `getFilesForModelVersionCache` returns.
+ * The first test is the POSITIVE CONTROL: it proves this harness can actually observe nested
+ * sharing, so the isolation assertions below are not passing vacuously.
+ */
+describe('degraded single-flight — nested `files` isolation through the real accessor (H2b)', () => {
+  const VERSION_ID = 42;
+  const dbRow = () => ({
+    id: 1,
+    name: 'base.safetensors',
+    modelVersionId: VERSION_ID,
+    metadata: {},
+    hashes: [],
+  });
+
+  // Hold lookupFn open so a second caller reaches the fail-open path and JOINS the in-flight
+  // promise rather than starting its own. Returns the gate itself as well, so a cache that does
+  // NOT go through dbRead (the raw control below) can be held open by the SAME barrier — without
+  // that, its first lookup resolves immediately and the second caller starts a fresh flight, which
+  // yields two independent arrays and a control that "fails" for a harness reason.
+  function gateOrigin() {
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    mockDbRead.modelFile.findMany.mockImplementation(async () => {
+      await gate;
+      return [dbRow()];
+    });
+    return { gate, release: () => release() };
+  }
+
+  beforeEach(() => {
+    mockDbRead.modelFile.findMany.mockReset();
+    mGetMock.mockRejectedValue(REDIS_TIMEOUT());
+  });
+
+  /**
+   * POSITIVE CONTROL — the hazard, at the layer, as it exists today.
+   *
+   * 🔴 If this test ever FAILS, the shared cache layer has been fixed to deep-clone the degraded
+   * record. That is the desired outcome (it is filed as a follow-up on `cached-array.ts`); when it
+   * lands, delete THIS test and keep the two below — do not "repair" it by weakening them.
+   */
+  it('CONTROL: the RAW cache layer hands both callers the SAME nested array', async () => {
+    const { gate, release } = gateOrigin();
+    type Rec = { modelVersionId: number; files: { id: number }[] };
+    const rawLookup = vi.fn(async (ids: number[]) => {
+      await gate; // SAME barrier as the accessor tests → a real joined single-flight
+      return Object.fromEntries(
+        ids.map((id) => [id, { modelVersionId: id, files: [{ id: 1 }] }])
+      ) as Record<string, Rec>;
+    });
+    const raw = createCachedObject<Rec>({
+      key: 'test:h2b-raw' as never,
+      idKey: 'modelVersionId',
+      lookupFn: rawLookup,
+    });
+
+    const p1 = raw.fetch([VERSION_ID]);
+    await flush();
+    const p2 = raw.fetch([VERSION_ID]);
+    await flush();
+    release();
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    // One lookup for two callers → they genuinely joined the same degraded flight.
+    expect(rawLookup).toHaveBeenCalledTimes(1);
+    // Same nested array object — the shallow clone protected only the top level.
+    expect(r1[VERSION_ID].files).toBe(r2[VERSION_ID].files);
+    // ...and it is genuinely ONE window, not two sequential fetches.
+    expect(r1[VERSION_ID]).not.toBe(r2[VERSION_ID]);
+  });
+
+  it('two callers joining ONE degraded single-flight get their OWN `files` array', async () => {
+    const { release } = gateOrigin();
+
+    const p1 = getFilesForModelVersionCache([VERSION_ID]);
+    await flush();
+    const p2 = getFilesForModelVersionCache([VERSION_ID]);
+    await flush();
+    release();
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    // ONE origin lookup served BOTH callers → they really did share a single flight. Without this
+    // the two `not.toBe` assertions below would pass trivially (two independent fetches).
+    expect(mockDbRead.modelFile.findMany).toHaveBeenCalledTimes(1);
+    expect(degradedInc).toHaveBeenCalledTimes(2); // both callers took the degraded path
+    expect(r1[VERSION_ID].files).toHaveLength(1);
+    expect(r2[VERSION_ID].files).toHaveLength(1);
+    expect(r1[VERSION_ID].files).not.toBe(r2[VERSION_ID].files);
+  });
+
+  it('one caller appending a linked VAE file is INVISIBLE to the other', async () => {
+    const { release } = gateOrigin();
+
+    const p1 = getFilesForModelVersionCache([VERSION_ID]);
+    await flush();
+    const p2 = getFilesForModelVersionCache([VERSION_ID]);
+    await flush();
+    release();
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(mockDbRead.modelFile.findMany).toHaveBeenCalledTimes(1);
+    // The behaviour `getModelsWithVersions` used to perform in place on this very array.
+    (r1[VERSION_ID].files as unknown[]).push({ id: 999, name: 'linked.vae.safetensors' });
+
+    expect(r1[VERSION_ID].files).toHaveLength(2);
+    expect(r2[VERSION_ID].files).toHaveLength(1);
+    expect(r2[VERSION_ID].files.map((f) => f.name)).toEqual(['base.safetensors']);
   });
 });
 


### PR DESCRIPTION
> **Updated after an adversarial audit** (commit `da3193c514`). The fix moved: the array mutation is now fixed **at the call site** in `getModelsWithVersions`, the cache object is **un-exported** so the accessor cannot be bypassed, the masking `as typeof records` cast is gone, and the degraded sharing window is now **driven for real** in `cache-helpers-failopen.test.ts` rather than reconstructed from a mock. The **Fix** and **Tests** sections below describe the FIRST pass and are superseded — see the summary comment on this PR for the current state, the red/green matrix and the full mutant battery.

## Problem

`getModelsWithVersions` appends a linked VAE file by mutating the array it got from the version-file cache:

```ts
const files = groupedFiles[version.id]?.files ?? [];
files.push(...vaeFile);
```

The batched per-id cache layer only ever **shallow-clones** a record before handing it out, and says so explicitly: *"shallow only protects TOP-LEVEL fields — nested refs are shared … consumers MUST treat returned values as read-only for nested fields."* So the contract offered is read-only-for-`files`, and this call site writes to it.

## Is it actually reachable?

Yes — in one specific, real state.

- **Healthy Redis path: safe.** Every hit msgpack-decodes a fresh object per read, and this cache sets no in-process `localTtl`, so nothing is shared between requests. The mutation also cannot reach the stored value: the write to Redis is serialized and awaited *before* `fetch` returns.
- **Fail-open degraded path: the hazard is live.** When a cluster read rejects, `fetch` falls open to an origin lookup guarded by a per-id single-flight. Every caller that joins the in-flight lookup for a given version id resolves the **same** record object, and the shallow clone made afterwards leaves all of them holding the **same `files` array**. One request's VAE append is then visible to every other request sharing that flight.

Verified with a throwaway probe against the real cache builder, run in three arms with a positive control:

| arm | config | result |
|---|---|---|
| A | `localTtl` unset (the live config) | second fetch sees 1 file — **not shared** |
| B | `localTtl` set (**positive control**) | second fetch sees 2 files — harness can observe pollution |
| C | Redis read throws (degraded) | 1 lookup, `a.files === b.files` is `true`, caller B sees caller A's push |

Arm B is what makes arm A's clean result meaningful rather than a probe wired to nothing.

## Blast radius

**Corrected — the original text here understated this, and it was wrong in the PR's own favour.**

The claim was: *"the sharing window is one in-flight degraded fetch, not the cache TTL … Nothing is ever written back to Redis."* That is true **of the file cache only**. The polluted value does not stay inside that window, because a downstream cache stores the shaped body built from it.

`GET /api/v1/models/:id` writes its shaped 200 body — `files` included — into a **Redis-backed origin response cache** (`src/pages/api/v1/models/[id].ts`: `PUBLIC_MODEL_RESPONSE_TTL = CacheTTL.sm` = **180s** logical, stored at `ttl * 2` physical, enabled when `IS_DATAPACKET` and the request is not block-scoped), and Cloudflare fronts the same endpoint at `s-maxage=300` with stale-while-revalidate. So if the leak lands in the body that gets stored:

- it **outlives the in-flight window by minutes**, not milliseconds, and
- it is served to **every** anonymous reader of that `(modelId, browsingLevel)` pair for the remainder of the TTL — the poisoned response is shared, not per-request.

Two things about the write path are still accurate and worth keeping: nothing is written back to the **file** cache, and the single-flight entry itself is deleted the moment the lookup settles. The correction is that "the file cache is not poisoned" is not the same claim as "the pollution is short-lived", and only the first one was ever established.

Within the window the leak also crosses request boundaries into consumers that never add VAE files at all — the generation-resource file hydration and the `modelFile.getByVersionId` handler — which would see a VAE-typed entry appear in a version's file list.

Mutating consumer (3 endpoints, all through `getModelsWithVersions`):
- `GET /api/v1/models/:id`
- `GET /api/v1/models`
- `GET /api/v1/blocks/models`

Non-mutating readers of the same cache entries (the victims): the generation resource-file lookup, and the `modelFile.getByVersionId` tRPC query.

## Fix

Copy the array once in `getFilesForModelVersionCache` — the single accessor all three consumers already go through — rather than at each call site. Array-level is the right depth: no consumer mutates an individual file object, only the list. The copy is guarded (`Array.isArray`) so a record without a `files` array keeps its existing shape instead of throwing on a public-API read path. Comments at both ends explain why, so the next reader doesn't re-derive the suspicion or "simplify" the copy away.

The **other** `files.push(...vaeFile)` in `model.controller.ts` does **not** share the hazard: its `files` comes from a Prisma read rather than this cache, and that handler is currently unwired. Left alone deliberately.

## Tests

New regression block drives the cache mock to return records sharing one nested array — exactly the degraded shape — and asserts the accessor isolates the caller.

| | result |
|---|---|
| pre-change code | **4 failed** / 17 passed (21) |
| post-change | **21 passed** (21) |

Mutation battery on the guard (all 21 tests ran in every arm):

| mutant | outcome |
|---|---|
| unmutated control | 21 passed |
| mutate-in-place restored (`return fetch(...)` verbatim) | killed — 4 failed |
| same, with the explanatory comment left in place | killed — 4 failed |
| copy too shallow (top-level clone only) | killed — 4 failed |
| guard inverted (alias kept when `files` *is* an array) | killed — 5 failed |
| only the first record of a batch copied | killed — 1 failed |
| copy computed then discarded | killed — 4 failed |
| over-copy (each file object cloned too) | **survived — semantically stronger, not a gap** |

Gates: `pnpm typecheck` 0 errors (negative control: a planted type error in this file produced exactly 1 `error TS2322`, rc=2). `pnpm test:lint-rules` 220/220. ESLint on the three changed files reports only pre-existing issues on untouched lines (negative control: a planted unused var in the test file was reported). Prettier flags both touched files, but they are already unformatted on `main` — no new formatting regression, and no unrelated reformat included.
