### PR TITLE
perf(tests): cut test-body time in the five slowest unit-suite files

### DIFF
--- a/scripts/__tests__/dev-server-port-reservation.test.ts
+++ b/scripts/__tests__/dev-server-port-reservation.test.ts
@@ -39,11 +39,21 @@ import {
   sessions,
 } from '../../.claude/skills/dev-server/scripts/daemon.mjs';
 
-// A 1ms poll with a generous deadline keeps every case below count-bound rather than clock-bound:
-// the probe mocks decide the outcome, so a slow box cannot turn a pass into the very failure these
-// tests exist to detect. The scan base sits above the default 3000 so no case can be satisfied by
-// a port a real session would be using.
+// A 1ms poll with a generous deadline keeps the cases where the port FREES count-bound rather than
+// clock-bound: the probe mocks decide the outcome, so a slow box cannot turn a pass into the very
+// failure these tests exist to detect. The scan base sits above the default 3000 so no case can be
+// satisfied by a port a real session would be using.
 const FAST_CLAIM = { timeoutMs: 5000, intervalMs: 1, baseDevPort: 3100 };
+
+// The cases where the port NEVER frees are a different shape, and the comment above used to claim
+// them too. They cannot be count-bound: claimPortForReuse polls until its deadline and only then
+// moves, so expiry IS the mechanism under test and the deadline is paid in full. At 5000ms the two
+// of them cost 10.0s of the file's 10.6s — measured, and unmoved by running the file alone, which
+// is what distinguishes a real wait from contention. 60ms buys the same expiry.
+//
+// Shortening it cannot make these flaky: the assertion is that the session MOVED, and the move is
+// what happens once the deadline passes however few probes fit inside it.
+const HELD_CLAIM = { ...FAST_CLAIM, timeoutMs: 60 };
 
 const ENV_PATH = '/nonexistent/.env'; // only read by start(), which no test here calls
 
@@ -149,7 +159,7 @@ describe('dev-server port claim on reuse', () => {
     makeSession('neighbour', 3100).status = 'running';
     isPortFreeMock.mockImplementation(async (port: number) => port !== 3101);
 
-    expect(await claimPortForReuse(session, FAST_CLAIM)).toBe(3102);
+    expect(await claimPortForReuse(session, HELD_CLAIM)).toBe(3102);
     expect(session.port).toBe(3102);
     expect(session.logs.at(-1)?.message).toContain('moving this session to 3102');
   });
@@ -162,7 +172,7 @@ describe('dev-server port claim on reuse', () => {
     makeSession('above', 3102).status = 'crashed';
     isPortFreeMock.mockImplementation(async (port: number) => port !== 3101);
 
-    expect(await claimPortForReuse(session, FAST_CLAIM)).toBe(3103);
+    expect(await claimPortForReuse(session, HELD_CLAIM)).toBe(3103);
   });
 });
 

--- a/scripts/__tests__/typecheck-tests-gate.test.ts
+++ b/scripts/__tests__/typecheck-tests-gate.test.ts
@@ -752,6 +752,26 @@ describe('the gate, end to end: a broken checker must never PASS', () => {
     expect(res.all).not.toContain('PASS —');
   });
 
