### PR TITLE
feat(licenses): register the MiniMax H3 Community License

### DIFF
--- a/packages/civitai-shared/src/basemodel.constants.ts
+++ b/packages/civitai-shared/src/basemodel.constants.ts
@@ -2386,6 +2386,16 @@ export const licenses: LicenseRecord[] = [
     name: 'LTX-2.x Community License Agreement',
     url: 'https://github.com/Lightricks/LTX-2/blob/2362161611a61154d342e02724fb8fe58efd455d/LICENSE.md',
   },
+  {
+    id: 41,
+    // Separate from id 33: that is the Hailuo hosted-service ToS, this is the
+    // 2 Aug 2026 open-weights licence the on-site H3 models carry.
+    name: 'MiniMax H3 Community License Agreement',
+    url: 'https://huggingface.co/MiniMaxAI/MiniMax-H3',
+    notice:
+      'MiniMax H3 is licensed by MiniMax under the MiniMax H3 Community License Agreement. That agreement’s Applicable Territory currently excludes the EU, the UK, South Korea and the USA; we are working with MiniMax on coverage for creators in those regions.',
+    poweredBy: 'MiniMax H3',
+  },
 ];
 
 export const licenseById = new Map(licenses.map((l) => [l.id, l]));
@@ -3405,7 +3415,7 @@ export const baseModelRecords: BaseModelRecord[] = [
     description: "MiniMax's video generation model with cinematic quality",
     type: 'video',
     ecosystemId: ECO.MiniMaxH3,
-    licenseId: 33,
+    licenseId: 41,
   },
 
   // Kling

--- a/packages/civitai-shared/src/basemodel.constants.ts
+++ b/packages/civitai-shared/src/basemodel.constants.ts
@@ -88,6 +88,10 @@ export type LicenseRecord = {
   url?: string;
   notice?: string;
   poweredBy?: string;
+  // Set only when the licence obliges us to name the model in the product's own
+  // UI, and holds the exact string it demands. Distinct from `poweredBy`, which
+  // several licences use for a liability disclaimer rather than an attribution.
+  attribution?: string;
   disableMature?: boolean;
   // License forbids commercial use (drives commercial-use override + monetization block).
   nonCommercial?: boolean;
@@ -2391,9 +2395,14 @@ export const licenses: LicenseRecord[] = [
     // Separate from id 33: that is the Hailuo hosted-service ToS, this is the
     // 2 Aug 2026 open-weights licence the on-site H3 models carry.
     name: 'MiniMax H3 Community License Agreement',
-    url: 'https://huggingface.co/MiniMaxAI/MiniMax-H3',
+    // Permalinked to the 2 Aug 2026 revision. The model page tracks the latest
+    // commit, and section III.1 obliges us to hand over a stable copy.
+    url: 'https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/42ed227ee7df40d41602854ae760620d6eb651fe/LICENSE',
     notice:
-      'MiniMax H3 is licensed by MiniMax under the MiniMax H3 Community License Agreement. That agreement’s Applicable Territory currently excludes the EU, the UK, South Korea and the USA; we are working with MiniMax on coverage for creators in those regions.',
+      'MiniMax H3 is licensed by MiniMax under the MiniMax H3 Community License Agreement. That agreement’s Applicable Territory excludes the European Union, the United Kingdom, the Republic of Korea and the United States of America. Your use of H3 and of any H3 derivative is subject to that agreement and its Acceptable Use Policy.',
+    // Section IV.2 demands this exact string in the product UI. "Powered by
+    // MiniMax H3" is the separate, merely encouraged notice in III.3(a).
+    attribution: 'MiniMax H3',
     poweredBy: 'MiniMax H3',
   },
 ];

--- a/src/components/generation_v2/FormFooter.tsx
+++ b/src/components/generation_v2/FormFooter.tsx
@@ -34,7 +34,7 @@ import {
   IconX,
 } from '@tabler/icons-react';
 import clsx from 'clsx';
-import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 
 import { useBuzzTransaction } from '~/components/Buzz/buzz.utils';
 import { useQueryBuzz } from '~/components/Buzz/useBuzz';
