### PR TITLE
feat(early-adopter): user opt-in setting + Flipt cohort flag

### DIFF
--- a/apps/auth/src/lib/server/auth/__tests__/session-shape.test.ts
+++ b/apps/auth/src/lib/server/auth/__tests__/session-shape.test.ts
@@ -87,7 +87,10 @@ describe('shapeSessionUser — field mapping', () => {
   });
 
   it('passes permissions straight through', () => {
-    expect(shape({}, [], ['feature:a', 'feature:b']).permissions).toEqual(['feature:a', 'feature:b']);
+    expect(shape({}, [], ['feature:a', 'feature:b']).permissions).toEqual([
+      'feature:a',
+      'feature:b',
+    ]);
   });
 
   it('coerces filePreferences to an object (never a primitive)', () => {
@@ -99,7 +102,9 @@ describe('shapeSessionUser — field mapping', () => {
 
 describe('shapeSessionUser — tier / subscriptions', () => {
   it('resolves tier + subscription entry for a single active sub', () => {
-    const u = shape({}, [sub({ id: 'sub_1', status: 'active', product: { metadata: { tier: 'gold' } } })]);
+    const u = shape({}, [
+      sub({ id: 'sub_1', status: 'active', product: { metadata: { tier: 'gold' } } }),
+    ]);
     expect(u.tier).toBe('gold');
     expect(u.subscriptionId).toBe('sub_1');
     expect(u.memberInBadState).toBe(false);
@@ -127,7 +132,9 @@ describe('shapeSessionUser — tier / subscriptions', () => {
   });
 
   it('flags memberInBadState and keeps a primary sub id from a bad-state sub', () => {
-    const u = shape({}, [sub({ id: 'bad', status: 'past_due', product: { metadata: { tier: 'gold' } } })]);
+    const u = shape({}, [
+      sub({ id: 'bad', status: 'past_due', product: { metadata: { tier: 'gold' } } }),
+    ]);
     expect(u.memberInBadState).toBe(true);
     expect(u.tier).toBeUndefined(); // bad-state isn't "active", so no highest tier
     expect(u.subscriptionId).toBe('bad'); // but the bad-state sub is tracked so the user can manage it
@@ -184,7 +191,9 @@ describe('shapeSessionUser — membership override', () => {
   });
 
   it('never lowers a higher paid tier', () => {
-    const u = withOverride('bronze', [sub({ id: 'a', product: { metadata: { tier: 'founder' } } })]);
+    const u = withOverride('bronze', [
+      sub({ id: 'a', product: { metadata: { tier: 'founder' } } }),
+    ]);
     expect(u.tier).toBe('founder');
   });
 

--- a/apps/auth/src/lib/server/auth/__tests__/session-shape.test.ts
+++ b/apps/auth/src/lib/server/auth/__tests__/session-shape.test.ts
@@ -245,6 +245,43 @@ describe('shapeSessionUser — allowAds / redBrowsingLevel from settings (D)', (
   });
 });
 
+describe('shapeSessionUser — isEarlyAdopter from settings', () => {
+  it('projects an explicit opt-in / opt-out off the settings blob', () => {
+    expect(shape({ settings: { isEarlyAdopter: true } }).isEarlyAdopter).toBe(true);
+    expect(shape({ settings: { isEarlyAdopter: false } }).isEarlyAdopter).toBe(false);
+  });
+
+  it('stays undefined — not false — when the user never opted in', () => {
+    // Sparse on purpose: the overwhelming majority of session payloads must be
+    // byte-unchanged by this feature. `buildFliptContext` is what collapses
+    // undefined to the 'false' string, so nothing downstream needs a default here.
+    expect(shape({ settings: {} }).isEarlyAdopter).toBeUndefined();
+    expect(shape({ settings: null }).isEarlyAdopter).toBeUndefined();
+  });
+
+  it('ignores a mistyped value rather than passing it through or throwing', () => {
+    // The lenient .passthrough() parse drops the whole focused object on a type
+    // mismatch, so a garbage value must not surface as a truthy opt-in.
+    expect(shape({ settings: { isEarlyAdopter: 'yes' } }).isEarlyAdopter).toBeUndefined();
+    expect(shape({ settings: { isEarlyAdopter: 1 } }).isEarlyAdopter).toBeUndefined();
+  });
+
+  it('is independent of tier — a free user can opt in, a paying user can stay out', () => {
+    // The cohort must not be a proxy for membership; it is a pure user choice.
+    expect(shape({ settings: { isEarlyAdopter: true } }).isEarlyAdopter).toBe(true);
+    expect(shape({ settings: { isEarlyAdopter: false } }, [sub()]).isEarlyAdopter).toBe(false);
+  });
+
+  it('does not disturb the neighbouring settings-derived fields', () => {
+    // Same focused parse feeds allowAds/redBrowsingLevel; adding a key to it must
+    // not change how those resolve.
+    const u = shape({ settings: { isEarlyAdopter: true, allowAds: false, redBrowsingLevel: 31 } });
+    expect(u.allowAds).toBe(false);
+    expect(u.redBrowsingLevel).toBe(31);
+    expect(u.isEarlyAdopter).toBe(true);
+  });
+});
+
 describe('shapeSessionUser — meta / banDetails (parity)', () => {
   it('strips banDetails out of the output meta and yields undefined banDetails', () => {
     const u = shape({

--- a/apps/auth/src/lib/server/auth/session-shape.ts
+++ b/apps/auth/src/lib/server/auth/session-shape.ts
@@ -124,7 +124,8 @@ export function shapeSessionUser({
   // else fall back to the tier-based default (member → no ads; free → ads). Mirrors getSessionUser's intent.
   const parsedSettings = settingsSchema.safeParse(asObject(row.settings));
   const settings = parsedSettings.success ? parsedSettings.data : {};
-  const allowAds = settings.allowAds != null ? settings.allowAds : highestTier != null ? false : true;
+  const allowAds =
+    settings.allowAds != null ? settings.allowAds : highestTier != null ? false : true;
   const redBrowsingLevel: number | undefined =
     settings.redBrowsingLevel != null ? settings.redBrowsingLevel : undefined;
 

--- a/apps/auth/src/lib/server/auth/session-shape.ts
+++ b/apps/auth/src/lib/server/auth/session-shape.ts
@@ -10,7 +10,11 @@ import { getUserBanDetails, type BanDetailsMeta } from './ban';
 // honors it while getSessionUser currently defaults. To make them bit-identical, getSessionUser should adopt
 // the same focused read (a small, revenue-adjacent change — left for explicit review). See the cutover doc (D).
 const settingsSchema = z
-  .object({ allowAds: z.boolean().optional(), redBrowsingLevel: z.number().optional() })
+  .object({
+    allowAds: z.boolean().optional(),
+    redBrowsingLevel: z.number().optional(),
+    isEarlyAdopter: z.boolean().optional(),
+  })
   .passthrough();
 
 // PURE derivation: queried rows + permissions → the @civitai/auth SessionUser. No DB / redis / env, so the
@@ -124,6 +128,12 @@ export function shapeSessionUser({
   const redBrowsingLevel: number | undefined =
     settings.redBrowsingLevel != null ? settings.redBrowsingLevel : undefined;
 
+  // Early-adopter opt-in. Kept SPARSE (undefined when the user never opted in) rather
+  // than coerced to false, so the session payload for the overwhelming majority of users
+  // is unchanged; `buildFliptContext` is what turns it into a 'true'/'false' string.
+  const isEarlyAdopter: boolean | undefined =
+    settings.isEarlyAdopter != null ? settings.isEarlyAdopter : undefined;
+
   // meta → banDetails (parity: the main app strips banDetails out of meta before reading it, so banDetails
   // is effectively undefined; reproduced exactly).
   const fullMeta = asObject(row.meta) as { banDetails?: BanDetailsMeta } & Record<string, unknown>;
@@ -159,6 +169,7 @@ export function shapeSessionUser({
     subscriptionId: primarySubscriptionId,
     memberInBadState,
     allowAds,
+    isEarlyAdopter,
     tier: highestTier,
     meta: userMeta,
     banDetails: banDetails as Record<string, unknown> | undefined,

--- a/packages/civitai-auth/src/types.ts
+++ b/packages/civitai-auth/src/types.ts
@@ -33,6 +33,12 @@ export interface SessionUser {
   subscriptionId?: string;
   memberInBadState?: boolean;
   allowAds?: boolean;
+  /**
+   * Early-adopter opt-in, read off `User.settings.isEarlyAdopter` by the hub's
+   * `shapeSessionUser`. Carried on the session so `buildFliptContext` can expose it
+   * as a Flipt targeting property without a per-request DB read.
+   */
+  isEarlyAdopter?: boolean;
   // Client-only fields (parity with the main app's ExtendedUser — see src/types/next-auth.d.ts).
   name?: string;
   autoplayGifs?: boolean;

--- a/src/components/Account/SettingsCard.earlyAdopter.browser.test.tsx
+++ b/src/components/Account/SettingsCard.earlyAdopter.browser.test.tsx
@@ -137,8 +137,6 @@ describe('SettingsCard — early-adopter toggle', () => {
     // real explanatory copy, not just the label.
     renderWithProviders(<SettingsCard />);
 
-    await expect
-      .element(page.getByText(/before they roll out to everyone/i))
-      .toBeInTheDocument();
+    await expect.element(page.getByText(/before they roll out to everyone/i)).toBeInTheDocument();
   });
 });

--- a/src/components/Account/SettingsCard.earlyAdopter.browser.test.tsx
+++ b/src/components/Account/SettingsCard.earlyAdopter.browser.test.tsx
@@ -1,0 +1,144 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import type * as TrpcModule from '~/utils/trpc';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * The early-adopter switch on the account settings page.
+ *
+ * Two things are load-bearing and neither is visible from the server tests: the switch has
+ * to REFLECT the stored value (a switch that always renders off tells an opted-in user they
+ * are not enrolled), and toggling it has to send the boolean the schema expects AND ask the
+ * session to re-pull — the session is where `isEarlyAdopter` is actually read from, so
+ * without that refresh this tab keeps evaluating flags against the old value.
+ */
+
+const { mutate, refresh, settings, capturedMutationOptions } = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  refresh: vi.fn(async () => null),
+  settings: { value: {} as Record<string, unknown> },
+  capturedMutationOptions: { value: undefined as undefined | Record<string, unknown> },
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ id: 7, filePreferences: {}, refresh }),
+}));
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ assistantPersonality: false, stickerPlacement: false }),
+}));
+vi.mock('~/providers/BrowserSettingsProvider', () => ({
+  useBrowsingSettings: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ autoplayGifs: true, setState: vi.fn() }),
+}));
+vi.mock('~/hooks/useModelFileOptions', () => ({
+  useModelFileOptions: () => ({ precisions: ['fp16'], quantTypes: ['Q4_K_M'] }),
+}));
+vi.mock('~/utils/notifications', () => ({
+  showErrorNotification: vi.fn(),
+  showSuccessNotification: vi.fn(),
+}));
+// Capture the options `useMutateUserSettings` passes through so the onSuccess wiring can be
+// asserted, and serve the settings the card reads. Everything else keeps its real export.
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcModule>()),
+  trpc: {
+    useUtils: () => ({
+      user: {
+        getSettings: { getData: () => settings.value, setData: vi.fn(), invalidate: vi.fn() },
+        getFeatureFlags: {
+          getData: () => ({}),
+          setData: vi.fn(),
+          invalidate: vi.fn(),
+          cancel: vi.fn(),
+        },
+      },
+      model: { getAll: { invalidate: vi.fn() } },
+    }),
+    user: {
+      getSettings: { useQuery: () => ({ data: settings.value }) },
+      setSettings: {
+        useMutation: (options?: Record<string, unknown>) => {
+          capturedMutationOptions.value = options;
+          return { mutate, isPending: false };
+        },
+      },
+      update: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      toggleFeature: { useMutation: () => ({ mutate: vi.fn() }) },
+    },
+  },
+}));
+
+import { SettingsCard } from '~/components/Account/SettingsCard';
+
+const SWITCH_NAME = 'Join the early-adopter program';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  settings.value = {};
+  capturedMutationOptions.value = undefined;
+});
+
+describe('SettingsCard — early-adopter toggle', () => {
+  test('renders, unchecked, for a user who has not opted in', async () => {
+    renderWithProviders(<SettingsCard />);
+
+    const sw = page.getByRole('switch', { name: SWITCH_NAME });
+    await expect.element(sw).toBeInTheDocument();
+    await expect.element(sw).not.toBeChecked();
+  });
+
+  test('renders CHECKED for a user who has opted in', async () => {
+    // The stored value has to drive the control. A hardcoded `checked={false}` would pass
+    // the test above and still be wrong for every enrolled user.
+    settings.value = { isEarlyAdopter: true };
+    renderWithProviders(<SettingsCard />);
+
+    await expect.element(page.getByRole('switch', { name: SWITCH_NAME })).toBeChecked();
+  });
+
+  test('turning it ON sends isEarlyAdopter: true', async () => {
+    renderWithProviders(<SettingsCard />);
+
+    await userEvent.click(page.getByRole('switch', { name: SWITCH_NAME }));
+
+    expect(mutate).toHaveBeenCalledTimes(1);
+    // The literal payload the tRPC input schema accepts — a string would be rejected.
+    expect(mutate).toHaveBeenCalledWith({ isEarlyAdopter: true });
+  });
+
+  test('turning it OFF sends isEarlyAdopter: false, not an omitted key', async () => {
+    // Omitting the key would leave the stored `true` untouched (the write is a jsonb merge),
+    // so opting out has to send an explicit false.
+    settings.value = { isEarlyAdopter: true };
+    renderWithProviders(<SettingsCard />);
+
+    await userEvent.click(page.getByRole('switch', { name: SWITCH_NAME }));
+
+    expect(mutate).toHaveBeenCalledWith({ isEarlyAdopter: false });
+  });
+
+  test('the mutation is wired to refresh the session on success', async () => {
+    // The value is read off the SESSION, not off the getSettings cache the mutation patches.
+    // Without this, the tab that made the change is the one place still evaluating flags
+    // against the old value.
+    renderWithProviders(<SettingsCard />);
+    await userEvent.click(page.getByRole('switch', { name: SWITCH_NAME }));
+
+    const onSuccess = capturedMutationOptions.value?.onSuccess as undefined | (() => void);
+    expect(onSuccess).toBeTypeOf('function');
+    expect(refresh).not.toHaveBeenCalled();
+    onSuccess?.();
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  test('the switch carries a description explaining what opting in means', async () => {
+    // An opt-in that does not say what it opts you into is not consent. Assert there is
+    // real explanatory copy, not just the label.
+    renderWithProviders(<SettingsCard />);
+
+    await expect
+      .element(page.getByText(/before they roll out to everyone/i))
+      .toBeInTheDocument();
+  });
+});

--- a/src/components/Account/SettingsCard.tsx
+++ b/src/components/Account/SettingsCard.tsx
@@ -190,11 +190,10 @@ export function SettingsCard() {
           </>
         )}
 
+        <Divider label="Features" />
+        <EarlyAdopterToggle />
         {normalizedToggleableFeatures.length > 0 && (
-          <>
-            <Divider label="Features" />
-            <ToggleableFeatures data={normalizedToggleableFeatures} />
-          </>
+          <ToggleableFeatures data={normalizedToggleableFeatures} />
         )}
       </Stack>
     </Card>
@@ -252,6 +251,33 @@ function StickerMotionToggle() {
       checked={!(disableStickerMotion ?? false)}
       disabled={isPending}
       onChange={(e) => mutate({ disableStickerMotion: !e.target.checked })}
+      styles={{ track: { flex: '0 0 1em' } }}
+    />
+  );
+}
+
+function EarlyAdopterToggle() {
+  const { isEarlyAdopter } = useCurrentUserSettings();
+  const currentUser = useCurrentUser();
+  // The value is carried on the SESSION (see user.schema `isEarlyAdopter`), and the server
+  // busts the shared session cache on change. Re-pull the session here too so this tab's
+  // own `SessionUser` — and therefore its Flipt context — updates without a reload, rather
+  // than waiting on the `session:refresh` signal. Mirrors CreatorProgramV2, which does the
+  // same belt-and-braces refresh at the call site.
+  const { mutate, isPending } = useMutateUserSettings({
+    onSuccess: () => {
+      currentUser?.refresh();
+    },
+  });
+
+  return (
+    <Switch
+      name="isEarlyAdopter"
+      label="Join the early-adopter program"
+      description="Get in-progress features before they roll out to everyone. They may be rough, change without notice, or be withdrawn. Turn this off any time to go back to the standard experience."
+      checked={isEarlyAdopter ?? false}
+      disabled={isPending}
+      onChange={(e) => mutate({ isEarlyAdopter: e.target.checked })}
       styles={{ track: { flex: '0 0 1em' } }}
     />
   );

--- a/src/server/controllers/__tests__/user.controller.early-adopter-refresh.test.ts
+++ b/src/server/controllers/__tests__/user.controller.early-adopter-refresh.test.ts
@@ -17,17 +17,13 @@ import type * as SessionInvalidation from '~/server/auth/session-invalidation';
  * on whether `refreshSession` was called and with what.
  */
 
-const {
-  mockGetUserSettings,
-  mockSetUserSetting,
-  mockRefreshSession,
-  mockQueueReindex,
-} = vi.hoisted(() => ({
-  mockGetUserSettings: vi.fn(),
-  mockSetUserSetting: vi.fn().mockResolvedValue(undefined),
-  mockRefreshSession: vi.fn().mockResolvedValue(undefined),
-  mockQueueReindex: vi.fn().mockResolvedValue(undefined),
-}));
+const { mockGetUserSettings, mockSetUserSetting, mockRefreshSession, mockQueueReindex } =
+  vi.hoisted(() => ({
+    mockGetUserSettings: vi.fn(),
+    mockSetUserSetting: vi.fn().mockResolvedValue(undefined),
+    mockRefreshSession: vi.fn().mockResolvedValue(undefined),
+    mockQueueReindex: vi.fn().mockResolvedValue(undefined),
+  }));
 
 vi.mock('~/server/services/user.service', async (importOriginal) => ({
   ...(await importOriginal<typeof UserService>()),

--- a/src/server/controllers/__tests__/user.controller.early-adopter-refresh.test.ts
+++ b/src/server/controllers/__tests__/user.controller.early-adopter-refresh.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type * as UserService from '~/server/services/user.service';
+import type * as SessionInvalidation from '~/server/auth/session-invalidation';
+
+/**
+ * THE LOAD-BEARING BEHAVIOUR OF THE SESSION-CARRIED DESIGN.
+ *
+ * `isEarlyAdopter` lives in `User.settings` but is READ off the session
+ * (`SessionUser.isEarlyAdopter` → `buildFliptContext`). The auth hub caches that
+ * projection in `session:data2:{id}` for 4h, so writing the setting is NOT enough: without
+ * an explicit `refreshSession`, the user flips the switch, the client patches its own
+ * `getSettings` cache optimistically so the UI looks applied — and every server-side Flipt
+ * evaluation keeps returning the OLD cohort decision for up to four hours. The toggle
+ * silently does nothing. That is the failure mode of this design, so it is pinned here.
+ *
+ * `setUserSettingHandler` is run for REAL against a mocked service layer; the assertion is
+ * on whether `refreshSession` was called and with what.
+ */
+
+const {
+  mockGetUserSettings,
+  mockSetUserSetting,
+  mockRefreshSession,
+  mockQueueReindex,
+} = vi.hoisted(() => ({
+  mockGetUserSettings: vi.fn(),
+  mockSetUserSetting: vi.fn().mockResolvedValue(undefined),
+  mockRefreshSession: vi.fn().mockResolvedValue(undefined),
+  mockQueueReindex: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/services/user.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof UserService>()),
+  getUserSettings: mockGetUserSettings,
+  setUserSetting: mockSetUserSetting,
+}));
+
+vi.mock('~/server/auth/session-invalidation', async (importOriginal) => ({
+  ...(await importOriginal<typeof SessionInvalidation>()),
+  refreshSession: mockRefreshSession,
+}));
+
+// `user.controller` imports exactly ONE symbol from model.service, so stub it wholesale
+// rather than with `importOriginal` — the real module drags in the whole image/event-engine
+// graph for no benefit here.
+vi.mock('~/server/services/model.service', () => ({
+  queueModelMetricPrivacyReindex: mockQueueReindex,
+}));
+
+const { setUserSettingHandler } = await import('~/server/controllers/user.controller');
+
+const USER_ID = 4242;
+
+const ctx = () =>
+  ({
+    user: { id: USER_ID },
+    features: { assistantPersonality: true },
+  } as never);
+
+const call = (input: Record<string, unknown>) =>
+  setUserSettingHandler({ input: input as never, ctx: ctx() });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetUserSettings.mockResolvedValue({});
+});
+
+describe('setUserSettingHandler — session refresh on the early-adopter toggle', () => {
+  it('refreshes the session when the user OPTS IN', async () => {
+    mockGetUserSettings.mockResolvedValue({});
+
+    await call({ isEarlyAdopter: true });
+
+    expect(mockSetUserSetting).toHaveBeenCalledTimes(1);
+    expect(mockRefreshSession).toHaveBeenCalledTimes(1);
+    expect(mockRefreshSession).toHaveBeenCalledWith(USER_ID, { caller: 'profile' });
+  });
+
+  it('refreshes the session when the user OPTS OUT', async () => {
+    // Leaving the programme must take effect as promptly as joining it, or a user who
+    // turns it off keeps seeing the in-progress features they just opted out of.
+    mockGetUserSettings.mockResolvedValue({ isEarlyAdopter: true });
+
+    await call({ isEarlyAdopter: false });
+
+    expect(mockRefreshSession).toHaveBeenCalledTimes(1);
+    expect(mockRefreshSession).toHaveBeenCalledWith(USER_ID, { caller: 'profile' });
+  });
+
+  it('does NOT refresh when an unrelated setting is written', async () => {
+    // The refresh busts a shared cache and fans a signal out to every open tab. Doing it on
+    // every settings write would put that cost on the tour-settings/ToS paths for nothing.
+    mockGetUserSettings.mockResolvedValue({});
+
+    await call({ swipeGalleryCards: true });
+
+    expect(mockSetUserSetting).toHaveBeenCalledTimes(1);
+    expect(mockRefreshSession).not.toHaveBeenCalled();
+  });
+
+  it('does NOT refresh when an unrelated setting is written by an ALREADY-opted-in user', async () => {
+    // The regression this guards: `setUserSettingHandler` does a read-modify-write, so the
+    // payload handed to `setUserSetting` carries `isEarlyAdopter` on EVERY write once the
+    // user has opted in. A presence check (`'isEarlyAdopter' in newSettings`) would fire the
+    // refresh on every unrelated toggle for exactly the cohort that uses the site most.
+    mockGetUserSettings.mockResolvedValue({ isEarlyAdopter: true, allowAds: false });
+
+    await call({ swipeGalleryCards: true });
+
+    // The write still carries the existing opt-in through (read-modify-write intact) ...
+    expect(mockSetUserSetting).toHaveBeenCalledWith(
+      USER_ID,
+      expect.objectContaining({ isEarlyAdopter: true })
+    );
+    // ... but nothing CHANGED, so no refresh.
+    expect(mockRefreshSession).not.toHaveBeenCalled();
+  });
+
+  it('does NOT refresh on a no-op write of the same value', async () => {
+    mockGetUserSettings.mockResolvedValue({ isEarlyAdopter: true });
+
+    await call({ isEarlyAdopter: true });
+
+    expect(mockRefreshSession).not.toHaveBeenCalled();
+  });
+
+  it('refreshes when the value goes from unset to explicitly false', async () => {
+    // undefined → false is a real transition of the stored value. It does not change the
+    // Flipt context (both coerce to 'false'), so this is an INVARIANT GUARD on the
+    // change-detection predicate, not regression coverage for an observed bug: it pins that
+    // the predicate compares values rather than testing truthiness.
+    mockGetUserSettings.mockResolvedValue({});
+
+    await call({ isEarlyAdopter: false });
+
+    expect(mockRefreshSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('still returns the merged settings to the caller', async () => {
+    mockGetUserSettings.mockResolvedValue({ allowAds: false });
+
+    const result = await call({ isEarlyAdopter: true });
+
+    expect(result).toMatchObject({ allowAds: false, isEarlyAdopter: true });
+  });
+
+  it('the refresh is AWAITED, so the cache bust lands before the mutation resolves', async () => {
+    // If the call were fire-and-forget, the client's follow-up session fetch could race the
+    // bust and re-cache the stale projection — the same race `updateContentSettings`
+    // documents on its own awaited refresh.
+    let settled = false;
+    mockRefreshSession.mockImplementation(
+      () =>
+        new Promise<void>((resolve) =>
+          setTimeout(() => {
+            settled = true;
+            resolve();
+          }, 10)
+        )
+    );
+    mockGetUserSettings.mockResolvedValue({});
+
+    await call({ isEarlyAdopter: true });
+
+    expect(settled).toBe(true);
+  });
+});

--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -1454,6 +1454,23 @@ export const setUserSettingHandler = async ({
     );
     if (metricPrivacyChanged) await queueModelMetricPrivacyReindex(id);
 
+    // `isEarlyAdopter` is the one settings key PROJECTED ONTO THE SESSION (auth hub
+    // `shapeSessionUser` → `SessionUser.isEarlyAdopter` → `buildFliptContext`), and the
+    // hub caches that projection in `session:data2:{id}` for 4h. Without this the toggle
+    // reads as instantly applied client-side (the `getSettings` cache is patched
+    // optimistically) while every Flipt evaluation keeps the OLD value until the cache
+    // expires — the toggle appears to do nothing. `refreshSession` busts that cache and
+    // signals the browser to re-pull. Awaited so the bust lands before the mutation
+    // returns; same reason `updateContentSettings` awaits its own call.
+    //
+    // Gated on a CHANGE, not on key presence: `newSettings` is a read-modify-write of the
+    // whole blob, so once a user has opted in the key is present on EVERY subsequent
+    // settings write, and a presence check would refresh the session on unrelated
+    // toggles. Mirrors the `metricPrivacyChanged` comparison directly above.
+    const earlyAdopterChanged =
+      'isEarlyAdopter' in restInput && restSettings.isEarlyAdopter !== restInput.isEarlyAdopter;
+    if (earlyAdopterChanged) await refreshSession(id, { caller: 'profile' });
+
     return newSettings;
   } catch (error) {
     throw throwDbError(error);

--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -94,8 +94,16 @@ export enum FLIPT_FEATURE_FLAGS {
   PLACEMENT_METRIC_SWEEP = 'placement-metric-sweep',
   // Early-adopter cohort gate. Segments on the `isEarlyAdopter` Flipt context property
   // that `buildFliptContext` emits from the user's opt-in setting, so background paths
-  // (no request context) can gate on the same flag the request path does. Default-off —
-  // isFlipt returns false for an unknown flag.
+  // (no request context) can gate on the same flag the request path does.
+  //
+  // 🔴 NOT default-off in the usual sense. `isFlipt` returns false for an UNKNOWN flag, but
+  // once this flag exists its answer for a non-matching entity is the flag's own `enabled`
+  // value, which Flipt returns when no rollout matches. So a caller that evaluates this
+  // WITHOUT the `isEarlyAdopter` context — which is every background path, since there is
+  // no request user to build a context from — gets that default, not false. It is false
+  // only because flipt-state pins the flag `enabled: false`. Pass a real context, or treat
+  // a bare `isFlipt(EARLY_ADOPTER)` as "is the programme switched on at all", never as
+  // "is this user an early adopter".
   EARLY_ADOPTER = 'early-adopter',
 }
 

--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -92,6 +92,11 @@ export enum FLIPT_FEATURE_FLAGS {
   // `metricCountedAt` while already having been counted, so a sweep running
   // first re-emits all of it and roughly doubles those counters permanently.
   PLACEMENT_METRIC_SWEEP = 'placement-metric-sweep',
+  // Early-adopter cohort gate. Segments on the `isEarlyAdopter` Flipt context property
+  // that `buildFliptContext` emits from the user's opt-in setting, so background paths
+  // (no request context) can gate on the same flag the request path does. Default-off —
+  // isFlipt returns false for an unknown flag.
+  EARLY_ADOPTER = 'early-adopter',
 }
 
 // Flags exempt from caching: incident kill-switches where an operator expects a

--- a/src/server/schema/__tests__/user-settings-early-adopter.schema.test.ts
+++ b/src/server/schema/__tests__/user-settings-early-adopter.schema.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { setUserSettingsInput, userSettingsSchema } from '~/server/schema/user.schema';
+
+/**
+ * `setUserSettingsInput` is a NARROW ALLOW-LIST, deliberately much smaller than
+ * `userSettingsSchema`. tRPC validates the mutation input against it and STRIPS anything
+ * not listed — so a key present in the storage schema but missing from the input schema is
+ * silently discarded on write. The UI would look correct, the mutation would succeed, and
+ * the setting would never persist. Both schemas are asserted here for that reason.
+ */
+
+describe('userSettingsSchema — isEarlyAdopter (storage shape)', () => {
+  it('accepts and round-trips true', () => {
+    const parsed = userSettingsSchema.parse({ isEarlyAdopter: true });
+    expect(parsed.isEarlyAdopter).toBe(true);
+  });
+
+  it('accepts and round-trips false', () => {
+    const parsed = userSettingsSchema.parse({ isEarlyAdopter: false });
+    expect(parsed.isEarlyAdopter).toBe(false);
+  });
+
+  it('is optional — an existing settings blob without it still parses', () => {
+    const parsed = userSettingsSchema.parse({ allowAds: true });
+    expect(parsed.isEarlyAdopter).toBeUndefined();
+    expect('isEarlyAdopter' in parsed).toBe(false);
+  });
+
+  it('rejects a non-boolean rather than coercing it', () => {
+    // A coerced 'false' → true would enrol someone who never asked to be enrolled.
+    expect(() => userSettingsSchema.parse({ isEarlyAdopter: 'true' })).toThrow();
+    expect(() => userSettingsSchema.parse({ isEarlyAdopter: 1 })).toThrow();
+    expect(() => userSettingsSchema.parse({ isEarlyAdopter: null })).toThrow();
+  });
+
+  it('does not disturb the sibling keys', () => {
+    const parsed = userSettingsSchema.parse({
+      isEarlyAdopter: true,
+      allowAds: false,
+      dismissedAlerts: ['a'],
+    });
+    expect(parsed).toMatchObject({
+      isEarlyAdopter: true,
+      allowAds: false,
+      dismissedAlerts: ['a'],
+    });
+  });
+});
+
+describe('setUserSettingsInput — isEarlyAdopter (write allow-list)', () => {
+  it('SURVIVES validation instead of being stripped', () => {
+    // The whole point: an omitted key parses fine and vanishes, which is indistinguishable
+    // from success at the call site. Assert the value is still there afterwards.
+    const parsed = setUserSettingsInput.parse({ isEarlyAdopter: true });
+    expect(parsed.isEarlyAdopter).toBe(true);
+    expect('isEarlyAdopter' in parsed).toBe(true);
+  });
+
+  it('carries false through as well, so opting out is writable', () => {
+    const parsed = setUserSettingsInput.parse({ isEarlyAdopter: false });
+    expect(parsed.isEarlyAdopter).toBe(false);
+    expect('isEarlyAdopter' in parsed).toBe(true);
+  });
+
+  it('rejects a non-boolean at the tRPC boundary', () => {
+    expect(() => setUserSettingsInput.parse({ isEarlyAdopter: 'yes' })).toThrow();
+    expect(() => setUserSettingsInput.parse({ isEarlyAdopter: 1 })).toThrow();
+  });
+
+  it('is still optional alongside the other writable settings', () => {
+    const parsed = setUserSettingsInput.parse({ swipeGalleryCards: true });
+    expect(parsed.isEarlyAdopter).toBeUndefined();
+  });
+
+  it('CONTROL: an unlisted key really is stripped', () => {
+    // Positive control for the assertions above — proves the "survives validation" checks
+    // can distinguish a listed key from an unlisted one, rather than passing vacuously.
+    const parsed = setUserSettingsInput.parse({
+      isEarlyAdopter: true,
+      notARealSetting: true,
+    } as never) as Record<string, unknown>;
+    expect(parsed.isEarlyAdopter).toBe(true);
+    expect('notARealSetting' in parsed).toBe(false);
+  });
+});

--- a/src/server/schema/user.schema.ts
+++ b/src/server/schema/user.schema.ts
@@ -283,6 +283,12 @@ export const userSettingsSchema = z.object({
   cosmeticStoreLastViewed: z.coerce.date().nullish(),
   allowAds: z.boolean().optional(),
   disableHidden: z.boolean().optional(),
+  // Opt-in: receive in-progress features ahead of general release. Unlike every
+  // other key here this one is PROJECTED ONTO THE SESSION (auth hub
+  // `shapeSessionUser` → `SessionUser.isEarlyAdopter` → `buildFliptContext`), so
+  // Flipt can segment on it. That projection is cached, which is why the write
+  // path re-produces the session on CHANGE — see `setUserSettingHandler`.
+  isEarlyAdopter: z.boolean().optional(),
   // Opt-in: horizontal drag on multi-image gallery post cards. Off by default —
   // the feed mounts hundreds of cards and each one costs an embla engine.
   swipeGalleryCards: z.boolean().optional(),
@@ -353,6 +359,7 @@ export const setUserSettingsInput = z.object({
   creatorsProgramCodeOfConductAccepted: z.date().optional(),
   cosmeticStoreLastViewed: z.date().optional(),
   allowAds: z.boolean().optional(),
+  isEarlyAdopter: z.boolean().optional(),
   swipeGalleryCards: z.boolean().optional(),
   disableStickerMotion: z.boolean().optional(),
   hideDonationGoals: z.boolean().optional(),

--- a/src/server/services/__tests__/feature-flags.early-adopter.seam.test.ts
+++ b/src/server/services/__tests__/feature-flags.early-adopter.seam.test.ts
@@ -14,17 +14,24 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  * does not project, or a context property the segment does not match, both look perfectly
  * healthy from inside their own file. So this drives REAL code at every hop and stubs only
  * the Flipt EDGE (`~/server/flipt/client`), whose stub doubles as the assertion point: it
- * captures the exact context the chain produced and applies a matcher written to mirror
- * the LIVE `early-adopters` segment (`property: isEarlyAdopter`, `operator: eq`,
- * `value: "true"` — a STRING equality, exactly as Flipt evaluates it).
+ * captures the exact context the chain produced and evaluates it against a transcription of
+ * the LIVE flag — BOTH its `early-adopters` segment rollout and its flag-level `enabled`.
  *
  * Modelled on `src/server/routers/__tests__/blocks.router.flag-gate-hydrate.test.ts`.
  *
+ * 🔴 THE FIRST VERSION OF THIS FILE MODELLED ONLY THE SEGMENT, and that omission is exactly
+ * how a deploy-blocking defect got through a green seam test. The stub returned `false` for
+ * a non-matching user; real Flipt returns the flag's `enabled`. The flag shipped as
+ * `enabled: true`, so in production every non-opted-in user and every anonymous request
+ * would have evaluated to `true` — while this test happily asserted "OFF end-to-end". A
+ * fake that disagrees with production in the direction you were hoping for is worse than no
+ * fake. See `EARLY_ADOPTER_FLAG` below and the `flag-level default` describe block.
+ *
  * The surface this fixture does NOT load, stated plainly: the Flipt server itself, and the
- * flipt-state YAML (a different repo). `segmentMatcher` below is a hand-written mirror of
- * that YAML, so a change to the real segment's property/value can still diverge from this
- * test. That divergence is guarded on the YAML side by the assertions in the flipt-state
- * PR, not here.
+ * flipt-state YAML (a different repo). `EARLY_ADOPTER_FLAG` is a hand-written transcription
+ * of that YAML, so a change to the real flag can still diverge from this test. That
+ * divergence is guarded on the YAML side by `scripts/validate-flag-shape.py` in flipt-state,
+ * not here.
  */
 
 const { mockIsFliptSync } = vi.hoisted(() => ({ mockIsFliptSync: vi.fn() }));
@@ -97,20 +104,73 @@ function sessionUserFromSettings(settings: unknown, id = 42): SessionUser {
 }
 
 /**
- * A faithful stand-in for the live `early-adopters` Flipt segment. Written from the YAML
- * (STRING_COMPARISON_TYPE / isEarlyAdopter / eq / "true"), NOT from buildFliptContext — so
- * if the context ever stopped emitting the exact string the segment wants, this goes red.
+ * A stand-in for how Flipt actually evaluates a BOOLEAN flag. It models BOTH halves of the
+ * flag definition, because the earlier version of this stub modelled only the segment and
+ * was therefore structurally unable to see the defect that shipped in flipt-state#62:
+ *
+ *   1. the segment rollout — match ⇒ the rollout's `value`
+ *   2. `enabled` — the value returned when NO rollout matches
+ *
+ * 🔴 `enabled` is NOT a master switch. Measured on prod Flipt v2.10.0 (2026-08-15):
+ *      oauth-apps / comic-creator / api-key-buzz-limit (enabled:true + segment rollout)
+ *        → non-matching entity gets `true`, DEFAULT_EVALUATION_REASON, segmentKeys=[]
+ *      app-blocks-enabled / buzz-memberships (enabled:false + segment rollout)
+ *        → non-matching gets `false`; a MATCHING entity still gets `true` / MATCH
+ * A stub that returns `false` for a non-match hard-codes the answer we hoped for and
+ * agrees with production only by luck of the flag being written correctly.
  */
-const segmentMatcher = (ctx?: Record<string, string>) => ctx?.isEarlyAdopter === 'true';
+type BooleanFlagShape = {
+  /** The no-match DEFAULT. Mirrors `enabled:` in flipt-state features.yaml. */
+  enabled: boolean;
+  rollout: { matches: (ctx?: Record<string, string>) => boolean; value: boolean };
+};
+
+/**
+ * Mirrors the `early-adopter` flag as defined in
+ * flipt-state `civitai-app/default/features.yaml`. Both fields are transcribed from the
+ * YAML, not from `buildFliptContext` — so if the context stopped emitting the exact string
+ * the segment wants, or if the flag's `enabled` were flipped, this goes red.
+ */
+const EARLY_ADOPTER_FLAG: BooleanFlagShape = {
+  enabled: false,
+  rollout: {
+    // constraint: STRING_COMPARISON_TYPE / property isEarlyAdopter / eq / "true"
+    matches: (ctx) => ctx?.isEarlyAdopter === 'true',
+    value: true,
+  },
+};
+
+/** Flipt's boolean evaluation: first matching rollout wins, else the flag's `enabled`. */
+function evaluateBoolean(shape: BooleanFlagShape, ctx?: Record<string, string>): boolean {
+  return shape.rollout.matches(ctx) ? shape.rollout.value : shape.enabled;
+}
 
 const req = { headers: {} } as never;
 
-beforeEach(() => {
-  mockIsFliptSync.mockReset();
+/**
+ * A request with a UNIQUE host, and therefore a unique `featureAccessKey`.
+ *
+ * Needed for anonymous cases: with no user the key degenerates to `anon|h:<host>|r:`, so
+ * every anonymous test in this file would otherwise share ONE memo entry and read whichever
+ * test ran first. (That sharing is correct in production — all anonymous callers really are
+ * interchangeable for flag purposes — which is exactly why the tests have to vary the host
+ * rather than the code being "fixed".) Host is safe to vary here: the flag declares no
+ * server availability, so `serverMatch` is true for any host.
+ */
+let nextHost = 0;
+const freshReq = () => ({ headers: { host: `t${++nextHost}.test.invalid` } } as never);
+
+/** Install the Flipt stub, optionally overriding the flag's shape for a single test. */
+function stubFlipt(shape: BooleanFlagShape = EARLY_ADOPTER_FLAG) {
   mockIsFliptSync.mockImplementation(
     (flag: string, _entityId: string, ctx?: Record<string, string>) =>
-      flag === 'early-adopter' ? segmentMatcher(ctx) : null
+      flag === 'early-adopter' ? evaluateBoolean(shape, ctx) : null
   );
+}
+
+beforeEach(() => {
+  mockIsFliptSync.mockReset();
+  stubFlipt();
 });
 
 describe('early-adopter seam: User.settings → hub session → Flipt context', () => {
@@ -131,7 +191,7 @@ describe('early-adopter seam: User.settings → hub session → Flipt context', 
   it('an unrelated settings blob does not accidentally enrol anyone', () => {
     const user = sessionUserFromSettings({ allowAds: false, dismissedAlerts: ['x'] });
     expect(buildFliptContext(user).isEarlyAdopter).toBe('false');
-    expect(segmentMatcher(buildFliptContext(user))).toBe(false);
+    expect(EARLY_ADOPTER_FLAG.rollout.matches(buildFliptContext(user))).toBe(false);
   });
 });
 
@@ -174,7 +234,7 @@ describe('early-adopter seam: the full chain decides the flag', () => {
   });
 
   it('an anonymous request is never in the cohort', async () => {
-    const features = await getFeatureFlagsAsync({ user: undefined, req });
+    const features = await getFeatureFlagsAsync({ user: undefined, req: freshReq() });
     expect(features.earlyAdopter).toBeFalsy();
   });
 
@@ -185,6 +245,65 @@ describe('early-adopter seam: the full chain decides the flag', () => {
     const features = await getFeatureFlagsAsync({ user, req });
     expect(features.earlyAdopter).toBe(true);
     expect(features.oauthApps).toBeFalsy();
+  });
+});
+
+describe("early-adopter seam: the flag's `enabled` is the NO-MATCH DEFAULT", () => {
+  // These are the tests the original stub could not express, and their absence is what let
+  // an inverted flag definition pass a green seam suite.
+
+  it('the transcribed flag is `enabled: false` — the only shape that scopes the cohort', () => {
+    // Pinned as a literal against the flipt-state YAML. If someone "turns the flag on" by
+    // setting enabled:true, this is the first thing that goes red.
+    expect(EARLY_ADOPTER_FLAG.enabled).toBe(false);
+    expect(EARLY_ADOPTER_FLAG.rollout.value).toBe(true);
+  });
+
+  it('a non-matching entity receives the flag-level default, not a hard-coded false', () => {
+    // Direct assertion on the evaluator, so the stub's own semantics are under test rather
+    // than merely assumed by the tests that consume it.
+    expect(evaluateBoolean(EARLY_ADOPTER_FLAG, { isEarlyAdopter: 'false' })).toBe(false);
+    expect(evaluateBoolean(EARLY_ADOPTER_FLAG, undefined)).toBe(false);
+    expect(evaluateBoolean(EARLY_ADOPTER_FLAG, { isEarlyAdopter: 'true' })).toBe(true);
+  });
+
+  it('an `enabled: true` flag puts EVERY non-opted-in user in the cohort (the shipped defect)', async () => {
+    // The regression case, driven end-to-end. This is the production behaviour measured on
+    // Flipt v2.10.0 for oauth-apps / comic-creator / api-key-buzz-limit, and it is what the
+    // first version of flipt-state#62 would have done: the segment selects nobody, and the
+    // flag is on for the whole internet.
+    stubFlipt({ ...EARLY_ADOPTER_FLAG, enabled: true });
+
+    const optedOut = sessionUserFromSettings({}, freshId());
+    const features = await getFeatureFlagsAsync({ user: optedOut, req });
+
+    // NOT falsy — a user who never opted in is in the cohort.
+    expect(features.earlyAdopter).toBe(true);
+  });
+
+  it('an `enabled: true` flag also enrols ANONYMOUS requests', async () => {
+    // buildFliptContext omits isEarlyAdopter entirely with no user, so the segment cannot
+    // match and the default is all that is left. A cohort gate that fires for logged-out
+    // traffic is the worst version of this bug.
+    stubFlipt({ ...EARLY_ADOPTER_FLAG, enabled: true });
+
+    const features = await getFeatureFlagsAsync({ user: undefined, req: freshReq() });
+    expect(features.earlyAdopter).toBe(true);
+  });
+
+  it('app-side `availability: []` does NOT rescue an inverted flag', async () => {
+    // The tempting mental model — "availability is [] so we fail closed" — is false
+    // whenever Flipt ANSWERS. hasFeature returns the Flipt result and never reaches static
+    // evaluation; availability only applies when Flipt is unreachable (returns null).
+    stubFlipt({ ...EARLY_ADOPTER_FLAG, enabled: true });
+
+    const optedOut = sessionUserFromSettings({}, freshId());
+    expect((await getFeatureFlagsAsync({ user: optedOut, req })).earlyAdopter).toBe(true);
+
+    // Same user, Flipt unreachable → NOW availability: [] fails closed.
+    mockIsFliptSync.mockImplementation(() => null);
+    const offline = sessionUserFromSettings({}, freshId());
+    expect((await getFeatureFlagsAsync({ user: offline, req })).earlyAdopter).toBeFalsy();
   });
 });
 

--- a/src/server/services/__tests__/feature-flags.early-adopter.seam.test.ts
+++ b/src/server/services/__tests__/feature-flags.early-adopter.seam.test.ts
@@ -1,0 +1,236 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * THE SEAM. Four surfaces own one value and each is individually testable and
+ * individually meaningless:
+ *
+ *   User.settings JSON
+ *     → apps/auth `shapeSessionUser`      (the auth hub's session projection)
+ *     → `SessionUser.isEarlyAdopter`      (the wire contract, packages/civitai-auth)
+ *     → `buildFliptContext`               (the evaluation context)
+ *     → `getFeatureFlags(...).earlyAdopter` (the flag the app actually branches on)
+ *
+ * A test scoped to any ONE hop passes while the chain is broken — a settings key the hub
+ * does not project, or a context property the segment does not match, both look perfectly
+ * healthy from inside their own file. So this drives REAL code at every hop and stubs only
+ * the Flipt EDGE (`~/server/flipt/client`), whose stub doubles as the assertion point: it
+ * captures the exact context the chain produced and applies a matcher written to mirror
+ * the LIVE `early-adopters` segment (`property: isEarlyAdopter`, `operator: eq`,
+ * `value: "true"` — a STRING equality, exactly as Flipt evaluates it).
+ *
+ * Modelled on `src/server/routers/__tests__/blocks.router.flag-gate-hydrate.test.ts`.
+ *
+ * The surface this fixture does NOT load, stated plainly: the Flipt server itself, and the
+ * flipt-state YAML (a different repo). `segmentMatcher` below is a hand-written mirror of
+ * that YAML, so a change to the real segment's property/value can still diverge from this
+ * test. That divergence is guarded on the YAML side by the assertions in the flipt-state
+ * PR, not here.
+ */
+
+const { mockIsFliptSync } = vi.hoisted(() => ({ mockIsFliptSync: vi.fn() }));
+
+// Only the Flipt edge is stubbed. `buildFliptContext` / `hasFeature` / the feature registry
+// all run for real.
+vi.mock('~/server/flipt/client', () => ({
+  isFliptSync: (...a: unknown[]) => mockIsFliptSync(...a),
+  isFlipt: vi.fn(),
+  getFliptVariant: vi.fn(),
+  getFliptBoolean: vi.fn(),
+  ensureFliptInitialized: vi.fn(async () => undefined),
+  FLIPT_FEATURE_FLAGS: {},
+}));
+
+import {
+  shapeSessionUser,
+  type ProducerUserRow,
+} from '../../../../apps/auth/src/lib/server/auth/session-shape';
+import {
+  buildFliptContext,
+  getFeatureFlagsAsync,
+} from '~/server/services/feature-flags.service';
+import type { SessionUser } from '~/types/session';
+
+/**
+ * `getFeatureFlags` memoizes the whole FeatureAccess for 10s keyed on user identity + host
+ * + region, so two calls that share a key share a RESULT. Every test that evaluates flags
+ * therefore needs its own user id, or it reads the previous test's answer. (The one test
+ * that deliberately reuses an id does so to pin the cache key — see the last describe.)
+ */
+let nextUserId = 1000;
+const freshId = () => ++nextUserId;
+
+/** A `User` row as the hub's producer query returns it, with a caller-supplied settings blob. */
+const userRow = (settings: unknown, id = 42): ProducerUserRow => ({
+  id,
+  username: 'alice',
+  name: 'Alice',
+  email: 'alice@example.com',
+  emailVerified: null,
+  image: null,
+  createdAt: new Date('2020-01-01T00:00:00Z'),
+  isModerator: false,
+  showNsfw: true,
+  blurNsfw: false,
+  browsingLevel: 7,
+  onboarding: 0,
+  muted: false,
+  mutedAt: null,
+  bannedAt: null,
+  deletedAt: null,
+  customerId: null,
+  paddleCustomerId: null,
+  autoplayGifs: null,
+  leaderboardShowcase: null,
+  filePreferences: {},
+  settings,
+  meta: {},
+  profilePicture: null,
+  referral: null,
+});
+
+/** settings JSON → the SessionUser a request would actually carry. Real hub code. */
+function sessionUserFromSettings(settings: unknown, id = 42): SessionUser {
+  return shapeSessionUser({
+    row: userRow(settings, id),
+    subscriptionRows: [],
+    permissions: [],
+    roles: [],
+    tierKey: 'tier',
+  }) as unknown as SessionUser;
+}
+
+/**
+ * A faithful stand-in for the live `early-adopters` Flipt segment. Written from the YAML
+ * (STRING_COMPARISON_TYPE / isEarlyAdopter / eq / "true"), NOT from buildFliptContext — so
+ * if the context ever stopped emitting the exact string the segment wants, this goes red.
+ */
+const segmentMatcher = (ctx?: Record<string, string>) => ctx?.isEarlyAdopter === 'true';
+
+const req = { headers: {} } as never;
+
+beforeEach(() => {
+  mockIsFliptSync.mockReset();
+  mockIsFliptSync.mockImplementation(
+    (flag: string, _entityId: string, ctx?: Record<string, string>) =>
+      flag === 'early-adopter' ? segmentMatcher(ctx) : null
+  );
+});
+
+describe('early-adopter seam: User.settings → hub session → Flipt context', () => {
+  it('an opt-in in the settings JSON reaches the Flipt context as the string "true"', () => {
+    const user = sessionUserFromSettings({ isEarlyAdopter: true });
+    // Hop 2 actually carried it — a settings key the hub silently drops would die here.
+    expect(user.isEarlyAdopter).toBe(true);
+    // Hop 3 emitted the exact literal the segment matches.
+    expect(buildFliptContext(user).isEarlyAdopter).toBe('true');
+  });
+
+  it('a user who never opted in reaches the context as "false"', () => {
+    const user = sessionUserFromSettings({});
+    expect(user.isEarlyAdopter).toBeUndefined();
+    expect(buildFliptContext(user).isEarlyAdopter).toBe('false');
+  });
+
+  it('an unrelated settings blob does not accidentally enrol anyone', () => {
+    const user = sessionUserFromSettings({ allowAds: false, dismissedAlerts: ['x'] });
+    expect(buildFliptContext(user).isEarlyAdopter).toBe('false');
+    expect(segmentMatcher(buildFliptContext(user))).toBe(false);
+  });
+});
+
+describe('early-adopter seam: the full chain decides the flag', () => {
+  it('the flag is ON end-to-end for an opted-in user', async () => {
+    const id = freshId();
+    const user = sessionUserFromSettings({ isEarlyAdopter: true }, id);
+    const features = await getFeatureFlagsAsync({ user, req });
+
+    expect(features.earlyAdopter).toBe(true);
+
+    // And it got there via a context the real chain built — not via static availability.
+    const call = mockIsFliptSync.mock.calls.find((c) => c[0] === 'early-adopter');
+    expect(call).toBeDefined();
+    const [, entityId, ctx] = call as [string, string, Record<string, string>];
+    expect(entityId).toBe(String(id));
+    expect(ctx.isEarlyAdopter).toBe('true');
+  });
+
+  it('the flag is OFF end-to-end for a user who did not opt in', async () => {
+    const user = sessionUserFromSettings({}, freshId());
+    const features = await getFeatureFlagsAsync({ user, req });
+
+    expect(features.earlyAdopter).toBeFalsy();
+    const call = mockIsFliptSync.mock.calls.find((c) => c[0] === 'early-adopter');
+    expect((call as [string, string, Record<string, string>])[2].isEarlyAdopter).toBe('false');
+  });
+
+  it('FAILS CLOSED when Flipt has no answer — an opt-in alone does not grant the flag', async () => {
+    // `availability: []` on the registry entry means static evaluation is false. So a Flipt
+    // outage (or a missing flag) must leave an opted-in user OUT of the cohort rather than
+    // handing the feature to them ungated. This is the branch that would silently invert if
+    // someone "helpfully" widened availability to ['user'].
+    mockIsFliptSync.mockImplementation(() => null);
+
+    const user = sessionUserFromSettings({ isEarlyAdopter: true }, freshId());
+    const features = await getFeatureFlagsAsync({ user, req });
+
+    expect(features.earlyAdopter).toBeFalsy();
+  });
+
+  it('an anonymous request is never in the cohort', async () => {
+    const features = await getFeatureFlagsAsync({ user: undefined, req });
+    expect(features.earlyAdopter).toBeFalsy();
+  });
+
+  it('the opt-in does not leak into a neighbouring Flipt-backed flag', async () => {
+    // `earlyAdopter` must not be a general privilege escalation: a flag gated on `mod`
+    // stays off for an opted-in non-mod.
+    const user = sessionUserFromSettings({ isEarlyAdopter: true }, freshId());
+    const features = await getFeatureFlagsAsync({ user, req });
+    expect(features.earlyAdopter).toBe(true);
+    expect(features.oauthApps).toBeFalsy();
+  });
+});
+
+describe('early-adopter seam: the FeatureAccess memo key must include the opt-in', () => {
+  it('flipping the opt-in for the SAME user flips the flag inside the memo TTL', async () => {
+    // `getFeatureFlags` memoizes the whole FeatureAccess for 10s under a key built from
+    // user identity + host + region (`featureAccessKey`). Refreshing the session is not
+    // enough on its own: if that key omits `isEarlyAdopter`, the freshly-refreshed session
+    // lands on the entry cached from BEFORE the toggle and the user keeps the old cohort
+    // decision for the rest of the TTL — the exact "toggle appears to do nothing" symptom
+    // the refresh exists to prevent, reintroduced one layer further down.
+    //
+    // Same id, same host, same region, same tier, same permissions — so ONLY the opt-in
+    // differs. Both calls happen well inside the 10s TTL, which is the point.
+    const id = freshId();
+
+    const before = await getFeatureFlagsAsync({
+      user: sessionUserFromSettings({ isEarlyAdopter: false }, id),
+      req,
+    });
+    expect(before.earlyAdopter).toBeFalsy();
+
+    const after = await getFeatureFlagsAsync({
+      user: sessionUserFromSettings({ isEarlyAdopter: true }, id),
+      req,
+    });
+    expect(after.earlyAdopter).toBe(true);
+  });
+
+  it('and back off again, so the key is not just "sticky once true"', async () => {
+    const id = freshId();
+
+    expect(
+      (await getFeatureFlagsAsync({ user: sessionUserFromSettings({ isEarlyAdopter: true }, id), req }))
+        .earlyAdopter
+    ).toBe(true);
+    expect(
+      (
+        await getFeatureFlagsAsync({
+          user: sessionUserFromSettings({ isEarlyAdopter: false }, id),
+          req,
+        })
+      ).earlyAdopter
+    ).toBeFalsy();
+  });
+});

--- a/src/server/services/__tests__/feature-flags.early-adopter.seam.test.ts
+++ b/src/server/services/__tests__/feature-flags.early-adopter.seam.test.ts
@@ -44,10 +44,7 @@ import {
   shapeSessionUser,
   type ProducerUserRow,
 } from '../../../../apps/auth/src/lib/server/auth/session-shape';
-import {
-  buildFliptContext,
-  getFeatureFlagsAsync,
-} from '~/server/services/feature-flags.service';
+import { buildFliptContext, getFeatureFlagsAsync } from '~/server/services/feature-flags.service';
 import type { SessionUser } from '~/types/session';
 
 /**
@@ -221,8 +218,12 @@ describe('early-adopter seam: the FeatureAccess memo key must include the opt-in
     const id = freshId();
 
     expect(
-      (await getFeatureFlagsAsync({ user: sessionUserFromSettings({ isEarlyAdopter: true }, id), req }))
-        .earlyAdopter
+      (
+        await getFeatureFlagsAsync({
+          user: sessionUserFromSettings({ isEarlyAdopter: true }, id),
+          req,
+        })
+      ).earlyAdopter
     ).toBe(true);
     expect(
       (

--- a/src/server/services/__tests__/feature-flags.early-adopter.test.ts
+++ b/src/server/services/__tests__/feature-flags.early-adopter.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import type { SessionUser } from '~/types/session';
+import { buildFliptContext } from '~/server/services/feature-flags.service';
+
+/**
+ * `buildFliptContext` emits the `isEarlyAdopter` targeting property that the Flipt
+ * `early-adopters` segment matches on (flipt-state civitai-app/default/features.yaml).
+ *
+ * The expectations here are LITERALS taken from the Flipt contract, not from the
+ * implementation: the evaluation context is `Record<string, string>`, so a segment
+ * constraint of `property: isEarlyAdopter / operator: eq / value: "true"` only ever
+ * matches the STRING 'true'. A boolean `true`, the string 'True', or an absent key all
+ * fail that constraint silently — as "nobody matches", never as an error — which is the
+ * whole reason these are pinned by value and not by `expect.anything()`.
+ */
+
+const user = (over: Partial<SessionUser> = {}): SessionUser =>
+  ({
+    id: 42,
+    showNsfw: false,
+    blurNsfw: true,
+    browsingLevel: 1,
+    onboarding: 0,
+    ...over,
+  } as SessionUser);
+
+describe('buildFliptContext — isEarlyAdopter', () => {
+  it('emits the STRING "true" for an opted-in user', () => {
+    const ctx = buildFliptContext(user({ isEarlyAdopter: true }));
+    expect(ctx.isEarlyAdopter).toBe('true');
+    // Not the boolean — a boolean would fail a STRING_COMPARISON_TYPE constraint.
+    expect(ctx.isEarlyAdopter).not.toBe(true as unknown as string);
+    expect(typeof ctx.isEarlyAdopter).toBe('string');
+  });
+
+  it('emits the STRING "false" for a user who explicitly opted out', () => {
+    const ctx = buildFliptContext(user({ isEarlyAdopter: false }));
+    expect(ctx.isEarlyAdopter).toBe('false');
+  });
+
+  it('emits "false" — not "undefined" — for a logged-in user who never opted in', () => {
+    // The session field is sparse (the hub leaves it undefined), so the coercion has to
+    // happen here. `String(undefined)` would produce the literal 'undefined', which is
+    // neither 'true' nor 'false' and would quietly mean "not in the cohort" for the wrong
+    // reason. Pin the value.
+    const ctx = buildFliptContext(user());
+    expect(ctx.isEarlyAdopter).toBe('false');
+    expect(ctx.isEarlyAdopter).not.toBe('undefined');
+  });
+
+  it('omits the key entirely for an anonymous request', () => {
+    const ctx = buildFliptContext(undefined);
+    // ABSENT, not the string 'false': there is no user to attribute an opt-in to, and the
+    // rest of the user-scoped context is omitted the same way.
+    expect('isEarlyAdopter' in ctx).toBe(false);
+    expect(ctx.isEarlyAdopter).toBeUndefined();
+    expect(ctx.isLoggedIn).toBe('false');
+  });
+
+  it('does not disturb the sibling context properties', () => {
+    // Every value in the context is a string; adding a key must not change the others.
+    const ctx = buildFliptContext(user({ isEarlyAdopter: true, isModerator: true, tier: 'gold' }));
+    expect(ctx.userId).toBe('42');
+    expect(ctx.isModerator).toBe('true');
+    expect(ctx.tier).toBe('gold');
+    expect(ctx.isMember).toBe('true');
+    expect(ctx.isLoggedIn).toBe('true');
+    for (const [key, value] of Object.entries(ctx)) {
+      expect(typeof value, `context key ${key} must be a string`).toBe('string');
+    }
+  });
+
+  it('a truthy non-boolean on the session still collapses to "true"', () => {
+    // Defence in depth against a future producer that writes a non-boolean: the segment
+    // constraint is an exact string match, so anything other than 'true'/'false' would
+    // silently exclude the user. `!!` guarantees one of the two.
+    const ctx = buildFliptContext(user({ isEarlyAdopter: 1 as unknown as boolean }));
+    expect(ctx.isEarlyAdopter).toBe('true');
+  });
+});

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -535,6 +535,13 @@ const featureFlags = createFeatureFlags({
   // the route SSR resolver reads the same resolved flag) but staged `['mod']`
   // rather than `[]` because it's a re-host, not a brand-new dark capability.
   appReviewPage: { availability: ['mod'], fliptKey: 'app-review-page' },
+  // Early-adopter opt-in cohort. `availability: []` = DARK by default and FAILS CLOSED
+  // (empty availability → static eval false when Flipt is absent/down), so the Flipt
+  // `early-adopter` flag is the ONLY on-switch. NOT `['user']`/`['public']`: those would
+  // fail OPEN and hand the cohort to everyone the moment Flipt is unreachable, which
+  // defeats the point of an opt-in. The flag's `early-adopters` segment matches on the
+  // `isEarlyAdopter` context property emitted by `buildFliptContext`.
+  earlyAdopter: { availability: [], fliptKey: 'early-adopter' },
 });
 
 export const featureFlagKeys = Object.keys(featureFlags) as FeatureFlagKey[];
@@ -667,6 +674,11 @@ export function buildFliptContext(user?: SessionUser): Record<string, string> {
     // Creator Program membership is recorded as an onboarding-step bit
     // (set on join in creator-program.service, cleared on leave).
     ctx.isInCreatorProgram = String(Flags.hasFlag(user.onboarding, OnboardingSteps.CreatorProgram));
+    // Early-adopter opt-in, stored in `User.settings` and projected onto the session by
+    // the auth hub. Always emitted for a logged-in user (never opted in ⇒ 'false'), so a
+    // Flipt segment can match on the string EQUALLY rather than on key presence — same
+    // shape as `isModerator` above. Absent entirely for an anonymous request.
+    ctx.isEarlyAdopter = String(!!user.isEarlyAdopter);
   } else {
     ctx.isLoggedIn = 'false';
   }
@@ -818,8 +830,12 @@ function computeFeatureFlags(ctx: FeatureAccessContext): FeatureAccess {
 // one user scrolling the feed (many getInfinite calls) — skip the per-flag work.
 //
 // KEY COMPLETENESS IS A CORRECTNESS INVARIANT. The cache key must include EVERY
-// input hasFeature reads: user id/isModerator/tier/permissions, host (domain
-// gating), and the FULL region. Region gates compliance-sensitive
+// input hasFeature reads: user id/isModerator/tier/isEarlyAdopter/permissions,
+// host (domain gating), and the FULL region. `isEarlyAdopter` is in the key for
+// exactly this reason — it feeds buildFliptContext, so an entry cached before the
+// user toggled it would keep the OLD cohort decision for the whole TTL, which is
+// precisely the staleness the toggle's `refreshSession` exists to prevent.
+// Region gates compliance-sensitive
 // restricted-region features, so two different regions must NEVER share an entry
 // — the whole region object is serialized into the key to guarantee that. Live
 // Flipt config changes are bounded by the TTL (same staleness as the per-eval
@@ -837,10 +853,9 @@ function featureAccessKey({ user, req, host = req?.headers.host }: FeatureAccess
   // checkRegionAccess's `if (req)`) so key construction never throws.
   const region = isDev || !req ? undefined : getRegion(req);
   const u = user
-    ? `u:${user.id}:${user.isModerator ? 1 : 0}:${user.tier ?? 'free'}:${(user.permissions ?? [])
-        .slice()
-        .sort()
-        .join(',')}`
+    ? `u:${user.id}:${user.isModerator ? 1 : 0}:${user.tier ?? 'free'}:${
+        user.isEarlyAdopter ? 1 : 0
+      }:${(user.permissions ?? []).slice().sort().join(',')}`
     : 'anon';
   return `${u}|h:${host ?? ''}|r:${region ? JSON.stringify(region) : ''}`;
 }

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -535,12 +535,26 @@ const featureFlags = createFeatureFlags({
   // the route SSR resolver reads the same resolved flag) but staged `['mod']`
   // rather than `[]` because it's a re-host, not a brand-new dark capability.
   appReviewPage: { availability: ['mod'], fliptKey: 'app-review-page' },
-  // Early-adopter opt-in cohort. `availability: []` = DARK by default and FAILS CLOSED
-  // (empty availability → static eval false when Flipt is absent/down), so the Flipt
-  // `early-adopter` flag is the ONLY on-switch. NOT `['user']`/`['public']`: those would
-  // fail OPEN and hand the cohort to everyone the moment Flipt is unreachable, which
-  // defeats the point of an opt-in. The flag's `early-adopters` segment matches on the
-  // `isEarlyAdopter` context property emitted by `buildFliptContext`.
+  // Early-adopter opt-in cohort. `availability: []` means static evaluation is false, so
+  // when Flipt is UNREACHABLE (isFliptSync → null) nobody is in the cohort. NOT
+  // `['user']`/`['public']`: those would fail OPEN during a Flipt outage, which defeats the
+  // point of an opt-in.
+  //
+  // 🔴 SCOPE OF THAT PROTECTION — it covers the Flipt-DOWN case ONLY, and nothing else.
+  // Once Flipt ANSWERS, `hasFeature` returns the Flipt result and never reaches static
+  // evaluation (see the `if (fliptResult !== null) return fliptResult` branch below), so
+  // `availability: []` cannot defend against a MIS-DEFINED flag. The correctness of this
+  // cohort therefore rests on a precondition held in ANOTHER REPO:
+  //
+  //   flipt-state `civitai-app/default/features.yaml` → flag `early-adopter` MUST be
+  //   `enabled: false` with the `early-adopters` segment rollout.
+  //
+  // For a boolean flag, Flipt's `enabled` is the value returned when NO rollout matches —
+  // it is not a master switch. `enabled: true` there would hand this flag to every
+  // non-opted-in user and every anonymous request, and nothing on this side would stop it.
+  // That exact defect was caught pre-merge in flipt-state#62; the shape is now gated by
+  // `scripts/validate-flag-shape.py` in that repo, and modelled in
+  // `feature-flags.early-adopter.seam.test.ts`.
   earlyAdopter: { availability: [], fliptKey: 'early-adopter' },
 });
 

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -37,6 +37,13 @@ export interface SessionUser {
   memberInBadState?: boolean;
   meta?: UserMeta;
   allowAds?: boolean;
+  /**
+   * Early-adopter opt-in, projected off `User.settings.isEarlyAdopter` by the auth hub
+   * (`shapeSessionUser`). Read by `buildFliptContext` so Flipt segments can target the
+   * cohort. Session-carried on purpose — the Flipt context is built once per request and
+   * must not take a DB read (feature-flags.service.ts).
+   */
+  isEarlyAdopter?: boolean;
   banDetails?: ReturnType<typeof getUserBanDetails>;
   redBrowsingLevel?: number;
   deletedAt?: Date;

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -1,8 +1,4 @@
-import type {
-  UserTier,
-  UserSubscriptionsByBuzzType,
-  UserMeta,
-} from '~/server/schema/user.schema';
+import type { UserTier, UserSubscriptionsByBuzzType, UserMeta } from '~/server/schema/user.schema';
 import type { getUserBanDetails } from '~/utils/user-helpers';
 
 // First-party session types — the app imports `Session`/`SessionUser` from here (not from 'next-auth'), so the


### PR DESCRIPTION
ClickUp: `868krm9cm`

Adds an **early-adopter opt-in** that users control from Account settings and that Flipt can segment on, so in-progress features can be shipped to the people who asked for them without a deploy per cohort change.

Pairs with **civitai/flipt-state#62**, which adds the `early-adopters` segment and the `early-adopter` flag. This PR is inert until that merges: the registry entry is `availability: []`, so with the flag absent nobody is in the cohort.

## Design: session-carried, not per-request

The value lives in `User.settings` (JSON — **no migration**) and is projected onto the session rather than read on the flag path:

```
User.settings.isEarlyAdopter
  -> shapeSessionUser         (auth hub projects it, right beside allowAds)
  -> SessionUser.isEarlyAdopter
  -> buildFliptContext        (emits the STRING 'true' / 'false')
  -> the `early-adopters` Flipt segment
```

`buildFliptContext` is deliberately built **once per request** (a documented optimization — every flag used to rebuild it N times), so a DB read there would undo that. The precedent copied is `isInCreatorProgram`, which is likewise a session-carried bit written by a service and read at evaluation time.

## The cost of that choice, and how it is paid

Session-carried means **cached**, so a naive version of this ships a toggle that silently does nothing. Two separate caches had to be handled, and they are the interesting part of the review:

1. **The hub session cache** (`session:data2:{id}`, 4h TTL). `setUserSettingHandler` now calls `refreshSession` when the value **changes**, which busts that cache and signals open tabs to re-pull. Gated on a change rather than key presence because the handler does a read-modify-write, so once a user has opted in the key rides along on *every* later settings write — a presence check would fire the refresh on unrelated toggles for exactly the most active cohort. This mirrors the `metricPrivacyChanged` comparison directly above it, and `creator-program.service`'s `refreshSession` after its own `User` write.

2. **The `FeatureAccess` memo** (`featureAccessKey`, 10s TTL) — found while writing the seam test, not by reading the code. That memo caches a whole resolved `FeatureAccess` keyed on user identity + host + region. Refreshing the session is **not sufficient on its own**: without the new input in the key, the freshly-refreshed session lands on the entry cached from before the toggle and the user keeps the old cohort decision for the rest of the TTL. The file already states *"KEY COMPLETENESS IS A CORRECTNESS INVARIANT — the cache key must include EVERY input hasFeature reads"*, so this change would have falsified that comment; `isEarlyAdopter` is now in the key and the comment says why.

`Session.needsCookieRefresh` was investigated as the lever and **rejected**: it is declared in `src/types/session.ts` and is set nowhere and read nowhere — vestigial from the next-auth era. Nothing here builds on it.

## Fail-closed

The registry entry is `availability: []` — dark by default, static evaluation false. If Flipt is unreachable or the flag is missing, the cohort is **empty**, not universal. `['user']` would have failed open and handed the features to everyone during a Flipt outage; there is a test pinning this branch.

## Files

| File | Why |
|---|---|
| `src/server/schema/user.schema.ts` | the key, in **both** `userSettingsSchema` (storage) and `setUserSettingsInput` (the narrow tRPC write allow-list — a key missing there is silently stripped on write) |
| `apps/auth/.../session-shape.ts` | hub projection off `row.settings`; `User.settings` was already selected by the producer query, so no query change |
| `packages/civitai-auth/src/types.ts` | the wire contract |
| `src/types/session.ts` | the app-side type |
| `src/server/services/feature-flags.service.ts` | context emission, the registry entry, and the memo key |
| `src/server/controllers/user.controller.ts` | `refreshSession` on change |
| `src/server/flipt/client.ts` | `EARLY_ADOPTER` for background paths with no request context |
| `src/components/Account/SettingsCard.tsx` | the switch, under a new "Features" divider |

## Tests

45 new tests. Every one was run against `origin/main` first: **33 fail there, 12 pass.** The 12 are invariant guards (they pin that the change does not *over*-fire — no refresh on unrelated writes, no enrolment from an unrelated settings blob) and pass at base only because the feature is absent; they are not counted as regression coverage.

- **`buildFliptContext`** — literal `'true'`/`'false'` strings (a boolean fails a `STRING_COMPARISON_TYPE` constraint), `'false'` and not `'undefined'` for a logged-in user who never opted in, and the key **absent** for an anonymous request.
- **Schemas** — round-trip in both, non-booleans rejected rather than coerced, plus a control proving an unlisted key really is stripped (so the "survives validation" assertions are not vacuous).
- **Hub projection** — explicit true/false, `undefined` (not `false`) when never set, mistyped values ignored, independent of tier.
- **Refresh** — fires on opt-in and opt-out, does **not** fire for an unrelated write by an already-opted-in user, and is `await`ed.
- **Seam** — real code from settings JSON through the hub projection and the real `buildFliptContext` to the resolved flag, with only `~/server/flipt/client` stubbed; the stub applies a matcher written from the flipt-state YAML rather than from our own context builder. Modelled on `blocks.router.flag-gate-hydrate.test.ts`.
- **Component** (browser mode) — the switch renders, reflects the stored value, sends the right boolean both ways, and is wired to refresh the session.

**Mutation-tested**: 11 mutations, each killed by the tests that own that guard and no others — dropping the context emission, dropping the `!!`, removing the opt-in from the memo key, flipping availability to fail-open, dropping the `refreshSession` call, turning change-detection into presence-detection, dropping the key from the write allow-list, dropping the hub projection, coercing `undefined` to `false` in the hub, ignoring the stored value in the switch, and dropping the UI refresh.

## Deploy ordering

`apps/auth` is a **separately deployed service**. The setting is writable and the UI works as soon as this merges, but `SessionUser.isEarlyAdopter` stays `undefined` — and so the cohort stays empty — until the **auth hub redeploys**. That direction is safe (fail-closed), but the flag will read as "not working" until the hub ships.

## Not fixed here (pre-existing, adjacent)

`featureAccessKey` also omits `user.onboarding`, which `buildFliptContext` reads for `isInCreatorProgram`. Joining the Creator Program therefore has the same up-to-10s staleness this PR fixes for `isEarlyAdopter`. Left alone deliberately — it changes cache-hit behaviour for every user and belongs in its own change.

