### PR TITLE
refactor(notices): one primitive + registry for server-persisted dismissals

### DIFF
--- a/src/components/Alerts/NavTidyNotice.tsx
+++ b/src/components/Alerts/NavTidyNotice.tsx
@@ -2,17 +2,15 @@ import { Button, CloseButton, Popover, Text } from '@mantine/core';
 import { IconArrowRight, IconInfoCircle } from '@tabler/icons-react';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
+import { FEATURE_NOTICES } from '~/components/Alerts/notice-registry';
+import { useFeatureNotice } from '~/components/Alerts/useFeatureNotice';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useFeatureFlags, useFeatureFlagsReady } from '~/providers/FeatureFlagsProvider';
-import { trpc } from '~/utils/trpc';
-
-const ALERT_ID = 'nav-tidy-notice';
 
 /**
  * Floating popover that appears right under the sub nav, where the Posts /
  * Events tabs used to live, letting users know they were tidied away and can
- * be turned back on from their account settings. Mirrors the dismiss pattern
- * used by {@link ./YellowBuzzMigrationNotice}.
+ * be turned back on from their account settings.
  */
 export function NavTidyNotice() {
   const currentUser = useCurrentUser();
@@ -20,44 +18,16 @@ export function NavTidyNotice() {
 
   const enabled = !!currentUser;
   const ready = useFeatureFlagsReady();
-  // SSR-seeded `user.getSettings` + the dismiss mutation's optimistic cache
-  // update keep `dismissedAlerts` authoritative without a per-mount refetch.
-  // Gate visibility on `ready` (per-user flag overlay) instead.
-  const { data: settings } = trpc.user.getSettings.useQuery(undefined, {
-    enabled,
-  });
-  const isDismissed = (settings?.dismissedAlerts ?? []).includes(ALERT_ID);
-
-  const utils = trpc.useUtils();
-  const dismissMutation = trpc.user.dismissAlert.useMutation({
-    onMutate: async () => {
-      await utils.user.getSettings.cancel();
-      const prev = utils.user.getSettings.getData();
-      utils.user.getSettings.setData(undefined, (old) => ({
-        ...old,
-        dismissedAlerts: [...(old?.dismissedAlerts ?? []), ALERT_ID],
-      }));
-      return { prev };
-    },
-    onError: (_err, _vars, ctx) => {
-      if (ctx?.prev) utils.user.getSettings.setData(undefined, ctx.prev);
-    },
-    // Reconcile with server truth after the optimistic update: the optimistic
-    // setData spreads `...old`, so if the cached base was incomplete (e.g. a
-    // failed SSR settings snapshot) it could persist a truncated settings
-    // object. Refetch once on dismiss to restore the full object + confirm the
-    // stored dismissedAlerts. One request per dismiss (rare) — not per mount.
-    onSettled: () => {
-      utils.user.getSettings.invalidate();
-    },
-  });
+  const { isDismissed, hasSettings, dismiss } = useFeatureNotice(FEATURE_NOTICES.navTidy);
 
   // Only nudge users who actually have one of the tidied items hidden.
   const hasHiddenNavItem = !features.postsNavItem || !features.eventsNavItem;
-  // `!!settings` guards the rare failed-SSR-snapshot path (undefined initialData):
-  // don't render against undefined `dismissedAlerts` until the self-healing mount
-  // fetch lands. Defined immediately on the normal SSR-seeded path → no delay.
-  const show = enabled && ready && !!settings && !isDismissed && hasHiddenNavItem;
+  // Two separate gates. `ready` waits for the per-user feature-flag overlay, so
+  // `hasHiddenNavItem` is read from real flags rather than defaults.
+  // `hasSettings` waits for a resolved settings object, so a rare failed SSR
+  // snapshot cannot flash this at someone who already dismissed it; on the
+  // normal SSR-seeded path it is true on the first render, so there is no delay.
+  const show = enabled && ready && hasSettings && !isDismissed && hasHiddenNavItem;
 
   // Open only AFTER the above-the-fold layout has settled. The popover is anchored
   // to a subnav target; opening it during the initial layout-settle window made its
@@ -74,7 +44,7 @@ export function NavTidyNotice() {
     return () => window.clearTimeout(id);
   }, [show]);
 
-  const handleDismiss = () => dismissMutation.mutate({ alertId: ALERT_ID });
+  const handleDismiss = () => dismiss();
 
   if (!show) return null;
 

--- a/src/components/Alerts/YellowBuzzMigrationNotice.tsx
+++ b/src/components/Alerts/YellowBuzzMigrationNotice.tsx
@@ -1,5 +1,7 @@
 import { Button, CloseButton, Popover, Text } from '@mantine/core';
 import { IconArrowRight } from '@tabler/icons-react';
+import { FEATURE_NOTICES } from '~/components/Alerts/notice-registry';
+import { useFeatureNotice } from '~/components/Alerts/useFeatureNotice';
 import { useFeatureFlags, useFeatureFlagsReady } from '~/providers/FeatureFlagsProvider';
 import { useServerDomains } from '~/providers/AppProvider';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
@@ -7,8 +9,6 @@ import { trpc } from '~/utils/trpc';
 import { BuzzBoltSvg } from '~/components/User/BuzzBoltSvg';
 import { abbreviateNumber } from '~/utils/number-helpers';
 import { syncAccount } from '~/utils/sync-account';
-
-const ALERT_ID = 'yellow-buzz-migration';
 
 /**
  * Floating popover card that wraps children (e.g. UserMenu) and shows
@@ -24,42 +24,20 @@ export function YellowBuzzMigrationNotice({ children }: { children: React.ReactN
   // Shares the `getBuzzAccount` cache with the global buzz display (signal-kept
   // live) — no need to force a refetch here.
   const { data: buzzAccounts } = trpc.buzz.getBuzzAccount.useQuery(undefined, { enabled });
-  // SSR-seeded `user.getSettings` + the dismiss mutation's optimistic cache
-  // update keep `dismissedAlerts` authoritative without a per-mount refetch.
-  const { data: settings } = trpc.user.getSettings.useQuery(undefined, { enabled });
-  const isDismissed = (settings?.dismissedAlerts ?? []).includes(ALERT_ID);
-
-  const utils = trpc.useUtils();
-  const dismissMutation = trpc.user.dismissAlert.useMutation({
-    onMutate: async () => {
-      await utils.user.getSettings.cancel();
-      const prev = utils.user.getSettings.getData();
-      utils.user.getSettings.setData(undefined, (old) => ({
-        ...old,
-        dismissedAlerts: [...(old?.dismissedAlerts ?? []), ALERT_ID],
-      }));
-      return { prev };
-    },
-    onError: (_err, _vars, ctx) => {
-      if (ctx?.prev) utils.user.getSettings.setData(undefined, ctx.prev);
-    },
-    // Reconcile with server truth after the optimistic update: the optimistic
-    // setData spreads `...old`, so if the cached base was incomplete (e.g. a
-    // failed SSR settings snapshot) it could persist a truncated settings
-    // object. Refetch once on dismiss to restore the full object + confirm the
-    // stored dismissedAlerts. One request per dismiss (rare) — not per mount.
-    onSettled: () => {
-      utils.user.getSettings.invalidate();
-    },
-  });
+  const { isDismissed, hasSettings, dismiss } = useFeatureNotice(
+    FEATURE_NOTICES.yellowBuzzMigration,
+    // `useFeatureNotice` ANDs in "is signed in" itself, so pass only the extra
+    // conditions.
+    { enabled: features.isGreen && features.buzz }
+  );
 
   const yellowBalance = buzzAccounts?.yellow ?? 0;
-  // `!!settings` guards the rare failed-SSR-snapshot path (undefined initialData):
-  // don't render against undefined `dismissedAlerts` until the self-healing mount
-  // fetch lands. Defined immediately on the normal SSR-seeded path → no delay.
-  const show = enabled && ready && !!settings && !isDismissed && yellowBalance > 0;
+  // `hasSettings` waits for a resolved settings object so a rare failed SSR
+  // snapshot cannot flash this at someone who already dismissed it; on the
+  // normal SSR-seeded path it is true on the first render, so there is no delay.
+  const show = enabled && ready && hasSettings && !isDismissed && yellowBalance > 0;
 
-  const handleDismiss = () => dismissMutation.mutate({ alertId: ALERT_ID });
+  const handleDismiss = () => dismiss();
 
   if (!show) return <>{children}</>;
 

--- a/src/components/Alerts/__tests__/feature-notice.characterization.browser.test.tsx
+++ b/src/components/Alerts/__tests__/feature-notice.characterization.browser.test.tsx
@@ -1,0 +1,396 @@
+import React from 'react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import type * as TrpcUtils from '~/utils/trpc';
+
+// =============================================================================
+// CHARACTERIZATION of the hand-rolled `dismissedAlerts` notice pattern.
+//
+// Written against UNMODIFIED code and kept byte-identical across the
+// consolidation onto `useFeatureNotice`, so a behaviour change during the
+// refactor shows up here rather than in production. It therefore asserts what
+// the four copies DO today, not what they arguably should do — the known
+// disagreements between them are recorded in the PR body, not fixed here.
+//
+// 🔴 Every `alertId` string below is a LITERAL on purpose. These strings are
+// already persisted in real users' `User.settings.dismissedAlerts`; importing
+// them from the registry would let a rename pass this file while silently
+// un-dismissing the notice for everyone who dismissed it. If one of these
+// literals has to change, that is a data migration, not a refactor.
+//
+// Mount contexts covered, deliberately structurally different (a notice's bugs
+// live in how it is mounted):
+//   * NavTidyNotice            — a deferred-open Popover under the sub-nav
+//   * YellowBuzzMigrationNotice — a Popover that WRAPS children in the header
+//   * OnrampGuidance + Toggle  — an inline page card, and the only restore path
+// =============================================================================
+
+const mocks = vi.hoisted(() => {
+  const state = {
+    // `undefined` models the rare failed-SSR-snapshot path the components guard
+    // against; `{}` models a settings object with no dismissedAlerts key.
+    settings: undefined as Record<string, any> | undefined,
+    isLoading: false,
+    currentUser: { id: 1 } as any,
+    flagsReady: true,
+    features: {} as Record<string, any>,
+    yellow: 0,
+    invalidateCount: 0,
+    mutateCalls: [] as Array<{ alertId: string; dismiss?: boolean }>,
+  };
+
+  // A tiny reactive store so `setData` actually re-renders the component, the
+  // way react-query would. Without this the optimistic write is observable only
+  // in the fake cache and never on screen, so "hides after dismiss" could not be
+  // asserted at all.
+  const listeners = new Set<() => void>();
+  const emit = () => listeners.forEach((l) => l());
+  const subscribe = (cb: () => void) => {
+    listeners.add(cb);
+    return () => void listeners.delete(cb);
+  };
+  const snapshot = () => state.settings;
+
+  const utils = {
+    user: {
+      getSettings: {
+        cancel: async () => undefined,
+        getData: () => state.settings,
+        setData: (_key: undefined, updater: any) => {
+          state.settings = typeof updater === 'function' ? updater(state.settings) : updater;
+          emit();
+        },
+        invalidate: () => {
+          state.invalidateCount += 1;
+        },
+      },
+    },
+  };
+
+  // Runs the REAL onMutate/onError/onSettled the component supplied, against the
+  // fake cache above — so the optimistic-update shape and the reconcile-refetch
+  // are both genuinely exercised rather than stubbed away.
+  const useDismissMutation = (opts: any) => ({
+    mutate: (vars: { alertId: string; dismiss?: boolean }) => {
+      state.mutateCalls.push(vars);
+      void Promise.resolve(opts?.onMutate?.(vars)).then((ctx) =>
+        opts?.onSettled?.(undefined, null, vars, ctx)
+      );
+    },
+    isPending: false,
+    isLoading: false,
+  });
+
+  return { state, subscribe, snapshot, utils, useDismissMutation };
+});
+
+// Browser mode serves native ESM, so `vi.hoisted` (which runs BEFORE any import
+// is evaluated) cannot reach React. The one mock that needs a hook therefore
+// lives out here as a hoisted function declaration, and the mock factory calls
+// it through an arrow so the reference resolves at render time, not at factory
+// time.
+function useSettingsQuery(_input?: unknown, opts?: { enabled?: boolean }) {
+  const data = React.useSyncExternalStore(mocks.subscribe, mocks.snapshot, mocks.snapshot);
+  const enabled = opts?.enabled ?? true;
+  return {
+    data: enabled ? data : undefined,
+    isLoading: enabled ? mocks.state.isLoading : false,
+    isError: false,
+  };
+}
+
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcUtils>()),
+  trpc: {
+    user: {
+      getSettings: {
+        useQuery: (input?: unknown, opts?: { enabled?: boolean }) => useSettingsQuery(input, opts),
+      },
+      dismissAlert: { useMutation: mocks.useDismissMutation },
+    },
+    buzz: {
+      getBuzzAccount: {
+        useQuery: (_i?: unknown, o?: { enabled?: boolean }) => ({
+          data: o?.enabled === false ? undefined : { yellow: mocks.state.yellow },
+        }),
+      },
+    },
+    useUtils: () => mocks.utils,
+  },
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => mocks.state.currentUser,
+}));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => mocks.state.features,
+  useFeatureFlagsReady: () => mocks.state.flagsReady,
+}));
+
+vi.mock('~/providers/AppProvider', () => ({
+  useServerDomains: () => ({ green: 'civitai.com', red: 'civitai.red', blue: 'civitai.blue' }),
+}));
+
+vi.mock('~/utils/sync-account', () => ({ syncAccount: (url: string) => url }));
+
+import { renderWithProviders } from '../../../../test/component-setup';
+import { NavTidyNotice } from '~/components/Alerts/NavTidyNotice';
+import { YellowBuzzMigrationNotice } from '~/components/Alerts/YellowBuzzMigrationNotice';
+import {
+  OnrampGuidance,
+  OnrampGuidanceToggle,
+} from '~/components/Buzz/CryptoDeposit/OnrampGuidance';
+
+beforeEach(() => {
+  mocks.state.settings = { dismissedAlerts: [] };
+  mocks.state.isLoading = false;
+  mocks.state.currentUser = { id: 1 };
+  mocks.state.flagsReady = true;
+  mocks.state.features = {};
+  mocks.state.yellow = 0;
+  mocks.state.invalidateCount = 0;
+  mocks.state.mutateCalls = [];
+});
+
+// -----------------------------------------------------------------------------
+// NavTidyNotice — sub-nav Popover, opens on a post-mount defer.
+//
+// 🔴 This block does NOT use `vi.waitFor(() => expect(...).toHaveLength(0))`.
+// A negative assertion is satisfied at t=0, and this tree mounts asynchronously
+// (a concurrent root + a `useSyncExternalStore` read), so the first poll fires
+// before React has committed anything — measured: the trigger is absent from
+// the DOM at t=0 and present at t=2200 even on the fully-rendering path. Every
+// such wait therefore passes instantly whether or not the notice renders, which
+// is how three of these tests survived a mutation that made the component
+// render when it must not.
+//
+// So each negative case: mount a SENTINEL alongside, wait for the sentinel
+// (proves the tree committed), wait past the 1500 ms open defer, and only then
+// assert absence — against `document`, because the trigger is not in the
+// accessibility tree until the popover opens.
+// -----------------------------------------------------------------------------
+describe('NavTidyNotice (sub-nav popover)', () => {
+  const NAV_TRIGGER_SELECTOR = '[aria-label="Navigation updated"]';
+  const OPEN_DEFER_MS = 1500;
+  const navTriggerCount = () => document.querySelectorAll(NAV_TRIGGER_SELECTOR).length;
+
+  // The component hides one of these behind a feature flag; the notice only
+  // nudges users who actually lost a nav item.
+  const withHiddenNavItem = () => {
+    mocks.state.features = { postsNavItem: false, eventsNavItem: true };
+  };
+
+  const renderWithSentinel = () =>
+    renderWithProviders(
+      <>
+        <NavTidyNotice />
+        <span data-testid="nav-tidy-sentinel">mounted</span>
+      </>
+    );
+
+  /** Commit the tree, then let the open defer elapse. */
+  const settle = async () => {
+    await expect.element(page.getByTestId('nav-tidy-sentinel')).toBeVisible();
+    await new Promise((resolve) => setTimeout(resolve, OPEN_DEFER_MS + 400));
+  };
+
+  test('renders its trigger and (after the open defer) its body when not dismissed', async () => {
+    withHiddenNavItem();
+    renderWithSentinel();
+
+    // Positive control for every `navTriggerCount() === 0` below: the selector
+    // CAN reach a non-zero count, so a zero elsewhere means absence, not a
+    // selector that never matches anything.
+    await settle();
+    expect(navTriggerCount()).toBe(1);
+    await expect.element(page.getByRole('button', { name: 'Navigation updated' })).toBeVisible();
+    await expect.element(page.getByText('We tidied up the nav')).toBeVisible();
+  });
+
+  test('renders nothing when the notice id is already in dismissedAlerts', async () => {
+    withHiddenNavItem();
+    mocks.state.settings = { dismissedAlerts: ['nav-tidy-notice'] };
+    renderWithSentinel();
+
+    await settle();
+    expect(navTriggerCount()).toBe(0);
+  });
+
+  test('renders nothing while `dismissedAlerts` is undefined (failed SSR snapshot)', async () => {
+    withHiddenNavItem();
+    mocks.state.settings = undefined;
+    renderWithSentinel();
+
+    await settle();
+    expect(navTriggerCount()).toBe(0);
+  });
+
+  test('renders nothing when no nav item is hidden', async () => {
+    mocks.state.features = { postsNavItem: true, eventsNavItem: true };
+    renderWithSentinel();
+
+    await settle();
+    expect(navTriggerCount()).toBe(0);
+  });
+
+  test('dismissing persists `nav-tidy-notice`, updates the cache optimistically, and reconciles', async () => {
+    withHiddenNavItem();
+    renderWithSentinel();
+
+    await expect.element(page.getByText('We tidied up the nav')).toBeVisible();
+    await userEvent.click(page.getByRole('button', { name: 'Dismiss' }));
+
+    await vi.waitFor(() => {
+      expect(mocks.state.mutateCalls).toEqual([{ alertId: 'nav-tidy-notice' }]);
+      // Optimistic write landed in the cache...
+      expect(mocks.state.settings?.dismissedAlerts).toEqual(['nav-tidy-notice']);
+      // ...and the truncated-settings reconcile fired exactly once.
+      expect(mocks.state.invalidateCount).toBe(1);
+    });
+    // And the optimistic write alone takes it off screen — no server round-trip.
+    // Safe as a `waitFor` because the tree is already committed and the notice
+    // was VISIBLE a moment ago, so this is a transition, not a bare absence.
+    await vi.waitFor(() => {
+      expect(navTriggerCount()).toBe(0);
+    });
+  });
+});
+
+// -----------------------------------------------------------------------------
+// YellowBuzzMigrationNotice — a Popover that WRAPS children in the app header.
+// -----------------------------------------------------------------------------
+describe('YellowBuzzMigrationNotice (children-wrapping header popover)', () => {
+  const child = <span data-testid="wrapped-child">menu</span>;
+
+  beforeEach(() => {
+    mocks.state.features = { isGreen: true, buzz: true };
+    mocks.state.yellow = 1234;
+  });
+
+  test('shows the notice alongside its children when the user holds yellow buzz', async () => {
+    renderWithProviders(<YellowBuzzMigrationNotice>{child}</YellowBuzzMigrationNotice>);
+
+    await expect.element(page.getByTestId('wrapped-child')).toBeVisible();
+    await expect.element(page.getByText('Yellow Buzz has moved')).toBeVisible();
+  });
+
+  test('renders children unwrapped when dismissed — the child never disappears', async () => {
+    mocks.state.settings = { dismissedAlerts: ['yellow-buzz-migration'] };
+    renderWithProviders(<YellowBuzzMigrationNotice>{child}</YellowBuzzMigrationNotice>);
+
+    await expect.element(page.getByTestId('wrapped-child')).toBeVisible();
+    await vi.waitFor(() => {
+      expect(page.getByText('Yellow Buzz has moved').elements()).toHaveLength(0);
+    });
+  });
+
+  test('renders children unwrapped on a zero yellow balance', async () => {
+    mocks.state.yellow = 0;
+    renderWithProviders(<YellowBuzzMigrationNotice>{child}</YellowBuzzMigrationNotice>);
+
+    await expect.element(page.getByTestId('wrapped-child')).toBeVisible();
+    await vi.waitFor(() => {
+      expect(page.getByText('Yellow Buzz has moved').elements()).toHaveLength(0);
+    });
+  });
+
+  test('renders children unwrapped while `dismissedAlerts` is undefined', async () => {
+    mocks.state.settings = undefined;
+    renderWithProviders(<YellowBuzzMigrationNotice>{child}</YellowBuzzMigrationNotice>);
+
+    await expect.element(page.getByTestId('wrapped-child')).toBeVisible();
+    await vi.waitFor(() => {
+      expect(page.getByText('Yellow Buzz has moved').elements()).toHaveLength(0);
+    });
+  });
+
+  test('dismissing persists `yellow-buzz-migration` and leaves the children mounted', async () => {
+    renderWithProviders(<YellowBuzzMigrationNotice>{child}</YellowBuzzMigrationNotice>);
+
+    await expect.element(page.getByText('Yellow Buzz has moved')).toBeVisible();
+    await userEvent.click(page.getByRole('button', { name: 'Dismiss' }));
+
+    await vi.waitFor(() => {
+      expect(mocks.state.mutateCalls).toEqual([{ alertId: 'yellow-buzz-migration' }]);
+      expect(mocks.state.settings?.dismissedAlerts).toEqual(['yellow-buzz-migration']);
+      expect(mocks.state.invalidateCount).toBe(1);
+    });
+    await expect.element(page.getByTestId('wrapped-child')).toBeVisible();
+  });
+});
+
+// -----------------------------------------------------------------------------
+// OnrampGuidance — inline page card, and the ONLY notice with a restore path.
+// -----------------------------------------------------------------------------
+describe('OnrampGuidance + OnrampGuidanceToggle (page card with restore)', () => {
+  const bothMounted = (
+    <>
+      <OnrampGuidance />
+      <OnrampGuidanceToggle />
+    </>
+  );
+
+  test('card shows and the restore toggle is absent when not dismissed', async () => {
+    renderWithProviders(bothMounted);
+
+    await expect.element(page.getByRole('heading', { name: 'New to crypto?' })).toBeVisible();
+    await vi.waitFor(() => {
+      expect(
+        page.getByRole('button', { name: 'New to crypto? Show guide' }).elements()
+      ).toHaveLength(0);
+    });
+  });
+
+  test('card hides and the restore toggle appears once dismissed', async () => {
+    mocks.state.settings = { dismissedAlerts: ['crypto-onramp-guidance'] };
+    renderWithProviders(bothMounted);
+
+    await expect
+      .element(page.getByRole('button', { name: 'New to crypto? Show guide' }))
+      .toBeVisible();
+    await vi.waitFor(() => {
+      expect(page.getByRole('heading', { name: 'New to crypto?' }).elements()).toHaveLength(0);
+    });
+  });
+
+  test('dismissing persists `crypto-onramp-guidance` and swaps card for toggle', async () => {
+    renderWithProviders(bothMounted);
+
+    await expect.element(page.getByRole('heading', { name: 'New to crypto?' })).toBeVisible();
+    await userEvent.click(page.getByRole('button', { name: 'Dismiss' }));
+
+    await vi.waitFor(() => {
+      expect(mocks.state.mutateCalls).toEqual([{ alertId: 'crypto-onramp-guidance' }]);
+      expect(mocks.state.settings?.dismissedAlerts).toEqual(['crypto-onramp-guidance']);
+      expect(mocks.state.invalidateCount).toBe(1);
+    });
+    await expect
+      .element(page.getByRole('button', { name: 'New to crypto? Show guide' }))
+      .toBeVisible();
+  });
+
+  test('restoring sends `dismiss: false`, removes the id, and brings the card back', async () => {
+    mocks.state.settings = { dismissedAlerts: ['other-alert', 'crypto-onramp-guidance'] };
+    renderWithProviders(bothMounted);
+
+    await userEvent.click(page.getByRole('button', { name: 'New to crypto? Show guide' }));
+
+    await vi.waitFor(() => {
+      expect(mocks.state.mutateCalls).toEqual([
+        { alertId: 'crypto-onramp-guidance', dismiss: false },
+      ]);
+      // Only this id is removed — an unrelated dismissal must survive.
+      expect(mocks.state.settings?.dismissedAlerts).toEqual(['other-alert']);
+      expect(mocks.state.invalidateCount).toBe(1);
+    });
+    await expect.element(page.getByRole('heading', { name: 'New to crypto?' })).toBeVisible();
+  });
+
+  test('an unknown id in dismissedAlerts does not dismiss this notice', async () => {
+    mocks.state.settings = { dismissedAlerts: ['crypto-onramp-guidance-v2', 'nav-tidy-notice'] };
+    renderWithProviders(bothMounted);
+
+    await expect.element(page.getByRole('heading', { name: 'New to crypto?' })).toBeVisible();
+  });
+});

