### PR TITLE
fix(observability): record the disabled verdict so wedge-capture has a denominator

### DIFF
--- a/src/server/__tests__/eventloop-watchdog.capture.test.ts
+++ b/src/server/__tests__/eventloop-watchdog.capture.test.ts
@@ -169,8 +169,18 @@ describe('starvation classifier', () => {
       await new Promise((r) => setTimeout(r, 1500));
     }
 
+    // Keep beating for the whole scrape. Recovery is one store, but the scrape that
+    // follows can outlast the threshold, and a silent stretch there would open a SECOND
+    // wedge mid-poll — a per-wedge counter would then settle on 2 on a loaded runner and
+    // on 1 everywhere else.
     Atomics.store(beat, 0, BigInt(Date.now()));
-    const body = await scrapeUntil(port, settleOn);
+    const recovered = setInterval(() => Atomics.store(beat, 0, BigInt(Date.now())), WORKER_POLL_MS);
+    let body: string;
+    try {
+      body = await scrapeUntil(port, settleOn);
+    } finally {
+      clearInterval(recovered);
+    }
     await worker.terminate();
     await Promise.all(spinners.map((s) => s.terminate()));
     return body;
@@ -278,6 +288,50 @@ describe('starvation classifier', () => {
     expect(body).toContain('civitai_app_watchdog_wedge_cpu_ratio_bucket{le="0.05"}');
     expect(body).toContain('civitai_app_watchdog_wedge_cpu_ratio_count 1');
     expect(read(body, 'civitai_app_watchdog_starved_ratio_threshold')).toBe(0.2);
+  }, 30_000);
+
+  // Summed from the body rather than a hand-listed set, so a verdict added later is
+  // counted here without anyone remembering to add it.
+  const captureDecisions = (body: string) =>
+    body
+      .split('\n')
+      .filter((l) => l.startsWith('civitai_app_watchdog_capture_total{'))
+      .reduce((sum, l) => sum + Number(l.slice(l.indexOf('} ') + 2)), 0);
+
+  it('🔴 records a decision for an executing wedge the starvation gate let through', async () => {
+    // The gate passing an executing wedge used to be UNOBSERVABLE: the disabled verdict
+    // was the one verdict that recorded nothing, so on a pool with capture off the only
+    // label that could ever move was skipped-starved. Reading it as a share of the
+    // counter then says every wedge was refused as starved, whatever the classifier
+    // says.
+    const body = await runWedge('executing', {
+      'civitai_app_watchdog_capture_total{result="skipped-disabled"}': 1,
+    });
+    expect(read(body, 'civitai_app_watchdog_capture_total{result="skipped-disabled"}')).toBe(1);
+    expect(read(body, 'civitai_app_watchdog_capture_total{result="skipped-starved"}')).toBe(0);
+  }, 30_000);
+
+  it('🔴 records exactly one decision per detected wedge, whatever the verdict', async () => {
+    // The denominator, pinned as a RELATIONSHIP rather than as a label: the decisions
+    // ledger has to equal the wedges, so no verdict can go unrecorded and none can be
+    // counted twice.
+    for (const kind of ['executing', 'starved'] as const) {
+      const body = await runWedge(kind, { civitai_app_watchdog_wedge_duration_seconds_count: 1 });
+      expect(captureDecisions(body), kind).toBe(
+        read(body, 'civitai_app_watchdog_wedge_duration_seconds_count')
+      );
+    }
+  }, 60_000);
+
+  it('refuses a starved wedge at the starvation gate, not at the disabled check', async () => {
+    // The protection this whole gate exists for: a descheduled thread has nothing to
+    // sample. The starved verdict must be the one recorded, so removing the gate is
+    // visible as the verdict MOVING rather than as a count staying the same.
+    const body = await runWedge('starved', {
+      'civitai_app_watchdog_capture_total{result="skipped-starved"}': 1,
+    });
+    expect(read(body, 'civitai_app_watchdog_capture_total{result="skipped-starved"}')).toBe(1);
+    expect(read(body, 'civitai_app_watchdog_capture_total{result="skipped-disabled"}')).toBe(0);
   }, 30_000);
 });
 

--- a/src/server/eventloop-watchdog.ts
+++ b/src/server/eventloop-watchdog.ts
@@ -410,19 +410,24 @@ async function captureWedge(wedgeStartMs) {
   }
 }
 
