### PR TITLE
feat(generation): add Grok Imagine Image 2.0 behind a feature flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "@civitai/app-sdk": "^0.14.0",
     "@civitai/auth": "workspace:*",
     "@civitai/buzz": "workspace:*",
-    "@civitai/client": "0.2.0-beta.89",
+    "@civitai/client": "0.2.0-beta.90",
     "@civitai/cybertipline-tools": "^0.1.0",
     "@civitai/db-queries": "workspace:*",
     "@civitai/db-schema": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,8 +50,8 @@ importers:
         specifier: workspace:*
         version: link:packages/civitai-buzz
       '@civitai/client':
-        specifier: 0.2.0-beta.89
-        version: 0.2.0-beta.89
+        specifier: 0.2.0-beta.90
+        version: 0.2.0-beta.90
       '@civitai/cybertipline-tools':
         specifier: ^0.1.0
         version: 0.1.0
@@ -2085,8 +2085,8 @@ packages:
     resolution: {integrity: sha512-dSXkI8hVoozzlPS9DymzoyncWz8eapH3wkSDzDVGWjjqamXn8Dbcq1hWu5xUZkZmqCaR76F7BS9BQNqvOJ++Sw==}
     engines: {git: '>=2.11.0', node: '>=18.0.0', npm: '>=7.19.0', yarn: '>=1.7.0'}
 
-  '@civitai/client@0.2.0-beta.89':
-    resolution: {integrity: sha512-4W22+zHiaB0ItcaAxK32Cr4s/2J885PaPHDcKCSxgE6kpG2scez745u2i2YI69b9RD4ZBaAEo+ez0NWbqYSACw==}
+  '@civitai/client@0.2.0-beta.90':
+    resolution: {integrity: sha512-k7NpqVvbNCglPxVkz7cM80Nq167ZCAwebklad1F/WbY8X1FED1hFxMWyVlyT/WHjxQt/xk7DZ9dytTcYBo6KvA==}
     engines: {git: '>=2.11.0', node: '>=18.0.0', npm: '>=7.19.0', yarn: '>=1.7.0'}
 
   '@civitai/cybertipline-tools@0.1.0':
@@ -13835,7 +13835,7 @@ snapshots:
       rfc6902: 5.2.0
       tslib: 2.8.1
 
-  '@civitai/client@0.2.0-beta.89':
+  '@civitai/client@0.2.0-beta.90':
     dependencies:
       '@hey-api/client-fetch': 0.1.14
       rfc6902: 5.2.0

--- a/src/libs/data-graph/data-graph.ts
+++ b/src/libs/data-graph/data-graph.ts
@@ -1188,6 +1188,8 @@ export class DataGraph<
    * 2. A factory with deps: `.merge((ctx, ext) => createGraph(...), ['dep1', 'dep2'])`
    *    - Each entry's deps will be combined with the merge deps
    *    - Allows dynamic graph creation based on context
+   *    - Deps are ctx keys, or `ext:<key>` to re-run on an external-context
+   *      change (same convention `node` documents)
    */
   merge<
     ChildCtx extends Record<string, unknown>,
@@ -1210,7 +1212,7 @@ export class DataGraph<
     ChildExternal extends Record<string, unknown>,
     ChildMeta extends Record<string, unknown>,
     ChildValues extends Record<string, unknown>,
