### PR TITLE
fix(challenges): require an auto-detected resource for challenge entry

### DIFF
--- a/docs/features/challenge-platform.md
+++ b/docs/features/challenge-platform.md
@@ -106,7 +106,7 @@ Transitions are date/job-driven and enforced at the application layer only (no D
 
 **Entry validation** (`reviewEntries()`; failure → rejected):
 1. **NSFW** — image `nsfwLevel` must satisfy the challenge's `allowedNsfwLevel` bitwise flag.
-2. **Required resource** — image must use ≥1 of the challenge's `modelVersionIds` (via `ImageResourceNew.modelVersionId`, SQL `ANY()` OR-match).
+2. **Required resource** — image must use ≥1 of the challenge's `modelVersionIds` (via `ImageResourceNew.modelVersionId`, SQL `ANY()` OR-match), and the match must be on a row with **`detected = true`** — i.e. the resource was read out of the image's own generation metadata. A `detected: false` row is asserted by the uploader (the post's model-version link, or the hand-credit mutation — see [image-resources.md](image-resources.md)), so counting it would make the requirement self-certifiable on challenges with real prize pools. Enforced identically at submit (`collection.service`), at promotion (`challenge-rewards`) and in the modal precheck (`checkImageEligibility`); challenges with no `modelVersionIds` skip the check entirely. An image that carries a required model only on a `detected: false` row is reported as **"Model not detected"** rather than "Wrong model".
 3. **Recency** — image `createdAt` ≥ challenge `startsAt`.
 
 **AI scoring** — each accepted entry is scored 0–10 per judging dimension. The LLM also returns a `reaction`, a `comment` (posted to the image), and a `summary`. Score/summary are stored on `CollectionItem.note`.

--- a/docs/features/image-resources.md
+++ b/docs/features/image-resources.md
@@ -80,8 +80,16 @@ The `detected` flag records *how the resource was associated with the image*, no
 - **`detected: false`** — inherited from the post's linked model version (`Post.modelVersionId`),
   via the one remaining branch.
 
-There is no per-image "tag a resource" mutation, so `detected: false` never means hand-tagged by a
-user. The only production writer is `createImageResources()`, fed entirely by the SQL function.
+`createImageResources()` is not the only writer, and `detected: false` does **not** imply the post
+link. `addResourceToPostImage()` (`post.service.ts`, exposed as a tRPC mutation) lets an image's
+owner credit a resource by hand and writes `detected: false` explicitly; it refuses on-site
+generations, so hand-crediting only ever applies to uploaded/external images. Treat `detected: false`
+as "asserted by the uploader" — through the post link or the credit mutation — and `detected: true`
+as "read out of the image's own metadata". Anything gating on provenance wants `detected: true`.
+
+Nothing deletes a `detected: false` row on its own: `refreshImageResources()` deletes
+`WHERE ... AND detected` only, so a row survives its post being re-linked. About half of recent
+manual rows no longer match their image's current `Post.modelVersionId`.
 
 Note `strength` is stored as `round(weight * 100)` — a weight of `1.0` is `100`, not `1`.
 

--- a/src/components/Challenge/ChallengeSelectableImageCard.tsx
+++ b/src/components/Challenge/ChallengeSelectableImageCard.tsx
@@ -43,12 +43,17 @@ function getEligibility(
     reasons.push('Created before challenge');
   }
 
-  // Check model version requirement
+  // Check model version requirement. Mirrors checkImageEligibility: only auto-detected resources
+  // satisfy it, and an image whose ONLY claim to the required model is an uploader-asserted resource
+  // gets the distinct reason — it is not the entrant picking the wrong model, it is the image
+  // carrying no generation metadata that names it.
   if (challenge.modelVersionIds.length > 0) {
-    const imageVersionIds = image.modelVersionIds ?? [];
-    const hasEligibleModel = imageVersionIds.some((vid) => challenge.modelVersionIds.includes(vid));
+    const detectedIds = image.modelVersionIds ?? [];
+    const hasEligibleModel = detectedIds.some((vid) => challenge.modelVersionIds.includes(vid));
     if (!hasEligibleModel) {
-      reasons.push('Wrong model');
+      const manualIds = image.modelVersionIdsManual ?? [];
+      const claimsEligibleModel = manualIds.some((vid) => challenge.modelVersionIds.includes(vid));
+      reasons.push(claimsEligibleModel ? 'Model not detected' : 'Wrong model');
     }
   }
 

--- a/src/components/Challenge/ChallengeSelectableImageCard.tsx
+++ b/src/components/Challenge/ChallengeSelectableImageCard.tsx
@@ -1,4 +1,4 @@
-import { AspectRatio, Badge, Checkbox } from '@mantine/core';
+import { AspectRatio, Badge, Checkbox, Tooltip } from '@mantine/core';
 import { IconInfoCircle } from '@tabler/icons-react';
 import { memo, useCallback, useMemo } from 'react';
 import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
@@ -14,7 +14,12 @@ import clsx from 'clsx';
 type EligibilityStatus = {
   eligible: boolean;
   reasons: string[];
+  /** Shown on the badge when the reason alone doesn't tell the entrant what to do about it. */
+  hint?: string;
 };
+
+const MODEL_NOT_DETECTED_HINT =
+  "The challenge's model has to be readable from the image's own generation metadata. A resource credited by hand doesn't count. Generate on site, or re-upload the image with its metadata intact.";
 
 type Props = {
   image: ImageGetInfinite[number];
@@ -32,6 +37,7 @@ function getEligibility(
   challenge: Pick<ChallengeDetail, 'allowedNsfwLevel' | 'startsAt' | 'modelVersionIds'>
 ): EligibilityStatus {
   const reasons: string[] = [];
+  let hint: string | undefined;
 
   // Check NSFW level
   if ((image.nsfwLevel as number) !== 0 && (image.nsfwLevel & challenge.allowedNsfwLevel) === 0) {
@@ -54,10 +60,11 @@ function getEligibility(
       const manualIds = image.modelVersionIdsManual ?? [];
       const claimsEligibleModel = manualIds.some((vid) => challenge.modelVersionIds.includes(vid));
       reasons.push(claimsEligibleModel ? 'Model not detected' : 'Wrong model');
+      if (claimsEligibleModel) hint = MODEL_NOT_DETECTED_HINT;
     }
   }
 
-  return { eligible: reasons.length === 0, reasons };
+  return { eligible: reasons.length === 0, reasons, hint };
 }
 
 function ChallengeSelectableImageCard({ image, challenge, selected, onToggle }: Props) {
@@ -105,14 +112,16 @@ function ChallengeSelectableImageCard({ image, challenge, selected, onToggle }: 
         {eligibility.eligible ? (
           <Checkbox size="lg" checked={selected} className="absolute right-1.5 top-1.5" readOnly />
         ) : (
-          <Badge
-            color="red"
-            variant="filled"
-            size="sm"
-            className="absolute right-1.5 top-1.5 max-w-[calc(100%-12px)]"
-          >
-            {eligibility.reasons[0] ?? 'Ineligible'}
-          </Badge>
+          <Tooltip label={eligibility.hint} disabled={!eligibility.hint} multiline maw={280}>
+            <Badge
+              color="red"
+              variant="filled"
+              size="sm"
+              className="absolute right-1.5 top-1.5 max-w-[calc(100%-12px)]"
+            >
+              {eligibility.reasons[0] ?? 'Ineligible'}
+            </Badge>
+          </Tooltip>
         )}
 
         {image.hasMeta && (

--- a/src/server/games/daily-challenge/challenge-rewards.ts
+++ b/src/server/games/daily-challenge/challenge-rewards.ts
@@ -42,7 +42,7 @@ export async function promoteChallengeEntries(args: {
         (i."nsfwLevel" & ${allowedNsfwLevel}) > 0 as "isSafe",
         ${
           hasModelVersionRestriction
-            ? Prisma.sql`EXISTS (SELECT 1 FROM "ImageResourceNew" ir WHERE ir."modelVersionId" = ANY(${modelVersionIds}) AND ir."imageId" = i.id)`
+            ? Prisma.sql`EXISTS (SELECT 1 FROM "ImageResourceNew" ir WHERE ir."modelVersionId" = ANY(${modelVersionIds}) AND ir."imageId" = i.id AND ir.detected IS TRUE)`
             : Prisma.sql`true`
         } as "hasResource",
         i."createdAt" >= ${challengeDate} as "isRecent"

--- a/src/server/services/__tests__/challenge-entry-eligibility.service.test.ts
+++ b/src/server/services/__tests__/challenge-entry-eligibility.service.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type * as FliptClient from '~/server/flipt/client';
+import type * as ChallengeHelpers from '~/server/games/daily-challenge/challenge-helpers';
 
 // `checkImageEligibility` is what the challenge submit modal prechecks each library image against.
 // Only an AUTO-DETECTED resource satisfies a challenge's model requirement: a manually-attached
@@ -23,7 +25,7 @@ const { mockDbRead, mockDbWrite, mockIsFlipt } = vi.hoisted(() => ({
 vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
 
 vi.mock('~/server/flipt/client', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('~/server/flipt/client')>()),
+  ...(await importOriginal<typeof FliptClient>()),
   isFlipt: mockIsFlipt,
 }));
 
@@ -41,9 +43,7 @@ vi.mock('~/server/games/daily-challenge/daily-challenge.utils', () => ({
 }));
 
 vi.mock('~/server/games/daily-challenge/challenge-helpers', async (importOriginal) => {
-  const actual = await importOriginal<
-    typeof import('~/server/games/daily-challenge/challenge-helpers')
-  >();
+  const actual = await importOriginal<typeof ChallengeHelpers>();
   return { ...actual, getChallengeById: vi.fn(), resolveEventContext: vi.fn() };
 });
 
@@ -122,7 +122,7 @@ function wireImage({
       nsfwLevel: 1,
       createdAt: new Date(),
       modelVersionIds: detected.length ? detected : null,
-      manualModelVersionIds: manual.length ? manual : null,
+      modelVersionIdsManual: manual.length ? manual : null,
     },
   ]);
 }

--- a/src/server/services/__tests__/challenge-entry-eligibility.service.test.ts
+++ b/src/server/services/__tests__/challenge-entry-eligibility.service.test.ts
@@ -3,15 +3,14 @@ import type * as FliptClient from '~/server/flipt/client';
 import type * as ChallengeHelpers from '~/server/games/daily-challenge/challenge-helpers';
 
 // `checkImageEligibility` is what the challenge submit modal prechecks each library image against.
-// Only an AUTO-DETECTED resource satisfies a challenge's model requirement: a manually-attached
-// resource is a claim the owner types into the image, so accepting one would let anyone tag any
-// upload with the required model and enter.
+// Only an AUTO-DETECTED resource satisfies a challenge's model requirement: a `detected: false` row
+// is asserted by the uploader (the post's model-version link, or `addResourceToPostImage`), so
+// accepting one would let anyone claim the required model on any upload and enter.
 //
 // The two rejections are reported separately on purpose. "Wrong model" is the entrant's mistake;
-// "Model not detected" means they did use the model but we could not read it out of the image, which
-// is a different thing to tell them and a different thing for them to do about it. Reporting the
-// former for the latter is what sent a user to support insisting their image used the required
-// model — it did.
+// "Model not detected" means the image carries no generation metadata naming the model, which is a
+// different thing to tell them and a different thing for them to do about it. Reporting the former
+// for the latter is what sent a user to support insisting their image used the required model.
 
 const { mockDbRead, mockDbWrite, mockIsFlipt } = vi.hoisted(() => ({
   mockDbRead: {
@@ -109,13 +108,7 @@ function wireChallenge(modelVersionIds: number[] = [REQUIRED_VERSION_ID]) {
   });
 }
 
-function wireImage({
-  detected = [],
-  manual = [],
-}: {
-  detected?: number[];
-  manual?: number[];
-}) {
+function wireImage({ detected = [], manual = [] }: { detected?: number[]; manual?: number[] }) {
   mockDbRead.$queryRawUnsafe.mockResolvedValue([
     {
       id: IMAGE_ID,

--- a/src/server/services/__tests__/challenge-entry-eligibility.service.test.ts
+++ b/src/server/services/__tests__/challenge-entry-eligibility.service.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// `checkImageEligibility` is what the challenge submit modal prechecks each library image against.
+// Only an AUTO-DETECTED resource satisfies a challenge's model requirement: a manually-attached
+// resource is a claim the owner types into the image, so accepting one would let anyone tag any
+// upload with the required model and enter.
+//
+// The two rejections are reported separately on purpose. "Wrong model" is the entrant's mistake;
+// "Model not detected" means they did use the model but we could not read it out of the image, which
+// is a different thing to tell them and a different thing for them to do about it. Reporting the
+// former for the latter is what sent a user to support insisting their image used the required
+// model — it did.
+
+const { mockDbRead, mockDbWrite, mockIsFlipt } = vi.hoisted(() => ({
+  mockDbRead: {
+    $queryRawUnsafe: vi.fn(),
+    challenge: { findUnique: vi.fn() },
+  },
+  mockDbWrite: { $queryRawUnsafe: vi.fn() },
+  mockIsFlipt: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
+
+vi.mock('~/server/flipt/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('~/server/flipt/client')>()),
+  isFlipt: mockIsFlipt,
+}));
+
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransaction: vi.fn(),
+  createBuzzTransactionMany: vi.fn(),
+}));
+
+vi.mock('~/server/games/daily-challenge/daily-challenge.utils', () => ({
+  getChallengeConfig: vi.fn(),
+  setChallengeConfig: vi.fn(),
+  deriveChallengeNsfwLevel: vi.fn(() => 1),
+  getJudgingConfig: vi.fn(),
+  parseJudgeScore: vi.fn(),
+}));
+
+vi.mock('~/server/games/daily-challenge/challenge-helpers', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('~/server/games/daily-challenge/challenge-helpers')
+  >();
+  return { ...actual, getChallengeById: vi.fn(), resolveEventContext: vi.fn() };
+});
+
+vi.mock('~/server/games/daily-challenge/generative-content', () => ({ generateWinners: vi.fn() }));
+
+vi.mock('~/server/jobs/daily-challenge-processing', () => ({ getJudgedEntries: vi.fn() }));
+
+vi.mock('~/server/search-index', () => ({ collectionsSearchIndex: { queueUpdate: vi.fn() } }));
+
+vi.mock('~/server/services/image.service', () => ({
+  createImage: vi.fn(),
+  enqueueImageIngestion: vi.fn(),
+  imagesForModelVersionsCache: { bust: vi.fn(), fetch: vi.fn(() => ({})) },
+}));
+
+vi.mock('~/server/services/user.service', () => ({
+  getCosmeticsForUsers: vi.fn(() => ({})),
+  getProfilePicturesForUsers: vi.fn(() => ({})),
+}));
+
+vi.mock('~/server/services/notification.service', () => ({ createNotification: vi.fn() }));
+
+vi.mock('~/server/services/challenge-eligibility.service', () => ({
+  assertCanCreateUserChallenge: vi.fn(),
+  assertUserInGoodStanding: vi.fn(),
+  assertUserAccountInGoodStanding: vi.fn(),
+}));
+
+vi.mock('~/server/services/challenge-category.service', () => ({
+  resolveJudgingCategories: vi.fn(() => []),
+}));
+
+vi.mock('~/server/services/challenge-judge.service', () => ({
+  getUserSelectableJudges: vi.fn(() => []),
+}));
+
+vi.mock('~/server/services/text-moderation.service', () => ({ submitTextModeration: vi.fn() }));
+
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn(() => Promise.resolve()) }));
+
+vi.mock('~/utils/errorHandling', () => ({ withRetries: vi.fn((fn: () => unknown) => fn()) }));
+
+vi.mock('~/utils/logging', () => ({ createLogger: vi.fn(() => vi.fn()) }));
+
+vi.mock('~/server/utils/errorHandling', () => ({
+  throwNotFoundError: vi.fn((msg: string) => {
+    throw new Error(msg);
+  }),
+}));
+
+const { checkImageEligibility } = await import('~/server/services/challenge.service');
+
+const CHALLENGE_ID = 511;
+const IMAGE_ID = 139575771;
+const REQUIRED_VERSION_ID = 3222543;
+
+/** PG only, started an hour ago — so nothing but the model check can make an entry ineligible. */
+function wireChallenge(modelVersionIds: number[] = [REQUIRED_VERSION_ID]) {
+  mockDbRead.challenge.findUnique.mockResolvedValue({
+    allowedNsfwLevel: 7,
+    modelVersionIds,
+    startsAt: new Date(Date.now() - 60 * 60 * 1000),
+  });
+}
+
+function wireImage({
+  detected = [],
+  manual = [],
+}: {
+  detected?: number[];
+  manual?: number[];
+}) {
+  mockDbRead.$queryRawUnsafe.mockResolvedValue([
+    {
+      id: IMAGE_ID,
+      nsfwLevel: 1,
+      createdAt: new Date(),
+      modelVersionIds: detected.length ? detected : null,
+      manualModelVersionIds: manual.length ? manual : null,
+    },
+  ]);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsFlipt.mockResolvedValue(false);
+});
+
+describe('checkImageEligibility model requirement', () => {
+  it('accepts an image whose required model was auto-detected', async () => {
+    wireChallenge();
+    wireImage({ detected: [REQUIRED_VERSION_ID, 3147780] });
+
+    const [result] = await checkImageEligibility(CHALLENGE_ID, [IMAGE_ID]);
+
+    expect(result).toEqual({ imageId: IMAGE_ID, eligible: true, reasons: [] });
+  });
+
+  it('reports "Model not detected" when the required model is only a manual resource', async () => {
+    wireChallenge();
+    wireImage({ detected: [], manual: [REQUIRED_VERSION_ID, 3147780] });
+
+    const [result] = await checkImageEligibility(CHALLENGE_ID, [IMAGE_ID]);
+
+    expect(result.eligible).toBe(false);
+    // Telling this entrant they used the wrong model is false — they used it, we could not read it.
+    expect(result.reasons).toEqual(['Model not detected']);
+  });
+
+  it('reports "Wrong model" when the image does not carry the required model at all', async () => {
+    wireChallenge();
+    wireImage({ detected: [999], manual: [888] });
+
+    const [result] = await checkImageEligibility(CHALLENGE_ID, [IMAGE_ID]);
+
+    expect(result.eligible).toBe(false);
+    expect(result.reasons).toEqual(['Wrong model']);
+  });
+
+  it('splits detected from manual resources in the query itself', async () => {
+    wireChallenge();
+    wireImage({ detected: [REQUIRED_VERSION_ID] });
+
+    await checkImageEligibility(CHALLENGE_ID, [IMAGE_ID]);
+
+    // Reading both buckets out of one aggregate is what lets the reason be specific; a query that
+    // aggregates every resource into one array can only ever say "Wrong model".
+    const [sql] = mockDbRead.$queryRawUnsafe.mock.calls[0];
+    expect(sql).toContain('ir.detected IS TRUE');
+    expect(sql).toContain('ir.detected IS NOT TRUE');
+  });
+
+  it('skips the model check when the challenge requires no model', async () => {
+    wireChallenge([]);
+    wireImage({ manual: [REQUIRED_VERSION_ID] });
+
+    const [result] = await checkImageEligibility(CHALLENGE_ID, [IMAGE_ID]);
+
+    expect(result.eligible).toBe(true);
+  });
+});

--- a/src/server/services/__tests__/contest-entry-resource-gate.test.ts
+++ b/src/server/services/__tests__/contest-entry-resource-gate.test.ts
@@ -158,13 +158,41 @@ describe('contest entry resource gate (Task 11)', () => {
         imageIds: [IMAGE_ID],
         metadata: {},
       })
-    ).rejects.toThrow('This image does not use a required model for this challenge.');
+    ).rejects.toThrow('This image does not use a required model for this challenge');
 
     expect(mockImageResourceNewFindMany).toHaveBeenCalledWith({
-      where: { imageId: { in: [IMAGE_ID] }, modelVersionId: { in: [REQUIRED_VERSION_ID] } },
+      where: {
+        imageId: { in: [IMAGE_ID] },
+        modelVersionId: { in: [REQUIRED_VERSION_ID] },
+        detected: true,
+      },
       select: { imageId: true },
       distinct: ['imageId'],
     });
+    expect(mockChargeEntryFees).not.toHaveBeenCalled();
+  });
+
+  it('does not accept a manually-attached resource as satisfying the requirement', async () => {
+    wireChallengeFindFirst({ hasResourceChallenge: true, hasFeeChallenge: true });
+    // The query is what enforces this: `detected: true` means an uploader-asserted row never comes
+    // back, so an image carrying the required model ONLY on such a row returns empty here. Without
+    // the filter the requirement is self-certified — link a post to the required version, or credit
+    // it by hand via addResourceToPostImage, and enter.
+    mockImageResourceNewFindMany.mockResolvedValue([]);
+
+    await expect(
+      validateContestCollectionEntry({
+        collectionId: COLLECTION_ID,
+        userId: USER_ID,
+        canAccessUserChallenges: true,
+        imageIds: [IMAGE_ID],
+        metadata: {},
+      })
+    ).rejects.toThrow('the model could not be detected from its metadata');
+
+    expect(mockImageResourceNewFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ detected: true }) })
+    );
     expect(mockChargeEntryFees).not.toHaveBeenCalled();
   });
 

