### PR TITLE
fix(home): stop the featured collections grid rendering 8 of 14

### DIFF
--- a/src/components/HomeBlocks/homeBlockItems.ts
+++ b/src/components/HomeBlocks/homeBlockItems.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
+import { HOME_BLOCK_ITEMS_PER_ROW } from '~/shared/constants/home-block.constants';
 
-export const ITEMS_PER_ROW = 7;
+export const ITEMS_PER_ROW = HOME_BLOCK_ITEMS_PER_ROW;
 
 type CappableItem = { user?: { id: number } | null };
 

--- a/src/server/services/__tests__/home-block-featured-collections-layout.test.ts
+++ b/src/server/services/__tests__/home-block-featured-collections-layout.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { resolveFeaturedCollectionsLayout } from '~/server/services/home-block.service';
+
+const resolve = resolveFeaturedCollectionsLayout;
+
+describe('resolveFeaturedCollectionsLayout', () => {
+  it('raises a fetch pool smaller than the visible slice', () => {
+    expect(resolve({ limit: 8, rows: 2 }, 11).limit).toBe(14);
+    expect(resolve({ limit: 8, rows: 4 }, 11).limit).toBe(28);
+  });
+
+  it('leaves a fetch pool already above the visible slice alone', () => {
+    expect(resolve({ limit: 40, rows: 2 }, 11).limit).toBe(40);
+    expect(resolve({ limit: 8, rows: 1 }, 11).limit).toBe(8);
+  });
+
+  it('keeps a stored maxPerUser of 0 as 0', () => {
+    expect(resolve({ maxPerUser: 0 }, 11).maxPerUser).toBe(0);
+    expect(resolve({}, 11).maxPerUser).toBe(2);
+  });
+});

--- a/src/server/services/home-block.service.ts
+++ b/src/server/services/home-block.service.ts
@@ -45,6 +45,7 @@ import {
   publicBrowsingLevelsFlag,
   sfwBrowsingLevelsFlag,
 } from '~/shared/constants/browsingLevel.constants';
+import { HOME_BLOCK_ITEMS_PER_ROW } from '~/shared/constants/home-block.constants';
 import { HomeBlockType, MetricTimeframe } from '~/shared/utils/prisma/enums';
 import type { DomainColor } from '~/shared/utils/prisma/enums';
 import { isDefined } from '~/utils/type-guards';
