### PR TITLE
fix(tests): stop the generation-surface guard collecting zero on Windows

### DIFF
--- a/src/server/services/orchestrator/__tests__/generation-surface-wiring.test.ts
+++ b/src/server/services/orchestrator/__tests__/generation-surface-wiring.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { readFileSync } from 'fs';
+import { readdirSync, readFileSync } from 'fs';
 import path from 'path';
-import { execFileSync } from 'child_process';
 import ts from 'typescript';
 
 import { GENERATION_SURFACES } from '~/shared/data-graph/generation/model-substitution';
@@ -70,6 +69,8 @@ import { REQUEST_RESOLVED_GENERATION_SURFACES } from '~/server/services/orchestr
  */
 
 const REPO_ROOT = path.resolve(__dirname, '../../../../..');
+
+const NEEDLE = 'buildGenerationContext';
 
 /** The declaration itself — not a call site. */
 const DEFINITION_FILE = 'src/server/services/orchestrator/orchestration-new.service.ts';
@@ -210,7 +211,7 @@ const EXPECTED_SURFACE_BY_CALL_SITE: Record<CallSiteKey, SurfacePin> = {
 /**
  * Candidate files, enumerated from the TREE rather than from a hand-kept list.
  *
- * The grep needle is the BARE identifier (no trailing paren): it only has to
+ * The needle is the BARE identifier (no trailing paren): it only has to
  * over-approximate, because the AST walk below decides what is really a call.
  * That removes every formatting dependency from the enumeration.
  *
@@ -219,15 +220,20 @@ const EXPECTED_SURFACE_BY_CALL_SITE: Record<CallSiteKey, SurfacePin> = {
  * (`src/**\/__tests__/**`) — see the arity guard for why that matters.
  */
 function candidateFiles({ includeTests }: { includeTests: boolean }): string[] {
-  const out = execFileSync(
-    'grep',
-    ['-rl', '--include=*.ts', '--include=*.tsx', 'buildGenerationContext', 'src'],
-    { cwd: REPO_ROOT, encoding: 'utf8' }
-  );
-  return out
-    .split('\n')
-    .map((l) => l.trim())
-    .filter(Boolean)
+  const found: string[] = [];
+  const walk = (rel: string) => {
+    for (const entry of readdirSync(path.join(REPO_ROOT, rel), { withFileTypes: true })) {
+      const child = `${rel}/${entry.name}`;
+      if (entry.isDirectory()) walk(child);
+      else if (
+        /\.tsx?$/.test(entry.name) &&
+        readFileSync(path.join(REPO_ROOT, child), 'utf8').includes(NEEDLE)
+      )
+        found.push(child);
+    }
+  };
+  walk('src');
+  return found
     .filter((f) => f !== DEFINITION_FILE && f !== GUARD_FILE)
     .filter((f) => includeTests || !(f.includes('__tests__') || f.endsWith('.test.ts')));
 }
@@ -396,9 +402,20 @@ function collectCallSites({ includeTests }: { includeTests: boolean }): CallSite
 const keyOf = (c: CallSite): CallSiteKey => `${c.file}::${c.fn}`;
 
 describe('generation-context surface wiring', () => {
-  const sites = collectCallSites({ includeTests: false });
+  // A throw in the describe BODY happens during registration, so no `it` below
+  // is declared and the file collects zero while reading green — which is how
+  // the `grep` shell-out this replaced hid on Windows. Catching it keeps
+  // registration total, so the guard below reports the breakage instead.
+  let sites: CallSite[] = [];
+  let enumerationError: unknown;
+  try {
+    sites = collectCallSites({ includeTests: false });
+  } catch (e) {
+    enumerationError = e;
+  }
 
   it('finds the call sites at all (guard the guard)', () => {
+    if (enumerationError) throw enumerationError;
     // Without this, a broken enumeration would make every assertion below pass
     // vacuously over an empty list.
     expect(sites.length).toBeGreaterThanOrEqual(Object.keys(EXPECTED_SURFACE_BY_CALL_SITE).length);


### PR DESCRIPTION
`src/server/services/orchestrator/__tests__/generation-surface-wiring.test.ts` has been contributing **zero tests to every full-suite run on Windows**, and reading as a pass while it did.

## What happens

The guard enumerates its candidate files by shelling out to `grep`:

```ts
const out = execFileSync('grep',
  ['-rl', '--include=*.ts', '--include=*.tsx', 'buildGenerationContext', 'src'],
  { cwd: REPO_ROOT, encoding: 'utf8' });
```

There is no `grep` on the Windows PATH for node — probed directly, two separate worktrees:

```
THREW code=ENOENT errno=-4058 syscall=spawnSync grep
```

The call runs from `collectCallSites()` in the **`describe` callback body**, which executes at collection time. So the throw lands during registration, no `it` is ever declared, and the file registers nothing. Solo it surfaces as `Failed Suites 1 / Tests no tests`; inside a 1,069-file run it is a file that quietly collected zero.

## What this changes

Replaces the shell-out with an in-process `readdirSync` walk — same population, same filters, no PATH dependency.

It also makes a future enumeration failure legible. The file already had a `guard the guard` test asserting the enumeration is non-empty, and the reasoning behind it is right, but **that control cannot fire when the enumeration throws before the test is registered** — a control can only fire if it exists, and collection is what makes it exist. Catching the error and rethrowing it inside that test keeps registration total, so the next breakage is a named red test rather than an empty file.

## Verification

Named-file runs on Windows, before and after, in the same worktree:

```
before   Error: spawnSync grep ENOENT   Test Files 1 failed (1)   Tests  no tests
after    Test Files 1 passed (1)        Tests 6 passed (6)        exit 0
```

The new enumeration was also probed standalone: **11 production files, 37 including tests**, ~1.2s, with the `all >= prod` invariant holding and a non-zero exit on an empty result so the probe could report a real failure.

## Scope, stated honestly in both directions

- **This is not a fix for a violation.** The guard's six assertions pass once they actually run, so the production tree already satisfies the surface pins. This restores a check that was inert locally.
- **It was never inert in CI.** `ubuntu-latest` has `grep`, so #3520's population guard has been genuinely enforced on every PR. What was broken is every Windows local run, silently.
- **`pnpm typecheck` does not cover this file** — `tsconfig.json` excludes `src/**/__tests__/**`, which the file's own comments note. A named-file vitest run is the only check on it, which is why both runs above are quoted rather than summarised.

## How it was found

Reading zero-collect **in absolute terms** across three full-suite runs, rather than reading the run-to-run diff. A permanent zero-collect is invisible to a diff-based check by construction: a file that never collected more can never lose any.
