### PR TITLE
fix(monetization): refuse a blank generation-only price, and stop a POI model resubmitting its hidden gate

### DIFF
--- a/packages/civitai-buzz/src/paid-access.test.ts
+++ b/packages/civitai-buzz/src/paid-access.test.ts
@@ -12,6 +12,7 @@ import {
   isPaidAccessActive,
   isTimedGateActive,
   paidGenerationGrant,
+  separateGenerationPriceMissing,
   CAP_TIERS,
   nextCapTier,
   shouldUpsellCap,
@@ -104,6 +105,27 @@ describe('generationPrice — effective generation-only purchase price', () => {
   it('undefined when there is no paid generation tier (free or bundled)', () => {
     expect(generationPrice({ generation: { free: true } })).toBeUndefined();
     expect(generationPrice({ download: { price: 500 } })).toBeUndefined();
+  });
+});
+
+describe('separateGenerationPriceMissing — the blank "cheaper price" box', () => {
+  it('a stated price is not missing', () => {
+    expect(separateGenerationPriceMissing(200)).toBe(false);
+  });
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    // Defensive: the form's zod schema rejects NaN before the guard runs, and its number input maps a
+    // cleared box to undefined. Kept so the predicate is total for callers without that schema.
+    ['NaN', Number.NaN],
+    ['zero', 0],
+    ['negative', -50],
+  ])('%s is missing', (_label, value) => {
+    expect(separateGenerationPriceMissing(value as number | null | undefined)).toBe(true);
+  });
+  it('what an unrefused blank costs the buyer: the FULL download price', () => {
+    const blank = buildModelVersionTerms({ accessPrice: 500, generationPrice: undefined });
+    expect(generationPrice(blank)).toBe(500);
   });
 });
 

