### PR TITLE
fix(monetization): enforce the POI and private rules on the server, not only in the editor

### DIFF
--- a/apps/creator-studio/src/lib/server/monetization/licensing-fee.ts
+++ b/apps/creator-studio/src/lib/server/monetization/licensing-fee.ts
@@ -8,6 +8,7 @@ import {
   maxLicensingFee,
   maxLicensingFeeCeiling,
   raisesOverCap,
+  licensingFeeBlockedFor,
 } from '@civitai/buzz';
 import { cappedTier, type Membership } from '$lib/server/membership';
 import { FEE_IMAGE_OPTIONS } from '$lib/monetization/fee';
@@ -77,6 +78,7 @@ type OwnedVersion = {
   modelType: string;
   currentFee: number;
   affirmed: boolean;
+  poi: boolean;
 };
 
 // The user's own (non-deleted) versions among the given ids, with the fields the fee ops need: base model for
@@ -92,6 +94,7 @@ async function ownedVersions(userId: number, versionIds: number[]): Promise<Owne
       'Model.type as modelType',
       'ModelVersion.licensingFee as currentFee',
       'ModelVersion.meta as meta',
+      'Model.poi as poi',
     ])
     .where('ModelVersion.id', 'in', versionIds)
     .where('Model.userId', '=', userId)
@@ -103,6 +106,7 @@ async function ownedVersions(userId: number, versionIds: number[]): Promise<Owne
     modelType: r.modelType,
     currentFee: r.currentFee == null ? 0 : Number(r.currentFee),
     affirmed: hasCurrentRightsAffirmation(r.meta, userId),
+    poi: !!r.poi,
   }));
 }
 
@@ -186,6 +190,14 @@ export async function setLicensingFee(
       ok: false,
       status: 400,
       error: `"${owned[0].baseModel}" is non-commercial and can't be monetized.`,
+    };
+  // This write is direct SQL and never reaches the main app, so the model-level policy has to be applied
+  // here too or Creator Studio is simply a way around it.
+  if (normalized != null && licensingFeeBlockedFor({ poi: owned[0].poi }))
+    return {
+      ok: false,
+      status: 400,
+      error: "A model depicting a real person can't be monetized.",
     };
 
   // Anyone may charge; the tier caps how much, and it varies by model type (CU 868kj4q49).
@@ -301,6 +313,14 @@ export async function bulkSetLicensingFee(
         ok: false,
         status: 400,
         error: `${nonCommercial.length} selected version(s) use a non-commercial base model and can't be monetized — deselect them and try again.`,
+      };
+
+    const poi = owned.filter((v) => licensingFeeBlockedFor({ poi: v.poi }));
+    if (poi.length > 0)
+      return {
+        ok: false,
+        status: 400,
+        error: `${poi.length} selected version(s) depict a real person and can't be monetized — deselect them and try again.`,
       };
 
     // One fee across a mixed selection, so the STRICTEST applicable cap governs — a LoRA in the batch holds

