### PR TITLE
fix(creator-studio): refuse a blank generation-only price at the write boundary

### DIFF
--- a/apps/creator-studio/src/lib/components/monetization/PaidAccessFields.svelte
+++ b/apps/creator-studio/src/lib/components/monetization/PaidAccessFields.svelte
@@ -163,6 +163,11 @@
     <div class="flex flex-col gap-2">
       <span class="text-sm text-dark-1">Generating on-site</span>
       <input type="hidden" name="freeGeneration" value={genMode === 'free' ? 'true' : 'false'} />
+      <!-- Submitted so the server can tell "cheaper generation-only price" from "same as the access
+           price". Without it the two produce identical form data — the price input is simply absent —
+           and a blank box stores a generation tier with no price of its own, which is charged at the
+           DOWNLOAD price. -->
+      <input type="hidden" name="genMode" value={genMode} />
       <RadioGroup bind:value={genMode} class="flex flex-col gap-1.5">
         <div class="flex items-center gap-2">
           <RadioGroupItem value="bundled" id="ea-gen-bundled" />

--- a/apps/creator-studio/src/lib/server/__tests__/paid-access-form-schema.test.ts
+++ b/apps/creator-studio/src/lib/server/__tests__/paid-access-form-schema.test.ts
@@ -1,5 +1,7 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
-import { paidAccessFormSchema } from '../monetization/paid-access-schema';
+import { bulkPaidAccessSchema, paidAccessFormSchema } from '../monetization/paid-access-schema';
 
 // The editor's three generation choices are a radio group, but only the chosen PRICE used to be
 // submitted. "A cheaper generation-only price" with an empty box therefore arrived as exactly the same
@@ -65,5 +67,63 @@ describe('paidAccessFormSchema — the generation choice', () => {
   // Only the browser's `min` attribute enforced this before; a crafted POST could set 1.
   it('refuses a generation price below the 50 Buzz floor', () => {
     expect(errors({ genMode: 'separate', generationPrice: '1' })).not.toEqual([]);
+  });
+});
+
+// The bulk dialog builds its parse input from a hand-listed object rather than the whole FormData, so a
+// field added to the schema is inert until it is also added there. That is how the first version of this
+// fix shipped a refine that could never fire — and mutation-testing the per-version schema said nothing
+// about it, because the two schemas are separate objects.
+describe('bulkPaidAccessSchema — the same choice, applied to many versions', () => {
+  const bulk = (over: Record<string, unknown> = {}) => {
+    const parsed = bulkPaidAccessSchema.safeParse({
+      accessPrice: '5000',
+      freePreviewGenerations: '10',
+      freeGeneration: 'false',
+      acceptsBlueBuzz: 'false',
+      ...over,
+    });
+    return parsed.success ? [] : parsed.error.issues.map((i) => i.message);
+  };
+
+  it('refuses "separate" with an empty price box', () => {
+    expect(bulk({ genMode: 'separate', generationPrice: '' })).toContain(
+      'Enter a generation-only price, or choose "Same as the access price".'
+    );
+  });
+
+  it('accepts "separate" once a price is given', () => {
+    expect(bulk({ genMode: 'separate', generationPrice: '500' })).toEqual([]);
+  });
+
+  it('accepts "bundled" with no price', () => {
+    expect(bulk({ genMode: 'bundled' })).toEqual([]);
+  });
+});
+
+// A field in the schema does nothing until the action also passes it. `bulkSetPaidAccess` builds its parse
+// input from a hand-listed object rather than the whole FormData, so the two can drift silently — and the
+// drift is invisible to every schema test above, because they call the schema directly. Structural, for
+// the same reason the repo's other convention guards are: it fails on the omission itself.
+describe('the bulk action passes every schema field to the parser', () => {
+  it('lists each bulkPaidAccessSchema key in its safeParse input', () => {
+    const route = fileURLToPath(
+      new URL('../../../routes/(app)/models/+page.server.ts', import.meta.url)
+    );
+    const src = readFileSync(route, 'utf8');
+    const call = src.slice(src.indexOf('bulkPaidAccessSchema.safeParse({'));
+    const input = call.slice(0, call.indexOf('});') + 3);
+
+    // Unwrap the `.refine()` wrappers to reach the object shape.
+    let shape = bulkPaidAccessSchema as unknown as {
+      shape?: Record<string, unknown>;
+      _def?: { schema?: unknown };
+    };
+    while (!shape.shape && shape._def?.schema) shape = shape._def.schema as typeof shape;
+    const keys = Object.keys(shape.shape ?? {});
+    expect(keys.length).toBeGreaterThan(0);
+
+    const missing = keys.filter((k) => !new RegExp(`\\b${k}:`).test(input));
+    expect(missing).toEqual([]);
   });
 });

