### PR TITLE
feat(home): stop home blocks repeating each other's items

### DIFF
--- a/src/components/HomeBlocks/CollectionHomeBlock.tsx
+++ b/src/components/HomeBlocks/CollectionHomeBlock.tsx
@@ -24,7 +24,8 @@ import { NextLink as Link } from '~/components/NextLink/NextLink';
 import { ImageCard } from '~/components/Cards/ImageCard';
 import { ModelCard } from '~/components/Cards/ModelCard';
 import { HomeBlockWrapper } from '~/components/HomeBlocks/HomeBlockWrapper';
-import { ITEMS_PER_ROW, useCappedItems } from '~/components/HomeBlocks/homeBlockItems';
+import { ITEMS_PER_ROW } from '~/components/HomeBlocks/homeBlockItems';
+import { dedupeOrder, useDedupedCappedItems } from '~/components/HomeBlocks/homeBlockDedupe';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { PostCard } from '~/components/Cards/PostCard';
 import { ArticleCard } from '~/components/Cards/ArticleCard';
@@ -60,7 +61,7 @@ export const CollectionHomeBlock = ({ showAds, ...props }: Props) => {
   );
 };
 
-const CollectionHomeBlockContent = ({ homeBlockId, metadata }: Props) => {
+const CollectionHomeBlockContent = ({ homeBlockId, metadata, blockIndex }: Props) => {
   const { data: homeBlock, isLoading } = trpc.homeBlock.getHomeBlock.useQuery(
     { id: homeBlockId },
     { trpc: { context: { skipBatch: true } } }
@@ -74,7 +75,7 @@ const CollectionHomeBlockContent = ({ homeBlockId, metadata }: Props) => {
 
   const shuffled = useMemo(() => {
     if (!collection?.items) return [];
-    return shuffle(collection.items);
+    return shuffle([...collection.items]);
   }, [collection?.items]);
 
   const shuffledData = useMemo(() => shuffled.map((x) => x.data), [shuffled]);
@@ -87,11 +88,12 @@ const CollectionHomeBlockContent = ({ homeBlockId, metadata }: Props) => {
   });
 
   const maxPerUser = metadata.collection?.maxPerUser;
-  const items = useCappedItems(
-    filtered as { user?: { id: number } | null }[],
+  const items = useDedupedCappedItems(filtered as { id: number; user?: { id: number } | null }[], {
+    order: dedupeOrder(blockIndex),
+    entity: type,
     rows,
-    maxPerUser
-  ) as typeof filtered;
+    maxPerUser,
+  }) as typeof filtered;
 
   // useEffect(() => console.log({ homeBlock, filtered, items }), [homeBlock, filtered, items]);
 
@@ -272,4 +274,9 @@ const CollectionHomeBlockContent = ({ homeBlockId, metadata }: Props) => {
   );
 };
 
-type Props = { homeBlockId: number; metadata: HomeBlockMetaSchema; showAds?: boolean };
+type Props = {
+  homeBlockId: number;
+  metadata: HomeBlockMetaSchema;
+  showAds?: boolean;
+  blockIndex: number;
+};

--- a/src/components/HomeBlocks/FeaturedCollectionsHomeBlock.tsx
+++ b/src/components/HomeBlocks/FeaturedCollectionsHomeBlock.tsx
@@ -9,7 +9,8 @@ import { useApplyHiddenPreferences } from '~/components/HiddenPreferences/useApp
 import { ImagesProvider } from '~/components/Image/Providers/ImagesProvider';
 import { ReactionSettingsProvider } from '~/components/Reaction/ReactionSettingsProvider';
 import { FeaturedCollectionHeader } from '~/components/HomeBlocks/FeaturedCollectionHeader';
-import { ITEMS_PER_ROW, useCappedItems } from '~/components/HomeBlocks/homeBlockItems';
+import { ITEMS_PER_ROW } from '~/components/HomeBlocks/homeBlockItems';
+import { dedupeOrder, useDedupedCappedItems } from '~/components/HomeBlocks/homeBlockDedupe';
 import { contestCollectionReactionsHidden } from '~/components/Collections/collection.utils';
 import classes from '~/components/HomeBlocks/HomeBlock.module.scss';
 import type { HomeBlockMetaSchema } from '~/server/schema/home-block.schema';
@@ -18,9 +19,9 @@ import { CollectionMode } from '~/shared/utils/prisma/enums';
 import { shuffle } from '~/utils/array-helpers';
 import { trpc } from '~/utils/trpc';
 
-type Props = { homeBlockId: number; metadata: HomeBlockMetaSchema };
+type Props = { homeBlockId: number; metadata: HomeBlockMetaSchema; blockIndex: number };
 
-export const FeaturedCollectionsHomeBlock = ({ homeBlockId }: Props) => {
+export const FeaturedCollectionsHomeBlock = ({ homeBlockId, blockIndex }: Props) => {
   const { data: homeBlock, isLoading } = trpc.homeBlock.getHomeBlock.useQuery(
     { id: homeBlockId },
     { trpc: { context: { skipBatch: true } } }
@@ -35,6 +36,7 @@ export const FeaturedCollectionsHomeBlock = ({ homeBlockId }: Props) => {
       <HomeBlockWrapper py={32}>
         <FeaturedCollectionSection
           pick={{ collection: null, items: [], rows: 2, limit: 8 }}
+          order={dedupeOrder(blockIndex)}
           isLoading
         />
       </HomeBlockWrapper>
@@ -43,10 +45,10 @@ export const FeaturedCollectionsHomeBlock = ({ homeBlockId }: Props) => {
 
   return (
     <>
-      {picks.map((pick) =>
+      {picks.map((pick, subIndex) =>
         pick.collection ? (
           <HomeBlockWrapper key={pick.collection.id} py={32}>
-            <FeaturedCollectionSection pick={pick} />
+            <FeaturedCollectionSection pick={pick} order={dedupeOrder(blockIndex, subIndex)} />
           </HomeBlockWrapper>
         ) : null
       )}
@@ -54,19 +56,20 @@ export const FeaturedCollectionsHomeBlock = ({ homeBlockId }: Props) => {
   );
 };
 
-type SectionProps =
+type SectionProps = { order: number } & (
   | { pick: PickedFeaturedCollection; isLoading?: false }
   | {
       pick: { collection: null; items: []; rows: number; limit: number; maxPerUser?: number };
       isLoading: true;
-    };
+    }
+);
 
-function FeaturedCollectionSection({ pick, isLoading }: SectionProps) {
+function FeaturedCollectionSection({ pick, isLoading, order }: SectionProps) {
   const { collection, items: rawItems } = pick;
   const rows = pick.rows;
   const maxPerUser = pick.maxPerUser;
 
-  const shuffled = useMemo(() => shuffle(rawItems ?? []), [rawItems]);
+  const shuffled = useMemo(() => shuffle([...(rawItems ?? [])]), [rawItems]);
   const shuffledData = useMemo(() => shuffled.map((x: { data: unknown }) => x.data), [shuffled]);
   const firstType = (shuffled[0] as { type?: string } | undefined)?.type ?? 'image';
   const type = firstType as 'image' | 'model' | 'post' | 'article';
@@ -76,7 +79,12 @@ function FeaturedCollectionSection({ pick, isLoading }: SectionProps) {
     data: shuffledData as any,
   });
 
-  const items = useCappedItems(filtered as { user?: { id: number } | null }[], rows, maxPerUser);
+  const items = useDedupedCappedItems(filtered as { id: number; user?: { id: number } | null }[], {
+    order,
+    entity: type,
+    rows,
+    maxPerUser,
+  });
 
   const title = collection?.name ?? 'Collection';
   const link = collection ? `/collections/${collection.id}` : '#';

--- a/src/components/HomeBlocks/FeaturedModelVersionHomeBlock.tsx
+++ b/src/components/HomeBlocks/FeaturedModelVersionHomeBlock.tsx
@@ -15,6 +15,8 @@ import { IconArrowRight, IconCategory, IconInfoCircle } from '@tabler/icons-reac
 import { useMemo } from 'react';
 import { ModelCard } from '~/components/Cards/ModelCard';
 import { useApplyHiddenPreferences } from '~/components/HiddenPreferences/useApplyHiddenPreferences';
+import { ITEMS_PER_ROW } from '~/components/HomeBlocks/homeBlockItems';
+import { dedupeOrder, useDedupedCappedItems } from '~/components/HomeBlocks/homeBlockDedupe';
 
 import { HomeBlockWrapper } from '~/components/HomeBlocks/HomeBlockWrapper';
 import { ImagesProvider } from '~/components/Image/Providers/ImagesProvider';
@@ -29,7 +31,11 @@ import { trpc } from '~/utils/trpc';
 import classes from '~/components/HomeBlocks/HomeBlock.module.scss';
 import clsx from 'clsx';
 
-type Props = { homeBlockId: number; metadata: Pick<HomeBlockMetaSchema, 'title' | 'description'> };
+type Props = {
+  homeBlockId: number;
+  metadata: Pick<HomeBlockMetaSchema, 'title' | 'description'>;
+  blockIndex: number;
+};
 
 export const FeaturedModelVersionHomeBlock = ({ ...props }: Props) => {
   return (
@@ -40,9 +46,8 @@ export const FeaturedModelVersionHomeBlock = ({ ...props }: Props) => {
 };
 
 const ROWS = 2;
-const ITEMS_PER_ROW = 7;
 
-const FeaturedModelVersionHomeBlockContent = ({ homeBlockId, metadata }: Props) => {
+const FeaturedModelVersionHomeBlockContent = ({ homeBlockId, metadata, blockIndex }: Props) => {
   const features = useFeatureFlags();
   const currentUser = useCurrentUser();
 
@@ -55,7 +60,7 @@ const FeaturedModelVersionHomeBlockContent = ({ homeBlockId, metadata }: Props) 
 
   const shuffled = useMemo(() => {
     if (!featuredModels) return [];
-    return shuffle(featuredModels);
+    return shuffle([...featuredModels]);
   }, [featuredModels]);
 
   const { loadingPreferences, items: filtered } = useApplyHiddenPreferences({
@@ -63,10 +68,11 @@ const FeaturedModelVersionHomeBlockContent = ({ homeBlockId, metadata }: Props) 
     data: shuffled,
   });
 
-  const items = useMemo(() => {
-    const itemsToShow = ITEMS_PER_ROW * ROWS;
-    return filtered.slice(0, itemsToShow);
-  }, [filtered]);
+  const items = useDedupedCappedItems(filtered, {
+    order: dedupeOrder(blockIndex),
+    entity: 'model',
+    rows: ROWS,
+  });
 
   const title = metadata.title ?? 'Featured Models';
   const useGrid = metadata.description && !currentUser;

--- a/src/components/HomeBlocks/FeedHomeBlock.tsx
+++ b/src/components/HomeBlocks/FeedHomeBlock.tsx
@@ -16,7 +16,8 @@ import { ImageCard } from '~/components/Cards/ImageCard';
 import { ModelCard } from '~/components/Cards/ModelCard';
 import { HomeBlockWrapper } from '~/components/HomeBlocks/HomeBlockWrapper';
 import { useApplyHiddenPreferences } from '~/components/HiddenPreferences/useApplyHiddenPreferences';
-import { ITEMS_PER_ROW, useCappedItems } from '~/components/HomeBlocks/homeBlockItems';
+import { ITEMS_PER_ROW } from '~/components/HomeBlocks/homeBlockItems';
+import { dedupeOrder, useDedupedCappedItems } from '~/components/HomeBlocks/homeBlockDedupe';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { ImagesProvider } from '~/components/Image/Providers/ImagesProvider';
 import { CustomMarkdown } from '~/components/Markdown/CustomMarkdown';
@@ -27,7 +28,7 @@ import { shuffle } from '~/utils/array-helpers';
 import { trpc } from '~/utils/trpc';
 import classes from '~/components/HomeBlocks/HomeBlock.module.scss';
 
-type Props = { homeBlockId: number; metadata: HomeBlockMetaSchema };
+type Props = { homeBlockId: number; metadata: HomeBlockMetaSchema; blockIndex: number };
 
 export const FeedHomeBlock = (props: Props) => (
   <HomeBlockWrapper py={32}>
@@ -40,7 +41,7 @@ export const FeedHomeBlock = (props: Props) => (
  * mirrors CollectionHomeBlock (same grid, rows and per-user cap) — the difference is
  * only where the items come from.
  */
-const FeedHomeBlockContent = ({ homeBlockId, metadata }: Props) => {
+const FeedHomeBlockContent = ({ homeBlockId, metadata, blockIndex }: Props) => {
   const { data: homeBlock, isLoading } = trpc.homeBlock.getHomeBlock.useQuery(
     { id: homeBlockId },
     { trpc: { context: { skipBatch: true } } }
@@ -127,9 +128,19 @@ const FeedHomeBlockContent = ({ homeBlockId, metadata }: Props) => {
     isLoading || !feedItems ? (
       <FeedSkeleton rows={rows} />
     ) : feedItems.entity === 'images' ? (
-      <ImageFeedGrid items={feedItems.items} rows={rows} maxPerUser={metadata.feed?.maxPerUser} />
+      <ImageFeedGrid
+        items={feedItems.items}
+        rows={rows}
+        maxPerUser={metadata.feed?.maxPerUser}
+        order={dedupeOrder(blockIndex)}
+      />
     ) : (
-      <ModelFeedGrid items={feedItems.items} rows={rows} maxPerUser={metadata.feed?.maxPerUser} />
+      <ModelFeedGrid
+        items={feedItems.items}
+        rows={rows}
+        maxPerUser={metadata.feed?.maxPerUser}
+        order={dedupeOrder(blockIndex)}
+      />
     );
 
   return (
@@ -170,19 +181,25 @@ function useShuffled<T>(items: T[]) {
   return useMemo(() => shuffle([...items]), [items]);
 }
 
-type GridProps<T> = { items: T; rows: number; maxPerUser?: number };
+type GridProps<T> = { items: T; rows: number; maxPerUser?: number; order: number };
 
 function ImageFeedGrid({
   items,
   rows,
   maxPerUser,
+  order,
 }: GridProps<Extract<FeedBlockItems, { entity: 'images' }>['items']>) {
   const rotated = useShuffled(items);
   const { loadingPreferences, items: filtered } = useApplyHiddenPreferences({
     type: 'images',
     data: rotated,
   });
-  const visible = useCappedItems(filtered, rows, maxPerUser);
+  const visible = useDedupedCappedItems(filtered, {
+    order,
+    entity: 'image',
+    rows,
+    maxPerUser,
+  });
 
   if (loadingPreferences) return <FeedSkeleton rows={rows} />;
 
@@ -203,13 +220,19 @@ function ModelFeedGrid({
   items,
   rows,
   maxPerUser,
+  order,
 }: GridProps<Extract<FeedBlockItems, { entity: 'models' }>['items']>) {
   const rotated = useShuffled(items);
   const { loadingPreferences, items: filtered } = useApplyHiddenPreferences({
     type: 'models',
     data: rotated,
   });
-  const visible = useCappedItems(filtered, rows, maxPerUser);
+  const visible = useDedupedCappedItems(filtered, {
+    order,
+    entity: 'model',
+    rows,
+    maxPerUser,
+  });
 
   if (loadingPreferences) return <FeedSkeleton rows={rows} />;
 

--- a/src/components/HomeBlocks/__tests__/homeBlockDedupe.test.ts
+++ b/src/components/HomeBlocks/__tests__/homeBlockDedupe.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import {
+  claimedBelow,
+  claimKey,
+  dedupeOrder,
+  selectDedupedItems,
+} from '~/components/HomeBlocks/homeBlockDedupe';
+
+const item = (id: number, userId = id) => ({ id, user: { id: userId } });
+const takenSet = (entity: string, ids: number[]) => new Set(ids.map((id) => claimKey(entity, id)));
+
+describe('dedupeOrder', () => {
+  it('orders blocks by render position, and sub-lists within a block', () => {
+    expect(dedupeOrder(1)).toBeLessThan(dedupeOrder(2));
+    expect(dedupeOrder(7, 0)).toBeLessThan(dedupeOrder(7, 1));
+    expect(dedupeOrder(7, 999)).toBeLessThan(dedupeOrder(8));
+  });
+
+  it('clamps a runaway subIndex rather than colliding with the next block', () => {
+    // Two blocks sharing an order would silently overwrite each other's claims, so the last
+    // sub-list slot saturates instead.
+    expect(dedupeOrder(7, 5000)).toBeLessThan(dedupeOrder(8));
+    expect(dedupeOrder(7, 5000)).toEqual(dedupeOrder(7, 999));
+  });
+});
+
+describe('selectDedupedItems', () => {
+  it('drops what an earlier block claimed and backfills from the overfetch', () => {
+    const out = selectDedupedItems(
+      [1, 2, 3, 4, 5].map((id) => item(id)),
+      {
+        taken: takenSet('image', [1, 2]),
+        entity: 'image',
+        itemsToShow: 3,
+      }
+    );
+    expect(out.map((x) => x.id)).toEqual([3, 4, 5]);
+  });
+
+  it('does not suppress an id claimed under a different entity', () => {
+    // Guards the entity segment in the key. Written so it fails if the key were just the id:
+    // ids 1 and 2 are claimed as models, and this block would come back [3] without them.
+    const out = selectDedupedItems(
+      [1, 2, 3].map((id) => item(id)),
+      {
+        taken: takenSet('model', [1, 2]),
+        entity: 'image',
+        itemsToShow: 2,
+      }
+    );
+    expect(out.map((x) => x.id)).toEqual([1, 2]);
+  });
+
+  it('readmits duplicates behind unclaimed items rather than rendering a short row', () => {
+    const out = selectDedupedItems(
+      [1, 2, 3, 4].map((id) => item(id)),
+      {
+        taken: takenSet('image', [1, 2, 3]),
+        entity: 'image',
+        itemsToShow: 3,
+      }
+    );
+    // 4 is the only unclaimed item, so it leads and two duplicates fill the row behind it.
+    expect(out[0].id).toEqual(4);
+    expect(out).toHaveLength(3);
+  });
+
+  it('prefers unclaimed items over claimed ones when it cannot fill either way', () => {
+    const out = selectDedupedItems([item(1), item(2), item(3), item(4)], {
+      taken: takenSet('image', [1, 2]),
+      entity: 'image',
+      itemsToShow: 3,
+    });
+    expect(out.slice(0, 2).map((x) => x.id)).toEqual([3, 4]);
+    expect([1, 2]).toContain(out[2].id);
+  });
+
+  it('counts readmitted duplicates against maxPerUser, so a short row is still possible', () => {
+    // The documented limit of the backfill: creator 10 is capped at 1, so its duplicate cannot
+    // fill the third slot even though an item exists for it.
+    const out = selectDedupedItems([item(1, 10), item(2, 10), item(3, 20)], {
+      taken: takenSet('image', [1, 2]),
+      entity: 'image',
+      itemsToShow: 3,
+      maxPerUser: 1,
+    });
+    expect(out.map((x) => x.id)).toEqual([3, 1]);
+  });
+
+  it('is a no-op when nothing has been claimed', () => {
+    const out = selectDedupedItems(
+      [1, 2, 3, 4].map((id) => item(id)),
+      {
+        taken: new Set<string>(),
+        entity: 'image',
+        itemsToShow: 3,
+      }
+    );
+    expect(out.map((x) => x.id)).toEqual([1, 2, 3]);
+  });
+});
+
+describe('claimedBelow', () => {
+  const claims = {
+    [dedupeOrder(0)]: ['image:1'],
+    [dedupeOrder(1)]: ['image:2'],
+    [dedupeOrder(2)]: ['image:3'],
+  };
+
+  it('reads only the orders ahead of the block', () => {
+    expect(claimedBelow(claims, dedupeOrder(1))).toEqual(['image:1']);
+  });
+
+  it('excludes the block’s own order, which would let it consume its own claim', () => {
+    expect(claimedBelow(claims, dedupeOrder(0))).toEqual([]);
+  });
+
+  it('accumulates every earlier order, not just the previous one', () => {
+    expect(claimedBelow(claims, dedupeOrder(2)).sort()).toEqual(['image:1', 'image:2']);
+  });
+});

--- a/src/components/HomeBlocks/homeBlockDedupe.browser.test.tsx
+++ b/src/components/HomeBlocks/homeBlockDedupe.browser.test.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { describe, expect, test } from 'vitest';
+import { page } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import { dedupeOrder, useDedupedCappedItems } from '~/components/HomeBlocks/homeBlockDedupe';
+import { ITEMS_PER_ROW } from '~/components/HomeBlocks/homeBlockItems';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import '../../../test/component-setup';
+
+/**
+ * Covers the effect lifecycle, which the pure-function suite cannot reach: a block that fails to
+ * release its claim on unmount goes on suppressing those items for every later block, and nothing
+ * looks wrong — the later block just quietly shows different items forever.
+ */
+
+const pool = Array.from({ length: ITEMS_PER_ROW * 2 }, (_, i) => ({ id: i + 1, user: { id: 1 } }));
+const firstRow = pool
+  .slice(0, ITEMS_PER_ROW)
+  .map((x) => x.id)
+  .join(',');
+
+function Block({ order, testId }: { order: number; testId: string }) {
+  const visible = useDedupedCappedItems(pool, { order, entity: 'image', rows: 1 });
+  return <div data-testid={testId}>{visible.map((x) => x.id).join(',')}</div>;
+}
+
+function Page() {
+  const [showFirst, setShowFirst] = useState(true);
+  return (
+    <>
+      {showFirst && <Block order={dedupeOrder(0)} testId="first" />}
+      <Block order={dedupeOrder(1)} testId="second" />
+      <button onClick={() => setShowFirst(false)}>drop first</button>
+    </>
+  );
+}
+
+describe('useDedupedCappedItems lifecycle', () => {
+  test('the later block avoids the earlier one, then reclaims its items once it unmounts', async () => {
+    render(<Page />);
+
+    // Every state asserted here is absorbing — nothing is on a timer — so no assertion is racing
+    // a value that leaves.
+    await expect.element(page.getByTestId('first')).toHaveTextContent(firstRow);
+    await expect.element(page.getByTestId('second')).not.toHaveTextContent(firstRow);
+
+    await page.getByRole('button', { name: 'drop first' }).click();
+
+    await expect.element(page.getByTestId('second')).toHaveTextContent(firstRow);
+  });
+});

--- a/src/components/HomeBlocks/homeBlockDedupe.ts
+++ b/src/components/HomeBlocks/homeBlockDedupe.ts
@@ -1,0 +1,109 @@
+import { useEffect, useMemo } from 'react';
+import { create } from 'zustand';
+import { useShallow } from 'zustand/react/shallow';
+import { capPerUser, ITEMS_PER_ROW } from '~/components/HomeBlocks/homeBlockItems';
+
+type ClaimState = {
+  claims: Record<number, string[]>;
+  setClaims: (order: number, keys: string[]) => void;
+  clearClaims: (order: number) => void;
+};
+
+const useHomeBlockClaims = create<ClaimState>((set) => ({
+  claims: {},
+  setClaims: (order, keys) => set((state) => ({ claims: { ...state.claims, [order]: keys } })),
+  clearClaims: (order) =>
+    set((state) => {
+      if (!(order in state.claims)) return state;
+      const next = { ...state.claims };
+      delete next[order];
+      return { claims: next };
+    }),
+}));
+
+const MAX_SUB_LISTS = 1000;
+
+/**
+ * Precedence is render position, not whichever request resolved first — otherwise a viewer's grid
+ * would depend on network timing. `subIndex` orders the lists inside a block that renders several,
+ * and is clamped so it can never reach the next block's slot: two blocks sharing an order would
+ * silently overwrite each other's claims.
+ */
+export const dedupeOrder = (blockIndex: number, subIndex = 0) =>
+  blockIndex * MAX_SUB_LISTS + Math.min(subIndex, MAX_SUB_LISTS - 1);
+
+// Model 42 and image 42 are different things.
+export const claimKey = (entity: string, id: number) => `${entity}:${id}`;
+
+/**
+ * Only the orders ahead of a block can affect it. Including its own order would let a block consume
+ * the claim it just published and empty itself.
+ */
+export const claimedBelow = (claims: Record<number, string[]>, order: number) =>
+  Object.entries(claims)
+    .filter(([claimOrder]) => Number(claimOrder) < order)
+    .flatMap(([, keys]) => keys);
+
+type DedupeSelection = {
+  taken: Set<string>;
+  entity: string;
+  itemsToShow: number;
+  maxPerUser?: number;
+};
+
+/**
+ * Duplicates go to the back rather than being dropped, so they fill slots only once the unclaimed
+ * items run out. `maxPerUser` still applies to them, so a readmitted duplicate from a capped-out
+ * creator does not fill a slot — this narrows short rows, it does not rule them out.
+ */
+export function selectDedupedItems<T extends { id: number; user?: { id: number } | null }>(
+  items: T[],
+  { taken, entity, itemsToShow, maxPerUser }: DedupeSelection
+) {
+  const preferred: T[] = [];
+  const duplicates: T[] = [];
+  for (const item of items) {
+    (taken.has(claimKey(entity, item.id)) ? duplicates : preferred).push(item);
+  }
+  return capPerUser([...preferred, ...duplicates], itemsToShow, maxPerUser);
+}
+
+type DedupeOptions = {
+  order: number;
+  entity: string;
+  rows: number;
+  maxPerUser?: number;
+};
+
+export function useDedupedCappedItems<T extends { id: number; user?: { id: number } | null }>(
+  items: T[],
+  { order, entity, rows, maxPerUser }: DedupeOptions
+) {
+  // `useShallow` compares the flattened keys, so a block publishing *below* this one — whose keys
+  // this block ignores anyway — does not re-derive it.
+  const takenKeys = useHomeBlockClaims(useShallow((state) => claimedBelow(state.claims, order)));
+  const setClaims = useHomeBlockClaims((state) => state.setClaims);
+  const clearClaims = useHomeBlockClaims((state) => state.clearClaims);
+
+  const visible = useMemo(
+    () =>
+      selectDedupedItems(items, {
+        taken: new Set(takenKeys),
+        entity,
+        itemsToShow: ITEMS_PER_ROW * rows,
+        maxPerUser,
+      }),
+    [takenKeys, entity, items, rows, maxPerUser]
+  );
+
+  // Reading only lower orders and writing only our own keeps this acyclic: publishing cannot change
+  // what this block itself consumed. Keyed on the joined string so an unchanged claim never
+  // republishes, whatever `visible`'s identity does.
+  const publishedKeys = visible.map((item) => claimKey(entity, item.id)).join(',');
+  useEffect(() => {
+    setClaims(order, publishedKeys ? publishedKeys.split(',') : []);
+    return () => clearClaims(order);
+  }, [order, publishedKeys, setClaims, clearClaims]);
+
+  return visible;
+}

--- a/src/components/HomeBlocks/homeBlockItems.ts
+++ b/src/components/HomeBlocks/homeBlockItems.ts
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import { HOME_BLOCK_ITEMS_PER_ROW } from '~/shared/constants/home-block.constants';
 
 export const ITEMS_PER_ROW = HOME_BLOCK_ITEMS_PER_ROW;
@@ -35,15 +34,4 @@ export function capPerUser<T extends CappableItem>(
     capped.push(item);
   }
   return capped;
-}
-
-export function useCappedItems<T extends CappableItem>(
-  items: T[],
-  rows: number,
-  maxPerUser?: number
-) {
-  return useMemo(
-    () => capPerUser(items, ITEMS_PER_ROW * rows, maxPerUser),
-    [items, rows, maxPerUser]
-  );
 }

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -68,19 +68,28 @@ export function Home() {
               return (
                 <React.Fragment key={homeBlock.id}>
                   {homeBlock.type === HomeBlockType.Collection && (
-                    <CollectionHomeBlock homeBlockId={homeBlock.id} metadata={homeBlock.metadata} />
+                    <CollectionHomeBlock
+                      homeBlockId={homeBlock.id}
+                      metadata={homeBlock.metadata}
+                      blockIndex={i}
+                    />
                   )}
                   {homeBlock.type === HomeBlockType.FeaturedCollections && (
                     <FeaturedCollectionsHomeBlock
                       homeBlockId={homeBlock.id}
                       metadata={homeBlock.metadata}
+                      blockIndex={i}
                     />
                   )}
                   {/* {homeBlock.type === HomeBlockType.Announcement && (
                     <AnnouncementHomeBlock homeBlockId={homeBlock.id} />
                   )} */}
                   {homeBlock.type === HomeBlockType.Feed && (
-                    <FeedHomeBlock homeBlockId={homeBlock.id} metadata={homeBlock.metadata} />
+                    <FeedHomeBlock
+                      homeBlockId={homeBlock.id}
+                      metadata={homeBlock.metadata}
+                      blockIndex={i}
+                    />
                   )}
                   {homeBlock.type === HomeBlockType.Leaderboard && (
                     <LeaderboardsHomeBlock
@@ -104,6 +113,7 @@ export function Home() {
                     <FeaturedModelVersionHomeBlock
                       homeBlockId={homeBlock.id}
                       metadata={homeBlock.metadata}
+                      blockIndex={i}
                     />
                   )}
                   {showAds && <AdUnitTop className="py-3" />}


### PR DESCRIPTION
## Problem

Featured Images, the New & Upcoming Creators feed and Featured Collections draw from overlapping pools, so the same picture shows up two or three times on one screen.

Measured on prod:

- **81 of the 200 most recent items in collection 107 (Featured Images) are also in the featured-collections pool** — 40%
- **2,462 images sit in more than one of that pool's 12 collections**, so Featured Collections can repeat against *itself*
- one live snapshot had **13 items shared between Featured Images and the images Feed block**

## Why this is client-side

Every block resolves in isolation — its own tRPC call (all six components set `skipBatch: true`), its own Redis entry, its own TTL, and Collection entries are keyed by collection id and shared across ~113k cloned blocks. There is no point on the server where the whole page's content is known at once.

So this goes where the choice already lives. Each block already runs `getHomeBlock → shuffle → useApplyHiddenPreferences → cap`, and the server already ships ~4x the visible count so `maxPerUser` has a pool to thin. **Dedupe is one more filter in that pipeline, and the existing overfetch is what backfills it.**

## Design

`homeBlockDedupe.ts` holds a page-scoped claim registry. A block takes the visible slice preferring items no earlier block claimed, then publishes what survived.

- **Precedence is render position**, not whichever request landed first — otherwise the grid would depend on network timing.
- **Acyclic**: a block reads only lower orders and writes only its own, so publishing cannot change what it consumed. It subscribes via `useShallow` to just those lower keys, so a block publishing *below* it does not re-derive it.
- **`dedupeOrder(blockIndex, subIndex)`** lets FeaturedCollections' lists dedupe against each other as well as against earlier blocks. `subIndex` is clamped so it can never reach the next block's slot — two blocks sharing an order would silently overwrite each other's claims.
- **Claims are namespaced by entity** — model 42 and image 42 are different things.
- **Shortfall readmits duplicates** behind the unclaimed items. `maxPerUser` still applies to them, so this *narrows* short rows rather than ruling them out; that limit is stated in the code and pinned by a test rather than left as an implied guarantee.

## Also in here

- `FeaturedModelVersionHomeBlock` had its own local `ITEMS_PER_ROW = 7` and a bare `.slice()`. Folded onto the shared helper.
- `useCappedItems` deleted — nothing calls it after this change.
- Three blocks passed a React Query cache array straight to `shuffle`, which sorts **in place** (`array-helpers.ts:85`). `FeedHomeBlock` already copied first and said why; the other three now do too. The ids these produce feed a shared registry, so mutating cache data other consumers read matters more than it did.

## Verification

- `pnpm run typecheck` — clean
- `pnpm run test:lint-rules` — 220 pass
- `homeBlockDedupe.test.ts` (11) + `homeBlockItems.test.ts` (5) — pass
- `homeBlockDedupe.browser.test.tsx` (1) — pass
- `pnpm exec eslint` over `src/components/HomeBlocks` + the home page — 0 errors; warnings are pre-existing (identical set on `main`)

**Mutation-checked**, each reverting in isolation and failing fast with a legible assertion:

| mutation | result |
|---|---|
| block reads its own order (`<` → `<=`) | 3 failures, `expected [ 'image:1', 'image:2' ] to deeply equal [ 'image:1' ]` |
| drop the `subIndex` clamp | `expected 12000 to be less than 8000` |
| discard duplicates instead of readmitting | `expected [ { id: 4 } ] to have a length of 3 but got 1` |
| drop the entity from the claim key | `expected [ 3, 1 ] to deeply equal [ 1, 2 ]` |
| **delete the unmount `clearClaims`** | browser test fails |

That last one is why there is a browser test at all: the pure suite cannot reach the effect lifecycle, and an orphaned claim suppresses items for every later block forever with nothing on the page looking wrong.

## Review history

Adversarial review of the first revision found: every block subscribed to the whole claims map (O(n²) re-derivations and a loss of referential stability for `<ImagesProvider images={...}>`); `useCappedItems` left dead; the `subIndex` scheme colliding silently at 100 sub-lists with the test pinned one step from the cliff; the duplicate-readmission comment promising something `maxPerUser` does not deliver; two prop conventions across four call sites; and 4 of 7 tests passing under a full revert. All addressed here.

## Not in scope

The other half — system home blocks being fully cloned per user rather than pointed at, which is why ~50-60k customized users have never seen Featured Collections, and 21,654 render a duplicate Announcements block. Scoped separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DZLqfdGtSK1ymgkxeNDLa