### PR TITLE
fix(generation): stop one user's gate decision stripping another user's moderation flags (#3873)

### DIFF
--- a/src/server/services/generation/__tests__/generation.service.resource-data-aliasing.test.ts
+++ b/src/server/services/generation/__tests__/generation.service.resource-data-aliasing.test.ts
@@ -1,0 +1,251 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Cross-request isolation for the moderation flags on a cached generation resource.
+ *
+ * `getResourceData` strips `model.sfwOnly` / `model.minor` from a resource the requesting user
+ * cannot generate with. `canGenerate` is a PER-USER decision (ownership, moderator status,
+ * per-user gates), so two concurrent callers can legitimately disagree about it.
+ *
+ * The record those flags hang off comes from the shared per-id resource cache. That cache clones a
+ * record only at the TOP level, so on its fail-open path — where one origin lookup is single-flighted
+ * and its result handed to every caller that joined the window — the nested `model` object is ONE
+ * object shared by all of them. Removing a field from it in place therefore applies one user's gate
+ * decision to another user's payload.
+ *
+ * Nothing here hand-constructs the sharing. A rejecting cache read forces the real fail-open path, a
+ * gated origin query holds the real lookup open so a second caller joins the same in-flight promise,
+ * and the assertions read what the real `getResourceData` returns.
+ */
+
+const mGetMock = vi.fn();
+const setMock = vi.fn().mockResolvedValue(undefined);
+const setNxMock = vi.fn().mockResolvedValue(true);
+const delMock = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('~/server/redis/client', () => {
+  const sysKeyProxy: any = new Proxy(() => 'sys', { get: () => sysKeyProxy });
+  return {
+    redis: {
+      packed: {
+        mGet: (...args: unknown[]) => mGetMock(...args),
+        set: (...args: unknown[]) => setMock(...args),
+        get: vi.fn(),
+      },
+      setNxKeepTtlWithEx: (...args: unknown[]) => setNxMock(...args),
+      del: (...args: unknown[]) => delMock(...args),
+      get: vi.fn(),
+      set: vi.fn(),
+    },
+    // getGateRules reads this; null => no gate rules configured.
+    sysRedis: { hGet: vi.fn().mockResolvedValue(null), hSet: vi.fn() },
+    REDIS_KEYS: {
+      CACHE_LOCKS: 'caches:lock',
+      GENERATION: { RESOURCE_DATA: 'packed:generation:resource-data-3' },
+    },
+    REDIS_SYS_KEYS: sysKeyProxy,
+    REDIS_SUB_KEYS: sysKeyProxy,
+    withSysReadDeadline: vi.fn((p: Promise<unknown>) => p),
+  };
+});
+
+const { degradedInc, originFetchInc } = vi.hoisted(() => ({
+  degradedInc: vi.fn(),
+  originFetchInc: vi.fn(),
+}));
+vi.mock('~/server/prom/client', () => ({
+  cacheHitCounter: { inc: vi.fn() },
+  cacheMissCounter: { inc: vi.fn() },
+  cacheRevalidateCounter: { inc: vi.fn() },
+  cacheFailOpenDegradedCounter: { inc: degradedInc },
+  cacheFailOpenOriginFetchCounter: { inc: originFetchInc },
+}));
+
+// The origin for the REAL resourceDataCache lookupFn (a raw query in resource-data.redis).
+const { queryRawMock } = vi.hoisted(() => ({ queryRawMock: vi.fn() }));
+vi.mock('~/server/db/client', () => ({
+  dbRead: { $queryRaw: queryRawMock },
+  dbWrite: { $queryRaw: queryRawMock },
+}));
+
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: vi.fn() }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/search-index', () => ({ modelsSearchIndex: {} }));
+vi.mock('~/server/services/common.service', () => ({ hasEntityAccess: vi.fn() }));
+vi.mock('~/server/services/orchestrator/ecosystems/wan.handler', () => ({
+  wanBaseModelGroupIdMap: {},
+}));
+vi.mock('~/server/db/db-lag-helpers', () => ({
+  getDbWithoutLag: vi.fn(),
+  // Only reached for resources needing substitutes; returns no candidate versions.
+  getDbWithoutLagBatch: vi.fn(async () => ({
+    modelVersion: { findMany: vi.fn(async () => []) },
+  })),
+}));
+vi.mock('~/server/services/model.service', () => ({ getFeaturedModels: vi.fn(async () => []) }));
+vi.mock('~/server/services/model-file.service', () => ({
+  getFilesForModelVersionCache: vi.fn(async () => ({})),
+}));
+vi.mock('~/server/services/model-version.service', () => ({
+  getLinkedVaeIds: vi.fn(),
+  bustMvCache: vi.fn(),
+}));
+vi.mock('~/server/services/image.service', () => ({ imagesForModelVersionsCache: {} }));
+vi.mock('~/server/services/generation/paid-access-gating', () => ({
+  applyPaidAccessGating: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/services/generation/version-generation-state.service', () => ({
+  getVisibleSystemWildcardSetIdsByVersionId: vi.fn(async () => new Map()),
+}));
+vi.mock('~/server/flipt/client', () => ({
+  FLIPT_FEATURE_FLAGS: { GENERATION_TESTING: 'generation-testing' },
+  isFlipt: vi.fn(async () => false),
+}));
+vi.mock('~/server/utils/otel-helpers', () => ({
+  withSpan: (_name: string, fn: () => unknown) => fn(),
+}));
+
+import { getResourceData } from '~/server/services/generation/generation.service';
+import { resourceDataCache } from '~/server/redis/resource-data.redis';
+
+const VERSION_ID = 4242;
+const REDIS_TIMEOUT = () => new Error('redis cluster command timed out after 3000ms');
+
+/** Flush queued microtasks so a concurrent caller reaches the fail-open path. */
+const flush = async () => {
+  for (let i = 0; i < 25; i++) await Promise.resolve();
+};
+
+/**
+ * A published, PUBLIC, covered version whose model carries BOTH moderation flags, marked
+ * `InternalGeneration`. That last field is the per-user split: moderators can generate with it,
+ * everyone else cannot — so the two callers below genuinely disagree on `canGenerate` while
+ * reading the very same cached record.
+ */
+const dbRow = () => ({
+  id: VERSION_ID,
+  name: 'v1',
+  trainedWords: [],
+  clipSkip: null,
+  vaeId: null,
+  baseModel: 'SD 1.5',
+  settings: null,
+  availability: 'Public',
+  aliasId: null,
+  covered: true,
+  status: 'Published',
+  usageControl: 'InternalGeneration',
+  flags: 0,
+  hasAccess: false,
+  model: { id: 99, name: 'A Model', type: 'LORA', nsfw: false, poi: false, userId: 777, minor: true, sfwOnly: true },
+});
+
+/** Holds the origin query open so a second caller joins the SAME degraded single-flight. */
+function gateOrigin() {
+  let release!: () => void;
+  const gate = new Promise<void>((r) => (release = r));
+  queryRawMock.mockImplementation(async () => {
+    await gate;
+    return [dbRow()];
+  });
+  return { gate, release: () => release() };
+}
+
+const MOD = { id: 1, isModerator: true };
+const ANON = {};
+
+beforeEach(() => {
+  mGetMock.mockReset().mockRejectedValue(REDIS_TIMEOUT());
+  setMock.mockClear();
+  setNxMock.mockClear();
+  delMock.mockClear();
+  degradedInc.mockClear();
+  originFetchInc.mockClear();
+  queryRawMock.mockReset();
+});
+
+describe('getResourceData — per-user moderation-flag stripping is caller-local', () => {
+  /**
+   * POSITIVE CONTROL for the harness, not for the fix.
+   *
+   * Proves this setup really does put two callers on ONE shared record with ONE shared nested
+   * `model` object — i.e. the harness is capable of observing the aliasing. It asserts the CACHE
+   * layer's behaviour, which this change deliberately does not alter, so it must pass before and
+   * after. If it ever fails, the shared cache layer started deep-cloning (filed separately) and
+   * these tests are no longer exercising a shared object.
+   */
+  it('CONTROL: two callers joining one degraded flight share the SAME nested `model` object', async () => {
+    const { release } = gateOrigin();
+
+    const p1 = resourceDataCache.fetch([VERSION_ID]);
+    await flush();
+    const p2 = resourceDataCache.fetch([VERSION_ID]);
+    await flush();
+    release();
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    // One origin query served both callers => a genuinely joined single-flight.
+    expect(queryRawMock).toHaveBeenCalledTimes(1);
+    expect(degradedInc).toHaveBeenCalledTimes(2);
+    // Top level is cloned per caller...
+    expect(r1[0]).not.toBe(r2[0]);
+    // ...the nested `model` is NOT.
+    expect(r1[0].model).toBe(r2[0].model);
+  });
+
+  it('a non-generating caller does NOT strip the flags from a concurrent caller who CAN generate', async () => {
+    const { release } = gateOrigin();
+
+    // The moderator can generate with an InternalGeneration resource; the anonymous caller cannot.
+    const pMod = getResourceData([VERSION_ID], { user: MOD });
+    await flush();
+    const pAnon = getResourceData([VERSION_ID], { user: ANON });
+    await flush();
+    release();
+    const [modResources, anonResources] = await Promise.all([pMod, pAnon]);
+
+    // Both callers really did join ONE degraded window over ONE record.
+    expect(queryRawMock).toHaveBeenCalledTimes(1);
+    expect(modResources).toHaveLength(1);
+    expect(anonResources).toHaveLength(1);
+    expect(modResources[0].canGenerate).toBe(true);
+    expect(anonResources[0].canGenerate).toBe(false);
+
+    // The moderator CAN generate, so the client-side content-restriction warning must survive.
+    expect(modResources[0].model.sfwOnly).toBe(true);
+    expect(modResources[0].model.minor).toBe(true);
+  });
+
+  it('still strips the flags for the caller who cannot generate', async () => {
+    const { release } = gateOrigin();
+
+    const pMod = getResourceData([VERSION_ID], { user: MOD });
+    await flush();
+    const pAnon = getResourceData([VERSION_ID], { user: ANON });
+    await flush();
+    release();
+    const [, anonResources] = await Promise.all([pMod, pAnon]);
+
+    expect(queryRawMock).toHaveBeenCalledTimes(1);
+    expect('sfwOnly' in anonResources[0].model).toBe(false);
+    expect('minor' in anonResources[0].model).toBe(false);
+  });
+
+  it('does not write the stripped shape back into the shared cached record', async () => {
+    const { release } = gateOrigin();
+
+    const pAnon = getResourceData([VERSION_ID], { user: ANON });
+    await flush();
+    const pRaw = resourceDataCache.fetch([VERSION_ID]);
+    await flush();
+    release();
+    const [anonResources, raw] = await Promise.all([pAnon, pRaw]);
+
+    expect(queryRawMock).toHaveBeenCalledTimes(1);
+    expect('sfwOnly' in anonResources[0].model).toBe(false);
+    // The record itself is untouched — a later reader still sees the flags.
+    expect(raw[0].model.sfwOnly).toBe(true);
+    expect(raw[0].model.minor).toBe(true);
+  });
+});

