### PR TITLE
perf(home): fetch what the feed config says, and cap images per model

### DIFF
--- a/src/server/services/__tests__/home-block-fetch-sizing.test.ts
+++ b/src/server/services/__tests__/home-block-fetch-sizing.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { HomeBlockType } from '~/shared/utils/prisma/enums';
+import { GET_ALL_IMAGES_PER_MODEL_SLIM } from '~/server/utils/model-getall-images';
+import type * as ModelService from '~/server/services/model.service';
+
+const { getModelsWithImagesAndModelVersionsMock, getFeaturedModelsMock } = vi.hoisted(() => ({
+  getModelsWithImagesAndModelVersionsMock: vi.fn(async () => ({ items: [] })),
+  getFeaturedModelsMock: vi.fn(async () => [{ modelId: 1 }]),
+}));
+
+vi.mock('~/server/services/model.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof ModelService>()),
+  getModelsWithImagesAndModelVersions: getModelsWithImagesAndModelVersionsMock,
+  getFeaturedModels: getFeaturedModelsMock,
+}));
+
+async function loadService() {
+  return import('~/server/services/home-block.service');
+}
+
+const callArgs = () =>
+  getModelsWithImagesAndModelVersionsMock.mock.calls[0]?.[0] as unknown as {
+    input: { limit?: number };
+    imagesPerModel?: number;
+    biasImageSlice?: boolean;
+  };
+
+const modelsFeed = (feed: Record<string, unknown>) => ({
+  id: 1,
+  type: HomeBlockType.Feed,
+  metadata: { feed: { entity: 'models', ...feed } },
+});
+
+beforeEach(() => {
+  getModelsWithImagesAndModelVersionsMock.mockClear();
+});
+
+// What the config says is what the block fetches. The number used to be tripled on its way
+// through, so a row reading 42 fetched 126 — invisible from the row, and the reason the two
+// homepage feeds shipped 3x what anyone had chosen.
+describe('feed fetch size', () => {
+  it('fetches exactly the configured limit', async () => {
+    const { getHomeBlockData } = await loadService();
+
+    await getHomeBlockData({ input: {}, homeBlock: modelsFeed({ limit: 42 }) });
+
+    expect(callArgs().input.limit).toBe(42);
+  });
+
+  it('still fetches exactly the configured limit when maxPerUser is set', async () => {
+    const { getHomeBlockData } = await loadService();
+
+    await getHomeBlockData({ input: {}, homeBlock: modelsFeed({ limit: 42, maxPerUser: 2 }) });
+
+    expect(callArgs().input.limit).toBe(42);
+  });
+
+  // Both feed entities take their size from `resolveFeedFetchLimit`, so the cases below cover
+  // the images branch too without mocking `image.service` — which is on the shared-mock
+  // migration ratchet, and a new direct mock there moves that count the wrong way.
+  it('does not scale the configured limit', async () => {
+    const { resolveFeedFetchLimit } = await loadService();
+
+    expect(resolveFeedFetchLimit(42)).toBe(42);
+    expect(resolveFeedFetchLimit(7)).toBe(7);
+  });
+
+  it('clamps a mistyped limit to the ceiling', async () => {
+    const { resolveFeedFetchLimit } = await loadService();
+
+    expect(resolveFeedFetchLimit(5000)).toBe(100);
+  });
+
+  // `Math.min(undefined, n)` is NaN, which would reach the fetch unchecked — the metadata is
+  // cast, never parsed, so the schema default cannot rescue it.
+  it('falls back to the schema default when limit is missing', async () => {
+    const { resolveFeedFetchLimit } = await loadService();
+
+    expect(resolveFeedFetchLimit(undefined)).toBe(28);
+  });
+});
+
+// A cap without `biasImageSlice` drops whole models from a viewer's block rather than
+// trimming their images, and it does so silently — no error, no server-side symptom, only a
+// shorter block for some viewers. These pin the pair at both call sites.
+describe('per-model image cap', () => {
+  it('caps and bias-slices the models Feed block', async () => {
+    const { getHomeBlockData } = await loadService();
+
+    await getHomeBlockData({ input: {}, homeBlock: modelsFeed({ limit: 42 }) });
+
+    expect(getModelsWithImagesAndModelVersionsMock).toHaveBeenCalledTimes(1);
+    expect(callArgs().imagesPerModel).toBe(GET_ALL_IMAGES_PER_MODEL_SLIM);
+    expect(callArgs().biasImageSlice).toBe(true);
+  });
+
+  it('caps and bias-slices the FeaturedModelVersion block', async () => {
+    const { getHomeBlockData } = await loadService();
+
+    await getHomeBlockData({
+      input: {},
+      homeBlock: { id: 2, type: HomeBlockType.FeaturedModelVersion, metadata: {} },
+    });
+
+    expect(getModelsWithImagesAndModelVersionsMock).toHaveBeenCalledTimes(1);
+    expect(callArgs().imagesPerModel).toBe(GET_ALL_IMAGES_PER_MODEL_SLIM);
+    expect(callArgs().biasImageSlice).toBe(true);
+  });
+});

