### PR TITLE
fix(images): fall back to Meilisearch on an empty BitDex page for signed-in callers too

### DIFF
--- a/src/server/services/__tests__/bitdex-empty-fallback.test.ts
+++ b/src/server/services/__tests__/bitdex-empty-fallback.test.ts
@@ -1,0 +1,345 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// A `null` return from the BitDex primary path is the signal to fall back to
+// Meilisearch. That signal used to be suppressed for signed-in callers: the
+// second ("own excluded") pass is only issued for an authenticated first-page
+// request, and its mere EXISTENCE — not its result — was enough to skip the
+// fallback. So when BitDex returned zero documents, anonymous visitors fell
+// back and were served normally while signed-in users got an empty feed.
+//
+// These tests pin the fallback on the POST-MERGE result: fall back when the
+// merged page is empty, keep serving when own-excluded content is the only
+// content there is.
+//
+// Same minimal-seam mocking as bitdex-feed-source.test.ts: stub the
+// event-engine-common submodule + infra clients + env so importing
+// image.service doesn't boot real infra, and null out the Meili client so the
+// Meili leg still RUNS (and still stamps source 'meili') without a live index.
+
+import type * as BitdexClient from '~/server/bitdex/client';
+import type * as FliptClient from '~/server/flipt/client';
+import type * as MeiliClient from '~/server/meilisearch/client';
+
+const { queryBitdexMock, getFliptVariantMock } = vi.hoisted(() => ({
+  queryBitdexMock: vi.fn(),
+  getFliptVariantMock: vi.fn(),
+}));
+
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: vi.fn(async () => undefined),
+  safeError: (e: unknown) => e,
+}));
+
+vi.mock('../../../../event-engine-common/feeds', () => ({
+  ImagesFeed: class {
+    populatedQuery = vi.fn();
+  },
+}));
+vi.mock('../../../../event-engine-common/services/metrics', () => ({
+  MetricService: class {
+    fetch = vi.fn();
+  },
+}));
+vi.mock('../../../../event-engine-common/services/cache', () => ({ CacheService: class {} }));
+
+vi.mock('~/env/server', () => ({
+  env: new Proxy({ LOGGING: [] as string[] } as Record<string, unknown>, {
+    get: (target, prop) => {
+      if (prop in target) return target[prop as string];
+      if (typeof prop === 'string' && (prop.endsWith('_URL') || prop.endsWith('_ENDPOINT')))
+        return 'https://test:test@localhost:5432/test';
+      if (
+        typeof prop === 'string' &&
+        /(_CONCURRENCY|_LIMIT|_MS|_PORT|_TIMEOUT|_MAX|_SIZE|_COUNT)$/.test(prop)
+      )
+        return 1;
+      return undefined;
+    },
+  }),
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/redis/client', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- self-referential key proxy
+  const make = (): any => new Proxy(() => 'k', { get: () => make() });
+  const keyProxy = make();
+  return {
+    redis: {
+      get: vi.fn().mockResolvedValue('[]'),
+      set: vi.fn().mockResolvedValue(undefined),
+      packed: { get: vi.fn(), set: vi.fn() },
+    },
+    sysRedis: {},
+    REDIS_KEYS: keyProxy,
+    REDIS_SYS_KEYS: keyProxy,
+  };
+});
+
+vi.mock('~/server/meilisearch/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof MeiliClient>()),
+  metricsSearchClient: null,
+}));
+
+vi.mock('~/server/bitdex/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof BitdexClient>()),
+  queryBitdex: queryBitdexMock,
+}));
+
+vi.mock('~/server/flipt/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof FliptClient>()),
+  getFliptVariant: getFliptVariantMock,
+  getFliptBoolean: vi.fn().mockResolvedValue(false),
+}));
+
+import { getImagesFromSearch } from '../image.service';
+
+const CURRENT_USER_ID = 42;
+
+/**
+ * Both BitDex passes go through the same `queryBitdex`, so the fake has to tell
+ * them apart from its arguments or it would answer the same thing to both and
+ * every assertion below would be meaningless.
+ *
+ * The main pass filters availability with `Not(Eq(availability, Private))`; the
+ * own-excluded pass asks for the opposite inside an `Or`. Keying on that `Or`
+ * distinguishes them structurally rather than by position or call order.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- raw BitDex filter clauses
+type Clause = any;
+function isOwnExcludedQuery(filters: unknown): boolean {
+  if (!Array.isArray(filters)) return false;
+  return filters.some(
+    (clause: Clause) =>
+      Array.isArray(clause?.Or) &&
+      clause.Or.some(
+        (member: Clause) =>
+          Array.isArray(member?.Eq) &&
+          member.Eq[0] === 'availability' &&
+          member.Eq[1]?.String === 'Private'
+      )
+  );
+}
+
+const publicDoc = {
+  id: 101,
+  url: 'abc',
+  hash: null,
+  nsfwLevel: 1,
+  userId: 7,
+  type: 'image',
+  availability: 'Public',
+  postId: 55,
+  postedToId: null,
+  hasMeta: true,
+  onSite: true,
+  poi: false,
+  minor: false,
+  width: 100,
+  height: 100,
+  reactionCount: 0,
+  commentCount: 0,
+  collectedCount: 0,
+  sortAt: 1_700_000_000,
+  publishedAt: 1_700_000_000,
+};
+
+// The caller's OWN private image — exactly what the second pass exists to
+// re-add. postId 55 is what the content-scope assertions key on.
+const ownPrivateDoc = {
+  ...publicDoc,
+  id: 777,
+  userId: CURRENT_USER_ID,
+  availability: 'Private',
+  postId: 55,
+};
+
+const EMPTY_PAGE = { documents: [], cursor: undefined };
+
+/**
+ * `cursor: undefined` terminates fetchBitdexPrimary's pass loop on the first
+ * iteration. A fake that always returned a cursor would spin to MAX_PASSES.
+ */
+function page(documents: Record<string, unknown>[]) {
+  return { documents, cursor: undefined };
+}
+
+/** Route each call to the pass it belongs to. */
+function serve({
+  main = EMPTY_PAGE,
+  ownExcluded = EMPTY_PAGE,
+}: {
+  main?: { documents: Record<string, unknown>[]; cursor: undefined };
+  ownExcluded?: { documents: Record<string, unknown>[]; cursor: undefined };
+}) {
+  queryBitdexMock.mockImplementation(async (_index: string, filters: unknown) =>
+    isOwnExcludedQuery(filters) ? ownExcluded : main
+  );
+}
+
+const baseInput = {
+  limit: 10,
+  browsingLevel: 1,
+  periodMode: 'published',
+  include: [],
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ImageSearchInput isn't exported
+} as any;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- ImageSearchInput isn't exported
+const authedInput = (overrides: Record<string, unknown> = {}): any => ({
+  ...baseInput,
+  currentUserId: CURRENT_USER_ID,
+  ...overrides,
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- ImageSearchInput isn't exported
+const anonInput = (overrides: Record<string, unknown> = {}): any => ({
+  ...baseInput,
+  currentUserId: undefined,
+  ...overrides,
+});
+
+describe('BitDex primary — empty result falls back to Meilisearch for every caller', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getFliptVariantMock.mockResolvedValue('primary');
+    serve({});
+  });
+
+  // INVARIANT GUARD — this is the arm that always worked. It is the control for
+  // the regression below, not regression coverage itself.
+  it('anonymous + zero BitDex documents → falls back to Meili', async () => {
+    serve({ main: EMPTY_PAGE });
+
+    const result = await getImagesFromSearch(anonInput());
+
+    expect(result.source).toBe('meili');
+    expect(result.data).toEqual([]);
+  });
+
+  // THE REGRESSION. Signed in, first page, own/global feed: the own-excluded
+  // pass is issued, so before the fix its existence alone suppressed the
+  // fallback and the caller was served an empty BitDex page.
+  it('authenticated + zero BitDex documents + no own-excluded content → falls back to Meili', async () => {
+    serve({ main: EMPTY_PAGE, ownExcluded: EMPTY_PAGE });
+
+    const result = await getImagesFromSearch(authedInput());
+
+    expect(result.source).toBe('meili');
+    expect(result.data).toEqual([]);
+  });
+
+  // The case the naive fix (`if (!accumulated.length) return null` BEFORE the
+  // merge) destroys: the main pass is empty but the caller does have their own
+  // excluded content in scope, which is a legitimate non-empty page.
+  it('authenticated + zero BitDex documents + own-excluded content in scope → serves it, no fallback', async () => {
+    serve({ main: EMPTY_PAGE, ownExcluded: page([ownPrivateDoc]) });
+
+    const result = await getImagesFromSearch(authedInput());
+
+    expect(result.source).toBe('bitdex');
+    expect(result.data.map((d: { id: number }) => d.id)).toEqual([777]);
+  });
+
+  // INVARIANT GUARD — the ordinary serving path must be untouched.
+  it('authenticated + BitDex returns documents → served by BitDex, no fallback', async () => {
+    serve({ main: page([publicDoc]), ownExcluded: EMPTY_PAGE });
+
+    const result = await getImagesFromSearch(authedInput());
+
+    expect(result.source).toBe('bitdex');
+    expect(result.data.map((d: { id: number }) => d.id)).toEqual([101]);
+  });
+
+  // Own-excluded content that does NOT survive the content-scope filters is not
+  // content: the page is still empty and must still fall back. This is also the
+  // negative arm of the content-scope positive control below.
+  it('authenticated + own-excluded content filtered out by content scope → falls back to Meili', async () => {
+    serve({ main: EMPTY_PAGE, ownExcluded: page([ownPrivateDoc]) }); // doc has postId 55
+
+    const result = await getImagesFromSearch(authedInput({ postId: 99 }));
+
+    expect(result.source).toBe('meili');
+    expect(result.data).toEqual([]);
+  });
+
+  // INVARIANT GUARD + the paginated decision: a subsequent page never issues the
+  // own-excluded pass, so an empty page already returned the fallback signal
+  // before this change and still does. Pinned so the decision is explicit.
+  it('authenticated + paginated (bdx cursor) + zero documents → falls back to Meili, no own-excluded pass', async () => {
+    serve({ main: EMPTY_PAGE, ownExcluded: page([ownPrivateDoc]) });
+
+    const result = await getImagesFromSearch(
+      authedInput({ cursor: 'bdx:{"sortAt":1700000000,"id":101}' })
+    );
+
+    expect(result.source).toBe('meili');
+    expect(result.data).toEqual([]);
+    // The own-excluded pass is first-page-only; proving it never ran is what
+    // makes "the paginated arm is unchanged" a claim about the code and not
+    // about the fake.
+    expect(queryBitdexMock.mock.calls.filter((c) => isOwnExcludedQuery(c[1]))).toHaveLength(0);
+  });
+});
+
+// A fake that ignores its arguments would make every assertion above vacuous.
+describe('fake fidelity — the BitDex fake honours its inputs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getFliptVariantMock.mockResolvedValue('primary');
+    serve({});
+  });
+
+  it('routes the two passes apart: exactly one main query and one own-excluded query', async () => {
+    serve({ main: page([publicDoc]), ownExcluded: page([ownPrivateDoc]) });
+
+    await getImagesFromSearch(authedInput());
+
+    expect(queryBitdexMock).toHaveBeenCalledTimes(2);
+
+    const ownCalls = queryBitdexMock.mock.calls.filter((c) => isOwnExcludedQuery(c[1]));
+    const mainCalls = queryBitdexMock.mock.calls.filter((c) => !isOwnExcludedQuery(c[1]));
+    expect(ownCalls).toHaveLength(1);
+    expect(mainCalls).toHaveLength(1);
+
+    // Own-excluded pass: unscoped, fixed page size, no cursor and no offset.
+    expect(ownCalls[0][3]).toBe(500);
+    expect(ownCalls[0][4]).toBeUndefined();
+    expect(ownCalls[0][5]).toBeUndefined();
+    // Main pass: the caller's own limit.
+    expect(mainCalls[0][3]).toBe(10);
+  });
+
+  it('issues no own-excluded query at all for an anonymous caller', async () => {
+    serve({ main: page([publicDoc]) });
+
+    await getImagesFromSearch(anonInput());
+
+    expect(queryBitdexMock).toHaveBeenCalledTimes(1);
+    expect(isOwnExcludedQuery(queryBitdexMock.mock.calls[0][1])).toBe(false);
+  });
+
+  it('the fake can return both empty and non-empty on the same pass', async () => {
+    serve({ main: EMPTY_PAGE, ownExcluded: page([ownPrivateDoc]) });
+    const withContent = await getImagesFromSearch(authedInput());
+    expect(withContent.data.map((d: { id: number }) => d.id)).toEqual([777]);
+
+    serve({ main: EMPTY_PAGE, ownExcluded: EMPTY_PAGE });
+    const withoutContent = await getImagesFromSearch(authedInput());
+    expect(withoutContent.data).toEqual([]);
+  });
+
+  // Positive control for the content-scope filters: the SAME own-excluded doc
+  // is kept under a matching scope and dropped under a non-matching one, so the
+  // "filtered out" test above is testing the filter and not an empty fake.
+  it('content-scope filters actually filter: same doc kept on a matching postId, dropped on another', async () => {
+    serve({ main: EMPTY_PAGE, ownExcluded: page([ownPrivateDoc]) }); // doc has postId 55
+
+    const matching = await getImagesFromSearch(authedInput({ postId: 55 }));
+    expect(matching.source).toBe('bitdex');
+    expect(matching.data.map((d: { id: number }) => d.id)).toEqual([777]);
+
+    const notMatching = await getImagesFromSearch(authedInput({ postId: 99 }));
+    expect(notMatching.data.map((d: { id: number }) => d.id)).toEqual([]);
+  });
+});

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -3068,8 +3068,6 @@ async function fetchBitdexPrimary(input: ImageSearchInput) {
     if (!result.cursor) break; // no more pages
   }
 