@@ -83,7 +83,11 @@ import {
   getEcosystemsForWorkflow,
   isWorkflowAvailable,
 } from '~/shared/data-graph/generation/config/workflows';
-import { ecosystemByKey } from '~/shared/constants/basemodel.constants';
+import {
+  ecosystemByKey,
+  getBaseModelLicense,
+  getBaseModelsByEcosystemId,
+} from '~/shared/constants/basemodel.constants';
 import {
   pickStrongerGate,
   rulesToStates,
@@ -974,6 +978,51 @@ function BlueBuzzMatureReminder() {
 // FormFooter Component
 // =============================================================================
 
+/**
+ * Model attribution under the submit button. Some vendor licences require the
+ * model to be named in the product's own UI, not just on the model page (e.g.
+ * the MiniMax H3 Community License §IV.2), and link a copy of the licence to
+ * anyone receiving the work (§III.1). Driven off the licence's `poweredBy`, so
+ * it covers any base model carrying one rather than naming ecosystems here.
+ */
+function EcosystemAttribution() {
+  const graph = useGraph<GenerationGraphTypes>();
+  const { ecosystem } = useGraphSubscriptions(graph, ['ecosystem'] as const) as {
+    ecosystem?: string;
+  };
+
+  const license = useMemo(() => {
+    const ecosystemId = ecosystem ? ecosystemByKey.get(ecosystem)?.id : undefined;
+    if (ecosystemId == null) return undefined;
+    return getBaseModelsByEcosystemId(ecosystemId)
+      .map((baseModel) => getBaseModelLicense(baseModel.id))
+      .find((found) => !!found?.poweredBy);
+  }, [ecosystem]);
+
+  if (!license?.poweredBy) return null;
+
+  return (
+    <Text size="xs" c="dimmed" ta="center">
+      {license.poweredBy}
+      {license.url && (
+        <>
+          {' · '}
+          <Text
+            component="a"
+            href={license.url}
+            target="_blank"
+            rel="noreferrer"
+            td="underline"
+            inherit
+          >
+            License
+          </Text>
+        </>
+      )}
+    </Text>
+  );
+}
+
 export function FormFooter({ onSubmitSuccess }: { onSubmitSuccess?: () => void } = {}) {
   const graph = useGraph<GenerationGraphTypes>();
   const currentUser = useCurrentUser();
@@ -1366,6 +1415,8 @@ export function FormFooter({ onSubmitSuccess }: { onSubmitSuccess?: () => void }
           </Tooltip>
         </div>
       )}
+
+      <EcosystemAttribution />
     </>
   );
 }