--- a/src/server/services/__tests__/contest-entry-resource-gate.test.ts
+++ b/src/server/services/__tests__/contest-entry-resource-gate.test.ts
@@ -74,7 +74,7 @@ vi.mock('@civitai/db', () => ({
 }));
 
 vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: {} }));
-vi.mock('~/server/db/pgDb', () => ({ pgDbReadLong: {},  pgDbRead: {}, pgDbWrite: {} }));
+vi.mock('~/server/db/pgDb', () => ({ pgDbReadLong: {}, pgDbRead: {}, pgDbWrite: {} }));
 vi.mock('~/server/db/db-lag-helpers', () => ({
   getDbWithoutLag: vi.fn(),
   preventReplicationLag: vi.fn(),
@@ -112,28 +112,30 @@ const { validateContestCollectionEntry } = await import('~/server/services/colle
 // Dispatch dbRead.challenge.findFirst by the distinguishing field in its `where` clause —
 // the function makes several distinct challenge lookups in sequence.
 function wireChallengeFindFirst(opts: { hasResourceChallenge: boolean; hasFeeChallenge: boolean }) {
-  mockChallengeFindFirst.mockImplementation(async ({ where }: { where: Record<string, unknown> }) => {
-    if ('createdById' in where) return null; // own-challenge self-entry check
-    if ('modelVersionIds' in where) {
-      return opts.hasResourceChallenge ? { modelVersionIds: [REQUIRED_VERSION_ID] } : null;
-    }
-    if ('maxParticipants' in where) return null; // no participant cap configured
-    if (where.source === 'User') {
-      // The fee-challenge lookup (collection.service.ts chargeContestEntryFeesForCollection) is the
-      // only source=User lookup that also filters `status: 'Active'` in its where;
-      // select: { id, entryFee, buzzType }.
-      if ('status' in where) {
-        return opts.hasFeeChallenge ? { id: 1, entryFee: 100, buzzType: 'yellow' } : null;
+  mockChallengeFindFirst.mockImplementation(
+    async ({ where }: { where: Record<string, unknown> }) => {
+      if ('createdById' in where) return null; // own-challenge self-entry check
+      if ('modelVersionIds' in where) {
+        return opts.hasResourceChallenge ? { modelVersionIds: [REQUIRED_VERSION_ID] } : null;
       }
-      // Otherwise this is the assertUserChallengeAcceptingEntries timing gate
-      // (challenge-entry-gate.ts), which runs BEFORE the resource gate and rejects
-      // unless the user challenge is Active. Return an Active challenge so execution
-      // reaches the resource gate under test. ('Active' is ChallengeStatus.Active —
-      // the same literal collection.service uses.)
-      return { status: 'Active', createdById: CREATOR_ID };
+      if ('maxParticipants' in where) return null; // no participant cap configured
+      if (where.source === 'User') {
+        // The fee-challenge lookup (collection.service.ts chargeContestEntryFeesForCollection) is the
+        // only source=User lookup that also filters `status: 'Active'` in its where;
+        // select: { id, entryFee, buzzType }.
+        if ('status' in where) {
+          return opts.hasFeeChallenge ? { id: 1, entryFee: 100, buzzType: 'yellow' } : null;
+        }
+        // Otherwise this is the assertUserChallengeAcceptingEntries timing gate
+        // (challenge-entry-gate.ts), which runs BEFORE the resource gate and rejects
+        // unless the user challenge is Active. Return an Active challenge so execution
+        // reaches the resource gate under test. ('Active' is ChallengeStatus.Active —
+        // the same literal collection.service uses.)
+        return { status: 'Active', createdById: CREATOR_ID };
+      }
+      return null;
     }
-    return null;
-  });
+  );
 }
 
 beforeEach(() => {
@@ -158,7 +160,7 @@ describe('contest entry resource gate (Task 11)', () => {
         imageIds: [IMAGE_ID],
         metadata: {},
       })
-    ).rejects.toThrow('This image does not use a required model for this challenge');
+    ).rejects.toThrow("This image doesn't use a required model for this challenge");
 
     expect(mockImageResourceNewFindMany).toHaveBeenCalledWith({
       where: {
@@ -188,7 +190,7 @@ describe('contest entry resource gate (Task 11)', () => {
         imageIds: [IMAGE_ID],
         metadata: {},
       })
-    ).rejects.toThrow('the model could not be detected from its metadata');
+    ).rejects.toThrow("readable from the image's own generation metadata");
 
     expect(mockImageResourceNewFindMany).toHaveBeenCalledWith(
       expect.objectContaining({ where: expect.objectContaining({ detected: true }) })
@@ -294,7 +296,10 @@ describe('validateContestCollectionEntry — creator block gate', () => {
       })
     ).rejects.toThrow('not available');
 
-    expect(mockAmIBlockedByUser).toHaveBeenCalledWith({ userId: USER_ID, targetUserId: CREATOR_ID });
+    expect(mockAmIBlockedByUser).toHaveBeenCalledWith({
+      userId: USER_ID,
+      targetUserId: CREATOR_ID,
+    });
     expect(mockChargeEntryFees).not.toHaveBeenCalled();
   });
 

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -3042,7 +3042,7 @@ export async function checkImageEligibility(
       nsfwLevel: number;
       createdAt: Date;
       modelVersionIds: number[] | null;
-      manualModelVersionIds: number[] | null;
+      modelVersionIdsManual: number[] | null;
     }>
   >(
     `
@@ -3051,7 +3051,7 @@ export async function checkImageEligibility(
       i."nsfwLevel",
       i."createdAt",
       array_agg(DISTINCT ir."modelVersionId") FILTER (WHERE ir."modelVersionId" IS NOT NULL AND ir.detected IS TRUE) AS "modelVersionIds",
-      array_agg(DISTINCT ir."modelVersionId") FILTER (WHERE ir."modelVersionId" IS NOT NULL AND ir.detected IS NOT TRUE) AS "manualModelVersionIds"
+      array_agg(DISTINCT ir."modelVersionId") FILTER (WHERE ir."modelVersionId" IS NOT NULL AND ir.detected IS NOT TRUE) AS "modelVersionIdsManual"
     FROM "Image" i
     LEFT JOIN "ImageResourceNew" ir ON ir."imageId" = i.id
     WHERE i.id = ANY($1::int[])
@@ -3087,7 +3087,7 @@ export async function checkImageEligibility(
       const detectedIds = image.modelVersionIds ?? [];
       const hasEligibleModel = detectedIds.some((vid) => challenge.modelVersionIds.includes(vid));
       if (!hasEligibleModel) {
-        const manualIds = image.manualModelVersionIds ?? [];
+        const manualIds = image.modelVersionIdsManual ?? [];
         const claimsEligibleModel = manualIds.some((vid) =>
           challenge.modelVersionIds.includes(vid)
         );

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -3042,6 +3042,7 @@ export async function checkImageEligibility(
       nsfwLevel: number;
       createdAt: Date;
       modelVersionIds: number[] | null;
+      manualModelVersionIds: number[] | null;
     }>
   >(
     `
@@ -3049,7 +3050,8 @@ export async function checkImageEligibility(
       i.id,
       i."nsfwLevel",
       i."createdAt",
-      array_agg(DISTINCT ir."modelVersionId") FILTER (WHERE ir."modelVersionId" IS NOT NULL) AS "modelVersionIds"
+      array_agg(DISTINCT ir."modelVersionId") FILTER (WHERE ir."modelVersionId" IS NOT NULL AND ir.detected IS TRUE) AS "modelVersionIds",
+      array_agg(DISTINCT ir."modelVersionId") FILTER (WHERE ir."modelVersionId" IS NOT NULL AND ir.detected IS NOT TRUE) AS "manualModelVersionIds"
     FROM "Image" i
     LEFT JOIN "ImageResourceNew" ir ON ir."imageId" = i.id
     WHERE i.id = ANY($1::int[])
@@ -3076,14 +3078,20 @@ export async function checkImageEligibility(
       reasons.push('Created before challenge');
     }
 
-    // Check model version requirement
+    // Check model version requirement. Only auto-detected resources count — a `detected: false` row
+    // is asserted by the uploader (post model-version link, or the hand-credit mutation), so it
+    // cannot certify the requirement. The two failures are told apart because they mean different
+    // things to the entrant: "wrong model" is their mistake, "not detected" means the image carries
+    // no generation metadata naming the model, which is what an off-site upload looks like.
     if (challenge.modelVersionIds.length > 0) {
-      const imageVersionIds = image.modelVersionIds ?? [];
-      const hasEligibleModel = imageVersionIds.some((vid) =>
-        challenge.modelVersionIds.includes(vid)
-      );
+      const detectedIds = image.modelVersionIds ?? [];
+      const hasEligibleModel = detectedIds.some((vid) => challenge.modelVersionIds.includes(vid));
       if (!hasEligibleModel) {
-        reasons.push('Wrong model');
+        const manualIds = image.manualModelVersionIds ?? [];
+        const claimsEligibleModel = manualIds.some((vid) =>
+          challenge.modelVersionIds.includes(vid)
+        );
+        reasons.push(claimsEligibleModel ? 'Model not detected' : 'Wrong model');
       }
     }
 

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -2805,17 +2805,26 @@ export const validateContestCollectionEntry = async ({
       select: { modelVersionIds: true },
     });
     if (resourceChallenge) {
+      // `detected: true` only — the resource has to have been read out of the image's own generation
+      // metadata. A `detected: false` row is asserted by the uploader, by either route that writes
+      // one: linking the post to the model version (unrestricted — about half of version-linked
+      // posts point at someone else's model), or `addResourceToPostImage`, which credits a resource
+      // by hand and refuses on-site generations. Counting those would make the requirement
+      // self-certifiable on a challenge with a real prize pool.
       const withRequiredResource = await dbRead.imageResourceNew.findMany({
         where: {
           imageId: { in: imageIds },
           modelVersionId: { in: resourceChallenge.modelVersionIds },
+          detected: true,
         },
         select: { imageId: true },
         distinct: ['imageId'],
       });
       const validImageIds = new Set(withRequiredResource.map((r) => r.imageId));
       if (imageIds.some((id) => !validImageIds.has(id))) {
-        throw throwBadRequestError('This image does not use a required model for this challenge.');
+        throw throwBadRequestError(
+          'This image does not use a required model for this challenge, or the model could not be detected from its metadata.'
+        );
       }
     }
   }

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -2823,7 +2823,7 @@ export const validateContestCollectionEntry = async ({
       const validImageIds = new Set(withRequiredResource.map((r) => r.imageId));
       if (imageIds.some((id) => !validImageIds.has(id))) {
         throw throwBadRequestError(
-          'This image does not use a required model for this challenge, or the model could not be detected from its metadata.'
+          "This image doesn't use a required model for this challenge. The model has to be readable from the image's own generation metadata — a resource credited by hand doesn't count. Generate on site, or re-upload the image with its metadata intact."
         );
       }
     }

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -2332,8 +2332,18 @@ export const getAllImages = async (
         model3dId: i.model3dId != null && visibleModel3DIds?.has(i.model3dId) ? i.model3dId : null,
         meta: imageMeta?.[i.id] ?? null,
         nsfwLevel: Math.max(thumbnail?.nsfwLevel ?? 0, i.nsfwLevel),
-        modelVersionIds: imageResources?.[i.id]?.resources?.map((r) => r.modelVersionId) ?? [],
-        modelVersionIdsManual: [],
+        // Split by `detected` to match what the search-index path serves: `modelVersionIds` is
+        // auto-detected only, `modelVersionIdsManual` is what the owner attached by hand. Lumping
+        // both into the first field made a consumer that distinguishes them (the challenge entry
+        // gate) read a manual claim as a detected resource on the DB feed path and not on the index
+        // path, i.e. the same image judged differently depending on which backend served the feed.
+        modelVersionIds:
+          imageResources?.[i.id]?.resources?.filter((r) => r.detected).map((r) => r.modelVersionId) ??
+          [],
+        modelVersionIdsManual:
+          imageResources?.[i.id]?.resources
+            ?.filter((r) => !r.detected)
+            .map((r) => r.modelVersionId) ?? [],
         publishedAt: i.publishedAt ? i.sortAt : undefined,
         baseModel: imageResources
           ? getBaseModelFromResources(imageResources[i.id]?.resources)

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -2332,11 +2332,8 @@ export const getAllImages = async (
         model3dId: i.model3dId != null && visibleModel3DIds?.has(i.model3dId) ? i.model3dId : null,
         meta: imageMeta?.[i.id] ?? null,
         nsfwLevel: Math.max(thumbnail?.nsfwLevel ?? 0, i.nsfwLevel),
-        // Split by `detected` to match what the search-index path serves: `modelVersionIds` is
-        // auto-detected only, `modelVersionIdsManual` is what the owner attached by hand. Lumping
-        // both into the first field made a consumer that distinguishes them (the challenge entry
-        // gate) read a manual claim as a detected resource on the DB feed path and not on the index
-        // path, i.e. the same image judged differently depending on which backend served the feed.
+        // `modelVersionIds` is auto-detected only and `modelVersionIdsManual` is uploader-asserted,
+        // matching what the search-index path serves — consumers gate on the difference.
         modelVersionIds:
           imageResources?.[i.id]?.resources?.filter((r) => r.detected).map((r) => r.modelVersionId) ??
           [],


### PR DESCRIPTION
Reported via Discord: a user's images were badged **WRONG MODEL** in the challenge submit modal for [Himmi's Aesthetic Challenge](https://civitai.red/challenges/511/himmis-aesthetic-challenge), and the images really did carry the required model on a resource row.

## What was actually wrong

**1. The model requirement was self-certifiable.** `ImageResourceNew.detected` distinguishes a resource read out of the image's own generation metadata (`true`) from one asserted by the uploader (`false`). Two routes write a `false` row, and both are entrant-controlled:

- the post's model-version link — unrestricted, and **6,625 of 12,969 (51%) of recent version-linked posts point at a model version owned by someone else**;
- `addResourceToPostImage` (`post.service.ts:1500`, a tRPC mutation) — credits a resource by hand, and explicitly refuses on-site generations.

None of the three gates filtered on it: submit (`collection.service.ts:2807`), promotion (`challenge-rewards.ts:45`), modal precheck (`challenge.service.ts:3079`). So on a challenge with a real prize pool the requirement could be met by asserting it.

**2. The same image was judged differently depending on which backend served the feed.** `getAllImages` lumped both kinds into `modelVersionIds` and hardcoded `modelVersionIdsManual: []`, while `getAllImagesIndex` serves them split (the index builds `modelVersionIds` from `FILTER (WHERE ir.detected is true)`). So an off-site upload was selectable on the DB path and badged ineligible on the index path.

The reported image (139575771) has both `false` routes in play: `Post.modelVersionId = 3222543` (the required LoRA) and a hand-credited row for 3147780 (a Krea 2 checkpoint). It carries no generation metadata at all — no `civitaiResources`, no `resources`, no `Model`, `generationProcess` null.

## Does `detected` actually work? Measured, because a false rejection reads to users as "your system is broken"

30 days of model-gated challenge entries:

| | Count | Share |
|---|---|---|
| Accepted entries | 78,041 | |
| Already satisfy detected-only | 76,863 | **98.5%** |
| Would now be rejected | 1,178 | 1.5% |
| Required version absent entirely | 0 | |

None of the 1,178 are detection failures:

- **0** carry on-site generation metadata (`meta->'civitaiResources'`).
- 194 carry resource hashes in metadata; **0** of those hashes match the required version's `AutoV2` hash. So there is no case of "used the model, we failed to match it".

And detection is healthy platform-wide: of **299,734** recent images with on-site generation metadata, **203 (0.07%)** have no detected row.

**The cost lands on winners harder than on entries: 13 of 158 recent winners (8.2%), across 8 challenges, entered on an asserted row and would now be blocked from entering at all.** All 13 have zero detected resources of any kind and no resource-identifying metadata — off-site uploads posted to the model's gallery. There is no evidence they used the required model, and none that they didn't; an image generated locally with the model and exported without metadata is indistinguishable from one that never touched it. That is the real trade this PR makes, and it is a product call rather than a technical one.

## Changes

- All three gates count auto-detected resources only.
- `getAllImages` splits the two buckets from the already-cached `detected` flag, matching the index. Also fixes `ImagesAsPostsCard`, which reads both fields and until now could never see an asserted resource on the DB path.
- Both eligibility checks distinguish the failures — `Wrong model` when the image lacks the model, `Model not detected` when it carries it only on an asserted row. The submit error says so too.
- Docs: `challenge-platform.md` now documents the requirement. `image-resources.md` claimed "There is no per-image 'tag a resource' mutation, so `detected: false` never means hand-tagged by a user" — false, `addResourceToPostImage` is exactly that. Also corrected the implication that a manual row tracks the post's *current* link: `refreshImageResources` deletes `WHERE ... AND detected` only, so rows survive a re-link, and **33,197 of 61,290 (54%)** of recent manual rows no longer match their image's current `Post.modelVersionId`.

## Verification

- `pnpm run typecheck` — 0 errors.
- `pnpm run test:unit:run` — 15,287 passed, 18 skipped, 0 failed (978 files).
- 5 new tests on `checkImageEligibility` (both reasons, the query split, and the no-constraint case); 1 new test on the submit gate; the existing gate assertion updated to require `detected: true`.
- Revert-checked the money-path gate: dropping `detected: true` fails two assertions with `- "detected": true` in the diff.

**Open challenges are unaffected.** Every gate sits behind a "does this challenge require a model" check, and the submit gate's `findFirst({ where: { …, modelVersionIds: { isEmpty: false } } })` returns null so the query never runs. Covered by the `skips the model check when the challenge requires no model` test, which passes an asserted-only resource and asserts eligible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)