-  if (!accumulated.length && !ownExcludedPromise) return null;
-
   let data = accumulated;
 
   // Merge user's own excluded content, re-sort by the active sort, then limit.
@@ -3127,6 +3125,15 @@ async function fetchBitdexPrimary(input: ImageSearchInput) {
       }
     }
   }
+
+  // Nothing to serve → return null so the caller falls back to Meilisearch.
+  // Checked HERE, on the merged result, and not on `accumulated` alone: the
+  // own-excluded second pass can be the only source of content on the page
+  // (and its docs are content-scoped just above), so an empty main pass is not
+  // yet an empty result. Checking earlier would either discard that content or
+  // — as it did before — make the fallback unreachable for any caller for whom
+  // the second pass was issued at all, i.e. every signed-in first-page request.
+  if (!data.length) return null;
 
   data = data.slice(0, limit);
 


### PR DESCRIPTION
## Symptom

On the BitDex-backed `/images` feed, during any window where BitDex returns **zero documents**, a **signed-in** user gets an **empty feed** while an **anonymous** visitor is served normally. Same page, same filters — the result depends on whether you are logged in. The asymmetry is also why it is easy to miss: the path anyone can check while logged out is the path that works.

## Mechanism

`fetchBitdexPrimary` signals *"I can't serve this — fall back to Meilisearch"* by returning `null`; the caller then runs the Meili leg. Before this change that signal was:

