### PR TITLE
fix(buzz): count green Buzz in creator earnings and the creator pool

### DIFF
--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -2267,9 +2267,13 @@ const REDIS_KEYS_UNPREFIXED = {
   },
   CACHE_LOCKS: 'cache-lock',
   BUZZ: {
-    POTENTIAL_POOL: 'buzz:potential-pool',
-    POTENTIAL_POOL_VALUE: 'buzz:potential-pool-value',
-    EARNED: 'buzz:earned',
+    // v2: these three feed one forecast (earned / poolSize x poolValue) and each expires on its own
+    // day-long TTL, `earned` per user. Widening them to count green without moving the keys would
+    // serve a green `earned` over a yellow-only pool for up to a day — every mixture wrong, none of
+    // them an error. Bump all three together whenever any of their predicates changes.
+    POTENTIAL_POOL: 'buzz:potential-pool:v2',
+    POTENTIAL_POOL_VALUE: 'buzz:potential-pool-value:v2',
+    EARNED: 'buzz:earned:v2',
   },
   CREATOR_PROGRAM: {
     CAPS: 'packed:caches:creator-program:caps',

--- a/src/server/services/buzz.service.ts
+++ b/src/server/services/buzz.service.ts
@@ -48,6 +48,7 @@ import {
   getTransactionsReportResultSchema,
 } from '~/server/schema/buzz.schema';
 import {
+  buzzBankTypes,
   BuzzTypes,
   buzzSpendTypes,
   CASH_SETTLED_ALIASES,
@@ -71,7 +72,7 @@ import { toCsv, toCsvRows } from '~/utils/csv';
 import { isDefined } from '~/utils/type-guards';
 import { numberWithCommas } from '~/utils/number-helpers';
 import { grantCosmetics } from '~/server/services/cosmetic.service';
-import { getBuzzBulkMultiplier, PAYOUT_ELIGIBLE_BUZZ_TYPES } from '~/server/utils/buzz-helpers';
+import { getBuzzBulkMultiplier } from '~/server/utils/buzz-helpers';
 import { isDev } from '~/env/other';
 import { toPascalCase } from '~/utils/string-helpers';
 // import type { BuzzAccountType as PrismaBuzzAccountType } from '~/shared/utils/prisma/enums';
@@ -1418,9 +1419,7 @@ export async function getEarnPotential({ userId, username }: GetEarnPotentialSch
   return potential;
 }
 
-const PAYOUT_ELIGIBLE_ACCOUNT_TYPES_SQL = [...PAYOUT_ELIGIBLE_BUZZ_TYPES]
-  .map((type) => `'${type}'`)
-  .join(', ');
+const BANKABLE_ACCOUNT_TYPES_SQL = buzzBankTypes.map((type) => `'${type}'`).join(', ');
 
 const earnedCache = createCachedObject<{ id: number; earned: number }>({
   key: REDIS_KEYS.BUZZ.EARNED,
@@ -1437,7 +1436,7 @@ const earnedCache = createCachedObject<{ id: number; earned: number }>({
         (type IN ('compensation')) -- Generation
         OR (type = 'purchase' AND fromAccountId != 0) -- Early Access
       )
-      AND toAccountType IN (${PAYOUT_ELIGIBLE_ACCOUNT_TYPES_SQL})
+      AND toAccountType IN (${BANKABLE_ACCOUNT_TYPES_SQL})
       AND toAccountId IN (${ids})
       AND toStartOfMonth(date) = toStartOfMonth(subtractMonths(now(), 1))
       GROUP BY toAccountId;

--- a/src/server/services/buzz.service.ts
+++ b/src/server/services/buzz.service.ts
@@ -71,7 +71,7 @@ import { toCsv, toCsvRows } from '~/utils/csv';
 import { isDefined } from '~/utils/type-guards';
 import { numberWithCommas } from '~/utils/number-helpers';
 import { grantCosmetics } from '~/server/services/cosmetic.service';
-import { getBuzzBulkMultiplier } from '~/server/utils/buzz-helpers';
+import { getBuzzBulkMultiplier, PAYOUT_ELIGIBLE_BUZZ_TYPES } from '~/server/utils/buzz-helpers';
 import { isDev } from '~/env/other';
 import { toPascalCase } from '~/utils/string-helpers';
 // import type { BuzzAccountType as PrismaBuzzAccountType } from '~/shared/utils/prisma/enums';
@@ -1418,6 +1418,10 @@ export async function getEarnPotential({ userId, username }: GetEarnPotentialSch
   return potential;
 }
 
+const PAYOUT_ELIGIBLE_ACCOUNT_TYPES_SQL = [...PAYOUT_ELIGIBLE_BUZZ_TYPES]
+  .map((type) => `'${type}'`)
+  .join(', ');
+
 const earnedCache = createCachedObject<{ id: number; earned: number }>({
   key: REDIS_KEYS.BUZZ.EARNED,
   idKey: 'id',
@@ -1433,7 +1437,7 @@ const earnedCache = createCachedObject<{ id: number; earned: number }>({
         (type IN ('compensation')) -- Generation
         OR (type = 'purchase' AND fromAccountId != 0) -- Early Access
       )
-      AND toAccountType = 'yellow'
+      AND toAccountType IN (${PAYOUT_ELIGIBLE_ACCOUNT_TYPES_SQL})
       AND toAccountId IN (${ids})
       AND toStartOfMonth(date) = toStartOfMonth(subtractMonths(now(), 1))
       GROUP BY toAccountId;

--- a/src/server/services/buzz.service.ts
+++ b/src/server/services/buzz.service.ts
@@ -1464,7 +1464,7 @@ export async function getPoolForecast({ userId, username }: GetEarnPotentialSche
         SELECT
           SUM(amount) AS balance
         FROM buzzTransactions
-        WHERE toAccountType = 'yellow'
+        WHERE toAccountType IN (${BANKABLE_ACCOUNT_TYPES_SQL})
         AND (
           (type IN ('compensation')) -- Generation
           OR (type = 'purchase' AND fromAccountId != 0) -- Early Access
@@ -1485,7 +1485,7 @@ export async function getPoolForecast({ userId, username }: GetEarnPotentialSche
         SELECT
             SUM(amount) / 1000 AS balance
         FROM buzzTransactions
-        WHERE toAccountType = 'yellow'
+        WHERE toAccountType IN (${BANKABLE_ACCOUNT_TYPES_SQL})
         AND type = 'purchase'
         AND fromAccountId = 0
         AND externalTransactionId NOT LIKE 'renewalBonus:%'


### PR DESCRIPTION
## What changed

All three legs of the creator-pool forecast — a creator's `earned`, the pool denominator (`poolSize`) and the pool's dollar value (`poolValue`) — filtered `toAccountType = 'yellow'`. They now filter `buzzBankTypes`, the set marked `bankable` in `buzz.constants.ts`, i.e. `'green', 'yellow'`.

### This is a regression fix, not an expansion — and that matters for reviewing it

The forecast did not "fail to count a new revenue stream". It counted this money until **April 2026**, when membership grants and Stripe Buzz purchases flipped from yellow to green (`stripe.service.ts:885`, `paddle.service.ts:738` — the account type follows product metadata). Measured, `Membership bonus` rows in the `poolValue` leg:

| month | yellow | green |
|---|---:|---:|
| 2026-02 | 36,940,000 | 2,910,000 |
| 2026-03 | 16,490,000 | 2,965,000 |
| 2026-04 | **10,000** | 23,235,000 |
| 2026-07 | 0 | 62,780,000 |

Meanwhile the **canonical** pool-value query that drives actual payouts — `creator-program.service.ts:321` `getPoolValue` — has used `'yellow', 'green'` all along. So since April the forecast and the real payout formula have been drifting apart, and the gap is still widening month over month:

| month | implied $/1,000 Buzz, yellow-only | with green | gap |
|---|---:|---:|---:|
| 2026-04 | 3.370 | 3.867 | +14.8% |
| 2026-05 | 3.929 | 4.837 | +23.1% |
| 2026-06 | 4.154 | 5.281 | +27.1% |
| 2026-07 | 3.513 | 4.541 | **+29.3%** |

The +29% is not a one-month artifact and not a plateau. Left alone it gets worse every month.

**Blue stays excluded, on purpose.** It is the free/daily-granted type; putting it in a payout figure is the farming vector that exists to be prevented. The widening is to the bankable set, not to "everything".

(First pass used `PAYOUT_ELIGIBLE_BUZZ_TYPES`. Same two values, wrong concept: that constant is the App Blocks spend-side Sybil gate and is documented as needing monetization sign-off to change, which would have made a creator-earnings display move whenever that gate moved. `buzzBankTypes` is the bankable set this query actually means, and `buzz.constants` was already imported here, so no new module edge.)

## Cache: handled in the PR, no deploy step needed

All three keys are versioned to `:v2` (`packages/civitai-redis/src/client.ts`), so the fix self-executes.

This was worth doing rather than leaving as a purge instruction. The three keys feed **one** formula — `earned / poolSize x poolValue` — each expires on its own day-long TTL, and `earned` is per user so its entries expire at scattered times. Without moving the keys, the window after deploy serves a **mixed-vintage forecast**: a widened green `earned` divided by a stale yellow-only `poolSize`, times a stale yellow-only `poolValue` that is ~25% low. Every combination is wrong and none of them errors. A purge fixes that only if someone remembers; a version bump cannot be forgotten.

The orphaned v1 keys expire by themselves. Only three call sites read these keys and all are in this PR.

(An earlier revision of this description asked for a manual purge and said the stale window was 24h. Both were wrong — `createCachedObject` defaults `staleWhileRevalidate: true`, so the physical expiry is `ttl * 2`, `cached-array.ts:100-107,138`.)

## Verified against real data, not just a passing test

Prod ClickHouse (read-only), last full month, using the query's own predicate:

| destination | legs | Buzz |
|---|---:|---:|
| yellow | 160,522 | 72,135,591 |
| **green (was dropped)** | 12,408 | 2,326,038 |
| blue (stays excluded) | 117,074 | 17,963,537 |

Running the new `toAccountType IN ('green', 'yellow')` predicate for the three largest green earners: earned goes **9,271,584 → 10,328,319 (+11.4%)**.

Who this moves: **2,509 creators** see a higher earned figure, **963** by more than 10%, and **283** currently show `0` because all their eligible income was green.

All 2,326,038 of that green is `compensation`, with **zero** green `purchase` legs — green paid-access income starts only now that #3917 has merged, so this grows from here.

## The pool legs move too — Justin's call, 2026-08-15

All three legs now count green: the creator's `earned`, the pool **denominator**, and the pool's **dollar value**. The denominator was the product decision; it was made with the measurement below rather than in the abstract.

**Counting green raises the rate, it does not dilute.** The value query was dropping **$84,723/month** (against yellow's $253,386), while green income is only 2.3M Buzz of a 72.1M denominator — so green is ~$0.0364 per earned Buzz against yellow's ~$0.00351, roughly 10x denser:

| | pool value | denominator | rate @50% bank |
|---|---:|---:|---:|
| before | $20,271 | 72,135,591 | 0.000562 |
| denominator only (**not** shipped) | $20,271 | 74,461,629 | 0.000545 (-3.1%) |
| **shipped — value and denominator** | **$27,049** | **74,461,629** | **0.000727 (+29.3%)** |

Verified on prod ClickHouse with each widened predicate: `poolSize` 72,135,591 → 74,461,629, gross revenue $253,385.99 → $338,109.10. The $0.001/Buzz cap does not bind at either figure, so none of this is hidden by it.

Widening `earned` alone would have left the dollar forecast ~22.6% low and over-allocated the stated pool by ~3.2% in aggregate. Landing all three keeps the maths coherent. Blue stays excluded on every leg.

⚠️ **Do not merge or cherry-pick this branch partially.** The intermediate state — the first two commits without `b03e939948` — puts a green+yellow numerator over a yellow-only denominator, so the sum of every creator's forecast exceeds the pool.

### What the $84,723 actually is

74% of it is membership subscription revenue (`Membership bonus`, 4,749 rows) and 26% is direct Stripe Buzz purchases (1,904 rows). Every row is cash: `Membership bonus` is written on `invoice.paid` with an `in_...` Stripe invoice id. Bucketing all 6,653 green rows by description and id shape turns up **no** promo credits, code redemptions, refunds or manual grants — this is not the `tip`-row trap below.

The dollar conversion holds too: active prices are $10/$25/$50 for 10,000/25,000/50,000 monthly Buzz, and the observed green `Membership bonus` amounts are exactly those three values, so `SUM(amount)/1000` reproduces the subscription price. The one overstatement is bonus Buzz recorded in `amount` but not paid for (multiplier and bulk bonuses), worth **$400–900 of a $338,109 gross** — under 0.3%, and identical in kind to what the yellow crypto rows already contribute at larger scale.

## The missing "tip clause" is not missing — checked and dropped

An earlier revision of this description claimed the query was wrong to omit `type = 'tip' AND fromAccountId = 0`, since `creator-program.service.ts:120` includes it and the UI promises "Generation Tips". That was wrong on both halves, and worth writing down so nobody re-adds it:

- **Generation tips already count.** They reach a creator as `compensation` rows — `deliver-creator-compensation` mints a separate transaction only for `licenseFee` and merges every other source into one compensation payout — and this predicate counts `compensation`.
- **The system-funded `tip` rows are not earnings.** Reading last month's 123 legs: "Make-whole for Early Access refund bug… restores creator earnings reversed by 10 erroneous refunds" (175,000), "Uncredited BTC deposits… ticket #68138" (142,963), "Missed 20% Gold membership bonus… tickets #67930 and #66575" (121,524), "Redelivery of Bronze membership Green Buzz (delivery miss)", "Crypto deposit credit… honored and credited manually". They are **manual support credits** — remediations, goodwill refunds and delivery fixes written by hand.

Counting them would inflate a creator's earned figure with refunds and put support credits into the pool denominator. Excluded is correct.

Not stacked: branched off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




## Reviewed

Three adversarial passes, each prompted to refute rather than approve. Findings applied: the constant was swapped off the App Blocks Sybil gate to `buzzBankTypes`; the framing above was rewritten from "green is revenue we ignored" to the regression it actually is; the cache keys were versioned instead of left as a purge instruction.

Checked and held, so a reviewer need not redo them: the pool-value rows contain no non-cash credits; green sells at the same 1000 Buzz = $1 as yellow; no row is double-counted across the two legs (0 duplicate `externalTransactionId`s); `earned` and `poolSize` are now identical predicates but for the id filter, so no creator's earnings sit outside the denominator.

Noted, pre-existing, **not** touched here:
- `creator-program.service.ts:74` holds a second, hand-written `'yellow', 'green'` literal. It agrees with `buzzBankTypes` today by coincidence; it is the copy that will drift.
- The forecast and the canonical program still differ on `type IN ('compensation','tip')` and `CREATOR_POOL_FORECAST_PORTION`. Given the `tip` rows are manual support credits (below), the `buzz.service` side is probably the correct one — but they should be reconciled deliberately.
- The `renewalBonus:` exclusion in `poolValue` matches zero rows in six months; it is dead but harmless.
- Both `if (!results.length)` fallbacks are unreachable — a `SUM()` with no `GROUP BY` always returns one row. Worth knowing that the `135000000` constant is ~1.8x the real pool size if it ever did fire.
