### PR TITLE
fix(images): delete from B2 unconditionally instead of falling through to a dead bucket

### DIFF
--- a/src/server/services/__tests__/delete-image-from-s3-logging.test.ts
+++ b/src/server/services/__tests__/delete-image-from-s3-logging.test.ts
@@ -233,10 +233,9 @@ describe('deleteImageFromS3', () => {
   });
 
   // THE REGRESSION. `resolveMediaLocation` returns null for a 404, a service error AND a timeout,
-  // and the code used to route that to a DigitalOcean bucket deleted 2026-05-18 — the delete threw
-  // on the proxy's text/plain "404 page not found", the row was already gone, and the object stayed
-  // publicly fetchable on an unsigned CDN url. 2,545 objects accumulated that way. An unregistered
-  // image is still on B2; there is nowhere else for it to be.
+  // and the code used to route that to a decommissioned second backend — the delete threw
+  // on a non-XML error body, the row was already gone, and the object stayed publicly fetchable on
+  // an unsigned CDN url. An unregistered image is still on B2; there is nowhere else for it to be.
   it('deletes the object from B2 when the resolver returns no location', async () => {
     mockFindFirst.mockResolvedValue(null);
     mockResolveMediaLocation.mockResolvedValue(null);
@@ -349,7 +348,38 @@ describe('deleteImageFromS3', () => {
     expect(mockLogToAxiom).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'delete-image-from-s3-unresolved-location',
-        error: expect.anything(),
+        // Content, not just presence. `expect.anything()` alone passed with the sanitiser dropped
+        // AND with the wrong value bound in — it pins that the key exists, not that it carries the
+        // reason this event is logged for.
+        error: expect.objectContaining({
+          message: expect.stringContaining('unexpected end of JSON input'),
+        }),
+      })
+    );
+  });
+
+  // `safeError` ends in `String(e)`, which THROWS on a value with no primitive conversion. Doing
+  // that work in the log payload put it inside the outer try, so a rejection carrying such a value
+  // skipped the B2 delete — the precise failure the `.catch` above exists to prevent, reintroduced
+  // by the code that reports it. Measured: this case passed at 85a31d11c7 and regressed at
+  // 156e050d69, so it is a real round-trip and not a hypothetical.
+  it('still deletes from B2 when the resolver rejects with an unserialisable value', async () => {
+    mockFindFirst.mockResolvedValue(null);
+    mockResolveMediaLocation.mockRejectedValue(Object.create(null));
+
+    await deleteImageFromS3({ id: 4242, url: 'abc-def/original.jpeg' });
+
+    expect(mockB2Send).toHaveBeenCalledTimes(1);
+    expect(mockLogToAxiom).not.toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'delete-image-from-s3-failed' })
+    );
+    // The reason is unknowable here, but the event must still say so rather than vanish.
+    expect(mockLogToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'delete-image-from-s3-unresolved-location',
+        error: expect.objectContaining({
+          message: expect.stringContaining('could not be serialised'),
+        }),
       })
     );
   });

--- a/src/server/services/__tests__/delete-image-from-s3-logging.test.ts
+++ b/src/server/services/__tests__/delete-image-from-s3-logging.test.ts
@@ -341,6 +341,17 @@ describe('deleteImageFromS3', () => {
     expect(mockLogToAxiom).not.toHaveBeenCalledWith(
       expect.objectContaining({ name: 'delete-image-from-s3-failed' })
     );
+    // Asserting the WARNING too, not just the delete. Without this the `.catch`'s return VALUE is
+    // unpinned: swapping `() => null` for one that returns a location still passes every other
+    // test here, and silently suppresses the one signal that a resolver outage is happening.
+    // It must also carry the reason — routing the rejection here rather than to the outer catch
+    // otherwise throws away the only record of why the resolver failed.
+    expect(mockLogToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'delete-image-from-s3-unresolved-location',
+        error: expect.anything(),
+      })
+    );
   });
 
   // The guard above is safe only while no row holds a url for a bucket we own. Nothing enforces

--- a/src/server/services/__tests__/delete-image-from-s3-logging.test.ts
+++ b/src/server/services/__tests__/delete-image-from-s3-logging.test.ts
@@ -9,11 +9,18 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // (unblock-image-nsfwlevel-reset.test.ts): stub env + infra clients + the event-engine-common
 // submodule so importing it boots no real infra.
 
