### PR TITLE
fix(challenges): gate challenge completion writes on the completion claim

### DIFF
--- a/src/server/games/daily-challenge/__tests__/challenge-degenerate-winners.test.ts
+++ b/src/server/games/daily-challenge/__tests__/challenge-degenerate-winners.test.ts
@@ -28,6 +28,7 @@ const {
   mockGetExistingWinnersForRetry,
   mockResolveEventContext,
   mockUpdateChallengeStatus,
+  mockCompleteChallengeIfClaimHeld,
   mockRefundUserChallengeFunds,
   mockCreateNotification,
   mockCreateChallengeWinner,
@@ -51,6 +52,7 @@ const {
   mockGetExistingWinnersForRetry: vi.fn().mockResolvedValue([]),
   mockResolveEventContext: vi.fn().mockResolvedValue(undefined),
   mockUpdateChallengeStatus: vi.fn().mockResolvedValue(undefined),
+  mockCompleteChallengeIfClaimHeld: vi.fn().mockResolvedValue(true),
   mockRefundUserChallengeFunds: vi.fn().mockResolvedValue({ refundedEntries: 0 }),
   mockCreateNotification: vi.fn().mockResolvedValue(undefined),
   mockCreateChallengeWinner: vi.fn(),
@@ -94,6 +96,8 @@ vi.mock('~/server/games/daily-challenge/daily-challenge.utils', async () => {
 });
 
 vi.mock('~/server/games/daily-challenge/challenge-helpers', () => ({
+  challengeClaimStillHeld: vi.fn().mockResolvedValue(true),
+  completeChallengeIfClaimHeld: mockCompleteChallengeIfClaimHeld,
   claimChallengeForCompletion: mockClaimChallengeForCompletion,
   computeDynamicPool: vi.fn(),
   distributePrizes: vi.fn(),
@@ -258,7 +262,7 @@ describe('pickWinnersForChallenge degenerate guard', () => {
         buzzAwarded: 500,
       })
     );
-    expect(mockUpdateChallengeStatus).not.toHaveBeenCalled();
+    expect(mockRefundUserChallengeFunds).not.toHaveBeenCalled();
   });
 
   it('calls generateWinners when there are 2+ distinct entrants (guard does not over-trigger)', async () => {
@@ -296,6 +300,8 @@ describe('pickWinnersForChallenge degenerate guard', () => {
     expect(mockGenerateWinners).not.toHaveBeenCalled();
     expect(mockCreateChallengeWinner).not.toHaveBeenCalled();
     expect(mockRefundUserChallengeFunds).toHaveBeenCalledWith(1);
-    expect(mockUpdateChallengeStatus).toHaveBeenCalledWith(1, 'Completed');
+    expect(mockCompleteChallengeIfClaimHeld).toHaveBeenCalledWith(
+      expect.objectContaining({ challengeId: 1 })
+    );
   });
 });

--- a/src/server/games/daily-challenge/__tests__/challenge-winner-mapping.test.ts
+++ b/src/server/games/daily-challenge/__tests__/challenge-winner-mapping.test.ts
@@ -99,6 +99,8 @@ vi.mock('~/server/games/daily-challenge/daily-challenge.utils', async () => {
 });
 
 vi.mock('~/server/games/daily-challenge/challenge-helpers', () => ({
+  challengeClaimStillHeld: vi.fn().mockResolvedValue(true),
+  completeChallengeIfClaimHeld: vi.fn().mockResolvedValue(true),
   claimChallengeForCompletion: mockClaimChallengeForCompletion,
   computeDynamicPool: vi.fn(),
   distributePrizes: vi.fn(),

--- a/src/server/games/daily-challenge/__tests__/challenge-winner-payout-dedupe.test.ts
+++ b/src/server/games/daily-challenge/__tests__/challenge-winner-payout-dedupe.test.ts
@@ -117,6 +117,8 @@ vi.mock('~/server/games/daily-challenge/daily-challenge.utils', async () => {
 });
 
 vi.mock('~/server/games/daily-challenge/challenge-helpers', () => ({
+  challengeClaimStillHeld: vi.fn().mockResolvedValue(true),
+  completeChallengeIfClaimHeld: vi.fn().mockResolvedValue(true),
   claimChallengeForCompletion: mockClaimChallengeForCompletion,
   computeDynamicPool: vi.fn(),
   distributePrizes: vi.fn(),

--- a/src/server/games/daily-challenge/challenge-helpers.ts
+++ b/src/server/games/daily-challenge/challenge-helpers.ts
@@ -907,9 +907,8 @@ export async function incrementOperationSpent(challengeId: number, amount: numbe
  * the run. `resetStuckCompletingChallenges` below revokes a `Completing` claim purely on elapsed
  * time — no liveness check, no ownership token — so a slow-but-alive run can have its claim taken
  * over by a second run while it is still executing. A re-claim overwrites the stamp, so a run that
- * re-reads the row and finds a DIFFERENT stamp knows it no longer owns the completion. That signal
- * is used to suppress duplicate TELEMETRY only (see `claimStillHeld` in daily-challenge-processing);
- * it does not gate any write, and the status writes remain unconditional as before.
+ * re-reads the row and finds a DIFFERENT stamp knows it no longer owns the completion — see
+ * `challengeClaimStillHeld` and `completeChallengeIfClaimHeld` below.
  */
 export async function claimChallengeForCompletion(challengeId: number): Promise<string | null> {
   const claimedAt = new Date().toISOString();
@@ -921,6 +920,55 @@ export async function claimChallengeForCompletion(challengeId: number): Promise<
     AND status = ${ChallengeStatus.Active}::"ChallengeStatus"
   `;
   return result > 0 ? claimedAt : null;
+}
+
+/**
+ * A stamp that is present AND different is the only proof of a takeover: an absent stamp reads the
+ * same whether nothing has claimed the row or the claim write is simply not visible yet, so it is
+ * treated as still held. Consequence: this can only ever stop a run that has demonstrably lost the
+ * challenge, never one that still owns it.
+ */
+export async function challengeClaimStillHeld(
+  challengeId: number,
+  claimedAt: string
+): Promise<boolean> {
+  const [row] = await dbWrite.$queryRaw<[{ held: boolean }?]>`
+    SELECT COALESCE(metadata->>'completingClaimedAt', '') IN ('', ${claimedAt}) AS held
+    FROM "Challenge"
+    WHERE id = ${challengeId}
+    LIMIT 1
+  `;
+  return row?.held ?? true;
+}
+
+/**
+ * Mark a challenge Completed only while this run still holds the claim it took, so a run that was
+ * evicted mid-flight cannot write an outcome over the run that replaced it. Same fail-open reading
+ * of a missing stamp as `challengeClaimStillHeld`.
+ *
+ * Returns whether the write landed; a `false` means some other run owns the completion, and the
+ * caller's completion side effects (telemetry, notifications) belong to that run instead.
+ */
+export async function completeChallengeIfClaimHeld({
+  challengeId,
+  claimedAt,
+  metadata,
+}: {
+  challengeId: number;
+  claimedAt: string;
+  metadata?: Prisma.InputJsonValue;
+}): Promise<boolean> {
+  const metadataUpdate =
+    metadata === undefined
+      ? Prisma.empty
+      : Prisma.sql`, metadata = ${JSON.stringify(metadata)}::jsonb`;
+  const result = await dbWrite.$executeRaw`
+    UPDATE "Challenge"
+    SET status = ${ChallengeStatus.Completed}::"ChallengeStatus"${metadataUpdate}
+    WHERE id = ${challengeId}
+    AND COALESCE(metadata->>'completingClaimedAt', '') IN ('', ${claimedAt})
+  `;
+  return result > 0;
 }
 
 /**

--- a/src/server/jobs/__tests__/challenge-completion-metrics.test.ts
+++ b/src/server/jobs/__tests__/challenge-completion-metrics.test.ts
@@ -32,7 +32,8 @@ const {
   mockClaimChallengeForCompletion,
   mockGetExistingWinnersForRetry,
   mockResolveEventContext,
-  mockUpdateChallengeStatus,
+  mockChallengeClaimStillHeld,
+  mockCompleteChallengeIfClaimHeld,
   mockRefundUserChallengeFunds,
   mockCreateNotification,
   mockCreateChallengeWinner,
@@ -58,7 +59,8 @@ const {
   mockClaimChallengeForCompletion: vi.fn().mockResolvedValue('2026-07-29T12:00:00.000Z'),
   mockGetExistingWinnersForRetry: vi.fn().mockResolvedValue([]),
   mockResolveEventContext: vi.fn().mockResolvedValue(undefined),
-  mockUpdateChallengeStatus: vi.fn().mockResolvedValue(undefined),
+  mockChallengeClaimStillHeld: vi.fn(),
+  mockCompleteChallengeIfClaimHeld: vi.fn(),
   mockRefundUserChallengeFunds: vi.fn().mockResolvedValue({ refundedEntries: 0 }),
   mockCreateNotification: vi.fn().mockResolvedValue(undefined),
   mockCreateChallengeWinner: vi.fn(),
@@ -115,7 +117,9 @@ vi.mock('~/server/games/daily-challenge/daily-challenge.utils', async () => {
 });
 
 vi.mock('~/server/games/daily-challenge/challenge-helpers', () => ({
+  challengeClaimStillHeld: mockChallengeClaimStillHeld,
   claimChallengeForCompletion: mockClaimChallengeForCompletion,
+  completeChallengeIfClaimHeld: mockCompleteChallengeIfClaimHeld,
   computeDynamicPool: vi.fn(),
   distributePrizes: vi.fn(),
   createChallengeRecord: vi.fn(),
@@ -126,7 +130,6 @@ vi.mock('~/server/games/daily-challenge/challenge-helpers', () => ({
   incrementOperationSpent: vi.fn().mockResolvedValue(undefined),
   resolveEventContext: mockResolveEventContext,
   setChallengeActive: vi.fn(),
-  updateChallengeStatus: mockUpdateChallengeStatus,
 }));
 
 vi.mock('~/server/games/daily-challenge/challenge-rewards', () => ({
@@ -176,11 +179,8 @@ vi.mock('~/utils/logging', () => ({
 
 const { pickWinnersForChallenge } = await import('~/server/jobs/daily-challenge-processing');
 const { ChallengeSource } = await import('~/shared/utils/prisma/enums');
-const {
-  recordChallengeCompleted,
-  recordChallengePrizePaidBuzz,
-  __resetChallengeMetricsForTest,
-} = await import('~/server/prom/challenge.metrics');
+const { recordChallengeCompleted, recordChallengePrizePaidBuzz, __resetChallengeMetricsForTest } =
+  await import('~/server/prom/challenge.metrics');
 
 const COMPLETED_METRIC = 'civitai_app_challenge_completed_total';
 const PRIZE_PAID_METRIC = 'civitai_app_challenge_prize_paid_buzz_total';
@@ -268,6 +268,19 @@ const CLAIM_STAMP = '2026-07-29T12:00:00.000Z';
 // The stamp a SECOND run would write after resetStuckCompletingChallenges revoked our claim.
 const TAKEOVER_STAMP = '2026-07-29T12:11:00.000Z';
 
+// Stands in for `Challenge.metadata.completingClaimedAt` as the row carries it while this run
+// executes; `undefined` is a row with no stamp at all.
+let rowClaimStamp: string | undefined = CLAIM_STAMP;
+
+// Mirrors the SQL predicate shared by both claim-guarded helpers: only a stamp that is present AND
+// different proves a takeover, so an absent stamp still lets the run through.
+const stampAllows = (claimedAt: string) =>
+  rowClaimStamp === undefined || rowClaimStamp === '' || rowClaimStamp === claimedAt;
+
+// Challenge ids this run actually managed to mark Completed — the claim-conditional write only
+// lands while the run still owns the challenge, so this stays empty for an evicted run.
+const completedChallengeIds: number[] = [];
+
 function challengeRecordWith(
   source: string,
   rowMetadata: Record<string, unknown> = { completingClaimedAt: CLAIM_STAMP }
@@ -323,6 +336,7 @@ function mockJudgedEntryRows(rows: Array<{ imageId: number; userId: number; user
  * TAKEOVER_STAMP to simulate this run's claim being revoked and re-taken mid-flight.
  */
 async function runTwoWinnerCompletion(source: string, rowStamp: string | undefined = CLAIM_STAMP) {
+  rowClaimStamp = rowStamp;
   const rowMetadata = rowStamp === undefined ? {} : { completingClaimedAt: rowStamp };
   mockGetChallengeById.mockResolvedValue(challengeRecordWith(source, rowMetadata));
   mockChallengeJudgeRow(source, rowMetadata);
@@ -358,7 +372,27 @@ beforeEach(() => {
   mockClaimChallengeForCompletion.mockResolvedValue(CLAIM_STAMP);
   mockGetExistingWinnersForRetry.mockResolvedValue([]);
   mockResolveEventContext.mockResolvedValue(undefined);
-  mockUpdateChallengeStatus.mockResolvedValue(undefined);
+  rowClaimStamp = CLAIM_STAMP;
+  completedChallengeIds.length = 0;
+  // Named so a failure reads "generateWinners" rather than "vi.fn()" — these are the mocks whose
+  // call counts carry the claim-guard assertions.
+  mockGenerateWinners.mockName('generateWinners');
+  mockCreateChallengeWinner.mockName('createChallengeWinner');
+  mockCreateBuzzTransactionMany.mockName('createBuzzTransactionMany');
+  mockCompleteChallengeIfClaimHeld.mockName('completeChallengeIfClaimHeld');
+  mockGetChallengeById.mockName('getChallengeById');
+  vi.mocked(recordChallengeCompleted).mockName('recordChallengeCompleted');
+  vi.mocked(recordChallengePrizePaidBuzz).mockName('recordChallengePrizePaidBuzz');
+  mockChallengeClaimStillHeld.mockImplementation(async (_challengeId: number, claimedAt: string) =>
+    stampAllows(claimedAt)
+  );
+  mockCompleteChallengeIfClaimHeld.mockImplementation(
+    async ({ challengeId, claimedAt }: { challengeId: number; claimedAt: string }) => {
+      const held = stampAllows(claimedAt);
+      if (held) completedChallengeIds.push(challengeId);
+      return held;
+    }
+  );
   mockRefundUserChallengeFunds.mockResolvedValue({ refundedEntries: 0 });
   mockDbWriteChallengeFindUnique.mockResolvedValue({ prizePool: 0, prizeDistribution: null });
   // Resolve to the PERSISTED row (fresh insert), the real return shape — see
@@ -380,7 +414,10 @@ describe('pickWinnersForChallenge — zero-entries completion telemetry', () => 
     await pickWinnersForChallenge(currentChallenge, BASE_CONFIG);
 
     // The completion actually happened...
-    expect(mockUpdateChallengeStatus).toHaveBeenCalledWith(1, 'Completed');
+    expect(mockCompleteChallengeIfClaimHeld).toHaveBeenCalledWith({
+      challengeId: 1,
+      claimedAt: CLAIM_STAMP,
+    });
     // ...and it was counted, once, with the right source.
     expect(recordChallengeCompleted).toHaveBeenCalledTimes(1);
     expect(recordChallengeCompleted).toHaveBeenCalledWith({ source: ChallengeSource.User });
@@ -471,9 +508,8 @@ describe('pickWinnersForChallenge — emit placement is retry-safe', () => {
   it('emits only AFTER the Completed status write, never at the payout call', async () => {
     await runTwoWinnerCompletion(ChallengeSource.System);
 
-    // Only one challenge.update runs for a System-source completion: the Completed write.
-    expect(mockDbWriteChallengeUpdate).toHaveBeenCalledTimes(1);
-    const completedWriteOrder = mockDbWriteChallengeUpdate.mock.invocationCallOrder[0];
+    expect(mockCompleteChallengeIfClaimHeld).toHaveBeenCalledTimes(1);
+    const completedWriteOrder = mockCompleteChallengeIfClaimHeld.mock.invocationCallOrder[0];
     const payoutOrder = mockCreateBuzzTransactionMany.mock.invocationCallOrder[0];
     const completedEmitOrder = vi.mocked(recordChallengeCompleted).mock.invocationCallOrder[0];
     const prizeEmitOrder = vi.mocked(recordChallengePrizePaidBuzz).mock.invocationCallOrder[0];
@@ -488,7 +524,7 @@ describe('pickWinnersForChallenge — emit placement is retry-safe', () => {
   });
 
   it('does not emit when the Completed status write throws', async () => {
-    mockDbWriteChallengeUpdate.mockRejectedValue(new Error('db down'));
+    mockCompleteChallengeIfClaimHeld.mockRejectedValue(new Error('db down'));
 
     await expect(runTwoWinnerCompletion(ChallengeSource.System)).rejects.toThrow('db down');
 
@@ -500,45 +536,96 @@ describe('pickWinnersForChallenge — emit placement is retry-safe', () => {
 // The ENTRY guard (claim never acquired) is covered above. This block covers the case that guard
 // cannot reach: the claim WAS acquired, then revoked mid-flight by resetStuckCompletingChallenges
 // (purely time-based — no liveness check, no ownership token) and re-taken by a second run, while
-// this run keeps executing. Both Completed writes are unconditional `UPDATE ... WHERE id = $1` with
-// no status predicate, so this run's write still lands; without a claim re-check it would also emit,
-// on top of the takeover run's emit. The re-checked claim stamp is what holds the counters to one
-// increment per completion.
-describe('pickWinnersForChallenge — claim REVOKED mid-flight (write still runs)', () => {
-  it('winners path: still performs the Completed write but does NOT emit', async () => {
-    await runTwoWinnerCompletion(ChallengeSource.System, TAKEOVER_STAMP);
-
-    // The unconditional write really did execute — this is the whole point of the case.
-    expect(mockDbWriteChallengeUpdate).toHaveBeenCalledTimes(1);
-    expect(mockDbWriteChallengeUpdate.mock.calls[0][0]).toMatchObject({
-      data: { status: 'Completed' },
+// this run keeps executing. Production close-time judging can outlast the 10-minute revocation, so
+// an evicted run reaching these lines is a normal outcome, not a freak one: on a 45-entry challenge
+// it produced two podiums, ~2x the comparison rows and ~2x the Buzz, with first and second place
+// decided by whichever run wrote last (#3822).
+//
+// A run in that state must not decide the outcome: the Completed write carries the claim as a
+// predicate, so it simply does not land, and the emits — which follow the write's own result —
+// stay with the run that owns the challenge.
+describe('pickWinnersForChallenge — claim REVOKED mid-flight', () => {
+  it('winners path: does NOT write Completed and does NOT emit', async () => {
+    // The takeover lands DURING judging — after the pre-judging guard has already let this run
+    // through — which is the only way to reach the final write having lost the claim.
+    mockGetChallengeById.mockResolvedValue(challengeRecordWith(ChallengeSource.System));
+    mockChallengeJudgeRow(ChallengeSource.System);
+    mockJudgedEntryRows([
+      { imageId: 1, userId: 100, username: 'alice' },
+      { imageId: 2, userId: 200, username: 'bob' },
+    ]);
+    mockDbWriteQueryRaw.mockResolvedValueOnce([]);
+    mockGenerateWinners.mockImplementation(async () => {
+      rowClaimStamp = TAKEOVER_STAMP;
+      return {
+        process: 'llm',
+        outcome: 'llm-picked',
+        model: 'test-model',
+        usage: {},
+        winners: [
+          { creator: 'alice', creatorId: 100, reason: 'best' },
+          { creator: 'bob', creatorId: 200, reason: 'second' },
+        ],
+      };
     });
-    // The payout ran too (it is retry-safe, so the takeover run re-issued the same one).
-    expect(mockCreateBuzzTransactionMany).toHaveBeenCalled();
 
-    // ...and neither counter moved, so the takeover run's own emits are the only ones.
+    await pickWinnersForChallenge(currentChallenge, BASE_CONFIG);
+
+    // Neither counter moved, so the takeover run's own emits are the only ones.
     expect(recordChallengeCompleted).not.toHaveBeenCalled();
     expect(recordChallengePrizePaidBuzz).not.toHaveBeenCalled();
     expect(await allSeries(COMPLETED_METRIC)).toHaveLength(0);
     expect(await allSeries(PRIZE_PAID_METRIC)).toHaveLength(0);
+
+    // ...because the write carried this run's stamp and was rejected by the claim predicate.
+    expect(completedChallengeIds).toEqual([]);
+    expect(mockCompleteChallengeIfClaimHeld.mock.calls[0]?.[0]).toMatchObject({
+      challengeId: 1,
+      claimedAt: CLAIM_STAMP,
+    });
   });
 
-  it('zero-entries path: still marks Completed but does NOT emit', async () => {
+  it('winners path: an evicted run stops before spending on judging', async () => {
+    // Takeover observed at the pre-judging re-check: the run must not buy a second podium, create a
+    // second set of winner rows, or pay a second time.
+    rowClaimStamp = TAKEOVER_STAMP;
+    mockGetChallengeById.mockResolvedValue(challengeRecordWith(ChallengeSource.System));
+    mockChallengeJudgeRow(ChallengeSource.System);
+    mockJudgedEntryRows([
+      { imageId: 1, userId: 100, username: 'alice' },
+      { imageId: 2, userId: 200, username: 'bob' },
+    ]);
+    mockDbWriteQueryRaw.mockResolvedValueOnce([]);
+
+    await pickWinnersForChallenge(currentChallenge, BASE_CONFIG);
+
+    expect(mockGenerateWinners).not.toHaveBeenCalled();
+    expect(mockCreateChallengeWinner).not.toHaveBeenCalled();
+    expect(mockCreateBuzzTransactionMany).not.toHaveBeenCalled();
+    expect(mockCompleteChallengeIfClaimHeld).not.toHaveBeenCalled();
+    expect(recordChallengeCompleted).not.toHaveBeenCalled();
+  });
+
+  it('zero-entries path: does NOT mark Completed and does NOT emit', async () => {
+    rowClaimStamp = TAKEOVER_STAMP;
     mockChallengeJudgeRow(ChallengeSource.User, { completingClaimedAt: TAKEOVER_STAMP });
     mockDbReadQueryRaw.mockResolvedValueOnce([]);
 
     await pickWinnersForChallenge(currentChallenge, BASE_CONFIG);
 
-    expect(mockUpdateChallengeStatus).toHaveBeenCalledWith(1, 'Completed');
     expect(recordChallengeCompleted).not.toHaveBeenCalled();
     expect(await allSeries(COMPLETED_METRIC)).toHaveLength(0);
+    expect(completedChallengeIds).toEqual([]);
+    // The run returned at the rejected write, so nothing downstream of it ran either.
+    expect(mockGetChallengeById).not.toHaveBeenCalled();
   });
 
-  it('fails OPEN when the row carries no claim stamp at all (replica lag is not a takeover)', async () => {
-    // A missing stamp is indistinguishable from a replica that has not caught up with our own claim
-    // write, so the gate must NOT suppress here — it may only ever drop a duplicate.
+  it('fails OPEN when the row carries no claim stamp at all (an unstamped row is not a takeover)', async () => {
+    // A missing stamp reads the same whether nothing claimed the row or our own claim write is not
+    // visible yet, so neither guard may fire on it — the run judges, completes and emits as normal.
     await runTwoWinnerCompletion(ChallengeSource.System, undefined);
 
+    expect(mockGenerateWinners).toHaveBeenCalledTimes(1);
     expect(recordChallengeCompleted).toHaveBeenCalledTimes(1);
     const series = await seriesFor(COMPLETED_METRIC, { source: 'System' });
     expect(series).toBeDefined();

--- a/src/server/jobs/__tests__/daily-challenge-processing.judging-categories.test.ts
+++ b/src/server/jobs/__tests__/daily-challenge-processing.judging-categories.test.ts
@@ -102,6 +102,8 @@ vi.mock('~/server/games/daily-challenge/daily-challenge.utils', async () => {
 });
 
 vi.mock('~/server/games/daily-challenge/challenge-helpers', () => ({
+  challengeClaimStillHeld: vi.fn().mockResolvedValue(true),
+  completeChallengeIfClaimHeld: vi.fn().mockResolvedValue(true),
   claimChallengeForCompletion: mockClaimChallengeForCompletion,
   computeDynamicPool: vi.fn(),
   distributePrizes: vi.fn(),

--- a/src/server/jobs/daily-challenge-processing.ts
+++ b/src/server/jobs/daily-challenge-processing.ts
@@ -5,7 +5,9 @@ import { NotificationCategory } from '~/server/common/enums';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { eventEngine } from '~/server/events';
 import {
+  challengeClaimStillHeld,
   claimChallengeForCompletion,
+  completeChallengeIfClaimHeld,
   computeDynamicPool,
   distributePrizes,
   createChallengeRecord,
@@ -16,7 +18,6 @@ import {
   incrementOperationSpent,
   resolveEventContext,
   setChallengeActive,
-  updateChallengeStatus,
   type ChallengeDetails,
   type EventContext,
   type RecentEntry,
@@ -1209,24 +1210,18 @@ async function logChallengeSpendMetric(challenge: ChallengeDetails) {
 }
 
 /**
- * True while `metadata.completingClaimedAt` still matches the stamp this run claimed with — i.e.
- * nobody has revoked and re-taken this completion since. TELEMETRY GATE ONLY: it guards the two
- * counter emits below and nothing else, so it can never change what is written or paid.
- *
- * Deliberately FAILS OPEN (returns true) when the row carries no stamp: `metadata` here is read
- * through the replica pool, where "no stamp yet" is indistinguishable from "the replica has not
- * caught up with our own claim write". Only a stamp that is present AND different is treated as
- * proof of a takeover. Consequence, stated plainly: this can only ever suppress a duplicate emit,
- * never manufacture one — and it does not make the emit exactly-once (see the emit sites).
+ * A run that has lost its completion claim stops here rather than judging, paying and writing an
+ * outcome alongside the run that took over. Best-effort telemetry; never throws.
  */
-function claimStillHeld(
-  metadata: Record<string, unknown> | null | undefined,
-  claimedAt: string | null
-): boolean {
-  if (!claimedAt) return false;
-  const current = metadata?.completingClaimedAt;
-  if (typeof current !== 'string' || current.length === 0) return true;
-  return current === claimedAt;
+function logClaimLost(challengeId: number | null, stage: string) {
+  log('Completion claim lost, abandoning run:', { challengeId, stage });
+  logToAxiom({
+    type: 'warning',
+    name: 'challenge-completion-claim-lost',
+    message: 'Completion claim was revoked and re-taken while this run was still executing',
+    challengeId,
+    stage,
+  }).catch(() => undefined);
 }
 
 /**
@@ -1250,7 +1245,7 @@ export async function pickWinnersForChallenge(
 
   // 1. Atomic claim — prevent duplicate processing. `claimedAt` is the stamp written to
   // metadata.completingClaimedAt; a later read showing a different stamp means this run's claim was
-  // revoked (resetStuckCompletingChallenges) and re-taken. Used to gate telemetry only.
+  // revoked (resetStuckCompletingChallenges) and re-taken, and this run must stop.
   const claimedAt = await claimChallengeForCompletion(currentChallenge.challengeId);
   if (!claimedAt) {
     log('Challenge already claimed for completion, skipping:', currentChallenge.challengeId);
@@ -1297,14 +1292,11 @@ export async function pickWinnersForChallenge(
               eventId: number | null;
               source: ChallengeSource;
               judgingCategories: unknown;
-              // Carried purely so the zero-entries emit below can re-check the claim stamp without
-              // a second round-trip — an extra COLUMN on a query that already runs, not a new read.
-              metadata: Record<string, unknown> | null;
             }
           | undefined
         ]
       >`
-        SELECT "judgeId", "judgingPrompt", "eventId", "source", "judgingCategories", "metadata" FROM "Challenge"
+        SELECT "judgeId", "judgingPrompt", "eventId", "source", "judgingCategories" FROM "Challenge"
         WHERE id = ${currentChallenge.challengeId}
         LIMIT 1
       `;
@@ -1379,28 +1371,29 @@ export async function pickWinnersForChallenge(
           await refundUserChallengeFunds(currentChallenge.challengeId);
           log('Refunded user challenge funds (no winners)');
         }
-        await updateChallengeStatus(currentChallenge.challengeId, ChallengeStatus.Completed);
+        const completed = await completeChallengeIfClaimHeld({
+          challengeId: currentChallenge.challengeId,
+          claimedAt,
+        });
+        if (!completed) {
+          logClaimLost(currentChallenge.challengeId, 'zero-entries-completion');
+          return;
+        }
         log('Challenge marked as completed (no entries)');
-        // Telemetry: emit AFTER the Completed write, never before, and only while this run still
-        // holds the claim it took at the top of the function.
-        //
-        // What that actually guarantees — stated precisely, because the write it follows does NOT
-        // provide exactly-once on its own: `updateChallengeStatus` is an unconditional
-        // `UPDATE ... WHERE id = $1` with no status predicate, and `resetStuckCompletingChallenges`
-        // is purely time-based, so a slow-but-alive run can be reset to Active, re-claimed by a
-        // second run, and STILL execute its own Completed write. The stamp check is what keeps that
-        // run from emitting a second time. Making the write itself conditional would be a real
-        // behaviour change and is deliberately out of scope.
-        //
-        // Residual window on THIS path: the freshest read of the row before the emit is the judge-row
-        // SELECT above, taken right after the claim — so a takeover during judging/refund is not
-        // observed here and would still double-count. The winners path below re-reads the row much
-        // later and is correspondingly tighter. Both fail open on a missing stamp (see claimStillHeld).
-        // `source`/`metadata` reuse the already-fetched judge row — no extra (throwable) query.
-        if (claimStillHeld(challengeJudgeRow?.metadata, claimedAt))
-          recordChallengeCompleted({ source: challengeJudgeRow?.source });
+        // Emit AFTER the Completed write: the write is what makes this run the one that completed
+        // the challenge, so a run whose write was rejected must not count a completion.
+        recordChallengeCompleted({ source: challengeJudgeRow?.source });
         const freshChallenge = await getChallengeById(currentChallenge.challengeId);
         if (freshChallenge) await logChallengeSpendMetric(freshChallenge);
+        return;
+      }
+
+      // Everything from here on spends (judging calls) and writes an outcome (winner rows, payouts,
+      // status). Judging a production-sized field can outlast the 10-minute claim revocation, so
+      // re-check ownership at the last point where stopping costs nothing — a run that has already
+      // been replaced would otherwise pick a second, different podium.
+      if (!(await challengeClaimStillHeld(currentChallenge.challengeId, claimedAt))) {
+        logClaimLost(currentChallenge.challengeId, 'pre-judging');
         return;
       }
 
@@ -1594,29 +1587,31 @@ export async function pickWinnersForChallenge(
     }
 
     const existingMetadata = parseChallengeMetadata(challengeRecord?.metadata);
-    await dbWrite.challenge.update({
-      where: { id: currentChallenge.challengeId },
-      data: {
-        metadata: {
-          ...existingMetadata,
-          completionSummary: {
-            judgingProcess: process,
-            outcome: outcome,
-            completedAt: new Date().toISOString(),
-          },
-          reconciliation: {
-            ...(existingMetadata.reconciliation ?? {}),
-            paidUserIds: Array.from(
-              new Set([
-                ...(existingMetadata.reconciliation?.paidUserIds ?? []),
-                ...paidParticipants,
-              ])
-            ),
-          },
+    const completed = await completeChallengeIfClaimHeld({
+      challengeId: currentChallenge.challengeId,
+      claimedAt,
+      metadata: {
+        ...existingMetadata,
+        completionSummary: {
+          judgingProcess: process,
+          outcome: outcome,
+          completedAt: new Date().toISOString(),
         },
-        status: ChallengeStatus.Completed,
-      },
+        reconciliation: {
+          ...(existingMetadata.reconciliation ?? {}),
+          paidUserIds: Array.from(
+            new Set([...(existingMetadata.reconciliation?.paidUserIds ?? []), ...paidParticipants])
+          ),
+        },
+      } as unknown as Prisma.InputJsonValue,
     });
+    if (!completed) {
+      // Winners and payouts this run already wrote stay behind — partial state left by an aborted
+      // run is #3842, not this guard's job. What stops here is everything that would announce or
+      // count an outcome this run no longer owns.
+      logClaimLost(currentChallenge.challengeId, 'winners-completion');
+      return;
+    }
     log('Challenge status updated to Completed');
 
     // Telemetry: emitted AFTER the Completed write, deliberately NOT next to the payout above.
@@ -1624,17 +1619,6 @@ export async function pickWinnersForChallenge(
     // and then crashes before this write is reset Completing -> Active and re-enters via the
     // `existingWinners` branch, which re-issues the same (already-settled) payout. An emit at the
     // payout site would count that Buzz twice.
-    //
-    // Post-write placement alone is NOT exactly-once, and the code does not pretend otherwise: this
-    // Completed write is an unconditional `UPDATE ... WHERE id = $1` (no status predicate), and
-    // `resetStuckCompletingChallenges` revokes a Completing claim on elapsed time alone with no
-    // liveness check — so a slow-but-alive run can lose its claim to a second run and still run this
-    // write. The `claimStillHeld` gate is what stops that run from emitting a second time:
-    // `challengeRecord` was read at step 7, AFTER judging and both payout steps, so a takeover during
-    // the long part of the run is observed here. Residual window: a takeover between that read and
-    // this line is not covered — closing it would mean a conditional write, i.e. a real behaviour
-    // change, which is out of scope. The gate fails open on a missing stamp (see claimStillHeld), so
-    // it can only ever suppress a duplicate, never a first emit under normal operation.
     //
     // Amount mirrors endChallengeAndPickWinners: the sum of the prizes SUBMITTED for the winners
     // paid on this completion (equal to each ChallengeWinner.buzzAwarded), not the configured prize
@@ -1644,14 +1628,12 @@ export async function pickWinnersForChallenge(
     // not move money is invisible here and is still counted. `winnerBuzzType` is the currency
     // buildWinnerPayoutTransactions actually paid in, and `challengeRecord` is already in scope —
     // neither needs a new query.
-    if (claimStillHeld(challengeRecord?.metadata, claimedAt)) {
-      recordChallengeCompleted({ source: challengeRecord?.source });
-      recordChallengePrizePaidBuzz({
-        source: challengeRecord?.source,
-        buzzType: winnerBuzzType,
-        amount: winningEntries.reduce((sum, e) => sum + (e.prize ?? 0), 0),
-      });
-    }
+    recordChallengeCompleted({ source: challengeRecord?.source });
+    recordChallengePrizePaidBuzz({
+      source: challengeRecord?.source,
+      buzzType: winnerBuzzType,
+      amount: winningEntries.reduce((sum, e) => sum + (e.prize ?? 0), 0),
+    });
 
     if (challengeRecord) await logChallengeSpendMetric(challengeRecord);
 

--- a/src/server/services/__tests__/challenge-completion-emit-boundary.service.test.ts
+++ b/src/server/services/__tests__/challenge-completion-emit-boundary.service.test.ts
@@ -27,6 +27,7 @@ const {
   mockDbWriteChallengeUpdate,
   mockDbWriteChallengeFindUnique,
   mockClaimChallengeForCompletion,
+  mockCompleteChallengeIfClaimHeld,
   mockGetChallengeById,
   mockGetExistingWinnersForRetry,
   mockCreateBuzzTransactionMany,
@@ -45,6 +46,7 @@ const {
     prizeDistribution: null,
   }),
   mockClaimChallengeForCompletion: vi.fn(),
+  mockCompleteChallengeIfClaimHeld: vi.fn().mockResolvedValue(true),
   mockGetChallengeById: vi.fn(),
   mockGetExistingWinnersForRetry: vi.fn(),
   mockCreateBuzzTransactionMany: vi.fn().mockResolvedValue(undefined),
@@ -111,6 +113,8 @@ vi.mock('~/server/games/daily-challenge/daily-challenge.utils', async () => {
 });
 
 vi.mock('~/server/games/daily-challenge/challenge-helpers', () => ({
+  challengeClaimStillHeld: vi.fn().mockResolvedValue(true),
+  completeChallengeIfClaimHeld: mockCompleteChallengeIfClaimHeld,
   buildChallengeModerationText: vi.fn(),
   claimChallengeForCompletion: mockClaimChallengeForCompletion,
   closeChallengeCollection: vi.fn().mockResolvedValue(undefined),
@@ -359,11 +363,8 @@ describe('mod -> job completion boundary — prize Buzz is counted exactly once'
 
     // The payout call really was made twice across the two runs — one settlement, two attempts.
     expect(mockCreateBuzzTransactionMany.mock.calls.length).toBeGreaterThanOrEqual(2);
-    // The job's Completed write landed.
-    expect(mockDbWriteChallengeUpdate).toHaveBeenCalledTimes(1);
-    expect(mockDbWriteChallengeUpdate.mock.calls[0][0]).toMatchObject({
-      data: { status: ChallengeStatus.Completed },
-    });
+    // The job's claim-conditional Completed write landed.
+    expect(mockCompleteChallengeIfClaimHeld).toHaveBeenCalledTimes(1);
 
     // ...and the Buzz was counted ONCE.
     expect(recordChallengePrizePaidBuzz).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Closes part of #3822 (option A — the guard, not the rolling-Swiss rework; independent of the pairwise branches).

## The bug

`pickWinnersForChallenge` checked its completion claim in exactly one place, and only to decide whether to emit two Prometheus counters (`claimStillHeld`'s own docblock said "TELEMETRY GATE ONLY"). `resetStuckCompletingChallenges` revokes a `Completing` claim on elapsed time alone, so a close-time judging stage longer than the 10-minute timeout is handed to a second run while the first is still executing — and the first kept judging, kept spending, and finished with an unconditional `UPDATE "Challenge" SET status = 'Completed' WHERE id = $1`.

Reproduced at production field size on a 45-entry challenge: two runs, 727 comparison rows instead of ~460, 403 Buzz instead of ~200, and first/second place decided by whichever run wrote last. Money is safe (payouts are keyed by deterministic `externalTransactionId`); the outcome is not.

## The fix

The claim now gates the writes, not just the telemetry:

- `completeChallengeIfClaimHeld` (new, in `challenge-helpers.ts`) writes `status = 'Completed'` (and, on the winners path, the completion metadata) with the claim stamp as an `UPDATE` predicate. It replaces both completion writes — the zero-entries path and the winners path — and returns whether the write landed.
- `challengeClaimStillHeld` (new) re-reads the stamp on the primary right before the judging call, so a run that has already been replaced stops instead of buying a second podium and creating a second set of winner rows.
- The two completion counters now follow the write's own result instead of a separately-read stamp, which also closes the read-then-write window the old comment called out as residual.
- An abort logs `challenge-completion-claim-lost` to Axiom with the stage (`pre-judging` / `zero-entries-completion` / `winners-completion`), so the condition is visible rather than inferred from a double payout.

**Missing-stamp semantics are unchanged.** Both new checks use `COALESCE(metadata->>'completingClaimedAt', '') IN ('', $claimedAt)` — the SQL equivalent of the old `claimStillHeld` fail-open. Only a stamp that is present *and* different stops a run, so this can never abort a run that still owns its challenge.

**Out of scope:** partial state left by a run that aborts after creating winners and paying but before completing is #3842, pre-existing and untouched. The winners-path abort deliberately leaves those rows alone and only stops the status write, the counters and the winner notifications, which belong to the run that owns the challenge.

## Tests

`challenge-completion-metrics.test.ts` grows a takeover model: the two claim helpers are faked against a simulated `metadata.completingClaimedAt`, so the tests exercise the same predicate the SQL uses. Three cases carry the fix — an evicted run that stops before judging, a takeover during judging that gets its final write rejected, and the zero-entries equivalent — plus the existing fail-open case, now asserted on both guards. The two older cases that pinned "the write still runs, only the emit is suppressed" were rewritten: that was the bug.

Each was checked by reverting the source and confirming the failure is readable:

| Test | Message with the fix reverted |
| --- | --- |
| an evicted run stops before spending on judging | `expected "generateWinners" to not be called at all, but actually been called 1 times` |
| winners path: does NOT write Completed and does NOT emit | `expected "recordChallengeCompleted" to not be called at all, but actually been called 1 times` |
| zero-entries path: does NOT mark Completed and does NOT emit | `expected "getChallengeById" to not be called at all, but actually been called 1 times` |

No new loops or loop-driving fakes.

## Verification

- `pnpm run typecheck` — no errors in any changed file (3 pre-existing environment errors remain in this worktree: a stale `@civitai/client` for LTX 2.5 and a missing `@opentelemetry/context-async-hooks`, both present at the base commit too).
- All 268 challenge-related suites green (3,622 tests).
- Sibling suites that mock `challenge-helpers` wholesale needed the two new exports added to their factories; `challenge-degenerate-winners` and `challenge-completion-emit-boundary` also had their Completed-write assertions retargeted at the new helper.
- Prettier run per-file (no repo-wide pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
