### PR TITLE
fix(app-listings): resolve listing ownership KIND-AWARE, not block-first (#3844)

### DIFF
--- a/src/server/routers/__tests__/blocks.router.getNavSummary.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getNavSummary.test.ts
@@ -91,7 +91,9 @@ vi.mock('~/server/db/client', () => ({
   dbWrite: { modelBlockInstall: { findUnique: vi.fn() }, model: { findUnique: vi.fn() } },
 }));
 vi.mock('~/server/redis/client', async () => {
-  const actual = await vi.importActual<typeof import('@civitai/redis/client')>('@civitai/redis/client');
+  const actual = await vi.importActual<typeof import('@civitai/redis/client')>(
+    '@civitai/redis/client'
+  );
   return { ...actual, redis: mockRedis, sysRedis: mockSysRedis };
 });
 vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
@@ -346,14 +348,24 @@ describe('getNavSummary — the collaborator-aware flags', () => {
     ]);
   });
 
-  it('ownership is resolved BLOCK-FIRST, shadows excluded — same predicate as listMine', async () => {
+  it('ownership is resolved KIND-AWARE, shadows excluded — same predicate as listMine', async () => {
+    // 🔴 WAS "BLOCK-FIRST" (two branches) UNTIL ISSUE #3844. That predicate let an
+    // attached `AppBlock` decide ownership on an OFF-SITE listing, where
+    // `AppListing.userId` is canonical — so after `claimListing` or an off-site
+    // `acceptTransfer` (both of which move only the column) the sub-nav offered the
+    // "My apps" route to the PREVIOUS owner and hid it from the rightful one. The third
+    // branch is that fix, and this assertion is enumerated equality on purpose: it is the
+    // structural half of "the tab and the page it opens cannot disagree", the other half
+    // being `app-access.kind-aware-owner.test.ts`, which asserts both reads pass the
+    // shared `canonicalOwnerWhereBranches` output.
     const caller = blocksRouter.createCaller(fakeCtx(otherModUser) as never);
     await caller.getNavSummary();
     const where = mockDbRead.appListing.findFirst.mock.calls[0][0].where;
     expect(where.revisionOfId).toBeNull();
     expect(where.OR).toEqual([
-      { appBlock: { app: { userId: otherModUser.id } } },
-      { appBlock: { is: null }, userId: otherModUser.id },
+      { kind: 'onsite', appBlock: { app: { userId: otherModUser.id } } },
+      { kind: 'onsite', appBlock: { is: null }, userId: otherModUser.id },
+      { kind: { not: 'onsite' }, userId: otherModUser.id },
     ]);
   });
 

--- a/src/server/routers/__tests__/blocks.router.getNavSummary.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getNavSummary.test.ts
@@ -44,10 +44,12 @@ const {
     appBlockPublishRequest: { findFirst: vi.fn() },
     blockUserSubscription: { findFirst: vi.fn() },
     blockBuzzAttribution: { groupBy: vi.fn() },
-    // The two COLLABORATOR-aware probes (`resolveAppsNavAccess`): an owned-or-seated
-    // listing drives "My apps", a pending invite drives "Invites".
+    // The COLLABORATOR-aware probes (`resolveAppsNavAccess`): an owned-or-seated listing
+    // drives "My apps"; a pending SEAT INVITE **or** an inbound live OWNERSHIP-TRANSFER
+    // OFFER drives "Invites" — `/apps/invites` renders both, so the tab has to see both.
     appListing: { findFirst: vi.fn() },
     appCollaborator: { findFirst: vi.fn() },
+    appOwnershipTransfer: { findFirst: vi.fn() },
   },
 }));
 
