### PR TITLE
perf(tests): uncap vitest workers, cap via VITEST_MAX_WORKERS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,16 +120,25 @@ pnpm run test:ui          # Playwright with UI
 
 Both vitest suites are projects in `vitest.config.mts` (`--project unit` / `--project component`).
 
-#### Worker count: uncapped by default, `VITEST_MAX_WORKERS` to cap
-A suite uses Vitest's own worker count (`cpus - 1` in run mode, `floor(cpus / 2)` in watch; the browser pool `min(12, cpus - 1)`). Set `VITEST_MAX_WORKERS=<n>` for a smaller pool — it applies to every project, including the browser one:
+#### Worker count: uncapped by default, `VITEST_MAX_WORKERS` / `--max-workers` to size it
+A suite uses Vitest's own worker count (`cpus - 1` in run mode, `floor(cpus / 2)` in watch; the browser pool `min(12, cpus - 1)`).
 
 ```bash
-VITEST_MAX_WORKERS=8 pnpm run test:unit:run
+VITEST_MAX_WORKERS=8 pnpm exec vitest run --project unit   # direct run
+pnpm run test:unit:run --max-workers=8                     # through the dev-server queue
 ```
 
-**Why uncapped is the default.** A flat cap of 8 lived in `vitest.config.mts` (#3900) because several agents each running a full suite at once saturated the box. The dev-server test queue now serialises full-suite runs at concurrency 1 (#3947), so one suite has the machine to itself. Measured on a 32-core Windows box, alternating runs through that queue: **8 workers 507.3s / 526.9s, uncapped (31 workers) 281.4s / 295.8s** — 1.79x on the means. Nothing changes on CI, which runs on 4-vCPU `ubuntu-latest`, where the old cap's `cpus > 9` guard already made it inert.
+🔴 **The env var does not reach a queued run.** With `CIVITAI_TEST_QUEUE` set, `test:unit:run` hands the run to the dev-server daemon, which spawns it with **its own** environment — so `VITEST_MAX_WORKERS=8 pnpm run test:unit:run` silently runs at the full pool while you believe you capped it. The CLI flag is forwarded and does work (verified: 3 distinct `VITEST_POOL_ID`s from a 40-file probe run through the queue with `--max-workers=3`).
+
+⚠️ Either knob sets the count for **every** project, browser included, and it is **not clamped** to the browser pool's 12 — `getThreadsCount` returns it unchanged, so `--max-workers=16` launches 16 Chromium instances, past what upstream calls safe. It sizes the pool; it does not only shrink it.
+
+**Why uncapped is the default.** A flat cap of 8 lived in `vitest.config.mts` (#3900) because several agents each running a full suite at once saturated the box. The dev-server test queue now serialises `test:unit:run` at concurrency 1 (#3947). Measured on a 32-core Windows box, alternating runs through that queue: **8 workers 507.3s / 526.9s, uncapped (31 workers) 281.4s / 295.8s** — 1.79x on the means. Nothing changes on GitHub CI, which runs on 4-vCPU `ubuntu-latest`, where the old cap's `cpus > 9` guard already made it inert.
+
+⚠️ Only `test:unit:run` is queued. `test:component`, `test:packages:run`, `test:apps:run` and `test:lint-rules` call `vitest` directly, so a queued unit run and an unqueued component run still overlap — 31 workers plus 12 Chromium instances, where the old config bounded the pair at 8 + 6. Cap one of them by hand if you are sharing the box.
 
 ⚠️ More workers is not monotonically better once other pool settings move: with `--no-isolate` the same box measured 119s at 8 workers and 1025s at 31. Measure both ends before changing one.
+
+⚠️ In a container limited by a **CPU quota** rather than a cpuset, `os.availableParallelism()` reports the host's cores, so an uncapped run resolves to host-cores-1 workers under a much smaller budget. Nothing in this repo invokes Vitest that way — the only CI that does is `ubuntu-latest` — but a pipeline defined outside it should set `VITEST_MAX_WORKERS` explicitly.
 
 #### Never put unit tests under `src/pages`
 Next.js 16 treats **every** `.ts`/`.tsx` file under `src/pages` (incl. nested `__tests__/`) as a route, and `next build` runs a route-type validator over it. A Vitest test file there fails the build with `Type '...test' does not satisfy the constraint 'ApiRouteConfig'. Property 'default' is missing` — and **only `next build` catches it**: `pnpm typecheck`, `pnpm test`/vitest, and the CI typecheck/unit/component tasks all pass, so it sneaks through to the preview `build-image` step. Keep handler tests in a `__tests__/` dir **outside** `src/pages` (e.g. `src/server/__tests__/`) and import the handler via the `~/pages/...` alias. (Bit us on PR #2653.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,17 @@ pnpm run test:ui          # Playwright with UI
 
 Both vitest suites are projects in `vitest.config.mts` (`--project unit` / `--project component`).
 
+#### Worker count: uncapped by default, `VITEST_MAX_WORKERS` to cap
+A suite uses Vitest's own worker count (`cpus - 1` in run mode, `floor(cpus / 2)` in watch; the browser pool `min(12, cpus - 1)`). Set `VITEST_MAX_WORKERS=<n>` for a smaller pool — it applies to every project, including the browser one:
+
+```bash
+VITEST_MAX_WORKERS=8 pnpm run test:unit:run
+```
+
+**Why uncapped is the default.** A flat cap of 8 lived in `vitest.config.mts` (#3900) because several agents each running a full suite at once saturated the box. The dev-server test queue now serialises full-suite runs at concurrency 1 (#3947), so one suite has the machine to itself. Measured on a 32-core Windows box, alternating runs through that queue: **8 workers 507.3s / 526.9s, uncapped (31 workers) 281.4s / 295.8s** — 1.79x on the means. Nothing changes on CI, which runs on 4-vCPU `ubuntu-latest`, where the old cap's `cpus > 9` guard already made it inert.
+
+⚠️ More workers is not monotonically better once other pool settings move: with `--no-isolate` the same box measured 119s at 8 workers and 1025s at 31. Measure both ends before changing one.
+
 #### Never put unit tests under `src/pages`
 Next.js 16 treats **every** `.ts`/`.tsx` file under `src/pages` (incl. nested `__tests__/`) as a route, and `next build` runs a route-type validator over it. A Vitest test file there fails the build with `Type '...test' does not satisfy the constraint 'ApiRouteConfig'. Property 'default' is missing` — and **only `next build` catches it**: `pnpm typecheck`, `pnpm test`/vitest, and the CI typecheck/unit/component tasks all pass, so it sneaks through to the preview `build-image` step. Keep handler tests in a `__tests__/` dir **outside** `src/pages` (e.g. `src/server/__tests__/`) and import the handler via the `~/pages/...` alias. (Bit us on PR #2653.)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,9 @@ pnpm exec eslint <files you added>
 Use `pnpm exec prettier --write <file>`, **not** `pnpm prettier:write -- <file>`.
 The latter ignores the argument and reformats the entire repository.
 
+Both suites use Vitest's own worker count. To leave the machine usable while one
+runs, cap it for that run: `VITEST_MAX_WORKERS=8 pnpm test:unit:run`.
+
 ### Compare against a baseline, not against zero
 
 `pnpm test:component` can report two extra failing files on a cold

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,8 +81,11 @@ pnpm exec eslint <files you added>
 Use `pnpm exec prettier --write <file>`, **not** `pnpm prettier:write -- <file>`.
 The latter ignores the argument and reformats the entire repository.
 
-Both suites use Vitest's own worker count. To leave the machine usable while one
-runs, cap it for that run: `VITEST_MAX_WORKERS=8 pnpm test:unit:run`.
+Both suites use Vitest's own worker count (`cpus - 1`, or `min(12, cpus - 1)` for
+the browser one). To leave the machine usable while a suite runs, size it for that
+run with `--max-workers=8`, or with `VITEST_MAX_WORKERS=8` in the environment. The
+number applies to every project and is not clamped, so a value above 12 raises the
+Chromium instance count rather than lowering it.
 
 ### Compare against a baseline, not against zero
 

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,40 +1,26 @@
 import { defineConfig } from 'vitest/config';
 import { playwright } from '@vitest/browser-playwright';
-import os from 'os';
 import path from 'path';
 
-// Vitest defaults to `cpus - 1` workers, so two concurrent suites saturate a 32-core dev box.
-// Measured here on the unit suite: 31 workers 235.9s, 8 workers 410.2s — 1.74x slower, for a
-// machine that stays usable while several agents run suites at once.
+// Worker count is UNCAPPED by default — Vitest's own resolution applies untouched (`cpus - 1` in
+// run mode, `floor(cpus / 2)` in watch; the browser pool sizes itself at `min(12, cpus - 1)`).
 //
-// The cap must only ever REDUCE. Vitest's default depends on the resolved mode (`cpus - 1` in run,
-// `floor(cpus / 2)` in watch) and that mode is NOT knowable from this file: `vitest run --watch` is
-// explicitly supported and resolves to watch while `process.argv` still says "run", so sniffing argv
-// raises the count on exactly the small machines this is meant to protect.
+// The flat cap of 8 that lived here (#3900) existed because several agents each running a full
+// suite at once saturated the box. The dev-server test queue now serialises full-suite runs at
+// concurrency 1 (#3947), so one suite has the machine to itself and may use all of it.
 //
-// So don't try to know the mode. Take the watch-mode default as the ceiling — it is the smaller of
-// the two at every core count — and apply nothing at all below 10 cores. That is mode-blind and
-// provably never exceeds either default, while leaving small boxes and CI (4 vCPU) untouched.
+// Set `VITEST_MAX_WORKERS=<n>` to cap a run. That is the name Vitest itself honours, so the number
+// is the same whichever layer reads it; it is read here as well because `getThreadsCount` consults
+// ONLY the project's own `maxWorkers`, never the root, so the browser (`component`) project has to
+// be handed it individually or it is not capped at all.
 //
-// `VITEST_MAX_WORKERS` still overrides everything below, per run.
+// `undefined` is genuinely identical to omitting the key — every consumer is a truthiness / `??`
+// check, and `configDefaults` has no `maxWorkers`.
 // (Unrelated but adjacent: `test.poolOptions` was removed in Vitest 4, so `poolOptions.forks.maxForks`
 // does nothing apart from logging a deprecation.)
-const WORKER_CAP = 8;
-// Below this the run-mode default (`cpus - 1`) is already <= WORKER_CAP, so there is nothing to cap.
-const CAP_ABOVE_CORES = WORKER_CAP + 1;
-const cpuCount = os.availableParallelism?.() ?? os.cpus().length;
-const capped = (ceiling: number) => Math.max(1, Math.min(WORKER_CAP, Math.floor(ceiling / 2)));
-
-// `undefined` leaves Vitest's own resolution completely alone.
-const maxWorkers = cpuCount > CAP_ABOVE_CORES ? capped(cpuCount) : undefined;
-
-// The browser pool sizes itself separately — `min(12, cpus - 1)`, because its main thread chokes
-// past ~12 — and `getThreadsCount` reads ONLY the project's own `maxWorkers`, never the root. So
-// the browser project has to be capped individually or it is not capped at all. Scope, stated
-// honestly: this equals the browser watch-mode default at every core count, so it bites only in
-// run mode (12 -> 6 at >= 13 cores) and is a deliberate no-op in watch.
-const componentMaxWorkers =
-  cpuCount > CAP_ABOVE_CORES ? capped(Math.min(12, cpuCount - 1)) : undefined;
+const envMaxWorkers = Number.parseInt(process.env.VITEST_MAX_WORKERS ?? '', 10);
+const maxWorkers = Number.isFinite(envMaxWorkers) && envMaxWorkers > 0 ? envMaxWorkers : undefined;
+const componentMaxWorkers = maxWorkers;
 
 // `component` resolves to a different worker count than the other projects, so it needs its own
 // group or `groupSpecs` throws — and that throw reports as `Test Files: no tests`, i.e. a run that

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -6,25 +6,35 @@ import path from 'path';
 // run mode, `floor(cpus / 2)` in watch; the browser pool sizes itself at `min(12, cpus - 1)`).
 //
 // The flat cap of 8 that lived here (#3900) existed because several agents each running a full
-// suite at once saturated the box. The dev-server test queue now serialises full-suite runs at
-// concurrency 1 (#3947), so one suite has the machine to itself and may use all of it.
+// suite at once saturated the box. The dev-server test queue now serialises `test:unit:run` at
+// concurrency 1 (#3947), so the unit suite no longer competes with a second copy of itself.
 //
-// Set `VITEST_MAX_WORKERS=<n>` to cap a run. That is the name Vitest itself honours, so the number
-// is the same whichever layer reads it; it is read here as well because `getThreadsCount` consults
-// ONLY the project's own `maxWorkers`, never the root, so the browser (`component`) project has to
-// be handed it individually or it is not capped at all.
+// Set `VITEST_MAX_WORKERS=<n>` to size a run. Vitest reads that name itself, in `resolveConfig`,
+// per project and AFTER this file — so the value here can only ever agree with it, never clamp it.
+// In particular it does NOT respect the browser pool's `min(12, cpus - 1)` default: `getThreadsCount`
+// returns `project.config.maxWorkers` unclamped, so a number above 12 raises the Chromium instance
+// count past what upstream considers safe rather than lowering it.
+//
+// A run routed through the dev-server queue does not see the caller's environment at all — the
+// daemon spawns it with its own — so cap those with the CLI flag instead, which is forwarded:
+// `pnpm run test:unit:run --max-workers=8`.
 //
 // `undefined` is genuinely identical to omitting the key — every consumer is a truthiness / `??`
 // check, and `configDefaults` has no `maxWorkers`.
 // (Unrelated but adjacent: `test.poolOptions` was removed in Vitest 4, so `poolOptions.forks.maxForks`
 // does nothing apart from logging a deprecation.)
+// Read here as well as natively so the knob survives Vitest dropping its own read; today the two
+// always resolve to the same number, so this cannot disagree with it.
 const envMaxWorkers = Number.parseInt(process.env.VITEST_MAX_WORKERS ?? '', 10);
 const maxWorkers = Number.isFinite(envMaxWorkers) && envMaxWorkers > 0 ? envMaxWorkers : undefined;
 const componentMaxWorkers = maxWorkers;
 
-// `component` resolves to a different worker count than the other projects, so it needs its own
-// group or `groupSpecs` throws — and that throw reports as `Test Files: no tests`, i.e. a run that
-// reads as having found nothing rather than as having failed.
+// `component` runs in its own group. The throw this used to dodge — `groupSpecs` refusing two
+// projects that share a group but resolve to different worker counts, reported as
+// `Test Files: no tests` rather than as a failure — can no longer happen now that nothing here
+// sets a per-project `maxWorkers` the others don't also get. What the group still buys is that a
+// bare `vitest run` serialises the browser project against the node one instead of interleaving
+// them; keep it for that, not for the throw.
 //
 // Declared statically below AND re-asserted here, deliberately. Static alone is not enough: a CLI
 // `--sequence.*` flag REPLACES `test.sequence` wholesale (cliOverrides is a spread, not a merge)


### PR DESCRIPTION
## What

`vitest.config.mts` no longer caps the worker pool. Vitest's own resolution applies (`cpus - 1` in run mode, `floor(cpus / 2)` in watch; browser pool `min(12, cpus - 1)`). Size a run with `VITEST_MAX_WORKERS=<n>`, or `--max-workers=<n>` when going through the dev-server queue.

## Why now

The flat cap of 8 (#3900) existed because several agents each running a full suite at once saturated the machine. The dev-server test queue now serialises `test:unit:run` at concurrency 1 (#3947, plus `e056028dbe`), so the unit suite no longer competes with a second copy of itself.

## Measurement

Four full unit-suite runs on a 32-core Windows box, alternating, each through the test queue at concurrency 1:

| config | run 1 | run 2 | mean |
|---|---|---|---|
| capped (8 workers, `main`) | 507.34s | 526.91s | 517.1s |
| uncapped (31 workers, this PR) | 281.39s | 295.83s | 288.6s |

**1.79x faster.** Every one of the four runs reported the identical `16 failed | 16738 passed | 18 skipped (16772)` across `6 failed | 1056 passed | 1 skipped (1063)` files — the known Windows path-separator baseline — and `blocks.router.workflow.test.ts` collected **347 tests** in all four, so no run silently collected nothing. Exit code read from the queue's own `test wait`, never through a pipe.

I could not reproduce the 429s figure the task carried; capped measured 507s and 527s in this worktree. Both arms ran in the same tree, alternating, through the same queue, so the comparison stands on its own.

## Positive control on the knob

Worker counts are not printed by Vitest, so they were observed directly: 40 throwaway test files each recording their `VITEST_POOL_ID`, distinct count = real worker count.

| config | distinct workers |
|---|---|
| `main` (old cap) | **8** |
| this PR, env unset | **31** |
| this PR, `VITEST_MAX_WORKERS=2` | **2** |
| this PR, `--max-workers=3` **through the queue** | **3** |

The probe files were deleted before committing.

## What review changed

An adversarial pass over the first commit found the documented escape hatch was inert on the one machine it matters on, plus three wrong claims. Second commit fixes all four:

- 🔴 **The env var does not reach a queued run.** With `CIVITAI_TEST_QUEUE` set, `test:unit:run` hands the run to the daemon, which spawns it with **its own** environment (`test-queue.mjs:65`), so `VITEST_MAX_WORKERS=8 pnpm run test:unit:run` runs at the full pool while reading as capped. The CLI flag is forwarded and does work — that is the last row of the table above. Documented; the queue itself is deliberately left alone rather than reaching into #3947's code.
- **The number is not clamped to 12 for the browser pool.** `getThreadsCount` (`cli-api:7096`) is `if (project.config.maxWorkers) return project.config.maxWorkers;` with no clamp, so `--max-workers=16` launches 16 Chromium instances — above what upstream considers safe. It sizes the pool; it does not only shrink it. The old code's "only ever REDUCE" invariant is genuinely gone, and that is now stated rather than contradicted.
- **Only `test:unit:run` is queued.** `test:component`, `test:packages:run`, `test:apps:run` and `test:lint-rules` call `vitest` directly, so a queued unit run and an unqueued component run still overlap: 31 workers plus 12 Chromium instances, where the old config bounded the pair at 8 + 6.
- **The `COMPONENT_GROUP_ORDER` comment was stale.** It justified the group by a `groupSpecs` throw that can no longer happen now that no project carries a `maxWorkers` the others don't. The group is kept for what it still does — serialising the two projects in a bare `vitest run` — and the comment says so.

## CI

**Nothing changes on GitHub CI.** The `unit`, `packages` and `apps` jobs run on `ubuntu-latest` (4 vCPU) and the old cap only applied above 9 cores, so it was already inert there. Both before and after, CI passes no `maxWorkers` and Vitest resolves its own.

Residual, stated rather than resolved: nothing in this repo invokes Vitest anywhere else, but a pipeline defined outside it in a **CPU-quota** container would see `os.availableParallelism()` report host cores and resolve far more workers than its budget. Such a runner should set `VITEST_MAX_WORKERS` explicitly. Noted in `CLAUDE.md`; I have no way to check it from here.

## Verification

- `pnpm run typecheck` — 0 errors in 234s, unfiltered (on the first commit; the second is comments and markdown only).
- `component` project smoke run under the new config — 10/10 pass, exit 0, so no `Test Files: no tests` group breakage.
- `pnpm run lint` exits 1 on this branch as it does on `main` (~1,322 pre-existing files); `lint` globs `src/` only and this PR touches no file under `src/`.
- `isolate` untouched — separate, explicitly declined work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)