### PR TITLE
fix(buzz): require a destination account type unless the bank is being paid

### DIFF
--- a/apps/creator-studio/src/lib/server/models-earnings.ts
+++ b/apps/creator-studio/src/lib/server/models-earnings.ts
@@ -64,8 +64,8 @@ export type ChannelTotals = {
   total: number;
   prev: number;
   // What the CREATOR was credited, by account type. The filter chips sum a subset of this.
-  // NOTE: `createMultiAccountBuzzTransaction` defaults the credit to yellow, so on the buyer-funded
-  // channels (access sales, donations) this is always yellow whatever the buyer actually paid with.
+  // Buyer-funded channels pay in the currency the buyer spent, so rows dated before that cutover
+  // are yellow-only whatever was actually paid.
   received: ChannelCurrency[];
 };
 

--- a/src/server/routers/comics.router.ts
+++ b/src/server/routers/comics.router.ts
@@ -93,7 +93,7 @@ import {
   refundMultiAccountTransaction,
 } from '~/server/services/buzz.service';
 import { TransactionType } from '~/shared/constants/buzz.constants';
-import { getAllowedAccountTypes } from '~/server/utils/buzz-helpers';
+import { domainSpendType, getAllowedAccountTypes } from '~/server/utils/buzz-helpers';
 import type { FeatureAccess } from '~/server/services/feature-flags.service';
 import { trackModActivity } from '~/server/services/moderator.service';
 import { PutObjectCommand } from '@aws-sdk/client-s3';