--- a/src/components/Alerts/__tests__/notice-registry.test.ts
+++ b/src/components/Alerts/__tests__/notice-registry.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from 'vitest';
+import {
+  FEATURE_NOTICES,
+  FEATURE_NOTICE_IDS,
+  isNoticeDismissed,
+} from '~/components/Alerts/notice-registry';
+
+// =============================================================================
+// The registry, and the dismissed predicate every notice now shares.
+//
+// SCOPE HONESTY: the id table below is an INVARIANT GUARD, not a regression
+// test. No bug ever changed one of these strings; it exists because changing
+// one would silently un-dismiss the notice for every user who had dismissed it,
+// and nothing else in the codebase would notice. The predicate cases below are
+// likewise guards on newly-extracted behaviour, not proof of a fixed defect.
+// The refactor's actual behavioural evidence is
+// `feature-notice.characterization.browser.test.tsx`, which was written and run
+// GREEN against the pre-refactor components before any of this existed.
+// =============================================================================
+
+describe('FEATURE_NOTICES', () => {
+  // 🔴 Hand-written literals, deliberately not derived from the registry.
+  // Deriving them (`Object.values(FEATURE_NOTICES).map(n => n.id)`) would make
+  // this table agree with any rename, which is the one thing it must not do.
+  // Each string below was copied from the `const ALERT_ID` that lived beside
+  // its component before the consolidation.
+  const ID_AT_ITS_ORIGINAL_CALL_SITE: Record<keyof typeof FEATURE_NOTICES, string> = {
+    navTidy: 'nav-tidy-notice',
+    yellowBuzzMigration: 'yellow-buzz-migration',
+    cryptoOnrampGuidance: 'crypto-onramp-guidance',
+    earnBlueBuzzRewards: 'earn-blue-buzz-rewards',
+    remixGalleryExplainer: 'remix-gallery-explainer',
+    referralLiteOnboarding: 'referral-lite-onboarding',
+    referralKickback: 'referral-kickback-info',
+    referralHowItWorks: 'referral-how-it-works',
+    referralTokenShop: 'referral-token-shop-info',
+  };
+
+  test.each(Object.entries(ID_AT_ITS_ORIGINAL_CALL_SITE))(
+    '%s keeps the exact id already persisted in users’ dismissedAlerts: %s',
+    (key, expected) => {
+      expect(FEATURE_NOTICES[key as keyof typeof FEATURE_NOTICES].id).toBe(expected);
+    }
+  );
+
+  test('the registry holds exactly the notices this table pins — no silent additions', () => {
+    // A new notice must be added to the table above too, which is what forces
+    // a human to look at the id string before it reaches production data.
+    expect(Object.keys(FEATURE_NOTICES).sort()).toEqual(
+      Object.keys(ID_AT_ITS_ORIGINAL_CALL_SITE).sort()
+    );
+  });
+
+  test('every id is unique — two notices sharing one id would dismiss each other', () => {
+    expect(new Set(FEATURE_NOTICE_IDS).size).toBe(FEATURE_NOTICE_IDS.length);
+  });
+
+  test('FEATURE_NOTICE_IDS actually enumerates the registry', () => {
+    // Positive control on the uniqueness check above: an empty or truncated
+    // array would make `new Set(...).size === length` pass vacuously.
+    expect(FEATURE_NOTICE_IDS).toHaveLength(Object.keys(FEATURE_NOTICES).length);
+    expect(FEATURE_NOTICE_IDS).toContain('nav-tidy-notice');
+  });
+
+  test('no id is blank or carries stray whitespace — either would never match a stored value', () => {
+    for (const id of FEATURE_NOTICE_IDS) {
+      expect(id).not.toBe('');
+      expect(id).toBe(id.trim());
+    }
+  });
+});
+
+describe('isNoticeDismissed', () => {
+  const notice = FEATURE_NOTICES.navTidy;
+
+  test('true when the id is present', () => {
+    expect(isNoticeDismissed(['nav-tidy-notice'], notice)).toBe(true);
+  });
+
+  test('true when present among other ids', () => {
+    expect(isNoticeDismissed(['a', 'nav-tidy-notice', 'b'], notice)).toBe(true);
+  });
+
+  test('false when a DIFFERENT notice is dismissed', () => {
+    expect(isNoticeDismissed(['yellow-buzz-migration'], notice)).toBe(false);
+  });
+
+  test('false on an empty array', () => {
+    expect(isNoticeDismissed([], notice)).toBe(false);
+  });
+
+  // 🔴 This is the case the old hand-rolled `(settings?.dismissedAlerts ?? [])`
+  // was written for. It answers "false" — NOT DISMISSED — for a settings object
+  // that has not resolved, which is indistinguishable from "the user never
+  // dismissed it". That is why the predicate alone is not a render gate and
+  // `hasSettings` exists; see useFeatureNotice's doc comment.
+  test('false when dismissedAlerts is undefined (unresolved settings)', () => {
+    expect(isNoticeDismissed(undefined, notice)).toBe(false);
+  });
+
+  test('an unknown id in the array does not dismiss anything registered', () => {
+    const dismissed = ['some-notice-that-was-never-registered'];
+    for (const key of Object.keys(FEATURE_NOTICES) as (keyof typeof FEATURE_NOTICES)[]) {
+      expect(isNoticeDismissed(dismissed, FEATURE_NOTICES[key])).toBe(false);
+    }
+  });
+
+  test('matching is exact, not prefix or substring', () => {
+    // `nav-tidy-notice-v2` is what a future replacement notice would be called.
+    // If the predicate ever became a `startsWith`/`some(includes)`, dismissing
+    // v2 would retroactively dismiss v1 and vice versa.
+    expect(isNoticeDismissed(['nav-tidy-notice-v2'], notice)).toBe(false);
+    expect(isNoticeDismissed(['tidy'], notice)).toBe(false);
+    expect(isNoticeDismissed(['xnav-tidy-notice'], notice)).toBe(false);
+  });
+
+  test('reads the notice it is given, not a captured default', () => {
+    // Guards against the predicate ignoring its `notice` argument — which would
+    // still pass every single-notice case above.
+    expect(
+      isNoticeDismissed(['crypto-onramp-guidance'], FEATURE_NOTICES.cryptoOnrampGuidance)
+    ).toBe(true);
+    expect(isNoticeDismissed(['crypto-onramp-guidance'], FEATURE_NOTICES.navTidy)).toBe(false);
+  });
+});

