### PR TITLE
fix(tests): make the packages and unit suites readable on Windows (48 failures -> 0)

### DIFF
--- a/packages/civitai-db-schema/src/schema-drift/__tests__/cli.test.ts
+++ b/packages/civitai-db-schema/src/schema-drift/__tests__/cli.test.ts
@@ -1,10 +1,9 @@
-import { execFile } from 'node:child_process';
 import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { promisify } from 'node:util';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { runTsxCli, type CliRun } from './support/tsx-cli';
 import type { DbCatalog } from '../types';
 
 /**
@@ -21,40 +20,25 @@ import type { DbCatalog } from '../types';
  */
 vi.setConfig({ testTimeout: 60_000 });
 
-const run = promisify(execFile);
-
 const here = fileURLToPath(new URL('.', import.meta.url));
 const packageRoot = join(here, '../../..');
-const tsx = join(packageRoot, 'node_modules/.bin/tsx');
 const cli = join(packageRoot, 'src/schema-drift/cli.ts');
 const fixtureSchema = join(here, 'fixtures/fixture.prisma');
 const realSchema = join(packageRoot, 'prisma/schema.full.prisma');
-
-interface Run {
-  code: number;
-  stdout: string;
-  stderr: string;
-}
 
 /**
  * Drive the real entry point as a process, so the assertions are about what a person
  * running the command actually gets — exit code included. The unit tests exercise the
  * differ; nobody runs the differ.
  */
