### PR TITLE
perf(tests): inline uniq and re-point the on-site predicate

### DIFF
--- a/src/server/services/post.service.ts
+++ b/src/server/services/post.service.ts
@@ -2,7 +2,7 @@ import { Prisma } from '@prisma/client';
 import { uniq } from 'lodash-es';
 import type { SessionUser } from '~/types/session';
 import * as z from 'zod';
-import { isMadeOnSite } from '~/components/ImageGeneration/GenerationForm/generation.utils';
+import { isImageMetaOnSite } from '~/server/utils/image-onsite';
 import { env } from '~/env/server';
 import { BlockedReason, PostSort, SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { dbRead, dbWrite } from '~/server/db/client';
@@ -1496,7 +1496,7 @@ export const addResourceToPostImage = async ({
     throw throwNotFoundError(`Image${imageIds.length > 1 ? 's' : ''} not found.`);
   }
   // TODO technically this can be called with a combo of on/off site imgs
-  if (images.some((i) => i.type !== MediaType.video && isMadeOnSite(i.meta as ImageMetaProps))) {
+  if (images.some((i) => i.type !== MediaType.video && isImageMetaOnSite(i.meta as ImageMetaProps))) {
     throw throwBadRequestError('Cannot add resources to on-site generations.');
   }
 

--- a/src/utils/array-helpers.ts
+++ b/src/utils/array-helpers.ts
@@ -1,6 +1,11 @@
-import { uniq } from 'instantsearch.js/es/lib/utils';
 import { uniqBy } from 'lodash-es';
 import { ModelType } from '~/shared/utils/prisma/enums';
+
+// Inlined from `instantsearch.js/es/lib/utils`, whose barrel costs ~0.7s to import in a fresh
+// process for this one four-line function. Same first-index-wins semantics, NaN included.
+function uniq<T>(array: T[]): T[] {
+  return array.filter((value, index, self) => self.indexOf(value) === index);
+}
 
 export const getRandom = <T>(array: T[]) => array[Math.floor(Math.random() * array.length)];
 

--- a/src/utils/array-helpers.ts
+++ b/src/utils/array-helpers.ts
@@ -1,8 +1,9 @@
 import { uniqBy } from 'lodash-es';
 import { ModelType } from '~/shared/utils/prisma/enums';
 
-// Inlined from `instantsearch.js/es/lib/utils`, whose barrel costs ~0.7s to import in a fresh
-// process for this one four-line function. Same first-index-wins semantics, NaN included.
+// Inlined from `instantsearch.js/es/lib/utils` to keep that barrel out of the graph for one
+// four-line function. First index wins, and it drops every NaN (indexOf(NaN) is -1). Do not
+// rewrite as `new Set` — that keeps one NaN, and every test still passes.
 function uniq<T>(array: T[]): T[] {
   return array.filter((value, index, self) => self.indexOf(value) === index);
 }


### PR DESCRIPTION
Split 5 of 5 out of #3958, alongside #3965 (A), #3968 (C), #3966 (D) and #3967 (B). See #3965 for why that PR was held.

## ⚠️ Read this first: unlike the other four, this one is not a relocation

A, C, D and B are all moves — the same function object reached through a different specifier, or a literal relocated verbatim. **This PR contains new code**: four lines of it. It was reviewed and approved on that basis rather than sliding in under the "it's just import cycles" heading that covers the others, and it is a separate PR so that a reviewer in six weeks does not have to work out why it is different.

## Change 1 — `uniq` inlined into `array-helpers.ts` (new code)

`~/utils/array-helpers` imported `uniq` from `instantsearch.js/es/lib/utils`, which pulls that package's barrel for one four-line function. The function is inlined instead.

**Equivalence, which is what makes a four-line copy defensible.** Upstream, `node_modules/instantsearch.js/es/lib/utils/uniq.js`:

```js
export function uniq(array) {
  return array.filter(function (value, index, self) {
    return self.indexOf(value) === index;
  });
}
```

The inlined version is the same expression. `Array.prototype.indexOf` uses strict equality, so the two agree on every case that distinguishes implementations of this function:

- **duplicates** — first index wins, in both
- **`-0` / `+0`** — `indexOf` treats them as equal, so both collapse them, unlike a `Set`- or `includes`-based `uniq` would
- **`NaN`** — `indexOf(NaN)` is always `-1` and `index` is never `-1`, so **both drop every `NaN`**, again unlike a `Set`-based implementation

That last pair is the reason this is an inline of the original rather than a rewrite: the obvious modern spellings (`[...new Set(a)]`, `filter(includes)`) are **not** equivalent here, and swapping to one would be a silent behaviour change wearing a cleanup's clothes.

⚠️ **The "~0.7s to import in a fresh process" figure in the code comment is the original author's and nobody has re-measured it.** It is not a measured win being claimed by this PR. The equivalence above is verified; the cost is inherited.

## Change 2 — `isMadeOnSite` → `isImageMetaOnSite` in `post.service.ts`

`post.service` imported `isMadeOnSite` from `~/components/ImageGeneration/GenerationForm/generation.utils` — a client module — to evaluate one predicate. It now calls `isImageMetaOnSite` from `~/server/utils/image-onsite` directly.

**This is the same function, one hop shorter.** `generation.utils.ts:300` is:

```ts
export const isMadeOnSite = (meta: ImageMetaProps | null) => isImageMetaOnSite(meta);
```

a one-line alias over the exact function being switched to. Both `image-onsite.ts` and that alias pre-date this branch and neither is modified here.

**Why it was checked hardest, and the reviewer's retraction:** this predicate gates a user-facing throw — `post.service.ts:1499`, `Cannot add resources to on-site generations.` — so a predicate disagreeing by even one case would be a real API behaviour change on `addResourceToPostImage`, not a performance change. It was the prime suspect of the whole 72-file review and it is nothing; the alias is the reason. Recorded here rather than only in the review, because "we checked the scary one and it was fine" is worth as much to a later reader as any finding.

Removing this edge also drops `generation.utils.ts:29` from the server graph — a module-scope `generationStatusSchema.parse({})` that can throw at import. Strictly safer.

## Scope

**Production files: 2.** No test files.

`post.service.ts` is split at hunk level between this PR and #3965, which takes only its `getEdgeUrl` line.

## What was run

**Nothing on this branch.** It is cut from the same `main` as the other four splits, which were verified in a single box tenancy (typecheck 0 errors on all four; full unit suite on C, D and B at 1066 files / 16809 tests, per-file identical to a control taken on `main` in the same window, zero failures introduced). **This branch has had no run of its own** and should get typecheck plus the unit suite before it merges.

## Review note

An independent reviewer (scarlet) caught that the code comment on the inlined `uniq` said *"Same first-index-wins semantics, NaN included"*, which reads as "NaN is kept" — the opposite of what it does — and that the wording invited exactly the rewrite it exists to prevent. Fixed in `bbcc239bd5`; the comment now states that every `NaN` is dropped and warns off `new Set`.

She also strengthened the case for the change: `array-helpers.ts` was the **only** importer of `instantsearch.js/es/lib/utils` anywhere in `src`, so the barrel leaves the graph entirely rather than merely leaving this file's.

<!-- provenance -->
- session: session_01SMWcYo5mJYs4tegt58hxLh
- voice-at-open: alexandra
- worktree: C:/Dev/Repos/work/wt-placement-durable (where every run below was taken)
- branches cut in: C:/Dev/Repos/work/wt-split-3958 — a scratch worktree, since removed
- base: main @ 6f54a21085
- handoff: _local/docs/plans/pr-3958-split-review.md @ ceaa030
- production files touched: 2 — **new code, not a relocation** (4-line inline + a predicate re-point)


