### PR TITLE
fix(apps): gate the /apps sub-nav on the shared store-visibility predicate

### DIFF
--- a/src/components/Apps/AppListingsMarketplaceBody.storeGate.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.storeGate.browser.test.tsx
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { useRouter } from 'next/router';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import type * as TrpcMod from '~/utils/trpc';
+import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema';
+
+/**
+ * 🔒 `AppListingsMarketplaceBody` — the STORE-VISIBILITY gate on the grid query.
+ *
+ * WHY A DEDICATED FILE: the shared-predicate extraction converted six sites, but
+ * an adversarial audit reverted four of them to `!!features.appBlocks` and the
+ * entire existing suite stayed green — the mutant survived. The call-site ledger
+ * (`__tests__/appsStoreAccessCallSites.test.ts`) now pins all six STRUCTURALLY,
+ * but a structural check cannot see a call passed the wrong argument. This file
+ * is the BEHAVIOURAL half for the busiest of the four: it drives the flag matrix
+ * and observes what the component actually does with `enabled`.
+ *
+ * Unlike the sibling `AppListingsMarketplaceBody.browser.test.tsx` (which pins
+ * `useFeatureFlags` to a constant and ignores query options), this file makes the
+ * flags a VARIABLE and captures the `enabled` option — the two things the gate is
+ * made of.
+ *
+ * 🔴 The gate here mirrors the SERVER read gate (`enforceAppListingsReadFlag` →
+ * `isAppListingsEnabled`, which ORs both flags), which is why this query DOES
+ * widen with the store — in deliberate contrast to `blocks.getNavSummary`, whose
+ * `enabled` stays on `appBlocks` alone because ITS proc gates on
+ * `enforceAppBlocksFlag`. See `AppsSubNav.storeGate.browser.test.tsx`.
+ */
+
+function makeCard(id: string, name: string): ListingCard {
+  return {
+    id,
+    slug: `slug-${id}`,
+    kind: 'onsite',
+    name,
+    tagline: 'tag',
+    category: null,
+    contentRating: null,
+    iconUrl: null,
+    coverUrl: null,
+    creator: null,
+    recommend: { recommendedCount: 0, notRecommendedCount: 0, recommendPct: null },
+    reviewCount: 0,
+    kindData: {
+      kind: 'onsite',
+      appBlockId: `blk-${id}`,
+      hasPage: false,
+      liveUrl: `https://slug-${id}.civit.ai`,
+    },
+  };
+}
+
+const mocks = vi.hoisted(() => ({
+  flags: {} as Record<string, boolean>,
+  items: [] as ListingCard[],
+  /** Every `enabled` value the grid query was called with, in order. */
+  enabledSeen: [] as unknown[],
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+vi.mock('~/providers/FeatureFlagsProvider', () => ({ useFeatureFlags: () => mocks.flags }));
+vi.mock('~/providers/IsClientProvider', () => ({ useIsClient: () => true }));
+vi.mock('~/hooks/useIsMobile', () => ({ useIsMobile: () => false, isMobileDevice: () => false }));
+
+// Spread the REAL module and override only `trpc` (local-rules/no-wholesale-module-
+// mock): a hand-written replacement silently breaks every importer the day
+// '~/utils/trpc' grows an export this factory omits — the whole FILE then fails to
+// load with 0 tests collected and no failing assertion.
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcMod>()),
+  trpc: {
+    appListings: {
+      listAvailable: {
+        useInfiniteQuery: (_input: Record<string, unknown>, opts?: { enabled?: boolean }) => {
+          mocks.enabledSeen.push(opts?.enabled);
+          // Honour `enabled` like the real hook: a disabled query resolves no data,
+          // so a gated-out viewer gets an empty grid rather than listings.
+          return {
+            data: opts?.enabled
+              ? { pages: [{ items: mocks.items, nextCursor: undefined }] }
+              : undefined,
+            isLoading: false,
+            isFetchingNextPage: false,
+            fetchNextPage: vi.fn(),
+            hasNextPage: false,
+          };
+        },
+      },
+    },
+  },
+}));
+
+const { AppListingsMarketplaceBody } = await import('./AppListingsMarketplaceBody');
+
+// Not a real hook: the scaffold mocks `next/router` with `useRouter: () => router`,
+// a plain function returning a singleton, so module-scope is fine (and is the
+// established idiom — a per-file `vi.mock` silently loses to the setup-file mock).
+// eslint-disable-next-line react-hooks/rules-of-hooks
+const router = useRouter();
+
+/**
+ * 🔴 RENDER BARRIER — required before any "did not render" assertion.
+ *
+ * React 18 commits on a LATER task, so a synchronous absence check straight after
+ * `renderWithProviders` reads an empty container and passes regardless of what the
+ * component did. Measured on the sibling sub-nav suite: with the barrier removed,
+ * the absence tests pass in ~4ms even with the gate neutered.
+ */
+const RENDER_BARRIER = 'render-barrier';
+const RenderBarrier = () => <div data-testid={RENDER_BARRIER} />;
+
+async function renderBody() {
+  renderWithProviders(
+    <>
+      <RenderBarrier />
+      <AppListingsMarketplaceBody />
+    </>
+  );
+  await expect.element(page.getByTestId(RENDER_BARRIER)).toBeInTheDocument();
+}
+
+beforeEach(() => {
+  mocks.flags = {};
+  mocks.items = [makeCard('a', 'Alpha App'), makeCard('b', 'Bravo App')];
+  mocks.enabledSeen = [];
+  // A FRESH object each test: `useZodRouteParams` memoises on the `query` reference.
+  router.query = {};
+});
+
+describe('AppListingsMarketplaceBody — the grid query uses the shared store predicate', () => {
+  test('🔴 appListings ONLY (appBlocks OFF) → the grid query is ENABLED and listings render', async () => {
+    // The exact mutant that survived: reverting this site to `!!features.appBlocks`
+    // disables the query for this cohort and fails HERE, on these assertions.
+    mocks.flags = { appListings: true, appBlocks: false };
+    await renderBody();
+
+    await expect.element(page.getByText('Alpha App')).toBeInTheDocument();
+    expect(mocks.enabledSeen.some((e) => e === true)).toBe(true);
+    expect(mocks.enabledSeen.every((e) => e !== false)).toBe(true);
+  });
+
+  test('appBlocks ONLY (appListings OFF) → enabled (the OR-fallback cohort)', async () => {
+    mocks.flags = { appListings: false, appBlocks: true };
+    await renderBody();
+
+    await expect.element(page.getByText('Alpha App')).toBeInTheDocument();
+    expect(mocks.enabledSeen.some((e) => e === true)).toBe(true);
+  });
+
+  test('BOTH flags true → enabled (today’s live cohort, unchanged)', async () => {
+    mocks.flags = { appListings: true, appBlocks: true };
+    await renderBody();
+
+    await expect.element(page.getByText('Bravo App')).toBeInTheDocument();
+    expect(mocks.enabledSeen.some((e) => e === true)).toBe(true);
+  });
+
+  test('NEITHER flag → the query is DISABLED and no listing renders', async () => {
+    mocks.flags = { appListings: false, appBlocks: false };
+    await renderBody(); // barrier awaited inside — absence below is a real observation
+
+    expect(mocks.enabledSeen.length).toBeGreaterThan(0); // the hook did run
+    expect(mocks.enabledSeen.every((e) => e === false)).toBe(true);
+    expect(page.getByText('Alpha App').elements()).toHaveLength(0);
+    expect(page.getByText('Bravo App').elements()).toHaveLength(0);
+  });
+
+  test('flags ABSENT entirely (Flipt down) → disabled (fails closed)', async () => {
+    mocks.flags = {};
+    await renderBody();
+
+    expect(mocks.enabledSeen.every((e) => e === false)).toBe(true);
+    expect(page.getByText('Alpha App').elements()).toHaveLength(0);
+  });
+
+  // 🔴 POSITIVE CONTROL for the two absence tests above: if `getByText` were
+  // wired to nothing it would report zero for every input, and both would be
+  // vacuously green.
+  test('POSITIVE CONTROL: the same reader DOES find the card when the gate opens', async () => {
+    mocks.flags = { appListings: true, appBlocks: false };
+    await renderBody();
+    await expect.element(page.getByText('Alpha App')).toBeInTheDocument();
+    expect(page.getByText('Alpha App').elements().length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/Apps/AppListingsMarketplaceBody.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.tsx
@@ -21,6 +21,7 @@ import {
 } from '~/components/Apps/recentlyOpenedAppsStore';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import type { ListingCard, ListingSort } from '~/server/schema/blocks/app-listing-read.schema';
+import { hasAppsStoreAccess } from '~/shared/utils/app-blocks-access';
 import { trpc } from '~/utils/trpc';
 
 /**
@@ -214,11 +215,12 @@ export function AppListingsMarketplaceBody() {
         limit: 24,
       },
       {
-        // W13 (PR-W1a/D8): store-visibility gate = dedicated `appListings`
-        // OR-falling-back to `appBlocks`. Mirrors the server read gate
-        // (`enforceAppListingsReadFlag` → `isAppListingsEnabled`). Zero behavior
-        // change today (the `app-listings` flag doesn't exist yet).
-        enabled: !!(features.appListings || features.appBlocks),
+        // W13 (PR-W1a/D8): store-visibility gate = the SHARED `hasAppsStoreAccess`
+        // predicate (dedicated `appListings` OR-falling-back to `appBlocks`).
+        // Mirrors the server read gate (`enforceAppListingsReadFlag` →
+        // `isAppListingsEnabled`), which is why this query — unlike
+        // `blocks.getNavSummary` — DOES widen with the store.
+        enabled: hasAppsStoreAccess(features),
         getNextPageParam: (lastPage) => lastPage.nextCursor,
       }
     );

--- a/src/components/Apps/AppsPageLayout.tsx
+++ b/src/components/Apps/AppsPageLayout.tsx
@@ -22,9 +22,16 @@ import { AppsSubNav } from '~/components/Apps/AppsSubNav';
  * subtitle and right-aligned header actions become props so the header geometry
  * is uniform; only the content slot differs.
  *
- * Flag-gating (`features.appBlocks`) + any per-page access redirect stay on the
- * page (`getServerSideProps` / the in-component `NotFound` guard) — this layout
- * is presentational chrome only and assumes the page already passed its gate.
+ * Flag-gating + any per-page access redirect stay on the page
+ * (`getServerSideProps` / the in-component `NotFound` guard) — this layout is
+ * presentational chrome only and assumes the page already passed its gate.
+ *
+ * Which flag depends on the surface, and the two are NOT interchangeable: the
+ * STORE surfaces (`/apps`, `/apps/store-preview/<slug>`) gate on the shared
+ * `hasAppsStoreAccess` predicate (`appListings || appBlocks`), while the block-
+ * RUNTIME surfaces (`/apps/installed`, `/apps/review`, `/apps/my-submissions`,
+ * `/apps/revenue`) gate on `appBlocks` alone because they need the runtime, not
+ * just the catalog.
  */
 export function AppsPageLayout({
   title,

--- a/src/components/Apps/AppsSubNav.storeGate.browser.test.tsx
+++ b/src/components/Apps/AppsSubNav.storeGate.browser.test.tsx
@@ -1,0 +1,286 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+// Type-only namespace import (NOT `typeof import('...')`, which
+// @typescript-eslint/consistent-type-imports rejects) so the spread below keeps the
+// real module's type.
+import type * as TrpcMod from '~/utils/trpc';
+
+/**
+ * 🔒 `AppsSubNav` — the STORE-VISIBILITY gate, aligned with the page it sits on.
+ *
+ * THE DEFECT THIS PINS: the container's render gate read `features.appBlocks`
+ * ALONE, while the canonical `/apps` gate (`resolveAppsPageAccess`, enforced in
+ * `getServerSideProps`) grants on `appListings || appBlocks`. A cohort holding
+ * `app-listings` WITHOUT `app-blocks-enabled` would therefore load `/apps`
+ * successfully and get NO sub-navigation at all. Both gates now call the ONE
+ * shared predicate `hasAppsStoreAccess`.
+ *
+ * Not reachable in production today — the current tester cohort holds BOTH flags,
+ * so the two predicates agree. `app-listings` exists precisely so the catalog can
+ * widen independently of the held block runtime, which is when they stop agreeing.
+ *
+ * ── WHY THIS FILE MOCKS `useQuery` DIFFERENTLY FROM THE HYDRATION SUITE ────────
+ * The sibling `AppsSubNav.hydration.browser.test.tsx` returns `mocks.navSummary`
+ * unconditionally, which is right for what it tests (the `useIsClient` deferral).
+ * Here the whole question is which viewer gets which tabs, and the `enabled:` flag
+ * on `blocks.getNavSummary` is load-bearing for that answer — so this mock HONOURS
+ * `enabled`, exactly like the real hook. That makes the tests below faithful to
+ * production AND makes the `enabled` predicate itself observable (see the last
+ * describe block, which pins the deliberate decision to leave it on `appBlocks`).
+ */
+
+const ALL_TRUE_SUMMARY = {
+  hasInstalls: true,
+  hasSubmissions: true,
+  hasApprovedApps: true,
+  isReviewer: true,
+};
+
+const mocks = vi.hoisted(() => ({
+  isClient: true,
+  navSummary: undefined as undefined | typeof ALL_TRUE_SUMMARY,
+  flags: {} as Record<string, boolean>,
+  user: null as null | { id: number; username: string; isModerator?: boolean },
+  /** Every `enabled` value `getNavSummary.useQuery` was called with, in order. */
+  navSummaryEnabled: [] as unknown[],
+}));
+
+vi.mock('~/providers/IsClientProvider', () => ({
+  useIsClient: () => mocks.isClient,
+}));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => mocks.flags,
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => mocks.user,
+}));
+
+// Spread the REAL module and override only `trpc` (local-rules/no-wholesale-module-
+// mock): a hand-written replacement silently breaks every importer the day
+// '~/utils/trpc' grows an export this factory omits — the whole FILE then fails to
+// load with 0 tests collected and no failing assertion.
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcMod>()),
+  trpc: {
+    blocks: {
+      getNavSummary: {
+        useQuery: (_input: unknown, opts?: { enabled?: boolean }) => {
+          mocks.navSummaryEnabled.push(opts?.enabled);
+          // Honour `enabled` like the real hook: a disabled query never resolves,
+          // so `data` stays undefined and the container falls back to EMPTY_SUMMARY.
+          return { data: opts?.enabled ? mocks.navSummary : undefined };
+        },
+      },
+    },
+  },
+}));
+
+const { AppsSubNav } = await import('./AppsSubNav');
+
+function tab(name: string) {
+  return page.getByRole('tab', { name });
+}
+
+/** The tab labels currently in the document, in DOM order. */
+function renderedTabs(): string[] {
+  return page
+    .getByRole('tab')
+    .elements()
+    .map((el) => (el.textContent ?? '').trim());
+}
+
+/**
+ * 🔴 RENDER BARRIER — required before EVERY "renders nothing" assertion here.
+ *
+ * `render()` commits through a React 18 concurrent root on a LATER task, so a
+ * synchronous `expect(renderedTabs()).toEqual([])` straight after
+ * `renderWithProviders` reads an EMPTY container and passes no matter what the
+ * component does — structurally unfailable. Render this sentinel alongside the
+ * component and AWAIT it; the commit has then happened and "absent" is a real
+ * observation.
+ *
+ * MEASURED, not assumed. Neutering the gate to a constant `true`:
+ *   - WITH the awaited barrier → both "renders nothing" tests below FAIL. ✅
+ *   - WITHOUT it (the `await expect.element(...)` line deleted) → both PASS,
+ *     i.e. structurally unfailable.
+ * Do not remove it, and do not add an absence assertion that does not sit behind
+ * `renderSubNav()`.
+ */
+const RENDER_BARRIER = 'render-barrier';
+const RenderBarrier = () => <div data-testid={RENDER_BARRIER} />;
+
+async function renderSubNav() {
+  renderWithProviders(
+    <>
+      <RenderBarrier />
+      <AppsSubNav />
+    </>
+  );
+  await expect.element(page.getByTestId(RENDER_BARRIER)).toBeInTheDocument();
+}
+
+beforeEach(() => {
+  mocks.isClient = true; // post-mount, so the full tab set is observable
+  mocks.navSummary = { ...ALL_TRUE_SUMMARY };
+  mocks.flags = {};
+  // An AUTHOR by capability (not a mod), so `Create` qualifies and the bar can
+  // clear the 2-tab floor on store-visibility alone — without it, an
+  // `appListings`-only viewer qualifies for Marketplace ONLY and the <2 collapse
+  // would hide the bar for a reason that has nothing to do with the gate under test.
+  mocks.user = { id: 7, username: 'author', isModerator: false };
+  mocks.navSummaryEnabled = [];
+});
+
+describe('AppsSubNav — store-visibility gate matches resolveAppsPageAccess', () => {
+  test('🔴 appListings ONLY (appBlocks OFF) → the sub-nav RENDERS (the broken case)', async () => {
+    // The cohort the canonical gate admits to /apps but the old sub-nav gate turned
+    // away. Reverting the container to `if (!features.appBlocks) return null` fails
+    // HERE, on this assertion.
+    mocks.flags = { appListings: true, appBlocks: false, appBlocksAuthor: true };
+    await renderSubNav();
+
+    await expect
+      .element(page.getByRole('navigation', { name: 'App sections' }))
+      .toBeInTheDocument();
+    await expect.element(tab('Marketplace')).toBeInTheDocument();
+    await expect.element(tab('Create')).toBeInTheDocument();
+  });
+
+  test('appBlocks ONLY (appListings OFF) → still renders (the OR-fallback cohort)', async () => {
+    mocks.flags = { appListings: false, appBlocks: true, appBlocksAuthor: true };
+    await renderSubNav();
+
+    await expect
+      .element(page.getByRole('navigation', { name: 'App sections' }))
+      .toBeInTheDocument();
+    await expect.element(tab('Marketplace')).toBeInTheDocument();
+    await expect.element(tab('Create')).toBeInTheDocument();
+  });
+
+  test('BOTH flags true → renders (today’s live cohort — unchanged behaviour)', async () => {
+    mocks.flags = { appListings: true, appBlocks: true, appBlocksAuthor: true };
+    await renderSubNav();
+
+    await expect
+      .element(page.getByRole('navigation', { name: 'App sections' }))
+      .toBeInTheDocument();
+    // With `appBlocks` on, the summary query is enabled, so the conditional tabs
+    // resolve too — the full bar today's testers actually see.
+    await expect.element(tab('Review')).toBeInTheDocument();
+    expect(renderedTabs()).toEqual([
+      'Marketplace',
+      'Create',
+      'Installed',
+      'My submissions',
+      'Revenue',
+      'Review',
+    ]);
+  });
+
+  test('NEITHER flag → renders NOTHING (the gate is still a gate)', async () => {
+    mocks.flags = { appListings: false, appBlocks: false, appBlocksAuthor: true };
+    await renderSubNav(); // barrier awaited inside — absence below is a real observation
+
+    expect(renderedTabs()).toEqual([]);
+    expect(page.getByRole('tablist').elements()).toHaveLength(0);
+    expect(page.getByRole('navigation', { name: 'App sections' }).elements()).toHaveLength(0);
+  });
+
+  test('flags ABSENT entirely (Flipt down / not yet created) → renders nothing (fails closed)', async () => {
+    mocks.flags = { appBlocksAuthor: true };
+    await renderSubNav();
+
+    expect(renderedTabs()).toEqual([]);
+    expect(page.getByRole('navigation', { name: 'App sections' }).elements()).toHaveLength(0);
+  });
+
+  // 🔴 POSITIVE CONTROL for the two `toEqual([])` assertions above. If
+  // `renderedTabs()` / the role queries were wired to nothing they would report an
+  // empty set for EVERY input, and both absence tests would be vacuously green.
+  test('POSITIVE CONTROL: the same readers DO observe a bar when the gate opens', async () => {
+    mocks.flags = { appListings: true, appBlocks: false, appBlocksAuthor: true };
+    await renderSubNav();
+    await expect.element(tab('Marketplace')).toBeInTheDocument();
+    expect(renderedTabs()).toEqual(['Marketplace', 'Create']);
+    expect(page.getByRole('navigation', { name: 'App sections' }).elements()).toHaveLength(1);
+  });
+});
+
+/**
+ * The gate is NOT the only thing that can hide the bar, and conflating the two
+ * would make the tests above pass for the wrong reason. `AppsSubNavView` also
+ * hides itself below two qualifying tabs. An `appListings`-only NON-author
+ * qualifies for Marketplace alone, so they get no bar — correctly, via the
+ * COLLAPSE rule, not via the store gate. Pinned so a future reader doesn't
+ * "fix" the collapse thinking it is gate drift.
+ */
+describe('AppsSubNav — the <2-tab collapse is a SEPARATE rule from the gate', () => {
+  test('appListings-only NON-author → no bar, by the collapse (Marketplace alone)', async () => {
+    mocks.flags = { appListings: true, appBlocks: false, appBlocksAuthor: false };
+    mocks.user = { id: 8, username: 'tester', isModerator: false };
+    await renderSubNav();
+
+    expect(page.getByRole('tablist').elements()).toHaveLength(0);
+    // …and the SAME viewer WITH the author capability does get a bar, which is
+    // what proves the hide above came from the collapse and not from the gate.
+    mocks.flags = { appListings: true, appBlocks: false, appBlocksAuthor: true };
+    await renderSubNav();
+    await expect.element(tab('Create')).toBeInTheDocument();
+  });
+
+  test('a logged-out viewer gets no bar even with the store flag lit', async () => {
+    mocks.flags = { appListings: true, appBlocks: false, appBlocksAuthor: true };
+    mocks.user = null;
+    await renderSubNav();
+
+    expect(page.getByRole('tablist').elements()).toHaveLength(0);
+  });
+});
+
+/**
+ * 🔴 THE `enabled:` PREDICATE ON `blocks.getNavSummary` IS DELIBERATELY *NOT*
+ * THE STORE PREDICATE — pinned so the two are not "aligned" by a later reader
+ * who assumes every flag read in this file must move together.
+ *
+ * A query gate mirrors the gate on the PROCEDURE it calls, not the gate on the
+ * page it renders in. `getNavSummary` is `protectedProcedure.use(enforceAppBlocksFlag)`
+ * — the strict `app-blocks-enabled` check — and because it is a QUERY the
+ * middleware short-circuits to the ALL-FALSE summary instead of throwing. So for
+ * an `appListings`-only viewer, widening this `enabled` buys a guaranteed
+ * round-trip to a guaranteed all-false answer; and all-false is ALSO the correct
+ * tab set, because every conditional tab points at a page that itself 404s
+ * without `appBlocks`.
+ */
+describe('AppsSubNav — the getNavSummary query gate stays on appBlocks', () => {
+  test('appListings-only: the summary query is DISABLED and no conditional tab renders', async () => {
+    mocks.flags = { appListings: true, appBlocks: false, appBlocksAuthor: true };
+    await renderSubNav();
+
+    await expect.element(tab('Marketplace')).toBeInTheDocument();
+    expect(mocks.navSummaryEnabled.length).toBeGreaterThan(0); // the hook did run
+    expect(mocks.navSummaryEnabled.every((e) => e === false)).toBe(true);
+    for (const name of ['Installed', 'My submissions', 'Revenue', 'Review']) {
+      expect(tab(name).elements()).toHaveLength(0);
+    }
+  });
+
+  test('appBlocks on + logged in: the summary query IS enabled (positive control)', async () => {
+    mocks.flags = { appListings: false, appBlocks: true, appBlocksAuthor: true };
+    await renderSubNav();
+
+    await expect.element(tab('Review')).toBeInTheDocument();
+    expect(mocks.navSummaryEnabled.some((e) => e === true)).toBe(true);
+  });
+
+  test('appBlocks on but LOGGED OUT: still disabled (the protectedProcedure half)', async () => {
+    mocks.flags = { appListings: false, appBlocks: true, appBlocksAuthor: true };
+    mocks.user = null;
+    await renderSubNav();
+
+    expect(mocks.navSummaryEnabled.every((e) => e === false)).toBe(true);
+  });
+});

