### PR TITLE
feat(stickers): report a sticker from the sticker itself

### DIFF
--- a/src/components/Modals/ReportModal.tsx
+++ b/src/components/Modals/ReportModal.tsx
@@ -32,7 +32,6 @@ import { showErrorNotification, showSuccessNotification } from '~/utils/notifica
 import { trpc } from '~/utils/trpc';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 import { getDisplayName } from '~/utils/string-helpers';
-import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { StickerPlacementForm } from '~/components/Report/StickerPlacementForm';
 import { ReportTargetProvider } from '~/components/Report/report-target.context';
 
@@ -134,7 +133,9 @@ const reports = [
     // report exists to carry.
     key: 'sticker-placement',
     reason: ReportReason.StickerPlacement,
-    label: 'Bad sticker placement',
+    // Never rendered in the reason list — this entry is reachable only from the
+    // flag on a sticker — so the label is the modal's title and nothing else.
+    label: 'Report this sticker',
     Element: StickerPlacementForm,
     availableFor: [ReportEntity.Image],
   },
@@ -170,15 +171,27 @@ const SEND_REPORT_ID = 'sending-report';
 export type ReportModalProps = {
   entityType: ReportEntity;
   entityId: number;
+  /**
+   * Open straight onto one form instead of the reason list.
+   *
+   * For a report that starts from the thing being reported rather than from the
+   * page it sits on: the flag on a sticker already knows the reason and the
+   * sticker, so a list of reasons is a question with one answer.
+   */
+  reportKey?: string;
+  /** The placement the flag was on, when the report started there. */
+  placementId?: number;
+  /** Which half of that placement the flag was on. */
+  placementTarget?: 'sticker' | 'comment';
 };
 
 export default function ReportModal({
   entityType,
   entityId,
-}: {
-  entityType: ReportEntity;
-  entityId: number;
-}) {
+  reportKey: initialReportKey,
+  placementId,
+  placementTarget,
+}: ReportModalProps) {
   const dialog = useDialogContext();
 
   // #region [temp for gallery image reports]
@@ -192,7 +205,7 @@ export default function ReportModal({
   // sticker — and keying on the reason silently resolved to whichever was
   // declared first, so picking the sticker option ran the generic TOS form and
   // filed a report with no placement id in it.
-  const [reportKey, setReportKey] = useState<string>();
+  const [reportKey, setReportKey] = useState<string | undefined>(initialReportKey);
   const [uploading, setUploading] = useState(false);
   const selected = useMemo(
     () => reports.find((x) => x.key === reportKey && x.availableFor.includes(entityType)) ?? null,
@@ -200,7 +213,10 @@ export default function ReportModal({
   );
   const reason = selected?.reason;
   const ReportForm = selected?.Element ?? null;
-  const title = selected?.label ?? `Report ${getDisplayName(entityType)}`;
+  const title =
+    selected?.key === 'sticker-placement' && placementTarget === 'comment'
+      ? 'Report this note'
+      : selected?.label ?? `Report ${getDisplayName(entityType)}`;
   const handleVote = useVoteForTags({ entityType: entityType as 'image' | 'model', entityId });
 
   const queryUtils = trpc.useUtils();
@@ -320,7 +336,6 @@ export default function ReportModal({
   };
 
   const currentUser = useCurrentUser();
-  const features = useFeatureFlags();
   useEffect(() => {
     if (currentUser) return;
     router.push(getLoginLink({ returnUrl: router.asPath, reason: 'report-content' }));
@@ -332,7 +347,10 @@ export default function ReportModal({
       <Stack>
         <Group justify="space-between" wrap="nowrap">
           <Group gap={4}>
-            {!!selected && (
+            {/* No way back when the reason arrived with the modal: the list
+                behind it was never shown, so "back" would land on a choice the
+                reporter did not make. */}
+            {!!selected && !initialReportKey && (
               <LegacyActionIcon onClick={() => setReportKey(undefined)}>
                 <IconArrowLeft size={16} />
               </LegacyActionIcon>
@@ -362,10 +380,12 @@ export default function ReportModal({
                         return !data?.reportStats?.ownershipPending;
                       }
                     }
-                    // Offering a reason for a feature the reporter cannot see is
-                    // an invitation to a form with nothing in it.
-                    if (item.reason === ReportReason.StickerPlacement)
-                      return !!features.stickerPlacement;
+                    // Reachable only from the flag on the sticker itself, never
+                    // from the image. Offered here it would have to ask which
+                    // sticker, and several copies of one sticker on an image are
+                    // indistinguishable in a list — the guess a moderator then
+                    // acts on is what the flag exists to remove.
+                    if (item.reason === ReportReason.StickerPlacement) return false;
                     return true;
                   }) // TEMP FIX
                   .map(({ key, label }) => (
@@ -376,7 +396,7 @@ export default function ReportModal({
           )
         )}
         {ReportForm && (
-          <ReportTargetProvider value={{ entityType, entityId }}>
+          <ReportTargetProvider value={{ entityType, entityId, placementId, placementTarget }}>
             <ReportForm onSubmit={handleSubmit} setUploading={setUploading}>
               <Group grow>
                 <Button variant="default" onClick={dialog.onClose}>

--- a/src/components/Report/StickerPlacementForm.tsx
+++ b/src/components/Report/StickerPlacementForm.tsx
@@ -29,7 +29,7 @@ function StickerPlacementFields({
   const placementId = target?.placementId;
   const half = target?.placementTarget ?? 'sticker';
 
-  const { data, isLoading } = trpc.placement.getStickerPlacementDetail.useQuery(
+  const { data, isLoading, isError } = trpc.placement.getStickerPlacementDetail.useQuery(
     { placementId: placementId as number },
     { enabled: !!placementId, staleTime: 5 * 60_000 }
   );
@@ -64,6 +64,19 @@ function StickerPlacementFields({
     <Stack gap="xs">
       {isLoading ? (
         <Skeleton height={48} radius="sm" />
+      ) : isError || !data ? (
+        // Named or nothing. The line below is the reporter's only confirmation
+        // that the right sticker was flagged, and rendering the generic version
+        // of it over a failed lookup is the form claiming to have checked
+        // something it could not. The report still sends: a sticker taken down
+        // between the flag and the modal is exactly what someone might be
+        // reporting, and the queue shows a moderator that it is already gone.
+        <Alert color="yellow">
+          <Text size="xs">
+            We couldn&apos;t load this sticker — it may have just been removed. You can still send
+            the report.
+          </Text>
+        </Alert>
       ) : (
         <Group gap={8} wrap="nowrap">
           {art && (

--- a/src/components/Report/StickerPlacementForm.tsx
+++ b/src/components/Report/StickerPlacementForm.tsx
@@ -1,87 +1,87 @@
-import { Alert, Text } from '@mantine/core';
+import { Alert, Group, Skeleton, Stack, Text } from '@mantine/core';
+import { useEffect } from 'react';
+import type { UseFormReturn } from 'react-hook-form';
+import type * as z from 'zod';
 import { EdgeImage } from '~/components/EdgeMedia/EdgeImage';
 import { useReportTarget } from '~/components/Report/report-target.context';
 import { createReportForm } from '~/components/Report/create-report-form';
-import { useStickerPlacements } from '~/components/Sticker/placement.util';
 import { useStickerCosmetics } from '~/components/Sticker/sticker.util';
-import { InputRadioGroup, InputTextArea } from '~/libs/form';
+import { InputTextArea } from '~/libs/form';
 import { reportStickerPlacementDetailsSchema } from '~/server/schema/report.schema';
-import { Radio, Stack, Group } from '@mantine/core';
+import { trpc } from '~/utils/trpc';
 
 /**
- * Reporting a sticker someone placed on this image.
+ * Reporting a sticker someone placed on this image, or the note hanging off it.
  *
- * The reporter picks the placement. An image can carry several, and a report
- * that only says "a sticker here is abusive" makes a moderator guess — the wrong
- * guess removes an innocent person's sticker and takes their Buzz with it.
+ * The form asks nothing about which one. It is only reached from a flag on the
+ * sticker itself, so the placement and the half being reported both arrive with
+ * the modal — the picker this replaced could not tell four copies of the same
+ * sticker apart, and a moderator acted on the guess.
  */
-function StickerPlacementFields() {
-  const target = useReportTarget();
-  const imageIds = target ? [target.entityId] : [];
-  const { byImage } = useStickerPlacements(imageIds, !!target);
-  const placements = target ? byImage.get(target.entityId) ?? [] : [];
-  const { sticker } = useStickerCosmetics(placements.map((p) => p.data.cosmeticId));
+type DetailsSchema = typeof reportStickerPlacementDetailsSchema;
 
-  // The field stays mounted with no options rather than being replaced by the
-  // alert. `placementId` is required and Submit lives in the parent modal, so an
-  // unmounted field meant pressing Submit failed validation with nowhere to
-  // render the error — the button simply did nothing.
-  if (!placements.length)
+function StickerPlacementFields({
+  context,
+}: {
+  context: { form: UseFormReturn<z.input<DetailsSchema>, any, z.output<DetailsSchema>> };
+}) {
+  const target = useReportTarget();
+  const placementId = target?.placementId;
+  const half = target?.placementTarget ?? 'sticker';
+
+  const { data, isLoading } = trpc.placement.getStickerPlacementDetail.useQuery(
+    { placementId: placementId as number },
+    { enabled: !!placementId, staleTime: 5 * 60_000 }
+  );
+  const cosmeticId = data?.sticker?.id;
+  const { sticker } = useStickerCosmetics(cosmeticId ? [cosmeticId] : []);
+  const art = cosmeticId ? sticker.get(cosmeticId) : undefined;
+
+  const { setValue } = context.form;
+
+  // Written into the form rather than assembled beside it at submit, so the
+  // value the report carries is the value the schema validated. Two sources of
+  // truth for the one field that decides which sticker a moderator acts on is
+  // how the wrong person loses a sticker and the Buzz under it.
+  useEffect(() => {
+    if (placementId) setValue('placementId', placementId);
+    setValue('target', half);
+  }, [placementId, half, setValue]);
+
+  // Unreachable from the app: nothing opens this form without a placement. Said
+  // out loud anyway, because the alternative is a Submit button that fails
+  // validation on a field with nowhere to render the error and so does nothing.
+  if (!placementId)
     return (
-      <Stack gap="xs">
-        <Alert color="yellow">
-          <Text size="xs">
-            There are no stickers on this image right now. If one was just removed, there is nothing
-            left to report.
-          </Text>
-        </Alert>
-        <InputRadioGroup name="placementId" label="Which sticker?" withAsterisk>
-          <div />
-        </InputRadioGroup>
-      </Stack>
+      <Alert color="yellow">
+        <Text size="xs">
+          Report a sticker from the flag on the sticker itself, so we know which one you mean.
+        </Text>
+      </Alert>
     );
 
   return (
     <Stack gap="xs">
-      <InputRadioGroup name="placementId" label="Which sticker?" withAsterisk>
-        <Stack gap={4}>
-          {placements.map((placement) => {
-            const art = sticker.get(placement.data.cosmeticId);
-            return (
-              <Radio
-                key={placement.id}
-                value={String(placement.id)}
-                label={
-                  <Group gap={6} wrap="nowrap">
-                    {art && (
-                      <EdgeImage
-                        src={art.url}
-                        alt={`:${art.slug}:`}
-                        options={{ height: 64, anim: art.animated, optimized: true }}
-                        style={{ height: 32, width: 'auto' }}
-                      />
-                    )}
-                    <Text size="xs">{art ? `:${art.slug}:` : `Placement ${placement.id}`}</Text>
-                  </Group>
-                }
-              />
-            );
-          })}
-        </Stack>
-      </InputRadioGroup>
-
-      {/* Offered only where a note exists to report. The two are separately
-          objectionable — a fine sticker can carry an abusive note — and they
-          have different remedies, since the owner can hide a note without the
-          sticker coming off. Hidden entirely when no placement here has one,
-          rather than asked and ignored. */}
-      {placements.some((placement) => placement.hasComment) && (
-        <InputRadioGroup name="target" label="What are you reporting?">
-          <Stack gap={4}>
-            <Radio value="sticker" label="The sticker itself" />
-            <Radio value="comment" label="The note attached to it" />
-          </Stack>
-        </InputRadioGroup>
+      {isLoading ? (
+        <Skeleton height={48} radius="sm" />
+      ) : (
+        <Group gap={8} wrap="nowrap">
+          {art && (
+            <EdgeImage
+              src={art.url}
+              alt={`:${art.slug}:`}
+              options={{ height: 96, anim: art.animated, optimized: true }}
+              style={{ height: 48, width: 'auto' }}
+            />
+          )}
+          {/* Named back, not chosen. Showing the sticker is the confirmation
+              that the right one was flagged, which is the job the list did
+              badly. */}
+          <Text size="sm">
+            Reporting {half === 'comment' ? 'the note on ' : ''}
+            {data?.sticker?.name ? <strong>{data.sticker.name}</strong> : 'this sticker'}.
+          </Text>
+        </Group>
       )}
 
       <InputTextArea

--- a/src/components/Report/report-target.context.tsx
+++ b/src/components/Report/report-target.context.tsx
@@ -9,7 +9,22 @@ import { createContext, useContext } from 'react';
  * form somehow. A context keeps that to the one form that needs it instead of
  * threading an id through every other.
  */
-type ReportTarget = { entityType: string; entityId: number };
+type ReportTarget = {
+  entityType: string;
+  entityId: number;
+  /**
+   * The placement being reported. A sticker report starts from the sticker's own
+   * flag, so this is always set on that path — there is no route that reaches
+   * the form without it, and the form asks nothing about which sticker.
+   */
+  placementId?: number;
+  /**
+   * Which half of the placement the flag was on — the artwork or the note
+   * hanging off it. Each has its own flag, so the reporter never picks: they
+   * pressed the one next to the thing they object to.
+   */
+  placementTarget?: 'sticker' | 'comment';
+};
 
 const ReportTargetContext = createContext<ReportTarget | null>(null);
 

--- a/src/components/Sticker/RemoveReportedPlacement.tsx
+++ b/src/components/Sticker/RemoveReportedPlacement.tsx
@@ -94,43 +94,51 @@ export function RemoveReportedPlacement({
 
   return (
     <Stack gap="xs">
-      {target === 'comment' && (
-        // The subject of the complaint, quoted where the action is taken. The
-        // service hands moderators the text even when the owner has hidden it,
-        // for exactly this: the alternative is answering a report about words
-        // nobody in the queue can read.
+      {!!placement.comment && (
+        // Shown whenever there is a note, not only when the reporter said the
+        // note was the problem. The service hands moderators the text even when
+        // the owner has hidden it, for exactly this — and the two reports on one
+        // placement do not dedupe, so the sticker-target one often arrives
+        // first, from someone who classified it differently to what a moderator
+        // finds when they look. `target` says what was reported; it does not
+        // decide which remedies exist.
         <Stack gap={4}>
           <Text size="xs" c="dimmed">
-            Reported: the note attached to this sticker
+            {target === 'comment' ? 'Reported: the note attached to this sticker' : 'Its note'}
             {placement.commentHidden ? ' (already hidden)' : ''}
           </Text>
           <div className="rounded-md bg-gray-2 px-2 py-1.5 dark:bg-dark-5">
             <Text size="sm" className="whitespace-pre-wrap break-words">
-              {/* Says what is true without guessing which: a report can name a
-                  note that has since gone, and one can be filed about a sticker
-                  that never carried a note at all. */}
-              {placement.comment ?? 'There is no note on this sticker.'}
+              {placement.comment}
             </Text>
           </div>
           <Group gap="xs" justify="space-between">
             <Text size="xs" c="dimmed">
-              Hiding leaves the sticker up and is reversible. Removing takes the whole sticker off.
+              Hiding leaves the sticker up and is reversible, and the owner can put it back.
+              Removing takes the whole sticker off.
             </Text>
-            {!!placement.comment && (
-              <Button
-                variant="default"
-                size="compact-sm"
-                leftSection={
-                  placement.commentHidden ? <IconEye size={14} /> : <IconEyeOff size={14} />
-                }
-                loading={setHidden.isPending}
-                onClick={() => setHidden.mutate({ placementId, hidden: !placement.commentHidden })}
-              >
-                {placement.commentHidden ? 'Restore note' : 'Hide note'}
-              </Button>
-            )}
+            <Button
+              variant="default"
+              size="compact-sm"
+              leftSection={
+                placement.commentHidden ? <IconEye size={14} /> : <IconEyeOff size={14} />
+              }
+              loading={setHidden.isPending}
+              onClick={() => setHidden.mutate({ placementId, hidden: !placement.commentHidden })}
+            >
+              {placement.commentHidden ? 'Restore note' : 'Hide note'}
+            </Button>
           </Group>
         </Stack>
+      )}
+      {!placement.comment && target === 'comment' && (
+        // The report says the note is the problem and there is no note. Nothing
+        // cross-checks the two at submit, and a note cannot be edited away, so
+        // this is a forged or mistaken classification rather than a race — and
+        // the moderator should see that rather than an empty panel.
+        <Text size="xs" c="dimmed">
+          This report names a note, but the sticker has none.
+        </Text>
       )}
       <Group justify="space-between">
         <Text size="sm">

--- a/src/components/Sticker/RemoveReportedPlacement.tsx
+++ b/src/components/Sticker/RemoveReportedPlacement.tsx
@@ -1,6 +1,6 @@
 import { Alert, Button, Group, Stack, Text } from '@mantine/core';
 import { openConfirmModal } from '@mantine/modals';
-import { IconTrash } from '@tabler/icons-react';
+import { IconEye, IconEyeOff, IconTrash } from '@tabler/icons-react';
 import { useForgetStickerPlacement } from '~/components/Sticker/placement.util';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
@@ -27,11 +27,25 @@ export function RemoveReportedPlacement({
   target?: 'sticker' | 'comment';
 }) {
   const forget = useForgetStickerPlacement();
+  const utils = trpc.useUtils();
 
   const { data: placement, isLoading } = trpc.placement.getStickerPlacementDetail.useQuery(
     { placementId },
     { retry: false }
   );
+
+  // The proportionate answer to a note report, and it is a moderator's to give:
+  // `setStickerCommentHidden` takes `isModerator` and waives the owner check.
+  // Without it the only button here removes a sticker whose artwork nobody
+  // complained about — and on a pending one, forfeits what the placer paid.
+  const setHidden = trpc.placement.setStickerCommentHidden.useMutation({
+    onSuccess: (result) => {
+      showSuccessNotification({ message: result.hidden ? 'Note hidden.' : 'Note restored.' });
+      return utils.placement.getStickerPlacementDetail.invalidate({ placementId });
+    },
+    onError: (error) =>
+      showErrorNotification({ title: "Couldn't change the note", error: new Error(error.message) }),
+  });
 
   const remove = trpc.placement.removePlacement.useMutation({
     onSuccess: async (result) => {
@@ -88,16 +102,34 @@ export function RemoveReportedPlacement({
         <Stack gap={4}>
           <Text size="xs" c="dimmed">
             Reported: the note attached to this sticker
-            {placement.commentHidden ? ' (the owner has already hidden it)' : ''}
+            {placement.commentHidden ? ' (already hidden)' : ''}
           </Text>
           <div className="rounded-md bg-gray-2 px-2 py-1.5 dark:bg-dark-5">
             <Text size="sm" className="whitespace-pre-wrap break-words">
-              {placement.comment ?? 'The note is no longer available.'}
+              {/* Says what is true without guessing which: a report can name a
+                  note that has since gone, and one can be filed about a sticker
+                  that never carried a note at all. */}
+              {placement.comment ?? 'There is no note on this sticker.'}
             </Text>
           </div>
-          <Text size="xs" c="dimmed">
-            Removing takes the whole sticker off. Only the image owner can hide a note.
-          </Text>
+          <Group gap="xs" justify="space-between">
+            <Text size="xs" c="dimmed">
+              Hiding leaves the sticker up and is reversible. Removing takes the whole sticker off.
+            </Text>
+            {!!placement.comment && (
+              <Button
+                variant="default"
+                size="compact-sm"
+                leftSection={
+                  placement.commentHidden ? <IconEye size={14} /> : <IconEyeOff size={14} />
+                }
+                loading={setHidden.isPending}
+                onClick={() => setHidden.mutate({ placementId, hidden: !placement.commentHidden })}
+              >
+                {placement.commentHidden ? 'Restore note' : 'Hide note'}
+              </Button>
+            )}
+          </Group>
         </Stack>
       )}
       <Group justify="space-between">

--- a/src/components/Sticker/RemoveReportedPlacement.tsx
+++ b/src/components/Sticker/RemoveReportedPlacement.tsx
@@ -14,7 +14,18 @@ import { trpc } from '~/utils/trpc';
  * removal is not reversible, and an id alone does not tell you whose sticker you
  * are taking down.
  */
-export function RemoveReportedPlacement({ placementId }: { placementId: number }) {
+export function RemoveReportedPlacement({
+  placementId,
+  target = 'sticker',
+}: {
+  placementId: number;
+  /**
+   * Which half the report is about. A note report is answered by reading the
+   * note, and this query is the only place a moderator can — the text is not on
+   * the report row, and the feed listing strips it.
+   */
+  target?: 'sticker' | 'comment';
+}) {
   const forget = useForgetStickerPlacement();
 
   const { data: placement, isLoading } = trpc.placement.getStickerPlacementDetail.useQuery(
@@ -68,20 +79,42 @@ export function RemoveReportedPlacement({ placementId }: { placementId: number }
     });
 
   return (
-    <Group justify="space-between">
-      <Text size="sm">
-        {placement.sticker?.name ?? `Placement ${placementId}`} &middot;{' '}
-        {placement.placer?.username ?? 'unknown placer'}
-      </Text>
-      <Button
-        color="red"
-        size="compact-sm"
-        leftSection={<IconTrash size={14} />}
-        loading={remove.isPending}
-        onClick={confirm}
-      >
-        Remove placement
-      </Button>
-    </Group>
+    <Stack gap="xs">
+      {target === 'comment' && (
+        // The subject of the complaint, quoted where the action is taken. The
+        // service hands moderators the text even when the owner has hidden it,
+        // for exactly this: the alternative is answering a report about words
+        // nobody in the queue can read.
+        <Stack gap={4}>
+          <Text size="xs" c="dimmed">
+            Reported: the note attached to this sticker
+            {placement.commentHidden ? ' (the owner has already hidden it)' : ''}
+          </Text>
+          <div className="rounded-md bg-gray-2 px-2 py-1.5 dark:bg-dark-5">
+            <Text size="sm" className="whitespace-pre-wrap break-words">
+              {placement.comment ?? 'The note is no longer available.'}
+            </Text>
+          </div>
+          <Text size="xs" c="dimmed">
+            Removing takes the whole sticker off. Only the image owner can hide a note.
+          </Text>
+        </Stack>
+      )}
+      <Group justify="space-between">
+        <Text size="sm">
+          {placement.sticker?.name ?? `Placement ${placementId}`} &middot;{' '}
+          {placement.placer?.username ?? 'unknown placer'}
+        </Text>
+        <Button
+          color="red"
+          size="compact-sm"
+          leftSection={<IconTrash size={14} />}
+          loading={remove.isPending}
+          onClick={confirm}
+        >
+          Remove placement
+        </Button>
+      </Group>
+    </Stack>
   );
 }

--- a/src/components/Sticker/StickerHistoryPanel.tsx
+++ b/src/components/Sticker/StickerHistoryPanel.tsx
@@ -378,8 +378,6 @@ function StickerHistoryList({
                 <StickerPlacementHoverCard
                   placementId={placement.id}
                   imageId={placement.imageId}
-                  placerId={placement.placerId}
-                  hasComment={placement.hasComment}
                   pending={placement.isPending}
                 >
                   <button

--- a/src/components/Sticker/StickerHistoryPanel.tsx
+++ b/src/components/Sticker/StickerHistoryPanel.tsx
@@ -375,7 +375,12 @@ function StickerHistoryList({
                 {/* The same hover card the sticker itself has: who placed it,
                     when, and their creator card. One component, so the answer
                     cannot differ depending on which one you hovered. */}
-                <StickerPlacementHoverCard placementId={placement.id} pending={placement.isPending}>
+                <StickerPlacementHoverCard
+                  placementId={placement.id}
+                  imageId={placement.imageId}
+                  placerId={placement.placerId}
+                  pending={placement.isPending}
+                >
                   <button
                     type="button"
                     onClick={() => stepTo(index)}

--- a/src/components/Sticker/StickerHistoryPanel.tsx
+++ b/src/components/Sticker/StickerHistoryPanel.tsx
@@ -379,6 +379,7 @@ function StickerHistoryList({
                   placementId={placement.id}
                   imageId={placement.imageId}
                   placerId={placement.placerId}
+                  hasComment={placement.hasComment}
                   pending={placement.isPending}
                 >
                   <button

--- a/src/components/Sticker/StickerPlacementHoverCard.tsx
+++ b/src/components/Sticker/StickerPlacementHoverCard.tsx
@@ -1,10 +1,12 @@
 import { Anchor, Badge, Group, HoverCard, Skeleton, Text, Tooltip } from '@mantine/core';
 import { openConfirmModal } from '@mantine/modals';
-import { IconEye, IconEyeOff, IconSticker, IconTrash } from '@tabler/icons-react';
+import { IconEye, IconEyeOff, IconFlag, IconSticker, IconTrash } from '@tabler/icons-react';
 import dynamic from 'next/dynamic';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
+import { openReportModal } from '~/components/Dialog/triggers/report';
 import { useForgetStickerPlacement } from '~/components/Sticker/placement.util';
+import { ReportEntity } from '~/shared/utils/report-helpers';
 import type { ReactElement } from 'react';
 import { useState } from 'react';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
@@ -54,10 +56,22 @@ const placedLabel = (placedAt: Date | string) => {
  */
 export function StickerPlacementHoverCard({
   placementId,
+  imageId,
+  placerId,
   pending = false,
   children,
 }: {
   placementId: number;
+  /**
+   * The image the sticker sits on. A sticker report is filed against the image
+   * carrying the placement id — one reason, one queue — so the flag needs both.
+   */
+  imageId: number;
+  /** Who placed it, so the flag can stay off the reporter's own sticker. Taken
+   * from the listing rather than the detail query, which lands after the card
+   * opens: keyed off that, the flag would appear on your own sticker and then
+   * vanish. */
+  placerId: number;
   pending?: boolean;
   children: ReactElement;
 }) {
@@ -138,6 +152,7 @@ export function StickerPlacementHoverCard({
               Awaiting review
             </Badge>
           )}
+          <ReportPlacement placementId={placementId} imageId={imageId} placerId={placerId} />
           <ModeratorRemove placementId={placementId} />
         </Group>
 
@@ -155,9 +170,21 @@ export function StickerPlacementHoverCard({
                 thing the placer said, and the card is who said it. */}
             {data.comment && (
               <div className="border-b border-gray-3 px-3 py-2 dark:border-dark-4">
-                <Text size="sm" className="whitespace-pre-wrap break-words">
-                  {data.comment}
-                </Text>
+                {/* The note carries its own flag, so neither flow asks which
+                    half is being reported. A fine sticker can carry an abusive
+                    note, and the remedies differ — the owner can hide a note
+                    without the sticker coming off. */}
+                <Group gap={6} align="flex-start" wrap="nowrap">
+                  <Text size="sm" className="min-w-0 flex-1 whitespace-pre-wrap break-words">
+                    {data.comment}
+                  </Text>
+                  <ReportPlacement
+                    placementId={placementId}
+                    imageId={imageId}
+                    placerId={placerId}
+                    target="comment"
+                  />
+                </Group>
                 {data.commentHidden && (
                   <Text size="xs" c="dimmed" mt={4}>
                     Hidden — only you, the person who placed it, and moderators can see this.
@@ -179,6 +206,63 @@ export function StickerPlacementHoverCard({
         )}
       </HoverCard.Dropdown>
     </HoverCard>
+  );
+}
+
+/**
+ * Reporting one sticker, from that sticker.
+ *
+ * The report opens with the placement already set, which is the whole point.
+ * The route this replaced was the image's report menu, where the reporter picked
+ * from a list of the stickers on the image — several copies of one sticker are
+ * indistinguishable there, so reporting one of them was a guess a moderator then
+ * acted on. Starting here there is nothing to identify.
+ *
+ * Not offered on the reporter's own placement. There is a real "I regret this"
+ * case and it is not a report; it belongs to whoever builds placer-side removal.
+ */
+function ReportPlacement({
+  placementId,
+  imageId,
+  placerId,
+  target = 'sticker',
+}: {
+  placementId: number;
+  imageId: number;
+  placerId: number;
+  target?: 'sticker' | 'comment';
+}) {
+  const currentUser = useCurrentUser();
+
+  if (!currentUser || currentUser.id === placerId) return null;
+
+  const label = target === 'comment' ? 'Report this note' : 'Report this sticker';
+
+  return (
+    <Tooltip label={label} withArrow>
+      <LegacyActionIcon
+        color="gray"
+        variant="subtle"
+        size="sm"
+        className="shrink-0"
+        aria-label={label}
+        onClick={() =>
+          openReportModal({
+            // Still an Image report carrying a placement id, not a new entity
+            // type: the reason, the mod queue and the dedupe all already work
+            // that way, and a second shape for the same complaint would give
+            // moderators two queues for one sticker.
+            entityType: ReportEntity.Image,
+            entityId: imageId,
+            reportKey: 'sticker-placement',
+            placementId,
+            placementTarget: target,
+          })
+        }
+      >
+        <IconFlag size={14} />
+      </LegacyActionIcon>
+    </Tooltip>
   );
 }
 

--- a/src/components/Sticker/StickerPlacementHoverCard.tsx
+++ b/src/components/Sticker/StickerPlacementHoverCard.tsx
@@ -504,8 +504,16 @@ function ModeratorRemove({
   const forget = useForgetStickerPlacement();
 
   const remove = trpc.placement.removePlacement.useMutation({
-    onSuccess: async () => {
-      showSuccessNotification({ message: 'Placement removed.' });
+    onSuccess: async (result) => {
+      // Reads the result rather than assuming it. The overlay can be drawing a
+      // placement someone else already settled, and reporting success on a
+      // takedown that removed nothing — beside a control that would have worked
+      // — is how a moderator concludes the sticker is handled.
+      showSuccessNotification({
+        message: result.removed
+          ? 'Placement removed.'
+          : 'Nothing to remove — it had already been settled.',
+      });
       await forget(placementId);
     },
     onError: (error) =>

--- a/src/components/Sticker/StickerPlacementHoverCard.tsx
+++ b/src/components/Sticker/StickerPlacementHoverCard.tsx
@@ -179,7 +179,13 @@ export function StickerPlacementHoverCard({
             placementId={placementId}
             imageId={imageId}
             placerId={placerId}
-            hasComment={hasComment}
+            // The listing's answer, corrected by the card's own once it lands.
+            // They disagree for a moderator on a hidden note: the listing scopes
+            // `hasComment` to the placer and the owner, while this query hands
+            // moderators the text — so without the second half, the one viewer
+            // who can read that note is the one who cannot report it. The
+            // control looks identical either way, so nothing moves.
+            hasComment={hasComment || !!data?.comment}
           />
           {/* One remove control, in one place. A moderator's remove and an
               owner's are different powers over the same sticker — the moderator
@@ -311,7 +317,12 @@ function ReportPlacement({
     );
 
   return (
-    <Menu withinPortal position="bottom-end" withArrow>
+    // `withinPortal={false}` is load-bearing, not a preference. A portalled
+    // dropdown is not a DOM descendant of the hover card, so moving the cursor
+    // onto a menu item leaves the card, the card closes, and the item the
+    // reporter is reaching for unmounts under them. Rendered inside, the pointer
+    // never leaves.
+    <Menu withinPortal={false} position="bottom-end" withArrow>
       <Menu.Target>
         <LegacyActionIcon
           color="gray"

--- a/src/components/Sticker/StickerPlacementHoverCard.tsx
+++ b/src/components/Sticker/StickerPlacementHoverCard.tsx
@@ -1,6 +1,13 @@
-import { Anchor, Badge, Group, HoverCard, Skeleton, Text, Tooltip } from '@mantine/core';
+import { Anchor, Badge, Group, HoverCard, Menu, Skeleton, Text, Tooltip } from '@mantine/core';
 import { openConfirmModal } from '@mantine/modals';
-import { IconEye, IconEyeOff, IconFlag, IconSticker, IconTrash } from '@tabler/icons-react';
+import {
+  IconEye,
+  IconEyeOff,
+  IconFlag,
+  IconMessage,
+  IconSticker,
+  IconTrash,
+} from '@tabler/icons-react';
 import dynamic from 'next/dynamic';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
@@ -58,6 +65,7 @@ export function StickerPlacementHoverCard({
   placementId,
   imageId,
   placerId,
+  hasComment = false,
   pending = false,
   children,
 }: {
@@ -72,10 +80,14 @@ export function StickerPlacementHoverCard({
    * opens: keyed off that, the flag would appear on your own sticker and then
    * vanish. */
   placerId: number;
+  /** Whether it carries a note this viewer can read, which decides whether the
+   * flag has to ask which half is being reported. */
+  hasComment?: boolean;
   pending?: boolean;
   children: ReactElement;
 }) {
   const [opened, setOpened] = useState(false);
+  const currentUser = useCurrentUser();
 
   const { data, isLoading } = trpc.placement.getStickerPlacementDetail.useQuery(
     { placementId },
@@ -105,7 +117,18 @@ export function StickerPlacementHoverCard({
           edge. Its border is dropped rather than the dropdown's, so there is one
           outline instead of two nested ones a pixel apart. */}
       <HoverCard.Dropdown p={0}>
-        <Group gap={6} px="sm" py={6} wrap="nowrap" justify="space-between">
+        {/* A divider under it, so the line reads as the card's title rather than
+            as the first of several stacked rows. Same header shape as the
+            approve-with-note popover, which is the same object seen from the
+            review queue. */}
+        <Group
+          gap={6}
+          px="sm"
+          py={6}
+          wrap="nowrap"
+          justify="space-between"
+          className="border-b border-gray-3 dark:border-dark-4"
+        >
           <Group gap={6} wrap="nowrap" className="min-w-0 flex-1">
             <IconSticker size={14} className="shrink-0 text-yellow-6" />
 
@@ -152,8 +175,25 @@ export function StickerPlacementHoverCard({
               Awaiting review
             </Badge>
           )}
-          <ReportPlacement placementId={placementId} imageId={imageId} placerId={placerId} />
-          <ModeratorRemove placementId={placementId} />
+          <ReportPlacement
+            placementId={placementId}
+            imageId={imageId}
+            placerId={placerId}
+            hasComment={hasComment}
+          />
+          {/* One remove control, in one place. A moderator's remove and an
+              owner's are different powers over the same sticker — the moderator
+              answers a report, the owner takes it off their own image after the
+              week the placer paid for — and offering both at once in two corners
+              read as two different buttons doing the same thing. */}
+          {currentUser?.isModerator ? (
+            <ModeratorRemove placementId={placementId} />
+          ) : (
+            data?.viewerIsOwner &&
+            data.status === 'approved' && (
+              <OwnerRemove placementId={placementId} removableAt={data.removableAt} />
+            )
+          )}
         </Group>
 
         {/* A skeleton rather than a spinner: the card's size is known before its
@@ -170,38 +210,30 @@ export function StickerPlacementHoverCard({
                 thing the placer said, and the card is who said it. */}
             {data.comment && (
               <div className="border-b border-gray-3 px-3 py-2 dark:border-dark-4">
-                {/* The note carries its own flag, so neither flow asks which
-                    half is being reported. A fine sticker can carry an abusive
-                    note, and the remedies differ — the owner can hide a note
-                    without the sticker coming off. */}
-                <Group gap={6} align="flex-start" wrap="nowrap">
-                  <Text size="sm" className="min-w-0 flex-1 whitespace-pre-wrap break-words">
+                {/* Its own surface, the same one the approve-with-note popover
+                    quotes a note on. The note is someone else's words sitting
+                    inside a card about the sticker, and unquoted it reads as the
+                    card talking. */}
+                <div className="rounded-md bg-gray-2 px-2 py-1.5 dark:bg-dark-5">
+                  <Text size="sm" className="whitespace-pre-wrap break-words">
                     {data.comment}
                   </Text>
-                  <ReportPlacement
-                    placementId={placementId}
-                    imageId={imageId}
-                    placerId={placerId}
-                    target="comment"
-                  />
-                </Group>
+                </div>
                 {data.commentHidden && (
                   <Text size="xs" c="dimmed" mt={4}>
                     Hidden — only you, the person who placed it, and moderators can see this.
                   </Text>
                 )}
+                {/* Under the note it acts on, not in a footer. Unlocked, unlike
+                    removal: the note came free with the placement and is the
+                    owner's to refuse at any time, and being able to put it back
+                    is what makes hiding a safe first move. */}
+                {data.viewerIsOwner && (
+                  <HideNote placementId={placementId} commentHidden={data.commentHidden} />
+                )}
               </div>
             )}
             <SmartCreatorCard user={data.placer} withActions={false} withBorder={false} />
-            {data.viewerIsOwner && (
-              <OwnerControls
-                placementId={placementId}
-                hasComment={!!data.comment}
-                commentHidden={data.commentHidden}
-                isLive={data.status === 'approved'}
-                removableAt={data.removableAt}
-              />
-            )}
           </>
         )}
       </HoverCard.Dropdown>
@@ -225,81 +257,138 @@ function ReportPlacement({
   placementId,
   imageId,
   placerId,
-  target = 'sticker',
+  hasComment,
 }: {
   placementId: number;
   imageId: number;
   placerId: number;
-  target?: 'sticker' | 'comment';
+  /**
+   * Whether a note the viewer can read hangs off this sticker, which decides
+   * whether the flag has to ask which half. Taken from the listing rather than
+   * the detail query so the control does not change shape under the cursor once
+   * the card loads.
+   */
+  hasComment: boolean;
 }) {
   const currentUser = useCurrentUser();
 
   if (!currentUser || currentUser.id === placerId) return null;
 
-  const label = target === 'comment' ? 'Report this note' : 'Report this sticker';
+  const report = (placementTarget: 'sticker' | 'comment') =>
+    openReportModal({
+      // Still an Image report carrying a placement id, not a new entity type:
+      // the reason, the mod queue and the dedupe all already work that way, and
+      // a second shape for the same complaint would give moderators two queues
+      // for one sticker.
+      entityType: ReportEntity.Image,
+      entityId: imageId,
+      reportKey: 'sticker-placement',
+      placementId,
+      placementTarget,
+    });
+
+  const icon = <IconFlag size={14} />;
+
+  // One flag either way. With a note there are two separately objectionable
+  // things behind it — a fine sticker can carry an abusive note, and the
+  // remedies differ, since the owner can hide a note without the sticker coming
+  // off — so the flag asks which, rather than the card growing a second flag
+  // that looks like the same control repeated.
+  if (!hasComment)
+    return (
+      <Tooltip label="Report this sticker" withArrow>
+        <LegacyActionIcon
+          color="gray"
+          variant="subtle"
+          size="sm"
+          className="shrink-0"
+          aria-label="Report this sticker"
+          onClick={() => report('sticker')}
+        >
+          {icon}
+        </LegacyActionIcon>
+      </Tooltip>
+    );
 
   return (
-    <Tooltip label={label} withArrow>
-      <LegacyActionIcon
-        color="gray"
-        variant="subtle"
-        size="sm"
-        className="shrink-0"
-        aria-label={label}
-        onClick={() =>
-          openReportModal({
-            // Still an Image report carrying a placement id, not a new entity
-            // type: the reason, the mod queue and the dedupe all already work
-            // that way, and a second shape for the same complaint would give
-            // moderators two queues for one sticker.
-            entityType: ReportEntity.Image,
-            entityId: imageId,
-            reportKey: 'sticker-placement',
-            placementId,
-            placementTarget: target,
-          })
-        }
-      >
-        <IconFlag size={14} />
-      </LegacyActionIcon>
-    </Tooltip>
+    <Menu withinPortal position="bottom-end" withArrow>
+      <Menu.Target>
+        <LegacyActionIcon
+          color="gray"
+          variant="subtle"
+          size="sm"
+          className="shrink-0"
+          aria-label="Report this sticker or its note"
+        >
+          {icon}
+        </LegacyActionIcon>
+      </Menu.Target>
+      <Menu.Dropdown>
+        <Menu.Label>What are you reporting?</Menu.Label>
+        <Menu.Item leftSection={<IconSticker size={14} />} onClick={() => report('sticker')}>
+          The sticker itself
+        </Menu.Item>
+        <Menu.Item leftSection={<IconMessage size={14} />} onClick={() => report('comment')}>
+          The note attached to it
+        </Menu.Item>
+      </Menu.Dropdown>
+    </Menu>
   );
 }
 
 /**
- * What the content owner can do about a sticker already on their image.
+ * The owner refusing a note without touching the sticker it came with.
  *
- * The two controls are deliberately unequal. Hiding the note is unlocked — it
- * came free with the placement and is the owner's to refuse at any time, and
- * being able to put it back is what makes hiding a safe first move. Removing
- * the sticker waits a week from approval, because approval already paid the
- * owner and nothing is refunded: without the wait an owner could take the Buzz
- * and wipe the sticker before anyone saw it.
- *
- * Both refusals live on the server. The disabled button and its date are what
- * the card *says*, not what decides it.
+ * Reversible on purpose, and the reverse is the same control: an owner who hides
+ * a note and changes their mind has to be able to put it back, or hiding is a
+ * decision they will avoid making.
  */
-function OwnerControls({
-  placementId,
-  hasComment,
-  commentHidden,
-  isLive,
-  removableAt,
-}: {
-  placementId: number;
-  hasComment: boolean;
-  commentHidden: boolean;
-  isLive: boolean;
-  removableAt: Date | string | null;
-}) {
+function HideNote({ placementId, commentHidden }: { placementId: number; commentHidden: boolean }) {
   const utils = trpc.useUtils();
-  const forget = useForgetStickerPlacement();
 
   const setHidden = trpc.placement.setStickerCommentHidden.useMutation({
     onSuccess: () => utils.placement.getStickerPlacementDetail.invalidate({ placementId }),
     onError: (error) =>
       showErrorNotification({ title: "Couldn't change the note", error: new Error(error.message) }),
   });
+
+  return (
+    <Anchor
+      component="button"
+      type="button"
+      size="xs"
+      mt={6}
+      onClick={() => setHidden.mutate({ placementId, hidden: !commentHidden })}
+    >
+      <Group gap={4} wrap="nowrap">
+        {commentHidden ? <IconEye size={14} /> : <IconEyeOff size={14} />}
+        {commentHidden ? 'Show the note' : 'Hide the note'}
+      </Group>
+    </Anchor>
+  );
+}
+
+/**
+ * The owner taking a sticker off their own image.
+ *
+ * Waits a week from approval, because approval already paid the owner and
+ * nothing is refunded: without the wait an owner could take the Buzz and wipe
+ * the sticker before anyone saw it. The refusal lives on the server — the
+ * disabled control and its date are what the card *says*, not what decides it.
+ *
+ * Shares the header slot with the moderator's remove rather than sitting in a
+ * footer of its own. A viewer has at most one of these powers, so the slot is
+ * never ambiguous, and two remove buttons in two corners read as one control
+ * duplicated.
+ */
+function OwnerRemove({
+  placementId,
+  removableAt,
+}: {
+  placementId: number;
+  removableAt: Date | string | null;
+}) {
+  const forget = useForgetStickerPlacement();
 
   const remove = trpc.placement.actOnStickers.useMutation({
     onSuccess: async () => {
@@ -310,79 +399,51 @@ function OwnerControls({
       showErrorNotification({ title: "Couldn't remove it", error: new Error(error.message) }),
   });
 
-  if (!hasComment && !isLive) return null;
-
   const locked = !!removableAt;
 
   return (
-    <Group
-      gap="xs"
-      px="sm"
-      py={6}
-      justify="flex-end"
-      className="border-t border-gray-3 dark:border-dark-4"
+    <Tooltip
+      withArrow
+      multiline
+      w={240}
+      label={
+        locked
+          ? `Someone paid to place this, so it stays up for a week. You can remove it from ${formatDate(
+              removableAt as Date
+            )}.`
+          : 'Takes the sticker off your image. No Buzz moves.'
+      }
     >
-      {hasComment && (
-        <Anchor
-          component="button"
-          type="button"
-          size="xs"
-          onClick={() => setHidden.mutate({ placementId, hidden: !commentHidden })}
-        >
-          <Group gap={4} wrap="nowrap">
-            {commentHidden ? <IconEye size={14} /> : <IconEyeOff size={14} />}
-            {commentHidden ? 'Show the note' : 'Hide the note'}
-          </Group>
-        </Anchor>
-      )}
-
-      {isLive && (
-        <Tooltip
-          withArrow
-          multiline
-          w={240}
-          label={
-            locked
-              ? `Someone paid to place this, so it stays up for a week. You can remove it from ${formatDate(
-                  removableAt as Date
-                )}.`
-              : 'Takes the sticker off your image. No Buzz moves.'
+      {/* Wrapped, because a disabled control fires no pointer events and a
+          tooltip on it never opens — which would leave the date explaining the
+          button visible only to people who did not need it. */}
+      <span className="shrink-0">
+        <LegacyActionIcon
+          color="red"
+          variant="subtle"
+          size="sm"
+          aria-label="Remove this sticker from your image"
+          disabled={locked}
+          loading={remove.isPending}
+          onClick={() =>
+            openConfirmModal({
+              title: 'Remove this sticker',
+              children: (
+                <Text size="sm">
+                  It comes off your image for everyone. The Buzz you were paid for it stays with
+                  you, and nobody is notified.
+                </Text>
+              ),
+              labels: { confirm: 'Remove', cancel: 'Cancel' },
+              confirmProps: { color: 'red' },
+              onConfirm: () => remove.mutate({ placementIds: [placementId], action: 'remove' }),
+            })
           }
         >
-          {/* Wrapped, because a disabled control fires no pointer events and a
-              tooltip on it never opens — which would leave the date explaining
-              the button visible only to people who did not need it. */}
-          <span>
-            <Anchor
-              component="button"
-              type="button"
-              size="xs"
-              c={locked ? 'dimmed' : 'red'}
-              disabled={locked}
-              onClick={() =>
-                openConfirmModal({
-                  title: 'Remove this sticker',
-                  children: (
-                    <Text size="sm">
-                      It comes off your image for everyone. The Buzz you were paid for it stays with
-                      you, and nobody is notified.
-                    </Text>
-                  ),
-                  labels: { confirm: 'Remove', cancel: 'Cancel' },
-                  confirmProps: { color: 'red' },
-                  onConfirm: () => remove.mutate({ placementIds: [placementId], action: 'remove' }),
-                })
-              }
-            >
-              <Group gap={4} wrap="nowrap">
-                <IconTrash size={14} />
-                Remove
-              </Group>
-            </Anchor>
-          </span>
-        </Tooltip>
-      )}
-    </Group>
+          <IconTrash size={14} />
+        </LegacyActionIcon>
+      </span>
+    </Tooltip>
   );
 }
 

--- a/src/components/Sticker/StickerPlacementHoverCard.tsx
+++ b/src/components/Sticker/StickerPlacementHoverCard.tsx
@@ -5,6 +5,7 @@ import {
   IconEyeOff,
   IconFlag,
   IconMessage,
+  IconShieldCancel,
   IconSticker,
   IconTrash,
 } from '@tabler/icons-react';
@@ -77,7 +78,6 @@ export function StickerPlacementHoverCard({
   children: ReactElement;
 }) {
   const [opened, setOpened] = useState(false);
-  const currentUser = useCurrentUser();
 
   const { data, isLoading } = trpc.placement.getStickerPlacementDetail.useQuery(
     { placementId },
@@ -181,24 +181,23 @@ export function StickerPlacementHoverCard({
               hasComment={!!data.comment}
             />
           )}
-          {/* One remove control, in one place. A moderator's remove and an
-              owner's are different powers over the same sticker — the moderator
-              answers a report, the owner takes it off their own image after the
-              week the placer paid for — and offering both at once in two corners
-              read as two different buttons doing the same thing. */}
-          {currentUser?.isModerator ? (
-            <ModeratorRemove
-              placementId={placementId}
-              // Both sources, because neither sees every case: the listing hands
-              // a moderator nobody else's pending rows, and the card's own query
-              // has not answered yet on the first frame.
-              pending={pending || data?.status === 'pending'}
-            />
-          ) : (
-            data?.viewerIsOwner &&
-            data.status === 'approved' && (
-              <OwnerRemove placementId={placementId} removableAt={data.removableAt} />
-            )
+          {/* Two controls where a viewer holds both powers, not one that guesses
+              which they meant. A takedown and an owner's removal differ in what
+              they do to the placer's money — a takedown of a pending placement
+              forfeits everything they paid, an owner's removal is held for the
+              week they paid for and moves nothing — and the server decides which
+              happened by the role exercised, not by the account. A moderator on
+              their own image is still the owner, so they get both, each saying
+              which it is. */}
+          <ModeratorRemove
+            placementId={placementId}
+            // Both sources, because neither sees every case: the listing hands a
+            // moderator nobody else's pending rows, and the card's own query has
+            // not answered yet on the first frame.
+            pending={pending || data?.status === 'pending'}
+          />
+          {data?.viewerIsOwner && data.status === 'approved' && (
+            <OwnerRemove placementId={placementId} removableAt={data.removableAt} />
           )}
         </Group>
 
@@ -501,31 +500,34 @@ function ModeratorRemove({
   if (!currentUser?.isModerator) return null;
 
   return (
-    <Tooltip label="Remove this sticker from the content" withArrow>
+    <Tooltip label="Take this sticker down as a moderator" withArrow>
       <LegacyActionIcon
         color="red"
         variant="subtle"
         size="sm"
         className="shrink-0"
-        aria-label="Remove placement"
+        aria-label="Take down placement as moderator"
         loading={remove.isPending}
         onClick={() =>
           openConfirmModal({
-            title: 'Remove this placement',
+            title: 'Take this placement down',
             children: (
               <Text size="sm">
                 {pending
-                  ? 'This one is still awaiting the owner. Removing it forfeits everything the placer paid — they get nothing back, and nobody is notified.'
-                  : 'The sticker comes off this content for everyone. No Buzz moves and nobody is notified.'}
+                  ? 'This one is still awaiting the owner. Taking it down forfeits everything the placer paid — they get nothing back, and nobody is notified.'
+                  : 'The sticker comes off this content for everyone, recorded as a moderator takedown. No Buzz moves and nobody is notified.'}
               </Text>
             ),
-            labels: { confirm: 'Remove', cancel: 'Cancel' },
+            labels: { confirm: 'Take down', cancel: 'Cancel' },
             confirmProps: { color: 'red' },
             onConfirm: () => remove.mutate({ placementId }),
           })
         }
       >
-        <IconTrash size={14} />
+        {/* A shield, not a second bin. The owner's remove sits beside this one
+            for an account holding both powers, and two identical icons would
+            make the pair a coin toss over whose money moves. */}
+        <IconShieldCancel size={14} />
       </LegacyActionIcon>
     </Tooltip>
   );

--- a/src/components/Sticker/StickerPlacementHoverCard.tsx
+++ b/src/components/Sticker/StickerPlacementHoverCard.tsx
@@ -189,15 +189,19 @@ export function StickerPlacementHoverCard({
               happened by the role exercised, not by the account. A moderator on
               their own image is still the owner, so they get both, each saying
               which it is. */}
-          <ModeratorRemove
-            placementId={placementId}
-            // Both sources, because neither sees every case: the listing hands a
-            // moderator nobody else's pending rows, and the card's own query has
-            // not answered yet on the first frame.
-            pending={pending || data?.status === 'pending'}
-          />
-          {data?.viewerIsOwner && data.status === 'approved' && (
-            <OwnerRemove placementId={placementId} removableAt={data.removableAt} />
+          {data && (
+            <>
+              {/* The card's own query, never the listing. A listing is fetched
+                  once and this app never refetches it on focus, so a party whose
+                  placement was approved in another tab carries `isPending: true`
+                  for as long as the page stays open — and that value would pick
+                  the confirmation's sentence about the placer's money, right
+                  before an irreversible click. */}
+              <ModeratorRemove placementId={placementId} pending={data.status === 'pending'} />
+              {data.viewerIsOwner && data.status === 'approved' && (
+                <OwnerRemove placementId={placementId} removableAt={data.removableAt} />
+              )}
+            </>
           )}
         </Group>
 
@@ -205,9 +209,20 @@ export function StickerPlacementHoverCard({
             data is, so holding the shape stops the dropdown resizing under the
             cursor the moment it loads — which on a hover card can move the
             target out from under you. */}
-        {isLoading || !data ? (
+        {isLoading ? (
           <div className="p-3">
             <Skeleton height={92} radius="md" />
+          </div>
+        ) : !data ? (
+          // A miss is the ordinary case, not an edge one: nothing refetches the
+          // placements listing, so an overlay keeps drawing a sticker a
+          // moderator took down minutes ago. Without this the card holds the
+          // skeleton for as long as it is open — a spinner that reads as slow
+          // rather than as gone, on a sticker that no longer exists.
+          <div className="p-3">
+            <Text size="sm" c="dimmed">
+              This sticker is no longer on the image.
+            </Text>
           </div>
         ) : (
           <>

--- a/src/components/Sticker/StickerPlacementHoverCard.tsx
+++ b/src/components/Sticker/StickerPlacementHoverCard.tsx
@@ -64,8 +64,6 @@ const placedLabel = (placedAt: Date | string) => {
 export function StickerPlacementHoverCard({
   placementId,
   imageId,
-  placerId,
-  hasComment = false,
   pending = false,
   children,
 }: {
@@ -75,14 +73,6 @@ export function StickerPlacementHoverCard({
    * carrying the placement id — one reason, one queue — so the flag needs both.
    */
   imageId: number;
-  /** Who placed it, so the flag can stay off the reporter's own sticker. Taken
-   * from the listing rather than the detail query, which lands after the card
-   * opens: keyed off that, the flag would appear on your own sticker and then
-   * vanish. */
-  placerId: number;
-  /** Whether it carries a note this viewer can read, which decides whether the
-   * flag has to ask which half is being reported. */
-  hasComment?: boolean;
   pending?: boolean;
   children: ReactElement;
 }) {
@@ -175,25 +165,35 @@ export function StickerPlacementHoverCard({
               Awaiting review
             </Badge>
           )}
-          <ReportPlacement
-            placementId={placementId}
-            imageId={imageId}
-            placerId={placerId}
-            // The listing's answer, corrected by the card's own once it lands.
-            // They disagree for a moderator on a hidden note: the listing scopes
-            // `hasComment` to the placer and the owner, while this query hands
-            // moderators the text — so without the second half, the one viewer
-            // who can read that note is the one who cannot report it. The
-            // control looks identical either way, so nothing moves.
-            hasComment={hasComment || !!data?.comment}
-          />
+          {/* Waits for the card's own query rather than reading the listing's
+              `hasComment`. The two disagree in both directions — the listing
+              scopes the note to the placer and the owner where this query also
+              hands it to moderators, and a listing fetched before the owner hid
+              a note still says there is one — and the flag is a different
+              element in each case, a button or a menu trigger. Rendered off the
+              listing it would swap under the cursor as the card loads, so a
+              click mid-swap lands on a node that no longer exists. */}
+          {data && (
+            <ReportPlacement
+              placementId={placementId}
+              imageId={imageId}
+              placerId={data.placer.id}
+              hasComment={!!data.comment}
+            />
+          )}
           {/* One remove control, in one place. A moderator's remove and an
               owner's are different powers over the same sticker — the moderator
               answers a report, the owner takes it off their own image after the
               week the placer paid for — and offering both at once in two corners
               read as two different buttons doing the same thing. */}
           {currentUser?.isModerator ? (
-            <ModeratorRemove placementId={placementId} />
+            <ModeratorRemove
+              placementId={placementId}
+              // Both sources, because neither sees every case: the listing hands
+              // a moderator nobody else's pending rows, and the card's own query
+              // has not answered yet on the first frame.
+              pending={pending || data?.status === 'pending'}
+            />
           ) : (
             data?.viewerIsOwner &&
             data.status === 'approved' && (
@@ -317,11 +317,13 @@ function ReportPlacement({
     );
 
   return (
-    // `withinPortal={false}` is load-bearing, not a preference. A portalled
-    // dropdown is not a DOM descendant of the hover card, so moving the cursor
-    // onto a menu item leaves the card, the card closes, and the item the
-    // reporter is reaching for unmounts under them. Rendered inside, the pointer
-    // never leaves.
+    // Inline, so the menu is a DOM descendant of the card and not only a React
+    // one. Either way the pointer may move onto an item without the hover card
+    // closing — React derives enter/leave from the fiber tree, so a portalled
+    // dropdown counts as inside it too — but the card still closes 150ms after
+    // the pointer leaves it entirely, taking an open menu with it. Nothing here
+    // changes that; keeping the dropdown inside just removes one way for the
+    // two positioning contexts to disagree.
     <Menu withinPortal={false} position="bottom-end" withArrow>
       <Menu.Target>
         <LegacyActionIcon
@@ -467,14 +469,23 @@ function OwnerRemove({
  * Same mutation either way, so the two cannot drift into different rules about
  * what removal means.
  *
- * Nothing else happens: no refund, and nobody is notified (Justin, 2026-08-08).
- * The escrow on a live placement was paid to a content owner who did not choose
- * the sticker, and clawing it back would charge them for someone else's problem.
+ * On a live placement nothing else happens: no refund, and nobody is notified
+ * (Justin, 2026-08-08). The escrow was paid to a content owner who did not
+ * choose the sticker, and clawing it back would charge them for someone else's
+ * problem. **A pending one is not that**: it settles as `removeByModerator`,
+ * whose payout is a forfeit of the whole escrow, fee and principal — so the
+ * confirmation has to say a different thing about the money.
  *
  * Rendered for moderators only, which is convenience — `removePlacement` is a
  * `moderatorProcedure`, so the refusal is on the mutation and stays there.
  */
-function ModeratorRemove({ placementId }: { placementId: number }) {
+function ModeratorRemove({
+  placementId,
+  pending = false,
+}: {
+  placementId: number;
+  pending?: boolean;
+}) {
   const currentUser = useCurrentUser();
   const forget = useForgetStickerPlacement();
 
@@ -503,8 +514,9 @@ function ModeratorRemove({ placementId }: { placementId: number }) {
             title: 'Remove this placement',
             children: (
               <Text size="sm">
-                The sticker comes off this content for everyone. No Buzz moves and nobody is
-                notified.
+                {pending
+                  ? 'This one is still awaiting the owner. Removing it forfeits everything the placer paid — they get nothing back, and nobody is notified.'
+                  : 'The sticker comes off this content for everyone. No Buzz moves and nobody is notified.'}
               </Text>
             ),
             labels: { confirm: 'Remove', cancel: 'Cancel' },

--- a/src/components/Sticker/StickerPlacementHoverCard.tsx
+++ b/src/components/Sticker/StickerPlacementHoverCard.tsx
@@ -79,10 +79,18 @@ export function StickerPlacementHoverCard({
 }) {
   const [opened, setOpened] = useState(false);
 
-  const { data, isLoading } = trpc.placement.getStickerPlacementDetail.useQuery(
+  const { data, isLoading, error } = trpc.placement.getStickerPlacementDetail.useQuery(
     { placementId },
     { enabled: opened, staleTime: 5 * 60_000 }
   );
+
+  // "Gone" and "could not ask" are different claims, and only the server can
+  // tell them apart: the service throws a not-found for a placement that is no
+  // longer live, and everything else here is a failed request. Batching runs
+  // these with no retries and fails a whole cohort together, so treating any
+  // error as a takedown would tell a viewer their sticker was removed because
+  // an unrelated query in the same batch fell over.
+  const gone = error?.data?.code === 'NOT_FOUND';
 
   // Both come from the service already resolved. Nothing here builds a URL from
   // a username, which is what produced a live link to `/user/null/shop`.
@@ -160,7 +168,12 @@ export function StickerPlacementHoverCard({
               </Text>
             )}
           </Group>
-          {pending && (
+          {/* The listing's answer until the card has its own, then retracted if
+              they disagree. The prop is what lets the badge be right on the
+              first frame; letting it stand afterwards is what had the card
+              saying "Awaiting review" beside a confirmation that correctly
+              treats the placement as live. */}
+          {pending && (!data || data.status === 'pending') && (
             <Badge size="xs" color="yellow" variant="light">
               Awaiting review
             </Badge>
@@ -221,7 +234,9 @@ export function StickerPlacementHoverCard({
           // rather than as gone, on a sticker that no longer exists.
           <div className="p-3">
             <Text size="sm" c="dimmed">
-              This sticker is no longer on the image.
+              {gone
+                ? 'This sticker is no longer on the image.'
+                : "We couldn't load this sticker just now."}
             </Text>
           </div>
         ) : (

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -424,6 +424,7 @@ export function StickerPlacementOverlay({
                 placementId={placement.id}
                 imageId={placement.imageId}
                 placerId={placement.placerId}
+                hasComment={placement.hasComment}
               >
                 {body}
               </StickerPlacementHoverCard>
@@ -517,6 +518,7 @@ export function StickerPlacementOverlay({
               placementId={placement.id}
               imageId={placement.imageId}
               placerId={placement.placerId}
+              hasComment={placement.hasComment}
               pending
             >
               {body}

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -423,8 +423,6 @@ export function StickerPlacementOverlay({
                 key={placement.id}
                 placementId={placement.id}
                 imageId={placement.imageId}
-                placerId={placement.placerId}
-                hasComment={placement.hasComment}
               >
                 {body}
               </StickerPlacementHoverCard>
@@ -517,8 +515,6 @@ export function StickerPlacementOverlay({
               key={placement.id}
               placementId={placement.id}
               imageId={placement.imageId}
-              placerId={placement.placerId}
-              hasComment={placement.hasComment}
               pending
             >
               {body}

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -419,7 +419,12 @@ export function StickerPlacementOverlay({
 
           if (!placement.isPending)
             return (
-              <StickerPlacementHoverCard key={placement.id} placementId={placement.id}>
+              <StickerPlacementHoverCard
+                key={placement.id}
+                placementId={placement.id}
+                imageId={placement.imageId}
+                placerId={placement.placerId}
+              >
                 {body}
               </StickerPlacementHoverCard>
             );
@@ -507,7 +512,13 @@ export function StickerPlacementOverlay({
             );
 
           return (
-            <StickerPlacementHoverCard key={placement.id} placementId={placement.id} pending>
+            <StickerPlacementHoverCard
+              key={placement.id}
+              placementId={placement.id}
+              imageId={placement.imageId}
+              placerId={placement.placerId}
+              pending
+            >
               {body}
             </StickerPlacementHoverCard>
           );

--- a/src/pages/moderator/reports.tsx
+++ b/src/pages/moderator/reports.tsx
@@ -356,7 +356,7 @@ function ReportDrawer({
             </Link>
           )}
           <ReportDetails report={report} />
-          {reportedPlacementId !== null && report && (
+          {reportedPlacementId !== null && (
             <RemoveReportedPlacement
               placementId={reportedPlacementId}
               target={getReportedPlacementTarget(report)}

--- a/src/pages/moderator/reports.tsx
+++ b/src/pages/moderator/reports.tsx
@@ -356,8 +356,11 @@ function ReportDrawer({
             </Link>
           )}
           <ReportDetails report={report} />
-          {reportedPlacementId !== null && (
-            <RemoveReportedPlacement placementId={reportedPlacementId} />
+          {reportedPlacementId !== null && report && (
+            <RemoveReportedPlacement
+              placementId={reportedPlacementId}
+              target={getReportedPlacementTarget(report)}
+            />
           )}
           <Input.Wrapper
             label="Status"
@@ -467,6 +470,19 @@ const getReportedPlacementId = (report: ReportDetail) => {
   const raw = (details as Record<string, unknown>).placementId;
   const id = typeof raw === 'string' ? Number(raw) : raw;
   return typeof id === 'number' && Number.isInteger(id) && id > 0 ? id : null;
+};
+
+/**
+ * Which half the report is about, for the one action that can show it.
+ *
+ * Anything but the note reads as the sticker, including a report filed before
+ * the field existed — that matches the schema's own default, so the queue and
+ * the form cannot disagree about what an absent value meant.
+ */
+const getReportedPlacementTarget = (report: ReportDetail): 'sticker' | 'comment' => {
+  const { details } = report;
+  if (!details || typeof details !== 'object' || Array.isArray(details)) return 'sticker';
+  return (details as Record<string, unknown>).target === 'comment' ? 'comment' : 'sticker';
 };
 
 const getReportLink = (report: ReportDetail) => {


### PR DESCRIPTION
Reporting a sticker started from the image's report menu, where the reporter picked the placement out of a list. Several copies of the same sticker on one image are indistinguishable there, so the pick was a guess — and a moderator acted on the guess, which is how the wrong person loses a sticker and the Buzz under it. Origin: Ellie asking how you tell four identical stickers apart, reshaped by Justin into "report from the sticker itself".

## What this does

A flag in the sticker's hover card. It carries the placement id and which half is being reported, so the report form asks nothing and opens straight onto the notes field. One flag: a plain button when there is no note, a two-item menu ("the sticker itself" / "the note attached to it") when there is.

The image-level **"Bad sticker placement" reason is removed from the reason list outright** (Justin's call, made with the tradeoff stated). The entry survives only as the flag's target — reason, form and modal title. There is deliberately no picker anywhere.

Consequences worth stating plainly:

- **There is no reporting route for a viewer who cannot land a hover** — touch, keyboard. Justin was shown this and accepted it.
- **Logged-out visitors cannot report a sticker.** Also Justin's call, asked and answered during review.

The hover card was reorganised around the flag while it was open:

- One title row with a divider under it, then the note on the quoted surface the approve-with-note popover already uses, with the owner's hide/show directly under the note instead of in a footer.
- The moderator takedown and the owner's removal are **two controls, not one** — a shield-cancel and a bin. They are different powers with different money: `removeApprovedSticker` holds an owner's removal for the week the placer paid for and moves nothing, while a moderator takedown of a *pending* placement forfeits the placer's whole escrow (`payoutLegsFor` → `forfeit`, fee + principal). The server decides which happened by the role exercised, not by the account, so an account that moderates its own image gets both, each with its own confirmation naming what happens to the money.

On the moderator side, a `target: 'comment'` report now shows the note itself and can **hide or restore it** without removing the sticker. `setStickerCommentHidden` already waives the owner check for moderators; the queue simply never offered it, so the only button on the panel took down artwork nobody had complained about.

No schema change, no migration, no new mutation.

## Known and unchanged

Carried out of review rather than fixed here, so they are on the record:

- `assertReportedPlacementIsOnEntity` checks that the placement is on the image but not its status or visibility. A hand-made request can file a report naming a pending placement, and the 400/200 difference is an existence oracle over sequential ids. Pre-existing; unchanged by this branch. Closing it means first deciding whether reports about already-removed stickers should still be filable — that is a product call.
- A report can still be *submitted* against a placement that was removed after the modal opened. The entry point is now closed (the flag requires a successful detail lookup), and the form says so instead of claiming to be reporting "this sticker".
- Once anyone removes a placement, its note becomes unreadable — the detail query returns only approved and pending rows — so a second, note-scoped report on the same placement is unanswerable. The dedupe deliberately keys on `(placementId, target)`, so one placement routinely yields two reports. The hide/show control reduces how often removal is the answer at all, but does not close that window.
- The owner still gets a flag on a pending placement they could simply decline.
- **A moderator's hide of a note is advisory.** `commentHidden` is one boolean with no provenance — an owner's hide and a moderator's write identical state — so the image owner can restore a note a moderator hid to answer a report, with no record and no notification. Created by this PR, since before it a moderator had no hide at all and the flag only ever meant "the owner refused this". Making it stick needs provenance on the flag or a moderator-only lock, and neither is a one-liner. Flagged to Justin for the call.
- `setStickerCommentHidden` returns `{ hidden }` — the input echoed back, not what was written; `hideStickerComment` has two silent early returns above it. Not currently reachable (both need the note to be absent while the panel still shows its text, and notes are immutable), and the honest fix is on the service rather than the caller.

## Verification

`pnpm run typecheck` clean (unfiltered), `pnpm run lint` clean on every changed file, `pnpm exec prettier --write` scoped to the diff. Unit suite: 16 failed / 15238 passed — the same 6 files that fail identically on clean `main` (app-blocks / comics / build-script drift guards). `blocks.router.workflow.test.ts` collected **347**, so the run means something.

**No tests are added, and every changed file is a component.** The candidate was the two-item menu inside the hover card, and per this repo's own rule you cannot await a hover card's transient open state — the honest version of that test needs the menu driven into an absorbing state first, and I would rather not ship a test whose failure mode I cannot make legible. The server machinery this rides on (dedupe on `(placementId, target)`, the placement-on-image check) is covered by the existing tests.

Reviewed adversarially across five rounds by two independent reviewers prompted to refute. Ten findings confirmed and fixed, including: the flag reading a listing that disagrees with the card and swapping element type under the cursor; the takedown confirmation quoting the wrong money because it read a listing this app never refetches; a failed lookup leaving the card spinning forever, then claiming a takedown for any error rather than only a not-found; the queue telling moderators they could not hide a note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
