### PR TITLE
perf(tests): split publicApiContext2 out of createContext

### DIFF
--- a/src/pages/api/v1/bugs.ts
+++ b/src/pages/api/v1/bugs.ts
@@ -1,7 +1,7 @@
 import { TRPCError } from '@trpc/server';
 import { getHTTPStatusCodeFromError } from '@trpc/server/http';
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { publicApiContext2 } from '~/server/createContext';
+import { publicApiContext2 } from '~/server/public-api-context';
 import { logToAxiom } from '~/server/logging/client';
 import { PublicEndpoint } from '~/server/utils/endpoint-helpers';
 import { isClientAbortError } from '~/server/utils/errorHandling';

--- a/src/pages/api/v1/bugs/[id].ts
+++ b/src/pages/api/v1/bugs/[id].ts
@@ -1,7 +1,7 @@
 import { TRPCError } from '@trpc/server';
 import { getHTTPStatusCodeFromError } from '@trpc/server/http';
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { publicApiContext2 } from '~/server/createContext';
+import { publicApiContext2 } from '~/server/public-api-context';
 import { logToAxiom } from '~/server/logging/client';
 import { PublicEndpoint } from '~/server/utils/endpoint-helpers';
 import { isClientAbortError } from '~/server/utils/errorHandling';

