### PR TITLE
feat(apps): make the external-only store scope reachable and segment-able

### DIFF
--- a/src/components/Apps/__tests__/appsStoreAccessCallSites.test.ts
+++ b/src/components/Apps/__tests__/appsStoreAccessCallSites.test.ts
@@ -39,6 +39,20 @@ import { describe, it, expect } from 'vitest';
  * (`preview / component-tests`) and do not block a merge. This unit-project ledger
  * does. So in CI all six sites are pinned STRUCTURALLY ONLY, by this file — which
  * is precisely why a hole in its masker (see below) is worth more than it looks.
+ *
+ * 🔴 TWO MEASURED LIMITS OF THIS FILE — issue #3932, not fixed here. Read them
+ * before treating a green run as "no site re-inlines the gate":
+ *   1. `INLINED_GATE` matches two flag names in PROXIMITY inside ONE expression.
+ *      Four re-inlining shapes evade it and were verified green: hoisted locals
+ *      (`const a = features.appListings; … a || b`), names split across a `;` (the
+ *      `[^;{}]` class stops there by design), a ternary, and
+ *      `[features.appListings, features.appBlocks].some(Boolean)`. Widening the
+ *      NAME list (as the external-only term did) does not touch the SHAPE.
+ *   2. The "EXACT" assertion below pins DIRECT importers only, so a site that
+ *      reaches the gate transitively is invisible to it — including
+ *      `pages/apps/[appBlockId]/index.tsx`, which routes through
+ *      `resolveLegacyAppRoute` → `resolveAppsPageAccess`. That is the site a real
+ *      disclosure defect appeared at, so the blindness is not academic.
  */
 
 const SRC = path.resolve(__dirname, '../../..');

--- a/src/components/Apps/__tests__/appsStoreAccessCallSites.test.ts
+++ b/src/components/Apps/__tests__/appsStoreAccessCallSites.test.ts
@@ -68,6 +68,15 @@ const SRC = path.resolve(__dirname, '../../..');
  *    entry point — that menu item is the only route TO `/apps` (the sub-nav's
  *    Marketplace tab only appears once you are already on `/apps/*`). Reachable by
  *    direct URL only. Tracked in issue #3907; not this file's to fix.