--- a/apps/creator-studio/src/lib/server/__tests__/paid-access-form-schema.test.ts
+++ b/apps/creator-studio/src/lib/server/__tests__/paid-access-form-schema.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { paidAccessFormSchema } from '../monetization/paid-access-schema';
+
+// The editor's three generation choices are a radio group, but only the chosen PRICE used to be
+// submitted. "A cheaper generation-only price" with an empty box therefore arrived as exactly the same
+// form data as "Same as the access price" — and a generation grant with no price of its own is charged
+// at the DOWNLOAD price (`generationPrice` in @civitai/buzz). The screen said cheaper, the buyer paid
+// full, and nothing downstream could tell the two apart afterwards.
+
+// A complete, valid submission; each test overrides only the field it is about.
+const form = (over: Record<string, unknown> = {}) => ({
+  timeframe: '0',
+  permanent: 'on',
+  accessPrice: '5000',
+  freeGeneration: 'false',
+  acceptsBlueBuzz: 'false',
+  freePreviewGenerations: '10',
+  donationGoalEnabled: 'false',
+  ...over,
+});
+
+const errors = (over: Record<string, unknown> = {}) => {
+  const parsed = paidAccessFormSchema.safeParse(form(over));
+  return parsed.success ? [] : parsed.error.issues.map((i) => i.message);
+};
+
+describe('paidAccessFormSchema — the generation choice', () => {
+  it('refuses "separate" with an empty price box', () => {
+    expect(errors({ genMode: 'separate', generationPrice: '' })).toContain(
+      'Enter a generation-only price, or choose "Same as the access price".'
+    );
+  });
+
+  it('refuses "separate" with the price field absent entirely', () => {
+    expect(errors({ genMode: 'separate' })).toContain(
+      'Enter a generation-only price, or choose "Same as the access price".'
+    );
+  });
+
+  it('accepts "separate" once a price is given', () => {
+    expect(errors({ genMode: 'separate', generationPrice: '500' })).toEqual([]);
+  });
+
+  it('accepts "bundled" with no price — that is what bundling means', () => {
+    expect(errors({ genMode: 'bundled', generationPrice: '' })).toEqual([]);
+  });
+
+  it('accepts "free" with no price', () => {
+    expect(errors({ genMode: 'free', freeGeneration: 'true' })).toEqual([]);
+  });
+
+  // The mode is optional so an in-flight page or a scripted POST keeps working; the refine only bites
+  // when `separate` is claimed. This is the arm that makes the guard non-breaking, and also the arm that
+  // would silently disable it if someone made the field required-but-defaulted.
+  it('accepts a submission that omits the mode', () => {
+    expect(errors({ generationPrice: '' })).toEqual([]);
+  });
+
+  it('still refuses a generation price above the access price', () => {
+    expect(errors({ genMode: 'separate', generationPrice: '9000' })).toContain(
+      'Generation-only price cannot be greater than the access price.'
+    );
+  });
+
+  // Only the browser's `min` attribute enforced this before; a crafted POST could set 1.
+  it('refuses a generation price below the 50 Buzz floor', () => {
+    expect(errors({ genMode: 'separate', generationPrice: '1' })).not.toEqual([]);
+  });
+});