```ts
if (!accumulated.length && !ownExcludedPromise) return null;
```

`ownExcludedPromise` is the optional **second pass** that re-adds the caller's own private / blocked / unpublished / nsfw0 / poi content, which the main (deliberately cacheable, per-user-clause-free) query filters out. It is issued only when:

```ts
const skipOwnExcluded =
  !input.currentUserId || bitdexCursor || (input.userId && input.userId !== input.currentUserId);
```

…i.e. **authenticated, first page, own/global feed**. So the guard keyed on whether that pass had been *issued*, never on what it *returned*:

| caller | second pass issued? | BitDex returns 0 docs |
|---|---|---|
| anonymous | no | `null` → falls back to Meili ✅ |
| authenticated, first page, own/global feed | **yes** | fallback unreachable → empty page served ❌ |
| authenticated, viewing another user's profile | no | falls back ✅ |
| authenticated, paginated (`bdx:` cursor) | no | falls back ✅ |

## The fix

Move the emptiness check onto the **post-merge** result:

```ts
const ownExcluded = await ownExcludedPromise;
if (ownExcluded?.documents?.length) { /* …merge + content-scope filters… */ }

if (!data.length) return null;

data = data.slice(0, limit);
```

The placement is load-bearing in both directions:

- **Not earlier.** The obvious edit — dropping `&& !ownExcludedPromise` so it reads `if (!accumulated.length) return null` — returns *before* the own-excluded merge and would throw away a legitimately non-empty page: a caller whose main pass returns nothing but who *does* have own-excluded content matching the current view must still be served that content.
- **After the content-scope filters.** The second pass is deliberately **unscoped** (its cache key is just `userId × sort × disablePoi`), and `modelVersionId` / `postId` / `postIds` / `types` / `baseModels` / `remixOfId` / `withMeta` / `fromPlatform` are applied during the merge. Own-excluded documents that don't survive those filters are not content for this view, so the emptiness that matters is the one *after* them.