--- a/src/components/Apps/AppsSubNav.tsx
+++ b/src/components/Apps/AppsSubNav.tsx
@@ -83,16 +83,18 @@ type SubNavLink = {
  * `app-blocks-author=false`) would click a tab straight into a 404. The tab now
  * keys off the SAME predicate the page's `getServerSideProps` does.
  *
- * ⚠️ KNOWN, PRE-EXISTING, DELIBERATELY NOT FIXED HERE: `/apps/submit`'s CLIENT
- * BODY carries an EXTRA `if (!features?.appBlocks) return <NotFound />` that its
- * own SSR gate does NOT. While the container gated on `appBlocks`, this tab could
- * only render when that flag was already true, so the extra check was unreachable.
- * With the container now on the shared STORE predicate it becomes reachable for the
- * cohort {`appListings` yes, `appBlocks` no, author} — empty today — who would SSR
- * into the page and then hit a client-side 404. The outlier is submit.tsx's body,
- * not this tab: re-inlining `appBlocks` here would re-create the very drift this
- * change removes, and whether authoring requires the block runtime is a product
- * decision. Left to a follow-up.
+ * ⚠️ KNOWN, PRE-EXISTING, DELIBERATELY NOT FIXED HERE — tracked in issue #3906:
+ * `/apps/submit`'s CLIENT BODY carries an EXTRA
+ * `if (!features?.appBlocks) return <NotFound />` (submit.tsx:68) that its own SSR
+ * gate does NOT. That check was always reachable by DIRECT navigation (a bookmark,
+ * a pasted link, the `?edit=` deep link from my-submissions); what the old
+ * `appBlocks` gate on this container prevented was reaching it *via this tab*.
+ * Now that the container is on the shared STORE predicate, the tab is one more
+ * route into it for the cohort {`appListings` yes, `appBlocks` no, author} — empty
+ * today, since `app-blocks-author` is a strict subset of `app-blocks-enabled`.
+ * The outlier is submit.tsx's body, not this tab: re-inlining `appBlocks` here
+ * would re-create the very drift this change removes, and whether authoring
+ * requires the block runtime is a product decision. See #3906.
  *
  * With "Create" conditional the bar can collapse to a single entry, so
  * {@link AppsSubNavView} hides itself entirely below two tabs — a one-tab

