### PR TITLE
fix(api): close the two remaining #3845 disclosure populations — 11 hand-rolled envelopes + driver text at 4xx

### DIFF
--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -233,8 +233,19 @@ vi.mock('~/server/prom/client', () => ({
   imageScanWebhookCounter: promMetricStub(),
 }));
 
-// Mock logging
-vi.mock('~/server/logging/client', () => ({
+// Mock logging.
+//
+// 🔴 Spreads the ORIGINAL rather than replacing the module with a one-key object.
+// `~/server/logging/client` has 7 exports; the previous wholesale mock provided
+// exactly one, so ANY code path reaching a second one died with
+// `[vitest] No "<name>" export is defined on the mock` — an error that surfaces
+// far from its cause. It bit when the REST routes were consolidated onto
+// `handleEndpointError` (civitai#3845/4): the helper needs `buildCentralErrorLog`
+// and `wasServerFaultLogged`, so nine previously-green route tests broke for a
+// reason that had nothing to do with what they assert. Only `logToAxiom` is
+// stubbed, because that is the one with an I/O side effect a test must not do.
+vi.mock('~/server/logging/client', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   logToAxiom: vi.fn().mockResolvedValue(undefined),
 }));
 

--- a/src/pages/api/notification/getDetails.ts
+++ b/src/pages/api/notification/getDetails.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { bareNotification } from '~/server/notifications/base.notifications';
 import { populateNotificationDetails } from '~/server/notifications/detail-fetchers';
-import { AuthedEndpoint } from '~/server/utils/endpoint-helpers';
+import { AuthedEndpoint, handleEndpointError } from '~/server/utils/endpoint-helpers';
 
 const schema = bareNotification;
 
@@ -16,7 +16,10 @@ export default AuthedEndpoint(
       await populateNotificationDetails([results.data]);
       return res.json(results.data);
     } catch (error) {
-      return res.status(500).json({ message: 'An unexpected error occurred', error });
+      // civitai#3845 (population B): `populateNotificationDetails` fans out over
+      // per-type detail fetchers that query the DB directly, so the whole error
+      // OBJECT serialized here was driver-derived.
+      return handleEndpointError(res, error);
     }
   },
   ['POST']

--- a/src/pages/api/run/[modelVersionId].ts
+++ b/src/pages/api/run/[modelVersionId].ts
@@ -3,6 +3,7 @@ import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
 import { dbRead, dbWrite } from '~/server/db/client';
 import * as z from 'zod';
 import { Tracker } from '~/server/clickhouse/client';
+import { handleEndpointError } from '~/server/utils/endpoint-helpers';
 
 const schema = z.object({
   modelVersionId: z.preprocess((val) => Number(val), z.number()),
@@ -61,7 +62,10 @@ export default async function runModel(req: NextApiRequest, res: NextApiResponse
       nsfw: modelVersion.model.nsfw,
     });
   } catch (error) {
-    return res.status(500).json({ error: 'Invalid database operation', cause: error });
+    // civitai#3845 (population B): `cause: error` serialized the whole error
+    // object under a second key. The generic `error` string next to it made this
+    // look sanitized — it was not; `cause` carried the driver payload.
+    return handleEndpointError(res, error);
   }
 
   // Append our QS

--- a/src/pages/api/v1/content/[[...slug]].ts
+++ b/src/pages/api/v1/content/[[...slug]].ts
@@ -1,9 +1,6 @@
-import { TRPCError } from '@trpc/server';
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { publicApiContext, publicApiContext2 } from '~/server/createContext';
-import { appRouter } from '~/server/routers';
-import { PublicEndpoint } from '~/server/utils/endpoint-helpers';
-import { isClientAbortError } from '~/server/utils/errorHandling';
+import { publicApiContext2 } from '~/server/createContext';
+import { handleEndpointError, PublicEndpoint } from '~/server/utils/endpoint-helpers';
 
 export default PublicEndpoint(async function handler(req: NextApiRequest, res: NextApiResponse) {
   // const apiCaller = appRouter.createCaller(publicApiContext(req, res));
@@ -12,12 +9,12 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
   try {
     const result = await apiCaller.content.get({ slug: req.query.slug });
     return res.status(200).json(result);
-  } catch (error: any) {
-    if (isClientAbortError(error)) {
-      if (!res.headersSent) res.status(499).end();
-      return;
-    }
-    if (error instanceof TRPCError) return res.status(500).json({ error: error.cause });
-    else return res.status(500).json({ error: 'Internal server error' });
+  } catch (error) {
+    // civitai#3845 (population B): `{ error: error.cause }` served the WRAPPED
+    // error, which for a `throwDbError`-produced TRPCError is the driver error
+    // itself — the most direct leak of the whole set. It also answered a hard 500
+    // for every TRPCError, so a NOT_FOUND slug was reported as a server fault;
+    // delegating gives it its real status.
+    return handleEndpointError(res, error);
   }
 });

--- a/src/pages/api/v1/creators.ts
+++ b/src/pages/api/v1/creators.ts
@@ -1,10 +1,7 @@
-import { TRPCError } from '@trpc/server';
-import { getHTTPStatusCodeFromError } from '@trpc/server/http';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getEdgeUrl } from '~/client-utils/cf-images-utils';
 import { publicApiContext2 } from '~/server/createContext';
-import { PublicEndpoint } from '~/server/utils/endpoint-helpers';
-import { isClientAbortError } from '~/server/utils/errorHandling';
+import { handleEndpointError, PublicEndpoint } from '~/server/utils/endpoint-helpers';
 import { getPaginationLinks } from '~/server/utils/pagination-helpers';
 
 type CreatorItem = {
@@ -45,28 +42,14 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
       },
     });
   } catch (error) {
-    if (isClientAbortError(error)) {
-      // Client disconnected mid-request — not a server fault. 499, not 500.
-      if (!res.headersSent) res.status(499).end();
-      return;
-    }
-    if (error instanceof TRPCError) {
-      const status = getHTTPStatusCodeFromError(error);
-      // Some TRPCErrors carry a JSON-stringified body (zod/validation); others
-      // (throwDbError-wrapped INTERNAL_SERVER_ERRORs) carry a plain string. A
-      // blind JSON.parse on the plain-string case throws, escapes this catch,
-      // and surfaces a raw unhandled 500 — so guard it with a fallback.
-      const parsedError = (() => {
-        try {
-          return JSON.parse(error.message);
-        } catch {
-          return { message: error.message };
-        }
-      })();
-
-      res.status(status).json(parsedError);
-    } else {
-      res.status(500).json({ message: 'An unexpected error occurred', error });
-    }
+    // civitai#3845 (population B): this catch used to be a hand-rolled copy of
+    // `handleEndpointError` that had drifted — it kept the abort/TRPCError/parse
+    // logic but NOT the genericization, so a `throwDbError`-wrapped driver error
+    // still put raw invocation text on the wire at a 500, and the else-branch
+    // serialized the whole error OBJECT (a Prisma error's enumerable own props
+    // carry the table + column). Delegating removes the copy rather than patching
+    // it; see `endpoint-helpers.ts` and `rest-envelope-ledger.test.ts`.
+    handleEndpointError(res, error);
+    return;
   }
 });

--- a/src/pages/api/v1/permissions/check.ts
+++ b/src/pages/api/v1/permissions/check.ts
@@ -3,8 +3,7 @@ import * as z from 'zod';
 import { EntityAccessPermission } from '~/server/common/enums';
 import { hasEntityAccess } from '~/server/services/common.service';
 import { sessionClient } from '~/server/auth/session-client';
-import { PublicEndpoint } from '~/server/utils/endpoint-helpers';
-import { isClientAbortError } from '~/server/utils/errorHandling';
+import { handleEndpointError, PublicEndpoint } from '~/server/utils/endpoint-helpers';
 import { commaDelimitedNumberArray, numericString } from '~/utils/zod-helpers';
 
 const schema = z.object({
@@ -52,11 +51,10 @@ export default PublicEndpoint(
 
       return res.json(data);
     } catch (error) {
-      if (isClientAbortError(error)) {
-        if (!res.headersSent) res.status(499).end();
-        return;
-      }
-      return res.status(500).json({ message: 'An unexpected error occurred', error });
+      // civitai#3845 (population B): this used to serialize the whole error
+      // OBJECT. `hasEntityAccess` runs `$queryRaw`, so a failure arrives as a
+      // Prisma P2010 whose enumerable own props carry the raw database message.
+      return handleEndpointError(res, error);
     }
   },
   ['GET']

--- a/src/pages/api/v1/tags.ts
+++ b/src/pages/api/v1/tags.ts
@@ -1,12 +1,8 @@
 import { TagTarget } from '~/shared/utils/prisma/enums';
-import { TRPCError } from '@trpc/server';
-import { getHTTPStatusCodeFromError } from '@trpc/server/http';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { publicApiContext2 } from '~/server/createContext';
 
-import { appRouter } from '~/server/routers';
-import { PublicEndpoint } from '~/server/utils/endpoint-helpers';
-import { isClientAbortError } from '~/server/utils/errorHandling';
+import { handleEndpointError, PublicEndpoint } from '~/server/utils/endpoint-helpers';
 import { getPaginationLinks } from '~/server/utils/pagination-helpers';
 
 export default PublicEndpoint(async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -35,28 +31,9 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
       },
     });
   } catch (error) {
-    if (isClientAbortError(error)) {
-      // Client disconnected mid-request — not a server fault. 499, not 500.
-      if (!res.headersSent) res.status(499).end();
-      return;
-    }
-    if (error instanceof TRPCError) {
-      const status = getHTTPStatusCodeFromError(error);
-      // Some TRPCErrors carry a JSON-stringified body (zod/validation); others
-      // (throwDbError-wrapped INTERNAL_SERVER_ERRORs) carry a plain string. A
-      // blind JSON.parse on the plain-string case throws, escapes this catch,
-      // and surfaces a raw unhandled 500 — so guard it with a fallback.
-      const parsedError = (() => {
-        try {
-          return JSON.parse(error.message);
-        } catch {
-          return { message: error.message };
-        }
-      })();
-
-      res.status(status).json(parsedError);
-    } else {
-      res.status(500).json({ message: 'An unexpected error occurred', error });
-    }
+    // civitai#3845 (population B) — see the note on `v1/creators.ts`. Same
+    // hand-rolled copy, same drift, same delegation.
+    handleEndpointError(res, error);
+    return;
   }
 });

--- a/src/pages/api/v1/users/index.ts
+++ b/src/pages/api/v1/users/index.ts
@@ -5,7 +5,7 @@ import * as z from 'zod';
 import { env } from '~/env/server';
 import { publicApiContext2 } from '~/server/createContext';
 import { getAllUsersInput } from '~/server/schema/user.schema';
-import { PublicEndpoint } from '~/server/utils/endpoint-helpers';
+import { handleEndpointError, PublicEndpoint } from '~/server/utils/endpoint-helpers';
 import { isClientAbortError } from '~/server/utils/errorHandling';
 import { isTransientMeiliError } from '~/server/meilisearch/client';
 
@@ -29,56 +29,39 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
       items: users ?? [],
     });
   } catch (error) {
-    if (isClientAbortError(error)) {
-      // Client disconnected mid-request — not a server fault. 499, not 500.
-      if (!res.headersSent) res.status(499).end();
-      return;
-    }
-    // Transient user-search backend failure → retryable 503 (mirrors
-    // /api/v1/images + #2759/#2765). The ?query= path runs getUsersWithSearch
-    // (Meilisearch), which now wraps a transient upstream error as TRPCError
-    // SERVICE_UNAVAILABLE (status 503). We match BOTH that wrapped 503 AND a raw
-    // SDK Meili error that escaped the service wrap (isTransientMeiliError) as
-    // defense-in-depth. no-store so an edge layer can't cache the error; a
-    // Retry-After so clients/CF retry the (typically seconds-long) flap. This
-    // MUST run before the generic TRPCError branch below, whose
-    // JSON.parse(error.message) would otherwise throw on the plain-text
-    // SERVICE_UNAVAILABLE message and bubble a raw 500 — the exact leak this
-    // fixes (transient search error was surfacing as an unhandled 500). A
-    // non-transient error (real app bug / auth / NOT_FOUND) is NOT matched and
-    // still surfaces as its real status.
-    const trpcStatus = error instanceof TRPCError ? getHTTPStatusCodeFromError(error) : undefined;
-    if (isTransientMeiliError(error) || trpcStatus === 503) {
-      if (!res.headersSent) {
-        res.setHeader('Cache-Control', 'no-store');
-        res.setHeader('Retry-After', '2');
-        res
-          .status(503)
-          .json({ error: 'User search is temporarily overloaded — please retry.' });
+    // ORDER MATTERS, and both arms end in `handleEndpointError` — there is no
+    // hand-rolled envelope left in this file (civitai#3845 population B).
+    //  1. A client abort is decided FIRST: an aborted Meili call can otherwise
+    //     look transient and be answered 503 instead of 499. `isClientAbortError`
+    //     is the same predicate the helper uses, so this only fixes the ORDER —
+    //     the helper still writes the 499.
+    //  2. The transient-search 503 is decided BEFORE delegating, because the
+    //     helper cannot know this route wants a Retry-After + no-store.
+    // Everything else delegates, which is what genericizes a 5xx body: the old
+    // `else` branch here put `err.message` on the wire verbatim, and the
+    // TRPCError branch put the raw driver text in `{ error, code }`.
+    if (!isClientAbortError(error)) {
+      // Transient user-search backend failure → retryable 503 (mirrors
+      // /api/v1/images + #2759/#2765). The ?query= path runs getUsersWithSearch
+      // (Meilisearch), which now wraps a transient upstream error as TRPCError
+      // SERVICE_UNAVAILABLE (status 503). We match BOTH that wrapped 503 AND a raw
+      // SDK Meili error that escaped the service wrap (isTransientMeiliError) as
+      // defense-in-depth. no-store so an edge layer can't cache the error; a
+      // Retry-After so clients/CF retry the (typically seconds-long) flap. A
+      // non-transient error (real app bug / auth / NOT_FOUND) is NOT matched and
+      // still surfaces as its real status.
+      const trpcStatus =
+        error instanceof TRPCError ? getHTTPStatusCodeFromError(error) : undefined;
+      if (isTransientMeiliError(error) || trpcStatus === 503) {
+        if (!res.headersSent) {
+          res.setHeader('Cache-Control', 'no-store');
+          res.setHeader('Retry-After', '2');
+          res.status(503).json({ error: 'User search is temporarily overloaded — please retry.' });
+        }
+        return;
       }
-      return;
     }
-    if (error instanceof TRPCError) {
-      const status = getHTTPStatusCodeFromError(error);
-      // Some tRPC errors carry a JSON-stringified message (e.g. zod/validation
-      // issues serialized as a JSON array) — preserve that shape. But a
-      // throwDbError-wrapped INTERNAL_SERVER_ERROR carries a PLAIN-STRING message
-      // (`message: e.message` — Prisma errors / generic app bugs), so a blind
-      // JSON.parse would THROW and escape this catch → a raw unhandled 500 (the
-      // exact failure mode this PR fixes, previously still live for the
-      // non-transient subset). Fall back to the /api/v1/images error shape
-      // ({ error, code }) on a non-JSON message so NO input path can produce a
-      // raw unhandled 500.
-      let body: unknown;
-      try {
-        body = JSON.parse(error.message);
-      } catch {
-        body = { error: error.message, code: error.code };
-      }
-      res.status(status).json(body);
-    } else {
-      const err = error as Error;
-      res.status(500).json({ message: 'An unexpected error occurred', error: err.message });
-    }
+    handleEndpointError(res, error);
+    return;
   }
 });

--- a/src/pages/api/v1/vault/all.tsx
+++ b/src/pages/api/v1/vault/all.tsx
@@ -2,7 +2,7 @@ import { TRPCError } from '@trpc/server';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import type { SessionUser } from '~/types/session';
 import { getPaginatedVaultItems } from '~/server/services/vault.service';
-import { AuthedEndpoint } from '~/server/utils/endpoint-helpers';
+import { AuthedEndpoint, handleEndpointError } from '~/server/utils/endpoint-helpers';
 import { getPaginatedVaultItemsSchema } from '~/server/schema/vault.schema';
 
 export default AuthedEndpoint(
@@ -23,7 +23,11 @@ export default AuthedEndpoint(
         }
       }
 
-      res.status(500).json({ message: 'An unexpected error occurred', error });
+      // civitai#3845 (population B): the whole error OBJECT used to be
+      // serialized here. The MEMBERSHIP_REQUIRED arm above is route-specific (it
+      // answers 200), so it stays; everything else delegates.
+      handleEndpointError(res, error);
+      return;
     }
   },
   ['GET']

--- a/src/pages/api/v1/vault/check-vault.tsx
+++ b/src/pages/api/v1/vault/check-vault.tsx
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import type { SessionUser } from '~/types/session';
 import * as z from 'zod';
 import { dbRead } from '~/server/db/client';
-import { AuthedEndpoint } from '~/server/utils/endpoint-helpers';
+import { AuthedEndpoint, handleEndpointError } from '~/server/utils/endpoint-helpers';
 import { commaDelimitedNumberArray } from '~/utils/zod-helpers';
 
 const schema = z.object({
@@ -37,7 +37,10 @@ export default AuthedEndpoint(
         }))
       );
     } catch (error) {
-      return res.status(500).json({ message: 'An unexpected error occurred', error });
+      // civitai#3845 (population B): a Prisma error's enumerable own props
+      // (`code`, `meta.{table,column}`, `clientVersion`) used to be serialized
+      // straight into `error`.
+      return handleEndpointError(res, error);
     }
   },
   ['GET']

--- a/src/pages/api/v1/vault/get.tsx
+++ b/src/pages/api/v1/vault/get.tsx
@@ -2,7 +2,7 @@ import { TRPCError } from '@trpc/server';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import type { SessionUser } from '~/types/session';
 import { getOrCreateVault } from '~/server/services/vault.service';
-import { AuthedEndpoint } from '~/server/utils/endpoint-helpers';
+import { AuthedEndpoint, handleEndpointError } from '~/server/utils/endpoint-helpers';
 
 export default AuthedEndpoint(
   async function handler(req: NextApiRequest, res: NextApiResponse, user: SessionUser) {
@@ -21,7 +21,10 @@ export default AuthedEndpoint(
         }
       }
 
-      res.status(500).json({ message: 'An unexpected error occurred', error });
+      // civitai#3845 (population B) — see `v1/vault/all.tsx`. Same shape, same
+      // MEMBERSHIP_REQUIRED arm kept, same delegation.
+      handleEndpointError(res, error);
+      return;
     }
   },
   ['GET']

--- a/src/pages/api/v1/vault/toggle-version.tsx
+++ b/src/pages/api/v1/vault/toggle-version.tsx
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import type { SessionUser } from '~/types/session';
 import * as z from 'zod';
 import { toggleModelVersionOnVault } from '~/server/services/vault.service';
-import { AuthedEndpoint } from '~/server/utils/endpoint-helpers';
+import { AuthedEndpoint, handleEndpointError } from '~/server/utils/endpoint-helpers';
 import { removeEmpty } from '~/utils/object-helpers';
 
 const schema = z.object({
@@ -27,7 +27,10 @@ export default AuthedEndpoint(
         })
       );
     } catch (error) {
-      return res.status(500).json({ message: 'An unexpected error occurred', error });
+      // civitai#3845 (population B). This is the one WRITE among the vault
+      // routes, so it is also the one that can raise a real unique-constraint
+      // violation — the class whose driver payload carries actual row data.
+      return handleEndpointError(res, error);
     }
   },
   ['POST']

--- a/src/server/utils/__tests__/endpoint-helpers-driver-4xx.test.ts
+++ b/src/server/utils/__tests__/endpoint-helpers-driver-4xx.test.ts
@@ -393,14 +393,26 @@ describe('handleEndpointError — driver-authored text at a 4xx (civitai#3845 in
     expect(res._header('Cache-Control')).toBe('no-store, max-age=0');
   });
 
-  it('does NOT touch headers once they are already SENT', () => {
-    // `noStore`'s internal `!res.headersSent` guard. Writing a header after the
-    // response has gone out throws in Node; the helper must be a no-op instead.
+  it('does NOT rewrite the cache header once headers are already SENT', () => {
+    // `noStore`'s internal `!res.headersSent` guard.
+    //
+    // 🔴 This deliberately asserts ONLY the header. An earlier version also
+    // asserted `.not.toThrow()` with a comment claiming "the helper must be a
+    // no-op" on an already-sent response. That was false in two ways: the
+    // assertion could not fail (this fixture's `json()` does not throw the way a
+    // real `ServerResponse` does), and the helper does NOT no-op — only the 499
+    // arm and `noStore` itself are `headersSent`-guarded, while every 4xx/5xx arm
+    // ends in `noStore(res).status(...).json(...)` unguarded and would throw
+    // ERR_HTTP_HEADERS_SENT for real. Callers guard themselves instead — e.g.
+    // `download/models/[modelVersionId].ts` has its own `if (res.headersSent)
+    // return;`. Asserting a property the code lacks would have told a maintainer
+    // that guard was redundant.
     const res = createRes();
     res.json({ already: 'sent' });
     const before = res._header('Cache-Control');
 
-    expect(() => handleEndpointError(res as never, new Error('late boom'))).not.toThrow();
+    handleEndpointError(res as never, new Error('late boom'));
+
     expect(res._header('Cache-Control'), 'must not rewrite a sent response').toBe(before);
   });
 

--- a/src/server/utils/__tests__/endpoint-helpers-driver-4xx.test.ts
+++ b/src/server/utils/__tests__/endpoint-helpers-driver-4xx.test.ts
@@ -310,7 +310,39 @@ describe('handleEndpointError — driver-authored text at a 4xx (civitai#3845 in
     ).not.toHaveBeenCalled();
   });
 
-  // ── The genericized response must not be edge-cached ───────────────────────
+  // ── NO error response may be edge-cached, on ANY arm ───────────────────────
+  it('a PASS-THROUGH 404 is marked no-store — the case the first fix missed', () => {
+    // 🔴 This is the shape that actually motivated the header work and was NOT
+    // covered by scoping it to the genericized arms. `v1/content` now answers a
+    // real 404 where it used to answer 500, and it does so via
+    // `throwNotFoundError` — whose message is OURS, so it takes the PASS-THROUGH
+    // arm and never reaches the genericized one. Measured before the fix:
+    // `public, s-maxage=300, stale-while-revalidate=150` on a 404.
+    const res = createRes();
+    handleEndpointError(
+      res as never,
+      new TRPCError({ code: 'NOT_FOUND', message: 'Could not find entity' })
+    );
+
+    expect(res._status()).toBe(404);
+    expect(res._json(), 'the body must still pass through byte-identically').toEqual({
+      message: 'Could not find entity',
+    });
+    expect(
+      res._header('Cache-Control'),
+      'a transient 404 pinned at the edge for 300s + 150s SWR serves "no such thing" ' +
+        'for five minutes after the thing exists'
+    ).toBe('no-store, max-age=0');
+  });
+
+  it('a NON-TRPCError 500 (the else-branch) is marked no-store', () => {
+    const res = createRes();
+    handleEndpointError(res as never, new Error('plain boom'));
+
+    expect(res._status()).toBe(500);
+    expect(res._header('Cache-Control')).toBe('no-store, max-age=0');
+  });
+
   it.each([
     { label: 'a genericized 4xx', code: 'P2025', status: 404 },
     { label: 'a genericized 5xx', code: 'P2022', status: 500 },

--- a/src/server/utils/__tests__/endpoint-helpers-driver-4xx.test.ts
+++ b/src/server/utils/__tests__/endpoint-helpers-driver-4xx.test.ts
@@ -26,9 +26,18 @@ const { mockLogToAxiom, mockBuildCentralErrorLog, mockWasServerFaultLogged } = v
   mockLogToAxiom: vi.fn().mockResolvedValue(undefined),
   // Message-FAITHFUL on purpose: it is what lets the observability guard detect a
   // future "fix" that stops a leak by redacting the LOG instead of the RESPONSE.
+  //
+  // `type` is stubbed to the SERVER-fault value ('error') deliberately, which is
+  // what the real builder returns for the case that matters — a TIMEOUT/408, the
+  // one status `classifyErrorFault` does NOT treat as a client fault. Returning a
+  // default of 'info' instead would make the severity assertions below pass
+  // whether or not the override exists: the mutant and the fix would be
+  // indistinguishable.
   mockBuildCentralErrorLog: vi.fn((e: unknown) => ({
     name: (e as Error)?.name,
     message: (e as Error)?.message,
+    type: 'error',
+    level: 'error',
   })),
   mockWasServerFaultLogged: vi.fn(() => false),
 }));
