### PR TITLE
fix(placement): page the sticker and remix review queues

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260813150000_placement_owner_queue_paging_index/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260813150000_placement_owner_queue_paging_index/migration.sql
@@ -1,0 +1,8 @@
+-- The owner review queue's paging order: filter on (ownerId, status), order by
+-- (createdAt, id). Without it every page rescans and re-sorts all of an owner's
+-- pending rows, and a refetch of a walk N pages deep pays that N+1 times.
+--
+-- CONCURRENTLY, so it cannot run inside a transaction. Safe to apply before or
+-- after the deploy — nothing reads it but the planner.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Placement_ownerId_status_createdAt_id_idx"
+  ON "Placement" ("ownerId", "status", "createdAt", "id");

--- a/packages/civitai-db-schema/prisma/migrations/20260813150000_placement_owner_queue_paging_index/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260813150000_placement_owner_queue_paging_index/migration.sql
@@ -1,8 +1,24 @@
--- The owner review queue's paging order: filter on (ownerId, status), order by
--- (createdAt, id). Without it every page rescans and re-sorts all of an owner's
--- pending rows, and a refetch of a walk N pages deep pays that N+1 times.
+-- The owner review queue's paging order: filter on (ownerId, surface, status),
+-- order by (createdAt, id). Without it every page rescans and re-sorts all of an
+-- owner's pending rows, and a refetch of a walk N pages deep pays that N+1 times.
 --
--- CONCURRENTLY, so it cannot run inside a transaction. Safe to apply before or
--- after the deploy — nothing reads it but the planner.
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "Placement_ownerId_status_createdAt_id_idx"
-  ON "Placement" ("ownerId", "status", "createdAt", "id");
+-- `surface` is in the key because both queues filter on it. Left out, it cannot
+-- be an index condition, and an owner with 900 pending stickers would touch all
+-- 900 heap tuples to fill one 50-row page of remix submissions.
+--
+-- CONCURRENTLY, so it cannot run inside a transaction. Order-free with respect
+-- to the deploy — nothing reads it but the planner.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Placement_ownerId_surface_status_createdAt_id_idx"
+  ON "Placement" ("ownerId", "surface", "status", "createdAt", "id");
+
+-- VERIFY, because this combination can report success having done nothing. An
+-- interrupted CONCURRENTLY build leaves the index in place marked invalid; the
+-- planner then ignores it while every write still maintains it, and IF NOT
+-- EXISTS makes every retry a silent no-op.
+--
+--   SELECT indisvalid FROM pg_index
+--   WHERE indexrelid = '"Placement_ownerId_surface_status_createdAt_id_idx"'::regclass;
+--
+-- If that returns false: REINDEX INDEX CONCURRENTLY
+-- "Placement_ownerId_surface_status_createdAt_id_idx"; or DROP INDEX
+-- CONCURRENTLY and re-run the statement above.

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -7880,6 +7880,10 @@ model Placement {
 
   @@index([surface, targetType, targetId, status])
   @@index([ownerId, status])
+  /// The owner review queue's paging order. Without it each page rescans and
+  /// re-sorts every pending row the owner has, and a refetch of a walk N pages
+  /// deep pays that N+1 times.
+  @@index([ownerId, status, createdAt, id])
   @@index([placerId, status])
   @@index([status, expiresAt])
 }

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -7883,7 +7883,13 @@ model Placement {
   /// The owner review queue's paging order. Without it each page rescans and
   /// re-sorts every pending row the owner has, and a refetch of a walk N pages
   /// deep pays that N+1 times.
-  @@index([ownerId, status, createdAt, id])
+  ///
+  /// `surface` is in it because both queues filter on it, and left out it cannot
+  /// be an index condition — an owner with 900 pending stickers would touch all
+  /// 900 heap tuples to fill one 50-row page of remix submissions. It sits after
+  /// `ownerId` rather than first so this does not become a strict prefix of
+  /// `[ownerId, status]` above, which the moderation lookups still want.
+  @@index([ownerId, surface, status, createdAt, id])
   @@index([placerId, status])
   @@index([status, expiresAt])
 }

