### PR TITLE
chore(skills): make the postgres-query target explicit and always printed

### DIFF
--- a/.claude/skills/postgres-query/.env.example
+++ b/.claude/skills/postgres-query/.env.example
@@ -1,13 +1,30 @@
 # PostgreSQL Query Runner Configuration
 #
 # This skill runs PostgreSQL queries for testing, debugging, and analysis.
-# By default, it uses the read-only replica for safety.
-# Use --writable flag to use the primary database for write operations.
+# The target is chosen per run with --prod / --dev / --data-packet / --notifications,
+# and defaults to --prod. Every run prints the host, port and database it connected to.
+#
+# NOTE: the keys below are ALSO defined in the app's root .env, pointing at a DIFFERENT
+# database. This file wins (it is loaded first). That is why the target is printed.
 
-# Primary database connection (used with --writable flag)
+# ---- --prod ----
+# Primary database connection (used by --prod --writable)
 # Format: postgresql://user:password@host:port/database?schema=public
 DATABASE_URL=postgresql://user:password@localhost:5432/civitai?schema=public
 
-# Read-only replica connection (used by default)
+# Read-only replica connection (used by --prod)
 # If not set, falls back to DATABASE_URL
 DATABASE_REPLICA_URL=postgresql://user:password@localhost:5432/civitai?schema=public
+
+# ---- --dev ----
+# Dev cnpg database, reached over the SSH bastion tunnel.
+# Ask an infra owner for the connection recipe; see SKILL.md.
+DEV_DATABASE_URL=postgresql://user:password@127.0.0.1:5432/civitai
+
+# ---- --data-packet ----
+# DataPacket logical replica (read-only)
+DATABASE_DATA_PACKET_URL=postgresql://user:password@localhost:5432/civitai
+
+# ---- --notifications ----
+# notifications-db replica (read-only), also over the bastion tunnel
+NOTIFICATION_DB_REPLICA_URL=postgresql://user:password@localhost:5432/notifications

--- a/.claude/skills/postgres-query/SKILL.md
+++ b/.claude/skills/postgres-query/SKILL.md
@@ -52,8 +52,10 @@ of the string, so the line cannot disagree with where the query actually went.
 define `DATABASE_URL`, and **they name different databases** — the skill's is production, the root
 one is the dev snapshot the dev server uses. The skill's `.env` wins: it is loaded first, and
 `loadEnv` only fills in keys that are not already **present** (an empty value counts as present, so
-a bare `DATABASE_REPLICA_URL=` left in this file does not hand the run to the root `.env`). So a
-bare `query.mjs` answers from production while your dev server answers from dev. Comparing a value
+a bare `DATABASE_REPLICA_URL=` left in this file does not hand that key to the root `.env` — the
+target falls back to this file's `DATABASE_URL` instead, and the banner says
+`read-only, but pointed at the primary`). So a bare `query.mjs` answers from production while your
+dev server answers from dev. Comparing a value
 read here against one read by the running app is comparing two different databases unless both lines
 say the same host and port. That cost an hour and produced a confidently wrong root cause on
 2026-08-16: `limit: 8` from the app's DB and `limit: 40` from this skill's, reported as a config bug

--- a/.claude/skills/postgres-query/SKILL.md
+++ b/.claude/skills/postgres-query/SKILL.md
@@ -18,7 +18,9 @@ node .claude/skills/postgres-query/query.mjs --dev  "SELECT * FROM \"User\" LIMI
 
 ### Targets
 
-Pick exactly one. Two target flags in one call is an error, not a silent precedence rule.
+Pick exactly one. Two target flags in one call is an error, not a silent precedence rule, and an
+unrecognised option (`--devv`, `--data_packet`) is rejected rather than ignored — a swallowed typo
+would fall through to the default target, which is production.
 
 | Flag | Connection string | Use when |
 |------|-------------------|----------|
@@ -33,23 +35,29 @@ Omitting the target still runs against prod, so old commands keep working — bu
 ### Every run prints which database answered
 
 Before connecting, the script writes a line to **stderr** naming the target, the access mode, the
-resolved `user@host:port/database`, and the env var it came from:
+`user@host:port/database` **pg itself resolved**, and the env var it came from:
 
 ```
 Target: PROD (read-only) -> <user>@<host>:25061/civitai [DATABASE_REPLICA_URL, timeout 30s]
 ```
 
-It prints under `--quiet` and `--json` too. It is on stderr, so `--json` piped to a file is still
-clean JSON.
+It prints under `--quiet` and `--json` too, and before every exit path that reaches a database —
+including a blocked write, so you can always see which database you just aimed a `DELETE` at. It is
+on stderr, so `--json` piped to a file is still clean JSON.
+
+The host and port come from the client's own resolved connection parameters rather than a re-parse
+of the string, so the line cannot disagree with where the query actually went.
 
 🔴 **Read that line before you trust a result.** This skill's `.env` and the app's root `.env` both
 define `DATABASE_URL`, and **they name different databases** — the skill's is production, the root
