### PR TITLE
fix(dev-server): a session keeps its port until it is stopped

### DIFF
--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -324,6 +324,14 @@ What's already handled:
   session it marked `crashed`, or any other local server on loopback — is skipped rather than handed
   out. Passing an explicit port is no longer a workaround for that. It still cannot see a listener
   bound only to a non-loopback address (`next dev -H <lan-ip>`), which on Windows nothing detects.
+- **A session holds its port until it is stopped, whatever its status says.** Status is a report
+  about a process the daemon cannot see into: it has read `crashed` for a session that was alive and
+  serving, and it reads dead for the moment inside a restart between the kill and the rebind. So the
+  reservation follows the session, not the status, and `stop <session-id>` (which removes the
+  session) is what frees the port.
+- **`start` on a worktree that already has a session takes that session over**, restarting it on its
+  own port rather than leaving it stranded and picking a new one. `start` and `restart` are now the
+  same thing for an existing worktree; there is no longer a port to lose by picking the wrong one.
 
 Fresh worktrees still need `pnpm install` (or a `node_modules` junction) and `git submodule update --init event-engine-common`.
 

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -333,6 +333,12 @@ What's already handled:
   own port rather than leaving it stranded and picking a new one. `start` and `restart` are now the
   same thing for an existing worktree; there is no longer a port to lose by picking the wrong one.
 
+  Both check the port is actually free in the moment between the stop and the start, and move the
+  session to a new one if something else is holding it — an orphan of its own that outlived a kill,
+  or another local server. That check is not optional: `next dev` does **not** fail on an occupied
+  port, it warns and quietly moves to another, so a session started onto a held port would report a
+  `url` and pass a health check against a server it does not own.
+
 Fresh worktrees still need `pnpm install` (or a `node_modules` junction) and `git submodule update --init event-engine-common`.
 
 ### Cache cannot be shared between worktrees

