### PR TITLE
fix(ci): typecheck-tests gate matched `__tests__` with the HOST path separator (red unit suite on Windows)

### DIFF
--- a/scripts/__tests__/typecheck-tests-gate.test.ts
+++ b/scripts/__tests__/typecheck-tests-gate.test.ts
@@ -9,12 +9,15 @@ import {
   classifyEmptyAllowance,
   classifyRun,
   compare,
+  countTestFilesInProgram,
   detectRenames,
   diffExcludes,
   isGatedTestFile,
+  isTestFileLine,
   parseDiagnostics,
   stripJsonComments,
   testFileFloor,
+  toPosixPath,
   validateBaseline,
 } from '../ci/typecheck-tests-compare.mjs';
 
@@ -1218,5 +1221,229 @@ describe('the gate, end to end: an unusable baseline is exit 2, not a pass', () 
     const res = runGate(wrapperStub('oc', 'process.exit(0);'), bl);
     expect(res.status).toBe(2);
     expect(res.all).toContain('measured against');
+  });
+});
+
+// ------------------------------------------------------- the platform seam
+/**
+ * REGRESSION COVERAGE — reported by a developer running `pnpm run test:unit:run`
+ * on Windows, where 18 of this file's cases were RED while CI stayed green.
+ *
+ * The gate built its `__tests__` marker out of `path.sep`
+ * (`` `${path.sep}__tests__${path.sep}` ``) and matched it against the output of
+ * `tsc --listFilesOnly`. **tsc emits FORWARD slashes on every platform, Windows
+ * included.** On Windows `path.sep` is `\`, so the marker matched nothing: 948
+ * output lines containing `__tests__`, 0 matching the marker, positive control
+ * trips, `CANNOT MEASURE — POSITIVE CONTROL FAILED … contains 0 file(s)`.
+ *
+ * WHY THE EXISTING SUITE COULD NOT SEE IT. Every case ran on Linux, where
+ * `path.sep === '/'`, so the marker happened to equal the shape tsc emits. The
+ * platform was a PINNED DIMENSION — not under-tested, structurally invisible:
+ * no amount of extra cases written the same way could have moved it, because
+ * every one of them would have read the same host separator.
+ *
+ * SO THESE CASES NEVER READ `path.sep`. They name both separators explicitly via
+ * `path.win32.sep` / `path.posix.sep`, which are the same two characters on every
+ * host, and they drive the gate end to end with `--listFilesOnly` output in each
+ * shape. That is what makes them mean the same thing on Linux and on Windows.
+ */
+
+// Always '\' and always '/', on every host. The whole point: the assertions
+// below are about a SEPARATOR, not about the machine running them.
+const WIN_SEP = path.win32.sep;
+const POSIX_SEP = path.posix.sep;
+
+/**
+ * The pre-fix predicate, transcribed verbatim from
+ * `typecheck-tests-gate.mjs`, with the one thing it read from the host — the
+ * separator — lifted into a parameter. This is the injection the production code
+ * could not offer: it read `path.sep` at module scope, which is exactly what made
+ * the behaviour untestable in-process.
+ */
+const preFixPredicate = (line: string, sep: string) =>
+  line.includes(`${sep}__tests__${sep}`) && !line.includes(`${sep}node_modules${sep}`);
+
+// The two shapes of the same path. `posixShaped` is what tsc ACTUALLY emits, on
+// both platforms; `winShaped` is what a naive reader assumes it emits on Windows.
+const posixShaped = 'C:/repo/src/a/__tests__/x.test.ts';
+const winShaped = 'C:\\repo\\src\\a\\__tests__\\x.test.ts';
+
+describe('the __tests__ marker must not depend on the host separator', () => {
+  it('DOCUMENTS THE DEFECT: the pre-fix marker cannot match tsc output on Windows', () => {
+    // Both halves are host-independent facts, so this case asserts the same
+    // thing wherever it runs — including on the Windows box that reported it.
+    expect(preFixPredicate(posixShaped, WIN_SEP)).toBe(false); // <- the Windows box
+    expect(preFixPredicate(posixShaped, POSIX_SEP)).toBe(true); // <- CI, green by luck
+  });
+
+  it.each([
+    ['posix-shaped (what tsc emits, everywhere)', posixShaped],
+    ['windows-shaped (a backslash path, if one ever reaches us)', winShaped],
+  ])('isTestFileLine claims a %s line', (_label, line) => {
+    expect(isTestFileLine(line)).toBe(true);
+  });
+
+  it.each([
+    ['posix-shaped', 'C:/repo/node_modules/pkg/src/a/__tests__/x.test.ts'],
+    ['windows-shaped', 'C:\\repo\\node_modules\\pkg\\src\\a\\__tests__\\x.test.ts'],
+  ])('isTestFileLine still excludes node_modules in a %s line', (_label, line) => {
+    // The exclusion half was built from `path.sep` too. Normalising only the
+    // marker and not this one would let vendored test files inflate the count —
+    // a positive control that passes by counting the wrong population.
+    expect(isTestFileLine(line)).toBe(false);
+  });
+
+  it('countTestFilesInProgram counts BOTH shapes in one listing, and neither vendored one', () => {
+    const listing = [
+      posixShaped,
+      winShaped,
+      'C:/repo/node_modules/pkg/src/a/__tests__/x.test.ts',
+      'C:\\repo\\node_modules\\pkg\\src\\a\\__tests__\\x.test.ts',
+      'C:/repo/src/a/notATest.ts',
+      'C:\\repo\\src\\a\\notATest.ts',
+    ].join('\n');
+    expect(countTestFilesInProgram(listing)).toBe(2);
+  });
+
+  it('toPosixPath is idempotent and leaves an already-posix path alone', () => {
+    expect(toPosixPath(winShaped)).toBe(posixShaped);
+    expect(toPosixPath(posixShaped)).toBe(posixShaped);
+    expect(toPosixPath(toPosixPath(winShaped))).toBe(posixShaped);
+  });
+
+  it('a diagnostic path is normalised to posix, so BASELINE KEYS are host-independent', () => {
+    // The baseline is a committed JSON file whose keys come straight from this
+    // parse. Normalising with `split(path.sep)` meant the key a Windows machine
+    // produced and the key a Linux machine produced were only ever equal because
+    // tsc happens to emit one shape. A key built with a host separator would
+    // never match the committed baseline written on the other host.
+    const r = parseDiagnostics(
+      [plain('src\\a\\__tests__\\x.test.ts'), plain('src/a/__tests__/x.test.ts')].join('\n')
+    );
+    expect(r.counts.get('src/a/__tests__/x.test.ts')).toBe(2);
+    expect([...r.counts.keys()]).toEqual(['src/a/__tests__/x.test.ts']);
+    // and the normalised key is one `isGatedTestFile` claims — the predicate is
+    // written against forward slashes, so a backslash key would be silently
+    // discarded as "outside src/**/__tests__/".
+    expect(isGatedTestFile([...r.counts.keys()][0])).toBe(true);
+  });
+
+  it('LEDGER: neither production module reads path.sep in executable code', () => {
+    // Structural, not behavioural, and deliberately a ledger over BOTH files: the
+    // defect is a class, and the two normalisation sites (the listFilesOnly
+    // filter and the diagnostic-path parse) sit in different modules. A future
+    // `path.sep` anywhere in either re-pins the dimension these cases exist to
+    // unpin, and would do it silently on Linux.
+    //
+    // Comments are stripped first — both files now DISCUSS `path.sep` at length,
+    // and a ledger that counted prose would be permanently red, i.e. a gate
+    // everyone learns to delete.
+    const stripComments = (src: string) =>
+      src
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .split('\n')
+        .filter((l) => !/^\s*(\/\/|\*)/.test(l))
+        .join('\n');
+
+    // NEGATIVE CONTROL on the instrument: the stripper must not be so eager that
+    // it eats real code. Without this the assertion below is satisfied by a
+    // function that returns the empty string.
+    expect(stripComments('/** `path.sep` */\n// path.sep\nconst m = path.sep;')).toContain(
+      'const m = path.sep;'
+    );
+    expect(stripComments('/** `path.sep` */\n// path.sep\nconst m = 1;')).not.toContain('path.sep');
+
+    for (const f of ['../ci/typecheck-tests-gate.mjs', '../ci/typecheck-tests-compare.mjs']) {
+      const code = stripComments(readFileSync(path.resolve(__dirname, f), 'utf8'));
+      expect({ file: f, hits: code.match(/path\.sep/g) ?? [] }).toEqual({ file: f, hits: [] });
+      // and the stripper genuinely read this file, rather than returning nothing
+      expect(code.length).toBeGreaterThan(500);
+    }
+  });
+});
+
+describe('the gate, end to end: a Windows-shaped run must not read as CANNOT MEASURE', () => {
+  /**
+   * A wrapper stub whose `--listFilesOnly` arm answers in BACKSLASH paths. This
+   * is the separator mismatch the reporter hit, mirrored: there the marker was
+   * `\__tests__\` and the lines were posix; here the lines are win32 and the
+   * marker (pre-fix, on this Linux host) is `/__tests__/`. Same defect, same
+   * symptom, and it is reproducible on the host the suite actually runs on —
+   * which is the only reason this bug is now catchable in CI at all.
+   */
+  function winWrapperStub(name: string, body: string) {
+    const file = path.join(dir, `${name}.mjs`);
+    writeFileSync(
+      file,
+      [
+        'const args = process.argv.slice(2);',
+        "if (args.includes('--listFilesOnly')) {",
+        '  const lines = [];',
+        // built by substitution rather than escaping, so the separator in the
+        // generated file is unambiguous when read back.
+        '  for (let i = 0; i < 950; i++)',
+        '    lines.push(`/repo/src/x${i}/__tests__/f${i}.test.ts`.split("/").join(String.fromCharCode(92)));',
+        "  console.log(lines.join('\\n'));",
+        '  process.exit(0);',
+        '}',
+        body,
+      ].join('\n')
+    );
+    return file;
+  }
+
+  const unchanged = [
+    ...Array(5).fill(plain('src/a/__tests__/x.test.ts')),
+    ...Array(2).fill(plain('src/b/__tests__/y.test.ts')),
+  ];
+  const emit = (lines: string[], code = 2) =>
+    `console.log(${JSON.stringify(lines.join('\n'))});\nprocess.exit(${code});`;
+
+  it('counts a BACKSLASH --listFilesOnly listing and reaches a real verdict', () => {
+    const res = runGate(
+      winWrapperStub('win-list', emit(unchanged)),
+      fixtureBaseline('win1', BASE_FILES)
+    );
+    // Pre-fix this is exit 3 with "POSITIVE CONTROL FAILED … contains 0 file(s)"
+    // — the reporter's exact symptom, arrived at from the other side.
+    expect(res.all).not.toContain('POSITIVE CONTROL FAILED');
+    expect(res.all).toContain('positive control OK — 950 test file(s)');
+    expect(res.status).toBe(0);
+    expect(res.all).toContain('7 error(s) across 2 file(s) (baseline: 7 across 2)');
+    expect(res.all).toContain('PASS —');
+  });
+
+  it('still BLOCKS a real regression when the listing is backslash-shaped', () => {
+    // The arm above proves the gate stops refusing; this proves it did not
+    // start rubber-stamping. A normalisation that made everything match would
+    // pass the first case and fail this one.
+    const res = runGate(
+      winWrapperStub('win-list-block', emit([...unchanged, plain('src/c/__tests__/z.test.ts')])),
+      fixtureBaseline('win2', BASE_FILES)
+    );
+    expect(res.status).toBe(1);
+    expect(res.all).toContain('src/c/__tests__/z.test.ts  (1)');
+  });
+
+  it('normalises BACKSLASH diagnostic paths, so they match the committed baseline keys', () => {
+    // Separate arm, separate module: this one exercises `parseDiagnostics`, not
+    // the listFilesOnly filter. Pre-fix on Linux the keys keep their backslashes,
+    // `isGatedTestFile` rejects them as "outside src/**/__tests__/", the measured
+    // total is 0, and the plausibility control refuses the run.
+    const winDiag = (f: string) => plain(f.split('/').join('\\'));
+    const res = runGate(
+      wrapperStub(
+        'win-diag',
+        emit([
+          ...Array(5).fill(winDiag('src/a/__tests__/x.test.ts')),
+          ...Array(2).fill(winDiag('src/b/__tests__/y.test.ts')),
+        ])
+      ),
+      fixtureBaseline('win3', BASE_FILES)
+    );
+    expect(res.all).not.toContain('file(s) with errors outside');
+    expect(res.status).toBe(0);
+    expect(res.all).toContain('7 error(s) across 2 file(s) (baseline: 7 across 2)');
+    expect(res.all).toContain('PASS —');
   });
 });