--- a/apps/creator-studio/src/lib/server/monetization/paid-access-schema.ts
+++ b/apps/creator-studio/src/lib/server/monetization/paid-access-schema.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+import { checkbox, optionalBuzz, optionalBuzzField, freePreviewsField } from './form-fields';
+// Relative, not `$lib`: this module is unit-tested by the app's plain node vitest project, which has no
+// SvelteKit plugin and so cannot resolve the alias — an aliased import here fails COLLECTION, which reads
+// as zero tests rather than as a failure.
+import { MIN_GENERATION_PRICE } from '../../monetization/paid-access';
+
+// Split out of `paid-access.ts` so it can be unit-tested: that module imports `$env/dynamic/private`
+// for the main-app URL, which is unresolvable under the node test runner and makes the whole suite fail
+// to COLLECT — reported as zero tests, not as a failure.
+
+// Validates the paid-access editor form → a PaidAccessConfig. Light shape validation only; the main-app
+// endpoint (updateEarlyAccessConfigSchema) is the source of truth for prices, per-user limits, side effects.
+export const paidAccessFormSchema = z
+  .object({
+    timeframe: z.coerce.number().int().min(0),
+    permanent: checkbox,
+    // On-site-generation-only versions charge via the generation price (no download tier).
+    usageControl: z.string().optional(),
+    accessPrice: optionalBuzz,
+    generationPrice: optionalBuzzField(MIN_GENERATION_PRICE),
+    // The generation choice itself, so a priceless "separate" tier can be refused here rather than
+    // stored as something indistinguishable from "bundled". Optional: an older page or a scripted POST
+    // that omits it keeps working, and the refine only bites when `separate` is explicitly claimed.
+    genMode: z.enum(['bundled', 'separate', 'free']).optional(),
+    freeGeneration: checkbox,
+    acceptsBlueBuzz: checkbox,
+    freePreviewGenerations: freePreviewsField(),
+    donationGoalEnabled: checkbox,
+    donationGoal: optionalBuzz,
+  })
+  .refine((v) => v.permanent || v.timeframe > 0, {
+    message: 'Set an early access duration, or make it permanent.',
+  })
+  // Every gated version needs an access price. For a gen-only version it's written as the generation price.
+  .refine((v) => v.accessPrice != null && v.accessPrice > 0, {
+    message: 'Enter a price for access.',
+  })
+  .refine(
+    (v) => v.generationPrice == null || v.accessPrice == null || v.generationPrice <= v.accessPrice,
+    { message: 'Generation-only price cannot be greater than the access price.' }
+  )
+  // A "separate" tier with no price falls back to the DOWNLOAD price (see `generationPrice` in
+  // @civitai/buzz), so the screen says cheaper while the buyer pays full. The stored terms can't be told
+  // apart from a deliberate bundle afterwards, which is why this is refused at the write boundary.
+  .refine((v) => v.genMode !== 'separate' || v.generationPrice != null, {
+    message: 'Enter a generation-only price, or choose "Same as the access price".',
+  });

--- a/apps/creator-studio/src/lib/server/monetization/paid-access-schema.ts
+++ b/apps/creator-studio/src/lib/server/monetization/paid-access-schema.ts
@@ -1,9 +1,15 @@
 import { z } from 'zod';
-import { checkbox, optionalBuzz, optionalBuzzField, freePreviewsField } from './form-fields';
+import {
+  checkbox,
+  optionalBuzz,
+  optionalBuzzField,
+  requiredBuzzField,
+  freePreviewsField,
+} from './form-fields';
 // Relative, not `$lib`: this module is unit-tested by the app's plain node vitest project, which has no
 // SvelteKit plugin and so cannot resolve the alias — an aliased import here fails COLLECTION, which reads
 // as zero tests rather than as a failure.
-import { MIN_GENERATION_PRICE } from '../../monetization/paid-access';
+import { MIN_ACCESS_PRICE, MIN_GENERATION_PRICE } from '../../monetization/paid-access';
 
 // Split out of `paid-access.ts` so it can be unit-tested: that module imports `$env/dynamic/private`
 // for the main-app URL, which is unresolvable under the node test runner and makes the whole suite fail
@@ -43,6 +49,30 @@ export const paidAccessFormSchema = z
   // A "separate" tier with no price falls back to the DOWNLOAD price (see `generationPrice` in
   // @civitai/buzz), so the screen says cheaper while the buyer pays full. The stored terms can't be told
   // apart from a deliberate bundle afterwards, which is why this is refused at the write boundary.