-one is the dev snapshot the dev server uses. The skill's `.env` wins (it is loaded first, and
-`loadEnv` never overwrites an already-set key), so a bare `query.mjs` answers from production while
-your dev server answers from dev. Comparing a value read here against one read by the running app
-is comparing two different databases unless both lines say the same host and port. That cost an hour
-and produced a confidently wrong root cause on 2026-08-16: `limit: 8` from the app's DB and
-`limit: 40` from this skill's, reported as a config bug that did not exist.
+one is the dev snapshot the dev server uses. The skill's `.env` wins: it is loaded first, and
+`loadEnv` only fills in keys that are not already **present** (an empty value counts as present, so
+a bare `DATABASE_REPLICA_URL=` left in this file does not hand the run to the root `.env`). So a
+bare `query.mjs` answers from production while your dev server answers from dev. Comparing a value
+read here against one read by the running app is comparing two different databases unless both lines
+say the same host and port. That cost an hour and produced a confidently wrong root cause on
+2026-08-16: `limit: 8` from the app's DB and `limit: 40` from this skill's, reported as a config bug
+that did not exist.
 
 ### Options
 
@@ -62,7 +70,8 @@ and produced a confidently wrong root cause on 2026-08-16: `limit: 8` from the a
 | `--json` | Output results as JSON |
 | `--quiet`, `-q` | Minimal output, only results |
 
-`--writable` is rejected on `--data-packet` and `--notifications`; both are read-only replicas.
+`--writable` combined with `--data-packet` or `--notifications` is an error — both are read-only
+replicas, so the combination can only mean a mistake.
 
 ### Examples
 
@@ -89,6 +98,13 @@ node .claude/skills/postgres-query/query.mjs --dev -f my-query.sql
 node .claude/skills/postgres-query/query.mjs --prod --json "SELECT id, username FROM \"User\" LIMIT 3"
 ```
 
+### There is a second skill with this name
+
+`apps/event-engine/.claude/skills/postgres-query/` is a separate copy with its own `.env`, and it
+has **none** of the above — no target flag, no banner. Skills are directory-scoped, so work under
+`apps/event-engine` resolves to that one. Check which script you are invoking by path before
+trusting its output.
+
 ## Querying the dev database (cnpg)
 
 The dev database is not reachable directly — it needs an SSH tunnel to an internal
@@ -108,6 +124,10 @@ node .claude/skills/postgres-query/query.mjs --dev "SELECT count(*) FROM \"User\
 # Writable DML (needs user permission)
 node .claude/skills/postgres-query/query.mjs --dev --writable "UPDATE ..."
 ```
+
+`--dev` uses `DEV_DATABASE_URL` either way — unlike `--prod`, there is no separate replica
+credential, so `--writable` only lifts the client-side guard. Whether a write lands is decided by
+the role in that URL.
 
 **DDL does not work through this credential.** `DEV_DATABASE_URL` connects as a
 non-superuser role, and the dev database has a `ddl_command_end` event trigger that
@@ -156,9 +176,15 @@ The role `notifications_readonly` only has `SELECT`. Writes are also rejected at
 
 1. **Read-only by default**: `--prod` uses `DATABASE_REPLICA_URL` to prevent accidental writes
 2. **Write protection**: Blocks INSERT/UPDATE/DELETE/DROP unless `--writable` flag is used
-3. **Replica targets are always read-only**: `--notifications` and `--data-packet` reject `--writable` client-side, and their roles/poolers reject writes too
+3. **Replica targets refuse `--writable`**: `--notifications` and `--data-packet` error on the flag, and their roles/poolers reject writes anyway
 4. **Explicit permission required**: Before using `--writable`, you MUST ask the user for permission
 5. **The target is printed on every run**: no result can be attributed to the wrong database by accident
+
+⚠️ **The write guard is a typo-catcher, not a sandbox.** It matches the query's leading keyword
+(after stripping leading comments) and the `(INSERT|UPDATE|DELETE|…` inside a leading `WITH`. A write
+buried deeper than that gets through the client. What actually stops writes is the **role** you
+connect as — which is why `--prod` defaults to the read-only replica credential. Do not treat a
+missing `--writable` as proof a query cannot write.
 
 ## When to Use --writable
 

--- a/.claude/skills/postgres-query/SKILL.md
+++ b/.claude/skills/postgres-query/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: postgres-query
-description: Run PostgreSQL queries for testing, debugging, and performance analysis. Use when you need to query the database directly, run EXPLAIN ANALYZE, compare query results, or test SQL optimizations. Always uses read-only connections unless explicitly directed otherwise.
+description: Run PostgreSQL queries for testing, debugging, and performance analysis. Use when you need to query the database directly, run EXPLAIN ANALYZE, compare query results, or test SQL optimizations. Always pass a target — `--prod` or `--dev` — because prod and dev are different databases and the default is prod. Always uses read-only connections unless explicitly directed otherwise.
 ---
 
 # PostgreSQL Query Testing
@@ -9,57 +9,85 @@ Use this skill to run ad-hoc PostgreSQL queries for testing, debugging, and perf
 
 ## Running Queries
 
-Use the included query script:
+Use the included query script, and **name the target**:
 
 ```bash
-node .claude/skills/postgres-query/query.mjs "SELECT * FROM \"User\" LIMIT 5"
+node .claude/skills/postgres-query/query.mjs --prod "SELECT * FROM \"User\" LIMIT 5"
+node .claude/skills/postgres-query/query.mjs --dev  "SELECT * FROM \"User\" LIMIT 5"
 ```