--- a/packages/civitai-buzz/src/paid-access.test.ts
+++ b/packages/civitai-buzz/src/paid-access.test.ts
@@ -12,6 +12,8 @@ import {
   isPaidAccessActive,
   isTimedGateActive,
   paidGenerationGrant,
+  paidAccessBlockedFor,
+  licensingFeeBlockedFor,
   CAP_TIERS,
   nextCapTier,
   shouldUpsellCap,
@@ -104,6 +106,28 @@ describe('generationPrice — effective generation-only purchase price', () => {
   it('undefined when there is no paid generation tier (free or bundled)', () => {
     expect(generationPrice({ generation: { free: true } })).toBeUndefined();
     expect(generationPrice({ download: { price: 500 } })).toBeUndefined();
+  });
+});
+
+describe('model-level monetization policy', () => {
+  it('refuses a gate on a POI model, and on a private one', () => {
+    expect(paidAccessBlockedFor({ poi: true, availability: 'Public' })).toBe(true);
+    expect(paidAccessBlockedFor({ poi: false, availability: 'Private' })).toBe(true);
+  });
+  it('allows a gate on an ordinary public model', () => {
+    expect(paidAccessBlockedFor({ poi: false, availability: 'Public' })).toBe(false);
+  });
+  // The asymmetry is deliberate: a private model has no audience to sell access to, but its fee is for
+  // when it is published. A POI model earns nothing either way.
+  it('refuses a licensing fee on a POI model but keeps it on a private one', () => {
+    expect(licensingFeeBlockedFor({ poi: true, availability: 'Public' })).toBe(true);
+    expect(licensingFeeBlockedFor({ poi: false, availability: 'Private' })).toBe(false);
+  });
+  // Rows arrive from two apps and two ORMs; an absent column must not read as permission granted by
+  // accident, nor as a block that strands every save.
+  it('treats missing fields as unblocked rather than guessing', () => {
+    expect(paidAccessBlockedFor({})).toBe(false);
+    expect(licensingFeeBlockedFor({ poi: null })).toBe(false);
   });
 });
 

--- a/packages/civitai-buzz/src/paid-access.ts
+++ b/packages/civitai-buzz/src/paid-access.ts
@@ -69,6 +69,22 @@ export const generationPrice = (terms: ModelVersionTerms): number | undefined =>
   return paid.price ?? (terms.download?.price as number | undefined);
 };
 /**
+ * Model-level monetization policy, shared so the main app, its REST endpoint and Creator Studio can't
+ * disagree about who may charge. A model depicting a real person may not be sold at all; a private model
+ * has no audience to sell to, but may still carry a per-generation fee for when it is published.
+ *
+ * `availability` is the Prisma enum as a string, so a caller can pass a row straight from either app.
+ */
+export type MonetizationSubject = { poi?: boolean | null; availability?: string | null };
+
+/** A paid-access gate is refused for a POI model and for a private one. */
+export const paidAccessBlockedFor = (model: MonetizationSubject): boolean =>
+  !!model.poi || model.availability === 'Private';
+
+/** A per-generation licensing fee is refused for a POI model. Private models keep theirs. */
+export const licensingFeeBlockedFor = (model: MonetizationSubject): boolean => !!model.poi;
+
+/**
  * Build a ModelVersion's `terms` from an editor's pricing. "Price for access" (accessPrice) is the one
  * required charge; for a `genOnly` version (no download tier) it IS the generation price, otherwise it's
  * the download bundle price and `generationPrice` is an optional cheaper generation-only tier. The

--- a/src/pages/api/v1/model-versions/early-access.ts
+++ b/src/pages/api/v1/model-versions/early-access.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { paidAccessBlockedFor } from '@civitai/buzz';
 import { updateModelVersionPaidAccessSchema } from '~/server/schema/model-version.schema';
 import {
   assertUserEarlyAccessLimits,
@@ -37,14 +38,28 @@ export default AuthedEndpoint(
     });
     if (!version) return res.status(404).json({ error: 'Model version not found' });
 
-    if (!user.isModerator) {
-      const model = await getModel({ id: version.modelId, select: { userId: true } });
-      if (model?.userId !== user.id) {
-        return res.status(403).json({ error: 'You do not own this model version' });
-      }
+    const model = await getModel({
+      id: version.modelId,
+      select: { userId: true, poi: true, availability: true },
+    });
+
+    if (!user.isModerator && model?.userId !== user.id) {
+      return res.status(403).json({ error: 'You do not own this model version' });
     }
 
     const { paidAccess } = input;
+
+    // Refused rather than stripped: this caller is explicitly asking to CREATE a gate, so silently
+    // writing nothing would report success for something that did not happen. Moderators included —
+    // the rule is about the model, not about who is asking. The tRPC upsert strips instead, because
+    // there an unrelated edit must not be blocked by a charge the creator can no longer see.
+    if (paidAccess && model && paidAccessBlockedFor(model)) {
+      return res.status(400).json({
+        error: model.poi
+          ? "A model depicting a real person can't have paid access."
+          : "A private model can't have paid access.",
+      });
+    }
 
     // Permanent access is reachable only from the Creator Studio — require the shared token. The tier caps
     // themselves are enforced below (assertPaidAccessCaps), not by whoever is calling.

--- a/src/server/services/__tests__/model-monetization-policy.test.ts
+++ b/src/server/services/__tests__/model-monetization-policy.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { applyModelMonetizationPolicy } from '~/server/services/model-monetization-policy';
 
@@ -79,5 +81,30 @@ describe('applyModelMonetizationPolicy', () => {
   it('does not ask to clear the fee columns on a model that may charge', () => {
     expect(applyModelMonetizationPolicy(ordinary, {}).clearFee).toBe(false);
     expect(applyModelMonetizationPolicy(priv, {}).clearFee).toBe(false);
+  });
+});
+
+// The helper being right protects nothing if the write doesn't use it. Both shipped bugs were exactly
+// that — the policy was correct and the call site read a pre-strip copy — and no test in this repo
+// exercises `upsertModelVersion`, so a revert of either line stays green above. Structural, and it fails
+// on the omission itself; the same guard the Creator Studio bulk action needed for the same reason.
+describe('upsertModelVersion consumes the policy result', () => {
+  const source = () =>
+    readFileSync(
+      fileURLToPath(new URL('../model-version.service.ts', import.meta.url)),
+      'utf8'
+    ).slice(0, 40_000);
+
+  it.each([
+    // B-2: the goal is written on its own arm, so a gate-only strip leaves it funding nothing.
+    ['donationGoal = policy.donationGoal', 'the donation goal must leave with the gate'],
+    // B-1: reading the pre-strip fee here made every stripped version demand an affirmation it cannot give.
+    ['policy.feeMonetizes', 'the affirmation gate must read the post-strip fee'],
+  ])('uses `%s` — %s', (needle) => {
+    expect(source()).toContain(needle);
+  });
+
+  it('no longer feeds the affirmation gate from the pre-strip fee', () => {
+    expect(source()).not.toContain('monetizes: hasLicensingFee');
   });
 });

--- a/src/server/services/__tests__/model-monetization-policy.test.ts
+++ b/src/server/services/__tests__/model-monetization-policy.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { applyModelMonetizationPolicy } from '~/server/services/model-monetization-policy';
+
+const gate = { permanent: true as const, terms: { download: { price: 5000 } } };
+const goal = { amount: 10_000 };
+const monetization = { type: 'PaidAccess' };
+
+const poi = { poi: true, availability: 'Public' };
+const priv = { poi: false, availability: 'Private' };
+const ordinary = { poi: false, availability: 'Public' };
+
+describe('applyModelMonetizationPolicy', () => {
+  it('leaves an ordinary public model alone', () => {
+    const out = applyModelMonetizationPolicy(ordinary, {
+      paidAccess: gate,
+      donationGoal: goal,
+      monetization,
+      licensingFee: 8,
+    });
+    expect(out).toMatchObject({
+      paidAccess: gate,
+      donationGoal: goal,
+      licensingFee: 8,
+      clearFee: false,
+      feeMonetizes: true,
+    });
+  });
+
+  it('strips everything from a POI model', () => {
+    const out = applyModelMonetizationPolicy(poi, {
+      paidAccess: gate,
+      donationGoal: goal,
+      monetization,
+      licensingFee: 8,
+    });
+    expect(out.paidAccess).toBeNull();
+    expect(out.donationGoal).toBeNull();
+    expect(out.monetization).toBeNull();
+    expect(out.licensingFee).toBeNull();
+    expect(out.clearFee).toBe(true);
+  });
+
+  // The goal is written on its own arm of the write, so dropping only the gate leaves a Buzz-collecting
+  // surface funding the unlock of something that no longer exists.
+  it('takes the donation goal with the gate on a private model, and keeps the fee', () => {
+    const out = applyModelMonetizationPolicy(priv, {
+      paidAccess: gate,
+      donationGoal: goal,
+      licensingFee: 8,
+    });
+    expect(out.paidAccess).toBeNull();
+    expect(out.donationGoal).toBeNull();
+    expect(out.licensingFee).toBe(8);
+    expect(out.feeMonetizes).toBe(true);
+  });
+
+  // The blocker this helper exists for: the rights-affirmation gate reads `monetizes`, and a version
+  // cannot affirm its way out of a charge that is being REMOVED. Reading the pre-strip fee here made
+  // every POI version with a stored fee and no current affirmation unsavable — for a fee field the
+  // editor no longer renders.
+  it('reports a stripped fee as no longer monetizing', () => {
+    const out = applyModelMonetizationPolicy(poi, { licensingFee: 8 });
+    expect(out.feeMonetizes).toBe(false);
+  });
+
+  it('still reports a surviving fee as monetizing', () => {
+    expect(applyModelMonetizationPolicy(ordinary, { licensingFee: 8 }).feeMonetizes).toBe(true);
+    expect(applyModelMonetizationPolicy(ordinary, { licensingFee: 0 }).feeMonetizes).toBe(false);
+  });
+
+  // A partial write (a moderator review action) sends no fee at all. The columns must still be cleared on
+  // a POI model, which is why `clearFee` is separate from the returned value.
+  it('asks for the fee columns to be cleared even when no fee was submitted', () => {
+    const out = applyModelMonetizationPolicy(poi, { paidAccess: gate });
+    expect(out.clearFee).toBe(true);
+    expect(out.feeMonetizes).toBe(false);
+  });
+
+  it('does not ask to clear the fee columns on a model that may charge', () => {
+    expect(applyModelMonetizationPolicy(ordinary, {}).clearFee).toBe(false);
+    expect(applyModelMonetizationPolicy(priv, {}).clearFee).toBe(false);
+  });
+});

--- a/src/server/services/model-monetization-policy.ts
+++ b/src/server/services/model-monetization-policy.ts
@@ -1,0 +1,56 @@
+import {
+  licensingFeeBlockedFor,
+  paidAccessBlockedFor,
+  type MonetizationSubject,
+} from '@civitai/buzz';
+
+/** Everything one version write can charge for. Shapes are the caller's; this only ever nulls them. */
+export type VersionCharges<TGate, TGoal, TMonetization> = {
+  paidAccess?: TGate | null;
+  donationGoal?: TGoal | null;
+  monetization?: TMonetization | null;
+  licensingFee?: number | null;
+};
+
+/**
+ * Apply the model-level monetization rules to one version write, returning what may actually be saved.
+ *
+ * Separate from the write itself so the two orderings that matter are testable: a stripped charge must
+ * not still count as monetizing (the rights affirmation is keyed to that, and demanding an affirmation
+ * for a charge that is being removed makes the version unsavable), and a donation goal must leave with
+ * the gate it funds rather than outliving it.
+ */
+export function applyModelMonetizationPolicy<TGate, TGoal, TMonetization>(
+  model: MonetizationSubject,
+  charges: VersionCharges<TGate, TGoal, TMonetization>
+): {
+  paidAccess: TGate | null | undefined;
+  donationGoal: TGoal | null | undefined;
+  monetization: TMonetization | null | undefined;
+  licensingFee: number | null | undefined;
+  /** True when the fee columns must be written as NULL, including when the caller sent no fee at all. */
+  clearFee: boolean;
+  /**
+   * Whether a per-generation fee survives the rules. The caller ORs this with whether the surviving gate
+   * charges; what matters here is that a stripped fee stops counting, because the rights-affirmation gate
+   * reads it and a version cannot affirm its way out of a charge that is being removed.
+   */
+  feeMonetizes: boolean;
+} {
+  const gateBlocked = paidAccessBlockedFor(model);
+  const feeBlocked = licensingFeeBlockedFor(model);
+
+  const paidAccess = gateBlocked ? null : charges.paidAccess;
+  const donationGoal = gateBlocked ? null : charges.donationGoal;
+  const monetization = feeBlocked ? null : charges.monetization;
+  const licensingFee = feeBlocked ? null : charges.licensingFee;
+
+  return {
+    paidAccess,
+    donationGoal,
+    monetization,
+    licensingFee,
+    clearFee: feeBlocked,
+    feeMonetizes: licensingFee != null && licensingFee > 0,
+  };
+}

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -94,12 +94,11 @@ import {
   generationPrice,
   isPaidAccessActive,
   isTimedGateActive,
-  licensingFeeBlockedFor,
   migrateTermsForUsageControl,
-  paidAccessBlockedFor,
   paidAccessCharges,
   paidGenerationGrant,
 } from '@civitai/buzz';