@@ -167,12 +169,14 @@ beforeEach(() => {
   mockDbRead.appBlock.findFirst.mockReset();
   mockDbRead.appListing.findFirst.mockReset();
   mockDbRead.appCollaborator.findFirst.mockReset();
+  mockDbRead.appOwnershipTransfer.findFirst.mockReset();
   // Default: nothing exists for anyone.
   mockDbRead.blockUserSubscription.findFirst.mockResolvedValue(null);
   mockDbRead.appBlockPublishRequest.findFirst.mockResolvedValue(null);
   mockDbRead.appBlock.findFirst.mockResolvedValue(null);
   mockDbRead.appListing.findFirst.mockResolvedValue(null);
   mockDbRead.appCollaborator.findFirst.mockResolvedValue(null);
+  mockDbRead.appOwnershipTransfer.findFirst.mockResolvedValue(null);
 });
 
 describe('getNavSummary — gate', () => {
@@ -184,6 +188,7 @@ describe('getNavSummary — gate', () => {
     expect(mockDbRead.appBlock.findFirst).not.toHaveBeenCalled();
     expect(mockDbRead.appListing.findFirst).not.toHaveBeenCalled();
     expect(mockDbRead.appCollaborator.findFirst).not.toHaveBeenCalled();
+    expect(mockDbRead.appOwnershipTransfer.findFirst).not.toHaveBeenCalled();
   });
 
   it('flag OFF: returns the all-false shape and runs NO existence query', async () => {
@@ -321,6 +326,32 @@ describe('getNavSummary — the collaborator-aware flags', () => {
     expect(result.hasEditableApps).toBe(true);
     expect(result.hasSubmissions).toBe(false);
     expect(result.hasApprovedApps).toBe(false);
+  });
+
+  it('🔴 an inbound OWNERSHIP-TRANSFER OFFER lights "Invites" through the router', async () => {
+    // The router-level half of the gap: `/apps/invites` renders a pending transfer offer
+    // as well as a seat invite, so the tab that routes there must see both. With seats
+    // empty, the ONLY thing that can light this flag is the transfer probe.
+    mockDbRead.appOwnershipTransfer.findFirst.mockResolvedValue({ id: 'aot_1' });
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    const result = await caller.getNavSummary();
+    expect(result.hasPendingInvites).toBe(true);
+    // …and an offer confers no capability, so "My apps" stays dark.
+    expect(result.hasEditableApps).toBe(false);
+  });
+
+  it('the transfer probe is scoped to ctx.user.id as the ADDRESSEE, and status-filtered', async () => {
+    // Cross-user leakage is the failure this shape prevents: `toUserId` is the addressee,
+    // so an offer the caller SENT can never light their own tab.
+    const caller = blocksRouter.createCaller(fakeCtx(otherModUser) as never);
+    await caller.getNavSummary();
+    const where = mockDbRead.appOwnershipTransfer.findFirst.mock.calls[0][0].where;
+    expect(where.toUserId).toBe(otherModUser.id);
+    expect(where.status).toBe('pending');
+    // Expiry is a READ-TIME predicate with no sweeper — a dead offer keeps
+    // `status='pending'` forever, so this bound is what stops the tab latching on.
+    expect(where.expiresAt.gt).toBeInstanceOf(Date);
+    expect(where.fromUserId).toBeUndefined();
   });
 
   it('a PENDING seat does NOT light "My apps" — only "Invites"', async () => {

--- a/src/server/services/blocks/__tests__/app-access.accessible-listings.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.accessible-listings.test.ts
@@ -114,16 +114,33 @@ function ownershipFake(table: Row[]) {
         }
         return undefined;
       })();
-      // 🔴 The predicate the branches are SUPPOSED to encode: block-first ownership.
-      // Written independently here (not copied from the implementation) so a mutant that
-      // drops a branch produces a genuinely different answer.
+      // 🔴 The predicate the branches are SUPPOSED to encode: KIND-AWARE ownership — the
+      // block's OauthClient for an onsite listing, the column for anything else. Written
+      // independently here (not copied from the implementation) so a mutant that drops a
+      // branch produces a genuinely different answer. It read "block-first" until issue
+      // #3844; that spelling is the bug, not the spec.
+      // 🔴 THE FAKE IS KIND-AWARE BECAUSE POSTGRES IS. Each branch is recognised by BOTH
+      // halves of what it actually says — its `kind` clause AND its ownership clause — so
+      // dropping either half from the implementation changes this fake's answer. A fake
+      // that ignored `kind` would score the three-branch predicate identically to the old
+      // two-branch one, which is exactly the mutant issue #3844 is about.
+      const isOnsiteBranch = (b: Record<string, unknown>) => b.kind === 'onsite';
       const wantsBlockBranch = where.OR.some(
-        (b) => (b.appBlock as { app?: { userId?: number } } | null)?.app?.userId != null
+        (b) =>
+          isOnsiteBranch(b) &&
+          (b.appBlock as { app?: { userId?: number } } | null)?.app?.userId != null
       );
       const wantsNoBlockBranch = where.OR.some(
-        (b) => (b.appBlock as unknown as { is?: null } | null)?.is === null
+        (b) => isOnsiteBranch(b) && (b.appBlock as unknown as { is?: null } | null)?.is === null
+      );
+      // The #3844 branch: NOT onsite ⇒ the column decides, whether or not a block hangs
+      // off the row.
+      const wantsNonOnsiteColumnBranch = where.OR.some(
+        (b) =>
+          (b.kind as { not?: string } | undefined)?.not === 'onsite' && typeof b.userId === 'number'
       );
       rows = rows.filter((r) => {
+        if (r.kind !== 'onsite') return wantsNonOnsiteColumnBranch && r.columnUserId === userId;
         if (r.blockOwnerUserId != null) return wantsBlockBranch && r.blockOwnerUserId === userId;
         return wantsNoBlockBranch && r.columnUserId === userId;
       });

--- a/src/server/services/blocks/__tests__/app-access.call-site-ledger.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.call-site-ledger.test.ts
@@ -143,9 +143,14 @@ const GATE_LEDGER: Record<string, string> = {
     'every gate that delegates here, refusing the real owner while admitting the name ' +
     'the row happens to carry. (NOT acceptTransfer’s onsite listing write, which is ' +
     'unconditional and heals the parent; see app-access.denormalized-owner-drift.test.ts ' +
-    'for the mechanism in full.) 🔴 The resolution is BLOCK-FIRST, not kind-branching, ' +
-    'and on an offsite-listing-that-carries-a-block it names the wrong owner after a ' +
-    'transfer or a mod claim — 0 rows and unmintable today, tracked as issue #3844.',
+    'for the mechanism in full.) 🔴 The resolution is KIND-AWARE, in ONE place — ' +
+    'resolveCanonicalListingOwner, plus canonicalOwnerWhereBranches as its query form: ' +
+    'onsite takes the block’s OauthClient.userId with the column as fallback, offsite ' +
+    'takes the column UNCONDITIONALLY even when a block is attached. It was BLOCK-FIRST ' +
+    'until issue #3844, which inverted every delegating gate on an offsite-with-a-block ' +
+    'listing after acceptTransfer’s offsite path or claimListing (both move only the ' +
+    'column) — the impersonation remedy’s ex-owner kept edit access. The column is read ' +
+    'from the PARENT on a shadow hop for the same reason.',
   'src/server/services/blocks/app-collaborator.service.ts':
     'assertOwner — seat management is OWNER-ONLY by product decision (an editor is a ' +
     'co-owner in every respect EXCEPT managing collaborators and initiating a ' +
@@ -153,7 +158,9 @@ const GATE_LEDGER: Record<string, string> = {
     'the wrong question here; only `owner` may pass. listCollaborators DOES use it, and ' +
     'requires a non-null role (or a moderator): the roster exposes accepted seats whose ' +
     'holder opted OUT of the public byline, plus invitedBy and timestamps, so it is not ' +
-    'a public read. A pending invitee reads their own invite via listMyPendingInvites.',
+    'a public read. A pending invitee reads their own invite via listMyPendingInvites. ' +
+    '🔴 toSeatListing (the write-side owner resolution) DELEGATES to ' +
+    'resolveCanonicalListingOwner rather than re-spelling it block-first — see #3844.',
   'src/server/services/blocks/app-ownership-transfer.service.ts':
     'loadOwnedListing — initiating a transfer is OWNER-ONLY, same reasoning as seat ' +
     'management. Accept is gated on being the transfer’s ADDRESSEE, not on any role, ' +
@@ -162,7 +169,10 @@ const GATE_LEDGER: Record<string, string> = {
     'anyone else, so the read cannot become an existence oracle. Editors are excluded: ' +
     'disposing of the listing is the one capability a seat never carries. 🔴 KIND-AWARE: ' +
     'onsite moves OauthClient.userId + AppListing.userId; offsite moves the listing ' +
-    'column ONLY and is REFUSED outright when the listing carries a connectClientId.',
+    'column ONLY and is REFUSED outright when the listing carries a connectClientId. ' +
+    '🔴 loadOwnedListing’s owner resolution DELEGATES to resolveCanonicalListingOwner, ' +
+    'so the gate that authorises a transfer reads ownership the same kind-aware way the ' +
+    'accept path WRITES it (#3844) — block-first, an ex-owner could re-offer the listing.',
   'src/server/services/blocks/app-collaborator-earnings.service.ts':
     'The app-scoped money read: resolves the role FIRST and filters by appBlockId + the ' +
     'CURRENT owner. Never appOwnerUserId alone — that is the portfolio leak. 🔴 Also the ' +
@@ -654,9 +664,7 @@ describe('app-ownership gate ledger', () => {
         ['nested member, optional', 'if (shot.appListing?.userId !== user.id) throw e;'],
       ];
       for (const [label, sample] of REMOVED) {
-        expect(DENORM_OWNER_RE.test(sample), `DENORM_OWNER_RE must recognise: ${label}`).toBe(
-          true
-        );
+        expect(DENORM_OWNER_RE.test(sample), `DENORM_OWNER_RE must recognise: ${label}`).toBe(true);
       }
     });
 
@@ -694,9 +702,9 @@ describe('app-ownership gate ledger', () => {
     it('NEGATIVE CONTROL: it does not match the canonical resolution or an unrelated owner', () => {
       // The replacement must NOT itself count as a member of the class, or the assertion
       // below could never go green; and an Image/Post owner check is a different subject.
-      expect(DENORM_OWNER_RE.test('const role = await resolveListingRole(listingId, userId);')).toBe(
-        false
-      );
+      expect(
+        DENORM_OWNER_RE.test('const role = await resolveListingRole(listingId, userId);')
+      ).toBe(false);
       expect(
         DENORM_OWNER_RE.test('const ownerUserId = row.appBlock?.app?.userId ?? row.userId;')
       ).toBe(false);
@@ -791,9 +799,7 @@ describe('app-ownership gate ledger', () => {
       // `appBlockId` would compile (both are strings) and would silently match NOTHING —
       // demoting every editor to no-access with no error anywhere.
       for (const [file, call] of SEAT_CALLS) {
-        expect(call, `${file}: a seat call must be keyed on appListingId`).toMatch(
-          /appListingId/
-        );
+        expect(call, `${file}: a seat call must be keyed on appListingId`).toMatch(/appListingId/);
       }
     });
 
@@ -817,9 +823,7 @@ describe('app-ownership gate ledger', () => {
 
     it('NEGATIVE CONTROL: the composite-key probe CAN match', () => {
       // Proves the assertion above is testing a string that would be found if present.
-      expect('where: { appBlockId_userId: { appBlockId, userId } }').toContain(
-        'appBlockId_userId'
-      );
+      expect('where: { appBlockId_userId: { appBlockId, userId } }').toContain('appBlockId_userId');
     });
   });
 

--- a/src/server/services/blocks/__tests__/app-access.denormalized-owner-drift.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.denormalized-owner-drift.test.ts
@@ -525,6 +525,223 @@ describe('app-listing-assets::resolveOwnerScreenshotTarget (via updateListingScr
   });
 });
 
+/**
+ * 🔴 ISSUE #3844, DRIVEN THROUGH ALL FIVE GATES — the same table twice, once per arm.
+ *
+ * The suites above pin the ON-SITE drift. These pin the OFF-SITE inversion the
+ * consolidation introduced, and they do it as a TABLE over the whole gate population
+ * rather than by sampling one gate: the population is every consumer of
+ * `resolveListingAccess` in these two services, and each is asserted in BOTH directions.
+ * A gate that only granted would leave "allow everyone" alive; one that only refused would
+ * leave "deny everyone" alive.
+ *
+ * The resolver-level assertions (and the `claimListing` seam) live in
+ * `app-access.kind-aware-owner.test.ts`; this file is the end-to-end half.
+ */
+const OFFSITE_GATES: Array<{
+  name: string;
+  /** Which fixture row this gate is entered through. */
+  entry: 'live' | 'shadow';
+  run: (userId: number) => Promise<unknown>;
+  granted: Record<string, unknown>;
+  refused: Record<string, unknown>;
+}> = [
+  {
+    name: 'offsite-listing::loadOwnedEditableListing (updateListing)',
+    entry: 'live',
+    run: (userId) => updateListing({ listingId: LIVE, patch: { name: 'Renamed' }, userId }),
+    granted: { listingId: LIVE },
+    refused: { code: 'NOT_OWNED', message: 'you can only edit your own listings' },
+  },
+  {
+    name: 'offsite-listing::getMyListingForApp',
+    entry: 'live',
+    run: (userId) => getMyListingForApp({ appBlockId: BLOCK, userId }),
+    granted: { appListingId: LIVE },
+    refused: { code: 'NOT_OWNED', message: 'you can only manage your own listings' },
+  },
+  {
+    name: 'app-listing-assets::loadOwnedListing (getListingAssets)',
+    entry: 'live',
+    run: (userId) => getListingAssets({ listingId: LIVE }, user(userId)),
+    granted: { listingId: LIVE },
+    refused: { code: 'FORBIDDEN', message: 'You do not own this listing' },
+  },
+  {
+    name: 'app-listing-assets::resolveOwnerScreenshotTarget (updateListingScreenshotCaption)',
+    entry: 'live',
+    run: (userId) =>
+      updateListingScreenshotCaption({ screenshotId: SHOT, caption: 'hi' }, user(userId)),
+    granted: { id: SHOT },
+    refused: { code: 'FORBIDDEN', message: 'You do not own this listing' },
+  },
+  {
+    name: 'offsite-listing::submitListingRevision',
+    entry: 'shadow',
+    run: (userId) => submitListingRevision({ shadowId: SHADOW, userId }),
+    granted: { shadowId: SHADOW },
+    refused: { code: 'NOT_OWNED', message: 'you can only submit your own revision' },
+  },
+];
+
+describe('🔴 #3844 ARM 1 — an OFF-SITE listing that CARRIES A BLOCK: the block must not decide', () => {
+  /**
+   * `mapAppBlockToListing` mints exactly this shape from an `AppBlock` with an
+   * `externalUrl`. The column names {@link REAL_OWNER}; the attached block names
+   * {@link STRANGER} — who, in the story this models, is the ex-owner or the impersonator
+   * `claimListing` just dispossessed, since both off-site ownership writers move only the
+   * column and leave the block naming whoever it named before.
+   */
+  const offsiteBlockParent = {
+    id: LIVE,
+    kind: 'offsite',
+    slug: 'my-app',
+    // `draft`, matching `liveRow()`: an APPROVED parent routes a material edit through
+    // `beginListingRevision`, which is a different code path and not what these gates are
+    // about. The shadow's own `revisionOf.status` below still says `approved`, exactly as
+    // the on-site fixture does.
+    status: 'draft',
+    userId: REAL_OWNER,
+    revisionOfId: null,
+    appBlockId: BLOCK,
+    appBlock: { app: { userId: STRANGER } },
+    name: 'My App',
+    tagline: null,
+    description: null,
+    category: null,
+    contentRating: 'g',
+    externalUrl: 'https://example.com/',
+    connectClientId: null,
+    connectRequestedScopes: null,
+    connectScopeJustifications: null,
+    iconId: 101,
+    coverId: 202,
+  };
+  const offsiteBlockShadow = {
+    ...shadowRow(),
+    kind: 'offsite',
+    // Frozen at clone time from the parent's column — the SAME user, so this arm varies
+    // only the block. Arm 2 below varies only the frozen column.
+    userId: REAL_OWNER,
+    externalUrl: 'https://example.com/',
+    revisionOf: {
+      id: LIVE,
+      slug: 'my-app',
+      status: 'approved',
+      kind: 'offsite',
+      // The PARENT's column — what the resolver must read for an off-site listing. Equal
+      // to the shadow's here on purpose: this arm varies the BLOCK and nothing else.
+      userId: REAL_OWNER,
+      appBlockId: BLOCK,
+      appBlock: { app: { userId: STRANGER } },
+    },
+  };
+
+  beforeEach(() => {
+    wireListings({ [LIVE]: offsiteBlockParent, [SHADOW]: offsiteBlockShadow });
+  });
+
+  it('🔴 POSITIVE CONTROL: the fixture is offsite, HAS a block, and the two owners differ', () => {
+    expect(offsiteBlockParent.kind).toBe('offsite');
+    expect(offsiteBlockParent.appBlockId).toBe(BLOCK);
+    expect(offsiteBlockParent.userId).toBe(REAL_OWNER);
+    expect(offsiteBlockParent.appBlock.app.userId).toBe(STRANGER);
+    expect(REAL_OWNER).not.toBe(STRANGER);
+  });
+
+  for (const gate of OFFSITE_GATES) {
+    it(`${gate.name} ADMITS the rightful (column) owner`, async () => {
+      await expect(gate.run(REAL_OWNER)).resolves.toMatchObject(gate.granted);
+    });
+
+    it(`${gate.name} REFUSES the user the attached block names`, async () => {
+      await expect(gate.run(STRANGER)).rejects.toMatchObject(gate.refused);
+    });
+  }
+});
+
+describe('🔴 #3844 ARM 2 — an OFF-SITE SHADOW must not freeze the pre-transfer owner', () => {
+  /**
+   * The arm that needs NO block, and therefore no unmintable shape:
+   * `beginListingRevision` clones the parent with `userId: parent.userId`, and neither
+   * `claimListing` nor `acceptTransfer`'s off-site path touches a shadow (both write
+   * `where: { id: <the parent> }`). So a shadow that outlives an off-site ownership move
+   * names the OLD owner forever, and for `offsite` the column is exactly what the resolver
+   * falls back to. Only the two shadow-reachable gates apply.
+   */
+  const offsiteParent = {
+    ...liveRow(),
+    kind: 'offsite',
+    userId: REAL_OWNER, // the ownership move already landed here
+    appBlockId: null,
+    appBlock: null,
+    externalUrl: 'https://example.com/',
+  };
+  const staleShadow = {
+    ...shadowRow(),
+    kind: 'offsite',
+    userId: STALE_NAME, // frozen at clone time, before the move
+    externalUrl: 'https://example.com/',
+    revisionOf: {
+      id: LIVE,
+      slug: 'my-app',
+      status: 'approved',
+      kind: 'offsite',
+      // 🔴 The PARENT's column, which the move DID update. This arm varies exactly this
+      // one field against the shadow's frozen copy — no block anywhere in the fixture.
+      userId: REAL_OWNER,
+      appBlockId: null,
+      appBlock: null,
+    },
+  };
+
+  beforeEach(() => {
+    wireListings({ [LIVE]: offsiteParent, [SHADOW]: staleShadow });
+  });
+
+  it('🔴 POSITIVE CONTROL: the shadow’s frozen column disagrees with its parent’s', () => {
+    expect(staleShadow.userId).toBe(STALE_NAME);
+    expect(offsiteParent.userId).toBe(REAL_OWNER);
+    expect(staleShadow.revisionOfId).toBe(LIVE);
+    expect(staleShadow.appBlockId).toBeNull();
+  });
+
+  it('submitListingRevision ADMITS the parent’s CURRENT owner', async () => {
+    await expect(
+      submitListingRevision({ shadowId: SHADOW, userId: REAL_OWNER })
+    ).resolves.toMatchObject({ shadowId: SHADOW });
+  });
+
+  it('submitListingRevision REFUSES the ex-owner the shadow still names', async () => {
+    await expect(
+      submitListingRevision({ shadowId: SHADOW, userId: STALE_NAME })
+    ).rejects.toMatchObject({
+      code: 'NOT_OWNED',
+      message: 'you can only submit your own revision',
+    });
+  });
+
+  it('the asset gate on the SHADOW admits the current owner and refuses the frozen one', async () => {
+    await expect(getListingAssets({ listingId: SHADOW }, user(REAL_OWNER))).resolves.toMatchObject({
+      listingId: SHADOW,
+    });
+    await expect(getListingAssets({ listingId: SHADOW }, user(STALE_NAME))).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'You do not own this listing',
+    });
+  });
+
+  it('an editor seated on the PARENT still reaches the shadow', async () => {
+    // The fix must move the OWNER half without disturbing the seat half.
+    seatFor(EDITOR);
+    await expect(
+      submitListingRevision({ shadowId: SHADOW, userId: EDITOR })
+    ).resolves.toMatchObject({
+      shadowId: SHADOW,
+    });
+  });
+});
+
 describe('🔴 THE OTHER DIRECTION: an OFF-SITE listing’s column IS the owner', () => {
   // The control on the fix itself. "Always take the block owner" would be a NEW inversion
   // — an off-site listing has no OauthClient in its ownership chain, so `AppListing.userId`
@@ -552,45 +769,41 @@ describe('🔴 THE OTHER DIRECTION: an OFF-SITE listing’s column IS the owner'
     ).rejects.toMatchObject({ code: 'NOT_OWNED' });
   });
 
-  it('🔴 KNOWN REGRESSION on an unreachable shape (issue #3844): offsite + a block ⇒ the BLOCK wins', async () => {
-    // 🔴 CALLED WHAT IT IS. An earlier version of this comment (and of the PR body)
-    // framed this as a "neutral recorded disagreement". It is not neutral: PRE-PR these
-    // five gates compared against `AppListing.userId` and were therefore CORRECT on this
-    // shape; routing them through the resolver makes them wrong on it. That is a
-    // regression — on a shape that cannot currently occur, but a regression.
+  it('🔴 FIXED (issue #3844): offsite + a block ⇒ the COLUMN still wins, the block does not', async () => {
+    // 🔴 THIS CASE WAS INVERTED, DELIBERATELY, AND THE OLD EXPECTATION IS RECORDED HERE
+    // SO NOBODY RE-DERIVES IT. Until #3844 it asserted the opposite — that the BLOCK
+    // decides on this shape — and called itself a KNOWN REGRESSION: PR #3840 routed five
+    // gates through `resolveListingAccess`, whose resolution was `appBlock.app.userId ??
+    // listing.userId` (BLOCK-FIRST, no branch on `kind`). That read as "kind-aware" only
+    // because an ordinary off-site listing has no block.
     //
-    // `resolveListingAccess` computes `appBlock.app.userId ?? listing.userId` —
-    // BLOCK-FIRST, with no branch on `kind`. That reads as "kind-aware" only because an
-    // ordinary off-site listing has no block, so the fallback is the only branch reached.
-    // On an OFFSITE listing that carries one, the block decides — and BOTH off-site
-    // ownership writers move only the column, so the block keeps naming the old owner:
+    // `mapAppBlockToListing` mints `kind:'offsite'` WITH an `appBlockId` from any
+    // `AppBlock` carrying an `externalUrl`, and BOTH off-site ownership writers move only
+    // the column:
     //   - `acceptTransfer` — its step (2) OauthClient move is `if (isOnsite)`-guarded;
     //   - `claimListing` — the mod impersonation remedy (report → delist → claim → ban),
     //     which refuses a non-offsite listing outright and writes only the column.
-    // So on this shape the ex-owner (or the impersonator the claim was meant to
-    // dispossess) keeps edit access and the rightful owner is refused.
+    // So block-first kept the ex-owner — or the impersonator the claim was meant to
+    // dispossess — in edit access, and refused the rightful owner. Both directions are
+    // asserted below, and the impersonation-remedy path has its own suite in
+    // `app-access.kind-aware-owner.test.ts`.
     //
-    // 🔴 WHY IT IS PINNED RATHER THAN FIXED: measured against production 2026-08-12 the
-    // shape is not merely 0-row, it is UNMINTABLE. `kind='offsite' AND app_block_id IS
-    // NOT NULL` → 0 rows; 0 of 22 `app_blocks` carry an `external_url`; and a grep of
-    // `src/server` finds NO writer of that column — every hit is a read, a projection or
-    // a test fixture. `mapAppBlockToListing` mints the shape only from an AppBlock that
-    // has one. Changing the resolver moves the primary listing-access predicate for every
-    // caller, so it belongs in its own PR: https://github.com/civitai/civitai/issues/3844
-    // (which also notes that `resolveAccessibleAppBlockIds`, in the same module, already
-    // discriminates on `kind` rather than on block-nullness — the two halves disagree
-    // about which discriminator is authoritative).
-    //
-    // This test failing means someone changed the resolver — read the issue first, and
-    // update this case deliberately rather than deleting it.
+    // The shape was measured UNMINTABLE on 2026-08-12 (`kind='offsite' AND app_block_id
+    // IS NOT NULL` → 0 rows; 0 of 22 `app_blocks` carry an `external_url`; no writer of
+    // that column in `src/server`), so this was a LATENT inversion closed before anything
+    // could mint it — not a live exploit.
     wireListings({
       [LIVE]: offsite({ appBlockId: BLOCK, appBlock: { app: { userId: STRANGER } } }),
     });
-    await expect(getListingAssets({ listingId: LIVE }, user(STRANGER))).resolves.toMatchObject({
+    // The listing's own column is canonical for offsite: its owner is admitted…
+    await expect(getListingAssets({ listingId: LIVE }, user(REAL_OWNER))).resolves.toMatchObject({
       listingId: LIVE,
     });
-    await expect(getListingAssets({ listingId: LIVE }, user(REAL_OWNER))).rejects.toMatchObject({
+    // …and the user the attached block names is a stranger, refused. Asserting only the
+    // first half would leave an "allow everyone" mutant alive.
+    await expect(getListingAssets({ listingId: LIVE }, user(STRANGER))).rejects.toMatchObject({
       code: 'FORBIDDEN',
+      message: 'You do not own this listing',
     });
   });
 });

--- a/src/server/services/blocks/__tests__/app-access.kind-aware-owner.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.kind-aware-owner.test.ts
@@ -247,7 +247,13 @@ const { read, write, store, branchMatches, ids } = vi.hoisted(() => {
     },
     appListingModerationEvent: { create: vi.fn(async (a: { data: unknown }) => a.data) },
     appListingReport: { updateMany: vi.fn(async () => ({ count: 0 })) },
-    appOwnershipTransfer: { updateMany: vi.fn(async () => ({ count: 0 })) },
+    appOwnershipTransfer: {
+      updateMany: vi.fn(async () => ({ count: 0 })),
+      // `resolveAppsNavAccess` also probes for an inbound ownership OFFER (it lights the
+      // same "Invites" tab as a seat invite). No transfers exist in this suite's fixtures
+      // — the offer arm is covered by `app-access.nav-pending-invites.test.ts`.
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+    },
     appOwnershipEvent: { create: vi.fn(async (a: { data: unknown }) => a.data) },
     user: { findUnique: vi.fn(async (a: { where: { id: number } }) => ({ id: a.where.id })) },
     $transaction: vi.fn(async (arg: unknown): Promise<unknown> => arg),

--- a/src/server/services/blocks/__tests__/app-access.kind-aware-owner.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.kind-aware-owner.test.ts
@@ -1,0 +1,714 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * 🔴 ISSUE #3844 — `resolveListingAccess` was BLOCK-FIRST, not KIND-AWARE.
+ *
+ * ## The defect, exactly
+ *
+ * Ownership was resolved as `appBlock.app.userId ?? listing.userId`, with no branch on
+ * `kind`. That READS as kind-aware only because an ordinary off-site listing has no
+ * `AppBlock`, so the `?? ` fallback was the only branch anyone ever reached.
+ *
+ * `mapAppBlockToListing` mints `kind:'offsite'` WITH a non-null `appBlockId` for any
+ * `AppBlock` carrying an `externalUrl` (reachable from `publish-request.service`'s approve
+ * path and the mod proc `backfillAppListings`). On THAT shape the block decided ownership
+ * — while both off-site ownership writers move only the column:
+ *
+ *   - `app-ownership-transfer.service::acceptTransfer` — its step (2) `OauthClient` move
+ *     is `if (isOnsite)`-guarded, so the off-site path writes `AppListing.userId` alone;
+ *   - `offsite-moderation.service::claimListing` — the mod IMPERSONATION REMEDY
+ *     (report → delist → claim → ban), which refuses a non-offsite listing outright.
+ *
+ * So after either write the resolver kept naming the OLD owner. The previous owner — or
+ * the impersonator a moderator had just dispossessed — retained edit access, and the
+ * rightful owner was refused. A two-sided authorization inversion.
+ *
+ * ## 🔴 A SECOND, INDEPENDENT ARM OF THE SAME DEFECT: the SHADOW's frozen column
+ *
+ * `beginListingRevision` clones an approved parent into a hidden draft with
+ * `userId: parent.userId` and `appBlockId: null`, and NOTHING ever revisits that clone
+ * (`claimListing` and `acceptTransfer` both write `where: { id: <the parent> }`). For an
+ * ON-SITE listing the block covers it — that is what
+ * `app-access.denormalized-owner-drift.test.ts` pins. For an OFF-SITE listing the column
+ * IS the owner, so reading the SHADOW's copy reproduces the identical inversion **with no
+ * block involved at all**. This suite fixes it by resolving the column from the PARENT,
+ * the same row the resolver already takes `kind` and `appBlockId` from.
+ *
+ * ## Blast radius, stated honestly
+ *
+ * The block arm was measured against production on 2026-08-12 and is not merely 0-row, it
+ * is UNMINTABLE: `kind='offsite' AND app_block_id IS NOT NULL` → 0 rows, 0 of 22
+ * `app_blocks` carry an `external_url`, and no writer of that column exists in
+ * `src/server`. So that arm is a LATENT inversion closed before anything can mint it — not
+ * a live exploit, and not cosmetic either.
+ *
+ * The shadow arm is NOT covered by that measurement: it needs no block. It was derived
+ * from the code (the clone, and the two `where: { id }` writes), not measured against
+ * production — this suite does not claim a row count for it.
+ *
+ * ## What this file asserts
+ *
+ * The DEFINING surface — `resolveListingAccess`, its pure helper
+ * `resolveCanonicalListingOwner`, and the query-predicate form
+ * `canonicalOwnerWhereBranches` that the two SET reads share. The five consolidated GATES
+ * are driven end-to-end in `app-access.denormalized-owner-drift.test.ts`; the two
+ * WRITE-side loaders in `app-collaborator.service.test.ts` and
+ * `app-ownership-transfer.service.test.ts`.
+ */
+
+const { read, write, store, branchMatches, ids } = vi.hoisted(() => {
+  type ListingRow = {
+    id: string;
+    kind: string;
+    status: string;
+    slug: string;
+    name: string;
+    userId: number;
+    appBlockId: string | null;
+    revisionOfId: string | null;
+    externalUrl: string | null;
+    connectClientId: string | null;
+  };
+  const store = {
+    listings: new Map<string, ListingRow>(),
+    /** `AppBlock.id` → the `OauthClient.userId` behind it (`null` = dangling `app_id`). */
+    blockOwners: new Map<string, number | null>(),
+    seats: [] as Array<{ appListingId: string; userId: number; status: string }>,
+  };
+
+  /**
+   * 🔴 THE FAKE RETURNS WHOLE ROWS AND IGNORES `select`, DELIBERATELY.
+   *
+   * Every assertion here is about WHICH FIELD the implementation reads, so a fake that
+   * pre-narrowed the row to the fields the CURRENT implementation happens to select would
+   * make the pre-fix code die on a `TypeError` instead of returning a wrong answer — a
+   * failure that proves nothing about the gate. Handing back everything means the pre-fix
+   * and the post-fix code see the SAME row and differ only in what they do with it.
+   *
+   * The one thing that is NOT ignored is the `where` clause: see `branchMatches`.
+   */
+  const projectListing = (id: string | null | undefined, depth = 0): unknown => {
+    if (!id) return null;
+    const row = store.listings.get(id);
+    if (!row) return null;
+    const blockOwner = row.appBlockId ? store.blockOwners.get(row.appBlockId) : undefined;
+    return {
+      ...row,
+      appBlock: row.appBlockId
+        ? {
+            id: row.appBlockId,
+            blockId: `blk-${row.appBlockId}`,
+            appId: `oc_${row.appBlockId}`,
+            app: blockOwner == null ? null : { userId: blockOwner },
+          }
+        : null,
+      // One level only — a shadow's parent is never itself a shadow
+      // (`beginListingRevision` refuses a revision of a revision).
+      revisionOf: depth === 0 ? projectListing(row.revisionOfId, 1) : null,
+    };
+  };
+
+  /**
+   * 🔴 AN INDEPENDENT EVALUATOR OF THE OWNERSHIP `OR`, WRITTEN FROM THE SPEC.
+   *
+   * It recognises each branch by BOTH halves of what it says — its `kind` clause AND its
+   * ownership clause — and THROWS on a branch shape it does not recognise. That last part
+   * is what makes it a guard rather than a rubber stamp: a predicate silently rewritten
+   * into a shape this evaluator was never taught would otherwise answer "no rows", the
+   * reassuring zero this repo keeps paying for. Here it is a loud error instead.
+   */
+  const branchMatches = (
+    branch: Record<string, unknown>,
+    row: Record<string, unknown>
+  ): boolean => {
+    const kind = branch.kind;
+    const block = branch.appBlock as { app?: { userId?: number }; is?: null } | undefined;
+    const rowKind = row.kind as string;
+    const rowBlockOwner = row.appBlockId
+      ? store.blockOwners.get(row.appBlockId as string) ?? null
+      : null;
+    // (1) onsite + the block's OauthClient owner.
+    if (kind === 'onsite' && block?.app?.userId != null) {
+      return rowKind === 'onsite' && rowBlockOwner === block.app.userId;
+    }
+    // (2) onsite + NO block ⇒ the column is the only owner signal left.
+    if (kind === 'onsite' && block?.is === null && typeof branch.userId === 'number') {
+      return rowKind === 'onsite' && row.appBlockId == null && row.userId === branch.userId;
+    }
+    // (3) NOT onsite ⇒ the column, whether or not a block hangs off the row. The #3844 arm.
+    if (
+      (kind as { not?: string } | undefined)?.not === 'onsite' &&
+      typeof branch.userId === 'number'
+    ) {
+      return rowKind !== 'onsite' && row.userId === branch.userId;
+    }
+    throw new Error(
+      `unrecognised ownership OR branch — the predicate changed shape: ${JSON.stringify(branch)}`
+    );
+  };
+
+  const matchesWhere = (where: Record<string, unknown>, row: Record<string, unknown>): boolean => {
+    if (where.revisionOfId === null && row.revisionOfId !== null) return false;
+    const or = where.OR as Array<Record<string, unknown>> | undefined;
+    if (or) return or.some((b) => branchMatches(b, row));
+    return true;
+  };
+
+  const makeClient = () => ({
+    appListing: {
+      findUnique: vi.fn(async (...a: unknown[]) => {
+        const args = (a[0] ?? {}) as { where?: { id?: string; appBlockId?: string } };
+        if (args.where?.appBlockId) {
+          for (const row of store.listings.values()) {
+            if (row.appBlockId === args.where.appBlockId) return projectListing(row.id);
+          }
+          return null;
+        }
+        return projectListing(args.where?.id);
+      }),
+      findFirst: vi.fn(async (...a: unknown[]) => {
+        const args = (a[0] ?? {}) as { where?: Record<string, unknown> };
+        for (const row of store.listings.values()) {
+          if (matchesWhere(args.where ?? {}, row as unknown as Record<string, unknown>)) {
+            return projectListing(row.id);
+          }
+        }
+        return null;
+      }),
+      findMany: vi.fn(async (...a: unknown[]) => {
+        const args = (a[0] ?? {}) as { where?: Record<string, unknown> };
+        const out: unknown[] = [];
+        for (const row of store.listings.values()) {
+          if (matchesWhere(args.where ?? {}, row as unknown as Record<string, unknown>)) {
+            out.push(projectListing(row.id));
+          }
+        }
+        return out;
+      }),
+      updateMany: vi.fn(async (...a: unknown[]) => {
+        const args = (a[0] ?? {}) as {
+          where: { id: string; kind?: string; status?: { in?: string[] }; userId?: number };
+          data: { userId?: number };
+        };
+        const row = store.listings.get(args.where.id);
+        if (!row) return { count: 0 };
+        if (args.where.kind != null && row.kind !== args.where.kind) return { count: 0 };
+        if (args.where.status?.in && !args.where.status.in.includes(row.status)) {
+          return { count: 0 };
+        }
+        if (args.where.userId != null && row.userId !== args.where.userId) return { count: 0 };
+        if (typeof args.data.userId === 'number') row.userId = args.data.userId;
+        return { count: 1 };
+      }),
+    },
+    appBlock: {
+      findUnique: vi.fn(async (...a: unknown[]) => {
+        const args = (a[0] ?? {}) as { where?: { id?: string } };
+        const id = args.where?.id;
+        if (!id || !store.blockOwners.has(id)) return null;
+        const owner = store.blockOwners.get(id) ?? null;
+        let appListing: { id: string } | null = null;
+        for (const row of store.listings.values()) {
+          if (row.appBlockId === id) appListing = { id: row.id };
+        }
+        return { id, app: owner == null ? null : { userId: owner }, appListing };
+      }),
+      findMany: vi.fn(async (...a: unknown[]) => {
+        const args = (a[0] ?? {}) as { where?: { app?: { userId?: number } } };
+        const want = args.where?.app?.userId;
+        return [...store.blockOwners.entries()]
+          .filter(([, owner]) => owner != null && owner === want)
+          .map(([id]) => ({ id }));
+      }),
+    },
+    appCollaborator: {
+      findFirst: vi.fn(async (...a: unknown[]) => {
+        const w = (a[0] as { where: { appListingId?: string; userId: number; status?: string } })
+          .where;
+        return (
+          store.seats.find(
+            (s) =>
+              (w.appListingId == null || s.appListingId === w.appListingId) &&
+              s.userId === w.userId &&
+              (w.status == null || s.status === w.status)
+          ) ?? null
+        );
+      }),
+      findMany: vi.fn(async (...a: unknown[]) => {
+        const w = (a[0] as { where: { userId?: number; status?: string } }).where;
+        return store.seats.filter(
+          (s) =>
+            (w.userId == null || s.userId === w.userId) &&
+            (w.status == null || s.status === w.status)
+        );
+      }),
+      count: vi.fn(async () => store.seats.length),
+      deleteMany: vi.fn(async () => ({ count: 0 })),
+    },
+    appListingModerationEvent: { create: vi.fn(async (a: { data: unknown }) => a.data) },
+    appListingReport: { updateMany: vi.fn(async () => ({ count: 0 })) },
+    appOwnershipTransfer: { updateMany: vi.fn(async () => ({ count: 0 })) },
+    appOwnershipEvent: { create: vi.fn(async (a: { data: unknown }) => a.data) },
+    user: { findUnique: vi.fn(async (a: { where: { id: number } }) => ({ id: a.where.id })) },
+    $transaction: vi.fn(async (arg: unknown): Promise<unknown> => arg),
+  });
+
+  return { read: makeClient(), write: makeClient(), store, branchMatches, ids: { n: 0 } };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: read, dbWrite: write }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn(async () => undefined) }));
+vi.mock('~/server/services/blocks/app-listing-notify', () => ({
+  notifyAppListingOwner: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/utils/app-block-ids', () => ({
+  newAppListingReportId: () => `alrp_${++ids.n}`,
+  newAppListingModerationEventId: () => `alme_${++ids.n}`,
+  newAppListingPublishRequestId: () => `alpr_${++ids.n}`,
+  newAppOwnershipEventId: () => `aoe_${++ids.n}`,
+  newAppListingId: () => `apl_${++ids.n}`,
+  newAppListingScreenshotId: () => `apls_${++ids.n}`,
+  newUlid: () => `ULID${++ids.n}`,
+}));
+
+const {
+  resolveCanonicalListingOwner,
+  canonicalOwnerWhereBranches,
+  resolveListingAccess,
+  resolveAccessibleListingIds,
+  resolveAppsNavAccess,
+} = await import('~/server/services/blocks/app-access.service');
+const { claimListing } = await import('~/server/services/blocks/offsite-moderation.service');
+
+// 🔴 PAIRWISE-DISTINCT. Two roles sharing a number is how a fixture "proves" a gate that
+// is actually reading the wrong field.
+/** Who `AppListing.userId` names — the RIGHTFUL owner of an off-site listing. */
+const RIGHTFUL = 41;
+/** Who the attached `AppBlock`'s OauthClient names — the EX-owner / impersonator. */
+const EX_OWNER = 62;
+/** Holds an ACCEPTED seat. */
+const EDITOR = 73;
+/** No relationship to anything. */
+const STRANGER = 84;
+/** The moderator running the impersonation remedy. */
+const REVIEWER = 95;
+
+const PARENT = 'apl_parent';
+const SHADOW = 'apl_shadow';
+const BLOCK = 'ab_backing';
+
+type RowOver = Partial<{
+  id: string;
+  kind: string;
+  status: string;
+  slug: string;
+  name: string;
+  userId: number;
+  appBlockId: string | null;
+  revisionOfId: string | null;
+  externalUrl: string | null;
+  connectClientId: string | null;
+}>;
+
+function putListing(over: RowOver & { id: string }) {
+  store.listings.set(over.id, {
+    kind: 'offsite',
+    status: 'approved',
+    slug: `slug-${over.id}`,
+    name: `Name ${over.id}`,
+    userId: RIGHTFUL,
+    appBlockId: null,
+    revisionOfId: null,
+    externalUrl: 'https://example.com/',
+    connectClientId: null,
+    ...over,
+  });
+}
+
+/** 🔴 THE HAZARDOUS SHAPE: `kind:'offsite'` carrying a block whose owner DISAGREES. */
+function offsiteWithBlock(over: RowOver = {}) {
+  store.blockOwners.set(BLOCK, EX_OWNER);
+  putListing({ id: PARENT, kind: 'offsite', appBlockId: BLOCK, userId: RIGHTFUL, ...over });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  ids.n = 0;
+  store.listings.clear();
+  store.blockOwners.clear();
+  store.seats.length = 0;
+  // The interactive transaction runs its callback against the WRITE mock itself, so an
+  // in-tx write lands on the same in-memory store the resolver then reads.
+  write.$transaction.mockImplementation(async (arg: unknown) =>
+    typeof arg === 'function'
+      ? (arg as (tx: unknown) => Promise<unknown>)(write)
+      : Promise.all(arg as Promise<unknown>[])
+  );
+  read.$transaction.mockImplementation(async (arg: unknown) =>
+    typeof arg === 'function'
+      ? (arg as (tx: unknown) => Promise<unknown>)(read)
+      : Promise.all(arg as Promise<unknown>[])
+  );
+});
+
+// ---------------------------------------------------------------------------
+
+describe('🔴 POSITIVE CONTROLS: the fixture and the fake are both real', () => {
+  it('the hazardous shape really is offsite, really carries a block, and the two owners DIFFER', () => {
+    offsiteWithBlock();
+    const row = store.listings.get(PARENT)!;
+    expect(row.kind).toBe('offsite');
+    expect(row.appBlockId).toBe(BLOCK);
+    expect(row.userId).toBe(RIGHTFUL);
+    expect(store.blockOwners.get(BLOCK)).toBe(EX_OWNER);
+    expect(RIGHTFUL).not.toBe(EX_OWNER);
+  });
+
+  it('the fake HONOURS a where-clause: it can match AND it can miss', async () => {
+    // 🔴 A prior round of this feature shipped a user fake that ignored its where-clause,
+    // which would have made every filter assertion below vacuously true. Both directions
+    // are exercised: the same call shape returns the row for one id and null for another.
+    offsiteWithBlock();
+    expect(await read.appListing.findUnique({ where: { id: PARENT } })).toMatchObject({
+      id: PARENT,
+    });
+    expect(await read.appListing.findUnique({ where: { id: 'apl_nope' } })).toBeNull();
+    // …and the relation hop is resolved from the store, not canned.
+    expect(await read.appListing.findUnique({ where: { appBlockId: BLOCK } })).toMatchObject({
+      id: PARENT,
+    });
+    expect(await read.appListing.findUnique({ where: { appBlockId: 'ab_nope' } })).toBeNull();
+  });
+
+  it('the ownership-OR evaluator can return TRUE and FALSE, and THROWS on an unknown branch', () => {
+    offsiteWithBlock();
+    const row = store.listings.get(PARENT)! as unknown as Record<string, unknown>;
+    const branches = canonicalOwnerWhereBranches(RIGHTFUL);
+    expect(branches.some((b) => branchMatches(b, row))).toBe(true);
+    expect(canonicalOwnerWhereBranches(STRANGER).some((b) => branchMatches(b, row))).toBe(false);
+    // The guard that keeps a silently-rewritten predicate from reading as "no rows".
+    expect(() => branchMatches({ somethingElse: true }, row)).toThrow(/unrecognised ownership OR/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('resolveCanonicalListingOwner — the pure kind branch', () => {
+  it('onsite: the BLOCK wins over the column', () => {
+    expect(
+      resolveCanonicalListingOwner({
+        kind: 'onsite',
+        blockOwnerUserId: EX_OWNER,
+        listingUserId: RIGHTFUL,
+      })
+    ).toBe(EX_OWNER);
+  });
+
+  it('onsite with a DANGLING app_id: falls back to the column', () => {
+    // An app nobody owns would lock the listing's real owner out entirely.
+    expect(
+      resolveCanonicalListingOwner({
+        kind: 'onsite',
+        blockOwnerUserId: null,
+        listingUserId: RIGHTFUL,
+      })
+    ).toBe(RIGHTFUL);
+    expect(
+      resolveCanonicalListingOwner({
+        kind: 'onsite',
+        blockOwnerUserId: undefined,
+        listingUserId: RIGHTFUL,
+      })
+    ).toBe(RIGHTFUL);
+  });
+
+  it('🔴 offsite: the COLUMN wins even when a block is attached (#3844)', () => {
+    expect(
+      resolveCanonicalListingOwner({
+        kind: 'offsite',
+        blockOwnerUserId: EX_OWNER,
+        listingUserId: RIGHTFUL,
+      })
+    ).toBe(RIGHTFUL);
+  });
+
+  it('an UNKNOWN kind falls through to the column — fail-closed, matching capabilitiesForKind', () => {
+    // `capabilitiesForKind` falls back to the narrower (offsite) row for an unknown kind;
+    // the owner resolution matches it rather than handing an unrecognised kind the block.
+    expect(
+      resolveCanonicalListingOwner({
+        kind: 'something-new',
+        blockOwnerUserId: EX_OWNER,
+        listingUserId: RIGHTFUL,
+      })
+    ).toBe(RIGHTFUL);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('🔴 resolveListingAccess on an OFF-SITE listing that carries a block (#3844)', () => {
+  it('GRANTS the rightful (column) owner', async () => {
+    offsiteWithBlock();
+    const access = await resolveListingAccess(PARENT, RIGHTFUL);
+    expect(access?.ownerUserId).toBe(RIGHTFUL);
+    expect(access?.role).toBe('owner');
+  });
+
+  it('REFUSES the ex-owner the attached block still names', async () => {
+    // The security-relevant half. A fix that only granted would be half a fix.
+    offsiteWithBlock();
+    const access = await resolveListingAccess(PARENT, EX_OWNER);
+    expect(access?.ownerUserId).toBe(RIGHTFUL);
+    expect(access?.role).toBeNull();
+  });
+
+  it('the block does NOT decide even when the column names nobody special', async () => {
+    offsiteWithBlock({ userId: STRANGER });
+    expect((await resolveListingAccess(PARENT, EX_OWNER))?.role).toBeNull();
+    expect((await resolveListingAccess(PARENT, STRANGER))?.role).toBe('owner');
+  });
+
+  it('an ACCEPTED seat still confers `editor`, and a stranger still gets null', async () => {
+    // The fix must move the OWNER half without touching the seat half in either direction.
+    offsiteWithBlock();
+    store.seats.push({ appListingId: PARENT, userId: EDITOR, status: 'accepted' });
+    expect((await resolveListingAccess(PARENT, EDITOR))?.role).toBe('editor');
+    expect((await resolveListingAccess(PARENT, STRANGER))?.role).toBeNull();
+  });
+
+  it('a PENDING seat confers nothing — the consent gate is untouched', async () => {
+    offsiteWithBlock();
+    store.seats.push({ appListingId: PARENT, userId: EDITOR, status: 'pending' });
+    expect((await resolveListingAccess(PARENT, EDITOR))?.role).toBeNull();
+  });
+});
+
+describe('🔴 CONTROL: ON-SITE precedence is NOT regressed', () => {
+  it('a STALE denormalized column loses to the block, in both directions', async () => {
+    // The case a naive "just use listing.userId" fix would break. `AppListing.userId` is a
+    // denormalized copy for onsite; `OauthClient.userId` is canonical.
+    store.blockOwners.set(BLOCK, RIGHTFUL);
+    putListing({ id: PARENT, kind: 'onsite', appBlockId: BLOCK, userId: EX_OWNER });
+    const asReal = await resolveListingAccess(PARENT, RIGHTFUL);
+    expect(asReal?.ownerUserId).toBe(RIGHTFUL);
+    expect(asReal?.role).toBe('owner');
+    const asStale = await resolveListingAccess(PARENT, EX_OWNER);
+    expect(asStale?.ownerUserId).toBe(RIGHTFUL);
+    expect(asStale?.role).toBeNull();
+  });
+
+  it('an onsite block with a DANGLING app_id still falls back to the column', async () => {
+    store.blockOwners.set(BLOCK, null);
+    putListing({ id: PARENT, kind: 'onsite', appBlockId: BLOCK, userId: RIGHTFUL });
+    const access = await resolveListingAccess(PARENT, RIGHTFUL);
+    expect(access?.ownerUserId).toBe(RIGHTFUL);
+    expect(access?.role).toBe('owner');
+  });
+
+  it('an onsite listing with NO block at all resolves from the column', async () => {
+    // Pre-approval onsite drafts exist with `appBlockId: null`.
+    putListing({ id: PARENT, kind: 'onsite', status: 'draft', appBlockId: null, userId: RIGHTFUL });
+    expect((await resolveListingAccess(PARENT, RIGHTFUL))?.role).toBe('owner');
+    expect((await resolveListingAccess(PARENT, STRANGER))?.role).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('🔴 the SHADOW arm: an off-site shadow must not freeze the old owner', () => {
+  /**
+   * The parent's ownership moved (a claim or an off-site transfer wrote its column); the
+   * shadow, cloned earlier, still carries the OLD value. No block is involved — this arm
+   * needs none, which is why it is the one that does not depend on the unmintable shape.
+   */
+  function offsiteParentWithStaleShadow() {
+    putListing({ id: PARENT, kind: 'offsite', userId: RIGHTFUL, appBlockId: null });
+    putListing({
+      id: SHADOW,
+      kind: 'offsite',
+      status: 'draft',
+      userId: EX_OWNER, // frozen at clone time
+      appBlockId: null,
+      revisionOfId: PARENT,
+    });
+  }
+
+  it('POSITIVE CONTROL: the shadow really does disagree with its parent', () => {
+    offsiteParentWithStaleShadow();
+    expect(store.listings.get(SHADOW)!.userId).toBe(EX_OWNER);
+    expect(store.listings.get(PARENT)!.userId).toBe(RIGHTFUL);
+  });
+
+  it('GRANTS the parent’s current owner on the shadow', async () => {
+    offsiteParentWithStaleShadow();
+    const access = await resolveListingAccess(SHADOW, RIGHTFUL);
+    expect(access?.seatListingId).toBe(PARENT);
+    expect(access?.ownerUserId).toBe(RIGHTFUL);
+    expect(access?.role).toBe('owner');
+  });
+
+  it('REFUSES the ex-owner the shadow’s frozen column still names', async () => {
+    offsiteParentWithStaleShadow();
+    const access = await resolveListingAccess(SHADOW, EX_OWNER);
+    expect(access?.ownerUserId).toBe(RIGHTFUL);
+    expect(access?.role).toBeNull();
+  });
+
+  it('an editor seated on the PARENT still reaches the shadow', async () => {
+    offsiteParentWithStaleShadow();
+    store.seats.push({ appListingId: PARENT, userId: EDITOR, status: 'accepted' });
+    expect((await resolveListingAccess(SHADOW, EDITOR))?.role).toBe('editor');
+  });
+
+  it('🔴 STRUCTURAL: the query SELECTS the parent’s owner column', async () => {
+    // A behavioural assertion alone cannot tell "read from the parent" from "the fake
+    // happened to return the same number". This pins that the field is asked for.
+    offsiteParentWithStaleShadow();
+    await resolveListingAccess(SHADOW, RIGHTFUL);
+    const args = read.appListing.findUnique.mock.calls[0][0] as {
+      select: { revisionOf?: { select: { userId?: boolean } } };
+    };
+    expect(args.select.revisionOf?.select.userId).toBe(true);
+  });
+
+  it('a narrow fixture with no `revisionOf` relation still resolves (no crash, column fallback)', async () => {
+    // `revisionOfId` is the authoritative "am I a shadow" signal; the relation may be
+    // absent from a narrow select. That path must degrade, not throw.
+    read.appListing.findUnique.mockResolvedValueOnce({
+      id: SHADOW,
+      userId: RIGHTFUL,
+      kind: 'offsite',
+      appBlockId: null,
+      revisionOfId: PARENT,
+      appBlock: null,
+      revisionOf: null,
+    });
+    const access = await resolveListingAccess(SHADOW, RIGHTFUL);
+    expect(access?.seatListingId).toBe(PARENT);
+    expect(access?.ownerUserId).toBe(RIGHTFUL);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('🔴 THE IMPERSONATION REMEDY: claimListing must actually dispossess', () => {
+  /**
+   * The concrete harm the issue names. `claimListing` is the mod remedy for impersonation
+   * (report → delist → claim → ban): a moderator verifies ownership out-of-band and
+   * re-points `AppListing.userId` at the real owner. It writes ONLY that column and
+   * refuses a non-offsite listing outright.
+   *
+   * 🔴 THIS IS A SEAM TEST, NOT TWO UNIT TESTS. The write and the read run against the
+   * SAME in-memory store, so nothing here can pass by a fixture that merely ASSERTS the
+   * post-claim state — the state is whatever `claimListing` actually wrote. Two components
+   * each individually correct can still be broken together; that is what this asserts.
+   */
+  const REASON = 'impersonates a real vendor';
+
+  it('POSITIVE CONTROL: before the claim, the impersonator IS the resolved owner', async () => {
+    // Without this, "the impersonator is refused afterwards" is indistinguishable from a
+    // fixture in which they never had access at all.
+    offsiteWithBlock({ userId: EX_OWNER });
+    expect((await resolveListingAccess(PARENT, EX_OWNER))?.role).toBe('owner');
+    expect((await resolveListingAccess(PARENT, RIGHTFUL))?.role).toBeNull();
+  });
+
+  it('🔴 after the claim, the impersonator LOSES edit access and the rightful owner GAINS it', async () => {
+    offsiteWithBlock({ userId: EX_OWNER });
+    const res = await claimListing({
+      input: { appListingId: PARENT, targetUserId: RIGHTFUL, reason: REASON },
+      reviewerUserId: REVIEWER,
+    });
+    expect(res).toEqual({ appListingId: PARENT, userId: RIGHTFUL });
+    // The claim moved the column — and NOT the block, which still names the impersonator.
+    expect(store.listings.get(PARENT)!.userId).toBe(RIGHTFUL);
+    expect(store.blockOwners.get(BLOCK)).toBe(EX_OWNER);
+    // …and the resolver agrees with the remedy rather than with the residue.
+    expect((await resolveListingAccess(PARENT, EX_OWNER))?.role).toBeNull();
+    const granted = await resolveListingAccess(PARENT, RIGHTFUL);
+    expect(granted?.ownerUserId).toBe(RIGHTFUL);
+    expect(granted?.role).toBe('owner');
+  });
+
+  it('the same remedy works on a listing with NO block (the ordinary off-site case)', async () => {
+    // The control that keeps the case above attributable to the KIND branch: the ordinary
+    // shape was always correct, and must stay correct.
+    putListing({ id: PARENT, kind: 'offsite', userId: EX_OWNER, appBlockId: null });
+    await claimListing({
+      input: { appListingId: PARENT, targetUserId: RIGHTFUL, reason: REASON },
+      reviewerUserId: REVIEWER,
+    });
+    expect((await resolveListingAccess(PARENT, EX_OWNER))?.role).toBeNull();
+    expect((await resolveListingAccess(PARENT, RIGHTFUL))?.role).toBe('owner');
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('🔴 the SET reads agree with the per-listing resolver', () => {
+  /**
+   * `resolveAccessibleListingIds` (the "my apps" set) and `resolveAppsNavAccess` (the
+   * sub-nav probe) express the same ownership rule as a Prisma predicate. A set that
+   * disagreed with the resolver would hand a user an entry point that then 403s — or hide
+   * a listing they do own. Before #3844 both were block-first, so they agreed on being
+   * WRONG on this shape; they must now agree on being right.
+   */
+  it('the offsite-with-a-block listing appears for the COLUMN owner, not the block owner', async () => {
+    offsiteWithBlock();
+    expect((await resolveAccessibleListingIds(RIGHTFUL)).ownedIds).toEqual([PARENT]);
+    expect((await resolveAccessibleListingIds(EX_OWNER)).ownedIds).toEqual([]);
+  });
+
+  it('and the two answers match `resolveListingAccess` user for user', async () => {
+    offsiteWithBlock();
+    for (const userId of [RIGHTFUL, EX_OWNER, STRANGER]) {
+      const inSet = (await resolveAccessibleListingIds(userId)).ownedIds.includes(PARENT);
+      const isOwner = (await resolveListingAccess(PARENT, userId))?.role === 'owner';
+      expect(inSet, `set and resolver disagree for user ${userId}`).toBe(isOwner);
+    }
+  });
+
+  it('the sub-nav probe uses the SAME branches (offers the tab to the column owner only)', async () => {
+    offsiteWithBlock();
+    expect((await resolveAppsNavAccess(RIGHTFUL)).hasEditableApps).toBe(true);
+    expect((await resolveAppsNavAccess(EX_OWNER)).hasEditableApps).toBe(false);
+  });
+
+  it('ON-SITE ownership in the set still resolves through the BLOCK', async () => {
+    store.blockOwners.set(BLOCK, RIGHTFUL);
+    putListing({ id: PARENT, kind: 'onsite', appBlockId: BLOCK, userId: EX_OWNER });
+    expect((await resolveAccessibleListingIds(RIGHTFUL)).ownedIds).toEqual([PARENT]);
+    expect((await resolveAccessibleListingIds(EX_OWNER)).ownedIds).toEqual([]);
+  });
+
+  it('an onsite listing with no block resolves from the column, and shadows stay excluded', async () => {
+    putListing({ id: PARENT, kind: 'onsite', status: 'draft', appBlockId: null, userId: RIGHTFUL });
+    putListing({
+      id: SHADOW,
+      kind: 'onsite',
+      status: 'draft',
+      appBlockId: null,
+      userId: RIGHTFUL,
+      revisionOfId: PARENT,
+    });
+    expect((await resolveAccessibleListingIds(RIGHTFUL)).ownedIds).toEqual([PARENT]);
+  });
+
+  it('🔴 the predicate is the SHARED helper — both reads pass its exact branches', async () => {
+    // Structural, so "they agree" cannot be an accident of two fixtures. Both call sites
+    // must hand the query the branches the helper produces, unmodified.
+    offsiteWithBlock();
+    await resolveAccessibleListingIds(RIGHTFUL);
+    await resolveAppsNavAccess(RIGHTFUL);
+    const expected = canonicalOwnerWhereBranches(RIGHTFUL);
+    const many = read.appListing.findMany.mock.calls[0][0] as { where: { OR: unknown } };
+    const first = read.appListing.findFirst.mock.calls[0][0] as { where: { OR: unknown } };
+    expect(many.where.OR).toEqual(expected);
+    expect(first.where.OR).toEqual(expected);
+    // …and the helper really does carry the #3844 branch, so `toEqual` above is not
+    // comparing two copies of a two-branch predicate.
+    expect(expected).toHaveLength(3);
+    expect(expected).toContainEqual({ kind: { not: 'onsite' }, userId: RIGHTFUL });
+  });
+});

--- a/src/server/services/blocks/__tests__/app-access.nav-pending-invites.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.nav-pending-invites.test.ts
@@ -1,0 +1,384 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * 🔴 THE "INVITES" SUB-NAV TAB MUST SEE **BOTH** KINDS OF PENDING ITEM.
+ *
+ * `/apps/invites` is where a pending SEAT INVITE and an inbound OWNERSHIP-TRANSFER OFFER
+ * both render. The tab that routes there is gated on `getNavSummary`'s
+ * `hasPendingInvites`, which is computed by `resolveAppsNavAccess` — and that predicate
+ * knew about seat invites ONLY. So a user who had been offered an app and held no seat
+ * invite got no tab at all: the offer existed, the page rendered it, and nothing in the
+ * chrome ever pointed at the page.
+ *
+ * This suite pins the widened predicate, its boundary, and the two ways widening it could
+ * go wrong.
+ *
+ * ## 🔴 THE CASE A NAIVE FIX GETS WRONG: expiry is a READ-TIME PREDICATE
+ *
+ * `AppOwnershipTransfer.expiresAt` is enforced at read time with NO sweeper behind it —
+ * `schema.full.prisma` says so on the column, the step-B migration repeats it, and
+ * `app-ownership-transfer.service::isLive` is where the accept path applies it. A dead
+ * offer therefore keeps `status = 'pending'` FOREVER. A predicate written as
+ * `status: 'pending'` alone would latch the tab on permanently for anyone who was ever
+ * offered an app, and it would look completely correct in every test that did not
+ * deliberately age a row. Both sides of the boundary are asserted below, with STRICT `>`
+ * matching `isLive` exactly so the tab and the page cannot disagree about the instant.
+ *
+ * ## The other two ways this goes wrong
+ *
+ *   - THE LEAK DIRECTION: keying on the wrong end of the transfer. `toUserId` is the
+ *     ADDRESSEE. Keying on `fromUserId` (or on neither) would light the tab for the person
+ *     who SENT an offer, or for a bystander.
+ *   - CAPABILITY CREEP: a pending offer confers ZERO capability until accepted (the same
+ *     consent principle as an unaccepted seat), so it must light "Invites" and must NOT
+ *     light "My apps". Asserted explicitly, because the cheapest possible implementation —
+ *     OR-ing the new probe into both booleans — would pass every "the tab appears" case.
+ */
+
+const { db, store } = vi.hoisted(() => {
+  const store = {
+    /** Rows of `app_collaborators` for the probed user. */
+    seats: [] as Array<{ appListingId: string; userId: number; status: string }>,
+    /** Rows of `app_ownership_transfers`. */
+    transfers: [] as Array<{
+      id: string;
+      toUserId: number;
+      fromUserId: number;
+      status: string;
+      expiresAt: Date;
+    }>,
+    /** Listings the ownership predicate should match, keyed by owner. */
+    ownedBy: new Set<number>(),
+    /** Force a thrown error out of a named table's probe (the degrade tests). */
+    throwOn: null as null | { table: 'appCollaborator' | 'appOwnershipTransfer'; err: unknown },
+  };
+
+  const db = {
+    appListing: {
+      findFirst: vi.fn(async (...a: unknown[]) => {
+        const args = (a[0] ?? {}) as { where?: { OR?: Array<Record<string, unknown>> } };
+        // Only the ownership question matters here; read the caller off any branch that
+        // carries a userId, which every branch of `canonicalOwnerWhereBranches` does.
+        for (const branch of args.where?.OR ?? []) {
+          const viaBlock = (branch.appBlock as { app?: { userId?: number } } | undefined)?.app
+            ?.userId;
+          const uid = viaBlock ?? (branch.userId as number | undefined);
+          if (typeof uid === 'number' && store.ownedBy.has(uid)) return { id: 'apl_owned' };
+        }
+        return null;
+      }),
+    },
+    appCollaborator: {
+      findFirst: vi.fn(async (...a: unknown[]) => {
+        if (store.throwOn?.table === 'appCollaborator') throw store.throwOn.err;
+        const w = (a[0] as { where: { userId: number; status: string } }).where;
+        return store.seats.find((s) => s.userId === w.userId && s.status === w.status) ?? null;
+      }),
+    },
+    appOwnershipTransfer: {
+      findFirst: vi.fn(async (...a: unknown[]) => {
+        if (store.throwOn?.table === 'appOwnershipTransfer') throw store.throwOn.err;
+        const w = (
+          a[0] as {
+            where: {
+              toUserId?: number;
+              fromUserId?: number;
+              status?: string;
+              expiresAt?: { gt?: Date };
+            };
+          }
+        ).where;
+        // 🔴 EVERY CLAUSE THE IMPLEMENTATION SENDS IS APPLIED, and only the clauses it
+        // sends. Written from the spec rather than copied from the query, so dropping a
+        // clause changes this fake's answer instead of being invisible to it.
+        const hit = store.transfers.find(
+          (t) =>
+            (w.toUserId == null || t.toUserId === w.toUserId) &&
+            (w.fromUserId == null || t.fromUserId === w.fromUserId) &&
+            (w.status == null || t.status === w.status) &&
+            (w.expiresAt?.gt == null || t.expiresAt.getTime() > w.expiresAt.gt.getTime())
+        );
+        return hit ? { id: hit.id } : null;
+      }),
+    },
+  };
+  return { db, store };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: db, dbWrite: db }));
+
+const { resolveAppsNavAccess } = await import('~/server/services/blocks/app-access.service');
+
+const ME = 501;
+const SOMEONE_ELSE = 502;
+const NOW = new Date('2026-08-14T12:00:00.000Z');
+const IN_AN_HOUR = new Date(NOW.getTime() + 3_600_000);
+const AN_HOUR_AGO = new Date(NOW.getTime() - 3_600_000);
+
+function seatInvite(userId = ME, status = 'pending') {
+  store.seats.push({ appListingId: 'apl_seat', userId, status });
+}
+
+function transferOffer(
+  over: Partial<{ toUserId: number; fromUserId: number; status: string; expiresAt: Date }> = {}
+) {
+  store.transfers.push({
+    id: `aot_${store.transfers.length + 1}`,
+    toUserId: ME,
+    fromUserId: SOMEONE_ELSE,
+    status: 'pending',
+    expiresAt: IN_AN_HOUR,
+    ...over,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  store.seats.length = 0;
+  store.transfers.length = 0;
+  store.ownedBy.clear();
+  store.throwOn = null;
+});
+
+// ---------------------------------------------------------------------------
+
+describe('🔴 POSITIVE CONTROLS: the fake honours its where-clauses', () => {
+  it('the transfer probe can MATCH and can MISS on every clause it filters', async () => {
+    // Without this, every "no tab" assertion below is indistinguishable from a fake that
+    // returns null unconditionally, and every "tab" assertion from one that returns a row
+    // unconditionally. Both directions, one clause at a time.
+    transferOffer();
+    const probe = (where: Record<string, unknown>) => db.appOwnershipTransfer.findFirst({ where });
+    expect(await probe({ toUserId: ME, status: 'pending', expiresAt: { gt: NOW } })).not.toBeNull();
+    expect(await probe({ toUserId: SOMEONE_ELSE, status: 'pending' })).toBeNull();
+    expect(await probe({ toUserId: ME, status: 'accepted' })).toBeNull();
+    expect(await probe({ toUserId: ME, expiresAt: { gt: IN_AN_HOUR } })).toBeNull();
+    // …and an unfiltered probe still finds it, so the misses above are the CLAUSES'
+    // doing and not a fact about the row.
+    expect(await probe({})).not.toBeNull();
+  });
+
+  it('the seat probe can MATCH and can MISS', async () => {
+    seatInvite(ME, 'pending');
+    expect(
+      await db.appCollaborator.findFirst({ where: { userId: ME, status: 'pending' } })
+    ).not.toBeNull();
+    expect(
+      await db.appCollaborator.findFirst({ where: { userId: ME, status: 'accepted' } })
+    ).toBeNull();
+    expect(
+      await db.appCollaborator.findFirst({ where: { userId: SOMEONE_ELSE, status: 'pending' } })
+    ).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('hasPendingInvites — the four-quadrant table', () => {
+  it('🔴 a pending TRANSFER OFFER alone lights the tab (the gap this closes)', async () => {
+    // The regression case. Before the widening this was `false`, so the only page that
+    // renders the offer had no route pointing at it.
+    transferOffer();
+    expect((await resolveAppsNavAccess(ME, NOW)).hasPendingInvites).toBe(true);
+  });
+
+  it('a pending SEAT INVITE alone still lights the tab (INVARIANT GUARD — unchanged)', async () => {
+    // 🔴 Labelled honestly: this passes before AND after the widening. It is here to keep
+    // the widening from REPLACING the seat arm rather than adding to it — it is not
+    // regression coverage for this change.
+    seatInvite();
+    expect((await resolveAppsNavAccess(ME, NOW)).hasPendingInvites).toBe(true);
+  });
+
+  it('BOTH kinds at once lights the tab (INVARIANT GUARD — unchanged)', async () => {
+    seatInvite();
+    transferOffer();
+    expect((await resolveAppsNavAccess(ME, NOW)).hasPendingInvites).toBe(true);
+  });
+
+  it('NEITHER kind ⇒ no tab', async () => {
+    // The "deny" half. Without it, "always true" satisfies all three cases above.
+    expect((await resolveAppsNavAccess(ME, NOW)).hasPendingInvites).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('🔴 EXPIRY is a read-time predicate — a dead offer must not latch the tab on', () => {
+  it('an EXPIRED transfer alone ⇒ NO tab', async () => {
+    // `status` stays 'pending' forever (no sweeper), so this row is exactly what a naive
+    // `status: 'pending'` predicate would light the tab on, permanently.
+    transferOffer({ expiresAt: AN_HOUR_AGO });
+    expect((await resolveAppsNavAccess(ME, NOW)).hasPendingInvites).toBe(false);
+  });
+
+  it('the boundary is STRICT — AT `expiresAt` is already dead, 1ms before is alive', async () => {
+    // Matches `app-ownership-transfer.service::isLive`'s `>` exactly. A `>=` here would
+    // make the tab outlive the offer by an instant; more importantly, a mismatch is how
+    // the tab and the page start disagreeing.
+    store.transfers.length = 0;
+    transferOffer({ expiresAt: NOW });
+    expect((await resolveAppsNavAccess(ME, NOW)).hasPendingInvites).toBe(false);
+
+    store.transfers.length = 0;
+    transferOffer({ expiresAt: new Date(NOW.getTime() + 1) });
+    expect((await resolveAppsNavAccess(ME, NOW)).hasPendingInvites).toBe(true);
+  });
+
+  it('an expired transfer does not suppress a live SEAT invite', async () => {
+    // The other direction of the same clause: widening must not let a dead transfer
+    // shadow the arm that already worked.
+    seatInvite();
+    transferOffer({ expiresAt: AN_HOUR_AGO });
+    expect((await resolveAppsNavAccess(ME, NOW)).hasPendingInvites).toBe(true);
+  });
+
+  it('the DEFAULT `now` is wall-clock — a far-future offer lights the tab with no injection', async () => {
+    // 🔴 Proves the injected `now` is a testing affordance and not the only wired path: a
+    // default-argument bug (e.g. `now = new Date(0)`) would make every real offer look
+    // alive forever, and every test above passes it explicitly.
+    transferOffer({ expiresAt: new Date(Date.now() + 86_400_000) });
+    expect((await resolveAppsNavAccess(ME)).hasPendingInvites).toBe(true);
+
+    store.transfers.length = 0;
+    transferOffer({ expiresAt: new Date(Date.now() - 86_400_000) });
+    expect((await resolveAppsNavAccess(ME)).hasPendingInvites).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('🔴 THE LEAK DIRECTION: only the ADDRESSEE is notified', () => {
+  it('a transfer addressed to SOMEONE ELSE does not light my tab', async () => {
+    transferOffer({ toUserId: SOMEONE_ELSE, fromUserId: 999 });
+    expect((await resolveAppsNavAccess(ME, NOW)).hasPendingInvites).toBe(false);
+    // …and the control: the same row DOES light the addressee's tab, so the miss above is
+    // the `toUserId` clause and not an inert probe.
+    expect((await resolveAppsNavAccess(SOMEONE_ELSE, NOW)).hasPendingInvites).toBe(true);
+  });
+
+  it('an offer I SENT does not light my own tab', async () => {
+    // Keying on `fromUserId` instead of `toUserId` is the one-token version of this bug.
+    transferOffer({ fromUserId: ME, toUserId: SOMEONE_ELSE });
+    expect((await resolveAppsNavAccess(ME, NOW)).hasPendingInvites).toBe(false);
+  });
+
+  it('every TERMINAL status is ignored', async () => {
+    // The CHECK constraint's full domain minus 'pending'. A predicate that dropped the
+    // status clause would light the tab on a transfer the caller already rejected.
+    for (const status of ['accepted', 'rejected', 'cancelled', 'expired']) {
+      store.transfers.length = 0;
+      transferOffer({ status });
+      expect(
+        (await resolveAppsNavAccess(ME, NOW)).hasPendingInvites,
+        `status=${status} must not light the tab`
+      ).toBe(false);
+    }
+    // Positive control on the loop itself: the same fixture with 'pending' DOES light it,
+    // so the four falses are the status clause and not a broken loop body.
+    store.transfers.length = 0;
+    transferOffer({ status: 'pending' });
+    expect((await resolveAppsNavAccess(ME, NOW)).hasPendingInvites).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('🔴 A PENDING OFFER CONFERS ZERO CAPABILITY — it must not light "My apps"', () => {
+  it('a live transfer offer leaves hasEditableApps FALSE', async () => {
+    // The cheapest wrong implementation — OR the new probe into both booleans — passes
+    // every "the tab appears" case above and fails only here.
+    transferOffer();
+    const nav = await resolveAppsNavAccess(ME, NOW);
+    expect(nav.hasPendingInvites).toBe(true);
+    expect(nav.hasEditableApps).toBe(false);
+  });
+
+  it('POSITIVE CONTROL: hasEditableApps still answers TRUE for a real owner', async () => {
+    // Without this, "hasEditableApps is false" is indistinguishable from an ownership
+    // probe this suite's fake never satisfies.
+    store.ownedBy.add(ME);
+    expect((await resolveAppsNavAccess(ME, NOW)).hasEditableApps).toBe(true);
+  });
+
+  it('…and TRUE for an ACCEPTED seat holder, with no transfer anywhere', async () => {
+    seatInvite(ME, 'accepted');
+    const nav = await resolveAppsNavAccess(ME, NOW);
+    expect(nav.hasEditableApps).toBe(true);
+    expect(nav.hasPendingInvites).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('🔴 the transfer probe DEGRADES with its manual-apply table', () => {
+  /**
+   * `app_ownership_transfers` is created by the SAME manual-apply migration as
+   * `app_collaborators` (`20260811170000_rekey_app_collaborators_step_b_…`), whose own
+   * rollback note promises that dropping those tables returns the deployed code to the
+   * 42P01 path — "inert-and-owner-only, NOT broken". An unwrapped read here would break
+   * that promise by 500-ing every `/apps` page's chrome for the whole deploy window.
+   */
+  it('a MISSING TABLE (42P01) degrades to false instead of throwing', async () => {
+    store.throwOn = {
+      table: 'appOwnershipTransfer',
+      err: Object.assign(new Error('relation "app_ownership_transfers" does not exist'), {
+        code: '42P01',
+      }),
+    };
+    seatInvite();
+    const nav = await resolveAppsNavAccess(ME, NOW);
+    // The seat arm still answers — the degrade is scoped to the probe that failed.
+    expect(nav.hasPendingInvites).toBe(true);
+    expect(nav.hasEditableApps).toBe(false);
+  });
+
+  it('…and with no seat invite either, it is simply false', async () => {
+    store.throwOn = {
+      table: 'appOwnershipTransfer',
+      err: Object.assign(new Error('relation "app_ownership_transfers" does not exist'), {
+        code: '42P01',
+      }),
+    };
+    expect((await resolveAppsNavAccess(ME, NOW)).hasPendingInvites).toBe(false);
+  });
+
+  it('🔴 a COLUMN error (42703) still PROPAGATES — a half-applied schema must surface', async () => {
+    // The narrowness is the point: swallowing this would turn a genuinely broken schema
+    // into a permanent silent "no invites".
+    store.throwOn = {
+      table: 'appOwnershipTransfer',
+      err: Object.assign(new Error('column "expires_at" does not exist'), { code: '42703' }),
+    };
+    await expect(resolveAppsNavAccess(ME, NOW)).rejects.toThrow(/column "expires_at"/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('🔴 STRUCTURAL: the probe is narrowed on the INDEXED pair', () => {
+  it('the query sends toUserId + status + a strict expiresAt bound, and selects one column', async () => {
+    // A behavioural assertion cannot tell "narrowed on (to_user_id, status)" from "scanned
+    // the table and filtered in JS". `app_ownership_transfers_to_status_idx` is the index
+    // this pair exists to hit.
+    await resolveAppsNavAccess(ME, NOW);
+    expect(db.appOwnershipTransfer.findFirst).toHaveBeenCalledTimes(1);
+    const args = db.appOwnershipTransfer.findFirst.mock.calls[0][0] as {
+      where: { toUserId: number; status: string; expiresAt: { gt: Date } };
+      select: Record<string, boolean>;
+    };
+    expect(args.where.toUserId).toBe(ME);
+    expect(args.where.status).toBe('pending');
+    expect(args.where.expiresAt.gt).toBe(NOW);
+    expect(args.select).toEqual({ id: true });
+    // …and it is an EXISTENCE probe: no `findMany`, no ordering, no rows hydrated.
+    expect(Object.keys(db.appOwnershipTransfer)).toEqual(['findFirst']);
+  });
+
+  it('all four probes are issued (the nav summary did not silently drop one)', async () => {
+    await resolveAppsNavAccess(ME, NOW);
+    expect(db.appListing.findFirst).toHaveBeenCalledTimes(1);
+    expect(db.appCollaborator.findFirst).toHaveBeenCalledTimes(2);
+    expect(db.appOwnershipTransfer.findFirst).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/services/blocks/__tests__/app-collaborator.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator.service.test.ts
@@ -109,6 +109,16 @@ const ONSITE_NO_BLOCK = 'apl_onsite_no_block';
  * `app-access.denormalized-owner-drift.test.ts`.)
  */
 const DRIFTED = 'apl_drifted';
+/**
+ * 🔴 An OFF-SITE listing that carries a block whose `OauthClient.userId` names SOMEONE
+ * ELSE — issue #3844. For an off-site listing `AppListing.userId` IS the owner (there is
+ * no OauthClient in the chain), and both off-site ownership writers (`acceptTransfer`'s
+ * offsite path, `claimListing`) move only that column, so the attached block keeps naming
+ * whoever owned it before. `toSeatListing` resolved BLOCK-FIRST until #3844, which meant
+ * `assertOwner` — seat MANAGEMENT — was answered by the block: the dispossessed
+ * impersonator could still invite and remove collaborators on the rightful owner's app.
+ */
+const OFFSITE_BLOCK_DRIFTED = 'apl_offsite_block_drifted';
 const OWNER = 10;
 const TARGET = 20;
 const STRANGER = 50;
@@ -119,8 +129,7 @@ const SECOND_SEAT = 30;
  * seat. Asserted VERBATIM so a mutant that breaks this gate dies to THIS error rather
  * than to a neighbouring owner check (`assertOwner`'s message is different on purpose).
  */
-const BYLINE_NOT_OWNER_MESSAGE =
-  'Only the app owner can change a collaborator’s public byline';
+const BYLINE_NOT_OWNER_MESSAGE = 'Only the app owner can change a collaborator’s public byline';
 /** The name left behind in a stale denormalized `AppListing.userId`. */
 const STALE_OWNER = 77;
 const NOW = new Date('2026-08-10T12:00:00Z');
@@ -190,6 +199,23 @@ function listingTable(): Record<string, Record<string, unknown>> {
       revisionOfId: null,
       revisionOf: null,
       appBlock: null,
+    },
+    // 🔴 OFFSITE, carrying a block whose OauthClient names someone ELSE — issue #3844.
+    // The column is canonical for an off-site listing, so OWNER owns this row and
+    // STRANGER (whom the block names) does not.
+    [OFFSITE_BLOCK_DRIFTED]: {
+      id: OFFSITE_BLOCK_DRIFTED,
+      slug: 'offsite-block-drifted',
+      kind: 'offsite',
+      userId: OWNER,
+      appBlockId: 'ab_offsiteDrifted',
+      revisionOfId: null,
+      revisionOf: null,
+      appBlock: {
+        appId: 'oc_offsiteDrifted',
+        blockId: 'offsite-drifted-repo',
+        app: { userId: STRANGER },
+      },
     },
     // 🔴 onsite, with the canonical owner and the denormalized column DISAGREEING.
     [DRIFTED]: {
@@ -363,7 +389,12 @@ describe('inviteCollaborator', () => {
 
   it('inviting the OWNER is INVALID_TARGET', async () => {
     await expect(
-      inviteCollaborator({ appListingId: LISTING, targetUserId: OWNER, actorUserId: OWNER, now: NOW })
+      inviteCollaborator({
+        appListingId: LISTING,
+        targetUserId: OWNER,
+        actorUserId: OWNER,
+        now: NOW,
+      })
     ).rejects.toMatchObject({ code: 'INVALID_TARGET' });
   });
 
@@ -1267,6 +1298,50 @@ describe('setCollaboratorDisplayed — OWNER control (targetUserId)', () => {
         setCollaboratorDisplayed({
           appListingId: DRIFTED,
           userId: STALE_OWNER,
+          targetUserId: TARGET,
+          displayed: false,
+        })
+      ).rejects.toMatchObject({ code: 'NOT_OWNER', message: BYLINE_NOT_OWNER_MESSAGE });
+      expect(mockDb.appCollaborator.updateMany).not.toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * 🔴 ISSUE #3844 — the OFF-SITE mirror image, and the one `toSeatListing` got wrong.
+   *
+   * On an off-site listing the column IS the owner and the attached block must NOT
+   * override it. `toSeatListing` resolved block-first, so on this row seat MANAGEMENT
+   * answered to whoever the block named — i.e. the ex-owner, or the impersonator a
+   * moderator had just dispossessed with `claimListing`, since both off-site ownership
+   * writers move only the column.
+   */
+  describe('on an OFF-SITE listing that CARRIES A BLOCK (#3844)', () => {
+    it('POSITIVE CONTROL: the fixture is offsite, has a block, and the two owners differ', async () => {
+      const row = (await mockDb.appListing.findUnique({
+        where: { id: OFFSITE_BLOCK_DRIFTED },
+      })) as { kind: string; userId: number; appBlock: { app: { userId: number } } };
+      expect(row.kind).toBe('offsite');
+      expect(row.userId).toBe(OWNER);
+      expect(row.appBlock.app.userId).toBe(STRANGER);
+      expect(OWNER).not.toBe(STRANGER);
+    });
+
+    it('the COLUMN owner may manage seats', async () => {
+      await expect(
+        setCollaboratorDisplayed({
+          appListingId: OFFSITE_BLOCK_DRIFTED,
+          userId: OWNER,
+          targetUserId: TARGET,
+          displayed: false,
+        })
+      ).resolves.toMatchObject({ userId: TARGET, displayed: false });
+    });
+
+    it('🔴 the user the BLOCK names is REFUSED — and writes nothing', async () => {
+      await expect(
+        setCollaboratorDisplayed({
+          appListingId: OFFSITE_BLOCK_DRIFTED,
+          userId: STRANGER,
           targetUserId: TARGET,
           displayed: false,
         })

--- a/src/server/services/blocks/__tests__/app-ownership-transfer.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-ownership-transfer.service.test.ts
@@ -124,6 +124,16 @@ const OFFSITE_REPO_SLUG = 'offsite-repo';
  * `app-access.denormalized-owner-drift.test.ts`.
  */
 const DRIFTED = 'apl_drifted';
+/**
+ * 🔴 An OFF-SITE listing carrying a block whose `OauthClient` names SOMEONE ELSE —
+ * issue #3844. For an off-site listing `AppListing.userId` IS the owner, and the accept
+ * path's step (2) is `if (isOnsite)`-guarded, so an off-site move writes only that
+ * column and leaves the attached block naming the PREVIOUS owner (as does the mod
+ * `claimListing` remedy). `loadOwnedListing` resolved BLOCK-FIRST until #3844, so this
+ * gate answered to the ex-owner: they could still INITIATE A TRANSFER of a listing they
+ * no longer owned and hand it straight back out.
+ */
+const OFFSITE_BLOCK_DRIFTED = 'apl_offsite_block_drifted';
 const OLD_OWNER = 10;
 const NEW_OWNER = 20;
 const STRANGER = 50;
@@ -198,6 +208,23 @@ function listingTable(): Record<string, Record<string, unknown>> {
         appId: 'oc_offsite',
         blockId: OFFSITE_REPO_SLUG,
         app: { userId: OLD_OWNER },
+      },
+    },
+    // 🔴 OFFSITE, with a block whose OauthClient names STRANGER. The column (OLD_OWNER)
+    // is canonical here; the block must not decide. Issue #3844.
+    [OFFSITE_BLOCK_DRIFTED]: {
+      id: OFFSITE_BLOCK_DRIFTED,
+      slug: 'offsite-block-drifted-slug',
+      kind: 'offsite',
+      userId: OLD_OWNER,
+      appBlockId: 'ab_offsiteDrifted',
+      connectClientId: null,
+      revisionOfId: null,
+      revisionOf: null,
+      appBlock: {
+        appId: 'oc_offsiteDrifted',
+        blockId: 'offsite-drifted-repo',
+        app: { userId: STRANGER },
       },
     },
     // 🔴 onsite, with the canonical owner and the denormalized column DISAGREEING.
@@ -323,8 +350,59 @@ describe('initiateTransfer', () => {
 
   it('a NON-OWNER cannot initiate', async () => {
     await expect(
-      initiateTransfer({ appListingId: LISTING, toUserId: NEW_OWNER, actorUserId: STRANGER, now: NOW })
+      initiateTransfer({
+        appListingId: LISTING,
+        toUserId: NEW_OWNER,
+        actorUserId: STRANGER,
+        now: NOW,
+      })
     ).rejects.toMatchObject({ code: 'NOT_OWNER' });
+  });
+
+  /**
+   * 🔴 ISSUE #3844 — `loadOwnedListing` must resolve ownership KIND-AWARE.
+   *
+   * On an OFF-SITE listing the column is canonical and the attached block must not
+   * override it. Block-first, this gate handed the power to DISPOSE OF THE LISTING to
+   * whoever the block still named — the ex-owner after an off-site accept, or the
+   * impersonator `claimListing` had just dispossessed. `claimListing` cancels a pending
+   * transfer in the same tx precisely so the listing cannot be handed back out; a gate
+   * that lets the same user open a NEW one undoes that.
+   */
+  describe('🔴 on an OFF-SITE listing that CARRIES A BLOCK (#3844)', () => {
+    it('POSITIVE CONTROL: the fixture is offsite, has a block, and the two owners differ', () => {
+      const l = LISTINGS[OFFSITE_BLOCK_DRIFTED] as {
+        kind: string;
+        userId: number;
+        appBlock: { app: { userId: number } };
+      };
+      expect(l.kind).toBe('offsite');
+      expect(l.userId).toBe(OLD_OWNER);
+      expect(l.appBlock.app.userId).toBe(STRANGER);
+      expect(OLD_OWNER).not.toBe(STRANGER);
+    });
+
+    it('the COLUMN owner may initiate', async () => {
+      const t = await initiateTransfer({
+        appListingId: OFFSITE_BLOCK_DRIFTED,
+        toUserId: NEW_OWNER,
+        actorUserId: OLD_OWNER,
+        now: NOW,
+      });
+      expect(t.status).toBe('pending');
+    });
+
+    it('🔴 the user the BLOCK names is REFUSED — and no transfer row is written', async () => {
+      await expect(
+        initiateTransfer({
+          appListingId: OFFSITE_BLOCK_DRIFTED,
+          toUserId: NEW_OWNER,
+          actorUserId: STRANGER,
+          now: NOW,
+        })
+      ).rejects.toMatchObject({ code: 'NOT_OWNER' });
+      expect(mockDb.appOwnershipTransfer.create).not.toHaveBeenCalled();
+    });
   });
 
   it('transferring to yourself is INVALID_TARGET', async () => {
@@ -352,7 +430,12 @@ describe('initiateTransfer', () => {
 
   it('a SHADOW revision cannot be transferred — there is nothing to own', async () => {
     await expect(
-      initiateTransfer({ appListingId: SHADOW, toUserId: NEW_OWNER, actorUserId: OLD_OWNER, now: NOW })
+      initiateTransfer({
+        appListingId: SHADOW,
+        toUserId: NEW_OWNER,
+        actorUserId: OLD_OWNER,
+        now: NOW,
+      })
     ).rejects.toMatchObject({ code: 'INVALID_TARGET' });
     expect(mockDb.appOwnershipTransfer.create).not.toHaveBeenCalled();
   });
@@ -464,16 +547,16 @@ describe('🔴 an OFF-SITE listing with a connectClientId is REFUSED', () => {
    * that window. An initiate-only check is simply false for the whole window.
    */
   it('the predicate is exported and states the rule in one place', () => {
-    expect(refusesTransferForConnectClient({ kind: 'offsite', connectClientId: CONNECT_CLIENT })).toBe(
-      true
-    );
+    expect(
+      refusesTransferForConnectClient({ kind: 'offsite', connectClientId: CONNECT_CLIENT })
+    ).toBe(true);
     expect(refusesTransferForConnectClient({ kind: 'offsite', connectClientId: null })).toBe(false);
     // 🔴 ON-SITE IS UNAFFECTED — its OauthClient is reached through the AppBlock, and
     // THAT one does move. A predicate that dropped the kind check would block every
     // on-site transfer the moment the column were ever populated.
-    expect(refusesTransferForConnectClient({ kind: 'onsite', connectClientId: CONNECT_CLIENT })).toBe(
-      false
-    );
+    expect(
+      refusesTransferForConnectClient({ kind: 'onsite', connectClientId: CONNECT_CLIENT })
+    ).toBe(false);
   });
 
   it('initiate REFUSES, and no transfer row is created', async () => {
@@ -1080,7 +1163,8 @@ describe('🔴 getPendingTransfer — who may read the offer', () => {
    * On `origin/main` this read did not exist in this shape; the re-key routed it through
    * the listing resolver, and while that resolver returned the DENORMALIZED
    * `AppListing.userId` the gate answered a different question than every sibling
-   * (`initiateTransfer`/`loadOwnedListing` resolve `appBlock.app.userId ?? userId`).
+   * (`initiateTransfer`/`loadOwnedListing` resolve through the shared, kind-aware
+   * `resolveCanonicalListingOwner` — the block for onsite, the column for offsite).
    * The consequence is specific and inverted: the REAL owner gets `null` for their own
    * outgoing offer — which reads as "there is no transfer", the one answer that is
    * indistinguishable from safety — while the stale name reads both parties and the

--- a/src/server/services/blocks/app-access.service.ts
+++ b/src/server/services/blocks/app-access.service.ts
@@ -145,21 +145,34 @@ export type ListingAccess = {
    * roster — including `displayed:false` seats, `invitedBy` and the timestamps — to
    * whoever the stale row names, while refusing the REAL owner `NOT_OWNER` on their own
    * app. For an OFF-SITE listing there is no OauthClient in the ownership chain, so the
-   * column IS the owner and the fallback is exact.
+   * column IS the owner — which is why the resolution BRANCHES on `kind` rather than
+   * merely falling back to the column when no block happens to be present.
    *
-   * 🔴 …WITH ONE MEASURED EXCEPTION TO "kind-aware", tracked as
-   * https://github.com/civitai/civitai/issues/3844. The implementation is BLOCK-FIRST
-   * (`appBlock.app.userId ?? listing.userId`) and never branches on `kind`, which reads
-   * as kind-aware only because an ordinary off-site listing has no block. On an OFF-SITE
-   * listing that DOES carry one, the block decides — and both off-site ownership writers
-   * (`acceptTransfer`'s offsite path and `claimListing`) move only the column, so this
-   * function keeps naming the OLD owner. 0 rows of that shape in production and no code
-   * path can mint one today (see the issue for the measurement). Do not fix it here; the
-   * behaviour is pinned in `app-access.denormalized-owner-drift.test.ts`.
+   * 🔴 THE BRANCH ON `kind` IS THE WHOLE POINT, and it used to be missing (issue #3844,
+   * fixed here). The implementation was BLOCK-FIRST (`appBlock.app.userId ?? listing
+   * .userId`) with no branch at all, which READ as kind-aware only because an ordinary
+   * off-site listing has no block, so the fallback was the only branch reached. On an
+   * OFF-SITE listing that DOES carry one — `mapAppBlockToListing` mints exactly that shape
+   * from an `AppBlock` with an `externalUrl` — the block decided, while BOTH off-site
+   * ownership writers move only the column:
+   *   - `app-ownership-transfer.service::acceptTransfer` — its `OauthClient` step is
+   *     `if (isOnsite)`-guarded, so the offsite path writes `AppListing.userId` alone; and
+   *   - `offsite-moderation.service::claimListing` — the mod IMPERSONATION REMEDY
+   *     (report → delist → claim → ban), which refuses a non-offsite listing outright.
+   * So the resolver kept naming the OLD owner: the ex-owner — or the impersonator the
+   * claim exists to dispossess — retained edit access while the rightful owner was
+   * refused. Both directions are pinned in `app-access.kind-aware-owner.test.ts`.
+   *
+   * 🔴 AND FOR AN OFF-SITE LISTING THE CANONICAL COLUMN IS THE **PARENT'S**, never a
+   * shadow's own. `beginListingRevision` clones with `userId: parent.userId` and nothing
+   * revisits the clone, so a shadow that outlives an off-site ownership move carries the
+   * OLD owner frozen. Reading the shadow's copy re-opened the same inversion on the one
+   * shape that needs no unmintable block — see {@link resolveCanonicalListingOwner}.
    *
    * The same resolution is written in `app-collaborator.service::toSeatListing` and in
    * `app-ownership-transfer.service::loadOwnedListing`, the two WRITE-side seat/transfer
-   * loaders; every other consumer delegates to THIS function rather than re-deriving it.
+   * loaders — both now delegate to {@link resolveCanonicalListingOwner} rather than
+   * re-spelling it; every other consumer delegates to THIS function.
    *
    * 🔴 WHAT THE LEDGER ACTUALLY PINS, stated exactly, because two earlier versions of
    * this paragraph overstated it. The ledger enumerates the POPULATION of gate sites, and
@@ -190,6 +203,93 @@ export type ListingAccess = {
 
 /** The one status that confers capability. Nothing else does. */
 export const ACCEPTED = 'accepted' as const;
+
+/**
+ * 🔴 THE CANONICAL OWNER OF AN APP LISTING — the ONE place the kind branch is written.
+ *
+ * Ownership is not one column. It depends on the listing's KIND, and the two kinds have
+ * genuinely different ownership chains:
+ *
+ *   - `onsite`  → the owner is `OauthClient.userId`, reached as `AppBlock.app.userId`.
+ *                 `AppListing.userId` is a DENORMALIZED COPY there and is stale-able (a
+ *                 shadow revision freezes it at clone time). The copy is still the
+ *                 fallback, and it is the only owner signal left when a block carries a
+ *                 dangling `app_id` — an app nobody owns is worse than a stale name.
+ *   - `offsite` → there is no `OauthClient` in the chain at all (a connect client is a
+ *                 linked CREDENTIAL, not an owner), so `AppListing.userId` IS the owner —
+ *                 UNCONDITIONALLY, ignoring any backing `AppBlock`.
+ *
+ * 🔴 THE `offsite` BRANCH IS NOT DEAD CODE, AND ITS ABSENCE WAS ISSUE #3844.
+ * `mapAppBlockToListing` mints `kind:'offsite'` WITH a non-null `appBlockId` for any
+ * `AppBlock` that carries an `externalUrl` (reachable through `publish-request.service`'s
+ * approve path and the mod proc `backfillAppListings`). On that shape a block-first
+ * resolution lets the BLOCK decide — while both off-site ownership writers
+ * (`acceptTransfer`'s offsite path, and `claimListing`, the impersonation remedy) move
+ * only `AppListing.userId`. The result is a two-sided authorization inversion: the
+ * previous owner keeps edit access and the rightful owner is refused.
+ *
+ * 🔴 AN UNKNOWN KIND FALLS THROUGH TO THE COLUMN, deliberately, matching
+ * {@link capabilitiesForKind}'s fail-closed fallback to the narrower (offsite) row. A
+ * kind this code does not recognise must not be handed the block's owner.
+ *
+ * 🔴 `listingUserId` MUST BE THE PARENT LISTING'S COLUMN when the row asked about is a
+ * shadow revision. `beginListingRevision` clones the parent with `userId: parent.userId`
+ * and `appBlockId: null`, and no ownership write ever revisits the clone
+ * (`claimListing` and `acceptTransfer` both write `where: { id: <the parent> }`), so a
+ * shadow that outlives an OFF-SITE ownership move names the OLD owner forever. For
+ * `onsite` the block covers that; for `offsite` the column IS the answer, so passing the
+ * shadow's own copy would reproduce #3844 on a shape that needs no unmintable block at
+ * all. {@link resolveListingAccess} resolves the column from the PARENT for exactly this
+ * reason — the same row it already takes `kind` and `appBlockId` from.
+ *
+ * Pure: no IO, no db. Callers that already hold the row (the write-side seat and transfer
+ * loaders) call it directly rather than paying a second read.
+ */
+export function resolveCanonicalListingOwner(args: {
+  /** The PARENT listing's kind. */
+  kind: string;
+  /** `AppBlock.app.userId`, or null/undefined when there is no block (or no app). */
+  blockOwnerUserId: number | null | undefined;
+  /** The PARENT listing's `userId` column. */
+  listingUserId: number;
+}): number {
+  if (args.kind === 'onsite') return args.blockOwnerUserId ?? args.listingUserId;
+  return args.listingUserId;
+}
+
+/**
+ * {@link resolveCanonicalListingOwner} expressed as a Prisma `OR`, for the two SET reads
+ * that enumerate "listings this user owns" without resolving them one at a time.
+ *
+ * 🔴 IT MUST STAY EQUIVALENT TO THE FUNCTION, branch for branch. A set that disagreed
+ * with the per-listing resolver would hand a user an entry point that then 403s — or,
+ * worse, hide a listing they do own. The three branches are the function's two arms:
+ *
+ *   1. onsite + a block   → the block's `OauthClient.userId`;
+ *   2. onsite + no block  → the column (the `?? ` fallback);
+ *   3. NOT onsite         → the column, unconditionally — the #3844 branch. An offsite
+ *                           listing that HAS a block is matched HERE and by nothing else,
+ *                           which is exactly the shape a block-first predicate got wrong.
+ *
+ * Branch 2 is spelled `appBlock: { is: null }` rather than a third
+ * `{ appBlock: { app: { is: null } } }` because `AppBlock.appId` is a REQUIRED FK with
+ * `onDelete: Cascade` (schema.full.prisma) — a block with a dangling `app_id` cannot
+ * exist in the database, so the fallback is reachable only when there is no block at all.
+ * (`resolveAppAccess`'s `!block?.app` guard defends a narrow SELECT / a test fixture, not
+ * a DB state.) A `{ app: { is: null } }` branch would additionally be a Prisma
+ * *validation error* on a required to-one.
+ *
+ * 🔴 CALLERS MUST STILL ADD `revisionOfId: null` themselves — a shadow revision is an
+ * internal draft with no authoring surface, and this helper deliberately answers only the
+ * ownership question so the two concerns stay separable.
+ */
+export function canonicalOwnerWhereBranches(userId: number): Array<Record<string, unknown>> {
+  return [
+    { kind: 'onsite', appBlock: { app: { userId } } },
+    { kind: 'onsite', appBlock: { is: null }, userId },
+    { kind: { not: 'onsite' }, userId },
+  ];
+}
 
 // ---------------------------------------------------------------------------
 // CAPABILITIES — derived from the listing KIND. No per-seat configuration.
@@ -359,6 +459,11 @@ export async function resolveListingAccess(
       revisionOf: {
         select: {
           id: true,
+          // 🔴 THE PARENT'S OWNER COLUMN, and it is NOT redundant with the shadow's own.
+          // The shadow froze a copy of it at clone time; for an OFF-SITE listing that
+          // column IS the owner, so reading the frozen one keeps naming whoever owned the
+          // listing when the revision was opened. See {@link resolveCanonicalListingOwner}.
+          userId: true,
           kind: true,
           appBlockId: true,
           appBlock: { select: { app: { select: { userId: true } } } },
@@ -373,15 +478,30 @@ export async function resolveListingAccess(
   // fall back to the id — never to the shadow's own (always-null) appBlockId.
   const parent = listing.revisionOfId ? listing.revisionOf : null;
   const seatListingId = listing.revisionOfId ?? listing.id;
-  const kind = ((listing.revisionOfId ? parent?.kind : listing.kind) ?? listing.kind) as ListingKind;
+  const kind = ((listing.revisionOfId ? parent?.kind : listing.kind) ??
+    listing.kind) as ListingKind;
   const appBlockId = (listing.revisionOfId ? parent?.appBlockId : listing.appBlockId) ?? null;
-  // 🔴 `AppBlock.app.userId` FIRST, the column only as the fallback — which is exact for
-  // offsite (no OauthClient in the chain) and covers an onsite block with a dangling
-  // `app_id`. Identical resolution to `toSeatListing` and `loadOwnedListing`, so the
-  // read side and the write side cannot disagree about who the owner is.
-  const ownerUserId =
-    (listing.revisionOfId ? parent?.appBlock?.app?.userId : listing.appBlock?.app?.userId) ??
-    listing.userId;
+  // 🔴 KIND-AWARE, via the ONE helper — see {@link resolveCanonicalListingOwner} for why
+  // a block-first resolution inverted every gate on an OFFSITE-listing-that-has-a-block
+  // (issue #3844). The same helper backs `toSeatListing` and the transfer service's
+  // `loadOwnedListing`, so the read side and the write side cannot disagree about who the
+  // owner is.
+  //
+  // 🔴 EVERY INPUT COMES FROM THE **PARENT** ROW — the column included, not just the
+  // block. A shadow's `userId` is a frozen clone of the parent's, and for `offsite` that
+  // column IS the owner, so taking the shadow's copy would hand an ex-owner (or an
+  // impersonator a moderator just dispossessed via `claimListing`) their old listing's
+  // in-flight revision. `?? listing.userId` keeps a narrow fixture that omits the
+  // `revisionOf` relation working, exactly as `kind` and `appBlockId` above do.
+  const columnUserId = (listing.revisionOfId ? parent?.userId : listing.userId) ?? listing.userId;
+  const blockOwnerUserId = listing.revisionOfId
+    ? parent?.appBlock?.app?.userId
+    : listing.appBlock?.app?.userId;
+  const ownerUserId = resolveCanonicalListingOwner({
+    kind,
+    blockOwnerUserId,
+    listingUserId: columnUserId,
+  });
   const base = {
     appListingId: listing.id,
     seatListingId,
@@ -595,23 +715,16 @@ export type AccessibleListings = {
  * there to its actual owner. Do not substitute one for the other.
  *
  * 🔴 OWNERSHIP IS RESOLVED THE SAME WAY {@link resolveListingAccess} RESOLVES IT —
- * BLOCK-FIRST, column as the fallback — expressed as a query predicate:
+ * KIND-AWARE — expressed as a query predicate by {@link canonicalOwnerWhereBranches},
+ * which is the ONE place that decomposition is written (this read and
+ * {@link resolveAppsNavAccess} share it, so the tab and the page it opens cannot
+ * disagree). Read that helper for what each branch is for.
  *
- *     ownerUserId = appBlock.app.userId ?? listing.userId
- *
- * decomposes into exactly the two OR branches below, because `AppBlock.appId` is a
- * REQUIRED FK with `onDelete: Cascade` (schema.full.prisma) — a block with a dangling
- * `app_id` cannot exist in the database, so the `?? ` fallback is reachable only when
- * there is no block at all. (`resolveAppAccess`'s `!block?.app` guard defends a narrow
- * SELECT / a test fixture, not a DB state.) A third `{ appBlock: { app: { is: null } } }`
- * branch would additionally be a Prisma *validation error* on a required to-one.
- *
- * That block-first reading deliberately inherits the ONE measured exception documented on
- * {@link ListingAccess.ownerUserId} (issue #3844): on an OFFSITE listing that carries a
- * block, the block decides and the denormalized column is ignored. Reproducing the
- * exception is the point — a set that disagreed with the per-listing resolver would hand
- * a user an entry point that then 403s, which is the failure this whole surface exists to
- * prevent.
+ * The set and the per-listing resolver MUST agree: a set that disagreed would hand a user
+ * an entry point that then 403s, or hide a listing they do own. Before issue #3844 both
+ * were block-first, so they agreed on being WRONG on an offsite-listing-that-has-a-block;
+ * they now agree on being right, and `app-access.kind-aware-owner.test.ts` asserts the
+ * agreement on that exact shape rather than trusting that two edits stayed in step.
  *
  * 🔴 SHADOWS ARE EXCLUDED (`revisionOfId: null`). A shadow revision is an internal draft
  * that holds no seats (see the module header) and has no authoring surface of its own;
@@ -628,10 +741,7 @@ export type AccessibleListings = {
 export async function resolveAccessibleListingIds(userId: number): Promise<AccessibleListings> {
   const [owned, seats] = await Promise.all([
     dbRead.appListing.findMany({
-      where: {
-        revisionOfId: null,
-        OR: [{ appBlock: { app: { userId } } }, { appBlock: { is: null }, userId }],
-      },
+      where: { revisionOfId: null, OR: canonicalOwnerWhereBranches(userId) },
       select: { id: true },
     }),
     safeCollaboratorQuery(
@@ -735,9 +845,10 @@ export type AppsNavAccess = {
  * site that can forget it, and a seat query missing `status: 'accepted'` would let a
  * PENDING invite light up a nav route (and, by the same drift elsewhere, confer access).
  *
- * 🔴 The ownership half re-uses the SAME two OR branches as
- * {@link resolveAccessibleListingIds}, so the tab cannot appear for a set the page then
- * renders empty, or stay hidden over a set the page would fill.
+ * 🔴 The ownership half re-uses the SAME {@link canonicalOwnerWhereBranches} as
+ * {@link resolveAccessibleListingIds} — literally the same function call, not a second
+ * copy of the branches — so the tab cannot appear for a set the page then renders empty,
+ * or stay hidden over a set the page would fill.
  *
  * Both seat probes degrade to `false` while the manual-apply collaborator table is
  * absent: an un-degraded read here would 500 the sub-nav, i.e. every `/apps` page's
@@ -747,10 +858,7 @@ export type AppsNavAccess = {
 export async function resolveAppsNavAccess(userId: number): Promise<AppsNavAccess> {
   const [ownedListing, seat, invite] = await Promise.all([
     dbRead.appListing.findFirst({
-      where: {
-        revisionOfId: null,
-        OR: [{ appBlock: { app: { userId } } }, { appBlock: { is: null }, userId }],
-      },
+      where: { revisionOfId: null, OR: canonicalOwnerWhereBranches(userId) },
       select: { id: true },
     }),
     safeCollaboratorQuery(

--- a/src/server/services/blocks/app-access.service.ts
+++ b/src/server/services/blocks/app-access.service.ts
@@ -828,14 +828,30 @@ async function hydrateMyAppListings(
 
 /** The two booleans the `/apps/*` sub-nav needs in order to offer a route at all. */
 export type AppsNavAccess = {
-  /** ≥1 listing OWNED or held via an ACCEPTED seat → the "My apps" route is non-empty. */
+  /**
+   * ≥1 listing OWNED or held via an ACCEPTED seat → the "My apps" route is non-empty.
+   *
+   * 🔴 A PENDING OWNERSHIP TRANSFER DELIBERATELY DOES **NOT** COUNT HERE. It confers ZERO
+   * capability until accepted — the same consent principle as a pending seat invite, and
+   * `app-ownership-transfer.service` states it in as many words. Lighting "My apps" for an
+   * offer would advertise a page the recipient's every child query refuses.
+   */
   hasEditableApps: boolean;
-  /** ≥1 PENDING invitation → the "Invites" route is non-empty. */
+  /**
+   * ≥1 pending item ADDRESSED TO the caller → the "Invites" route is non-empty.
+   *
+   * 🔴 TWO KINDS OF PENDING ITEM, and the second used to be missing. `/apps/invites` is
+   * where BOTH a pending seat invite and an inbound ownership-transfer OFFER render, but
+   * this predicate knew only about seats — so a user with an offer and no seat invite got
+   * no tab at all, i.e. no route to the only page that shows the offer. The name is kept
+   * (it gates the "Invites" tab, and the tab covers both) but the meaning is now
+   * "anything pending for you", not "a seat invite".
+   */
   hasPendingInvites: boolean;
 };
 
 /**
- * The sub-nav's collaborator-aware visibility probe. EXISTENCE ONLY — two `findFirst`s,
+ * The sub-nav's collaborator-aware visibility probe. EXISTENCE ONLY — four `findFirst`s,
  * no rows, matching `getNavSummary`'s existing shape.
  *
  * 🔴 IT LIVES HERE RATHER THAN IN `blocks.router` FOR A MEASURED REASON. Writing the two
@@ -850,13 +866,35 @@ export type AppsNavAccess = {
  * copy of the branches — so the tab cannot appear for a set the page then renders empty,
  * or stay hidden over a set the page would fill.
  *
- * Both seat probes degrade to `false` while the manual-apply collaborator table is
- * absent: an un-degraded read here would 500 the sub-nav, i.e. every `/apps` page's
- * chrome, for the whole window between the code deploy and a human applying the
- * migration.
+ * 🔴 ALL THREE MANUAL-APPLY PROBES DEGRADE to `false` while their tables are absent: an
+ * un-degraded read here would 500 the sub-nav, i.e. every `/apps` page's chrome, for the
+ * whole window between the code deploy and a human applying the migration. That includes
+ * the TRANSFER probe — `app_ownership_transfers` is created by the very same manual-apply
+ * migration as `app_collaborators` (`20260811170000_rekey_app_collaborators_step_b_…`),
+ * and that migration's own rollback note says dropping them must return the deployed code
+ * to the 42P01 path, "inert-and-owner-only, NOT broken". An unwrapped transfer read would
+ * break exactly that promise. A 42703 (half-applied schema) still propagates, by design.
+ *
+ * 🔴 QUERY COST, stated rather than left to be discovered: this is now FOUR existence
+ * probes instead of three. They run inside the SAME `Promise.all`, so the added serial
+ * latency is zero, but it is one more concurrent round trip (and one more pool slot) per
+ * `getNavSummary` — which the `/apps` chrome renders on every page load. It cannot be
+ * folded into an existing query: the four probes hit three different tables, and unioning
+ * across them would mean hand-written SQL. The probe itself is as cheap as it gets — a
+ * `findFirst` selecting one column, narrowed on the indexed `(to_user_id, status)` pair
+ * (`app_ownership_transfers_to_status_idx`) with `expires_at` as a residual filter over
+ * the handful of rows that pair can return.
  */
-export async function resolveAppsNavAccess(userId: number): Promise<AppsNavAccess> {
-  const [ownedListing, seat, invite] = await Promise.all([
+export async function resolveAppsNavAccess(
+  userId: number,
+  /**
+   * Injected so the EXPIRY BOUNDARY is testable at an exact instant rather than raced
+   * against wall-clock. Mirrors `app-ownership-transfer.service`'s convention, where every
+   * lifecycle function threads a `now`.
+   */
+  now: Date = new Date()
+): Promise<AppsNavAccess> {
+  const [ownedListing, seat, invite, transferOffer] = await Promise.all([
     dbRead.appListing.findFirst({
       where: { revisionOfId: null, OR: canonicalOwnerWhereBranches(userId) },
       select: { id: true },
@@ -877,10 +915,31 @@ export async function resolveAppsNavAccess(userId: number): Promise<AppsNavAcces
         }),
       null
     ),
+    // 🔴 AN INBOUND OWNERSHIP OFFER LIGHTS THE SAME TAB — see {@link
+    // AppsNavAccess.hasPendingInvites}. `toUserId` is the ADDRESSEE, so this can never be
+    // lit by an offer the caller SENT, only by one they received.
+    //
+    // 🔴 `expiresAt: { gt: now }` IS NOT OPTIONAL, and it is the half a naive
+    // `status: 'pending'` check gets wrong. Expiry here is a READ-TIME PREDICATE with no
+    // sweeper behind it (schema.full.prisma says so on the column, and the migration
+    // repeats it), so a long-dead offer keeps `status = 'pending'` forever. Without this
+    // clause the tab would latch on permanently for anyone who was ever offered an app.
+    // STRICT `>` matches `app-ownership-transfer.service::isLive` exactly — an offer AT
+    // its expiry instant is already dead — so the tab and the page cannot disagree about
+    // the boundary.
+    safeCollaboratorQuery(
+      () =>
+        dbRead.appOwnershipTransfer.findFirst({
+          where: { toUserId: userId, status: 'pending', expiresAt: { gt: now } },
+          select: { id: true },
+        }),
+      null
+    ),
   ]);
   return {
+    // 🔴 `transferOffer` is deliberately ABSENT from this disjunct. See the type.
     hasEditableApps: ownedListing !== null || seat !== null,
-    hasPendingInvites: invite !== null,
+    hasPendingInvites: invite !== null || transferOffer !== null,
   };
 }
 

--- a/src/server/services/blocks/app-collaborator.service.ts
+++ b/src/server/services/blocks/app-collaborator.service.ts
@@ -6,6 +6,7 @@ import { dbRead, dbWrite } from '~/server/db/client';
 import {
   ACCEPTED,
   listingKindSupports,
+  resolveCanonicalListingOwner,
   resolveListingAccess,
   type ListingKind,
 } from '~/server/services/blocks/app-access.service';
@@ -212,11 +213,19 @@ function toSeatListing(row: RawSeatListing, wasShadow: boolean): SeatListing {
     kind: row.kind as ListingKind,
     appBlockId: row.appBlockId,
     blockSlug: row.appBlock?.blockId ?? null,
-    // 🔴 ONSITE OWNERSHIP IS CANONICALLY THE OauthClient's. `AppListing.userId` is a
-    // denormalized copy there; for OFFSITE it IS the owner (a connect client is a
-    // linked credential, never the owner). Falling back to the column also covers an
-    // onsite listing whose block has a dangling `app_id`.
-    ownerUserId: row.appBlock?.app?.userId ?? row.userId,
+    // 🔴 KIND-AWARE, through the SHARED resolver — not a second spelling of it. This used
+    // to be written here as `row.appBlock?.app?.userId ?? row.userId`, i.e. BLOCK-FIRST,
+    // which is wrong on an OFFSITE listing that carries a block (issue #3844): the block
+    // names the previous owner after `claimListing`/`acceptTransfer`, so this gate —
+    // `assertOwner`, i.e. seat MANAGEMENT — would let an impersonator a moderator had
+    // just dispossessed keep inviting and removing collaborators on the rightful owner's
+    // listing. `row` is always the PARENT (loadSeatListing hops a shadow first), so the
+    // column passed here is the canonical one and not a frozen clone.
+    ownerUserId: resolveCanonicalListingOwner({
+      kind: row.kind,
+      blockOwnerUserId: row.appBlock?.app?.userId,
+      listingUserId: row.userId,
+    }),
     wasShadow,
   };
 }

--- a/src/server/services/blocks/app-listing-assets.service.ts
+++ b/src/server/services/blocks/app-listing-assets.service.ts
@@ -339,7 +339,9 @@ export { nsfwLevelFromContentRating };
  * collaborator fallback. It is SHADOW-AWARE (a shadow revision carries `appBlockId: null`, so both the seat and
  * the canonical owner are resolved via its parent; without that an editor would lose
  * access to their own in-flight revision the moment their first media edit minted it)
- * and it is KIND-AWARE about ownership (`appBlock.app.userId ?? listing.userId`).
+ * and it is KIND-AWARE about ownership: `OauthClient.userId` via the block for `onsite`,
+ * the listing's own column for `offsite` — where the block, if one is attached, must NOT
+ * override it (issue #3844).
  *
  * 🔴 THIS IS THE ONLY OWNERSHIP GATE ON THE ASSET PATH. `resolveOwnerScreenshotTarget`
  * used to run a second, denormalized-column copy of it one line before calling this;
@@ -415,8 +417,9 @@ async function loadOwnedListing(
  * Extracted so every gate in this file asks the question the SAME way
  * (`resolveListingAccess` is the single predicate; this is a thin read of it) and so the
  * seam has one name to mock in tests. It answers BOTH halves: the canonical owner
- * (kind-aware — `appBlock.app.userId ?? listing.userId`, never the denormalized column
- * alone) and the ACCEPTED seat, in one call.
+ * (kind-aware — the BLOCK's `OauthClient.userId` for an onsite listing, the listing's own
+ * column for an offsite one even when it carries a block) and the ACCEPTED seat, in one
+ * call.
  *
  * `db` defaults to the replica and MUST be passed on by any caller that itself received
  * a pool override — see the note at the `loadOwnedListing` call site.

--- a/src/server/services/blocks/app-ownership-transfer.service.ts
+++ b/src/server/services/blocks/app-ownership-transfer.service.ts
@@ -183,7 +183,25 @@ async function loadOwnedListing(appListingId: string, actorUserId: number): Prom
       'Ownership is transferred on the live listing, not on a revision draft'
     );
   }
-  const ownerUserId = row.appBlock?.app?.userId ?? row.userId;
+  // 🔴 KIND-AWARE, through the SHARED resolver — see `app-access.service
+  // ::resolveCanonicalListingOwner`. This was written here as `row.appBlock?.app?.userId
+  // ?? row.userId` (BLOCK-FIRST), which on an OFFSITE listing that carries a block named
+  // the PREVIOUS owner after `claimListing` / an offsite `acceptTransfer`, both of which
+  // move only the column. The consequence at THIS gate is the sharpest in the feature: an
+  // impersonator a moderator had just dispossessed could still INITIATE A TRANSFER of the
+  // listing and hand it straight back out — the very outcome `claimListing`'s in-tx
+  // pending-transfer cancellation exists to prevent. Dynamic import: this module is
+  // reached from `app-access.service`'s orbit and the helper is pure, but the file's
+  // existing discipline for cross-service reach is a deferred import (see
+  // `getPendingTransfer`), so it is kept.
+  const { resolveCanonicalListingOwner } = await import(
+    '~/server/services/blocks/app-access.service'
+  );
+  const ownerUserId = resolveCanonicalListingOwner({
+    kind: row.kind,
+    blockOwnerUserId: row.appBlock?.app?.userId,
+    listingUserId: row.userId,
+  });
   if (ownerUserId !== actorUserId) {
     throw new AppCollaboratorError('NOT_OWNER', 'Only the app owner can transfer ownership');
   }

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -851,8 +851,10 @@ const editableListingSelect = {
  * copy of the owner for an ON-SITE listing — the canonical owner is the backing
  * `AppBlock.app.userId`. Comparing against the copy inverts the gate in BOTH directions
  * on a drifted row: it refuses the real owner and admits whoever the stale row names.
- * `resolveListingAccess` resolves the owner from the block, hops a shadow revision to its
- * parent, and answers the seat question in the same call.
+ * `resolveListingAccess` resolves the owner KIND-AWARE (the block's `OauthClient.userId`
+ * for an onsite listing; the PARENT listing's own column for an offsite one, even when it
+ * carries a block — issue #3844), hops a shadow revision to its parent, and answers the
+ * seat question in the same call.
  *
  * 🔴 WHERE THE DRIFT ACTUALLY COMES FROM — a SHADOW REVISION, and this is worth stating
  * precisely because an earlier version of this comment named the wrong mechanism and


### PR DESCRIPTION
Fixes #3844.

## The defect

`resolveListingAccess` resolved the owner as:

```ts
const ownerUserId =
  (listing.revisionOfId ? parent?.appBlock?.app?.userId : listing.appBlock?.app?.userId) ??
  listing.userId;
```

Block-first with a column fallback, and **no branch on `kind`**. Its own doc comment
called it kind-aware, and that read as true only because an ordinary off-site listing has
no `AppBlock`, so the `??` fallback was the only branch anyone ever reached.

`mapAppBlockToListing` mints `kind:'offsite'` **with** a non-null `appBlockId` for any
`AppBlock` carrying an `externalUrl`. On that shape the **block** decided ownership — even
though for an off-site listing there is no `OauthClient` in the ownership chain and
`AppListing.userId` *is* the owner. Meanwhile both off-site ownership writers move only
that column and leave the block naming whoever it named before:

- `app-ownership-transfer.service::acceptTransfer` — its step (2) `OauthClient` move is
  `if (isOnsite)`-guarded, so the off-site path writes `AppListing.userId` alone;
- `offsite-moderation.service::claimListing` — the **impersonation remedy** (report →
  delist → claim → ban), which refuses a non-`offsite` listing outright.

The consequence, stated at its sharpest: **an impersonator would retain edit access after
a moderator claimed the listing away from them**, while the rightful owner was refused. A
two-sided inversion — a fix that only granted would be half a fix.

PR #3840 consolidated five ownership gates onto this resolver. Before that they compared
against `AppListing.userId` directly and were therefore *correct* on this shape; the
consolidation is what introduced the inversion, and #3844 recorded it honestly rather than
describing it as neutral.

### A second, independent arm found while fixing this

`beginListingRevision` clones a shadow revision with `userId: parent.userId` and
`appBlockId: null`, and **neither ownership writer ever touches a shadow** — `claimListing`
and `acceptTransfer` both write `where: { id: <the parent> }`. For an on-site listing the
block covers that (which is what `app-access.denormalized-owner-drift.test.ts` already
pins). For an **off-site** listing the column is the answer, so reading the shadow's frozen
copy reproduced the identical inversion **with no block involved at all** — an ex-owner
keeps their old listing's in-flight revision draft.

This was derived from the code (the clone plus the two `where: { id }` writes), not
measured against production; the PR does not claim a row count for it.

## Blast radius: latent, not live

Measured against production on 2026-08-12, the block arm is not merely 0-row, it is
**unmintable**: `kind='offsite' AND app_block_id IS NOT NULL` → 0 rows; 0 of 22 `app_blocks`
carry an `external_url`; and no writer of that column exists anywhere in `src/server`
(every hit is a read, a projection, or a test fixture). So this closes a latent
authorization inversion before something can mint the shape. It is not a live exploit, and
it is not cosmetic.

## The fix

One kind branch, written once:

```ts
export function resolveCanonicalListingOwner(args: {
  kind: string;
  blockOwnerUserId: number | null | undefined;
  listingUserId: number;
}): number {
  if (args.kind === 'onsite') return args.blockOwnerUserId ?? args.listingUserId;
  return args.listingUserId;
}
```

plus `canonicalOwnerWhereBranches(userId)`, the same rule as a Prisma `OR` for the two set
reads that enumerate ownership without resolving row by row.

**Every ownership-resolution site now routes through them** (population and how it was
established, below):

1. `app-access.service::resolveListingAccess` — the primary predicate. It additionally
   resolves the **column from the PARENT** on a shadow hop, the same row it already takes
   `kind` and `appBlockId` from (that is the second arm above; `revisionOf.userId` is now
   selected).
2. `app-access.service::resolveAccessibleListingIds` — the "my apps" set.
3. `app-access.service::resolveAppsNavAccess` — the `/apps` sub-nav probe. It and (2) now
   share one function call rather than two copies of the branches, so the tab and the page
   it opens cannot disagree.
4. `app-collaborator.service::toSeatListing` — the write-side seat loader behind
   `assertOwner`. Block-first, a dispossessed impersonator could still invite and remove
   collaborators on the rightful owner's app.
5. `app-ownership-transfer.service::loadOwnedListing` — the transfer-initiation gate.
   Block-first, an ex-owner could **initiate a new transfer** and hand the listing straight
   back out — the exact outcome `claimListing`'s in-tx pending-transfer cancellation exists
   to prevent.

### What deliberately does not change

- **On-site precedence.** `OauthClient.userId` (via `AppBlock.app.userId`) stays canonical,
  with the denormalized column still the fallback for a block with a dangling `app_id`.
  There is an explicit test for a **stale** denormalized column that disagrees — the case a
  naive "just use `listing.userId`" fix would break.
- **The seat half.** Accepted seats still confer `editor`; pending/rejected still confer
  nothing.
- **Moderator bypasses.** Untouched on both sides of the D1 divergence.
- **`DENORM_OWNER_HOLDOUTS`** in `app-access.call-site-ledger.test.ts` is **unchanged** —
  none of its three entries moved. Widening `AccessDb` to a `TransactionClient` (what
  `loadOwnedListingInTx` would need) is explicitly out of scope.
- **No schema change**, no migration.

## Test coverage

New: `src/server/services/blocks/__tests__/app-access.kind-aware-owner.test.ts` — the
resolver, the pure helper, the shadow arm, a **seam test** that drives `claimListing` and
the resolver against one shared in-memory store (so the post-claim state is what the remedy
actually wrote, not a fixture asserting it), and set-vs-resolver agreement.

Extended: the five consolidated gates are driven end-to-end as a **table** in
`app-access.denormalized-owner-drift.test.ts`, in both directions, on both arms. That
file's `🔴 KNOWN REGRESSION … the BLOCK wins` pin is **inverted deliberately**, with the old
expectation and its reasoning preserved in the comment. Write-side loader cases added to
the collaborator and transfer suites; the `getNavSummary` predicate assertion updated from
two branches to three.

**43 of the added/changed assertions are red at `origin/main` and green at HEAD.** Every
new case asserts both the grant and the refusal; positive controls prove each fixture is
genuinely drifted, that the DB fake honours its where-clause (it can match *and* miss), and
that the independent OR-evaluator can return true, false, and **throws** on a predicate
shape it was not taught — so a silently rewritten predicate cannot read as "no rows".

Mutation-tested: 7 mutants (drop the kind branch, invert it, drop the offsite OR branch,
drop a branch's `kind` clause, read the shadow's column instead of the parent's, and revert
each write-side loader to block-first). All 7 die, each on a named test with a specific
message.

Full unit project: **16,263 passed / 17 skipped / 16,280 total across 1,030 files**,
identical population to the pre-change run. `pnpm typecheck` clean. Prettier clean.


---

# Second commit: the "Invites" sub-nav tab must see ownership offers too

Found while auditing the resolver in commit 1, and fixed here rather than left as a note.

`/apps/invites` renders **both** a pending seat invite and an inbound ownership-transfer
offer. The tab that routes there is gated on `getNavSummary`'s `hasPendingInvites`,
computed by `resolveAppsNavAccess` — and that predicate knew about **seat invites only**.
So a user who had been offered an app and held no seat invite got **no tab at all**: the
offer existed, the page rendered it, and nothing in the chrome ever pointed at the page.

`hasPendingInvites` now also probes `app_ownership_transfers`:

```ts
{ toUserId: userId, status: 'pending', expiresAt: { gt: now } }
```

- **`toUserId` is the ADDRESSEE.** An offer the caller *sent* can never light their own
  tab, and a third party's offer can never light anyone else's. Keying on `fromUserId` is
  the one-token version of that leak, and it has its own test.
- **`expiresAt: { gt: now }` is the half a naive `status: 'pending'` check gets wrong.**
  Expiry here is a **read-time predicate with no sweeper behind it** — the schema says so
  on the column and the migration repeats it — so a long-dead offer keeps
  `status = 'pending'` forever and the tab would latch on permanently for anyone who was
  ever offered an app. Strict `>` matches `app-ownership-transfer.service::isLive`
  exactly, so the tab and the page cannot disagree about the instant.
- **Narrowed on the indexed `(to_user_id, status)` pair**
  (`app_ownership_transfers_to_status_idx`), `select: { id: true }`, existence only.
- **Wrapped in `safeCollaboratorQuery`.** `app_ownership_transfers` is created by the *same*
  manual-apply migration as `app_collaborators`, whose own rollback note promises that
  dropping those tables returns deployed code to the 42P01 path — "inert-and-owner-only,
  NOT broken". An unwrapped read would break that promise by 500-ing every `/apps` page's
  chrome for the whole deploy window. A 42703 (half-applied schema) still propagates.

`hasEditableApps` is deliberately **not** widened: a pending offer confers zero capability
until accepted, the same consent principle as an unaccepted seat. Lighting "My apps" for an
offer would advertise a page every child query refuses. That has its own test, because the
cheapest wrong implementation — OR-ing the new probe into both booleans — passes every
"the tab appears" case and fails only there.

## Query cost — stated, not buried

This makes the nav summary **four** existence probes instead of three. They share the
existing `Promise.all`, so **added serial latency is zero**, but it is **one more
concurrent round trip (and one more pool slot) per `getNavSummary`**, which the `/apps`
chrome renders on every page load. It **cannot** be folded into an existing query: the four
probes hit three different tables (`app_listings`, `app_collaborators` ×2,
`app_ownership_transfers`), and unioning across them would mean hand-written SQL. The probe
itself is as cheap as it gets — one indexed `findFirst` selecting one column.

## Independence

This depends on **nothing outside `main`**. `app_ownership_transfers` is in the schema here
and is queried directly; nothing from the in-flight transfer-UI PR is imported.

## Coverage

New `app-access.nav-pending-invites.test.ts` (21 tests): the four-quadrant table
(transfer-only / seat-only / both / neither), the expiry boundary asserted on **both** sides
of a strict `>`, an expired offer not suppressing a live seat invite, the default-`now`
path proving the injected clock is an affordance and not the only wired path, the leak
direction in both forms, all four terminal statuses with a positive control on the loop,
the zero-capability rule, the 42P01 degrade, the 42703 propagation, and the structural
narrowing. Plus two router-level cases in `blocks.router.getNavSummary.test.ts`.

**11 of these are red at the previous branch tip** (`acf7b6375c` — not merely at
`origin/main`) and green after. Two cases are labelled in-file as invariant guards rather
than counted as regression coverage: seat-invite-only and both-kinds pass on either side of
the change, and exist to keep the widening from *replacing* the seat arm.

**5 mutants, all killed**, each on a named test with its own message: drop the transfer arm;
drop the expiry bound; key on `fromUserId`; OR the offer into `hasEditableApps`; unwrap the
42P01 degrade.

Full unit project after both commits: **16,290 passed / 17 skipped / 16,307 total across
1,032 files**, 0 failures. `pnpm typecheck` 0 errors. Prettier clean. `test:lint-rules`
220/220.
