### PR TITLE
fix(apps): stop the listing editor telling an on-site app to change its link

### DIFF
--- a/src/components/Apps/ExternalListingEditForm.tsx
+++ b/src/components/Apps/ExternalListingEditForm.tsx
@@ -12,6 +12,7 @@ import {
 } from '@mantine/core';
 import {
   IconAlertTriangle,
+  IconApps,
   IconDeviceFloppy,
   IconExternalLink,
   IconInfoCircle,
@@ -42,6 +43,7 @@ import {
   isOnsiteEdit,
   hasScalarChanges,
   isApprovedEdit,
+  listingEditHeaderCopy,
   type ListingEditContext,
 } from '~/components/Apps/offsiteEditConfig';
 import type { MarketplaceCategory } from '~/server/services/blocks/marketplace-categories.constants';
@@ -90,6 +92,8 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
    * Assets on an on-site listing. Off-site keeps 0/1/2 exactly as before.
    */
   const showUrlStep = !isOnsiteEdit(edit);
+  // 🔴 The HEADER reads the SAME flag the wizard shape does — see `listingEditHeaderCopy`.
+  const headerCopy = listingEditHeaderCopy(showUrlStep);
   const STEP_DETAILS = showUrlStep ? 1 : 0;
   const STEP_ASSETS = showUrlStep ? 2 : 1;
 
@@ -268,16 +272,18 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
 
   return (
     <Stack gap="md" data-testid="apps-offsite-edit-form">
+      {/* 🔴 KIND-AWARE HEADER, off the SAME `showUrlStep` flag as the wizard shape. Both
+          the icon and the sentence used to be hardcoded to the off-site case, so an
+          on-site listing was told to "change the link" — under an external-link icon —
+          about an app that has no link and no URL step. See `listingEditHeaderCopy`. */}
       <Alert
         color="blue"
         variant="light"
-        icon={<IconExternalLink size={16} />}
+        icon={showUrlStep ? <IconExternalLink size={16} /> : <IconApps size={16} />}
         title={`Editing ${edit.slug}`}
+        data-testid={headerCopy.testId}
       >
-        <Text size="sm">
-          Update your external-link app. Change the link, details, or assets across the steps below,
-          then save.
-        </Text>
+        <Text size="sm">{headerCopy.blurb}</Text>
       </Alert>
 
       {approved && (

--- a/src/components/Apps/ExternalSubmitForm.edit.browser.test.tsx
+++ b/src/components/Apps/ExternalSubmitForm.edit.browser.test.tsx
@@ -446,3 +446,87 @@ describe('ExternalSubmitForm (edit) — kind-aware wizard shape', () => {
     await expect.element(page.getByTestId('apps-offsite-wizard-step-url')).toBeInTheDocument();
   });
 });
+
+/**
+ * 🔴 THE EDIT HEADER, pinned in BOTH directions — the last piece of the form that was
+ * NOT kind-aware.
+ *
+ * Observed in production on the canonical editor for an ON-SITE listing: an
+ * external-link icon over "Update your external-link app. Change the link, details, or
+ * assets across the steps below, then save." — about an app that has no link, on a
+ * wizard that (correctly) renders it no URL step. The shape was fixed; the header was
+ * not, so the page contradicted itself.
+ *
+ * 🔴 ASSERTED AS STATE, NOT AS SPELLING. The two branches render DIFFERENT elements
+ * (`apps-listing-edit-header-onsite` / `-offsite`), so the primary assertion is which
+ * element exists — a check no other feature's copy can satisfy by coincidence. The
+ * word-level assertion is SCOPED to that element rather than to the page, for the same
+ * reason: a page-wide "does the body contain 'link'" search is satisfied by the Assets
+ * step, the OG re-pull button, or any future control that happens to say it.
+ */
+describe('ExternalSubmitForm (edit) — the kind-aware header', () => {
+  test('🔴 an ON-SITE listing gets the on-site header, and it does NOT promise a link', async () => {
+    renderWithProviders(<ExternalSubmitForm edit={makeCtx({ kind: 'onsite' })} />);
+
+    // 🔴 AWAITED PRESENT ELEMENT FIRST. `locator.elements()` is SYNCHRONOUS, so an
+    // absence asserted before React has committed passes whatever the component renders.
+    const header = page.getByTestId('apps-listing-edit-header-onsite');
+    await expect.element(header).toBeInTheDocument();
+
+    // The STATE: the off-site header is not the one that rendered.
+    expect(page.getByTestId('apps-listing-edit-header-offsite').elements()).toHaveLength(0);
+
+    // …and the sentence inside THAT element makes no claim about a link.
+    await expect.element(header).not.toHaveTextContent(/\blinks?\b/i);
+    await expect.element(header).not.toHaveTextContent(/external/i);
+    // It still says what an on-site owner CAN change, so this is not "delete the copy".
+    await expect.element(header).toHaveTextContent(/details/i);
+    await expect.element(header).toHaveTextContent(/assets/i);
+    // The slug title is untouched by the kind branch.
+    await expect.element(header).toHaveTextContent(/Editing vitrine/i);
+  });
+
+  test('🔴 the ON-SITE header carries the app icon, not the external-link icon', async () => {
+    renderWithProviders(<ExternalSubmitForm edit={makeCtx({ kind: 'onsite' })} />);
+    const header = page.getByTestId('apps-listing-edit-header-onsite');
+    await expect.element(header).toBeInTheDocument();
+    // An external-link glyph is the same wrong claim in pictorial form. Asserted on the
+    // icon COMPONENT that rendered (its own class), scoped inside the header.
+    const el = header.element();
+    expect(el.querySelector('svg.tabler-icon-apps')).not.toBeNull();
+    expect(el.querySelector('svg.tabler-icon-external-link')).toBeNull();
+  });
+
+  test('an OFF-SITE listing STILL gets the off-site header, link and all (the control)', async () => {
+    renderWithProviders(<ExternalSubmitForm edit={makeCtx({ kind: 'offsite' })} />);
+    const header = page.getByTestId('apps-listing-edit-header-offsite');
+    await expect.element(header).toBeInTheDocument();
+    expect(page.getByTestId('apps-listing-edit-header-onsite').elements()).toHaveLength(0);
+    await expect.element(header).toHaveTextContent(/Change the link, details, or assets/i);
+    expect(header.element().querySelector('svg.tabler-icon-external-link')).not.toBeNull();
+  });
+
+  test('a context with NO kind keeps the OFF-SITE header — unchanged behaviour', async () => {
+    // Every pre-existing caller and fixture predates the field; absent must mean off-site,
+    // exactly as it does for the URL step.
+    renderWithProviders(<ExternalSubmitForm edit={makeCtx()} />);
+    await expect.element(page.getByTestId('apps-listing-edit-header-offsite')).toBeInTheDocument();
+  });
+
+  /**
+   * 🔴 THE SEAM, asserted on the RENDERED page rather than on two pure functions: the
+   * header may mention a link EXACTLY when the URL step exists. This is the contradiction
+   * the defect actually was — a header describing a step that is not on screen.
+   */
+  test('🔴 the header mentions the link exactly when the URL step is rendered', async () => {
+    renderWithProviders(<ExternalSubmitForm edit={makeCtx({ kind: 'onsite' })} />);
+    await expect.element(page.getByTestId('apps-listing-edit-header-onsite')).toBeInTheDocument();
+    expect(page.getByTestId('apps-offsite-wizard-step-url').elements()).toHaveLength(0);
+
+    renderWithProviders(<ExternalSubmitForm edit={makeCtx({ kind: 'offsite' })} />);
+    await expect.element(page.getByTestId('apps-offsite-wizard-step-url')).toBeInTheDocument();
+    await expect
+      .element(page.getByTestId('apps-listing-edit-header-offsite'))
+      .toHaveTextContent(/link/i);
+  });
+});

--- a/src/components/Apps/__tests__/offsiteEditConfig.test.ts
+++ b/src/components/Apps/__tests__/offsiteEditConfig.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildScalarPatch,
   isOnsiteEdit,
+  listingEditHeaderCopy,
   editContextToForm,
   hasScalarChanges,
   isApprovedEdit,
@@ -241,5 +242,54 @@ describe('isApprovedEdit', () => {
     expect(isApprovedEdit(makeCtx({ status: 'approved' }))).toBe(true);
     expect(isApprovedEdit(makeCtx({ status: 'draft' }))).toBe(false);
     expect(isApprovedEdit(makeCtx({ status: 'pending' }))).toBe(false);
+  });
+});
+
+/**
+ * 🔴 THE HEADER BLURB, keyed on the SAME flag as the wizard shape.
+ *
+ * The defect this pins was observed in production: the canonical editor for an ON-SITE
+ * listing rendered "Update your external-link app. Change the link, details, or
+ * assets…" over an external-link icon, about an app with no link and no URL step. The
+ * wizard SHAPE was already kind-aware; only the header was left behind.
+ */
+describe('listingEditHeaderCopy', () => {
+  it('🔴 the ON-SITE blurb never promises a link', () => {
+    const onsite = listingEditHeaderCopy(false);
+    expect(onsite.kind).toBe('onsite');
+    expect(onsite.blurb).not.toMatch(/\blinks?\b/i);
+    expect(onsite.blurb).not.toMatch(/external/i);
+    expect(onsite.blurb).not.toMatch(/\burl\b/i);
+    // …and it still says what CAN be changed, so the fix is not "delete the sentence".
+    expect(onsite.blurb).toMatch(/details/i);
+    expect(onsite.blurb).toMatch(/assets/i);
+  });
+
+  it('the OFF-SITE blurb is UNCHANGED, character for character', () => {
+    const offsite = listingEditHeaderCopy(true);
+    expect(offsite.kind).toBe('offsite');
+    // 🔴 A LITERAL, not a pattern derived from the implementation. An off-site listing
+    // really does have a link, and this is the string that shipped.
+    expect(offsite.blurb).toBe(
+      'Update your external-link app. Change the link, details, or assets across the steps below, then save.'
+    );
+  });
+
+  it('the two branches render DIFFERENT elements, so a test can pin STATE not spelling', () => {
+    expect(listingEditHeaderCopy(true).testId).not.toBe(listingEditHeaderCopy(false).testId);
+  });
+
+  /**
+   * 🔴 THE SEAM WITH THE WIZARD SHAPE. `showUrlStep` is `!isOnsiteEdit(edit)`, so an
+   * absent kind must yield the OFF-SITE header for the same reason it yields the URL
+   * step — one predicate, one answer. Asserting the composition rather than the two
+   * halves is what stops the header promising a step the wizard does not render.
+   */
+  it('🔴 a header that mentions the link is rendered EXACTLY when the URL step is', () => {
+    for (const ctx of [makeCtx({ kind: 'onsite' }), makeCtx({ kind: 'offsite' }), makeCtx()]) {
+      const showUrlStep = !isOnsiteEdit(ctx);
+      const copy = listingEditHeaderCopy(showUrlStep);
+      expect(/\blink\b/i.test(copy.blurb), `kind=${String(ctx.kind)}`).toBe(showUrlStep);
+    }
   });
 });