+ *
+ *    🔴 THE EXTERNAL-ONLY COHORT INHERITS THAT GAP, AND IS THE FIRST REAL POPULATION
+ *    TO HIT IT. `{appListingsPublicExternal, NOT appBlocks, NOT appListings}` holders
+ *    now pass the six gates below but the user-menu entry still reads `appBlocks`
+ *    alone, so `/apps` is direct-URL-only for them. Until #3907 lands, an
+ *    external-only rollout needs its own entry point (a link in the announcement, a
+ *    campaign URL) — the store being reachable is NOT the same as it being findable.
+ *    Deliberately out of scope here: converting that menu item is a product decision
+ *    on a module with its own standing doc, not a mechanical alignment.
  */
 const STORE_GATE_SITES = [
   'components/Apps/AppListingsMarketplaceBody.tsx',
@@ -205,6 +214,21 @@ function stripComments(code: string): string {
 }
 
 /**
+ * The flag names the store gate is built from. The predicate is
+ * `appListings || appBlocks || appListingsPublicExternal` — the third term admits
+ * the EXTERNAL-ONLY cohort, who reach the store and are then scoped SERVER-side to
+ * `kind='offsite'` listings. Any TWO of these joined by a logical operator in live
+ * code under SCAN_ROOTS is a re-inlined gate.
+ *
+ * 🔴 Kept as data, not baked into one literal regex, because the gate GREW: a
+ * two-name regex would have gone on reporting a clean zero for a site that
+ * re-inlined `appListings || appListingsPublicExternal` — the newest and least
+ * familiar half of the rule, i.e. the one most likely to be open-coded by someone
+ * who has not read this file.
+ */
+const STORE_FLAG_NAMES = ['appListingsPublicExternal', 'appListings', 'appBlocks'] as const;
+
+/**
  * An open-coded store gate in LIVE code.
  *
  * Deliberately matched on PROXIMITY + a logical operator rather than one literal
@@ -215,11 +239,18 @@ function stripComments(code: string): string {
  * collapsed first so line wrapping is irrelevant, and `[^;{}]` keeps a match inside
  * one expression rather than spanning statements.
  *
- * `\b` after each flag name matters: it stops `appBlocksPages` / `appBlocksAuthor`
- * — different flags with their own rules — from being read as `appBlocks`.
+ * `\b` after each flag name matters twice over: it stops `appBlocksPages` /
+ * `appBlocksAuthor` — different flags with their own rules — from being read as
+ * `appBlocks`, and it stops `appListingsPublicExternal` from being read as
+ * `appListings`. Both directions are pinned by the masker controls below.
  */
-const INLINED_GATE =
-  /appListings\b[^;{}]{0,120}?(?:\|\||&&|\?\?)[^;{}]{0,120}?appBlocks\b|appBlocks\b[^;{}]{0,120}?(?:\|\||&&|\?\?)[^;{}]{0,120}?appListings\b/;
+const INLINED_GATE = new RegExp(
+  STORE_FLAG_NAMES.flatMap((a) =>
+    STORE_FLAG_NAMES.filter((b) => b !== a).map(
+      (b) => `${a}\\b[^;{}]{0,120}?(?:\\|\\||&&|\\?\\?)[^;{}]{0,120}?${b}\\b`
+    )
+  ).join('|')
+);
 
 /** Collapse whitespace so a prettier line-wrap cannot hide a gate from the regex. */
 function flatten(code: string): string {
@@ -352,6 +383,58 @@ describe('the masker (validate the instrument before reading its verdict)', () =
     // would read them as `appBlocks` and flag legitimate code.
     expect(
       flatten(maskNonCode('const x = features.appListings || features.appBlocksPages;', 'p.ts'))
+    ).not.toMatch(INLINED_GATE);
+    expect(
+      flatten(maskNonCode('const x = features.appListings || features.appBlocksAuthor;', 'p.ts'))
+    ).not.toMatch(INLINED_GATE);
+  });
+
+  /**
+   * 🔴 THE THIRD TERM. `appListingsPublicExternal` admits the EXTERNAL-ONLY cohort
+   * and is now part of the gate, so a site re-inlining a pair that includes it must
+   * be caught — while `appListingsPublicExternal` alone must NOT be mistaken for
+   * `appListings` (they are different flags with different meanings, and the prefix
+   * relationship makes that the easy mistake for a `\b`-less regex).
+   */
+  it('🔴 catches a re-inlined gate built from the EXTERNAL-only term', () => {
+    const cases: Record<string, string> = {
+      'external OR listings':
+        'const ok = features.appListings || features.appListingsPublicExternal;',
+      'external OR blocks': 'const ok = features.appListingsPublicExternal || features.appBlocks;',
+      'external first, wrapped':
+        'const ok =\n  features.appListingsPublicExternal ||\n  features.appListings;',
+      'De Morgan with external':
+        'if (!features.appBlocks && !features.appListingsPublicExternal) return null;',
+      'destructured external': 'const ok = appListingsPublicExternal || appBlocks;',
+    };
+    for (const [label, src] of Object.entries(cases)) {
+      expect(flatten(maskNonCode(src, 'probe.ts')), label).toMatch(INLINED_GATE);
+    }
+  });
+
+  it('🔴 does NOT read appListingsPublicExternal as appListings (prefix collision)', () => {
+    // A single mention of the longer name, OR-ed with an unrelated flag, is not a
+    // store gate. Without `\b` the `appListings` alternative would match its prefix
+    // and report a false offender at every external-cohort call site.
+    expect(
+      flatten(
+        maskNonCode('const x = features.appListingsPublicExternal || features.canViewNsfw;', 'p.ts')
+      )
+    ).not.toMatch(INLINED_GATE);
+    expect(
+      flatten(maskNonCode('const x = features.appListingsPublicExternal;', 'p.ts'))
+    ).not.toMatch(INLINED_GATE);
+    // The sharp case: a hypothetical SIBLING of the longest name. Only the `\b` on
+    // `appListingsPublicExternal` itself rejects this — every other guard in this
+    // file passes it either way, so this is the one assertion that dies for that
+    // specific reason.
+    expect(
+      flatten(
+        maskNonCode(
+          'const x = features.appListingsPublicExternalOverride || features.appBlocksPages;',
+          'p.ts'
+        )
+      )
     ).not.toMatch(INLINED_GATE);
   });
 

--- a/src/components/Apps/__tests__/hasAppsStoreAccess.test.ts
+++ b/src/components/Apps/__tests__/hasAppsStoreAccess.test.ts
@@ -56,6 +56,96 @@ describe('hasAppsStoreAccess — the 2×2 flag matrix', () => {
 });
 
 /**
+ * 🔴 THE THIRD TERM — `appListingsPublicExternal` (the EXTERNAL-ONLY cohort).
+ *
+ * Its holders are viewers the SERVER will serve a `kind='offsite'`-only catalog to
+ * (`resolveStoreVisibilityScope` → `public-external`). Before it was added here,
+ * a viewer whose ONLY qualification was that flag hit `notFound` at the page gate
+ * and could never reach the store the server was ready to serve them — the gate and
+ * the data path disagreeing about the same flag.
+ *
+ * The full 2×2×2 is asserted rather than the one interesting cell, because the
+ * dangerous mistakes are the boring cells: an `&&` instead of an `||` (only the
+ * both-true row would notice), or the term being dropped from one branch.
+ */
+describe('hasAppsStoreAccess — the external-only term (full 2×2×2)', () => {
+  const BOOLS = [true, false] as const;
+  for (const appListings of BOOLS)
+    for (const appBlocks of BOOLS)
+      for (const appListingsPublicExternal of BOOLS) {
+        const expected = appListings || appBlocks || appListingsPublicExternal;
+        it(`{listings:${appListings}, blocks:${appBlocks}, external:${appListingsPublicExternal}} → ${expected}`, () => {
+          expect(hasAppsStoreAccess({ appListings, appBlocks, appListingsPublicExternal })).toBe(
+            expected
+          );
+        });
+      }
+
+  it('🔴 the EXTERNAL flag ALONE grants access (the blocker this term removes)', () => {
+    expect(hasAppsStoreAccess({ appListingsPublicExternal: true })).toBe(true);
+    expect(
+      hasAppsStoreAccess({ appListings: false, appBlocks: false, appListingsPublicExternal: true })
+    ).toBe(true);
+  });
+
+  it('🔴 the external flag being FALSE cannot revoke either older flag', () => {
+    // The `&&`/de-Morgan mutant: a viewer who qualifies via `appListings` or
+    // `appBlocks` must keep access no matter what the new flag says.
+    expect(hasAppsStoreAccess({ appListings: true, appListingsPublicExternal: false })).toBe(true);
+    expect(hasAppsStoreAccess({ appBlocks: true, appListingsPublicExternal: false })).toBe(true);
+  });
+
+  it('still fails CLOSED when the new key is absent / undefined', () => {
+    expect(hasAppsStoreAccess({ appListingsPublicExternal: undefined })).toBe(false);
+    expect(hasAppsStoreAccess({ appListings: false, appBlocks: false })).toBe(false);
+  });
+});
+
+/**
+ * 🔴 THE SSR SEAM, EXTENDED TO THE NEW TERM. The block below (unchanged) pins the
+ * 2×2; this pins the cells the third flag adds — above all "external ONLY reaches
+ * /apps", which is the whole point of the change and which the original matrix
+ * cannot express.
+ */
+describe('resolveAppsPageAccess agrees with the predicate on the external-only cells', () => {
+  const MATRIX: Array<{
+    appListings?: boolean;
+    appBlocks?: boolean;
+    appListingsPublicExternal?: boolean;
+  }> = [
+    { appListingsPublicExternal: true },
+    { appListings: false, appBlocks: false, appListingsPublicExternal: true },
+    { appListings: false, appBlocks: false, appListingsPublicExternal: false },
+    { appListings: true, appBlocks: false, appListingsPublicExternal: true },
+    { appListings: false, appBlocks: true, appListingsPublicExternal: false },
+    { appListingsPublicExternal: undefined },
+  ];
+
+  for (const features of MATRIX) {
+    it(`agrees for ${JSON.stringify(features)}`, () => {
+      const granted = hasAppsStoreAccess(features);
+      const result = resolveAppsPageAccess({ features });
+      expect('props' in result).toBe(granted);
+      expect('notFound' in result).toBe(!granted);
+    });
+  }
+
+  it('🔴 external-only viewer reaches /apps — NOT notFound', () => {
+    expect(resolveAppsPageAccess({ features: { appListingsPublicExternal: true } })).toEqual({
+      props: {},
+    });
+  });
+
+  it('🔴 a viewer qualifying via NOTHING still gets notFound', () => {
+    expect(
+      resolveAppsPageAccess({
+        features: { appListings: false, appBlocks: false, appListingsPublicExternal: false },
+      })
+    ).toEqual({ notFound: true });
+  });
+});
+
+/**
  * 🔴 THE SEAM. The point of the extraction is that the SSR gate and the shared
  * predicate cannot disagree — a component tested in isolation and a resolver
  * tested in isolation can both be green while the pair is incoherent. This

--- a/src/components/Apps/__tests__/resolveLegacyAppRedirect.test.ts
+++ b/src/components/Apps/__tests__/resolveLegacyAppRedirect.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import type { StoreVisibilityScope } from '~/server/services/app-blocks-flag';
 import {
   approvedListingSlugQuery,
   resolveLegacyAppRedirect,
@@ -29,6 +30,24 @@ import {
  *     WHOLE suite; see that test for why.
  *   - rewrite a dot-only slug in the destination → 1 FAIL (the narrowed
  *     traversal-claim pin).
+ *
+ * The STORE-SCOPE guard (the disclosure gate added when the `/apps` page gate was
+ * widened to admit the external-only cohort) was measured the same way:
+ *   - delete the scope guard entirely → 4 FAIL.
+ *   - check the WRONG scope (`!== 'public-external'`) → 7 FAIL.
+ *   - denylist (`=== 'public-external'`) instead of the allowlist → 2 FAIL — and
+ *     note it is only 2, because a denylist is right about the headline case and
+ *     wrong only about `none`. That is precisely why the allowlist case exists.
+ *   - move the guard BELOW the DB read → 4 FAIL, and the first failure is a CALL
+ *     COUNT, not a result: the mutant still returns `notFound`, so only the
+ *     no-query assertions can see it.
+ *   - make the guard inert (`if (false)`) → 4 FAIL.
+ *   - 🔴 move the guard below the ROUTE-PARAM check → **0 FAIL — SURVIVES, and it
+ *     is an EQUIVALENT MUTANT, not a hole.** The param check has no side effect
+ *     and returns the identical bare `{ notFound: true }`, so no input can
+ *     distinguish the two orders. Recorded rather than papered over with a
+ *     fixture that fakes a difference; the overclaiming test name that used to
+ *     imply otherwise was removed. See that `it` for the full reasoning.
  *
  * 🔴 Two assertions in this file were REMOVED rather than kept, because they could
  * not fail: an `includes('/')` sub-assertion following a literal-equality assertion
@@ -227,6 +246,7 @@ describe('resolveLegacyAppRoute — SSR gate ordering', () => {
     const findApprovedListingSlug = lookup('model-benchmarking');
     const result = await resolveLegacyAppRoute({
       features: { appBlocks: false, appListings: false },
+      storeScope: 'none',
       appBlockId: 'apb_01KXPENN70SG0RXQKN7WMJMJHF',
       findApprovedListingSlug,
     });
@@ -238,7 +258,12 @@ describe('resolveLegacyAppRoute — SSR gate ordering', () => {
     for (const features of [undefined, null, {}]) {
       const findApprovedListingSlug = lookup('vitrine');
       expect(
-        await resolveLegacyAppRoute({ features, appBlockId: 'apb_x', findApprovedListingSlug })
+        await resolveLegacyAppRoute({
+          features,
+          storeScope: 'none',
+          appBlockId: 'apb_x',
+          findApprovedListingSlug,
+        })
       ).toEqual({ notFound: true });
       expect(findApprovedListingSlug).not.toHaveBeenCalled();
     }
@@ -251,7 +276,12 @@ describe('resolveLegacyAppRoute — SSR gate ordering', () => {
     ]) {
       const findApprovedListingSlug = lookup('vitrine');
       expect(
-        await resolveLegacyAppRoute({ features, appBlockId: 'apb_x', findApprovedListingSlug })
+        await resolveLegacyAppRoute({
+          features,
+          storeScope: 'full',
+          appBlockId: 'apb_x',
+          findApprovedListingSlug,
+        })
       ).toEqual({
         redirect: { destination: '/apps/store-preview/vitrine', permanent: false },
       });
@@ -260,14 +290,165 @@ describe('resolveLegacyAppRoute — SSR gate ordering', () => {
   });
 });
 
+/**
+ * 🔴 THE STORE-SCOPE GATE — the disclosure this route would otherwise arm.
+ *
+ * Until the `/apps` page gate gained its third term (`appListingsPublicExternal`,
+ * so the EXTERNAL-ONLY cohort could reach the store at all), gate (1) of
+ * `getListingDetail` — `scope === 'public-external' && kind !== 'offsite'` — was
+ * unreachable here purely by flag alignment: every viewer past the page gate
+ * resolved `full`. Widening the page gate ENDED that coincidence. Without the
+ * scope check, an external-only viewer would pass the page gate and receive
+ * `302 Location: /apps/store-preview/<onsite-slug>` — disclosing the slug AND the
+ * existence of an approved on-site listing to exactly the audience
+ * `public-external` exists to hide on-site apps from, plus a DB read on their
+ * behalf. The destination 404s for them, so the leak is the header and the query,
+ * not the page body.
+ *
+ * These pin BOTH halves, because `notFound` alone is only half the property: the
+ * gate-first ordering means an ungranted viewer also issues NO QUERY. A guard that
+ * returned `notFound` after the lookup would satisfy a result-only assertion while
+ * leaving the DB read (and its timing side channel) intact.
+ */
+describe('🔴 resolveLegacyAppRoute — the store-scope gate (on-site disclosure)', () => {
+  // The page gate is deliberately GRANTED in every case here, so the only thing
+  // that can decide the outcome is the scope. With `appListingsPublicExternal`
+  // this is the exact shape of a real external-only viewer.
+  const externalOnlyFeatures = {
+    appBlocks: false,
+    appListings: false,
+    appListingsPublicExternal: true,
+  };
+
+  it('public-external → notFound, and NO SLUG LOOKUP IS PERFORMED', async () => {
+    const findApprovedListingSlug = vi.fn(async () => 'model-benchmarking');
+    const result = await resolveLegacyAppRoute({
+      features: externalOnlyFeatures,
+      storeScope: 'public-external',
+      appBlockId: 'apb_01KXPENN70SG0RXQKN7WMJMJHF',
+      findApprovedListingSlug,
+    });
+    expect(result).toEqual({ notFound: true });
+    // 🔴 The half a result-only assertion cannot see. Moving the scope check
+    // BELOW the lookup still returns notFound; only this line catches it.
+    expect(findApprovedListingSlug).not.toHaveBeenCalled();
+    // …and nothing resembling a Location header escaped.
+    expect('redirect' in result).toBe(false);
+  });
+
+  it('🔴 CONTROL: the SAME viewer with scope `full` DOES redirect', async () => {
+    // Without this, the case above could be passing because the fixture is broken
+    // (a features object that never grants, a lookup that never resolves) rather
+    // than because the scope gate fired. Same features, same id, same lookup —
+    // only the scope differs.
+    const findApprovedListingSlug = vi.fn(async () => 'model-benchmarking');
+    const result = await resolveLegacyAppRoute({
+      features: externalOnlyFeatures,
+      storeScope: 'full',
+      appBlockId: 'apb_01KXPENN70SG0RXQKN7WMJMJHF',
+      findApprovedListingSlug,
+    });
+    expect(result).toEqual({
+      redirect: { destination: '/apps/store-preview/model-benchmarking', permanent: false },
+    });
+    expect(findApprovedListingSlug).toHaveBeenCalledTimes(1);
+  });
+
+  it('none → notFound, no query (the Flipt-outage case the page gate misses)', async () => {
+    // During a Flipt outage a MODERATOR's `features.appListings` resolves true from
+    // its static `availability: ['mod']` fallback while the server resolves scope
+    // `none` — so the page gate grants where the data layer would serve nothing.
+    // The allowlist rejects it; a denylist keyed only on `public-external` would not.
+    const findApprovedListingSlug = vi.fn(async () => 'vitrine');
+    const result = await resolveLegacyAppRoute({
+      features: { appListings: true, appBlocks: true },
+      storeScope: 'none',
+      appBlockId: 'apb_x',
+      findApprovedListingSlug,
+    });
+    expect(result).toEqual({ notFound: true });
+    expect(findApprovedListingSlug).not.toHaveBeenCalled();
+  });
+
+  it('full is the ONLY scope that proceeds (allowlist, not a denylist)', async () => {
+    // Data-driven over the whole union so a future fourth scope defaults to DENY
+    // and shows up here as a decision to make, rather than silently inheriting
+    // access. `satisfies` ties the list to the real type.
+    const scopes = ['full', 'public-external', 'none'] satisfies StoreVisibilityScope[];
+    const granting: StoreVisibilityScope[] = [];
+    for (const storeScope of scopes) {
+      const findApprovedListingSlug = vi.fn(async () => 'vitrine');
+      const result = await resolveLegacyAppRoute({
+        features: { appListings: true, appBlocks: true, appListingsPublicExternal: true },
+        storeScope,
+        appBlockId: 'apb_x',
+        findApprovedListingSlug,
+      });
+      if ('redirect' in result) granting.push(storeScope);
+      // The no-query property holds for EVERY non-granting scope, not just the
+      // one case spelled out above.
+      expect(findApprovedListingSlug.mock.calls.length, `scope ${storeScope} query count`).toBe(
+        'redirect' in result ? 1 : 0
+      );
+    }
+    expect(granting).toEqual(['full']);
+  });
+
+  it('a scope-rejected viewer gets an INDISTINGUISHABLE notFound for every param shape', async () => {
+    // The property that is actually observable and actually matters: a rejected
+    // viewer cannot tell a real app id from a malformed one — every param shape
+    // yields the same bare `notFound` with no `Location`, no body difference, and
+    // no query. So the route leaks nothing about which ids exist.
+    //
+    // 🔴 THIS `it` IS DELIBERATELY **NOT** NAMED "the gate runs before the param
+    // check", which is what it said in an earlier draft. That name was a claim it
+    // could not support, and the mutation run proved it: moving the scope guard to
+    // sit AFTER the param check left the entire suite green. It is an EQUIVALENT
+    // MUTANT — the param check has no side effect and returns the identical bare
+    // `{ notFound: true }`, so NO input distinguishes the two orders. Rather than
+    // invent a fixture that pretends otherwise, the overclaiming name is gone and
+    // the limit is recorded here.
+    //
+    // The ordering that IS security-relevant — guard before the DB READ — is a
+    // different thing entirely and IS killed: see the `NO SLUG LOOKUP IS
+    // PERFORMED` case above, which the after-the-query mutant fails on its own
+    // call-count assertion. The source keeps the guard above the param check for
+    // defence in depth (a future edit between the two would otherwise inherit an
+    // ungated param), not because a test can see it.
+    const findApprovedListingSlug = vi.fn(async () => 'vitrine');
+    const results = [];
+    for (const appBlockId of ['apb_real', '', undefined, 123, ['apb_x']]) {
+      results.push(
+        await resolveLegacyAppRoute({
+          features: externalOnlyFeatures,
+          storeScope: 'public-external',
+          appBlockId,
+          findApprovedListingSlug,
+        })
+      );
+    }
+    // Every outcome identical to the first — indistinguishability asserted as a
+    // relationship over the set, not case by case.
+    for (const result of results) expect(result).toEqual({ notFound: true });
+    expect(new Set(results.map((r) => JSON.stringify(r))).size).toBe(1);
+    expect(findApprovedListingSlug).not.toHaveBeenCalled();
+  });
+});
+
 describe('resolveLegacyAppRoute — route param handling', () => {
   const granted = { appBlocks: true };
+  const grantedScope = 'full' satisfies StoreVisibilityScope;
 
   it('a missing / non-string route param → notFound without querying', async () => {
     for (const appBlockId of [undefined, null, '', '   ', 123, ['apb_x']]) {
       const findApprovedListingSlug = vi.fn(async () => 'vitrine');
       expect(
-        await resolveLegacyAppRoute({ features: granted, appBlockId, findApprovedListingSlug })
+        await resolveLegacyAppRoute({
+          features: granted,
+          storeScope: grantedScope,
+          appBlockId,
+          findApprovedListingSlug,
+        })
       ).toEqual({ notFound: true });
       expect(findApprovedListingSlug).not.toHaveBeenCalled();
     }
@@ -287,6 +468,7 @@ describe('resolveLegacyAppRoute — route param handling', () => {
     expect(
       await resolveLegacyAppRoute({
         features: granted,
+        storeScope: grantedScope,
         appBlockId: '  apb_x  ',
         findApprovedListingSlug,
       })
@@ -300,6 +482,7 @@ describe('resolveLegacyAppRoute — route param handling', () => {
     expect(
       await resolveLegacyAppRoute({
         features: granted,
+        storeScope: grantedScope,
         appBlockId: 'apb_01KXPENN70SG0RXQKN7WMJMJHF',
         findApprovedListingSlug,
       })
@@ -312,6 +495,7 @@ describe('resolveLegacyAppRoute — route param handling', () => {
     const findApprovedListingSlug = vi.fn(async () => null);
     const result = await resolveLegacyAppRoute({
       features: granted,
+      storeScope: grantedScope,
       appBlockId: 'apb_pending',
       findApprovedListingSlug,
     });

--- a/src/components/Apps/resolveAppsPageAccess.ts
+++ b/src/components/Apps/resolveAppsPageAccess.ts
@@ -9,10 +9,19 @@
  *     to `appBlocks`. The boolean itself is NOT written here — it lives in the
  *     shared `hasAppsStoreAccess` predicate (`~/shared/utils/app-blocks-access`)
  *     that every store surface calls, so the SSR gate and the client-side gates
- *     cannot drift apart. Access = `features.appListings || features.appBlocks`. A
- *     logged-out / non-mod user satisfies NEITHER (both are mod-segmented today),
- *     so access is false for them → notFound. The store stays dark for real
- *     anon/non-mod users until a segment is widened at launch.
+ *     cannot drift apart. Access =
+ *     `features.appListings || features.appBlocks || features.appListingsPublicExternal`.
+ *     A logged-out / non-mod user satisfies NONE of them today (the first two are
+ *     mod-segmented, the third does not exist in Flipt), so access is false for them
+ *     → notFound. The store stays dark for real anon/non-mod users until a segment
+ *     is widened at launch.
+ *   - The THIRD term is the EXTERNAL-ONLY cohort, and it exists so that cohort can
+ *     REACH the store at all. Without it a viewer whose only qualification is
+ *     `app-listings-public-external` gets `notFound` here while the SERVER
+ *     (`resolveStoreVisibilityScope` → `public-external`) would happily serve them
+ *     the offsite catalog — the gate and the data path disagreeing about the same
+ *     flag. What they then SEE is still the server's call: offsite listings only,
+ *     onsite hidden. This gate decides reachability, never scope.
  *   - WHY the OR-fallback: `appListings` (Flipt `app-listings`) does not exist at
  *     merge time, so `features.appListings` resolves via its `availability:['mod']`
  *     Flipt-down fallback (mods only) while `appBlocks` still carries the

--- a/src/components/Apps/resolveLegacyAppRedirect.ts
+++ b/src/components/Apps/resolveLegacyAppRedirect.ts
@@ -56,6 +56,7 @@
  * `/apps/store-preview/` (an open redirect) or splicing a query/fragment onto it.
  */
 import { resolveAppsPageAccess } from '~/components/Apps/resolveAppsPageAccess';
+import type { StoreVisibilityScope } from '~/server/services/app-blocks-flag';
 import type { AppsStoreFeatureFlags } from '~/shared/utils/app-blocks-access';
 
 export type LegacyAppRedirectResult =
@@ -135,36 +136,72 @@ export function approvedListingSlugQuery(appBlockId: string) {
  *   2. DEPLOY — `row.kind === 'onsite' && appBlock.currentVersionDeployedAt == null`.
  *   3. MATURITY — `!redCapable && isMatureContentRating(row.contentRating)`.
  *
- * (2) and (3) are 0-instance today and would each affect a handful of apps at
- * most. (1) is categorically different and is the reason this disclosure is worth
- * reading twice: this route's param is an `AppBlock.id`, and EVERY listing that
- * carries an `appBlockId` is `kind='onsite'` — so **every** listing this route can
- * resolve is exactly the set `public-external` exists to hide. Under that scope
- * the coverage gap is 100%, not a corner.
+ * ## (1) IS NOW REPLICATED HERE. (2) and (3) ARE STILL OWED.
  *
- * It is UNREACHABLE TODAY, and only by an accident of flag alignment: the page
- * gate (`resolveAppsPageAccess`) grants on `features.appListings || appBlocks`,
- * and `features.appListings` reads the same `app-listings` Flipt key that
- * `resolveStoreVisibilityScope`'s axis 1 uses to return `full`. So any viewer who
- * gets past the page gate resolves `full`, where the kind gate is a no-op, and any
- * viewer who would resolve `public-external` is already 404'd by the page gate. If
- * `app-listings-public-external` is switched on and the PAGE gate is widened
- * alongside it, that alignment breaks and every `/apps/<appBlockId>` becomes a 302
- * disclosing an on-site app's slug to a viewer whose store scope excludes on-site
- * entirely.
+ * 🔴 THE ALIGNMENT ARGUMENT THIS COMMENT USED TO REST ON IS GONE — DO NOT RESTORE
+ * IT. It said gate (1) was unreachable "by an accident of flag alignment": the page
+ * gate granted on `features.appListings || appBlocks`, `features.appListings` read
+ * the same `app-listings` Flipt key that `resolveStoreVisibilityScope`'s axis 1
+ * uses to return `full`, so every viewer past the page gate resolved `full` and
+ * every viewer who would resolve `public-external` was already 404'd. That
+ * coincidence ENDED when the page gate gained a third term
+ * (`appListingsPublicExternal`) so the external-only cohort could reach `/apps`:
+ * from then on a `public-external` viewer passes the page gate, and without a
+ * scope check every `/apps/<appBlockId>` would 302 with an on-site listing's slug
+ * in the `Location` header — disclosing both the slug and the existence of an
+ * approved on-site listing to precisely the audience `public-external` exists to
+ * hide on-site apps from. (The destination 404s for them, so the leak is the
+ * header and the DB read, not the page.)
  *
- * So: replicating gates here needs all THREE — a store-scope check (which for this
- * route reduces to "`public-external` → `notFound`", since the resolvable set is
- * wholly on-site), a `currentVersionDeployedAt` filter, and a `contentRating`
- * filter keyed on the request's red-capability. NOT DONE IN THIS CHANGE and still
- * owed: it needs the resolved store scope and red-capability threaded into this
- * SSR resolver, neither of which it takes today. Doing it before the store widens
- * past its current audience is the fix.
+ * So the guard is no longer an alignment coincidence — it is the explicit
+ * `storeScope` check below, and it is what the no-disclosure property now rests
+ * on. `storeScope` is a REQUIRED argument for that reason: a caller that forgets
+ * it is a compile error, not a silent re-opening.
+ *
+ * It is an ALLOWLIST (`!== 'full'`), not a denylist on `public-external`. A
+ * denylist fails OPEN the moment a fourth scope is added — and the scope union is
+ * exactly the kind of thing that grows. `none` is rejected by the same line, which
+ * also closes a case the page gate alone does not: during a Flipt OUTAGE a
+ * moderator's `features.appListings` resolves true from its static
+ * `availability: ['mod']` fallback while the server resolves scope `none`, so the
+ * page gate grants where the data layer would serve nothing.
+ *
+ * STILL OWED (deliberately not done here — each needs another input threaded into
+ * this SSR resolver, and neither is reachable today): a `currentVersionDeployedAt`
+ * filter, and a `contentRating` filter keyed on the request's red-capability. Both
+ * are 0-instance today and would each affect a handful of apps at most.
+ *
+ * ⚠️ A SIZING CLAIM THAT USED TO LIVE HERE WAS WRONG, and is corrected rather than
+ * deleted so nobody re-derives it: this comment asserted that "EVERY listing that
+ * carries an `appBlockId` is `kind='onsite'`", making the gap under
+ * `public-external` exactly 100%. `schema.full.prisma` says otherwise — `appBlockId`
+ * is set for on-site listings AND for the #2821 off-site backfilled rows, and it is
+ * explicitly "NOT a kind discriminator: discriminate on `kind`, never on appBlockId
+ * nullness." The guard below is unaffected (it rejects the scope outright rather
+ * than reasoning about kinds), but the old blast-radius estimate was unreliable.
+ * Tracked in issue #3932 with the other findings from #3928's audit.
  */
 export async function resolveLegacyAppRoute(args: {
   // The SHARED flag type (derived from `FeatureAccess`), so a rename at GA is a
   // compile error here too — this resolver forwards straight into the store gate.
   features?: AppsStoreFeatureFlags;
+  /**
+   * The viewer's resolved store scope, from the SERVER helper
+   * `resolveStoreVisibilityScope({ user })` — NOT re-derived from `features`.
+   *
+   * 🔴 Why the server helper and not the client feature object: they are two
+   * evaluations of the same flags and they can disagree (a Flipt outage makes the
+   * client fall back to each flag's static `availability` while the server has no
+   * such fallback). This is a DISCLOSURE gate, so it must key off the same value
+   * the DATA layer keys off — `getListingDetail`'s `scope` — or the gate and the
+   * thing it is gating are answering different questions. This is an async SSR
+   * resolver, so the server helper is simply available; there is no reason to
+   * approximate it.
+   *
+   * REQUIRED, not optional-with-a-default: a default would let a new caller
+   * silently re-open the disclosure.
+   */
+  storeScope: StoreVisibilityScope;
   appBlockId?: unknown;
   /** Approved-only slug lookup. Use `approvedListingSlugQuery` to build it. */
   findApprovedListingSlug: (appBlockId: string) => Promise<string | null | undefined>;
@@ -172,6 +209,13 @@ export async function resolveLegacyAppRoute(args: {
   // 🔒 GATE FIRST — before the param is read, before anything is queried.
   const access = resolveAppsPageAccess({ features: args.features });
   if ('notFound' in access) return { notFound: true };
+
+  // 🔒 STORE-SCOPE GATE, also before the param and the query. ALLOWLIST: only a
+  // `full` viewer may resolve this route. `public-external` must not learn an
+  // on-site listing's slug from a `Location` header, and `none` has no store at
+  // all. See the block comment — this replaces an alignment coincidence that the
+  // widened page gate ended.
+  if (args.storeScope !== 'full') return { notFound: true };
 
   const appBlockId = typeof args.appBlockId === 'string' ? args.appBlockId.trim() : '';
   if (!appBlockId) return { notFound: true };

--- a/src/pages/apps/[appBlockId]/index.tsx
+++ b/src/pages/apps/[appBlockId]/index.tsx
@@ -49,6 +49,7 @@ import {
   SLOT_DESCRIPTIONS,
 } from '~/server/services/blocks/scope-descriptions.constants';
 import { dbRead } from '~/server/db/client';
+import { resolveStoreVisibilityScope } from '~/server/services/app-blocks-flag';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { hasInstallSlot } from '~/shared/constants/slot-registry';
 import { trpc } from '~/utils/trpc';
@@ -110,13 +111,20 @@ import { trpc } from '~/utils/trpc';
  *     approved on-site listing declares a page), but it is why the follow-up
  *     should retarget that branch, not merely delete the route.
  *
- * 🔒 GATING INVARIANT (E2 — unchanged, do not violate):
- *   - The SSR resolver runs `resolveAppsPageAccess` FIRST: the `features.appBlocks`
- *     flag gate is the ONLY access control. A real anon / non-mod viewer does not
- *     satisfy the mod-segmented Flipt `app-blocks-enabled` flag, so they get
+ * 🔒 GATING INVARIANT (E2, + the external-only store scope):
+ *   - The SSR resolver runs `resolveAppsPageAccess` FIRST. A real anon / non-mod
+ *     viewer does not satisfy the mod-segmented Flipt flags behind it, so they get
  *     `notFound`. The page is anon-CAPABLE in code (no session→login redirect)
- *     but DARK until the segment is widened at launch — there is intentionally
+ *     but DARK until a segment is widened at launch — there is intentionally
  *     NO hardcoded isModerator belt (that would break the eventual public flip).
+ *   - 🔴 THE PAGE GATE IS NO LONGER THE ONLY ACCESS CONTROL, and the old wording
+ *     saying it was is retired rather than softened. A SECOND gate — the resolved
+ *     store scope — runs immediately after it and admits ONLY `full`. It exists
+ *     because the page gate now also grants the EXTERNAL-ONLY cohort (so they can
+ *     reach `/apps`), and this route resolves on-site listings: without the scope
+ *     check they would get a 302 disclosing an on-site listing's slug. Both gates
+ *     run before the route param is read and before any query — see
+ *     `resolveLegacyAppRoute`.
  *   - `deIndex` stays ON in the page <Meta> (per-app OG/title/description are
  *     added now, but the page is not crawlable pre-launch — drop `deIndex` only
  *     at launch).
@@ -143,9 +151,18 @@ export const getServerSideProps = createServerSideProps({
   // existence of an approved listing the actual precondition of the redirect —
   // the decided behaviour — and it stays correct if a slug ever diverges from
   // its block id (off-site listings already choose their own slugs).
-  resolver: async ({ ctx, features }) =>
+  //
+  // 🔴 `storeScope` is resolved SERVER-SIDE here (`resolveStoreVisibilityScope`),
+  // not re-derived from `features`. It is a DISCLOSURE gate — it must key off the
+  // same value the DATA layer keys off (`getListingDetail`'s `scope`), and the two
+  // can disagree during a Flipt outage. Without it, once
+  // `app-listings-public-external` is enabled an external-only viewer would pass
+  // the (now-widened) page gate and get a 302 carrying an on-site listing's slug.
+  // See the block comment on `resolveLegacyAppRoute`.
+  resolver: async ({ ctx, features, session }) =>
     resolveLegacyAppRoute({
       features,
+      storeScope: await resolveStoreVisibilityScope({ user: session?.user }),
       appBlockId: ctx.params?.appBlockId,
       findApprovedListingSlug: async (appBlockId) =>
         (await dbRead.appListing.findFirst(approvedListingSlugQuery(appBlockId)))?.slug ?? null,

--- a/src/server/services/__tests__/app-blocks-flag.external-scope.seam.test.ts
+++ b/src/server/services/__tests__/app-blocks-flag.external-scope.seam.test.ts
@@ -1,0 +1,502 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IncomingMessage } from 'http';
+import type { NextApiRequest } from 'next';
+import type { SessionUser } from '~/types/session';
+
+/**
+ * 🔴 THE SERVER/CLIENT SEAM for `app-listings-public-external`.
+ *
+ * The SAME Flipt flag is evaluated TWICE per request, by two different code paths
+ * that have never shared a test:
+ *
+ *   SERVER DATA PATH   `isExternalListingsPublicEnabled({ user })`
+ *                      → `isFlipt(key, id, ctx)`            (ASYNC eval)
+ *                      → `resolveStoreVisibilityScope` → the store read procs.
+ *
+ *   PAGE GATE          `featureFlags.appListingsPublicExternal`
+ *                      → `isFliptSync(key, id, ctx)`        (SYNC eval, + a static
+ *                        `availability` fallback when Flipt answers `null`)
+ *                      → `ctx.features` → `hasAppsStoreAccess` → `resolveAppsPageAccess`.
+ *
+ * If they disagree the feature is broken in one of two silent ways: the viewer
+ * passes the page gate and sees an EMPTY store, or the viewer is 404'd off a
+ * catalog the server would happily have served. Neither surfaces as an error.
+ *
+ * ⚠️ EVERY OTHER SUITE HERE TESTS ONE SIDE IN ISOLATION. `app-blocks-flag.*` mocks
+ * Flipt and exercises only the server helpers; `hasAppsStoreAccess.test.ts` feeds
+ * the predicate a hand-written features object. Both can be green while the pair is
+ * incoherent — the isolated-seam failure mode. So this file loads BOTH REAL sides
+ * (the real `feature-flags.service`, the real `app-blocks-flag`, the real shared
+ * predicate and the real SSR resolver) against ONE fake Flipt configuration and
+ * asserts the RELATIONSHIP:
+ *
+ *      resolveAppsPageAccess grants  ⟺  resolveStoreVisibilityScope !== 'none'
+ *
+ * The two asymmetries the fake models faithfully, because they are exactly what a
+ * hand-written double would get wrong:
+ *   - the ASYNC `isEnabled` returns `false` for an absent flag / eval error, while
+ *     the SYNC `isEnabledSync` returns `null` and lets the caller fall through to
+ *     the static `availability`. That asymmetry is why the client entry is
+ *     `availability: []` and not `['mod']`.
+ *   - the anon eval identity differs by construction: `'global'`/`{}` on the server
+ *     vs `'anonymous'`/`{isLoggedIn:'false'}` in the client gate. Pinned explicitly
+ *     at the bottom rather than papered over.
+ */
+
+// Read at IMPORT time by feature-flags.service (color-host sets) — set before the
+// module evaluates, mirroring feature-flags.lazy-equivalence.test.ts.
+vi.hoisted(() => {
+  process.env.SERVER_DOMAIN_GREEN = 'civitai.com';
+  process.env.SERVER_DOMAIN_BLUE = 'civitai.blue';
+  process.env.SERVER_DOMAIN_RED = 'civitai.red';
+});
+
+type FlagShape =
+  | { kind: 'absent' }
+  | { kind: 'base'; enabled: boolean }
+  | { kind: 'segment'; base: boolean; match: (ctx: Record<string, string>) => boolean }
+  /** Percentage-style: the decision is a function of the ENTITY ID, not the context. */
+  | { kind: 'byEntity'; match: (entityId: string) => boolean };
+
+const { flagState } = vi.hoisted(() => ({
+  flagState: { flags: {} as Record<string, unknown> },
+}));
+
+/** Shared truth table. `evalFlag` returns `null` for "flag not found", like Flipt. */
+function evalFlag(flag: string, entityId: string, context: Record<string, string>): boolean | null {
+  const shape = (flagState.flags[flag] as FlagShape | undefined) ?? { kind: 'absent' };
+  switch (shape.kind) {
+    case 'absent':
+      return null;
+    case 'base':
+      return shape.enabled;
+    case 'segment':
+      return shape.match(context) ? true : shape.base;
+    case 'byEntity':
+      return shape.match(entityId);
+  }
+}
+
+vi.mock('~/server/flipt/client', () => ({
+  // ASYNC: swallows "not found" and returns FALSE (see @civitai/flipt isEnabled).
+  isFlipt: async (flag: string, entityId = 'global', context: Record<string, string> = {}) =>
+    evalFlag(flag, entityId, context) ?? false,
+  // SYNC: returns NULL for "not found" so the caller falls through to the static
+  // availability (see @civitai/flipt isEnabledSync).
+  isFliptSync: (flag: string, entityId = 'global', context: Record<string, string> = {}) =>
+    evalFlag(flag, entityId, context),
+  // Already "initialized" — the fake evaluates synchronously off `flagState`.
+  ensureFliptInitialized: async () => undefined,
+}));
+
+import { resolveAppsPageAccess } from '~/components/Apps/resolveAppsPageAccess';
+import {
+  APP_LISTINGS_PUBLIC_EXTERNAL_FLAG,
+  isExternalListingsPublicEnabled,
+  resolveStoreVisibilityScope,
+} from '../app-blocks-flag';
+import {
+  getFeatureFlags,
+  getFeatureFlagsAsync,
+  getFeatureFlagsLazy,
+} from '../feature-flags.service';
+import { hasAppsStoreAccess } from '~/shared/utils/app-blocks-access';
+
+const EXTERNAL = APP_LISTINGS_PUBLIC_EXTERNAL_FLAG;
+const LISTINGS = 'app-listings';
+const BLOCKS = 'app-blocks-enabled';
+
+function makeUser(over: Partial<SessionUser> = {}): SessionUser {
+  return {
+    id: 100,
+    username: 'u',
+    isModerator: false,
+    tier: 'free',
+    permissions: [],
+    onboarding: 0,
+    ...over,
+  } as SessionUser;
+}
+
+/**
+ * `getFeatureFlags` memoizes on (user identity, host, region) for 10s, so two cases
+ * with the SAME user and DIFFERENT flag config would silently read one cached
+ * answer — the whole matrix would then be one measurement repeated. Each call gets
+ * a fresh host, which is part of the cache key and inert for these three flags
+ * (none declares a server/color availability, so `serverMatch` is unconditionally
+ * true). The `cache is actually bypassed` control below proves it works.
+ */
+let hostSeq = 0;
+function makeReq(): NextApiRequest {
+  return { headers: { host: `c${hostSeq++}.civitai.com` } } as unknown as NextApiRequest;
+}
+
+type Ctx = { user?: SessionUser; req: NextApiRequest | IncomingMessage };
+
+beforeAll(async () => {
+  // Prime the service's private `_fliptModule` (our mock) so the SYNC Flipt branch
+  // inside `hasFeature` is live. Without this the branch is skipped entirely and
+  // every flag falls to its static availability — the suite would still be green
+  // and would be measuring nothing.
+  await getFeatureFlagsAsync({ req: makeReq() });
+});
+
+beforeEach(() => {
+  flagState.flags = {};
+});
+
+/** The client's view, taken through the EAGER path the `/apps` SSR resolver uses. */
+function clientFeatures(user?: SessionUser) {
+  return getFeatureFlags({ user, req: makeReq() } as Ctx);
+}
+
+/** Both halves of the seam, measured against one flag config. */
+async function measure(user?: SessionUser) {
+  const scope = await resolveStoreVisibilityScope({ user });
+  const features = clientFeatures(user);
+  const page = resolveAppsPageAccess({ features });
+  return {
+    scope,
+    features,
+    pageGranted: 'props' in page,
+    predicate: hasAppsStoreAccess(features),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Instrument controls — a verdict from an unvalidated harness is worthless
+// ---------------------------------------------------------------------------
+
+describe('the harness (validate the instrument before reading its verdict)', () => {
+  it('🔴 POSITIVE CONTROL: the Flipt branch is LIVE (a config change moves BOTH sides)', async () => {
+    // Without this, a suite whose flags never take effect reports a reassuring
+    // "everything agrees" — two sides agreeing because neither is wired to anything.
+    const user = makeUser({ id: 555 });
+    expect(clientFeatures(user).appListingsPublicExternal).toBeFalsy();
+    await expect(isExternalListingsPublicEnabled({ user })).resolves.toBe(false);
+    flagState.flags[EXTERNAL] = { kind: 'base', enabled: true } satisfies FlagShape;
+    expect(clientFeatures(user).appListingsPublicExternal).toBe(true);
+    await expect(isExternalListingsPublicEnabled({ user })).resolves.toBe(true);
+  });
+
+  it('🔴 KEY IDENTITY, proven behaviourally: both sides read the SAME Flipt key', async () => {
+    // A typo in the client entry's `fliptKey` would make every agreement assertion
+    // below pass vacuously (two flags nobody ever sets). Setting a NEIGHBOURING key
+    // must move NEITHER side; setting the real one must move BOTH.
+    const user = makeUser({ id: 558 });
+    flagState.flags['app-listings-public-external-typo'] = {
+      kind: 'base',
+      enabled: true,
+    } satisfies FlagShape;
+    expect(clientFeatures(user).appListingsPublicExternal).toBeFalsy();
+    await expect(isExternalListingsPublicEnabled({ user })).resolves.toBe(false);
+    flagState.flags[EXTERNAL] = { kind: 'base', enabled: true } satisfies FlagShape;
+    expect(clientFeatures(user).appListingsPublicExternal).toBe(true);
+    await expect(isExternalListingsPublicEnabled({ user })).resolves.toBe(true);
+  });
+
+  it('🔴 the 10s feature-flag CACHE is actually bypassed between cases', () => {
+    // If it were not, every case after the first would read a stale answer and the
+    // matrix would be one measurement wearing many hats.
+    const user = makeUser({ id: 556 });
+    flagState.flags[EXTERNAL] = { kind: 'base', enabled: false } satisfies FlagShape;
+    expect(clientFeatures(user).appListingsPublicExternal).toBeFalsy();
+    flagState.flags[EXTERNAL] = { kind: 'base', enabled: true } satisfies FlagShape;
+    expect(clientFeatures(user).appListingsPublicExternal).toBe(true);
+  });
+
+  it('🔴 the client entry is fail-closed for a MODERATOR when the flag is ABSENT', () => {
+    // The behavioural form of "availability: [] and not ['mod']". This is the exact
+    // mutant the entry's comment warns about: with `['mod']` the static fallback
+    // would light this for a moderator while the SERVER's async eval — which has no
+    // static fallback at all — returned false for the same absent flag.
+    // The async/sync asymmetry is real and modelled: absent ⇒ false vs null.
+    const mod = makeUser({ id: 557, isModerator: true });
+    expect(clientFeatures(mod).appListingsPublicExternal).toBeFalsy();
+    // Control: a `['mod']`-availability sibling flag DOES light up for the same
+    // user under the same absent-flag conditions, so the assertion above is a fact
+    // about THIS entry rather than about the harness.
+    expect(clientFeatures(mod).appListings).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The seam itself
+// ---------------------------------------------------------------------------
+
+/**
+ * The invariant, over every flag configuration the rollout can produce:
+ *   page gate grants  ⟺  the server resolves a NON-EMPTY scope.
+ */
+describe('🔴 SEAM: page-gate access ⟺ a non-empty server scope', () => {
+  const MOD_SEGMENT: FlagShape = {
+    kind: 'segment',
+    base: false,
+    match: (ctx) => ctx.isModerator === 'true',
+  };
+  const TESTER_SEGMENT: FlagShape = {
+    kind: 'segment',
+    base: false,
+    match: (ctx) => ctx.userId === '777' || ctx.userId === '778',
+  };
+
+  const users: Array<[string, SessionUser | undefined]> = [
+    ['moderator', makeUser({ id: 1, isModerator: true })],
+    ['app-dev-tester (app-listings)', makeUser({ id: 888 })],
+    ['external tester (in segment)', makeUser({ id: 777 })],
+    ['plain logged-in user', makeUser({ id: 555 })],
+  ];
+
+  const configs: Array<[string, Record<string, FlagShape>]> = [
+    ['as-merged (external flag ABSENT)', { [BLOCKS]: MOD_SEGMENT, [LISTINGS]: TESTER_LISTINGS() }],
+    [
+      'external flag SEGMENTED to testers',
+      { [BLOCKS]: MOD_SEGMENT, [LISTINGS]: TESTER_LISTINGS(), [EXTERNAL]: TESTER_SEGMENT },
+    ],
+    [
+      'external flag base-ENABLED (the later public flip)',
+      {
+        [BLOCKS]: MOD_SEGMENT,
+        [LISTINGS]: TESTER_LISTINGS(),
+        [EXTERNAL]: { kind: 'base', enabled: true },
+      },
+    ],
+    [
+      'external flag base-DISABLED',
+      {
+        [BLOCKS]: MOD_SEGMENT,
+        [LISTINGS]: TESTER_LISTINGS(),
+        [EXTERNAL]: { kind: 'base', enabled: false },
+      },
+    ],
+  ];
+
+  function TESTER_LISTINGS(): FlagShape {
+    return { kind: 'segment', base: false, match: (ctx) => ctx.userId === '888' };
+  }
+
+  for (const [configName, config] of configs) {
+    for (const [userName, user] of users) {
+      it(`${configName} × ${userName}`, async () => {
+        flagState.flags = { ...config };
+        const { scope, pageGranted, predicate } = await measure(user);
+        expect(pageGranted, `scope=${scope}`).toBe(scope !== 'none');
+        // …and the page result is exactly the shared predicate, so a future
+        // re-inlining of the gate cannot slip past this.
+        expect(predicate).toBe(pageGranted);
+      });
+    }
+  }
+
+  /**
+   * 🔴 SCOPE OF THE CLAIM ABOVE — the matrix is deliberately restricted to
+   * "Flipt is REACHABLE". It says nothing about a Flipt OUTAGE, and that is not an
+   * oversight: a PRE-EXISTING divergence lives there, measured in the next describe.
+   * Stating the boundary here so the biconditional is not read as unconditional.
+   */
+  it('the matrix is NON-VACUOUS: it produced all three scopes and both gate outcomes', async () => {
+    const seen = new Set<string>();
+    const gates = new Set<boolean>();
+    for (const [, config] of configs) {
+      for (const [, user] of users) {
+        flagState.flags = { ...config };
+        const { scope, pageGranted } = await measure(user);
+        seen.add(scope);
+        gates.add(pageGranted);
+      }
+    }
+    expect([...seen].sort()).toEqual(['full', 'none', 'public-external']);
+    expect([...gates].sort()).toEqual([false, true]);
+  });
+});
+
+/**
+ * 🔴 A PRE-EXISTING SEAM GAP, FOUND WHILE BUILDING THIS FILE — recorded, not fixed.
+ *
+ * When Flipt is UNREACHABLE (or a flag is absent) the two sides are asymmetric BY
+ * DESIGN: the CLIENT gate falls through to each entry's static `availability`,
+ * while the SERVER helpers have no static fallback at all and simply resolve
+ * `false`. For a MODERATOR that means `appListings`/`appBlocks` resolve `true`
+ * statically → the page gate GRANTS, while `resolveStoreVisibilityScope` resolves
+ * `none` → the store is empty. A moderator during a Flipt outage therefore loads
+ * `/apps` and sees nothing.
+ *
+ * That predates this change (it is a property of `app-listings` +
+ * `app-blocks-enabled`, both `availability: ['mod']`), it is in the SAFE direction
+ * (a mod sees an empty page; nobody sees anything they should not), and closing it
+ * means giving the server a static mod floor — a behaviour change to the privileged
+ * path, out of scope here. It is asserted rather than left implicit so it cannot be
+ * mistaken for something this change introduced, and so a future fix has a test to
+ * flip.
+ *
+ * What DOES hold for the new flag: the external-only cohort is dark on BOTH sides
+ * during an outage. That is the property this change is responsible for.
+ */
+describe('🔴 Flipt DOWN: the new flag is dark on both sides (and the pre-existing mod gap is pinned)', () => {
+  beforeEach(() => {
+    flagState.flags = {}; // every flag absent === Flipt unreachable
+  });
+
+  it('the NEW flag fails closed on BOTH sides, for every cohort', async () => {
+    for (const user of [
+      makeUser({ id: 1, isModerator: true }),
+      makeUser({ id: 777 }),
+      makeUser({ id: 555 }),
+      undefined,
+    ]) {
+      await expect(isExternalListingsPublicEnabled({ user })).resolves.toBe(false);
+      expect(clientFeatures(user).appListingsPublicExternal).toBeFalsy();
+    }
+  });
+
+  it('a non-privileged viewer is dark on both sides (no page, no scope)', async () => {
+    const { scope, pageGranted } = await measure(makeUser({ id: 555 }));
+    expect(scope).toBe('none');
+    expect(pageGranted).toBe(false);
+  });
+
+  it('PRE-EXISTING (not introduced here): a MODERATOR gets the page but an empty scope', async () => {
+    const { scope, pageGranted, features } = await measure(makeUser({ id: 1, isModerator: true }));
+    expect(pageGranted).toBe(true);
+    expect(scope).toBe('none');
+    // …and it comes from the two OLD flags' `['mod']` static fallback, not the new
+    // one — which is exactly why the new entry is `availability: []`.
+    expect(features.appListings).toBe(true);
+    expect(features.appBlocks).toBe(true);
+    expect(features.appListingsPublicExternal).toBeFalsy();
+  });
+});
+
+describe('🔴 the external-ONLY viewer: reachable, and scoped to offsite', () => {
+  beforeEach(() => {
+    // Deliberately NO app-listings / app-blocks-enabled grant for this user: the
+    // external flag is their ONLY qualification.
+    flagState.flags[EXTERNAL] = {
+      kind: 'segment',
+      base: false,
+      match: (ctx) => ctx.userId === '777',
+    } satisfies FlagShape;
+  });
+
+  it('reaches /apps — no notFound (the blocker this change removes)', async () => {
+    const user = makeUser({ id: 777 });
+    const { scope, pageGranted, features } = await measure(user);
+    expect(scope).toBe('public-external');
+    expect(pageGranted).toBe(true);
+    // …and they hold NEITHER of the two older store flags, so the grant really did
+    // come from the new term rather than from an accidental widening.
+    expect(features.appListings).toBeFalsy();
+    expect(features.appBlocks).toBeFalsy();
+    expect(features.appListingsPublicExternal).toBe(true);
+  });
+
+  it('a viewer qualifying via NOTHING still gets notFound', async () => {
+    const user = makeUser({ id: 555 });
+    const { scope, pageGranted } = await measure(user);
+    expect(scope).toBe('none');
+    expect(pageGranted).toBe(false);
+    expect(resolveAppsPageAccess({ features: clientFeatures(user) })).toEqual({ notFound: true });
+  });
+
+  it('🔴 does NOT widen any block-RUNTIME surface', async () => {
+    // `/apps/installed`, `/apps/run/<slug>`, the `blocks.*` procs and the author
+    // surfaces gate on `appBlocks` / `appBlocksPages` / `appBlocksAuthor` alone.
+    // The external cohort must reach the CATALOG and nothing else.
+    const features = clientFeatures(makeUser({ id: 777 }));
+    expect(features.appBlocks).toBeFalsy();
+    expect(features.appBlocksPages).toBeFalsy();
+    expect(features.appBlocksAuthor).toBeFalsy();
+    expect(features.appListings).toBeFalsy();
+  });
+});
+
+describe('the eager and lazy client paths agree on the new key', () => {
+  // `/apps` SSR uses eager (`getFeatureFlagsAsync`), tRPC uses lazy
+  // (`getFeatureFlagsLazy`). A viewer whose page gate and API gate disagreed would
+  // be a second seam.
+  for (const shape of [
+    { name: 'absent', flag: undefined },
+    { name: 'base-enabled', flag: { kind: 'base', enabled: true } as FlagShape },
+    {
+      name: 'segmented',
+      flag: {
+        kind: 'segment',
+        base: false,
+        match: (ctx: Record<string, string>) => ctx.userId === '777',
+      } as FlagShape,
+    },
+  ]) {
+    it(`${shape.name}`, () => {
+      if (shape.flag) flagState.flags[EXTERNAL] = shape.flag;
+      for (const id of [777, 555]) {
+        const user = makeUser({ id });
+        const eager = getFeatureFlags({ user, req: makeReq() });
+        const lazy = getFeatureFlagsLazy({ user, req: makeReq() });
+        expect(!!lazy.appListingsPublicExternal, `id=${id}`).toBe(
+          !!eager.appListingsPublicExternal
+        );
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// The residual divergence — stated and measured, not papered over
+// ---------------------------------------------------------------------------
+
+/**
+ * 🔴 THE ONE PLACE THE TWO SIDES CAN DISAGREE, pinned so it is a known bound rather
+ * than a surprise. For an ANONYMOUS viewer the server evals with entityId
+ * `'global'` and an EMPTY context (the byte-identical backward-compatible path the
+ * brief requires), while the client gate evals with `'anonymous'` and
+ * `{isLoggedIn:'false'}`. That is PRE-EXISTING for every flag in this family —
+ * `app-listings` and `app-blocks-enabled` have always had it — and it is invisible
+ * for the two flag shapes this rollout uses.
+ */
+describe('anon eval identity: agrees for the supported shapes, diverges only under a percentage rollout', () => {
+  it('base-enabled → both sides TRUE for anon (the public flip works)', async () => {
+    flagState.flags[EXTERNAL] = { kind: 'base', enabled: true } satisfies FlagShape;
+    await expect(isExternalListingsPublicEnabled()).resolves.toBe(true);
+    expect(clientFeatures(undefined).appListingsPublicExternal).toBe(true);
+    expect(resolveAppsPageAccess({ features: clientFeatures(undefined) })).toEqual({ props: {} });
+  });
+
+  it('user-property segment → both sides FALSE for anon (anon carries no userId)', async () => {
+    flagState.flags[EXTERNAL] = {
+      kind: 'segment',
+      base: false,
+      match: (ctx) => ctx.userId === '777',
+    } satisfies FlagShape;
+    await expect(isExternalListingsPublicEnabled()).resolves.toBe(false);
+    expect(clientFeatures(undefined).appListingsPublicExternal).toBeFalsy();
+  });
+
+  it('absent flag → both sides FALSE for anon (fail-closed together)', async () => {
+    await expect(isExternalListingsPublicEnabled()).resolves.toBe(false);
+    expect(clientFeatures(undefined).appListingsPublicExternal).toBeFalsy();
+  });
+
+  it('🔴 a PERCENTAGE/entityId rollout DOES diverge for anon — do not configure one', async () => {
+    // The measured bound on the claim above. Matching only `'anonymous'` lights the
+    // CLIENT gate while the server (`'global'`) stays dark: the viewer would load
+    // /apps and get an empty store. Documented on APP_LISTINGS_PUBLIC_EXTERNAL_FLAG.
+    flagState.flags[EXTERNAL] = {
+      kind: 'byEntity',
+      match: (entityId) => entityId === 'anonymous',
+    } satisfies FlagShape;
+    await expect(isExternalListingsPublicEnabled()).resolves.toBe(false);
+    expect(clientFeatures(undefined).appListingsPublicExternal).toBe(true);
+  });
+
+  it('a LOGGED-IN viewer never diverges, even under an entityId rollout (same entityId)', async () => {
+    flagState.flags[EXTERNAL] = {
+      kind: 'byEntity',
+      match: (entityId) => entityId === '777',
+    } satisfies FlagShape;
+    for (const id of [777, 555]) {
+      const user = makeUser({ id });
+      const server = await isExternalListingsPublicEnabled({ user });
+      expect(!!clientFeatures(user).appListingsPublicExternal, `id=${id}`).toBe(server);
+    }
+  });
+});

--- a/src/server/services/__tests__/app-blocks-flag.external-scope.test.ts
+++ b/src/server/services/__tests__/app-blocks-flag.external-scope.test.ts
@@ -1,0 +1,355 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionUser } from '~/types/session';
+
+/**
+ * EXTERNAL-ONLY store scope — the segment-capable `app-listings-public-external`
+ * flag and the `resolveStoreVisibilityScope` priority order it feeds.
+ *
+ * WHAT CHANGED AND WHY IT MATTERS: `isExternalListingsPublicEnabled` used to be a
+ * bare `isFlipt(FLAG)` — a GLOBAL eval (entityId='global', empty context). A Flipt
+ * SEGMENT can only match on the context it is handed, so a `testers` segment on
+ * that flag resolved `false` for every member of the cohort and the whole feature
+ * was unreachable by construction. It now evaluates PER-USER when a user is
+ * present, exactly like `isAppBlocksEnabled` / `isAppListingsEnabled`.
+ *
+ * Two properties are load-bearing and are pinned separately below:
+ *   1. BACKWARD COMPATIBILITY — with NO user the call must be byte-identical to
+ *      the old global eval, and a BASE-ENABLED flag must still resolve true for
+ *      everyone. Adding context may only ADD segmentation, never narrow.
+ *   2. PRIORITY ORDER — the privileged axis is checked FIRST, so a moderator who
+ *      also falls inside the external cohort still resolves `full` and is never
+ *      NARROWED to `public-external`.
+ *
+ * `isFlipt` is mocked with a faithful re-implementation of how a real Flipt boolean
+ * flag evaluates (base value + optional segment rollout matched against the eval
+ * context), so the assertions mirror production wiring rather than the helper's own
+ * branches. `buildFliptContext` is the REAL function — the same one the CLIENT gate
+ * uses, which is the anti-drift mechanism this whole seam rests on.
+ */
+
+const { mockIsFlipt } = vi.hoisted(() => ({ mockIsFlipt: vi.fn() }));
+
+vi.mock('~/server/flipt/client', () => ({
+  isFlipt: mockIsFlipt,
+}));
+
+import {
+  APP_LISTINGS_PUBLIC_EXTERNAL_FLAG,
+  isExternalListingsPublicEnabled,
+  resolveStoreVisibilityScope,
+} from '../app-blocks-flag';
+import { buildFliptContext } from '../feature-flags.service';
+
+const EXTERNAL = APP_LISTINGS_PUBLIC_EXTERNAL_FLAG;
+
+function makeUser(over: Partial<SessionUser> = {}): SessionUser {
+  return { id: 123, username: 'u', isModerator: false, tier: 'free', ...over } as SessionUser;
+}
+
+/**
+ * A faithful stand-in for ONE Flipt boolean flag.
+ *
+ * Real Flipt evaluates rollouts in order and falls back to the flag's base
+ * `enabled` when none match — that is precisely why a base-enabled flag is immune
+ * to the entityId/context you hand it, and why a segmented one is not. Modelling
+ * both shapes (rather than a bare boolean) is what lets the backward-compatibility
+ * assertions below mean anything.
+ */
+type FlagShape =
+  | { kind: 'absent' }
+  | { kind: 'base'; enabled: boolean }
+  | { kind: 'segment'; base: boolean; match: (ctx: Record<string, string>) => boolean };
+
+let flags: Record<string, FlagShape>;
+
+// Tuple params with a destructuring HOLE for entityId: these shapes are all
+// context-driven (that is the point — a segment matches on context, not on the
+// entity), so entityId is deliberately unread rather than named-and-ignored.
+function evaluate(
+  ...args: [flag: string, entityId?: string, context?: Record<string, string>]
+): boolean {
+  const [flag, , ctxArg] = args;
+  const context = ctxArg ?? {};
+  const shape = flags[flag] ?? { kind: 'absent' };
+  // Absent flag / Flipt down: the real async `isFlipt` swallows the error and
+  // returns false. Fail-closed.
+  if (shape.kind === 'absent') return false;
+  if (shape.kind === 'base') return shape.enabled;
+  return shape.match(context) ? true : shape.base;
+}
+
+/** The tester cohort segment: a userId allowlist, matched off the eval context. */
+const TESTERS = new Set(['777', '778']);
+const testerSegment: FlagShape = {
+  kind: 'segment',
+  base: false,
+  match: (ctx) => typeof ctx.userId === 'string' && TESTERS.has(ctx.userId),
+};
+
+beforeEach(() => {
+  flags = {};
+  mockIsFlipt.mockReset();
+  mockIsFlipt.mockImplementation(async (...args: Parameters<typeof evaluate>) => evaluate(...args));
+});
+
+// ---------------------------------------------------------------------------
+// 1. The user-aware eval
+// ---------------------------------------------------------------------------
+
+describe('isExternalListingsPublicEnabled — user-aware eval (segment-capable)', () => {
+  it('🔴 a SEGMENT-scoped flag matches for an IN-segment user', async () => {
+    flags[EXTERNAL] = testerSegment;
+    await expect(isExternalListingsPublicEnabled({ user: makeUser({ id: 777 }) })).resolves.toBe(
+      true
+    );
+  });
+
+  it('🔴 …and does NOT match for an OUT-of-segment user', async () => {
+    flags[EXTERNAL] = testerSegment;
+    await expect(isExternalListingsPublicEnabled({ user: makeUser({ id: 555 }) })).resolves.toBe(
+      false
+    );
+  });
+
+  it('threads entityId + the SHARED context builder (the arguments the client gate uses)', async () => {
+    flags[EXTERNAL] = testerSegment;
+    const user = makeUser({ id: 777 });
+    await isExternalListingsPublicEnabled({ user });
+    // Not `objectContaining`: the seam is that the server passes the EXACT triple
+    // the client gate passes. A partial match would pass while the two drifted.
+    expect(mockIsFlipt).toHaveBeenCalledWith(EXTERNAL, '777', buildFliptContext(user));
+  });
+
+  it('a segment keyed on isModerator matches off the SERVER-side flag, not a spoofed field', async () => {
+    flags[EXTERNAL] = {
+      kind: 'segment',
+      base: false,
+      match: (ctx) => ctx.isModerator === 'true',
+    };
+    const user = makeUser({ id: 555, isModerator: false });
+    (user as unknown as Record<string, unknown>).is_moderator = 'true';
+    await expect(isExternalListingsPublicEnabled({ user })).resolves.toBe(false);
+  });
+
+  it('reads ONLY the app-listings-public-external key', async () => {
+    flags[EXTERNAL] = testerSegment;
+    await isExternalListingsPublicEnabled({ user: makeUser({ id: 777 }) });
+    for (const call of mockIsFlipt.mock.calls) expect(call[0]).toBe(EXTERNAL);
+  });
+});
+
+describe('isExternalListingsPublicEnabled — BACKWARD COMPATIBILITY (no user)', () => {
+  it('🔴 no user → the ORIGINAL global eval, byte-identical (flag key alone)', async () => {
+    flags[EXTERNAL] = { kind: 'base', enabled: false };
+    await isExternalListingsPublicEnabled();
+    expect(mockIsFlipt).toHaveBeenCalledTimes(1);
+    // Exactly one argument — entityId + context fall back to the client's
+    // ('global', {}) defaults, which is what the pre-change call did.
+    expect(mockIsFlipt).toHaveBeenCalledWith(EXTERNAL);
+    mockIsFlipt.mockClear();
+    await isExternalListingsPublicEnabled({ user: undefined });
+    expect(mockIsFlipt).toHaveBeenCalledWith(EXTERNAL);
+  });
+
+  it('🔴 a BASE-ENABLED flag still resolves TRUE for everyone — context only ADDS', async () => {
+    // The no-narrowing invariant. A plain base-`enabled` boolean has no rollout
+    // rules, so it is immune to whatever entityId/context the eval carries: the
+    // anonymous global path, an in-cohort user and a random user must ALL be true.
+    flags[EXTERNAL] = { kind: 'base', enabled: true };
+    await expect(isExternalListingsPublicEnabled()).resolves.toBe(true);
+    await expect(isExternalListingsPublicEnabled({ user: undefined })).resolves.toBe(true);
+    await expect(isExternalListingsPublicEnabled({ user: makeUser({ id: 777 }) })).resolves.toBe(
+      true
+    );
+    await expect(isExternalListingsPublicEnabled({ user: makeUser({ id: 555 }) })).resolves.toBe(
+      true
+    );
+    await expect(
+      isExternalListingsPublicEnabled({ user: makeUser({ id: 1, isModerator: true }) })
+    ).resolves.toBe(true);
+  });
+
+  it('a base-DISABLED flag stays false everywhere (base value is the fallback)', async () => {
+    flags[EXTERNAL] = { kind: 'base', enabled: false };
+    await expect(isExternalListingsPublicEnabled()).resolves.toBe(false);
+    await expect(isExternalListingsPublicEnabled({ user: makeUser({ id: 777 }) })).resolves.toBe(
+      false
+    );
+  });
+
+  it('a SEGMENTED flag cannot match on the no-user path (anon stays dark this phase)', async () => {
+    flags[EXTERNAL] = testerSegment;
+    await expect(isExternalListingsPublicEnabled()).resolves.toBe(false);
+    await expect(isExternalListingsPublicEnabled({ user: undefined })).resolves.toBe(false);
+  });
+
+  it('fail-closed: absent flag / Flipt down → false, user or not', async () => {
+    // `flags` is empty → every key is `absent` → the real async isFlipt's
+    // catch-and-return-false path.
+    await expect(isExternalListingsPublicEnabled()).resolves.toBe(false);
+    await expect(isExternalListingsPublicEnabled({ user: makeUser({ id: 777 }) })).resolves.toBe(
+      false
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. resolveStoreVisibilityScope — the full matrix
+// ---------------------------------------------------------------------------
+
+/**
+ * The scope resolver over all three keys at once. `app-blocks-enabled` is modelled
+ * as the live mod segment, `app-listings` as a per-user tester grant, and
+ * `app-listings-public-external` as whatever the case under test configures.
+ */
+describe('resolveStoreVisibilityScope — the external-only matrix', () => {
+  const MOD_SEGMENT: FlagShape = {
+    kind: 'segment',
+    base: false,
+    match: (ctx) => ctx.isModerator === 'true',
+  };
+
+  beforeEach(() => {
+    flags['app-blocks-enabled'] = MOD_SEGMENT;
+    // `app-listings` grants the app-dev-testers cohort (id 888 here).
+    flags['app-listings'] = {
+      kind: 'segment',
+      base: false,
+      match: (ctx) => ctx.userId === '888',
+    };
+  });
+
+  it('privileged: a MODERATOR resolves full', async () => {
+    await expect(
+      resolveStoreVisibilityScope({ user: makeUser({ id: 1, isModerator: true }) })
+    ).resolves.toBe('full');
+  });
+
+  it('privileged: an app-listings TESTER resolves full', async () => {
+    await expect(resolveStoreVisibilityScope({ user: makeUser({ id: 888 }) })).resolves.toBe(
+      'full'
+    );
+  });
+
+  it('non-privileged + external flag ON (in segment) → public-external', async () => {
+    flags[EXTERNAL] = testerSegment;
+    await expect(resolveStoreVisibilityScope({ user: makeUser({ id: 777 }) })).resolves.toBe(
+      'public-external'
+    );
+  });
+
+  it('🔴 non-privileged + external flag SEGMENTED but user OUT of segment → none', async () => {
+    // The case a global eval could never distinguish — and the reason the helper
+    // had to become user-aware. If the eval ignored its user, every non-privileged
+    // viewer would get the in-segment answer.
+    flags[EXTERNAL] = testerSegment;
+    await expect(resolveStoreVisibilityScope({ user: makeUser({ id: 555 }) })).resolves.toBe(
+      'none'
+    );
+  });
+
+  it('non-privileged + external flag OFF → none', async () => {
+    flags[EXTERNAL] = { kind: 'base', enabled: false };
+    await expect(resolveStoreVisibilityScope({ user: makeUser({ id: 555 }) })).resolves.toBe(
+      'none'
+    );
+  });
+
+  it('no user → unchanged global behaviour (base-enabled lifts, segmented does not)', async () => {
+    flags[EXTERNAL] = testerSegment;
+    await expect(resolveStoreVisibilityScope()).resolves.toBe('none');
+    await expect(resolveStoreVisibilityScope({ user: undefined })).resolves.toBe('none');
+    flags[EXTERNAL] = { kind: 'base', enabled: true };
+    await expect(resolveStoreVisibilityScope()).resolves.toBe('public-external');
+    await expect(resolveStoreVisibilityScope({ user: undefined })).resolves.toBe('public-external');
+  });
+
+  it('🔴 A MODERATOR IN THE EXTERNAL COHORT IS STILL `full`, NEVER NARROWED', async () => {
+    // The regression the priority order exists to prevent. A mod who is ALSO a
+    // member of the tester segment must keep the whole catalog — if the external
+    // axis were checked first they would silently lose every onsite listing.
+    flags[EXTERNAL] = {
+      kind: 'segment',
+      base: false,
+      // Matches EVERY logged-in user, moderators included — the worst case.
+      match: (ctx) => ctx.isLoggedIn === 'true',
+    };
+    await expect(
+      resolveStoreVisibilityScope({ user: makeUser({ id: 1, isModerator: true }) })
+    ).resolves.toBe('full');
+    await expect(resolveStoreVisibilityScope({ user: makeUser({ id: 888 }) })).resolves.toBe(
+      'full'
+    );
+    // …and the same config DOES lift a non-privileged viewer, so the assertion
+    // above is not passing because the external flag was simply off.
+    await expect(resolveStoreVisibilityScope({ user: makeUser({ id: 555 }) })).resolves.toBe(
+      'public-external'
+    );
+  });
+
+  it('🔴 the external flag is never even EVALUATED for a privileged viewer', async () => {
+    flags[EXTERNAL] = { kind: 'base', enabled: true };
+    await resolveStoreVisibilityScope({ user: makeUser({ id: 1, isModerator: true }) });
+    for (const call of mockIsFlipt.mock.calls) expect(call[0]).not.toBe(EXTERNAL);
+  });
+
+  it('reads ONLY the three store keys', async () => {
+    flags[EXTERNAL] = { kind: 'base', enabled: true };
+    await resolveStoreVisibilityScope({ user: makeUser({ id: 555 }) });
+    for (const call of mockIsFlipt.mock.calls) {
+      expect(['app-listings', 'app-blocks-enabled', EXTERNAL]).toContain(call[0]);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. DARK BY DEFAULT — the as-merged state
+// ---------------------------------------------------------------------------
+
+/**
+ * 🔴 THE SHIP-SAFETY PROOF. `app-listings-public-external` does not exist in Flipt
+ * today. This models EXACTLY that (`flags` holds only the two flags that DO exist)
+ * and asserts every cohort lands where it lands today: mods/testers `full`,
+ * everyone else `none`. If this file's other changes ever leak an observable
+ * difference into the as-merged state, this goes red.
+ */
+describe('🔴 DARK BY DEFAULT — flag ABSENT from Flipt (the as-merged state)', () => {
+  beforeEach(() => {
+    flags['app-blocks-enabled'] = {
+      kind: 'segment',
+      base: false,
+      match: (ctx) => ctx.isModerator === 'true',
+    };
+    flags['app-listings'] = {
+      kind: 'segment',
+      base: false,
+      match: (ctx) => ctx.userId === '888',
+    };
+    // `app-listings-public-external` deliberately NOT registered.
+  });
+
+  it('the external flag really is absent (control — else every case below is vacuous)', async () => {
+    await expect(isExternalListingsPublicEnabled()).resolves.toBe(false);
+    await expect(isExternalListingsPublicEnabled({ user: makeUser({ id: 777 }) })).resolves.toBe(
+      false
+    );
+  });
+
+  const cohorts: Array<[string, SessionUser | undefined, string]> = [
+    ['moderator', makeUser({ id: 1, isModerator: true }), 'full'],
+    ['app-dev-tester', makeUser({ id: 888 }), 'full'],
+    ['plain logged-in user', makeUser({ id: 555 }), 'none'],
+    ['would-be external tester', makeUser({ id: 777 }), 'none'],
+    ['anonymous', undefined, 'none'],
+  ];
+
+  for (const [name, user, expected] of cohorts) {
+    it(`${name} → ${expected}`, async () => {
+      await expect(resolveStoreVisibilityScope({ user })).resolves.toBe(expected);
+    });
+  }
+
+  it('no-arg call is dark too', async () => {
+    await expect(resolveStoreVisibilityScope()).resolves.toBe('none');
+  });
+});

--- a/src/server/services/app-blocks-flag.ts
+++ b/src/server/services/app-blocks-flag.ts
@@ -397,9 +397,7 @@ export const APP_BLOCKS_DEV_TUNNEL_FLAG = 'app-blocks-dev-tunnel';
  * is a brand-new surface (no existing mod access to preserve), so fail-closed for
  * all until the flag exists is the safe posture.
  */
-export async function isAppBlocksDevTunnelEnabled(opts?: {
-  user?: SessionUser;
-}): Promise<boolean> {
+export async function isAppBlocksDevTunnelEnabled(opts?: { user?: SessionUser }): Promise<boolean> {
   if (!opts?.user) return isFlipt(APP_BLOCKS_DEV_TUNNEL_FLAG);
   const user = opts.user;
   return isFlipt(APP_BLOCKS_DEV_TUNNEL_FLAG, String(user.id), buildFliptContext(user));
@@ -608,40 +606,92 @@ export async function isAppBlocksSharedStorageEnabled(opts?: {
 }
 
 /**
- * Dedicated GLOBAL flag for the PUBLIC EXTERNAL App-store read GA — the mechanism
- * that lets the store serve `kind='offsite'` (external app) listings to the
- * ANONYMOUS public while `kind='onsite'` App Blocks stay gated to the existing
- * mods + app-dev-testers cohort. This is a SEPARATE, ORTHOGONAL axis from the
- * `app-listings` catalog-visibility flag: `app-listings` gates WHO sees the FULL
- * catalog (all kinds); this flag opens ONLY the offsite subset to EVERYONE.
+ * Dedicated flag for the EXTERNAL-ONLY App-store read scope — the mechanism that
+ * lets the store serve `kind='offsite'` (external app) listings to a viewer while
+ * `kind='onsite'` App Blocks stay hidden from them. This is a SEPARATE, ORTHOGONAL
+ * axis from the `app-listings` catalog-visibility flag: `app-listings` gates WHO
+ * sees the FULL catalog (all kinds); this flag opens ONLY the offsite subset.
  *
- * ## Why a GLOBAL boolean (not segmented)
+ * ## Audience: a SEGMENTED tester cohort FIRST, the anonymous public LATER
  *
- * The audience is the anonymous public — an anon viewer carries NO user context,
- * so a segment could never match and the flag would silently stay dark. It is
- * therefore evaluated globally (entityId='global', empty context), mirroring
- * `isAppBlocksPipelineEnabled` / `isAppBlocksRuntimeEnabled` exactly, and MUST be
- * created in Flipt as a PLAIN base-`enabled` boolean (NO segment).
+ * The first audience is a curated tester cohort (logged-in users) who should see
+ * external listings ONLY, with onsite apps held back until a later phase. A
+ * segment can only match when the eval carries the viewer's context, so
+ * {@link isExternalListingsPublicEnabled} is evaluated PER-USER when a user is
+ * present (entityId = user id, context from `buildFliptContext`) — the identical
+ * eval shape `isAppBlocksEnabled` / `isAppListingsEnabled` use.
+ *
+ * 🔴 That does NOT narrow the eventual anonymous-public flip. With NO user the
+ * helper preserves the ORIGINAL global eval (entityId='global', empty context)
+ * verbatim, and a flag created as a PLAIN base-`enabled` boolean (no rollout
+ * rules) resolves `true` for every entityId/context — so a base-enabled flip still
+ * lights the flag for everyone, logged-in or anon. Per-user context only ADDS the
+ * ability to segment; it can never subtract from a base-enabled flag. The two
+ * supported Flipt shapes are therefore:
+ *   - segment rollout (`app-dev-testers` / `moderators` / any user property) →
+ *     matches only for the in-segment logged-in cohort. Anon carries no context,
+ *     so anon stays dark — intended for this phase.
+ *   - plain base `enabled: true` (no rollouts) → matches for EVERYONE incl. anon.
+ * ⚠️ A PERCENTAGE (threshold) rollout is the one shape to avoid: it hashes the
+ * entityId, so the server's `'global'` anon eval and the client gate's
+ * `'anonymous'` anon eval can land on opposite sides. See the SEAM note on
+ * {@link isExternalListingsPublicEnabled}.
  *
  * ## Fail-closed / dark posture
  *
  * The flag does NOT exist in Flipt at merge time (it is created in a LATER phase,
- * base `enabled: false`, only when the offsite store is ready to go public) or if
- * Flipt is unreachable → `isFlipt` returns `false` → `resolveStoreVisibilityScope`
- * returns `none` for a non-privileged viewer and `full` for a mod/tester — i.e.
+ * base `enabled: false`, only when the external-only store is ready) or if Flipt is
+ * unreachable → `isFlipt` returns `false` → `resolveStoreVisibilityScope` returns
+ * `none` for a non-privileged viewer and `full` for a mod/tester — i.e.
  * BYTE-IDENTICAL to today. This flag NEVER upgrades a mod/tester away from `full`;
  * it only ever moves a non-privileged viewer from `none` → `public-external`.
  */
 export const APP_LISTINGS_PUBLIC_EXTERNAL_FLAG = 'app-listings-public-external';
 
 /**
- * GLOBAL gate for the PUBLIC EXTERNAL App-store read GA. Evaluates the dedicated
- * `app-listings-public-external` flag with no user context (entityId='global',
- * empty context), mirroring `isAppBlocksPipelineEnabled`. Fail-closed: absent flag
- * / Flipt-down → `false`. See APP_LISTINGS_PUBLIC_EXTERNAL_FLAG.
+ * Gate for the EXTERNAL-ONLY App-store read scope. Evaluates the dedicated
+ * `app-listings-public-external` flag WITH the viewer's context when a user is
+ * present (entityId = user id, context from `buildFliptContext`), so a `testers`
+ * segment can actually match — identical eval shape to `isAppBlocksEnabled` /
+ * `isAppListingsEnabled`. No user → the ORIGINAL global eval (entityId='global',
+ * empty context), byte-identical to the pre-segmentation behaviour, so the machine
+ * / anonymous callers are unchanged. Fail-closed: absent flag / Flipt-down →
+ * `false`. See APP_LISTINGS_PUBLIC_EXTERNAL_FLAG.
+ *
+ * 🔴 SERVER/CLIENT SEAM — this flag is evaluated TWICE per request, and the two
+ * evaluations must agree or a viewer passes the page gate and gets an empty store
+ * (or the reverse):
+ *   - HERE (server data path) → `isFlipt(FLAG, id, ctx)`, feeding
+ *     `resolveStoreVisibilityScope` → the store read procs + REST endpoints.
+ *   - `featureFlags.appListingsPublicExternal` (feature-flags.service.ts, same
+ *     `fliptKey`) → `isFliptSync(FLAG, id, ctx)` → `ctx.features` / `useFeatureFlags()`
+ *     → the shared `hasAppsStoreAccess` predicate → the `/apps` SSR + client gates.
+ * They agree BY CONSTRUCTION for a logged-in viewer: same flag key, same entityId
+ * (`String(user.id)`), same context object (both call the SHARED `buildFliptContext`).
+ * They agree in the fail-closed direction too: an absent flag makes the async
+ * `isFlipt` return `false` while the sync `isEnabledSync` returns `null` and falls
+ * through to the client entry's STATIC availability — which is `[]` (deliberately,
+ * not `['mod']`) precisely so that static answer is also `false`.
+ * RESIDUAL, bounded, and PRE-EXISTING for every flag in this family: for an
+ * ANONYMOUS viewer the entityId/context differ (`'global'`/`{}` here vs
+ * `'anonymous'`/`{isLoggedIn:'false'}` in the client gate). Irrelevant for a plain
+ * base-enabled boolean or a user-property segment (both sides resolve the same);
+ * it bites only under a percentage rollout or an `isLoggedIn`-keyed rule — hence
+ * the shape guidance on APP_LISTINGS_PUBLIC_EXTERNAL_FLAG. The whole seam — both
+ * REAL sides against one fake Flipt config — is pinned by
+ * `app-blocks-flag.external-scope.seam.test.ts`.
  */
-export async function isExternalListingsPublicEnabled(): Promise<boolean> {
-  return isFlipt(APP_LISTINGS_PUBLIC_EXTERNAL_FLAG);
+export async function isExternalListingsPublicEnabled(opts?: {
+  user?: SessionUser;
+}): Promise<boolean> {
+  // No user → preserve the ORIGINAL global eval verbatim (entityId='global', empty
+  // context). Byte-identical to the pre-segmentation behaviour: a base-enabled flag
+  // still resolves true, a segmented one still cannot match.
+  if (!opts?.user) return isFlipt(APP_LISTINGS_PUBLIC_EXTERNAL_FLAG);
+  // Per-user eval — reuse the client gate's context builder so the server data
+  // path and the `/apps` page gate share one context shape and cannot drift.
+  const user = opts.user;
+  return isFlipt(APP_LISTINGS_PUBLIC_EXTERNAL_FLAG, String(user.id), buildFliptContext(user));
 }
 
 /**
@@ -660,25 +710,37 @@ export type StoreVisibilityScope = 'full' | 'public-external' | 'none';
  * NEVER narrowed by the public flag:
  *   1. `isAppListingsEnabled({ user })` (mods + app-dev-testers, OR-falling-back to
  *      `app-blocks-enabled`) → `full` — sees every kind, byte-identical to today.
- *   2. else `isExternalListingsPublicEnabled()` (the global public flag) →
- *      `public-external` — sees only offsite listings.
+ *   2. else `isExternalListingsPublicEnabled({ user })` (the external-only flag,
+ *      segment-capable) → `public-external` — sees only offsite listings.
  *   3. else → `none` — dark.
+ *
+ * 🔴 PRIORITY ORDER IS THE "NEVER NARROW A MODERATOR" INVARIANT, not a style
+ * choice. Axis 1 short-circuits, so a mod/tester resolves `full` WITHOUT the
+ * external flag ever being evaluated. Swap the two checks and a moderator inside
+ * the external cohort would silently be NARROWED from the whole catalog down to
+ * offsite-only. Pinned by `app-blocks-flag.external-scope.test.ts`.
  *
  * 🔴 DARK-by-default invariant: with `app-listings-public-external` ABSENT in Flipt
  * (its as-merged state), a mod/tester still resolves `full` and everyone else
- * resolves `none` — ZERO observable change until the public flag is created +
- * enabled in a later phase.
+ * resolves `none` — ZERO observable change until the flag is created + enabled in a
+ * later phase.
+ *
+ * 🔴 `opts` is threaded into BOTH axes. Dropping it on axis 2 (the pre-segmentation
+ * shape) forces a global eval that no segment can ever match, so a `testers` segment
+ * would resolve `false` for every member and the whole cohort would silently stay on
+ * `none`.
  */
 export async function resolveStoreVisibilityScope(opts?: {
   user?: SessionUser;
 }): Promise<StoreVisibilityScope> {
   // Axis 1 — the existing catalog-visibility gate (mods + app-dev-testers). MUST be
   // checked FIRST so a privileged viewer always gets `full`, never `public-external`
-  // (the public flag can only ever LIFT a non-privileged viewer, never narrow a mod).
+  // (the external flag can only ever LIFT a non-privileged viewer, never narrow a mod).
   if (await isAppListingsEnabled(opts)) return 'full';
-  // Axis 2 — the global public-external flag (anon + everyone). Global eval; a
-  // non-privileged viewer sees ONLY offsite listings.
-  if (await isExternalListingsPublicEnabled()) return 'public-external';
+  // Axis 2 — the external-only flag. Per-user eval when a user is present (so a
+  // tester segment matches), global otherwise; a non-privileged viewer in the
+  // cohort sees ONLY offsite listings.
+  if (await isExternalListingsPublicEnabled(opts)) return 'public-external';
   // Fail-closed: neither flag → dark.
   return 'none';
 }

--- a/src/server/services/app-blocks-flag.ts
+++ b/src/server/services/app-blocks-flag.ts
@@ -397,7 +397,9 @@ export const APP_BLOCKS_DEV_TUNNEL_FLAG = 'app-blocks-dev-tunnel';
  * is a brand-new surface (no existing mod access to preserve), so fail-closed for
  * all until the flag exists is the safe posture.
  */
-export async function isAppBlocksDevTunnelEnabled(opts?: { user?: SessionUser }): Promise<boolean> {
+export async function isAppBlocksDevTunnelEnabled(opts?: {
+  user?: SessionUser;
+}): Promise<boolean> {
   if (!opts?.user) return isFlipt(APP_BLOCKS_DEV_TUNNEL_FLAG);
   const user = opts.user;
   return isFlipt(APP_BLOCKS_DEV_TUNNEL_FLAG, String(user.id), buildFliptContext(user));

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -450,6 +450,31 @@ const featureFlags = createFeatureFlags({
   // to `app-blocks-enabled` — i.e. ZERO behavior change today (the currently
   // mod+app-dev-testers cohort keeps identical store access).
   appListings: { availability: ['mod'], fliptKey: 'app-listings' },
+  // App Blocks — EXTERNAL-ONLY store scope. The CLIENT/SSR half of the server's
+  // `isExternalListingsPublicEnabled()` (same Flipt key), so the `/apps` page gate
+  // can admit a viewer whose ONLY qualification is this flag — without it the store
+  // is structurally unreachable for that cohort (`hasAppsStoreAccess` would be
+  // false → `notFound`) even though the server would happily serve them the offsite
+  // catalog. Read via the shared `hasAppsStoreAccess` predicate, never open-coded.
+  //
+  // 🔴 `availability: []` (DARK + fail-closed for EVERYONE, mods included), NOT
+  // `['mod']`, and that is load-bearing for the server/client seam rather than
+  // taste: an ABSENT flag makes the SERVER's async `isFlipt` return `false`, while
+  // the CLIENT's `isEnabledSync` returns `null` and falls through to this static
+  // availability. With `['mod']` a moderator's client value would be `true` against
+  // a server `false` — the two evaluations of one flag disagreeing, which is exactly
+  // the failure this entry exists to prevent. `[]` makes the static answer `false`
+  // too, so both sides are dark until Flipt says otherwise. (Mirrors the
+  // `appBlocksAgenticReview` precedent.) A mod loses nothing: they already hold
+  // `appListings`/`appBlocks`, and the server checks the privileged axis FIRST.
+  //
+  // Grants ONLY store CATALOG reachability — the server still scopes the data to
+  // `kind='offsite'` (`resolveStoreVisibilityScope` → `public-external`). It does
+  // NOT widen any block-RUNTIME surface (those stay on `appBlocks` alone).
+  appListingsPublicExternal: {
+    availability: [],
+    fliptKey: 'app-listings-public-external',
+  },
   // App Blocks W10 — full-page apps (`/apps/run/<slug>`). A SEPARATE dark flag
   // so the page surface enables independently of the master `app-blocks-enabled`
   // gate. The page route + page-token mint require BOTH `appBlocks` AND

--- a/src/shared/utils/app-blocks-access.ts
+++ b/src/shared/utils/app-blocks-access.ts
@@ -72,12 +72,13 @@ export function isAppDeveloper(
  * bundle (the established pattern — see `src/shared/data-graph/generation/context.ts`).
  */
 export type AppsStoreFeatureFlags =
-  | Partial<Pick<FeatureAccess, 'appBlocks' | 'appListings'>>
+  | Partial<Pick<FeatureAccess, 'appBlocks' | 'appListings' | 'appListingsPublicExternal'>>
   | null
   | undefined;
 
 /**
- * App Blocks — App STORE-VISIBILITY gate (`appListings || appBlocks`).
+ * App Blocks — App STORE-VISIBILITY gate
+ * (`appListings || appBlocks || appListingsPublicExternal`).
  *
  * 🔒 THE SINGLE SOURCE OF TRUTH for "may this viewer see the /apps store", for
  * the six surfaces under `components/Apps` and `pages/apps`: the `/apps` SSR
@@ -119,16 +120,46 @@ export type AppsStoreFeatureFlags =
  * of truth. Server-side mirror: `isAppListingsEnabled` in
  * `~/server/services/app-blocks-flag`.
  *
+ * `appListingsPublicExternal` (Flipt `app-listings-public-external`) is the THIRD,
+ * ORTHOGONAL term: the EXTERNAL-ONLY cohort. Its holders are not "less privileged
+ * catalog viewers" — they are viewers the SERVER will serve a `kind='offsite'`-only
+ * catalog to (`resolveStoreVisibilityScope` → `public-external`). They must be
+ * admitted HERE or `/apps` is structurally unreachable for them: this predicate is
+ * the only thing standing between them and `notFound`, so the server would resolve
+ * a perfectly good external catalog for a page they can never load.
+ *
+ * 🔴 REACHABILITY ONLY — this term does NOT decide WHAT they see. That is the
+ * server's `StoreVisibilityScope`, threaded into the data-layer kind predicate. A
+ * viewer admitted solely by this flag reaches the store and sees offsite listings
+ * and nothing else; onsite App Blocks stay hidden by the SERVER, not by this gate.
+ * So do NOT read this OR as "external-flag holders get the full catalog."
+ *
+ * 🔴 SEAM: `appListingsPublicExternal` and the server's
+ * `isExternalListingsPublicEnabled()` are two evaluations of ONE Flipt key and must
+ * agree, or a viewer passes this gate and gets an empty store (or is 404'd off a
+ * catalog the server would serve). They agree by construction for a logged-in
+ * viewer (same key, same entityId, same `buildFliptContext`) and fail closed
+ * together when the flag is absent — the client entry is deliberately
+ * `availability: []` so its Flipt-down static answer is `false` too. Full
+ * reasoning + the anon residual: `isExternalListingsPublicEnabled` in
+ * `~/server/services/app-blocks-flag`. Pinned by
+ * `components/Apps/__tests__/hasAppsStoreAccess.test.ts` and — with BOTH real sides
+ * driven against one fake Flipt config —
+ * `server/services/__tests__/app-blocks-flag.external-scope.seam.test.ts`.
+ *
  * 🔴 This is NOT the gate for the block-RUNTIME surfaces. `/apps/installed`,
  * `/apps/review`, `/apps/my-submissions`, `/apps/revenue`, `/apps/run/<slug>`
  * and the `blocks.*` tRPC procedures gate on `appBlocks` alone, on purpose —
  * they need the runtime, not just the catalog. Widening them is a product
  * decision, not a mechanical alignment; do not sweep them into this predicate.
+ * The external-only cohort in particular must NOT reach them: they hold neither
+ * `appBlocks` nor `appListings`, and adding this third term here leaves those
+ * surfaces untouched.
  *
  * Fails CLOSED: absent / null features, or an empty object, → `false`.
  */
 export function hasAppsStoreAccess(features: AppsStoreFeatureFlags): boolean {
-  return !!features?.appListings || !!features?.appBlocks;
+  return !!features?.appListings || !!features?.appBlocks || !!features?.appListingsPublicExternal;
 }
 
 /**


### PR DESCRIPTION
Makes the **external-only** (`kind='offsite'`) App-store scope actually reachable by a segmented tester cohort. `resolveStoreVisibilityScope` already modelled `public-external`; two blockers meant no cohort could ever land in it. Code only — **no Flipt configuration is touched**.

## What changed

**1. `isExternalListingsPublicEnabled` is now user-aware** (`src/server/services/app-blocks-flag.ts`)

It was a bare `isFlipt(FLAG)` — a global eval (`entityId='global'`, empty context). A Flipt segment can only match on the context it is handed, so a `testers` segment resolved `false` for **every** member and the feature was unreachable by construction. It now mirrors `isAppBlocksEnabled` / `isAppListingsEnabled`: `isFlipt(FLAG, String(user.id), buildFliptContext(user))` when a user is present, and `resolveStoreVisibilityScope` threads its `opts` into that second axis.

Backward compatibility is a hard invariant and is tested three ways:
- **no user → the original global eval, byte-identical** — the mock is asserted to be called with the flag key *alone* (one argument), so entityId/context still fall back to the client's `('global', {})` defaults.
- **a base-enabled flag still resolves `true` for everyone** — anon, in-cohort, out-of-cohort and moderator. A plain base-`enabled` boolean has no rollout rules, so it is immune to whatever entityId/context the eval carries. Adding context can only **add** segmentation.
- **fail-closed** — absent flag / Flipt down → `false` → `none`, with or without a user.

**2. The page gate can now express the scope**

There was no client-side feature for `app-listings-public-external` at all, so `hasAppsStoreAccess` → `resolveAppsPageAccess` returned `notFound` for a viewer whose only qualification was that flag — while the server would have happily served them the offsite catalog. Two changes:
- new `appListingsPublicExternal` entry in `feature-flags.service.ts`, `fliptKey: 'app-listings-public-external'`;
- the **shared** `hasAppsStoreAccess` predicate becomes `appListings || appBlocks || appListingsPublicExternal`. Extended in the one place it lives (PR #3905's consolidation); no call site open-codes anything, and the call-site ledger test was read and kept accurate.

The new term grants **reachability only**. What the viewer then sees is still the server's `StoreVisibilityScope` → offsite listings only; onsite App Blocks stay hidden by the server, not by this gate. It also widens no block-RUNTIME surface — `/apps/installed`, `/apps/run/<slug>`, the author surfaces and the `blocks.*` procs still gate on `appBlocks` alone, asserted in the seam suite.

## Dark-by-default proof

`app-listings-public-external` does not exist in Flipt. `app-blocks-flag.external-scope.test.ts` models exactly that (only the two flags that *do* exist are registered) and asserts each cohort lands where it lands today:

| cohort | scope |
|---|---|
| moderator | `full` |
| app-dev-tester (`app-listings`) | `full` |
| plain logged-in user | `none` |
| would-be external tester | `none` |
| anonymous / no-arg | `none` |

It carries its own control (`the external flag really is absent`) so the block cannot pass vacuously. The pre-existing `app-blocks-flag.test.ts` — including `isExternalListingsPublicEnabled evaluates the plain global flag (no context)` — passes **unmodified**, and `resolveAppsPageAccess.test.ts` is **untouched**.

## The server/client seam

The same flag is evaluated twice per request, by two paths that had never shared a test:

- **server data path** — `isExternalListingsPublicEnabled({user})` → `isFlipt` (**async**) → `resolveStoreVisibilityScope` → the store read procs / REST endpoints.
- **page gate** — `featureFlags.appListingsPublicExternal` → `isFliptSync` (**sync**, plus a static `availability` fallback when Flipt answers `null`) → `ctx.features` → `hasAppsStoreAccess` → `resolveAppsPageAccess`.

Disagreement is silent in both directions: the viewer passes the page gate and gets an empty store, or is 404'd off a catalog the server would serve.

**Decision:** they agree *by construction* for a logged-in viewer — same key, same entityId (`String(user.id)`), same context object (both call the shared `buildFliptContext`). And they fail closed together: an absent flag makes the async `isEnabled` return `false` while the sync `isEnabledSync` returns `null` and falls through to the static availability — which is why the client entry is **`availability: []` and not `['mod']`**. With `['mod']` a moderator's client value would be `true` against a server `false`. That is the entry's whole reason for being `[]`, and it is mutation-tested.

**How it is tested:** `app-blocks-flag.external-scope.seam.test.ts` loads **both real sides** (real `feature-flags.service`, real `app-blocks-flag`, real shared predicate, real SSR resolver) against **one** fake Flipt config that faithfully models the async/sync asymmetry, and asserts the relationship over a 4-config × 4-cohort matrix:

> `resolveAppsPageAccess` grants ⟺ `resolveStoreVisibilityScope() !== 'none'`

with a non-vacuity check that the matrix really produced all three scopes and both gate outcomes, a positive control that the Flipt branch is live, a behavioural key-identity control (a neighbouring key moves neither side; the real key moves both), and a control that the service's 10s feature-flag cache is genuinely bypassed between cases.

**Residual, bounded, and pre-existing:** for an *anonymous* viewer the two evals differ in identity — `'global'`/`{}` on the server vs `'anonymous'`/`{isLoggedIn:'false'}` in the client gate. That is true of `app-listings` and `app-blocks-enabled` today and is invisible for both shapes this rollout uses (a user-property segment, or a plain base-enabled boolean). It bites only under a **percentage/entityId rollout** — which is measured and pinned in a test rather than asserted away, and called out on the flag's doc comment as the shape to avoid.

## Mutation matrix

Every mutant applied to the final tree; each dies on its **own** assertion, not incidentally. Run over `app-blocks-flag{,.external-scope,.external-scope.seam}.test.ts` + `hasAppsStoreAccess` + `resolveAppsPageAccess` + the call-site ledger (149 tests green at baseline).

| # | mutant | killed | representative failing assertion |
|---|---|---|---|
| 1 | `resolveStoreVisibilityScope`: external axis checked **before** privileged | 4 | `A MODERATOR IN THE EXTERNAL COHORT IS STILL full, NEVER NARROWED` — `expected 'public-external' to be 'full'` |
| 2 | axis 1 reads the **external** flag (arm/flag swap) | 19 | `privileged: a MODERATOR resolves full` |
| 3 | axis 2 drops `opts` (global eval, ignores user) | 4 | `non-privileged + external flag ON (in segment) → public-external` |
| 4 | helper **ignores its user argument** (silent revert to global) | 7 | `a SEGMENT-scoped flag matches for an IN-segment user` |
| 5 | helper reads `app-listings` instead (flag swap) | 15 | `reads ONLY the app-listings-public-external key` |
| 6 | helper drops the no-user branch (breaks byte-identical compat) | 2 | `no user → the ORIGINAL global eval, byte-identical (flag key alone)` |
| 7 | predicate `\|\|` → `&&` on the new term | 17 | `the external flag being FALSE cannot revoke either older flag` |
| 8 | predicate drops the new term (revert) | 8 | `the EXTERNAL flag ALONE grants access` |
| 9 | predicate `\|\|` → `??` (whole chain; mixing is a syntax error) | 6 | `{listings:false, blocks:true, external:false} → true` |
| 10 | predicate returns constant `true` | 19 | `a viewer qualifying via NOTHING still gets notFound` |
| 11 | predicate returns constant `false` | 33 | `external-only viewer reaches /apps — NOT notFound` |
| 12 | client entry `availability: []` → `['mod']` | 3 | `the client entry is fail-closed for a MODERATOR when the flag is ABSENT` |
| 13 | client entry `fliptKey` → `'app-listings'` | 10 | `KEY IDENTITY, proven behaviourally: both sides read the SAME Flipt key` |
| 14 | `resolveAppsPageAccess` grants unconditionally | 18 | `neither flag → notFound (gate intact, even with no session)` |
| 15 | ledger regex reverted to two flag names | 1 | `catches a re-inlined gate built from the EXTERNAL-only term` |
| 16 | ledger regex loses its `\b` word boundaries | 2 | `does NOT read appListingsPublicExternal as appListings (prefix collision)` |

16/16 killed, 0 survivors. Mutants 12 and 13 are the ones that matter for the seam: neither is reachable by any test that looks at one side.

## Verified / not verified

**Verified locally:** `pnpm typecheck` clean — instrument validated first with a planted `TS2322`, which was reported (1 error, exit 2), then removed (0 errors, exit 0). `vitest --project unit` across `components/Apps/__tests__`, `server/services/__tests__`, `server/routers/__tests__`, `tests/api/v1/apps`: **312 files / 5033 tests passed**, 0 timeout panics. `--project component` on the three store-gate browser suites: **55 tests passed** (non-zero, so the browser really ran). ESLint + Prettier clean on all 8 touched files.

**NOT verified:** nothing was run against a live Flipt instance or a deployed environment — the flag does not exist, so there is nothing to evaluate. The Flipt-side segment shape (`app-dev-testers`, a user-property segment, etc.) is asserted only against a faithful in-test model of Flipt's boolean evaluation, not against Flipt itself. No manual browser walk of `/apps` as an external-only viewer. The tRPC read procs and REST endpoints already branch on `scope` and were not changed, so their offsite-only filtering is unchanged and untested here.

## Two things worth knowing before the rollout

**Found while building the seam suite — a pre-existing divergence, recorded not fixed.** When Flipt is *unreachable*, the client gate falls through to each entry's static `availability` while the server helpers have none. A **moderator** therefore gets `appListings`/`appBlocks` true statically → the page gate grants — while `resolveStoreVisibilityScope` resolves `none` → empty store. It predates this change (a property of the two `availability: ['mod']` flags), is in the safe direction, and closing it means giving the server a static mod floor — a behaviour change to the privileged path, out of scope here. It is asserted explicitly so it cannot be mistaken for something this PR introduced, and so a future fix has a test to flip.

**No in-product entry point for the external-only cohort.** `components/AppLayout/AppHeader/appsNavVisibility.ts` still gates the user-menu "Apps" → `/apps` item on `appBlocks` alone (a standing decision with its own doc, deliberately not swept in). That menu item is the only route *to* `/apps`, so this cohort reaches the store by direct URL only. Tracked in #3907; the external-only cohort is the first real population to hit it, so an announcement link or campaign URL is needed until it lands.

## 🔴 Rollout ordering

**This code must deploy BEFORE the Flipt flags change.** The order is not interchangeable:

1. Merge + deploy this PR. Nothing observable changes — the flag does not exist, so every cohort resolves exactly as it does today.
2. **Then** create `app-listings-public-external` in Flipt, base `enabled: false`, with the tester segment.
3. Enable it for the cohort.

If the Flipt flag is created and segmented **first**, the still-deployed old code evaluates it globally (a segment can never match) *and* has no client-side feature to gate the page on — so the cohort gets `notFound` at `/apps` and the flag looks broken. The server and page gates only agree once this code is live.

**Flipt shape guidance** (documented on `APP_LISTINGS_PUBLIC_EXTERNAL_FLAG`): use a **segment rollout** for the tester phase, or a **plain base-`enabled` boolean** for a later anonymous-public flip. Avoid a **percentage/threshold rollout** — it hashes the entityId, and the server (`'global'`) and client (`'anonymous'`) disagree for anonymous viewers.

**Rollback** is flipping the Flipt flag off (or deleting it): everything returns to `full`/`none` with no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
