### PR TITLE
fix(post): hide/show-prompt toggle nulls the image's generation metadata

### DIFF
--- a/src/server/services/__tests__/update-post-image-hidemeta-bust.test.ts
+++ b/src/server/services/__tests__/update-post-image-hidemeta-bust.test.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '@prisma/client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
@@ -48,7 +49,7 @@ vi.mock('@civitai/db', () => ({
   createLagTracker: vi.fn(() => ({})),
   loadDbEnv: vi.fn(() => ({})),
 }));
-vi.mock('~/server/db/pgDb', () => ({ pgDbReadLong: {},  pgDbRead: {}, pgDbWrite: {} }));
+vi.mock('~/server/db/pgDb', () => ({ pgDbReadLong: {}, pgDbRead: {}, pgDbWrite: {} }));
 vi.mock('~/server/db/db-lag-helpers', () => ({
   getDbWithoutLag: vi.fn(),
   preventReplicationLag: vi.fn(),
@@ -143,15 +144,27 @@ const KEY_URL = IMAGE_URL;
 
 // Build a currentImage row. blockedFor is anything BUT AiNotVerified so shouldIngest=false
 // (no enqueueImageIngestion side effect on this path).
-function wireCurrentImage(hideMeta: boolean) {
+function wireCurrentImage(hideMeta: boolean, meta: unknown = null) {
   mockFindUniqueOrThrow.mockResolvedValue({
     hideMeta,
     ingestion: 'Scanned',
     blockedFor: null,
     metadata: {},
     nsfwLevel: 1,
+    meta,
   });
   mockImageUpdate.mockResolvedValue({ id: IMAGE_ID, url: IMAGE_URL, userId: USER_ID });
+}
+
+/**
+ * The `data` object actually handed to `dbWrite.image.update`. Asserting the update
+ * HAPPENED first is load-bearing: `expect(data.meta).toBeUndefined()` passes vacuously
+ * against a mock that was never called, which is exactly how a "meta is untouched"
+ * claim can be green while the column is being nulled.
+ */
+function updateData() {
+  expect(mockImageUpdate).toHaveBeenCalledTimes(1);
+  return mockImageUpdate.mock.calls[0][0].data as Record<string, unknown>;
 }
 
 beforeEach(() => {
@@ -207,5 +220,97 @@ describe('updatePostImage — image-delivery metadata cache bust wiring', () => 
     await updatePostImage({ id: IMAGE_ID } as any); // hideMeta not part of the update
 
     expect(mockBustImageDeliveryMetadataCache).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * What gets WRITTEN to `Image.meta`. The suite above pins the cache wiring and asserts
+ * nothing about the write, which is how a hideMeta-only toggle came to null the column:
+ * `meta` is absent from the input for that call, and an absent `meta` must mean "leave the
+ * stored value alone", not "clear it". Prisma distinguishes the two by `undefined` (field
+ * omitted from the UPDATE) vs `Prisma.JsonNull` (SQL NULL written), so these tests assert
+ * on the `data` object handed to `dbWrite.image.update` rather than on any return value.
+ */
+describe('updatePostImage — Image.meta write semantics', () => {
+  it('does NOT write meta when the input omits it (hideMeta: true — hide direction)', async () => {
+    wireCurrentImage(false, { prompt: 'stored prompt' });
+
+    await updatePostImage({ id: IMAGE_ID, hideMeta: true } as any);
+
+    const data = updateData();
+    expect(data.meta).toBeUndefined();
+    // Explicit: `undefined` omits the column, `Prisma.JsonNull` destroys it. Only the
+    // second is a data-loss bug, so name it rather than relying on toBeUndefined alone.
+    expect(data.meta).not.toBe(Prisma.JsonNull);
+    expect(data.hideMeta).toBe(true);
+  });
+
+  it('does NOT write meta when the input omits it (hideMeta: false — un-hide direction)', async () => {
+    // The button toggles, so the destructive path fires in BOTH directions; a fix that
+    // only covered the hide direction would leave "Show prompt" wiping the prompt.
+    wireCurrentImage(true, { prompt: 'stored prompt' });
+
+    await updatePostImage({ id: IMAGE_ID, hideMeta: false } as any);
+
+    const data = updateData();
+    expect(data.meta).toBeUndefined();
+    expect(data.meta).not.toBe(Prisma.JsonNull);
+    expect(data.hideMeta).toBe(false);
+  });
+
+  it('does NOT write meta when the input carries neither meta nor hideMeta', async () => {
+    wireCurrentImage(false, { prompt: 'stored prompt' });
+
+    await updatePostImage({ id: IMAGE_ID } as any);
+
+    const data = updateData();
+    expect(data.meta).toBeUndefined();
+    expect(data.meta).not.toBe(Prisma.JsonNull);
+  });
+
+  it('DOES write Prisma.JsonNull when meta is explicitly null (the clear path still works)', async () => {
+    // `updatePostImageSchema` also folds an all-undefined meta object down to `null`, so
+    // this is the shape an intentional "clear the metadata" edit arrives in.
+    wireCurrentImage(false, { prompt: 'stored prompt' });
+
+    await updatePostImage({ id: IMAGE_ID, meta: null } as any);
+
+    expect(updateData().meta).toBe(Prisma.JsonNull);
+  });
+
+  it('writes the supplied meta object when meta is provided', async () => {
+    wireCurrentImage(false, { prompt: 'stored prompt' });
+
+    await updatePostImage({ id: IMAGE_ID, meta: { prompt: 'new prompt' } } as any);
+
+    const data = updateData();
+    expect(data.meta).toEqual({ prompt: 'new prompt' });
+    expect(data.meta).not.toBe(Prisma.JsonNull);
+  });
+
+  it('still re-derives provenance from the stored row when meta is provided', async () => {
+    // #3871's actual purpose: a client cannot assert a derivation by editing its own
+    // image. The verified ids come from the stored row, never from the payload.
+    wireCurrentImage(false, { prompt: 'stored', extra: { sourceImageIds: [42] } });
+
+    await updatePostImage({
+      id: IMAGE_ID,
+      meta: { prompt: 'new prompt', extra: { sourceImageIds: [999] } },
+    } as any);
+
+    const meta = updateData().meta as { extra: { sourceImageIds: number[] } };
+    expect(meta.extra.sourceImageIds).toEqual([42]);
+  });
+
+  it('strips an unverified provenance claim when the stored row has none', async () => {
+    wireCurrentImage(false, { prompt: 'stored' });
+
+    await updatePostImage({
+      id: IMAGE_ID,
+      meta: { prompt: 'new prompt', extra: { sourceImageIds: [999] } },
+    } as any);
+
+    const meta = updateData().meta as { extra: Record<string, unknown> };
+    expect(meta.extra).not.toHaveProperty('sourceImageIds');
   });
 });

--- a/src/server/services/post.service.ts
+++ b/src/server/services/post.service.ts
@@ -1366,13 +1366,21 @@ export const updatePostImage = async (image: UpdatePostImageInput) => {
     },
   });
 
+  // `meta` is optional on this input, and the difference matters: absent means "leave the
+  // stored metadata alone" (the hide/show-prompt toggle sends only `hideMeta`), while an
+  // explicit `null` means "clear it". Collapsing the two writes SQL NULL over metadata the
+  // caller never touched, so the write below is skipped entirely unless the key was sent.
+  const metaProvided = image.meta !== undefined;
+
   // This edit replaces meta wholesale from client input, so provenance has to be
   // re-derived from the row rather than accepted: otherwise editing an image you
   // already own is a way to assert a derivation you never made.
-  const meta = sanitizeProvenance(
-    image.meta as Record<string, unknown> | null | undefined,
-    storedSourceImageIds(currentImage.meta)
-  );
+  const meta = metaProvided
+    ? sanitizeProvenance(
+        image.meta as Record<string, unknown> | null | undefined,
+        storedSourceImageIds(currentImage.meta)
+      )
+    : undefined;
 
   const blockedForVerification = currentImage.blockedFor === BlockedReason.AiNotVerified;
   const updatedIsVerifiable = isValidAIGeneration({
@@ -1389,7 +1397,12 @@ export const updatePostImage = async (image: UpdatePostImageInput) => {
       ...image,
       id: undefined, // prevent updating the id!
       updatedAt: new Date(),
-      meta: meta != null ? (meta as Prisma.JsonObject) : Prisma.JsonNull,
+      // undefined = omit the column from the UPDATE; Prisma.JsonNull = write SQL NULL.
+      meta: metaProvided
+        ? meta != null
+          ? (meta as Prisma.JsonObject)
+          : Prisma.JsonNull
+        : undefined,
       // If this image was blocked due to missing metadata, we need to set it back to pending
       ingestion: shouldIngest ? 'Pending' : undefined,
       blockedFor: shouldIngest ? null : undefined,
@@ -1416,9 +1429,7 @@ export const updatePostImage = async (image: UpdatePostImageInput) => {
     //
     // The delete path (deleteImageFromS3 below) deliberately does NOT pass a scope — there the row
     // is already gone and the image must stop serving entirely.
-    cacheRefreshPromises.push(
-      purgeResizeCache({ url: result.url, scope: 'hidden-meta-orphans' })
-    );
+    cacheRefreshPromises.push(purgeResizeCache({ url: result.url, scope: 'hidden-meta-orphans' }));
   }
   // Bust the image-delivery metadata cache on ANY hideMeta change (both directions): that
   // cache serves { hideMeta } to the delivery/resize path, and a stale value would keep


### PR DESCRIPTION
## The bug

**This is data-destructive and is happening to users right now.** Toggling **Hide prompt / Show prompt** on a post-editor image card permanently nulls that image's generation metadata (`Image.meta`): prompt, negative prompt, sampler, seed, resources — everything.

The button toggles, so **both directions destroy it**. Revealing a prompt wipes it exactly like hiding it does.

## Cause

`post.updateImage` takes an optional `meta`, and the two absent-ish cases have to stay distinct:

- `undefined` — the key was not sent → **leave the stored value alone**
- `null` — the user explicitly cleared it → **write SQL NULL**

Prisma expresses that difference as `undefined` (omit the column from the `UPDATE`) vs `Prisma.JsonNull` (write NULL).

The write used to read:

```ts
meta: image.meta !== null ? (image.meta as Prisma.JsonObject) : Prisma.JsonNull,
```

An absent `meta` is `undefined`, and `undefined !== null` is **true**, so it took the first branch and Prisma omitted the field. The column was preserved.

#3871 (server-side remix-provenance verification) routed the value through `sanitizeProvenance` first and changed the comparison to loose `!=`:

```ts
meta: meta != null ? (meta as Prisma.JsonObject) : Prisma.JsonNull,
```

Two things compose into the regression:

1. `sanitizeProvenance` returns its input unchanged when falsy (`if (!meta) return meta`), so `undefined` in stays `undefined` out.
2. Loose `!=` is true for **both** `null` and `undefined`, so `undefined` now falls into the `Prisma.JsonNull` branch.

Result: an update that never mentioned `meta` writes SQL NULL over it. No error, no client-visible failure — the row just loses its metadata.

The reachable caller is the hide/show-prompt button on the post-editor image card, which sends `{ id, hideMeta: !hideMeta }` and nothing else. The metadata editor modal (and the comics panel drawer, which opens that same modal) both send `meta`, so those paths were never affected.

This is a factual attribution, not a criticism — the strict-vs-loose distinction was doing load-bearing work that nothing in the file or the tests named.

## The fix

Derive the discriminator the schema already provides and omit the field entirely when the key was not sent:

```ts
const metaProvided = image.meta !== undefined;

const meta = metaProvided
  ? sanitizeProvenance(image.meta as …, storedSourceImageIds(currentImage.meta))
  : undefined;

// …
meta: metaProvided ? (meta != null ? (meta as Prisma.JsonObject) : Prisma.JsonNull) : undefined,
```

Sanitization is skipped when nothing is written: there is no client-authored meta to sanitize, and the stored row is not being rewritten. #3871's guarantee is untouched on every path that *does* write `meta` — a client still cannot assert a derivation by editing its own image.

Deliberately minimal; this is a hotfix for live data loss.

## Tests

The existing `update-post-image-hidemeta-bust` suite covered the cache-bust wiring and asserted **nothing** about what is written to `meta` — that gap is why this shipped. It now pins the write, asserting on the `data` object actually handed to `dbWrite.image.update`:

| Input | Expected |
|---|---|
| `{ id, hideMeta: true }` | `meta` absent from the update, and specifically **not** `Prisma.JsonNull` |
| `{ id, hideMeta: false }` | same (the un-hide direction is equally destructive) |
| `{ id }` | same |
| `{ id, meta: null }` | **does** write `Prisma.JsonNull` — the explicit-clear path still works |
| `{ id, meta: {...} }` | writes the object |
| `{ id, meta: { extra: { sourceImageIds: [999] } } }` | written ids come from the stored row, never the payload |

Every assertion first requires the update call to have happened, so none can pass vacuously against a mock that was never invoked.

**Verification matrix**

- **Red at base** `baee4d418b`: 3 failed / 8 passed / **11 tests** — the three omitted-`meta` cases all receive `JsonNull {}`.
- **Green at HEAD**: 11 passed / **11 tests**.
- Related suites at HEAD: 278 passed, 0 failed (28 files; 2 fail to import for an unrelated, pre-existing reason that reproduces identically at base).
- `pnpm typecheck`: 12 errors at base, 12 at HEAD — no delta.

**Mutation table** — each mutant killed by a named test with its own message:

| Mutant | Killed by | Message |
|---|---|---|
| `metaProvided = true` | `does NOT write meta when the input omits it (hideMeta: true / false)`, `…neither meta nor hideMeta` | `expected JsonNull{} to be undefined` (3 failures) |
| `!==` → `!=` | `DOES write Prisma.JsonNull when meta is explicitly null` | `expected undefined to be JsonNull{}` |
| drop the guard on the write line | the same three omitted-`meta` tests | `expected JsonNull{} to be undefined` (3 failures) |
| provenance re-derived from the payload instead of the stored row | `still re-derives provenance from the stored row`, `strips an unverified provenance claim` | `expected [ 999 ] to deeply equal [ 42 ]`; `expected { sourceImageIds: [ 999 ] } to not have property "sourceImageIds"` |
| vacuity control — return before the update | **all 7** new tests | `expected "vi.fn()" to be called 1 times, but got 0 times` |

The last row is the control for the vacuity hazard: with the update never called, every new test fails on the call-count assertion rather than passing on an `undefined` read.

## Possible follow-up (not in this PR)

`isValidAIGeneration({ …, meta: image.meta })` a few lines above reads the client-supplied value rather than `currentImage.meta`, so a `hideMeta`-only toggle judges verifiability against no metadata at all. That predates #3871 and is a separate behavioural question; keeping it out to hold this PR to the data-loss fix.

## Remediation

Rows already nulled cannot be recovered from the row itself — worth a separate conversation about whether any point-in-time copy can be mined for affected images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
