### PR TITLE
feat(image-delivery): return the media type from the internal lookup

### DIFF
--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -2182,14 +2182,20 @@ const REDIS_KEYS_UNPREFIXED = {
     // only (bid submission re-validates the true minimum server-side). See
     // `getAllAuctions` in auction.service.
     ACTIVE_AUCTIONS: 'packed:caches:active-auctions',
-    // url -> {id, url, hideMeta} lookup backing the internal image-delivery endpoint
-    // (`/api/internal/image-delivery/[id]`, ~9.2 req/s at peak). The near-immutable
+    // url -> {id, url, hideMeta, type, mimeType} lookup backing the internal image-delivery
+    // endpoint (`/api/internal/image-delivery/[id]`, ~9.2 req/s at peak). The near-immutable
     // `Image WHERE url = $1` single-row read is the highest-volume DB query in the
     // profile. Keyed by the EXACT url (case/whitespace-sensitive — the WHERE key is not
     // normalized), positive results only (an unknown url stays uncached so a newly
     // registered image resolves immediately), busted when `hideMeta` flips in
     // updatePostImage. See `getCachedImageDeliveryMetadata` in image-delivery.service.
-    IMAGE_DELIVERY_METADATA: 'packed:caches:image-delivery-metadata',
+    // `:v2` — the cached value gained `type`/`mimeType`. Entries packed by the previous
+    // release hold only `{id, url, hideMeta}`, and a hit on one would serve a response with
+    // the media-type fields MISSING (indistinguishable, to a caller, from "this image has
+    // no mimeType") for up to the TTL after a release. A new key prefix makes the widened
+    // shape correct from the first request instead; the cold window costs at most one
+    // single-row indexed lookup per url per TTL.
+    IMAGE_DELIVERY_METADATA: 'packed:caches:image-delivery-metadata:v2',
     // Per-user `id -> isValidCreatorMember(boolean)` for the read-time metric-privacy /
     // donation-goal hide gate (#3266). Near-static per user; both TRUE and FALSE are
     // cached (the resolver is a total function over the id). Busted on any subscription

--- a/src/pages/api/internal/image-delivery/[id].ts
+++ b/src/pages/api/internal/image-delivery/[id].ts
@@ -23,7 +23,9 @@ export default WebhookEndpoint(async function handler(req: NextApiRequest, res: 
   const { id } = results.data;
 
   // `id` is the image url (the raw query keys on `WHERE url = $1`). Read-through Redis cache
-  // fronts the near-immutable url -> {id, url, hideMeta} lookup; fails open to the DB.
+  // fronts the near-immutable url -> {id, url, hideMeta, type, mimeType} lookup; fails open
+  // to the DB. `type`/`mimeType` let the caller tell a video from an image before it picks a
+  // delivery path; `hideMeta` is unchanged, so a caller that reads only it is unaffected.
   const image = await getCachedImageDeliveryMetadata(id);
 
   if (!image) {

--- a/src/server/services/__tests__/image-delivery-metadata-cache.test.ts
+++ b/src/server/services/__tests__/image-delivery-metadata-cache.test.ts
@@ -35,12 +35,32 @@ import {
   bustImageDeliveryMetadataCache,
 } from '~/server/services/image-delivery.service';
 import { CacheTTL } from '~/server/common/constants';
+// The DB fake narrows each fixture row to the columns the statement actually SELECTs, the way
+// a real database does. Without it, `mockResolvedValue([row])` hands back the whole fixture no
+// matter what was asked for, and every assertion about a NEWLY-selected column passes on code
+// that never selects it — measured: 5 of the media-type assertions below went green against
+// the pre-change service until this was introduced.
+import { respondWithRows } from '~/test-utils/queryRawProjection';
 
-const KEY_PREFIX = 'packed:caches:image-delivery-metadata';
+// `:v2` — bumped when the cached value gained `type`/`mimeType`, so a hit on an entry packed
+// by the previous release can never serve a response missing those fields.
+const KEY_PREFIX = 'packed:caches:image-delivery-metadata:v2';
 
-// A row exactly as the raw `Image WHERE url = $1` query returns it.
+// A row exactly as the raw `Image WHERE url = $1` query returns it. Every field holds a
+// DISTINCT value so an assertion cannot pass by one field aliasing another.
 const URL = 'abc123/def456.jpeg';
-const IMAGE_ROW = { id: 42, url: URL, hideMeta: false };
+const IMAGE_ROW = { id: 42, url: URL, hideMeta: false, type: 'image', mimeType: 'image/jpeg' };
+
+// A video row — the case the media-type fields exist for. Distinct in every field from
+// IMAGE_ROW (different id, url, hideMeta, type and mimeType).
+const VIDEO_URL = 'vid987/clip.mp4';
+const VIDEO_ROW = {
+  id: 77,
+  url: VIDEO_URL,
+  hideMeta: true,
+  type: 'video',
+  mimeType: 'video/mp4',
+};
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -63,7 +83,7 @@ beforeEach(() => {
 
 describe('getCachedImageDeliveryMetadata — read-through cache', () => {
   it('serves the second call for the same url from cache without re-hitting the DB', async () => {
-    dbReadQueryRaw.mockResolvedValue([IMAGE_ROW]);
+    dbReadQueryRaw.mockImplementation(respondWithRows([IMAGE_ROW]));
 
     const first = await getCachedImageDeliveryMetadata(URL);
     const second = await getCachedImageDeliveryMetadata(URL);
@@ -74,10 +94,16 @@ describe('getCachedImageDeliveryMetadata — read-through cache', () => {
   });
 
   it('returns output byte-identical to the raw query', async () => {
-    dbReadQueryRaw.mockResolvedValue([IMAGE_ROW]);
+    dbReadQueryRaw.mockImplementation(respondWithRows([IMAGE_ROW]));
 
     const result = await getCachedImageDeliveryMetadata(URL);
-    expect(result).toEqual({ id: 42, url: URL, hideMeta: false });
+    expect(result).toEqual({
+      id: 42,
+      url: URL,
+      hideMeta: false,
+      type: 'image',
+      mimeType: 'image/jpeg',
+    });
 
     // Prove byte-identity THROUGH the real msgpackr codec: unpack the actual stored Buffer
     // and assert every field survives the serializer — number id, string url, boolean.
@@ -91,18 +117,30 @@ describe('getCachedImageDeliveryMetadata — read-through cache', () => {
   });
 
   it('serves a msgpackr-codec round-tripped result on the cache HIT path', async () => {
-    dbReadQueryRaw.mockResolvedValue([IMAGE_ROW]);
+    dbReadQueryRaw.mockImplementation(respondWithRows([IMAGE_ROW]));
     await getCachedImageDeliveryMetadata(URL); // populate
 
     const hit = await getCachedImageDeliveryMetadata(URL); // served from unpack(Buffer)
     expect(dbReadQueryRaw).toHaveBeenCalledTimes(1);
-    expect(hit).toEqual({ id: 42, url: URL, hideMeta: false });
+    expect(hit).toEqual({
+      id: 42,
+      url: URL,
+      hideMeta: false,
+      type: 'image',
+      mimeType: 'image/jpeg',
+    });
     expect(hit?.hideMeta).toBe(false);
   });
 
   it('preserves hideMeta:true through the codec on the hit path', async () => {
-    const hidden = { id: 7, url: 'hidden/img.png', hideMeta: true };
-    dbReadQueryRaw.mockResolvedValue([hidden]);
+    const hidden = {
+      id: 7,
+      url: 'hidden/img.png',
+      hideMeta: true,
+      type: 'image',
+      mimeType: 'image/png',
+    };
+    dbReadQueryRaw.mockImplementation(respondWithRows([hidden]));
 
     await getCachedImageDeliveryMetadata(hidden.url); // populate
     const hit = await getCachedImageDeliveryMetadata(hidden.url);
@@ -113,13 +151,19 @@ describe('getCachedImageDeliveryMetadata — read-through cache', () => {
   });
 
   it('keys by the EXACT url — a case/whitespace variant is a MISS (no collision)', async () => {
-    dbReadQueryRaw.mockResolvedValueOnce([IMAGE_ROW]);
+    dbReadQueryRaw.mockImplementationOnce(respondWithRows([IMAGE_ROW]));
     await getCachedImageDeliveryMetadata(URL);
 
     // An uppercased variant must NOT resolve to the same cached row (url WHERE is
     // case-sensitive, unlike citext) — it re-hits the DB with its own row.
-    const variantRow = { id: 99, url: URL.toUpperCase(), hideMeta: false };
-    dbReadQueryRaw.mockResolvedValueOnce([variantRow]);
+    const variantRow = {
+      id: 99,
+      url: URL.toUpperCase(),
+      hideMeta: false,
+      type: 'image',
+      mimeType: 'image/webp',
+    };
+    dbReadQueryRaw.mockImplementationOnce(respondWithRows([variantRow]));
     const variant = await getCachedImageDeliveryMetadata(URL.toUpperCase());
 
     expect(dbReadQueryRaw).toHaveBeenCalledTimes(2); // no collision — separate DB read
@@ -130,14 +174,14 @@ describe('getCachedImageDeliveryMetadata — read-through cache', () => {
   });
 
   it('passes the exact url to the DB query as the WHERE value', async () => {
-    dbReadQueryRaw.mockResolvedValue([IMAGE_ROW]);
+    dbReadQueryRaw.mockImplementation(respondWithRows([IMAGE_ROW]));
     await getCachedImageDeliveryMetadata(URL);
     const values = dbReadQueryRaw.mock.calls[0].slice(1);
     expect(values).toContain(URL);
   });
 
   it('sets the cache entry with the short TTL', async () => {
-    dbReadQueryRaw.mockResolvedValue([IMAGE_ROW]);
+    dbReadQueryRaw.mockImplementation(respondWithRows([IMAGE_ROW]));
     await getCachedImageDeliveryMetadata(URL);
     expect(redisPackedSet).toHaveBeenCalledWith(`${KEY_PREFIX}:${URL}`, IMAGE_ROW, {
       EX: CacheTTL.sm,
@@ -145,7 +189,7 @@ describe('getCachedImageDeliveryMetadata — read-through cache', () => {
   });
 
   it('does NOT cache a negative result — an unknown url re-hits the DB every call', async () => {
-    dbReadQueryRaw.mockResolvedValue([]); // no such image
+    dbReadQueryRaw.mockImplementation(respondWithRows([])); // no such image
 
     const first = await getCachedImageDeliveryMetadata('missing/url.jpg');
     const second = await getCachedImageDeliveryMetadata('missing/url.jpg');
@@ -159,17 +203,23 @@ describe('getCachedImageDeliveryMetadata — read-through cache', () => {
   });
 
   it('becomes findable immediately after the image is registered (no stale negative)', async () => {
-    dbReadQueryRaw.mockResolvedValueOnce([]); // miss — not cached
+    dbReadQueryRaw.mockImplementationOnce(respondWithRows([])); // miss — not cached
     expect(await getCachedImageDeliveryMetadata('brandnew/img.png')).toBeNull();
 
-    const created = { id: 555, url: 'brandnew/img.png', hideMeta: false };
-    dbReadQueryRaw.mockResolvedValueOnce([created]);
+    const created = {
+      id: 555,
+      url: 'brandnew/img.png',
+      hideMeta: false,
+      type: 'image',
+      mimeType: 'image/png',
+    };
+    dbReadQueryRaw.mockImplementationOnce(respondWithRows([created]));
     expect(await getCachedImageDeliveryMetadata('brandnew/img.png')).toEqual(created);
   });
 
   it('fails open to dbRead when the Redis read throws (hot path must not 500)', async () => {
     redisPackedGet.mockRejectedValueOnce(new Error('redis down'));
-    dbReadQueryRaw.mockResolvedValue([IMAGE_ROW]);
+    dbReadQueryRaw.mockImplementation(respondWithRows([IMAGE_ROW]));
 
     const result = await getCachedImageDeliveryMetadata(URL);
     expect(result).toEqual(IMAGE_ROW); // degraded to origin, correct result
@@ -178,7 +228,7 @@ describe('getCachedImageDeliveryMetadata — read-through cache', () => {
   it('still returns the DB result when the Redis WRITE (populate) throws', async () => {
     redisPackedGet.mockResolvedValueOnce(null); // miss
     redisPackedSet.mockRejectedValueOnce(new Error('redis write down'));
-    dbReadQueryRaw.mockResolvedValue([IMAGE_ROW]);
+    dbReadQueryRaw.mockImplementation(respondWithRows([IMAGE_ROW]));
 
     const result = await getCachedImageDeliveryMetadata(URL);
     expect(result).toEqual(IMAGE_ROW); // request succeeds despite the write failure
@@ -188,7 +238,7 @@ describe('getCachedImageDeliveryMetadata — read-through cache', () => {
   it('falls over to dbWrite (primary) when the read replica query rejects', async () => {
     redisPackedGet.mockResolvedValue(null); // cache miss
     dbReadQueryRaw.mockRejectedValueOnce(new Error('replica error'));
-    dbWriteQueryRaw.mockResolvedValueOnce([IMAGE_ROW]);
+    dbWriteQueryRaw.mockImplementationOnce(respondWithRows([IMAGE_ROW]));
 
     const result = await getCachedImageDeliveryMetadata(URL);
     expect(result).toEqual(IMAGE_ROW); // primary fallback resolved
@@ -196,9 +246,194 @@ describe('getCachedImageDeliveryMetadata — read-through cache', () => {
   });
 });
 
+/**
+ * Media-type fields. The delivery caller has no way to tell a video from an image from
+ * `{ id, url, hideMeta }` alone, so every entry looks like an image and video uploads get
+ * routed to an image-only conversion path. `type` is the discriminator (NOT NULL on the
+ * row, present on every image old and new); `mimeType` refines the container and is
+ * genuinely nullable.
+ *
+ * REGRESSION coverage, not invariant guards: every assertion below fails on the pre-change
+ * service, which returns only `{ id, url, hideMeta }`.
+ */
+describe('getCachedImageDeliveryMetadata — media type', () => {
+  it('returns type "video" and the video mimeType for a video row', async () => {
+    dbReadQueryRaw.mockImplementation(respondWithRows([VIDEO_ROW]));
+
+    const result = await getCachedImageDeliveryMetadata(VIDEO_URL);
+
+    expect(result?.type).toBe('video');
+    expect(result?.mimeType).toBe('video/mp4');
+    expect(result).toEqual(VIDEO_ROW);
+  });
+
+  it('returns type "image" and the image mimeType for an image row', async () => {
+    dbReadQueryRaw.mockImplementation(respondWithRows([IMAGE_ROW]));
+
+    const result = await getCachedImageDeliveryMetadata(URL);
+
+    expect(result?.type).toBe('image');
+    expect(result?.mimeType).toBe('image/jpeg');
+    expect(result).toEqual(IMAGE_ROW);
+  });
+
+  it('carries the media type through the msgpackr codec on the cache HIT path', async () => {
+    dbReadQueryRaw.mockImplementation(respondWithRows([VIDEO_ROW]));
+    await getCachedImageDeliveryMetadata(VIDEO_URL); // populate
+
+    const hit = await getCachedImageDeliveryMetadata(VIDEO_URL); // served from unpack(Buffer)
+
+    expect(dbReadQueryRaw).toHaveBeenCalledTimes(1); // genuinely the cached copy
+    expect(hit?.type).toBe('video');
+    expect(hit?.mimeType).toBe('video/mp4');
+
+    // And through the real serializer, not just the in-memory object.
+    const roundTripped = unpack(store.get(`${KEY_PREFIX}:${VIDEO_URL}`)!) as typeof VIDEO_ROW;
+    expect(roundTripped.type).toBe('video');
+    expect(roundTripped.mimeType).toBe('video/mp4');
+  });
+
+  it('reports mimeType as explicit null (key PRESENT) when the row has none', async () => {
+    // Old rows predate `mimeType`. The key must still be in the payload and must be null —
+    // a missing key is indistinguishable from "this deployment does not send the field".
+    const legacyRow = {
+      id: 3,
+      url: 'legacy/old.jpeg',
+      hideMeta: false,
+      type: 'image',
+      mimeType: null,
+    };
+    dbReadQueryRaw.mockImplementation(respondWithRows([legacyRow]));
+
+    const result = await getCachedImageDeliveryMetadata(legacyRow.url);
+
+    expect(result?.mimeType).toBeNull();
+    expect(result).toHaveProperty('mimeType'); // present, not dropped
+    expect(Object.keys(result!)).toContain('mimeType');
+    expect(result?.type).toBe('image'); // the discriminator still resolves without a mimeType
+    // The null must survive JSON serialization as a key, since that is what the endpoint
+    // hands the caller — `undefined` would be dropped by JSON.stringify.
+    expect(JSON.parse(JSON.stringify(result))).toHaveProperty('mimeType', null);
+  });
+
+  it('normalizes an undefined mimeType to null rather than dropping the key', async () => {
+    // Explicit `undefined`, not an omitted key: the column IS selected, it just has no value.
+    // (The DB fake requires every selected column to be modelled, so an omitted key would be a
+    // loud fixture error rather than a silent `undefined` — see queryRawProjection.)
+    const undefinedRow = {
+      id: 4,
+      url: 'legacy/undef.jpeg',
+      hideMeta: false,
+      type: 'image',
+      mimeType: undefined,
+    };
+    dbReadQueryRaw.mockImplementation(respondWithRows([undefinedRow]));
+
+    const result = await getCachedImageDeliveryMetadata(undefinedRow.url);
+
+    expect(result?.mimeType).toBeNull();
+    expect(JSON.parse(JSON.stringify(result))).toHaveProperty('mimeType', null);
+  });
+
+  it('normalizes a blank mimeType to null (never a present-but-meaningless value)', async () => {
+    const blankRow = {
+      id: 5,
+      url: 'legacy/blank.jpeg',
+      hideMeta: false,
+      type: 'image',
+      mimeType: '   ',
+    };
+    dbReadQueryRaw.mockImplementation(respondWithRows([blankRow]));
+
+    const result = await getCachedImageDeliveryMetadata(blankRow.url);
+
+    expect(result?.mimeType).toBeNull(); // not '', not '   '
+  });
+
+  it('caches and re-serves a null mimeType as null on the hit path', async () => {
+    const legacyRow = {
+      id: 6,
+      url: 'legacy/hit.jpeg',
+      hideMeta: false,
+      type: 'video',
+      mimeType: null,
+    };
+    dbReadQueryRaw.mockImplementation(respondWithRows([legacyRow]));
+
+    await getCachedImageDeliveryMetadata(legacyRow.url); // populate
+    const hit = await getCachedImageDeliveryMetadata(legacyRow.url);
+
+    expect(dbReadQueryRaw).toHaveBeenCalledTimes(1);
+    expect(hit?.mimeType).toBeNull();
+    // A missing mimeType must NOT mask the discriminator — this row is still a video.
+    expect(hit?.type).toBe('video');
+  });
+
+  it('selects the media-type columns from the SAME single query — no extra round-trip', async () => {
+    dbReadQueryRaw.mockImplementation(respondWithRows([VIDEO_ROW]));
+
+    await getCachedImageDeliveryMetadata(VIDEO_URL);
+
+    expect(dbReadQueryRaw).toHaveBeenCalledTimes(1); // one query total, not two
+    expect(dbWriteQueryRaw).not.toHaveBeenCalled();
+    // The columns come from that one statement's SELECT list.
+    const sql = (dbReadQueryRaw.mock.calls[0][0] as string[]).join('?');
+    expect(sql).toContain('"mimeType"');
+    expect(sql).toMatch(/\btype\b/);
+    expect(sql).toContain('"hideMeta"');
+  });
+
+  it('keeps the media type on the dbWrite (primary) fallback path', async () => {
+    redisPackedGet.mockResolvedValue(null);
+    dbReadQueryRaw.mockRejectedValueOnce(new Error('replica error'));
+    dbWriteQueryRaw.mockImplementationOnce(respondWithRows([VIDEO_ROW]));
+
+    const result = await getCachedImageDeliveryMetadata(VIDEO_URL);
+
+    expect(dbWriteQueryRaw).toHaveBeenCalledTimes(1);
+    expect(result?.type).toBe('video');
+    expect(result?.mimeType).toBe('video/mp4');
+  });
+
+  it('never serves a pre-widening cached entry — the deploy window cannot leak a 3-field row', async () => {
+    // THE DEPLOY-WINDOW HAZARD. The response has been cached (before this change) for the
+    // whole TTL, so entries packed by the previous release hold only {id, url, hideMeta}. If
+    // those were still readable, a hit on one would serve a video with NO `type` at all for up
+    // to the TTL after release — and a caller has no way to tell that apart from a row whose
+    // media type is genuinely unknown, so every video in the window silently falls back to the
+    // image path. Bumping the cache key prefix is what removes the window entirely.
+    //
+    // Seed the OLD (pre-bump) key with an old-shape value and prove it is never read.
+    const legacyKey = `packed:caches:image-delivery-metadata:${VIDEO_URL}`;
+    store.set(legacyKey, pack({ id: 77, url: VIDEO_URL, hideMeta: true }));
+    dbReadQueryRaw.mockImplementation(respondWithRows([VIDEO_ROW]));
+
+    const result = await getCachedImageDeliveryMetadata(VIDEO_URL);
+
+    // The stale 3-field entry was ignored: the DB was consulted and the full shape returned.
+    expect(dbReadQueryRaw).toHaveBeenCalledTimes(1);
+    expect(result?.type).toBe('video');
+    expect(result).toEqual(VIDEO_ROW);
+    // ...and the old entry is left alone rather than overwritten, so a rollback still finds it.
+    expect(unpack(store.get(legacyKey)!)).toEqual({ id: 77, url: VIDEO_URL, hideMeta: true });
+    expect(store.has(`${KEY_PREFIX}:${VIDEO_URL}`)).toBe(true); // written under the new key
+  });
+
+  it('leaves hideMeta untouched — the pre-existing field is unchanged for old callers', async () => {
+    dbReadQueryRaw.mockImplementation(respondWithRows([VIDEO_ROW]));
+
+    const result = await getCachedImageDeliveryMetadata(VIDEO_URL);
+
+    // The additive change must not rename, reshape or drop what a caller already reads.
+    expect(result?.hideMeta).toBe(true);
+    expect(result?.id).toBe(77);
+    expect(result?.url).toBe(VIDEO_URL);
+  });
+});
+
 describe('bustImageDeliveryMetadataCache', () => {
   it('deletes the exact url key so the next read re-queries', async () => {
-    dbReadQueryRaw.mockResolvedValue([IMAGE_ROW]);
+    dbReadQueryRaw.mockImplementation(respondWithRows([IMAGE_ROW]));
     await getCachedImageDeliveryMetadata(URL); // populate
     expect(store.has(`${KEY_PREFIX}:${URL}`)).toBe(true);
 
@@ -207,8 +442,8 @@ describe('bustImageDeliveryMetadataCache', () => {
     expect(store.has(`${KEY_PREFIX}:${URL}`)).toBe(false);
 
     // Next read re-hits the DB (fresh row) rather than serving the busted entry.
-    const fresh = { id: 42, url: URL, hideMeta: true };
-    dbReadQueryRaw.mockResolvedValue([fresh]);
+    const fresh = { id: 42, url: URL, hideMeta: true, type: 'image', mimeType: 'image/jpeg' };
+    dbReadQueryRaw.mockImplementation(respondWithRows([fresh]));
     const after = await getCachedImageDeliveryMetadata(URL);
     expect(after).toEqual(fresh);
     expect(after?.hideMeta).toBe(true); // the flipped value is now served

--- a/src/server/services/image-delivery.service.ts
+++ b/src/server/services/image-delivery.service.ts
@@ -2,52 +2,107 @@ import { CacheTTL } from '~/server/common/constants';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { dbReadFallbackCounter } from '~/server/prom/client';
 import { redis, REDIS_KEYS } from '~/server/redis/client';
+import type { MediaType } from '~/shared/utils/prisma/enums';
 
 // The row shape returned by the internal image-delivery endpoint. `hideMeta` gates whether
 // the delivery/resize path embeds the image's generation metadata (EXIF) in the served
 // bytes — it controls METADATA VISIBILITY, not access to the image itself.
-export type ImageDeliveryMetadata = { id: number; url: string; hideMeta: boolean };
+//
+// `type` / `mimeType` describe WHAT the stored media is, so a caller can tell a video from
+// an image before choosing how to serve it. Without them every entry looks like an image,
+// and video uploads get pushed down an image-only conversion path that cannot handle them.
+//
+// `type` is the discriminator to branch on: `Image.type` is NOT NULL with a default, so it
+// is present on every row, old and new. `mimeType` is NULLABLE — it refines the container
+// (`video/mp4` vs `image/gif`) but is genuinely absent on older rows, so it is typed and
+// documented as `string | null` and must never be treated as a fallback discriminator.
+export type ImageDeliveryMetadata = {
+  id: number;
+  url: string;
+  hideMeta: boolean;
+  type: MediaType;
+  /**
+   * A non-empty mime type (`video/mp4`, `image/jpeg`, …) or `null` when the stored row has
+   * none. NEVER `undefined` and never `''` — see `normalizeMimeType`.
+   */
+  mimeType: string | null;
+};
 
-// Cache key for the `url -> {id, url, hideMeta}` lookup. The origin query is
+// The raw row as Postgres hands it back, BEFORE the mimeType normalization below — which is
+// why `mimeType` is wider here than on the public type: the normalization is what narrows it
+// to `string | null`, so this must not already promise that.
+type ImageDeliveryMetadataRow = Omit<ImageDeliveryMetadata, 'mimeType'> & {
+  mimeType: string | null | undefined;
+};
+
+// `Image.mimeType` is nullable and old rows predate it. Collapse every "no usable value"
+// spelling to a single explicit `null`:
+//   - `undefined` would be DROPPED by JSON.stringify, so the key would vanish from the
+//     response body and a caller could not tell "unknown mime type" from "this deployment
+//     does not send the field at all";
+//   - `''` is a PRESENT value that is not a real mime type — exactly the kind of thing a
+//     caller mistakes for data.
+// The contract is therefore: a non-empty string, or `null`.
+const normalizeMimeType = (mimeType: string | null | undefined): string | null => {
+  if (typeof mimeType !== 'string') return null;
+  const trimmed = mimeType.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+// Cache key for the `url -> {id, url, hideMeta, type, mimeType}` lookup. The origin query is
 // `WHERE url = $1`, which is CASE- and WHITESPACE-SENSITIVE, so — unlike the citext tag
 // cache — the key must be the EXACT url string, never lowercased or trimmed. Trimming or
 // case-folding here would let a different url collide onto another image's cached row and
-// serve the wrong { id, hideMeta }.
+// serve the wrong { id, hideMeta, type, mimeType }.
 const getImageDeliveryMetadataCacheKey = (url: string) =>
   `${REDIS_KEYS.CACHES.IMAGE_DELIVERY_METADATA}:${url}` as `${typeof REDIS_KEYS.CACHES.IMAGE_DELIVERY_METADATA}:${string}`;
 
 // Origin read: the single-row `Image WHERE url = $1` lookup, with the endpoint's existing
 // dbRead -> dbWrite (primary) fallback preserved so a read-replica error still resolves.
+// `type`/`mimeType` are additional COLUMNS on the row already being fetched for `hideMeta` —
+// same single indexed lookup, no extra round-trip.
 const queryImageDeliveryMetadata = async (url: string): Promise<ImageDeliveryMetadata | null> => {
-  const [image] = await dbRead
-    .$queryRaw<ImageDeliveryMetadata[]>`
+  const [image] = await dbRead.$queryRaw<ImageDeliveryMetadataRow[]>`
       SELECT
         id,
         url,
-        "hideMeta"
+        "hideMeta",
+        type,
+        "mimeType"
       FROM "Image"
       WHERE url = ${url}
       LIMIT 1
-    `
-    .catch(() => {
-      dbReadFallbackCounter.inc({ entity: 'image', caller: 'imageDelivery' });
-      return dbWrite.$queryRaw<ImageDeliveryMetadata[]>`
+    `.catch(() => {
+    dbReadFallbackCounter.inc({ entity: 'image', caller: 'imageDelivery' });
+    return dbWrite.$queryRaw<ImageDeliveryMetadataRow[]>`
         SELECT
           id,
           url,
-          "hideMeta"
+          "hideMeta",
+          type,
+          "mimeType"
         FROM "Image"
         WHERE url = ${url}
         LIMIT 1
       `;
-    });
+  });
 
-  return image ?? null;
+  if (!image) return null;
+
+  return {
+    id: image.id,
+    url: image.url,
+    hideMeta: image.hideMeta,
+    type: image.type,
+    mimeType: normalizeMimeType(image.mimeType),
+  };
 };
 
-// Read-through cache over the near-immutable url -> {id, url, hideMeta} lookup — the hot
-// caller of the highest-volume DB query in the profile (`Image WHERE url = $1`). Output is
-// byte-identical to the raw query. Bucket A: DB total-exec-time / call-count reduction only,
+// Read-through cache over the near-immutable url -> {id, url, hideMeta, type, mimeType}
+// lookup — the hot caller of the highest-volume DB query in the profile
+// (`Image WHERE url = $1`). Output matches the raw query field-for-field, with the single
+// documented normalization of `mimeType` (see `normalizeMimeType`).
+// Bucket A: DB total-exec-time / call-count reduction only,
 // no behaviour change — the DB runs ~4% CPU, so this is a pod-neutral cost/margin win, NOT a
 // capacity win. This offloads ONLY the image-delivery endpoint's calls; the same query has
 // other callers (feed hydration, scanning) that are untouched.
@@ -68,7 +123,9 @@ const queryImageDeliveryMetadata = async (url: string): Promise<ImageDeliveryMet
 // flip (mod tooling / direct DB) lags at most TTL; because the delivered image BYTES are
 // still separately purged/CDN-managed and this value only gates embedded-metadata
 // visibility, a bounded ≤TTL window is acceptable. TTL is deliberately short (3 min) to keep
-// that window tight.
+// that window tight. `type`/`mimeType` need no bust of their own: they are set when the
+// media row is created and no writer in this repo updates them afterwards, so the existing
+// hideMeta bust plus the TTL already covers every way a cached entry can go stale.
 export const getCachedImageDeliveryMetadata = async (
   url: string
 ): Promise<ImageDeliveryMetadata | null> => {

--- a/src/test-utils/__tests__/queryRawProjection.test.ts
+++ b/src/test-utils/__tests__/queryRawProjection.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import {
+  projectOntoSelect,
+  respondWithRows,
+  selectedColumns,
+} from '~/test-utils/queryRawProjection';
+
+/**
+ * Validates the INSTRUMENT before any suite reads a verdict from it.
+ *
+ * The helper's whole job is to DROP a column the statement did not select. A projection that
+ * silently passed rows through would look identical from a passing suite, so the negative
+ * control below (a column that must NOT survive) is the load-bearing case here.
+ */
+
+const stmt = (sql: string) => [sql, ''] as unknown as TemplateStringsArray;
+
+const IMAGE_SELECT = stmt(`
+  SELECT
+    id,
+    url,
+    "hideMeta",
+    type,
+    "mimeType"
+  FROM "Image"
+  WHERE url = `);
+
+const LEGACY_SELECT = stmt(`
+  SELECT
+    id,
+    url,
+    "hideMeta"
+  FROM "Image"
+  WHERE url = `);
+
+const ROW = {
+  id: 1,
+  url: 'a/b.mp4',
+  hideMeta: false,
+  type: 'video',
+  mimeType: 'video/mp4',
+  userId: 99,
+};
+
+describe('selectedColumns', () => {
+  it('reads the SELECT list, unquoting identifiers', () => {
+    expect(selectedColumns(IMAGE_SELECT)).toEqual(['id', 'url', 'hideMeta', 'type', 'mimeType']);
+  });
+
+  it('reports an aliased expression under its alias', () => {
+    expect(selectedColumns(stmt('SELECT id, "mimeType" AS "mime" FROM "Image"'))).toEqual([
+      'id',
+      'mime',
+    ]);
+  });
+
+  it('reports SELECT * as *', () => {
+    expect(selectedColumns(stmt('SELECT * FROM "Image"'))).toEqual(['*']);
+  });
+
+  it('THROWS rather than guessing when there is no SELECT list', () => {
+    expect(() => selectedColumns(stmt('UPDATE "Image" SET x = 1'))).toThrow(
+      /could not find a SELECT/
+    );
+  });
+});
+
+describe('projectOntoSelect', () => {
+  it('NEGATIVE CONTROL: drops a column the statement did not select', () => {
+    // `userId` is on the fixture and not in the SELECT list — it must not survive. If this
+    // ever passes through, every suite built on this helper becomes vacuous.
+    const [projected] = projectOntoSelect(IMAGE_SELECT, [ROW]);
+    expect(projected).not.toHaveProperty('userId');
+    expect(Object.keys(projected).sort()).toEqual(
+      ['hideMeta', 'id', 'mimeType', 'type', 'url'].sort()
+    );
+  });
+
+  it('NEGATIVE CONTROL: a narrower SELECT yields a narrower row', () => {
+    // This is precisely the pre-change image-delivery statement. The media-type fields must
+    // be absent, which is what makes an assertion on them genuinely red against that code.
+    const [projected] = projectOntoSelect(LEGACY_SELECT, [ROW]);
+    expect(projected).not.toHaveProperty('type');
+    expect(projected).not.toHaveProperty('mimeType');
+    expect(projected).toEqual({ id: 1, url: 'a/b.mp4', hideMeta: false });
+  });
+
+  it('POSITIVE CONTROL: keeps every selected column, values intact', () => {
+    expect(projectOntoSelect(IMAGE_SELECT, [ROW])[0]).toEqual({
+      id: 1,
+      url: 'a/b.mp4',
+      hideMeta: false,
+      type: 'video',
+      mimeType: 'video/mp4',
+    });
+  });
+
+  it('keeps a key that is explicitly undefined (presence, not definedness)', () => {
+    const row = { ...ROW, mimeType: undefined };
+    const [projected] = projectOntoSelect(IMAGE_SELECT, [row]);
+    expect(Object.keys(projected)).toContain('mimeType');
+    expect(projected.mimeType).toBeUndefined();
+  });
+
+  it('keeps a null column as null', () => {
+    const [projected] = projectOntoSelect(IMAGE_SELECT, [{ ...ROW, mimeType: null }]);
+    expect(projected.mimeType).toBeNull();
+  });
+
+  it('THROWS, naming the column, when the fixture does not model a selected column', () => {
+    const incomplete = { id: 1, url: 'a/b.mp4', hideMeta: false, type: 'video' };
+    expect(() => projectOntoSelect(IMAGE_SELECT, [incomplete])).toThrow(/selects "mimeType"/);
+  });
+
+  it('projects every row, and an empty result set stays empty', () => {
+    expect(projectOntoSelect(IMAGE_SELECT, [])).toEqual([]);
+    expect(projectOntoSelect(IMAGE_SELECT, [ROW, { ...ROW, id: 2 }])).toHaveLength(2);
+  });
+});
+
+describe('respondWithRows', () => {
+  it('resolves the projected rows', async () => {
+    await expect(respondWithRows([ROW])(LEGACY_SELECT)).resolves.toEqual([
+      { id: 1, url: 'a/b.mp4', hideMeta: false },
+    ]);
+  });
+});

--- a/src/test-utils/queryRawProjection.ts
+++ b/src/test-utils/queryRawProjection.ts
@@ -1,0 +1,102 @@
+/**
+ * Select-aware projection for `$queryRaw` fakes.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The obvious `$queryRaw` fake — `mock.mockResolvedValue([FIXTURE_ROW])` — returns the WHOLE
+ * fixture row no matter what the statement's SELECT list asks for. A real database does not
+ * do that: it returns exactly the selected columns. That infidelity makes a whole class of
+ * test VACUOUS, and it is silent.
+ *
+ * Measured on the internal image-delivery lookup: a suite written to prove the query had
+ * gained `type`/`mimeType` columns went GREEN against the pre-change service, which selects
+ * neither. The service returned the fixture row it was handed, the fields were present
+ * because the FIXTURE carried them, and the assertion could not tell the difference. Five
+ * such assertions passed on code that did not implement them.
+ *
+ * WHAT IT DOES
+ * ------------
+ * Parses the SELECT list out of the tagged-template statement and narrows each fixture row to
+ * those columns. A test that asserts on a column then genuinely depends on the production
+ * statement selecting it.
+ *
+ * WHAT IT DELIBERATELY DOES NOT DO
+ * --------------------------------
+ * It never falls back to pass-through. An unparseable statement and a fixture missing a
+ * selected column both THROW, loudly and by name. A permissive fallback would restore exactly
+ * the silent-vacuous-green this exists to remove: the one outcome worse than a red test is a
+ * green one that proves nothing. If a fixture legitimately models "column present, value
+ * absent", give the key an explicit `undefined` — the check is key PRESENCE, not definedness.
+ */
+
+/** The tagged-template first argument, as Prisma's `$queryRaw` receives it. */
+type TemplateStrings = TemplateStringsArray | readonly string[];
+
+const stripQuotes = (identifier: string) => identifier.replace(/^"(.*)"$/s, '$1');
+
+/**
+ * The column names a statement's SELECT list projects. `SELECT *` is reported as `'*'`.
+ * `expr AS alias` reports the alias, since that is the key the row comes back under.
+ */
+export function selectedColumns(strings: TemplateStrings): string[] {
+  // Interpolated values become bind parameters; the placeholder keeps the SQL well-formed.
+  const sql = Array.from(strings).join(' $ ');
+  const match = /\bSELECT\b([\s\S]*?)\bFROM\b/i.exec(sql);
+  if (!match) {
+    throw new Error(
+      `queryRawProjection: could not find a SELECT ... FROM list in the statement, so the ` +
+        `projection cannot be applied and the fake would silently return unselected columns. ` +
+        `Statement was:\n${sql}`
+    );
+  }
+
+  if (/^\s*\*\s*$/.test(match[1])) return ['*'];
+
+  return match[1]
+    .split(',')
+    .map((column) => column.trim())
+    .filter((column) => column.length > 0)
+    .map((column) => {
+      const aliased = /\bAS\s+("?[\w$]+"?)\s*$/i.exec(column);
+      return stripQuotes(aliased ? aliased[1] : column);
+    });
+}
+
+/**
+ * Narrow `rows` to the columns the statement selects.
+ *
+ * Throws when a selected column is absent from a fixture row: that means the production
+ * statement asks for something the fixture does not model, which would otherwise surface as a
+ * quiet `undefined` in an assertion instead of a legible failure.
+ */
+export function projectOntoSelect<T extends Record<string, unknown>>(
+  strings: TemplateStrings,
+  rows: T[]
+): Partial<T>[] {
+  const columns = selectedColumns(strings);
+  if (columns[0] === '*') return rows.map((row) => ({ ...row }));
+
+  return rows.map((row, index) => {
+    const projected: Partial<T> = {};
+    for (const column of columns) {
+      if (!Object.prototype.hasOwnProperty.call(row, column)) {
+        throw new Error(
+          `queryRawProjection: statement selects "${column}" but fixture row ${index} has no ` +
+            `such key (has: ${Object.keys(row).join(', ') || '<none>'}). Add the column to the ` +
+            `fixture — an explicit \`undefined\` is fine if the point is that it has no value.`
+        );
+      }
+      projected[column as keyof T] = row[column as keyof T];
+    }
+    return projected;
+  });
+}
+
+/**
+ * A `$queryRaw` mock implementation over a fixed result set, applying the projection above.
+ *
+ *     dbReadQueryRaw.mockImplementation(respondWithRows([IMAGE_ROW]));
+ */
+export function respondWithRows<T extends Record<string, unknown>>(rows: T[]) {
+  return async (strings: TemplateStrings) => projectOntoSelect(strings, rows);
+}

--- a/src/tests/api/internal/image-delivery.test.ts
+++ b/src/tests/api/internal/image-delivery.test.ts
@@ -1,0 +1,223 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
+// The DB fake narrows each fixture row to the columns the statement actually SELECTs, the way
+// a real database does. Without it, a fake returns the whole fixture regardless of the query,
+// so an assertion about a newly selected column passes even against code that never selects
+// it — which is exactly how these media-type assertions first went green against unchanged
+// production code.
+import { respondWithRows } from '~/test-utils/queryRawProjection';
+import type * as RedisClientModule from '~/server/redis/client';
+
+/**
+ * Coverage for GET /api/internal/image-delivery/[id] — the per-request lookup the image
+ * delivery service makes to learn how to serve a stored file.
+ *
+ * The body used to carry only `hideMeta`, which left the caller unable to tell a video from
+ * an image: everything looked like an image, so videos were handed to an image-only
+ * conversion path and failed. The body now also carries `type` (the discriminator) and
+ * `mimeType` (the container, nullable).
+ *
+ * Deliberately NOT mocking `image-delivery.service` — that would make the media-type
+ * assertions a pass-through tautology, green whether or not the service actually reads the
+ * columns. Only the DB and Redis are faked, so this runs the REAL lookup end to end and the
+ * assertions below are genuine regression coverage: they fail on the pre-change service,
+ * which never selects `type`/`mimeType`.
+ */
+
+const { store, dbReadQueryRaw, dbWriteQueryRaw } = vi.hoisted(() => ({
+  store: new Map<string, unknown>(),
+  dbReadQueryRaw: vi.fn(),
+  dbWriteQueryRaw: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { $queryRaw: dbReadQueryRaw },
+  dbWrite: { $queryRaw: dbWriteQueryRaw },
+}));
+
+// Keep the real REDIS_KEYS (so the key prefix matches the real one) and swap only the client.
+vi.mock('~/server/redis/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof RedisClientModule>();
+  return {
+    ...actual,
+    redis: {
+      del: vi.fn(async (key: string) => (store.delete(key), 1)),
+      packed: {
+        get: vi.fn(async (key: string) => store.get(key) ?? null),
+        set: vi.fn(async (key: string, value: unknown) => {
+          store.set(key, value);
+        }),
+      },
+    },
+  };
+});
+
+// WebhookEndpoint wraps the handler with the shared internal-auth check we don't exercise
+// here — pass it through so the route's own logic (query validation, 404, body shape) is
+// what's under test. Mirrors the PublicEndpoint pass-through in ping.test.ts.
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  WebhookEndpoint: (handler: any) => handler,
+}));
+
+vi.mock('~/server/prom/client', () => ({
+  registerCounterWithLabels: () => ({ inc: vi.fn() }),
+  dbReadFallbackCounter: { inc: vi.fn() },
+}));
+
+function makeRes() {
+  const res = {} as NextApiResponse & { _status?: number; _body?: any };
+  res.status = vi.fn((code: number) => {
+    res._status = code;
+    return res;
+  }) as any;
+  res.json = vi.fn((body: unknown) => {
+    res._body = body;
+    return res;
+  }) as any;
+  return res;
+}
+
+const makeReq = (id: string) => ({ method: 'GET', query: { id } } as unknown as NextApiRequest);
+
+const VIDEO_URL = 'vid987/clip.mp4';
+const IMAGE_URL = 'abc123/def456.jpeg';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  store.clear();
+});
+
+describe('GET /api/internal/image-delivery/[id]', () => {
+  it('returns the media type alongside hideMeta for a VIDEO row', async () => {
+    const handler = (await import('~/pages/api/internal/image-delivery/[id]')).default;
+    dbReadQueryRaw.mockImplementation(
+      respondWithRows([
+        { id: 77, url: VIDEO_URL, hideMeta: true, type: 'video', mimeType: 'video/mp4' },
+      ])
+    );
+    const res = makeRes();
+
+    await handler(makeReq(VIDEO_URL) as any, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res._body.type).toBe('video');
+    expect(res._body.mimeType).toBe('video/mp4');
+    expect(res._body.hideMeta).toBe(true); // pre-existing field unchanged
+  });
+
+  it('returns the media type alongside hideMeta for an IMAGE row', async () => {
+    const handler = (await import('~/pages/api/internal/image-delivery/[id]')).default;
+    dbReadQueryRaw.mockImplementation(
+      respondWithRows([
+        { id: 42, url: IMAGE_URL, hideMeta: false, type: 'image', mimeType: 'image/jpeg' },
+      ])
+    );
+    const res = makeRes();
+
+    await handler(makeReq(IMAGE_URL) as any, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res._body.type).toBe('image');
+    expect(res._body.mimeType).toBe('image/jpeg');
+    expect(res._body.hideMeta).toBe(false);
+  });
+
+  it('serializes an absent mimeType as an explicit null key, not a dropped field', async () => {
+    const handler = (await import('~/pages/api/internal/image-delivery/[id]')).default;
+    dbReadQueryRaw.mockImplementation(
+      respondWithRows([
+        { id: 3, url: 'legacy/old.jpeg', hideMeta: false, type: 'image', mimeType: null },
+      ])
+    );
+    const res = makeRes();
+
+    await handler(makeReq('legacy/old.jpeg') as any, res);
+
+    // What the caller actually parses off the wire — `undefined` would be dropped here.
+    const wire = JSON.parse(JSON.stringify(res._body));
+    expect(wire).toHaveProperty('mimeType', null);
+    expect(wire.type).toBe('image'); // the discriminator survives a missing mimeType
+  });
+
+  it('is additive — the response still carries every field it carried before', async () => {
+    const handler = (await import('~/pages/api/internal/image-delivery/[id]')).default;
+    dbReadQueryRaw.mockImplementation(
+      respondWithRows([
+        { id: 42, url: IMAGE_URL, hideMeta: false, type: 'image', mimeType: 'image/jpeg' },
+      ])
+    );
+    const res = makeRes();
+
+    await handler(makeReq(IMAGE_URL) as any, res);
+
+    // A caller that reads only `hideMeta` (and `id`/`url`) is unaffected: same names, same
+    // types, same values.
+    expect(res._body).toMatchObject({ id: 42, url: IMAGE_URL, hideMeta: false });
+  });
+
+  /**
+   * WIRE CONTRACT — the key name is load-bearing and is pinned here deliberately.
+   *
+   * The caller binds the media type from the JSON key `type` and treats an absent/null value
+   * as "unknown", falling back to today's behaviour. So renaming this key does NOT fail
+   * anywhere: the caller quietly reads null forever and the fix becomes inert. A silently
+   * inert fix is the worst outcome available, hence a test on the literal key rather than
+   * only on the value.
+   */
+  it('emits the media type under the literal JSON key "type"', async () => {
+    const handler = (await import('~/pages/api/internal/image-delivery/[id]')).default;
+    dbReadQueryRaw.mockImplementation(
+      respondWithRows([
+        { id: 77, url: VIDEO_URL, hideMeta: true, type: 'video', mimeType: 'video/mp4' },
+      ])
+    );
+    const res = makeRes();
+
+    await handler(makeReq(VIDEO_URL) as any, res);
+
+    // Assert against the SERIALIZED body — that is what the caller parses.
+    const wire = JSON.parse(JSON.stringify(res._body));
+    expect(Object.keys(wire)).toContain('type');
+    // Bare enum value, not a full mime string: 'video', not 'video/mp4'.
+    expect(wire.type).toBe('video');
+    expect(['image', 'video', 'audio']).toContain(wire.type);
+  });
+
+  it('emits "image" for an image so the caller can tell the two apart', async () => {
+    const handler = (await import('~/pages/api/internal/image-delivery/[id]')).default;
+    dbReadQueryRaw.mockImplementation(
+      respondWithRows([
+        { id: 42, url: IMAGE_URL, hideMeta: false, type: 'image', mimeType: 'image/jpeg' },
+      ])
+    );
+    const res = makeRes();
+
+    await handler(makeReq(IMAGE_URL) as any, res);
+
+    // The whole point of the field: these two must be distinguishable, not both "unknown".
+    expect(JSON.parse(JSON.stringify(res._body)).type).toBe('image');
+  });
+
+  // --- Invariant guards (NOT regression coverage): these pass on the pre-change code too.
+  // They pin the error shape the widening must not disturb.
+  it('[invariant] still 404s an unknown url', async () => {
+    const handler = (await import('~/pages/api/internal/image-delivery/[id]')).default;
+    dbReadQueryRaw.mockImplementation(respondWithRows([]));
+    const res = makeRes();
+
+    await handler(makeReq('missing/url.jpg') as any, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res._body).toEqual({ error: 'Image not found' });
+  });
+
+  it('[invariant] still 400s a request with no id, without querying', async () => {
+    const handler = (await import('~/pages/api/internal/image-delivery/[id]')).default;
+    const res = makeRes();
+
+    await handler({ method: 'GET', query: {} } as unknown as NextApiRequest, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(dbReadQueryRaw).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Why

The internal image-delivery lookup (`GET /api/internal/image-delivery/{imageKey}`) returned a single field, `hideMeta`. The image delivery service calls it on every request, so with only that boolean it has no way to tell a **video** from an **image** — everything looks like an image. Videos therefore get handed to an image-only conversion path that cannot process them, and they fail.

This PR widens that response so the caller can tell the two apart. It changes nothing about how any media is converted or served here; that is the consumer's side.

## Wire contract (stated verbatim so it can be checked against the consumer without reading this diff)

Successful (`200`) response body:

```json
{
  "id": 77,
  "url": "vid987/clip.mp4",
  "hideMeta": true,
  "type": "video",
  "mimeType": "video/mp4"
}
```

- **Key: `type`** — the media-type discriminator. This key name is load-bearing (see below).
- **Value: the bare media type**, one of `"image"`, `"video"`, `"audio"`. Not a full mime string.
- **Key: `mimeType`** — the exact container, e.g. `"video/mp4"`, `"image/jpeg"`, or `null`.

`400` and `404` bodies are unchanged (`{ "error": ... }`).

There was **no pre-existing `type` key** on this response to collide with — before this change the `200` body was exactly `{ id, url, hideMeta }`.

## `type` vs `mimeType` — why both, and which to branch on

Branch on **`type`**. `Image.type` is `NOT NULL` with a default, so it is present on every row, old and new — it is a total discriminator and can never be the reason a caller falls back to "unknown".

`mimeType` is included as well because it is genuinely useful (it names the exact container, which `type` does not) and it is **free** — it is another column on a row that was already being fetched. But it is `NULLABLE` and older rows predate it, so it must never be used as the fallback discriminator; that is stated in the type's doc comment so the next reader does not reach for it.

## Null / absent handling

`mimeType` is normalized to an explicit `null`. Two spellings are deliberately collapsed:

- **`undefined`** — `JSON.stringify` *drops* an undefined value, so the key would vanish from the body entirely and a caller could not distinguish "this image has no mime type" from "this deployment does not send the field at all".
- **`''` / whitespace** — a *present* value that is not a real mime type, i.e. exactly the kind of thing a caller mistakes for data.

So the contract is: **a non-empty string, or `null`** — the key is always present.

## Backward compatibility

Purely additive. `id`, `url` and `hideMeta` keep their names, their types and their values; nothing is renamed, reordered or reshaped, and the two new keys are appended. A caller that reads only the boolean is unaffected. There is a test pinning exactly this (`is additive — the response still carries every field it carried before`).

## No extra database round-trip

`type` and `mimeType` are two additional columns in the `SELECT` list of the **existing** single-row `WHERE url = $1` lookup — the same statement that was already fetching `hideMeta`, on both the replica path and the primary-fallback path. No second query, no second round-trip. A test asserts one query total and that the columns come from that one statement.

No schema change and no migration: these columns already exist.

## The cached-response window (why `packages/civitai-redis` is in this diff)

This response is cached (that cache is pre-existing, not added here). Entries written by the **previous** release hold only `{ id, url, hideMeta }`. If those stayed readable, then for up to the cache TTL after release a cache hit would serve a video with **no `type` at all** — and the caller cannot tell that apart from a row whose media type is genuinely unknown, so it would fall back to today's broken behaviour and the fix would appear not to work for the first few minutes.

Bumping the cache key prefix to `:v2` (a one-line change plus its comment, and the reason that file is touched) removes the window entirely: the widened shape is correct from the very first request. The cold period costs at most one single-row indexed lookup per url per TTL. There is a dedicated test that seeds the *old* key with an old-shape value and proves it is never served.

## A note on the test-only helper

`src/test-utils/queryRawProjection.ts` exists because the obvious `$queryRaw` fake — `mockResolvedValue([fixtureRow])` — returns the **whole fixture row regardless of what the statement selected**, which a real database never does. Measured on this change: **five** of the media-type assertions passed against unmodified `main`, which selects neither column, purely because the fixture carried the fields. The helper narrows each row to the statement's actual `SELECT` list, which is what makes the assertions below genuinely depend on the production query. It never falls back to pass-through — an unparseable statement or a fixture missing a selected column throws by name. It has its own tests, including the negative control that it really does drop an unselected column.

## Test matrix

Run with `pnpm test:unit:run` (counts read off the pass/fail lines, not an exit code).

| Suite | At `origin/main` | At HEAD |
|---|---|---|
| `image-delivery-metadata-cache.test.ts` | 19 failed / 5 passed (24) | **24 passed** |
| `image-delivery.test.ts` (route) | 3 failed / 3 passed (6) | **6 passed** |
| `queryRawProjection.test.ts` (helper) | 12 passed | **12 passed** |
| **Total** | **22 failed / 20 passed (42)** | **45 passed (45)** |

The base run is the new tests executed against unmodified `origin/main` production code. Representative failure, at the assertion itself:

```
FAIL  ... media type > returns type "video" and the video mimeType for a video row
AssertionError: expected undefined to be 'video' // Object.is equality
```

The helper's own 12 tests pass at base, correctly — it is a pure function and does not depend on the change.

### Mutation checks

Each mutation applied alone to otherwise-final code, and the failure message checked to be *this* assertion's rather than a compile error or a neighbouring test's:

| # | Mutation | Result |
|---|---|---|
| M1 | Drop `type`, `"mimeType"` from both `SELECT` lists | **20 failed** — `expected undefined to be 'video'` |
| M2 | Bypass `normalizeMimeType` (return the raw column) | **exactly 2 failed** — `expected undefined to be null`, `expected '   ' to be null` |
| M3 | Revert the cache key prefix to the un-bumped value | **6 failed**, incl. the deploy-window test — `expected "vi.fn()" to be called 1 times, but got 0 times` (i.e. the stale 3-field entry *was* served and the DB never consulted) |
| M4 | Rename the response key `type` → `mediaType` | **5 failed** — `expected [ 'id', 'url', 'hideMeta', …(2) ] to include 'type'` |

M4 is the important one: because the consumer treats an absent value as "unknown" and falls back, a renamed key would fail *nowhere* and silently make this fix inert. That is why the literal key name is asserted on the serialized body.

### Labelled invariant guards (not regression coverage)

Two route tests are marked `[invariant]` in the source — `still 404s an unknown url` and `still 400s a request with no id`. They pass on unmodified code and are there to pin the error shape this widening must not disturb. They are not counted as evidence the change works.

### Other checks

- `pnpm typecheck`: **4278 errors at `origin/main`, 4278 at HEAD** — zero delta, and none in any file touched here. (The absolute number is a pre-existing condition of the tree, unrelated to this change.)
- `eslint` on every changed file: **0 errors**, 11 warnings, all `no-explicit-any` in the route test, matching the existing convention in `src/tests/api/internal/ping.test.ts`.
- Adjacent suites `update-post-image-hidemeta-bust.test.ts` and `pgDbMock.parity.test.ts` fail **identically at base and at HEAD** — pre-existing, not introduced here.
