### PR TITLE
fix(prepaid-membership): roll over onto the canonical tier product

### DIFF
--- a/src/pages/api/admin/temp/prepaid-product-repoint.ts
+++ b/src/pages/api/admin/temp/prepaid-product-repoint.ts
@@ -1,0 +1,173 @@
+/**
+ * One-time backfill for memberships pointed at a non-canonical tier product.
+ * =============================================================================
+ *
+ * Mod-only admin route. Requires an authenticated moderator session.
+ *
+ * The prepaid rollover cron used to resolve a tier to whichever product the planner
+ * returned last, so paying members were moved onto the Buzz-purchase variant of their own
+ * tier — same badge and limits, but `rewardsMultiplier` / `purchasesMultiplier` reset to 1.
+ * The cron is fixed and re-points these rows on their next rollover; this route corrects
+ * them now instead of up to a month from now.
+ *
+ * Usage:
+ *   POST /api/admin/temp/prepaid-product-repoint
+ *   Content-Type: application/json
+ *
+ * Body shape:
+ *   { "action": "preview" | "apply", "subscriptionIds": ["sub_x", ...] }
+ *
+ * Actions:
+ *   preview - Report every affected row and the product it would move to. No writes.
+ *   apply   - Re-point productId/priceId to the canonical tier product and bust the
+ *             user's subscription caches (multipliers, session, vault).
+ *
+ * `subscriptionIds` is optional; omit it to sweep every affected row. Rows whose
+ * `buzzType` is a kind-discriminator ('buzzPurchase' / 'referral') belong on the variant
+ * product and are never touched.
+ */
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+import * as z from 'zod';
+import { dbWrite } from '~/server/db/client';
+import { ModEndpoint } from '~/server/utils/endpoint-helpers';
+import { invalidateSubscriptionCaches } from '~/server/utils/subscription.utils';
+import { isCanonicalTierProduct } from '~/shared/utils/buzz-membership';
+import type { SubscriptionProductMetadata } from '~/server/schema/subscriptions.schema';
+
+const PAID_TIERS = ['bronze', 'silver', 'gold'];
+
+// `CustomerSubscription.buzzType` is a Buzz colour for ordinary rows and a subscription-kind
+// discriminator for these two. A row carrying one of them is genuinely a Buzz-purchase or
+// referral membership and belongs on the variant product.
+const VARIANT_SUBSCRIPTION_TYPES = ['buzzPurchase', 'referral'];
+
+const schema = z.object({
+  action: z.enum(['preview', 'apply']),
+  subscriptionIds: z.array(z.string().min(1)).min(1).max(2000).optional(),
+});
+
+type EntryResult = {
+  subscriptionId: string;
+  userId: number;
+  status: string | null;
+  buzzType: string | null;
+  tier: string;
+  fromProductId: string;
+  toProductId: string;
+  toPriceId: string;
+  applied: boolean;
+  error?: string;
+};
+
+export default ModEndpoint(
+  async function (req: NextApiRequest, res: NextApiResponse) {
+    const payload = schema.safeParse(req.body ?? {});
+    if (!payload.success) {
+      return res.status(400).json({ error: 'Invalid request', issues: payload.error.issues });
+    }
+    const { action, subscriptionIds } = payload.data;
+
+    const products = await dbWrite.product.findMany({
+      where: { provider: 'Civitai' },
+      include: {
+        prices: { where: { active: true, interval: 'month' }, take: 1, orderBy: { id: 'asc' } },
+      },
+      orderBy: { id: 'asc' },
+    });
+
+    const canonicalByTier = new Map<string, (typeof products)[0]>();
+    const variantProductTiers = new Map<string, string>();
+    for (const product of products) {
+      const meta = product.metadata as SubscriptionProductMetadata;
+      if (!meta?.tier || !PAID_TIERS.includes(meta.tier)) continue;
+
+      if (!isCanonicalTierProduct(product.metadata)) {
+        variantProductTiers.set(product.id, meta.tier);
+        continue;
+      }
+      if (!canonicalByTier.has(meta.tier)) canonicalByTier.set(meta.tier, product);
+    }
+
+    const missingCanonical = [...new Set(variantProductTiers.values())].filter((tier) => {
+      const canonical = canonicalByTier.get(tier);
+      return !canonical || !canonical.prices.length;
+    });
+
+    const subscriptions = await dbWrite.customerSubscription.findMany({
+      where: {
+        productId: { in: [...variantProductTiers.keys()] },
+        status: { in: ['active', 'trialing', 'expired_claimable'] },
+        ...(subscriptionIds ? { id: { in: subscriptionIds } } : {}),
+      },
+      select: { id: true, userId: true, status: true, buzzType: true, productId: true },
+    });
+
+    const entries: EntryResult[] = [];
+    const skipped: Array<{ subscriptionId: string; reason: string }> = [];
+
+    for (const sub of subscriptions) {
+      if (sub.buzzType && VARIANT_SUBSCRIPTION_TYPES.includes(sub.buzzType)) {
+        skipped.push({ subscriptionId: sub.id, reason: `buzzType ${sub.buzzType}` });
+        continue;
+      }
+
+      const tier = variantProductTiers.get(sub.productId);
+      const canonical = tier ? canonicalByTier.get(tier) : undefined;
+      if (!tier || !canonical || !canonical.prices.length) {
+        skipped.push({
+          subscriptionId: sub.id,
+          reason: `no canonical product with an active monthly price for tier ${tier ?? 'unknown'}`,
+        });
+        continue;
+      }
+
+      entries.push({
+        subscriptionId: sub.id,
+        userId: sub.userId,
+        status: sub.status,
+        buzzType: sub.buzzType,
+        tier,
+        fromProductId: sub.productId,
+        toProductId: canonical.id,
+        toPriceId: canonical.prices[0].id,
+        applied: false,
+      });
+    }
+
+    if (action === 'apply') {
+      for (const entry of entries) {
+        try {
+          await dbWrite.customerSubscription.update({
+            where: { id: entry.subscriptionId },
+            data: {
+              productId: entry.toProductId,
+              priceId: entry.toPriceId,
+              updatedAt: new Date(),
+            },
+          });
+          entry.applied = true;
+          await invalidateSubscriptionCaches(entry.userId);
+        } catch (err) {
+          entry.error = err instanceof Error ? err.message : String(err);
+        }
+      }
+    }
+
+    return res.status(200).json({
+      action,
+      summary: {
+        variantProducts: [...variantProductTiers.keys()],
+        missingCanonical,
+        candidates: subscriptions.length,
+        affected: entries.length,
+        applied: entries.filter((e) => e.applied).length,
+        failed: entries.filter((e) => e.error).length,
+        skipped: skipped.length,
+      },
+      entries,
+      skipped,
+    });
+  },
+  ['POST']
+);

