### PR TITLE
fix(download): rejoin a query a client split with a second `?`

### DIFF
--- a/src/__tests__/pages/api/download/split-query-repair.test.ts
+++ b/src/__tests__/pages/api/download/split-query-repair.test.ts
@@ -189,7 +189,9 @@ describe('download route — a query split by a stray `?`', () => {
     expect(logged.query, 'the caller API key was shipped to Axiom in plaintext').not.toHaveProperty(
       'token'
     );
-    expect(logged.query.fileId, 'the rest of the query is still there to debug with').toBe('484398');
+    expect(logged.query.fileId, 'the rest of the query is still there to debug with').toBe(
+      '484398'
+    );
   });
 
   it('CONTROL: the same request already worked when the client used `&`', async () => {

--- a/src/__tests__/pages/api/download/split-query-repair.test.ts
+++ b/src/__tests__/pages/api/download/split-query-repair.test.ts
@@ -1,0 +1,176 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The download route against the URL shape a client builds by appending the
+ * documented `?type=…&format=…&token=…` suffix to a `downloadUrl` that already
+ * carries `?fileId=<id>` — `…/models/568485?fileId=484398?type=Model&…`.
+ *
+ * The unit suite owns the repair itself; this file owns the WIRING, which the
+ * unit suite cannot see: that the repair runs before the route parses its
+ * schema (otherwise `fileId` is NaN → 400) and before it resolves a session
+ * (otherwise `?token=` is swallowed → the caller is anonymous, which on a
+ * gated file is a 401/404 rather than a redirect).
+ */
+
+const {
+  mockFindUnique,
+  mockGetServerAuthSession,
+  mockGetFileForModelVersion,
+  mockHasExceededLimit,
+  mockIncrement,
+} = vi.hoisted(() => ({
+  mockFindUnique: vi.fn(),
+  mockGetServerAuthSession: vi.fn(),
+  mockGetFileForModelVersion: vi.fn(),
+  mockHasExceededLimit: vi.fn(),
+  mockIncrement: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { keyValue: { findUnique: mockFindUnique } },
+  dbWrite: { keyValue: { findUnique: mockFindUnique } },
+}));
+
+vi.mock('~/server/auth/get-server-auth-session', () => ({
+  getServerAuthSession: mockGetServerAuthSession,
+}));
+
+vi.mock('~/server/services/file.service', () => ({
+  getFileForModelVersion: mockGetFileForModelVersion,
+}));
+
+vi.mock('~/server/services/user.service', () => ({
+  bustUserDownloadsCache: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/clickhouse/client', () => ({
+  clickhouse: undefined,
+  Tracker: class {
+    modelVersionEvent = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/redis/client', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const make = (): any => new Proxy(() => 'k', { get: () => make() });
+  return { REDIS_SYS_KEYS: make(), REDIS_KEYS: make(), redis: {}, sysRedis: {} };
+});
+
+vi.mock('~/server/utils/rate-limiting', () => ({
+  createLimiter: () => ({
+    hasExceededLimit: mockHasExceededLimit,
+    increment: mockIncrement,
+    getCount: vi.fn(),
+  }),
+}));
+
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  PublicEndpoint: (handler: (req: NextApiRequest, res: NextApiResponse) => unknown) => handler,
+}));
+
+import handler from '~/pages/api/download/models/[modelVersionId]';
+
+const REDIRECT_URL = 'https://example.invalid/signed/model.safetensors';
+
+/** Drive the route the way Next would for `url`, with the query it parses out of it. */
+function run(url: string, modelVersionId: string) {
+  const parsed = new URL(url, 'https://civitai.com');
+  const query: Record<string, string> = { modelVersionId };
+  for (const [key, value] of parsed.searchParams) query[key] = value;
+
+  const req = {
+    method: 'GET',
+    url,
+    query,
+    headers: { 'user-agent': 'civitai-downloader/1.0' },
+    socket: { remoteAddress: '203.0.113.7' },
+  } as unknown as NextApiRequest;
+
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+    send: vi.fn().mockReturnThis(),
+    redirect: vi.fn().mockReturnThis(),
+    setHeader: vi.fn().mockReturnThis(),
+    headersSent: false,
+  } as unknown as NextApiResponse;
+
+  return { promise: handler(req, res), req, res };
+}
+
+function statuses(res: NextApiResponse) {
+  return (res.status as unknown as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0]);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFindUnique.mockResolvedValue(null);
+  mockGetServerAuthSession.mockResolvedValue({ user: { id: 5 } });
+  mockHasExceededLimit.mockResolvedValue(false);
+  mockIncrement.mockResolvedValue(undefined);
+  mockGetFileForModelVersion.mockResolvedValue({
+    status: 'success',
+    url: REDIRECT_URL,
+    metadata: {},
+    isDownloadable: true,
+    published: true,
+    modelId: 1,
+    modelVersionId: 568485,
+    fileId: 484398,
+    nsfw: false,
+    inEarlyAccess: false,
+  });
+});
+
+describe('download route — a query split by a stray `?`', () => {
+  const url =
+    '/api/download/models/568485?fileId=484398?type=Model&format=SafeTensor&token=secret-key';
+
+  it('redirects instead of answering 400', async () => {
+    const { promise, res } = run(url, '568485');
+    await promise;
+
+    expect(
+      statuses(res),
+      'the schema rejected the request — `fileId` parsed as NaN, so the repair did not run first'
+    ).not.toContain(400);
+    expect(res.redirect).toHaveBeenCalledWith(REDIRECT_URL);
+  });
+
+  it('resolves the file by the id the client pinned', async () => {
+    const { promise } = run(url, '568485');
+    await promise;
+
+    expect(mockGetFileForModelVersion).toHaveBeenCalledWith(
+      expect.objectContaining({ modelVersionId: 568485, fileId: 484398, type: 'Model' })
+    );
+  });
+
+  it('hands auth a url the API key is still readable from', async () => {
+    const { promise } = run(url, '568485');
+    await promise;
+
+    const authReq = mockGetServerAuthSession.mock.calls[0][0].req as NextApiRequest;
+    const seen = new URL(authReq.url as string, 'https://civitai.com');
+    expect(
+      seen.searchParams.get('token'),
+      'auth saw the unrepaired url, so an API-key caller is treated as anonymous'
+    ).toBe('secret-key');
+  });
+
+  it('CONTROL: the same request already worked when the client used `&`', async () => {
+    const { promise, res } = run(
+      '/api/download/models/568485?fileId=484398&type=Model&format=SafeTensor&token=secret-key',
+      '568485'
+    );
+    await promise;
+
+    expect(statuses(res)).not.toContain(400);
+    expect(res.redirect).toHaveBeenCalledWith(REDIRECT_URL);
+  });
+});

