### PR TITLE
fix(apps): stop the /apps search box ping-ponging the URL forever

### DIFF
--- a/src/components/Apps/AppListingsMarketplaceBody.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.tsx
@@ -76,7 +76,7 @@ const SORT_OPTIONS: { value: ListingSort; label: string }[] = [
 
 export function AppListingsMarketplaceBody() {
   const features = useFeatureFlags();
-  const { filters, setFilters, isWritePending } = useAppsStoreQueryParams();
+  const { filters, setFilters, hasPendingWrite } = useAppsStoreQueryParams();
   const { kind, category, sort } = filters;
 
   // 🔴 The search input is LOCAL, seeded ONCE from the URL. It is not a
@@ -116,20 +116,56 @@ export function AppListingsMarketplaceBody() {
    * guard is what makes it timing-independent.
    *
    * The two early returns are what stop it fighting the viewer or our own echo:
-   *   - `isWritePending` — our write is still on its way to the URL, so the URL
-   *     disagreeing is expected and must not be adopted;
+   *   - `hasPendingWrite()` — our write is still on its way to the URL, so the
+   *     URL disagreeing is expected and must not be adopted;
    *   - `searchInput !== debouncedSearch` — the viewer is mid-keystroke, and
    *     adopting now would yank characters out from under the caret.
    * Only when both are settled does a disagreement mean the URL genuinely moved.
+   *
+   * 🔴 `hasPendingWrite()` IS CALLED, NOT READ FROM A RENDER-TIME BOOLEAN — and
+   * that one character is the whole fix for the unbounded `replaceState`
+   * ping-pong measured on production 2026-08-13 (~1.8 route writes/sec, forever,
+   * with the URL ending on `/apps` and the term never sticking).
+   *
+   * MECHANISM. The debounce landing produces ONE commit in which BOTH effects
+   * run, in declaration order:
+   *   1. the echo effect above sees `debouncedSearch` ('benchmark') differ from
+   *      `filters.query` (still '', the pre-write URL) and calls `setFilters` —
+   *      which bumps the hook's in-flight counter and fires an async
+   *      `router.replace`;
+   *   2. THIS effect then runs — in the same commit, so `filters.query` is still
+   *      the pre-write '' and, when the guard was a render-time boolean, the
+   *      pending flag was still the `false` captured BEFORE step 1 incremented
+   *      it. Both guards passed, the stale URL looked like an external
+   *      navigation, and the box was wiped to ''.
+   * 300 ms later the debounce echoes that wipe back into the URL, this effect
+   * sees the disagreement again and restores 'benchmark', and the two writers
+   * ping-pong in anti-phase forever. Measured with a deliberately slowed
+   * `router.replace`: the box cleared 6 ms after the replace CALL and 410 ms
+   * BEFORE the URL changed — i.e. same commit, not a later router render.
+   *
+   * So the guard was never wrong about WHAT to check, only about WHEN: a value
+   * sampled during render cannot describe a write issued during that render's
+   * effect phase. Reading the ref at effect time makes it cover the window it
+   * was always meant to cover — from the instant we issue a write until we
+   * observe it arrive.
+   *
+   * ⚠️ ORDER-SENSITIVE BY DESIGN. React runs a component's effects in
+   * declaration order, so the echo effect above MUST stay declared before this
+   * one — that is what guarantees the counter is already incremented when this
+   * effect asks. Do not reorder them. (A value-only guard cannot replace this:
+   * "we are about to move the URL" and "the viewer pressed Back" produce the
+   * IDENTICAL value disagreement — see the v1/v2 post-mortem in
+   * `useAppsStoreQueryParams.ts`.)
    */
-  // The rule's own suggestion here — "pass [isWritePending, searchInput,
+  // The rule's own suggestion here — "pass [hasPendingWrite, searchInput,
   // debouncedSearch, filters.query]" — is exactly the dependency-array form that
   // does NOT work (see above): under render coalescing `filters.query` never
   // appears to change and the effect never fires. The three guards inside are
   // what make this terminate, not the dep list.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
-    if (isWritePending) return;
+    if (hasPendingWrite()) return;
     if (searchInput !== debouncedSearch) return;
     if (filters.query !== searchInput) setSearchInput(filters.query);
   });

--- a/src/components/Apps/AppListingsMarketplaceBody.urlState.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.urlState.browser.test.tsx
@@ -120,6 +120,18 @@ const ROUTER_LATENCY_MS = 500;
 let forceRerender: (() => void) | null = null;
 
 /**
+ * Every `router.replace` the component issues, counted.
+ *
+ * 🔴 THE ONLY ASSERTION THAT CAN SEE THE PING-PONG. Every other check in this
+ * file is a RETRYING matcher (`vi.waitFor`, `expect.element(...).toHaveValue`),
+ * and a retrying matcher passes the moment the oscillation happens to swing
+ * through the expected value. The whole suite was green on the unfixed code
+ * while `/apps` burned ~1.8 route writes/sec forever in production. A COUNT that
+ * must stop growing is the shape of assertion the defect cannot satisfy.
+ */
+let replaceCalls = 0;
+
+/**
  * A router that behaves like the real one: `replace` applies the new query AFTER
  * a delay and then re-renders the subscribers, and it returns a promise.
  *
@@ -133,6 +145,7 @@ function StatefulRouterHarness({ latencyMs }: { latencyMs: number }) {
     forceRerender = force;
     const original = router.replace;
     router.replace = ((url: unknown) => {
+      replaceCalls += 1;
       const nextQuery = { ...((url as { query?: Record<string, unknown> })?.query ?? {}) };
       return new Promise<boolean>((resolve) => {
         setTimeout(() => {
@@ -166,7 +179,10 @@ beforeEach(() => {
   mocks.lastArgs = null;
   router.query = {};
   forceRerender = null;
+  replaceCalls = 0;
 });
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 async function openFilters() {
   await userEvent.click(page.getByTestId('apps-store-filters-dropdown'));
@@ -276,5 +292,82 @@ describe('(b) two fast filter clicks must not drop one', () => {
       expect(currentQuery()).not.toHaveProperty('kind');
       expect(currentQuery()).not.toHaveProperty('category');
     });
+  });
+});
+
+/**
+ * (c) THE PING-PONG. Reproduced on production 2026-08-13: typing into the store
+ * search box started an UNBOUNDED `history.replaceState` oscillation —
+ * `/apps?query=X` → `/apps` → `/apps?query=X` → … at ~1.8 writes/sec, never
+ * settling, ending with the term stripped from the URL.
+ *
+ * 🔴 WHY THE SUITE ABOVE COULD NOT SEE IT. Every assertion in (a) and (b) is a
+ * RETRYING matcher, and an oscillation swings through the expected value on
+ * every cycle — so "typing is NOT clobbered by the re-sync" was GREEN on the
+ * broken code. The defect is not a wrong value, it is a value that will not stop
+ * changing, and only a COUNT that must stop growing can express that.
+ *
+ * The mechanism is written up at the adopt effect in
+ * `AppListingsMarketplaceBody.tsx`: the debounced echo and the URL→box adopt
+ * both run in the SAME commit, and the adopt's `isWritePending` guard used to be
+ * a render-time boolean, sampled before the echo had incremented it.
+ */
+describe('(c) typing must SETTLE — no unbounded route-write ping-pong', () => {
+  test('🔴 one search term → route writes STOP, and `?query=` sticks', async () => {
+    renderWithProviders(<StatefulRouterHarness latencyMs={0} />);
+    const search = page.getByLabelText('Search');
+    await expect.element(search).toBeInTheDocument();
+
+    await search.fill('Alpha');
+    await vi.waitFor(() => expect(currentQuery()).toMatchObject({ query: 'Alpha' }));
+
+    // 1.8s ≈ 3 full periods of the production loop (2 × the 300ms debounce), so
+    // on the unfixed code this window CANNOT be quiet. Sampling — rather than
+    // one reading at the end — is deliberate: a single final read of the URL is
+    // a coin flip against an oscillation, and would make this test flaky-green
+    // instead of reliably red.
+    const settledAt = replaceCalls;
+    const writes: number[] = [];
+    const urlQueries: unknown[] = [];
+    const boxValues: string[] = [];
+    for (let i = 0; i < 18; i++) {
+      await sleep(100);
+      writes.push(replaceCalls);
+      urlQueries.push(currentQuery().query);
+      boxValues.push((search.element() as HTMLInputElement).value);
+    }
+
+    // BOUNDED: not one further route write after the term landed.
+    expect(writes).toEqual(writes.map(() => settledAt));
+    // STICKS: `?query=Alpha` is present at EVERY instant — it never reverts to a
+    // bare `/apps`, which is the end state the production repro landed on.
+    expect(urlQueries).toEqual(urlQueries.map(() => 'Alpha'));
+    // …and the box is not wiped out from under the viewer on the way there.
+    expect(boxValues).toEqual(boxValues.map(() => 'Alpha'));
+  });
+
+  test('🔴 …and with a SLOW router too (the in-flight window is real)', async () => {
+    // Same claim at the other end of the dimension the hook's counter exists
+    // for: a `router.replace` that takes 500ms to land. One measurement at
+    // latency 0 would say nothing about the window where the counter is doing
+    // the work.
+    renderWithProviders(<StatefulRouterHarness latencyMs={ROUTER_LATENCY_MS} />);
+    const search = page.getByLabelText('Search');
+    await expect.element(search).toBeInTheDocument();
+
+    await search.fill('Alpha');
+    await vi.waitFor(() => expect(currentQuery()).toMatchObject({ query: 'Alpha' }));
+
+    const settledAt = replaceCalls;
+    const writes: number[] = [];
+    const urlQueries: unknown[] = [];
+    for (let i = 0; i < 18; i++) {
+      await sleep(100);
+      writes.push(replaceCalls);
+      urlQueries.push(currentQuery().query);
+    }
+    expect(writes).toEqual(writes.map(() => settledAt));
+    expect(urlQueries).toEqual(urlQueries.map(() => 'Alpha'));
+    await expect.element(search).toHaveValue('Alpha');
   });
 });

--- a/src/components/Apps/useAppsStoreQueryParams.ts
+++ b/src/components/Apps/useAppsStoreQueryParams.ts
@@ -43,8 +43,18 @@ export function useAppsStoreQueryParams(): {
    * can coalesce our write's render away entirely, so the URL value never even
    * appears to CHANGE and a dependency-array effect never fires. That is the
    * exact shape of the stale-search bug.
+   *
+   * 🔴 A FUNCTION, NOT A BOOLEAN, AND THAT IS THE WHOLE POINT. It used to be
+   * `isWritePending: boolean` — a value computed DURING RENDER — and that made
+   * it structurally blind to the one write it most needed to mask: a write
+   * issued from a SIBLING EFFECT of the very same commit. `setFilters` bumps
+   * this counter in the effect phase, i.e. AFTER the render that produced the
+   * boolean, so the consumer's effect closed over `false` while a write to that
+   * exact field was already on its way. See the ping-pong write-up in
+   * `AppListingsMarketplaceBody.tsx`. Calling it inside the effect reads the ref
+   * at the moment the question is actually being asked.
    */
-  isWritePending: boolean;
+  hasPendingWrite: () => boolean;
 } {
   const { query, replace } = useZodRouteParams(appsStoreQuerySchema);
 
@@ -124,5 +134,12 @@ export function useAppsStoreQueryParams(): {
     [replace, urlFilters]
   );
 
-  return { filters, setFilters, isWritePending: inFlightRef.current > 0 };
+  /**
+   * Stable identity (refs never change), so a consumer can hold this in a
+   * dependency array — or, as the search box does, in an effect with NO
+   * dependency array — without re-subscribing.
+   */
+  const hasPendingWrite = useCallback(() => inFlightRef.current > 0, []);
+
+  return { filters, setFilters, hasPendingWrite };
 }


### PR DESCRIPTION
## The bug

Typing into the `/apps` store search box (`placeholder="Search by name"`) starts an **unbounded `history.replaceState` oscillation**:

```
replace /apps?query=benchmark
replace /apps
replace /apps?query=benchmark
replace /apps
...
```

Reproduced live on production 2026-08-13: ~1.8 route writes/sec, indefinitely, never settling. `history.length` stays 1 (it is `replaceState`, so no back-button pollution) but it is a permanent render/route loop burning CPU, and the URL ends on a bare `/apps` — **the filter never sticks**, so a shared or reloaded link loses the term.

## Root cause — a guard sampled one commit too early

Not a router bug, not a duplicate hook instance, not the URL schema. The two search writers in `AppListingsMarketplaceBody` disagree inside a **single commit**.

When the 300 ms debounce lands, both effects run in that one commit, in declaration order:

1. **The debounced echo** (`useEffect(..., [debouncedSearch])`) sees `debouncedSearch` (`'benchmark'`) differ from `filters.query` (still `''` — the pre-write URL) and calls `setFilters({ query: debouncedSearch })`. That increments `useAppsStoreQueryParams`' in-flight counter and fires an **async** `router.replace`.
2. **The URL→box adopt effect** (deliberately no dependency array) then runs — *in the same commit*. So `filters.query` is still the pre-write `''`, and `isWritePending` is still the `false` that was computed **during render**, i.e. before step 1 incremented anything.

Both guards passed. The stale URL looked like an external navigation (a browser Back), so the box was wiped to `''`. 300 ms later the debounce echoed that wipe back into the URL (`replace /apps`), the adopt effect saw the disagreement again and restored `'benchmark'`, and the two writers ping-ponged in **anti-phase forever**.

`isWritePending` was never wrong about *what* to check, only about **when**: a value sampled during render cannot describe a write issued during that render's effect phase. It is the one write the guard most needed to mask, and it was the one write the guard was structurally blind to.

### The measurement that settles it

The rival explanation — "a later router re-render carried a stale `router.query`", plausible because Next's `makePublicRouterInstance` hands out a fresh `query` object on every `AppContainer` render — predicts the box is clobbered *after* the URL moves. So I wrapped the live page's `next/router` `replace` with a deliberate 400 ms delay and sampled the URL and the input on independent channels every 2 ms:

```
t=679   replace_CALLED   {"query":"benchmark"}
t=685   BOX              ''                      <-- box wiped, 6ms after the CALL
t=1009  replace_CALLED   {}                      <-- the echo of the wipe
t=1080  replace_APPLIED  {"query":"benchmark"}
t=1095  URL              '?query=benchmark'      <-- URL only moves here, 410ms later
```

The box is cleared **410 ms before the URL changes** and 6 ms after the replace *call* — same commit, no router render in between. That rules the rival mechanism out.

## The fix

`isWritePending: boolean` → `hasPendingWrite: () => boolean`, read from the ref at the moment the question is actually asked. One call site; `useZodRouteParams` is **not** touched (it is shared with `/models`).

This is not a re-entrancy guard or a loop-breaker bolted on top — it makes the *existing* arbiter cover the window it was always documented to cover ("from the instant we issue a write until we observe it arrive"). A value-only guard cannot replace it: "we are about to move the URL" and "the viewer pressed Back" produce the **identical** value disagreement, which is exactly why the two value-comparing versions in the hook's post-mortem comment both failed.

The adopt effect's dependence on effect declaration order is now stated explicitly at the call site, since that ordering is what guarantees the counter is already incremented when the adopt effect asks.

## Test matrix — red at base, green at HEAD

New `describe('(c) typing must SETTLE …')` in `AppListingsMarketplaceBody.urlState.browser.test.tsx`, run with the two source files reverted to `origin/main` and then restored:

| | `origin/main` source | HEAD |
|---|---|---|
| 🔴 one search term → route writes STOP, and `?query=` sticks | **FAIL** — `expected [1,1,2,2,2,3,3,3,4,4,…] to deeply equal [1,1,1,1,…]` | PASS |
| 🔴 …and with a SLOW router too (500 ms in-flight window) | **FAIL** — `expected ['Alpha','Alpha',undefined,…] to deeply equal ['Alpha','Alpha','Alpha',…]` | PASS |
| the 7 pre-existing tests in the file (Back adopts the URL value ×2, typing not clobbered, two rapid filter clicks, sort racing kind, clear-still-clears, harness round-trip) | PASS | PASS |

Full file: **9/9 pass at HEAD**. Related suites (`AppListingsMarketplaceBody`, `.hydration`, `.recentsReconcile`, `AppsStoreFiltersDropdown`, `.urlState`): **44/44 pass**.

**Why the existing suite could not see this.** Every assertion in the file was a *retrying* matcher (`vi.waitFor`, `expect.element(...).toHaveValue`), and an oscillation swings through the expected value on every cycle — so "typing is NOT clobbered by the re-sync" was **green on the broken code** while production burned route writes forever. The defect is not a wrong value, it is a value that will not stop changing, so the new tests assert a **count that must stop growing**, sampled 18× over 1.8 s (≈3 full periods of the production loop). Sampling rather than one final reading is deliberate: a single end-of-test URL read is a coin flip against an oscillation and would be flaky-green instead of reliably red.

**Mutation test.** Reverting only the sampling — keeping the new `hasPendingWrite()` API but making it return a render-time boolean (`useCallback(() => renderTimePending, [renderTimePending])`) — turns exactly the two new tests red on their own assertions and leaves the other 7 green. So the guards die for *this* change's reason, and the API rename alone fixes nothing.

## Verified

- Live reproduction + the discriminating 400 ms-delay control, on production.
- `pnpm typecheck` — **0 errors in 74 s** (instrument validated: it reported 12 errors before the `event-engine-common` submodule was initialised in this worktree, so it can go red).
- `eslint` and `prettier --check` clean on all three changed files, both validated against a deliberately-bad control file first.

## Not verified / still open

- **The fix is verified in the browser-mode harness, not against production.** The harness reproduces the loop with the same signature (anti-phase box/URL, write count growing without bound) and the fix stops it, but nothing here proves the deployed page behaves identically until this ships. Re-run the live repro after deploy.
- Next's `makePublicRouterInstance` really does mint a **fresh `router.query` object and fresh `replace` on every `AppContainer` render**, so the hook's in-flight counter can in principle be consumed by a root re-render that is not our write landing. That latent sharp edge is **not** what caused this bug (measurement above) and is not addressed here. If it ever bites, the symptom would be the same class of stale-adopt.
- `useZodRouteParams`' `schema.parse({ ...query, ...params })` merge against a memoised snapshot remains a sharp edge for every consumer; still worked around locally rather than fixed, per the existing comment.
- The two Back-adoption cases and the two rapid-filter-click cases are covered by the pre-existing tests only — I did not add new coverage there, I confirmed they stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