--- a/.claude/skills/dev-server/console.mjs
+++ b/.claude/skills/dev-server/console.mjs
@@ -323,7 +323,14 @@ async function cmdDashboard(initialWorktree) {
       case 'r':
         flash('Restarting session...');
         try {
-          await daemonRequest(`/sessions/${sessionId}/restart`, { method: 'POST' });
+          // daemonRequest resolves for every response, so a refusal arrives here as ok:false.
+          // Reporting it as a restart would clear the log pane as confirmation of something that
+          // did not happen — pressing `r` during a restart is exactly when that reads as damage.
+          const restart = await daemonRequest(`/sessions/${sessionId}/restart`, { method: 'POST' });
+          if (!restart.ok) {
+            flash(restart.data?.error || `Restart refused (${restart.status})`);
+            break;
+          }
           logCursor = -1;
           logLines = [];
           flash('Session restarted');

--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -547,13 +547,36 @@ class DevSession {
       spawnOptions.detached = true;
     }
 
-    this.process = spawn(npmCmd, ['run', 'dev'], spawnOptions);
+    const proc = spawn(npmCmd, ['run', 'dev'], spawnOptions);
+    this.process = proc;
 
     this.startedAt = new Date().toISOString();
+    this.stoppedAt = null;
+    this.exitCode = null;
     this.status = 'running';
 
-    // Handle stdout
-    this.process.stdout.on('data', (data) => {
+    this.attachProcessHandlers(proc);
+
+    // Start health check polling if configured
+    if (healthCheckConfig.healthCheckUrl) {
+      this.startHealthCheck();
+    }
+
+    this.startBranchWatch();
+
+    return {
+      id: this.id,
+      port: this.port,
+      worktree: this.worktree,
+      branch: this.branch,
+      distDir: this.distDir,
+      status: this.status,
+      ready: this.ready,
+    };
+  }
+
+  attachProcessHandlers(proc) {
+    proc.stdout.on('data', (data) => {
       const lines = data.toString().split('\n').filter(l => l.trim());
       for (const line of lines) {
         this.addLog('stdout', line);
@@ -572,8 +595,7 @@ class DevSession {
       }
     });
 
-    // Handle stderr
-    this.process.stderr.on('data', (data) => {
+    proc.stderr.on('data', (data) => {
       const lines = data.toString().split('\n').filter(l => l.trim());
       for (const line of lines) {
         // Classify error levels
@@ -588,36 +610,35 @@ class DevSession {
       }
     });
 
-    // Handle exit
-    this.process.on('exit', (code, signal) => {
+    proc.on('exit', (code, signal) => {
+      this.addLog('info', `Process exited with code ${code}, signal ${signal}`);
+      // Only the process this session is currently running may move its state. stop() and
+      // start() both detach eagerly, so a kill that lands after either one belongs to a
+      // process the session has already let go of — reporting it would mark a live session
+      // crashed and leave a stale pid that Windows is free to hand to something else.
+      if (this.process !== proc) return;
+      this.process = null;
       this.exitCode = code;
       this.status = code === 0 ? 'stopped' : 'crashed';
       this.stoppedAt = new Date().toISOString();
-      this.addLog('info', `Process exited with code ${code}, signal ${signal}`);
       this.stopHealthCheck();
     });
 
-    this.process.on('error', (err) => {
+    proc.on('error', (err) => {
+      if (this.process !== proc) return;
       this.status = 'error';
       this.addLog('error', `Process error: ${err.message}`);
     });
+  }
 
-    // Start health check polling if configured
-    if (healthCheckConfig.healthCheckUrl) {
-      this.startHealthCheck();
-    }
-
-    this.startBranchWatch();
-
-    return {
-      id: this.id,
-      port: this.port,
-      worktree: this.worktree,
-      branch: this.branch,
-      distDir: this.distDir,
-      status: this.status,
-      ready: this.ready,
-    };
+  killProcessTree(proc) {
+    try {
+      if (process.platform === 'win32') {
+        spawn('taskkill', ['/pid', String(proc.pid), '/f', '/t'], { shell: true });
+      } else {
+        process.kill(-proc.pid, 'SIGKILL');
+      }
+    } catch (e) {}
   }
 
   startBranchWatch() {
@@ -881,21 +902,25 @@ class DevSession {
     this.stopHealthCheck();
     this.stopBranchWatch();
     this.prewarming = false;
-    if (!this.process) return;
+    const proc = this.process;
+    if (!proc) {
+      this.status = 'stopped';
+      this.ready = false;
+      return;
+    }
 
     this.addLog('info', 'Stopping dev server...');
 
-    return new Promise((resolve) => {
-      this.process.once('exit', resolve);
+    // Record the outcome before killing, not from the exit code. A hard kill exits nonzero,
+    // so reading the code would file every deliberate stop as a crash.
+    this.process = null;
+    this.ready = false;
+    this.status = 'stopped';
+    this.stoppedAt = new Date().toISOString();
 
-      // Hard kill immediately
-      try {
-        if (process.platform === 'win32') {
-          spawn('taskkill', ['/pid', String(this.process.pid), '/f', '/t'], { shell: true });
-        } else {
-          process.kill(-this.process.pid, 'SIGKILL');
-        }
-      } catch (e) {}
+    return new Promise((resolve) => {
+      proc.once('exit', resolve);
+      this.killProcessTree(proc);
 
       // Resolve after a short delay if process doesn't exit
       setTimeout(resolve, 500);
@@ -1347,12 +1372,16 @@ async function stopSpokeApps() {
 // Session manager
 const sessions = new Map();
 
+// A tracked session owns its port whatever its status says. Status is a report the daemon
+// writes about a process it cannot see into — it has read `crashed` for a session whose
+// process was alive and serving 200s, and it necessarily reads dead for the window inside
+// restart() between the kill and the rebind. Handing that port to another worktree in either
+// case produces an EADDRINUSE nobody can trace back to here. Membership of this map is the
+// reservation, and DELETE /sessions/:id (what `cli stop` sends) is the release.
 function getUsedPorts() {
   const ports = new Set();
   for (const session of sessions.values()) {
-    if (session.status === 'running' || session.status === 'starting') {
-      ports.add(session.port);
-    }
+    ports.add(session.port);
   }
   return ports;
 }
@@ -1635,6 +1664,22 @@ async function main() {
           return;
         }
 
+        // A dead session still holds its port, so starting this worktree again has to take that
+        // session over rather than strand it and pick a fresh port — otherwise every crash costs
+        // a port for the life of the daemon. Only when a different port is asked for is a second
+        // session created, and the old one keeps its reservation because its process may be alive.
+        if (existing && (!requestedPort || requestedPort === existing.port)) {
+          await existing.restart();
+
+          res.writeHead(200);
+          res.end(JSON.stringify({
+            existing: false,
+            reused: true,
+            session: existing.getStatus(),
+          }));
+          return;
+        }
+
         // Determine port
         const usedPorts = getUsedPorts();
         let port;
@@ -1734,10 +1779,18 @@ async function main() {
           await session.stop();
           sessions.delete(sessionId);
 
+          // Removing the session is what releases its port, so say plainly when something is
+          // still listening on it — a kill that missed an orphaned grandchild leaves a port the
+          // daemon no longer reserves and only the picker's probe stands between it and reuse.
+          const stillListening = !(await isPortFree(session.port));
+
           res.writeHead(200);
           res.end(JSON.stringify({
             success: true,
             id: sessionId,
+            ...(stillListening && {
+              warning: `Port ${session.port} still has a listener after stopping this session — a process outlived the kill.`,
+            }),
           }));
           return;
         }
@@ -1841,7 +1894,23 @@ async function main() {
   });
 }
 
-main().catch(err => {
-  console.error('Fatal error:', err);
-  process.exit(1);
-});
+// Importing this file must not start a daemon — the tests drive DevSession and the port
+// reservation directly, and a second daemon would fight the running one for its port.
+// Windows hands back whatever drive-letter case the caller typed, and a mismatch here would
+// look exactly like a daemon that starts and immediately does nothing.
+const samePath = (a, b) =>
+  process.platform === 'win32'
+    ? resolve(a).toLowerCase() === resolve(b).toLowerCase()
+    : resolve(a) === resolve(b);
+
+const invokedDirectly =
+  !!process.argv[1] && samePath(process.argv[1], fileURLToPath(import.meta.url));
+
+if (invokedDirectly) {
+  main().catch(err => {
+    console.error('Fatal error:', err);
+    process.exit(1);
+  });
+}
+
+export { DevSession, sessions, getUsedPorts };

--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -13,7 +13,7 @@
 
 import http from 'http';
 import { spawn, execSync } from 'child_process';
-import { existsSync, readFileSync, writeFileSync, unlinkSync, statSync, readdirSync, rmSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, unlinkSync, statSync, readdirSync, rmSync, realpathSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { randomBytes, createHash } from 'crypto';
@@ -159,6 +159,17 @@ function parseArgs() {
   }
 
   return config;
+}
+
+// Where the port scan starts. Set once from the parsed args so the session-side code paths — a
+// branch switch restarting itself, a session moved off a stolen port — can reach it too.
+let baseDevPort = DEFAULT_BASE_DEV_PORT;
+
+// Windows hands back whatever drive-letter and casing the caller typed.
+function samePath(a, b) {
+  return process.platform === 'win32'
+    ? resolve(a).toLowerCase() === resolve(b).toLowerCase()
+    : resolve(a) === resolve(b);
 }
 
 // Generate session ID
@@ -402,7 +413,13 @@ async function findAvailablePort(basePort, usedPorts = new Set()) {
   while (usedPorts.has(port) || !(await isPortFree(port))) {
     port++;
     if (port > basePort + 100) {
-      throw new Error('No available ports found within range');
+      // Reserved ports come back only when their session is stopped, so an agent reading this
+      // needs to be told that is the lever, not left to conclude the machine is out of ports.
+      const cli = 'node .claude/skills/dev-server/cli.mjs';
+      throw new Error(
+        `No available ports in ${basePort}-${basePort + 100}. ${usedPorts.size} are reserved by ` +
+          `tracked sessions — \`${cli} list\` shows them, \`${cli} stop <session-id>\` releases one.`
+      );
     }
   }
   return port;
@@ -547,6 +564,8 @@ class DevSession {
       spawnOptions.detached = true;
     }
 
+    this.detachRunningProcess();
+
     const proc = spawn(npmCmd, ['run', 'dev'], spawnOptions);
     this.process = proc;
 
@@ -573,6 +592,18 @@ class DevSession {
       status: this.status,
       ready: this.ready,
     };
+  }
+
+  // Anything still attached when a new process is about to take its place is a process this
+  // session is about to stop referring to, and the exit guard would then discard even its exit.
+  // Two starts can interleave — a branch switch restarting while a request takes the session over
+  // — and the loser would otherwise keep running, unreachable and holding the port, for the
+  // daemon's lifetime.
+  detachRunningProcess() {
+    if (!this.process) return;
+    this.addLog('warn', 'A process was still attached at start — killing it before replacing it');
+    this.killProcessTree(this.process);
+    this.process = null;
   }
 
   attachProcessHandlers(proc) {
@@ -638,7 +669,11 @@ class DevSession {
       } else {
         process.kill(-proc.pid, 'SIGKILL');
       }
-    } catch (e) {}
+    } catch (e) {
+      // A kill that fails leaves a server running while the session reports stopped, and that
+      // is only diagnosable if it is written down somewhere.
+      this.addLog('error', `Could not kill pid ${proc.pid}: ${e.message}`);
+    }
   }
 
   startBranchWatch() {
@@ -734,6 +769,10 @@ class DevSession {
       if (mustRestart) {
         await this.stop();
         this.restartCount++;
+        // Same check the request-driven restarts make. This one runs unattended, so a session
+        // silently coming back up on a port an orphan of its own still holds is the case nobody
+        // would be watching for.
+        await claimPortForReuse(this);
         this.switching = false;
         await this.start();
         return;
@@ -904,7 +943,9 @@ class DevSession {
     this.prewarming = false;
     const proc = this.process;
     if (!proc) {
-      this.status = 'stopped';
+      // An `error` session never had a process to stop; overwriting that with `stopped` would
+      // report a failed spawn as a clean shutdown.
+      if (this.status !== 'error') this.status = 'stopped';
       this.ready = false;
       return;
     }
@@ -927,13 +968,16 @@ class DevSession {
     });
   }
 
-  async restart() {
+  // `claimPort` runs between the stop and the start, which is the only moment the session's own
+  // process is gone and a probe of its port says something about anyone else.
+  async restart(claimPort) {
     await this.stop();
     this.restartCount++;
     this.logs = [];
     this.logIndex = 0;
     this.ready = false;
     this.readyAt = null;
+    if (claimPort) await claimPort(this);
     return this.start();
   }
 
@@ -1386,10 +1430,57 @@ function getUsedPorts() {
   return ports;
 }
 
+// Taking a session over means starting a server on the port that session owns, and its own
+// orphaned process may be the thing holding that port. `next dev` does not fail on a taken port —
+// it warns and moves to another one — so a session restarted onto an occupied port would report a
+// URL nothing of its own is serving, and the health check would go green against whatever is.
+//
+// A single probe cannot tell that apart from the session's own process still dying, and defaulting
+// to "stranger" is the destructive answer: it moves a healthy session off its port, which for the
+// primary session on 3000 silently unhooks the rgb-proxy (hardcoded to 3000) and rewrites the auth
+// URLs. Measured on this box, a killed listener releases the socket 630-668 ms after taskkill is
+// spawned, and stop() waits at most 500 ms — so the naive probe reads "held" on every restart. Wait
+// the port out instead, and move only when it stays held long past any plausible teardown.
+const PORT_RELEASE_TIMEOUT = 8000;
+const PORT_RELEASE_POLL = 250;
+
+async function claimPortForReuse(session, opts = {}) {
+  const timeoutMs = opts.timeoutMs ?? PORT_RELEASE_TIMEOUT;
+  const intervalMs = opts.intervalMs ?? PORT_RELEASE_POLL;
+  const scanFrom = opts.baseDevPort ?? baseDevPort;
+
+  if (await isPortFree(session.port)) return session.port;
+
+  session.addLog(
+    'info',
+    `Port ${session.port} is still held — waiting up to ${timeoutMs}ms for it to clear`
+  );
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, intervalMs));
+    if (await isPortFree(session.port)) return session.port;
+  }
+
+  // Its own port is excluded from the reservations so that a port freeing during the scan can
+  // still be handed back to the session it belongs to.
+  const used = getUsedPorts();
+  used.delete(session.port);
+  const moved = await findAvailablePort(scanFrom, used);
+  session.addLog(
+    'warn',
+    `Port ${session.port} is held by something this daemon does not control — moving this session to ${moved}`
+  );
+  session.port = moved;
+  return moved;
+}
+
 function findSessionByWorktree(worktree) {
   const normalizedWorktree = resolve(worktree);
   for (const session of sessions.values()) {
-    if (resolve(session.worktree) === normalizedWorktree) {
+    // Case-insensitively on Windows: `cli start c:/dev/...` and a session created as `C:\Dev\...`
+    // are the same tree, and treating them as two would put two dev servers on it — each now
+    // holding a port for the daemon's lifetime. worktree.mjs already compares this way.
+    if (samePath(session.worktree, normalizedWorktree)) {
       return session;
     }
   }
@@ -1397,7 +1488,12 @@ function findSessionByWorktree(worktree) {
 }
 
 function listSessions() {
-  return Array.from(sessions.values()).map(s => s.getStatus());
+  // A session whose worktree has been deleted still holds its port and cannot be started again,
+  // and this listing is where someone hunting a reserved port actually looks.
+  return Array.from(sessions.values()).map((s) => ({
+    ...s.getStatus(),
+    worktreeMissing: !existsSync(s.worktree),
+  }));
 }
 
 // HTTP request body reader
@@ -1416,6 +1512,8 @@ async function main() {
 
   // Write PID file
   writeFileSync(pidFile, String(process.pid));
+
+  baseDevPort = config.baseDevPort;
 
   console.error(`Starting dev-server daemon...`);
   console.error(`  Daemon port: ${config.port}`);
@@ -1648,14 +1746,26 @@ async function main() {
 
         // Check if worktree exists
         if (!existsSync(resolvedWorktree)) {
+          // A tree deleted out from under its session leaves that session holding a port with no
+          // way to reach it through this endpoint, so name the session rather than only the tree.
+          const orphaned = findSessionByWorktree(resolvedWorktree);
           res.writeHead(400);
-          res.end(JSON.stringify({ error: `Worktree not found: ${resolvedWorktree}` }));
+          res.end(JSON.stringify({
+            error: `Worktree not found: ${resolvedWorktree}`,
+            ...(orphaned && {
+              trackedSession: orphaned.id,
+              hint: `Session ${orphaned.id} still holds port ${orphaned.port} for this path — release it with \`node .claude/skills/dev-server/cli.mjs stop ${orphaned.id}\`.`,
+            }),
+          }));
           return;
         }
 
         // Check if already running for this worktree
         const existing = findSessionByWorktree(resolvedWorktree);
-        if (existing && (existing.status === 'running' || existing.status === 'starting')) {
+        if (
+          existing &&
+          (existing.status === 'running' || existing.status === 'starting' || existing.switching)
+        ) {
           res.writeHead(200);
           res.end(JSON.stringify({
             existing: true,
@@ -1669,11 +1779,11 @@ async function main() {
         // a port for the life of the daemon. Only when a different port is asked for is a second
         // session created, and the old one keeps its reservation because its process may be alive.
         if (existing && (!requestedPort || requestedPort === existing.port)) {
-          await existing.restart();
+          await existing.restart((s) => claimPortForReuse(s));
 
           res.writeHead(200);
           res.end(JSON.stringify({
-            existing: false,
+            existing: true,
             reused: true,
             session: existing.getStatus(),
           }));
@@ -1765,7 +1875,7 @@ async function main() {
 
         // POST /sessions/:id/restart - Restart session
         if (subPath === '/restart' && req.method === 'POST') {
-          const result = await session.restart();
+          await session.restart((s) => claimPortForReuse(s));
 
           res.writeHead(200);
           res.end(JSON.stringify({
@@ -1777,12 +1887,18 @@ async function main() {
         // DELETE /sessions/:id - Stop session
         if (subPath === '' && req.method === 'DELETE') {
           await session.stop();
-          sessions.delete(sessionId);
 
-          // Removing the session is what releases its port, so say plainly when something is
-          // still listening on it — a kill that missed an orphaned grandchild leaves a port the
-          // daemon no longer reserves and only the picker's probe stands between it and reuse.
-          const stillListening = !(await isPortFree(session.port));
+          // A process winding down still answers, so a single busy read means nothing — only a
+          // port still held on a second look is worth reporting. The session is removed either
+          // way: keeping it would leave `wt stale` counting the tree as a keeper forever, and the
+          // picker's probe is what stands between a leftover listener and reuse.
+          let stillListening = !(await isPortFree(session.port));
+          if (stillListening) {
+            await new Promise((r) => setTimeout(r, 300));
+            stillListening = !(await isPortFree(session.port));
+          }
+
+          sessions.delete(sessionId);
 
           res.writeHead(200);
           res.end(JSON.stringify({
@@ -1896,15 +2012,20 @@ async function main() {
 
 // Importing this file must not start a daemon — the tests drive DevSession and the port
 // reservation directly, and a second daemon would fight the running one for its port.
-// Windows hands back whatever drive-letter case the caller typed, and a mismatch here would
-// look exactly like a daemon that starts and immediately does nothing.
-const samePath = (a, b) =>
-  process.platform === 'win32'
-    ? resolve(a).toLowerCase() === resolve(b).toLowerCase()
-    : resolve(a) === resolve(b);
+// `import.meta.url` is realpathed by node and `process.argv[1]` is not, so a launch through a
+// junction — which this repo's tooling creates routinely — would otherwise leave the daemon
+// exiting 0 having started nothing.
+function realPath(path) {
+  try {
+    return realpathSync(path);
+  } catch (e) {
+    return path;
+  }
+}
 
 const invokedDirectly =
-  !!process.argv[1] && samePath(process.argv[1], fileURLToPath(import.meta.url));
+  !!process.argv[1] &&
+  samePath(realPath(process.argv[1]), realPath(fileURLToPath(import.meta.url)));
 
 if (invokedDirectly) {
   main().catch(err => {
@@ -1913,4 +2034,4 @@ if (invokedDirectly) {
   });
 }
 
-export { DevSession, sessions, getUsedPorts };
+export { claimPortForReuse, DevSession, findSessionByWorktree, getUsedPorts, sessions };

--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -17,6 +17,7 @@ import { existsSync, readFileSync, writeFileSync, unlinkSync, statSync, readdirS
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { randomBytes, createHash } from 'crypto';
+import { access } from 'fs/promises';
 import { isPortFree } from './port-probe.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -451,6 +452,9 @@ class DevSession {
     this.branchWatchTimer = null;
     this.branchSwitchTimer = null;
     this.switching = false;
+    this.removed = false;
+    this.busyDepth = 0;
+    this.lifecycleLock = Promise.resolve();
     this.prewarming = false;
     this.lockHash = null;
     this.schemaHash = null;
@@ -502,6 +506,14 @@ class DevSession {
   }
 
   async start() {
+    // A session removed while a branch switch was mid-install would otherwise reach its start and
+    // spawn a dev server nothing tracks, on a port nothing reserves — the one state the whole
+    // reservation model cannot see.
+    if (this.removed) {
+      this.addLog('info', 'Start abandoned — this session has been removed');
+      return this.getStatus();
+    }
+
     // Re-read the skill .env each start so edits to PREWARM_ROUTES et al. take effect
     // on the next branch switch instead of needing a daemon restart. Mutated in place
     // because healthCheckConfig aliases this object.
@@ -592,6 +604,28 @@ class DevSession {
       status: this.status,
       ready: this.ready,
     };
+  }
+
+  // Everything that stops or starts this session runs through here, one at a time. Two restarts
+  // overlapping would have the second probe the port the first had just bound, read it as taken,
+  // and move the session off a port it had only just been given.
+  // `fn` must not re-enter lifecycle() on this session: it would wait on a lock it is itself
+  // holding, and the session would then report busy forever with DELETE the only way out.
+  lifecycle(fn) {
+    // Counted, not a boolean: each queued op chains its own clear onto the lock, so with a plain
+    // flag the first op's clear runs before the second op's body and the session reads idle while
+    // a restart is still going. That fails in the pile-up case the flag exists for.
+    this.busyDepth++;
+    const done = () => {
+      this.busyDepth--;
+    };
+    const run = this.lifecycleLock.then(fn, fn);
+    this.lifecycleLock = run.then(done, done);
+    return run;
+  }
+
+  get busy() {
+    return this.busyDepth > 0;
   }
 
   // Anything still attached when a new process is about to take its place is a process this
@@ -724,6 +758,15 @@ class DevSession {
   }
 
   async finishBranchSwitch() {
+    return this.lifecycle(() => this.runBranchSwitch());
+  }
+
+  async runBranchSwitch() {
+    // A DELETE that lands after this was queued would otherwise spend minutes on an install for a
+    // session nobody tracks — against a worktree `wt rm` may have just deleted — before start()
+    // refuses at the end of it.
+    if (this.removed) return;
+
     this.branchSwitchTimer = null;
     this.switching = true;
     const head = readHeadRef(this.headPath);
@@ -971,14 +1014,16 @@ class DevSession {
   // `claimPort` runs between the stop and the start, which is the only moment the session's own
   // process is gone and a probe of its port says something about anyone else.
   async restart(claimPort) {
-    await this.stop();
-    this.restartCount++;
-    this.logs = [];
-    this.logIndex = 0;
-    this.ready = false;
-    this.readyAt = null;
-    if (claimPort) await claimPort(this);
-    return this.start();
+    return this.lifecycle(async () => {
+      await this.stop();
+      this.restartCount++;
+      this.logs = [];
+      this.logIndex = 0;
+      this.ready = false;
+      this.readyAt = null;
+      if (claimPort) await claimPort(this);
+      return this.start();
+    });
   }
 
   getStatus() {
@@ -989,6 +1034,7 @@ class DevSession {
       envPath: this.envPath,
       distDir: this.distDir,
       switching: this.switching,
+      busy: this.busy,
       prewarming: this.prewarming,
       port: this.port,
       status: this.status,
@@ -1444,6 +1490,19 @@ function getUsedPorts() {
 const PORT_RELEASE_TIMEOUT = 8000;
 const PORT_RELEASE_POLL = 250;
 
+// Anything already under way owns this session, and a second request must report that rather than
+// start a competing one. `status` alone is not enough: a restart waiting out its port reads
+// `stopped` with no process for as long as the wait lasts — and a start that seems to hang is
+// exactly what makes an agent run it again.
+function sessionIsBusy(session) {
+  return (
+    session.status === 'running' ||
+    session.status === 'starting' ||
+    session.switching ||
+    session.busy
+  );
+}
+
 async function claimPortForReuse(session, opts = {}) {
   const timeoutMs = opts.timeoutMs ?? PORT_RELEASE_TIMEOUT;
   const intervalMs = opts.intervalMs ?? PORT_RELEASE_POLL;
@@ -1487,13 +1546,92 @@ function findSessionByWorktree(worktree) {
   return null;
 }
 
-function listSessions() {
-  // A session whose worktree has been deleted still holds its port and cannot be started again,
-  // and this listing is where someone hunting a reserved port actually looks.
-  return Array.from(sessions.values()).map((s) => ({
-    ...s.getStatus(),
-    worktreeMissing: !existsSync(s.worktree),
-  }));
+// A session whose worktree has been deleted still holds its port and cannot be started again, and
+// this listing is where someone hunting a reserved port actually looks. The check is async because
+// this runs on the daemon's only thread and the TUI polls it twice a second: a synchronous
+// existsSync against a path that has gone unreachable — a network share, a dropped VPN, a stale
+// reparse point — took 21s in one measurement, and every other agent's request queues behind it.
+async function listSessions() {
+  return Promise.all(
+    Array.from(sessions.values()).map(async (s) => {
+      const { exists, timedOut } = await checkPath(s.worktree);
+      return {
+        ...s.getStatus(),
+        worktreeMissing: !exists,
+        ...(timedOut && { worktreeCheckTimedOut: true }),
+      };
+    })
+  );
+}
+
+// `access` runs on libuv's 4-slot threadpool, and one unreachable path takes 21s there — four of
+// them starve every other filesystem call on the process, including the healthy worktrees in the
+// same listing. Racing a timeout bounds the caller's wait but NOT the slot: the loser of a race
+// keeps running. So a path gets at most one probe in flight at a time, and a settled answer is
+// reused briefly — without that, the TUI polling twice a second injects two 21s jobs per second
+// into a four-slot pool and it never drains.
+//
+// A timeout reports the worktree as present: "slow" is not evidence of deletion, and calling a
+// live tree missing is the more damaging wrong answer. The caller is told the check timed out so
+// it can say "could not tell" rather than "fine".
+const WORKTREE_CHECK_TIMEOUT = 250;
+const WORKTREE_CHECK_TTL = 2000;
+const WORKTREE_CHECK_MAX_ENTRIES = 64;
+
+const worktreeChecks = new Map();
+
+function probePath(path) {
+  const cached = worktreeChecks.get(path);
+  if (cached && (cached.pending || Date.now() - cached.settledAt < WORKTREE_CHECK_TTL)) {
+    return cached;
+  }
+
+  if (worktreeChecks.size >= WORKTREE_CHECK_MAX_ENTRIES) {
+    for (const [key, entry] of worktreeChecks) {
+      if (!entry.pending && Date.now() - entry.settledAt >= WORKTREE_CHECK_TTL) {
+        worktreeChecks.delete(key);
+      }
+    }
+  }
+
+  const entry = { pending: true, exists: true, settledAt: 0 };
+  entry.probe = access(path).then(
+    () => true,
+    () => false
+  );
+  entry.probe.then((exists) => {
+    entry.exists = exists;
+    entry.pending = false;
+    // A miss is never slow — ENOENT comes back in microseconds — so caching one protects nothing
+    // and makes a worktree created seconds after a failed start read as still missing, with the
+    // error naming the path and sending the reader after the wrong thing.
+    entry.settledAt = exists ? Date.now() : 0;
+    if (!exists) worktreeChecks.delete(path);
+  });
+  worktreeChecks.set(path, entry);
+  return entry;
+}
+
+async function checkPath(path) {
+  const entry = probePath(path);
+  if (!entry.pending) return { exists: entry.exists, timedOut: false };
+
+  let timer;
+  try {
+    const timedOut = await Promise.race([
+      entry.probe.then(() => false),
+      new Promise((resolve) => {
+        timer = setTimeout(() => resolve(true), WORKTREE_CHECK_TIMEOUT);
+      }),
+    ]);
+    return timedOut ? { exists: true, timedOut: true } : { exists: entry.exists, timedOut: false };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function pathExists(path) {
+  return (await checkPath(path)).exists;
 }
 
 // HTTP request body reader
@@ -1549,7 +1687,7 @@ async function main() {
           status: 'running',
           pid: process.pid,
           uptime: process.uptime(),
-          sessions: listSessions(),
+          sessions: await listSessions(),
         }));
         return;
       }
@@ -1561,7 +1699,7 @@ async function main() {
           status: 'running',
           pid: process.pid,
           uptime: process.uptime(),
-          sessions: listSessions(),
+          sessions: await listSessions(),
           rgbProxy: rgbProxy.getStatus(),
           authHub: authHub.getStatus(),
           projectRoot,
@@ -1714,7 +1852,7 @@ async function main() {
       if (path === '/sessions' && req.method === 'GET') {
         res.writeHead(200);
         res.end(JSON.stringify({
-          sessions: listSessions(),
+          sessions: await listSessions(),
         }));
         return;
       }
@@ -1744,8 +1882,10 @@ async function main() {
 
         const resolvedWorktree = resolve(worktree);
 
-        // Check if worktree exists
-        if (!existsSync(resolvedWorktree)) {
+        // Async for the same reason listSessions is: a synchronous stat on a path that has gone
+        // unreachable blocks the daemon's only thread, and `cli start` is not worth freezing every
+        // other agent's requests for.
+        if (!(await pathExists(resolvedWorktree))) {
           // A tree deleted out from under its session leaves that session holding a port with no
           // way to reach it through this endpoint, so name the session rather than only the tree.
           const orphaned = findSessionByWorktree(resolvedWorktree);
@@ -1762,10 +1902,7 @@ async function main() {
 
         // Check if already running for this worktree
         const existing = findSessionByWorktree(resolvedWorktree);
-        if (
-          existing &&
-          (existing.status === 'running' || existing.status === 'starting' || existing.switching)
-        ) {
+        if (existing && sessionIsBusy(existing)) {
           res.writeHead(200);
           res.end(JSON.stringify({
             existing: true,
@@ -1814,7 +1951,11 @@ async function main() {
         const worktreeEnvPath = resolve(resolvedWorktree, '.env');
         const resolvedEnvPath = envPath
           ? resolve(envPath)
-          : existsSync(worktreeEnvPath)
+          : // "Present" is the safe answer for the worktree and the unsafe one here: picking a
+            // file that may not exist over a known-good fallback starts the server with no env at
+            // all — no DATABASE_URL, no secrets — failing in a way that looks nothing like a slow
+            // filesystem. So an unknown answer falls back to the main .env.
+            await checkPath(worktreeEnvPath).then((r) => r.exists && !r.timedOut)
             ? worktreeEnvPath
             : mainEnvPath;
 
@@ -1875,6 +2016,18 @@ async function main() {
 
         // POST /sessions/:id/restart - Restart session
         if (subPath === '/restart' && req.method === 'POST') {
+          // Queueing behind an op that never finishes hangs this request forever — the CLI's fetch
+          // has no timeout either — so refuse instead. POST /sessions already short-circuits on
+          // the same predicate.
+          if (session.busy) {
+            res.writeHead(409);
+            res.end(JSON.stringify({
+              error: `Session ${session.id} is busy — a start, restart or branch switch is already running.`,
+              session: session.getStatus(),
+            }));
+            return;
+          }
+
           await session.restart((s) => claimPortForReuse(s));
 
           res.writeHead(200);
@@ -1886,6 +2039,9 @@ async function main() {
 
         // DELETE /sessions/:id - Stop session
         if (subPath === '' && req.method === 'DELETE') {
+          // Set before stopping: a branch switch already past its own stop would otherwise start
+          // a server for a session this request is in the middle of removing.
+          session.removed = true;
           await session.stop();
 
           // A process winding down still answers, so a single busy read means nothing — only a
@@ -2034,4 +2190,13 @@ if (invokedDirectly) {
   });
 }
 
-export { claimPortForReuse, DevSession, findSessionByWorktree, getUsedPorts, sessions };
+export {
+  checkPath,
+  claimPortForReuse,
+  DevSession,
+  findSessionByWorktree,
+  getUsedPorts,
+  listSessions,
+  sessionIsBusy,
+  sessions,
+};

--- a/scripts/__tests__/dev-server-port-reservation.test.ts
+++ b/scripts/__tests__/dev-server-port-reservation.test.ts
@@ -1,21 +1,48 @@
+import type * as ChildProcess from 'child_process';
 import { EventEmitter } from 'events';
 import { tmpdir } from 'os';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Nothing in this file may reach a real process. The mock is on the module rather than on
+// DevSession.killProcessTree so that reverting the daemon's kill path back inline cannot make
+// these tests fire a real `taskkill` at whatever owns pid 4242 today.
+const spawnMock = vi.hoisted(() => vi.fn());
+vi.mock('child_process', async (importOriginal) => ({
+  ...(await importOriginal<typeof ChildProcess>()),
+  spawn: spawnMock,
+}));
+
+const isPortFreeMock = vi.hoisted(() => vi.fn(async () => true));
+vi.mock('../../.claude/skills/dev-server/scripts/port-probe.mjs', () => ({
+  isPortFree: isPortFreeMock,
+}));
 
 // The daemon ships with the dev-server skill (plain .mjs, run by node, never bundled), so it is
 // imported by path the way its port probe already is. Importing it does not start a daemon —
 // `main()` runs only when the file is the entry point.
 import {
+  claimPortForReuse,
   DevSession,
+  findSessionByWorktree,
   getUsedPorts,
   sessions,
 } from '../../.claude/skills/dev-server/scripts/daemon.mjs';
+
+// Short waits so a test that must observe the wait does not spend the real 8s doing it, and a
+// scan base above the default 3000 so these cases cannot be satisfied by a port a real session
+// would be using.
+const FAST_CLAIM = { timeoutMs: 60, intervalMs: 10, baseDevPort: 3100 };
 
 const ENV_PATH = '/nonexistent/.env'; // only read by start(), which no test here calls
 
 afterEach(() => {
   sessions.clear();
+  // restoreAllMocks does not undo the module mocks (they are not spies), so both are reset
+  // explicitly; it is kept so the next spyOn written without a finally cannot leak.
   vi.restoreAllMocks();
+  spawnMock.mockClear();
+  isPortFreeMock.mockReset();
+  isPortFreeMock.mockResolvedValue(true);
 });
 
 function makeSession(id: string, port: number) {
@@ -40,7 +67,6 @@ function fakeProcess(pid = 4242) {
 
 function wire(session: ReturnType<typeof makeSession>, proc: ReturnType<typeof fakeProcess>) {
   session.process = proc;
-  session.killProcessTree = vi.fn();
   session.attachProcessHandlers(proc);
   return proc;
 }
@@ -78,6 +104,121 @@ describe('dev-server port reservation', () => {
   });
 });
 
+describe('dev-server port claim on reuse', () => {
+  it('keeps the port when nothing else holds it', async () => {
+    const session = makeSession('free', 3101);
+
+    expect(await claimPortForReuse(session, FAST_CLAIM)).toBe(3101);
+    expect(session.port).toBe(3101);
+  });
+
+  // The measured case, and the one that makes this dangerous: a killed listener on this box
+  // released its socket 630-668ms after taskkill was spawned, while stop() waits at most 500ms.
+  // So the session's OWN dying process reads as busy on the first probe of every restart, and
+  // moving on that reading takes a healthy session off its port — which for the primary session
+  // unhooks the rgb-proxy (hardcoded to 3000) and rewrites its auth URLs, silently.
+  it('waits out its own process still dying rather than moving', async () => {
+    const session = makeSession('dying', 3101);
+    let probes = 0;
+    isPortFreeMock.mockImplementation(async () => ++probes > 3);
+
+    expect(await claimPortForReuse(session, FAST_CLAIM)).toBe(3101);
+    expect(session.port).toBe(3101);
+    expect(probes).toBeGreaterThan(1);
+  });
+
+  // `next dev` does not fail on an occupied port, it warns and moves. So restarting a session
+  // onto a port an orphan still holds gives a session whose reported url and health check both
+  // point at a server it does not own.
+  it('moves the session off a port that stays held', async () => {
+    const session = makeSession('held', 3101);
+    makeSession('neighbour', 3100).status = 'running';
+    isPortFreeMock.mockImplementation(async (port: number) => port !== 3101);
+
+    expect(await claimPortForReuse(session, FAST_CLAIM)).toBe(3102);
+    expect(session.port).toBe(3102);
+    expect(session.logs.at(-1)?.message).toContain('moving this session to 3102');
+  });
+
+  // The replacement must respect the other sessions' reservations, or taking one session over
+  // would land it on a port another worktree owns.
+  it('skips ports reserved by other sessions when it moves', async () => {
+    const session = makeSession('held', 3101);
+    makeSession('below', 3100).status = 'running';
+    makeSession('above', 3102).status = 'crashed';
+    isPortFreeMock.mockImplementation(async (port: number) => port !== 3101);
+
+    expect(await claimPortForReuse(session, FAST_CLAIM)).toBe(3103);
+  });
+});
+
+describe('dev-server restart wiring', () => {
+  // The whole reason the probe means anything: run it before the stop and it sees the session's
+  // own live server; run it after the start and the session is already on the port. Between the
+  // two is the only moment it says something about anyone else.
+  it('claims the port after stopping and before starting', async () => {
+    const session = makeSession('ordered', 3111);
+    const proc = wire(session, fakeProcess(5150));
+    const order: string[] = [];
+
+    session.start = vi.fn(async () => {
+      order.push('start');
+      return session.getStatus();
+    });
+    const stopping = session.restart(async () => {
+      order.push(session.process ? 'claim-before-stop' : 'claim-after-stop');
+    });
+    proc.emit('exit', 1, 'SIGKILL');
+    await stopping;
+
+    expect(order).toEqual(['claim-after-stop', 'start']);
+  });
+
+  // Two starts can interleave — a branch switch restarting while a request takes the session
+  // over. Without this the loser keeps running, unreachable and holding the port, for the
+  // daemon's lifetime, and the exit guard then discards even its exit.
+  it('kills a process still attached before replacing it', () => {
+    const session = makeSession('replacing', 3121);
+    const doomed = fakeProcess(6161);
+    session.process = doomed;
+
+    session.detachRunningProcess();
+
+    expect(session.process).toBe(null);
+    if (process.platform === 'win32') {
+      expect(spawnMock).toHaveBeenCalledWith('taskkill', ['/pid', '6161', '/f', '/t'], {
+        shell: true,
+      });
+    }
+  });
+});
+
+describe('dev-server worktree matching', () => {
+  // worktree.mjs compares these case-insensitively. If the daemon does not, `cli start c:/dev/...`
+  // after a session created as `C:\Dev\...` gives that one tree two sessions, two dev servers and
+  // two permanently-reserved ports.
+  // Windows is spoofed rather than skipped so this still guards the behaviour on a Linux CI box,
+  // where the case fold would otherwise never be exercised at all.
+  it('matches a worktree path that differs only in case', () => {
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')!;
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    try {
+      const session = makeSession('cased', 3131);
+      session.worktree = '/Dev/Repos/work/wt-example';
+
+      expect(findSessionByWorktree('/dev/repos/work/wt-example')).toBe(session);
+    } finally {
+      Object.defineProperty(process, 'platform', platform);
+    }
+  });
+
+  it('does not match a different worktree', () => {
+    makeSession('other', 3132).worktree = '/Dev/Repos/work/wt-example';
+
+    expect(findSessionByWorktree('/Dev/Repos/work/wt-different')).toBe(null);
+  });
+});
+
 describe('dev-server session process lifecycle', () => {
   // stop() hard-kills, so the process exits nonzero. Reading the outcome off that exit code
   // filed every deliberate stop as a crash, which is most of what made `crashed` untrustworthy.
@@ -91,7 +232,6 @@ describe('dev-server session process lifecycle', () => {
     await stopping;
 
     expect(session.status).toBe('stopped');
-    expect(session.killProcessTree).toHaveBeenCalledTimes(1);
     expect(session.process).toBe(null);
   });
 
@@ -119,6 +259,17 @@ describe('dev-server session process lifecycle', () => {
     expect(session.status).toBe('stopped');
   });
 
+  // A failed spawn is not a clean shutdown, and stopping a session that never had a process
+  // must not rewrite that.
+  it('leaves an errored session reporting error when stopped', async () => {
+    const session = makeSession('errored', 3062);
+    session.status = 'error';
+
+    await session.stop();
+
+    expect(session.status).toBe('error');
+  });
+
   // A restart replaces the process. The old one exits afterwards, and before the identity guard
   // that late exit marked the live session crashed — the exact state that then lost its port.
   it('ignores the exit of a process the session has already replaced', () => {
@@ -142,5 +293,25 @@ describe('dev-server session process lifecycle', () => {
     old.emit('error', new Error('spawn ENOENT'));
 
     expect(session.status).toBe('running');
+  });
+
+  it('kills the tracked process rather than any other', () => {
+    const session = makeSession('killer', 3091);
+    const proc = fakeProcess(31337);
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+    try {
+      session.killProcessTree(proc);
+
+      if (process.platform === 'win32') {
+        expect(spawnMock).toHaveBeenCalledWith('taskkill', ['/pid', '31337', '/f', '/t'], {
+          shell: true,
+        });
+      } else {
+        expect(killSpy).toHaveBeenCalledWith(-31337, 'SIGKILL');
+      }
+    } finally {
+      killSpy.mockRestore();
+    }
   });
 });

--- a/scripts/__tests__/dev-server-port-reservation.test.ts
+++ b/scripts/__tests__/dev-server-port-reservation.test.ts
@@ -1,0 +1,146 @@
+import { EventEmitter } from 'events';
+import { tmpdir } from 'os';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// The daemon ships with the dev-server skill (plain .mjs, run by node, never bundled), so it is
+// imported by path the way its port probe already is. Importing it does not start a daemon —
+// `main()` runs only when the file is the entry point.
+import {
+  DevSession,
+  getUsedPorts,
+  sessions,
+} from '../../.claude/skills/dev-server/scripts/daemon.mjs';
+
+const ENV_PATH = '/nonexistent/.env'; // only read by start(), which no test here calls
+
+afterEach(() => {
+  sessions.clear();
+  vi.restoreAllMocks();
+});
+
+function makeSession(id: string, port: number) {
+  const session = new DevSession(id, tmpdir(), port, ENV_PATH);
+  sessions.set(id, session);
+  return session;
+}
+
+// A child process stand-in. It emits only what a test emits, so nothing here can outlive the
+// test or drive a loop of its own.
+function fakeProcess(pid = 4242) {
+  const proc = new EventEmitter() as EventEmitter & {
+    pid: number;
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+  };
+  proc.pid = pid;
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  return proc;
+}
+
+function wire(session: ReturnType<typeof makeSession>, proc: ReturnType<typeof fakeProcess>) {
+  session.process = proc;
+  session.killProcessTree = vi.fn();
+  session.attachProcessHandlers(proc);
+  return proc;
+}
+
+describe('dev-server port reservation', () => {
+  // The negative control: without it, a getUsedPorts hardwired to reserve every port in the
+  // range would pass every case below.
+  it('reserves nothing when no session is tracked', () => {
+    expect([...getUsedPorts()]).toEqual([]);
+  });
+
+  // The bug. `crashed` is a report about a process the daemon cannot see into, and it has been
+  // written for a session whose process was alive and holding its port.
+  it('reserves the port of a session marked crashed', () => {
+    makeSession('crashed-one', 3011).status = 'crashed';
+    expect([...getUsedPorts()]).toEqual([3011]);
+  });
+
+  it.each(['starting', 'running', 'crashed', 'error', 'stopped'])(
+    'reserves the port of a session in status %s',
+    (status) => {
+      makeSession(`s-${status}`, 3021).status = status;
+      expect(getUsedPorts().has(3021)).toBe(true);
+    }
+  );
+
+  // The release path. `cli stop <id>` sends DELETE /sessions/:id, which removes the session from
+  // this map — so if removal did not release the port, a stopped session would strand it.
+  it('releases the port when the session is no longer tracked', () => {
+    const session = makeSession('gone', 3031);
+    expect(getUsedPorts().has(3031)).toBe(true);
+
+    sessions.delete(session.id);
+    expect(getUsedPorts().has(3031)).toBe(false);
+  });
+});
+
+describe('dev-server session process lifecycle', () => {
+  // stop() hard-kills, so the process exits nonzero. Reading the outcome off that exit code
+  // filed every deliberate stop as a crash, which is most of what made `crashed` untrustworthy.
+  it('records a deliberate stop as stopped, not crashed', async () => {
+    const session = makeSession('deliberate', 3041);
+    const proc = wire(session, fakeProcess());
+    session.status = 'running';
+
+    const stopping = session.stop();
+    proc.emit('exit', 1, 'SIGKILL');
+    await stopping;
+
+    expect(session.status).toBe('stopped');
+    expect(session.killProcessTree).toHaveBeenCalledTimes(1);
+    expect(session.process).toBe(null);
+  });
+
+  // The other half of that: an exit nobody asked for must still read as a crash, or the fix
+  // above would be indistinguishable from deleting crash reporting altogether.
+  it('records an unprompted nonzero exit as crashed', () => {
+    const session = makeSession('genuine', 3051);
+    const proc = wire(session, fakeProcess());
+    session.status = 'running';
+
+    proc.emit('exit', 1, null);
+
+    expect(session.status).toBe('crashed');
+    expect(session.exitCode).toBe(1);
+    expect(getUsedPorts().has(3051)).toBe(true);
+  });
+
+  it('records a clean exit as stopped', () => {
+    const session = makeSession('clean', 3061);
+    const proc = wire(session, fakeProcess());
+    session.status = 'running';
+
+    proc.emit('exit', 0, null);
+
+    expect(session.status).toBe('stopped');
+  });
+
+  // A restart replaces the process. The old one exits afterwards, and before the identity guard
+  // that late exit marked the live session crashed — the exact state that then lost its port.
+  it('ignores the exit of a process the session has already replaced', () => {
+    const session = makeSession('replaced', 3071);
+    const old = wire(session, fakeProcess(1111));
+    const fresh = wire(session, fakeProcess(2222));
+    session.status = 'running';
+
+    old.emit('exit', 1, 'SIGKILL');
+
+    expect(session.status).toBe('running');
+    expect(session.process).toBe(fresh);
+  });
+
+  it('ignores a spawn error from a process the session has already replaced', () => {
+    const session = makeSession('replaced-error', 3081);
+    const old = wire(session, fakeProcess(1111));
+    wire(session, fakeProcess(2222));
+    session.status = 'running';
+
+    old.emit('error', new Error('spawn ENOENT'));
+
+    expect(session.status).toBe('running');
+  });
+});

--- a/scripts/__tests__/dev-server-port-reservation.test.ts
+++ b/scripts/__tests__/dev-server-port-reservation.test.ts
@@ -1,6 +1,8 @@
 import type * as ChildProcess from 'child_process';
+import type * as FsPromises from 'fs/promises';
 import { EventEmitter } from 'events';
 import { tmpdir } from 'os';
+import { resolve } from 'path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Nothing in this file may reach a real process. The mock is on the module rather than on
@@ -12,6 +14,12 @@ vi.mock('child_process', async (importOriginal) => ({
   spawn: spawnMock,
 }));
 
+const accessMock = vi.hoisted(() => vi.fn(async () => undefined));
+vi.mock('fs/promises', async (importOriginal) => ({
+  ...(await importOriginal<typeof FsPromises>()),
+  access: accessMock,
+}));
+
 const isPortFreeMock = vi.hoisted(() => vi.fn(async () => true));
 vi.mock('../../.claude/skills/dev-server/scripts/port-probe.mjs', () => ({
   isPortFree: isPortFreeMock,
@@ -21,17 +29,21 @@ vi.mock('../../.claude/skills/dev-server/scripts/port-probe.mjs', () => ({
 // imported by path the way its port probe already is. Importing it does not start a daemon —
 // `main()` runs only when the file is the entry point.
 import {
+  checkPath,
   claimPortForReuse,
   DevSession,
   findSessionByWorktree,
   getUsedPorts,
+  listSessions,
+  sessionIsBusy,
   sessions,
 } from '../../.claude/skills/dev-server/scripts/daemon.mjs';
 
-// Short waits so a test that must observe the wait does not spend the real 8s doing it, and a
-// scan base above the default 3000 so these cases cannot be satisfied by a port a real session
-// would be using.
-const FAST_CLAIM = { timeoutMs: 60, intervalMs: 10, baseDevPort: 3100 };
+// A 1ms poll with a generous deadline keeps every case below count-bound rather than clock-bound:
+// the probe mocks decide the outcome, so a slow box cannot turn a pass into the very failure these
+// tests exist to detect. The scan base sits above the default 3000 so no case can be satisfied by
+// a port a real session would be using.
+const FAST_CLAIM = { timeoutMs: 5000, intervalMs: 1, baseDevPort: 3100 };
 
 const ENV_PATH = '/nonexistent/.env'; // only read by start(), which no test here calls
 
@@ -43,6 +55,8 @@ afterEach(() => {
   spawnMock.mockClear();
   isPortFreeMock.mockReset();
   isPortFreeMock.mockResolvedValue(true);
+  accessMock.mockReset();
+  accessMock.mockResolvedValue(undefined);
 });
 
 function makeSession(id: string, port: number) {
@@ -174,22 +188,199 @@ describe('dev-server restart wiring', () => {
     expect(order).toEqual(['claim-after-stop', 'start']);
   });
 
+  // Two restarts overlapping would have the second probe the port the first had just bound, read
+  // it as taken, and move the session off a port it had only just been given.
+  it('serializes overlapping restarts', async () => {
+    const session = makeSession('serial', 3141);
+    const order: string[] = [];
+    let releaseFirst: (() => void) | null = null;
+
+    session.start = vi.fn(async () => session.getStatus());
+    const first = session.restart(async () => {
+      order.push('first-in');
+      await new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      order.push('first-out');
+    });
+    const second = session.restart(async () => {
+      order.push('second-in');
+    });
+
+    // The lock defers through a promise chain, so let the queue drain before reading it.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(order).toEqual(['first-in']);
+    releaseFirst?.();
+    await Promise.all([first, second]);
+
+    expect(order).toEqual(['first-in', 'first-out', 'second-in']);
+  });
+
+  // A session removed while a branch switch was mid-install would otherwise reach its start and
+  // spawn a dev server nothing tracks, on a port nothing reserves.
+  it('refuses to start a session that has been removed', async () => {
+    const session = makeSession('removed', 3151);
+    session.removed = true;
+
+    // Returns a usable stand-in, so a start that wrongly proceeds fails on the assertion below
+    // rather than on a mock that handed it undefined.
+    spawnMock.mockImplementation(() => fakeProcess(7171));
+
+    await session.start();
+
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(session.process).toBe(null);
+  });
+
   // Two starts can interleave — a branch switch restarting while a request takes the session
   // over. Without this the loser keeps running, unreachable and holding the port, for the
   // daemon's lifetime, and the exit guard then discards even its exit.
   it('kills a process still attached before replacing it', () => {
     const session = makeSession('replacing', 3121);
-    const doomed = fakeProcess(6161);
-    session.process = doomed;
+    session.process = fakeProcess(6161);
+    // The module-level spawn mock only covers the win32 branch. Off Windows the kill is
+    // `process.kill(-pid)`, and CI runs this suite as root, so an unspied call would send a real
+    // SIGKILL to whatever holds process group 6161 in the container.
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
 
-    session.detachRunningProcess();
+    try {
+      session.detachRunningProcess();
 
-    expect(session.process).toBe(null);
-    if (process.platform === 'win32') {
-      expect(spawnMock).toHaveBeenCalledWith('taskkill', ['/pid', '6161', '/f', '/t'], {
-        shell: true,
-      });
+      expect(session.process).toBe(null);
+      if (process.platform === 'win32') {
+        expect(spawnMock).toHaveBeenCalledWith('taskkill', ['/pid', '6161', '/f', '/t'], {
+          shell: true,
+        });
+      } else {
+        expect(killSpy).toHaveBeenCalledWith(-6161, 'SIGKILL');
+      }
+    } finally {
+      killSpy.mockRestore();
     }
+  });
+});
+
+describe('dev-server session busy reporting', () => {
+  // A restart waiting out its port reads `stopped` with no process for as long as the wait lasts,
+  // and a start that seems to hang is exactly what makes an agent run it again. Reporting the
+  // session as busy is what stops that second call booting a competing server.
+  it.each([
+    ['a running session', { status: 'running' }],
+    ['a starting session', { status: 'starting' }],
+    ['a session mid branch switch', { status: 'stopped', switching: true }],
+    ['a session waiting on its own restart', { status: 'stopped', busyDepth: 1 }],
+  ])('reports %s as busy', (_label, state) => {
+    const session = makeSession(`busy-${_label}`, 3161);
+    Object.assign(session, state);
+
+    expect(sessionIsBusy(session)).toBe(true);
+  });
+
+  // The cases above set the flag by hand, so they pin how it is read and nothing about how it is
+  // maintained. With a plain boolean the first queued op's clear runs before the second op's body,
+  // so the session reads idle while a restart is still running — it fails in exactly the pile-up
+  // the flag exists for, and every hand-set case stays green.
+  it('still reports busy while a second queued restart is running', async () => {
+    const session = makeSession('queued', 3163);
+    session.status = 'stopped';
+    const seen: boolean[] = [];
+    let releaseFirst: (() => void) | null = null;
+
+    session.start = vi.fn(async () => session.getStatus());
+    const first = session.restart(async () => {
+      seen.push(sessionIsBusy(session));
+      await new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+    });
+    const second = session.restart(async () => {
+      seen.push(sessionIsBusy(session));
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    releaseFirst?.();
+    await Promise.all([first, second]);
+
+    expect(seen).toEqual([true, true]);
+    expect(sessionIsBusy(session)).toBe(false);
+  });
+
+  // The negative control. Without it, a predicate hardwired to true would pass every case above
+  // and no session could ever be taken over.
+  it('reports a plain dead session as free to take over', () => {
+    const session = makeSession('idle', 3162);
+    session.status = 'crashed';
+
+    expect(sessionIsBusy(session)).toBe(false);
+  });
+});
+
+describe('dev-server worktree checks', () => {
+  // Racing a timeout bounds the caller's wait, not the libuv slot the loser keeps — so without
+  // dedupe the TUI polling twice a second injects two 21s jobs per second into a four-slot pool
+  // and it never drains. One probe in flight per path is what actually bounds it.
+  it('runs one probe at a time for a path', async () => {
+    accessMock.mockImplementation(() => new Promise(() => undefined));
+
+    const first = checkPath('/slow/worktree');
+    const second = checkPath('/slow/worktree');
+
+    expect(await first).toEqual({ exists: true, timedOut: true });
+    expect(await second).toEqual({ exists: true, timedOut: true });
+    expect(accessMock).toHaveBeenCalledTimes(1);
+  });
+
+  // Slow is not evidence of deletion, and calling a live worktree missing is the more damaging
+  // wrong answer — but the caller is told the check never landed, so a listing can say "could not
+  // tell" instead of "fine".
+  it('reports a worktree that will not answer as present, and says so', async () => {
+    accessMock.mockImplementation(() => new Promise(() => undefined));
+
+    expect(await checkPath('/unreachable/worktree')).toEqual({ exists: true, timedOut: true });
+  });
+
+  it('reports a missing worktree as missing', async () => {
+    accessMock.mockRejectedValue(new Error('ENOENT'));
+
+    expect(await checkPath('/deleted/worktree')).toEqual({ exists: false, timedOut: false });
+  });
+
+  // A miss is never slow, so caching one protects nothing and makes a worktree created seconds
+  // after a failed start read as still missing — with an error naming the path, which sends the
+  // reader after the wrong thing entirely.
+  it('re-probes a path that was missing rather than trusting the last answer', async () => {
+    accessMock.mockRejectedValueOnce(new Error('ENOENT'));
+    expect(await checkPath('/worktree/created/late')).toEqual({ exists: false, timedOut: false });
+
+    accessMock.mockResolvedValue(undefined);
+    expect(await checkPath('/worktree/created/late')).toEqual({ exists: true, timedOut: false });
+  });
+
+  // The other half: a settled hit IS reused, which is what collapses the TUI's twice-a-second
+  // polling into one probe.
+  it('reuses a settled hit within the cache window', async () => {
+    expect(await checkPath('/worktree/present')).toEqual({ exists: true, timedOut: false });
+    expect(await checkPath('/worktree/present')).toEqual({ exists: true, timedOut: false });
+
+    expect(accessMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('dev-server session listing', () => {
+  // Where someone hunting a permanently-reserved port actually looks: a session whose worktree has
+  // been deleted still holds its port and can never be started again.
+  it('marks a session whose worktree is gone', async () => {
+    const gone = resolve(tmpdir(), 'wt-that-does-not-exist');
+    makeSession('present', 3171);
+    makeSession('vanished', 3172).worktree = gone;
+    accessMock.mockImplementation(async (path: string) => {
+      if (path === gone) throw new Error('ENOENT');
+    });
+
+    const listed = await listSessions();
+
+    expect(listed.find((s) => s.id === 'present')?.worktreeMissing).toBe(false);
+    expect(listed.find((s) => s.id === 'vanished')?.worktreeMissing).toBe(true);
   });
 });
 


### PR DESCRIPTION
@
Closes ClickUp `868kr5k0g`.

## The bug

`getUsedPorts()` reserved a port only for sessions in `running` or `starting`. A session marked `crashed` lost its reservation **while its process may still be alive and holding the port** — which is not hypothetical: the daemon has reported `crashed` for a session that was serving 200s.

This is not #3889. That one fixed the *probe* (the picker now checks all three occupied states instead of one), which makes the picker safe in the presence of this bug without fixing it. The probe still cannot see a listener bound only to a non-loopback address, and it cannot see the window inside `restart()` where the process is dead and the port is about to be rebound.

## The rule

**A tracked session owns its port whatever its status says.** Status is a report the daemon writes about a process it cannot see into. Membership of the `sessions` map is the reservation; removal is the release, and removal is exactly what `cli stop <id>` already does (`DELETE /sessions/:id`). No new manual step.

## Three causes of the wrong status, fixed with it

1. **`stop()` filed its own kills as crashes.** It hard-kills, the process exits nonzero, and the exit handler read `code !== 0` as `crashed`. It now records `stopped` and detaches before killing. This is likely most of what made `crashed` untrustworthy in the first place.
2. **Exit/error handlers were not identity-guarded.** A process exiting *after* a restart replaced it marked the **new, live** session crashed, and taskkilled a pid Windows may already have reused. `AuthHub` already guards on process identity; `DevSession` now does too.
3. **`start` on a worktree with a dead session stranded that session.** It created a second session while the first kept its port — which under the new rule would cost a port per crash. It now restarts the existing session on its own port, so `start` and `restart` are the same thing for an existing worktree. That also removes the "use `restart`, never `start`, or you will steal a live session's port" footgun.

`DELETE` now probes the port after stopping and returns a `warning` when something still listens — the case where a kill missed an orphaned grandchild. It reports; it does not hold the reservation open.

## Tests

`scripts/__tests__/dev-server-port-reservation.test.ts` — 13 tests, driving the real `DevSession` with fake child processes (EventEmitters; nothing is spawned, no pid is killed, no fake drives a loop).

To make that possible, `daemon.mjs` calls `main()` only when it is the process entry point and exports `{ DevSession, sessions, getUsedPorts }`. Positive control for that guard: run directly on an alt port, it still boots and serves (`{"sessions":[]}`) and shuts down cleanly.

Each fix was mutation-tested by reverting it and confirming the failure names the wrong value:

| reverted | failure |
|---|---|
| status-gated `getUsedPorts` | `expected [] to deeply equal [ 3011 ]` |
| eager `stopped` in `stop()` | `expected 'crashed' to be 'stopped'` |
| identity guard on exit | `expected 'crashed' to be 'running'` |

## Verification

- `pnpm run typecheck` — 0 errors.
- `pnpm run lint` — clean on both changed files.
- `pnpm run test:unit:run` — 16616 passed; `blocks.router.workflow.test.ts` collected **347** tests, so the submodule was initialised and the run means something. 16 tests in 6 files fail, all `src/`-scanning drift guards (app-spend-tier, block-scope, analytics-bucket-labels, orchestrator-chat wait, singletons, typecheck wrapper). They fail identically on a clean checkout of this base with the change removed — pre-existing, not mine.

## ⚠️ Needs a daemon restart

**A running daemon holds the old code in memory**, which is why #3889 did nothing until the daemon was restarted. This does not take effect on merge; someone has to restart the daemon on 9444, and that interrupts every agent's dev server. I am coordinating that window with Justin rather than doing it silently.

## What this does not fix

- A listener bound only to a non-loopback address is still invisible on Windows (unchanged from #3889).
- `cli stop` on a session whose grandchild outlived the kill still releases the port; the new `warning` makes that visible, and the picker's probe is what stands between it and reuse.
- The restart-reuse path and the `DELETE` warning are HTTP-handler code and are covered by review, not by the unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@