### PR TITLE
fix(settings): bound the SSR settings bootstrap so one parked read can't pin every page

### DIFF
--- a/src/__tests__/mocks/direct-mock-allowlist.json
+++ b/src/__tests__/mocks/direct-mock-allowlist.json
@@ -20,7 +20,7 @@
   ],
   "totals": {
     "canonicalFiles": 218,
-    "pendingFiles": 395,
+    "pendingFiles": 396,
     "allFiles": 482,
     "canonicalSites": 288,
     "pendingSites": 864
@@ -29,17 +29,17 @@
     "~/server/db/client": 135,
     "~/server/redis/client": 88,
     "~/server/logging/client": 65,
-    "~/env/server": 107,
+    "~/env/server": 108,
     "~/server/services/buzz.service": 99,
     "~/server/services/image.service": 89,
     "~/server/clickhouse/client": 78,
     "~/server/services/notification.service": 77,
-    "~/server/services/user.service": 74,
+    "~/server/services/user.service": 75,
     "~/server/search-index": 65,
     "~/server/flipt/client": 64,
     "~/server/redis/fail-open-log": 55,
     "~/server/utils/endpoint-helpers": 53,
-    "~/server/redis/caches": 53,
+    "~/server/redis/caches": 54,
     "~/server/prom/client": 50
   },
   "files": [
@@ -293,6 +293,7 @@
     "src/server/__tests__/owned-sticker-cache-choice.test.ts",
     "src/server/__tests__/pack-detail-agreement.test.ts",
     "src/server/__tests__/pending-review-mute.test.ts",
+    "src/server/__tests__/settings-endpoint-deadlines.test.ts",
     "src/server/__tests__/sticker-topup.test.ts",
     "src/server/__tests__/upload-backend.test.ts",
     "src/server/__tests__/warmup.test.ts",

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -310,6 +310,11 @@ export const serverSchema = z
     // of silently disabling the guard (withTimeoutFallback passes through unbounded
     // when ms<=0 → the exact ~30s hang this exists to prevent, with no signal).
     CLICKHOUSE_IMAGE_METRICS_TIMEOUT_MS: z.coerce.number().int().positive().default(3000),
+    // Per-read deadline for `/api/user/settings`, which `_app` self-fetches on every SSR
+    // render. Must stay well under `APP_SETTINGS_FETCH_TIMEOUT_MS` (8s): a response the
+    // caller has stopped waiting for is the same outage. .int().positive() for the same
+    // reason as above — withTimeoutFallback passes through unbounded when ms<=0.
+    SETTINGS_READ_DEADLINE_MS: z.coerce.number().int().positive().default(2000),
     NODE_ENV: z.enum(['development', 'test', 'production']),
     NEXTAUTH_SECRET: z.string(),
     NEXTAUTH_URL: z.preprocess(

--- a/src/pages/api/user/settings.ts
+++ b/src/pages/api/user/settings.ts
@@ -6,21 +6,57 @@ import { getCurrentAnnouncements } from '~/server/services/announcement.service'
 import { getUserFollows } from '~/server/redis/caches';
 import { getRequestDomainColor } from '~/server/utils/server-domain';
 import { getBrowsingSettingAddons, getLiveNow } from '~/server/services/system-cache';
+import { withTimeoutFallback } from '~/server/utils/timeout-helpers';
+import { env } from '~/env/server';
+import { logToAxiom } from '~/server/logging/client';
+
+/**
+ * `_app` self-fetches this route on every SSR render, so a member that never replies pins
+ * every page at that fetch's own abort and renders it signed-out. A `.catch` cannot answer
+ * a parked read — only a deadline can. Timing out is reported, not swallowed: the incident
+ * this exists to prevent was invisible precisely because nothing logged.
+ */
+function settle<T, F>(promise: Promise<T>, fallback: F, member: string): Promise<T | F> {
+  const timeoutMs = env.SETTINGS_READ_DEADLINE_MS;
+  return withTimeoutFallback<T | F>(promise, timeoutMs, fallback, () => {
+    logToAxiom(
+      {
+        type: 'warning',
+        name: 'settings bootstrap deadline',
+        message: `${member} exceeded ${timeoutMs}ms`,
+        member,
+        timeoutMs,
+      },
+      'settings'
+    ).catch();
+  }).catch(() => fallback);
+}
 
 export default PublicEndpoint(
   async function handler(req, res) {
     try {
+      // Deliberately unbounded: failing this open renders a logged-in user anonymous, which
+      // `_app`'s hasAuthCookie carve-out exists to avoid.
       const session = await getServerAuthSession({ req, res });
-      // Use the content-settings view so SSR initialData matches the tRPC
-      // getSettings response shape (JSON settings + User-column toggles).
-      const settings = await getUserContentSettings(session?.user?.id ?? -1);
       // Concurrent, to keep this hot per-bootstrap route off the critical path.
       // EVERY member swallows its own errors: a single rejection diverts the whole
       // payload to the outer catch, which `_app` reads as "endpoint degraded" — so
       // one blip would drop the session seed and the browsing-settings addons too.
       const domainColor = getRequestDomainColor(req);
-      const [tosMeta, announcements, following, browsingSettingsAddons, liveNow] =
+      const [settings, tosMeta, announcements, following, browsingSettingsAddons, liveNow] =
         await Promise.all([
+          // Content-settings view so SSR initialData matches the tRPC getSettings response
+          // shape. `undefined` — NOT `{}` — because AppProvider passes this straight to
+          // `useQuery({ initialData })` under a global `staleTime: Infinity`: any defined
+          // value is fresh from frame 0 and never refetched, and an empty one resolves
+          // showNsfw/blurNsfw off the JWT, which lags a user who just turned nsfw OFF.
+          // `undefined` leaves the query unseeded so it fetches and self-heals, matching
+          // what `_app` already does on its degraded path.
+          settle(
+            getUserContentSettings(session?.user?.id ?? -1),
+            undefined,
+            'getUserContentSettings'
+          ),
           // Resolve the static per-domain ToS metadata here (server-only API route)
           // so `_app` getInitialProps can deliver it WITHOUT importing
           // `content.service` — which pulls `fs/promises` into `_app`'s client-bundled
@@ -30,7 +66,7 @@ export default PublicEndpoint(
           // createContext's `getRequestDomainColor(req) ?? 'blue'`.
           // `undefined` on failure: `useToSUpdateModal` guards on it and simply
           // doesn't prompt, which beats degrading the whole payload.
-          getTosMeta({ domainColor: domainColor ?? 'blue' }).catch(() => undefined),
+          settle(getTosMeta({ domainColor: domainColor ?? 'blue' }), undefined, 'getTosMeta'),
           // SSR-seed the ambient `announcement.getAnnouncements` query (fires on every
           // bootstrap, anon + authed). Computed here — NOT in `_app` getInitialProps —
           // because `announcement.service` is server-only and importing it into `_app`
@@ -39,8 +75,10 @@ export default PublicEndpoint(
           // `getRequestDomainColor(req)` (NO 'blue' fallback), so we pass the same raw
           // value here. On failure fall back to undefined and let the client self-heal
           // via a live fetch.
-          getCurrentAnnouncements({ domain: domainColor, userId: session?.user?.id }).catch(
-            () => undefined
+          settle(
+            getCurrentAnnouncements({ domain: domainColor, userId: session?.user?.id }),
+            undefined,
+            'getCurrentAnnouncements'
           ),
           // SSR-seed the ambient, auth-gated `user.getFollowingUsers` query (fires
           // on every logged-in bootstrap wherever a follow/notify button mounts).
@@ -48,7 +86,7 @@ export default PublicEndpoint(
           // seed is byte-identical (a `number[]` of followed userIds). Anon never
           // fires this query (`enabled: !!currentUser`), so seed authed-only.
           session?.user
-            ? getUserFollows(session.user.id).catch(() => undefined)
+            ? settle(getUserFollows(session.user.id), undefined, 'getUserFollows')
             : Promise.resolve(undefined),
           // Global, user-independent sysRedis reads moved off `_app` getInitialProps:
           // importing `system-cache` there pulled `~/server/db/client` (Prisma) and
@@ -62,11 +100,11 @@ export default PublicEndpoint(
           // passes this to `useQuery({ initialData, staleTime: Infinity })` they are
           // pinned for the session; the live config is only picked up on the next
           // bootstrap. Telling "live config" apart from "failed open" would need a
-          // sentinel out of system-cache. The `.catch` below is unreachable today and
-          // kept only so a future refactor that lets this reject can't seed `[]` —
-          // which react-query would treat as valid data and pin as "no restrictions".
-          getBrowsingSettingAddons().catch(() => undefined),
-          getLiveNow().catch(() => false),
+          // sentinel out of system-cache. `undefined` on the deadline path for the same
+          // reason the old `.catch` used it — react-query treats a `[]` seed as valid
+          // data and pins it as "no restrictions".
+          settle(getBrowsingSettingAddons(), undefined, 'getBrowsingSettingAddons'),
+          settle(getLiveNow(), false, 'getLiveNow'),
         ]);
       res.status(200).json({
         settings,

--- a/src/server/__tests__/settings-endpoint-deadlines.test.ts
+++ b/src/server/__tests__/settings-endpoint-deadlines.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Pins the read deadlines in `/api/user/settings`.
+ *
+ * Every I/O member in that handler already had a `.catch` fallback, which answers a
+ * REJECTION. None of them answered a dependency that accepts the read and never replies —
+ * and `_app.getInitialProps` awaits this route on every SSR render, so one parked read
+ * pinned EVERY page at the client's abort (8s) and rendered it signed-out, with nothing
+ * logged. Measured 2026-08-16: `getUserContentSettings`, `getCurrentAnnouncements` and
+ * `getLiveNow` all hung together against one bad dependency.
+ *
+ * Deliberately NOT covered: `getServerAuthSession`. It is awaited unguarded on purpose —
+ * failing it open renders a logged-in user anonymous, and `_app`'s `hasAuthCookie`
+ * carve-out exists precisely because that is worse than a slow page.
+ *
+ * Lives outside `src/pages`: Next treats every file under there as a route and `next build`
+ * rejects a test file, which only that build catches.
+ */
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as UserService from '~/server/services/user.service';
+import type * as AnnouncementService from '~/server/services/announcement.service';
+import type * as SystemCache from '~/server/services/system-cache';
+import type * as ContentService from '~/server/services/content.service';
+import type * as AuthSession from '~/server/auth/get-server-auth-session';
+import type * as RedisCaches from '~/server/redis/caches';
+
+const h = vi.hoisted(() => ({
+  contentSettings: vi.fn(),
+  announcements: vi.fn(),
+  liveNow: vi.fn(),
+  follows: vi.fn(),
+  addons: vi.fn(),
+  session: vi.fn(),
+}));
+
+// The real `~/env/server` validates every prod var and throws under test. Only the deadline
+// matters here; the Proxy answers anything else the graph reads at import time. Set small so
+// `runAllTimersAsync` reaches it, and non-zero so `withTimeoutFallback` does not pass through.
+vi.mock('~/env/server', () => ({
+  env: new Proxy(
+    {
+      SETTINGS_READ_DEADLINE_MS: 20,
+      LOGGING: [] as string[],
+      // endpoint-helpers spreads this at module load.
+      TRPC_ORIGINS: [] as string[],
+    } as Record<string, unknown>,
+    {
+      get: (target, prop) => {
+        if (prop in target) return target[prop as string];
+        if (typeof prop === 'string' && (prop.endsWith('_URL') || prop.endsWith('_ENDPOINT')))
+          return 'https://test:test@localhost:5432/test';
+        if (
+          typeof prop === 'string' &&
+          /(_CONCURRENCY|_LIMIT|_MS|_PORT|_TIMEOUT|_MAX|_SIZE|_COUNT)$/.test(prop)
+        )
+          return 1;
+        return undefined;
+      },
+    }
+  ),
+}));
+
+vi.mock('~/server/auth/get-server-auth-session', async (importOriginal) => ({
+  ...(await importOriginal<typeof AuthSession>()),
+  getServerAuthSession: h.session,
+}));
+vi.mock('~/server/services/user.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof UserService>()),
+  getUserContentSettings: h.contentSettings,
+}));
+vi.mock('~/server/services/announcement.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof AnnouncementService>()),
+  getCurrentAnnouncements: h.announcements,
+}));
+vi.mock('~/server/services/content.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof ContentService>()),
+  getTosMeta: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/services/system-cache', async (importOriginal) => ({
+  ...(await importOriginal<typeof SystemCache>()),
+  getBrowsingSettingAddons: h.addons,
+  getLiveNow: h.liveNow,
+}));
+
+vi.mock('~/server/redis/caches', async (importOriginal) => ({
+  ...(await importOriginal<typeof RedisCaches>()),
+  getUserFollows: h.follows,
+}));
+
+import handler from '~/pages/api/user/settings';
+
+const invoke = () => {
+  const json = vi.fn();
+  const res = { status: vi.fn(() => res), json, setHeader: vi.fn(), end: vi.fn() };
+  const req = { method: 'GET', headers: { host: 'civitai.com' }, query: {}, cookies: {} };
+  const done = (handler as unknown as (q: NextApiRequest, s: NextApiResponse) => Promise<void>)(
+    req as unknown as NextApiRequest,
+    res as unknown as NextApiResponse
+  );
+  return { done, json };
+};
+
+describe('/api/user/settings read deadlines', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    h.session.mockResolvedValue(null);
+    h.contentSettings.mockResolvedValue({ showNsfw: true });
+    h.announcements.mockResolvedValue([{ id: 1 }]);
+    h.liveNow.mockResolvedValue(true);
+    h.follows.mockResolvedValue([7]);
+    h.addons.mockResolvedValue([{ id: 'a' }]);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('answers normally when every dependency replies', async () => {
+    const { done, json } = invoke();
+    await vi.runAllTimersAsync();
+    await done;
+
+    const body = json.mock.calls[0][0];
+    expect(body.settings).toEqual({ showNsfw: true });
+    expect(body.announcements).toEqual([{ id: 1 }]);
+    expect(body.liveNow).toBe(true);
+  });
+
+  it('still answers when a dependency never replies, and seeds the SAFE settings default', async () => {
+    // A promise that never settles is the whole point — a `.catch` cannot see it. The
+    // assertion is that the handler resolves anyway; fake timers make the deadline fire
+    // without the test waiting on a real clock, so a revert fails fast rather than hanging.
+    h.contentSettings.mockReturnValue(new Promise(() => undefined));
+    const { json } = invoke();
+    await vi.runAllTimersAsync();
+
+    // Asserted WITHOUT awaiting the handler: with the deadline removed it never settles, so
+    // awaiting it would wedge the runner for the full test timeout instead of reporting.
+    // A revert fails here in milliseconds with "spy not called".
+    expect(json).toHaveBeenCalled();
+    const body = json.mock.calls[0][0];
+    // MUST be undefined, not `{}`. AppProvider passes this to `useQuery({ initialData })`
+    // under a global `staleTime: Infinity`, so any defined value is pinned for the whole
+    // SPA session and never refetched — and an empty one resolves showNsfw off the JWT,
+    // which lags a user who just turned nsfw OFF. Seeding `{}` here is a content leak.
+    expect(body.settings).toBeUndefined();
+    // The rest of the payload still lands — one bad dependency must not degrade the whole
+    // response, which is what the outer catch would do.
+    expect(body.announcements).toEqual([{ id: 1 }]);
+    expect('session' in body).toBe(true);
+  });
+
+  it('bounds the authed-only members too', async () => {
+    // Every other case runs the anonymous path, where `getUserFollows` is never called and
+    // its deadline is unreachable — removing it would pass those tests.
+    h.session.mockResolvedValue({ user: { id: 42 } });
+    h.follows.mockReturnValue(new Promise(() => undefined));
+    h.addons.mockReturnValue(new Promise(() => undefined));
+    const { json } = invoke();
+    await vi.runAllTimersAsync();
+
+    expect(json).toHaveBeenCalled();
+    const body = json.mock.calls[0][0];
+    expect(body.following).toBeUndefined();
+    expect(body.browsingSettingsAddons).toBeUndefined();
+    // The authed session still lands — a bounded member must not cost the session seed.
+    expect(body.session).toEqual({ user: { id: 42 } });
+  });
+
+  it('degrades each hanging member independently', async () => {
+    h.announcements.mockReturnValue(new Promise(() => undefined));
+    h.liveNow.mockReturnValue(new Promise(() => undefined));
+    const { json } = invoke();
+    await vi.runAllTimersAsync();
+
+    expect(json).toHaveBeenCalled();
+    const body = json.mock.calls[0][0];
+    expect(body.announcements).toBeUndefined();
+    expect(body.liveNow).toBe(false);
+    // The member that did reply is unaffected.
+    expect(body.settings).toEqual({ showNsfw: true });
+  });
+});


### PR DESCRIPTION
## Problem

`_app.getInitialProps` self-fetches `/api/user/settings` on **every SSR render**. Every I/O member there carried a `.catch` fallback — but a `.catch` answers a **rejection**. Nothing answered a dependency that accepts the read and never replies.

One parked read pinned **every page** at that fetch's 8s abort and rendered it **signed-out**, with no error logged and no 5xx to alert on.

## Evidence

A per-await trace of the handler, on a dev session against the production database:

```
    2 ok    getServerAuthSession
10011 HUNG  getUserContentSettings
    7 ok    getTosMeta
10015 HUNG  getCurrentAnnouncements
    1 ok    getBrowsingSettingAddons
10012 HUNG  getLiveNow
```

Everything that hangs touches the DB or Redis; `getTosMeta` is filesystem-only; and **`getBrowsingSettingAddons` — the one call already wrapped in a read deadline — is the only I/O call that keeps working.** This generalises that pattern.

## Change

Race each read against `env.SETTINGS_READ_DEADLINE_MS` (default 2s, well under the 8s abort) using the existing `withTimeoutFallback` (`src/server/utils/timeout-helpers.ts:12`), which already folds the deadline and the fallback together, handles `ms <= 0`, and reaps a late rejection. Same shape as the ClickHouse read at `image.service.ts:5213`, which solved the identical "a try/catch cannot catch a hang" problem on the same SSR path.

**A timeout is logged to Axiom, not swallowed.** The incident this prevents was invisible precisely because nothing logged; shipping six silent fallbacks would have reproduced that one layer down.

**The settings fallback is `undefined`, not `{}`.** AppProvider passes it to `useQuery({ initialData })` under a global `staleTime: Infinity`, so any defined value is fresh from frame 0 and **never refetched** — and an empty one resolves `showNsfw`/`blurNsfw` off the JWT in `CivitaiSessionProvider`, which lags a user who has just turned nsfw **off**. `undefined` leaves the query unseeded so it fetches and self-heals, matching `_app`'s own degraded path (`_app.tsx:471`).

`getUserContentSettings` also moves into the existing `Promise.all` — nothing read it serially, and awaiting it first made the real worst case two deadlines rather than one.

**`getServerAuthSession` stays unbounded on purpose.** A deadline there returns `session: null` with the key *present*, which `_app` reads as authoritative and turns into a hard anonymous render; the current path preserves `hasAuthCookie` and lets the client resolve it. So this PR covers the DB/Redis reads and deliberately not the hub call.

## Known limits

- **A timeout sheds the waiter, not the load.** The orphaned Prisma/Redis work is not cancellable, so under a brownout each render still enqueues work while the previous orphan is outstanding. This unblocks the request path; it does not bound backend concurrency.
- **It does not explain what makes a dependency park.** Still open and chased separately.

## Verification

- `pnpm run typecheck` — clean
- `pnpm run test:lint-rules` — 220 pass
- `settings-endpoint-deadlines.test.ts` (4) + the shared-mock ratchet + `image-metrics-timeout` — 10 pass

**Mutation-checked**, each failing fast and legibly:

| mutation | result |
|---|---|
| seed `{}` instead of `undefined` | `expected {} to be undefined` |
| drop the deadline on the authed-only `getUserFollows` | `expected "vi.fn()" to be called at least once` |
| drop the deadline on `getBrowsingSettingAddons` | `expected "vi.fn()" to be called at least once` |

The hanging tests assert on the `res.json` spy **without awaiting the handler** — awaiting under a revert would wedge the runner for the full 60s timeout and report a timeout rather than a diagnosis.

## Review history

Adversarial review of the first revision found: a hand-rolled `withDeadline` duplicating `withTimeoutFallback`; `process.env` bypassing the env schema (where a negative value would have silently become a 250ms deadline on every bootstrap read site-wide); six deadlines firing in total silence; a serial await making the worst case 2x the stated bound; **and the important one — the `{}` fallback being pinned by `staleTime: Infinity` and resolving off a stale JWT, which was a content-safety regression versus pre-PR behaviour rather than the no-op the comment claimed.** It also caught that the new test file breaks the shared-mock ratchet (`396` vs `395`), which `pnpm run test:lint-rules` does not cover — the allowlist is updated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DZLqfdGtSK1ymgkxeNDLa