+  // A wrapper that NEVER LAUNCHES, which is a different failure from one that runs and exits
+  // non-zero. It is worth its own case because the neighbouring class bit us elsewhere: an
+  // `execFile` on an extensionless `node_modules/.bin` script never started on Windows, and the
+  // ENOENT landed in the same `code` field as a real exit status, so a process that never ran
+  // reported as one that exited 2.
+  //
+  // The gate is structurally immune to that shape rather than defended against it: it spawns
+  // `process.execPath` — always present — and passes the wrapper as an ARGUMENT, so a missing
+  // wrapper is node's own exit 1 with no diagnostics, which the FAILURE-TO-RUN rule already owns.
+  // There is no resolved-binary lookup anywhere in this path to fail silently. This pins that.
+  it('a wrapper that does not exist -> exit 3, never a pass', () => {
+    const res = runGate(
+      path.join(dir, 'no-such-wrapper.mjs'),
+      fixtureBaseline('b-missing', BASE_FILES)
+    );
+    expect(res.status).toBe(3);
+    expect(res.all).toContain('CANNOT MEASURE');
+    expect(res.all).not.toContain('PASS —');
+  });
+
   it('a run killed by a signal -> exit 3', () => {
     const res = runGate(
       wrapperStub('killed', 'process.kill(process.pid, "SIGKILL");'),

--- a/src/server/games/daily-challenge/__tests__/challenge-ladder.test.ts
+++ b/src/server/games/daily-challenge/__tests__/challenge-ladder.test.ts
@@ -355,16 +355,10 @@ describe('findSlot seating', () => {
 describe('the per-tick placement budget fits the job lock', () => {
   // The bound this exists for is the JOB lock, which is not the completion claim and is not the
   // cron interval. Getting the three confused is how a cap gets sized against the wrong number.
-  it('is the lock the job actually asks for, not createJob’s default', async () => {
-    const { createJob } = await import('~/server/jobs/job');
-    const inherited = createJob('probe', '*/10 * * * *', async () => undefined);
-    const { dailyChallengeJobs } = await import('~/server/jobs/daily-challenge-processing');
-    const job = dailyChallengeJobs.find((j) => j.name === 'daily-challenge-process-entries')!;
-
-    expect(job.options.lockExpiration).toBe(REVIEW_JOB_LOCK_SECONDS);
-    // The point of the override: the inherited default is too short to hold a drain.
-    expect(REVIEW_JOB_LOCK_SECONDS).toBeGreaterThan(inherited.options.lockExpiration);
-    // Still shorter than the interval, so a tick can never overlap itself.
+  // The other half of this — that the JOB actually asks for REVIEW_JOB_LOCK_SECONDS — lives in
+  // `src/server/jobs/__tests__/challenge-jobs-scale.test.ts`, which already loads
+  // daily-challenge-processing.ts. Importing that graph here cost 35s of test-body time on its own.
+  it('is shorter than the interval, so a tick can never overlap itself', () => {
     expect(REVIEW_JOB_LOCK_SECONDS).toBeLessThan(REVIEW_JOB_INTERVAL_SECONDS);
   });
 

--- a/src/server/jobs/__tests__/challenge-jobs-scale.test.ts
+++ b/src/server/jobs/__tests__/challenge-jobs-scale.test.ts
@@ -139,9 +139,11 @@ vi.mock('~/server/jobs/daily-challenge-processing', async (importOriginal) => {
   return { ...actual, pickWinnersForChallenge: mockPickWinnersForChallenge };
 });
 
-const { reviewEntries, challengeReviewInternals } = await import(
+const { reviewEntries, challengeReviewInternals, dailyChallengeJobs } = await import(
   '~/server/jobs/daily-challenge-processing'
 );
+const { createJob } = await import('~/server/jobs/job');
+const { REVIEW_JOB_LOCK_SECONDS } = await import('~/server/games/daily-challenge/challenge-ladder');
 const { runChallengeCompletion } = await import('~/server/jobs/challenge-completion');
 const { CHALLENGE_JOB_BATCH_SIZE, CHALLENGE_JOB_CONCURRENCY } = await import(
   '~/shared/constants/challenge.constants'
@@ -172,6 +174,20 @@ beforeEach(() => {
   mockGetEndedActiveChallenges.mockResolvedValue([]);
   mockGetChallengesToReconcile.mockResolvedValue([]);
   mockResetStuckCompletingChallenges.mockResolvedValue(0);
+});
+
+describe('the review job asks for the lock the placement budget was sized against', () => {
+  // The bound REVIEW_TICK_BUDGET_MS is sized against is the JOB lock, not the completion claim and
+  // not the cron interval. The arithmetic lives beside those constants in challenge-ladder.test.ts;
+  // this is the wiring half, here because loading daily-challenge-processing.ts is what it costs.
+  it('is the lock the job actually asks for, not createJob’s default', () => {
+    const inherited = createJob('probe', '*/10 * * * *', async () => undefined);
+    const job = dailyChallengeJobs.find((j) => j.name === 'daily-challenge-process-entries')!;
+
+    expect(job.options.lockExpiration).toBe(REVIEW_JOB_LOCK_SECONDS);
+    // The point of the override: the inherited default is too short to hold a drain.
+    expect(REVIEW_JOB_LOCK_SECONDS).toBeGreaterThan(inherited.options.lockExpiration);
+  });
 });
 
 describe('reviewEntries at volume', () => {

--- a/src/server/rewards/__tests__/base.reward.failsoft.test.ts
+++ b/src/server/rewards/__tests__/base.reward.failsoft.test.ts
@@ -233,7 +233,15 @@ describe('base.reward batch process() still rethrows (cron path unchanged)', () 
     });
   }
 
+  // The batch path retries 5 times with a 500ms backoff, all of it real: this one test cost 2556ms
+  // of the file's 3837ms. The retry budget IS what is under test here — shrinking it would change
+  // the behaviour rather than the clock — so the clock is driven instead.
+  //
+  // The loop is bounded and the assertion is awaited afterwards, so a retry chain that stopped
+  // terminating fails on the awaited rejection rather than spinning: 12 turns of 1000ms is far past
+  // the 5 x 500ms this path can schedule.
   it('(e) rethrows on update failure in the batch process path', async () => {
+    vi.useFakeTimers();
     h.insertImpl.mockRejectedValue(new Error('CH down'));
     const reward = makeProcessableReward();
 
@@ -253,6 +261,21 @@ describe('base.reward batch process() still rethrows (cron path unchanged)', () 
       db: {} as any,
     };
 
-    await expect(reward.process(ctx)).rejects.toThrow(/Buzz Event Processing Failure/);
+    const settled = expect(reward.process(ctx)).rejects.toThrow(/Buzz Event Processing Failure/);
+    try {
+      for (let turn = 0; turn < 12; turn++) await vi.advanceTimersByTimeAsync(1000);
+      await settled;
+    } finally {
+      vi.useRealTimers();
+    }
+
+    // 1 attempt plus the 5 retries `updateBuzzEvents` passes to withRetries as a literal — NOT
+    // BATCH_RETRY_COUNT, which is `addBuzzEvent`'s default and which this path never reads. Checked:
+    // dropping BATCH_RETRY_COUNT to 1 leaves this green, dropping the literal to 1 gives
+    // "expected 6 times, but got 2 times".
+    //
+    // Doubles as the control on the fake clock: without it driving the 500ms backoff, these attempts
+    // would not have happened.
+    expect(h.insertImpl).toHaveBeenCalledTimes(6);
   });
 });

--- a/src/server/services/__tests__/challenge-category.service.test.ts
+++ b/src/server/services/__tests__/challenge-category.service.test.ts
@@ -1,11 +1,21 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// No ~/server/db/client mock on purpose: the service imports it lazily and falls back to the
-// preset constants when the import/query fails, which is exactly the pre-seed behavior these
-// tests pin down. (In prod the same path covers an env whose ChallengeCategory table hasn't
-// been created/seeded yet — migrations are applied manually.)
+// The service imports dbRead lazily and falls back to the preset constants when the read fails —
+// the pre-seed behavior the "preset fallback" tests below pin down. (In prod the same path covers
+// an env whose ChallengeCategory table hasn't been created/seeded yet: migrations are applied
+// manually.) The read is stubbed to reject rather than left to a real connection attempt: the
+// unmocked client took ~4s per call to time out, and whether it failed at all depended on what the
+// box could reach.
+const { findManyMock } = vi.hoisted(() => ({ findManyMock: vi.fn() }));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { challengeCategory: { findMany: findManyMock } },
+  dbWrite: { challengeCategory: { upsert: vi.fn() } },
+}));
+
 import {
   assertCategoryActiveAllowed,
+  clearChallengeCategoryCache,
   getJudgingCategoryOptions,
   mergeCategoryRows,
   pickCategoryRubric,
@@ -62,6 +72,33 @@ describe('pickCategoryRubric precedence', () => {
 });
 
 describe('preset fallback (no DB available)', () => {
+  beforeEach(() => {
+    clearChallengeCategoryCache();
+    findManyMock.mockReset();
+    findManyMock.mockRejectedValue(new Error('relation "ChallengeCategory" does not exist'));
+  });
+
+  // Every assertion below this line also holds when the read SUCCEEDS and returns no rows, because
+  // merging presets with an empty row set gives the same answer. These two pin which path ran: the
+  // failure path deliberately does not cache, so a blip cannot make resolveJudgingCategories reject
+  // valid keys for a whole TTL.
+  it('does not cache a failed read — the next call retries the DB', async () => {
+    await getJudgingCategoryOptions();
+    await getJudgingCategoryOptions();
+    expect(findManyMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('caches a successful read, and lets its rows override the presets', async () => {
+    findManyMock.mockReset();
+    findManyMock.mockResolvedValue([row({ key: 'theme', label: 'Theme (from DB)' })]);
+
+    const first = await getJudgingCategoryOptions();
+    await getJudgingCategoryOptions();
+
+    expect(first.find((o) => o.key === 'theme')?.label).toBe('Theme (from DB)');
+    expect(findManyMock).toHaveBeenCalledTimes(1);
+  });
+
   it('getJudgingCategoryOptions returns the preset library without rubric columns', async () => {
     const options = await getJudgingCategoryOptions();
     expect(options.map((o) => o.key)).toContain('theme');
@@ -104,7 +141,9 @@ describe('preset fallback (no DB available)', () => {
   it('resolveRubricBlock derives per-key blocks from the preset library when the DB is unavailable', async () => {
     const block = await resolveRubricBlock([{ key: 'theme' }, { key: 'aesthetic' }]);
     const derive = (k: 'theme' | 'aesthetic') =>
-      `${CHALLENGE_PRESET_CATEGORIES[k].label.toUpperCase()} SCORING (0-10):\n${CHALLENGE_PRESET_CATEGORIES[k].criteria}`.trim();
+      `${CHALLENGE_PRESET_CATEGORIES[k].label.toUpperCase()} SCORING (0-10):\n${
+        CHALLENGE_PRESET_CATEGORIES[k].criteria
+      }`.trim();
     expect(block).toBe([derive('theme'), derive('aesthetic')].join('\n\n'));
   });
 });

--- a/src/server/services/__tests__/prisma-inconsistent-orphan-relations.test.ts
+++ b/src/server/services/__tests__/prisma-inconsistent-orphan-relations.test.ts
@@ -1,70 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-
-// The modules under test (model.service, article.selector → tag.selector, etc.)
-// call `Prisma.validator<...>()(...)` and the `Prisma.sql`/`raw`/`join` tagged-
-// template helpers at MODULE-LOAD (top-level consts). Under the unit vitest env
-// the real `@prisma/client` is externalised and those runtime members aren't
-// available at SSR import time → `Prisma.validator is not a function`. Mirror the
-// house pattern (see block-registry.page-only-launch / showcase.service tests):
-// stub `@prisma/client` with passthrough runtime helpers. A Proxy backs `Prisma`
-// so any enum the wide import graph references at load resolves to a stub member
-// instead of `undefined`, while the helpers we know the graph calls are real fns.
-vi.mock('@prisma/client', () => {
-  // `Prisma.validator<T>()(x)` → returns a function that returns its argument
-  // unchanged, so the validated select/where object is preserved verbatim (the
-  // tests assert against that exact shape).
-  const validator = () => (x: unknown) => x;
-  // Tagged-template SQL helpers used at module load by caches.ts / selectors.
-  const sql = (strings: TemplateStringsArray, ...values: unknown[]) => ({
-    strings,
-    values,
-    sql: strings.join('?'),
-  });
-  const raw = (s: string) => ({ sql: s, values: [] });
-  const join = (values: unknown[], separator = ',') => ({ values, separator });
-  const empty = { sql: '', values: [] };
-  class Sql {}
-
-  const known: Record<string, unknown> = {
-    validator,
-    sql,
-    raw,
-    join,
-    empty,
-    Sql,
-    // Common Prisma sort/null constants referenced in selectors at load.
-    SortOrder: { asc: 'asc', desc: 'desc' },
-    QueryMode: { default: 'default', insensitive: 'insensitive' },
-    JsonNull: 'JsonNull',
-    DbNull: 'DbNull',
-    AnyNull: 'AnyNull',
-  };
-
-  // Any other `Prisma.<member>` access (Prisma-generated enums referenced at
-  // load time across the wide import graph) resolves to an empty object stub,
-  // so module evaluation never trips over an undefined member.
-  const Prisma = new Proxy(known, {
-    get(target, prop: string) {
-      if (prop in target) return target[prop];
-      return {};
-    },
-  });
-
-  // Prisma-generated *enums* are exported as top-level named exports too
-  // (e.g. `import { MediaType } from '@prisma/client'`). Back the whole module
-  // with a Proxy: `Prisma` resolves above; any other named import (an enum)
-  // resolves to an empty object stub.
-  return new Proxy(
-    { Prisma, PrismaClient: class PrismaClient {} },
-    {
-      get(target, prop: string) {
-        if (prop in target) return (target as Record<string, unknown>)[prop];
-        if (prop === '__esModule') return true;
-        return {};
-      },
-    }
-  );
-});
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * Regression tests for the "Inconsistent query result" 500s on
@@ -83,35 +17,124 @@ vi.mock('@prisma/client', () => {
  * resolvable rows / empty) instead of erroring.
  */
 
-// --- model.getRecentlyManuallyAdded ----------------------------------------
-// The handler is a thin wrapper over a single dbRead.imageResourceNew.findMany,
-// so we mock the db client and the env, and stub the (heavy) transitive imports
-// of model.service that aren't exercised by this code path.
+// model.service.ts has a very large import graph and only one thin handler on it
+// is exercised here, so its transitive service/db/search dependencies are stubbed.
+// Mirrors the scaffold in set-model-minor.service.test.ts.
+const { mockDbRead, mockDbWrite, findManyMock } = vi.hoisted(() => {
+  const findManyMock = vi.fn();
+  const mk = () => ({
+    findFirst: vi.fn(),
+    findUnique: vi.fn(),
+    findMany: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    updateMany: vi.fn(),
+  });
+  return {
+    findManyMock,
+    mockDbRead: {
+      model: mk(),
+      modelVersion: mk(),
+      imageResourceNew: { findMany: findManyMock },
+      $queryRaw: vi.fn(),
+    },
+    mockDbWrite: {
+      model: mk(),
+      modelVersion: mk(),
+      $queryRaw: vi.fn(),
+      $executeRaw: vi.fn(),
+    },
+  };
+});
 
-const findManyMock = vi.fn();
-
-vi.mock('~/server/db/client', () => ({
-  dbRead: { imageResourceNew: { findMany: findManyMock } },
-  dbWrite: {},
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
+vi.mock('~/server/db/db-lag-helpers', () => ({
+  preventReplicationLag: vi.fn(),
+  getDbWithoutLag: vi.fn(async () => mockDbRead),
+  preventModelVersionLagBatch: vi.fn(),
 }));
+vi.mock('~/server/db/pgDb', () => ({ pgDbRead: {}, pgDbWrite: {}, pgDbReadLong: {} }));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: null, Tracker: class {} }));
+vi.mock('~/server/flipt/client', () => ({ isFlipt: vi.fn(() => false), FLIPT_FEATURE_FLAGS: {} }));
+vi.mock('~/server/metrics', () => ({ modelMetrics: {} }));
+vi.mock('~/server/redis/caches', () => ({
+  dataForModelsCache: {},
+  modelTagCache: { refresh: vi.fn() },
+  modelVotableTagsCache: { bust: vi.fn() },
+  userBasicCache: {},
+  userModelCountCache: { refresh: vi.fn() },
+}));
+vi.mock('~/server/redis/client', () => ({
+  redis: { del: vi.fn() },
+  REDIS_KEYS: { MODEL: { GALLERY_SETTINGS: 'model:gallery-settings' } },
+}));
+vi.mock('~/server/search-index', () => ({
+  collectionsSearchIndex: { queueUpdate: vi.fn() },
+  imagesMetricsSearchIndex: { queueUpdate: vi.fn() },
+  imagesSearchIndex: { queueUpdate: vi.fn() },
+  modelsSearchIndex: { queueUpdate: vi.fn() },
+}));
+vi.mock('~/server/services/auction.service', () => ({
+  deleteBidsForModel: vi.fn(),
+  getLastAuctionReset: vi.fn(),
+}));
+vi.mock('~/server/services/buzz.service', () => ({
+  getMultiAccountTransactionsByPrefix: vi.fn(),
+  getUserBuzzAccountByAccountTypes: vi.fn(),
+  refundMultiAccountTransaction: vi.fn(),
+}));
+vi.mock('~/server/services/blocked-browsing-tags.service', () => ({
+  enforceBlockedBrowsingTagsForModels: vi.fn(),
+}));
+vi.mock('~/server/services/blocklist.service', () => ({ throwOnBlockedLinkDomain: vi.fn() }));
+vi.mock('~/server/services/collection.service', () => ({
+  getAvailableCollectionItemsFilterForUser: vi.fn(),
+  getUserCollectionPermissionsById: vi.fn(),
+  saveItemInCollections: vi.fn(),
+}));
+vi.mock('~/server/services/cosmetic.service', () => ({ getCosmeticsForEntity: vi.fn() }));
+vi.mock('~/server/services/creator-program.service', () => ({
+  getValidCreatorMembershipMap: vi.fn(),
+}));
+vi.mock('~/server/services/generation/generation.service', () => ({
+  getUnavailableResources: vi.fn(),
+}));
+vi.mock('~/server/services/image.service', () => ({
+  getImagesForModelVersion: vi.fn(),
+  getImagesForModelVersionCache: {},
+  queueImageSearchIndexUpdate: vi.fn(),
+}));
+vi.mock('~/server/services/model-file.service', () => ({ getFilesForModelVersionCache: {} }));
+vi.mock('~/server/services/model-version.service', () => ({
+  bustMvCache: vi.fn(),
+  bustPublicModelResponseCache: vi.fn(),
+  createModelVersionPostFromTraining: vi.fn(),
+  publishModelVersionsWithEarlyAccess: vi.fn(),
+}));
+vi.mock('~/server/services/moderator.service', () => ({ trackModActivity: vi.fn() }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn() }));
+vi.mock('~/server/services/subscriptions.service', () => ({ getHighestTierSubscription: vi.fn() }));
+vi.mock('~/server/services/system-cache', () => ({ getCategoryTags: vi.fn() }));
+vi.mock('~/server/services/user.service', () => ({
+  deleteBasicDataForUser: vi.fn(),
+  getCosmeticsForUsers: vi.fn(),
+  getProfilePicturesForUsers: vi.fn(),
+}));
+vi.mock('~/server/utils/cache-helpers', () => ({
+  bustFetchThroughCache: vi.fn(),
+  fetchThroughCache: vi.fn(),
+}));
+vi.mock('~/utils/s3-utils', () => ({ deleteModelFileObjects: vi.fn() }));
+vi.mock('~/utils/storage-resolver', () => ({ deregisterFileLocationsBatch: vi.fn() }));
+
+import { getBountyDetailsSelect } from '~/server/selectors/bounty.selector';
+import { articleDetailSelect } from '~/server/selectors/article.selector';
+import { postSelect } from '~/server/selectors/post.selector';
+import { getRecentlyManuallyAdded } from '~/server/services/model.service';
+
+// --- model.getRecentlyManuallyAdded ----------------------------------------
 
 describe('getRecentlyManuallyAdded — orphaned ImageResourceNew.modelVersion', () => {
-  // `../model.service` is a ~2500-line module that transitively imports the heavy
-  // image/event-engine service graph; its first cold transform+import takes ~16s in
-  // isolation and balloons further when it has to race the rest of the suite's worker
-  // pool for CPU — which made a PER-TEST `await import(...)` blow even a 30s timeout
-  // under full-suite parallelism (and cascade the later tests into "not a function").
-  // Pay that real-module load ONCE here, off the per-test budget, with a generous
-  // import-only timeout that absorbs worst-case contention. The actual assertions
-  // (the regression guard on the real `{ is: {} }` filter) stay instant + unchanged.
-  let getRecentlyManuallyAdded: (
-    args: { take: number; userId: number }
-  ) => Promise<number[]>;
-
-  beforeAll(async () => {
-    ({ getRecentlyManuallyAdded } = await import('../model.service'));
-  }, 120000);
-
   beforeEach(() => {
     findManyMock.mockReset();
   });
@@ -157,12 +180,10 @@ describe('getRecentlyManuallyAdded — orphaned ImageResourceNew.modelVersion', 
 // The article 500 comes from the `tags.tag` required relation in the shared
 // `articleDetailSelect`, reused by getArticleById, getModeratorArticles, the
 // search indexer, and the outbound webhook. The fix lives in the selector, so
-// we assert the selector shape directly (a pure data object — no heavy imports).
+// we assert the selector shape directly.
 
 describe('articleDetailSelect — orphaned TagsOnArticle.tag', () => {
-  it('filters the tags relation on tag existence so orphaned join rows are excluded', async () => {
-    const { articleDetailSelect } = await import('~/server/selectors/article.selector');
-
+  it('filters the tags relation on tag existence so orphaned join rows are excluded', () => {
     // tags must carry a where-clause requiring the related Tag to exist; a
     // bare `{ select: { tag: ... } }` (no where) re-introduces the 500 because
     // TagsOnArticle.tag is a required relation with orphaned rows in prod.
@@ -179,8 +200,7 @@ describe('articleDetailSelect — orphaned TagsOnArticle.tag', () => {
 // so they need the identical existence filter or they 500 the same way.
 
 describe('postSelect — orphaned TagsOnPost.tag', () => {
-  it('filters the tags relation on tag existence', async () => {
-    const { postSelect } = await import('~/server/selectors/post.selector');
+  it('filters the tags relation on tag existence', () => {
     expect(postSelect.tags).toMatchObject({
       where: { tag: { is: {} } },
       select: { tag: { select: expect.anything() } },
@@ -189,8 +209,7 @@ describe('postSelect — orphaned TagsOnPost.tag', () => {
 });
 
 describe('getBountyDetailsSelect — orphaned TagsOnBounty.tag', () => {
-  it('filters the tags relation on tag existence', async () => {
-    const { getBountyDetailsSelect } = await import('~/server/selectors/bounty.selector');
+  it('filters the tags relation on tag existence', () => {
     expect(getBountyDetailsSelect.tags).toMatchObject({
       where: { tag: { is: {} } },
       select: { tag: { select: expect.anything() } },

--- a/src/server/services/blocks/__tests__/listing-asset-upload-integrity.test.ts
+++ b/src/server/services/blocks/__tests__/listing-asset-upload-integrity.test.ts
@@ -93,6 +93,17 @@ vi.mock('~/utils/s3-utils', async (importOriginal) => ({
   }),
 }));
 
+// Imported here rather than from inside the helpers below. Reached from a test BODY, this graph is
+// billed to that one test's `duration` instead of to `collect` — it put 6664ms of this file's
+// 6992ms on the first test to run. The mocks above still apply: vi.mock is hoisted above imports.
+import {
+  addListingScreenshot,
+  setListingCover,
+  setListingIcon,
+} from '../app-listing-assets.service';
+import { persistListingAssetImage } from '../offsite-listing.service';
+import { readRecordedEtag } from '../stored-object-integrity';
+
 // ---------------------------------------------------------------------------
 // A minimal object store the real probe + the real head both talk to.
 // ---------------------------------------------------------------------------
@@ -176,7 +187,6 @@ const owner = { id: OWNER, isModerator: false } as never;
  */
 async function persistAndCaptureMetadata() {
   mockCreateImage.mockClear();
-  const { persistListingAssetImage } = await import('../offsite-listing.service');
   await persistListingAssetImage({
     input: { url: KEY, name: 'icon.png', width: 1, height: 1, mimeType: 'image/png' },
     userId: OWNER,
@@ -202,7 +212,6 @@ function rowWith(metadata: unknown, measured: { width: number; height: number })
 }
 
 async function attachAsIcon() {
-  const { setListingIcon } = await import('../app-listing-assets.service');
   return setListingIcon({ listingId: 'apl_1', imageId: 500 }, owner);
 }
 
@@ -230,7 +239,6 @@ const KIND_FIXTURES = [
     measured: { width: 1280, height: 720 },
     sameShape: { width: 1280, height: 720, shade: 200 },
     attach: async () => {
-      const { setListingCover } = await import('../app-listing-assets.service');
       return setListingCover({ listingId: 'apl_1', imageId: 500 }, owner);
     },
     attached: { status: 'attached', coverId: 500 },
@@ -241,7 +249,6 @@ const KIND_FIXTURES = [
     measured: { width: 1280, height: 720 },
     sameShape: { width: 1280, height: 720, shade: 200 },
     attach: async () => {
-      const { addListingScreenshot } = await import('../app-listing-assets.service');
       return addListingScreenshot({ listingId: 'apl_1', imageId: 500 }, owner);
     },
     attached: { status: 'attached', id: 'apls_test_1', order: 0 },
@@ -275,7 +282,6 @@ describe('listing media — the persisted measurement is re-verified at attach',
     // Recorded, and recorded as the store's own token for THESE bytes — not some
     // value the caller supplied and not a constant.
     expect(metadata).toMatchObject({ size: original.byteLength });
-    const { readRecordedEtag } = await import('../stored-object-integrity');
     expect(readRecordedEtag(metadata)).toBe(etagOf(original).replaceAll('"', ''));
   });
 
@@ -515,7 +521,6 @@ describe('listing media — every non-match verdict is reported with its reason'
     mockLogToAxiom.mockClear();
     putObject(KEY, await flatPng(160, 120, 200));
 
-    const { setListingCover } = await import('../app-listing-assets.service');
     await expect(setListingCover({ listingId: 'apl_1', imageId: 500 }, owner)).rejects.toThrow();
     expect(integrityEvents()).toEqual([expect.objectContaining({ kind: 'cover' })]);
   });

--- a/src/store/__tests__/s3-upload.store.test.ts
+++ b/src/store/__tests__/s3-upload.store.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest';
 import { useS3UploadStore } from '~/store/s3-upload.store';
 import { UploadType } from '~/server/common/enums';
+import { MAX_PART_ATTEMPTS } from '~/utils/upload-retry';
 
 /**
  * Regression cover for large-file uploads that transferred every byte and then
@@ -163,7 +164,50 @@ function makeFile(bytes: number) {
   return new File([new Uint8Array(bytes)], 'model.safetensors');
 }
 
+type UploadArgs = Parameters<ReturnType<typeof useS3UploadStore.getState>['upload']>;
+
+/** Above MAX_BACKOFF_MS, so one turn always clears whatever the longest sleep resolved to. */
+const CLOCK_TURN_MS = 60_000;
+/**
+ * Far above the store's longest chain (MAX_PART_ATTEMPTS backoffs per part, then 3 completion
+ * attempts) and above the microtask turns the fetch chain needs between them.
+ */
+const MAX_CLOCK_TURNS = 200;
+
+/**
+ * Runs an upload with the store's retry sleeps driven rather than waited out. Both give-up paths
+ * sleep for real — parts back off exponentially over MAX_PART_ATTEMPTS, and `withRetries` holds a
+ * flat second between completion attempts — which is wall clock this file was paying in full.
+ *
+ * 🔴 The loop is bounded and THROWS, which is the whole reason a fake clock is safe here. Driving a
+ * loop with a fake is normally how a regression turns into an unreportable hang: the runner's
+ * timeout is itself a timer, so a test that never settles can wedge CI with nothing to read. A
+ * retry loop that stopped terminating fails here with a message instead.
+ *
+ * 🔴 It advances the clock unconditionally rather than while `vi.getTimerCount() > 0`. That was the
+ * first shape and it hung: at the moment the upload is handed back, no timer exists yet — the first
+ * one is scheduled only after `fetch('/api/upload')` resolves — so the guard read 0 and exited
+ * before the run had begun. A count of pending timers says nothing about whether more are coming.
+ */
+async function runUpload(...args: UploadArgs) {
+  let settled = false;
+  const promise = useS3UploadStore
+    .getState()
+    .upload(...args)
+    .finally(() => {
+      settled = true;
+    });
+  for (let turn = 0; !settled && turn < MAX_CLOCK_TURNS; turn++)
+    await vi.advanceTimersByTimeAsync(CLOCK_TURN_MS);
+  if (!settled)
+    throw new Error(
+      `upload did not settle within ${MAX_CLOCK_TURNS} clock turns — a retry loop is not terminating`
+    );
+  return promise;
+}
+
 beforeEach(() => {
+  vi.useFakeTimers();
   useS3UploadStore.setState({ items: [] });
   completeStatus = 200;
   completeStatusQueue = [];
@@ -181,6 +225,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.unstubAllGlobals();
 });
 
@@ -193,7 +238,7 @@ describe('useS3UploadStore.upload', () => {
       return { status: 200, etag: 'etag' };
     };
 
-    const result = await useS3UploadStore.getState().upload({
+    const result = await runUpload({
       file: makeFile(CHUNK * 3),
       type: UploadType.Model,
     });
@@ -209,11 +254,44 @@ describe('useS3UploadStore.upload', () => {
     partHandler = (_url, partNumber) =>
       partNumber === 2 ? { status: 400 } : { status: 200, etag: 'etag' };
 
-    const result = await useS3UploadStore.getState().upload({
+    const result = await runUpload({
       file: makeFile(CHUNK * 2),
       type: UploadType.Model,
     });
 
+    expect(result).toBeUndefined();
+    expect(useS3UploadStore.getState().items[0].status).toBe('error');
+  });
+
+  // Nothing covered the TRANSIENT part-retry path: flipping shouldRetryPartError so 429/5xx were
+  // never retried left all 17 of the older tests green. It went untested because it was expensive —
+  // exhausting the backoff is ~1s + 2s + 4s + 8s of real sleeping. On the fake clock it is free.
+  it('retries a part that answers with a transient status, and finishes', async () => {
+    vi.stubGlobal('fetch', makeFetch(1));
+    let attempts = 0;
+    partHandler = () => {
+      attempts++;
+      return attempts === 1 ? { status: 503 } : { status: 200, etag: 'etag' };
+    };
+
+    const result = await runUpload({ file: makeFile(CHUNK), type: UploadType.Model });
+
+    expect(attempts).toBe(2);
+    expect(result).toBeTruthy();
+    expect(useS3UploadStore.getState().items[0].status).toBe('success');
+  });
+
+  it('stops at MAX_PART_ATTEMPTS when a part is transient forever, rather than retrying without end', async () => {
+    vi.stubGlobal('fetch', makeFetch(1));
+    let attempts = 0;
+    partHandler = () => {
+      attempts++;
+      return { status: 503 };
+    };
+
+    const result = await runUpload({ file: makeFile(CHUNK), type: UploadType.Model });
+
+    expect(attempts).toBe(MAX_PART_ATTEMPTS);
     expect(result).toBeUndefined();
     expect(useS3UploadStore.getState().items[0].status).toBe('error');
   });
@@ -226,7 +304,7 @@ describe('useS3UploadStore.upload', () => {
       return { status: 200, etag: 'etag' };
     };
 
-    const result = await useS3UploadStore.getState().upload({
+    const result = await runUpload({
       file: makeFile(CHUNK * 2),
       type: UploadType.Model,
     });
@@ -241,7 +319,7 @@ describe('useS3UploadStore.upload', () => {
     signPartStatus = 500;
     partHandler = () => ({ status: 403 });
 
-    const result = await useS3UploadStore.getState().upload({
+    const result = await runUpload({
       file: makeFile(CHUNK),
       type: UploadType.Model,
     });
@@ -255,9 +333,7 @@ describe('useS3UploadStore.upload', () => {
     completeStatusQueue = [503];
     const cb = vi.fn();
 
-    const result = await useS3UploadStore
-      .getState()
-      .upload({ file: makeFile(CHUNK), type: UploadType.Model }, cb);
+    const result = await runUpload({ file: makeFile(CHUNK), type: UploadType.Model }, cb);
 
     expect(completeCalls).toBe(2);
     expect(result).toBeTruthy();
@@ -269,9 +345,7 @@ describe('useS3UploadStore.upload', () => {
     completeStatus = 503;
     const cb = vi.fn();
 
-    const result = await useS3UploadStore
-      .getState()
-      .upload({ file: makeFile(CHUNK), type: UploadType.Model }, cb);
+    const result = await runUpload({ file: makeFile(CHUNK), type: UploadType.Model }, cb);
 
     expect(result).toBeUndefined();
     expect(cb).not.toHaveBeenCalled();
@@ -282,9 +356,7 @@ describe('useS3UploadStore.upload', () => {
     vi.stubGlobal('fetch', makeFetch(1));
     completeStatus = 409;
 
-    const result = await useS3UploadStore
-      .getState()
-      .upload({ file: makeFile(CHUNK), type: UploadType.Model });
+    const result = await runUpload({ file: makeFile(CHUNK), type: UploadType.Model });
 
     expect(completeCalls).toBe(1);
     expect(result).toBeUndefined();
@@ -311,9 +383,7 @@ describe('useS3UploadStore.upload multipart teardown', () => {
     vi.stubGlobal('fetch', makeFetch(1));
     completeStatus = 503;
 
-    const result = await useS3UploadStore
-      .getState()
-      .upload({ file: makeFile(CHUNK), type: UploadType.Model });
+    const result = await runUpload({ file: makeFile(CHUNK), type: UploadType.Model });
 
     expect(result).toBeUndefined();
     expect(useS3UploadStore.getState().items[0].status).toBe('error');
@@ -326,7 +396,7 @@ describe('useS3UploadStore.upload multipart teardown', () => {
     vi.stubGlobal('fetch', makeFetch(2));
     completeStatus = 422;
 
-    await useS3UploadStore.getState().upload({ file: makeFile(CHUNK * 2), type: UploadType.Model });
+    await runUpload({ file: makeFile(CHUNK * 2), type: UploadType.Model });
 
     expect(completeCalls).toBe(1);
     expect(abortCalls).toEqual([expectedAbort]);
@@ -338,7 +408,7 @@ describe('useS3UploadStore.upload multipart teardown', () => {
     vi.stubGlobal('fetch', makeFetch(1));
     completeStatus = 409;
 
-    await useS3UploadStore.getState().upload({ file: makeFile(CHUNK), type: UploadType.Model });
+    await runUpload({ file: makeFile(CHUNK), type: UploadType.Model });
 
     expect(abortCalls).toEqual([expectedAbort]);
   });
@@ -350,7 +420,7 @@ describe('useS3UploadStore.upload multipart teardown', () => {
     partHandler = (_url, partNumber) =>
       partNumber === 2 ? { status: 400 } : { status: 200, etag: 'etag' };
 
-    await useS3UploadStore.getState().upload({ file: makeFile(CHUNK * 2), type: UploadType.Model });
+    await runUpload({ file: makeFile(CHUNK * 2), type: UploadType.Model });
 
     expect(useS3UploadStore.getState().items[0].status).toBe('error');
     expect(abortCalls).toEqual([expectedAbort]);
@@ -361,9 +431,7 @@ describe('useS3UploadStore.upload multipart teardown', () => {
   it('does not abort an upload that completed successfully', async () => {
     vi.stubGlobal('fetch', makeFetch(2));
 
-    const result = await useS3UploadStore
-      .getState()
-      .upload({ file: makeFile(CHUNK * 2), type: UploadType.Model });
+    const result = await runUpload({ file: makeFile(CHUNK * 2), type: UploadType.Model });
 
     expect(result).toBeTruthy();
     expect(abortCalls).toEqual([]);
@@ -377,9 +445,7 @@ describe('useS3UploadStore.upload multipart teardown', () => {
     completeStatus = 503;
     onCompleteRequest = () => useS3UploadStore.setState({ items: [] });
 
-    const result = await useS3UploadStore
-      .getState()
-      .upload({ file: makeFile(CHUNK), type: UploadType.Model });
+    const result = await runUpload({ file: makeFile(CHUNK), type: UploadType.Model });
 
     expect(result).toBeUndefined();
     expect(abortCalls).toEqual([expectedAbort]);
@@ -392,9 +458,7 @@ describe('useS3UploadStore.upload multipart teardown', () => {
       return { status: 400 };
     };
 
-    const result = await useS3UploadStore
-      .getState()
-      .upload({ file: makeFile(CHUNK), type: UploadType.Model });
+    const result = await runUpload({ file: makeFile(CHUNK), type: UploadType.Model });
 
     expect(result).toBeUndefined();
     expect(abortCalls).toEqual([expectedAbort]);
@@ -407,9 +471,7 @@ describe('useS3UploadStore.upload multipart teardown', () => {
     completeStatus = 503;
     abortShouldReject = true;
 
-    const result = await useS3UploadStore
-      .getState()
-      .upload({ file: makeFile(CHUNK), type: UploadType.Model });
+    const result = await runUpload({ file: makeFile(CHUNK), type: UploadType.Model });
 
     expect(result).toBeUndefined();
     expect(useS3UploadStore.getState().items[0].status).toBe('error');
@@ -451,7 +513,7 @@ describe('useS3UploadStore.upload teardown ordering', () => {
     const { timeline, unsubscribe } = recordTimeline('error');
 
     try {
-      await useS3UploadStore.getState().upload({ file: makeFile(CHUNK), type: UploadType.Model });
+      await runUpload({ file: makeFile(CHUNK), type: UploadType.Model });
     } finally {
       unsubscribe();
     }
@@ -466,9 +528,7 @@ describe('useS3UploadStore.upload teardown ordering', () => {
     const { timeline, unsubscribe } = recordTimeline('error');
 
     try {
-      await useS3UploadStore
-        .getState()
-        .upload({ file: makeFile(CHUNK * 2), type: UploadType.Model });
+      await runUpload({ file: makeFile(CHUNK * 2), type: UploadType.Model });
     } finally {
       unsubscribe();
     }

--- a/src/utils/__tests__/upload-retry.test.ts
+++ b/src/utils/__tests__/upload-retry.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { isTerminalCompleteStatus } from '~/utils/upload-retry';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getPartRetryDelay, isTerminalCompleteStatus } from '~/utils/upload-retry';
 
 /**
  * `isTerminalCompleteStatus` is the ONE place both upload clients decide whether a
@@ -47,5 +47,70 @@ describe('isTerminalCompleteStatus', () => {
       .filter((s) => s >= 100)
       .filter(isTerminalCompleteStatus);
     expect(terminal).toEqual([409, 422]);
+  });
+});
+
+/**
+ * The backoff POLICY is only observable through the store as elapsed wall clock, so it had no
+ * cover at all: making 429 and 5xx non-retryable left every s3-upload.store test green. Pinned
+ * here, where the numbers can be read directly instead of waited for.
+ */
+describe('getPartRetryDelay', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('grows exponentially with the attempt, so a struggling backend gets backed off', () => {
+    const delays = [0, 1, 2].map((attempt) => getPartRetryDelay({ status: 503 }, attempt));
+    // ~1s, 2s, 4s, each plus up to 1s of jitter — asserted as bands, since the jitter is random.
+    expect(delays[0]).toBeGreaterThanOrEqual(1000);
+    expect(delays[0]).toBeLessThan(2000);
+    expect(delays[1]).toBeGreaterThanOrEqual(2000);
+    expect(delays[1]).toBeLessThan(3000);
+    expect(delays[2]).toBeGreaterThanOrEqual(4000);
+    expect(delays[2]).toBeLessThan(5000);
+  });
+
+  it('caps at a minute however many attempts have gone by', () => {
+    // Without a ceiling, attempt 20 is 2^20 seconds — the upload would never resume. The cap is
+    // applied to the base and the jitter is added after, so a minute is the floor of the capped
+    // value, not a hard ceiling.
+    const delay = getPartRetryDelay({ status: 503 }, 20);
+    expect(delay).toBeGreaterThanOrEqual(60_000);
+    expect(delay).toBeLessThan(61_000);
+  });
+
+  it('obeys a numeric Retry-After ahead of its own schedule', () => {
+    // The server's number is authoritative: retrying sooner than it asked is what turns a 429
+    // into a ban.
+    expect(getPartRetryDelay({ status: 429, retryAfter: '30' }, 0)).toBe(30_000);
+  });
+
+  it('caps a Retry-After the same way', () => {
+    expect(getPartRetryDelay({ status: 429, retryAfter: '3600' }, 0)).toBe(60_000);
+  });
+
+  it('reads an HTTP-date Retry-After as a delta from now', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    expect(getPartRetryDelay({ status: 429, retryAfter: 'Thu, 01 Jan 2026 00:00:20 GMT' }, 0)).toBe(
+      20_000
+    );
+  });
+
+  it('floors a Retry-After date that has already passed, rather than retrying instantly', () => {
+    // A skewed client clock can put the server's date in the past; hammering it immediately is
+    // the opposite of what the header asked for.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:01:00Z'));
+    expect(getPartRetryDelay({ status: 429, retryAfter: 'Thu, 01 Jan 2026 00:00:00 GMT' }, 0)).toBe(
+      1000
+    );
+  });
+
+  it('falls back to the schedule when Retry-After is unparseable', () => {
+    const delay = getPartRetryDelay({ status: 429, retryAfter: 'soon' }, 0);
+    expect(delay).toBeGreaterThanOrEqual(1000);
+    expect(delay).toBeLessThan(2000);
   });
 });

--- a/src/utils/metadata/__tests__/audit-matching-equivalence.test.ts
+++ b/src/utils/metadata/__tests__/audit-matching-equivalence.test.ts
@@ -34,6 +34,11 @@ import youngWords from '~/utils/metadata/lists/words-young.json';
  */
 
 // --- Reference (pre-optimization) per-word matching, copied verbatim ---
+// 🔴 Do not optimise anything in this section, and specifically: refIncludesPoi runs
+// refInPromptEdit (a String.match plus slicing) before regex.test, so a non-matching word pays
+// both. Reordering halves the two poi tests. It is still wrong — the value of an oracle is that
+// it is a COPY, and an optimised copy is a second implementation you believe is equivalent, which
+// is the one thing a differential test exists to not have to trust. Slow is the price.
 function refPrepareWordRegex(word: string, pluralize = false, leet = true) {
   let regexStr = word;
   regexStr = regexStr.replace(/\s+/g, `[^a-zA-Z0-9]+`);
@@ -184,8 +189,7 @@ const oldPerAgeRegexes = __buildOldAgeRegexesForTest();
 
 // Copied verbatim from audit.ts (module-private there). These two are NOT what the
 // refactor changed; replicating them keeps the comparison about the boundary only.
-const refFalsePositiveTagPattern =
-  /\bscore_\d(?:_up|_down)?\b|\bsource_\w+\b|\brating_\w+\b/gi;
+const refFalsePositiveTagPattern = /\bscore_\d(?:_up|_down)?\b|\bsource_\w+\b|\brating_\w+\b/gi;
 const refQuickScreenPattern =
   /(?:age[ds]?|year|old|birthday|anos|\b(?:1[0-7]|[1-9])\b|teen|eleven|twelve|one|two|three|four|five|six|seven|eight|nine|ten)/i;
 
@@ -537,17 +541,13 @@ describe('audit matching equivalence (gate vs brute-force)', () => {
   // Brute-force POI equivalence over the full corpus is CPU-bound (the POI
   // reference set is large); it correctly asserts but can exceed the 10s global
   // testTimeout on a loaded CI runner. Give it room — logic is unchanged.
-  it(
-    'includesPoi returns the same matched name as the reference',
-    () => {
-      for (const p of corpus) {
-        expect(includesPoi(p), `includesPoi mismatch for: ${JSON.stringify(p)}`).toEqual(
-          refIncludesPoi(p)
-        );
-      }
-    },
-    60000
-  );
+  it('includesPoi returns the same matched name as the reference', () => {
+    for (const p of corpus) {
+      expect(includesPoi(p), `includesPoi mismatch for: ${JSON.stringify(p)}`).toEqual(
+        refIncludesPoi(p)
+      );
+    }
+  }, 60000);
 
   // AGE PATH old-vs-new boundary guard (closes the #2722 audit gap). Asserts the
   // live includesMinorAge (zero-width boundaries) agrees with the old consuming-
@@ -657,16 +657,12 @@ describe('audit matching equivalence (gate vs brute-force)', () => {
 
   // Same CPU-bound POI brute-force shape as above — generous per-test timeout
   // so a loaded runner does not flake it. Assertions are unchanged.
-  it(
-    'highlight: poi gated highlight equals the un-gated reference',
-    () => {
-      const poiRefRegexList = poiRefRegexes.map((x) => x.regex);
-      for (const p of [...corpus, ...youngCorpus]) {
-        const gated = poiCheckable.highlight(p, highlightFn);
-        const reference = refHighlight(p, poiRefRegexList, poiPreprocess, highlightFn);
-        expect(gated, `poi highlight mismatch for: ${JSON.stringify(p)}`).toBe(reference);
-      }
-    },
-    60000
-  );
+  it('highlight: poi gated highlight equals the un-gated reference', () => {
+    const poiRefRegexList = poiRefRegexes.map((x) => x.regex);
+    for (const p of [...corpus, ...youngCorpus]) {
+      const gated = poiCheckable.highlight(p, highlightFn);
+      const reference = refHighlight(p, poiRefRegexList, poiPreprocess, highlightFn);
+      expect(gated, `poi highlight mismatch for: ${JSON.stringify(p)}`).toBe(reference);
+    }
+  }, 60000);
 });


### PR DESCRIPTION
Cuts test-body time in the slowest files of the unit suite. **The branch name is from a superseded plan — this is not a mock migration.** Nothing here touches the mock system, import slimming or pool config; those are other branches.

## Why this lane exists

Import time is attacked elsewhere. This is the cost no worker count can touch: the test bodies. Measured at `3863adcbb0`, the full suite spent **564 worker-seconds** in test bodies, and the top 20 files held 50.5% of it. A single 37.9s file is also a wall-clock floor — the suite cannot finish faster than its slowest file.

## What changed

**Two "before" columns, because they disagree and only one of them is a paired measurement.**

| # | file | baseline `duration` | measured before | after | mechanism |
|---|---|---|---|---|---|
| 1 | `challenge-ladder.test.ts` | 37875ms | 35731ms | **427ms** | deferred import of a heavy module |
| 2 | `prisma-inconsistent-orphan-relations.test.ts` | 31963ms | 19148ms | **9ms** | unmocked import graph that seven sibling suites already stub |
| 3 | `challenge-category.service.test.ts` | 18055ms | 18400ms | **39ms** | a real TCP timeout standing in for a mocked failure |
| 4 | `audit-matching-equivalence.test.ts` | 17491ms | 10152ms | *(unchanged)* | **irreducible** — brute-force differential oracle |
| 5 | `s3-upload.store.test.ts` | 16418ms | 16358ms | **36ms** | real retry backoff in the code under test |
| 6 | `listing-asset-upload-integrity.test.ts` | 14513ms | 6992ms | **773ms** | deferred import — **relocation, not a cut** |
| 7 | `dev-server-port-reservation.test.ts` | 10607ms | 10600ms | **734ms** | two tests paying a 5s claim deadline in full |
| 8 | `base.reward.failsoft.test.ts` | 3832ms | 3837ms | **1270ms** | real 5 x 500ms retry backoff |

- **baseline `duration`** — this file's row in the shipped full-suite artifact (`baseline-full-uncapped`, `head: 3863adcbb0`), measured under full-suite parallelism.
- **measured before** — a named-file run I took immediately before the change, in the same window as its "after".

**Only the second and third columns are a pair.** The two "before" columns disagree by up to 2.1x (#6: 14513 vs 6992), because a file measured under 31-way contention is not the same measurement as one measured alone. Quote the paired columns; the baseline column is here to locate the file in the suite, not to compute a saving from.

**Measured in-window: ~107 seconds off the test-body floor — ~101s a real cut, ~6s relocated.** Those two are kept apart deliberately. Against the baseline column the same work reads as ~110s, and that larger number is the one *not* to use: its two halves come from different windows on a box whose drift has since been measured at **+20.5% on `collect` between two identical full runs**.

The suite's slowest-file floor drops from 37.9s to 18.1s on the baseline's own terms, which is the one comparison where using that column is right — it is baseline-vs-baseline.

#6 moves cost from `duration` into `collect` (561ms → 6140ms) and leaves wall clock unchanged within this box's noise. It ships anyway because a graph billed to `duration` is invisible to the lane attacking import cost — the file reads as cheap to import and expensive to run when the opposite is true, so leaving it mislabelled hides a real target.

**Why #2's trick was not repeated on #6**, since the two files otherwise look alike: #2's graph was cut with a mock scaffold seven sibling suites already used, and nothing in that file exercised what the scaffold replaced. #6 is a seam test whose header is explicit that only the backend accessor is stubbed — the real persist proc, the real `sharp` decode, the real head re-read and the real comparison all run, because each half is trivially correct alone while the pair does nothing if they disagree about the metadata key. Cutting that graph would buy seconds by removing the thing the file exists to check.

🔴 **An earlier draft of this PR said "every before/after pair was taken in the same window" while the table's before column came from the baseline artifact and the after column from my own runs. That sentence was wrong**, and it is the same defect I raised against three other lanes — a control and a treatment from different windows, presented as a pair. The table above now carries both columns and says which two are comparable.

No full-suite run was taken for this branch. Every "after" is a named-file run, each paired with a "measured before" taken minutes earlier in the same session. That pairing is what the numbers rest on; the baseline column is context.

## The finding that outlives the diff

**The tail has six causes, not one.** Five are fixable, one is a floor. Anyone planning further work here should not expect a sweep.

1. a deferred import of a heavy module (#1, #6, and most of what remains)
2. an unmocked import graph the sibling suites all stub (#2)
3. a real network timeout substituted for a mocked failure (#3)
4. real retry or backoff sleeps in the code under test (#5, #7, #8 — three instances, the most common fixable cause)
5. real `spawnSync` subprocesses (`typecheck-tests-gate`)
6. whole-source-tree scans, several files each rebuilding the same one — **the only cause wanting a shared fix rather than a per-file one**

And beneath them the floor: differential oracles and scaling guards, where the time **is** the assertion (#4, `audit-redos`).

**A dynamic `await import()` inside a test body bills the whole module graph to `duration`, not `collect`.** The file then reads as cheap to import and expensive to run, when it is exactly the opposite — and it is invisible to anyone attacking import time. `challenge-ladder` was `collect 476 / duration 37875`; 35273ms of that was one test importing `daily-challenge-processing` to read a single job option.

Scanning the baseline for that shape — a dynamic import inside **any** function body rather than at module top level, excluding `vi.mock` factories, which are normal — over the top 50 slowest bodies with the six files touched here removed:

```
remaining top-50 files:            44 files, 281.3s of test-body time
  carrying a deferred import:      31 files, 202.3s   (72%)
  genuinely slow bodies:           13 files,  79.0s
```

Read as an **upper bound on a class**, not a measurement: it says a file with a deferred import holds N seconds, not that N seconds is import cost. It is a strong indicator rather than a proof — but where it was checked, it held. In `challenge-ladder` the first test held 35273ms of 37875ms; in `app-listing-backfill` 5765ms of 5776ms; in `run-page-maturity` 4364ms of 4369ms.

Three caveats travel with the number:
- vite-node caches repeated `await import()` of the same module within a file, so per-file hit counts index shape, not cost. `app-listing-backfill` imports the same service in 10 separate tests and pays once.
- Hoisting is not always safe. A test that imports late to observe module-scope initialisation, or after mutating env, changes meaning when moved. Judge each one.
- A first pass at this scan looked only for imports lexically inside `it`/`beforeAll` and reported 28/50. It **undercounted**, because the common shape routes the import through a plain helper — `async function loadResolver() { await import('~/pages/…'); }` — called from the tests. Anything measuring this class needs the by-depth criterion, not the by-construct one.

**Three of the first four fixed files also had a coverage defect underneath.** This was not a coincidence:

- **#3** could not distinguish the branch it was named for. Flipping its stub from rejecting to resolving-empty left all 16 tests green, because merging presets with an empty row set gives the same answer as the preset fallback. Fixed by pinning the behaviour that actually differs — the failure path deliberately does not cache. 16 tests → 18.
- **#5** had *no* cover for the transient part-retry path. Making 429 and 5xx non-retryable left all 17 tests green. It went untested because testing it meant sitting through 1s + 2s + 4s + 8s of real backoff — the cost *was* the gap. 17 → 19, plus `getPartRetryDelay` gaining 7 unit tests where it previously had none.
- **#1**'s slow test welded two claims together: arithmetic (`lock < interval`) and wiring (`the job asks for that lock`). Only the wiring half needed the graph.

So: **slow tests here are usually slow because something real was substituted for something that should have been controlled, and an uncontrolled dependency is an untested one.** Every fix in this PR raised coverage or held it level; none traded coverage for speed.

## How each one was fixed

**#1** — split the test. The wiring half moved to `challenge-jobs-scale.test.ts`, which already loads `daily-challenge-processing` behind a mock preamble, so it lands at ~0 marginal cost. Test count preserved: 40 + 6 where it was 40 + 5.

**#2** — the header claimed `@prisma/client` could not be stubbed under the unit env, so it installed a Proxy and let the real `model.service` graph load from a `beforeAll` with a 120s timeout. Seven sibling suites import the same module *statically* behind a mock scaffold and pay 11.9–33.0s in `collect`; this file paid 32s in `duration`. Took the sibling scaffold, dropped the Proxy, hoisted every dynamic import. A real cut, not a relocation: wall 19.6s → 7.2s.

**#3** — `~/server/db/client` was left unmocked so a real connection attempt would fail and exercise the preset fallback, at ~4s per call. Stubbed the read to reject instead: same `catch`, deterministic, and no longer dependent on what the box can reach.

**#4** — **deliberately not optimised.** `refIncludesPoi` runs a `String.match` before `regex.test` for every word, so non-matching words pay both; reordering would roughly halve two tests. An oracle's value is that it is a *copy* — an optimised copy is a second implementation you believe is equivalent, which is the one thing a differential test exists to not have to trust. The reasoning is now a comment at the head of the reference section, where the next person meets the lever before taking it.

**#5** — a `runUpload()` helper advances a fake clock until the upload settles.

Worth naming so a reader does not assume otherwise: the target was **not** the exponential part backoff. That path contributed nothing, because no test reached it. All six slow tests were the flat `withRetries(…, 3, 1000)` on the completion path — 3s each.

🔴 The first version drained `while (!settled && vi.getTimerCount() > 0)` and **hung**: at the moment the upload is handed back no timer exists yet — the first is scheduled after `fetch('/api/upload')` resolves — so the guard read 0 and exited before the run began. A count of pending timers says nothing about whether more are coming. The shipped version advances unconditionally, is bounded, and throws.

That bound is what makes a fake clock safe here rather than dangerous. Driving a loop with a fake is normally how a regression becomes an unreportable hang — the runner's own timeout is a timer too. Setting `MAX_PART_ATTEMPTS` to 100000 so the retry loop never ends now produces:

```
× stops at MAX_PART_ATTEMPTS when a part is transient forever ... 113ms
   Error: upload did not settle within 200 clock turns — a retry loop is not terminating
```

113ms and a sentence, where the same regression against the real clock would have wedged CI with nothing to read.

## Mutation tests

Every change was verified by breaking the production behaviour and reading the actual failure, not just confirming red.

| mutation | resulting failure |
|---|---|
| drop the job's `lockExpiration` override | `expected 300 to be 540` (createJob's default vs `9*60`) |
| `REVIEW_JOB_LOCK_SECONDS` 9→11 min | `expected 660 to be less than 600` |
| drop `modelVersion: { is: {} }` from the where-clause | `expected undefined to deeply equal { is: {} }` |
| drop `where: { tag: { is: {} } }` from `articleDetailSelect` | `expected { select: { tag: … } } to match object { where: { tag: { is: {} } }, … }` |
| catch returns `[]` instead of the presets | `expected [] to include 'theme'` + `TRPCError: Unknown judging category: theme` |
| cache the failed read | `expected "vi.fn()" to be called 2 times, but got 1 times` |
| `withRetries(…, 3, 1000)` → 0 attempts | `expected 1 to be 2` |
| `MAX_PART_ATTEMPTS` 5 → 1 | `expected [] to deeply equal [ 'https://b2.test/upload?part=2&v=1' ]` |
| 429/5xx no longer retryable | `expected 1 to be 2` and `expected 1 to be 5` |
| `MAX_PART_ATTEMPTS` → 100000 | `upload did not settle within 200 clock turns` |
| drop `session.port = moved` (daemon) | `expected 3101 to be 3102` |
| `findAvailablePort` ignores other sessions' reservations | `expected 3100 to be 3102`, `expected 3100 to be 3103` |
| the reward batch path swallows instead of rethrowing | `promise resolved "undefined" instead of rejecting` |
| `updateBuzzEvents` retry literal 5 → 1 | `expected "vi.fn()" to be called 6 times, but got 2 times` |

🔴 **One of these corrected a false claim I had just written.** In `base.reward.failsoft` I added `expect(h.insertImpl).toHaveBeenCalledTimes(6)` and commented it as pinning `BATCH_RETRY_COUNT`. Mutating that constant 5 → 1 left the file **green** — the path runs through `updateBuzzEvents`, which passes `5, 500` to `withRetries` as a literal and never reads the constant. The assertion was right; the sentence about it was wrong, and it would have credited a constant with coverage it does not have.

It was caught only by mutating the constant I had **named** rather than the one I had **pinned**. Both results are recorded in the test's comment. Worth generalising: a mutation that fails legibly still only proves the mechanism you actually broke.

## Verification

- `pnpm run typecheck` — 0 errors
- `scripts/__tests__/typecheck-tests-gate.test.ts` — 147/147 (`typecheck` does not see `__tests__`)
- `pnpm run test:lint-rules` — 220/220, including `no-wholesale-module-mock`, which #2 improves by dropping its `@prisma/client` Proxy
- named-file runs throughout; no full-suite run was taken for this branch

## One named-file run tells you whether a slow file is fixable

Files 7 and 8 came out of the 13 in the top 50 that had **no** deferred import — the "genuinely slow body" set. Measuring all 13 alone produced a filter worth more than the two fixes:

```
baseline (31-way contention)      solo
        11133  lazy-revision  ->   6407
        10607  port-reserv.   ->  10600   <- unmoved
         5817  placement      ->   3452
         5542  model-subst.   ->   3267
         5458  audit-redos    ->   2550
         5450  scoped-cors    ->   2375
         4887  block-scope    ->   4471
         4015  dev-tunnel     ->   2274
         3991  hostTheme      ->   1950
         3832  failsoft       ->   3837   <- unmoved
         3702  gen-surface    ->   1165
         3548  chal.metrics   ->   1747
```

Most of the tail is **contention, not work** — solo they land at 40-60% of their baseline row, which means several are in the top 50 partly because they were unlucky in that run's scheduling.

🔴 **A file whose solo time equals its contended time is waiting on a clock, not competing for CPU.** The only two that did not move are the only two that were fixable, and that is the filter working rather than a coincidence: a wall-clock wait does not get shorter when the box is quiet. It costs one named-file run, and it separates the fixable from the merely unlucky before any code is read.

### The eleven left alone, and why

- **`audit-redos`** — asserts that matching scales *linearly* across adversarial inputs. The time is the assertion. Irreducible, same as #4.
- **`scoped-endpoints-cors-wiring`, `generation-surface-wiring`, `hostThemeChangeParity`, `block-scope.anytoken-mode`** — whole-source-tree scans: each walks `src` and regexes every file, and **each rebuilds the same scan independently**. See the lead below.
- **The rest** — 1.2-3.5s solo, spread across their tests with no dominator. Grind, not a mechanism.

## Lead, not taken: the four guard files that each rebuild the same source-tree scan

`scoped-endpoints-cors-wiring`, `generation-surface-wiring`, `hostThemeChangeParity` and `block-scope.anytoken-mode` are convention guards that each walk `src` and regex every file. Solo they are 1.1-4.5s each; in the baseline they are 3.7-5.5s. `app-spend-tier-privilege` does the same walk again, and so does `orchestrator-chat.wait-unit`.

A shared, cached tree scan behind one helper is the only real lever left in this tail — worth roughly **10-15s of test-body time**, and it is the sixth mechanism, the only one that wants a shared fix rather than a per-file one.

**Deliberately not attempted here.** It is a cross-file refactor touching four guard files whose whole value is being loud about drift, for a few seconds. That trade wants a reviewer and an unhurried window, not the end of a long day. Whoever takes it should note that a cached scan introduces cross-file coupling into guards that are currently independent — which is exactly the property that makes them trustworthy.

## Where this lane stops, and why

Working down the ranked list stopped at the next deferred-import file, because it measured as the same relocation and the scan says most of what remains is too:

```
app-listing-backfill.service.test.ts   17 tests, 5776ms — 5765ms of it on the first test,
                                       which is the one that first imports the service
```

Grinding out three more relocations would move seconds between columns and produce no wall-clock change. **The remaining tail is 72% deferred-import cost wearing a disguise — a finding for the import-slimming lane, not a fix for this one.** The genuinely-slow-body set was then swept separately, which is where files 7 and 8 came from.

## Not done, and deliberately

- **The `block-registry.service` cluster** — the same module imported inside test bodies across 12 files, ~53s together. It is import-graph work and belongs to that lane, not this one.
- **`typecheck-tests-gate.test.ts` (10982ms)** — real `spawnSync` subprocesses, left alone for timing. It was checked for correctness first, because a gate that reports a clean result for a process that never ran is a worse problem than a slow one.

  **It is clean, and structurally so.** The gate spawns `process.execPath` — always present — and passes the wrapper as an *argument*, so there is no resolved-binary lookup to fail silently and an `ENOENT` can never land in the status field. Verified against the real gate with a wrapper path that does not exist: `error= undefined`, `status= 3`, `CANNOT MEASURE`. It is also defended twice — with the FAILURE-TO-RUN rule disabled the positive-control floor still refuses the same run (`0 file(s) under a __tests__ directory, below the floor of 844`).

  Nothing pinned that, so this PR adds the case. It asserts the run is **refused**, not *which* guard refuses it: both catch it, and pinning one mechanism would go red on a change that left the property intact.

All 13 of the top-50 "genuinely slow body" files were measured; two are fixed here and the rest are accounted for above. `typecheck-tests-gate` is the one left unexamined for timing, for the reason given above.