@@ -4938,9 +4938,7 @@ export const comicsRouter = router({
       let buzzTransactionId: string | undefined;
       try {
         const externalTransactionIdPrefix = `comic-ea-${chapter.id}-${ctx.user.id}`;
-        // One currency, the domain's, spent AND received. `getAllowedAccountTypes`
-        // with no seed returns exactly one element.
-        const [spendType] = getAllowedAccountTypes(ctx.features);
+        const spendType = domainSpendType(ctx.features);
         const data = await createMultiAccountBuzzTransaction({
           fromAccountId: ctx.user.id,
           toAccountId: chapter.project.userId,

--- a/src/server/routers/comics.router.ts
+++ b/src/server/routers/comics.router.ts
@@ -4938,6 +4938,9 @@ export const comicsRouter = router({
       let buzzTransactionId: string | undefined;
       try {
         const externalTransactionIdPrefix = `comic-ea-${chapter.id}-${ctx.user.id}`;
+        // One currency, the domain's, spent AND received. `getAllowedAccountTypes`
+        // with no seed returns exactly one element.
+        const [spendType] = getAllowedAccountTypes(ctx.features);
         const data = await createMultiAccountBuzzTransaction({
           fromAccountId: ctx.user.id,
           toAccountId: chapter.project.userId,
@@ -4946,7 +4949,8 @@ export const comicsRouter = router({
           description: `Early access: ${chapter.project.name} - ${chapter.name}`,
           details: { comicChapterId: chapter.id, earlyAccessPurchase: true },
           externalTransactionIdPrefix,
-          fromAccountTypes: getAllowedAccountTypes(ctx.features),
+          fromAccountTypes: [spendType],
+          toAccountType: spendType,
         });
 
         if (data?.transactionCount === 0) {

--- a/src/server/services/__tests__/buzz.service.multi-account-destination.test.ts
+++ b/src/server/services/__tests__/buzz.service.multi-account-destination.test.ts
@@ -25,10 +25,14 @@ import { createMultiAccountBuzzTransaction } from '~/server/services/buzz.servic
 const SELLER = 4242;
 const BANK = 0;
 
+// The spend list is deliberately a DIFFERENT currency from every destination asserted below.
+// Spending green while paying green would make `fromAccountTypes[0]` a perfect proxy for the
+// destination, so an implementation that pays in the currency spent — ignoring the named
+// destination entirely — would pass every assertion here.
 const charge = (overrides: Record<string, unknown>) =>
   createMultiAccountBuzzTransaction({
     fromAccountId: 111,
-    fromAccountTypes: ['green'],
+    fromAccountTypes: ['blue'],
     amount: 500,
     externalTransactionIdPrefix: 'test-prefix',
     ...overrides,
@@ -63,6 +67,23 @@ describe('createMultiAccountBuzzTransaction destination', () => {
     const [payload] = createMultiTransaction.mock.calls[0];
     expect(payload.toAccountId).toBe(SELLER);
     expect(payload.toAccountType).toBe('green');
+  });
+
+  it('refuses a user destination at COMPILE time', () => {
+    // The `charge` helper casts, which erases the union — this is the only assertion covering the
+    // type half. Widening the destination back to an always-optional `toAccountType` makes the
+    // directive unused and fails the build with TS2578.
+    const payUserWithNoDestinationType = () =>
+      // @ts-expect-error - toAccountType is required whenever toAccountId is not the bank
+      createMultiAccountBuzzTransaction({
+        fromAccountId: 111,
+        fromAccountTypes: ['blue'],
+        amount: 500,
+        externalTransactionIdPrefix: 'test-prefix',
+        toAccountId: SELLER,
+      });
+
+    expect(payUserWithNoDestinationType).toBeTypeOf('function');
   });
 
   it('lets a bank charge omit the account type and books it as yellow', async () => {

--- a/src/server/services/__tests__/buzz.service.multi-account-destination.test.ts
+++ b/src/server/services/__tests__/buzz.service.multi-account-destination.test.ts
@@ -72,7 +72,8 @@ describe('createMultiAccountBuzzTransaction destination', () => {
   it('refuses a user destination at COMPILE time', () => {
     // The `charge` helper casts, which erases the union — this is the only assertion covering the
     // type half. Widening the destination back to an always-optional `toAccountType` makes the
-    // directive unused and fails the build with TS2578.
+    // directive unused, which only `scripts/ci/typecheck-tests-gate.mjs` reports: `pnpm typecheck`
+    // runs the root tsconfig, and that excludes `src/**/__tests__/**`.
     const payUserWithNoDestinationType = () =>
       // @ts-expect-error - toAccountType is required whenever toAccountId is not the bank
       createMultiAccountBuzzTransaction({

--- a/src/server/services/__tests__/buzz.service.multi-account-destination.test.ts
+++ b/src/server/services/__tests__/buzz.service.multi-account-destination.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * A multi-account charge that pays a USER must name the destination account type.
+ *
+ * It used to default to `'yellow'` when omitted, which four separate features shipped
+ * without noticing (#3911, #3917, #3919, #3921): a green purchase paid the seller yellow,
+ * silently, with no error and no log. Paying the BANK (account 0) may still omit it —
+ * the bank is a ledger, not a balance, and it pays out in colours it was never credited in.
+ */
+
+import type * as BuzzClient from '@civitai/buzz';
+
+const { createMultiTransaction } = vi.hoisted(() => ({ createMultiTransaction: vi.fn() }));
+
+// Spread the real package and override only the client factory: a hand-listed factory would
+// couple this file to every export buzz.service happens to import from it.
+vi.mock('@civitai/buzz', async (importOriginal) => ({
+  ...(await importOriginal<typeof BuzzClient>()),
+  createBuzzClient: () => ({ createMultiTransaction }),
+}));
+
+import { createMultiAccountBuzzTransaction } from '~/server/services/buzz.service';
+
+const SELLER = 4242;
+const BANK = 0;
+
+const charge = (overrides: Record<string, unknown>) =>
+  createMultiAccountBuzzTransaction({
+    fromAccountId: 111,
+    fromAccountTypes: ['green'],
+    amount: 500,
+    externalTransactionIdPrefix: 'test-prefix',
+    ...overrides,
+  } as Parameters<typeof createMultiAccountBuzzTransaction>[0]);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  createMultiTransaction.mockResolvedValue({
+    transactionIds: [{ transactionId: 'tx-1', accountType: 'user', amount: 500 }],
+    totalAmount: 500,
+    transactionCount: 1,
+  });
+});
+
+describe('createMultiAccountBuzzTransaction destination', () => {
+  it('refuses a user destination with no account type instead of paying yellow', async () => {
+    // Resolved-vs-rejected as data, so a regression reports the currency the seller WOULD have
+    // been paid in rather than "promise resolved instead of rejecting".
+    const outcome = await charge({ toAccountId: SELLER }).then(
+      () => ({ paidWith: createMultiTransaction.mock.calls[0]?.[0]?.toAccountType }),
+      (error: Error) => ({ refusedWith: error.message })
+    );
+
+    expect(outcome).toEqual({ refusedWith: expect.stringContaining('toAccountType is required') });
+    expect(createMultiTransaction).not.toHaveBeenCalled();
+  });
+
+  it('pays a user in the account type named, not the default', async () => {
+    await charge({ toAccountId: SELLER, toAccountType: 'green' });
+
+    expect(createMultiTransaction).toHaveBeenCalledTimes(1);
+    const [payload] = createMultiTransaction.mock.calls[0];
+    expect(payload.toAccountId).toBe(SELLER);
+    expect(payload.toAccountType).toBe('green');
+  });
+
+  it('lets a bank charge omit the account type and books it as yellow', async () => {
+    await charge({ toAccountId: BANK });
+
+    const [payload] = createMultiTransaction.mock.calls[0];
+    expect(payload.toAccountId).toBe(BANK);
+    expect(payload.toAccountType).toBe('yellow');
+  });
+});

--- a/src/server/services/buzz.service.ts
+++ b/src/server/services/buzz.service.ts
@@ -1111,13 +1111,33 @@ export async function refundTransaction(
   return buzzService.refundTransaction(transactionId, { description, details });
 }
 
+/**
+ * The bank (account 0) is a system ledger, not a balance-constrained account, so what it is
+ * credited in is bookkeeping: it pays out in colours it was never credited in. Callers paying the
+ * bank may omit the destination type and land here; callers paying a USER may not, because for
+ * them the colour is the payout.
+ */
+const BANK_LEDGER_ACCOUNT_TYPE = 'yellow' satisfies BuzzAccountType;
+
+type MultiAccountBuzzDestination =
+  | { toAccountId: 0; toAccountType?: BuzzAccountType }
+  | { toAccountId: number; toAccountType: BuzzAccountType };
+
 export async function createMultiAccountBuzzTransaction(
-  input: CreateMultiAccountBuzzTransactionInput & { fromAccountId: number },
+  input: Omit<CreateMultiAccountBuzzTransactionInput, 'toAccountId' | 'toAccountType'> & {
+    fromAccountId: number;
+  } & MultiAccountBuzzDestination,
   opts?: BuzzWriteOptions
 ) {
-  // Default user acc:
-  input.toAccountType = input.toAccountType ?? 'yellow'; // Default to bank if not provided
-  const data = await buzzService.createMultiTransaction(input, opts);
+  if (input.toAccountId !== 0 && !input.toAccountType)
+    throw throwBadRequestError(
+      `toAccountType is required when paying account ${input.toAccountId}; only the bank (account 0) may omit it`
+    );
+
+  const data = await buzzService.createMultiTransaction(
+    { ...input, toAccountType: input.toAccountType ?? BANK_LEDGER_ACCOUNT_TYPE },
+    opts
+  );
 
   return createMultiAccountBuzzTransactionResponse.parse(data);
 }


### PR DESCRIPTION
## The defect

`createMultiAccountBuzzTransaction` did `input.toAccountType = input.toAccountType ?? 'yellow'`. Omitting the destination compiled, typechecked and passed every test, and paid a green buyer's seller in yellow with no error and no log. Four independent authors shipped that same omission today — #3911 placements, #3917 paid access, #3919 donations, #3921 comics. This is the change that stops a fifth.

## The shape

The destination is **required at compile time whenever `toAccountId` is not literally `0`**:

```ts
type MultiAccountBuzzDestination =
  | { toAccountId: 0; toAccountType?: BuzzAccountType }
  | { toAccountId: number; toAccountType: BuzzAccountType };
```

The `?? 'yellow'` survives only on the bank path, where it is now named `BANK_LEDGER_ACCOUNT_TYPE`. A runtime guard sits behind the type for anything reaching the function untyped.

Deliberately **not** done: changing the default while leaving the parameter optional. That silently fixes some sites and breaks others, which is the failure this PR exists to end.

### Why the ten bank call sites are untouched

The bank (`toAccountId: 0`) is a system ledger, not a balance-constrained account — it pays out in colours it was never credited in, and does so in production routinely. Making those sites write `toAccountType: 'yellow'` would read as a decision where there is none. They keep omitting it; the type now says why that is legal.

### Comic early access

`comics.router.ts` was the only user-paying site left on the default, so it is the only site this PR had to change — the same fix as **open PR #3921**. Whichever lands second takes a trivial conflict. Not stacked: this branch is off `main`.

### Bounty award: checked, not a defect

`bountyEntry.service.ts` does not call this function. It uses `createBuzzTransactionMany` and already derives one transaction per account type from the actual funding legs, so a winner is paid in the currencies the benefactors funded. Its legacy fallback at `:441` (reached only when no `buzzTransactionId` was recorded) uses `createBuzzTransaction` — a different function, outside this change, worth its own look.

## Verification

- `pnpm run typecheck` — clean.
- **Positive control:** removing `toAccountType` from the comics call reproduces `Property 'toAccountType' is missing … but required in type '{ toAccountId: number; toAccountType: BuzzAccountType }'`.
- **Adversarial review** probed nine bad caller shapes — literal non-zero id, `number` variable, spread of a pre-built object, explicit `toAccountType: undefined`, `as const` spread, a wholesale-forwarded raw zod input, a `let`-widened `number` holding 0, a `cond ? 0 : SELLER` ternary — all fail to compile, and four legitimate shapes still do. Only `any` escapes the type, and the runtime guard catches that.
- All 13 call sites pass freshly-built object literals, so removing the old input **mutation** breaks no caller; the two `withRetries` sites rebuild per attempt.
- `pnpm run test:unit:run` — 16617 passed. The 16 failures in 6 files reproduce identically on a stash of this branch. `blocks.router.workflow.test.ts` collected **347** tests, so the run means something.
- **Mutation test 1** — delete the runtime guard: `expected { paidWith: 'yellow' } to deeply equal { refusedWith: … }`. Names the currency the seller would have been paid in.
- **Mutation test 2** — make the service pay in the currency *spent*, ignoring the named destination: `expected 'blue' to be 'green'`. The first version of this test passed that mutation, because it spent green and asserted green; the fixture now spends **blue** against a **green** destination so the two can't stand in for each other.
- The compile-time half is pinned by a `@ts-expect-error` on an uncast bad shape. Its positive control is the `typecheck-tests` gate count staying at 801/141 — an unused directive would raise it.

⚠️ Unrelated and pre-existing: that gate is BLOCKED on `sticker-placement.service.test.ts` (16→17). It fails identically on `origin/main` at `8da74a5ef7`.

No money moved during verification; every prod query was read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)