### PR TITLE
test(creator-studio): pin the POI guard on the licensing-fee writes

### DIFF
--- a/apps/creator-studio/src/lib/server/__tests__/licensing-fee-poi-guard.test.ts
+++ b/apps/creator-studio/src/lib/server/__tests__/licensing-fee-poi-guard.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Membership } from '../membership';
+
+// Kysely fake. `rows` is what the owned-versions read returns; `written` records every `.set()` so a test
+// can assert the write never happened — a guard that returns 400 after writing would otherwise pass.
+const state = vi.hoisted(() => ({
+  rows: [] as Record<string, unknown>[],
+  written: [] as Record<string, unknown>[],
+}));
+
+vi.mock('$lib/server/db', () => {
+  const select: Record<string, unknown> = {};
+  const update: Record<string, unknown> = {};
+  const chain = (target: Record<string, unknown>) =>
+    new Proxy(target, {
+      get: (t, prop: string) => t[prop] ?? (() => chain(t)),
+    });
+  select.execute = async () => state.rows;
+  update.set = (values: Record<string, unknown>) => {
+    state.written.push(values);
+    return chain(update);
+  };
+  update.executeTakeFirst = async () => ({ numUpdatedRows: BigInt(state.rows.length) });
+  update.execute = async () => [];
+  const db = {
+    selectFrom: () => chain(select),
+    updateTable: () => chain(update),
+    transaction: () => ({ execute: async (cb: (trx: unknown) => unknown) => cb(db) }),
+  };
+  return { dbRead: db, dbWrite: db };
+});
+
+const { setLicensingFee, bulkSetLicensingFee } = await import('../monetization/licensing-fee');
+
+const GOLD: Membership = { tier: 'gold', isMember: true, isCreatorProgramMember: true };
+
+const version = (over: Partial<Record<string, unknown>> = {}) => ({
+  id: 1,
+  baseModel: 'SDXL 1.0',
+  modelType: 'Checkpoint',
+  currentFee: null,
+  meta: null,
+  poi: false,
+  ...over,
+});
+
+beforeEach(() => {
+  state.rows = [];
+  state.written = [];
+});
+
+// Creator Studio writes `licensingFee` with its own SQL and never reaches the main app, so the POI rule
+// #3903 enforces there has to be re-applied here or this spoke is a way around it. The non-POI cases are
+// the positive control: they prove the refusal comes from `poi`, not from a fixture that can't save at all.
+describe('licensing fee POI guard', () => {
+  it('refuses a fee on a version whose model depicts a real person', async () => {
+    state.rows = [version({ poi: true })];
+
+    const result = await setLicensingFee(7, GOLD, 1, 1, true);
+
+    expect(result).toEqual({
+      ok: false,
+      status: 400,
+      error: "A model depicting a real person can't be monetized.",
+    });
+    expect(state.written).toEqual([]);
+  });
+
+  it('allows the same fee when the model is not POI', async () => {
+    state.rows = [version()];
+
+    const result = await setLicensingFee(7, GOLD, 1, 1, true);
+
+    expect(result).toEqual({ ok: true });
+    expect(state.written[0]).toMatchObject({ licensingFee: '1.00' });
+  });
+
+  it('refuses a bulk fee when any selected version is POI', async () => {
+    state.rows = [version(), version({ id: 2, poi: true })];
+
+    const result = await bulkSetLicensingFee(7, GOLD, [1, 2], 1, true);
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: 400,
+      error: expect.stringContaining('depict a real person'),
+    });
+    expect(state.written).toEqual([]);
+  });
+
+  it('allows the same bulk fee when no selected version is POI', async () => {
+    state.rows = [version(), version({ id: 2 })];
+
+    const result = await bulkSetLicensingFee(7, GOLD, [1, 2], 1, true);
+
+    expect(result).toMatchObject({ ok: true, updated: 2 });
+    expect(state.written[0]).toMatchObject({ licensingFee: '1.00' });
+  });
+});

