### PR TITLE
fix(placement): domain-correct review queues, honest paging, and a price-cap band

### DIFF
--- a/src/components/Account/PlacementSpaceSection.tsx
+++ b/src/components/Account/PlacementSpaceSection.tsx
@@ -199,11 +199,10 @@ export function PlacementSpaceSection() {
             commit(mode, value);
           }}
         />
-        {/* No negative margin lifting this onto the marks' row: the marks are
-            pinned left and right and this is centred, so a caption that wrapped
-            collided with both. Same fix as the gallery's. */}
+        {/* On the marks' row, which only holds while the caption is one short
+            line — see `placementPriceCaption`, which is bounded to the amount. */}
         {caption && (
-          <Text size="xs" ta="center" c={caption.warning ? 'yellow' : 'dimmed'}>
+          <Text size="xs" ta="center" mt={-22} c={caption.warning ? 'yellow' : 'dimmed'}>
             {caption.text}
           </Text>
         )}

--- a/src/components/Account/PlacementSpaceSection.tsx
+++ b/src/components/Account/PlacementSpaceSection.tsx
@@ -199,8 +199,11 @@ export function PlacementSpaceSection() {
             commit(mode, value);
           }}
         />
+        {/* No negative margin lifting this onto the marks' row: the marks are
+            pinned left and right and this is centred, so a caption that wrapped
+            collided with both. Same fix as the gallery's. */}
         {caption && (
-          <Text size="xs" ta="center" mt={-22} c={caption.warning ? 'yellow' : 'dimmed'}>
+          <Text size="xs" ta="center" c={caption.warning ? 'yellow' : 'dimmed'}>
             {caption.text}
           </Text>
         )}

--- a/src/components/RemixGallery/RemixGalleryCard.tsx
+++ b/src/components/RemixGallery/RemixGalleryCard.tsx
@@ -30,7 +30,7 @@ import { LoginRedirect } from '~/components/LoginRedirect/LoginRedirect';
 import { RemixGalleryExplainer } from '~/components/RemixGallery/RemixGalleryExplainer';
 import { RemixGalleryManageModal } from '~/components/RemixGallery/RemixGalleryManageModal';
 import { RemixGallerySubmitModal } from '~/components/RemixGallery/RemixGallerySubmitModal';