@@ -440,18 +441,8 @@ export const getHomeBlockData = async ({
         candidates = eligible;
       }
 
-      // Clamp to sane bounds — metadata is mutable JSON, don't trust blindly.
-      // Deliberately not `input.limit`: the by-id cache path passes one fixed number for
-      // every block type, and letting it win made this block's own `limit` dead config.
-      const limit = Math.min(
-        100,
-        Math.max(1, effectivePool.limit || FEATURED_COLLECTIONS_DEFAULTS.limit)
-      );
-      const rows = Math.min(4, Math.max(1, effectivePool.rows || 2));
-      const maxPerUser = effectivePool.maxPerUser ?? FEATURED_COLLECTIONS_DEFAULTS.maxPerUser;
-      const renderCount = Math.min(
-        10,
-        Math.max(1, effectivePool.renderCount ?? 3),
+      const { limit, rows, maxPerUser, renderCount } = resolveFeaturedCollectionsLayout(
+        effectivePool,
         candidates.length
       );
 
@@ -490,7 +481,9 @@ export const getHomeBlockData = async ({
       return {
         ...homeBlock,
         type: HomeBlockType.FeaturedCollections,
-        metadata,
+        // A clone's own copy is a snapshot from clone time; serving it advertises config that
+        // isn't in effect.
+        metadata: { ...metadata, featuredCollections: effectivePool },
         pickedCollections,
       };
     }
@@ -664,6 +657,30 @@ export const deleteHomeBlockById = async ({
     // Ignore errors
   }
 };
+
+type FeaturedCollectionsPool = NonNullable<HomeBlockMetaSchema['featuredCollections']>;
+
+/**
+ * `limit` is the fetch pool, not the visible count — it meant the visible count once, and stored
+ * metadata predating that still says 8. Floored at the visible slice so it can't starve the grid.
+ */
+export function resolveFeaturedCollectionsLayout(
+  // Partial: the caller's value is an unvalidated JSON cast, not schema output.
+  pool: Partial<Pick<FeaturedCollectionsPool, 'limit' | 'rows' | 'renderCount' | 'maxPerUser'>>,
+  candidateCount: number
+) {
+  const rows = Math.min(4, Math.max(1, pool.rows || 2));
+  // Deliberately not `input.limit`: the by-id cache path passes one fixed number for every
+  // block type, and letting it win made this block's own `limit` dead config.
+  const limit = Math.min(
+    100,
+    Math.max(rows * HOME_BLOCK_ITEMS_PER_ROW, pool.limit || FEATURED_COLLECTIONS_DEFAULTS.limit)
+  );
+  const maxPerUser = pool.maxPerUser ?? FEATURED_COLLECTIONS_DEFAULTS.maxPerUser;
+  const renderCount = Math.min(10, Math.max(1, pool.renderCount ?? 3), candidateCount);
+
+  return { limit, rows, maxPerUser, renderCount };
+}
 
 export const FEATURED_COLLECTIONS_DEFAULTS = {
   // The fetch pool, not the visible count (rows * 7 of these render). Sized well above the

--- a/src/shared/constants/home-block.constants.ts
+++ b/src/shared/constants/home-block.constants.ts
@@ -1,0 +1,2 @@
+// Shared because the server sizes its fetch from this and the client slices the render by it.
+export const HOME_BLOCK_ITEMS_PER_ROW = 7;


### PR DESCRIPTION
Fixes the report on https://app.clickup.com/t/868kqvdtt — curated collections on the home page showing at most 8 images each.

## What was wrong

`featuredCollections.limit` used to mean the visible count. It now means the **fetch pool**, which the client slices to `rows * ITEMS_PER_ROW` (`2 * 7 = 14`). The stored metadata still said `8`, so the grid could never fill.

Two things in the ticket turned out not to hold:

- **It is not red-only.** `HomeBlock` has no domain column, and the `FeaturedCollections` branch of `getHomeBlockData` never reads `input.domain`. One system row (388990) drives civitai.com and civitai.red alike. The reporter happened to be on red.
- **The clone rows did not need updating to fix rendering.** `FeaturedCollections` is in `readThroughTypes`, so `effectivePool = sourceMetadata ?? metadata` — the source block wins. Every clone in prod has `sourceId = 388990`.

## The actual fix is already applied

The stored value was corrected directly in production: 10,890 rows, `featuredCollections.limit` 8 → 40, verified. `rows` stays 2, so 14 render per collection.

`40` rather than the code default of `100`: only `rows * 7 = 14` items can render, and the surplus exists so `maxPerUser: 2` has other creators to promote instead of leaving holes. At ~2 KB of payload per item, `100` would ship ~630 KB per block request to render 42 cards, cached per home block id across ~10,900 ids and both domains.

No migration file here — it was a one-off data correction, not schema. Other environments still carry `8`, and the code floor below makes them render the full 14 regardless.

## What this PR changes

- **Floors the fetch pool at the visible slice.** `Math.max(rows * HOME_BLOCK_ITEMS_PER_ROW, …)` — a stored value below the visible slice renders a short grid with nothing in the UI to say why. Extracted into `resolveFeaturedCollectionsLayout` so it is testable without standing up hydration, Redis and the collection service.
- **Returns the pool actually rendered from.** The case returned the block's own `metadata`, so clones advertised config that was not in effect. The `CosmeticShop` case directly above already does this and says why. Harmless today only because the component ignores the prop.
- **`ITEMS_PER_ROW` moved to `src/shared/constants/home-block.constants.ts`** so the server's fetch sizing and the client's slice cannot drift. Three other components still carry their own copy of `7`; not touched here.

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm run lint` — clean on changed files
- `pnpm run test:unit:run` — 15,685 passed. 8 files / 35 tests failed; `app-spend-tier-privilege.test.ts` fails **identically on clean main** (its own positive control reports a stale path), so it is pre-existing. The other 7 files were not individually baselined against main.
- `blocks.router.workflow.test.ts` collected **347** tests (submodule initialised).
- Positive control on the new test: removing the floor prints `expected 8 to be 14`.

Reviewed adversarially; the payload-size finding above came out of that pass and set the stored value at 40 rather than 100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