-    const Deps extends readonly (keyof Ctx & string)[]
+    const Deps extends readonly ((keyof Ctx & string) | `ext:${string}`)[]
   >(
     factory: (
       ctx: Ctx,

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -423,6 +423,13 @@ const featureFlags = createFeatureFlags({
   // from the img2model3d picker and rejected on submit (see ecosystem-graph.ts).
   tripoGenerator: { availability: ['mod'], fliptKey: 'tripo-generator' },
   hunyuan3dGenerator: { availability: ['mod'], fliptKey: 'hunyuan3d-generator' },
+  // Grok Imagine Image 2.0 — gates ONLY the v2.0 entry in the Grok version
+  // picker; v1.0 / v1.5 stay live regardless, so Grok image + video generation
+  // is unaffected when this is off. Mod-only until the `grok-imagine-2` Flipt
+  // flag exists (absent ⇒ this static fallback), which is also the widen and
+  // kill lever. Off ⇒ v2.0 is dropped from the picker and a submitted v2.0
+  // version id falls back to the ecosystem default (see grok-graph.ts).
+  grokImagine2: { availability: ['mod'], fliptKey: 'grok-imagine-2' },
   // Retool privileged endpoints — `granted` means the moderator must carry the
   // matching permission key in user.permissions. Endpoints lookup the key
   // directly from `RetoolAction.privileged`, so the permission name MUST stay

--- a/src/server/services/orchestrator/__tests__/grok.handler.test.ts
+++ b/src/server/services/orchestrator/__tests__/grok.handler.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Mocked for the EXIT CODE, not the assertions — see ecosystems.test.ts.
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+
+import { createGrokImageInput } from '../ecosystems/grok.handler';
+import { grokVersionIds } from '~/shared/data-graph/generation/version-ids';
+import type { GenerationHandlerCtx } from '../orchestration-new.service';
+
+const ctx = {
+  airs: {} as any,
+  user: { id: 1, isModerator: false },
+  baseStepIndex: 0,
+} as GenerationHandlerCtx;
+
+async function input(data: Record<string, unknown>) {
+  const [step] = await createGrokImageInput(data as any, ctx);
+  return step.input as Record<string, unknown>;
+}
+
+describe('createGrokImageInput', () => {
+  it('emits a v1.0 createImage without the v2-only fields', async () => {
+    const result = await input({
+      ecosystem: 'Grok',
+      workflow: 'txt2img',
+      model: { id: grokVersionIds['v1.0'] },
+      prompt: 'a cat',
+      quantity: 2,
+      aspectRatio: { value: '16:9' },
+    });
+
+    expect(result).toMatchObject({
+      engine: 'grok',
+      version: 'v1.0',
+      operation: 'createImage',
+      aspectRatio: '16:9',
+      quantity: 2,
+    });
+    expect(result.resolution).toBeUndefined();
+    expect(result.quality).toBeUndefined();
+  });
+
+  it('emits a v2.0 createImage carrying resolution and quality', async () => {
+    const result = await input({
+      ecosystem: 'Grok',
+      workflow: 'txt2img',
+      model: { id: grokVersionIds['v2.0'] },
+      prompt: 'a cat',
+      quantity: 1,
+      aspectRatio: { value: '1:1' },
+      resolution: '2k',
+      quality: 'medium',
+    });
+
+    expect(result).toMatchObject({
+      engine: 'grok',
+      version: 'v2.0',
+      operation: 'createImage',
+      aspectRatio: '1:1',
+      resolution: '2k',
+      quality: 'medium',
+    });
+  });
+
+  it('emits a v2.0 editImage with the source image urls', async () => {
+    const result = await input({
+      ecosystem: 'Grok',
+      workflow: 'img2img:edit',
+      model: { id: grokVersionIds['v2.0'] },
+      prompt: 'make it blue',
+      quantity: 1,
+      resolution: '1k',
+      quality: 'low',
+      images: [{ url: 'https://example.com/a.png' }, { url: 'https://example.com/b.png' }],
+    });
+
+    expect(result).toMatchObject({
+      engine: 'grok',
+      version: 'v2.0',
+      operation: 'editImage',
+      resolution: '1k',
+      quality: 'low',
+      images: ['https://example.com/a.png', 'https://example.com/b.png'],
+    });
+  });
+
+  it('emits a v1.0 editImage when v1.0 is selected with source images', async () => {
+    const result = await input({
+      ecosystem: 'Grok',
+      workflow: 'img2img:edit',
+      model: { id: grokVersionIds['v1.0'] },
+      prompt: 'make it blue',
+      quantity: 1,
+      images: [{ url: 'https://example.com/a.png' }],
+    });
+
+    expect(result).toMatchObject({
+      engine: 'grok',
+      version: 'v1.0',
+      operation: 'editImage',
+      images: ['https://example.com/a.png'],
+    });
+  });
+});

--- a/src/server/services/orchestrator/ecosystems/grok.handler.ts
+++ b/src/server/services/orchestrator/ecosystems/grok.handler.ts
@@ -4,9 +4,13 @@
  * Handles xAI Grok Imagine workflows for both image and video generation.
  * Image workflows use imageGen step type, video workflows use videoGen step type.
  *
- * Image operations (version-less on the API — v1.5 is video-only):
+ * Image operations, v1.0:
  * - createImage: Text to image (GrokCreateImageGenInput)
  * - editImage: Edit with source images (GrokEditImageGenInput)
+ *
+ * Image operations, v2.0 (Grok Imagine Image 2.0 — image-only version):
+ * - createImage: Text to image (GrokV2CreateImageGenInput)
+ * - editImage: Edit with 1-3 source images (GrokV2EditImageGenInput)
  *
  * Video operations, v1.0:
  * - text-to-video: Text to video (GrokTextToVideoInput)
@@ -22,6 +26,8 @@
 import type {
   GrokCreateImageGenInput,
   GrokEditImageGenInput,
+  GrokV2CreateImageGenInput,
+  GrokV2EditImageGenInput,
   GrokTextToVideoInput,
   GrokImageToVideoInput,
   GrokEditVideoInput,
@@ -37,6 +43,7 @@ import type { GenerationGraphTypes } from '~/shared/data-graph/generation/genera
 import {
   grokVideoAspectRatiosByResolution,
   isGrokV15,
+  isGrokV2,
 } from '~/shared/data-graph/generation/grok-graph';
 import { defineHandler } from './handler-factory';
 
@@ -46,7 +53,7 @@ type GrokCtx = EcosystemGraphOutput & { ecosystem: 'Grok' };
 
 /**
  * Creates imageGen input for Grok image workflows.
- * Handles both createImage and editImage operations.
+ * Handles both createImage and editImage operations, on v1.0 and v2.0.
  */
 export const createGrokImageInput = defineHandler<GrokCtx, [ImageGenStepTemplate]>((data) => {
   const hasImages = !!data.images?.length;
@@ -58,12 +65,50 @@ export const createGrokImageInput = defineHandler<GrokCtx, [ImageGenStepTemplate
     aspectRatio: data.aspectRatio?.value,
   };
 
+  if (isGrokV2(data.model?.id)) {
+    const v2Base = {
+      ...baseData,
+      version: 'v2.0' as const,
+      resolution:
+        'resolution' in data
+          ? (data.resolution as GrokV2CreateImageGenInput['resolution'])
+          : undefined,
+      quality:
+        'quality' in data ? (data.quality as GrokV2CreateImageGenInput['quality']) : undefined,
+    };
+
+    if (hasImages) {
+      return [
+        {
+          $type: 'imageGen',
+          input: removeEmpty({
+            ...v2Base,
+            operation: 'editImage',
+            images: data.images!.map((x) => x.url),
+          }) as GrokV2EditImageGenInput,
+        },
+      ];
+    }
+
+    return [
+      {
+        $type: 'imageGen',
+        input: removeEmpty({
+          ...v2Base,
+          operation: 'createImage',
+        }) as GrokV2CreateImageGenInput,
+      },
+    ];
+  }
+
+  const v1Base = { ...baseData, version: 'v1.0' as const };
+
   if (hasImages) {
     return [
       {
         $type: 'imageGen',
         input: removeEmpty({
-          ...baseData,
+          ...v1Base,
           operation: 'editImage',
           images: data.images!.map((x) => x.url),
         }) as GrokEditImageGenInput,
@@ -75,7 +120,7 @@ export const createGrokImageInput = defineHandler<GrokCtx, [ImageGenStepTemplate
     {
       $type: 'imageGen',
       input: removeEmpty({
-        ...baseData,
+        ...v1Base,
         operation: 'createImage',
       }) as GrokCreateImageGenInput,
     },

--- a/src/shared/data-graph/generation/config/workflows.ts
+++ b/src/shared/data-graph/generation/config/workflows.ts
@@ -173,7 +173,7 @@ export const workflowConfigs: WorkflowConfigs = {
     description: 'Generate an AI image from text',
     category: 'image',
     ecosystemIds: TXT2IMG_IDS,
-    // Grok image generation is version-less on the API — v1.5 is video-only.
+    // Grok v1.5 is video-only.
     excludeModelVersionIds: [grokVersionIds['v1.5']],
   },
 
@@ -290,6 +290,8 @@ export const workflowConfigs: WorkflowConfigs = {
     description: 'Generate video from text',
     category: 'video',
     ecosystemIds: TXT2VID_IDS,
+    // Grok v2.0 is image-only.
+    excludeModelVersionIds: [grokVersionIds['v2.0']],
   },
 
   img2vid: {
@@ -297,6 +299,7 @@ export const workflowConfigs: WorkflowConfigs = {
     description: 'Generate video from an image',
     category: 'video',
     ecosystemIds: [...TXT2VID_IDS, ...I2V_ONLY_IDS],
+    excludeModelVersionIds: [grokVersionIds['v2.0']],
   },
 
   'img2vid:first-last': {
@@ -333,7 +336,7 @@ export const workflowConfigs: WorkflowConfigs = {
       ECO.Grok,
     ],
     // Grok referenceToVideo is a v1.5-only operation.
-    excludeModelVersionIds: [viduVersionIds.q3, grokVersionIds['v1.0']],
+    excludeModelVersionIds: [viduVersionIds.q3, grokVersionIds['v1.0'], grokVersionIds['v2.0']],
   },
 
   // ===========================================================================
@@ -363,7 +366,11 @@ export const workflowConfigs: WorkflowConfigs = {
     ecosystemIds: [ECO.Grok, ECO.WanVideo27, ECO.HappyHorse],
     // HappyHorse v1.1 has no videoEdit operation — v1.0 only.
     // Grok edit-video is likewise v1.0-only.
-    excludeModelVersionIds: [happyHorseVersionIds['v1.1'], grokVersionIds['v1.5']],
+    excludeModelVersionIds: [
+      happyHorseVersionIds['v1.1'],
+      grokVersionIds['v1.5'],
+      grokVersionIds['v2.0'],
+    ],
   },
 
   // Disabled — LTXV23 extendVideo is producing poor results. Re-enable once

--- a/src/shared/data-graph/generation/grok-graph.test.ts
+++ b/src/shared/data-graph/generation/grok-graph.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { generationGraph } from './generation-graph';
+import { grokVersionIds } from './version-ids';
+import type { GenerationCtx } from './context';
+
+const baseExt: GenerationCtx = {
+  limits: { maxQuantity: 4, maxResources: 9, vidQuantity: 1 },
+  user: { isMember: true, tier: 'gold' },
+  gateRules: [],
+};
+
+const flagOn: GenerationCtx = { ...baseExt, flags: { grokImagine2: true } };
+
+function init(workflow: string, modelId: number, ext: GenerationCtx = flagOn) {
+  const graph = generationGraph as any;
+  graph.init(
+    {
+      workflow,
+      ecosystem: 'Grok',
+      model: { id: modelId, baseModel: 'Grok', model: { type: 'Checkpoint' } },
+    },
+    ext
+  );
+  return graph;
+}
+
+const imagesMax = (g: any) => g.getSnapshot('images').meta.max;
+const versionIds = (g: any) =>
+  (g.getNodeMeta('model')?.versions?.options ?? []).map((o: any) => o.value);
+const selectedModelId = (g: any) => g.getSnapshot().model?.id;
+
+describe('grok image versions', () => {
+  // `hasNode` is what `useGraphSubscription` checks; a missing node makes
+  // `Controller` render null, which is how a control disappears from the form.
+  it('exposes resolution and quality only on v2.0', () => {
+    const v2 = init('txt2img', grokVersionIds['v2.0']);
+    expect(v2.hasNode('resolution')).toBe(true);
+    expect(v2.hasNode('quality')).toBe(true);
+
+    const v1 = init('txt2img', grokVersionIds['v1.0']);
+    expect(v1.hasNode('resolution')).toBe(false);
+    expect(v1.hasNode('quality')).toBe(false);
+  });
+
+  it('caps edit source images at 3 on v2.0 and 7 on v1.0', () => {
+    expect(imagesMax(init('img2img:edit', grokVersionIds['v2.0']))).toBe(3);
+    expect(imagesMax(init('img2img:edit', grokVersionIds['v1.0']))).toBe(7);
+  });
+
+  it('re-evaluates the image cap when the version is switched in place', () => {
+    const g = init('img2img:edit', grokVersionIds['v1.0']);
+    expect(imagesMax(g)).toBe(7);
+    g.set({ model: { id: grokVersionIds['v2.0'], model: { type: 'Checkpoint' } } });
+    expect(imagesMax(g)).toBe(3);
+  });
+});
+
+describe('grokImagine2 feature flag', () => {
+  it('offers v2.0 in the version picker only when the flag is on', () => {
+    expect(versionIds(init('txt2img', grokVersionIds['v1.0']))).toContain(grokVersionIds['v2.0']);
+
+    const off = init('txt2img', grokVersionIds['v1.0'], baseExt);
+    expect(versionIds(off)).toEqual([grokVersionIds['v1.0'], grokVersionIds['v1.5']]);
+  });
+
+  it('fails closed — an absent flags object hides v2.0', () => {
+    const noFlags = init('txt2img', grokVersionIds['v1.0'], baseExt);
+    expect(versionIds(noFlags)).not.toContain(grokVersionIds['v2.0']);
+  });
+
+  // Grok is `modelLocked`, so the model node clamps any id outside the version
+  // options back to the ecosystem default. That is the server-side half of the
+  // gate: a v2.0 id submitted with the flag off generates v1.0, it does not
+  // reach the v2.0 handler branch.
+  it('clamps a submitted v2.0 id back to v1.0 when the flag is off', () => {
+    const off = init('txt2img', grokVersionIds['v2.0'], baseExt);
+    expect(selectedModelId(off)).toBe(grokVersionIds['v1.0']);
+    expect(off.hasNode('resolution')).toBe(false);
+
+    const on = init('txt2img', grokVersionIds['v2.0']);
+    expect(selectedModelId(on)).toBe(grokVersionIds['v2.0']);
+  });
+});

--- a/src/shared/data-graph/generation/grok-graph.ts
+++ b/src/shared/data-graph/generation/grok-graph.ts
@@ -4,13 +4,16 @@
  * Controls for Grok ecosystem (xAI Grok Imagine).
  * Supports both image and video generation workflows.
  *
- * Version-selectable (v1.0 / v1.5) via the model picker. Image generation is
- * version-less on the API, so the image workflows are v1.0-only and excluded for
- * v1.5 in config/workflows.ts.
+ * Version-selectable (v1.0 / v1.5 / v2.0) via the model picker. v1.5 is
+ * video-only and v2.0 is image-only, so each is excluded from the workflows it
+ * can't serve in config/workflows.ts.
  *
- * Image workflows (v1.0 only):
- * - txt2img: Create image from text (GrokCreateImageGenInput)
- * - img2img:edit: Edit image with AI (GrokEditImageGenInput)
+ * Image workflows (v1.0 and v2.0):
+ * - txt2img: Create image from text (GrokCreateImageGenInput / GrokV2CreateImageGenInput)
+ * - img2img:edit: Edit image with AI (GrokEditImageGenInput / GrokV2EditImageGenInput)
+ *
+ * v2.0 additionally exposes resolution (1k/2k) and quality (low/medium), and
+ * accepts at most 3 source images to edit against v1.0's 7.
  *
  * Video workflows:
  * - txt2vid          → 'text-to-video' (v1.0) / 'textToVideo' (v1.5)
@@ -41,6 +44,7 @@ import {
   type GenerationAspectRatio,
 } from '~/shared/constants/generation.constants';
 import { grokVersionIds } from './version-ids';
+import type { FeatureAccess } from '~/server/services/feature-flags.service';
 
 // =============================================================================
 // Constants
@@ -85,14 +89,37 @@ const grokResolutions = [
 /** v1.5 text-to-video and image-to-video additionally accept 1080p */
 const grokV15Resolutions = [...grokResolutions, { label: '1080p', value: '1080p' }] as const;
 
-/** Options for the Grok version selector (using version IDs as values) */
-const grokVersionOptions = [
+/** Grok Imagine Image 2.0 output resolutions */
+const grokV2Resolutions = [
+  { label: '1K', value: '1k' },
+  { label: '2K', value: '2k' },
+] as const;
+
+/** Grok Imagine Image 2.0 quality tiers */
+const grokV2Qualities = [
+  { label: 'Low', value: 'low' },
+  { label: 'Medium', value: 'medium' },
+] as const;
+
+/**
+ * Options for the Grok version selector (using version IDs as values).
+ *
+ * v2.0 is behind the `grokImagine2` flag. Dropping it from the options both
+ * hides it client-side and makes the model node reject it: Grok is
+ * `modelLocked`, so a submitted id outside the version options is clamped back
+ * to the ecosystem default. Fail-closed — an absent `ext.flags` hides v2.0.
+ */
+const getGrokVersionOptions = (flags?: Partial<FeatureAccess>) => [
   { label: 'v1.0', value: grokVersionIds['v1.0'] },
   { label: 'v1.5', value: grokVersionIds['v1.5'] },
+  ...(flags?.grokImagine2 === true ? [{ label: 'v2.0', value: grokVersionIds['v2.0'] }] : []),
 ];
 
 /** True when the selected model version is Grok Imagine v1.5 */
 const isGrokV15 = (modelId?: number) => modelId === grokVersionIds['v1.5'];
+
+/** True when the selected model version is Grok Imagine Image 2.0 */
+const isGrokV2 = (modelId?: number) => modelId === grokVersionIds['v2.0'];
 
 // =============================================================================
 // Image Subgraph
@@ -104,6 +131,7 @@ type GrokImageCtx = {
   ecosystem: string;
   workflow: string;
   output: 'image';
+  model?: { id: number };
   images?: ImageEntry[];
 };
 
@@ -111,10 +139,10 @@ const grokImageGraph = new DataGraph<GrokImageCtx, GenerationCtx>()
   .node(
     'images',
     (ctx) => ({
-      ...imagesNode({ max: 7 }),
+      ...imagesNode({ max: isGrokV2(ctx.model?.id) ? 3 : 7 }),
       when: ctx.workflow === 'img2img:edit',
     }),
-    ['workflow']
+    ['workflow', 'model']
   )
   .node(
     'aspectRatio',
@@ -123,6 +151,22 @@ const grokImageGraph = new DataGraph<GrokImageCtx, GenerationCtx>()
       when: ctx.workflow !== 'img2img:edit',
     }),
     ['workflow']
+  )
+  .node(
+    'resolution',
+    (ctx) => ({
+      ...enumNode({ options: grokV2Resolutions, defaultValue: '2k' }),
+      when: isGrokV2(ctx.model?.id),
+    }),
+    ['model']
+  )
+  .node(
+    'quality',
+    (ctx) => ({
+      ...enumNode({ options: grokV2Qualities, defaultValue: 'medium' }),
+      when: isGrokV2(ctx.model?.id),
+    }),
+    ['model']
   );
 
 // =============================================================================
@@ -215,9 +259,14 @@ type GrokCtx = {
  * Uses a discriminator on the parent's `output` node to split into image/video subgraphs.
  */
 export const grokGraph = new DataGraph<GrokCtx, GenerationCtx>()
-  // Version-locked model (v1.0 / v1.5) — swap button hidden via modelLocked in
-  // ecosystemSettings; the default model id comes from ecosystemSettings.
-  .merge(() => createCheckpointGraph({ versions: { options: grokVersionOptions } }), [])
+  // Version-locked model (v1.0 / v1.5, plus v2.0 when its flag is on) — swap
+  // button hidden via modelLocked in ecosystemSettings; the default model id
+  // comes from ecosystemSettings.
+  .merge(
+    (_ctx, ext) =>
+      createCheckpointGraph({ versions: { options: getGrokVersionOptions(ext.flags) } }),
+    ['ext:flags']
+  )
 
   // Seed node
   .node('seed', seedNode())
@@ -240,5 +289,9 @@ export {
   grokVideoAspectRatiosByResolution,
   grokResolutions,
   grokV15Resolutions,
+  grokV2Resolutions,
+  grokV2Qualities,
+  getGrokVersionOptions,
   isGrokV15,
+  isGrokV2,
 };

--- a/src/shared/data-graph/generation/version-ids.ts
+++ b/src/shared/data-graph/generation/version-ids.ts
@@ -50,4 +50,5 @@ export const flux3VideoVersionIds = {
 export const grokVersionIds = {
   'v1.0': 2738377,
   'v1.5': 3197990,
+  'v2.0': 3225510,
 } as const;

--- a/src/shared/orchestrator/ImageGen/grok.config.ts
+++ b/src/shared/orchestrator/ImageGen/grok.config.ts
@@ -3,6 +3,7 @@ import { ImageGenConfig } from '~/shared/orchestrator/ImageGen/ImageGenConfig';
 
 export const grokModelVersionToModelMap = new Map<number, { name: string }>([
   [2738377, { name: 'grok-imagine' }],
+  [3225510, { name: 'grok-imagine' }],
 ]);
 
 export const grokConfig = ImageGenConfig({
@@ -23,6 +24,7 @@ export const grokConfig = ImageGenConfig({
     if (!params.images?.length) {
       return {
         engine: 'grok',
+        version: 'v1.0',
         operation: 'createImage',
         prompt: params.prompt,
         quantity: params.quantity,
@@ -32,6 +34,7 @@ export const grokConfig = ImageGenConfig({
 
     return {
       engine: 'grok',
+      version: 'v1.0',
       operation: 'editImage',
       prompt: params.prompt,
       quantity: params.quantity,


### PR DESCRIPTION
Adds a v2.0 entry to the Grok version picker with its own resolution/quality controls, a 3-image edit cap, and v2-specific orchestrator inputs, bumping @civitai/client to beta.90 for the new types. The version is gated by the mod-only `grokImagine2` flag and excluded from the video workflows it can't serve, so existing Grok image and video generation is unchanged when the flag is off.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
Implemented by the local ticket agent (task `868kqktub`). Reviewed locally before push.