### PR TITLE
fix(test-perf): stop the mock-allowlist generator reading a directory

### DIFF
--- a/scripts/test-perf/gen-mock-allowlist.mjs
+++ b/scripts/test-perf/gen-mock-allowlist.mjs
@@ -13,7 +13,7 @@
  * The PENDING list has no such rule: those specifiers have no canonical mock to migrate to,
  * so their count moves with ordinary development and is measurement, not enforcement.
  */
-import { readFileSync, writeFileSync, existsSync, globSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, globSync, statSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import ts from 'typescript';
@@ -37,6 +37,10 @@ const pattern = (spec) =>
 const testFiles = globSync('src/**/*.test.{ts,tsx}', { cwd: repoRoot })
   .map((f) => f.replace(/\\/g, '/'))
   .filter((f) => !f.startsWith('src/__tests__/mocks/'))
+  // Vitest browser mode names each snapshot DIRECTORY after its spec, so
+  // `__screenshots__/Foo.browser.test.tsx` is a directory that matches this glob and the read
+  // below dies EISDIR. Gitignored, so it reproduces only for someone who has run a browser test.
+  .filter((f) => statSync(path.join(repoRoot, f)).isFile())
   .sort();
 
 const files = [];


### PR DESCRIPTION
`globSync('src/**/*.test.{ts,tsx}')` matches directories as well as files, and vitest browser mode names each snapshot directory after its spec — so `__screenshots__/AppListingCard.browser.test.tsx` is a **directory** that matches, and the `readFileSync` below it dies with `EISDIR` before the generator produces anything.

Those directories are gitignored, so the generator works on a fresh checkout and breaks permanently for anyone who has ever run a browser test locally — which reads as "this script is broken for me specifically" rather than as a bug. It cost someone a full purge-and-rebuild cycle before they spotted it.

Filter to regular files. Verified against a tree with three such directories: `EISDIR` before, `canonical 218 -> 218 files (0 migrated)` after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KvXBiAVpWyhNS85tsBMuDU