+  .refine((v) => v.genMode !== 'separate' || v.generationPrice != null, {
+    message: 'Enter a generation-only price, or choose "Same as the access price".',
+  });
+
+// The bulk dialog posts the same fields for many versions at once. It lives here beside the
+// per-version schema so the two can be read against each other — they drifted before, and the bulk one is
+// the higher-blast-radius of the pair: one blank price box mis-prices every selected version.
+export const bulkPaidAccessSchema = z
+  .object({
+    accessPrice: requiredBuzzField(MIN_ACCESS_PRICE, 'Enter a price for access.'),
+    generationPrice: optionalBuzzField(MIN_GENERATION_PRICE),
+    freePreviewGenerations: freePreviewsField(),
+    // Without this the shared form's "Free for everyone" choice is silently dropped and the version
+    // gets a PRICED generation tier with a zero trial limit — the opposite of what was picked.
+    freeGeneration: checkbox,
+    acceptsBlueBuzz: checkbox,
+    // Same reason as the per-version schema: without the chosen mode, "a cheaper generation-only price"
+    // with an empty box is indistinguishable from "same as the access price", and lands as a generation
+    // tier charged at the download price. In bulk that mis-prices every selected version at once.
+    genMode: z.enum(['bundled', 'separate', 'free']).optional(),
+  })
+  .refine((v) => v.generationPrice == null || v.generationPrice <= v.accessPrice, {
+    message: 'Generation-only price cannot be greater than the access price.',
+  })
   .refine((v) => v.genMode !== 'separate' || v.generationPrice != null, {
     message: 'Enter a generation-only price, or choose "Same as the access price".',
   });

