### PR TITLE
perf(tests): import getEdgeUrl from the React-free edge-url module

### DIFF
--- a/src/pages/api/admin/temp/backfill-video-blurhash.ts
+++ b/src/pages/api/admin/temp/backfill-video-blurhash.ts
@@ -1,7 +1,7 @@
 import { encode } from 'blurhash';
 import sharp from 'sharp';
 import * as z from 'zod';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { dataProcessor } from '~/server/db/db-helpers';
 import { pgDbRead, pgDbWrite } from '~/server/db/pgDb';
 import { limitConcurrency } from '~/server/utils/concurrency-helpers';

--- a/src/pages/api/mod/daily-challenge/re-review.ts
+++ b/src/pages/api/mod/daily-challenge/re-review.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import * as z from 'zod';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { Prisma } from '@prisma/client';
 import { dbRead, dbWrite } from '~/server/db/client';
 import {

--- a/src/pages/api/mod/scan-images.ts
+++ b/src/pages/api/mod/scan-images.ts
@@ -5,7 +5,7 @@ import { ModEndpoint } from '~/server/utils/endpoint-helpers';
 import type { Prisma } from '@prisma/client';
 import { env } from '~/env/server';
 import { chunk } from 'lodash-es';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 
 const stringToNumberArraySchema = z
   .string()

--- a/src/pages/api/testing/daily-challenge.ts
+++ b/src/pages/api/testing/daily-challenge.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import * as z from 'zod';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { dbRead } from '~/server/db/client';
 import {
   getChallengeById,

--- a/src/pages/api/v1/collections/[id].ts
+++ b/src/pages/api/v1/collections/[id].ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import type { Session } from '~/types/session';
 import * as z from 'zod';
 
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import {
   getCollectionById,
   getUserCollectionPermissionsById,

--- a/src/pages/api/v1/collections/index.ts
+++ b/src/pages/api/v1/collections/index.ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import type { Session } from '~/types/session';
 import * as z from 'zod';
 
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { CollectionSort } from '~/server/common/enums';
 import {
   getAllCollections,

--- a/src/pages/api/v1/creators.ts
+++ b/src/pages/api/v1/creators.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { publicApiContext2 } from '~/server/createContext';
 import { handleEndpointError, PublicEndpoint } from '~/server/utils/endpoint-helpers';
 import { getPaginationLinks } from '~/server/utils/pagination-helpers';

--- a/src/pages/api/v1/model-versions/[id].ts
+++ b/src/pages/api/v1/model-versions/[id].ts
@@ -4,7 +4,7 @@ import { ModelFileVisibility, ModelModifier, ModelStatus } from '~/shared/utils/
 import type { NextApiRequest, NextApiResponse } from 'next';
 import * as z from 'zod';
 
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { isProd } from '~/env/other';
 import { getDownloadFilename } from '~/server/services/file.service';
 import {

--- a/src/pages/api/v1/models/[id].ts
+++ b/src/pages/api/v1/models/[id].ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import type { ModelHashType } from '~/shared/utils/prisma/enums';
 import { ModelFileVisibility, ModelModifier } from '~/shared/utils/prisma/enums';
 
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { ModelSort } from '~/server/common/enums';
 import {
   createModelFileDownloadUrl,

--- a/src/server/games/daily-challenge/challenge-pairwise.ts
+++ b/src/server/games/daily-challenge/challenge-pairwise.ts
@@ -1,4 +1,4 @@
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import type { JudgingCategory } from '~/server/games/daily-challenge/daily-challenge-scoring';
 import type { Seat } from '~/server/games/daily-challenge/challenge-ladder';
 import {

--- a/src/server/jobs/__tests__/process-vault-items.test.ts
+++ b/src/server/jobs/__tests__/process-vault-items.test.ts
@@ -46,7 +46,7 @@ vi.mock('~/utils/s3-utils', () => ({
   getCustomPutUrl: mockGetCustomPutUrl,
   getS3Client: mockGetS3Client,
 }));
-vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (url: string) => url }));
+vi.mock('~/client-utils/edge-url', () => ({ getEdgeUrl: (url: string) => url }));
 vi.mock('~/server/utils/errorHandling', () => ({
   withRetries: (fn: () => Promise<unknown>) => fn(),
 }));

--- a/src/server/jobs/collection-ai-review.ts
+++ b/src/server/jobs/collection-ai-review.ts
@@ -22,7 +22,7 @@ import {
 import type { AiReviewDecision } from '~/server/services/ai/collection-review.service';
 import { isDefined } from '~/utils/type-guards';
 import { withDistributedLock } from '~/server/utils/distributed-lock';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { createJob } from './job';
 
 // Chunks are barriers waiting on the slowest call (~3s median, 13-20s tail), so they must be wide

--- a/src/server/jobs/collection-contest-vimeo-upload.ts
+++ b/src/server/jobs/collection-contest-vimeo-upload.ts
@@ -1,6 +1,6 @@
 import { CollectionMode, CollectionType } from '@prisma/client';
 import sanitize from 'sanitize-html';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { env } from '~/env/server';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { createJob, getJobDate } from '~/server/jobs/job';

--- a/src/server/jobs/collection-contest-youtube-upload.ts
+++ b/src/server/jobs/collection-contest-youtube-upload.ts
@@ -1,5 +1,5 @@
 import { CollectionMode, CollectionType } from '@prisma/client';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { env } from '~/env/server';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { createJob, getJobDate } from '~/server/jobs/job';

--- a/src/server/jobs/daily-challenge-processing.ts
+++ b/src/server/jobs/daily-challenge-processing.ts
@@ -1,6 +1,6 @@
 import { CollectionReadConfiguration, Prisma } from '@prisma/client';
 import dayjs from '~/shared/utils/dayjs';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { NotificationCategory } from '~/server/common/enums';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { eventEngine } from '~/server/events';

--- a/src/server/jobs/process-vault-items.ts
+++ b/src/server/jobs/process-vault-items.ts
@@ -1,7 +1,7 @@
 import { Prisma } from '@prisma/client';
 import { VaultItemStatus } from '~/shared/utils/prisma/enums';
 import JSZip from 'jszip';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { env } from '~/env/server';
 import { constants } from '~/server/common/constants';
 import { dbWrite } from '~/server/db/client';

--- a/src/server/routers/comics.router.ts
+++ b/src/server/routers/comics.router.ts
@@ -66,7 +66,7 @@ import {
 import { imageMetaSchema } from '~/server/schema/image.schema';
 import { createNotification } from '~/server/services/notification.service';
 import { planChapterPanels } from '~/server/services/comics/story-plan';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { userWithCosmeticsSelect } from '~/server/selectors/user.selector';
 import { commentV2Select } from '~/server/selectors/commentv2.selector';
 import {

--- a/src/server/routers/orchestrator.router.ts
+++ b/src/server/routers/orchestrator.router.ts
@@ -68,7 +68,7 @@ import {
   submitPresetImageGen,
   whatIfPresetImageGen,
 } from '~/server/services/orchestrator/preset-image-gen.service';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { enhanceComicPrompt } from '~/server/services/comics/prompt-enhance';
 import type { SessionUser } from '~/types/session';
 import { reviewConsumerStrikes } from '../http/orchestrator/flagged-consumers';

--- a/src/server/services/__tests__/image-search.client-ip.test.ts
+++ b/src/server/services/__tests__/image-search.client-ip.test.ts
@@ -39,7 +39,7 @@ vi.mock('~/server/flipt/client', () => ({
 vi.mock('~/server/redis/caches', () => ({
   imageMetaCache: { fetch: vi.fn(async () => ({})) },
 }));
-vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: vi.fn(() => 'https://edge/x') }));
+vi.mock('~/client-utils/edge-url', () => ({ getEdgeUrl: vi.fn(() => 'https://edge/x') }));
 
 const feedSearch = vi.fn(async () => ({ items: [], nextCursor: undefined }));
 vi.mock('~/server/services/image.service', () => ({

--- a/src/server/services/__tests__/model-search-file-shape.test.ts
+++ b/src/server/services/__tests__/model-search-file-shape.test.ts
@@ -32,7 +32,7 @@ vi.mock('~/server/meilisearch/client', () => ({
 vi.mock('~/server/services/file.service', () => ({
   getDownloadFilename: ({ file }: any) => `${file.id}.safetensors`,
 }));
-vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (url: string) => url }));
+vi.mock('~/client-utils/edge-url', () => ({ getEdgeUrl: (url: string) => url }));
 
 import { runModelSearch } from '~/server/services/model-search.service';
 

--- a/src/server/services/__tests__/model-search.image-filter.test.ts
+++ b/src/server/services/__tests__/model-search.image-filter.test.ts
@@ -43,7 +43,7 @@ vi.mock('~/server/meilisearch/client', () => ({
 vi.mock('~/server/services/file.service', () => ({
   getDownloadFilename: vi.fn(() => 'model.safetensors'),
 }));
-vi.mock('~/client-utils/cf-images-utils', () => ({
+vi.mock('~/client-utils/edge-url', () => ({
   getEdgeUrl: (url: string) => url,
 }));
 vi.mock('~/server/common/model-helpers', () => ({

--- a/src/server/services/__tests__/model-search.minor-gate.test.ts
+++ b/src/server/services/__tests__/model-search.minor-gate.test.ts
@@ -23,7 +23,7 @@ vi.mock('~/server/meilisearch/client', () => ({
 vi.mock('~/server/services/file.service', () => ({
   getDownloadFilename: vi.fn(() => 'model.safetensors'),
 }));
-vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (url: string) => url }));
+vi.mock('~/client-utils/edge-url', () => ({ getEdgeUrl: (url: string) => url }));
 vi.mock('~/server/common/model-helpers', () => ({
   createModelFileDownloadUrl: vi.fn(() => '/download'),
 }));

--- a/src/server/services/__tests__/model-search.transient-503.test.ts
+++ b/src/server/services/__tests__/model-search.transient-503.test.ts
@@ -31,7 +31,7 @@ vi.mock('~/server/meilisearch/client', async (importOriginal) => {
 // never drives — mocked so the import stays light (mirrors model-search.image-filter).
 vi.mock('~/server/services/model.service', () => ({ getModelsWithVersions: vi.fn() }));
 vi.mock('~/server/services/file.service', () => ({ getDownloadFilename: vi.fn() }));
-vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (u: string) => u }));
+vi.mock('~/client-utils/edge-url', () => ({ getEdgeUrl: (u: string) => u }));
 vi.mock('~/server/common/model-helpers', () => ({ createModelFileDownloadUrl: vi.fn() }));
 
 const makeCommunicationError = (statusCode: number) => {

--- a/src/server/services/__tests__/model-search.type-filter.test.ts
+++ b/src/server/services/__tests__/model-search.type-filter.test.ts
@@ -22,7 +22,7 @@ vi.mock('~/server/meilisearch/client', () => ({
 }));
 vi.mock('~/server/services/model.service', () => ({ getModelsWithVersions: vi.fn() }));
 vi.mock('~/server/services/file.service', () => ({ getDownloadFilename: vi.fn() }));
-vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (url: string) => url }));
+vi.mock('~/client-utils/edge-url', () => ({ getEdgeUrl: (url: string) => url }));
 vi.mock('~/server/common/model-helpers', () => ({ createModelFileDownloadUrl: vi.fn() }));
 
 import { resolveModelSearchIds } from '~/server/services/model-search.service';

--- a/src/server/services/blocks/__tests__/app-access.denormalized-owner-drift.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.denormalized-owner-drift.test.ts
@@ -95,7 +95,7 @@ const { mockRead, mockWrite, seq } = vi.hoisted(() => {
 });
 
 vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockWrite }));
-vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (url: string) => `edge:${url}` }));
+vi.mock('~/client-utils/edge-url', () => ({ getEdgeUrl: (url: string) => `edge:${url}` }));
 vi.mock('~/server/utils/app-block-ids', () => ({
   newAppListingId: () => `apl_new_${++seq.n}`,
   newAppListingPublishRequestId: () => `alpr_new_${++seq.n}`,

--- a/src/server/services/blocks/__tests__/app-collaborator.public-byline-offsite.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator.public-byline-offsite.test.ts
@@ -40,7 +40,7 @@ const { mockDb } = vi.hoisted(() => ({
 }));
 
 vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
-vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (src: string) => src }));
+vi.mock('~/client-utils/edge-url', () => ({ getEdgeUrl: (src: string) => src }));
 vi.mock('~/env/server', () => ({ env: { APPS_DOMAIN: 'civit.ai' } }));
 vi.mock('~/server/common/constants', () => ({ CacheTTL: { hour: 3600 } }));
 vi.mock('~/server/utils/cache-helpers', () => ({

--- a/src/server/services/blocks/__tests__/app-listing.deploy-gate.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.deploy-gate.test.ts
@@ -37,7 +37,7 @@ const { mockDbRead } = vi.hoisted(() => ({
 }));
 
 vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbRead }));
-vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (src: string) => src }));
+vi.mock('~/client-utils/edge-url', () => ({ getEdgeUrl: (src: string) => src }));
 vi.mock('~/env/server', () => ({ env: { APPS_DOMAIN: 'civit.ai' } }));
 vi.mock('~/server/common/constants', () => ({ CacheTTL: { hour: 3600 } }));
 vi.mock('~/server/utils/cache-helpers', () => ({

--- a/src/server/services/blocks/__tests__/app-listing.moderation.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.moderation.service.test.ts
@@ -20,7 +20,7 @@ const { mockDbRead } = vi.hoisted(() => ({
 }));
 
 vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbRead }));
-vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (src: string) => src }));
+vi.mock('~/client-utils/edge-url', () => ({ getEdgeUrl: (src: string) => src }));
 vi.mock('~/env/server', () => ({ env: { APPS_DOMAIN: 'civit.ai' } }));
 vi.mock('~/server/common/constants', () => ({ CacheTTL: { hour: 3600 } }));
 vi.mock('~/server/utils/cache-helpers', () => ({

--- a/src/server/services/blocks/__tests__/app-listing.public-scope.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.public-scope.test.ts
@@ -35,7 +35,7 @@ const { mockDbRead } = vi.hoisted(() => ({
 }));
 
 vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbRead }));
-vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (src: string) => src }));
+vi.mock('~/client-utils/edge-url', () => ({ getEdgeUrl: (src: string) => src }));
 vi.mock('~/env/server', () => ({ env: { APPS_DOMAIN: 'civit.ai' } }));
 vi.mock('~/server/common/constants', () => ({ CacheTTL: { hour: 3600 } }));
 vi.mock('~/server/utils/cache-helpers', () => ({

--- a/src/server/services/blocks/__tests__/app-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.service.test.ts
@@ -33,7 +33,7 @@ const { mockDbRead } = vi.hoisted(() => ({
 
 vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbRead }));
 // getEdgeUrl → identity so URL fields assert against the stored key.
-vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (src: string) => src }));
+vi.mock('~/client-utils/edge-url', () => ({ getEdgeUrl: (src: string) => src }));
 vi.mock('~/env/server', () => ({ env: { APPS_DOMAIN: 'civit.ai' } }));
 vi.mock('~/server/common/constants', () => ({ CacheTTL: { hour: 3600 } }));
 // queryCache → passthrough to the mocked $queryRaw (no Redis in unit tests).

--- a/src/server/services/blocks/__tests__/block-gated-images.service.test.ts
+++ b/src/server/services/blocks/__tests__/block-gated-images.service.test.ts
@@ -10,7 +10,7 @@ vi.mock('~/server/db/client', () => ({
 // Deterministic edge-url so the assertion is stable and we never import the real
 // CF util (which pulls env). The gated url embeds the raw key so we can assert it
 // is ONLY ever produced for a visible image.
-vi.mock('~/client-utils/cf-images-utils', () => ({
+vi.mock('~/client-utils/edge-url', () => ({
   getEdgeUrl: (url: string, opts?: { width?: number }) => `edge:${url}@${opts?.width}`,
 }));
 // Viewer hidden-preferences — default: nothing blocked. Overridden per test.

--- a/src/server/services/blocks/__tests__/block-image-upload.persist.test.ts
+++ b/src/server/services/blocks/__tests__/block-image-upload.persist.test.ts
@@ -25,7 +25,7 @@ const { mockCreateImage } = vi.hoisted(() => ({
 const { mockS3Send } = vi.hoisted(() => ({ mockS3Send: vi.fn() }));
 
 vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
-vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (u: string) => `edge:${u}` }));
+vi.mock('~/client-utils/edge-url', () => ({ getEdgeUrl: (u: string) => `edge:${u}` }));
 vi.mock('~/server/services/image.service', () => ({ createImage: mockCreateImage }));
 vi.mock('~/utils/s3-utils', async (importOriginal) => ({
   ...(await importOriginal<typeof S3Utils>()),

--- a/src/server/services/blocks/__tests__/block-image-upload.service.test.ts
+++ b/src/server/services/blocks/__tests__/block-image-upload.service.test.ts
@@ -23,7 +23,7 @@ const { mockUpload, mockCreateImage } = vi.hoisted(() => ({
 // The service statically imports dbRead + getEdgeUrl; stub both so the module
 // graph never touches a real Prisma client / cf-images env.
 vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
-vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (u: string) => `edge:${u}` }));
+vi.mock('~/client-utils/edge-url', () => ({ getEdgeUrl: (u: string) => `edge:${u}` }));
 vi.mock('~/utils/s3-utils', () => ({ uploadImageBufferToStore: mockUpload }));
 // `createImage` is dynamically imported inside the service.
 vi.mock('~/server/services/image.service', () => ({ createImage: mockCreateImage }));

--- a/src/server/services/blocks/__tests__/offsite-listing.edit-consolidate.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.edit-consolidate.service.test.ts
@@ -52,7 +52,7 @@ const { mockRead, mockWrite, seq } = vi.hoisted(() => {
 });
 
 vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockWrite }));
-vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (url: string) => `edge:${url}` }));
+vi.mock('~/client-utils/edge-url', () => ({ getEdgeUrl: (url: string) => `edge:${url}` }));
 vi.mock('~/server/utils/app-block-ids', () => ({
   newAppListingId: () => `apl_new_${++seq.n}`,
   newAppListingPublishRequestId: () => `alpr_new_${++seq.n}`,

--- a/src/server/services/blocks/__tests__/offsite-listing.get-my-listing-for-app.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.get-my-listing-for-app.service.test.ts
@@ -63,7 +63,7 @@ const { mockRead, mockWrite, seq } = vi.hoisted(() => {
 });
 
 vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockWrite }));
-vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (url: string) => `edge:${url}` }));
+vi.mock('~/client-utils/edge-url', () => ({ getEdgeUrl: (url: string) => `edge:${url}` }));
 vi.mock('~/server/utils/app-block-ids', () => ({
   newAppListingId: () => `apl_new_${++seq.n}`,
   newAppListingPublishRequestId: () => `alpr_new_${++seq.n}`,

--- a/src/server/services/blocks/__tests__/showcase.service.test.ts
+++ b/src/server/services/blocks/__tests__/showcase.service.test.ts
@@ -23,7 +23,7 @@ vi.mock('~/server/services/image.service', () => ({
   getImageMetricsObject: mockGetImageMetricsObject,
 }));
 // Mock getEdgeUrl as identity so tests assert against the input urls.
-vi.mock('~/client-utils/cf-images-utils', () => ({
+vi.mock('~/client-utils/edge-url', () => ({
   getEdgeUrl: (src: string) => src,
 }));
 

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -1,6 +1,6 @@
 import { Prisma } from '@prisma/client';
 
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { env } from '~/env/server';
 import { CacheTTL } from '~/server/common/constants';
 import { dbRead } from '~/server/db/client';

--- a/src/server/services/blocks/block-collections.service.ts
+++ b/src/server/services/blocks/block-collections.service.ts
@@ -21,7 +21,7 @@
  */
 
 import { Prisma } from '@prisma/client';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { dbRead } from '~/server/db/client';
 import { sessionClient } from '~/server/auth/session-client';
 import type { SessionUser } from '~/types/session';

--- a/src/server/services/blocks/block-gated-images.service.ts
+++ b/src/server/services/blocks/block-gated-images.service.ts
@@ -1,6 +1,6 @@
 import { Prisma } from '@prisma/client';
 import { dbRead } from '~/server/db/client';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import {
   contentRatingFromNsfwLevel,
   onlySelectableLevels,

--- a/src/server/services/blocks/block-image-upload.service.ts
+++ b/src/server/services/blocks/block-image-upload.service.ts
@@ -1,7 +1,7 @@
 import { TRPCError } from '@trpc/server';
 
 import { dbRead } from '~/server/db/client';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import {
   classifyBlockImageUploadScan,
   isAllowedOutputHost,

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -1393,7 +1393,7 @@ async function loadListingEditView(
   connectRequestedScopes: number | null;
   connectScopeJustifications: Record<string, string> | null;
 }> {
-  const { getEdgeUrl } = await import('~/client-utils/cf-images-utils');
+  const { getEdgeUrl } = await import('~/client-utils/edge-url');
   const row = (await db.appListing.findUnique({
     where: { id: listingId },
     select: {

--- a/src/server/services/blocks/showcase.service.ts
+++ b/src/server/services/blocks/showcase.service.ts
@@ -1,6 +1,6 @@
 import { dbRead } from '~/server/db/client';
 import { getImageMetricsObject } from '~/server/services/image.service';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { Flags } from '~/shared/utils/flags';
 import {
   domainBrowsingCeiling,

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -179,7 +179,7 @@ import {
 import { createNotification } from '~/server/services/notification.service';
 import { sendChallengeResultsNotification } from '~/server/services/challenge-engagement.service';
 import { withRetries } from '~/utils/errorHandling';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import type { AIModel } from '~/server/services/ai/openrouter';
 import { createLogger } from '~/utils/logging';
 import { isDefined } from '~/utils/type-guards';

--- a/src/server/services/creator-shop.service.ts
+++ b/src/server/services/creator-shop.service.ts
@@ -1,7 +1,7 @@
 import { Prisma } from '@prisma/client';
 import { createHash } from 'node:crypto';
 import sharp from 'sharp';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { refreshOwnedStickerCache } from '~/server/redis/caches';
 import { queueCosmeticPerceptualHash } from '~/server/services/cosmetic-phash.service';

--- a/src/server/services/csam.service-new.ts
+++ b/src/server/services/csam.service-new.ts
@@ -8,7 +8,7 @@ import type {
 } from '~/server/schema/csam.schema';
 import { csamCapabilitiesDictionary, csamContentsDictionary } from '~/server/schema/csam.schema';
 import { clickhouse } from '~/server/clickhouse/client';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { isDefined } from '~/utils/type-guards';
 import { blobToFile, fetchBlob, fetchBlobAsFile } from '~/utils/file-utils';
 import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';

--- a/src/server/services/csam.service.ts
+++ b/src/server/services/csam.service.ts
@@ -8,7 +8,7 @@ import type {
 } from '~/server/schema/csam.schema';
 import { csamCapabilitiesDictionary, csamContentsDictionary } from '~/server/schema/csam.schema';
 import { clickhouse } from '~/server/clickhouse/client';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { isDefined } from '~/utils/type-guards';
 import { fetchBlob } from '~/utils/file-utils';
 import { S3Client } from '@aws-sdk/client-s3';

--- a/src/server/services/image-search.service.ts
+++ b/src/server/services/image-search.service.ts
@@ -2,7 +2,7 @@ import type { NextApiRequest } from 'next';
 import type { SessionUser } from '~/types/session';
 import { resolveClientIpOrNull } from '~/server/utils/client-ip';
 
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { buildFliptContext, getFeatureFlags } from '~/server/services/feature-flags.service';
 import { buildSearchActor } from '~/server/meilisearch/client';
 import {

--- a/src/server/services/model-search.service.ts
+++ b/src/server/services/model-search.service.ts
@@ -1,7 +1,7 @@
 import type { SearchResponse } from 'meilisearch';
 import type { SessionUser } from '~/types/session';
 
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { MODELS_SEARCH_INDEX } from '~/server/common/constants';
 import { createModelFileDownloadUrl } from '~/server/common/model-helpers';
 import {

--- a/src/server/services/orchestrator/__tests__/createModelFileScanRequest.test.ts
+++ b/src/server/services/orchestrator/__tests__/createModelFileScanRequest.test.ts
@@ -57,9 +57,9 @@ vi.mock('~/env/server', () => ({
   },
 }));
 
-// orchestrator.service.ts pulls in cf-images-utils which validates
+// orchestrator.service.ts pulls in edge-url which validates
 // NEXT_PUBLIC_* env vars at import-time. Stub it to keep tests hermetic.
-vi.mock('~/client-utils/cf-images-utils', () => ({
+vi.mock('~/client-utils/edge-url', () => ({
   getEdgeUrl: (url: string) => url,
 }));
 

--- a/src/server/services/orchestrator/orchestrator.service.ts
+++ b/src/server/services/orchestrator/orchestrator.service.ts
@@ -10,7 +10,7 @@ import type {
 import { submitWorkflow } from '@civitai/client';
 import { randomUUID } from 'crypto';
 import { Prisma } from '@prisma/client';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { env } from '~/env/server';
 import { isProd } from '~/env/other';

--- a/src/server/services/post.service.ts
+++ b/src/server/services/post.service.ts
@@ -84,7 +84,7 @@ import {
 } from '~/shared/utils/prisma/enums';
 import { isValidAIGeneration } from '~/utils/image-utils';
 import type { PreprocessFileReturnType } from '~/utils/media-preprocessors';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import {
   resolveVerifiedSourceImageIds,
   sanitizeProvenance,

--- a/src/server/services/product-badge.service.ts
+++ b/src/server/services/product-badge.service.ts
@@ -12,7 +12,7 @@ import type {
 import { internalOrchestratorClient } from '~/server/services/orchestrator/client';
 import { queueCosmeticPerceptualHash } from '~/server/services/cosmetic-phash.service';
 import { registerMediaLocation } from '~/server/services/storage-resolver';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { getImageUploadBackend } from '~/utils/s3-utils';
 import { CosmeticSource, CosmeticType } from '~/shared/utils/prisma/enums';
 

--- a/src/server/utils/og-image-helpers.ts
+++ b/src/server/utils/og-image-helpers.ts
@@ -1,4 +1,4 @@
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { MediaType } from '~/shared/utils/prisma/enums';
 
 /**

--- a/src/server/vimeo/client.ts
+++ b/src/server/vimeo/client.ts
@@ -1,5 +1,5 @@
 import sanitize from 'sanitize-html';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 
 type S3ToVimeoUpload = {
   url: string;

--- a/src/server/webhooks/article.webhooks.ts
+++ b/src/server/webhooks/article.webhooks.ts
@@ -1,4 +1,4 @@
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { articleDetailSelect } from '~/server/selectors/article.selector';
 import { getCategoryTags } from '~/server/services/system-cache';
 import { getBaseUrl } from '~/server/utils/url-helpers';

--- a/src/server/webhooks/bounty.webhooks.ts
+++ b/src/server/webhooks/bounty.webhooks.ts
@@ -1,4 +1,4 @@
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { getBountyDetailsSelect } from '~/server/selectors/bounty.selector';
 import { getBaseUrl } from '~/server/utils/url-helpers';
 import { createWebhookProcessor } from '~/server/webhooks/base.webhooks';

--- a/src/server/webhooks/daily-challenge.webhooks.ts
+++ b/src/server/webhooks/daily-challenge.webhooks.ts
@@ -1,4 +1,4 @@
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { getChallengeConfig } from '~/server/games/daily-challenge/daily-challenge.utils';
 import { getBaseUrl } from '~/server/utils/url-helpers';
 import { createWebhookProcessor } from '~/server/webhooks/base.webhooks';

--- a/src/server/webhooks/model.webooks.ts
+++ b/src/server/webhooks/model.webooks.ts
@@ -1,4 +1,4 @@
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { createModelFileDownloadUrl } from '~/server/common/model-helpers';
 import { modelTagCache } from '~/server/redis/caches';
 import { getAllModelsWithVersionsSelect } from '~/server/selectors/model.selector';

--- a/src/server/webhooks/research.webhooks.ts
+++ b/src/server/webhooks/research.webhooks.ts
@@ -1,5 +1,5 @@
 import { Prisma } from '@prisma/client';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { addToQueue, checkoutQueue } from '~/server/redis/queues';
 import { ratingsCounter } from '~/server/routers/research.router';
 import { calculateLevelProgression } from '~/server/utils/research-utils';

--- a/src/server/youtube/client.ts
+++ b/src/server/youtube/client.ts
@@ -1,7 +1,7 @@
 import type { OAuth2Client } from 'google-auth-library';
 import { Readable } from 'node:stream';
 import sanitize from 'sanitize-html';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import { env } from '~/env/server';
 import { fetchBlob } from '~/utils/file-utils';
 import type { youtube_v3 } from 'googleapis/build/src/apis/youtube';

--- a/src/tests/api/v1/blocks/block-collections-cover.test.ts
+++ b/src/tests/api/v1/blocks/block-collections-cover.test.ts
@@ -11,7 +11,7 @@ import { beforeEach, describe, it, expect, vi } from 'vitest';
  */
 
 // Echo the args so we can assert exactly what getEdgeUrl was asked to produce.
-vi.mock('~/client-utils/cf-images-utils', () => ({
+vi.mock('~/client-utils/edge-url', () => ({
   getEdgeUrl: (src: string, opts: Record<string, unknown>) => JSON.stringify({ src, ...opts }),
 }));
 const mockQueryRaw = vi.hoisted(() => vi.fn());

--- a/src/tests/api/v1/collections/index.test.ts
+++ b/src/tests/api/v1/collections/index.test.ts
@@ -34,7 +34,7 @@ vi.mock('~/server/utils/public-api-rate-limit', () => ({
   checkPublicApiRateLimit: mockRateLimit,
 }));
 
-vi.mock('~/client-utils/cf-images-utils', () => ({
+vi.mock('~/client-utils/edge-url', () => ({
   getEdgeUrl: (url: string) => `edge:${url}`,
 }));
 

--- a/src/tests/api/v1/creators-map.test.ts
+++ b/src/tests/api/v1/creators-map.test.ts
@@ -15,9 +15,8 @@ vi.mock('~/server/utils/endpoint-helpers', () => ({
 vi.mock('~/server/createContext', () => ({ publicApiContext2: vi.fn() }));
 vi.mock('~/server/utils/pagination-helpers', () => ({ getPaginationLinks: vi.fn() }));
 vi.mock('~/server/utils/errorHandling', () => ({ isClientAbortError: () => false }));
-// getEdgeUrl reaches into client-only modules (react hooks, providers) at import;
-// stub it to a deterministic, inspectable string.
-vi.mock('~/client-utils/cf-images-utils', () => ({
+// Stub it to a deterministic, inspectable string.
+vi.mock('~/client-utils/edge-url', () => ({
   getEdgeUrl: (src: string, opts: { width?: number; name?: string | null }) =>
     `edge:${src}:${opts?.width}:${opts?.name ?? ''}`,
 }));

--- a/src/tests/api/v1/images/index.test.ts
+++ b/src/tests/api/v1/images/index.test.ts
@@ -48,7 +48,7 @@ vi.mock('~/server/flipt/client', () => ({
   getFliptVariant: mockGetFliptVariant,
 }));
 
-vi.mock('~/client-utils/cf-images-utils', () => ({
+vi.mock('~/client-utils/edge-url', () => ({
   getEdgeUrl: (url: string) => `https://cf-images.com/${url}`,
 }));
 

--- a/src/tests/api/v1/model-versions/id-file-download-url.test.ts
+++ b/src/tests/api/v1/model-versions/id-file-download-url.test.ts
@@ -55,7 +55,7 @@ vi.mock('~/server/services/file.service', () => ({
   getDownloadFilename: ({ file }: any) => `${file.id}.safetensors`,
 }));
 vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn() }));
-vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (url: string) => url }));
+vi.mock('~/client-utils/edge-url', () => ({ getEdgeUrl: (url: string) => url }));
 vi.mock('~/server/utils/endpoint-helpers', () => ({
   MixedAuthEndpoint: (handler: any) => handler,
   // by-hash/[hash] is wrapped in PublicEndpoint(handler, ['GET'], {maxAge}).

--- a/src/tests/api/v1/models/id-file-download-url.test.ts
+++ b/src/tests/api/v1/models/id-file-download-url.test.ts
@@ -65,7 +65,7 @@ vi.mock('~/env/server', () => ({
   env: { IS_DATAPACKET: false, LOGGING: '', IS_BUILD: true },
 }));
 
-vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (url: string) => url }));
+vi.mock('~/client-utils/edge-url', () => ({ getEdgeUrl: (url: string) => url }));
 // The serialized `name` is not the subject here; a per-file deterministic name
 // keeps the fixture readable while staying distinct per file.
 vi.mock('~/server/services/file.service', () => ({

--- a/src/tests/api/v1/models/id-origin-cache.test.ts
+++ b/src/tests/api/v1/models/id-origin-cache.test.ts
@@ -112,7 +112,7 @@ vi.mock('~/env/server', () => ({
 
 // Trim the serialization helper graph so the handler body is deterministic and
 // no Prisma client loads through them.
-vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (url: string) => url }));
+vi.mock('~/client-utils/edge-url', () => ({ getEdgeUrl: (url: string) => url }));
 // Keep the REAL module and override only the URL builders. A wholesale factory
 // here silently drops any export the handler later starts using — which is
 // exactly what happened when `createSerializedFileDownloadUrl` was added: the

--- a/src/tests/api/v1/models/id-overflow-validation.test.ts
+++ b/src/tests/api/v1/models/id-overflow-validation.test.ts
@@ -55,7 +55,7 @@ vi.mock('~/server/utils/region-blocking', () => ({
   getRegion: () => 'US',
   isRegionRestricted: () => false,
 }));
-vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (url: string) => url }));
+vi.mock('~/client-utils/edge-url', () => ({ getEdgeUrl: (url: string) => url }));
 vi.mock('~/server/services/file.service', () => ({ getDownloadFilename: () => 'file.safetensors' }));
 
 // --- shared / mini/[id] handler graph ---

--- a/src/utils/generator-import.ts
+++ b/src/utils/generator-import.ts
@@ -1,5 +1,5 @@
 import pLimit from 'p-limit';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl } from '~/client-utils/edge-url';
 import type { SelectedImage } from '~/components/Training/Form/ImageSelectModal';
 import { IMAGE_MIME_TYPE, MIME_TYPES, VIDEO_MIME_TYPE } from '~/shared/constants/mime-types';
 import { isDefined } from '~/utils/type-guards';


### PR DESCRIPTION
Split 1 of 4 out of #3958, which was held because it is labelled a test-performance change and touches 72 production files with its author closed out. This is the lowest-risk of the five independent moves inside it.

## What changes

`~/client-utils/edge-url` is the pure, React-free URL builder. `~/client-utils/cf-images-utils` imports it, re-exports it, and adds the React hooks (`useEdgeUrl`, `useGetEdgeUrl`) on top. Both files already exist on `main` and neither is modified here.

41 server-side modules were importing `getEdgeUrl` from the barrel, which dragged `react`, `useCurrentUser` and `BrowserSettingsProvider` into the import graph of jobs, webhooks, API routes and services for a function that touches none of them. They now import the leaf directly. The 28 test files that stub `getEdgeUrl` move their `vi.mock` to match.

## Why this is not a behaviour change

`cf-images-utils.ts:16-22` re-exports `getEdgeUrl` straight from `edge-url`, so **both specifiers resolve to the same function object**. Every hunk is a single-name `import { getEdgeUrl }`; none dropped a second binding it still needed.

Confirmed rather than assumed: the set of modules still importing `cf-images-utils` is identical on this branch and on #3958's branch, and neither `edge-url.ts` nor `cf-images-utils.ts` appears in either diff.

One deferred import moves too — `offsite-listing.service.ts:1396` does `await import(...)` inside `loadListingEditView`. Same binding, and it stops pulling React into a server function at call time.

## Scope

**Production files: 41.** All are one-line import re-points. Non-production: 28 test files, also one-line.

Two extras beyond #3958's version, both deliberate:

- `creators-map.test.ts` carried a comment explaining that `getEdgeUrl` "reaches into client-only modules (react hooks, providers) at import". That stopped being true the moment the mock moved to the React-free module, so it is removed rather than left to mislead.
- `creators.ts` and `post.service.ts` appear in more than one of the five splits, so only their `getEdgeUrl` line is taken here.

## What was run

Verified in a single box tenancy on `1f8c3a1240`:

- **`pnpm run typecheck`: 0 errors in 154s**, exit 0.
- 🔑 **The 28 moved `vi.mock` sites got their own probe, because a typecheck cannot see them.** Moving a mock from `~/client-utils/cf-images-utils` to `~/client-utils/edge-url` puts it *under* a re-export barrel: `cf-images-utils` re-exports six more bindings from `edge-url`, and these factories supply only `getEdgeUrl`. So a test whose graph reaches the barrel would get `undefined` for `getInferredMediaType` and fail at `cf-images-utils.ts:29`.

  A static import-closure walk says none of the 28 can reach the barrel — 0 of 28 by static edges, 0 of 28 with test-body `await import()` followed — and that across all **1,057** unit test files in the repo, exactly **5** can reach it. Those 5 plus the 28 were run as **one set of 33**, which is the only shape that could have shown the interaction:

  ```
  Test Files  33 passed (33)
       Tests  515 passed (515)
    Duration  9.21s     exit 0
  ```

  ⚠️ A static graph cannot see a second file re-pointing something into the barrel at runtime, and 33 files in one worker is not the worker membership a future `isolate: false` flip would produce. Strong evidence, not a proof.

- The full unit suite was **not** run on this branch specifically. It was run on the three sibling splits in the same tenancy (1066 files / 16809 tests, per-file identical to a control taken on `origin/main` `6f54a21085` in the same window, zero failures introduced).

<!-- provenance -->
- session: session_01SMWcYo5mJYs4tegt58hxLh
- voice-at-open: alexandra
- worktree: C:/Dev/Repos/work/wt-placement-durable (where every run below was taken)
- branches cut in: C:/Dev/Repos/work/wt-split-3958 — a scratch worktree, since removed
- base: main @ 6f54a21085
- handoff: _local/docs/plans/pr-3958-split-review.md @ ceaa030
- production files touched: 41 (import specifier only; no logic changes)