-import { SubmissionThumb } from '~/components/RemixGallery/SubmissionThumb';
+import { QueueThumb } from '~/components/RemixGallery/SubmissionPair';
 import {
   dedupeGalleryItems,
   galleryDialogImages,
@@ -361,11 +361,14 @@ export function RemixGalleryCard({ imageId }: { imageId: number }) {
             </Text>
           </Group>
           <Group gap={6} wrap="nowrap" className="overflow-x-auto">
-            {viewerPending.map((pending) =>
-              pending.image ? (
-                <SubmissionThumb key={pending.placementId} image={pending.image} />
-              ) : null
-            )}
+            {viewerPending.map((pending) => (
+              <QueueThumb
+                key={pending.placementId}
+                image={pending.image}
+                label="Open this remix in a new tab"
+                missing="This image is no longer available to preview"
+              />
+            ))}
           </Group>
           {/* No username: it wrapped this to two lines, and it was saying what
               the page already does — this card sits on that creator's own image.

--- a/src/components/RemixGallery/RemixGalleryManageModal.tsx
+++ b/src/components/RemixGallery/RemixGalleryManageModal.tsx
@@ -9,16 +9,20 @@ import {
   Button,
   Card,
   Divider,
+  Anchor,
   Group,
   Loader,
   Modal,
+  Popover,
   Stack,
   Text,
   Tooltip,
 } from '@mantine/core';
 import { openConfirmModal } from '@mantine/modals';
 import {
+  IconAlertTriangle,
   IconCheck,
+  IconExternalLink,
   IconInbox,
   IconPin,
   IconPinnedOff,
@@ -30,22 +34,29 @@ import {
 } from '@tabler/icons-react';
 import clsx from 'clsx';
 import { useEffect, useMemo, useState } from 'react';
+import { BrowsingModeMenu } from '~/components/BrowsingMode/BrowsingMode';
 import { AspectRatioImageCard } from '~/components/CardTemplates/AspectRatioImageCard';
 import { CurrencyIcon } from '~/components/Currency/CurrencyIcon';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import type { RemixGalleryItem } from '~/components/RemixGallery/remix-gallery.utils';
 import { dedupeGalleryItems } from '~/components/RemixGallery/remix-gallery.utils';
-import { SubmissionThumb } from '~/components/RemixGallery/SubmissionThumb';
+import { QueueThumb } from '~/components/RemixGallery/SubmissionPair';
 import { VerifiedRemixBadge } from '~/components/RemixGallery/VerifiedRemixBadge';
 import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useServerDomains } from '~/providers/AppProvider';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { getBrowsingLevelLabel } from '~/shared/constants/browsingLevel.constants';
 import { Currency } from '~/shared/utils/prisma/enums';
+import { syncAccount } from '~/utils/sync-account';
 import { REMIX_GALLERY_MAX_PINNED, remixGalleryRemovableAt } from '~/shared/utils/remix-gallery';
 import { daysFromNow, formatDateMin } from '~/utils/date-helpers';
-import { showErrorNotification } from '~/utils/notifications';
+import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 
 const A_DAY_MS = 24 * 60 * 60 * 1000;
+
+const countLabel = (n: number) => (n === 1 ? '1 submission is' : `${n} submissions are`);
 
 /**
  * "2 hours ago" while it is still news, the stamp once it is history.
@@ -168,6 +179,24 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
       showErrorNotification({ title: "Couldn't do that", error: new Error(error.message) }),
   });
 
+  // Reports what actually settled rather than assuming the whole set did: rows
+  // race the expiry sweep, and a silent "done" over a partial run is the failure
+  // this counts to avoid.
+  const declineOutOfBand = trpc.placement.declineOutOfBandRemixGallerySubmissions.useMutation({
+    onSuccess: ({ considered, settled }) => {
+      utils.placement.invalidate();
+      showSuccessNotification({
+        title: settled === considered ? 'Declined' : 'Partly declined',
+        message:
+          settled === considered
+            ? `Declined ${settled} ${settled === 1 ? 'submission' : 'submissions'}.`
+            : `Declined ${settled} of ${considered}. The rest were resolved elsewhere — reopen to see what is left.`,
+      });
+    },
+    onError: (error) =>
+      showErrorNotification({ title: "Couldn't decline those", error: new Error(error.message) }),
+  });
+
   const actingOn = (placementId: number, action: 'approve' | 'decline' | 'remove') =>
     act.isPending && act.variables?.placementId === placementId && act.variables?.action === action;
 
@@ -182,6 +211,34 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
   });
 
   const forThisImage = (pending?.items ?? []).filter((row) => row.targetId === imageId);
+
+  // Owner-only, and null for everyone else — `maxSubmissionLevel` beside it is
+  // the submitter's copy and is null for the owner, so the two are not
+  // interchangeable.
+  const serverDomains = useServerDomains();
+  const features = useFeatureFlags();
+  const acceptedMaxLevel = visibility?.acceptedMaxLevel ?? null;
+  // Above the band the owner set, which is a state the submit mutation refuses
+  // but the queue can still hold: a host re-rated downwards after submissions
+  // arrived leaves entries that were admissible when they were sent.
+  const aboveBand =
+    acceptedMaxLevel == null
+      ? []
+      : forThisImage.filter((row) => !!row.image && row.image.nsfwLevel > acceptedMaxLevel);
+
+  // Three different reasons an owner can't see what they're judging, and each
+  // has a different answer — conflating them would offer a control that cannot
+  // help. Keyed on the remix rather than the host: the remix is the thing being
+  // judged, and a row can be in-band for one and not the other.
+  const withheld = forThisImage.filter((row) => !!row.image && !row.image.viewable);
+  const outsideViewerBand = forThisImage.filter(
+    (row) => !!row.image && row.image.viewable && !row.image.withinViewerLevel
+  );
+  const ratingsOf = (rows: typeof forThisImage) =>
+    [...new Set(rows.map((row) => row.image!.nsfwLevel))]
+      .sort((a, b) => a - b)
+      .map((level) => getBrowsingLevelLabel(level))
+      .join(', ');
   const byId = new Map(items.map((item) => [item.placementId, item]));
   const pinnedItems = pinnedIds.map((id) => byId.get(id)).filter((x): x is RemixGalleryItem => !!x);
   const unpinned = items.filter((item) => !pinnedIds.includes(item.placementId));
@@ -259,11 +316,108 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
                     Nothing on this page can be shown. There are more waiting.
                   </Text>
                 )}
+                {/* Named by rating rather than left to the thumbnails, which the
+                    owner's own browsing settings may blur. */}
+                {(aboveBand.length > 0 || withheld.length > 0 || outsideViewerBand.length > 0) && (
+                  // One block rather than a box per reason: they overlap in
+                  // practice — the same row is often both above the gallery's
+                  // rule and outside the owner's own settings — and three
+                  // stacked alerts over a two-row queue reads as an error state.
+                  <Alert color="yellow" icon={<IconAlertTriangle size={18} />} p="xs">
+                    <Stack gap={6}>
+                      {aboveBand.length > 0 && acceptedMaxLevel != null && (
+                        <Group gap="xs" wrap="nowrap" align="flex-start">
+                          <Text size="sm" className="min-w-0 flex-1">
+                            {countLabel(aboveBand.length)} rated above what this gallery accepts (
+                            {ratingsOf(aboveBand)}). You accept up to{' '}
+                            {getBrowsingLevelLabel(acceptedMaxLevel)} — review them one at a time,
+                            or decline them together.
+                          </Text>
+                          {/* The count is this page's; the mutation resolves the
+                              set itself and may find more behind the cursor, so
+                              the confirm hedges rather than promising a number
+                              the button cannot know. */}
+                          <Button
+                            size="compact-xs"
+                            variant="default"
+                            className="shrink-0"
+                            loading={declineOutOfBand.isPending}
+                            onClick={() =>
+                              openConfirmModal({
+                                title: 'Decline everything out of band?',
+                                children: (
+                                  <Text size="sm">
+                                    Every pending submission rated above{' '}
+                                    {getBrowsingLevelLabel(acceptedMaxLevel)} is declined. Each one
+                                    keeps you the decline fee and returns the rest to its submitter.
+                                    This can&apos;t be undone.
+                                  </Text>
+                                ),
+                                labels: { confirm: 'Decline them', cancel: 'Cancel' },
+                                confirmProps: { color: 'red' },
+                                onConfirm: () => declineOutOfBand.mutate({ hostImageId: imageId }),
+                              })
+                            }
+                          >
+                            Decline all
+                          </Button>
+                        </Group>
+                      )}
+
+                      {/* No widen affordance offered: the asset was never sent,
+                          so no setting on this domain can produce it. */}
+                      {withheld.length > 0 && (
+                        <Text size="sm">
+                          {countLabel(withheld.length)} rated above what this site shows (
+                          {ratingsOf(withheld)}). Decline here, or open this image on{' '}
+                          <Anchor
+                            href={syncAccount(`//${serverDomains.red}/images/${imageId}`)}
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            civitai.red
+                          </Anchor>{' '}
+                          to see and approve them.
+                        </Text>
+                      )}
+
+                      {/* The one case a control can fix, so it gets the control.
+                          Gated on `canViewNsfw` because the header hides these
+                          same settings on green (AppHeader:109) — offering them
+                          here would be the only place on the site that does. */}
+                      {outsideViewerBand.length > 0 && features.canViewNsfw && (
+                        <Group gap="xs" wrap="nowrap" align="flex-start">
+                          <Text size="sm" className="min-w-0 flex-1">
+                            {countLabel(outsideViewerBand.length)} outside your content settings (
+                            {ratingsOf(outsideViewerBand)}), so{' '}
+                            {outsideViewerBand.length === 1 ? 'it is' : 'they are'} hidden until you
+                            include{' '}
+                            {outsideViewerBand.length === 1 ? 'that rating' : 'those ratings'}.
+                          </Text>
+                          <Popover width={320} position="bottom-end" withArrow>
+                            <Popover.Target>
+                              <Button size="compact-xs" variant="default" className="shrink-0">
+                                Content controls
+                              </Button>
+                            </Popover.Target>
+                            <Popover.Dropdown>
+                              <BrowsingModeMenu />
+                            </Popover.Dropdown>
+                          </Popover>
+                        </Group>
+                      )}
+                    </Stack>
+                  </Alert>
+                )}
                 {forThisImage.map((row) => (
                   <Card key={row.id} withBorder p="xs" radius="md">
                     <Group justify="space-between" wrap="nowrap" align="center">
                       <Group gap="sm" wrap="nowrap" className="min-w-0">
-                        {row.image && <SubmissionThumb image={row.image} />}
+                        <QueueThumb
+                          image={row.image}
+                          label="Open this remix in a new tab"
+                          missing="This remix is no longer available"
+                        />
                         {/* `align="flex-start"` because a Stack stretches its
                             children: without it the badge and the username row
                             each spanned the full card width, which also dragged
@@ -277,6 +431,26 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
                             <Text size="xs" c="dimmed" className="truncate">
                               Remix submitted {sentLabel(row.createdAt)}
                             </Text>
+                            {/* The rating in words, because the thumbnail beside
+                                it may be blurred by the reviewer's own browsing
+                                settings and `explain={false}` leaves that tile
+                                with nothing to read. Approving is irreversible
+                                for a week, so what is being approved must be
+                                legible without revealing it. */}
+                            {!!row.image?.nsfwLevel && (
+                              <Badge
+                                size="xs"
+                                variant="light"
+                                color={
+                                  acceptedMaxLevel != null && row.image.nsfwLevel > acceptedMaxLevel
+                                    ? 'yellow'
+                                    : undefined
+                                }
+                                className="shrink-0"
+                              >
+                                {getBrowsingLevelLabel(row.image.nsfwLevel)}
+                              </Badge>
+                            )}
                           </Group>
                           {row.placer ? (
                             <UserAvatar user={row.placer} withUsername size="sm" linkToProfile />
@@ -302,17 +476,46 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
                           come from the server, computed with the settlement's own
                           helpers against this row's amount. */}
                       <Stack gap={6} className="w-36 shrink-0">
-                        <Button
-                          size="compact-sm"
-                          fullWidth
-                          classNames={{ label: 'w-full justify-between gap-2' }}
-                          leftSection={<IconCheck size={14} />}
-                          rightSection={<EarningsChip amount={row.earnings.approve} />}
-                          loading={actingOn(row.id, 'approve')}
-                          onClick={() => act.mutate({ placementId: row.id, action: 'approve' })}
-                        >
-                          Approve
-                        </Button>
+                        {/* Approving is the one answer that needs the picture.
+                            Declining does not — it is a refusal, and a rating is
+                            enough to refuse on — so only this half moves to the
+                            domain that can render the asset. The link goes to the
+                            HOST image, not the submitted one: red is where this
+                            same modal will both show the submission and act on
+                            it, and a link to the submission alone would show them
+                            the image with no way to answer for it. */}
+                        {row.image && !row.image.viewable ? (
+                          <Tooltip
+                            label="Not viewable on this domain — approve it on civitai.red"
+                            withArrow
+                          >
+                            <Button
+                              component="a"
+                              href={syncAccount(`//${serverDomains.red}/images/${imageId}`)}
+                              target="_blank"
+                              rel="noreferrer"
+                              size="compact-sm"
+                              fullWidth
+                              variant="light"
+                              classNames={{ label: 'w-full justify-between gap-2' }}
+                              leftSection={<IconExternalLink size={14} />}
+                            >
+                              Approve on .red
+                            </Button>
+                          </Tooltip>
+                        ) : (
+                          <Button
+                            size="compact-sm"
+                            fullWidth
+                            classNames={{ label: 'w-full justify-between gap-2' }}
+                            leftSection={<IconCheck size={14} />}
+                            rightSection={<EarningsChip amount={row.earnings.approve} />}
+                            loading={actingOn(row.id, 'approve')}
+                            onClick={() => act.mutate({ placementId: row.id, action: 'approve' })}
+                          >
+                            Approve
+                          </Button>
+                        )}
                         <Button
                           size="compact-sm"
                           fullWidth

--- a/src/components/RemixGallery/RemixGallerySettings.tsx
+++ b/src/components/RemixGallery/RemixGallerySettings.tsx
@@ -170,15 +170,17 @@ export function RemixGallerySettings() {
             commit(mode, value);
           }}
         />
-        {/* Sits on the same line as the track's min/max marks rather than under
-            them — the slider reserves that row, so a caption below it leaves a
-            gap and reads as detached from the control it describes.
+        {/* Below the track's min/max marks, not lifted onto their line. It used
+            to sit on that row via a negative margin, which fit only while the
+            caption stayed on one line: the marks are pinned left and right, the
+            caption is centred, and a wrapped one ran straight into both. The
+            slider reserves that row for the marks, so this needs no offset.
 
             The shared helper, so galleries get the over-cap and off-grid
             warnings stickers already had; a hand-rolled caption here said only
             what the price was and stayed silent when the cap had overridden it. */}
         {caption && (
-          <Text size="xs" ta="center" mt={-22} c={caption.warning ? 'yellow' : 'dimmed'}>
+          <Text size="xs" ta="center" c={caption.warning ? 'yellow' : 'dimmed'}>
             {caption.text}
             {price === '' && ', the platform default'}
           </Text>

--- a/src/components/RemixGallery/RemixGallerySettings.tsx
+++ b/src/components/RemixGallery/RemixGallerySettings.tsx
@@ -170,19 +170,14 @@ export function RemixGallerySettings() {
             commit(mode, value);
           }}
         />
-        {/* Below the track's min/max marks, not lifted onto their line. It used
-            to sit on that row via a negative margin, which fit only while the
-            caption stayed on one line: the marks are pinned left and right, the
-            caption is centred, and a wrapped one ran straight into both. The
-            slider reserves that row for the marks, so this needs no offset.
-
-            The shared helper, so galleries get the over-cap and off-grid
-            warnings stickers already had; a hand-rolled caption here said only
-            what the price was and stayed silent when the cap had overridden it. */}
+        {/* Sits on the track's mark row rather than under it, so the price costs
+            no vertical space of its own. That only works while the caption is
+            one short line — the marks are pinned left and right and this is
+            centred, so anything longer runs into both. `placementPriceCaption`
+            is bounded to the amount for that reason; do not append to it here. */}
         {caption && (
-          <Text size="xs" ta="center" c={caption.warning ? 'yellow' : 'dimmed'}>
+          <Text size="xs" ta="center" mt={-22} c={caption.warning ? 'yellow' : 'dimmed'}>
             {caption.text}
-            {price === '' && ', the platform default'}
           </Text>
         )}
       </Stack>

--- a/src/components/RemixGallery/RemixGallerySettings.tsx
+++ b/src/components/RemixGallery/RemixGallerySettings.tsx
@@ -48,9 +48,7 @@ export function RemixGallerySettings() {
     {},
     { enabled }
   );
-  const { data: sent } = trpc.placement.getMyRemixGallerySubmissions.useQuery(undefined, {
-    enabled,
-  });
+  const { data: sent } = trpc.placement.getMyRemixGallerySubmissions.useQuery({}, { enabled });
 
   const stored = spaces?.[0];
   // Seeded from the surface default, not from `'off'`. A creator with no row is

--- a/src/components/RemixGallery/RemixGallerySubmitModal.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.tsx
@@ -1,5 +1,5 @@
 import { Alert, Anchor, Button, Divider, Group, Loader, Modal, Stack, Text } from '@mantine/core';
-import { IconAlertTriangle } from '@tabler/icons-react';
+import { IconAlertTriangle, IconInfoCircle } from '@tabler/icons-react';
 import clsx from 'clsx';
 import { useState } from 'react';
 import { BuzzTransactionButton } from '~/components/Buzz/BuzzTransactionButton';
@@ -73,58 +73,93 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
     // scroll container can run edge to edge and own its own insets.
     <Modal
       {...dialog}
-      title="Submit your remix"
+      // Spans, not a `div`/`Text` stack: Mantine renders the title inside an
+      // `h2`, and block elements there are invalid nesting that React reparses.
+      title={
+        <span className="flex flex-col gap-0.5">
+          <span>Submit your remix</span>
+          <Text span size="xs" fw={400} c="dimmed" className="block leading-snug">
+            The creator reviews every submission and decides what belongs in their gallery.
+          </Text>
+        </span>
+      }
       size="lg"
-      classNames={{ body: 'p-0', header: 'pb-2' }}
+      classNames={{ body: 'p-0', header: 'items-start pb-3' }}
     >
       {/* Three bands: the explanation and the actions stay put, only the picker
           scrolls. The fee warning is money copy, so it must not be the thing
           that scrolls out of sight while someone hunts for an image. */}
       <div className="flex max-h-[70vh] flex-col">
         <Stack gap="xs" className="shrink-0 px-4 pb-3 pt-0">
-          {/* The decline consequence used to be said here too. The footer now
-              states it with the actual number, and saying it twice made the
-              vaguer version the one people read first. */}
-          <Text size="sm" c="dimmed">
-            The creator reviews every submission and decides what belongs in their gallery.
-          </Text>
-
-          {/* The picker lists published images because that is all the mutation
-              accepts, and a freshly generated image is not one. Said here rather
-              than only in the empty state: the case that confuses people is
-              having images in the grid and not the one they just made. */}
-          <Text size="xs" c="dimmed">
-            Only images you have posted appear below.{' '}
-            <Anchor href="/posts/create" target="_blank" rel="noreferrer" size="xs">
-              Post your remix first
-            </Anchor>{' '}
-            if you don&apos;t see it.
-          </Text>
-
-          {/* Says why the grid is short. Without it a submitter whose work is
-              mostly mature sees a picker missing their best images and no
-              reason, which reads as a bug rather than a rule. The reason is not
-              named: which rule bit is the host's business, not the
-              submitter's. */}
-          {maxLevel === 0 ? (
-            <Text size="xs" c="dimmed">
-              This image has no rating yet, so nothing can be submitted to it.
-            </Text>
-          ) : (
-            overRated > 0 && (
+          {/* Footnotes on the title's sentence, not statements of equal weight —
+              icon rows in the crypto deposit card's shape, so a stack of them
+              reads as one block rather than as paragraphs. */}
+          <Stack gap={4}>
+            {/* The picker lists published images because that is all the mutation
+                accepts, and a freshly generated image is not one. Said here rather
+                than only in the empty state: the case that confuses people is
+                having images in the grid and not the one they just made. */}
+            <Group gap="xs" wrap="nowrap" align="flex-start">
+              <IconInfoCircle
+                size={14}
+                className="text-blue-5"
+                style={{ flexShrink: 0, marginTop: 2 }}
+              />
               <Text size="xs" c="dimmed">
-                {overRated === 1 ? '1 of your images is' : `${overRated} of your images are`} rated
-                above what this gallery accepts, so {overRated === 1 ? 'it is' : 'they are'} not
-                shown.
+                Only images you have posted appear below.{' '}
+                <Anchor href="/posts/create" target="_blank" rel="noreferrer" size="xs">
+                  Post your remix first
+                </Anchor>{' '}
+                if you don&apos;t see it.
               </Text>
-            )
-          )}
+            </Group>
 
-          {visibility && !visibility.open && (
-            <Alert color="yellow" icon={<IconAlertTriangle />}>
-              This creator has stopped accepting submissions.
-            </Alert>
-          )}
+            {/* Says why the grid is short. Without it a submitter whose work is
+                mostly mature sees a picker missing their best images and no
+                reason, which reads as a bug rather than a rule. The reason is not
+                named: which rule bit is the host's business, not the
+                submitter's. */}
+            {maxLevel === 0 ? (
+              <Group gap="xs" wrap="nowrap" align="flex-start">
+                <IconAlertTriangle
+                  size={14}
+                  className="text-yellow-500"
+                  style={{ flexShrink: 0, marginTop: 2 }}
+                />
+                <Text size="xs" c="dimmed">
+                  This image has no rating yet, so nothing can be submitted to it.
+                </Text>
+              </Group>
+            ) : (
+              overRated > 0 && (
+                <Group gap="xs" wrap="nowrap" align="flex-start">
+                  <IconAlertTriangle
+                    size={14}
+                    className="text-yellow-500"
+                    style={{ flexShrink: 0, marginTop: 2 }}
+                  />
+                  <Text size="xs" c="dimmed">
+                    {overRated === 1 ? '1 of your images is' : `${overRated} of your images are`}{' '}
+                    rated above what this gallery accepts, so{' '}
+                    {overRated === 1 ? 'it is' : 'they are'} not shown.
+                  </Text>
+                </Group>
+              )
+            )}
+
+            {visibility && !visibility.open && (
+              <Group gap="xs" wrap="nowrap" align="flex-start">
+                <IconAlertTriangle
+                  size={14}
+                  className="text-yellow-500"
+                  style={{ flexShrink: 0, marginTop: 2 }}
+                />
+                <Text size="xs" c="yellow">
+                  This creator has stopped accepting submissions.
+                </Text>
+              </Group>
+            )}
+          </Stack>
         </Stack>
 
         <Divider />
@@ -230,9 +265,12 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
             the operator-set rate — quoting "30%" here would be a number this
             file cannot keep true, and it is the one fact a submitter needs
             before spending. */}
-        <Group justify="space-between" gap="sm" wrap="nowrap" className="shrink-0 px-4 py-3">
+        <div className="flex shrink-0 items-center justify-between gap-3 px-4 py-3">
           {visibility?.declineFee ? (
-            <Group gap="xs" wrap="nowrap" align="flex-start">
+            // `min-w-0` is what makes the note wrap instead of pushing: a flex
+            // item's floor is its content width otherwise, so a long sentence
+            // squeezed the Submit button until its label clipped.
+            <Group gap="xs" wrap="nowrap" align="flex-start" className="min-w-0 flex-1">
               <IconAlertTriangle
                 size={14}
                 className="text-yellow-500"
@@ -244,12 +282,9 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
               </Text>
             </Group>
           ) : (
-            <span />
+            <span className="flex-1" />
           )}
-          <Group gap="sm" wrap="nowrap">
-            <Button variant="default" onClick={dialog.onClose}>
-              Cancel
-            </Button>
+          <div className="shrink-0">
             {/* The price shown here is the one the balance check runs against, and
               the owner can move it between this render and the click. The
               mutation reads the price fresh, so the button is honest about
@@ -273,8 +308,8 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
                 submit.mutate({ hostImageId, imageId: selected, expectedPrice: price })
               }
             />
-          </Group>
-        </Group>
+          </div>
+        </div>
       </div>
     </Modal>
   );

--- a/src/components/RemixGallery/SubmissionPair.tsx
+++ b/src/components/RemixGallery/SubmissionPair.tsx
@@ -1,0 +1,129 @@
+import { Center, Skeleton, Text, Tooltip } from '@mantine/core';
+import { IconEyeOff, IconPhotoOff } from '@tabler/icons-react';
+import type { ReactNode } from 'react';
+import { SubmissionThumb } from '~/components/RemixGallery/SubmissionThumb';
+import { getBrowsingLevelLabel } from '~/shared/constants/browsingLevel.constants';
+import type { RouterOutput } from '~/types/router';
+
+type QueueImage = NonNullable<
+  RouterOutput['placement']['getPendingRemixGallerySubmissions']['items'][number]['image']
+>;
+
+/**
+ * Stands in for an image that will not resolve — deleted, unpublished, still
+ * ingesting, or filtered by the visibility rules the feed applies.
+ *
+ * The row survives it: the action beside it is the only route to the escrow
+ * behind it, so a missing preview must not take the decision with it.
+ */
+function MissingThumb({ reason }: { reason: string }) {
+  return (
+    <Tooltip label={reason} withArrow>
+      <div className="relative w-20 shrink-0">
+        <Skeleton animate={false} className="aspect-square w-full rounded-md" />
+        <Center className="absolute inset-0">
+          <IconPhotoOff size={20} className="text-dimmed" />
+        </Center>
+      </div>
+    </Tooltip>
+  );
+}
+
+/**
+ * An image this domain may not be served.
+ *
+ * Deliberately not a blurred tile with a reveal: there is nothing behind it to
+ * reveal, because the asset was never sent. Showing a Show button that cannot
+ * work is worse than showing none. The rating is named instead, which is what
+ * the reviewer needs to decide.
+ */
+export function WithheldThumb({ nsfwLevel }: { nsfwLevel: number }) {
+  const rating = getBrowsingLevelLabel(nsfwLevel);
+  return (
+    <Tooltip label={`Rated ${rating} — not viewable on this domain`} withArrow>
+      <div className="relative flex aspect-square w-20 shrink-0 flex-col items-center justify-center gap-1 rounded-md border border-solid border-gray-3 bg-gray-1 dark:border-dark-4 dark:bg-dark-6">
+        <IconEyeOff size={18} className="text-dimmed" />
+        <Text size="xs" fw={600} className="leading-none">
+          {rating}
+        </Text>
+      </div>
+    </Tooltip>
+  );
+}
+
+/**
+ * The three states a queue image can arrive in, in one place.
+ *
+ * Exported because both review surfaces need the same branch, and two copies of
+ * "what do we draw when there are no pixels" is how one of them ends up drawing
+ * a reveal control over an asset that was never sent.
+ *
+ * No href of its own: the callers point at different things — the submissions
+ * page at the image, the manage modal at the host on the domain that can serve
+ * it — so the link belongs beside the tile rather than inside it.
+ */
+export function QueueThumb({
+  image,
+  label,
+  missing,
+}: {
+  image: QueueImage | null;
+  label: string;
+  missing: string;
+}) {
+  if (!image) return <MissingThumb reason={missing} />;
+  // The union is the control: with `viewable: false` there is no url to reach
+  // for, so this cannot fall through to a card that expects one.
+  if (!image.viewable) return <WithheldThumb nsfwLevel={image.nsfwLevel} />;
+  return <SubmissionThumb image={image} label={label} />;
+}
+
+function Captioned({ caption, children }: { caption: string; children: ReactNode }) {
+  return (
+    <div className="flex w-20 shrink-0 flex-col gap-1">
+      {children}
+      <Text size="xs" c="dimmed" ta="center" className="leading-none">
+        {caption}
+      </Text>
+    </div>
+  );
+}
+
+/**
+ * The host image beside the remix of it.
+ *
+ * Showing only the submission asks the reviewer to judge it against an image
+ * they have to go and open, and the round trip loses their place in the queue.
+ * Both are captioned because at this size, side by side, nothing else says which
+ * is whose — and the two tabs put them in opposite roles.
+ */
+export function SubmissionPair({
+  host,
+  remix,
+  hostCaption,
+  remixCaption,
+  hostLabel,
+  remixLabel,
+  hostMissing,
+  remixMissing = 'This image is no longer available to preview',
+}: {
+  host: QueueImage | null;
+  remix: QueueImage | null;
+  hostCaption: string;
+  remixCaption: string;
+  hostLabel: string;
+  remixLabel: string;
+  hostMissing: string;
+  remixMissing?: string;
+}) {
+  return (
+    <div className="flex shrink-0 gap-2">
+      <Captioned caption={hostCaption}>
+        <QueueThumb image={host} label={hostLabel} missing={hostMissing} />
+      </Captioned>
+      <Captioned caption={remixCaption}>
+        <QueueThumb image={remix} label={remixLabel} missing={remixMissing} />
+      </Captioned>
+    </div>
+  );
+}

--- a/src/components/RemixGallery/SubmissionPair.tsx
+++ b/src/components/RemixGallery/SubmissionPair.tsx
@@ -37,16 +37,33 @@ function MissingThumb({ reason }: { reason: string }) {
  * work is worse than showing none. The rating is named instead, which is what
  * the reviewer needs to decide.
  */
-export function WithheldThumb({ nsfwLevel }: { nsfwLevel: number }) {
+export function WithheldThumb({ nsfwLevel, href }: { nsfwLevel: number; href?: string }) {
   const rating = getBrowsingLevelLabel(nsfwLevel);
+  const tile = (
+    <div className="relative flex aspect-square w-20 shrink-0 flex-col items-center justify-center gap-1 rounded-md border border-solid border-gray-3 bg-gray-1 dark:border-dark-4 dark:bg-dark-6">
+      <IconEyeOff size={18} className="text-dimmed" />
+      <Text size="xs" fw={600} className="leading-none">
+        {rating}
+      </Text>
+    </div>
+  );
+
+  // The destination is the caller's, never this component's: the submissions
+  // page points at the image, the manage modal at the host. Without one, an
+  // owner on a SFW domain has no route to their own content at all — which is
+  // the hole that opened when the queue stopped linking through its text.
+  if (!href)
+    return (
+      <Tooltip label={`Rated ${rating} — not viewable here`} withArrow>
+        {tile}
+      </Tooltip>
+    );
+
   return (
-    <Tooltip label={`Rated ${rating} — not viewable on this domain`} withArrow>
-      <div className="relative flex aspect-square w-20 shrink-0 flex-col items-center justify-center gap-1 rounded-md border border-solid border-gray-3 bg-gray-1 dark:border-dark-4 dark:bg-dark-6">
-        <IconEyeOff size={18} className="text-dimmed" />
-        <Text size="xs" fw={600} className="leading-none">
-          {rating}
-        </Text>
-      </div>
+    <Tooltip label={`Rated ${rating} — open it on the domain that shows it`} withArrow>
+      <a href={href} target="_blank" rel="noreferrer" className="block w-20 shrink-0">
+        {tile}
+      </a>
     </Tooltip>
   );
 }
@@ -58,23 +75,26 @@ export function WithheldThumb({ nsfwLevel }: { nsfwLevel: number }) {
  * "what do we draw when there are no pixels" is how one of them ends up drawing
  * a reveal control over an asset that was never sent.
  *
- * No href of its own: the callers point at different things — the submissions
- * page at the image, the manage modal at the host on the domain that can serve
- * it — so the link belongs beside the tile rather than inside it.
+ * The withheld destination is passed in rather than defaulted, because the
+ * callers point at different things — the submissions page at the image, the
+ * manage modal at the host — and a default would quietly be wrong for one.
  */
 export function QueueThumb({
   image,
   label,
   missing,
+  withheldHref,
 }: {
   image: QueueImage | null;
   label: string;
   missing: string;
+  /** Where to send someone whose domain may not show this. */
+  withheldHref?: string;
 }) {
   if (!image) return <MissingThumb reason={missing} />;
   // The union is the control: with `viewable: false` there is no url to reach
   // for, so this cannot fall through to a card that expects one.
-  if (!image.viewable) return <WithheldThumb nsfwLevel={image.nsfwLevel} />;
+  if (!image.viewable) return <WithheldThumb nsfwLevel={image.nsfwLevel} href={withheldHref} />;
   return <SubmissionThumb image={image} label={label} />;
 }
 
@@ -105,6 +125,7 @@ export function SubmissionPair({
   hostLabel,
   remixLabel,
   hostMissing,
+  withheldHref,
   remixMissing = 'This image is no longer available to preview',
 }: {
   host: QueueImage | null;
@@ -115,14 +136,26 @@ export function SubmissionPair({
   remixLabel: string;
   hostMissing: string;
   remixMissing?: string;
+  /** Applied to whichever side is withheld; both point at the same pair. */
+  withheldHref?: (image: QueueImage) => string;
 }) {
   return (
     <div className="flex shrink-0 gap-2">
       <Captioned caption={hostCaption}>
-        <QueueThumb image={host} label={hostLabel} missing={hostMissing} />
+        <QueueThumb
+          image={host}
+          label={hostLabel}
+          missing={hostMissing}
+          withheldHref={host && withheldHref ? withheldHref(host) : undefined}
+        />
       </Captioned>
       <Captioned caption={remixCaption}>
-        <QueueThumb image={remix} label={remixLabel} missing={remixMissing} />
+        <QueueThumb
+          image={remix}
+          label={remixLabel}
+          missing={remixMissing}
+          withheldHref={remix && withheldHref ? withheldHref(remix) : undefined}
+        />
       </Captioned>
     </div>
   );

--- a/src/components/RemixGallery/SubmissionThumb.tsx
+++ b/src/components/RemixGallery/SubmissionThumb.tsx
@@ -6,6 +6,12 @@ import type { RouterOutput } from '~/types/router';
 type PendingSubmission =
   RouterOutput['placement']['getPendingRemixGallerySubmissions']['items'][number];
 
+/** The variant that carries an asset. The other one has no pixels to open. */
+export type ViewableQueueImage = Extract<
+  NonNullable<PendingSubmission['image']>,
+  { viewable: true }
+>;
+
 /**
  * The submitted image, openable.
  *
@@ -17,9 +23,15 @@ type PendingSubmission =
  * still waiting on them, and sending the reviewer away to see one submission
  * loses the list and their place in it.
  */
-export function SubmissionThumb({ image }: { image: NonNullable<PendingSubmission['image']> }) {
+export function SubmissionThumb({
+  image,
+  label = 'Open this remix in a new tab',
+}: {
+  image: ViewableQueueImage;
+  label?: string;
+}) {
   return (
-    <Tooltip label="Open this remix in a new tab" withArrow openDelay={400}>
+    <Tooltip label={label} withArrow openDelay={400}>
       <a
         href={`/images/${image.id}`}
         target="_blank"

--- a/src/pages/user/remix-submissions.tsx
+++ b/src/pages/user/remix-submissions.tsx
@@ -17,6 +17,8 @@ import { IconCheck, IconX } from '@tabler/icons-react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useBrowsingLevelDebounced } from '~/components/BrowsingLevel/BrowsingLevelProvider';
+import { useServerDomains } from '~/providers/AppProvider';
+import { syncAccount } from '~/utils/sync-account';
 import { CurrencyIcon } from '~/components/Currency/CurrencyIcon';
 import { Meta } from '~/components/Meta/Meta';
 import { SubmissionPair } from '~/components/RemixGallery/SubmissionPair';
@@ -148,6 +150,16 @@ export default function RemixSubmissions() {
   );
 }
 
+/**
+ * Where to send someone whose domain will not serve an image. The queue keeps
+ * the row so the escrow can still be answered; this is the only route left to
+ * the picture itself, since the withheld tile has no pixels to reveal.
+ */
+function useWithheldHref() {
+  const domains = useServerDomains();
+  return (image: { id: number }) => syncAccount(`//${domains.red}/images/${image.id}`);
+}
+
 type ReceivedRow = RouterOutput['placement']['getPendingRemixGallerySubmissions']['items'][number];
 
 function ReceivedTab({
@@ -166,6 +178,7 @@ function ReceivedTab({
   onLoadMore: () => void;
 }) {
   const utils = trpc.useUtils();
+  const withheldHref = useWithheldHref();
 
   const act = trpc.placement.actOnRemixGallerySubmission.useMutation({
     onSuccess: (_result, variables) => {
@@ -247,6 +260,7 @@ function ReceivedTab({
                 hostLabel="Open your image in a new tab"
                 remixLabel="Open this remix in a new tab"
                 hostMissing="Your image is no longer available to preview"
+                withheldHref={withheldHref}
               />
               <Stack gap={4}>
                 <Text size="sm">
@@ -314,6 +328,7 @@ type SentRow = RouterOutput['placement']['getMyRemixGallerySubmissions'][number]
 
 function SentTab({ rows, isLoading }: { rows: SentRow[]; isLoading: boolean }) {
   const utils = trpc.useUtils();
+  const withheldHref = useWithheldHref();
 
   const retract = trpc.placement.retractRemixGallerySubmission.useMutation({
     onSuccess: () => {
@@ -375,6 +390,7 @@ function SentTab({ rows, isLoading }: { rows: SentRow[]; isLoading: boolean }) {
                 hostLabel="Open the gallery image in a new tab"
                 remixLabel="Open your remix in a new tab"
                 hostMissing="This gallery image is no longer available to preview"
+                withheldHref={withheldHref}
               />
               <Stack gap={4}>
                 <Group gap="xs">

--- a/src/pages/user/remix-submissions.tsx
+++ b/src/pages/user/remix-submissions.tsx
@@ -4,24 +4,22 @@ import {
   Badge,
   Button,
   Card,
-  Center,
   Container,
   Group,
   Loader,
-  Skeleton,
   Stack,
   Tabs,
   Text,
   Title,
-  Tooltip,
 } from '@mantine/core';
 import { openConfirmModal } from '@mantine/modals';
-import { IconCheck, IconExternalLink, IconPhotoOff, IconX } from '@tabler/icons-react';
+import { IconCheck, IconX } from '@tabler/icons-react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
+import { useBrowsingLevelDebounced } from '~/components/BrowsingLevel/BrowsingLevelProvider';
 import { CurrencyIcon } from '~/components/Currency/CurrencyIcon';
 import { Meta } from '~/components/Meta/Meta';
-import { SubmissionThumb } from '~/components/RemixGallery/SubmissionThumb';
+import { SubmissionPair } from '~/components/RemixGallery/SubmissionPair';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { Currency } from '~/shared/utils/prisma/enums';
 import type { RouterOutput } from '~/types/router';
@@ -59,6 +57,11 @@ const agedLabel = (at: Date | string) => {
  */
 export default function RemixSubmissions() {
   const router = useRouter();
+  // The queue marks rows against this rather than filtering on it. A submission
+  // hidden for being outside the owner's band still expires, and expiry costs
+  // the submitter nothing and the owner their fee — so it has to be visible
+  // enough to act on.
+  const browsingLevel = useBrowsingLevelDebounced();
   const tab: TabValue = isTabValue(router.query.tab) ? router.query.tab : 'received';
 
   const setTab = (value: string | null) =>
@@ -78,11 +81,11 @@ export default function RemixSubmissions() {
     hasNextPage,
     isFetchingNextPage,
   } = trpc.placement.getPendingRemixGallerySubmissions.useInfiniteQuery(
-    {},
+    { browsingLevel },
     { getNextPageParam: (lastPage) => lastPage.nextCursor }
   );
   const { data: sent, isLoading: sentLoading } =
-    trpc.placement.getMyRemixGallerySubmissions.useQuery();
+    trpc.placement.getMyRemixGallerySubmissions.useQuery({ browsingLevel });
 
   const receivedRows = received?.pages.flatMap((page) => page.items) ?? [];
   const waiting = receivedRows.length;
@@ -236,7 +239,15 @@ function ReceivedTab({
         <Card key={row.id} withBorder>
           <Group justify="space-between" wrap="nowrap" align="flex-start">
             <Group gap="sm" wrap="nowrap" align="flex-start">
-              {row.image && <SubmissionThumb image={row.image} />}
+              <SubmissionPair
+                host={row.targetImage}
+                remix={row.image}
+                hostCaption="Yours"
+                remixCaption="Theirs"
+                hostLabel="Open your image in a new tab"
+                remixLabel="Open this remix in a new tab"
+                hostMissing="Your image is no longer available to preview"
+              />
               <Stack gap={4}>
                 <Text size="sm">
                   <Text span fw={600}>
@@ -254,12 +265,6 @@ function ReceivedTab({
                   Sent {agedLabel(row.createdAt)}
                   {row.expiresAt ? ` — expires ${formatDate(row.expiresAt)}` : ''}
                 </Text>
-                <Anchor component={Link} href={`/images/${row.targetId}`} size="xs">
-                  <Group gap={4} wrap="nowrap">
-                    <IconExternalLink size={12} />
-                    See your image
-                  </Group>
-                </Anchor>
               </Stack>
             </Group>
 
@@ -362,22 +367,15 @@ function SentTab({ rows, isLoading }: { rows: SentRow[]; isLoading: boolean }) {
         <Card key={row.id} withBorder>
           <Group justify="space-between" wrap="nowrap" align="flex-start">
             <Group gap="sm" wrap="nowrap" align="flex-start">
-              {row.image ? (
-                <SubmissionThumb image={row.image} />
-              ) : (
-                // The row is kept even when its image will not resolve —
-                // unpublished, deleted, flagged — because the withdraw beside it
-                // is the only route back to the escrow. A placeholder says the
-                // preview is gone without implying the submission is.
-                <Tooltip label="This image is no longer available to preview" withArrow>
-                  <div className="relative w-20 shrink-0">
-                    <Skeleton animate={false} className="aspect-square w-full rounded-md" />
-                    <Center className="absolute inset-0">
-                      <IconPhotoOff size={20} className="text-dimmed" />
-                    </Center>
-                  </div>
-                </Tooltip>
-              )}
+              <SubmissionPair
+                host={row.targetImage}
+                remix={row.image}
+                hostCaption="Theirs"
+                remixCaption="Yours"
+                hostLabel="Open the gallery image in a new tab"
+                remixLabel="Open your remix in a new tab"
+                hostMissing="This gallery image is no longer available to preview"
+              />
               <Stack gap={4}>
                 <Group gap="xs">
                   <Badge
@@ -401,12 +399,6 @@ function SentTab({ rows, isLoading }: { rows: SentRow[]; isLoading: boolean }) {
                     ? ` — expires ${formatDate(row.expiresAt)}`
                     : ''}
                 </Text>
-                <Anchor component={Link} href={`/images/${row.targetId}`} size="xs">
-                  <Group gap={4} wrap="nowrap">
-                    <IconExternalLink size={12} />
-                    See the gallery
-                  </Group>
-                </Anchor>
               </Stack>
             </Group>
 

--- a/src/pages/user/sticker-placements.tsx
+++ b/src/pages/user/sticker-placements.tsx
@@ -13,12 +13,16 @@ import {
 import { IconExternalLink } from '@tabler/icons-react';
 import Link from 'next/link';
 import { useState } from 'react';
+import { useBrowsingLevelDebounced } from '~/components/BrowsingLevel/BrowsingLevelProvider';
 import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
 import { EdgeImage } from '~/components/EdgeMedia/EdgeImage';
 import { Meta } from '~/components/Meta/Meta';
 import { stickerArtworkStyle } from '~/components/Sticker/placement-appearance';
 import { StickerPlacementActions } from '~/components/Sticker/StickerPlacementActions';
+import { WithheldThumb } from '~/components/RemixGallery/SubmissionPair';
 import { useStickerCosmetics } from '~/components/Sticker/sticker.util';
+import { useServerDomains } from '~/providers/AppProvider';
+import { syncAccount } from '~/utils/sync-account';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { formatDate } from '~/utils/date-helpers';
 import { trpc } from '~/utils/trpc';
@@ -32,9 +36,16 @@ import { trpc } from '~/utils/trpc';
  * and to clear a backlog in one pass.
  */
 export default function StickerPlacements() {
+  // Marked on each row rather than filtered on: a placement hidden for being
+  // outside your own band still expires, and expiry pays the placer back and
+  // costs the owner their fee.
+  const browsingLevel = useBrowsingLevelDebounced();
+  const domains = useServerDomains();
+  const withheldHref = (image: { id: number }) =>
+    syncAccount(`//${domains.red}/images/${image.id}`);
   const { data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
     trpc.placement.getPending.useInfiniteQuery(
-      {},
+      { browsingLevel },
       { getNextPageParam: (lastPage) => lastPage.nextCursor }
     );
   const [selected, setSelected] = useState<number[]>([]);
@@ -119,22 +130,32 @@ export default function StickerPlacements() {
                     aria-label="Select this placement"
                   />
 
-                  {row.image && (
-                    // `anim={false}` is what keeps a list of these quiet: it
-                    // suppresses the autoplay observer and the autoPlay
-                    // attribute, leaving a poster frame that plays on hover.
-                    // The type has to be the real one — forcing `image` asks the
-                    // CDN to transform a video as a still, which it will not do.
-                    <EdgeMedia
-                      src={row.image.url}
-                      type={row.image.type}
-                      anim={false}
-                      name={row.image.name ?? row.image.id.toString()}
-                      alt={row.image.name ?? undefined}
-                      width={180}
-                      style={{ width: 90, height: 'auto', borderRadius: 6 }}
-                    />
-                  )}
+                  {row.image &&
+                    (row.image.viewable ? (
+                      // `anim={false}` is what keeps a list of these quiet: it
+                      // suppresses the autoplay observer and the autoPlay
+                      // attribute, leaving a poster frame that plays on hover.
+                      // The type has to be the real one — forcing `image` asks the
+                      // CDN to transform a video as a still, which it will not do.
+                      <EdgeMedia
+                        src={row.image.url}
+                        type={row.image.type}
+                        anim={false}
+                        name={row.image.name ?? row.image.id.toString()}
+                        alt={row.image.name ?? undefined}
+                        width={180}
+                        style={{ width: 90, height: 'auto', borderRadius: 6 }}
+                      />
+                    ) : (
+                      // Your own image, on a domain that may not serve it. The
+                      // row stays actionable — the escrow behind it expires
+                      // either way — and the link is the only route left, since
+                      // no asset was sent to reveal.
+                      <WithheldThumb
+                        nsfwLevel={row.image.nsfwLevel}
+                        href={withheldHref(row.image)}
+                      />
+                    ))}
 
                   {art && (
                     // Drawn with the placer's own opacity and flip, not at full

--- a/src/server/routers/placement.router.ts
+++ b/src/server/routers/placement.router.ts
@@ -6,6 +6,7 @@ import {
   getPlacementSpaceSchema,
   countPendingPlacementsFromSchema,
   getPlacementSettlementStatesSchema,
+  getMyRemixGallerySubmissionsSchema,
   getPendingRemixGallerySubmissionsSchema,
   getPendingStickerPlacementsSchema,
   getRemixGallerySchema,
@@ -60,7 +61,10 @@ import {
 } from '~/server/services/remix-gallery.service';
 import { moderatorProcedure, protectedProcedure, publicProcedure, router } from '~/server/trpc';
 import { throwAuthorizationError } from '~/server/utils/errorHandling';
-import { sfwBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constants';
+import {
+  allBrowsingLevelsFlag,
+  sfwBrowsingLevelsFlag,
+} from '~/shared/constants/browsingLevel.constants';
 import type { PlacementSurface } from '~/shared/utils/placement';
 import type { Context } from '~/server/createContext';
 
@@ -119,6 +123,17 @@ function assertSurfaceEnabled(ctx: Context, surface: PlacementSurface) {
  */
 const viewerBrowsingLevel = (ctx: Context, requested: number) =>
   ctx.features.isGreen ? requested & sfwBrowsingLevelsFlag : requested;
+
+/**
+ * What this domain may be SENT, as opposed to what the viewer asked for.
+ *
+ * The review queues carry no browsing level by design — an owner has to see what
+ * is waiting on them whatever their own settings say — which makes them the one
+ * path that hands an above-ceiling asset to a SFW client. Blur is not that
+ * control: it is built from the viewer's own level and never reads the domain's.
+ */
+const domainServableLevels = (ctx: Context) =>
+  ctx.features.isGreen ? sfwBrowsingLevelsFlag : allBrowsingLevelsFlag;
 
 export const placementRouter = router({
   getSpace: publicProcedure
@@ -327,6 +342,7 @@ export const placementRouter = router({
       getRemixGalleryVisibility({
         hostImageId: input.imageId,
         browsingLevel: viewerBrowsingLevel(ctx, input.browsingLevel),
+        domainLevels: domainServableLevels(ctx),
         // The service only counts pending submissions when this matches the
         // space owner, so a signed-out or unrelated viewer never learns how
         // many someone has waiting.
@@ -378,10 +394,18 @@ export const placementRouter = router({
         ownerId: ctx.user.id,
         hostImageId: input.hostImageId,
         cursor: input.cursor,
+        domainLevels: domainServableLevels(ctx),
+        viewerLevels: viewerBrowsingLevel(ctx, input.browsingLevel),
       })
     ),
 
-  getMyRemixGallerySubmissions: protectedProcedure.query(({ ctx }) =>
-    getMyRemixGallerySubmissions({ placerId: ctx.user.id })
-  ),
+  getMyRemixGallerySubmissions: protectedProcedure
+    .input(getMyRemixGallerySubmissionsSchema)
+    .query(({ input, ctx }) =>
+      getMyRemixGallerySubmissions({
+        placerId: ctx.user.id,
+        domainLevels: domainServableLevels(ctx),
+        viewerLevels: viewerBrowsingLevel(ctx, input.browsingLevel),
+      })
+    ),
 });

--- a/src/server/routers/placement.router.ts
+++ b/src/server/routers/placement.router.ts
@@ -1,5 +1,6 @@
 import {
   actOnRemixGallerySubmissionSchema,
+  declineOutOfBandRemixGallerySubmissionsSchema,
   actOnStickerPlacementsSchema,
   createStickerPlacementSchema,
   getPlacementSpaceRowSchema,
@@ -51,6 +52,7 @@ import {
 } from '~/server/services/sticker-placement.service';
 import {
   actOnRemixGallerySubmission,
+  declineOutOfBandRemixGallerySubmissions,
   createRemixGallerySubmission,
   getMyRemixGallerySubmissions,
   getPendingRemixGallerySubmissions,
@@ -300,7 +302,12 @@ export const placementRouter = router({
   getPending: protectedProcedure
     .input(getPendingStickerPlacementsSchema)
     .query(({ input, ctx }) =>
-      getPendingStickerPlacements({ ownerId: ctx.user.id, cursor: input.cursor })
+      getPendingStickerPlacements({
+        ownerId: ctx.user.id,
+        cursor: input.cursor,
+        domainLevels: domainServableLevels(ctx),
+        viewerLevels: viewerBrowsingLevel(ctx, input.browsingLevel),
+      })
     ),
 
   // How many pending placements blocking someone would decline, so the confirm
@@ -370,6 +377,21 @@ export const placementRouter = router({
         userId: ctx.user.id,
         isModerator: ctx.user.isModerator,
       })
+    ),
+
+  /**
+   * Ungated for the same reason as the single action above: an owner must be
+   * able to clear submissions their own rule should never have taken, whatever
+   * the flag says.
+   *
+   * `isModerator` is deliberately not passed. This resolves a set from a
+   * gallery's own rule and settles every row in it — a moderator running it on
+   * someone else's gallery would be a bulk action attributed to the owner.
+   */
+  declineOutOfBandRemixGallerySubmissions: protectedProcedure
+    .input(declineOutOfBandRemixGallerySubmissionsSchema)
+    .mutation(({ input, ctx }) =>
+      declineOutOfBandRemixGallerySubmissions({ ...input, userId: ctx.user.id })
     ),
 
   // Also ungated: a submitter must be able to get their Buzz back out of escrow

--- a/src/server/routers/placement.router.ts
+++ b/src/server/routers/placement.router.ts
@@ -299,16 +299,14 @@ export const placementRouter = router({
     .input(placerSchema)
     .mutation(({ input }) => restorePlacementPrivileges(input.userId)),
 
-  getPending: protectedProcedure
-    .input(getPendingStickerPlacementsSchema)
-    .query(({ input, ctx }) =>
-      getPendingStickerPlacements({
-        ownerId: ctx.user.id,
-        cursor: input.cursor,
-        domainLevels: domainServableLevels(ctx),
-        viewerLevels: viewerBrowsingLevel(ctx, input.browsingLevel),
-      })
-    ),
+  getPending: protectedProcedure.input(getPendingStickerPlacementsSchema).query(({ input, ctx }) =>
+    getPendingStickerPlacements({
+      ownerId: ctx.user.id,
+      cursor: input.cursor,
+      domainLevels: domainServableLevels(ctx),
+      viewerLevels: viewerBrowsingLevel(ctx, input.browsingLevel),
+    })
+  ),
 
   // How many pending placements blocking someone would decline, so the confirm
   // dialog can say. Advisory by construction — holding it accurate across a

--- a/src/server/schema/placement.schema.ts
+++ b/src/server/schema/placement.schema.ts
@@ -205,10 +205,23 @@ export const setRemixGalleryPinsSchema = z.object({
 /** Where the last page stopped. Opaque to the client; see `placementQueueKeyset`. */
 const placementQueueCursorSchema = z.string().max(100).nullish();
 
+/**
+ * The review queues take a browsing level like every image listing, but they do
+ * not filter on it: an owner has to be shown everything waiting on them, or the
+ * escrow behind what they cannot see expires unreviewed. It marks rows instead,
+ * so the surface can say what is outside the viewer's band and offer to widen it.
+ * The domain ceiling is the separate, non-negotiable one, applied in the router.
+ */
 export const getPendingRemixGallerySubmissionsSchema = z.object({
   /** Omitted for the account-wide queue; set to scope to one gallery. */
   hostImageId: z.number().int().positive().optional(),
+  browsingLevel: z.number().min(0).default(allBrowsingLevelsFlag),
   cursor: placementQueueCursorSchema,
+});
+
+/** Same marking rule as the owner queue: the submitter's own band, not a filter. */
+export const getMyRemixGallerySubmissionsSchema = z.object({
+  browsingLevel: z.number().min(0).default(allBrowsingLevelsFlag),
 });
 
 export const getPendingStickerPlacementsSchema = z.object({

--- a/src/server/schema/placement.schema.ts
+++ b/src/server/schema/placement.schema.ts
@@ -193,6 +193,15 @@ export const retractRemixGallerySubmissionSchema = z.object({
 });
 
 /**
+ * The gallery, not the rows. The set is resolved server-side from the owner's
+ * own content rule — accepting placement ids here would let a caller decline
+ * submissions that are perfectly in band.
+ */
+export const declineOutOfBandRemixGallerySubmissionsSchema = z.object({
+  hostImageId: z.number().int().positive(),
+});
+
+/**
  * The whole pinned set, in order, rather than a per-entry toggle — the cap is a
  * property of the set, and enforcing it one toggle at a time lets two concurrent
  * pins both see room for one more.
@@ -226,4 +235,5 @@ export const getMyRemixGallerySubmissionsSchema = z.object({
 
 export const getPendingStickerPlacementsSchema = z.object({
   cursor: placementQueueCursorSchema,
+  browsingLevel: z.number().min(0).default(allBrowsingLevelsFlag),
 });

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -125,8 +125,29 @@ const {
   REMIX_GALLERY_REMOVAL_LOCK_HOURS,
 } = await import('~/shared/utils/remix-gallery');
 
+/**
+ * Declared rather than inferred, because every test here builds its case by
+ * spreading the good one and overriding a field. Inference narrowed `null`s to
+ * `null` and the rating to a literal, so the overrides that make each test a
+ * test — `needsReview: 'reported'`, `nsfwLevel: 0`, `publishedAt: null` — were
+ * type errors against their own fixture.
+ */
+type SubmissionFixture = {
+  id: number;
+  userId: number;
+  nsfwLevel: number;
+  minor: boolean;
+  poi: boolean;
+  tosViolation: boolean;
+  ingestion: string;
+  needsReview: string | null;
+  publishedAt: Date | null;
+  remixOfId: number | null;
+  sourceImageIds: number[] | null;
+};
+
 /** A submission that passes every check, so each test breaks exactly one thing. */
-const goodSubmission = {
+const goodSubmission: SubmissionFixture = {
   id: REMIX_IMAGE,
   userId: PLACER,
   nsfwLevel: NsfwLevel.PG,

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NsfwLevel } from '~/server/common/enums';
+import { allBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constants';
 import type * as MetricHelpers from '~/server/utils/metric-helpers';
 
 const updateEntityMetricDetached = vi.fn(async () => undefined);
@@ -1062,130 +1063,204 @@ describe('getPendingRemixGallerySubmissions paging', () => {
     placer: { id: PLACER, username: 'someone', image: null },
   });
 
-  /** Only the first image resolves, so the rest of the page is filtered out. */
-  const onlyFirstImageVisible = (imageId: number) =>
-    queryRaw.mockResolvedValue([
-      { id: imageId, url: 'x', width: 1, height: 1, type: 'image', metadata: null, nsfwLevel: 1 },
-    ]);
+  const image = (id: number) => ({
+    id,
+    url: 'x',
+    width: 1,
+    height: 1,
+    type: 'image',
+    metadata: null,
+    nsfwLevel: 1,
+  });
+
+  const LEVELS = allBrowsingLevelsFlag;
+  const ask = (args: { limit: number; cursor?: string | null }) =>
+    getPendingRemixGallerySubmissions({
+      ownerId: OWNER,
+      domainLevels: LEVELS,
+      viewerLevels: LEVELS,
+      ...args,
+    });
+
+  let queueSelects: { sql: string; values: unknown[] }[] = [];
+  const lastQueueSelect = () => queueSelects.at(-1) ?? { sql: '', values: [] as unknown[] };
+
+  /**
+   * A composed statement hides its own text: an interpolated `Prisma.sql`
+   * fragment arrives as a VALUE, not as part of the outer template. Reading only
+   * the outer strings would make every assertion about the keyset pass whether
+   * or not the keyset was there.
+   */
+  const isSql = (value: unknown): value is { strings: string[]; values: unknown[] } =>
+    !!value && typeof value === 'object' && 'strings' in value;
+
+  const sqlTextOf = (value: unknown): string => {
+    if (Array.isArray(value)) return value.map(sqlTextOf).join(' ');
+    if (isSql(value)) return [sqlTextOf(value.strings), sqlTextOf(value.values)].join(' ');
+    return typeof value === 'string' ? value : '';
+  };
+
+  const flatValues = (value: unknown): unknown[] => {
+    if (isSql(value)) return value.values.flatMap(flatValues);
+    if (Array.isArray(value)) return value.flatMap(flatValues);
+    return typeof value === 'string' && value.includes('SELECT') ? [] : [value];
+  };
+
+  /**
+   * The page is a SQL select over `Placement`; the images are a second select
+   * over `Image`. Both arrive at the same `$queryRaw` mock, so they are told
+   * apart by the statement rather than by call order — the early return changes
+   * that order, and call-order coupling would then feed one query's rows to the
+   * other while every assertion still passed.
+   */
+  const respond = ({
+    page,
+    images,
+  }: {
+    page: { id: number; createdAt: Date }[];
+    images: unknown[];
+  }) =>
+    queryRaw.mockImplementation(async (...args: unknown[]) => {
+      const sql = sqlTextOf(args);
+      if (sql.includes('FROM "Placement"')) {
+        queueSelects.push({ sql, values: flatValues(args) });
+        return page;
+      }
+      return images;
+    });
 
   beforeEach(() => {
-    queryRaw.mockResolvedValue([]);
+    queueSelects = [];
+    respond({ page: [], images: [] });
+    placementFindMany.mockResolvedValue([]);
   });
 
   it('takes the cursor from the last row of the page, not the last row it returns', async () => {
-    // Three rows for a page of two: the third is the "is there more" probe, and
-    // the second is dropped below because its image no longer resolves.
+    // Three rows for a page of two: the third is the "is there more" probe. Row
+    // 2 is selected but dropped afterwards for an unreadable payload — exactly
+    // the case where a cursor built from what was RETURNED says row 1 and the
+    // next page serves row 2 a second time.
+    respond({
+      page: [
+        { id: 1, createdAt: new Date('2026-01-01T00:00:00.000Z') },
+        { id: 2, createdAt: new Date('2026-01-02T00:00:00.000Z') },
+        { id: 3, createdAt: new Date('2026-01-03T00:00:00.000Z') },
+      ],
+      images: [image(101), image(HOST_IMAGE)],
+    });
     placementFindMany.mockResolvedValue([
       queueRow(1, 101, '2026-01-01T00:00:00.000Z'),
-      queueRow(2, 102, '2026-01-02T00:00:00.000Z'),
-      queueRow(3, 103, '2026-01-03T00:00:00.000Z'),
+      { ...queueRow(2, 0, '2026-01-02T00:00:00.000Z'), data: { nonsense: true } },
     ]);
-    onlyFirstImageVisible(101);
 
-    const result = await getPendingRemixGallerySubmissions({ ownerId: OWNER, limit: 2 });
+    const result = await ask({ limit: 2 });
 
     expect(result.items.map((item) => item.id)).toEqual([1]);
-    // Row 2's key. A cursor built from what was returned would say row 1, and
-    // the next page would serve row 2 a second time.
     expect(result.nextCursor).toBe(`${new Date('2026-01-02T00:00:00.000Z').getTime()}:2`);
   });
 
-  it('still hands back a cursor when EVERY row on the page was filtered out', async () => {
-    // The state the UI now depends on. Return `nextCursor: null` here and the
-    // owner is told "nothing is waiting" over a queue with entries behind it —
-    // the original bug, one layer up, with every other test still green.
-    placementFindMany.mockResolvedValue([
-      queueRow(1, 101, '2026-01-01T00:00:00.000Z'),
-      queueRow(2, 102, '2026-01-02T00:00:00.000Z'),
-      queueRow(3, 103, '2026-01-03T00:00:00.000Z'),
-    ]);
-    queryRaw.mockResolvedValue([]);
+  it('selects only renderable rows, so a page is full rows or the end of the queue', async () => {
+    // The bug this replaced: the page was fetched and THEN filtered, so a queue
+    // of 66 whose first 50 were unrenderable returned 4 items with a cursor —
+    // "4+" over a page size of 50, and "load more" then produced 2. Both images
+    // are tested, the submission and the host it sits on.
+    await ask({ limit: 2 });
 
-    const result = await getPendingRemixGallerySubmissions({ ownerId: OWNER, limit: 2 });
-
-    expect(result.items).toEqual([]);
-    expect(result.nextCursor).toBe(`${new Date('2026-01-02T00:00:00.000Z').getTime()}:2`);
+    const { sql } = lastQueueSelect();
+    expect(sql).toContain(`data ->> 'imageId'`);
+    expect(sql).toContain('pl."targetId"');
+    expect(sql).toContain('publishedAt');
+    expect(sql).toContain(`ingestion = 'Scanned'`);
   });
 
-  it('hands back a cursor on the early return too, when no row even names an image', async () => {
-    // The `!imageIds.length` short-circuit is a second exit from this function
-    // and it has to carry the cursor for the same reason the main one does. The
-    // test above cannot reach it — those rows name images that simply are not
-    // visible, so it leaves by the filter at the end instead.
+  it('hands back a cursor when every row it selected was dropped afterwards', async () => {
+    // The unreadable-payload filter is the one drop left after selection, and
+    // returning `null` here tells the owner "nothing is waiting" over a queue
+    // with entries behind it — the original bug, one layer up.
+    respond({
+      page: [
+        { id: 1, createdAt: new Date('2026-01-01T00:00:00.000Z') },
+        { id: 2, createdAt: new Date('2026-01-02T00:00:00.000Z') },
+        { id: 3, createdAt: new Date('2026-01-03T00:00:00.000Z') },
+      ],
+      images: [],
+    });
     placementFindMany.mockResolvedValue([
       { ...queueRow(1, 0, '2026-01-01T00:00:00.000Z'), data: { nonsense: true } },
       { ...queueRow(2, 0, '2026-01-02T00:00:00.000Z'), data: { nonsense: true } },
-      { ...queueRow(3, 0, '2026-01-03T00:00:00.000Z'), data: { nonsense: true } },
     ]);
 
-    const result = await getPendingRemixGallerySubmissions({ ownerId: OWNER, limit: 2 });
+    const result = await ask({ limit: 2 });
 
     expect(result.items).toEqual([]);
     expect(result.nextCursor).toBe(`${new Date('2026-01-02T00:00:00.000Z').getTime()}:2`);
   });
 
   it('reports no next page when the queue ends inside the page', async () => {
+    respond({
+      page: [{ id: 1, createdAt: new Date('2026-01-01T00:00:00.000Z') }],
+      images: [image(101), image(HOST_IMAGE)],
+    });
     placementFindMany.mockResolvedValue([queueRow(1, 101, '2026-01-01T00:00:00.000Z')]);
-    onlyFirstImageVisible(101);
 
-    const result = await getPendingRemixGallerySubmissions({ ownerId: OWNER, limit: 2 });
+    const result = await ask({ limit: 2 });
 
+    expect(result.items.map((item) => item.id)).toEqual([1]);
     expect(result.nextCursor).toBeNull();
   });
 
   it('resumes strictly after the cursor row, including its same-millisecond twin', async () => {
-    placementFindMany.mockResolvedValue([]);
     const createdAt = new Date('2026-01-02T00:00:00.000Z');
 
-    await getPendingRemixGallerySubmissions({
-      ownerId: OWNER,
-      limit: 2,
-      cursor: `${createdAt.getTime()}:2`,
-    });
+    await ask({ limit: 2, cursor: `${createdAt.getTime()}:2` });
 
-    const { where, orderBy, take } = placementFindMany.mock.calls.at(-1)?.[0] as {
-      where: { OR?: unknown[] };
-      orderBy: unknown;
-      take: number;
-    };
+    const { sql, values } = lastQueueSelect();
     // Two placements can share a millisecond. Without the id tie-break one of
     // them is stepped over and its escrow expires unreviewed.
-    expect(where.OR).toEqual([{ createdAt: { gt: createdAt } }, { createdAt, id: { gt: 2 } }]);
-    expect(orderBy).toEqual([{ createdAt: 'asc' }, { id: 'asc' }]);
+    expect(sql).toMatch(/createdAt"\s*>/);
+    expect(sql).toMatch(/pl\.id\s*>/);
+    expect(sql).toMatch(/ORDER BY[\s\S]*createdAt/);
+    expect(values).toContain(2);
+    expect(
+      values.some((value) => value instanceof Date && value.getTime() === createdAt.getTime())
+    ).toBe(true);
     // limit + 1: the extra row is what says whether another page exists.
-    expect(take).toBe(3);
+    expect(values).toContain(3);
   });
 
   it('reports no next page when the queue ends exactly on the page boundary', async () => {
-    // The case the old `truncated = rows.length >= limit` got wrong. `take` is
-    // limit + 1, so a queue of exactly `limit` returns `limit` rows and there is
-    // nothing behind it — a cursor here sends the owner to an empty page.
+    // The case the old `truncated = rows.length >= limit` got wrong. The select
+    // takes limit + 1, so a queue of exactly `limit` has nothing behind it — a
+    // cursor here sends the owner to an empty page.
+    respond({
+      page: [
+        { id: 1, createdAt: new Date('2026-01-01T00:00:00.000Z') },
+        { id: 2, createdAt: new Date('2026-01-02T00:00:00.000Z') },
+      ],
+      images: [image(101), image(102), image(HOST_IMAGE)],
+    });
     placementFindMany.mockResolvedValue([
       queueRow(1, 101, '2026-01-01T00:00:00.000Z'),
       queueRow(2, 102, '2026-01-02T00:00:00.000Z'),
     ]);
-    onlyFirstImageVisible(101);
 
-    const result = await getPendingRemixGallerySubmissions({ ownerId: OWNER, limit: 2 });
+    const result = await ask({ limit: 2 });
 
     expect(result.nextCursor).toBeNull();
   });
 
   it('starts a fresh page rather than a bad value in a query when the cursor is malformed', async () => {
-    placementFindMany.mockResolvedValue([]);
     const wellFormed = `${new Date('2026-01-02T00:00:00.000Z').getTime()}:2`;
 
     // The positive control. Without it this test passes with the keyset removed
-    // entirely, because then no cursor ever produces an `OR`.
-    await getPendingRemixGallerySubmissions({ ownerId: OWNER, limit: 2, cursor: wellFormed });
-    const accepted = placementFindMany.mock.calls.at(-1)?.[0] as { where: { OR?: unknown[] } };
-    expect(accepted.where.OR).toHaveLength(2);
+    // entirely, because then no cursor ever produces the clause.
+    await ask({ limit: 2, cursor: wellFormed });
+    expect(lastQueueSelect().sql).toMatch(/pl\.id\s*>/);
 
     for (const cursor of ['nonsense', '1e21:1', '1700000000000:1.5', '1:2:3', '-1:2', ':']) {
-      await getPendingRemixGallerySubmissions({ ownerId: OWNER, limit: 2, cursor });
+      await ask({ limit: 2, cursor });
 
-      const { where } = placementFindMany.mock.calls.at(-1)?.[0] as { where: { OR?: unknown[] } };
-      expect(where.OR, `cursor ${cursor} reached the query`).toBeUndefined();
+      expect(lastQueueSelect().sql, `cursor ${cursor} reached the query`).not.toMatch(/pl\.id\s*>/);
     }
   });
 });

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NsfwLevel } from '~/server/common/enums';
-import { allBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constants';
+import {
+  allBrowsingLevelsFlag,
+  sfwBrowsingLevelsFlag,
+} from '~/shared/constants/browsingLevel.constants';
 import type * as MetricHelpers from '~/server/utils/metric-helpers';
 
 const updateEntityMetricDetached = vi.fn(async () => undefined);
@@ -68,6 +71,7 @@ const placementCount = vi.fn(async () => 0);
 const placementFindFirst = vi.fn(async () => null as unknown);
 const placementFindUnique = vi.fn(async () => null as unknown);
 const placementFindMany = vi.fn(async () => [] as unknown[]);
+const imageFindMany = vi.fn(async () => [] as unknown[]);
 const placementUpdate = vi.fn(async () => ({}));
 const placementUpdateMany = vi.fn(async () => ({ count: 1 }));
 const dbTransaction = vi.fn(async (ops: unknown) => (Array.isArray(ops) ? ops : []));
@@ -93,6 +97,7 @@ vi.mock('~/server/db/client', () => ({
       findUnique: placementFindUnique,
       count: placementCount,
     },
+    image: { findMany: imageFindMany },
     user: { findUnique: async () => ({ username: 'someone' }) },
   },
 }));
@@ -106,6 +111,7 @@ const {
   getRemixGallery,
   getRemixGalleryVisibility,
   getPendingRemixGallerySubmissions,
+  declineOutOfBandRemixGallerySubmissions,
 } = await import('~/server/services/remix-gallery.service');
 
 const {
@@ -463,7 +469,11 @@ describe('the ceiling is applied on read, not only on the mutation', () => {
   // gallery query will not return.
   it('carries it in the has-entries read', async () => {
     resolvePlacementSpaceFor.mockResolvedValue(openSpace);
-    await getRemixGalleryVisibility({ hostImageId: HOST_IMAGE, browsingLevel: 1 });
+    await getRemixGalleryVisibility({
+      hostImageId: HOST_IMAGE,
+      browsingLevel: 1,
+      domainLevels: allBrowsingLevelsFlag,
+    });
     expectCeiling(sqlFrom());
   });
 });
@@ -1094,10 +1104,36 @@ describe('getPendingRemixGallerySubmissions paging', () => {
   const isSql = (value: unknown): value is { strings: string[]; values: unknown[] } =>
     !!value && typeof value === 'object' && 'strings' in value;
 
+  /**
+   * Rebuilt in ORDER — each string, then the fragment interpolated after it.
+   * Concatenating all the outer strings and then all the values reads as valid
+   * SQL and is not: the `AND`/`OR` joining two fragments lives in the outer
+   * strings while the fragments live in the values, so an `AND` -> `OR` flip
+   * between them is invisible to any assertion made on the scrambled text.
+   * Measured: that exact mutation passed 91/91 before this was interleaved.
+   */
   const sqlTextOf = (value: unknown): string => {
+    if (isSql(value))
+      return value.strings
+        .map(
+          (part, index) =>
+            part + (index < value.values.length ? sqlTextOf(value.values[index]) : '')
+        )
+        .join('');
     if (Array.isArray(value)) return value.map(sqlTextOf).join(' ');
-    if (isSql(value)) return [sqlTextOf(value.strings), sqlTextOf(value.values)].join(' ');
     return typeof value === 'string' ? value : '';
+  };
+
+  /**
+   * A tagged-template call arrives as `(strings, ...values)`, which is the same
+   * interleaving problem one level up.
+   */
+  const renderCall = (args: unknown[]): string => {
+    const [strings, ...values] = args as [string[], ...unknown[]];
+    if (!Array.isArray(strings)) return '';
+    return strings
+      .map((part, index) => part + (index < values.length ? sqlTextOf(values[index]) : ''))
+      .join('');
   };
 
   const flatValues = (value: unknown): unknown[] => {
@@ -1121,7 +1157,7 @@ describe('getPendingRemixGallerySubmissions paging', () => {
     images: unknown[];
   }) =>
     queryRaw.mockImplementation(async (...args: unknown[]) => {
-      const sql = sqlTextOf(args);
+      const sql = renderCall(args);
       if (sql.includes('FROM "Placement"')) {
         queueSelects.push({ sql, values: flatValues(args) });
         return page;
@@ -1169,8 +1205,19 @@ describe('getPendingRemixGallerySubmissions paging', () => {
     const { sql } = lastQueueSelect();
     expect(sql).toContain(`data ->> 'imageId'`);
     expect(sql).toContain('pl."targetId"');
-    expect(sql).toContain('publishedAt');
-    expect(sql).toContain(`ingestion = 'Scanned'`);
+    // Named individually. `toContain('publishedAt')` alone survives deleting any
+    // of the other four, and a queue that stopped filtering `tosViolation` would
+    // read as covered.
+    for (const clause of ['publishedAt', `ingestion = 'Scanned'`, 'tosViolation', 'minor', 'poi'])
+      expect(sql, `${clause} is not in the select`).toContain(clause);
+
+    // Both images, ANDed. An `OR` here passes every assertion above while
+    // relisting exactly what the count excludes — badge and list disagree again,
+    // which is the bug this shares one fragment to prevent.
+    const [, betweenTheTwoTests] = sql.split('EXISTS');
+    expect(sql.match(/EXISTS/g)).toHaveLength(2);
+    expect(betweenTheTwoTests).toContain('AND');
+    expect(betweenTheTwoTests).not.toContain('OR');
   });
 
   it('hands back a cursor when every row it selected was dropped afterwards', async () => {
@@ -1262,5 +1309,240 @@ describe('getPendingRemixGallerySubmissions paging', () => {
 
       expect(lastQueueSelect().sql, `cursor ${cursor} reached the query`).not.toMatch(/pl\.id\s*>/);
     }
+  });
+});
+
+/**
+ * What the SFW domain is SENT, which is a different question from what it
+ * paints. Blur is built from the viewer's own settings and never reads the
+ * domain, and these queues carry no browsing level by design — so the payload is
+ * the only control, and it needs a test that fails when it is removed rather
+ * than a suite that passes either way.
+ */
+describe('getPendingRemixGallerySubmissions domain ceiling', () => {
+  const SUBMITTED = 301;
+
+  const rated = (id: number, nsfwLevel: number) => ({
+    id,
+    url: `asset-${id}`,
+    width: 1,
+    height: 1,
+    type: 'image',
+    metadata: { hash: `h-${id}` },
+    nsfwLevel,
+  });
+
+  const queueRow = (imageId: number) => ({
+    id: 1,
+    targetId: HOST_IMAGE,
+    placerId: PLACER,
+    amount: PRICE,
+    data: { imageId },
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    expiresAt: null,
+    placer: { id: PLACER, username: 'someone', image: null },
+  });
+
+  const ask = ({
+    submittedLevel,
+    hostLevel = NsfwLevel.PG,
+    domainLevels,
+    viewerLevels = allBrowsingLevelsFlag,
+  }: {
+    submittedLevel: number;
+    hostLevel?: number;
+    domainLevels: number;
+    viewerLevels?: number;
+  }) => {
+    queryRaw.mockImplementation(async (...args: unknown[]) => {
+      const [template] = args as [{ strings?: string[] }];
+      const sql = (template?.strings ?? []).join(' ');
+      if (sql.includes('FROM "Placement"'))
+        return [{ id: 1, createdAt: new Date('2026-01-01T00:00:00.000Z') }];
+      return [rated(SUBMITTED, submittedLevel), rated(HOST_IMAGE, hostLevel)];
+    });
+    placementFindMany.mockResolvedValue([queueRow(SUBMITTED)]);
+
+    return getPendingRemixGallerySubmissions({
+      ownerId: OWNER,
+      limit: 10,
+      domainLevels,
+      viewerLevels,
+    });
+  };
+
+  it('sends the asset when the image is inside the ceiling', async () => {
+    // The positive control. Without it, every assertion below passes against a
+    // query that withholds everything — including the vacuous case where
+    // `domainLevels` arrives undefined and `level & undefined` is 0.
+    const { items } = await ask({
+      submittedLevel: NsfwLevel.PG,
+      domainLevels: sfwBrowsingLevelsFlag,
+    });
+
+    expect(items).toHaveLength(1);
+    expect(items[0].image).toMatchObject({ viewable: true, url: `asset-${SUBMITTED}` });
+  });
+
+  it('withholds the asset for a submission above the ceiling, keeping the row actionable', async () => {
+    const { items } = await ask({
+      submittedLevel: NsfwLevel.X,
+      domainLevels: sfwBrowsingLevelsFlag,
+    });
+
+    expect(items).toHaveLength(1);
+    const { image } = items[0];
+    expect(image).toEqual({ viewable: false, id: SUBMITTED, nsfwLevel: NsfwLevel.X });
+    // Asserted as absence of the FIELDS, not just of `viewable`. A branch that
+    // set the flag and spread the row anyway would pass an `image.viewable`
+    // check while shipping the bytes it claims to withhold.
+    for (const field of ['url', 'metadata', 'width', 'height', 'type'])
+      expect(image, `${field} was sent to a domain that may not serve it`).not.toHaveProperty(
+        field
+      );
+    // Still reviewable: the escrow behind it expires if the owner cannot act.
+    expect(items[0].earnings.approve).toBeGreaterThan(0);
+  });
+
+  it('withholds the host image by the same rule', async () => {
+    const { items } = await ask({
+      submittedLevel: NsfwLevel.PG,
+      hostLevel: NsfwLevel.XXX,
+      domainLevels: sfwBrowsingLevelsFlag,
+    });
+
+    expect(items[0].targetImage).toEqual({
+      viewable: false,
+      id: HOST_IMAGE,
+      nsfwLevel: NsfwLevel.XXX,
+    });
+    expect(items[0].targetImage).not.toHaveProperty('url');
+  });
+
+  it('sends an above-ceiling asset on a domain that may serve it', async () => {
+    // The other half of the control: withholding on green has to be the domain
+    // deciding, not the queue refusing X everywhere.
+    const { items } = await ask({
+      submittedLevel: NsfwLevel.X,
+      domainLevels: allBrowsingLevelsFlag,
+    });
+
+    expect(items[0].image).toMatchObject({ viewable: true, url: `asset-${SUBMITTED}` });
+  });
+
+  it('marks what is outside the viewer band without withholding it', async () => {
+    // The viewer's own band is a preference, not a delivery rule — an owner has
+    // to be able to widen it and act. Withholding here would be indistinguishable
+    // from the domain case, which is the distinction the UI turns on.
+    const { items } = await ask({
+      submittedLevel: NsfwLevel.R,
+      domainLevels: allBrowsingLevelsFlag,
+      viewerLevels: sfwBrowsingLevelsFlag,
+    });
+
+    expect(items[0].image).toMatchObject({
+      viewable: true,
+      withinViewerLevel: false,
+      url: `asset-${SUBMITTED}`,
+    });
+  });
+
+  it('withholds an unrated image rather than defaulting it in', async () => {
+    // `0 & mask` is 0, so this passes today by arithmetic. Pinned because the
+    // failure mode is silent: an unscanned image would ship its asset to green.
+    const { items } = await ask({ submittedLevel: 0, domainLevels: sfwBrowsingLevelsFlag });
+
+    expect(items[0].image).toMatchObject({ viewable: false });
+  });
+});
+
+describe('declining everything out of band', () => {
+  const IN_BAND = 201;
+  const OUT_OF_BAND = 202;
+  const UNRATED = 203;
+
+  /**
+   * Host at PG-13 under `atOrBelow`, so the band is PG-13 and only the R row is
+   * out of it. The unrated row is the one worth keeping in the fixture: it is
+   * inadmissible for approval and must still not be swept up here, because
+   * charging a decline fee for an image with no rating yet answers a question
+   * nobody asked.
+   */
+  const arrange = () => {
+    resolvePlacementSpaceFor.mockResolvedValue({
+      ownerId: OWNER,
+      mode: 'review',
+      price: PRICE,
+      settings: { contentRule: 'atOrBelow' },
+    });
+    queryRaw.mockImplementation(async () => [
+      { nsfwLevel: NsfwLevel.PG13, minor: false, showable: true },
+    ]);
+    placementFindMany.mockResolvedValue([
+      { id: IN_BAND, data: { imageId: 1 } },
+      { id: OUT_OF_BAND, data: { imageId: 2 } },
+      { id: UNRATED, data: { imageId: 3 } },
+    ]);
+    imageFindMany.mockResolvedValue([
+      { id: 1, nsfwLevel: NsfwLevel.PG },
+      { id: 2, nsfwLevel: NsfwLevel.R },
+      { id: 3, nsfwLevel: 0 },
+    ]);
+    // Each row re-reads itself through the single-placement path.
+    placementFindUnique.mockImplementation(async ({ where }: { where: { id: number } }) => ({
+      id: where.id,
+      ownerId: OWNER,
+      status: 'pending',
+      surface: 'remixGallery',
+      targetId: HOST_IMAGE,
+      data: { imageId: where.id === OUT_OF_BAND ? 2 : 1 },
+      resolvedAt: null,
+      createdAt: new Date('2026-01-01'),
+    }));
+  };
+
+  it('settles only the rows above the band, and reports what it did', async () => {
+    arrange();
+
+    const result = await declineOutOfBandRemixGallerySubmissions({
+      hostImageId: HOST_IMAGE,
+      userId: OWNER,
+    });
+
+    expect(result).toEqual({ considered: 1, settled: 1 });
+    // The identity matters more than the count: a guard that declined the whole
+    // queue also settles once when the queue holds one out-of-band row.
+    expect(settlePlacement).toHaveBeenCalledTimes(1);
+    expect(lastSettleArgs()?.placementId).toBe(OUT_OF_BAND);
+  });
+
+  it('counts a row that fails to settle without abandoning the rest', async () => {
+    arrange();
+    imageFindMany.mockResolvedValue([
+      { id: 1, nsfwLevel: NsfwLevel.X },
+      { id: 2, nsfwLevel: NsfwLevel.R },
+      { id: 3, nsfwLevel: 0 },
+    ]);
+    settlePlacement.mockRejectedValueOnce(new Error('payout leg is down'));
+
+    const result = await declineOutOfBandRemixGallerySubmissions({
+      hostImageId: HOST_IMAGE,
+      userId: OWNER,
+    });
+
+    // Two were out of band, one throw: the second must still have been tried,
+    // and the caller must be told the difference rather than shown a success.
+    expect(result).toEqual({ considered: 2, settled: 1 });
+    expect(settlePlacement).toHaveBeenCalledTimes(2);
+  });
+
+  it('refuses someone else’s gallery before touching anything', async () => {
+    arrange();
+
+    await expect(
+      declineOutOfBandRemixGallerySubmissions({ hostImageId: HOST_IMAGE, userId: STRANGER })
+    ).rejects.toThrow();
+
+    expect(settlePlacement).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -69,7 +69,11 @@ const placementCreate = vi.fn(async () => {
 });
 const placementCount = vi.fn(async () => 0);
 const placementFindFirst = vi.fn(async () => null as unknown);
-const placementFindUnique = vi.fn(async () => null as unknown);
+// Typed with its argument because `declineOutOfBand` re-reads each row by id, so
+// one of its fakes has to answer per-placement rather than with a fixed row.
+const placementFindUnique = vi.fn<(args: { where: { id: number } }) => Promise<unknown>>(
+  async () => null
+);
 const placementFindMany = vi.fn(async () => [] as unknown[]);
 const imageFindMany = vi.fn(async () => [] as unknown[]);
 const placementUpdate = vi.fn(async () => ({}));

--- a/src/server/services/__tests__/sticker-placement.service.test.ts
+++ b/src/server/services/__tests__/sticker-placement.service.test.ts
@@ -1,4 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NsfwLevel } from '~/server/common/enums';
+import {
+  allBrowsingLevelsFlag,
+  sfwBrowsingLevelsFlag,
+} from '~/shared/constants/browsingLevel.constants';
 import type * as MetricHelpers from '~/server/utils/metric-helpers';
 import { STICKER_REMOVAL_LOCK_HOURS } from '~/shared/utils/sticker-placement';
 
@@ -1140,6 +1145,7 @@ describe('the note on a placement', () => {
  * nobody ever reviews while its escrow expires.
  */
 describe('getPendingStickerPlacements paging', () => {
+  const LEVELS = { domainLevels: allBrowsingLevelsFlag, viewerLevels: allBrowsingLevelsFlag };
   const good = { cosmeticId: COSMETIC, x: 0.5, y: 0.5, scale: 0.2, rotation: 0 };
 
   const queueRow = (id: number, data: unknown, createdAt: string) => ({
@@ -1161,7 +1167,7 @@ describe('getPendingStickerPlacements paging', () => {
       queueRow(3, good, '2026-01-03T00:00:00.000Z'),
     ]);
 
-    const result = await getPendingStickerPlacements({ ownerId: OWNER, limit: 2 });
+    const result = await getPendingStickerPlacements({ ownerId: OWNER, limit: 2, ...LEVELS });
 
     expect(result.items.map((item) => item.id)).toEqual([1]);
     // Row 2's key. Built from what was returned it would say row 1, and row 2
@@ -1178,7 +1184,7 @@ describe('getPendingStickerPlacements paging', () => {
       queueRow(3, good, '2026-01-03T00:00:00.000Z'),
     ]);
 
-    const result = await getPendingStickerPlacements({ ownerId: OWNER, limit: 2 });
+    const result = await getPendingStickerPlacements({ ownerId: OWNER, limit: 2, ...LEVELS });
 
     expect(result.items).toEqual([]);
     expect(result.nextCursor).toBe(`${new Date('2026-01-02T00:00:00.000Z').getTime()}:2`);
@@ -1190,7 +1196,7 @@ describe('getPendingStickerPlacements paging', () => {
       queueRow(2, good, '2026-01-02T00:00:00.000Z'),
     ]);
 
-    const result = await getPendingStickerPlacements({ ownerId: OWNER, limit: 2 });
+    const result = await getPendingStickerPlacements({ ownerId: OWNER, limit: 2, ...LEVELS });
 
     expect(result.items).toHaveLength(2);
     expect(result.nextCursor).toBeNull();
@@ -1201,6 +1207,7 @@ describe('getPendingStickerPlacements paging', () => {
     const createdAt = new Date('2026-01-02T00:00:00.000Z');
 
     await getPendingStickerPlacements({
+      ...LEVELS,
       ownerId: OWNER,
       limit: 2,
       cursor: `${createdAt.getTime()}:2`,
@@ -1214,5 +1221,98 @@ describe('getPendingStickerPlacements paging', () => {
     expect(where.OR).toEqual([{ createdAt: { gt: createdAt } }, { createdAt, id: { gt: 2 } }]);
     expect(orderBy).toEqual([{ createdAt: 'asc' }, { id: 'asc' }]);
     expect(take).toBe(3);
+  });
+});
+
+/**
+ * The queue carries no browsing level by design — an owner has to see what is
+ * waiting on them — so the payload is the only thing standing between an
+ * above-ceiling asset and a SFW client. Unlike the remix gallery the image here
+ * is the owner's OWN upload, which changes who is being protected from what but
+ * not whether the domain may be sent it.
+ */
+describe('getPendingStickerPlacements domain ceiling', () => {
+  const good = { cosmeticId: COSMETIC, x: 0.5, y: 0.5, scale: 0.2, rotation: 0 };
+
+  const ask = ({
+    nsfwLevel,
+    domainLevels,
+    viewerLevels = allBrowsingLevelsFlag,
+  }: {
+    nsfwLevel: number;
+    domainLevels: number;
+    viewerLevels?: number;
+  }) => {
+    placementFindMany.mockResolvedValue([
+      {
+        id: 1,
+        targetId: IMAGE,
+        placerId: PLACER,
+        amount: PRICE,
+        data: good,
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        expiresAt: null,
+        placer: { id: PLACER, username: 'someone', image: null },
+      },
+    ]);
+    imageFindMany.mockResolvedValue([
+      {
+        id: IMAGE,
+        url: 'asset',
+        name: 'a name',
+        width: 1,
+        height: 1,
+        type: 'image',
+        metadata: null,
+        nsfwLevel,
+      },
+    ]);
+
+    return getPendingStickerPlacements({ ownerId: OWNER, limit: 10, domainLevels, viewerLevels });
+  };
+
+  it('sends the asset when the image is inside the ceiling', async () => {
+    // The positive control: without it every assertion below passes against a
+    // queue that withholds everything, which is what `domainLevels: undefined`
+    // silently produced before this parameter was required.
+    const { items } = await ask({
+      nsfwLevel: NsfwLevel.PG,
+      domainLevels: sfwBrowsingLevelsFlag,
+    });
+
+    expect(items[0].image).toMatchObject({ viewable: true, url: 'asset', name: 'a name' });
+  });
+
+  it('withholds the asset above the ceiling while keeping the row actionable', async () => {
+    const { items } = await ask({ nsfwLevel: NsfwLevel.X, domainLevels: sfwBrowsingLevelsFlag });
+
+    expect(items).toHaveLength(1);
+    expect(items[0].image).toEqual({ viewable: false, id: IMAGE, nsfwLevel: NsfwLevel.X });
+    // The fields, not just the flag: a branch that sets `viewable: false` and
+    // spreads the row anyway passes a flag check while shipping the bytes.
+    for (const field of ['url', 'name', 'metadata', 'width', 'height', 'type'])
+      expect(items[0].image, `${field} reached a domain that may not serve it`).not.toHaveProperty(
+        field
+      );
+  });
+
+  it('sends an above-ceiling asset on a domain that may serve it', async () => {
+    const { items } = await ask({ nsfwLevel: NsfwLevel.X, domainLevels: allBrowsingLevelsFlag });
+
+    expect(items[0].image).toMatchObject({ viewable: true, url: 'asset' });
+  });
+
+  it('marks what is outside the viewer band without withholding it', async () => {
+    const { items } = await ask({
+      nsfwLevel: NsfwLevel.R,
+      domainLevels: allBrowsingLevelsFlag,
+      viewerLevels: sfwBrowsingLevelsFlag,
+    });
+
+    expect(items[0].image).toMatchObject({
+      viewable: true,
+      withinViewerLevel: false,
+      url: 'asset',
+    });
   });
 });

--- a/src/server/services/remix-gallery.service.ts
+++ b/src/server/services/remix-gallery.service.ts
@@ -11,6 +11,8 @@ import { assertCanPlace } from '~/server/services/placement-moderation.service';
 import { getPlacementConfig } from '~/server/services/placement.service';
 import { resolvePlacementSpaceFor } from '~/server/services/placement-space.service';
 import { imageReviewedSql } from '~/server/common/image-visibility';
+import type { QueueImage as SharedQueueImage } from '~/server/utils/queue-image';
+import { toQueueImage } from '~/server/utils/queue-image';
 import { throwAuthorizationError, throwBadRequestError } from '~/server/utils/errorHandling';
 import { onlySelectableLevels } from '~/shared/constants/browsingLevel.constants';
 import {
@@ -1156,48 +1158,11 @@ type GalleryThumbImage = {
 };
 
 /**
- * A queue image, or the fact that this domain may not be sent it.
- *
- * A discriminated union rather than a nullable `url`: the reviewer still has to
- * act on a row whose asset cannot be served here, so the row must survive with
- * its rating and its buttons — and the caller must be unable to reach for pixels
- * that were never sent. A null check is forgettable in a refactor; this is not.
+ * Re-exported rather than redeclared. Both queues answer one question — may this
+ * domain be sent this asset — and two copies of that answer is the drift the
+ * shared listability fragment exists to prevent.
  */
-export type QueueImage =
-  | ({ viewable: true; withinViewerLevel: boolean } & GalleryThumbImage)
-  | { viewable: false; id: number; nsfwLevel: number };
-
-/**
- * The asset is withheld, not merely unpainted.
- *
- * `ImageGuard2`'s blur is built from the viewer's own settings and never reads
- * the domain ceiling, and this queue deliberately sends no browsing level — so
- * on a SFW domain a component was the only thing between an X-rated payload and
- * the screen, and it consulted the wrong field. Refusing in the payload is the
- * control; anything the client does is a courtesy on top of it.
- *
- * Fails closed on an unrated image: `0 & mask` is 0.
- *
- * The viewer's own browsing level is carried as a mark, not applied as a filter.
- * The feed drops what is outside your band because nobody has to act on it; an
- * owner does, and a queue that silently hides a submission expires its escrow
- * without a decision. Marking lets the surface name what is being held back and
- * offer the band control — which is the only way the product widens a band.
- */
-const toQueueImage = (
-  image: GalleryThumbImage | undefined,
-  domainLevels: number,
-  viewerLevels: number
-): QueueImage | null =>
-  !image
-    ? null
-    : (image.nsfwLevel & domainLevels) !== 0
-    ? {
-        viewable: true,
-        withinViewerLevel: (image.nsfwLevel & viewerLevels) !== 0,
-        ...image,
-      }
-    : { viewable: false, id: image.id, nsfwLevel: image.nsfwLevel };
+export type QueueImage = SharedQueueImage<GalleryThumbImage>;
 
 /**
  * Whether an image can be shown in a review queue, as one definition rather than

--- a/src/server/services/remix-gallery.service.ts
+++ b/src/server/services/remix-gallery.service.ts
@@ -445,6 +445,104 @@ export async function actOnRemixGallerySubmission({
 }
 
 /**
+ * Decline every pending submission rated above what this gallery accepts.
+ *
+ * The set is resolved here from (hostImageId, the owner's own rule) rather than
+ * taken as a list of ids: an id list on a money path is forgeable, and a caller
+ * who could name the rows could decline ones that are perfectly in band.
+ *
+ * Loops the single-placement path rather than growing a bulk settlement, for the
+ * reason `actOnStickerPlacements` gives — a second route to a state that already
+ * has rules is where this feature's defects have come from. Failures are counted,
+ * not thrown: one row whose payout leg is having a bad day must not strand the
+ * other nine, and `settlePlacement` claims with `WHERE status = 'pending'`, so a
+ * partial run is safe to repeat.
+ */
+export async function declineOutOfBandRemixGallerySubmissions({
+  hostImageId,
+  userId,
+}: {
+  hostImageId: number;
+  userId: number;
+}) {
+  const space = await resolvePlacementSpaceFor({
+    surface: SURFACE,
+    targetType: TARGET_TYPE,
+    targetId: hostImageId,
+  });
+  // Not a permission check with a friendlier error — `actOnRemixGallerySubmission`
+  // authorises every row it touches. This only avoids doing the work to build a
+  // set that every settle would then refuse.
+  if (space.ownerId !== userId)
+    throw throwAuthorizationError('remix gallery: that gallery is not yours');
+
+  const host = await loadHostImage(hostImageId);
+  const band = remixGalleryMaxSubmissionLevel({
+    rule: remixGalleryContentRule(space.settings),
+    hostLevel: host.nsfwLevel,
+    // Same fail-closed as the read path: an unresolvable host must not widen the
+    // band, which here would mean declining fewer rows rather than more.
+    hostMinor: host.minor,
+  });
+
+  const rows = await dbRead.placement.findMany({
+    where: {
+      surface: SURFACE,
+      targetType: TARGET_TYPE,
+      targetId: hostImageId,
+      ownerId: userId,
+      status: 'pending',
+    },
+    select: { id: true, data: true },
+  });
+
+  const entries = rows.filter((row) => isRemixGalleryPlacementData(row.data));
+  const imageIds = entries.map((row) => (row.data as RemixGalleryPlacementData).imageId);
+  if (!imageIds.length) return { considered: 0, settled: 0 };
+
+  // Read straight from `Image` rather than through the queue's listability
+  // filter: a submission whose image was since unpublished no longer appears in
+  // the queue but is still pending, still holding escrow, and still out of band.
+  // Leaving those behind would make the button quietly disagree with its label.
+  const levels = await dbRead.image.findMany({
+    where: { id: { in: imageIds } },
+    select: { id: true, nsfwLevel: true },
+  });
+  const levelById = new Map(levels.map((image) => [image.id, image.nsfwLevel]));
+
+  const outOfBand = entries.filter((row) => {
+    const level = levelById.get((row.data as RemixGalleryPlacementData).imageId);
+    // `band` is a ceiling compared with `<=`, not a bitmask — see
+    // `remixGalleryLevelAllowed`, which is defined in terms of it.
+    //
+    // Strictly above, so an unrated row (level 0) is left alone rather than
+    // swept up. `remixGalleryLevelAllowed` would call 0 inadmissible, which is
+    // right for approval and wrong here: charging a decline fee for an image
+    // that has no rating yet answers a question nobody asked. Its escrow is the
+    // expiry sweep's to return in full.
+    return !!level && level > band;
+  });
+
+  let settled = 0;
+  for (const row of outOfBand) {
+    try {
+      await actOnRemixGallerySubmission({ placementId: row.id, action: 'decline', userId });
+      settled++;
+    } catch (error) {
+      await logToAxiom({
+        name: 'remix-gallery',
+        type: 'error',
+        message: 'decline-out-of-band: one row failed to settle',
+        placementId: row.id,
+        error: error instanceof Error ? error.message : String(error),
+      }).catch(() => undefined);
+    }
+  }
+
+  return { considered: outOfBand.length, settled };
+}
+
+/**
  * Everything the submission had to satisfy to be sent, checked again at the
  * moment it becomes public.
  *

--- a/src/server/services/remix-gallery.service.ts
+++ b/src/server/services/remix-gallery.service.ts
@@ -19,7 +19,6 @@ import {
   parsePlacementQueueCursor,
   PLACEMENT_QUEUE_PAGE_SIZE,
   PLACEMENT_SURFACES,
-  placementQueueKeyset,
   splitPlacementPayment,
 } from '~/shared/utils/placement';
 import type { RemixGalleryPlacementData } from '~/shared/utils/remix-gallery';
@@ -1001,9 +1000,15 @@ async function galleryHasEntries({
 async function getViewerPendingSubmissions({
   hostImageId,
   viewerId,
+  domainLevels,
+  viewerLevels,
 }: {
   hostImageId: number;
   viewerId: number;
+  /** Levels this domain may serve. Rows above it come back without their asset. */
+  domainLevels: number;
+  /** The viewer own band. Marked on each row, never filtered on. */
+  viewerLevels: number;
 }) {
   const rows = await dbRead.placement.findMany({
     where: {
@@ -1034,7 +1039,11 @@ async function getViewerPendingSubmissions({
     amount: row.amount,
     createdAt: row.createdAt,
     expiresAt: row.expiresAt,
-    image: byId.get((row.data as RemixGalleryPlacementData).imageId) ?? null,
+    image: toQueueImage(
+      byId.get((row.data as RemixGalleryPlacementData).imageId),
+      domainLevels,
+      viewerLevels
+    ),
   }));
 }
 
@@ -1048,15 +1057,108 @@ type GalleryThumbImage = {
   nsfwLevel: number;
 };
 
+/**
+ * A queue image, or the fact that this domain may not be sent it.
+ *
+ * A discriminated union rather than a nullable `url`: the reviewer still has to
+ * act on a row whose asset cannot be served here, so the row must survive with
+ * its rating and its buttons — and the caller must be unable to reach for pixels
+ * that were never sent. A null check is forgettable in a refactor; this is not.
+ */
+export type QueueImage =
+  | ({ viewable: true; withinViewerLevel: boolean } & GalleryThumbImage)
+  | { viewable: false; id: number; nsfwLevel: number };
+
+/**
+ * The asset is withheld, not merely unpainted.
+ *
+ * `ImageGuard2`'s blur is built from the viewer's own settings and never reads
+ * the domain ceiling, and this queue deliberately sends no browsing level — so
+ * on a SFW domain a component was the only thing between an X-rated payload and
+ * the screen, and it consulted the wrong field. Refusing in the payload is the
+ * control; anything the client does is a courtesy on top of it.
+ *
+ * Fails closed on an unrated image: `0 & mask` is 0.
+ *
+ * The viewer's own browsing level is carried as a mark, not applied as a filter.
+ * The feed drops what is outside your band because nobody has to act on it; an
+ * owner does, and a queue that silently hides a submission expires its escrow
+ * without a decision. Marking lets the surface name what is being held back and
+ * offer the band control — which is the only way the product widens a band.
+ */
+const toQueueImage = (
+  image: GalleryThumbImage | undefined,
+  domainLevels: number,
+  viewerLevels: number
+): QueueImage | null =>
+  !image
+    ? null
+    : (image.nsfwLevel & domainLevels) !== 0
+    ? {
+        viewable: true,
+        withinViewerLevel: (image.nsfwLevel & viewerLevels) !== 0,
+        ...image,
+      }
+    : { viewable: false, id: image.id, nsfwLevel: image.nsfwLevel };
+
+/**
+ * Whether an image can be shown in a review queue, as one definition rather than
+ * two copies of a WHERE clause. The badge and the list that badge counts must
+ * agree, and they disagreed for as long as each carried its own.
+ */
+const queueImageIsListable = (imageId: Prisma.Sql) => Prisma.sql`
+  EXISTS (
+    SELECT 1
+    FROM "Image" i
+    JOIN "Post" p ON p.id = i."postId"
+    WHERE i.id = ${imageId}
+      AND p."publishedAt" IS NOT NULL
+      AND i.ingestion = 'Scanned'
+      AND NOT i."tosViolation"
+      AND NOT i.minor
+      AND NOT i.poi
+  )`;
+
+/**
+ * Both images are tested: a submission the owner can see, on a host that still
+ * renders. A host taken down after submissions arrived leaves rows nobody can
+ * judge — the gallery they would appear in is gone — and those refund in full on
+ * expiry rather than costing the submitter a decline fee.
+ */
+async function countListablePendingSubmissions({
+  hostImageId,
+  ownerId,
+}: {
+  hostImageId: number;
+  ownerId: number;
+}) {
+  const [row] = await dbRead.$queryRaw<{ count: number }[]>`
+    SELECT count(*)::int AS count
+    FROM "Placement" pl
+    WHERE pl.surface = ${SURFACE}
+      AND pl."targetType" = ${TARGET_TYPE}
+      AND pl."targetId" = ${hostImageId}
+      AND pl."ownerId" = ${ownerId}
+      AND pl.status = 'pending'
+      AND ${queueImageIsListable(Prisma.sql`(pl.data ->> 'imageId')::int`)}
+      AND ${queueImageIsListable(Prisma.sql`pl."targetId"`)}
+  `;
+
+  return row?.count ?? 0;
+}
+
 export async function getRemixGalleryVisibility({
   hostImageId,
   browsingLevel,
   viewerId,
+  domainLevels,
 }: {
   hostImageId: number;
   browsingLevel: number;
   /** Decides whether the pending count is computed at all. */
   viewerId?: number;
+  /** Levels this domain may serve. Rows above it come back without their asset. */
+  domainLevels: number;
 }) {
   const [space, hasEntries, host] = await Promise.all([
     resolvePlacementSpaceFor({ surface: SURFACE, targetType: TARGET_TYPE, targetId: hostImageId }),
@@ -1068,17 +1170,16 @@ export async function getRemixGalleryVisibility({
   // the owner — it is the one number that makes the panel actionable, and
   // nobody else may know how many submissions someone is sitting on. The card
   // already awaits this query, so for every other viewer this costs nothing.
+  //
+  // Counts what the queue can actually render, not every pending row. A bare
+  // count counts submissions whose image is deleted, unpublished, mid-ingestion
+  // or filtered, and the queue drops exactly those — so the badge said 2 over a
+  // list that showed none, and the owner went looking for work that was not
+  // there. The escrow behind a row that cannot be listed is released by the
+  // expiry sweep rather than by a decision nobody could make.
   const pendingCount =
     viewerId && viewerId === space.ownerId
-      ? await dbRead.placement.count({
-          where: {
-            surface: SURFACE,
-            targetType: TARGET_TYPE,
-            targetId: hostImageId,
-            ownerId: space.ownerId,
-            status: 'pending',
-          },
-        })
+      ? await countListablePendingSubmissions({ hostImageId, ownerId: space.ownerId })
       : 0;
 
   // The submitter's own pending rows. Without this, submitting shows nothing at
@@ -1086,7 +1187,12 @@ export async function getRemixGalleryVisibility({
   // unchanged. Skipped for the owner, whose pending view is the queue above.
   const viewerPending =
     viewerId && viewerId !== space.ownerId
-      ? await getViewerPendingSubmissions({ hostImageId, viewerId })
+      ? await getViewerPendingSubmissions({
+          hostImageId,
+          viewerId,
+          domainLevels,
+          viewerLevels: browsingLevel,
+        })
       : [];
 
   // The ceiling the picker filters on, so a submitter is not offered an image the
@@ -1112,6 +1218,20 @@ export async function getRemixGalleryVisibility({
         hostMinor: host?.minor ?? true,
       })
     : null;
+
+  // The same ceiling, for the owner instead of the submitter. `maxSubmissionLevel`
+  // is withheld from them by the rule above, which is right for every other
+  // caller and leaves the review UI unable to say what its own gallery accepts.
+  // Named apart so that rule keeps its contract: this is the owner's setting
+  // applied to the owner's image, and tells them nothing they did not set.
+  const acceptedMaxLevel =
+    viewerId && viewerId === space.ownerId
+      ? remixGalleryMaxSubmissionLevel({
+          rule: remixGalleryContentRule(space.settings),
+          hostLevel: host?.nsfwLevel ?? 0,
+          hostMinor: host?.minor ?? true,
+        })
+      : null;
 
   // The owner's name and cut, so the submit button can say where the money goes
   // without the copy asserting it. The shares are operator-tunable at runtime,
@@ -1142,6 +1262,7 @@ export async function getRemixGalleryVisibility({
     pendingCount,
     viewerPending,
     maxSubmissionLevel,
+    acceptedMaxLevel,
   };
 }
 
@@ -1157,8 +1278,14 @@ export async function getPendingRemixGallerySubmissions({
   hostImageId,
   limit = PLACEMENT_QUEUE_PAGE_SIZE,
   cursor,
+  domainLevels,
+  viewerLevels,
 }: {
   ownerId: number;
+  /** Levels this domain may serve. Rows above it come back without their asset. */
+  domainLevels: number;
+  /** The viewer own band. Marked on each row, never filtered on. */
+  viewerLevels: number;
   /**
    * Scopes the queue to one gallery. Filtering client-side instead meant an
    * owner with 50 submissions elsewhere saw "nothing waiting" on an image that
@@ -1168,14 +1295,43 @@ export async function getPendingRemixGallerySubmissions({
   limit?: number;
   cursor?: string | null;
 }) {
+  const keyset = parsePlacementQueueCursor(cursor);
+
+  // Selected in SQL rather than paged and then filtered in memory. Filtering
+  // after the fact pages over rows the queue cannot render: a queue of 66 whose
+  // first 50 are unlistable returned 4 items with a cursor — "4+" over a page
+  // size of 50 — and "load more" then produced 2. The page is now 50 listable
+  // rows or the end of the queue, and `hasNextPage` means what it says.
+  const listable = await dbRead.$queryRaw<{ id: number; createdAt: Date }[]>`
+    SELECT pl.id, pl."createdAt"
+    FROM "Placement" pl
+    WHERE pl.surface = ${SURFACE}
+      AND pl."ownerId" = ${ownerId}
+      AND pl.status = 'pending'
+      ${
+        hostImageId
+          ? Prisma.sql`AND pl."targetType" = ${TARGET_TYPE} AND pl."targetId" = ${hostImageId}`
+          : Prisma.empty
+      }
+      ${
+        keyset
+          ? Prisma.sql`AND (pl."createdAt" > ${keyset.createdAt}
+              OR (pl."createdAt" = ${keyset.createdAt} AND pl.id > ${keyset.id}))`
+          : Prisma.empty
+      }
+      AND ${queueImageIsListable(Prisma.sql`(pl.data ->> 'imageId')::int`)}
+      AND ${queueImageIsListable(Prisma.sql`pl."targetId"`)}
+    ORDER BY pl."createdAt" ASC, pl.id ASC
+    LIMIT ${limit + 1}
+  `;
+
+  const page = listable.slice(0, limit);
+  const nextCursor =
+    listable.length > limit ? encodePlacementQueueCursor(page[page.length - 1]) : null;
+  if (!page.length) return { items: [], nextCursor };
+
   const rows = await dbRead.placement.findMany({
-    where: {
-      surface: SURFACE,
-      ownerId,
-      status: 'pending',
-      ...(hostImageId ? { targetType: TARGET_TYPE, targetId: hostImageId } : {}),
-      ...placementQueueKeyset(parsePlacementQueueCursor(cursor)),
-    },
+    where: { id: { in: page.map((row) => row.id) } },
     select: {
       id: true,
       targetId: true,
@@ -1187,20 +1343,18 @@ export async function getPendingRemixGallerySubmissions({
       placer: { select: { id: true, username: true, image: true } },
     },
     orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
-    take: limit + 1,
   });
 
-  // Read off the row the page ends on, before the rows below are dropped for an
-  // unreadable payload or a deleted image. Taking it from what is returned would
-  // point the next page at an earlier row and serve everything between twice —
-  // and the earlier `truncated` flag had the mirror-image bug, reporting a full
-  // queue as complete once the filter took it under the cap.
-  const page = rows.slice(0, limit);
-  const nextCursor = rows.length > limit ? encodePlacementQueueCursor(page[page.length - 1]) : null;
-
-  const entries = page.filter((row) => isRemixGalleryPlacementData(row.data));
+  const entries = rows.filter((row) => isRemixGalleryPlacementData(row.data));
   const imageIds = entries.map((row) => (row.data as RemixGalleryPlacementData).imageId);
   if (!imageIds.length) return { items: [], nextCursor };
+
+  // The host image rides along in the same fetch: the reviewer is judging a
+  // remix against what it remixed, and a queue that shows only the submission
+  // asks them to decide from memory. Same visibility filter either way — an
+  // owner's own image reaching this list unpublished or unscanned renders as a
+  // placeholder rather than as content this query vouched for.
+  const lookupIds = [...new Set([...imageIds, ...entries.map((row) => row.targetId)])];
 
   const images = await dbRead.$queryRaw<
     {
@@ -1218,7 +1372,7 @@ export async function getPendingRemixGallerySubmissions({
     SELECT i.id, i.url, i.width, i.height, i.type, i.metadata, i."nsfwLevel"
     FROM "Image" i
     JOIN "Post" p ON p.id = i."postId"
-    WHERE i.id IN (${Prisma.join(imageIds)})
+    WHERE i.id IN (${Prisma.join(lookupIds)})
       AND p."publishedAt" IS NOT NULL
       AND i.ingestion = 'Scanned'
       AND NOT i."tosViolation"
@@ -1240,7 +1394,12 @@ export async function getPendingRemixGallerySubmissions({
       .map((row) => ({
         ...row,
         data: row.data as RemixGalleryPlacementData,
-        image: byId.get((row.data as RemixGalleryPlacementData).imageId) ?? null,
+        image: toQueueImage(
+          byId.get((row.data as RemixGalleryPlacementData).imageId),
+          domainLevels,
+          viewerLevels
+        ),
+        targetImage: toQueueImage(byId.get(row.targetId), domainLevels, viewerLevels),
         earnings: {
           approve: splitPlacementPayment({
             amount: row.amount,
@@ -1252,7 +1411,11 @@ export async function getPendingRemixGallerySubmissions({
           decline: declineFeeAmount(row.amount, declineFeeRate),
         },
       }))
-      .filter((row) => row.image),
+      // Both halves, for the same reason: the owner cannot judge a remix they
+      // cannot see, and cannot judge it against a host that no longer renders.
+      // `countListablePendingSubmissions` applies the identical pair, so the
+      // badge and this list cannot disagree.
+      .filter((row) => row.image && row.targetImage),
     nextCursor,
   };
 }
@@ -1268,9 +1431,15 @@ export async function getPendingRemixGallerySubmissions({
 export async function getMyRemixGallerySubmissions({
   placerId,
   limit = REMIX_GALLERY_QUEUE_LIMIT,
+  domainLevels,
+  viewerLevels,
 }: {
   placerId: number;
   limit?: number;
+  /** Levels this domain may serve. Rows above it come back without their asset. */
+  domainLevels: number;
+  /** The viewer own band. Marked on each row, never filtered on. */
+  viewerLevels: number;
 }) {
   const rows = await dbRead.placement.findMany({
     where: { surface: SURFACE, placerId, status: { in: ['pending', 'approved'] } },
@@ -1312,10 +1481,45 @@ export async function getMyRemixGallerySubmissions({
     : [];
   const byId = new Map(images.map((image) => [image.id, image]));
 
+  // The host image is someone else's, so unlike the submitter's own image above
+  // it is fetched under the same visibility filter the public feed applies. A
+  // host that fails it renders as a placeholder; the row stays either way,
+  // because the withdraw beside it is the only route back to the escrow.
+  const targetIds = [...new Set(rows.map((row) => row.targetId))];
+  const targetImages = targetIds.length
+    ? await dbRead.$queryRaw<
+        {
+          id: number;
+          url: string;
+          width: number | null;
+          height: number | null;
+          type: MediaType;
+          metadata: MixedObject | null;
+          nsfwLevel: number;
+        }[]
+      >`
+        SELECT i.id, i.url, i.width, i.height, i.type, i.metadata, i."nsfwLevel"
+        FROM "Image" i
+        JOIN "Post" p ON p.id = i."postId"
+        WHERE i.id IN (${Prisma.join(targetIds)})
+          AND p."publishedAt" IS NOT NULL
+          AND i.ingestion = 'Scanned'
+          AND NOT i."tosViolation"
+          AND NOT i.minor
+          AND NOT i.poi
+      `
+    : [];
+  const targetById = new Map(targetImages.map((image) => [image.id, image]));
+
   return rows.map((row) => ({
     ...row,
     image: isRemixGalleryPlacementData(row.data)
-      ? byId.get((row.data as RemixGalleryPlacementData).imageId) ?? null
+      ? toQueueImage(
+          byId.get((row.data as RemixGalleryPlacementData).imageId),
+          domainLevels,
+          viewerLevels
+        )
       : null,
+    targetImage: toQueueImage(targetById.get(row.targetId), domainLevels, viewerLevels),
   }));
 }

--- a/src/server/services/sticker-placement.service.ts
+++ b/src/server/services/sticker-placement.service.ts
@@ -1,3 +1,4 @@
+import { toQueueImage } from '~/server/utils/queue-image';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
 import {
@@ -824,10 +825,16 @@ export async function getPendingStickerPlacements({
   ownerId,
   limit = PLACEMENT_QUEUE_PAGE_SIZE,
   cursor,
+  domainLevels,
+  viewerLevels,
 }: {
   ownerId: number;
   limit?: number;
   cursor?: string | null;
+  /** Levels this domain may serve. Rows above it come back without their asset. */
+  domainLevels: number;
+  /** The viewer own band. Marked on each row, never filtered on. */
+  viewerLevels: number;
 }) {
   const rows = await dbRead.placement.findMany({
     where: {
@@ -856,9 +863,22 @@ export async function getPendingStickerPlacements({
   const page = rows.slice(0, limit);
   const nextCursor = rows.length > limit ? encodePlacementQueueCursor(page[page.length - 1]) : null;
 
+  // `nsfwLevel` is not decoration here: without it this payload cannot express
+  // the domain ceiling at all, and the queue deliberately sends no browsing
+  // level — so it was an image listing with nothing between an above-ceiling
+  // asset and a SFW client.
   const images = await dbRead.image.findMany({
     where: { id: { in: page.map((row) => row.targetId) } },
-    select: { id: true, url: true, name: true, width: true, height: true, type: true },
+    select: {
+      id: true,
+      url: true,
+      name: true,
+      width: true,
+      height: true,
+      type: true,
+      metadata: true,
+      nsfwLevel: true,
+    },
   });
   const byId = new Map(images.map((image) => [image.id, image]));
 
@@ -866,7 +886,16 @@ export async function getPendingStickerPlacements({
     const data = parseStickerPlacementData(row.data);
     if (!data) return [];
 
-    return [{ ...row, data, image: byId.get(row.targetId) ?? null }];
+    return [
+      {
+        ...row,
+        data,
+        // The image is the owner's own upload, so nothing is filtered out here.
+        // Dropping the row would take the approve/decline with it and the escrow
+        // would expire unanswered — withheld, not hidden.
+        image: toQueueImage(byId.get(row.targetId), domainLevels, viewerLevels),
+      },
+    ];
   });
 
   return { items, nextCursor };

--- a/src/server/utils/queue-image.ts
+++ b/src/server/utils/queue-image.ts
@@ -1,0 +1,56 @@
+/**
+ * The minimum a queue image must carry. Each surface selects more — the sticker
+ * queue takes `name` for its alt text — and the generic below preserves whatever
+ * it selected, so widening this to a concrete shape would silently erase fields
+ * the caller still reads.
+ */
+export type QueueThumbImage = {
+  id: number;
+  url: string;
+  nsfwLevel: number;
+};
+
+/**
+ * A review-queue image, or the fact that this domain may not be sent it.
+ *
+ * A discriminated union rather than a nullable `url`: the reviewer still has to
+ * act on a row whose asset cannot be served here — the escrow behind it expires
+ * either way — so the row must survive with its rating and its buttons, while
+ * the caller must be unable to reach for pixels that were never sent. A null
+ * check is forgettable in a refactor; a missing property is not.
+ */
+export type QueueImage<T extends QueueThumbImage = QueueThumbImage> =
+  | ({ viewable: true; withinViewerLevel: boolean } & T)
+  | { viewable: false; id: number; nsfwLevel: number };
+
+/**
+ * The asset is withheld, not merely unpainted.
+ *
+ * `ImageGuard2`'s blur is built from the viewer's own settings and never reads
+ * the domain ceiling, and the review queues deliberately send no browsing level
+ * — an owner has to see what is waiting on them — so on a SFW domain a component
+ * was the only thing between an above-ceiling payload and the screen, and it
+ * consulted the wrong field. Refusing in the payload is the control; whatever
+ * the client draws is a courtesy on top of it.
+ *
+ * The viewer's OWN band is carried as a mark rather than applied as a filter.
+ * The feed drops what is outside your band because nobody has to act on it; a
+ * queue cannot, because a submission hidden that way still expires.
+ *
+ * Fails closed on an unrated image: `0 & mask` is 0.
+ */
+export function toQueueImage<T extends QueueThumbImage>(
+  image: T | undefined,
+  domainLevels: number,
+  viewerLevels: number
+): QueueImage<T> | null {
+  if (!image) return null;
+  if ((image.nsfwLevel & domainLevels) === 0)
+    return { viewable: false, id: image.id, nsfwLevel: image.nsfwLevel };
+
+  return {
+    viewable: true,
+    withinViewerLevel: (image.nsfwLevel & viewerLevels) !== 0,
+    ...image,
+  };
+}

--- a/src/shared/utils/__tests__/placement.test.ts
+++ b/src/shared/utils/__tests__/placement.test.ts
@@ -255,8 +255,8 @@ describe('clampDeclineFeeRate', () => {
 describe('pricing', () => {
   it('caps by score band and tier', () => {
     expect(placementPriceCap(0, 'free')).toBe(100);
-    expect(placementPriceCap(4_999, 'gold')).toBe(500);
-    expect(placementPriceCap(5_000, 'gold')).toBe(1_000);
+    expect(placementPriceCap(9_999, 'gold')).toBe(500);
+    expect(placementPriceCap(10_000, 'gold')).toBe(1_000);
     expect(placementPriceCap(1_000_000, 'free')).toBe(1_000);
   });
 

--- a/src/shared/utils/placement.ts
+++ b/src/shared/utils/placement.ts
@@ -384,16 +384,15 @@ export function placementPriceCaption(
 ): { text: string; warning: boolean } | null {
   if (cap == null) return null;
 
-  if (price > cap)
-    return {
-      text: `${payer} pay ${cap} Buzz — your current cap — until your score or membership raises it`,
-      warning: true,
-    };
+  // Kept to one short line. These sit in a narrow settings column under a
+  // slider's own labels, and the long forms wrapped into them — which is a
+  // layout the copy must not be able to break from the inside.
+  if (price > cap) return { text: `${payer} pay ${cap} Buzz — your cap`, warning: true };
 
   const track = placementPriceTrack(surface, cap);
   if (!onPlacementPriceGrid(price, track))
     return {
-      text: `${payer} pay ${price} Buzz. The slider moves in ${PLACEMENT_PRICE_STEP}s from ${track.min}, so using it will change this price`,
+      text: `${payer} pay ${price} Buzz — the slider will round this`,
       warning: true,
     };
 

--- a/src/shared/utils/placement.ts
+++ b/src/shared/utils/placement.ts
@@ -311,13 +311,14 @@ type PriceCapTier = 'free' | MembershipTier;
  * What a creator may charge, capped by creator score and membership tier. The
  * creator sets the price; this only ceilings it.
  *
- * ⚠️ The numbers are placeholders pending a product decision. The shape is the
+ * ⚠️ The cap values are placeholders pending a product decision; the 10k
+ * threshold on band 2 is decided and published. The shape is the
  * commitment: read at request time, overridable through `KeyValue` without a
  * deploy, and never written to a placement row.
  */
 export const PLACEMENT_PRICE_CAP_TIERS: PlacementPriceTier[] = [
   { minScore: 0, caps: { free: 100, bronze: 200, silver: 300, gold: 500 } },
-  { minScore: 5_000, caps: { free: 250, bronze: 500, silver: 750, gold: 1_000 } },
+  { minScore: 10_000, caps: { free: 250, bronze: 500, silver: 750, gold: 1_000 } },
   { minScore: 25_000, caps: { free: 500, bronze: 1_000, silver: 1_500, gold: 2_500 } },
   { minScore: 100_000, caps: { free: 1_000, bronze: 2_000, silver: 3_000, gold: 5_000 } },
 ];

--- a/src/shared/utils/placement.ts
+++ b/src/shared/utils/placement.ts
@@ -384,19 +384,18 @@ export function placementPriceCaption(
 ): { text: string; warning: boolean } | null {
   if (cap == null) return null;
 
-  // Kept to one short line. These sit in a narrow settings column under a
-  // slider's own labels, and the long forms wrapped into them — which is a
-  // layout the copy must not be able to break from the inside.
-  if (price > cap) return { text: `${payer} pay ${cap} Buzz — your cap`, warning: true };
-
+  // The amount and nothing else. It sits on the slider's own mark row, between
+  // labels pinned left and right, so a second clause is not a wordier caption —
+  // it is one that wraps into them. The explanations it used to carry (the cap,
+  // the grid) live in the alert below, which has room for them.
+  //
+  // A price over the cap quotes the cap, because that is what a placer is
+  // charged; the colour is what says something is off, and it needs no words.
   const track = placementPriceTrack(surface, cap);
-  if (!onPlacementPriceGrid(price, track))
-    return {
-      text: `${payer} pay ${price} Buzz — the slider will round this`,
-      warning: true,
-    };
-
-  return { text: `${payer} pay ${price} Buzz`, warning: false };
+  return {
+    text: `${payer} pay ${Math.min(price, cap)} Buzz`,
+    warning: price > cap || !onPlacementPriceGrid(price, track),
+  };
 }
 
 export function placementPriceTrack(surface: PlacementSurface, cap: number | null) {


### PR DESCRIPTION
Two review queues — remix gallery and stickers — were sending assets a SFW domain may not serve, paging in a way that under-reported what was waiting, and counting a population the list could not render. This fixes all three, plus the review UI that has to explain what is being withheld.

## Why the payload, not the component

`ImageGuard2`'s blur is built from the viewer's own settings and **never reads the domain ceiling**. Green is normally safe because above-SFW rows never reach the client — the queries clamp. These review queues deliberately send no browsing level, because an owner has to see everything waiting on them, which made them the one path handing an above-ceiling asset to a SFW client.

So the fix is in what is sent. Above-ceiling rows now come back as `{ viewable: false, id, nsfwLevel }` — no url, no metadata, nothing that resolves to the asset. A discriminated union rather than a nullable `url`, so a caller that forgets the check does not compile.

The viewer's **own** band is marked, not filtered. The feed drops what is outside your band because nobody has to act on it; a queue cannot — a submission hidden that way still expires, costing the owner their fee and the submitter nothing.

## Paging

The remix queue fetched a page and *then* discarded unrenderable rows, so a queue of 66 whose first 50 were unrenderable returned 4 items **and** a cursor — "4+" over a page size of 50, and "load more" produced 2. Selection now happens in SQL, so a page is `limit` renderable rows or the end of the queue.

## Badge vs list

`pendingCount` was a bare count with no image join while the list required published + Scanned + not tos/minor/poi — two populations, so the badge could read 2 over a list that rendered none. One shared SQL fragment now serves both.

## The sticker queue deliberately differs

It gets the domain ceiling but **not** the visibility filter or SQL-side paging. Its `targetId` is the owner's *own* upload, so dropping rows would take the approve/decline with it and expire the escrow unanswered. With no filter there is no fetch-then-filter gap, and its badge reads the same query as its list. Stated here so it doesn't read as an oversight next to the remix queue.

## Review UI

Three states, each with the only answer that helps it:

- **Above the domain ceiling** — decline here, or open it on the domain that serves it. No widen control, because no setting on this domain can produce an asset that was never sent. Note there is **no per-item click-through to out-of-band content anywhere in the product**: such content is filtered server-side and dropped again client-side, and `ImageGuard2`'s reveal only un-blurs items already inside your band. Inventing a per-item override here would have been a new pattern on a surface where approval is irreversible for a week.
- **Outside your content settings** — the existing `BrowsingModeMenu`, gated on `canViewNsfw` so green is never offered settings it does not have.
- **Above the gallery's own accepted band** — the owner can decline every out-of-band submission at once. The set is resolved server-side from (hostImageId, the owner's rule); accepting placement ids would let a caller decline rows that are perfectly in band. It loops the existing single-decline path rather than growing a bulk settlement, per `actOnStickerPlacements`, counts failures instead of throwing so one bad payout leg cannot strand the rest, and returns `{ considered, settled }` so the UI reports "declined 2 of 3" rather than a success it did not have. Unrated rows are left alone: charging a decline fee for an image with no rating answers a question nobody asked.

All three share one alert rather than three stacked ones — they overlap constantly.

## Also here

- The second **price-cap band** moves 5,000 → 10,000 creator score. 5,000 was reachable on a throwaway account with one model and a handful of images. This aligns the source with the live `placement:config` KeyValue row, which already reads 10,000 — so it changes no behaviour in production.
- The **price caption** is cut to the amount in every branch (an over-cap price quotes the cap, since that is what a placer is charged), so it stops colliding with the slider's own min/max marks. Colour carries the warning.
- The **Sent tab** now honours the viewer's content settings, matching Received — the same image was banded on one tab and not the other.
- The **submit modal** gains a hierarchy, and its footer note can wrap: it previously squeezed the Submit button until the label clipped.

## Testing

Mutation-tested, not assumed. Removing the domain ceiling fails named tests on both surfaces.

That discipline was earned during this branch. An adversarial review found the first version had **no test for the ceiling at all** — deleting it outright left the suite green at 82 passing. It also found that a first attempt at a stronger SQL assertion still passed against an `AND` → `OR` flip, because a composed `Prisma.sql` puts the joining operator in the outer template and the fragment bodies in the interpolated values, so concatenating strings-then-values reads as plausible SQL and is not.

## Known, and not fixed here

- `db:check-generated` is red on `main` independently of this branch — `models.ts` regenerates ~604 lines differently on a clean checkout. Reproduced in a separate worktree; deliberately left alone.
- `typecheck-tests` reports `sticker-placement.service.test.ts` at 41 against a baseline of 16. **That file is in this diff** — this branch adds 103 lines of domain-ceiling tests to it — and **none of the 41 errors fall in them**: every error is at or below line 910 except one at 1216, our additions begin at 1148, and that 1216 blames to `f8a2e5f125` rather than to this branch. So these are errors this branch neither caused nor fixed. Note what that does *not* claim: nobody has checked the file out at `origin/main` to measure it there. Being handled separately by elise in #3918, which takes it to 0.

  `remix-gallery.service.test.ts` is at **28 against a baseline of 29 on this branch** — it is *not* fixed on `main`, where elise measured 39. That improvement lands only when this PR merges, so this branch is doing real work against the gate rather than reporting a state that already exists.
- 16 unit tests fail on this branch, all in repo-scanning drift guards (`blocks/`, `comics/`, `middleware/`, `scripts/`) that name no file in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
