### PR TITLE
fix(dev-server): compile /api/user/settings before anything can render

### DIFF
--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -60,7 +60,20 @@ function loadSkillConfig() {
     perBranchDistDir: false,
     killOnBranchSwitch: false,
     autoInstall: true,
-    prewarmRoutes: [],
+    // NOT empty by default. `_app` SSR-fetches /api/user/settings on every page render and gives
+    // up after APP_SETTINGS_FETCH_TIMEOUT_MS (8s). On a cold build dir that fetch is what triggers
+    // the on-demand COMPILE of that route, and the compile does not fit in the budget — measured
+    // on this repo at 15.4s and 28.6s — so every render in flight degrades to a signed-out page
+    // and the server looks broken while being perfectly healthy.
+    //
+    // Compiling it once, up front, on prewarm's 300s budget removes the whole failure. Measured,
+    // same worktree, same cold `.next`, four concurrent /home requests: without this, four
+    // `[_app] settings bootstrap fetch failed` and the settings route taking 15.4s per render;
+    // with it, zero failures and 162-200ms per render.
+    //
+    // It stays FIRST in the list: any page route ahead of it would trigger the same compile from
+    // inside a render, which is the thing being avoided.
+    prewarmRoutes: ['/api/user/settings'],
     prewarmTimeout: 300000,
     testConcurrency: 1,
     prodGroups: [],
@@ -741,6 +754,11 @@ class DevSession {
               this.ready = true;
               this.readyAt = new Date().toISOString();
               this.addLog('info', 'Server ready (detected from logs)');
+              // Prewarming used to happen only on the health-check path, so a checkout with no
+              // skill `.env` — which is every fresh one, the file is gitignored — reached ready
+              // and warmed nothing. That is exactly the configuration the settings compile
+              // deadlock needs (see PREWARM_ROUTES below).
+              this.prewarm();
               break;
             }
           }


### PR DESCRIPTION
The dev server was reproducibly degrading itself on a cold build dir, and the mechanism is a **compile**, not a database.

`_app` SSR-fetches `/api/user/settings` from its own server on every page render and aborts at `APP_SETTINGS_FETCH_TIMEOUT_MS` (8s). On a cold `.next` that fetch is what triggers Next's on-demand **compile** of the route — measured at 15.4s and 28.6s on this repo, both well past the budget. So the first page request makes the server compile the very thing it is blocking on, every render in flight degrades to signed-out, and the page time pins to exactly the timeout. Nothing in the logs names a cause: the server is healthy, the database is fine, and `/api/health` passes throughout (it is a cheap, already-compiled route).

## Reproduced, with a control

Same worktree, same cold `.next`, same **dev** database, four concurrent `/home` — only the request ORDER changed:

| | `_app` failures | settings route | page application-code |
|---|---|---|---|
| page first | **4** | 15.4s (next.js 15.2s) | 22-29s |
| API first | **0** | 76-103ms | 1.5s |

## The fix, and why it needed two changes

Prewarm has a 300s budget where a render has 8s. For that to hold on a machine nobody has configured:

- **Default `PREWARM_ROUTES` to `['/api/user/settings']`** instead of empty, first in the list. A page route ahead of it would trigger the same compile from inside a render.
- **Fire prewarm on log-detected readiness too.** It previously ran only on the health-check path, so a checkout with no skill `.env` — which is every fresh one, since the file is gitignored — reached ready and warmed nothing. That is precisely the configuration this deadlock needs.

Verified under fresh-checkout conditions (skill `.env` deleted, `.next` purged): prewarm absorbs a 22.9s compile, four concurrent renders then resolve the route in 71-99ms, page application-code drops to 1.7s, **zero failures**.

Also verified it holds past cold start: editing a module the settings route imports on a warm session recompiles in **924ms** with zero failures. Only the cold graph is expensive.

## Relationship to #3974

These must be reasoned about together. #3974's deadline is dead weight while the route is prewarmed — the fetch is 16ms-924ms, nowhere near it. Its value is entirely in the paths this does not cover, including **production**, where there is no on-demand compile but a parked read is still possible. If prewarm ever regresses, that deadline is what keeps the failure to one degraded render that self-heals rather than a wedge.

Dev tooling only (`.claude/**`); nothing here ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KvXBiAVpWyhNS85tsBMuDU