### PR TITLE
fix(apps): tell the owner ownership transfer is refused BEFORE they do the work

### DIFF
--- a/src/components/Apps/AppCollaboratorsPanel.tsx
+++ b/src/components/Apps/AppCollaboratorsPanel.tsx
@@ -5,6 +5,7 @@ import type { SearchIndexDataMap } from '~/components/Search/search.utils2';
 import type {
   CollaboratorRosterRow,
   PendingTransferRow,
+  TransferListingFacts,
 } from '~/components/Apps/AppCollaboratorsPanelView';
 import {
   AppCollaboratorsPanelView,
@@ -32,10 +33,19 @@ export function AppCollaboratorsPanel({
   appListingId,
   role,
   capabilities,
+  listing,
 }: {
   appListingId: string;
   role: AppRole;
   capabilities: Readonly<Record<ListingCapability, boolean>>;
+  /**
+   * 🔴 REQUIRED, DELIBERATELY. This is the field whose absence WAS the bug: the transfer
+   * verdict is a property of the listing, so a caller that has an authoring context and
+   * does not hand it over would put the tab back to learning the refusal from a mutation
+   * error. Non-optional means `tsc` refuses the page that forgets it, rather than the page
+   * silently rendering an enabled control again.
+   */
+  listing: TransferListingFacts;
 }) {
   const currentUser = useCurrentUser();
   const utils = trpc.useUtils();
@@ -158,6 +168,9 @@ export function AppCollaboratorsPanel({
       }
       onLeave={() => leave.mutate({ appListingId })}
       pendingTransfer={(transferQuery.data ?? null) as PendingTransferRow | null}
+      // The listing facts the View reaches the up-front transfer verdict from. Forwarded
+      // whole rather than pre-computed here, so the rule has exactly one call site.
+      listing={listing}
       transferErrorMessage={transferErrorMessage}
       transferBusy={transferBusy}
       onCancelTransfer={(transferId) => cancelTransfer.mutate({ transferId })}

--- a/src/components/Apps/AppCollaboratorsPanel.tsx
+++ b/src/components/Apps/AppCollaboratorsPanel.tsx
@@ -11,6 +11,7 @@ import {
   AppCollaboratorsPanelView,
   inviteBlockedReason,
   pickerExcludedUserIds,
+  TRANSFER_PICKER_PLACEHOLDER,
 } from '~/components/Apps/AppCollaboratorsPanelView';
 import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
@@ -95,9 +96,9 @@ export function AppCollaboratorsPanel({
     void utils.appCollaborators.getPendingTransfer.invalidate({ appListingId });
   };
   // 🔴 The refusal is held in STATE and rendered inline by the View, instead of being
-  // thrown at a toast. The connect-client refusal names a concrete remedy ("unlink the
-  // OAuth client first"); a transient toast is exactly where an actionable message goes
-  // to die, and the owner is left with a control that fails every time.
+  // thrown at a toast. A refusal names WHY the transfer cannot happen, and a transient
+  // toast is exactly where a reason goes to die — leaving the owner with a control that
+  // fails every time and nothing on screen explaining it.
   const [transferErrorMessage, setTransferErrorMessage] = useState<string | null>(null);
   const initiateTransfer = trpc.appCollaborators.initiateTransfer.useMutation({
     onSuccess: () => {
@@ -182,7 +183,7 @@ export function AppCollaboratorsPanel({
           showIndexSelect={false}
           dropdownItemLimit={25}
           disabled={transferBusy}
-          placeholder="Search for the person who should own this app"
+          placeholder={TRANSFER_PICKER_PLACEHOLDER}
           onItemSelected={(_entity, item) => {
             const selected = item as SearchIndexDataMap['users'][number];
             setTransferErrorMessage(null);

--- a/src/components/Apps/AppCollaboratorsPanelView.browser.test.tsx
+++ b/src/components/Apps/AppCollaboratorsPanelView.browser.test.tsx
@@ -534,10 +534,17 @@ describe('AppCollaboratorsPanelView — ownership transfer (owner half)', () => 
    * 🔴 THE CONNECT-CLIENT REFUSAL, RENDERED WITH ITS REASON.
    *
    * A connect-linked off-site listing is refused at initiate AND again in-transaction at
-   * accept, with a message that names a concrete remedy: unlink the OAuth client first.
-   * Collapsing that into a generic "something went wrong" leaves the owner with a control
-   * that fails forever and no way to learn why — so the message is asserted VERBATIM
-   * against the server's own exported constant rather than against a paraphrase.
+   * accept, with a message that names the REASON (the credentials/split-ownership
+   * consequence) rather than a remedy — there is no unlink path in the product, so the
+   * string deliberately instructs nothing. Collapsing it into a generic "something went
+   * wrong" would leave the owner with a control that fails forever and no way to learn
+   * why, so the message is asserted VERBATIM against the server's own exported constant
+   * rather than against a paraphrase.
+   *
+   * NOTE: this test drives the MUTATION-ERROR route (the prop), which still exists for
+   * every other refusal reason. The connect-client case is now caught BEFORE submission —
+   * see `src/tests/pages/apps/listing-collaborators-transfer.browser.test.tsx`, which
+   * drives it from listing data with no prop at all.
    */
   test('🔴 a refusal renders inline, with the server’s reason intact', async () => {
     renderWithProviders(
@@ -553,7 +560,9 @@ describe('AppCollaboratorsPanelView — ownership transfer (owner half)', () => 
     const error = page.getByTestId('apps-transfer-owner-error');
     await expect.element(error).toBeInTheDocument();
     await expect.element(error).toHaveTextContent(/linked to an OAuth application/i);
-    await expect.element(error).toHaveTextContent(/Unlink the OAuth client first/i);
+    // NOT `/cannot be transferred/i` — this Alert's `title` prop already spells that, so
+    // the regex would match the chrome rather than the message. Assert on the body.
+    await expect.element(error).toHaveTextContent(/split ownership/i);
     // 🔴 The message the SERVER will send, character for character — a paraphrase here
     // would let the copy drift out from under the assertion.
     await expect.element(error).toHaveTextContent(CONNECT_CLIENT_TRANSFER_REFUSAL);

--- a/src/components/Apps/AppCollaboratorsPanelView.tsx
+++ b/src/components/Apps/AppCollaboratorsPanelView.tsx
@@ -10,6 +10,7 @@ import {
   Stack,
   Switch,
   Text,
+  TextInput,
   Title,
 } from '@mantine/core';
 import { IconAlertTriangle, IconCoin, IconInfoCircle } from '@tabler/icons-react';
@@ -18,6 +19,10 @@ import { useMemo } from 'react';
 
 import { constants } from '~/server/common/constants';
 import type { AppRole, ListingCapability } from '~/shared/constants/app-capabilities.constants';
+import {
+  CONNECT_CLIENT_TRANSFER_REFUSAL,
+  refusesTransferForConnectClient,
+} from '~/shared/constants/app-transfer.constants';
 
 /**
  * App Listing COLLABORATORS — the PRESENTATIONAL roster panel.
@@ -89,6 +94,31 @@ export type AppCollaboratorsPanelViewProps = {
   transferPicker?: ReactNode;
   onCancelTransfer?: (transferId: string) => void;
   transferBusy?: boolean;
+  /**
+   * 🔴 THE LISTING ITSELF, so the transfer verdict can be reached BEFORE the owner acts.
+   *
+   * `transferErrorMessage` above is a mutation RESULT — it can only ever arrive after the
+   * owner has picked a recipient and submitted. A connect-linked off-site listing is
+   * refused every single time, so that path made the refusal something the owner could
+   * only discover by doing the work. This prop is the same fact BEFORE the click, and the
+   * verdict is {@link refusesTransferForConnectClient} — the SAME function the service
+   * gates on, imported from `shared/` so the two cannot drift.
+   *
+   * Optional so the roster half of this View stays renderable without it; when it is
+   * absent nothing is refused, which is the pre-existing behaviour exactly.
+   */
+  listing?: TransferListingFacts | null;
+};
+
+/**
+ * The listing facts the transfer verdict is computed from. Structurally the argument of
+ * {@link refusesTransferForConnectClient} — deliberately, so widening the rule cannot
+ * leave this surface behind.
+ */
+export type TransferListingFacts = {
+  kind: string;
+  /** The linked OAuth `client_id`, or `null`. Public, not a secret. */
+  connectClientId: string | null;
 };
 
 /** The live outgoing offer, as `appCollaborators.getPendingTransfer` returns it. */
@@ -181,6 +211,7 @@ function OwnerTransferSection({
   onCancelTransfer,
   transferBusy,
   renderUser,
+  listing,
 }: {
   pendingTransfer: PendingTransferRow | null;
   transferErrorMessage: string | null;
@@ -188,7 +219,16 @@ function OwnerTransferSection({
   onCancelTransfer?: (transferId: string) => void;
   transferBusy: boolean;
   renderUser: (userId: number) => ReactNode;
+  listing: TransferListingFacts | null;
 }) {
+  /**
+   * 🔴 THE UP-FRONT VERDICT, and it is the ONLY call of the rule on this surface. The
+   * service asks the same function at initiate and again in-transaction at accept; asking
+   * it here too is what stops the tab from offering an action the server will refuse. It
+   * is NOT a replacement for either server gate — those are unchanged and authoritative,
+   * and this one runs on data the client can lie to itself about.
+   */
+  const refusedForConnectClient = listing ? refusesTransferForConnectClient(listing) : false;
   return (
     <Stack gap="sm" data-testid="apps-transfer-owner-section">
       <Title order={4}>Transfer ownership</Title>
@@ -207,6 +247,22 @@ function OwnerTransferSection({
           <Text size="sm">Nothing moves until the person you choose accepts.</Text>
         </Stack>
       </Alert>
+
+      {/* 🔴 THE REFUSAL, UP FRONT — before a recipient is chosen, not after.
+          Rendered from the LISTING, so it is on screen the moment the tab opens. The
+          message is the server's own constant, not a paraphrase: the owner reads the same
+          sentence here that the mutation would have returned, including its remedy. */}
+      {refusedForConnectClient ? (
+        <Alert
+          color="yellow"
+          variant="light"
+          icon={<IconAlertTriangle size={16} />}
+          title="Ownership cannot be transferred for this app"
+          data-testid="apps-transfer-blocked"
+        >
+          {CONNECT_CLIENT_TRANSFER_REFUSAL}
+        </Alert>
+      ) : null}
 
       {/* 🔴 THE REFUSAL, WITH ITS REASON. See `transferErrorMessage`. */}
       {transferErrorMessage ? (
@@ -249,7 +305,24 @@ function OwnerTransferSection({
            lose on P2002 — offering the control while an offer is open would render an
            action that cannot succeed. */
         <Stack gap="xs">
-          {transferPicker}
+          {/* 🔴 DISABLED, NOT HIDDEN. Removing the section entirely would leave the owner
+              asking why their app has no transfer control at all — a different confusion,
+              not a smaller one. The control stays where they expect it, visibly off, with
+              the reason directly above it and a remedy they can act on. The real picker is
+              not merely disabled but UNMOUNTED, so no path through it can fire the
+              mutation; this stand-in occupies its place and states the same purpose. */}
+          {refusedForConnectClient ? (
+            <TextInput
+              disabled
+              readOnly
+              value=""
+              aria-label="Search for the person who should own this app"
+              placeholder="Search for the person who should own this app"
+              data-testid="apps-transfer-picker-disabled"
+            />
+          ) : (
+            transferPicker
+          )}
           <Text size="xs" c="dimmed">
             One transfer offer at a time. It expires after{' '}
             {constants.appCollaborators.transferExpiryDays} days if it is not accepted.
@@ -278,6 +351,7 @@ export function AppCollaboratorsPanelView({
   transferPicker,
   onCancelTransfer,
   transferBusy = false,
+  listing = null,
 }: AppCollaboratorsPanelViewProps) {
   const isOwner = role === 'owner';
   const identity = renderUser ?? ((userId: number) => <Text fw={500}>User #{userId}</Text>);
@@ -446,6 +520,7 @@ export function AppCollaboratorsPanelView({
           onCancelTransfer={onCancelTransfer}
           transferBusy={transferBusy}
           renderUser={identity}
+          listing={listing}
         />
       ) : null}
 

--- a/src/components/Apps/AppCollaboratorsPanelView.tsx
+++ b/src/components/Apps/AppCollaboratorsPanelView.tsx
@@ -320,12 +320,21 @@ function OwnerTransferSection({
                 precisely why `acceptTransfer` re-asserts the refusal IN-TRANSACTION rather
                 than trusting the initiate-time check. Without this line the tab renders
                 "ownership cannot be transferred" directly above a "Transfer pending" card
-                and leaves the owner to guess which one is true — and the recipient would
-                hit the refusal on accept with no warning either. */}
+                and leaves the owner to guess which one is true.
+
+                🔴 SCOPE: THE OWNER ONLY. This is the owner's Collaborators tab. The
+                RECIPIENT's surfaces (`AppTransferOffersView`, `AppInvitesBody`) carry no
+                connect-client awareness at all, so an addressee still sees a normal-looking
+                offer and meets the refusal only on clicking accept — the same
+                learn-it-by-doing-the-work shape this section fixes for the owner, on the
+                other side of the wire. That gap is OPEN and deliberately NOT closed here;
+                it needs the recipient read to carry the verdict, which is its own change. */}
             {refusedForConnectClient ? (
               <Text size="xs" c="red.6" data-testid="apps-transfer-pending-dead">
-                This offer can no longer be accepted, because the listing is now linked to an OAuth
-                application. Cancel it to tidy it up.
+                {/* No "because the listing is linked to an OAuth application" here — the
+                    banner above says exactly that, and both render under the SAME
+                    condition, so a second wording of one fact could only drift from it. */}
+                This offer can no longer be accepted. Cancel it to tidy it up.
               </Text>
             ) : null}
           </Stack>

--- a/src/components/Apps/AppCollaboratorsPanelView.tsx
+++ b/src/components/Apps/AppCollaboratorsPanelView.tsx
@@ -84,10 +84,13 @@ export type AppCollaboratorsPanelViewProps = {
   /**
    * 🔴 The REASON the last transfer attempt was refused, rendered inline.
    *
-   * A connect-linked off-site listing is refused with a specific, actionable message
-   * ("unlink the OAuth client first"). Collapsing that into a generic "something went
-   * wrong" toast would leave the owner with an action that fails forever and no way to
-   * learn why, so the message is surfaced where the control is.
+   * A refusal carries a specific reason. Collapsing that into a generic "something went
+   * wrong" toast would leave the owner with an action that fails and no way to learn why,
+   * so the message is surfaced where the control is.
+   *
+   * The connect-client case no longer needs to travel this way — it is caught up front
+   * from `listing` below — but every OTHER refusal reason (a banned recipient, a stale
+   * offer, "you already own this app") still arrives as a mutation error, so this stays.
    */
   transferErrorMessage?: string | null;
   /** The recipient picker. Injected, like `userPicker`, to keep the search stack out. */
@@ -120,6 +123,13 @@ export type TransferListingFacts = {
   /** The linked OAuth `client_id`, or `null`. Public, not a secret. */
   connectClientId: string | null;
 };
+
+/**
+ * The recipient picker's placeholder. ONE definition, read by the real picker in the
+ * container and by the disabled stand-in here — they sit in different files and are the
+ * same control to the owner, so a second copy would drift the moment either is reworded.
+ */
+export const TRANSFER_PICKER_PLACEHOLDER = 'Search for the person who should own this app';
 
 /** The live outgoing offer, as `appCollaborators.getPendingTransfer` returns it. */
 export type PendingTransferRow = {
@@ -279,25 +289,45 @@ function OwnerTransferSection({
 
       {pendingTransfer ? (
         <Paper withBorder p="sm" radius="md" data-testid="apps-transfer-pending">
-          <Group justify="space-between" wrap="wrap" gap="sm">
-            <Group gap="xs">
-              <Badge color="orange">Transfer pending</Badge>
-              <Text size="sm">Offered to</Text>
-              {renderUser(pendingTransfer.toUserId)}
+          <Stack gap="xs">
+            <Group justify="space-between" wrap="wrap" gap="sm">
+              <Group gap="xs">
+                <Badge color="orange">Transfer pending</Badge>
+                <Text size="sm">Offered to</Text>
+                {renderUser(pendingTransfer.toUserId)}
+              </Group>
+              {/* 🔴 CANCEL STAYS AVAILABLE EVEN WHEN THE LISTING IS REFUSED. It is the
+                  owner's only way out of a stale offer, and `cancelTransfer` carries no
+                  connect-client gate — withdrawing an offer that can never complete is
+                  exactly the action that should still work. */}
+              {onCancelTransfer ? (
+                <Button
+                  size="xs"
+                  variant="light"
+                  color="red"
+                  disabled={transferBusy}
+                  data-testid="apps-transfer-cancel"
+                  onClick={() => onCancelTransfer(pendingTransfer.id)}
+                >
+                  Cancel transfer
+                </Button>
+              ) : null}
             </Group>
-            {onCancelTransfer ? (
-              <Button
-                size="xs"
-                variant="light"
-                color="red"
-                disabled={transferBusy}
-                data-testid="apps-transfer-cancel"
-                onClick={() => onCancelTransfer(pendingTransfer.id)}
-              >
-                Cancel transfer
-              </Button>
+            {/* 🔴 A LIVE OFFER ON A REFUSED LISTING IS DEAD ON ACCEPT, AND SAYING SO IS THE
+                WHOLE POINT OF THIS SECTION. The states co-exist for a real reason: a
+                revision approve can link an OAuth client while an offer sits open, which is
+                precisely why `acceptTransfer` re-asserts the refusal IN-TRANSACTION rather
+                than trusting the initiate-time check. Without this line the tab renders
+                "ownership cannot be transferred" directly above a "Transfer pending" card
+                and leaves the owner to guess which one is true — and the recipient would
+                hit the refusal on accept with no warning either. */}
+            {refusedForConnectClient ? (
+              <Text size="xs" c="red.6" data-testid="apps-transfer-pending-dead">
+                This offer can no longer be accepted, because the listing is now linked to an OAuth
+                application. Cancel it to tidy it up.
+              </Text>
             ) : null}
-          </Group>
+          </Stack>
         </Paper>
       ) : (
         /* 🔴 The picker and the pending card are MUTUALLY EXCLUSIVE. One live offer per
@@ -307,26 +337,33 @@ function OwnerTransferSection({
         <Stack gap="xs">
           {/* 🔴 DISABLED, NOT HIDDEN. Removing the section entirely would leave the owner
               asking why their app has no transfer control at all — a different confusion,
-              not a smaller one. The control stays where they expect it, visibly off, with
-              the reason directly above it and a remedy they can act on. The real picker is
-              not merely disabled but UNMOUNTED, so no path through it can fire the
-              mutation; this stand-in occupies its place and states the same purpose. */}
+              not a smaller one, and one they cannot even ask a useful question about. The
+              control stays where they expect it, visibly off, with the reason directly
+              above it. The real picker is not merely disabled but UNMOUNTED, so no path
+              through it can fire the mutation; this stand-in occupies its place and states
+              the same purpose. */}
           {refusedForConnectClient ? (
             <TextInput
               disabled
               readOnly
               value=""
-              aria-label="Search for the person who should own this app"
-              placeholder="Search for the person who should own this app"
+              aria-label={TRANSFER_PICKER_PLACEHOLDER}
+              placeholder={TRANSFER_PICKER_PLACEHOLDER}
               data-testid="apps-transfer-picker-disabled"
             />
           ) : (
             transferPicker
           )}
-          <Text size="xs" c="dimmed">
-            One transfer offer at a time. It expires after{' '}
-            {constants.appCollaborators.transferExpiryDays} days if it is not accepted.
-          </Text>
+          {/* 🔴 SUPPRESSED WHEN REFUSED. "One transfer offer at a time. It expires after N
+              days" describes the mechanics of a transfer this listing can never start —
+              reassuring, specific, and irrelevant, which is the combination most likely to
+              be read as "so a transfer IS possible here". */}
+          {refusedForConnectClient ? null : (
+            <Text size="xs" c="dimmed">
+              One transfer offer at a time. It expires after{' '}
+              {constants.appCollaborators.transferExpiryDays} days if it is not accepted.
+            </Text>
+          )}
         </Stack>
       )}
     </Stack>

--- a/src/components/Apps/AppCollaboratorsPanelView.tsx
+++ b/src/components/Apps/AppCollaboratorsPanelView.tsx
@@ -261,7 +261,8 @@ function OwnerTransferSection({
       {/* 🔴 THE REFUSAL, UP FRONT — before a recipient is chosen, not after.
           Rendered from the LISTING, so it is on screen the moment the tab opens. The
           message is the server's own constant, not a paraphrase: the owner reads the same
-          sentence here that the mutation would have returned, including its remedy. */}
+          sentence here that the mutation would have returned. It states a CONSTRAINT and
+          instructs nothing — there is no unlink flow to send them to; see the constant. */}
       {refusedForConnectClient ? (
         <Alert
           color="yellow"

--- a/src/pages/apps/listing/[appListingId]/edit.tsx
+++ b/src/pages/apps/listing/[appListingId]/edit.tsx
@@ -76,6 +76,8 @@ type AuthoringContext = {
   status: string;
   kind: 'onsite' | 'offsite';
   appBlockId: string | null;
+  /** Linked OAuth `client_id`, or null. Decides whether ownership transfer is offerable. */
+  connectClientId: string | null;
   role: AppRole;
   capabilities: Readonly<Record<ListingCapability, boolean>>;
 };
@@ -213,6 +215,11 @@ export default function AppListingEditPage() {
                   appListingId={context.appListingId}
                   role={context.role}
                   capabilities={context.capabilities}
+                  // 🔴 The two facts the transfer verdict is made of, straight off the
+                  // authoring context. Ownership of a connect-linked off-site listing can
+                  // never move, and the tab has to be able to say so BEFORE the owner
+                  // picks a recipient — see `refusesTransferForConnectClient`.
+                  listing={{ kind: context.kind, connectClientId: context.connectClientId }}
                 />
               </Tabs.Panel>
             ) : null}

--- a/src/pages/apps/listing/[appListingId]/edit.tsx
+++ b/src/pages/apps/listing/[appListingId]/edit.tsx
@@ -26,8 +26,8 @@ import { ListingMediaEditor } from '~/components/Apps/ListingMediaEditor';
 import { ManifestEditForm } from '~/components/Apps/ManifestEditForm';
 import { Meta } from '~/components/Meta/Meta';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import type { AppListingAuthoringContext } from '~/server/services/blocks/app-access.service';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
-import type { AppRole, ListingCapability } from '~/shared/constants/app-capabilities.constants';
 import { getLoginLink } from '~/utils/login-helpers';
 import { trpc } from '~/utils/trpc';
 
@@ -69,18 +69,18 @@ const TAB_ICONS: Record<EditorTab, typeof IconSettings> = {
   collaborators: IconUsers,
 };
 
-type AuthoringContext = {
-  appListingId: string;
-  slug: string;
-  name: string;
-  status: string;
-  kind: 'onsite' | 'offsite';
-  appBlockId: string | null;
-  /** Linked OAuth `client_id`, or null. Decides whether ownership transfer is offerable. */
-  connectClientId: string | null;
-  role: AppRole;
-  capabilities: Readonly<Record<ListingCapability, boolean>>;
-};
+/**
+ * 🔴 DERIVED FROM THE SERVER'S OWN RETURN TYPE, not hand-written alongside it.
+ *
+ * This was a duplicated structural type, and the `data as AuthoringContext` cast below
+ * made the duplication INVISIBLE to `tsc`: dropping a field from the service — the exact
+ * shape of the original defect — left the page compiling cleanly against its own stale
+ * copy, and a later RENAME would have been applied to the service and its tests while this
+ * page silently kept reading the old key. A type-only import costs nothing at runtime (it
+ * is erased) and is the established pattern here; the cast is now checked against the
+ * thing it is casting from.
+ */
+type AuthoringContext = AppListingAuthoringContext;
 
 /** The manifest tab's body. Its own query, so it costs nothing on the other tabs. */
 function ManifestTabPanel({ appBlockId }: { appBlockId: string }) {

--- a/src/server/services/blocks/__tests__/app-access.authoring-context-connect-client.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.authoring-context-connect-client.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * `getAppListingAuthoringContext` MUST CARRY `connectClientId` — the backend half of the
+ * up-front ownership-transfer refusal.
+ *
+ * 🔴 THE READ IS THE SEAM THAT WAS MISSING, not the component. The Collaborators tab can
+ * only refuse a transfer up front if it knows the listing is connect-linked, and this is
+ * the only read the authoring page makes. Until this field was added the column existed,
+ * the server gated on it, the component test asserted the refusal MESSAGE renders — and
+ * the fact never crossed the wire, so the owner met the refusal only after picking a
+ * recipient. A field is not a guard; this pins the field, and the browser suite
+ * (`src/tests/pages/apps/listing-collaborators-transfer.browser.test.tsx`) pins the
+ * branch that reads it.
+ *
+ * 🔴 THE FAKE HONOURS THE `select`. It returns ONLY the columns the query asked for, so
+ * deleting `connectClientId: true` from the service's `select` makes this go red — which
+ * a canned fixture, returning the whole row regardless, could never do. That is the exact
+ * fixture-collapse the sibling suites' headers warn about.
+ *
+ * DB deps mocked per the sibling convention (a `vi.hoisted` fake handed to
+ * `dbRead`/`dbWrite`); no real Prisma.
+ */
+
+const { mockDb, mockWriteDb, table } = vi.hoisted(() => {
+  /** The one row every read below is answered from. Mutable per test. */
+  const table = {
+    id: 'apl_1',
+    slug: 'my-app',
+    name: 'My App',
+    status: 'approved',
+    kind: 'offsite' as string,
+    appBlockId: null as string | null,
+    connectClientId: null as string | null,
+    revisionOfId: null as string | null,
+    userId: 10,
+  };
+
+  /**
+   * Project `row` through a Prisma-style `select`. Columns NOT selected are ABSENT, the
+   * way Prisma returns them — this is what makes the service's `select` observable.
+   */
+  const project = (select: Record<string, unknown> | undefined) => {
+    const row: Record<string, unknown> = { ...table, appBlock: null, revisionOf: null };
+    if (!select) return row;
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(select)) if (v) out[k] = row[k];
+    return out;
+  };
+
+  const make = () => ({
+    appBlock: {
+      findUnique: vi.fn(async (): Promise<unknown> => null),
+      findMany: vi.fn(async (): Promise<unknown[]> => []),
+      findFirst: vi.fn(async (): Promise<unknown> => null),
+    },
+    appListing: {
+      findUnique: vi.fn(
+        async (...a: unknown[]): Promise<unknown> =>
+          project((a[0] as { select?: Record<string, unknown> }).select)
+      ),
+      findMany: vi.fn(async (): Promise<unknown[]> => []),
+      findFirst: vi.fn(async (): Promise<unknown> => null),
+    },
+    appCollaborator: {
+      findFirst: vi.fn(async (): Promise<unknown> => null),
+      findMany: vi.fn(async (): Promise<unknown[]> => []),
+    },
+  });
+  return { mockDb: make(), mockWriteDb: make(), table };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockWriteDb }));
+
+const { getAppListingAuthoringContext } = await import(
+  '~/server/services/blocks/app-access.service'
+);
+
+/**
+ * 🔴 THE TRANSFER PREDICATE IS DELIBERATELY NOT IMPORTED HERE. This suite's whole claim is
+ * "the FIELD crosses the wire", and running it against a base revision has to produce a
+ * BEHAVIOURAL red (`undefined` where a client id belongs), not an unresolved-import red —
+ * a suite that fails to collect reports "no tests", which is indistinguishable from a
+ * pass. The predicate's agreement with this value is pinned where it is actually
+ * exercised: `src/tests/pages/apps/listing-collaborators-transfer.browser.test.tsx` drives
+ * the real View, which calls the real `refusesTransferForConnectClient` on the real
+ * payload.
+ */
+
+const OWNER = 10;
+
+describe('the fake honours its select (positive control)', () => {
+  /**
+   * 🔴 Before believing anything below: prove the fake can return BOTH shapes and that
+   * an unselected column really is absent. Without this, "the field came back" and "the
+   * fake always returns everything" are indistinguishable.
+   */
+  it('omits a column the select did not ask for, and returns one it did', async () => {
+    table.connectClientId = 'oc_1';
+    const withField = (await mockDb.appListing.findUnique({
+      where: { id: 'apl_1' },
+      select: { id: true, connectClientId: true },
+    })) as Record<string, unknown>;
+    expect(withField).toEqual({ id: 'apl_1', connectClientId: 'oc_1' });
+
+    const without = (await mockDb.appListing.findUnique({
+      where: { id: 'apl_1' },
+      select: { id: true },
+    })) as Record<string, unknown>;
+    expect('connectClientId' in without).toBe(false);
+  });
+});
+
+describe('getAppListingAuthoringContext carries connectClientId', () => {
+  it('🔴 a connect-linked OFF-SITE listing returns its client id to the owner', async () => {
+    table.kind = 'offsite';
+    table.appBlockId = null;
+    table.connectClientId = 'oc_linked';
+
+    const ctx = await getAppListingAuthoringContext({ appListingId: 'apl_1', userId: OWNER });
+
+    expect(ctx.role).toBe('owner');
+    expect(ctx.kind).toBe('offsite');
+    expect(ctx.connectClientId).toBe('oc_linked');
+  });
+
+  it('🔴 THE CONTROL — an off-site listing with NO client returns null, not a truthy stub', async () => {
+    table.kind = 'offsite';
+    table.appBlockId = null;
+    table.connectClientId = null;
+
+    const ctx = await getAppListingAuthoringContext({ appListingId: 'apl_1', userId: OWNER });
+
+    expect(ctx.connectClientId).toBeNull();
+  });
+
+  it('an ON-SITE listing returns null and stays transferable', async () => {
+    table.kind = 'onsite';
+    table.appBlockId = 'ab_1';
+    table.connectClientId = null;
+
+    const ctx = await getAppListingAuthoringContext({ appListingId: 'apl_1', userId: OWNER });
+
+    expect(ctx.kind).toBe('onsite');
+    expect(ctx.connectClientId).toBeNull();
+  });
+});

--- a/src/server/services/blocks/__tests__/app-ownership-transfer.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-ownership-transfer.service.test.ts
@@ -572,11 +572,21 @@ describe('🔴 an OFF-SITE listing with a connectClientId is REFUSED', () => {
     expect(mockDb.appOwnershipEvent.create).not.toHaveBeenCalled();
   });
 
-  it('🔴 the message NAMES the reason — "unlink the OAuth client first" is actionable', async () => {
-    // A bare FORBIDDEN would leave the owner with no idea what to do, and the whole
-    // point of refusing rather than guessing is that the human makes the call.
+  it('🔴 the message NAMES THE REASON, and instructs NO action the owner cannot take', async () => {
+    // A bare FORBIDDEN would leave the owner with no idea why, and the whole point of
+    // refusing explicitly is that the reason survives to the surface.
     expect(CONNECT_CLIENT_TRANSFER_REFUSAL).toMatch(/OAuth application/i);
-    expect(CONNECT_CLIENT_TRANSFER_REFUSAL).toMatch(/Unlink the OAuth client first/i);
+    expect(CONNECT_CLIENT_TRANSFER_REFUSAL).toMatch(/cannot be transferred/i);
+    // …and it names the CONSEQUENCE, which is the part that makes the refusal legible.
+    expect(CONNECT_CLIENT_TRANSFER_REFUSAL).toMatch(/credentials|split ownership/i);
+
+    // 🔴 NO REMEDY, DELIBERATELY — pinned as a NEGATIVE assertion because this string
+    // used to end "Unlink the OAuth client first" and there is no unlink path in the
+    // product: `connectClientId` is required at submit and immutable on edit. Once the
+    // tab began rendering this permanently rather than only after a failed mutation, a
+    // false instruction became an always-on one. Re-adding a remedy here must fail until
+    // the flow it names actually exists.
+    expect(CONNECT_CLIENT_TRANSFER_REFUSAL).not.toMatch(/unlink/i);
   });
 
   it('🔴 ACCEPT re-asserts it: a client LINKED after the offer was made blocks the accept', async () => {

--- a/src/server/services/blocks/app-access.service.ts
+++ b/src/server/services/blocks/app-access.service.ts
@@ -780,6 +780,19 @@ export type MyAppListing = {
   kind: ListingKind;
   /** `null` for an off-site listing — legitimately absent, not missing. */
   appBlockId: string | null;
+  /**
+   * The listing's linked OAuth `client_id`, or `null`. PUBLIC, not a secret — the same
+   * column the public listing-detail read already exposes (`ListingDetailKindData`).
+   *
+   * 🔴 CARRIED SO AN AUTHORING SURFACE CAN REACH THE TRANSFER VERDICT UP FRONT. A
+   * connect-linked off-site listing can never be transferred
+   * ({@link refusesTransferForConnectClient}), and without this field the Collaborators
+   * tab could not know that until the mutation came back refused — so it rendered an
+   * enabled recipient picker and the owner only found out after choosing someone.
+   * A field is not a guard, though: the branch that reads it lives in
+   * `AppCollaboratorsPanelView`, and the server gate is unchanged and still authoritative.
+   */
+  connectClientId: string | null;
   role: AppRole;
   /**
    * 🔴 DERIVED FROM THE KIND, at the same seam every gate derives it — never stored, and
@@ -797,7 +810,15 @@ async function hydrateMyAppListings(
   if (ids.allIds.length === 0) return [];
   const rows = await dbRead.appListing.findMany({
     where: { id: { in: ids.allIds } },
-    select: { id: true, slug: true, name: true, status: true, kind: true, appBlockId: true },
+    select: {
+      id: true,
+      slug: true,
+      name: true,
+      status: true,
+      kind: true,
+      appBlockId: true,
+      connectClientId: true,
+    },
     orderBy: { serialId: 'desc' },
     take: limit,
   });
@@ -810,6 +831,7 @@ async function hydrateMyAppListings(
       status: string;
       kind: string;
       appBlockId: string | null;
+      connectClientId: string | null;
     }) => {
       const kind = r.kind as ListingKind;
       return {
@@ -819,6 +841,7 @@ async function hydrateMyAppListings(
         status: r.status,
         kind,
         appBlockId: r.appBlockId,
+        connectClientId: r.connectClientId,
         role: (ownedSet.has(r.id) ? 'owner' : 'editor') as AppRole,
         capabilities: capabilitiesForKind(kind),
       };
@@ -985,7 +1008,11 @@ export async function getAppListingAuthoringContext(opts: {
   }
   const row = await dbRead.appListing.findUnique({
     where: { id: access.seatListingId },
-    select: { id: true, slug: true, name: true, status: true },
+    // 🔴 `connectClientId` IS READ FROM THE SEAT (PARENT) ROW, which is the same row
+    // `app-ownership-transfer::loadOwnedListing` reads — so the tab's up-front verdict and
+    // the server's refusal are looking at one column on one row. Reading it off a SHADOW
+    // would be the `kind`/`appBlockId` trap below in a new place.
+    select: { id: true, slug: true, name: true, status: true, connectClientId: true },
   });
   if (!row) {
     throw new TRPCError({ code: 'NOT_FOUND', message: 'App listing not found' });
@@ -1009,6 +1036,7 @@ export async function getAppListingAuthoringContext(opts: {
     // make an in-flight revision look off-site and silently strip the block-only tabs.
     kind: access.kind,
     appBlockId: access.appBlockId,
+    connectClientId: row.connectClientId,
     role: access.role,
     capabilities: capabilitiesForKind(access.kind),
   };

--- a/src/server/services/blocks/app-access.service.ts
+++ b/src/server/services/blocks/app-access.service.ts
@@ -780,11 +780,37 @@ export type MyAppListing = {
   kind: ListingKind;
   /** `null` for an off-site listing — legitimately absent, not missing. */
   appBlockId: string | null;
+  role: AppRole;
+  /**
+   * 🔴 DERIVED FROM THE KIND, at the same seam every gate derives it — never stored, and
+   * never widened per row. A surface that renders an action for a `false` capability is
+   * rendering a guaranteed 403.
+   */
+  capabilities: Readonly<Record<ListingCapability, boolean>>;
+};
+
+/**
+ * The SINGLE-LISTING authoring read's row — {@link MyAppListing} plus the one extra fact
+ * the authoring page needs. Returned by {@link getAppListingAuthoringContext}.
+ *
+ * 🔴 A SEPARATE TYPE RATHER THAN A WIDER `MyAppListing`, and the distinction is a
+ * disclosure boundary rather than tidiness. `connectClientId` was first added to
+ * `MyAppListing` itself, which silently widened `listMine` — a LIST read over every
+ * listing the caller can touch — for no consumer at all. Both reads are reachable by an
+ * accepted EDITOR, not just the owner, so that would have handed a seated collaborator the
+ * client_id of every listing they hold a seat on, including `draft` ones the public read
+ * does not expose yet. Harmless in itself (it is the public client_id, never the secret)
+ * and bought nothing, which is precisely why it should not be paid.
+ *
+ * So the field is carried ONLY on the read that has a consumer. If a list surface ever
+ * needs it, widen `MyAppListing` then — with the consumer, and a test that pins it.
+ */
+export type AppListingAuthoringContext = MyAppListing & {
   /**
    * The listing's linked OAuth `client_id`, or `null`. PUBLIC, not a secret — the same
    * column the public listing-detail read already exposes (`ListingDetailKindData`).
    *
-   * 🔴 CARRIED SO AN AUTHORING SURFACE CAN REACH THE TRANSFER VERDICT UP FRONT. A
+   * 🔴 CARRIED SO THE AUTHORING SURFACE CAN REACH THE TRANSFER VERDICT UP FRONT. A
    * connect-linked off-site listing can never be transferred
    * ({@link refusesTransferForConnectClient}), and without this field the Collaborators
    * tab could not know that until the mutation came back refused — so it rendered an
@@ -793,13 +819,6 @@ export type MyAppListing = {
    * `AppCollaboratorsPanelView`, and the server gate is unchanged and still authoritative.
    */
   connectClientId: string | null;
-  role: AppRole;
-  /**
-   * 🔴 DERIVED FROM THE KIND, at the same seam every gate derives it — never stored, and
-   * never widened per row. A surface that renders an action for a `false` capability is
-   * rendering a guaranteed 403.
-   */
-  capabilities: Readonly<Record<ListingCapability, boolean>>;
 };
 
 /** Hydrate {@link resolveAccessibleListingIds} into rows, newest listing first. */
@@ -810,15 +829,10 @@ async function hydrateMyAppListings(
   if (ids.allIds.length === 0) return [];
   const rows = await dbRead.appListing.findMany({
     where: { id: { in: ids.allIds } },
-    select: {
-      id: true,
-      slug: true,
-      name: true,
-      status: true,
-      kind: true,
-      appBlockId: true,
-      connectClientId: true,
-    },
+    // 🔴 NO `connectClientId` HERE, deliberately — see {@link AppListingAuthoringContext}.
+    // This is a LIST read reachable by an accepted editor; only the single-listing
+    // authoring read has a consumer for that column.
+    select: { id: true, slug: true, name: true, status: true, kind: true, appBlockId: true },
     orderBy: { serialId: 'desc' },
     take: limit,
   });
@@ -831,7 +845,6 @@ async function hydrateMyAppListings(
       status: string;
       kind: string;
       appBlockId: string | null;
-      connectClientId: string | null;
     }) => {
       const kind = r.kind as ListingKind;
       return {
@@ -841,7 +854,6 @@ async function hydrateMyAppListings(
         status: r.status,
         kind,
         appBlockId: r.appBlockId,
-        connectClientId: r.connectClientId,
         role: (ownedSet.has(r.id) ? 'owner' : 'editor') as AppRole,
         capabilities: capabilitiesForKind(kind),
       };
@@ -998,7 +1010,7 @@ export async function listMyAppListings(opts: {
 export async function getAppListingAuthoringContext(opts: {
   appListingId: string;
   userId: number;
-}): Promise<MyAppListing> {
+}): Promise<AppListingAuthoringContext> {
   const access = await resolveListingAccess(opts.appListingId, opts.userId);
   if (!access) {
     throw new TRPCError({ code: 'NOT_FOUND', message: 'App listing not found' });

--- a/src/server/services/blocks/app-ownership-transfer.service.ts
+++ b/src/server/services/blocks/app-ownership-transfer.service.ts
@@ -8,7 +8,10 @@ import {
 import { notifyAppCollaborator } from '~/server/services/blocks/app-collaborator-notify';
 import { grantAppRepoWrite, revokeAppRepoWrite } from '~/server/services/blocks/app-repo-access';
 import { newAppOwnershipTransferId } from '~/server/utils/app-block-ids';
-import { CONNECT_CLIENT_TRANSFER_REFUSAL } from '~/shared/constants/app-transfer.constants';
+import {
+  CONNECT_CLIENT_TRANSFER_REFUSAL,
+  refusesTransferForConnectClient,
+} from '~/shared/constants/app-transfer.constants';
 
 /**
  * App Listing COLLABORATORS — OWNERSHIP TRANSFER (owner initiates → recipient accepts).
@@ -130,18 +133,14 @@ function isLive(t: { status: string; expiresAt: Date }, now: Date): boolean {
 }
 
 /**
- * 🔴 THE ONE PREDICATE for "may this listing's ownership move?", written once so the
- * initiate-time check and the in-tx accept-time re-assert cannot drift apart.
+ * The predicate behind BOTH server gates below — and now behind the Collaborators tab's
+ * up-front disable as well.
  *
- * On-site listings are unaffected: their connect column is always null (an on-site
- * listing's OauthClient is reached through the AppBlock, and THAT one does move).
+ * 🔴 RE-EXPORTED FROM `shared/`, exactly like the message above and for the same reason:
+ * the tab has to reach the same verdict the server will, and it cannot import this module.
+ * See the definition for the shipped defect that moved it. One definition, three callers.
  */
-export function refusesTransferForConnectClient(listing: {
-  kind: string;
-  connectClientId: string | null;
-}): boolean {
-  return listing.kind === 'offsite' && listing.connectClientId != null;
-}
+export { refusesTransferForConnectClient };
 
 type OwnedListing = {
   appListingId: string;

--- a/src/shared/constants/app-transfer.constants.ts
+++ b/src/shared/constants/app-transfer.constants.ts
@@ -26,3 +26,28 @@ export const CONNECT_CLIENT_TRANSFER_REFUSAL =
   'This listing is linked to an OAuth application. Ownership transfer would either hand ' +
   'over that application’s credentials or split ownership between the listing and the ' +
   'client, so it is not available for connect listings. Unlink the OAuth client first.';
+
+/**
+ * 🔴 THE ONE PREDICATE for "may this listing's ownership move?", written once so the
+ * initiate-time check, the in-tx accept-time re-assert, and the COLLABORATORS TAB cannot
+ * drift apart.
+ *
+ * On-site listings are unaffected: their connect column is always null (an on-site
+ * listing's OauthClient is reached through the AppBlock, and THAT one does move).
+ *
+ * 🔴 IT MOVED HERE FROM `app-ownership-transfer.service.ts`, FOR THE SAME REASON THE
+ * MESSAGE ABOVE DID, and the reason is a shipped defect rather than tidiness. The
+ * Collaborators tab needs this verdict BEFORE the owner picks a recipient — otherwise the
+ * transfer control renders enabled on a listing the server will always refuse, and the
+ * owner learns that only after choosing someone. The tab cannot import the service (its
+ * module graph reaches the database client), so the choice was "a second copy of the rule
+ * in the component" or "one copy both sides import". A second copy is how the UI and the
+ * server end up disagreeing about who may transfer. The service RE-EXPORTS this, so every
+ * existing server-side import keeps working and there is still only one definition.
+ */
+export function refusesTransferForConnectClient(listing: {
+  kind: string;
+  connectClientId: string | null;
+}): boolean {
+  return listing.kind === 'offsite' && listing.connectClientId != null;
+}

--- a/src/shared/constants/app-transfer.constants.ts
+++ b/src/shared/constants/app-transfer.constants.ts
@@ -14,18 +14,32 @@
 
 /**
  * The message a connect-linked off-site listing is refused with, at initiate AND again
- * in-transaction at accept. Asserted verbatim on both sides.
+ * in-transaction at accept — and, since the tab learned to refuse up front, the banner an
+ * owner reads on every visit to the Collaborators tab of such a listing.
  *
- * 🔴 IT NAMES A REMEDY. Moving an off-site listing that carries an `OauthClient` would
- * either hand over live credentials the recipient never asked for, or split ownership
- * between the listing and the client. Both are refused; "unlink the OAuth client first"
- * is the one thing the owner can actually do about it, so the UI must not swallow this
- * into a generic error.
+ * 🔴 IT STATES A CONSTRAINT AND DOES NOT INSTRUCT. It used to end "Unlink the OAuth client
+ * first", and that sentence was WRONG about this product: there is no unlink path.
+ * `connectClientId` is REQUIRED at submit (`submitExternalListingSchema`, `z.string()
+ * .min(1).max(64)`), it is immutable on edit (`offsite-listing.service::…` says so in as
+ * many words), and the only writer of `connectClientId: null` anywhere in `src/server` is
+ * `app-listing-mapper.ts`, which MINTS a listing from an AppBlock rather than unlinking an
+ * existing one. So the remedy named an action the owner could not take.
+ *
+ * 🔴 THAT WAS SURVIVABLE WHILE THE STRING ONLY APPEARED AFTER A FAILED MUTATION, AND IS
+ * NOT NOW. Promoting the refusal to an always-on banner promotes a false instruction to an
+ * always-on instruction — a permanent dead end, on a surface whose whole purpose is to
+ * stop the owner wasting effort. Nothing points at support or docs either: inventing a
+ * "contact support" route would swap one unverified promise for another.
+ *
+ * 🔴 IT IS READ IN TWO PLACES AND MUST PARSE IN BOTH — as a tRPC error message at the API,
+ * and as banner prose in the tab. Keep it a single self-contained sentence for that reason.
+ * Adding a remedy later is a PRODUCT change (an unlink flow) and belongs with the code that
+ * implements it, not here.
  */
 export const CONNECT_CLIENT_TRANSFER_REFUSAL =
-  'This listing is linked to an OAuth application. Ownership transfer would either hand ' +
-  'over that application’s credentials or split ownership between the listing and the ' +
-  'client, so it is not available for connect listings. Unlink the OAuth client first.';
+  'This listing is linked to an OAuth application, so its ownership cannot be transferred: ' +
+  'moving it would either hand over that application’s credentials or split ownership ' +
+  'between the listing and the client.';
 
 /**
  * 🔴 THE ONE PREDICATE for "may this listing's ownership move?", written once so the

--- a/src/tests/pages/apps/listing-collaborators-transfer.browser.test.tsx
+++ b/src/tests/pages/apps/listing-collaborators-transfer.browser.test.tsx
@@ -5,6 +5,7 @@ import { renderWithProviders } from '../../../../test/component-setup';
 import { useRouter } from 'next/router';
 import { CONNECT_CLIENT_TRANSFER_REFUSAL } from '~/shared/constants/app-transfer.constants';
 import { capabilitiesForKind } from '~/shared/constants/app-capabilities.constants';
+import { constants } from '~/server/common/constants';
 import type * as TrpcModule from '~/utils/trpc';
 
 /**
@@ -437,6 +438,35 @@ describe('🔴 THE CONTROL ARM — an OFF-SITE listing with NO connect client', 
     // Absence, with the awaited present element above as its positive control.
     expect(page.getByTestId('apps-transfer-blocked').elements()).toHaveLength(0);
     expect(page.getByTestId('apps-transfer-picker-disabled').elements()).toHaveLength(0);
+  });
+
+  /**
+   * 🔴 THE POSITIVE CONTROL FOR THE SUPPRESSION TEST, and its absence was a real hole.
+   *
+   * The refused arm asserts the expiry copy is NOT rendered. Nothing anywhere asserted it
+   * is EVER rendered — so DELETING the block outright left the whole suite green, and the
+   * negative assertion could not distinguish "correctly suppressed when refused" from
+   * "this helper text no longer exists for anybody".
+   *
+   * 🔴 THE INVERSION MUTANT DOES NOT COVER THIS. "Stop suppressing" and "delete entirely"
+   * fail in OPPOSITE directions: a suite that catches one is structurally blind to the
+   * other, which is why the deletion mutant survived a battery that killed the inversion.
+   * A negative assertion is only meaningful next to a positive one on the same string.
+   */
+  test('…and the transfer helper copy DOES render on a listing that can transfer', async () => {
+    state.context = contextFor({ kind: 'offsite', connectClientId: null });
+    renderWithProviders(<AppListingEditPage />);
+
+    const section = page.getByTestId('apps-transfer-owner-section');
+    await expect.element(section).toBeInTheDocument();
+    await expect.element(section).toHaveTextContent(/One transfer offer at a time/i);
+    // The expiry figure comes from `constants`, so pin that it is interpolated at all
+    // rather than left as a literal — the sentence is only useful with a number in it.
+    await expect
+      .element(section)
+      .toHaveTextContent(
+        new RegExp(`expires after\\s*${constants.appCollaborators.transferExpiryDays}\\s*days`, 'i')
+      );
   });
 });
 

--- a/src/tests/pages/apps/listing-collaborators-transfer.browser.test.tsx
+++ b/src/tests/pages/apps/listing-collaborators-transfer.browser.test.tsx
@@ -24,11 +24,20 @@ import type * as TrpcModule from '~/utils/trpc';
  *
  * 🔴 SO NOTHING HERE PASSES A TRANSFER PROP. Every arm sets ONE thing — the
  * `connectClientId` on the authoring-context payload — and then asserts what the owner
- * sees. The whole chain is real: the page reads the payload, hands the two listing facts
- * to the container, the container forwards them, and the View asks
- * `refusesTransferForConnectClient` — the SAME predicate the service gates on. Break any
- * link of that chain and these tests go red, which is exactly what the props-only suite
- * could not do.
+ * sees. The chain from that payload down is real: the page reads it, hands the two listing
+ * facts to the container, the container forwards them, and the View asks
+ * `refusesTransferForConnectClient`, the SAME predicate the service gates on.
+ *
+ * 🔴 WHAT THIS SUITE DOES **NOT** COVER, stated exactly, because an earlier version of this
+ * comment claimed "break any link of that chain and these tests go red" and that was
+ * measurably false. The payload comes from the local `contextFor()` fixture below, NOT from
+ * the server — so the `tRPC proc → payload` hop is OUT of frame here, and deleting
+ * `connectClientId` from `getAppListingAuthoringContext` leaves this file at 10 passed.
+ * That hop is covered by its own suite
+ * (`src/server/services/blocks/__tests__/app-access.authoring-context-connect-client.test.ts`,
+ * whose Prisma fake projects through the `select`) and, since the page's `AuthoringContext`
+ * is now an alias of the service's own return type rather than a hand-written duplicate,
+ * by `tsc`. Three instruments, three hops; no one of them sees all of it.
  *
  * 🔴 AND THE CONTROL ARM IS NOT OPTIONAL. "Disable the transfer section" satisfies the
  * positive arm on its own, and would ship a panel where nobody can ever transfer
@@ -277,7 +286,19 @@ describe('🔴 an OFF-SITE listing WITH a connect client — refused UP FRONT', 
     // Verbatim against the SERVER's own constant — a paraphrase here would let the two
     // sides drift, which is the whole reason the string lives in `shared/`.
     await expect.element(blocked).toHaveTextContent(CONNECT_CLIENT_TRANSFER_REFUSAL);
-    await expect.element(blocked).toHaveTextContent(/Unlink the OAuth client first/i);
+    // 🔴 `/split ownership/i` and NOT `/cannot be transferred/i`, which would be a
+    // TAUTOLOGY: this Alert's own `title` prop reads "Ownership cannot be transferred for
+    // this app", so that regex matches the chrome whatever the message says. Caught by
+    // running this file against the previous branch tip, where the assertion passed
+    // against the OLD constant. Match on the message BODY, which the title cannot supply.
+    await expect.element(blocked).toHaveTextContent(/split ownership/i);
+    // 🔴 AND IT INSTRUCTS NOTHING THE OWNER CANNOT DO. This banner is now PERMANENT on a
+    // connect-linked listing, so a false remedy would be a permanent false remedy — there
+    // is no unlink path in the product (`connectClientId` is required at submit and
+    // immutable on edit). Pinned on the RENDERED text, not just the constant, because this
+    // surface is what made the difference between "a wrong sentence in an error" and "a
+    // wrong sentence on every visit".
+    await expect.element(blocked).not.toHaveTextContent(/unlink/i);
   });
 
   /**
@@ -317,6 +338,21 @@ describe('🔴 an OFF-SITE listing WITH a connect client — refused UP FRONT', 
   });
 
   /**
+   * …but the section does NOT keep reciting the mechanics of a transfer that can never
+   * start. "One transfer offer at a time. It expires after N days if it is not accepted"
+   * is reassuring, specific and irrelevant here — the combination most easily read as
+   * "so a transfer IS possible, I just have to find the button".
+   */
+  test('the one-offer-at-a-time expiry copy is suppressed', async () => {
+    state.context = contextFor({ kind: 'offsite', connectClientId: 'oc_linked' });
+    renderWithProviders(<AppListingEditPage />);
+
+    const section = page.getByTestId('apps-transfer-owner-section');
+    await expect.element(section).toBeInTheDocument();
+    await expect.element(section).not.toHaveTextContent(/One transfer offer at a time/i);
+  });
+
+  /**
    * 🔴 THE REFUSAL ARRIVES WITHOUT A MUTATION ERROR — which is the entire fix. The
    * mutation-error panel (`apps-transfer-owner-error`) is the OLD route to this message,
    * and it must still be empty: nothing has been submitted, and nothing can be.
@@ -328,6 +364,54 @@ describe('🔴 an OFF-SITE listing WITH a connect client — refused UP FRONT', 
     await expect.element(page.getByTestId('apps-transfer-blocked')).toBeInTheDocument();
     expect(page.getByTestId('apps-transfer-owner-error').elements()).toHaveLength(0);
     expect(state.initiateCalls).toEqual([]);
+  });
+});
+
+describe('🔴 a LIVE OFFER on a connect-linked listing — dead on accept, and said so', () => {
+  /**
+   * 🔴 A REAL CO-EXISTING STATE, NOT A HYPOTHETICAL. `app-ownership-transfer.service`
+   * re-asserts the connect-client refusal IN-TRANSACTION at accept precisely because "a
+   * revision approve can link a client while the offer sits open" — so a listing can carry
+   * a live `pending` offer AND be un-transferable at the same time.
+   *
+   * Before this arm existed the tab rendered "ownership cannot be transferred" directly
+   * above a "Transfer pending → Cancel transfer" card, with nothing saying which one won.
+   * The offer is dead on accept, and the recipient will hit the refusal with no warning.
+   *
+   * 🔴 THIS IS ALSO THE ARM THAT KILLS A MUTANT THAT PREVIOUSLY SURVIVED THE WHOLE SUITE:
+   * gating the verdict on `pendingTransfer == null` passed all 40 tests, because every
+   * other arm here has no pending offer. A guard nothing exercises in this state is a
+   * guard that can be silently removed in this state.
+   */
+  test('the refusal, a dead-offer notice, and a still-usable Cancel all render together', async () => {
+    state.context = contextFor({ kind: 'offsite', connectClientId: 'oc_linked' });
+    state.pendingTransfer = { id: 'aot_live', toUserId: 42, expiresAt: new Date() };
+    renderWithProviders(<AppListingEditPage />);
+
+    // The verdict still applies while an offer is open…
+    await expect.element(page.getByTestId('apps-transfer-blocked')).toBeInTheDocument();
+    // …the owner is told the open offer is now dead…
+    const dead = page.getByTestId('apps-transfer-pending-dead');
+    await expect.element(dead).toBeInTheDocument();
+    await expect.element(dead).toHaveTextContent(/can no longer be accepted/i);
+    // …and Cancel — the only way out of a stale offer — is present and NOT disabled.
+    await expect.element(page.getByTestId('apps-transfer-cancel')).toBeEnabled();
+  });
+
+  /**
+   * The control for the arm above: with an offer open and NO client, the pending card is
+   * ordinary. Without this, "always render the dead-offer notice" would satisfy the test
+   * above — the same over-reach the enabled-picker control arm guards against.
+   */
+  test('CONTROL — an offer on a listing with no client shows no dead-offer notice', async () => {
+    state.context = contextFor({ kind: 'offsite', connectClientId: null });
+    state.pendingTransfer = { id: 'aot_live', toUserId: 42, expiresAt: new Date() };
+    renderWithProviders(<AppListingEditPage />);
+
+    await expect.element(page.getByTestId('apps-transfer-pending')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-transfer-cancel')).toBeEnabled();
+    expect(page.getByTestId('apps-transfer-pending-dead').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-transfer-blocked').elements()).toHaveLength(0);
   });
 });
 

--- a/src/tests/pages/apps/listing-collaborators-transfer.browser.test.tsx
+++ b/src/tests/pages/apps/listing-collaborators-transfer.browser.test.tsx
@@ -1,0 +1,392 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../../test/component-setup';
+import { useRouter } from 'next/router';
+import { CONNECT_CLIENT_TRANSFER_REFUSAL } from '~/shared/constants/app-transfer.constants';
+import { capabilitiesForKind } from '~/shared/constants/app-capabilities.constants';
+import type * as TrpcModule from '~/utils/trpc';
+
+/**
+ * OWNERSHIP TRANSFER, DRIVEN FROM LISTING DATA — the `/apps/listing/<id>/edit`
+ * Collaborators tab, end to end from the `getAuthoringContext` payload.
+ *
+ * 🔴 THIS SUITE EXISTS BECAUSE THE PANEL WAS VERIFIED IN ISOLATION AND THE DEFECT LIVED
+ * IN THE SEAM. `AppCollaboratorsPanelView.browser.test.tsx` proves the connect-client
+ * refusal RENDERS — by handing `transferErrorMessage={CONNECT_CLIENT_TRANSFER_REFUSAL}`
+ * in as a prop. That is a true statement about the View and says nothing whatsoever about
+ * whether the app can ever REACH that state, and it could not: `transferErrorMessage` is
+ * only ever set from a MUTATION ERROR, so the owner of a connect-linked off-site listing
+ * saw an ordinary enabled recipient picker, chose someone, submitted, and learned only
+ * then that the server refuses this listing every time. Measured on production: three of
+ * the four off-site listings carry a `connect_client_id`, and the transfer section
+ * rendered byte-identically on all of them and on a listing with no client at all.
+ *
+ * 🔴 SO NOTHING HERE PASSES A TRANSFER PROP. Every arm sets ONE thing — the
+ * `connectClientId` on the authoring-context payload — and then asserts what the owner
+ * sees. The whole chain is real: the page reads the payload, hands the two listing facts
+ * to the container, the container forwards them, and the View asks
+ * `refusesTransferForConnectClient` — the SAME predicate the service gates on. Break any
+ * link of that chain and these tests go red, which is exactly what the props-only suite
+ * could not do.
+ *
+ * 🔴 AND THE CONTROL ARM IS NOT OPTIONAL. "Disable the transfer section" satisfies the
+ * positive arm on its own, and would ship a panel where nobody can ever transfer
+ * anything. A listing with NO client must still render an ENABLED picker; that arm is
+ * how the defect was found in the first place (an off-site listing without a client
+ * rendering the same as one with a client is what proved the copy was not client-aware),
+ * so it is pinned here with equal weight.
+ */
+
+type AuthoringContext = {
+  appListingId: string;
+  slug: string;
+  name: string;
+  status: string;
+  kind: 'onsite' | 'offsite';
+  appBlockId: string | null;
+  connectClientId: string | null;
+  role: string;
+  capabilities: Readonly<Record<string, boolean>>;
+};
+
+const state = vi.hoisted(() => ({
+  /** The `getAuthoringContext` payload — THE ONLY THING ANY ARM VARIES. */
+  context: null as unknown,
+  /** Roster rows `appCollaborators.list` returns. Empty everywhere here. */
+  rows: [] as unknown[],
+  /** A live outgoing offer, or null. Null everywhere here (the picker is the subject). */
+  pendingTransfer: null as unknown,
+  /** Every `initiateTransfer.mutate` call. MUST stay empty — nothing here submits. */
+  initiateCalls: [] as unknown[],
+  /**
+   * The props the REAL recipient picker was mounted with, or null if it never mounted.
+   * `null` is the assertion that matters on a refused listing: the control is not merely
+   * greyed out, it is not in the tree, so no path through it can fire the mutation.
+   */
+  transferPickerProps: null as null | { disabled?: boolean; placeholder?: string },
+  flags: { appBlocks: true } as Record<string, boolean>,
+}));
+
+// The page's `getServerSideProps` calls createServerSideProps at module top — stub it so
+// importing the page in a browser test doesn't pull the server graph (and `sharp`).
+vi.mock('~/server/utils/server-side-helpers', () => ({
+  createServerSideProps: () => async () => ({ props: {} }),
+}));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => state.flags,
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ id: 10, username: 'owner' }),
+}));
+
+vi.mock('~/components/AppLayout/NotFound', () => ({
+  NotFound: () => <div data-testid="not-found">Not found</div>,
+}));
+
+// `Meta` reads the app-wide BrowserRouter context, which `renderWithProviders`
+// deliberately does not mount. It contributes nothing to this suite's subject.
+vi.mock('~/components/Meta/Meta', () => ({
+  Meta: () => null,
+}));
+
+vi.mock('~/utils/notifications', () => ({
+  showSuccessNotification: vi.fn(),
+  showErrorNotification: vi.fn(),
+}));
+
+/**
+ * 🔴 THE RECIPIENT PICKER STUB, AND IT HONOURS ITS INPUT. It renders a REAL `<input>`
+ * carrying the `disabled` it was handed, so "the picker is usable" is read off the DOM
+ * rather than off a prop we captured — and it records its props, so a test can tell "not
+ * mounted" from "mounted and disabled". A stub that ignored `disabled` would make the
+ * control arm vacuous.
+ *
+ * Stubbing it is also what makes importing the page possible at all: the real
+ * `QuickSearchDropdown` reaches a Meilisearch client that reads its host URL AT IMPORT
+ * TIME and throws.
+ */
+vi.mock('~/components/Search/QuickSearchDropdown', () => ({
+  QuickSearchDropdown: (props: { disabled?: boolean; placeholder?: string }) => {
+    // The TRANSFER picker is the one whose placeholder names an owner; the invite picker
+    // uses different copy. Only the transfer one is the subject here.
+    const isTransfer = (props.placeholder ?? '').includes('should own this app');
+    if (isTransfer) state.transferPickerProps = props;
+    return (
+      <input
+        readOnly
+        disabled={props.disabled}
+        aria-label={props.placeholder}
+        placeholder={props.placeholder}
+        data-testid={isTransfer ? 'stub-transfer-picker' : 'stub-invite-picker'}
+      />
+    );
+  },
+}));
+
+vi.mock('~/components/UserAvatar/UserAvatar', () => ({
+  UserAvatar: ({ userId }: { userId: number }) => <span>user:{userId}</span>,
+}));
+
+// The other tabs' bodies — never rendered here (`?tab=collaborators`), stubbed only to
+// keep their module graphs out of the browser build.
+vi.mock('~/components/Apps/AppsSubmitEditView', () => ({
+  AppsListingDetailsEditor: () => <div data-testid="stub-details" />,
+}));
+vi.mock('~/components/Apps/ListingMediaEditor', () => ({
+  ListingMediaEditor: () => <div data-testid="stub-media" />,
+}));
+vi.mock('~/components/Apps/ManifestEditForm', () => ({
+  ManifestEditForm: () => <div data-testid="stub-manifest" />,
+}));
+vi.mock('~/components/Apps/AppEarningsPanel', () => ({
+  AppEarningsPanel: () => <div data-testid="stub-earnings" />,
+}));
+
+// Spread the REAL module and override only `trpc` (per `local-rules/no-wholesale-module-mock`):
+// a hand-written replacement silently drops any export a transitive importer needs, and the
+// whole file then fails to load as "0 tests collected" — green for the worst possible reason.
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof TrpcModule>();
+  const mutation = (record?: (args: unknown) => void) => ({
+    useMutation: () => ({
+      mutate: (args: unknown) => record?.(args),
+      isPending: false,
+    }),
+  });
+  return {
+    ...actual,
+    trpc: {
+      useUtils: () => ({
+        appCollaborators: {
+          list: { invalidate: vi.fn().mockResolvedValue(undefined) },
+          getPendingTransfer: { invalidate: vi.fn().mockResolvedValue(undefined) },
+        },
+      }),
+      appListings: {
+        getAuthoringContext: {
+          useQuery: () => ({
+            data: state.context,
+            isLoading: state.context == null,
+            error: null,
+          }),
+        },
+      },
+      appCollaborators: {
+        list: { useQuery: () => ({ data: state.rows, isLoading: false, error: null }) },
+        getPendingTransfer: {
+          useQuery: () => ({ data: state.pendingTransfer, isLoading: false, error: null }),
+        },
+        invite: mutation(),
+        remove: mutation(),
+        setDisplayed: mutation(),
+        leave: mutation(),
+        // 🔴 Recorded, and asserted EMPTY. A refused listing must not be able to submit.
+        initiateTransfer: mutation((args) => state.initiateCalls.push(args)),
+        cancelTransfer: mutation(),
+      },
+    },
+  };
+});
+
+const AppListingEditPage = (await import('~/pages/apps/listing/[appListingId]/edit')).default;
+
+const LISTING_ID = 'apl_transfer';
+
+function contextFor(over: Partial<AuthoringContext>): AuthoringContext {
+  const kind = over.kind ?? 'offsite';
+  return {
+    appListingId: LISTING_ID,
+    slug: 'my-app',
+    name: 'My App',
+    status: 'approved',
+    kind,
+    appBlockId: kind === 'onsite' ? 'ab_1' : null,
+    connectClientId: null,
+    role: 'owner',
+    capabilities: capabilitiesForKind(kind),
+    ...over,
+  };
+}
+
+/** Point the mocked router at the Collaborators tab of this listing. */
+function openCollaboratorsTab() {
+  const router = (useRouter as unknown as () => { query: Record<string, string> })();
+  router.query.appListingId = LISTING_ID;
+  router.query.tab = 'collaborators';
+}
+
+beforeEach(() => {
+  state.context = null;
+  state.rows = [];
+  state.pendingTransfer = null;
+  state.initiateCalls = [];
+  state.transferPickerProps = null;
+  state.flags = { appBlocks: true };
+  openCollaboratorsTab();
+});
+
+describe('the authoring-context fake honours its input (positive control)', () => {
+  /**
+   * 🔴 THE FAKE'S OWN CONTROL, and it is deliberately NOT read through the feature under
+   * test. Every arm below distinguishes itself by ONE field on the payload this mock
+   * returns; if the mock served a frozen listing regardless, the positive arm and the
+   * control arm would be reading the same shape and both could pass for reasons unrelated
+   * to the code.
+   *
+   * So: prove the payload REACHES the page and VARIES, using a rendered fact this PR does
+   * not touch — the invite disclosure, which promises code/version access on an ON-SITE
+   * listing and must not on an OFF-SITE one. Two payloads in, two different renders out.
+   */
+  test('the payload reaches the page and different payloads render differently', async () => {
+    state.context = contextFor({ kind: 'onsite', connectClientId: null });
+    renderWithProviders(<AppListingEditPage />);
+    await expect
+      .element(page.getByTestId('apps-collaborators-invite-disclosure'))
+      .toHaveTextContent(/Push code/i);
+  });
+
+  test('…and the off-site payload renders the other way (same assertion, other shape)', async () => {
+    state.context = contextFor({ kind: 'offsite', connectClientId: null });
+    renderWithProviders(<AppListingEditPage />);
+    const disclosure = page.getByTestId('apps-collaborators-invite-disclosure');
+    await expect.element(disclosure).toBeInTheDocument();
+    await expect.element(disclosure).not.toHaveTextContent(/Push code/i);
+  });
+
+  /** And the field this PR turns on is genuinely different between the two shapes. */
+  test('the two listing shapes differ in connectClientId', () => {
+    expect(contextFor({ connectClientId: 'oc_linked' }).connectClientId).toBe('oc_linked');
+    expect(contextFor({ connectClientId: null }).connectClientId).toBeNull();
+  });
+});
+
+describe('🔴 an OFF-SITE listing WITH a connect client — refused UP FRONT', () => {
+  /**
+   * The regression test. NO transfer prop is passed anywhere; the only input is the
+   * listing's own `connectClientId` on the payload the page fetches.
+   */
+  test('the refusal is on screen before the owner picks anyone, with the server’s reason', async () => {
+    state.context = contextFor({ kind: 'offsite', connectClientId: 'oc_linked' });
+    renderWithProviders(<AppListingEditPage />);
+
+    const blocked = page.getByTestId('apps-transfer-blocked');
+    await expect.element(blocked).toBeInTheDocument();
+    // Verbatim against the SERVER's own constant — a paraphrase here would let the two
+    // sides drift, which is the whole reason the string lives in `shared/`.
+    await expect.element(blocked).toHaveTextContent(CONNECT_CLIENT_TRANSFER_REFUSAL);
+    await expect.element(blocked).toHaveTextContent(/Unlink the OAuth client first/i);
+  });
+
+  /**
+   * 🔴 STATE, NOT SPELLING. A text match on /client/i would be satisfied by any copy that
+   * happens to mention a client; this asserts the actual `disabled` attribute on the
+   * actual control that stands where the picker would be.
+   */
+  test('the recipient control is DISABLED, and the real picker is not mounted at all', async () => {
+    state.context = contextFor({ kind: 'offsite', connectClientId: 'oc_linked' });
+    renderWithProviders(<AppListingEditPage />);
+
+    // Positive control FIRST: the section is present, so the absence below is a real
+    // absence and not an un-awaited render. (`elements()` is synchronous.)
+    await expect.element(page.getByTestId('apps-transfer-owner-section')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-transfer-picker-disabled')).toBeDisabled();
+    expect(page.getByTestId('stub-transfer-picker').elements()).toHaveLength(0);
+    expect(state.transferPickerProps).toBeNull();
+  });
+
+  /**
+   * 🔴 THE SECTION IS DISABLED, NOT HIDDEN — a deliberate product choice. A vanished
+   * section leaves the owner wondering why transfer does not exist for their app, which
+   * is a different confusion rather than a smaller one. The heading and the disclosure
+   * stay, so the reason sits next to the thing it is about.
+   *
+   * INVARIANT GUARD, labelled: this PASSES on `origin/main` too, because main rendered
+   * the section as well (just enabled). It pins the disable-don't-hide decision against a
+   * future "simplify" that deletes the section, and is NOT regression coverage for the
+   * shipped defect — the three tests above are.
+   */
+  test('the section itself still renders — the refusal explains a control, not a void', async () => {
+    state.context = contextFor({ kind: 'offsite', connectClientId: 'oc_linked' });
+    renderWithProviders(<AppListingEditPage />);
+
+    await expect.element(page.getByTestId('apps-transfer-owner-section')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-transfer-owner-disclosure')).toBeInTheDocument();
+  });
+
+  /**
+   * 🔴 THE REFUSAL ARRIVES WITHOUT A MUTATION ERROR — which is the entire fix. The
+   * mutation-error panel (`apps-transfer-owner-error`) is the OLD route to this message,
+   * and it must still be empty: nothing has been submitted, and nothing can be.
+   */
+  test('no mutation error panel, and initiateTransfer is never called', async () => {
+    state.context = contextFor({ kind: 'offsite', connectClientId: 'oc_linked' });
+    renderWithProviders(<AppListingEditPage />);
+
+    await expect.element(page.getByTestId('apps-transfer-blocked')).toBeInTheDocument();
+    expect(page.getByTestId('apps-transfer-owner-error').elements()).toHaveLength(0);
+    expect(state.initiateCalls).toEqual([]);
+  });
+});
+
+describe('🔴 THE CONTROL ARM — an OFF-SITE listing with NO connect client', () => {
+  /**
+   * 🔴 AS IMPORTANT AS THE POSITIVE ARM. Without it, "disable the section" trivially
+   * satisfies everything above and ships a panel nobody can transfer from. This is also
+   * the arm that made the live diff meaningful: an off-site listing with no client
+   * rendering identically to one with a client is what proved the copy was not
+   * client-aware.
+   *
+   * PASSES ON `origin/main` TOO, and that is what a control arm is FOR rather than a
+   * weakness in it — main also rendered an enabled picker here. Its job is to go red the
+   * moment the fix over-reaches, which the mutation battery confirms it does.
+   */
+  test('the transfer picker is ENABLED and no refusal is shown', async () => {
+    state.context = contextFor({ kind: 'offsite', connectClientId: null });
+    renderWithProviders(<AppListingEditPage />);
+
+    const picker = page.getByTestId('stub-transfer-picker');
+    await expect.element(picker).toBeInTheDocument();
+    await expect.element(picker).toBeEnabled();
+    // Absence, with the awaited present element above as its positive control.
+    expect(page.getByTestId('apps-transfer-blocked').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-transfer-picker-disabled').elements()).toHaveLength(0);
+  });
+});
+
+describe('🔴 an ON-SITE listing — transfer stays available', () => {
+  /**
+   * On-site listings carry no `connectClientId` (their OauthClient is reached through the
+   * AppBlock, and THAT one does move with the app), so the refusal must never reach them.
+   */
+  test('the transfer picker is ENABLED and no refusal is shown', async () => {
+    state.context = contextFor({ kind: 'onsite', connectClientId: null });
+    renderWithProviders(<AppListingEditPage />);
+
+    const picker = page.getByTestId('stub-transfer-picker');
+    await expect.element(picker).toBeInTheDocument();
+    await expect.element(picker).toBeEnabled();
+    expect(page.getByTestId('apps-transfer-blocked').elements()).toHaveLength(0);
+  });
+
+  /**
+   * 🔴 THE KIND ARM OF THE PREDICATE, pinned against the SERVER's behaviour rather than
+   * against a guess. `refusesTransferForConnectClient` requires `kind === 'offsite'`, so
+   * an on-site row that somehow carried a client id is still transferable server-side —
+   * and the tab must agree with that, not invent a stricter rule of its own. A UI that
+   * refused here would block a transfer the server would have allowed.
+   *
+   * INVARIANT GUARD, labelled: this passes on `origin/main` too (nothing was disabled
+   * there). It is here to kill the "drop the kind check" mutation, not as regression
+   * coverage for the shipped defect.
+   */
+  test('a (hypothetical) on-site row carrying a client id is still transferable', async () => {
+    state.context = contextFor({ kind: 'onsite', connectClientId: 'oc_onsite' });
+    renderWithProviders(<AppListingEditPage />);
+
+    await expect.element(page.getByTestId('stub-transfer-picker')).toBeEnabled();
+    expect(page.getByTestId('apps-transfer-blocked').elements()).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## The defect

Open `/apps/listing/<appListingId>/edit?tab=collaborators` as the owner of an **off-site listing that carries a `connect_client_id`**. The "Transfer ownership" section renders an **enabled** recipient picker, identical to a listing where transfer *is* permitted. Choosing someone and submitting is the first time the owner learns it is refused.

The server is correct and stays correct: `refusesTransferForConnectClient` refuses at initiate (`app-ownership-transfer.service.ts`) and re-asserts it in-transaction at accept. Nothing transferable was ever at risk. **This is a UX defect, not a safety one** — the fix is an addition in front of the server gate, never a replacement.

### Measured live, with a control

I drove the real logged-in UI and diffed the raw DOM text of the transfer section across three listings:

| listing | kind | `connect_client_id` | transfer section |
|---|---|---|---|
| `radio` | off-site | **yes** | *"Transfer ownership / … / One transfer offer at a time…"* |
| `vitrine` | off-site | no (**control**) | byte-identical |
| `sensei` | on-site | no | byte-identical |

All three identical; no mention of a linked OAuth client anywhere. `vitrine` rendering the same as `radio` is what makes this evidence — without that arm, "radio looks normal" would prove nothing.

**Scope:** 3 of the 4 off-site listings in production carry a `connect_client_id`.

### Why the tests missed it — the part that must not repeat

`AppCollaboratorsPanelView.browser.test.tsx:550` passes `transferErrorMessage={CONNECT_CLIENT_TRANSFER_REFUSAL}` **in as a prop** and asserts it renders. That is a true statement about the View and says nothing about whether the app can ever **reach** that state — and it could not: `transferErrorMessage` is only ever set from a *mutation error*. Two hermetically-tested halves, and the defect living entirely in the join.

## The fix

**1. `connectClientId` did NOT reach the client.** `getAppListingAuthoringContext` selected `{ id, slug, name, status }` only, and `MyAppListing` had no such field — the component was structurally unable to know. Adding it to that read is part of this PR. The column is **public, not a secret**: the public listing-detail read (`ListingDetailKindData`) already exposes it and says so in a comment. It is read off the **seat (parent) row** — the same row `loadOwnedListing` reads — so the tab's verdict and the server's refusal look at one column on one row.

**2. One predicate, three callers.** `refusesTransferForConnectClient` moves to `shared/constants/app-transfer.constants.ts`, beside the message it produces, and the service **re-exports** it — exactly the pattern the constant already used, and for the same reason (the tab cannot import the service; its module graph reaches the database client). The alternative was a second copy of the rule in the component, which is how a UI and a server end up disagreeing about who may transfer.

**3. The View asks the predicate up front** and renders the refusal before the owner acts, reusing `CONNECT_CLIENT_TRANSFER_REFUSAL` verbatim — no second copy of the wording.

### Disable vs hide — I chose disabled, and here is why

**Disabled, with the reason shown, not hidden.** A vanished section leaves the owner wondering why ownership transfer does not exist for their app — that is a *different* confusion, not a smaller one, and it is unactionable in a way the refusal is not. The refusal names a concrete remedy ("unlink the OAuth client first"), and a remedy is only useful next to the thing it applies to. So the heading and the ownership disclosure stay, the message sits directly above the control, and the control is visibly off.

One nuance: the real picker is **unmounted**, not merely greyed out, with a disabled stand-in in its place. Greying out an injected `QuickSearchDropdown` would still leave a live component in the tree; unmounting means no path through it can fire the mutation, while the disabled stand-in preserves the "the control is here, and it is off" reading.

## Test coverage

**The central requirement — driven from listing data, not from a prop.** `src/tests/pages/apps/listing-collaborators-transfer.browser.test.tsx` renders the **real page**; every arm varies exactly one thing, `connectClientId` on the `getAuthoringContext` payload, and **no transfer prop is passed anywhere**. Page → container → View → shared predicate is all real.

### Red at base / green at HEAD (base = `b5ec2f8525`, measured in a clean worktree)

| test | at base | at HEAD |
|---|---|---|
| browser: the refusal is on screen before the owner picks anyone | 🔴 `Cannot find element with locator: getByTestId('apps-transfer-blocked')` | ✅ |
| browser: the recipient control is DISABLED, real picker not mounted | 🔴 `Cannot find element … getByTestId('apps-transfer-picker-disabled')` | ✅ |
| browser: no mutation error panel, `initiateTransfer` never called | 🔴 `Cannot find element … getByTestId('apps-transfer-blocked')` | ✅ |
| server: connect-linked off-site returns its client id | 🔴 `expected undefined to be 'oc_linked'` | ✅ |
| server: off-site with NO client returns **null**, not absent | 🔴 `expected undefined to be null` | ✅ |
| server: on-site returns null | 🔴 `expected undefined to be null` | ✅ |

Failing tests at base took ~15 s each (locator timeout) while every other test in the same run took ~50 ms — one inflated test per failed assertion, not a uniformly slow run, so these are real assertion failures rather than load flake.

**Labelled honestly as NOT regression coverage** (they pass at base, by design):
- the **control arm** — off-site with **no** client still renders an **enabled** picker. Without it, "disable the section" trivially satisfies everything above and would ship a panel nobody can ever transfer from. Mutant (b) below is what proves it earns its place.
- the **on-site** arms, including a hypothetical on-site row carrying a client id, which pins the predicate's `kind` arm against the *server's* behaviour rather than a stricter rule invented in the UI.
- "the section still renders" — an invariant guard for the disable-don't-hide decision.

### Mutation table — 7 mutants, 7 killed

| # | mutation | killed by | exact message |
|---|---|---|---|
| a | remove the branch (`refusedForConnectClient = false`) | 3 browser tests | `Cannot find element with locator: getByTestId('apps-transfer-blocked')` / `…('apps-transfer-picker-disabled')` |
| b | invert it (disable when there is **no** client) | **6** browser tests — incl. both control arms | `…getByTestId('apps-transfer-blocked')`, `…getByTestId('stub-transfer-picker')` |
| **c** | **the seam** — container drops `listing={listing}`, View's branch intact | 3 browser tests | `Cannot find element with locator: getByTestId('apps-transfer-blocked')` |
| d | server read drops `connectClientId: true` from its `select` | 3 server tests | `expected undefined to be 'oc_linked'` |
| e | server selects it but drops it from the returned DTO | 3 server tests | `expected undefined to be 'oc_linked'` |
| f | stand-in renders **enabled** (spelling unchanged, state changed) | 1 browser test | `expect(element).toBeDisabled()` — `Received element is not disabled` |
| g | predicate loses its `kind` arm | 1 browser test | `Cannot find element with locator: getByTestId('stub-transfer-picker')` |

(c) is the one that matters — it is the seam that actually failed here, and it is caught behaviourally rather than structurally. The tree was checksum-verified identical to its pre-mutation state afterwards, and (c) was **re-run after** the lint-driven change to the tRPC mock, since an audit fix resets the verification gate.

The remaining hop, page → container, is guarded **deterministically by `tsc`**: `listing` is a required prop. Verified by watching it go red — removing it from the page gives `TS2741: Property 'listing' is missing…`, rather than assumed.

### Assertions are state, not spelling
Every assertion pins a `data-testid` plus the real `disabled` attribute, or the verbatim server constant. Mutant (f) exists specifically to prove this: it changes only the disabled *state* while leaving all copy identical, and the suite still goes red.

### Absence assertions have positive controls
`locator.elements()` is synchronous, so every `toHaveLength(0)` is preceded by an **awaited present element** in the same render.

### The fakes honour their inputs
- The browser suite has a positive control proving the mocked payload **reaches the page and varies**, read through a rendered fact this PR does not touch (the invite disclosure differs on-site vs off-site) — plus a check that the two shapes really differ in `connectClientId`.
- The server suite's Prisma fake **projects through the `select`**: a column not asked for is genuinely absent. That is what makes mutant (d) killable; a canned fixture returning the whole row would have survived it. It has its own positive control asserting both shapes.
- The `QuickSearchDropdown` stub renders a real `<input>` carrying the `disabled` it was handed, so "usable" is read off the DOM, not off a captured prop.

## Verification run

- New browser suite: **10 executed, 10 passed** (`PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` set; count read from output, not an exit code).
- New server suite: 4 executed, 4 passed.
- No regressions in the neighbours: `AppCollaboratorsPanelView.browser.test.tsx` 30/30 (its prop-driven refusal test is untouched and still green), and 135/135 across `app-ownership-transfer.service` / `.seam` / `app-access.accessible-listings` / `app-access.call-site-ledger` — the existing `refusesTransferForConnectClient` import from the service still resolves through the re-export.
- `pnpm typecheck`: 0 errors. `tsc -p tsconfig.tests.json`: **875** errors, the known pre-existing repo-wide baseline, **0 of them in either new file**. (A bare `tsc --noEmit` OOMs at `rc=134` and reports a meaningless "0"; the count above comes from a run with the heap cap raised.)
- ESLint + Prettier clean on all 8 changed files. Both instruments were seen to go red first — Prettier on one file and ESLint on `local-rules/no-wholesale-module-mock`, which is why the tRPC mock spreads `importOriginal` instead of hand-writing the module.

## What I did not establish

- **The browser suite is ungated, not unrun.** `preview / component-tests` (the Tekton preview pipeline) does execute this layer and reads `success — Component suite passed (report-only)`. **Report-only means it cannot block a merge**, so the local runs above remain the substantive evidence — but an earlier version of this line said "local-only", which was false, and true only of the GitHub Actions `lint.yml` tier.
- I did **not** re-drive the live production UI after the change; the fix is verified against the real page component in a browser test, not against a deployed environment.
- **Whether an unlink flow is wanted** is a product question I deliberately did not answer — see the round-2 section on F1. The banner now states the constraint and points nowhere.
- The `tsconfig.tests.json` baseline of 875 is quoted from the documented figure and matched exactly at HEAD; I attributed via filename grep rather than by re-running the same command at base.
- `preview / component-tests` is intermittently red on an unrelated tooltip-hover timeout; that is pre-existing and not from this PR.

---

# Round 2 — adversarial audit follow-up

Audit verdict was **safe to merge, no 🔴**. Five 🟡s; three fixed, two corrected, plus two nits and one thing I found myself. **The previous round's green was not carried forward — the full battery was re-run.**

## F1 — the banner named a remedy that does not exist ✅ fixed

The message ended *"Unlink the OAuth client first."* **There is no unlink path.** I re-verified all three legs: `connectClientId` is **required** at submit (`submitExternalListingSchema`, `z.string().min(1).max(64)`), it is **immutable on edit**, and the only writer of `connectClientId: null` anywhere in `src/server` is `app-listing-mapper.ts`, which *mints* a listing from an AppBlock rather than unlinking one.

This was survivable while the string only appeared after a failed mutation. It is **not** survivable once this PR promotes it to an always-on banner — that turns a false instruction into a permanent one, on the very surface built to stop owners wasting effort.

**New wording** (works as a tRPC error message *and* as banner prose, which is why it stays one self-contained sentence):

> This listing is linked to an OAuth application, so its ownership cannot be transferred: moving it would either hand over that application's credentials or split ownership between the listing and the client.

**No support/docs pointer either.** Inventing a "contact support" route would swap one unverified promise for another; nobody has agreed such a route exists or resolves. Adding a remedy later is a **product change** (an unlink flow) and belongs with the code that implements it.

Pinned as a **negative** assertion — `not.toMatch(/unlink/i)` on the constant, `not.toHaveTextContent(/unlink/i)` on the rendered banner — so re-adding a remedy fails until the flow it names exists.

**This weakens my original disable-vs-hide argument, which leant on "the refusal names a concrete remedy".** Restating rather than quietly keeping it: a **permanent** constraint is *more* worth explaining in place than a temporary one. Hiding the section leaves the owner unable to even formulate the question — they see an app missing a control other apps have, with nothing on screen to name why. The disabled section with its reason is still the better of the two, but on a different argument than I first gave.

## F2 — unconsumed second widening ✅ reverted

Confirmed: nothing reads `MyAppListing.connectClientId` off `listMine`. Reverted `hydrateMyAppListings` to its original `select`.

`MyAppListing` keeps its old shape; the field now lives on a new type carried **only** by the read that has a consumer:

```ts
export type AppListingAuthoringContext = MyAppListing & { connectClientId: string | null };
```

This also removes the one new exposure the audit found: both reads are reachable by an accepted **editor**, so the widening had been handing seated collaborators the client_id of every listing they hold a seat on — including `draft` ones the public read does not expose yet. Low severity (public client_id, never the secret) and it bought nothing, which is exactly why it should not be paid. No consumer in mind; if a list surface ever needs it, widen then, with the consumer and a test.

Mutation row (d) is therefore **authoring-context only**, as the audit said.

## F5 — pending offer + connect-linked ✅ fixed and pinned

Reproduced the survivor: gating on `pendingTransfer == null` passed **all 40** tests.

The state is real — `acceptTransfer` re-asserts the refusal *in-transaction* precisely because "a revision approve can link a client while the offer sits open". The tab rendered "Ownership cannot be transferred" directly above a live "Transfer pending → Cancel transfer" card, with nothing saying which one won, and the recipient would have hit the refusal on accept with no warning.

**What it shows now:** the refusal banner stays, the pending card gains a dead-on-accept notice (*"This offer can no longer be accepted, because the listing is now linked to an OAuth application. Cancel it to tidy it up."*), and **Cancel stays enabled** — it is the owner's only way out of a stale offer, and `cancelTransfer` carries no connect-client gate, so withdrawing an offer that can never complete is exactly the action that should still work.

Pinned with a positive arm **and** its own control (offer + no client ⇒ no notice), so "always render the notice" cannot satisfy it.

## F4 — false comment ✅ corrected

The comment claimed *"break any link of that chain and these tests go red"*. Measurably false: the payload comes from the local `contextFor()` fixture, so the **proc → payload** hop is out of frame and deleting `connectClientId` from the service leaves that file at 10 passed. Replaced with an explicit statement of what the suite does **not** cover and which instrument covers each hop — three instruments, three hops, none seeing all of it.

## F3 — server → page hop ✅ fixed (it was cheap)

The page's `AuthoringContext` was a hand-written duplicate behind a `data as` cast, so `tsc` could not see the service drifting from it — **the hop the original bug lived on**. `import type` from a server service is an established pattern here (8+ pages do it) and is erased at runtime, so:

```ts
type AuthoringContext = AppListingAuthoringContext;
```

**Verified, not assumed:** mutant (l) reproduces the original defect's exact shape — drop the field from the server type and its return site — and now fails **at the page**: `edit.tsx(222,75): error TS2339: Property 'connectClientId' does not exist on type 'MyAppListing'`. The audit measured that same mutation passing `pnpm typecheck` clean.

## Nits ✅ both taken

- The recipient-picker placeholder had **two** copies in two files, in a PR whose thesis is one-copy discipline. Now one exported `TRANSFER_PICKER_PLACEHOLDER`.
- *"One transfer offer at a time. It expires after N days…"* no longer renders under the disabled stand-in. Reassuring, specific and irrelevant is the combination most easily read as "so a transfer **is** possible, I just have to find the button".

## Found while re-running the matrix, not reported by the audit

Two assertions used `/cannot be transferred/i` — which the Alert's own `title` prop already spells, so the regex matched the **chrome** regardless of the message. A tautology of exactly the kind this PR's own "assert state, not spelling" rule forbids. Caught because the assertion stayed green against the *old* constant at the previous tip. Both now assert on the message body (`/split ownership/i`).

## Re-run mutation table — 12 mutants, 12 killed

| # | mutation | killed by | exact message |
|---|---|---|---|
| a | remove the branch | 5 browser | `getByTestId('apps-transfer-blocked')` not found |
| b | invert it | **9** browser (incl. both controls) | `…('apps-transfer-blocked')`, `…('stub-transfer-picker')` |
| c | **seam** — container drops `listing={listing}` | 5 browser | `getByTestId('apps-transfer-blocked')` not found |
| d | authoring read drops `connectClientId` from `select` | 3 server | `expected undefined to be 'oc_linked'` |
| e | authoring read drops it from the returned DTO | 3 server | `expected undefined to be 'oc_linked'` |
| f | stand-in renders **enabled** | 1 browser | `expect(element).toBeDisabled()` — `Received element is not disabled` |
| g | predicate loses its `kind` arm | 1 browser | `getByTestId('stub-transfer-picker')` not found |
| **h** | **audit survivor** — gate verdict on `pendingTransfer == null` | 1 browser | `getByTestId('apps-transfer-blocked')` not found |
| i | drop the dead-offer notice | 1 browser | `getByTestId('apps-transfer-pending-dead')` not found |
| j | stop suppressing the expiry copy | 1 browser | `expect(element).not.toHaveTextContent()` |
| k | re-add "Unlink the OAuth client first" | 1 server | `expected 'This listing is linked to an OAuth ap…' not to match /unlink/i` |
| **l** | **the original defect's shape** — server type + return site lose the field | `tsc` | `TS2339: Property 'connectClientId' does not exist on type 'MyAppListing'` |

**The other audit survivor** — dropping `connectClientId` from `hydrateMyAppListings`'s `select` — is a **kill by deletion of the surface**: F2 removed that widening entirely, so the mutation has no target left.

Every mutant was re-confirmed **after** the last source edit (a Prettier reformat of the View), since an audit fix resets the gate. The tree was checksum-verified byte-identical to its pre-mutation state afterwards.

## Red at `0104a96288` / green at HEAD

| test | at previous tip | at HEAD |
|---|---|---|
| browser: dead-offer notice + refusal + usable Cancel (F5) | 🔴 `Cannot find element with locator: getByTestId('apps-transfer-pending-dead')` | ✅ |
| browser: the expiry copy is suppressed | 🔴 `expect(element).not.toHaveTextContent()` | ✅ |
| browser: the banner instructs nothing (`not … /unlink/i`) | 🔴 `expect(element).not.toHaveTextContent()` | ✅ |
| server: the message instructs no impossible action | 🔴 `expected 'This listing…' to match /cannot be transferred/i` | ✅ |

Labelled **control, not regression coverage** (passes at the previous tip by design): *"an offer on a listing with no client shows no dead-offer notice"* — it exists to stop the F5 fix over-reaching, and mutant (b) is what proves it earns its place.

## Verification totals

- Browser: **43 executed, 43 passed** (13 in the new page suite, up from 10; 30 in the panel suite) with `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` set.
- Unit: **177 files / 4333 tests, 0 failures** across `src/server/services/blocks` + `src/server/routers/__tests__` — the F2 revert breaks nothing.
- `pnpm typecheck` 0 errors; ESLint and Prettier clean on all changed files (both instruments were seen to go red first this round too).

## For the delta re-audit — where I would look hardest

1. **The new wording**, in both readings. It is now a tRPC error message *and* permanent banner prose. I checked both parse; I have not had a second pair of eyes on the phrasing.
2. **The dead-offer notice text is a second hardcoded string** describing the same constraint as `CONNECT_CLIENT_TRANSFER_REFUSAL`, deliberately not shared (it says something different — *this offer* is dead, not *transfer is unavailable*). That is a judgement call in a PR about one-copy discipline, and worth challenging.
3. **`AppListingAuthoringContext` is an intersection type.** Excess-property checking behaves differently through intersections than through a flat type; I verified mutant (l) fails at the page, but not every drift shape.
4. **Cancel-while-refused is asserted as rendered-and-enabled, never clicked.** I did not drive the cancel mutation in that state.

---

# Round 3 — delta re-audit follow-up

Delta re-audit of `0104a96288..5a2b5d96ef` came back **safe to merge, no 🔴**. Two 🟡s, both verified independently before acting; both taken, plus the optional 🟢.

## 🟡-1 — the suppression test had no positive control, and a **deletion** mutant survived ✅ fixed

Confirmed by my own grep: `"One transfer offer at a time"` appeared in exactly three places — the component, a comment, and my negative assertion. **Nothing asserted it ever renders.**

🔴 **My mutant (j) could never have caught this.** (j) is an *inversion* ("stop suppressing"); this is a *deletion*. They fail in **opposite directions**, so a suite that kills one is structurally blind to the other. The test could not distinguish "correctly suppressed when refused" from "this helper text no longer exists for anybody", and an edit dropping it from the **working** transfer flow would have shipped green.

**Measured both ways:**

| | deletion mutant (m) |
|---|---|
| with `5a2b5d96ef`'s test file | **survives — 43/43 green** |
| with the new assertion | **dies** — `expect(element).toHaveTextContent()` / `Expected element to have text content: /One transfer offer at a time/i` |

Added to the control arm, and the expiry figure is pinned as *interpolated* (`expires after N days`) rather than left as a literal — the sentence is only useful with a number in it. Battery is now **13 mutants**.

## 🟡-2 — a comment claimed a reach the code lacks ✅ fixed

Same class as F4, introduced by the round that fixed F4. I verified it: `AppTransferOffersView.tsx`, `AppTransferOffers.tsx` and `AppInvitesBody.tsx` contain **zero** OAuth/connect references. The comment now scopes itself to the owner and marks the recipient-side gap as **explicitly OPEN**, so it cannot be read as covered.

## 🟢-3 — taken

The notice's middle clause (*"because the listing is now linked to an OAuth application"*) restated the banner rendered a few lines above, in different words, under the **same** condition — the two always co-occur by construction, so it could only ever drift from it. Dropped. What the notice uniquely says is kept:

> This offer can no longer be accepted. Cancel it to tidy it up.

The co-occurrence the removal leans on is already pinned: the F5 test asserts `apps-transfer-blocked` **and** `apps-transfer-pending-dead` in the same render.

## Recipient-side gap — **confirmed**, reported not fixed

Your reading is correct. I traced it end to end: `initiateTransfer` refuses a connect-linked listing, so an offer can only exist on a listing that was unlinked at the time; a revision approve then promotes a shadow carrying `connectClientId` to the parent; `acceptTransfer` re-asserts at step **(1c)** and throws `INVALID_TARGET` with `CONNECT_CLIENT_TRANSFER_REFUSAL`. The recipient's surfaces have no connect-client awareness, so the addressee sees a normal-looking offer and meets the refusal only on clicking accept.

**It is the same learn-it-by-doing-the-work shape this PR fixes for the owner, on the other side of the wire.** Narrow (needs a client linked mid-window) and not built here.

## Re-run mutation table — 13 mutants, 13 killed

| # | mutation | killed by | exact message |
|---|---|---|---|
| a | remove branch | 5 browser | `getByTestId('apps-transfer-blocked')` not found |
| b | invert | **10** browser | `…('apps-transfer-blocked')`, `…('stub-transfer-picker')` |
| c | seam: container drops `listing` | 5 browser | `getByTestId('apps-transfer-blocked')` not found |
| d | authoring `select` drops column | 3 server | `expected undefined to be 'oc_linked'` |
| e | drops it from the DTO | 3 server | `expected undefined to be 'oc_linked'` |
| f | stand-in enabled | 1 browser | `expect(element).toBeDisabled()` — `Received element is not disabled` |
| g | predicate loses `kind` arm | 1 browser | `getByTestId('stub-transfer-picker')` not found |
| h | gate on `pendingTransfer == null` | 1 browser | `getByTestId('apps-transfer-blocked')` not found |
| i | drop dead-offer notice | 1 browser | `getByTestId('apps-transfer-pending-dead')` not found |
| j | **invert** the expiry suppression | 1 browser | `expect(element).not.toHaveTextContent()` |
| k | re-add "Unlink the OAuth client first" | 1 server | `expected 'This listing is linked to an OAuth ap…' not to match /unlink/i` |
| l | original defect shape (server type + return) | `tsc` | `TS2339: Property 'connectClientId' does not exist on type 'MyAppListing'` |
| **m** | **delete** the expiry copy entirely | 1 browser | `Expected element to have text content: /One transfer offer at a time/i` |

(j) and (m) are the same line in opposite directions and are both needed — that pairing is the lesson of this round.

## Red/green matrix — and one honest correction

**There is no red-at-base for the new assertion, and I did not manufacture one.** Measured: the new suite is **14/14 green against `5a2b5d96ef`'s source**, because that source renders the copy too. It is a **positive control**, not regression coverage — its job is to make the neighbouring negative assertion mean something, and **mutant (m) is what proves it earns its place**, not a base-red.

Everything from earlier rounds still holds; nothing was carried forward on trust — the full battery was re-run from scratch after every source edit this round.

## Verification totals

- Browser: **44 executed, 44 passed** (14 in the page suite, up from 13) with `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` set.
- Unit: **177 files / 4333 tests, 0 failures.**
- `pnpm typecheck` 0 errors; ESLint + Prettier clean.
- Tree checksum-verified byte-identical to its pre-mutation state after the battery.
- **CI on `5a2b5d96ef`: 13 checks, all settled, all pass** — including `preview / component-tests: pass`, which independently confirms the browser layer does execute in CI (report-only, so ungated).