--- a/src/components/Apps/offsiteEditConfig.ts
+++ b/src/components/Apps/offsiteEditConfig.ts
@@ -139,6 +139,59 @@ export function isOnsiteEdit(ctx: Pick<ListingEditContext, 'kind'>): boolean {
   return ctx.kind === 'onsite';
 }
 
+/**
+ * The edit form's HEADER copy, by kind. PURE.
+ *
+ * 🔴 THIS FINISHES A PATTERN THAT WAS ALREADY HERE, it does not start one. The wizard
+ * SHAPE went kind-aware — an on-site listing gets no App URL step and no scope
+ * disclosure, and `buildScalarPatch` refuses to emit `externalUrl` for it — but the
+ * header alert was left behind, hardcoded to the off-site case. So the canonical editor
+ * for an ON-SITE listing rendered an external-link icon over the sentence "Update your
+ * external-link app. Change the link, details, or assets…", about an app that has no
+ * link and no external anything. Observed in production, not inferred.
+ *
+ * 🔴 KEYED ON THE SAME BOOLEAN THE WIZARD SHAPE USES (`showUrlStep`, i.e.
+ * `!isOnsiteEdit(edit)`), deliberately, rather than taking its own look at `ctx.kind`. A
+ * second kind check is a second thing to get wrong: the header could then promise a step
+ * the wizard does not render, which is the exact class of defect this is fixing. One
+ * predicate decides whether the URL step exists AND whether the header may mention a
+ * link, so the two cannot disagree.
+ *
+ * The fail-safe default rides along for free: `isOnsiteEdit` reads an absent kind as
+ * off-site, so a context that predates the field keeps today's copy verbatim.
+ *
+ * The `testId` is what makes this assertable as STATE rather than as a substring — the
+ * two branches render DIFFERENT elements, so a test can pin which one exists instead of
+ * grepping the page for a word that some other feature might also spell.
+ */
+export type ListingEditHeaderCopy = {
+  kind: 'onsite' | 'offsite';
+  testId: string;
+  blurb: string;
+};
+
+export function listingEditHeaderCopy(showUrlStep: boolean): ListingEditHeaderCopy {
+  return showUrlStep
+    ? {
+        kind: 'offsite',
+        testId: 'apps-listing-edit-header-offsite',
+        // UNCHANGED, character for character — an off-site listing really does have a
+        // link, and the URL step really is one of "the steps below".
+        blurb:
+          'Update your external-link app. Change the link, details, or assets across the ' +
+          'steps below, then save.',
+      }
+    : {
+        kind: 'onsite',
+        testId: 'apps-listing-edit-header-onsite',
+        // 🔴 MUST NOT SAY "the link". An on-site listing has no external URL, and the
+        // wizard renders it no step that could change one.
+        blurb:
+          'Update your app’s listing. Change the details or assets across the steps below, ' +
+          'then save.',
+      };
+}
+
 /** True iff two string→string maps have identical keys + values. PURE. */
 function shallowEqualStringMap(
   a: Record<string, string>,


### PR DESCRIPTION
## The defect

On the canonical listing editor for an **ON-SITE** listing, the header alert reads:

> **Editing &lt;slug&gt;**
> Update your external-link app. Change the link, details, or assets across the steps below, then save.

…under an external-link icon. An on-site app has no link. Observed on a real listing after
the 5.1.5 deploy, not inferred from the code.

## Why it happened, and why the fix is small

The form is **already kind-aware and does it well.** An on-site listing gets neither the
App URL step nor the OAuth-scope disclosure, both keyed off a single `showUrlStep` flag,
and `buildScalarPatch` refuses to emit `externalUrl` for that kind. The wizard steps are
right in both directions — on-site renders `Details → Assets`, off-site renders
`URL → Details → Assets`.

**Only the header alert was left behind**, hardcoded to the off-site case in both its icon
and its sentence. So the page contradicted itself: it described a step it had (correctly)
decided not to render.

This finishes that pattern rather than starting a new one. The header now reads **the same
`showUrlStep` flag the wizard shape does**, through a pure `listingEditHeaderCopy` helper
in the file that already owns `isOnsiteEdit`. It deliberately does **not** take its own
look at `ctx.kind`: a second kind check is a second thing to get wrong, and the failure it
would produce is exactly the one being fixed — a header promising a step that is not on
screen. One predicate decides both.

The 16 lines that changed in the component are the whole behavioural change.

- Off-site copy: **unchanged, character for character** (asserted as a literal).
- Absent kind: still resolves to off-site, exactly as it does for the URL step — every
  pre-existing context and fixture predates the field.
- Icon: follows the same flag (`IconApps`, the established "an app" glyph in this component
  family, in place of `IconExternalLink`).

⚠️ **The on-site wording is worth a human's eye** — it is user-facing copy and I picked it:
*"Update your app's listing. Change the details or assets across the steps below, then
save."* The only hard constraint the tests encode is that it must not promise a link, a URL
or anything "external", and must still say what *can* be changed.

## `AppsSubmitEditView.tsx` — checked, deliberately NOT changed

Its `subtitle="Update your external-link app's link, details, or assets."` is the same
class of claim, so I traced it before deciding:

- It renders on the **standalone** `/apps/submit?edit=` page only. The canonical editor
  imports the chromeless `AppsListingDetailsEditor` from the same module and owns its own
  chrome, so this subtitle never appears in the Details tab. (`AppsSubmitEditView` has
  exactly one consumer: the submit page.)
- **No in-product path routes an on-site listing there.** The two link builders are
  `getOwnerEditHref`, which sends on-site to `/apps/<appBlockId>/edit` → the canonical
  editor, and the off-site submissions list. The submit page's own comment says as much:
  "an on-site App isn't edited here".

So for every reachable user it is correct copy, and I left it. The residual is that the
proc behind it is kind-agnostic, so a hand-typed `/apps/submit?edit=<on-site listing id>`
would still show the stale subtitle above a now-correct alert. Closing that properly means
lifting the `getMyListingForEdit` query out of the chromeless child — which would fork the
bounded-loader logic that component exists to hold in one copy — so it is a separate change,
not a line to slip into a copy fix. Happy to do it if you want the hand-typed URL covered.

## Tests

Both directions, in both tiers, asserted as **state** rather than spelling: the two branches
render **different elements** (`apps-listing-edit-header-onsite` / `-offsite`), so the
primary assertion is which one exists — nothing another feature's copy can satisfy by
coincidence. The word-level checks are scoped **inside that element**, never against the
page, because "does the body contain 'link'" is satisfied by the Assets step or any future
control that happens to say it.

Every absence assertion awaits a **present** element first (`locator.elements()` is
synchronous, so an emptiness asserted before React commits passes whatever renders).

There is also a seam test in each tier: the header may mention a link **exactly when the URL
step is rendered** — which is the contradiction the defect actually was.

Local: component/browser **1,550 passed** across 146 files (real Chromium, 271 s of test
execution — executed, not collected); `src/components/Apps` unit **826 passed** across 47
files; typecheck **0 errors**.

## Note on formatting

Both touched files were already prettier-dirty on `main`. I did **not** reformat them —
running the formatter turned a 16-line fix into a 362-line whole-file diff and buried the
change. CI's modified-file prettier and eslint steps are report-only for exactly this
reason. The 3 eslint findings on the browser test file are pre-existing and identical at
`origin/main` (verified by linting the base version); this branch adds none.