+
+### Targets
+
+Pick exactly one. Two target flags in one call is an error, not a silent precedence rule.
+
+| Flag | Connection string | Use when |
+|------|-------------------|----------|
+| `--prod` (default) | `DATABASE_REPLICA_URL`, or `DATABASE_URL` with `--writable` | The production main database |
+| `--dev` | `DEV_DATABASE_URL` | The dev cnpg database; requires SSH tunnel |
+| `--data-packet` | `DATABASE_DATA_PACKET_URL` | The DataPacket replica (read-only) |
+| `--notifications` | `NOTIFICATION_DB_REPLICA_URL` | notifications-db (read-only); requires SSH tunnel |
+
+Omitting the target still runs against prod, so old commands keep working — but the run prints
+`No target flag given, defaulted to --prod`. Pass the flag.
+
+### Every run prints which database answered
+
+Before connecting, the script writes a line to **stderr** naming the target, the access mode, the
+resolved `user@host:port/database`, and the env var it came from:
+
+```
+Target: PROD (read-only) -> <user>@<host>:25061/civitai [DATABASE_REPLICA_URL, timeout 30s]
+```
+
+It prints under `--quiet` and `--json` too. It is on stderr, so `--json` piped to a file is still
+clean JSON.
+
+🔴 **Read that line before you trust a result.** This skill's `.env` and the app's root `.env` both
+define `DATABASE_URL`, and **they name different databases** — the skill's is production, the root
+one is the dev snapshot the dev server uses. The skill's `.env` wins (it is loaded first, and
+`loadEnv` never overwrites an already-set key), so a bare `query.mjs` answers from production while
+your dev server answers from dev. Comparing a value read here against one read by the running app
+is comparing two different databases unless both lines say the same host and port. That cost an hour
+and produced a confidently wrong root cause on 2026-08-16: `limit: 8` from the app's DB and
+`limit: 40` from this skill's, reported as a config bug that did not exist.
 
 ### Options
 
 | Flag | Description |
 |------|-------------|
 | `--explain` | Run EXPLAIN ANALYZE on the query |
-| `--writable` | Use primary database instead of read replica (requires user permission) |
-| `--data-packet` | Use the DataPacket replica (`DATABASE_DATA_PACKET_URL`) — read-only |
-| `--notifications` | Query the notifications-db (DataPacket) — read-only via SSH bastion (see setup below) |
-| `--dev` | Query the dev cnpg database (`DEV_DATABASE_URL`) via SSH bastion (see setup below) |
+| `--writable` | Use the primary connection instead of the read replica (requires user permission) |
 | `--timeout <s>`, `-t` | Query timeout in seconds (default: 30) |
 | `--file`, `-f` | Read query from a file |
 | `--json` | Output results as JSON |
 | `--quiet`, `-q` | Minimal output, only results |
 
+`--writable` is rejected on `--data-packet` and `--notifications`; both are read-only replicas.
+
 ### Examples
 
 ```bash
 # Simple query
-node .claude/skills/postgres-query/query.mjs "SELECT id, username FROM \"User\" LIMIT 5"
+node .claude/skills/postgres-query/query.mjs --prod "SELECT id, username FROM \"User\" LIMIT 5"
+
+# Same query against the dev database
+node .claude/skills/postgres-query/query.mjs --dev "SELECT id, username FROM \"User\" LIMIT 5"
 
 # Check query performance
-node .claude/skills/postgres-query/query.mjs --explain "SELECT * FROM \"Model\" WHERE id = 1"
+node .claude/skills/postgres-query/query.mjs --prod --explain "SELECT * FROM \"Model\" WHERE id = 1"
 
 # Override default 30s timeout for longer queries
-node .claude/skills/postgres-query/query.mjs --timeout 60 "SELECT ... (complex query)"
+node .claude/skills/postgres-query/query.mjs --prod --timeout 60 "SELECT ... (complex query)"
 
 # Query the notifications-db
 node .claude/skills/postgres-query/query.mjs --notifications "SELECT count(*) FROM \"Notification\""
 
 # Query from file
-node .claude/skills/postgres-query/query.mjs -f my-query.sql
+node .claude/skills/postgres-query/query.mjs --dev -f my-query.sql
 
-# JSON output for processing
-node .claude/skills/postgres-query/query.mjs --json "SELECT id, username FROM \"User\" LIMIT 3"
+# JSON output for processing (banner goes to stderr, stdout stays valid JSON)
+node .claude/skills/postgres-query/query.mjs --prod --json "SELECT id, username FROM \"User\" LIMIT 3"
 ```
-
-## Connection Targets
-
-| Flag | Connection string | Use when |
-|------|-------------------|----------|
-| (default) | `DATABASE_REPLICA_URL` (falls back to `DATABASE_URL`) | Most queries — read-only main replica |
-| `--writable` | `DATABASE_URL` | Writes against primary; needs user permission |
-| `--data-packet` | `DATABASE_DATA_PACKET_URL` | Querying the DataPacket replica (read-only) |
-| `--notifications` | `NOTIFICATION_DB_REPLICA_URL` | Querying notifications-db (read-only); requires SSH tunnel |
-| `--dev` | `DEV_DATABASE_URL` | Querying the dev cnpg database; requires SSH tunnel |
 
 ## Querying the dev database (cnpg)
 
