### PR TITLE
fix(donations): pay the creator in the currency the donor gave

### DIFF
--- a/src/server/services/__tests__/donation-goal.currency.test.ts
+++ b/src/server/services/__tests__/donation-goal.currency.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * A donation reaches the creator in the currency the donor gave.
+ *
+ * It did not: the charge named no destination account, so the buzz service
+ * applied its yellow default and a green donation arrived as yellow — 137 legs
+ * / 85,210 Buzz between 2025-11-21 and 2026-08-09. Same defect as paid access
+ * (#3917) and placements (#3911), and the third place it was found.
+ */
+
+const { mockDbRead, mockDbWrite } = vi.hoisted(() => ({
+  mockDbRead: { $queryRaw: vi.fn() },
+  mockDbWrite: {
+    donationGoal: { findUniqueOrThrow: vi.fn() },
+    donation: { create: vi.fn() },
+    $queryRaw: vi.fn(),
+  },
+}));
+
+const { createMultiAccountBuzzTransaction, refundMultiAccountTransaction } = vi.hoisted(() => ({
+  createMultiAccountBuzzTransaction: vi.fn(),
+  refundMultiAccountTransaction: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
+vi.mock('~/server/services/buzz.service', () => ({
+  createMultiAccountBuzzTransaction,
+  refundMultiAccountTransaction,
+}));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn().mockResolvedValue(undefined) }));
+
+import { donateToGoal } from '~/server/services/donation-goal.service';
+
+const DONOR = 20;
+const CREATOR = 10;
+const GOAL_ID = 77;
+
+const seed = () => {
+  mockDbWrite.donationGoal.findUniqueOrThrow.mockResolvedValue({
+    id: GOAL_ID,
+    title: 'A goal',
+    userId: CREATOR,
+    active: true,
+    isEarlyAccess: false,
+    entityType: 'ModelVersion',
+    entityId: 555,
+    goalAmount: 1000,
+  });
+  mockDbRead.$queryRaw.mockResolvedValue([{ total: 0 }]);
+  mockDbWrite.$queryRaw.mockResolvedValue([{ total: 0 }]);
+  createMultiAccountBuzzTransaction.mockResolvedValue({ transactionIds: ['tx-1'] });
+  mockDbWrite.donation.create.mockResolvedValue({});
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  seed();
+});
+
+describe('donateToGoal — the creator receives what the donor gave', () => {
+  it.each(['green', 'yellow'] as const)('pays a %s donation in kind', async (buzzType) => {
+    await donateToGoal({ donationGoalId: GOAL_ID, amount: 500, userId: DONOR, buzzType }).catch(
+      () => undefined
+    );
+
+    const charge = createMultiAccountBuzzTransaction.mock.calls[0][0];
+    expect(charge.fromAccountTypes).toEqual([buzzType]);
+    expect(charge.toAccountType).toBe(buzzType);
+    expect(charge.toAccountId).toBe(CREATOR);
+  });
+
+  // Blue is refused before any money moves. It is non-transferable, so a blue
+  // donation paying the creator ANY currency is a transfer channel for it —
+  // and the pre-fix behaviour was worse than paying blue: it paid YELLOW,
+  // turning free Buzz into cashable currency.
+  it('refuses Blue Buzz without charging anything', async () => {
+    await expect(
+      donateToGoal({ donationGoalId: GOAL_ID, amount: 500, userId: DONOR, buzzType: 'blue' })
+    ).rejects.toThrow(/Blue Buzz/);
+
+    expect(createMultiAccountBuzzTransaction).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/donation-goal.service.ts
+++ b/src/server/services/donation-goal.service.ts
@@ -187,20 +187,19 @@ const donationGoalByEntity = async ({
 // Creates a donation goal for an entity. This is purely a DonationGoal concern — it knows nothing
 // about PaidAccess/early-access; the gate is created separately by its own writer. Create-once:
 // later edits don't retroactively replace an existing goal (an entity has at most one).
-export async function ensureDonationGoal(
-  {
-    entityType,
-    entityId,
-    amount,
-    userId,
-    title = 'Donation Goal',
-  }: {
-    entityType: PaidAccessEntityType;
-    entityId: number;
-    amount: number;
-    userId: number;
-    title?: string;
-  }) {
+export async function ensureDonationGoal({
+  entityType,
+  entityId,
+  amount,
+  userId,
+  title = 'Donation Goal',
+}: {
+  entityType: PaidAccessEntityType;
+  entityId: number;
+  amount: number;
+  userId: number;
+  title?: string;
+}) {
   // Create-once is enforced by the partial unique index on (entityType, entityId), not by a prior
   // read: a read-then-create left a window where concurrent early-access writes all saw no goal and
   // each inserted one, splitting the entity's donations across rows that donationGoalByEntity then
@@ -262,6 +261,10 @@ export const donateToGoal = async ({
       amount,
       fromAccountId: userId,
       fromAccountTypes: [buzzType],
+      // The creator receives what the donor gave. Naming no destination let the
+      // buzz service apply its yellow default, so a green donation reached the
+      // creator as yellow — 137 legs / 85,210 Buzz since green launched.
+      toAccountType: buzzType,
       toAccountId: goal.userId,
       externalTransactionIdPrefix,
       description: `Donation to ${goal.title}`,


### PR DESCRIPTION
Third instance of the same defect, after #3911 (placements) and #3917 (paid access). Found by a sweep for other places we convert currency silently.

## What was wrong

`donateToGoal` charged the donor's chosen account but named **no destination**, so `createMultiAccountBuzzTransaction` applied the buzz service's yellow default (`buzz.service.ts:1119`, `toAccountType ?? 'yellow'`). A **green donation reached the creator as yellow**.

Measured on ClickHouse `buzzTransactions`: **137 legs / 85,210 Buzz** green→yellow, first 2025-11-21, most recent **2026-08-09** — live at the time of writing.

## The change

One line: `toAccountType: buzzType`.

Safe by construction, not by convention:
- `buzzType` is derived server-side from the request's domain (`donation-goal.router.ts`, `getAllowedAccountTypes(ctx.features)[0]`). The wire carries no currency.
- **Blue is refused before any money moves** (`donation-goal.service.ts:241`). So only green and yellow can reach `toAccountType`.

Worth noting what the old behaviour did to blue, had it ever been reachable: it would have paid the creator **yellow** for a blue donation — turning non-transferable Buzz into cashable currency. The existing refusal is what prevented that, and the test now pins it.

## Tests

New `donation-goal.currency.test.ts`:
- green and yellow donations pay in kind, to the goal owner
- blue is refused with **no charge attempted**

**Mutation-tested**: removing the line prints `AssertionError: expected undefined to be 'green'` — it fails because the destination is unnamed, which is exactly the defect.

`pnpm run typecheck` 0 errors; 11/11 across both donation-goal suites.

## Related

Independent of #3911 and #3917 — different file, no shared code, any merge order.

Still open from the same sweep: **comic chapter early access** (`comics.router.ts:4949`) has the identical shape with zero traffic so far, and the root cause is that `createMultiAccountBuzzTransaction` defaults to yellow when the destination is omitted — which is how this bug has now appeared four times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