--- a/src/components/Apps/AppsSubNav.tsx
+++ b/src/components/Apps/AppsSubNav.tsx
@@ -13,7 +13,7 @@ import { trpc } from '~/utils/trpc';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { useIsClient } from '~/providers/IsClientProvider';
-import { isAppDeveloper } from '~/shared/utils/app-blocks-access';
+import { hasAppsStoreAccess, isAppDeveloper } from '~/shared/utils/app-blocks-access';
 
 /**
  * The conditions that drive which sub-nav tabs are visible. Sourced from the
@@ -81,7 +81,18 @@ type SubNavLink = {
  * `isAppDeveloper` and otherwise returns `notFound` — so a store-visible
  * NON-author (the widened `app-listings` tester cohort: `app-listings=true`,
  * `app-blocks-author=false`) would click a tab straight into a 404. The tab now
- * keys off the SAME predicate the page does.
+ * keys off the SAME predicate the page's `getServerSideProps` does.
+ *
+ * ⚠️ KNOWN, PRE-EXISTING, DELIBERATELY NOT FIXED HERE: `/apps/submit`'s CLIENT
+ * BODY carries an EXTRA `if (!features?.appBlocks) return <NotFound />` that its
+ * own SSR gate does NOT. While the container gated on `appBlocks`, this tab could
+ * only render when that flag was already true, so the extra check was unreachable.
+ * With the container now on the shared STORE predicate it becomes reachable for the
+ * cohort {`appListings` yes, `appBlocks` no, author} — empty today — who would SSR
+ * into the page and then hit a client-side 404. The outlier is submit.tsx's body,
+ * not this tab: re-inlining `appBlocks` here would re-create the very drift this
+ * change removes, and whether authoring requires the block runtime is a product
+ * decision. Left to a follow-up.
  *
  * With "Create" conditional the bar can collapse to a single entry, so
  * {@link AppsSubNavView} hides itself entirely below two tabs — a one-tab
@@ -242,10 +253,19 @@ export function AppsSubNavView({
  * top of every apps page (the nav dropdown now exposes a single `/apps`
  * entry — this is the second-level navigation).
  *
- * Gated on `features.appBlocks` (the page itself 404s without it, so this is a
- * belt for non-flag callers) and on a logged-in user (the summary query is a
- * `protectedProcedure`; an anon viewer resolves to `NO_CAPABILITIES` + an empty
- * summary ⇒ Marketplace alone ⇒ the bar hides itself entirely).
+ * Gated on the SHARED store-visibility predicate `hasAppsStoreAccess(features)`
+ * — the SAME rule `resolveAppsPageAccess` enforces in `getServerSideProps` — and
+ * on a logged-in user (the summary query is a `protectedProcedure`; an anon
+ * viewer resolves to `NO_CAPABILITIES` + an empty summary ⇒ Marketplace alone ⇒
+ * the bar hides itself entirely).
+ *
+ * 🔴 THIS GATE USED TO READ `features.appBlocks` ALONE while the page it sits on
+ * granted access on `appListings || appBlocks`. The two could therefore disagree:
+ * a cohort holding `app-listings` WITHOUT `app-blocks-enabled` would load `/apps`
+ * successfully and get NO sub-navigation. That is not reachable today (both flags
+ * resolve true for the current mods + `app-dev-testers` cohort), but `app-listings`
+ * exists precisely so the catalog can widen INDEPENDENTLY of the block runtime, so
+ * the disagreement is one flag flip away. Both gates now call one predicate.
  */
 export function AppsSubNav() {
   const router = useRouter();
@@ -265,12 +285,24 @@ export function AppsSubNav() {
   // AFTER mount, once hydration has already matched.
   const isClient = useIsClient();
 
+  // 🔴 DELIBERATELY *NOT* `hasAppsStoreAccess` — this one stays on `appBlocks`
+  // alone, and that is not an oversight. A query gate must mirror the gate on the
+  // PROCEDURE it calls, not the gate on the page it renders in. `blocks.getNavSummary`
+  // is `protectedProcedure.use(enforceAppBlocksFlag)` (blocks.router.ts), i.e. the
+  // strict `app-blocks-enabled` check — and because it is a QUERY the middleware
+  // short-circuits rather than throwing, returning the ALL-FALSE summary without
+  // running a single DB read. So for an `app-listings`-only viewer, widening this
+  // `enabled` would buy a guaranteed round-trip to a guaranteed all-false answer.
+  // The conditional tabs it feeds (Installed / My submissions / Revenue / Review)
+  // all point at pages that themselves 404 without `appBlocks`, so all-false is
+  // also the CORRECT tab set for that viewer. If the server proc ever moves to
+  // `enforceAppListingsReadFlag`, move this with it.
   const { data } = trpc.blocks.getNavSummary.useQuery(undefined, {
     enabled: !!features.appBlocks && !!currentUser,
     staleTime: 60_000,
   });
 
-  if (!features.appBlocks) return null;
+  if (!hasAppsStoreAccess(features)) return null;
 
   const summary = isClient ? data ?? EMPTY_SUMMARY : EMPTY_SUMMARY;
 

--- a/src/components/Apps/RelatedListings.tsx
+++ b/src/components/Apps/RelatedListings.tsx
@@ -14,6 +14,7 @@ import {
   MARKETPLACE_CATEGORY_LABELS,
 } from '~/server/services/blocks/marketplace-categories.constants';
 import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema';
+import { hasAppsStoreAccess } from '~/shared/utils/app-blocks-access';
 import { trpc } from '~/utils/trpc';
 
 /**
@@ -50,10 +51,10 @@ export interface RelatedListingsProps {
 
 export function RelatedListings({ listingId, category }: RelatedListingsProps) {
   const features = useFeatureFlags();
-  // Same store-visibility gate the grid + detail use (`appListings` OR-falling-
-  // back to `appBlocks`), so this rail can never fire a read the page itself
-  // isn't allowed to make.
-  const canSeeStore = !!(features.appListings || features.appBlocks);
+  // Same store-visibility gate the grid + detail use — the SHARED
+  // `hasAppsStoreAccess` predicate — so this rail can never fire a read the page
+  // itself isn't allowed to make.
+  const canSeeStore = hasAppsStoreAccess(features);
 
   // The DTO's `category` is a free-text column (`string | null`), while the
   // query input is the closed taxonomy enum. Narrow through the shared type

--- a/src/components/Apps/__tests__/appsStoreAccessCallSites.test.ts
+++ b/src/components/Apps/__tests__/appsStoreAccessCallSites.test.ts
@@ -1,0 +1,253 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, it, expect } from 'vitest';
+
+/**
+ * 🔒 THE CALL-SITE LEDGER for the App-store visibility gate.
+ *
+ * WHY THIS FILE EXISTS — measured, not hypothetical. The PR that extracted
+ * `hasAppsStoreAccess` converted SIX sites, but only TWO of them
+ * (`resolveAppsPageAccess`, `AppsSubNav`) had behavioural tests that could
+ * observe the conversion. An adversarial audit reverted the other four to
+ * `!!features.appBlocks` and re-ran the ENTIRE cited suite — 93/93 component +
+ * 21/21 unit still GREEN. The mutant survived completely. A consolidation that
+ * nothing pins is a comment, not an invariant.
+ *
+ * So this asserts the RELATIONSHIP rather than any one component: the exact set
+ * of modules that decide "may this viewer see the /apps store", that each one
+ * routes through the shared predicate, and that none of them re-inlines the
+ * boolean. It fails when the ledger GROWS (a new store surface that forgot the
+ * predicate) and when it SHRINKS (a site reverted to open-coding).
+ *
+ * 🔴 A STRUCTURAL CHECK IS NOT A BEHAVIOURAL ONE. This proves each site CALLS
+ * the predicate; it cannot prove the call was passed the right argument, and it
+ * would type-check past `hasAppsStoreAccess(someOtherObject)`. Behavioural
+ * coverage lives alongside it and is deliberately NOT replaced by this file:
+ *   - `AppsSubNav.storeGate.browser.test.tsx`      — the sub-nav's rendered output
+ *   - `AppListingsMarketplaceBody.storeGate.browser.test.tsx` — the grid query gate
+ *   - `hasAppsStoreAccess.test.ts`                 — the predicate + the SSR seam
+ * The two page bodies (`pages/apps/index.tsx`, `pages/apps/store-preview/[slug].tsx`)
+ * are pinned STRUCTURALLY ONLY — they are Next pages with no component harness, so
+ * rendering them would cost more scaffolding than the gate is worth. Stated plainly
+ * rather than implied: those two are covered against reversion, not against a
+ * wrong-argument call.
+ */
+
+const SRC = path.resolve(__dirname, '../../..');
+
+/**
+ * Every module that decides store VISIBILITY. Adding a store surface means adding
+ * it here — that is the point, not an inconvenience.
+ *
+ * NOT in this ledger, on purpose: the block-RUNTIME surfaces (`/apps/installed`,
+ * `/apps/review`, `/apps/my-submissions`, `/apps/revenue`, `/apps/run/<slug>`)
+ * gate on `appBlocks` ALONE because they need the runtime, not just the catalog.
+ * Sweeping them in here would be a silent access widening.
+ */
+const STORE_GATE_SITES = [
+  'components/Apps/AppListingsMarketplaceBody.tsx',
+  'components/Apps/AppsSubNav.tsx',
+  'components/Apps/RelatedListings.tsx',
+  'components/Apps/resolveAppsPageAccess.ts',
+  'pages/apps/index.tsx',
+  'pages/apps/store-preview/[slug].tsx',
+] as const;
+
+/** The ONE module allowed to spell the boolean out — it defines it. */
+const DEFINING_MODULE = 'shared/utils/app-blocks-access.ts';
+
+/** Directories scanned for a re-inlined gate. The definition lives outside them. */
+const SCAN_ROOTS = ['components/Apps', 'pages/apps'];
+
+/**
+ * Blank the CONTENTS of comments and string/template literals while preserving
+ * length and line breaks, so a gate spelled out in a DOC COMMENT is not mistaken
+ * for a live one. This is load-bearing here, not hygiene: the shared predicate's
+ * own doc comment and `resolveAppsPageAccess`'s header both contain the literal
+ * text `features.appListings || features.appBlocks`, so an unmasked scan would
+ * report the very files that were fixed. Self-tested below.
+ */
+function maskNonCode(code: string): string {
+  const out = code.split('');
+  const blank = (from: number, to: number) => {
+    for (let i = from; i < Math.min(to, out.length); i++) {
+      if (out[i] !== '\n') out[i] = ' ';
+    }
+  };
+  let i = 0;
+  while (i < code.length) {
+    const two = code.slice(i, i + 2);
+    if (two === '//') {
+      const end = code.indexOf('\n', i);
+      blank(i, end === -1 ? code.length : end);
+      i = end === -1 ? code.length : end;
+    } else if (two === '/*') {
+      const end = code.indexOf('*/', i + 2);
+      blank(i, end === -1 ? code.length : end + 2);
+      i = end === -1 ? code.length : end + 2;
+    } else if (code[i] === '"' || code[i] === "'" || code[i] === '`') {
+      const quote = code[i];
+      let j = i + 1;
+      while (j < code.length && code[j] !== quote) {
+        if (code[j] === '\\') j++;
+        j++;
+      }
+      blank(i, j + 1);
+      i = j + 1;
+    } else {
+      i++;
+    }
+  }
+  return out.join('');
+}
+
+/**
+ * Blank COMMENT contents only, leaving string literals intact. Needed for the
+ * import assertions: a module specifier IS a string (`from '~/shared/...'`), so
+ * the full masker above blanks the very path being asserted — which is exactly
+ * how the first version of this file failed all six site checks while the code
+ * was correct.
+ */
+function maskComments(code: string): string {
+  const out = code.split('');
+  const blank = (from: number, to: number) => {
+    for (let i = from; i < Math.min(to, out.length); i++) {
+      if (out[i] !== '\n') out[i] = ' ';
+    }
+  };
+  let i = 0;
+  while (i < code.length) {
+    const two = code.slice(i, i + 2);
+    if (two === '//') {
+      const end = code.indexOf('\n', i);
+      blank(i, end === -1 ? code.length : end);
+      i = end === -1 ? code.length : end;
+    } else if (two === '/*') {
+      const end = code.indexOf('*/', i + 2);
+      blank(i, end === -1 ? code.length : end + 2);
+      i = end === -1 ? code.length : end + 2;
+    } else {
+      i++;
+    }
+  }
+  return out.join('');
+}
+
+/** An open-coded store gate in LIVE code (either operand order). */
+const INLINED_GATE =
+  /appListings\s*\|\|[^;\n]{0,80}appBlocks|appBlocks\s*\|\|[^;\n]{0,80}appListings/;
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(SRC, rel), 'utf8');
+}
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, out);
+    else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) out.push(full);
+  }
+  return out;
+}
+
+const SCANNED = SCAN_ROOTS.flatMap((root) => walk(path.join(SRC, root))).map((file) => {
+  const raw = fs.readFileSync(file, 'utf8');
+  return {
+    rel: path.relative(SRC, file).split(path.sep).join('/'),
+    raw,
+    code: maskNonCode(raw),
+  };
+});
+
+describe('the masker (validate the instrument before reading its verdict)', () => {
+  it('blanks a gate written in a line comment, a block comment and a string', () => {
+    expect(maskNonCode('// features.appListings || features.appBlocks')).not.toMatch(INLINED_GATE);
+    expect(maskNonCode('/* a = features.appListings || features.appBlocks; */')).not.toMatch(
+      INLINED_GATE
+    );
+    expect(maskNonCode("const s = 'features.appListings || features.appBlocks';")).not.toMatch(
+      INLINED_GATE
+    );
+  });
+
+  it('🔴 POSITIVE CONTROL: it does NOT blank real code (else every scan below is vacuous)', () => {
+    // If this ever stops matching, the "no re-inlined gate" test becomes a probe
+    // wired to nothing and would report a reassuring zero forever.
+    expect(maskNonCode('if (!(features.appListings || features.appBlocks)) return null;')).toMatch(
+      INLINED_GATE
+    );
+    expect(maskNonCode('enabled: !!(features.appBlocks || features.appListings),')).toMatch(
+      INLINED_GATE
+    );
+    expect(maskNonCode('const x = hasAppsStoreAccess(features);')).toContain('hasAppsStoreAccess');
+  });
+
+  it('preserves line count so a reported offender can be located', () => {
+    const src = 'a\n// x\n/* y\nz */\nb\n';
+    expect(maskNonCode(src).split('\n')).toHaveLength(src.split('\n').length);
+  });
+
+  it('🔴 maskComments keeps STRINGS (the import-path regression this file already hit)', () => {
+    // The first version of this file masked strings too, so `from '~/shared/...'`
+    // was blanked and all six site checks failed against correct code.
+    const line = "import { hasAppsStoreAccess } from '~/shared/utils/app-blocks-access';";
+    expect(maskComments(line)).toContain('~/shared/utils/app-blocks-access');
+    expect(maskNonCode(line)).not.toContain('~/shared/utils/app-blocks-access');
+    // …while still blanking a commented-out import (the false-positive it prevents).
+    expect(maskComments(`// ${line}`)).not.toContain('~/shared/utils/app-blocks-access');
+  });
+});
+
+describe('the scan itself (a zero must be earned, not assumed)', () => {
+  it('walked a plausible number of store modules', () => {
+    // Floor deliberately well below the live count so retiring one file does not
+    // red the guard; the point is that the walk is not returning an empty set.
+    expect(SCANNED.length).toBeGreaterThanOrEqual(40);
+  });
+
+  it('every ledger site was actually reached by the walk', () => {
+    const seen = new Set(SCANNED.map((f) => f.rel));
+    expect(STORE_GATE_SITES.filter((s) => !seen.has(s))).toEqual([]);
+  });
+});
+
+describe('🔒 every store-visibility site routes through the shared predicate', () => {
+  for (const rel of STORE_GATE_SITES) {
+    it(`${rel} imports AND calls hasAppsStoreAccess`, () => {
+      const raw = read(rel);
+      // The import — so a call cannot be satisfied by a same-named local helper.
+      // Comment-masked only: the module specifier is a string literal.
+      expect(maskComments(raw)).toMatch(
+        /import\s*\{[^}]*\bhasAppsStoreAccess\b[^}]*\}\s*from\s*['"]~\/shared\/utils\/app-blocks-access['"]/
+      );
+      // …and a real invocation, not merely a mention in prose.
+      expect(maskNonCode(raw)).toMatch(/\bhasAppsStoreAccess\s*\(/);
+    });
+  }
+
+  /**
+   * 🔴 THE MUTANT THAT SURVIVED. Reverting any of the four unpinned sites to
+   * `!!features.appBlocks` left the whole cited suite green. It cannot now: the
+   * revert deletes the call, so that site's case above goes red, and the site
+   * disappears from the ledger below.
+   */
+  it('the ledger is EXACT — it fails if a site is added OR silently reverted', () => {
+    const importers = SCANNED.filter((f) =>
+      /import\s*\{[^}]*\bhasAppsStoreAccess\b[^}]*\}\s*from\s*['"]~\/shared\/utils\/app-blocks-access['"]/.test(
+        maskComments(f.raw)
+      )
+    ).map((f) => f.rel);
+    expect(importers.sort()).toEqual([...STORE_GATE_SITES].sort());
+  });
+});
+
+describe('🔴 no store surface re-inlines the gate', () => {
+  it('the boolean is spelled out in exactly one module — the one that defines it', () => {
+    const offenders = SCANNED.filter((f) => INLINED_GATE.test(f.code)).map((f) => f.rel);
+    expect(offenders).toEqual([]);
+    // The definition itself lives OUTSIDE the scanned roots and is where the
+    // expression belongs; assert it is still there so "zero offenders" cannot be
+    // achieved by the rule having evaporated entirely.
+    expect(maskNonCode(read(DEFINING_MODULE))).toMatch(INLINED_GATE);
+  });
+});

