### PR TITLE
fix(tests): clear the 10 test files that entered the ratchet unbaselined

### DIFF
--- a/src/components/Challenge/challenge-messages.ts
+++ b/src/components/Challenge/challenge-messages.ts
@@ -9,7 +9,7 @@
  * A string inside a page component is also unreachable from any test we run; here it is a function
  * with a test, so reverting it fails something.
  */
-export function challengeEndedMessage(result: { queued?: boolean; winnersCount: number }): string {
+export function challengeEndedMessage(result: { queued: boolean; winnersCount: number }): string {
   if (result.queued) {
     return 'Challenge ended. Judging has been queued — winners will be posted when it completes.';
   }

--- a/src/server/clickhouse/__tests__/tracker.awaitDelivery.test.ts
+++ b/src/server/clickhouse/__tests__/tracker.awaitDelivery.test.ts
@@ -38,8 +38,18 @@ const metric = () => ({
   metricValue: 100,
 });
 
+/**
+ * The parameters are declared on the mock's type rather than left to inference: a
+ * bare `vi.fn(async () => …)` is a zero-arg signature, which makes `mock.calls` the
+ * empty tuple and every `calls[0][1]` below unreadable.
+ */
+type FetchStub = (
+  url: string,
+  init?: { signal?: AbortSignal }
+) => Promise<{ ok: boolean; status: number; text: () => Promise<string> }>;
+
 const respond = (status: number) =>
-  vi.fn(async () => ({ ok: status < 400, status, text: async () => '' }));
+  vi.fn<FetchStub>(async () => ({ ok: status < 400, status, text: async () => '' }));
 
 let fetchMock: ReturnType<typeof respond>;
 
@@ -81,9 +91,7 @@ describe('awaitDelivery', () => {
 
     // Nothing configures an undici dispatcher, so an unsignalled fetch inherits
     // a 300s header timeout — three of those on one row is a wedge, not a retry.
-    const signals = fetchMock.mock.calls.map(
-      (call) => (call as [string, { signal?: AbortSignal }])[1].signal
-    );
+    const signals = fetchMock.mock.calls.map((call) => call[1]?.signal);
     expect(signals.every((signal) => signal instanceof AbortSignal)).toBe(true);
     // One signal hoisted out of the loop would be worse than none: `fetch`
     // rejects immediately on an already-aborted signal, so the first slow
@@ -99,8 +107,11 @@ describe('fire and forget', () => {
     // The dispatch is not awaited, so let its first attempt reach fetch.
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    const [, init] = fetchMock.mock.calls[0] as [string, { signal?: AbortSignal }];
-    expect(init.signal).toBeUndefined();
+    const [, init] = fetchMock.mock.calls[0];
+    // Asserted present first: `init?.signal` on a missing init is also undefined,
+    // and would pass this without the request ever having been made.
+    expect(init).toBeDefined();
+    expect(init?.signal).toBeUndefined();
   });
 
   // LAST on purpose. Its retry chain outlives the test by ~750ms and `fetch` is

--- a/src/server/common/__tests__/serialized-file-download-url.test.ts
+++ b/src/server/common/__tests__/serialized-file-download-url.test.ts
@@ -198,7 +198,14 @@ describe('toApiModelFile — the owning version id survives the reduction', () =
   });
 
   it('tolerates a missing metadata blob', () => {
-    const out = toApiModelFile({ id: 5, modelVersionId: 4242 });
+    // `metadata` is declared and not passed: the type argument is spelled out because
+    // `{ metadata?: unknown }` is a weak type, so a row that names none of its members
+    // fails the constraint and TS falls back to the constraint itself — which then
+    // reports `id` as an excess property and drops `modelVersionId` from the result.
+    const out = toApiModelFile<{ id: number; modelVersionId: number; metadata?: unknown }>({
+      id: 5,
+      modelVersionId: 4242,
+    });
     expect(out.modelVersionId).toBe(4242);
     expect(out.metadata.format).toBeUndefined();
   });

--- a/src/server/games/daily-challenge/__tests__/challenge-engine-rolling-swiss.test.ts
+++ b/src/server/games/daily-challenge/__tests__/challenge-engine-rolling-swiss.test.ts
@@ -10,7 +10,7 @@ const getStandings = vi.fn();
 const getSwissState = vi.fn();
 const incrementOperationSpent = vi.fn();
 const operationBudgetRemaining = vi.fn();
-const logToAxiom = vi.fn(() => Promise.resolve());
+const logToAxiom = vi.fn<(...args: unknown[]) => Promise<void>>(() => Promise.resolve());
 const queryRaw = vi.fn();
 
 // Spread the real modules and override only what this suite drives. Hand-listing exports couples a
@@ -66,7 +66,7 @@ function stubQueries(imageCount: number) {
         { startsAt: new Date(Date.now() - 60_000), endsAt: new Date(Date.now() + 60_000) },
       ]);
     }
-    if (sql.includes('COUNT(*)')) return Promise.resolve([{ relations: 0n }]);
+    if (sql.includes('COUNT(*)')) return Promise.resolve([{ relations: BigInt(0) }]);
     return Promise.resolve(
       Array.from({ length: imageCount }, (_, i) => ({
         id: i + 1,

--- a/src/server/games/daily-challenge/__tests__/challenge-pairwise-store.test.ts
+++ b/src/server/games/daily-challenge/__tests__/challenge-pairwise-store.test.ts
@@ -227,8 +227,8 @@ describe('replaceStandings — the comparison count survives a reorder', () => {
   // compared" about an entry that had been compared nine times.
   it('recounts from the comparison rows instead of writing zero', async () => {
     queryRaw.mockResolvedValue([
-      { imageId: 10, count: 9n },
-      { imageId: 20, count: 4n },
+      { imageId: 10, count: BigInt(9) },
+      { imageId: 20, count: BigInt(4) },
     ]);
 
     await store.replaceStandings(424, [
@@ -256,7 +256,7 @@ describe('replaceStandings — the comparison count survives a reorder', () => {
   });
 
   it('writes 0 for an entry that genuinely has no comparisons', async () => {
-    queryRaw.mockResolvedValue([{ imageId: 10, count: 3n }]);
+    queryRaw.mockResolvedValue([{ imageId: 10, count: BigInt(3) }]);
 
     await store.replaceStandings(424, [
       { imageId: 10, userId: 100 },

--- a/src/server/games/daily-challenge/__tests__/challenge-winner-mapping.test.ts
+++ b/src/server/games/daily-challenge/__tests__/challenge-winner-mapping.test.ts
@@ -195,6 +195,12 @@ const JUDGING_CONFIG = {
   reviewTemplate: null,
 } as never;
 
+const PRIZES = [
+  { buzz: 500, points: 10 },
+  { buzz: 250, points: 5 },
+  { buzz: 100, points: 2 },
+];
+
 const currentChallenge = {
   challengeId: 1,
   type: 'daily',
@@ -206,7 +212,7 @@ const currentChallenge = {
   title: 'Test',
   invitation: '',
   coverUrl: '',
-  prizes: [{ buzz: 500, points: 10 }, { buzz: 250, points: 5 }, { buzz: 100, points: 2 }],
+  prizes: PRIZES,
   entryPrizeRequirement: 10,
   entryPrize: { buzz: 0, points: 0 },
 } as never;
@@ -268,8 +274,18 @@ describe('pickWinnersForChallenge winner mapping (name-spoof hardening)', () => 
     // name-based (or name-OR-id) match would resolve BOTH winners to whichever entry happens to
     // come first in array order, since both share the spoofed name.
     mockJudgedEntryRows([
-      { imageId: 1, userId: 100, username: 'Alice', score: { theme: 10, aesthetic: 10, humor: 10, wittiness: 10 } },
-      { imageId: 2, userId: 200, username: 'Alice', score: { theme: 8, aesthetic: 8, humor: 8, wittiness: 8 } },
+      {
+        imageId: 1,
+        userId: 100,
+        username: 'Alice',
+        score: { theme: 10, aesthetic: 10, humor: 10, wittiness: 10 },
+      },
+      {
+        imageId: 2,
+        userId: 200,
+        username: 'Alice',
+        score: { theme: 8, aesthetic: 8, humor: 8, wittiness: 8 },
+      },
     ]);
     // Global winner-cooldown query (System source, no event context) — nobody excluded.
     mockDbWriteQueryRaw.mockResolvedValueOnce([]);
@@ -362,7 +378,7 @@ describe('pickWinnersForChallenge unmatched picks (challenge 390)', () => {
     mockDbWriteQueryRaw.mockResolvedValueOnce([]);
     mockGetChallengeById.mockResolvedValue({
       source: ChallengeSource.System,
-      prizes: currentChallenge.prizes,
+      prizes: PRIZES,
       metadata: null,
     });
 

--- a/src/server/notifications/__tests__/app-collaborator.notifications.test.ts
+++ b/src/server/notifications/__tests__/app-collaborator.notifications.test.ts
@@ -22,7 +22,11 @@ const defs = appCollaboratorNotifications as Record<string, Def>;
 function msg(type: string, details: AppCollaboratorNotificationDetails) {
   const def = defs[type];
   expect(def, `${type} is not registered`).toBeTruthy();
-  return def.prepareMessage({ details } as Parameters<Def['prepareMessage']>[0]);
+  const message = def.prepareMessage({ type, details } as Parameters<Def['prepareMessage']>[0]);
+  // Thrown rather than `!`: `prepareMessage` returns `NotificationMessage | undefined`, and a
+  // caller reading `.url` off nothing is the one failure that would otherwise read as a null url.
+  if (!message) throw new Error(`${type} produced no message`);
+  return message;
 }
 
 const ONSITE: AppCollaboratorNotificationDetails = {

--- a/src/server/services/__tests__/file-download-lookup.test.ts
+++ b/src/server/services/__tests__/file-download-lookup.test.ts
@@ -386,6 +386,7 @@ describe('getFileForModelVersion — orphan model relation + unresolvable URL', 
 describe('serialized downloadUrl → getFileForModelVersion (the pair actually resolves)', () => {
   let getFileForModelVersion: typeof import('../file.service')['getFileForModelVersion'];
   let createSerializedFileDownloadUrl: typeof import('~/server/common/model-helpers')['createSerializedFileDownloadUrl'];
+  type RouteInput = Omit<Parameters<typeof getFileForModelVersion>[0], 'user' | 'noAuth'>;
   beforeAll(async () => {
     ({ getFileForModelVersion } = await import('../file.service'));
     ({ createSerializedFileDownloadUrl } = await import('~/server/common/model-helpers'));
@@ -404,7 +405,7 @@ describe('serialized downloadUrl → getFileForModelVersion (the pair actually r
     overrideName: null,
     type: 'Model',
     visibility: 'Public',
-    metadata: { format: 'SafeTensor', size: 'pruned', fp: 'fp16' },
+    metadata: { format: 'SafeTensor', size: 'pruned', fp: 'fp16' } as BasicFileMetadata,
     hashes: [{ hash: 'aaaa1111' }],
   };
   const OWNED_SECOND = {
@@ -415,7 +416,7 @@ describe('serialized downloadUrl → getFileForModelVersion (the pair actually r
     overrideName: null,
     type: 'Model',
     visibility: 'Public',
-    metadata: { format: 'PickleTensor', size: 'full', fp: 'fp32' },
+    metadata: { format: 'PickleTensor', size: 'full', fp: 'fp32' } as BasicFileMetadata,
     hashes: [{ hash: 'bbbb2222' }],
   };
   // Lives on the LINKED version. `getVaeFiles` relabels its `type` to 'VAE'
@@ -428,7 +429,7 @@ describe('serialized downloadUrl → getFileForModelVersion (the pair actually r
     overrideName: null,
     type: 'Model',
     visibility: 'Public',
-    metadata: { format: 'SafeTensor', size: 'full', fp: 'fp32' },
+    metadata: { format: 'SafeTensor', size: 'full', fp: 'fp32' } as BasicFileMetadata,
     hashes: [{ hash: 'eeee5555' }],
   };
   const UNIVERSE = [OWNED_PRIMARY, OWNED_SECOND, LINKED_VAE];
@@ -480,20 +481,23 @@ describe('serialized downloadUrl → getFileForModelVersion (the pair actually r
 
   /** Parse an emitted URL into the route's handler input (schema at
    * src/pages/api/download/models/[modelVersionId].ts). */
-  function toRouteInput(path: string) {
+  function toRouteInput(path: string): RouteInput {
     const url = new URL(`https://civitai.com${path}`);
     const modelVersionId = Number(url.pathname.split('/').pop());
     const q = url.searchParams;
     const fileIdParam = q.get('fileId');
+    // The enum-shaped params are cast one by one rather than the whole object being
+    // widened: the route's zod schema is what narrows them in production, and a cast
+    // per field still fails here if the service stops accepting one.
     return {
       modelVersionId,
       fileId: fileIdParam ? Number(fileIdParam) : undefined,
-      type: q.get('type') ?? undefined,
-      format: q.get('format') ?? undefined,
-      size: q.get('size') ?? undefined,
+      type: (q.get('type') ?? undefined) as RouteInput['type'],
+      format: (q.get('format') ?? undefined) as RouteInput['format'],
+      size: (q.get('size') ?? undefined) as RouteInput['size'],
       fp: q.get('fp') ?? undefined,
       quantType: q.get('quantType') ?? undefined,
-    } as never;
+    };
   }
 
   it('a pinned URL for a file the version OWNS resolves to exactly that file', async () => {

--- a/src/server/services/__tests__/image-cacher-invalidate-scope.test.ts
+++ b/src/server/services/__tests__/image-cacher-invalidate-scope.test.ts
@@ -22,7 +22,11 @@ const { envOverrides } = vi.hoisted(() => ({
 const { mockLogToAxiom, mockFindFirst, mockFetch } = vi.hoisted(() => ({
   mockLogToAxiom: vi.fn(async () => undefined),
   mockFindFirst: vi.fn(),
-  mockFetch: vi.fn(async () => ({ ok: true })),
+  // Typed rather than inferred: a zero-arg `vi.fn` makes `mock.calls` the empty
+  // tuple, and `invalidateCalls()` below reads both positions off it.
+  mockFetch: vi.fn<(url: string | URL, init?: RequestInit) => Promise<{ ok: boolean }>>(
+    async () => ({ ok: true })
+  ),
 }));
 
 function makePermissive(overrides: Record<string, unknown> = {}): any {

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -2442,8 +2442,9 @@ export const getAllImages = async (
         // `modelVersionIds` is auto-detected only and `modelVersionIdsManual` is uploader-asserted,
         // matching what the search-index path serves — consumers gate on the difference.
         modelVersionIds:
-          imageResources?.[i.id]?.resources?.filter((r) => r.detected).map((r) => r.modelVersionId) ??
-          [],
+          imageResources?.[i.id]?.resources
+            ?.filter((r) => r.detected)
+            .map((r) => r.modelVersionId) ?? [],
         modelVersionIdsManual:
           imageResources?.[i.id]?.resources
             ?.filter((r) => !r.detected)
@@ -2519,9 +2520,18 @@ const getThumbnailsForImages = async (imageIds: number[]) => {
 };
 
 type GetAllImagesIndexResult = AsyncReturnType<typeof getAllImages>;
+/**
+ * Only this path reports a `source`, so it is added here rather than to the shared
+ * alias — `getImagesFromFeedSearch` returns the same alias and never sets one, and
+ * widening that would let a caller test it for a value it can never hold. Optional
+ * because the blocked-browsing early return and a search reporting none both omit it.
+ */
+type GetAllImagesIndexSourcedResult = GetAllImagesIndexResult & {
+  source?: AsyncReturnType<typeof getImagesFromSearch>['source'];
+};
 export const getAllImagesIndex = async (
   input: GetAllImagesInput
-): Promise<GetAllImagesIndexResult> => {
+): Promise<GetAllImagesIndexSourcedResult> => {
   // const {
   //   user,
   //   limit,


### PR DESCRIPTION
## What

`scripts/ci/typecheck-tests-gate.mjs` blocks on any file under `src/**/__tests__/` that has type errors and **no baseline entry**. Ten files merged after the baseline was captured in #3868 and arrived carrying **33** such errors between them. This clears all 33.

`pnpm typecheck` cannot see any of it — the root tsconfig excludes `src/**/__tests__/**`, which is the whole reason the gate exists. Reproduce with:

```bash
pnpm exec tsc -p tsconfig.tests.json --noEmit
```

**The baseline JSON is untouched.** Nothing here is bought by re-baselining, and no fix widens a mock's return, casts to `any`, or loosens an assertion.

| file | was | now |
|---|---|---|
| `Challenge/__tests__/challenge-messages.test.ts` | 1 | 0 |
| `clickhouse/__tests__/tracker.awaitDelivery.test.ts` | 2 | 0 |
| `common/__tests__/serialized-file-download-url.test.ts` | 2 | 0 |
| `controllers/__tests__/image.controller.feed-source.test.ts` | 4 | 0 |
| `daily-challenge/__tests__/challenge-engine-rolling-swiss.test.ts` | 2 | 0 |
| `daily-challenge/__tests__/challenge-pairwise-store.test.ts` | 3 | 0 |
| `daily-challenge/__tests__/challenge-winner-mapping.test.ts` | 1 | 0 |
| `notifications/__tests__/app-collaborator.notifications.test.ts` | 9 | 0 |
| `services/__tests__/file-download-lookup.test.ts` | 6 | 0 |
| `services/__tests__/image-cacher-invalidate-scope.test.ts` | 3 | 0 |

Gate overall: **869 errors across 151 files -> 836 across 141.**

## Three of these are corrections, not cleanups

Worth reading, because they change production types:

**`challengeEndedMessage` took `queued?: boolean`.** So the `@ts-expect-error` in its test — asserting that omitting `queued` is a compile error — was unused (TS2578). The contract the test names had quietly stopped being enforced. `EndChallengeResult` in `challenge.service.ts` declares `queued: boolean` required, with a comment stating that optional would let a return site omit it and render the inline "0 winner(s) selected" message for a challenge whose judging was merely *queued*. The helper now requires it too; both call sites already pass a full `EndChallengeResult`.

**`GetAllImagesIndexResult` was `AsyncReturnType<typeof getAllImages>`**, which has no `source` — while `getAllImagesIndex` returns `...(searchSource && { source: searchSource })` and the controller stamps `source: 'db'` on the other branch *specifically* so a client can tell a BitDex page from a database page. The field was invisible to every caller. Added as optional, since the blocked-browsing early return legitimately omits it.

**`toApiModelFile<T extends { metadata?: unknown }>` has a weak-type constraint.** An argument naming none of its members fails inference, falls back to the constraint itself, and then reports `id` as an excess property while dropping `modelVersionId` from the result — which is the exact field that test file exists to protect. The call exercising "no metadata blob" now spells out its type argument.

## The rest

- `vi.fn(async () => …)` infers a **zero-arg** signature, so `mock.calls` is the empty tuple `[]` and every `calls[0][0]` is a type error. Fixed with `vi.fn<Sig>(impl)` rather than a placeholder parameter — the repo's `no-unused-vars` has no `argsIgnorePattern`, so `_args` warns.
- `target: ES2018` rejects `0n` / `9n` BigInt literals -> `BigInt(0)` / `BigInt(9)`.
- Property reads off an `as never` fixture (TS no longer allows them) -> the value is named once and read from there.
- `prepareMessage` returns `NotificationMessage | undefined` and was read without narrowing -> the helper throws a named error instead, so a missing message fails as itself rather than as `undefined.url`.

## Still red, and whose

The gate remains BLOCKED on **`sticker-placement.service.test.ts` (16 -> 41)** alone. That file is @alexandra's and @zuri's, is untouched here by agreement, and is tracked in #3914. `remix-gallery.service.test.ts` is at 28/29 since `82170251d0` and no longer blocks.

Roughly 19 of its 41 are not a mock-signature problem at all: `flip` and `opacity` became required members of `StickerPlacementData` in #3865 while `normalizeStickerPlacement` still defaults both at runtime, and a test at ~line 413 omits them deliberately to pin that defaulting. Filling the fixtures in would leave that test green and proving nothing, so it wants a type split rather than a fixture edit — noted here so nobody solves it the fast way.

## Verification

- `pnpm run typecheck` — **0 errors** (unfiltered).
- Lint **unchanged** on the touched set: 39 problems / 7 errors before and after, all pre-existing.
- `pnpm run test:unit:run` — failures identical with and without this diff (4 files / 14 tests in isolation, all pre-existing on this base and unrelated to these files).
- `blocks.router.workflow.test.ts` collected **347** tests, so the worktree's submodule is real and the run means something.
- `db:check-generated` deliberately not chased — it is independently red on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