--- a/src/server/jobs/__tests__/prepaid-membership-jobs.test.ts
+++ b/src/server/jobs/__tests__/prepaid-membership-jobs.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type * as SubscriptionsService from '~/server/services/subscriptions.service';
 import type {
   SubscriptionMetadata,
   SubscriptionProductMetadata,
@@ -47,44 +48,40 @@ function fakePrepaidTokens({
 }
 
 // Use vi.hoisted to define mocks that will be available in vi.mock factories
-const {
-  mockDbWrite,
-  mockDeliverMonthlyCosmetics,
-  mockRefreshSession,
-  mockGetPrepaidTokens,
-} = vi.hoisted(() => {
-  const mockCustomerSubscription = {
-    findFirst: vi.fn(),
-    findMany: vi.fn(),
-    create: vi.fn(),
-    update: vi.fn(),
-    updateMany: vi.fn(),
-    delete: vi.fn(),
-    updateManyAndReturn: vi.fn(),
-  };
+const { mockDbWrite, mockDeliverMonthlyCosmetics, mockRefreshSession, mockGetPrepaidTokens } =
+  vi.hoisted(() => {
+    const mockCustomerSubscription = {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+      delete: vi.fn(),
+      updateManyAndReturn: vi.fn(),
+    };
 
-  const mockProduct = {
-    findMany: vi.fn(),
-  };
+    const mockProduct = {
+      findMany: vi.fn(),
+    };
 
-  return {
-    mockDbWrite: {
-      customerSubscription: mockCustomerSubscription,
-      product: mockProduct,
-      $transaction: vi.fn(async (callback: (tx: any) => Promise<any>) => {
-        return callback({
-          customerSubscription: mockCustomerSubscription,
-          product: mockProduct,
-        });
-      }),
-      $queryRaw: vi.fn(),
-      $executeRaw: vi.fn(),
-    },
-    mockDeliverMonthlyCosmetics: vi.fn().mockResolvedValue(undefined),
-    mockRefreshSession: vi.fn().mockResolvedValue(undefined),
-    mockGetPrepaidTokens: vi.fn().mockImplementation(fakePrepaidTokens),
-  };
-});
+    return {
+      mockDbWrite: {
+        customerSubscription: mockCustomerSubscription,
+        product: mockProduct,
+        $transaction: vi.fn(async (callback: (tx: any) => Promise<any>) => {
+          return callback({
+            customerSubscription: mockCustomerSubscription,
+            product: mockProduct,
+          });
+        }),
+        $queryRaw: vi.fn(),
+        $executeRaw: vi.fn(),
+      },
+      mockDeliverMonthlyCosmetics: vi.fn().mockResolvedValue(undefined),
+      mockRefreshSession: vi.fn().mockResolvedValue(undefined),
+      mockGetPrepaidTokens: vi.fn().mockImplementation(fakePrepaidTokens),
+    };
+  });
 
 // Mock modules
 vi.mock('~/env/server', () => ({
@@ -120,13 +117,16 @@ vi.mock('~/server/db/client', () => ({
   // returns nothing lets the sync complete as a no-op (0 synced).
   dbRead: {
     product: { findMany: vi.fn().mockResolvedValue([]) },
-    cosmetic: { findMany: vi.fn().mockResolvedValue([]), findUnique: vi.fn().mockResolvedValue(null) },
+    cosmetic: {
+      findMany: vi.fn().mockResolvedValue([]),
+      findUnique: vi.fn().mockResolvedValue(null),
+    },
   },
   dbWrite: mockDbWrite,
 }));
 
 vi.mock('~/server/services/subscriptions.service', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('~/server/services/subscriptions.service')>();
+  const actual = await importOriginal<typeof SubscriptionsService>();
   return {
     ...actual,
     deliverMonthlyCosmetics: mockDeliverMonthlyCosmetics,
@@ -146,9 +146,9 @@ vi.mock('~/utils/errorHandling', () => ({
 }));
 
 // Mock dayjs to use standard dayjs that respects vi.useFakeTimers
-vi.mock('~/shared/utils/dayjs', () => {
-  const dayjs = require('dayjs');
-  return { default: dayjs };
+vi.mock('~/shared/utils/dayjs', async () => {
+  const dayjs = await import('dayjs');
+  return { default: dayjs.default };
 });
 
 // Mock the createJob to return a Job-like object for testing
@@ -252,9 +252,7 @@ describe('prepaid-membership-jobs', () => {
       const unlockedTokens = updatedMeta.tokens.filter(
         (t: PrepaidToken) => t.status === 'unlocked'
       );
-      const lockedTokens = updatedMeta.tokens.filter(
-        (t: PrepaidToken) => t.status === 'locked'
-      );
+      const lockedTokens = updatedMeta.tokens.filter((t: PrepaidToken) => t.status === 'locked');
       expect(unlockedTokens).toHaveLength(1);
       expect(lockedTokens).toHaveLength(1);
       expect(unlockedTokens[0].unlockedAt).toContain('2024-01-15');
@@ -316,9 +314,7 @@ describe('prepaid-membership-jobs', () => {
       const updatedMeta = JSON.parse(updates[0].metadata);
 
       // Legacy token should be unlocked
-      const unlocked = updatedMeta.tokens.filter(
-        (t: PrepaidToken) => t.status === 'unlocked'
-      );
+      const unlocked = updatedMeta.tokens.filter((t: PrepaidToken) => t.status === 'unlocked');
       expect(unlocked).toHaveLength(1);
       expect(unlocked[0].id).toMatch(/^legacy_/);
 
@@ -388,9 +384,7 @@ describe('prepaid-membership-jobs', () => {
         id: `sub_${i}`,
         userId: i + 1,
         metadata: {
-          tokens: [
-            { id: `tok_${i}`, tier: 'bronze', status: 'locked', buzzAmount: 10000 },
-          ],
+          tokens: [{ id: `tok_${i}`, tier: 'bronze', status: 'locked', buzzAmount: 10000 }],
         },
         tier: 'bronze',
       }));
@@ -511,9 +505,7 @@ describe('prepaid-membership-jobs', () => {
         id: 'sub_1',
         userId: 1,
         metadata: {
-          tokens: [
-            { id: 'tok_1', tier: 'gold', status: 'claimed', buzzAmount: 50000 },
-          ],
+          tokens: [{ id: 'tok_1', tier: 'gold', status: 'claimed', buzzAmount: 50000 }],
           proratedDays: {},
         },
         currentPeriodStart: new Date('2023-12-15'),
@@ -698,7 +690,111 @@ describe('prepaid-membership-jobs', () => {
       expect(updatedMeta.tokens).toHaveLength(4);
       // Gold token still claimed, silver tokens still locked (unlock job handles unlocking later)
       expect(updatedMeta.tokens.find((t: PrepaidToken) => t.id === 'tok_1').status).toBe('claimed');
-      expect(updatedMeta.tokens.filter((t: PrepaidToken) => t.tier === 'silver' && t.status === 'locked')).toHaveLength(3);
+      expect(
+        updatedMeta.tokens.filter((t: PrepaidToken) => t.tier === 'silver' && t.status === 'locked')
+      ).toHaveLength(3);
+    });
+
+    it('should resolve the tier to the cash product, not the buzz-purchase or referral variant', async () => {
+      vi.setSystemTime(new Date('2024-01-15T00:00:00Z'));
+
+      // Both variants share tier 'gold' with the cash product, and one brackets it on each
+      // side: dropping the exclusion lands on the referral variant under first-writer-wins
+      // and on the Buzz variant under the last-writer-wins this bug came from.
+      const tierProducts = [
+        {
+          id: 'prod_referral_gold',
+          name: 'Gold Membership (Referral)',
+          metadata: { tier: 'gold', referralGrantable: true, rewardsMultiplier: 1 },
+          provider: 'Civitai',
+          prices: [{ id: 'price_referral_gold', currency: 'USD', interval: 'month', active: true }],
+        },
+        ...createTierProducts(),
+        {
+          id: 'prod_buzz_gold',
+          name: 'Gold Membership (Buzz)',
+          metadata: { tier: 'gold', buzzPurchase: 'true', rewardsMultiplier: 1 },
+          provider: 'Civitai',
+          prices: [{ id: 'price_buzz_gold', currency: 'USD', interval: 'month', active: true }],
+        },
+      ];
+
+      const expiringMembership = {
+        id: 'sub_1',
+        userId: 1,
+        metadata: {
+          tokens: [{ id: 'tok_1', tier: 'gold', status: 'locked', buzzAmount: 50000 }],
+          proratedDays: {},
+        },
+        currentPeriodStart: new Date('2023-12-15'),
+        currentPeriodEnd: new Date('2024-01-15'),
+        product: {
+          id: 'prod_buzz_gold',
+          metadata: { tier: 'gold', buzzPurchase: 'true' },
+        },
+        price: { id: 'price_buzz_gold', interval: 'month' },
+      };
+
+      mockDbWrite.product.findMany.mockResolvedValue(tierProducts);
+      mockDbWrite.customerSubscription.findMany.mockResolvedValue([expiringMembership]);
+      mockDbWrite.$executeRaw.mockResolvedValue({ count: 1 });
+
+      await processPrepaidMembershipTransitions.run().result;
+
+      const updates = JSON.parse(mockDbWrite.$executeRaw.mock.calls[0][1]);
+      expect(updates[0].productId).toBe('prod_gold');
+      expect(updates[0].priceId).toBe('price_gold');
+    });
+
+    it('should order the tier product query deterministically', async () => {
+      vi.setSystemTime(new Date('2024-01-15T00:00:00Z'));
+
+      mockDbWrite.product.findMany.mockResolvedValue(createTierProducts());
+      mockDbWrite.customerSubscription.findMany.mockResolvedValue([]);
+
+      await processPrepaidMembershipTransitions.run().result;
+
+      expect(mockDbWrite.product.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: { id: 'asc' },
+          include: expect.objectContaining({
+            prices: expect.objectContaining({ orderBy: { id: 'asc' } }),
+          }),
+        })
+      );
+    });
+
+    it('should leave productId and priceId alone when the tier product is unchanged', async () => {
+      vi.setSystemTime(new Date('2024-01-15T00:00:00Z'));
+
+      const expiringMembership = {
+        id: 'sub_1',
+        userId: 1,
+        metadata: {
+          tokens: [{ id: 'tok_1', tier: 'gold', status: 'locked', buzzAmount: 50000 }],
+          proratedDays: {},
+        },
+        currentPeriodStart: new Date('2023-12-15'),
+        currentPeriodEnd: new Date('2024-01-15'),
+        product: {
+          id: 'prod_gold',
+          metadata: { tier: 'gold', monthlyBuzz: 50000 },
+        },
+        price: { id: 'price_gold', interval: 'month' },
+      };
+
+      mockDbWrite.product.findMany.mockResolvedValue(createTierProducts());
+      mockDbWrite.customerSubscription.findMany.mockResolvedValue([expiringMembership]);
+      mockDbWrite.$executeRaw.mockResolvedValue({ count: 1 });
+
+      await processPrepaidMembershipTransitions.run().result;
+
+      const updates = JSON.parse(mockDbWrite.$executeRaw.mock.calls[0][1]);
+      // null means "leave the column as-is" to the batch UPDATE's CASE expressions.
+      expect(updates[0].productId).toBeNull();
+      expect(updates[0].priceId).toBeNull();
+      // The rollover itself still happened.
+      expect(updates[0].currentPeriodEnd).toBeTruthy();
     });
 
     it('should not process if no expiring memberships', async () => {
@@ -736,8 +832,20 @@ describe('prepaid-membership-jobs', () => {
 
       const tokens: PrepaidToken[] = [
         { id: 'tok_1', tier: 'gold', status: 'locked', buzzAmount: 50000 },
-        { id: 'tok_2', tier: 'gold', status: 'unlocked', buzzAmount: 50000, unlockedAt: '2024-01-14T01:00:00Z' },
-        { id: 'tok_3', tier: 'gold', status: 'claimed', buzzAmount: 50000, claimedAt: '2024-01-13T00:00:00Z' },
+        {
+          id: 'tok_2',
+          tier: 'gold',
+          status: 'unlocked',
+          buzzAmount: 50000,
+          unlockedAt: '2024-01-14T01:00:00Z',
+        },
+        {
+          id: 'tok_3',
+          tier: 'gold',
+          status: 'claimed',
+          buzzAmount: 50000,
+          claimedAt: '2024-01-13T00:00:00Z',
+        },
       ];
 
       const expiredMembership = {
@@ -786,7 +894,13 @@ describe('prepaid-membership-jobs', () => {
       vi.setSystemTime(new Date('2024-01-15T02:00:00Z'));
 
       const tokens: PrepaidToken[] = [
-        { id: 'tok_1', tier: 'gold', status: 'claimed', buzzAmount: 50000, claimedAt: '2024-01-10T00:00:00Z' },
+        {
+          id: 'tok_1',
+          tier: 'gold',
+          status: 'claimed',
+          buzzAmount: 50000,
+          claimedAt: '2024-01-10T00:00:00Z',
+        },
       ];
 
       const expiredMembership = {
@@ -823,9 +937,7 @@ describe('prepaid-membership-jobs', () => {
           userId: 1,
           status: 'active',
           metadata: {
-            tokens: [
-              { id: 'tok_a', tier: 'gold', status: 'locked', buzzAmount: 50000 },
-            ],
+            tokens: [{ id: 'tok_a', tier: 'gold', status: 'locked', buzzAmount: 50000 }],
           },
           currentPeriodEnd: new Date('2024-01-14'),
         },
@@ -835,7 +947,13 @@ describe('prepaid-membership-jobs', () => {
           status: 'active',
           metadata: {
             tokens: [
-              { id: 'tok_b', tier: 'silver', status: 'claimed', buzzAmount: 25000, claimedAt: '2024-01-10T00:00:00Z' },
+              {
+                id: 'tok_b',
+                tier: 'silver',
+                status: 'claimed',
+                buzzAmount: 25000,
+                claimedAt: '2024-01-10T00:00:00Z',
+              },
             ],
           },
           currentPeriodEnd: new Date('2024-01-13'),
@@ -846,7 +964,13 @@ describe('prepaid-membership-jobs', () => {
           status: 'active',
           metadata: {
             tokens: [
-              { id: 'tok_c', tier: 'bronze', status: 'unlocked', buzzAmount: 10000, unlockedAt: '2024-01-12T00:00:00Z' },
+              {
+                id: 'tok_c',
+                tier: 'bronze',
+                status: 'unlocked',
+                buzzAmount: 10000,
+                unlockedAt: '2024-01-12T00:00:00Z',
+              },
             ],
           },
           currentPeriodEnd: new Date('2024-01-10'),
@@ -880,7 +1004,13 @@ describe('prepaid-membership-jobs', () => {
           status: 'active',
           metadata: {
             tokens: [
-              { id: 'tok_a', tier: 'gold', status: 'claimed', buzzAmount: 50000, claimedAt: '2024-01-10T00:00:00Z' },
+              {
+                id: 'tok_a',
+                tier: 'gold',
+                status: 'claimed',
+                buzzAmount: 50000,
+                claimedAt: '2024-01-10T00:00:00Z',
+              },
             ],
           },
           currentPeriodEnd: new Date('2024-01-14'),
@@ -890,9 +1020,7 @@ describe('prepaid-membership-jobs', () => {
           userId: 2,
           status: 'active',
           metadata: {
-            tokens: [
-              { id: 'tok_b', tier: 'silver', status: 'locked', buzzAmount: 25000 },
-            ],
+            tokens: [{ id: 'tok_b', tier: 'silver', status: 'locked', buzzAmount: 25000 }],
           },
           currentPeriodEnd: new Date('2024-01-13'),
         },
@@ -918,7 +1046,13 @@ describe('prepaid-membership-jobs', () => {
         status: 'expired_claimable',
         metadata: {
           tokens: [
-            { id: 'tok_1', tier: 'gold', status: 'unlocked', buzzAmount: 50000, unlockedAt: '2024-01-14T00:00:00Z' },
+            {
+              id: 'tok_1',
+              tier: 'gold',
+              status: 'unlocked',
+              buzzAmount: 50000,
+              unlockedAt: '2024-01-14T00:00:00Z',
+            },
           ],
         },
         currentPeriodEnd: new Date('2024-01-14'),

--- a/src/server/jobs/prepaid-membership-jobs.ts
+++ b/src/server/jobs/prepaid-membership-jobs.ts
@@ -8,10 +8,13 @@ import {
 } from '../services/subscriptions.service';
 import { syncActiveBadgeMetadata } from '../services/product-badge.service';
 import { refreshSession } from '~/server/auth/session-invalidation';
+import { isCanonicalTierProduct } from '~/shared/utils/buzz-membership';
 import type {
   SubscriptionMetadata,
   SubscriptionProductMetadata,
 } from '~/server/schema/subscriptions.schema';
+
+const PAID_TIERS = ['bronze', 'silver', 'gold'];
 
 /**
  * Unlock prepaid tokens based on the subscription's currentPeriodStart day-of-month matching today.
@@ -59,17 +62,22 @@ export const processPrepaidMembershipTransitions = createJob(
             interval: 'month',
           },
           take: 1,
+          orderBy: { id: 'asc' },
         },
       },
+      orderBy: { id: 'asc' },
     });
 
-    // Create a map for quick tier lookup
+    // Create a map for quick tier lookup. Skip the Buzz-purchase and referral variants —
+    // they share the tier but have the perks zeroed out — and keep the first match rather
+    // than the last so an unexpected duplicate can't silently change which product wins.
     const productsByTier = new Map<string, (typeof tierProducts)[0]>();
     tierProducts.forEach((product) => {
       const meta = product.metadata as SubscriptionProductMetadata;
-      if (meta?.tier && ['bronze', 'silver', 'gold'].includes(meta.tier)) {
-        productsByTier.set(meta.tier, product);
-      }
+      if (!meta?.tier || !PAID_TIERS.includes(meta.tier)) return;
+      if (!isCanonicalTierProduct(product.metadata)) return;
+      if (productsByTier.has(meta.tier)) return;
+      productsByTier.set(meta.tier, product);
     });
 
     // Find all Civitai memberships expiring today. Referral-granted subs use
@@ -158,13 +166,12 @@ export const processPrepaidMembershipTransitions = createJob(
         // For tier TRANSITIONS (period expired), find the best available tier to switch to.
         // Check both tokens AND prorated days per tier — a tier with only prorated days
         // still wins over a lower tier with tokens (e.g., 10 Silver prorated days > 2 Bronze tokens).
-        const paidTiers = ['bronze', 'silver', 'gold'];
         let nextTier: string | null = null;
         let nextMonths = 0;
         let nextProratedDays = 0;
 
-        for (let i = paidTiers.length - 1; i >= 0; i--) {
-          const tier = paidTiers[i];
+        for (let i = PAID_TIERS.length - 1; i >= 0; i--) {
+          const tier = PAID_TIERS[i];
           const tierTokenCount = futureTokens.filter((t) => t.tier === tier).length;
           const tierProratedDays = proratedDays[tier as keyof typeof proratedDays] || 0;
 
@@ -207,10 +214,16 @@ export const processPrepaidMembershipTransitions = createJob(
           proratedDays: updatedProratedDays,
         };
 
+        // A rollover that stays on the same product has no reason to touch productId/priceId.
+        // Leaving them alone keeps a rollover from rewriting a row it isn't transitioning,
+        // while a row already sitting on the wrong product still gets corrected here.
+        const productChanged = nextTierProduct.id !== membership.product.id;
+
         membershipUpdates.push({
           id: membership.id,
-          productId: nextTierProduct.id,
-          priceId: nextTierProduct.prices[0].id,
+          ...(productChanged
+            ? { productId: nextTierProduct.id, priceId: nextTierProduct.prices[0].id }
+            : {}),
           currentPeriodStart: newPeriodStart.toDate(),
           currentPeriodEnd: newPeriodEnd.toDate(),
           metadata: updatedMeta,

--- a/src/shared/utils/__tests__/buzz-membership.test.ts
+++ b/src/shared/utils/__tests__/buzz-membership.test.ts
@@ -3,6 +3,7 @@ import {
   BUZZ_MEMBERSHIP_SUBSCRIPTION_TYPE,
   getBuzzMembershipPrice,
   getSubscriptionDisplayBuzzType,
+  isCanonicalTierProduct,
   isMembershipActive,
 } from '~/shared/utils/buzz-membership';
 import { getBuzzCurrencyConfig } from '~/shared/constants/currency.constants';
@@ -215,6 +216,27 @@ describe('getSubscriptionDisplayBuzzType', () => {
       const config = getBuzzCurrencyConfig(getSubscriptionDisplayBuzzType(raw, 'green'));
       expect(config?.icon).toBeDefined();
     }
+  });
+});
+
+describe('isCanonicalTierProduct', () => {
+  it('accepts the cash tier product', () => {
+    expect(isCanonicalTierProduct({ tier: 'gold', rewardsMultiplier: 4 })).toBe(true);
+    expect(isCanonicalTierProduct({})).toBe(true);
+    expect(isCanonicalTierProduct(null)).toBe(true);
+  });
+
+  it('rejects the buzz-purchase and referral variants', () => {
+    expect(isCanonicalTierProduct({ tier: 'gold', buzzPurchase: true })).toBe(false);
+    expect(isCanonicalTierProduct({ tier: 'gold', referralGrantable: true })).toBe(false);
+  });
+
+  it('reads the marker whether it was stored as a boolean or a string', () => {
+    // `buzzPurchase` goes through booleanString(), so both forms exist in Product.metadata.
+    expect(isCanonicalTierProduct({ buzzPurchase: 'true' })).toBe(false);
+    expect(isCanonicalTierProduct({ referralGrantable: 'true' })).toBe(false);
+    expect(isCanonicalTierProduct({ buzzPurchase: 'false' })).toBe(true);
+    expect(isCanonicalTierProduct({ buzzPurchase: false })).toBe(true);
   });
 });
 

--- a/src/shared/utils/buzz-membership.ts
+++ b/src/shared/utils/buzz-membership.ts
@@ -17,6 +17,20 @@ export const BUZZ_MEMBERSHIP_PREMIUM_MULTIPLIER = 1.25;
  */
 export const BUZZ_MEMBERSHIP_SUBSCRIPTION_TYPE = 'buzzPurchase';
 
+const isMetadataTrue = (value: unknown) => value === true || value === 'true';
+
+/**
+ * Several products share a `tier`: the cash one, the Buzz-purchase variant
+ * (`buzzPurchase`) and the referral-grant variant (`referralGrantable`). Only the cash one
+ * carries the tier's real perks — the variants zero out `rewardsMultiplier` /
+ * `purchasesMultiplier` — so anything resolving a tier to a product must exclude them or it
+ * silently strips those perks from whoever it points at.
+ */
+export function isCanonicalTierProduct(metadata: unknown) {
+  const meta = (metadata ?? {}) as Record<string, unknown>;
+  return !isMetadataTrue(meta.buzzPurchase) && !isMetadataTrue(meta.referralGrantable);
+}
+
 type MembershipStanding = {
   isBadState?: boolean;
   currentPeriodEnd: Date;


### PR DESCRIPTION
The rollover cron resolved a tier to whichever product the planner returned last, moving paying members onto the Buzz-purchase variant of their tier and resetting rewardsMultiplier/purchasesMultiplier to 1. Tier lookup now excludes the buzzPurchase and referral variants and orders deterministically, leaves productId/priceId untouched when the product is unchanged, and a mod-only temp endpoint re-points already-affected rows instead of waiting a month for their next rollover.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
Implemented by the local ticket agent (task `868kr8bh3`). Reviewed locally before push.