--- a/src/server/services/home-block.service.ts
+++ b/src/server/services/home-block.service.ts
@@ -233,6 +233,38 @@ const imageFeedDefaults = {
   types: undefined,
 } as const;
 
+// Mirrors `homeBlockMetaSchema.feed.limit`, which never runs: `getHomeBlockData` casts the
+// stored metadata rather than parsing it, and no route writes a Feed block — the only writer is
+// hand-written SQL. So these are the sole guard against a typo, not a redundant second one.
+const FEED_FETCH_CEILING = 100;
+const FEED_FETCH_DEFAULT = 28;
+
+/**
+ * How many items a Feed block fetches. Nothing scales the configured value, so what the config
+ * says is what ships — a `limit` of 42 fetches 42.
+ *
+ * The value has to sit well above the rendered slice (`rows * HOME_BLOCK_ITEMS_PER_ROW`), because
+ * `maxPerUser` and the viewer's own hidden-preferences filter both thin the pool after the fetch,
+ * and the fetch applies no per-creator cap of its own — so the head of the pool is
+ * creator-concentrated. Measured on the two live blocks: 454066 (7 slots) fills at 7, but 454065
+ * (14 slots) needs 21, and its first 7 items come from only 4 creators.
+ *
+ * Exported for unit tests.
+ */
+export function resolveFeedFetchLimit(limit?: number) {
+  return Math.min(limit ?? FEED_FETCH_DEFAULT, FEED_FETCH_CEILING);
+}
+
+// Both model-carrying home blocks take this pair. The images come straight from the shared
+// cache, in `postId,index` order and never browsing-level filtered, so a plain cap can leave
+// a mixed-level model with no image a given viewer may see — and the client-side filter then
+// drops the whole model rather than the image. The bit-coverage slice is what makes the cap
+// safe, which is why the two travel together.
+const slimModelImages = {
+  imagesPerModel: GET_ALL_IMAGES_PER_MODEL_SLIM,
+  biasImageSlice: true,
+} as const;
+
 const modelFeedDefaults = {
   period: MetricTimeframe.Week,
   periodMode: 'published',
@@ -360,9 +392,7 @@ export const getHomeBlockData = async ({
       const feed = sourceMetadata?.feed ?? metadata.feed;
       if (!feed) return null;
 
-      // Overfetch so `maxPerUser` has a pool to thin, matching how Collection blocks
-      // pair a larger fetch limit with their cap.
-      const limit = feed.maxPerUser ? Math.min(feed.limit * 3, 200) : feed.limit;
+      const limit = resolveFeedFetchLimit(feed.limit);
 
       if (feed.entity === 'images') {
         const { items } = await getAllImagesIndex({
@@ -393,6 +423,7 @@ export const getHomeBlockData = async ({
         },
         user,
         domain: input.domain,
+        ...slimModelImages,
       });
 
       return { ...homeBlock, metadata, feedItems: { entity: 'models' as const, items } };
@@ -507,13 +538,7 @@ export const getHomeBlockData = async ({
                   periodMode: 'stats',
                   browsingLevel: allBrowsingLevelsFlag,
                 },
-                // The images attached here are NOT browsing-level filtered — they come straight
-                // from the shared cache — so the cap has to keep a representative of every
-                // distinct nsfwLevel, which is what `biasImageSlice` does and what sizes the
-                // slim cap. Going below it drops mixed-level models for whoever's level isn't
-                // among the first bits in cache order.
-                imagesPerModel: GET_ALL_IMAGES_PER_MODEL_SLIM,
-                biasImageSlice: true,
+                ...slimModelImages,
               })
             ).items
           : ([] as GetModelsWithImagesAndModelVersions[]);

--- a/src/server/utils/__tests__/model-getall-images.test.ts
+++ b/src/server/utils/__tests__/model-getall-images.test.ts
@@ -8,6 +8,7 @@ import {
   selectSlimGetAllModelImages,
   stripGetAllModelImage,
 } from '~/server/utils/model-getall-images';
+import { browsingLevels } from '~/shared/constants/browsingLevel.constants';
 
 // The browse-feed (`model.getAll`) response is the #1 serialize-freeze source.
 // Its image trim has two parts: an ALWAYS-ON per-image field drop
@@ -51,6 +52,14 @@ describe('model-getall-images — cap', () => {
     expect(GET_ALL_IMAGES_PER_MODEL).toBe(12);
     expect(GET_ALL_IMAGES_PER_MODEL_SLIM).toBe(6);
     expect(GET_ALL_IMAGES_PER_MODEL_SLIM).toBeLessThan(GET_ALL_IMAGES_PER_MODEL);
+  });
+
+  it('keeps room for one representative of every browsing level', () => {
+    // What makes the slim cap safe is `selectSlimGetAllModelImages` fitting a
+    // representative of every distinct nsfwLevel bit, so a viewer who had a visible
+    // image still has one. Below this the guarantee is silently gone, and the two
+    // home blocks that rely on it have no flag to fall back to.
+    expect(GET_ALL_IMAGES_PER_MODEL_SLIM).toBeGreaterThanOrEqual(browsingLevels.length);
   });
 
   it('caps to at most the default limit', () => {

--- a/src/server/utils/model-getall-images.ts
+++ b/src/server/utils/model-getall-images.ts
@@ -82,17 +82,30 @@ export const GET_ALL_IMAGES_PER_MODEL = 12;
  * ~42% of the browse-feed page bytes (and the proportional superjson walk) when
  * models carry a full showcase.
  *
- * 🔴 FLAG-GATED (DARK `getAllModelImagesSlim`, `availability: []`) — NOT always-on
- * — because it REINTRODUCES the browsing-level feed-drop risk the 3→8→12 reviews
- * walked away from: with only 6 leading (postId,index-ordered, browsing-agnostic)
- * images, a mixed-level model whose only browsing-safe image sits past index 6 is
- * dropped from an SFW-mode viewer's feed (`hidden.noImages`). 6 (vs 1) preserves 5
- * fall-through candidates beyond the cover and mirrors the sibling
- * `GALLERY_POST_IMAGE_SLICE`; the residual risk is real but bounded, measured, and
- * instantly reversible. OFF ⇒ the cap stays `GET_ALL_IMAGES_PER_MODEL` (12) — the
- * COUNT is byte-identical to today (the always-on field trim still applies to both
- * branches). Ramp ONLY by the Flipt threshold while watching
- * `feed_noimages_drop`; instant rollback = drop the threshold to 0. Tune here.
+ * 🔴 On the BROWSE FEED this is FLAG-GATED (DARK `getAllModelImagesSlim`,
+ * `availability: []`) — NOT always-on — because it REINTRODUCES the browsing-level
+ * feed-drop risk the 3→8→12 reviews walked away from: with only 6 leading
+ * (postId,index-ordered, browsing-agnostic) images, a mixed-level model whose only
+ * browsing-safe image sits past index 6 is dropped from an SFW-mode viewer's feed
+ * (`hidden.noImages`). 6 (vs 1) preserves 5 fall-through candidates beyond the cover
+ * and mirrors the sibling `GALLERY_POST_IMAGE_SLICE`; the residual risk is real but
+ * bounded, measured, and instantly reversible. OFF ⇒ the cap stays
+ * `GET_ALL_IMAGES_PER_MODEL` (12) — the COUNT is byte-identical to today (the
+ * always-on field trim still applies to both branches). Ramp ONLY by the Flipt
+ * threshold while watching `feed_noimages_drop`; instant rollback = drop the
+ * threshold to 0. Tune here.
+ *
+ * 🔴 The two HOME BLOCK callers take it UNFLAGGED, paired with `biasImageSlice`
+ * (`home-block.service.ts`, `slimModelImages`). A per-user Flipt evaluation cannot
+ * reach them: `getHomeBlockCached` keys on `type:identifier:domain` with no user
+ * segment and calls `getHomeBlockData` with no user, so whichever request missed the
+ * cache would pick the payload for every viewer of that domain until it expires.
+ * Consequences to know before changing this number: those blocks have NO flag
+ * rollback — only revert, deploy, and wait out a 10 min (Feed) / 1 hr
+ * (FeaturedModelVersion) cache TTL — and `emitFeedNoImagesDrop` carries no block or
+ * source discriminator, so a rise in `feed_noimages_drop` cannot be attributed to
+ * them. Their safety rests entirely on `biasImageSlice`'s bit-coverage guarantee,
+ * which needs this cap to stay >= the number of browsing levels.
  */
 export const GET_ALL_IMAGES_PER_MODEL_SLIM = 6;
 


### PR DESCRIPTION
The two homepage Feed blocks each ship **126 items to render 7 and 14 cards**. Nobody chose
126. Their config says `limit: 42`, and the service silently tripled it on the way through:

```js
const limit = feed.maxPerUser ? Math.min(feed.limit * 3, 200) : feed.limit;
```

So the number in the row was never the number that shipped, and you could not tell what a block
fetched by reading its config. Worse, 126 was never a legal value: `homeBlockMetaSchema.feed.limit`
is `.min(1).max(100)`. The multiplier pushed the effective fetch past the schema's own maximum,
and nothing noticed — see "the schema never runs" below.

This makes `limit` mean what it says, and caps how many images each model carries.

## What ships

```js
export function resolveFeedFetchLimit(limit?: number) {
  return Math.min(limit ?? FEED_FETCH_DEFAULT, FEED_FETCH_CEILING);
}
```

Both constants mirror the schema (`28` / `100`). **No database change is needed to land this** —
both blocks already store `limit: 42`, which is the right number once nothing multiplies it:

| block | renders | ships now | ships after | brotli |
|---|---|---|---|---|
| 454066 "New & Upcoming Model Creators" | 7 | 126 models / 973 images | 42 models / 228 images | 144.5 → **41.4 KB** |
| 454065 "New & Upcoming Creators" | 14 | 126 images | 42 images | 21.5 → **9.5 KB** |

**~115 KB brotli off a ~360 KB page**, and far more parse cost — brotli discounts these repeated
image records about 5:1, so ~1.0 MB less JSON is walked for a ~115 KB wire saving.

Raising the rows to `limit: 60` to buy back discovery breadth (see below) is an optional
follow-up, worth ~19 KB of the above in exchange for 9 and 2 more creators.

⚠️ **If that follow-up happens, it must come after this deploys** — setting `limit: 60` while the
multiplier still exists would fetch 180.

## The pool size is also an editorial decision

Both blocks shuffle the **whole fetched pool** before slicing (`FeedHomeBlock.tsx:165-171`), so
the fetch size is the rotation pool. Shrinking it narrows how many creators the shelf can ever
surface — on shelves named "New & Upcoming Creators", that is an editorial change, not just a
perf one:

| `limit` | 454066 creators | 454065 creators | saved |
|---|---|---|---|
| 126 (today) | 59 | 30 | — |
| 100 (schema max) | 48 | 25 | ~26 KB |
| 60 | 32 | 18 | ~66 KB |
| **42 (what this ships)** | **23** | **16** | **~115 KB** |

This lands on 42 because that is what the rows already say, and 42 fills every slot. 60 is the
agreed compromise if the shelves look too repetitive once this is live — one `jsonb_set` per
block, no deploy.

The pool must also stay well above the rendered slice, because `maxPerUser` and the viewer's own
hidden-preferences filter both thin it *after* the fetch — and the fetch applies no per-creator
cap, so the head of the pool is creator-concentrated. Measured on the live payloads at PG-only:

| fetched | 454066 fills (7 slots) | 454065 fills (14 slots) |
|---|---|---|
| 7 | 7/7 | — |
| 14 | 7/7 | 10/14 |
| 21 | 7/7 | 14/14 |
| **42 (shipped)** | **7/7** | **14/14** |

454065 is the tighter block: its first 7 items come from only 4 creators, and 13.5% of 454066's
models have no PG-visible image and drop client-side via `hidden.noImages`.

## Second change: cap images per model on the models Feed branch

It was taking `GET_ALL_IMAGES_PER_MODEL` (12) because the service default fell through — #3969
added `GET_ALL_IMAGES_PER_MODEL_SLIM` + `biasImageSlice` to the FeaturedModelVersion branch only.
Both now spread one `slimModelImages` const, so a future call site cannot take the cap without
the slice that makes it safe.

`biasImageSlice` is load-bearing. These images are never browsing-level filtered —
`getModelsWithImagesAndModelVersions` filters `versionImages` by `excludedTagIds` alone
(`model.service.ts:1543`) — so they arrive in the shared cache's browsing-agnostic
`postId,index` order, and `useApplyHiddenPreferences` drops the whole model when nothing
survives. `selectSlimGetAllModelImages` keeps a representative of every distinct `nsfwLevel`
bit; a level is always a single bit and there are <= 6, so they always fit in 6.

**In the browsing-level dimension it is provably neutral.** If a viewer's first survivor under
the 12-cap is at index `i` and `i` is excluded from the biased 6, it was excluded only because
an earlier image shares its bit — same bit means same visibility, so that earlier image was
already their cover. Simulated at browsing levels 1, 3, 7 and 31 on both live payloads: zero
models newly dropped, zero covers changed.

**Outside it, small but non-zero.** The client filter also drops on `hiddenImages`, viewer
`hiddenTags`, `systemHiddenTags`, `poi` and `minor`; halving the array halves the fall-through
depth there. Measured on a prod replica (1500 most recent versions, cache predicates reproduced
exactly): **53%** of models have >6 eligible images, and **0.13%** of those have no clean image
in the leading 6 but one at index 7-12 in the poi/minor dimension. Same risk class #3969 already
ships and the flag-gated browse feed accepts.

No consumer reads `images[1+]`: `FeedHomeBlock.tsx:213-241` → `ModelCard` →
`AspectRatioImageCard`, one image. The shared `imagesForModelVersionsCache` is untouched.

## The schema never runs

`getHomeBlockData` casts stored metadata (`as HomeBlockMetaSchema`) rather than parsing it, and
no tRPC route creates or edits a Feed block — `upsertHomeBlock` is exported and reachable from
the controller, but nothing wires it. The only writer is hand-written SQL.

So `homeBlockMetaSchema.feed`'s `min(1).max(100).default(28)` is decorative for these rows, which
is how an effective fetch of 126 survived a documented max of 100. `FEED_FETCH_CEILING` and
`FEED_FETCH_DEFAULT` are therefore the *only* guard, not a redundant second one — hence mirroring
the schema's numbers rather than picking new ones. Parsing this metadata on read would be the
real fix and belongs in its own change.

## Why the image cap is not behind `getAllModelImagesSlim`

That flag is a per-request, per-user Flipt evaluation. Home-block payloads are neither:
`home-block-cache.service.ts` keys on `${type}:${identifier}:${domain}` with no user segment and
calls `getHomeBlockData` with no user. Gating here would let whichever request missed the cache
pick the payload for every viewer of that domain for 10-60 minutes; a percentage ramp would be a
coin flip. #3969 hard-coded it for the same reason.

Two costs, stated rather than buried: **rollback is revert + deploy + waiting out the TTL**, and
`emitFeedNoImagesDrop` carries no block discriminator, so a rise in `feed_noimages_drop` cannot
be attributed to these blocks. This PR corrects `GET_ALL_IMAGES_PER_MODEL_SLIM`'s docstring,
which still asserted the cap is never used unflagged — false since #3969.

## Tests

`home-block-fetch-sizing.test.ts` covers both halves: that a configured `limit` reaches the fetch
unscaled, that the ceiling clamps, that a missing `limit` falls back rather than becoming `NaN`, and that both model call sites pass the cap pair —
including the FeaturedModelVersion one #3969 shipped with no test. One assertion in
`model-getall-images.test.ts` ties the cap to the reason for the cap:

```ts
expect(GET_ALL_IMAGES_PER_MODEL_SLIM).toBeGreaterThanOrEqual(browsingLevels.length);
```

Every guard mutation-checked, all fast and legible, no hangs:

| mutation | result |
|---|---|
| restore the `* 3` multiplier | 4 tests, `expected 100 to be 42` |
| remove the `?? FEED_FETCH_DEFAULT` | `expected NaN to be 28` |
| remove the ceiling | `expected 5000 to be 100` |
| drop the cap pair from either model call site | `expected undefined to be 6` |
| drop `biasImageSlice` from the shared const | `expected undefined to be true` |
| `GET_ALL_IMAGES_PER_MODEL_SLIM` 6 → 4 | 6 assertions incl. the coverage guard |

## Left alone, with numbers

- **Collection blocks** take `Math.max(input.limit ?? 0, metadata.collection.limit ?? 0)` where
  the cache path passes `14 * 4 = 56`, so they can never ship fewer than 56 however the config
  reads. Block 109027 has had `limit: 8` its whole life and ships 56 — its config is dead.
  Fixing that floor is worth ~8 KB, but block 3 has **73,015 clones** carrying their own
  metadata that do not read through, so it needs its own change.
- **Featured Collections** (40 per collection, 14 rendered each): cutting to 28 was measured and
  rejected. Items are pre-filtered to PG+PG13 server-side, but signed-out viewers are PG-only,
  and at 28 one of the three collections has exactly 14 PG-visible items for 14 slots.
- **Trimming `user`** (`profilePicture.metadata`, redundant with its own `width`/`height`/`hash`;
  `ProfileBackground` cosmetics no card renders): 76 KB raw across five blocks but **5.1 KB
  brotli**.
- **`image.tags`**: not droppable — it is what `useApplyHiddenPreferences` matches hidden tags
  against.
- **`skipBatch: true`**: saves zero bytes and would gate every block on the slowest.
- **Server-side shuffling to ship fewer while keeping variety**: `getHomeBlock` runs
  `edgeCacheIt({ ttl: 60 })` over a 10-minute Redis entry keyed with no user segment, so
  per-request sampling is flattened before it reaches a viewer.

## Verification

`pnpm run typecheck` · `pnpm run test:lint-rules` · `pnpm run test:unit:run` · `prettier` on the
changed files. Reviewed adversarially by three agents — render equivalence, reuse, and the feed
sizing. The 53% / 0.13% replica figures and the dedupe order-invariance proof are theirs.