--- a/src/components/generation_v2/FormFooter.tsx
+++ b/src/components/generation_v2/FormFooter.tsx
@@ -979,11 +979,8 @@ function BlueBuzzMatureReminder() {
 // =============================================================================
 
 /**
- * Model attribution under the submit button. Some vendor licences require the
- * model to be named in the product's own UI, not just on the model page (e.g.
- * the MiniMax H3 Community License §IV.2), and link a copy of the licence to
- * anyone receiving the work (§III.1). Driven off the licence's `poweredBy`, so
- * it covers any base model carrying one rather than naming ecosystems here.
+ * Names the selected model under the submit button, for licences that oblige us
+ * to do it in the product's own UI rather than only on the model page.
  */
 function EcosystemAttribution() {
   const graph = useGraph<GenerationGraphTypes>();
@@ -996,14 +993,14 @@ function EcosystemAttribution() {
     if (ecosystemId == null) return undefined;
     return getBaseModelsByEcosystemId(ecosystemId)
       .map((baseModel) => getBaseModelLicense(baseModel.id))
-      .find((found) => !!found?.poweredBy);
+      .find((found) => !!found?.attribution);
   }, [ecosystem]);
 
-  if (!license?.poweredBy) return null;
+  if (!license?.attribution) return null;
 
   return (
-    <Text size="xs" c="dimmed" ta="center">
-      {license.poweredBy}
+    <Text size="xs" ta="center">
+      {license.attribution}
       {license.url && (
         <>
           {' · '}

--- a/src/server/__tests__/minimax-h3-license.test.ts
+++ b/src/server/__tests__/minimax-h3-license.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ECO,
+  baseModelRecords,
+  getBaseModelLicense,
+  getBaseModelsByEcosystemId,
+  licenses as sharedLicenses,
+} from '@civitai/shared/basemodel.constants';
+import { baseModelLicenses } from '~/server/common/constants';
+import type { BaseModel } from '~/server/common/constants';
+
+// The 2 Aug 2026 revision the on-site weights carry. A moving ref here would let
+// MiniMax rewrite the terms we point creators at, which is what section III.1's
+// "provide a copy" exists to prevent.
+const PERMALINK =
+  'https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/42ed227ee7df40d41602854ae760620d6eb651fe/LICENSE';
+
+// Section IV.2 names the string verbatim: "You shall prominently display
+// "MiniMax H3" on the user interface". Not the on-site display name
+// ("Hailuo H3 by MiniMax"), and not III.3(a)'s encouraged "Powered by" form.
+const REQUIRED_ATTRIBUTION = 'MiniMax H3';
+
+// Throws rather than returning undefined so a removed record fails as a named
+// error everywhere, instead of a TypeError in whichever test dereferences first.
+function h3Record() {
+  const record = baseModelRecords.find((r) => r.ecosystemId === ECO.MiniMaxH3);
+  if (!record) throw new Error('no base-model record registered for ECO.MiniMaxH3');
+  return record;
+}
+
+const serverLicense = () => baseModelLicenses[h3Record().name as BaseModel];
+
+describe('MiniMax H3 licence registration', () => {
+  it('registers the licence in the copy that enforces, under the live base-model name', () => {
+    // `BaseModel` is `string`, so a drifted key compiles fine and goes silently
+    // inert. Deriving the key from the record is what catches that.
+    const license = serverLicense();
+    expect(license, `no licence bound for base model '${h3Record().name}'`).toBeDefined();
+    expect(license!.name).toBe('MiniMax H3 Community License Agreement');
+  });
+
+  it('resolves through the chain the generator actually walks', () => {
+    const license = getBaseModelsByEcosystemId(ECO.MiniMaxH3)
+      .map((baseModel) => getBaseModelLicense(baseModel.id))
+      .find((found) => !!found?.attribution);
+    expect(license?.attribution).toBe(REQUIRED_ATTRIBUTION);
+  });
+
+  // Hand-listing the fields would let a policy flag added to one copy alone pass
+  // unnoticed, which is the drift this test exists to catch. `id` is the shared
+  // copy's join key and has no counterpart in the map keyed by display name.
+  it('keeps the two unsynced copies saying the same thing', () => {
+    const shared = sharedLicenses.find((l) => l.id === h3Record().licenseId);
+    expect(shared, `no shared licence record for id ${h3Record().licenseId}`).toBeDefined();
+    const { id: _id, ...sharedFields } = shared!;
+    expect(sharedFields).toEqual(serverLicense());
+  });
+
+  it('points at a pinned revision of the licence text', () => {
+    expect(serverLicense()!.url).toBe(PERMALINK);
+  });
+
+  it('names the excluded territories the agreement defines', () => {
+    const notice = serverLicense()!.notice ?? '';
+    for (const territory of [
+      'European Union',
+      'United Kingdom',
+      'Republic of Korea',
+      'United States of America',
+    ]) {
+      expect(notice, `notice omits ${territory}`).toContain(territory);
+    }
+  });
+
+  // Both were considered and deliberately rejected: the agreement permits
+  // commercial use below its revenue threshold, and does not bar mature
+  // derivatives. Either flag appearing here would block creators.
+  it('imposes no commercial or mature restriction', () => {
+    const server = serverLicense()!;
+    expect(server.nonCommercial).toBeUndefined();
+    expect(server.disableMature).toBeUndefined();
+    expect(server.restrictedNsfwLevels).toBeUndefined();
+    expect(server.requiresSameLicense).toBeUndefined();
+  });
+});
+
+describe('attribution is not a dumping ground', () => {
+  // `poweredBy` holds a 300-character liability disclaimer for the three Flux
+  // licences, so anything iterating it renders that under the generator's CTA.
+  // `attribution` exists to mean one thing only; this is the whitelist, not a
+  // spot-check, because the cost of a wrong entry is paid on every ecosystem.
+  it('is set only where a licence demands in-product naming', () => {
+    const carrying = sharedLicenses.filter((l) => !!l.attribution).map((l) => l.name);
+    expect(carrying).toEqual(['MiniMax H3 Community License Agreement']);
+  });
+
+  // Same whitelist over the other copy, which the shared one cannot see.
+  it('is set on no other base model in the enforcing copy', () => {
+    const carrying = Object.entries(baseModelLicenses)
+      .filter(([, license]) => !!license?.attribution)
+      .map(([baseModel]) => baseModel);
+    expect(carrying).toEqual([h3Record().name]);
+  });
+
+  // The disclaimer that motivated the split is 300 characters.
+  it('holds a short attribution string, never a disclaimer', () => {
+    for (const license of sharedLicenses.filter((l) => !!l.attribution)) {
+      expect(license.attribution!.length, `${license.name} attribution is too long`).toBeLessThan(
+        60
+      );
+    }
+  });
+});

--- a/src/server/common/constants.ts
+++ b/src/server/common/constants.ts
@@ -759,6 +759,13 @@ const baseLicenses: Record<string, LicenseDetails> = {
     // Ideogram Non-Commercial Model Agreement forbids commercial use.
     nonCommercial: true,
   },
+  'minimax h3': {
+    url: 'https://huggingface.co/MiniMaxAI/MiniMax-H3',
+    name: 'MiniMax H3 Community License Agreement',
+    notice:
+      'MiniMax H3 is licensed by MiniMax under the MiniMax H3 Community License Agreement. That agreement’s Applicable Territory currently excludes the EU, the UK, South Korea and the USA; we are working with MiniMax on coverage for creators in those regions.',
+    poweredBy: 'MiniMax H3',
+  },
 };
 
 export const baseModelLicenses: Record<BaseModel, LicenseDetails | undefined> = {
@@ -841,6 +848,7 @@ export const baseModelLicenses: Record<BaseModel, LicenseDetails | undefined> = 
   'Vidu Q1': baseLicenses['vidu'],
   Seedance: baseLicenses['seedream'],
   'Ideogram 4.0': baseLicenses['ideogram nc'],
+  'MiniMax H3': baseLicenses['minimax h3'],
 };
 
 export type ModelFileType = (typeof constants.modelFileTypes)[number];

--- a/src/server/common/constants.ts
+++ b/src/server/common/constants.ts
@@ -580,6 +580,10 @@ type LicenseDetails = {
   name: string;
   notice?: string;
   poweredBy?: string;
+  // Set only when the licence obliges us to name the model in the product's own
+  // UI, and holds the exact string it demands. Distinct from `poweredBy`, which
+  // several licences use for a liability disclaimer rather than an attribution.
+  attribution?: string;
   restrictedNsfwLevels?: NsfwLevel[];
   // When true, mature content is restricted (auto-derives `restrictedNsfwLevels`
   // to MATURE_NSFW_LEVELS). Use this instead of hand-listing levels.
@@ -760,10 +764,15 @@ const baseLicenses: Record<string, LicenseDetails> = {
     nonCommercial: true,
   },
   'minimax h3': {
-    url: 'https://huggingface.co/MiniMaxAI/MiniMax-H3',
+    // Permalinked to the 2 Aug 2026 revision. The model page tracks the latest
+    // commit, and section III.1 obliges us to hand over a stable copy.
+    url: 'https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/42ed227ee7df40d41602854ae760620d6eb651fe/LICENSE',
     name: 'MiniMax H3 Community License Agreement',
     notice:
-      'MiniMax H3 is licensed by MiniMax under the MiniMax H3 Community License Agreement. That agreement’s Applicable Territory currently excludes the EU, the UK, South Korea and the USA; we are working with MiniMax on coverage for creators in those regions.',
+      'MiniMax H3 is licensed by MiniMax under the MiniMax H3 Community License Agreement. That agreement’s Applicable Territory excludes the European Union, the United Kingdom, the Republic of Korea and the United States of America. Your use of H3 and of any H3 derivative is subject to that agreement and its Acceptable Use Policy.',
+    // Section IV.2 demands this exact string in the product UI. "Powered by
+    // MiniMax H3" is the separate, merely encouraged notice in III.3(a).
+    attribution: 'MiniMax H3',
     poweredBy: 'MiniMax H3',
   },
 };

--- a/src/server/services/orchestrator/ecosystems/minimax.handler.ts
+++ b/src/server/services/orchestrator/ecosystems/minimax.handler.ts
@@ -32,6 +32,10 @@ export const createMiniMaxInput = defineHandler<MiniMaxCtx, [VideoGenStepTemplat
   const isRef2Vid = data.workflow === 'img2vid:ref2vid';
   const hasImages = !!images?.length;
 
+  // H3 rejects a text-less request on every workflow, images or not (2013).
+  const prompt = data.prompt?.trim();
+  if (!prompt) throw new Error('A prompt is required for MiniMax H3');
+
   if (data.minimaxVariant === 'comfy') {
     const loras: Record<string, number> = {};
     for (const resource of data.resources ?? []) {
@@ -40,7 +44,7 @@ export const createMiniMaxInput = defineHandler<MiniMaxCtx, [VideoGenStepTemplat
 
     const shared = {
       engine: 'minimax-h3-comfy' as const,
-      prompt: data.prompt,
+      prompt,
       duration: data.duration,
       seed: data.seed,
       steps: data.steps,
@@ -95,7 +99,7 @@ export const createMiniMaxInput = defineHandler<MiniMaxCtx, [VideoGenStepTemplat
       $type: 'videoGen',
       input: removeEmpty({
         engine: 'minimax-h3',
-        prompt: data.prompt,
+        prompt,
         // A supplied frame dictates the framing, so let the provider adapt to it.
         aspectRatio: firstFrameImage
           ? 'adaptive'

--- a/src/server/services/orchestrator/ecosystems/minimax.handler.ts
+++ b/src/server/services/orchestrator/ecosystems/minimax.handler.ts
@@ -17,6 +17,7 @@ import type {
   VideoGenStepTemplate,
 } from '@civitai/client';
 import { removeEmpty } from '~/utils/object-helpers';
+import { throwBadRequestError } from '~/server/utils/errorHandling';
 import type { GenerationGraphTypes } from '~/shared/data-graph/generation/generation-graph';
 import { defineHandler } from './handler-factory';
 
@@ -34,7 +35,7 @@ export const createMiniMaxInput = defineHandler<MiniMaxCtx, [VideoGenStepTemplat
 
   // H3 rejects a text-less request on every workflow, images or not (2013).
   const prompt = data.prompt?.trim();
-  if (!prompt) throw new Error('A prompt is required for MiniMax H3');
+  if (!prompt) throw throwBadRequestError('A prompt is required for MiniMax H3');
 
   if (data.minimaxVariant === 'comfy') {
     const loras: Record<string, number> = {};

--- a/src/shared/data-graph/generation/minimax-graph.test.ts
+++ b/src/shared/data-graph/generation/minimax-graph.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { generationGraph } from './generation-graph';
+import { minimaxVersionIds } from './minimax-graph';
+import type { GenerationCtx } from './context';
+
+const ext: GenerationCtx = {
+  limits: { maxQuantity: 4, maxResources: 9, vidQuantity: 1 },
+  user: { isMember: true, tier: 'gold' },
+  gateRules: [],
+};
+
+function init(
+  workflow: string,
+  modelId: number,
+  images?: { url: string; width: number; height: number }[]
+) {
+  const graph = generationGraph as any;
+  graph.init(
+    {
+      workflow,
+      ecosystem: 'MiniMaxH3',
+      model: { id: modelId, baseModel: 'MiniMax H3', model: { type: 'Checkpoint' } },
+      ...(images ? { images } : {}),
+    },
+    ext
+  );
+  return graph;
+}
+
+const frame = [{ url: 'https://example.test/first-frame.jpeg', width: 1280, height: 720 }];
+
+// The shared prompt rule treats an attached image as excusing the prompt, which
+// is right for image models and wrong here: H3 rejects a text-less request on
+// every workflow (`content[0].text is empty for type=text`, 2013). A revert of
+// that reads as `expected false to be true` on the image-bearing workflows.
+describe('minimax prompt requirement', () => {
+  it.each([
+    ['txt2vid', undefined],
+    ['img2vid', frame],
+    ['img2vid:first-last', frame],
+    ['img2vid:ref2vid', frame],
+  ])('requires a prompt on %s', (workflow, images) => {
+    const graph = init(workflow, minimaxVersionIds['v1.0'], images);
+    expect(graph.getSnapshot('prompt').meta.required).toBe(true);
+  });
+
+  it('requires it on the comfy variant too', () => {
+    const graph = init('img2vid', minimaxVersionIds.comfy, frame);
+    expect(graph.getSnapshot('prompt').meta.required).toBe(true);
+  });
+
+  it('fails validation on the prompt when it is empty despite an attached frame', () => {
+    const graph = init('img2vid', minimaxVersionIds['v1.0'], frame);
+    graph.set({ prompt: '' });
+    const result = graph.validate();
+    expect(result.success).toBe(false);
+    // Naming the key matters: a fixture missing an unrelated field also fails
+    // validation, which would make this pass while proving nothing.
+    expect(Object.keys(result.errors)).toEqual(['prompt']);
+  });
+
+  it('passes once a prompt is present', () => {
+    const graph = init('img2vid', minimaxVersionIds['v1.0'], frame);
+    graph.set({ prompt: 'a slow dolly through a neon arcade' });
+    expect(graph.validate().success).toBe(true);
+  });
+});

--- a/src/shared/data-graph/generation/minimax-graph.ts
+++ b/src/shared/data-graph/generation/minimax-graph.ts
@@ -21,8 +21,8 @@ import {
   aspectRatioNode,
   createCheckpointGraph,
   createResourcesGraph,
+  createTextEditorGraph,
   imagesNode,
-  promptGraph,
   seedNode,
   sliderNode,
   snippetsGraph,
@@ -168,6 +168,8 @@ export const minimaxGraph = new DataGraph<
 
   .merge(triggerWordsGraph)
   .merge(snippetsGraph)
-  .merge(promptGraph);
+  // Unlike the shared promptGraph, an attached image does not excuse the prompt:
+  // H3 rejects a text-less request outright (`content[0].text is empty`, 2013).
+  .merge(createTextEditorGraph({ name: 'prompt', required: true }));
 
 export { minimaxAspectRatios };


### PR DESCRIPTION
@
Registers the MiniMax H3 Community License, surfaces the attribution it requires in the generator, and fixes an empty-prompt bug that made three H3 workflows fail 100% of the time.

Reviewed against the licence text itself and adversarially against the code; both passes are reflected below.

## License record

H3 pointed at license id 33, the Hailuo hosted-service terms — not the licence the on-site weights carry. Added the Community License as its own record (id 41) rather than overwriting 33, since they are two different documents. Both copies of the licence system are updated:

- `packages/civitai-shared/src/basemodel.constants.ts` — the typed display-side `licenses[]`, joined via `BaseModelRecord.licenseId`.
- `src/server/common/constants.ts` — `baseLicenses` + `baseModelLicenses`, the copy that actually enforces.

Adding to only one is a silent no-op, hence both, and a test now pins that they agree field for field.

No `nonCommercial` and no `disableMature`: the licence permits commercial use below its revenue threshold, and mature derivatives are not restricted. The URL is pinned to the 2 Aug 2026 revision of the LICENSE file rather than the model page, because §III.1 obliges us to provide a stable copy and the page tracks the latest commit.

## Attribution in the generator

§IV.2 requires the string `MiniMax H3` be displayed prominently in the UI of the product that uses the model. That is the generator, which previously had no licence surface at all — `poweredBy` rendered in exactly one place, the model detail page.

`EcosystemAttribution` in `FormFooter.tsx` renders `MiniMax H3 · License` under the Generate button, the second half linking the pinned licence copy (§III.1).

This is driven by a new `attribution` field rather than the existing `poweredBy`. Review caught that `poweredBy` is not a uniform attribution line: licences 14, 15 and 30 use it for a 300-character all-caps Black Forest Labs liability disclaimer, which the first version of this component would have rendered under the Generate button for every Flux, SD and Hunyuan user. `attribution` means one thing only — the exact string a licence obliges us to display in-product — and a test keeps it a whitelist of one.

## Empty prompt

The shared `promptGraph` rule requires a prompt only when no image is attached. That is right for image models and wrong for H3, which rejects a text-less request outright (`content[0].text is empty for type=text`, code 2013). Image-to-video, first-last-frame and reference-to-video could all submit a request that could never succeed — 19 such workflows, 0 successes.

Fixed in two layers: the minimax graph now requires the prompt (matching what Kling V3 and Grok already do), and the handler rejects a blank prompt so the API and preset paths cannot bypass the form. The handler uses `throwBadRequestError`, so this logs as a client fault and returns 400 rather than a 500.

Scoped to H3 deliberately. Nine other video ecosystems inherit the same shared rule (`ltx`, `wan`, `seedance`, `vidu`, `veo3`, `sora`, `flux3-video`, `mochi`, `hunyuan`, plus Kling non-V3), but the measured provider rejection is H3-only, and flipping the others blind could break flows that work today.

## Known compliance gaps — NOT addressed here

Recorded so they are on file rather than assumed handled:

- **§V.2 — binding and notifying users.** Before providing access we must bind each user to enforceable terms at least as protective as Section V and Exhibit A, *and* notify them that those restrictions apply. Our generator provides access; a licence link neither binds nor notifies. This needs a Civitai ToS change, it is a decision for Justin with counsel, and it is live in the ongoing negotiation — deliberately not resolved unilaterally in this PR.
- **§III.4 — NOTICE file.** All distributions to third parties other than through hosted services must be accompanied by a text file containing a verbatim notice. Not triggered while we are hosted-only. It triggers the day we serve H3 weights for download; whoever builds that path needs to handle it.
- **The territorial notice is not shown in the generator.** The `notice` field naming the excluded territories renders on the model page only. A user who reaches H3 solely through the generator sees the attribution and the licence link, but not the territorial restriction.

## Verification

- `pnpm run typecheck` — 0 errors.
- `pnpm run lint` on the touched files — 0 errors.
- `pnpm run test:unit:run` — 16 failures, all pre-existing. Confirmed by reverting the patch and rerunning the failing files against a clean tree, where they fail identically: `check-server-graph-singletons`, `typecheck.test`, `analytics-bucket-labels.drift`, `block-scope.normalize-endpoint`, `app-spend-tier-privilege`. None touch licenses, graphs or the generator.
- New tests mutation-checked rather than assumed: reverting the prompt fix fails 5 of 7 graph tests with `expected false to be true`; adding `disableMature` to one licence copy alone fails the two-copies test. An earlier version of the empty-prompt test passed for the wrong reason (fixture missing image dimensions, so validation failed on `images`), which is why the assertion now pins the error key.

## Notes for review

- Licence row 33 is left intact and is now unreferenced. It remains the correct document for MiniMax API models.
- One base-model record covers both the hosted `H3 (API)` and local `H3 (Comfy)` versions, so both now resolve to the open-weights licence. Splitting them would need a second record.
- Requiring the prompt on the comfy variant is an assumption: error 2013 is a hosted-API code, and the local pipeline never talks to MiniMax. That path has 19 jobs all-time, so the risk is small, but the test locks the behaviour in rather than verifying it.
- Worth one prod query before this matters: confirm no existing H3 model version carries a base-model string other than `MiniMax H3`, since `type BaseModel = string` means a drifted key would be silently inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@