@@ -126,10 +154,11 @@ The role `notifications_readonly` only has `SELECT`. Writes are also rejected at
 
 ## Safety Features
 
-1. **Read-only by default**: Uses `DATABASE_REPLICA_URL` to prevent accidental writes
+1. **Read-only by default**: `--prod` uses `DATABASE_REPLICA_URL` to prevent accidental writes
 2. **Write protection**: Blocks INSERT/UPDATE/DELETE/DROP unless `--writable` flag is used
-3. **Notifications is always read-only**: `--notifications` blocks writes client-side AND the database role/pooler reject them
+3. **Replica targets are always read-only**: `--notifications` and `--data-packet` reject `--writable` client-side, and their roles/poolers reject writes too
 4. **Explicit permission required**: Before using `--writable`, you MUST ask the user for permission
+5. **The target is printed on every run**: no result can be attributed to the wrong database by accident
 
 ## When to Use --writable
 
@@ -142,18 +171,18 @@ Only use the `--writable` flag when:
 
 ## Comparing Query Performance
 
-To compare two query approaches:
+To compare two query approaches — same target on both runs, or the comparison is meaningless:
 
 ```bash
 # Run first approach
-node .claude/skills/postgres-query/query.mjs --explain "SELECT ... (approach 1)"
+node .claude/skills/postgres-query/query.mjs --prod --explain "SELECT ... (approach 1)"
 
 # Run second approach
-node .claude/skills/postgres-query/query.mjs --explain "SELECT ... (approach 2)"
+node .claude/skills/postgres-query/query.mjs --prod --explain "SELECT ... (approach 2)"
 
 # Compare actual results
-node .claude/skills/postgres-query/query.mjs --json "SELECT ... (approach 1)" > /tmp/q1.json
-node .claude/skills/postgres-query/query.mjs --json "SELECT ... (approach 2)" > /tmp/q2.json
+node .claude/skills/postgres-query/query.mjs --prod --json "SELECT ... (approach 1)" > /tmp/q1.json
+node .claude/skills/postgres-query/query.mjs --prod --json "SELECT ... (approach 2)" > /tmp/q2.json
 ```
 
 ## Verifying Index Usage
@@ -163,5 +192,5 @@ Run with `--explain` and look for:
 - **Bad**: "Seq Scan" on large tables (indicates missing or unused index)
 
 ```bash
-node .claude/skills/postgres-query/query.mjs --explain "SELECT * FROM \"Account\" WHERE provider = 'discord'"
+node .claude/skills/postgres-query/query.mjs --prod --explain "SELECT * FROM \"Account\" WHERE provider = 'discord'"
 ```

--- a/.claude/skills/postgres-query/query.mjs
+++ b/.claude/skills/postgres-query/query.mjs
@@ -53,7 +53,9 @@ function loadEnv() {
         if (eqIndex === -1) continue;
         const key = trimmed.slice(0, eqIndex);
         const value = trimmed.slice(eqIndex + 1);
-        if (!process.env[key]) {
+        // Presence wins, not truthiness: `DATABASE_REPLICA_URL=` left empty in the skill's .env
+        // must not hand the run to the root .env, which names a different database.
+        if (process.env[key] === undefined) {
           process.env[key] = value;
         }
       }
@@ -150,7 +152,13 @@ for (let i = 0; i < args.length; i++) {
       process.exit(1);
     }
     query = readFileSync(resolve(process.cwd(), filePath), 'utf-8');
-  } else if (!arg.startsWith('-')) {
+  } else if (arg.startsWith('-')) {
+    // A swallowed typo falls through to the default target, which is production.
+    console.error(`Error: unknown option "${arg}".`);
+    console.error(`Targets: ${Object.values(TARGETS).map((t) => t.flag).join(', ')}`);
+    console.error('Options: --explain --writable --timeout <s> --file <path> --json --quiet');
+    process.exit(1);
+  } else {
     query = arg;
   }
 }
@@ -191,6 +199,11 @@ const targetName = requestedTargets[0] ?? DEFAULT_TARGET;
 const target = TARGETS[targetName];
 const targetWasExplicit = requestedTargets.length === 1;
 
+if (writable && target.readOnly) {
+  console.error(`Error: ${target.flag} is a read-only replica; --writable cannot apply to it.`);
+  process.exit(1);
+}
+
 const candidateVars = [...new Set([target.envVar(writable), target.fallbackEnvVar].filter(Boolean))];
 const connectionVar = candidateVars.find((name) => process.env[name]);
 const connectionString = connectionVar && process.env[connectionVar];
@@ -201,36 +214,26 @@ if (!connectionString) {
   process.exit(1);
 }
 
