### PR TITLE
fix(apps): user-menu Apps entry follows store visibility, not appBlocks

### DIFF
--- a/src/components/AppLayout/AppHeader/appsNavVisibility.test.ts
+++ b/src/components/AppLayout/AppHeader/appsNavVisibility.test.ts
@@ -3,17 +3,22 @@ import { appsNavVisibility } from '~/components/AppLayout/AppHeader/appsNavVisib
 
 // Scope-A invariant: the PUBLIC "Build apps" → /apps/get-started nav entry is
 // visible whenever the public `appBlocksGetStarted` flag is on, INDEPENDENTLY of
-// the mod-only `appBlocks` flag; the "Apps Marketplace" → /apps entry stays gated
-// on `appBlocks` (mod-only) and never leaks to non-mods just because the public
-// get-started flag is on.
-describe('appsNavVisibility — public get-started vs mod-only marketplace', () => {
+// the store flags.
+//
+// #3907 invariant: the "Apps" → /apps entry is visible exactly when the STORE is
+// visible (`hasAppsStoreAccess` = appListings || appBlocks ||
+// appListingsPublicExternal). It is the ONLY in-product route to `/apps`, so a
+// cohort that can load the store but not see this entry has a store it cannot
+// find. It used to read `appBlocks` alone.
+describe('appsNavVisibility — public get-started vs store-gated marketplace', () => {
   it('shows the public get-started entry when appBlocksGetStarted is on', () => {
     const nav = appsNavVisibility({ appBlocksGetStarted: true, appBlocks: false });
     expect(nav.getStarted).toBe(true);
   });
 
-  it('keeps the marketplace entry mod-gated even when the public flag is on', () => {
-    // A non-mod (appBlocks off) with the public flag on sees ONLY get-started.
+  it('keeps the marketplace entry hidden for a viewer with NO store flag', () => {
+    // The public get-started flag alone grants no store access, so the entry that
+    // links to the store stays hidden.
     const nav = appsNavVisibility({ appBlocksGetStarted: true, appBlocks: false });
     expect(nav.getStarted).toBe(true);
     expect(nav.marketplace).toBe(false);
@@ -42,5 +47,64 @@ describe('appsNavVisibility — public get-started vs mod-only marketplace', () 
     const nav = appsNavVisibility({});
     expect(nav.getStarted).toBe(false);
     expect(nav.marketplace).toBe(false);
+  });
+
+  /**
+   * 🔴 THE THREE CASES THAT KILL A REVERT TO `!!features.appBlocks`.
+   *
+   * Each is a cohort that HAS store access without `appBlocks`. Under the old
+   * gate every one of them resolved `marketplace: false` — a store rendered by
+   * the SSR resolver with no in-product link to it. These are not hypothetical
+   * shapes: the external-only one is the live tester cohort as of 2026-08-14
+   * (Flipt `app-listings-public-external`, base off, rollout `[testers]`), and
+   * the catalog-only one is the documented shape of the public store launch.
+   */
+  describe('🔴 #3907 — the entry follows STORE visibility, not the block runtime', () => {
+    it('EXTERNAL-ONLY cohort (appListingsPublicExternal alone) sees the entry', () => {
+      const nav = appsNavVisibility({
+        appBlocksGetStarted: true,
+        appBlocks: false,
+        appListings: false,
+        appListingsPublicExternal: true,
+      });
+      expect(nav.marketplace).toBe(true);
+    });
+
+    it('CATALOG-ONLY cohort (appListings alone) sees the entry', () => {
+      const nav = appsNavVisibility({
+        appBlocksGetStarted: false,
+        appBlocks: false,
+        appListings: true,
+      });
+      expect(nav.marketplace).toBe(true);
+      // …and the get-started kill switch still governs its own entry.
+      expect(nav.getStarted).toBe(false);
+    });
+
+    it('a viewer with EVERY store flag off does not see it (the gate is not `true`)', () => {
+      // The negative control for the two above: without it, a mutation that made
+      // `marketplace` unconditionally true would pass both.
+      const nav = appsNavVisibility({
+        appBlocksGetStarted: true,
+        appBlocks: false,
+        appListings: false,
+        appListingsPublicExternal: false,
+      });
+      expect(nav.marketplace).toBe(false);
+    });
+  });
+
+  /**
+   * The entry widens DISCOVERY, not capability: it is a link, and every surface
+   * behind `/apps` keeps its own gate. Pinned as a relationship so the two
+   * cannot silently converge — the block-RUNTIME flag is not consulted for the
+   * catalog-only cohort, and the catalog flags are not consulted by the runtime
+   * surfaces (which live in their own modules and gate on `appBlocks` alone).
+   */
+  it('the marketplace entry is decided WITHOUT requiring the block runtime', () => {
+    const catalogOnly = appsNavVisibility({ appListings: true, appBlocks: false });
+    const runtimeOnly = appsNavVisibility({ appListings: false, appBlocks: true });
+    expect(catalogOnly.marketplace).toBe(true);
+    expect(runtimeOnly.marketplace).toBe(true);
   });
 });

--- a/src/components/AppLayout/AppHeader/appsNavVisibility.ts
+++ b/src/components/AppLayout/AppHeader/appsNavVisibility.ts
@@ -1,3 +1,6 @@
+import type { AppsStoreFeatureFlags } from '~/shared/utils/app-blocks-access';
+import { hasAppsStoreAccess } from '~/shared/utils/app-blocks-access';
+
 /**
  * Pure visibility logic for the two App Blocks nav entries in the user menu.
  *
@@ -7,24 +10,55 @@
  *  - the PUBLIC "Build apps" → `/apps/get-started` entry is visible whenever the
  *    public `appBlocksGetStarted` flag is on (everyone by default; Flipt kill
  *    switch);
- *  - the mod-only "Apps Marketplace" → `/apps` entry stays gated on `appBlocks`
- *    (mod-only today) — its visibility is INDEPENDENT of the get-started flag.
+ *  - the "Apps" → `/apps` entry is visible exactly when the STORE is visible —
+ *    {@link hasAppsStoreAccess}, i.e. `appListings || appBlocks ||
+ *    appListingsPublicExternal`. Its visibility is INDEPENDENT of the
+ *    get-started flag.
+ *
+ * 🔴 THE MARKETPLACE ENTRY USED TO READ `appBlocks` ALONE, and that is what
+ * issue #3907 was. Until the W13 decoupling, `appBlocks` WAS store visibility,
+ * so gating the menu item on it was correct. Afterwards the store grants on
+ * `appListings || appBlocks || appListingsPublicExternal` while this entry —
+ * the ONLY in-product route to `/apps` (the `/apps/*` sub-nav's Marketplace tab
+ * renders only once you are already on an `/apps/*` route) — still read
+ * `appBlocks`. So the external-only tester cohort
+ * (`{appListingsPublicExternal, NOT appBlocks, NOT appListings}`, created
+ * 2026-08-14) could load a store it had no way to FIND: reachable by direct URL
+ * only. Reachable is not findable.
+ *
+ * A viewer admitted by the catalog flags alone lands on a page that renders
+ * fine — the store, scoped server-side to whatever catalog they may see (the
+ * external-only cohort gets `kind='offsite'` listings and nothing else). The
+ * block-RUNTIME surfaces behind it (`/apps/installed`, `/apps/run/<slug>`, …)
+ * keep their own `appBlocks` gates, so showing this entry widens discovery, not
+ * capability.
+ *
+ * 🔴 Do NOT re-inline the boolean here. This is the SEVENTH site routed through
+ * the shared predicate and it is pinned by the call-site ledger
+ * (`components/Apps/__tests__/appsStoreAccessCallSites.test.ts`) — a revert to
+ * `!!features.appBlocks` fails that suite AND the external-only case in
+ * `appsNavVisibility.test.ts`.
  *
  * This file imports no React/Mantine so it stays a pure unit.
  */
 export type AppsNavVisibility = {
   /** PUBLIC get-started landing page (`/apps/get-started`). */
   getStarted: boolean;
-  /** Mod-only marketplace hub (`/apps`). */
+  /** Store hub (`/apps`) — visible exactly when the store is. */
   marketplace: boolean;
 };
 
-export function appsNavVisibility(features: {
-  appBlocksGetStarted?: boolean;
-  appBlocks?: boolean;
-}): AppsNavVisibility {
+/**
+ * The store half of the parameter is `AppsStoreFeatureFlags`, which is DERIVED
+ * from `FeatureAccess` rather than hand-written — deliberately, so a rename of
+ * `appListings` upstream is a compile error here instead of a silent
+ * degradation to `appBlocks`-only. See that type's doc.
+ */
+export function appsNavVisibility(
+  features: { appBlocksGetStarted?: boolean } & NonNullable<AppsStoreFeatureFlags>
+): AppsNavVisibility {
   return {
     getStarted: !!features.appBlocksGetStarted,
-    marketplace: !!features.appBlocks,
+    marketplace: hasAppsStoreAccess(features),
   };
 }

--- a/src/components/AppLayout/AppHeader/hooks.tsx
+++ b/src/components/AppLayout/AppHeader/hooks.tsx
@@ -195,10 +195,13 @@ export function useGetMenuItems(): UserMenuItemGroup[] {
           newUntil: new Date('2026-08-01'),
         },
         {
-          // Mod-only App Blocks marketplace + in-page AppsSubNav hub (installed,
-          // submit, my-submissions, revenue, review). Stays gated on `appBlocks`
-          // (mod-only today). Labeled "Apps" so it reads distinctly from the
-          // public "Build apps" entry above.
+          // App store + in-page AppsSubNav hub (installed, submit,
+          // my-submissions, revenue, review). Visible exactly when the STORE is
+          // — `hasAppsStoreAccess`, via `appsNavVisibility` (#3907): this is the
+          // only in-product route to `/apps`, so gating it on `appBlocks` alone
+          // hid the store from the catalog-only and external-only cohorts. The
+          // sub-nav entries behind it keep their own gates. Labeled "Apps" so it
+          // reads distinctly from the public "Build apps" entry above.
           href: '/apps',
           visible: appsNav.marketplace,
           icon: IconPlugConnected,

--- a/src/components/Apps/__tests__/appsStoreAccessCallSites.test.ts
+++ b/src/components/Apps/__tests__/appsStoreAccessCallSites.test.ts
@@ -28,17 +28,26 @@ import { describe, it, expect } from 'vitest';
  *   - `AppListingsMarketplaceBody.storeGate.browser.test.tsx` — the grid query gate
  *   - `hasAppsStoreAccess.test.ts`                 — the predicate + the SSR seam
  *
- * THREE of the six sites are pinned STRUCTURALLY ONLY — `pages/apps/index.tsx`
+ * THREE of the seven sites are pinned STRUCTURALLY ONLY — `pages/apps/index.tsx`
  * and `pages/apps/store-preview/[slug].tsx` (Next pages, no component harness) and
  * `components/Apps/RelatedListings.tsx` (its only existing test covers the pure
  * selection helper and never mounts the component, so it never touches
  * `useFeatureFlags` / `canSeeStore`). Those three are covered against REVERSION,
- * not against a wrong-argument call. Stated rather than implied.
+ * not against a wrong-argument call. Stated rather than implied. The seventh —
+ * `appsNavVisibility.ts` — has behavioural cover in the same unit project
+ * (`AppHeader/appsNavVisibility.test.ts`, which asserts the external-only and
+ * catalog-only cohorts resolve `marketplace: true`), so its own argument IS
+ * checked. What no test covers, there or here: that `useGetMenuItems` hands it
+ * the real `useFeatureFlags()` object and wires `appsNav.marketplace` to the
+ * right menu item. That seam is untested for BOTH nav entries and predates this
+ * ledger — do not read the behavioural cover as reaching it.
  *
  * 🔴 AND THE SCOPE THAT MATTERS IN CI: the component suites above are REPORT-ONLY
  * (`preview / component-tests`) and do not block a merge. This unit-project ledger
- * does. So in CI all six sites are pinned STRUCTURALLY ONLY, by this file — which
- * is precisely why a hole in its masker (see below) is worth more than it looks.
+ * does. So in CI six of the seven sites are pinned STRUCTURALLY ONLY, by this file
+ * — which is precisely why a hole in its masker (see below) is worth more than it
+ * looks. (`appsNavVisibility` is the exception: its behavioural test is a unit
+ * test, so it blocks too.)
  *
  * 🔴 TWO MEASURED LIMITS OF THIS FILE — issue #3932, not fixed here. Read them
  * before treating a green run as "no site re-inlines the gate":
@@ -69,30 +78,24 @@ const SRC = path.resolve(__dirname, '../../..');
  *    `appBlocks` ALONE because they need the runtime, not just the catalog.
  *    Sweeping them in here would be a silent access widening.
  *
- * 2. 🔴 `components/AppLayout/AppHeader/appsNavVisibility.ts` — `marketplace:
- *    !!features.appBlocks`, which drives the user-menu "Apps" → `/apps` entry.
- *    That IS a store-visibility decision and it is NOT converted, deliberately:
- *    that module's own doc comment states the entry "stays gated on `appBlocks`",
- *    so it is a standing decision, not drift. It is also outside `SCAN_ROOTS`
- *    (`components/AppLayout`), so grow-detection below is STRUCTURALLY BLIND to
- *    it — do not read the ledger's exactness as covering it.
+ * 2. The user-menu entry is IN the ledger now (#3907, resolved), and its module
+ *    lives outside `components/Apps` — `components/AppLayout/AppHeader/
+ *    appsNavVisibility.ts` — which is why `SCAN_ROOTS` carries that directory
+ *    too. Earlier revisions of this comment recorded it as deliberately NOT
+ *    converted and therefore structurally invisible here; both halves are now
+ *    false, and the reason it changed is worth keeping:
  *
- *    CONSEQUENCE, recorded so nobody rediscovers it during the launch: for the
- *    `{appListings, NOT appBlocks}` cohort the store renders but has NO in-product
- *    entry point — that menu item is the only route TO `/apps` (the sub-nav's
- *    Marketplace tab only appears once you are already on `/apps/*`). Reachable by
- *    direct URL only. Tracked in issue #3907; not this file's to fix.
- *
- *    🔴 THE EXTERNAL-ONLY COHORT INHERITS THAT GAP, AND IS THE FIRST REAL POPULATION
- *    TO HIT IT. `{appListingsPublicExternal, NOT appBlocks, NOT appListings}` holders
- *    now pass the six gates below but the user-menu entry still reads `appBlocks`
- *    alone, so `/apps` is direct-URL-only for them. Until #3907 lands, an
- *    external-only rollout needs its own entry point (a link in the announcement, a
- *    campaign URL) — the store being reachable is NOT the same as it being findable.
- *    Deliberately out of scope here: converting that menu item is a product decision
- *    on a module with its own standing doc, not a mechanical alignment.
+ *    that entry is the ONLY in-product route TO `/apps` (the sub-nav's
+ *    Marketplace tab only appears once you are already on `/apps/*`), and it read
+ *    `!!features.appBlocks`. So `{appListings, NOT appBlocks}` — the documented
+ *    shape of the store launch — and `{appListingsPublicExternal, NOT appBlocks,
+ *    NOT appListings}` — the live external-only tester cohort — both passed the
+ *    other six gates onto a store they could reach only by direct URL. Reachable
+ *    is not findable. Widening it moves DISCOVERY only: every runtime surface
+ *    behind `/apps` keeps its own `appBlocks` gate (see 1).
  */
 const STORE_GATE_SITES = [
+  'components/AppLayout/AppHeader/appsNavVisibility.ts',
   'components/Apps/AppListingsMarketplaceBody.tsx',
   'components/Apps/AppsSubNav.tsx',
   'components/Apps/RelatedListings.tsx',
@@ -104,8 +107,16 @@ const STORE_GATE_SITES = [
 /** The ONE module allowed to spell the boolean out — it defines it. */
 const DEFINING_MODULE = 'shared/utils/app-blocks-access.ts';
 
-/** Directories scanned for a re-inlined gate. The definition lives outside them. */
-const SCAN_ROOTS = ['components/Apps', 'pages/apps'];
+/**
+ * Directories scanned for a re-inlined gate. The definition lives outside them.
+ *
+ * `components/AppLayout/AppHeader` is here for ONE file — `appsNavVisibility.ts`,
+ * the user-menu route to the store (#3907). Scanning the whole directory rather
+ * than allowlisting that file is deliberate: the header is where a future "show
+ * the Apps entry when …" tweak would most plausibly open-code the gate, and the
+ * re-inline scan below only has teeth over directories it walks.
+ */
+const SCAN_ROOTS = ['components/AppLayout/AppHeader', 'components/Apps', 'pages/apps'];
 
 /**
  * 🔴 MASKING RUNS THROUGH THE REAL TypeScript PARSER, NOT A QUOTE SCANNER.
@@ -502,10 +513,10 @@ describe('🔒 every store-visibility site routes through the shared predicate',
         flatten(f.comments)
       )
     ).map((f) => f.rel);
-    // ⚠️ "EXACT" is scoped to SCAN_ROOTS. `components/AppLayout/AppHeader/
-    // appsNavVisibility.ts` is a real store-visibility decision that lives outside
-    // them and is deliberately excluded — see the STORE_GATE_SITES doc. This
-    // assertion cannot and does not speak for it.
+    // ⚠️ "EXACT" is scoped to SCAN_ROOTS — three directories now, the third
+    // added for the user-menu entry (#3907). A store-visibility decision made
+    // OUTSIDE those roots is still invisible here; the scoping is the limit, not
+    // the file list.
     expect(importers.sort()).toEqual([...STORE_GATE_SITES].sort());
   });
 });

--- a/src/shared/utils/app-blocks-access.ts
+++ b/src/shared/utils/app-blocks-access.ts
@@ -81,20 +81,19 @@ export type AppsStoreFeatureFlags =
  * (`appListings || appBlocks || appListingsPublicExternal`).
  *
  * 🔒 THE SINGLE SOURCE OF TRUTH for "may this viewer see the /apps store", for
- * the six surfaces under `components/Apps` and `pages/apps`: the `/apps` SSR
- * resolver (`resolveAppsPageAccess`), the `/apps` page body, the store-preview
- * route, the marketplace grid query, the related-listings rail, and the `/apps/*`
- * sub-nav. All six route through THIS predicate.
+ * seven surfaces: the `/apps` SSR resolver (`resolveAppsPageAccess`), the `/apps`
+ * page body, the store-preview route, the marketplace grid query, the
+ * related-listings rail, the `/apps/*` sub-nav — all six under `components/Apps`
+ * / `pages/apps` — and, since #3907, the user-menu "Apps" → `/apps` entry
+ * (`components/AppLayout/AppHeader/appsNavVisibility.ts`). All seven route
+ * through THIS predicate.
  *
- * ⚠️ "Every store surface" would be TOO STRONG, so it is not claimed. One
- * store-visibility decision is deliberately NOT converted:
- * `components/AppLayout/AppHeader/appsNavVisibility.ts` gates the user-menu
- * "Apps" → `/apps` entry on `appBlocks` alone, and its own doc says it "stays
- * gated on `appBlocks`" — a standing decision, not drift. Consequence worth
- * knowing before the launch: for a `{appListings, NOT appBlocks}` cohort the
- * store renders but has no in-product entry point, since that menu item is the
- * only route TO `/apps`. Tracked in issue #3907 — settle it BEFORE widening
- * `app-listings`, not after.
+ * ⚠️ "Every store surface" would still be TOO STRONG, so it is not claimed —
+ * only that these seven are pinned. The seventh was converted because it is the
+ * ONLY in-product route to `/apps`, so while it read `appBlocks` alone a
+ * `{appListings, NOT appBlocks}` or external-only cohort got a store that
+ * rendered but could not be found. Converting it widens DISCOVERY only: the
+ * block-runtime surfaces listed below keep their own gates.
  *
  * Do NOT re-inline `features.appListings || features.appBlocks`; the
  * gates drifting apart is exactly what this function exists to prevent, and it
@@ -104,7 +103,7 @@ export type AppsStoreFeatureFlags =
  * sub-navigation at all.
  *
  * ENFORCED, not merely requested: `components/Apps/__tests__/appsStoreAccessCallSites.test.ts`
- * pins the exact ledger of the six sites and fails if one is added, reverted, or
+ * pins the exact ledger of the seven sites and fails if one is added, reverted, or
  * re-inlines the boolean. Adding a store surface means adding it to that ledger.
  *
  * ## Why an OR, and which flag is which


### PR DESCRIPTION
Closes #3907.

## What

The user-menu "Apps" → `/apps` entry now follows **store visibility** (`hasAppsStoreAccess` = `appListings || appBlocks || appListingsPublicExternal`) instead of `appBlocks` alone.

```diff
-    marketplace: !!features.appBlocks,
+    marketplace: hasAppsStoreAccess(features),
```

That is option 1 from the issue.

## Why now — it stopped being theoretical

That menu item is the **only** in-product route to `/apps`. The `/apps/*` sub-nav's Marketplace tab renders only once you are already on an `/apps/*` route, so there is no second way in.

Since the W13 decoupling, store access grants on `appListings || appBlocks || appListingsPublicExternal`, but this entry still read `appBlocks`. Two cohorts therefore pass every one of the six store gates and land on a page they cannot find:

- `{appListings, NOT appBlocks}` — the documented shape of the public store launch;
- `{appListingsPublicExternal, NOT appBlocks, NOT appListings}` — the **live external-only tester cohort** (Flipt `app-listings-public-external`, base off, rollout `[testers]`). For them `/apps` is direct-URL-only today.

Reachable is not findable.

## Blast radius: discovery, not capability

This adds a **link**. Every surface behind `/apps` keeps its own gate:

- the block-runtime surfaces (`/apps/installed`, `/apps/review`, `/apps/my-submissions`, `/apps/revenue`, `/apps/run/<slug>`) still gate on `appBlocks` alone — untouched;
- the store itself is still scoped server-side, so the external-only cohort sees `kind='offsite'` listings and nothing else;
- a viewer with no store flag still gets `marketplace: false`, and the page would 404 for them anyway.

## The ledger grew to seven

`appsNavVisibility.ts` is now in `STORE_GATE_SITES`, and `components/AppLayout/AppHeader` was added to `SCAN_ROOTS` so the ledger's grow/shrink detection and the re-inline scan actually cover it (previously it was structurally invisible to both — that limitation was documented in the ledger and is now obsolete).

Three doc comments asserted the old decision ("stays gated on `appBlocks`", "deliberately NOT converted") in `appsNavVisibility.ts`, `app-blocks-access.ts`, `appsStoreAccessCallSites.test.ts`, plus the call-site comment in `hooks.tsx`. All four are rewritten — a stale comment here is what a future reader would revert the change from.

## Tests

`src/components/AppLayout/AppHeader/appsNavVisibility.test.ts` — 4 new cases: external-only cohort, catalog-only cohort, a negative control (every store flag off ⇒ hidden, so a `marketplace: true` mutant cannot pass), and a relationship test that catalog-only and runtime-only both resolve visible.

**Mutation-checked, not just green.** Reverting the line to `!!features.appBlocks` fails **4** tests for their own reasons:

| test | project |
|---|---|
| `EXTERNAL-ONLY cohort (appListingsPublicExternal alone) sees the entry` | unit |
| `CATALOG-ONLY cohort (appListings alone) sees the entry` | unit |
| `the marketplace entry is decided WITHOUT requiring the block runtime` | unit |
| `components/AppLayout/AppHeader/appsNavVisibility.ts imports AND calls hasAppsStoreAccess` | unit (ledger) |

`32 passed` on the two suites at HEAD; `4 failed | 28 passed` with the mutant.