--- a/src/server/services/generation/__tests__/generation.service.resource-data-aliasing.test.ts
+++ b/src/server/services/generation/__tests__/generation.service.resource-data-aliasing.test.ts
@@ -138,7 +138,16 @@ const dbRow = () => ({
   usageControl: 'InternalGeneration',
   flags: 0,
   hasAccess: false,
-  model: { id: 99, name: 'A Model', type: 'LORA', nsfw: false, poi: false, userId: 777, minor: true, sfwOnly: true },
+  model: {
+    id: 99,
+    name: 'A Model',
+    type: 'LORA',
+    nsfw: false,
+    poi: false,
+    userId: 777,
+    minor: true,
+    sfwOnly: true,
+  },
 });
 
 /** Holds the origin query open so a second caller joins the SAME degraded single-flight. */

--- a/src/server/services/generation/generation.service.ts
+++ b/src/server/services/generation/generation.service.ts
@@ -1160,14 +1160,23 @@ export async function getResourceData(
       hiddenGates,
     });
 
+    // Drop these props so the client doesn't notify the user about them — they are irrelevant if
+    // the resource cannot be used for generation.
+    //
+    // 🔴 Build a NEW model object rather than `delete`-ing on `item.model`. `{ settings, ...item }`
+    // above clones only the TOP level, so `item.model` is still the object the resource cache
+    // handed us — and on the cache's fail-open path one origin lookup is single-flighted and its
+    // record shared by every caller that joined that window. `canGenerate` is a PER-USER decision,
+    // so mutating in place applies this user's gate outcome to a concurrent user's payload.
+    let model = item.model;
     if (!canGenerate) {
-      // Delete these items so that the client doesn't have to notify users about these props. They are irrelevant if the resource cannot be used for generation.
-      delete item.model.sfwOnly;
-      delete item.model.minor;
+      const { sfwOnly: _sfwOnly, minor: _minor, ...rest } = item.model;
+      model = rest;
     }
 
     return {
       ...item,
+      model,
       // Merged in after the cache read (see mergePaidAccess) from PaidAccess — NOT stored in the 1h
       // resourceDataCache, whose TTL would serve stale gating terms after a config change.
       paidAccess: null as { endsAt: Date | null; terms: ModelVersionTerms } | null,


### PR DESCRIPTION
Confirms and fixes the lead in #3873. It is **real**, on **one** path.

## What was wrong

`transformGenerationData` (in `getResourceData`) strips `model.sfwOnly` / `model.minor` from a resource the requesting user cannot generate with:

```ts
if (!canGenerate) {
  delete item.model.sfwOnly;
  delete item.model.minor;
}
```

`item` comes from `{ settings, ...item }` — a **top-level** clone — so `item.model` is still the object the shared per-id resource cache handed out, and the `delete` writes one level deeper than the clone protects.

## Which path — and which one is safe

- **Degraded / fail-open path: affected.** When a cache read rejects, the layer falls open to a per-id single-flighted origin fetch and clones the resolved record only at the top level, so every caller that joins that window holds the **same nested `model` object**. `canGenerate` is a **per-user** decision (ownership, moderator status, per-user gates), so one caller's negative outcome removed the fields from a concurrent caller's payload.
- **Healthy path: not affected.** Each read decodes its own object graph, and this cache enables no in-process L1 — so two callers never share a record there. (The lead flagged this as uncertain; re-derived from the cache definition, which sets no local TTL.)
- **Nothing is written back.** The degraded path performs no cache writes, and on the healthy path the write-back is serialized before the transform runs, so the stripped shape never reaches the cache. A test pins this.

The direction of the defect is only ever "fields **disappear**" — the `delete` cannot make a hidden field appear, so nothing is disclosed that would otherwise be withheld.

## What is actually exposed — priced from the consumers, not the mutation site

These two fields on a generation resource are read in exactly three places, all client-side and all advisory:

- `components/generation_v2/inputs/ResourceItemContent.tsx` — the shield icon ("This resource cannot be used to generate mature content")
- `components/ImageGeneration/GenerationForm/ResourceSelectCard.tsx` (two sites) — the same shield affordance
- `components/generation_v2/ResourceAlerts.tsx` — the "Content Restricted" alert

No server-side generation, submission or authorization path reads them; the real enforcement is downstream (the alert copy itself says the image will not be returned but the user is still charged). So the consequence is **a suppressed warning**, not a permission bypass: during the window, a user who *can* generate with a flagged resource may not be told about the restriction and can spend on a generation that will be withheld. Moderation-relevant and worth fixing, but the severity is UI-advisory, not disclosure.

## Frequency

Two things must coincide: the cache read must be failing open, **and** two callers with different `canGenerate` outcomes must join the same in-flight window for the same version id. **I did not measure how often the fail-open path engages** — that is a runtime figure, not something this repo can answer — so I am not characterising it as rare or routine.

## The fix, and why here

Build a new `model` projection instead of mutating the cached-derived one. Chosen over the alternatives:

- **Deep-clone at the consumer** — pays a clone on every resource on a hot path to work around a mutation that does not need to exist.
- **Fix the shared cache layer** — that is #3872, deliberately deferred for blast radius. This change does not depend on it.

Once #3872 lands this specific defect becomes unreachable (the nested object would no longer be shared), but the change should stay: not mutating a value a shared cache handed you is the contract that layer documents, and it costs nothing.

## Other consumers — enumerated, not sampled

`resourceDataCache` is an exported const, so imports are the complete population:

| Site | Use |
|---|---|
| `services/generation/generation.service.ts` (main + substitutes) | `.fetch` — the two `transformGenerationData` call sites |
| `services/orchestrator/models.ts` | `.fetch` — reads `baseModel` / `model.type` / `model.id`, no mutation |
| `services/model-version.service.ts`, `jobs/handle-auctions.ts`, `jobs/refresh-auction-cache.ts` | `.bust` only |

`transformGenerationData` is a local closure with exactly two call sites, both in this function. Scanning the generation service for the same shape found no other nested mutation of a cached row: the nearby `delete resource.epochNumber` acts on the freshly-built top-level result (as #3873 already noted), and `stripHiddenPrompt` operates on a rest-object it built itself.

## Verification

Regression coverage drives the **real** cache layer end to end — a rejecting cache read forces the real fail-open path, a gated origin query holds the real lookup open so a second caller joins the same in-flight promise, and assertions read what the real `getResourceData` returns. Nothing about the aliasing is hand-constructed.

- **Red/green:** pre-fix `2 failed | 2 passed (4)`; post-fix `4 passed (4)`.
  - The 2 that flip are the regression tests.
  - `CONTROL: two callers joining one degraded flight share the SAME nested model object` passes both ways **by design** — it proves the harness can observe the sharing, so the isolation assertions are not vacuous. It asserts cache-layer behaviour this PR does not change; it should start failing only when #3872 lands.
  - `still strips the flags for the caller who cannot generate` also passes both ways — an **invariant guard** that the intended stripping still happens, not regression coverage.
- **Mutation battery** (6 mutants, all as expected): shallow `delete` restored → died; clone taken at the wrong level → died; guard present but dead (`if (false && …)`) → died; projection built but never assigned → died; sibling field left aliased (`minor` dropped from the destructure) → died; **known-equivalent control** (same logic as a ternary + IIFE) → **survived**.
- **Gates:** `pnpm typecheck` 0 errors, negative-controlled (a planted type error produced exactly 1 `error TS2322` and rc=2). Full unit project: **1016 files / 15941 tests passed**, 0 failed. Repo lint-rule suites: 6 files passed.

Refs #3873. Related: #3872 (cache layer), #3867 (confirmed sibling instance).
