### PR TITLE
fix(placement): split a sticker placement's INPUT shape from its stored shape

### DIFF
--- a/src/server/services/__tests__/sticker-placement.service.test.ts
+++ b/src/server/services/__tests__/sticker-placement.service.test.ts
@@ -26,7 +26,9 @@ const CAP = 700;
 const PRICE = 700;
 
 const holdPlacementEscrow = vi.fn();
-const settlePlacement = vi.fn(async () => ({ settled: true }));
+const settlePlacement = vi.fn<(args: { action: string }) => Promise<{ settled: boolean }>>(
+  async () => ({ settled: true })
+);
 vi.mock('~/server/services/placement-escrow.service', () => ({
   holdPlacementEscrow,
   settlePlacement,
@@ -51,22 +53,31 @@ vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn().mockResolvedValu
  */
 const calls: string[] = [];
 
+/**
+ * Every Prisma stub declares its argument, rather than letting `vi.fn(async () => …)`
+ * infer a zero-arg signature. That inference makes `mock.calls` the empty tuple `[]`,
+ * so the `calls[0][0]` reads below — which are how this file asserts the WHERE clauses
+ * the guards are made of — are type errors against their own mock. `unknown` is the
+ * honest parameter type: the per-site casts stay, and they are what pins each shape.
+ */
+type PrismaStub<T> = (args: unknown) => Promise<T>;
+
 const queryRaw = vi.fn();
-const placementCreate = vi.fn(async () => {
+const placementCreate = vi.fn<PrismaStub<{ id: number }>>(async () => {
   calls.push('create');
   return { id: PLACEMENT };
 });
-const placementCount = vi.fn(async () => 0);
-const placementFindMany = vi.fn(async () => [] as unknown[]);
-const placementGroupBy = vi.fn(async () => [] as unknown[]);
-const transactionFindMany = vi.fn(async () => [] as unknown[]);
-const placementFindFirst = vi.fn(async () => null as unknown);
-const cosmeticFindUnique = vi.fn(async () => null as unknown);
+const placementCount = vi.fn<PrismaStub<number>>(async () => 0);
+const placementFindMany = vi.fn<PrismaStub<unknown[]>>(async () => []);
+const placementGroupBy = vi.fn<PrismaStub<unknown[]>>(async () => []);
+const transactionFindMany = vi.fn<PrismaStub<unknown[]>>(async () => []);
+const placementFindFirst = vi.fn<PrismaStub<unknown>>(async () => null);
+const cosmeticFindUnique = vi.fn<PrismaStub<unknown>>(async () => null);
 
-const imageFindMany = vi.fn(async () => [] as unknown[]);
-const placementFindUnique = vi.fn(async () => null as unknown);
-const placementUpdate = vi.fn(async () => ({}));
-const placementUpdateMany = vi.fn(async () => ({ count: 1 }));
+const imageFindMany = vi.fn<PrismaStub<unknown[]>>(async () => []);
+const placementFindUnique = vi.fn<PrismaStub<unknown>>(async () => null);
+const placementUpdate = vi.fn<PrismaStub<object>>(async () => ({}));
+const placementUpdateMany = vi.fn<PrismaStub<{ count: number }>>(async () => ({ count: 1 }));
 
 vi.mock('~/server/db/client', () => ({
   dbWrite: {

--- a/src/server/services/__tests__/sticker-placement.service.test.ts
+++ b/src/server/services/__tests__/sticker-placement.service.test.ts
@@ -26,9 +26,7 @@ const CAP = 700;
 const PRICE = 700;
 
 const holdPlacementEscrow = vi.fn();
-const settlePlacement = vi.fn<(args: { action: string }) => Promise<{ settled: boolean }>>(
-  async () => ({ settled: true })
-);
+const settlePlacement = vi.fn<PrismaStub<{ settled: boolean }>>(async () => ({ settled: true }));
 vi.mock('~/server/services/placement-escrow.service', () => ({
   holdPlacementEscrow,
   settlePlacement,
@@ -163,7 +161,8 @@ beforeEach(() => {
   spendStickerUsesFor.mockImplementation(async () => {
     calls.push('spend');
   });
-  settlePlacement.mockImplementation(async ({ action }: { action: string }) => {
+  settlePlacement.mockImplementation(async (args) => {
+    const { action } = args as { action: string };
     calls.push(`settle:${action}`);
     return { settled: true };
   });

--- a/src/server/services/sticker-placement.service.ts
+++ b/src/server/services/sticker-placement.service.ts
@@ -24,6 +24,7 @@ import {
 import type {
   PlacementSettlementState,
   StickerPlacementData,
+  StickerPlacementInput,
 } from '~/shared/utils/sticker-placement';
 import {
   isStickerPlacementData,
@@ -110,7 +111,7 @@ async function loadPlaceableSticker({
 export type CreateStickerPlacement = {
   placerId: number;
   imageId: number;
-  data: Omit<StickerPlacementData, 'cosmeticId'> & { cosmeticId: number };
+  data: Omit<StickerPlacementInput, 'cosmeticId'> & { cosmeticId: number };
   /** Moderators may exceed a creator's size limit. Justin's call. */
   isModerator?: boolean;
 };

--- a/src/shared/utils/sticker-placement.ts
+++ b/src/shared/utils/sticker-placement.ts
@@ -106,6 +106,25 @@ export function stickerMaxScale(settings?: Record<string, unknown> | null) {
 
 export const STICKER_MAX_SCALE_KEY = 'maxScale';
 
+/**
+ * What a caller may hand IN, as against `StickerPlacementData`, which is what a
+ * stored row holds.
+ *
+ * `flip` and `opacity` are optional here and required there, deliberately. #3865
+ * added both and put the defaulting for rows written before they existed into
+ * `parseStickerPlacementData` — "which is now the one way to read
+ * `Placement.data`, rather than in each reader" — so data genuinely reaches the
+ * write path without them. The zod schema defaults both, so the router's parsed
+ * value always carries them and the real call path is unaffected.
+ *
+ * Do not collapse the two back together. `parseStickerPlacementData` and
+ * `PlacedSticker` are the narrowing half and must keep both required; making the
+ * input side match them is what left the defaulting below unreachable to the
+ * compiler while it stayed necessary at runtime.
+ */
+export type StickerPlacementInput = Omit<StickerPlacementData, 'flip' | 'opacity'> &
+  Partial<Pick<StickerPlacementData, 'flip' | 'opacity'>>;
+
 const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
 
 /**
@@ -113,9 +132,11 @@ const clamp = (value: number, min: number, max: number) => Math.min(Math.max(val
  * leaves the image by a pixel is a normal gesture, not a malformed request. The
  * schema still refuses anything non-finite — a NaN would render nowhere and be
  * indistinguishable from the sticker not existing.
+ *
+ * Widening to narrowing: it takes the input shape and returns the stored one.
  */
 export const normalizeStickerPlacement = (
-  data: Omit<StickerPlacementData, 'cosmeticId'>
+  data: Omit<StickerPlacementInput, 'cosmeticId'>
 ): Omit<StickerPlacementData, 'cosmeticId'> => ({
   x: clamp(data.x, 0, 1),
   y: clamp(data.y, 0, 1),
@@ -127,7 +148,9 @@ export const normalizeStickerPlacement = (
   // on its way through `parseStickerPlacementData`, and anything hand-written.
   // NaN would be written to the row and drawn as no sticker at all.
   opacity: clamp(
-    Number.isFinite(data.opacity) ? data.opacity : STICKER_PLACEMENT_DEFAULT_OPACITY,
+    typeof data.opacity === 'number' && Number.isFinite(data.opacity)
+      ? data.opacity
+      : STICKER_PLACEMENT_DEFAULT_OPACITY,
     STICKER_PLACEMENT_MIN_OPACITY,
     STICKER_PLACEMENT_MAX_OPACITY
   ),


### PR DESCRIPTION
Clears `sticker-placement.service.test.ts` — **41 errors against a ratchet baseline of 16, now 0** — without editing a single fixture. Baseline JSON untouched.

`pnpm typecheck` cannot see any of this; the root tsconfig excludes `src/**/__tests__/**`. Reproduce with `pnpm exec tsc -p tsconfig.tests.json --noEmit`.

## Nineteen of the 41 were a bug in the types, not in the tests

#3865 added `flip` and `opacity` to `StickerPlacementData` as **required**. That type describes a *stored row*, and required is correct there. But the same type was also the parameter of `normalizeStickerPlacement` — whose body exists precisely because callers arrive without both keys:

```ts
flip: data.flip === true,
opacity: clamp(Number.isFinite(data.opacity) ? data.opacity : DEFAULT, …)
```

Under the old signature **those two branches were unreachable as far as the compiler was concerned**, while staying necessary at runtime. #3865's own commit message says why they're needed:

> Stored rows written before this have neither key. They default to full strength and unmirrored in `parseStickerPlacementData`, which is now the one way to read `Placement.data`, rather than in each reader.

The defaulting was put in the read path knowingly. The write path never got the same treatment, and its signature ended up claiming input equals output for a function that exists because they differ.

So `StickerPlacementInput` is what a caller may hand **in** (both optional), and `StickerPlacementData` is unchanged for anything reading a **placed row**. `normalizeStickerPlacement` takes the first and returns the second — which is what it always did.

**Which side stayed required matters, so stating it plainly:** `parseStickerPlacementData` and `PlacedSticker` keep both required. They are the narrowing half. This is not "the type got loosened" — the input and the stored shape were one type doing two jobs, and only the input job moved.

Nothing on the real call path changes: `stickerPlacementDataSchema` defaults both (`z.boolean().default(false)`, `.default(STICKER_PLACEMENT_DEFAULT_OPACITY)`), so the router's parsed value always carries them.

**The alternative would have been worse than doing nothing.** Filling `flip`/`opacity` into every fixture turns the gate green and deletes the only test pinning the defaulting — the case at ~line 413 omits both deliberately and asserts the row comes back `flip: false, opacity: 1`. It would still have passed, and proved nothing.

## The other ~20

`vi.fn(async () => …)` infers a **zero-arg** signature, so `mock.calls` is the empty tuple `[]` and every `calls[0][0]` — how this file asserts the WHERE clauses its guards are made of — is a type error against its own mock. Declared with `vi.fn<Sig>(impl)` rather than a placeholder parameter (the repo's `no-unused-vars` has no `argsIgnorePattern`). The per-site casts stay; they are what pins each shape.

## Verification

- `pnpm run typecheck` — **0 errors**, unfiltered.
- Gate reports this file **CLEAN** (`1 file(s) now clean`), baseline entry of 16 left in place.
- **113 tests pass** across `sticker-placement.service.test.ts`, `sticker-placement-opacity.test.ts`, `placement.test.ts`.
- eslint clean on all three changed files.
- **Mutation-tested**, because a split like this is exactly how a test goes vacuous: replacing the opacity defaulting with `data.opacity as number` fails the ~413 case with `- "opacity": 1 / + "opacity": NaN`. It still proves what it was written to prove.

## The invariant this rests on, traced rather than argued

Making `flip`/`opacity` optional on the INPUT is only safe if nothing writes input-shaped data straight to `Placement.data`. If anything did, a row would land without them and the "stored rows always have both" half — which `parseStickerPlacementData` and `PlacedSticker` depend on — would quietly stop being true.

Checked at the call sites, not inferred from the types:

- `sticker-placement.service.ts:227` is the **only** `placement.create` for this surface, and it spreads `...normalizeStickerPlacement(data)` — which returns the stored shape with both fields set.
- The two other `data:` spreads (`:524`, `:776`) operate on rows already read back, not on input.

So no row can be written missing either field. Credit: this trace is @zuri's — I had argued it from the type signature, which is not the same thing.

**Known and deliberate:** `placementUpdate` is `PrismaStub<object>`. Fine today because nothing reads its resolved value; it will fight the first test that does.

## Gate state on `main`, measured here

```
828 error(s) across 150 file(s)  (baseline: 801 across 141)
```

Still blocked, on two things that are **not** this PR:

- the 10 unbaselined files — fixed in **#3915**, open
- `remix-gallery.service.test.ts` at 29 -> 39 — fixed in **#3914**, open

⚠️ One correction worth recording: `remix-gallery.service.test.ts` is at 28/29 **on `fix/placement-content-levels`, not on `main`** — `82170251d0` is not an ancestor of `origin/main`. I checked, because I was about to repeat it as fact. On `main` it still measures 39.

With #3915 and #3914 both merged, this takes the gate to green.

Coordination: @alexandra and @zuri held off these files while I worked. `stickerPlacementDataSchema` is deliberately untouched, so #3914's schema and queue changes are clear of this. The input/output split was zuri's reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

