### PR TITLE
DO NOT MERGE — fix(placement): sticker control hysteresis (infinite render loop, parked)

### DIFF
--- a/src/components/Sticker/DraftSticker.browser.test.tsx
+++ b/src/components/Sticker/DraftSticker.browser.test.tsx
@@ -1,0 +1,225 @@
+import { describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import type * as PlacementUtil from '~/components/Sticker/placement.util';
+import type * as StickerUtil from '~/components/Sticker/sticker.util';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import { DraftSticker } from '~/components/Sticker/DraftSticker';
+import type { StickerTreatment } from '~/components/Sticker/treatments/sticker-treatments';
+import type { StickerDraft } from '~/store/sticker-placement-draft.store';
+
+/**
+ * The two control layouts sit in different places in the tree — flush against
+ * the sticker's own top corners while it is wide enough, inside the buy cluster
+ * once it is not — so crossing the width that decides between them unmounts one
+ * and mounts the other. Everything here is about what that crossing must not
+ * cost: an open opacity slider, and a layout that changes its mind on every
+ * frame of a resize.
+ */
+
+/**
+ * Narrow enough to sit inside the browser-mode viewport. A media box wider than
+ * the window puts the sticker's controls off the side of it, and a click on
+ * something that cannot be scrolled into view fails as a 15s actionability
+ * timeout rather than as anything about the sticker.
+ */
+const MEDIA_BOX_WIDTH = 260;
+
+// Wide enough for the flush panels (182px), narrow enough to be well under the
+// leave width (78px), and inside the hysteresis band (117px). Fractions of the
+// media box, which is how a draft's scale is stored.
+const WIDE = 0.7;
+const NARROW = 0.3;
+const IN_BAND = 0.45;
+
+vi.mock('~/components/Sticker/placement.util', async (importOriginal) => ({
+  ...(await importOriginal<typeof PlacementUtil>()),
+  useCreateStickerPlacement: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+// The button pulls in the Buzz balance, a tRPC query and a purchase path, none
+// of which this is about. A plain button keeps the cluster's shape.
+vi.mock('~/components/Buzz/BuzzTransactionButton', () => ({
+  BuzzTransactionButton: ({ label }: { label: string }) => <button type="button">{label}</button>,
+}));
+
+vi.mock('~/components/EdgeMedia/EdgeImage', () => ({
+  EdgeImage: ({ alt }: { alt: string }) => (
+    // A real EdgeImage has no intrinsic size until it loads, and the sticker's
+    // height feeds the flip decision. A fixed box makes both measurements
+    // deterministic without touching the width, which is what is under test.
+    <div aria-label={alt} style={{ width: '100%', height: 80 }} />
+  ),
+}));
+
+const draft = (scale: number): StickerDraft => ({
+  id: 'draft-1',
+  imageId: 1,
+  cosmeticId: 2,
+  x: 0.5,
+  y: 0.5,
+  scale,
+  rotation: 0,
+  flip: false,
+  opacity: 1,
+});
+
+/** No plate, no edge, no animation — nothing that would change the sticker's box. */
+const PLAIN: StickerTreatment = { key: 'none', label: 'None', note: '' };
+
+const art = {
+  id: 2,
+  slug: 'test-sticker',
+  url: 'sticker.png',
+  animated: false,
+} as unknown as StickerUtil.ResolvedSticker;
+
+const renderDraft = async (scale: number) => {
+  const result = await renderWithProviders(
+    <div style={{ position: 'relative', width: MEDIA_BOX_WIDTH, height: 400 }}>
+      <DraftSticker
+        draft={draft(scale)}
+        art={art}
+        selected
+        dressed={PLAIN}
+        price={100}
+        ownerShare={undefined}
+        ownerUsername={undefined}
+        onGesture={() => true}
+      />
+    </div>
+  );
+
+  const resize = (next: number) =>
+    result.rerender(
+      <div style={{ position: 'relative', width: MEDIA_BOX_WIDTH, height: 400 }}>
+        <DraftSticker
+          draft={draft(next)}
+          art={art}
+          selected
+          dressed={PLAIN}
+          price={100}
+          ownerShare={undefined}
+          ownerUsername={undefined}
+          onGesture={() => true}
+        />
+      </div>
+    );
+
+  return { resize };
+};
+
+/**
+ * Which layout is live, read from DOM containment rather than from the position
+ * classes: the flush panels hang off the sticker itself, the narrow layout puts
+ * the same controls inside the buy cluster.
+ */
+const controlsAreInTheCluster = () => {
+  const cluster = document.querySelector('[data-testid="sticker-buy-cluster"]');
+  const flip = page.getByRole('button', { name: /flip this sticker/i }).element();
+  return !!cluster?.contains(flip);
+};
+
+const sliders = () => page.getByRole('slider').elements().length;
+
+const openOpacity = () =>
+  page
+    .getByRole('button', { name: /set this sticker's opacity/i })
+    .element()
+    .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+describe('DraftSticker control geometry', () => {
+  test('hands the controls to the buy cluster once the sticker is too narrow for them', async () => {
+    const { resize } = await renderDraft(WIDE);
+    // Arriving state, and it stays: safe to await.
+    await expect.element(page.getByRole('button', { name: 'Place' })).toBeInTheDocument();
+    expect(controlsAreInTheCluster()).toBe(false);
+
+    await resize(NARROW);
+
+    expect(controlsAreInTheCluster()).toBe(true);
+  });
+
+  // The band, not a shift of the line. A width inside it keeps whichever layout
+  // it already had, so a resize gesture dragging the sticker through that region
+  // does not swap the two on every frame.
+  test('keeps the flush panels through the band under the width that earned them', async () => {
+    const { resize } = await renderDraft(WIDE);
+    await expect.element(page.getByRole('button', { name: 'Place' })).toBeInTheDocument();
+
+    await resize(IN_BAND);
+
+    expect(controlsAreInTheCluster()).toBe(false);
+  });
+
+  test('does not give a draft the flush panels merely for reaching the band', async () => {
+    // The negative control for the case above: the same width, approached from
+    // below, must NOT produce the flush layout — otherwise that test would pass
+    // against a hysteresis that had simply moved the threshold down.
+    const { resize } = await renderDraft(NARROW);
+    await expect.element(page.getByRole('button', { name: 'Place' })).toBeInTheDocument();
+    expect(controlsAreInTheCluster()).toBe(true);
+
+    await resize(IN_BAND);
+
+    expect(controlsAreInTheCluster()).toBe(true);
+  });
+
+  // The reason any of this matters. The opacity slider is the one piece of state
+  // up there, and the layout swap destroys the element holding it.
+  //
+  // ⚠️ The open slider is a state that DELETES ITSELF on a regression, so it is
+  // never awaited after the resize — a matcher polling for something already
+  // gone can only ever time out. The awaits are all before the crossing, on
+  // states that arrive and stay; the assertion that carries the test is read
+  // synchronously on the commit the resize produced, so a revert fails in
+  // milliseconds naming the count.
+  test('keeps an open opacity slider open across the width that swaps the layouts', async () => {
+    const { resize } = await renderDraft(WIDE);
+    await expect.element(page.getByRole('button', { name: 'Place' })).toBeInTheDocument();
+
+    // A DOM click, not the browser driver's. The controls are Mantine
+    // `ActionIcon`s, which take their size entirely from Mantine's stylesheet —
+    // absent here, so they measure 0x0 and the driver's actionability check
+    // waits out its whole budget on an element that will never have a hit box.
+    // That failure says nothing about the sticker, and the handler under test is
+    // an ordinary onClick either way.
+    openOpacity();
+    await expect.element(page.getByRole('slider')).toBeInTheDocument();
+
+    await resize(NARROW);
+
+    expect(sliders()).toBe(1);
+    // And in the layout it moved to, not orphaned beside the one it left.
+    expect(controlsAreInTheCluster()).toBe(true);
+  });
+
+  // The other direction unmounts a different subtree — the control row inside
+  // the buy cluster rather than the two flush pills — so one direction is only
+  // half the claim.
+  test('keeps an open opacity slider open going the other way too', async () => {
+    const { resize } = await renderDraft(NARROW);
+    await expect.element(page.getByRole('button', { name: 'Place' })).toBeInTheDocument();
+    expect(controlsAreInTheCluster()).toBe(true);
+
+    openOpacity();
+    await expect.element(page.getByRole('slider')).toBeInTheDocument();
+
+    await resize(WIDE);
+
+    expect(sliders()).toBe(1);
+    expect(controlsAreInTheCluster()).toBe(false);
+  });
+
+  test('leaves a closed slider closed across the same crossing', async () => {
+    // Without this, the case above would also pass against a popover wedged
+    // permanently open.
+    const { resize } = await renderDraft(WIDE);
+    await expect.element(page.getByRole('button', { name: 'Place' })).toBeInTheDocument();
+    expect(sliders()).toBe(0);
+
+    await resize(NARROW);
+
+    expect(sliders()).toBe(0);
+  });
+});

--- a/src/components/Sticker/DraftSticker.browser.test.tsx
+++ b/src/components/Sticker/DraftSticker.browser.test.tsx
@@ -211,6 +211,28 @@ describe('DraftSticker control geometry', () => {
     expect(controlsAreInTheCluster()).toBe(false);
   });
 
+  // The other half of the reported symptom, and the half no slider count can
+  // see. Mantine's own `returnFocus` cannot do this one: it captures the element
+  // to return to in a hook that skips its first run, so a Popover remounting
+  // already-open captures nothing and restores to null.
+  test('returns focus to the control that replaced the one it was opened from', async () => {
+    const { resize } = await renderDraft(WIDE);
+    await expect.element(page.getByRole('button', { name: 'Place' })).toBeInTheDocument();
+
+    openOpacity();
+    await expect.element(page.getByRole('slider')).toBeInTheDocument();
+
+    await resize(NARROW);
+    // Read synchronously: focus lands on the body if this regresses, and body is
+    // an absorbing state no matcher could ever catch leaving.
+    openOpacity();
+
+    expect(document.activeElement?.getAttribute('aria-label')).toBe("Set this sticker's opacity");
+    // The control it returned to is the newly mounted one, not a detached node
+    // left over from the layout it was opened in.
+    expect(document.body.contains(document.activeElement)).toBe(true);
+  });
+
   test('leaves a closed slider closed across the same crossing', async () => {
     // Without this, the case above would also pass against a popover wedged
     // permanently open.

--- a/src/components/Sticker/DraftSticker.browser.test.tsx
+++ b/src/components/Sticker/DraftSticker.browser.test.tsx
@@ -214,7 +214,9 @@ describe('DraftSticker control geometry', () => {
   // The other half of the reported symptom, and the half no slider count can
   // see. Mantine's own `returnFocus` cannot do this one: it captures the element
   // to return to in a hook that skips its first run, so a Popover remounting
-  // already-open captures nothing and restores to null.
+  // already-open captures nothing and restores to null. Measured without the
+  // fix, focus is left on a non-control `div` — not the body, and either way not
+  // anywhere a keyboard user can carry on from.
   test('returns focus to the control that replaced the one it was opened from', async () => {
     const { resize } = await renderDraft(WIDE);
     await expect.element(page.getByRole('button', { name: 'Place' })).toBeInTheDocument();
@@ -223,11 +225,21 @@ describe('DraftSticker control geometry', () => {
     await expect.element(page.getByRole('slider')).toBeInTheDocument();
 
     await resize(NARROW);
-    // Read synchronously: focus lands on the body if this regresses, and body is
-    // an absorbing state no matcher could ever catch leaving.
+    // Queried AFTER the crossing: this is the control the remount built, and a
+    // different node from the one the slider was opened from.
+    const control = page.getByRole('button', { name: /set this sticker's opacity/i }).element();
+
+    // Closes rather than opens — the helper is a toggle, and the close is the
+    // whole point here. Read synchronously afterwards: a regression parks focus
+    // somewhere absorbing that no matcher could catch leaving.
     openOpacity();
 
     expect(document.activeElement?.getAttribute('aria-label')).toBe("Set this sticker's opacity");
+    // Identity, not just the label: the assertion above is the legible one, this
+    // is the one that cannot be satisfied by some other element carrying the
+    // same name, and it pins that focus went to the control the crossing BUILT
+    // rather than the detached one it replaced.
+    expect(document.activeElement).toBe(control);
     // The control it returned to is the newly mounted one, not a detached node
     // left over from the layout it was opened in.
     expect(document.body.contains(document.activeElement)).toBe(true);

--- a/src/components/Sticker/DraftSticker.tsx
+++ b/src/components/Sticker/DraftSticker.tsx
@@ -389,6 +389,18 @@ export function DraftSticker({
   // re-attached to whichever control is currently mounted, so it survives the
   // swap by construction. (`Popover.Target` merges the child's own ref rather
   // than replacing it, so holding one costs nothing.)
+  //
+  // It lands on Escape and on the control's own click. A close caused by a
+  // mousedown elsewhere overwrites it a moment later with whatever was clicked,
+  // which is the browser's own default action and the behaviour you want —
+  // clicking into the note field must leave focus in the note field.
+  //
+  // Dropping the `returnFocus` PROP did not unwire Mantine's returnFocus
+  // FUNCTION: `Popover.Dropdown` passes it as `onTrigger` to its escape handler
+  // unconditionally, and the prop only gates the separate restore-on-close
+  // branch. It runs after this one and is a no-op or a repeat today, because the
+  // node it captured is this same control. It would start winning if the popover
+  // could ever be opened with focus somewhere else.
   const [opacityOpen, setOpacityOpen] = useState(false);
   const opacityTargetRef = useRef<HTMLButtonElement>(null);
 

--- a/src/components/Sticker/DraftSticker.tsx
+++ b/src/components/Sticker/DraftSticker.tsx
@@ -271,6 +271,12 @@ export function DraftSticker({
 
   const begin =
     (mode: Gesture['mode'], corner?: { sx: number; sy: number }) => (event: React.PointerEvent) => {
+      // `preventDefault` also suppresses the compatibility `mousedown` — measured
+      // in Chromium, and `stopPropagation` alone does not do it. That is what
+      // keeps an open opacity slider alive through a drag, resize or rotate:
+      // Mantine's click-outside listens for `mousedown`, so a press on the
+      // sticker never reaches it. Removing this would close the popover on every
+      // gesture.
       event.preventDefault();
       event.stopPropagation();
 

--- a/src/components/Sticker/DraftSticker.tsx
+++ b/src/components/Sticker/DraftSticker.tsx
@@ -142,10 +142,10 @@ export function DraftSticker({
 
   // `measure` is what the ResizeObserver and the window listener are bound to,
   // so it has to keep its identity across a drag — otherwise re-binding them is
-  // back on the pointermove path, which is the whole problem. It reads the two
+  // back on the pointermove path, which is the whole problem. It reads the
   // values it needs through a ref instead of closing over them.
-  const frame = useRef({ flipped, rotation: draft.rotation });
-  frame.current = { flipped, rotation: draft.rotation };
+  const frame = useRef({ flipped, rotation: draft.rotation, panelsInside });
+  frame.current = { flipped, rotation: draft.rotation, panelsInside };
 
   const clip = useRef<HTMLElement | null>(null);
 
@@ -154,7 +154,7 @@ export function DraftSticker({
     const button = buttonRef.current;
     if (!element || !button) return;
 
-    const { flipped, rotation } = frame.current;
+    const { flipped, rotation, panelsInside } = frame.current;
     const tray = useStickerPlacementDraftStore.getState().tray;
     const height = element.offsetHeight;
     // Layout size, not the bounding box: `offsetWidth` ignores the CSS rotation,
@@ -169,7 +169,7 @@ export function DraftSticker({
       // does not scale with it — and on a narrow draft they are not drawn at
       // all, so there is nothing there to clear. Clearing a band that is not
       // there only costs the button a flip it could have taken.
-      panelBand: panelBandFor(width),
+      panelBand: panelBandFor(width, panelsInside),
     });
     // From the button's own measured rect, both times: the pair that comes out
     // is the same whichever side the button is currently on, which is what stops
@@ -194,7 +194,7 @@ export function DraftSticker({
         clip: clip.current?.getBoundingClientRect() ?? null,
       }),
       flippedOffset: offset,
-      panelsInside: panelsFitInsideEdges(width),
+      panelsInside: panelsFitInsideEdges(width, panelsInside),
     };
 
     // Every pointer move re-measures, so bail on an unchanged result rather
@@ -372,8 +372,31 @@ export function DraftSticker({
 
   // The slider is behind a control rather than always on screen: it is set once,
   // and a slider parked on the artwork would be in the way of every later drag.
+  //
+  // Open state is held here rather than inside the Popover because the control
+  // itself does not survive: the flush panels and the buy cluster are different
+  // places in the tree, so a draft resized across the panel threshold unmounts
+  // whichever one it was in. Uncontrolled, that closed an open slider mid-drag —
+  // a window resize was enough, since the sticker's width is a fraction of the
+  // media box. `trapFocus` is the other half: the dropdown is genuinely rebuilt,
+  // so focus has to be put back into it rather than merely not taken away.
+  const [opacityOpen, setOpacityOpen] = useState(false);
   const opacityControl = (
-    <Popover width={210} position="top" withArrow withinPortal shadow="md">
+    <Popover
+      width={210}
+      position="top"
+      withArrow
+      withinPortal
+      shadow="md"
+      trapFocus
+      // Paired with `trapFocus`, which Mantine defaults to leaving unpaired: the
+      // trap moves focus into the slider on open, and without this it is
+      // abandoned on document.body at close, so the next Tab restarts at the top
+      // of the page.
+      returnFocus
+      opened={opacityOpen}
+      onChange={setOpacityOpen}
+    >
       <Popover.Target>
         <ActionIcon
           size="sm"
@@ -381,6 +404,7 @@ export function DraftSticker({
           variant="subtle"
           color={draft.opacity < 1 ? 'blue' : 'gray'}
           aria-label="Set this sticker's opacity"
+          onClick={() => setOpacityOpen((open) => !open)}
         >
           <IconDropletHalf2 size={14} />
         </ActionIcon>
@@ -535,6 +559,10 @@ export function DraftSticker({
 
       <div
         ref={buttonRef}
+        // Which of the two layouts is live is otherwise only legible from
+        // Tailwind position classes, and a test reading those fails for the
+        // wrong reason the moment the styling moves.
+        data-testid="sticker-buy-cluster"
         // `w-max` and the floor together: an absolutely positioned child is
         // shrink-to-fit against its containing block, which here is the sticker
         // itself — so a small sticker was squeezing the button until its label

--- a/src/components/Sticker/DraftSticker.tsx
+++ b/src/components/Sticker/DraftSticker.tsx
@@ -380,7 +380,23 @@ export function DraftSticker({
   // a window resize was enough, since the sticker's width is a fraction of the
   // media box. `trapFocus` is the other half: the dropdown is genuinely rebuilt,
   // so focus has to be put back into it rather than merely not taken away.
+  //
+  // Returning focus on close is ours rather than Mantine's `returnFocus`, which
+  // is inert in exactly the case this exists for. `useFocusReturn` captures the
+  // element to return to inside a `useDidUpdate`, and that hook skips its first
+  // invocation — so a Popover REMOUNTING with `opened` already true never
+  // captures anything, and the close then restores to null. A ref here is
+  // re-attached to whichever control is currently mounted, so it survives the
+  // swap by construction. (`Popover.Target` merges the child's own ref rather
+  // than replacing it, so holding one costs nothing.)
   const [opacityOpen, setOpacityOpen] = useState(false);
+  const opacityTargetRef = useRef<HTMLButtonElement>(null);
+
+  const showOpacity = (open: boolean) => {
+    setOpacityOpen(open);
+    if (!open) opacityTargetRef.current?.focus({ preventScroll: true });
+  };
+
   const opacityControl = (
     <Popover
       width={210}
@@ -389,22 +405,18 @@ export function DraftSticker({
       withinPortal
       shadow="md"
       trapFocus
-      // Paired with `trapFocus`, which Mantine defaults to leaving unpaired: the
-      // trap moves focus into the slider on open, and without this it is
-      // abandoned on document.body at close, so the next Tab restarts at the top
-      // of the page.
-      returnFocus
       opened={opacityOpen}
-      onChange={setOpacityOpen}
+      onChange={showOpacity}
     >
       <Popover.Target>
         <ActionIcon
+          ref={opacityTargetRef}
           size="sm"
           radius="xl"
           variant="subtle"
           color={draft.opacity < 1 ? 'blue' : 'gray'}
           aria-label="Set this sticker's opacity"
-          onClick={() => setOpacityOpen((open) => !open)}
+          onClick={() => showOpacity(!opacityOpen)}
         >
           <IconDropletHalf2 size={14} />
         </ActionIcon>

--- a/src/components/Sticker/__tests__/place-button-position.test.ts
+++ b/src/components/Sticker/__tests__/place-button-position.test.ts
@@ -8,6 +8,7 @@ import {
   placeButtonBoxes,
   shouldFlipPlaceButton,
   STICKER_PANEL_BAND_PX,
+  STICKER_PANEL_LEAVE_WIDTH_PX,
   STICKER_PANEL_MIN_WIDTH_PX,
 } from '~/components/Sticker/place-button-position';
 
@@ -112,32 +113,66 @@ describe('panelsFitInsideEdges', () => {
   it('refuses the flush layout on the sizes where delete would cover opacity', () => {
     // The 5% scale floor on a 1024px media box, and the default 18% on a
     // phone-width one. Both are states the product actually produces.
-    expect(panelsFitInsideEdges(51)).toBe(false);
-    expect(panelsFitInsideEdges(65)).toBe(false);
+    expect(panelsFitInsideEdges(51, false)).toBe(false);
+    expect(panelsFitInsideEdges(65, false)).toBe(false);
   });
 
   // The rotate knob is centred and 16px wide, and the left panel reaches 54px
   // in: below 124 the knob ends up under it, and the panel swallows the press.
   it('is bounded by the knob, not merely by the two panels touching', () => {
-    expect(panelsFitInsideEdges(STICKER_PANEL_MIN_WIDTH_PX - 1)).toBe(false);
-    expect(panelsFitInsideEdges(STICKER_PANEL_MIN_WIDTH_PX)).toBe(true);
+    expect(panelsFitInsideEdges(STICKER_PANEL_MIN_WIDTH_PX - 1, false)).toBe(false);
+    expect(panelsFitInsideEdges(STICKER_PANEL_MIN_WIDTH_PX, false)).toBe(true);
     // 92 is where the panels alone stop overlapping (54 + 26 + a gap). Wide
     // enough for them, still too narrow for the knob — the case a fix aimed at
     // the panels alone would get wrong.
-    expect(panelsFitInsideEdges(92)).toBe(false);
+    expect(panelsFitInsideEdges(92, false)).toBe(false);
   });
 
   it('allows it at the sizes the flush layout was designed for', () => {
-    expect(panelsFitInsideEdges(144)).toBe(true);
-    expect(panelsFitInsideEdges(400)).toBe(true);
+    expect(panelsFitInsideEdges(144, false)).toBe(true);
+    expect(panelsFitInsideEdges(400, false)).toBe(true);
+  });
+
+  // The two layouts live in different places in the component tree, so every
+  // crossing swaps one for the other. A single threshold makes a width parked on
+  // it do that on every frame of a resize.
+  it('holds the flush layout below the width that would have earned it', () => {
+    for (const width of [116, 118, 123]) {
+      expect(panelsFitInsideEdges(width, false)).toBe(false);
+      expect(panelsFitInsideEdges(width, true)).toBe(true);
+    }
+  });
+
+  it('gives up the flush layout once the width leaves the band underneath it', () => {
+    expect(panelsFitInsideEdges(STICKER_PANEL_LEAVE_WIDTH_PX, true)).toBe(true);
+    expect(panelsFitInsideEdges(STICKER_PANEL_LEAVE_WIDTH_PX - 1, true)).toBe(false);
+  });
+
+  // The band is a deadzone, not a shift of the line: a draft that has never had
+  // the panels still has to reach the full width to get them, and one that has
+  // them keeps them until it drops out the bottom.
+  it('agrees with itself on both sides of the band', () => {
+    for (const width of [40, 51, 65, 92, 115]) {
+      expect(panelsFitInsideEdges(width, true)).toBe(false);
+      expect(panelsFitInsideEdges(width, false)).toBe(false);
+    }
+    for (const width of [124, 144, 400]) {
+      expect(panelsFitInsideEdges(width, true)).toBe(true);
+      expect(panelsFitInsideEdges(width, false)).toBe(true);
+    }
   });
 
   // The band exists only where the panels do. Clearing one that is not there is
   // not harmful in itself, but it shrinks the flipped candidate box and so makes
   // the button decline a flip it could have taken.
   it('reports no band to clear where no panels are drawn', () => {
-    expect(panelBandFor(51)).toBe(0);
-    expect(panelBandFor(144)).toBe(STICKER_PANEL_BAND_PX);
+    expect(panelBandFor(51, false)).toBe(0);
+    expect(panelBandFor(144, false)).toBe(STICKER_PANEL_BAND_PX);
+  });
+
+  it('reports the band on the same widths the panels are drawn on', () => {
+    expect(panelBandFor(118, false)).toBe(0);
+    expect(panelBandFor(118, true)).toBe(STICKER_PANEL_BAND_PX);
   });
 });
 
@@ -272,10 +307,29 @@ describe('shouldFlipPlaceButton', () => {
     expect(decide(box(480), box(200), TRAY, tallClip)).toBe(true);
   });
 
-  it('does not flip when the flipped position is also hidden', () => {
-    // A sticker tall enough that both ends are in trouble. Flipping here moves
-    // the button without fixing anything.
-    expect(decide(box(800), box(730))).toBe(false);
+  // A sticker tall enough that both ends are in trouble. Standing still is what
+  // leaves a narrow draft with no controls at all — the cluster carries the only
+  // copy of flip, opacity and delete — so the less buried position wins.
+  it('takes the less hidden position when both are hidden', () => {
+    // 36px of the button behind the tray, against 6px.
+    expect(decide(box(800), box(730))).toBe(true);
+  });
+
+  it('stays put when the alternative is hidden by more', () => {
+    // The mirror of the case above, so this cannot pass by always flipping.
+    expect(decide(box(730), box(800))).toBe(false);
+  });
+
+  it('stays put when the two are hidden by exactly as much', () => {
+    // No tie-break worth having, and moving on a tie is how it would oscillate
+    // if the pair ever stopped being position-independent.
+    expect(decide(box(730), box(730, 36, 100, 232))).toBe(false);
+  });
+
+  it('prefers a visible position over a merely less hidden one', () => {
+    // Ranking must not get a say while one side is actually clear.
+    expect(decide(box(730), box(400))).toBe(true);
+    expect(decide(box(400), box(730))).toBe(false);
   });
 
   it('does not flip a button off the top of the viewport', () => {
@@ -296,9 +350,21 @@ describe('shouldFlipPlaceButton', () => {
 
   it('flips away from the top edge of the clip, not just the bottom', () => {
     // Above the carousel viewport but still on screen: clipped at the top, which
-    // nothing else would catch.
+    // nothing else would catch. The first case stays because 40px lost at the
+    // clip's top edge is MORE than the 36 the tray takes, not because a
+    // top-clipped position is disqualified — see the case below.
     expect(decide(box(800), box(20))).toBe(false);
     expect(decide(box(800), box(65))).toBe(true);
+  });
+
+  it('prefers a partly visible top-clipped position over one wholly behind the tray', () => {
+    // The 52px two-line button that lands with the merged payout copy, at the
+    // same two positions as the case above. Below is now swallowed whole by the
+    // tray; above keeps 12px below the clip's top edge. Deliberate, and the
+    // reason the pair above is a margin rather than a rule: top-of-clip is
+    // rankable, unlike top-of-viewport, because what is left of the box is on
+    // screen and can be pressed.
+    expect(decide(box(800, 52), box(20, 52))).toBe(true);
   });
 
   it('treats a button resting exactly on the tray edge as visible', () => {

--- a/src/components/Sticker/place-button-position.ts
+++ b/src/components/Sticker/place-button-position.ts
@@ -44,9 +44,10 @@ export const STICKER_PANEL_MIN_WIDTH_PX = 124;
  *
  * The two layouts are in different places in the component tree, so every
  * crossing of a single threshold unmounts one and mounts the other. A monotonic
- * drag crosses once and is fine; what a band buys is the NON-monotonic case — a
- * width parked on the line, where `scale * mediaWidth` rounds to 123 and 124 on
- * alternate frames, swapping the layouts for as long as the sticker sits there.
+ * drag crosses once and is fine; what a band buys is the NON-monotonic case,
+ * where the width itself moves back and forth across the line — a corner-resize
+ * gesture held near it, or a window-resize drag doing the same to the media box
+ * the sticker's width is a percentage of. Each wobble is a full swap without it.
  *
  * It buys jitter resistance and nothing else: one deliberate crossing still
  * swaps the layouts, so anything stateful up there has to survive that on its
@@ -168,10 +169,17 @@ export function placeButtonBoxes({
  * Whether the buy button belongs above the sticker rather than below it.
  *
  * Two different things hide it, and both were measured on the image detail page
- * at 1400x900: the tray is `fixed` at `z-30` and paints over the whole sticker
- * overlay, and the carousel's viewport is `overflow: hidden` ending exactly at
- * the bottom of the media box (846px), which clips anything hanging below it.
- * A button can hit either without the other, so both are checked.
+ * at 1400x900: the tray is `fixed` at `z-30` over the whole sticker overlay, and
+ * the carousel's viewport is `overflow: hidden` ending exactly at the bottom of
+ * the media box (846px), which clips anything hanging below it. A button can hit
+ * either without the other, so both are checked.
+ *
+ * The tray's rect is where the button cannot be PRESSED, which is deliberately
+ * wider than what the tray paints: its root spans the viewport and hit-tests
+ * across all of it, so the transparent gutters either side of the visible card
+ * swallow a click just as thoroughly as the card does. Read it as painting and
+ * the gutters look like slack worth trimming; they are not, and the ranking
+ * below depends on the difference.
  *
  * Takes the visible side when there is one, and otherwise the LESS hidden of the
  * two. Standing still when both are bad reads as conservative and is not: on a

--- a/src/components/Sticker/place-button-position.ts
+++ b/src/components/Sticker/place-button-position.ts
@@ -39,6 +39,22 @@ export const STICKER_PANEL_BAND_PX = 36;
 export const STICKER_PANEL_MIN_WIDTH_PX = 124;
 
 /**
+ * The width a draft that already has flush panels has to fall BELOW before they
+ * are taken away again, 8px under the width it had to reach to get them.
+ *
+ * The two layouts are in different places in the component tree, so every
+ * crossing of a single threshold unmounts one and mounts the other. A monotonic
+ * drag crosses once and is fine; what a band buys is the NON-monotonic case — a
+ * width parked on the line, where `scale * mediaWidth` rounds to 123 and 124 on
+ * alternate frames, swapping the layouts for as long as the sticker sits there.
+ *
+ * It buys jitter resistance and nothing else: one deliberate crossing still
+ * swaps the layouts, so anything stateful up there has to survive that on its
+ * own rather than by being crossed less often.
+ */
+export const STICKER_PANEL_LEAVE_WIDTH_PX = 116;
+
+/**
  * Whether the panels can sit flush with the sticker's own edges.
  *
  * They are drawn against the edges by design, which reads as bracketing the box
@@ -47,13 +63,17 @@ export const STICKER_PANEL_MIN_WIDTH_PX = 124;
  * opacity button. At the 5% scale floor that is a 51px-wide sticker, and at the
  * default 18% on a phone-width media box it is 65px, so this is a default state
  * rather than an edge case.
+ *
+ * `currentlyInside` is required, with no default, for the same reason
+ * `flippedButtonOffset` demands its band: a caller that forgets it would get a
+ * single threshold back and nothing would say so.
  */
-export const panelsFitInsideEdges = (stickerWidth: number) =>
-  stickerWidth >= STICKER_PANEL_MIN_WIDTH_PX;
+export const panelsFitInsideEdges = (stickerWidth: number, currentlyInside: boolean) =>
+  stickerWidth >= (currentlyInside ? STICKER_PANEL_LEAVE_WIDTH_PX : STICKER_PANEL_MIN_WIDTH_PX);
 
 /** The band to clear, which is nothing at all when no panels are drawn. */
-export const panelBandFor = (stickerWidth: number) =>
-  panelsFitInsideEdges(stickerWidth) ? STICKER_PANEL_BAND_PX : 0;
+export const panelBandFor = (stickerWidth: number, currentlyInside: boolean) =>
+  panelsFitInsideEdges(stickerWidth, currentlyInside) ? STICKER_PANEL_BAND_PX : 0;
 
 /**
  * How far above the sticker the flipped button sits.
@@ -153,9 +173,13 @@ export function placeButtonBoxes({
  * the bottom of the media box (846px), which clips anything hanging below it.
  * A button can hit either without the other, so both are checked.
  *
- * Flips only when that strictly helps. A sticker low on a short viewport can
- * have nowhere good to put the button, and moving it to a second bad position
- * is worse than leaving it where the user last saw it.
+ * Takes the visible side when there is one, and otherwise the LESS hidden of the
+ * two. Standing still when both are bad reads as conservative and is not: on a
+ * narrow draft the cluster carries the only copy of flip, opacity and delete, so
+ * a button nobody can see is a draft with no controls at all until it is dragged
+ * somewhere else. Ranking is free of feedback for the same reason the pair is:
+ * both boxes come out identical whichever side the button is currently on, so a
+ * flip cannot change its own score. Ties keep it where it is.
  */
 export function shouldFlipPlaceButton({
   below,
@@ -170,10 +194,27 @@ export function shouldFlipPlaceButton({
   clip: Box | null;
   viewportTop?: number;
 }) {
-  const hidden = (box: Box) =>
-    box.top < viewportTop ||
-    (!!tray && overlaps(box, tray)) ||
-    (!!clip && (box.bottom > clip.bottom || box.top < clip.top));
+  // Off the top of the viewport is not a worse degree of the same thing: the
+  // page may not scroll there at all, so it is disqualifying rather than
+  // rankable. Keeping it out of the arithmetic is what stops a button 36px under
+  // the tray being "improved" onto one 20px above the window.
+  const hiddenExtent = (box: Box) => {
+    if (box.top < viewportTop) return Infinity;
 
-  return hidden(below) && !hidden(above);
+    const behindTray =
+      tray && overlaps(box, tray)
+        ? Math.min(box.bottom, tray.bottom) - Math.max(box.top, tray.top)
+        : 0;
+    const pastClip = clip
+      ? Math.max(0, box.bottom - clip.bottom) + Math.max(0, clip.top - box.top)
+      : 0;
+
+    return Math.max(behindTray, pastClip);
+  };
+
+  const belowHidden = hiddenExtent(below);
+  if (belowHidden === 0) return false;
+
+  const aboveHidden = hiddenExtent(above);
+  return aboveHidden === 0 || aboveHidden < belowHidden;
 }


### PR DESCRIPTION
Closes the three items carried from #3865. All three were re-audited against current `main` first; all three still reproduced.

## What was wrong

The sticker's flip/opacity/delete controls live in **two different places in the React tree** — flush against the sticker's top corners while it is at least 124px wide, inside the buy cluster once it is narrower. Crossing that width unmounts one and mounts the other. The opacity `Popover` was uncontrolled, so the crossing destroyed an open slider and dropped keyboard focus with it. A plain browser window resize is enough to trigger it, because the sticker's width is a fraction of the media box.

Worth being explicit, since the ticket proposed hysteresis as the fix: **hysteresis alone does not fix that.** It stops a width parked on the line from flip-flopping, but one deliberate crossing still swaps the layouts. The popover had to stop depending on the element surviving.

## Changes

- **`panelsFitInsideEdges(width, currentlyInside)` / `panelBandFor(width, currentlyInside)`** — 124 to enter the flush layout, 116 to leave it. The second parameter is required with no default, matching this module's existing stance (`flippedButtonOffset`'s `panelBand`) that a caller which forgets it must not silently get the old behaviour. The band exists for the non-monotonic case: `scale * mediaWidth` rounding to 123 and 124 on alternate frames while the sticker sits on the line. A monotonic drag crosses once and was never the problem.

- **`shouldFlipPlaceButton` ranks instead of standing still.** It previously returned `hidden(below) && !hidden(above)`, so with both positions hidden it stayed put. On a narrow draft the buy cluster carries the *only* copy of the controls, so that is a draft with nothing to press until it is dragged. It now takes the less hidden position; ties keep it put; off the top of the viewport scores as disqualifying rather than rankable, since the page may not scroll there.

- **The opacity `Popover`'s open state moves into `DraftSticker`,** with `trapFocus` and `returnFocus`. The element is genuinely rebuilt by the remount, so focus has to be *put back* rather than merely not taken away.

## Deliberate behaviour change worth a reviewer's eye

With the 52px two-line button (the one that lands once the payout copy merges), the button will now flip onto a position clipped at the top of the carousel viewport in preference to one wholly behind the tray — 12 visible pixels beating zero. That is the ranking rule doing what it says, and there is a test naming it.

## Not fixed, deliberately

The third carried item — panels inverting at rotation 180 in the wide branch — reproduces, but the rotate knob and all four resize handles invert with them by design. Making only the pills screen-aware makes them the odd chrome out, and counter-rotating them breaks the panel-band assumption the buy button clears. Left as a won't-fix rather than silently dropped.

## Verification

- `pnpm run typecheck` — 0 errors. `eslint` and `prettier` clean on the four changed files.
- Sticker unit + `blocks.router.workflow.test.ts`: **426 passing** (that file collected 347, so the submodule is real and the run means something). Sticker component: **23 passing**.
- Full unit suite: 35 failures, all of which reproduce identically on clean `main` in the same worktree. The one exception passes in isolation on both sides and has no import path from `Sticker/`.
- **Every added test was mutation-checked.** Reverting the controlled popover gives `expected +0 to be 1` on both crossing directions; collapsing the band to a single threshold gives `expected +0 to be 36` and `expected true to be false`; restoring the old both-hidden rule gives `expected false to be true`. All in milliseconds, none as a timeout.

An adversarial review over this diff refuted the oscillation concern on three independent grounds (the layouts are `absolute`, so neither can feed the measured `offsetWidth`; the threshold map is monotone with no 2-cycle; and the band value is identical on both sides of every crossing frame), and confirmed via Mantine 7.17.8's source that a controlled `Popover` attaches no competing `onClick` to its target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
