### PR TITLE
Fix blurry model carousel previews on high-DPI displays

### DIFF
--- a/src/components/EdgeMedia/EdgeMedia.tsx
+++ b/src/components/EdgeMedia/EdgeMedia.tsx
@@ -31,7 +31,7 @@ export type EdgeMediaProps = EdgeUrlProps &
     disablePoster?: boolean;
     videoProps?: React.HTMLAttributes<HTMLVideoElement> &
       React.MediaHTMLAttributes<HTMLVideoElement>;
-    imageProps?: React.HTMLAttributes<HTMLImageElement>;
+    imageProps?: React.ImgHTMLAttributes<HTMLImageElement>;
     /** Database image ID — forwarded to EdgeImage for drag-and-drop metadata lookup */
     imageId?: number;
   };

--- a/src/components/Model/ModelCarousel/ModelCarousel.tsx
+++ b/src/components/Model/ModelCarousel/ModelCarousel.tsx
@@ -30,6 +30,17 @@ import { useContainerSmallerThan } from '~/components/ContainerProvider/useConta
 import classes from './ModelCarousel.module.css';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 import clsx from 'clsx';
+import {
+  COMMON_IMAGE_WIDTHS,
+  getEdgeUrl,
+  snapWidthToCommonSize,
+} from '~/client-utils/cf-images-utils';
+import { DEFAULT_EDGE_IMAGE_WIDTH } from '~/server/common/constants';
+
+const maxModelCarouselImageWidth = snapWidthToCommonSize(DEFAULT_EDGE_IMAGE_WIDTH * 3);
+const modelCarouselImageWidths = COMMON_IMAGE_WIDTHS.filter(
+  (width) => width >= DEFAULT_EDGE_IMAGE_WIDTH && width <= maxModelCarouselImageWidth
+);
 
 export function ModelCarousel(props: Props) {
   const currentUser = useCurrentUser();
@@ -95,6 +106,19 @@ function ModelCarouselContent({ modelId, modelVersionId, modelUserId, limit = 10
         >
           {images.map((image, index) => {
             const fromCommunity = image.user.id !== modelUserId;
+            const srcSet = modelCarouselImageWidths
+              .map(
+                (width) =>
+                  `${getEdgeUrl(image.url, {
+                    name: image.name,
+                    type: image.type,
+                    width,
+                    anim: false,
+                    optimized: true,
+                  })} ${width}w`
+              )
+              .join(', ');
+
             return (
               <Embla.Slide
                 key={image.id}
@@ -162,7 +186,13 @@ function ModelCarouselContent({ modelId, modelVersionId, modelUserId, limit = 10
                               >
                                 <ImagePreview
                                   image={image}
-                                  edgeImageProps={{ width: 450 }}
+                                  edgeImageProps={{
+                                    width: DEFAULT_EDGE_IMAGE_WIDTH,
+                                    imageProps: {
+                                      srcSet,
+                                      sizes: mobile ? '100vw' : `${DEFAULT_EDGE_IMAGE_WIDTH}px`,
+                                    },
+                                  }}
                                   aspectRatio={(image.width ?? 1) / (image.height ?? 1)}
                                   // radius="md"
                                   style={{ width: '100%' }}


### PR DESCRIPTION
Model carousel images always request a 450px-wide thumbnail, even on high-DPI displays where that image may occupy 675–900 physical pixels. I noticed that with my display at 1.5x or 2x DPI the carousel preview images don't get scaled up and looked significantly worse because of the fixed width, usually more noticeable on illustration-style images with crisp lineart.

This change adds carousel-scoped srcset/sizes values using the existing CDN image widths, allowing the browser to select an appropriate resolution while retaining 450px as the fallback.

It's a subtle effect but here's a zoomed in example on a 1.5x DPI display (top is current appearance, bottom is with this PR's change):
<img width="577" height="512" alt="image" src="https://github.com/user-attachments/assets/d194753c-7d20-4d05-93ec-f288e96a716a" />

Happy to defer to you all on the right way to do this (or if this is even a good idea), but wanted to at least bring it to your attention since it's pretty noticable when viewing some model image previews.