### PR TITLE
fix(dev-server): stop the branch watcher dropping checkouts, two ways

### DIFF
--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -486,6 +486,18 @@ Real-time protection scans all ~210k files in `node_modules` plus every build-ca
 powershell -File .claude\skills\dev-server\scripts\defender-exclusions.ps1
 ```
 
+## Self-tests
+
+The daemon's trickier invariants are pinned by plain-node self-tests. Run them after touching the
+files they cover — they take milliseconds and need no daemon:
+
+```bash
+node .claude/skills/dev-server/scripts/branch-watch.selftest.mjs
+```
+
+Each case is a shape measured on this repo, and each is mutation-checked: reverting the code it
+covers produces a wrong number, not a hang.
+
 ## Notes
 
 - The daemon starts automatically when you run CLI commands

--- a/.claude/skills/dev-server/scripts/branch-watch.selftest.mjs
+++ b/.claude/skills/dev-server/scripts/branch-watch.selftest.mjs
@@ -1,0 +1,66 @@
+/**
+ * `node .claude/skills/dev-server/scripts/branch-watch.selftest.mjs`
+ *
+ * The shipped defaults (poll 1000ms, debounce 3000ms) livelocked the branch watcher: it re-armed
+ * the debounce on every poll, so the timer could never expire and no switch ever ran. Nothing about
+ * that was visible — the session kept serving, kept reporting `switching: false`, and simply
+ * reported the branch it started on forever.
+ *
+ * The last two cases are the regression. They simulate the poll loop against a HEAD that has moved
+ * once and then holds still, and assert the switch is scheduled EXACTLY once; a revert makes the
+ * count equal the number of polls, which prints as a number, not as a hang.
+ */
+
+import { shouldScheduleSwitch } from './daemon.mjs';
+
+let failures = 0;
+function check(name, actual, expected) {
+  const pass = actual === expected;
+  if (!pass) failures++;
+  console.log(`${pass ? 'PASS' : 'FAIL'}  ${name}  got=${actual} want=${expected}`);
+}
+
+check('unreadable HEAD is not a switch', shouldScheduleSwitch(null, 'main', null), false);
+// Not redundant with the row above: with no `!head` guard that one still returns false by accident
+// (null !== null), so it pins nothing. This row is the one that fails without the guard — a null
+// head would otherwise arm a debounce for a ref the watcher can no longer tell apart from "none".
+check('unreadable HEAD while already debouncing', shouldScheduleSwitch(null, 'main', 'feat/x'), false);
+check('HEAD unchanged', shouldScheduleSwitch('main', 'main', null), false);
+check('HEAD moved, nothing pending', shouldScheduleSwitch('feat/x', 'main', null), true);
+check('already debouncing this exact head', shouldScheduleSwitch('feat/x', 'main', 'feat/x'), false);
+check('moved AGAIN mid-debounce re-arms', shouldScheduleSwitch('feat/y', 'main', 'feat/x'), true);
+check('landed back on the running branch', shouldScheduleSwitch('main', 'main', 'feat/x'), false);
+
+// Drive the poll loop the way the daemon does: `branch` does not move until the switch runs, so a
+// guard that ignores `pendingHead` keeps firing and keeps pushing the deadline out of reach.
+function pollsUntilSwitch({ polls, intervalMs, debounceMs }) {
+  let pendingHead = null;
+  let armedAt = null;
+  let scheduled = 0;
+  let ranAt = null;
+  const branch = 'main';
+
+  for (let t = 0; t <= polls * intervalMs; t += intervalMs) {
+    if (armedAt !== null && t - armedAt >= debounceMs) {
+      ranAt = t;
+      break;
+    }
+    if (shouldScheduleSwitch('feat/x', branch, pendingHead)) {
+      pendingHead = 'feat/x';
+      armedAt = t; // re-arming resets the deadline, which is the whole bug
+      scheduled++;
+    }
+  }
+  return { scheduled, ranAt };
+}
+
+const shipped = pollsUntilSwitch({ polls: 20, intervalMs: 1000, debounceMs: 3000 });
+check('scheduled exactly once on the shipped defaults', shipped.scheduled, 1);
+check('and the switch actually runs', shipped.ranAt, 3000);
+
+// Interval > debounce was the only configuration the old code could ever complete under.
+const slowPoll = pollsUntilSwitch({ polls: 20, intervalMs: 5000, debounceMs: 3000 });
+check('completes with a slow poll too', slowPoll.ranAt, 5000);
+
+console.log(failures ? `\n${failures} FAILURES` : '\nall green');
+process.exit(failures ? 1 : 0);

--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -323,6 +323,22 @@ function readHeadRef(headPath) {
   }
 }
 
+// The debounce exists so a rebase — HEAD moving several times in a second — settles before the
+// session reacts. It must therefore be re-armed when HEAD moves AGAIN, and only then.
+//
+// Re-arming on every poll instead is a livelock, because the poll keeps seeing the same unchanged
+// HEAD: `session.branch` is not updated until the switch actually runs, so with the shipped
+// defaults (poll 1000ms, debounce 3000ms) the timer was cleared and re-set three times per debounce
+// window and could never expire. Every consequence of a switch — `pnpm install` on a lockfile
+// change, `db:generate` on a schema change, re-prewarm, even the reported branch name — was
+// therefore unreachable whenever the poll interval was shorter than the debounce, which is what the
+// defaults specify. `pendingHead` is what makes "moved again" distinguishable from "still moved".
+export function shouldScheduleSwitch(head, branch, pendingHead) {
+  if (!head) return false;
+  if (head === branch) return false;
+  return head !== pendingHead;
+}
+
 function branchSlug(branch) {
   const safe = branch.toLowerCase().replace(/[^a-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
   const digest = createHash('sha1').update(branch).digest('hex').slice(0, 6);
@@ -505,6 +521,7 @@ class DevSession {
     this.headPath = resolveGitHeadPath(worktree);
     this.branchWatchTimer = null;
     this.branchSwitchTimer = null;
+    this.pendingHead = null;
     this.switching = false;
     this.removed = false;
     this.busyDepth = 0;
@@ -512,6 +529,7 @@ class DevSession {
     this.prewarming = false;
     this.lockHash = null;
     this.schemaHash = null;
+    this.depsBaselined = false;
   }
 
   lockfilePath() {
@@ -578,8 +596,40 @@ class DevSession {
     this.branch =
       (this.headPath && readHeadRef(this.headPath)) || getGitBranch(this.worktree) || 'unknown';
     this.distDir = skillConfig.perBranchDistDir ? distDirForBranch(this.branch) : '.next';
-    this.lockHash = fileHash(this.lockfilePath());
-    this.schemaHash = fileHash(this.schemaPath());
+
+    // Baseline the dependency hashes ONCE, on the session's first start.
+    //
+    // Re-baselining on every start is how a checkout gets swallowed for good. `stop()` kills the
+    // poller and drops any pending switch, so a restart landing inside the debounce window — or a
+    // second checkout during the `pnpm install` of the first, which also runs with the poller off
+    // — arrives here with HEAD already on the new branch. Re-reading the hashes then adopts that
+    // branch's lockfile as the baseline WITHOUT having installed it, and every later poll sees
+    // `head === this.branch` and returns. The result is a stale `node_modules` that nothing will
+    // ever reconcile: `Module not found` 500s until someone installs by hand.
+    //
+    // Keeping the earlier hashes instead means the mismatch survives the restart, and
+    // reconcileDeps() below acts on it.
+    //
+    // Scope, honestly: the baseline is "what was on disk when this session first started", which is
+    // only the same thing as "what was installed" if nobody checked out a branch while the daemon
+    // was down. Restart the daemon after a checkout and the new session baselines the new lockfile
+    // against a node_modules that was never installed for it, and nothing here notices.
+    // An explicit flag, not `lockHash === null`. `fileHash` returns null on ANY read error, and
+    // pnpm-lock.yaml is exactly the file another process briefly locks on Windows — one unlucky
+    // read at first start would leave the baseline unset, so the next start re-baselines and
+    // silently restores the swallow this is here to remove.
+    if (!this.depsBaselined) {
+      const lockHash = fileHash(this.lockfilePath());
+      // Only claim a baseline we actually read. `fileHash` returns null on any read error, and
+      // pnpm-lock.yaml is the file another process briefly locks on Windows — baselining a null
+      // would make reconcileDeps() see a mismatch on the next start and run one install for
+      // nothing. Leaving it unbaselined just tries again.
+      if (lockHash !== null) {
+        this.lockHash = lockHash;
+        this.schemaHash = fileHash(this.schemaPath());
+        this.depsBaselined = true;
+      }
+    }
 
     // Load environment variables
     let envVars = loadEnvFile(this.envPath);
@@ -695,6 +745,7 @@ class DevSession {
     }
 
     this.startBranchWatch();
+    this.reconcileDeps();
 
     return {
       id: this.id,
@@ -816,13 +867,35 @@ class DevSession {
     }
   }
 
+  // What the poller cannot see, because it was not running. Any restart can land on a tree whose
+  // lockfile or schema no longer matches what was last installed — a stop/start inside the debounce
+  // window, a second checkout during an install, a crash restart after someone switched branches.
+  // Comparing the files on disk against the last INSTALLED hashes catches all of those without
+  // needing to have observed the checkout that caused them.
+  reconcileDeps() {
+    if (this.removed || this.switching) return;
+    const lockChanged = fileHash(this.lockfilePath()) !== this.lockHash;
+    const schemaChanged = fileHash(this.schemaPath()) !== this.schemaHash;
+    if (!lockChanged && !schemaChanged) return;
+    this.addLog(
+      'info',
+      `${lockChanged ? 'pnpm-lock.yaml' : 'schema.full.prisma'} does not match what was last ` +
+        `installed — reconciling`
+    );
+    // Through the ordinary switch path so it installs, regenerates and restarts exactly as a
+    // watched checkout would; it is the same work, just triggered by state instead of by an event.
+    this.pendingHead = null;
+    clearTimeout(this.branchSwitchTimer);
+    this.branchSwitchTimer = setTimeout(() => this.finishBranchSwitch(), 0);
+  }
+
   startBranchWatch() {
     if (!skillConfig.branchWatchEnabled || !this.headPath || this.branchWatchTimer) return;
 
     this.branchWatchTimer = setInterval(() => {
       if (this.switching) return;
       const head = readHeadRef(this.headPath);
-      if (!head || head === this.branch) return;
+      if (!shouldScheduleSwitch(head, this.branch, this.pendingHead)) return;
       this.onHeadChanged(head);
     }, skillConfig.branchWatchInterval);
     this.branchWatchTimer.unref?.();
@@ -837,6 +910,7 @@ class DevSession {
       clearTimeout(this.branchSwitchTimer);
       this.branchSwitchTimer = null;
     }
+    this.pendingHead = null;
   }
 
   // HEAD moved. Measured: leaving the server up through a checkout beats killing it —
@@ -856,6 +930,7 @@ class DevSession {
       }
     }
 
+    this.pendingHead = head;
     clearTimeout(this.branchSwitchTimer);
     this.branchSwitchTimer = setTimeout(
       () => this.finishBranchSwitch(),
@@ -871,11 +946,22 @@ class DevSession {
     // A DELETE that lands after this was queued would otherwise spend minutes on an install for a
     // session nobody tracks — against a worktree `wt rm` may have just deleted — before start()
     // refuses at the end of it.
-    if (this.removed) return;
+    if (this.removed) {
+      // Cleared here too: this is the one exit that runs before the clear below, and leaving it set
+      // would make a later switch to this same ref look like one already scheduled. Safe today only
+      // because the DELETE handler stops the session first — which is a long way from this line.
+      this.pendingHead = null;
+      return;
+    }
 
+    clearTimeout(this.branchSwitchTimer);
     this.branchSwitchTimer = null;
     this.switching = true;
     const head = readHeadRef(this.headPath);
+    // Cleared as the switch begins, not when it ends: `switching` suppresses the poll for the
+    // duration, and leaving it set would make a later switch BACK to this same ref look like one
+    // already scheduled.
+    this.pendingHead = null;
     if (!head) {
       this.switching = false;
       return;
@@ -884,7 +970,13 @@ class DevSession {
     try {
       const from = this.branch;
       this.branch = head;
-      this.addLog('info', `Branch switch: ${from} -> ${head}`);
+      // A rebase that lands back where it started, and reconcileDeps(), both arrive here with HEAD
+      // unmoved. Saying "switch: main -> main" reads as a bug in the watcher; the work below is
+      // still correct and still worth doing.
+      this.addLog(
+        'info',
+        from === head ? `Re-checking ${head} for dependency changes` : `Branch switch: ${from} -> ${head}`
+      );
 
       const env = { ...process.env, ...loadEnvFile(this.envPath) };
       const log = (l, m) => this.addLog(l, m);
@@ -912,8 +1004,13 @@ class DevSession {
         await runCommand(pnpmCmd, ['run', 'db:generate'], this.worktree, env, log);
       }
 
-      this.lockHash = lockHash;
-      this.schemaHash = schemaHash;
+      // Re-read AFTER the install, not the values captured before it. `pnpm install` can rewrite
+      // pnpm-lock.yaml (a stale lock against a changed package.json, a workspace bump), and storing
+      // the pre-install hash then makes reconcileDeps() see a mismatch on the way back up and run
+      // the whole stop/install/restart again.
+      this.lockHash = fileHash(this.lockfilePath());
+      this.schemaHash = fileHash(this.schemaPath());
+      this.depsBaselined = true;
 
       if (mustRestart) {
         await this.stop();


### PR DESCRIPTION
Two independent paths silently discarded a branch switch. Both end in the same place — a stale `node_modules` serving `Module not found` 500s that nothing will ever reconcile — which reads as "the dev server breaks when I change branches" rather than as a daemon that stopped paying attention.

## 1. The watcher re-armed its own debounce forever

It polls HEAD every `BRANCH_WATCH_INTERVAL` and, on any difference from `session.branch`, clears and re-arms a `BRANCH_SWITCH_DEBOUNCE` timer. But `session.branch` is not updated until the switch runs, so the poll keeps seeing the same already-moved HEAD and keeps pushing the deadline out. With the shipped defaults — poll 1000ms, debounce 3000ms — the deadline was pushed out three times per window.

Scope, precisely: this needs the poll faster than the debounce (the defaults) **and** `KILL_ON_BRANCH_SWITCH` off (also the default). With the kill enabled the old code worked, because stopping the session also stops the poller doing the re-arming. And "never fires" is really "needs one >3000ms gap between polls to escape" — a blocked event loop can supply one, which is likely why this was intermittent enough to go unnoticed rather than being reported as simply broken.

`pendingHead` makes "HEAD moved again" distinguishable from "HEAD is still where it was a second ago", so a rebase still re-arms the debounce — the only thing it was for — and a settled checkout does not.

**Consequence beyond the reported branch:** re-prewarm-after-branch-switch has never run for anyone either, which matters now that prewarming the settings route is what prevents the compile deadlock (#3977).

## 2. A restart inside the window swallowed the switch permanently

`stop()` kills the poller and drops any pending switch, and `start()` then re-read the lockfile and schema hashes as its new baseline. So a restart landing in the 3s debounce — or a second checkout during the `pnpm install` of the first, which also runs with the poller off — adopted the new branch's lockfile as "already installed" without installing it. Every later poll then saw `head === this.branch` and returned: not deferred, gone.

Now the hashes are baselined once, on first start, and `reconcileDeps()` compares the files on disk against what was last installed. That catches a mismatch however it arose, including checkouts the poller never saw because it was not running.

## Verified end to end, against a second daemon on an isolated port

- a quiet checkout logs `Branch switch: probe/watchtest -> probe/vitest-...` and the session reports the new branch; before, it logged `HEAD moved` and stopped
- a restart onto a modified `pnpm-lock.yaml` logs `pnpm-lock.yaml does not match what was last installed — reconciling`; before, it silently adopted it

The self-test drives a replica of the poll loop, so it pins the predicate and the livelock, **not** the surrounding state machine — that is covered by the end-to-end runs above. Reverting the fix prints `got=21 want=1` and `got=null want=3000` in under a second rather than hanging.

Dev tooling only (`.claude/**`); nothing here ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KvXBiAVpWyhNS85tsBMuDU