-async function drift(args: string[]): Promise<Run> {
-  try {
-    const { stdout, stderr } = await run(tsx, [cli, ...args], {
-      cwd: packageRoot,
-      // No DATABASE_URL: every case here is --catalog driven, and an inherited one must
-      // never be reachable from a test.
-      env: { ...process.env, DATABASE_URL: '' },
-      maxBuffer: 32 * 1024 * 1024,
-    });
-    return { code: 0, stdout, stderr };
-  } catch (error) {
-    const e = error as { code?: number; stdout?: string; stderr?: string };
-    return { code: e.code ?? -1, stdout: e.stdout ?? '', stderr: e.stderr ?? '' };
-  }
+async function drift(args: string[]): Promise<CliRun> {
+  return runTsxCli(cli, args, {
+    cwd: packageRoot,
+    // No DATABASE_URL: every case here is --catalog driven, and an inherited one must
+    // never be reachable from a test.
+    env: { ...process.env, DATABASE_URL: '' },
+    maxBuffer: 32 * 1024 * 1024,
+  });
 }
 
 let dir: string;

--- a/packages/civitai-db-schema/src/schema-drift/__tests__/dump-catalog-stamp.test.ts
+++ b/packages/civitai-db-schema/src/schema-drift/__tests__/dump-catalog-stamp.test.ts
@@ -1,10 +1,9 @@
-import { execFile } from 'node:child_process';
 import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { promisify } from 'node:util';
 import { beforeAll, describe, expect, it } from 'vitest';
+import { runTsxCli, type CliRun } from './support/tsx-cli';
 import type { DbCatalog } from '../types';
 
 /**
@@ -25,28 +24,19 @@ import type { DbCatalog } from '../types';
  * These drive the real entry point as a process, so they exercise the actual command an
  * operator runs after a recapture.
  */
-const run = promisify(execFile);
-
 const here = fileURLToPath(new URL('.', import.meta.url));
 const packageRoot = join(here, '../../..');
-const tsx = join(packageRoot, 'node_modules/.bin/tsx');
 const cli = join(packageRoot, 'src/schema-drift/cli.ts');
 const snapshot = join(here, 'fixtures/catalog-production-2026-08-03.json');
 
-async function dump(args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
-  try {
-    const { stdout, stderr } = await run(tsx, [cli, '--dump-catalog', ...args], {
-      cwd: packageRoot,
-      // Every case here is --catalog driven. An inherited DATABASE_URL must never be
-      // reachable from a test, and this command would otherwise try to connect.
-      env: { ...process.env, DATABASE_URL: '' },
-      maxBuffer: 64 * 1024 * 1024,
-    });
-    return { code: 0, stdout, stderr };
-  } catch (error) {
-    const e = error as { code?: number; stdout?: string; stderr?: string };
-    return { code: e.code ?? -1, stdout: e.stdout ?? '', stderr: e.stderr ?? '' };
-  }
+async function dump(args: string[]): Promise<CliRun> {
+  return runTsxCli(cli, ['--dump-catalog', ...args], {
+    cwd: packageRoot,
+    // Every case here is --catalog driven. An inherited DATABASE_URL must never be
+    // reachable from a test, and this command would otherwise try to connect.
+    env: { ...process.env, DATABASE_URL: '' },
+    maxBuffer: 64 * 1024 * 1024,
+  });
 }
 
 describe('drift --dump-catalog stamps capturedAt', { timeout: 60_000 }, () => {

--- a/packages/civitai-db-schema/src/schema-drift/__tests__/gate.test.ts
+++ b/packages/civitai-db-schema/src/schema-drift/__tests__/gate.test.ts
@@ -1,10 +1,9 @@
-import { execFile } from 'node:child_process';
 import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { promisify } from 'node:util';
 import { beforeAll, describe, expect, it } from 'vitest';
+import { runTsxCli, type CliRun } from './support/tsx-cli';
 import { compareSchemaToCatalog } from '../compare';
 import {
   absorbedEscalations,
@@ -22,11 +21,8 @@ import {
 import { parsePrismaSchema } from '../parse-prisma-schema';
 import type { DbCatalog, DriftFinding } from '../types';
 
-const run = promisify(execFile);
-
 const here = fileURLToPath(new URL('.', import.meta.url));
 const packageRoot = join(here, '../../..');
-const tsx = join(packageRoot, 'node_modules/.bin/tsx');
 const gateCli = join(packageRoot, 'src/schema-drift/gate-cli.ts');
 const realSchema = join(packageRoot, 'prisma/schema.full.prisma');
 const snapshotRelative = 'src/schema-drift/__tests__/fixtures/catalog-production-2026-08-03.json';
@@ -570,30 +566,18 @@ describe('assertMeasuredSomething', () => {
   });
 });
 
-interface Run {
-  code: number;
-  stdout: string;
-  stderr: string;
-}
-
 /**
  * Drive the real entry point as a process. The functions above are the gate's logic; this is
  * what CI actually invokes, exit code and all — and an exit code is the only part of it CI
  * reads.
  */
-async function gate(args: string[]): Promise<Run> {
-  try {
-    const { stdout, stderr } = await run(tsx, [gateCli, ...args], {
-      cwd: packageRoot,
-      // The gate has no database code path; this asserts it does not grow one by accident.
-      env: { ...process.env, DATABASE_URL: '' },
-      maxBuffer: 32 * 1024 * 1024,
-    });
-    return { code: 0, stdout, stderr };
-  } catch (error) {
-    const e = error as { code?: number; stdout?: string; stderr?: string };
-    return { code: e.code ?? -1, stdout: e.stdout ?? '', stderr: e.stderr ?? '' };
-  }
+async function gate(args: string[]): Promise<CliRun> {
+  return runTsxCli(gateCli, args, {
+    cwd: packageRoot,
+    // The gate has no database code path; this asserts it does not grow one by accident.
+    env: { ...process.env, DATABASE_URL: '' },
+    maxBuffer: 32 * 1024 * 1024,
+  });
 }
 
 // Every case below spawns the real entry point as a PROCESS, so each pays a cold tsx

--- a/packages/civitai-db-schema/src/schema-drift/__tests__/support/tsx-cli.ts
+++ b/packages/civitai-db-schema/src/schema-drift/__tests__/support/tsx-cli.ts
@@ -9,8 +9,14 @@ const run = promisify(execFile);
  * `execFile` cannot exec the extensionless one, so every spawn there failed `ENOENT` before the
  * CLI started. Resolving tsx's own entry module and running it under the current `node` is the
  * same command on every platform and skips the shim entirely.
+ *
+ * 🔴 Resolved per call, NOT at module scope. All three drift test files import this module, so a
+ * resolve that throws at module scope — a tsx release dropping the `./cli` export subpath, a
+ * partial install — takes all three down during module evaluation, and each collects ZERO tests
+ * while the failure count stays at 0. Inside the function it surfaces as a test failure naming
+ * the module, which is the same reason the spawn failure below throws instead of returning.
  */
-const tsxCli = createRequire(import.meta.url).resolve('tsx/cli');
+const resolveTsxCli = () => createRequire(import.meta.url).resolve('tsx/cli');
 
 export interface CliRun {
   code: number;
@@ -31,6 +37,7 @@ export async function runTsxCli(
   args: string[],
   options: ExecFileOptions
 ): Promise<CliRun> {
+  const tsxCli = resolveTsxCli();
   try {
     const { stdout, stderr } = await run(process.execPath, [tsxCli, script, ...args], options);
     return { code: 0, stdout: String(stdout), stderr: String(stderr) };
@@ -42,9 +49,11 @@ export async function runTsxCli(
       stderr?: string;
     };
     if (typeof e.code !== 'number') {
-      throw new Error(
-        `${script} did not run: ${e.code ?? e.signal ?? String(error)}\n${e.stderr ?? ''}`
-      );
+      // A signal kill DID run — saying otherwise sends the reader looking for a spawn failure.
+      const how = e.signal
+        ? `was killed by ${e.signal}`
+        : `did not run: ${e.code ?? String(error)}`;
+      throw new Error(`${script} ${how}\n${e.stderr ?? ''}`);
     }
     return { code: e.code, stdout: e.stdout ?? '', stderr: e.stderr ?? '' };
   }

--- a/packages/civitai-db-schema/src/schema-drift/__tests__/support/tsx-cli.ts
+++ b/packages/civitai-db-schema/src/schema-drift/__tests__/support/tsx-cli.ts
@@ -1,0 +1,51 @@
+import { execFile, type ExecFileOptions } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { promisify } from 'node:util';
+
+const run = promisify(execFile);
+
+/**
+ * `node_modules/.bin/tsx` is a POSIX shell script — Windows gets `tsx.CMD` alongside it and
+ * `execFile` cannot exec the extensionless one, so every spawn there failed `ENOENT` before the
+ * CLI started. Resolving tsx's own entry module and running it under the current `node` is the
+ * same command on every platform and skips the shim entirely.
+ */
+const tsxCli = createRequire(import.meta.url).resolve('tsx/cli');
+
+export interface CliRun {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Run one of this package's CLIs as a real process and report what an operator would get.
+ *
+ * A spawn that never produced an exit code THROWS rather than reporting one. `execFile` puts
+ * `ENOENT` in the same `code` field as a real exit status, so returning it made a CLI that never
+ * ran indistinguishable from one that ran and exited — 32 tests read `expected 'ENOENT' to be 2`,
+ * which names the assertion and not the cause.
+ */
+export async function runTsxCli(
+  script: string,
+  args: string[],
+  options: ExecFileOptions
+): Promise<CliRun> {
+  try {
+    const { stdout, stderr } = await run(process.execPath, [tsxCli, script, ...args], options);
+    return { code: 0, stdout: String(stdout), stderr: String(stderr) };
+  } catch (error) {
+    const e = error as {
+      code?: number | string;
+      signal?: string;
+      stdout?: string;
+      stderr?: string;
+    };
+    if (typeof e.code !== 'number') {
+      throw new Error(
+        `${script} did not run: ${e.code ?? e.signal ?? String(error)}\n${e.stderr ?? ''}`
+      );
+    }
+    return { code: e.code, stdout: e.stdout ?? '', stderr: e.stderr ?? '' };
+  }
+}

--- a/scripts/__tests__/typecheck.test.ts
+++ b/scripts/__tests__/typecheck.test.ts
@@ -93,12 +93,30 @@ describe('typecheck wrapper outcome classification', () => {
     expect(res.stderr).not.toContain(DIAGNOSTIC_MARKER);
   });
 
-  it('distinguishes an outside kill from V8 running out of heap', () => {
-    const res = run(stub('sigkill', "process.kill(process.pid, 'SIGKILL');\n"));
+  // Windows has no signals: `process.kill(pid, 'SIGKILL')` terminates the child with
+  // exit code 1 and `signal === null`, so the shape this case exists to produce cannot
+  // occur there and the wrapper correctly reports the generic crash instead. The 137
+  // case below carries the same classification on every platform.
+  it.skipIf(process.platform === 'win32')(
+    'distinguishes an outside kill (by signal) from V8 running out of heap',
+    () => {
+      const res = run(stub('sigkill', "process.kill(process.pid, 'SIGKILL');\n"));
+
+      expect(res.status).not.toBe(0);
+      expect(res.stdout).toContain(CRASH_MARKER);
+      // Different cause, different fix: more RAM / a LOWER cap, not a higher one.
+      expect(res.stderr).toContain('killed from outside');
+      expect(res.stderr).not.toContain('ran out of old-space heap');
+    }
+  );
+
+  // The other half of the same branch, and the half a container actually delivers: a
+  // shell reports an OOM-killed child as 128+9 rather than as a signal.
+  it('distinguishes an outside kill (exit 137) from V8 running out of heap', () => {
+    const res = run(stub('exit137', 'process.exit(137);\n'));
 
     expect(res.status).not.toBe(0);
     expect(res.stdout).toContain(CRASH_MARKER);
-    // Different cause, different fix: more RAM / a LOWER cap, not a higher one.
     expect(res.stderr).toContain('killed from outside');
     expect(res.stderr).not.toContain('ran out of old-space heap');
   });

--- a/scripts/check-server-graph-singletons.mjs
+++ b/scripts/check-server-graph-singletons.mjs
@@ -104,6 +104,10 @@ if (mapFiles.length === 0) {
 
 // chunk (relative .js path) -> Set(source modules inlined into it)
 const chunkSources = new Map();
+// The same key -> the absolute .js path, so reading a chunk never goes back through
+// the key. The key is a NAME: it is what every violation above prints, so it carries
+// posix separators on all platforms rather than whatever the host filesystem uses.
+const chunkFiles = new Map();
 for (const m of mapFiles) {
   let sources;
   try {
@@ -112,12 +116,15 @@ for (const m of mapFiles) {
     continue; // an unparseable map is not evidence of a violation
   }
   if (!Array.isArray(sources)) continue;
-  chunkSources.set(relative(SERVER_DIR, m).replace(/\.map$/, ''), sources);
+  const abs = m.replace(/\.map$/, '');
+  const rel = relative(SERVER_DIR, abs).replace(/\\/g, '/');
+  chunkSources.set(rel, sources);
+  chunkFiles.set(rel, abs);
 }
 
 const readChunk = (rel) => {
   try {
-    return readFileSync(join(SERVER_DIR, rel), 'utf8');
+    return readFileSync(chunkFiles.get(rel) ?? join(SERVER_DIR, rel), 'utf8');
   } catch {
     return '';
   }

--- a/src/components/AppBlocks/__tests__/analytics-bucket-labels.drift.test.ts
+++ b/src/components/AppBlocks/__tests__/analytics-bucket-labels.drift.test.ts
@@ -37,7 +37,9 @@ function grepFiles(dir: string, re: RegExp): string[] {
         if (entry.name !== 'node_modules' && entry.name !== '__tests__') walk(child);
       } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
         if (re.test(readFileSync(child, 'utf8'))) {
-          out.push(path.relative(REPO_ROOT, child));
+          // Compared against the `/`-separated literals in WRITER_FILES, so posix
+          // separators on every platform.
+          out.push(path.relative(REPO_ROOT, child).replace(/\\/g, '/'));
         }
       }
     }

--- a/src/server/middleware/__tests__/block-scope.normalize-endpoint.test.ts
+++ b/src/server/middleware/__tests__/block-scope.normalize-endpoint.test.ts
@@ -200,7 +200,10 @@ describe('KNOWN_STATIC_ENDPOINT_SEGMENTS ⇄ withBlockScope route files drift gu
           // `const handler = withBlockScope(...); export default handler`, which
           // is one refactor away and was previously invisible to this walk.
           if (/export default\s+withBlockScope\(/.test(src) || /=\s*withBlockScope\(/.test(src)) {
-            out.push(path.relative(PAGES_API, child));
+            // A URL path, not a filesystem path: it is split on `/` below and
+            // compared against `/`-separated literals, so it must not carry
+            // Windows separators.
+            out.push(path.relative(PAGES_API, child).replace(/\\/g, '/'));
           }
         }
       }

--- a/src/server/services/blocks/__tests__/app-spend-tier-privilege.test.ts
+++ b/src/server/services/blocks/__tests__/app-spend-tier-privilege.test.ts
@@ -178,8 +178,13 @@ type Scan = {
 const SCANNED_TOKENS = [...SPEND_FIELDS, RAW_COLUMN] as const;
 
 async function scanSourceTree(): Promise<Scan> {
+  // Repo-relative paths are IDENTIFIERS here — matched against the `/`-separated
+  // literals in PUBLISHER_REACHABLE and by `/`-anchored regexes — so they carry
+  // posix separators on every platform. Without this `alwaysDecode` never hits on
+  // Windows, and the ENOENT that is supposed to announce a renamed publisher path
+  // silently becomes an empty `raw` map instead.
   const files = (await walk(join(ROOT, 'src'), []))
-    .map((f) => relative(ROOT, f))
+    .map((f) => relative(ROOT, f).replace(/\\/g, '/'))
     .filter((f) => !/__tests__|\.test\.tsx?$|(^|\/)src\/tests\//.test(f));
 
   const code = new Map<string, string>();

--- a/src/server/services/blocks/__tests__/app-spend-tier-privilege.test.ts
+++ b/src/server/services/blocks/__tests__/app-spend-tier-privilege.test.ts
@@ -183,9 +183,10 @@ async function scanSourceTree(): Promise<Scan> {
   // posix separators on every platform. Without this `alwaysDecode` never hits on
   // Windows, and the ENOENT that is supposed to announce a renamed publisher path
   // silently becomes an empty `raw` map instead.
-  const files = (await walk(join(ROOT, 'src'), []))
-    .map((f) => relative(ROOT, f).replace(/\\/g, '/'))
-    .filter((f) => !/__tests__|\.test\.tsx?$|(^|\/)src\/tests\//.test(f));
+  const scanned = (await walk(join(ROOT, 'src'), []))
+    .map((abs) => ({ abs, file: relative(ROOT, abs).replace(/\\/g, '/') }))
+    .filter(({ file }) => !/__tests__|\.test\.tsx?$|(^|\/)src\/tests\//.test(file));
+  const files = scanned.map((s) => s.file);
 
   const code = new Map<string, string>();
   const raw = new Map<string, string>();
@@ -194,8 +195,11 @@ async function scanSourceTree(): Promise<Scan> {
   // renamed or deleted path a loud ENOENT instead of a silently vacuous pass.
   const alwaysDecode = new Set<string>(PUBLISHER_REACHABLE);
 
-  await forEachConcurrent(files, READ_CONCURRENCY, async (file) => {
-    const bytes = await readFile(join(ROOT, file));
+  await forEachConcurrent(scanned, READ_CONCURRENCY, async ({ abs, file }) => {
+    // Read the path the walk produced, never the normalised key: the key is an identifier,
+    // and handing a posix-separated string back to the filesystem happens to work today but
+    // would not under a `\\?\` prefixed path.
+    const bytes = await readFile(abs);
     if (!alwaysDecode.has(file) && !INTERESTING.some((t) => bytes.includes(t))) return;
     const text = bytes.toString('utf8');
     if (alwaysDecode.has(file)) raw.set(file, text);

--- a/src/server/services/comics/__tests__/orchestrator-chat.wait-unit.test.ts
+++ b/src/server/services/comics/__tests__/orchestrator-chat.wait-unit.test.ts
@@ -217,7 +217,7 @@ describe('every statically-resolvable `wait:` in src/ is a seconds value', () =>
       .map((m) => {
         const token = (m[1] ?? m[2]).trim();
         return {
-          file: path.relative(SRC, file),
+          file: path.relative(SRC, file).replace(/\\/g, '/'),
           token,
           kind: classify(token),
           seconds: resolveWait(token, source),


### PR DESCRIPTION
> Branch name is from a superseded plan — this PR is **"make the test suites readable on Windows"**, not a mock migration.

## 🔴 The expected-failure baseline moves. Read 0 as correct, not as suspicious.

If you know these suites, you know the shared expectation has been **"16 failures across 6 files is green"** for the unit suite, and nobody had written down that `test:packages:run` fails 32. Both are now **0**. A reviewer who checks against the old number will read the new one as a suite that stopped running — it isn't:

| suite | before | after |
|---|---|---|
| `pnpm run test:packages:run` | **32 failed**, exit 1 | **0 failed**, 1056 passed, exit 0 |
| the 6 known-red `unit` files | **16 failed** | **0 failed**, 70 passed, 1 skipped |

Nothing was deleted, loosened, or exempted to get there. Test counts went **up** (1055 → 1056 in packages; a new `exit 137` case in `typecheck.test.ts`).

On any branch carrying this, non-zero is now a real regression. That property is the point of the PR — the individual fixes matter less than the fact that these suites' exit codes become readable on this platform at all.

---

## These were three unrelated bugs wearing one label

### 1. `execFile` on a POSIX shell script — 32 tests, all of `packages/civitai-db-schema/src/schema-drift/__tests__/`

All three files spawn their CLI via `join(packageRoot, 'node_modules/.bin/tsx')`. That file is a **shell script**; Windows gets `tsx.CMD` beside it and `execFile` cannot exec the extensionless one. The CLI never started.

The reason this sat around unrecognised is the helper's catch:

```ts
const e = error as { code?: number; ... };
return { code: e.code ?? -1, ... };
```

`execFile` reports `ENOENT` in the **same `code` field as a real exit status**, so a process that never launched was reported as one that exited — 32 tests read `expected 'ENOENT' to be 2`, which names the assertion and hides the cause.

Fixed by resolving tsx's own entry and running it under `process.execPath` (one command on every platform, no shim), extracted to `__tests__/support/tsx-cli.ts`. The helper now **throws** when a spawn produces a non-numeric code, so a spawn failure can never again be laundered into an exit code. That is the durable half — it closes the class, not the instance.

### 2. Path-as-identifier — 14 tests across 4 `unit` files

Each builds a repo-relative path with `path.relative()` and then uses it as an **identifier**: matched against `/`-separated literals, or split on `/`. On Windows `path.relative()` returns backslashes, so the match can never hit. Normalised at the point the path stops being a filesystem path; the paths handed to the filesystem are untouched (in `app-spend-tier-privilege` the read now goes through the walk's absolute path and never through the normalised key).

**One of these is not a red test — it is a guard that was reporting the wrong thing.** In `app-spend-tier-privilege.test.ts` the mismatched key is `alwaysDecode`, whose stated job is to read the publisher-facing modules unconditionally, so that a renamed or deleted path is loud rather than a quietly vacuous pass.

I mutation-tested it in both states by renaming a `PUBLISHER_REACHABLE` entry:

- **Before the fix, renamed:** 7 failed — *the same 7 that are red on Windows anyway*. Same count, same tests, same messages. The rename changed **nothing about the output**. With backslash keys, `SCAN.code.get(file)` returns `undefined` for **every** entry, present or stale, so the guard could not distinguish a stale path from ambient platform breakage. It did not fail to fire; it fired identically in both worlds, which is worse — the failure carried no information.
- **After the fix, renamed:** fails by name —
  `src/server/routers/blocks.router.RENAMED.ts was not read — is the path stale?: expected undefined to be defined`
- **After the fix, real path:** 9/9 green.

So the restored guarantee is not "silent becomes loud" — it is *a failure that identifies the stale path* rather than one indistinguishable from the platform's noise. Any Windows checkout has been in the degraded state since the guard was written.

### 3. `check-server-graph-singletons.mjs` — a **product** bug, found by a test everyone assumed was broken

The gate keyed its chunk map on `relative()` output, so on Windows every violation printed `chunks\ssr\b.js`. That key is what the **report** prints — it is a name, not a path — so a Linux developer reading a Windows-generated report gets a chunk name they cannot grep for. Fixed in the script; the test is unchanged. The absolute path is now stored alongside the key so `readChunk` never round-trips through it.

### 4. `typecheck.test.ts` — a premise Windows cannot reproduce

The case simulated an outside kill with `process.kill(pid, 'SIGKILL')`. Windows has no signals: the child exits 1 with `signal === null`, and the wrapper **correctly** reports a generic crash. Nothing was broken — the test's premise is unreproducible there.

**The `skipIf(win32)` is not a weakening, and should not be reviewed as one:** it ships together with a **new `exit 137` case** covering the other half of the same branch (`signal === 'SIGKILL' || code === 137`) — which is what a container actually reports when it OOM-kills a child, and which runs on every platform. Coverage went up while the skip went in.

---

## Mutation evidence

Every guard touched was mutation-tested — the fix is only worth having if the guard still goes red for the right reason, and "the test now passes" proves nothing when it passed before too.

| mutation | failure |
|---|---|
| drop `process.exitCode = main()` (gate-cli) | `expected +0 to be 1`, plus both baseline-integrity cases `expected +0 to be 2` |
| drop the `?? new Date().toISOString()` stamp (cli.ts) | `expected undefined to be truthy` |
| rename a `PUBLISHER_REACHABLE` entry | `blocks.router.RENAMED.ts was not read — is the path stale?` |
| drop `'generation-resources'` from `KNOWN_STATIC_ENDPOINT_SEGMENTS` | `expected '/api/v1/blocks/:seg' to be '/api/v1/blocks/generation-resources'` |
| drop the `'user-settings:write'` label | `expected [ 'user-settings:write' ] to deeply equal []` |
| set orchestrator-chat's wait to `60000` | `expected 60000 to be less than or equal to 150`, and the ledger names `server/services/comics/orchestrator-chat.ts:60000` |
| drop `\|\| code === 137` from the wrapper's classifier | new case fails to find `killed from outside` |

The `?? new Date().toISOString()` one is worth noting: that file's own header records that this exact mutation once survived the entire suite at PASS=44 FAIL=0. It doesn't now.

---

## One near-miss, recorded for the rule it produced

While mutation-testing, my automated mutate/restore reinserted a deleted line by replacing the **empty string** — which matches at index 0, so it wrote `'generation-resources',` into the **top of a product file**, outside the Set it belonged to.

It never reached the diff: vitest reported it as a transform error (`Expected "(" but found "{"`) rather than a test failure, and `git diff --stat` **before** committing caught the stray file. Reverted with `git checkout --`; the final verification run was clean and the diff contains only the intended files.

The general rule: **an automated mutate/restore is only safe if every anchor is non-empty in both directions.** A restore whose "find" is `''` does not restore, it prepends.

---

## Verification

- 6 previously-red `unit` files: **70 passed, 1 skipped, exit 0** (`--max-workers=2`, targeted file runs).
- `pnpm run test:packages:run`: **0 failed / 1056 passed / exit 0**.
- `pnpm run typecheck`: **0 errors** against the full branch (all three commits).
- Not verified by me: that these behave identically on Linux/CI. Every change is either platform-neutral (posix separators are what Linux already produced) or explicitly platform-gated, but CI is the check that matters and it has not run yet.

## Not in scope

The `component` project is red on Windows too — three sub-pixel geometry pins (`expected 94.875 to be >= 95`, `expected 133.13 to be close to 133.27`). Those are **not** this class: a pinned sub-pixel measurement is machine-dependent by nature, so loosening it would make the test pass without making it correct. Deliberately untouched — the fix is a decision about what those tests should assert.
