### PR TITLE
fix(tests): clear the three type errors that reddened the typecheck-tests gate

### DIFF
--- a/scripts/ci/typecheck-tests-baseline.json
+++ b/scripts/ci/typecheck-tests-baseline.json
@@ -1,8 +1,8 @@
 {
   "_comment": "Type errors inside src/**/__tests__/** that pnpm typecheck cannot see. Entries may shrink or disappear freely; adding one, or raising a count, is a deliberate act visible in review. Regenerate with: node scripts/ci/typecheck-tests-gate.mjs --write-baseline",
   "config": "tsconfig.tests.json",
-  "testFilesInProgram": 938,
-  "totalErrors": 801,
+  "testFilesInProgram": 1018,
+  "totalErrors": 784,
   "files": {
     "src/__tests__/pages/api/download/attachment-blocklist.test.ts": 1,
     "src/components/AppBlocks/__tests__/iframeInitController.test.ts": 4,
@@ -92,9 +92,8 @@
     "src/server/services/__tests__/nsfwLevels.buffer-flag.test.ts": 2,
     "src/server/services/__tests__/placement-escrow.service.test.ts": 27,
     "src/server/services/__tests__/reaction-stale-replica-delete.test.ts": 2,
-    "src/server/services/__tests__/remix-gallery.service.test.ts": 29,
+    "src/server/services/__tests__/remix-gallery.service.test.ts": 28,
     "src/server/services/__tests__/set-user-setting.sql.service.test.ts": 1,
-    "src/server/services/__tests__/sticker-placement.service.test.ts": 16,
     "src/server/services/__tests__/sticker-usage-database-target.test.ts": 2,
     "src/server/services/__tests__/unblock-image-nsfwlevel-reset.test.ts": 1,
     "src/server/services/__tests__/update-user-profile.sql.service.test.ts": 1,

--- a/src/server/__tests__/minimax-h3-license.test.ts
+++ b/src/server/__tests__/minimax-h3-license.test.ts
@@ -7,7 +7,7 @@ import {
   licenses as sharedLicenses,
 } from '@civitai/shared/basemodel.constants';
 import { baseModelLicenses } from '~/server/common/constants';
-import type { BaseModel } from '~/server/common/constants';
+import type { BaseModel } from '@civitai/shared/basemodel.constants';
 
 // The 2 Aug 2026 revision the on-site weights carry. A moving ref here would let
 // MiniMax rewrite the terms we point creators at, which is what section III.1's

--- a/src/server/services/__tests__/cosmetic-phash.service.test.ts
+++ b/src/server/services/__tests__/cosmetic-phash.service.test.ts
@@ -77,7 +77,7 @@ describe('normalizeCosmeticHashHex', () => {
 
 describe('legacyBigIntHash', () => {
   it('writes the legacy BIGINT only for the perceptual lane', () => {
-    expect(legacyBigIntHash('a6e0c4c4cce8a4b6', 'perceptual')).toBe(-6421916719099894602n);
+    expect(legacyBigIntHash('a6e0c4c4cce8a4b6', 'perceptual')).toBe(BigInt('-6421916719099894602'));
   });
 
   // `perceptualDct` is ALSO 64 bits, so a width check passes it. `Cosmetic.pHash`
@@ -321,7 +321,7 @@ describe('getSimilarCosmetics', () => {
     mocks.queryRaw.mockResolvedValue(
       Array.from({ length: 300 }, (_, i) => ({
         id: i + 2,
-        pHashHex: (BigInt(i) + 2n).toString(16).padStart(16, '0'),
+        pHashHex: (BigInt(i) + BigInt(2)).toString(16).padStart(16, '0'),
       }))
     );
     mocks.cosmeticFindMany.mockImplementation(

--- a/src/server/services/__tests__/sticker-placement.service.test.ts
+++ b/src/server/services/__tests__/sticker-placement.service.test.ts
@@ -6,6 +6,7 @@ import {
 } from '~/shared/constants/browsingLevel.constants';
 import type * as MetricHelpers from '~/server/utils/metric-helpers';
 import { STICKER_REMOVAL_LOCK_HOURS } from '~/shared/utils/sticker-placement';
+import type { CreateStickerPlacement } from '~/server/services/sticker-placement.service';
 
 /**
  * Fixture discipline: every quantity in scope is a distinct number, so a value
@@ -138,10 +139,14 @@ const givenStickerAndBalance = (
     .mockResolvedValueOnce([balance]);
 };
 
-const placeInput = {
+// Same discipline as the numbers above: the default currency is deliberately not
+// the one the escrow test asserts ('green'), so a placement that never carried
+// the caller's currency cannot pass by matching the fixture.
+const placeInput: CreateStickerPlacement = {
   placerId: PLACER,
   imageId: IMAGE,
   data: { cosmeticId: COSMETIC, x: 0.25, y: 0.75, scale: 0.2, rotation: 15 },
+  spendType: 'yellow',
 };
 
 beforeEach(() => {
@@ -247,9 +252,9 @@ describe("the creator's size limit", () => {
     resolvePlacementSpaceFor.mockResolvedValue(capped);
     givenStickerAndBalance();
 
-    await expect(
-      createStickerPlacement({ spendType: 'yellow', ...placeInput, data: OVERSIZE })
-    ).rejects.toThrow(/up to 20%/);
+    await expect(createStickerPlacement({ ...placeInput, data: OVERSIZE })).rejects.toThrow(
+      /up to 20%/
+    );
     expect(placementCreate).not.toHaveBeenCalled();
   });
 
@@ -259,7 +264,6 @@ describe("the creator's size limit", () => {
 
     await expect(
       createStickerPlacement({
-        spendType: 'yellow',
         ...placeInput,
         data: OVERSIZE,
         isModerator: true,
@@ -273,9 +277,9 @@ describe("the creator's size limit", () => {
 
     // 0.35 is inside the global ceiling and outside the default, so this fails
     // only if the default is being applied rather than the hard maximum.
-    await expect(
-      createStickerPlacement({ spendType: 'yellow', ...placeInput, data: OVERSIZE })
-    ).rejects.toThrow(/up to 25%/);
+    await expect(createStickerPlacement({ ...placeInput, data: OVERSIZE })).rejects.toThrow(
+      /up to 25%/
+    );
   });
 
   /**
@@ -444,7 +448,6 @@ describe('what gets written to the row', () => {
     givenStickerAndBalance();
 
     await createStickerPlacement({
-      spendType: 'yellow',
       ...placeInput,
       // Past the edges: a drag that left the image is a normal gesture, so the
       // position clamps rather than rejecting. Size is a different matter — it
@@ -909,7 +912,6 @@ describe('the note on a placement', () => {
     givenStickerAndBalance();
 
     await createStickerPlacement({
-      spendType: 'yellow',
       ...placeInput,
       data: { ...placeInput.data, comment: '  love   this\n\none  ' },
     });
@@ -922,7 +924,6 @@ describe('the note on a placement', () => {
     givenStickerAndBalance();
 
     await createStickerPlacement({
-      spendType: 'yellow',
       ...placeInput,
       data: { ...placeInput.data, comment: '   ' },
     });

--- a/src/server/services/__tests__/sticker-placement.service.test.ts
+++ b/src/server/services/__tests__/sticker-placement.service.test.ts
@@ -139,14 +139,18 @@ const givenStickerAndBalance = (
     .mockResolvedValueOnce([balance]);
 };
 
-// Same discipline as the numbers above: the default currency is deliberately not
-// the one the escrow test asserts ('green'), so a placement that never carried
-// the caller's currency cannot pass by matching the fixture.
+// Same discipline as the numbers above, applied to the currency: the escrow test
+// overrides the fixture default, and the two must differ or a service that
+// stopped forwarding the caller's currency would pass by matching the fixture.
+// Kept apart as constants so that stays true when someone edits one of them.
+const FIXTURE_SPEND = 'yellow' as const;
+const CALLER_SPEND = 'green' as const;
+
 const placeInput: CreateStickerPlacement = {
   placerId: PLACER,
   imageId: IMAGE,
   data: { cosmeticId: COSMETIC, x: 0.25, y: 0.75, scale: 0.2, rotation: 15 },
-  spendType: 'yellow',
+  spendType: FIXTURE_SPEND,
 };
 
 beforeEach(() => {
@@ -435,12 +439,14 @@ describe('what gets written to the row', () => {
   // untouched. A placement that reached the escrow without it would be held —
   // and later paid out — in whatever the Buzz service defaults to.
   it('carries the caller currency into the escrow', async () => {
+    // The assertion below is only worth anything while these differ.
+    expect(CALLER_SPEND).not.toBe(FIXTURE_SPEND);
     givenStickerAndBalance();
 
-    await createStickerPlacement({ ...placeInput, spendType: 'green' });
+    await createStickerPlacement({ ...placeInput, spendType: CALLER_SPEND });
 
     expect(holdPlacementEscrow).toHaveBeenCalledWith(
-      expect.objectContaining({ spendType: 'green' })
+      expect.objectContaining({ spendType: CALLER_SPEND })
     );
   });
 


### PR DESCRIPTION
`scripts/ci/typecheck-tests-gate.mjs` was BLOCKED on `origin/main` at `3863adcbb0`. Three regressions arrived with tonight's merges and nobody's verification could have seen them: the root tsconfig excludes `src/**/__tests__/**`, so **`pnpm run typecheck` is blind to every one of them**. Test files have their own ratchet, and that ratchet is the only thing that looks here.

Before:

```
2 test file(s) have type errors and are NOT in the baseline:
  src/server/__tests__/minimax-h3-license.test.ts               (1)
  src/server/services/__tests__/cosmetic-phash.service.test.ts  (2)
1 baselined file(s) got WORSE:
  src/server/services/__tests__/sticker-placement.service.test.ts  16 -> 17
```

After: `PASS — no new or worsened test-file type errors.`

## The three fixes

Types fixed, nothing baselined away.

**`minimax-h3-license.test.ts`** — `~/server/common/constants` *imports* `BaseModel`, it does not re-export it (TS2459). Taken from its origin, `@civitai/shared/basemodel.constants`, which the file already imports from. Same type: `BaseModel = string`, which the test's own comment on line 35 depends on.

**`cosmetic-phash.service.test.ts`** — BigInt literals need `target: ES2020`; the repo targets ES2018 (TS2737). Rewritten as `BigInt(...)` calls rather than moving the repo's target, which is not this PR's business. `BigInt('-6421916719099894602')` and `BigInt(2)` are value-identical to the literals they replace.

**`sticker-placement.service.test.ts`** — `createStickerPlacement` grew a required `spendType: BuzzSpendType`; the shared `placeInput` fixture never did, so 17 call sites disagreed with the signature (TS2345). Three call sites had already been patched by hand with an inline `spendType`, which is why 16 of the 17 were sitting in the baseline.

This is a fixture that fell behind a signature, not a behavioural mismatch — `spendType` is threaded straight through to `holdPlacementEscrow`, which is mocked, so no assertion changes. The file goes from 16 baselined errors to **clean**.

Two deliberate choices in that fix:

- **The fixture carries `'yellow'`, and the escrow test asserts `'green'`.** They must not be the same value. `it('carries the caller currency into the escrow')` does `{ ...placeInput, spendType: 'green' }` and asserts `'green'` reached the escrow — if the fixture also said `'green'`, a `createStickerPlacement` that dropped the caller's currency entirely would still pass. Same discipline as the distinct-numbers block at the top of the file, applied to the currency.
- **The fixture is typed `CreateStickerPlacement`.** The next required field then fails once, at the fixture, instead of silently at 17 call sites — which is exactly how this one got in.

Six inline `spendType: 'yellow',` literals were removed where they sat *before* a `...placeInput` spread and were therefore already shadowed by it. The one at line 441 sits *after* the spread and is a real override; it stays.

## Baseline

Regenerated with `--write-baseline`, and it only goes **down**: `sticker-placement.service.test.ts` leaves the file entirely (16 → 0) and `remix-gallery.service.test.ts` drops 29 → 28 from an unrelated merge. `testFilesInProgram` moves 938 → 1018, which raises the gate's own positive-control floor.

## Verification

| check | result |
|---|---|
| `node scripts/ci/typecheck-tests-gate.mjs` | **PASS**, read from its printed output |
| `pnpm run typecheck` | `OK — 0 type errors`, unfiltered |
| `pnpm run lint` | exit 0 |
| `pnpm run test:unit:run` | 16 failed / 16750 passed, 6 files — the known Windows path-separator baseline |
| `blocks.router.workflow.test.ts` | **347 tests** collected |
| the three touched files | 72 / 17 / 9 tests, all green |

Positive control on the gate itself: I observed it print **BLOCKED and exit 1** before the change and **PASS and exit 0** after, in the same tree.

## Two findings I am reporting, not fixing here

1. **The gate is wired into nothing.** It appears in no `.github/workflows` job and no `package.json` script. It is a standalone file somebody has to remember to run — which is the whole reason it went red four hours after #3915 cleared it, and stayed red through several merges.
2. **`pnpm typecheck` was red in my worktree for a reason that had nothing to do with any of this**: 19 errors across `cosmetic-phash.service.ts`, `placement-escrow.service.ts` and the two grok files, all from a stale `node_modules` and Prisma client after a branch switch (`@civitai/client` beta.89 → .90; the new `Cosmetic.pHashHex` and `Placement.spendType` columns). `pnpm install && pnpm run db:generate` cleared all 19. Worth knowing before anyone reads those as real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