--- a/src/components/Alerts/__tests__/useFeatureNotice.browser.test.tsx
+++ b/src/components/Alerts/__tests__/useFeatureNotice.browser.test.tsx
@@ -1,0 +1,331 @@
+import React from 'react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import type * as TrpcUtils from '~/utils/trpc';
+
+// =============================================================================
+// The `useFeatureNotice` primitive, driven directly.
+//
+// The characterization suite covers three real mount contexts (sub-nav popover,
+// children-wrapping header popover, inline page card). This file covers what
+// those cannot reach:
+//   * the ERRORED-settings path, where `isLoading` and `hasSettings` disagree —
+//     the divergence that made `BuyBuzzModal` the odd one out
+//   * rollback: a failed mutation restores the previous cache
+//   * the restore direction removing only its own id
+//   * the notice argument actually being READ (two notices, one hook)
+// =============================================================================
+
+const mocks = vi.hoisted(() => {
+  const state = {
+    settings: undefined as Record<string, any> | undefined,
+    isLoading: false,
+    currentUser: { id: 1 } as any,
+    mutationFails: false,
+    invalidateCount: 0,
+    mutateCalls: [] as Array<{ alertId: string; dismiss?: boolean }>,
+    queryEnabledSeen: [] as (boolean | undefined)[],
+  };
+
+  const listeners = new Set<() => void>();
+  const emit = () => listeners.forEach((l) => l());
+  const subscribe = (cb: () => void) => {
+    listeners.add(cb);
+    return () => void listeners.delete(cb);
+  };
+  const snapshot = () => state.settings;
+
+  const utils = {
+    user: {
+      getSettings: {
+        cancel: async () => undefined,
+        getData: () => state.settings,
+        setData: (_key: undefined, updater: any) => {
+          state.settings = typeof updater === 'function' ? updater(state.settings) : updater;
+          emit();
+        },
+        invalidate: () => {
+          state.invalidateCount += 1;
+        },
+      },
+    },
+  };
+
+  const useDismissMutation = (opts: any) => ({
+    mutate: (vars: { alertId: string; dismiss?: boolean }) => {
+      state.mutateCalls.push(vars);
+      void Promise.resolve(opts?.onMutate?.(vars)).then((ctx) => {
+        if (state.mutationFails) opts?.onError?.(new Error('boom'), vars, ctx);
+        opts?.onSettled?.(undefined, state.mutationFails ? new Error('boom') : null, vars, ctx);
+      });
+    },
+    isPending: false,
+    isLoading: false,
+  });
+
+  return { state, subscribe, snapshot, utils, useDismissMutation };
+});
+
+function useSettingsQuery(_input?: unknown, opts?: { enabled?: boolean }) {
+  const data = React.useSyncExternalStore(mocks.subscribe, mocks.snapshot, mocks.snapshot);
+  const enabled = opts?.enabled ?? true;
+  mocks.state.queryEnabledSeen.push(opts?.enabled);
+  return {
+    data: enabled ? data : undefined,
+    isLoading: enabled ? mocks.state.isLoading : false,
+    isError: false,
+  };
+}
+
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcUtils>()),
+  trpc: {
+    user: {
+      getSettings: {
+        useQuery: (input?: unknown, opts?: { enabled?: boolean }) => useSettingsQuery(input, opts),
+      },
+      dismissAlert: { useMutation: mocks.useDismissMutation },
+    },
+    useUtils: () => mocks.utils,
+  },
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => mocks.state.currentUser,
+}));
+
+import { renderWithProviders } from '../../../../test/component-setup';
+import { FEATURE_NOTICES } from '~/components/Alerts/notice-registry';
+import { useFeatureNotice } from '~/components/Alerts/useFeatureNotice';
+
+/** Minimal harness: renders the hook's whole state as assertable DOM state. */
+function Probe({
+  notice = FEATURE_NOTICES.navTidy,
+  enabled,
+  testId = 'probe',
+}: {
+  notice?: (typeof FEATURE_NOTICES)[keyof typeof FEATURE_NOTICES];
+  enabled?: boolean;
+  testId?: string;
+}) {
+  const { isDismissed, hasSettings, isLoading, dismiss, restore } = useFeatureNotice(
+    notice,
+    enabled === undefined ? undefined : { enabled }
+  );
+  return (
+    <div
+      data-testid={testId}
+      // State is asserted via attributes, never via rendered words — a word can
+      // be spelled by unrelated copy, an attribute pair cannot.
+      data-dismissed={String(isDismissed)}
+      data-has-settings={String(hasSettings)}
+      data-loading={String(isLoading)}
+    >
+      <button type="button" onClick={dismiss} aria-label={`dismiss-${testId}`}>
+        dismiss
+      </button>
+      <button type="button" onClick={restore} aria-label={`restore-${testId}`}>
+        restore
+      </button>
+    </div>
+  );
+}
+
+const probeState = async (testId = 'probe') => {
+  // `.element()` is synchronous and throws if the tree has not mounted yet, so
+  // wait for it rather than racing the first paint.
+  await expect.element(page.getByTestId(testId)).toBeInTheDocument();
+  const el = page.getByTestId(testId).element();
+  return {
+    dismissed: el.getAttribute('data-dismissed'),
+    hasSettings: el.getAttribute('data-has-settings'),
+    loading: el.getAttribute('data-loading'),
+  };
+};
+
+beforeEach(() => {
+  mocks.state.settings = { dismissedAlerts: [] };
+  mocks.state.isLoading = false;
+  mocks.state.currentUser = { id: 1 };
+  mocks.state.mutationFails = false;
+  mocks.state.invalidateCount = 0;
+  mocks.state.mutateCalls = [];
+  mocks.state.queryEnabledSeen = [];
+});
+
+describe('useFeatureNotice — reading dismissed state', () => {
+  test('not dismissed, settings resolved', async () => {
+    renderWithProviders(<Probe />);
+    expect(await probeState()).toEqual({
+      dismissed: 'false',
+      hasSettings: 'true',
+      loading: 'false',
+    });
+  });
+
+  test('dismissed when the registered id is stored', async () => {
+    mocks.state.settings = { dismissedAlerts: ['nav-tidy-notice'] };
+    renderWithProviders(<Probe />);
+    expect((await probeState()).dismissed).toBe('true');
+  });
+
+  test('the notice ARGUMENT is read — two probes, one stored id, different answers', async () => {
+    mocks.state.settings = { dismissedAlerts: ['crypto-onramp-guidance'] };
+    renderWithProviders(
+      <>
+        <Probe notice={FEATURE_NOTICES.cryptoOnrampGuidance} testId="onramp" />
+        <Probe notice={FEATURE_NOTICES.navTidy} testId="navtidy" />
+      </>
+    );
+    expect((await probeState('onramp')).dismissed).toBe('true');
+    expect((await probeState('navtidy')).dismissed).toBe('false');
+  });
+});
+
+describe('useFeatureNotice — hasSettings vs isLoading', () => {
+  // 🔴 The distinction that separated the four copies. A settled-but-empty
+  // settings read reports `isLoading: false` AND `hasSettings: false`. A caller
+  // gating on `isLoading` renders; a caller gating on `hasSettings` does not.
+  test('a settled-but-undefined settings read: isLoading false, hasSettings false', async () => {
+    mocks.state.settings = undefined;
+    mocks.state.isLoading = false;
+    renderWithProviders(<Probe />);
+    expect(await probeState()).toEqual({
+      dismissed: 'false',
+      hasSettings: 'false',
+      loading: 'false',
+    });
+  });
+
+  test('an in-flight settings read: isLoading true, hasSettings false', async () => {
+    mocks.state.settings = undefined;
+    mocks.state.isLoading = true;
+    renderWithProviders(<Probe />);
+    expect(await probeState()).toEqual({
+      dismissed: 'false',
+      hasSettings: 'false',
+      loading: 'true',
+    });
+  });
+
+  test('a resolved settings object with no dismissedAlerts key still counts as resolved', async () => {
+    mocks.state.settings = {};
+    renderWithProviders(<Probe />);
+    expect(await probeState()).toEqual({
+      dismissed: 'false',
+      hasSettings: 'true',
+      loading: 'false',
+    });
+  });
+});
+
+describe('useFeatureNotice — query gating', () => {
+  test('signed out disables the settings query regardless of the enabled option', async () => {
+    mocks.state.currentUser = null;
+    renderWithProviders(<Probe enabled />);
+    expect(mocks.state.queryEnabledSeen.every((v) => v === false)).toBe(true);
+    expect((await probeState()).hasSettings).toBe('false');
+  });
+
+  test('enabled:false disables the query even when signed in', async () => {
+    renderWithProviders(<Probe enabled={false} />);
+    expect(mocks.state.queryEnabledSeen.every((v) => v === false)).toBe(true);
+  });
+
+  test('signed in with no option leaves the query enabled', async () => {
+    renderWithProviders(<Probe />);
+    expect(mocks.state.queryEnabledSeen.every((v) => v === true)).toBe(true);
+  });
+});
+
+describe('useFeatureNotice — writing', () => {
+  test('dismiss sends the registered id with no explicit flag, appends it, and reconciles', async () => {
+    renderWithProviders(<Probe />);
+    await userEvent.click(page.getByRole('button', { name: 'dismiss-probe' }));
+
+    await vi.waitFor(async () => {
+      // Payload shape matters: the server schema defaults `dismiss` to true, and
+      // this is the exact payload every call site sent before consolidation.
+      expect(mocks.state.mutateCalls).toEqual([{ alertId: 'nav-tidy-notice' }]);
+      expect(mocks.state.settings?.dismissedAlerts).toEqual(['nav-tidy-notice']);
+      expect(mocks.state.invalidateCount).toBe(1);
+      expect((await probeState()).dismissed).toBe('true');
+    });
+  });
+
+  test('dismiss preserves unrelated settings keys and unrelated dismissals', async () => {
+    mocks.state.settings = { dismissedAlerts: ['other'], hideModelsFrom: [7], someFlag: true };
+    renderWithProviders(<Probe />);
+    await userEvent.click(page.getByRole('button', { name: 'dismiss-probe' }));
+
+    await vi.waitFor(() => {
+      expect(mocks.state.settings).toEqual({
+        dismissedAlerts: ['other', 'nav-tidy-notice'],
+        hideModelsFrom: [7],
+        someFlag: true,
+      });
+    });
+  });
+
+  test('restore sends dismiss:false and removes ONLY its own id', async () => {
+    mocks.state.settings = { dismissedAlerts: ['a', 'nav-tidy-notice', 'b'] };
+    renderWithProviders(<Probe />);
+    await userEvent.click(page.getByRole('button', { name: 'restore-probe' }));
+
+    await vi.waitFor(async () => {
+      expect(mocks.state.mutateCalls).toEqual([{ alertId: 'nav-tidy-notice', dismiss: false }]);
+      expect(mocks.state.settings?.dismissedAlerts).toEqual(['a', 'b']);
+      expect(mocks.state.invalidateCount).toBe(1);
+      expect((await probeState()).dismissed).toBe('false');
+    });
+  });
+
+  test('restore on a notice that was never dismissed is a no-op on the array', async () => {
+    mocks.state.settings = { dismissedAlerts: ['a'] };
+    renderWithProviders(<Probe />);
+    await userEvent.click(page.getByRole('button', { name: 'restore-probe' }));
+    await vi.waitFor(() => {
+      expect(mocks.state.settings?.dismissedAlerts).toEqual(['a']);
+    });
+  });
+
+  test('a failed dismiss rolls the cache back to the previous value', async () => {
+    mocks.state.mutationFails = true;
+    mocks.state.settings = { dismissedAlerts: ['a'], someFlag: true };
+    renderWithProviders(<Probe />);
+    await userEvent.click(page.getByRole('button', { name: 'dismiss-probe' }));
+
+    await vi.waitFor(async () => {
+      expect(mocks.state.settings).toEqual({ dismissedAlerts: ['a'], someFlag: true });
+      expect((await probeState()).dismissed).toBe('false');
+      // The reconcile still fires on failure — that is what repairs a cache the
+      // optimistic write may already have touched.
+      expect(mocks.state.invalidateCount).toBe(1);
+    });
+  });
+
+  test('a failed restore rolls the cache back — the notice stays dismissed', async () => {
+    mocks.state.mutationFails = true;
+    mocks.state.settings = { dismissedAlerts: ['nav-tidy-notice'] };
+    renderWithProviders(<Probe />);
+    await userEvent.click(page.getByRole('button', { name: 'restore-probe' }));
+
+    await vi.waitFor(async () => {
+      expect(mocks.state.settings?.dismissedAlerts).toEqual(['nav-tidy-notice']);
+      expect((await probeState()).dismissed).toBe('true');
+    });
+  });
+
+  test('dismissing on an UNRESOLVED cache does not fabricate a settings object beyond the id', async () => {
+    // The truncated-settings hazard the reconcile exists for: the optimistic
+    // write spreads `...old`, and `old` is undefined here.
+    mocks.state.settings = undefined;
+    renderWithProviders(<Probe />);
+    await userEvent.click(page.getByRole('button', { name: 'dismiss-probe' }));
+
+    await vi.waitFor(() => {
+      expect(mocks.state.settings).toEqual({ dismissedAlerts: ['nav-tidy-notice'] });
+      expect(mocks.state.invalidateCount).toBe(1);
+    });
+  });
+});

