### PR TITLE
perf(tests): split icon and theme constants off the data they sit beside

### DIFF
--- a/src/components/Model/Actions/MergeVersions.tsx
+++ b/src/components/Model/Actions/MergeVersions.tsx
@@ -41,9 +41,9 @@ import { getFileExtension } from '~/utils/string-helpers';
 import {
   comfyFileTypeLabels,
   filterFileTypeByExtension,
-  getFileIconConfig,
   UNQUANTIZED_QUANT_TYPE,
 } from '~/utils/file-display-helpers';
+import { getFileIconConfig } from '~/utils/file-display-icons';
 import { trpc } from '~/utils/trpc';
 
 type FileMetadataUpdate = {

--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -151,7 +151,7 @@ import type { ModelById } from '~/types/router';
 import { HiddenMetricNotice } from '~/components/Model/HiddenMetricNotice';
 import { formatDate, formatDateMin } from '~/utils/date-helpers';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
-import { componentTypeConfig, getFileIconConfig } from '~/utils/file-display-helpers';
+import { componentTypeConfig, getFileIconConfig } from '~/utils/file-display-icons';
 import { formatKBytes } from '~/utils/number-helpers';
 import { getDisplayName, getModelUrl, removeTags } from '~/utils/string-helpers';
 import { trpc } from '~/utils/trpc';

--- a/src/components/Model/ModelVersions/RequiredComponentsSection.tsx
+++ b/src/components/Model/ModelVersions/RequiredComponentsSection.tsx
@@ -31,11 +31,8 @@ import { createModelFileDownloadUrl } from '~/server/common/model-helpers';
 import type { LinkedComponent } from '~/server/schema/model-file.schema';
 import { getPrimaryFile, type GroupedFileVariants } from '~/server/utils/model-helpers';
 import type { ModelById } from '~/types/router';
-import {
-  componentTypeConfig,
-  getFileDescription,
-  getFileLabel,
-} from '~/utils/file-display-helpers';
+import { getFileDescription, getFileLabel } from '~/utils/file-display-helpers';
+import { componentTypeConfig } from '~/utils/file-display-icons';
 import { VerifiedText } from '~/components/VerifiedText/VerifiedText';
 import { abbreviateNumber, formatKBytes } from '~/utils/number-helpers';
 import { getModelUrl } from '~/utils/string-helpers';

--- a/src/components/Model/ModelVersions/model-version.utils.ts
+++ b/src/components/Model/ModelVersions/model-version.utils.ts
@@ -8,9 +8,6 @@ import { type ModelVersionTerms, generationOpenToNonBuyers, isFreeGeneration } f
 import { ModelUsageControl } from '~/shared/utils/prisma/enums';
 import { handleTRPCError, trpc } from '~/utils/trpc';
 
-export const MIN_DONATION_GOAL = 1000;
-export const MAX_DONATION_GOAL = 1000000000;
-
 export const useQueryModelVersionsEngagement = (
   { modelId, versionId }: { modelId: number; versionId: number },
   options?: { enabled?: boolean }

--- a/src/components/Resource/Files.tsx
+++ b/src/components/Resource/Files.tsx
@@ -64,7 +64,7 @@ import type { LinkedComponent } from '~/server/schema/model-file.schema';
 import { openResourceSelectModal } from '~/components/Dialog/triggers/resource-select';
 import type { GenerationResource } from '~/shared/types/generation.types';
 import { ModelType, ModelUsageControl } from '~/shared/utils/prisma/enums';
-import { componentTypeConfig, getFileIconConfig } from '~/utils/file-display-helpers';
+import { componentTypeConfig, getFileIconConfig } from '~/utils/file-display-icons';
 
 // Small inline dropzone for adding files within a section
 function InlineDropzone({

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -30,7 +30,7 @@ import InputResourceSelectMultiple from '~/components/ImageGeneration/Generation
 import {
   MAX_DONATION_GOAL,
   MIN_DONATION_GOAL,
-} from '~/components/Model/ModelVersions/model-version.utils';
+} from '~/shared/constants/donation-goal.constants';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useCreatorProgramRequirements } from '~/components/Buzz/CreatorProgramV2/CreatorProgram.util';
 import { useCurrentUserSettings, useMutateUserSettings } from '~/components/UserSettings/hooks';

--- a/src/components/Training/Form/TrainingCommon.ts
+++ b/src/components/Training/Form/TrainingCommon.ts
@@ -23,12 +23,6 @@ import { isDefined } from '~/utils/type-guards';
 export const basePath = '/models/train';
 export const maxSteps = 3;
 
-// nb: these should be proper AIRs now
-export const blockedCustomModels = [
-  'civitai:53761@285757',
-  'urn:air:sd1:checkpoint:civitai:53761@285757',
-];
-
 /**
  * Computes the number of decimal points in a given input using magic math
  */

--- a/src/components/Training/Form/TrainingSubmit.tsx
+++ b/src/components/Training/Form/TrainingSubmit.tsx
@@ -42,11 +42,8 @@ import { useSelectedBuzzType, BuzzTypeSelector } from '~/components/generation_v
 import { DescriptionTable } from '~/components/DescriptionTable/DescriptionTable';
 import { DismissibleAlert } from '~/components/DismissibleAlert/DismissibleAlert';
 import { InfoPopover } from '~/components/InfoPopover/InfoPopover';
-import {
-  blockedCustomModels,
-  goBack,
-  minsToHours,
-} from '~/components/Training/Form/TrainingCommon';
+import { goBack, minsToHours } from '~/components/Training/Form/TrainingCommon';
+import { blockedCustomModels } from '~/shared/constants/training.constants';
 import {
   type NumberTrainingSettingsType,
   trainingSettings,

--- a/src/components/Training/Form/TrainingSubmitModelSelect.tsx
+++ b/src/components/Training/Form/TrainingSubmitModelSelect.tsx
@@ -17,7 +17,7 @@ import React from 'react';
 import { AlertWithIcon } from '~/components/AlertWithIcon/AlertWithIcon';
 import { CustomMarkdown } from '~/components/Markdown/CustomMarkdown';
 import { ResourceSelect } from '~/components/ImageGeneration/GenerationForm/ResourceSelect';
-import { blockedCustomModels } from '~/components/Training/Form/TrainingCommon';
+import { blockedCustomModels } from '~/shared/constants/training.constants';
 import { useTrainingServiceStatus } from '~/components/Training/training.utils';
 import { trpc } from '~/utils/trpc';
 import type {

--- a/src/server/schema/model-version.schema.ts
+++ b/src/server/schema/model-version.schema.ts
@@ -5,7 +5,7 @@ import * as z from 'zod';
 import {
   MAX_DONATION_GOAL,
   MIN_DONATION_GOAL,
-} from '~/components/Model/ModelVersions/model-version.utils';
+} from '~/shared/constants/donation-goal.constants';
 import type { BaseModel } from '~/shared/constants/basemodel.constants';
 import { constants } from '~/server/common/constants';
 import { infiniteQuerySchema } from '~/server/schema/base.schema';

--- a/src/server/schema/training.schema.ts
+++ b/src/server/schema/training.schema.ts
@@ -1,5 +1,5 @@
 import * as z from 'zod';
-import { blockedCustomModels } from '~/components/Training/Form/TrainingCommon';
+import { blockedCustomModels } from '~/shared/constants/training.constants';
 import { autoCaptionSchema, autoLabelLimits } from '~/store/training.store';
 
 // Auto-label workflow batches map 1 step per image; the orchestrator can ingest larger

--- a/src/shared/constants/currency-theme.constants.ts
+++ b/src/shared/constants/currency-theme.constants.ts
@@ -1,0 +1,113 @@
+import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
+import { Currency } from '~/shared/utils/prisma/enums';
+
+// Split out of `currency.constants` so a non-React consumer can read a currency's colours
+// without the icon COMPONENTS — and therefore without `@tabler/icons-react` — entering its
+// module graph. `currency.constants` re-attaches the icons on top of this.
+export type CurrencyThemeColors = {
+  color: string;
+  fill?: string | undefined;
+  cssVariableName?: string;
+  css?: {
+    gradient?: string;
+  };
+  classNames?: {
+    btn?: string;
+    gradient?: string;
+    gradientText?: string;
+  };
+};
+
+type CurrencyThemeConfig = {
+  USD: CurrencyThemeColors;
+  USDC: CurrencyThemeColors;
+  BUZZ: CurrencyThemeColors & { themes: Record<BuzzSpendType, CurrencyThemeColors> };
+};
+
+export const CurrencyThemeConfig: CurrencyThemeConfig = {
+  [Currency.BUZZ]: {
+    color: '#f59f00',
+    fill: '#f59f00',
+    css: {
+      gradient:
+        'linear-gradient(135deg, var(--mantine-color-yellow-4) 0%, var(--mantine-color-orange-5) 100%)',
+    },
+    classNames: {
+      btn: 'bg-gradient-to-r from-orange-500 to-yellow-400 hover:from-orange-600 hover:to-yellow-500 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 shadow min-w-[140px] font-bold transition-all duration-150 border-none text-white',
+      gradient: 'bg-gradient-to-r from-orange-500 to-yellow-400',
+      gradientText: 'bg-gradient-to-r from-orange-500 to-yellow-400 bg-clip-text text-transparent',
+    },
+    themes: {
+      blue: {
+        color: '#4dabf7',
+        fill: '#4dabf7',
+        classNames: {
+          btn: 'bg-gradient-to-r from-blue-500 to-cyan-400 hover:from-blue-600 hover:to-cyan-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 shadow min-w-[140px] font-bold transition-all duration-150 border-none text-white',
+          gradient: 'bg-gradient-to-r from-blue-500 to-cyan-400',
+          gradientText: 'bg-gradient-to-r from-blue-500 to-cyan-400 bg-clip-text text-transparent',
+        },
+        css: {
+          gradient:
+            'linear-gradient(135deg, var(--mantine-color-cyan-4) 0%, var(--mantine-color-blue-5) 100%)',
+        },
+      },
+      green: {
+        color: '#40c057',
+        fill: '#40c057',
+        classNames: {
+          btn: 'bg-gradient-to-r from-green-500 to-emerald-400 hover:from-green-600 hover:to-emerald-500 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 shadow min-w-[140px] font-bold transition-all duration-150 border-none text-white',
+          gradient: 'bg-gradient-to-r from-green-500 to-emerald-400',
+          gradientText:
+            'bg-gradient-to-r from-green-500 to-emerald-400 bg-clip-text text-transparent',
+        },
+        css: {
+          gradient:
+            'linear-gradient(135deg, var(--mantine-color-lime-4) 0%, var(--mantine-color-green-6) 100%)',
+        },
+      },
+      yellow: {
+        color: '#f59f00',
+        fill: '#f59f00',
+        css: {
+          gradient:
+            'linear-gradient(135deg, var(--mantine-color-yellow-4) 0%, var(--mantine-color-orange-5) 100%)',
+        },
+        classNames: {
+          btn: 'bg-gradient-to-r from-orange-500 to-yellow-400 hover:from-orange-600 hover:to-yellow-500 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 shadow min-w-[140px] font-bold transition-all duration-150 border-none text-white',
+          gradient: 'bg-gradient-to-r from-orange-500 to-yellow-400',
+          gradientText:
+            'bg-gradient-to-r from-orange-500 to-yellow-400 bg-clip-text text-transparent',
+        },
+      },
+      red: {
+        color: '#f03e3e',
+        fill: '#f03e3e',
+        classNames: {
+          btn: 'bg-gradient-to-r from-rose-500 to-pink-400 hover:from-rose-600 hover:to-pink-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 shadow min-w-[140px] font-bold transition-all duration-150 border-none text-white dark:border-rose-600',
+          gradient: 'bg-gradient-to-r from-rose-500 to-pink-400',
+          gradientText: 'bg-gradient-to-r from-rose-500 to-pink-400 bg-clip-text text-transparent',
+        },
+        css: {
+          gradient:
+            'linear-gradient(135deg, var(--mantine-color-red-5) 0%, var(--mantine-color-pink-6) 100%)',
+        },
+      },
+    },
+  },
+  [Currency.USD]: {
+    color: '#f59f00',
+    fill: undefined,
+  },
+  [Currency.USDC]: {
+    color: '#f59f00',
+    fill: undefined,
+  },
+};
+
+export function getCurrencyThemeConfig(
+  args: { currency: 'USD' | 'USDC' } | { currency: 'BUZZ'; type?: BuzzSpendType }
+) {
+  if (args.currency === Currency.BUZZ)
+    return CurrencyThemeConfig.BUZZ.themes[args.type ?? 'yellow'];
+  else return CurrencyThemeConfig[args.currency];
+}

--- a/src/shared/constants/currency.constants.ts
+++ b/src/shared/constants/currency.constants.ts
@@ -1,22 +1,13 @@
 import type { IconProps, Icon } from '@tabler/icons-react';
 import { IconBolt, IconCurrencyDollar } from '@tabler/icons-react';
-import type { ForwardRefExoticComponent, RefAttributes } from 'react';
+import type { ForwardRefExoticComponent } from 'react';
 import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
+import type { CurrencyThemeColors } from '~/shared/constants/currency-theme.constants';
+import { CurrencyThemeConfig } from '~/shared/constants/currency-theme.constants';
 import { Currency } from '~/shared/utils/prisma/enums';
 
-type CurrencyTheme = {
+type CurrencyTheme = CurrencyThemeColors & {
   icon: ForwardRefExoticComponent<IconProps & React.RefAttributes<Icon>>;
-  color: string;
-  fill?: string | undefined;
-  cssVariableName?: string;
-  css?: {
-    gradient?: string;
-  };
-  classNames?: {
-    btn?: string;
-    gradient?: string;
-    gradientText?: string;
-  };
 };
 
 type CurrencyConfig = {
@@ -25,91 +16,23 @@ type CurrencyConfig = {
   BUZZ: CurrencyTheme & { themes: Record<BuzzSpendType, CurrencyTheme> };
 };
 
+const withIcon = <T extends CurrencyThemeColors>(theme: T, icon: CurrencyTheme['icon']) => ({
+  ...theme,
+  icon,
+});
+
 export const CurrencyConfig: CurrencyConfig = {
   [Currency.BUZZ]: {
-    icon: IconBolt,
-    color: '#f59f00',
-    fill: '#f59f00',
-    css: {
-      gradient:
-        'linear-gradient(135deg, var(--mantine-color-yellow-4) 0%, var(--mantine-color-orange-5) 100%)',
-    },
-    classNames: {
-      btn: 'bg-gradient-to-r from-orange-500 to-yellow-400 hover:from-orange-600 hover:to-yellow-500 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 shadow min-w-[140px] font-bold transition-all duration-150 border-none text-white',
-      gradient: 'bg-gradient-to-r from-orange-500 to-yellow-400',
-      gradientText: 'bg-gradient-to-r from-orange-500 to-yellow-400 bg-clip-text text-transparent',
-    },
-    themes: {
-      blue: {
-        icon: IconBolt,
-        color: '#4dabf7',
-        fill: '#4dabf7',
-        classNames: {
-          btn: 'bg-gradient-to-r from-blue-500 to-cyan-400 hover:from-blue-600 hover:to-cyan-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 shadow min-w-[140px] font-bold transition-all duration-150 border-none text-white',
-          gradient: 'bg-gradient-to-r from-blue-500 to-cyan-400',
-          gradientText: 'bg-gradient-to-r from-blue-500 to-cyan-400 bg-clip-text text-transparent',
-        },
-        css: {
-          gradient:
-            'linear-gradient(135deg, var(--mantine-color-cyan-4) 0%, var(--mantine-color-blue-5) 100%)',
-        },
-      },
-      green: {
-        icon: IconBolt,
-        color: '#40c057',
-        fill: '#40c057',
-        classNames: {
-          btn: 'bg-gradient-to-r from-green-500 to-emerald-400 hover:from-green-600 hover:to-emerald-500 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 shadow min-w-[140px] font-bold transition-all duration-150 border-none text-white',
-          gradient: 'bg-gradient-to-r from-green-500 to-emerald-400',
-          gradientText:
-            'bg-gradient-to-r from-green-500 to-emerald-400 bg-clip-text text-transparent',
-        },
-        css: {
-          gradient:
-            'linear-gradient(135deg, var(--mantine-color-lime-4) 0%, var(--mantine-color-green-6) 100%)',
-        },
-      },
-      yellow: {
-        icon: IconBolt,
-        color: '#f59f00',
-        fill: '#f59f00',
-        css: {
-          gradient:
-            'linear-gradient(135deg, var(--mantine-color-yellow-4) 0%, var(--mantine-color-orange-5) 100%)',
-        },
-        classNames: {
-          btn: 'bg-gradient-to-r from-orange-500 to-yellow-400 hover:from-orange-600 hover:to-yellow-500 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 shadow min-w-[140px] font-bold transition-all duration-150 border-none text-white',
-          gradient: 'bg-gradient-to-r from-orange-500 to-yellow-400',
-          gradientText:
-            'bg-gradient-to-r from-orange-500 to-yellow-400 bg-clip-text text-transparent',
-        },
-      },
-      red: {
-        icon: IconBolt,
-        color: '#f03e3e',
-        fill: '#f03e3e',
-        classNames: {
-          btn: 'bg-gradient-to-r from-rose-500 to-pink-400 hover:from-rose-600 hover:to-pink-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 shadow min-w-[140px] font-bold transition-all duration-150 border-none text-white dark:border-rose-600',
-          gradient: 'bg-gradient-to-r from-rose-500 to-pink-400',
-          gradientText: 'bg-gradient-to-r from-rose-500 to-pink-400 bg-clip-text text-transparent',
-        },
-        css: {
-          gradient:
-            'linear-gradient(135deg, var(--mantine-color-red-5) 0%, var(--mantine-color-pink-6) 100%)',
-        },
-      },
-    },
+    ...withIcon(CurrencyThemeConfig.BUZZ, IconBolt),
+    themes: Object.fromEntries(
+      Object.entries(CurrencyThemeConfig.BUZZ.themes).map(([type, theme]) => [
+        type,
+        withIcon(theme, IconBolt),
+      ])
+    ) as Record<BuzzSpendType, CurrencyTheme>,
   },
-  [Currency.USD]: {
-    icon: IconCurrencyDollar,
-    color: '#f59f00',
-    fill: undefined,
-  },
-  [Currency.USDC]: {
-    icon: IconCurrencyDollar,
-    color: '#f59f00',
-    fill: undefined,
-  },
+  [Currency.USD]: withIcon(CurrencyThemeConfig.USD, IconCurrencyDollar),
+  [Currency.USDC]: withIcon(CurrencyThemeConfig.USDC, IconCurrencyDollar),
 };
 
 export function getBuzzCurrencyConfig(type: BuzzSpendType = 'yellow') {

--- a/src/shared/constants/donation-goal.constants.ts
+++ b/src/shared/constants/donation-goal.constants.ts
@@ -1,0 +1,2 @@
+export const MIN_DONATION_GOAL = 1000;
+export const MAX_DONATION_GOAL = 1000000000;

--- a/src/shared/constants/training.constants.ts
+++ b/src/shared/constants/training.constants.ts
@@ -1,6 +1,12 @@
 import type { MantineColor } from '@mantine/core';
 import { TrainingStatus } from '~/shared/utils/prisma/enums';
 
+// nb: these should be proper AIRs now
+export const blockedCustomModels = [
+  'civitai:53761@285757',
+  'urn:air:sd1:checkpoint:civitai:53761@285757',
+];
+
 export const trainingStatusFields: {
   [key in TrainingStatus]: { color: MantineColor; description: string };
 } = {

--- a/src/utils/buzz.ts
+++ b/src/utils/buzz.ts
@@ -8,7 +8,7 @@ import {
 } from '~/shared/constants/buzz.constants';
 import { Currency } from '~/shared/utils/prisma/enums';
 import { capitalize, getModelUrl } from '~/utils/string-helpers';
-import { getCurrencyConfig } from '~/shared/constants/currency.constants';
+import { getCurrencyThemeConfig } from '~/shared/constants/currency-theme.constants';
 
 export const parseBuzzTransactionDetails = (
   details?: BuzzTransactionDetails,
@@ -217,7 +217,7 @@ export const createBuzzDistributionGradient = ({
   if (entries.length <= 1) {
     if (entries.length === 0) return undefined;
 
-    const config = getCurrencyConfig({
+    const config = getCurrencyThemeConfig({
       currency: Currency.BUZZ,
       type: entries[0]?.[0] as BuzzSpendType,
     });
@@ -227,7 +227,7 @@ export const createBuzzDistributionGradient = ({
 
   let currentPct = 0;
   const gradientStops = entries.map(([accountType, pct]) => {
-    const typeConfig = getCurrencyConfig({
+    const typeConfig = getCurrencyThemeConfig({
       currency: Currency.BUZZ,
       type: accountType as BuzzSpendType,
     });

--- a/src/utils/file-display-helpers.ts
+++ b/src/utils/file-display-helpers.ts
@@ -6,21 +6,6 @@
 import type { ModelFileType } from '~/server/common/constants';
 import type { ModelType } from '~/shared/utils/prisma/enums';
 import { getFileExtension } from '~/utils/string-helpers';
-import {
-  IconAdjustments,
-  IconArrowsMaximize,
-  IconBrain,
-  IconCube,
-  IconEye,
-  IconFile3d,
-  IconFileSettings,
-  IconFileZip,
-  IconPackage,
-  IconPhotoScan,
-  IconSettings,
-  IconTopologyRing,
-  IconTypography,
-} from '@tabler/icons-react';
 
 /**
  * Metadata shape expected for file display functions
@@ -31,28 +16,6 @@ interface FileMetadata {
   format?: string | null;
   size?: string | null;
 }
-
-/**
- * Icon/color config for component types — shared between sidebar and file upload UI
- */
-export const componentTypeConfig: Record<
-  ModelFileComponentType,
-  { name: string; icon: typeof IconPhotoScan; color: string }
-> = {
-  Checkpoint: { name: 'Checkpoint', icon: IconCube, color: 'red' },
-  VAE: { name: 'VAE', icon: IconPhotoScan, color: 'purple' },
-  TextEncoder: { name: 'Text Encoder', icon: IconTypography, color: 'blue' },
-  UNet: { name: 'UNet', icon: IconBrain, color: 'orange' },
-  DiffusionModel: { name: 'Diffusion Model', icon: IconBrain, color: 'orange' },
-  CLIPVision: { name: 'CLIP Vision', icon: IconEye, color: 'green' },
-  CLIP: { name: 'CLIP', icon: IconTypography, color: 'violet' },
-  VisionLanguage: { name: 'VLM', icon: IconEye, color: 'grape' },
-  ControlNet: { name: 'ControlNet', icon: IconAdjustments, color: 'cyan' },
-  Upscaler: { name: 'Upscale Model', icon: IconArrowsMaximize, color: 'teal' },
-  Workflow: { name: 'Workflow', icon: IconTopologyRing, color: 'indigo' },
-  Config: { name: 'Config', icon: IconSettings, color: 'gray' },
-  Other: { name: 'Other', icon: IconPackage, color: 'gray' },
-};
 
 /**
  * ComfyUI-friendly display labels for model file types.
@@ -68,53 +31,6 @@ export const comfyFileTypeLabels: Record<string, string> = {
   Upscaler: 'Upscale Model',
   'Enhancement LoRA': 'Enhancement LoRA',
 };
-
-/**
- * Icon/color config for model file formats
- */
-export const fileFormatConfig: Record<string, { icon: typeof IconFile3d; color: string }> = {
-  SafeTensor: { icon: IconFile3d, color: 'blue' },
-  GGUF: { icon: IconFile3d, color: 'green' },
-  PickleTensor: { icon: IconFile3d, color: 'yellow' },
-  Other: { icon: IconFile3d, color: 'gray' },
-};
-
-/**
- * Get icon/color for a file based on its extension and metadata
- */
-export function getFileIconConfig(
-  fileName: string,
-  metadata?: { format?: string | null } | null
-): { icon: typeof IconFile3d; color: string } {
-  // ZIP files
-  if (fileName.endsWith('.zip')) {
-    return { icon: IconFileZip, color: 'yellow' };
-  }
-
-  // Check format from metadata
-  const format = metadata?.format;
-  if (format && format in fileFormatConfig) {
-    return fileFormatConfig[format];
-  }
-
-  // Infer from extension
-  if (fileName.endsWith('.safetensors')) {
-    return fileFormatConfig.SafeTensor;
-  }
-  if (fileName.endsWith('.gguf')) {
-    return fileFormatConfig.GGUF;
-  }
-
-  // Optional/misc files
-  if (fileName.endsWith('.json')) {
-    return { icon: IconFileSettings, color: 'gray' };
-  }
-  if (fileName.endsWith('.yaml') || fileName.endsWith('.yml')) {
-    return { icon: IconSettings, color: 'gray' };
-  }
-
-  return fileFormatConfig.Other;
-}
 
 /**
  * File types that are still honored on existing files but are no longer offered

--- a/src/utils/file-display-icons.ts
+++ b/src/utils/file-display-icons.ts
@@ -1,0 +1,87 @@
+import {
+  IconAdjustments,
+  IconArrowsMaximize,
+  IconBrain,
+  IconCube,
+  IconEye,
+  IconFile3d,
+  IconFileSettings,
+  IconFileZip,
+  IconPackage,
+  IconPhotoScan,
+  IconSettings,
+  IconTopologyRing,
+  IconTypography,
+} from '@tabler/icons-react';
+
+// Split out of `file-display-helpers` because these three exports are the only ones carrying icon
+// COMPONENTS, and the rest of that file is pure file-type data that eight server modules import.
+
+/**
+ * Icon/color config for component types — shared between sidebar and file upload UI
+ */
+export const componentTypeConfig: Record<
+  ModelFileComponentType,
+  { name: string; icon: typeof IconPhotoScan; color: string }
+> = {
+  Checkpoint: { name: 'Checkpoint', icon: IconCube, color: 'red' },
+  VAE: { name: 'VAE', icon: IconPhotoScan, color: 'purple' },
+  TextEncoder: { name: 'Text Encoder', icon: IconTypography, color: 'blue' },
+  UNet: { name: 'UNet', icon: IconBrain, color: 'orange' },
+  DiffusionModel: { name: 'Diffusion Model', icon: IconBrain, color: 'orange' },
+  CLIPVision: { name: 'CLIP Vision', icon: IconEye, color: 'green' },
+  CLIP: { name: 'CLIP', icon: IconTypography, color: 'violet' },
+  VisionLanguage: { name: 'VLM', icon: IconEye, color: 'grape' },
+  ControlNet: { name: 'ControlNet', icon: IconAdjustments, color: 'cyan' },
+  Upscaler: { name: 'Upscale Model', icon: IconArrowsMaximize, color: 'teal' },
+  Workflow: { name: 'Workflow', icon: IconTopologyRing, color: 'indigo' },
+  Config: { name: 'Config', icon: IconSettings, color: 'gray' },
+  Other: { name: 'Other', icon: IconPackage, color: 'gray' },
+};
+
+/**
+ * Icon/color config for model file formats
+ */
+export const fileFormatConfig: Record<string, { icon: typeof IconFile3d; color: string }> = {
+  SafeTensor: { icon: IconFile3d, color: 'blue' },
+  GGUF: { icon: IconFile3d, color: 'green' },
+  PickleTensor: { icon: IconFile3d, color: 'yellow' },
+  Other: { icon: IconFile3d, color: 'gray' },
+};
+
+/**
+ * Get icon/color for a file based on its extension and metadata
+ */
+export function getFileIconConfig(
+  fileName: string,
+  metadata?: { format?: string | null } | null
+): { icon: typeof IconFile3d; color: string } {
+  // ZIP files
+  if (fileName.endsWith('.zip')) {
+    return { icon: IconFileZip, color: 'yellow' };
+  }
+
+  // Check format from metadata
+  const format = metadata?.format;
+  if (format && format in fileFormatConfig) {
+    return fileFormatConfig[format];
+  }
+
+  // Infer from extension
+  if (fileName.endsWith('.safetensors')) {
+    return fileFormatConfig.SafeTensor;
+  }
+  if (fileName.endsWith('.gguf')) {
+    return fileFormatConfig.GGUF;
+  }
+
+  // Optional/misc files
+  if (fileName.endsWith('.json')) {
+    return { icon: IconFileSettings, color: 'gray' };
+  }
+  if (fileName.endsWith('.yaml') || fileName.endsWith('.yml')) {
+    return { icon: IconSettings, color: 'gray' };
+  }
+
+  return fileFormatConfig.Other;
+}


### PR DESCRIPTION
Split 4 of 4 out of #3958. See #3965 for the context on why that PR was held.

**Merge this one LAST of the four** — see the merge-order note below, it is not a preference.

## What changes

Four extractions, all moving literals verbatim so a non-React consumer can read the data without the icon *components* entering its graph.

- **`currency-theme.constants`** — colours, gradients and classNames with no `@tabler/icons-react`. `currency.constants` re-attaches the icons on top of it.
- **`file-display-icons`** — `componentTypeConfig`, `fileFormatConfig` and `getFileIconConfig`, the only three exports in `file-display-helpers` carrying icon components, where eight server modules import the rest of that file for pure file-type data.
- **`donation-goal.constants`** and **`training.constants`** — two constant sets that lived in React modules (`model-version.utils`, `TrainingCommon`) and are read by server schemas.

## Why this is not a behaviour change

Checked mechanically rather than by eye: every non-structural line deleted from the two large literals reappears verbatim in its destination. `file-display-helpers` -> `file-display-icons` came back 68 deleted lines, 0 unaccounted. `currency.constants` -> `currency-theme.constants` came back 76 deleted lines, 9 unaccounted — and all 9 are exactly the `icon:` entries the new `withIcon` helper re-attaches (5 `IconBolt`, 2 `IconCurrencyDollar`) plus a type-import line and a type header. All 67 colour/gradient/className literals are byte-identical.

`MIN_DONATION_GOAL` (1000), `MAX_DONATION_GOAL` (1000000000) and both `blockedCustomModels` AIR strings are unchanged, and every consumer moved with them — a repo-wide search for those three names returns hits only on the new specifiers.

`getCurrencyThemeConfig` mirrors `getCurrencyConfig` exactly. `getBuzzCurrencyConfig` keeps its documented `?? themes.yellow` fallback and is untouched. `CurrencyConfig[Currency.USD]` keeps an explicit `fill: undefined`, so the key is still own-present after the spread.

## Merge order: last, and re-check before merging

The `file-display-helpers` -> `file-display-icons` split is **hard**: no re-export is left behind. So any parallel branch that adds an import of those three symbols from `~/utils/file-display-helpers` **fails to compile on merge with no conflict marker to warn anyone**. There are zero such importers today, but that is a statement about today's `main` — please re-run the check immediately before merging.

🔑 The asymmetry with #3965 is forced, not chosen. `cf-images-utils` can re-export from `edge-url` because the barrel is the heavy side and the leaf is light. Here it is reversed — `file-display-helpers` is the light file that eight server modules import — so a re-export back into `file-display-icons` would put `@tabler/icons-react` straight into the server graph and undo the split. **A split can be soft only when the file keeping the old name is the heavier of the two.**

## Scope

**Production files: 18.** No test files.

One extra beyond #3958's version: that PR left two consecutive blank lines in `model-version.utils.ts` where the two exports were deleted, which Prettier collapses. Fixed here.

## What was run

Verified in a single box tenancy on `f07fa026a8`:

- **`pnpm run typecheck`: 0 errors in 143s**, exit 0.
- **`pnpm run test:unit:run`: 1066 files / 16809 tests**, 6 files / 16 tests failed — **identical to the base**. A control on `origin/main` `6f54a21085` in the same window over exactly those six failing files gives the same per-file counts (`1/11, 1/5, 1/6, 3/27, 7/9, 3/12`), and none of the six is touched by this PR. **Zero failures introduced.**
- **The residual-importer check was re-run on this branch** with the split applied, one invocation per symbol and no alternation: every occurrence of `componentTypeConfig`, `getFileIconConfig` and `fileFormatConfig` in `src` is either the definition in `file-display-icons.ts` or an import from it. Zero references left pointing at `file-display-helpers`.

⚠️ That last check is a statement about the tree it was run on. **Re-run it against `main` immediately before merging** — see the merge-order section.

<!-- provenance -->
- session: session_01SMWcYo5mJYs4tegt58hxLh
- voice-at-open: alexandra
- worktree: C:/Dev/Repos/work/wt-placement-durable (where every run below was taken)
- branches cut in: C:/Dev/Repos/work/wt-split-3958 — a scratch worktree, since removed
- base: main @ 6f54a21085
- handoff: _local/docs/plans/pr-3958-split-review.md @ ceaa030
- production files touched: 18 (verbatim literal relocation; one hard split, see merge order)