+// Every verdict is recorded, 'disabled' included. Leaving that one silent made the
+// counter denominator-less: on a pool with capture off the only label that could move
+// was skipped-starved, so the counter read 100% starved no matter what the classifier
+// said, and "capture is not enabled here" was indistinguishable from "every wedge was
+// refused".
 function maybeCaptureWedge(wedgeStartMs) {
   const verdict = captureAllowed(Date.now());
   if (verdict !== 'ok') {
-    if (verdict !== 'disabled') tallyCapture('skipped-' + verdict);
+    tallyCapture('skipped-' + verdict);
     return;
   }
   captureWedge(wedgeStartMs);
 }
 
 function renderCaptureMetrics(out) {
-  out.push('# HELP civitai_app_watchdog_capture_total Wedge CPU-profile captures attempted, by result. skipped-* results mean the trigger fired but was refused by backoff or the hourly capCfg.');
+  out.push('# HELP civitai_app_watchdog_capture_total Wedge CPU-profile capture decisions, by result — exactly one per detected wedge, so the labels sum to the wedge count and any one of them can be read as a share. skipped-disabled means capture is not turned on for this pool at all, which is the reading that separates a refused capture from an absent one; the other skipped-* results mean the trigger fired and was refused, by the starvation gate or by the in-flight, backoff and hourly limits.');
   out.push('# TYPE civitai_app_watchdog_capture_total counter');
-  const captureKeys = ['ok', 'error', 'skipped-in-flight', 'skipped-backoff', 'skipped-hourly-cap', 'skipped-starved'];
+  const captureKeys = ['ok', 'error', 'skipped-in-flight', 'skipped-backoff', 'skipped-hourly-cap', 'skipped-starved', 'skipped-disabled'];
   for (const k of captureKeys) {
     out.push('civitai_app_watchdog_capture_total{result="' + k + '"} ' + (captureResults[k] || 0));
   }


### PR DESCRIPTION
## The defect

`maybeCaptureWedge` recorded every capture verdict except one:

```js
if (verdict !== 'ok') {
  if (verdict !== 'disabled') tallyCapture('skipped-' + verdict);
  return;
}
```

`disabled` is the verdict returned when capture is not turned on for a pool — and
capture is opt-in per pool, so it is the common case. The consequence is that
`civitai_app_watchdog_capture_total` has **no denominator**: on such a pool the only
label that can ever move is `skipped-starved`, because that one is tallied *before*
`maybeCaptureWedge` is reached. Every wedge the starvation gate lets through is
accounted for nowhere.

Read as a share of its own total, the counter therefore reports **100% `skipped-starved`**
regardless of what actually happened, and "capture is not enabled here" is
indistinguishable from "every wedge was refused as starved". That is a reading the
counter cannot be talked out of, and it directly contradicts the wedge-kind classifier
sitting next to it.

## What the measurement actually says

Measured across the serving fleet (counters since process start):

| series | value |
|---|---|
| `watchdog_wedge_duration_seconds_count` (wedges) | 1,596 |
| `watchdog_wedge_kind_total{kind="executing"}` | 1,488 |
| `watchdog_wedge_kind_total{kind="starved"}` | 108 |
| `watchdog_capture_total{result="skipped-starved"}` | 122 |
| every other `watchdog_capture_total{result=…}` | 0 |
| `watchdog_cpu_source{source="main-thread"}` | 1 on every pod |

The capture gate refused 122; the classifier scored 108 starved. **They agree to within
14 of 1,596 wedges (0.9%)** — the residual being the handful of wedges whose CPU ratio
over the window that exists at detection differs from the ratio over the whole wedge,
which is exactly what the gate's comment says it is trading away.

So the gate is not rejecting executing-class wedges. 1,488 of them went through it and
produced no counter movement at all, which is what made it look as though it had.

## The fix

Tally `disabled` like any other verdict, and pre-initialise the series alongside the
rest. The labels now sum to the wedge count, so any one of them can be read as a share.

The gate itself is unchanged, and deliberately so: the capture gate and the wedge-kind
classifier already call the same `cpuRatioSince()` against the same `starvedCutoff`, one
at detection and one on recovery. They are already a single source of truth — one
predicate evaluated at two instants — and the numbers above are the evidence that they
behave like it.

## Test evidence — red at `origin/main`, green here

Three new tests in `eventloop-watchdog.capture.test.ts`, driving the real inlined worker
source (it is neither type-checked nor linted, so spawning it is the only way it gets
exercised).

**At `origin/main`, with the new tests applied to the unfixed source:**

```
 ✓ 🔴 classifies a CPU-burning wedge as executing                              1986ms
 ✓ 🔴 classifies an idle wedge as starved, and skips the capture               1999ms
 ✓ 🔴 classifies a wedge as starved even while OTHER threads burn CPU          1953ms
 ✓ exposes the ratio distribution and the threshold echo                       1955ms
 × 🔴 records a decision for an executing wedge the starvation gate let through 11937ms
 × 🔴 records exactly one decision per detected wedge, whatever the verdict      2001ms
 × refuses a starved wedge at the starvation gate, not at the disabled check     1951ms

Error: watchdog metrics never settled: waited 10000ms for
  civitai_app_watchdog_capture_total{result="skipped-disabled"} = 1.
AssertionError: executing: expected +0 to be 1
AssertionError: expected NaN to be +0

Tests  3 failed | 9 passed (12)
```

The middle failure is the defect stated numerically: one wedge was detected, zero capture
decisions were recorded.

**On this branch:**

```
Test Files  1 passed (1)
     Tests  12 passed (12)
```

Both halves of the fix are independently covered — reverting only the `captureKeys`
entry, leaving the tally in place, reproduces the same 3 failures.

The regression test asserts the *executing* path, because that is the one that was
unobservable. The starvation protection is pinned separately, and by the verdict rather
than by a count, so removing the gate shows up as the verdict moving rather than as a
number staying the same.

### Also fixed: a latent race in the shared test helper

`runWedge` stored a single recovery beat and then scraped for up to 10s against a 300ms
threshold, so a scrape that outlived the threshold opened a second wedge mid-poll. Any
per-wedge counter would settle on 2 on a loaded runner and 1 everywhere else. The helper
now keeps beating for the duration of the scrape.

## Gates

| gate | result |
|---|---|
| `pnpm run typecheck` | OK — 0 type errors in 73s |
| `npx eslint` on both changed files | 0 problems |
| `npx prettier --check` on both changed files | clean (verified the check can go red on a known-bad file) |
| `pnpm run test:unit:run` | 15,258 passed, 17 skipped, 0 failed (976 files) |
| `pnpm run test:lint-rules` | 220 passed (6 files) |

`pnpm run lint` reports 393 errors repo-wide, all pre-existing; neither changed file
contributes any.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
