### PR TITLE
fix(apps): gate the Create tab on the author capability, hide a 1-tab sub-nav

### DIFF
--- a/src/components/Apps/AppsPageLayout.browser.test.tsx
+++ b/src/components/Apps/AppsPageLayout.browser.test.tsx
@@ -20,11 +20,19 @@ import type * as TrpcMod from '~/utils/trpc';
  * tabs' rule is pinned as present in the same test.
  */
 
+// 🔴 The viewer MUST be one the sub-nav renders for. `AppsSubNav` now hides itself
+// entirely below two qualifying tabs, and the summary query is stubbed empty here, so
+// an anonymous / non-author viewer would render NO `<nav>` at all and every assertion
+// below would fail on a null lookup rather than on the geometry it is about. An author
+// (`appBlocksAuthor`) yields Marketplace + Create — the same two-tab bar this file was
+// written against.
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
-  useFeatureFlags: () => ({ appBlocks: true }),
+  useFeatureFlags: () => ({ appBlocks: true, appBlocksAuthor: true }),
 }));
 vi.mock('~/providers/IsClientProvider', () => ({ useIsClient: () => true }));
-vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ id: 1, username: 'author', isModerator: false }),
+}));
 // Spread the REAL module and override only `trpc` (local-rules/no-wholesale-
 // module-mock): a hand-written replacement silently breaks every importer the day
 // '~/utils/trpc' grows an export this factory omits — the whole FILE then fails to

--- a/src/components/Apps/AppsPageLayout.geometry.browser.test.tsx
+++ b/src/components/Apps/AppsPageLayout.geometry.browser.test.tsx
@@ -42,11 +42,19 @@ import { page } from 'vitest/browser';
 import { renderWithProviders } from '../../../test/component-setup';
 import type * as TrpcMod from '~/utils/trpc';
 
+// 🔴 The viewer MUST be one the sub-nav renders for. `AppsSubNav` now hides itself
+// entirely below two qualifying tabs, and the summary query is stubbed empty here, so
+// an anonymous / non-author viewer would render NO `<nav>` at all and `measure()` would
+// throw on a null lookup instead of measuring. An author (`appBlocksAuthor`) yields
+// Marketplace + Create — the same two-tab bar every number in the table above was
+// measured against, so the pixels are unchanged.
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
-  useFeatureFlags: () => ({ appBlocks: true }),
+  useFeatureFlags: () => ({ appBlocks: true, appBlocksAuthor: true }),
 }));
 vi.mock('~/providers/IsClientProvider', () => ({ useIsClient: () => true }));
-vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ id: 1, username: 'author', isModerator: false }),
+}));
 // Spread the REAL module and override only `trpc` (local-rules/no-wholesale-
 // module-mock) — see the sibling browser test for why.
 vi.mock('~/utils/trpc', async (importOriginal) => ({

--- a/src/components/Apps/AppsSubNav.browser.test.tsx
+++ b/src/components/Apps/AppsSubNav.browser.test.tsx
@@ -4,6 +4,7 @@ import {
   activeAppsTab,
   AppsSubNavView,
   isActiveAppsRoute,
+  type AppsNavContext,
   type AppsNavSummary,
 } from '~/components/Apps/AppsSubNav';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
@@ -13,6 +14,13 @@ import { renderWithProviders } from '../../../test/component-setup';
 // `AppsSubNavView` (props-only) so it renders in isolation without the tRPC
 // query / router that the `AppsSubNav` container wires. We drive the booleans
 // directly and assert which tabs render.
+//
+// TWO input objects, on purpose (they have different provenance and different
+// hydration behaviour — see the type docs):
+//   - `summary`  — the `blocks.getNavSummary` booleans (client-only, revealed
+//                  post-mount).
+//   - `context`  — viewer CAPABILITIES resolved from SSR-seeded values
+//                  (`isAuthor`), safe on the first paint.
 //
 // The sub-nav uses the Mantine **Tabs** LOOK but is wrapped in a real
 // `<nav aria-label="App sections">` so it's exposed as a navigation LANDMARK
@@ -38,13 +46,42 @@ const NONE: AppsNavSummary = {
   isReviewer: false,
 };
 
+const ALL: AppsNavSummary = {
+  hasInstalls: true,
+  hasSubmissions: true,
+  hasApprovedApps: true,
+  isReviewer: true,
+};
+
+/** May author apps (mod, or a non-mod holding `appBlocksAuthor`). */
+const AUTHOR: AppsNavContext = { isAuthor: true };
+/** The widened store-visibility tester cohort: sees the store, cannot author. */
+const NOT_AUTHOR: AppsNavContext = { isAuthor: false };
+
 function tab(name: string) {
   return page.getByRole('tab', { name });
 }
 
+/**
+ * 🔴 RENDER BARRIER — required for every "this renders NOTHING" assertion here.
+ *
+ * `render()` mounts through a React 18 concurrent root, so the DOM is committed on a
+ * LATER task, not synchronously. A bare `expect(locator.elements()).toHaveLength(0)`
+ * straight after `renderWithProviders` therefore observes an EMPTY container and passes
+ * no matter what the component does — structurally unfailable. Caught here by mutation:
+ * deleting the `links.length < 2` hide left the collapse tests GREEN until the barrier
+ * was added. Render this sentinel alongside the unit under test and AWAIT it; the
+ * commit has then happened and "absent" is a real observation.
+ */
+const RENDER_BARRIER = 'render-barrier';
+const RenderBarrier = () => <div data-testid={RENDER_BARRIER} />;
+async function awaitCommit() {
+  await expect.element(page.getByTestId(RENDER_BARRIER)).toBeInTheDocument();
+}
+
 describe('AppsSubNavView (conditional sub-nav tabs)', () => {
-  test('Marketplace + Create are ALWAYS present (even with an all-false summary)', async () => {
-    renderWithProviders(<AppsSubNavView summary={NONE} currentPath="/apps" />);
+  test('Marketplace is present for an author with an all-false summary', async () => {
+    renderWithProviders(<AppsSubNavView summary={NONE} context={AUTHOR} currentPath="/apps" />);
     await expect.element(tab('Marketplace')).toBeInTheDocument();
     await expect.element(tab('Create')).toBeInTheDocument();
   });
@@ -54,21 +91,21 @@ describe('AppsSubNavView (conditional sub-nav tabs)', () => {
   // visible label flipped, the OLD label is gone (mutation-sanity: reverting the
   // label to "Submit" fails the "no Submit tab" expectation), the route is
   // unchanged, and the new create-affordance icon renders inside the tab.
-  test('the always-on author tab reads "Create", NOT "Submit"', async () => {
-    renderWithProviders(<AppsSubNavView summary={NONE} currentPath="/apps" />);
+  test('the author tab reads "Create", NOT "Submit"', async () => {
+    renderWithProviders(<AppsSubNavView summary={NONE} context={AUTHOR} currentPath="/apps" />);
     await expect.element(tab('Create')).toBeInTheDocument();
     // The old label must be gone entirely (no tab named "Submit").
     expect(tab('Submit').elements()).toHaveLength(0);
   });
 
   test('the Create tab still points at /apps/submit (route unchanged)', async () => {
-    renderWithProviders(<AppsSubNavView summary={NONE} currentPath="/apps" />);
+    renderWithProviders(<AppsSubNavView summary={NONE} context={AUTHOR} currentPath="/apps" />);
     await expect.element(tab('Create')).toBeInTheDocument();
     expect(tab('Create').element().getAttribute('href')).toBe('/apps/submit');
   });
 
   test('the Create tab renders its leftSection icon (create affordance)', async () => {
-    renderWithProviders(<AppsSubNavView summary={NONE} currentPath="/apps" />);
+    renderWithProviders(<AppsSubNavView summary={NONE} context={AUTHOR} currentPath="/apps" />);
     await expect.element(tab('Create')).toBeInTheDocument();
     // The tab's leftSection mounts a tabler SVG; assert an <svg> is present
     // inside the Create tab so the icon affordance isn't silently dropped.
@@ -77,8 +114,8 @@ describe('AppsSubNavView (conditional sub-nav tabs)', () => {
   });
 
   test('with an all-false summary the conditional tabs are hidden', async () => {
-    renderWithProviders(<AppsSubNavView summary={NONE} currentPath="/apps" />);
-    // None of the conditional tabs should render.
+    renderWithProviders(<AppsSubNavView summary={NONE} context={AUTHOR} currentPath="/apps" />);
+    // None of the summary-driven tabs should render.
     expect(tab('Installed').elements()).toHaveLength(0);
     expect(tab('My submissions').elements()).toHaveLength(0);
     expect(tab('Revenue').elements()).toHaveLength(0);
@@ -87,7 +124,7 @@ describe('AppsSubNavView (conditional sub-nav tabs)', () => {
 
   test('Installed shows ONLY when hasInstalls', async () => {
     renderWithProviders(
-      <AppsSubNavView summary={{ ...NONE, hasInstalls: true }} currentPath="/apps" />
+      <AppsSubNavView summary={{ ...NONE, hasInstalls: true }} context={AUTHOR} currentPath="/apps" />
     );
     await expect.element(tab('Installed')).toBeInTheDocument();
     // The other conditionals stay hidden.
@@ -98,7 +135,11 @@ describe('AppsSubNavView (conditional sub-nav tabs)', () => {
 
   test('My submissions shows ONLY when hasSubmissions', async () => {
     renderWithProviders(
-      <AppsSubNavView summary={{ ...NONE, hasSubmissions: true }} currentPath="/apps" />
+      <AppsSubNavView
+        summary={{ ...NONE, hasSubmissions: true }}
+        context={AUTHOR}
+        currentPath="/apps"
+      />
     );
     await expect.element(tab('My submissions')).toBeInTheDocument();
     expect(tab('Installed').elements()).toHaveLength(0);
@@ -108,7 +149,11 @@ describe('AppsSubNavView (conditional sub-nav tabs)', () => {
 
   test('Revenue shows ONLY when hasApprovedApps', async () => {
     renderWithProviders(
-      <AppsSubNavView summary={{ ...NONE, hasApprovedApps: true }} currentPath="/apps" />
+      <AppsSubNavView
+        summary={{ ...NONE, hasApprovedApps: true }}
+        context={AUTHOR}
+        currentPath="/apps"
+      />
     );
     await expect.element(tab('Revenue')).toBeInTheDocument();
     expect(tab('Installed').elements()).toHaveLength(0);
@@ -118,7 +163,7 @@ describe('AppsSubNavView (conditional sub-nav tabs)', () => {
 
   test('Review shows ONLY when isReviewer', async () => {
     renderWithProviders(
-      <AppsSubNavView summary={{ ...NONE, isReviewer: true }} currentPath="/apps" />
+      <AppsSubNavView summary={{ ...NONE, isReviewer: true }} context={AUTHOR} currentPath="/apps" />
     );
     await expect.element(tab('Review')).toBeInTheDocument();
     expect(tab('Installed').elements()).toHaveLength(0);
@@ -126,17 +171,143 @@ describe('AppsSubNavView (conditional sub-nav tabs)', () => {
     expect(tab('Revenue').elements()).toHaveLength(0);
   });
 
-  test('an all-true summary shows every tab', async () => {
-    const ALL: AppsNavSummary = {
-      hasInstalls: true,
-      hasSubmissions: true,
-      hasApprovedApps: true,
-      isReviewer: true,
-    };
-    renderWithProviders(<AppsSubNavView summary={ALL} currentPath="/apps" />);
-    for (const name of ['Marketplace', 'Create', 'Installed', 'My submissions', 'Revenue', 'Review']) {
+  test('an all-true summary + author shows every tab', async () => {
+    renderWithProviders(<AppsSubNavView summary={ALL} context={AUTHOR} currentPath="/apps" />);
+    for (const name of [
+      'Marketplace',
+      'Create',
+      'Installed',
+      'My submissions',
+      'Revenue',
+      'Review',
+    ]) {
       await expect.element(tab(name)).toBeInTheDocument();
     }
+  });
+
+  // 🔴 THE FOUR SUMMARY PREDICATES ARE UNCHANGED BY THE AUTHOR GATE. Only
+  // `Create` reads `context`; the rest still read the summary alone. Asserted
+  // against a NON-author so a predicate that accidentally picked up `isAuthor`
+  // (e.g. `(s, c) => c.isAuthor && s.hasInstalls`) fails here even though the
+  // author-context tests above would stay green.
+  test('the four summary-driven tabs are independent of isAuthor (non-author, all-true summary)', async () => {
+    renderWithProviders(<AppsSubNavView summary={ALL} context={NOT_AUTHOR} currentPath="/apps" />);
+    for (const name of ['Marketplace', 'Installed', 'My submissions', 'Revenue', 'Review']) {
+      await expect.element(tab(name)).toBeInTheDocument();
+    }
+    // …and Create is the ONLY one the author gate removes.
+    expect(tab('Create').elements()).toHaveLength(0);
+  });
+});
+
+/**
+ * 🔴 THE AUTHOR GATE ON `Create` (this change).
+ *
+ * `/apps/submit`'s `getServerSideProps` returns `notFound` unless
+ * `features.appBlocksAuthor` AND `isAppDeveloper(user, …)` hold. The tab used to
+ * be hardcoded `visible: () => true`, so the widened store-visibility cohort
+ * (`app-listings=true`, `app-blocks-author=false` — verified live on a real
+ * tester account) saw a "Create" tab that navigated straight into a 404. The tab
+ * now keys off the SAME predicate as the page.
+ *
+ * MODERATORS ARE A HARD FLOOR: `isAppDeveloper` is `isModerator || appBlocksAuthor`,
+ * so a mod keeps the tab even with the capability off. That floor lives in the
+ * shared predicate (`~/shared/utils/app-blocks-access`) and is resolved by the
+ * CONTAINER; at this level it surfaces as `isAuthor: true`, and the container
+ * derivation is covered in `AppsSubNav.hydration.browser.test.tsx`.
+ */
+describe('AppsSubNavView (Create is gated on the author capability)', () => {
+  test('Create is HIDDEN for a non-author (appBlocksAuthor=false, not a mod)', async () => {
+    // Give the viewer an install so the bar still has two tabs and renders —
+    // otherwise the <2 hide would remove the whole nav and this assertion would
+    // pass for the WRONG reason (see the dedicated collapse tests below).
+    renderWithProviders(
+      <AppsSubNavView
+        summary={{ ...NONE, hasInstalls: true }}
+        context={NOT_AUTHOR}
+        currentPath="/apps"
+      />
+    );
+    // Positive control: the bar IS rendered…
+    await expect.element(tab('Marketplace')).toBeInTheDocument();
+    await expect.element(tab('Installed')).toBeInTheDocument();
+    // …and Create is absent from it.
+    expect(tab('Create').elements()).toHaveLength(0);
+  });
+
+  test('Create is VISIBLE when the author capability is held', async () => {
+    renderWithProviders(
+      <AppsSubNavView
+        summary={{ ...NONE, hasInstalls: true }}
+        context={AUTHOR}
+        currentPath="/apps"
+      />
+    );
+    await expect.element(tab('Create')).toBeInTheDocument();
+    expect(tab('Create').element().getAttribute('href')).toBe('/apps/submit');
+  });
+
+  test('a non-author does NOT get a Create tab even with every summary flag true', async () => {
+    renderWithProviders(<AppsSubNavView summary={ALL} context={NOT_AUTHOR} currentPath="/apps" />);
+    await expect.element(tab('Review')).toBeInTheDocument();
+    expect(tab('Create').elements()).toHaveLength(0);
+  });
+});
+
+/**
+ * The <2-tab collapse. With `Create` conditional, a store-visible non-author
+ * with no installs / submissions / approved apps and no reviewer bit qualifies
+ * for Marketplace ALONE — a one-entry "navigation" that can only link to the
+ * page you are on, while still costing the tab row + its bottom rule. The whole
+ * bar (nav landmark included) is dropped below two tabs.
+ */
+describe('AppsSubNavView (hides entirely below two tabs)', () => {
+  test('renders NOTHING when only Marketplace qualifies', async () => {
+    renderWithProviders(
+      <>
+        <RenderBarrier />
+        <AppsSubNavView summary={NONE} context={NOT_AUTHOR} currentPath="/apps" />
+      </>
+    );
+    await awaitCommit(); // without this the assertions below cannot fail — see RENDER_BARRIER
+    // No tabs, no tablist, and no navigation landmark — the component returned null.
+    expect(tab('Marketplace').elements()).toHaveLength(0);
+    expect(page.getByRole('tablist').elements()).toHaveLength(0);
+    expect(page.getByRole('navigation', { name: 'App sections' }).elements()).toHaveLength(0);
+  });
+
+  test('renders as soon as a SECOND tab qualifies (one install)', async () => {
+    renderWithProviders(
+      <AppsSubNavView
+        summary={{ ...NONE, hasInstalls: true }}
+        context={NOT_AUTHOR}
+        currentPath="/apps"
+      />
+    );
+    await expect.element(page.getByRole('navigation', { name: 'App sections' })).toBeInTheDocument();
+    await expect.element(tab('Marketplace')).toBeInTheDocument();
+    await expect.element(tab('Installed')).toBeInTheDocument();
+    expect(page.getByRole('tab').elements()).toHaveLength(2);
+  });
+
+  test('the second tab can be Create (author, otherwise-empty summary)', async () => {
+    renderWithProviders(<AppsSubNavView summary={NONE} context={AUTHOR} currentPath="/apps" />);
+    await expect.element(page.getByRole('navigation', { name: 'App sections' })).toBeInTheDocument();
+    expect(page.getByRole('tab').elements()).toHaveLength(2);
+  });
+
+  // The hide applies to EVERY viewer — there is no moderator carve-out. A mod
+  // always resolves to `isAuthor: true` in the container, so the only way a mod
+  // reaches one tab is `isAuthor: false`, which is what this drives directly.
+  test('the collapse has no moderator carve-out (isAuthor=false ⇒ hidden, whoever the viewer is)', async () => {
+    renderWithProviders(
+      <>
+        <RenderBarrier />
+        <AppsSubNavView summary={NONE} context={NOT_AUTHOR} currentPath="/apps/installed" />
+      </>
+    );
+    await awaitCommit();
+    expect(page.getByRole('tablist').elements()).toHaveLength(0);
   });
 });
 
@@ -147,7 +318,7 @@ describe('AppsSubNavView (navigation landmark)', () => {
   // `<nav aria-label="App sections">` so the landmark is restored while the Tabs
   // LOOK (active underline) is preserved. Reverting the nav-wrap fails this.
   test('the sub-nav is exposed as a `navigation` landmark named "App sections"', async () => {
-    renderWithProviders(<AppsSubNavView summary={NONE} currentPath="/apps" />);
+    renderWithProviders(<AppsSubNavView summary={NONE} context={AUTHOR} currentPath="/apps" />);
     const nav = page.getByRole('navigation', { name: 'App sections' });
     await expect.element(nav).toBeInTheDocument();
     // The accessible name is on the <nav> landmark, NOT on the tablist.
@@ -155,7 +326,7 @@ describe('AppsSubNavView (navigation landmark)', () => {
   });
 
   test('the tablist itself does NOT carry the `App sections` name (it moved to the nav)', async () => {
-    renderWithProviders(<AppsSubNavView summary={NONE} currentPath="/apps" />);
+    renderWithProviders(<AppsSubNavView summary={NONE} context={AUTHOR} currentPath="/apps" />);
     await expect.element(page.getByRole('tablist')).toBeInTheDocument();
     const tablist = page.getByRole('tablist').element();
     expect(tablist.getAttribute('aria-label')).not.toBe('App sections');
@@ -165,7 +336,11 @@ describe('AppsSubNavView (navigation landmark)', () => {
 describe('AppsSubNavView (active tab reflects the current route)', () => {
   test('the current route is the selected tab (aria-selected=true)', async () => {
     renderWithProviders(
-      <AppsSubNavView summary={{ ...NONE, hasInstalls: true }} currentPath="/apps/installed" />
+      <AppsSubNavView
+        summary={{ ...NONE, hasInstalls: true }}
+        context={AUTHOR}
+        currentPath="/apps/installed"
+      />
     );
     await expect.element(tab('Installed')).toBeInTheDocument();
     const installed = tab('Installed').element();
@@ -177,7 +352,11 @@ describe('AppsSubNavView (active tab reflects the current route)', () => {
     // (the exact-match guard), proving the active-route highlight + the /apps
     // prefix guard at once.
     renderWithProviders(
-      <AppsSubNavView summary={{ ...NONE, hasInstalls: true }} currentPath="/apps/installed" />
+      <AppsSubNavView
+        summary={{ ...NONE, hasInstalls: true }}
+        context={AUTHOR}
+        currentPath="/apps/installed"
+      />
     );
     await expect.element(tab('Installed')).toBeInTheDocument();
     const marketplace = tab('Marketplace').element();
@@ -185,7 +364,7 @@ describe('AppsSubNavView (active tab reflects the current route)', () => {
   });
 
   test('Marketplace IS selected on the exact /apps route', async () => {
-    renderWithProviders(<AppsSubNavView summary={NONE} currentPath="/apps" />);
+    renderWithProviders(<AppsSubNavView summary={NONE} context={AUTHOR} currentPath="/apps" />);
     await expect.element(tab('Marketplace')).toBeInTheDocument();
     const marketplace = tab('Marketplace').element();
     expect(marketplace.getAttribute('aria-selected')).toBe('true');
@@ -194,10 +373,42 @@ describe('AppsSubNavView (active tab reflects the current route)', () => {
   });
 
   test('Create tab is selected on /apps/submit (and Marketplace is not)', async () => {
-    renderWithProviders(<AppsSubNavView summary={NONE} currentPath="/apps/submit" />);
+    renderWithProviders(
+      <AppsSubNavView summary={NONE} context={AUTHOR} currentPath="/apps/submit" />
+    );
     await expect.element(tab('Create')).toBeInTheDocument();
     expect(tab('Create').element().getAttribute('aria-selected')).toBe('true');
     expect(tab('Marketplace').element().getAttribute('aria-selected')).toBe('false');
+  });
+
+  // 🔴 Highlighting with `Create` ABSENT. `activeAppsTab` resolves against the
+  // full link table, so a hidden tab must not steal or suppress the highlight on
+  // the tabs that DID render.
+  test('with Create hidden, the active route still lights the right tab', async () => {
+    renderWithProviders(
+      <AppsSubNavView summary={ALL} context={NOT_AUTHOR} currentPath="/apps/my-submissions" />
+    );
+    await expect.element(tab('My submissions')).toBeInTheDocument();
+    expect(tab('Create').elements()).toHaveLength(0);
+    expect(tab('My submissions').element().getAttribute('aria-selected')).toBe('true');
+    // Every other rendered tab is unselected — exactly one highlight.
+    for (const name of ['Marketplace', 'Installed', 'Revenue', 'Review']) {
+      expect(tab(name).element().getAttribute('aria-selected')).toBe('false');
+    }
+  });
+
+  test('with Create hidden, /apps still lights Marketplace', async () => {
+    renderWithProviders(
+      <AppsSubNavView
+        summary={{ ...NONE, hasInstalls: true }}
+        context={NOT_AUTHOR}
+        currentPath="/apps"
+      />
+    );
+    await expect.element(tab('Marketplace')).toBeInTheDocument();
+    expect(tab('Create').elements()).toHaveLength(0);
+    expect(tab('Marketplace').element().getAttribute('aria-selected')).toBe('true');
+    expect(tab('Installed').element().getAttribute('aria-selected')).toBe('false');
   });
 });
 
@@ -206,13 +417,7 @@ describe('AppsSubNavView (each tab navigates to its route)', () => {
   // click follows. Asserting the href is the deterministic equivalent of "a
   // click navigates to the right route" for a link-based tab.
   test('every visible tab points its href at the matching /apps route', async () => {
-    const ALL: AppsNavSummary = {
-      hasInstalls: true,
-      hasSubmissions: true,
-      hasApprovedApps: true,
-      isReviewer: true,
-    };
-    renderWithProviders(<AppsSubNavView summary={ALL} currentPath="/apps" />);
+    renderWithProviders(<AppsSubNavView summary={ALL} context={AUTHOR} currentPath="/apps" />);
     const cases: Array<[string, string]> = [
       ['Marketplace', '/apps'],
       ['Create', '/apps/submit'],
@@ -244,7 +449,7 @@ describe('AppsSubNavView (keyboard: arrow keys scan, do not auto-navigate)', () 
   // `activateTabWithKeyboard={true}` flips selection onto the focused tab and
   // fails this test.
   test('ArrowRight moves focus but does NOT change the selected tab (no auto-activate)', async () => {
-    renderWithProviders(<AppsSubNavView summary={NONE} currentPath="/apps" />);
+    renderWithProviders(<AppsSubNavView summary={NONE} context={AUTHOR} currentPath="/apps" />);
     // Wait for the async render before reaching into the DOM synchronously.
     await expect.element(tab('Marketplace')).toBeInTheDocument();
 
@@ -273,7 +478,7 @@ describe('AppsSubNavView (keyboard: arrow keys scan, do not auto-navigate)', () 
     // instead we assert the keyboard-activation contract structurally — the
     // focusable element IS the `<a href>` the route points at, so native
     // anchor activation (Enter) navigates correctly even with arrow-activation off.
-    renderWithProviders(<AppsSubNavView summary={NONE} currentPath="/apps" />);
+    renderWithProviders(<AppsSubNavView summary={NONE} context={AUTHOR} currentPath="/apps" />);
     await expect.element(tab('Create')).toBeInTheDocument();
     const submit = tab('Create').element() as HTMLElement;
     submit.focus();

--- a/src/components/Apps/AppsSubNav.hydration.browser.test.tsx
+++ b/src/components/Apps/AppsSubNav.hydration.browser.test.tsx
@@ -2,30 +2,42 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
+// Type-only namespace import (NOT `typeof import('...')`, which
+// @typescript-eslint/consistent-type-imports rejects) so the spread below keeps the
+// real module's type.
+import type * as TrpcMod from '~/utils/trpc';
 
 /**
  * Regression: `AppsSubNav` HYDRATION SAFETY (prod incident — every /apps page inert).
  *
  * The conditional sub-nav tabs (Installed / My submissions / Revenue / Review) are
  * driven by the client-only `blocks.getNavSummary` query. tRPC runs with `ssr:false`,
- * so the SERVER always renders the always-on set (`EMPTY_SUMMARY` → Marketplace +
- * Create), while the query's data is present in the CLIENT's FIRST render. For a user
- * with installs/submissions/approved-apps/reviewer status the first client paint
- * rendered 6 tabs against the server's 2 — a React hydration mismatch (#418/#425)
- * that bailed hydration of the ENTIRE /apps page ROOT, leaving every /apps page
- * un-hydrated and inert (dead buttons; the `/apps/submit?edit=` query never fired →
- * a permanent "Loading your listing…").
+ * so the SERVER always renders the always-on set (`EMPTY_SUMMARY`), while the query's
+ * data is present in the CLIENT's FIRST render. For a user with
+ * installs/submissions/approved-apps/reviewer status the first client paint rendered
+ * 6 tabs against the server's 2 — a React hydration mismatch (#418/#425) that bailed
+ * hydration of the ENTIRE /apps page ROOT, leaving every /apps page un-hydrated and
+ * inert (dead buttons; the `/apps/submit?edit=` query never fired → a permanent
+ * "Loading your listing…").
  *
- * The fix gates the conditional tabs on `useIsClient()` (false on the server AND the
- * first client paint, true only AFTER mount) so the server render and the first
- * client render are IDENTICAL — the conditional tabs reveal only post-hydration.
+ * The fix gates the SUMMARY-driven tabs on `useIsClient()` (false on the server AND
+ * the first client paint, true only AFTER mount) so the server render and the first
+ * client render are IDENTICAL — those tabs reveal only post-hydration.
+ *
+ * ── THE AUTHOR GATE IS DELIBERATELY *NOT* `isClient`-DEFERRED ────────────────────
+ * `Create` now renders only for `isAuthor` (`isAppDeveloper(user, { appBlocksAuthor })`).
+ * Both of that predicate's inputs are SSR-seeded and FROZEN — `features.appBlocksAuthor`
+ * comes from `pageProps.flags` (resolved server-side in `_app.getInitialProps`, frozen
+ * by `useState(initialFlags)`; it is NOT a `toggleable` flag so the client
+ * `user.getFeatureFlags` overlay cannot move it), and `isModerator` rides
+ * `SessionProvider`'s `useState(initial)` seed. So it is safe on the FIRST paint, and
+ * these tests pin the distinction: the summary tabs stay deferred, the author tab does
+ * not, and the pre-mount output must not vary with the query's data.
  *
  * These tests drive the `AppsSubNav` CONTAINER (not the pure `AppsSubNavView`) so the
- * `useIsClient` gate is exercised. A summary with EVERY flag true is supplied via the
- * mocked query; the assertion is that the pre-mount render still shows ONLY the
- * always-on tabs. Reverting the fix (using `data ?? EMPTY_SUMMARY` unconditionally)
- * renders all 6 tabs pre-mount and fails the first test — the exact divergence that
- * broke hydration in prod.
+ * `useIsClient` gate + the `isAppDeveloper` derivation are both exercised.
+ * (The REAL `renderToString` → `hydrateRoot` check, with a console.error positive
+ * control, lives in `AppsSubNav.ssrHydration.browser.test.tsx`.)
  */
 
 const ALL_TRUE_SUMMARY = {
@@ -41,6 +53,10 @@ const mocks = vi.hoisted(() => ({
   isClient: false,
   // The resolved `getNavSummary` data available to the CLIENT render.
   navSummary: undefined as undefined | typeof ALL_TRUE_SUMMARY,
+  // `useFeatureFlags()` — SSR-seeded + frozen in the real provider.
+  flags: { appBlocks: true, appBlocksAuthor: true } as Record<string, boolean>,
+  // `useCurrentUser()` — SSR-seeded via SessionProvider; `null` = logged out.
+  user: null as null | { id: number; username: string; isModerator?: boolean },
 }));
 
 vi.mock('~/providers/IsClientProvider', () => ({
@@ -48,21 +64,20 @@ vi.mock('~/providers/IsClientProvider', () => ({
 }));
 
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
-  useFeatureFlags: () => ({ appBlocks: true }),
+  useFeatureFlags: () => mocks.flags,
 }));
 
 vi.mock('~/hooks/useCurrentUser', () => ({
-  useCurrentUser: () => ({ id: 1, username: 'dev' }),
+  useCurrentUser: () => mocks.user,
 }));
 
-vi.mock('~/utils/trpc', () => ({
-  trpc: {
-    blocks: {
-      getNavSummary: {
-        useQuery: () => ({ data: mocks.navSummary }),
-      },
-    },
-  },
+// Spread the REAL module and override only `trpc` (local-rules/no-wholesale-module-
+// mock): a hand-written replacement silently breaks every importer the day
+// '~/utils/trpc' grows an export this factory omits — the whole FILE then fails to
+// load with 0 tests collected and no failing assertion.
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcMod>()),
+  trpc: { blocks: { getNavSummary: { useQuery: () => ({ data: mocks.navSummary }) } } },
 }));
 
 const { AppsSubNav } = await import('./AppsSubNav');
@@ -71,19 +86,54 @@ function tab(name: string) {
   return page.getByRole('tab', { name });
 }
 
+/** The tab labels currently in the document, in DOM order. */
+function renderedTabs(): string[] {
+  return page
+    .getByRole('tab')
+    .elements()
+    .map((el) => (el.textContent ?? '').trim());
+}
+
+/**
+ * 🔴 RENDER BARRIER — required before every "renders nothing" assertion.
+ *
+ * `render()` commits through a React 18 concurrent root on a LATER task, so a
+ * synchronous `expect(renderedTabs()).toEqual([])` right after `renderWithProviders`
+ * reads an EMPTY container and passes whatever the component does. Caught by mutation:
+ * deleting the `links.length < 2` hide left these tests green until the barrier was
+ * added. Render the sentinel alongside the component and AWAIT it first.
+ */
+const RENDER_BARRIER = 'render-barrier';
+const RenderBarrier = () => <div data-testid={RENDER_BARRIER} />;
+
+/** Render `AppsSubNav` behind a render barrier and wait for the commit. */
+async function renderSubNav() {
+  renderWithProviders(
+    <>
+      <RenderBarrier />
+      <AppsSubNav />
+    </>
+  );
+  await expect.element(page.getByTestId(RENDER_BARRIER)).toBeInTheDocument();
+}
+
 const CONDITIONAL = ['Installed', 'My submissions', 'Revenue', 'Review'] as const;
 
 beforeEach(() => {
   mocks.isClient = false;
-  // Simulate the query data being present on the client (the prod condition): a mod
-  // user whose summary is fully populated.
+  // Simulate the query data being present on the client (the prod condition): a user
+  // whose summary is fully populated.
   mocks.navSummary = { ...ALL_TRUE_SUMMARY };
+  // Default viewer: an AUTHOR (this is the shape the original incident was found in —
+  // a mod), so the pre-mount set is the two-tab bar and the bar renders.
+  mocks.flags = { appBlocks: true, appBlocksAuthor: true };
+  mocks.user = { id: 1, username: 'dev', isModerator: false };
 });
 
 describe('AppsSubNav container — hydration-safe conditional tabs', () => {
   test('pre-mount (server + first client paint) renders ONLY the always-on tabs, even when the query already has a full summary', async () => {
     mocks.isClient = false; // server / first client paint
-    renderWithProviders(<AppsSubNav />);
+    await renderSubNav();
 
     // The always-on tabs render.
     await expect.element(tab('Marketplace')).toBeInTheDocument();
@@ -99,7 +149,7 @@ describe('AppsSubNav container — hydration-safe conditional tabs', () => {
 
   test('post-mount (isClient=true) reveals the conditional tabs from the summary', async () => {
     mocks.isClient = true; // after mount / hydration has matched
-    renderWithProviders(<AppsSubNav />);
+    await renderSubNav();
 
     for (const name of ['Marketplace', 'Create', ...CONDITIONAL]) {
       await expect.element(tab(name)).toBeInTheDocument();
@@ -109,12 +159,183 @@ describe('AppsSubNav container — hydration-safe conditional tabs', () => {
   test('pre-mount with NO summary data also shows only the always-on tabs (server parity)', async () => {
     mocks.isClient = false;
     mocks.navSummary = undefined; // server: query never resolved
-    renderWithProviders(<AppsSubNav />);
+    await renderSubNav();
 
     await expect.element(tab('Marketplace')).toBeInTheDocument();
     await expect.element(tab('Create')).toBeInTheDocument();
     for (const name of CONDITIONAL) {
       expect(tab(name).elements()).toHaveLength(0);
     }
+  });
+});
+
+/**
+ * 🔴 SSR TAB SET ≡ FIRST CLIENT RENDER.
+ *
+ * The server render (query never resolved) and the first client paint (query data
+ * already in the cache) are BOTH `isClient === false`. The invariant that keeps
+ * hydration matching is that the pre-mount output must be a function of the SSR-seeded
+ * inputs ONLY — the query's data must not be able to change it.
+ *
+ * Each cohort is asserted TWICE against the SAME pinned literal (once with the data
+ * absent = the server, once with it present = the first client paint) rather than by
+ * comparing one render to another: a pinned literal cannot be satisfied by two renders
+ * that are equally wrong, and the AUTHOR pair below is deliberately NON-EMPTY so the
+ * equality is not an `[] === []` that any broken render would also satisfy.
+ */
+describe('AppsSubNav container — SSR tab set === first client render', () => {
+  const NON_AUTHOR = () => {
+    // The widened store-visibility tester cohort, verified live: sees the store,
+    // cannot author.
+    mocks.flags = { appBlocks: true, appBlocksAuthor: false };
+    mocks.user = { id: 7, username: 'tester', isModerator: false };
+  };
+  const AUTHOR = () => {
+    mocks.flags = { appBlocks: true, appBlocksAuthor: true };
+    mocks.user = { id: 7, username: 'author', isModerator: false };
+  };
+
+  test('NON-AUTHOR, server render (no query data) → no bar at all', async () => {
+    NON_AUTHOR();
+    mocks.isClient = false;
+    mocks.navSummary = undefined;
+    await renderSubNav();
+    expect(renderedTabs()).toEqual([]);
+    expect(page.getByRole('tablist').elements()).toHaveLength(0);
+  });
+
+  test('NON-AUTHOR, first client paint (query data PRESENT) → the identical set', async () => {
+    NON_AUTHOR();
+    mocks.isClient = false;
+    mocks.navSummary = { ...ALL_TRUE_SUMMARY }; // the prod condition that broke hydration
+    await renderSubNav();
+    expect(renderedTabs()).toEqual([]);
+    expect(page.getByRole('tablist').elements()).toHaveLength(0);
+  });
+
+  test('AUTHOR, server render (no query data) → Marketplace + Create', async () => {
+    AUTHOR();
+    mocks.isClient = false;
+    mocks.navSummary = undefined;
+    await renderSubNav();
+    await expect.element(tab('Marketplace')).toBeInTheDocument();
+    expect(renderedTabs()).toEqual(['Marketplace', 'Create']);
+  });
+
+  test('AUTHOR, first client paint (query data PRESENT) → the identical set', async () => {
+    AUTHOR();
+    mocks.isClient = false;
+    mocks.navSummary = { ...ALL_TRUE_SUMMARY };
+    await renderSubNav();
+    await expect.element(tab('Marketplace')).toBeInTheDocument();
+    // Non-empty on BOTH sides of the pair: the author gate applied on the first
+    // paint (Create is here pre-mount) while the summary gate did NOT (none of the
+    // four conditional tabs leaked in).
+    expect(renderedTabs()).toEqual(['Marketplace', 'Create']);
+  });
+
+  test('POSITIVE CONTROL: the same reader DOES see the conditional tabs post-mount', async () => {
+    // Guards every `toEqual([])` above against being vacuously green — if
+    // `renderedTabs()` were wired to nothing it would return `[]` here too.
+    NON_AUTHOR();
+    mocks.isClient = true;
+    mocks.navSummary = { ...ALL_TRUE_SUMMARY };
+    await renderSubNav();
+    await expect.element(tab('Installed')).toBeInTheDocument();
+    expect(renderedTabs()).toEqual([
+      'Marketplace',
+      'Installed',
+      'My submissions',
+      'Revenue',
+      'Review',
+    ]);
+    // Create is the one tab the author gate removes.
+    expect(renderedTabs()).not.toContain('Create');
+  });
+});
+
+/**
+ * The author-capability derivation IN THE CONTAINER — the half that
+ * `AppsSubNavView` (props-only) cannot cover: that `AppsSubNav` feeds the shared
+ * `isAppDeveloper(user, { appBlocksAuthor })` predicate, not an inlined check.
+ */
+describe('AppsSubNav container — the Create tab keys off isAppDeveloper', () => {
+  beforeEach(() => {
+    mocks.isClient = true; // post-mount, so the full tab set is observable
+    mocks.navSummary = { ...ALL_TRUE_SUMMARY };
+  });
+
+  test('non-mod WITHOUT the author capability → no Create tab', async () => {
+    mocks.flags = { appBlocks: true, appBlocksAuthor: false };
+    mocks.user = { id: 7, username: 'tester', isModerator: false };
+    await renderSubNav();
+    await expect.element(tab('Marketplace')).toBeInTheDocument();
+    expect(tab('Create').elements()).toHaveLength(0);
+  });
+
+  test('non-mod WITH the author capability → Create tab', async () => {
+    mocks.flags = { appBlocks: true, appBlocksAuthor: true };
+    mocks.user = { id: 7, username: 'author', isModerator: false };
+    await renderSubNav();
+    await expect.element(tab('Create')).toBeInTheDocument();
+  });
+
+  test('🔴 MODERATOR FLOOR: a mod keeps Create even with appBlocksAuthor=false', async () => {
+    mocks.flags = { appBlocks: true, appBlocksAuthor: false };
+    mocks.user = { id: 1, username: 'mod', isModerator: true };
+    await renderSubNav();
+    await expect.element(tab('Create')).toBeInTheDocument();
+  });
+
+  test('the flag being ABSENT entirely behaves as false for a non-mod', async () => {
+    // Flipt-down / flag-not-yet-created: `appBlocksAuthor` is simply missing.
+    mocks.flags = { appBlocks: true };
+    mocks.user = { id: 7, username: 'tester', isModerator: false };
+    await renderSubNav();
+    await expect.element(tab('Marketplace')).toBeInTheDocument();
+    expect(tab('Create').elements()).toHaveLength(0);
+  });
+
+  test('a logged-out viewer never gets Create, even if the flag reads true', async () => {
+    mocks.flags = { appBlocks: true, appBlocksAuthor: true };
+    mocks.user = null;
+    mocks.navSummary = undefined; // the summary query is protected — no data for anon
+    await renderSubNav();
+    // Marketplace alone ⇒ the whole bar is hidden.
+    expect(page.getByRole('tablist').elements()).toHaveLength(0);
+    expect(tab('Create').elements()).toHaveLength(0);
+  });
+});
+
+/** The <2-tab collapse, driven through the container. */
+describe('AppsSubNav container — hides entirely below two tabs', () => {
+  test('a non-author with an empty summary renders no nav at all', async () => {
+    mocks.isClient = true;
+    mocks.flags = { appBlocks: true, appBlocksAuthor: false };
+    mocks.user = { id: 7, username: 'tester', isModerator: false };
+    mocks.navSummary = {
+      hasInstalls: false,
+      hasSubmissions: false,
+      hasApprovedApps: false,
+      isReviewer: false,
+    };
+    await renderSubNav();
+    expect(page.getByRole('navigation', { name: 'App sections' }).elements()).toHaveLength(0);
+    expect(page.getByRole('tablist').elements()).toHaveLength(0);
+  });
+
+  test('one install is enough to bring the bar back', async () => {
+    mocks.isClient = true;
+    mocks.flags = { appBlocks: true, appBlocksAuthor: false };
+    mocks.user = { id: 7, username: 'tester', isModerator: false };
+    mocks.navSummary = {
+      hasInstalls: true,
+      hasSubmissions: false,
+      hasApprovedApps: false,
+      isReviewer: false,
+    };
+    await renderSubNav();
+    await expect.element(page.getByRole('navigation', { name: 'App sections' })).toBeInTheDocument();
+    expect(renderedTabs()).toEqual(['Marketplace', 'Installed']);
   });
 });

--- a/src/components/Apps/AppsSubNav.ssrHydration.browser.test.tsx
+++ b/src/components/Apps/AppsSubNav.ssrHydration.browser.test.tsx
@@ -1,0 +1,263 @@
+import { MantineProvider } from '@mantine/core';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import * as React from 'react';
+import { renderToString } from 'react-dom/server';
+import { hydrateRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { IsClientProvider } from '~/providers/IsClientProvider';
+// Type-only namespace import (NOT `typeof import('...')`, which
+// @typescript-eslint/consistent-type-imports rejects) so the spread below keeps the
+// real module's type.
+import type * as TrpcMod from '~/utils/trpc';
+
+/**
+ * 🔴 THE REAL HYDRATION CHECK — `renderToString` → `hydrateRoot`, with a POSITIVE
+ * CONTROL proving the detector can go red.
+ *
+ * Its sibling `AppsSubNav.hydration.browser.test.tsx` SIMULATES the two frames by
+ * driving a mocked `useIsClient`. That pins the tab sets, but it never performs a
+ * hydration — so a "no hydration warning" assertion there would be a probe wired to
+ * nothing, i.e. a reassuring zero. This file does the actual thing: it renders the
+ * component to an HTML string with the REAL `IsClientProvider` (server semantics),
+ * plants that HTML in a container, hydrates it, and asserts React reported no
+ * hydration recovery.
+ *
+ * DETECTOR = `hydrateRoot`'s `onRecoverableError`, which is exactly what React calls
+ * on a hydration mismatch (and, as a bonus, providing it stops React's default
+ * `reportError` from surfacing as an unhandled error in the run). A `console.error`
+ * text match is kept as a SECOND, independent signal — the two fail differently, so a
+ * change to React's warning text can't silently disarm both.
+ *
+ * `INSTRUMENT CHECK` below is the control for the detector itself: a component that
+ * deliberately renders different markup on the server than on the client MUST make
+ * both signals fire. Without it, "no mismatch" is indistinguishable from a spy
+ * attached to nothing.
+ *
+ * WHY THIS MATTERS FOR THIS CHANGE. `Create` is now gated on
+ * `isAppDeveloper(currentUser, { appBlocksAuthor: features.appBlocksAuthor })`, and
+ * that gate is deliberately NOT deferred behind `useIsClient()` — the claim being that
+ * both inputs are SSR-seeded and frozen, so applying them on the first paint is safe.
+ * This file is where that claim gets exercised end-to-end instead of asserted.
+ */
+
+type Summary = {
+  hasInstalls: boolean;
+  hasSubmissions: boolean;
+  hasApprovedApps: boolean;
+  isReviewer: boolean;
+};
+
+const ALL_TRUE: Summary = {
+  hasInstalls: true,
+  hasSubmissions: true,
+  hasApprovedApps: true,
+  isReviewer: true,
+};
+
+const mocks = vi.hoisted(() => ({
+  navSummary: undefined as undefined | Summary,
+  flags: { appBlocks: true, appBlocksAuthor: false } as Record<string, boolean>,
+  user: null as null | { id: number; username: string; isModerator?: boolean },
+}));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => mocks.flags,
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => mocks.user,
+}));
+
+// Spread the REAL module and override only `trpc` (local-rules/no-wholesale-module-
+// mock). The SERVER never has this query's data (tRPC runs with `ssr: false`); the
+// CLIENT's very first render does. Driving it as a plain value lets the same tree be
+// rendered under both conditions.
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcMod>()),
+  trpc: { blocks: { getNavSummary: { useQuery: () => ({ data: mocks.navSummary }) } } },
+}));
+
+const { AppsSubNav } = await import('./AppsSubNav');
+
+function Tree({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <MantineProvider>
+        <IsClientProvider>{children}</IsClientProvider>
+      </MantineProvider>
+    </QueryClientProvider>
+  );
+}
+
+/**
+ * React's hydration-mismatch vocabulary (React 18). Deliberately NARROW — a broad
+ * /hydrat/ matches MantineProvider's benign
+ * "useLayoutEffect does nothing on the server … non-hydrated UI" SSR notice, which
+ * fires on every server render of any Mantine tree and would make every test here
+ * fail for a reason that has nothing to do with this component.
+ */
+const HYDRATION_RE =
+  /(Hydration failed|An error occurred during hydration|The server HTML was replaced|Expected server HTML|did not match|Text content does not match)/i;
+
+let consoleErrors: string[] = [];
+let recoverable: string[] = [];
+let restoreConsole: (() => void) | null = null;
+const containers: HTMLElement[] = [];
+
+beforeEach(() => {
+  consoleErrors = [];
+  recoverable = [];
+  const original = console.error;
+  console.error = ((...args: unknown[]) => {
+    consoleErrors.push(args.map((a) => (typeof a === 'string' ? a : String(a))).join(' '));
+    original.apply(console, args as []);
+  }) as typeof console.error;
+  restoreConsole = () => {
+    console.error = original;
+  };
+  mocks.flags = { appBlocks: true, appBlocksAuthor: false };
+  mocks.user = null;
+  mocks.navSummary = undefined;
+});
+
+afterEach(() => {
+  restoreConsole?.();
+  restoreConsole = null;
+  for (const c of containers.splice(0)) c.remove();
+});
+
+/** console.error lines that name a hydration problem (the SECOND signal). */
+function hydrationConsoleErrors() {
+  return consoleErrors.filter(
+    (e) => HYDRATION_RE.test(e) && !/useLayoutEffect does nothing on the server/.test(e)
+  );
+}
+
+/**
+ * Plant `html` in a fresh container and hydrate it with `tree`, capturing every
+ * recoverable error React reports.
+ *
+ * NO `act()`: React 18.3's `act` lives in `react-dom/test-utils`, which this repo's
+ * `@types/react-dom` cannot resolve through its `exports` map (TS7016), and `React.act`
+ * postdates the pinned `@types/react` (18.0.x). Instead we hydrate and then yield a few
+ * macrotasks so React's scheduler runs the hydration + its passive effects. That is
+ * only sound because the INSTRUMENT CHECK below would report ZERO recoverable errors if
+ * the hydration had not actually run — so "no mismatch" cannot come from "nothing
+ * happened".
+ */
+async function hydrateInto(html: string, tree: React.ReactElement) {
+  const container = document.createElement('div');
+  container.innerHTML = html;
+  document.body.appendChild(container);
+  containers.push(container);
+  hydrateRoot(container, tree, {
+    onRecoverableError: (err) => {
+      recoverable.push(err instanceof Error ? err.message : String(err));
+    },
+  });
+  // Hydration is scheduled, not synchronous. Yield until the DOM has been claimed
+  // (or a bounded number of turns has passed, so a legitimately-empty render still
+  // returns).
+  for (let i = 0; i < 20; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  return container;
+}
+
+const subNav = () => (
+  <Tree>
+    <AppsSubNav />
+  </Tree>
+);
+
+describe('AppsSubNav — real SSR → hydrate', () => {
+  test('🔴 INSTRUMENT CHECK: a genuine server/client divergence IS reported by BOTH signals', async () => {
+    // Renders <p>server</p> on the server and <span>client</span> on the client —
+    // exactly the class of divergence the /apps incident was. If this does not fire,
+    // every "clean hydration" assertion below is meaningless.
+    let onServer = true;
+    function Diverges() {
+      return onServer ? <p>server</p> : <span>client</span>;
+    }
+    const html = renderToString(<Diverges />);
+    onServer = false;
+    await hydrateInto(html, <Diverges />);
+
+    expect(recoverable.length).toBeGreaterThan(0);
+    expect(recoverable.join('\n')).toMatch(HYDRATION_RE);
+    expect(hydrationConsoleErrors().length).toBeGreaterThan(0);
+  });
+
+  test('NON-AUTHOR (app-listings tester): no bar in the server HTML, and hydration is clean', async () => {
+    mocks.flags = { appBlocks: true, appBlocksAuthor: false };
+    mocks.user = { id: 7, username: 'tester', isModerator: false };
+
+    // SERVER: the protected summary query has not resolved.
+    mocks.navSummary = undefined;
+    const html = renderToString(subNav());
+    // A non-author with no summary qualifies for Marketplace alone ⇒ nothing renders.
+    expect(html).not.toContain('role="tab"');
+
+    // CLIENT: the query data IS in the cache on the very first render — the exact
+    // condition that bailed hydration before the `useIsClient` gate existed.
+    mocks.navSummary = { ...ALL_TRUE };
+    await hydrateInto(html, subNav());
+
+    expect(recoverable).toEqual([]);
+    expect(hydrationConsoleErrors()).toEqual([]);
+  });
+
+  test('AUTHOR: Create IS in the server HTML (the gate applies pre-hydration) and hydration is clean', async () => {
+    mocks.flags = { appBlocks: true, appBlocksAuthor: true };
+    mocks.user = { id: 7, username: 'author', isModerator: false };
+    mocks.navSummary = undefined;
+
+    const html = renderToString(subNav());
+    // 🔴 The load-bearing observation: `appBlocksAuthor` is available DURING SSR, so
+    // the author tab is in the server HTML. That is what makes gating it WITHOUT the
+    // `useIsClient` deferral correct rather than lucky.
+    expect(html).toContain('/apps/submit');
+    expect(html).toContain('Create');
+    // …while the summary-driven tabs are NOT (those are still deferred).
+    expect(html).not.toContain('/apps/installed');
+    expect(html).not.toContain('/apps/review');
+
+    mocks.navSummary = { ...ALL_TRUE };
+    await hydrateInto(html, subNav());
+
+    expect(recoverable).toEqual([]);
+    expect(hydrationConsoleErrors()).toEqual([]);
+  });
+
+  test('MODERATOR with appBlocksAuthor=false: the mod floor is server-rendered and hydration is clean', async () => {
+    mocks.flags = { appBlocks: true, appBlocksAuthor: false };
+    mocks.user = { id: 1, username: 'mod', isModerator: true };
+    mocks.navSummary = undefined;
+
+    const html = renderToString(subNav());
+    expect(html).toContain('/apps/submit');
+
+    mocks.navSummary = { ...ALL_TRUE };
+    await hydrateInto(html, subNav());
+
+    expect(recoverable).toEqual([]);
+    expect(hydrationConsoleErrors()).toEqual([]);
+  });
+
+  test('logged-out: the server renders no bar, and hydration is clean', async () => {
+    mocks.flags = { appBlocks: true, appBlocksAuthor: true };
+    mocks.user = null;
+    mocks.navSummary = undefined;
+
+    const html = renderToString(subNav());
+    expect(html).not.toContain('role="tab"');
+
+    await hydrateInto(html, subNav());
+
+    expect(recoverable).toEqual([]);
+    expect(hydrationConsoleErrors()).toEqual([]);
+  });
+});

--- a/src/components/Apps/AppsSubNav.tsx
+++ b/src/components/Apps/AppsSubNav.tsx
@@ -13,6 +13,7 @@ import { trpc } from '~/utils/trpc';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { useIsClient } from '~/providers/IsClientProvider';
+import { isAppDeveloper } from '~/shared/utils/app-blocks-access';
 
 /**
  * The conditions that drive which sub-nav tabs are visible. Sourced from the
@@ -39,22 +40,61 @@ const EMPTY_SUMMARY: AppsNavSummary = {
   isReviewer: false,
 };
 
+/**
+ * The viewer CAPABILITIES that drive tab visibility, as opposed to the
+ * `getNavSummary` booleans above. Kept a SEPARATE object (rather than folded
+ * into {@link AppsNavSummary}) because the two have different provenance and
+ * different hydration behaviour, and that difference is load-bearing:
+ *
+ *  - `AppsNavSummary` comes from the client-only `blocks.getNavSummary` query,
+ *    so it is ABSENT during SSR + the first client paint (see the `useIsClient`
+ *    note on the container) and its tabs reveal only after mount.
+ *  - `AppsNavContext` is resolved from values that are SSR-seeded and identical
+ *    on the first client render, so it can be applied to the very first paint
+ *    without a hydration mismatch. See the container for the derivation.
+ */
+export type AppsNavContext = {
+  /**
+   * May AUTHOR apps (submit / `dev:live`) → show "Create". Resolved via the
+   * shared {@link isAppDeveloper} predicate — moderators are a hard floor, the
+   * `appBlocksAuthor` capability widens it to the curated non-mod cohort.
+   */
+  isAuthor: boolean;
+};
+
+/** No capabilities — the shape a logged-out / non-author viewer resolves to. */
+const NO_CAPABILITIES: AppsNavContext = { isAuthor: false };
+
 type SubNavLink = {
   href: string;
   label: string;
   icon: typeof IconPlugConnected;
-  /** Whether this tab renders for the given summary. */
-  visible: (s: AppsNavSummary) => boolean;
+  /** Whether this tab renders for the given summary + viewer capabilities. */
+  visible: (s: AppsNavSummary, c: AppsNavContext) => boolean;
 };
 
 /**
- * Tab order = discovery → author → manage → revenue → moderate. The two
- * always-on tabs (Marketplace + Create) lead so the bar never collapses to
- * fewer than two entries.
+ * Tab order = discovery → author → manage → revenue → moderate.
+ *
+ * Only **Marketplace** is unconditional. "Create" links at `/apps/submit`,
+ * whose `getServerSideProps` gates on `features.appBlocksAuthor` +
+ * `isAppDeveloper` and otherwise returns `notFound` — so a store-visible
+ * NON-author (the widened `app-listings` tester cohort: `app-listings=true`,
+ * `app-blocks-author=false`) would click a tab straight into a 404. The tab now
+ * keys off the SAME predicate the page does.
+ *
+ * With "Create" conditional the bar can collapse to a single entry, so
+ * {@link AppsSubNavView} hides itself entirely below two tabs — a one-tab
+ * "navigation" is chrome that navigates nowhere.
  */
 const SUB_NAV_LINKS: SubNavLink[] = [
   { href: '/apps', label: 'Marketplace', icon: IconBuildingStore, visible: () => true },
-  { href: '/apps/submit', label: 'Create', icon: IconSquarePlus, visible: () => true },
+  {
+    href: '/apps/submit',
+    label: 'Create',
+    icon: IconSquarePlus,
+    visible: (_s, c) => c.isAuthor,
+  },
   {
     href: '/apps/installed',
     label: 'Installed',
@@ -116,6 +156,12 @@ export function activeAppsTab(currentPath: string): string | null {
  * there's no `onChange` (the route is the single source of truth, so clicking
  * just follows the link and the new route lights the matching tab).
  *
+ * Renders NOTHING when fewer than two tabs qualify (moderators included). A
+ * single-entry "navigation" bar is pure chrome — it can only link to the page
+ * you are already on — and it still costs the tab row's height plus its bottom
+ * rule on every `/apps/*` surface. Two is the floor at which the bar is a
+ * navigation affordance rather than a decoration.
+ *
  * `activateTabWithKeyboard={false}`: Mantine's default arrow-key handler
  * synthesizes a `.click()` on the focused tab, which on these real `<Link>`
  * anchors triggers a full page navigation — so a keyboard user can't ARROW to
@@ -125,12 +171,17 @@ export function activeAppsTab(currentPath: string): string | null {
  */
 export function AppsSubNavView({
   summary,
+  context,
   currentPath,
 }: {
   summary: AppsNavSummary;
+  context: AppsNavContext;
   currentPath: string;
 }) {
-  const links = SUB_NAV_LINKS.filter((l) => l.visible(summary));
+  const links = SUB_NAV_LINKS.filter((l) => l.visible(summary, context));
+  // Fewer than two qualifying tabs ⇒ no navigation bar at all. Applies to every
+  // viewer, moderators included.
+  if (links.length < 2) return null;
   const active = activeAppsTab(currentPath);
   return (
     <Box component="nav" aria-label="App sections" w="100%">
@@ -193,8 +244,8 @@ export function AppsSubNavView({
  *
  * Gated on `features.appBlocks` (the page itself 404s without it, so this is a
  * belt for non-flag callers) and on a logged-in user (the summary query is a
- * `protectedProcedure`; anon viewers — once the segment widens — just see the
- * two always-on tabs).
+ * `protectedProcedure`; an anon viewer resolves to `NO_CAPABILITIES` + an empty
+ * summary ⇒ Marketplace alone ⇒ the bar hides itself entirely).
  */
 export function AppsSubNav() {
   const router = useRouter();
@@ -223,5 +274,26 @@ export function AppsSubNav() {
 
   const summary = isClient ? data ?? EMPTY_SUMMARY : EMPTY_SUMMARY;
 
-  return <AppsSubNavView summary={summary} currentPath={router.pathname} />;
+  // 🔴 NOT gated on `useIsClient()` — deliberately, and verified against the
+  // incident above rather than assumed. Both inputs are SSR-seeded and FROZEN,
+  // so this value is byte-identical on the server render and the first client
+  // render, which is the whole condition for hydration safety:
+  //   • `features.appBlocksAuthor` is resolved server-side in `_app`'s
+  //     `getInitialProps` (`getFeatureFlagsAsync({ user: session.user, … })`,
+  //     Flipt included), serialized into `pageProps.flags`, and frozen by
+  //     `useState(initialFlags)` in `FeatureFlagsProvider`. It is NOT a
+  //     `toggleable: true` flag, so `computeUserFeatureFlagsOverlay` never emits
+  //     it and the client `user.getFeatureFlags` overlay cannot move it.
+  //   • `currentUser.isModerator` rides `SessionProvider`'s `useState(initial)`,
+  //     seeded from the same SSR `pageProps.session`. When that seed is
+  //     `undefined` (auth cookie present, session unresolved) the SERVER also
+  //     rendered without a user, so the first client paint still matches — the
+  //     session only arrives in a LATER render, post-hydration.
+  // Contrast `getNavSummary` above, which really is client-only and therefore
+  // really does need the `isClient` deferral.
+  const context: AppsNavContext = currentUser
+    ? { isAuthor: isAppDeveloper(currentUser, { appBlocksAuthor: features.appBlocksAuthor }) }
+    : NO_CAPABILITIES;
+
+  return <AppsSubNavView summary={summary} context={context} currentPath={router.pathname} />;
 }

--- a/src/components/Apps/RecentlyOpenedApps.browser.test.tsx
+++ b/src/components/Apps/RecentlyOpenedApps.browser.test.tsx
@@ -156,6 +156,46 @@ describe('RecentlyOpenedListingsView', () => {
     await expect.element(page.getByText('Other App')).toBeInTheDocument();
   });
 
+  /**
+   * The "Jump back in" caption that sat opposite the section title is REMOVED.
+   *
+   * 🔴 PAIRED WITH A POSITIVE CONTROL, on purpose. "the copy is gone" is trivially
+   * satisfiable by deleting the rail — or by any render that produces nothing at all
+   * (see RENDER_BARRIER: an un-committed tree makes every absence assertion pass).
+   * So the absence is asserted in the SAME test as the rail, its section label, its
+   * remaining heading and one tile PER ENTRY, with the barrier awaited first. Deleting
+   * the rail to satisfy the absence fails the four positive assertions; restoring the
+   * caption fails the absence.
+   */
+  test('the "Jump back in" caption is gone — and the rail + its tiles still render', async () => {
+    renderWithProviders(
+      <>
+        <RenderBarrier />
+        <RecentlyOpenedListingsView
+          entries={[
+            onsite(),
+            onsite({ id: 'ab_2', slug: 'other', blockId: 'other', name: 'Other App' }),
+          ]}
+          canOpenPage={false}
+        />
+      </>
+    );
+    // Barrier first, so "absent" is a real observation and not an empty container.
+    await expect.element(page.getByTestId(RENDER_BARRIER)).toBeInTheDocument();
+
+    // POSITIVE CONTROL — the rail, its landmark, its heading and its tiles are intact.
+    await expect.element(page.getByTestId('apps-recent-rail')).toBeInTheDocument();
+    await expect.element(page.getByRole('region', { name: 'Recently opened' })).toBeInTheDocument();
+    await expect
+      .element(page.getByRole('heading', { name: 'Recently opened' }))
+      .toBeInTheDocument();
+    expect(page.getByTestId('apps-recent-rail-item').elements()).toHaveLength(2);
+    await expect.element(page.getByText('Gen Matrix')).toBeInTheDocument();
+
+    // THE CHANGE — the caption is nowhere in the rendered output.
+    expect(page.getByText('Jump back in').elements()).toHaveLength(0);
+  });
+
   test('an on-site page app re-opens at /apps/run/<blockId> when the pages flag is lit', async () => {
     renderWithProviders(<RecentlyOpenedListingsView entries={[onsite()]} canOpenPage />);
     await expect

--- a/src/components/Apps/RecentlyOpenedApps.tsx
+++ b/src/components/Apps/RecentlyOpenedApps.tsx
@@ -7,7 +7,6 @@ import {
   Group,
   SimpleGrid,
   Stack,
-  Text,
   Title,
   Tooltip,
 } from '@mantine/core';
@@ -402,12 +401,12 @@ export function RecentlyOpenedListingsView({
 
   return (
     <Stack gap="xs" component="section" aria-label="Recently opened" data-testid="apps-recent-rail">
-      <Group justify="space-between" align="center">
-        <Title order={4}>Recently opened</Title>
-        <Text size="xs" c="dimmed">
-          Jump back in
-        </Text>
-      </Group>
+      {/* The "Jump back in" caption that used to sit opposite the title is gone —
+          it restated what "Recently opened" already says. With one child left the
+          `Group justify="space-between"` had nothing to space, so it went too;
+          the Title is the section heading directly. The rail + its tiles are
+          untouched. */}
+      <Title order={4}>Recently opened</Title>
       <SimpleGrid cols={{ base: 2, sm: 3, md: 4, lg: 6 }} spacing="xs">
         {entries.map((entry) => (
           <RecentTile

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -173,6 +173,18 @@ export default defineConfig({
             'vitest-browser-react',
             'react/jsx-dev-runtime',
             'react/jsx-runtime',
+            // `react-dom/server` — used by the SSR→hydrate tests
+            // (`*.ssrHydration.browser.test.tsx`) to produce real server HTML and
+            // hydrate it. WITHOUT this entry Vite discovers it mid-run and emits a
+            // SEPARATE optimized chunk that carries its OWN copy of `react`, so
+            // `ReactCurrentDispatcher.current` is null inside it and every hook call
+            // during `renderToString` throws
+            // `Cannot read properties of null (reading 'useState')` — the dual-React
+            // failure the `dedupe` above exists to prevent, arriving through the
+            // optimizer rather than through a transitive dependency. Listing it here
+            // pre-bundles it in the same pass as `react`/`react-dom`, so all three
+            // share one instance.
+            'react-dom/server',
           ],
           // `@vitest/browser` seeds optimizeDeps.entries from EVERY `*.browser.test.tsx` file
           // (globTestFiles), not just the one you ran. The review app-listing browser tests


### PR DESCRIPTION
## What changed

**1. `Create` is gated on the author capability.**
`SUB_NAV_LINKS`' `Create` entry was hardcoded `visible: () => true`. Now that store visibility has widened past the author cohort, a store-visible non-author sees the tab, clicks it, and `/apps/submit` returns `notFound` — its `getServerSideProps` gates on `features.appBlocksAuthor` **and** `isAppDeveloper(session.user, …)`.

The tab now keys off the **same shared predicate** — `isAppDeveloper(user, { appBlocksAuthor })` from `~/shared/utils/app-blocks-access` — so the two gates cannot drift and moderators keep their hard floor (`isModerator || appBlocksAuthor`) without an inlined `isModerator` check.

Threaded as a new **`AppsNavContext`** prop (`{ isAuthor: boolean }`), deliberately kept separate from `AppsNavSummary` rather than folded into it. The two have different provenance *and* different hydration behaviour, and that difference is the load-bearing part of this PR:

| | source | on the first paint |
|---|---|---|
| `AppsNavSummary` | client-only `blocks.getNavSummary` | absent — deferred behind `useIsClient()` |
| `AppsNavContext` | SSR-seeded flags + session | applied |

No new server round-trip: `blocks.getNavSummary` is untouched.

**2. The sub-nav hides entirely below two qualifying tabs** — every viewer, moderators included. This replaces the old *"the two always-on tabs lead so the bar never collapses to fewer than two entries"* rationale, which only held because `Create` was unconditional. A one-entry navigation bar can only link to the page you are already on, while still costing the tab row and its bottom rule on every `/apps/*` surface.

**3. `Jump back in` removed** from the recents rail (`RecentlyOpenedListingsView`). The now-single-child `Group justify="space-between"` went with it. The rail, its `region` landmark, its `Recently opened` heading and its tiles are untouched.

---

## Hydration finding

**`features.appBlocksAuthor` IS available and identical during SSR and the first client render, so the author gate does NOT need the `useIsClient()` deferral and does NOT reintroduce the bail.** Traced through the code, then verified with a real `renderToString` → `hydrateRoot`:

- **The flag.** `_app`'s `getInitialProps` calls `getFeatureFlagsAsync({ user: session?.user, host, req })` server-side (Flipt included) and serializes the result into `pageProps.flags`. `FeatureFlagsProvider` freezes it with `useState(initialFlags)`. Critically, `appBlocksAuthor` is **not** declared `toggleable: true`, so `computeUserFeatureFlagsOverlay` filters it out and the client `user.getFeatureFlags` overlay can never move it. Server value ≡ client frame-0 value.
- **The moderator floor.** `currentUser.isModerator` comes from `SessionProvider`'s `useState(initial)`, seeded from the same SSR `pageProps.session`. The one ambiguous case is a present auth cookie with an unresolved session (`session: undefined` → fetch on mount) — but there the **server also rendered without a user**, so the first client paint still matches; the session only arrives in a later render, post-hydration.
- Contrast `getNavSummary`, which really is client-only (tRPC `ssr: false`) and really does still need the `isClient` gate. That gate is unchanged.

**Verified, not asserted.** `AppsSubNav.ssrHydration.browser.test.tsx` renders the component to an HTML string under the *real* `IsClientProvider`, plants it in a container, hydrates it, and asserts React reported nothing — via **two independent detectors** (`hydrateRoot`'s `onRecoverableError`, plus a narrow `console.error` text match). Its first test is an **instrument check**: a component that deliberately renders `<p>server</p>` / `<span>client</span>` must make *both* detectors fire. It does. It also asserts the shape directly: `Create` **is in the server HTML** for an author, while `/apps/installed` and `/apps/review` are **not**.

**Known cosmetic consequence (not a hydration bug).** A non-author whose only second tab comes from the summary (e.g. one install) gets no bar on the first paint and the bar appears after mount — a pop-in, identical in kind to the conditional tabs' existing post-mount reveal. It is unavoidable without a server round-trip, which the brief rules out (and which the summary query deliberately avoids).

---

## Mutation matrix

Every guard was reverted individually and watched go red. Baseline: **52/52 green** across the three `AppsSubNav` suites; **36/36** across the recents suites.

| # | Mutation | Result | Killed on |
|---|---|---|---|
| M1 | `Create` back to `visible: () => true` | **18 failed** / 34 passed | `Create is HIDDEN for a non-author` → *expected [\<a>] to have length 0, got 1*; `NON-AUTHOR … no bar in the server HTML` → *expected … not to contain `role="tab"`*; `MODERATOR FLOOR` untouched (correctly still green) |
| M2 | delete `if (links.length < 2) return null` | **8 failed** / 44 passed | `renders NOTHING when only Marketplace qualifies` → *expected [\<a>] length 0, got 1*; `no moderator carve-out` → *[\<div>] length 0, got 1*; `NON-AUTHOR, server render → no bar at all` → *expected ['Marketplace'] to deeply equal []*; `a non-author with an empty summary renders no nav` → *[\<nav>] length 0, got 1* |
| M3 | drop the mod floor: `isAppDeveloper(user, …)` → `!!features.appBlocksAuthor` | **exactly 2 failed** / 50 passed | `🔴 MODERATOR FLOOR: a mod keeps Create even with appBlocksAuthor=false`, and its SSR twin. Nothing else moved — the floor has its own dedicated coverage |
| M4 | restore the `Jump back in` caption | **1 failed** / 35 passed | `the "Jump back in" caption is gone …` → *expected [\<p>] to have length 0, got 1* |
| M5 | delete the recents rail entirely (`entries.length >= 0 → null`) | **22 failed** | the **same** test fails, on its *positive* assertions — so "the caption is gone" cannot be satisfied by removing the rail |

### 🔴 The mutation run found a real defect in my own tests

M2 initially killed **only 2** tests — and *neither* was one of the four I wrote for the collapse. Cause: `render()` commits through a React 18 concurrent root on a later task, so a bare `expect(locator.elements()).toHaveLength(0)` immediately after `renderWithProviders` observes an **empty container and passes no matter what the component does**. Every "renders NOTHING" assertion I had written was structurally unfailable. Fixed by adopting the `RENDER_BARRIER` idiom already used in `RecentlyOpenedApps.browser.test.tsx` (render a sentinel alongside the unit under test and `await` it first). M2 then killed 8, each on its own collapse assertion. The four suites that *did* catch it unaided were the `renderToString` ones, which are synchronous.

---

## What I ran

- **Browser (`component`) project, full: 138/139 files, 1437 tests, 0 failures.** The single failing file — `ImagesAsPostsCardLazyCarousel.browser.test.tsx`, `SyntaxError: … does not provide an export named 'fetchGenerationData'` — **fails identically on `origin/main`** (measured in a clean baseline worktree), so it is pre-existing and untouched by this PR.
- **`src/components/Apps/` + `src/tests/pages/apps/`: 63 files / 758 tests green.**
- **Unit project, full: identical to `origin/main`** — 95 failed / 909 passed / 20 skipped files and 20 / 14470 / 20 tests on **both** sides, and the `FAIL` file list diffs **empty** (111 lines each). Those 95 are pre-existing local-environment collection failures (no DB / un-generated Prisma client / a gitignored `event-engine-common` tree), not regressions.
- **`pnpm typecheck` (the repo script, not bare `tsc`): 18 errors — byte-identical to the `origin/main` baseline log (`diff` empty). Zero in any file this PR touches.**
- **ESLint on every changed file: clean.** This also fixed a pre-existing `local-rules/no-wholesale-module-mock` error in `AppsSubNav.hydration.browser.test.tsx` (it now spreads `importOriginal`), which was already red on `main`.

## What I did NOT verify

- **No live/browser check against a real deploy.** Everything here is component-level; nobody drove `/apps` in a running app as a real `app-listings`-only tester. The 404-on-click symptom itself is inferred from `submit.tsx`'s `getServerSideProps`, not reproduced.
- **The civitai Vitest browser suites are report-only and do not block merge**, so "green" above is evidence, not a gate.
- **Hydration was exercised via `renderToString` → `hydrateRoot` in a test harness, not against a Next SSR response.** The provider stack in that test is `QueryClientProvider` → `MantineProvider` → `IsClientProvider`, not the full `_app` tree; a mismatch introduced by some *other* provider in the real tree would not show up here.
- **The claim that `appBlocksAuthor` is SSR-stable is read off the code** (`_app.getInitialProps` → `pageProps.flags` → `useState`, plus its absence from `toggleableFeatures`). I did not observe a production `__NEXT_DATA__` payload to confirm the flag is present in `pageProps.flags` for a live tester account.
- **No visual/pixel review.** The `AppsPageLayout.geometry` numbers still pass with the fixtures updated to an author (same two-tab bar), but nobody looked at a rendered `/apps` page for a non-author with the bar absent, nor at the recents rail without its caption.
- **`vitest.config.mts` change**: `react-dom/server` in `optimizeDeps.include` was validated by running the **full** component project (above), but only on one machine and one cold/warm cache cycle. It is additive.

## Contradictions with the brief

- The brief said `AppsSubNav.tsx:57` and `features` were the only moving parts; the sub-nav's **`AppsNavSummary` type is exported and consumed by the tests only** — `AppsSubNavView` has no non-test callers, so widening its props was cheap.
- The brief predicted the hydration gate would be the hard part. It was — but not where expected: the risk turned out to be **in the tests**, not the component (see the M2 finding above). The component-side hydration claim held on the first attempt.
- Two existing fixtures had to change (`AppsPageLayout.browser.test.tsx`, `AppsPageLayout.geometry.browser.test.tsx`): both mocked `useCurrentUser: () => null` with an empty summary, which under the new `<2` rule renders **no `<nav>` at all**, so `measure()` threw on a null lookup. They now describe an author, which reproduces the exact two-tab bar their pixel table was measured against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