--- a/src/components/Apps/__tests__/appsStoreAccessCallSites.test.ts
+++ b/src/components/Apps/__tests__/appsStoreAccessCallSites.test.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import ts from 'typescript';
 import { describe, it, expect } from 'vitest';
 
 /**
@@ -26,23 +27,47 @@ import { describe, it, expect } from 'vitest';
  *   - `AppsSubNav.storeGate.browser.test.tsx`      — the sub-nav's rendered output
  *   - `AppListingsMarketplaceBody.storeGate.browser.test.tsx` — the grid query gate
  *   - `hasAppsStoreAccess.test.ts`                 — the predicate + the SSR seam
- * The two page bodies (`pages/apps/index.tsx`, `pages/apps/store-preview/[slug].tsx`)
- * are pinned STRUCTURALLY ONLY — they are Next pages with no component harness, so
- * rendering them would cost more scaffolding than the gate is worth. Stated plainly
- * rather than implied: those two are covered against reversion, not against a
- * wrong-argument call.
+ *
+ * THREE of the six sites are pinned STRUCTURALLY ONLY — `pages/apps/index.tsx`
+ * and `pages/apps/store-preview/[slug].tsx` (Next pages, no component harness) and
+ * `components/Apps/RelatedListings.tsx` (its only existing test covers the pure
+ * selection helper and never mounts the component, so it never touches
+ * `useFeatureFlags` / `canSeeStore`). Those three are covered against REVERSION,
+ * not against a wrong-argument call. Stated rather than implied.
+ *
+ * 🔴 AND THE SCOPE THAT MATTERS IN CI: the component suites above are REPORT-ONLY
+ * (`preview / component-tests`) and do not block a merge. This unit-project ledger
+ * does. So in CI all six sites are pinned STRUCTURALLY ONLY, by this file — which
+ * is precisely why a hole in its masker (see below) is worth more than it looks.
  */
 
 const SRC = path.resolve(__dirname, '../../..');
 
 /**
- * Every module that decides store VISIBILITY. Adding a store surface means adding
- * it here — that is the point, not an inconvenience.
+ * Every module INSIDE {@link SCAN_ROOTS} that decides store VISIBILITY. Adding a
+ * store surface under those roots means adding it here — that is the point, not
+ * an inconvenience.
  *
- * NOT in this ledger, on purpose: the block-RUNTIME surfaces (`/apps/installed`,
- * `/apps/review`, `/apps/my-submissions`, `/apps/revenue`, `/apps/run/<slug>`)
- * gate on `appBlocks` ALONE because they need the runtime, not just the catalog.
- * Sweeping them in here would be a silent access widening.
+ * ── NOT in this ledger, on purpose ──────────────────────────────────────────
+ *
+ * 1. The block-RUNTIME surfaces (`/apps/installed`, `/apps/review`,
+ *    `/apps/my-submissions`, `/apps/revenue`, `/apps/run/<slug>`) gate on
+ *    `appBlocks` ALONE because they need the runtime, not just the catalog.
+ *    Sweeping them in here would be a silent access widening.
+ *
+ * 2. 🔴 `components/AppLayout/AppHeader/appsNavVisibility.ts` — `marketplace:
+ *    !!features.appBlocks`, which drives the user-menu "Apps" → `/apps` entry.
+ *    That IS a store-visibility decision and it is NOT converted, deliberately:
+ *    that module's own doc comment states the entry "stays gated on `appBlocks`",
+ *    so it is a standing decision, not drift. It is also outside `SCAN_ROOTS`
+ *    (`components/AppLayout`), so grow-detection below is STRUCTURALLY BLIND to
+ *    it — do not read the ledger's exactness as covering it.
+ *
+ *    CONSEQUENCE, recorded so nobody rediscovers it during the launch: for the
+ *    `{appListings, NOT appBlocks}` cohort the store renders but has NO in-product
+ *    entry point — that menu item is the only route TO `/apps` (the sub-nav's
+ *    Marketplace tab only appears once you are already on `/apps/*`). Reachable by
+ *    direct URL only. Tracked in issue #3907; not this file's to fix.
  */
 const STORE_GATE_SITES = [
   'components/Apps/AppListingsMarketplaceBody.tsx',
@@ -60,82 +85,146 @@ const DEFINING_MODULE = 'shared/utils/app-blocks-access.ts';
 const SCAN_ROOTS = ['components/Apps', 'pages/apps'];
 
 /**
- * Blank the CONTENTS of comments and string/template literals while preserving
- * length and line breaks, so a gate spelled out in a DOC COMMENT is not mistaken
- * for a live one. This is load-bearing here, not hygiene: the shared predicate's
- * own doc comment and `resolveAppsPageAccess`'s header both contain the literal
- * text `features.appListings || features.appBlocks`, so an unmasked scan would
- * report the very files that were fixed. Self-tested below.
+ * 🔴 MASKING RUNS THROUGH THE REAL TypeScript PARSER, NOT A QUOTE SCANNER.
+ *
+ * Masking is load-bearing, not hygiene: the shared predicate's own doc comment and
+ * `resolveAppsPageAccess`'s header both contain the literal text
+ * `features.appListings || features.appBlocks`, so an UNMASKED scan reports the
+ * very files that were fixed. But a hand-rolled masker is worse than none, because
+ * it fails SILENTLY and in one direction — toward a reassuring zero.
+ *
+ * The previous version treated every `'` as a string delimiter. An ASCII
+ * apostrophe in JSX TEXT (`The app's data…`, `installed.tsx:132`) therefore opened
+ * a phantom string that ran to EOF, blanking 71% of that file (14,229 / 20,037
+ * chars) and 17% of `my-submissions.tsx`. Measured with a discriminating control,
+ * not inferred: an open-coded `f.appListings || f.appBlocks` planted AFTER the
+ * apostrophe was INVISIBLE (suite 14/14 green); the identical probe planted BEFORE
+ * it was caught. A live store gate could have shipped through the hole.
+ *
+ * JSX text, template-literal chunks, regex literals and nested quotes are exactly
+ * the cases an ad-hoc lexer gets wrong, so the parser owns it now: parse as TSX,
+ * blank the ranges the AST says are literals, then strip comments from the result
+ * (safe at that point — every string is already blanked, so no `//` inside one can
+ * be misread). Expression holes inside `${...}` are children of the template node
+ * and are deliberately LEFT LIVE: they are real code.
  */
-function maskNonCode(code: string): string {
-  const out = code.split('');
-  const blank = (from: number, to: number) => {
-    for (let i = from; i < Math.min(to, out.length); i++) {
+function parseTsx(fileName: string, text: string): ts.SourceFile {
+  return ts.createSourceFile(fileName, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+}
+
+function blankRanges(text: string, ranges: Array<[number, number]>): string {
+  const out = text.split('');
+  for (const [from, to] of ranges) {
+    for (let i = Math.max(from, 0); i < Math.min(to, out.length); i++) {
       if (out[i] !== '\n') out[i] = ' ';
-    }
-  };
-  let i = 0;
-  while (i < code.length) {
-    const two = code.slice(i, i + 2);
-    if (two === '//') {
-      const end = code.indexOf('\n', i);
-      blank(i, end === -1 ? code.length : end);
-      i = end === -1 ? code.length : end;
-    } else if (two === '/*') {
-      const end = code.indexOf('*/', i + 2);
-      blank(i, end === -1 ? code.length : end + 2);
-      i = end === -1 ? code.length : end + 2;
-    } else if (code[i] === '"' || code[i] === "'" || code[i] === '`') {
-      const quote = code[i];
-      let j = i + 1;
-      while (j < code.length && code[j] !== quote) {
-        if (code[j] === '\\') j++;
-        j++;
-      }
-      blank(i, j + 1);
-      i = j + 1;
-    } else {
-      i++;
     }
   }
   return out.join('');
+}
+
+/** Ranges the PARSER classifies as literal text — never live code. */
+function literalRanges(sf: ts.SourceFile): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  const visit = (node: ts.Node) => {
+    switch (node.kind) {
+      case ts.SyntaxKind.StringLiteral:
+      case ts.SyntaxKind.NoSubstitutionTemplateLiteral:
+      case ts.SyntaxKind.TemplateHead:
+      case ts.SyntaxKind.TemplateMiddle:
+      case ts.SyntaxKind.TemplateTail:
+      case ts.SyntaxKind.RegularExpressionLiteral:
+      case ts.SyntaxKind.JsxText:
+        ranges.push([node.getStart(sf), node.getEnd()]);
+        break;
+    }
+    node.forEachChild(visit);
+  };
+  visit(sf);
+  return ranges;
+}
+
+/** Blank comments AND literals. Use for anything that scans for live code. */
+function maskNonCode(code: string, fileName = 'probe.tsx'): string {
+  const withoutLiterals = blankRanges(code, literalRanges(parseTsx(fileName, code)));
+  // Safe now: every string/template/JSX-text range is spaces, so a `//` or `/*`
+  // that survives can only be a real comment.
+  return stripComments(withoutLiterals);
 }
 
 /**
  * Blank COMMENT contents only, leaving string literals intact. Needed for the
  * import assertions: a module specifier IS a string (`from '~/shared/...'`), so
- * the full masker above blanks the very path being asserted — which is exactly
- * how the first version of this file failed all six site checks while the code
- * was correct.
+ * the full masker blanks the very path being asserted — which is exactly how the
+ * first version of this file failed all six site checks while the code was
+ * correct. Comment ranges come from the parser, so an apostrophe cannot desync it.
  */
-function maskComments(code: string): string {
-  const out = code.split('');
-  const blank = (from: number, to: number) => {
-    for (let i = from; i < Math.min(to, out.length); i++) {
-      if (out[i] !== '\n') out[i] = ' ';
+function maskComments(code: string, fileName = 'probe.tsx'): string {
+  const sf = parseTsx(fileName, code);
+  const ranges: Array<[number, number]> = [];
+  const seen = new Set<string>();
+  const add = (found: ts.CommentRange[] | undefined) => {
+    for (const c of found ?? []) {
+      const key = `${c.pos}:${c.end}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        ranges.push([c.pos, c.end]);
+      }
     }
   };
+  const visit = (node: ts.Node) => {
+    add(ts.getLeadingCommentRanges(code, node.getFullStart()));
+    add(ts.getTrailingCommentRanges(code, node.getEnd()));
+    node.forEachChild(visit);
+  };
+  visit(sf);
+  add(ts.getLeadingCommentRanges(code, 0));
+  return blankRanges(code, ranges);
+}
+
+/** Line + block comment strip, run only on text whose literals are already blank. */
+function stripComments(code: string): string {
+  const ranges: Array<[number, number]> = [];
   let i = 0;
   while (i < code.length) {
     const two = code.slice(i, i + 2);
     if (two === '//') {
       const end = code.indexOf('\n', i);
-      blank(i, end === -1 ? code.length : end);
-      i = end === -1 ? code.length : end;
+      const stop = end === -1 ? code.length : end;
+      ranges.push([i, stop]);
+      i = stop;
     } else if (two === '/*') {
       const end = code.indexOf('*/', i + 2);
-      blank(i, end === -1 ? code.length : end + 2);
-      i = end === -1 ? code.length : end + 2;
+      const stop = end === -1 ? code.length : end + 2;
+      ranges.push([i, stop]);
+      i = stop;
     } else {
       i++;
     }
   }
-  return out.join('');
+  return blankRanges(code, ranges);
 }
 
-/** An open-coded store gate in LIVE code (either operand order). */
+/**
+ * An open-coded store gate in LIVE code.
+ *
+ * Deliberately matched on PROXIMITY + a logical operator rather than one literal
+ * shape. The previous single-line `X || Y` regex was evaded by every form the
+ * codebase can actually produce: a prettier-wrapped multi-line OR (the formatter
+ * inserts the newline for you), a De Morgan negation
+ * (`!features.appListings && !features.appBlocks`), and a `??` chain. Whitespace is
+ * collapsed first so line wrapping is irrelevant, and `[^;{}]` keeps a match inside
+ * one expression rather than spanning statements.
+ *
+ * `\b` after each flag name matters: it stops `appBlocksPages` / `appBlocksAuthor`
+ * — different flags with their own rules — from being read as `appBlocks`.
+ */
 const INLINED_GATE =
-  /appListings\s*\|\|[^;\n]{0,80}appBlocks|appBlocks\s*\|\|[^;\n]{0,80}appListings/;
+  /appListings\b[^;{}]{0,120}?(?:\|\||&&|\?\?)[^;{}]{0,120}?appBlocks\b|appBlocks\b[^;{}]{0,120}?(?:\|\||&&|\?\?)[^;{}]{0,120}?appListings\b/;
+
+/** Collapse whitespace so a prettier line-wrap cannot hide a gate from the regex. */
+function flatten(code: string): string {
+  return code.replace(/\s+/g, ' ');
+}
 
 function read(rel: string): string {
   return fs.readFileSync(path.join(SRC, rel), 'utf8');
@@ -152,11 +241,8 @@ function walk(dir: string, out: string[] = []): string[] {
 
 const SCANNED = SCAN_ROOTS.flatMap((root) => walk(path.join(SRC, root))).map((file) => {
   const raw = fs.readFileSync(file, 'utf8');
-  return {
-    rel: path.relative(SRC, file).split(path.sep).join('/'),
-    raw,
-    code: maskNonCode(raw),
-  };
+  const rel = path.relative(SRC, file).split(path.sep).join('/');
+  return { rel, raw, code: maskNonCode(raw, file), comments: maskComments(raw, file) };
 });
 
 describe('the masker (validate the instrument before reading its verdict)', () => {
@@ -185,6 +271,88 @@ describe('the masker (validate the instrument before reading its verdict)', () =
   it('preserves line count so a reported offender can be located', () => {
     const src = 'a\n// x\n/* y\nz */\nb\n';
     expect(maskNonCode(src).split('\n')).toHaveLength(src.split('\n').length);
+  });
+
+  /**
+   * 🔴 THE REGRESSION THAT MOTIVATED THE PARSER REWRITE.
+   *
+   * The old quote-scanner treated every `'` as a delimiter, so an APOSTROPHE IN
+   * JSX TEXT opened a phantom string to EOF and blanked 71% of `installed.tsx`.
+   * The masker's controls at the time were all synthetic one-liners, which is
+   * exactly why they could not see it — none of them contained JSX. These use
+   * REALISTIC shapes, per the rule that a scanner allowlists its own examples.
+   */
+  it('🔴 an apostrophe in JSX TEXT does not desync the masker (71%-blind regression)', () => {
+    const src = [
+      'export function C() {',
+      '  return (',
+      '    <Text>',
+      "      The app's data and any other installs of it are untouched.",
+      '    </Text>',
+      '  );',
+      '}',
+      'const gate = features.appListings || features.appBlocks;',
+    ].join('\n');
+    const masked = maskNonCode(src, 'probe.tsx');
+    // Code AFTER the apostrophe must survive — this is the whole bug.
+    expect(masked).toMatch(INLINED_GATE);
+    // …and the JSX prose itself is still treated as non-code.
+    expect(masked).not.toContain('any other installs');
+  });
+
+  it('🔴 the real installed.tsx keeps its post-apostrophe code visible', () => {
+    // Anchored on the FILE that broke it, not a fixture: a synthetic case can be
+    // fixed while the real one still desyncs (different JSX nesting, entities…).
+    const raw = read('pages/apps/installed.tsx');
+    const masked = maskNonCode(raw, 'installed.tsx');
+    expect(raw).toMatch(/app's/); // the trigger is still present upstream
+    // Both live gates sit AFTER it (~line 460 and ~500) and must remain readable.
+    expect(masked.match(/features\.appBlocks/g) ?? []).toHaveLength(
+      (raw.match(/features\.appBlocks/g) ?? []).length
+    );
+    // Blanking must be bounded: the file cannot be mostly spaces.
+    const blanked = masked.split('').filter((c) => c === ' ').length;
+    expect(blanked / masked.length).toBeLessThan(0.55);
+  });
+
+  it('nested quotes, templates and regex literals do not desync it either', () => {
+    const src = [
+      'const a = "it\'s fine";',
+      'const b = `a ${features.appListings} b`;',
+      "const c = /don't/.test(x);",
+      'const gate = features.appListings || features.appBlocks;',
+    ].join('\n');
+    const masked = maskNonCode(src, 'probe.ts');
+    expect(masked).toMatch(INLINED_GATE);
+    // The template EXPRESSION hole is live code and must survive. (Its delimiters
+    // `${` and `}` belong to the TemplateHead/Tail TOKENS and are correctly
+    // blanked — only the expression between them is code.)
+    expect(masked).toContain('features.appListings');
+    // …while the literal chunks around it are blanked, apostrophe and all.
+    expect(masked).not.toContain("it's fine");
+    expect(masked).not.toContain("don't");
+  });
+
+  it('🔴 catches the evasions the single-line regex missed', () => {
+    const cases: Record<string, string> = {
+      'prettier-wrapped multi-line OR':
+        'const ok =\n  features.appListings ||\n  features.appBlocks;',
+      'De Morgan negation': 'if (!features.appListings && !features.appBlocks) return null;',
+      'nullish chain': 'const ok = features.appListings ?? features.appBlocks;',
+      destructured: 'const ok = appListings || appBlocks;',
+      'reversed order': 'const ok = features.appBlocks || features.appListings;',
+    };
+    for (const [label, src] of Object.entries(cases)) {
+      expect(flatten(maskNonCode(src, 'probe.ts')), label).toMatch(INLINED_GATE);
+    }
+  });
+
+  it('does NOT confuse sibling flags that have their own rules', () => {
+    // `appBlocksPages` / `appBlocksAuthor` are different gates; a `\b`-less regex
+    // would read them as `appBlocks` and flag legitimate code.
+    expect(
+      flatten(maskNonCode('const x = features.appListings || features.appBlocksPages;', 'p.ts'))
+    ).not.toMatch(INLINED_GATE);
   });
 
   it('🔴 maskComments keeps STRINGS (the import-path regression this file already hit)', () => {
@@ -217,11 +385,11 @@ describe('🔒 every store-visibility site routes through the shared predicate',
       const raw = read(rel);
       // The import — so a call cannot be satisfied by a same-named local helper.
       // Comment-masked only: the module specifier is a string literal.
-      expect(maskComments(raw)).toMatch(
+      expect(flatten(maskComments(raw, rel))).toMatch(
         /import\s*\{[^}]*\bhasAppsStoreAccess\b[^}]*\}\s*from\s*['"]~\/shared\/utils\/app-blocks-access['"]/
       );
       // …and a real invocation, not merely a mention in prose.
-      expect(maskNonCode(raw)).toMatch(/\bhasAppsStoreAccess\s*\(/);
+      expect(maskNonCode(raw, rel)).toMatch(/\bhasAppsStoreAccess\s*\(/);
     });
   }
 
@@ -234,20 +402,24 @@ describe('🔒 every store-visibility site routes through the shared predicate',
   it('the ledger is EXACT — it fails if a site is added OR silently reverted', () => {
     const importers = SCANNED.filter((f) =>
       /import\s*\{[^}]*\bhasAppsStoreAccess\b[^}]*\}\s*from\s*['"]~\/shared\/utils\/app-blocks-access['"]/.test(
-        maskComments(f.raw)
+        flatten(f.comments)
       )
     ).map((f) => f.rel);
+    // ⚠️ "EXACT" is scoped to SCAN_ROOTS. `components/AppLayout/AppHeader/
+    // appsNavVisibility.ts` is a real store-visibility decision that lives outside
+    // them and is deliberately excluded — see the STORE_GATE_SITES doc. This
+    // assertion cannot and does not speak for it.
     expect(importers.sort()).toEqual([...STORE_GATE_SITES].sort());
   });
 });
 
 describe('🔴 no store surface re-inlines the gate', () => {
   it('the boolean is spelled out in exactly one module — the one that defines it', () => {
-    const offenders = SCANNED.filter((f) => INLINED_GATE.test(f.code)).map((f) => f.rel);
+    const offenders = SCANNED.filter((f) => INLINED_GATE.test(flatten(f.code))).map((f) => f.rel);
     expect(offenders).toEqual([]);
     // The definition itself lives OUTSIDE the scanned roots and is where the
     // expression belongs; assert it is still there so "zero offenders" cannot be
     // achieved by the rule having evaporated entirely.
-    expect(maskNonCode(read(DEFINING_MODULE))).toMatch(INLINED_GATE);
+    expect(flatten(maskNonCode(read(DEFINING_MODULE), DEFINING_MODULE))).toMatch(INLINED_GATE);
   });
 });

--- a/src/components/Apps/__tests__/hasAppsStoreAccess.test.ts
+++ b/src/components/Apps/__tests__/hasAppsStoreAccess.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { hasAppsStoreAccess } from '~/shared/utils/app-blocks-access';
+import { resolveAppsPageAccess } from '../resolveAppsPageAccess';
+
+/**
+ * `hasAppsStoreAccess` — the SHARED App-store visibility predicate.
+ *
+ * WHY IT EXISTS: the rule `appListings || appBlocks` was open-coded at six
+ * places, and one of them — the `/apps/*` sub-nav (`AppsSubNav`) — had drifted to
+ * `appBlocks` ALONE. A cohort holding `app-listings` without `app-blocks-enabled`
+ * would therefore load `/apps` (the SSR resolver ORs both) and get NO
+ * sub-navigation. Not reachable today (both flags resolve true for the current
+ * mods + `app-dev-testers` cohort), but `app-listings` exists precisely so the
+ * catalog can widen independently of the block runtime.
+ *
+ * These pin the predicate itself across the FULL 2×2 flag matrix, so the
+ * behaviour is asserted in one place rather than re-derived at each call site.
+ * The companion browser suite (`AppsSubNav.storeGate.browser.test.tsx`) pins the
+ * sub-nav's rendered output for the same four combinations, and
+ * `resolveAppsPageAccess.test.ts` (UNMODIFIED by this change) pins the SSR gate.
+ */
+describe('hasAppsStoreAccess — the 2×2 flag matrix', () => {
+  it('both flags true → access', () => {
+    expect(hasAppsStoreAccess({ appListings: true, appBlocks: true })).toBe(true);
+  });
+
+  it('appListings ONLY → access (the case AppsSubNav used to get wrong)', () => {
+    expect(hasAppsStoreAccess({ appListings: true, appBlocks: false })).toBe(true);
+    // …and with `appBlocks` absent from the object entirely.
+    expect(hasAppsStoreAccess({ appListings: true })).toBe(true);
+  });
+
+  it('appBlocks ONLY → access (the OR-fallback that keeps today’s cohort in)', () => {
+    expect(hasAppsStoreAccess({ appListings: false, appBlocks: true })).toBe(true);
+    expect(hasAppsStoreAccess({ appBlocks: true })).toBe(true);
+  });
+
+  it('neither flag → NO access', () => {
+    expect(hasAppsStoreAccess({ appListings: false, appBlocks: false })).toBe(false);
+  });
+
+  it('fails CLOSED on an absent / empty features object', () => {
+    expect(hasAppsStoreAccess(undefined)).toBe(false);
+    expect(hasAppsStoreAccess(null)).toBe(false);
+    expect(hasAppsStoreAccess({})).toBe(false);
+  });
+
+  it('returns a real boolean, never the raw flag value', () => {
+    // Callers use it in `enabled:` positions that are typed `boolean`, and the
+    // old open-coded form (`features.appListings || features.appBlocks`) could
+    // yield `undefined`. Assert the type, not just truthiness.
+    expect(hasAppsStoreAccess({ appListings: undefined, appBlocks: undefined })).toBe(false);
+    expect(typeof hasAppsStoreAccess({ appListings: true })).toBe('boolean');
+    expect(typeof hasAppsStoreAccess({})).toBe('boolean');
+  });
+});
+
+/**
+ * 🔴 THE SEAM. The point of the extraction is that the SSR gate and the shared
+ * predicate cannot disagree — a component tested in isolation and a resolver
+ * tested in isolation can both be green while the pair is incoherent. This
+ * asserts the RELATIONSHIP over the full matrix rather than either side alone,
+ * so it fails if `resolveAppsPageAccess` is ever re-inlined and then edited.
+ */
+describe('resolveAppsPageAccess is EXACTLY hasAppsStoreAccess (no drift)', () => {
+  const MATRIX: Array<{ appListings?: boolean; appBlocks?: boolean }> = [
+    { appListings: true, appBlocks: true },
+    { appListings: true, appBlocks: false },
+    { appListings: false, appBlocks: true },
+    { appListings: false, appBlocks: false },
+    { appListings: true },
+    { appBlocks: true },
+    {},
+  ];
+
+  for (const features of MATRIX) {
+    it(`agrees for ${JSON.stringify(features)}`, () => {
+      const granted = hasAppsStoreAccess(features);
+      const result = resolveAppsPageAccess({ features });
+      expect('props' in result).toBe(granted);
+      expect('notFound' in result).toBe(!granted);
+    });
+  }
+
+  it('agrees on the nullish features cases too', () => {
+    for (const features of [undefined, null] as const) {
+      expect(hasAppsStoreAccess(features)).toBe(false);
+      expect(resolveAppsPageAccess({ features })).toEqual({ notFound: true });
+    }
+  });
+});

--- a/src/components/Apps/resolveAppsPageAccess.ts
+++ b/src/components/Apps/resolveAppsPageAccess.ts
@@ -6,7 +6,10 @@
  * 🔒 GATING INVARIANT (F-E E1 + W13 PR-W1a/D8 — do not violate):
  *   - The STORE-VISIBILITY flag gate is FIRST and is the ONLY access control.
  *     W13 repoints it onto the dedicated `appListings` flag with an OR-fallback
- *     to `appBlocks`: access = `features.appListings || features.appBlocks`. A
+ *     to `appBlocks`. The boolean itself is NOT written here — it lives in the
+ *     shared `hasAppsStoreAccess` predicate (`~/shared/utils/app-blocks-access`)
+ *     that every store surface calls, so the SSR gate and the client-side gates
+ *     cannot drift apart. Access = `features.appListings || features.appBlocks`. A
  *     logged-out / non-mod user satisfies NEITHER (both are mod-segmented today),
  *     so access is false for them → notFound. The store stays dark for real
  *     anon/non-mod users until a segment is widened at launch.
@@ -24,15 +27,17 @@
  *     (mods-only today). (`deIndex` is kept ON in the page <Meta> so the page is
  *     not crawlable pre-launch.)
  */
+import { hasAppsStoreAccess } from '~/shared/utils/app-blocks-access';
+
 export type AppsPageAccessResult = { notFound: true } | { props: Record<string, never> };
 
 export function resolveAppsPageAccess(args: {
   features?: { appBlocks?: boolean; appListings?: boolean } | null;
 }): AppsPageAccessResult {
   // Store-visibility gate FIRST and ONLY. No session check — the dark anon path
-  // renders behind the flag. W13: dedicated `appListings` flag OR-falling-back to
-  // `appBlocks` so the current mods+testers cohort keeps access while
-  // `app-listings` doesn't yet exist (zero behavior change today).
-  if (!(args.features?.appListings || args.features?.appBlocks)) return { notFound: true };
+  // renders behind the flag. The predicate is SHARED (`hasAppsStoreAccess`) with
+  // every other store surface, including the `/apps/*` sub-nav, so there is one
+  // rule in one place and the gates cannot disagree.
+  if (!hasAppsStoreAccess(args.features)) return { notFound: true };
   return { props: {} };
 }

--- a/src/components/Apps/resolveAppsPageAccess.ts
+++ b/src/components/Apps/resolveAppsPageAccess.ts
@@ -27,12 +27,15 @@
  *     (mods-only today). (`deIndex` is kept ON in the page <Meta> so the page is
  *     not crawlable pre-launch.)
  */
-import { hasAppsStoreAccess } from '~/shared/utils/app-blocks-access';
+import { hasAppsStoreAccess, type AppsStoreFeatureFlags } from '~/shared/utils/app-blocks-access';
 
 export type AppsPageAccessResult = { notFound: true } | { props: Record<string, never> };
 
 export function resolveAppsPageAccess(args: {
-  features?: { appBlocks?: boolean; appListings?: boolean } | null;
+  // The SHARED flag type, derived from `FeatureAccess` — so renaming/removing
+  // `appListings` at GA breaks HERE at compile time rather than silently
+  // degrading this gate to `appBlocks`-only.
+  features?: AppsStoreFeatureFlags;
 }): AppsPageAccessResult {
   // Store-visibility gate FIRST and ONLY. No session check — the dark anon path
   // renders behind the flag. The predicate is SHARED (`hasAppsStoreAccess`) with

--- a/src/components/Apps/resolveLegacyAppRedirect.ts
+++ b/src/components/Apps/resolveLegacyAppRedirect.ts
@@ -56,6 +56,7 @@
  * `/apps/store-preview/` (an open redirect) or splicing a query/fragment onto it.
  */
 import { resolveAppsPageAccess } from '~/components/Apps/resolveAppsPageAccess';
+import type { AppsStoreFeatureFlags } from '~/shared/utils/app-blocks-access';
 
 export type LegacyAppRedirectResult =
   | { redirect: { destination: string; permanent: false } }
@@ -161,7 +162,9 @@ export function approvedListingSlugQuery(appBlockId: string) {
  * past its current audience is the fix.
  */
 export async function resolveLegacyAppRoute(args: {
-  features?: { appBlocks?: boolean; appListings?: boolean } | null;
+  // The SHARED flag type (derived from `FeatureAccess`), so a rename at GA is a
+  // compile error here too — this resolver forwards straight into the store gate.
+  features?: AppsStoreFeatureFlags;
   appBlockId?: unknown;
   /** Approved-only slug lookup. Use `approvedListingSlugQuery` to build it. */
   findApprovedListingSlug: (appBlockId: string) => Promise<string | null | undefined>;

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -36,7 +36,8 @@ export default function AppsPage() {
           `AppListing` record (both on-site App Blocks AND off-site OAuth apps)
           via `AppListingsMarketplaceBody` (the P2a `appListings.listAvailable`
           read path). Still dark/mod-only — the page gate is UNCHANGED
-          (`resolveAppsPageAccess` → `features.appBlocks` Flipt mod segment,
+          (`resolveAppsPageAccess` → the shared `hasAppsStoreAccess` predicate,
+          i.e. `appListings || appBlocks`, both mod-segmented in Flipt today;
           `deIndex`), this only swaps WHICH grid renders.
 
           ROLLBACK = one-line revert: the legacy AppBlock path

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -6,6 +6,7 @@ import { resolveAppsPageAccess } from '~/components/Apps/resolveAppsPageAccess';
 import { Meta } from '~/components/Meta/Meta';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
+import { hasAppsStoreAccess } from '~/shared/utils/app-blocks-access';
 
 export const getServerSideProps = createServerSideProps({
   useSession: true,
@@ -20,10 +21,9 @@ export default function AppsPage() {
   const features = useFeatureFlags();
 
   // W13 (PR-W1a/D8): store-visibility gate = dedicated `appListings` OR-falling-
-  // back to `appBlocks` (mirrors the SSR `resolveAppsPageAccess` gate). Zero
-  // behavior change today — `app-listings` doesn't exist yet, so `appListings`
-  // resolves mods-only and `appBlocks` covers the app-dev-testers cohort.
-  if (!(features.appListings || features.appBlocks)) return <NotFound />;
+  // back to `appBlocks`. The SHARED predicate, so this body and the SSR
+  // `resolveAppsPageAccess` gate above are literally the same rule.
+  if (!hasAppsStoreAccess(features)) return <NotFound />;
 
   return (
     <>

--- a/src/pages/apps/store-preview/[slug].tsx
+++ b/src/pages/apps/store-preview/[slug].tsx
@@ -9,6 +9,7 @@ import { Meta } from '~/components/Meta/Meta';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import type { ListingDetail } from '~/server/schema/blocks/app-listing-read.schema';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
+import { hasAppsStoreAccess } from '~/shared/utils/app-blocks-access';
 import { trpc } from '~/utils/trpc';
 
 /**
@@ -42,9 +43,9 @@ export default function AppStoreListingDetailPage() {
   // today) with a slug. Returns ONLY the ListingDetail allowlist; a missing /
   // non-approved slug 404s server-side. retry:false so it settles into NotFound.
   // W13 (PR-W1a/D8): store-visibility gate = dedicated `appListings` OR-falling-
-  // back to `appBlocks`. Zero behavior change today (the `app-listings` flag
-  // doesn't exist yet, so this resolves to today's mods+app-dev-testers cohort).
-  const canSeeStore = features.appListings || features.appBlocks;
+  // back to `appBlocks`. The SHARED predicate, identical to the SSR
+  // `resolveAppsPageAccess` gate above.
+  const canSeeStore = hasAppsStoreAccess(features);
   const { data, isLoading, error } = trpc.appListings.getAppDetail.useQuery(
     { slug },
     { enabled: !!canSeeStore && !!slug, retry: false }

--- a/src/shared/utils/app-blocks-access.ts
+++ b/src/shared/utils/app-blocks-access.ts
@@ -79,11 +79,23 @@ export type AppsStoreFeatureFlags =
 /**
  * App Blocks — App STORE-VISIBILITY gate (`appListings || appBlocks`).
  *
- * 🔒 THE SINGLE SOURCE OF TRUTH for "may this viewer see the /apps store".
- * Every store surface — the `/apps` SSR resolver (`resolveAppsPageAccess`),
- * the `/apps` page body, the store-preview route, the marketplace grid query,
- * the related-listings rail, and the `/apps/*` sub-nav — routes through THIS
- * predicate. Do NOT re-inline `features.appListings || features.appBlocks`; the
+ * 🔒 THE SINGLE SOURCE OF TRUTH for "may this viewer see the /apps store", for
+ * the six surfaces under `components/Apps` and `pages/apps`: the `/apps` SSR
+ * resolver (`resolveAppsPageAccess`), the `/apps` page body, the store-preview
+ * route, the marketplace grid query, the related-listings rail, and the `/apps/*`
+ * sub-nav. All six route through THIS predicate.
+ *
+ * ⚠️ "Every store surface" would be TOO STRONG, so it is not claimed. One
+ * store-visibility decision is deliberately NOT converted:
+ * `components/AppLayout/AppHeader/appsNavVisibility.ts` gates the user-menu
+ * "Apps" → `/apps` entry on `appBlocks` alone, and its own doc says it "stays
+ * gated on `appBlocks`" — a standing decision, not drift. Consequence worth
+ * knowing before the launch: for a `{appListings, NOT appBlocks}` cohort the
+ * store renders but has no in-product entry point, since that menu item is the
+ * only route TO `/apps`. Tracked in issue #3907 — settle it BEFORE widening
+ * `app-listings`, not after.
+ *
+ * Do NOT re-inline `features.appListings || features.appBlocks`; the
  * gates drifting apart is exactly what this function exists to prevent, and it
  * had already happened once: of the SIX store-visibility sites, five spelled the
  * OR out and the sixth — `AppsSubNav` — spelled only half of it (`appBlocks`

--- a/src/shared/utils/app-blocks-access.ts
+++ b/src/shared/utils/app-blocks-access.ts
@@ -51,6 +51,55 @@ export function isAppDeveloper(
 }
 
 /**
+ * The store-visibility flag pair, in the shape every caller already has in hand
+ * (`ctx.features` on the SSR side, `useFeatureFlags()` on the client). Optional
+ * + nullable so a Flipt-down / not-yet-created flag and an absent `features`
+ * object both flow in without a cast.
+ */
+export type AppsStoreFeatureFlags =
+  | { appBlocks?: boolean; appListings?: boolean }
+  | null
+  | undefined;
+
+/**
+ * App Blocks — App STORE-VISIBILITY gate (`appListings || appBlocks`).
+ *
+ * 🔒 THE SINGLE SOURCE OF TRUTH for "may this viewer see the /apps store".
+ * Every store surface — the `/apps` SSR resolver (`resolveAppsPageAccess`),
+ * the `/apps` page body, the store-preview route, the marketplace grid query,
+ * the related-listings rail, and the `/apps/*` sub-nav — routes through THIS
+ * predicate. Do NOT re-inline `features.appListings || features.appBlocks`; the
+ * gates drifting apart is exactly what this function exists to prevent, and it
+ * had already happened once: `AppsSubNav` gated on `appBlocks` ALONE while the
+ * canonical resolver ORed both, so an `app-listings`-only cohort would have
+ * loaded `/apps` with no sub-navigation at all.
+ *
+ * ## Why an OR, and which flag is which
+ *
+ * `appListings` (Flipt `app-listings`) is the DEDICATED catalog-visibility flag;
+ * `appBlocks` (Flipt `app-blocks-enabled`) doubles as the block-RUNTIME
+ * kill-switch. W13 split them so the store catalog can widen to public
+ * INDEPENDENTLY of the deliberately-held block-runtime GA — a public launch
+ * widens ONLY `app-listings`. The OR-fallback to `appBlocks` keeps the CURRENT
+ * mods + `app-dev-testers` cohort's store access verbatim through the transition
+ * window (both flags resolve true for them today, so this is zero behaviour
+ * change). Drop the fallback only once `app-listings` is the sole, wider source
+ * of truth. Server-side mirror: `isAppListingsEnabled` in
+ * `~/server/services/app-blocks-flag`.
+ *
+ * 🔴 This is NOT the gate for the block-RUNTIME surfaces. `/apps/installed`,
+ * `/apps/review`, `/apps/my-submissions`, `/apps/revenue`, `/apps/run/<slug>`
+ * and the `blocks.*` tRPC procedures gate on `appBlocks` alone, on purpose —
+ * they need the runtime, not just the catalog. Widening them is a product
+ * decision, not a mechanical alignment; do not sweep them into this predicate.
+ *
+ * Fails CLOSED: absent / null features, or an empty object, → `false`.
+ */
+export function hasAppsStoreAccess(features: AppsStoreFeatureFlags): boolean {
+  return !!features?.appListings || !!features?.appBlocks;
+}
+
+/**
  * App Blocks — moderator REVIEW-surface access gate (`/apps/review`).
  *
  * Distinct from {@link isAppDeveloper} on purpose: reviewing OTHER people's

--- a/src/shared/utils/app-blocks-access.ts
+++ b/src/shared/utils/app-blocks-access.ts
@@ -1,3 +1,5 @@
+import type { FeatureAccess } from '~/server/services/feature-flags.service';
+
 /**
  * App Blocks — developer-surface access gate.
  *
@@ -55,9 +57,22 @@ export function isAppDeveloper(
  * (`ctx.features` on the SSR side, `useFeatureFlags()` on the client). Optional
  * + nullable so a Flipt-down / not-yet-created flag and an absent `features`
  * object both flow in without a cast.
+ *
+ * 🔴 DERIVED FROM `FeatureAccess`, NOT hand-written — this is load-bearing, and a
+ * hand-written `{ appBlocks?: boolean; appListings?: boolean }` was measurably
+ * worse. Under the structural version, dropping or renaming `appListings` in
+ * `feature-flags.service.ts` would make the OLD open-coded `features.appListings`
+ * reads fail with `TS2339`, but `hasAppsStoreAccess(features)` would keep
+ * compiling — silently degrading every store surface to `appBlocks`-only. That
+ * rename is not hypothetical: it is exactly the documented "drop the OR-fallback
+ * once `app-listings` is the sole source of truth" step at GA. Keying off
+ * `FeatureAccess` turns that silent degradation into a compile error here.
+ *
+ * The import is TYPE-ONLY, so nothing from the server module reaches a runtime
+ * bundle (the established pattern — see `src/shared/data-graph/generation/context.ts`).
  */
 export type AppsStoreFeatureFlags =
-  | { appBlocks?: boolean; appListings?: boolean }
+  | Partial<Pick<FeatureAccess, 'appBlocks' | 'appListings'>>
   | null
   | undefined;
 
@@ -70,9 +85,14 @@ export type AppsStoreFeatureFlags =
  * the related-listings rail, and the `/apps/*` sub-nav — routes through THIS
  * predicate. Do NOT re-inline `features.appListings || features.appBlocks`; the
  * gates drifting apart is exactly what this function exists to prevent, and it
- * had already happened once: `AppsSubNav` gated on `appBlocks` ALONE while the
- * canonical resolver ORed both, so an `app-listings`-only cohort would have
- * loaded `/apps` with no sub-navigation at all.
+ * had already happened once: of the SIX store-visibility sites, five spelled the
+ * OR out and the sixth — `AppsSubNav` — spelled only half of it (`appBlocks`
+ * alone), so an `app-listings`-only cohort would have loaded `/apps` with no
+ * sub-navigation at all.
+ *
+ * ENFORCED, not merely requested: `components/Apps/__tests__/appsStoreAccessCallSites.test.ts`
+ * pins the exact ledger of the six sites and fails if one is added, reverted, or
+ * re-inlines the boolean. Adding a store surface means adding it to that ledger.
  *
  * ## Why an OR, and which flag is which
  *


### PR DESCRIPTION
## The defect

Two capabilities grant `/apps` store visibility, and the canonical predicate ORs them:

```ts
// src/components/Apps/resolveAppsPageAccess.ts — enforced in getServerSideProps
if (!(args.features?.appListings || args.features?.appBlocks)) return { notFound: true };
```

The sub-nav gated on only one of them:

```ts
// src/components/Apps/AppsSubNav.tsx:273
if (!features.appBlocks) return null;
```

So a cohort holding `app-listings` **without** `app-blocks-enabled` would load `/apps`
successfully — SSR grants access, the page renders — and get **no sub-navigation at all**.

## Why it is not reachable today

The current tester cohort holds **both** `app-listings=true` and `app-blocks-enabled=true`
(verified live against Flipt), so the two predicates agree and the disagreement is
unobservable. This is forward-looking, not a live outage.

The risk is structural: `appListings` exists *precisely* so the store catalog can widen
INDEPENDENTLY of the deliberately-held block runtime — that is the documented purpose in
`resolveAppsPageAccess`'s header and in `app-blocks-flag.ts`. The expected shape of the
public store launch is "widen `app-listings` alone", which is exactly the flip that makes
the two gates disagree.

## The fix — one rule, one place

Rather than open-code the OR a second time, the rule is extracted into a single shared
predicate `hasAppsStoreAccess(features)` in `~/shared/utils/app-blocks-access` (alongside
the existing `isAppDeveloper` / `isAppReviewer` access gates), and **every** store surface
calls it. The expression was already open-coded at five sites; consolidating them is what
makes a future disagreement impossible rather than merely unlikely:

| Surface | Before | After |
|---|---|---|
| `resolveAppsPageAccess.ts` (SSR gate) | `appListings \|\| appBlocks` | `hasAppsStoreAccess` |
| `AppsSubNav.tsx:273` (render gate) | **`appBlocks` only** ← the bug | `hasAppsStoreAccess` |
| `pages/apps/index.tsx:26` | `appListings \|\| appBlocks` | `hasAppsStoreAccess` |
| `pages/apps/store-preview/[slug].tsx:47` | `appListings \|\| appBlocks` | `hasAppsStoreAccess` |
| `AppListingsMarketplaceBody.tsx:221` | `!!(appListings \|\| appBlocks)` | `hasAppsStoreAccess` |
| `RelatedListings.tsx:56` | `!!(appListings \|\| appBlocks)` | `hasAppsStoreAccess` |

The four beyond the two named in the report are byte-identical restatements of the same
rule; adopting them is the consolidation, not scope creep. Behaviour is unchanged for
every cohort holding both flags — i.e. everyone today.

Deliberately **not** swept in: `/apps/installed`, `/apps/review`, `/apps/my-submissions`,
`/apps/revenue`, `/apps/run/<slug>` and the `blocks.*` procs all gate on `appBlocks` alone
**on purpose** — they need the block runtime, not just the catalog. Widening them is a
product decision, and the shared predicate's doc comment says so explicitly.

## The `:269` decision — the query gate stays on `appBlocks`

`enabled: !!features.appBlocks && !!currentUser` on `blocks.getNavSummary` is **left
alone**, and that is a decision, not an oversight.

A query gate must mirror the gate on the **procedure it calls**, not the gate on the page
it renders in. `getNavSummary` is `protectedProcedure.use(enforceAppBlocksFlag)`
(`blocks.router.ts:2537`) — the strict `app-blocks-enabled` check. Because it is a *query*,
that middleware short-circuits rather than throwing (`blocks.router.ts:260-264`), returning
the all-false summary **without running a single DB read**.

So for an `appListings`-only viewer, widening this `enabled` would buy a guaranteed
round-trip to a guaranteed all-false answer. And all-false is also the *correct* tab set for
that viewer: every conditional tab it feeds (Installed / My submissions / Revenue / Review)
points at a page that itself 404s without `appBlocks`. Showing them would recreate the
"tab straight into a 404" bug this component already fixed once for `Create`.

Reasoning is documented inline and pinned by three tests, so a later reader cannot "align"
the two flag reads on the assumption that everything in the file moves together.

## Honest scoping of the user-visible effect

The report framed the consequence as the cohort losing access to Installed / My submissions
/ Review / Create. **That overstates it, and the code disagrees.** Tracing it through:

- Installed / My submissions / Revenue / Review are driven by `getNavSummary`, which is
  server-gated on `app-blocks-enabled` and returns all-false for this cohort regardless.
  Those tabs stay hidden either way — correctly.
- `AppsSubNavView` also hides itself below two qualifying tabs. An `appListings`-only
  **non-author** qualifies for Marketplace alone, so they get no bar before *or* after this
  change — via the collapse rule, not via the gate.
- The one cohort whose rendered output actually changes is
  `{appListings, NOT appBlocks, isAuthor}`: previously no bar, now `[Marketplace, Create]`.

So the practical value here is **coherence, not a restored feature**: the two gates can no
longer drift, and the store predicate now has one definition instead of six. Worth stating
plainly rather than claiming a fix that the collapse rule and the server gate already cover.

## Known exposure this surfaces (pre-existing, not fixed here)

`/apps/submit`'s SSR gate is `appBlocksAuthor` + `isAppDeveloper` — it does **not** require
`appBlocks`. Its client body carries an extra `if (!features?.appBlocks) return <NotFound />`
(`submit.tsx:68`) that its own SSR gate does not. While the sub-nav gated on `appBlocks`,
the Create tab could only render when that flag was already true, so this check was
unreachable. It becomes reachable for the (empty today) cohort above, who would SSR into
the page and then hit a client-side 404.

The outlier is `submit.tsx`'s body, not the tab. Re-inlining `appBlocks` into the sub-nav
would recreate the very drift this PR removes, and whether authoring requires the block
runtime is a product call. Documented in a `⚠️` block above `SUB_NAV_LINKS` and left to a
follow-up.

## Mutation matrix

Every mutant was applied to the real source, both suites re-run, and the **specific failing
test names** read — not an exit code. Restores were `cp -a` from a backup, never
`git checkout --`.

| # | Mutant | Unit | Component | Killed on its own assertion? |
|---|---|---|---|---|
| M0 | baseline (unmutated) | 21 passed | 58 passed | — |
| **M1** | **revert `:273` → `!features.appBlocks` (the original defect)** | 21 passed | **4 failed** | ✅ `🔴 appListings ONLY (appBlocks OFF) → the sub-nav RENDERS` fails on its own `toBeInTheDocument`. Unit correctly unaffected — the mutant is component-only. |
| M2 | `hasAppsStoreAccess`: OR → **AND** | 6 failed | 17 failed | ✅ `appListings ONLY → access` and `appBlocks ONLY → access` both fail |
| M3 | `hasAppsStoreAccess`: **inverted** | 14 failed | 20 failed | ✅ every arm of the 2×2 flips |
| M4 | `hasAppsStoreAccess`: **constant `true`** | 7 failed | 2 failed | ✅ exactly the two "renders nothing" tests + all fail-closed unit cases |
| M5 | `hasAppsStoreAccess`: **constant `false`** | 7 failed | 18 failed | ✅ all three grant cases |
| M6 | drop the `appListings` arm (the exact historical drift) | 2 failed | 4 failed | ✅ `appListings ONLY → access` + the headline sub-nav test |

M1 is the required "watched it fail on pre-change code" evidence: red with the gate
reverted, green at HEAD.

Note M4's shape — constant `true` kills only **2** component tests, and they are precisely
the two absence assertions. That narrowness is what makes the barrier proof below meaningful.

### The absence assertions provably CAN fail

The report flagged that under a React 18 concurrent root, an absence assertion taken
immediately after render reads an empty container and passes regardless. Measured rather
than assumed, by neutering the gate to constant `true`:

| Configuration | "renders nothing" tests |
|---|---|
| **With** the awaited `RENDER_BARRIER` | **FAIL** ✅ (they can observe the defect) |
| **Without** it (the `await expect.element(...)` deleted) | **PASS** ❌ structurally unfailable |

So the barrier is load-bearing here, not ceremonial. That finding is recorded in the
suite's own comment so it cannot be removed as boilerplate. Each absence test is also
paired with an explicit positive control proving the same readers *do* observe a bar when
the gate opens — a reassuring zero is otherwise indistinguishable from a probe wired to
nothing.

## Test coverage added

- `__tests__/hasAppsStoreAccess.test.ts` (14 unit tests) — the full 2×2 matrix, fail-closed
  on absent/null/empty features, strict-boolean return, **plus a seam test asserting
  `resolveAppsPageAccess` agrees with the predicate across the whole matrix**. A component
  and a resolver each tested in isolation can both be green while the pair is incoherent;
  this pins the relationship.
- `AppsSubNav.storeGate.browser.test.tsx` (11 browser tests) — the sub-nav's rendered
  output for all four flag combinations, the collapse-vs-gate distinction, and the `:269`
  query-gate decision.

This suite mocks `useQuery` so it **honours `enabled`**, unlike the sibling hydration suite
which returns data unconditionally (right for what *that* file tests). Here the `enabled`
predicate is load-bearing for the answer, so the mock matches production and the decision
above is directly observable.

`src/components/Apps/__tests__/resolveAppsPageAccess.test.ts` is **unmodified** and green.

## Verification

- Typecheck: **0 errors**, baseline **0 errors** on a clean checkout of the base commit
  (`pnpm typecheck`, after `git submodule update --init --recursive` — an unpopulated
  `event-engine-common` produces phantom errors).
- Component suites touched by this change: **93 passed / 93** across 8 files
  (`AppsSubNav` ×4, `AppListingsMarketplaceBody` ×4). Baseline for the three pre-existing
  `AppsSubNav` suites measured first: 52/52.
- Unit: 45 passed / 45.
- ESLint **0 errors, 0 warnings across 9 files** — file count read from JSON output, and
  validated with a negative control (planted `const x: any` → 2 findings) so the clean
  verdict is not a claim about an empty file list. Prettier clean on all 9.

## What I did NOT verify

- **No live/browser check against a real `app-listings`-only account.** The cohort does not
  exist in Flipt today (both flags resolve true for the tester segment), so it cannot be
  driven end-to-end without changing flag state in production. Everything above is code
  tracing + component tests.
- **Server-side flag resolution was read, not exercised.** The `:269` reasoning rests on
  reading `enforceAppBlocksFlag` and `isAppListingsEnabled`; I did not stand up Flipt to
  confirm the short-circuit at runtime. The existing
  `blocks.router.getNavSummary.test.ts` does assert the flag-off path returns the all-false
  shape and runs no DB query, which is the load-bearing half.
- **`/apps/submit`'s client-body 404 exposure is reasoned, not reproduced** — the cohort
  that would hit it is empty, so there is no way to observe it today.
- The full component project was not run — only the 8 files touching the changed modules.
  Those are report-only in CI regardless; the live gate is `tekton / typecheck`, which is
  clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
