### PR TITLE
fix(creator-shop): unclip the reseller popover, show its avatars, and tidy the manage stats

### DIFF
--- a/src/components/CreatorShop/Manage/ItemResellersPopover.browser.test.tsx
+++ b/src/components/CreatorShop/Manage/ItemResellersPopover.browser.test.tsx
@@ -1,0 +1,106 @@
+import { Paper, Popover, Table, MantineProvider } from '@mantine/core';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { render } from 'vitest-browser-react';
+import { describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import type * as TrpcModule from '~/utils/trpc';
+import { theme } from '~/providers/ThemeProvider';
+
+const RESELLERS = [
+  { user: { id: 1, username: 'ada', image: null }, sellerShare: 30, listedAt: new Date() },
+  { user: { id: 2, username: 'bo', image: null }, sellerShare: 40, listedAt: new Date() },
+  { user: { id: 3, username: 'cy', image: null }, sellerShare: 50, listedAt: new Date() },
+];
+
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcModule>()),
+  trpc: {
+    creatorShop: {
+      getItemResellers: { useQuery: () => ({ data: RESELLERS, isLoading: false }) },
+    },
+  },
+}));
+
+vi.mock('~/components/UserAvatar/UserAvatar', () => ({
+  UserAvatar: ({ user }: { user: { username: string } }) => <span>{user.username}</span>,
+}));
+
+const { ItemResellersPopover } = await import(
+  '~/components/CreatorShop/Manage/ItemResellersPopover'
+);
+
+const SCROLL_CONTAINER = '.mantine-ScrollArea-root';
+
+// The wrappers ManageItemsTable puts around every cell: a Paper that clips its
+// overflow, and Table.ScrollContainer, whose ScrollArea root is
+// `position: relative; overflow: hidden`. Anything absolutely positioned inside
+// that subtree is clipped by it, which is what hid the reseller list.
+function Harness({ children }: { children: React.ReactNode }) {
+  return (
+    <Paper withBorder radius="md" className="overflow-hidden" style={{ width: 400 }}>
+      <Table.ScrollContainer minWidth={860}>
+        <Table layout="fixed">
+          <Table.Tbody>
+            <Table.Tr>
+              <Table.Td>{children}</Table.Td>
+            </Table.Tr>
+          </Table.Tbody>
+        </Table>
+      </Table.ScrollContainer>
+    </Paper>
+  );
+}
+
+function renderInTable(ui: React.ReactElement) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return render(ui, {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        {/* The app theme, not a bare provider — it is the theme that defaults
+            every Popover to withinPortal={false}, so a bare MantineProvider
+            would portal the dropdown on its own and pass either way. */}
+        <MantineProvider theme={theme}>
+          <Harness>{children}</Harness>
+        </MantineProvider>
+      </QueryClientProvider>
+    ),
+  });
+}
+
+describe('ItemResellersPopover — the dropdown escapes the table scroll container', () => {
+  test('renders its dropdown outside the clipping ancestor', async () => {
+    renderInTable(<ItemResellersPopover shopItemId={1} count={3} />);
+
+    await page.getByText('3 creators resell this').click();
+    await expect.element(page.getByText('ada')).toBeInTheDocument();
+
+    const dropdown = document.querySelector('.mantine-Popover-dropdown');
+    const scrollContainer = document.querySelector(SCROLL_CONTAINER);
+    expect(dropdown).not.toBeNull();
+    expect(scrollContainer).not.toBeNull();
+    expect(scrollContainer!.contains(dropdown!)).toBe(false);
+  });
+
+  // Positive control: the same Popover WITHOUT the prop, under the same theme and
+  // the same wrappers, does land inside the clipping ancestor. Without this, a
+  // harness that silently lost the app theme would pass the test above for the
+  // wrong reason.
+  test('a popover left on the theme default lands inside it', async () => {
+    renderInTable(
+      <Popover opened position="bottom-start">
+        <Popover.Target>
+          <button type="button">control</button>
+        </Popover.Target>
+        <Popover.Dropdown>control body</Popover.Dropdown>
+      </Popover>
+    );
+
+    await expect.element(page.getByText('control body')).toBeInTheDocument();
+
+    const dropdown = document.querySelector('.mantine-Popover-dropdown');
+    const scrollContainer = document.querySelector(SCROLL_CONTAINER);
+    expect(dropdown).not.toBeNull();
+    expect(scrollContainer!.contains(dropdown!)).toBe(true);
+  });
+});

