### PR TITLE
perf(tests): cache the test RSA keypair on disk instead of regenerating it 1,065 times

### DIFF
--- a/src/__tests__/rsa-test-key.ts
+++ b/src/__tests__/rsa-test-key.ts
@@ -1,0 +1,67 @@
+import { generateKeyPairSync, randomBytes } from 'crypto';
+import { mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'fs';
+import path from 'path';
+
+export type TestKeyPair = { publicPem: string; privatePem: string };
+
+// Vitest's default `forks` pool with isolate:true starts a NEW OS PROCESS for every test file
+// (measured: 8 files, 8 distinct pids), so nothing in-process — module registry, globalThis,
+// worker-scoped memo — survives to the next file. A 2048-bit RSA keygen costs ~143ms here and
+// setup.ts is a setupFile, so the suite paid it 1065 times. The only cache that outlives a fork
+// is on disk.
+const CACHE_DIR = path.resolve(process.cwd(), 'node_modules/.cache/civitai-test-keys');
+const CACHE_FILE = path.join(CACHE_DIR, 'block-token-rsa2048-v1.json');
+
+function looksValid(parsed: unknown): parsed is TestKeyPair {
+  if (typeof parsed !== 'object' || parsed === null) return false;
+  const { publicPem, privatePem } = parsed as Partial<TestKeyPair>;
+  return (
+    typeof publicPem === 'string' &&
+    publicPem.startsWith('-----BEGIN PUBLIC KEY-----') &&
+    typeof privatePem === 'string' &&
+    privatePem.startsWith('-----BEGIN PRIVATE KEY-----')
+  );
+}
+
+function generate(): TestKeyPair {
+  const { publicKey, privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+  return {
+    publicPem: publicKey.export({ type: 'spki', format: 'pem' }) as string,
+    privatePem: privateKey.export({ type: 'pkcs8', format: 'pem' }) as string,
+  };
+}
+
+function persist(pair: TestKeyPair) {
+  // Write-then-rename so a reader in another fork never observes a half-written file. Every
+  // failure here is survivable — the caller already holds a usable pair — so a lost race just
+  // costs that fork one keygen.
+  const tmp = `${CACHE_FILE}.${process.pid}.${randomBytes(4).toString('hex')}.tmp`;
+  try {
+    mkdirSync(CACHE_DIR, { recursive: true });
+    writeFileSync(tmp, JSON.stringify(pair));
+    renameSync(tmp, CACHE_FILE);
+  } catch {
+    try {
+      unlinkSync(tmp);
+    } catch {
+      /* nothing to clean up */
+    }
+  }
+}
+
+/**
+ * A stable RSA-2048 keypair for tests that sign with the private key and verify with the matching
+ * public one. Stable, not fresh: no test depends on a per-file key, and the pair never leaves
+ * `node_modules/.cache`, so no PEM is committed to this public repo.
+ */
+export function getTestRsaKeyPair(): TestKeyPair {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(CACHE_FILE, 'utf8'));
+    if (looksValid(parsed)) return parsed;
+  } catch {
+    /* missing, truncated or corrupt — fall through and regenerate */
+  }
+  const pair = generate();
+  persist(pair);
+  return pair;
+}

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -1,5 +1,5 @@
 import { vi } from 'vitest';