-// The wrong-database failure is silent by construction: the skill's own .env and the app's root
-// .env name different databases under the same key names. Print what actually answered, every run,
-// so a result can never be attributed to the wrong target.
-function describeConnection(str) {
-  try {
-    const url = new URL(str);
-    const db = url.pathname.replace(/^\//, '') || '(default db)';
-    const user = url.username ? `${decodeURIComponent(url.username)}@` : '';
-    return `${user}${url.hostname}:${url.port || '5432'}/${db}`;
-  } catch {
-    return '(unparsable connection string)';
-  }
+let client;
+try {
+  client = new Client({
+    connectionString,
+    ssl: { rejectUnauthorized: false },
+    statement_timeout: timeoutSeconds * 1000,
+    query_timeout: timeoutSeconds * 1000,
+  });
+} catch (err) {
+  console.error(`Error: ${connectionVar} is not a usable connection string: ${err.message}`);
+  process.exit(1);
 }
 
-// Safety check for writable operations
-// --notifications and --data-packet connect through read-only roles on replicas — writes
-// would fail anyway, but block them client-side so users get a clearer error.
-if (!writable || target.readOnly) {
-  const upperQuery = query.toUpperCase().trim();
-  const writeOps = ['INSERT', 'UPDATE', 'DELETE', 'DROP', 'ALTER', 'TRUNCATE', 'CREATE'];
-  for (const op of writeOps) {
-    if (upperQuery.startsWith(op)) {
-      const ctx = target.readOnly
-        ? `${target.flag} is read-only.`
-        : 'Use --writable flag to confirm.';
-      console.error(`Error: Write operation detected (${op}). ${ctx}`);
-      console.error('This requires explicit user permission as it modifies the database.');
-      process.exit(1);
-    }
-  }
+// The wrong-database failure is silent by construction: this skill's .env and the app's root .env
+// name different databases under the same key names. Report the parameters pg itself resolved —
+// not a re-parse of the string — so the line can't disagree with what the query actually hit.
+function describeConnection() {
+  const { user, host, port, database } = client.connectionParameters ?? {};
+  if (!host) return '(connection parameters unavailable)';
+  return `${user ? `${user}@` : ''}${host}:${port}/${database ?? '(default db)'}`;
 }
 
 const onFallback = connectionVar !== target.envVar(writable);
@@ -241,7 +244,7 @@ const access =
       ? 'read-only, but pointed at the primary'
       : 'read-only';
 console.error(
-  `Target: ${target.label} (${access}) -> ${describeConnection(connectionString)} ` +
+  `Target: ${target.label} (${access}) -> ${describeConnection()} ` +
     `[${connectionVar}, timeout ${timeoutSeconds}s]`
 );
 if (!targetWasExplicit) {
@@ -251,14 +254,29 @@ if (!targetWasExplicit) {
 }
 console.error('');
 
-async function main() {
-  const client = new Client({
-    connectionString,
-    ssl: { rejectUnauthorized: false },
-    statement_timeout: timeoutSeconds * 1000,
-    query_timeout: timeoutSeconds * 1000,
-  });
+// Client-side write guard. It matches the query's first keyword, so it is a guard against an
+// accidental write, not a sandbox: a write nested in a CTE gets through, and only the server-side
+// role stops that. Leading comments are stripped first so `/* note */ DELETE` can't slip past.
+if (!writable || target.readOnly) {
+  const upperQuery = query
+    .replace(/^(\s|--[^\n]*\n|\/\*[\s\S]*?\*\/)+/, '')
+    .toUpperCase()
+    .trim();
+  const writeOps = ['INSERT', 'UPDATE', 'DELETE', 'DROP', 'ALTER', 'TRUNCATE', 'CREATE'];
+  for (const op of writeOps) {
+    const nested = upperQuery.startsWith('WITH') && new RegExp(`\\(\\s*${op}\\b`).test(upperQuery);
+    if (upperQuery.startsWith(op) || nested) {
+      const ctx = target.readOnly
+        ? `${target.flag} is read-only.`
+        : 'Use --writable flag to confirm.';
+      console.error(`Error: Write operation detected (${op}). ${ctx}`);
+      console.error('This requires explicit user permission as it modifies the database.');
+      process.exit(1);
+    }
+  }
+}
 
+async function main() {
   try {
     await client.connect();
 

--- a/.claude/skills/postgres-query/query.mjs
+++ b/.claude/skills/postgres-query/query.mjs
@@ -4,11 +4,17 @@
  * PostgreSQL Query Runner
  *
  * Usage:
- *   node .claude/skills/postgres-query/query.mjs "SELECT * FROM \"User\" LIMIT 5"
- *   node .claude/skills/postgres-query/query.mjs --explain "SELECT * FROM \"User\" WHERE id = 1"
- *   node .claude/skills/postgres-query/query.mjs --writable "UPDATE ..." (requires explicit flag)
- *   node .claude/skills/postgres-query/query.mjs --file query.sql
- *   node .claude/skills/postgres-query/query.mjs --timeout 60 "SELECT ..." (override 30s default)
+ *   node .claude/skills/postgres-query/query.mjs --prod "SELECT * FROM \"User\" LIMIT 5"
+ *   node .claude/skills/postgres-query/query.mjs --dev --explain "SELECT * FROM \"User\" WHERE id = 1"
+ *   node .claude/skills/postgres-query/query.mjs --prod --writable "UPDATE ..." (requires explicit flag)
+ *   node .claude/skills/postgres-query/query.mjs --dev --file query.sql
+ *   node .claude/skills/postgres-query/query.mjs --prod --timeout 60 "SELECT ..." (override 30s default)
+ *
+ * Targets (pick one; defaults to --prod):
+ *   --prod          Production main database
+ *   --dev           Dev cnpg database (DEV_DATABASE_URL)
+ *   --data-packet   DataPacket logical replica
+ *   --notifications notifications-db replica
  *
  * Options:
  *   --explain       Run EXPLAIN ANALYZE on the query
@@ -75,30 +81,57 @@ pg.types.setTypeParser(1114, (value) =>
 
 const DEFAULT_TIMEOUT_SECONDS = 30;
 
+const TARGETS = {
+  prod: {
+    flag: '--prod',
+    label: 'PROD',
+    envVar: (writable) => (writable ? 'DATABASE_URL' : 'DATABASE_REPLICA_URL'),
+    fallbackEnvVar: 'DATABASE_URL',
+    readOnly: false,
+  },
+  dev: {
+    flag: '--dev',
+    label: 'DEV',
+    envVar: () => 'DEV_DATABASE_URL',
+    readOnly: false,
+    hint: 'Start the SSH bastion tunnel and add DEV_DATABASE_URL to the skill .env (see SKILL.md).',
+  },
+  'data-packet': {
+    flag: '--data-packet',
+    label: 'DATA-PACKET REPLICA',
+    envVar: () => 'DATABASE_DATA_PACKET_URL',
+    readOnly: true,
+  },
+  notifications: {
+    flag: '--notifications',
+    label: 'NOTIFICATIONS-DB REPLICA',
+    envVar: () => 'NOTIFICATION_DB_REPLICA_URL',
+    readOnly: true,
+    hint: 'Start the SSH bastion tunnel and add NOTIFICATION_DB_REPLICA_URL to the skill .env (see SKILL.md).',
+  },
+};
+
+const DEFAULT_TARGET = 'prod';
+
 // Parse arguments
 const args = process.argv.slice(2);
 let query = '';
 let explain = false;
 let writable = false;
-let dataPacket = false;
-let notifications = false;
-let dev = false;
 let jsonOutput = false;
 let quiet = false;
 let timeoutSeconds = DEFAULT_TIMEOUT_SECONDS;
+const requestedTargets = [];
 
 for (let i = 0; i < args.length; i++) {
   const arg = args[i];
-  if (arg === '--explain') {
+  const targetName = Object.keys(TARGETS).find((name) => TARGETS[name].flag === arg);
+  if (targetName) {
+    if (!requestedTargets.includes(targetName)) requestedTargets.push(targetName);
+  } else if (arg === '--explain') {
     explain = true;
   } else if (arg === '--writable') {
     writable = true;
-  } else if (arg === '--data-packet') {
-    dataPacket = true;
-  } else if (arg === '--notifications') {
-    notifications = true;
-  } else if (arg === '--dev') {
-    dev = true;
   } else if (arg === '--json') {
     jsonOutput = true;
   } else if (arg === '--quiet' || arg === '-q') {
@@ -123,7 +156,13 @@ for (let i = 0; i < args.length; i++) {
 }
 
 if (!query) {
-  console.error(`Usage: node query.mjs [options] "SQL query"
+  console.error(`Usage: node query.mjs [--prod|--dev] [options] "SQL query"
+
+Targets (pick one, defaults to --prod):
+  --prod          Production main database
+  --dev           Dev cnpg database (needs SSH bastion tunnel)
+  --data-packet   DataPacket logical replica (read-only)
+  --notifications notifications-db replica (read-only, needs tunnel)
 
 Options:
   --explain       Run EXPLAIN ANALYZE on the query
@@ -134,52 +173,58 @@ Options:
   --quiet, -q     Minimal output
 
 Examples:
-  node query.mjs "SELECT id, username FROM \\"User\\" LIMIT 5"
-  node query.mjs --explain "SELECT * FROM \\"Model\\" WHERE id = 1"
-  node query.mjs --timeout 60 "SELECT ... (long running query)"
-  node query.mjs -f my-query.sql`);
+  node query.mjs --prod "SELECT id, username FROM \\"User\\" LIMIT 5"
+  node query.mjs --dev --explain "SELECT * FROM \\"Model\\" WHERE id = 1"
+  node query.mjs --prod --timeout 60 "SELECT ... (long running query)"
+  node query.mjs --dev -f my-query.sql`);
   process.exit(1);
 }
 
-// Select connection string
-let connectionString;
-if (notifications) {
-  // notifications-db on DataPacket (read-only via SSH bastion tunnel).
-  // Set NOTIFICATION_DB_REPLICA_URL in .env after starting the tunnel.
-  connectionString = process.env.NOTIFICATION_DB_REPLICA_URL;
-} else if (dev) {
-  // Dev cnpg cluster via SSH bastion tunnel (port 15432).
-  // Writes still require --writable (the postgres superuser can write).
-  connectionString = process.env.DEV_DATABASE_URL;
-} else if (dataPacket) {
-  connectionString = process.env.DATABASE_DATA_PACKET_URL;
-} else if (writable) {
-  connectionString = process.env.DATABASE_URL;
-} else {
-  connectionString = process.env.DATABASE_REPLICA_URL || process.env.DATABASE_URL;
+if (requestedTargets.length > 1) {
+  console.error(
+    `Error: pick one target. Got ${requestedTargets.map((t) => TARGETS[t].flag).join(' and ')}.`
+  );
+  process.exit(1);
 }
+
+const targetName = requestedTargets[0] ?? DEFAULT_TARGET;
+const target = TARGETS[targetName];
+const targetWasExplicit = requestedTargets.length === 1;
+
+const candidateVars = [...new Set([target.envVar(writable), target.fallbackEnvVar].filter(Boolean))];
+const connectionVar = candidateVars.find((name) => process.env[name]);
+const connectionString = connectionVar && process.env[connectionVar];
 
 if (!connectionString) {
-  if (notifications) {
-    console.error('Error: NOTIFICATION_DB_REPLICA_URL is not set. Start the SSH tunnel and add it to .env (see SKILL.md).');
-  } else if (dev) {
-    console.error('Error: DEV_DATABASE_URL is not set. Start the SSH tunnel (ssh civitai -N) and add it to .env (see SKILL.md).');
-  } else {
-    console.error('Error: No database connection string found in environment');
-  }
+  console.error(`Error: ${target.flag} needs ${candidateVars.join(' or ')} set, and it is not.`);
+  if (target.hint) console.error(target.hint);
   process.exit(1);
+}
+
+// The wrong-database failure is silent by construction: the skill's own .env and the app's root
+// .env name different databases under the same key names. Print what actually answered, every run,
+// so a result can never be attributed to the wrong target.
+function describeConnection(str) {
+  try {
+    const url = new URL(str);
+    const db = url.pathname.replace(/^\//, '') || '(default db)';
+    const user = url.username ? `${decodeURIComponent(url.username)}@` : '';
+    return `${user}${url.hostname}:${url.port || '5432'}/${db}`;
+  } catch {
+    return '(unparsable connection string)';
+  }
 }
 
 // Safety check for writable operations
-// --notifications connects through a read-only role on a replica — writes
+// --notifications and --data-packet connect through read-only roles on replicas — writes
 // would fail anyway, but block them client-side so users get a clearer error.
-if (!writable || notifications) {
+if (!writable || target.readOnly) {
   const upperQuery = query.toUpperCase().trim();
   const writeOps = ['INSERT', 'UPDATE', 'DELETE', 'DROP', 'ALTER', 'TRUNCATE', 'CREATE'];
   for (const op of writeOps) {
     if (upperQuery.startsWith(op)) {
-      const ctx = notifications
-        ? '--notifications is read-only (bastion routes through a replica).'
+      const ctx = target.readOnly
+        ? `${target.flag} is read-only.`
         : 'Use --writable flag to confirm.';
       console.error(`Error: Write operation detected (${op}). ${ctx}`);
       console.error('This requires explicit user permission as it modifies the database.');
@@ -187,6 +232,24 @@ if (!writable || notifications) {
     }
   }
 }
+
+const onFallback = connectionVar !== target.envVar(writable);
+const access =
+  writable && !target.readOnly
+    ? 'writable'
+    : onFallback
+      ? 'read-only, but pointed at the primary'
+      : 'read-only';
+console.error(
+  `Target: ${target.label} (${access}) -> ${describeConnection(connectionString)} ` +
+    `[${connectionVar}, timeout ${timeoutSeconds}s]`
+);
+if (!targetWasExplicit) {
+  console.error(
+    `No target flag given, defaulted to ${target.flag}. Pass --prod or --dev to be explicit.`
+  );
+}
+console.error('');
 
 async function main() {
   const client = new Client({
@@ -198,19 +261,6 @@ async function main() {
 
   try {
     await client.connect();
-
-    if (!quiet) {
-      const dbType = notifications
-        ? 'NOTIFICATIONS-DB REPLICA via bastion (read-only)'
-        : dev
-          ? `DEV via bastion (${writable ? 'writable' : 'read-only'})`
-          : dataPacket
-            ? 'DATA-PACKET REPLICA (read-only)'
-            : writable
-              ? 'PRIMARY (writable)'
-              : 'REPLICA (read-only)';
-      console.error(`Connected to ${dbType} (timeout: ${timeoutSeconds}s)\n`);
-    }
 
     const finalQuery = explain ? `EXPLAIN ANALYZE ${query}` : query;
     const start = Date.now();

--- a/.claude/skills/postgres-query/query.mjs
+++ b/.claude/skills/postgres-query/query.mjs
@@ -152,8 +152,9 @@ for (let i = 0; i < args.length; i++) {
       process.exit(1);
     }
     query = readFileSync(resolve(process.cwd(), filePath), 'utf-8');
-  } else if (arg.startsWith('-')) {
-    // A swallowed typo falls through to the default target, which is production.
+  } else if (arg.startsWith('-') && !/^--(\s|$)/.test(arg) && !/\s/.test(arg)) {
+    // A swallowed typo falls through to the default target, which is production. SQL opening with
+    // a `--` comment is still SQL, hence the two exceptions above.
     console.error(`Error: unknown option "${arg}".`);
     console.error(`Targets: ${Object.values(TARGETS).map((t) => t.flag).join(', ')}`);
     console.error('Options: --explain --writable --timeout <s> --file <path> --json --quiet');
@@ -199,11 +200,6 @@ const targetName = requestedTargets[0] ?? DEFAULT_TARGET;
 const target = TARGETS[targetName];
 const targetWasExplicit = requestedTargets.length === 1;
 
-if (writable && target.readOnly) {
-  console.error(`Error: ${target.flag} is a read-only replica; --writable cannot apply to it.`);
-  process.exit(1);
-}
-
 const candidateVars = [...new Set([target.envVar(writable), target.fallbackEnvVar].filter(Boolean))];
 const connectionVar = candidateVars.find((name) => process.env[name]);
 const connectionString = connectionVar && process.env[connectionVar];
@@ -214,18 +210,12 @@ if (!connectionString) {
   process.exit(1);
 }
 
-let client;
-try {
-  client = new Client({
-    connectionString,
-    ssl: { rejectUnauthorized: false },
-    statement_timeout: timeoutSeconds * 1000,
-    query_timeout: timeoutSeconds * 1000,
-  });
-} catch (err) {
-  console.error(`Error: ${connectionVar} is not a usable connection string: ${err.message}`);
-  process.exit(1);
-}
+const client = new Client({
+  connectionString,
+  ssl: { rejectUnauthorized: false },
+  statement_timeout: timeoutSeconds * 1000,
+  query_timeout: timeoutSeconds * 1000,
+});
 
 // The wrong-database failure is silent by construction: this skill's .env and the app's root .env
 // name different databases under the same key names. Report the parameters pg itself resolved —
@@ -254,12 +244,19 @@ if (!targetWasExplicit) {
 }
 console.error('');
 
-// Client-side write guard. It matches the query's first keyword, so it is a guard against an
-// accidental write, not a sandbox: a write nested in a CTE gets through, and only the server-side
-// role stops that. Leading comments are stripped first so `/* note */ DELETE` can't slip past.
+if (writable && target.readOnly) {
+  console.error(`Error: ${target.flag} is a read-only replica; --writable cannot apply to it.`);
+  process.exit(1);
+}
+
+// Client-side write guard. It matches the query's leading keyword, so it catches an accidental
+// write, not a determined one: anything nested deeper than a leading CTE gets through, and only
+// the role you connect as stops that. Comments and string literals are blanked first, so
+// `/* note */ DELETE` can't slip past and a SELECT mentioning "delete" in a literal isn't blocked.
 if (!writable || target.readOnly) {
   const upperQuery = query
-    .replace(/^(\s|--[^\n]*\n|\/\*[\s\S]*?\*\/)+/, '')
+    .replace(/'([^']|'')*'/g, "''")
+    .replace(/--[^\n]*|\/\*[\s\S]*?\*\//g, ' ')
     .toUpperCase()
     .trim();
   const writeOps = ['INSERT', 'UPDATE', 'DELETE', 'DROP', 'ALTER', 'TRUNCATE', 'CREATE'];


### PR DESCRIPTION
## Why

`.claude/skills/postgres-query/.env` and the app's root `.env` both define `DATABASE_URL`, and **they name different databases** — the skill's is production, the root one is the dev snapshot the dev server runs on. The skill's file wins (loaded first; `loadEnv` never overwrites an already-set key), so a bare `query.mjs` answers from prod while the running app answers from dev, and nothing in the output says which.

That cost about an hour on 2026-08-16 and produced a confidently wrong analysis: `limit: 8` read from the app's DB and `limit: 40` read from this skill's, concluded a home block was misconfigured, short homepage rows reported as a code bug. They were the same row in two different databases.

## What changed

- **`--prod` added**, alongside the existing `--dev`, `--data-packet`, `--notifications`. One target concept in a `TARGETS` table instead of four booleans resolved by if/else precedence.
- **Two target flags in one call is an error**, not a silent winner.
- **Every run prints which database answered**, before connecting:

  ```
  Target: PROD (read-only) -> <user>@<host>:25061/civitai [DATABASE_REPLICA_URL, timeout 30s]
  ```

  On **stderr**, so `--json | jq` still gets clean JSON, and it prints under `--quiet` too — the failure mode was silence about the target, not the absence of a flag.
- Omitting the target still runs against prod (existing commands unaffected), but prints `No target flag given, defaulted to --prod`.
- `--writable` is now rejected client-side on `--data-packet` as well as `--notifications`; both are read-only replicas.
- When `--prod` falls back from `DATABASE_REPLICA_URL` to `DATABASE_URL`, the banner says `read-only, but pointed at the primary` rather than plain `read-only`.
- `SKILL.md` and `.env.example` updated; the skill description now tells the caller to pass a target.

Connection strings are parsed with `new URL()`, not a regex — a sanitising regex silently eating the port is what sent the original investigation down the wrong path. The password is never printed.

## Verification

Manual, against all four resolutions (creds/hosts elided):

| Command | Resolved |
|---|---|
| `--prod` | `DATABASE_REPLICA_URL` → port 25061 |
| `--prod --writable` | `DATABASE_URL` → port 25060 |
| `--dev` | `DEV_DATABASE_URL` → port 25071 |
| `--dev --writable` | `DEV_DATABASE_URL` → port 25071 |

Plus: `--prod --dev` exits 1 with `pick one target`; `--prod "UPDATE ..."` and `--data-packet --writable "UPDATE ..."` both blocked; `--json -q 2>/dev/null` emits valid JSON and nothing else; no-flag run warns and still works.

`--notifications` fails on a self-signed certificate chain — pre-existing, unrelated to this change, untouched.

No repo checks apply to this path: `.claude/**` is outside `tsc`, and root Prettier globs `.ts`/`.tsx` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181mgyqPi6S2UormsRtXQgM