### PR TITLE
feat(dev-server): serialise unit-test runs behind the daemon

### DIFF
--- a/.claude/skills/dev-server/.env.example
+++ b/.claude/skills/dev-server/.env.example
@@ -39,3 +39,7 @@ PREWARM_TIMEOUT=300000
 PER_BRANCH_DIST_DIR=false
 DIST_CACHE_KEEP=4              # per-branch build dirs to retain (PER_BRANCH_DIST_DIR only)
 DIST_CACHE_MAX_GB=40           # total budget across those dirs; LRU-evicted on start
+
+# Serialised unit-test runs (`cli.mjs test run`). The suite takes every core, so concurrent runs
+# from several agents flatten the machine. 1 = one run at a time; 0 = queue paused, nothing starts.
+TEST_CONCURRENCY=1

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -43,7 +43,49 @@ node .claude/skills/dev-server/cli.mjs stop <session-id>
 | `app` | List the spoke apps and their state |
 | `app <name> [subcmd]` | Spoke app control (`status`\|`start`\|`stop`\|`restart`\|`logs`) |
 | `auth [subcmd]` | Auth hub control (`status`\|`start`\|`stop`\|`restart`\|`logs`) |
+| `test run [worktree]` | Queue a unit-test run; returns position + the command to wait on it |
+| `test wait <run-id>` | Block until that run finishes; exits with the run's exit code |
+| `test list` / `test show <id>` / `test logs <id>` | Queue state, one run, one run's output |
+| `test cancel <id>` | Cancel a queued or running run |
+| `test config [n]` | Show or set the concurrency limit (`0` pauses the queue) |
 | `shutdown` | Shutdown the daemon |
+
+## Queued test runs
+
+The unit suite takes every core. One run is fine; five agents each starting one at the same moment
+is what flattens the machine. The daemon serialises them.
+
+```bash
+# 1. Request a run. Returns immediately, whether it started or queued.
+node .claude/skills/dev-server/cli.mjs test run
+#    Run t3f9a2 queued at position 2 of 3 (1/1 running).
+#    Wait for it in the background: node .claude/skills/dev-server/cli.mjs test wait t3f9a2
+
+# 2. Wait for it — in the background, so you can work meanwhile.
+node .claude/skills/dev-server/cli.mjs test wait t3f9a2
+```
+
+`test wait` exits with the run's own exit code, so it substitutes for `pnpm run test:unit:run`
+wherever that was being checked. Extra args after `--` are passed to vitest, so
+`test run . -- path/to/one.test.ts` narrows the run.
+
+**Concurrency defaults to 1**, configurable with `TEST_CONCURRENCY` in the skill's `.env` or at
+runtime with `test config <n>`. `0` is legal and means *paused* — nothing starts until it is raised.
+A caller that queues behind a paused queue is told so explicitly rather than being handed a position
+and left waiting.
+
+Things worth knowing before you rely on it:
+
+- **The daemon owns the run, not you.** An agent that dies mid-wait releases nothing, because it was
+  holding nothing. The slot frees when the child process exits.
+- **A queued run whose caller stopped polling is dropped** after 10 minutes, so a dead agent cannot
+  hold the queue. `test wait` polls every 2s, so a live waiter never trips this.
+- **A run that overruns 30 minutes is killed** and reported as `timeout`. If the kill produces no
+  exit, the slot is released anyway after a grace period rather than held forever.
+- **A daemon restart drops the queue.** `test wait` treats an unknown run id as terminal and exits
+  nonzero telling you to re-request — it will not poll forever against a daemon that has forgotten
+  you.
+- **Position is exact**, not an estimate: it is the index in one ordered list.
 
 ## Session Object
 

--- a/.claude/skills/dev-server/cli.mjs
+++ b/.claude/skills/dev-server/cli.mjs
@@ -8,6 +8,7 @@ import { spawn, execSync } from 'child_process';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'fs';
+import { exitCodeFor, isTerminal as isTerminalStatus } from './scripts/test-queue.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -398,7 +399,7 @@ async function cmdTestWait(id) {
       );
       lastStatus = run.status;
     }