-import { generateKeyPairSync } from 'crypto';
+import { getTestRsaKeyPair } from './rsa-test-key';
 
 // Mock @civitai/client to avoid ESM resolution issues
 vi.mock('@civitai/client', () => ({
@@ -57,22 +57,14 @@ vi.mock('@civitai/client', () => ({
 }));
 
 // App Blocks: provision a real RSA keypair so BlockTokenService can sign and
-// tests can verify against the matching public key. Generated once per test
-// process. The public PEM is re-exported so the block-token round-trip test
-// verifies against the exact key the service signed with. (The block-tokens
-// API "503 when keys not configured" test overrides ~/env/server per-test, so
-// these defaults don't interfere with that negative case.)
-const { publicKey: _btPublicKey, privateKey: _btPrivateKey } = generateKeyPairSync('rsa', {
-  modulusLength: 2048,
-});
-export const TEST_BLOCK_TOKEN_PUBLIC_PEM = _btPublicKey.export({
-  type: 'spki',
-  format: 'pem',
-}) as string;
-const TEST_BLOCK_TOKEN_PRIVATE_PEM = _btPrivateKey.export({
-  type: 'pkcs8',
-  format: 'pem',
-}) as string;
+// tests can verify against the matching public key. The public PEM is
+// re-exported so the block-token round-trip test verifies against the exact key
+// the service signed with. (The block-tokens API "503 when keys not configured"
+// test overrides ~/env/server per-test, so these defaults don't interfere with
+// that negative case.) See rsa-test-key.ts for why it is cached on disk.
+const { publicPem: TEST_BLOCK_TOKEN_PUBLIC_PEM_, privatePem: TEST_BLOCK_TOKEN_PRIVATE_PEM } =
+  getTestRsaKeyPair();
+export const TEST_BLOCK_TOKEN_PUBLIC_PEM = TEST_BLOCK_TOKEN_PUBLIC_PEM_;
 
 // Mock environment variables. Use a Proxy so any env.X access returns a
 // reasonable default — saves us from enumerating every URL/endpoint var that


### PR DESCRIPTION
## What

`src/__tests__/setup.ts` generated a 2048-bit RSA keypair at module scope. It is a `setupFile`, so that ran **once per test file** — 1,065 times per unit run, at ~143ms each (median of 10 on a 32-core Windows box; range 74-257ms, since keygen is a prime search).

This caches the pair on disk instead.

## Why no in-process cache would have worked

The unit project runs on Vitest's default `forks` pool with `isolate: true`, and that means **a brand new OS process per test file** — not a recycled worker. Measured with 8 trivial test files at `--max-workers=2`, logging `process.pid` and a `globalThis` accumulator:

```
PROBE p1 pid=43180 tid=1 seen=p1
PROBE p2 pid=44752 tid=2 seen=p2
PROBE p3 pid=55164 tid=1 seen=p3
...
```

8 files, 8 distinct pids, and the accumulator never read back more than its own entry. So `globalThis`, a module-level memo, or any worker-scoped singleton would all have been worth exactly zero. The only cache that outlives a fork is on disk.

## How

`src/__tests__/rsa-test-key.ts` caches the pair under `node_modules/.cache/civitai-test-keys/`, writing to a tmp file and renaming so a concurrent fork never reads a half-written file, and regenerating on any read, parse or shape failure. Every failure path is survivable — a lost race just costs that fork one keygen.

**No PEM is committed.** This repo is public and permanently world-readable, and a secret scanner will fire on a PEM even when it is test-only. The cache lives inside `node_modules`.

**Nothing needs the key to be fresh**, which I checked before changing it. Only two files consume the real pair — `block-token.service.test.ts` (imports `TEST_BLOCK_TOKEN_PUBLIC_PEM`) and `block-scope.middleware.test.ts` (`importPKCS8` of the env private key) — and both need the public key to *match* the private one, not to be new. Every other `BLOCK_TOKEN_*` test uses literal `'fake-private'` / `'fake-public'` strings and is untouched. Both consumers pass, 53 tests, including the RS256 round-trip.

## Numbers

90-file yardstick at 4 workers, the two runs taken back to back in the same window:

| | wall | collect | **setup** | tests | failed |
|---|---|---|---|---|---|
| HEAD | 106.4s | 311s | **18s** | 49s | 0 |
| this change | 101.4s | 323s | **3s** | 40s | 0 |

**Setup 18s -> 3s across 90 files = ~167ms per file.** Wall moved 106.4 -> 101.4s, which is the arithmetic you would predict (15 worker-seconds / 4 workers = 3.75s), so the delta is real rather than noise in `tests`.

Projected across the full 1,065-file suite: 167ms x 1065 = **~178 worker-seconds**, or **~6.6s off its 206.6s wall** at ~27 effective parallelism (~3.2%). Total setup should fall from 354s to ~176s.

That is the conservative read and it is the one to bank. The full suite's setup is 333ms/file at 31 workers where this 4-worker baseline was 200ms/file, so the keygen very likely costs more under real contention — but I have not measured that and am not claiming it.

## And here is why I stopped

The obvious next move is to keep going through `setup.ts` — the prom-client stub, the env Proxy, the five `vi.mock` registrations. I measured them before touching them, and they are not worth it. Fixed 30-file slice at 4 workers, three variants of the setup file, reading only the `setup` phase:

```
  setup.ts empty (no imports)          177ms / 30 =  5.9 ms/file
  setup.ts = `import { vi } ...` only  846ms / 30 = 28.2 ms/file
  setup.ts real (this branch)         1200ms / 30 = 40.0 ms/file
```

Which decomposes the whole remaining setup phase as:

- **5.9ms** — Vitest's own per-file `setupFile` overhead. Not ours.
- **22.3ms** — importing `vitest` into the setup file. The largest remaining item, and unavoidable: `vi` is needed for every `vi.mock`.
- **~12ms** — everything we wrote, all five mock registrations included.

Our own content is therefore ~12ms x 1065 = ~13 worker-seconds, about **0.5s of the 206.6s wall**. Even the unavoidable `vitest` import is only ~0.9s. Roughly **1.3s of headroom in total (0.6%)** — against a real risk, because every mock in that file exists because something broke without it and the comments say what.

One reason the prom stub looks more expensive than it is: `vi.mock` **factories are lazy**. They run when the mocked module is first imported, so their cost lands in `import`, not `setup`. Only the registration is paid here.

The ~12ms figure is an upper bound rather than a point estimate — the two cheap variants ran on a less loaded box, and contention inflates the real-setup number. The conclusion only gets stronger if that bias is larger than I think.

## Verification

- `pnpm run typecheck` — clean. (Note it cannot see this file: `tsconfig.json` excludes `src/**/__tests__/**`. `tsc --noEmit -p tsconfig.tests.json`, which exists for exactly this, is also clean for both files against the known pre-existing backlog in that scope.)
- `pnpm exec prettier` — clean.
- 90-file yardstick, 0 failed, before and after.
- Full unit suite not run on this branch; runs are serialised across the box today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
