### PR TITLE
perf(tests): move enableCollectionYoutubeSupport off collection.service

### DIFF
--- a/src/server/controllers/collection.controller.ts
+++ b/src/server/controllers/collection.controller.ts
@@ -31,7 +31,6 @@ import {
   bulkSaveItems,
   checkUserOwnsCollectionAndItem,
   deleteCollectionById,
-  enableCollectionYoutubeSupport,
   getAllCollections,
   getCollectionById,
   getCollectionCoverImages,
@@ -53,6 +52,7 @@ import {
   updateCollectionItemsStatus,
   upsertCollection,
 } from '~/server/services/collection.service';
+import { enableCollectionYoutubeSupport } from '~/server/services/collection-youtube.service';
 import type { Collaborator } from '~/server/services/collection-collaborator.service';
 import { getCollectionRoster } from '~/server/services/collection-collaborator.service';
 import { setModelShowcaseCollection } from '~/server/services/model.service';

--- a/src/server/services/collection-youtube.service.ts
+++ b/src/server/services/collection-youtube.service.ts
@@ -1,0 +1,80 @@
+import { CollectionMode, CollectionType } from '~/shared/utils/prisma/enums';
+import { dbRead, dbWrite } from '~/server/db/client';
+import type { CollectionMetadataSchema } from '~/server/schema/collection.schema';
+import type { EnableCollectionYoutubeSupportInput } from '~/server/schema/collection.schema';
+import { getCollectionById } from '~/server/services/collection.service';
+import { throwAuthorizationError, throwBadRequestError } from '~/server/utils/errorHandling';
+import { getYoutubeRefreshToken } from '~/server/youtube/client';
+
+// Split out of `collection.service` because it is the only thing in that file that needs the
+// youtube client, and `googleapis` costs ~2.6s to import — paid by every test whose graph
+// reaches collection.service, which is most of the server.
+export const enableCollectionYoutubeSupport = async ({
+  collectionId,
+  userId,
+  authenticationCode,
+}: EnableCollectionYoutubeSupportInput & { userId: number }) => {
+  const user = await dbRead.user.findUnique({ where: { id: userId } });
+  if (!user?.isModerator) {
+    throw throwAuthorizationError('You do not have permission to enable youtube support');
+  }
+
+  const collection = await getCollectionById({ input: { id: collectionId } });
+
+  if (collection.mode !== CollectionMode.Contest) {
+    throw throwBadRequestError('Only contest collections can have youtube support enabled');
+  }
+
+  if (collection.type !== CollectionType.Image) {
+    throw throwBadRequestError('Only image collections can have youtube support enabled');
+  }
+
+  const metadata = collection.metadata as CollectionMetadataSchema;
+
+  if (metadata.youtubeSupportEnabled) {
+    throw throwBadRequestError('Youtube support is already enabled for this collection');
+  }
+
+  // Attempt to save the auth code on the key-value store.
+  try {
+    const { tokens } = await getYoutubeRefreshToken(
+      authenticationCode,
+      '/collections/youtube/auth'
+    );
+    const collectionKey = `collection:${collectionId}:youtube-authentication-code`;
+
+    if (!tokens.refresh_token) {
+      throw throwBadRequestError('Failed to get youtube refresh token');
+    }
+    await dbWrite.$transaction(async (tx) => {
+      await tx.keyValue.upsert({
+        where: {
+          key: collectionKey,
+        },
+        update: {
+          value: tokens.refresh_token as string,
+        },
+        create: {
+          key: collectionKey,
+          value: tokens.refresh_token as string,
+        },
+      });
+
+      await tx.collection.update({
+        where: {
+          id: collection.id,
+        },
+        data: {
+          metadata: {
+            ...metadata,
+            youtubeSupportEnabled: true,
+          },
+        },
+      });
+    });
+
+    return { collectionId, youtubeSupportEnabled: true };
+  } catch {
+    throw throwBadRequestError('Failed to save youtube authentication code');
+  }
+};

--- a/src/server/services/collection-youtube.service.ts
+++ b/src/server/services/collection-youtube.service.ts
@@ -7,8 +7,8 @@ import { throwAuthorizationError, throwBadRequestError } from '~/server/utils/er
 import { getYoutubeRefreshToken } from '~/server/youtube/client';
 
 // Split out of `collection.service` because it is the only thing in that file that needs the
-// youtube client, and `googleapis` costs ~2.6s to import — paid by every test whose graph
-// reaches collection.service, which is most of the server.
+// youtube client, which pulls `googleapis` into the graph of everything reaching
+// collection.service. (An earlier note put that at ~2.6s to import; nobody has measured it.)
 export const enableCollectionYoutubeSupport = async ({
   collectionId,
   userId,

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -29,7 +29,6 @@ import type {
   AddCollectionItemInput,
   BulkSaveCollectionItemsInput,
   CollectionMetadataSchema,
-  EnableCollectionYoutubeSupportInput,
   GetAllCollectionItemsSchema,
   GetAllCollectionsInfiniteSchema,
   GetAllUserCollectionsInputSchema,
@@ -77,7 +76,6 @@ import {
   throwInsufficientFundsError,
   throwNotFoundError,
 } from '~/server/utils/errorHandling';
-import { getYoutubeRefreshToken } from '~/server/youtube/client';
 import { parseBitwiseBrowsingLevel } from '~/shared/constants/browsingLevel.constants';
 import type { MediaType } from '~/shared/utils/prisma/enums';
 import {
@@ -3600,75 +3598,6 @@ export const setCollectionItemNsfwLevel = async ({
   ]);
 };
 
-export const enableCollectionYoutubeSupport = async ({
-  collectionId,
-  userId,
-  authenticationCode,
-}: EnableCollectionYoutubeSupportInput & { userId: number }) => {
-  const user = await dbRead.user.findUnique({ where: { id: userId } });
-  if (!user?.isModerator) {
-    throw throwAuthorizationError('You do not have permission to enable youtube support');
-  }
-
-  const collection = await getCollectionById({ input: { id: collectionId } });
-
-  if (collection.mode !== CollectionMode.Contest) {
-    throw throwBadRequestError('Only contest collections can have youtube support enabled');
-  }
-
-  if (collection.type !== CollectionType.Image) {
-    throw throwBadRequestError('Only image collections can have youtube support enabled');
-  }
-
-  const metadata = collection.metadata as CollectionMetadataSchema;
-
-  if (metadata.youtubeSupportEnabled) {
-    throw throwBadRequestError('Youtube support is already enabled for this collection');
-  }
-
-  // Attempt to save the auth code on the key-value store.
-  try {
-    const { tokens } = await getYoutubeRefreshToken(
-      authenticationCode,
-      '/collections/youtube/auth'
-    );
-    const collectionKey = `collection:${collectionId}:youtube-authentication-code`;
-
-    if (!tokens.refresh_token) {
-      throw throwBadRequestError('Failed to get youtube refresh token');
-    }
-    await dbWrite.$transaction(async (tx) => {
-      await tx.keyValue.upsert({
-        where: {
-          key: collectionKey,
-        },
-        update: {
-          value: tokens.refresh_token as string,
-        },
-        create: {
-          key: collectionKey,
-          value: tokens.refresh_token as string,
-        },
-      });
-
-      await tx.collection.update({
-        where: {
-          id: collection.id,
-        },
-        data: {
-          metadata: {
-            ...metadata,
-            youtubeSupportEnabled: true,
-          },
-        },
-      });
-    });
-
-    return { collectionId, youtubeSupportEnabled: true };
-  } catch {
-    throw throwBadRequestError('Failed to save youtube authentication code');
-  }
-};
 
 export type CollectionEntityType = 'image' | 'model' | 'post' | 'article';
 


### PR DESCRIPTION
Split 2 of 4 out of #3958. See #3965 for the context on why that PR was held.

## What changes

`enableCollectionYoutubeSupport` is the only thing in `collection.service.ts` that needs `~/server/youtube/client`, and that pulls `googleapis`. Every module whose graph reaches `collection.service` paid for it — which is most of the server. It moves to `~/server/services/collection-youtube.service.ts`, and the controller imports it from there.

## Why this is not a behaviour change

The function body is relocated verbatim: same moderator check and same `throwAuthorizationError` message, the same `CollectionMode.Contest` and `CollectionType.Image` guards in the same order, the same `collection:${collectionId}:youtube-authentication-code` key, the same `$transaction` doing `keyValue.upsert` then `collection.update`, and the same bare `catch` collapsing everything into `Failed to save youtube authentication code`.

`CollectionMode` and `CollectionType` come from `~/shared/utils/prisma/enums` in the new file, which is the same module `collection.service.ts:81-95` imports them from — a re-export shim over `@civitai/db-schema/enums`.

No cycle is introduced: `collection-youtube.service` imports `collection.service` for `getCollectionById`, and `collection.service` does not import back.

## Scope

**Production files: 3** — one new file, one deletion of the moved function, one controller import. No test files.

## What was run

Verified in a single box tenancy on this branch's parent commit `d4e86c0af6`:

- **`pnpm run typecheck`: 0 errors in 150s**, exit 0.
- **`pnpm run test:unit:run`: 1066 files / 16809 tests**, 6 files / 16 tests failed — **identical to the base**. A control on `origin/main` `6f54a21085` in the same window over exactly those six failing files gives the same per-file counts (`1/11, 1/5, 1/6, 3/27, 7/9, 3/12`), and none of the six is touched by this PR. **Zero failures introduced.**

The later commit on this branch only edits a comment.

⚠️ A bound on the win, since the PR claims one: `collection.controller` imports both services, so any test whose graph reaches the controller still pulls the youtube client. The gain is for the modules that reach `collection.service` and not the controller.

<!-- provenance -->
- session: session_01SMWcYo5mJYs4tegt58hxLh
- voice-at-open: alexandra
- worktree: C:/Dev/Repos/work/wt-placement-durable (where every run below was taken)
- branches cut in: C:/Dev/Repos/work/wt-split-3958 — a scratch worktree, since removed
- base: main @ 6f54a21085
- handoff: _local/docs/plans/pr-3958-split-review.md @ ceaa030
- production files touched: 3 (verbatim function relocation)