--- a/src/components/Alerts/notice-registry.ts
+++ b/src/components/Alerts/notice-registry.ts
@@ -1,0 +1,92 @@
+/**
+ * The registry of in-product feature notices.
+ *
+ * A "notice" is a one-off, per-user, server-persisted nudge: shown until the
+ * user dismisses it, and then never again on any device. Dismissal lives in
+ * `User.settings.dismissedAlerts` (see `dismissAlertHandler`), which is what
+ * distinguishes a notice from `DismissibleAlert`'s `localStorage` behaviour —
+ * a notice explains a FEATURE, so someone who has read it should not meet it
+ * again on their phone.
+ *
+ * Before this file each notice declared a loose `const ALERT_ID = '…'` beside
+ * its component. Seven files did that, and the copies had drifted from each
+ * other in four separate ways (recorded in the PR that introduced this file).
+ * Declaring them here is what makes the set enumerable — which is also what a
+ * future "announce this flag" surface needs to iterate over.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * 🔴 EVERY `id` BELOW IS PRODUCTION DATA.
+ *
+ * These exact strings are already stored in real users' `dismissedAlerts`
+ * arrays. Changing one does not rename anything — it mints a NEW notice and
+ * re-shows the old one to every user who had already dismissed it. Treat an id
+ * change as a data migration with an explicit decision behind it, never as a
+ * refactor. `notice-registry.test.ts` pins each one as a literal for that
+ * reason.
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * WHERE AUDIENCE TARGETING GOES (deliberately not here yet): add an optional
+ * `audience` field to `FeatureNotice` below and branch on it inside
+ * `useFeatureNotice`'s returned `isDismissed`/visibility. It is omitted today
+ * because nothing reads it — an unread field on a definition looks like a gate
+ * and gates nothing. The early-adopter session flag it would consume is being
+ * added separately; wiring the two together is a follow-up.
+ */
+
+export type FeatureNotice = {
+  /**
+   * The string persisted into `User.settings.dismissedAlerts`.
+   * 🔴 Production data — see the file header before touching one.
+   */
+  readonly id: string;
+};
+
+export const FEATURE_NOTICES = {
+  /** Sub-nav popover pointing at the settings toggle for the tidied-away tabs. */
+  navTidy: { id: 'nav-tidy-notice' },
+  /** Header popover telling holders of yellow buzz where their balance went. */
+  yellowBuzzMigration: { id: 'yellow-buzz-migration' },
+  /** Crypto-deposit onboarding card. The only notice a user can bring back. */
+  cryptoOnrampGuidance: { id: 'crypto-onramp-guidance' },
+  /** Blue-buzz rewards banner inside the buy-buzz modal. */
+  earnBlueBuzzRewards: { id: 'earn-blue-buzz-rewards' },
+  /** Inline explainer at the top of a remix gallery. */
+  remixGalleryExplainer: { id: 'remix-gallery-explainer' },
+  /** Referral dashboard (lite): the 3-card onboarding stepper. */
+  referralLiteOnboarding: { id: 'referral-lite-onboarding' },
+  /**
+   * Referral kickback explainer. Deliberately ONE id shared by the lite and
+   * full dashboards — dismissing it on either must dismiss it on both. That was
+   * previously two identical string literals in two files, one keystroke away
+   * from silently becoming two different notices.
+   */
+  referralKickback: { id: 'referral-kickback-info' },
+  /** Referral dashboard (full): the "How it works" card. */
+  referralHowItWorks: { id: 'referral-how-it-works' },
+  /** Referral dashboard (full): the token-shop explainer. */
+  referralTokenShop: { id: 'referral-token-shop-info' },
+} as const satisfies Record<string, FeatureNotice>;
+
+export type FeatureNoticeKey = keyof typeof FEATURE_NOTICES;
+
+/** Every registered id. Exported so the registry can be checked as a whole. */
+export const FEATURE_NOTICE_IDS: readonly string[] = Object.values(FEATURE_NOTICES).map(
+  (n) => n.id
+);
+
+/**
+ * Is this notice dismissed, given the user's stored `dismissedAlerts`?
+ *
+ * `dismissedAlerts` is `undefined` in two different situations and this returns
+ * `false` for both: the settings query has not resolved yet, and the user has
+ * simply never dismissed anything. They are indistinguishable from here, so a
+ * caller that must not render against an unresolved settings object has to gate
+ * on `hasSettings` from `useFeatureNotice` as well — "not dismissed" is not the
+ * same claim as "known not to be dismissed".
+ */
+export function isNoticeDismissed(
+  dismissedAlerts: readonly string[] | undefined,
+  notice: FeatureNotice
+): boolean {
+  return (dismissedAlerts ?? []).includes(notice.id);
+}

