### PR TITLE
feat(dev-server): probe/unwedge so a sick dev server names its own fault

### DIFF
--- a/.claude/hooks/check-writable.mjs
+++ b/.claude/hooks/check-writable.mjs
@@ -75,6 +75,42 @@ function isUnscoped(target) {
   return segments.length < required;
 }
 
+// A dev server that has stopped answering does not refuse connections — it accepts and never
+// replies, so an unbounded request against it hangs until the 300s tool timeout and the agent
+// learns nothing. Chaining several in one call multiplies that.
+//
+// This ASKS rather than blocks. A hard block was tried and is wrong: the matcher reads text, so it
+// cannot reliably tell a request from a shell comment, a note being written down, or a production
+// URL carrying a dev port in a query parameter — and `$(curl ...)` defeats it anyway. A guard with
+// those false positives and no override is one people route around, and the routes around it are
+// shorter than the compliant path. Asking keeps the nudge and costs a keystroke when it is wrong.
+const DEV_PORTS = /(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[?::1\]?):(?:30\d\d|51[67]\d|9444)\b/i;
+
+// Any of curl's, wget's or PowerShell's own timeout flags, including `-m5` and bundled shorts.
+// `-T` is wget's timeout but curl's --upload-file, and `-m` is curl's --max-time but wget's
+// --mirror, so the ambiguous shorts are scoped to the tool that means "timeout" by them.
+const BOUNDED_LONG = /--max-time|--connect-timeout|--timeout|-TimeoutSec/i;
+const BOUNDED_CURL = /(?:^|\s)-[a-zA-Z]*m\s*\d/i;
+const BOUNDED_WGET = /(?:^|\s)-T\s*\d/i;
+const isBounded = (seg) =>
+  BOUNDED_LONG.test(seg) ||
+  (/(?:^|[;&|`]|\$\()\s*(?:\w+=\S*\s+)*(?:sudo\s+)?curl\b/i.test(seg) && BOUNDED_CURL.test(seg)) ||
+  (/(?:^|[;&|`]|\$\()\s*(?:\w+=\S*\s+)*(?:sudo\s+)?wget\b/i.test(seg) && BOUNDED_WGET.test(seg));
+
+// Command position only: start of a segment, after a pipe, or inside `$(`/backticks.
+const REQUEST_TOOL =
+  /(?:^|[;&|`]|\$\()\s*(?:\w+=\S*\s+)*(?:sudo\s+)?(?:curl|wget|iwr|Invoke-WebRequest|Invoke-RestMethod)(?:\s|$)/i;
+
+export function unboundedDevRequest(command) {
+  return command
+    .split(/[;&|\n]+/)
+    .map((seg) => seg.trim())
+    .filter((seg) => seg && !seg.startsWith('#'))
+    .filter((seg) => DEV_PORTS.test(seg.replace(/[?&][^\s"']*/g, '')))
+    .filter((seg) => REQUEST_TOOL.test(seg))
+    .filter((seg) => !isBounded(seg));
+}
+
 // Patterns that would kill Claude Code or critical processes - BLOCK OUTRIGHT
 const DANGEROUS_PATTERNS = [
   { pattern: /taskkill\s+\/\/F\s+\/\/IM\s+node\.exe/i, reason: 'This would kill all Node.js processes including Claude Code itself' },
@@ -97,6 +133,14 @@ const DANGEROUS_PATTERNS = [
 
 // Expensive or historically destructive, but sometimes legitimate — confirm rather than block.
 const GUARDED_PATTERNS = [
+  {
+    check: (command) => unboundedDevRequest(command).length > 0,
+    reason:
+      'An unbounded request at a local dev port hangs for the full 300s tool timeout when the ' +
+      'server is unhealthy, and tells you nothing about why. Prefer: node ' +
+      '.claude/skills/dev-server/cli.mjs probe <route> — it bounds the request and reports WHY it ' +
+      'was slow, with the matching remedy. Or add --max-time <seconds>.',
+  },
   {
     pattern: /svelte-kit\s+sync|pnpm\s+(run\s+)?check\b/i,
     reason:
@@ -126,7 +170,10 @@ stdin.on('end', () => {
     // describes a blocked command is not an attempt to run it, and blocking those makes the incident
     // impossible to write down.
     const command = rawCommand
-      .replace(/<<-?\s*['"]?(\w+)['"]?[\s\S]*?^\1$/gm, ' ')
+      // `^[ \t]*\1[ \t]*$`, not `^\1$`: the `<<-` form exists precisely to allow an indented
+      // terminator, and a heredoc written inside an indented block has one too. Requiring column 0
+      // leaked those bodies into the matcher, so writing the incident down got flagged.
+      .replace(/<<-?\s*['"]?(\w+)['"]?[\s\S]*?^[ \t]*\1[ \t]*$/gm, ' ')
       .replace(/-m\s+(['"])[\s\S]*?\1/g, ' ');
 
     // Check for dangerous commands that should be blocked outright (no confirmation possible)

--- a/.claude/hooks/check-writable.selftest.mjs
+++ b/.claude/hooks/check-writable.selftest.mjs
@@ -1,0 +1,54 @@
+/**
+ * `node .claude/hooks/check-writable.selftest.mjs`
+ *
+ * A guard people route around protects nothing, so the false-positive rows matter as much as the
+ * blocked ones: a request that already carries a bound, a request to production, and a command that
+ * only mentions a port must all run untouched.
+ */
+
+import { unboundedDevRequest } from './check-writable.mjs';
+
+let failures = 0;
+const check = (name, cmd, expectBlocked) => {
+  const blocked = unboundedDevRequest(cmd).length > 0;
+  const pass = blocked === expectBlocked;
+  if (!pass) failures++;
+  console.log(`${pass ? 'PASS' : 'FAIL'}  ${name}  blocked=${blocked} want=${expectBlocked}`);
+};
+
+check('bare curl at 3000', 'curl http://localhost:3000/home', true);
+check('port 3010 (findAvailablePort scans 100 ports)', 'curl http://localhost:3010/home', true);
+check('command substitution', 'X=$(curl http://localhost:3000/home)', true);
+check('backticks', 'X=`curl http://localhost:3000/home`', true);
+check('0.0.0.0', 'curl http://0.0.0.0:3000/x', true);
+
+// False positives. Every row below was a hard BLOCK before this was narrowed to command position;
+// a guard that stops prose, comments and production traffic is one people route around.
+check('prose mentioning it', 'echo "do not curl http://localhost:3000/home"', false);
+check('shell comment', '# curl http://localhost:3000/home is what NOT to do', false);
+check('writing the incident down', 'printf "%s" " curl http://localhost:3000/x" >> notes.md', false);
+check('production URL with a dev port in a query param', 'curl "https://civitai.com/cb?redirect=http://localhost:3000/x"', false);
+check('curl -m5 (no space)', 'curl -m5 http://localhost:3000/home', false);
+check('curl -sm 5 (bundled shorts)', 'curl -sm 5 http://localhost:3000/home', false);
+check('wget -T 5', 'wget -T 5 http://localhost:3000/x', false);
+// -T is curl's --upload-file and -m is wget's --mirror: neither bounds anything.
+check('curl -T is upload-file, not a bound', 'curl -T 5.json http://localhost:3000/upload', true);
+check('wget -m is mirror, not a bound', 'wget -m 3 http://localhost:3000/', true);
+check('curl 127.0.0.1', 'curl -s http://127.0.0.1:3001/models', true);
+check('chained curls', 'curl localhost:3000/a && curl localhost:3000/b && node x.mjs', true);
+check('vite app port', 'curl http://localhost:5174/', true);
+check('daemon port', 'curl http://localhost:9444/sessions', true);
+check('powershell iwr', 'Invoke-WebRequest http://localhost:3000/home', true);
+
+check('curl with --max-time', 'curl --max-time 30 http://localhost:3000/home', false);
+check('curl with -m', 'curl -m 5 http://localhost:3000/home', false);
+check('curl with --connect-timeout', 'curl --connect-timeout 3 http://localhost:3000/x', false);
+check('iwr with -TimeoutSec', 'Invoke-WebRequest -TimeoutSec 10 http://localhost:3000/x', false);
+check('curl to prod', 'curl https://civitai.com/api/v1/models', false);
+check('curl to other local port', 'curl http://localhost:8080/thing', false);
+check('no curl at all', 'node .claude/skills/dev-server/cli.mjs probe /home', false);
+check('mentions the port only', 'echo "the dev server is on localhost:3000"', false);
+check('probe command itself', 'node cli.mjs probe /home --port 3000', false);
+
+console.log(failures ? `\n${failures} FAILURES` : '\nall green');
+process.exit(failures ? 1 : 0);

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -31,10 +31,120 @@ node .claude/skills/dev-server/cli.mjs stop <session-id>
 
 **Checking if server is ready:** After starting, poll the session status to check `ready: true`. The daemon marks sessions ready either via configured health check endpoint or by detecting "Ready" patterns in logs.
 
+## Never curl a dev port — `probe` instead
+
+```bash
+node .claude/skills/dev-server/cli.mjs probe /home
+```
+
+A dev server that has stopped serving properly does not refuse connections. It accepts and answers
+slowly, or accepts and never answers — so an unbounded `curl` sits there until the 300s tool timeout
+and returns nothing you can act on. Chaining a few in one shell call is how ten minutes disappear.
+A `PreToolUse` hook blocks unbounded requests at dev ports for this reason; `--max-time` is the
+escape hatch if you really want curl.
+
+`probe` requests the route twice with a hard budget, reads the session's own log for those two
+requests, and returns a verdict with the matching remedy. It always terminates.
+
+```
+UPSTREAM-SLOW  http://localhost:3000/home
+  UPSTREAM-SLOW — the framework is fine; time is spent in application code (database, tunnel, cache).
+  first : 200 in 8.10s  [next.js 30ms | application-code 8.10s]
+  repeat: 200 in 8.10s  [next.js 31ms | application-code 8.10s]
+  -> Not a cache problem — do NOT purge, it will not help. [...]
+```
+
+Exit code is 0 for `ok`/`cold` and 1 for everything else, so it substitutes for a curl in a check.
+
+Two verdicts worth knowing before you meet them. **`stopped-answering`** means the first request was
+served and the second was not — the process is up and something inside it has parked, so starting
+another session is the wrong move and the remedy says so. And a probe may add
+`note: more than one request to this route in the window`: `probe` tags its own request with a
+`?__probe=` nonce so it can find its own log line, but a route that already has a query string —
+and every `/api/trpc/*` route, whose handlers parse their query — falls back to matching on the
+path, where a busy session's traffic is genuinely indistinguishable from ours. The note means the
+reading may not be about your request, which is different from the server declining to explain
+itself.
+
+### Why timing alone cannot tell you what is wrong
+
+Two different failures produce the **same** shape — a page that takes ~8s, warm and cold alike, with
+a 200 and nothing in the log that reads as an error. Health checks keep passing through both, because
+`/api/health` is a cheap already-compiled API route and neither failure touches what it does.
+
+Next already separates them on every request line it prints:
+
+```
+ GET /home 200 in 8.1s (next.js: 39ms, proxy.ts: 8ms, application-code: 8.1s)
+```
+
+| Reading | Meaning | Remedy |
+|---|---|---|
+| `next.js` dominates on a **repeat** hit | The build cache is not serving; the framework redoes the work every time | `unwedge` — purge and restart |
+| `application-code` dominates | The framework is fine; the time is downstream (database, tunnel, cache) | Fix the upstream. **Purging costs 45s and changes nothing** |
+| Repeat is fast | Cold compile, working as designed | Nothing |
+
+**Two failures are FAST, and both are checked before any timing rule**, because a verdict of `ok` on
+a broken page is worse than no verdict. A stale `node_modules` after a merge or checkout 500s in
+milliseconds (`STALE-DEPS` — the fix is `pnpm install`, and purging the build cache installs
+nothing); and the settings self-fetch case below renders a degraded page quickly.
+
+**One case defeats the split, and `probe` checks for it first.** `_app` self-fetches
+`/api/user/settings` on every SSR render and aborts at `APP_SETTINGS_FETCH_TIMEOUT_MS` (8s default).
+That abort is billed to *application-code*, so a server that cannot answer its own API route reads as
+"slow database" on the split alone. The greppable marker `[_app] settings bootstrap fetch failed`
+outranks the timing, and the verdict is `SELF-FETCH-FAILING`; `probe` then requests that endpoint
+directly and tells you which of the two causes you have — a self-fetch aimed at the wrong port
+(`NEXTAUTH_URL_INTERNAL` vs the session's port) or an endpoint that genuinely never answers.
+
+The tell that separates it from any slow dependency: **the page time is a constant equal to a
+configured timeout**, identical warm and cold. A slow dependency varies; a timeout does not. Measured
+2026-08-16 — moving `APP_SETTINGS_FETCH_TIMEOUT_MS` from 8000 to 30000 moved `/home` from 8.1s to
+30.1s in lockstep, and purging `.next` did not help at either value.
+
+Worth knowing when you read that verdict: `updateEnvUrlsForPort` returns early on port 3000, so a
+primary session uses `NEXTAUTH_URL_INTERNAL` exactly as the `.env` writes it while every secondary
+session gets it rewritten to its own port. The value is correct today — this is only why the two
+kinds of session can differ, and why the verdict asks you to compare it against the session's port.
+
+This is why "flat 8s means purge `.next`" is wrong as a rule and cost real time as a habit: measured
+on this repo on 2026-08-16, a flat 8.1s `/home` was **30ms of framework and 8.1s of application
+code** — a purge would have deleted several GB and fixed nothing. Read the split, not the total.
+
+When the split is unavailable (log buffer overran, no session), the verdict is `slow-unclassified`
+and it says so rather than guessing.
+
+### `unwedge` — only after a `WEDGED` verdict
+
+```bash
+node .claude/skills/dev-server/cli.mjs unwedge <session-id>
+```
+
+Stops the session, deletes its build dir, restarts on the same env modes, waits for ready, re-probes,
+and prints each timing. It costs a guaranteed ~45s rebuild, so it is not automatic and it does not
+guess a session: name the id, because the session you did not name is usually the one someone is
+looking at.
+
+Self-tests — run all three after touching `probe.mjs` or the hook:
+
+```bash
+node .claude/skills/dev-server/scripts/probe.selftest.mjs              # the classifier, pure
+node .claude/skills/dev-server/scripts/probe.integration.selftest.mjs  # the real probe() end to end
+node .claude/hooks/check-writable.selftest.mjs                         # the hook, both directions
+```
+
+The integration one exists because the unit one cannot see the bug that matters most. `runSample`
+once dropped `missingModule` on the way to `classify`, so the whole `stale-deps` verdict was dead
+code — and every unit case for it passed, because they hand-built the field the shipping code never
+produced. **Reintroduce that bug today and the unit test is still green while the integration test
+fails.** Anything that adds a new signal belongs in the integration file, not just the unit one.
+
 ## CLI Commands
 
 | Command | Description |
 |---------|-------------|
+| `probe [route]` | Bounded request + verdict (`ok`/`cold`/`wedged`/`stale-deps`/`upstream-slow`/`proxy-slow`/`error-status`/`self-fetch-failing`). Use instead of curl |
+| `unwedge <session-id>` | Stop, purge the build dir, restart, wait, re-probe (~45s) |
 | `status` | Check daemon status and list all sessions |
 | `list` | List all dev sessions |
 | `start [worktree] [--prod a,b] [--dev a,b]` | Start dev server (default: current directory) |

--- a/.claude/skills/dev-server/cli.mjs
+++ b/.claude/skills/dev-server/cli.mjs
@@ -511,6 +511,220 @@ async function cmdShutdown() {
   }
 }
 
+function samePath(a, b) {
+  if (!a || !b) return false;
+  const norm = (p) => resolve(p).replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+  return norm(a) === norm(b);
+}
+
+async function resolveSession(sessionId) {
+  const result = await daemonRequest('/sessions');
+  const sessions = result.data?.sessions ?? [];
+  if (sessionId) {
+    const found = sessions.find((s) => s.id === sessionId);
+    if (!found) {
+      console.error(`No session ${sessionId}. Known: ${sessions.map((s) => s.id).join(', ') || 'none'}`);
+      process.exit(1);
+    }
+    return found;
+  }
+  const cwd = process.cwd();
+  return (
+    sessions.find((s) => samePath(s.worktree, cwd)) ??
+    sessions.find((s) => s.status === 'running') ??
+    sessions[0] ??
+    null
+  );
+}
+
+// Flags that take a VALUE. Without this the positional scan treats the value as the route, so
+// `probe --port 3005 /home` probes `/3005` — a fast 404 that used to report `ok`. Same class of
+// wrong-confident answer the Git Bash de-mangling exists to prevent, arriving from the caller.
+const VALUE_FLAGS = new Set(['--port', '--session', '--timeout', '--route']);
+
+// A flag nobody reads is a flag silently ignored, and `unwedge` is the destructive command — so it
+// gets the check too, not just `probe`.
+function rejectUnknownFlags(args, allowed, usage) {
+  const unknown = args.filter((a) => a.startsWith('--') && !allowed.includes(a.split('=')[0]));
+  if (!unknown.length) return;
+  console.error(`Unknown option${unknown.length > 1 ? 's' : ''}: ${unknown.join(', ')}`);
+  console.error(`Usage: ${usage}`);
+  process.exit(1);
+}
+
+export function positionalArgs(args) {
+  const out = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (VALUE_FLAGS.has(a)) {
+      i++;
+      continue;
+    }
+    if (a.startsWith('--')) continue;
+    out.push(a);
+  }
+  return out;
+}
+
+// Both spellings. `--session=abc` used to be skipped by the positional scan and ignored by the
+// lookup, so it read as accepted and silently probed a different session.
+export function stringFlag(args, name) {
+  const inline = args.find((a) => a.startsWith(`${name}=`));
+  if (inline) return inline.slice(name.length + 1) || undefined;
+  const index = args.indexOf(name);
+  return index !== -1 ? args[index + 1] : undefined;
+}
+
+// `min` is per-flag: a timeout under a second is a mistake, but `--port 80` is not.
+function numericFlag(args, name, fallback, min = 1) {
+  const raw = stringFlag(args, name);
+  if (raw === undefined) return fallback;
+  const value = Number(raw);
+  // `??` does not catch NaN, and `AbortSignal.timeout(NaN)` is not a timeout.
+  if (!Number.isFinite(value) || value < min) {
+    console.error(`${name} needs a number of at least ${min}, got "${raw}"`);
+    process.exit(1);
+  }
+  return value;
+}
+
+async function cmdProbe(rest) {
+  await ensureDaemon();
+  const { probe, formatProbe, normalizeRoute } = await import('./scripts/probe.mjs');
+
+  rejectUnknownFlags(rest, ['--route', '--session', '--port', '--timeout', '--json'],
+    'probe [route] [--route /x] [--session id] [--port n] [--timeout ms] [--json]');
+  // Two routes given, one silently discarded, is the same class of quiet wrong answer as the rest
+  // of this function.
+  if (stringFlag(rest, '--route') && positionalArgs(rest)[0]) {
+    console.error('Give the route once: either positionally or with --route, not both.');
+    process.exit(1);
+  }
+  // `--route` is what the sibling `unwedge` documents, so it gets typed here. Accepting it silently
+  // probed `/` and reported a confident verdict about a route nobody asked for.
+  const { route, mangled } = normalizeRoute(
+    stringFlag(rest, '--route') ?? positionalArgs(rest)[0] ?? '/'
+  );
+  if (mangled) console.log(`(Git Bash rewrote the route; probing ${route})`);
+  const sessionId = stringFlag(rest, '--session');
+  const session = await resolveSession(sessionId);
+  const port = numericFlag(rest, '--port', session?.port);
+
+  if (!port) {
+    console.error('No dev session and no --port. Start one: cli.mjs start');
+    process.exit(1);
+  }
+
+  const result = await probe({
+    route,
+    port,
+    sessionId: session?.id ?? null,
+    worktree: session?.worktree,
+    daemonRequest,
+    timeoutMs: numericFlag(rest, '--timeout', undefined, 1000),
+  });
+
+  console.log(formatProbe(result));
+  if (rest.includes('--json')) console.log(JSON.stringify(result, null, 2));
+  // A wedged or unreachable server is a failure for whoever asked, not a report.
+  process.exit(['ok', 'cold'].includes(result.verdict) ? 0 : 1);
+}
+
+// Explicit session id, always: this stops a running server and deletes several GB, and the session
+// it would otherwise guess at is usually the one someone is looking at.
+async function cmdUnwedge(rest) {
+  await ensureDaemon();
+  const { probe, formatProbe, purgeDistDir, normalizeRoute } = await import('./scripts/probe.mjs');
+
+  rejectUnknownFlags(rest, ['--route'], 'unwedge <session-id> [--route /x]');
+  const sessionId = positionalArgs(rest)[0];
+  if (!sessionId) {
+    console.error('Usage: unwedge <session-id> [--route /home]');
+    console.error('Takes the server down for ~45s. Name the session deliberately.');
+    process.exit(1);
+  }
+  const session = await resolveSession(sessionId);
+  const { route } = normalizeRoute(stringFlag(rest, '--route') ?? '/');
+
+  // Restart on the modes it is already running, so unwedging never silently relocates a session.
+  // Both halves, explicitly. Sending only the prod list lets DEVSERVER_PROD_GROUPS re-decide every
+  // group that was not named — so a session deliberately started `--dev db` could come back up on
+  // the PRODUCTION database, with nothing but a mode summary scrolling past to say so.
+  const groups = Object.entries(session.envModes || {});
+  const prod = groups.filter(([, m]) => m === 'prod').map(([g]) => g).join(',');
+  // `m === 'dev'`, NOT `m !== 'prod'`. getStatus() also reports `base` — a group with no section
+  // for the chosen mode, which the resolver deliberately tolerates. Naming one on a flag turns that
+  // tolerated case into a throw, and this runs AFTER the purge, so the session is already down.
+  const dev = groups.filter(([, m]) => m === 'dev').map(([g]) => g).join(',');
+
+  console.log(`Stopping ${session.id} (${session.branch}) on port ${session.port}...`);
+  const stopped = await daemonRequest(`/sessions/${session.id}`, { method: 'DELETE' });
+  if (!stopped.ok) {
+    console.error('Error stopping session:', stopped.error || stopped.data?.error);
+    process.exit(1);
+  }
+
+  const purgeStart = Date.now();
+  let purged;
+  try {
+    purged = purgeDistDir(session.worktree, session.distDir);
+  } catch (err) {
+    console.error(`${err.message}\nThe session is stopped; start it again with: cli.mjs start ${session.worktree}`);
+    process.exit(1);
+  }
+  console.log(
+    purged.removed
+      ? `Purged ${purged.path} in ${((Date.now() - purgeStart) / 1000).toFixed(1)}s`
+      : `Nothing to purge at ${purged.path}`
+  );
+
+  const started = await daemonRequest('/sessions', {
+    method: 'POST',
+    body: JSON.stringify({ worktree: session.worktree, prod, dev }),
+  });
+  if (!started.ok) {
+    console.error('Error restarting session:', started.error || started.data?.error);
+    // The build dir is already gone at this point; say how to get a server back.
+    console.error(`The session is stopped and its build dir was purged. Start it again with:`);
+    console.error(`  node .claude/skills/dev-server/cli.mjs start ${session.worktree}`);
+    process.exit(1);
+  }
+  const fresh = started.data?.session ?? started.data;
+  const newId = fresh?.id ?? session.id;
+  console.log(`Restarted as ${newId} on port ${fresh?.port ?? session.port}.`);
+
+  const readyStart = Date.now();
+  const READY_TIMEOUT_MS = 180_000;
+  for (;;) {
+    const check = await daemonRequest(`/sessions/${newId}`);
+    const state = check.data?.session ?? check.data;
+    if (state?.ready) {
+      console.log(`Ready in ${((Date.now() - readyStart) / 1000).toFixed(1)}s.`);
+      break;
+    }
+    if (state?.status === 'crashed' || state?.status === 'error') {
+      console.error(`Session ${state.status}. Read: cli.mjs logs ${newId}`);
+      process.exit(1);
+    }
+    if (Date.now() - readyStart > READY_TIMEOUT_MS) {
+      console.error(`Not ready after ${READY_TIMEOUT_MS / 1000}s. Read: cli.mjs logs ${newId}`);
+      process.exit(1);
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+
+  console.log('');
+  const result = await probe({
+    route,
+    port: fresh?.port ?? session.port,
+    sessionId: newId,
+    worktree: session.worktree,
+    daemonRequest,
+  });
+  console.log(formatProbe(result));
+  process.exit(['ok', 'cold'].includes(result.verdict) ? 0 : 1);
+}
+
 async function cmdWorktree(rest) {
   const [action, ...tail] = rest;
   const { cmdStale, cmdRemove } = await import('./scripts/worktree.mjs');
@@ -581,6 +795,12 @@ switch (command) {
   case 'test':
     cmdTest(arg1, args.slice(2));
     break;
+  case 'probe':
+    cmdProbe(args.slice(1));
+    break;
+  case 'unwedge':
+    cmdUnwedge(args.slice(1));
+    break;
   case 'wt':
     cmdWorktree(args.slice(1));
     break;
@@ -594,6 +814,11 @@ Commands:
                       Start a dev server (default: current directory).
                       Every env group defaults to dev; --prod moves named groups
                       (or "all") to production for this start only. See SKILL.md.
+  probe [route]       Request a route with a hard timeout and say WHY it was slow.
+                      Never hangs. Use this instead of curl against a dev port.
+                      [--session id] [--port n] [--timeout ms] [--json]
+  unwedge <session>   Stop, delete the build dir, restart, wait for ready, re-probe.
+                      ~45s of downtime — only after probe says WEDGED.
   logs [session-id]   Get logs for a session
   tail [session-id]   Tail logs continuously
   stop <session-id>   Stop a session

--- a/.claude/skills/dev-server/scripts/probe.integration.selftest.mjs
+++ b/.claude/skills/dev-server/scripts/probe.integration.selftest.mjs
@@ -1,0 +1,244 @@
+/**
+ * `node .claude/skills/dev-server/scripts/probe.integration.selftest.mjs`
+ *
+ * Drives the REAL `probe()` against a real local HTTP server and a stubbed daemon, because the
+ * unit self-test could not have caught the bug that mattered most: `runSample` destructured the
+ * fields it forwarded to `classify`, and `missingModule` was simply not among them. The whole
+ * `stale-deps` verdict was dead code, and every unit case for it passed — they hand-built the very
+ * field the shipping code never produced.
+ *
+ * So the rule these cases enforce is the propagation boundary: a signal that `readServerView`
+ * extracts has to survive all the way to a verdict.
+ */
+
+import { createServer } from 'http';
+import { probe, REMEDIES } from './probe.mjs';
+
+let failures = 0;
+function check(name, actual, expected) {
+  const pass = actual === expected;
+  if (!pass) failures++;
+  console.log(`${pass ? 'PASS' : 'FAIL'}  ${name}  got=${actual} want=${expected}`);
+}
+
+// The URL the server actually saw. `probe` appends a `__probe=` nonce so it can identify its own
+// request in the log, so a fixture that hardcodes the bare path no longer matches — which is the
+// point of the nonce. `{url}` in a fixture line is substituted with what the server received.
+let lastUrl = '/';
+
+const stubDaemon = (lines) => async (path) => {
+  if (path.includes('/logs')) {
+    return {
+      ok: true,
+      data: {
+        logs: lines.map((message, index) => ({ index, message: message.replace('{url}', lastUrl) })),
+      },
+    };
+  }
+  return { ok: true, data: { session: { currentLogIndex: 0 } } };
+};
+
+async function withServer(handler, fn) {
+  const server = createServer((req, res) => {
+    lastUrl = req.url;
+    handler(req, res);
+  });
+  // Bind what `probe` dials. Binding 127.0.0.1 while probing `localhost` relies on the client
+  // falling back from ::1, and if it ever stops, every case here fails as `down` and reads as five
+  // real regressions.
+  await new Promise((r) => server.listen(0, 'localhost', r));
+  try {
+    return await fn(server.address().port);
+  } finally {
+    await new Promise((r) => server.close(r));
+  }
+}
+
+const run = (port, lines, route = '/home') =>
+  probe({ route, port, sessionId: 's1', daemonRequest: stubDaemon(lines), timeoutMs: 5000 });
+
+// The regression. A stale node_modules 500s FAST, so every timing signal reads healthy.
+await withServer(
+  (req, res) => {
+    res.statusCode = 500;
+    res.end('boom');
+  },
+  async (port) => {
+    const r = await run(port, [
+      "Module not found: Can't resolve 'html2canvas'",
+      ' GET {url} 500 in 120ms (next.js: 90ms, application-code: 20ms)',
+    ]);
+    check('stale-deps survives the runSample boundary', r.verdict, 'stale-deps');
+    check('and it reaches the sample payload', Boolean(r.samples[0].missingModule), true);
+  }
+);
+
+// A fast 404 is not a healthy server.
+await withServer(
+  (req, res) => {
+    res.statusCode = 404;
+    res.end('nope');
+  },
+  async (port) => {
+    const r = await run(port, [' GET {url} 404 in 30ms (next.js: 20ms, application-code: 5ms)']);
+    check('fast 404 is not ok', r.verdict, 'error-status');
+  }
+);
+
+// Someone else's compile in the window must not authorise a purge.
+await withServer(
+  (req, res) => setTimeout(() => res.end('slow'), 60),
+  async (port) => {
+    const r = await run(port, [
+      '○ Compiling /models ...',
+      ' GET {url} 200 in 8.1s (next.js: 30ms, application-code: 8.1s)',
+    ]);
+    check('unrelated compile does not mean wedged', r.verdict, 'upstream-slow');
+  }
+);
+
+// Middleware time is neither the build cache nor the database.
+await withServer(
+  (req, res) => setTimeout(() => res.end('slow'), 60),
+  async (port) => {
+    const r = await run(port, [
+      ' GET {url} 200 in 8.0s (next.js: 50ms, proxy.ts: 7.9s, application-code: 40ms)',
+    ]);
+    check('proxy-dominant is its own verdict', r.verdict, 'proxy-slow');
+  }
+);
+
+// An ambiguous split must not authorise a 45s rebuild.
+await withServer(
+  (req, res) => setTimeout(() => res.end('slow'), 60),
+  async (port) => {
+    const r = await run(port, [
+      ' GET {url} 200 in 8.0s (next.js: 4.1s, application-code: 3.9s)',
+    ]);
+    check('51/49 split is unclassified, not wedged', r.verdict, 'slow-unclassified');
+  }
+);
+
+// The other signal that travels the same spread as `missingModule`. Without a case here, moving
+// the bug one identifier to the left is invisible again.
+await withServer(
+  (req, res) => res.end('degraded'),
+  async (port) => {
+    const r = await run(port, [
+      '[_app] settings bootstrap fetch failed, rendering without it: The operation was aborted',
+      ' GET {url} 200 in 300ms (next.js: 40ms, application-code: 200ms)',
+    ]);
+    check('self-fetch marker survives the same boundary', r.verdict, 'self-fetch-failing');
+  }
+);
+
+// R3: ranking the slices against each other only. `proxy.ts: 0ms` is the normal reading for a route
+// middleware does not match, and `x < 0 * 1.3` is false for every x.
+await withServer(
+  (req, res) => setTimeout(() => res.end('slow'), 60),
+  async (port) => {
+    const r = await run(port, [
+      ' GET {url} 200 in 8.0s (next.js: 5ms, proxy.ts: 0ms, application-code: 0ms)',
+    ]);
+    check('a 5ms slice cannot explain an 8s request', r.verdict, 'slow-unclassified');
+  }
+);
+
+// R6: a SLOW error must keep its diagnosis instead of being labelled fast-and-wrong.
+await withServer(
+  (req, res) => {
+    res.statusCode = 500;
+    setTimeout(() => res.end('boom'), 60);
+  },
+  async (port) => {
+    const r = await run(port, [
+      ' GET {url} 500 in 8.0s (next.js: 40ms, application-code: 7.9s)',
+    ]);
+    check('slow 500 keeps the split', r.verdict, 'upstream-slow');
+  }
+);
+
+// R4: Next announces the route PATTERN, so a dynamic route never matched by string equality.
+await withServer(
+  (req, res) => setTimeout(() => res.end('slow'), 60),
+  async (port) => {
+    const r = await run(
+      port,
+      [
+        '○ Compiling /models/[id] ...',
+        ' GET {url} 200 in 8.0s (next.js: 7.9s, application-code: 40ms)',
+      ],
+      '/models/1234'
+    );
+    check('dynamic-route compile is recognised', r.verdict, 'wedged');
+  }
+);
+
+// R5: a FAILED log read is not the server declining to explain itself.
+await withServer(
+  (req, res) => res.end('ok'),
+  async (port) => {
+    const failingDaemon = async (path) =>
+      path.includes('/logs') ? { ok: false } : { ok: true, data: { session: { currentLogIndex: 0 } } };
+    const r = await probe({
+      route: '/home',
+      port,
+      sessionId: 's1',
+      daemonRequest: failingDaemon,
+      timeoutMs: 5000,
+    });
+    check('failed log read is reported as unread', r.samples[0].logUnread, true);
+  }
+);
+
+// The remedy is where a wrong verdict actually costs someone 45s, so pin the mapping, not just the
+// label.
+await withServer(
+  (req, res) => setTimeout(() => res.end('slow'), 60),
+  async (port) => {
+    const r = await run(port, [
+      ' GET {url} 200 in 8.0s (next.js: 50ms, proxy.ts: 7.9s, application-code: 40ms)',
+    ]);
+    // The command, not the word: the remedy says "do NOT purge", and matching on `purge` alone
+    // fails a correct string.
+    check('proxy-slow does not hand over the unwedge command', /cli\.mjs unwedge/.test(r.remedy), false);
+    check('wedged does hand it over', /cli\.mjs unwedge/.test(REMEDIES.wedged({ sessionId: 'x' })), true);
+  }
+);
+
+// Nothing listening at all.
+const r = await probe({
+  route: '/home',
+  port: 1,
+  sessionId: null,
+  daemonRequest: stubDaemon([]),
+  timeoutMs: 2000,
+});
+check('closed port is down', r.verdict, 'down');
+check('and it says the log was never read', r.samples[0].logUnread, true);
+
+// An explicit --timeout must bound BOTH samples. The previous arithmetic,
+// max(30000, min(30000, x)), is the constant 30000 for every input, so a 5s budget ran a 30s
+// repeat — and every case in this file passes 5000, so all of them were doing it unnoticed.
+await withServer(
+  () => {
+    /* never responds */
+  },
+  async (port) => {
+    const started = Date.now();
+    const r = await probe({
+      route: '/home',
+      port,
+      sessionId: 's1',
+      daemonRequest: stubDaemon([]),
+      timeoutMs: 2000,
+    });
+    const elapsed = Date.now() - started;
+    check('an explicit timeout bounds both samples', elapsed < 6000, true);
+    check('and a server that never answers is a timeout', r.verdict, 'timeout');
+    if (elapsed >= 6000) console.log(`      took ${elapsed}ms`);
+  }
+);
+
+console.log(failures ? `\n${failures} FAILURES` : '\nall green');
+process.exit(failures ? 1 : 0);

--- a/.claude/skills/dev-server/scripts/probe.mjs
+++ b/.claude/skills/dev-server/scripts/probe.mjs
@@ -1,0 +1,446 @@
+/**
+ * Bounded request against a dev session, classified by mechanism rather than by wall time.
+ *
+ * Next prints its own split on every request line —
+ *   ` GET /images 500 in 3.7s (next.js: 3.7s, proxy.ts: 6ms, application-code: 8ms)`
+ * — so "the framework is redoing work" and "something downstream is slow" are already separated at
+ * the source. That is the whole discriminator: a timing threshold cannot tell a stale build cache
+ * from a slow database over a tunnel, and both produce the same flat slow page.
+ */
+
+import { randomUUID } from 'crypto';
+import { rmSync, existsSync } from 'fs';
+import { resolve, relative, isAbsolute } from 'path';
+
+// A warm page in this app answers in ~0.6s; /api/health's application-code alone is ~1s.
+const FAST_MS = 1500;
+
+// A first hit that compiles the shared graph legitimately costs ~45s.
+const DEFAULT_TIMEOUT_MS = 90_000;
+const REPEAT_TIMEOUT_MS = 30_000;
+
+const REQUEST_LINE =
+  /^\s*(GET|POST|PUT|PATCH|DELETE|HEAD)\s+(\S+)\s+(\d{3})\s+in\s+([\d.]+\s*m?s)(?:\s*\(([^)]*)\))?/;
+
+export function parseDuration(text) {
+  const match = String(text).trim().match(/^([\d.]+)\s*(ms|s|m)$/);
+  if (!match) return null;
+  const value = parseFloat(match[1]);
+  if (Number.isNaN(value)) return null;
+  return match[2] === 'ms' ? value : match[2] === 's' ? value * 1000 : value * 60_000;
+}
+
+// ` GET /x 200 in 3.1s (next.js: 3.0s, application-code: 47ms)` -> the parts that discriminate.
+export function parseRequestLine(message) {
+  const match = String(message).match(REQUEST_LINE);
+  if (!match) return null;
+  const parts = {};
+  for (const chunk of (match[5] || '').split(',')) {
+    const [name, value] = chunk.split(':').map((s) => s && s.trim());
+    if (name && value) parts[name] = parseDuration(value);
+  }
+  return {
+    method: match[1],
+    path: match[2],
+    status: Number(match[3]),
+    totalMs: parseDuration(match[4]),
+    nextMs: parts['next.js'] ?? null,
+    proxyMs: parts['proxy.ts'] ?? null,
+    appMs: parts['application-code'] ?? null,
+  };
+}
+
+// Git Bash rewrites a leading-slash argument into a Windows path (`/home` -> `C:/Program
+// Files/Git/home`) before this process ever sees it. Probing the mangled string returns a fast,
+// confident 404 about a route nobody asked for — the exact shape of wrong answer this command
+// exists to stop — so undo it rather than trusting the argument.
+export function normalizeRoute(route) {
+  const match = String(route).match(/^[A-Za-z]:[\\/].*?[\\/]Git[\\/](.*)$/);
+  const cleaned = match ? `/${match[1]}` : route;
+  const normalized = cleaned.replace(/\\/g, '/');
+  return {
+    route: normalized.startsWith('/') ? normalized : `/${normalized}`,
+    mangled: Boolean(match),
+  };
+}
+
+// `/models/[id]` matches `/models/1234`; `/docs/[...slug]` matches the rest of the path. Next also
+// strips a trailing slash when it formats the trigger, so compare without one.
+export function routePatternMatches(pattern, pathname) {
+  const trim = (v) => (v.length > 1 ? v.replace(/\/+$/, '') : v);
+  const pat = trim(pathnameOf(pattern));
+  const path = trim(pathname);
+  if (pat === path) return true;
+  if (!pat.includes('[')) return false;
+  let source = '';
+  for (const seg of pat.replace(/^\//, '').split('/')) {
+    // `[[...slug]]` is the OPTIONAL catch-all and must match zero segments, so it swallows the
+    // slash in front of it: `/docs/[[...slug]]` has to match `/docs`.
+    if (/^\[\[\.\.\..+\]\]$/.test(seg)) source += '(?:/.*)?';
+    else if (/^\[\.\.\..+\]$/.test(seg)) source += '/.*';
+    else if (/^\[.+\]$/.test(seg)) source += '/[^/]+';
+    else source += `/${seg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`;
+  }
+  try {
+    return new RegExp(`^${source}$`).test(path);
+  } catch {
+    // This reads arbitrary server stdout. A pattern that will not compile is not a match, and it is
+    // certainly not a reason to take `probe` down mid-window.
+    return false;
+  }
+}
+
+function pathnameOf(target) {
+  const q = target.indexOf('?');
+  return q === -1 ? target : target.slice(0, q);
+}
+
+// Reads the session's own stdout for what the server thought it was doing during our request.
+// `_app` self-fetches /api/user/settings on every SSR render and aborts it at
+// APP_SETTINGS_FETCH_TIMEOUT_MS (8s). That abort is charged to application-code, so a server too
+// sick to answer its own API route reads as "slow upstream" on the split alone — the one case where
+// the split points at the wrong half of the stack. The marker is the tell, and it outranks timing.
+const SELF_FETCH_FAILED = /\[_app\] settings bootstrap fetch failed/;
+
+// A branch or merge that adds a dependency leaves node_modules behind, and the page then 500s
+// FAST. Fast is what makes this one its own verdict: every other failure here is slow, so the
+// timing signals say "healthy" and the reflex that follows is to purge the build cache — a ~45s
+// rebuild that reinstalls nothing and changes nothing. Cost someone a full purge cycle on
+// 2026-08-15 after a merge brought in html2canvas.
+const MISSING_MODULE = /Module not found|Cannot find module|ERR_MODULE_NOT_FOUND/;
+const SETTINGS_ROUTE = '/api/user/settings';
+const SETTINGS_PROBE_MS = 15_000;
+
+function readServerView(logs, route, nonce) {
+  const wanted = pathnameOf(route);
+  let line = null;
+  let matches = 0;
+  let compiled = false;
+  let selfFetchFailed = false;
+  let missingModule = null;
+  for (const entry of logs) {
+    const message = entry.message || '';
+    // Only OUR route counts. A human clicking around, or a file save, puts someone else's
+    // `Compiling` line in the window — and `compiled` short-circuits straight to `wedged`, whose
+    // remedy deletes the build dir of a session they are using.
+    //
+    // Next logs the route PATTERN, not the URL: /models/1234 is announced as
+    // `Compiling /models/[id]`. Comparing strings made this inert for every dynamic route —
+    // 113 of 566 files under src/pages, including all of /api/trpc.
+    const compiling = message.match(/[○o]?\s*Compiling\s+(\S+)/);
+    if (compiling && routePatternMatches(compiling[1], wanted)) compiled = true;
+    if (SELF_FETCH_FAILED.test(message)) selfFetchFailed = true;
+    if (!missingModule && MISSING_MODULE.test(message)) missingModule = message.trim().slice(0, 200);
+    const parsed = parseRequestLine(message);
+    if (!parsed) continue;
+    // With a nonce we can identify OUR request exactly: Next logs the full query string, so the
+    // token appears on our line and on nobody else's. Without one (see probe()), fall back to the
+    // pathname and count the matches, so an ambiguous window can say so instead of picking.
+    const mine = nonce ? parsed.path.includes(nonce) : pathnameOf(parsed.path) === wanted;
+    if (mine) {
+      line = parsed;
+      matches++;
+    }
+  }
+  // Counted on both paths. Both samples share one nonce, so a request line flushed after its own
+  // window closes shows up in the next one — and a nonce path that never counts cannot say so.
+  return { line, compiled, selfFetchFailed, missingModule, ambiguous: matches > 1 };
+}
+
+async function timedFetch(url, timeoutMs) {
+  const started = Date.now();
+  try {
+    // `manual`: following a redirect measures a route we never asked about, and then matches
+    // the log line of the one we did — the timing and the verdict come from different requests.
+    const res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs), redirect: 'manual' });
+    // Draining matters: TTFB alone would call a server healthy that never finishes the body.
+    await res.arrayBuffer();
+    return { ok: true, status: res.status, elapsedMs: Date.now() - started };
+  } catch (err) {
+    const timedOut = err.name === 'TimeoutError' || err.name === 'AbortError';
+    return {
+      ok: false,
+      timedOut,
+      error: err.message,
+      elapsedMs: Date.now() - started,
+    };
+  }
+}
+
+const VERDICTS = {
+  ok: (s) => `OK — answered in ${ms(s.totalMs)} on repeat.`,
+  cold: (s) => `COLD — first hit compiled, repeat came back in ${ms(s.totalMs)}. Nothing to fix.`,
+  wedged: () => 'WEDGED — the build cache is not serving; the framework redoes the work every hit.',
+  'upstream-slow': () =>
+    'UPSTREAM-SLOW — the framework is fine; time is spent in application code (database, tunnel, cache).',
+  'slow-unclassified': () =>
+    'SLOW — repeat is no faster than the first hit, but the server log did not say why.',
+  'stale-deps': () =>
+    'STALE-DEPS — the server answered fast, but it cannot resolve a module. node_modules is behind the checkout, so this is an install, not a cache problem.',
+  'self-fetch-failing': () =>
+    "SELF-FETCH-FAILING — the server cannot reach its OWN /api/user/settings, so every page renders signed-out and degraded. The 8s abort is billed to application-code, so the timing split points the wrong way here.",
+  'error-status': (s) => `ERROR-STATUS — answered ${s.status} in ${ms(s.totalMs)}. Fast, and wrong.`,
+  'proxy-slow': () =>
+    'PROXY-SLOW — the time is in middleware (proxy.ts), not in the framework or in application code.',
+  'stopped-answering': (s) =>
+    `STOPPED-ANSWERING — it answered once, in ${ms(s.firstMs)}, then did not answer at all. The process is up; something inside it has parked.`,
+  timeout: () => 'TIMEOUT — the server did not answer within the budget.',
+  down: () => 'DOWN — nothing answered on that port.',
+};
+
+export const REMEDIES = {
+  wedged: (ctx) =>
+    `Purge and restart: node .claude/skills/dev-server/cli.mjs unwedge ${ctx.sessionId || '<session-id>'}   (~45s rebuild)`,
+  'upstream-slow': () =>
+    'Not a cache problem — do NOT purge, it will not help. Time is in the data this route reads: a session on a remote database pays real latency per query, and a dropped tunnel to one looks exactly like this. Check the session env modes (cli.mjs list) and whatever connection your setup uses to reach them.',
+  'error-status': () =>
+    'Check the route you asked for actually exists — a mistyped route, or a flag value swallowed as the route, lands here. If the route is right, this is the app returning an error, not a sick dev server.',
+  'proxy-slow': () =>
+    'Not the build cache and not the database — do NOT purge. Look at the middleware chain (proxy.ts) for this route.',
+  'slow-unclassified': (ctx) =>
+    `Read the server log before purging: node .claude/skills/dev-server/cli.mjs logs ${ctx.sessionId || '<session-id>'}`,
+  'stale-deps': (ctx) =>
+    `Install, do not purge: pnpm install --prefer-offline${ctx.worktree ? ` (in ${ctx.worktree})` : ''}. A merge or checkout that adds a dependency leaves node_modules behind; the build cache is fine and rebuilding it installs nothing.`,
+  'self-fetch-failing': (ctx) =>
+    ctx.settingsHangs
+      ? `/api/user/settings itself never answers (probed above), so this is the endpoint, not the build cache — a purge costs 45s and changes nothing (measured 2026-08-16: it still hung on a freshly built session). Find what that handler awaits. Meanwhile every page renders signed-out at exactly APP_SETTINGS_FETCH_TIMEOUT_MS.`
+      : `The self-fetch failed but /api/user/settings answers directly, so it is aimed at the wrong place: check NEXTAUTH_URL_INTERNAL in this session's .env against the port in \`cli.mjs list\`. If it matches, the server is too sick to reach itself: node .claude/skills/dev-server/cli.mjs unwedge ${ctx.sessionId || '<session-id>'}`,
+  timeout: (ctx) =>
+    `Check the session is alive (node .claude/skills/dev-server/cli.mjs list). If it is running and every route behaves this way, unwedge ${ctx.sessionId || '<session-id>'}.`,
+  'stopped-answering': (ctx) =>
+    `Do NOT start another session — this one is running. Read what it was doing when it stopped: node .claude/skills/dev-server/cli.mjs logs ${ctx.sessionId || '<session-id>'}`,
+  down: () => 'Start a session: node .claude/skills/dev-server/cli.mjs start',
+};
+
+function ms(value) {
+  if (value == null) return 'unknown';
+  return value >= 1000 ? `${(value / 1000).toFixed(2)}s` : `${Math.round(value)}ms`;
+}
+
+// How much bigger the dominant slice must be before it names a culprit. A 51/49 split between
+// framework and application time is not evidence for either, and the `wedged` remedy costs a ~45s
+// rebuild — so an ambiguous split says so instead of guessing.
+const DOMINANCE = 1.3;
+
+export function classify(first, second) {
+  if (!first.ok && !second.ok) return first.timedOut || second.timedOut ? 'timeout' : 'down';
+  // Answered once, then stopped answering. Falling back to the good sample here reported `ok` for
+  // the exact "sick, not dead" server this command exists to catch — but "nothing is listening" and
+  // "it answered 600ms ago and then stopped" are different states, and the second is the worrying
+  // one. Reporting it as `down` sends you to start a session that is already running.
+  if (!second.ok) return second.timedOut ? 'timeout' : 'stopped-answering';
+
+  // Both of these are FAST failures, so they must beat every timing rule below: a verdict of `ok`
+  // on a broken page is worse than no verdict at all.
+  if (first.missingModule || second.missingModule) return 'stale-deps';
+  if (first.selfFetchFailed || second.selfFetchFailed) return 'self-fetch-failing';
+
+  const view = second.server;
+  const totalMs = view?.totalMs ?? second.elapsedMs;
+  const status = view?.status ?? second.status;
+
+  // A 404/500 served in 30ms is a fast wrong answer, most often a route argument that never
+  // arrived intact. A SLOW error is a different thing entirely — Next dev serves compile-error
+  // 500s slowly as a matter of course — so it falls through to the timing rules, which are what
+  // can still explain it.
+  if (status != null && status >= 400 && totalMs < FAST_MS) return 'error-status';
+  if (totalMs < FAST_MS) return first.compiled || first.elapsedMs >= FAST_MS ? 'cold' : 'ok';
+
+  // Slow on the repeat, so something is doing the work twice or waiting on something.
+  if (second.compiled) return 'wedged';
+  if (!view) return 'slow-unclassified';
+
+  // Next splits its own request line three ways. Name the dominant slice, not the bigger of two.
+  const slices = [
+    ['wedged', view.nextMs],
+    ['upstream-slow', view.appMs],
+    ['proxy-slow', view.proxyMs],
+  ].filter(([, v]) => v != null);
+  if (!slices.length) return 'slow-unclassified';
+  slices.sort((a, b) => b[1] - a[1]);
+  const [[verdict, top], runnerUp] = [slices[0], slices[1]];
+  // Ranking the slices against EACH OTHER is not enough: `proxy.ts: 0ms` is the normal reading for
+  // a route middleware does not match, and `x < 0 * 1.3` is false for every x, so 40ms of framework
+  // time on an 8s request came out "dominant" and authorised deleting the build dir. The slice has
+  // to explain the request before it gets to name it.
+  if (top < totalMs * 0.5) return 'slow-unclassified';
+  if (runnerUp && top < runnerUp[1] * DOMINANCE) return 'slow-unclassified';
+  return verdict;
+}
+
+/**
+ * @param {object} opts
+ * @param {string} opts.route      path to request, e.g. `/home`
+ * @param {number} opts.port
+ * @param {string|null} opts.sessionId
+ * @param {string} [opts.worktree]   named in the stale-deps remedy, so the install lands in the right tree
+ * @param {function} opts.daemonRequest
+ * @param {number} [opts.timeoutMs]
+ */
+export async function probe({ route, port, sessionId, worktree, daemonRequest, timeoutMs }) {
+  const path = route.startsWith('/') ? route : `/${route}`;
+  // A nonce makes our own request identifiable in the log. Skipped when the route already carries a
+  // query string, and for tRPC, whose handlers parse their query rather than ignoring it — there,
+  // matching falls back to the pathname and reports ambiguity instead.
+  const canNonce = !path.includes('?') && !path.startsWith('/api/trpc');
+  // Random, not clock-derived. A `performance.now()`-based token measured across fresh processes
+  // clustered in a ~68,000-wide band because every one of them starts the clock at the same point
+  // in module load — and a collision here is SILENT, since a matched nonce is what suppresses the
+  // ambiguity note.
+  const nonce = canNonce ? `p${randomUUID().slice(0, 8)}` : null;
+  const url = `http://localhost:${port}${path}${nonce ? `?__probe=${nonce}` : ''}`;
+  const budget = timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  // Where the session's log sits before we ask for anything, so each sample reads only its own
+  // window. The buffer is 2000 lines and this app is chatty, so we read it back immediately.
+  const markLog = async () => {
+    if (!sessionId) return null;
+    // Guarded like the log read: a daemon that dies between the CLI's readiness check and this
+    // call would otherwise reject out of probe() with a raw `TypeError: fetch failed` and no
+    // verdict — the same shape as the known crash in the queued-test path.
+    const res = await daemonRequest(`/sessions/${sessionId}`).catch(() => ({ ok: false }));
+    // GET /sessions/:id answers `{ session: {...} }`, unlike the list endpoint.
+    return res.ok ? res.data?.session?.currentLogIndex ?? null : null;
+  };
+  const readLog = async (since) => {
+    if (!sessionId || since == null)
+      return { line: null, compiled: false, selfFetchFailed: false, missingModule: null, unread: true };
+    const res = await daemonRequest(`/sessions/${sessionId}/logs?since=${since}`).catch(() => ({
+      ok: false,
+    }));
+    // `unread` has to cover a FAILED read, not just a skipped one. Otherwise a daemon that dropped
+    // the request prints "no matching request line in the log window" — a claim about the server.
+    return { ...readServerView(res.ok ? res.data?.logs ?? [] : [], route, nonce), unread: !res.ok };
+  };
+
+  const runSample = async (perRequestMs) => {
+    const since = await markLog();
+    const result = await timedFetch(url, perRequestMs);
+    const view = await readLog(since);
+    return { ...result, server: view.line, ...view, line: undefined };
+  };
+
+  const first = await runSample(budget);
+  const spent = first.elapsedMs;
+  // Floor the repeat generously. A first hit that legitimately compiled for most of the budget
+  // used to leave the repeat 5s, which turned a slow-but-recovering server into a `timeout` whose
+  // remedy is a purge.
+  // An explicit `--timeout` is a bound the caller asked for, so honour it on both samples — capped
+  // by what is left of the budget, floored at 1s so an exhausted budget still gets a real attempt.
+  // The default path is a flat 30s: a first hit that compiled for 85s should still get a full
+  // repeat, and a first hit that took 600ms does not need 89 seconds to answer again.
+  //
+  // Both halves have been wrong once. `max(30000, min(30000, x))` is the constant 30000, which
+  // ignored `--timeout` entirely; `max(30000, remaining)` is a floor with no ceiling, which gave a
+  // default probe an 89s repeat. Evaluate this over a table before changing it — it does not read
+  // the way it computes.
+  const remaining = budget - spent;
+  const repeatBudget =
+    timeoutMs != null ? Math.max(1000, Math.min(timeoutMs, Math.max(remaining, 1000)))
+    : REPEAT_TIMEOUT_MS;
+  const second = await runSample(repeatBudget);
+
+  const verdict = classify(first, second);
+  const sample = second.ok ? second : first;
+
+  // The remedy for a failing self-fetch splits on whether the endpoint answers at all, and that is
+  // one bounded request away — asking the agent to run it is asking them to improvise a curl.
+  let followUp = null;
+  if (verdict === 'self-fetch-failing' && route !== SETTINGS_ROUTE) {
+    const res = await timedFetch(`http://localhost:${port}${SETTINGS_ROUTE}`, SETTINGS_PROBE_MS);
+    followUp = {
+      route: SETTINGS_ROUTE,
+      ok: res.ok,
+      status: res.status ?? null,
+      elapsedMs: res.elapsedMs,
+      error: res.error ?? null,
+    };
+  }
+  const ctx = { sessionId, worktree, settingsHangs: followUp ? !followUp.ok : false };
+
+  return {
+    verdict,
+    followUp,
+    url,
+    sessionId,
+    headline: VERDICTS[verdict]({
+      totalMs: sample.server?.totalMs ?? sample.elapsedMs,
+      status: sample.server?.status ?? sample.status,
+      firstMs: first.elapsedMs,
+    }),
+    remedy: REMEDIES[verdict] ? REMEDIES[verdict](ctx) : null,
+    samples: [first, second].map((s) => ({
+      ok: s.ok,
+      status: s.status ?? null,
+      elapsedMs: s.elapsedMs,
+      compiled: s.compiled,
+      selfFetchFailed: Boolean(s.selfFetchFailed),
+      missingModule: s.missingModule ?? null,
+      logUnread: Boolean(s.unread),
+      ambiguous: Boolean(s.ambiguous),
+      serverTotalMs: s.server?.totalMs ?? null,
+      nextMs: s.server?.nextMs ?? null,
+      proxyMs: s.server?.proxyMs ?? null,
+      appMs: s.server?.appMs ?? null,
+      error: s.error ?? null,
+    })),
+  };
+}
+
+export function formatProbe(result) {
+  const [a, b] = result.samples;
+  const line = (label, s) => {
+    if (!s.ok) return `  ${label}: ${s.error} after ${ms(s.elapsedMs)}`;
+    const split =
+      s.nextMs != null || s.appMs != null
+        ? `  [next.js ${ms(s.nextMs)}${s.proxyMs != null ? ` | proxy.ts ${ms(s.proxyMs)}` : ''} | application-code ${ms(s.appMs)}]`
+        : '';
+    return `  ${label}: ${s.status} in ${ms(s.serverTotalMs ?? s.elapsedMs)}${
+      s.compiled ? ' (compiled)' : ''
+    }${s.selfFetchFailed ? ' (settings self-fetch FAILED)' : ''}${split}`;
+  };
+  const out = [
+    `${result.verdict.toUpperCase()}  ${result.url}`,
+    `  ${result.headline}`,
+    line('first ', a),
+    line('repeat', b),
+  ];
+  const missing = a.missingModule || b.missingModule;
+  if (missing) out.push(`  log: ${missing}`);
+  // "the log did not say why" and "we never read the log" are different claims, and only one of
+  // them is about the server.
+  if (a.ambiguous || b.ambiguous) {
+    out.push(
+      '  note: more than one request to this route in the window — the line read may not be ours.'
+    );
+  }
+  if (a.logUnread || b.logUnread) {
+    out.push('  note: the session log was NOT read, so this verdict is wall-clock only.');
+  } else if (!a.serverTotalMs && !b.serverTotalMs) {
+    out.push('  note: no matching request line in the log window; verdict is wall-clock only.');
+  }
+  if (result.followUp) {
+    const f = result.followUp;
+    out.push(
+      `  ${f.route}: ${f.ok ? `${f.status} in ${ms(f.elapsedMs)}` : `${f.error} after ${ms(f.elapsedMs)}`}`
+    );
+  }
+  if (result.remedy) out.push(`  -> ${result.remedy}`);
+  return out.join('\n');
+}
+
+// Deleting the build dir is the fix for `wedged` and nothing else; it costs a guaranteed ~45s
+// rebuild, so it is never applied on a guess.
+export function purgeDistDir(worktree, distDir) {
+  const target = resolve(worktree, distDir || '.next');
+  const rel = relative(worktree, target);
+  if (!rel || rel.startsWith('..') || isAbsolute(rel)) {
+    throw new Error(`Refusing to purge ${target}: outside the worktree.`);
+  }
+  if (!rel.replace(/\\/g, '/').startsWith('.next')) {
+    throw new Error(`Refusing to purge ${target}: not a Next build dir.`);
+  }
+  if (!existsSync(target)) return { path: target, removed: false };
+  rmSync(target, { recursive: true, force: true });
+  return { path: target, removed: true };
+}

--- a/.claude/skills/dev-server/scripts/probe.selftest.mjs
+++ b/.claude/skills/dev-server/scripts/probe.selftest.mjs
@@ -1,0 +1,133 @@
+/**
+ * `node .claude/skills/dev-server/scripts/probe.selftest.mjs`
+ *
+ * The classifier is the whole value of `probe` — every case below is a shape measured on this repo,
+ * and getting one wrong sends an agent to purge a 10 GB cache for a slow database (or the reverse).
+ * Pure functions, no daemon, no server: it runs in milliseconds and a wrong verdict prints
+ * `got=ok want=wedged` rather than hanging.
+ */
+
+import { classify, parseRequestLine, normalizeRoute, routePatternMatches } from './probe.mjs';
+
+let failures = 0;
+function check(name, actual, expected) {
+  const pass = actual === expected;
+  if (!pass) failures++;
+  console.log(`${pass ? 'PASS' : 'FAIL'}  ${name}  got=${actual} want=${expected}`);
+}
+
+const sample = ({ total, next, app, compiled = false, ok = true, timedOut = false }) => ({
+  ok,
+  timedOut,
+  elapsedMs: total,
+  compiled,
+  server: total == null ? null : { totalMs: total, nextMs: next, appMs: app, path: '/home', status: 200 },
+});
+
+// Healthy warm: both fast.
+check('ok', classify(sample({ total: 600, next: 40, app: 500 }), sample({ total: 570, next: 30, app: 500 })), 'ok');
+
+// Healthy cold: first compiles, repeat is fast.
+check(
+  'cold',
+  classify(sample({ total: 45000, next: 44000, app: 300, compiled: true }), sample({ total: 570, next: 30, app: 500 })),
+  'cold'
+);
+
+// Charlie's wedge: flat and slow, framework time dominant.
+check(
+  'wedged (framework dominant)',
+  classify(sample({ total: 8160, next: 8000, app: 100 }), sample({ total: 8150, next: 8000, app: 100 })),
+  'wedged'
+);
+
+// Recompiling a route it already compiled.
+check(
+  'wedged (recompiles on repeat)',
+  classify(sample({ total: 8160, next: 8000, app: 100, compiled: true }), sample({ total: 8150, next: 8000, app: 100, compiled: true })),
+  'wedged'
+);
+
+// Tonight's real specimen: flat and slow, application code dominant.
+check(
+  'upstream-slow',
+  classify(sample({ total: 8100, next: 30, app: 8100 }), sample({ total: 8100, next: 31, app: 8100 })),
+  'upstream-slow'
+);
+
+// The 2026-08-12 incident: a sick server aborts its own settings self-fetch at 8s, and that abort is
+// billed to application-code — so the split alone would say "upstream" and send you to the database.
+// The marker outranks the split, and it wins even when the degraded render is fast.
+check(
+  'self-fetch-failing (beats an upstream-shaped split)',
+  classify(
+    { ...sample({ total: 8050, next: 40, app: 8000 }), selfFetchFailed: true },
+    { ...sample({ total: 8050, next: 40, app: 8000 }), selfFetchFailed: true }
+  ),
+  'self-fetch-failing'
+);
+check(
+  'self-fetch-failing (beats a fast degraded render)',
+  classify(
+    { ...sample({ total: 300, next: 40, app: 200 }), selfFetchFailed: true },
+    { ...sample({ total: 300, next: 40, app: 200 }), selfFetchFailed: true }
+  ),
+  'self-fetch-failing'
+);
+
+// A stale node_modules 500s FAST, so every timing signal calls it healthy. It has to beat the fast
+// path or `probe` returns `ok` on a broken page — the one verdict worse than no verdict.
+check(
+  'stale-deps (beats a fast 500)',
+  classify(
+    { ...sample({ total: 120, next: 90, app: 20 }), missingModule: "Module not found: Can't resolve 'html2canvas'" },
+    { ...sample({ total: 110, next: 80, app: 20 }), missingModule: "Module not found: Can't resolve 'html2canvas'" }
+  ),
+  'stale-deps'
+);
+check(
+  'stale-deps seen on only one sample still counts',
+  classify(
+    { ...sample({ total: 120, next: 90, app: 20 }), missingModule: 'Cannot find module foo' },
+    sample({ total: 110, next: 80, app: 20 })
+  ),
+  'stale-deps'
+);
+
+// Slow with no log line to read (buffer overran, or no session).
+check(
+  'slow-unclassified',
+  classify(sample({ total: 8220, next: null, app: null }), { ok: true, elapsedMs: 8130, compiled: false, server: null }),
+  'slow-unclassified'
+);
+
+check('timeout', classify(sample({ ok: false, timedOut: true, total: 90000 }), sample({ ok: false, timedOut: true, total: 30000 })), 'timeout');
+check('down', classify({ ok: false, timedOut: false, elapsedMs: 5, error: 'ECONNREFUSED', server: null }, { ok: false, timedOut: false, elapsedMs: 5, error: 'ECONNREFUSED', server: null }), 'down');
+
+// Parser
+const p = parseRequestLine(' GET /home 200 in 8.1s (next.js: 39ms, proxy.ts: 8ms, application-code: 8.1s)');
+check('parse total', p.totalMs, 8100);
+check('parse next', p.nextMs, 39);
+check('parse app', p.appMs, 8100);
+check('parse no-split', parseRequestLine(' GET /x 200 in 1.2s').nextMs, null);
+check('parse non-request', parseRequestLine('○ Compiling /home ...'), null);
+
+check('route mangled', normalizeRoute('C:/Program Files/Git/home').route, '/home');
+check('route mangled flag', normalizeRoute('C:/Program Files/Git/home').mangled, true);
+check('route plain', normalizeRoute('/models').route, '/models');
+check('route bare', normalizeRoute('models').route, '/models');
+
+// Next announces the route PATTERN, not the URL, so string equality made the compile match inert
+// for every dynamic route — 113 of 566 files under src/pages, including all of /api/trpc.
+check('pattern: dynamic segment', routePatternMatches('/models/[id]', '/models/1234'), true);
+check('pattern: one segment only', routePatternMatches('/models/[id]', '/models/1/reviews'), false);
+check('pattern: catch-all', routePatternMatches('/docs/[...slug]', '/docs/a/b/c'), true);
+check('pattern: catch-all needs a segment', routePatternMatches('/docs/[...slug]', '/docs'), false);
+check('pattern: OPTIONAL catch-all matches zero', routePatternMatches('/docs/[[...slug]]', '/docs'), true);
+check('pattern: optional catch-all matches many', routePatternMatches('/docs/[[...slug]]', '/docs/a/b'), true);
+check('pattern: literal dot is escaped', routePatternMatches('/a.b/[id]', '/axb/1'), false);
+check('pattern: trailing slash', routePatternMatches('/home', '/home/'), true);
+check('pattern: malformed does not throw', routePatternMatches('['.repeat(30), '/x'), false);
+
+console.log(failures ? `\n${failures} FAILURES` : '\nall green');
+process.exit(failures ? 1 : 0);

--- a/src/pages/api/testing/settings-trace.ts
+++ b/src/pages/api/testing/settings-trace.ts
@@ -1,0 +1,170 @@
+/**
+ * Times each await that `/api/user/settings` performs, individually and bounded.
+ *
+ * GET /api/testing/settings-trace?token=<WEBHOOK_TOKEN>[&ms=10000][&pools=write][&userq=-8123]
+ *   ms  per-step budget in milliseconds (default 10000)
+ *
+ * When one of those dependencies parks, the request hangs and the server log says only that the
+ * client gave up — which step it was hanging in is exactly what it does not say. Each step here is
+ * raced against its own budget, so the answer is which one.
+ *
+ * Reach for it BEFORE restarting a session that has gone bad; a restart destroys the only state
+ * that can be measured. This repo is public: keep the output to timings and step names.
+ */
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
+import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
+import { getUserContentSettings } from '~/server/services/user.service';
+import { getTosMeta } from '~/server/services/content.service';
+import { getCurrentAnnouncements } from '~/server/services/announcement.service';
+import { getUserFollows } from '~/server/redis/caches';
+import { getRequestDomainColor } from '~/server/utils/server-domain';
+import { getBrowsingSettingAddons, getLiveNow } from '~/server/services/system-cache';
+import { dbRead, dbWrite } from '~/server/db/client';
+import { pgDbRead } from '~/server/db/pgDb';
+
+type StepResult = { step: string; ms: number; outcome: 'ok' | 'threw' | 'HUNG'; detail?: string };
+
+async function time<T>(step: string, budgetMs: number, fn: () => Promise<T>): Promise<StepResult> {
+  const started = Date.now();
+  let timer: NodeJS.Timeout | undefined;
+  const budget = new Promise<'HUNG'>((resolve) => {
+    timer = setTimeout(() => resolve('HUNG'), budgetMs);
+  });
+  try {
+    const result = await Promise.race([fn().then(() => 'ok' as const), budget]);
+    return { step, ms: Date.now() - started, outcome: result === 'HUNG' ? 'HUNG' : 'ok' };
+  } catch (e) {
+    return {
+      step,
+      ms: Date.now() - started,
+      outcome: 'threw',
+      // Name and code only. Prisma and pg embed host:port — and sometimes the failing SQL — in
+      // `message`, and this output lands in dev-server logs and in whatever gets pasted into a PR
+      // on a public repo. The code (`P1001`) is the part anyone actually wants.
+      detail:
+        e instanceof Error
+          ? [e.name, (e as { code?: string }).code].filter(Boolean).join(' ')
+          : 'unknown',
+    };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+export default WebhookEndpoint(async function handler(req: NextApiRequest, res: NextApiResponse) {
+  // Bounded at both ends. An unbounded `?ms=` would make the worst case of a debug endpoint a hang
+  // of 13 sequential steps — in a change about unbounded hangs.
+  const budgetMs = Math.min(60_000, Math.max(1000, Number(req.query.ms) || 10000));
+
+  const domainColor = getRequestDomainColor(req);
+  const steps: StepResult[] = [];
+
+  // First-touch cost of each pool, measured before anything else has opened a connection.
+  // `?pools=1` on a freshly started session is the only way to see it — every later request is
+  // served by an already-open connection, which is why this is invisible once warm.
+  if (req.query.pools) {
+    const writeFirst = req.query.pools === 'write';
+    const stepA = writeFirst
+      ? await time('prisma dbWrite first touch', budgetMs, () => dbWrite.$queryRaw`SELECT 1`)
+      : await time('prisma dbRead first touch', budgetMs, () => dbRead.$queryRaw`SELECT 1`);
+    const stepB = writeFirst
+      ? await time('prisma dbRead second', budgetMs, () => dbRead.$queryRaw`SELECT 1`)
+      : await time('prisma dbWrite second', budgetMs, () => dbWrite.$queryRaw`SELECT 1`);
+    steps.push(stepA, stepB);
+  }
+
+  // `?userq=<id>` runs the settings cache's own lookup SELECT on both pools, bypassing redis, so a
+  // slow cache FILL can be attributed to the query rather than to the cache machinery around it.
+  // The redis cache is shared across sessions, so a warm key hides this on every session but the
+  // first — pick an id nobody has cached.
+  const userq = Number(req.query.userq);
+  if (Number.isFinite(userq) && req.query.userq) {
+    const sql = `SELECT id, settings, "showNsfw", "blurNsfw", "autoplayGifs" FROM "User" WHERE id IN (${userq})`;
+    steps.push(
+      await time(`dbWrite lookup id=${userq}`, budgetMs, () => dbWrite.$queryRawUnsafe(sql))
+    );
+    steps.push(
+      await time(`dbRead lookup id=${userq}`, budgetMs, () => dbRead.$queryRawUnsafe(sql))
+    );
+    // Same id through the full cache path. The redis key for it does not exist, so this is a real
+    // cold fill: redis miss, whatever locking createCachedObject does, the SELECT, the redis write.
+    steps.push(
+      await time(`getUserContentSettings COLD id=${userq}`, budgetMs, () =>
+        getUserContentSettings(userq)
+      )
+    );
+    steps.push(
+      await time(`getUserContentSettings warm id=${userq}`, budgetMs, () =>
+        getUserContentSettings(userq)
+      )
+    );
+  }
+
+  // Sequential, in the real handler's order: a step that hangs is the one that would have hung
+  // there, and running them concurrently would hide which came first.
+  // Once, not twice. Calling it a second time doubles work on the step most suspected of hanging,
+  // and the second call's own race meant a genuinely stuck session silently resolved to anonymous —
+  // quietly changing what every later step measured.
+  let userId = -1;
+  const authStep = await time('getServerAuthSession', budgetMs, async () => {
+    const session = await getServerAuthSession({ req, res });
+    userId = session?.user?.id ?? -1;
+  });
+  steps.push(authStep);
+
+  // Stop at the first parked step. Once one dependency hangs, the ones after it are measuring a
+  // machine in a different state — and 13 sequential steps at the 60s cap is a 13-minute request
+  // from an endpoint that exists because of unbounded hangs.
+  //
+  // Scoped to the MAIN sequence, not the whole array. `?pools=` and `?userq=` are caller-requested
+  // side-quests, and they are also the likeliest to park — `?pools=` is for a freshly started
+  // session, which is exactly when a first-touch hangs. A hang there is a finding in itself, not a
+  // reason to abandon everything the endpoint exists to measure.
+  const mainFrom = steps.length;
+  const bail = () => steps.slice(mainFrom).some((step) => step.outcome === 'HUNG');
+  if (!bail())
+    steps.push(
+      await time('getUserContentSettings', budgetMs, () => getUserContentSettings(userId))
+    );
+  if (!bail())
+    steps.push(
+      await time('getTosMeta', budgetMs, () => getTosMeta({ domainColor: domainColor ?? 'blue' }))
+    );
+  if (!bail())
+    steps.push(
+      await time('getCurrentAnnouncements', budgetMs, () =>
+        getCurrentAnnouncements({ domain: domainColor, userId: userId > 0 ? userId : undefined })
+      )
+    );
+  if (!bail())
+    steps.push(
+      await time('getUserFollows', budgetMs, () =>
+        userId > 0 ? getUserFollows(userId) : Promise.resolve(undefined)
+      )
+    );
+  if (!bail())
+    steps.push(await time('getBrowsingSettingAddons', budgetMs, () => getBrowsingSettingAddons()));
+  if (!bail()) steps.push(await time('getLiveNow', budgetMs, () => getLiveNow()));
+
+  // The two database clients separately: /api/health exercises the raw pg pool, while these
+  // handlers go through Prisma, so a green health check says nothing about the pool they use.
+  if (!bail())
+    steps.push(await time('prisma dbRead SELECT 1', budgetMs, () => dbRead.$queryRaw`SELECT 1`));
+  if (!bail())
+    steps.push(
+      await time('raw pg pool SELECT 1', budgetMs, () =>
+        pgDbRead.query('SELECT 1').then(() => null)
+      )
+    );
+
+  res.status(200).json({
+    // Whether a session resolved, not whose. A real user id in a public repo's log stream is not
+    // something this endpoint needs to say.
+    authenticated: userId > 0,
+    budgetMs,
+    hung: steps.filter((s) => s.outcome === 'HUNG').map((s) => s.step),
+    steps,
+  });
+});


### PR DESCRIPTION
A dev server that has gone bad does not refuse connections — it accepts and answers slowly, or accepts and never answers. So the reflex (curl the route) hangs for the full 300s tool timeout and returns nothing to act on, and the fallback reflex (purge `.next`) is right for one cause out of several and costs a guaranteed ~45s rebuild when it is not.

`probe` requests a route twice with a hard budget, reads the session's own log for those two requests, and returns a verdict with the matching remedy.

```
UPSTREAM-SLOW  http://localhost:3000/home
  first : 200 in 8.10s  [next.js 30ms | proxy.ts 5ms | application-code 8.10s]
  repeat: 200 in 8.10s  [next.js 31ms | proxy.ts 5ms | application-code 8.10s]
  -> Not a cache problem — do NOT purge, it will not help. [...]
```

## The discriminator is a mechanism, not a threshold

Next already splits every request line into framework, middleware and application time, so "the build cache is not serving", "middleware is slow" and "something downstream is slow" are separated at the source and stay separated on a contended machine. An ambiguous split — under 1.3x, or a slice that does not account for at least half the request — is reported as `slow-unclassified` rather than guessed, because the `wedged` remedy is destructive.

Measured on this repo: a flat 8.1s `/home` was **30ms of framework and 8.1s of application code**. The rule it replaces ("flat 8s means purge `.next`") would have deleted ~10 GB and fixed nothing.

Two failures are **fast**, so they are checked ahead of every timing rule — `ok` on a broken page is worse than no verdict: a stale `node_modules` after a merge (`stale-deps`; the fix is an install, and purging installs nothing) and a 4xx/5xx served quickly (`error-status`, most often a route argument that never arrived intact). A third, `self-fetch-failing`, outranks the split entirely: `_app` self-fetches `/api/user/settings` and its abort is billed to application-code, so a server that cannot answer its own route reads as a slow database.

## `unwedge`

The purge, behind an explicit session id: stop, delete the build dir, restart on the modes it was already running — **both halves stated explicitly**, so `DEVSERVER_PROD_GROUPS` cannot re-decide the unnamed half and move a session onto the production database — wait for ready, re-probe. It never guesses a session, because the session it would guess is usually the one someone is looking at.

## The hook asks, it does not block

A hard block was tried and reverted. The matcher reads text, so it cannot reliably tell a request from a shell comment, a note being written down, or a production URL carrying a dev port in a query parameter — and `$(curl ...)` defeats it anyway. A guard with those false positives and no override is one people route around, and the routes around it are shorter than the compliant path.

## Tests

Three self-tests, all mutation-checked. The integration one drives the real `probe()` against a live local server and a stubbed daemon, and it exists because the unit tests could not have caught the worst bug in this change: `runSample` dropped `missingModule` on the way to `classify`, so `stale-deps` was dead code while every unit case for it passed — they asserted a shape the shipping code never produced. Reintroduce that bug today and the unit suite stays green while the integration suite fails.

Four rounds of adversarial review; every finding landed.

Also adds `src/pages/api/testing/settings-trace.ts` — times each await the settings bootstrap performs, individually and bounded. It is what identified the three calls that park while the auth session resolves in 2ms. `WebhookEndpoint`-guarded like its siblings, reports error **names** rather than messages and whether a session resolved rather than whose, because this repo and its logs are public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KvXBiAVpWyhNS85tsBMuDU