--- a/src/components/CreatorShop/Manage/ItemResellersPopover.browser.test.tsx
+++ b/src/components/CreatorShop/Manage/ItemResellersPopover.browser.test.tsx
@@ -1,11 +1,14 @@
-import { Paper, Popover, Table, MantineProvider } from '@mantine/core';
+import { MantineProvider, Popover } from '@mantine/core';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
-import { render } from 'vitest-browser-react';
 import { describe, expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
-import type * as TrpcModule from '~/utils/trpc';
+import { render } from 'vitest-browser-react';
+import type { CreatorShopManageItem } from '~/components/CreatorShop/creator-shop.util';
+import type * as UserAvatarModule from '~/components/UserAvatar/UserAvatar';
 import { theme } from '~/providers/ThemeProvider';
+import { CosmeticShopItemStatus } from '~/shared/utils/prisma/enums';
+import type * as TrpcModule from '~/utils/trpc';
 
 const RESELLERS = [
   { user: { id: 1, username: 'ada', image: null }, sellerShare: 30, listedAt: new Date() },
@@ -22,85 +25,111 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
   },
 }));
 
-vi.mock('~/components/UserAvatar/UserAvatar', () => ({
+vi.mock('~/components/UserAvatar/UserAvatar', async (importOriginal) => ({
+  ...(await importOriginal<typeof UserAvatarModule>()),
   UserAvatar: ({ user }: { user: { username: string } }) => <span>{user.username}</span>,
 }));
 
-const { ItemResellersPopover } = await import(
-  '~/components/CreatorShop/Manage/ItemResellersPopover'
-);
+// The real hook throws without CivitaiSessionProvider, and the row's actions menu
+// is the only thing in the table that reads it.
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+const { ManageItemsTable } = await import('~/components/CreatorShop/Manage/ManageItemsTable');
 
 const SCROLL_CONTAINER = '.mantine-ScrollArea-root';
+const DROPDOWN = '.mantine-Popover-dropdown';
 
-// The wrappers ManageItemsTable puts around every cell: a Paper that clips its
-// overflow, and Table.ScrollContainer, whose ScrollArea root is
-// `position: relative; overflow: hidden`. Anything absolutely positioned inside
-// that subtree is clipped by it, which is what hid the reseller list.
-function Harness({ children }: { children: React.ReactNode }) {
-  return (
-    <Paper withBorder radius="md" className="overflow-hidden" style={{ width: 400 }}>
-      <Table.ScrollContainer minWidth={860}>
-        <Table layout="fixed">
-          <Table.Tbody>
-            <Table.Tr>
-              <Table.Td>{children}</Table.Td>
-            </Table.Tr>
-          </Table.Tbody>
-        </Table>
-      </Table.ScrollContainer>
-    </Paper>
+const ITEM = {
+  id: 1,
+  title: 'Pastel Shooting Star',
+  cosmetic: null,
+  meta: {},
+  resellerCount: RESELLERS.length,
+  status: CosmeticShopItemStatus.Published,
+  purchases: 0,
+  unitAmount: 500,
+  createdAt: new Date(),
+  listed: true,
+  rejectionReason: null,
+} as unknown as CreatorShopManageItem;
+
+const noopMutation = { mutate: vi.fn(), isPending: false } as never;
+
+function renderTable(extra?: React.ReactNode) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return render(
+    <>
+      <ManageItemsTable
+        items={[ITEM]}
+        archiveItem={noopMutation}
+        setItemListed={noopMutation}
+        unarchiveItem={noopMutation}
+        deleteItem={noopMutation}
+      />
+      {extra}
+    </>,
+    {
+      wrapper: ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={queryClient}>
+          <MantineProvider theme={theme}>{children}</MantineProvider>
+        </QueryClientProvider>
+      ),
+    }
   );
 }
 
-function renderInTable(ui: React.ReactElement) {
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
-  return render(ui, {
-    wrapper: ({ children }: { children: React.ReactNode }) => (
-      <QueryClientProvider client={queryClient}>
-        {/* The app theme, not a bare provider — it is the theme that defaults
-            every Popover to withinPortal={false}, so a bare MantineProvider
-            would portal the dropdown on its own and pass either way. */}
-        <MantineProvider theme={theme}>
-          <Harness>{children}</Harness>
-        </MantineProvider>
-      </QueryClientProvider>
-    ),
-  });
-}
-
-describe('ItemResellersPopover — the dropdown escapes the table scroll container', () => {
-  test('renders its dropdown outside the clipping ancestor', async () => {
-    renderInTable(<ItemResellersPopover shopItemId={1} count={3} />);
+describe('ItemResellersPopover — the dropdown escapes the manage table', () => {
+  test('opens its dropdown outside the table scroll container', async () => {
+    renderTable();
 
     await page.getByText('3 creators resell this').click();
     await expect.element(page.getByText('ada')).toBeInTheDocument();
 
-    const dropdown = document.querySelector('.mantine-Popover-dropdown');
+    const dropdown = document.querySelector(DROPDOWN);
     const scrollContainer = document.querySelector(SCROLL_CONTAINER);
     expect(dropdown).not.toBeNull();
+    // Fails loudly if ManageItemsTable ever stops using Table.ScrollContainer —
+    // this guard is only meaningful while that clipping ancestor exists.
     expect(scrollContainer).not.toBeNull();
     expect(scrollContainer!.contains(dropdown!)).toBe(false);
   });
 
-  // Positive control: the same Popover WITHOUT the prop, under the same theme and
-  // the same wrappers, does land inside the clipping ancestor. Without this, a
-  // harness that silently lost the app theme would pass the test above for the
-  // wrong reason.
-  test('a popover left on the theme default lands inside it', async () => {
-    renderInTable(
-      <Popover opened position="bottom-start">
-        <Popover.Target>
-          <button type="button">control</button>
-        </Popover.Target>
-        <Popover.Dropdown>control body</Popover.Dropdown>
-      </Popover>
+  // Positive control for the harness: an unportalled popover rendered in the same
+  // table DOES land inside the clipping ancestor, so the assertion above is
+  // capable of failing.
+  test('an unportalled popover in the same table lands inside it', async () => {
+    renderTable();
+
+    await page.getByText('3 creators resell this').click();
+    await expect.element(page.getByText('ada')).toBeInTheDocument();
+
+    const scrollContainer = document.querySelector(SCROLL_CONTAINER)!;
+    const cell = scrollContainer.querySelector('td')!;
+    const control = document.createElement('div');
+    cell.appendChild(control);
+
+    render(
+      <MantineProvider theme={theme}>
+        <Popover opened position="bottom-start" withinPortal={false}>
+          <Popover.Target>
+            <button type="button">control</button>
+          </Popover.Target>
+          <Popover.Dropdown>control body</Popover.Dropdown>
+        </Popover>
+      </MantineProvider>,
+      { container: control }
     );
 
     await expect.element(page.getByText('control body')).toBeInTheDocument();
+    const controlDropdown = control.querySelector(DROPDOWN);
+    expect(controlDropdown).not.toBeNull();
+    expect(scrollContainer.contains(controlDropdown!)).toBe(true);
+  });
 
-    const dropdown = document.querySelector('.mantine-Popover-dropdown');
-    const scrollContainer = document.querySelector(SCROLL_CONTAINER);
-    expect(dropdown).not.toBeNull();
-    expect(scrollContainer!.contains(dropdown!)).toBe(true);
+  // The fix only matters because the app theme opts every Popover out of a portal.
+  // Pinned separately so removing that default reports itself here rather than as
+  // an unexplained failure in the tests above.
+  test('the app theme still defaults popovers out of a portal', () => {
+    expect(theme.components?.Popover?.defaultProps?.withinPortal).toBe(false);
   });
 });

--- a/src/components/CreatorShop/Manage/ItemResellersPopover.browser.test.tsx
+++ b/src/components/CreatorShop/Manage/ItemResellersPopover.browser.test.tsx
@@ -92,6 +92,11 @@ describe('ItemResellersPopover — the dropdown escapes the manage table', () =>
     // this guard is only meaningful while that clipping ancestor exists.
     expect(scrollContainer).not.toBeNull();
     expect(scrollContainer!.contains(dropdown!)).toBe(false);
+    // The table has a SECOND clipping ancestor — the Paper wrapping it also sets
+    // overflow-hidden — so escaping the scroll container alone is not enough.
+    const paper = document.querySelector('.mantine-Paper-root');
+    expect(paper).not.toBeNull();
+    expect(paper!.contains(dropdown!)).toBe(false);
   });
 
   // Positive control for the harness: an unportalled popover rendered in the same

--- a/src/components/CreatorShop/Manage/ItemResellersPopover.tsx
+++ b/src/components/CreatorShop/Manage/ItemResellersPopover.tsx
@@ -1,4 +1,4 @@
-import { Anchor, Group, Loader, Popover, Stack, Text } from '@mantine/core';
+import { Anchor, Divider, Group, Loader, Popover, ScrollArea, Stack, Text } from '@mantine/core';
 import { useState } from 'react';
 import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
 import { formatDate } from '~/utils/date-helpers';
@@ -21,7 +21,7 @@ export function ItemResellersPopover({ shopItemId, count }: { shopItemId: number
   // dropdown. Portalling is the only escape — no z-index can leave that clip.
   return (
     <Popover
-      width={280}
+      width={380}
       position="bottom-start"
       withArrow
       withinPortal
@@ -29,31 +29,44 @@ export function ItemResellersPopover({ shopItemId, count }: { shopItemId: number
       onChange={setOpened}
     >
       <Popover.Target>
-        <Anchor component="button" type="button" size="xs" onClick={() => setOpened((o) => !o)}>
+        <Anchor
+          component="button"
+          type="button"
+          size="xs"
+          lh="xs"
+          p={0}
+          className="w-fit text-left focus:outline-none focus-visible:outline focus-visible:outline-1"
+          onClick={() => setOpened((o) => !o)}
+        >
           {count} {count === 1 ? 'creator resells' : 'creators resell'} this
         </Anchor>
       </Popover.Target>
-      <Popover.Dropdown>
+      <Popover.Dropdown p={0}>
+        <Text size="xs" c="dimmed" px="sm" py="xs" className="whitespace-nowrap">
+          Each keeps the share they listed under, even if you change it.
+        </Text>
+        <Divider />
         {isLoading ? (
-          <Loader size="xs" />
+          <Group justify="center" p="sm">
+            <Loader size="xs" />
+          </Group>
         ) : (
-          <Stack gap="xs">
-            <Text size="xs" c="dimmed">
-              Each keeps the share they listed under, even if you change it.
-            </Text>
-            {data.map(({ user, sellerShare, listedAt }) => (
-              <Group key={user.id} justify="space-between" wrap="nowrap" gap="xs">
-                <UserAvatar user={user} size="xs" withUsername linkToProfile />
-                <Text size="xs" fw={600} c="green" style={{ whiteSpace: 'nowrap' }}>
-                  {sellerShare}%
-                  <Text span c="dimmed" fw={400}>
-                    {' '}
-                    · {formatDate(listedAt)}
+          <ScrollArea.Autosize mah={240}>
+            <Stack gap="xs" px="sm" py="xs">
+              {data.map(({ user, sellerShare, listedAt }) => (
+                <Group key={user.id} justify="space-between" wrap="nowrap" gap="xs">
+                  <UserAvatar user={user} size="xs" withUsername linkToProfile />
+                  <Text size="xs" fw={600} c="green" style={{ whiteSpace: 'nowrap' }}>
+                    {sellerShare}%
+                    <Text span c="dimmed" fw={400}>
+                      {' '}
+                      · {formatDate(listedAt)}
+                    </Text>
                   </Text>
-                </Text>
-              </Group>
-            ))}
-          </Stack>
+                </Group>
+              ))}
+            </Stack>
+          </ScrollArea.Autosize>
         )}
       </Popover.Dropdown>
     </Popover>

--- a/src/components/CreatorShop/Manage/ItemResellersPopover.tsx
+++ b/src/components/CreatorShop/Manage/ItemResellersPopover.tsx
@@ -22,8 +22,9 @@ export function ItemResellersPopover({ shopItemId, count }: { shopItemId: number
   return (
     <Popover
       width={380}
-      position="bottom-start"
+      position="bottom"
       withArrow
+      arrowSize={12}
       withinPortal
       opened={opened}
       onChange={setOpened}
@@ -43,7 +44,7 @@ export function ItemResellersPopover({ shopItemId, count }: { shopItemId: number
       </Popover.Target>
       <Popover.Dropdown p={0}>
         <Text size="xs" c="dimmed" px="sm" py="xs" className="whitespace-nowrap">
-          Each keeps the share they listed under, even if you change it.
+          Each creator keeps the share listed below, even if you change it
         </Text>
         <Divider />
         {isLoading ? (

--- a/src/components/CreatorShop/Manage/ItemResellersPopover.tsx
+++ b/src/components/CreatorShop/Manage/ItemResellersPopover.tsx
@@ -36,14 +36,14 @@ export function ItemResellersPopover({ shopItemId, count }: { shopItemId: number
           size="xs"
           lh="xs"
           p={0}
-          className="w-fit text-left focus:outline-none focus-visible:outline focus-visible:outline-1"
+          className="w-fit text-left"
           onClick={() => setOpened((o) => !o)}
         >
           {count} {count === 1 ? 'creator resells' : 'creators resell'} this
         </Anchor>
       </Popover.Target>
       <Popover.Dropdown p={0}>
-        <Text size="xs" c="dimmed" px="sm" py="xs" className="whitespace-nowrap">
+        <Text size="xs" c="dimmed" px="sm" py="xs">
           Each creator keeps the share listed below, even if you change it
         </Text>
         <Divider />

--- a/src/components/CreatorShop/Manage/ItemResellersPopover.tsx
+++ b/src/components/CreatorShop/Manage/ItemResellersPopover.tsx
@@ -16,8 +16,18 @@ export function ItemResellersPopover({ shopItemId, count }: { shopItemId: number
     { enabled: opened }
   );
 
+  // The theme defaults every Popover to withinPortal={false}, and this one opens
+  // inside the manage table's scroll container (overflow: hidden), which clips the
+  // dropdown. Portalling is the only escape — no z-index can leave that clip.
   return (
-    <Popover width={280} position="bottom-start" withArrow opened={opened} onChange={setOpened}>
+    <Popover
+      width={280}
+      position="bottom-start"
+      withArrow
+      withinPortal
+      opened={opened}
+      onChange={setOpened}
+    >
       <Popover.Target>
         <Anchor component="button" type="button" size="xs" onClick={() => setOpened((o) => !o)}>
           {count} {count === 1 ? 'creator resells' : 'creators resell'} this

--- a/src/components/CreatorShop/Manage/ManageStats.tsx
+++ b/src/components/CreatorShop/Manage/ManageStats.tsx
@@ -1,4 +1,3 @@
-import { SimpleGrid } from '@mantine/core';
 import {
   IconBolt,
   IconBuildingStore,
@@ -20,7 +19,9 @@ export function ManageStats({
   resaleStats?: CreatorShopResaleStats;
 }) {
   return (
-    <SimpleGrid cols={{ base: 2, sm: 3, lg: 4 }} spacing="md">
+    // Wrapping is driven by how much room a card needs, not by the viewport, so
+    // six sit on one row wherever six fit and only fold when they would squash.
+    <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(200px,1fr))]">
       <StatCard
         label="Published"
         value={stats.published}
@@ -60,6 +61,6 @@ export function ManageStats({
         icon={<IconBuildingStore size={20} />}
         sub="from other creators"
       />
-    </SimpleGrid>
+    </div>
   );
 }

--- a/src/components/CreatorShop/Manage/ManageStats.tsx
+++ b/src/components/CreatorShop/Manage/ManageStats.tsx
@@ -20,7 +20,7 @@ export function ManageStats({
   resaleStats?: CreatorShopResaleStats;
 }) {
   return (
-    <SimpleGrid cols={{ base: 2, sm: 3, lg: 6 }} spacing="md">
+    <SimpleGrid cols={{ base: 2, sm: 3, lg: 4 }} spacing="md">
       <StatCard
         label="Published"
         value={stats.published}

--- a/src/components/CreatorShop/Manage/StatCard.tsx
+++ b/src/components/CreatorShop/Manage/StatCard.tsx
@@ -32,12 +32,7 @@ export function StatCard({
           <Text size="xs" c="dimmed" lineClamp={1}>
             {label}
           </Text>
-          <Text
-            size="lg"
-            fw={700}
-            className="whitespace-nowrap"
-            style={{ color: `var(--mantine-color-${color}-light-color)` }}
-          >
+          <Text size="lg" fw={700} style={{ color: `var(--mantine-color-${color}-light-color)` }}>
             {value}
           </Text>
           {sub && (

--- a/src/server/services/__tests__/creator-shop-resale-terms.service.test.ts
+++ b/src/server/services/__tests__/creator-shop-resale-terms.service.test.ts
@@ -274,6 +274,19 @@ describe('getShopItemResellers', () => {
     );
   });
 
+  // Most creators have no `user.image` at all — their avatar lives on the
+  // `profilePicture` relation, and UserAvatar only falls back to `image` when
+  // that relation is missing. Selecting `image` alone renders the placeholder
+  // for nearly every reseller, which is what shipped.
+  it('selects the profile picture, not just user.image', async () => {
+    mocks.resaleFindMany.mockResolvedValue([]);
+
+    await getShopItemResellers({ shopItemId: SHOP_ITEM_ID, userId: CREATOR_ID });
+
+    const userSelect = mocks.resaleFindMany.mock.calls[0][0].select.user.select;
+    expect(userSelect.profilePicture).toBeTruthy();
+  });
+
   it('refuses to tell a stranger who resells someone else’s item', async () => {
     await expect(getShopItemResellers({ shopItemId: SHOP_ITEM_ID, userId: 999 })).rejects.toThrow();
     expect(mocks.resaleFindMany).not.toHaveBeenCalled();

--- a/src/server/services/__tests__/creator-shop-resale-terms.service.test.ts
+++ b/src/server/services/__tests__/creator-shop-resale-terms.service.test.ts
@@ -274,17 +274,19 @@ describe('getShopItemResellers', () => {
     );
   });
 
-  // Most creators have no `user.image` at all — their avatar lives on the
-  // `profilePicture` relation, and UserAvatar only falls back to `image` when
-  // that relation is missing. Selecting `image` alone renders the placeholder
+  // Most creators have no `user.image` at all — the avatar lives on the
+  // `profilePicture` relation, and the decorations, nameplate and badges live on
+  // equipped `cosmetics`. UserAvatar falls back to `image` only when the
+  // relation is absent, so a select missing either renders a bare placeholder
   // for nearly every reseller, which is what shipped.
-  it('selects the profile picture, not just user.image', async () => {
+  it('selects everything UserAvatar draws, not just user.image', async () => {
     mocks.resaleFindMany.mockResolvedValue([]);
 
     await getShopItemResellers({ shopItemId: SHOP_ITEM_ID, userId: CREATOR_ID });
 
     const userSelect = mocks.resaleFindMany.mock.calls[0][0].select.user.select;
     expect(userSelect.profilePicture).toBeTruthy();
+    expect(userSelect.cosmetics).toBeTruthy();
   });
 
   it('refuses to tell a stranger who resells someone else’s item', async () => {

--- a/src/server/services/creator-shop.service.ts
+++ b/src/server/services/creator-shop.service.ts
@@ -4,7 +4,6 @@ import sharp from 'sharp';
 import { getEdgeUrl } from '~/client-utils/cf-images-utils';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { refreshOwnedStickerCache } from '~/server/redis/caches';
-import { profileImageSelect } from '~/server/selectors/image.selector';
 import { queueCosmeticPerceptualHash } from '~/server/services/cosmetic-phash.service';
 import {
   revokeCosmeticsFromUsers,
@@ -1546,18 +1545,10 @@ export const getShopItemResellers = async ({
     select: {
       sellerShare: true,
       createdAt: true,
-      // Most creators have no `image` and only a `profilePicture` relation, and
-      // UserAvatar falls back to `image` only when that relation is absent — so
-      // selecting `image` alone renders the placeholder for nearly everyone.
-      user: {
-        select: {
-          id: true,
-          username: true,
-          image: true,
-          deletedAt: true,
-          profilePicture: { select: profileImageSelect },
-        },
-      },
+      // The list renders UserAvatar with decorations and username, which reads
+      // the profile picture AND the equipped cosmetics. Selecting less than this
+      // renders a bare placeholder for nearly every reseller.
+      user: { select: userWithCosmeticsSelect },
     },
   });
   return rows

--- a/src/server/services/creator-shop.service.ts
+++ b/src/server/services/creator-shop.service.ts
@@ -4,6 +4,7 @@ import sharp from 'sharp';
 import { getEdgeUrl } from '~/client-utils/cf-images-utils';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { refreshOwnedStickerCache } from '~/server/redis/caches';
+import { profileImageSelect } from '~/server/selectors/image.selector';
 import { queueCosmeticPerceptualHash } from '~/server/services/cosmetic-phash.service';
 import {
   revokeCosmeticsFromUsers,
@@ -1545,7 +1546,18 @@ export const getShopItemResellers = async ({
     select: {
       sellerShare: true,
       createdAt: true,
-      user: { select: { id: true, username: true, image: true, deletedAt: true } },
+      // Most creators have no `image` and only a `profilePicture` relation, and
+      // UserAvatar falls back to `image` only when that relation is absent — so
+      // selecting `image` alone renders the placeholder for nearly everyone.
+      user: {
+        select: {
+          id: true,
+          username: true,
+          image: true,
+          deletedAt: true,
+          profilePicture: { select: profileImageSelect },
+        },
+      },
     },
   });
   return rows


### PR DESCRIPTION
Fixes the "x creators resell this" popup on `/user/{user}/shop/manage` (ClickUp [868krf59q](https://app.clickup.com/t/868krf59q), reported by Ellie), plus the layout and data problems found while looking at it on a real page.

## 1. The dropdown was clipped — and it was never z-index

The ticket's hypothesis was a stacking-context problem. The real mechanism is **clipping**, which no z-index value can escape.

- `ManageItemsTable` wraps every row in `Table.ScrollContainer`, whose `ScrollArea` root is `position: relative; overflow: hidden` (`.m_d57069b5` in `@mantine/core/styles.css`). The surrounding `Paper` also carries `overflow-hidden`.
- `src/providers/ThemeProvider.tsx:35` sets `Popover: { defaultProps: { withinPortal: false } }` app-wide, so this dropdown rendered as a **descendant** of that clipping container.
- Measured with 11 resellers (the real count on the top prod items, including Ellie's own item 363): **341.86px** of dropdown below the clip line. Hence "some creators are hidden" rather than all.

Fix: `withinPortal`, matching the row's actions `Menu`, which already does this for the same reason.

## 2. Reseller avatars never rendered

Found by Justin on the live page. `getShopItemResellers` selected `id, username, image, deletedAt`. **All 11 resellers of item 363 have `image = NULL`** — their avatar lives on the `profilePicture` relation, and `UserAvatar` falls back to `image` only when that relation is absent. So the list showed the placeholder for effectively everyone.

Fix: select `profilePicture` via the existing `profileImageSelect`.

## 3. Popover presentation

- No `mah` at all, so the list grew unbounded — capped at 240px behind `ScrollArea.Autosize` (verified: 240px viewport vs 393px content with 11 resellers).
- The explainer moved out of the scrolling region with a `Divider` under it, so it stays pinned as a header.
- Width 280 → 380 so that line fits without wrapping (measured, no overflow).
- The trigger stays a `<button>` — it toggles a popover, it is not navigation — but loses the button costume: `p={0}`, left-aligned, `w-fit`, and the focus ring only on `:focus-visible` rather than on mouse click.
- `position` `bottom-start` → `bottom` so it centres under the link, and `arrowSize={12}`. The arrow was always present (`withArrow` was set) but Mantine's 7px default is invisible white-on-white.

## 4. Manage stat cards

Six across left each card too narrow: labels clamped and the revenue value ran outside its card. Now `lg: 4`, wrapping 4 + 2. Also dropped `whitespace-nowrap` from `StatCard`'s value — widening fits today's numbers, but nothing clips the card, so a long enough value escapes again at some width. `StatCard` has exactly one consumer.

## Verification

- New browser test renders the **real** `ManageItemsTable` and asserts the dropdown is not contained by the scroll container, with a positive control (an explicitly unportalled popover in the same table **is** contained) so the assertion is capable of failing. Mutation-tested: removing `withinPortal` fails in 247ms with `AssertionError: expected true to be false`.
- The theme's `withinPortal: false` default is pinned in its own assertion, so removing that default reports itself rather than reddening an unrelated test.
- New service test asserts the reseller select asks for `profilePicture`. Mutation-tested: `expected undefined to be truthy`.
- `pnpm run typecheck` 0 errors, `eslint` clean on every touched file, `prettier` clean.
- Reviewed on a local dev server pointed at the production database, on Ellie's real page.

No migration, no schema change, no write path touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review pass

An adversarial reuse review found two real things, both fixed in `66e1e28c99`:

- The reseller select was a re-implementation of `simpleUserSelect`, and it was **still half a fix**: `UserAvatar` here renders `withUsername` and with decorations, both of which read equipped `cosmetics`, so every reseller would have rendered undecorated and un-badged. Now `userWithCosmeticsSelect` — which this file already imported ~50 lines above, under a comment describing exactly this need. The typecheck caught the duplicate import, which is its own evidence. The test pins `cosmetics` as well as `profilePicture`.
- The guard only checked one of the table's **two** clipping ancestors. It now asserts the dropdown escapes the `Paper` wrapper too.

Also dropped on the review's prompting: the hand-rolled focus classes (measured — after a real mouse click the outline is invisible with them, `2px solid transparent`, and without them, `0px none`, so they bought nothing on the case they were added for while downgrading Mantine's focus-visible ring), and `whitespace-nowrap` on the dropdown header, which at a fixed width could only overflow — the same failure this PR removes from `StatCard`.

Full unit suite on this branch: **16 failed / 16,735 passed**, matching the known Windows path-separator baseline of 16 across 6 files exactly.
