### PR TITLE
feat(dev-server): add `wt stale` and `wt rm` for worktree cleanup

### DIFF
--- a/.claude/skills/dev-server/cli.mjs
+++ b/.claude/skills/dev-server/cli.mjs
@@ -69,7 +69,7 @@ async function startDaemon() {
 
   // Wait for daemon to be ready
   for (let i = 0; i < 50; i++) {
-    await new Promise(r => setTimeout(r, 100));
+    await new Promise((r) => setTimeout(r, 100));
     if (await isDaemonRunning()) {
       return true;
     }
@@ -135,7 +135,7 @@ async function cmdLogs(sessionId, since) {
       console.error('No sessions found');
       process.exit(1);
     }
-    const running = listResult.data.sessions.find(s => s.status === 'running');
+    const running = listResult.data.sessions.find((s) => s.status === 'running');
     sessionId = running ? running.id : listResult.data.sessions[0].id;
   }
 
@@ -158,7 +158,7 @@ async function cmdTail(sessionId) {
       console.error('No sessions found');
       process.exit(1);
     }
-    const running = listResult.data.sessions.find(s => s.status === 'running');
+    const running = listResult.data.sessions.find((s) => s.status === 'running');
     sessionId = running ? running.id : listResult.data.sessions[0].id;
   }
 
@@ -306,7 +306,10 @@ async function cmdApp(name, subcmd) {
   }
 
   const [suffix, method] = route;