--- a/src/components/Alerts/useFeatureNotice.ts
+++ b/src/components/Alerts/useFeatureNotice.ts
@@ -1,0 +1,102 @@
+import { trpc } from '~/utils/trpc';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+import type { FeatureNotice } from '~/components/Alerts/notice-registry';
+import { isNoticeDismissed } from '~/components/Alerts/notice-registry';
+
+export type UseFeatureNoticeResult = {
+  /** The notice's id is present in the user's stored `dismissedAlerts`. */
+  isDismissed: boolean;
+  /**
+   * A settings object has resolved, so `isDismissed` reflects stored state
+   * rather than the absence of an answer. Gate rendering on this wherever
+   * flashing a notice at someone who already dismissed it would be wrong: the
+   * settings query is normally SSR-seeded and this is `true` on the first
+   * render, but a failed SSR snapshot leaves it `false` until the mount fetch
+   * lands.
+   */
+  hasSettings: boolean;
+  /** The settings query is in flight. Weaker than `!hasSettings` — see below. */
+  isLoading: boolean;
+  /** Persist a dismissal, optimistically. */
+  dismiss: () => void;
+  /** Undo a dismissal, optimistically. Only meaningful where UI offers it. */
+  restore: () => void;
+};
+
+/**
+ * Read and write one feature notice's dismissed state.
+ *
+ * Owns the four things every notice used to hand-roll: the settings read, the
+ * dismissed predicate, the optimistic cache update with its rollback, and the
+ * post-write reconcile.
+ *
+ * The reconcile (`onSettled` → `invalidate`) is not optional bookkeeping. The
+ * optimistic write spreads `...old`, so if the cached base was incomplete — a
+ * failed SSR settings snapshot — the optimistic write would persist a TRUNCATED
+ * settings object into the cache and every other reader of `user.getSettings`
+ * would see it. One refetch per dismiss restores the full object. Dismissals
+ * are rare, so this costs one request per dismissal, not one per mount.
+ *
+ * 🔴 `isLoading` and `hasSettings` are NOT interchangeable. `isLoading` goes
+ * false when a query settles, including when it settles as an ERROR, at which
+ * point `settings` is still undefined; `hasSettings` stays false. A caller that
+ * uses `isLoading` will render the notice on an errored settings fetch — which
+ * means showing it to someone who already dismissed it. Prefer `hasSettings`
+ * for anything a user can dismiss.
+ *
+ * Deliberately NOT owned here: WHEN a notice should be shown. Visibility is
+ * per-site (a feature flag, a balance, a mount context) and folding it in would
+ * mean every site paying for every other site's conditions. Sites compose
+ * `hasSettings && !isDismissed && <their own condition>`.
+ *
+ * @param notice  A registry entry, never a bare string — that is what keeps the
+ *                persisted id set enumerable and collision-checkable.
+ * @param enabled Extra gate on the settings read, ANDed with "is signed in".
+ *                Signed out there is nowhere to record a dismissal.
+ */
+export function useFeatureNotice(
+  notice: FeatureNotice,
+  { enabled = true }: { enabled?: boolean } = {}
+): UseFeatureNoticeResult {
+  const currentUser = useCurrentUser();
+  const queryEnabled = enabled && !!currentUser;
+
+  const { data: settings, isLoading } = trpc.user.getSettings.useQuery(undefined, {
+    enabled: queryEnabled,
+  });
+
+  const utils = trpc.useUtils();
+  const mutation = trpc.user.dismissAlert.useMutation({
+    onMutate: async (vars) => {
+      // `dismissAlertSchema` defaults `dismiss` to true, so an omitted flag
+      // means "dismiss" on the server. Mirror that here rather than reading
+      // `vars.dismiss` as a boolean.
+      const dismissing = vars.dismiss !== false;
+      await utils.user.getSettings.cancel();
+      const prev = utils.user.getSettings.getData();
+      utils.user.getSettings.setData(undefined, (old) => ({
+        ...old,
+        dismissedAlerts: dismissing
+          ? [...(old?.dismissedAlerts ?? []), notice.id]
+          : (old?.dismissedAlerts ?? []).filter((id: string) => id !== notice.id),
+      }));
+      return { prev };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.prev) utils.user.getSettings.setData(undefined, ctx.prev);
+    },
+    onSettled: () => {
+      utils.user.getSettings.invalidate();
+    },
+  });
+
+  return {
+    isDismissed: isNoticeDismissed(settings?.dismissedAlerts, notice),
+    hasSettings: !!settings,
+    isLoading,
+    // `dismiss` omits the flag and `restore` sends `false`, matching the wire
+    // payloads these call sites have always sent.
+    dismiss: () => mutation.mutate({ alertId: notice.id }),
+    restore: () => mutation.mutate({ alertId: notice.id, dismiss: false }),
+  };
+}

