### PR TITLE
fix(model-flag): make the ModelFlag upsert executable, and test it against real Postgres

### DIFF
--- a/src/server/services/__tests__/model-flag-upsert-sql.test.ts
+++ b/src/server/services/__tests__/model-flag-upsert-sql.test.ts
@@ -79,9 +79,28 @@ function splitTopLevel(input: string): string[] {
   return parts;
 }
 
+/**
+ * Index of `needle`, or throw.
+ *
+ * 🔴 This exists because `indexOf` FAILS OPEN here. It returns -1 when the
+ * clause is missing, and `String.prototype.indexOf` CLAMPS a negative start
+ * position to 0 — so `parenGroupAfter(text, -1)` used to quietly re-scan from
+ * the top of the statement and hand back a perfectly valid group belonging to
+ * a different clause. A misspelled `INSER INTO` then passed every structural
+ * assertion below. An anchor that cannot be missing is the point; a keyword
+ * typo in raw SQL is the exact defect class this file exists for.
+ */
+function anchorOf(sql: string, needle: string | RegExp): number {
+  const index = typeof needle === 'string' ? sql.indexOf(needle) : sql.search(needle);
+  if (index < 0) throw new Error(`generated SQL is missing ${needle}:\n${sql}`);
+  return index;
+}
+
 /** Body of the first parenthesised group starting at `fromIndex`. */
 function parenGroupAfter(sql: string, fromIndex: number): string {
+  if (fromIndex < 0) throw new Error('parenGroupAfter called with a missing anchor');
   const open = sql.indexOf('(', fromIndex);
+  if (open < 0) throw new Error('generated SQL has no parenthesised group after the anchor');
   let depth = 0;
   for (let i = open; i < sql.length; i++) {
     if (sql[i] === '(') depth++;
@@ -101,11 +120,41 @@ describe('buildModelFlagUpsert — structure', () => {
     expect(statement.text).toContain('$1');
   });
 
+  it('has each SQL clause exactly once, so a keyword typo cannot slip through', () => {
+    const { text } = buildModelFlagUpsert({ modelId: 1, scanResult: SCAN_RESULT });
+
+    // A misspelled keyword (`INSER INTO`, `DO UPDATED`, `ON CONFLICTS`) is a
+    // text-only corruption that every shape assertion below happily tolerates,
+    // and it is the same class as the punctuation defects this file exists
+    // for. Counting occurrences rather than testing presence also catches a
+    // doubled keyword (`VALUES VALUES`), which an anchor would just skip past.
+    // Counted as BARE TOKENS, not as `VALUES\s*\(`-style shapes: a shaped
+    // pattern skips the first of a doubled `VALUES VALUES` and matches the
+    // second, reporting one. A bare token count sees two. A typo takes the
+    // count to zero.
+    const clauses: [string, RegExp][] = [
+      ['INSERT', /\bINSERT\b/g],
+      ['INTO', /\bINTO\b/g],
+      ['VALUES', /\bVALUES\b/g],
+      ['CONFLICT', /\bCONFLICT\b/g],
+      ['UPDATE', /\bUPDATE\b/g],
+      ['SET', /\bSET\b/g],
+      ['RETURNING', /\bRETURNING\b/g],
+    ];
+
+    for (const [name, pattern] of clauses) {
+      expect({ clause: name, count: text.match(pattern)?.length ?? 0 }).toEqual({
+        clause: name,
+        count: 1,
+      });
+    }
+  });
+
   it('inserts exactly one value per column', () => {
     const { text } = buildModelFlagUpsert({ modelId: 1, scanResult: SCAN_RESULT });
 
-    const columns = splitTopLevel(parenGroupAfter(text, text.indexOf('INSERT INTO')));
-    const values = splitTopLevel(parenGroupAfter(text, text.indexOf('VALUES')));
+    const columns = splitTopLevel(parenGroupAfter(text, anchorOf(text, /INSERT INTO\s/)));
+    const values = splitTopLevel(parenGroupAfter(text, anchorOf(text, /\bVALUES\s*\(/)));
 
     // Pinned literally rather than derived from `columns.length`, so a column
     // silently dropped from BOTH lists still fails here. The order is pinned
@@ -131,9 +180,10 @@ describe('buildModelFlagUpsert — structure', () => {
   it('assigns every non-key column exactly once in DO UPDATE, with no empty slot', () => {
     const { text } = buildModelFlagUpsert({ modelId: 1, scanResult: SCAN_RESULT });
 
+    const doUpdate = anchorOf(text, /DO UPDATE\s+SET\s/);
     const setClause = text.slice(
-      text.indexOf('SET ', text.indexOf('DO UPDATE')) + 'SET '.length,
-      text.indexOf('RETURNING')
+      doUpdate + text.slice(doUpdate).indexOf('SET ') + 'SET '.length,
+      anchorOf(text, /\bRETURNING\s/)
     );
     const assignments = splitTopLevel(setClause);
 
@@ -144,7 +194,7 @@ describe('buildModelFlagUpsert — structure', () => {
     }
 
     const assigned = assignments.map((a) => a.split('"')[1]);
-    const columns = splitTopLevel(parenGroupAfter(text, text.indexOf('INSERT INTO'))).map((c) =>
+    const columns = splitTopLevel(parenGroupAfter(text, anchorOf(text, /INSERT INTO\s/))).map((c) =>
       c.replaceAll('"', '')
     );
     // Every column except the conflict target is refreshed on conflict.
@@ -154,7 +204,7 @@ describe('buildModelFlagUpsert — structure', () => {
   it('writes SQL NULL — not a JSON object — when details are absent', () => {
     const { text, values } = buildModelFlagUpsert({ modelId: 1, scanResult: SCAN_RESULT });
 
-    const valueSlots = splitTopLevel(parenGroupAfter(text, text.indexOf('VALUES')));
+    const valueSlots = splitTopLevel(parenGroupAfter(text, anchorOf(text, /\bVALUES\s*\(/)));
     // `Prisma.JsonNull` interpolates as a bound parameter and lands as `{}`.
     expect(valueSlots).toContain('NULL');
     expect(values).not.toContainEqual({});
@@ -174,19 +224,22 @@ describe('buildModelFlagUpsert — structure', () => {
  *
  * 🔴 What this does NOT cover, so nobody reads it as closing the class: these
  * cases read `statement.values`, so anything living only in the statement TEXT
- * has to be caught elsewhere. Measured over a 25-mutant battery, exactly three
+ * has to be caught elsewhere. Over the 31 mutants measured so far, three
  * corruptions survive the whole always-on suite and are caught only by the
  * execution arm — i.e. never in CI:
  *
  *   - the table name
- *   - the ON CONFLICT target
+ *   - the ON CONFLICT target column
  *   - narrowing `RETURNING *`
  *
- * Everything else text-only IS covered without a database: the column list's
- * order and contents (pinned by the shape suite above), `DO UPDATE` vs
- * `DO NOTHING`, a commented-out SET clause, and all three original punctuation
- * defects. Do not treat a green always-on run as proof the statement is
- * correct; run the execution arm when you change it.
+ * The rest of the text-only space that battery covers IS caught without a
+ * database: the column list's order and contents, `DO UPDATE` vs `DO NOTHING`,
+ * a commented-out SET clause, a misspelled or doubled SQL keyword, a cast-name
+ * typo, and all three original punctuation defects. That list is a measurement
+ * over the mutants someone thought of, NOT a proof about the whole grammar —
+ * two earlier rounds each found survivors the previous battery had missed. Do
+ * not treat a green always-on run as proof the statement is correct; run the
+ * execution arm when you change it.
  */
 describe('buildModelFlagUpsert — value binding', () => {
   // Measured against the built statement, not assumed. `Prisma.sql`NULL`` is
@@ -254,9 +307,9 @@ describe('buildModelFlagUpsert — value binding', () => {
       true,
     ]);
     // A `::text` cast would store the payload as a string, not queryable jsonb.
-    expect(text).toContain('::jsonb');
+    expect(text).toMatch(/::jsonb\b/);
     // New flags must land Pending or they never reach the moderator queue.
-    expect(text).toContain('::"ModelFlagStatus"');
+    expect(text).toMatch(/::"ModelFlagStatus"(?!\w)/);
   });
 });
 

--- a/src/server/services/__tests__/model-flag-upsert-sql.test.ts
+++ b/src/server/services/__tests__/model-flag-upsert-sql.test.ts
@@ -1,0 +1,232 @@
+import { Client } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildModelFlagUpsert } from '~/server/services/model-flag.sql';
+
+/**
+ * Execution + structure gate for the `ModelFlag` upsert.
+ *
+ * WHY THIS EXISTS: the statement shipped broken for 15.5 months. Three
+ * punctuation defects, each masking the next — a missing comma between the
+ * `details` and `sfwOnly` values, a missing comma in the DO UPDATE SET list,
+ * and a trailing comma before RETURNING — plus a `Prisma.JsonNull` that lands
+ * as `{}` rather than SQL NULL. Every one of them is invisible to a mock: a
+ * raw SQL string is just a string until something parses it, and nothing in
+ * the suite ever did. Content flagging recorded nothing for 15.5 months.
+ *
+ * TWO ARMS, deliberately:
+ *
+ *  - `structure` always runs. It re-derives the statement's shape from the
+ *    generated text — arity of the VALUES list against the column list, and
+ *    the DO UPDATE assignments — so the exact three defects cannot come back
+ *    silently in CI. It is a backstop, not a parser: it knows the shapes that
+ *    broke us, not the whole PostgreSQL grammar.
+ *
+ *  - `execution` is the real proof and is OPT-IN, because it needs a server.
+ *    It runs the statement against a real PostgreSQL, so it answers the only
+ *    question that actually matters — does this parse and do what it says.
+ *    🔴 Run it whenever you touch the statement; a green unit suite alone
+ *    tells you nothing about whether the SQL is valid.
+ *
+ *      docker run -d --rm --name pg-modelflag -e POSTGRES_PASSWORD=postgres \
+ *        -e POSTGRES_DB=modelflag -p 54330:5432 postgres:17
+ *      MODEL_FLAG_TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:54330/modelflag \
+ *        pnpm vitest run --project unit src/server/services/__tests__/model-flag-upsert-sql.test.ts
+ *
+ *    It points at its own variable and deliberately does NOT fall back to
+ *    `DATABASE_URL` — that names a real environment in any checkout that has
+ *    one, and this suite creates and drops tables. Same rule as
+ *    `kysely-prisma-parity.test.ts`.
+ */
+
+const testDatabaseUrl = process.env.MODEL_FLAG_TEST_DATABASE_URL;
+
+const SCAN_RESULT = {
+  poi: true,
+  nsfw: false,
+  minor: true,
+  triggerWords: false,
+  poiName: true,
+  sfwOnly: true,
+};
+
+/**
+ * Split on commas that sit at paren depth 0 and outside a quoted identifier or
+ * literal. A naive `.split(',')` would cut inside `('a','b')` and inside any
+ * literal containing a comma, and would then agree with a broken statement.
+ */
+function splitTopLevel(input: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let inDoubleQuote = false;
+  let inSingleQuote = false;
+  let current = '';
+
+  for (const char of input) {
+    if (char === '"' && !inSingleQuote) inDoubleQuote = !inDoubleQuote;
+    else if (char === "'" && !inDoubleQuote) inSingleQuote = !inSingleQuote;
+    else if (!inDoubleQuote && !inSingleQuote) {
+      if (char === '(') depth++;
+      else if (char === ')') depth--;
+      else if (char === ',' && depth === 0) {
+        parts.push(current.trim());
+        current = '';
+        continue;
+      }
+    }
+    current += char;
+  }
+  parts.push(current.trim());
+  return parts;
+}
+
+/** Body of the first parenthesised group starting at `fromIndex`. */
+function parenGroupAfter(sql: string, fromIndex: number): string {
+  const open = sql.indexOf('(', fromIndex);
+  let depth = 0;
+  for (let i = open; i < sql.length; i++) {
+    if (sql[i] === '(') depth++;
+    else if (sql[i] === ')') {
+      depth--;
+      if (depth === 0) return sql.slice(open + 1, i);
+    }
+  }
+  throw new Error('unbalanced parentheses in generated SQL');
+}
+
+describe('buildModelFlagUpsert — structure', () => {
+  // `Prisma.Sql#text` is the Postgres form ($1, $2 …); `#sql` is the MySQL `?`
+  // form. Asserting this pins which one the execution arm sends to `pg`.
+  it('emits numbered Postgres placeholders on .text', () => {
+    const statement = buildModelFlagUpsert({ modelId: 1, scanResult: SCAN_RESULT });
+    expect(statement.text).toContain('$1');
+  });
+
+  it('inserts exactly one value per column', () => {
+    const { text } = buildModelFlagUpsert({ modelId: 1, scanResult: SCAN_RESULT });
+
+    const columns = splitTopLevel(parenGroupAfter(text, text.indexOf('INSERT INTO')));
+    const values = splitTopLevel(parenGroupAfter(text, text.indexOf('VALUES')));
+
+    // Pinned literally rather than derived from `columns.length`, so a column
+    // silently dropped from BOTH lists still fails here.
+    expect(columns).toHaveLength(9);
+    expect(values).toHaveLength(9);
+    expect(values.every((value) => value.length > 0)).toBe(true);
+  });
+
+  it('assigns every non-key column exactly once in DO UPDATE, with no empty slot', () => {
+    const { text } = buildModelFlagUpsert({ modelId: 1, scanResult: SCAN_RESULT });
+
+    const setClause = text.slice(
+      text.indexOf('SET ', text.indexOf('DO UPDATE')) + 'SET '.length,
+      text.indexOf('RETURNING')
+    );
+    const assignments = splitTopLevel(setClause);
+
+    // A trailing comma before RETURNING leaves an empty final element; a
+    // missing comma fuses two assignments so one element fails the pattern.
+    for (const assignment of assignments) {
+      expect(assignment).toMatch(/^"(\w+)" = EXCLUDED\."\1"$/);
+    }
+
+    const assigned = assignments.map((a) => a.split('"')[1]);
+    const columns = splitTopLevel(parenGroupAfter(text, text.indexOf('INSERT INTO'))).map((c) =>
+      c.replaceAll('"', '')
+    );
+    // Every column except the conflict target is refreshed on conflict.
+    expect(new Set(assigned)).toEqual(new Set(columns.filter((c) => c !== 'modelId')));
+  });
+
+  it('writes SQL NULL — not a JSON object — when details are absent', () => {
+    const { text, values } = buildModelFlagUpsert({ modelId: 1, scanResult: SCAN_RESULT });
+
+    const valueSlots = splitTopLevel(parenGroupAfter(text, text.indexOf('VALUES')));
+    // `Prisma.JsonNull` interpolates as a bound parameter and lands as `{}`.
+    expect(valueSlots).toContain('NULL');
+    expect(values).not.toContainEqual({});
+  });
+});
+
+describe.skipIf(!testDatabaseUrl)('buildModelFlagUpsert — execution (real Postgres)', () => {
+  const client = new Client({ connectionString: testDatabaseUrl });
+
+  beforeAll(async () => {
+    await client.connect();
+    // Mirrors the live `ModelFlag` table, including `sfwOnly`, whose migration
+    // (20250425225502_add_model_flag_sfw_only) had never been applied — the
+    // fourth defect, and the one no amount of source reading finds.
+    await client.query(`
+      DROP TABLE IF EXISTS "ModelFlag";
+      DROP TYPE IF EXISTS "ModelFlagStatus";
+      CREATE TYPE "ModelFlagStatus" AS ENUM ('Pending', 'Resolved');
+      CREATE TABLE "ModelFlag" (
+        "modelId" integer PRIMARY KEY,
+        "minor" boolean NOT NULL DEFAULT false,
+        "nsfw" boolean NOT NULL DEFAULT false,
+        "poi" boolean NOT NULL DEFAULT false,
+        "status" "ModelFlagStatus" NOT NULL DEFAULT 'Pending',
+        "triggerWords" boolean NOT NULL DEFAULT false,
+        "createdAt" timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        "details" jsonb,
+        "poiName" boolean NOT NULL DEFAULT false,
+        "sfwOnly" boolean NOT NULL DEFAULT false
+      );
+    `);
+  });
+
+  afterAll(async () => {
+    await client.end();
+  });
+
+  const run = (args: Parameters<typeof buildModelFlagUpsert>[0]) => {
+    const statement = buildModelFlagUpsert(args);
+    return client.query(statement.text, statement.values as unknown[]);
+  };
+
+  it('inserts a flag and returns the row', async () => {
+    const { rows } = await run({ modelId: 101, scanResult: SCAN_RESULT, details: { a: 1 } });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      modelId: 101,
+      poi: true,
+      nsfw: false,
+      minor: true,
+      triggerWords: false,
+      poiName: true,
+      sfwOnly: true,
+      status: 'Pending',
+      details: { a: 1 },
+    });
+  });
+
+  it('updates every flag column on conflict', async () => {
+    await run({ modelId: 202, scanResult: SCAN_RESULT, details: { first: true } });
+    const { rows } = await run({
+      modelId: 202,
+      scanResult: { ...SCAN_RESULT, poi: false, nsfw: true, sfwOnly: false },
+      details: { second: true },
+    });
+
+    expect(rows[0]).toMatchObject({
+      modelId: 202,
+      poi: false,
+      nsfw: true,
+      sfwOnly: false,
+      details: { second: true },
+    });
+
+    const { rows: all } = await client.query(
+      'SELECT count(*)::int AS n FROM "ModelFlag" WHERE "modelId" = 202'
+    );
+    expect(all[0].n).toBe(1);
+  });
+
+  it('stores SQL NULL when details are absent', async () => {
+    const { rows } = await run({ modelId: 303, scanResult: SCAN_RESULT });
+
+    // The `Prisma.JsonNull` defect stored `{}` here, which reads as "scanned,
+    // no findings" rather than "no details recorded".
+    expect(rows[0].details).toBeNull();
+  });
+});

--- a/src/server/services/__tests__/model-flag-upsert-sql.test.ts
+++ b/src/server/services/__tests__/model-flag-upsert-sql.test.ts
@@ -147,10 +147,104 @@ describe('buildModelFlagUpsert — structure', () => {
   });
 });
 
+/**
+ * The assertions above constrain the statement's SHAPE. Shape cannot see a
+ * wrong BIND: swap two columns in the VALUES list, or point the `sfwOnly` slot
+ * at `poi`, and every arity and assignment check above still passes. Booleans
+ * cannot be told apart by value, so they are told apart by POSITION.
+ *
+ * Each case sets exactly one flag and pins `statement.values` exactly, so any
+ * swap, stale bind or defaulted flag lands a `true` in the wrong slot. This
+ * runs with no database, which matters: CI provides no Postgres server, so the
+ * execution arm below never runs there and this is the guard that does.
+ */
+describe('buildModelFlagUpsert — value binding', () => {
+  // Measured against the built statement, not assumed. `Prisma.sql`NULL`` is
+  // spliced as literal text and consumes no placeholder, so with details
+  // absent there are 8 bound values and `sfwOnly` sits at index 7.
+  const VALUE_INDEX = {
+    poi: 1,
+    nsfw: 2,
+    minor: 3,
+    triggerWords: 4,
+    poiName: 5,
+    sfwOnly: 7,
+  } as const;
+  const ALL_FALSE = {
+    poi: false,
+    nsfw: false,
+    minor: false,
+    triggerWords: false,
+    poiName: false,
+    sfwOnly: false,
+  };
+
+  it.each(Object.keys(VALUE_INDEX) as (keyof typeof VALUE_INDEX)[])(
+    'binds %s to its own slot and leaves every other flag false',
+    (flag) => {
+      const { values } = buildModelFlagUpsert({
+        modelId: 4242,
+        scanResult: { ...ALL_FALSE, [flag]: true },
+      });
+
+      const expected: unknown[] = [4242, false, false, false, false, false, 'Pending', false];
+      expected[VALUE_INDEX[flag]] = true;
+      expect(values).toEqual(expected);
+    }
+  );
+
+  it('defaults a flag the caller omitted to false, never true', () => {
+    // `sfwOnly` is the optional field, so this is the `?? false` path. Without
+    // a case that OMITS a flag, none of the six defaults is ever exercised.
+    const { values } = buildModelFlagUpsert({
+      modelId: 4242,
+      scanResult: { poi: true, nsfw: false, minor: false, triggerWords: false, poiName: false },
+    });
+
+    expect(values).toEqual([4242, true, false, false, false, false, 'Pending', false]);
+  });
+
+  it('forwards details as jsonb and shifts sfwOnly, keeping status Pending', () => {
+    const { text, values } = buildModelFlagUpsert({
+      modelId: 4242,
+      scanResult: { ...ALL_FALSE, sfwOnly: true },
+      details: { verdict: 'x' },
+    });
+
+    // details occupies index 7 when present, pushing sfwOnly to 8.
+    expect(values).toEqual([
+      4242,
+      false,
+      false,
+      false,
+      false,
+      false,
+      'Pending',
+      JSON.stringify({ verdict: 'x' }),
+      true,
+    ]);
+    // A `::text` cast would store the payload as a string, not queryable jsonb.
+    expect(text).toContain('::jsonb');
+    // New flags must land Pending or they never reach the moderator queue.
+    expect(text).toContain('::"ModelFlagStatus"');
+  });
+});
+
 describe.skipIf(!testDatabaseUrl)('buildModelFlagUpsert — execution (real Postgres)', () => {
   const client = new Client({ connectionString: testDatabaseUrl });
 
   beforeAll(async () => {
+    // This suite DROPs "ModelFlag". The env-var isolation above stops it
+    // pointing at a real environment by default, but a mis-set variable would
+    // still destroy the table, so refuse anything that isn't visibly scratch.
+    const databaseName = new URL(testDatabaseUrl as string).pathname.replace(/^\//, '');
+    if (!/(^|[-_])(test|modelflag|scratch|tmp)([-_]|$)/i.test(databaseName)) {
+      throw new Error(
+        `MODEL_FLAG_TEST_DATABASE_URL must name a throwaway database (got "${databaseName}"). ` +
+          'This suite drops and recreates "ModelFlag".'
+      );
+    }
+
     await client.connect();
     // Mirrors the live `ModelFlag` table, including `sfwOnly`, whose migration
     // (20250425225502_add_model_flag_sfw_only) had never been applied — the
@@ -182,6 +276,28 @@ describe.skipIf(!testDatabaseUrl)('buildModelFlagUpsert — execution (real Post
     const statement = buildModelFlagUpsert(args);
     return client.query(statement.text, statement.values as unknown[]);
   };
+
+  it('returns every column ModelFlagRow declares', async () => {
+    const { rows } = await run({ modelId: 99, scanResult: SCAN_RESULT, details: { a: 1 } });
+
+    // `$queryRaw`'s generic is an unchecked cast, so `ModelFlagRow` is only a
+    // claim until something compares it to a real row. This also pins
+    // `RETURNING *`: narrowing it drops keys the type promises callers.
+    expect(Object.keys(rows[0]).sort()).toEqual(
+      [
+        'modelId',
+        'poi',
+        'nsfw',
+        'minor',
+        'sfwOnly',
+        'triggerWords',
+        'poiName',
+        'status',
+        'details',
+        'createdAt',
+      ].sort()
+    );
+  });
 
   it('inserts a flag and returns the row', async () => {
     const { rows } = await run({ modelId: 101, scanResult: SCAN_RESULT, details: { a: 1 } });

--- a/src/server/services/__tests__/model-flag-upsert-sql.test.ts
+++ b/src/server/services/__tests__/model-flag-upsert-sql.test.ts
@@ -173,11 +173,19 @@ describe('buildModelFlagUpsert — structure', () => {
  * execution arm below never runs there and this is the guard that does.
  *
  * 🔴 What this does NOT cover, so nobody reads it as closing the class: these
- * cases read `statement.values` and are therefore blind to everything that
- * lives only in the statement TEXT — the column list's order (pinned by the
- * shape suite above instead), the conflict target, the table name, and
- * `DO UPDATE` vs `DO NOTHING`. Those are caught only by the execution arm,
- * i.e. not in CI. Do not treat a green always-on run as proof the statement is
+ * cases read `statement.values`, so anything living only in the statement TEXT
+ * has to be caught elsewhere. Measured over a 25-mutant battery, exactly three
+ * corruptions survive the whole always-on suite and are caught only by the
+ * execution arm — i.e. never in CI:
+ *
+ *   - the table name
+ *   - the ON CONFLICT target
+ *   - narrowing `RETURNING *`
+ *
+ * Everything else text-only IS covered without a database: the column list's
+ * order and contents (pinned by the shape suite above), `DO UPDATE` vs
+ * `DO NOTHING`, a commented-out SET clause, and all three original punctuation
+ * defects. Do not treat a green always-on run as proof the statement is
  * correct; run the execution arm when you change it.
  */
 describe('buildModelFlagUpsert — value binding', () => {
@@ -311,9 +319,10 @@ describe.skipIf(!testDatabaseUrl)('buildModelFlagUpsert — execution (real Post
 
     // Named for what it actually pins. This compares the returned keys against
     // a hand-written list, so it does NOT verify `ModelFlagRow` against the
-    // live schema — adding a field to either the type or the table leaves it
-    // green. What it does catch is `RETURNING *` being narrowed, which would
-    // drop keys the type promises callers.
+    // live schema — adding a field to the type, or to the live table without
+    // updating the fixture DDL above, leaves it green. (Adding one to that
+    // fixture DDL does turn it red.) What it does catch is `RETURNING *` being
+    // narrowed, which would drop keys the type promises callers.
     expect(Object.keys(rows[0]).sort()).toEqual(
       [
         'modelId',

--- a/src/server/services/__tests__/model-flag-upsert-sql.test.ts
+++ b/src/server/services/__tests__/model-flag-upsert-sql.test.ts
@@ -148,6 +148,18 @@ describe('buildModelFlagUpsert — structure', () => {
         count: 1,
       });
     }
+
+    // The conflict target itself, not just the keyword. Removing it
+    // (`ON CONFLICT DO UPDATE`) or widening it (`("modelId", "poi")`) both
+    // change which rows collide, and both otherwise pass this whole suite.
+    expect(parenGroupAfter(text, anchorOf(text, /\bON CONFLICT\b/))).toBe('"modelId"');
+
+    // The table being written to, and the promise to return the whole row.
+    // Both are contract-level and both were previously visible only to
+    // Postgres: a wrong table name is silent here, and narrowing `RETURNING *`
+    // drops columns `ModelFlagRow` tells callers they will get.
+    expect(text).toMatch(/INSERT\s+INTO\s+"ModelFlag"\s*\(/);
+    expect(text).toMatch(/RETURNING\s+\*/);
   });
 
   it('inserts exactly one value per column', () => {
@@ -180,9 +192,14 @@ describe('buildModelFlagUpsert — structure', () => {
   it('assigns every non-key column exactly once in DO UPDATE, with no empty slot', () => {
     const { text } = buildModelFlagUpsert({ modelId: 1, scanResult: SCAN_RESULT });
 
-    const doUpdate = anchorOf(text, /DO UPDATE\s+SET\s/);
+    // Advance past the matched keyword rather than re-searching for `SET `:
+    // a re-search finds nothing if the SQL is reformatted as `SET\n  "poi"`,
+    // and the slice then starts mid-keyword and fails with a message that
+    // points at the wrong thing.
+    const doUpdate = text.match(/DO UPDATE\s+SET\s/);
+    if (!doUpdate?.index) throw new Error(`generated SQL is missing DO UPDATE SET:\n${text}`);
     const setClause = text.slice(
-      doUpdate + text.slice(doUpdate).indexOf('SET ') + 'SET '.length,
+      doUpdate.index + doUpdate[0].length,
       anchorOf(text, /\bRETURNING\s/)
     );
     const assignments = splitTopLevel(setClause);
@@ -193,12 +210,18 @@ describe('buildModelFlagUpsert — structure', () => {
       expect(assignment).toMatch(/^"(\w+)" = EXCLUDED\."\1"$/);
     }
 
-    const assigned = assignments.map((a) => a.split('"')[1]);
-    const columns = splitTopLevel(parenGroupAfter(text, anchorOf(text, /INSERT INTO\s/))).map((c) =>
-      c.replaceAll('"', '')
+    const assigned = assignments.map((a) => a.split('"')[1]).sort();
+    const columns = splitTopLevel(parenGroupAfter(text, anchorOf(text, /INSERT\s+INTO\s/))).map(
+      (c) => c.replaceAll('"', '')
     );
     // Every column except the conflict target is refreshed on conflict.
-    expect(new Set(assigned)).toEqual(new Set(columns.filter((c) => c !== 'modelId')));
+    //
+    // Compared as SORTED ARRAYS, not Sets. A Set is duplicate-blind, so
+    // `SET "poi" = EXCLUDED."poi", "poi" = EXCLUDED."poi", …` passed this
+    // assertion while Postgres rejects it outright with
+    // `multiple assignments to same column "poi"` — a survivor that directly
+    // contradicted this test's own name.
+    expect(assigned).toEqual(columns.filter((c) => c !== 'modelId').sort());
   });
 
   it('writes SQL NULL — not a JSON object — when details are absent', () => {
@@ -222,24 +245,24 @@ describe('buildModelFlagUpsert — structure', () => {
  * runs with no database, which matters: CI provides no Postgres server, so the
  * execution arm below never runs there and this is the guard that does.
  *
- * 🔴 What this does NOT cover, so nobody reads it as closing the class: these
- * cases read `statement.values`, so anything living only in the statement TEXT
- * has to be caught elsewhere. Over the 31 mutants measured so far, three
- * corruptions survive the whole always-on suite and are caught only by the
- * execution arm — i.e. never in CI:
+ * 🔴 Read this before trusting a green run. These cases read
+ * `statement.values`, so anything living only in the statement TEXT has to be
+ * caught by the shape suite above instead. Between the two, 35 mutants have
+ * been measured and none currently survives without a database: the column
+ * list's order and contents, the table name, the ON CONFLICT target,
+ * `DO UPDATE` vs `DO NOTHING`, a duplicated SET assignment, a commented-out
+ * SET clause, a misspelled or doubled SQL keyword, a cast-name typo, a cast on
+ * the wrong slot, a narrowed `RETURNING *`, and all three original punctuation
+ * defects.
  *
- *   - the table name
- *   - the ON CONFLICT target column
- *   - narrowing `RETURNING *`
- *
- * The rest of the text-only space that battery covers IS caught without a
- * database: the column list's order and contents, `DO UPDATE` vs `DO NOTHING`,
- * a commented-out SET clause, a misspelled or doubled SQL keyword, a cast-name
- * typo, and all three original punctuation defects. That list is a measurement
- * over the mutants someone thought of, NOT a proof about the whole grammar —
- * two earlier rounds each found survivors the previous battery had missed. Do
- * not treat a green always-on run as proof the statement is correct; run the
- * execution arm when you change it.
+ * 🔴 That is a MEASUREMENT OVER THE MUTANTS SOMEONE THOUGHT OF, not a proof
+ * about the PostgreSQL grammar, and the difference has been load-bearing here:
+ * five review rounds ran, and EVERY ONE of them found a family the previous
+ * battery had missed — wrong binds, then a swallowed error, then helpers that
+ * failed open on a missing clause, then duplicate-blind Set comparison and
+ * casts checked anywhere rather than on their slot. Assume a sixth family
+ * exists. Do not treat a green always-on run as proof the statement is
+ * correct; run the execution arm when you change it.
  */
 describe('buildModelFlagUpsert — value binding', () => {
   // Measured against the built statement, not assumed. `Prisma.sql`NULL`` is
@@ -306,10 +329,18 @@ describe('buildModelFlagUpsert — value binding', () => {
       JSON.stringify({ verdict: 'x' }),
       true,
     ]);
+    // Casts are checked ON THEIR SLOT, not anywhere in the statement. A
+    // whole-text search only proves the cast EXISTS: move `::jsonb` onto the
+    // `sfwOnly` value and a bare-text match still passes, while Postgres says
+    // `column "sfwOnly" is of type boolean but expression is of type jsonb`.
+    const slots = splitTopLevel(parenGroupAfter(text, anchorOf(text, /\bVALUES\s*\(/)));
+
     // A `::text` cast would store the payload as a string, not queryable jsonb.
-    expect(text).toMatch(/::jsonb\b/);
+    expect(slots[7]).toMatch(/::jsonb$/);
     // New flags must land Pending or they never reach the moderator queue.
-    expect(text).toMatch(/::"ModelFlagStatus"(?!\w)/);
+    expect(slots[6]).toMatch(/::"ModelFlagStatus"$/);
+    // …and no other slot carries a cast that would retype a boolean column.
+    expect(slots.filter((slot) => slot.includes('::'))).toHaveLength(2);
   });
 });
 

--- a/src/server/services/__tests__/model-flag-upsert-sql.test.ts
+++ b/src/server/services/__tests__/model-flag-upsert-sql.test.ts
@@ -108,8 +108,22 @@ describe('buildModelFlagUpsert — structure', () => {
     const values = splitTopLevel(parenGroupAfter(text, text.indexOf('VALUES')));
 
     // Pinned literally rather than derived from `columns.length`, so a column
-    // silently dropped from BOTH lists still fails here.
-    expect(columns).toHaveLength(9);
+    // silently dropped from BOTH lists still fails here. The order is pinned
+    // too: the value-binding suite below reads `statement.values`, which is
+    // blind to a swap in the COLUMN list — reorder `"minor"` and
+    // `"triggerWords"` here with the values untouched and the minor flag is
+    // written into `triggerWords`, which only Postgres would otherwise catch.
+    expect(columns).toEqual([
+      '"modelId"',
+      '"poi"',
+      '"nsfw"',
+      '"minor"',
+      '"triggerWords"',
+      '"poiName"',
+      '"status"',
+      '"details"',
+      '"sfwOnly"',
+    ]);
     expect(values).toHaveLength(9);
     expect(values.every((value) => value.length > 0)).toBe(true);
   });
@@ -149,7 +163,7 @@ describe('buildModelFlagUpsert — structure', () => {
 
 /**
  * The assertions above constrain the statement's SHAPE. Shape cannot see a
- * wrong BIND: swap two columns in the VALUES list, or point the `sfwOnly` slot
+ * wrong BIND: swap two entries in the VALUES list, or point the `sfwOnly` slot
  * at `poi`, and every arity and assignment check above still passes. Booleans
  * cannot be told apart by value, so they are told apart by POSITION.
  *
@@ -157,6 +171,14 @@ describe('buildModelFlagUpsert — structure', () => {
  * swap, stale bind or defaulted flag lands a `true` in the wrong slot. This
  * runs with no database, which matters: CI provides no Postgres server, so the
  * execution arm below never runs there and this is the guard that does.
+ *
+ * 🔴 What this does NOT cover, so nobody reads it as closing the class: these
+ * cases read `statement.values` and are therefore blind to everything that
+ * lives only in the statement TEXT — the column list's order (pinned by the
+ * shape suite above instead), the conflict target, the table name, and
+ * `DO UPDATE` vs `DO NOTHING`. Those are caught only by the execution arm,
+ * i.e. not in CI. Do not treat a green always-on run as proof the statement is
+ * correct; run the execution arm when you change it.
  */
 describe('buildModelFlagUpsert — value binding', () => {
   // Measured against the built statement, not assumed. `Prisma.sql`NULL`` is
@@ -237,8 +259,15 @@ describe.skipIf(!testDatabaseUrl)('buildModelFlagUpsert — execution (real Post
     // This suite DROPs "ModelFlag". The env-var isolation above stops it
     // pointing at a real environment by default, but a mis-set variable would
     // still destroy the table, so refuse anything that isn't visibly scratch.
-    const databaseName = new URL(testDatabaseUrl as string).pathname.replace(/^\//, '');
-    if (!/(^|[-_])(test|modelflag|scratch|tmp)([-_]|$)/i.test(databaseName)) {
+    //
+    // 🔴 Read the name off the CLIENT, not off `new URL(...).pathname`. They
+    // disagree: `pg-connection-string` resolves `socket:/tmp?db=civitai` to
+    // database `civitai`, whose pathname is `tmp` — so a pathname check
+    // ACCEPTS a URL that connects to production, and rejects the legitimate
+    // `socket:/var/run/postgresql?db=modelflag_test`. `client.database` is
+    // populated at construction, before `connect()`, and is what pg will use.
+    const databaseName = client.database;
+    if (!databaseName || !/(^|[-_])(test|modelflag|scratch|tmp)([-_]|$)/i.test(databaseName)) {
       throw new Error(
         `MODEL_FLAG_TEST_DATABASE_URL must name a throwaway database (got "${databaseName}"). ` +
           'This suite drops and recreates "ModelFlag".'
@@ -277,12 +306,14 @@ describe.skipIf(!testDatabaseUrl)('buildModelFlagUpsert — execution (real Post
     return client.query(statement.text, statement.values as unknown[]);
   };
 
-  it('returns every column ModelFlagRow declares', async () => {
+  it('returns the whole row, so RETURNING * cannot be narrowed', async () => {
     const { rows } = await run({ modelId: 99, scanResult: SCAN_RESULT, details: { a: 1 } });
 
-    // `$queryRaw`'s generic is an unchecked cast, so `ModelFlagRow` is only a
-    // claim until something compares it to a real row. This also pins
-    // `RETURNING *`: narrowing it drops keys the type promises callers.
+    // Named for what it actually pins. This compares the returned keys against
+    // a hand-written list, so it does NOT verify `ModelFlagRow` against the
+    // live schema — adding a field to either the type or the table leaves it
+    // green. What it does catch is `RETURNING *` being narrowed, which would
+    // drop keys the type promises callers.
     expect(Object.keys(rows[0]).sort()).toEqual(
       [
         'modelId',

--- a/src/server/services/__tests__/upsert-model-flag.service.test.ts
+++ b/src/server/services/__tests__/upsert-model-flag.service.test.ts
@@ -77,6 +77,20 @@ describe('upsertModelFlag', () => {
     expect(result).toBeNull();
   });
 
+  it('lets a database error propagate instead of swallowing it', async () => {
+    const { upsertModelFlag } = await import('~/server/services/model-flag.service');
+    mockQueryRaw.mockRejectedValue(new Error('relation "ModelFlag" does not exist'));
+
+    // This whole incident was a statement that threw on every call while the
+    // caller's `.catch(...)` hid it, so nothing recorded anything for 15.5
+    // months and nobody saw an error. A `.catch(() => [null])` added here
+    // would recreate that silence one layer lower — and it is the one mutant
+    // that survives both the statement suite and the rest of this file.
+    await expect(upsertModelFlag({ modelId: 7, scanResult: FLAGGED })).rejects.toThrow(
+      'relation "ModelFlag" does not exist'
+    );
+  });
+
   it('forwards modelId, every flag and details through to the statement', async () => {
     const { upsertModelFlag } = await import('~/server/services/model-flag.service');
 

--- a/src/server/services/__tests__/upsert-model-flag.service.test.ts
+++ b/src/server/services/__tests__/upsert-model-flag.service.test.ts
@@ -18,6 +18,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const { mockQueryRaw } = vi.hoisted(() => ({ mockQueryRaw: vi.fn() }));
 
 // `model-flag.service` imports only `dbRead`/`dbWrite` from this module.
+//
+// This is a partial factory for a module that also does `export * from
+// '@civitai/db/client'`, i.e. the shape that goes stale when the service
+// starts importing something else from it. 🔴 The `await import(...)` inside
+// each test below is load-bearing, not style: importing the service at module
+// scope would let that staleness surface as a collection failure (0 tests,
+// which reads as "nothing to see"). Importing inside the test body makes it
+// fail loudly instead — verified by adding an unmocked export to the service's
+// import graph and watching all four tests fail rather than vanish.
 vi.mock('~/server/db/client', () => ({
   dbRead: {},
   dbWrite: { $queryRaw: mockQueryRaw },

--- a/src/server/services/__tests__/upsert-model-flag.service.test.ts
+++ b/src/server/services/__tests__/upsert-model-flag.service.test.ts
@@ -89,6 +89,9 @@ describe('upsertModelFlag', () => {
     await expect(upsertModelFlag({ modelId: 7, scanResult: FLAGGED })).rejects.toThrow(
       'relation "ModelFlag" does not exist'
     );
+    // Without this the test also passes if the service threw that same message
+    // BEFORE reaching the query — a different bug wearing the same error.
+    expect(mockQueryRaw).toHaveBeenCalledTimes(1);
   });
 
   it('forwards modelId, every flag and details through to the statement', async () => {

--- a/src/server/services/__tests__/upsert-model-flag.service.test.ts
+++ b/src/server/services/__tests__/upsert-model-flag.service.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Seam test for `upsertModelFlag`.
+ *
+ * `model-flag-upsert-sql.test.ts` proves the STATEMENT. It cannot prove that
+ * the caller reaches the statement, or hands it the right arguments — and that
+ * is the half where the production symptom lives. Mutating the guard below to
+ * `if (isFlagged) return null` silently recreates the exact outage this code
+ * was fixed for (nothing is ever recorded) while every statement-level test
+ * stays green. So the guard is asserted in BOTH directions, by observing
+ * whether a query is issued at all.
+ *
+ * `buildModelFlagUpsert` is deliberately NOT mocked: the point is to read the
+ * arguments as they actually arrive at the database call.
+ */
+
+const { mockQueryRaw } = vi.hoisted(() => ({ mockQueryRaw: vi.fn() }));
+
+// `model-flag.service` imports only `dbRead`/`dbWrite` from this module.
+vi.mock('~/server/db/client', () => ({
+  dbRead: {},
+  dbWrite: { $queryRaw: mockQueryRaw },
+}));
+
+const FLAGGED = {
+  poi: false,
+  nsfw: true,
+  minor: false,
+  triggerWords: false,
+  poiName: false,
+  sfwOnly: false,
+};
+const NOTHING_FLAGGED = { ...FLAGGED, nsfw: false };
+
+describe('upsertModelFlag', () => {
+  beforeEach(() => {
+    mockQueryRaw.mockReset();
+    mockQueryRaw.mockResolvedValue([{ modelId: 7 }]);
+  });
+
+  it('issues the upsert and returns the row when a flag is set', async () => {
+    const { upsertModelFlag } = await import('~/server/services/model-flag.service');
+
+    const result = await upsertModelFlag({ modelId: 7, scanResult: FLAGGED });
+
+    expect(mockQueryRaw).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ modelId: 7 });
+  });
+
+  it('issues NO query and returns null when nothing is flagged', async () => {
+    const { upsertModelFlag } = await import('~/server/services/model-flag.service');
+
+    const result = await upsertModelFlag({ modelId: 7, scanResult: NOTHING_FLAGGED });
+
+    // The other half of the guard. Asserting only the flagged case above would
+    // leave an inverted condition passing.
+    expect(mockQueryRaw).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  it('issues NO query when there is no scan result at all', async () => {
+    const { upsertModelFlag } = await import('~/server/services/model-flag.service');
+
+    const result = await upsertModelFlag({ modelId: 7 });
+
+    expect(mockQueryRaw).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  it('forwards modelId, every flag and details through to the statement', async () => {
+    const { upsertModelFlag } = await import('~/server/services/model-flag.service');
+
+    await upsertModelFlag({
+      modelId: 7,
+      scanResult: { ...FLAGGED, minor: true },
+      details: { verdict: 'x' },
+    });
+
+    // Reading the bound values proves the arguments survived the call, which a
+    // "was it called" assertion cannot: dropping `details` or `scanResult` on
+    // the way through still calls the query exactly once.
+    const [statement] = mockQueryRaw.mock.calls[0];
+    expect(statement.values).toEqual([
+      7,
+      false,
+      true,
+      true,
+      false,
+      false,
+      'Pending',
+      JSON.stringify({ verdict: 'x' }),
+      false,
+    ]);
+  });
+});

--- a/src/server/services/model-flag.service.ts
+++ b/src/server/services/model-flag.service.ts
@@ -1,9 +1,10 @@
-import { Prisma } from '@prisma/client';
 import { ModelFlagStatus } from '~/shared/utils/prisma/enums';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
 import type { GetByIdsInput } from '~/server/schema/base.schema';
 import type { GetFlaggedModelsInput, ModelScanResult } from '~/server/schema/model-flag.schema';
+import type { ModelFlagRow, ModelFlagScanResult } from '~/server/services/model-flag.sql';
+import { buildModelFlagUpsert } from '~/server/services/model-flag.sql';
 import { trackModActivity } from '~/server/services/moderator.service';
 import { getPagedData } from '~/server/utils/pagination-helpers';
 
@@ -14,54 +15,15 @@ export async function upsertModelFlag({
 }: {
   modelId: number;
   poiName?: string;
-  scanResult?: {
-    poi: boolean;
-    nsfw: boolean;
-    minor: boolean;
-    triggerWords: boolean;
-    poiName: boolean;
-    sfwOnly?: boolean;
-  };
+  scanResult?: ModelFlagScanResult;
   details?: MixedObject;
 }) {
   const isFlagged = scanResult && Object.values(scanResult).some((flag) => flag);
   if (!isFlagged) return null;
 
-  const [modelFlag] = await dbWrite.$queryRaw<
-    {
-      modelId: number;
-      poi: boolean;
-      nsfw: boolean;
-      minor: boolean;
-      sfwOnly: boolean;
-      triggerWords: boolean;
-      poiName: string | null;
-      status: ModelFlagStatus;
-    }[]
-  >`
-    INSERT INTO "ModelFlag" ("modelId", "poi", "nsfw", "minor", "triggerWords", "poiName", "status", "details", "sfwOnly")
-    VALUES (
-      ${modelId},
-      ${scanResult?.poi ?? false},
-      ${scanResult?.nsfw ?? false},
-      ${scanResult?.minor ?? false},
-      ${scanResult?.triggerWords ?? false},
-      ${scanResult?.poiName ?? false},
-      ${Prisma.sql`${ModelFlagStatus.Pending}::"ModelFlagStatus"`},
-      ${details ? Prisma.sql`${JSON.stringify(details)}::jsonb` : Prisma.JsonNull}
-      ${scanResult?.sfwOnly ?? false}
-    )
-    ON CONFLICT ("modelId") DO UPDATE
-      SET "poi" = EXCLUDED."poi",
-        "nsfw" = EXCLUDED."nsfw",
-        "minor" = EXCLUDED."minor",
-        "triggerWords" = EXCLUDED."triggerWords",
-        "poiName" = EXCLUDED."poiName",
-        "status" = EXCLUDED."status",
-        "details" = EXCLUDED."details"
-        "sfwOnly" = EXCLUDED."sfwOnly",
-    RETURNING *;
-  `;
+  const [modelFlag] = await dbWrite.$queryRaw<ModelFlagRow[]>(
+    buildModelFlagUpsert({ modelId, scanResult, details })
+  );
 
   return modelFlag;
 }

--- a/src/server/services/model-flag.service.ts
+++ b/src/server/services/model-flag.service.ts
@@ -14,7 +14,6 @@ export async function upsertModelFlag({
   details,
 }: {
   modelId: number;
-  poiName?: string;
   scanResult?: ModelFlagScanResult;
   details?: MixedObject;
 }) {

--- a/src/server/services/model-flag.sql.ts
+++ b/src/server/services/model-flag.sql.ts
@@ -1,0 +1,82 @@
+import { Prisma } from '@prisma/client';
+import { ModelFlagStatus } from '~/shared/utils/prisma/enums';
+
+/**
+ * The `ModelFlag` upsert statement, isolated from `model-flag.service`.
+ *
+ * WHY ITS OWN MODULE: so a test can build and execute this statement without
+ * importing the service, which pulls in the Prisma client, Axiom logging and
+ * the search index at module scope. Extracting the helper is the repo's
+ * preferred fix over widening a module mock.
+ *
+ * WHY IT IS TESTED AT ALL: this statement shipped broken for 15.5 months with
+ * three separate punctuation defects, each masking the next, and no test in
+ * the suite ever noticed — a raw SQL string is opaque to every mock, so
+ * nothing parsed it. See `__tests__/model-flag-upsert-sql.test.ts`.
+ */
+
+export type ModelFlagScanResult = {
+  poi: boolean;
+  nsfw: boolean;
+  minor: boolean;
+  triggerWords: boolean;
+  poiName: boolean;
+  sfwOnly?: boolean;
+};
+
+export type ModelFlagRow = {
+  modelId: number;
+  poi: boolean;
+  nsfw: boolean;
+  minor: boolean;
+  sfwOnly: boolean;
+  triggerWords: boolean;
+  // `ModelFlag."poiName"` is a NOT NULL boolean column, not a name string.
+  // `$queryRaw`'s generic is an unchecked cast, so the previous
+  // `string | null` was silently lying to callers about the row shape.
+  poiName: boolean;
+  status: ModelFlagStatus;
+};
+
+/**
+ * `details` absent must write a real SQL `NULL`.
+ *
+ * `Prisma.JsonNull` is a *value* sentinel for the Prisma query engine's typed
+ * JSON inputs; interpolated into a `$queryRaw` template it is serialized as a
+ * bound parameter and lands as the JSON object `{}`, not `NULL`. `Prisma.sql`
+ * emits the literal into the statement instead.
+ */
+export function buildModelFlagUpsert({
+  modelId,
+  scanResult,
+  details,
+}: {
+  modelId: number;
+  scanResult?: ModelFlagScanResult;
+  details?: MixedObject;
+}): Prisma.Sql {
+  return Prisma.sql`
+    INSERT INTO "ModelFlag" ("modelId", "poi", "nsfw", "minor", "triggerWords", "poiName", "status", "details", "sfwOnly")
+    VALUES (
+      ${modelId},
+      ${scanResult?.poi ?? false},
+      ${scanResult?.nsfw ?? false},
+      ${scanResult?.minor ?? false},
+      ${scanResult?.triggerWords ?? false},
+      ${scanResult?.poiName ?? false},
+      ${Prisma.sql`${ModelFlagStatus.Pending}::"ModelFlagStatus"`},
+      ${details ? Prisma.sql`${JSON.stringify(details)}::jsonb` : Prisma.sql`NULL`},
+      ${scanResult?.sfwOnly ?? false}
+    )
+    ON CONFLICT ("modelId") DO UPDATE
+      SET "poi" = EXCLUDED."poi",
+        "nsfw" = EXCLUDED."nsfw",
+        "minor" = EXCLUDED."minor",
+        "triggerWords" = EXCLUDED."triggerWords",
+        "poiName" = EXCLUDED."poiName",
+        "status" = EXCLUDED."status",
+        "details" = EXCLUDED."details",
+        "sfwOnly" = EXCLUDED."sfwOnly"
+    RETURNING *;
+  `;
+}

--- a/src/server/services/model-flag.sql.ts
+++ b/src/server/services/model-flag.sql.ts
@@ -37,8 +37,9 @@ export type ModelFlagRow = {
   poiName: boolean;
   status: ModelFlagStatus;
   // `RETURNING *` returns these too; naming them keeps the type an honest
-  // description of the row rather than a partial one.
-  details: unknown;
+  // description of the row rather than a partial one. `details` matches the
+  // canonical `ModelFlag` interface rather than widening to `unknown`.
+  details: Prisma.JsonValue | null;
   createdAt: Date;
 };
 

--- a/src/server/services/model-flag.sql.ts
+++ b/src/server/services/model-flag.sql.ts
@@ -36,6 +36,10 @@ export type ModelFlagRow = {
   // `string | null` was silently lying to callers about the row shape.
   poiName: boolean;
   status: ModelFlagStatus;
+  // `RETURNING *` returns these too; naming them keeps the type an honest
+  // description of the row rather than a partial one.
+  details: unknown;
+  createdAt: Date;
 };
 
 /**


### PR DESCRIPTION
## What

`upsertModelFlag` builds its `ModelFlag` upsert as a raw SQL string. That string has never been able to execute. It carries three punctuation defects, each of which masks the next, plus a `Prisma.JsonNull` that does not mean what it looks like:

| # | Defect | What Postgres says |
|---|---|---|
| 1 | no comma between the `details` and `sfwOnly` values | `syntax error at or near "$9"` |
| 2 | no comma between `"details" = EXCLUDED."details"` and `"sfwOnly" = …` | `syntax error at or near ""sfwOnly""` |
| 3 | trailing comma before `RETURNING` | `syntax error at or near "RETURNING"` |
| 4 | `Prisma.JsonNull` interpolated into `$queryRaw` | stored as `{}`, not `NULL` |

(1)–(3) are fixed punctuation. (4) becomes `Prisma.sql\`NULL\``: `Prisma.JsonNull` is a value sentinel for the Prisma query engine's typed JSON inputs — interpolated into a `$queryRaw` template it is sent as a bound parameter and lands as an empty JSON object. `{}` in `details` reads as "scanned, no findings" rather than "no details recorded", which is the more damaging of the two.

The statement is reachable from the model-scan-result webhook, and it throws on every call. **No model content flag — POI, NSFW, minor, trigger words, POI-name — has been recorded since 2025-04-28.**

There is also a fifth problem this PR does not fix in code, because it is not code: the column `ModelFlag."sfwOnly"` did not exist. Migration `20250425225502_add_model_flag_sfw_only` was committed but never applied, while its sibling `20250425193919_add_model_sfw_only` was. **The column has since been added by hand to the relevant environments**, so this branch's SQL has a table to run against. Migrations here are applied manually per environment, so nothing in this PR applies it.

## Why nothing caught it

A raw SQL string is opaque to every mock in the suite. Nothing ever parsed it, so no unit test could have failed — the defect is invisible by construction, not by oversight. Reading the source finds (1)–(3) if you are looking; nothing but execution finds (4) or the missing column.

So the fix is only half the change. The other half is making the statement executable by a test at all:

- `buildModelFlagUpsert` is extracted to `model-flag.sql.ts`, its own module, so a test can build and run the statement without importing the service (which pulls in the Prisma client, Axiom logging and the search index at module scope). Extracting the helper is this repo's documented preference over widening a module mock.
- `model-flag-upsert-sql.test.ts` has two arms:
  - **structure** — always runs. Re-derives the statement's shape from the generated text: arity of the VALUES list against the column list, and the DO UPDATE assignments. It is a backstop that knows the shapes that broke us, not a PostgreSQL grammar.
  - **execution** — the real proof, opt-in via `MODEL_FLAG_TEST_DATABASE_URL` because it needs a server. Creates the table, runs the statement, exercises the `ON CONFLICT` path, and asserts `details IS NULL` when details are absent. It points at its own variable and deliberately does not fall back to `DATABASE_URL`, matching `kysely-prisma-parity.test.ts`.

## Verification

Both arms were run against a real PostgreSQL 17. **7 passed** with a database, **4 passed / 3 skipped** without — so the execution arm demonstrably ran rather than silently skipping.

Each defect was then reintroduced one at a time and the suite watched to fail:

| Mutation | Killed by | Postgres error |
|---|---|---|
| drop the VALUES comma | `inserts exactly one value per column` | `syntax error at or near "$9"` |
| drop the DO UPDATE comma | `assigns every non-key column exactly once…` | `syntax error at or near ""sfwOnly""` |
| trailing comma before RETURNING | `assigns every non-key column exactly once…` | `syntax error at or near "RETURNING"` |
| restore `Prisma.JsonNull` | `writes SQL NULL — not a JSON object…` | — (row stored `{}`) |

Each mutant dies to its **own** guard, and all four are also caught by the always-on `structure` arm with no database present — so CI is protected, not just the opt-in path.

Related: `poiName` in the `$queryRaw` return type said `string | null`; the column is a `NOT NULL boolean`. `$queryRaw`'s generic is an unchecked cast, so that was silently lying about the row shape. The only caller discards the return value, so this is type-only.

`pnpm typecheck` and the related existing suites (`model-flag-side-effects`, `set-model-minor`, `minor-flag-notification`) are unchanged by this branch.

## Scope

**This PR does not restore flagging on its own.** The upstream model-scan pipeline stopped independently in April 2026 and is a separate, non-code problem being tracked elsewhere; until it resumes, this statement is correct but unexercised in production. It is worth landing now so the defect is not re-derived from scratch later, and so the moderator queue's write path is sound when scanning returns.