Net diff in the hot path: two lines removed, one guard (plus comment) added. No refactor, no restructuring, no extra query.

Preserved exactly: anonymous behaviour; own-excluded-only pages; the main loop's early `break` and cursor/pagination handling.

## Paginated (`bdx:` cursor) callers — decision and justification

**Unchanged: an empty subsequent page still returns the fallback signal.**

The second pass is first-page-only (`bitdexCursor` sets `skipOwnExcluded`), so on a paginated request `ownExcludedPromise` is `null` and `accumulated` is empty ⇒ the old guard already returned `null` there. The new post-merge guard reaches the same conclusion by the same route: `data` is empty, so `null`. **This PR does not change the paginated arm at all**, and a test pins that (including an assertion that the own-excluded pass is never issued on that path, so the claim is about the code and not about the test's fake).

Why not "fix" it in the same change: making end-of-feed return an empty page instead of falling back is a **separate behaviour change** to the pagination contract, on the hottest feed path, and it is not what this bug is about. Worth noting as a follow-up rather than smuggling in here: the Meili leg parses a cursor as `offset|entry`, so a `bdx:`-shaped cursor yields `offset = 0` — a paginated fallback therefore re-serves from the top rather than continuing where the user was. That is pre-existing on `main`; it is not introduced, worsened, or newly reachable here. It should be decided on its own merits (suppress the fallback for paginated callers, or translate the cursor) rather than bundled into a bug fix.

Note also that a BitDex **error** is caught by the caller and falls back regardless — the `null` path is specifically "zero documents", which on a subsequent page is legitimately end-of-feed and on a first page is not.

## Tests

`src/server/services/__tests__/bitdex-empty-fallback.test.ts` (10 tests) drives the real seam through `getImagesFromSearch` and asserts the **reported source** (`bitdex` vs `meili`) plus literal expected ids — so "did it fall back" is observed end-to-end, not inferred from an internal return value. Expectations are pinned to literals, not derived from the implementation.

Red on `main`, green here:

| test | on `main` |
|---|---|
| authenticated + 0 documents + no own-excluded content → falls back | **RED** (`expected 'bitdex' to be 'meili'`) |
| authenticated + own-excluded content filtered out by content scope → falls back | **RED** (`expected 'bitdex' to be 'meili'`) |

Invariant guards (green on `main` — they pin behaviour that must not change, and are not counted as regression coverage): anonymous + 0 documents falls back (the control arm); authenticated + documents returned is served by BitDex; authenticated + own-excluded content in scope is served, not discarded; paginated + 0 documents falls back with no own-excluded pass; and four fake-fidelity/positive-control tests.

**Mutation results** — both BitDex passes go through the same `queryBitdex`, so each mutant was applied to the source and the suite re-run:

| mutant | killed by | message |
|---|---|---|
| revert to `if (!accumulated.length && !ownExcludedPromise) return null` at its old position | the 2 regression tests | `expected 'bitdex' to be 'meili'` |
| re-add `&& !ownExcludedPromise` to the new post-merge guard | the 2 regression tests | `expected 'bitdex' to be 'meili'` |
| **naive** `if (!accumulated.length) return null` placed before the merge | own-excluded-in-scope test, content-scope positive control, fake-fidelity test | `expected 'meili' to be 'bitdex'`, `expected [] to deeply equal [ 777 ]` |
| invert the guard (`if (data.length) return null`) | 8 of 10 tests | `expected 'meili' to be 'bitdex'` / `expected 'bitdex' to be 'meili'` |

**Fake fidelity.** The two BitDex passes are told apart structurally (the own-excluded pass asks for `availability = Private` inside an `Or`; the main pass filters it out with `Not(Eq(...))`), and that discrimination is itself asserted: exactly one main query at the caller's `limit` and exactly one own-excluded query at the fixed page size with no cursor/offset; zero own-excluded queries for an anonymous caller; the fake demonstrated returning both empty and non-empty on the same pass; and the content-scope filters shown to actually filter — the *same* document is kept under a matching `postId` and dropped under a different one.