--- a/src/components/Buzz/CryptoDeposit/OnrampGuidance.tsx
+++ b/src/components/Buzz/CryptoDeposit/OnrampGuidance.tsx
@@ -10,9 +10,9 @@ import {
   Tooltip,
 } from '@mantine/core';
 import { IconAlertTriangle, IconExternalLink, IconInfoCircle, IconX } from '@tabler/icons-react';
+import { FEATURE_NOTICES } from '~/components/Alerts/notice-registry';
+import { useFeatureNotice } from '~/components/Alerts/useFeatureNotice';
 import { outerCardStyle } from '~/components/Buzz/CryptoDeposit/crypto-deposit.constants';
-import { useCurrentUserSettings } from '~/components/UserSettings/hooks';
-import { trpc } from '~/utils/trpc';
 
 type OnrampService = {
   name: string;
@@ -230,31 +230,12 @@ const regions: OnrampRegion[] = [
   },
 ];
 
-const ALERT_ID = 'crypto-onramp-guidance';
-
 export function useOnrampDismissed() {
-  const settings = useCurrentUserSettings();
-  return (settings.dismissedAlerts ?? []).includes(ALERT_ID);
+  return useFeatureNotice(FEATURE_NOTICES.cryptoOnrampGuidance).isDismissed;
 }
 
 export function OnrampGuidance() {
-  const isDismissed = useOnrampDismissed();
-  const utils = trpc.useUtils();
-  const dismissMutation = trpc.user.dismissAlert.useMutation({
-    onMutate: async () => {
-      await utils.user.getSettings.cancel();
-      const prev = utils.user.getSettings.getData();
-      utils.user.getSettings.setData(undefined, (old) => ({
-        ...old,
-        dismissedAlerts: [...(old?.dismissedAlerts ?? []), ALERT_ID],
-      }));
-      return { prev };
-    },
-    onError: (_err, _vars, ctx) => {
-      if (ctx?.prev) utils.user.getSettings.setData(undefined, ctx.prev);
-    },
-    onSettled: () => utils.user.getSettings.invalidate(),
-  });
+  const { isDismissed, dismiss } = useFeatureNotice(FEATURE_NOTICES.cryptoOnrampGuidance);
 
   if (isDismissed) return null;
 
@@ -269,7 +250,7 @@ export function OnrampGuidance() {
           variant="subtle"
           size="xs"
           color="gray"
-          onClick={() => dismissMutation.mutate({ alertId: ALERT_ID })}
+          onClick={() => dismiss()}
           leftSection={<IconX size={14} />}
         >
           Dismiss
@@ -393,29 +374,11 @@ export function OnrampGuidance() {
 
 /** Small toggle to re-show the guidance card after it's been dismissed. Place at page bottom. */
 export function OnrampGuidanceToggle() {
-  const isDismissed = useOnrampDismissed();
-  const utils = trpc.useUtils();
-  const restoreMutation = trpc.user.dismissAlert.useMutation({
-    onMutate: async () => {
-      await utils.user.getSettings.cancel();
-      const prev = utils.user.getSettings.getData();
-      utils.user.getSettings.setData(undefined, (old) => ({
-        ...old,
-        dismissedAlerts: (old?.dismissedAlerts ?? []).filter((id: string) => id !== ALERT_ID),
-      }));
-      return { prev };
-    },
-    onError: (_err, _vars, ctx) => {
-      if (ctx?.prev) utils.user.getSettings.setData(undefined, ctx.prev);
-    },
-    onSettled: () => utils.user.getSettings.invalidate(),
-  });
+  const { isDismissed, restore } = useFeatureNotice(FEATURE_NOTICES.cryptoOnrampGuidance);
 
   if (!isDismissed) return null;
 
-  const handleRestore = () => {
-    restoreMutation.mutate({ alertId: ALERT_ID, dismiss: false });
-  };
+  const handleRestore = () => restore();
 
   return (
     <Button

--- a/src/components/Modals/BuyBuzzModal.tsx
+++ b/src/components/Modals/BuyBuzzModal.tsx
@@ -13,6 +13,8 @@ import {
 import { IconArrowRight, IconBolt } from '@tabler/icons-react';
 
 import { useTrackEvent } from '../TrackView/track.utils';
+import { FEATURE_NOTICES } from '~/components/Alerts/notice-registry';
+import { useFeatureNotice } from '~/components/Alerts/useFeatureNotice';
 import { AvailableBuzzBadge } from '~/components/Buzz/AvailableBuzzBadge';
 import { BuzzPurchaseLayout } from '~/components/Buzz/BuzzPurchaseLayout';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
@@ -45,8 +47,6 @@ export type BuyBuzzModalProps = {
   attribution?: BlockAttribution;
 };
 
-const ALERT_ID = 'earn-blue-buzz-rewards';
-
 function EarnRewardsBanner({ initialBuzzType }: { initialBuzzType?: BuzzSpendType }) {
   const currentUser = useCurrentUser();
   const features = useFeatureFlags();
@@ -55,25 +55,11 @@ function EarnRewardsBanner({ initialBuzzType }: { initialBuzzType?: BuzzSpendTyp
   const showMemberUpsell =
     !isMember && features.membershipsV2 && initialBuzzType === 'yellow';
 
-  const utils = trpc.useUtils();
-  const { data: settings, isLoading: settingsLoading } = trpc.user.getSettings.useQuery(
-    undefined,
-    { enabled: !!currentUser }
-  );
-  const dismissMutation = trpc.user.dismissAlert.useMutation({
-    onMutate: async () => {
-      await utils.user.getSettings.cancel();
-      const prev = utils.user.getSettings.getData();
-      utils.user.getSettings.setData(undefined, (old) => ({
-        ...old,
-        dismissedAlerts: [...(old?.dismissedAlerts ?? []), ALERT_ID],
-      }));
-      return { prev };
-    },
-    onError: (_err, _vars, ctx) => {
-      if (ctx?.prev) utils.user.getSettings.setData(undefined, ctx.prev);
-    },
-  });
+  const {
+    isDismissed,
+    isLoading: settingsLoading,
+    dismiss,
+  } = useFeatureNotice(FEATURE_NOTICES.earnBlueBuzzRewards);
 
   const { data: plans = [] } = trpc.subscriptions.getPlans.useQuery(
     { paymentProvider },
@@ -84,7 +70,11 @@ function EarnRewardsBanner({ initialBuzzType }: { initialBuzzType?: BuzzSpendTyp
     ...plans.map((p) => (p.metadata as SubscriptionProductMetadata)?.rewardsMultiplier ?? 1)
   );
 
-  const isDismissed = (settings?.dismissedAlerts ?? []).includes(ALERT_ID);
+  // 🔴 `settingsLoading`, not `hasSettings`: an ERRORED settings fetch settles
+  // `isLoading` to false while leaving the data undefined, so this banner can
+  // still be shown to someone who already dismissed it. Preserved as-is because
+  // it is pre-existing behaviour, not something this refactor should change
+  // silently — see the notice-consolidation PR for the decision.
   if (!currentUser || settingsLoading || isDismissed) return null;
 
   return (
@@ -92,7 +82,7 @@ function EarnRewardsBanner({ initialBuzzType }: { initialBuzzType?: BuzzSpendTyp
       color="blue"
       radius="md"
       py="sm"
-      onClose={() => dismissMutation.mutate({ alertId: ALERT_ID })}
+      onClose={() => dismiss()}
       withCloseButton
       closeButtonLabel="Dismiss"
     >

--- a/src/components/Referrals/ReferralDashboard.tsx
+++ b/src/components/Referrals/ReferralDashboard.tsx
@@ -52,6 +52,7 @@ import {
 import { openConfirmModal } from '@mantine/modals';
 import clsx from 'clsx';
 import { Fragment, useMemo, useState } from 'react';
+import { FEATURE_NOTICES } from '~/components/Alerts/notice-registry';
 import { ReferralTimelineProgress } from '~/components/Referrals/ReferralTimelineProgress';
 import { useSpotlight } from '~/hooks/useSpotlight';
 import { useScrollAreaRef } from '~/components/ScrollArea/ScrollAreaContext';
@@ -89,8 +90,10 @@ const rankAccent: Record<string, string> = {
 };
 
 const INITIAL_ACTIVITY_COUNT = 5;
-const ALERT_LITE_ONBOARDING = 'referral-lite-onboarding';
-const ALERT_KICKBACK = 'referral-kickback-info';
+// Declared in the notice registry so the persisted-id set stays enumerable, and
+// so the kickback id is literally the SAME value the full dashboard dismisses.
+const ALERT_LITE_ONBOARDING = FEATURE_NOTICES.referralLiteOnboarding.id;
+const ALERT_KICKBACK = FEATURE_NOTICES.referralKickback.id;
 
 const premiumCardStyle: React.CSSProperties = {
   background: 'light-dark(var(--mantine-color-white), var(--mantine-color-dark-6))',

--- a/src/components/Referrals/ReferralDashboardFull.tsx
+++ b/src/components/Referrals/ReferralDashboardFull.tsx
@@ -47,6 +47,7 @@ import {
 import { openConfirmModal } from '@mantine/modals';
 import clsx from 'clsx';
 import { Fragment, useMemo, useState } from 'react';
+import { FEATURE_NOTICES } from '~/components/Alerts/notice-registry';
 import { ReferralTimelineProgress } from '~/components/Referrals/ReferralTimelineProgress';
 import { useSpotlight } from '~/hooks/useSpotlight';
 import type { BenefitItem } from '~/components/Subscriptions/PlanBenefitList';
@@ -81,9 +82,11 @@ const rankAccent: Record<string, string> = {
 };
 
 const INITIAL_ACTIVITY_COUNT = 10;
-const ALERT_HOW_IT_WORKS = 'referral-how-it-works';
-const ALERT_KICKBACK = 'referral-kickback-info';
-const ALERT_TOKEN_SHOP = 'referral-token-shop-info';
+// Declared in the notice registry so the persisted-id set stays enumerable, and
+// so the kickback id is literally the SAME value the lite dashboard dismisses.
+const ALERT_HOW_IT_WORKS = FEATURE_NOTICES.referralHowItWorks.id;
+const ALERT_KICKBACK = FEATURE_NOTICES.referralKickback.id;
+const ALERT_TOKEN_SHOP = FEATURE_NOTICES.referralTokenShop.id;
 
 const premiumCardStyle: React.CSSProperties = {
   background: 'light-dark(var(--mantine-color-white), var(--mantine-color-dark-6))',

--- a/src/components/RemixGallery/RemixGalleryExplainer.tsx
+++ b/src/components/RemixGallery/RemixGalleryExplainer.tsx
@@ -1,9 +1,11 @@
 import { Anchor, CloseButton, Text } from '@mantine/core';
 import { IconHierarchy } from '@tabler/icons-react';
+import { FEATURE_NOTICES } from '~/components/Alerts/notice-registry';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { trpc } from '~/utils/trpc';
 
-const ALERT_ID = 'remix-gallery-explainer';
+// Declared in the notice registry so the persisted-id set stays enumerable.
+const ALERT_ID = FEATURE_NOTICES.remixGalleryExplainer.id;
 
 /**
  * Where the reasoning lives in full, for anyone who wants it.


### PR DESCRIPTION
Phase 1 of the in-product feature-notice work: one reusable primitive plus a registry, with the existing hand-rolled notices migrated onto it.

The premise going in was that `dismissedAlerts` is "ready-built infrastructure" for a new notice system. It is more than that — **the pattern already exists, hand-rolled and copy-pasted, at seven call sites covering nine notice ids.** The give-away is that the explanatory comments are verbatim-identical across files. Consolidating them was expected to surface disagreements, and it did.

## What the copies disagreed about

A predicate open-coded at N sites is usually wrong at N−1 of them in the same direction. That is exactly what turned up.

**1. The reconcile refetch is missing at three of seven sites.** `NavTidyNotice`, `YellowBuzzMigrationNotice` and both of `OnrampGuidance`'s mutations carry `onSettled: () => utils.user.getSettings.invalidate()`, with a comment explaining why: the optimistic write spreads `...old`, so a cache seeded from a failed SSR snapshot would persist a **truncated settings object** into the shared `user.getSettings` cache, where every other reader picks it up. `BuyBuzzModal`, `ReferralDashboard` and `ReferralDashboardFull` omit it entirely — while `ReferralDashboard`'s *restore* mutation, ten lines below its dismiss mutation in the same file, has it. This is the highest-value finding: the sites that documented the hazard fixed it, and the sites that copied the code without the comment did not.

**2. Four different answers to "don't render against undefined `dismissedAlerts`".**

| site | guard | consequence when settings are unresolved or errored |
|---|---|---|
| NavTidy, YellowBuzz, RemixGallery | `!!settings` | correct — renders nothing until settings resolve |
| BuyBuzzModal | `isLoading` | **renders.** `isLoading` settles to `false` on an *errored* fetch while the data stays `undefined` |
| OnrampGuidance | none (`useCurrentUserSettings` defaults to `{}`) | **flashes** the card at a user who already dismissed it |
| ReferralDashboard, ReferralDashboardFull | none | same flash, ×5 notices |

`isLoading` and `hasSettings` are not interchangeable, and the difference is only visible on the error path. Both are now returned from the hook with the distinction documented, and there is a test pinning the case where they disagree.

**3. The referral dashboards query `user.getSettings` with no `enabled` gate** — `trpc.user.getSettings.useQuery()` with no options, against a `protectedProcedure`, so it fires for signed-out visitors too. Every other site gates on `!!currentUser`.

**4. `referral-kickback-info` was two identical string literals in two files.** Dismissing it on the lite dashboard must dismiss it on the full one — that behaviour rested entirely on two hand-typed strings staying byte-identical. It is now one registry entry both files import.

**Bonus, not a copy-disagreement:** `user.restoreAlert` is wired up on the router (`restoreAlertHandler`) and **nothing calls it**. Both restore paths in the app go through `dismissAlert({ alertId, dismiss: false })` instead. The two handlers also write differently — `dismissAlertHandler` uses `setDismissedAlerts` (a raw `jsonb_set`), `restoreAlertHandler` uses `setUserSetting` (the merge path). Left alone here; flagging it as dead server code worth a decision.

## What this PR adds

**`src/components/Alerts/notice-registry.ts`** — every persisted id declared once, with the production-data warning attached to the type rather than scattered across seven files.

The structural gain is in the signature: `useFeatureNotice` accepts a **registry entry, never a bare string**. A notice cannot be dismissed without being declared, so the id set stays enumerable and collision-checkable by construction rather than by convention. That enumerability is what a later "mark a flag as worth announcing" surface needs to iterate over.

**`src/components/Alerts/useFeatureNotice.ts`** — owns the settings read, the dismissed predicate, the optimistic update with its rollback, the reconcile, and the restore direction.

It deliberately does **not** own *when* a notice shows. Visibility is per-site (a feature flag, a buzz balance, a mount context); folding it in would make every site pay for every other site's conditions. Sites compose `hasSettings && !isDismissed && <their own condition>`.

The registry entry is `{ id }` and nothing else — on purpose. A field that exists but that no code branches on looks like a gate and gates nothing, so fields get added when a consumer reads them.

## Where early-adopter targeting lands (follow-up)

Out of scope here and untouched: nothing in this PR imports `isEarlyAdopter`, the session type, or `feature-flags.service.ts`.

The hook goes in **two places**:
1. `FeatureNotice` in `notice-registry.ts` gains an optional `audience` field.
2. `useFeatureNotice` branches on it — it already resolves the current user, so it is the natural place to evaluate audience and fold the result into what it returns.

Both are additive; no call site changes. Wiring it up is a follow-up once the session flag has merged, and the field should land **in the same PR as the branch that reads it**.

## Behaviour

Preserved at all four migrated sites, including `BuyBuzzModal`'s weaker `isLoading` guard — left as-is with a comment rather than silently changed, since fixing it is a product decision about who sees that banner.

**One deliberate change:** `BuyBuzzModal` now gets the `onSettled` reconcile the other sites already had. It costs one refetch per dismissal (rare) and closes the truncated-cache hazard described above. If that is unwanted, the alternative is a per-site opt-out flag on the hook — say so and I will add it.

`RemixGalleryExplainer`, `ReferralDashboard` and `ReferralDashboardFull` are **not** migrated. They only had their `const ALERT_ID` re-pointed at the registry — a constant move with no logic touched — so the registry is authoritative for the whole id namespace. Migrating them would *change* behaviour (they would gain the reconcile and the `enabled` gate), and each deserves its own decision rather than riding along in a refactor.

**No `ALERT_ID` string changed.** All nine are pinned as hand-typed literals in two separate test files.

**Dependency arrays: none removed, none added, none moved.** `useEffect`/`useMemo`/`useCallback` counts are identical per file before and after (NavTidy 1→1, both referral dashboards 3→3, everything else 0→0). The one `useEffect` in the set — NavTidy's `[show]` open defer, which exists to keep the popover from painting during layout-settle and registering CLS — stays in its component and was deliberately not folded into the shared hook.

## Tests

**Characterization first, against unmodified code.** `feature-notice.characterization.browser.test.tsx` was written and run **green at `origin/main` before the primitive existed**, then kept unchanged across the migration — so it grades the refactor rather than restating it. Three structurally different mount contexts, because a notice's bugs live in how it is mounted:

- `NavTidyNotice` — deferred-open popover under the sub-nav
- `YellowBuzzMigrationNotice` — popover that *wraps children* in the header
- `OnrampGuidance` + `OnrampGuidanceToggle` — inline page card, and the only restore path

**Test matrix.** A characterization test is supposed to be green on both sides; "red at base" does not apply and claiming it would be false. So the split is stated honestly:

| suite | at `origin/main` | at HEAD | kind |
|---|---|---|---|
| characterization (15) | **green** (run before any change) | green | regression evidence for the refactor — proven by mutation, below |
| registry + predicate (21) | n/a — module did not exist | green | **invariant guards**, not regression coverage |
| `useFeatureNotice` (16) | n/a — module did not exist | green | **invariant guards** |

Because two of the three suites can only be vacuously red at base, their power comes from mutation testing, not from the matrix.

**Nine mutants, each killed with its own specific message** (not merely "something went red"):

| mutant | killed by | message |
|---|---|---|
| registry id → `nav-tidy-notice-v2` | 5 unit + 7 component | `expected 'nav-tidy-notice-v2' to be 'nav-tidy-notice'` |
| predicate ignores its `notice` arg | *reads the notice it is given* only | `expected false to be true` |
| predicate → `startsWith` | *matching is exact* only | `expected true to be false` |
| `hasSettings := !isLoading` | 2 hook + NavTidy + YellowBuzz undefined-guards | `expected 1 to be +0` |
| reconcile removed | 8 tests across both files | `expected +0 to be 1` |
| restore sends `dismiss: true` | 3 restore tests | `expected [ 'a', 'nav-tidy-notice' ] to deeply equal [ 'a' ]` |
| query not gated on `currentUser` | *signed out disables the query* only | `expected 'true' to be 'false'` |
| optimistic add drops existing ids | *preserves unrelated dismissals* only | deep-equal mismatch |
| NavTidy drops its dismissed + nav-item gates | 3 NavTidy negatives | `expected 1 to be +0` |

**The mutation round found a real defect in the test suite itself, and it is the part worth reading.** Under the `hasSettings := !isLoading` mutant, `YellowBuzzMigrationNotice`'s undefined-guard test failed after 10s — but `NavTidyNotice`'s passed in **2ms**. Chasing that down: a bare `await vi.waitFor(() => expect(...).toHaveLength(0))` is a *negative* assertion, satisfied at t=0, and this tree mounts asynchronously. Measured directly: the NavTidy trigger is absent from the DOM at t=0 and present at t=2200 **even on the fully-rendering path**. So three NavTidy assertions were passing whether or not the component rendered. The YellowBuzz tests were sound only by accident — they happen to `await` a positive assertion on the wrapped child first, which commits the tree.

Rewritten with a mount sentinel, an explicit wait past the 1500ms open defer, a DOM-level query (the trigger is not in the accessibility tree until the popover opens), and a positive control proving the selector can reach a non-zero count. All three are now lethal — confirmed by re-running two mutants against them.

**Assertions are structural, not spelled.** State is read as `data-dismissed` / `data-has-settings` / `data-loading` attributes and by role + accessible name, never by a word that unrelated copy could spell.

## Verification

- `pnpm run typecheck` — **0 errors in 69s (heap cap 8192 MB)**, on the rebased tree. Instrument validated: the same command reported 12 errors minutes earlier (an uninitialised `event-engine-common` submodule), so it demonstrably can go red rather than OOM-ing to a silent pass.
- Component suite **31 passed**, unit suite **21 passed**, read as counted `✓`/`×` lines with ANSI stripped, not as exit codes.
- `eslint` on all 12 changed files: **0 errors**. The two `src/` warnings (tailwind class order in `OnrampGuidance`, unused `IconX` in `ReferralDashboard`) were confirmed **pre-existing on `origin/main`** by running eslint against a clean worktree of the base.
- Rebased onto current `origin/main` and re-verified there; `origin/main` moved during this work but touched **none** of the files in this diff.
- **Click path:** the notices are driven in a real Chromium (Vitest browser mode) via real `userEvent.click` on the real components with real Mantine — dismiss and restore both. Scope stated honestly: the tRPC boundary is mocked, so this is not a logged-in end-to-end run.

## Not verified

The prettier reformat of `OnrampGuidance` was reverted deliberately — that file is not prettier-clean on `main` and formatting all of it added ~250 lines of unrelated churn. The final diff is **+1104 / −149** with the bulk in new tests; the production-code change is net **−91 lines**.
