### PR TITLE
fix(auth): make the SSR session prop actually serializable

### DIFF
--- a/src/server/__tests__/session-props.test.ts
+++ b/src/server/__tests__/session-props.test.ts
@@ -93,12 +93,21 @@ describe('jsonSafeSession', () => {
   // The load-bearing edge: the helper is worthless if it isn't applied. A unit test cannot drive
   // createServerSideProps without wholesale-mocking `~/server/routers` (banned by no-wholesale-module-mock),
   // so pin the call site itself.
-  it('is applied at the props boundary in createServerSideProps', () => {
-    const source = fs.readFileSync(
-      path.resolve(__dirname, '../utils/server-side-helpers.ts'),
-      'utf8'
-    );
+  describe('the call site in createServerSideProps', () => {
+    const source = () =>
+      fs.readFileSync(path.resolve(__dirname, '../utils/server-side-helpers.ts'), 'utf8');
 
-    expect(source).toContain('session: jsonSafeSession(session)');
+    it('applies jsonSafeSession to the session prop', () => {
+      expect(source()).toContain('session: jsonSafeSession(session)');
+    });
+
+    // `session` must stay the LAST key in the props object: a later spread would re-add the raw
+    // session over the sanitized one, which leaves the call above present but dead.
+    it('keeps it last, so nothing can spread a raw session over it', () => {
+      expect(
+        source(),
+        'nothing may be added after `session:` in the returned props object'
+      ).toMatch(/session: jsonSafeSession\(session\),\s*\}\s*as NonNullable<P>/);
+    });
   });
 });

--- a/src/server/__tests__/session-props.test.ts
+++ b/src/server/__tests__/session-props.test.ts
@@ -1,0 +1,82 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import type { Session } from '~/types/session';
+import { SESSION_DATE_FIELDS, jsonSafeSession } from '~/server/utils/session-props';
+
+const sessionWith = (user: Record<string, unknown>) =>
+  ({ user, expires: '2030-01-01T00:00:00.000Z' } as unknown as Session);
+
+const userOf = (session: Session | null) => session?.user as unknown as Record<string, unknown>;
+
+// Mirrors what Next's `isSerializableProps` rejects: any Date anywhere under the props object.
+function findDates(value: unknown, at = 'session'): string[] {
+  if (value instanceof Date) return [at];
+  if (Array.isArray(value)) return value.flatMap((v, i) => findDates(v, `${at}[${i}]`));
+  if (value && typeof value === 'object')
+    return Object.entries(value).flatMap(([k, v]) => findDates(v, `${at}.${k}`));
+  return [];
+}
+
+describe('jsonSafeSession', () => {
+  it('converts every Date field to an ISO string', () => {
+    const session = sessionWith(
+      Object.fromEntries(SESSION_DATE_FIELDS.map((f) => [f, new Date('2024-03-04T05:06:07.000Z')]))
+    );
+
+    const safe = jsonSafeSession(session);
+
+    for (const field of SESSION_DATE_FIELDS) {
+      // typeof first: a Date and its ISO string print identically in the diff, so asserting the value
+      // alone reports `expected <date> to be '<same text>'` and reads like a bug in the test.
+      expect(typeof userOf(safe)[field], `${field} must be a string in props, not a Date`).toBe(
+        'string'
+      );
+      expect(userOf(safe)[field]).toBe('2024-03-04T05:06:07.000Z');
+    }
+    expect(findDates(safe), 'no Date may survive into props').toEqual([]);
+  });
+
+  // The cold-miss path (hub HTTP JSON) already hands us ISO strings, so normalizing must not depend on
+  // which side of the session cache the request landed on.
+  it('leaves ISO strings, absent fields and null alone', () => {
+    const safe = jsonSafeSession(
+      sessionWith({ id: 1, createdAt: '2024-03-04T05:06:07.000Z', mutedAt: null })
+    );
+
+    expect(userOf(safe).createdAt).toBe('2024-03-04T05:06:07.000Z');
+    expect(userOf(safe).mutedAt).toBeNull();
+    expect(userOf(safe).emailVerified).toBeUndefined();
+    expect(userOf(safe).id).toBe(1);
+  });
+
+  it('passes through a null session and a session with no user', () => {
+    expect(jsonSafeSession(null)).toBeNull();
+    expect(jsonSafeSession({ expires: 'x' } as Session)).toEqual({ expires: 'x' });
+  });
+
+  it('does not mutate the session it was given', () => {
+    const createdAt = new Date('2024-03-04T05:06:07.000Z');
+    const session = sessionWith({ createdAt });
+
+    jsonSafeSession(session);
+
+    expect(userOf(session).createdAt).toBe(createdAt);
+  });
+
+  // A Date field added to SessionUser and not listed in SESSION_DATE_FIELDS is a page-wide dev 500 that
+  // nothing else catches: the type says Date, and no runtime check reads the type.
+  it('lists every Date-typed field on SessionUser', () => {
+    const source = fs.readFileSync(path.resolve(__dirname, '../../types/session.ts'), 'utf8');
+    const body = source.slice(source.indexOf('interface SessionUser'));
+    const declared = [...body.slice(0, body.indexOf('\n}')).matchAll(/^\s*(\w+)\??:\s*Date/gm)].map(
+      (m) => m[1]
+    );
+
+    expect(
+      declared.length,
+      'failed to parse SessionUser — fix this test, not the list'
+    ).toBeGreaterThan(0);
+    expect(declared.sort()).toEqual([...SESSION_DATE_FIELDS].sort());
+  });
+});

--- a/src/server/__tests__/session-props.test.ts
+++ b/src/server/__tests__/session-props.test.ts
@@ -1,53 +1,69 @@
 import fs from 'fs';
 import path from 'path';
+// Next's REAL props validator — the rule that was actually being violated. Asserting against our own
+// idea of "serializable" is what let an earlier version of this fix pass while Next still rejected the
+// props: it checked for Dates and missed `undefined`.
+import { isSerializableProps } from 'next/dist/lib/is-serializable-props';
 import { describe, expect, it } from 'vitest';
 import type { Session } from '~/types/session';
-import { SESSION_DATE_FIELDS, jsonSafeSession } from '~/server/utils/session-props';
+import { jsonSafeSession } from '~/server/utils/session-props';
 
-const sessionWith = (user: Record<string, unknown>) =>
-  ({ user, expires: '2030-01-01T00:00:00.000Z' } as unknown as Session);
+const asProps = (session: Session | null) => ({ session, adsGated: false });
+const serializable = (session: Session | null) => () =>
+  isSerializableProps('/models', 'getServerSideProps', asProps(session));
+
+// What a warm `session:data2` msgpack hit actually yields: real Dates AND keys present with `undefined`
+// (shapeSessionUser assigns explicit undefined to ~20 optional fields).
+const cachedSession = () =>
+  ({
+    user: {
+      id: 1,
+      username: 'ivy',
+      createdAt: new Date('2024-03-04T05:06:07.000Z'),
+      emailVerified: new Date('2024-03-04T05:06:07.000Z'),
+      mutedAt: undefined,
+      bannedAt: undefined,
+      deletedAt: undefined,
+      leaderboardShowcase: undefined,
+      tier: undefined,
+      meta: { firstImage: new Date('2024-03-04T05:06:07.000Z') },
+    },
+    expires: '2030-01-01T00:00:00.000Z',
+  } as unknown as Session);
 
 const userOf = (session: Session | null) => session?.user as unknown as Record<string, unknown>;
 
-// Mirrors what Next's `isSerializableProps` rejects: any Date anywhere under the props object.
-function findDates(value: unknown, at = 'session'): string[] {
-  if (value instanceof Date) return [at];
-  if (Array.isArray(value)) return value.flatMap((v, i) => findDates(v, `${at}[${i}]`));
-  if (value && typeof value === 'object')
-    return Object.entries(value).flatMap(([k, v]) => findDates(v, `${at}.${k}`));
-  return [];
-}
-
 describe('jsonSafeSession', () => {
-  it('converts every Date field to an ISO string', () => {
-    const session = sessionWith(
-      Object.fromEntries(SESSION_DATE_FIELDS.map((f) => [f, new Date('2024-03-04T05:06:07.000Z')]))
-    );
+  it('produces props Next accepts, where the raw session does not', () => {
+    const raw = cachedSession();
 
-    const safe = jsonSafeSession(session);
-
-    for (const field of SESSION_DATE_FIELDS) {
-      // typeof first: a Date and its ISO string print identically in the diff, so asserting the value
-      // alone reports `expected <date> to be '<same text>'` and reads like a bug in the test.
-      expect(typeof userOf(safe)[field], `${field} must be a string in props, not a Date`).toBe(
-        'string'
-      );
-      expect(userOf(safe)[field]).toBe('2024-03-04T05:06:07.000Z');
-    }
-    expect(findDates(safe), 'no Date may survive into props').toEqual([]);
+    expect(serializable(raw), 'the raw cached session must be the thing Next rejects').toThrow();
+    expect(serializable(jsonSafeSession(raw))).not.toThrow();
   });
 
-  // The cold-miss path (hub HTTP JSON) already hands us ISO strings, so normalizing must not depend on
-  // which side of the session cache the request landed on.
-  it('leaves ISO strings, absent fields and null alone', () => {
-    const safe = jsonSafeSession(
-      sessionWith({ id: 1, createdAt: '2024-03-04T05:06:07.000Z', mutedAt: null })
-    );
+  it('ISO-strings Dates and drops undefined keys', () => {
+    const safe = jsonSafeSession(cachedSession());
 
+    expect(typeof userOf(safe).createdAt).toBe('string');
     expect(userOf(safe).createdAt).toBe('2024-03-04T05:06:07.000Z');
-    expect(userOf(safe).mutedAt).toBeNull();
-    expect(userOf(safe).emailVerified).toBeUndefined();
-    expect(userOf(safe).id).toBe(1);
+    expect('mutedAt' in userOf(safe), 'an undefined key must be gone, not merely undefined').toBe(
+      false
+    );
+  });
+
+  // A shallow field-by-field pass cannot reach these; SessionUser.meta declares four z.date() fields.
+  it('recurses into nested values', () => {
+    const safe = jsonSafeSession(cachedSession());
+
+    expect((userOf(safe).meta as Record<string, unknown>).firstImage).toBe(
+      '2024-03-04T05:06:07.000Z'
+    );
+  });
+
+  it('is idempotent on the ISO strings the cold-miss HTTP path returns', () => {
+    const once = jsonSafeSession(cachedSession());
+
+    expect(jsonSafeSession(once)).toEqual(once);
   });
 
   it('passes through a null session and a session with no user', () => {
@@ -56,27 +72,33 @@ describe('jsonSafeSession', () => {
   });
 
   it('does not mutate the session it was given', () => {
-    const createdAt = new Date('2024-03-04T05:06:07.000Z');
-    const session = sessionWith({ createdAt });
+    const session = cachedSession();
 
     jsonSafeSession(session);
 
-    expect(userOf(session).createdAt).toBe(createdAt);
+    expect(userOf(session).createdAt).toBeInstanceOf(Date);
   });
 
-  // A Date field added to SessionUser and not listed in SESSION_DATE_FIELDS is a page-wide dev 500 that
-  // nothing else catches: the type says Date, and no runtime check reads the type.
-  it('lists every Date-typed field on SessionUser', () => {
-    const source = fs.readFileSync(path.resolve(__dirname, '../../types/session.ts'), 'utf8');
-    const body = source.slice(source.indexOf('interface SessionUser'));
-    const declared = [...body.slice(0, body.indexOf('\n}')).matchAll(/^\s*(\w+)\??:\s*Date/gm)].map(
-      (m) => m[1]
+  // An invalid date must not become a throw: this runs on every SSR render, including in production,
+  // where the unnormalized value used to pass through harmlessly.
+  it('does not throw on a malformed date', () => {
+    const safe = jsonSafeSession({
+      user: { id: 1, createdAt: new Date('nope') },
+    } as unknown as Session);
+
+    expect(userOf(safe).createdAt).toBeNull();
+    expect(serializable(safe)).not.toThrow();
+  });
+
+  // The load-bearing edge: the helper is worthless if it isn't applied. A unit test cannot drive
+  // createServerSideProps without wholesale-mocking `~/server/routers` (banned by no-wholesale-module-mock),
+  // so pin the call site itself.
+  it('is applied at the props boundary in createServerSideProps', () => {
+    const source = fs.readFileSync(
+      path.resolve(__dirname, '../utils/server-side-helpers.ts'),
+      'utf8'
     );
 
-    expect(
-      declared.length,
-      'failed to parse SessionUser — fix this test, not the list'
-    ).toBeGreaterThan(0);
-    expect(declared.sort()).toEqual([...SESSION_DATE_FIELDS].sort());
+    expect(source).toContain('session: jsonSafeSession(session)');
   });
 });

--- a/src/server/utils/server-side-helpers.ts
+++ b/src/server/utils/server-side-helpers.ts
@@ -1,6 +1,7 @@
 import { createServerSideHelpers } from '@trpc/react-query/server';
 import type { GetServerSidePropsContext, GetServerSidePropsResult, Redirect } from 'next';
 import type { Session } from '~/types/session';
+import { jsonSafeSession } from '~/server/utils/session-props';
 import { Tracker } from '~/server/clickhouse/client';
 import { unionTransformer } from '~/shared/utils/trpc-union-transformer';
 import {
@@ -135,7 +136,7 @@ export function createServerSideProps<P>({
               ),
             }
           : {}),
-        session,
+        session: jsonSafeSession(session),
       } as NonNullable<P>,
     };
   };

--- a/src/server/utils/session-props.ts
+++ b/src/server/utils/session-props.ts
@@ -1,28 +1,17 @@
-import type { Session, SessionUser } from '~/types/session';
-
-// Every `Date`-typed field on SessionUser. Kept in sync by `session-props.test.ts`, which reads
-// `src/types/session.ts` and fails if a new one is added without being listed here.
-export const SESSION_DATE_FIELDS = [
-  'emailVerified',
-  'createdAt',
-  'mutedAt',
-  'bannedAt',
-  'deletedAt',
-] as const;
+import type { Session } from '~/types/session';
 
 /**
- * Props are plain JSON — nothing transforms them the way `trpcState` is transformed — and the session
- * legitimately carries real `Date`s: a warm `session:data2` hit is msgpack, which round-trips Dates
- * (`@civitai/auth`'s `getSessionUser` documents this; only the cold-miss HTTP path yields ISO strings).
- * Next's dev server rejects a Date in props with a page-wide 500, while production serializes it to an
- * ISO string silently — so normalizing here makes dev agree with what prod already sends to the client.
+ * Make the session safe to hand to Next as a prop.
+ *
+ * Props are plain JSON — nothing transforms them the way `trpcState` is transformed — and a warm
+ * `session:data2` hit is msgpack, which round-trips both real `Date`s and `undefined` values with their
+ * keys intact (`@civitai/auth`'s `getSessionUser` documents the Date half; only the cold-miss HTTP path
+ * yields plain JSON). Next rejects BOTH with a page-wide 500 under the dev server, and production
+ * serializes them silently — so the two are inseparable and normalizing only the Dates fixes nothing.
+ *
+ * A JSON round-trip is deliberate rather than a field-by-field pass: it drops `undefined`, ISO-strings
+ * Dates, recurses into nested values like `meta`, and needs no list to maintain. It is also exactly what
+ * `/api/auth/session` does to the same object, so the SSR seed and every later refetch now agree.
  */
-export const jsonSafeSession = (session: Session | null): Session | null => {
-  if (!session?.user) return session;
-  const user: Record<string, unknown> = { ...session.user };
-  for (const field of SESSION_DATE_FIELDS) {
-    const value = user[field];
-    if (value != null) user[field] = new Date(value as Date).toISOString();
-  }
-  return { ...session, user: user as unknown as SessionUser };
-};
+export const jsonSafeSession = (session: Session | null): Session | null =>
+  session ? (JSON.parse(JSON.stringify(session)) as Session) : session;

--- a/src/server/utils/session-props.ts
+++ b/src/server/utils/session-props.ts
@@ -1,0 +1,28 @@
+import type { Session, SessionUser } from '~/types/session';
+
+// Every `Date`-typed field on SessionUser. Kept in sync by `session-props.test.ts`, which reads
+// `src/types/session.ts` and fails if a new one is added without being listed here.
+export const SESSION_DATE_FIELDS = [
+  'emailVerified',
+  'createdAt',
+  'mutedAt',
+  'bannedAt',
+  'deletedAt',
+] as const;
+
+/**
+ * Props are plain JSON — nothing transforms them the way `trpcState` is transformed — and the session
+ * legitimately carries real `Date`s: a warm `session:data2` hit is msgpack, which round-trips Dates
+ * (`@civitai/auth`'s `getSessionUser` documents this; only the cold-miss HTTP path yields ISO strings).
+ * Next's dev server rejects a Date in props with a page-wide 500, while production serializes it to an
+ * ISO string silently — so normalizing here makes dev agree with what prod already sends to the client.
+ */
+export const jsonSafeSession = (session: Session | null): Session | null => {
+  if (!session?.user) return session;
+  const user: Record<string, unknown> = { ...session.user };
+  for (const field of SESSION_DATE_FIELDS) {
+    const value = user[field];
+    if (value != null) user[field] = new Date(value as Date).toISOString();
+  }
+  return { ...session, user: user as unknown as SessionUser };
+};


### PR DESCRIPTION
## The report

`createServerSideProps` returns `session` straight into Next props. Justin hits a page-wide SSR 500 in dev "on the regular", it clears on its own, and purging `.next` also clears it. The reported cause was `SessionUser` typing `emailVerified`/`createdAt` as `Date`.

## Diagnosis

**A warm `session:data2` cache hit hands us an object Next will not accept as props — for two reasons, not one.**

The hub is the sole producer. `apps/auth/.../session-shape.ts:134-167` builds the `SessionUser` with `new Date(...)` for five fields **and explicit `undefined` for ~20 optional ones** (`leaderboardShowcase`, `tier`, `mutedAt`, `bannedAt`, `deletedAt`, `banDetails`, …). `session-producer.ts:129` writes it with `redis.packed.set` — a bare `pack()` (`civitai-redis/src/client.ts:1349`, msgpackr).

msgpackr round-trips **both**: `Date` comes back as a real `Date`, and `undefined` comes back **with its key intact**. `readCachedUser` (`packages/civitai-auth/src/session-client.ts:101-108`) returns that object unnormalized. `@civitai/auth` documents the Date half at `session-client.ts:22`; the `undefined` half is undocumented and is the part that actually bites, because for a normal free, non-muted user most of those 20 fields are `undefined` while only two date fields are populated.

Next's `isSerializableProps` rejects `undefined` exactly as hard as `Date`. Measured against the real validator and the repo's own msgpackr:

```
RAW cached session         => THROWS: `.session.user.leaderboardShowcase` … `undefined` cannot be serialized
Date-fields-only fix       => THROWS: `.session.user.leaderboardShowcase`   (unchanged)
JSON round-trip            => OK
```

The first version of this PR normalized only the Dates and **did not fix the bug**. The `undefined` keys also sort earlier in the shaped object than most date fields, so the error text Justin saw may well have been naming an `undefined` field rather than a Date.

**Production cannot 500 on this** — confirmed two independent ways. `render.js:826` gates on `(process.env.__NEXT_DEV_SERVER || isBuildTimeSSG)`. `__NEXT_DEV_SERVER` has exactly one assignment in all of Next, on the dev server's child process; nothing in this repo sets it (`Dockerfile`, `next.config.mjs`, `scripts/`, `.github/`, `.env.example` — zero hits), and the deployed container is `CMD ["node", "--", "server.js"]` on a standalone build. And `isBuildTimeSSG = isSSG && isBuildTimePrerendering` where `isSSG = !!getStaticProps` (`render.js:249-250`), so that disjunct is structurally dead on any `getServerSideProps` page. No other prod path rejects it either: `/_next/data` shares the same gate, there is no app router in this repo, and Next's bundled devalue never touches the props path.

Note `NODE_ENV` is **not** the discriminator — `pnpm prod` is `next dev` with `NODE_ENV=production` and *does* set the flag.

**Not a stale-`.next` artifact.** The trigger is whether the shared cache read succeeds; `readCachedUser` fails *open*, so a blip falls through to the hub's HTTP JSON, which is already plain JSON and renders fine. A `.next` purge restarts the process and drops the redis connection, which plausibly explains why purging appears to fix it — that last step is inference, not verified.

## The fix

```ts
session ? (JSON.parse(JSON.stringify(session)) as Session) : session
```

A round-trip rather than a field-by-field pass, deliberately:

- drops `undefined` keys — the half a Date-only fix misses entirely
- ISO-strings Dates
- **recurses**, so it covers the four `z.date()` fields declared on `SessionUser.meta` (`user.schema.ts:425-445`) that a shallow pass can never reach. Those are strings at runtime today (JSONB, never zod-parsed), so not a live 500 — but the declared type says otherwise and nothing would have caught it
- needs no field list to keep in sync, and no source-parsing guard test to police that list
- no `RangeError`. An earlier version called `new Date(x).toISOString()`, which **throws** on a malformed value — a new production 500 on a path that previously passed the value through. A round-trip serializes an invalid Date to `null`

It is also exactly what `/api/auth/session` does to the same object, which is the real argument for this change: prod currently renders SSR HTML from a real `Date` while the client hydrates from the ISO string in `__NEXT_DATA__`, and every `SessionProvider.fetchSession` refetch returns strings. The seed and the refetch disagree in shape today. This makes them agree.

## Consumers

No consumer breaks. Every read of these fields off a session-shaped object is a truthiness test (`!!user.bannedAt`, `currentUser?.emailVerified`) or goes through `formatDate`, which is dayjs `ConfigType` and accepts both. Zero `.getTime()`/`.toISOString()`/comparison/sort on a session field. Two server-side sites already coerce defensively — `apps-shared.router.ts:133` and `api/auth/post-login.ts:72`, the latter already typing it `Date | string` — which is direct evidence the codebase treats these as possibly-strings today.

`ctx.user` is unaffected: only the props copy is normalized, so `article.schema.ts:29` / `post.schema.ts:31`, which pass a session `createdAt` to the `Date`-typed `isBetweenToday`, keep receiving real Dates. Normalizing further upstream would have turned those into compile errors — the props boundary is the right seam, narrowly.

Nothing else puts a session into props: of 216 files declaring their own `getServerSideProps`, none reference `getServerAuthSession` or build a `session` prop. `_app.tsx:584` puts one in `pageProps`, but it comes from `fetch('/api/user/settings')` then `res.json()` (already strings), and `render.js:833` merges `data.props` over `pageProps` anyway.

## Tests

`src/server/__tests__/session-props.test.ts`, 8 cases asserting against Next's **real** `isSerializableProps` rather than a local approximation. That matters: the first version of this PR asserted "no Dates anywhere", which is not the rule Next enforces, and that is precisely how a green suite coexisted with props Next still rejected.

Both failure modes mutation-tested:

| Mutation | Result |
|---|---|
| helper to identity | `Error serializing .session.user.createdAt …` |
| call site to bare `session,` | fails the boundary assertion |

The second was **silent before** — all five original tests passed with the fix disconnected. It is pinned by asserting the call site's source text rather than by driving `createServerSideProps`, because a unit test there would need a wholesale mock of `~/server/routers`, which `no-wholesale-module-mock` bans. `pnpm run test:lint-rules` passes 220.

## Verification

- `pnpm run typecheck` — **OK, 0 errors**, unfiltered
- `pnpm run lint` — exit 0; new file clean. The 5 `no-explicit-any` warnings on `server-side-helpers.ts` are the same 5 `as any` casts already on `origin/main`
- `pnpm run test:lint-rules` — 220 passed
- `pnpm exec prettier --check` on touched files — clean
- `pnpm run test:unit:run` — 16 failures across 6 files, **all pre-existing**: reverting to a clean tree and re-running those 6 gives the identical 16 test names
- `blocks.router.workflow.test.ts` — 347 collected, 0 failed (submodule initialized)
- Dev server on the branch renders `/models` 200, no serialization errors in its log

## Not covered

**The return type still lies.** `jsonSafeSession` returns `Session`, so `session.user.createdAt` is typed `Date` while holding a string — `.getTime()` on it typechecks and would crash. The honest signature is a mapped `JsonSafe<Session>`, which would make the compiler enumerate every consumer instead of relying on the grep above. That cascades through `_app.tsx`'s `session` prop type and its consumers, so it is deliberately left out of this PR rather than half-done.

**An authenticated SSR render was not exercised.** No API key was available for the bearer path, and enabling the hub's stub provider would have meant reconfiguring the auth hub shared with other agents' dev servers. The mechanism is verified by executing Next's validator and msgpackr directly; the end-to-end authed page load is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