--- a/packages/civitai-buzz/src/paid-access.ts
+++ b/packages/civitai-buzz/src/paid-access.ts
@@ -69,6 +69,14 @@ export const generationPrice = (terms: ModelVersionTerms): number | undefined =>
   return paid.price ?? (terms.download?.price as number | undefined);
 };
 /**
+ * Whether a chosen "cheaper generation-only price" is missing the price it promises. Such a grant is
+ * indistinguishable in `terms` from generation bundled with the download, and `generationPrice` prices
+ * both at the download price — so an editor must refuse the write rather than store the choice.
+ */
+export const separateGenerationPriceMissing = (price: number | null | undefined): boolean =>
+  price == null || !Number.isFinite(price) || price <= 0;
+
+/**
  * Build a ModelVersion's `terms` from an editor's pricing. "Price for access" (accessPrice) is the one
  * required charge; for a `genOnly` version (no download tier) it IS the generation price, otherwise it's
  * the download bundle price and `generationPrice` is an optional cheaper generation-only tier. The

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
@@ -422,10 +422,11 @@ describe('ModelVersionUpsertForm — monetization disclosure', () => {
     expect(page.getByText(/A private model can't have paid access/).elements()).toHaveLength(1);
   });
 
-  // `model.poi` hid the paid-access editor without touching what the submit sent, so a POI model
-  // re-asserted its stored gate from a control that never rendered. The PAYLOAD is the assertion that
-  // matters here: the warning alone would still read green while the gate shipped.
-  test('a POI model warns about its stored gate, and submits none', async () => {
+  // A POI model can't earn at all. The editors used to render (and, on the standalone edit route, the
+  // endpoint didn't even send `poi`), so a stored gate and fee resubmitted from controls the creator was
+  // never meant to see. The PAYLOAD is the assertion that matters: the alert alone would read green while
+  // the charges shipped.
+  test('a POI model hides every monetization control, and submits no charge', async () => {
     flags.current = { licensingFee: true, earlyAccessModel: true };
     renderWithProviders(
       <ModelVersionUpsertForm
@@ -437,25 +438,27 @@ describe('ModelVersionUpsertForm — monetization disclosure', () => {
       </ModelVersionUpsertForm>
     );
 
-    // Present at first render, so anchor on the switch and then read synchronously.
-    await expect.element(chargeSwitch()).toBeChecked();
-    expect(page.getByText(/Saving now removes this version's paid access/).elements()).toHaveLength(
-      1
-    );
+    // The whole section collapses to one explanation: no charge switch, no gate editor, no fee editor.
+    await expect
+      .element(page.getByText(/Models depicting a real person can't be monetized/))
+      .toBeInTheDocument();
     expect(
-      page.getByText(/A model depicting a real person can't have paid access/).elements()
+      page.getByText(/Saving now removes this version's license fee and paid access/).elements()
     ).toHaveLength(1);
-    // The gate editor is off screen — which is why the warning has to carry the message.
+    expect(chargeSwitch().elements()).toHaveLength(0);
     expect(accessSwitch().elements()).toHaveLength(0);
+    expect(feeSwitch().elements()).toHaveLength(0);
 
-    // An edit elsewhere: the stored config is unchanged, so without this the save short-circuits as
-    // pristine and the payload assertion below would never run.
+    // An edit elsewhere: the stored charges are unchanged, so without this the save short-circuits as
+    // pristine and the payload assertions below would never run.
     await userEvent.fill(page.getByLabelText('Name'), 'v1.1');
     await userEvent.click(page.getByRole('button', { name: 'Save' }));
     await vi.waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
-    // Null because of POI, not because this form never sends a gate: the blank-price test below submits a
-    // gate from the same model and version with POI off.
-    expect((mutateAsync.mock.calls[0][0] as { paidAccess?: unknown }).paidAccess).toBeNull();
+    // Null/zero because of POI, not because this form never sends them: the blank-price test below
+    // submits a gate from the same model and version with POI off, and `chargingVersion` stores a fee.
+    const payload = mutateAsync.mock.calls[0][0] as { paidAccess?: unknown; licensingFee?: number };
+    expect(payload.paidAccess).toBeNull();
+    expect(payload.licensingFee).toBe(0);
   });
 
   // Surfacing the POI notice meant rendering the Monetization card whenever a stored charge is going away.

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
@@ -467,11 +467,10 @@ describe('ModelVersionUpsertForm — monetization disclosure', () => {
     renderWithProviders(
       <ModelVersionUpsertForm
         model={model}
-        version={
-          { ...(chargingVersion as object), licensingFee: 0 } as React.ComponentProps<
-            typeof ModelVersionUpsertForm
-          >['version']
-        }
+        // `chargingVersion` as-is: it carries a licensing fee AND a gate, which is the shape that
+        // exercises the Restore link — `removingStoredFee` is a left-hand OR in its condition, so a
+        // fee-free fixture would pass while the affordance still rendered.
+        version={chargingVersion}
         onSubmit={vi.fn()}
       >
         {() => <button type="submit">Save</button>}
@@ -488,14 +487,16 @@ describe('ModelVersionUpsertForm — monetization disclosure', () => {
     // reason is simply the wrong sentence, and waiting for the right one would spend the full matcher
     // timeout only to report that some text never appeared.
     await expect
-      .element(page.getByText(/Saving now removes this version's paid access/))
+      .element(page.getByText(/Saving now removes this version's license fee and paid access/))
       .toBeInTheDocument();
     expect(
       page.getByText(/This base model is licensed for non-commercial use/).elements()
     ).toHaveLength(1);
     // The wrong sentence for this removal: nothing here is about early access ending.
     expect(page.getByText(/your payment for early access will be lost/).elements()).toHaveLength(0);
-    // And no restore: it would re-apply a gate the server rejects for this base model.
+    // And no restore: it would re-apply a fee and a gate the server rejects for this base model — the
+    // fee behind an editor that is unmounted for non-commercial base models, which is the hidden charge
+    // the disclosure work exists to prevent.
     expect(
       page.getByRole('button', { name: 'Restore the stored settings' }).elements()
     ).toHaveLength(0);

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
@@ -465,48 +465,78 @@ describe('ModelVersionUpsertForm — monetization disclosure', () => {
   // That also made this case reachable for the first time — a non-commercial base model clears the gate
   // through an effect rather than at submit — and a removal with no arm of its own falls through to the
   // reversible early-access wording, offering a Restore that puts back a config the server rejects.
-  test('a non-commercial base model says why the gate goes, and offers no restore', async () => {
+  test('a non-commercial base model blocks monetization on load, and un-blocks on switching back', async () => {
     flags.current = { licensingFee: true, earlyAccessModel: true };
     renderWithProviders(
       <ModelVersionUpsertForm
         model={model}
-        // `chargingVersion` as-is: it carries a licensing fee AND a gate, which is the shape that
-        // exercises the Restore link — `removingStoredFee` is a left-hand OR in its condition, so a
-        // fee-free fixture would pass while the affordance still rendered.
-        version={chargingVersion}
+        // Loaded already on the non-commercial base model: the clearing effect is keyed to the value
+        // CHANGING, so on-load it never fires and the stored charges used to ride through to a save the
+        // server then rejected, with nothing on screen having predicted it.
+        version={
+          { ...(chargingVersion as object), baseModel: 'Ideogram 4.0' } as React.ComponentProps<
+            typeof ModelVersionUpsertForm
+          >['version']
+        }
         onSubmit={vi.fn()}
       >
         {() => <button type="submit">Save</button>}
       </ModelVersionUpsertForm>
     );
 
-    // Switched in-session, not loaded that way: the clearing effect is keyed to the base model CHANGING,
-    // which is what empties the config behind the unmounted editor and makes this removal reachable.
-    await expect.element(accessSwitch()).toBeChecked();
-    await userEvent.click(page.getByRole('textbox', { name: 'Base Model' }));
-    await userEvent.click(page.getByRole('option', { name: 'Ideogram 4.0' }));
-
-    // Anchor on the line that arrives either way, then read the reason synchronously: on a revert the
-    // reason is simply the wrong sentence, and waiting for the right one would spend the full matcher
-    // timeout only to report that some text never appeared.
-    await expect
-      .element(page.getByText(/Saving now removes this version's license fee and paid access/))
-      .toBeInTheDocument();
+    // Anchor on the card, then read the alert synchronously: both are in the same render, and a revert
+    // still renders the card — so this fails in about a second naming the missing alert, instead of
+    // spending the full matcher timeout on text that is never coming.
+    await expect.element(page.getByText('Monetization')).toBeInTheDocument();
     expect(
       page.getByText(/This base model is licensed for non-commercial use/).elements()
     ).toHaveLength(1);
-    // The wrong sentence for this removal: nothing here is about early access ending.
-    expect(page.getByText(/your payment for early access will be lost/).elements()).toHaveLength(0);
-    // The way back is the picker, not a link, and the sentence has to say so — unlike POI and private,
-    // this removal is reversible.
     expect(
-      page.getByText(/Switch back to a commercial base model to restore it/).elements()
+      page.getByText(/Saving now removes this version's license fee and paid access/).elements()
     ).toHaveLength(1);
-    // And no restore: it would re-apply a fee and a gate the server rejects for this base model — the
-    // fee behind an editor that is unmounted for non-commercial base models, which is the hidden charge
-    // the disclosure work exists to prevent.
+    expect(chargeSwitch().elements()).toHaveLength(0);
+    expect(accessSwitch().elements()).toHaveLength(0);
+
+    await userEvent.fill(page.getByLabelText('Name'), 'v1.1');
+    await userEvent.click(page.getByRole('button', { name: 'Save' }));
+    await vi.waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+    const payload = mutateAsync.mock.calls[0][0] as { paidAccess?: unknown; licensingFee?: number };
+    expect(payload.paidAccess).toBeNull();
+    expect(payload.licensingFee).toBe(0);
+  });
+
+  // Unlike POI, this block is the creator's to undo — the copy says so, and the controls have to actually
+  // come back or that sentence is a lie.
+  test('switching off a non-commercial base model brings the charge controls back', async () => {
+    flags.current = { licensingFee: true, earlyAccessModel: true };
+    renderWithProviders(
+      <ModelVersionUpsertForm
+        model={model}
+        version={
+          { ...(chargingVersion as object), baseModel: 'Ideogram 4.0' } as React.ComponentProps<
+            typeof ModelVersionUpsertForm
+          >['version']
+        }
+        onSubmit={vi.fn()}
+      >
+        {() => <button type="submit">Save</button>}
+      </ModelVersionUpsertForm>
+    );
+
+    // Anchor on the card, then read the alert synchronously: both are in the same render, and a revert
+    // still renders the card — so this fails in about a second naming the missing alert, instead of
+    // spending the full matcher timeout on text that is never coming.
+    await expect.element(page.getByText('Monetization')).toBeInTheDocument();
     expect(
-      page.getByRole('button', { name: 'Restore the stored settings' }).elements()
+      page.getByText(/This base model is licensed for non-commercial use/).elements()
+    ).toHaveLength(1);
+
+    await userEvent.click(page.getByRole('textbox', { name: 'Base Model' }));
+    await userEvent.click(page.getByRole('option', { name: 'SDXL 1.0' }));
+
+    await expect.element(chargeSwitch()).toBeInTheDocument();
+    expect(
+      page.getByText(/This base model is licensed for non-commercial use/).elements()
     ).toHaveLength(0);
   });
 

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
@@ -453,7 +453,52 @@ describe('ModelVersionUpsertForm — monetization disclosure', () => {
     await userEvent.fill(page.getByLabelText('Name'), 'v1.1');
     await userEvent.click(page.getByRole('button', { name: 'Save' }));
     await vi.waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+    // Null because of POI, not because this form never sends a gate: the blank-price test below submits a
+    // gate from the same model and version with POI off.
     expect((mutateAsync.mock.calls[0][0] as { paidAccess?: unknown }).paidAccess).toBeNull();
+  });
+
+  // Surfacing the POI notice meant rendering the Monetization card whenever a stored charge is going away.
+  // That also made this case reachable for the first time — a non-commercial base model clears the gate
+  // through an effect rather than at submit — and a removal with no arm of its own falls through to the
+  // reversible early-access wording, offering a Restore that puts back a config the server rejects.
+  test('a non-commercial base model says why the gate goes, and offers no restore', async () => {
+    flags.current = { licensingFee: true, earlyAccessModel: true };
+    renderWithProviders(
+      <ModelVersionUpsertForm
+        model={model}
+        version={
+          { ...(chargingVersion as object), licensingFee: 0 } as React.ComponentProps<
+            typeof ModelVersionUpsertForm
+          >['version']
+        }
+        onSubmit={vi.fn()}
+      >
+        {() => <button type="submit">Save</button>}
+      </ModelVersionUpsertForm>
+    );
+
+    // Switched in-session, not loaded that way: the clearing effect is keyed to the base model CHANGING,
+    // which is what empties the config behind the unmounted editor and makes this removal reachable.
+    await expect.element(accessSwitch()).toBeChecked();
+    await userEvent.click(page.getByRole('textbox', { name: 'Base Model' }));
+    await userEvent.click(page.getByRole('option', { name: 'Ideogram 4.0' }));
+
+    // Anchor on the line that arrives either way, then read the reason synchronously: on a revert the
+    // reason is simply the wrong sentence, and waiting for the right one would spend the full matcher
+    // timeout only to report that some text never appeared.
+    await expect
+      .element(page.getByText(/Saving now removes this version's paid access/))
+      .toBeInTheDocument();
+    expect(
+      page.getByText(/This base model is licensed for non-commercial use/).elements()
+    ).toHaveLength(1);
+    // The wrong sentence for this removal: nothing here is about early access ending.
+    expect(page.getByText(/your payment for early access will be lost/).elements()).toHaveLength(0);
+    // And no restore: it would re-apply a gate the server rejects for this base model.
+    expect(
+      page.getByRole('button', { name: 'Restore the stored settings' }).elements()
+    ).toHaveLength(0);
   });
 
   // "A cheaper generation-only price" with an empty box used to save a generation grant carrying no price
@@ -479,14 +524,14 @@ describe('ModelVersionUpsertForm — monetization disclosure', () => {
     // Both outcomes in one poll, on a short budget. `expect.element` alone would spend the full 15 s
     // matcher timeout on a revert and then report only that some text never appeared; this names the thing
     // that actually went wrong — the blank price was saved — in about a second.
-    await vi.waitFor(
-      () => {
-        if (mutateAsync.mock.calls.length)
-          throw new Error('saved a blank generation-only price instead of refusing it');
-        expect(page.getByText(/Enter a generation-only price/).elements()).toHaveLength(1);
-      },
-      { timeout: 3000 }
-    );
+    // Both outcomes in one poll, on the suite's default budget: a revert throws the named error on every
+    // attempt, so that is what the timeout reports — rather than fifteen seconds of `expect.element`
+    // waiting for text that never comes and then blaming the text.
+    await vi.waitFor(() => {
+      if (mutateAsync.mock.calls.length)
+        throw new Error('saved a blank generation-only price instead of refusing it');
+      expect(page.getByText(/Enter a generation-only price/).elements()).toHaveLength(1);
+    });
 
     // The positive control: the same save goes through once the price exists, so the refusal above is the
     // missing price and not the form being unsavable for some unrelated reason.

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
@@ -422,6 +422,85 @@ describe('ModelVersionUpsertForm — monetization disclosure', () => {
     expect(page.getByText(/A private model can't have paid access/).elements()).toHaveLength(1);
   });
 
+  // `model.poi` hid the paid-access editor without touching what the submit sent, so a POI model
+  // re-asserted its stored gate from a control that never rendered. The PAYLOAD is the assertion that
+  // matters here: the warning alone would still read green while the gate shipped.
+  test('a POI model warns about its stored gate, and submits none', async () => {
+    flags.current = { licensingFee: true, earlyAccessModel: true };
+    renderWithProviders(
+      <ModelVersionUpsertForm
+        model={{ ...model, poi: true } as typeof model}
+        version={chargingVersion}
+        onSubmit={vi.fn()}
+      >
+        {() => <button type="submit">Save</button>}
+      </ModelVersionUpsertForm>
+    );
+
+    // Present at first render, so anchor on the switch and then read synchronously.
+    await expect.element(chargeSwitch()).toBeChecked();
+    expect(page.getByText(/Saving now removes this version's paid access/).elements()).toHaveLength(
+      1
+    );
+    expect(
+      page.getByText(/A model depicting a real person can't have paid access/).elements()
+    ).toHaveLength(1);
+    // The gate editor is off screen — which is why the warning has to carry the message.
+    expect(accessSwitch().elements()).toHaveLength(0);
+
+    // An edit elsewhere: the stored config is unchanged, so without this the save short-circuits as
+    // pristine and the payload assertion below would never run.
+    await userEvent.fill(page.getByLabelText('Name'), 'v1.1');
+    await userEvent.click(page.getByRole('button', { name: 'Save' }));
+    await vi.waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+    expect((mutateAsync.mock.calls[0][0] as { paidAccess?: unknown }).paidAccess).toBeNull();
+  });
+
+  // "A cheaper generation-only price" with an empty box used to save a generation grant carrying no price
+  // of its own — which `generationPrice` charges at the DOWNLOAD price. The stored terms are identical to a
+  // deliberate "same as the access price", so nothing after this form can tell the two apart.
+  test('refuses a blank generation-only price, and saves the one that is typed', async () => {
+    flags.current = { licensingFee: true, earlyAccessModel: true };
+    renderWithProviders(
+      <ModelVersionUpsertForm model={model} version={chargingVersion} onSubmit={vi.fn()}>
+        {() => <button type="submit">Save</button>}
+      </ModelVersionUpsertForm>
+    );
+
+    await userEvent.click(page.getByRole('radio', { name: 'A cheaper generation-only price' }));
+    // By placeholder: the label text also matches the radio that reveals this input.
+    const genPrice = page.getByPlaceholder('Generation-only price');
+    await expect.element(genPrice).toBeInTheDocument();
+
+    // An edit elsewhere, so the save is not short-circuited as pristine: without it the unfixed build
+    // writes nothing either, and the test would pass against the bug it exists to catch.
+    await userEvent.fill(page.getByLabelText('Name'), 'v1.1');
+    await userEvent.click(page.getByRole('button', { name: 'Save' }));
+    // Both outcomes in one poll, on a short budget. `expect.element` alone would spend the full 15 s
+    // matcher timeout on a revert and then report only that some text never appeared; this names the thing
+    // that actually went wrong — the blank price was saved — in about a second.
+    await vi.waitFor(
+      () => {
+        if (mutateAsync.mock.calls.length)
+          throw new Error('saved a blank generation-only price instead of refusing it');
+        expect(page.getByText(/Enter a generation-only price/).elements()).toHaveLength(1);
+      },
+      { timeout: 3000 }
+    );
+
+    // The positive control: the same save goes through once the price exists, so the refusal above is the
+    // missing price and not the form being unsavable for some unrelated reason.
+    // 400, not a round 1000: the free tier's paid-access cap bounds this input at 500, and a value above
+    // it is clamped rather than rejected — which would make the payload assertion below read as a bug.
+    await userEvent.fill(genPrice, '400');
+    await userEvent.click(page.getByRole('button', { name: 'Save' }));
+    await vi.waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+    const terms = (mutateAsync.mock.calls[0][0] as { paidAccess?: { terms?: ModelVersionTerms } })
+      .paidAccess?.terms;
+    expect(terms?.generation).toMatchObject({ price: 400 });
+    expect(terms?.download?.price).toBe(5000);
+  });
+
   // A grandfathered version — priced before the affirmation existed — has to tick the box to save at all.
   // Clearing that tick on a switch round-trip that changed nothing puts the creator back in front of
   // "Confirmation required", which is the error this ticket was filed about.

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
@@ -494,6 +494,11 @@ describe('ModelVersionUpsertForm — monetization disclosure', () => {
     ).toHaveLength(1);
     // The wrong sentence for this removal: nothing here is about early access ending.
     expect(page.getByText(/your payment for early access will be lost/).elements()).toHaveLength(0);
+    // The way back is the picker, not a link, and the sentence has to say so — unlike POI and private,
+    // this removal is reversible.
+    expect(
+      page.getByText(/Switch back to a commercial base model to restore it/).elements()
+    ).toHaveLength(1);
     // And no restore: it would re-apply a fee and a gate the server rejects for this base model — the
     // fee behind an editor that is unmounted for non-commercial base models, which is the hidden charge
     // the disclosure work exists to prevent.

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -410,6 +410,13 @@ export function ModelVersionUpsertForm({
   const currentLicensingFee = form.watch('licensingFee') ?? 0;
   const existingSettlementCurrency = version?.licensingFeeSettlementCurrency ?? null;
   const hasExistingLicensingFee = Number(version?.licensingFee ?? 0) > 0;
+  // A model depicting a real person can't earn at all — not a gate, not a per-generation fee. Every
+  // control goes and the section explains itself, rather than leaving editable inputs whose values the
+  // submit would drop. Private models keep their fee editor; only the gate is theirs to lose.
+  const monetizationBlocked = !!model?.poi;
+  // What the submit actually sends, so the warnings and the affirmation gate read the same value the
+  // payload carries instead of the untouched form state.
+  const submittedFee = monetizationBlocked ? 0 : currentLicensingFee ?? 0;
   // A version that already charges opens with the monetization section expanded; everything else starts
   // collapsed behind the master switch below.
   const hasExistingCharge = !!version?.paidAccess || hasExistingLicensingFee;
@@ -472,6 +479,7 @@ export function ModelVersionUpsertForm({
   // version (which has no download tier, so `download?.price` alone would read as unpriced).
   const storedAccessPrice = storedTerms?.download?.price ?? storedPaidGen?.price ?? 0;
   const showLicensingFeeBlock =
+    !monetizationBlocked &&
     !isNonCommercial &&
     (!!features.licensingFee ||
       hasExistingLicensingFee ||
@@ -512,7 +520,7 @@ export function ModelVersionUpsertForm({
   const moderatingSomeoneElsesModel =
     !!currentUser?.isModerator && modelOwnerId != null && modelOwnerId !== currentUser.id;
   const requiresRightsAffirmation =
-    !alreadyAffirmed && !moderatingSomeoneElsesModel && (currentLicensingFee > 0 || gateCharges);
+    !alreadyAffirmed && !moderatingSomeoneElsesModel && (submittedFee > 0 || gateCharges);
   // Step 2 of the disclosure: asked as soon as the creator says they want to charge, so the pricing
   // controls never appear before the affirmation. Distinct from `requiresRightsAffirmation`, which is the
   // submit gate and stays keyed to an actual charge — toggling the switch and changing your mind must not
@@ -534,7 +542,7 @@ export function ModelVersionUpsertForm({
   // Step 4 for the fee: its own opt-in, so the fee editor is reached by saying you want to charge per
   // generation rather than by the section being open at all.
   const feeEditorOpen = showChargeSettings && showLicensingFeeBlock && feeEnabled;
-  const removingStoredFee = hasExistingLicensingFee && (currentLicensingFee ?? 0) <= 0;
+  const removingStoredFee = hasExistingLicensingFee && submittedFee <= 0;
   // Read through `gateCharges` — what the submit actually sends — for the same reason it exists: the raw
   // config survives behind a hidden editor, so a version that went private, or whose usage control can no
   // longer be gated, drops its gate on save while the config still reads non-null.
@@ -775,13 +783,16 @@ export function ModelVersionUpsertForm({
         epochs: data.epochs ?? null,
         steps: data.steps ?? null,
         modelId: model?.id ?? -1,
+        // A POI model earns nothing: the fee editor is unmounted for one, so its stored value would
+        // otherwise ride along untouched behind a section that shows no controls at all.
+        licensingFee: submittedFee,
         paidAccess: submittedGate,
         // Keyed to the gate that is actually sent: a goal ends a timed window early, so writing one for a
         // version whose gate was just rejected leaves a goal against nothing to end.
         donationGoal: submittedGate ? toDonationGoalInput(gatedConfig) : null,
         trainedWords: skipTrainedWords ? [] : trainedWords,
         baseModelType: data.baseModelType,
-        monetization: data.monetization,
+        monetization: monetizationBlocked ? null : data.monetization,
         recommendedResources,
         templateId,
         bountyId,
@@ -1255,13 +1266,37 @@ export function ModelVersionUpsertForm({
           {(showPaidAccessInput ||
             showLicensingFeeBlock ||
             requiresRightsAffirmation ||
-            removingStoredCharge) && (
+            removingStoredCharge ||
+            monetizationBlocked) && (
             <Card withBorder p="md">
               <Stack gap={0}>
                 <Text fw={600} mb="sm">
                   Monetization
                 </Text>
-                {(showPaidAccessInput || showLicensingFeeBlock) && (
+                {monetizationBlocked && (
+                  <Alert
+                    color="red"
+                    icon={<IconAlertTriangle size={18} />}
+                    title="Models depicting a real person can't be monetized"
+                  >
+                    <Text size="sm">
+                      Paid access and per-generation license fees are both unavailable for this
+                      model.
+                    </Text>
+                    {removingStoredCharge && (
+                      <Text size="xs" mt={4}>
+                        Saving now removes this version&apos;s{' '}
+                        {removingStoredFee && removingStoredGate
+                          ? 'license fee and paid access'
+                          : removingStoredFee
+                          ? 'license fee'
+                          : 'paid access'}
+                        .
+                      </Text>
+                    )}
+                  </Alert>
+                )}
+                {!monetizationBlocked && (showPaidAccessInput || showLicensingFeeBlock) && (
                   <Switch
                     label="I want to charge for this version"
                     description="Sell access to the version, charge a fee per generation, or both."
@@ -1274,7 +1309,7 @@ export function ModelVersionUpsertForm({
                     disabled={isEarlyAccessOver && !!version?.paidAccess}
                   />
                 )}
-                {removingStoredCharge && (
+                {removingStoredCharge && !monetizationBlocked && (
                   <Stack gap={4} mt="sm" align="flex-start">
                     {/* Red only when the control the sentence is about is off screen — that's the case
                         the creator can't see. On screen, this describes an edit they just made. */}

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -1305,8 +1305,10 @@ export function ModelVersionUpsertForm({
                         </Text>
                       ))}
                     {/* No affordance for a removal the creator cannot prevent: the submit substitutes
-                        null for these regardless, so restoring would clear nothing and read as broken. */}
-                    {(removingStoredFee || !gateRemovalIsStructural) && (
+                        null for these regardless, so restoring would clear nothing and read as broken.
+                        A non-commercial base model rejects BOTH charges server-side, and its fee editor is
+                        unmounted — restoring there re-applies a fee nobody can see to a save that fails. */}
+                    {!isNonCommercial && (removingStoredFee || !gateRemovalIsStructural) && (
                       <Anchor
                         component="button"
                         type="button"

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -410,10 +410,11 @@ export function ModelVersionUpsertForm({
   const currentLicensingFee = form.watch('licensingFee') ?? 0;
   const existingSettlementCurrency = version?.licensingFeeSettlementCurrency ?? null;
   const hasExistingLicensingFee = Number(version?.licensingFee ?? 0) > 0;
-  // A model depicting a real person can't earn at all — not a gate, not a per-generation fee. Every
+  // Two reasons a version can't earn anything at all — not a gate, not a per-generation fee. Every
   // control goes and the section explains itself, rather than leaving editable inputs whose values the
   // submit would drop. Private models keep their fee editor; only the gate is theirs to lose.
-  const monetizationBlocked = !!model?.poi;
+  const monetizationBlockedReason = model?.poi ? 'poi' : isNonCommercial ? 'nonCommercial' : null;
+  const monetizationBlocked = !!monetizationBlockedReason;
   // What the submit actually sends, so the warnings and the affirmation gate read the same value the
   // payload carries instead of the untouched form state.
   const submittedFee = monetizationBlocked ? 0 : currentLicensingFee ?? 0;
@@ -480,7 +481,6 @@ export function ModelVersionUpsertForm({
   const storedAccessPrice = storedTerms?.download?.price ?? storedPaidGen?.price ?? 0;
   const showLicensingFeeBlock =
     !monetizationBlocked &&
-    !isNonCommercial &&
     (!!features.licensingFee ||
       hasExistingLicensingFee ||
       existingSettlementCurrency === LicensingFeeSettlementCurrency.Cash);
@@ -492,7 +492,8 @@ export function ModelVersionUpsertForm({
   // (`showPaidAccessInput`, which has further reasons of its own) and the submitted gate, because hiding
   // alone leaves the stored config intact (`shouldUnregister: false`) and resubmits a gate the creator can
   // neither see nor clear — which is what POI did.
-  const gateSuppressed = model?.availability === Availability.Private || !!model?.poi;
+  const gateSuppressed =
+    model?.availability === Availability.Private || !!model?.poi || isNonCommercial;
 
   // Asked once per version, the first time it earns anything — a version already on record keeps its
   // affirmation, so editing a price later doesn't ask again.
@@ -945,8 +946,7 @@ export function ModelVersionUpsertForm({
   // substitutes null (suppressed model, ungatable usage control) or an effect already cleared the config
   // (non-commercial base model). Nothing to offer them, so say why instead. Anything reachable here
   // without an arm below reads as the reversible early-access loss, which is the wrong sentence.
-  const gateRemovalIsStructural =
-    removingStoredGate && (gateSuppressed || !paidAccessUsageOk || isNonCommercial);
+  const gateRemovalIsStructural = removingStoredGate && (gateSuppressed || !paidAccessUsageOk);
   // Whether the control each sentence is about is actually on screen (see the colour rule below).
   const removalControlsVisible =
     (!removingStoredFee || (showChargeSettings && showLicensingFeeBlock)) &&
@@ -1277,11 +1277,17 @@ export function ModelVersionUpsertForm({
                   <Alert
                     color="red"
                     icon={<IconAlertTriangle size={18} />}
-                    title="Models depicting a real person can't be monetized"
+                    title={
+                      monetizationBlockedReason === 'poi'
+                        ? "Models depicting a real person can't be monetized"
+                        : 'This base model is licensed for non-commercial use'
+                    }
                   >
                     <Text size="sm">
-                      Paid access and per-generation license fees are both unavailable for this
-                      model.
+                      Paid access and per-generation license fees are both unavailable for this{' '}
+                      {monetizationBlockedReason === 'poi' ? 'model' : 'base model'}.
+                      {monetizationBlockedReason === 'nonCommercial' &&
+                        ' Switch back to a commercial base model to restore them.'}
                     </Text>
                     {removingStoredCharge && (
                       <Text size="xs" mt={4}>
@@ -1327,10 +1333,6 @@ export function ModelVersionUpsertForm({
                         <Text size="xs" c="red">
                           {isPrivateModel
                             ? "A private model can't have paid access, so this can't be kept."
-                            : model?.poi
-                            ? "A model depicting a real person can't have paid access, so this can't be kept."
-                            : isNonCommercial
-                            ? "This base model is licensed for non-commercial use, so this can't be kept. Switch back to a commercial base model to restore it."
                             : "This version's usage control can't be gated, so this can't be kept."}
                         </Text>
                       ) : (
@@ -1341,9 +1343,9 @@ export function ModelVersionUpsertForm({
                       ))}
                     {/* No affordance for a removal the creator cannot prevent: the submit substitutes
                         null for these regardless, so restoring would clear nothing and read as broken.
-                        A non-commercial base model rejects BOTH charges server-side, and its fee editor is
-                        unmounted — restoring there re-applies a fee nobody can see to a save that fails. */}
-                    {!isNonCommercial && (removingStoredFee || !gateRemovalIsStructural) && (
+                        The fully-blocked reasons (POI, non-commercial) never reach here — they render the
+                        alert above instead, which has no controls to restore into. */}
+                    {(removingStoredFee || !gateRemovalIsStructural) && (
                       <Anchor
                         component="button"
                         type="button"

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -1295,7 +1295,7 @@ export function ModelVersionUpsertForm({
                             : model?.poi
                             ? "A model depicting a real person can't have paid access, so this can't be kept."
                             : isNonCommercial
-                            ? "This base model is licensed for non-commercial use, so this can't be kept."
+                            ? "This base model is licensed for non-commercial use, so this can't be kept. Switch back to a commercial base model to restore it."
                             : "This version's usage control can't be gated, so this can't be kept."}
                         </Text>
                       ) : (

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -480,9 +480,10 @@ export function ModelVersionUpsertForm({
     existingSettlementCurrency === LicensingFeeSettlementCurrency.Cash ||
     !!currentUser?.isModerator;
 
-  // Models that may not be gated at all. One source for both the hidden editor (`showPaidAccessInput`) and
-  // the submitted gate: hiding alone leaves the stored config intact (`shouldUnregister: false`) and
-  // resubmits a gate the creator can neither see nor clear, which is what POI did.
+  // POI and private: the two model-level reasons a gate can't exist. Read by both the hidden editor
+  // (`showPaidAccessInput`, which has further reasons of its own) and the submitted gate, because hiding
+  // alone leaves the stored config intact (`shouldUnregister: false`) and resubmits a gate the creator can
+  // neither see nor clear — which is what POI did.
   const gateSuppressed = model?.availability === Availability.Private || !!model?.poi;
 
   // Asked once per version, the first time it earns anything — a version already on record keeps its
@@ -775,7 +776,9 @@ export function ModelVersionUpsertForm({
         steps: data.steps ?? null,
         modelId: model?.id ?? -1,
         paidAccess: submittedGate,
-        donationGoal: toDonationGoalInput(gatedConfig),
+        // Keyed to the gate that is actually sent: a goal ends a timed window early, so writing one for a
+        // version whose gate was just rejected leaves a goal against nothing to end.
+        donationGoal: submittedGate ? toDonationGoalInput(gatedConfig) : null,
         trainedWords: skipTrainedWords ? [] : trainedWords,
         baseModelType: data.baseModelType,
         monetization: data.monetization,
@@ -927,9 +930,12 @@ export function ModelVersionUpsertForm({
   // A card header carrying its own toggle needs to read as a header, not as another row of fields.
   const cardHeaderBg = colorScheme === 'dark' ? 'dark.6' : 'gray.1';
 
-  // A private model, or a usage control that can't be gated, loses its gate on save no matter what the
-  // creator does — the submit substitutes null either way. Nothing to offer them, so say why instead.
-  const gateRemovalIsStructural = removingStoredGate && (gateSuppressed || !paidAccessUsageOk);
+  // Removals the creator cannot prevent — the gate goes on save whatever they do, whether the submit
+  // substitutes null (suppressed model, ungatable usage control) or an effect already cleared the config
+  // (non-commercial base model). Nothing to offer them, so say why instead. Anything reachable here
+  // without an arm below reads as the reversible early-access loss, which is the wrong sentence.
+  const gateRemovalIsStructural =
+    removingStoredGate && (gateSuppressed || !paidAccessUsageOk || isNonCommercial);
   // Whether the control each sentence is about is actually on screen (see the colour rule below).
   const removalControlsVisible =
     (!removingStoredFee || (showChargeSettings && showLicensingFeeBlock)) &&
@@ -1288,6 +1294,8 @@ export function ModelVersionUpsertForm({
                             ? "A private model can't have paid access, so this can't be kept."
                             : model?.poi
                             ? "A model depicting a real person can't have paid access, so this can't be kept."
+                            : isNonCommercial
+                            ? "This base model is licensed for non-commercial use, so this can't be kept."
                             : "This version's usage control can't be gated, so this can't be kept."}
                         </Text>
                       ) : (

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -90,6 +90,7 @@ import {
   monetizationLimits,
   ratioToFee,
   resolveCapTier,
+  separateGenerationPriceMissing,
   suggestedFee,
 } from '@civitai/buzz';
 import type { ModelUpsertInput } from '~/server/schema/model.schema';
@@ -479,6 +480,11 @@ export function ModelVersionUpsertForm({
     existingSettlementCurrency === LicensingFeeSettlementCurrency.Cash ||
     !!currentUser?.isModerator;
 
+  // Models that may not be gated at all. One source for both the hidden editor (`showPaidAccessInput`) and
+  // the submitted gate: hiding alone leaves the stored config intact (`shouldUnregister: false`) and
+  // resubmits a gate the creator can neither see nor clear, which is what POI did.
+  const gateSuppressed = model?.availability === Availability.Private || !!model?.poi;
+
   // Asked once per version, the first time it earns anything — a version already on record keeps its
   // affirmation, so editing a price later doesn't ask again.
   //
@@ -488,9 +494,7 @@ export function ModelVersionUpsertForm({
   // The cast is the input-vs-output type of the form schema; both seed paths write concrete values.
   const gateCharges = paidAccessCharges(
     toPaidAccessInput(
-      model?.availability === Availability.Private
-        ? null
-        : (paidAccessConfig as FormPaidAccessConfig | null | undefined),
+      gateSuppressed ? null : (paidAccessConfig as FormPaidAccessConfig | null | undefined),
       usageControl
     )
   );
@@ -710,6 +714,28 @@ export function ModelVersionUpsertForm({
       return;
     }
 
+    const gatedConfig = gateSuppressed ? null : data.paidAccessConfig;
+    // Keyed to the gate the submit actually sends, not to the config: a usage control that can't be gated
+    // leaves the pricing controls unmounted with their values intact, and refusing over a price nobody can
+    // see (for a gate that would be dropped anyway) is a save the creator has no way to unblock.
+    const submittedGate = toPaidAccessInput(gatedConfig, data.usageControl);
+
+    // A generation grant with no price of its own is charged at the DOWNLOAD price (see `generationPrice`),
+    // so an empty box under "a cheaper generation-only price" bills the full access price while the screen
+    // says cheaper. Nothing downstream can tell that apart from a deliberate "same as access price", so the
+    // refusal has to happen here, where the creator's choice still exists.
+    if (
+      genMode === 'separate' &&
+      submittedGate &&
+      data.usageControl !== ModelUsageControl.Generation &&
+      separateGenerationPriceMissing(data.paidAccessConfig?.generationPrice)
+    ) {
+      const message = 'Enter a generation-only price, or choose "Same as the access price"';
+      form.setError('paidAccessConfig.generationPrice', { message });
+      showErrorNotification({ error: new Error(message), title: 'Generation price required' });
+      return;
+    }
+
     if (requiresRightsAffirmation && !data.rightsAffirmed) {
       const message = 'You must confirm you hold the rights to monetize this model';
       form.setError('rightsAffirmed', { message });
@@ -741,8 +767,6 @@ export function ModelVersionUpsertForm({
           settings: { strength },
         })) ?? [];
 
-      const gatedConfig =
-        model?.availability === Availability.Private ? null : data.paidAccessConfig;
       const result = await upsertVersionMutation.mutateAsync({
         ...data,
         // Don't persist a stale clip skip for base models that don't use it.
@@ -750,7 +774,7 @@ export function ModelVersionUpsertForm({
         epochs: data.epochs ?? null,
         steps: data.steps ?? null,
         modelId: model?.id ?? -1,
-        paidAccess: toPaidAccessInput(gatedConfig, data.usageControl),
+        paidAccess: submittedGate,
         donationGoal: toDonationGoalInput(gatedConfig),
         trainedWords: skipTrainedWords ? [] : trainedWords,
         baseModelType: data.baseModelType,
@@ -868,8 +892,7 @@ export function ModelVersionUpsertForm({
       (!isPublished || atEarlyAccess)) ||
     isPublished;
   const showPaidAccessInput =
-    !model?.poi && // POI models won't allow EA.
-    !isPrivateModel &&
+    !gateSuppressed &&
     !isNonCommercial && // Non-commercial base models can't be monetized.
     paidAccessUsageOk &&
     canConfigurePaidAccess;
@@ -906,7 +929,7 @@ export function ModelVersionUpsertForm({
 
   // A private model, or a usage control that can't be gated, loses its gate on save no matter what the
   // creator does — the submit substitutes null either way. Nothing to offer them, so say why instead.
-  const gateRemovalIsStructural = removingStoredGate && (isPrivateModel || !paidAccessUsageOk);
+  const gateRemovalIsStructural = removingStoredGate && (gateSuppressed || !paidAccessUsageOk);
   // Whether the control each sentence is about is actually on screen (see the colour rule below).
   const removalControlsVisible =
     (!removingStoredFee || (showChargeSettings && showLicensingFeeBlock)) &&
@@ -1223,7 +1246,10 @@ export function ModelVersionUpsertForm({
               )}
             </Stack>
           </Card>
-          {(showPaidAccessInput || showLicensingFeeBlock || requiresRightsAffirmation) && (
+          {(showPaidAccessInput ||
+            showLicensingFeeBlock ||
+            requiresRightsAffirmation ||
+            removingStoredCharge) && (
             <Card withBorder p="md">
               <Stack gap={0}>
                 <Text fw={600} mb="sm">
@@ -1260,6 +1286,8 @@ export function ModelVersionUpsertForm({
                         <Text size="xs" c="red">
                           {isPrivateModel
                             ? "A private model can't have paid access, so this can't be kept."
+                            : model?.poi
+                            ? "A model depicting a real person can't have paid access, so this can't be kept."
                             : "This version's usage control can't be gated, so this can't be kept."}
                         </Text>
                       ) : (
@@ -1576,6 +1604,7 @@ export function ModelVersionUpsertForm({
                                       )}
                                       step={100}
                                       leftSection={<CurrencyIcon currency="BUZZ" size={16} />}
+                                      withAsterisk
                                       disabled={isEarlyAccessOver}
                                     />
                                   )}

--- a/src/server/controllers/model-version.controller.ts
+++ b/src/server/controllers/model-version.controller.ts
@@ -146,6 +146,10 @@ const loadModelVersion = async ({
             status: true,
             publishedAt: true,
             nsfw: true,
+            // The version editor gates paid access on this. Omitted, `model.poi` reads undefined and the
+            // gate is neither hidden nor suppressed at submit — the editor renders as if the model were
+            // ordinary.
+            poi: true,
             uploadType: true,
             user: { select: { id: true } },
             availability: true,


### PR DESCRIPTION
Closes the two ClickUp items on the model-version upload/submit path (868kqr3qa, 868kqr3qd). Both were audited against current `origin/main` first, on the chance they were already fixed by #3862 — neither was.

## 1. Blank generation-only price silently charges the full download price (money path)

Picking **"A cheaper generation-only price"** and leaving the box empty submitted `generation: { trialLimit }` with no `price`. `generationPrice(terms)` falls back to `download.price`, and that is the value `model-version.service.ts` charges — so the radio said cheaper and the buyer paid the full access price, with nothing on screen to notice.

`#3862` doesn't cover it: that fix makes the radio follow the config it just wrote, and this is the one place the radio *leads* the config, so the resync has nothing to correct.

**This cannot be fixed server-side.** A priceless paid-generation grant beside a download tier is byte-identical to a deliberate "same as the access price". `assertPaidAccessInput` already rejects the priceless case where there is *no* download tier — precisely because that one is distinguishable. With a download tier it isn't, so the refusal belongs in the editor while the creator's choice still exists.

The guard keys off the gate the submit actually sends (`toPaidAccessInput(...) != null`), not the raw config: a usage control that can't be gated leaves the pricing controls unmounted with their values intact, and refusing over a price nobody can see — for a gate that would be dropped anyway — is a save with no way to unblock it.

## 2. `model.poi` excluded in the UI, never re-checked at submit (safety gate)

`model.poi` appeared exactly once on the whole write path — a render condition. With `shouldUnregister: false`, the stored config survived behind the hidden editor and every save re-asserted a gate the creator could not see or change.

`gateSuppressed` (private **or** POI) is now the single source for both the hidden editor and the submitted gate, so adding a third reason later can't hide the editor while leaving the submit intact. The existing removal notice picks up the case and says why the gate can't be kept.

Prod at time of writing: **12 POI model versions carry a paid-access gate.** 11 permanent, and **one live timed early-access window** (version 3144960, 50,000 Buzz, closing 2026-08-14) — that one is deleted by its owner's next save, and is the case worth a decision before merge.

## 3. Fallout from making the notice visible (found by review, fixed here)

Rendering the Monetization card whenever a stored charge is going away is what makes the POI notice reachable. It also made the **non-commercial base model** removal reachable for the first time — that gate is cleared by an effect rather than at submit, and with no arm of its own it fell through to the reversible early-access wording *and* offered "Restore the stored settings". Restoring re-applied a licensing fee behind an editor that is unmounted for non-commercial base models (CU 868kq69rv, the exact hidden charge this disclosure work exists to prevent) and the save then failed server-side.

Both halves are fixed: `isNonCommercial` has its own sentence, and Restore is suppressed under it entirely. `donationGoal` is also now keyed to the gate that is actually sent, so an ungatable usage control can't write a goal against no gate.

Note the on-load path is a **separate, still-open hole of the same family**: a version *loaded* on a non-commercial base model never renders the card at all (the reset effect repopulates the config after the clearing effect) and just fails server-side with nothing on screen predicting it. Not a regression from this PR; not fixed here.

## Scope, stated plainly

- **Both fixes are client-side.** For POI that is a deliberate product call; a direct API call or the REST early-access endpoint can still create a gate on a POI model. For the blank price, the server genuinely cannot enforce it — see above.
- **Creator Studio has the same blank-price bug** (`PaidAccessFields.svelte` + `monetization/paid-access.ts:44`, where the only refine passes vacuously on `undefined`) and is not fixed here. It needs its own submitted-mode field to become enforceable, which is a change in another app. Flagged, not silently folded in.

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm exec eslint` on the changed files — clean apart from two issues that reproduce identically on untouched files (`vitest` extraneous-dep, a pre-existing unused import)
- `ModelVersionUpsertForm.browser.test.tsx` — 18 passed, three of them new
- `paid-access.test.ts` + `blocks.router.workflow.test.ts` — 347 collected, all passing (nonzero, so the submodule is initialised)
- Unit-suite failures are all pre-existing: the same subset gives 34 failures on this branch and 35 on the clean base, and the totals are unstable between local runs

**Mutation-checked**, since a passing test says nothing about how it fails:

| Revert | Failure | Time |
|---|---|---|
| drop `poi` from `gateSuppressed` | `expected [] to have a length of 1` (the POI notice) | 0.4s |
| disable the price guard | `Error: saved a blank generation-only price instead of refusing it` | 4.0s |
| drop the non-commercial arm | `expected [] to have a length of 1` (the reason sentence) | 0.7s |
| un-suppress Restore | `expected [ <button …> ] to have a length of +0 but got 1` | 0.8s |

The blank-price test also carries a positive control — the same save goes through once a price is typed — so the refusal can't pass for an unrelated reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)