### PR TITLE
feat(feedback): image attachments, RUM session id, and opt-in page capture

### DIFF
--- a/package.json
+++ b/package.json
@@ -246,6 +246,7 @@
     "happy-dom": "^20.0.2",
     "he": "^1.2.0",
     "html-to-text": "^9.0.5",
+    "html2canvas": "1.4.1",
     "idb-keyval": "^6.2.0",
     "immer": "^9.0.15",
     "instantsearch.js": "4.64.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -421,6 +421,9 @@ importers:
       html-to-text:
         specifier: ^9.0.5
         version: 9.0.5
+      html2canvas:
+        specifier: 1.4.1
+        version: 1.4.1
       idb-keyval:
         specifier: ^6.2.0
         version: 6.2.2
@@ -6414,6 +6417,10 @@ packages:
   base-x@3.0.11:
     resolution: {integrity: sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==}
 
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
+
   base64-js@0.0.8:
     resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
     engines: {node: '>= 0.4'}
@@ -6954,6 +6961,9 @@ packages:
     engines: {node: ^14 || ^16 || >=18}
     peerDependencies:
       postcss: ^8.0.9
+
+  css-line-break@2.1.0:
+    resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
 
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
@@ -8293,6 +8303,10 @@ packages:
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  html2canvas@1.4.1:
+    resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
+    engines: {node: '>=8.0.0'}
 
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
@@ -11905,6 +11919,9 @@ packages:
   text-encoding-utf-8@1.0.2:
     resolution: {integrity: sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg==}
 
+  text-segmentation@1.0.3:
+    resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
+
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
@@ -12423,6 +12440,9 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  utrie@1.0.2:
+    resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
@@ -18943,6 +18963,8 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  base64-arraybuffer@1.0.2: {}
+
   base64-js@0.0.8: {}
 
   base64-js@1.5.1: {}
@@ -19499,6 +19521,10 @@ snapshots:
   css-declaration-sorter@7.2.0(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
+
+  css-line-break@2.1.0:
+    dependencies:
+      utrie: 1.0.2
 
   css-select@5.2.2:
     dependencies:
@@ -21305,6 +21331,11 @@ snapshots:
   html-url-attributes@3.0.1: {}
 
   html-void-elements@3.0.0: {}
+
+  html2canvas@1.4.1:
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
 
   htmlparser2@8.0.2:
     dependencies:
@@ -25836,6 +25867,10 @@ snapshots:
 
   text-encoding-utf-8@1.0.2: {}
 
+  text-segmentation@1.0.3:
+    dependencies:
+      utrie: 1.0.2
+
   text-table@0.2.0: {}
 
   thenify-all@1.6.0:
@@ -26414,6 +26449,10 @@ snapshots:
     optional: true
 
   util-deprecate@1.0.2: {}
+
+  utrie@1.0.2:
+    dependencies:
+      base64-arraybuffer: 1.0.2
 
   uuid@8.3.2: {}
 

--- a/src/components/Feedback/FeedbackPrompt.browser.test.tsx
+++ b/src/components/Feedback/FeedbackPrompt.browser.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 import type * as CaptureModule from '~/components/Feedback/captureScreenshot';
 import type * as TrpcModule from '~/utils/trpc';
+import { constants } from '~/server/common/constants';
 import { renderWithProviders } from '../../../test/component-setup';
 
 /**
@@ -101,6 +102,21 @@ const CAPTURED_JPEG = new Blob(['captured-pixels'], { type: 'image/jpeg' });
 
 const imageFile = (name = 'screen.png') => new File(['png-bytes'], name, { type: 'image/png' });
 
+/**
+ * A File that reports a size over `constants.mediaUpload.maxImageFileSize` without
+ * allocating 50 MB in the browser. `size` is a read-only accessor on File, so it is
+ * redefined on the instance — allocating the real bytes would make the suite
+ * memory-bound for no extra coverage.
+ */
+const oversizedFile = (name: string) => {
+  const file = imageFile(name);
+  Object.defineProperty(file, 'size', {
+    value: constants.mediaUpload.maxImageFileSize + 1,
+    configurable: true,
+  });
+  return file;
+};
+
 const renderPrompt = () =>
   renderWithProviders(
     <FeedbackPrompt
@@ -136,8 +152,53 @@ const fileInputEl = () =>
     return el;
   });
 
+/**
+ * Pick files, preserving each File instance.
+ *
+ * `userEvent.upload` rebuilds the FileList and DROPS an instance property redefined
+ * on a File — which silently turned `oversizedFile()` back into a small one, so the
+ * size test passed the oversized file straight through and read as the cap not
+ * working. Assigning `files` + dispatching `change` is exactly what the browser does
+ * on a real pick, and it keeps the objects.
+ *
+ * 🔴 The size assertion below is the instrument check: if a future runtime copies the
+ * File again, this fails loudly instead of quietly testing a small file.
+ */
+const pickFiles = async (files: File[]) => {
+  const input = await fileInputEl();
+  const transfer = new DataTransfer();
+  for (const file of files) transfer.items.add(file);
+  input.files = transfer.files;
+  for (let i = 0; i < files.length; i++)
+    expect(
+      input.files[i].size,
+      `the picked File lost its size — this test would prove nothing (${files[i].name})`
+    ).toBe(files[i].size);
+  input.dispatchEvent(new Event('change', { bubbles: true }));
+};
+
 const consentCheckbox = () =>
   page.getByRole('checkbox', { name: 'Attach a screenshot of this page' });
+
+const sendButton = () => page.getByRole('button', { name: 'Send feedback' });
+
+/**
+ * Hold a capture open so the in-flight window can be inspected. Returns the resolver
+ * — the capture does not settle until it is called, which is how the "user presses
+ * Send while the capture is still running" race is made deterministic rather than
+ * timing-dependent.
+ */
+const deferCapture = () => {
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  mocks.html2canvas.mockImplementation(async () => {
+    await gate;
+    return canvasYielding(CAPTURED_JPEG);
+  });
+  return release;
+};
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -263,6 +324,73 @@ describe('capture happens on consent, and the user sees it first', () => {
   });
 });
 
+/**
+ * 🔴 Sending while a capture is still in flight.
+ *
+ * `handleSubmit` reads `screenshot`, which is still `null` until the capture
+ * resolves. Before `capturing` was folded into `busy`, a user could tick the box,
+ * type, and press Send inside that window: the report went out with NO screenshot,
+ * the panel switched to "Got it, thanks", and the capture landed afterwards on a
+ * hidden panel. The user believes they attached a screenshot and did not — a silent
+ * mismatch between what was assembled and what was sent.
+ */
+describe('🔴 Send is blocked while a capture is in flight', () => {
+  test('the Send button is disabled until the capture resolves, then sends WITH it', async () => {
+    const releaseCapture = deferCapture();
+    await openPrompt();
+    await typeMessage();
+
+    await userEvent.click(consentCheckbox());
+    // In-flight: a non-empty message would otherwise leave Send enabled.
+    await expect.element(page.getByText('Capturing the page…')).toBeInTheDocument();
+    await expect.element(sendButton()).toBeDisabled();
+
+    releaseCapture();
+
+    await expect
+      .element(page.getByAltText('Preview of the page screenshot that will be sent'))
+      .toBeInTheDocument();
+    await expect.element(sendButton()).toBeEnabled();
+
+    await send();
+    // The capture the user asked for is the one that shipped.
+    expect(submittedContext().screenshotId).toBe('cf-page-capture.jpg');
+  });
+
+  test('clicking Send mid-capture submits nothing at all', async () => {
+    const releaseCapture = deferCapture();
+    await openPrompt();
+    await typeMessage();
+    await userEvent.click(consentCheckbox());
+    await expect.element(page.getByText('Capturing the page…')).toBeInTheDocument();
+
+    // A real click on the disabled control. The claim is about the OUTCOME — no
+    // submission — not about the word "disabled" appearing in the markup.
+    await userEvent.click(sendButton(), { force: true });
+
+    expect(mocks.createMutate).not.toHaveBeenCalled();
+    expect(mocks.uploadToCF).not.toHaveBeenCalled();
+    // And the panel has not switched to the success state behind the user's back.
+    await expect.element(page.getByText(/Got it, thanks/)).not.toBeInTheDocument();
+
+    releaseCapture();
+    await expect
+      .element(page.getByAltText('Preview of the page screenshot that will be sent'))
+      .toBeInTheDocument();
+  });
+
+  test('Send stays available when no capture was ever requested', async () => {
+    // The other half of the branch: `busy` must not disable Send for everyone just
+    // because the capture path exists.
+    await openPrompt();
+    await typeMessage();
+
+    await expect.element(sendButton()).toBeEnabled();
+    await send();
+    expect(submittedContext()).not.toHaveProperty('screenshotId');
+  });
+});
+
 describe('image attachments', () => {
   test('attaching a file previews it locally without uploading', async () => {
     await openPrompt();
@@ -330,6 +458,53 @@ describe('image attachments', () => {
 
     expect(submittedContext().images).toEqual(['cf-one.png']);
     expect(submittedContext().screenshotId).toBe('cf-page-capture.jpg');
+  });
+
+  /**
+   * The size cap reaching the real picker. `selectAttachments.test.ts` pins the rule
+   * exhaustively in the gating `unit` tier; these two pin that the component actually
+   * CALLS it — a correct rule nobody invokes is the same bug as no rule.
+   */
+  test('an oversized file is refused, named, and never uploaded', async () => {
+    await openPrompt();
+    await typeMessage();
+
+    await pickFiles([oversizedFile('enormous.png'), imageFile('small.png')]);
+
+    await expect.element(page.getByAltText('Attached image small.png')).toBeInTheDocument();
+    await expect.element(page.getByAltText('Attached image enormous.png')).not.toBeInTheDocument();
+    expect(mocks.showErrorNotification).toHaveBeenCalledTimes(1);
+    expect(mocks.showErrorNotification.mock.calls[0][0]).toMatchObject({
+      title: 'Image too large',
+    });
+    // The filename has to be in the message or the user cannot tell which one lost.
+    expect(
+      (mocks.showErrorNotification.mock.calls[0][0] as { error: Error }).error.message
+    ).toContain('enormous.png');
+
+    await send();
+    // Only the acceptable file was ever uploaded.
+    expect(mocks.uploadToCF).toHaveBeenCalledTimes(1);
+    expect(submittedContext().images).toEqual(['cf-small.png']);
+  });
+
+  test('an oversized file does not consume one of the three slots', async () => {
+    await openPrompt();
+
+    await pickFiles([
+      oversizedFile('enormous.png'),
+      imageFile('a.png'),
+      imageFile('b.png'),
+      imageFile('c.png'),
+    ]);
+
+    await expect.element(page.getByText('3 of 3 attached')).toBeInTheDocument();
+    await expect.element(page.getByAltText('Attached image c.png')).toBeInTheDocument();
+    // Size only — the count cap was never reached, so no second notification.
+    expect(mocks.showErrorNotification).toHaveBeenCalledTimes(1);
+    expect(mocks.showErrorNotification.mock.calls[0][0]).toMatchObject({
+      title: 'Image too large',
+    });
   });
 });
 

--- a/src/components/Feedback/FeedbackPrompt.browser.test.tsx
+++ b/src/components/Feedback/FeedbackPrompt.browser.test.tsx
@@ -1,0 +1,347 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import type * as CaptureModule from '~/components/Feedback/captureScreenshot';
+import type * as TrpcModule from '~/utils/trpc';
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * FeedbackPrompt — the real click path for image attachments and the opt-in page
+ * capture.
+ *
+ * 🔴 WHAT IS AND IS NOT FAKED, stated up front.
+ *
+ * `captureConsentedScreenshot` is NOT replaced. The mock below delegates to the
+ * REAL implementation and only substitutes its html2canvas LOADER — so the consent
+ * guard that decides whether anything is captured executes for real on every click
+ * in this file, and `loadHtml2Canvas` is the observable for "did a capture start".
+ * Replacing the whole module would have made the consent tests assertions about the
+ * mock instead of about the product.
+ *
+ * `useCFImageUpload` IS replaced, with a stub whose signature was written against
+ * the real hook (`uploadToCF(file, metadata?, options?) => Promise<{ url, id,
+ * objectUrl, type }>`, plus `files` / `resetFiles` / `removeImage`). The real one
+ * does an XHR PUT to a Cloudflare URL fetched from `/api/v1/image-upload`; nothing
+ * serves either in the test browser.
+ *
+ * `trpc` is replaced because the scaffold wires no tRPC transport.
+ */
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    // Stands in for html2canvas. Called ONLY if the real consent guard lets a
+    // capture proceed — this is the load-bearing observable of this file.
+    loadHtml2Canvas: vi.fn(),
+    html2canvas: vi.fn(),
+    uploadToCF: vi.fn(),
+    createMutate: vi.fn(),
+    showErrorNotification: vi.fn(),
+  },
+}));
+
+vi.mock('~/components/Feedback/captureScreenshot', async (importOriginal) => {
+  const actual = await importOriginal<typeof CaptureModule>();
+  return {
+    ...actual,
+    // Delegate to the REAL capture — only the dependency loader is swapped.
+    captureConsentedScreenshot: (args: CaptureModule.CaptureScreenshotArgs) =>
+      actual.captureConsentedScreenshot({ ...args, loader: mocks.loadHtml2Canvas }),
+  };
+});
+
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof TrpcModule>();
+  return {
+    ...actual,
+    trpc: {
+      feedback: {
+        getArea: { useQuery: () => ({ data: { enabled: true } }) },
+        create: {
+          useMutation: (opts?: { onSuccess?: () => void }) => ({
+            mutate: (input: unknown) => {
+              mocks.createMutate(input);
+              opts?.onSuccess?.();
+            },
+            isPending: false,
+          }),
+        },
+      },
+    },
+  };
+});
+
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ id: 1, username: 'reporter' }),
+}));
+
+vi.mock('~/hooks/useCFImageUpload', () => ({
+  useCFImageUpload: () => ({
+    uploadToCF: mocks.uploadToCF,
+    files: [],
+    resetFiles: vi.fn(),
+    removeImage: vi.fn(),
+  }),
+}));
+
+vi.mock('~/utils/notifications', () => ({
+  showErrorNotification: mocks.showErrorNotification,
+  showSuccessNotification: vi.fn(),
+}));
+
+const { FeedbackPrompt } = await import('~/components/Feedback/FeedbackPrompt');
+
+/** A canvas stand-in; `toBlob` is callback-style, as in the DOM. */
+const canvasYielding = (blob: Blob) =>
+  ({
+    toBlob: (callback: CanvasBlobCallback) => callback(blob),
+  } as unknown as HTMLCanvasElement);
+
+type CanvasBlobCallback = (blob: Blob | null) => void;
+
+const CAPTURED_JPEG = new Blob(['captured-pixels'], { type: 'image/jpeg' });
+
+const imageFile = (name = 'screen.png') => new File(['png-bytes'], name, { type: 'image/png' });
+
+const renderPrompt = () =>
+  renderWithProviders(
+    <FeedbackPrompt
+      area="bitdex-image-feed"
+      notice="We're testing a new system behind this feed."
+      context={{ path: '/images', reportedSource: 'bitdex' }}
+    />
+  );
+
+const openPrompt = async () => {
+  renderPrompt();
+  await userEvent.click(page.getByRole('button', { name: 'Give feedback' }));
+  await expect.element(page.getByPlaceholder('What looked wrong?')).toBeInTheDocument();
+};
+
+const typeMessage = async (text = 'the feed repeated itself') => {
+  await userEvent.fill(page.getByPlaceholder('What looked wrong?'), text);
+};
+
+const send = async () => {
+  await userEvent.click(page.getByRole('button', { name: 'Send feedback' }));
+  await vi.waitFor(() => expect(mocks.createMutate).toHaveBeenCalledTimes(1));
+};
+
+const submittedContext = () =>
+  (mocks.createMutate.mock.calls[0][0] as { context: Record<string, unknown> }).context;
+
+/** The multi-file input Mantine's FileButton renders for "Attach images". */
+const fileInputEl = () =>
+  vi.waitFor(() => {
+    const el = document.querySelector<HTMLInputElement>('input[type="file"][multiple]');
+    if (!el) throw new Error('file input not found');
+    return el;
+  });
+
+const consentCheckbox = () =>
+  page.getByRole('checkbox', { name: 'Attach a screenshot of this page' });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.html2canvas.mockResolvedValue(canvasYielding(CAPTURED_JPEG));
+  mocks.loadHtml2Canvas.mockResolvedValue(mocks.html2canvas);
+  mocks.uploadToCF.mockImplementation(async (file: File) => ({
+    url: `https://cf.example/${file.name}`,
+    id: `cf-${file.name}`,
+    objectUrl: `blob:${file.name}`,
+    type: 'image',
+  }));
+});
+
+describe('🔴 DOM capture never fires without explicit consent', () => {
+  test('nothing is captured merely by opening the prompt', async () => {
+    await openPrompt();
+
+    await expect.element(consentCheckbox()).not.toBeChecked();
+    expect(mocks.loadHtml2Canvas).not.toHaveBeenCalled();
+    expect(mocks.html2canvas).not.toHaveBeenCalled();
+  });
+
+  test('a full submit with the checkbox untouched captures and uploads nothing', async () => {
+    await openPrompt();
+    await typeMessage();
+    await send();
+
+    // The three independent observables of "no capture happened": the renderer was
+    // never loaded, no upload was attempted, and no id reached the payload.
+    expect(mocks.loadHtml2Canvas).not.toHaveBeenCalled();
+    expect(mocks.uploadToCF).not.toHaveBeenCalled();
+    expect(submittedContext()).not.toHaveProperty('screenshotId');
+  });
+
+  test('typing does not start a capture', async () => {
+    await openPrompt();
+    await typeMessage('still typing');
+
+    expect(mocks.loadHtml2Canvas).not.toHaveBeenCalled();
+  });
+});
+
+describe('capture happens on consent, and the user sees it first', () => {
+  test('checking the box captures once and shows a preview', async () => {
+    await openPrompt();
+    await userEvent.click(consentCheckbox());
+
+    await expect
+      .element(page.getByAltText('Preview of the page screenshot that will be sent'))
+      .toBeInTheDocument();
+    expect(mocks.loadHtml2Canvas).toHaveBeenCalledTimes(1);
+    expect(mocks.html2canvas).toHaveBeenCalledTimes(1);
+    // Preview only — the capture must not be uploaded before Send.
+    expect(mocks.uploadToCF).not.toHaveBeenCalled();
+  });
+
+  test('sending after consent uploads the capture and carries its id', async () => {
+    await openPrompt();
+    await typeMessage();
+    await userEvent.click(consentCheckbox());
+    await expect
+      .element(page.getByAltText('Preview of the page screenshot that will be sent'))
+      .toBeInTheDocument();
+    await send();
+
+    expect(mocks.uploadToCF).toHaveBeenCalledTimes(1);
+    const uploaded = mocks.uploadToCF.mock.calls[0][0] as File;
+    expect(uploaded.name).toBe('page-capture.jpg');
+    expect(uploaded.type).toBe('image/jpeg');
+    expect(submittedContext().screenshotId).toBe('cf-page-capture.jpg');
+    // The caller's own context is preserved alongside it.
+    expect(submittedContext().path).toBe('/images');
+    expect(submittedContext().reportedSource).toBe('bitdex');
+  });
+
+  test('🔴 the user can drop the preview and still submit', async () => {
+    await openPrompt();
+    await typeMessage();
+    await userEvent.click(consentCheckbox());
+    await expect
+      .element(page.getByAltText('Preview of the page screenshot that will be sent'))
+      .toBeInTheDocument();
+
+    await userEvent.click(page.getByRole('button', { name: 'Remove the page screenshot' }));
+
+    await expect
+      .element(page.getByAltText('Preview of the page screenshot that will be sent'))
+      .not.toBeInTheDocument();
+    // Dropping the preview also clears consent — the control returns to its
+    // off state rather than claiming a capture that no longer exists.
+    await expect.element(consentCheckbox()).not.toBeChecked();
+
+    await send();
+    expect(mocks.uploadToCF).not.toHaveBeenCalled();
+    expect(submittedContext()).not.toHaveProperty('screenshotId');
+  });
+
+  test('unchecking the box discards the capture', async () => {
+    await openPrompt();
+    await userEvent.click(consentCheckbox());
+    await expect
+      .element(page.getByAltText('Preview of the page screenshot that will be sent'))
+      .toBeInTheDocument();
+
+    await userEvent.click(consentCheckbox());
+
+    await expect
+      .element(page.getByAltText('Preview of the page screenshot that will be sent'))
+      .not.toBeInTheDocument();
+  });
+
+  test('a failed capture surfaces an error and leaves the box unchecked', async () => {
+    mocks.html2canvas.mockRejectedValue(new Error('render failed'));
+    await openPrompt();
+
+    await userEvent.click(consentCheckbox());
+
+    await vi.waitFor(() => expect(mocks.showErrorNotification).toHaveBeenCalledTimes(1));
+    expect(mocks.showErrorNotification.mock.calls[0][0]).toMatchObject({
+      title: 'Could not capture the page',
+    });
+    await expect.element(consentCheckbox()).not.toBeChecked();
+  });
+});
+
+describe('image attachments', () => {
+  test('attaching a file previews it locally without uploading', async () => {
+    await openPrompt();
+    await userEvent.upload(await fileInputEl(), imageFile('one.png'));
+
+    await expect.element(page.getByAltText('Attached image one.png')).toBeInTheDocument();
+    await expect.element(page.getByText('1 of 3 attached')).toBeInTheDocument();
+    expect(mocks.uploadToCF).not.toHaveBeenCalled();
+  });
+
+  test('sending uploads each attachment and carries the ids in order', async () => {
+    await openPrompt();
+    await typeMessage();
+    await userEvent.upload(await fileInputEl(), [imageFile('one.png'), imageFile('two.png')]);
+    await expect.element(page.getByAltText('Attached image two.png')).toBeInTheDocument();
+
+    await send();
+
+    expect(mocks.uploadToCF).toHaveBeenCalledTimes(2);
+    expect(submittedContext().images).toEqual(['cf-one.png', 'cf-two.png']);
+  });
+
+  test('an attachment can be removed before sending', async () => {
+    await openPrompt();
+    await typeMessage();
+    await userEvent.upload(await fileInputEl(), [imageFile('one.png'), imageFile('two.png')]);
+    await expect.element(page.getByAltText('Attached image two.png')).toBeInTheDocument();
+
+    await userEvent.click(page.getByRole('button', { name: 'Remove attached image one.png' }));
+    await expect.element(page.getByAltText('Attached image one.png')).not.toBeInTheDocument();
+
+    await send();
+    expect(mocks.uploadToCF).toHaveBeenCalledTimes(1);
+    expect(submittedContext().images).toEqual(['cf-two.png']);
+  });
+
+  test('the fourth file is refused and the cap is stated out loud', async () => {
+    await openPrompt();
+    await userEvent.upload(await fileInputEl(), [
+      imageFile('one.png'),
+      imageFile('two.png'),
+      imageFile('three.png'),
+      imageFile('four.png'),
+    ]);
+
+    await expect.element(page.getByText('3 of 3 attached')).toBeInTheDocument();
+    await expect.element(page.getByAltText('Attached image four.png')).not.toBeInTheDocument();
+    expect(mocks.showErrorNotification).toHaveBeenCalledTimes(1);
+    expect(mocks.showErrorNotification.mock.calls[0][0]).toMatchObject({
+      title: 'Too many images',
+    });
+  });
+
+  test('attachments and a consented capture travel together', async () => {
+    await openPrompt();
+    await typeMessage();
+    await userEvent.upload(await fileInputEl(), imageFile('one.png'));
+    await expect.element(page.getByAltText('Attached image one.png')).toBeInTheDocument();
+    await userEvent.click(consentCheckbox());
+    await expect
+      .element(page.getByAltText('Preview of the page screenshot that will be sent'))
+      .toBeInTheDocument();
+
+    await send();
+
+    expect(submittedContext().images).toEqual(['cf-one.png']);
+    expect(submittedContext().screenshotId).toBe('cf-page-capture.jpg');
+  });
+});
+
+describe('submitting without Faro (the dev/test/preview case)', () => {
+  test('a submission succeeds and simply omits sessionId', async () => {
+    // Faro is never initialised in the component harness, so this is the real
+    // absence path rather than a simulated one.
+    await openPrompt();
+    await typeMessage();
+    await send();
+
+    expect(submittedContext()).not.toHaveProperty('sessionId');
+    await expect.element(page.getByText(/Got it, thanks/)).toBeInTheDocument();
+  });
+});

