### PR TITLE
fix(leaderboard): let a showcase change take effect, and stop it erasing the badge

### DIFF
--- a/src/components/Generation/Input/DrawingEditor/DrawingCanvas.tsx
+++ b/src/components/Generation/Input/DrawingEditor/DrawingCanvas.tsx
@@ -322,7 +322,8 @@ export function DrawingCanvas({
               width: Math.max(5, bubbleEl.width * scaleX),
               height: Math.max(5, bubbleEl.height * scaleY),
               tailX: node.x() + bubbleEl.width * scaleX * 0.25,
-              tailY: node.y() + bubbleEl.height * scaleY + Math.max(20, bubbleEl.height * scaleY * 0.4),
+              tailY:
+                node.y() + bubbleEl.height * scaleY + Math.max(20, bubbleEl.height * scaleY * 0.4),
               rotation: node.rotation(),
             };
           }
@@ -884,11 +885,7 @@ export function DrawingCanvas({
                     onTransformEnd={(e) => handleTransformEnd(e, element)}
                   >
                     {/* Invisible hit rect for reliable Transformer bounds detection */}
-                    <Rect
-                      width={arrowWidth || 1}
-                      height={arrowHeight || 1}
-                      fill="transparent"
-                    />
+                    <Rect width={arrowWidth || 1} height={arrowHeight || 1} fill="transparent" />
                     <Arrow
                       points={localPoints}
                       stroke={element.color}
@@ -921,11 +918,7 @@ export function DrawingCanvas({
                     onTransformEnd={(e) => handleTransformEnd(e, element)}
                   >
                     {/* Invisible hit rect for reliable Transformer bounds detection */}
-                    <Rect
-                      width={element.width}
-                      height={totalHeight}
-                      fill="transparent"
-                    />
+                    <Rect width={element.width} height={totalHeight} fill="transparent" />
                     <Shape
                       sceneFunc={(context, shape) => {
                         const w = element.width;
@@ -1053,59 +1046,69 @@ export function DrawingCanvas({
       {renderCursor()}
 
       {/* Floating action buttons for selected element */}
-      {selectedId && isSelectMode && (() => {
-        const selectedElement = elements.find((el) => el.id === selectedId);
-        const isFlippable = selectedElement?.type === 'image' || selectedElement?.type === 'rectangle' || selectedElement?.type === 'speechBubble' || selectedElement?.type === 'circle' || selectedElement?.type === 'arrow';
-        return (
-          <div
-            style={{
-              position: 'absolute',
-              bottom: 20,
-              left: '50%',
-              transform: 'translateX(-50%)',
-              zIndex: 10,
-              display: 'flex',
-              gap: 6,
-            }}
-          >
-            {isFlippable && (
-              <>
-                <Tooltip label="Flip horizontal" withArrow position="top">
-                  <ActionIcon
-                    size="lg"
-                    variant="filled"
-                    color="dark"
-                    onClick={() => handleFlipElement('x')}
-                    style={{ boxShadow: '0 2px 8px rgba(0, 0, 0, 0.2)' }}
-                  >
-                    <IconFlipHorizontal size={18} />
-                  </ActionIcon>
-                </Tooltip>
-                <Tooltip label="Flip vertical" withArrow position="top">
-                  <ActionIcon
-                    size="lg"
-                    variant="filled"
-                    color="dark"
-                    onClick={() => handleFlipElement('y')}
-                    style={{ boxShadow: '0 2px 8px rgba(0, 0, 0, 0.2)' }}
-                  >
-                    <IconFlipVertical size={18} />
-                  </ActionIcon>
-                </Tooltip>
-              </>
-            )}
-            <ActionIcon
-              size="lg"
-              color="red"
-              variant="filled"
-              onClick={handleRemoveElement}
-              style={{ boxShadow: '0 2px 8px rgba(0, 0, 0, 0.2)' }}
+      {selectedId &&
+        isSelectMode &&
+        (() => {
+          const selectedElement = elements.find((el) => el.id === selectedId);
+          const isFlippable =
+            selectedElement?.type === 'image' ||
+            selectedElement?.type === 'rectangle' ||
+            selectedElement?.type === 'speechBubble' ||
+            selectedElement?.type === 'circle' ||
+            selectedElement?.type === 'arrow';
+          return (
+            <div
+              style={{
+                position: 'absolute',
+                bottom: 20,
+                left: '50%',
+                transform: 'translateX(-50%)',
+                zIndex: 10,
+                display: 'flex',
+                gap: 6,
+              }}
             >
-              <IconTrash size={18} />
-            </ActionIcon>
-          </div>
-        );
-      })()}
+              {isFlippable && (
+                <>
+                  <Tooltip label="Flip horizontal" withArrow position="top">
+                    <ActionIcon
+                      size="lg"
+                      variant="filled"
+                      color="dark"
+                      onClick={() => handleFlipElement('x')}
+                      style={{ boxShadow: '0 2px 8px rgba(0, 0, 0, 0.2)' }}
+                    >
+                      {/* Tabler names these for the MIRROR AXIS, not the motion:
+                        IconFlipHorizontal draws a horizontal mirror line, which reads
+                        as a vertical flip. The pairing below is deliberately crossed. */}
+                      <IconFlipVertical size={18} />
+                    </ActionIcon>
+                  </Tooltip>
+                  <Tooltip label="Flip vertical" withArrow position="top">
+                    <ActionIcon
+                      size="lg"
+                      variant="filled"
+                      color="dark"
+                      onClick={() => handleFlipElement('y')}
+                      style={{ boxShadow: '0 2px 8px rgba(0, 0, 0, 0.2)' }}
+                    >
+                      <IconFlipHorizontal size={18} />
+                    </ActionIcon>
+                  </Tooltip>
+                </>
+              )}
+              <ActionIcon
+                size="lg"
+                color="red"
+                variant="filled"
+                onClick={handleRemoveElement}
+                style={{ boxShadow: '0 2px 8px rgba(0, 0, 0, 0.2)' }}
+              >
+                <IconTrash size={18} />
+              </ActionIcon>
+            </div>
+          );
+        })()}
     </div>
   );
 }

--- a/src/components/Modals/UserProfileEditModal.tsx
+++ b/src/components/Modals/UserProfileEditModal.tsx
@@ -47,7 +47,7 @@ import {
   creatorCardStats,
   creatorCardStatsDefaults,
 } from '~/server/common/constants';
-import { CosmeticType, LinkType } from '~/shared/utils/prisma/enums';
+import { CosmeticType, DomainColor, LinkType } from '~/shared/utils/prisma/enums';
 import * as z from 'zod';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import type { UserWithCosmetics } from '~/server/selectors/user.selector';
@@ -267,16 +267,24 @@ export default function UserProfileEditModal() {
     [user]
   );
 
-  const leaderboardOptions = useMemo(
-    () =>
-      leaderboards
-        .filter((board) => board.public)
-        .map(({ title, id }) => ({
-          label: titleCase(title),
-          value: id,
-        })),
-    [leaderboards]
-  );
+  // Mirrors the exclusion in `updateLeaderboardRank`: a RED-exclusive board's title
+  // would render sitewide, so it never earns a badge. Offering it here let people
+  // pick an option that could never take effect. A board already stored as this user's
+  // showcase stays listed regardless, so the Select doesn't render blank while still
+  // holding that value. That only reaches boards `getLeaderboards` returned at all —
+  // on a domain where the stored board isn't visible it was already blank before this.
+  const leaderboardOptions = useMemo(() => {
+    const current = user?.leaderboardShowcase;
+    return leaderboards
+      .filter((board) => board.public)
+      .filter(
+        (board) => board.id === current || board.domain.some((color) => color !== DomainColor.red)
+      )
+      .map(({ title, id }) => ({
+        label: titleCase(title),
+        value: id,
+      }));
+  }, [leaderboards, user?.leaderboardShowcase]);
 
   const form = useForm({ schema, shouldUnregister: false });
 

--- a/src/server/controllers/__tests__/user.controller.leaderboard-showcase.test.ts
+++ b/src/server/controllers/__tests__/user.controller.leaderboard-showcase.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as UserService from '~/server/services/user.service';
+
+/**
+ * A showcase change that only lands in the nightly rebuild is invisible for up to 24h,
+ * which is what the report described. The recompute has to be scoped: the full rebuild
+ * TRUNCATEs a table the whole site reads.
+ */
+
+const { mockUpdateUserById, mockGetUserById, mockUpdateRankForUsers } = vi.hoisted(() => ({
+  mockUpdateUserById: vi.fn(),
+  mockGetUserById: vi.fn(),
+  mockUpdateRankForUsers: vi.fn(),
+}));
+
+vi.mock('~/server/services/user.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof UserService>()),
+  getUserById: mockGetUserById,
+  updateUserById: mockUpdateUserById,
+  updateLeaderboardRankForUsers: mockUpdateRankForUsers,
+  equipCosmetic: vi.fn(),
+  unequipCosmeticByType: vi.fn(),
+  createUserReferral: vi.fn(),
+  isUsernamePermitted: vi.fn(async () => true),
+}));
+vi.mock('~/server/search-index', () => ({
+  usersSearchIndex: { queueUpdate: vi.fn() },
+}));
+vi.mock('~/server/cloudflare/client', () => ({ purgeCache: vi.fn(() => ({ catch: vi.fn() })) }));
+vi.mock('~/server/auth/session-invalidation', () => ({ refreshSession: vi.fn() }));
+
+import { updateUserHandler } from '~/server/controllers/user.controller';
+
+const call = (input: Record<string, unknown>) =>
+  updateUserHandler({ ctx: { user: { id: 5 } }, input: { id: 5, ...input } } as never);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetUserById.mockResolvedValue({ profilePictureId: null });
+  mockUpdateUserById.mockResolvedValue({ id: 5, profilePictureId: null });
+});
+
+describe('updateUserHandler — leaderboard showcase', () => {
+  it('recomputes that user rank as soon as the showcase changes', async () => {
+    await call({ leaderboardShowcase: 'flux' });
+    expect(mockUpdateRankForUsers).toHaveBeenCalledWith({ userIds: 5 });
+  });
+
+  it('recomputes when the showcase is cleared', async () => {
+    await call({ leaderboardShowcase: null });
+    expect(mockUpdateRankForUsers).toHaveBeenCalledWith({ userIds: 5 });
+  });
+
+  // The recompute reads `User.leaderboardShowcase` back out of the database, so it has to
+  // run after the write. Ordering is the whole property; both calls happen either way.
+  it('recomputes only after the new showcase has been written', async () => {
+    await call({ leaderboardShowcase: 'flux' });
+    expect(mockUpdateUserById.mock.invocationCallOrder[0]).toBeLessThan(
+      mockUpdateRankForUsers.mock.invocationCallOrder[0]
+    );
+  });
+
+  // Deliberately NOT compared against the stored value: the only cheap read of it is the
+  // replica, and an A->B->A save inside the replication window would compare equal and skip
+  // the recompute. Recomputing on a cosmetic save is the cheap side of that trade.
+  it('recomputes on a cosmetic save that carries the showcase along', async () => {
+    await call({ leaderboardShowcase: 'flux', nameplateId: 12 });
+    expect(mockUpdateRankForUsers).toHaveBeenCalledWith({ userIds: 5 });
+  });
+
+  it('leaves the rank alone when the save omits the showcase', async () => {
+    await call({ image: null });
+    expect(mockUpdateRankForUsers).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -109,6 +109,7 @@ import {
   toggleUserBountyEngagement,
   unequipCosmeticByType,
   updateLeaderboardRank,
+  updateLeaderboardRankForUsers,
   updateUserById,
   userByReferralCode,
 } from '~/server/services/user.service';
@@ -553,6 +554,15 @@ export const updateUserHandler = async ({
 
     if (isSettingCosmetics)
       postUpdatePromises.push(equipCosmetic({ userId: id, cosmeticId: payloadCosmeticIds }));
+
+    // Without this the new showcase isn't visible until the nightly rebuild, up to 24h later.
+    // The modal sends the field on every user-level save, so this recomputes on cosmetic
+    // saves too. That is deliberate: comparing against the stored value would have to read
+    // it back, and the only cheap read is the replica — an A->B->A save inside the
+    // replication window would then compare equal and skip the recompute it needs. The
+    // upsert is 0.87 ms and idempotent, so the redundant call costs less than that risk.
+    if (input.leaderboardShowcase !== undefined)
+      postUpdatePromises.push(updateLeaderboardRankForUsers({ userIds: id }));
 
     if (userReferralCode || source || landingPage) {
       postUpdatePromises.push(

--- a/src/server/services/__tests__/leaderboard-rank-showcase.test.ts
+++ b/src/server/services/__tests__/leaderboard-rank-showcase.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Two properties that a green suite could not otherwise tell apart from the old code:
+ * the showcase must bias the choice of board rather than filter it away, and the
+ * per-user path must not TRUNCATE a table the whole site reads.
+ */
+
+type Statement = { sql: string; values: unknown[] };
+
+const { mockExecuteRaw, mockTransaction, statements } = vi.hoisted(() => {
+  const statements: Statement[] = [];
+  const mockExecuteRaw = vi.fn((...args: any[]): Statement => {
+    const statement: Statement = Array.isArray(args[0])
+      ? { sql: args[0].join(' ? '), values: args.slice(1) }
+      : { sql: args[0].sql, values: args[0].values };
+    statements.push(statement);
+    return statement;
+  });
+  return { mockExecuteRaw, mockTransaction: vi.fn(async () => []), statements };
+});
+
+vi.mock('~/server/db/client', () => ({
+  dbWrite: { $executeRaw: mockExecuteRaw, $transaction: mockTransaction },
+  dbRead: {},
+  dbKV: {},
+}));
+
+import {
+  updateLeaderboardRank,
+  updateLeaderboardRankForUsers,
+} from '~/server/services/user.service';
+
+const insertStatement = () => {
+  const insert = statements.find((s) => s.sql.includes('INSERT INTO "UserRank"'));
+  if (!insert) throw new Error(`no UserRank insert issued; got ${statements.length} statement(s)`);
+  return insert;
+};
+
+beforeEach(() => {
+  statements.length = 0;
+  vi.clearAllMocks();
+});
+
+describe('leaderboard rank — showcase is a preference, not a filter', () => {
+  it.each([
+    ['full rebuild', () => updateLeaderboardRank()],
+    ['per-user rebuild', () => updateLeaderboardRankForUsers({ userIds: 42 })],
+  ])('%s ranks the showcased board first instead of excluding the rest', async (_label, run) => {
+    await run();
+    const { sql } = insertStatement();
+
+    // The old shape dropped every other board: `AND (u."leaderboardShowcase" IS NULL
+    // OR lr."leaderboardId" = u."leaderboardShowcase")`. A user whose showcased board
+    // can't produce a badge then got no badge at all.
+    expect(sql).not.toContain('u."leaderboardShowcase" IS NULL');
+
+    // Direction and term order both carry the fix. `ASC` sorts the showcased board LAST,
+    // and putting `lr."position"` first demotes the preference to a tiebreaker — either
+    // mutation inverts the behaviour while still mentioning the showcase.
+    const orderBy = sql.slice(sql.indexOf('ORDER BY')).replace(/\s+/g, ' ');
+    expect(orderBy).toMatch(
+      /^ORDER BY \(lr\."leaderboardId" IS NOT DISTINCT FROM u\."leaderboardShowcase"\) DESC, lr\."position"/
+    );
+  });
+});
+
+describe('updateLeaderboardRankForUsers', () => {
+  it('scopes the rebuild to the given users and never truncates', async () => {
+    await updateLeaderboardRankForUsers({ userIds: 42 });
+
+    const insert = insertStatement();
+    expect(insert.sql).toContain('AND u.id IN');
+    expect(insert.values).toEqual([42]);
+  });
+
+  // Removing a row is the nightly rebuild's job, and that one is guarded by
+  // `isLeaderboardPopulated`. A delete here would strip the badge and then insert
+  // nothing on any day the 23:00 population failed.
+  it('upserts rather than removing anything', async () => {
+    await updateLeaderboardRankForUsers({ userIds: 42 });
+
+    const removing = statements.filter((s) => /DELETE|TRUNCATE/.test(s.sql));
+    expect(removing.map((s) => s.sql)).toEqual([]);
+    expect(insertStatement().sql).toContain('ON CONFLICT ("userId") DO UPDATE');
+  });
+
+  it('accepts a list of users', async () => {
+    await updateLeaderboardRankForUsers({ userIds: [7, 9] });
+    expect(insertStatement().values).toEqual([7, 9]);
+  });
+
+  it('issues nothing for an empty list', async () => {
+    await updateLeaderboardRankForUsers({ userIds: [] });
+    expect(statements).toEqual([]);
+  });
+});
+
+describe('updateLeaderboardRank', () => {
+  it('still truncates, because it rebuilds every user', async () => {
+    await updateLeaderboardRank();
+    expect(statements.some((s) => s.sql.includes('TRUNCATE TABLE "UserRank"'))).toBe(true);
+    expect(insertStatement().sql).not.toContain('AND u.id IN');
+  });
+});

--- a/src/server/services/leaderboard.service.ts
+++ b/src/server/services/leaderboard.service.ts
@@ -73,6 +73,7 @@ export async function getLeaderboards(input: GetLeaderboardsInput) {
       title: true,
       description: true,
       scoringDescription: true,
+      domain: true,
       public: isModerator ? true : undefined,
     },
     orderBy: {

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -1469,6 +1469,72 @@ export const getUserBookmarkedModels = async ({ userId }: { userId: number }) =>
   return bookmarked.map(({ modelId }) => modelId).filter(isDefined);
 };
 
+const leaderboardRankInsert = ({
+  leaderboardFilter,
+  userFilter,
+  onConflict = Prisma.empty,
+}: {
+  leaderboardFilter: Prisma.Sql;
+  userFilter: Prisma.Sql;
+  onConflict?: Prisma.Sql;
+}) => Prisma.sql`
+  WITH user_positions AS (
+    SELECT
+      lr."userId",
+      lr."leaderboardId",
+      l."title",
+      lr.position,
+      -- The showcase is a PREFERENCE, not a filter. Applied as a WHERE clause it
+      -- deleted the badge outright whenever the showcased board couldn't produce
+      -- one — a RED-exclusive or non-public board, or one the user has since
+      -- dropped out of the top 100 on. Measured on prod 2026-08-14: 62 users had
+      -- a top-100 placement on an eligible board and no UserRank row at all.
+      row_number() OVER (
+        PARTITION BY lr."userId"
+        ORDER BY
+          (lr."leaderboardId" IS NOT DISTINCT FROM u."leaderboardShowcase") DESC,
+          lr."position"
+      ) row_num
+    FROM "User" u
+    JOIN "LeaderboardResult" lr ON lr."userId" = u.id
+    JOIN "Leaderboard" l ON l.id = lr."leaderboardId" AND l.public
+    WHERE lr.date = current_date
+      AND lr.position <= 100
+      -- UserRank is a single global table but the badge (title + cosmetic) renders
+      -- on every domain, so a RED-EXCLUSIVE board would leak its name sitewide —
+      -- e.g. "Creators (mature)" on civitai.com. Exclude only those; a board that
+      -- is visible on any SFW domain still earns a badge (requiring 'all' would
+      -- strip the badge from everyone on the green/blue-scoped boards).
+      AND NOT (l.domain <@ ARRAY['red']::"DomainColor"[])
+      ${leaderboardFilter}
+      ${userFilter}
+  ),
+  lowest_position AS (
+    SELECT
+      up."userId",
+      up.position,
+      up."leaderboardId",
+      up."title" "leaderboardTitle",
+      (SELECT data ->> 'url'
+       FROM "Cosmetic" c
+       WHERE c."leaderboardId" = up."leaderboardId"
+         AND up.position <= c."leaderboardPosition"
+       ORDER BY c."leaderboardPosition"
+       LIMIT 1) as "leaderboardCosmetic"
+    FROM user_positions up
+    WHERE row_num = 1
+  )
+  INSERT INTO "UserRank" ("userId", "leaderboardRank", "leaderboardId", "leaderboardTitle", "leaderboardCosmetic")
+  SELECT
+    "userId",
+    position,
+    "leaderboardId",
+    "leaderboardTitle",
+    "leaderboardCosmetic"
+  FROM lowest_position
+  ${onConflict};
+`;
+
 export const updateLeaderboardRank = async ({
   leaderboardIds,
 }: {
@@ -1484,56 +1550,44 @@ export const updateLeaderboardRank = async ({
     // Truncate the table - much faster than DELETE and we're rebuilding anyway
     dbWrite.$executeRaw`TRUNCATE TABLE "UserRank";`,
     // Only insert users with top 100 ranks (position <= 100)
-    dbWrite.$executeRaw`
-      WITH user_positions AS (
-        SELECT
-          lr."userId",
-          lr."leaderboardId",
-          l."title",
-          lr.position,
-          row_number() OVER (PARTITION BY "userId" ORDER BY "position") row_num
-        FROM "User" u
-        JOIN "LeaderboardResult" lr ON lr."userId" = u.id
-        JOIN "Leaderboard" l ON l.id = lr."leaderboardId" AND l.public
-        WHERE lr.date = current_date
-          AND lr.position <= 100
-          -- UserRank is a single global table but the badge (title + cosmetic) renders
-          -- on every domain, so a RED-EXCLUSIVE board would leak its name sitewide —
-          -- e.g. "Creators (mature)" on civitai.com. Exclude only those; a board that
-          -- is visible on any SFW domain still earns a badge (requiring 'all' would
-          -- strip the badge from everyone on the green/blue-scoped boards).
-          AND NOT (l.domain <@ ARRAY['red']::"DomainColor"[])
-          ${leaderboardFilter}
-          AND (
-            u."leaderboardShowcase" IS NULL
-            OR lr."leaderboardId" = u."leaderboardShowcase"
-          )
-      ),
-      lowest_position AS (
-        SELECT
-          up."userId",
-          up.position,
-          up."leaderboardId",
-          up."title" "leaderboardTitle",
-          (SELECT data ->> 'url'
-           FROM "Cosmetic" c
-           WHERE c."leaderboardId" = up."leaderboardId"
-             AND up.position <= c."leaderboardPosition"
-           ORDER BY c."leaderboardPosition"
-           LIMIT 1) as "leaderboardCosmetic"
-        FROM user_positions up
-        WHERE row_num = 1
-      )
-      INSERT INTO "UserRank" ("userId", "leaderboardRank", "leaderboardId", "leaderboardTitle", "leaderboardCosmetic")
-      SELECT
-        "userId",
-        position,
-        "leaderboardId",
-        "leaderboardTitle",
-        "leaderboardCosmetic"
-      FROM lowest_position;
-    `,
+    dbWrite.$executeRaw(leaderboardRankInsert({ leaderboardFilter, userFilter: Prisma.empty })),
   ]);
+};
+
+/**
+ * Per-user variant, for when a user changes their showcase and expects to see it.
+ * `updateLeaderboardRank` cannot serve that: it TRUNCATEs a table the whole site
+ * reads, so calling it on a profile save blanks every user's badge mid-rebuild.
+ * Measured on the prod replica 2026-08-14: 0.87 ms scoped vs 196 ms full.
+ *
+ * Upsert-only, deliberately. Deleting first would strip a badge and then have nothing
+ * to replace it with on any day the 23:00 population failed — the exact symptom this
+ * path exists to fix, re-entered through a new door. `prepare-leaderboard` guards the
+ * nightly rebuild with `isLeaderboardPopulated` for that reason, and removal stays that
+ * job's business: under the ordering above a user with any eligible placement always
+ * produces a row, so a save never needs to remove one. It also keeps two concurrent
+ * saves off a delete-then-insert race into the `UserRank` primary key.
+ */
+export const updateLeaderboardRankForUsers = async ({
+  userIds,
+}: {
+  userIds: number | number[];
+}) => {
+  const ids = Array.isArray(userIds) ? userIds : [userIds];
+  if (!ids.length) return;
+
+  await dbWrite.$executeRaw(
+    leaderboardRankInsert({
+      leaderboardFilter: Prisma.empty,
+      userFilter: Prisma.sql`AND u.id IN (${Prisma.join(ids)})`,
+      onConflict: Prisma.sql`
+    ON CONFLICT ("userId") DO UPDATE SET
+      "leaderboardRank" = EXCLUDED."leaderboardRank",
+      "leaderboardId" = EXCLUDED."leaderboardId",
+      "leaderboardTitle" = EXCLUDED."leaderboardTitle",
+      "leaderboardCosmetic" = EXCLUDED."leaderboardCosmetic"`,
+    })
+  );
 };
 
 /**


### PR DESCRIPTION
Fixes three reported bugs. The first one is not what the ticket said it was, so the diagnosis is worth reading before the diff.

## 1. Leaderboard showcase — `868krf59z`

**The ticket's root cause is wrong.** It says the only write path is the commented-out `tx.user.update` block in `user-profile.service.ts`, and that the column has been frozen since. That block was not orphaned: commit `24b905a0c6` (2023-12-10) commented it out **and** added the `trpc.user.update` call to the profile modal in the same commit. The modal strips `leaderboardShowcase` out of the `userProfile.update` payload (`UserProfileEditModal.tsx:397`) and sends it to `user.update` instead (`:420`), where `updateUserHandler` spreads it into `updateUserById` -> `dbWrite.user.update`. It is a plain scalar spread, which is why a grep for `update`/`data:`/`SET` around the column missed it.

Proof from prod: users' showcases point at boards that did not exist in 2023 — `zimage` (57 users), `anima` (28), `krea2` (19), `holiday2024:all-time` (23). The column is being written.

Profile picture, badge and nameplate were migrated to that same handler and are fine.

**What is actually broken** is two things downstream:

**a. The showcase was a filter, not a preference.** `updateLeaderboardRank` selected a user's badge with

```sql
AND (u."leaderboardShowcase" IS NULL OR lr."leaderboardId" = u."leaderboardShowcase")
```

so if the showcased board could not produce a badge — RED-exclusive (excluded on the line above, because its title would render sitewide), non-public, or one the user has since dropped out of the top 100 on — no row matched and they got **no badge at all**, including the one they had earned elsewhere. That is bug `868knvn13`.

Now expressed as an `ORDER BY` inside the existing `row_number()` window, so the showcased board wins when it can and the best eligible board is used otherwise.

Measured on the prod replica, 2026-08-14, running the old and new winner queries side by side over every user:

| | Winners |
|---|---|
| old (filter) | 1,440 — exactly today's `UserRank` row count |
| new (preference) | 1,728 |

**288 users gain a badge, 0 lose one, 0 end up on a worse position.** And where the showcase *is* eligible it still wins: 237 of 237 such users get their showcased board. Sev's report ("I am in top 10 mature and top 100 comedians but both wouldn't show up and lost discord roles too") is exactly this shape — the Discord role job reads `UserRank`.

**b. The rebuild only ran nightly.** `update-user-leaderboard-rank` is `1 0 * * *`, so a change was invisible for up to 24 hours — which reads exactly like "no matter what option I choose it stays as comedians".

`updateLeaderboardRankForUsers` recomputes a single user on save. The existing helper cannot be reused for this: it `TRUNCATE`s a table the whole site reads, so calling it per-save would blank every user's badge mid-rebuild. Cost audited before building it, on the prod replica:

| | Rows | Exec | Buffers | Side effect |
|---|---|---|---|---|
| scoped (one user) | 1 | **0.87 ms** | 74 | none |
| full rebuild SELECT | 1440 | **196 ms** | ~97k | plus `TRUNCATE "UserRank"` |

The scoped plan is an index scan on `LeaderboardResult_userId_date_idx`.

**It is upsert-only, with no delete, and that is load-bearing.** A `DELETE`-then-`INSERT` would strip the badge and then write nothing on any day the 23:00 population failed — re-entering the exact bug this PR fixes through a new door, which is why `prepare-leaderboard` guards the nightly rebuild with `isLeaderboardPopulated`. It also keeps two concurrent saves off a race into the `UserRank` primary key. Removal stays the nightly job's business: under the new ordering, a user with any eligible placement always produces a row, so a save never needs to remove one.

Verified on the dev database rather than assumed — the composed statement plans as `Insert on "UserRank" / Conflict Resolution: UPDATE / Conflict Arbiter Indexes: pk_UserRank`.

It fires whenever the payload carries `leaderboardShowcase`, which the modal sends on every user-level save — so a badge or nameplate change recomputes too. That is deliberate. Comparing against the stored value would mean reading it back, and the only cheap read is the replica: an A→B→A save inside the replication window would compare equal and skip the recompute it needs. A redundant 0.87 ms idempotent upsert is the cheaper side of that trade.

## 2. RED-exclusive boards in the picker — `868knvn13`

Fixed by (a) above for everyone already stuck. Additionally the picker no longer offers RED-exclusive boards, since by design they can never earn a badge — `getLeaderboards` now returns `domain` so the client can mirror the SQL's exclusion.

A board already stored as the user's own showcase stays in the list regardless, so the Select doesn't render blank while still holding that value. On civitai.red that covers 6,661 accounts whose showcase is a red-only board.

## 3. Flip icon — `868krf59v`

Confirmed from the glyph geometry, not just the names. `IconFlipHorizontal` is `M3 12 l18 0` — a *horizontal mirror line* with triangles above and below, i.e. it depicts a top-to-bottom flip. `IconFlipVertical` is `M12 3 l0 18`, the reverse. Tabler names them for the mirror axis, not the motion. The two are now crossed, with a comment saying why so nobody "fixes" it back.

Behaviour was already correct; only the glyph was wrong. Note `src/components/Sticker/DraftSticker.tsx:369` uses `IconFlipHorizontal` for a button labelled just "Flip" — same glyph confusion, but its label claims no axis and it is outside this ticket, so it is untouched.

## Tests

- `src/server/services/__tests__/leaderboard-rank-showcase.test.ts` — asserts the generated SQL expresses the showcase as an `ORDER BY` preference and not a `WHERE` filter, pins the direction and term order, and asserts the per-user path emits neither `DELETE` nor `TRUNCATE`.
- `src/server/controllers/__tests__/user.controller.leaderboard-showcase.test.ts` — asserts the recompute fires whenever the payload carries the field (including a clear to `null`), not when it is omitted, and only *after* the User row is written.

All four properties were mutation-tested, not just asserted:

| Mutation | Failure |
|---|---|
| restore the `WHERE` filter | `expected '...' not to contain 'u."leaderboardShowcase" IS NULL'` |
| `DESC` → `ASC` in the new ORDER BY | `expected 'ORDER BY (...)' to match /^ORDER BY \(...\) DESC, lr\."position"/` |
| remove the controller call | `expected "vi.fn()" to be called with arguments: [ { userIds: 5 } ]` |
| move the recompute before the write | `expected 50 to be less than 49` |

Full unit suite: **16 failed / 16,621 passed**. All 16 failures are pre-existing — the same 16 in the same 6 files on unmodified `src/` in this worktree (16,609 passed there, so the delta is exactly these 12 new tests). `blocks.router.workflow.test.ts` collected 347, so the submodule is initialised and the run means something.

## Adversarial review

I ran a reviewer over this diff twice, prompted to refute. It found seven real problems in the first pass, all fixed here: the missing population guard on the scoped path, a primary-key race, the guard firing on every cosmetic save, two tests that would have passed with the fix inverted, a blank picker for 6,661 red-domain users, and a headline number that didn't reproduce (I had written 62 from a narrower query; the honest number is 288).

Second pass closed all of those and found one more — that comparing against the stored value read the replica, so an A→B→A save inside the replication window would skip the recompute. That is why the guard is a presence check rather than a comparison.

It could not refute the SQL rewrite itself.

## Known limits

- **A board demoted mid-day leaves a stale row.** If a `Leaderboard` is flipped to `public = false` or narrowed to `{red}` by direct DB edit, a user whose `UserRank` row is that board keeps it until the next nightly rebuild, because the upsert never removes. Accepted: the alternative is the delete that reintroduces the population-failure bug. Self-heals within 24h.
- **On a failed-population day, changing the showcase is a silent no-op.** The save still reports success and the badge keeps showing the old board. Correct behaviour — better than clearing it — but silent.

## Not done

No migration. Nothing to apply by hand.

The 288 users currently missing a badge are repaired by the first nightly rebuild after this deploys — no backfill needed.

Not fixed, noticed in passing and left alone as out of scope: `leaderboard.service.ts:77` reads `public: isModerator ? true : undefined`, where `isModerator` is the tRPC **middleware** imported at line 6, so it is always truthy and `public` is always selected. Harmless today (line 62 uses `input.isModerator` correctly and the client filters on `public`), but it is not what it looks like. And `src/components/Sticker/DraftSticker.tsx:369` has the same Tabler glyph confusion as #3, on a button labelled just "Flip" — no axis claimed, different ticket.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