-    if (run.paused && !announcedPause) {
+    if (run.paused && !announcedPause && !isTerminalStatus(run.status)) {
       console.log('queue is PAUSED (concurrency 0) — nothing will start until it is raised');
       announcedPause = true;
     }
@@ -413,15 +414,11 @@ async function cmdTestWait(id) {
 
     if (isTerminalStatus(run.status)) {
       console.log(`Run ${id} ${run.status}${run.error ? ` (${run.error})` : ''}`);
-      process.exit(run.status === 'completed' ? 0 : run.exitCode ?? 1);
+      process.exit(exitCodeFor(run));
     }
 
     await new Promise((r) => setTimeout(r, WAIT_POLL_MS));
   }
-}
-
-function isTerminalStatus(status) {
-  return ['completed', 'failed', 'cancelled', 'timeout', 'abandoned', 'error'].includes(status);
 }
 
 async function cmdTest(sub, rest) {

--- a/.claude/skills/dev-server/cli.mjs
+++ b/.claude/skills/dev-server/cli.mjs
@@ -27,7 +27,8 @@ const projectRoot = findProjectRoot(__dirname);
 const pidFile = resolve(__dirname, 'daemon.pid');
 const serverScript = resolve(__dirname, 'scripts/daemon.mjs');
 
-const DAEMON_PORT = 9444;
+// Overridable so a second daemon can be exercised without touching the shared one on 9444.
+const DAEMON_PORT = parseInt(process.env.DEV_DAEMON_PORT || '9444', 10);
 const DAEMON_URL = `http://127.0.0.1:${DAEMON_PORT}`;
 
 async function daemonRequest(path, options = {}) {
@@ -318,6 +319,152 @@ async function cmdApp(name, subcmd) {
   console.log(JSON.stringify(result.data, null, 2));
 }
 
+const WAIT_POLL_MS = 2000;
+
+// Exit codes: the run's own code when it ran, 2 when the daemon can no longer tell us anything.
+const EXIT_UNKNOWN_RUN = 2;
+
+function describeRun(run) {
+  const lines = [];
+  if (run.status === 'running') {
+    lines.push(`Run ${run.id} started (nothing ahead of it).`);
+  } else if (run.paused) {
+    lines.push(
+      `Run ${run.id} queued at position ${run.position}, but the queue is PAUSED (concurrency 0).`,
+      `Nothing will start until someone raises it: node .claude/skills/dev-server/cli.mjs test config 1`
+    );
+  } else {
+    lines.push(
+      `Run ${run.id} queued at position ${run.position} of ${run.queueLength} ` +
+        `(${run.running}/${run.concurrency} running).`
+    );
+  }
+  lines.push(`Wait for it in the background: ${run.waitCommand}`);
+  return lines.join('\n');
+}
+
+async function cmdTestRun(rest) {
+  await ensureDaemon();
+  const sep = rest.indexOf('--');
+  const args = sep === -1 ? [] : rest.slice(sep + 1);
+  const target = (sep === -1 ? rest : rest.slice(0, sep)).find((a) => !a.startsWith('--'));
+  const worktree = target ? resolve(target) : process.cwd();
+
+  const result = await daemonRequest('/test-runs', {
+    method: 'POST',
+    body: JSON.stringify({ worktree, args }),
+  });
+  if (!result.ok) {
+    console.error('Error:', result.error || result.data?.error);
+    process.exit(1);
+  }
+  console.log(describeRun(result.data));
+}
+
+async function cmdTestWait(id) {
+  if (!id) {
+    console.error('Usage: test wait <run-id>');
+    process.exit(1);
+  }
+
+  let lastStatus = null;
+  let lastLogIndex = -1;
+  let announcedPause = false;
+
+  for (;;) {
+    const result = await daemonRequest(`/test-runs/${id}`);
+
+    // A daemon that has forgotten this run — or that is gone — is terminal, not something to keep
+    // polling. Restarting the daemon drops the in-memory queue, and a waiter that polled through
+    // that would hang forever.
+    if (result.status === 404) {
+      console.error(
+        `Run ${id} is unknown to the daemon. It was most likely restarted, which drops queued and ` +
+          `in-flight runs. Request a new run.`
+      );
+      process.exit(EXIT_UNKNOWN_RUN);
+    }
+    if (!result.ok) {
+      console.error(`Cannot reach the daemon: ${result.error || result.data?.error}`);
+      process.exit(EXIT_UNKNOWN_RUN);
+    }
+
+    const run = result.data;
+    if (run.status !== lastStatus) {
+      console.log(
+        run.status === 'queued'
+          ? `queued at position ${run.position} of ${run.queueLength}`
+          : `${run.status}`
+      );
+      lastStatus = run.status;
+    }
+    if (run.paused && !announcedPause) {
+      console.log('queue is PAUSED (concurrency 0) — nothing will start until it is raised');
+      announcedPause = true;
+    }
+
+    if (run.status === 'running' || isTerminalStatus(run.status)) {
+      const logs = await daemonRequest(`/test-runs/${id}/logs?since=${lastLogIndex}`);
+      for (const entry of logs.data?.logs ?? []) {
+        console.log(entry.message);
+        lastLogIndex = entry.index;
+      }
+    }
+
+    if (isTerminalStatus(run.status)) {
+      console.log(`Run ${id} ${run.status}${run.error ? ` (${run.error})` : ''}`);
+      process.exit(run.status === 'completed' ? 0 : run.exitCode ?? 1);
+    }
+
+    await new Promise((r) => setTimeout(r, WAIT_POLL_MS));
+  }
+}
+
+function isTerminalStatus(status) {
+  return ['completed', 'failed', 'cancelled', 'timeout', 'abandoned', 'error'].includes(status);
+}
+
+async function cmdTest(sub, rest) {
+  const action = sub || 'list';
+  if (action === 'run') return cmdTestRun(rest);
+  if (action === 'wait') return cmdTestWait(rest[0]);
+
+  await ensureDaemon();
+  let result;
+  switch (action) {
+    case 'list':
+    case 'status':
+      result = await daemonRequest('/test-runs');
+      break;
+    case 'show':
+      result = await daemonRequest(`/test-runs/${rest[0]}`);
+      break;
+    case 'logs':
+      result = await daemonRequest(`/test-runs/${rest[0]}/logs`);
+      break;
+    case 'cancel':
+      result = await daemonRequest(`/test-runs/${rest[0]}`, { method: 'DELETE' });
+      break;
+    case 'config':
+      result = rest[0]
+        ? await daemonRequest('/test-runs/config', {
+            method: 'POST',
+            body: JSON.stringify({ concurrency: Number(rest[0]) }),
+          })
+        : await daemonRequest('/test-runs/config');
+      break;
+    default:
+      console.error(`Unknown test subcommand: ${action}`);
+      console.error('Usage: test [run|wait|list|show|logs|cancel|config]');
+      process.exit(1);
+  }
+  if (!result.ok) {
+    console.error('Error:', result.error || result.data?.error || JSON.stringify(result.data));
+    process.exit(1);
+  }
+  console.log(JSON.stringify(result.data, null, 2));
+}
+
 async function cmdShutdown() {
   const result = await daemonRequest('/shutdown', { method: 'POST' });
   if (!result.ok && result.status !== 0) {
@@ -396,6 +543,9 @@ switch (command) {
   case 'shutdown':
     cmdShutdown();
     break;
+  case 'test':
+    cmdTest(arg1, args.slice(2));
+    break;
   case 'wt':
     cmdWorktree(args.slice(1));
     break;
@@ -415,6 +565,11 @@ Commands:
   app                 List spoke apps (moderator, creator-studio, storage, notifications)
   app <name> [subcmd] Spoke app control (status|start|stop|restart|logs)
   shutdown            Shutdown the daemon
+  test run [wt]       Queue a unit-test run; returns position + the command to wait on it
+  test wait <run-id>  Block until that run finishes; exits with the run's exit code
+  test list           List runs and queue state
+  test cancel <id>    Cancel a queued or running run
+  test config [n]     Show or set the concurrency limit (0 pauses the queue)
   wt stale            List worktrees whose PR merged (read-only)
   wt rm <path>        Remove a worktree safely (unlinks junctions first)
                       [--stop-server] [--force]

--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -19,6 +19,7 @@ import { fileURLToPath } from 'url';
 import { randomBytes, createHash } from 'crypto';
 import { access } from 'fs/promises';
 import { isPortFree } from './port-probe.mjs';
+import { TestQueue } from './test-queue.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const skillDir = resolve(__dirname, '..');
@@ -53,6 +54,7 @@ function loadSkillConfig() {
     autoInstall: true,
     prewarmRoutes: [],
     prewarmTimeout: 300000,
+    testConcurrency: 1,
   };
 
   if (existsSync(envPath)) {
@@ -122,6 +124,9 @@ function loadSkillConfig() {
           break;
         case 'PREWARM_TIMEOUT':
           if (value) config.prewarmTimeout = parseInt(value, 10);
+          break;
+        case 'TEST_CONCURRENCY':
+          if (value) config.testConcurrency = parseInt(value, 10);
           break;
       }
     }
@@ -1462,6 +1467,8 @@ async function stopSpokeApps() {
 // Session manager
 const sessions = new Map();
 
+const testQueue = new TestQueue({ concurrency: skillConfig.testConcurrency });
+
 // A tracked session owns its port whatever its status says. Status is a report the daemon
 // writes about a process it cannot see into — it has read `crashed` for a session whose
 // process was alive and serving 200s, and it necessarily reads dead for the window inside
@@ -1848,6 +1855,114 @@ async function main() {
         return;
       }
 
+      // Test-run queue. Registered above the /sessions/:id regex so these paths are not read as
+      // session ids. Deadlines are swept on every request as well as on a timer, so a queue that
+      // is being polled cannot sit on a stale slot between ticks.
+      if (path.startsWith('/test-runs')) {
+        testQueue.sweep();
+
+        if (path === '/test-runs' && req.method === 'GET') {
+          res.writeHead(200);
+          res.end(JSON.stringify({
+            runs: testQueue.list(),
+            concurrency: testQueue.concurrency,
+            paused: testQueue.paused,
+          }));
+          return;
+        }
+
+        if (path === '/test-runs' && req.method === 'POST') {
+          let parsed;
+          try {
+            parsed = JSON.parse(await readBody(req) || '{}');
+          } catch (e) {
+            res.writeHead(400);
+            res.end(JSON.stringify({ error: 'Invalid JSON body' }));
+            return;
+          }
+          if (!parsed.worktree) {
+            res.writeHead(400);
+            res.end(JSON.stringify({
+              error: 'worktree path required',
+              usage: '{ "worktree": "/path/to/worktree", "args": ["path/to/one.test.ts"] }',
+            }));
+            return;
+          }
+          res.writeHead(200);
+          res.end(JSON.stringify(testQueue.request({
+            worktree: resolve(parsed.worktree),
+            args: Array.isArray(parsed.args) ? parsed.args : [],
+          })));
+          return;
+        }
+
+        if (path === '/test-runs/config') {
+          if (req.method === 'POST') {
+            let parsed;
+            try {
+              parsed = JSON.parse(await readBody(req) || '{}');
+            } catch (e) {
+              res.writeHead(400);
+              res.end(JSON.stringify({ error: 'Invalid JSON body' }));
+              return;
+            }
+            try {
+              testQueue.setConcurrency(parsed.concurrency);
+            } catch (err) {
+              res.writeHead(400);
+              res.end(JSON.stringify({ error: err.message }));
+              return;
+            }
+          }
+          res.writeHead(200);
+          res.end(JSON.stringify({
+            concurrency: testQueue.concurrency,
+            paused: testQueue.paused,
+            queued: testQueue.order.length,
+            running: testQueue.running.size,
+          }));
+          return;
+        }
+
+        const runMatch = path.match(/^\/test-runs\/([^/]+)(\/logs)?$/);
+        if (runMatch) {
+          const [, runId, logsSuffix] = runMatch;
+
+          if (logsSuffix && req.method === 'GET') {
+            const since = parseInt(url.searchParams.get('since') || '-1', 10);
+            const logs = testQueue.logs(runId, since);
+            if (logs === null) {
+              res.writeHead(404);
+              res.end(JSON.stringify({ error: 'Unknown run', id: runId }));
+              return;
+            }
+            res.writeHead(200);
+            res.end(JSON.stringify({ logs }));
+            return;
+          }
+
+          const run =
+            req.method === 'DELETE' ? testQueue.cancel(runId) :
+            req.method === 'GET' ? testQueue.get(runId) : undefined;
+
+          if (run === undefined) {
+            res.writeHead(405);
+            res.end(JSON.stringify({ error: 'Method not allowed', path }));
+            return;
+          }
+          // The 404 is load-bearing: it is how `test wait` learns the daemon was restarted and its
+          // run is gone, instead of polling for a result nobody will produce.
+          if (run === null) {
+            res.writeHead(404);
+            res.end(JSON.stringify({ error: 'Unknown run', id: runId }));
+            return;
+          }
+          res.writeHead(200);
+          res.end(JSON.stringify(run));
+          return;
+        }
+      }
+
       // GET /sessions - List all sessions
       if (path === '/sessions' && req.method === 'GET') {
         res.writeHead(200);
@@ -2077,6 +2192,7 @@ async function main() {
           await session.stop();
         }
         sessions.clear();
+        testQueue.shutdown();
         await rgbProxy.stop();
         await authHub.stop();
         await stopSpokeApps();
@@ -2101,6 +2217,11 @@ async function main() {
       res.end(JSON.stringify({ error: err.message }));
     }
   };
+
+  // Deadlines still have to advance when nobody is polling — an abandoned queue is exactly the
+  // case where no requests arrive.
+  const testSweeper = setInterval(() => testQueue.sweep(), 5000);
+  testSweeper.unref();
 
   // Start server - bind to localhost only for security
   const server = http.createServer(handler);
@@ -2144,6 +2265,7 @@ async function main() {
     for (const session of sessions.values()) {
       await session.stop();
     }
+    testQueue.shutdown();
     await rgbProxy.stop();
     await authHub.stop();
     await stopSpokeApps();
@@ -2157,6 +2279,7 @@ async function main() {
     for (const session of sessions.values()) {
       await session.stop();
     }
+    testQueue.shutdown();
     await rgbProxy.stop();
     await authHub.stop();
     await stopSpokeApps();

--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -125,9 +125,16 @@ function loadSkillConfig() {
         case 'PREWARM_TIMEOUT':
           if (value) config.prewarmTimeout = parseInt(value, 10);
           break;
-        case 'TEST_CONCURRENCY':
-          if (value) config.testConcurrency = parseInt(value, 10);
+        case 'TEST_CONCURRENCY': {
+          // Every other setting here degrades to its default on a bad value. This one feeds a
+          // constructor that throws, and the queue is built at module scope — so a typo in an
+          // optional test setting would stop the daemon binding at all, taking every agent's dev
+          // server with it.
+          const parsed = parseInt(value, 10);
+          if (Number.isInteger(parsed) && parsed >= 0) config.testConcurrency = parsed;
+          else if (value) console.error(`Ignoring TEST_CONCURRENCY=${value} (want an integer >= 0)`);
           break;
+        }
       }
     }
   }

--- a/.claude/skills/dev-server/scripts/test-queue.mjs
+++ b/.claude/skills/dev-server/scripts/test-queue.mjs
@@ -12,7 +12,7 @@
  */
 
 import { EventEmitter } from 'events';
-import { spawn } from 'child_process';
+import { spawn, execFileSync } from 'child_process';
 
 export const DEFAULT_CONCURRENCY = 1;
 const DEFAULT_ABANDON_AFTER_MS = 10 * 60 * 1000;
@@ -28,7 +28,18 @@ export function isTerminal(status) {
   return TERMINAL.has(status);
 }
 
-function defaultStartRun({ worktree, args, onLog }) {
+/**
+ * The exit code a waiter should exit with. Only a completed run that itself exited 0 is a pass:
+ * a cancelled or timed-out run can carry exitCode 0 (the child exited cleanly in the window
+ * between the kill being issued and it landing), and treating that as success would report a
+ * green suite that never finished.
+ */
+export function exitCodeFor(run) {
+  if (run.status === 'completed' && run.exitCode === 0) return 0;
+  return run.exitCode || 1;
+}
+
+function defaultStartRun({ worktree, args, onLog, onExit }) {
   const emitter = new EventEmitter();
   const isWindows = process.platform === 'win32';
   const pnpm = isWindows ? 'pnpm.cmd' : 'pnpm';
@@ -43,9 +54,13 @@ function defaultStartRun({ worktree, args, onLog }) {
       env: process.env,
       stdio: ['ignore', 'pipe', 'pipe'],
       shell: isWindows,
+      // Its own process group, so the kill below can take the whole vitest tree. Without this,
+      // killing by negative pid names no group, fails with ESRCH, and leaves the run burning
+      // cores while its slot is handed to the next caller.
+      detached: !isWindows,
     });
   } catch (err) {
-    queueMicrotask(() => emitter.emit('exit', -1, err.message));
+    queueMicrotask(() => onExit(-1, err.message));
     emitter.kill = () => {};
     return emitter;
   }
@@ -59,16 +74,23 @@ function defaultStartRun({ worktree, args, onLog }) {
   pipe(child.stdout, 'stdout');
   pipe(child.stderr, 'stderr');
 
-  child.on('exit', (code) => emitter.emit('exit', code ?? -1));
-  child.on('error', (err) => emitter.emit('exit', -1, err.message));
+  child.on('exit', (code) => onExit(code ?? -1));
+  child.on('error', (err) => onExit(-1, err.message));
 
   emitter.pid = child.pid;
-  emitter.kill = () => {
+  // `sync` is for daemon shutdown, where an asynchronously spawned taskkill would never get to
+  // run before the daemon exits, leaving vitest orphaned and still holding every core.
+  emitter.kill = (sync = false) => {
     try {
-      if (isWindows) spawn('taskkill', ['/pid', String(child.pid), '/f', '/t'], { shell: true });
-      else process.kill(-child.pid, 'SIGKILL');
+      if (isWindows) {
+        const argv = ['/pid', String(child.pid), '/f', '/t'];
+        if (sync) execFileSync('taskkill', argv, { stdio: 'ignore' });
+        else spawn('taskkill', argv, { shell: true });
+      } else {
+        process.kill(-child.pid, 'SIGKILL');
+      }
     } catch {
-      /* already gone */
+      /* already gone, or refused — the sweep releases the slot either way */
     }
   };
   return emitter;
@@ -229,7 +251,7 @@ export class TestQueue {
       const run = this.runs.get(id);
       run.cancelReason = 'daemon-shutdown';
       run.killRequestedAt = this.now();
-      run.handle?.kill();
+      run.handle?.kill(true);
     }
   }
 
@@ -251,26 +273,35 @@ export class TestQueue {
     this.running.add(id);
 
     const onLog = (level, message) => this.addLog(run, level, message);
-    let handle;
+
+    // The exit path is built BEFORE the runner is called. A runner that reports its exit
+    // synchronously would otherwise report into a listener that does not exist yet, leaving a
+    // finished run holding the only slot until the run ceiling expires.
+    let settled = false;
+    let handle = null;
+    const onExit = (code, errorMessage) => {
+      // A run only settles once, and only from the handle it currently owns: a late exit from a
+      // replaced handle must neither settle it nor release a slot it no longer holds.
+      if (settled || (handle !== null && run.handle !== handle)) return;
+      settled = true;
+      run.handle = null;
+      this.release(id);
+      this.settle(run, this.outcomeFor(run, code), code, errorMessage ?? run.cancelReason ?? null);
+      this.pump();
+    };
+
     try {
-      handle = this.startRun({ worktree: run.worktree, args: run.args, onLog });
+      handle = this.startRun({ worktree: run.worktree, args: run.args, onLog, onExit });
     } catch (err) {
       this.release(id);
       this.settle(run, 'error', null, err.message);
       this.pump();
       return;
     }
-    run.handle = handle;
 
-    handle.on('exit', (code, errorMessage) => {
-      // Identity guard: an exit from a handle this run no longer owns must not settle it, and
-      // must not release a slot it no longer holds.
-      if (run.handle !== handle) return;
-      run.handle = null;
-      this.release(id);
-      this.settle(run, this.outcomeFor(run, code), code, errorMessage ?? run.cancelReason ?? null);
-      this.pump();
-    });
+    if (settled) return; // the runner reported an exit before it returned a handle
+    run.handle = handle;
+    handle.on?.('exit', onExit);
   }
 
   outcomeFor(run, code) {

--- a/.claude/skills/dev-server/scripts/test-queue.mjs
+++ b/.claude/skills/dev-server/scripts/test-queue.mjs
@@ -36,7 +36,10 @@ export function isTerminal(status) {
  */
 export function exitCodeFor(run) {
   if (run.status === 'completed' && run.exitCode === 0) return 0;
-  return run.exitCode || 1;
+  // A real failing code is worth passing through, but a child killed by a signal reports no code
+  // at all (recorded as -1), and exiting -1 gives a shell 255 — a number that means nothing here
+  // and that `[ $? -eq 1 ]` misreads.
+  return Number.isInteger(run.exitCode) && run.exitCode > 0 ? run.exitCode : 1;
 }
 
 function defaultStartRun({ worktree, args, onLog, onExit }) {
@@ -84,8 +87,12 @@ function defaultStartRun({ worktree, args, onLog, onExit }) {
     try {
       if (isWindows) {
         const argv = ['/pid', String(child.pid), '/f', '/t'];
-        if (sync) execFileSync('taskkill', argv, { stdio: 'ignore' });
-        else spawn('taskkill', argv, { shell: true });
+        // The sync form runs on the daemon's event loop, including inside the SIGINT handler.
+        // Without a timeout a taskkill that blocks would wedge the daemon with no way to shut it
+        // down; a kill we cannot complete is better abandoned, since the sweep frees the slot.
+        if (sync)
+          execFileSync('taskkill', argv, { stdio: 'ignore', timeout: 5000, windowsHide: true });
+        else spawn('taskkill', argv, { shell: true, windowsHide: true });
       } else {
         process.kill(-child.pid, 'SIGKILL');
       }
@@ -307,7 +314,10 @@ export class TestQueue {
   outcomeFor(run, code) {
     if (run.timedOut) return 'timeout';
     if (run.cancelReason) return 'cancelled';
-    return code === 0 ? 'completed' : 'failed';
+    if (code === 0) return 'completed';
+    // No exit code means the child died by signal or never started — an OOM kill, not a verdict
+    // on the tests. Calling that `failed` would report a test result nothing produced.
+    return code < 0 ? 'error' : 'failed';
   }
 
   release(id) {

--- a/.claude/skills/dev-server/scripts/test-queue.mjs
+++ b/.claude/skills/dev-server/scripts/test-queue.mjs
@@ -1,0 +1,347 @@
+/**
+ * Serialised unit-test runs.
+ *
+ * The daemon owns the run, not the caller. That is the whole point: an agent that dies mid-wait
+ * releases nothing, because it was never holding anything. A slot is held while a run is TRACKED
+ * and released when the child process exits — never on a status field, which is a report rather
+ * than an observation (a grandchild can outlive a kill; on Windows the tracked process is the
+ * shell, not vitest).
+ *
+ * Timer-free by design. `sweep()` is called by the daemon, so every deadline in here is driven by
+ * the injected clock and a test can advance it without waiting.
+ */
+
+import { EventEmitter } from 'events';
+import { spawn } from 'child_process';
+
+export const DEFAULT_CONCURRENCY = 1;
+const DEFAULT_ABANDON_AFTER_MS = 10 * 60 * 1000;
+const DEFAULT_RUN_TIMEOUT_MS = 30 * 60 * 1000;
+const DEFAULT_KILL_GRACE_MS = 30 * 1000;
+const MAX_LOG_LINES = 2000;
+const KEEP_FINISHED = 50;
+const DEFAULT_WAIT_COMMAND = 'node .claude/skills/dev-server/cli.mjs test wait';
+
+const TERMINAL = new Set(['completed', 'failed', 'cancelled', 'timeout', 'abandoned', 'error']);
+
+export function isTerminal(status) {
+  return TERMINAL.has(status);
+}
+
+function defaultStartRun({ worktree, args, onLog }) {
+  const emitter = new EventEmitter();
+  const isWindows = process.platform === 'win32';
+  const pnpm = isWindows ? 'pnpm.cmd' : 'pnpm';
+  const argv = ['run', 'test:unit:run', ...args];
+
+  onLog('info', `> ${pnpm} ${argv.join(' ')}`);
+
+  let child;
+  try {
+    child = spawn(pnpm, argv, {
+      cwd: worktree,
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: isWindows,
+    });
+  } catch (err) {
+    queueMicrotask(() => emitter.emit('exit', -1, err.message));
+    emitter.kill = () => {};
+    return emitter;
+  }
+
+  const pipe = (stream, level) =>
+    stream.on('data', (d) => {
+      for (const line of d.toString().split('\n')) {
+        if (line.trim()) onLog(level, line.trim());
+      }
+    });
+  pipe(child.stdout, 'stdout');
+  pipe(child.stderr, 'stderr');
+
+  child.on('exit', (code) => emitter.emit('exit', code ?? -1));
+  child.on('error', (err) => emitter.emit('exit', -1, err.message));
+
+  emitter.pid = child.pid;
+  emitter.kill = () => {
+    try {
+      if (isWindows) spawn('taskkill', ['/pid', String(child.pid), '/f', '/t'], { shell: true });
+      else process.kill(-child.pid, 'SIGKILL');
+    } catch {
+      /* already gone */
+    }
+  };
+  return emitter;
+}
+
+let counter = 0;
+function nextId() {
+  counter += 1;
+  return `t${counter.toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+}
+
+export class TestQueue {
+  constructor(options = {}) {
+    const {
+      concurrency = DEFAULT_CONCURRENCY,
+      startRun = defaultStartRun,
+      now = () => Date.now(),
+      abandonAfterMs = DEFAULT_ABANDON_AFTER_MS,
+      runTimeoutMs = DEFAULT_RUN_TIMEOUT_MS,
+      killGraceMs = DEFAULT_KILL_GRACE_MS,
+      waitCommand = DEFAULT_WAIT_COMMAND,
+    } = options;
+
+    this.concurrency = normalizeConcurrency(concurrency);
+    this.startRun = startRun;
+    this.now = now;
+    this.abandonAfterMs = abandonAfterMs;
+    this.runTimeoutMs = runTimeoutMs;
+    this.killGraceMs = killGraceMs;
+    this.waitCommand = waitCommand;
+
+    this.runs = new Map();
+    this.order = [];
+    this.running = new Set();
+  }
+
+  get paused() {
+    return this.concurrency === 0;
+  }
+
+  request({ worktree, args = [] } = {}) {
+    if (!worktree) throw new Error('worktree is required');
+    const at = this.now();
+    const run = {
+      id: nextId(),
+      worktree,
+      args,
+      status: 'queued',
+      enqueuedAt: at,
+      touchedAt: at,
+      startedAt: null,
+      finishedAt: null,
+      exitCode: null,
+      error: null,
+      handle: null,
+      killRequestedAt: null,
+      cancelReason: null,
+      timedOut: false,
+      logs: [],
+      logIndex: 0,
+    };
+    this.runs.set(run.id, run);
+    this.order.push(run.id);
+    this.pump();
+    return this.view(run.id);
+  }
+
+  /** Reading a run is also the liveness signal that keeps a queued entry from being swept. */
+  get(id) {
+    const run = this.runs.get(id);
+    if (!run) return null;
+    run.touchedAt = this.now();
+    return this.view(id);
+  }
+
+  list() {
+    return Array.from(this.runs.keys()).map((id) => this.view(id));
+  }
+
+  logs(id, since = -1) {
+    const run = this.runs.get(id);
+    if (!run) return null;
+    run.touchedAt = this.now();
+    return run.logs.filter((entry) => entry.index > since);
+  }
+
+  cancel(id, reason = 'cancelled') {
+    const run = this.runs.get(id);
+    if (!run) return null;
+    if (isTerminal(run.status)) return this.view(id);
+    if (run.status === 'running') {
+      run.cancelReason = reason;
+      run.killRequestedAt = this.now();
+      run.handle?.kill();
+      return this.view(id);
+    }
+    this.dequeue(id);
+    this.settle(run, 'cancelled', null, reason === 'cancelled' ? null : reason);
+    return this.view(id);
+  }
+
+  setConcurrency(value) {
+    this.concurrency = normalizeConcurrency(value);
+    this.pump();
+    return this.concurrency;
+  }
+
+  /**
+   * Deadlines, driven by the injected clock rather than a timer. Returns what it acted on so a
+   * caller (and a test) can assert on it rather than infer it.
+   */
+  sweep() {
+    const at = this.now();
+    const swept = { abandoned: [], timedOut: [], forced: [] };
+
+    for (const id of [...this.order]) {
+      const run = this.runs.get(id);
+      if (at - run.touchedAt < this.abandonAfterMs) continue;
+      this.dequeue(id);
+      this.settle(run, 'abandoned', null);
+      swept.abandoned.push(id);
+    }
+
+    for (const id of [...this.running]) {
+      const run = this.runs.get(id);
+      if (!run || run.startedAt === null) continue;
+
+      // A kill that produced no exit would hold the slot forever — which is the wedge this queue
+      // exists to prevent. Past the grace, detach the handle (so a late exit cannot double-settle)
+      // and free the slot on our own authority.
+      if (run.killRequestedAt !== null && at - run.killRequestedAt >= this.killGraceMs) {
+        run.handle = null;
+        this.release(id);
+        this.settle(
+          run,
+          run.timedOut ? 'timeout' : 'cancelled',
+          null,
+          'process did not exit after kill; slot released anyway'
+        );
+        swept.forced.push(id);
+        continue;
+      }
+
+      if (run.killRequestedAt !== null) continue;
+      if (at - run.startedAt < this.runTimeoutMs) continue;
+      run.timedOut = true;
+      run.killRequestedAt = at;
+      run.handle?.kill();
+      swept.timedOut.push(id);
+    }
+
+    if (swept.abandoned.length || swept.forced.length) this.pump();
+    return swept;
+  }
+
+  shutdown() {
+    for (const id of [...this.running]) {
+      const run = this.runs.get(id);
+      run.cancelReason = 'daemon-shutdown';
+      run.killRequestedAt = this.now();
+      run.handle?.kill();
+    }
+  }
+
+  // --- internals ---
+
+  pump() {
+    while (this.running.size < this.concurrency && this.order.length > 0) {
+      this.start(this.order.shift());
+    }
+  }
+
+  start(id) {
+    const run = this.runs.get(id);
+    if (!run || run.status !== 'queued') return;
+
+    run.status = 'running';
+    run.startedAt = this.now();
+    run.touchedAt = run.startedAt;
+    this.running.add(id);
+
+    const onLog = (level, message) => this.addLog(run, level, message);
+    let handle;
+    try {
+      handle = this.startRun({ worktree: run.worktree, args: run.args, onLog });
+    } catch (err) {
+      this.release(id);
+      this.settle(run, 'error', null, err.message);
+      this.pump();
+      return;
+    }
+    run.handle = handle;
+
+    handle.on('exit', (code, errorMessage) => {
+      // Identity guard: an exit from a handle this run no longer owns must not settle it, and
+      // must not release a slot it no longer holds.
+      if (run.handle !== handle) return;
+      run.handle = null;
+      this.release(id);
+      this.settle(run, this.outcomeFor(run, code), code, errorMessage ?? run.cancelReason ?? null);
+      this.pump();
+    });
+  }
+
+  outcomeFor(run, code) {
+    if (run.timedOut) return 'timeout';
+    if (run.cancelReason) return 'cancelled';
+    return code === 0 ? 'completed' : 'failed';
+  }
+
+  release(id) {
+    this.running.delete(id);
+  }
+
+  dequeue(id) {
+    const at = this.order.indexOf(id);
+    if (at !== -1) this.order.splice(at, 1);
+  }
+
+  settle(run, status, exitCode, error = null) {
+    run.status = status;
+    run.exitCode = exitCode;
+    run.error = error;
+    run.finishedAt = this.now();
+    this.prune();
+  }
+
+  prune() {
+    const finished = Array.from(this.runs.values())
+      .filter((run) => isTerminal(run.status))
+      .sort((a, b) => a.finishedAt - b.finishedAt);
+    while (finished.length > KEEP_FINISHED) this.runs.delete(finished.shift().id);
+  }
+
+  addLog(run, level, message) {
+    run.logs.push({ index: run.logIndex++, level, message, at: this.now() });
+    if (run.logs.length > MAX_LOG_LINES) run.logs.shift();
+  }
+
+  positionOf(id) {
+    const at = this.order.indexOf(id);
+    return at === -1 ? 0 : at + 1;
+  }
+
+  view(id) {
+    const run = this.runs.get(id);
+    if (!run) return null;
+    return {
+      id: run.id,
+      status: run.status,
+      worktree: run.worktree,
+      args: run.args,
+      // Exact, not estimated: the index in one ordered array. 0 means "not waiting behind anyone".
+      position: this.positionOf(id),
+      queueLength: this.order.length,
+      running: this.running.size,
+      concurrency: this.concurrency,
+      paused: this.paused,
+      enqueuedAt: run.enqueuedAt,
+      startedAt: run.startedAt,
+      finishedAt: run.finishedAt,
+      exitCode: run.exitCode,
+      error: run.error,
+      logIndex: run.logIndex,
+      waitCommand: `${this.waitCommand} ${run.id}`,
+    };
+  }
+}
+
+function normalizeConcurrency(value) {
+  const parsed = typeof value === 'number' ? value : parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`concurrency must be an integer >= 0 (0 pauses the queue), got: ${value}`);
+  }
+  return parsed;
+}

--- a/.claude/skills/dev-server/scripts/test-queue.mjs
+++ b/.claude/skills/dev-server/scripts/test-queue.mjs
@@ -300,6 +300,9 @@ export class TestQueue {
     try {
       handle = this.startRun({ worktree: run.worktree, args: run.args, onLog, onExit });
     } catch (err) {
+      // A runner that reported an exit and then threw has already produced a verdict; overwriting
+      // it here would replace a real result with the noise that followed it.
+      if (settled) return;
       this.release(id);
       this.settle(run, 'error', null, err.message);
       this.pump();

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "test:gen": "cross-env NODE_ENV=development npx playwright codegen",
     "test:reset": "make bootstrap-db",
     "test:unit": "vitest --project unit",
-    "test:unit:run": "vitest run --project unit",
+    "test:unit:run": "node scripts/test-unit-run.mjs",
     "test:unit:coverage": "vitest run --project unit --coverage",
     "test:packages": "vitest --project '@civitai/*'",
     "test:packages:run": "vitest run --project '@civitai/*'",

--- a/scripts/__tests__/dev-server-test-queue.test.ts
+++ b/scripts/__tests__/dev-server-test-queue.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Ships with the dev-server skill (plain .mjs, loaded by the daemon under node, never bundled),
 // so it is imported by path rather than moved into src/ — same arrangement as the port probe.
-import { TestQueue } from '../../.claude/skills/dev-server/scripts/test-queue.mjs';
+import { TestQueue, exitCodeFor } from '../../.claude/skills/dev-server/scripts/test-queue.mjs';
 
 type FakeRun = EventEmitter & {
   kill: ReturnType<typeof vi.fn>;
@@ -14,9 +14,11 @@ type FakeRun = EventEmitter & {
 // Every fake terminates on demand and nothing here drives a loop: the queue owns no timers, so
 // each deadline is reached by moving the injected clock. A regression fails on an assertion
 // naming the wrong position or status, never by hanging the runner.
+type RunnerArgs = { worktree: string; onExit?: (code: number, error?: string) => void };
+
 function makeRunner() {
   const started: FakeRun[] = [];
-  const startRun = ({ worktree }: { worktree: string }) => {
+  const startRun = ({ worktree }: RunnerArgs): FakeRun => {
     const handle = new EventEmitter() as FakeRun;
     handle.kill = vi.fn(() => handle.emit('exit', 1));
     handle.finish = (code: number) => handle.emit('exit', code);
@@ -34,7 +36,7 @@ describe('dev-server test queue', () => {
   const build = (overrides = {}) =>
     new TestQueue({
       // Indirect so a test can swap the runner after construction.
-      startRun: (opts: { worktree: string }) => runner.startRun(opts),
+      startRun: (opts: RunnerArgs) => runner.startRun(opts),
       now: () => now,
       abandonAfterMs: 10_000,
       runTimeoutMs: 60_000,
@@ -140,14 +142,18 @@ describe('dev-server test queue', () => {
   });
 
   it('never abandons a run that is already executing — the daemon owns it, not the caller', () => {
-    const queue = build();
-    const run = queue.request({ worktree: '/wt/a' });
+    const queue = build({ concurrency: 2 });
+    const executing = queue.request({ worktree: '/wt/a' });
+    queue.request({ worktree: '/wt/b' });
+    const waiting = queue.request({ worktree: '/wt/c' });
 
     now += 30_000; // three times the abandon window, half the run ceiling
     const swept = queue.sweep();
 
-    expect(swept.abandoned).toEqual([]);
-    expect(queue.get(run.id).status).toBe('running');
+    // The queued sibling proves the sweep ran and was capable of abandoning something; without it
+    // an empty `abandoned` list would be true no matter what the sweep did.
+    expect(swept.abandoned).toEqual([waiting.id]);
+    expect(queue.get(executing.id).status).toBe('running');
   });
 
   it('kills a run that overruns the ceiling and hands the slot to the next caller', () => {
@@ -175,7 +181,7 @@ describe('dev-server test queue', () => {
   it('frees the slot when a killed process never exits, rather than holding it forever', () => {
     const queue = build({ killGraceMs: 5_000 });
     // A process that swallows the kill — the wedge this whole queue exists to prevent.
-    runner.startRun = ({ worktree }: { worktree: string }) => {
+    runner.startRun = ({ worktree }: RunnerArgs): FakeRun => {
       const handle = new EventEmitter() as FakeRun;
       handle.kill = vi.fn();
       handle.finish = () => {};
@@ -257,6 +263,94 @@ describe('dev-server test queue', () => {
     expect(queue.get('nope')).toBeNull();
     expect(queue.logs('nope')).toBeNull();
     expect(queue.cancel('nope')).toBeNull();
+  });
+
+  // Every sweep between the kill and the grace expiring must leave the deadline alone. Sweeping
+  // resets it, the force-release never fires, and the queue wedges permanently -- and the daemon
+  // sweeps every 5s plus on every request, against a 30s default grace.
+  it('does not restart the kill grace on each sweep', () => {
+    const queue = build({ killGraceMs: 5_000 });
+    runner.startRun = ({ worktree }: RunnerArgs): FakeRun => {
+      const handle = new EventEmitter() as FakeRun;
+      handle.kill = vi.fn();
+      handle.finish = () => {};
+      handle.worktree = worktree;
+      runner.started.push(handle);
+      return handle;
+    };
+    const stuck = queue.request({ worktree: '/wt/a' });
+    const next = queue.request({ worktree: '/wt/b' });
+
+    now += 60_001;
+    queue.get(next.id);
+    expect(queue.sweep().timedOut).toEqual([stuck.id]);
+
+    // Four sweeps inside the grace, the way the daemon's own 5s timer would.
+    for (let i = 0; i < 4; i += 1) {
+      now += 1_000;
+      queue.get(next.id);
+      expect(queue.sweep().forced).toEqual([]);
+    }
+    now += 1_001;
+
+    expect(queue.sweep().forced).toEqual([stuck.id]);
+    expect(queue.get(next.id).status).toBe('running');
+  });
+
+  it('refuses to call a killed run a pass, even when its process exited 0', () => {
+    const queue = build();
+    // A kill that does not itself end the process — on Windows it is a separately spawned
+    // taskkill, so the child can still exit on its own terms first.
+    runner.startRun = ({ worktree }: RunnerArgs): FakeRun => {
+      const handle = new EventEmitter() as FakeRun;
+      handle.kill = vi.fn();
+      handle.finish = (code: number) => handle.emit('exit', code);
+      handle.worktree = worktree;
+      runner.started.push(handle);
+      return handle;
+    };
+    const run = queue.request({ worktree: '/wt/a' });
+
+    queue.cancel(run.id);
+    // The child exited cleanly in the window between the kill being issued and it landing.
+    runner.started[0].finish(0);
+
+    const view = queue.get(run.id);
+    expect(view.status).toBe('cancelled');
+    expect(view.exitCode).toBe(0);
+    // What a waiter would exit with. 0 here would report a green suite that never finished.
+    expect(exitCodeFor(view)).toBe(1);
+  });
+
+  it('exits nonzero for every terminal state that is not a clean pass', () => {
+    expect(exitCodeFor({ status: 'completed', exitCode: 0 })).toBe(0);
+    expect(exitCodeFor({ status: 'failed', exitCode: 1 })).toBe(1);
+    expect(exitCodeFor({ status: 'timeout', exitCode: 0 })).toBe(1);
+    expect(exitCodeFor({ status: 'cancelled', exitCode: 0 })).toBe(1);
+    expect(exitCodeFor({ status: 'abandoned', exitCode: null })).toBe(1);
+    expect(exitCodeFor({ status: 'error', exitCode: null })).toBe(1);
+  });
+
+  it('settles a runner that reports its exit before it returns a handle', () => {
+    const queue = build();
+    runner.startRun = ({ worktree, onExit }: RunnerArgs): FakeRun => {
+      const handle = new EventEmitter() as FakeRun;
+      handle.kill = vi.fn();
+      handle.finish = () => {};
+      handle.worktree = worktree;
+      runner.started.push(handle);
+      onExit!(0); // synchronous, before this function has returned anything
+      return handle;
+    };
+
+    const first = queue.request({ worktree: '/wt/a' });
+    const second = queue.request({ worktree: '/wt/b' });
+
+    // Without this, the finished run holds the only slot until the run ceiling expires and
+    // everything behind it is abandoned instead of run.
+    expect(queue.get(first.id).status).toBe('completed');
+    expect(queue.get(second.id).status).toBe('completed');
+    expect(runner.started).toHaveLength(2);
   });
 
   it('hands back a wait command naming the run', () => {

--- a/scripts/__tests__/dev-server-test-queue.test.ts
+++ b/scripts/__tests__/dev-server-test-queue.test.ts
@@ -324,11 +324,54 @@ describe('dev-server test queue', () => {
 
   it('exits nonzero for every terminal state that is not a clean pass', () => {
     expect(exitCodeFor({ status: 'completed', exitCode: 0 })).toBe(0);
-    expect(exitCodeFor({ status: 'failed', exitCode: 1 })).toBe(1);
     expect(exitCodeFor({ status: 'timeout', exitCode: 0 })).toBe(1);
     expect(exitCodeFor({ status: 'cancelled', exitCode: 0 })).toBe(1);
     expect(exitCodeFor({ status: 'abandoned', exitCode: null })).toBe(1);
     expect(exitCodeFor({ status: 'error', exitCode: null })).toBe(1);
+    // A distinctive code, so the table distinguishes passing the real code through from
+    // returning a bare 1.
+    expect(exitCodeFor({ status: 'failed', exitCode: 130 })).toBe(130);
+    // A child killed by a signal reports no code; -1 must not reach a shell as 255.
+    expect(exitCodeFor({ status: 'error', exitCode: -1 })).toBe(1);
+  });
+
+  it('calls a signal-killed run an error, not a test failure', () => {
+    const queue = build();
+    const run = queue.request({ worktree: '/wt/a' });
+
+    runner.started[0].finish(-1); // node reports no code when a child dies by signal
+
+    expect(queue.get(run.id).status).toBe('error');
+    expect(exitCodeFor(queue.get(run.id))).toBe(1);
+  });
+
+  it('ignores a late exit arriving after the slot was force-released', () => {
+    const queue = build({ killGraceMs: 5_000 });
+    runner.startRun = ({ worktree }: RunnerArgs): FakeRun => {
+      const handle = new EventEmitter() as FakeRun;
+      handle.kill = vi.fn();
+      handle.finish = (code: number) => handle.emit('exit', code);
+      handle.worktree = worktree;
+      runner.started.push(handle);
+      return handle;
+    };
+    const stuck = queue.request({ worktree: '/wt/a' });
+    const next = queue.request({ worktree: '/wt/b' });
+
+    now += 60_001;
+    queue.get(next.id);
+    queue.sweep();
+    now += 5_001;
+    expect(queue.sweep().forced).toEqual([stuck.id]);
+    expect(queue.get(next.id).status).toBe('running');
+
+    // The abandoned process finally exits, cleanly, long after its slot was given away.
+    runner.started[0].finish(0);
+
+    expect(queue.get(stuck.id).status).toBe('timeout');
+    expect(queue.get(stuck.id).exitCode).toBeNull();
+    expect(queue.get(next.id).status).toBe('running');
+    expect(runner.started).toHaveLength(2);
   });
 
   it('settles a runner that reports its exit before it returns a handle', () => {

--- a/scripts/__tests__/dev-server-test-queue.test.ts
+++ b/scripts/__tests__/dev-server-test-queue.test.ts
@@ -1,0 +1,268 @@
+import { EventEmitter } from 'events';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Ships with the dev-server skill (plain .mjs, loaded by the daemon under node, never bundled),
+// so it is imported by path rather than moved into src/ — same arrangement as the port probe.
+import { TestQueue } from '../../.claude/skills/dev-server/scripts/test-queue.mjs';
+
+type FakeRun = EventEmitter & {
+  kill: ReturnType<typeof vi.fn>;
+  finish: (code: number) => void;
+  worktree: string;
+};
+
+// Every fake terminates on demand and nothing here drives a loop: the queue owns no timers, so
+// each deadline is reached by moving the injected clock. A regression fails on an assertion
+// naming the wrong position or status, never by hanging the runner.
+function makeRunner() {
+  const started: FakeRun[] = [];
+  const startRun = ({ worktree }: { worktree: string }) => {
+    const handle = new EventEmitter() as FakeRun;
+    handle.kill = vi.fn(() => handle.emit('exit', 1));
+    handle.finish = (code: number) => handle.emit('exit', code);
+    handle.worktree = worktree;
+    started.push(handle);
+    return handle;
+  };
+  return { started, startRun };
+}
+
+describe('dev-server test queue', () => {
+  let now: number;
+  let runner: ReturnType<typeof makeRunner>;
+
+  const build = (overrides = {}) =>
+    new TestQueue({
+      // Indirect so a test can swap the runner after construction.
+      startRun: (opts: { worktree: string }) => runner.startRun(opts),
+      now: () => now,
+      abandonAfterMs: 10_000,
+      runTimeoutMs: 60_000,
+      ...overrides,
+    });
+
+  beforeEach(() => {
+    now = 1_000;
+    runner = makeRunner();
+  });
+
+  it('runs the first request immediately and queues the rest with exact positions', () => {
+    const queue = build();
+
+    const first = queue.request({ worktree: '/wt/a' });
+    const second = queue.request({ worktree: '/wt/b' });
+    const third = queue.request({ worktree: '/wt/c' });
+
+    expect(first.status).toBe('running');
+    expect(first.position).toBe(0);
+    expect(second.status).toBe('queued');
+    expect(second.position).toBe(1);
+    expect(third.position).toBe(2);
+    expect(runner.started).toHaveLength(1);
+  });
+
+  it('starts the next run when the running one exits, and reports the outcome', () => {
+    const queue = build();
+    const first = queue.request({ worktree: '/wt/a' });
+    const second = queue.request({ worktree: '/wt/b' });
+
+    runner.started[0].finish(0);
+
+    expect(queue.get(first.id).status).toBe('completed');
+    expect(queue.get(first.id).exitCode).toBe(0);
+    expect(queue.get(second.id).status).toBe('running');
+    expect(queue.get(second.id).position).toBe(0);
+    expect(runner.started).toHaveLength(2);
+  });
+
+  it('reports a nonzero exit as failed and still frees the slot', () => {
+    const queue = build();
+    const first = queue.request({ worktree: '/wt/a' });
+    const second = queue.request({ worktree: '/wt/b' });
+
+    runner.started[0].finish(1);
+
+    expect(queue.get(first.id).status).toBe('failed');
+    expect(queue.get(first.id).exitCode).toBe(1);
+    expect(queue.get(second.id).status).toBe('running');
+  });
+
+  it('honours a configured concurrency above one', () => {
+    const queue = build({ concurrency: 2 });
+
+    queue.request({ worktree: '/wt/a' });
+    queue.request({ worktree: '/wt/b' });
+    const third = queue.request({ worktree: '/wt/c' });
+
+    expect(runner.started).toHaveLength(2);
+    expect(third.status).toBe('queued');
+    expect(third.position).toBe(1);
+  });
+
+  it('treats concurrency 0 as paused, and says so rather than leaving the caller guessing', () => {
+    const queue = build({ concurrency: 0 });
+
+    const run = queue.request({ worktree: '/wt/a' });
+
+    expect(run.status).toBe('queued');
+    expect(run.paused).toBe(true);
+    expect(run.position).toBe(1);
+    expect(runner.started).toHaveLength(0);
+
+    queue.setConcurrency(1);
+
+    expect(queue.get(run.id).status).toBe('running');
+    expect(queue.get(run.id).paused).toBe(false);
+  });
+
+  it('rejects a negative concurrency instead of quietly clamping it', () => {
+    expect(() => build({ concurrency: -1 })).toThrow(/concurrency must be an integer/);
+  });
+
+  it('drops a queued run whose caller stopped polling, and starts the one behind it', () => {
+    const queue = build();
+    const first = queue.request({ worktree: '/wt/a' });
+    const abandoned = queue.request({ worktree: '/wt/b' });
+    const behind = queue.request({ worktree: '/wt/c' });
+
+    // The caller of `behind` is alive and polling; the caller of `abandoned` died.
+    now += 9_000;
+    queue.get(behind.id);
+    now += 2_000;
+
+    const swept = queue.sweep();
+
+    expect(swept.abandoned).toEqual([abandoned.id]);
+    expect(queue.get(abandoned.id).status).toBe('abandoned');
+    expect(queue.get(behind.id).status).toBe('queued');
+    expect(queue.get(behind.id).position).toBe(1);
+    expect(queue.get(first.id).status).toBe('running');
+  });
+
+  it('never abandons a run that is already executing — the daemon owns it, not the caller', () => {
+    const queue = build();
+    const run = queue.request({ worktree: '/wt/a' });
+
+    now += 30_000; // three times the abandon window, half the run ceiling
+    const swept = queue.sweep();
+
+    expect(swept.abandoned).toEqual([]);
+    expect(queue.get(run.id).status).toBe('running');
+  });
+
+  it('kills a run that overruns the ceiling and hands the slot to the next caller', () => {
+    const queue = build();
+    const stuck = queue.request({ worktree: '/wt/a' });
+    const next = queue.request({ worktree: '/wt/b' });
+
+    // `next` has a live waiter polling it, which is what keeps it out of the abandon sweep during
+    // a long run ahead of it.
+    for (let elapsed = 5_000; elapsed <= 55_000; elapsed += 5_000) {
+      now += 5_000;
+      queue.get(next.id);
+      expect(queue.sweep().timedOut).toEqual([]);
+    }
+    now += 5_001;
+
+    const swept = queue.sweep();
+
+    expect(swept.timedOut).toEqual([stuck.id]);
+    expect(runner.started[0].kill).toHaveBeenCalledTimes(1);
+    expect(queue.get(stuck.id).status).toBe('timeout');
+    expect(queue.get(next.id).status).toBe('running');
+  });
+
+  it('frees the slot when a killed process never exits, rather than holding it forever', () => {
+    const queue = build({ killGraceMs: 5_000 });
+    // A process that swallows the kill — the wedge this whole queue exists to prevent.
+    runner.startRun = ({ worktree }: { worktree: string }) => {
+      const handle = new EventEmitter() as FakeRun;
+      handle.kill = vi.fn();
+      handle.finish = () => {};
+      handle.worktree = worktree;
+      runner.started.push(handle);
+      return handle;
+    };
+    const stuck = queue.request({ worktree: '/wt/a' });
+    const next = queue.request({ worktree: '/wt/b' });
+
+    now += 60_001;
+    queue.get(next.id);
+    expect(queue.sweep().timedOut).toEqual([stuck.id]);
+    expect(queue.get(stuck.id).status).toBe('running'); // kill issued, exit not seen yet
+    expect(queue.get(next.id).status).toBe('queued');
+
+    now += 5_000;
+    const swept = queue.sweep();
+
+    expect(swept.forced).toEqual([stuck.id]);
+    expect(queue.get(stuck.id).status).toBe('timeout');
+    expect(queue.get(stuck.id).error).toMatch(/did not exit after kill/);
+    expect(queue.get(next.id).status).toBe('running');
+  });
+
+  it('does not settle a forced run twice when its exit finally arrives', () => {
+    const queue = build({ killGraceMs: 5_000 });
+    const stuck = queue.request({ worktree: '/wt/a' });
+    const next = queue.request({ worktree: '/wt/b' });
+
+    now += 60_001;
+    queue.get(next.id);
+    queue.sweep(); // kill requested; the fake's kill emits exit, settling it here
+    expect(queue.get(stuck.id).status).toBe('timeout');
+    expect(queue.get(next.id).status).toBe('running');
+
+    now += 10_000;
+    const swept = queue.sweep();
+
+    expect(swept.forced).toEqual([]);
+    expect(queue.get(next.id).status).toBe('running');
+    expect(runner.started).toHaveLength(2);
+  });
+
+  it('ignores an exit from a handle the run no longer owns', () => {
+    const queue = build();
+    const first = queue.request({ worktree: '/wt/a' });
+    const second = queue.request({ worktree: '/wt/b' });
+
+    runner.started[0].finish(0);
+    expect(queue.get(second.id).status).toBe('running');
+
+    // A late exit from the first run's dead handle must not settle anything or free a second slot.
+    runner.started[0].finish(1);
+
+    expect(queue.get(first.id).status).toBe('completed');
+    expect(queue.get(first.id).exitCode).toBe(0);
+    expect(queue.get(second.id).status).toBe('running');
+    expect(runner.started).toHaveLength(2);
+  });
+
+  it('cancels a queued run without disturbing the running one', () => {
+    const queue = build();
+    const running = queue.request({ worktree: '/wt/a' });
+    const doomed = queue.request({ worktree: '/wt/b' });
+    const behind = queue.request({ worktree: '/wt/c' });
+
+    queue.cancel(doomed.id);
+
+    expect(queue.get(doomed.id).status).toBe('cancelled');
+    expect(queue.get(behind.id).position).toBe(1);
+    expect(queue.get(running.id).status).toBe('running');
+    expect(runner.started).toHaveLength(1);
+  });
+
+  it('returns null for a run it has never heard of, so a waiter can fail instead of poll forever', () => {
+    const queue = build();
+
+    expect(queue.get('nope')).toBeNull();
+    expect(queue.logs('nope')).toBeNull();
+    expect(queue.cancel('nope')).toBeNull();
+  });
+
+  it('hands back a wait command naming the run', () => {
+    const queue = build({ waitCommand: 'node cli.mjs test wait' });
+    const run = queue.request({ worktree: '/wt/a' });
+
+    expect(run.waitCommand).toBe(`node cli.mjs test wait ${run.id}`);
+  });
+});

--- a/scripts/__tests__/dev-server-test-queue.test.ts
+++ b/scripts/__tests__/dev-server-test-queue.test.ts
@@ -345,6 +345,24 @@ describe('dev-server test queue', () => {
     expect(exitCodeFor(queue.get(run.id))).toBe(1);
   });
 
+  it('keeps the verdict of a runner that reported an exit and then threw', () => {
+    const queue = build();
+    runner.startRun = ({ worktree, onExit }: RunnerArgs): FakeRun => {
+      const handle = new EventEmitter() as FakeRun;
+      handle.kill = vi.fn();
+      handle.finish = () => {};
+      handle.worktree = worktree;
+      runner.started.push(handle);
+      onExit!(0);
+      throw new Error('boom after reporting');
+    };
+
+    const run = queue.request({ worktree: '/wt/a' });
+
+    expect(queue.get(run.id).status).toBe('completed');
+    expect(queue.get(run.id).exitCode).toBe(0);
+  });
+
   it('ignores a late exit arriving after the slot was force-released', () => {
     const queue = build({ killGraceMs: 5_000 });
     runner.startRun = ({ worktree }: RunnerArgs): FakeRun => {

--- a/scripts/__tests__/test-unit-run.test.ts
+++ b/scripts/__tests__/test-unit-run.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+// The wrapper `pnpm run test:unit:run` now points at. Imported by path for the same reason the
+// dev-server probes are: it runs under plain node and is never bundled.
+import { queueDecision } from '../test-unit-run.mjs';
+
+// The flag is what keeps this change invisible to CI and to anyone who does not run the daemon.
+// If any of these flip, a shared script starts behaving differently for people who never opted in.
+describe('test:unit:run — when the queue is used', () => {
+  it('runs directly when the flag is unset, which is everyone by default', () => {
+    expect(queueDecision([], {}).queue).toBe(false);
+    expect(queueDecision([], {}).why).toMatch(/not set/);
+  });
+
+  it('runs directly in CI even with the flag set', () => {
+    expect(queueDecision([], { CI: 'true', CIVITAI_TEST_QUEUE: '1' }).queue).toBe(false);
+    expect(queueDecision([], { CI: 'true', CIVITAI_TEST_QUEUE: '1' }).why).toMatch(/CI/);
+  });
+
+  it('treats the usual off-values as off, not as "set"', () => {
+    for (const value of ['0', 'false', 'off', 'no', 'FALSE', '']) {
+      expect(queueDecision([], { CIVITAI_TEST_QUEUE: value }).queue).toBe(false);
+    }
+  });
+
+  it('queues a bare full-suite run when the flag is on', () => {
+    expect(queueDecision([], { CIVITAI_TEST_QUEUE: '1' }).queue).toBe(true);
+    expect(queueDecision(['--reporter=dot'], { CIVITAI_TEST_QUEUE: '1' }).queue).toBe(true);
+  });
+
+  it('runs a file-scoped request directly — the fast loop must not queue behind a full suite', () => {
+    const env = { CIVITAI_TEST_QUEUE: '1' };
+    expect(queueDecision(['scripts/__tests__/a.test.ts'], env).queue).toBe(false);
+    expect(queueDecision(['src/b.spec.tsx'], env).queue).toBe(false);
+    expect(queueDecision(['--reporter=dot', 'src/c.test.mts'], env).queue).toBe(false);
+  });
+
+  it('does not mistake a flag value or a directory for a test file', () => {
+    const env = { CIVITAI_TEST_QUEUE: '1' };
+    // A trailing slash is a directory, and `--exclude '**/*.test.ts'` is a glob, not a target.
+    expect(queueDecision(['--dir', 'src/x.test.ts/'], env).queue).toBe(true);
+    expect(queueDecision(['--reporter=verbose'], env).queue).toBe(true);
+  });
+});

--- a/scripts/test-unit-run.mjs
+++ b/scripts/test-unit-run.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * `pnpm run test:unit:run` — runs the unit suite, optionally through the dev-server queue.
+ *
+ * Off by default: with no flag set this spawns exactly the vitest command the script used to be,
+ * so CI and anyone who does not run the daemon see no change at all.
+ *
+ * With CIVITAI_TEST_QUEUE set, a full-suite run is routed through the daemon's queue instead, which
+ * serialises it against every other agent on the machine. Routing rather than refusing is the whole
+ * point: there is no second command to learn, nothing to wrap around, and an agent that never read
+ * the guidance still gets queued.
+ */
+
+import { spawn } from 'child_process';
+import { existsSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const CLI = resolve(repoRoot, '.claude/skills/dev-server/cli.mjs');
+const DAEMON = 'http://127.0.0.1:9444';
+const POLL_MS = 2000;
+
+const TEST_FILE = /\.(?:test|spec)\.[cm]?[jt]sx?$/;
+
+export function queueDecision(args, env) {
+  if (env.CI) return { queue: false, why: 'CI runs the suite directly' };
+  if (!env.CIVITAI_TEST_QUEUE || /^(0|false|off|no)$/i.test(env.CIVITAI_TEST_QUEUE)) {
+    return { queue: false, why: 'CIVITAI_TEST_QUEUE is not set' };
+  }
+  // A narrow run is cheap and is the fast iteration loop. Queueing it behind a full suite would
+  // turn a two-second check into a nine-minute wait, and push callers toward batching more work
+  // into each run — the opposite of what this is for.
+  if (args.some((a) => TEST_FILE.test(a))) return { queue: false, why: 'run names specific files' };
+  return { queue: true };
+}
+
+function runDirect(args) {
+  // Resolved from node_modules rather than PATH, so this behaves the same when run directly as it
+  // does under `pnpm run`, which is the only context that puts .bin on PATH.
+  const local = resolve(
+    repoRoot,
+    'node_modules/.bin',
+    process.platform === 'win32' ? 'vitest.cmd' : 'vitest'
+  );
+  const bin = existsSync(local) ? local : 'vitest';
+  const child = spawn(bin, ['run', '--project', 'unit', ...args], {
+    cwd: repoRoot,
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  });
+  child.on('exit', (code, signal) => process.exit(signal ? 1 : code ?? 1));
+  child.on('error', (err) => {
+    console.error(`Failed to start vitest: ${err.message}`);
+    process.exit(1);
+  });
+}
+
+async function post(path, body) {
+  const res = await fetch(`${DAEMON}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`daemon returned ${res.status}`);
+  return res.json();
+}
+
+function ensureDaemon() {
+  return new Promise((done) => {
+    const child = spawn(process.execPath, [CLI, 'status'], { cwd: repoRoot, stdio: 'ignore' });
+    child.on('exit', () => done());
+    child.on('error', () => done());
+  });
+}
+
+async function runQueued(args) {
+  let run;
+  try {
+    run = await post('/test-runs', { worktree: repoRoot, args });
+  } catch {
+    await ensureDaemon();
+    try {
+      run = await post('/test-runs', { worktree: repoRoot, args });
+    } catch (err) {
+      // Never leave a caller unable to run tests because the queue is unavailable.
+      console.error(`Test queue unreachable (${err.message}); running directly.`);
+      return runDirect(args);
+    }
+  }
+
+  if (run.status === 'queued') {
+    console.error(
+      run.paused
+        ? `Queued at position ${run.position}. The queue is PAUSED (concurrency 0) — nothing starts until it is raised.`
+        : `Queued at position ${run.position} of ${run.queueLength} (${run.running}/${run.concurrency} running).`
+    );
+  }
+
+  let lastLog = -1;
+  for (;;) {
+    const res = await fetch(`${DAEMON}/test-runs/${run.id}`);
+    if (res.status === 404) {
+      console.error(
+        `The daemon forgot run ${run.id} — it was most likely restarted. Re-run this command.`
+      );
+      process.exit(2);
+    }
+    if (!res.ok) {
+      console.error(`Lost contact with the test queue (${res.status}).`);
+      process.exit(2);
+    }
+    const state = await res.json();
+
+    const logs = await fetch(`${DAEMON}/test-runs/${run.id}/logs?since=${lastLog}`).then((r) =>
+      r.json()
+    );
+    for (const entry of logs.logs ?? []) {
+      console.log(entry.message);
+      lastLog = entry.index;
+    }
+
+    if (state.status !== 'queued' && state.status !== 'running') {
+      if (state.status !== 'completed')
+        console.error(`Run ${state.status}${state.error ? `: ${state.error}` : ''}`);
+      // Only a completed run that exited 0 is a pass; a cancelled or timed-out run can carry a 0.
+      process.exit(state.status === 'completed' && state.exitCode === 0 ? 0 : state.exitCode || 1);
+    }
+    await new Promise((r) => setTimeout(r, POLL_MS));
+  }
+}
+
+if (
+  import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1] === fileURLToPath(import.meta.url)
+) {
+  const args = process.argv.slice(2);
+  const decision = queueDecision(args, process.env);
+  if (decision.queue && existsSync(CLI)) runQueued(args);
+  else runDirect(args);
+}


### PR DESCRIPTION
The unit suite takes every core. One run is fine; several agents each starting one at the same moment is what flattens the machine, and #3900's worker-pool cap is a precondition rather than the fix — nothing stopped five agents each starting a capped run at once. This adds the scheduler.

**This is a scheduling change, not a test-speed one.** Two people report the suite does not hurt them on their own machines; the variable is parallel agent count.

## Using it

```bash
node .claude/skills/dev-server/cli.mjs test run       # immediate: "started", or an exact position + the wait command
node .claude/skills/dev-server/cli.mjs test wait <id> # blocks; exits with the suite's own exit code
```

Two calls, because a caller needs to know where it stands before deciding how to wait. The wait polls from the CLI rather than inside the daemon — the daemon is single-process, so a request that held until its turn would stall every other agent's polling.

`pnpm run test:unit:run` also routes through the queue **when `CIVITAI_TEST_QUEUE` is set**, which is off by default and off in CI regardless. Unset, it spawns exactly the vitest command it always did, so this is a no-op for anyone not running the daemon. A file-scoped run stays direct: queueing a two-second check behind a nine-minute suite would break the fast loop.

## Design

**The daemon owns the run, not the caller** — that is what makes a dead agent harmless: it releases nothing because it was holding nothing. Slots are held while a run is *tracked* and released on child exit, **never on a status field**. Same rule #3936 applies to ports, for the same reason: status is a report about a process the daemon cannot see into.

Three deadlines close the rest: a queued run whose caller stops polling is dropped, a run past its ceiling is killed, and a kill that produces no exit frees the slot anyway after a grace.

Concurrency defaults to 1, configurable via `TEST_CONCURRENCY`. **0 is legal and means paused**, reported to callers rather than left to be inferred from a position that never moves. A malformed value falls back to 1 rather than throwing — the queue is built at module scope, so a typo in an optional setting would otherwise stop the daemon binding at all.

⚠️ **Needs a daemon restart to take effect** — a running daemon holds its code in memory.

## Verification

22 queue tests + 6 wrapper tests. Every fix carries a mutation control that names a value on revert. Typecheck clean. `blocks.router.workflow.test.ts` collects 347, so the submodule is intact.

Reviewed adversarially twice; **eight findings fixed**. The worst: `test wait` exited 0 for a cancelled or timed-out run whose child exited 0 in the kill window — a false green in the one command meant to substitute for the suite.

**Not verified, stated as gaps:** whether daemon shutdown orphans a vitest child (process-table probes could not see the child at all), and the POSIX `detached`/SIGKILL branch, unreachable on Windows.

The 16 pre-existing `src/`-scan failures on Windows are unchanged by this branch, which touches nothing under `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## The flag-unset path, measured rather than asserted

"No-op when the flag is unset" is the kind of claim that reads true and is never tested, so:

| Path | Observed |
|---|---|
| `CIVITAI_TEST_QUEUE` unset, bare run | vitest starts immediately; **no daemon contacted and none started** (nothing listening on 9444 afterwards) |
| Flag set, daemon running **without** the queue routes | `Test queue unreachable (daemon returned 404); running directly.` |
| `CI=true` + flag set | direct run — and this PR's own **Unit tests** job is that path, green |

The second row is the one that matters on a machine where the flag is already set and the daemon has not been restarted yet: the fallback is what every run hits until then, and it runs the suite rather than failing.