--- a/src/components/Account/PlacementSpaceSection.tsx
+++ b/src/components/Account/PlacementSpaceSection.tsx
@@ -251,7 +251,14 @@ export function PlacementSpaceSection() {
           size="sm"
           rightSection={
             waiting > 0 ? (
-              <Badge size="sm" color="yellow" variant="filled" circle>
+              <Badge
+                size="sm"
+                color="yellow"
+                variant="filled"
+                // See the remix tab badge: a disc clips the "+" off "50+".
+                circle={!pending?.nextCursor}
+                px={pending?.nextCursor ? 6 : undefined}
+              >
                 {waitingLabel}
               </Badge>
             ) : undefined

--- a/src/components/Account/PlacementSpaceSection.tsx
+++ b/src/components/Account/PlacementSpaceSection.tsx
@@ -59,7 +59,7 @@ export function PlacementSpaceSection() {
     isPending: spacesPending,
     isError: spacesFailed,
   } = trpc.placement.getMySpaces.useQuery({ surface: 'sticker' }, { enabled });
-  const { data: pending } = trpc.placement.getPending.useQuery(undefined, { enabled });
+  const { data: pending } = trpc.placement.getPending.useQuery({}, { enabled });
 
   const stored = spaces?.[0];
   // Seeded from the surface defaults, not from `off`. With no row the cascade
@@ -107,7 +107,11 @@ export function PlacementSpaceSection() {
   if (spacesPending || spacesFailed) return null;
 
   const cap = range?.max ?? 0;
-  const waiting = pending?.length ?? 0;
+  const waiting = pending?.items.length ?? 0;
+  // One page's worth is a floor, not a total. Badging it as an exact number
+  // tells an owner with 200 waiting that they have 50, which is the same lie
+  // the unpaged queue told.
+  const waitingLabel = pending?.nextCursor ? `${waiting}+` : `${waiting}`;
   const caption = placementPriceCaption(
     'sticker',
     price === '' ? DEFAULT_PRICE ?? 0 : price,
@@ -248,7 +252,7 @@ export function PlacementSpaceSection() {
           rightSection={
             waiting > 0 ? (
               <Badge size="sm" color="yellow" variant="filled" circle>
-                {waiting}
+                {waitingLabel}
               </Badge>
             ) : undefined
           }

--- a/src/components/RemixGallery/RemixGalleryManageModal.tsx
+++ b/src/components/RemixGallery/RemixGalleryManageModal.tsx
@@ -121,6 +121,7 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
   const {
     data: pendingPages,
     isLoading: pendingLoading,
+    isError: pendingFailed,
     fetchNextPage: fetchMorePending,
     hasNextPage: hasMorePending,
     isFetchingNextPage: fetchingMorePending,
@@ -240,6 +241,13 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
               <Group justify="center" py="md">
                 <Loader size="sm" />
               </Group>
+            ) : pendingFailed ? (
+              // No pages means `hasMorePending` is false too, so without this the
+              // branch below would say "nothing waiting" over a queue that failed
+              // to load.
+              <Text size="sm" c="red" mt="sm">
+                Couldn&rsquo;t load the review queue. Refresh to try again.
+              </Text>
             ) : forThisImage.length || hasMorePending ? (
               <Stack gap="xs" mt="sm">
                 {/* A page can come back empty with a cursor still set — every

--- a/src/components/RemixGallery/RemixGalleryManageModal.tsx
+++ b/src/components/RemixGallery/RemixGalleryManageModal.tsx
@@ -231,7 +231,7 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
               badge={
                 forThisImage.length ? (
                   <Badge size="sm" variant="light" color="yellow">
-                    {forThisImage.length}
+                    {hasMorePending ? `${forThisImage.length}+` : forThisImage.length}
                   </Badge>
                 ) : null
               }
@@ -240,8 +240,17 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
               <Group justify="center" py="md">
                 <Loader size="sm" />
               </Group>
-            ) : forThisImage.length ? (
+            ) : forThisImage.length || hasMorePending ? (
               <Stack gap="xs" mt="sm">
+                {/* A page can come back empty with a cursor still set — every
+                    submission on it had its image deleted, unpublished or still
+                    ingesting. Saying "nothing waiting" here would hide the ones
+                    behind it, which is the bug the paging exists to end. */}
+                {!forThisImage.length && (
+                  <Text size="sm" c="dimmed">
+                    Nothing on this page can be shown. There are more waiting.
+                  </Text>
+                )}
                 {forThisImage.map((row) => (
                   <Card key={row.id} withBorder p="xs" radius="md">
                     <Group justify="space-between" wrap="nowrap" align="center">

--- a/src/components/RemixGallery/RemixGalleryManageModal.tsx
+++ b/src/components/RemixGallery/RemixGalleryManageModal.tsx
@@ -40,11 +40,7 @@ import { VerifiedRemixBadge } from '~/components/RemixGallery/VerifiedRemixBadge
 import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { Currency } from '~/shared/utils/prisma/enums';
-import {
-  REMIX_GALLERY_MAX_PINNED,
-  REMIX_GALLERY_QUEUE_LIMIT,
-  remixGalleryRemovableAt,
-} from '~/shared/utils/remix-gallery';
+import { REMIX_GALLERY_MAX_PINNED, remixGalleryRemovableAt } from '~/shared/utils/remix-gallery';
 import { daysFromNow, formatDateMin } from '~/utils/date-helpers';
 import { showErrorNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
@@ -122,8 +118,20 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
   // Scoped server-side. Filtering the account-wide list here meant its limit
   // truncated before the filter ran, so a busy owner saw "nothing waiting" on
   // an image that had submissions.
-  const { data: pending, isLoading: pendingLoading } =
-    trpc.placement.getPendingRemixGallerySubmissions.useQuery({ hostImageId: imageId });
+  const {
+    data: pendingPages,
+    isLoading: pendingLoading,
+    fetchNextPage: fetchMorePending,
+    hasNextPage: hasMorePending,
+    isFetchingNextPage: fetchingMorePending,
+  } = trpc.placement.getPendingRemixGallerySubmissions.useInfiniteQuery(
+    { hostImageId: imageId },
+    { getNextPageParam: (lastPage) => lastPage.nextCursor }
+  );
+  const pending = useMemo(
+    () => ({ items: pendingPages?.pages.flatMap((page) => page.items) ?? [] }),
+    [pendingPages]
+  );
 
   // **Deliberately does not send the viewer's browsing level**, unlike the
   // gallery card. This is the owner managing what sits on their own image, so a
@@ -304,14 +312,15 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
                     </Group>
                   </Card>
                 ))}
-                {/* The queue does not page. Without this line a busy owner
-                    sees a full list that looks complete and never learns the
-                    rest exist — and the escrow behind those sits until it
-                    expires. */}
-                {pending?.truncated && (
-                  <Text size="xs" c="dimmed">
-                    Showing the first {REMIX_GALLERY_QUEUE_LIMIT}. Answer some to see the rest.
-                  </Text>
+                {hasMorePending && (
+                  <Button
+                    variant="default"
+                    size="xs"
+                    loading={fetchingMorePending}
+                    onClick={() => fetchMorePending()}
+                  >
+                    Load more
+                  </Button>
                 )}
               </Stack>
             ) : (

--- a/src/components/RemixGallery/RemixGalleryManageModal.tsx
+++ b/src/components/RemixGallery/RemixGalleryManageModal.tsx
@@ -402,7 +402,12 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
             <div className="mt-2 grid grid-cols-4 gap-3">
               {unpinned.map((item) => (
                 <div key={item.placementId} className="relative">
-                  <AspectRatioImageCard aspectRatio="square" image={item.image} />
+                  {/* `explain={false}` for the same reason the submission
+                      thumbnail does it: the default stacks a centered "rated X"
+                      block with its own Show button on top of the corner
+                      toggle, and in a four-across grid it covers the tile and
+                      the pin and remove controls sitting on it. */}
+                  <AspectRatioImageCard aspectRatio="square" image={item.image} explain={false} />
                   <Group gap={4} className="absolute right-1 top-1">
                     {/* Pinning is the creator's curation, and `setRemixGalleryPins`
                         scopes its lookup to the caller as owner — a moderator
@@ -598,7 +603,9 @@ function SortablePin({ item, onUnpin }: { item: RemixGalleryItem; onUnpin: () =>
       {...attributes}
       {...listeners}
     >
-      <AspectRatioImageCard aspectRatio="square" image={item.image} />
+      {/* Same as the unpinned grid above — and here the centered overlay also
+          sits on top of a drag handle. */}
+      <AspectRatioImageCard aspectRatio="square" image={item.image} explain={false} />
       <Tooltip label="Unpin">
         <ActionIcon
           size="sm"

--- a/src/components/RemixGallery/RemixGallerySettings.tsx
+++ b/src/components/RemixGallery/RemixGallerySettings.tsx
@@ -82,6 +82,8 @@ export function RemixGallerySettings() {
   // Waiting on the owner, and waiting on someone else. Only the first is a
   // to-do, which is why it is the one badged in yellow.
   const receivedCount = pending?.items.length ?? 0;
+  // A floor once the queue pages — see the sticker twin in PlacementSpaceSection.
+  const receivedLabel = pending?.nextCursor ? `${receivedCount}+` : `${receivedCount}`;
   const sentCount = (sent ?? []).filter((row) => row.status === 'pending').length;
   const caption = placementPriceCaption(
     'remixGallery',
@@ -227,7 +229,7 @@ export function RemixGallerySettings() {
           rightSection={
             receivedCount > 0 ? (
               <Badge size="sm" color="yellow" variant="filled" circle>
-                {receivedCount}
+                {receivedLabel}
               </Badge>
             ) : undefined
           }

--- a/src/components/RemixGallery/RemixGallerySettings.tsx
+++ b/src/components/RemixGallery/RemixGallerySettings.tsx
@@ -228,7 +228,14 @@ export function RemixGallerySettings() {
           size="sm"
           rightSection={
             receivedCount > 0 ? (
-              <Badge size="sm" color="yellow" variant="filled" circle>
+              <Badge
+                size="sm"
+                color="yellow"
+                variant="filled"
+                // See the remix tab badge: a disc clips the "+" off "50+".
+                circle={!pending?.nextCursor}
+                px={pending?.nextCursor ? 6 : undefined}
+              >
                 {receivedLabel}
               </Badge>
             ) : undefined

--- a/src/components/RemixGallery/SubmissionThumb.tsx
+++ b/src/components/RemixGallery/SubmissionThumb.tsx
@@ -26,7 +26,12 @@ export function SubmissionThumb({ image }: { image: NonNullable<PendingSubmissio
         rel="noreferrer"
         className="group relative block w-20 shrink-0"
       >
-        <AspectRatioImageCard aspectRatio="square" image={image} />
+        {/* `explain={false}` because this is 80px wide. The default renders the
+            centered "This image is rated X" block with its own Show button on
+            top of the corner toggle — two reveal controls on one thumbnail, and
+            at this size the centered one covers the whole tile and takes the
+            click that should open the image. The corner toggle is the reveal. */}
+        <AspectRatioImageCard aspectRatio="square" image={image} explain={false} />
         {/* Hidden until hover: the affordance has to be discoverable without
             putting a permanent scrim over every thumbnail in the queue. */}
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-md bg-black/50 opacity-0 transition-opacity group-hover:opacity-100">

--- a/src/pages/user/remix-submissions.tsx
+++ b/src/pages/user/remix-submissions.tsx
@@ -105,7 +105,15 @@ export default function RemixSubmissions() {
                 value="received"
                 rightSection={
                   waiting || hasNextPage ? (
-                    <Badge size="sm" variant="filled" circle>
+                    // `circle` fixes the width to a one- or two-character disc,
+                    // so the "+" of a truncated count clips to "5…". A pill for
+                    // the wider label, the disc for the plain count.
+                    <Badge
+                      size="sm"
+                      variant="filled"
+                      circle={!hasNextPage}
+                      px={hasNextPage ? 6 : undefined}
+                    >
                       {hasNextPage ? `${waiting}+` : waiting}
                     </Badge>
                   ) : null

--- a/src/pages/user/remix-submissions.tsx
+++ b/src/pages/user/remix-submissions.tsx
@@ -73,6 +73,7 @@ export default function RemixSubmissions() {
   const {
     data: received,
     isLoading: receivedLoading,
+    isError: receivedFailed,
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
@@ -103,7 +104,7 @@ export default function RemixSubmissions() {
               <Tabs.Tab
                 value="received"
                 rightSection={
-                  waiting ? (
+                  waiting || hasNextPage ? (
                     <Badge size="sm" variant="filled" circle>
                       {hasNextPage ? `${waiting}+` : waiting}
                     </Badge>
@@ -119,6 +120,7 @@ export default function RemixSubmissions() {
               <ReceivedTab
                 rows={receivedRows}
                 isLoading={receivedLoading}
+                isError={receivedFailed}
                 hasMore={!!hasNextPage}
                 isFetchingMore={isFetchingNextPage}
                 onLoadMore={() => fetchNextPage()}
@@ -140,12 +142,14 @@ type ReceivedRow = RouterOutput['placement']['getPendingRemixGallerySubmissions'
 function ReceivedTab({
   rows,
   isLoading,
+  isError,
   hasMore,
   isFetchingMore,
   onLoadMore,
 }: {
   rows: ReceivedRow[];
   isLoading: boolean;
+  isError: boolean;
   hasMore: boolean;
   isFetchingMore: boolean;
   onLoadMore: () => void;
@@ -179,6 +183,16 @@ function ReceivedTab({
       <Group justify="center" py="xl">
         <Loader />
       </Group>
+    );
+
+  // A failed read has no pages, so `hasMore` is false and the empty state below
+  // would say "nothing is waiting" over a queue nobody could load. Said out loud
+  // instead — the owner can retry; escrow they never hear about expires.
+  if (isError)
+    return (
+      <Alert color="red">
+        <Text size="sm">Couldn&rsquo;t load your review queue. Refresh to try again.</Text>
+      </Alert>
     );
 
   // `&& !hasMore` is the whole point. A page whose rows were all dropped —

--- a/src/pages/user/remix-submissions.tsx
+++ b/src/pages/user/remix-submissions.tsx
@@ -70,12 +70,21 @@ export default function RemixSubmissions() {
 
   // Both run on mount rather than per-tab: the received count is shown on the
   // tab itself, so it has to be known while `sent` is the one on screen.
-  const { data: received, isLoading: receivedLoading } =
-    trpc.placement.getPendingRemixGallerySubmissions.useQuery({});
+  const {
+    data: received,
+    isLoading: receivedLoading,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = trpc.placement.getPendingRemixGallerySubmissions.useInfiniteQuery(
+    {},
+    { getNextPageParam: (lastPage) => lastPage.nextCursor }
+  );
   const { data: sent, isLoading: sentLoading } =
     trpc.placement.getMyRemixGallerySubmissions.useQuery();
 
-  const waiting = received?.items.length ?? 0;
+  const receivedRows = received?.pages.flatMap((page) => page.items) ?? [];
+  const waiting = receivedRows.length;
 
   return (
     <>
@@ -96,7 +105,7 @@ export default function RemixSubmissions() {
                 rightSection={
                   waiting ? (
                     <Badge size="sm" variant="filled" circle>
-                      {waiting}
+                      {hasNextPage ? `${waiting}+` : waiting}
                     </Badge>
                   ) : null
                 }
@@ -108,9 +117,11 @@ export default function RemixSubmissions() {
 
             <Tabs.Panel value="received" pt="md">
               <ReceivedTab
-                rows={received?.items ?? []}
-                truncated={!!received?.truncated}
+                rows={receivedRows}
                 isLoading={receivedLoading}
+                hasMore={!!hasNextPage}
+                isFetchingMore={isFetchingNextPage}
+                onLoadMore={() => fetchNextPage()}
               />
             </Tabs.Panel>
 
@@ -128,12 +139,16 @@ type ReceivedRow = RouterOutput['placement']['getPendingRemixGallerySubmissions'
 
 function ReceivedTab({
   rows,
-  truncated,
   isLoading,
+  hasMore,
+  isFetchingMore,
+  onLoadMore,
 }: {
   rows: ReceivedRow[];
-  truncated: boolean;
   isLoading: boolean;
+  hasMore: boolean;
+  isFetchingMore: boolean;
+  onLoadMore: () => void;
 }) {
   const utils = trpc.useUtils();
 
@@ -183,14 +198,6 @@ function ReceivedTab({
 
   return (
     <Stack gap="md">
-      {/* Neither queue pages. A list that stops at the cap and says nothing
-          reads as complete. */}
-      {truncated && (
-        <Text size="xs" c="dimmed">
-          Showing the first {REMIX_GALLERY_QUEUE_LIMIT}.
-        </Text>
-      )}
-
       {rows.map((row) => (
         <Card key={row.id} withBorder>
           <Group justify="space-between" wrap="nowrap" align="flex-start">
@@ -254,6 +261,12 @@ function ReceivedTab({
           </Group>
         </Card>
       ))}
+
+      {hasMore && (
+        <Button variant="default" loading={isFetchingMore} onClick={onLoadMore}>
+          Load more
+        </Button>
+      )}
     </Stack>
   );
 }

--- a/src/pages/user/remix-submissions.tsx
+++ b/src/pages/user/remix-submissions.tsx
@@ -181,7 +181,12 @@ function ReceivedTab({
       </Group>
     );
 
-  if (!rows.length)
+  // `&& !hasMore` is the whole point. A page whose rows were all dropped —
+  // submissions whose image was deleted, unpublished or is still ingesting —
+  // returns no items and a cursor. Returning the empty state here would put
+  // "nothing is waiting" over a queue with entries behind it, which is the
+  // failure this paging exists to end, moved one layer up.
+  if (!rows.length && !hasMore)
     return (
       <Alert color="gray">
         <Text size="sm">Nothing is waiting for your review.</Text>
@@ -198,6 +203,13 @@ function ReceivedTab({
 
   return (
     <Stack gap="md">
+      {!rows.length && (
+        <Text size="sm" c="dimmed">
+          Nothing on this page can be shown — the images behind these submissions are gone or still
+          processing. There are more waiting.
+        </Text>
+      )}
+
       {rows.map((row) => (
         <Card key={row.id} withBorder>
           <Group justify="space-between" wrap="nowrap" align="flex-start">

--- a/src/pages/user/sticker-placements.tsx
+++ b/src/pages/user/sticker-placements.tsx
@@ -64,7 +64,10 @@ export default function StickerPlacements() {
             </div>
             {rows.length > 0 && (
               <Checkbox
-                label="Select all"
+                // Names what it selects. With the queue paged it reaches the
+                // rows on screen, and an owner who bulk-declined believing they
+                // had cleared 200 would find 150 still waiting.
+                label={hasNextPage ? 'Select all loaded' : 'Select all'}
                 checked={allSelected}
                 indeterminate={selected.length > 0 && !allSelected}
                 onChange={() => setSelected(allSelected ? [] : rows.map((row) => row.id))}
@@ -83,7 +86,10 @@ export default function StickerPlacements() {
           )}
 
           {isLoading && <Text size="sm">Loading…</Text>}
-          {!isLoading && !rows.length && (
+          {/* `&& !hasNextPage`: a page whose rows were all dropped returns
+              nothing with a cursor still set, and "nothing waiting" over a
+              queue that has more is the failure paging exists to end. */}
+          {!isLoading && !rows.length && !hasNextPage && (
             <Alert>
               <Text size="sm">Nothing waiting. Placements you approve show up on your images.</Text>
             </Alert>

--- a/src/pages/user/sticker-placements.tsx
+++ b/src/pages/user/sticker-placements.tsx
@@ -1,4 +1,15 @@
-import { Alert, Anchor, Card, Checkbox, Container, Group, Stack, Text, Title } from '@mantine/core';
+import {
+  Alert,
+  Anchor,
+  Button,
+  Card,
+  Checkbox,
+  Container,
+  Group,
+  Stack,
+  Text,
+  Title,
+} from '@mantine/core';
 import { IconExternalLink } from '@tabler/icons-react';
 import Link from 'next/link';
 import { useState } from 'react';
@@ -21,10 +32,14 @@ import { trpc } from '~/utils/trpc';
  * and to clear a backlog in one pass.
  */
 export default function StickerPlacements() {
-  const { data: pending, isLoading } = trpc.placement.getPending.useQuery();
+  const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    trpc.placement.getPending.useInfiniteQuery(
+      {},
+      { getNextPageParam: (lastPage) => lastPage.nextCursor }
+    );
   const [selected, setSelected] = useState<number[]>([]);
 
-  const rows = pending ?? [];
+  const rows = data?.pages.flatMap((page) => page.items) ?? [];
   const cosmeticIds = rows.map((row) => row.data.cosmeticId);
   const { sticker } = useStickerCosmetics(cosmeticIds);
 
@@ -177,6 +192,12 @@ export default function StickerPlacements() {
               </Card>
             );
           })}
+
+          {hasNextPage && (
+            <Button variant="default" loading={isFetchingNextPage} onClick={() => fetchNextPage()}>
+              Load more
+            </Button>
+          )}
         </Stack>
       </Container>
     </>

--- a/src/pages/user/sticker-placements.tsx
+++ b/src/pages/user/sticker-placements.tsx
@@ -32,7 +32,7 @@ import { trpc } from '~/utils/trpc';
  * and to clear a backlog in one pass.
  */
 export default function StickerPlacements() {
-  const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
+  const { data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
     trpc.placement.getPending.useInfiniteQuery(
       {},
       { getNextPageParam: (lastPage) => lastPage.nextCursor }
@@ -86,13 +86,26 @@ export default function StickerPlacements() {
           )}
 
           {isLoading && <Text size="sm">Loading…</Text>}
+          {/* A failed read has no pages, so `hasNextPage` is false and the
+              empty state below would claim the queue is clear. */}
+          {isError && (
+            <Alert color="red">
+              <Text size="sm">Couldn&rsquo;t load your queue. Refresh to try again.</Text>
+            </Alert>
+          )}
           {/* `&& !hasNextPage`: a page whose rows were all dropped returns
               nothing with a cursor still set, and "nothing waiting" over a
               queue that has more is the failure paging exists to end. */}
-          {!isLoading && !rows.length && !hasNextPage && (
+          {!isLoading && !isError && !rows.length && !hasNextPage && (
             <Alert>
               <Text size="sm">Nothing waiting. Placements you approve show up on your images.</Text>
             </Alert>
+          )}
+
+          {!rows.length && hasNextPage && (
+            <Text size="sm" c="dimmed">
+              Nothing on this page can be shown. There are more waiting.
+            </Text>
           )}
 
           {rows.map((row) => {

--- a/src/server/routers/placement.router.ts
+++ b/src/server/routers/placement.router.ts
@@ -7,6 +7,7 @@ import {
   countPendingPlacementsFromSchema,
   getPlacementSettlementStatesSchema,
   getPendingRemixGallerySubmissionsSchema,
+  getPendingStickerPlacementsSchema,
   getRemixGallerySchema,
   getRemixGalleryVisibilitySchema,
   getStickerPlacementDetailSchema,
@@ -281,9 +282,11 @@ export const placementRouter = router({
     .input(placerSchema)
     .mutation(({ input }) => restorePlacementPrivileges(input.userId)),
 
-  getPending: protectedProcedure.query(({ ctx }) =>
-    getPendingStickerPlacements({ ownerId: ctx.user.id })
-  ),
+  getPending: protectedProcedure
+    .input(getPendingStickerPlacementsSchema)
+    .query(({ input, ctx }) =>
+      getPendingStickerPlacements({ ownerId: ctx.user.id, cursor: input.cursor })
+    ),
 
   // How many pending placements blocking someone would decline, so the confirm
   // dialog can say. Advisory by construction — holding it accurate across a
@@ -371,7 +374,11 @@ export const placementRouter = router({
   getPendingRemixGallerySubmissions: protectedProcedure
     .input(getPendingRemixGallerySubmissionsSchema)
     .query(({ input, ctx }) =>
-      getPendingRemixGallerySubmissions({ ownerId: ctx.user.id, hostImageId: input.hostImageId })
+      getPendingRemixGallerySubmissions({
+        ownerId: ctx.user.id,
+        hostImageId: input.hostImageId,
+        cursor: input.cursor,
+      })
     ),
 
   getMyRemixGallerySubmissions: protectedProcedure.query(({ ctx }) =>

--- a/src/server/schema/placement.schema.ts
+++ b/src/server/schema/placement.schema.ts
@@ -202,7 +202,15 @@ export const setRemixGalleryPinsSchema = z.object({
   placementIds: z.array(z.number().int().positive()).max(REMIX_GALLERY_MAX_PINNED),
 });
 
+/** Where the last page stopped. Opaque to the client; see `placementQueueKeyset`. */
+const placementQueueCursorSchema = z.string().max(100).nullish();
+
 export const getPendingRemixGallerySubmissionsSchema = z.object({
   /** Omitted for the account-wide queue; set to scope to one gallery. */
   hostImageId: z.number().int().positive().optional(),
+  cursor: placementQueueCursorSchema,
+});
+
+export const getPendingStickerPlacementsSchema = z.object({
+  cursor: placementQueueCursorSchema,
 });

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -44,7 +44,10 @@ vi.mock('~/server/services/placement-space.service', () => ({ resolvePlacementSp
 vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn().mockResolvedValue(undefined) }));
 
 vi.mock('~/server/services/placement.service', () => ({
-  getPlacementConfig: async () => ({ declineFeeRate: () => 0.3 }),
+  getPlacementConfig: async () => ({
+    declineFeeRate: () => 0.3,
+    approvalShares: () => ({ seller: 0, platform: 0 }),
+  }),
 }));
 
 /**
@@ -99,6 +102,7 @@ const {
   parseGalleryCursor,
   getRemixGallery,
   getRemixGalleryVisibility,
+  getPendingRemixGallerySubmissions,
 } = await import('~/server/services/remix-gallery.service');
 
 const {
@@ -1050,5 +1054,92 @@ describe('an approved submission counts toward the host image buzz counter', () 
       actOnRemixGallerySubmission({ placementId: PLACEMENT, action: 'approve', userId: OWNER })
     ).rejects.toThrow(/already resolved/i);
     expect(updateEntityMetricDetached).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The review queue pages, and the escrow behind an entry it skips expires
+ * without the owner ever being offered the choice — so "did we skip one" is the
+ * only question these ask.
+ */
+describe('getPendingRemixGallerySubmissions paging', () => {
+  const queueRow = (id: number, imageId: number, createdAt: string) => ({
+    id,
+    targetId: HOST_IMAGE,
+    placerId: PLACER,
+    amount: PRICE,
+    data: { imageId },
+    createdAt: new Date(createdAt),
+    expiresAt: null,
+    placer: { id: PLACER, username: 'someone', image: null },
+  });
+
+  /** Only the first image resolves, so the rest of the page is filtered out. */
+  const onlyFirstImageVisible = (imageId: number) =>
+    queryRaw.mockResolvedValue([
+      { id: imageId, url: 'x', width: 1, height: 1, type: 'image', metadata: null, nsfwLevel: 1 },
+    ]);
+
+  beforeEach(() => {
+    queryRaw.mockResolvedValue([]);
+  });
+
+  it('takes the cursor from the last row of the page, not the last row it returns', async () => {
+    // Three rows for a page of two: the third is the "is there more" probe, and
+    // the second is dropped below because its image no longer resolves.
+    placementFindMany.mockResolvedValue([
+      queueRow(1, 101, '2026-01-01T00:00:00.000Z'),
+      queueRow(2, 102, '2026-01-02T00:00:00.000Z'),
+      queueRow(3, 103, '2026-01-03T00:00:00.000Z'),
+    ]);
+    onlyFirstImageVisible(101);
+
+    const result = await getPendingRemixGallerySubmissions({ ownerId: OWNER, limit: 2 });
+
+    expect(result.items.map((item) => item.id)).toEqual([1]);
+    // Row 2's key. A cursor built from what was returned would say row 1, and
+    // the next page would serve row 2 a second time.
+    expect(result.nextCursor).toBe(`${new Date('2026-01-02T00:00:00.000Z').getTime()}:2`);
+  });
+
+  it('reports no next page when the queue ends inside the page', async () => {
+    placementFindMany.mockResolvedValue([queueRow(1, 101, '2026-01-01T00:00:00.000Z')]);
+    onlyFirstImageVisible(101);
+
+    const result = await getPendingRemixGallerySubmissions({ ownerId: OWNER, limit: 2 });
+
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it('resumes strictly after the cursor row, including its same-millisecond twin', async () => {
+    placementFindMany.mockResolvedValue([]);
+    const createdAt = new Date('2026-01-02T00:00:00.000Z');
+
+    await getPendingRemixGallerySubmissions({
+      ownerId: OWNER,
+      limit: 2,
+      cursor: `${createdAt.getTime()}:2`,
+    });
+
+    const { where, orderBy, take } = placementFindMany.mock.calls.at(-1)?.[0] as {
+      where: { OR?: unknown[] };
+      orderBy: unknown;
+      take: number;
+    };
+    // Two placements can share a millisecond. Without the id tie-break one of
+    // them is stepped over and its escrow expires unreviewed.
+    expect(where.OR).toEqual([{ createdAt: { gt: createdAt } }, { createdAt, id: { gt: 2 } }]);
+    expect(orderBy).toEqual([{ createdAt: 'asc' }, { id: 'asc' }]);
+    // limit + 1: the extra row is what says whether another page exists.
+    expect(take).toBe(3);
+  });
+
+  it('starts a fresh page rather than a NaN query when the cursor is malformed', async () => {
+    placementFindMany.mockResolvedValue([]);
+
+    await getPendingRemixGallerySubmissions({ ownerId: OWNER, limit: 2, cursor: 'nonsense' });
+
+    const { where } = placementFindMany.mock.calls.at(-1)?.[0] as { where: { OR?: unknown[] } };
+    expect(where.OR).toBeUndefined();
   });
 });

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -46,6 +46,8 @@ vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn().mockResolvedValu
 vi.mock('~/server/services/placement.service', () => ({
   getPlacementConfig: async () => ({
     declineFeeRate: () => 0.3,
+    // Not the real defaults — no test here asserts an owner payout. Anything
+    // that starts to must set these, or it will read 100% to the owner.
     approvalShares: () => ({ seller: 0, platform: 0 }),
   }),
 }));
@@ -1134,12 +1136,36 @@ describe('getPendingRemixGallerySubmissions paging', () => {
     expect(take).toBe(3);
   });
 
-  it('starts a fresh page rather than a NaN query when the cursor is malformed', async () => {
+  it('reports no next page when the queue ends exactly on the page boundary', async () => {
+    // The case the old `truncated = rows.length >= limit` got wrong. `take` is
+    // limit + 1, so a queue of exactly `limit` returns `limit` rows and there is
+    // nothing behind it — a cursor here sends the owner to an empty page.
+    placementFindMany.mockResolvedValue([
+      queueRow(1, 101, '2026-01-01T00:00:00.000Z'),
+      queueRow(2, 102, '2026-01-02T00:00:00.000Z'),
+    ]);
+    onlyFirstImageVisible(101);
+
+    const result = await getPendingRemixGallerySubmissions({ ownerId: OWNER, limit: 2 });
+
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it('starts a fresh page rather than a bad value in a query when the cursor is malformed', async () => {
     placementFindMany.mockResolvedValue([]);
+    const wellFormed = `${new Date('2026-01-02T00:00:00.000Z').getTime()}:2`;
 
-    await getPendingRemixGallerySubmissions({ ownerId: OWNER, limit: 2, cursor: 'nonsense' });
+    // The positive control. Without it this test passes with the keyset removed
+    // entirely, because then no cursor ever produces an `OR`.
+    await getPendingRemixGallerySubmissions({ ownerId: OWNER, limit: 2, cursor: wellFormed });
+    const accepted = placementFindMany.mock.calls.at(-1)?.[0] as { where: { OR?: unknown[] } };
+    expect(accepted.where.OR).toHaveLength(2);
 
-    const { where } = placementFindMany.mock.calls.at(-1)?.[0] as { where: { OR?: unknown[] } };
-    expect(where.OR).toBeUndefined();
+    for (const cursor of ['nonsense', '1e21:1', '1700000000000:1.5', '1:2:3', '-1:2']) {
+      await getPendingRemixGallerySubmissions({ ownerId: OWNER, limit: 2, cursor });
+
+      const { where } = placementFindMany.mock.calls.at(-1)?.[0] as { where: { OR?: unknown[] } };
+      expect(where.OR, `cursor ${cursor} reached the query`).toBeUndefined();
+    }
   });
 });

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -1104,6 +1104,40 @@ describe('getPendingRemixGallerySubmissions paging', () => {
     expect(result.nextCursor).toBe(`${new Date('2026-01-02T00:00:00.000Z').getTime()}:2`);
   });
 
+  it('still hands back a cursor when EVERY row on the page was filtered out', async () => {
+    // The state the UI now depends on. Return `nextCursor: null` here and the
+    // owner is told "nothing is waiting" over a queue with entries behind it —
+    // the original bug, one layer up, with every other test still green.
+    placementFindMany.mockResolvedValue([
+      queueRow(1, 101, '2026-01-01T00:00:00.000Z'),
+      queueRow(2, 102, '2026-01-02T00:00:00.000Z'),
+      queueRow(3, 103, '2026-01-03T00:00:00.000Z'),
+    ]);
+    queryRaw.mockResolvedValue([]);
+
+    const result = await getPendingRemixGallerySubmissions({ ownerId: OWNER, limit: 2 });
+
+    expect(result.items).toEqual([]);
+    expect(result.nextCursor).toBe(`${new Date('2026-01-02T00:00:00.000Z').getTime()}:2`);
+  });
+
+  it('hands back a cursor on the early return too, when no row even names an image', async () => {
+    // The `!imageIds.length` short-circuit is a second exit from this function
+    // and it has to carry the cursor for the same reason the main one does. The
+    // test above cannot reach it — those rows name images that simply are not
+    // visible, so it leaves by the filter at the end instead.
+    placementFindMany.mockResolvedValue([
+      { ...queueRow(1, 0, '2026-01-01T00:00:00.000Z'), data: { nonsense: true } },
+      { ...queueRow(2, 0, '2026-01-02T00:00:00.000Z'), data: { nonsense: true } },
+      { ...queueRow(3, 0, '2026-01-03T00:00:00.000Z'), data: { nonsense: true } },
+    ]);
+
+    const result = await getPendingRemixGallerySubmissions({ ownerId: OWNER, limit: 2 });
+
+    expect(result.items).toEqual([]);
+    expect(result.nextCursor).toBe(`${new Date('2026-01-02T00:00:00.000Z').getTime()}:2`);
+  });
+
   it('reports no next page when the queue ends inside the page', async () => {
     placementFindMany.mockResolvedValue([queueRow(1, 101, '2026-01-01T00:00:00.000Z')]);
     onlyFirstImageVisible(101);
@@ -1161,7 +1195,7 @@ describe('getPendingRemixGallerySubmissions paging', () => {
     const accepted = placementFindMany.mock.calls.at(-1)?.[0] as { where: { OR?: unknown[] } };
     expect(accepted.where.OR).toHaveLength(2);
 
-    for (const cursor of ['nonsense', '1e21:1', '1700000000000:1.5', '1:2:3', '-1:2']) {
+    for (const cursor of ['nonsense', '1e21:1', '1700000000000:1.5', '1:2:3', '-1:2', ':']) {
       await getPendingRemixGallerySubmissions({ ownerId: OWNER, limit: 2, cursor });
 
       const { where } = placementFindMany.mock.calls.at(-1)?.[0] as { where: { OR?: unknown[] } };

--- a/src/server/services/__tests__/sticker-placement.service.test.ts
+++ b/src/server/services/__tests__/sticker-placement.service.test.ts
@@ -1191,6 +1191,21 @@ describe('getPendingStickerPlacements paging', () => {
     expect(result.nextCursor).toBe(`${new Date('2026-01-02T00:00:00.000Z').getTime()}:2`);
   });
 
+  it('still hands back a cursor when EVERY row on the page was filtered out', async () => {
+    // Same contract the remix twin pins, and the one the empty-state guard in
+    // the page reads: no items is not the same as no more.
+    placementFindMany.mockResolvedValue([
+      queueRow(1, { nonsense: true }, '2026-01-01T00:00:00.000Z'),
+      queueRow(2, { nonsense: true }, '2026-01-02T00:00:00.000Z'),
+      queueRow(3, good, '2026-01-03T00:00:00.000Z'),
+    ]);
+
+    const result = await getPendingStickerPlacements({ ownerId: OWNER, limit: 2 });
+
+    expect(result.items).toEqual([]);
+    expect(result.nextCursor).toBe(`${new Date('2026-01-02T00:00:00.000Z').getTime()}:2`);
+  });
+
   it('reports no next page when the queue ends exactly on the page boundary', async () => {
     placementFindMany.mockResolvedValue([
       queueRow(1, good, '2026-01-01T00:00:00.000Z'),

--- a/src/server/services/__tests__/sticker-placement.service.test.ts
+++ b/src/server/services/__tests__/sticker-placement.service.test.ts
@@ -63,6 +63,7 @@ const transactionFindMany = vi.fn(async () => [] as unknown[]);
 const placementFindFirst = vi.fn(async () => null as unknown);
 const cosmeticFindUnique = vi.fn(async () => null as unknown);
 
+const imageFindMany = vi.fn(async () => [] as unknown[]);
 const placementFindUnique = vi.fn(async () => null as unknown);
 const placementUpdate = vi.fn(async () => ({}));
 const placementUpdateMany = vi.fn(async () => ({ count: 1 }));
@@ -84,6 +85,7 @@ vi.mock('~/server/db/client', () => ({
       groupBy: placementGroupBy,
       findFirst: placementFindFirst,
     },
+    image: { findMany: imageFindMany },
     placementTransaction: { findMany: transactionFindMany },
     cosmetic: { findUnique: cosmeticFindUnique },
   },
@@ -102,6 +104,7 @@ const {
   getStickerPlacements,
   getPlacementSettlementStates,
   getStickerPlacementDetail,
+  getPendingStickerPlacements,
 } = await import('~/server/services/sticker-placement.service');
 
 const OPEN_SPACE = { ownerId: OWNER, mode: 'review', setPrice: ASKED, price: PRICE, cap: CAP };
@@ -1150,5 +1153,73 @@ describe('the note on a placement', () => {
     });
 
     expect(placementUpdate).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The sticker copy of the queue paging. Its own tests rather than trusting the
+ * remix twin: the two are hand-duplicated, and the failure mode is a placement
+ * nobody ever reviews while its escrow expires.
+ */
+describe('getPendingStickerPlacements paging', () => {
+  const good = { cosmeticId: COSMETIC, x: 0.5, y: 0.5, scale: 0.2, rotation: 0 };
+
+  const queueRow = (id: number, data: unknown, createdAt: string) => ({
+    id,
+    targetId: IMAGE,
+    placerId: PLACER,
+    amount: PRICE,
+    data,
+    createdAt: new Date(createdAt),
+    expiresAt: null,
+    placer: { id: PLACER, username: 'someone', image: null },
+  });
+
+  it('takes the cursor from the last row of the page, not the last row it returns', async () => {
+    // Row 2 is dropped below for an unreadable payload; row 3 is the probe.
+    placementFindMany.mockResolvedValue([
+      queueRow(1, good, '2026-01-01T00:00:00.000Z'),
+      queueRow(2, { nonsense: true }, '2026-01-02T00:00:00.000Z'),
+      queueRow(3, good, '2026-01-03T00:00:00.000Z'),
+    ]);
+
+    const result = await getPendingStickerPlacements({ ownerId: OWNER, limit: 2 });
+
+    expect(result.items.map((item) => item.id)).toEqual([1]);
+    // Row 2's key. Built from what was returned it would say row 1, and row 2
+    // would be served again on the next page.
+    expect(result.nextCursor).toBe(`${new Date('2026-01-02T00:00:00.000Z').getTime()}:2`);
+  });
+
+  it('reports no next page when the queue ends exactly on the page boundary', async () => {
+    placementFindMany.mockResolvedValue([
+      queueRow(1, good, '2026-01-01T00:00:00.000Z'),
+      queueRow(2, good, '2026-01-02T00:00:00.000Z'),
+    ]);
+
+    const result = await getPendingStickerPlacements({ ownerId: OWNER, limit: 2 });
+
+    expect(result.items).toHaveLength(2);
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it('resumes strictly after the cursor row, including its same-millisecond twin', async () => {
+    placementFindMany.mockResolvedValue([]);
+    const createdAt = new Date('2026-01-02T00:00:00.000Z');
+
+    await getPendingStickerPlacements({
+      ownerId: OWNER,
+      limit: 2,
+      cursor: `${createdAt.getTime()}:2`,
+    });
+
+    const { where, orderBy, take } = placementFindMany.mock.calls.at(-1)?.[0] as {
+      where: { OR?: unknown[] };
+      orderBy: unknown;
+      take: number;
+    };
+    expect(where.OR).toEqual([{ createdAt: { gt: createdAt } }, { createdAt, id: { gt: 2 } }]);
+    expect(orderBy).toEqual([{ createdAt: 'asc' }, { id: 'asc' }]);
+    expect(take).toBe(3);
   });
 });

--- a/src/server/services/remix-gallery.service.ts
+++ b/src/server/services/remix-gallery.service.ts
@@ -16,7 +16,11 @@ import { throwAuthorizationError, throwBadRequestError } from '~/server/utils/er
 import { onlySelectableLevels } from '~/shared/constants/browsingLevel.constants';
 import {
   declineFeeAmount,
+  encodePlacementQueueCursor,
+  parsePlacementQueueCursor,
+  PLACEMENT_QUEUE_PAGE_SIZE,
   PLACEMENT_SURFACES,
+  placementQueueKeyset,
   splitPlacementPayment,
 } from '~/shared/utils/placement';
 import type { RemixGalleryPlacementData } from '~/shared/utils/remix-gallery';
@@ -1171,7 +1175,8 @@ export async function getRemixGalleryVisibility({
 export async function getPendingRemixGallerySubmissions({
   ownerId,
   hostImageId,
-  limit = REMIX_GALLERY_QUEUE_LIMIT,
+  limit = PLACEMENT_QUEUE_PAGE_SIZE,
+  cursor,
 }: {
   ownerId: number;
   /**
@@ -1181,6 +1186,7 @@ export async function getPendingRemixGallerySubmissions({
    */
   hostImageId?: number;
   limit?: number;
+  cursor?: string | null;
 }) {
   const rows = await dbRead.placement.findMany({
     where: {
@@ -1188,6 +1194,7 @@ export async function getPendingRemixGallerySubmissions({
       ownerId,
       status: 'pending',
       ...(hostImageId ? { targetType: TARGET_TYPE, targetId: hostImageId } : {}),
+      ...placementQueueKeyset(parsePlacementQueueCursor(cursor)),
     },
     select: {
       id: true,
@@ -1199,19 +1206,21 @@ export async function getPendingRemixGallerySubmissions({
       expiresAt: true,
       placer: { select: { id: true, username: true, image: true } },
     },
-    orderBy: { createdAt: 'asc' },
-    take: limit,
+    orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+    take: limit + 1,
   });
 
-  // Measured before the image filter below, not after. A queue that hit the cap
-  // and then dropped rows whose image was deleted returns fewer than `limit`, so
-  // a caller counting the returned rows concludes it saw everything — precisely
-  // when it did not, and the escrow behind the rest sits until it expires.
-  const truncated = rows.length >= limit;
+  // Read off the row the page ends on, before the rows below are dropped for an
+  // unreadable payload or a deleted image. Taking it from what is returned would
+  // point the next page at an earlier row and serve everything between twice —
+  // and the earlier `truncated` flag had the mirror-image bug, reporting a full
+  // queue as complete once the filter took it under the cap.
+  const page = rows.slice(0, limit);
+  const nextCursor = rows.length > limit ? encodePlacementQueueCursor(page[page.length - 1]) : null;
 
-  const entries = rows.filter((row) => isRemixGalleryPlacementData(row.data));
+  const entries = page.filter((row) => isRemixGalleryPlacementData(row.data));
   const imageIds = entries.map((row) => (row.data as RemixGalleryPlacementData).imageId);
-  if (!imageIds.length) return { items: [], truncated };
+  if (!imageIds.length) return { items: [], nextCursor };
 
   const images = await dbRead.$queryRaw<
     {
@@ -1264,7 +1273,7 @@ export async function getPendingRemixGallerySubmissions({
         },
       }))
       .filter((row) => row.image),
-    truncated,
+    nextCursor,
   };
 }
 

--- a/src/server/services/sticker-placement.service.ts
+++ b/src/server/services/sticker-placement.service.ts
@@ -16,6 +16,12 @@ import {
   throwNotFoundError,
 } from '~/server/utils/errorHandling';
 import type { PlacementStatus } from '~/shared/utils/placement';
+import {
+  PLACEMENT_QUEUE_PAGE_SIZE,
+  encodePlacementQueueCursor,
+  parsePlacementQueueCursor,
+  placementQueueKeyset,
+} from '~/shared/utils/placement';
 import type {
   PlacementSettlementState,
   StickerPlacementData,
@@ -829,16 +835,26 @@ export async function setStickerCommentHidden({
  * Carries the image and the placer with it, because the queue's whole job is
  * deciding without leaving — a list of ids would send someone to eleven pages to
  * answer eleven placements.
+ *
+ * Pages, because escrow sits behind every entry: an owner who saw the first 50
+ * and nothing else had the rest expire without ever being offered the choice.
  */
 export async function getPendingStickerPlacements({
   ownerId,
-  limit = 50,
+  limit = PLACEMENT_QUEUE_PAGE_SIZE,
+  cursor,
 }: {
   ownerId: number;
   limit?: number;
+  cursor?: string | null;
 }) {
   const rows = await dbRead.placement.findMany({
-    where: { surface: SURFACE, ownerId, status: 'pending' },
+    where: {
+      surface: SURFACE,
+      ownerId,
+      status: 'pending',
+      ...placementQueueKeyset(parsePlacementQueueCursor(cursor)),
+    },
     select: {
       id: true,
       targetId: true,
@@ -849,22 +865,30 @@ export async function getPendingStickerPlacements({
       expiresAt: true,
       placer: { select: { id: true, username: true, image: true } },
     },
-    orderBy: { createdAt: 'asc' },
-    take: limit,
+    orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+    take: limit + 1,
   });
 
+  // Read off the row the page ends on, before the unparseable ones are dropped
+  // below. Taking it from what is returned would hand back a cursor pointing at
+  // an earlier row, and everything between the two would be served twice.
+  const page = rows.slice(0, limit);
+  const nextCursor = rows.length > limit ? encodePlacementQueueCursor(page[page.length - 1]) : null;
+
   const images = await dbRead.image.findMany({
-    where: { id: { in: rows.map((row) => row.targetId) } },
+    where: { id: { in: page.map((row) => row.targetId) } },
     select: { id: true, url: true, name: true, width: true, height: true, type: true },
   });
   const byId = new Map(images.map((image) => [image.id, image]));
 
-  return rows.flatMap((row) => {
+  const items = page.flatMap((row) => {
     const data = parseStickerPlacementData(row.data);
     if (!data) return [];
 
     return [{ ...row, data, image: byId.get(row.targetId) ?? null }];
   });
+
+  return { items, nextCursor };
 }
 
 /**

--- a/src/shared/utils/placement.ts
+++ b/src/shared/utils/placement.ts
@@ -210,7 +210,10 @@ export function parsePlacementQueueCursor(cursor?: string | null): PlacementQueu
   if (!cursor) return null;
 
   const parts = cursor.split(':');
-  if (parts.length !== 2) return null;
+  // Length AND emptiness: `''.split(':')` is `['', '']` and `Number('')` is 0,
+  // so `':'` would otherwise pass every check below and reach the query as a
+  // keyset from 1970 — harmless, and a counterexample to what this says it does.
+  if (parts.length !== 2 || parts.some((part) => !part.length)) return null;
 
   const [createdAt, id] = parts.map(Number);
   if (![createdAt, id].every((value) => Number.isSafeInteger(value) && value >= 0)) return null;

--- a/src/shared/utils/placement.ts
+++ b/src/shared/utils/placement.ts
@@ -186,6 +186,50 @@ export const placementSurfaceLabel = (surface: PlacementSurface) =>
   PLACEMENT_SURFACES[surface].label;
 
 // ---------------------------------------------------------------------------
+// Review queues
+// ---------------------------------------------------------------------------
+
+/** How many pending placements one page of a review queue carries. */
+export const PLACEMENT_QUEUE_PAGE_SIZE = 50;
+
+export type PlacementQueueCursor = { createdAt: Date; id: number };
+
+export const encodePlacementQueueCursor = (row: PlacementQueueCursor) =>
+  `${row.createdAt.getTime()}:${row.id}`;
+
+/** A malformed cursor becomes a fresh first page rather than a NaN in a query. */
+export function parsePlacementQueueCursor(cursor?: string | null): PlacementQueueCursor | null {
+  if (!cursor) return null;
+
+  const [createdAt, id] = cursor.split(':').map(Number);
+  if (![createdAt, id].every(Number.isFinite)) return null;
+
+  return { createdAt: new Date(createdAt), id };
+}
+
+/**
+ * Where the last page stopped, as a keyset rather than an offset.
+ *
+ * Both columns the queues order on, in the same order and direction. `createdAt`
+ * alone is not unique — two placements made in the same millisecond would either
+ * repeat across pages or be stepped over, and an entry stepped over is escrow
+ * nobody ever reviews, which is the failure this paging exists to end.
+ *
+ * An offset would have the same hole for a different reason: acting on a
+ * placement takes it out of the queue, so page two of an offset walk skips as
+ * many entries as the owner just approved.
+ */
+export const placementQueueKeyset = (cursor: PlacementQueueCursor | null) =>
+  cursor
+    ? {
+        OR: [
+          { createdAt: { gt: cursor.createdAt } },
+          { createdAt: cursor.createdAt, id: { gt: cursor.id } },
+        ],
+      }
+    : {};
+
+// ---------------------------------------------------------------------------
 // Space resolution
 // ---------------------------------------------------------------------------
 

--- a/src/shared/utils/placement.ts
+++ b/src/shared/utils/placement.ts
@@ -197,15 +197,30 @@ export type PlacementQueueCursor = { createdAt: Date; id: number };
 export const encodePlacementQueueCursor = (row: PlacementQueueCursor) =>
   `${row.createdAt.getTime()}:${row.id}`;
 
-/** A malformed cursor becomes a fresh first page rather than a NaN in a query. */
+/**
+ * A malformed cursor becomes a fresh first page rather than reaching a query.
+ *
+ * `Number.isSafeInteger`, not `isFinite`: `1e21` is finite and makes an Invalid
+ * Date (the max time value is 8.64e15), and `1.5` is finite and goes to an `INT`
+ * column as a fraction. Both are hand-crafted-cursor-only, and both are a 500
+ * rather than anything worse — but the guard is here to say a cursor never
+ * reaches the database unparsed, so it has to actually do that.
+ */
 export function parsePlacementQueueCursor(cursor?: string | null): PlacementQueueCursor | null {
   if (!cursor) return null;
 
-  const [createdAt, id] = cursor.split(':').map(Number);
-  if (![createdAt, id].every(Number.isFinite)) return null;
+  const parts = cursor.split(':');
+  if (parts.length !== 2) return null;
+
+  const [createdAt, id] = parts.map(Number);
+  if (![createdAt, id].every((value) => Number.isSafeInteger(value) && value >= 0)) return null;
+  if (createdAt > MAX_CURSOR_TIME) return null;
 
   return { createdAt: new Date(createdAt), id };
 }
+
+/** ECMAScript's max time value. Past it, `new Date` is an Invalid Date. */
+const MAX_CURSOR_TIME = 8.64e15;
 
 /**
  * Where the last page stopped, as a keyset rather than an offset.


### PR DESCRIPTION
[868kqq73p](https://app.clickup.com/t/868kqq73p). Follow-up to #3857, which added the "this list is truncated" line; this replaces it with real paging.

## The problem

Neither review queue paged. Both stopped at 50 with no cursor, so a busy owner
saw a list that looked complete while the escrow behind everything past the 50th
sat untouched until it expired. The failure is money silently returning to
submitters for a decision the owner was never offered, not a UI limit.

## What this does

Keyset paging on both queues, matching what the gallery already does.

**The cursor carries `createdAt` AND `id`.** Two placements can share a
millisecond; a `createdAt`-only cursor either repeats one across pages or steps
over it — and the one stepped over is precisely the entry nobody ever reviews.
An offset has the same hole for a different reason: answering a placement takes
it out of the queue, so page two of an offset walk skips as many entries as the
owner just cleared.

**The next cursor is read off the last row of the raw page**, before rows are
dropped for an unreadable payload or an image that no longer resolves. Taking it
from what was *returned* would point the next page at an earlier row and serve
the gap twice. The `truncated` flag this replaces had the mirror-image bug — it
reported a full queue as complete once the filter took the count under the cap,
which is why #3857 measured it before filtering.

A malformed cursor starts a fresh first page rather than putting NaN in a query.

Count badges that can only see one page now read `50+` instead of `50`.

Out of scope, stated rather than hidden: the submitter's own "Sent" list
(`getMyRemixGallerySubmissions`) still caps at 50 and keeps its truncation
notice. Nothing expires behind it — it is the submitter's own view of their own
holds — so it did not carry the same cost.

## Verification

- `pnpm run typecheck` — 0 errors
- `npx eslint` over the 11 changed files — no issues
- `remix-gallery.service.test.ts` — 79 pass, including 4 new paging cases
- Positive control: making the cursor come from the probe row instead of the last
  page row fails with `expected '1767398400000:3' to be '1767312000000:2'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)