@@ -53,6 +62,7 @@ function createRes() {
   let statusCode = 200;
   let payload: unknown;
   let headersSent = false;
+  const headers: Record<string, unknown> = {};
   const res = {
     status(c: number) {
       statusCode = c;
@@ -63,8 +73,11 @@ function createRes() {
       headersSent = true;
       return res;
     },
-    setHeader() {
-      /* noop */
+    // Records rather than no-ops: the genericized arms must mark the response
+    // uncacheable, and a no-op setHeader cannot tell a set header from an unset one.
+    setHeader(k: string, v: unknown) {
+      headers[k] = v;
+      return res;
     },
     end() {
       headersSent = true;
@@ -75,6 +88,7 @@ function createRes() {
     },
     _status: () => statusCode,
     _json: () => payload,
+    _header: (k: string) => headers[k],
   };
   return res;
 }
@@ -150,6 +164,7 @@ describe('handleEndpointError — driver-authored text at a 4xx (civitai#3845 in
       code: 'P2000',
       status: 400,
       restCode: 'BAD_REQUEST',
+      expected: 'The request could not be processed',
       message:
         "\nInvalid `prisma.appListing.create()` invocation:\n\nThe provided value for the column is too long for the column's type. Column: app_listings.slug",
       secrets: ['app_listings', 'slug', 'appListing', 'prisma.', 'invocation'],
@@ -159,6 +174,7 @@ describe('handleEndpointError — driver-authored text at a 4xx (civitai#3845 in
       code: 'P2003',
       status: 409,
       restCode: 'CONFLICT',
+      expected: 'The request conflicts with the current state',
       message:
         '\nInvalid `prisma.appCollaborator.create()` invocation:\n\nForeign key constraint failed on the field: `app_collaborators_app_listing_id_fkey`',
       secrets: ['app_collaborators_app_listing_id_fkey', 'appCollaborator', 'prisma.'],
@@ -168,6 +184,7 @@ describe('handleEndpointError — driver-authored text at a 4xx (civitai#3845 in
       code: 'P2025',
       status: 404,
       restCode: 'NOT_FOUND',
+      expected: 'Not found',
       message:
         '\nInvalid `prisma.appListing.delete()` invocation:\n\nAn operation failed because it depends on one or more records that were required but not found.',
       secrets: ['appListing', 'delete()', 'prisma.', 'invocation'],
@@ -177,26 +194,38 @@ describe('handleEndpointError — driver-authored text at a 4xx (civitai#3845 in
       code: 'P2024',
       status: 408,
       restCode: 'TIMEOUT',
+      expected: 'The request timed out',
       message:
         'Timed out fetching a new connection from the connection pool. (More info: http://pris.ly/d/connection-pool) (Current connection pool timeout: 10, connection limit: 21)',
       secrets: ['connection limit', 'pris.ly', 'connection pool timeout'],
     },
-  ])('$label — status kept, message genericized', ({ code, status, restCode, message, secrets }) => {
-    const res = throughTheSeam(prismaError(code, message));
+  ])(
+    '$label — status kept, message genericized',
+    ({ code, status, restCode, message, secrets, expected }) => {
+      const res = throughTheSeam(prismaError(code, message));
 
-    expect(res._status(), 'the STATUS must be preserved — this really is a 4xx').toBe(status);
-    expectNoneDisclosed(res, secrets);
+      expect(res._status(), 'the STATUS must be preserved — this really is a 4xx').toBe(status);
+      expectNoneDisclosed(res, secrets);
 
-    const body = res._json() as Record<string, unknown>;
-    expect(body.code, 'the envelope discriminator must match the status').toBe(restCode);
-    expect(body.message).toBe(GENERIC_CLIENT_ERROR_BY_STATUS[status].message);
-    // `message` MUST stay a string — the Go CLI decodes it into `Message string`
-    // and a non-string fails the whole envelope unmarshal.
-    expect(typeof body.message).toBe('string');
-    // The CLI renders `error` in preference to `message`, so it must be non-empty
-    // AND must not be the place the leak relocates to.
-    expect(body.error).toBe(GENERIC_CLIENT_ERROR_BY_STATUS[status].message);
-  });
+      const body = res._json() as Record<string, unknown>;
+      expect(body.code, 'the envelope discriminator must match the status').toBe(restCode);
+      // 🔴 Pinned as a LITERAL, not read back out of
+      // `GENERIC_CLIENT_ERROR_BY_STATUS`. Deriving the expectation from the
+      // implementation makes the assertion vacuous: an audit mutated 400's message
+      // to `''` and this suite stayed green, because both sides moved together.
+      // The wire contract is the literal text, so the literal is what a test owes.
+      expect(body.message).toBe(expected);
+      // `message` MUST stay a string — the Go CLI decodes it into `Message string`
+      // and a non-string fails the whole envelope unmarshal.
+      expect(typeof body.message).toBe('string');
+      // The CLI renders `error` in preference to `message`, so it must be non-empty
+      // AND must not be the place the leak relocates to.
+      expect(body.error).toBe(expected);
+      // Cross-check the table this arm reads from, so a change to it that does NOT
+      // reach the wire (a stale/unused entry) is also visible.
+      expect(GENERIC_CLIENT_ERROR_BY_STATUS[status]).toEqual({ code: restCode, message: expected });
+    }
+  );
 
   // ── The headline severity case: actual ROW DATA, from `pg`, not Prisma ──────
   it('INVARIANT: a real pg 23505 does NOT put the offending row value (an email) on the wire', () => {
@@ -279,6 +308,55 @@ describe('handleEndpointError — driver-authored text at a 4xx (civitai#3845 in
       mockLogToAxiom,
       'a hand-authored 4xx is client feedback, not a fault — logging it would flood the error stream'
     ).not.toHaveBeenCalled();
+  });
+
+  // ── The genericized response must not be edge-cached ───────────────────────
+  it.each([
+    { label: 'a genericized 4xx', code: 'P2025', status: 404 },
+    { label: 'a genericized 5xx', code: 'P2022', status: 500 },
+  ])('$label is marked no-store', ({ code, status }) => {
+    // 🔴 `PublicEndpoint` sets `Cache-Control: public, s-maxage=300,
+    // stale-while-revalidate=150` on EVERY response before the handler runs.
+    // That was survivable while every failure was a 5xx (shared caches do not
+    // cache 5xx by default); it stops being survivable once an error answers
+    // 404, which IS in the default cacheable set. A transient NOT_FOUND would
+    // otherwise be pinned at the edge for 300s + 150s SWR — serving "no such
+    // thing" for five minutes after the thing exists.
+    const res = throughTheSeam(prismaError(code, 'raw driver text'));
+
+    expect(res._status()).toBe(status);
+    expect(
+      res._header('Cache-Control'),
+      'a genericized error response must never be edge-cacheable'
+    ).toBe('no-store, max-age=0');
+  });
+
+  // ── Log severity: forensics, not an incident ───────────────────────────────
+  it('logs a genericized 408 at INFO, not ERROR — pool exhaustion is wave-shaped', () => {
+    // 🔴 The only Prisma codes reaching 408 are P1008/P2024 — connection-pool
+    // exhaustion. Logging those at error severity would add one error-board line
+    // per affected public request during exactly the incident you need signal in.
+    // That is the same "fires in high-volume waves" property for which
+    // `isRestServerFault` excludes 503 from the error stream.
+    // `classifyErrorFault` treats TIMEOUT as a SERVER fault repo-wide (correct in
+    // general), so this arm overrides `type`/`level` locally instead.
+    throughTheSeam(prismaError('P2024', 'Timed out fetching a new connection'));
+
+    expect(mockLogToAxiom).toHaveBeenCalledTimes(1);
+    const logged = mockLogToAxiom.mock.calls[0][0] as { type?: string; level?: string };
+    // `type` is the load-bearing one: Alloy extracts it into Loki detected_level.
+    expect(logged.type, 'a genericized 4xx must not land on the error board').toBe('info');
+    expect(logged.level).toBe('info');
+  });
+
+  it('still logs a genuine 5xx at ERROR severity (the info override is scoped)', () => {
+    // Negative control for the override: if it leaked into the 5xx arm it would
+    // silently empty the error board of real faults.
+    throughTheSeam(prismaError('P2022', 'raw driver text'));
+
+    expect(mockLogToAxiom).toHaveBeenCalledTimes(1);
+    const logged = mockLogToAxiom.mock.calls[0][0] as { type?: string };
+    expect(logged.type, 'a real server fault must still be error-severity').not.toBe('info');
   });
 
   // ── INVARIANT GUARDS: green on both sides, pinning what must NOT change ─────

--- a/src/server/utils/__tests__/endpoint-helpers-driver-4xx.test.ts
+++ b/src/server/utils/__tests__/endpoint-helpers-driver-4xx.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * civitai#3845 **investigation 3** — driver-authored text reaching the wire at a
+ * **4xx**, which the original fix deliberately left alone.
+ *
+ * `handleEndpointError` genericizes 5xx and passes 4xx through byte-identically,
+ * justified in `isRestServerFault` by "4xx is client feedback the caller is meant
+ * to read". That holds for a zod issue list or a hand-written "not found". It does
+ * NOT hold on the `throwDbError` path: that helper copies the driver's own
+ * `message` verbatim, and `prismaErrorToTrpcCode` sends a large slice of Prisma
+ * codes to 4xx — so the raw invocation text arrived at 400/404/408/409.
+ *
+ * The fix keeps the STATUS (a driver error mapped to 404 really is a 404) and
+ * replaces only the MESSAGE, logging the un-redacted text on the way out so the
+ * suite-wide invariant still holds: text leaves the wire exactly when it enters
+ * the log.
+ *
+ * Mocks ONLY the logging client (spreading the original), because one of the
+ * guards below is about what that client receives. `throwDbError`,
+ * `handleEndpointError`, `isDriverAuthoredMessage` and the Prisma/pg error classes
+ * are all REAL — the defect lives in the seam between them.
+ */
+
+const { mockLogToAxiom, mockBuildCentralErrorLog, mockWasServerFaultLogged } = vi.hoisted(() => ({
+  mockLogToAxiom: vi.fn().mockResolvedValue(undefined),
+  // Message-FAITHFUL on purpose: it is what lets the observability guard detect a
+  // future "fix" that stops a leak by redacting the LOG instead of the RESPONSE.
+  mockBuildCentralErrorLog: vi.fn((e: unknown) => ({
+    name: (e as Error)?.name,
+    message: (e as Error)?.message,
+  })),
+  mockWasServerFaultLogged: vi.fn(() => false),
+}));
+
+vi.mock('~/server/logging/client', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  logToAxiom: mockLogToAxiom,
+  buildCentralErrorLog: mockBuildCentralErrorLog,
+  wasServerFaultLogged: mockWasServerFaultLogged,
+}));
+
+import { Prisma } from '@prisma/client';
+import { DatabaseError } from 'pg';
+import { TRPCError } from '@trpc/server';
+import { handleEndpointError } from '~/server/utils/endpoint-helpers';
+import { throwBadRequestError, throwDbError } from '~/server/utils/errorHandling';
+import { GENERIC_CLIENT_ERROR_BY_STATUS } from '~/server/utils/rest-error-envelope';
+
+const CLIENT_VERSION = '6.13.0';
+
+function createRes() {
+  let statusCode = 200;
+  let payload: unknown;
+  let headersSent = false;
+  const res = {
+    status(c: number) {
+      statusCode = c;
+      return res;
+    },
+    json(b: unknown) {
+      payload = b;
+      headersSent = true;
+      return res;
+    },
+    setHeader() {
+      /* noop */
+    },
+    end() {
+      headersSent = true;
+      return res;
+    },
+    get headersSent() {
+      return headersSent;
+    },
+    _status: () => statusCode,
+    _json: () => payload,
+  };
+  return res;
+}
+
+/** A real `PrismaClientKnownRequestError`, message shaped like the driver's own. */
+function prismaError(code: string, message: string, meta?: Record<string, unknown>) {
+  return new Prisma.PrismaClientKnownRequestError(message, {
+    code,
+    clientVersion: CLIENT_VERSION,
+    meta,
+  });
+}
+
+/**
+ * A real `pg` unique-constraint violation. This is the WORST case in the whole
+ * disclosure class and it is not hypothetical: `DatabaseError` carries its fields
+ * as ENUMERABLE own properties, and `detail` on a 23505 quotes the offending row
+ * VALUE — here a user's email address. Kysely (`~/server/db/kyselyDb`) runs on the
+ * `pg` pool, so this class is reachable without Prisma.
+ */
+const VICTIM_EMAIL = 'victim@example.com';
+function pgUniqueViolation() {
+  const e = new DatabaseError(
+    'duplicate key value violates unique constraint "User_email_key"',
+    100,
+    'error'
+  );
+  Object.assign(e, {
+    severity: 'ERROR',
+    code: '23505',
+    detail: `Key (email)=(${VICTIM_EMAIL}) already exists.`,
+    schema: 'public',
+    table: 'User',
+    constraint: 'User_email_key',
+  });
+  return e;
+}
+
+/** Drive the REAL `throwDbError` → REAL `handleEndpointError` seam. */
+function throughTheSeam(driver: unknown) {
+  const res = createRes();
+  try {
+    throwDbError(driver);
+  } catch (e) {
+    handleEndpointError(res as never, e);
+  }
+  return res;
+}
+
+function expectNoneDisclosed(res: ReturnType<typeof createRes>, secrets: string[]) {
+  const serialized = JSON.stringify(res._json());
+  for (const secret of secrets) {
+    expect(
+      serialized,
+      `#3845/3: a public 4xx body must not disclose ${JSON.stringify(
+        secret
+      )} — full body was ${serialized}`
+    ).not.toContain(secret);
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWasServerFaultLogged.mockReturnValue(false);
+});
+
+describe('handleEndpointError — driver-authored text at a 4xx (civitai#3845 investigation 3)', () => {
+  // ── The four statuses `prismaErrorToTrpcCode` can actually reach ────────────
+  // Each case names the real disclosure that shipped at that status.
+  it.each([
+    {
+      label: 'P2000 → 400 discloses the COLUMN',
+      code: 'P2000',
+      status: 400,
+      restCode: 'BAD_REQUEST',
+      message:
+        "\nInvalid `prisma.appListing.create()` invocation:\n\nThe provided value for the column is too long for the column's type. Column: app_listings.slug",
+      secrets: ['app_listings', 'slug', 'appListing', 'prisma.', 'invocation'],
+    },
+    {
+      label: 'P2003 → 409 discloses the FOREIGN KEY CONSTRAINT name',
+      code: 'P2003',
+      status: 409,
+      restCode: 'CONFLICT',
+      message:
+        '\nInvalid `prisma.appCollaborator.create()` invocation:\n\nForeign key constraint failed on the field: `app_collaborators_app_listing_id_fkey`',
+      secrets: ['app_collaborators_app_listing_id_fkey', 'appCollaborator', 'prisma.'],
+    },
+    {
+      label: 'P2025 → 404 discloses the MODEL and METHOD',
+      code: 'P2025',
+      status: 404,
+      restCode: 'NOT_FOUND',
+      message:
+        '\nInvalid `prisma.appListing.delete()` invocation:\n\nAn operation failed because it depends on one or more records that were required but not found.',
+      secrets: ['appListing', 'delete()', 'prisma.', 'invocation'],
+    },
+    {
+      label: 'P2024 → 408 discloses the CONNECTION POOL shape',
+      code: 'P2024',
+      status: 408,
+      restCode: 'TIMEOUT',
+      message:
+        'Timed out fetching a new connection from the connection pool. (More info: http://pris.ly/d/connection-pool) (Current connection pool timeout: 10, connection limit: 21)',
+      secrets: ['connection limit', 'pris.ly', 'connection pool timeout'],
+    },
+  ])('$label — status kept, message genericized', ({ code, status, restCode, message, secrets }) => {
+    const res = throughTheSeam(prismaError(code, message));
+
+    expect(res._status(), 'the STATUS must be preserved — this really is a 4xx').toBe(status);
+    expectNoneDisclosed(res, secrets);
+
+    const body = res._json() as Record<string, unknown>;
+    expect(body.code, 'the envelope discriminator must match the status').toBe(restCode);
+    expect(body.message).toBe(GENERIC_CLIENT_ERROR_BY_STATUS[status].message);
+    // `message` MUST stay a string — the Go CLI decodes it into `Message string`
+    // and a non-string fails the whole envelope unmarshal.
+    expect(typeof body.message).toBe('string');
+    // The CLI renders `error` in preference to `message`, so it must be non-empty
+    // AND must not be the place the leak relocates to.
+    expect(body.error).toBe(GENERIC_CLIENT_ERROR_BY_STATUS[status].message);
+  });
+
+  // ── The headline severity case: actual ROW DATA, from `pg`, not Prisma ──────
+  it('INVARIANT: a real pg 23505 does NOT put the offending row value (an email) on the wire', () => {
+    // 🔴 An INVARIANT GUARD, not regression coverage for THIS change: it is green
+    // on both sides. `throwDbError`'s generic tail maps a non-Prisma error to a
+    // 500, which #3850 already genericizes. It is asserted here anyway because it
+    // pins the worst payload in the class against a future 5xx regression, and
+    // because it is the exact payload the deleted hand-rolled envelopes would
+    // have serialized field-by-field. The pg case that this change actually
+    // FIXES is the 409 one below, which was red before it.
+    const res = throughTheSeam(pgUniqueViolation());
+
+    expectNoneDisclosed(res, [
+      VICTIM_EMAIL,
+      'Key (email)',
+      'User_email_key',
+      'duplicate key value',
+      '23505',
+      'nbtinsert',
+    ]);
+  });
+
+  it('a pg 23505 mapped to a 409 by a caller is genericized too — status kept, row value gone', () => {
+    // The identity predicate is driver-agnostic: it matches whenever the text on
+    // the wire IS the driver's text, whatever wrapped it and at whatever status.
+    const driver = pgUniqueViolation();
+    const res = createRes();
+    handleEndpointError(
+      res as never,
+      new TRPCError({ code: 'CONFLICT', message: driver.message, cause: driver })
+    );
+
+    expect(res._status()).toBe(409);
+    expectNoneDisclosed(res, [VICTIM_EMAIL, 'User_email_key', 'duplicate key value']);
+    expect((res._json() as Record<string, unknown>).code).toBe('CONFLICT');
+  });
+
+  // ── 🔴 The guard that makes IDENTITY-vs-CHAIN observable ────────────────────
+  it('does NOT genericize a HAND-AUTHORED 4xx that merely carries a driver `cause`', () => {
+    // `throwBadRequestError(msg, dbError)` attaches the driver as `cause` while
+    // writing a message FOR the caller. A predicate that asked "is a driver error
+    // in the cause chain" would destroy this message and tell the user nothing.
+    // The identity predicate keeps it, because the wire text is not the driver's.
+    const HUMAN = 'That slug is already taken — pick another';
+    const res = createRes();
+    try {
+      throwBadRequestError(HUMAN, prismaError('P2002', 'raw driver text nobody should read'));
+    } catch (e) {
+      handleEndpointError(res as never, e);
+    }
+
+    expect(res._status()).toBe(400);
+    expect(
+      res._json(),
+      'a message we wrote must survive verbatim — genericizing it redacts nothing and costs the caller real feedback'
+    ).toEqual({ message: HUMAN });
+  });
+
+  // ── Observability: genericizing must RELOCATE the text, never destroy it ────
+  it('logs the UN-REDACTED driver text for every 4xx it genericizes', () => {
+    const message =
+      "\nInvalid `prisma.appListing.create()` invocation:\n\nColumn: app_listings.slug";
+    throughTheSeam(prismaError('P2000', message));
+
+    expect(mockLogToAxiom, 'a genericized 4xx must be logged — else the only copy is destroyed')
+      .toHaveBeenCalledTimes(1);
+    const logged = mockLogToAxiom.mock.calls[0][0] as { message?: string };
+    expect(logged.message, 'the LOG keeps the driver text the RESPONSE dropped').toContain(
+      'app_listings.slug'
+    );
+  });
+
+  it('does NOT log a 4xx it passes through — only genericized ones become faults', () => {
+    const res = createRes();
+    handleEndpointError(res as never, new TRPCError({ code: 'NOT_FOUND', message: 'No such app' }));
+
+    expect(res._status()).toBe(404);
+    expect(res._json()).toEqual({ message: 'No such app' });
+    expect(
+      mockLogToAxiom,
+      'a hand-authored 4xx is client feedback, not a fault — logging it would flood the error stream'
+    ).not.toHaveBeenCalled();
+  });
+
+  // ── INVARIANT GUARDS: green on both sides, pinning what must NOT change ─────
+  it('INVARIANT: a zod-issue-ARRAY 400 still yields the identical parsed array', () => {
+    const issues = [{ code: 'too_small', path: ['limit'], message: 'Number must be >= 1' }];
+    const res = createRes();
+    handleEndpointError(
+      res as never,
+      new TRPCError({ code: 'BAD_REQUEST', message: JSON.stringify(issues) })
+    );
+
+    expect(res._status()).toBe(400);
+    expect(res._json()).toStrictEqual(issues);
+  });
+
+  it('INVARIANT: a 503 retry hint stays verbatim even when a driver sits in its cause', () => {
+    // 503 is excluded from the fault log, so the response is the ONLY copy of its
+    // message — genericizing it would destroy an actionable retry hint rather than
+    // relocate it. The `status !== 503` guard is what enforces that.
+    const HINT = 'Model search is temporarily overloaded — please retry.';
+    const res = createRes();
+    handleEndpointError(
+      res as never,
+      new TRPCError({
+        code: 'SERVICE_UNAVAILABLE',
+        message: HINT,
+        cause: prismaError('P2024', 'Timed out fetching a new connection'),
+      })
+    );
+
+    expect(res._status()).toBe(503);
+    expect(res._json()).toEqual({ message: HINT });
+    expect(mockLogToAxiom).not.toHaveBeenCalled();
+  });
+
+  it('INVARIANT: a client abort is still 499 with no body, ahead of every other arm', () => {
+    const res = createRes();
+    handleEndpointError(res as never, new Error('The operation was aborted'));
+
+    expect(res._status()).toBe(499);
+    expect(res._json()).toBeUndefined();
+  });
+});