--- a/scripts/ci/typecheck-tests-compare.mjs
+++ b/scripts/ci/typecheck-tests-compare.mjs
@@ -7,8 +7,67 @@
  * drives them directly.
  *
  * Nothing in this file reads the filesystem, spawns a process, or exits.
+ *
+ * Nothing in this file reads `path.sep` either, and that is load-bearing rather
+ * than incidental — see `toPosixPath` below.
  */
-import path from 'node:path';
+
+/**
+ * Normalise any path-ish string to forward slashes.
+ *
+ * EVERY path this gate compares is compared as TEXT — against the `/__tests__/`
+ * marker, against `TESTS_PATH_RE`, against the keys of a committed baseline JSON.
+ * So each of those comparisons needs one canonical separator, and the one thing
+ * it must NOT be is the HOST's.
+ *
+ * `tsc` emits forward slashes on every platform it runs on, Windows included.
+ * `path.sep` on Windows is `\`. Building a marker or a normalisation out of
+ * `path.sep` therefore produces a value that matches tsc's output on Linux and
+ * matches nothing at all on Windows — green in CI, red on a developer's machine,
+ * for a reason no amount of extra cases written on Linux could surface.
+ *
+ * Forward slash is the canonical form because it is what the tool actually
+ * emits, what the committed baseline's keys are written in, and what
+ * `TESTS_PATH_RE` is written against. Backslashes are folded into it so a path
+ * that DOES arrive win32-shaped still lands in the same space — a normalisation
+ * that only handled the shape we expect would just move the assumption.
+ */
+export function toPosixPath(p) {
+  return String(p ?? '').replace(/\\/g, '/');
+}
+
+/**
+ * The two path segments the positive control matches on, in canonical form.
+ * They are plain constants, not host-derived: that is the whole fix.
+ */
+export const TESTS_DIR_SEGMENT = '/__tests__/';
+export const NODE_MODULES_SEGMENT = '/node_modules/';
+
+/**
+ * Does this `--listFilesOnly` line name a file the positive control should
+ * count? Both halves normalise — the `node_modules` exclusion was built from
+ * `path.sep` too, and fixing only the marker would leave a control that passes
+ * by counting vendored test files.
+ */
+export function isTestFileLine(line) {
+  const p = toPosixPath(line);
+  return p.includes(TESTS_DIR_SEGMENT) && !p.includes(NODE_MODULES_SEGMENT);
+}
+
+/**
+ * The positive control's measurement: how many files under a `__tests__`
+ * directory the program actually contains, given raw `--listFilesOnly` output.
+ *
+ * It lives here, in the pure module, rather than inline in the gate, because the
+ * gate is only reachable by spawning a process and this is the exact computation
+ * that was wrong. A predicate that can only be exercised end to end is one whose
+ * platform assumptions nobody checks.
+ */
+export function countTestFilesInProgram(output) {
+  return String(output ?? '')
+    .split('\n')
+    .filter(isTestFileLine).length;
+}
 
 /**
  * The root `tsconfig.json` excludes exactly `src/ ** /__tests__/ ** `, anchored at
@@ -87,7 +146,14 @@ export function parseDiagnostics(output) {
     }
     formats.add(plain ? 'plain' : 'pretty');
     total++;
-    const file = m[1].split(path.sep).join('/').replace(/^\.\//, '');
+    // Canonical forward slashes, NOT `split(path.sep)`: these strings become the
+    // keys of the committed baseline and the input to `isGatedTestFile`, whose
+    // regex is anchored on `/`. Splitting on the host separator made a Windows
+    // run's keys and a Linux run's keys equal only by the accident of tsc
+    // emitting one shape — and left a backslash key, if one ever arrived, both
+    // unmatchable against the baseline and silently discarded as "outside
+    // src/**/__tests__/".
+    const file = toPosixPath(m[1]).replace(/^\.\//, '');
     counts.set(file, (counts.get(file) || 0) + 1);
   }
 