--- a/src/__tests__/pages/api/download/split-query-repair.test.ts
+++ b/src/__tests__/pages/api/download/split-query-repair.test.ts
@@ -19,12 +19,14 @@ const {
   mockGetFileForModelVersion,
   mockHasExceededLimit,
   mockIncrement,
+  mockLogToAxiom,
 } = vi.hoisted(() => ({
   mockFindUnique: vi.fn(),
   mockGetServerAuthSession: vi.fn(),
   mockGetFileForModelVersion: vi.fn(),
   mockHasExceededLimit: vi.fn(),
   mockIncrement: vi.fn(),
+  mockLogToAxiom: vi.fn(),
 }));
 
 vi.mock('~/server/db/client', () => ({
@@ -51,9 +53,7 @@ vi.mock('~/server/clickhouse/client', () => ({
   },
 }));
 
-vi.mock('~/server/logging/client', () => ({
-  logToAxiom: vi.fn().mockResolvedValue(undefined),
-}));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: mockLogToAxiom }));
 
 vi.mock('~/server/redis/client', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -77,11 +77,17 @@ import handler from '~/pages/api/download/models/[modelVersionId]';
 
 const REDIRECT_URL = 'https://example.invalid/signed/model.safetensors';
 
-/** Drive the route the way Next would for `url`, with the query it parses out of it. */
+/**
+ * Drive the route the way Next would for `url`: the query string parsed with
+ * `URLSearchParams`, then the path params spread OVER it — params win on a
+ * collision (`next-server.ts`), which is the precedence the repair must not
+ * invert.
+ */
 function run(url: string, modelVersionId: string) {
   const parsed = new URL(url, 'https://civitai.com');
-  const query: Record<string, string> = { modelVersionId };
+  const query: Record<string, string> = {};
   for (const [key, value] of parsed.searchParams) query[key] = value;
+  query.modelVersionId = modelVersionId;
 
   const req = {
     method: 'GET',
@@ -113,6 +119,7 @@ beforeEach(() => {
   mockGetServerAuthSession.mockResolvedValue({ user: { id: 5 } });
   mockHasExceededLimit.mockResolvedValue(false);
   mockIncrement.mockResolvedValue(undefined);
+  mockLogToAxiom.mockResolvedValue(undefined);
   mockGetFileForModelVersion.mockResolvedValue({
     status: 'success',
     url: REDIRECT_URL,
@@ -161,6 +168,28 @@ describe('download route — a query split by a stray `?`', () => {
       seen.searchParams.get('token'),
       'auth saw the unrepaired url, so an API-key caller is treated as anonymous'
     ).toBe('secret-key');
+  });
+
+  it('resolves the version in the PATH, not one the repaired query names', async () => {
+    const { promise } = run('/api/download/models/568485?modelVersionId=999?fileId=2', '568485');
+    await promise;
+
+    expect(mockGetFileForModelVersion).toHaveBeenCalledWith(
+      expect.objectContaining({ modelVersionId: 568485 })
+    );
+  });
+
+  it('keeps the caller API key out of the error log', async () => {
+    mockGetFileForModelVersion.mockRejectedValue(new Error('resolver exploded'));
+
+    const { promise } = run(url, '568485');
+    await promise;
+
+    const logged = mockLogToAxiom.mock.calls[0][0] as { query: Record<string, unknown> };
+    expect(logged.query, 'the caller API key was shipped to Axiom in plaintext').not.toHaveProperty(
+      'token'
+    );
+    expect(logged.query.fileId, 'the rest of the query is still there to debug with').toBe('484398');
   });
 
   it('CONTROL: the same request already worked when the client used `&`', async () => {

--- a/src/pages/api/download/models/[modelVersionId].ts
+++ b/src/pages/api/download/models/[modelVersionId].ts
@@ -12,7 +12,7 @@ import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
 import { createLimiter } from '~/server/utils/rate-limiting';
 import { getTrustedClientIp, parseIpBlocklist, parseUserBlocklist } from '~/server/utils/client-ip';
 import { fetchDownloadCount } from '~/server/utils/download-count';
-import { isRequestFromBrowser } from '~/server/utils/request-helpers';
+import { isRequestFromBrowser, repairSplitQueryString } from '~/server/utils/request-helpers';
 import { getLoginLink } from '~/utils/login-helpers';
 import { GENERIC_SERVER_ERROR_MESSAGE } from '~/server/utils/rest-error-envelope';
 
@@ -44,6 +44,11 @@ export default PublicEndpoint(
     // cache window after the origin already returns 404 — defeating DMCA
     // takedowns. Override with no-store so deletes take effect immediately.
     res.setHeader('Cache-Control', 'no-store, max-age=0');
+
+    // Must run before `getServerAuthSession` below, which reads `?token=` off
+    // `req.url` — a stray `?` swallows that param into the one before it, so an
+    // API-key caller would otherwise be treated as anonymous.
+    repairSplitQueryString(req);
 
     const isBrowser = isRequestFromBrowser(req);
     function errorResponse(status: number, message: string) {

--- a/src/pages/api/download/models/[modelVersionId].ts
+++ b/src/pages/api/download/models/[modelVersionId].ts
@@ -250,12 +250,14 @@ export default PublicEndpoint(
       res.redirect(fileResult.url);
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
+      // `token` is the caller's API key, and Axiom applies no redaction of its own.
+      const { token, ...loggableQuery } = req.query;
       logToAxiom({
         name: 'download-model-endpoint',
         type: 'error',
         message: err.message,
         stack: err.stack,
-        query: req.query,
+        query: loggableQuery,
       }).catch(() => {
         // swallow logging failure
       });

--- a/src/server/utils/__tests__/repair-split-query-string.test.ts
+++ b/src/server/utils/__tests__/repair-split-query-string.test.ts
@@ -7,9 +7,13 @@ import { repairSplitQueryString } from '~/server/utils/request-helpers';
  *
  * The shape under test is what a caller produces by appending the documented
  * `?type=…&format=…` / `?token=…` suffix to a `downloadUrl` that already carries
- * `?fileId=<id>`. Every assertion below names what the caller loses without the
+ * `?fileId=<id>`. Every assertion names what the caller loses without the
  * repair, because a revert makes each one report a swallowed param rather than
  * a bare falsy.
+ *
+ * `query` fixtures are what Next itself would hand the route for the given url:
+ * the query string parsed with `URLSearchParams`, then the path params spread
+ * OVER it (`next-server.ts` — params win on a collision).
  */
 
 function makeReq(url: string, query: NextApiRequest['query']) {
@@ -78,7 +82,7 @@ describe('repairSplitQueryString', () => {
   it('treats an encoded %3F as data, not as a separator', () => {
     const req = makeReq('/api/download/models/1?fp=fp%3F16?type=Model', {
       modelVersionId: '1',
-      fp: 'fp?16',
+      fp: 'fp?16?type=Model',
     });
 
     repairSplitQueryString(req);
@@ -86,22 +90,41 @@ describe('repairSplitQueryString', () => {
     expect(req.query.fp, 'a percent-encoded ? is a value the client meant to send').toBe('fp?16');
     expect(req.query.type).toBe('Model');
   });
+});
 
-  it('never lets a repaired param overwrite a path param', () => {
-    // The route resolves `modelVersionId` from the path. A repair that let the
-    // query win would re-point the request at a different resource.
-    const req = makeReq('/api/download/models/568485?fileId=1?modelVersionId=999', {
+describe('repairSplitQueryString — what it refuses to touch', () => {
+  it('leaves a raw `?` that does not open a new param inside its value', () => {
+    // RFC 3986 §3.4 permits a raw `?` in a query value. Splitting on it would
+    // truncate the token and hand the route a phantom `cd` param.
+    const req = makeReq('/api/download/models/1?token=ab?cd', {
+      modelVersionId: '1',
+      token: 'ab?cd',
+    });
+
+    expect(repairSplitQueryString(req)).toBe(false);
+    expect(req.query.token).toBe('ab?cd');
+    expect(req.query).not.toHaveProperty('cd');
+  });
+
+  it('never lets a repaired param overwrite the path param it collides with', () => {
+    // The path is what a user reads and a log records. `modelVersionId` here is
+    // BOTH the route's path param and the first query key, which is the
+    // arrangement that defeats a naive "keys not in the query string are path
+    // params" guard — the query key deletes itself from that set.
+    const req = makeReq('/api/download/models/568485?modelVersionId=999?fileId=2', {
       modelVersionId: '568485',
-      fileId: '1?modelVersionId=999',
+      fileId: '2',
     });
 
     repairSplitQueryString(req);
 
-    expect(req.query.modelVersionId).toBe('568485');
-    expect(req.query.fileId).toBe('1');
+    expect(
+      req.query.modelVersionId,
+      'the repair re-pointed the request at another model version'
+    ).toBe('568485');
   });
 
-  it('keeps repeated params as an array, matching how the query was parsed', () => {
+  it('never replaces a param that already arrived intact', () => {
     const req = makeReq('/api/download/models/1?fileId=2?type=Model&type=Config', {
       modelVersionId: '1',
       fileId: '2?type=Model',
@@ -110,6 +133,36 @@ describe('repairSplitQueryString', () => {
 
     repairSplitQueryString(req);
 
-    expect(req.query.type).toEqual(['Model', 'Config']);
+    expect(req.query.fileId).toBe('2');
+    expect(req.query.type, 'a value Next parsed cleanly was overwritten by the repair').toBe(
+      'Config'
+    );
+  });
+});
+
+describe('repairSplitQueryString — what it leaves behind', () => {
+  it('drops the split entry rather than keeping it beside the repair', () => {
+    // Here the stray `?` lands inside a KEY, so Next parses `debug?type`. Left
+    // in place it reaches everything that iterates req.query, logging included.
+    const req = makeReq('/api/download/models/1?debug?type=Model', {
+      modelVersionId: '1',
+      'debug?type': 'Model',
+    });
+
+    repairSplitQueryString(req);
+
+    expect(req.query).not.toHaveProperty('debug?type');
+    expect(req.query.type).toBe('Model');
+  });
+
+  it('rewrites req.url without empty query segments', () => {
+    const req = makeReq('/api/download/models/1?fileId=2?&type=Model', {
+      modelVersionId: '1',
+      fileId: '2?',
+    });
+
+    repairSplitQueryString(req);
+
+    expect(req.url).toBe('/api/download/models/1?fileId=2&type=Model');
   });
 });

--- a/src/server/utils/__tests__/repair-split-query-string.test.ts
+++ b/src/server/utils/__tests__/repair-split-query-string.test.ts
@@ -1,0 +1,115 @@
+import type { NextApiRequest } from 'next';
+import { describe, expect, it } from 'vitest';
+import { repairSplitQueryString } from '~/server/utils/request-helpers';
+
+/**
+ * `repairSplitQueryString` rejoins a query a client split with a second `?`.
+ *
+ * The shape under test is what a caller produces by appending the documented
+ * `?type=…&format=…` / `?token=…` suffix to a `downloadUrl` that already carries
+ * `?fileId=<id>`. Every assertion below names what the caller loses without the
+ * repair, because a revert makes each one report a swallowed param rather than
+ * a bare falsy.
+ */
+
+function makeReq(url: string, query: NextApiRequest['query']) {
+  return { url, query } as NextApiRequest;
+}
+
+describe('repairSplitQueryString', () => {
+  it('splits the reported shape back into its params', () => {
+    const req = makeReq(
+      '/api/download/models/568485?fileId=484398?type=Model&format=SafeTensor&token=abc',
+      { modelVersionId: '568485', fileId: '484398?type=Model', format: 'SafeTensor', token: 'abc' }
+    );
+
+    expect(repairSplitQueryString(req)).toBe(true);
+    expect(req.query.fileId, 'fileId still carries the swallowed `?type=Model`').toBe('484398');
+    expect(req.query.type, 'the param after the stray `?` never reached the handler').toBe('Model');
+    expect(req.query.format).toBe('SafeTensor');
+    expect(req.query.token).toBe('abc');
+  });
+
+  it('repairs req.url too, which is where API-key auth reads ?token=', () => {
+    const req = makeReq('/api/download/models/501240?fileId=418901?token=secret', {
+      modelVersionId: '501240',
+      fileId: '418901?token=secret',
+    });
+
+    repairSplitQueryString(req);
+
+    const parsed = new URL(req.url as string, 'https://civitai.com');
+    expect(
+      parsed.searchParams.get('token'),
+      'auth reads the token off req.url — an unrepaired url authenticates nobody'
+    ).toBe('secret');
+    expect(parsed.searchParams.get('fileId')).toBe('418901');
+  });
+
+  it('leaves a well-formed request untouched', () => {
+    const url = '/api/download/models/501240?fileId=418901&token=abc';
+    const req = makeReq(url, { modelVersionId: '501240', fileId: '418901', token: 'abc' });
+
+    expect(repairSplitQueryString(req)).toBe(false);
+    expect(req.url).toBe(url);
+    expect(req.query).toEqual({ modelVersionId: '501240', fileId: '418901', token: 'abc' });
+  });
+
+  it('leaves a request with no query string untouched', () => {
+    const req = makeReq('/api/download/models/501240', { modelVersionId: '501240' });
+
+    expect(repairSplitQueryString(req)).toBe(false);
+    expect(req.url).toBe('/api/download/models/501240');
+  });
+
+  it('rejoins every stray `?`, not just the first', () => {
+    const req = makeReq('/api/download/models/1?fileId=2?type=Model?format=SafeTensor', {
+      modelVersionId: '1',
+      fileId: '2?type=Model?format=SafeTensor',
+    });
+
+    repairSplitQueryString(req);
+
+    expect(req.query.fileId).toBe('2');
+    expect(req.query.type).toBe('Model');
+    expect(req.query.format).toBe('SafeTensor');
+  });
+
+  it('treats an encoded %3F as data, not as a separator', () => {
+    const req = makeReq('/api/download/models/1?fp=fp%3F16?type=Model', {
+      modelVersionId: '1',
+      fp: 'fp?16',
+    });
+
+    repairSplitQueryString(req);
+
+    expect(req.query.fp, 'a percent-encoded ? is a value the client meant to send').toBe('fp?16');
+    expect(req.query.type).toBe('Model');
+  });
+
+  it('never lets a repaired param overwrite a path param', () => {
+    // The route resolves `modelVersionId` from the path. A repair that let the
+    // query win would re-point the request at a different resource.
+    const req = makeReq('/api/download/models/568485?fileId=1?modelVersionId=999', {
+      modelVersionId: '568485',
+      fileId: '1?modelVersionId=999',
+    });
+
+    repairSplitQueryString(req);
+
+    expect(req.query.modelVersionId).toBe('568485');
+    expect(req.query.fileId).toBe('1');
+  });
+
+  it('keeps repeated params as an array, matching how the query was parsed', () => {
+    const req = makeReq('/api/download/models/1?fileId=2?type=Model&type=Config', {
+      modelVersionId: '1',
+      fileId: '2?type=Model',
+      type: 'Config',
+    });
+
+    repairSplitQueryString(req);
+
+    expect(req.query.type).toEqual(['Model', 'Config']);
+  });
+});

--- a/src/server/utils/request-helpers.ts
+++ b/src/server/utils/request-helpers.ts
@@ -17,25 +17,22 @@ export function getProtocol(req: ProtocolRequest): Protocol {
   return proto as Protocol;
 }
 
+/** A raw `?` is only a separator when what follows it opens a new param. */
+const RESUMES_QUERY = /^&*[^&=?]+=/;
+
 /**
- * Rejoin a query string a client built by appending a SECOND `?…` to a URL that
- * already carried one — `…/models/1?fileId=2?type=Model&token=abc`.
+ * Rejoin a query a client split by appending a second `?…` to a URL that already
+ * carried one, e.g. `…/models/1?fileId=2?type=Model&token=abc`. RFC 3986 makes
+ * that one param — `fileId=2?type=Model` — so the id fails to parse and every
+ * later param is swallowed, `token` (API-key auth) included.
  *
- * That is a legal URI whose query holds one param, `fileId=2?type=Model`, so
- * nothing upstream repairs it: the id fails to parse and every param the client
- * meant to send before the stray `?` is swallowed into it — including `token`,
- * which the endpoint reads for API-key auth.
+ * A raw `?` is legal INSIDE a value, so only a `?` followed by `key=` is treated
+ * as a separator; `?token=ab?cd` is left alone.
  *
- * Appending `?type=…&format=…` or `?token=…` to a `downloadUrl` we handed out is
- * a long-standing client habit that was harmless while those URLs had no query
- * of their own. `createModelFileDownloadUrl` now pins `?fileId=<id>` into them,
- * so the same habit produces the broken shape above.
- *
- * `%3F` is left alone — only a raw `?`, which cannot be part of a value the
- * client meant to send, is treated as a separator.
- *
- * Keys that reached `req.query` from the ROUTE PATH are never overwritten, so a
- * repaired param cannot rewrite the resource being addressed.
+ * Rewrites `req.url` as well as `req.query`, because auth re-parses the url.
+ * Only a param that is missing or itself split is written, so a repair can never
+ * replace a value that arrived intact — including the path params Next spreads
+ * over the query string.
  */
 export function repairSplitQueryString(req: NextApiRequest): boolean {
   const url = req.url;
@@ -45,17 +42,33 @@ export function repairSplitQueryString(req: NextApiRequest): boolean {
   if (start === -1) return false;
 
   const raw = url.slice(start + 1);
-  if (!raw.includes('?')) return false;
+  const [head, ...rest] = raw.split('?');
+  if (!rest.length) return false;
 
-  const repaired = raw.split('?').join('&');
-  const pathOwned = new Set(Object.keys(req.query));
-  for (const key of new URLSearchParams(raw).keys()) pathOwned.delete(key);
+  let repaired = head;
+  let split = false;
+  for (const segment of rest) {
+    if (!RESUMES_QUERY.test(segment)) {
+      repaired += `?${segment}`;
+      continue;
+    }
+    repaired += `&${segment.replace(/^&+/, '')}`;
+    split = true;
+  }
+  if (!split) return false;
 
   const params = new URLSearchParams(repaired);
   for (const key of new Set(params.keys())) {
-    if (pathOwned.has(key)) continue;
+    const current = req.query[key];
+    if (current !== undefined && !(typeof current === 'string' && current.includes('?'))) continue;
     const values = params.getAll(key);
     req.query[key] = values.length > 1 ? values : values[0];
+  }
+
+  // Drop the split entries themselves, so `req.query` never carries both a
+  // `fileId=2?type` key and the repaired pair it was split into.
+  for (const key of new URLSearchParams(raw).keys()) {
+    if (key.includes('?')) delete req.query[key];
   }
 
   req.url = `${url.slice(0, start)}?${repaired}`;

--- a/src/server/utils/request-helpers.ts
+++ b/src/server/utils/request-helpers.ts
@@ -16,3 +16,48 @@ export function getProtocol(req: ProtocolRequest): Protocol {
   const proto = hasHttps ? 'https' : req.headers['x-forwarded-proto'] ?? 'http';
   return proto as Protocol;
 }
+
+/**
+ * Rejoin a query string a client built by appending a SECOND `?…` to a URL that
+ * already carried one — `…/models/1?fileId=2?type=Model&token=abc`.
+ *
+ * That is a legal URI whose query holds one param, `fileId=2?type=Model`, so
+ * nothing upstream repairs it: the id fails to parse and every param the client
+ * meant to send before the stray `?` is swallowed into it — including `token`,
+ * which the endpoint reads for API-key auth.
+ *
+ * Appending `?type=…&format=…` or `?token=…` to a `downloadUrl` we handed out is
+ * a long-standing client habit that was harmless while those URLs had no query
+ * of their own. `createModelFileDownloadUrl` now pins `?fileId=<id>` into them,
+ * so the same habit produces the broken shape above.
+ *
+ * `%3F` is left alone — only a raw `?`, which cannot be part of a value the
+ * client meant to send, is treated as a separator.
+ *
+ * Keys that reached `req.query` from the ROUTE PATH are never overwritten, so a
+ * repaired param cannot rewrite the resource being addressed.
+ */
+export function repairSplitQueryString(req: NextApiRequest): boolean {
+  const url = req.url;
+  if (!url || !req.query) return false;
+
+  const start = url.indexOf('?');
+  if (start === -1) return false;
+
+  const raw = url.slice(start + 1);
+  if (!raw.includes('?')) return false;
+
+  const repaired = raw.split('?').join('&');
+  const pathOwned = new Set(Object.keys(req.query));
+  for (const key of new URLSearchParams(raw).keys()) pathOwned.delete(key);
+
+  const params = new URLSearchParams(repaired);
+  for (const key of new Set(params.keys())) {
+    if (pathOwned.has(key)) continue;
+    const values = params.getAll(key);
+    req.query[key] = values.length > 1 ? values : values[0];
+  }
+
+  req.url = `${url.slice(0, start)}?${repaired}`;
+  return true;
+}


### PR DESCRIPTION
## What broke

Reported: `https://api.civitai.com/download/models/568485?fileId=484398?type=Model&format=SafeTensor&token=…` returns

```
400 {"error":"✖ Invalid input: expected number, received NaN\n  → at fileId"}
```

Two `?` in that URL. It is a legal URI whose query holds a **single** param, `fileId=484398?type=Model` — so the id parses as `NaN` and every param the caller meant to send after the stray `?` is swallowed into it, **including `token`**, which the route reads for API-key auth.

## Why it started now

#3864 (`adb2850c3e`, shipped in v5.1.1) pins `?fileId=<id>` into every per-file `downloadUrl` on `/api/v1/model-versions/[id]`. Our public docs tell callers to pass their key as `?token=` (`site/reference/model-versions.md`), and appending `?type=…&format=…` to a download URL is a long-standing client habit. Both were harmless while those URLs carried no query of their own.

Reproduced live on a healthy public model — not the deleted one from the report:

```
/api/download/models/501240?fileId=418901?token=…   → 400
/api/download/models/501240?token=…                 → 307
```

So any client that appends `?token=` to a `model-versions` `downloadUrl` has been broken since that deploy.

## Fix

`repairSplitQueryString(req)` in `src/server/utils/request-helpers.ts` rejoins raw `?` separators into `&`, rewriting **both** `req.query` and `req.url`. Called at the top of the download route — it has to run before `getServerAuthSession`, which reads `?token=` off `req.url`, or an API-key caller is still treated as anonymous.

- `%3F` is left alone; only a raw `?`, which cannot be part of a value the client meant to send, is treated as a separator.
- Params recovered from the split never overwrite a path param, so a repair cannot re-point the request at another resource.

## Verification

- 12 new tests (8 unit + 4 route-wiring); 107 pass across the download-adjacent suites
- Mutation check: stubbing the helper to a no-op fails 6+ with legible messages (`expected '2?type=Model' to be '2'`, `auth saw the unrepaired url…`)
- `typecheck: OK — 0 type errors`

## Review round (second commit)

- **Path param could be overwritten.** `?modelVersionId=999?fileId=2` defeated the first guard — it inferred path params by subtracting the query-string keys, and a query key with the same name deleted itself from that set, so the repair re-pointed the request at another model version. The guard no longer reasons about origin at all: a param is written only when it is missing or itself split, so anything Next parsed cleanly (path params included) is never replaced.
- **A raw `?` is legal inside a value** (RFC 3986 §3.4), so `?token=ab?cd` was truncated to `token=ab` plus a phantom `cd`. Only a `?` that opens a new `key=` is a separator now; that input is a no-op.
- **The split entry survived the repair** (`debug?type` stayed beside the `debug`/`type` pair it produced) and the rewritten url could carry an empty `&&` segment. Both fixed.
- **The error path logged `query: req.query` to Axiom**, which on this route includes the caller's API key. Redacted. Pre-existing, but this PR is what makes `token` parse correctly in the split case.
- Route test harness modelled Next's precedence backwards (query over path). Corrected to params-last, which is what let the path-param regression test be written at all.

Verification after the round: 112 pass across the download suites, `typecheck: OK — 0 type errors`. Both new guards are mutation-checked — loosening the separator rule fails the RFC test, dropping the intact-value rule fails the path-param and intact-param tests.

### Knowingly not done

- **Hoisting the repair into `withApiMetrics`** so every wrapper that reads `?token=` benefits. It is the more complete fix and probably the right one, but it changes query parsing for every API route in the app, which wants its own PR and its own risk call rather than riding along on a hotfix.
- **A counter on the repair** so we can tell when no client still needs the shim. The metric registry lives in `@civitai/telemetry`, so it is a cross-package change; an Axiom log per repair was the alternative and the volume is unknown.
- **Sharing the route-test mock harness** with the two sibling files in that directory, which are near-identical copies. Real duplication, but the extraction touches suites this PR otherwise leaves alone. `importOriginal` is not the fix here — spreading the real `~/server/redis/client` or `~/server/db/client` constructs clients at import.

## Not in this PR

- `/api/v1/models` still emits the older `?type=&format=` shape while `/api/v1/model-versions` emits `?fileId=` — the two endpoints disagree and that is worth its own look.
- The developer docs could say to append with `&`.
- The model in the original report (`497255`, SD3) is `Deleted`, so it 404s for non-moderators regardless of URL shape. Unrelated to this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