+import { applyModelMonetizationPolicy } from '~/server/services/model-monetization-policy';
 import { resolveRightsAffirmation } from '~/server/services/monetization-rights.service';
 import { throwOnBlockedLinkDomain } from '~/server/services/blocklist.service';
 import { findOfficialFileByHash } from '~/server/services/model-file.service';
@@ -517,6 +516,9 @@ export const upsertModelVersion = async ({
   // `undefined` means the caller didn't send a fee at all — requestReviewHandler / declineReviewHandler
   // pass a partial version — so only an explicitly supplied fee may rewrite fee state below. Treating
   // absent as cleared would wipe a creator's fee when a moderator declines a review.
+  // Note the model-level strip below bypasses this: on a POI model the fee columns are cleared even when
+  // the caller sent no fee at all, which is how a partial write (a moderator review action) stops
+  // carrying one forward.
   const feeProvided = data.licensingFee !== undefined;
   const hasLicensingFee = data.licensingFee != null && data.licensingFee > 0;
 
@@ -540,12 +542,19 @@ export const upsertModelVersion = async ({
   // each of them unsavable until someone cleared it by hand, which is the "blocked version saves
   // entirely" shape hot-fixed in 82f64846ba. Callers that explicitly ASK to create a charge (the REST
   // endpoint, Creator Studio) refuse instead, where there is nothing to strand.
-  if (paidAccessBlockedFor(model)) paidAccess = null;
-  if (licensingFeeBlockedFor(model)) {
+  const policy = applyModelMonetizationPolicy(model, {
+    paidAccess,
+    donationGoal,
+    monetization,
+    licensingFee: data.licensingFee,
+  });
+  paidAccess = policy.paidAccess;
+  donationGoal = policy.donationGoal;
+  monetization = policy.monetization;
+  if (policy.clearFee) {
     data.licensingFee = null;
     data.licensingFeeType = null;
     data.licensingFeeSettlementCurrency = null;
-    monetization = null;
   }
 
   // Validate NSFW + restricted base model combination
@@ -612,7 +621,10 @@ export const upsertModelVersion = async ({
     userId: actorUserId ?? model.userId,
     ownerId: model.userId,
     versionId: createsNewVersion ? undefined : id,
-    monetizes: hasLicensingFee || paidAccessCharges(paidAccess),
+    // Post-policy, not `hasLicensingFee` above it: a POI version whose stored fee was just stripped
+    // monetizes nothing, and asking it to affirm rights it no longer exercises makes the save impossible
+    // — for a fee field the editor no longer shows.
+    monetizes: policy.feeMonetizes || paidAccessCharges(paidAccess),
     rightsAffirmed,
     isModerator,
   });

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -94,7 +94,9 @@ import {
   generationPrice,
   isPaidAccessActive,
   isTimedGateActive,
+  licensingFeeBlockedFor,
   migrateTermsForUsageControl,
+  paidAccessBlockedFor,
   paidAccessCharges,
   paidGenerationGrant,
 } from '@civitai/buzz';
@@ -529,8 +531,22 @@ export const upsertModelVersion = async ({
   // Get model information to check NSFW + restricted base model combination
   const model = await dbWrite.model.findUniqueOrThrow({
     where: { id: data.modelId },
-    select: { nsfw: true, meta: true, userId: true },
+    select: { nsfw: true, meta: true, userId: true, poi: true, availability: true },
   });
+
+  // Model-level monetization policy, enforced here because the editors are only the explanation. A POI
+  // model earns nothing; a private model can't be sold. STRIPPED rather than rejected: every edit
+  // resubmits the whole version, and 207 POI versions already carry a stored fee — rejecting would make
+  // each of them unsavable until someone cleared it by hand, which is the "blocked version saves
+  // entirely" shape hot-fixed in 82f64846ba. Callers that explicitly ASK to create a charge (the REST
+  // endpoint, Creator Studio) refuse instead, where there is nothing to strand.
+  if (paidAccessBlockedFor(model)) paidAccess = null;
+  if (licensingFeeBlockedFor(model)) {
+    data.licensingFee = null;
+    data.licensingFeeType = null;
+    data.licensingFeeSettlementCurrency = null;
+    monetization = null;
+  }
 
   // Validate NSFW + restricted base model combination
   if (


### PR DESCRIPTION
Third of three. #3894 makes the main app's version editor honest about POI; #3902 fixes Creator Studio's blank generation price. This one moves the POI/private rule itself to where it can't be walked around.

## The problem

The rule "a model depicting a real person can't be sold" lived in **one boolean in one React component**. An audit of both write paths found:

- No server-side check anywhere. `assertPaidAccessCaps`, `assertUserEarlyAccessLimits`, `assertPaidAccessInput`, the tRPC licensing-fee block and the REST early-access endpoint never read `Model.poi` or `Model.availability`.
- `POST /api/v1/model-versions/early-access` with a session cookie sets a gate on a POI or private model.
- Creator Studio contains **zero** references to `poi` or `availability`. It lists and edits those versions, and its licensing-fee write is **direct Kysely SQL** that never reaches the main app — so nothing the main app does can cover it.
- Nothing clears an existing gate or fee when a moderator flips `poi` to true, which is how 12 gates and 207 fees came to exist in prod.

A second client that renders no such control isn't a parallel gap; it's a bypass of the only control there was.

## The rule, in one place

Two predicates in `@civitai/buzz`, so the three writers can't drift:

- `paidAccessBlockedFor` — POI **or** private
- `licensingFeeBlockedFor` — POI only

The asymmetry is deliberate: a private model has no audience to sell *access* to, but its per-generation fee is for when it's published. This also matches what #3894 shows creators — private models keep their fee editor, POI models lose everything.

## Strip vs refuse, chosen per caller

| Caller | Behaviour | Why |
|---|---|---|
| `upsertModelVersion` (tRPC) | **strips** | Every edit resubmits the whole version and 207 POI versions already carry a fee. Rejecting makes each unsavable until cleared by hand — the "blocked version saves entirely" shape hot-fixed in 82f64846ba. The editor already explains it. |
| `/api/v1/model-versions/early-access` | **400** | Explicitly asks to create a gate. Writing nothing while returning success would report something that didn't happen. Moderators included: the rule is about the model, not the caller. |
| Creator Studio `setLicensingFee` / `bulkSetLicensingFee` | **400** | Same reason, and bulk reports which selected versions to deselect, matching the existing non-commercial refusal beside it. |

## Verification

- `pnpm run typecheck` — 0 errors
- `apps/creator-studio` svelte-check — 8919 files, **0 errors** (3 warnings pre-existing in `packages/civitai-ui`)
- `eslint` on changed files — every warning reproduces identically on the clean base (checked by stashing)
- `@civitai/buzz` — 74 tests pass (4 new)
- `app:creator-studio` — 27 tests, 0 failed suites
- Related main-app suites + the submodule canary — **359 collected**, all passing

**Mutation-checked**: neutering `paidAccessBlockedFor` fails `expected false to be true` on the named case.

## What this does NOT do

- **No backfill.** The 12 existing gates and 207 existing fees on POI models stay until each version's next save (which now strips them). Clearing them deliberately is a separate decision — say the word and it's a migration plus a one-shot script.
- `poi` flipping to true still doesn't clear charges at the moment it flips; it only stops them being re-asserted or created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)