--- a/apps/creator-studio/src/lib/server/__tests__/licensing-fee-poi-guard.test.ts
+++ b/apps/creator-studio/src/lib/server/__tests__/licensing-fee-poi-guard.test.ts
@@ -51,17 +51,18 @@ beforeEach(() => {
 
 // Creator Studio writes `licensingFee` with its own SQL and never reaches the main app, so the POI rule
 // #3903 enforces there has to be re-applied here or this spoke is a way around it. The non-POI cases are
-// the positive control: they prove the refusal comes from `poi`, not from a fixture that can't save at all.
+// the positive control: they prove the refusal is attributable to `poi` rather than to ownership or a
+// missing rights affirmation, which refuse through this same return shape.
 describe('licensing fee POI guard', () => {
   it('refuses a fee on a version whose model depicts a real person', async () => {
     state.rows = [version({ poi: true })];
 
     const result = await setLicensingFee(7, GOLD, 1, 1, true);
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       ok: false,
       status: 400,
-      error: "A model depicting a real person can't be monetized.",
+      error: expect.stringContaining('real person'),
     });
     expect(state.written).toEqual([]);
   });

--- a/apps/creator-studio/vitest.config.ts
+++ b/apps/creator-studio/vitest.config.ts
@@ -1,8 +1,17 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
 // Separate from vite.config.ts: node-env unit tests over plain modules, no SvelteKit
 // pipeline needed. `name` is required — see the `apps/*` note in the root vitest.config.mts.
 export default defineConfig({
+  // SvelteKit resolves `$lib` through its own plugin, which this config deliberately doesn't load, so a
+  // suite over a module that imports `$lib/...` fails to collect without this.
+  resolve: {
+    alias: {
+      $lib: path.resolve(path.dirname(fileURLToPath(import.meta.url)), './src/lib'),
+    },
+  },
   test: {
     name: 'app:creator-studio',
     environment: 'node',


### PR DESCRIPTION
## Why

Audit of `868kr8a69` asked whether a POI/private guard covers **every** fee/paid-access write in `apps/creator-studio`. It does:

- `licensingFee` is written only by `writeFee`, whose two callers `setLicensingFee` and `bulkSetLicensingFee` both apply `licensingFeeBlockedFor` (POI-only) first.
- Paid access never touches SQL from this app — it POSTs `/api/v1/model-versions/early-access`, which applies `paidAccessBlockedFor` (POI **or** private) *before* the permanent/`WEBHOOK_TOKEN` branch, so Creator Studio's permanent path does not bypass it.
- The other two direct Kysely writes in the app set `usageControl` only.
- `fee-csv.ts` is export-only; `ownedVersionsWithFee`, `VariedFeeEntry`, `VariedFeeSkip`, `FeeChange` and `FeePreview` have zero callers.

No guard was missing, so this PR adds **no** behaviour. What was missing is a check: deleting either guard call site broke no test. #3903's positive control pins the *predicate* in `@civitai/buzz`, not that Creator Studio calls it.

## What

Four cases over the two exported fee writers, with a fake Kysely so the test can assert the write never happened (a guard that refuses *after* writing would otherwise pass).

## Positive control

With `licensingFeeBlockedFor` neutered to `=> false`:

```
PASS (2) FAIL (2)
AssertionError: expected { ok: true } to deeply equal { ok: false, status: 400, …(1) }
AssertionError: expected { ok: true, updated: 2 } to match object { ok: false, status: 400, …(1) }
```

The two that keep passing are the non-POI cases, so the refusal is attributable to `poi` and not to a fixture that cannot save at all.

## Verification

- `pnpm typecheck` (creator-studio, svelte-check): `0 ERRORS 3 WARNINGS` — all three pre-existing in `packages/civitai-ui`.
- `pnpm lint` (creator-studio): exit 0, only pre-existing warnings.
- `pnpm test` (creator-studio): 7 files, 43 passed.
- `pnpm run test:unit:run`: `16 failed | 16609 passed (16643)`. **Identical on a clean tree with this diff removed** — six repo-scan drift guards whose own positive controls fail locally. Not introduced here.
- `blocks.router.workflow.test.ts` collected **347** tests (submodule initialised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)