-const { mockLogToAxiom, mockFindFirst, mockFetch } = vi.hoisted(() => ({
-  mockLogToAxiom: vi.fn(async () => undefined),
-  mockFindFirst: vi.fn(),
-  mockFetch: vi.fn(async () => ({ ok: true })),
-}));
+const { mockLogToAxiom, mockFindFirst, mockFetch, mockB2Send, mockResolveMediaLocation } =
+  vi.hoisted(() => ({
+    mockLogToAxiom: vi.fn(async () => undefined),
+    mockFindFirst: vi.fn(),
+    mockFetch: vi.fn(async () => ({ ok: true })),
+    // Typed to take the command so `mock.calls[0][0].input` is assertable — an untyped `vi.fn()`
+    // here gives `calls` an empty tuple type and the bucket/key assertions stop compiling.
+    mockB2Send: vi.fn(async (command: { input: Record<string, unknown> }) => ({
+      Key: command.input.Key,
+    })),
+    mockResolveMediaLocation: vi.fn(),
+  }));
 
 function makePermissive(overrides: Record<string, unknown> = {}): any {
   const handler: ProxyHandler<any> = {
@@ -48,14 +55,35 @@ vi.mock('../../../../event-engine-common/services/metrics', () => ({
 vi.mock('../../../../event-engine-common/feeds', () => ({ ImagesFeed: class {} }));
 vi.mock('../../../../event-engine-common/services/cache', () => ({ CacheService: class {} }));
 
+// The S3 client and the registry are the two things this file is actually about, so both are
+// mocked explicitly rather than left to fall out of the permissive scaffolding below.
+vi.mock('~/utils/s3-utils', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getB2ImageS3Client: () => ({ send: mockB2Send }),
+}));
+
+vi.mock('~/server/services/storage-resolver', () => ({
+  resolveMediaLocation: mockResolveMediaLocation,
+  registerMediaLocation: vi.fn(),
+}));
+
 // Real env validation throws in test; a Proxy hands back safe defaults for whatever
 // image.service reads at import time. DATABASE_IS_PROD gates deleteImageFromS3 entirely.
+//
+// 🔴 S3_IMAGE_B2_BUCKET must be a REAL value here. The proxy's fallthrough returns undefined for
+// any name it does not recognise, and the delete used to sit behind `env.S3_IMAGE_B2_ACCESS_KEY`
+// — so before this fixture existed, every test in this file ran with BOTH delete branches
+// unreachable and every "the delete throws" case actually threw at the db refcount query. The
+// suite was green and covered the S3 call zero times. Assert against this constant, not a literal.
 vi.mock('~/env/server', () => ({
   env: new Proxy(
     {
       LOGGING: [] as string[],
       DATABASE_IS_PROD: true,
       IMAGE_CACHER_URL: 'https://image-cacher.test',
+      S3_IMAGE_B2_BUCKET: 'civitai-media-uploads',
+      S3_IMAGE_B2_ACCESS_KEY: 'test-b2-key',
+      S3_IMAGE_B2_SECRET_KEY: 'test-b2-secret',
     } as Record<string, unknown>,
     {
       get: (target, prop) => {
@@ -109,6 +137,9 @@ describe('deleteImageFromS3', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.stubGlobal('fetch', mockFetch);
+    // Default to the registered case; the tests that care set their own.
+    mockResolveMediaLocation.mockResolvedValue({ backend: 'backblaze', url: 'https://b2/x' });
+    mockB2Send.mockResolvedValue({ Key: 'abc-def/original.jpeg' });
   });
 
   it('logs the image id and url when the delete throws', async () => {
@@ -166,6 +197,93 @@ describe('deleteImageFromS3', () => {
     expect(mockFindFirst).not.toHaveBeenCalled();
     expect(mockLogToAxiom).not.toHaveBeenCalled();
     expect(invalidateCalls()).toHaveLength(0);
+  });
+
+  // ── The delete itself. Everything above asserts around the S3 call; these assert the call. ──
+
+  it('deletes the object from B2 when the resolver reports backblaze', async () => {
+    mockFindFirst.mockResolvedValue(null);
+
+    await deleteImageFromS3({ id: 4242, url: 'abc-def/original.jpeg' });
+
+    expect(mockB2Send).toHaveBeenCalledTimes(1);
+    const command = mockB2Send.mock.calls[0][0] as { input: Record<string, unknown> };
+    expect(command.input).toMatchObject({
+      Bucket: 'civitai-media-uploads',
+      Key: 'abc-def/original.jpeg',
+    });
+    expect(mockLogToAxiom).not.toHaveBeenCalled();
+  });
+
+  // THE REGRESSION. `resolveMediaLocation` returns null for a 404, a service error AND a timeout,
+  // and the code used to route that to a DigitalOcean bucket deleted 2026-05-18 — the delete threw
+  // on the proxy's text/plain "404 page not found", the row was already gone, and the object stayed
+  // publicly fetchable on an unsigned CDN url. 2,545 objects accumulated that way. An unregistered
+  // image is still on B2; there is nowhere else for it to be.
+  it('deletes the object from B2 when the resolver returns no location', async () => {
+    mockFindFirst.mockResolvedValue(null);
+    mockResolveMediaLocation.mockResolvedValue(null);
+
+    await deleteImageFromS3({ id: 4242, url: 'abc-def/original.jpeg' });
+
+    expect(mockB2Send).toHaveBeenCalledTimes(1);
+    const command = mockB2Send.mock.calls[0][0] as { input: Record<string, unknown> };
+    expect(command.input).toMatchObject({
+      Bucket: 'civitai-media-uploads',
+      Key: 'abc-def/original.jpeg',
+    });
+    expect(mockLogToAxiom).not.toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'delete-image-from-s3-failed' })
+    );
+  });
+
+  // Deleting on a resolver miss is right, but it must not be silent: the miss is the tell for a
+  // registry gap or a storage-resolver outage, and burying it is what kept this invisible.
+  it('warns about the unresolved location without failing the delete', async () => {
+    mockFindFirst.mockResolvedValue(null);
+    mockResolveMediaLocation.mockResolvedValue(null);
+
+    await deleteImageFromS3({ id: 4242, url: 'abc-def/original.jpeg' });
+
+    expect(mockLogToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'warning',
+        name: 'delete-image-from-s3-unresolved-location',
+        imageId: 4242,
+        url: 'abc-def/original.jpeg',
+      })
+    );
+    expect(mockB2Send).toHaveBeenCalledTimes(1);
+  });
+
+  // Negative control for the warning above — a warning that fires on every delete is not a signal.
+  it('stays silent when the resolver does have a location', async () => {
+    mockFindFirst.mockResolvedValue(null);
+
+    await deleteImageFromS3({ id: 4242, url: 'abc-def/original.jpeg' });
+
+    expect(mockLogToAxiom).not.toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'delete-image-from-s3-unresolved-location' })
+    );
+  });
+
+  // Positive control that the failure path is reached THROUGH the S3 call rather than through the
+  // db refcount query above it — the distinction the rest of this file could not previously make.
+  it('logs the failure and still invalidates when the B2 delete itself throws', async () => {
+    mockFindFirst.mockResolvedValue(null);
+    mockB2Send.mockRejectedValue(new Error('b2 refused'));
+
+    await deleteImageFromS3({ id: 4242, url: 'abc-def/original.jpeg' });
+
+    expect(mockLogToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'error',
+        name: 'delete-image-from-s3-failed',
+        imageId: 4242,
+        url: 'abc-def/original.jpeg',
+      })
+    );
+    expect(invalidateCalls()).toHaveLength(1);
   });
 
   // The guard above is safe only while no row holds a url for a bucket we own. Nothing enforces