-  const result = await daemonRequest(`/app/${name}${suffix}`, method === 'POST' ? { method } : undefined);
+  const result = await daemonRequest(
+    `/app/${name}${suffix}`,
+    method === 'POST' ? { method } : undefined
+  );
   if (!result.ok) {
     console.error('Error:', result.error || result.data?.error || JSON.stringify(result.data));
     if (result.data?.available) console.error('Available apps:', result.data.available.join(', '));
@@ -325,6 +328,32 @@ async function cmdShutdown() {
   if (existsSync(pidFile)) {
     unlinkSync(pidFile);
   }
+}
+
+async function cmdWorktree(rest) {
+  const [action, ...tail] = rest;
+  const { cmdStale, cmdRemove } = await import('./scripts/worktree.mjs');
+
+  if (action === 'stale') {
+    await cmdStale(projectRoot, daemonRequest);
+    return;
+  }
+  if (action === 'rm') {
+    const target = tail.find((a) => !a.startsWith('--'));
+    if (!target) {
+      console.error('Usage: wt rm <worktree-path> [--stop-server] [--force]');
+      process.exit(1);
+    }
+    await cmdRemove(
+      projectRoot,
+      target,
+      { stopServer: tail.includes('--stop-server'), force: tail.includes('--force') },
+      daemonRequest
+    );
+    return;
+  }
+  console.error('Usage: wt <stale|rm>');
+  process.exit(1);
 }
 
 // Parse arguments
@@ -367,6 +396,9 @@ switch (command) {
   case 'shutdown':
     cmdShutdown();
     break;
+  case 'wt':
+    cmdWorktree(args.slice(1));
+    break;
   default:
     console.log(`Dev Server CLI
 
@@ -383,6 +415,9 @@ Commands:
   app                 List spoke apps (moderator, creator-studio, storage, notifications)
   app <name> [subcmd] Spoke app control (status|start|stop|restart|logs)
   shutdown            Shutdown the daemon
+  wt stale            List worktrees whose PR merged (read-only)
+  wt rm <path>        Remove a worktree safely (unlinks junctions first)
+                      [--stop-server] [--force]
 `);
     if (command) {
       console.error(`Unknown command: ${command}`);

--- a/.claude/skills/dev-server/scripts/worktree.mjs
+++ b/.claude/skills/dev-server/scripts/worktree.mjs
@@ -1,0 +1,271 @@
+/**
+ * Worktree teardown and staleness reporting.
+ *
+ * Links are unlinked before the recursive delete for SPEED, not safety: pnpm makes nearly every
+ * package a reparse point (8,180 under node_modules in one measured tree), and removing them as
+ * links avoids walking ~200k files through them. Seven delete instruments were tested against a
+ * sentinel behind a junction on 2026-08-12 and none followed the link, so the widely-repeated
+ * "recursive delete eats the junction target" did not reproduce — don't restore that claim without
+ * a fixture that shows it. The assert-zero gate stays as insurance against a tool or link type
+ * that behaves differently.
+ */
+
+import { execFileSync } from 'child_process';
+import { readdirSync, lstatSync, rmdirSync, rmSync, existsSync } from 'fs';
+import { resolve, sep } from 'path';
+
+function git(args, cwd) {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function gitQuiet(args, cwd) {
+  try {
+    return git(args, cwd);
+  } catch {
+    return null;
+  }
+}
+
+export function listWorktrees(primary) {
+  const out = git(['worktree', 'list', '--porcelain'], primary);
+  const trees = [];
+  let cur = null;
+  for (const line of out.split(/\r?\n/)) {
+    if (line.startsWith('worktree ')) {
+      cur = { path: resolve(line.slice(9)), branch: null, detached: false, locked: false };
+      trees.push(cur);
+    } else if (!cur) {
+      continue;
+    } else if (line.startsWith('branch refs/heads/')) {
+      cur.branch = line.slice('branch refs/heads/'.length);
+    } else if (line === 'detached') {
+      cur.detached = true;
+    } else if (line.startsWith('locked')) {
+      cur.locked = true;
+    }
+  }
+  return trees;
+}
+
+/** Depth-first, and deliberately does NOT descend into reparse points. */
+function findReparsePoints(root) {
+  const found = [];
+  const stack = [root];
+  while (stack.length) {
+    const dir = stack.pop();
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+      const full = dir + sep + entry.name;
+      let link = false;
+      try {
+        link = lstatSync(full).isSymbolicLink();
+      } catch {
+        continue;
+      }
+      if (link) found.push(full);
+      else if (entry.isDirectory()) stack.push(full);
+    }
+  }
+  return found.sort((a, b) => b.split(sep).length - a.split(sep).length);
+}
+
+/**
+ * `--is-ancestor` is useless here: the repo squash-merges, so a merged branch's tip is never an
+ * ancestor of origin/main. It reported "not merged" for 24 of 26 branches on one run.
+ */
+function mergedPr(branch, cwd) {
+  const raw = spawnGh(
+    ['pr', 'list', '--state', 'all', '--head', branch, '--json', 'number,state', '--limit', '5'],
+    cwd
+  );
+  if (!raw) return null;
+  let rows;
+  try {
+    rows = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  const merged = rows.find((r) => r.state === 'MERGED');
+  return merged ? merged.number : null;
+}
+
+function spawnGh(args, cwd) {
+  try {
+    return execFileSync('gh', args, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/** `git log --not --remotes` with no positive rev prints nothing and reads as "clean". */
+function unpushedCount(branch, cwd) {
+  const n = gitQuiet(['rev-list', '--count', branch, '--not', '--remotes'], cwd);
+  return n === null ? null : Number(n);
+}
+
+function dirtyCount(worktreePath) {
+  const out = gitQuiet(['status', '--porcelain'], worktreePath);
+  if (out === null) return null;
+  return out === '' ? 0 : out.split(/\r?\n/).length;
+}
+
+function lastCommit(worktreePath) {
+  return gitQuiet(['log', '-1', '--format=%ci'], worktreePath);
+}
+
+async function sessionsFor(worktreePath, daemonRequest) {
+  const res = await daemonRequest('/sessions');
+  if (!res.ok) return [];
+  const target = resolve(worktreePath).toLowerCase();
+  return (res.data.sessions || []).filter((s) => resolve(s.worktree).toLowerCase() === target);
+}
+
+export async function inspect(primary, daemonRequest) {
+  const trees = listWorktrees(primary);
+  const primaryPath = resolve(primary);
+  const rows = [];
+  for (const t of trees) {
+    const isPrimary = t.path === primaryPath;
+    const sessions = await sessionsFor(t.path, daemonRequest);
+    rows.push({
+      path: t.path,
+      branch: t.branch,
+      detached: t.detached,
+      isPrimary,
+      mergedPr: t.branch ? mergedPr(t.branch, primary) : null,
+      dirty: dirtyCount(t.path),
+      unpushed: t.branch ? unpushedCount(t.branch, primary) : null,
+      lastCommit: lastCommit(t.path),
+      sessions: sessions.map((s) => ({ id: s.id, port: s.port, status: s.status })),
+    });
+  }
+  return rows;
+}
+
+export async function cmdStale(primary, daemonRequest) {
+  const rows = await inspect(primary, daemonRequest);
+  const candidates = rows.filter((r) => !r.isPrimary);
+
+  const removable = candidates.filter((r) => r.mergedPr && !r.dirty && r.sessions.length === 0);
+  const blocked = candidates.filter((r) => !removable.includes(r));
+
+  console.log(`\nSAFE TO REMOVE (${removable.length}) - merged PR, clean tree, no dev server\n`);
+  if (!removable.length) console.log('  (none)');
+  for (const r of removable) {
+    const age = r.lastCommit ? r.lastCommit.slice(0, 10) : '?';
+    const warn = r.unpushed
+      ? `  [!] ${r.unpushed} commit(s) on no remote - branch will be KEPT`
+      : '';
+    console.log(`  ${r.path}`);
+    console.log(`      ${r.branch || '(detached)'}  PR #${r.mergedPr}  last commit ${age}${warn}`);
+  }
+
+  console.log(`\nKEEP (${blocked.length})\n`);
+  for (const r of blocked) {
+    const why = [];
+    if (r.sessions.length)
+      why.push(`dev server ${r.sessions.map((s) => `${s.id}:${s.port}`).join(',')}`);
+    if (r.dirty) why.push(`${r.dirty} uncommitted`);
+    if (!r.mergedPr) why.push(r.branch ? 'no merged PR' : 'detached');
+    console.log(`  ${r.path}`);
+    console.log(`      ${r.branch || '(detached)'}  ${why.join('; ')}`);
+  }
+  console.log('\nRemove one with:  node .claude/skills/dev-server/cli.mjs wt rm <path>\n');
+}
+
+export async function cmdRemove(primary, targetArg, opts, daemonRequest) {
+  const primaryPath = resolve(primary);
+  const target = resolve(targetArg);
+
+  if (target === primaryPath) fail('refusing to remove the primary worktree');
+
+  const trees = listWorktrees(primary);
+  const entry = trees.find((t) => t.path === target);
+  if (!entry) fail(`not a registered worktree: ${target}\nrun: git worktree list`);
+
+  const sessions = await sessionsFor(target, daemonRequest);
+  const live = sessions.filter((s) => s.status === 'running');
+  if (live.length && !opts.stopServer) {
+    fail(
+      `dev server running for this worktree (${live
+        .map((s) => `${s.id} on ${s.port}`)
+        .join(', ')})\n` + `stop it first, or re-run with --stop-server`
+    );
+  }
+  for (const s of sessions) {
+    await daemonRequest(`/sessions/${s.id}`, { method: 'DELETE' });
+    console.log(`stopped session ${s.id}`);
+  }
+
+  const dirty = dirtyCount(target);
+  if (dirty && !opts.force) {
+    fail(`${dirty} uncommitted change(s) in ${target}\ninspect them, or re-run with --force`);
+  }
+
+  const unpushed = entry.branch ? unpushedCount(entry.branch, primary) : null;
+
+  if (!existsSync(target)) {
+    console.log('directory already gone; pruning');
+  } else {
+    const links = findReparsePoints(target);
+    console.log(`reparse points: ${links.length}`);
+    for (const link of links) {
+      rmdirSync(link); // link-only; a recursive delete would walk THROUGH it
+    }
+    const left = findReparsePoints(target);
+    if (left.length) {
+      fail(
+        `${left.length} reparse point(s) still present - refusing to delete\n  ${left
+          .slice(0, 5)
+          .join('\n  ')}`
+      );
+    }
+    console.log('reparse points remaining: 0');
+
+    try {
+      rmSync(target, { recursive: true, force: true });
+    } catch (err) {
+      fail(
+        `could not delete ${target}: ${err.message}\nsomething is holding it open (a shell cwd'd inside it?)`
+      );
+    }
+    if (existsSync(target)) fail(`directory still present after delete: ${target}`);
+    console.log('directory deleted');
+  }
+
+  console.log(git(['worktree', 'prune', '-v'], primary) || 'pruned');
+
+  if (!entry.branch) return;
+
+  const pr = mergedPr(entry.branch, primary);
+  if (!pr) {
+    console.log(`branch KEPT: ${entry.branch} (no merged PR found)`);
+  } else if (unpushed) {
+    console.log(
+      `branch KEPT: ${entry.branch} (PR #${pr} merged, but ${unpushed} commit(s) exist on no remote)`
+    );
+  } else {
+    const sha = gitQuiet(['rev-parse', entry.branch], primary);
+    git(['branch', '-D', entry.branch], primary);
+    console.log(`branch deleted: ${entry.branch} (PR #${pr}, was ${sha})`);
+  }
+}
+
+function fail(msg) {
+  console.error(`\n${msg}\n`);
+  process.exit(1);
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,7 +325,42 @@ Comments are not type-checked, so they rot silently and become misleading. Write
 3. Start dev server: Use `/dev-server` skill
 
 ### Git Worktrees
-When you create a new worktree (`git worktree add …`), **always initialize the `event-engine-common` submodule
+
+Create one with (place it under the repos root — `scripts/defender-exclusions.ps1` excludes that path
+from Defender real-time scanning, and a tree outside it silently runs slow):
+
+```bash
+git fetch origin main
+git worktree add <repos-root>/wt-<name> -b <branch> origin/main   # origin/main, not a stale local main
+git -C <repos-root>/model-share submodule sync --recursive
+git -C <repos-root>/wt-<name> submodule update --init event-engine-common
+printf 'use flake\n' > <repos-root>/wt-<name>/.envrc && direnv allow   # from inside the worktree
+pnpm install
+```
+
+**Remove one when its PR merges** — don't hand-roll this, and don't reach for `git worktree remove`
+(it refuses whenever `event-engine-common` is checked out):
+
+```bash
+node .claude/skills/dev-server/cli.mjs wt stale        # what's finished, and what's blocking each keeper
+node .claude/skills/dev-server/cli.mjs wt rm <path>    # stops the server, unlinks links, deletes, prunes
+```
+
+`wt rm` refuses the primary worktree, a tree with uncommitted changes (`--force`), and a tree with a
+running dev server (`--stop-server`). It deletes the branch only when `gh` reports a **merged** PR, keeps
+it when commits exist on no remote, and prints the SHA when it does delete. Left alone, worktrees
+accumulate: 22 stale ones were removed in one sweep on 2026-08-12, 15 with already-merged PRs.
+
+**Two checks that fail *clean* if you verify merge state yourself.** Both return success-shaped output
+while telling you nothing:
+- `git merge-base --is-ancestor <branch> origin/main` — this repo squash-merges, so a merged branch's tip
+  is never an ancestor. It reported "not merged" for 24 of 26 branches, including ones demonstrably in
+  `main`. Use `gh pr list --state all --head <branch>`.
+- `git log --not --remotes` with **no positive rev** prints nothing, which reads as "no unpushed commits."
+  It has nothing to list commits *from*. Use `git rev-list --count <branch> --not --remotes` — run
+  correctly, six branches turned out to hold commits that existed on no remote at all.
+
+When you create a new worktree, **always initialize the `event-engine-common` submodule
 in it**: `git submodule sync --recursive && git submodule update --init event-engine-common`.
 Worktrees don't check out submodules automatically,
 and without it `pnpm typecheck`/`build` fail with a wall of `Cannot find module '.../event-engine-common/...'`


### PR DESCRIPTION
`git worktree remove` refuses whenever `event-engine-common` is checked out, and `submodule deinit` doesn't help, so removal has been hand-rolled per agent. Two instruments have caused real cascades that way:

- `git worktree remove --force` — 667 tracked files under `packages/` on one occasion, 1,314 on another, the second *after* the junction had been removed and verified gone (pnpm links `packages/*` from inside the worktree too).
- `Get-ChildItem -Recurse` used to **find** the links — it follows reparse points into the primary and returns paths that resolve outside the worktree; deleting those took out 867 files. The enumeration did the damage, not the delete.

A plain recursive delete is **not** the hazard: tested seven ways against a real junction (`Remove-Item -Recurse`, `fs.rmSync`, `rd /s /q`, `rmdir /s /q`, piped `Get-ChildItem`, git-bash `rm -rf`, and a `/D` symlink) the target survived every time.

## What this adds

`wt rm <path>` avoids both vectors — no `--force`, and a stack-based enumeration that never descends into a link. It unlinks every reparse point, asserts zero remain before deleting, prunes, and deletes the branch only when `gh` reports a merged PR: printing the SHA when it does, keeping the branch when commits exist on no remote. Refuses the primary worktree, a dirty tree without `--force`, and a tree with a live dev server without `--stop-server`.

`wt stale` is the read-only half: every worktree split into safe-to-remove and keep, with the blocking reason named.

The point is that the refusals live in one place instead of in every agent's head.

## Verification

Run against `wt-remix-button`: 8,529 reparse points unlinked, **zero remaining** before the delete, branch removed with its SHA printed, and the primary's `git ls-files packages` unchanged at 1,364 with a clean `git status`. That pair is the probe that actually detects a cascade — counting entries in root `node_modules` checks the one thing the hazard does not touch.

Context: 22 worktrees and ~70 GiB were cleaned in one sweep on 2026-08-12, 15 of them with already-merged PRs. Nothing removes a tree when its PR merges, which is why they accumulate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)