--- a/scripts/ci/typecheck-tests-gate.mjs
+++ b/scripts/ci/typecheck-tests-gate.mjs
@@ -110,6 +110,7 @@ import {
   classifyEmptyAllowance,
   classifyRun,
   compare,
+  countTestFilesInProgram,
   diffExcludes,
   isGatedTestFile,
   parseDiagnostics,
@@ -142,8 +143,6 @@ const WRAPPER = process.env.TYPECHECK_TESTS_WRAPPER || path.join(REPO_ROOT, 'scr
 // END, i.e. to pin that the gate ACTS on `diffExcludes`, not merely that
 // `diffExcludes` computes the right answer.
 const CONFIG_DIR = process.env.TYPECHECK_TESTS_CONFIG_DIR || REPO_ROOT;
-
-const TEST_PATH_MARKER = `${path.sep}__tests__${path.sep}`;
 
 function fail(msg, code) {
   console.error(msg);
@@ -298,10 +297,12 @@ const listed = runWrapper(['--listFilesOnly']);
 if (!listed.verdict.ok) {
   cannotMeasure(`the positive control could not run: ${listed.verdict.reason}`);
 }
-const testFilesInProgram = listed.output
-  .split('\n')
-  .filter((line) => line.includes(TEST_PATH_MARKER) && !line.includes(`${path.sep}node_modules${path.sep}`))
-  .length;
+// The count is computed in the pure module, on forward slashes. It used to be an
+// inline filter against a marker built from `path.sep` — which is `\` on Windows
+// while `tsc --listFilesOnly` emits `/` on every platform, so the marker matched
+// ZERO of 948 `__tests__` lines there and this control refused every run on a
+// Windows machine while passing in CI. See `toPosixPath`.
+const testFilesInProgram = countTestFilesInProgram(listed.output);
 
 const recordedTestFiles = baseline.testFilesInProgram ?? previous?.testFilesInProgram;
 const floorResult = testFileFloor(recordedTestFiles);


### PR DESCRIPTION
## The defect

`scripts/ci/typecheck-tests-gate.mjs` built the marker for its positive control out of the **host** path separator:

```js
const TEST_PATH_MARKER = `${path.sep}__tests__${path.sep}`;
```

and matched it against the output of `tsc --listFilesOnly`.

**`tsc` emits forward slashes on every platform, Windows included.** On Windows `path.sep` is `\`, so the marker matched nothing: a developer running the suite locally measured **948 output lines containing `__tests__` and 0 matching the marker**. The positive control then correctly refused the run —

```
CANNOT MEASURE — POSITIVE CONTROL FAILED — the program built from tsconfig.tests.json
contains 0 file(s) under a __tests__ directory, below the floor of 844
```

— and because `scripts/**/*.test.ts` is in the `unit` project's `include`, **18 of the 134 cases in `scripts/__tests__/typecheck-tests-gate.test.ts` were RED, so `pnpm run test:unit:run` was red on `main` for every developer on a Windows box.** On Linux `path.sep` is `/`, so CI was green — which is exactly why it merged clean. Nothing is wired into CI as a gate yet, so nothing was blocked; this was the local suite going red.

Reported by a developer hitting it on their own machine. Thank you — this is not a class of bug the repo's own tests could have found.

A second instance of the same class was found in the same audit and is fixed here too: `parseDiagnostics` normalised diagnostic paths with `m[1].split(path.sep).join('/')`. Those strings become the **keys of the committed baseline JSON** and the input to `isGatedTestFile`, whose regex is anchored on `/`. Splitting on the host separator meant a Windows run's keys and a Linux run's keys were equal only by the accident of tsc emitting one shape; a backslash path that did arrive would be both unmatchable against the baseline and silently discarded as "outside `src/**/__tests__/`".

## The fix

One canonical separator — forward slash, because it is what the tool emits, what the committed baseline's keys are written in, and what `TESTS_PATH_RE` is anchored on — applied to the **input**, never derived from the host:

- `toPosixPath()`, `TESTS_DIR_SEGMENT`, `NODE_MODULES_SEGMENT`, `isTestFileLine()` and `countTestFilesInProgram()` are new exports in the pure module `typecheck-tests-compare.mjs`.
- The gate's inline filter becomes `countTestFilesInProgram(listed.output)`.
- `parseDiagnostics` uses `toPosixPath` instead of `split(path.sep)`.
- The `node_modules` exclusion normalises too. Fixing only the marker would leave a control that passes by counting vendored test files.
- **Neither production module reads `path.sep` in executable code any more.**

Moving the predicate into the pure module is the part that makes it testable: it used to be reachable only by spawning the gate, and it read `path.sep` at module scope, so its platform assumption could not be exercised in-process at all.

## Why the existing suite could not see this

Every test ran on Linux, where `path.sep === '/'`, so the marker happened to equal the shape tsc emits. **The platform was a pinned dimension — not under-tested, structurally invisible.** No number of additional cases written the same way could have moved it, because every one of them would have read the same host separator. This change had a full green suite, a mutation battery and two adversarial review rounds behind it and shipped the bug anyway.

## What the new tests do differently

They never read `path.sep`. They name both separators explicitly via `path.win32.sep` / `path.posix.sep` — the same two characters on every host — so each case means the same thing on Linux and on Windows:

- a case that **documents the defect**: the pre-fix predicate, transcribed verbatim with the separator lifted into a parameter, is asserted `false` for tsc-shaped output at `path.win32.sep` and `true` at `path.posix.sep`;
- `isTestFileLine` / `countTestFilesInProgram` / `toPosixPath` driven directly with both path shapes, including the `node_modules` exclusion in both;
- `parseDiagnostics` asserted to fold a backslash diagnostic path onto the same baseline key as its forward-slash twin;
- three **end-to-end** cases that drive the gate through its existing wrapper seam with a `--listFilesOnly` listing in **backslash** shape — the reporter's separator mismatch, mirrored so that it reproduces on the Linux host CI actually runs on. Pre-fix these fail with the reporter's exact message (`POSITIVE CONTROL FAILED … contains 0 file(s)`); one of them asserts the gate still **blocks** a real regression, so a normalisation that made everything match cannot pass;
- a ledger asserting neither production module reads `path.sep` in executable code (comments stripped, with a control proving the stripper still sees real code).

## Red / green

Whole file, on Linux:

| | Tests |
|---|---|
| new tests against pre-fix code | **11 failed / 135 passed (146)** |
| after the fix | **146 passed (146)** |

The end-to-end arm fails pre-fix with the reported message verbatim, not incidentally.

## Mutation battery

9 mutants, run against the whole gate suite; verdicts read from the `Tests` line, never an exit code.

| Mutant | Expected | Result |
|---|---|---|
| M1 revert the `--listFilesOnly` fix (`path.sep` marker again) | die | died — 2 failed |
| M2 revert the diagnostic-path normalisation only | die | died — 2 failed |
| M3 dead text: normalisation commented out, wording left behind | die | died — 7 failed |
| M4 one direction: marker canonical, line not normalised | die | died — 4 failed |
| M5 one direction: line normalised, marker left win32 | die | died — 24 failed |
| M6 half fix: `node_modules` exclusion reads the raw line | die | died — 2 failed |
| M7 wrong function: normalise in the counter, not the predicate | die | died — 1 failed |
| **E1 equivalent**: `split('\\').join('/')` instead of `replace` | **survive** | survived — 146 passed |
| **E2 equivalent**: predicate conjunction reordered | **survive** | survived — 146 passed |

Both equivalent controls survived and all seven breaking mutants died. M7 is killed by exactly one case — the direct unit test of the predicate — which is why that tier exists alongside the end-to-end one.

## Gate behaviour is unchanged on Linux

Running the gate for real, with and without this change, in the same tree:

```
this branch:  positive control OK — 963 test file(s) … 843 error(s) across 146 file(s)
origin/main:  positive control OK — 963 test file(s) … 843 error(s) across 146 file(s)
```

Identical. And a `--write-baseline` regeneration under each version produces a **byte-identical** file (`sha256 a4ae0238…` both) — so this change cannot move a baseline key.

Proof-of-concept, this branch: plant a type error in a test file → `844 error(s) across 147 file(s)`, `BLOCKED`, naming `src/__tests__/zz-winpath-poc.test.ts (1)`; revert it → back to `843 / 146`. The gate still works end to end.

### Pre-existing, not from this PR

The committed baseline is **stale relative to current `main`**: the gate today reports `843 errors across 146 files` against a baseline of `801 across 141` (and `963` test files against a recorded `938`), i.e. it is **already blocking on `main`** — 5 test files newly dirty, 3 worsened, from changes merged since the baseline was taken. Identical numbers on `origin/main`, so it is not caused by this change. Deliberately **not** regenerated here: that would fold an unrelated ratchet change into a platform fix and hide it from review. It wants its own PR.

`pnpm typecheck` is 0 errors on this branch (instrument validated: a planted error reports 1). Note that `scripts/__tests__/` is inside no tsconfig program — `pnpm typecheck` excludes `src/**/__tests__/**` and `include` never names `scripts/` — so **the new test file is type-checked by nothing**, same as the rest of that suite.

Prettier: both `.mjs` files were already non-conforming on `main`; every hunk Prettier wants is in pre-existing code, none in the lines added here.