--- a/src/server/utils/__tests__/endpoint-helpers-driver-4xx.test.ts
+++ b/src/server/utils/__tests__/endpoint-helpers-driver-4xx.test.ts
@@ -313,11 +313,13 @@ describe('handleEndpointError — driver-authored text at a 4xx (civitai#3845 in
   // ── Observability: genericizing must RELOCATE the text, never destroy it ────
   it('logs the UN-REDACTED driver text for every 4xx it genericizes', () => {
     const message =
-      "\nInvalid `prisma.appListing.create()` invocation:\n\nColumn: app_listings.slug";
+      '\nInvalid `prisma.appListing.create()` invocation:\n\nColumn: app_listings.slug';
     throughTheSeam(prismaError('P2000', message));
 
-    expect(mockLogToAxiom, 'a genericized 4xx must be logged — else the only copy is destroyed')
-      .toHaveBeenCalledTimes(1);
+    expect(
+      mockLogToAxiom,
+      'a genericized 4xx must be logged — else the only copy is destroyed'
+    ).toHaveBeenCalledTimes(1);
     const logged = mockLogToAxiom.mock.calls[0][0] as { message?: string };
     expect(logged.message, 'the LOG keeps the driver text the RESPONSE dropped').toContain(
       'app_listings.slug'

--- a/src/server/utils/__tests__/endpoint-helpers-driver-4xx.test.ts
+++ b/src/server/utils/__tests__/endpoint-helpers-driver-4xx.test.ts
@@ -58,11 +58,31 @@ import { GENERIC_CLIENT_ERROR_BY_STATUS } from '~/server/utils/rest-error-envelo
 
 const CLIENT_VERSION = '6.13.0';
 
+/**
+ * 🔴 Pre-stamped with the header `PublicEndpoint` actually sets.
+ *
+ * An earlier version started with an EMPTY header map, so every `no-store`
+ * assertion only proved "the header ends up no-store when nothing set it first" —
+ * which is never the case in production: `PublicEndpoint` calls
+ * `addPublicCacheHeaders` BEFORE `await handler(req, res)`, so `Cache-Control` is
+ * always already populated when the helper runs.
+ *
+ * An audit demonstrated the gap by mutating `noStore` into a plausible
+ * "don't clobber the route's own Cache-Control" refactor:
+ *
+ *   if (!res.headersSent && !res.getHeader('Cache-Control')) res.setHeader(...)
+ *
+ * That silently restores `public, s-maxage=300` on EVERY error the helper writes,
+ * on every public route — and the whole suite stayed green. The fixture is the
+ * fix: with the header pre-stamped, that mutant now dies.
+ */
+const PUBLIC_ENDPOINT_CACHE_HEADER = 'public, s-maxage=300, stale-while-revalidate=150';
+
 function createRes() {
   let statusCode = 200;
   let payload: unknown;
   let headersSent = false;
-  const headers: Record<string, unknown> = {};
+  const headers: Record<string, unknown> = { 'Cache-Control': PUBLIC_ENDPOINT_CACHE_HEADER };
   const res = {
     status(c: number) {
       statusCode = c;
@@ -78,6 +98,12 @@ function createRes() {
     setHeader(k: string, v: unknown) {
       headers[k] = v;
       return res;
+    },
+    // Present so a "don't clobber an existing Cache-Control" mutant is
+    // EXPRESSIBLE against this fixture. Without it such a mutant throws rather
+    // than surviving, which would look like a kill for the wrong reason.
+    getHeader(k: string) {
+      return headers[k];
     },
     end() {
       headersSent = true;
@@ -341,6 +367,41 @@ describe('handleEndpointError — driver-authored text at a 4xx (civitai#3845 in
 
     expect(res._status()).toBe(500);
     expect(res._header('Cache-Control')).toBe('no-store, max-age=0');
+  });
+
+  it('a 499 client-abort is marked no-store', () => {
+    // The one arm the first pass left unpinned. Low stakes — no shared cache
+    // stores a 499 — but "every arm" was the claim, so every arm gets a test.
+    const res = createRes();
+    handleEndpointError(res as never, new Error('The operation was aborted'));
+
+    expect(res._status()).toBe(499);
+    expect(res._header('Cache-Control')).toBe('no-store, max-age=0');
+  });
+
+  it('OVERWRITES an existing cache header — not merely sets one when absent', () => {
+    // 🔴 The assertion the empty-fixture version could not make. In production the
+    // header is ALWAYS already set when the helper runs, so "set it if absent" is
+    // indistinguishable from "do nothing".
+    const res = createRes();
+    expect(res._header('Cache-Control'), 'fixture must start pre-stamped').toBe(
+      PUBLIC_ENDPOINT_CACHE_HEADER
+    );
+
+    handleEndpointError(res as never, new TRPCError({ code: 'NOT_FOUND', message: 'nope' }));
+
+    expect(res._header('Cache-Control')).toBe('no-store, max-age=0');
+  });
+
+  it('does NOT touch headers once they are already SENT', () => {
+    // `noStore`'s internal `!res.headersSent` guard. Writing a header after the
+    // response has gone out throws in Node; the helper must be a no-op instead.
+    const res = createRes();
+    res.json({ already: 'sent' });
+    const before = res._header('Cache-Control');
+
+    expect(() => handleEndpointError(res as never, new Error('late boom'))).not.toThrow();
+    expect(res._header('Cache-Control'), 'must not rewrite a sent response').toBe(before);
   });
 
   it.each([

--- a/src/server/utils/__tests__/rest-error-envelope-ledger.test.ts
+++ b/src/server/utils/__tests__/rest-error-envelope-ledger.test.ts
@@ -73,9 +73,23 @@ function jsonBodies(source: string): string[] {
   for (let m = call.exec(source); m; m = call.exec(source)) {
     const start = source.indexOf('{', m.index);
     let depth = 0;
+    let quote: string | null = null;
     for (let i = start; i < source.length; i++) {
-      if (source[i] === '{') depth++;
-      else if (source[i] === '}') {
+      const ch = source[i];
+      // Skip string/template literals: a `}` inside `'oops }'` used to close the
+      // body early and silently TRUNCATE what got matched — a false negative in
+      // the mechanism itself.
+      if (quote) {
+        if (ch === '\\') i++;
+        else if (ch === quote) quote = null;
+        continue;
+      }
+      if (ch === "'" || ch === '"' || ch === '`') {
+        quote = ch;
+        continue;
+      }
+      if (ch === '{') depth++;
+      else if (ch === '}') {
         depth--;
         if (depth === 0) {
           out.push(source.slice(start, i + 1));
@@ -87,78 +101,179 @@ function jsonBodies(source: string): string[] {
   return out;
 }
 
-/** An identifier a `catch (…)` binding realistically uses. */
-const CAUGHT = String.raw`(?:e|err|error|ex)`;
+/**
+ * Strip NESTED object literals, leaving only the body's top-level keys.
+ *
+ * The shapes below anchor on `[{,]`, which without this matches a key at ANY
+ * depth: `res.status(200).json({ items, summary: { error, warnings } })` and
+ * `{ incident: { cause: 'flood' } }` were both flagged as leaks. A guard that
+ * matches everything is as useless as one that matches nothing — it just trains
+ * the next author to edit the baseline instead of the code.
+ *
+ * Nesting an error object one level down (`{ data: { detail: err.message } }`)
+ * is consequently NOT detected. That is a stated blind spot, not an oversight;
+ * see the JSDoc on the offender-set test.
+ */
+function topLevelKeys(body: string): string {
+  let out = '';
+  let depth = 0;
+  for (let i = 0; i < body.length; i++) {
+    const ch = body[i];
+    if (ch === '{') {
+      depth++;
+      if (depth === 1) out += ch;
+      continue;
+    }
+    if (ch === '}') {
+      depth--;
+      if (depth === 0) out += ch;
+      continue;
+    }
+    if (depth === 1) out += ch;
+  }
+  return out;
+}
+
+/**
+ * Any identifier, not a fixed spelling.
+ *
+ * 🔴 A delta audit defeated the previous version — `(?:e|err|error|ex)` — with a
+ * REAL, live, unauthenticated leak: `v1/images/index.ts` binds its caught error
+ * to `trpcError` and serves `{ error: trpcError.message, code: trpcError.code }`
+ * from a `PublicEndpoint`. Anchoring on the variable NAME was the same species of
+ * spelled guard as the literal-message regex it replaced, just a smaller hole.
+ *
+ * Widening to any identifier costs false positives on legitimate string-valued
+ * bodies (`{ error: message }`), so the value must additionally end in `.message`
+ * / be the bare binding / be `.cause` — and an allowlist below exempts the
+ * identifiers that are known NOT to be errors.
+ */
+const IDENT = String.raw`[A-Za-z_$][\w$]*`;
+
+/**
+ * Identifiers that name a STRING we wrote, not a caught error. Without these the
+ * widened pattern flags `{ error: message }` and `{ error: reason }`, which
+ * disclose nothing.
+ */
+const NOT_AN_ERROR = ['message', 'msg', 'reason', 'detail', 'text', 'status', 'code', 'label'];
 
 /**
  * The value shapes that put a whole error object — or its driver-authored text —
  * on the wire. A string-literal value (`{ error: 'Forbidden' }`) is deliberately
  * NOT matched: the hazard is serializing an Error, not using the key.
  */
-const LEAKING_BODY_SHAPES: { name: string; re: RegExp }[] = [
+const LEAKING_BODY_SHAPES: { name: string; test: (body: string) => boolean }[] = [
   {
     name: '`error` bound to a caught error object (its enumerable own props serialize)',
     // `{ error }` shorthand, `{ error: err }`, `{ error: e as Error }`.
-    re: new RegExp(
-      String.raw`(?:^|[{,])\s*error\s*(?:\}|,|:\s*\(?${CAUGHT}\)?(?:\s+as\s+\w+)?\s*[,}\)])`
-    ),
+    test: (b) =>
+      new RegExp(
+        String.raw`(?:^|[{,])\s*error\s*(?:\}|,|:\s*\(?(${IDENT})\)?(?:\s+as\s+\w+)?\s*[,}\)])`
+      ).test(b) &&
+      !NOT_AN_ERROR.includes(
+        new RegExp(String.raw`(?:^|[{,])\s*error\s*:\s*\(?(${IDENT})`).exec(b)?.[1] ?? ''
+      ),
   },
   {
     name: '`cause` in a response body (the wrapped driver error, under a second key)',
-    re: /(?:^|[{,])\s*cause\s*(?:\}|,|:)/,
+    test: (b) => /(?:^|[{,])\s*cause\s*(?:\}|,|:)/.test(b),
   },
   {
     name: '`error: <expr>.cause` (serves the error the TRPCError wrapped)',
-    re: new RegExp(String.raw`(?:^|[{,])\s*error\s*:\s*[A-Za-z_$][\w$]*\.cause\b`),
+    test: (b) => new RegExp(String.raw`(?:^|[{,])\s*error\s*:\s*${IDENT}\.cause\b`).test(b),
   },
   {
     name: "`error`/`message` set to a caught error's `.message` (verbatim driver text)",
-    re: new RegExp(
-      String.raw`(?:^|[{,])\s*(?:error|message)\s*:\s*\(?${CAUGHT}\)?(?:\s+as\s+\w+)?\)?\.message\b`
-    ),
+    // Any identifier, `?.` allowed, optional cast/parens. This is the shape the
+    // widened IDENT exists for — `{ error: trpcError.message }` on a public route.
+    // 🔴 The NOT_AN_ERROR allowlist deliberately does NOT apply here. It exists for
+    // the BARE-identifier shape (`{ error: message }` is a string we wrote), and
+    // applying it to `.message` ACCESS exempted `(reason as Error).message` —
+    // unmistakably an error, exempted only because `reason` was on a list of
+    // string-ish names. Reading `.message` off something is itself the signal.
+    test: (b) =>
+      new RegExp(
+        String.raw`(?:^|[{,])\s*(?:error|message)\s*:\s*\(?${IDENT}\)?(?:\s+as\s+[\w.<>\[\]]+)?\)?\??\.message\b`
+      ).test(b),
   },
 ];
+
+/** Does this response body serve an error object or its text? */
+function bodyLeaks(body: string): boolean {
+  const top = topLevelKeys(body);
+  return LEAKING_BODY_SHAPES.some((s) => s.test(top));
+}
 
 /**
  * 🔴 Sites of the SAME class this change does not fix — enumerated, not glossed.
  *
- * Making the guard structural surfaced this: the class was never confined to the
- * 11 routes civitai#3845 enumerated. Every entry is recorded rather than
- * exempted-by-glob, so the list fails if it GROWS (a new site) or SHRINKS (one
- * was fixed — delete its line). Ordered by exposure, which is the order to fix in:
+ * This list has now been re-derived TWICE, and grew each time the guard got less
+ * spelled: 3 regexes → 41 sites → **52**. That trajectory is the finding. Each
+ * widening was driven by an audit defeating the previous version with a real
+ * shape, most recently `v1/images/index.ts` — a `PublicEndpoint` serving
+ * `{ error: trpcError.message }`, invisible only because the variable was not
+ * named `e`/`err`/`error`/`ex`.
+ *
+ * 🔴 **KNOWN BLIND SPOTS — this list is a floor, not a ceiling.** The extractor
+ * cannot see: a body built in a variable and passed as `res.json(body)`; an error
+ * nested below the top level (`{ data: { detail: err.message } }`); `String(e)` /
+ * `e.toString()` / `{ ...error }`; `res.send({ error })`. Do not read a green run
+ * as "no leaks exist" — read it as "no leak of a shape this guard knows".
+ *
+ * Every entry is recorded rather than exempted-by-glob, so the list fails if it
+ * GROWS (a new site) or SHRINKS (one was fixed — delete its line). Ordered by
+ * exposure, which is the order to fix in:
  *
  * 🔴 TIER 1 — UNAUTHENTICATED. Same severity as the routes this change fixes.
+ *   v1/images/index.ts                    PublicEndpoint; `{ error: trpcError.message }`
  *   generation/{data,resources}.ts        PublicEndpoint; catch-all → 400 + e.message
  *   v1/model-files/[id]/tensor-metadata   MixedAuthEndpoint (public read) → 422 + err.message
  * NOT fixed here because the fix is not a delegation: each answers 4xx for EVERY
  * failure including zod-parse rejections, so routing them through the helper turns
  * a legitimate client 400 into a 500. That needs its own red/green and review.
+ * `v1/images/index.ts` is pre-existing and unrelated to this change's diff.
  *
  * 🟡 TIER 2 — session-authed: a logged-in user can trigger it, the public cannot.
+ * Includes `orchestrator/refreshBlobs.ts`: `OrchestratorEndpoint` is
+ * `AuthedEndpoint` + a per-user token (`endpoint-helpers.ts`), with NO moderator
+ * check — an earlier draft filed it under TIER 3, which would have dispositioned a
+ * session-authed disclosure as "arguably the point". It is not.
+ * The `v1/blocks/*` entries are `withAxiom` + block-scope auth.
+ *
  * 🟢 TIER 3 — operator surfaces behind JOB_TOKEN / WEBHOOK_TOKEN / moderator auth
- * (`WebhookEndpoint`, `ModEndpoint`, `OrchestratorEndpoint`). There the driver
- * detail is arguably the POINT — admin/backfill/debug tools whose caller is us.
- * Listed for completeness; fixing them is optional and may be undesirable.
+ * (`WebhookEndpoint`, `ModEndpoint` ONLY). There the driver detail is arguably the
+ * POINT — admin/backfill/debug tools whose caller is us. Listed for completeness;
+ * fixing them is optional and may be undesirable.
  */
 const KNOWN_UNFIXED_SAME_CLASS: string[] = [
   // TIER 1 — unauthenticated
   'generation/data.ts',
   'generation/resources.ts',
+  'v1/images/index.ts',
   'v1/model-files/[id]/tensor-metadata.ts',
   // TIER 2 — session-authed
   'blocks/submit-version.ts',
   'download/user-transactions.ts',
   'image/ingest.ts',
   'media/ingest/[mediaId].ts',
+  'orchestrator/refreshBlobs.ts',
   'upload/abort.ts',
   'upload/complete.ts',
   'upload/sign-part.ts',
+  'v1/blocks/collections/[id]/follow.ts',
+  'v1/blocks/images.ts',
   'v1/blocks/models.ts',
+  'v1/blocks/shared-storage/increment.ts',
+  'v1/blocks/shared-storage/top.ts',
   'v1/blocks/submit-version.ts',
   'v1/blocks/withdraw.ts',
+  'v1/creator-program/join.ts',
   'v1/image-upload/multipart/index.ts',
+  'v1/model-versions/early-access.ts',
   // TIER 3 — operator / token-gated
   'admin/temp/backfill-b2-file-locations.ts',
+  'admin/temp/backfill-metric-agg.ts',
+  'admin/temp/backfill-user-downloads.ts',
   'admin/temp/dedupe-official-files.ts',
   'admin/temp/migrate-article-images.ts',
   'admin/temp/migrate-model-flags.ts',
@@ -173,14 +288,15 @@ const KNOWN_UNFIXED_SAME_CLASS: string[] = [
   'mod/reconcile-nowpayments.ts',
   'mod/reprocess-buzz-purchases.ts',
   'mod/reprocess-order.ts',
+  'mod/resource-training-v2.ts',
   'mod/scanner-policies/export-dataset.ts',
   'mod/unblock-images.ts',
   'mod/withdraw-from-bank.ts',
-  'orchestrator/refreshBlobs.ts',
   'testing/blue-buzz-paid-access.ts',
   'testing/model-file-scan.ts',
   'testing/redis-cluster.ts',
   'testing/xguard-test.ts',
+  'webhooks/resource-training-v2/[modelVersionId].ts',
   'webhooks/resource-training.ts',
   'webhooks/run-jobs/[[...run]].ts',
   'webhooks/scanner-policy-result.ts',
@@ -228,11 +344,7 @@ describe('LEDGER: no REST route serializes an error object or its text (civitai#
 
   it('the offender set is EXACTLY the recorded baseline — a new one fails here', () => {
     const offenders = files
-      .filter((f) =>
-        jsonBodies(stripLineComments(readFileSync(f, 'utf8'))).some((b) =>
-          LEAKING_BODY_SHAPES.some((s) => s.re.test(b))
-        )
-      )
+      .filter((f) => jsonBodies(stripLineComments(readFileSync(f, 'utf8'))).some(bodyLeaks))
       .map((f) => path.relative(API_ROOT, f).split(path.sep).join('/'))
       .sort();
 
@@ -258,9 +370,10 @@ describe('LEDGER: no REST route serializes an error object or its text (civitai#
         stripLineComments(readFileSync(path.join(API_ROOT, rel), 'utf8'))
       );
       for (const shape of LEAKING_BODY_SHAPES) {
-        expect(bodies.some((b) => shape.re.test(b)), `${rel} still matches "${shape.name}"`).toBe(
-          false
-        );
+        expect(
+          bodies.some((b) => shape.test(topLevelKeys(b))),
+          `${rel} still matches "${shape.name}"`
+        ).toBe(false);
       }
     }
   });
@@ -277,12 +390,17 @@ describe('LEDGER: no REST route serializes an error object or its text (civitai#
       [`return res.status(500).json({ error: error.cause });`, 2],
       [`res.status(500).json({ message: 'x', error: err.message });`, 3],
       [`res.status(422).json({ error: (err as Error).message });`, 3],
+      // 🔴 The delta-audit probes. Each of these walked through the previous
+      // version untouched, and one of them is a LIVE unauthenticated route.
+      [`res.status(500).json({ error: trpcError.message, code: trpcError.code });`, 3],
+      [`res.status(500).json({ error: (reason as Error).message });`, 3],
+      [`res.status(500).json({ error: err?.message ?? 'failed' });`, 3],
     ];
     for (const [sample, shapeIndex] of mustMatch) {
       const body = jsonBodies(sample)[0];
       expect(body, `extractor failed on: ${sample}`).toBeDefined();
       expect(
-        LEAKING_BODY_SHAPES[shapeIndex].re.test(body),
+        LEAKING_BODY_SHAPES[shapeIndex].test(topLevelKeys(body)),
         `shape "${LEAKING_BODY_SHAPES[shapeIndex].name}" failed on its own exemplar: ${sample}`
       ).toBe(true);
     }
@@ -297,11 +415,20 @@ describe('LEDGER: no REST route serializes an error object or its text (civitai#
       `res.status(400).json({ error: z.prettifyError(result.error) ?? 'Invalid file id' });`,
       `res.status(400).json({ error: parsed.error.flatten() });`,
       `res.status(200).json({ items, metadata });`,
+      // 🔴 Delta-audit false positives: a key at a NESTED depth is not a leak of
+      // the top-level envelope, and flagging it would make the ledger
+      // permanently red for the wrong reason.
+      `res.status(200).json({ items, summary: { error, warnings } });`,
+      `res.status(200).json({ incident: { cause: 'flood' } });`,
+      // A string we wrote, bound to a normal identifier.
+      `res.status(400).json({ error: reason });`,
     ];
     for (const sample of mustNotMatch) {
       const body = jsonBodies(sample)[0];
       for (const shape of LEAKING_BODY_SHAPES) {
-        expect(shape.re.test(body), `"${shape.name}" false-positives on: ${sample}`).toBe(false);
+        expect(shape.test(topLevelKeys(body)), `"${shape.name}" false-positives on: ${sample}`).toBe(
+          false
+        );
       }
     }
   });

--- a/src/server/utils/__tests__/rest-error-envelope-ledger.test.ts
+++ b/src/server/utils/__tests__/rest-error-envelope-ledger.test.ts
@@ -236,8 +236,8 @@ function bodyLeaks(body: string): boolean {
  * `v1/images/index.ts` is pre-existing and unrelated to this change's diff.
  *
  * 🟡 TIER 2 — session-authed: a logged-in user can trigger it, the public cannot.
- * `blocks/submit-version.ts` and `v1/blocks/submit-version.ts` are `ModEndpoint`
- * and so belong in TIER 3, where they now are.
+ * `blocks/submit-version.ts` is `ModEndpoint` and so belongs in TIER 3, where it
+ * now is. Its `v1/` namesake is NOT — see the note on that entry.
  * TIER 2 includes `orchestrator/refreshBlobs.ts`: `OrchestratorEndpoint` is
  * `AuthedEndpoint` + a per-user token (`endpoint-helpers.ts`), with NO moderator
  * check — an earlier draft filed it under TIER 3, which would have dispositioned a
@@ -276,6 +276,14 @@ const KNOWN_UNFIXED_SAME_CLASS: string[] = [
   'v1/blocks/models.ts',
   'v1/blocks/shared-storage/increment.ts',
   'v1/blocks/shared-storage/top.ts',
+  // NOT ModEndpoint — `withAxiom` + `Authorization: Bearer <API key>`, gated by
+  // `isAppBlocksAuthorEnabled`, a Flipt flag whose own docs say it grants
+  // authoring to a curated cohort INDEPENDENT of the mod-only flag. An earlier
+  // round filed it under TIER 3 as "ModEndpoint", which is exactly the
+  // misclassification corrected for `orchestrator/refreshBlobs.ts` — signing off
+  // a non-operator-reachable disclosure as "arguably the point". Mod-only in
+  // practice today only because of the static mod floor.
+  'v1/blocks/submit-version.ts',
   'v1/blocks/withdraw.ts',
   'v1/creator-program/join.ts',
   'v1/image-upload/multipart/index.ts',
@@ -309,7 +317,6 @@ const KNOWN_UNFIXED_SAME_CLASS: string[] = [
   'testing/model-file-scan.ts',
   'testing/redis-cluster.ts',
   'testing/xguard-test.ts',
-  'v1/blocks/submit-version.ts', // ModEndpoint
   'webhooks/resource-training-v2/[modelVersionId].ts',
   'webhooks/resource-training.ts',
   'webhooks/run-jobs/[[...run]].ts',
@@ -358,6 +365,35 @@ describe('LEDGER: no REST route serializes an error object or its text (civitai#
       jsonBodies(`res.status(500).json({ error: 'x', nested: { a: 1 } });`),
       'nested literals elided, string contents blanked, braces balanced'
     ).toEqual([`{ error: '', nested:  }`]);
+  });
+
+  it('the extractor handles the branches no real file exercises today', () => {
+    // 🔴 Both branches below are UNREACHABLE across all ~970 `.json({…})` sites in
+    // the tree (measured: 0 fallbacks, 0 escape-skips), and deleting either left
+    // the ledger fully green. A dead branch with no exemplar is exactly the shape
+    // these rounds keep finding, so they get one here rather than a claim in a
+    // comment.
+
+    // Unterminated quote — an apostrophe in a TRAILING `//` comment survives
+    // `stripLineComments`, which only drops whole-line comments. Without the
+    // fallback the scan runs to EOF and emits NOTHING for this call: silence,
+    // which is the worse failure direction because it reads as "clean".
+    const unterminated = `res.status(500).json({ error: err.message, ok: false // don't care\n});`;
+    const bodies = jsonBodies(unterminated);
+    expect(bodies.length, 'the fallback must still yield a body').toBe(1);
+    expect(bodies.some(bodyLeaks), 'and the leak in it must still be seen').toBe(true);
+
+    // Escaped quote at depth 1. 🔴 The exemplar needs a `}` INSIDE the string or
+    // it does not discriminate: without the escape skip the scan just runs to EOF
+    // and the fallback above rescues it, so the leak is still found and the mutant
+    // survives (measured — it did). With a brace in there, dropping the escape
+    // skip ends the body EARLY at a real depth-0 `}`, the scan "succeeds" so the
+    // fallback never fires, and `error: err.message` lands outside the extracted
+    // body — a silent false negative.
+    const escaped = String.raw`res.status(500).json({ note: 'it\'s } fine', error: err.message });`;
+    expect(jsonBodies(escaped).some(bodyLeaks), 'an escaped quote must not blind the scan').toBe(
+      true
+    );
   });
 
   it('the offender set is EXACTLY the recorded baseline — a new one fails here', () => {

--- a/src/server/utils/__tests__/rest-error-envelope-ledger.test.ts
+++ b/src/server/utils/__tests__/rest-error-envelope-ledger.test.ts
@@ -72,53 +72,59 @@ function jsonBodies(source: string): string[] {
   const call = /\.\s*json\(\s*\{/g;
   for (let m = call.exec(source); m; m = call.exec(source)) {
     const start = source.indexOf('{', m.index);
-    let depth = 0;
-    let quote: string | null = null;
-    for (let i = start; i < source.length; i++) {
-      const ch = source[i];
-      // Skip string/template literals: a `}` inside `'oops }'` used to close the
-      // body early and silently TRUNCATE what got matched — a false negative in
-      // the mechanism itself.
-      if (quote) {
-        if (ch === '\\') i++;
-        else if (ch === quote) quote = null;
-        continue;
-      }
-      if (ch === "'" || ch === '"' || ch === '`') {
-        quote = ch;
-        continue;
-      }
-      if (ch === '{') depth++;
-      else if (ch === '}') {
-        depth--;
-        if (depth === 0) {
-          out.push(source.slice(start, i + 1));
-          break;
-        }
-      }
-    }
+    const body = scanBody(source, start, true);
+    // An UNTERMINATED quote (an apostrophe in a trailing `//` comment, a regex
+    // literal containing one) would otherwise consume to end-of-file and emit
+    // NOTHING for this call — silence, which is the worse failure direction.
+    // Fall back to a quote-blind scan rather than dropping the body.
+    const fallback = body ?? scanBody(source, start, false);
+    if (fallback) out.push(fallback);
   }
   return out;
 }
 
 /**
- * Strip NESTED object literals, leaving only the body's top-level keys.
+ * Brace-match from `start`, returning ONLY the depth-1 slice — the body's
+ * top-level keys, with nested object literals elided.
  *
- * The shapes below anchor on `[{,]`, which without this matches a key at ANY
- * depth: `res.status(200).json({ items, summary: { error, warnings } })` and
- * `{ incident: { cause: 'flood' } }` were both flagged as leaks. A guard that
- * matches everything is as useless as one that matches nothing — it just trains
- * the next author to edit the baseline instead of the code.
+ * 🔴 Two bugs merged into one pass, because as two passes the second undid the
+ * first. Round 2 made `jsonBodies` quote-aware to stop a `}` inside `'oops }'`
+ * truncating the body — then handed its output to a *separate*, quote-BLIND
+ * `topLevelKeys()` which truncated it again at exactly the same character. An
+ * audit measured the end-to-end result as unchanged, and both mutants that
+ * deleted the quote-handling left the suite green: the fix was inert, while its
+ * JSDoc claimed the hazard was closed. One pass now does both.
  *
- * Nesting an error object one level down (`{ data: { detail: err.message } }`)
- * is consequently NOT detected. That is a stated blind spot, not an oversight;
- * see the JSDoc on the offender-set test.
+ * Nesting is elided because the shapes anchor on `[{,]` and would otherwise match
+ * a key at ANY depth — `json({ items, summary: { error, warnings } })` and
+ * `json({ incident: { cause: 'flood' } })` were both flagged as leaks. A guard
+ * that matches everything just trains the next author to edit the baseline.
+ *
+ * Consequence, stated: an error nested one level down
+ * (`{ data: { detail: err.message } }`) is NOT detected.
  */
-function topLevelKeys(body: string): string {
+function scanBody(source: string, start: number, quoteAware: boolean): string | null {
   let out = '';
   let depth = 0;
-  for (let i = 0; i < body.length; i++) {
-    const ch = body[i];
+  let quote: string | null = null;
+  for (let i = start; i < source.length; i++) {
+    const ch = source[i];
+    if (quoteAware && quote) {
+      if (ch === '\\') i++;
+      else if (ch === quote) {
+        quote = null;
+        // Emit the closing quote so a string value survives as an EMPTY literal
+        // (`'x'` -> `''`). It must remain visibly a string: the shapes match an
+        // IDENT, so `{ error: '' }` correctly does not look like `{ error: err }`.
+        if (depth === 1) out += ch;
+      }
+      continue;
+    }
+    if (quoteAware && (ch === "'" || ch === '"' || ch === '`')) {
+      quote = ch;
+      if (depth === 1) out += ch;
+      continue;
+    }
     if (ch === '{') {
       depth++;
       if (depth === 1) out += ch;
@@ -126,12 +132,12 @@ function topLevelKeys(body: string): string {
     }
     if (ch === '}') {
       depth--;
-      if (depth === 0) out += ch;
+      if (depth === 0) return out + ch;
       continue;
     }
     if (depth === 1) out += ch;
   }
-  return out;
+  return null;
 }
 
 /**
@@ -143,19 +149,20 @@ function topLevelKeys(body: string): string {
  * from a `PublicEndpoint`. Anchoring on the variable NAME was the same species of
  * spelled guard as the literal-message regex it replaced, just a smaller hole.
  *
- * Widening to any identifier costs false positives on legitimate string-valued
- * bodies (`{ error: message }`), so the value must additionally end in `.message`
- * / be the bare binding / be `.cause` — and an allowlist below exempts the
- * identifiers that are known NOT to be errors.
+ * 🔴 **The round-2 fix then re-added the same species on the VALUE side.** A
+ * `NOT_AN_ERROR` allowlist (`message`, `reason`, `detail`, …) exempted any body
+ * whose error value was bound to a "string-ish" name. That laundered
+ * `download/models/[modelVersionId].ts:257` — `errorResponse(500, err.message)` →
+ * `res.json({ error: message })` on a **`PublicEndpoint`**, i.e. an
+ * unauthenticated `err.message` 500 of exactly the #3845 shape — out of the
+ * offender set entirely. The allowlist is GONE.
+ *
+ * The cost is over-reporting: a body that genuinely serves a string we wrote
+ * (`{ error: message }` where `message` is a literal) is now flagged. That is the
+ * right direction to be wrong in. Those land in the baseline once, annotated,
+ * instead of a name heuristic silently deciding which disclosures count.
  */
 const IDENT = String.raw`[A-Za-z_$][\w$]*`;
-
-/**
- * Identifiers that name a STRING we wrote, not a caught error. Without these the
- * widened pattern flags `{ error: message }` and `{ error: reason }`, which
- * disclose nothing.
- */
-const NOT_AN_ERROR = ['message', 'msg', 'reason', 'detail', 'text', 'status', 'code', 'label'];
 
 /**
  * The value shapes that put a whole error object — or its driver-authored text —
@@ -168,11 +175,8 @@ const LEAKING_BODY_SHAPES: { name: string; test: (body: string) => boolean }[] =
     // `{ error }` shorthand, `{ error: err }`, `{ error: e as Error }`.
     test: (b) =>
       new RegExp(
-        String.raw`(?:^|[{,])\s*error\s*(?:\}|,|:\s*\(?(${IDENT})\)?(?:\s+as\s+\w+)?\s*[,}\)])`
-      ).test(b) &&
-      !NOT_AN_ERROR.includes(
-        new RegExp(String.raw`(?:^|[{,])\s*error\s*:\s*\(?(${IDENT})`).exec(b)?.[1] ?? ''
-      ),
+        String.raw`(?:^|[{,])\s*error\s*(?:\}|,|:\s*\(?${IDENT}\)?(?:\s+as\s+\w+)?\s*[,}\)])`
+      ).test(b),
   },
   {
     name: '`cause` in a response body (the wrapped driver error, under a second key)',
@@ -186,11 +190,6 @@ const LEAKING_BODY_SHAPES: { name: string; test: (body: string) => boolean }[] =
     name: "`error`/`message` set to a caught error's `.message` (verbatim driver text)",
     // Any identifier, `?.` allowed, optional cast/parens. This is the shape the
     // widened IDENT exists for — `{ error: trpcError.message }` on a public route.
-    // 🔴 The NOT_AN_ERROR allowlist deliberately does NOT apply here. It exists for
-    // the BARE-identifier shape (`{ error: message }` is a string we wrote), and
-    // applying it to `.message` ACCESS exempted `(reason as Error).message` —
-    // unmistakably an error, exempted only because `reason` was on a list of
-    // string-ish names. Reading `.message` off something is itself the signal.
     test: (b) =>
       new RegExp(
         String.raw`(?:^|[{,])\s*(?:error|message)\s*:\s*\(?${IDENT}\)?(?:\s+as\s+[\w.<>\[\]]+)?\)?\??\.message\b`
@@ -200,19 +199,21 @@ const LEAKING_BODY_SHAPES: { name: string; test: (body: string) => boolean }[] =
 
 /** Does this response body serve an error object or its text? */
 function bodyLeaks(body: string): boolean {
-  const top = topLevelKeys(body);
-  return LEAKING_BODY_SHAPES.some((s) => s.test(top));
+  return LEAKING_BODY_SHAPES.some((s) => s.test(body));
 }
 
 /**
  * 🔴 Sites of the SAME class this change does not fix — enumerated, not glossed.
  *
- * This list has now been re-derived TWICE, and grew each time the guard got less
- * spelled: 3 regexes → 41 sites → **52**. That trajectory is the finding. Each
- * widening was driven by an audit defeating the previous version with a real
- * shape, most recently `v1/images/index.ts` — a `PublicEndpoint` serving
- * `{ error: trpcError.message }`, invisible only because the variable was not
- * named `e`/`err`/`error`/`ex`.
+ * This list has been re-derived THREE times, growing each time the guard got
+ * less spelled: 3 regexes → 41 → 52 → **57**. That trajectory is the finding.
+ * Every widening was forced by an audit defeating the previous version with a
+ * REAL shape — `v1/images/index.ts` (invisible because the binding was named
+ * `trpcError`), then `download/models/[modelVersionId].ts` (invisible because a
+ * name allowlist exempted the value `message`). Both are `PublicEndpoint`,
+ * i.e. unauthenticated, and both are pre-existing rather than introduced here.
+ * Two rounds of 'now it is structural' were each still spelled. Assume a fourth
+ * shape exists.
  *
  * 🔴 **KNOWN BLIND SPOTS — this list is a floor, not a ceiling.** The extractor
  * cannot see: a body built in a variable and passed as `res.json(body)`; an error
@@ -226,6 +227,7 @@ function bodyLeaks(body: string): boolean {
  *
  * 🔴 TIER 1 — UNAUTHENTICATED. Same severity as the routes this change fixes.
  *   v1/images/index.ts                    PublicEndpoint; `{ error: trpcError.message }`
+ *   download/models/[modelVersionId].ts   PublicEndpoint; `errorResponse(500, err.message)`
  *   generation/{data,resources}.ts        PublicEndpoint; catch-all → 400 + e.message
  *   v1/model-files/[id]/tensor-metadata   MixedAuthEndpoint (public read) → 422 + err.message
  * NOT fixed here because the fix is not a delegation: each answers 4xx for EVERY
@@ -234,7 +236,9 @@ function bodyLeaks(body: string): boolean {
  * `v1/images/index.ts` is pre-existing and unrelated to this change's diff.
  *
  * 🟡 TIER 2 — session-authed: a logged-in user can trigger it, the public cannot.
- * Includes `orchestrator/refreshBlobs.ts`: `OrchestratorEndpoint` is
+ * `blocks/submit-version.ts` and `v1/blocks/submit-version.ts` are `ModEndpoint`
+ * and so belong in TIER 3, where they now are.
+ * TIER 2 includes `orchestrator/refreshBlobs.ts`: `OrchestratorEndpoint` is
  * `AuthedEndpoint` + a per-user token (`endpoint-helpers.ts`), with NO moderator
  * check — an earlier draft filed it under TIER 3, which would have dispositioned a
  * session-authed disclosure as "arguably the point". It is not.
@@ -246,17 +250,24 @@ function bodyLeaks(body: string): boolean {
  * fixing them is optional and may be undesirable.
  */
 const KNOWN_UNFIXED_SAME_CLASS: string[] = [
-  // TIER 1 — unauthenticated
+  // ── TIER 1 — UNAUTHENTICATED ────────────────────────────────────────────────
+  'download/models/[modelVersionId].ts', // PublicEndpoint; errorResponse(500, err.message)
   'generation/data.ts',
   'generation/resources.ts',
-  'v1/images/index.ts',
+  'v1/images/index.ts', // PublicEndpoint; { error: trpcError.message }
   'v1/model-files/[id]/tensor-metadata.ts',
-  // TIER 2 — session-authed
-  'blocks/submit-version.ts',
+  // ── OVER-REPORTS — flagged by shape, NOT leaks. Kept so the count is honest ──
+  // Both build `{ error: message }` from a local helper whose every call site
+  // passes a STRING LITERAL ('File not found', 'Not Found'). The guard cannot
+  // see that without types; the previous round's answer was a name allowlist,
+  // which is what buried `download/models` above. Recorded instead.
+  'download/attachments/[fileId].ts',
+  'download/vault/[vaultItemId].ts',
+  // ── TIER 2 — session-authed ─────────────────────────────────────────────────
   'download/user-transactions.ts',
   'image/ingest.ts',
   'media/ingest/[mediaId].ts',
-  'orchestrator/refreshBlobs.ts',
+  'orchestrator/refreshBlobs.ts', // OrchestratorEndpoint = AuthedEndpoint + token, NO mod check
   'upload/abort.ts',
   'upload/complete.ts',
   'upload/sign-part.ts',
@@ -265,21 +276,22 @@ const KNOWN_UNFIXED_SAME_CLASS: string[] = [
   'v1/blocks/models.ts',
   'v1/blocks/shared-storage/increment.ts',
   'v1/blocks/shared-storage/top.ts',
-  'v1/blocks/submit-version.ts',
   'v1/blocks/withdraw.ts',
   'v1/creator-program/join.ts',
   'v1/image-upload/multipart/index.ts',
   'v1/model-versions/early-access.ts',
-  // TIER 3 — operator / token-gated
+  // ── TIER 3 — operator / token-gated (WebhookEndpoint or ModEndpoint) ────────
   'admin/temp/backfill-b2-file-locations.ts',
   'admin/temp/backfill-metric-agg.ts',
   'admin/temp/backfill-user-downloads.ts',
+  'admin/temp/clamp-publishedat-bumps.ts',
   'admin/temp/dedupe-official-files.ts',
   'admin/temp/migrate-article-images.ts',
   'admin/temp/migrate-model-flags.ts',
   'admin/temp/remove-deprecated-base-models.ts',
   'admin/test.ts',
   'admin/update-freshdesk-customer.ts',
+  'blocks/submit-version.ts', // ModEndpoint
   'mod/clavata-image-process.ts',
   'mod/csam-upload.ts',
   'mod/mute-user-pending-review.ts',
@@ -292,10 +304,12 @@ const KNOWN_UNFIXED_SAME_CLASS: string[] = [
   'mod/scanner-policies/export-dataset.ts',
   'mod/unblock-images.ts',
   'mod/withdraw-from-bank.ts',
+  'testing/blocks.ts',
   'testing/blue-buzz-paid-access.ts',
   'testing/model-file-scan.ts',
   'testing/redis-cluster.ts',
   'testing/xguard-test.ts',
+  'v1/blocks/submit-version.ts', // ModEndpoint
   'webhooks/resource-training-v2/[modelVersionId].ts',
   'webhooks/resource-training.ts',
   'webhooks/run-jobs/[[...run]].ts',
@@ -336,10 +350,14 @@ describe('LEDGER: no REST route serializes an error object or its text (civitai#
     const bodies = files.flatMap((f) => jsonBodies(stripLineComments(readFileSync(f, 'utf8'))));
     expect(bodies.length, 'no `.json({…})` bodies extracted — the extractor is inert').
       toBeGreaterThan(100);
+    // The extractor returns the DEPTH-1 SLICE with nested literals elided and
+    // string contents blanked — both deliberate (see `scanBody`). Pinned by value
+    // so a change to either behaviour is visible here rather than only as a
+    // mysterious shift in the offender count.
     expect(
       jsonBodies(`res.status(500).json({ error: 'x', nested: { a: 1 } });`),
-      'brace matching must survive a nested object'
-    ).toEqual([`{ error: 'x', nested: { a: 1 } }`]);
+      'nested literals elided, string contents blanked, braces balanced'
+    ).toEqual([`{ error: '', nested:  }`]);
   });
 
   it('the offender set is EXACTLY the recorded baseline — a new one fails here', () => {
@@ -371,7 +389,7 @@ describe('LEDGER: no REST route serializes an error object or its text (civitai#
       );
       for (const shape of LEAKING_BODY_SHAPES) {
         expect(
-          bodies.some((b) => shape.test(topLevelKeys(b))),
+          bodies.some((b) => shape.test(b)),
           `${rel} still matches "${shape.name}"`
         ).toBe(false);
       }
@@ -400,7 +418,7 @@ describe('LEDGER: no REST route serializes an error object or its text (civitai#
       const body = jsonBodies(sample)[0];
       expect(body, `extractor failed on: ${sample}`).toBeDefined();
       expect(
-        LEAKING_BODY_SHAPES[shapeIndex].test(topLevelKeys(body)),
+        LEAKING_BODY_SHAPES[shapeIndex].test(body),
         `shape "${LEAKING_BODY_SHAPES[shapeIndex].name}" failed on its own exemplar: ${sample}`
       ).toBe(true);
     }
@@ -411,7 +429,6 @@ describe('LEDGER: no REST route serializes an error object or its text (civitai#
     // one that matches nothing, and would force the next author to work around it.
     const mustNotMatch = [
       `res.status(403).json({ error: 'Forbidden' });`,
-      `res.status(404).json({ error: message });`,
       `res.status(400).json({ error: z.prettifyError(result.error) ?? 'Invalid file id' });`,
       `res.status(400).json({ error: parsed.error.flatten() });`,
       `res.status(200).json({ items, metadata });`,
@@ -420,13 +437,11 @@ describe('LEDGER: no REST route serializes an error object or its text (civitai#
       // permanently red for the wrong reason.
       `res.status(200).json({ items, summary: { error, warnings } });`,
       `res.status(200).json({ incident: { cause: 'flood' } });`,
-      // A string we wrote, bound to a normal identifier.
-      `res.status(400).json({ error: reason });`,
     ];
     for (const sample of mustNotMatch) {
       const body = jsonBodies(sample)[0];
       for (const shape of LEAKING_BODY_SHAPES) {
-        expect(shape.test(topLevelKeys(body)), `"${shape.name}" false-positives on: ${sample}`).toBe(
+        expect(shape.test(body), `"${shape.name}" false-positives on: ${sample}`).toBe(
           false
         );
       }

--- a/src/server/utils/__tests__/rest-error-envelope-ledger.test.ts
+++ b/src/server/utils/__tests__/rest-error-envelope-ledger.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { TRPCError } from '@trpc/server';
+import { getHTTPStatusCodeFromError } from '@trpc/server/http';
+import { prismaErrorToTrpcCode } from '~/server/utils/errorHandling';
+import { GENERIC_CLIENT_ERROR_BY_STATUS } from '~/server/utils/rest-error-envelope';
+
+/**
+ * Two LEDGERS, both structural, both failing when their set GROWS **or** SHRINKS.
+ *
+ * The behavioural coverage for civitai#3845 lives in
+ * `endpoint-helpers-driver-4xx.test.ts` (the helper) and
+ * `src/tests/api/rest-envelope-consolidation.test.ts` (the 11 routes). Those pin
+ * that the sites we KNOW about behave. Neither can see a TWELFTH copy written
+ * next week, and neither can see a new Prisma→4xx mapping that outruns the
+ * genericization map. That is what these two guards are for.
+ *
+ * 🔴 PR #3850 explicitly predicted the regrowth: "Leaving them patched-in-place
+ * would keep the pattern alive to regrow." A ledger is the deterministic answer to
+ * that; a code-review convention is not.
+ */
+
+// ── Ledger 1: no hand-rolled error envelope anywhere under src/pages/api ──────
+
+const API_ROOT = path.resolve(__dirname, '../../../pages/api');
+
+/**
+ * Drop whole-line `//` comments before matching.
+ *
+ * Found the hard way: `download/attachments/[fileId].ts` carries a commented-out
+ * `return res.status(500).json({ error: 'Invalid database operation', cause: error })`
+ * — dead code, byte-identical to the live `run/[modelVersionId]` leak this PR
+ * fixes. Reported as an offender, it is a false positive; the live body there is
+ * already generic. Only whole-line comments are stripped, so a `//` inside a
+ * string literal (`'https://…'`) cannot silently blind the sweep.
+ */
+function stripLineComments(source: string): string {
+  return source
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('//'))
+    .join('\n');
+}
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...walk(full));
+    else if (/\.tsx?$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * The four shapes population B actually used, as source-level patterns. Each one
+ * is a real leak that shipped, NOT a stylistic preference:
+ *
+ *   `{ message: 'An unexpected error occurred', error }`  — whole object
+ *   `{ error: err.message }` next to that message         — verbatim driver text
+ *   `res.status(…).json({ error: <expr>.cause })`         — the WRAPPED driver error
+ *   `res.status(…).json({ …, cause: error })`             — object under a 2nd key
+ *
+ * Matched on the GENERIC_SERVER_ERROR_MESSAGE literal and on `cause` appearing in
+ * a response body, because those are the tells that survive reformatting. A site
+ * that needs a bespoke body should build it with `restErrorBody`, which cannot
+ * carry an error object.
+ */
+const HAND_ROLLED_PATTERNS: { name: string; re: RegExp }[] = [
+  {
+    name: "the '{ message: <generic>, error }' envelope (population B's shape)",
+    re: /['"]An unexpected error occurred['"]\s*,\s*\n?\s*error\b/,
+  },
+  {
+    name: 'a response body carrying `cause:` (serializes the wrapped driver error)',
+    re: /res\s*\.\s*status\([^)]*\)\s*\.\s*json\(\s*\{[^}]*\bcause\s*:/s,
+  },
+  {
+    name: 'a response body carrying `error: <expr>.cause` (the wrapped driver error)',
+    re: /res\s*\.\s*status\([^)]*\)\s*\.\s*json\(\s*\{\s*error\s*:\s*[A-Za-z_$][\w$]*\.cause\b/,
+  },
+];
+
+describe('LEDGER: no REST route hand-rolls the error envelope (civitai#3845/4)', () => {
+  const files = walk(API_ROOT);
+
+  it('finds the API tree (positive control — an empty sweep must not read as clean)', () => {
+    // 🔴 A zero from a file walk is indistinguishable from a walk wired to
+    // nothing. Prove the instrument can see before believing what it reports.
+    expect(files.length, 'the src/pages/api walk returned nothing — the guard is inert').
+      toBeGreaterThan(200);
+    expect(files.some((f) => f.endsWith(path.join('v1', 'creators.ts')))).toBe(true);
+  });
+
+  it.each(HAND_ROLLED_PATTERNS)('no file matches $name', ({ re }) => {
+    const offenders = files.filter((f) => re.test(stripLineComments(readFileSync(f, 'utf8'))));
+    expect(
+      offenders.map((f) => path.relative(API_ROOT, f)).sort(),
+      'route these through `handleEndpointError` instead of re-creating the envelope — ' +
+        'a whole error object serializes its enumerable own props, which for a Prisma error ' +
+        'is the table + column and for a pg 23505 is the offending ROW VALUE'
+    ).toEqual([]);
+  });
+
+  it('the patterns CAN match (negative control — a guard that never fires is not a guard)', () => {
+    // Each pattern is fed a synthetic offender built from the shape it exists to
+    // catch. Without this, all three could be typos matching nothing and the sweep
+    // above would report a reassuring, meaningless zero.
+    const samples = [
+      `res.status(500).json({ message: 'An unexpected error occurred', error });`,
+      `res.status(500).json({ error: 'Invalid database operation', cause: error });`,
+      `return res.status(500).json({ error: error.cause });`,
+    ];
+    HAND_ROLLED_PATTERNS.forEach((p, i) => {
+      expect(p.re.test(samples[i]), `pattern "${p.name}" failed to match its own exemplar`).toBe(
+        true
+      );
+    });
+  });
+});
+
+// ── Ledger 2: the 4xx genericization map covers every reachable 4xx ───────────
+
+describe('LEDGER: GENERIC_CLIENT_ERROR_BY_STATUS covers every 4xx a driver can reach', () => {
+  /**
+   * Derived from `prismaErrorToTrpcCode` itself rather than hand-copied, so adding
+   * `P2031: 'FORBIDDEN'` upstream turns THIS red instead of silently reopening the
+   * leak at 403 — `handleEndpointError` leaves a status with no entry alone.
+   */
+  const reachable4xx = [
+    ...new Set(
+      Object.values(prismaErrorToTrpcCode)
+        .map((code) => getHTTPStatusCodeFromError(new TRPCError({ code })))
+        .filter((status) => status >= 400 && status < 500)
+    ),
+  ].sort((a, b) => a - b);
+
+  it('derives a non-empty reachable set (positive control)', () => {
+    expect(reachable4xx.length, 'the derivation found no 4xx — the ledger would be vacuous').
+      toBeGreaterThan(0);
+  });
+
+  it('the map keys EQUAL the reachable set — fails if either side grows or shrinks', () => {
+    const mapped = Object.keys(GENERIC_CLIENT_ERROR_BY_STATUS)
+      .map(Number)
+      .sort((a, b) => a - b);
+    expect(
+      mapped,
+      'a Prisma code now maps to a 4xx with no generic replacement — `handleEndpointError` ' +
+        'leaves unmapped statuses ALONE, so that status would serve raw driver text. ' +
+        'Add an entry to GENERIC_CLIENT_ERROR_BY_STATUS (and a case to ' +
+        'endpoint-helpers-driver-4xx.test.ts).'
+    ).toEqual(reachable4xx);
+  });
+
+  /**
+   * 🔴 A KNOWN, BOUNDED GAP — recorded so it cannot grow silently.
+   *
+   * `isDriverAuthoredMessage` matches on message identity against a driver error
+   * in the `cause` chain. A site that re-wraps a caught error's `.message` into a
+   * 4xx TRPCError WITHOUT setting `cause` therefore defeats it: the text on the
+   * wire is the driver's, but nothing in the chain proves that. If the underlying
+   * error is a Prisma or pg error, its text still reaches a 4xx body.
+   *
+   * There are 17 such sites today, all on the App Blocks / referral tRPC surface.
+   * They are NOT fixed here: the one-word fix (`cause: err`) touches four router
+   * files on a different surface, with its own review and test considerations,
+   * and a mechanical sweep over them is exactly the sort of edit that should not
+   * ride along inside a security fix. Tracked as follow-up.
+   *
+   * This test pins the CURRENT set. It fails if a fifth file joins (the gap is
+   * spreading — fix it there) and equally if the counts drop (someone fixed some;
+   * update the ledger and delete the entry when it reaches zero). Either way the
+   * gap stays visible instead of decaying into folklore.
+   */
+  it('LEDGER: the known `no-cause` bypass sites are exactly these — grow or shrink and this fails', () => {
+    const SERVER_ROOT = path.resolve(__dirname, '../..');
+    const KNOWN_BYPASS: [string, number][] = [
+      ['routers/app-listings.router.ts', 2],
+      ['routers/apps-shared.router.ts', 1],
+      ['routers/blocks.router.ts', 13],
+      ['routers/referral.router.ts', 1],
+    ];
+
+    const ctor = /new TRPCError\(\{(?<body>[^{}]*?)\}\)/gs;
+    const fromCaught = /message:\s*\(?(?:e|err|error|ex)\)?(?:\s+as\s+\w+)?\)?\.message/;
+
+    const found: Record<string, number> = {};
+    for (const file of walk(SERVER_ROOT)) {
+      if (file.includes('__tests__')) continue;
+      const source = stripLineComments(readFileSync(file, 'utf8'));
+      let n = 0;
+      for (const m of source.matchAll(ctor)) {
+        const body = m.groups?.body ?? '';
+        if (fromCaught.test(body) && !body.includes('cause')) n++;
+      }
+      if (n) found[path.relative(SERVER_ROOT, file).split(path.sep).join('/')] = n;
+    }
+
+    // Positive control: the detector must be able to see a site at all, or the
+    // "exactly these" assertion below is satisfied by a regex that matches nothing.
+    expect(
+      fromCaught.test(`code: 'BAD_REQUEST', message: (err as Error).message`),
+      'the bypass detector cannot match its own exemplar — this ledger would be vacuous'
+    ).toBe(true);
+
+    expect(
+      Object.entries(found).sort(),
+      'the set of TRPCError sites that forward a caught error\'s `.message` at a 4xx WITHOUT ' +
+        '`cause` has changed. Adding one re-opens the civitai#3845/3 leak at that site, because ' +
+        '`isDriverAuthoredMessage` cannot see a driver error that is not in the cause chain. ' +
+        'Fix: pass `cause: err` alongside the message.'
+    ).toEqual(KNOWN_BYPASS.sort());
+  });
+
+  it('every entry discloses nothing beyond what the status already says', () => {
+    for (const [status, { message }] of Object.entries(GENERIC_CLIENT_ERROR_BY_STATUS)) {
+      expect(typeof message, `${status} message must be a string for the CLI decoder`).toBe(
+        'string'
+      );
+      for (const tell of ['prisma', 'invocation', 'column', 'constraint', 'Key (', 'SELECT']) {
+        expect(
+          message.toLowerCase(),
+          `${status}'s replacement text must not itself name internals`
+        ).not.toContain(tell.toLowerCase());
+      }
+    }
+  });
+});

--- a/src/server/utils/__tests__/rest-error-envelope-ledger.test.ts
+++ b/src/server/utils/__tests__/rest-error-envelope-ledger.test.ts
@@ -53,35 +53,156 @@ function walk(dir: string): string[] {
 }
 
 /**
- * The four shapes population B actually used, as source-level patterns. Each one
- * is a real leak that shipped, NOT a stylistic preference:
+ * Extract the text of every object literal passed to a `.json(...)` call.
  *
- *   `{ message: 'An unexpected error occurred', error }`  — whole object
- *   `{ error: err.message }` next to that message         — verbatim driver text
- *   `res.status(…).json({ error: <expr>.cause })`         — the WRAPPED driver error
- *   `res.status(…).json({ …, cause: error })`             — object under a 2nd key
+ * 🔴 This replaced three regexes that were **spelled guards, not structural ones**.
+ * An audit defeated all three at once by simply dropping the literal
+ * `'An unexpected error occurred'`: a file containing only
+ * `return res.status(500).json({ error });` — the exact whole-object leak the
+ * ledger exists to stop — swept CLEAN. Two narrower holes died with them:
+ * `res.status(getHTTPStatusCodeFromError(e))` could not match a `[^)]*` status
+ * group, and `res.json({ error })` with no `.status()` was never considered.
  *
- * Matched on the GENERIC_SERVER_ERROR_MESSAGE literal and on `cause` appearing in
- * a response body, because those are the tells that survive reformatting. A site
- * that needs a bespoke body should build it with `restErrorBody`, which cannot
- * carry an error object.
+ * So: find the CALL, brace-match its argument, and inspect the object's KEYS AND
+ * VALUE SHAPES — which is what the hazard actually is. These cannot be spelled
+ * around, because they name what the value IS rather than what sits next to it.
  */
-const HAND_ROLLED_PATTERNS: { name: string; re: RegExp }[] = [
+function jsonBodies(source: string): string[] {
+  const out: string[] = [];
+  const call = /\.\s*json\(\s*\{/g;
+  for (let m = call.exec(source); m; m = call.exec(source)) {
+    const start = source.indexOf('{', m.index);
+    let depth = 0;
+    for (let i = start; i < source.length; i++) {
+      if (source[i] === '{') depth++;
+      else if (source[i] === '}') {
+        depth--;
+        if (depth === 0) {
+          out.push(source.slice(start, i + 1));
+          break;
+        }
+      }
+    }
+  }
+  return out;
+}
+
+/** An identifier a `catch (…)` binding realistically uses. */
+const CAUGHT = String.raw`(?:e|err|error|ex)`;
+
+/**
+ * The value shapes that put a whole error object — or its driver-authored text —
+ * on the wire. A string-literal value (`{ error: 'Forbidden' }`) is deliberately
+ * NOT matched: the hazard is serializing an Error, not using the key.
+ */
+const LEAKING_BODY_SHAPES: { name: string; re: RegExp }[] = [
   {
-    name: "the '{ message: <generic>, error }' envelope (population B's shape)",
-    re: /['"]An unexpected error occurred['"]\s*,\s*\n?\s*error\b/,
+    name: '`error` bound to a caught error object (its enumerable own props serialize)',
+    // `{ error }` shorthand, `{ error: err }`, `{ error: e as Error }`.
+    re: new RegExp(
+      String.raw`(?:^|[{,])\s*error\s*(?:\}|,|:\s*\(?${CAUGHT}\)?(?:\s+as\s+\w+)?\s*[,}\)])`
+    ),
   },
   {
-    name: 'a response body carrying `cause:` (serializes the wrapped driver error)',
-    re: /res\s*\.\s*status\([^)]*\)\s*\.\s*json\(\s*\{[^}]*\bcause\s*:/s,
+    name: '`cause` in a response body (the wrapped driver error, under a second key)',
+    re: /(?:^|[{,])\s*cause\s*(?:\}|,|:)/,
   },
   {
-    name: 'a response body carrying `error: <expr>.cause` (the wrapped driver error)',
-    re: /res\s*\.\s*status\([^)]*\)\s*\.\s*json\(\s*\{\s*error\s*:\s*[A-Za-z_$][\w$]*\.cause\b/,
+    name: '`error: <expr>.cause` (serves the error the TRPCError wrapped)',
+    re: new RegExp(String.raw`(?:^|[{,])\s*error\s*:\s*[A-Za-z_$][\w$]*\.cause\b`),
+  },
+  {
+    name: "`error`/`message` set to a caught error's `.message` (verbatim driver text)",
+    re: new RegExp(
+      String.raw`(?:^|[{,])\s*(?:error|message)\s*:\s*\(?${CAUGHT}\)?(?:\s+as\s+\w+)?\)?\.message\b`
+    ),
   },
 ];
 
-describe('LEDGER: no REST route hand-rolls the error envelope (civitai#3845/4)', () => {
+/**
+ * 🔴 Sites of the SAME class this change does not fix — enumerated, not glossed.
+ *
+ * Making the guard structural surfaced this: the class was never confined to the
+ * 11 routes civitai#3845 enumerated. Every entry is recorded rather than
+ * exempted-by-glob, so the list fails if it GROWS (a new site) or SHRINKS (one
+ * was fixed — delete its line). Ordered by exposure, which is the order to fix in:
+ *
+ * 🔴 TIER 1 — UNAUTHENTICATED. Same severity as the routes this change fixes.
+ *   generation/{data,resources}.ts        PublicEndpoint; catch-all → 400 + e.message
+ *   v1/model-files/[id]/tensor-metadata   MixedAuthEndpoint (public read) → 422 + err.message
+ * NOT fixed here because the fix is not a delegation: each answers 4xx for EVERY
+ * failure including zod-parse rejections, so routing them through the helper turns
+ * a legitimate client 400 into a 500. That needs its own red/green and review.
+ *
+ * 🟡 TIER 2 — session-authed: a logged-in user can trigger it, the public cannot.
+ * 🟢 TIER 3 — operator surfaces behind JOB_TOKEN / WEBHOOK_TOKEN / moderator auth
+ * (`WebhookEndpoint`, `ModEndpoint`, `OrchestratorEndpoint`). There the driver
+ * detail is arguably the POINT — admin/backfill/debug tools whose caller is us.
+ * Listed for completeness; fixing them is optional and may be undesirable.
+ */
+const KNOWN_UNFIXED_SAME_CLASS: string[] = [
+  // TIER 1 — unauthenticated
+  'generation/data.ts',
+  'generation/resources.ts',
+  'v1/model-files/[id]/tensor-metadata.ts',
+  // TIER 2 — session-authed
+  'blocks/submit-version.ts',
+  'download/user-transactions.ts',
+  'image/ingest.ts',
+  'media/ingest/[mediaId].ts',
+  'upload/abort.ts',
+  'upload/complete.ts',
+  'upload/sign-part.ts',
+  'v1/blocks/models.ts',
+  'v1/blocks/submit-version.ts',
+  'v1/blocks/withdraw.ts',
+  'v1/image-upload/multipart/index.ts',
+  // TIER 3 — operator / token-gated
+  'admin/temp/backfill-b2-file-locations.ts',
+  'admin/temp/dedupe-official-files.ts',
+  'admin/temp/migrate-article-images.ts',
+  'admin/temp/migrate-model-flags.ts',
+  'admin/temp/remove-deprecated-base-models.ts',
+  'admin/test.ts',
+  'admin/update-freshdesk-customer.ts',
+  'mod/clavata-image-process.ts',
+  'mod/csam-upload.ts',
+  'mod/mute-user-pending-review.ts',
+  'mod/overturn-user-mute.ts',
+  'mod/queue-model-metric-update.ts',
+  'mod/reconcile-nowpayments.ts',
+  'mod/reprocess-buzz-purchases.ts',
+  'mod/reprocess-order.ts',
+  'mod/scanner-policies/export-dataset.ts',
+  'mod/unblock-images.ts',
+  'mod/withdraw-from-bank.ts',
+  'orchestrator/refreshBlobs.ts',
+  'testing/blue-buzz-paid-access.ts',
+  'testing/model-file-scan.ts',
+  'testing/redis-cluster.ts',
+  'testing/xguard-test.ts',
+  'webhooks/resource-training.ts',
+  'webhooks/run-jobs/[[...run]].ts',
+  'webhooks/scanner-policy-result.ts',
+  'webhooks/text-moderation-result.ts',
+];
+
+/** Routes this change fixed — must never appear in the exception list above. */
+const FIXED_BY_THIS_CHANGE = [
+  'notification/getDetails.ts',
+  'run/[modelVersionId].ts',
+  'v1/content/[[...slug]].ts',
+  'v1/creators.ts',
+  'v1/permissions/check.ts',
+  'v1/tags.ts',
+  'v1/users/index.ts',
+  'v1/vault/all.tsx',
+  'v1/vault/check-vault.tsx',
+  'v1/vault/get.tsx',
+  'v1/vault/toggle-version.tsx',
+];
+
+describe('LEDGER: no REST route serializes an error object or its text (civitai#3845/4)', () => {
   const files = walk(API_ROOT);
 
   it('finds the API tree (positive control — an empty sweep must not read as clean)', () => {
@@ -92,30 +213,97 @@ describe('LEDGER: no REST route hand-rolls the error envelope (civitai#3845/4)',
     expect(files.some((f) => f.endsWith(path.join('v1', 'creators.ts')))).toBe(true);
   });
 
-  it.each(HAND_ROLLED_PATTERNS)('no file matches $name', ({ re }) => {
-    const offenders = files.filter((f) => re.test(stripLineComments(readFileSync(f, 'utf8'))));
+  it('extracts json bodies at all (positive control on the extractor itself)', () => {
+    // The sweep is `bodies.some(...)`. If `jsonBodies` returned [] for every file,
+    // every shape would report zero offenders and the ledger would be a very
+    // convincing no-op.
+    const bodies = files.flatMap((f) => jsonBodies(stripLineComments(readFileSync(f, 'utf8'))));
+    expect(bodies.length, 'no `.json({…})` bodies extracted — the extractor is inert').
+      toBeGreaterThan(100);
     expect(
-      offenders.map((f) => path.relative(API_ROOT, f)).sort(),
-      'route these through `handleEndpointError` instead of re-creating the envelope — ' +
-        'a whole error object serializes its enumerable own props, which for a Prisma error ' +
-        'is the table + column and for a pg 23505 is the offending ROW VALUE'
-    ).toEqual([]);
+      jsonBodies(`res.status(500).json({ error: 'x', nested: { a: 1 } });`),
+      'brace matching must survive a nested object'
+    ).toEqual([`{ error: 'x', nested: { a: 1 } }`]);
   });
 
-  it('the patterns CAN match (negative control — a guard that never fires is not a guard)', () => {
-    // Each pattern is fed a synthetic offender built from the shape it exists to
-    // catch. Without this, all three could be typos matching nothing and the sweep
-    // above would report a reassuring, meaningless zero.
-    const samples = [
-      `res.status(500).json({ message: 'An unexpected error occurred', error });`,
-      `res.status(500).json({ error: 'Invalid database operation', cause: error });`,
-      `return res.status(500).json({ error: error.cause });`,
-    ];
-    HAND_ROLLED_PATTERNS.forEach((p, i) => {
-      expect(p.re.test(samples[i]), `pattern "${p.name}" failed to match its own exemplar`).toBe(
-        true
+  it('the offender set is EXACTLY the recorded baseline — a new one fails here', () => {
+    const offenders = files
+      .filter((f) =>
+        jsonBodies(stripLineComments(readFileSync(f, 'utf8'))).some((b) =>
+          LEAKING_BODY_SHAPES.some((s) => s.re.test(b))
+        )
+      )
+      .map((f) => path.relative(API_ROOT, f).split(path.sep).join('/'))
+      .sort();
+
+    expect(
+      offenders,
+      'a REST route now serializes an error object (or its text) into a response body. ' +
+        'Route it through `handleEndpointError` instead — a whole error object serializes its ' +
+        'enumerable own props, which for a Prisma error is the table + column and for a pg ' +
+        '23505 is the offending ROW VALUE. If you FIXED a baseline entry, delete its line ' +
+        'from KNOWN_UNFIXED_SAME_CLASS.'
+    ).toEqual([...KNOWN_UNFIXED_SAME_CLASS].sort());
+  });
+
+  it('none of the routes THIS change fixed are in the offender set', () => {
+    // A list of exceptions can swallow the very thing it was written around.
+    // Assert the 11 explicitly, both ways.
+    for (const rel of FIXED_BY_THIS_CHANGE) {
+      expect(
+        KNOWN_UNFIXED_SAME_CLASS,
+        `${rel} is in the exception list — it is supposed to be FIXED`
+      ).not.toContain(rel);
+      const bodies = jsonBodies(
+        stripLineComments(readFileSync(path.join(API_ROOT, rel), 'utf8'))
       );
-    });
+      for (const shape of LEAKING_BODY_SHAPES) {
+        expect(bodies.some((b) => shape.re.test(b)), `${rel} still matches "${shape.name}"`).toBe(
+          false
+        );
+      }
+    }
+  });
+
+  it('every shape CAN match, incl. the probe that defeated the previous patterns', () => {
+    // Negative control per shape. The FIRST sample is the one an audit used to
+    // walk through the old ledger untouched: no generic message literal, no
+    // `cause`, no `.status()` chain to anchor on.
+    const mustMatch: [string, number][] = [
+      [`return res.json({ error });`, 0],
+      [`res.status(500).json({ message: 'An unexpected error occurred', error });`, 0],
+      [`res.status(getHTTPStatusCodeFromError(e)).json({ ok: false, error: err });`, 0],
+      [`res.status(500).json({ error: 'Invalid database operation', cause: error });`, 1],
+      [`return res.status(500).json({ error: error.cause });`, 2],
+      [`res.status(500).json({ message: 'x', error: err.message });`, 3],
+      [`res.status(422).json({ error: (err as Error).message });`, 3],
+    ];
+    for (const [sample, shapeIndex] of mustMatch) {
+      const body = jsonBodies(sample)[0];
+      expect(body, `extractor failed on: ${sample}`).toBeDefined();
+      expect(
+        LEAKING_BODY_SHAPES[shapeIndex].re.test(body),
+        `shape "${LEAKING_BODY_SHAPES[shapeIndex].name}" failed on its own exemplar: ${sample}`
+      ).toBe(true);
+    }
+  });
+
+  it('does NOT match a hand-written string body (guards against an over-broad sweep)', () => {
+    // The counterpart control: a guard that matches EVERYTHING is as useless as
+    // one that matches nothing, and would force the next author to work around it.
+    const mustNotMatch = [
+      `res.status(403).json({ error: 'Forbidden' });`,
+      `res.status(404).json({ error: message });`,
+      `res.status(400).json({ error: z.prettifyError(result.error) ?? 'Invalid file id' });`,
+      `res.status(400).json({ error: parsed.error.flatten() });`,
+      `res.status(200).json({ items, metadata });`,
+    ];
+    for (const sample of mustNotMatch) {
+      const body = jsonBodies(sample)[0];
+      for (const shape of LEAKING_BODY_SHAPES) {
+        expect(shape.re.test(body), `"${shape.name}" false-positives on: ${sample}`).toBe(false);
+      }
+    }
   });
 });
 

--- a/src/server/utils/__tests__/rest-error-envelope-ledger.test.ts
+++ b/src/server/utils/__tests__/rest-error-envelope-ledger.test.ts
@@ -345,8 +345,10 @@ describe('LEDGER: no REST route serializes an error object or its text (civitai#
   it('finds the API tree (positive control — an empty sweep must not read as clean)', () => {
     // 🔴 A zero from a file walk is indistinguishable from a walk wired to
     // nothing. Prove the instrument can see before believing what it reports.
-    expect(files.length, 'the src/pages/api walk returned nothing — the guard is inert').
-      toBeGreaterThan(200);
+    expect(
+      files.length,
+      'the src/pages/api walk returned nothing — the guard is inert'
+    ).toBeGreaterThan(200);
     expect(files.some((f) => f.endsWith(path.join('v1', 'creators.ts')))).toBe(true);
   });
 
@@ -355,8 +357,10 @@ describe('LEDGER: no REST route serializes an error object or its text (civitai#
     // every shape would report zero offenders and the ledger would be a very
     // convincing no-op.
     const bodies = files.flatMap((f) => jsonBodies(stripLineComments(readFileSync(f, 'utf8'))));
-    expect(bodies.length, 'no `.json({…})` bodies extracted — the extractor is inert').
-      toBeGreaterThan(100);
+    expect(
+      bodies.length,
+      'no `.json({…})` bodies extracted — the extractor is inert'
+    ).toBeGreaterThan(100);
     // The extractor returns the DEPTH-1 SLICE with nested literals elided and
     // string contents blanked — both deliberate (see `scanBody`). Pinned by value
     // so a change to either behaviour is visible here rather than only as a
@@ -420,9 +424,7 @@ describe('LEDGER: no REST route serializes an error object or its text (civitai#
         KNOWN_UNFIXED_SAME_CLASS,
         `${rel} is in the exception list — it is supposed to be FIXED`
       ).not.toContain(rel);
-      const bodies = jsonBodies(
-        stripLineComments(readFileSync(path.join(API_ROOT, rel), 'utf8'))
-      );
+      const bodies = jsonBodies(stripLineComments(readFileSync(path.join(API_ROOT, rel), 'utf8')));
       for (const shape of LEAKING_BODY_SHAPES) {
         expect(
           bodies.some((b) => shape.test(b)),
@@ -477,9 +479,7 @@ describe('LEDGER: no REST route serializes an error object or its text (civitai#
     for (const sample of mustNotMatch) {
       const body = jsonBodies(sample)[0];
       for (const shape of LEAKING_BODY_SHAPES) {
-        expect(shape.test(body), `"${shape.name}" false-positives on: ${sample}`).toBe(
-          false
-        );
+        expect(shape.test(body), `"${shape.name}" false-positives on: ${sample}`).toBe(false);
       }
     }
   });
@@ -502,8 +502,10 @@ describe('LEDGER: GENERIC_CLIENT_ERROR_BY_STATUS covers every 4xx a driver can r
   ].sort((a, b) => a - b);
 
   it('derives a non-empty reachable set (positive control)', () => {
-    expect(reachable4xx.length, 'the derivation found no 4xx — the ledger would be vacuous').
-      toBeGreaterThan(0);
+    expect(
+      reachable4xx.length,
+      'the derivation found no 4xx — the ledger would be vacuous'
+    ).toBeGreaterThan(0);
   });
 
   it('the map keys EQUAL the reachable set — fails if either side grows or shrinks', () => {
@@ -572,7 +574,7 @@ describe('LEDGER: GENERIC_CLIENT_ERROR_BY_STATUS covers every 4xx a driver can r
 
     expect(
       Object.entries(found).sort(),
-      'the set of TRPCError sites that forward a caught error\'s `.message` at a 4xx WITHOUT ' +
+      "the set of TRPCError sites that forward a caught error's `.message` at a 4xx WITHOUT " +
         '`cause` has changed. Adding one re-opens the civitai#3845/3 leak at that site, because ' +
         '`isDriverAuthoredMessage` cannot see a driver error that is not in the cause chain. ' +
         'Fix: pass `cause: err` alongside the message.'

--- a/src/server/utils/endpoint-helpers.ts
+++ b/src/server/utils/endpoint-helpers.ts
@@ -146,30 +146,42 @@ function isRestServerFault(status: number): boolean {
  * right axis is "is this a response a cache should keep", and for an error the
  * answer is always no.
  *
- * **Accepted trade.** Which routes lose edge absorption on a 404:
+ * **Accepted trade.** 🔴 **Do not trust a list here — three successive attempts to
+ * enumerate the affected routes were each wrong, in the same way.** v1 asserted
+ * without checking ("these routes are not under that kind of load"); v2 gave a
+ * "measured" count of ONE, having surveyed only `PublicEndpoint`; v3 added the
+ * `MixedAuthEndpoint` by-id routes but missed `v1/models/index.ts` and then made a
+ * false blanket claim about rate limiters. Each version was more precise and more
+ * quotable than the last, and wrong.
  *
- *   - `v1/content/[[...slug]]`   — `PublicEndpoint`; low volume, small slug space
- *   - `v1/articles/[id]`         — `MixedAuthEndpoint`; `throwNotFoundError`
- *   - `v1/collections/[id]`      — `MixedAuthEndpoint`; `throwNotFoundError`
+ * So: the RULE, and how to re-derive the set yourself.
  *
- * plus any other caller that 404s through this helper. `v1/models/[id]` — the
- * highest-traffic one — is NOT affected: it answers its common 404 directly
- * (`res.status(404).json(...)`) without reaching here.
+ * **Rule** — a route loses 404 edge absorption iff (a) its wrapper stamps the
+ * public cache header, and (b) its 404 reaches THIS helper.
+ *   (a) `PublicEndpoint` stamps it unconditionally; `MixedAuthEndpoint` stamps it
+ *       on every ANONYMOUS request (`if (!session) addPublicCacheHeaders(...)`
+ *       below) — that second one is what keeps getting missed.
+ *   (b) a route that answers 404 itself (`res.status(404).json(...)`) is
+ *       unaffected. `v1/models/[id]` — the highest-traffic caller — does exactly
+ *       that at `:197`, so it keeps its edge cache.
  *
- * 🔴 **`MixedAuthEndpoint` is the easy one to miss, and I missed it twice.** The
- * first version of this note asserted, without checking, that "these routes are
- * not under that kind of load". The second replaced it with a *measured* claim of
- * exactly ONE affected route — arrived at by surveying only the six
- * `PublicEndpoint` callers. But `MixedAuthEndpoint` calls `addPublicCacheHeaders`
- * on **every anonymous request** (`if (!session) addPublicCacheHeaders(...)`
- * below), so its by-id routes carry the same header. A precise wrong number is
- * more quotable than a vague one — and this file already said so 250 lines down,
- * where the 5xx arm names "`GET /api/v1/articles/{id}` (a public
- * MixedAuthEndpoint)" as unauthenticated-reachable.
+ * **Re-derive:** grep `handleEndpointError` under `src/pages/api`, keep the
+ * `PublicEndpoint`/`MixedAuthEndpoint` ones, and check which can reach a
+ * `throwNotFoundError` (directly or through a service).
  *
- * Worth knowing if you extend `noStore` further: the six `PublicEndpoint` callers
- * have NO rate limiter, so edge absorption is the only thing in front of them;
- * the `MixedAuthEndpoint` ones do have one.
+ * Known examples at time of writing, NOT a complete set: `v1/content/[[...slug]]`
+ * (PublicEndpoint), `v1/articles/[id]`, `v1/collections/[id]`, and
+ * `v1/models/index.ts` — the last via `?username=<nonexistent>`, which reaches
+ * `throwNotFoundError('User not found')` in `model.service.ts`.
+ *
+ * **Rate limiting is NOT a blanket reassurance.** Measured: the six
+ * `PublicEndpoint` callers have none, so edge absorption was the only thing in
+ * front of them. Of the seven `MixedAuthEndpoint` callers, six are limited
+ * (`checkPublicApiRateLimit`, `enforceAppsCatalogRateLimit`) and
+ * **`v1/models/index.ts` is not** — which makes it the sharp case: unlimited,
+ * anonymous, and its miss costs two user lookups, the second against the PRIMARY
+ * (`model.service.ts` falls back to `dbWrite` when the read misses, and a
+ * nonexistent username always misses).
  *
  * Uniform application also removes a **fault-classification oracle**: with the
  * narrower version, `no-store` vs `s-maxage=300` on the same status told a caller

--- a/src/server/utils/endpoint-helpers.ts
+++ b/src/server/utils/endpoint-helpers.ts
@@ -41,6 +41,36 @@ function logRestServerFault(e: unknown) {
 }
 
 /**
+ * Same log, forced to INFO severity — for a 4xx whose message we genericized.
+ *
+ * The entry must still be emitted: genericizing is only defensible because it
+ * RELOCATES the driver text rather than destroying it. But it must not land on
+ * the error board, and one status makes that concrete rather than theoretical.
+ *
+ * 🔴 The only Prisma codes that reach **408** are `P1008` / `P2024` — connection
+ * pool exhaustion. That is wave-shaped: during an incident every affected public
+ * request would add an error-severity line, on routes that previously logged
+ * nothing at all. It is the same "fires in high-volume waves" property for which
+ * `isRestServerFault` excludes 503 from the error stream.
+ *
+ * `classifyErrorFault` treats `TIMEOUT` as a SERVER fault, and that is correct
+ * for the repo at large (a timeout usually IS ours), so this does NOT change the
+ * global classification — it overrides `type`/`level` for this arm only. `type`
+ * is the load-bearing field: Alloy extracts it into Loki's `detected_level`.
+ *
+ * 400/404/409 already classify as client faults, so for those this is a no-op and
+ * the uniform treatment is the point — "a genericized 4xx is logged for forensics,
+ * never as an incident" is one rule rather than three.
+ */
+function logRestGenericizedClientFault(e: unknown) {
+  if (wasServerFaultLogged(e)) return;
+  logToAxiom(
+    { ...buildCentralErrorLog(e), type: 'info', level: 'info', source: 'handleEndpointError' },
+    'civitai-prod'
+  ).catch(() => undefined);
+}
+
+/**
  * Is this REST status a SERVER FAULT — i.e. one whose error text is OURS, never a
  * message written for the caller?
  *
@@ -87,6 +117,32 @@ function logRestServerFault(e: unknown) {
  */
 function isRestServerFault(status: number): boolean {
   return status >= 500 && status !== 503;
+}
+
+/**
+ * Mark a genericized error response uncacheable.
+ *
+ * 🔴 `PublicEndpoint` sets `Cache-Control: public, s-maxage=300,
+ * stale-while-revalidate=150` on EVERY response, unconditionally, BEFORE the
+ * handler runs — errors included. That was survivable while every failure on
+ * those routes was a 5xx, because shared caches do not cache 5xx by default. It
+ * stops being survivable the moment an error answers **404**: 404 IS in the
+ * default cacheable set, so a `NOT_FOUND` produced by a transient condition
+ * (replica lag, a `throwDbError`-mapped P2001/P2025) would be pinned at the edge
+ * for 300s + 150s SWR — serving "no such thing" for five minutes after the thing
+ * exists.
+ *
+ * This PR creates exactly that situation (`v1/content` 500 → real status, and the
+ * driver-authored 4xx arm), so the genericized arms opt out. The route-level 503
+ * arm in `v1/users/index.ts` already does the same thing for the same reason.
+ *
+ * Deliberately NOT applied to the 4xx pass-through arm: that arm's headers are
+ * byte-identical to pre-PR behaviour, and widening the change to responses this
+ * PR does not otherwise touch would be scope this cannot claim to have tested.
+ */
+function noStore(res: NextApiResponse) {
+  if (!res.headersSent) res.setHeader('Cache-Control', 'no-store, max-age=0');
+  return res;
 }
 
 type AxiomAPIRequest = NextApiRequest & { log: Logger };
@@ -327,7 +383,7 @@ export function handleEndpointError(res: NextApiResponse, e: unknown) {
     // this genericizes the RESPONSE only, never the LOG.
     if (isRestServerFault(status)) {
       logRestServerFault(apiError);
-      return res
+      return noStore(res)
         .status(status)
         .json(restErrorBody(REST_ERROR_CODE.INTERNAL_SERVER_ERROR, GENERIC_SERVER_ERROR_MESSAGE));
     }
@@ -346,14 +402,19 @@ export function handleEndpointError(res: NextApiResponse, e: unknown) {
     //
     // Logged BEFORE genericizing, on purpose: this arm buys into exactly the same
     // invariant as the 5xx arm — the un-redacted text leaves the wire precisely
-    // when it enters the log, so no message is ever destroyed outright. (That is
-    // also the reason 503 is left alone: it is NOT logged, so its response is the
-    // only copy — and no Prisma code maps to SERVICE_UNAVAILABLE, so nothing
-    // driver-authored can arrive as one.)
+    // when it enters the log, so no message is ever destroyed outright.
+    //
+    // 503 needs no explicit exclusion here: `GENERIC_CLIENT_ERROR_BY_STATUS` has
+    // no 503 key, so `generic` is already undefined for it, and
+    // `rest-error-envelope-ledger.test.ts` FAILS if a 503 key is ever added
+    // (its key set must equal the 4xx statuses `prismaErrorToTrpcCode` reaches).
+    // An earlier draft carried a `status !== 503` clause; it was dead — removing
+    // it left the whole suite green — and a test comment claimed it was what
+    // enforced the exclusion, which was false. The map's key set is.
     const generic = GENERIC_CLIENT_ERROR_BY_STATUS[status];
-    if (generic && status !== 503 && isDriverAuthoredMessage(apiError.message, apiError)) {
-      logRestServerFault(apiError);
-      return res.status(status).json(restErrorBody(generic.code, generic.message));
+    if (generic && isDriverAuthoredMessage(apiError.message, apiError)) {
+      logRestGenericizedClientFault(apiError);
+      return noStore(res).status(status).json(restErrorBody(generic.code, generic.message));
     }
     // ── CLIENT FEEDBACK (4xx) + 503 — passed through BYTE-IDENTICALLY ──────────
     // Older Zod-validation TRPCErrors stuff a JSON-encoded issue array into

--- a/src/server/utils/endpoint-helpers.ts
+++ b/src/server/utils/endpoint-helpers.ts
@@ -146,17 +146,30 @@ function isRestServerFault(status: number): boolean {
  * right axis is "is this a response a cache should keep", and for an error the
  * answer is always no.
  *
- * **Accepted trade, measured rather than asserted.** Across the 25 callers of this
- * helper, exactly ONE route's 404 changes cacheability: `v1/content/[[...slug]]`,
- * which is low-volume over a small known slug space. `v1/models/[id]` — the only
- * high-traffic one — answers its common 404 DIRECTLY (`res.status(404).json(...)`)
- * without going through this helper, so it keeps its edge cache untouched.
+ * **Accepted trade.** Which routes lose edge absorption on a 404:
  *
- * (An earlier version of this note said "these routes are not the ones under that
- * kind of load". That was an unverifiable assertion of the sort that gets quoted
- * back as fact; the sentence above is the check that replaced it. Worth knowing if
- * you extend `noStore` further: the six `PublicEndpoint` callers have NO rate
- * limiter, so edge absorption is the only thing in front of them.)
+ *   - `v1/content/[[...slug]]`   — `PublicEndpoint`; low volume, small slug space
+ *   - `v1/articles/[id]`         — `MixedAuthEndpoint`; `throwNotFoundError`
+ *   - `v1/collections/[id]`      — `MixedAuthEndpoint`; `throwNotFoundError`
+ *
+ * plus any other caller that 404s through this helper. `v1/models/[id]` — the
+ * highest-traffic one — is NOT affected: it answers its common 404 directly
+ * (`res.status(404).json(...)`) without reaching here.
+ *
+ * 🔴 **`MixedAuthEndpoint` is the easy one to miss, and I missed it twice.** The
+ * first version of this note asserted, without checking, that "these routes are
+ * not under that kind of load". The second replaced it with a *measured* claim of
+ * exactly ONE affected route — arrived at by surveying only the six
+ * `PublicEndpoint` callers. But `MixedAuthEndpoint` calls `addPublicCacheHeaders`
+ * on **every anonymous request** (`if (!session) addPublicCacheHeaders(...)`
+ * below), so its by-id routes carry the same header. A precise wrong number is
+ * more quotable than a vague one — and this file already said so 250 lines down,
+ * where the 5xx arm names "`GET /api/v1/articles/{id}` (a public
+ * MixedAuthEndpoint)" as unauthenticated-reachable.
+ *
+ * Worth knowing if you extend `noStore` further: the six `PublicEndpoint` callers
+ * have NO rate limiter, so edge absorption is the only thing in front of them;
+ * the `MixedAuthEndpoint` ones do have one.
  *
  * Uniform application also removes a **fault-classification oracle**: with the
  * narrower version, `no-store` vs `s-maxage=300` on the same status told a caller

--- a/src/server/utils/endpoint-helpers.ts
+++ b/src/server/utils/endpoint-helpers.ts
@@ -146,11 +146,17 @@ function isRestServerFault(status: number): boolean {
  * right axis is "is this a response a cache should keep", and for an error the
  * answer is always no.
  *
- * **Accepted trade:** a 404 flood (scrapers hitting bad slugs) now reaches the
- * origin instead of being absorbed at the edge for 5 minutes. Correctness on a
- * transient 404 is worth more than cache efficiency on an error path, and these
- * routes are not the ones under that kind of load. Stated so the next person
- * knows it was a decision, not an oversight.
+ * **Accepted trade, measured rather than asserted.** Across the 25 callers of this
+ * helper, exactly ONE route's 404 changes cacheability: `v1/content/[[...slug]]`,
+ * which is low-volume over a small known slug space. `v1/models/[id]` — the only
+ * high-traffic one — answers its common 404 DIRECTLY (`res.status(404).json(...)`)
+ * without going through this helper, so it keeps its edge cache untouched.
+ *
+ * (An earlier version of this note said "these routes are not the ones under that
+ * kind of load". That was an unverifiable assertion of the sort that gets quoted
+ * back as fact; the sentence above is the check that replaced it. Worth knowing if
+ * you extend `noStore` further: the six `PublicEndpoint` callers have NO rate
+ * limiter, so edge absorption is the only thing in front of them.)
  *
  * Uniform application also removes a **fault-classification oracle**: with the
  * narrower version, `no-store` vs `s-maxage=300` on the same status told a caller

--- a/src/server/utils/endpoint-helpers.ts
+++ b/src/server/utils/endpoint-helpers.ts
@@ -15,10 +15,11 @@ import { generateSecretHash } from '~/server/utils/key-generator';
 import { getAllServerHosts } from '~/server/utils/server-domain';
 import type { Partner } from '~/shared/utils/prisma/models';
 import { instrumentApiResponse } from '~/server/prom/http-errors';
-import { isClientAbortError } from '~/server/utils/errorHandling';
+import { isClientAbortError, isDriverAuthoredMessage } from '~/server/utils/errorHandling';
 import { isDefined } from '~/utils/type-guards';
 import { logToAxiom, buildCentralErrorLog, wasServerFaultLogged } from '~/server/logging/client';
 import {
+  GENERIC_CLIENT_ERROR_BY_STATUS,
   GENERIC_SERVER_ERROR_MESSAGE,
   REST_ERROR_CODE,
   restErrorBody,
@@ -53,8 +54,21 @@ function logRestServerFault(e: unknown) {
  *   the log — so genericizing can never destroy the only copy of a message.
  *
  * Two exclusions, both load-bearing:
- *   - **4xx** is client feedback the caller is meant to read (zod issues, "not
- *     found", rate-limit hints). Never logged as a fault, never genericized.
+ *   - **4xx** is *usually* client feedback the caller is meant to read (zod
+ *     issues, "not found", rate-limit hints), so it is not a server fault and is
+ *     not genericized HERE.
+ *
+ *     🔴 That used to be stated without the "usually", and as written it was
+ *     FALSE — civitai#3845 investigation 3. `throwDbError` maps a large slice of
+ *     Prisma codes to 4xx (P2000→400, P2025→404, P2003→409, P2024→408) while
+ *     copying the driver's own `message` verbatim, so a 4xx body could be a raw
+ *     `Invalid \`prisma.<model>.<method>()\` invocation` dump disclosing the table,
+ *     the column or the constraint name. Those are now caught by a SECOND
+ *     predicate, `isDriverAuthoredMessage`, applied inside the 4xx arm below: it
+ *     asks who WROTE the text rather than how severe the status is, keeps the
+ *     status, and — crucially — logs the un-redacted text on the way out, so the
+ *     "genericized exactly when logged" invariant holds for it too. A 4xx whose
+ *     message is ours is still passed through byte-identically.
  *   - **503** is the retryable transient-upstream mapping
  *     (`throwServiceUnavailableError`, the Meili/ClickHouse/orchestrator brownout
  *     guards). It fires in high-volume waves, so it is excluded from the error
@@ -316,6 +330,30 @@ export function handleEndpointError(res: NextApiResponse, e: unknown) {
       return res
         .status(status)
         .json(restErrorBody(REST_ERROR_CODE.INTERNAL_SERVER_ERROR, GENERIC_SERVER_ERROR_MESSAGE));
+    }
+    // ── DRIVER-AUTHORED 4xx — status kept, MESSAGE genericized ────────────────
+    // 🔴 civitai#3845 investigation 3. The arm below this one is correct for a
+    // message we wrote and wrong for one Postgres wrote. `throwDbError` forwards
+    // the driver's `message` verbatim and `prismaErrorToTrpcCode` sends a large
+    // slice of codes to 4xx, so `P2000 → 400` shipped the offending COLUMN,
+    // `P2003 → 409` the CONSTRAINT name and `P2025 → 404` the model + method.
+    //
+    // The discriminator is message IDENTITY against a driver error in the cause
+    // chain — NOT "is a driver error present". The chain test has a real false
+    // positive: `throwBadRequestError('That slug is already taken', dbError)`
+    // attaches the driver as `cause` while writing a message FOR the caller, and
+    // genericizing that would destroy good client feedback to redact nothing.
+    //
+    // Logged BEFORE genericizing, on purpose: this arm buys into exactly the same
+    // invariant as the 5xx arm — the un-redacted text leaves the wire precisely
+    // when it enters the log, so no message is ever destroyed outright. (That is
+    // also the reason 503 is left alone: it is NOT logged, so its response is the
+    // only copy — and no Prisma code maps to SERVICE_UNAVAILABLE, so nothing
+    // driver-authored can arrive as one.)
+    const generic = GENERIC_CLIENT_ERROR_BY_STATUS[status];
+    if (generic && status !== 503 && isDriverAuthoredMessage(apiError.message, apiError)) {
+      logRestServerFault(apiError);
+      return res.status(status).json(restErrorBody(generic.code, generic.message));
     }
     // ── CLIENT FEEDBACK (4xx) + 503 — passed through BYTE-IDENTICALLY ──────────
     // Older Zod-validation TRPCErrors stuff a JSON-encoded issue array into

--- a/src/server/utils/endpoint-helpers.ts
+++ b/src/server/utils/endpoint-helpers.ts
@@ -120,25 +120,46 @@ function isRestServerFault(status: number): boolean {
 }
 
 /**
- * Mark a genericized error response uncacheable.
+ * Mark an error response uncacheable. Applied to EVERY response this helper
+ * writes — there is no such thing as an error worth serving from a shared cache.
  *
  * 🔴 `PublicEndpoint` sets `Cache-Control: public, s-maxage=300,
  * stale-while-revalidate=150` on EVERY response, unconditionally, BEFORE the
  * handler runs — errors included. That was survivable while every failure on
  * those routes was a 5xx, because shared caches do not cache 5xx by default. It
  * stops being survivable the moment an error answers **404**: 404 IS in the
- * default cacheable set, so a `NOT_FOUND` produced by a transient condition
- * (replica lag, a `throwDbError`-mapped P2001/P2025) would be pinned at the edge
- * for 300s + 150s SWR — serving "no such thing" for five minutes after the thing
- * exists.
+ * default cacheable set, so a `NOT_FOUND` from a transient condition (replica
+ * lag, a `throwDbError`-mapped P2001/P2025) would be pinned at the edge for 300s
+ * + 150s SWR — serving "no such thing" for five minutes after the thing exists.
  *
- * This PR creates exactly that situation (`v1/content` 500 → real status, and the
- * driver-authored 4xx arm), so the genericized arms opt out. The route-level 503
- * arm in `v1/users/index.ts` already does the same thing for the same reason.
+ * 🔴 **An earlier version of this scoped the opt-out to the GENERICIZED arms, and
+ * that missed the case it was written for.** Measured, per arm, against a `res`
+ * pre-stamped with `PublicEndpoint`'s header:
  *
- * Deliberately NOT applied to the 4xx pass-through arm: that arm's headers are
- * byte-identical to pre-PR behaviour, and widening the change to responses this
- * PR does not otherwise touch would be scope this cannot claim to have tested.
+ *   pass-through 404 (`throwNotFoundError`)  →  public, s-maxage=300   ← the hazard
+ *   non-TRPCError 500 (else-branch)          →  public, s-maxage=300
+ *   genericized 5xx                          →  no-store
+ *
+ * The routes this change touches answer 404 mostly via `throwNotFoundError`,
+ * whose message is OURS — so it takes the pass-through arm and never reached the
+ * genericized one. Scoping by "did we rewrite the body" was the wrong axis; the
+ * right axis is "is this a response a cache should keep", and for an error the
+ * answer is always no.
+ *
+ * **Accepted trade:** a 404 flood (scrapers hitting bad slugs) now reaches the
+ * origin instead of being absorbed at the edge for 5 minutes. Correctness on a
+ * transient 404 is worth more than cache efficiency on an error path, and these
+ * routes are not the ones under that kind of load. Stated so the next person
+ * knows it was a decision, not an oversight.
+ *
+ * Uniform application also removes a **fault-classification oracle**: with the
+ * narrower version, `no-store` vs `s-maxage=300` on the same status told a caller
+ * whether the message had been rewritten — one bit of exactly the kind the 5xx
+ * arm's own comment says genericizing exists to remove.
+ *
+ * `v1/users/index.ts` and `v1/images/index.ts` already do this at their 503 arms.
+ * They emit bare `no-store` where this emits `no-store, max-age=0`; both are
+ * correct, and their tests pin the exact string, so they are left alone.
  */
 function noStore(res: NextApiResponse) {
   if (!res.headersSent) res.setHeader('Cache-Control', 'no-store, max-age=0');
@@ -351,7 +372,7 @@ export function handleEndpointError(res: NextApiResponse, e: unknown) {
     // navigated away), cancelling the request signal. Not a server fault: respond
     // 499 (client closed request) so it stays out of the 5xx SLO + the
     // civitai_app_http_errors_total counter and isn't logged as a spurious 500.
-    if (!res.headersSent) res.status(499).end();
+    if (!res.headersSent) noStore(res).status(499).end();
     return;
   }
   if (e instanceof TRPCError) {
@@ -430,7 +451,7 @@ export function handleEndpointError(res: NextApiResponse, e: unknown) {
     } catch {
       body = { message: apiError.message };
     }
-    return res.status(status).json(body);
+    return noStore(res).status(status).json(body);
   } else {
     const error = e as Error;
     // This branch increments the http-errors counter (via the wrapper's
@@ -455,7 +476,7 @@ export function handleEndpointError(res: NextApiResponse, e: unknown) {
     // above (structured, cause-walked, queryable in `_axiom`) — this genericizes
     // the RESPONSE only, never the LOG. Pinned by
     // `src/server/utils/__tests__/endpoint-helpers-error-envelope.test.ts`.
-    return res
+    return noStore(res)
       .status(500)
       .json(restErrorBody(REST_ERROR_CODE.INTERNAL_SERVER_ERROR, GENERIC_SERVER_ERROR_MESSAGE));
   }

--- a/src/server/utils/errorHandling.ts
+++ b/src/server/utils/errorHandling.ts
@@ -1,4 +1,8 @@
 import { Prisma } from '@prisma/client';
+// `pg` re-exports pg-protocol's DatabaseError; import it from `pg` because that
+// is the direct dependency — `pg-protocol` is transitive and is NOT hoisted under
+// this repo's pnpm layout, so importing it directly fails to resolve.
+import { DatabaseError } from 'pg';
 import { TRPCError } from '@trpc/server';
 import type { TRPC_ERROR_CODE_KEY } from '@trpc/server/rpc';
 import { isProd } from '~/env/other';
@@ -72,7 +76,83 @@ export function isPrismaForeignKeyViolation(error: unknown): boolean {
   return error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2003';
 }
 
-const prismaErrorToTrpcCode: Record<string, TRPC_ERROR_CODE_KEY> = {
+/** Is this specific object a database driver's own error? */
+function isDriverError(e: unknown): e is Error {
+  return (
+    e instanceof Prisma.PrismaClientKnownRequestError ||
+    e instanceof Prisma.PrismaClientUnknownRequestError ||
+    e instanceof Prisma.PrismaClientValidationError ||
+    e instanceof Prisma.PrismaClientInitializationError ||
+    e instanceof Prisma.PrismaClientRustPanicError ||
+    e instanceof DatabaseError
+  );
+}
+
+/**
+ * True when `message` is not merely ACCOMPANIED by a driver error but IS that
+ * driver error's own text — query/schema prose nobody wrote for a caller to read.
+ *
+ * 🔴 civitai#3845 investigation 3. `throwDbError` copies `error.message` verbatim
+ * into the TRPCError it throws, and `prismaErrorToTrpcCode` maps a large slice of
+ * Prisma codes to **4xx** statuses (P2000→400, P2001/P2015/P2018/P2025→404,
+ * P2002/P2003/P2004/P2014→409, P1008/P2024→408). `handleEndpointError` passes 4xx
+ * bodies through byte-identically on the stated grounds that "4xx is client
+ * feedback the caller is meant to read" — TRUE for a zod issue list or a
+ * hand-written "not found", FALSE for these, which reach the wire as e.g.
+ *
+ *   P2000 → 400  "…Invalid `prisma.appListing.create()` invocation… The provided
+ *                 value for the column is too long for the column's type.
+ *                 Column: app_listings.slug"
+ *   P2003 → 409  discloses the foreign-key CONSTRAINT name
+ *   P2025 → 404  discloses the model and the method
+ *
+ * 🔴 **Why message IDENTITY and not "is there a driver in the cause chain".** The
+ * chain test has a real false positive that would have destroyed good messages:
+ * `throwBadRequestError('That slug is already taken', dbError)` and
+ * `throwConflictError`/`throwRateLimitError`/`throwDbCustomError(msg)` all attach
+ * the driver error as `cause` while writing a message FOR the caller. Identity
+ * separates them by construction — if the text on the wire is byte-identical to
+ * the driver's own text, it is the driver's text, whoever forwarded it.
+ *
+ * The walk covers `cause` (that is where `throwDbError` puts the driver error) and
+ * the error itself (some sites reach the helper unwrapped). Depth 4 matches
+ * `isClientAbortError`: tRPC wraps once, a service layer may wrap again.
+ *
+ * `pg` is included deliberately and is the WORST case, not a hypothetical. A real
+ * `DatabaseError` carries its fields as ENUMERABLE own properties, so a `23505`
+ * unique violation serializes `detail: "Key (email)=(victim@example.com) already
+ * exists."` — an actual user row value — alongside `schema`, `table` and
+ * `constraint`. Kysely (`~/server/db/kyselyDb`) runs on that `pg` pool, so the
+ * class is not Prisma-only.
+ *
+ * NB this asks "who WROTE the text", not "how severe is it". A driver error mapped
+ * to a 4xx is still a legitimate 4xx — `handleEndpointError` keeps the STATUS and
+ * replaces only the MESSAGE.
+ *
+ * 🔴 **KNOWN GAP, deliberately not closed here.** A site that re-wraps a caught
+ * error's `.message` into a 4xx TRPCError *without* setting `cause` defeats this
+ * predicate — the wire text is the driver's, but nothing in the chain says so.
+ * There are 17 such sites (App Blocks + referral routers); the one-word fix is
+ * `cause: err`. They are enumerated and pinned by
+ * `rest-error-envelope-ledger.test.ts`, which fails if the set grows, so the gap
+ * is bounded and visible rather than silent.
+ */
+export function isDriverAuthoredMessage(message: string, e: unknown): boolean {
+  let cur = e as { cause?: unknown } | undefined;
+  for (let depth = 0; depth < 4 && cur; depth++) {
+    if (isDriverError(cur) && cur.message === message) return true;
+    cur = cur.cause as typeof cur;
+  }
+  return false;
+}
+
+/**
+ * Exported for `rest-error-envelope-ledger.test.ts`, which derives the set of 4xx
+ * statuses a driver-authored message can reach from THIS map rather than from a
+ * hand-copied list — so adding a mapping here cannot silently outrun
+ * `GENERIC_CLIENT_ERROR_BY_STATUS`.
+ */
+export const prismaErrorToTrpcCode: Record<string, TRPC_ERROR_CODE_KEY> = {
   P1008: 'TIMEOUT',
   P2000: 'BAD_REQUEST',
   P2001: 'NOT_FOUND',

--- a/src/server/utils/rest-error-envelope.ts
+++ b/src/server/utils/rest-error-envelope.ts
@@ -47,6 +47,8 @@
 export const REST_ERROR_CODE = {
   BAD_REQUEST: 'BAD_REQUEST',
   NOT_FOUND: 'NOT_FOUND',
+  CONFLICT: 'CONFLICT',
+  TIMEOUT: 'TIMEOUT',
   TOO_MANY_REQUESTS: 'TOO_MANY_REQUESTS',
   INTERNAL_SERVER_ERROR: 'INTERNAL_SERVER_ERROR',
 } as const;
@@ -61,6 +63,39 @@ export type RestErrorCode = (typeof REST_ERROR_CODE)[keyof typeof REST_ERROR_COD
  * `isRestServerFault` for which statuses that covers and why 503 is excluded.
  */
 export const GENERIC_SERVER_ERROR_MESSAGE = 'An unexpected error occurred';
+
+/**
+ * Replacement text for a **4xx** whose message turned out to be a database
+ * driver's own prose (civitai#3845 investigation 3 — see
+ * `isDriverAuthoredMessage`). The STATUS is kept, so the caller still learns what
+ * kind of failure this is; only the driver's query/schema text is dropped.
+ *
+ * 🔴 These strings must disclose nothing an attacker could not already infer from
+ * the status code itself — that is the entire point. They are deliberately less
+ * informative than the driver text they replace: the driver text was never written
+ * for a caller, and (unlike a 503 hint) it is NOT the only copy — genericizing a
+ * 4xx here also promotes it into the fault log, exactly as a 5xx does.
+ *
+ * Keyed by HTTP status because that is what `handleEndpointError` has in hand.
+ *
+ * 🔴 **The key set is a CLOSED LEDGER, and a test enforces it.** These four are
+ * exactly the 4xx statuses `prismaErrorToTrpcCode` can produce (400, 404, 408,
+ * 409). A status with no entry is left alone — i.e. unchanged from today — so the
+ * safety of this design rests entirely on the ledger staying complete. That is why
+ * `rest-error-envelope-ledger.test.ts` derives the reachable set from
+ * `prismaErrorToTrpcCode` itself and fails when this map's keys and that set
+ * disagree in EITHER direction: adding `P2031: 'FORBIDDEN'` upstream turns the
+ * test red instead of silently reopening the leak at 403.
+ */
+export const GENERIC_CLIENT_ERROR_BY_STATUS: Record<
+  number,
+  { code: RestErrorCode; message: string }
+> = {
+  400: { code: 'BAD_REQUEST', message: 'The request could not be processed' },
+  404: { code: 'NOT_FOUND', message: 'Not found' },
+  408: { code: 'TIMEOUT', message: 'The request timed out' },
+  409: { code: 'CONFLICT', message: 'The request conflicts with the current state' },
+};
 
 export type RestErrorBody = {
   error: unknown;

--- a/src/tests/api/rest-envelope-consolidation.test.ts
+++ b/src/tests/api/rest-envelope-consolidation.test.ts
@@ -1,0 +1,506 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * civitai#3845 **investigation 4** — the ~11 hand-rolled copies of the error
+ * envelope that do NOT go through `handleEndpointError`.
+ *
+ * PR #3850 fixed "population A" (the 14 routes that DO use the helper) and
+ * enumerated population B without fixing it, because patching 11 copies would
+ * keep the pattern alive to regrow. This suite covers the consolidation: every
+ * one of those routes now delegates, and the property is asserted **at the route**
+ * rather than only at the helper — the defect lived in the seam between them, and
+ * a helper-only test is blind to a route that never calls it.
+ *
+ * 🔴 Why the whole SERIALIZED BODY is asserted rather than one field: the old
+ * shapes leaked through four different keys — `error: err.message` (verbatim),
+ * `error` (the whole error OBJECT), `error: error.cause` (the wrapped driver
+ * error) and `cause: error` (the object under a second key). A per-field
+ * assertion would have passed on three of them.
+ *
+ * The driver errors are REAL (`Prisma.PrismaClientKnownRequestError`, `pg`'s
+ * `DatabaseError`) because that is the entire point: a plain `Error` has
+ * non-enumerable props and serializes to `{}`, which is exactly why the
+ * whole-object sites looked safe for years.
+ */
+
+const { mockLogToAxiom, mockBuildCentralErrorLog, mockWasServerFaultLogged } = vi.hoisted(() => ({
+  mockLogToAxiom: vi.fn().mockResolvedValue(undefined),
+  mockBuildCentralErrorLog: vi.fn((e: unknown) => ({
+    name: (e as Error)?.name,
+    message: (e as Error)?.message,
+  })),
+  mockWasServerFaultLogged: vi.fn(() => false),
+}));
+
+vi.mock('~/server/logging/client', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  logToAxiom: mockLogToAxiom,
+  buildCentralErrorLog: mockBuildCentralErrorLog,
+  wasServerFaultLogged: mockWasServerFaultLogged,
+}));
+
+// 🔴 Spread the ORIGINAL. `handleEndpointError` is the thing under test here, so
+// replacing this module wholesale with `{ PublicEndpoint: h => h }` — the pattern
+// the older route suites used — would make every route below call `undefined` and
+// fail for a reason that has nothing to do with the disclosure.
+vi.mock('~/server/utils/endpoint-helpers', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  PublicEndpoint: (handler: unknown) => handler,
+  AuthedEndpoint: (handler: unknown) => handler,
+}));
+
+const {
+  mockPublicApiContext2,
+  mockHasEntityAccess,
+  mockGetSessionUserById,
+  mockGetPaginatedVaultItems,
+  mockGetOrCreateVault,
+  mockToggleModelVersionOnVault,
+  mockPopulateNotificationDetails,
+  mockVaultItemFindMany,
+  mockModelVersionFindFirst,
+  mockTracker,
+} = vi.hoisted(() => ({
+  mockPublicApiContext2: vi.fn(),
+  mockHasEntityAccess: vi.fn(),
+  mockGetSessionUserById: vi.fn(),
+  mockGetPaginatedVaultItems: vi.fn(),
+  mockGetOrCreateVault: vi.fn(),
+  mockToggleModelVersionOnVault: vi.fn(),
+  mockPopulateNotificationDetails: vi.fn(),
+  mockVaultItemFindMany: vi.fn(),
+  mockModelVersionFindFirst: vi.fn(),
+  mockTracker: vi.fn(),
+}));
+
+vi.mock('~/server/createContext', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  publicApiContext2: mockPublicApiContext2,
+}));
+vi.mock('~/server/services/common.service', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  hasEntityAccess: mockHasEntityAccess,
+}));
+vi.mock('~/server/auth/session-client', () => ({
+  sessionClient: { getSessionUserById: mockGetSessionUserById },
+}));
+vi.mock('~/server/services/vault.service', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getPaginatedVaultItems: mockGetPaginatedVaultItems,
+  getOrCreateVault: mockGetOrCreateVault,
+  toggleModelVersionOnVault: mockToggleModelVersionOnVault,
+}));
+vi.mock('~/server/notifications/detail-fetchers', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  populateNotificationDetails: mockPopulateNotificationDetails,
+}));
+vi.mock('~/server/db/client', () => ({
+  dbRead: {
+    vaultItem: { findMany: mockVaultItemFindMany },
+    modelVersion: { findFirst: mockModelVersionFindFirst },
+    partner: { findUnique: vi.fn() },
+  },
+  dbWrite: {},
+}));
+vi.mock('~/server/clickhouse/client', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  Tracker: mockTracker,
+}));
+
+import { Prisma } from '@prisma/client';
+import { DatabaseError } from 'pg';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import type { SessionUser } from '~/types/session';
+
+import creatorsHandler from '~/pages/api/v1/creators';
+import tagsHandler from '~/pages/api/v1/tags';
+import usersHandler from '~/pages/api/v1/users/index';
+import contentHandler from '~/pages/api/v1/content/[[...slug]]';
+import permissionsHandler from '~/pages/api/v1/permissions/check';
+import vaultAllRoute from '~/pages/api/v1/vault/all';
+import vaultGetRoute from '~/pages/api/v1/vault/get';
+import vaultCheckRoute from '~/pages/api/v1/vault/check-vault';
+import vaultToggleRoute from '~/pages/api/v1/vault/toggle-version';
+import notificationDetailsRoute from '~/pages/api/notification/getDetails';
+import runHandler from '~/pages/api/run/[modelVersionId]';
+
+/**
+ * `AuthedEndpoint` is mocked to an identity function above, so these modules
+ * export their INNER 3-arg handler at runtime while TypeScript still sees the
+ * wrapper's 2-arg signature. Cast once, here, rather than at each call site.
+ */
+type AuthedHandler = (
+  req: NextApiRequest,
+  res: NextApiResponse,
+  user: SessionUser
+) => Promise<unknown>;
+const vaultAllHandler = vaultAllRoute as unknown as AuthedHandler;
+const vaultGetHandler = vaultGetRoute as unknown as AuthedHandler;
+const vaultCheckHandler = vaultCheckRoute as unknown as AuthedHandler;
+const vaultToggleHandler = vaultToggleRoute as unknown as AuthedHandler;
+const notificationDetailsHandler = notificationDetailsRoute as unknown as AuthedHandler;
+
+// ── The payloads. Both are REAL driver errors, not stand-ins. ────────────────
+const LEAKED_TABLE = 'app_collaborators';
+const LEAKED_COLUMN = 'app_listing_id';
+const CLIENT_VERSION = '6.13.0';
+const VICTIM_EMAIL = 'victim@example.com';
+
+/**
+ * The exact error class and code from the #3845 incident. Its own props are
+ * ENUMERABLE, so `JSON.stringify({ error })` yields
+ * `{"code":"P2022","meta":{"column":"app_collaborators.app_listing_id"},…}`.
+ */
+function prismaDriverError() {
+  return new Prisma.PrismaClientKnownRequestError(
+    `\nInvalid \`prisma.appCollaborator.findMany()\` invocation:\n\nThe column \`${LEAKED_TABLE}.${LEAKED_COLUMN}\` does not exist in the current database.`,
+    { code: 'P2022', clientVersion: CLIENT_VERSION, meta: { column: `${LEAKED_TABLE}.${LEAKED_COLUMN}` } }
+  );
+}
+
+/**
+ * A real `pg` unique violation. `detail` on a 23505 quotes the offending row
+ * VALUE — here a user's email address — and every field is enumerable, so a
+ * whole-object envelope puts actual user data on the wire.
+ */
+function pgDriverError() {
+  const e = new DatabaseError(
+    'duplicate key value violates unique constraint "User_email_key"',
+    100,
+    'error'
+  );
+  Object.assign(e, {
+    severity: 'ERROR',
+    code: '23505',
+    detail: `Key (email)=(${VICTIM_EMAIL}) already exists.`,
+    schema: 'public',
+    table: 'User',
+    constraint: 'User_email_key',
+  });
+  return e;
+}
+
+const PRISMA_SECRETS = [
+  LEAKED_TABLE,
+  LEAKED_COLUMN,
+  'appCollaborator',
+  'findMany',
+  'prisma.',
+  'invocation',
+  'P2022',
+  CLIENT_VERSION,
+];
+
+const PG_SECRETS = [
+  VICTIM_EMAIL,
+  'Key (email)',
+  'User_email_key',
+  'duplicate key value',
+  '23505',
+  'User_email',
+];
+
+function createMocks({
+  query = {},
+  body = {},
+  method = 'GET',
+}: { query?: Record<string, unknown>; body?: unknown; method?: string } = {}) {
+  const req = {
+    method,
+    url: '/api/test',
+    headers: { host: 'civitai.com' },
+    query,
+    body,
+  } as unknown as NextApiRequest;
+
+  let statusCode = 200;
+  let payload: unknown;
+  let headersSent = false;
+  const res = {
+    status(c: number) {
+      statusCode = c;
+      return res;
+    },
+    json(b: unknown) {
+      payload = b;
+      headersSent = true;
+      return res;
+    },
+    setHeader() {
+      return res;
+    },
+    redirect() {
+      headersSent = true;
+      return res;
+    },
+    end() {
+      headersSent = true;
+      return res;
+    },
+    get headersSent() {
+      return headersSent;
+    },
+    _status: () => statusCode,
+    _json: () => payload,
+  };
+  return { req, res: res as unknown as NextApiResponse & typeof res };
+}
+
+const USER = { id: 1, username: 'zach' } as unknown as SessionUser;
+
+/**
+ * Every route in population B, with the ONE dependency whose failure used to be
+ * serialized into the response, and the shape it used to be serialized in.
+ *
+ * 🔴 This list is also a LEDGER. `rest-error-envelope-ledger.test.ts` asserts that
+ * no file under `src/pages/api` hand-rolls the envelope any more, so a new copy
+ * fails there; this list is what proves the ones we already know about actually
+ * BEHAVE, rather than merely no longer matching a grep.
+ */
+const ROUTES = [
+  {
+    name: 'GET /api/v1/creators',
+    oldShape: 'error: <whole object> (else-branch) / raw driver text (TRPCError branch)',
+    run: (throwing: () => never) => {
+      mockPublicApiContext2.mockResolvedValue({ user: { getCreators: throwing } });
+      const { req, res } = createMocks({ query: {} });
+      return { promise: creatorsHandler(req, res), res };
+    },
+  },
+  {
+    name: 'GET /api/v1/tags',
+    oldShape: 'error: <whole object>',
+    run: (throwing: () => never) => {
+      mockPublicApiContext2.mockResolvedValue({ tag: { getAll: throwing } });
+      const { req, res } = createMocks({ query: {} });
+      return { promise: tagsHandler(req, res), res };
+    },
+  },
+  {
+    name: 'GET /api/v1/users',
+    oldShape: 'error: err.message (verbatim)',
+    run: (throwing: () => never) => {
+      mockPublicApiContext2.mockResolvedValue({ user: { getAll: throwing } });
+      const { req, res } = createMocks({ query: {} });
+      return { promise: usersHandler(req, res), res };
+    },
+  },
+  {
+    name: 'GET /api/v1/content/[[...slug]]',
+    oldShape: 'error: error.cause (the WRAPPED driver error)',
+    run: (throwing: () => never) => {
+      mockPublicApiContext2.mockResolvedValue({ content: { get: throwing } });
+      const { req, res } = createMocks({ query: { slug: ['tos'] } });
+      return { promise: contentHandler(req, res), res };
+    },
+  },
+  {
+    name: 'GET /api/v1/permissions/check',
+    oldShape: 'error: <whole object>',
+    run: (throwing: () => never) => {
+      mockGetSessionUserById.mockResolvedValue(null);
+      mockHasEntityAccess.mockImplementation(throwing);
+      const { req, res } = createMocks({ query: { entityIds: '1,2' } });
+      return { promise: permissionsHandler(req, res), res };
+    },
+  },
+  {
+    name: 'GET /api/v1/vault/all',
+    oldShape: 'error: <whole object>',
+    run: (throwing: () => never) => {
+      mockGetPaginatedVaultItems.mockImplementation(throwing);
+      const { req, res } = createMocks({ query: {} });
+      return { promise: vaultAllHandler(req, res, USER), res };
+    },
+  },
+  {
+    name: 'GET /api/v1/vault/get',
+    oldShape: 'error: <whole object>',
+    run: (throwing: () => never) => {
+      mockGetOrCreateVault.mockImplementation(throwing);
+      const { req, res } = createMocks({ query: {} });
+      return { promise: vaultGetHandler(req, res, USER), res };
+    },
+  },
+  {
+    name: 'GET /api/v1/vault/check-vault',
+    oldShape: 'error: <whole object>',
+    run: (throwing: () => never) => {
+      mockVaultItemFindMany.mockImplementation(throwing);
+      const { req, res } = createMocks({ query: { modelVersionIds: '1,2' } });
+      return { promise: vaultCheckHandler(req, res, USER), res };
+    },
+  },
+  {
+    name: 'POST /api/v1/vault/toggle-version',
+    oldShape: 'error: <whole object>',
+    run: (throwing: () => never) => {
+      mockToggleModelVersionOnVault.mockImplementation(throwing);
+      const { req, res } = createMocks({ query: { modelVersionId: '1' }, method: 'POST' });
+      return { promise: vaultToggleHandler(req, res, USER), res };
+    },
+  },
+  {
+    name: 'POST /api/notification/getDetails',
+    oldShape: 'error: <whole object>',
+    run: (throwing: () => never) => {
+      mockPopulateNotificationDetails.mockImplementation(throwing);
+      const { req, res } = createMocks({
+        method: 'POST',
+        body: { id: 1, type: 'comment', details: {}, category: null },
+      });
+      return { promise: notificationDetailsHandler(req, res, USER), res };
+    },
+  },
+  {
+    name: 'GET /api/run/[modelVersionId]',
+    oldShape: 'cause: <whole object> (under a SECOND key, next to a generic `error`)',
+    run: (throwing: () => never) => {
+      mockModelVersionFindFirst.mockResolvedValue({
+        id: 1,
+        model: { id: 1, name: 'm', type: 'Checkpoint', nsfw: false },
+        name: 'v1',
+        trainedWords: [],
+        runStrategies: [{ url: 'https://partner.example/run', partner: { id: 1, name: 'p' } }],
+      });
+      // 🔴 Must be a `function`, not an arrow, and must throw from `partnerEvent`
+      // rather than from the constructor. An arrow `mockImplementation` makes
+      // `new Tracker(...)` raise `TypeError: … is not a constructor` — a DIFFERENT
+      // error that also genericizes, so the three disclosure assertions below went
+      // green without ever carrying the driver payload. The log-attribution
+      // assertion is what exposed that.
+      mockTracker.mockImplementation(function (this: unknown) {
+        return { partnerEvent: throwing };
+      });
+      const { req, res } = createMocks({ query: { modelVersionId: '1' } });
+      return { promise: runHandler(req, res), res };
+    },
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWasServerFaultLogged.mockReturnValue(false);
+});
+
+describe('civitai#3845/4 — no REST route hand-rolls a driver-leaking error envelope', () => {
+  describe.each(ROUTES)('$name (was: $oldShape)', ({ run }) => {
+    it('does NOT disclose Prisma driver, table or column detail', async () => {
+      const throwing = (() => {
+        throw prismaDriverError();
+      }) as () => never;
+      const { promise, res } = run(throwing);
+      await promise;
+
+      const serialized = JSON.stringify(res._json());
+      for (const secret of PRISMA_SECRETS) {
+        expect(
+          serialized,
+          `must not disclose ${JSON.stringify(secret)} — full body was ${serialized}`
+        ).not.toContain(secret);
+      }
+    });
+
+    it('does NOT disclose a pg unique-violation detail (an actual user row value)', async () => {
+      const throwing = (() => {
+        throw pgDriverError();
+      }) as () => never;
+      const { promise, res } = run(throwing);
+      await promise;
+
+      const serialized = JSON.stringify(res._json());
+      for (const secret of PG_SECRETS) {
+        expect(
+          serialized,
+          `must not disclose ${JSON.stringify(secret)} — full body was ${serialized}`
+        ).not.toContain(secret);
+      }
+    });
+
+    it('still answers 5xx with the shared envelope (code + string message + error)', async () => {
+      const throwing = (() => {
+        throw prismaDriverError();
+      }) as () => never;
+      const { promise, res } = run(throwing);
+      await promise;
+
+      expect(res._status()).toBeGreaterThanOrEqual(400);
+      const body = res._json() as Record<string, unknown>;
+      expect(body.code, 'the envelope discriminator must be present').toBeTypeOf('string');
+      // The Go CLI decodes `message` into a `Message string`; a non-string fails
+      // the whole envelope unmarshal.
+      expect(typeof body.message).toBe('string');
+      // …and it renders `error` in PREFERENCE to `message`, so an empty `error`
+      // empties every CLI-rendered error string.
+      expect(body.error).toBeTruthy();
+    });
+
+    it('attributes the fault in the log — genericizing relocates the text, never destroys it', async () => {
+      const throwing = (() => {
+        throw prismaDriverError();
+      }) as () => never;
+      const { promise } = run(throwing);
+      await promise;
+
+      expect(mockLogToAxiom, 'the un-redacted text must reach `_axiom`').toHaveBeenCalledTimes(1);
+      const logged = mockLogToAxiom.mock.calls[0][0] as { message?: string };
+      expect(logged.message).toContain(LEAKED_COLUMN);
+    });
+  });
+
+  // ── Route-specific behaviour the delegation must NOT have broken ────────────
+  it('v1/users keeps its transient-search 503, ahead of the delegation', async () => {
+    const { TRPCError } = await import('@trpc/server');
+    mockPublicApiContext2.mockResolvedValue({
+      user: {
+        getAll: () => {
+          throw new TRPCError({
+            code: 'SERVICE_UNAVAILABLE',
+            message: 'User search is temporarily overloaded — please retry.',
+          });
+        },
+      },
+    });
+    const { req, res } = createMocks({ query: { query: 'heidi' } });
+    await usersHandler(req, res);
+
+    expect(res._status()).toBe(503);
+    expect(res._json()).toEqual({
+      error: 'User search is temporarily overloaded — please retry.',
+    });
+  });
+
+  it('v1/users answers 499 for a client abort, NOT the 503 (ordering guard)', async () => {
+    // The abort check runs first precisely because an aborted Meili call can look
+    // transient. Without the ordering this returns 503 + Retry-After to a client
+    // that has already gone away.
+    mockPublicApiContext2.mockResolvedValue({
+      user: {
+        getAll: () => {
+          throw new Error('The operation was aborted');
+        },
+      },
+    });
+    const { req, res } = createMocks({ query: { query: 'heidi' } });
+    await usersHandler(req, res);
+
+    expect(res._status()).toBe(499);
+    expect(res._json()).toBeUndefined();
+  });
+
+  it('vault/all keeps its MEMBERSHIP_REQUIRED 200 arm, ahead of the delegation', async () => {
+    const { TRPCError } = await import('@trpc/server');
+    mockGetPaginatedVaultItems.mockRejectedValue(
+      new TRPCError({
+        code: 'FORBIDDEN',
+        message: 'nope',
+        cause: new Error('MEMBERSHIP_REQUIRED'),
+      })
+    );
+    const { req, res } = createMocks({ query: {} });
+    await vaultAllHandler(req, res, USER);
+
+    expect(res._status()).toBe(200);
+    expect(res._json()).toEqual({ vault: null });
+  });
+});

--- a/src/tests/api/rest-envelope-consolidation.test.ts
+++ b/src/tests/api/rest-envelope-consolidation.test.ts
@@ -154,7 +154,11 @@ const VICTIM_EMAIL = 'victim@example.com';
 function prismaDriverError() {
   return new Prisma.PrismaClientKnownRequestError(
     `\nInvalid \`prisma.appCollaborator.findMany()\` invocation:\n\nThe column \`${LEAKED_TABLE}.${LEAKED_COLUMN}\` does not exist in the current database.`,
-    { code: 'P2022', clientVersion: CLIENT_VERSION, meta: { column: `${LEAKED_TABLE}.${LEAKED_COLUMN}` } }
+    {
+      code: 'P2022',
+      clientVersion: CLIENT_VERSION,
+      meta: { column: `${LEAKED_TABLE}.${LEAKED_COLUMN}` },
+    }
   );
 }
 

--- a/src/tests/api/rest-envelope-consolidation.test.ts
+++ b/src/tests/api/rest-envelope-consolidation.test.ts
@@ -470,21 +470,40 @@ describe('civitai#3845/4 — no REST route hand-rolls a driver-leaking error env
     });
   });
 
-  it('v1/users answers 499 for a client abort, NOT the 503 (ordering guard)', async () => {
-    // The abort check runs first precisely because an aborted Meili call can look
-    // transient. Without the ordering this returns 503 + Retry-After to a client
-    // that has already gone away.
+  it('v1/users answers 499 for a client abort that ALSO looks transient (ordering guard)', async () => {
+    // 🔴 This guard must be REACHABLE, not merely breakable. An earlier version
+    // threw a bare `new Error('The operation was aborted')` — which satisfies
+    // `isClientAbortError` but NOT `isTransientMeiliError`, so the 503 arm could
+    // never have fired for it and the test passed with the ordering REVERSED.
+    // Mutating `if (!isClientAbortError(error))` to `if (true)` — i.e. restoring
+    // the exact pre-PR order this test exists to pin — left the suite green.
+    //
+    // The shape below satisfies BOTH predicates, which is the only way into the
+    // branch. It is the real prod shape, not a contrivance: meilisearch-js's
+    // `request()` catch re-wraps a failed fetch as `MeiliSearchCommunicationError`
+    // preserving `name` and the original `message`, and
+    // `isTransientMeiliError` returns true for that name once `code`/`errno` is a
+    // string (`meilisearch/client.ts` — the network-level branch). An aborted
+    // fetch is exactly how that arises.
+    //
+    // Without the ordering, a client that has ALREADY GONE AWAY is answered
+    // 503 + `Retry-After: 2` + `Cache-Control: no-store`, and the abort is
+    // counted as a search brownout.
+    const abortedMeiliCall = Object.assign(new Error('The operation was aborted'), {
+      name: 'MeiliSearchCommunicationError',
+      code: 'ECONNRESET',
+    });
     mockPublicApiContext2.mockResolvedValue({
       user: {
         getAll: () => {
-          throw new Error('The operation was aborted');
+          throw abortedMeiliCall;
         },
       },
     });
     const { req, res } = createMocks({ query: { query: 'heidi' } });
     await usersHandler(req, res);
 
-    expect(res._status()).toBe(499);
+    expect(res._status(), 'a departed client gets 499, never the transient-search 503').toBe(499);
     expect(res._json()).toBeUndefined();
   });
 

--- a/src/tests/api/v1/creators.test.ts
+++ b/src/tests/api/v1/creators.test.ts
@@ -45,6 +45,8 @@ function createMocks({ query = {} }: { query?: Record<string, string | string[]>
   let payload: any = undefined;
   let ended = false;
 
+  const headers: Record<string, unknown> = {};
+
   const res = {
     headersSent: false,
     status(code: number) {
@@ -55,14 +57,25 @@ function createMocks({ query = {} }: { query?: Record<string, string | string[]>
       payload = body;
       return res;
     },
+    // Required since the route delegates to `handleEndpointError`, which marks a
+    // genericized error response `no-store` (civitai#3845/4). Its absence here
+    // surfaced as `TypeError: res.setHeader is not a function` in the full suite —
+    // a fixture gap, not a production one, but the header IS asserted below so the
+    // stub cannot quietly swallow a regression.
+    setHeader(key: string, value: unknown) {
+      headers[key] = value;
+      return res;
+    },
     end() {
       ended = true;
       return res;
     },
+    _getHeader: (k: string) => headers[k],
     _getStatusCode: () => statusCode,
     _getJSONData: () => payload,
     _ended: () => ended,
   } as unknown as NextApiResponse & {
+    _getHeader: (k: string) => unknown;
     _getStatusCode: () => number;
     _getJSONData: () => any;
     _ended: () => boolean;
@@ -175,6 +188,9 @@ describe('/api/v1/creators error-body JSON.parse guard', () => {
       message: 'An unexpected error occurred',
       error: 'An unexpected error occurred',
     });
+    // `PublicEndpoint` stamps `public, s-maxage=300` on every response before the
+    // handler runs, errors included. A genericized error must opt out.
+    expect(res._getHeader('Cache-Control')).toBe('no-store, max-age=0');
   });
 
   it('client abort (499) branch is unchanged — ends without a body', async () => {

--- a/src/tests/api/v1/creators.test.ts
+++ b/src/tests/api/v1/creators.test.ts
@@ -17,7 +17,13 @@ vi.mock('~/server/createContext', () => ({
 }));
 
 // PublicEndpoint is a simple passthrough wrapper in tests.
-vi.mock('~/server/utils/endpoint-helpers', () => ({
+// 🔴 Spread the ORIGINAL. This handler's catch now delegates to
+// `handleEndpointError` (civitai#3845/4 — the hand-rolled envelope it used to
+// carry leaked driver text), so replacing the module wholesale with a one-key
+// object makes the route call `undefined` and fail for a reason unrelated to
+// what this suite tests.
+vi.mock('~/server/utils/endpoint-helpers', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   PublicEndpoint: (handler: any) => handler,
 }));
 
@@ -144,8 +150,16 @@ describe('/api/v1/creators error-body JSON.parse guard', () => {
     // The real prod non-transient shape: a Prisma/app failure becomes a TRPCError
     // INTERNAL_SERVER_ERROR whose `message` is a bare string, NOT JSON. Against the
     // UN-hardened handler `JSON.parse('Database connection lost')` throws a
-    // SyntaxError that escapes the catch → raw unhandled Next 500. The hardened
-    // handler falls back to { message } with the correct HTTP status.
+    // SyntaxError that escapes the catch → raw unhandled Next 500. The point of
+    // this test is that no input shape can produce that throw; it still holds.
+    //
+    // 🔴 The BODY assertion changed with civitai#3845/4. It used to read
+    // `toEqual({ message: 'Database connection lost' })` — i.e. it PINNED the
+    // driver text reaching an unauthenticated caller. This route now delegates to
+    // `handleEndpointError`, which genericizes every 5xx and logs the un-redacted
+    // text instead. The generic body is asserted by VALUE (not just "some 500") so
+    // a regression that re-widens it fails here as well as in
+    // `src/tests/api/rest-envelope-consolidation.test.ts`.
     const dbError = new TRPCError({
       code: 'INTERNAL_SERVER_ERROR',
       message: 'Database connection lost',
@@ -156,7 +170,11 @@ describe('/api/v1/creators error-body JSON.parse guard', () => {
     await expect(handler(req, res)).resolves.toBeUndefined();
 
     expect(res._getStatusCode()).toBe(500);
-    expect(res._getJSONData()).toEqual({ message: 'Database connection lost' });
+    expect(res._getJSONData()).toEqual({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'An unexpected error occurred',
+      error: 'An unexpected error occurred',
+    });
   });
 
   it('client abort (499) branch is unchanged — ends without a body', async () => {

--- a/src/tests/api/v1/tags.test.ts
+++ b/src/tests/api/v1/tags.test.ts
@@ -48,6 +48,8 @@ function createMocks({ query = {} }: { query?: Record<string, string | string[]>
   let payload: any = undefined;
   let ended = false;
 
+  const headers: Record<string, unknown> = {};
+
   const res = {
     headersSent: false,
     status(code: number) {
@@ -58,14 +60,25 @@ function createMocks({ query = {} }: { query?: Record<string, string | string[]>
       payload = body;
       return res;
     },
+    // Required since the route delegates to `handleEndpointError`, which marks a
+    // genericized error response `no-store` (civitai#3845/4). Its absence here
+    // surfaced as `TypeError: res.setHeader is not a function` in the full suite —
+    // a fixture gap, not a production one, but the header IS asserted below so the
+    // stub cannot quietly swallow a regression.
+    setHeader(key: string, value: unknown) {
+      headers[key] = value;
+      return res;
+    },
     end() {
       ended = true;
       return res;
     },
+    _getHeader: (k: string) => headers[k],
     _getStatusCode: () => statusCode,
     _getJSONData: () => payload,
     _ended: () => ended,
   } as unknown as NextApiResponse & {
+    _getHeader: (k: string) => unknown;
     _getStatusCode: () => number;
     _getJSONData: () => any;
     _ended: () => boolean;
@@ -141,6 +154,9 @@ describe('/api/v1/tags error-body JSON.parse guard', () => {
       message: 'An unexpected error occurred',
       error: 'An unexpected error occurred',
     });
+    // `PublicEndpoint` stamps `public, s-maxage=300` on every response before the
+    // handler runs, errors included. A genericized error must opt out.
+    expect(res._getHeader('Cache-Control')).toBe('no-store, max-age=0');
   });
 
   it('client abort (499) branch is unchanged — ends without a body', async () => {

--- a/src/tests/api/v1/tags.test.ts
+++ b/src/tests/api/v1/tags.test.ts
@@ -16,7 +16,13 @@ vi.mock('~/server/createContext', () => ({
 }));
 
 // PublicEndpoint is a simple passthrough wrapper in tests.
-vi.mock('~/server/utils/endpoint-helpers', () => ({
+// 🔴 Spread the ORIGINAL. This handler's catch now delegates to
+// `handleEndpointError` (civitai#3845/4 — the hand-rolled envelope it used to
+// carry leaked driver text), so replacing the module wholesale with a one-key
+// object makes the route call `undefined` and fail for a reason unrelated to
+// what this suite tests.
+vi.mock('~/server/utils/endpoint-helpers', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   PublicEndpoint: (handler: any) => handler,
 }));
 
@@ -110,8 +116,16 @@ describe('/api/v1/tags error-body JSON.parse guard', () => {
     // The real prod non-transient shape: a Prisma/app failure becomes a TRPCError
     // INTERNAL_SERVER_ERROR whose `message` is a bare string, NOT JSON. Against the
     // UN-hardened handler `JSON.parse('Database connection lost')` throws a
-    // SyntaxError that escapes the catch → raw unhandled Next 500. The hardened
-    // handler falls back to { message } with the correct HTTP status.
+    // SyntaxError that escapes the catch → raw unhandled Next 500. The point of
+    // this test is that no input shape can produce that throw; it still holds.
+    //
+    // 🔴 The BODY assertion changed with civitai#3845/4. It used to read
+    // `toEqual({ message: 'Database connection lost' })` — i.e. it PINNED the
+    // driver text reaching an unauthenticated caller. This route now delegates to
+    // `handleEndpointError`, which genericizes every 5xx and logs the un-redacted
+    // text instead. The generic body is asserted by VALUE (not just "some 500") so
+    // a regression that re-widens it fails here as well as in
+    // `src/tests/api/rest-envelope-consolidation.test.ts`.
     const dbError = new TRPCError({
       code: 'INTERNAL_SERVER_ERROR',
       message: 'Database connection lost',
@@ -122,7 +136,11 @@ describe('/api/v1/tags error-body JSON.parse guard', () => {
     await expect(handler(req, res)).resolves.toBeUndefined();
 
     expect(res._getStatusCode()).toBe(500);
-    expect(res._getJSONData()).toEqual({ message: 'Database connection lost' });
+    expect(res._getJSONData()).toEqual({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'An unexpected error occurred',
+      error: 'An unexpected error occurred',
+    });
   });
 
   it('client abort (499) branch is unchanged — ends without a body', async () => {

--- a/src/tests/api/v1/users/index.test.ts
+++ b/src/tests/api/v1/users/index.test.ts
@@ -17,7 +17,13 @@ vi.mock('~/server/createContext', () => ({
 }));
 
 // Mock PublicEndpoint to be a simple passthrough wrapper (same as the images test).
-vi.mock('~/server/utils/endpoint-helpers', () => ({
+// 🔴 Spread the ORIGINAL. This handler's catch now delegates to
+// `handleEndpointError` (civitai#3845/4 — the hand-rolled envelope it used to
+// carry leaked driver text), so replacing the module wholesale with a one-key
+// object makes the route call `undefined` and fail for a reason unrelated to
+// what this suite tests.
+vi.mock('~/server/utils/endpoint-helpers', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   PublicEndpoint: (handler: any) => handler,
 }));
 
@@ -190,9 +196,16 @@ describe('/api/v1/users transient-upstream 503 reclassification', () => {
     // INTERNAL_SERVER_ERROR whose `message` is a bare string, NOT JSON. Against
     // the UN-hardened handler this hits `JSON.parse('Database connection lost')`
     // → SyntaxError → the throw escapes the catch → a raw unhandled Next 500 (the
-    // original failure mode, still live for the non-transient subset). The
-    // hardened handler falls back to the { error, code } shape with the correct
-    // HTTP status — a clean 500, never a throw, never a 503.
+    // original failure mode, still live for the non-transient subset). No input
+    // shape may produce that throw; that is still what this test is for.
+    //
+    // 🔴 The BODY assertion changed with civitai#3845/4. It used to read
+    // `{ error: 'Database connection lost', code: 'INTERNAL_SERVER_ERROR' }` — i.e.
+    // it PINNED the driver text reaching an unauthenticated caller through the
+    // field the Go CLI renders in PREFERENCE to `message`. The route now delegates
+    // to `handleEndpointError`, which genericizes every 5xx and logs the
+    // un-redacted text instead. `code` survives unchanged, so a client branching
+    // on it is unaffected.
     const dbError = new TRPCError({
       code: 'INTERNAL_SERVER_ERROR',
       message: 'Database connection lost',
@@ -205,7 +218,8 @@ describe('/api/v1/users transient-upstream 503 reclassification', () => {
 
     expect(res._getStatusCode()).toBe(500);
     expect(res._getJSONData()).toEqual({
-      error: 'Database connection lost',
+      error: 'An unexpected error occurred',
+      message: 'An unexpected error occurred',
       code: 'INTERNAL_SERVER_ERROR',
     });
     expect(res._getHeader('Retry-After')).toBeUndefined();
@@ -220,9 +234,14 @@ describe('/api/v1/users transient-upstream 503 reclassification', () => {
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(500);
+    // 🔴 civitai#3845/4: `error` used to carry `'cannot read properties of
+    // undefined'` verbatim. A null-deref message is not itself sensitive, but the
+    // SAME field carried raw Prisma invocation text on the driver-error path — the
+    // leak is the field, not the value, so it is genericized unconditionally.
     expect(res._getJSONData()).toEqual({
       message: 'An unexpected error occurred',
-      error: 'cannot read properties of undefined',
+      error: 'An unexpected error occurred',
+      code: 'INTERNAL_SERVER_ERROR',
     });
     expect(res._getHeader('Retry-After')).toBeUndefined();
   });


### PR DESCRIPTION
Follow-up to #3850, which fixed the `handleEndpointError` disclosure (#3845) and **enumerated two remaining populations without fixing them**, on the explicit reasoning that a security fix should not carry an 11-file refactor. This is those two, as two separable commits.

Both are the same defect class — **text a database driver wrote, served to a caller it was never written for** — and both are closed at one chokepoint rather than at N call sites.

---

## Why this is severity, not tidiness

The whole-object envelopes have looked safe for years because a plain `Error` has **non-enumerable** props and serializes to `{}`. A real driver error does not. Red control on `origin/main`, verbatim from the test output — this is a live public product's response body:

```json
{"message":"An unexpected error occurred",
 "error":{"length":100,"name":"error","severity":"ERROR","code":"23505",
          "detail":"Key (email)=(victim@example.com) already exists.",
          "schema":"public","table":"User","constraint":"User_email_key"}}
```

That `detail` is an **actual user row value**. `pg`'s `DatabaseError` is reachable via Kysely (`~/server/db/kyselyDb` runs on the `pg` pool), so this is not Prisma-only. Measured with a real `DatabaseError`, not reasoned about.

---

## Commit 1 — driver-authored text at a **4xx** (#3845 investigation 3)

`handleEndpointError` genericizes every 5xx and passes 4xx through byte-identically, justified in `isRestServerFault` by *"4xx is client feedback the caller is meant to read"*.

🔴 **That comment was false**, and is corrected here. `throwDbError` copies the driver's `message` verbatim, and `prismaErrorToTrpcCode` sends a large slice of codes to 4xx:

| code | status | what shipped |
|---|---|---|
| `P2000` | 400 | the offending **column** (`app_listings.slug`) |
| `P2003` | 409 | the foreign-key **constraint** name |
| `P2025` | 404 | the **model** and **method** |
| `P2024` | 408 | the connection-pool shape |

all carrying the raw ``Invalid `prisma.<model>.<method>()` invocation`` preamble, on public unauthenticated routes.

**The fix keeps the STATUS and replaces only the MESSAGE** — a driver error mapped to 404 really is a 404 — and **logs the un-redacted text on the way out**. That last part is load-bearing, not incidental: it buys the 4xx arm exactly the invariant the 5xx arm already has —

> the un-redacted text leaves the wire **exactly when** it enters the log, so genericizing can never destroy the only copy of a message.

503 is still untouched, for the mirror-image reason: it is *excluded* from the fault log, so its response **is** the only copy, and no Prisma code maps to `SERVICE_UNAVAILABLE`.

### The discriminator is message IDENTITY, not "is a driver in the cause chain"

The chain test has a **real false positive** that would have destroyed good messages: `throwBadRequestError('That slug is already taken', dbError)` — and `throwConflictError` / `throwRateLimitError` / `throwDbCustomError(msg)` — all attach the driver as `cause` while writing a message *for* the caller. Genericizing those redacts nothing and costs the user real feedback.

`isDriverAuthoredMessage(message, e)` instead asks whether the text on the wire **is byte-identical to a driver error's own text**. That separates the two by construction, whoever forwarded it. A test pins the false-positive case.

---

## Commit 2 — the 11 hand-rolled envelopes (#3845 investigation 4)

Population B leaked through **four different shapes**, which is why a per-field assertion would have missed most of them:

| shape | what it serialized | sites |
|---|---|---|
| `error: err.message` | verbatim driver text | `v1/users` |
| `error` | the whole error **object** | `v1/creators`, `v1/tags`, `v1/permissions/check`, `v1/vault/{all,get,check-vault,toggle-version}`, `notification/getDetails` |
| `error: error.cause` | the **wrapped** driver error | `v1/content/[[...slug]]` |
| `cause: error` | the object under a second key, next to a *generic* `error` string that made it look sanitized | `run/[modelVersionId]` |

Each catch now delegates. The copy is **deleted**, not corrected — `v1/creators` and `v1/tags` were verbatim copies of `handleEndpointError` that had drifted, keeping the abort/parse logic but not the genericization.

### Route-specific behaviour preserved (and pinned)

- **`v1/users` keeps its transient-search 503**, and the client-abort check moved **ahead** of it. An aborted Meili call can look transient, and the old order could answer `503 + Retry-After` to a client that had already gone away.
- **`v1/vault/{all,get}` keep their `MEMBERSHIP_REQUIRED` → `200 {vault:null}` arm.**
- The five routes whose catch previously ended **without** a `return` still resolve to `undefined` — only the body changes.
- ⚠️ **One intentional status change:** `v1/content` no longer answers a hard 500 for every `TRPCError`. A `NOT_FOUND` slug now gets its real **404**. Flagging it as the one wire change beyond the body.

---

## Test evidence

Every regression test below was **observed failing** against `origin/main`, and the reverts were scoped so the red is an assertion failure, not a module error.

| suite | red at `origin/main` | green at HEAD | how the control was taken |
|---|---|---|---|
| `endpoint-helpers-driver-4xx` | **6 / 12** | 12 / 12 | reverted **only** `endpoint-helpers.ts` (the other two files are pure additions with no behaviour of their own) |
| `rest-envelope-consolidation` | **42 / 47** | 47 / 47 | reverted the 11 route files |
| `rest-error-envelope-ledger` | see mutations | 9 / 9 | mutation-tested, below |

The tests that stay green are labelled `INVARIANT:` in the source and are **not** counted as regression coverage — they pin what must not change (4xx byte-identity for our own messages, the 503 hint, the 499 abort, observability, the route-specific arms).

### The guards were validated, not assumed

- **Both ledgers mutation-tested.** Reverting one route makes ledger 1 name it (`+ "v1/creators.ts"`); adding `P9999: 'FORBIDDEN'` to `prismaErrorToTrpcCode` makes ledger 2 fail with `expected [400,404,408,409] to deeply equal [400,403,404,408,409]`.
- **Positive control on the file walk**, because a zero from a sweep wired to nothing is indistinguishable from a clean repo. **Negative control on each pattern**, fed its own exemplar, because a typo'd regex matches nothing and reports a reassuring zero.
- **Ledger 2 derives its expected set from `prismaErrorToTrpcCode` itself** rather than a hand-copied list, so a new mapping cannot outrun the genericization map — `handleEndpointError` leaves an unmapped status alone, so completeness is what makes the design safe.
- **A false green was caught and fixed mid-review.** The `run/[modelVersionId]` case mocked `Tracker` with an arrow function, so `new Tracker()` raised `TypeError: … is not a constructor` — a *different* error that also genericizes. Its three "no secret in body" assertions were passing without ever carrying the driver payload. The log-attribution assertion is what exposed it.

Full gate on the final tree: `pnpm typecheck` **0 errors**; `vitest --project unit` **15,350 passed / 0 failed / 17 skipped** across 980 files. ESLint on the changed files: **0 errors, 5 warnings** vs a **6-warning** baseline on the same files at `origin/main` (I removed a dead `appRouter` import). The gate was run on the merged tree, not per-commit.

---

## Two changes a reviewer should look at deliberately

**1. The global test setup.** `src/__tests__/setup.ts` replaced `~/server/logging/client` (7 exports) with a **one-key object**. Any path reaching a second export died with `[vitest] No "<name>" export is defined on the mock`, surfacing far from its cause — it broke nine previously-green route tests the moment they delegated to a helper needing `buildCentralErrorLog` and `wasServerFaultLogged`. It now spreads the original and stubs only `logToAxiom` (the one with an I/O side effect). This is a repo-wide test-infra change in a fix PR; it is here because the fix cannot land without it.

**2. Three existing suites had assertions that PINNED the leak** — `toEqual({ message: 'Database connection lost' })` at a 500, and the `{ error, code }` shape carrying driver text through the field the Go CLI renders *in preference to* `message`. They now assert the genericized body **by value**, each with a comment saying what changed and why. Changing a test to match new behaviour deserves scrutiny; the new behaviour is independently covered by the red→green suites above, so these are not the evidence.

---

## Known gap — bounded and pinned, deliberately not fixed here

**17 sites** re-wrap a caught error's `.message` into a 4xx `TRPCError` **without** setting `cause`, which defeats `isDriverAuthoredMessage`: the wire text is the driver's, but nothing in the chain proves it.

```
routers/app-listings.router.ts   2
routers/apps-shared.router.ts    1
routers/blocks.router.ts        13
routers/referral.router.ts       1
```

The fix is one word per site (`cause: err`). It is **not** in this PR: it touches four router files on the App Blocks surface, with their own review and test surface, and a mechanical sweep over them should not ride along inside a security fix. *(I attempted it, got the caught-variable name wrong at nearly every site via a bad regex, and reverted — which is itself the argument for doing it deliberately rather than as a ride-along.)*

`rest-error-envelope-ledger` **pins the current set**, failing if it grows *or* shrinks — mutation-verified by adding an 18th site. The gap stays visible instead of decaying into folklore.

## Consumer compatibility

No breaking change. `message` stays a **string** at every status (the Go CLI's `readError` decodes it into `Message string`; a non-string fails the whole envelope unmarshal). `error` is retained and non-empty at every status (the CLI renders it *in preference to* `message`, so blanking it would empty every rendered CLI error). `code` is added where it was absent and is unchanged where it existed. The zod-flatten object on a 400 is untouched.