--- a/apps/creator-studio/src/lib/server/monetization/paid-access.ts
+++ b/apps/creator-studio/src/lib/server/monetization/paid-access.ts
@@ -10,7 +10,6 @@ import {
 import { env } from '$env/dynamic/private';
 import { dbRead, dbWrite } from '$lib/server/db';
 import { mapWithConcurrency, MAIN_APP_WRITE_CONCURRENCY } from '$lib/server/concurrency';
-import { checkbox, optionalBuzz, freePreviewsField } from './form-fields';
 import {
   GENERATION_ONLY_HINT,
   isCreatorUsageControl,
@@ -32,33 +31,7 @@ export { isCreatorUsageControl, type CreatorUsageControl } from '$lib/monetizati
 
 export type PaidAccessResult = { ok: true } | { ok: false; status: number; error: string };
 
-// Validates the paid-access editor form → a PaidAccessConfig. Light shape validation only; the main-app
-// endpoint (updateEarlyAccessConfigSchema) is the source of truth for prices, per-user limits, side effects.
-export const paidAccessFormSchema = z
-  .object({
-    timeframe: z.coerce.number().int().min(0),
-    permanent: checkbox,
-    // On-site-generation-only versions charge via the generation price (no download tier).
-    usageControl: z.string().optional(),
-    accessPrice: optionalBuzz,
-    generationPrice: optionalBuzz,
-    freeGeneration: checkbox,
-    acceptsBlueBuzz: checkbox,
-    freePreviewGenerations: freePreviewsField(),
-    donationGoalEnabled: checkbox,
-    donationGoal: optionalBuzz,
-  })
-  .refine((v) => v.permanent || v.timeframe > 0, {
-    message: 'Set an early access duration, or make it permanent.',
-  })
-  // Every gated version needs an access price. For a gen-only version it's written as the generation price.
-  .refine((v) => v.accessPrice != null && v.accessPrice > 0, {
-    message: 'Enter a price for access.',
-  })
-  .refine(
-    (v) => v.generationPrice == null || v.accessPrice == null || v.generationPrice <= v.accessPrice,
-    { message: 'Generation-only price cannot be greater than the access price.' }
-  );
+export { paidAccessFormSchema } from './paid-access-schema';
 
 // versionId + config (null clears the gate). `cookie` is the incoming request's raw Cookie header,
 // forwarded verbatim for auth. `genOnly` = the version is on-site-generation-only (no download tier), so

--- a/apps/creator-studio/src/lib/server/monetization/paid-access.ts
+++ b/apps/creator-studio/src/lib/server/monetization/paid-access.ts
@@ -1,4 +1,3 @@
-import { z } from 'zod';
 import { sql } from '@civitai/db/kysely';
 import {
   buildModelVersionTerms,

--- a/apps/creator-studio/src/routes/(app)/models/+page.server.ts
+++ b/apps/creator-studio/src/routes/(app)/models/+page.server.ts
@@ -20,6 +20,7 @@ import {
   licensingFeeRatioSchema,
 } from '$lib/server/monetization/licensing-fee';
 import { bustVersionCache } from '$lib/server/monetization/bust-cache';
+import { bulkPaidAccessSchema } from '$lib/server/monetization/paid-access-schema';
 import {
   setPaidAccessConfig,
   paidAccessFormSchema,
@@ -66,26 +67,6 @@ const versionIdsSchema = z
       .filter((n) => Number.isInteger(n) && n > 0)
   )
   .refine((ids) => ids.length > 0, 'Select at least one version.');
-const bulkPaidAccessSchema = z
-  .object({
-    accessPrice: requiredBuzzField(MIN_ACCESS_PRICE, 'Enter a price for access.'),
-    generationPrice: optionalBuzzField(MIN_GENERATION_PRICE),
-    freePreviewGenerations: freePreviewsField(),
-    // Without this the shared form's "Free for everyone" choice is silently dropped and the version
-    // gets a PRICED generation tier with a zero trial limit — the opposite of what was picked.
-    freeGeneration: checkbox,
-    acceptsBlueBuzz: checkbox,
-    // Same reason as the per-version schema: without the chosen mode, "a cheaper generation-only price"
-    // with an empty box is indistinguishable from "same as the access price", and lands as a generation
-    // tier charged at the download price. In bulk that mis-prices every selected version at once.
-    genMode: z.enum(['bundled', 'separate', 'free']).optional(),
-  })
-  .refine((v) => v.generationPrice == null || v.generationPrice <= v.accessPrice, {
-    message: 'Generation-only price cannot be greater than the access price.',
-  })
-  .refine((v) => v.genMode !== 'separate' || v.generationPrice != null, {
-    message: 'Enter a generation-only price, or choose "Same as the access price".',
-  });
 const modelsQuerySchema = z.object({
   q: z.string().optional(),
   fee: z.enum(['set', 'off']).optional().catch(undefined),
@@ -250,6 +231,7 @@ export const actions: Actions = {
       freePreviewGenerations: form.get('freePreviewGenerations'),
       freeGeneration: form.get('freeGeneration'),
       acceptsBlueBuzz: form.get('acceptsBlueBuzz'),
+      genMode: form.get('genMode'),
     });
     if (!pricing.success) return fail(400, { paidAccess: true, error: firstError(pricing.error) });
 

--- a/apps/creator-studio/src/routes/(app)/models/+page.server.ts
+++ b/apps/creator-studio/src/routes/(app)/models/+page.server.ts
@@ -38,12 +38,7 @@ import {
   bulkSetUsageControl,
   versionsLosingFreeGeneration,
 } from '$lib/server/monetization/paid-access';
-import {
-  checkbox,
-  optionalBuzzField,
-  requiredBuzzField,
-  freePreviewsField,
-} from '$lib/server/monetization/form-fields';
+import { checkbox } from '$lib/server/monetization/form-fields';
 import { resolveModelsScore, TEST_MODELS_SCORE_COOKIE } from '$lib/server/creator-score';
 import { canSetGenerationOnlyFresh } from '$lib/server/generation-only';
 import {
@@ -51,8 +46,6 @@ import {
   earlyAccessQuantityForScore,
   maxPermanentAccessModels,
   maxPaidAccessPrice,
-  MIN_ACCESS_PRICE,
-  MIN_GENERATION_PRICE,
 } from '$lib/monetization/paid-access';
 
 // --- input schemas: every load/action input is zod-validated ---

--- a/apps/creator-studio/src/routes/(app)/models/+page.server.ts
+++ b/apps/creator-studio/src/routes/(app)/models/+page.server.ts
@@ -75,9 +75,16 @@ const bulkPaidAccessSchema = z
     // gets a PRICED generation tier with a zero trial limit — the opposite of what was picked.
     freeGeneration: checkbox,
     acceptsBlueBuzz: checkbox,
+    // Same reason as the per-version schema: without the chosen mode, "a cheaper generation-only price"
+    // with an empty box is indistinguishable from "same as the access price", and lands as a generation
+    // tier charged at the download price. In bulk that mis-prices every selected version at once.
+    genMode: z.enum(['bundled', 'separate', 'free']).optional(),
   })
   .refine((v) => v.generationPrice == null || v.generationPrice <= v.accessPrice, {
     message: 'Generation-only price cannot be greater than the access price.',
+  })
+  .refine((v) => v.genMode !== 'separate' || v.generationPrice != null, {
+    message: 'Enter a generation-only price, or choose "Same as the access price".',
   });
 const modelsQuerySchema = z.object({
   q: z.string().optional(),


### PR DESCRIPTION
The same money bug as #3894, in the other writer. Found by auditing Creator Studio after #3894's review flagged it; **this one is server-enforceable and #3894's is not**, which is the whole difference between the two fixes.

## The bug

`PaidAccessFields.svelte` offers the same three-way choice — bundled / **a cheaper generation-only price** / free. Pick the middle one, leave the box empty, save:

- The price input is only mounted for `separate`, and `optionalBuzz` maps both *absent* and `''` to `undefined` (`form-fields.ts`). So **"separate with an empty box" and "bundled" submit byte-identical form data.**
- The only refine touching the field was `generationPrice == null || generationPrice <= accessPrice` — the `== null` arm passes vacuously on exactly the broken value.
- `buildModelVersionTerms` omits the price key, and `generationPrice(terms)` falls back to `download.price`. The screen said cheaper; the buyer is charged the full download price.
- Reopening the drawer reseeds the radio to "bundled" (`models.ts` maps the stored terms back), so the creator's choice leaves no trace to notice.

Both writers had it: the per-version editor and the **bulk dialog**, where one blank box mis-prices every selected version at once. Reachable by any signed-in creator — no flag, no role gate.

## The fix, and why it differs from #3894

The mode was never submitted, which is why the server couldn't tell the two cases apart. It is now a hidden field (`genMode`) beside the existing `freeGeneration` one, so **the refusal lives in zod, at the write boundary**, for both schemas.

The main app cannot do this: its radio is React state that never reaches the payload, and the stored terms are ambiguous by then — so #3894 refuses in the form. If both are wanted in one place later, the shared predicate `separateGenerationPriceMissing` in `@civitai/buzz` (added by #3894) is where they'd converge. Deliberately not depended on here, so this PR is not stacked on an open one.

`genMode` is `.optional()`: an in-flight page or a scripted POST keeps working, and the refine bites only when `separate` is explicitly claimed.

## Also in here

- **The 50 Buzz generation floor is now enforced server-side.** The per-version schema used bare `optionalBuzz`, so only the browser's `min` attribute stopped a crafted POST setting 1. The bulk schema already had it.
- **The schema moved to its own module.** `paid-access.ts` imports `$env/dynamic/private`, which the app's plain-node vitest project cannot resolve — and that failure reads as **zero collected tests**, not as a failure. It bit this PR: the first run of the new test file reported "27 passed" while the file never loaded. Same reason its one internal import is relative rather than `$lib`.

## Verification

- `apps/creator-studio` `typecheck` (svelte-check) — **8921 files, 0 errors**; the 3 warnings are pre-existing in `packages/civitai-ui`
- `eslint` on the changed files — clean
- `prettier --write` via the app's own Prettier 3 (it owns its formatting)
- `vitest --project app:creator-studio` — **35 tests, 0 failed, 0 failed suites** (was 27; the new file adds 8). Suite-collection count checked explicitly, for the reason above.

**Mutation-checked**: neutering the refine fails two named assertions —
`expected [] to include 'Enter a generation-only price, or choose "Same as the access price".'` — rather than timing out or passing quietly.

## Not fixed here

Creator Studio contains **zero** references to `poi` or `availability`: it will happily create a *new* paid gate or licensing fee on a POI or private model, and its fee write is direct Kysely SQL that never touches the main app. That is a bypass of the client-side control #3894 adds, not a parallel gap, and it is being addressed separately by moving the POI/private check server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)