--- a/src/components/Feedback/FeedbackPrompt.tsx
+++ b/src/components/Feedback/FeedbackPrompt.tsx
@@ -15,8 +15,10 @@ import { IconAlertTriangle, IconPaperclip, IconX } from '@tabler/icons-react';
 import type { CSSProperties } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { captureConsentedScreenshot } from '~/components/Feedback/captureScreenshot';
+import { selectAttachments } from '~/components/Feedback/selectAttachments';
 import { useCFImageUpload } from '~/hooks/useCFImageUpload';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { constants } from '~/server/common/constants';
 import type { CreateFeedbackInput } from '~/server/schema/feedback.schema';
 import type { FeedbackArea } from '~/shared/constants/feedback.constants';
 import {
@@ -25,7 +27,20 @@ import {
 } from '~/shared/constants/feedback.constants';
 import { getFaroSessionId } from '~/utils/faro/getFaroSessionId';
 import { showErrorNotification } from '~/utils/notifications';
+import { formatBytes } from '~/utils/number-helpers';
 import { trpc } from '~/utils/trpc';
+
+/**
+ * Ceiling on a file the USER chose, as distinct from `SCREENSHOT_MAX_BYTES`, which
+ * bounds the capture this feature generates. Taken from the shared upload constant
+ * that nine other upload surfaces in this repo already enforce
+ * (ImageDropzone, SimpleImageUpload, ProfileImageUpload, ImageUpload, …), rather
+ * than a number invented here — the point is to stop being the one picker that
+ * silently accepts a 40-megapixel phone photo at full size, not to introduce a
+ * different limit for feedback. Note there is NO server backstop: the presigned PUT
+ * from `/api/v1/image-upload` carries no size condition, so this is the only check.
+ */
+const FEEDBACK_ATTACHMENT_MAX_BYTES = constants.mediaUpload.maxImageFileSize;
 
 const cardStyle: CSSProperties = {
   background: 'light-dark(var(--mantine-color-white), var(--mantine-color-dark-6))',
@@ -148,16 +163,32 @@ export function FeedbackPrompt({
 
   const handleFilesSelected = (selected: File[] | null) => {
     if (!selected?.length) return;
-    const remaining = FEEDBACK_IMAGE_MAX_COUNT - attachments.length;
-    if (remaining <= 0) return;
-    // Silently taking the first N would look like the extras failed to attach, so
-    // say the cap out loud and still take what fits.
-    if (selected.length > remaining)
+    const { accepted, rejectedForSize, rejectedForCount } = selectAttachments({
+      selected,
+      alreadyAttached: attachments.length,
+      maxCount: FEEDBACK_IMAGE_MAX_COUNT,
+      maxBytes: FEEDBACK_ATTACHMENT_MAX_BYTES,
+    });
+
+    // Both rejections are said out loud, and separately. Silently dropping a file
+    // looks like the picker failed; collapsing the two reasons into one message
+    // sends the user to fix the wrong thing.
+    if (rejectedForSize.length)
+      showErrorNotification({
+        title: 'Image too large',
+        error: new Error(
+          `${rejectedForSize.map((file) => file.name).join(', ')} — images must be under ` +
+            `${formatBytes(FEEDBACK_ATTACHMENT_MAX_BYTES)}.`
+        ),
+      });
+    if (rejectedForCount.length)
       showErrorNotification({
         title: 'Too many images',
         error: new Error(`You can attach up to ${FEEDBACK_IMAGE_MAX_COUNT} images.`),
       });
-    const added = selected.slice(0, remaining).map((file) => ({
+    if (!accepted.length) return;
+
+    const added = accepted.map((file) => ({
       key: nextAttachmentKey(),
       file,
       objectUrl: trackObjectUrl(URL.createObjectURL(file)),
@@ -269,7 +300,15 @@ export function FeedbackPrompt({
     }
   };
 
-  const busy = uploading || createFeedback.isPending;
+  // 🔴 `capturing` belongs here, not only on the checkbox's own `disabled`. A capture
+  // is async, and `handleSubmit` reads `screenshot` — which is still null while it is
+  // in flight. Without this, a user who ticks the box, types, and presses Send before
+  // the capture resolves gets "Got it, thanks" for a submission with NO screenshot,
+  // while the capture completes onto a panel that is already hidden. They believe
+  // they attached a screenshot and did not. Blocking Send is the honest resolution:
+  // the button is briefly unavailable and says so via its spinner, rather than
+  // silently sending something other than what the user assembled.
+  const busy = uploading || capturing || createFeedback.isPending;
   const canAddMore = attachments.length < FEEDBACK_IMAGE_MAX_COUNT;
 
   return (
@@ -386,7 +425,9 @@ export function FeedbackPrompt({
             <Checkbox
               size="xs"
               checked={screenshotConsent}
-              disabled={busy || capturing}
+              // `busy` now subsumes `capturing` (see its definition); kept as one
+              // term so the two cannot drift apart again.
+              disabled={busy}
               onChange={(event) => void handleScreenshotConsentChange(event.currentTarget.checked)}
               label="Attach a screenshot of this page"
               description="We'll show it to you before anything is sent. Only what's on screen is captured."

--- a/src/components/Feedback/FeedbackPrompt.tsx
+++ b/src/components/Feedback/FeedbackPrompt.tsx
@@ -1,11 +1,29 @@
-import { ActionIcon, Button, Divider, Group, Paper, Text, Textarea } from '@mantine/core';
-import { IconAlertTriangle, IconX } from '@tabler/icons-react';
+import {
+  ActionIcon,
+  Button,
+  Checkbox,
+  Divider,
+  FileButton,
+  Group,
+  Loader,
+  Paper,
+  Stack,
+  Text,
+  Textarea,
+} from '@mantine/core';
+import { IconAlertTriangle, IconPaperclip, IconX } from '@tabler/icons-react';
 import type { CSSProperties } from 'react';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { captureConsentedScreenshot } from '~/components/Feedback/captureScreenshot';
+import { useCFImageUpload } from '~/hooks/useCFImageUpload';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import type { CreateFeedbackInput } from '~/server/schema/feedback.schema';
 import type { FeedbackArea } from '~/shared/constants/feedback.constants';
-import { FEEDBACK_MESSAGE_MAX_LENGTH } from '~/shared/constants/feedback.constants';
+import {
+  FEEDBACK_IMAGE_MAX_COUNT,
+  FEEDBACK_MESSAGE_MAX_LENGTH,
+} from '~/shared/constants/feedback.constants';
+import { getFaroSessionId } from '~/utils/faro/getFaroSessionId';
 import { showErrorNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 
@@ -35,6 +53,25 @@ function writeDismissed(area: FeedbackArea) {
   }
 }
 
+/**
+ * A file the user has chosen (or a capture they accepted) that has NOT been
+ * uploaded yet. Previews come from a local object URL, so nothing leaves the
+ * browser until Send is pressed — see the upload-budget note on
+ * FEEDBACK_IMAGE_MAX_COUNT.
+ */
+type PendingAttachment = { key: string; file: File; objectUrl: string };
+
+let attachmentKeySeq = 0;
+const nextAttachmentKey = () => `attachment-${++attachmentKeySeq}`;
+
+const revoke = (objectUrl: string) => {
+  try {
+    URL.revokeObjectURL(objectUrl);
+  } catch {
+    // Nothing to do; the URL dies with the document either way.
+  }
+};
+
 type FeedbackPromptProps = {
   area: FeedbackArea;
   notice: string;
@@ -58,6 +95,37 @@ export function FeedbackPrompt({
   const [message, setMessage] = useState('');
   const [sent, setSent] = useState(false);
 
+  const [attachments, setAttachments] = useState<PendingAttachment[]>([]);
+  // 🔴 The consent flag for DOM capture. Starts OFF and is only ever set by the
+  // user's own click on the checkbox below. Nothing else may set it true.
+  const [screenshotConsent, setScreenshotConsent] = useState(false);
+  const [screenshot, setScreenshot] = useState<PendingAttachment | null>(null);
+  const [capturing, setCapturing] = useState(false);
+  const [uploading, setUploading] = useState(false);
+
+  const { uploadToCF } = useCFImageUpload();
+
+  // Object URLs outlive React state unless revoked. A ref (not the state itself)
+  // because this must run on unmount with whatever was live at that moment, and a
+  // cleanup closed over `attachments` would see the value from its own render.
+  const liveObjectUrls = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    const urls = liveObjectUrls.current;
+    return () => {
+      urls.forEach(revoke);
+      urls.clear();
+    };
+  }, []);
+
+  const trackObjectUrl = (objectUrl: string) => {
+    liveObjectUrls.current.add(objectUrl);
+    return objectUrl;
+  };
+  const releaseObjectUrl = (objectUrl: string) => {
+    liveObjectUrls.current.delete(objectUrl);
+    revoke(objectUrl);
+  };
+
   const enabled = active && !!currentUser && !dismissed;
   const { data } = trpc.feedback.getArea.useQuery({ area }, { enabled });
 
@@ -77,6 +145,132 @@ export function FeedbackPrompt({
     writeDismissed(area);
     setDismissed(true);
   };
+
+  const handleFilesSelected = (selected: File[] | null) => {
+    if (!selected?.length) return;
+    const remaining = FEEDBACK_IMAGE_MAX_COUNT - attachments.length;
+    if (remaining <= 0) return;
+    // Silently taking the first N would look like the extras failed to attach, so
+    // say the cap out loud and still take what fits.
+    if (selected.length > remaining)
+      showErrorNotification({
+        title: 'Too many images',
+        error: new Error(`You can attach up to ${FEEDBACK_IMAGE_MAX_COUNT} images.`),
+      });
+    const added = selected.slice(0, remaining).map((file) => ({
+      key: nextAttachmentKey(),
+      file,
+      objectUrl: trackObjectUrl(URL.createObjectURL(file)),
+    }));
+    setAttachments((current) => [...current, ...added]);
+  };
+
+  const handleRemoveAttachment = (key: string) => {
+    setAttachments((current) => {
+      const match = current.find((x) => x.key === key);
+      if (match) releaseObjectUrl(match.objectUrl);
+      return current.filter((x) => x.key !== key);
+    });
+  };
+
+  const clearScreenshot = () => {
+    setScreenshot((current) => {
+      if (current) releaseObjectUrl(current.objectUrl);
+      return null;
+    });
+  };
+
+  /**
+   * 🔴 The ONLY path in this component that can start a capture, and it is reached
+   * only from the checkbox's own `onChange`. `checked` IS the user's consent.
+   *
+   * Honest note on the two layers: by the time `captureConsentedScreenshot` is
+   * called, the `!checked` branch has already returned, so the argument is always
+   * `true` — the module's own guard is redundant *from this call site*. It is not
+   * redundant in general (it is the guard for every future caller, and it is what
+   * `captureScreenshot.test.ts` pins). The guarantee THIS function carries is a
+   * different one: no other code path here calls capture at all.
+   */
+  const handleScreenshotConsentChange = async (checked: boolean) => {
+    setScreenshotConsent(checked);
+    if (!checked) {
+      clearScreenshot();
+      return;
+    }
+    setCapturing(true);
+    try {
+      const file = await captureConsentedScreenshot({ consented: checked });
+      if (!file) {
+        // Defensive: `null` is the module's "no consent" answer, which this call
+        // site cannot currently produce. Handled rather than asserted away so a
+        // future refactor that loosens the argument fails visibly (the checkbox
+        // snaps back) instead of silently rendering an empty preview.
+        setScreenshotConsent(false);
+        return;
+      }
+      setScreenshot({
+        key: nextAttachmentKey(),
+        file,
+        objectUrl: trackObjectUrl(URL.createObjectURL(file)),
+      });
+    } catch (error) {
+      // A failed capture must not look like a silently attached one.
+      setScreenshotConsent(false);
+      showErrorNotification({
+        title: 'Could not capture the page',
+        error: error instanceof Error ? error : new Error('Screenshot failed'),
+      });
+    } finally {
+      setCapturing(false);
+    }
+  };
+
+  /** Drop the preview but leave the prompt usable — the user saw it and said no. */
+  const handleDropScreenshot = () => {
+    clearScreenshot();
+    setScreenshotConsent(false);
+  };
+
+  const handleSubmit = async () => {
+    setUploading(true);
+    try {
+      // Uploads happen HERE, not at attach time, so nothing is spent on a
+      // submission the user abandons.
+      const images: string[] = [];
+      for (const attachment of attachments) {
+        const { id } = await uploadToCF(attachment.file);
+        images.push(id);
+      }
+      const screenshotId = screenshot ? (await uploadToCF(screenshot.file)).id : undefined;
+
+      // Read at submit time rather than at mount: Faro may finish starting between
+      // the two. Undefined whenever Faro is not running at all — dev/test/preview,
+      // or a session that blocked it — and the field is then simply omitted, which
+      // is the ordinary case and never blocks the submission.
+      const sessionId = getFaroSessionId();
+
+      createFeedback.mutate({
+        area,
+        message: message.trim(),
+        context: {
+          ...context,
+          ...(images.length ? { images } : {}),
+          ...(screenshotId ? { screenshotId } : {}),
+          ...(sessionId ? { sessionId } : {}),
+        },
+      });
+    } catch (error) {
+      showErrorNotification({
+        title: 'Could not attach your images',
+        error: error instanceof Error ? error : new Error('Upload failed'),
+      });
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const busy = uploading || createFeedback.isPending;
+  const canAddMore = attachments.length < FEEDBACK_IMAGE_MAX_COUNT;
 
   return (
     <Paper withBorder radius="md" style={cardStyle}>
@@ -127,17 +321,117 @@ export function FeedbackPrompt({
               size="sm"
               radius="xl"
               style={{ flexShrink: 0 }}
-              disabled={!message.trim()}
+              disabled={!message.trim() || busy}
               // Mantine's disabled fill is near-invisible on this card surface.
               classNames={{
                 root: 'data-[disabled]:!bg-blue-6 data-[disabled]:!text-white data-[disabled]:!opacity-50',
               }}
-              loading={createFeedback.isPending}
-              onClick={() => createFeedback.mutate({ area, message: message.trim(), context })}
+              loading={busy}
+              onClick={handleSubmit}
             >
               Send feedback
             </Button>
           </Group>
+          <Stack px="sm" pb="sm" gap="xs">
+            <Group gap="xs" wrap="wrap" align="center">
+              <FileButton onChange={handleFilesSelected} accept="image/*" multiple>
+                {(props) => (
+                  <Button
+                    {...props}
+                    size="compact-sm"
+                    radius="xl"
+                    variant="light"
+                    leftSection={<IconPaperclip size={14} />}
+                    disabled={!canAddMore || busy}
+                  >
+                    Attach images
+                  </Button>
+                )}
+              </FileButton>
+              <Text size="xs" c="dimmed">
+                {attachments.length} of {FEEDBACK_IMAGE_MAX_COUNT} attached
+              </Text>
+            </Group>
+            {!!attachments.length && (
+              <Group gap="xs" wrap="wrap">
+                {attachments.map((attachment) => (
+                  <div key={attachment.key} style={{ position: 'relative' }}>
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={attachment.objectUrl}
+                      alt={`Attached image ${attachment.file.name}`}
+                      style={{
+                        width: 64,
+                        height: 64,
+                        objectFit: 'cover',
+                        borderRadius: 8,
+                        display: 'block',
+                      }}
+                    />
+                    <ActionIcon
+                      size="xs"
+                      radius="xl"
+                      variant="filled"
+                      color="dark"
+                      style={{ position: 'absolute', top: -6, right: -6 }}
+                      aria-label={`Remove attached image ${attachment.file.name}`}
+                      onClick={() => handleRemoveAttachment(attachment.key)}
+                    >
+                      <IconX size={12} />
+                    </ActionIcon>
+                  </div>
+                ))}
+              </Group>
+            )}
+            <Checkbox
+              size="xs"
+              checked={screenshotConsent}
+              disabled={busy || capturing}
+              onChange={(event) => void handleScreenshotConsentChange(event.currentTarget.checked)}
+              label="Attach a screenshot of this page"
+              description="We'll show it to you before anything is sent. Only what's on screen is captured."
+            />
+            {capturing && (
+              <Group gap="xs" align="center">
+                <Loader size="xs" />
+                <Text size="xs" c="dimmed">
+                  Capturing the page…
+                </Text>
+              </Group>
+            )}
+            {screenshot && (
+              <Stack gap={4} align="flex-start">
+                <Text size="xs" c="dimmed">
+                  This is what will be sent:
+                </Text>
+                <div style={{ position: 'relative' }}>
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={screenshot.objectUrl}
+                    alt="Preview of the page screenshot that will be sent"
+                    style={{
+                      maxWidth: 240,
+                      maxHeight: 160,
+                      borderRadius: 8,
+                      display: 'block',
+                      border: '1px solid var(--mantine-color-default-border)',
+                    }}
+                  />
+                  <ActionIcon
+                    size="xs"
+                    radius="xl"
+                    variant="filled"
+                    color="dark"
+                    style={{ position: 'absolute', top: -6, right: -6 }}
+                    aria-label="Remove the page screenshot"
+                    onClick={handleDropScreenshot}
+                  >
+                    <IconX size={12} />
+                  </ActionIcon>
+                </div>
+              </Stack>
+            )}
+          </Stack>
         </>
       )}
     </Paper>

--- a/src/components/Feedback/__tests__/captureScreenshot.test.ts
+++ b/src/components/Feedback/__tests__/captureScreenshot.test.ts
@@ -123,14 +123,15 @@ describe('capture fires with explicit consent', () => {
     expect(html2canvas.mock.calls[0][0]).toBe(document.body);
   });
 
-  it('captures only the viewport, not the whole scrollable document', async () => {
-    // The privacy half of the posture: anything the reporter scrolled past is not
-    // drawn. Asserted as literals against a pinned window, not read back from the
-    // call.
+  const pinWindow = () => {
     vi.spyOn(window, 'scrollX', 'get').mockReturnValue(120);
     vi.spyOn(window, 'scrollY', 'get').mockReturnValue(340);
     vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(800);
     vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(600);
+  };
+
+  it('crops to the viewport, not the whole scrollable document', async () => {
+    pinWindow();
 
     await captureConsentedScreenshot({ consented: true, loader });
 
@@ -140,6 +141,54 @@ describe('capture fires with explicit consent', () => {
       width: 800,
       height: 600,
       allowTaint: false,
+    });
+  });
+
+  /**
+   * 🔴 REGRESSION GUARD — `scrollX`/`scrollY` must be ABSENT.
+   *
+   * This is the one shape a `toMatchObject` crop assertion cannot see: it only says
+   * the listed keys are right, never that an EXTRA key is absent. `scrollX: 0,
+   * scrollY: 0` looks like it belongs beside `x`/`y` and shipped in the first draft.
+   * html2canvas adds those values to every cloned element's viewport-relative rect
+   * to recover document coordinates; forcing them to 0 relocates `position:
+   * fixed`/`sticky` elements to document y=0, outside the crop, so the app's sticky
+   * header disappears from every capture and the feed behind it is drawn instead.
+   * The defaults (`pageXOffset`/`pageYOffset`) are correct.
+   *
+   * Asserted as an EXACT key set rather than two `toBeUndefined()`s, so any future
+   * option that shifts the coordinate space also has to be looked at.
+   */
+  it('omits scrollX/scrollY so fixed and sticky elements keep their real position', async () => {
+    pinWindow();
+
+    await captureConsentedScreenshot({ consented: true, loader });
+
+    const options = html2canvas.mock.calls[0][1] as Record<string, unknown>;
+    expect(options).not.toHaveProperty('scrollX');
+    expect(options).not.toHaveProperty('scrollY');
+    expect(Object.keys(options).sort()).toEqual([
+      'allowTaint',
+      'height',
+      'logging',
+      'scale',
+      'useCORS',
+      'width',
+      'windowHeight',
+      'windowWidth',
+      'x',
+      'y',
+    ]);
+  });
+
+  it('reports the window size to html2canvas as the real viewport', async () => {
+    pinWindow();
+
+    await captureConsentedScreenshot({ consented: true, loader });
+
+    expect(html2canvas.mock.calls[0][1]).toMatchObject({
+      windowWidth: 800,
+      windowHeight: 600,
     });
   });
 

--- a/src/components/Feedback/__tests__/captureScreenshot.test.ts
+++ b/src/components/Feedback/__tests__/captureScreenshot.test.ts
@@ -1,0 +1,191 @@
+// @vitest-environment happy-dom
+// The module reads `window`/`document` and builds a `File`, so the node default
+// would fail for environmental reasons rather than for anything about the guard.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Html2CanvasFn } from '~/components/Feedback/captureScreenshot';
+import {
+  captureConsentedScreenshot,
+  SCREENSHOT_FILENAME,
+  SCREENSHOT_MAX_BYTES,
+  SCREENSHOT_MIME_TYPE,
+  ScreenshotTooLargeError,
+} from '~/components/Feedback/captureScreenshot';
+
+/**
+ * 🔴 THE CONSENT GUARD. This is the load-bearing guarantee of the opt-in DOM-capture
+ * design: a rendered capture of this site can contain NSFW imagery, another user's
+ * private message content, or moderator-only UI, so nothing may be captured unless
+ * the user turned the control on themselves.
+ *
+ * The guard is asserted STRUCTURALLY, not by a word on screen: the observable is
+ * whether the html2canvas loader was invoked at all. A capture that never loads its
+ * renderer cannot have produced a pixel, and no unrelated feature can spell that.
+ *
+ * The loader fake is typed as the real `Html2CanvasLoader`/`Html2CanvasFn`, which is
+ * written from html2canvas's published signature — so the fake cannot encode a
+ * different contract from the dependency without a type error.
+ */
+
+const { loader, html2canvas, toBlob } = vi.hoisted(() => {
+  const toBlobMock = vi.fn();
+  const html2canvasMock = vi.fn();
+  return {
+    toBlob: toBlobMock,
+    html2canvas: html2canvasMock,
+    loader: vi.fn(),
+  };
+});
+
+/**
+ * A canvas stand-in whose `toBlob` we control. `toBlob` is callback-style in the DOM
+ * (`toBlob(callback, type?, quality?)`); the mime/quality arguments are still recorded
+ * on `toBlob.mock.calls` and asserted below, so the implementation ignores them.
+ */
+const makeCanvas = (blob: Blob | null) => {
+  toBlob.mockImplementation((callback: BlobCallback) => callback(blob));
+  return { toBlob } as unknown as HTMLCanvasElement;
+};
+
+const jpeg = (bytes: number) => new Blob([new Uint8Array(bytes)], { type: SCREENSHOT_MIME_TYPE });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  html2canvas.mockResolvedValue(makeCanvas(jpeg(1024)));
+  loader.mockResolvedValue(html2canvas as unknown as Html2CanvasFn);
+});
+
+describe('🔴 capture does not fire without explicit consent', () => {
+  it('never loads html2canvas when consent is false', async () => {
+    const result = await captureConsentedScreenshot({ consented: false, loader });
+
+    expect(loader).not.toHaveBeenCalled();
+    expect(html2canvas).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  // Every one of these is a value some caller could plausibly hand in — a missing
+  // prop, a checkbox that was never touched, a truthy string from a query param, a
+  // `1` from a serialised flag. The guard is `!== true`, so none of them capture.
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['the string "true"', 'true'],
+    ['the number 1', 1],
+    ['an empty string', ''],
+    ['the number 0', 0],
+    ['an object', {}],
+  ])('never loads html2canvas when consent is %s', async (_label, consented) => {
+    const result = await captureConsentedScreenshot({
+      consented: consented as unknown as boolean,
+      loader,
+    });
+
+    expect(loader).not.toHaveBeenCalled();
+    expect(html2canvas).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  it('short-circuits BEFORE touching the DOM, so a null target is irrelevant', async () => {
+    // Reaching for `document.body` past the guard would be a capture attempt even if
+    // it failed. This pins the ORDER: consent is checked first.
+    const result = await captureConsentedScreenshot({
+      consented: false,
+      target: null,
+      loader,
+    });
+
+    expect(result).toBeNull();
+    expect(loader).not.toHaveBeenCalled();
+  });
+});
+
+describe('capture fires with explicit consent', () => {
+  it('loads html2canvas and returns a JPEG File', async () => {
+    const result = await captureConsentedScreenshot({ consented: true, loader });
+
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(html2canvas).toHaveBeenCalledTimes(1);
+    expect(result).toBeInstanceOf(File);
+    expect(result?.name).toBe(SCREENSHOT_FILENAME);
+    expect(result?.type).toBe('image/jpeg');
+  });
+
+  it('captures the given target rather than always document.body', async () => {
+    const target = document.createElement('div');
+    await captureConsentedScreenshot({ consented: true, target, loader });
+
+    expect(html2canvas.mock.calls[0][0]).toBe(target);
+  });
+
+  it('defaults to document.body', async () => {
+    await captureConsentedScreenshot({ consented: true, loader });
+
+    expect(html2canvas.mock.calls[0][0]).toBe(document.body);
+  });
+
+  it('captures only the viewport, not the whole scrollable document', async () => {
+    // The privacy half of the posture: anything the reporter scrolled past is not
+    // drawn. Asserted as literals against a pinned window, not read back from the
+    // call.
+    vi.spyOn(window, 'scrollX', 'get').mockReturnValue(120);
+    vi.spyOn(window, 'scrollY', 'get').mockReturnValue(340);
+    vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(800);
+    vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(600);
+
+    await captureConsentedScreenshot({ consented: true, loader });
+
+    expect(html2canvas.mock.calls[0][1]).toMatchObject({
+      x: 120,
+      y: 340,
+      width: 800,
+      height: 600,
+      allowTaint: false,
+    });
+  });
+
+  it('encodes as JPEG rather than PNG', async () => {
+    await captureConsentedScreenshot({ consented: true, loader });
+
+    expect(toBlob.mock.calls[0][1]).toBe('image/jpeg');
+    expect(toBlob.mock.calls[0][2]).toBe(0.8);
+  });
+});
+
+describe('capture failures are distinguishable from "declined"', () => {
+  it('throws when the canvas will not encode', async () => {
+    html2canvas.mockResolvedValue(makeCanvas(null));
+
+    await expect(captureConsentedScreenshot({ consented: true, loader })).rejects.toThrow(
+      'Could not encode the page capture.'
+    );
+  });
+
+  it('throws ScreenshotTooLargeError past the byte ceiling', async () => {
+    html2canvas.mockResolvedValue(makeCanvas(jpeg(SCREENSHOT_MAX_BYTES + 1)));
+
+    await expect(captureConsentedScreenshot({ consented: true, loader })).rejects.toBeInstanceOf(
+      ScreenshotTooLargeError
+    );
+  });
+
+  it('accepts a capture exactly at the ceiling', async () => {
+    html2canvas.mockResolvedValue(makeCanvas(jpeg(SCREENSHOT_MAX_BYTES)));
+
+    const result = await captureConsentedScreenshot({ consented: true, loader });
+    expect(result).toBeInstanceOf(File);
+  });
+
+  it('propagates an html2canvas rejection rather than returning null', async () => {
+    // Returning null here would be indistinguishable from "no consent" — the one
+    // conflation this module must not make.
+    html2canvas.mockRejectedValue(new Error('render failed'));
+
+    await expect(captureConsentedScreenshot({ consented: true, loader })).rejects.toThrow(
+      'render failed'
+    );
+  });
+
+  it('pins the byte ceiling at 5 MiB', () => {
+    expect(SCREENSHOT_MAX_BYTES).toBe(5 * 1024 * 1024);
+  });
+});

--- a/src/components/Feedback/__tests__/selectAttachments.test.ts
+++ b/src/components/Feedback/__tests__/selectAttachments.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+import { selectAttachments } from '~/components/Feedback/selectAttachments';
+import { constants } from '~/server/common/constants';
+import { FEEDBACK_IMAGE_MAX_COUNT } from '~/shared/constants/feedback.constants';
+
+/**
+ * The two caps on user-chosen attachments: how many, and how big.
+ *
+ * The size cap is the one that was missing. `SCREENSHOT_MAX_BYTES` bounds the capture
+ * this feature GENERATES; nothing bounded the files the user PICKS, so a 40-megapixel
+ * phone photo would upload at full size. There is no server backstop — the presigned
+ * PUT from `/api/v1/image-upload` carries no size condition — so this function is the
+ * only check that exists.
+ *
+ * Sizes are literals in bytes; nothing here is derived from the implementation.
+ */
+const MB = 1024 * 1024;
+const MAX_BYTES = 50 * MB;
+
+const file = (name: string, bytes: number) =>
+  new File([new Uint8Array(bytes)], name, { type: 'image/png' });
+
+const run = (selected: File[], alreadyAttached = 0) =>
+  selectAttachments({
+    selected,
+    alreadyAttached,
+    maxCount: FEEDBACK_IMAGE_MAX_COUNT,
+    maxBytes: MAX_BYTES,
+  });
+
+const names = (files: File[]) => files.map((f) => f.name);
+
+describe('the caps themselves', () => {
+  it('takes the size cap from the shared upload constant nine other surfaces use', () => {
+    // Pinned so the feedback picker cannot quietly diverge from the rest of the app.
+    expect(constants.mediaUpload.maxImageFileSize).toBe(50 * 1024 ** 2);
+    expect(MAX_BYTES).toBe(constants.mediaUpload.maxImageFileSize);
+  });
+
+  it('caps the count at 3', () => {
+    expect(FEEDBACK_IMAGE_MAX_COUNT).toBe(3);
+  });
+});
+
+describe('size cap', () => {
+  it('accepts a file one byte under the limit', () => {
+    const result = run([file('ok.png', MAX_BYTES - 1)]);
+    expect(names(result.accepted)).toEqual(['ok.png']);
+    expect(result.rejectedForSize).toEqual([]);
+  });
+
+  it('accepts a file exactly at the limit', () => {
+    const result = run([file('edge.png', MAX_BYTES)]);
+    expect(names(result.accepted)).toEqual(['edge.png']);
+    expect(result.rejectedForSize).toEqual([]);
+  });
+
+  it('rejects a file one byte over the limit', () => {
+    const result = run([file('huge.png', MAX_BYTES + 1)]);
+    expect(result.accepted).toEqual([]);
+    expect(names(result.rejectedForSize)).toEqual(['huge.png']);
+  });
+
+  it('rejects only the oversized files and keeps the rest', () => {
+    const result = run([file('a.png', 1 * MB), file('huge.png', 60 * MB), file('b.png', 2 * MB)]);
+    expect(names(result.accepted)).toEqual(['a.png', 'b.png']);
+    expect(names(result.rejectedForSize)).toEqual(['huge.png']);
+    expect(result.rejectedForCount).toEqual([]);
+  });
+
+  it('reports every oversized file, not just the first', () => {
+    const result = run([file('h1.png', 60 * MB), file('h2.png', 70 * MB)]);
+    expect(names(result.rejectedForSize)).toEqual(['h1.png', 'h2.png']);
+  });
+});
+
+describe('count cap', () => {
+  it('accepts exactly 3 from an empty draft', () => {
+    const result = run([file('a.png', 1), file('b.png', 1), file('c.png', 1)]);
+    expect(names(result.accepted)).toEqual(['a.png', 'b.png', 'c.png']);
+    expect(result.rejectedForCount).toEqual([]);
+  });
+
+  it('rejects the fourth', () => {
+    const result = run([file('a.png', 1), file('b.png', 1), file('c.png', 1), file('d.png', 1)]);
+    expect(names(result.accepted)).toEqual(['a.png', 'b.png', 'c.png']);
+    expect(names(result.rejectedForCount)).toEqual(['d.png']);
+  });
+
+  it('counts what is already attached', () => {
+    const result = run([file('b.png', 1), file('c.png', 1), file('d.png', 1)], 2);
+    expect(names(result.accepted)).toEqual(['b.png']);
+    expect(names(result.rejectedForCount)).toEqual(['c.png', 'd.png']);
+  });
+
+  it('accepts nothing when the draft is already full', () => {
+    const result = run([file('d.png', 1)], 3);
+    expect(result.accepted).toEqual([]);
+    expect(names(result.rejectedForCount)).toEqual(['d.png']);
+  });
+
+  /**
+   * 🔴 The negative-remaining clamp, with the case that actually discriminates.
+   *
+   * `alreadyAttached` comes from live component state, so `maxCount - alreadyAttached`
+   * can go negative. Without `Math.max(0, …)`, `slice(0, negative)` counts from the
+   * END of the array and ACCEPTS files.
+   *
+   * The first draft of this test used `alreadyAttached: 5` with 2 files — remaining
+   * -2, and `slice(0, -2)` on a 2-element array is `[]`, so it passed WITH the clamp
+   * removed. A mutation run caught that. The discriminating shape is
+   * `|remaining| < selected.length`: at remaining -1 with 3 files, the unclamped
+   * version accepts the first two.
+   */
+  it.each([
+    ['remaining -1, 3 files (the shape that discriminates)', 4, 3],
+    ['remaining -2, 3 files', 5, 3],
+    ['remaining -2, 2 files', 5, 2],
+  ])('accepts nothing on a negative remaining — %s', (_label, alreadyAttached, count) => {
+    const files = Array.from({ length: count }, (_, i) => file(`f${i}.png`, 1));
+
+    const result = run(files, alreadyAttached);
+
+    expect(result.accepted).toEqual([]);
+    expect(names(result.rejectedForCount)).toEqual(names(files));
+  });
+});
+
+describe('the two caps together', () => {
+  it('checks size FIRST, so an oversized file does not consume a slot', () => {
+    // The whole reason for the ordering. With count applied first, the 60MB file
+    // would take a slot and then be discarded, leaving the user with 2 attachments
+    // and no explanation.
+    const result = run([
+      file('huge.png', 60 * MB),
+      file('a.png', 1 * MB),
+      file('b.png', 1 * MB),
+      file('c.png', 1 * MB),
+    ]);
+    expect(names(result.accepted)).toEqual(['a.png', 'b.png', 'c.png']);
+    expect(names(result.rejectedForSize)).toEqual(['huge.png']);
+    expect(result.rejectedForCount).toEqual([]);
+  });
+
+  it('reports both rejection reasons separately when both apply', () => {
+    const result = run([
+      file('huge.png', 60 * MB),
+      file('a.png', 1),
+      file('b.png', 1),
+      file('c.png', 1),
+      file('d.png', 1),
+    ]);
+    expect(names(result.accepted)).toEqual(['a.png', 'b.png', 'c.png']);
+    expect(names(result.rejectedForSize)).toEqual(['huge.png']);
+    expect(names(result.rejectedForCount)).toEqual(['d.png']);
+  });
+
+  it('preserves the picked order in accepted', () => {
+    const result = run([file('z.png', 1), file('a.png', 1)]);
+    expect(names(result.accepted)).toEqual(['z.png', 'a.png']);
+  });
+
+  it('returns three empty lists for an empty selection', () => {
+    expect(run([])).toEqual({ accepted: [], rejectedForSize: [], rejectedForCount: [] });
+  });
+});

--- a/src/components/Feedback/captureScreenshot.render.browser.test.tsx
+++ b/src/components/Feedback/captureScreenshot.render.browser.test.tsx
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { captureConsentedScreenshot } from '~/components/Feedback/captureScreenshot';
+
+/**
+ * 🔴 RENDER SEAM — what html2canvas actually DRAWS, not what options we passed it.
+ *
+ * `captureScreenshot.test.ts` pins the arguments. That is a real guard, and it is not
+ * this one: passing `x: window.scrollY` and passing the RIGHT coordinate space are
+ * different claims, and only one of them is about the picture the user gets. The
+ * `scrollX: 0, scrollY: 0` defect lived exactly in that gap — every argument
+ * assertion was green while the app's sticky header was silently missing from every
+ * capture and the feed content behind it was drawn in its place.
+ *
+ * So this file runs the REAL html2canvas against a REAL scrolled document in real
+ * Chromium and reads pixels out of the produced JPEG.
+ *
+ * 🔴 It carries its own NEGATIVE CONTROL. The first test re-applies the defect
+ * through the same fixture and the same encode path, and requires the OPPOSITE
+ * pixel. Without it, a green in the second test is indistinguishable from a fixture
+ * where the header never landed at that pixel for unrelated reasons — the capture
+ * could be blank, or cropped somewhere else entirely, and the assertion would still
+ * pass. The two arms differ in exactly the two options under test.
+ */
+
+const BAR_HEIGHT = 200;
+const BLUE_TOP = 1000;
+const DOC_HEIGHT = 3000;
+/** Where we sample. Inside the fixed bar when the coordinate space is right. */
+const PROBE = { x: 10, y: 10 };
+
+type Rgb = { r: number; g: number; b: number };
+
+let fixture: HTMLElement[] = [];
+let previousBodyMargin = '';
+
+/**
+ * A scrollable document with two landmarks:
+ *  - a `position: fixed` red bar pinned to the VIEWPORT's top-left, and
+ *  - a blue block at DOCUMENT y 1000..1200.
+ * Scrolled to y=1000, the probe pixel is inside the red bar if fixed elements are
+ * placed correctly, and inside the blue block if they are relocated to document y=0.
+ */
+function buildFixture() {
+  previousBodyMargin = document.body.style.margin;
+  document.body.style.margin = '0';
+
+  const spacer = document.createElement('div');
+  spacer.style.cssText = `height:${DOC_HEIGHT}px;width:100%;background:#ffffff;`;
+
+  const blue = document.createElement('div');
+  blue.style.cssText =
+    `position:absolute;left:0;top:${BLUE_TOP}px;width:100%;height:200px;` +
+    `background:rgb(0,0,255);z-index:1;`;
+
+  const red = document.createElement('div');
+  red.style.cssText =
+    `position:fixed;left:0;top:0;width:100%;height:${BAR_HEIGHT}px;` +
+    // Above everything the test runner itself might paint at the top-left.
+    `background:rgb(255,0,0);z-index:2147483647;`;
+
+  for (const el of [spacer, blue, red]) document.body.appendChild(el);
+  fixture = [spacer, blue, red];
+}
+
+/** Decode a JPEG File and read one pixel. Both arms go through this same path. */
+async function pixelAt(file: Blob, x: number, y: number): Promise<Rgb> {
+  const bitmap = await createImageBitmap(file);
+  const canvas = document.createElement('canvas');
+  canvas.width = bitmap.width;
+  canvas.height = bitmap.height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('no 2d context');
+  ctx.drawImage(bitmap, 0, 0);
+  const [r, g, b] = ctx.getImageData(x, y, 1, 1).data;
+  bitmap.close();
+  return { r, g, b };
+}
+
+const encode = (canvas: HTMLCanvasElement) =>
+  new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => (blob ? resolve(blob) : reject(new Error('encode failed'))),
+      'image/jpeg',
+      0.8
+    );
+  });
+
+// JPEG is lossy, so the assertions are on channel DOMINANCE rather than exact
+// values. The two landmarks are pure red and pure blue precisely so the margin
+// between them is far larger than any compression error.
+const isRed = ({ r, g, b }: Rgb) => r > 180 && g < 90 && b < 90;
+const isBlue = ({ r, g, b }: Rgb) => b > 180 && r < 90 && g < 90;
+
+beforeEach(() => {
+  buildFixture();
+  window.scrollTo(0, BLUE_TOP);
+});
+
+afterEach(() => {
+  for (const el of fixture) el.remove();
+  fixture = [];
+  document.body.style.margin = previousBodyMargin;
+  window.scrollTo(0, 0);
+});
+
+describe('viewport capture places fixed/sticky elements correctly', () => {
+  test('the fixture is genuinely scrolled — otherwise both arms are meaningless', () => {
+    // A document that is not tall enough silently clamps `scrollTo`, and then the
+    // buggy and correct coordinate spaces coincide and nothing below discriminates.
+    expect(window.scrollY).toBe(BLUE_TOP);
+    expect(window.innerHeight).toBeGreaterThan(0);
+    expect(document.documentElement.scrollHeight).toBeGreaterThan(BLUE_TOP + window.innerHeight);
+  });
+
+  test('🔴 NEGATIVE CONTROL — with scrollX/scrollY forced to 0 the fixed bar is LOST', async () => {
+    const html2canvas = (await import('html2canvas')).default;
+    const canvas = await html2canvas(document.body, {
+      logging: false,
+      useCORS: true,
+      allowTaint: false,
+      scale: 1,
+      x: window.scrollX,
+      y: window.scrollY,
+      width: window.innerWidth,
+      height: window.innerHeight,
+      // THE DEFECT, reapplied deliberately. Everything else matches production.
+      scrollX: 0,
+      scrollY: 0,
+      windowWidth: window.innerWidth,
+      windowHeight: window.innerHeight,
+    });
+
+    const pixel = await pixelAt(await encode(canvas), PROBE.x, PROBE.y);
+
+    // The bar is relocated to document y=0, outside the crop, so the probe lands on
+    // the blue block that the bar was covering.
+    expect(isBlue(pixel), `expected blue, got rgb(${pixel.r},${pixel.g},${pixel.b})`).toBe(true);
+    expect(isRed(pixel)).toBe(false);
+  });
+
+  test('🔴 the shipped capture KEEPS the fixed bar the user can see', async () => {
+    const file = await captureConsentedScreenshot({ consented: true });
+    expect(file).toBeInstanceOf(File);
+
+    const pixel = await pixelAt(file!, PROBE.x, PROBE.y);
+
+    expect(isRed(pixel), `expected red, got rgb(${pixel.r},${pixel.g},${pixel.b})`).toBe(true);
+    expect(isBlue(pixel)).toBe(false);
+  });
+
+  test('the capture is the viewport’s size, not the document’s', async () => {
+    const file = await captureConsentedScreenshot({ consented: true });
+    const bitmap = await createImageBitmap(file!);
+
+    expect(bitmap.width).toBe(window.innerWidth);
+    expect(bitmap.height).toBe(window.innerHeight);
+    // The document is 3000px tall; a whole-document capture would be far larger.
+    expect(bitmap.height).toBeLessThan(DOC_HEIGHT);
+    bitmap.close();
+  });
+});

--- a/src/components/Feedback/captureScreenshot.ts
+++ b/src/components/Feedback/captureScreenshot.ts
@@ -1,0 +1,127 @@
+/**
+ * Opt-in DOM capture for the feedback prompt.
+ *
+ * 🔴 PRIVACY POSTURE — OPT-IN WITH PREVIEW. This is a deliberate product decision,
+ * not an implementation detail, and the guard below is the thing that enforces it.
+ * A rendered capture of this site can contain NSFW imagery, another user's private
+ * message content, or moderator-only UI. So:
+ *   1. capture NEVER runs unless the caller passes an explicit consent flag,
+ *   2. the caller shows the result to the user before anything is uploaded, and
+ *   3. only the VIEWPORT is captured — what the reporter can actually see — not
+ *      the whole scrollable document.
+ * Do not "optimise" step 1 away by inferring consent from the presence of a
+ * callback or from the prompt being open. Consent is a value the user set.
+ *
+ * 🔴 `html2canvas` (~200 kB) is reached ONLY through a dynamic `import()`, so it is
+ * code-split out of the main bundle and costs nothing on the ~100% of page loads
+ * that never open the prompt. That property is pinned by the source gate in
+ * `src/server/services/__tests__/no-static-html2canvas-import.test.ts` — a static
+ * `import html2canvas from 'html2canvas'` anywhere under `src/` fails that test.
+ */
+
+/**
+ * The subset of html2canvas's real signature this module uses.
+ *
+ * Written against the published types (`html2canvas(element, options?) =>
+ * Promise<HTMLCanvasElement>`), not against a convenient shape — a loader fake in a
+ * test has to satisfy this, so a fake cannot encode a different contract from the
+ * real dependency without a type error.
+ */
+export type Html2CanvasFn = (
+  element: HTMLElement,
+  options?: Record<string, unknown>
+) => Promise<HTMLCanvasElement>;
+
+export type Html2CanvasLoader = () => Promise<Html2CanvasFn>;
+
+/** JPEG rather than PNG: a full-viewport PNG of an image feed is routinely 10x larger. */
+export const SCREENSHOT_MIME_TYPE = 'image/jpeg';
+export const SCREENSHOT_QUALITY = 0.8;
+export const SCREENSHOT_FILENAME = 'page-capture.jpg';
+
+/**
+ * Hard ceiling on a capture the user did not choose the size of. A viewport JPEG at
+ * quality 0.8 lands far below this; the cap exists so an unusually large viewport
+ * cannot push a multi-megabyte upload through a control the user thinks of as "attach
+ * a screenshot".
+ */
+export const SCREENSHOT_MAX_BYTES = 5 * 1024 * 1024;
+
+const defaultLoader: Html2CanvasLoader = async () =>
+  (await import('html2canvas')).default as unknown as Html2CanvasFn;
+
+export type CaptureScreenshotArgs = {
+  /**
+   * 🔴 THE CONSENT GATE. `true` means the user turned the control on themselves.
+   * Anything else — `false`, `undefined`, a truthy non-boolean — is treated as no
+   * consent and short-circuits before the dependency is even loaded.
+   */
+  consented: boolean;
+  /** Defaults to `document.body`. Only the visible viewport region of it is drawn. */
+  target?: HTMLElement | null;
+  /** Seam for tests; production callers use the dynamic-import default. */
+  loader?: Html2CanvasLoader;
+};
+
+export class ScreenshotTooLargeError extends Error {
+  constructor(public readonly bytes: number) {
+    super(`Screenshot is too large to attach (${bytes} bytes).`);
+    this.name = 'ScreenshotTooLargeError';
+  }
+}
+
+/**
+ * Returns a JPEG `File` of the current viewport, or `null` when there is no consent
+ * or nothing to capture.
+ *
+ * Returns `null` — rather than throwing — for the no-consent case specifically,
+ * because "the user did not ask for a screenshot" is not an error condition. Real
+ * capture failures (a rejected html2canvas, a canvas that will not encode, a
+ * capture over the byte ceiling) DO throw, so the caller can tell "declined" from
+ * "tried and failed" and say so.
+ */
+export async function captureConsentedScreenshot({
+  consented,
+  target,
+  loader = defaultLoader,
+}: CaptureScreenshotArgs): Promise<File | null> {
+  // 🔴 The consent gate. Deliberately `!== true`, not falsy-check: this must not be
+  // satisfiable by any value other than a real boolean true.
+  if (consented !== true) return null;
+
+  if (typeof window === 'undefined' || typeof document === 'undefined') return null;
+  const element = target ?? document.body;
+  if (!element) return null;
+
+  const html2canvas = await loader();
+
+  // Viewport only. `x`/`y` are document coordinates of the current scroll position
+  // and `width`/`height` the visible box, so nothing the reporter has scrolled past
+  // is drawn. `allowTaint` stays false so a cross-origin image without CORS headers
+  // is dropped from the capture rather than tainting the canvas and making
+  // `toBlob` throw.
+  const canvas = await html2canvas(element, {
+    logging: false,
+    useCORS: true,
+    allowTaint: false,
+    // html2canvas's default opaque white is deliberate here: the output is JPEG,
+    // which has no alpha channel, so a transparent canvas would encode as black.
+    scale: 1,
+    x: window.scrollX,
+    y: window.scrollY,
+    width: window.innerWidth,
+    height: window.innerHeight,
+    scrollX: 0,
+    scrollY: 0,
+    windowWidth: window.innerWidth,
+    windowHeight: window.innerHeight,
+  });
+
+  const blob = await new Promise<Blob | null>((resolve) => {
+    canvas.toBlob((result) => resolve(result), SCREENSHOT_MIME_TYPE, SCREENSHOT_QUALITY);
+  });
+  if (!blob) throw new Error('Could not encode the page capture.');
+  if (blob.size > SCREENSHOT_MAX_BYTES) throw new ScreenshotTooLargeError(blob.size);
+
+  return new File([blob], SCREENSHOT_FILENAME, { type: SCREENSHOT_MIME_TYPE });
+}

--- a/src/components/Feedback/captureScreenshot.ts
+++ b/src/components/Feedback/captureScreenshot.ts
@@ -100,6 +100,20 @@ export async function captureConsentedScreenshot({
   // is drawn. `allowTaint` stays false so a cross-origin image without CORS headers
   // is dropped from the capture rather than tainting the canvas and making
   // `toBlob` throw.
+  //
+  // 🔴 DO NOT ADD `scrollX: 0, scrollY: 0`. They look like they belong beside the
+  // `x`/`y` crop and they are actively wrong. html2canvas builds `windowBounds` from
+  // those two options and ADDS it to every cloned element's `getBoundingClientRect()`
+  // to recover document coordinates, while separately scrolling the clone iframe to
+  // the same values. The two cancel for in-flow content — which is why the mistake is
+  // invisible in a static fixture — but NOT for `position: fixed`/`sticky` elements,
+  // whose rect is viewport-relative by definition. Forcing both to 0 places the app's
+  // sticky header at document y=0, outside the `y: window.scrollY` crop: the header
+  // silently vanishes from every capture and the feed content it was covering is
+  // drawn instead. That makes the checkbox's "Only what's on screen is captured"
+  // false in BOTH directions. The defaults (`pageXOffset`/`pageYOffset`) are correct.
+  // Pinned by `omits scrollX/scrollY` in captureScreenshot.test.ts and by the real
+  // render fixture in captureScreenshot.render.browser.test.ts.
   const canvas = await html2canvas(element, {
     logging: false,
     useCORS: true,
@@ -111,8 +125,6 @@ export async function captureConsentedScreenshot({
     y: window.scrollY,
     width: window.innerWidth,
     height: window.innerHeight,
-    scrollX: 0,
-    scrollY: 0,
     windowWidth: window.innerWidth,
     windowHeight: window.innerHeight,
   });

--- a/src/components/Feedback/selectAttachments.ts
+++ b/src/components/Feedback/selectAttachments.ts
@@ -1,0 +1,56 @@
+/**
+ * Which of the files a user just picked may be attached to a feedback report.
+ *
+ * Pure, and separate from the component, for two reasons. It is the only place the
+ * count cap and the size cap are applied, so having one function makes "the rules"
+ * a single object rather than a predicate open-coded across handlers. And it lives
+ * in the `unit` test project, which is the tier that actually gates — a rule pinned
+ * only by a browser-mode component test is a rule nobody's CI reads.
+ */
+export type AttachmentSelection = {
+  /** In picked order, already trimmed to the remaining slots. */
+  accepted: File[];
+  /** Dropped for exceeding `maxBytes`. */
+  rejectedForSize: File[];
+  /** Dropped because the count cap was already reached or would be exceeded. */
+  rejectedForCount: File[];
+};
+
+export type SelectAttachmentsArgs = {
+  selected: File[];
+  /** How many attachments are already on the draft. */
+  alreadyAttached: number;
+  maxCount: number;
+  maxBytes: number;
+};
+
+/**
+ * SIZE IS CHECKED BEFORE COUNT, deliberately. The other order lets one oversized
+ * file consume a slot and then be thrown away, so a user who picks
+ * `[60MB, small, small]` against a 3-slot cap would end up with two attachments and
+ * no way to see why. Filtering by size first means the slots go to files that can
+ * actually be sent.
+ */
+export function selectAttachments({
+  selected,
+  alreadyAttached,
+  maxCount,
+  maxBytes,
+}: SelectAttachmentsArgs): AttachmentSelection {
+  const rejectedForSize: File[] = [];
+  const withinSize: File[] = [];
+  for (const file of selected) {
+    if (file.size > maxBytes) rejectedForSize.push(file);
+    else withinSize.push(file);
+  }
+
+  // `Math.max(0, …)` because `alreadyAttached` is a live count from component state
+  // and a negative remaining would make `slice` count from the end of the array.
+  const remaining = Math.max(0, maxCount - alreadyAttached);
+
+  return {
+    accepted: withinSize.slice(0, remaining),
+    rejectedForSize,
+    rejectedForCount: withinSize.slice(remaining),
+  };
+}

--- a/src/server/routers/__tests__/feedback.router.test.ts
+++ b/src/server/routers/__tests__/feedback.router.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as MiddlewareTrpc from '~/server/middleware.trpc';
+import type * as FeedbackService from '~/server/services/feedback.service';
+import { OnboardingSteps } from '~/server/common/enums';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+import { FEEDBACK_RATE_LIMIT } from '~/shared/constants/feedback.constants';
+
+/**
+ * `feedback.create` — the extended context must survive the ROUTER, and the
+ * per-user quota must stay a quota on SUBMISSIONS.
+ *
+ * The quota point is the one worth stating plainly: a submission can now carry up
+ * to four uploads, so "5 per hour" is only a real bound if attaching images buys no
+ * extra submissions. Nothing about the payload may feed into the limiter — hence
+ * the configuration assertion below rather than a behavioural one. `rateLimit` is a
+ * hard no-op in test/dev/preview by design (`middleware.trpc.ts` returns early for
+ * `isTest`), so a behavioural rate-limit test in this project would pass whether or
+ * not the limiter were wired at all. What IS observable here is the argument the
+ * router hands it, captured at import time.
+ */
+
+const { rateLimitCalls, createFeedbackMock, isFeedbackAreaEnabledMock } = vi.hoisted(() => ({
+  // A plain array, not a spy: `vi.clearAllMocks()` in `beforeEach` would erase a
+  // spy's record of a call that happened once, at module import.
+  rateLimitCalls: [] as unknown[][],
+  createFeedbackMock: vi.fn(),
+  isFeedbackAreaEnabledMock: vi.fn(),
+}));
+
+vi.mock('~/server/middleware.trpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof MiddlewareTrpc>();
+  return {
+    ...actual,
+    rateLimit: (...args: Parameters<typeof actual.rateLimit>) => {
+      rateLimitCalls.push(args);
+      return actual.rateLimit(...args);
+    },
+  };
+});
+
+vi.mock('~/server/services/feedback.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof FeedbackService>()),
+  createFeedback: createFeedbackMock,
+  isFeedbackAreaEnabled: isFeedbackAreaEnabledMock,
+}));
+
+const { feedbackRouter } = await import('~/server/routers/feedback.router');
+
+const USER_ID = 42;
+
+const caller = () =>
+  feedbackRouter.createCaller({
+    user: {
+      id: USER_ID,
+      isModerator: false,
+      muted: false,
+      onboarding: OnboardingSteps.Buzz,
+    },
+    acceptableOrigin: true,
+    // Without a full token scope the procedure throws FORBIDDEN for a SCOPE reason.
+    // That matters: the "disabled area" test below also expects FORBIDDEN, so an
+    // under-specified ctx would make it pass for entirely the wrong reason.
+    tokenScope: TokenScope.Full,
+    features: {},
+  } as never);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  createFeedbackMock.mockResolvedValue({ id: 1 });
+  isFeedbackAreaEnabledMock.mockResolvedValue(true);
+});
+
+const submission = {
+  area: 'bitdex-image-feed' as const,
+  message: 'the feed repeated itself',
+  context: {
+    path: '/images',
+    images: ['cf-1', 'cf-2', 'cf-3'],
+    screenshotId: 'cf-shot',
+    sessionId: 'faro-abc',
+  },
+};
+
+describe('feedback.create — extended context reaches the service', () => {
+  it('forwards images, screenshotId and sessionId with the caller’s user id', async () => {
+    await caller().create(submission);
+
+    expect(createFeedbackMock).toHaveBeenCalledTimes(1);
+    expect(createFeedbackMock.mock.calls[0][0]).toEqual({
+      area: 'bitdex-image-feed',
+      message: 'the feed repeated itself',
+      userId: USER_ID,
+      context: {
+        path: '/images',
+        images: ['cf-1', 'cf-2', 'cf-3'],
+        screenshotId: 'cf-shot',
+        sessionId: 'faro-abc',
+      },
+    });
+  });
+
+  it('rejects a four-image submission at the boundary, before the service is reached', async () => {
+    await expect(
+      caller().create({
+        ...submission,
+        context: { ...submission.context, images: ['a', 'b', 'c', 'd'] },
+      })
+    ).rejects.toThrow();
+    expect(createFeedbackMock).not.toHaveBeenCalled();
+  });
+
+  it('still refuses a disabled area even when uploads are attached', async () => {
+    isFeedbackAreaEnabledMock.mockResolvedValue(false);
+
+    // Matched on the MESSAGE as well as the code: several unrelated middlewares in
+    // this chain (token scope, mute, onboarding) also throw FORBIDDEN, and any of
+    // them would satisfy a code-only assertion while saying nothing about the flag.
+    await expect(caller().create(submission)).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'Feedback is not being collected here right now.',
+    });
+    expect(createFeedbackMock).not.toHaveBeenCalled();
+  });
+
+  it('accepts a submission with no sessionId (Faro absent)', async () => {
+    await caller().create({
+      area: 'bitdex-image-feed',
+      message: 'no faro here',
+      context: { path: '/images', images: ['cf-1'] },
+    });
+
+    expect(createFeedbackMock).toHaveBeenCalledTimes(1);
+    expect(createFeedbackMock.mock.calls[0][0].context).not.toHaveProperty('sessionId');
+  });
+});
+
+describe('feedback.create — the submission quota is not widened by uploads', () => {
+  it('is configured at 5 per hour', () => {
+    expect(FEEDBACK_RATE_LIMIT).toEqual({ max: 5, periodSeconds: 3600 });
+  });
+
+  it('wires exactly those numbers into the router’s rate limiter', () => {
+    expect(rateLimitCalls).toHaveLength(1);
+    const [limits] = rateLimitCalls[0] as [{ limit: number; period: number }];
+    expect(limits.limit).toBe(5);
+    expect(limits.period).toBe(3600);
+  });
+
+  it('takes no condition and no shared key — nothing about the payload can widen it', () => {
+    // `rateLimit(limits, condition?, options?)`: a `condition` returning false SKIPS
+    // the limiter entirely. Passing neither is what makes the quota unconditional,
+    // so a future `condition` that exempted, say, image-free submissions would fail
+    // here rather than silently uncapping the surface.
+    const [, condition, options] = rateLimitCalls[0];
+    expect(condition).toBeUndefined();
+    expect(options).toBeUndefined();
+  });
+
+  it('caps the feedback surface at 20 uploads per hour on the successful path', () => {
+    // 5 submissions x (3 attachments + 1 screenshot). Stated as a derivation so a
+    // change to either constant makes the resulting budget visible in the diff.
+    const perSubmission = 3 + 1;
+    expect(FEEDBACK_RATE_LIMIT.max * perSubmission).toBe(20);
+  });
+});

--- a/src/server/schema/__tests__/feedback.schema.test.ts
+++ b/src/server/schema/__tests__/feedback.schema.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+import { createFeedbackSchema } from '~/server/schema/feedback.schema';
+import {
+  FEEDBACK_IMAGE_ID_MAX_LENGTH,
+  FEEDBACK_IMAGE_MAX_COUNT,
+  FEEDBACK_SESSION_ID_MAX_LENGTH,
+} from '~/shared/constants/feedback.constants';
+
+/**
+ * Boundary contract for `createFeedbackSchema.context` — the three fields added for
+ * image attachments, the Faro session id, and the opt-in DOM capture.
+ *
+ * WHY THIS FILE IS THE LOAD-BEARING ONE. `feedbackContextSchema` is a `z.object`,
+ * and a `z.object` STRIPS keys it does not declare. So a client that sends
+ * `context.images` against a schema that never declared it does not get an error —
+ * it gets a successful submission with the images silently gone. The round-trip
+ * assertions below are what distinguish "declared and carried" from "declared in a
+ * TypeScript type and dropped at the wire".
+ *
+ * Every expectation here is a LITERAL, not a value read back out of the schema. The
+ * constants are asserted against literals too (first block), so widening a bound
+ * shows up as a failing test rather than as a test that quietly follows the change.
+ */
+describe('feedback schema — context bounds', () => {
+  const base = { area: 'bitdex-image-feed' as const, message: 'something looked wrong' };
+  const parse = (context: Record<string, unknown>) =>
+    createFeedbackSchema.parse({ ...base, context });
+  const id = (length: number) => 'a'.repeat(length);
+
+  describe('the bounds themselves', () => {
+    // Pins the numbers this whole file is written against. If one of these moves,
+    // the intent below has to be re-read rather than silently re-derived.
+    it('is 3 images, 100-char ids, 64-char session ids', () => {
+      expect(FEEDBACK_IMAGE_MAX_COUNT).toBe(3);
+      expect(FEEDBACK_IMAGE_ID_MAX_LENGTH).toBe(100);
+      expect(FEEDBACK_SESSION_ID_MAX_LENGTH).toBe(64);
+    });
+  });
+
+  describe('images', () => {
+    it('carries the ids through instead of stripping them', () => {
+      const parsed = parse({ images: ['cf-image-1', 'cf-image-2'] });
+      expect(parsed.context?.images).toEqual(['cf-image-1', 'cf-image-2']);
+    });
+
+    it('accepts exactly 3', () => {
+      const parsed = parse({ images: ['a', 'b', 'c'] });
+      expect(parsed.context?.images).toHaveLength(3);
+    });
+
+    it('rejects 4', () => {
+      expect(() => parse({ images: ['a', 'b', 'c', 'd'] })).toThrow();
+    });
+
+    it('accepts an id of exactly 100 characters', () => {
+      const parsed = parse({ images: [id(100)] });
+      expect(parsed.context?.images?.[0]).toHaveLength(100);
+    });
+
+    it('rejects an id of 101 characters', () => {
+      expect(() => parse({ images: [id(101)] })).toThrow();
+    });
+
+    it('rejects an empty id', () => {
+      expect(() => parse({ images: [''] })).toThrow();
+    });
+
+    it('rejects a whitespace-only id (it trims to empty)', () => {
+      expect(() => parse({ images: ['   '] })).toThrow();
+    });
+
+    it('rejects a non-string id', () => {
+      expect(() => parse({ images: [42] })).toThrow();
+    });
+
+    it('accepts an omitted images field', () => {
+      const parsed = parse({ path: '/images' });
+      expect(parsed.context?.images).toBeUndefined();
+    });
+  });
+
+  describe('screenshotId', () => {
+    it('carries the id through instead of stripping it', () => {
+      const parsed = parse({ screenshotId: 'cf-screenshot-1' });
+      expect(parsed.context?.screenshotId).toBe('cf-screenshot-1');
+    });
+
+    it('accepts exactly 100 characters', () => {
+      const parsed = parse({ screenshotId: id(100) });
+      expect(parsed.context?.screenshotId).toHaveLength(100);
+    });
+
+    it('rejects 101 characters', () => {
+      expect(() => parse({ screenshotId: id(101) })).toThrow();
+    });
+
+    it('rejects an empty id', () => {
+      expect(() => parse({ screenshotId: '' })).toThrow();
+    });
+
+    // Distinct fields, not one array: triage must be able to tell a rendered capture
+    // of the reporter's own screen from a file they picked.
+    it('is separate from images — both can travel on one submission', () => {
+      const parsed = parse({ images: ['attached-1'], screenshotId: 'captured-1' });
+      expect(parsed.context?.images).toEqual(['attached-1']);
+      expect(parsed.context?.screenshotId).toBe('captured-1');
+    });
+  });
+
+  describe('sessionId', () => {
+    it('carries the id through instead of stripping it', () => {
+      const parsed = parse({ sessionId: 'faro-session-abc' });
+      expect(parsed.context?.sessionId).toBe('faro-session-abc');
+    });
+
+    it('accepts exactly 64 characters', () => {
+      const parsed = parse({ sessionId: id(64) });
+      expect(parsed.context?.sessionId).toHaveLength(64);
+    });
+
+    it('rejects 65 characters', () => {
+      expect(() => parse({ sessionId: id(65) })).toThrow();
+    });
+
+    // The dev/test/preview case, and every production session where Faro did not
+    // start. It must parse — a missing session id can never block a submission.
+    it('accepts an omitted sessionId', () => {
+      const parsed = createFeedbackSchema.parse({ ...base, context: { path: '/images' } });
+      expect(parsed.context?.sessionId).toBeUndefined();
+      expect(parsed.message).toBe('something looked wrong');
+    });
+
+    it('accepts a submission with no context at all', () => {
+      const parsed = createFeedbackSchema.parse(base);
+      expect(parsed.context).toBeUndefined();
+    });
+  });
+
+  describe('unknown keys', () => {
+    // This is the behaviour that makes every round-trip assertion above meaningful:
+    // an undeclared key is DROPPED, not rejected, so "the field arrived" is only
+    // ever provable by reading it back.
+    it('are stripped silently rather than rejected', () => {
+      const parsed = parse({ images: ['a'], notAField: 'x' } as Record<string, unknown>);
+      expect(parsed.context).not.toHaveProperty('notAField');
+      expect(parsed.context?.images).toEqual(['a']);
+    });
+  });
+
+  describe('pre-existing context fields (invariant guard — not regression coverage)', () => {
+    // These already passed before this change. They are here so a future edit to the
+    // context schema cannot drop them while the new fields keep the file green.
+    it('still carries path, reportedSource, pagesLoaded and filters', () => {
+      const parsed = parse({
+        path: '/images',
+        reportedSource: 'bitdex',
+        reportedPageSources: ['bitdex', 'meili'],
+        pagesLoaded: 3,
+        filters: { sort: 'Newest', period: 'Day' },
+      });
+      expect(parsed.context?.path).toBe('/images');
+      expect(parsed.context?.reportedSource).toBe('bitdex');
+      expect(parsed.context?.pagesLoaded).toBe(3);
+      expect(parsed.context?.filters).toEqual({ sort: 'Newest', period: 'Day' });
+    });
+
+    it('still rejects a message past 2000 characters', () => {
+      expect(() => createFeedbackSchema.parse({ ...base, message: 'x'.repeat(2001) })).toThrow();
+    });
+  });
+});

--- a/src/server/schema/feedback.schema.ts
+++ b/src/server/schema/feedback.schema.ts
@@ -1,11 +1,26 @@
 import * as z from 'zod';
-import { FEEDBACK_AREAS, FEEDBACK_MESSAGE_MAX_LENGTH } from '~/shared/constants/feedback.constants';
+import {
+  FEEDBACK_AREAS,
+  FEEDBACK_IMAGE_ID_MAX_LENGTH,
+  FEEDBACK_IMAGE_MAX_COUNT,
+  FEEDBACK_MESSAGE_MAX_LENGTH,
+  FEEDBACK_SESSION_ID_MAX_LENGTH,
+} from '~/shared/constants/feedback.constants';
 
 export const feedbackAreaSchema = z.enum(FEEDBACK_AREAS);
 
 // Everything here is client-supplied and therefore a claim, not evidence — the
 // submit request cannot re-derive which backend served the page the user was
 // looking at. Stored to make a one-line report actionable, never read as proof.
+//
+// The same reading applies to the three fields added for images / session / DOM
+// capture. `images` and `screenshotId` are ids the CLIENT says it uploaded: this
+// request never proves the objects exist, that they belong to this user, or that
+// the screenshot is of the page named in `path`. `sessionId` is whatever the
+// browser's Faro instance reported, and is absent whenever Faro is not running
+// (dev, test, preview, an ad-blocked or opted-out session) — absence is the
+// ordinary case, not an error. Every one of them is bounded because a JSONB
+// column will store exactly what it is handed.
 const feedbackContextSchema = z.object({
   path: z.string().max(300).optional(),
   reportedSource: z.string().max(50).optional(),
@@ -15,6 +30,19 @@ const feedbackContextSchema = z.object({
     .record(z.string().max(50), z.union([z.string().max(200), z.number(), z.boolean()]))
     .refine((val) => Object.keys(val).length <= 20, 'Too many filter keys')
     .optional(),
+  /** Cloudflare image ids for files the user attached by hand. */
+  images: z
+    .array(z.string().trim().min(1).max(FEEDBACK_IMAGE_ID_MAX_LENGTH))
+    .max(FEEDBACK_IMAGE_MAX_COUNT)
+    .optional(),
+  /**
+   * Cloudflare image id of the opt-in page capture. Kept separate from `images`
+   * so triage can tell a rendered screenshot of the reporter's own screen from a
+   * file they chose to send — the two carry different privacy weight.
+   */
+  screenshotId: z.string().trim().min(1).max(FEEDBACK_IMAGE_ID_MAX_LENGTH).optional(),
+  /** Grafana Faro session id, to join a report to that session's RUM signals. */
+  sessionId: z.string().trim().min(1).max(FEEDBACK_SESSION_ID_MAX_LENGTH).optional(),
 });
 
 export type CreateFeedbackInput = z.infer<typeof createFeedbackSchema>;

--- a/src/server/services/__tests__/feedback.service.test.ts
+++ b/src/server/services/__tests__/feedback.service.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createFeedbackSchema } from '~/server/schema/feedback.schema';
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    feedbackCreate: vi.fn(),
+    isFlipt: vi.fn(),
+  },
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: {},
+  dbWrite: { feedback: { create: mocks.feedbackCreate } },
+}));
+
+vi.mock('~/server/flipt/client', () => ({ isFlipt: mocks.isFlipt }));
+
+const { createFeedback, isFeedbackAreaEnabled } = await import('../feedback.service');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.feedbackCreate.mockResolvedValue({ id: 1 });
+  mocks.isFlipt.mockResolvedValue(true);
+});
+
+/** What the write layer was actually handed, read off the real call. */
+const writtenContext = () => mocks.feedbackCreate.mock.calls[0][0].data.context;
+
+/**
+ * `createFeedback` persistence for the extended context.
+ *
+ * The point of asserting on `dbWrite.feedback.create`'s argument rather than on the
+ * function's return value: the return is `{ id }` and says nothing about what was
+ * stored. A context field can be accepted by the schema, typed in the DTO, and still
+ * never reach the column — that is the failure this file exists to catch, and it is
+ * invisible from the outside.
+ */
+describe('createFeedback — extended context', () => {
+  const args = {
+    userId: 7,
+    area: 'bitdex-image-feed' as const,
+    message: 'the feed repeated itself',
+  };
+
+  it('writes attached image ids into the stored context', async () => {
+    await createFeedback({ ...args, context: { images: ['cf-1', 'cf-2'] } });
+    expect(writtenContext()).toEqual({ images: ['cf-1', 'cf-2'] });
+  });
+
+  it('writes the screenshot id into the stored context', async () => {
+    await createFeedback({ ...args, context: { screenshotId: 'cf-shot' } });
+    expect(writtenContext()).toEqual({ screenshotId: 'cf-shot' });
+  });
+
+  it('writes the Faro session id into the stored context', async () => {
+    await createFeedback({ ...args, context: { sessionId: 'faro-abc' } });
+    expect(writtenContext()).toEqual({ sessionId: 'faro-abc' });
+  });
+
+  it('writes all three alongside the pre-existing fields', async () => {
+    await createFeedback({
+      ...args,
+      context: {
+        path: '/images',
+        reportedSource: 'bitdex',
+        images: ['cf-1'],
+        screenshotId: 'cf-shot',
+        sessionId: 'faro-abc',
+      },
+    });
+    expect(writtenContext()).toEqual({
+      path: '/images',
+      reportedSource: 'bitdex',
+      images: ['cf-1'],
+      screenshotId: 'cf-shot',
+      sessionId: 'faro-abc',
+    });
+    expect(mocks.feedbackCreate.mock.calls[0][0].data.userId).toBe(7);
+    expect(mocks.feedbackCreate.mock.calls[0][0].data.area).toBe('bitdex-image-feed');
+  });
+
+  /**
+   * THE SEAM. The two halves above are each hermetic — the schema test proves the
+   * boundary keeps the fields, this file proves the service writes whatever it is
+   * handed — and both would stay green if the schema stripped a field the service
+   * happily forwards. Parsing first is what makes them meet.
+   */
+  it('persists what the BOUNDARY SCHEMA produced, not what the caller typed', async () => {
+    const parsed = createFeedbackSchema.parse({
+      area: 'bitdex-image-feed',
+      message: 'the feed repeated itself',
+      context: {
+        path: '/images',
+        images: ['cf-1', 'cf-2'],
+        screenshotId: 'cf-shot',
+        sessionId: 'faro-abc',
+      },
+    });
+    await createFeedback({ ...parsed, userId: 7 });
+    expect(writtenContext()).toEqual({
+      path: '/images',
+      images: ['cf-1', 'cf-2'],
+      screenshotId: 'cf-shot',
+      sessionId: 'faro-abc',
+    });
+  });
+
+  // Faro absent (dev/test/preview, or a blocked SDK) is the ordinary case: the
+  // submission must be written with no sessionId rather than failing.
+  it('writes a submission that carries no sessionId', async () => {
+    await createFeedback({ ...args, context: { images: ['cf-1'] } });
+    expect(writtenContext()).not.toHaveProperty('sessionId');
+    expect(writtenContext()).toEqual({ images: ['cf-1'] });
+  });
+
+  it('writes an empty object when there is no context at all (invariant guard)', async () => {
+    await createFeedback(args);
+    expect(writtenContext()).toEqual({});
+  });
+});
+
+describe('isFeedbackAreaEnabled (invariant guard — unchanged by this work)', () => {
+  it('asks Flipt for the area flag keyed on the user id', async () => {
+    await isFeedbackAreaEnabled({ area: 'bitdex-image-feed', userId: 7 });
+    expect(mocks.isFlipt).toHaveBeenCalledWith('feedback-area-bitdex-image-feed', '7');
+  });
+
+  it('falls back to the anonymous entity id', async () => {
+    await isFeedbackAreaEnabled({ area: 'bitdex-image-feed' });
+    expect(mocks.isFlipt).toHaveBeenCalledWith('feedback-area-bitdex-image-feed', 'anonymous');
+  });
+});

--- a/src/server/services/__tests__/no-static-html2canvas-import.test.ts
+++ b/src/server/services/__tests__/no-static-html2canvas-import.test.ts
@@ -120,13 +120,37 @@ describe(`🔴 ${DEPENDENCY} is code-split out of the main bundle`, () => {
   it('is still reached dynamically — the gate is not passing because the dependency vanished', () => {
     // Without this, deleting the feature would leave the file above green forever
     // while claiming to protect a split that no longer exists.
-    const dynamicUsers = files.filter((file) =>
-      dynamicReference.test(stripComments(readFileSync(file, 'utf8')))
-    );
+    //
+    // An EXACT set, not a `toContain`. Both entries are deliberate and each has a
+    // different reason to exist, so a third one should have to be justified:
+    //   - captureScreenshot.ts — the production lazy load. This is the one the split
+    //     is about.
+    //   - captureScreenshot.render.browser.test.ts(x) — the render-seam test's
+    //     NEGATIVE CONTROL, which drives html2canvas directly with the historical
+    //     `scrollX/scrollY: 0` defect to prove the fixture discriminates. Test files
+    //     are not in the app bundle, so this costs a user nothing; it is listed
+    //     rather than filtered out so the set stays honest about what the scan saw.
+    const dynamicUsers = files
+      .filter((file) => dynamicReference.test(stripComments(readFileSync(file, 'utf8'))))
+      .map((f) => path.relative(SRC, f))
+      .sort();
 
-    expect(dynamicUsers.map((f) => path.relative(SRC, f))).toEqual([
-      path.join('components', 'Feedback', 'captureScreenshot.ts'),
-    ]);
+    expect(dynamicUsers).toEqual(
+      [
+        path.join('components', 'Feedback', 'captureScreenshot.render.browser.test.tsx'),
+        path.join('components', 'Feedback', 'captureScreenshot.ts'),
+      ].sort()
+    );
+  });
+
+  it('the PRODUCTION module is one of them (not just the test)', () => {
+    // Guards the set above from being "satisfied" by test files alone if the
+    // production lazy load were ever deleted or made static.
+    const production = path.join(SRC, 'components', 'Feedback', 'captureScreenshot.ts');
+    const source = stripComments(readFileSync(production, 'utf8'));
+
+    expect(dynamicReference.test(source)).toBe(true);
+    expect(staticReference.test(source)).toBe(false);
   });
 });
 

--- a/src/server/services/__tests__/no-static-html2canvas-import.test.ts
+++ b/src/server/services/__tests__/no-static-html2canvas-import.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'fs';
+import path from 'path';
+
+/**
+ * 🔴 SOURCE GATE — `html2canvas` may only be reached through a dynamic `import()`.
+ *
+ * WHY. html2canvas is ~200 kB and exists for one control on one prompt: the opt-in
+ * page capture in `src/components/Feedback/captureScreenshot.ts`. Behind a dynamic
+ * `import()` the bundler code-splits it into its own chunk, so the ~100% of page
+ * loads that never open the feedback prompt never download it. A single static
+ * `import html2canvas from 'html2canvas'` anywhere in the app graph collapses that
+ * — the chunk merges back into whatever entry reaches it — and NOTHING else in the
+ * repo would notice: the feature still works, the tests still pass, and the cost
+ * lands on every visitor.
+ *
+ * WHY A SOURCE GATE RATHER THAN A BUNDLE ASSERTION. Measuring the emitted chunks
+ * needs a full `next build` (many minutes, and it does not run in the `unit`
+ * project). This reads the property that CAUSES the split, deterministically, in
+ * the tier that actually gates. It is a claim about the import form, not about the
+ * byte count — see the scope note at the end.
+ */
+
+const SRC = path.resolve(__dirname, '../../../../src');
+const DEPENDENCY = 'html2canvas';
+
+const CODE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mts', '.cts']);
+const SKIP_DIRS = new Set(['node_modules', '__screenshots__']);
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) walk(full, out);
+    else if (CODE_EXTENSIONS.has(path.extname(entry))) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Strip comments before matching. This very file, and the header of
+ * `captureScreenshot.ts`, both write the forbidden form out in prose; an unstripped
+ * scan would find the counter-example in a comment and fail on documentation.
+ */
+const stripComments = (s: string) =>
+  s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '');
+
+/**
+ * A STATIC reference: an ESM `import ... from 'html2canvas'`, a bare side-effect
+ * `import 'html2canvas'`, an `export ... from 'html2canvas'`, or a CommonJS
+ * `require('html2canvas')`. A dynamic `import('html2canvas')` is deliberately NOT
+ * matched — the `import` keyword there is followed by `(`, not by a specifier list
+ * or a quote.
+ */
+const staticReference = new RegExp(
+  String.raw`(?:^|[\s;}])(?:import|export)\s+(?:[^'"();]*?\sfrom\s+)?['"]${DEPENDENCY}['"]` +
+    String.raw`|require\(\s*['"]${DEPENDENCY}['"]\s*\)`,
+  'm'
+);
+
+const dynamicReference = new RegExp(String.raw`import\(\s*['"]${DEPENDENCY}['"]\s*\)`);
+
+const files = walk(SRC);
+
+describe(`🔴 ${DEPENDENCY} is code-split out of the main bundle`, () => {
+  it('the scan actually reached the source tree', () => {
+    // A broken walker returning [] would make every assertion below vacuously green.
+    // 1000 is far under the real count and far over anything a broken glob returns.
+    expect(files.length).toBeGreaterThan(1000);
+  });
+
+  /**
+   * 🔴 Every fixture below INTERPOLATES `DEPENDENCY` rather than spelling it. The
+   * scan runs over `src/` and this file lives in `src/`, so a literal
+   * `import x from 'html2canvas'` written here as a control would be found by the
+   * scan and reported as a real offender. Interpolating keeps the file honest
+   * without an exclusion list — and an exclusion list is exactly where a genuine
+   * offender would eventually hide.
+   */
+  describe('positive controls — the matcher can see what it is looking for', () => {
+    it.each([
+      [`import h from '${DEPENDENCY}';`],
+      [`import h from "${DEPENDENCY}";`],
+      [`import '${DEPENDENCY}';`],
+      [`import { foo } from '${DEPENDENCY}';`],
+      [`export { default } from '${DEPENDENCY}';`],
+      [`const h = require('${DEPENDENCY}');`],
+      [`import type H from '${DEPENDENCY}';`],
+    ])('flags %s', (source) => {
+      expect(staticReference.test(source)).toBe(true);
+    });
+
+    it.each([
+      [`const h = await import('${DEPENDENCY}');`],
+      [`(await import("${DEPENDENCY}")).default;`],
+    ])('does NOT flag the dynamic form %s', (source) => {
+      expect(staticReference.test(source)).toBe(false);
+      expect(dynamicReference.test(source)).toBe(true);
+    });
+
+    it('the comment stripper leaves real code intact', () => {
+      const commented = `// import h from '${DEPENDENCY}';`;
+      expect(stripComments(`${commented}\nconst a = 1;`)).toContain('const a = 1;');
+      expect(staticReference.test(stripComments(commented))).toBe(false);
+    });
+  });
+
+  it('no file under src/ imports it statically', () => {
+    const offenders = files.filter((file) =>
+      staticReference.test(stripComments(readFileSync(file, 'utf8')))
+    );
+
+    expect(
+      offenders.map((f) => path.relative(SRC, f)),
+      `A static import of ${DEPENDENCY} merges its ~200 kB back into the importing entry. ` +
+        `Reach it through 'await import()' instead — see src/components/Feedback/captureScreenshot.ts.`
+    ).toEqual([]);
+  });
+
+  it('is still reached dynamically — the gate is not passing because the dependency vanished', () => {
+    // Without this, deleting the feature would leave the file above green forever
+    // while claiming to protect a split that no longer exists.
+    const dynamicUsers = files.filter((file) =>
+      dynamicReference.test(stripComments(readFileSync(file, 'utf8')))
+    );
+
+    expect(dynamicUsers.map((f) => path.relative(SRC, f))).toEqual([
+      path.join('components', 'Feedback', 'captureScreenshot.ts'),
+    ]);
+  });
+});
+
+/**
+ * 🔴 SCOPE, stated honestly. This proves the import FORM across `src/`. It does not
+ * measure emitted chunk sizes, and it does not see a static import introduced from
+ * `packages/`, `apps/`, or a transitive dependency that happens to bundle
+ * html2canvas itself. Those are different failure modes and would need a real build
+ * to catch.
+ */

--- a/src/shared/constants/feedback.constants.ts
+++ b/src/shared/constants/feedback.constants.ts
@@ -8,4 +8,30 @@ export const FEEDBACK_MESSAGE_MAX_LENGTH = 2000;
 
 export const FEEDBACK_RATE_LIMIT = { max: 5, periodSeconds: 60 * 60 };
 
+/**
+ * Attachments a single submission may carry, and the length of one stored id.
+ *
+ * Both are storage bounds first: `context` is a JSONB column and every value in it
+ * is client-supplied, so an unbounded array or an unbounded string is a write-amp
+ * vector regardless of what the UI does. The UI cap is a convenience on top.
+ *
+ * UPLOAD BUDGET. The prompt uploads nothing until Send is pressed, so the feedback
+ * surface can mint at most `FEEDBACK_IMAGE_MAX_COUNT + 1` Cloudflare uploads per
+ * submit attempt (attachments plus the opt-in screenshot), and a user who stays
+ * inside the 5-per-hour submit limit tops out at
+ * `FEEDBACK_RATE_LIMIT.max * (FEEDBACK_IMAGE_MAX_COUNT + 1)` = 20 uploads/hour.
+ * That is a bound on the SUCCESSFUL path only: the rate limiter runs on the tRPC
+ * mutation, which is after the uploads, so a user who keeps re-pressing Send past
+ * the limit still spends uploads. `/api/v1/image-upload` carries no quota of its
+ * own today (any signed-in user can already mint upload URLs from anywhere in the
+ * app), so closing that is a change to that endpoint, not to this constant.
+ */
+export const FEEDBACK_IMAGE_MAX_COUNT = 3;
+
+/** Cloudflare image ids written here are `randomUUID()` (36 chars); this is headroom, not a fit. */
+export const FEEDBACK_IMAGE_ID_MAX_LENGTH = 100;
+
+/** Faro session ids are short opaque strings; bounded because it is still client-supplied. */
+export const FEEDBACK_SESSION_ID_MAX_LENGTH = 64;
+
 export const feedbackAreaFlagKey = (area: FeedbackArea) => `feedback-area-${area}`;

--- a/src/utils/faro/__tests__/getFaroSessionId.test.ts
+++ b/src/utils/faro/__tests__/getFaroSessionId.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { FEEDBACK_SESSION_ID_MAX_LENGTH } from '~/shared/constants/feedback.constants';
+
+/**
+ * `getFaroSessionId` — reading the RUM session id, with ABSENCE as a first-class case.
+ *
+ * `FaroProvider` only calls `initializeFaro` when the build-arg, the collector URL
+ * and the `faro` feature flag all agree, so Faro is NOT running in dev, test or
+ * preview, and in production it is still absent for any session that blocked or
+ * did not sample the SDK. Until then the SDK's `faro` export is a bare `{}`.
+ *
+ * The uninitialised shapes below are modelled on that: `{}` (never initialised),
+ * `{ api: {} }` (partially wired), and an `api.getSession()` that returns
+ * `undefined` (running, no session). None of them may throw, because the caller is
+ * a submit handler and a throw there would make feedback unsubmittable on every
+ * non-production build.
+ */
+
+const { faro } = vi.hoisted(() => ({ faro: {} as Record<string, unknown> }));
+
+vi.mock('@grafana/faro-web-sdk', () => ({ faro }));
+
+const { getFaroSessionId } = await import('~/utils/faro/getFaroSessionId');
+
+/** Replace the mocked module's `faro` object in place — the import is a live binding. */
+const setFaro = (value: Record<string, unknown>) => {
+  for (const key of Object.keys(faro)) delete faro[key];
+  Object.assign(faro, value);
+};
+
+const withSession = (session: unknown) => setFaro({ api: { getSession: () => session } });
+
+beforeEach(() => setFaro({}));
+
+describe('Faro is running', () => {
+  it('returns the session id', () => {
+    withSession({ id: 'sess-abc123' });
+    expect(getFaroSessionId()).toBe('sess-abc123');
+  });
+
+  it('trims surrounding whitespace', () => {
+    withSession({ id: '  sess-abc123  ' });
+    expect(getFaroSessionId()).toBe('sess-abc123');
+  });
+
+  it('truncates an over-long id to the boundary schema’s bound rather than failing', () => {
+    withSession({ id: 'x'.repeat(FEEDBACK_SESSION_ID_MAX_LENGTH + 50) });
+    const id = getFaroSessionId();
+    expect(id).toHaveLength(64);
+    expect(FEEDBACK_SESSION_ID_MAX_LENGTH).toBe(64);
+  });
+});
+
+describe('🔴 Faro is absent — the ordinary dev/test/preview case', () => {
+  it('returns undefined when the SDK was never initialised', () => {
+    setFaro({});
+    expect(getFaroSessionId()).toBeUndefined();
+  });
+
+  it('returns undefined when `api` exists but has no getSession', () => {
+    setFaro({ api: {} });
+    expect(getFaroSessionId()).toBeUndefined();
+  });
+
+  it('returns undefined when there is no active session', () => {
+    withSession(undefined);
+    expect(getFaroSessionId()).toBeUndefined();
+  });
+
+  it('returns undefined when the session carries no id', () => {
+    withSession({});
+    expect(getFaroSessionId()).toBeUndefined();
+  });
+
+  it('returns undefined for a non-string id', () => {
+    withSession({ id: 12345 });
+    expect(getFaroSessionId()).toBeUndefined();
+  });
+
+  it('returns undefined for a whitespace-only id', () => {
+    withSession({ id: '   ' });
+    expect(getFaroSessionId()).toBeUndefined();
+  });
+
+  it('does not throw when getSession itself throws', () => {
+    setFaro({
+      api: {
+        getSession: () => {
+          throw new Error('faro is paused');
+        },
+      },
+    });
+    expect(() => getFaroSessionId()).not.toThrow();
+    expect(getFaroSessionId()).toBeUndefined();
+  });
+});

--- a/src/utils/faro/getFaroSessionId.ts
+++ b/src/utils/faro/getFaroSessionId.ts
@@ -1,0 +1,35 @@
+import { faro } from '@grafana/faro-web-sdk';
+import { FEEDBACK_SESSION_ID_MAX_LENGTH } from '~/shared/constants/feedback.constants';
+
+/**
+ * The current Grafana Faro session id, or `undefined`.
+ *
+ * 🔴 ABSENCE IS THE ORDINARY CASE, NOT AN ERROR. `FaroProvider` only calls
+ * `initializeFaro` when the build-arg, the collector URL and the `faro` feature
+ * flag all agree, so Faro is NOT running in dev, test or preview, and in
+ * production it is still absent for anyone whose session was not sampled or whose
+ * browser blocked the SDK. Until `initializeFaro` runs, the SDK's `faro` export is
+ * a bare `{}` — `faro.api` is `undefined` — which is why every hop below is
+ * optional-chained rather than guarded by an "is Faro up?" flag.
+ *
+ * This returns a value; it never throws. A caller that treats a missing session id
+ * as a failure would make feedback unsubmittable on every non-production build,
+ * which is the exact bug this shape exists to prevent.
+ *
+ * The result is truncated to the boundary schema's own bound. The truncation is a
+ * belt-and-braces measure and should never fire: a Faro session id is a short
+ * opaque string. It is here so a future SDK that lengthens the id degrades to a
+ * clipped id instead of a rejected submission.
+ */
+export function getFaroSessionId(): string | undefined {
+  try {
+    const id = faro?.api?.getSession?.()?.id;
+    if (typeof id !== 'string') return undefined;
+    const trimmed = id.trim();
+    if (!trimmed) return undefined;
+    return trimmed.slice(0, FEEDBACK_SESSION_ID_MAX_LENGTH);
+  } catch {
+    // A partially-initialised or paused SDK is still "no session id", not a crash.
+    return undefined;
+  }
+}


### PR DESCRIPTION
Extends the feedback system from #3901 with the three gaps: image attachments, the RUM session id, and DOM auto-capture. All three ride in the existing `context` JSONB column — **no migration**, and none is needed.

ClickUp: `868krm9cn`

---

## 1. Images

A file picker feeds the existing `useCFImageUpload` hook; the Cloudflare image ids land in `context.images`.

**Upload budget** (`FEEDBACK_IMAGE_MAX_COUNT` carries the reasoning):
- Nothing is uploaded on attach — previews come from a local object URL, and the CF upload happens on **Send**. So an abandoned submission costs zero uploads.
- Bound: 3 attachments + 1 screenshot per submission × the existing 5/hour submit limit = **20 uploads/hour** on the successful path.
- Stated honestly in the constant's comment: that is a bound on the *successful* path. The rate limiter runs on the tRPC mutation, i.e. **after** the uploads, so a user who keeps re-pressing Send past the limit still spends uploads. `/api/v1/image-upload` carries no quota of its own today — any signed-in user can already mint upload URLs from anywhere in the app — so closing that is a change to *that endpoint*, deliberately not in this PR.

## 2. Session id

`faro.api.getSession()?.id` → `context.sessionId`, so a one-line report can be joined to that browser session's RUM signals.

🔴 **Absence is a first-class case, not an exception.** `FaroProvider` only initialises Faro when the build-arg, the collector URL and the `faro` flag all agree, so it is **not running in dev/test/preview**, and in production it is still absent for any session that blocked or did not sample the SDK. Until `initializeFaro` runs, the SDK's `faro` export is a bare `{}`. `getFaroSessionId()` returns a value and never throws; the field is omitted and the submission succeeds. Nine of its ten tests cover absence shapes.

No bundle cost: `@grafana/faro-web-sdk` is already in the shared graph via `_app.tsx` → `FaroProvider`.

## 3. DOM capture — opt-in with preview

**Posture, and why it is a product decision rather than an implementation detail:** a rendered capture of this site can contain NSFW imagery, another user's private message content in a DM, or moderator-only UI. Silent capture is a retention and compliance question. So:

- an explicit checkbox, **OFF by default**;
- the user **sees the capture before anything is uploaded** and can drop it;
- only the **viewport** is drawn — not the whole scrollable document — so anything they scrolled past is never captured;
  <br>⚠️ **This sentence was FALSE for `position: fixed`/`sticky` content until `7cb18983fa`** — a `scrollX: 0, scrollY: 0` option dropped the app's sticky header from every capture and drew the feed behind it. Fixed, and pinned by a real-render test with a control arm. Full write-up in [this PR comment](https://github.com/civitai/civitai/pull/3944#issuecomment-5300603878); the claim is accurate as written now.
- `allowTaint: false`, so a cross-origin image without CORS headers is dropped from the capture rather than tainting the canvas.

`html2canvas` (~200 kB) is reached **only** through a dynamic `import()`, so it costs nothing on the ~100% of page loads that never open the prompt.

### Bundle impact — measured

Controlled A/B through esbuild 0.25.8 (the bundler already in this repo's Vite toolchain), same entry, `--bundle --splitting --format=esm --minify`:

| | entry chunk | html2canvas |
|---|---|---|
| dynamic `import()` (this PR) | **122 B** | separate 204,242 B chunk, loaded on demand |
| static `import` (control) | **204,795 B** | merged into the entry |

Raw dep: 198,689 B minified / 45,896 B gzipped.

Scope, honestly: that is an **esbuild** measurement, not a `next build` one. I did not run a full production build. The durable protection is the source gate `src/server/services/__tests__/no-static-html2canvas-import.test.ts`, which fails if any file under `src/` imports html2canvas statically — it runs in the `unit` project, the tier that actually gates.

---

## Bounds (all client-supplied, all bounded)

| field | bound |
|---|---|
| `context.images` | 3 ids, 1–100 chars each, non-empty after trim |
| `context.screenshotId` | 1 id, 1–100 chars |
| `context.sessionId` | 1–64 chars |

Kept in keeping with the schema's existing header — client-supplied context is *a claim, not evidence* — and because a JSONB column stores exactly what it is handed. `screenshotId` is deliberately a **separate field** from `images`: triage needs to tell a rendered capture of the reporter's own screen from a file they chose to send, because the two carry different privacy weight.

## Tests — 126 new (103 unit, 23 component), from zero

There was **no feedback test coverage anywhere in the repo** before this.

| file | tests | project |
|---|---|---|
| `feedback.schema.test.ts` | 23 | unit |
| `feedback.service.test.ts` | 10 | unit |
| `feedback.router.test.ts` | 8 | unit |
| `captureScreenshot.test.ts` | 21 | unit |
| `getFaroSessionId.test.ts` | 10 | unit |
| `no-static-html2canvas-import.test.ts` | 14 | unit |
| `FeedbackPrompt.browser.test.tsx` | 19 | component (real Chromium) |
| `selectAttachments.test.ts` | 18 | unit |
| `captureScreenshot.render.browser.test.tsx` | 4 | component (real Chromium) |

**Red-at-`origin/main` / green-at-HEAD** — measured, not asserted. A baseline worktree at `origin/main` carrying only the new *modules* (constants, `captureScreenshot.ts`, `getFaroSessionId.ts`) plus the test files, so failures are behavioural rather than missing-import:

- schema: **17 of 23 red** at main (the round-trip and bound assertions; `z.object` silently strips undeclared keys, which is the exact bug shape)
- service: **1 of 10 red** — the boundary→service **seam** test. The direct forwarding tests pass at main because the service forwards whatever it is handed; they are labelled **invariant guards**, not regression coverage.
- router: **2 of 7 red**. The rate-limit configuration tests pass at main and are labelled invariant guards.
- component: **11 of 14 red**
- bundle gate against *pure* `origin/main`: **1 of 13 red**
- `captureScreenshot` / `getFaroSessionId`: new modules, so no meaningful main baseline — teeth proven by mutation instead (below).

**Mutation-tested, each killed by its own guard's message:**

| mutation | result |
|---|---|
| A: delete `if (consented !== true) return null` | **9 red**, message `expected "vi.fn()" to not be called at all, but actually been called 1 times` — i.e. the loader observable, not a neighbouring error |
| B: weaken it to `if (!consented)` | **3 red** — exactly the `'true'` / `1` / `{}` cases, proving the strictness is load-bearing |
| C: pass `consented: true` at the component call site | **survived — and the mutant is INVALID, not a survival**: the `!checked` branch has already returned there, so it is semantically equivalent. Recorded rather than hidden, and the code comment now says so instead of overclaiming. |
| C′: capture on prompt-open with no consent | **11 red**, including all three "no consent" tests that were vacuous at the main baseline |
| D: drop the schema's image-count cap | 1 red (`rejects 4`) |
| G: remove `getFaroSessionId`'s try/catch | 1 red (`does not throw when getSession itself throws`) |
| H: plant a real static `import html2canvas` | 1 red — the bundle gate's negative control |

**Reachability:** the consent check is the first statement in `captureConsentedScreenshot`; nothing precedes it, and `short-circuits BEFORE touching the DOM` pins that order.

**Real-dependency dogfood:** the browser test does **not** stub `captureConsentedScreenshot` — it delegates to the real implementation and swaps only the html2canvas *loader*, so the consent guard executes for real on every click. Separately, a throwaway browser spec (not committed) drove the **real** html2canvas against a live DOM in Chromium and produced a genuine 4,544-byte JPEG — so the options and the `toBlob` encode path are measured, not inferred.

## Verification

- `pnpm run typecheck`: **9 errors, byte-identical to `origin/main`** (all in `placement-escrow.service.ts` and `packages/civitai-telemetry`, unrelated). Instrument validated: it caught a real `TS2367` in my own code earlier in this branch.
- `prettier --list-different` on all 13 changed files: clean. Positive control observed — it flagged 3 files before they were formatted.
- `eslint` on all changed files: **0 errors, 0 warnings**.
- `pnpm install --frozen-lockfile`: resolves (`rc=0`). Lockfile change is purely additive: html2canvas + 4 transitive deps.

## Not covered

- No in-app **reader** for `Feedback.context` exists — true of the pre-existing fields too. Consumption is manual triage / SQL. The realistic failure mode here is *silent stripping at the boundary*, which is what the schema round-trip and the service `create`-argument assertions pin.
- Rate-limit enforcement cannot be tested behaviourally: `rateLimit` is a hard no-op under `isTest` by design. The tests assert the *configuration* the router hands it (5/3600, no `condition`, no `sharedKey`) — a `condition` is what would let a payload widen the quota.
- No `next build`; see the bundle-impact scope note above.



---

## Audit round — `7cb18983fa`

A blind adversarial audit found three user-visible issues, all now fixed. The one that mattered is a **correction to this description's own privacy claim** and is written up in full in [this comment](https://github.com/civitai/civitai/pull/3944#issuecomment-5300603878) — read that rather than trusting the annotated bullet above on its own.

1. 🔴 `scrollX: 0, scrollY: 0` dropped the sticky header from every capture.
2. `capturing` was missing from `busy`, so Send mid-capture silently submitted without the screenshot.
3. No size cap on user-chosen attachments (the generated capture was bounded; the picked files were not).

**A review fix resets the verification gate**, so everything was re-run rather than just the changed part:

- **Full 12-mutant battery re-run from scratch, all 12 killed by their own test's message.** Each mutant asserts its anchor occurrence count before applying, so a mutant that does not apply cannot score as a survival.
- Two findings came out of the battery itself and are recorded rather than hidden:
  - **Mutant G was INVALID on the first run** — it left a dangling `catch`, so the file failed to parse and vitest reported `Tests no tests`. That is a broken mutant, not a kill. Rewritten to a syntactically valid form; it now kills 1.
  - **Mutant J3 genuinely SURVIVED** — my negative-remaining clamp test used `alreadyAttached: 5` with 2 files, and `slice(0, -2)` on a 2-element array is `[]`, so it passed with the clamp deleted. The discriminating shape is `|remaining| < selected.length`. Test rewritten; the mutant now dies on the `remaining -1, 3 files` case.
- **Red at the pre-fix commit `d43eda8814`, green at HEAD**, per new behavioural test:

| test | pre-fix |
|---|---|
| `omits scrollX/scrollY …` (unit) | 🔴 red |
| `the shipped capture KEEPS the fixed bar the user can see` (render) | 🔴 red |
| `the Send button is disabled until the capture resolves …` | 🔴 red |
| `clicking Send mid-capture submits nothing at all` | 🔴 red |
| `an oversized file is refused, named, and never uploaded` | 🔴 red |
| `an oversized file does not consume one of the three slots` | 🔴 red |

`selectAttachments.test.ts` is new-module coverage with no meaningful pre-fix baseline; its teeth come from mutants J / J2 / J3 (5, 2 and 2 kills).

- Typecheck: **9 errors, byte-identical to `origin/main`**, none in any file this branch touches. Prettier clean (positive control: it flagged 3 files before formatting). ESLint 0 errors / 0 warnings.
- One test-harness trap worth naming: `userEvent.upload` **rebuilds the FileList and drops an instance property redefined on a File**, which silently turned the oversized fixture back into a small one — the size test passed the oversized file straight through and read as the cap not working. Those two tests now set `input.files` directly and **assert the picked size survived** before dispatching `change`, so a future runtime that copies again fails loudly instead of testing nothing.

## 🔴 Known open decision — NOT resolved by this PR

Stored captures and attachments land on the **public, unauthenticated CDN** with **no `Image` row**: no moderation scan, no retention policy, they survive account deletion, and they are **invisible to any orphan sweep keyed on the `Image` table**. That is a product/compliance decision, not a code change, and it is deliberately out of scope here. It should be settled **before a second feedback area is enabled** — one flag-gated area is a bounded exposure; a general mechanism is not.

Also noted and deliberately left as follow-ups: `useCFImageUpload` resolves `success` on a failed upload (`useCFImageUpload.tsx:138-145`, pre-existing), the retry-orphan case, and html2canvas's whole-document clone / CORS refetch cost.
