### PR TITLE
feat(apps): wire app-listing ownership transfer, incl. the missing recipient inbox

### DIFF
--- a/src/components/Apps/AppCollaboratorsPanel.tsx
+++ b/src/components/Apps/AppCollaboratorsPanel.tsx
@@ -1,6 +1,11 @@
+import { useState } from 'react';
+
 import { QuickSearchDropdown } from '~/components/Search/QuickSearchDropdown';
 import type { SearchIndexDataMap } from '~/components/Search/search.utils2';
-import type { CollaboratorRosterRow } from '~/components/Apps/AppCollaboratorsPanelView';
+import type {
+  CollaboratorRosterRow,
+  PendingTransferRow,
+} from '~/components/Apps/AppCollaboratorsPanelView';
 import {
   AppCollaboratorsPanelView,
   inviteBlockedReason,
@@ -13,8 +18,15 @@ import { showErrorNotification, showSuccessNotification } from '~/utils/notifica
 import { trpc } from '~/utils/trpc';
 
 /**
- * Data container. Owns the four `appCollaborators.*` calls this surface wires:
- * `list`, `invite`, `remove`, `setDisplayed` and `leave`.
+ * Data container. Owns the `appCollaborators.*` calls this surface wires: `list`,
+ * `invite`, `remove`, `setDisplayed`, `leave`, plus the OWNER half of ownership transfer
+ * (`getPendingTransfer`, `initiateTransfer`, `cancelTransfer`).
+ *
+ * 🔴 THE TRANSFER READ IS OWNER-ONLY AT THE CALL SITE, not merely hidden in the View.
+ * `getPendingTransfer` returns `null` to anyone who is neither the owner nor the
+ * addressee — deliberately, so it cannot be used as an existence oracle — so an editor's
+ * query would be a guaranteed-useless round trip on every render of the tab. `enabled`
+ * keeps it from being issued at all.
  */
 export function AppCollaboratorsPanel({
   appListingId,
@@ -64,8 +76,41 @@ export function AppCollaboratorsPanel({
     onError,
   });
 
+  const isOwner = role === 'owner';
+  const transferQuery = trpc.appCollaborators.getPendingTransfer.useQuery(
+    { appListingId },
+    { retry: false, enabled: isOwner }
+  );
+  const invalidateTransfer = () => {
+    void utils.appCollaborators.getPendingTransfer.invalidate({ appListingId });
+  };
+  // 🔴 The refusal is held in STATE and rendered inline by the View, instead of being
+  // thrown at a toast. The connect-client refusal names a concrete remedy ("unlink the
+  // OAuth client first"); a transient toast is exactly where an actionable message goes
+  // to die, and the owner is left with a control that fails every time.
+  const [transferErrorMessage, setTransferErrorMessage] = useState<string | null>(null);
+  const initiateTransfer = trpc.appCollaborators.initiateTransfer.useMutation({
+    onSuccess: () => {
+      setTransferErrorMessage(null);
+      showSuccessNotification({
+        message: 'Ownership offer sent. Nothing moves until they accept it.',
+      });
+      invalidateTransfer();
+    },
+    onError: (error) => setTransferErrorMessage(error.message ?? 'Something went wrong.'),
+  });
+  const cancelTransfer = trpc.appCollaborators.cancelTransfer.useMutation({
+    onSuccess: () => {
+      setTransferErrorMessage(null);
+      showSuccessNotification({ message: 'Ownership offer withdrawn.' });
+      invalidateTransfer();
+    },
+    onError: (error) => setTransferErrorMessage(error.message ?? 'Something went wrong.'),
+  });
+
   const rows = (listQuery.data ?? []) as CollaboratorRosterRow[];
   const busy = invite.isPending || remove.isPending || setDisplayed.isPending || leave.isPending;
+  const transferBusy = initiateTransfer.isPending || cancelTransfer.isPending;
 
   return (
     <AppCollaboratorsPanelView
@@ -112,6 +157,33 @@ export function AppCollaboratorsPanel({
         setDisplayed.mutate({ appListingId, displayed, targetUserId })
       }
       onLeave={() => leave.mutate({ appListingId })}
+      pendingTransfer={(transferQuery.data ?? null) as PendingTransferRow | null}
+      transferErrorMessage={transferErrorMessage}
+      transferBusy={transferBusy}
+      onCancelTransfer={(transferId) => cancelTransfer.mutate({ transferId })}
+      transferPicker={
+        <QuickSearchDropdown
+          disableInitialSearch
+          supportedIndexes={['users']}
+          startingIndex="users"
+          showIndexSelect={false}
+          dropdownItemLimit={25}
+          disabled={transferBusy}
+          placeholder="Search for the person who should own this app"
+          onItemSelected={(_entity, item) => {
+            const selected = item as SearchIndexDataMap['users'][number];
+            setTransferErrorMessage(null);
+            initiateTransfer.mutate({ appListingId, toUserId: selected.id });
+          }}
+          // The current owner cannot be the recipient — the service refuses it with
+          // "You already own this app", and the DB carries a `from <> to` CHECK.
+          filters={[currentUser?.id]
+            .filter((id): id is number => !!id)
+            .map((id) => `AND NOT id=${id}`)
+            .join(' ')
+            .slice(4)}
+        />
+      }
     />
   );
 }

--- a/src/components/Apps/AppCollaboratorsPanelView.browser.test.tsx
+++ b/src/components/Apps/AppCollaboratorsPanelView.browser.test.tsx
@@ -10,6 +10,7 @@ import {
   pickerExcludedUserIds,
 } from '~/components/Apps/AppCollaboratorsPanelView';
 import { capabilitiesForKind } from '~/shared/constants/app-capabilities.constants';
+import { CONNECT_CLIENT_TRANSFER_REFUSAL } from '~/shared/constants/app-transfer.constants';
 
 /**
  * The collaborator roster panel, driven props-only (the container's tRPC + search-stack
@@ -396,5 +397,200 @@ describe('inviteBlockedReason / pickerExcludedUserIds', () => {
       const hidden = pickerExcludedUserIds(rows).includes(row.userId);
       expect(blocked, `disagreement on user ${row.userId}`).toBe(hidden);
     }
+  });
+});
+
+/**
+ * 🔴 OWNERSHIP TRANSFER — THE OWNER HALF of the Collaborators tab.
+ *
+ * The product rule this pins: a COLLABORATOR cannot transfer the app. The panel says so
+ * in its own disclosure ("Collaborators cannot invite or remove anyone, and cannot
+ * transfer the app"), the service refuses an editor at `loadOwnedListing` with NOT_OWNER,
+ * and this is where the promise and the control are checked against each other.
+ */
+describe('AppCollaboratorsPanelView — ownership transfer (owner half)', () => {
+  test('an OWNER gets the transfer section, its warning, and the recipient picker', async () => {
+    renderWithProviders(
+      <AppCollaboratorsPanelView
+        role="owner"
+        capabilities={ONSITE}
+        rows={[]}
+        viewerUserId={OWNER_ID}
+        transferPicker={<div data-testid="stub-transfer-picker" />}
+      />
+    );
+    await expect.element(page.getByTestId('apps-transfer-owner-section')).toBeInTheDocument();
+    await expect
+      .element(page.getByTestId('apps-transfer-owner-disclosure'))
+      .toHaveTextContent(/no longer the owner/i);
+    await expect.element(page.getByTestId('stub-transfer-picker')).toBeInTheDocument();
+  });
+
+  /**
+   * 🔴 ABSENCE, WITH AN AWAITED POSITIVE CONTROL FIRST. `locator.elements()` is
+   * SYNCHRONOUS: an emptiness asserted before React commits passes whatever the component
+   * renders. The editor notice is the branch this render MUST produce, so awaiting it
+   * proves the tree is committed before anything is claimed to be missing.
+   */
+  test('🔴 an EDITOR gets NO transfer section, NO picker and NO cancel control', async () => {
+    renderWithProviders(
+      <AppCollaboratorsPanelView
+        role="editor"
+        capabilities={ONSITE}
+        rows={[seat({ userId: EDITOR_ID })]}
+        viewerUserId={EDITOR_ID}
+        transferPicker={<div data-testid="stub-transfer-picker" />}
+        pendingTransfer={{ id: 'aot_1', toUserId: 99, expiresAt: new Date() }}
+        onCancelTransfer={() => undefined}
+      />
+    );
+    await expect.element(page.getByTestId('apps-collaborators-editor-notice')).toBeInTheDocument();
+    expect(page.getByTestId('apps-transfer-owner-section').elements()).toHaveLength(0);
+    expect(page.getByTestId('stub-transfer-picker').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-transfer-pending').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-transfer-cancel').elements()).toHaveLength(0);
+  });
+
+  /**
+   * 🔴 POSITIVE CONTROL FOR THE ZEROES ABOVE. Identical props, `role="owner"` — every one
+   * of those testids appears. Without this, the four zeroes are indistinguishable from
+   * testids that never render for anyone.
+   */
+  test('🔴 POSITIVE CONTROL: the same props with role="owner" DO render all four', async () => {
+    renderWithProviders(
+      <AppCollaboratorsPanelView
+        role="owner"
+        capabilities={ONSITE}
+        rows={[seat({ userId: EDITOR_ID })]}
+        viewerUserId={OWNER_ID}
+        transferPicker={<div data-testid="stub-transfer-picker" />}
+        pendingTransfer={{ id: 'aot_1', toUserId: 99, expiresAt: new Date() }}
+        onCancelTransfer={() => undefined}
+      />
+    );
+    await expect.element(page.getByTestId('apps-transfer-owner-section')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-transfer-pending')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-transfer-cancel')).toBeInTheDocument();
+  });
+
+  /**
+   * 🔴 ONE LIVE OFFER PER LISTING is a partial-unique index in the database, so a second
+   * initiate loses on P2002. Rendering the picker beside a pending offer would be
+   * rendering an action that cannot succeed.
+   */
+  test('a PENDING offer replaces the picker with the offer and a Cancel control', async () => {
+    renderWithProviders(
+      <AppCollaboratorsPanelView
+        role="owner"
+        capabilities={ONSITE}
+        rows={[]}
+        viewerUserId={OWNER_ID}
+        transferPicker={<div data-testid="stub-transfer-picker" />}
+        pendingTransfer={{ id: 'aot_1', toUserId: 42, expiresAt: new Date() }}
+        onCancelTransfer={() => undefined}
+        renderUser={(id) => <span data-testid={`stub-user-${id}`}>user {id}</span>}
+      />
+    );
+    // Awaited PRESENT element first, then the absence.
+    await expect.element(page.getByTestId('apps-transfer-pending')).toBeInTheDocument();
+    await expect.element(page.getByTestId('stub-user-42')).toBeInTheDocument();
+    expect(page.getByTestId('stub-transfer-picker').elements()).toHaveLength(0);
+  });
+
+  test('Cancel reports the pending offer’s id', async () => {
+    const cancelled: string[] = [];
+    renderWithProviders(
+      <AppCollaboratorsPanelView
+        role="owner"
+        capabilities={ONSITE}
+        rows={[]}
+        viewerUserId={OWNER_ID}
+        pendingTransfer={{ id: 'aot_specific', toUserId: 42, expiresAt: new Date() }}
+        onCancelTransfer={(id) => cancelled.push(id)}
+      />
+    );
+    const cancel = page.getByTestId('apps-transfer-cancel');
+    await expect.element(cancel).toBeInTheDocument();
+    await userEvent.click(cancel.element());
+    expect(cancelled).toEqual(['aot_specific']);
+  });
+
+  test('the Cancel control is disabled while a transfer mutation is in flight', async () => {
+    renderWithProviders(
+      <AppCollaboratorsPanelView
+        role="owner"
+        capabilities={ONSITE}
+        rows={[]}
+        viewerUserId={OWNER_ID}
+        pendingTransfer={{ id: 'aot_1', toUserId: 42, expiresAt: new Date() }}
+        onCancelTransfer={() => undefined}
+        transferBusy
+      />
+    );
+    await expect.element(page.getByTestId('apps-transfer-cancel')).toBeDisabled();
+  });
+
+  /**
+   * 🔴 THE CONNECT-CLIENT REFUSAL, RENDERED WITH ITS REASON.
+   *
+   * A connect-linked off-site listing is refused at initiate AND again in-transaction at
+   * accept, with a message that names a concrete remedy: unlink the OAuth client first.
+   * Collapsing that into a generic "something went wrong" leaves the owner with a control
+   * that fails forever and no way to learn why — so the message is asserted VERBATIM
+   * against the server's own exported constant rather than against a paraphrase.
+   */
+  test('🔴 a refusal renders inline, with the server’s reason intact', async () => {
+    renderWithProviders(
+      <AppCollaboratorsPanelView
+        role="owner"
+        capabilities={OFFSITE}
+        rows={[]}
+        viewerUserId={OWNER_ID}
+        transferPicker={<div data-testid="stub-transfer-picker" />}
+        transferErrorMessage={CONNECT_CLIENT_TRANSFER_REFUSAL}
+      />
+    );
+    const error = page.getByTestId('apps-transfer-owner-error');
+    await expect.element(error).toBeInTheDocument();
+    await expect.element(error).toHaveTextContent(/linked to an OAuth application/i);
+    await expect.element(error).toHaveTextContent(/Unlink the OAuth client first/i);
+    // 🔴 The message the SERVER will send, character for character — a paraphrase here
+    // would let the copy drift out from under the assertion.
+    await expect.element(error).toHaveTextContent(CONNECT_CLIENT_TRANSFER_REFUSAL);
+  });
+
+  test('no refusal ⇒ no error panel (awaited control first)', async () => {
+    renderWithProviders(
+      <AppCollaboratorsPanelView
+        role="owner"
+        capabilities={ONSITE}
+        rows={[]}
+        viewerUserId={OWNER_ID}
+        transferPicker={<div data-testid="stub-transfer-picker" />}
+      />
+    );
+    await expect.element(page.getByTestId('apps-transfer-owner-section')).toBeInTheDocument();
+    expect(page.getByTestId('apps-transfer-owner-error').elements()).toHaveLength(0);
+  });
+
+  /**
+   * The disclosure two sections up PROMISES that a collaborator cannot transfer the app.
+   * This pins the promise and the control together — a panel that grew a transfer control
+   * for editors would contradict its own copy.
+   */
+  test('the invite disclosure’s promise and the transfer control agree', async () => {
+    renderWithProviders(
+      <AppCollaboratorsPanelView
+        role="owner"
+        capabilities={ONSITE}
+        rows={[]}
+        viewerUserId={OWNER_ID}
+        transferPicker={<div data-testid="stub-transfer-picker" />}
+      />
+    );
+    await expect
+      .element(page.getByTestId('apps-collaborators-invite-disclosure'))
+      .toHaveTextContent(/cannot transfer the app/i);
+    await expect.element(page.getByTestId('apps-transfer-owner-section')).toBeInTheDocument();
   });
 });

--- a/src/components/Apps/AppCollaboratorsPanelView.tsx
+++ b/src/components/Apps/AppCollaboratorsPanelView.tsx
@@ -70,6 +70,32 @@ export type AppCollaboratorsPanelViewProps = {
   busy?: boolean;
   /** Identity renderer. Defaults to a plain id label so the View needs no data layer. */
   renderUser?: (userId: number) => ReactNode;
+
+  // ---------------------------------------------------------------------------
+  // OWNERSHIP TRANSFER — owner-only. See {@link OwnerTransferSection}.
+  // ---------------------------------------------------------------------------
+  /** The live outgoing offer on this listing, or null. */
+  pendingTransfer?: PendingTransferRow | null;
+  /**
+   * 🔴 The REASON the last transfer attempt was refused, rendered inline.
+   *
+   * A connect-linked off-site listing is refused with a specific, actionable message
+   * ("unlink the OAuth client first"). Collapsing that into a generic "something went
+   * wrong" toast would leave the owner with an action that fails forever and no way to
+   * learn why, so the message is surfaced where the control is.
+   */
+  transferErrorMessage?: string | null;
+  /** The recipient picker. Injected, like `userPicker`, to keep the search stack out. */
+  transferPicker?: ReactNode;
+  onCancelTransfer?: (transferId: string) => void;
+  transferBusy?: boolean;
+};
+
+/** The live outgoing offer, as `appCollaborators.getPendingTransfer` returns it. */
+export type PendingTransferRow = {
+  id: string;
+  toUserId: number;
+  expiresAt: Date | string;
 };
 
 /**
@@ -135,6 +161,105 @@ function statusBadge(status: string) {
   return <Badge color="gray">Declined</Badge>;
 }
 
+/**
+ * 🔴 OWNERSHIP TRANSFER — THE OWNER HALF, and it renders for the OWNER ONLY.
+ *
+ * `initiateTransfer` and `cancelTransfer` are owner-gated in the service
+ * (`loadOwnedListing` → NOT_OWNER; `cancelTransfer` → "you are not party to this
+ * transfer"), and the collaborator disclosure two sections up promises in so many words
+ * that "collaborators cannot invite or remove anyone, and cannot transfer the app".
+ * Rendering the control for an editor would both contradict that promise and offer a
+ * button that is guaranteed to 403.
+ *
+ * Extracted as its own component so the owner/editor split is ONE condition at ONE call
+ * site rather than a `isOwner &&` repeated across five controls.
+ */
+function OwnerTransferSection({
+  pendingTransfer,
+  transferErrorMessage,
+  transferPicker,
+  onCancelTransfer,
+  transferBusy,
+  renderUser,
+}: {
+  pendingTransfer: PendingTransferRow | null;
+  transferErrorMessage: string | null;
+  transferPicker?: ReactNode;
+  onCancelTransfer?: (transferId: string) => void;
+  transferBusy: boolean;
+  renderUser: (userId: number) => ReactNode;
+}) {
+  return (
+    <Stack gap="sm" data-testid="apps-transfer-owner-section">
+      <Title order={4}>Transfer ownership</Title>
+      <Alert
+        color="red"
+        variant="light"
+        icon={<IconAlertTriangle size={16} />}
+        title="Transferring hands the whole app to someone else"
+        data-testid="apps-transfer-owner-disclosure"
+      >
+        <Stack gap={4}>
+          <Text size="sm">
+            Once they accept, you are no longer the owner: you lose editing, submitting and every
+            other owner control. Buzz you have already earned stays with you.
+          </Text>
+          <Text size="sm">Nothing moves until the person you choose accepts.</Text>
+        </Stack>
+      </Alert>
+
+      {/* 🔴 THE REFUSAL, WITH ITS REASON. See `transferErrorMessage`. */}
+      {transferErrorMessage ? (
+        <Alert
+          color="red"
+          variant="filled"
+          icon={<IconAlertTriangle size={16} />}
+          title="Ownership cannot be transferred"
+          data-testid="apps-transfer-owner-error"
+        >
+          {transferErrorMessage}
+        </Alert>
+      ) : null}
+
+      {pendingTransfer ? (
+        <Paper withBorder p="sm" radius="md" data-testid="apps-transfer-pending">
+          <Group justify="space-between" wrap="wrap" gap="sm">
+            <Group gap="xs">
+              <Badge color="orange">Transfer pending</Badge>
+              <Text size="sm">Offered to</Text>
+              {renderUser(pendingTransfer.toUserId)}
+            </Group>
+            {onCancelTransfer ? (
+              <Button
+                size="xs"
+                variant="light"
+                color="red"
+                disabled={transferBusy}
+                data-testid="apps-transfer-cancel"
+                onClick={() => onCancelTransfer(pendingTransfer.id)}
+              >
+                Cancel transfer
+              </Button>
+            ) : null}
+          </Group>
+        </Paper>
+      ) : (
+        /* 🔴 The picker and the pending card are MUTUALLY EXCLUSIVE. One live offer per
+           listing is a partial-unique index in the database, so a second initiate would
+           lose on P2002 — offering the control while an offer is open would render an
+           action that cannot succeed. */
+        <Stack gap="xs">
+          {transferPicker}
+          <Text size="xs" c="dimmed">
+            One transfer offer at a time. It expires after{' '}
+            {constants.appCollaborators.transferExpiryDays} days if it is not accepted.
+          </Text>
+        </Stack>
+      )}
+    </Stack>
+  );
+}
+
 export function AppCollaboratorsPanelView({
   role,
   capabilities,
@@ -148,6 +273,11 @@ export function AppCollaboratorsPanelView({
   onLeave,
   busy = false,
   renderUser,
+  pendingTransfer = null,
+  transferErrorMessage = null,
+  transferPicker,
+  onCancelTransfer,
+  transferBusy = false,
 }: AppCollaboratorsPanelViewProps) {
   const isOwner = role === 'owner';
   const identity = renderUser ?? ((userId: number) => <Text fw={500}>User #{userId}</Text>);
@@ -306,6 +436,17 @@ export function AppCollaboratorsPanelView({
             </Group>
           ) : null}
         </Stack>
+      ) : null}
+
+      {isOwner ? (
+        <OwnerTransferSection
+          pendingTransfer={pendingTransfer}
+          transferErrorMessage={transferErrorMessage}
+          transferPicker={transferPicker}
+          onCancelTransfer={onCancelTransfer}
+          transferBusy={transferBusy}
+          renderUser={identity}
+        />
       ) : null}
 
       {!isOwner ? (

--- a/src/components/Apps/AppTransferOffers.tsx
+++ b/src/components/Apps/AppTransferOffers.tsx
@@ -1,0 +1,75 @@
+import type { IncomingTransferRow } from '~/components/Apps/AppTransferOffersView';
+import {
+  AppTransferOffersView,
+  invalidationsForTransferResponse,
+} from '~/components/Apps/AppTransferOffersView';
+import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
+import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
+import { trpc } from '~/utils/trpc';
+
+/**
+ * Data container for the recipient's ownership-offer inbox.
+ *
+ * Wires three of the four transfer procs: `listMyPendingTransfers` (the read that made
+ * the feature reachable), `acceptTransfer`, and `cancelTransfer` — the last one is how a
+ * recipient DECLINES, since either party may cancel a pending offer and both land on the
+ * same terminal state.
+ */
+export function AppTransferOffers() {
+  const utils = trpc.useUtils();
+  const transfersQuery = trpc.appCollaborators.listMyPendingTransfers.useQuery(undefined, {
+    retry: false,
+  });
+
+  // 🔴 DRIVEN FROM the exported list rather than a parallel copy of it — a pure function
+  // that merely DESCRIBES what the callback does is a declaration, not a code path.
+  const invalidate = (accept: boolean) => {
+    const invalidators = {
+      'appCollaborators.listMyPendingTransfers': () =>
+        utils.appCollaborators.listMyPendingTransfers.invalidate(),
+      'appListings.listMine': () => utils.appListings.listMine.invalidate(),
+      'blocks.getNavSummary': () => utils.blocks.getNavSummary.invalidate(),
+    } as const;
+    for (const key of invalidationsForTransferResponse(accept)) void invalidators[key]();
+  };
+
+  const onError = (error: { message?: string }) =>
+    showErrorNotification({
+      title: 'App ownership transfer',
+      error: new Error(error.message ?? 'Something went wrong.'),
+    });
+
+  const accept = trpc.appCollaborators.acceptTransfer.useMutation({
+    onSuccess: () => {
+      showSuccessNotification({ message: 'Ownership accepted — the app is now yours.' });
+      invalidate(true);
+    },
+    onError,
+  });
+  const decline = trpc.appCollaborators.cancelTransfer.useMutation({
+    onSuccess: () => {
+      showSuccessNotification({ message: 'Ownership offer declined.' });
+      invalidate(false);
+    },
+    onError,
+  });
+
+  const busyTransferId = accept.isPending
+    ? accept.variables?.transferId ?? null
+    : decline.isPending
+    ? decline.variables?.transferId ?? null
+    : null;
+
+  return (
+    <AppTransferOffersView
+      transfers={(transfersQuery.data ?? []) as IncomingTransferRow[]}
+      isLoading={transfersQuery.isLoading}
+      errorMessage={transfersQuery.error?.message ?? null}
+      busyTransferId={busyTransferId}
+      onRespond={(transferId, isAccept) =>
+        isAccept ? accept.mutate({ transferId }) : decline.mutate({ transferId })
+      }
+      renderOfferer={(userId) => <UserAvatar userId={userId} withUsername size="xs" />}
+    />
+  );
+}

--- a/src/components/Apps/AppTransferOffersView.browser.test.tsx
+++ b/src/components/Apps/AppTransferOffersView.browser.test.tsx
@@ -1,0 +1,259 @@
+import { describe, expect, test } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import type { PendingInviteRow } from '~/components/Apps/AppInvitesBody';
+import { AppInvitesBodyView } from '~/components/Apps/AppInvitesBody';
+import type { IncomingTransferRow } from '~/components/Apps/AppTransferOffersView';
+import {
+  AppTransferOffersView,
+  formatTransferExpiry,
+  invalidationsForTransferResponse,
+  transferDisclosureItems,
+} from '~/components/Apps/AppTransferOffersView';
+
+/**
+ * `/apps/invites` — the OWNERSHIP-OFFER half of the inbox. Props-only view; no tRPC.
+ */
+
+function offer(over: Partial<IncomingTransferRow> & { transferId: string }): IncomingTransferRow {
+  return {
+    appListingId: `apl-${over.transferId}`,
+    slug: `slug-${over.transferId}`,
+    name: `Name ${over.transferId}`,
+    kind: 'onsite',
+    appBlockId: 'ab_1',
+    iconUrl: null,
+    fromUserId: 10,
+    expiresAt: new Date('2026-08-17T12:00:00Z'),
+    createdAt: new Date('2026-08-10T12:00:00Z'),
+    ...over,
+  };
+}
+
+function invite(over: Partial<PendingInviteRow> & { appListingId: string }): PendingInviteRow {
+  return {
+    slug: `slug-${over.appListingId}`,
+    kind: 'onsite',
+    appBlockId: 'ab_1',
+    invitedBy: 10,
+    createdAt: new Date('2026-08-01T00:00:00Z'),
+    ...over,
+  };
+}
+
+describe('AppTransferOffersView', () => {
+  test('renders one card per live offer, named by the listing', async () => {
+    renderWithProviders(
+      <AppTransferOffersView
+        transfers={[
+          offer({ transferId: 'aot_1', name: 'Shiny Thing' }),
+          offer({ transferId: 'aot_2', name: 'Other Thing' }),
+        ]}
+      />
+    );
+    await expect.element(page.getByTestId('apps-transfer-aot_1')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-transfer-aot_2')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-transfer-aot_1')).toHaveTextContent('Shiny Thing');
+  });
+
+  /**
+   * 🔴 THE DISTINCTION FROM A SEAT INVITE, asserted on the RENDERED OUTPUT of BOTH
+   * components in ONE tree — which is the only place the claim can be settled. Each view
+   * tested alone can look perfectly distinct and still render as two identical cards
+   * beside each other, because "distinct" is a property of the PAIR.
+   */
+  test('🔴 an ownership offer reads differently from a seat invite on the same page', async () => {
+    renderWithProviders(
+      <div>
+        <AppTransferOffersView transfers={[offer({ transferId: 'aot_1' })]} />
+        <AppInvitesBodyView invites={[invite({ appListingId: 'apl_1' })]} />
+      </div>
+    );
+    // Both are present — this is the combined state, not one component in isolation.
+    await expect.element(page.getByTestId('apps-transfer-aot_1')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-invite-apl_1')).toBeInTheDocument();
+
+    // 1. Its own titled section, which the seat inbox does not sit inside.
+    await expect
+      .element(page.getByTestId('apps-transfers-section'))
+      .toHaveTextContent(/Ownership transfers/i);
+    // 2. A badge that says what it is.
+    await expect
+      .element(page.getByTestId('apps-transfer-badge-aot_1'))
+      .toHaveTextContent(/Ownership transfer/i);
+    // 3. A warning naming the consequence, which the invite's disclosure does not carry.
+    await expect
+      .element(page.getByTestId('apps-transfer-warning-aot_1'))
+      .toHaveTextContent(/current owner loses ownership/i);
+    await expect
+      .element(page.getByTestId('apps-invite-disclosure-apl_1'))
+      .not.toHaveTextContent(/loses ownership/i);
+    // 4. Different button copy — "Accept ownership", not "Accept".
+    await expect
+      .element(page.getByTestId('apps-transfer-accept-aot_1'))
+      .toHaveTextContent(/Accept ownership/i);
+    await expect
+      .element(page.getByTestId('apps-invite-accept-apl_1'))
+      .toHaveTextContent(/^Accept$/);
+  });
+
+  test('the warning names the irreversible half BEFORE the button', async () => {
+    renderWithProviders(<AppTransferOffersView transfers={[offer({ transferId: 'aot_1' })]} />);
+    const warning = page.getByTestId('apps-transfer-warning-aot_1');
+    await expect.element(warning).toHaveTextContent(/current owner loses ownership/i);
+    await expect.element(warning).toHaveTextContent(/collaborators keep their seats/i);
+    await expect.element(page.getByTestId('apps-transfer-accept-aot_1')).toBeInTheDocument();
+  });
+
+  /**
+   * 🔴 THE MONEY LINE. Buzz accrued before the transfer stays with the OLD owner — the
+   * service deliberately never rewrites `BlockBuzzAttribution.appOwnerUserId`. A
+   * recipient who is not told that will read a zeroed earnings page as a bug.
+   */
+  test('an ON-SITE offer says prior Buzz stays with the previous owner', async () => {
+    renderWithProviders(<AppTransferOffersView transfers={[offer({ transferId: 'aot_1' })]} />);
+    await expect
+      .element(page.getByTestId('apps-transfer-warning-aot_1'))
+      .toHaveTextContent(/stays with the previous owner/i);
+  });
+
+  test('an OFF-SITE offer promises no repo and no earnings, which cannot exist for it', async () => {
+    renderWithProviders(
+      <AppTransferOffersView
+        transfers={[offer({ transferId: 'aot_off', kind: 'offsite', appBlockId: null })]}
+      />
+    );
+    const warning = page.getByTestId('apps-transfer-warning-aot_off');
+    await expect.element(warning).toBeInTheDocument();
+    await expect.element(warning).not.toHaveTextContent(/repository/i);
+    await expect.element(warning).not.toHaveTextContent(/Buzz/i);
+    // …and it still says the owner-losing part, which is kind-independent.
+    await expect.element(warning).toHaveTextContent(/loses ownership/i);
+  });
+
+  test('Accept and Decline report the right transfer and the right verdict', async () => {
+    const calls: Array<[string, boolean]> = [];
+    renderWithProviders(
+      <AppTransferOffersView
+        transfers={[offer({ transferId: 'aot_1' }), offer({ transferId: 'aot_2' })]}
+        onRespond={(id, accept) => calls.push([id, accept])}
+      />
+    );
+    const accept2 = page.getByTestId('apps-transfer-accept-aot_2');
+    await expect.element(accept2).toBeInTheDocument();
+    await userEvent.click(accept2.element());
+    await userEvent.click(page.getByTestId('apps-transfer-decline-aot_1').element());
+    expect(calls).toEqual([
+      ['aot_2', true],
+      ['aot_1', false],
+    ]);
+  });
+
+  test('the in-flight offer is disabled; the others stay clickable', async () => {
+    const calls: string[] = [];
+    renderWithProviders(
+      <AppTransferOffersView
+        transfers={[offer({ transferId: 'aot_1' }), offer({ transferId: 'aot_2' })]}
+        busyTransferId="aot_1"
+        onRespond={(id) => calls.push(id)}
+      />
+    );
+    await expect.element(page.getByTestId('apps-transfer-accept-aot_1')).toBeDisabled();
+    await expect.element(page.getByTestId('apps-transfer-accept-aot_2')).not.toBeDisabled();
+    await userEvent.click(page.getByTestId('apps-transfer-accept-aot_2').element());
+    expect(calls).toEqual(['aot_2']);
+  });
+
+  test('the deadline is shown, so an offer that is about to lapse is visible', async () => {
+    renderWithProviders(
+      <AppTransferOffersView
+        transfers={[offer({ transferId: 'aot_1', expiresAt: new Date('2026-08-17T12:00:00Z') })]}
+      />
+    );
+    await expect
+      .element(page.getByTestId('apps-transfer-expiry-aot_1'))
+      .toHaveTextContent('Aug 17, 2026');
+  });
+
+  /**
+   * 🔴 ABSENCE, WITH A POSITIVE CONTROL FIRST. `locator.elements()` is SYNCHRONOUS, so an
+   * emptiness asserted straight after `render` passes whatever the component does. The
+   * seat inbox beside it is the awaited proof that React has committed.
+   */
+  test('🔴 renders NOTHING when there are no offers — the seat inbox is untouched', async () => {
+    renderWithProviders(
+      <div>
+        <AppTransferOffersView transfers={[]} />
+        <AppInvitesBodyView invites={[invite({ appListingId: 'apl_1' })]} />
+      </div>
+    );
+    await expect.element(page.getByTestId('apps-invite-apl_1')).toBeInTheDocument();
+    expect(page.getByTestId('apps-transfers-section').elements()).toHaveLength(0);
+  });
+
+  test('🔴 renders NOTHING while loading, rather than an empty state that then flips', async () => {
+    renderWithProviders(
+      <div>
+        <AppTransferOffersView transfers={[offer({ transferId: 'aot_1' })]} isLoading />
+        <AppInvitesBodyView invites={[invite({ appListingId: 'apl_1' })]} />
+      </div>
+    );
+    await expect.element(page.getByTestId('apps-invite-apl_1')).toBeInTheDocument();
+    expect(page.getByTestId('apps-transfers-section').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-transfer-aot_1').elements()).toHaveLength(0);
+  });
+
+  /** A failed read is NOT an empty inbox — saying "no offers" would be a false negative. */
+  test('an error renders the error, not silence', async () => {
+    renderWithProviders(<AppTransferOffersView transfers={[]} errorMessage="Nope." />);
+    await expect.element(page.getByTestId('apps-transfers-error')).toHaveTextContent('Nope.');
+  });
+
+  test('the offering user is rendered through the injected identity slot', async () => {
+    renderWithProviders(
+      <AppTransferOffersView
+        transfers={[offer({ transferId: 'aot_1', fromUserId: 77 })]}
+        renderOfferer={(id) => <span data-testid={`stub-user-${id}`}>user {id}</span>}
+      />
+    );
+    await expect.element(page.getByTestId('stub-user-77')).toBeInTheDocument();
+  });
+});
+
+describe('transferDisclosureItems / formatTransferExpiry / invalidations', () => {
+  test('the on-site list names the repo and the Buzz cut-off; the off-site one does not', () => {
+    const onsite = transferDisclosureItems('onsite');
+    const offsite = transferDisclosureItems('offsite');
+    expect(onsite.some((i) => /repository/i.test(i))).toBe(true);
+    expect(onsite.some((i) => /Buzz/i.test(i))).toBe(true);
+    expect(offsite.some((i) => /repository/i.test(i))).toBe(false);
+    expect(offsite.some((i) => /Buzz/i.test(i))).toBe(false);
+    // Both still state the two kind-independent facts.
+    for (const items of [onsite, offsite]) {
+      expect(items.some((i) => /become the owner/i.test(i))).toBe(true);
+      expect(items.some((i) => /loses ownership/i.test(i))).toBe(true);
+    }
+  });
+
+  test('the expiry formatter is timezone-pinned and survives a string', () => {
+    expect(formatTransferExpiry(new Date('2026-08-17T12:00:00Z'))).toBe('Aug 17, 2026');
+    expect(formatTransferExpiry('2026-08-17T12:00:00Z')).toBe('Aug 17, 2026');
+    expect(formatTransferExpiry('not a date')).toBe('soon');
+  });
+
+  /**
+   * 🔴 PINNED AS EQUAL rather than pinned once and assumed: DECLINING is the case that can
+   * take the offer count to zero, so an invalidation set gated on `accept` would leave a
+   * nav entry pointing at an empty page.
+   */
+  test('accept and decline invalidate exactly the same keys', () => {
+    expect(invalidationsForTransferResponse(true)).toEqual(invalidationsForTransferResponse(false));
+    expect(invalidationsForTransferResponse(true)).toEqual([
+      'appCollaborators.listMyPendingTransfers',
+      'appListings.listMine',
+      'blocks.getNavSummary',
+    ]);
+  });
+});

--- a/src/components/Apps/AppTransferOffersView.tsx
+++ b/src/components/Apps/AppTransferOffersView.tsx
@@ -1,0 +1,240 @@
+import { Alert, Badge, Button, Group, List, Paper, Stack, Text, Title } from '@mantine/core';
+import { IconAlertTriangle, IconArrowsExchange } from '@tabler/icons-react';
+import type { ReactNode } from 'react';
+
+import type { ListingKind } from '~/shared/constants/app-capabilities.constants';
+import { capabilitiesForKind } from '~/shared/constants/app-capabilities.constants';
+
+/**
+ * `/apps/invites` — the OWNERSHIP-OFFER half of the inbox.
+ *
+ * 🔴 A SEPARATE COMPONENT, RENDERED ABOVE THE SEAT INVITES, because the two are not the
+ * same size of decision and must not read as the same row in a list. A seat invite adds
+ * an editor; an ownership transfer moves the app OUT of one account and INTO another,
+ * and the person who currently owns it loses every capability on it the instant the
+ * offer is accepted. Presenting both as generic "invitation" cards would make the
+ * irreversible one a one-click sibling of the reversible one.
+ *
+ * The distinction is carried by three things a test can assert, not by tone:
+ *   - its own heading and section testid (`apps-transfers-section`);
+ *   - a RED warning panel naming what accepting does (`apps-transfer-warning-<id>`);
+ *   - a button that says "Accept ownership", not "Accept".
+ *
+ * 🔴 PROPS-ONLY, no tRPC — same split as `AppCollaboratorsPanelView`, so every branch is
+ * directly renderable in a component test.
+ */
+
+export type IncomingTransferRow = {
+  transferId: string;
+  appListingId: string;
+  slug: string;
+  name: string;
+  kind: ListingKind;
+  appBlockId: string | null;
+  iconUrl: string | null;
+  fromUserId: number;
+  expiresAt: Date | string;
+  createdAt: Date | string;
+};
+
+export type AppTransferOffersViewProps = {
+  transfers: IncomingTransferRow[];
+  isLoading?: boolean;
+  /** Set when the read failed. An empty inbox and an unknown inbox are NOT the same. */
+  errorMessage?: string | null;
+  /** The transfer id currently in flight, if any. */
+  busyTransferId?: string | null;
+  onRespond?: (transferId: string, accept: boolean) => void;
+  /** Renders the offering user. Injected so this View keeps no data-layer dependency. */
+  renderOfferer?: (userId: number) => ReactNode;
+};
+
+/**
+ * What accepting an ownership offer actually does, kind-aware.
+ *
+ * 🔴 DERIVED FROM THE SAME CAPABILITY ROW the collaborator disclosure uses, so the two
+ * cannot drift into promising an off-site recipient a repo or an earnings page that
+ * cannot exist for a listing with no AppBlock.
+ */
+export function transferDisclosureItems(kind: ListingKind): string[] {
+  const capabilities = capabilitiesForKind(kind);
+  const items = [
+    'You become the owner of this app’s store listing.',
+    'The current owner loses ownership, including the ability to edit, submit or transfer it.',
+  ];
+  if (capabilities.submitVersion) {
+    items.push('You take over the app’s code repository and can ship new versions.');
+  }
+  if (capabilities.earnings) {
+    items.push(
+      'Buzz earned BEFORE the transfer stays with the previous owner — you start from zero.'
+    );
+  }
+  items.push('Existing collaborators keep their seats.');
+  return items;
+}
+
+/** Human date for the offer deadline. Fixed locale so a test can pin the string. */
+export function formatTransferExpiry(expiresAt: Date | string): string {
+  const d = expiresAt instanceof Date ? expiresAt : new Date(expiresAt);
+  if (Number.isNaN(d.getTime())) return 'soon';
+  return d.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
+export function AppTransferOffersView({
+  transfers,
+  isLoading = false,
+  errorMessage = null,
+  busyTransferId = null,
+  onRespond,
+  renderOfferer,
+}: AppTransferOffersViewProps) {
+  const offerer =
+    renderOfferer ??
+    ((userId: number) => (
+      <Text size="xs" c="dimmed">
+        user #{userId}
+      </Text>
+    ));
+
+  if (errorMessage) {
+    return (
+      <Alert
+        color="red"
+        variant="light"
+        icon={<IconAlertTriangle size={16} />}
+        data-testid="apps-transfers-error"
+      >
+        {errorMessage}
+      </Alert>
+    );
+  }
+  // 🔴 NOTHING is rendered while loading, and NOTHING is rendered when there are no
+  // offers. Deliberately unlike the seat inbox, which shows "you have no pending
+  // invitations": an empty-state for a surface that is empty for virtually every user,
+  // sitting above the surface they actually came for, is noise. The absence of the
+  // section IS the empty state.
+  if (isLoading || transfers.length === 0) return null;
+
+  return (
+    <Stack gap="md" data-testid="apps-transfers-section">
+      <Title order={4}>Ownership transfers</Title>
+      {transfers.map((transfer) => {
+        const busy = busyTransferId === transfer.transferId;
+        return (
+          <Paper
+            key={transfer.transferId}
+            withBorder
+            p="md"
+            radius="md"
+            data-testid={`apps-transfer-${transfer.transferId}`}
+          >
+            <Stack gap="sm">
+              <Group justify="space-between" wrap="wrap" gap="xs">
+                <Group gap="xs">
+                  <Text fw={600}>{transfer.name || transfer.slug}</Text>
+                  <Badge
+                    color="red"
+                    variant="filled"
+                    leftSection={<IconArrowsExchange size={12} />}
+                    data-testid={`apps-transfer-badge-${transfer.transferId}`}
+                  >
+                    Ownership transfer
+                  </Badge>
+                  <Badge variant="light" color={transfer.kind === 'onsite' ? 'blue' : 'grape'}>
+                    {transfer.kind === 'onsite' ? 'On-site app' : 'External app'}
+                  </Badge>
+                </Group>
+                <Group
+                  gap={4}
+                  wrap="nowrap"
+                  data-testid={`apps-transfer-offerer-${transfer.transferId}`}
+                >
+                  <Text size="xs" c="dimmed">
+                    Offered by
+                  </Text>
+                  {offerer(transfer.fromUserId)}
+                </Group>
+              </Group>
+
+              {/* 🔴 RED, not the seat invite's yellow, and it names the consequences
+                  BEFORE the button rather than after the click. */}
+              <Alert
+                color="red"
+                variant="light"
+                icon={<IconAlertTriangle size={16} />}
+                title="Accepting this transfers the whole app to you"
+                data-testid={`apps-transfer-warning-${transfer.transferId}`}
+              >
+                <List size="sm" spacing={2}>
+                  {transferDisclosureItems(transfer.kind).map((item) => (
+                    <List.Item key={item}>{item}</List.Item>
+                  ))}
+                </List>
+              </Alert>
+
+              <Text
+                size="xs"
+                c="dimmed"
+                data-testid={`apps-transfer-expiry-${transfer.transferId}`}
+              >
+                This offer expires on {formatTransferExpiry(transfer.expiresAt)}.
+              </Text>
+
+              <Group gap="xs">
+                <Button
+                  size="xs"
+                  color="red"
+                  disabled={busy}
+                  loading={busy}
+                  data-testid={`apps-transfer-accept-${transfer.transferId}`}
+                  onClick={() => onRespond?.(transfer.transferId, true)}
+                >
+                  Accept ownership
+                </Button>
+                <Button
+                  size="xs"
+                  variant="light"
+                  disabled={busy}
+                  data-testid={`apps-transfer-decline-${transfer.transferId}`}
+                  onClick={() => onRespond?.(transfer.transferId, false)}
+                >
+                  Decline
+                </Button>
+              </Group>
+            </Stack>
+          </Paper>
+        );
+      })}
+    </Stack>
+  );
+}
+
+/**
+ * What a settled transfer response must invalidate. PURE and exported for the same
+ * reason `invalidationsForInviteResponse` is: the bug lives in the mutation callback, and
+ * a callback is not testable without a tRPC client.
+ *
+ * 🔴 IDENTICAL ON BOTH VERDICTS, and `accept` stays a parameter so a test can pin the two
+ * as EQUAL rather than pin one and assume the other. `appListings.listMine` matters on
+ * ACCEPT (a whole app arrives); the inbox and the nav counts matter on BOTH, because
+ * DECLINING is the case that can take the offer count to zero.
+ */
+export type TransferInvalidationKey =
+  | 'appCollaborators.listMyPendingTransfers'
+  | 'appListings.listMine'
+  | 'blocks.getNavSummary';
+
+export function invalidationsForTransferResponse(accept: boolean): TransferInvalidationKey[] {
+  void accept;
+  return [
+    'appCollaborators.listMyPendingTransfers',
+    'appListings.listMine',
+    'blocks.getNavSummary',
+  ];
+}

--- a/src/pages/apps/invites.tsx
+++ b/src/pages/apps/invites.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 
 import { AppInvitesBody } from '~/components/Apps/AppInvitesBody';
 import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
+import { AppTransferOffers } from '~/components/Apps/AppTransferOffers';
 import { APPS_PAGE_WIDTHS } from '~/components/Apps/appsPageWidths';
 import { Meta } from '~/components/Meta/Meta';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
@@ -45,9 +46,15 @@ export default function AppInvitesPage() {
       <AppsPageLayout
         size={APPS_PAGE_WIDTHS['/apps/invites']}
         title="App invitations"
-        subtitle="Invitations to collaborate on someone else's app."
+        subtitle="Invitations to collaborate on someone else's app, and offers to take one over."
       >
         <Stack gap="md">
+          {/* 🔴 OWNERSHIP OFFERS FIRST, and in their own titled section. An offer to take
+              over an app is a materially bigger decision than a seat invitation — the
+              previous owner loses the app — so it must not read as another row in the
+              same list. The section renders nothing at all when there are no offers, so
+              the ordinary invitee sees exactly what they saw before. */}
+          <AppTransferOffers />
           <AppInvitesBody />
           <Text size="sm" c="dimmed">
             Once you accept, the app appears in <Link href="/apps/mine">My apps</Link>.

--- a/src/server/notifications/__tests__/app-collaborator.notifications.test.ts
+++ b/src/server/notifications/__tests__/app-collaborator.notifications.test.ts
@@ -95,3 +95,48 @@ describe('the other collaborator notifications still point at the APP', () => {
     expect(msg('app-collaborator-accepted', OFFSITE).url).toBe('/apps');
   });
 });
+
+/**
+ * 🔴 THE OWNERSHIP-OFFER NOTIFICATION MUST POINT AT THE INBOX, for exactly the reason the
+ * invite one does — and it did not.
+ *
+ * It pointed at `appUrl(details)`, i.e. `/apps/<appBlockId>` or `/apps`. Neither has an
+ * Accept control on it, and the first one REFUSES the recipient outright: a pending
+ * ownership offer confers no role, so `/apps/<appBlockId>` resolves their access, finds
+ * none, and 404s them. A notification that says "accept it to take over" pointing at a
+ * page with nothing to accept on it is the whole feature's only entry point, aimed at a
+ * dead end. `/apps/invites` is where the offer is now rendered and actionable.
+ */
+describe('🔴 the ownership-transfer OFFER points at the inbox where it can be accepted', () => {
+  it('links to /apps/invites for an ON-SITE listing', () => {
+    expect(msg('app-ownership-transfer-offered', ONSITE).url).toBe('/apps/invites');
+  });
+
+  it('…and for an OFF-SITE listing, which has no app-block route at all', () => {
+    expect(msg('app-ownership-transfer-offered', OFFSITE).url).toBe('/apps/invites');
+  });
+
+  it('the target does not vary with the app — it is the recipient’s own inbox', () => {
+    const a = msg('app-ownership-transfer-offered', ONSITE).url;
+    const b = msg('app-ownership-transfer-offered', {
+      ...ONSITE,
+      appBlockId: 'ab_totally_other',
+    }).url;
+    expect(a).toBe(b);
+    expect(a).not.toContain('ab_1');
+  });
+
+  it('still names the app in the MESSAGE, so the offer is identifiable', () => {
+    expect(msg('app-ownership-transfer-offered', ONSITE).message).toContain('My App');
+  });
+
+  /**
+   * CONTROL, mirroring the invite one: the ACCEPTED notification goes to the OLD owner,
+   * who no longer has an offer to answer — so it must NOT be redirected to the inbox.
+   */
+  it('the ACCEPTED notification still points at the app, not the inbox', () => {
+    const { url } = msg('app-ownership-transfer-accepted', ONSITE);
+    expect(url).not.toBe('/apps/invites');
+    expect(url).toContain('ab_1');
+  });
+});

--- a/src/server/notifications/app-collaborator.notifications.ts
+++ b/src/server/notifications/app-collaborator.notifications.ts
@@ -117,7 +117,14 @@ export const appCollaboratorNotifications = createNotificationProcessor({
       const details = notification.details as AppCollaboratorNotificationDetails;
       return {
         message: `You were offered ownership of ${appLabel(details)}. Accept it to take over.`,
-        url: appUrl(details),
+        // 🔴 THE INBOX, not the app page — the same target `app-collaborator-invited`
+        // uses, and for the same reason. A pending offer confers NO role on the
+        // recipient, so `/apps/<appBlockId>` resolves their access, finds none and
+        // refuses; and an OFF-SITE listing has no such page at all, so `appUrl` fell
+        // back to `/apps`, which has no accept control on it either. Pointing a
+        // "accept it to take over" message at a page with no Accept button on it made
+        // the notification unactionable in every case.
+        url: APP_INVITES_URL,
       };
     },
   },

--- a/src/server/routers/__tests__/app-collaborators.client-seam.test.ts
+++ b/src/server/routers/__tests__/app-collaborators.client-seam.test.ts
@@ -8,8 +8,8 @@ import { stripCommentsAndStrings } from '../../../../test/strip-comments';
 
 /**
  * 🔴 THE PROC↔CLIENT SEAM. Every `appCollaborators.*` procedure must have at least one
- * CALLER in the app, except the four ownership-TRANSFER procs, which are deliberately
- * deferred to a follow-up PR.
+ * CALLER in the app. {@link DEFERRED_PROCS} is now EMPTY — the four ownership-transfer
+ * procs it used to hold were wired by the follow-up PR, and their entries were deleted.
  *
  * ## Why this guard exists, stated as the failure it caught
  *
@@ -50,17 +50,37 @@ const ROUTER_FILE = 'src/server/routers/app-collaborators.router.ts';
 const ROUTER_EXPORT = 'appCollaboratorsRouter';
 
 /**
- * 🔴 THE DEFERRED SET — the four ownership-TRANSFER procs, out of scope for the
- * collaborator-UI PR and wired by its follow-up.
+ * 🔴 THE DEFERRED SET — procs knowingly shipped without a client. **EMPTY.**
+ *
+ * It held the four ownership-TRANSFER procs while the collaborator-UI PR shipped without
+ * them. The follow-up PR wired them and DELETED the four entries, which is the event
+ * {@link TRANSFER_PROCS} below asserts on.
  *
  * DELETE an entry from this list when its proc gets a client. Do NOT widen it, and do NOT
  * replace it with a pattern.
  */
-const DEFERRED_PROCS = [
+const DEFERRED_PROCS = [] as const;
+
+/**
+ * 🔴 THE DELETION LEDGER — the entries that had to leave {@link DEFERRED_PROCS}.
+ *
+ * This is the assertion the file's own predecessor recommended, and it exists because the
+ * "every DEFERRED proc still has ZERO clients" test below is now VACUOUS: it iterates an
+ * empty list, so it passes whatever anyone does to the transfer procs. Naming them here
+ * moves the guard from "no deferred proc is wired" (unfalsifiable once the list empties)
+ * to "THESE FIVE procs are not deferred AND each has a client" — which fails in both
+ * directions: re-adding an entry, and deleting the last caller of one.
+ *
+ * 🔴 IT DOES NOT DEPEND ON `PROC_REFERENCE_RE`'s FAIL-OPEN DIRECTION. The membership half
+ * is a plain list comparison the scanner cannot influence at all, so even a scanner that
+ * missed every call still fails this test the moment a proc is re-deferred.
+ */
+const TRANSFER_PROCS = [
   'initiateTransfer',
   'acceptTransfer',
   'cancelTransfer',
   'getPendingTransfer',
+  'listMyPendingTransfers',
 ] as const;
 
 /**
@@ -122,24 +142,44 @@ function readDeclaredProcs(): string[] {
  * turn this guard RED. Red is the direction someone looks at; a regex loose enough to
  * count prose is not.
  *
- * 🔴 BUT IT IS FAIL-OPEN FOR THE OPPOSITE DIRECTION — the `DEFERRED_PROCS` "must have ZERO
- * clients" assertion — AND THAT MATTERS FOR PR2, WHICH WIRES TRANSFER.
+ * 🔴 IT USED TO BE FAIL-OPEN FOR THE OPPOSITE DIRECTION — the `DEFERRED_PROCS` "must have
+ * ZERO clients" assertion. A proc reached through a shape a single receiver-anchored regex
+ * does not recognise (`const { initiateTransfer } = trpc.appCollaborators;`, or an aliased
+ * `const u = trpc.useUtils(); u.appCollaborators.…`) was NOT counted, so that check kept
+ * passing while the proc was in fact wired.
  *
- * A transfer proc reached through a shape this regex does not recognise —
- * `const { initiateTransfer } = trpc.appCollaborators;`, or an aliased
- * `const u = trpc.useUtils(); u.appCollaborators.…` — would NOT be counted, so the
- * deferred-set check would keep passing while the proc was in fact wired. The old bare
- * `\bappCollaborators\.(\w+)` was STRICTER here (it would have caught the destructured
- * receiver), and the trade was made knowingly: that regex also counted comments, strings
- * and `constants.appCollaborators.*`, which is how `getAppEarnings` shipped "wired".
+ * BOTH remedies its predecessor named were taken, because they cover different failures:
+ *   - the scanner now recognises the two extra receiver shapes (below), so a wired proc
+ *     is COUNTED however it was reached; and
+ *   - the deferred set is asserted by DELETION (`TRANSFER_PROCS`), which does not depend
+ *     on the scanner at all — a list comparison cannot be fooled by a receiver shape
+ *     nobody anticipated, and receiver shapes are open-ended.
  *
- * Left as-is DELIBERATELY, because the fix belongs with the work it protects: PR2 should
- * either widen `PROC_REFERENCE_RE` to recognise the destructured/aliased shapes, or —
- * better — assert on the DELETION of the `DEFERRED_PROCS` entries themselves, which is
- * the event that PR actually performs. Do not assume this guard will notice transfer
- * being wired behind an unusual receiver.
+ * The old bare `\bappCollaborators\.(\w+)` is still NOT the answer: it counted comments,
+ * strings and `constants.appCollaborators.*` (the config bag), which is how
+ * `getAppEarnings` shipped "wired". Each shape below is anchored on a receiver that can
+ * only be the tRPC client.
  */
 const PROC_REFERENCE_RE = /\b(?:trpc|utils)\.appCollaborators\.([A-Za-z_$][\w$]*)/g;
+
+/**
+ * SHAPE 2 — a DESTRUCTURED receiver: `const { initiateTransfer, list } = trpc.appCollaborators;`
+ * The names come from the brace group; `foo: bar` and `foo = fallback` are reduced to the
+ * KEY, which is the proc name (the local binding is irrelevant to the seam).
+ */
+const DESTRUCTURED_RECEIVER_RE = /\{([^{}]*)\}\s*=\s*(?:trpc|utils)\.appCollaborators\b/g;
+
+/**
+ * SHAPE 3 — an ALIASED utils binding: `const u = trpc.useUtils(); u.appCollaborators.…`.
+ *
+ * 🔴 The alias is DISCOVERED from the file, never guessed: only an identifier this file
+ * actually assigns from `trpc.useUtils()` / `trpc.useContext()` is treated as a receiver.
+ * Accepting an arbitrary `<ident>.appCollaborators.<name>` would re-admit
+ * `constants.appCollaborators.transferExpiryDays`, which is the exact false positive the
+ * receiver anchor exists to exclude.
+ */
+const UTILS_ALIAS_RE =
+  /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*trpc\.(?:useUtils|useContext)\(\)/g;
 
 /**
  * `appCollaborators.<proc>` CALL SITES in `text`.
@@ -152,7 +192,25 @@ const PROC_REFERENCE_RE = /\b(?:trpc|utils)\.appCollaborators\.([A-Za-z_$][\w$]*
  * surface. A guard a COMMENT can satisfy is not a guard.
  */
 export function findCollaboratorProcReferences(text: string): string[] {
-  return [...stripCommentsAndStrings(text).matchAll(PROC_REFERENCE_RE)].map((m) => m[1]);
+  const code = stripCommentsAndStrings(text);
+  const found: string[] = [];
+
+  for (const m of code.matchAll(PROC_REFERENCE_RE)) found.push(m[1]);
+
+  for (const m of code.matchAll(DESTRUCTURED_RECEIVER_RE)) {
+    for (const part of m[1].split(',')) {
+      // `foo`, `foo: local`, `foo = fallback`, `foo: local = fallback` → `foo`.
+      const key = part.split(/[:=]/)[0].trim();
+      if (/^[A-Za-z_$][\w$]*$/.test(key)) found.push(key);
+    }
+  }
+
+  for (const alias of new Set([...code.matchAll(UTILS_ALIAS_RE)].map((m) => m[1]))) {
+    const aliasRe = new RegExp(`\\b${alias}\\.appCollaborators\\.([A-Za-z_$][\\w$]*)`, 'g');
+    for (const m of code.matchAll(aliasRe)) found.push(m[1]);
+  }
+
+  return found;
 }
 
 function walk(dir: string, out: string[] = []): string[] {
@@ -203,6 +261,57 @@ describe('appCollaborators proc↔client seam', () => {
     ).toEqual(['listMyPendingInvites']);
     // …and does NOT match a different router with a similar name.
     expect(findCollaboratorProcReferences('trpc.appListings.list.useQuery()')).toEqual([]);
+  });
+
+  /**
+   * 🔴 THE BYPASS THIS SCANNER USED TO WAVE THROUGH, now a control.
+   *
+   * Each of these is a REAL way to call a proc that the receiver-anchored regex alone did
+   * not see, which made the `DEFERRED_PROCS` "zero clients" assertion fail-OPEN: a
+   * transfer proc could be fully wired behind one of them and the guard would stay green.
+   * Written as an expectation of the SPECIFIC proc name so a scanner that returned
+   * everything (or nothing) fails.
+   */
+  describe('🔴 the scanner sees the receiver shapes that used to bypass it', () => {
+    it('a DESTRUCTURED receiver counts as a client', () => {
+      expect(
+        findCollaboratorProcReferences('const { initiateTransfer } = trpc.appCollaborators;')
+      ).toEqual(['initiateTransfer']);
+    });
+
+    it('…including several at once, renamed, and off `utils`', () => {
+      expect(
+        findCollaboratorProcReferences(
+          'const { acceptTransfer, cancelTransfer: cancel } = utils.appCollaborators;'
+        )
+      ).toEqual(['acceptTransfer', 'cancelTransfer']);
+    });
+
+    it('an ALIASED useUtils() binding counts as a client', () => {
+      expect(
+        findCollaboratorProcReferences(
+          'const u = trpc.useUtils();\nvoid u.appCollaborators.getPendingTransfer.invalidate();'
+        )
+      ).toEqual(['getPendingTransfer']);
+    });
+
+    /**
+     * 🔴 NEGATIVE CONTROL ON THE WIDENING, and it is the reason the alias is discovered
+     * rather than assumed. `constants.appCollaborators.transferExpiryDays` is a
+     * `<ident>.appCollaborators.<name>` too — accepting any identifier as a receiver would
+     * have re-created the exact false positive that shipped `getAppEarnings` as "wired".
+     */
+    it('an identifier that is NOT bound to trpc.useUtils() is still not a receiver', () => {
+      expect(
+        findCollaboratorProcReferences(
+          'const days = constants.appCollaborators.transferExpiryDays;'
+        )
+      ).toEqual([]);
+      // …and a destructure off something that is not the tRPC client is not one either.
+      expect(
+        findCollaboratorProcReferences('const { maxCollaborators } = constants.appCollaborators;')
+      ).toEqual([]);
+    });
   });
 
   /**
@@ -296,5 +405,39 @@ describe('appCollaborators proc↔client seam', () => {
           `(delete the entry — do not widen the list into a pattern).`
       ).toEqual([]);
     }
+  });
+
+  /**
+   * 🔴 THE DELETION ASSERTION. The test above is VACUOUS now that `DEFERRED_PROCS` is
+   * empty — it iterates nothing — so it can no longer notice anything about transfer. This
+   * one names the procs directly and fails in both directions: re-adding an entry to the
+   * deferred list, and dropping the last caller of any of them.
+   */
+  describe('🔴 ownership transfer is WIRED — the deferred entries were deleted', () => {
+    it('none of the transfer procs is deferred any more', () => {
+      for (const proc of TRANSFER_PROCS) {
+        expect(
+          DEFERRED_PROCS as readonly string[],
+          `${proc} is back in DEFERRED_PROCS. Ownership transfer has a UI — a proc it uses ` +
+            `may not be excused from the client-seam check.`
+        ).not.toContain(proc);
+      }
+      // POSITIVE CONTROL on this assertion's own instrument: the list really is empty, so
+      // "not contained" is a fact about the list rather than about a typo in a name.
+      expect(DEFERRED_PROCS).toEqual([]);
+    });
+
+    it('every transfer proc is DECLARED on the router', () => {
+      for (const proc of TRANSFER_PROCS) expect(declared).toContain(proc);
+    });
+
+    it('every transfer proc has at least one CLIENT', () => {
+      const unwired = TRANSFER_PROCS.filter((proc) => (clients.get(proc)?.length ?? 0) === 0);
+      expect(
+        unwired,
+        `These ownership-transfer procs have ZERO clients. The transfer UI is the thing ` +
+          `that makes them reachable; if it was removed, re-defer them explicitly.`
+      ).toEqual([]);
+    });
   });
 });

--- a/src/server/routers/app-collaborators.router.ts
+++ b/src/server/routers/app-collaborators.router.ts
@@ -231,6 +231,30 @@ export const appCollaboratorsRouter = router({
       return run(() => listMyPendingInvites(ctx.user!.id));
     }),
 
+  /**
+   * The caller's own live ownership OFFERS (the same inbox surface).
+   *
+   * 🔴 KEYED ON THE RECIPIENT, which is what makes the transfer feature reachable at
+   * all. `getPendingTransfer` is keyed per LISTING, so it can only answer a question the
+   * recipient is unable to ask: a pending offer confers no role, so they cannot resolve
+   * the listing and, in the ordinary case, do not know it exists.
+   *
+   * Gated like its sibling `listMyPendingInvites` — `protectedProcedure +
+   * enforceAppBlocksAuthorFlag`, NOT `appDeveloperProcedure`. Being offered your FIRST
+   * app is precisely the case where "do you already own an app" is the wrong gate.
+   *
+   * Scoped to `ctx.user.id` in the SERVICE signature, so there is no id on the wire that
+   * a caller could point at somebody else's inbox.
+   */
+  listMyPendingTransfers: protectedProcedure
+    .use(enforceAppBlocksAuthorFlag)
+    .query(async ({ ctx }) => {
+      const { listMyPendingTransfers } = await import(
+        '~/server/services/blocks/app-ownership-transfer.service'
+      );
+      return run(() => listMyPendingTransfers(ctx.user!.id));
+    }),
+
   // -------------------------------------------------------------------------
   // READ.
   // -------------------------------------------------------------------------

--- a/src/server/services/blocks/__tests__/app-access.call-site-ledger.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.call-site-ledger.test.ts
@@ -229,6 +229,15 @@ const KIND_CAPABILITY_LEDGER: Record<string, string> = {
     'off-site one must promise NEITHER, because no BlockBuzzAttribution row can exist and ' +
     'there is no repo. Reading the table rather than hard-coding the copy is what keeps ' +
     'the invitee’s disclosure identical to the owner’s at invite time.',
+  'src/components/Apps/AppTransferOffersView.tsx':
+    'CONSUMES the row to build the RECIPIENT-side ownership-transfer disclosure, for the ' +
+    'same reason AppInvitesBody does and with the same two cells doing the work: an ' +
+    'on-site offer says the recipient takes over the repo (`submitVersion`) and that Buzz ' +
+    'accrued BEFORE the transfer stays with the previous owner (`earnings`); an off-site ' +
+    'offer must promise NEITHER, because there is no repo and no BlockBuzzAttribution row ' +
+    'can exist for a listing with no AppBlock. Reading the table rather than hard-coding ' +
+    'the copy is what stops the transfer disclosure and the invite disclosure drifting ' +
+    'into two different accounts of what an off-site listing can do.',
   'src/server/services/blocks/app-access.service.ts':
     'RE-EXPORTS the table and resolves each listing’s kind + appBlockId, and is where ' +
     'every server consumer still reaches it (CAPABILITIES_BY_KIND / capabilitiesForKind / ' +
@@ -654,9 +663,7 @@ describe('app-ownership gate ledger', () => {
         ['nested member, optional', 'if (shot.appListing?.userId !== user.id) throw e;'],
       ];
       for (const [label, sample] of REMOVED) {
-        expect(DENORM_OWNER_RE.test(sample), `DENORM_OWNER_RE must recognise: ${label}`).toBe(
-          true
-        );
+        expect(DENORM_OWNER_RE.test(sample), `DENORM_OWNER_RE must recognise: ${label}`).toBe(true);
       }
     });
 
@@ -694,9 +701,9 @@ describe('app-ownership gate ledger', () => {
     it('NEGATIVE CONTROL: it does not match the canonical resolution or an unrelated owner', () => {
       // The replacement must NOT itself count as a member of the class, or the assertion
       // below could never go green; and an Image/Post owner check is a different subject.
-      expect(DENORM_OWNER_RE.test('const role = await resolveListingRole(listingId, userId);')).toBe(
-        false
-      );
+      expect(
+        DENORM_OWNER_RE.test('const role = await resolveListingRole(listingId, userId);')
+      ).toBe(false);
       expect(
         DENORM_OWNER_RE.test('const ownerUserId = row.appBlock?.app?.userId ?? row.userId;')
       ).toBe(false);
@@ -791,9 +798,7 @@ describe('app-ownership gate ledger', () => {
       // `appBlockId` would compile (both are strings) and would silently match NOTHING —
       // demoting every editor to no-access with no error anywhere.
       for (const [file, call] of SEAT_CALLS) {
-        expect(call, `${file}: a seat call must be keyed on appListingId`).toMatch(
-          /appListingId/
-        );
+        expect(call, `${file}: a seat call must be keyed on appListingId`).toMatch(/appListingId/);
       }
     });
 
@@ -817,9 +822,7 @@ describe('app-ownership gate ledger', () => {
 
     it('NEGATIVE CONTROL: the composite-key probe CAN match', () => {
       // Proves the assertion above is testing a string that would be found if present.
-      expect('where: { appBlockId_userId: { appBlockId, userId } }').toContain(
-        'appBlockId_userId'
-      );
+      expect('where: { appBlockId_userId: { appBlockId, userId } }').toContain('appBlockId_userId');
     });
   });
 

--- a/src/server/services/blocks/__tests__/app-ownership-transfer.inbox.test.ts
+++ b/src/server/services/blocks/__tests__/app-ownership-transfer.inbox.test.ts
@@ -1,0 +1,321 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * App Listing COLLABORATORS — the RECIPIENT INBOX (`listMyPendingTransfers`).
+ *
+ * 🔴 THIS READ IS WHAT MAKES OWNERSHIP TRANSFER REACHABLE, and its absence is why the
+ * four transfer procs shipped unwired. Every other transfer read is keyed on the LISTING
+ * (`getPendingTransfer` takes an `appListingId`), which is a question only somebody who
+ * already knows the app can ask — and a pending offer confers NO role, so the recipient
+ * resolves no access to it and, in the ordinary case, does not know it exists. The
+ * `(to_user_id, status)` index was built for this shape and had no reader in the app.
+ *
+ * The properties pinned here:
+ *   - the LEAK direction: an offer addressed to somebody else is never returned;
+ *   - only `pending` rows;
+ *   - an EXPIRED row is absent, by the same read-time predicate the accept path uses;
+ *   - the listing metadata the UI needs comes back with it.
+ *
+ * 🔴 THE FAKE HONOURS ITS `where` CLAUSE, and that is load-bearing rather than tidy: a
+ * `findMany` fake that ignored the clause would return every row to every caller, which
+ * makes the leak test — the one that matters most here — pass no matter what the service
+ * queries. `the fake CAN filter` below is the positive control for exactly that.
+ */
+
+const { mockDb } = vi.hoisted(() => ({
+  mockDb: {
+    appOwnershipTransfer: {
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    },
+  },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
+
+const { listMyPendingTransfers } = await import(
+  '~/server/services/blocks/app-ownership-transfer.service'
+);
+
+const ME = 20;
+const SOMEONE_ELSE = 30;
+const OWNER = 10;
+const NOW = new Date('2026-08-10T12:00:00Z');
+const FUTURE = new Date('2026-08-17T12:00:00Z');
+const PAST = new Date('2026-08-03T12:00:00Z');
+
+type Row = {
+  id: string;
+  appListingId: string;
+  fromUserId: number;
+  toUserId: number;
+  status: string;
+  expiresAt: Date;
+  createdAt: Date;
+  appListing: {
+    slug: string;
+    name: string;
+    kind: string;
+    appBlockId: string | null;
+    icon: { url: string } | null;
+  } | null;
+};
+
+/**
+ * The transfer table. Every row differs from every other in id, listing, recipient,
+ * status, expiry AND listing name, so no assertion can be satisfied by the wrong row.
+ */
+function transferTable(): Row[] {
+  return [
+    {
+      id: 'aot_mine_onsite',
+      appListingId: 'apl_onsite',
+      fromUserId: OWNER,
+      toUserId: ME,
+      status: 'pending',
+      expiresAt: FUTURE,
+      createdAt: new Date('2026-08-09T00:00:00Z'),
+      appListing: {
+        slug: 'shiny-thing',
+        name: 'Shiny Thing',
+        kind: 'onsite',
+        appBlockId: 'ab_shiny',
+        icon: { url: 'https://img.example/shiny.png' },
+      },
+    },
+    {
+      id: 'aot_mine_offsite',
+      appListingId: 'apl_offsite',
+      fromUserId: 11,
+      toUserId: ME,
+      status: 'pending',
+      expiresAt: FUTURE,
+      createdAt: new Date('2026-08-08T00:00:00Z'),
+      appListing: {
+        slug: 'external-thing',
+        name: 'External Thing',
+        kind: 'offsite',
+        appBlockId: null,
+        icon: null,
+      },
+    },
+    // 🔴 THE LEAK ROW — a live, perfectly valid offer addressed to somebody else.
+    {
+      id: 'aot_not_mine',
+      appListingId: 'apl_secret',
+      fromUserId: 12,
+      toUserId: SOMEONE_ELSE,
+      status: 'pending',
+      expiresAt: FUTURE,
+      createdAt: new Date('2026-08-09T06:00:00Z'),
+      appListing: {
+        slug: 'someone-elses-app',
+        name: 'Someone Else’s App',
+        kind: 'onsite',
+        appBlockId: 'ab_secret',
+        icon: null,
+      },
+    },
+    // Addressed to me, but already answered.
+    {
+      id: 'aot_mine_accepted',
+      appListingId: 'apl_done',
+      fromUserId: 13,
+      toUserId: ME,
+      status: 'accepted',
+      expiresAt: FUTURE,
+      createdAt: new Date('2026-08-01T00:00:00Z'),
+      appListing: {
+        slug: 'already-taken',
+        name: 'Already Taken',
+        kind: 'onsite',
+        appBlockId: 'ab_done',
+        icon: null,
+      },
+    },
+    {
+      id: 'aot_mine_cancelled',
+      appListingId: 'apl_gone',
+      fromUserId: 14,
+      toUserId: ME,
+      status: 'cancelled',
+      expiresAt: FUTURE,
+      createdAt: new Date('2026-08-02T00:00:00Z'),
+      appListing: {
+        slug: 'withdrawn',
+        name: 'Withdrawn',
+        kind: 'offsite',
+        appBlockId: null,
+        icon: null,
+      },
+    },
+    // Addressed to me, still `pending` in the column, but past its deadline.
+    {
+      id: 'aot_mine_expired',
+      appListingId: 'apl_stale',
+      fromUserId: 15,
+      toUserId: ME,
+      status: 'pending',
+      expiresAt: PAST,
+      createdAt: new Date('2026-07-25T00:00:00Z'),
+      appListing: {
+        slug: 'lapsed-offer',
+        name: 'Lapsed Offer',
+        kind: 'onsite',
+        appBlockId: 'ab_stale',
+        icon: null,
+      },
+    },
+  ];
+}
+
+let ROWS: Row[];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  ROWS = transferTable();
+  mockDb.appOwnershipTransfer.findMany.mockImplementation(async (args: unknown) => {
+    const where = (args as { where?: { toUserId?: number; status?: string } }).where ?? {};
+    return ROWS.filter(
+      (r) =>
+        (where.toUserId === undefined || r.toUserId === where.toUserId) &&
+        (where.status === undefined || r.status === where.status)
+    );
+  });
+});
+
+describe('listMyPendingTransfers — the fake', () => {
+  /**
+   * 🔴 POSITIVE CONTROL ON THE FIXTURE ITSELF. Every assertion below is about rows the
+   * service did NOT return, and a fake that ignored `where` would hand back everything —
+   * making the leak test green while the service leaked. This proves the clause bites,
+   * and that the two users' rows are disjoint and both non-empty, so a filter can be
+   * observed to have happened at all.
+   */
+  it('CAN filter — the where clause actually narrows the table', async () => {
+    const mine = (await mockDb.appOwnershipTransfer.findMany({
+      where: { toUserId: ME, status: 'pending' },
+    })) as Row[];
+    const theirs = (await mockDb.appOwnershipTransfer.findMany({
+      where: { toUserId: SOMEONE_ELSE, status: 'pending' },
+    })) as Row[];
+    const everything = (await mockDb.appOwnershipTransfer.findMany({})) as Row[];
+
+    expect(mine.length).toBeGreaterThan(0);
+    expect(theirs.length).toBeGreaterThan(0);
+    expect(everything.length).toBeGreaterThan(mine.length + theirs.length);
+    expect(mine.map((r) => r.id)).not.toContain('aot_not_mine');
+    expect(theirs.map((r) => r.id)).toEqual(['aot_not_mine']);
+  });
+});
+
+describe('listMyPendingTransfers', () => {
+  it('returns the caller’s LIVE pending offers', async () => {
+    const rows = await listMyPendingTransfers(ME, NOW);
+    expect(rows.map((r) => r.transferId)).toEqual(['aot_mine_onsite', 'aot_mine_offsite']);
+  });
+
+  /**
+   * 🔴 THE LEAK TEST. An ownership offer names both parties and the app; showing one to a
+   * third party discloses that somebody is handing over an app, to whom, and by when.
+   */
+  it('🔴 NEVER returns an offer addressed to a DIFFERENT user', async () => {
+    const rows = await listMyPendingTransfers(ME, NOW);
+    expect(rows.map((r) => r.transferId)).not.toContain('aot_not_mine');
+    expect(rows.map((r) => r.appListingId)).not.toContain('apl_secret');
+    expect(rows.every((r) => r.transferId !== 'aot_not_mine')).toBe(true);
+    // POSITIVE CONTROL: that offer is real, live, and visible to ITS OWN recipient — so
+    // its absence above is the filter working, not the fixture being empty.
+    const theirs = await listMyPendingTransfers(SOMEONE_ELSE, NOW);
+    expect(theirs.map((r) => r.transferId)).toEqual(['aot_not_mine']);
+  });
+
+  it('🔴 the query is SCOPED IN THE `where`, on the indexed (to_user_id, status) pair', async () => {
+    await listMyPendingTransfers(ME, NOW);
+    const args = mockDb.appOwnershipTransfer.findMany.mock.calls[0][0] as {
+      where: Record<string, unknown>;
+    };
+    expect(args.where).toMatchObject({ toUserId: ME, status: 'pending' });
+  });
+
+  it('excludes ACCEPTED and CANCELLED offers', async () => {
+    const ids = (await listMyPendingTransfers(ME, NOW)).map((r) => r.transferId);
+    expect(ids).not.toContain('aot_mine_accepted');
+    expect(ids).not.toContain('aot_mine_cancelled');
+  });
+
+  /**
+   * 🔴 EXPIRY IS A READ-TIME PREDICATE, matching `getPendingTransfer` and `acceptTransfer`
+   * — no sweeper job is involved, so a lapsed row must be invisible even though its
+   * `status` column still says `pending`.
+   */
+  it('🔴 an EXPIRED pending row is ABSENT even though its status column says pending', async () => {
+    const ids = (await listMyPendingTransfers(ME, NOW)).map((r) => r.transferId);
+    expect(ids).not.toContain('aot_mine_expired');
+    // POSITIVE CONTROL: the row IS in the table and IS `pending` — it is the deadline
+    // that removed it, not the status filter.
+    const raw = ROWS.find((r) => r.id === 'aot_mine_expired');
+    expect(raw?.status).toBe('pending');
+    expect(raw?.toUserId).toBe(ME);
+  });
+
+  it('…and the SAME row is returned when "now" is before its deadline', async () => {
+    const ids = (await listMyPendingTransfers(ME, new Date('2026-07-28T00:00:00Z'))).map(
+      (r) => r.transferId
+    );
+    expect(ids).toContain('aot_mine_expired');
+  });
+
+  /**
+   * The recipient holds NO role on the listing, so they cannot look any of this up. If it
+   * does not arrive with the offer, the UI has nothing to render but an opaque id.
+   */
+  it('returns the listing metadata the inbox renders', async () => {
+    const [onsite, offsite] = await listMyPendingTransfers(ME, NOW);
+    expect(onsite).toEqual({
+      transferId: 'aot_mine_onsite',
+      appListingId: 'apl_onsite',
+      slug: 'shiny-thing',
+      name: 'Shiny Thing',
+      kind: 'onsite',
+      appBlockId: 'ab_shiny',
+      iconUrl: 'https://img.example/shiny.png',
+      fromUserId: OWNER,
+      expiresAt: FUTURE,
+      createdAt: new Date('2026-08-09T00:00:00Z'),
+    });
+    // An OFF-SITE offer legitimately carries no block and no icon — absent, not missing.
+    expect(offsite.kind).toBe('offsite');
+    expect(offsite.appBlockId).toBeNull();
+    expect(offsite.iconUrl).toBeNull();
+    expect(offsite.name).toBe('External Thing');
+  });
+
+  it('names the OFFERING user, so the recipient can see who is handing it over', async () => {
+    const rows = await listMyPendingTransfers(ME, NOW);
+    expect(rows.map((r) => r.fromUserId)).toEqual([OWNER, 11]);
+    // POSITIVE CONTROL: the offerers are distinct from each other and from the recipient,
+    // so a mixed-up column is observable.
+    expect(new Set([OWNER, 11, ME]).size).toBe(3);
+  });
+
+  it('a row whose listing relation is missing is DROPPED, not rendered blank', async () => {
+    ROWS.push({
+      id: 'aot_orphan',
+      appListingId: 'apl_vanished',
+      fromUserId: 16,
+      toUserId: ME,
+      status: 'pending',
+      expiresAt: FUTURE,
+      createdAt: new Date('2026-08-09T12:00:00Z'),
+      appListing: null,
+    });
+    const ids = (await listMyPendingTransfers(ME, NOW)).map((r) => r.transferId);
+    expect(ids).not.toContain('aot_orphan');
+    // POSITIVE CONTROL: the other rows still come back, so the drop is targeted.
+    expect(ids).toEqual(['aot_mine_onsite', 'aot_mine_offsite']);
+  });
+
+  it('an empty inbox is an empty array, not a throw', async () => {
+    await expect(listMyPendingTransfers(999, NOW)).resolves.toEqual([]);
+  });
+});

--- a/src/server/services/blocks/__tests__/app-ownership-transfer.seam.test.ts
+++ b/src/server/services/blocks/__tests__/app-ownership-transfer.seam.test.ts
@@ -1,0 +1,428 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * App Listing COLLABORATORS — OWNERSHIP TRANSFER, END TO END, AGAINST ONE MUTABLE STATE.
+ *
+ * 🔴 THIS SUITE EXISTS BECAUSE EVERY OTHER ONE IS SCOPED TO A SINGLE SURFACE.
+ * `app-ownership-transfer.service.test.ts` proves each function in isolation against
+ * hand-set fixtures, `app-ownership-transfer.inbox.test.ts` proves the recipient read
+ * against its own table, and both are green on a feature nobody can complete — because
+ * neither ever builds the state the NEXT step would actually see. That is the isolation
+ * seam: two hermetically-tested halves and a defect that lives only in the join.
+ *
+ * So here the fake DB is STATEFUL. `initiateTransfer` writes a row that
+ * `listMyPendingTransfers` then has to find; the id THAT read returns is the one handed
+ * to `acceptTransfer`; and the ownership columns `acceptTransfer` writes are the ones
+ * `resolveListingAccess` is asked about afterwards. Nothing is re-stubbed between steps —
+ * a step that wrote the wrong column, or a read that queried the wrong one, fails here
+ * even though both would pass in isolation.
+ *
+ * The relationship being pinned, in order:
+ *   1. the owner offers → NOTHING moves;
+ *   2. the RECIPIENT can discover the offer (this is the link that did not exist);
+ *   3. while it is open, the recipient still has NO role;
+ *   4. the recipient accepts → BOTH ownership columns move in one transaction;
+ *   5. the OLD owner loses `owner`, the new owner gains it;
+ *   6. the offer leaves the inbox.
+ */
+
+const { mockDb, state } = vi.hoisted(() => {
+  type Transfer = {
+    id: string;
+    appListingId: string;
+    fromUserId: number;
+    toUserId: number;
+    status: string;
+    expiresAt: Date;
+    createdAt: Date;
+    respondedAt: Date | null;
+  };
+  const state = {
+    /** `OauthClient.userId` — the CANONICAL owner of an on-site app. */
+    clientOwner: 0,
+    /** `AppListing.userId` — the denormalized copy. */
+    listingOwner: 0,
+    kind: 'onsite' as string,
+    transfers: [] as Transfer[],
+    seats: [] as Array<{ appListingId: string; userId: number; status: string }>,
+    events: [] as Array<Record<string, unknown>>,
+    bannedAt: null as Date | null,
+  };
+
+  const LISTING_ID = 'apl_seam';
+  const CLIENT_ID = 'oc_seam';
+  const BLOCK_ID = 'ab_seam';
+
+  /** The listing row, ASSEMBLED FROM STATE on every read — never a frozen fixture. */
+  const listingRow = () => ({
+    id: LISTING_ID,
+    slug: 'seam-app',
+    name: 'Seam App',
+    kind: state.kind,
+    userId: state.listingOwner,
+    appBlockId: state.kind === 'onsite' ? BLOCK_ID : null,
+    connectClientId: null,
+    revisionOfId: null,
+    revisionOf: null,
+    icon: null,
+    appBlock:
+      state.kind === 'onsite'
+        ? { appId: CLIENT_ID, blockId: 'seam-app', app: { userId: state.clientOwner } }
+        : null,
+  });
+
+  const db = {
+    appListing: {
+      findUnique: vi.fn(async (args: unknown) => {
+        const w = (args as { where: { id?: string } }).where;
+        return w.id === LISTING_ID ? listingRow() : null;
+      }),
+      updateMany: vi.fn(async (args: unknown) => {
+        const { where, data } = args as {
+          where: { id: string; userId?: number };
+          data: { userId: number };
+        };
+        if (where.id !== LISTING_ID) return { count: 0 };
+        if (where.userId !== undefined && where.userId !== state.listingOwner) return { count: 0 };
+        state.listingOwner = data.userId;
+        return { count: 1 };
+      }),
+    },
+    oauthClient: {
+      updateMany: vi.fn(async (args: unknown) => {
+        const { where, data } = args as {
+          where: { id: string; userId?: number };
+          data: { userId: number };
+        };
+        if (where.id !== CLIENT_ID) return { count: 0 };
+        if (where.userId !== undefined && where.userId !== state.clientOwner) return { count: 0 };
+        state.clientOwner = data.userId;
+        return { count: 1 };
+      }),
+    },
+    user: {
+      findUnique: vi.fn(async (args: unknown) => {
+        const id = (args as { where: { id: number } }).where.id;
+        return { id, bannedAt: state.bannedAt };
+      }),
+    },
+    appCollaborator: {
+      findFirst: vi.fn(async (args: unknown) => {
+        const w = (args as { where: { appListingId: string; userId: number; status: string } })
+          .where;
+        return (
+          state.seats.find(
+            (s) =>
+              s.appListingId === w.appListingId && s.userId === w.userId && s.status === w.status
+          ) ?? null
+        );
+      }),
+    },
+    appOwnershipTransfer: {
+      create: vi.fn(async (args: unknown) => {
+        const data = (args as { data: Record<string, unknown> }).data;
+        const row = { ...data, createdAt: new Date(), respondedAt: null } as Transfer;
+        state.transfers.push(row);
+        return row;
+      }),
+      findUnique: vi.fn(async (args: unknown) => {
+        const id = (args as { where: { id: string } }).where.id;
+        const t = state.transfers.find((r) => r.id === id);
+        return t ? { ...t, appListing: listingRow() } : null;
+      }),
+      findFirst: vi.fn(async (args: unknown) => {
+        const w = (args as { where: { appListingId?: string; status?: string } }).where;
+        return (
+          state.transfers.find(
+            (r) =>
+              (w.appListingId === undefined || r.appListingId === w.appListingId) &&
+              (w.status === undefined || r.status === w.status)
+          ) ?? null
+        );
+      }),
+      findMany: vi.fn(async (args: unknown) => {
+        const w = (args as { where: { toUserId?: number; status?: string } }).where ?? {};
+        return state.transfers
+          .filter(
+            (r) =>
+              (w.toUserId === undefined || r.toUserId === w.toUserId) &&
+              (w.status === undefined || r.status === w.status)
+          )
+          .map((r) => ({ ...r, appListing: listingRow() }));
+      }),
+      updateMany: vi.fn(async (args: unknown) => {
+        const { where, data } = args as {
+          where: { id?: string; appListingId?: string; status?: string; expiresAt?: unknown };
+          data: Record<string, unknown>;
+        };
+        let count = 0;
+        for (const r of state.transfers) {
+          if (where.id !== undefined && r.id !== where.id) continue;
+          if (where.appListingId !== undefined && r.appListingId !== where.appListingId) continue;
+          if (where.status !== undefined && r.status !== where.status) continue;
+          if (where.expiresAt !== undefined) {
+            const lte = (where.expiresAt as { lte?: Date }).lte;
+            if (lte && r.expiresAt.getTime() > lte.getTime()) continue;
+          }
+          Object.assign(r, data);
+          count += 1;
+        }
+        return { count };
+      }),
+    },
+    appOwnershipEvent: {
+      create: vi.fn(async (args: unknown) => {
+        const data = (args as { data: Record<string, unknown> }).data;
+        state.events.push(data);
+        return data;
+      }),
+    },
+    $transaction: vi.fn(),
+  };
+  db.$transaction.mockImplementation(async (cb: (tx: typeof db) => Promise<unknown>) => cb(db));
+
+  return { mockDb: db, state, LISTING_ID, CLIENT_ID };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
+vi.mock('~/server/services/blocks/app-repo-access', () => ({
+  grantAppRepoWrite: vi.fn(async () => undefined),
+  revokeAppRepoWrite: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/services/blocks/app-collaborator-notify', () => ({
+  notifyAppCollaborator: vi.fn(async () => undefined),
+}));
+
+const { acceptTransfer, initiateTransfer, listMyPendingTransfers } = await import(
+  '~/server/services/blocks/app-ownership-transfer.service'
+);
+const { resolveListingAccess } = await import('~/server/services/blocks/app-access.service');
+
+const LISTING = 'apl_seam';
+const OLD_OWNER = 10;
+const NEW_OWNER = 20;
+const BYSTANDER = 30;
+const EDITOR = 40;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.clientOwner = OLD_OWNER;
+  state.listingOwner = OLD_OWNER;
+  state.kind = 'onsite';
+  state.transfers.length = 0;
+  state.seats.length = 0;
+  state.events.length = 0;
+  state.bannedAt = null;
+  mockDb.$transaction.mockImplementation(async (cb: (tx: typeof mockDb) => Promise<unknown>) =>
+    cb(mockDb)
+  );
+});
+
+describe('🔴 THE WHOLE HAND-OVER, against one mutable state (ON-SITE)', () => {
+  it('offer → the recipient DISCOVERS it → accepts → ownership has moved, and the old owner has lost it', async () => {
+    // ── PRECONDITION, measured rather than assumed.
+    expect((await resolveListingAccess(LISTING, OLD_OWNER))?.role).toBe('owner');
+    expect((await resolveListingAccess(LISTING, NEW_OWNER))?.role).toBeNull();
+
+    // ── 1. THE OWNER OFFERS.
+    const offer = await initiateTransfer({
+      appListingId: LISTING,
+      toUserId: NEW_OWNER,
+      actorUserId: OLD_OWNER,
+    });
+    expect(offer.status).toBe('pending');
+    // NOTHING has moved yet — asserted on the STATE, not on a mock call count.
+    expect(state.clientOwner).toBe(OLD_OWNER);
+    expect(state.listingOwner).toBe(OLD_OWNER);
+
+    // ── 2. THE RECIPIENT DISCOVERS IT. 🔴 This is the link that did not exist: the
+    // recipient never saw the listing id, so the id used below comes from the READ, not
+    // from the write above.
+    const inbox = await listMyPendingTransfers(NEW_OWNER);
+    expect(inbox).toHaveLength(1);
+    expect(inbox[0].appListingId).toBe(LISTING);
+    expect(inbox[0].name).toBe('Seam App');
+    expect(inbox[0].fromUserId).toBe(OLD_OWNER);
+    const discoveredTransferId = inbox[0].transferId;
+    expect(discoveredTransferId).toBe(offer.id);
+
+    // ── 3. A PENDING OFFER CONFERS NOTHING while it sits open.
+    expect((await resolveListingAccess(LISTING, NEW_OWNER))?.role).toBeNull();
+    expect((await resolveListingAccess(LISTING, OLD_OWNER))?.role).toBe('owner');
+
+    // ── 4. THE RECIPIENT ACCEPTS, using the id the inbox gave them.
+    const accepted = await acceptTransfer({
+      transferId: discoveredTransferId,
+      userId: NEW_OWNER,
+    });
+    expect(accepted.fromUserId).toBe(OLD_OWNER);
+    expect(accepted.toUserId).toBe(NEW_OWNER);
+
+    // BOTH columns moved — the canonical one and the denormalized copy.
+    expect(state.clientOwner).toBe(NEW_OWNER);
+    expect(state.listingOwner).toBe(NEW_OWNER);
+
+    // ── 5. THE ROLE FLIP, read back through the real resolver.
+    expect((await resolveListingAccess(LISTING, NEW_OWNER))?.role).toBe('owner');
+    expect((await resolveListingAccess(LISTING, OLD_OWNER))?.role).toBeNull();
+
+    // ── 6. THE OFFER LEAVES THE INBOX.
+    expect(await listMyPendingTransfers(NEW_OWNER)).toEqual([]);
+    expect(state.transfers[0].status).toBe('accepted');
+  });
+
+  /**
+   * 🔴 THE OLD OWNER IS NOT DOWNGRADED TO EDITOR — they lose the app entirely. A hand-over
+   * that quietly left the previous owner with edit rights would be indistinguishable from
+   * a completed transfer at every surface that only asks "can I edit this?".
+   */
+  it('the old owner is left with NO role at all, not an editor seat', async () => {
+    const offer = await initiateTransfer({
+      appListingId: LISTING,
+      toUserId: NEW_OWNER,
+      actorUserId: OLD_OWNER,
+    });
+    await acceptTransfer({ transferId: offer.id, userId: NEW_OWNER });
+
+    const after = await resolveListingAccess(LISTING, OLD_OWNER);
+    expect(after?.role).toBeNull();
+    expect(after?.ownerUserId).toBe(NEW_OWNER);
+    // POSITIVE CONTROL: the resolver CAN still return `editor` off this same state, so a
+    // null above is a real absence rather than a resolver that answers null to everyone.
+    state.seats.push({ appListingId: LISTING, userId: EDITOR, status: 'accepted' });
+    expect((await resolveListingAccess(LISTING, EDITOR))?.role).toBe('editor');
+  });
+
+  /** Seats survive the hand-over — the listing keeps its editors. */
+  it('an existing editor keeps their seat across the transfer', async () => {
+    state.seats.push({ appListingId: LISTING, userId: EDITOR, status: 'accepted' });
+    expect((await resolveListingAccess(LISTING, EDITOR))?.role).toBe('editor');
+
+    const offer = await initiateTransfer({
+      appListingId: LISTING,
+      toUserId: NEW_OWNER,
+      actorUserId: OLD_OWNER,
+    });
+    await acceptTransfer({ transferId: offer.id, userId: NEW_OWNER });
+
+    expect((await resolveListingAccess(LISTING, EDITOR))?.role).toBe('editor');
+  });
+
+  /**
+   * 🔴 THE LEAK, ASSERTED ACROSS THE SEAM rather than against a stubbed table: an offer
+   * created by the real `initiateTransfer` must not be discoverable by anyone but its
+   * addressee.
+   */
+  it('a bystander’s inbox never sees the offer, at any point in the flow', async () => {
+    expect(await listMyPendingTransfers(BYSTANDER)).toEqual([]);
+    const offer = await initiateTransfer({
+      appListingId: LISTING,
+      toUserId: NEW_OWNER,
+      actorUserId: OLD_OWNER,
+    });
+    expect(await listMyPendingTransfers(BYSTANDER)).toEqual([]);
+    // POSITIVE CONTROL: the offer really is live and really is discoverable — by its
+    // addressee. Without this the two empties above are indistinguishable from a read
+    // that always returns nothing.
+    expect((await listMyPendingTransfers(NEW_OWNER)).map((r) => r.transferId)).toEqual([offer.id]);
+  });
+
+  /**
+   * 🔴 THE OFFER IS NOT SELF-SERVE. The owner cannot accept their own offer on the
+   * recipient's behalf, and the id being valid does not help them.
+   */
+  it('the OFFERING owner cannot accept the offer themselves', async () => {
+    const offer = await initiateTransfer({
+      appListingId: LISTING,
+      toUserId: NEW_OWNER,
+      actorUserId: OLD_OWNER,
+    });
+    await expect(acceptTransfer({ transferId: offer.id, userId: OLD_OWNER })).rejects.toMatchObject(
+      { code: 'NOT_OWNER' }
+    );
+    expect(state.clientOwner).toBe(OLD_OWNER);
+    expect(state.listingOwner).toBe(OLD_OWNER);
+  });
+
+  /**
+   * 🔴 A SECOND ACCEPT OF THE SAME OFFER MOVES NOTHING. The status guard on step (4) is
+   * what makes the flow idempotent; without a stateful fake this is untestable, because
+   * the row's status never changes.
+   */
+  it('accepting twice is refused the second time, and nothing moves again', async () => {
+    const offer = await initiateTransfer({
+      appListingId: LISTING,
+      toUserId: NEW_OWNER,
+      actorUserId: OLD_OWNER,
+    });
+    await acceptTransfer({ transferId: offer.id, userId: NEW_OWNER });
+    expect(state.clientOwner).toBe(NEW_OWNER);
+
+    await expect(acceptTransfer({ transferId: offer.id, userId: NEW_OWNER })).rejects.toMatchObject(
+      { code: 'NO_INVITE' }
+    );
+    expect(state.clientOwner).toBe(NEW_OWNER);
+    expect(state.listingOwner).toBe(NEW_OWNER);
+  });
+
+  /**
+   * 🔴 MONEY INVARIANCE ACROSS THE COMPLETED FLOW. `BlockBuzzAttribution` is not even
+   * present on this fake: a service that reached for it would throw rather than silently
+   * pass, which is the stronger form of "never touched".
+   */
+  it('the completed hand-over touches no attribution table', async () => {
+    const offer = await initiateTransfer({
+      appListingId: LISTING,
+      toUserId: NEW_OWNER,
+      actorUserId: OLD_OWNER,
+    });
+    await acceptTransfer({ transferId: offer.id, userId: NEW_OWNER });
+    expect(Object.keys(mockDb)).not.toContain('blockBuzzAttribution');
+    // The audit trail IS written, so "nothing was recorded" is excluded as the reason.
+    expect(state.events.map((e) => e.action)).toEqual(['transfer_initiated', 'transfer_accepted']);
+  });
+});
+
+describe('🔴 THE WHOLE HAND-OVER (OFF-SITE) — one column, and it is the authority', () => {
+  beforeEach(() => {
+    state.kind = 'offsite';
+  });
+
+  it('offer → discover → accept moves AppListing.userId and leaves the client alone', async () => {
+    expect((await resolveListingAccess(LISTING, OLD_OWNER))?.role).toBe('owner');
+    const offer = await initiateTransfer({
+      appListingId: LISTING,
+      toUserId: NEW_OWNER,
+      actorUserId: OLD_OWNER,
+    });
+    const inbox = await listMyPendingTransfers(NEW_OWNER);
+    expect(inbox.map((r) => r.kind)).toEqual(['offsite']);
+    expect(inbox[0].appBlockId).toBeNull();
+
+    await acceptTransfer({ transferId: offer.id, userId: NEW_OWNER });
+
+    expect(state.listingOwner).toBe(NEW_OWNER);
+    // 🔴 The OauthClient was never asked to move — there is none in an off-site
+    // listing's ownership chain.
+    expect(mockDb.oauthClient.updateMany).not.toHaveBeenCalled();
+    expect(state.clientOwner).toBe(OLD_OWNER);
+    expect((await resolveListingAccess(LISTING, NEW_OWNER))?.role).toBe('owner');
+    expect((await resolveListingAccess(LISTING, OLD_OWNER))?.role).toBeNull();
+  });
+
+  /**
+   * 🔴 POSITIVE CONTROL for the zero above: on the ON-SITE path this same fake DOES
+   * record an `oauthClient.updateMany`, so `not.toHaveBeenCalled()` means the kind
+   * branch fired — not that the mock is unreachable.
+   */
+  it('POSITIVE CONTROL: the same fake DOES see an oauthClient write when the kind is onsite', async () => {
+    state.kind = 'onsite';
+    const offer = await initiateTransfer({
+      appListingId: LISTING,
+      toUserId: NEW_OWNER,
+      actorUserId: OLD_OWNER,
+    });
+    await acceptTransfer({ transferId: offer.id, userId: NEW_OWNER });
+    expect(mockDb.oauthClient.updateMany).toHaveBeenCalled();
+  });
+});

--- a/src/server/services/blocks/app-ownership-transfer.service.ts
+++ b/src/server/services/blocks/app-ownership-transfer.service.ts
@@ -8,6 +8,7 @@ import {
 import { notifyAppCollaborator } from '~/server/services/blocks/app-collaborator-notify';
 import { grantAppRepoWrite, revokeAppRepoWrite } from '~/server/services/blocks/app-repo-access';
 import { newAppOwnershipTransferId } from '~/server/utils/app-block-ids';
+import { CONNECT_CLIENT_TRANSFER_REFUSAL } from '~/shared/constants/app-transfer.constants';
 
 /**
  * App Listing COLLABORATORS — OWNERSHIP TRANSFER (owner initiates → recipient accepts).
@@ -106,11 +107,16 @@ export type TransferView = {
   createdAt: Date;
 };
 
-/** The message a connect-linked off-site listing is refused with. Asserted verbatim. */
-export const CONNECT_CLIENT_TRANSFER_REFUSAL =
-  'This listing is linked to an OAuth application. Ownership transfer would either hand ' +
-  'over that application’s credentials or split ownership between the listing and the ' +
-  'client, so it is not available for connect listings. Unlink the OAuth client first.';
+/**
+ * The message a connect-linked off-site listing is refused with. Asserted verbatim on
+ * BOTH sides of the wire.
+ *
+ * 🔴 RE-EXPORTED FROM `shared/`, not defined here. The Collaborators tab renders this
+ * string and its component test asserts the rendered text against the constant — which a
+ * browser test cannot do while the only definition sits in a module whose graph reaches
+ * the database client. One definition, two importers.
+ */
+export { CONNECT_CLIENT_TRANSFER_REFUSAL };
 
 /**
  * A pending transfer that has passed `expiresAt` is treated as ABSENT everywhere.
@@ -645,4 +651,104 @@ export async function getPendingTransfer(opts: {
   // initiate — so it is not theirs to watch either.
   if (access.role !== 'owner' && row.toUserId !== opts.viewerUserId) return null;
   return row;
+}
+
+/**
+ * One incoming ownership OFFER, as the recipient's inbox renders it.
+ *
+ * 🔴 The listing metadata is JOINED IN rather than left to a second round trip. The
+ * recipient has, by construction, no access to the listing yet — a pending transfer
+ * confers nothing, so `resolveListingAccess` gives them no role and every per-app read
+ * refuses them. A client that got back bare ids would have nothing it could call to turn
+ * them into a name, and would render "you were offered ownership of apl_01J…".
+ */
+export type IncomingTransferView = {
+  transferId: string;
+  appListingId: string;
+  slug: string;
+  name: string;
+  kind: ListingKind;
+  /** Null for an off-site listing — it has no backing AppBlock. */
+  appBlockId: string | null;
+  iconUrl: string | null;
+  /** The current owner, i.e. who is offering. */
+  fromUserId: number;
+  expiresAt: Date;
+  createdAt: Date;
+};
+
+/**
+ * RECIPIENT: every LIVE ownership offer addressed to `userId`.
+ *
+ * 🔴 THIS IS THE READ THAT MAKES THE FEATURE REACHABLE, and its absence is why the four
+ * transfer procs sat unwired. `getPendingTransfer` is keyed PER LISTING — it answers "is
+ * there an offer on THIS app", which the recipient cannot ask, because they do not know
+ * the app exists and hold no role on it. Discovery has to be keyed on the RECIPIENT, and
+ * nothing else in the app queried `to_user_id` at all. The
+ * `(to_user_id, status)` index exists for exactly this shape and had no reader.
+ *
+ * 🔴 EXPIRY IS A READ-TIME PREDICATE, not a `WHERE` clause and not a sweeper — the same
+ * {@link isLive} used by `getPendingTransfer` and `acceptTransfer`, so all three agree
+ * about what "live" means with no cron dependency. The `WHERE` narrows to the recipient
+ * and to `pending` (the indexed pair); expiry is applied in one place afterwards.
+ *
+ * A row whose listing relation is missing is DROPPED rather than rendered with blanks:
+ * the FK is `ON DELETE CASCADE`, so it cannot legitimately happen, and an offer you
+ * cannot name is not an offer anyone can act on.
+ */
+export async function listMyPendingTransfers(
+  userId: number,
+  now: Date = new Date()
+): Promise<IncomingTransferView[]> {
+  const rows = (await dbRead.appOwnershipTransfer.findMany({
+    where: { toUserId: userId, status: 'pending' },
+    select: {
+      id: true,
+      appListingId: true,
+      fromUserId: true,
+      toUserId: true,
+      status: true,
+      expiresAt: true,
+      createdAt: true,
+      appListing: {
+        select: {
+          slug: true,
+          name: true,
+          kind: true,
+          appBlockId: true,
+          icon: { select: { url: true } },
+        },
+      },
+    },
+    orderBy: { createdAt: 'desc' },
+  })) as Array<
+    TransferView & {
+      appListing: {
+        slug: string;
+        name: string;
+        kind: string;
+        appBlockId: string | null;
+        icon: { url: string } | null;
+      } | null;
+    }
+  >;
+
+  const out: IncomingTransferView[] = [];
+  for (const row of rows) {
+    if (!row.appListing) continue;
+    if (!isLive(row, now)) continue;
+    out.push({
+      transferId: row.id,
+      appListingId: row.appListingId,
+      slug: row.appListing.slug,
+      name: row.appListing.name,
+      kind: row.appListing.kind as ListingKind,
+      appBlockId: row.appListing.appBlockId,
+      iconUrl: row.appListing.icon?.url ?? null,
+      fromUserId: row.fromUserId,
+      expiresAt: row.expiresAt,
+      createdAt: row.createdAt,
+    });
+  }
+  return out;
 }

--- a/src/shared/constants/app-transfer.constants.ts
+++ b/src/shared/constants/app-transfer.constants.ts
@@ -1,0 +1,28 @@
+/**
+ * App Listing OWNERSHIP TRANSFER — the strings both sides of the wire have to agree on.
+ *
+ * 🔴 IN `shared/` SO THERE IS EXACTLY ONE COPY. The refusal below is produced by the
+ * server and rendered verbatim by the Collaborators tab, and the component test asserts
+ * the rendered text against it. Leaving it in the service would have forced that test to
+ * either import a module whose graph reaches the database client, or to keep a
+ * hand-copied paraphrase — and a paraphrase is exactly how a user-facing message drifts
+ * out from under the assertion that is supposed to pin it.
+ *
+ * `app-ownership-transfer.service.ts` imports and RE-EXPORTS it, so every existing
+ * server-side import keeps working and there is still only one definition.
+ */
+
+/**
+ * The message a connect-linked off-site listing is refused with, at initiate AND again
+ * in-transaction at accept. Asserted verbatim on both sides.
+ *
+ * 🔴 IT NAMES A REMEDY. Moving an off-site listing that carries an `OauthClient` would
+ * either hand over live credentials the recipient never asked for, or split ownership
+ * between the listing and the client. Both are refused; "unlink the OAuth client first"
+ * is the one thing the owner can actually do about it, so the UI must not swallow this
+ * into a generic error.
+ */
+export const CONNECT_CLIENT_TRANSFER_REFUSAL =
+  'This listing is linked to an OAuth application. Ownership transfer would either hand ' +
+  'over that application’s credentials or split ownership between the listing and the ' +
+  'client, so it is not available for connect listings. Unlink the OAuth client first.';


### PR DESCRIPTION
Follow-up to #3891, which shipped the collaborators UI and deliberately left the four
ownership-transfer procs at **zero clients**. This wires them — and closes the read that
made "deferred" the only honest option.

## The blocker this had to fix first: there was no recipient inbox

`initiateTransfer` / `acceptTransfer` / `cancelTransfer` / `getPendingTransfer` were all
written and tested. But **nothing in the app could put an offer in front of the person it
was addressed to.** `getPendingTransfer` is keyed per LISTING — it answers "is there an
offer on THIS app", which the recipient cannot ask: a pending offer confers no role, so
they resolve no access to the listing and in the ordinary case do not know it exists.
Nothing outside tests queried `to_user_id` at all; the `(to_user_id, status)` index had no
reader.

So this is not a pure front-end PR:

- **`listMyPendingTransfers(userId)`** — the recipient-keyed read. Narrows on the indexed
  `(to_user_id, status)` pair in the `WHERE`, joins the listing for the name/kind/icon the
  recipient has no other way to fetch, and applies expiry as a **read-time predicate** (the
  same `isLive` the accept path uses), matching this codebase's existing convention — no
  sweeper job.
- **`appCollaborators.listMyPendingTransfers`** — gated like its sibling
  `listMyPendingInvites` (`protectedProcedure` + the author flag), not `appDeveloperProcedure`.
  Being offered your *first* app is exactly the case where "do you already own an app" is
  the wrong gate.

## Recipient surface — `/apps/invites`

Ownership offers render **above** the seat invites, in their own titled section. An offer
to take over an app is a materially bigger decision than a seat invitation, and it must not
read as another row in the same list. The distinction is carried by things a test can
assert, not by tone: its own section, a red consequence panel, and an **"Accept ownership"**
button rather than "Accept". The panel is kind-aware off the same capability table the
invite disclosure uses, so an off-site offer promises neither a repo nor Buzz — neither can
exist for a listing with no backing app record. On-site offers say plainly that **Buzz
earned before the transfer stays with the previous owner**, which is what the service
actually does.

The section renders **nothing at all** when there are no offers, so the ordinary invitee's
page is unchanged.

The "you were offered ownership" notification pointed at the app page — which *refuses the
recipient outright*, because a pending offer confers no role — or at `/apps` for an
off-site listing. Neither has an Accept control on it. It now points at the inbox.

## Owner surface — the Collaborators tab

Initiate, the pending offer, and cancel. **Owner-only**, matching the service gate and the
panel's own existing promise that "collaborators cannot invite or remove anyone, and cannot
transfer the app". The picker and the pending-offer card are mutually exclusive: one live
offer per listing is a partial-unique index, so offering the control while an offer is open
would render an action that cannot succeed.

**The connect-client refusal is rendered inline, with its reason.** That message names a
concrete remedy ("unlink the OAuth client first"); collapsing it into a generic toast would
leave the owner with a control that fails forever and no way to learn why. Its text moved
to `shared/` so the server and the component test share exactly one copy rather than a
paraphrase.

## The guard was fail-open in the direction this PR exercises

`app-collaborators.client-seam.test.ts` documented the hazard itself: its
`PROC_REFERENCE_RE` requires an explicit `trpc.`/`utils.` receiver, which is fail-safe for
"every proc has a client" but **fail-OPEN for the `DEFERRED_PROCS` must-have-zero-clients
assertion** — a proc wired via `const { initiateTransfer } = trpc.appCollaborators;` or an
aliased `useUtils()` binding was not counted, so the check stayed green while the proc was
wired.

Both remedies the file named were taken, because they fail differently:

1. **The deferred entries are deleted and the deletion is asserted directly.** With
   `DEFERRED_PROCS` empty, the "every deferred proc has zero clients" test iterates nothing
   and is vacuous — so a named `TRANSFER_PROCS` ledger now asserts those procs are *not*
   deferred, *are* declared, and *do* have clients. That half is a plain list comparison the
   scanner cannot influence at all.
2. **The scanner recognises the two extra receiver shapes.** Destructured
   (`const { x } = trpc.appCollaborators`) and aliased (`const u = trpc.useUtils(); u.appCollaborators.x`).
   The alias is *discovered* from the file rather than assumed — accepting any
   `<ident>.appCollaborators.<name>` would re-admit `constants.appCollaborators.*`, the
   config bag whose false positive shipped `getAppEarnings` as "wired". There is a negative
   control for exactly that.

Verified by mutation: with the old single-regex scanner, a proc reachable *only* through a
destructured receiver reports **zero clients**; with the widened scanner the same wiring is
counted.

## No schema change

Every table and index this uses already exists, including the `(to_user_id, status)` index
this read was built for. No migration is added.

## Product decisions carried over unchanged

- Transfer is refused on an off-site listing carrying a linked OAuth client, at initiate and
  again in-transaction at accept — the UI surfaces that refusal with its reason.
- An on-site accept moves both the canonical and the denormalized owner columns in one
  transaction.
- Buzz attribution is **not** rewritten; prior earnings stay with the old owner.
- Submission history does not move.
- Collaborators keep their seats across a transfer, and cannot initiate one.

## Tests

- **New:** the recipient-inbox suite (leak / status / expiry / metadata, with a positive
  control proving the fake honours its `where` clause), an end-to-end **seam** suite driving
  offer → discover → accept against ONE mutable state and reading the role flip back through
  the real access resolver, the ownership-offer component suite, and the owner-half suite on
  the Collaborators tab.
- Every absence assertion awaits a **present** element first — `locator.elements()` is
  synchronous, so an emptiness asserted before React commits passes whatever the component
  renders — and each is paired with a positive control that renders the same testids.
- Guards were mutation-tested individually; each mutant was confirmed to die on its own
  test's specific message.

Local: unit **16,243 passed / 17 skipped** (1,031 files), component/browser **1,569 passed**
(147 files, real Chromium), apps **524 passed**. Typecheck clean. The only red anywhere is
the pre-existing `@civitai/db-queries` EXPLAIN suite, which needs a live database and fails
with `ECONNREFUSED` on this machine; nothing here touches it.