--- a/src/pages/api/v1/content/[[...slug]].ts
+++ b/src/pages/api/v1/content/[[...slug]].ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { publicApiContext2 } from '~/server/createContext';
+import { publicApiContext2 } from '~/server/public-api-context';
 import { handleEndpointError, PublicEndpoint } from '~/server/utils/endpoint-helpers';
 
 export default PublicEndpoint(async function handler(req: NextApiRequest, res: NextApiResponse) {

--- a/src/pages/api/v1/creators.ts
+++ b/src/pages/api/v1/creators.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getEdgeUrl } from '~/client-utils/cf-images-utils';
-import { publicApiContext2 } from '~/server/createContext';
+import { publicApiContext2 } from '~/server/public-api-context';
 import { handleEndpointError, PublicEndpoint } from '~/server/utils/endpoint-helpers';
 import { getPaginationLinks } from '~/server/utils/pagination-helpers';
 

--- a/src/pages/api/v1/tags.ts
+++ b/src/pages/api/v1/tags.ts
@@ -1,6 +1,6 @@
 import { TagTarget } from '~/shared/utils/prisma/enums';
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { publicApiContext2 } from '~/server/createContext';
+import { publicApiContext2 } from '~/server/public-api-context';
 
 import { handleEndpointError, PublicEndpoint } from '~/server/utils/endpoint-helpers';
 import { getPaginationLinks } from '~/server/utils/pagination-helpers';

--- a/src/pages/api/v1/users/index.ts
+++ b/src/pages/api/v1/users/index.ts
@@ -3,7 +3,7 @@ import { getHTTPStatusCodeFromError } from '@trpc/server/http';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import * as z from 'zod';
 import { env } from '~/env/server';
-import { publicApiContext2 } from '~/server/createContext';
+import { publicApiContext2 } from '~/server/public-api-context';
 import { getAllUsersInput } from '~/server/schema/user.schema';
 import { handleEndpointError, PublicEndpoint } from '~/server/utils/endpoint-helpers';
 import { isClientAbortError } from '~/server/utils/errorHandling';

--- a/src/server/__tests__/createContext.client-ip.test.ts
+++ b/src/server/__tests__/createContext.client-ip.test.ts
@@ -69,7 +69,8 @@ vi.mock('~/server/trpc', () => ({
   createCallerFactory: () => (ctx: unknown) => ctx,
 }));
 
-import { createContext, publicApiContext, publicApiContext2 } from '../createContext';
+import { createContext, publicApiContext } from '../createContext';
+import { publicApiContext2 } from '../public-api-context';
 import { UNRESOLVED_CLIENT_IP, resolveClientIp } from '~/server/utils/client-ip';
 
 function reqWith(

--- a/src/server/createContext.ts
+++ b/src/server/createContext.ts
@@ -4,8 +4,6 @@ import { Tracker } from './clickhouse/client';
 import { resolveClientIpOrNull } from '~/server/utils/client-ip';
 import { isProd } from '~/env/other';
 import { getFeatureFlagsLazy } from '~/server/services/feature-flags.service';
-import { createCallerFactory } from '~/server/trpc';
-import { appRouter } from '~/server/routers';
 import { getRequestDomainColor } from '~/server/utils/server-domain';
 import { isAllowedOriginRequest } from '~/server/utils/origin-helpers';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
@@ -107,36 +105,6 @@ export const createContext = async ({
     apiKeyId,
     subject,
   };
-};
-
-const createCaller = createCallerFactory(appRouter);
-export const publicApiContext2 = async (req: NextApiRequest, res: NextApiResponse) => {
-  const domain = getRequestDomainColor(req) ?? 'blue';
-
-  return createCaller({
-    user: undefined,
-    acceptableOrigin: true,
-    features: getFeatureFlagsLazy({ req }),
-    track: new Tracker(req, res),
-    // ATTRIBUTION surface — see the note on `ip` in `createContext` above.
-    ip: resolveClientIpOrNull(req) ?? '',
-    cache: {
-      browserTTL: 3 * 60,
-      edgeTTL: 3 * 60,
-      staleWhileRevalidate: 60,
-      canCache: true,
-      skip: false,
-    },
-    res,
-    req,
-    domain,
-    // Non-client-facing context â€” use an always-open signal so downstream
-    // callers that expect AbortSignal have a valid value.
-    signal: new AbortController().signal,
-    tokenScope: TokenScope.Full,
-    apiKeyId: undefined,
-    subject: undefined,
-  });
 };
 
 export const publicApiContext = async (req: NextApiRequest, res: NextApiResponse) => {

--- a/src/server/public-api-context.ts
+++ b/src/server/public-api-context.ts
@@ -1,0 +1,41 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { Tracker } from '~/server/clickhouse/client';
+import { resolveClientIpOrNull } from '~/server/utils/client-ip';
+import { getFeatureFlagsLazy } from '~/server/services/feature-flags.service';
+import { createCallerFactory } from '~/server/trpc';
+import { appRouter } from '~/server/routers';
+import { getRequestDomainColor } from '~/server/utils/server-domain';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+// Kept out of `~/server/createContext` deliberately: this is the only piece that needs
+// `appRouter`, and having it there put the entire tRPC router in the graph of every module
+// that only wanted the `Context` type or `createContext` itself.
+const createCaller = createCallerFactory(appRouter);
+export const publicApiContext2 = async (req: NextApiRequest, res: NextApiResponse) => {
+  const domain = getRequestDomainColor(req) ?? 'blue';
+
+  return createCaller({
+    user: undefined,
+    acceptableOrigin: true,
+    features: getFeatureFlagsLazy({ req }),
+    track: new Tracker(req, res),
+    // ATTRIBUTION surface — see the note on `ip` in `createContext` above.
+    ip: resolveClientIpOrNull(req) ?? '',
+    cache: {
+      browserTTL: 3 * 60,
+      edgeTTL: 3 * 60,
+      staleWhileRevalidate: 60,
+      canCache: true,
+      skip: false,
+    },
+    res,
+    req,
+    domain,
+    // Non-client-facing context â€” use an always-open signal so downstream
+    // callers that expect AbortSignal have a valid value.
+    signal: new AbortController().signal,
+    tokenScope: TokenScope.Full,
+    apiKeyId: undefined,
+    subject: undefined,
+  });
+};

--- a/src/tests/api/rest-envelope-consolidation.test.ts
+++ b/src/tests/api/rest-envelope-consolidation.test.ts
@@ -73,7 +73,7 @@ const {
   mockTracker: vi.fn(),
 }));
 
-vi.mock('~/server/createContext', async (importOriginal) => ({
+vi.mock('~/server/public-api-context', async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   publicApiContext2: mockPublicApiContext2,
 }));

--- a/src/tests/api/v1/creators-map.test.ts
+++ b/src/tests/api/v1/creators-map.test.ts
@@ -12,7 +12,7 @@ import { describe, it, expect, vi } from 'vitest';
 vi.mock('~/server/utils/endpoint-helpers', () => ({
   PublicEndpoint: (fn: unknown) => fn,
 }));
-vi.mock('~/server/createContext', () => ({ publicApiContext2: vi.fn() }));
+vi.mock('~/server/public-api-context', () => ({ publicApiContext2: vi.fn() }));
 vi.mock('~/server/utils/pagination-helpers', () => ({ getPaginationLinks: vi.fn() }));
 vi.mock('~/server/utils/errorHandling', () => ({ isClientAbortError: () => false }));
 // getEdgeUrl reaches into client-only modules (react hooks, providers) at import;

--- a/src/tests/api/v1/creators.test.ts
+++ b/src/tests/api/v1/creators.test.ts
@@ -12,7 +12,7 @@ const { mockPublicApiContext2, mockGetCreators } = vi.hoisted(() => ({
   mockGetCreators: vi.fn(),
 }));
 
-vi.mock('~/server/createContext', () => ({
+vi.mock('~/server/public-api-context', () => ({
   publicApiContext2: mockPublicApiContext2,
 }));
 

--- a/src/tests/api/v1/tags.test.ts
+++ b/src/tests/api/v1/tags.test.ts
@@ -11,7 +11,7 @@ const { mockPublicApiContext2, mockGetAll } = vi.hoisted(() => ({
   mockGetAll: vi.fn(),
 }));
 
-vi.mock('~/server/createContext', () => ({
+vi.mock('~/server/public-api-context', () => ({
   publicApiContext2: mockPublicApiContext2,
 }));
 

--- a/src/tests/api/v1/users/index.test.ts
+++ b/src/tests/api/v1/users/index.test.ts
@@ -12,7 +12,7 @@ const { mockPublicApiContext2, mockGetAll } = vi.hoisted(() => ({
   mockGetAll: vi.fn(),
 }));
 
-vi.mock('~/server/createContext', () => ({
+vi.mock('~/server/public-api-context', () => ({
   publicApiContext2: mockPublicApiContext2,
 }));
 


### PR DESCRIPTION
Split 3 of 5 out of #3958. See #3965 for the context on why that PR was held.

## What changes

`publicApiContext2` is the only thing in `~/server/createContext` that needs `appRouter`. It moves to `~/server/public-api-context.ts`; the six v1 routes that call it import the new module. The function body is relocated verbatim — same `tokenScope: TokenScope.Full`, same `acceptableOrigin: true`, same 3/3/60 cache numbers, same always-open `AbortController().signal`.

Nothing else in `createContext` changes. Every remaining imported identifier there is still used; `createCallerFactory` and `appRouter` drop to zero occurrences.

## 🔴 Correction: an earlier version of this body claimed this breaks an import cycle. It does not.

**That claim was wrong and is withdrawn.** It said `createContext → ~/server/routers → controllers → createContext` was a real runtime cycle, and rated this PR medium-risk on that basis. Found by an independent reviewer (scarlet) and confirmed here at source, two ways:

- **`src/server/routers/index.ts` has exactly two top-level imports** (`@trpc/server`, `~/server/trpc`) and **all 99 router entries are `lazy(() => import(...))`**. The `routers → controllers` edge does not execute at load.
- **`src/server/trpc.ts:36` is `import type { Context } from './createContext'`** — its only reference, and erased at compile time.

Either link alone is enough to mean there was never a cycle to break.

**A second claim in the same paragraph was also overstated:** that ~100 controllers importing `createContext` for the `Context` type dragged the tRPC router into their graph. Classified across the tree by parsing each import clause: **54 type-only importers and 9 value-shaped ones** on `main` (6 of the 9 are the v1 routes this PR moves, leaving 3 after it lands). Type-only imports put nothing in the runtime graph, and loading `~/server/routers` pulls zero router modules because they are all lazy.

⚠️ **The reason this matters even though the code is fine:** the next person to measure this PR against that model would get a much smaller number than the body promises, and the natural conclusion is that *the instrument* is broken rather than the model. A wrong model in a PR body outlives the session that wrote it.

## What it actually buys

The six v1 routes stop pulling `~/server/auth/get-server-auth-session`, `~/server/utils/origin-helpers` and `~/env/other` into their graph — `createContext` needs those and `publicApiContext2` never did. They still pull `~/server/trpc` and `~/server/routers` through the new module, because building the caller genuinely requires them.

Modest, real, and much less than the earlier body claimed.

## Scope

**Production files: 8** — one new file, `createContext.ts`, and six v1 API routes. Non-production: 6 test files updating a mock path.

⚠️ Four of those six test files wholesale-mock the context module either way, so their own import graph is unchanged by this PR; the test-side benefit is not in them.

`creators.ts` appears in more than one split, so only its `publicApiContext2` line is taken here.

## What was run

Verified in a single box tenancy on `affd64977c`:

- **`pnpm run typecheck`: 0 errors in 144s**, exit 0.
- **`pnpm run test:unit:run`: 1066 files / 16809 tests**, 6 files / 16 tests failed — **identical to the base**. A control on `origin/main` `6f54a21085` in the same window over exactly those six files gives the same per-file counts (`1/11, 1/5, 1/6, 3/27, 7/9, 3/12`). None of the six is touched by this PR. **Zero failures introduced.**
- **`next build`** at `NODE_OPTIONS=--max-old-space-size=8192`: reaches **`✓ Compiled successfully in 3.2min`**, `.next` at 4.4 GB.

⚠️ Two caveats on that build, both facts about the machine rather than about this PR:

1. At Node's default heap the build **OOMs during type-checking on `origin/main` itself** — `package.json` runs a bare `next build` (~4 GB default) while `scripts/typecheck.mjs` gives the same check 8192 MB. Pre-existing repo issue, unrelated to any branch here.
2. It does not run to completion: `Collecting page data` needs `DATABASE_URL`, `DATABASE_REPLICA_URL` and `REDIS_URL`, and this worktree has no `.env`. Finishing it needs live infrastructure, not a code change.

`✓ Compiled successfully` is the phase that validates the client/server bundle graph, which is what typecheck and both vitest projects are blind to and the reason this PR was held for a build.

## Merge order

No constraint against #3965, #3966 or #3971. Only #3968 (C) has one — it lands last.

<!-- provenance -->
- session: session_01SMWcYo5mJYs4tegt58hxLh
- voice-at-open: alexandra
- worktree: C:/Dev/Repos/work/wt-placement-durable (where every run below was taken)
- branches cut in: C:/Dev/Repos/work/wt-split-3958 — a scratch worktree, since removed
- base: main @ 6f54a21085
- handoff: _local/docs/plans/pr-3958-split-review.md @ ceaa030
- production files touched: 8 (verbatim function relocation)
- independent review: scarlet — found the withdrawn cycle claim above