--- a/src/server/services/__tests__/delete-image-from-s3-logging.test.ts
+++ b/src/server/services/__tests__/delete-image-from-s3-logging.test.ts
@@ -9,18 +9,28 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // (unblock-image-nsfwlevel-reset.test.ts): stub env + infra clients + the event-engine-common
 // submodule so importing it boots no real infra.
 
-const { mockLogToAxiom, mockFindFirst, mockFetch, mockB2Send, mockResolveMediaLocation } =
-  vi.hoisted(() => ({
-    mockLogToAxiom: vi.fn(async () => undefined),
-    mockFindFirst: vi.fn(),
-    mockFetch: vi.fn(async () => ({ ok: true })),
-    // Typed to take the command so `mock.calls[0][0].input` is assertable — an untyped `vi.fn()`
-    // here gives `calls` an empty tuple type and the bucket/key assertions stop compiling.
-    mockB2Send: vi.fn(async (command: { input: Record<string, unknown> }) => ({
-      Key: command.input.Key,
-    })),
-    mockResolveMediaLocation: vi.fn(),
-  }));
+const {
+  mockLogToAxiom,
+  mockFindFirst,
+  mockFetch,
+  mockB2Send,
+  mockResolveMediaLocation,
+  mockGetB2ImageS3Client,
+} = vi.hoisted(() => ({
+  mockLogToAxiom: vi.fn(async () => undefined),
+  mockFindFirst: vi.fn(),
+  mockFetch: vi.fn(async () => ({ ok: true })),
+  // Typed to take the command so `mock.calls[0][0].input` is assertable — an untyped `vi.fn()`
+  // here gives `calls` an empty tuple type and the bucket/key assertions stop compiling.
+  mockB2Send: vi.fn(async (command: { input: Record<string, unknown> }) => ({
+    Key: command.input.Key,
+  })),
+  mockResolveMediaLocation: vi.fn(),
+  // A vi.fn rather than a fixed arrow so a test can make the client CONSTRUCTOR throw — the real
+  // one does exactly that when B2 credentials are absent, which is the case the removed
+  // `env.S3_IMAGE_B2_ACCESS_KEY` guard used to swallow.
+  mockGetB2ImageS3Client: vi.fn(),
+}));
 
 function makePermissive(overrides: Record<string, unknown> = {}): any {
   const handler: ProxyHandler<any> = {
@@ -59,7 +69,7 @@ vi.mock('../../../../event-engine-common/services/cache', () => ({ CacheService:
 // mocked explicitly rather than left to fall out of the permissive scaffolding below.
 vi.mock('~/utils/s3-utils', async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
-  getB2ImageS3Client: () => ({ send: mockB2Send }),
+  getB2ImageS3Client: mockGetB2ImageS3Client,
 }));
 
 vi.mock('~/server/services/storage-resolver', () => ({
@@ -74,14 +84,20 @@ vi.mock('~/server/services/storage-resolver', () => ({
 // any name it does not recognise, and the delete used to sit behind `env.S3_IMAGE_B2_ACCESS_KEY`
 // — so before this fixture existed, every test in this file ran with BOTH delete branches
 // unreachable and every "the delete throws" case actually threw at the db refcount query. The
-// suite was green and covered the S3 call zero times. Assert against this constant, not a literal.
+// suite was green and covered the S3 call zero times.
+//
+// 🔴 And it must DIFFER from the code's own fallback (`?? 'civitai-media-uploads'`). Setting it to
+// the same string makes "reads the env var" and "hardcodes the literal" byte-identical in every
+// assertion — measured: with both set to 'civitai-media-uploads', replacing the whole expression
+// with the bare literal passed all 11 tests. A fixture of default/matching values collapses
+// distinct implementations into the same output.
 vi.mock('~/env/server', () => ({
   env: new Proxy(
     {
       LOGGING: [] as string[],
       DATABASE_IS_PROD: true,
       IMAGE_CACHER_URL: 'https://image-cacher.test',
-      S3_IMAGE_B2_BUCKET: 'civitai-media-uploads',
+      S3_IMAGE_B2_BUCKET: 'test-b2-bucket',
       S3_IMAGE_B2_ACCESS_KEY: 'test-b2-key',
       S3_IMAGE_B2_SECRET_KEY: 'test-b2-secret',
     } as Record<string, unknown>,
@@ -140,6 +156,7 @@ describe('deleteImageFromS3', () => {
     // Default to the registered case; the tests that care set their own.
     mockResolveMediaLocation.mockResolvedValue({ backend: 'backblaze', url: 'https://b2/x' });
     mockB2Send.mockResolvedValue({ Key: 'abc-def/original.jpeg' });
+    mockGetB2ImageS3Client.mockReturnValue({ send: mockB2Send });
   });
 
   it('logs the image id and url when the delete throws', async () => {
@@ -209,7 +226,7 @@ describe('deleteImageFromS3', () => {
     expect(mockB2Send).toHaveBeenCalledTimes(1);
     const command = mockB2Send.mock.calls[0][0] as { input: Record<string, unknown> };
     expect(command.input).toMatchObject({
-      Bucket: 'civitai-media-uploads',
+      Bucket: 'test-b2-bucket',
       Key: 'abc-def/original.jpeg',
     });
     expect(mockLogToAxiom).not.toHaveBeenCalled();
@@ -229,7 +246,7 @@ describe('deleteImageFromS3', () => {
     expect(mockB2Send).toHaveBeenCalledTimes(1);
     const command = mockB2Send.mock.calls[0][0] as { input: Record<string, unknown> };
     expect(command.input).toMatchObject({
-      Bucket: 'civitai-media-uploads',
+      Bucket: 'test-b2-bucket',
       Key: 'abc-def/original.jpeg',
     });
     expect(mockLogToAxiom).not.toHaveBeenCalledWith(
@@ -284,6 +301,46 @@ describe('deleteImageFromS3', () => {
       })
     );
     expect(invalidateCalls()).toHaveLength(1);
+  });
+
+  // This PR removed the `env.S3_IMAGE_B2_ACCESS_KEY` half of the old guard, so a deployment with
+  // no B2 credentials now reaches getB2ImageS3Client(), which throws by design. That must be a
+  // LOUD failure rather than the silent no-op the old `else if` produced when neither bucket var
+  // was set — and the cache invalidation still has to run, because the object is still there.
+  it('logs loudly when B2 credentials are missing instead of skipping silently', async () => {
+    mockFindFirst.mockResolvedValue(null);
+    mockGetB2ImageS3Client.mockImplementation(() => {
+      throw new Error('B2 image upload credentials not configured');
+    });
+
+    await deleteImageFromS3({ id: 4242, url: 'abc-def/original.jpeg' });
+
+    expect(mockLogToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'error',
+        name: 'delete-image-from-s3-failed',
+        imageId: 4242,
+      })
+    );
+    expect(mockB2Send).not.toHaveBeenCalled();
+    expect(invalidateCalls()).toHaveLength(1);
+  });
+
+  // resolveMediaLocation is typed `| null` and callers are written as if it cannot throw, but a
+  // `return res.json()` inside its try let a rejection escape that try entirely (a 200 carrying a
+  // non-JSON body — an ingress error page — is exactly that). Reaching this delete through a
+  // REJECTING resolver is the case that produced the very orphan this change exists to stop, so
+  // the delete must survive it rather than be skipped by it.
+  it('still deletes from B2 when the resolver rejects outright', async () => {
+    mockFindFirst.mockResolvedValue(null);
+    mockResolveMediaLocation.mockRejectedValue(new Error('unexpected end of JSON input'));
+
+    await deleteImageFromS3({ id: 4242, url: 'abc-def/original.jpeg' });
+
+    expect(mockB2Send).toHaveBeenCalledTimes(1);
+    expect(mockLogToAxiom).not.toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'delete-image-from-s3-failed' })
+    );
   });
 
   // The guard above is safe only while no row holds a url for a bucket we own. Nothing enforces

--- a/src/server/services/__tests__/storage-resolver-null-contract.test.ts
+++ b/src/server/services/__tests__/storage-resolver-null-contract.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// `resolveMediaLocation` is typed `Promise<{…} | null>` and every caller is written as if it
+// cannot throw — deleteImageFromS3 in particular, where a throw skips the S3 delete entirely and
+// leaves a publicly-fetchable object behind a deleted row.
+//
+// It used to end `return res.json() as Promise<…>` INSIDE its try. In an async function a returned
+// promise is adopted after control leaves the try, so its rejection was never seen by the catch
+// and escaped to the caller — silently violating the `| null` contract. A 200 response carrying a
+// non-JSON body (an ingress or proxy error page) is exactly that shape, and it is the same
+// storage-resolver-outage case the null branch exists to tolerate.
+
+vi.mock('~/env/server', () => ({
+  env: {
+    STORAGE_RESOLVER_INTERNAL_URL: 'http://storage-resolver.test',
+    STORAGE_RESOLVER_INTERNAL_TOKEN: 'test-token',
+  },
+}));
+
+const { resolveMediaLocation } = await import('../storage-resolver');
+
+const mockFetch = vi.fn();
+
+describe('resolveMediaLocation — the `| null` contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  // THE REGRESSION. Without `await` on res.json() this rejects instead of resolving to null.
+  it('returns null when a 200 response carries a body that is not JSON', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.reject(new SyntaxError('Unexpected end of JSON input')),
+    });
+
+    await expect(resolveMediaLocation('abc-def/original.jpeg')).resolves.toBeNull();
+  });
+
+  it('returns null on a non-ok response', async () => {
+    mockFetch.mockResolvedValue({ ok: false, json: () => Promise.resolve({}) });
+
+    await expect(resolveMediaLocation('abc-def/original.jpeg')).resolves.toBeNull();
+  });
+
+  it('returns null when the request itself rejects', async () => {
+    mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    await expect(resolveMediaLocation('abc-def/original.jpeg')).resolves.toBeNull();
+  });
+
+  // Positive control: the null cases above must not be passing because the function returns null
+  // unconditionally. A resolvable location has to come back intact.
+  it('returns the parsed location on success', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ backend: 'backblaze', url: 'https://b2.test/abc' }),
+    });
+
+    await expect(resolveMediaLocation('abc-def/original.jpeg')).resolves.toEqual({
+      backend: 'backblaze',
+      url: 'https://b2.test/abc',
+    });
+  });
+});

--- a/src/server/services/__tests__/storage-resolver-null-contract.test.ts
+++ b/src/server/services/__tests__/storage-resolver-null-contract.test.ts
@@ -62,4 +62,22 @@ describe('resolveMediaLocation — the `| null` contract', () => {
       url: 'https://b2.test/abc',
     });
   });
+
+  // The base URL is `env.STORAGE_RESOLVER_INTERNAL_URL ?? '<cluster-dns fallback>'`, and nothing
+  // above asserts which side of that `??` is used — so dropping either half leaves every test
+  // green. The fixture URL is deliberately distinct from the fallback, which makes the two
+  // distinguishable; this is the assertion that actually distinguishes them.
+  it('addresses the resolver at the configured url, not the compiled-in fallback', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ backend: 'backblaze', url: 'https://b2.test/abc' }),
+    });
+
+    await resolveMediaLocation('abc-def/original.jpeg');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://storage-resolver.test/resolve-media',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
 });

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -367,9 +367,19 @@ export async function deleteImageFromS3({ id, url }: { id: number; url: string }
     // The `.catch` is belt and braces with the `await` fix inside resolveMediaLocation: no failure
     // of the lookup may stop the delete, and inlining the guard keeps that true even if the
     // resolver later grows a throwing path again.
-    let resolverError: unknown;
+    //
+    // The reason is sanitised INSIDE that `.catch`, under its own try, which is what keeps it total.
+    // `safeError` ends in `String(e)` for a non-Error, and that throws on a value with no primitive
+    // conversion — `Object.create(null)`, or anything with a throwing `toString`. Calling it in the
+    // log payload below instead would put that throw inside the OUTER try, skipping the B2 delete:
+    // the exact failure this `.catch` exists to prevent, reintroduced by the code reporting it.
+    let resolverError: MixedObject | undefined;
     const location = await resolveMediaLocation(url).catch((error: unknown) => {
-      resolverError = error;
+      try {
+        resolverError = safeError(error);
+      } catch {
+        resolverError = { message: 'resolver rejected with a value that could not be serialised' };
+      }
       return null;
     });
     if (!location) {
@@ -384,7 +394,7 @@ export async function deleteImageFromS3({ id, url }: { id: number; url: string }
         message: 'storage-resolver returned no location; deleting from B2 anyway',
         imageId: id,
         url,
-        ...(resolverError !== undefined && { error: safeError(resolverError) }),
+        ...(resolverError !== undefined && { error: resolverError }),
       }).catch(() => undefined);
     }
 

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -359,27 +359,32 @@ export async function deleteImageFromS3({ id, url }: { id: number; url: string }
 
     if (!!otherImagesWithSameUrl) return;
 
-    // B2 is the only backend an image can be on: the DigitalOcean-Spaces bucket was deleted
-    // 2026-05-18 and `ImageUploadBackend` has exactly one member. So the registry is consulted
-    // for observability, not to choose a destination — a miss means "unregistered", never
-    // "somewhere else". This used to branch to a DO delete on a miss, which is how 2,545 objects
-    // outlived their rows: `resolveMediaLocation` returns null on a 404, a service error AND a
-    // timeout, and the DO endpoint answers `404 page not found` as text/plain, which the SDK's
-    // XML error deserializer throws on. The row was already gone, so the object stayed public.
-    // Belt and braces with the `await` fix in resolveMediaLocation: the lookup is observability, so
-    // no failure of it may stop the delete. Inlining the guard here keeps that true even if the
+    // B2 is the only backend an image can be on, so the registry is consulted for observability
+    // rather than to choose a destination — a miss means "unregistered", never "somewhere else".
+    // This used to branch to a second backend on a miss, and that branch could not succeed, so
+    // every miss left the object behind a row that was already deleted.
+    //
+    // The `.catch` is belt and braces with the `await` fix inside resolveMediaLocation: no failure
+    // of the lookup may stop the delete, and inlining the guard keeps that true even if the
     // resolver later grows a throwing path again.
-    const location = await resolveMediaLocation(url).catch(() => null);
+    let resolverError: unknown;
+    const location = await resolveMediaLocation(url).catch((error: unknown) => {
+      resolverError = error;
+      return null;
+    });
     if (!location) {
       // Not a failure — the delete proceeds against B2 below. But an unregistered image is a
       // registry gap (or a storage-resolver outage), and silently treating it as B2 is exactly
-      // what made the gap invisible for three months. Rate of this line is the health signal.
+      // what made the gap invisible. Rate of this line is the health signal, so it carries the
+      // reason too: routing a rejection here instead of to the catch below would otherwise discard
+      // the only record of WHY the resolver failed.
       await logToAxiom({
         type: 'warning',
         name: 'delete-image-from-s3-unresolved-location',
         message: 'storage-resolver returned no location; deleting from B2 anyway',
         imageId: id,
         url,
+        ...(resolverError !== undefined && { error: safeError(resolverError) }),
       }).catch(() => undefined);
     }
 

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -225,7 +225,6 @@ import { fetchBlob } from '~/utils/file-utils';
 import { getMetadata } from '~/utils/metadata';
 import { removeEmpty } from '~/utils/object-helpers';
 import { DeleteObjectCommand } from '@aws-sdk/client-s3';
-import { getImageS3Client } from '~/utils/s3-client';
 import { serverUploadImage, getB2ImageS3Client } from '~/utils/s3-utils';
 import { resolveMediaLocation } from '~/server/services/storage-resolver';
 import { isDefined, isNumber } from '~/utils/type-guards';
@@ -360,23 +359,36 @@ export async function deleteImageFromS3({ id, url }: { id: number; url: string }
 
     if (!!otherImagesWithSameUrl) return;
 
-    // Check storage-resolver for backend location (during media migration)
+    // B2 is the only backend an image can be on: the DigitalOcean-Spaces bucket was deleted
+    // 2026-05-18 and `ImageUploadBackend` has exactly one member. So the registry is consulted
+    // for observability, not to choose a destination — a miss means "unregistered", never
+    // "somewhere else". This used to branch to a DO delete on a miss, which is how 2,545 objects
+    // outlived their rows: `resolveMediaLocation` returns null on a 404, a service error AND a
+    // timeout, and the DO endpoint answers `404 page not found` as text/plain, which the SDK's
+    // XML error deserializer throws on. The row was already gone, so the object stayed public.
     const location = await resolveMediaLocation(url);
-    if (location?.backend === 'backblaze' && env.S3_IMAGE_B2_ACCESS_KEY) {
-      const b2Client = getB2ImageS3Client();
-      await withRetries(() =>
-        b2Client.send(
-          new DeleteObjectCommand({
-            Bucket: env.S3_IMAGE_B2_BUCKET ?? 'civitai-media-uploads',
-            Key: url,
-          })
-        )
-      );
-    } else if (env.S3_IMAGE_UPLOAD_BUCKET) {
-      await withRetries(() =>
-        getImageS3Client().deleteObject({ bucket: env.S3_IMAGE_UPLOAD_BUCKET!, key: url })
-      );
+    if (!location) {
+      // Not a failure — the delete proceeds against B2 below. But an unregistered image is a
+      // registry gap (or a storage-resolver outage), and silently treating it as B2 is exactly
+      // what made the gap invisible for three months. Rate of this line is the health signal.
+      await logToAxiom({
+        type: 'warning',
+        name: 'delete-image-from-s3-unresolved-location',
+        message: 'storage-resolver returned no location; deleting from B2 anyway',
+        imageId: id,
+        url,
+      }).catch(() => undefined);
     }
+
+    const b2Client = getB2ImageS3Client();
+    await withRetries(() =>
+      b2Client.send(
+        new DeleteObjectCommand({
+          Bucket: env.S3_IMAGE_B2_BUCKET ?? 'civitai-media-uploads',
+          Key: url,
+        })
+      )
+    );
   } catch (error) {
     // Nothing retries this: deleteImages drops the DB row first, so a lost object stays
     // publicly reachable (CDN urls are unsigned) with only this line to find it by.

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -293,10 +293,10 @@ export async function purgeResizeCache({ url }: { url: string }) {
   // request) and must never fail the caller's mutation.
   //
   // NOTE: this used to also do a direct S3 listObjects+deleteManyObjects against
-  // env.S3_IMAGE_CACHE_BUCKET ("civitai-media-cache") via getImageS3Client().
+  // env.S3_IMAGE_CACHE_BUCKET ("civitai-media-cache") via the legacy image S3 client.
   // That path was DEAD in prod and has been removed: the cache bucket now lives
   // on Backblaze B2 (us-west-004) and is owned by the image-cacher service,
-  // while getImageS3Client() points at the DigitalOcean-Spaces object-read proxy
+  // while that client pointed at the DigitalOcean-Spaces object-read proxy
   // (S3_IMAGE_UPLOAD_ENDPOINT). That proxy does not implement ListObjectsV2 — a
   // path-style list request returns a plain-text "404 page not found", which the
   // AWS SDK's XML error deserializer chokes on (`char '4' is not expected.:1:1`).
@@ -366,7 +366,10 @@ export async function deleteImageFromS3({ id, url }: { id: number; url: string }
     // outlived their rows: `resolveMediaLocation` returns null on a 404, a service error AND a
     // timeout, and the DO endpoint answers `404 page not found` as text/plain, which the SDK's
     // XML error deserializer throws on. The row was already gone, so the object stayed public.
-    const location = await resolveMediaLocation(url);
+    // Belt and braces with the `await` fix in resolveMediaLocation: the lookup is observability, so
+    // no failure of it may stop the delete. Inlining the guard here keeps that true even if the
+    // resolver later grows a throwing path again.
+    const location = await resolveMediaLocation(url).catch(() => null);
     if (!location) {
       // Not a failure — the delete proceeds against B2 below. But an unregistered image is a
       // registry gap (or a storage-resolver outage), and silently treating it as B2 is exactly

--- a/src/server/services/storage-resolver.ts
+++ b/src/server/services/storage-resolver.ts
@@ -3,8 +3,7 @@ import { fetchTimeoutSignal } from '~/server/utils/fetch-timeout';
 import type { ImageUploadBackend } from '~/utils/s3-utils';
 
 const STORAGE_RESOLVER_URL =
-  env.STORAGE_RESOLVER_INTERNAL_URL ??
-  'http://storage-resolver.storage-resolver.svc.cluster.local';
+  env.STORAGE_RESOLVER_INTERNAL_URL ?? 'http://storage-resolver.storage-resolver.svc.cluster.local';
 const STORAGE_RESOLVER_TOKEN = env.STORAGE_RESOLVER_INTERNAL_TOKEN;
 
 export async function registerMediaLocation(
@@ -43,7 +42,11 @@ export async function resolveMediaLocation(
       signal: fetchTimeoutSignal(60_000),
     });
     if (!res.ok) return null;
-    return res.json() as Promise<{ backend: ImageUploadBackend; url: string }>;
+    // `await` is load-bearing, not style. `return res.json()` inside a try returns the promise and
+    // leaves the try before it settles, so the async function adopts a REJECTION that this catch
+    // never sees — and the signature says `| null`, so every caller is written as if it cannot
+    // throw. A 200 carrying a non-JSON body (an ingress/proxy error page) is exactly that case.
+    return (await res.json()) as { backend: ImageUploadBackend; url: string };
   } catch {
     return null;
   }

--- a/src/utils/s3-client.ts
+++ b/src/utils/s3-client.ts
@@ -251,6 +251,6 @@ export class S3Bucket implements HasKeys<S3Client> {
 }
 
 // The legacy DO Spaces image client lived here. Its last caller was deleteImageFromS3's fallback
-// branch, which pointed at a bucket deleted 2026-05-18 — every delete routed through it failed.
+// branch, which pointed at a decommissioned bucket — every delete routed through it failed.
 // Nothing constructs an S3 client from S3_IMAGE_UPLOAD_* any more; those vars are inert and can be
 // dropped from prod config independently of this change.

--- a/src/utils/s3-client.ts
+++ b/src/utils/s3-client.ts
@@ -13,7 +13,6 @@ import {
   ListObjectsV2Command,
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import { env } from '~/env/server';
 
 const DOWNLOAD_EXPIRATION = 60 * 60 * 24; // 24 hours
 const UPLOAD_EXPIRATION = 60 * 60 * 12; // 12 hours
@@ -251,19 +250,7 @@ export class S3Bucket implements HasKeys<S3Client> {
   }
 }
 
-// Legacy DO Spaces image client — only used for deleting old images.
-// Lazy-initialized because the env vars are now optional.
-let _imageS3Client: S3Client | null = null;
-export function getImageS3Client(): S3Client {
-  if (!_imageS3Client) {
-    _imageS3Client = new S3Client({
-      name: 'image-s3-client',
-      uploadKey: env.S3_IMAGE_UPLOAD_KEY,
-      uploadSecret: env.S3_IMAGE_UPLOAD_SECRET,
-      uploadEndpoint: env.S3_IMAGE_UPLOAD_ENDPOINT,
-      uploadRegion: env.S3_IMAGE_UPLOAD_REGION,
-      forcePathStyle: env.S3_IMAGE_FORCE_PATH_STYLE,
-    });
-  }
-  return _imageS3Client;
-}
+// The legacy DO Spaces image client lived here. Its last caller was deleteImageFromS3's fallback
+// branch, which pointed at a bucket deleted 2026-05-18 — every delete routed through it failed.
+// Nothing constructs an S3 client from S3_IMAGE_UPLOAD_* any more; those vars are inert and can be
+// dropped from prod config independently of this change.


### PR DESCRIPTION
## What

`deleteImageFromS3` deleted from B2 only when the storage-resolver returned `backend === 'backblaze'`. Every other outcome — a 404, a service error, a timeout, all of which `resolveMediaLocation` collapses to `null` — fell through to a DigitalOcean Spaces bucket that was deleted on 2026-05-18.

That path cannot succeed. The endpoint answers `404 page not found` as `text/plain`, which the AWS SDK's XML error deserializer throws on (the same failure already documented above `purgeResizeCache`). And `deleteImages` drops the DB row *before* calling this, so the object outlives its row and stays publicly fetchable — CDN urls are unsigned — with one Axiom line as the only record that it happened. **2,545 images accumulated this way, growing ~350/day**, ~96% of them from the account-deletion drain.

## The fix

B2 is the only place an image can be: `ImageUploadBackend` has exactly one member and the DO bucket no longer exists. So the registry lookup is now for **observability, not routing** — a miss means "unregistered", never "somewhere else", and the delete proceeds against B2 either way.

A miss emits a new `delete-image-from-s3-unresolved-location` warning, so a registry gap or a storage-resolver outage stays visible rather than being papered over by the more permissive delete.

Removing the fallback leaves `getImageS3Client` with no callers, so it goes too. Nothing constructs a client from `S3_IMAGE_UPLOAD_*` any more — those vars are inert and can be dropped from config separately.

## 🔴 The test fixture could not have caught this

Worth a reviewer's attention independent of the fix. The env mock in `delete-image-from-s3-logging.test.ts` only returned values for names ending `_URL`/`_ENDPOINT`, so `S3_IMAGE_B2_ACCESS_KEY` and `S3_IMAGE_UPLOAD_BUCKET` were both `undefined` — **both delete branches were unreachable in every test in the file**, and each "the delete throws" case actually threw at the db refcount query *above* the S3 call. The suite was green with zero coverage of the thing it is named after.

Fixed here (real B2 env values + a mocked client + a mocked resolver), then 5 tests added.

## Red/green matrix

Measured, not assumed. Base = `054d25bab3`.

| Test | base | HEAD | what it is |
|---|---|---|---|
| deletes from B2 when the resolver returns no location | ❌ | ✅ | **regression** |
| warns about the unresolved location without failing the delete | ❌ | ✅ | **regression** |
| deletes from B2 when the resolver reports backblaze | ✅ | ✅ | invariant guard |
| stays silent when the resolver does have a location | ✅ | ✅ | invariant guard (negative control for the warning) |
| logs the failure and still invalidates when the B2 delete itself throws | ✅ | ✅ | positive control — proves the failure path is now reached *through* the S3 call, not the refcount query |

3 of the 5 pass at base too. They are guards and controls, not regression coverage, and are labelled as such in the file rather than counted as proof.

## Verification

- `unit` sweep of `src/server/services/__tests__/` + `src/server/jobs/__tests__/` → **244 files / 3329 tests passed, 0 failed**
- `typecheck` → exit 0, 0 `error TS`. Instrument validated first: a planted `const x: number = 'nope'` in `src/utils/s3-client.ts` was caught (`error TS2322`), so the clean verdict is a real result and not an empty log.
- `eslint` on both source files → 28 problems / 3 errors, **byte-identical to base** (all pre-existing).

**Not deployed, not verified against production.** The claim here is about the code and the suite.

## Still open (not in this PR)

1. Partition the Axiom `error` field (`| summarize count() by error`) — the `try` also wraps the db refcount query, so some share of those 2,545 lines may be a *second* defect this does not fix.
2. Recover the accumulated orphans. A bucket-vs-DB reconciliation is the right instrument, not a replay of the log — the log only captures throws, is retention-bounded, and cannot see anything before the drain landed on 2026-08-03, while the leak dates from 2026-05-18. Any replay needs the same refcount guard the live path has; a blind key-list delete can destroy media still referenced by a live row.
3. A counter + alert on delete failures, and a tombstone written with the row delete rather than after it — the ordering is what makes every failure unrecoverable by design.

Rationale and the full diagnosis live in the private infra repo, not here. See the pinned comment below for two corrections to this description.

ClickUp: https://app.clickup.com/t/868kpaenx

🤖 Generated with [Claude Code](https://claude.com/claude-code)
