### PR TITLE
fix(creator-shop): auto-fit the manage stats, not auto-fill

### DIFF
--- a/src/components/CreatorShop/Manage/ManageStats.tsx
+++ b/src/components/CreatorShop/Manage/ManageStats.tsx
@@ -21,7 +21,9 @@ export function ManageStats({
   return (
     // Wrapping is driven by how much room a card needs, not by the viewport, so
     // six sit on one row wherever six fit and only fold when they would squash.
-    <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(200px,1fr))]">
+    // auto-FIT, not auto-fill: the count here is fixed at six, so empty tracks
+    // would be dead space rather than room for more cards.
+    <div className="grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(200px,1fr))]">
       <StatCard
         label="Published"
         value={stats.published}


### PR DESCRIPTION
Follow-up to #3950, from the adversarial review pass that finished after it merged.

## What's wrong

I took `repeat(auto-fill, minmax(200px, 1fr))` from the storefront card grids (`ShopItemGrid.tsx:32`, `ModelsSection.tsx:78`, `CommunityCosmeticsSection.tsx:91`). That was the right *shape* and the wrong *half of the idiom*: in those grids the item count is unknown and paginated, so the empty tracks are the point — they keep card width steady as items stream in.

`ManageStats` renders exactly six cards, forever. And nothing above it caps the width — `manage.tsx` → `UserProfileLayout` → `ProfileLayout2.tsx:169` is a bare `<div className="px-3">` — so on a wide display those empty tracks are just dead space.

## Measured

| container | `auto-fill` (merged) | `auto-fit` (this PR) |
|---|---|---|
| 2200px | 10 tracks, cards **206px**, **886px dead space** | 10 tracks, cards **353px**, **0 dead space** |
| 1440px | 6 tracks, cards 227px | 6 tracks, cards 227px |

Below 1440px the two are identical, so this only changes the wide case — it does not touch the wrapping behaviour #3950 was after.

Also checked while I was here: at 1440px an 8-digit revenue (`12,345,678 Buzz` — larger than the biggest real creator) still renders on one line with no wrap and no overflow, so the 200px minimum stands.

`pnpm run typecheck` 0 errors, eslint and prettier clean. No test change — the behaviour is a computed style at a container width, and the repo has no harness that would pin it without stubbing the layout it depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)