### PR TITLE
test(app-store): cover the real Flipt client + make the silent store gate loud (#3983)

### DIFF
--- a/src/__tests__/mocks/direct-mock-allowlist.json
+++ b/src/__tests__/mocks/direct-mock-allowlist.json
@@ -20,10 +20,10 @@
   ],
   "totals": {
     "canonicalFiles": 218,
-    "pendingFiles": 396,
-    "allFiles": 482,
+    "pendingFiles": 398,
+    "allFiles": 485,
     "canonicalSites": 288,
-    "pendingSites": 864
+    "pendingSites": 869
   },
   "bySpecifier": {
     "~/server/db/client": 135,
@@ -36,7 +36,7 @@
     "~/server/services/notification.service": 77,
     "~/server/services/user.service": 75,
     "~/server/search-index": 65,
-    "~/server/flipt/client": 64,
+    "~/server/flipt/client": 66,
     "~/server/redis/fail-open-log": 55,
     "~/server/utils/endpoint-helpers": 53,
     "~/server/redis/caches": 54,
@@ -398,6 +398,8 @@
     "src/server/services/__tests__/app-blocks-flag.agentic-review.test.ts",
     "src/server/services/__tests__/app-blocks-flag.external-scope.seam.test.ts",
     "src/server/services/__tests__/app-blocks-flag.external-scope.test.ts",
+    "src/server/services/__tests__/app-blocks-flag.real-flipt-client.integration.test.ts",
+    "src/server/services/__tests__/app-blocks-flag.silent-gate-signal.test.ts",
     "src/server/services/__tests__/app-blocks-flag.test.ts",
     "src/server/services/__tests__/app-blocks-pipeline-flag.test.ts",
     "src/server/services/__tests__/app-blocks-runtime-flag.test.ts",

--- a/src/pages/api/v1/apps/[slug].ts
+++ b/src/pages/api/v1/apps/[slug].ts
@@ -1,6 +1,7 @@
 import * as z from 'zod';
 import { resolveStoreVisibilityScope } from '~/server/services/app-blocks-flag';
 import { getListingDetail } from '~/server/services/blocks/app-listing.service';
+import { recordStoreScopeApplied } from '~/server/prom/store-scope.metrics';
 import { MixedAuthEndpoint, handleEndpointError } from '~/server/utils/endpoint-helpers';
 import { enforceAppsCatalogRateLimit } from '~/server/utils/apps-catalog-rate-limit';
 import { isHostForColor } from '~/server/utils/server-domain';
@@ -82,6 +83,9 @@ export default MixedAuthEndpoint(async function handler(req, res, user) {
 
     // DEFAULT-CLOSED scope gate — pass the resolved scope EXPLICITLY to the service.
     const scope = await resolveStoreVisibilityScope({ user });
+    // See the sibling `index.ts` + store-scope.metrics: recorded so an ABSENT scope
+    // is distinguishable from a resolved one in production (civitai#3983).
+    recordStoreScopeApplied(scope, 'rest-detail');
     if (scope === 'none') {
       return res.status(404).json(restErrorBody(REST_ERROR_CODE.NOT_FOUND, 'App not found'));
     }

--- a/src/pages/api/v1/apps/index.ts
+++ b/src/pages/api/v1/apps/index.ts
@@ -2,6 +2,7 @@ import * as z from 'zod';
 import { getAppListingsListQuery } from '~/server/schema/blocks/app-listing-read.schema';
 import { resolveStoreVisibilityScope } from '~/server/services/app-blocks-flag';
 import { listAvailableListings } from '~/server/services/blocks/app-listing.service';
+import { recordStoreScopeApplied } from '~/server/prom/store-scope.metrics';
 import { MixedAuthEndpoint, handleEndpointError } from '~/server/utils/endpoint-helpers';
 import { enforceAppsCatalogRateLimit } from '~/server/utils/apps-catalog-rate-limit';
 import { getNextPage } from '~/server/utils/pagination-helpers';
@@ -87,6 +88,11 @@ export default MixedAuthEndpoint(async function handler(req, res, user) {
 
     // DEFAULT-CLOSED scope gate — pass the resolved scope EXPLICITLY to the service.
     const scope = await resolveStoreVisibilityScope({ user });
+    // Record what this entry point actually branched on. 🔴 The listing service
+    // defaults an ABSENT scope to `full`, so "no scope arrived" and "resolved full"
+    // produce the identical response here — `recordStoreScopeApplied` is what keeps
+    // those two apart in production (see store-scope.metrics; civitai#3983).
+    recordStoreScopeApplied(scope, 'rest-list');
     if (scope === 'none') {
       // Anon / non-privileged pre-launch → empty page, NEVER the full catalog.
       return res

--- a/src/server/prom/store-scope.metrics.ts
+++ b/src/server/prom/store-scope.metrics.ts
@@ -1,0 +1,158 @@
+import client from 'prom-client';
+import { PROM_PREFIX } from '@civitai/telemetry/client';
+
+/**
+ * APP-STORE READ-SCOPE metrics — the detection net for civitai#3983.
+ *
+ * ## Why this exists
+ *
+ * `resolveStoreVisibilityScope` is a SILENT gate. Every wrong answer it can give
+ * renders as an ordinary, successful, empty page:
+ *   - `scope === 'none'` → the tRPC read procs return `{ items: [] }` and
+ *     `getAppDetail` throws NOT_FOUND;
+ *   - the procedures' `?? 'none'` makes an ABSENT scope indistinguishable from a
+ *     genuine `none`;
+ *   - and from outside, `none` and `public-external`-with-no-matching-rows are the
+ *     same two bytes.
+ *
+ * So when the external-only tester cohort was granted the store and got an empty
+ * grid, nothing anywhere reported a problem — not to the users, not to operators,
+ * and not to the investigation, which spent its whole length unable to tell those
+ * cases apart from the outside. The bug was live and silent.
+ *
+ * These counters make the gate legible.
+ *
+ * ## The three signals
+ *
+ * `civitai_app_store_scope_resolutions_total{scope, principal}` — every resolution,
+ * labelled with the answer (`full|public-external|none`) and whether a session user
+ * was present (`user|anon`). SIX series, fixed. This is the signal that answers
+ * "what is production actually resolving for a logged-in viewer?" — the question
+ * that previously required an instrumented deploy to ask.
+ *
+ * `civitai_app_store_scope_applied_total{scope, entrypoint}` — what each entry point
+ * actually BRANCHED on, recorded before its own `??` default. Its extra `absent`
+ * value is the one thing a response can never tell you: whether a scope arrived at
+ * all. Read as a PAIR with the resolution counter — agreement means the answer is
+ * simply wrong, disagreement means the answer is being lost in transit. Those two
+ * faults need opposite fixes and were indistinguishable for the whole of #3983.
+ *
+ * `civitai_app_store_scope_divergence_total{flag}` — the IMPOSSIBLE COMBINATION: a
+ * LOGGED-IN principal for whom the async read path resolved `none`, while a
+ * same-request re-read of the very same store flag says the viewer holds it. That
+ * is precisely the shape of the reported defect — a viewer the `/apps` page gate
+ * admits (it keys on the sync evaluation) reaching a read path that serves them
+ * nothing. `flag` is one of the three store flag keys, so the label is bounded and
+ * names the axis that disagreed.
+ *
+ * 🔴 WHAT THE DIVERGENCE COUNTER CANNOT SEE — say it plainly rather than let a flat
+ * zero read as "healthy":
+ *   - a scope that is resolved CORRECTLY and then lost or ignored downstream (the
+ *     ctx-plumbing / caller-default class). The resolution counter is what covers
+ *     that: compare its `full|public-external` counts against what the read paths
+ *     actually return.
+ *   - a Flipt client that is uniformly dead. Then both evaluations agree on `false`,
+ *     no divergence is recorded, and the tell is instead an all-`none` resolution
+ *     mix plus the client's own `init-flipt-error` log.
+ *   - an ANONYMOUS caller. There is no page-gate/read-path pairing to contradict for
+ *     a principal with no session, so anon is deliberately out of scope here.
+ *
+ * Pinned on globalThis so an HMR re-eval / a second request-graph eval reuse the one
+ * instance instead of throwing prom-client's duplicate-registration error (the same
+ * trap documented for the http-error and dev-tunnel counters).
+ */
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __civitaiStoreScopeMetrics:
+    | {
+        resolutions: client.Counter<string>;
+        applied: client.Counter<string>;
+        divergence: client.Counter<string>;
+      }
+    | undefined;
+}
+
+const metrics =
+  globalThis.__civitaiStoreScopeMetrics ??
+  (globalThis.__civitaiStoreScopeMetrics = {
+    resolutions: new client.Counter({
+      name: PROM_PREFIX + 'store_scope_resolutions_total',
+      help:
+        'Cumulative App-store read-scope resolutions, by resolved scope ' +
+        '(full|public-external|none) and whether a session user was present (user|anon). ' +
+        'Monotonic; use rate(). A logged-in population that is entirely `none` while a ' +
+        'cohort flag is open is the civitai#3983 signature.',
+      labelNames: ['scope', 'principal'],
+    }),
+    applied: new client.Counter({
+      name: PROM_PREFIX + 'store_scope_applied_total',
+      help:
+        'Cumulative store-scope values a read ENTRY POINT actually branched on, by entrypoint. ' +
+        "`scope` is `absent` when no scope reached the branch at all — the one case a caller's " +
+        'own default (`?? none` on tRPC, `?? full` in the listing service) silently erases. ' +
+        'Compare against store_scope_resolutions_total: a resolution mix that disagrees with ' +
+        'the applied mix means the scope is being LOST between the resolver and the branch.',
+      labelNames: ['scope', 'entrypoint'],
+    }),
+    divergence: new client.Counter({
+      name: PROM_PREFIX + 'store_scope_divergence_total',
+      help:
+        'Cumulative IMPOSSIBLE combinations: a logged-in principal whose store read scope ' +
+        'resolved `none` while a same-request re-read of the labelled store flag says they ' +
+        'hold it. Any non-zero rate means the page gate and the read path disagree for a ' +
+        'real viewer — alert on it.',
+      labelNames: ['flag'],
+    }),
+  });
+
+export type StoreScopePrincipal = 'user' | 'anon';
+
+/** Every store read surface that branches on a resolved scope. */
+export type StoreScopeEntrypoint =
+  | 'trpc-list'
+  | 'trpc-detail'
+  | 'trpc-reviews'
+  | 'rest-list'
+  | 'rest-detail';
+
+/**
+ * Record the scope an entry point actually branched on.
+ *
+ * 🔴 `undefined` is recorded as the DISTINCT value `absent`, never folded into
+ * `none`. That distinction is the whole point: from outside the service,
+ * "resolved `none`" and "no scope arrived, so the caller's default applied" produce
+ * byte-identical responses (`{ items: [] }` on tRPC, the FULL catalog through the
+ * listing service's `?? 'full'`), and telling them apart was the single thing
+ * civitai#3983 could not do without an instrumented deploy.
+ *
+ * Never throws — telemetry must not break a read.
+ */
+export function recordStoreScopeApplied(
+  scope: string | undefined,
+  entrypoint: StoreScopeEntrypoint
+): void {
+  try {
+    metrics.applied.inc({ scope: scope ?? 'absent', entrypoint });
+  } catch {
+    /* never throw from telemetry */
+  }
+}
+
+/** Record one scope resolution. Never throws — telemetry must not break a read. */
+export function recordStoreScopeResolution(scope: string, principal: StoreScopePrincipal): void {
+  try {
+    metrics.resolutions.inc({ scope, principal });
+  } catch {
+    /* never throw from telemetry */
+  }
+}
+
+/** Record one page-gate/read-path divergence for `flag`. Never throws. */
+export function recordStoreScopeDivergence(flag: string): void {
+  try {
+    metrics.divergence.inc({ flag });
+  } catch {
+    /* never throw from telemetry */
+  }
+}

--- a/src/server/routers/__tests__/app-listings.router.applied-scope-signal.test.ts
+++ b/src/server/routers/__tests__/app-listings.router.applied-scope-signal.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * 🔴 `none` vs `absent` — the distinction civitai#3983 could not make.
+ *
+ * Every store read entry point folds a missing scope into a safe default: the tRPC
+ * procs `?? 'none'` (fail closed → `{ items: [] }`), the listing service `?? 'full'`
+ * (fail open → the whole catalog). Both defaults are individually defensible and
+ * TOGETHER they are why the same underlying fault presented as an empty store on one
+ * entry point and a full catalog on the other — while being invisible on both,
+ * because a response cannot say which branch produced it.
+ *
+ * `recordStoreScopeApplied` is called BEFORE the fallback, so `absent` is a value an
+ * operator can see. This suite pins that:
+ *   - a resolved scope is recorded as itself, per entry point;
+ *   - a scope that never arrives is recorded as `absent` and NOT as `none`.
+ *
+ * The second case is the POSITIVE CONTROL for the whole diagnostic: it proves the
+ * instrument can actually observe the state it was built to detect, rather than
+ * being a counter that only ever emits the values everything else already reports.
+ */
+
+const { mockResolveStoreVisibilityScope, recordStoreScopeApplied } = vi.hoisted(() => ({
+  mockResolveStoreVisibilityScope: vi.fn(),
+  recordStoreScopeApplied: vi.fn(),
+}));
+
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  resolveStoreVisibilityScope: mockResolveStoreVisibilityScope,
+}));
+vi.mock('~/server/prom/store-scope.metrics', () => ({ recordStoreScopeApplied }));
+vi.mock('~/server/services/blocks/app-listing.service', () => ({
+  listAvailableListings: vi.fn(async () => ({ items: [], nextCursor: undefined })),
+  getListingDetail: vi.fn(async () => ({ id: 'apl_1', slug: 'x', kind: 'offsite' })),
+}));
+vi.mock('~/server/services/blocks/app-listing-review.service', () => ({
+  listAppListingReviews: vi.fn(async () => ({ items: [], nextCursor: undefined })),
+}));
+vi.mock('~/server/middleware.trpc', async () => {
+  const { middleware } = await import('~/server/trpc');
+  return { rateLimit: () => middleware(async ({ next }) => next()) };
+});
+vi.mock('~/server/utils/server-domain', () => ({ isHostForColor: () => false }));
+
+import { appListingsRouter } from '../app-listings.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+function fakeCtx(user: unknown) {
+  return {
+    acceptableOrigin: true,
+    user,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: {} as never,
+    track: undefined,
+  };
+}
+
+const listInput = { kind: 'all', sort: 'newest', limit: 24, direction: 'forward' } as never;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('the scope an entry point BRANCHED on is recorded per entry point', () => {
+  it('records `public-external` on the list proc', async () => {
+    mockResolveStoreVisibilityScope.mockResolvedValue('public-external');
+    const caller = appListingsRouter.createCaller(fakeCtx({ id: 7 }) as never);
+    await caller.listAvailable(listInput);
+    expect(recordStoreScopeApplied).toHaveBeenCalledWith('public-external', 'trpc-list');
+  });
+
+  it('records `full` on the detail proc', async () => {
+    mockResolveStoreVisibilityScope.mockResolvedValue('full');
+    const caller = appListingsRouter.createCaller(fakeCtx({ id: 7 }) as never);
+    await caller.getAppDetail({ slug: 'x' } as never);
+    expect(recordStoreScopeApplied).toHaveBeenCalledWith('full', 'trpc-detail');
+  });
+
+  it('records `none` on the reviews proc', async () => {
+    mockResolveStoreVisibilityScope.mockResolvedValue('none');
+    const caller = appListingsRouter.createCaller(fakeCtx(undefined) as never);
+    await caller.listReviews({ appListingId: 'apl_1', limit: 10 } as never);
+    expect(recordStoreScopeApplied).toHaveBeenCalledWith('none', 'trpc-reviews');
+  });
+});
+
+describe('🔴 POSITIVE CONTROL: a scope that never arrives reads as `absent`, not `none`', () => {
+  it('list: an absent scope is distinguishable from a resolved `none`', async () => {
+    // The shape under suspicion: the middleware runs but no usable scope reaches the
+    // procedure. The response is byte-identical to a genuine `none` — the counter is
+    // the only thing that can tell them apart.
+    mockResolveStoreVisibilityScope.mockResolvedValue(undefined);
+    const caller = appListingsRouter.createCaller(fakeCtx({ id: 7 }) as never);
+
+    await expect(caller.listAvailable(listInput)).resolves.toEqual({
+      items: [],
+      nextCursor: undefined,
+    });
+
+    expect(recordStoreScopeApplied).toHaveBeenCalledWith(undefined, 'trpc-list');
+    expect(recordStoreScopeApplied).not.toHaveBeenCalledWith('none', 'trpc-list');
+  });
+
+  it('detail: an absent scope still fails CLOSED (NOT_FOUND) while being recorded', async () => {
+    mockResolveStoreVisibilityScope.mockResolvedValue(undefined);
+    const caller = appListingsRouter.createCaller(fakeCtx({ id: 7 }) as never);
+
+    await expect(caller.getAppDetail({ slug: 'x' } as never)).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+    expect(recordStoreScopeApplied).toHaveBeenCalledWith(undefined, 'trpc-detail');
+  });
+});

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -58,6 +58,10 @@ import {
   unpublishOwnListingSchema,
 } from '~/server/schema/blocks/offsite-moderation.schema';
 import { rateLimit } from '~/server/middleware.trpc';
+import {
+  recordStoreScopeApplied,
+  type StoreScopeEntrypoint,
+} from '~/server/prom/store-scope.metrics';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
 import {
   isAppBlocksAuthorEnabled,
@@ -204,6 +208,23 @@ function isRedCapableRequest(ctx: { req?: { headers?: { host?: string } } }): bo
 }
 
 /**
+ * Read the visibility scope `enforceAppListingsReadFlag` put on ctx, RECORDING what
+ * this entry point actually branched on.
+ *
+ * 🔴 The record happens BEFORE the `?? 'none'` fallback, and that ordering is the
+ * point. The fallback is correct (an absent scope must fail CLOSED), but it also
+ * erases the difference between "the resolver said `none`" and "no scope ever
+ * reached this procedure" — two very different faults that produce the identical
+ * `{ items: [] }`. civitai#3983 was stuck on exactly that ambiguity for the whole
+ * investigation. `recordStoreScopeApplied` keeps them apart (`none` vs `absent`).
+ */
+function applyStoreScope(ctx: unknown, entrypoint: StoreScopeEntrypoint): StoreVisibilityScope {
+  const raw = (ctx as { _storeScope?: StoreVisibilityScope })._storeScope;
+  recordStoreScopeApplied(raw, entrypoint);
+  return raw ?? 'none';
+}
+
+/**
  * Map a thrown off-site SERVICE error to the correct TRPC error for the mod client.
  *
  *   - A `TRPCError` the service already shaped (BAD_REQUEST: assets-incomplete /
@@ -253,7 +274,9 @@ export const appListingsRouter = router({
     .use(enforceAppBlocksAuthorFlag)
     .input(listingAssetsQuerySchema)
     .query(async ({ ctx, input }) => {
-      const { getListingAssets } = await import('~/server/services/blocks/app-listing-assets.service');
+      const { getListingAssets } = await import(
+        '~/server/services/blocks/app-listing-assets.service'
+      );
       return getListingAssets({ listingId: input.listingId }, ctx.user);
     }),
 
@@ -314,7 +337,9 @@ export const appListingsRouter = router({
     .use(enforceAppBlocksAuthorFlag)
     .input(setListingIconSchema)
     .mutation(async ({ ctx, input }) => {
-      const { setListingIcon } = await import('~/server/services/blocks/app-listing-assets.service');
+      const { setListingIcon } = await import(
+        '~/server/services/blocks/app-listing-assets.service'
+      );
       try {
         return await setListingIcon(input, ctx.user);
       } catch (err) {
@@ -327,7 +352,9 @@ export const appListingsRouter = router({
     .use(enforceAppBlocksAuthorFlag)
     .input(setListingCoverSchema)
     .mutation(async ({ ctx, input }) => {
-      const { setListingCover } = await import('~/server/services/blocks/app-listing-assets.service');
+      const { setListingCover } = await import(
+        '~/server/services/blocks/app-listing-assets.service'
+      );
       try {
         return await setListingCover(input, ctx.user);
       } catch (err) {
@@ -959,9 +986,7 @@ export const appListingsRouter = router({
     .input(reportListingSchema)
     .mutation(async ({ ctx, input }) => {
       if (!ctx.user) throw throwAuthorizationError('Not authenticated');
-      const { reportListing } = await import(
-        '~/server/services/blocks/offsite-moderation.service'
-      );
+      const { reportListing } = await import('~/server/services/blocks/offsite-moderation.service');
       try {
         return await reportListing({ input, userId: ctx.user.id });
       } catch (err) {
@@ -1005,34 +1030,30 @@ export const appListingsRouter = router({
    * `reportId` in the same tx. Typed failures map via `mapOffsiteError`
    * (NOT_FOUND→NOT_FOUND, NOT_TRANSITIONABLE→BAD_REQUEST, infra→INTERNAL/no leak).
    */
-  delistListing: moderatorProcedure
-    .input(delistListingSchema)
-    .mutation(async ({ ctx, input }) => {
-      if (!ctx.user?.isModerator) {
-        throw throwAuthorizationError('Delisting off-site listings is restricted to civitai team');
-      }
-      const { delistListing } = await import('~/server/services/blocks/offsite-moderation.service');
-      try {
-        return await delistListing({ input, reviewerUserId: ctx.user.id });
-      } catch (err) {
-        throw mapOffsiteError(err);
-      }
-    }),
+  delistListing: moderatorProcedure.input(delistListingSchema).mutation(async ({ ctx, input }) => {
+    if (!ctx.user?.isModerator) {
+      throw throwAuthorizationError('Delisting off-site listings is restricted to civitai team');
+    }
+    const { delistListing } = await import('~/server/services/blocks/offsite-moderation.service');
+    try {
+      return await delistListing({ input, reviewerUserId: ctx.user.id });
+    } catch (err) {
+      throw mapOffsiteError(err);
+    }
+  }),
 
   /** MOD relist a removed off-site listing (removed → approved). Reversibility. */
-  relistListing: moderatorProcedure
-    .input(relistListingSchema)
-    .mutation(async ({ ctx, input }) => {
-      if (!ctx.user?.isModerator) {
-        throw throwAuthorizationError('Relisting off-site listings is restricted to civitai team');
-      }
-      const { relistListing } = await import('~/server/services/blocks/offsite-moderation.service');
-      try {
-        return await relistListing({ input, reviewerUserId: ctx.user.id });
-      } catch (err) {
-        throw mapOffsiteError(err);
-      }
-    }),
+  relistListing: moderatorProcedure.input(relistListingSchema).mutation(async ({ ctx, input }) => {
+    if (!ctx.user?.isModerator) {
+      throw throwAuthorizationError('Relisting off-site listings is restricted to civitai team');
+    }
+    const { relistListing } = await import('~/server/services/blocks/offsite-moderation.service');
+    try {
+      return await relistListing({ input, reviewerUserId: ctx.user.id });
+    } catch (err) {
+      throw mapOffsiteError(err);
+    }
+  }),
 
   /**
    * MOD claim (reassign ownership of) an approved/removed off-site listing (PR4) —
@@ -1044,21 +1065,17 @@ export const appListingsRouter = router({
    * `mapOffsiteError` (NOT_FOUND→NOT_FOUND, NOT_TRANSITIONABLE/INVALID_TARGET_USER→
    * BAD_REQUEST, infra→INTERNAL with no leak).
    */
-  claimListing: moderatorProcedure
-    .input(claimListingSchema)
-    .mutation(async ({ ctx, input }) => {
-      if (!ctx.user?.isModerator) {
-        throw throwAuthorizationError(
-          'Reassigning off-site listings is restricted to civitai team'
-        );
-      }
-      const { claimListing } = await import('~/server/services/blocks/offsite-moderation.service');
-      try {
-        return await claimListing({ input, reviewerUserId: ctx.user.id });
-      } catch (err) {
-        throw mapOffsiteError(err);
-      }
-    }),
+  claimListing: moderatorProcedure.input(claimListingSchema).mutation(async ({ ctx, input }) => {
+    if (!ctx.user?.isModerator) {
+      throw throwAuthorizationError('Reassigning off-site listings is restricted to civitai team');
+    }
+    const { claimListing } = await import('~/server/services/blocks/offsite-moderation.service');
+    try {
+      return await claimListing({ input, reviewerUserId: ctx.user.id });
+    } catch (err) {
+      throw mapOffsiteError(err);
+    }
+  }),
 
   /**
    * MOD hard-delete (purge) an off-site listing — the final expunge + the
@@ -1069,51 +1086,45 @@ export const appListingsRouter = router({
    * index / raw SQL (a slug-keyed orphaned-events read path is deferred to pre-GA).
    * Destructive — the UI gates it behind a confirm.
    */
-  purgeListing: moderatorProcedure
-    .input(purgeListingSchema)
-    .mutation(async ({ ctx, input }) => {
-      if (!ctx.user?.isModerator) {
-        throw throwAuthorizationError('Purging off-site listings is restricted to civitai team');
-      }
-      const { purgeListing } = await import('~/server/services/blocks/offsite-moderation.service');
-      try {
-        return await purgeListing({ input, reviewerUserId: ctx.user.id });
-      } catch (err) {
-        throw mapOffsiteError(err);
-      }
-    }),
+  purgeListing: moderatorProcedure.input(purgeListingSchema).mutation(async ({ ctx, input }) => {
+    if (!ctx.user?.isModerator) {
+      throw throwAuthorizationError('Purging off-site listings is restricted to civitai team');
+    }
+    const { purgeListing } = await import('~/server/services/blocks/offsite-moderation.service');
+    try {
+      return await purgeListing({ input, reviewerUserId: ctx.user.id });
+    } catch (err) {
+      throw mapOffsiteError(err);
+    }
+  }),
 
   /** MOD resolve a pending report (pending → resolved) + audit event. */
-  resolveReport: moderatorProcedure
-    .input(resolveReportSchema)
-    .mutation(async ({ ctx, input }) => {
-      if (!ctx.user?.isModerator) {
-        throw throwAuthorizationError('Resolving reports is restricted to civitai team');
-      }
-      const { resolveReport } = await import('~/server/services/blocks/offsite-moderation.service');
-      try {
-        await resolveReport({ input, reviewerUserId: ctx.user.id });
-      } catch (err) {
-        throw mapOffsiteError(err);
-      }
-      return { ok: true };
-    }),
+  resolveReport: moderatorProcedure.input(resolveReportSchema).mutation(async ({ ctx, input }) => {
+    if (!ctx.user?.isModerator) {
+      throw throwAuthorizationError('Resolving reports is restricted to civitai team');
+    }
+    const { resolveReport } = await import('~/server/services/blocks/offsite-moderation.service');
+    try {
+      await resolveReport({ input, reviewerUserId: ctx.user.id });
+    } catch (err) {
+      throw mapOffsiteError(err);
+    }
+    return { ok: true };
+  }),
 
   /** MOD dismiss a pending report (pending → dismissed) + audit event. */
-  dismissReport: moderatorProcedure
-    .input(dismissReportSchema)
-    .mutation(async ({ ctx, input }) => {
-      if (!ctx.user?.isModerator) {
-        throw throwAuthorizationError('Dismissing reports is restricted to civitai team');
-      }
-      const { dismissReport } = await import('~/server/services/blocks/offsite-moderation.service');
-      try {
-        await dismissReport({ input, reviewerUserId: ctx.user.id });
-      } catch (err) {
-        throw mapOffsiteError(err);
-      }
-      return { ok: true };
-    }),
+  dismissReport: moderatorProcedure.input(dismissReportSchema).mutation(async ({ ctx, input }) => {
+    if (!ctx.user?.isModerator) {
+      throw throwAuthorizationError('Dismissing reports is restricted to civitai team');
+    }
+    const { dismissReport } = await import('~/server/services/blocks/offsite-moderation.service');
+    try {
+      await dismissReport({ input, reviewerUserId: ctx.user.id });
+    } catch (err) {
+      throw mapOffsiteError(err);
+    }
+    return { ok: true };
+  }),
 
   /** MOD per-listing moderation history (audit trail), newest-first, keyset. */
   listModerationEvents: moderatorProcedure
@@ -1309,7 +1320,7 @@ export const appListingsRouter = router({
     )
     .input(listAppListingsSchema)
     .query(async ({ ctx, input }) => {
-      const scope = (ctx as { _storeScope?: StoreVisibilityScope })._storeScope ?? 'none';
+      const scope = applyStoreScope(ctx, 'trpc-list');
       if (scope === 'none') {
         return { items: [], nextCursor: undefined };
       }
@@ -1331,7 +1342,7 @@ export const appListingsRouter = router({
     )
     .input(getAppListingDetailSchema)
     .query(async ({ ctx, input }) => {
-      const scope = (ctx as { _storeScope?: StoreVisibilityScope })._storeScope ?? 'none';
+      const scope = applyStoreScope(ctx, 'trpc-detail');
       if (scope === 'none') {
         throw throwNotFoundError('Listing not found');
       }
@@ -1415,7 +1426,7 @@ export const appListingsRouter = router({
     )
     .input(listAppListingReviewsSchema)
     .query(async ({ ctx, input }) => {
-      const scope = (ctx as { _storeScope?: StoreVisibilityScope })._storeScope ?? 'none';
+      const scope = applyStoreScope(ctx, 'trpc-reviews');
       if (scope === 'none') {
         return { items: [], nextCursor: undefined };
       }

--- a/src/server/services/__tests__/app-blocks-flag.real-flipt-client.integration.test.ts
+++ b/src/server/services/__tests__/app-blocks-flag.real-flipt-client.integration.test.ts
@@ -1,0 +1,189 @@
+import { createServer, type Server } from 'http';
+import type { AddressInfo } from 'net';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import snapshot from './fixtures/flipt-store-scope.snapshot.json';
+import type { SessionUser } from '~/types/session';
+
+/**
+ * 🔴 THE ONE LAYER THE OTHER STORE-SCOPE SUITES CANNOT SEE: the REAL Flipt client.
+ *
+ * `app-listings.router.read-flag-gate.test.ts` MOCKS `resolveStoreVisibilityScope`
+ * outright (it proves the middleware→procedure ctx plumbing, nothing about the
+ * answer). `app-blocks-flag.external-scope.seam.test.ts` runs both REAL sides but
+ * against a hand-written fake of the Flipt CONFIG — a truth table, not the client.
+ * So between them, every layer of the store gate is pinned EXCEPT the one that
+ * actually decides: `createFliptClient` → the wasm evaluation engine → the segment
+ * matcher. civitai#3983 was diagnosed with 75 of those tests green.
+ *
+ * This suite closes that gap end to end, with nothing about the evaluator faked:
+ *
+ *   fixture snapshot  →  a real HTTP server on localhost
+ *                     →  the REAL `createFliptClient` from `@civitai/flipt`
+ *                     →  the REAL `@flipt-io/flipt-client-js` wasm engine
+ *                     →  the REAL `resolveStoreVisibilityScope` / `buildFliptContext`
+ *
+ * ## About the fixture
+ *
+ * `fixtures/flipt-store-scope.snapshot.json` is a real Flipt v2 evaluation snapshot
+ * (`GET /internal/v1/evaluation/snapshot/namespace/default`), captured from a Flipt
+ * server loaded with the production flag DEFINITIONS for the three store flags, then
+ * trimmed to those flags. It therefore carries the production SHAPE verbatim —
+ * `enabled: false` base + a single `SEGMENT_ROLLOUT_TYPE` whose `OR_SEGMENT_OPERATOR`
+ * combines an `ALL_SEGMENT_MATCH_TYPE` moderator segment (`isModerator eq "true"`)
+ * with an `ANY_SEGMENT_MATCH_TYPE` allowlist segment (`userId isoneof [...]`).
+ *
+ * 🔴 The user ids in it are SYNTHETIC (`9000xxxxx`). This repo is public; the real
+ * cohort allowlists are not ours to publish, and the ids are not what is under test —
+ * the constraint/rollout SHAPE is. Re-capturing the fixture means re-anonymising it.
+ *
+ * ## What this suite structurally CANNOT see
+ *
+ * - The live production flag document. The fixture is a point-in-time copy of the
+ *   shape; a live config edit that changes the shape will not fail this suite.
+ * - The real network path to the production Flipt (TLS, auth token, the circuit
+ *   breaker, `updateInterval` refreshes, a snapshot fetch that times out).
+ * - The tRPC ctx plumbing downstream of the resolver (that is the router suite's job)
+ *   and the REST handler's own branch on the returned scope.
+ * - Whichever build artifact production is actually running.
+ */
+
+// Read at IMPORT time by feature-flags.service (color-host sets), mirroring the
+// sibling seam suite.
+vi.hoisted(() => {
+  process.env.SERVER_DOMAIN_GREEN = 'civitai.com';
+  process.env.SERVER_DOMAIN_BLUE = 'civitai.blue';
+  process.env.SERVER_DOMAIN_RED = 'civitai.red';
+});
+
+const SNAPSHOT_PATH = '/internal/v1/evaluation/snapshot/namespace/default';
+
+/** Requests the fake Flipt actually received — used as the positive control. */
+const received: { url: string; environment?: string; auth?: string }[] = [];
+
+let server: Server;
+let baseUrl = '';
+
+/**
+ * Substitutes ONLY the app's env plumbing (`~/env/server` is not loadable in a unit
+ * run): the exported `isFlipt` is a REAL `createFliptClient` instance pointed at the
+ * fixture server. Everything the defect could live in — the client factory, its cache,
+ * the wasm engine, the segment matcher — is the production code.
+ */
+vi.mock('~/server/flipt/client', async () => {
+  const { createFliptClient } = await import('@civitai/flipt');
+  const flipt = createFliptClient({
+    url: process.env.__TEST_FLIPT_URL as string,
+    clientToken: 'test-token',
+    environment: 'civitai-app',
+    log: () => undefined,
+    onInitError: (e) => {
+      throw e;
+    },
+  });
+  return {
+    isFlipt: flipt.isEnabled,
+    isFliptSync: flipt.isEnabledSync,
+    getFliptVariant: flipt.getVariant,
+    getFliptBoolean: flipt.getBoolean,
+    ensureFliptInitialized: flipt.ensureInitialized,
+  };
+});
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    received.push({
+      url: req.url ?? '',
+      environment: req.headers['x-flipt-environment'] as string | undefined,
+      auth: req.headers.authorization as string | undefined,
+    });
+    if (!req.url?.startsWith(SNAPSHOT_PATH)) {
+      res.writeHead(404).end('{}');
+      return;
+    }
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify(snapshot));
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${port}`;
+  process.env.__TEST_FLIPT_URL = baseUrl;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+/** Minimal SessionUser — only the fields `buildFliptContext` reads. */
+function sessionUser(id: number, extra: Partial<SessionUser> = {}): SessionUser {
+  return { id, isModerator: false, tier: 'free', onboarding: 0, ...extra } as SessionUser;
+}
+
+/** Synthetic ids, matching the fixture's synthetic allowlists. */
+const TESTERS_COHORT_ID = 900001001; // in `testers` only → external-only store
+const APP_DEV_TESTER_ID = 900000001; // in `app-dev-testers` → full store
+const UNAFFILIATED_ID = 4242; // in no segment → dark
+const MODERATOR_ID = 777;
+
+describe('resolveStoreVisibilityScope over the REAL Flipt client (civitai#3983)', () => {
+  it('INSTRUMENT CONTROL: the fixture server is actually reached, in the right environment', async () => {
+    const { isFlipt } = await import('~/server/flipt/client');
+    // A flag key that is NOT in the fixture: proves an unknown flag fails CLOSED
+    // rather than the client answering `true` for everything.
+    await expect(isFlipt('a-flag-that-does-not-exist')).resolves.toBe(false);
+    expect(received.length).toBeGreaterThan(0);
+    expect(received[0].url).toContain(SNAPSHOT_PATH);
+    expect(received[0].environment).toBe('civitai-app');
+    expect(received[0].auth).toBe('Bearer test-token');
+  });
+
+  it('POSITIVE CONTROL: the wasm engine really does match a segment (not a suite wired to nothing)', async () => {
+    const { isFlipt } = await import('~/server/flipt/client');
+    const { buildFliptContext } = await import('~/server/services/feature-flags.service');
+    const user = sessionUser(TESTERS_COHORT_ID);
+    await expect(
+      isFlipt('app-listings-public-external', String(user.id), buildFliptContext(user))
+    ).resolves.toBe(true);
+    // ...and the same flag is false for someone outside the segment, so the `true`
+    // above is attributable to the segment and not to a flag open to everyone.
+    const other = sessionUser(UNAFFILIATED_ID);
+    await expect(
+      isFlipt('app-listings-public-external', String(other.id), buildFliptContext(other))
+    ).resolves.toBe(false);
+  });
+
+  it('anonymous (no user) resolves `none` — the global eval matches no segment', async () => {
+    const { resolveStoreVisibilityScope } = await import('~/server/services/app-blocks-flag');
+    await expect(resolveStoreVisibilityScope()).resolves.toBe('none');
+    await expect(resolveStoreVisibilityScope({ user: undefined })).resolves.toBe('none');
+  });
+
+  it('a logged-in user in NO cohort resolves `none`', async () => {
+    const { resolveStoreVisibilityScope } = await import('~/server/services/app-blocks-flag');
+    await expect(resolveStoreVisibilityScope({ user: sessionUser(UNAFFILIATED_ID) })).resolves.toBe(
+      'none'
+    );
+  });
+
+  it('🔴 the EXTERNAL-ONLY cohort resolves `public-external`, not `none` (the civitai#3983 symptom)', async () => {
+    const { resolveStoreVisibilityScope } = await import('~/server/services/app-blocks-flag');
+    await expect(
+      resolveStoreVisibilityScope({ user: sessionUser(TESTERS_COHORT_ID) })
+    ).resolves.toBe('public-external');
+  });
+
+  it('the app-dev-tester cohort resolves `full`', async () => {
+    const { resolveStoreVisibilityScope } = await import('~/server/services/app-blocks-flag');
+    await expect(
+      resolveStoreVisibilityScope({ user: sessionUser(APP_DEV_TESTER_ID) })
+    ).resolves.toBe('full');
+  });
+
+  it('a moderator resolves `full` and is NEVER narrowed to `public-external`', async () => {
+    const { resolveStoreVisibilityScope } = await import('~/server/services/app-blocks-flag');
+    // A moderator matches the `testers` segment too (its `isModerator eq "true"`
+    // constraint), so this is exactly the case the priority order exists to protect.
+    await expect(
+      resolveStoreVisibilityScope({ user: sessionUser(MODERATOR_ID, { isModerator: true }) })
+    ).resolves.toBe('full');
+  });
+});

--- a/src/server/services/__tests__/app-blocks-flag.silent-gate-signal.test.ts
+++ b/src/server/services/__tests__/app-blocks-flag.silent-gate-signal.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionUser } from '~/types/session';
+
+/**
+ * 🔴 THE DETECTION NET (civitai#3983 item B) — make a silent store gate LOUD.
+ *
+ * `resolveStoreVisibilityScope` returning `none` renders as an ordinary empty grid,
+ * so a mis-gated cohort is indistinguishable from an empty catalog. The whole of the
+ * #3983 investigation was spent unable to separate those two from outside. This suite
+ * pins the signal that separates them from INSIDE:
+ *
+ *   1. every resolution is counted by (scope, principal) — the permanent replacement
+ *      for the one-off "instrumented deploy" that would otherwise be needed to ask
+ *      "what is production resolving for a logged-in viewer?";
+ *   2. the IMPOSSIBLE COMBINATION — the async read path says `none` while the SYNC
+ *      evaluation the `/apps` page gate uses says the same viewer holds a store flag —
+ *      is counted and logged, per offending flag.
+ *
+ * The two evaluations are asserted as a RELATIONSHIP (they must agree for one
+ * principal), not as two independently-correct components: that is the seam the
+ * existing suites each test only one side of.
+ */
+
+vi.hoisted(() => {
+  process.env.SERVER_DOMAIN_GREEN = 'civitai.com';
+  process.env.SERVER_DOMAIN_BLUE = 'civitai.blue';
+  process.env.SERVER_DOMAIN_RED = 'civitai.red';
+});
+
+const { asyncFlags, syncFlags } = vi.hoisted(() => ({
+  asyncFlags: { value: {} as Record<string, boolean> },
+  syncFlags: { value: {} as Record<string, boolean | null> },
+}));
+
+vi.mock('~/server/flipt/client', () => ({
+  isFlipt: vi.fn(async (flag: string) => asyncFlags.value[flag] ?? false),
+  isFliptSync: vi.fn((flag: string) => syncFlags.value[flag] ?? null),
+  getFliptVariant: vi.fn(async () => null),
+  getFliptBoolean: vi.fn(async () => false),
+  ensureFliptInitialized: vi.fn(async () => undefined),
+}));
+
+const { recordStoreScopeResolution, recordStoreScopeDivergence } = vi.hoisted(() => ({
+  recordStoreScopeResolution: vi.fn(),
+  recordStoreScopeDivergence: vi.fn(),
+}));
+
+vi.mock('~/server/prom/store-scope.metrics', () => ({
+  recordStoreScopeResolution,
+  recordStoreScopeDivergence,
+}));
+
+// `~/server/logging/client` has a CANONICAL mock registered in setup.ts — a direct
+// per-file `vi.mock` of it would freeze this file's shape into every later file in the
+// same worker (`isolate: false`), which is what `no-direct-shared-module-mock` guards.
+import { loggingMock } from '~/__tests__/mocks/logging.mock';
+
+const LISTINGS = 'app-listings';
+const BLOCKS = 'app-blocks-enabled';
+const EXTERNAL = 'app-listings-public-external';
+
+function sessionUser(id: number, extra: Partial<SessionUser> = {}): SessionUser {
+  return { id, isModerator: false, tier: 'free', onboarding: 0, ...extra } as SessionUser;
+}
+
+beforeEach(() => {
+  asyncFlags.value = {};
+  syncFlags.value = {};
+  vi.clearAllMocks();
+});
+
+describe('store-scope resolution counter', () => {
+  it('counts an anonymous dark resolution as (none, anon)', async () => {
+    const { resolveStoreVisibilityScope } = await import('~/server/services/app-blocks-flag');
+    await expect(resolveStoreVisibilityScope()).resolves.toBe('none');
+    expect(recordStoreScopeResolution).toHaveBeenCalledWith('none', 'anon');
+  });
+
+  it('counts a logged-in privileged resolution as (full, user)', async () => {
+    asyncFlags.value = { [LISTINGS]: true };
+    const { resolveStoreVisibilityScope } = await import('~/server/services/app-blocks-flag');
+    await expect(resolveStoreVisibilityScope({ user: sessionUser(1) })).resolves.toBe('full');
+    expect(recordStoreScopeResolution).toHaveBeenCalledWith('full', 'user');
+  });
+
+  it('counts the external-only cohort as (public-external, user)', async () => {
+    asyncFlags.value = { [EXTERNAL]: true };
+    const { resolveStoreVisibilityScope } = await import('~/server/services/app-blocks-flag');
+    await expect(resolveStoreVisibilityScope({ user: sessionUser(2) })).resolves.toBe(
+      'public-external'
+    );
+    expect(recordStoreScopeResolution).toHaveBeenCalledWith('public-external', 'user');
+  });
+});
+
+describe('🔴 the impossible combination: page gate admits, read path resolves `none`', () => {
+  it('records a divergence naming the flag the sync gate says the viewer holds', async () => {
+    // The reported #3983 shape: the viewer reaches /apps because the SYNC evaluation
+    // of `app-listings-public-external` says they hold it, and the ASYNC read path
+    // resolves `none` anyway.
+    asyncFlags.value = {};
+    syncFlags.value = { [EXTERNAL]: true };
+    const { resolveStoreVisibilityScope } = await import('~/server/services/app-blocks-flag');
+
+    await expect(resolveStoreVisibilityScope({ user: sessionUser(11) })).resolves.toBe('none');
+
+    expect(recordStoreScopeDivergence).toHaveBeenCalledTimes(1);
+    expect(recordStoreScopeDivergence).toHaveBeenCalledWith(EXTERNAL);
+    expect(loggingMock.logToAxiom).toHaveBeenCalledTimes(1);
+    expect(loggingMock.logToAxiom.mock.calls[0][0]).toMatchObject({
+      type: 'store-scope-divergence',
+      userId: 11,
+      heldFlags: [EXTERNAL],
+    });
+  });
+
+  it('names EVERY disagreeing axis, not just the first', async () => {
+    syncFlags.value = { [LISTINGS]: true, [BLOCKS]: true, [EXTERNAL]: true };
+    const { resolveStoreVisibilityScope } = await import('~/server/services/app-blocks-flag');
+
+    await expect(resolveStoreVisibilityScope({ user: sessionUser(12) })).resolves.toBe('none');
+
+    expect(recordStoreScopeDivergence.mock.calls.map((c) => c[0]).sort()).toEqual(
+      [BLOCKS, LISTINGS, EXTERNAL].sort()
+    );
+  });
+
+  it('is SILENT when the two evaluations agree the viewer is dark (no false alarm)', async () => {
+    syncFlags.value = { [LISTINGS]: false, [BLOCKS]: false, [EXTERNAL]: false };
+    const { resolveStoreVisibilityScope } = await import('~/server/services/app-blocks-flag');
+
+    await expect(resolveStoreVisibilityScope({ user: sessionUser(13) })).resolves.toBe('none');
+
+    expect(recordStoreScopeDivergence).not.toHaveBeenCalled();
+    expect(loggingMock.logToAxiom).not.toHaveBeenCalled();
+  });
+
+  it('treats a `null` sync answer (Flipt not initialized) as NOT a divergence', async () => {
+    // `isFliptSync` returns null before the client is warm; the documented behaviour
+    // is to fall through to static availability, not to report a contradiction.
+    syncFlags.value = {};
+    const { resolveStoreVisibilityScope } = await import('~/server/services/app-blocks-flag');
+
+    await expect(resolveStoreVisibilityScope({ user: sessionUser(14) })).resolves.toBe('none');
+
+    expect(recordStoreScopeDivergence).not.toHaveBeenCalled();
+  });
+
+  it('does not fire for an ANONYMOUS caller (no page-gate pairing to contradict)', async () => {
+    syncFlags.value = { [EXTERNAL]: true };
+    const { resolveStoreVisibilityScope } = await import('~/server/services/app-blocks-flag');
+
+    await expect(resolveStoreVisibilityScope()).resolves.toBe('none');
+
+    expect(recordStoreScopeDivergence).not.toHaveBeenCalled();
+  });
+
+  it('does not fire when the scope is NOT `none` (only a silent DENY is impossible)', async () => {
+    asyncFlags.value = { [EXTERNAL]: true };
+    syncFlags.value = { [EXTERNAL]: true };
+    const { resolveStoreVisibilityScope } = await import('~/server/services/app-blocks-flag');
+
+    await expect(resolveStoreVisibilityScope({ user: sessionUser(15) })).resolves.toBe(
+      'public-external'
+    );
+
+    expect(recordStoreScopeDivergence).not.toHaveBeenCalled();
+  });
+
+  it('a telemetry failure can NEVER break the read path', async () => {
+    recordStoreScopeDivergence.mockImplementation(() => {
+      throw new Error('prom exploded');
+    });
+    syncFlags.value = { [EXTERNAL]: true };
+    const { resolveStoreVisibilityScope } = await import('~/server/services/app-blocks-flag');
+
+    await expect(resolveStoreVisibilityScope({ user: sessionUser(16) })).resolves.toBe('none');
+  });
+});

--- a/src/server/services/__tests__/fixtures/flipt-store-scope.snapshot.json
+++ b/src/server/services/__tests__/fixtures/flipt-store-scope.snapshot.json
@@ -1,0 +1,144 @@
+{
+  "namespace": {
+    "key": "default"
+  },
+  "flags": [
+    {
+      "key": "app-blocks-enabled",
+      "name": "",
+      "description": "",
+      "enabled": false,
+      "type": "BOOLEAN_FLAG_TYPE",
+      "rules": [],
+      "rollouts": [
+        {
+          "type": "SEGMENT_ROLLOUT_TYPE",
+          "rank": 1,
+          "segment": {
+            "value": true,
+            "segmentOperator": "OR_SEGMENT_OPERATOR",
+            "segments": [
+              {
+                "key": "moderators",
+                "name": "",
+                "description": "",
+                "matchType": "ALL_SEGMENT_MATCH_TYPE",
+                "constraints": [
+                  {
+                    "type": "STRING_CONSTRAINT_COMPARISON_TYPE",
+                    "property": "isModerator",
+                    "operator": "eq",
+                    "value": "true"
+                  }
+                ]
+              },
+              {
+                "key": "app-dev-testers",
+                "name": "",
+                "description": "",
+                "matchType": "ANY_SEGMENT_MATCH_TYPE",
+                "constraints": [
+                  {
+                    "type": "STRING_CONSTRAINT_COMPARISON_TYPE",
+                    "property": "userId",
+                    "operator": "isoneof",
+                    "value": "[\"900000001\", \"900000002\"]"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "key": "app-listings",
+      "name": "",
+      "description": "",
+      "enabled": false,
+      "type": "BOOLEAN_FLAG_TYPE",
+      "rules": [],
+      "rollouts": [
+        {
+          "type": "SEGMENT_ROLLOUT_TYPE",
+          "rank": 1,
+          "segment": {
+            "value": true,
+            "segmentOperator": "OR_SEGMENT_OPERATOR",
+            "segments": [
+              {
+                "key": "moderators",
+                "name": "",
+                "description": "",
+                "matchType": "ALL_SEGMENT_MATCH_TYPE",
+                "constraints": [
+                  {
+                    "type": "STRING_CONSTRAINT_COMPARISON_TYPE",
+                    "property": "isModerator",
+                    "operator": "eq",
+                    "value": "true"
+                  }
+                ]
+              },
+              {
+                "key": "app-dev-testers",
+                "name": "",
+                "description": "",
+                "matchType": "ANY_SEGMENT_MATCH_TYPE",
+                "constraints": [
+                  {
+                    "type": "STRING_CONSTRAINT_COMPARISON_TYPE",
+                    "property": "userId",
+                    "operator": "isoneof",
+                    "value": "[\"900000001\", \"900000002\"]"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "key": "app-listings-public-external",
+      "name": "",
+      "description": "",
+      "enabled": false,
+      "type": "BOOLEAN_FLAG_TYPE",
+      "rules": [],
+      "rollouts": [
+        {
+          "type": "SEGMENT_ROLLOUT_TYPE",
+          "rank": 1,
+          "segment": {
+            "value": true,
+            "segmentOperator": "OR_SEGMENT_OPERATOR",
+            "segments": [
+              {
+                "key": "testers",
+                "name": "",
+                "description": "",
+                "matchType": "ANY_SEGMENT_MATCH_TYPE",
+                "constraints": [
+                  {
+                    "type": "STRING_CONSTRAINT_COMPARISON_TYPE",
+                    "property": "isModerator",
+                    "operator": "eq",
+                    "value": "true"
+                  },
+                  {
+                    "type": "STRING_CONSTRAINT_COMPARISON_TYPE",
+                    "property": "userId",
+                    "operator": "isoneof",
+                    "value": "[\"900001001\", \"900001002\"]"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "digest": "store-scope-fixture"
+}

--- a/src/server/services/app-blocks-flag.ts
+++ b/src/server/services/app-blocks-flag.ts
@@ -1,5 +1,10 @@
 import type { SessionUser } from '~/types/session';
-import { isFlipt } from '~/server/flipt/client';
+import { isFlipt, isFliptSync } from '~/server/flipt/client';
+import { logToAxiom } from '~/server/logging/client';
+import {
+  recordStoreScopeDivergence,
+  recordStoreScopeResolution,
+} from '~/server/prom/store-scope.metrics';
 import { buildFliptContext } from '~/server/services/feature-flags.service';
 
 const APP_BLOCKS_FLAG = 'app-blocks-enabled';
@@ -397,9 +402,7 @@ export const APP_BLOCKS_DEV_TUNNEL_FLAG = 'app-blocks-dev-tunnel';
  * is a brand-new surface (no existing mod access to preserve), so fail-closed for
  * all until the flag exists is the safe posture.
  */
-export async function isAppBlocksDevTunnelEnabled(opts?: {
-  user?: SessionUser;
-}): Promise<boolean> {
+export async function isAppBlocksDevTunnelEnabled(opts?: { user?: SessionUser }): Promise<boolean> {
   if (!opts?.user) return isFlipt(APP_BLOCKS_DEV_TUNNEL_FLAG);
   const user = opts.user;
   return isFlipt(APP_BLOCKS_DEV_TUNNEL_FLAG, String(user.id), buildFliptContext(user));
@@ -735,6 +738,19 @@ export type StoreVisibilityScope = 'full' | 'public-external' | 'none';
 export async function resolveStoreVisibilityScope(opts?: {
   user?: SessionUser;
 }): Promise<StoreVisibilityScope> {
+  const scope = await resolveStoreVisibilityScopeUninstrumented(opts);
+  // Instrumentation is deliberately at THIS choke point and nowhere else: it is the
+  // single place both read paths (tRPC middleware + the REST handlers) and the SSR
+  // store pages agree on, so one counter covers every entry point and cannot drift
+  // the way per-call-site logging would.
+  recordStoreScopeResolution(scope, opts?.user ? 'user' : 'anon');
+  if (scope === 'none' && opts?.user) reportSilentStoreGate(opts.user);
+  return scope;
+}
+
+async function resolveStoreVisibilityScopeUninstrumented(opts?: {
+  user?: SessionUser;
+}): Promise<StoreVisibilityScope> {
   // Axis 1 — the existing catalog-visibility gate (mods + app-dev-testers). MUST be
   // checked FIRST so a privileged viewer always gets `full`, never `public-external`
   // (the external flag can only ever LIFT a non-privileged viewer, never narrow a mod).
@@ -745,4 +761,50 @@ export async function resolveStoreVisibilityScope(opts?: {
   if (await isExternalListingsPublicEnabled(opts)) return 'public-external';
   // Fail-closed: neither flag → dark.
   return 'none';
+}
+
+/** The three flags a `full` / `public-external` scope can come from. */
+const STORE_SCOPE_FLAGS = [
+  APP_LISTINGS_FLAG,
+  APP_BLOCKS_FLAG,
+  APP_LISTINGS_PUBLIC_EXTERNAL_FLAG,
+] as const;
+
+/**
+ * 🔴 DETECTION NET for the civitai#3983 failure mode: a store gate that denies
+ * SILENTLY (empty grid, NOT_FOUND detail) and is therefore indistinguishable from an
+ * empty catalog — to the viewer, to operators, and for the whole of that
+ * investigation.
+ *
+ * The check is a RELATIONSHIP, not a component: the `/apps` page gate admits a viewer
+ * on the SYNC evaluation of these same three flags (`isFliptSync` →
+ * `featureFlags.appListings*` → `hasAppsStoreAccess`), while the read path admits them
+ * on the ASYNC one. A logged-in viewer for whom the async side resolved `none` while
+ * the sync side still says they hold a store flag is a state that should not exist —
+ * it is exactly "reaches /apps, store is empty". Emitting it converts a silent
+ * mis-gate into an alertable event.
+ *
+ * Deliberately narrow so it cannot become background noise: only a LOGGED-IN viewer
+ * (anon has no page-gate pairing to contradict), only after the resolver already
+ * answered `none`, and `isFliptSync` reuses the eval cache the awaited call above just
+ * populated, so the re-read is a cache hit rather than three more wasm evaluations.
+ * A `null` sync answer (client not initialized) is NOT a divergence — it is the
+ * documented fall-through to static availability.
+ */
+function reportSilentStoreGate(user: SessionUser): void {
+  try {
+    const context = buildFliptContext(user);
+    const entityId = String(user.id);
+    const held = STORE_SCOPE_FLAGS.filter((flag) => isFliptSync(flag, entityId, context) === true);
+    if (!held.length) return;
+    for (const flag of held) recordStoreScopeDivergence(flag);
+    logToAxiom({
+      type: 'store-scope-divergence',
+      message: 'store read scope resolved `none` for a logged-in viewer who holds a store flag',
+      userId: user.id,
+      heldFlags: [...held],
+    }).catch(() => null);
+  } catch {
+    /* never throw from telemetry — a detection net must not break the read path */
+  }
 }


### PR DESCRIPTION
Closes nothing yet. Addresses #3983.

## 🔴 Read this first: this PR does not contain a point fix, and here is why

#3983's central claim is that the real `isFlipt` client is "the one surface nothing
covers", and therefore where the defect must live. **I built that coverage and drove the
real client. It answers correctly.** That refutes the hypothesis rather than confirming
it, so shipping a "fix" to the resolver would have been a guess dressed as a diagnosis.

What this PR does ship: the coverage that was missing, the production signal that was
missing, and a much narrower search space with a named next discriminator.

### The experiment

I stood up a real Flipt v2 server loaded with the **actual production definitions** of
`app-listings`, `app-blocks-enabled` and `app-listings-public-external`, captured its
evaluation snapshot, and drove the production `createFliptClient` → wasm engine →
`resolveStoreVisibilityScope` against it. Results:

| principal | `app-listings` | `app-blocks-enabled` | `app-listings-public-external` | resolved scope |
|---|---|---|---|---|
| no user (global eval) | false | false | false | **`none`** |
| the external-only cohort | false | false | **true** | **`public-external`** |
| a moderator | true | true | (not reached) | `full` |
| a logged-in non-cohort user | false | false | false | `none` |

Those are exactly the answers the flag configuration implies, and exactly the answers
production contradicts — in both directions. The client, the wasm engine, the segment
matcher, `buildFliptContext`, the resolver's priority order and the flag definitions are
all now **measured correct**, not assumed correct.

I also confirmed the code that serves production is the code in this repo: the four files
on the store scope path are identical between `main` and the release branch apart from one
unrelated import-path change in `app-listing.service.ts`. So this is not a branch-skew
artefact either.

### The constraint that survives, and why it is new

Working back from the two reported observations to what the code requires:

- REST returning the full catalog (**including on-site listings**) to an anonymous caller
  requires `resolveStoreVisibilityScope` to have returned something other than `none`.
  Anonymous evaluates globally, and every global evaluation of all three flags is `false`.
- tRPC returning nothing to a cohort member requires all three flags to be `false` **for
  that user**, where the external flag measurably evaluates `true`.

**No single Flipt configuration or client behaviour produces both**, because the two
requirements are opposite. Every surviving explanation therefore has to break the chain
*after* the evaluation, not inside it. Concretely, there are exactly two shapes left:

1. **The scope is being lost between the resolver and the branch.** This fits both
   observations with ONE mechanism, because the two entry points have opposite defaults
   for an absent scope: the tRPC procs `?? 'none'` (empty page) and the listing service
   `?? 'full'` (the whole catalog, on-site included). An absent scope produces *precisely*
   the reported split — empty on tRPC, full on REST — for every caller, deterministically
   and independently of the user, which is also exactly how the issue describes it.
2. **The running artefact is not this source.** Nothing in the repo can distinguish that.

I could not settle which. Both are invisible from outside, because — as the issue already
notes — every one of these states returns the same bytes.

### Verified independently for this PR (live, read-only, no cluster access needed)

Re-checked today rather than taken from the issue: the anonymous catalog response is still
14 items including 10 on-site, is served from origin on a fresh cache key (`MISS`), and
honours query parameters (`kind=onsite&limit=9` → 9 on-site items). So the handler
genuinely runs, genuinely parses input, genuinely reaches the listing service, and its
scope genuinely permits on-site. The symptom is live and is not an edge-cache artefact.

---

## What is in this PR

### A. The coverage gap, closed — and demonstrated, not asserted

`src/server/services/__tests__/app-blocks-flag.real-flipt-client.integration.test.ts`
drives the REAL `createFliptClient` and the REAL wasm evaluation engine through the REAL
`resolveStoreVisibilityScope`. It is hermetic: a committed evaluation-snapshot fixture is
served from an in-process HTTP server, so there is no Flipt server, no container and no
network in CI.

The fixture carries the production flag SHAPE verbatim (`enabled: false` base + an
`OR_SEGMENT_OPERATOR` rollout combining an `ALL_SEGMENT_MATCH_TYPE` moderator segment with
an `ANY_SEGMENT_MATCH_TYPE` user-id allowlist). **The user ids in it are synthetic** —
this repo is public and the real cohort allowlists are not ours to publish; the ids are
not what is under test, the constraint shape is.

**Why this is worth having, measured rather than claimed.** I introduced a mutant that
makes the Flipt client silently drop the evaluation context — which reproduces the
reported symptom exactly, since a segment can then never match for anyone:

| suite | result against that mutant |
|---|---|
| the 75 existing store-scope tests | **all 75 green** — structurally blind, they mock the client module outright |
| the flipt package's own 16 tests | **all 16 green** — they never assemble a real snapshot |
| this new suite | **4 failed** |

The suite also carries its own controls: an instrument control asserting the fixture
server is actually reached in the right environment with the right auth header, and a
positive control asserting the engine really does match a segment *and* really does refuse
the same flag to someone outside it — so a `true` is attributable to the segment rather
than to a flag that is open to everyone.

**What it structurally cannot see** (stated in the file, not left implicit): the live flag
document, the real network path to production Flipt (TLS, the circuit breaker, snapshot
refreshes, a fetch that times out), the tRPC ctx plumbing downstream of the resolver, and
whichever artefact production is actually running.

### B. The silent gate, made loud

`src/server/prom/store-scope.metrics.ts` adds three low-cardinality counters, wired at the
single choke point both read paths and the SSR store pages share:

- `store_scope_resolutions_total{scope, principal}` — what the resolver answers, split by
  whether a session user was present. Six fixed series. **This is the permanent form of
  the one-off "instrumented deploy" the issue asks for**: it answers "what is production
  resolving for a logged-in viewer?" without anyone shipping a debug build.
- `store_scope_applied_total{scope, entrypoint}` — what each entry point actually branched
  on, recorded **before** its own `??` default. Its extra `absent` value is the thing no
  response can ever tell you.
- `store_scope_divergence_total{flag}` — the impossible combination: a logged-in principal
  whose read scope resolved `none` while a same-request re-read of that same flag through
  the *sync* evaluation (the one the `/apps` page gate keys on) says they hold it. That is
  a relationship between the two gates, not a property of either, and it is precisely the
  shape of "reaches /apps, store is empty". A structured log accompanies it.

Deliberately narrow so it cannot become noise: logged-in only, only after the resolver has
already answered `none`, and the sync re-read hits the evaluation cache the awaited call
just populated rather than costing three more evaluations. A `null` sync answer (client
not warm) is explicitly **not** a divergence. All of it is `try`/`catch`ed — telemetry
must never throw into a read path, and there is a test for that.

**What the divergence counter cannot see**, so a flat zero is not read as health: a scope
that is resolved correctly and then lost downstream (shape 1 above — the resolution and
applied counters are what cover that), and a uniformly dead Flipt client (both evaluations
then agree on `false`).

### The `none` vs `absent` discriminator — the part that ends the investigation

This is the piece I would keep if I could keep only one. Recording the branched-on scope
before the fallback makes shape 1 and shape 2 **separable from a dashboard**:

- `resolutions{scope="public-external",principal="user"}` climbing while
  `applied{scope="absent",entrypoint="trpc-list"}` climbs in step ⇒ the scope is resolved
  correctly and **lost in transit**.
- `resolutions{scope="none",principal="user"}` climbing instead ⇒ the resolver itself is
  answering wrongly in production, which — given the measurements above — means the
  running artefact is not this source.

Those two need opposite fixes and have been indistinguishable for the entire life of this
issue.

### C. One resolver, one answer, per principal — proposed, not done

Both entry points already call the same resolver, so the drift is not in *which* rule they
apply; it is in what they do when the answer is missing, and those defaults point in
opposite directions (`none` vs `full`). Minimum viable proposal, for a follow-up:

1. **Make `scope` a required parameter of `listAvailableListings` / `getListingDetail`.**
   The `?? 'full'` default is a fail-OPEN path that only exists for callers that forget to
   pass a scope; both production callers already pass one, so this is a compile-time-only
   change with zero runtime behaviour change today. I deliberately did not do it here: it
   touches ~40 call sites in existing tests, which is a large unrelated diff on a PR whose
   point is the diagnosis.
2. **A contract test asserting both entry points return the same scope for the same
   principal**, driven off one Flipt configuration — the cheap version of a shared entry
   point.

🔴 **Explicitly NOT proposed: narrowing the public REST catalog.** Public API access to
listings is intended product behaviour. Nothing in this PR changes what `/api/v1/apps`
returns, and a follow-up should make that intent explicit in code rather than let it keep
emerging from a gate that does not fire.

---

## Verification

**Red → green matrix.** Base ref `2c8c072dfa` (`origin/main` at branch point), head
`da2ce0cd2c`.

| suite | at base | at head |
|---|---|---|
| `app-listings.router.applied-scope-signal.test.ts` | **5 failed / 5** | 5 passed |
| `app-blocks-flag.silent-gate-signal.test.ts` | **5 failed, 5 passed / 10** | 10 passed |
| `app-blocks-flag.real-flipt-client.integration.test.ts` | 7 passed (see note) | 7 passed |

The base runs were done by restoring only the pre-change source file, leaving the new
suites in place, so the reds are substantive assertion failures — not module-not-found.

🔴 **Honest label on the third row: the real-client suite is green at base, so it is an
invariant guard, not a regression test.** It cannot be red at base, because the behaviour
it pins is behaviour the current code already has — that is the whole finding. Its value
is proven by the mutation table above (green everywhere else, red here), not by a red
base. The five negative cases in the item-B suite also pass vacuously at base, for the
ordinary reason that nothing fires when nothing exists; the five substantive ones fail.

**Other checks:** `pnpm typecheck` — 0 errors. Instrument positive-controlled: a planted
`const __probe: number = 'not-a-number'` in the new metrics module was reported as
`error TS2322` at that exact line, and the run then returned to 0 after reverting.

Full unit run over every touched area (`src/server/routers/__tests__`,
`src/server/services/__tests__`, `src/server/services/blocks/__tests__`,
`src/tests/api/v1/apps`): **418 files / 7,372 tests, 0 failures, 4 skipped.** ESLint clean
on all changed files (one pre-existing unused-import warning in `apps/index.ts`, untouched).

**Diff-noise notice:** Prettier reformatted ~180 unrelated lines of
`app-listings.router.ts`. That file was already prettier-dirty on `main` (6 files under
`src/server/routers/` are), so leaving it unformatted risked a newly-red format check on a
file this PR touches. Review with `git diff --ignore-all-space` to see only the four
substantive edits.

## 🔴 What remains UNVERIFIED

- **The production symptom is not fixed and I do not claim a root cause.** The two
  surviving shapes are named above; neither is confirmed.
- **Nothing here has been observed in production.** `main` is not what serves; this needs
  a promotion before any counter emits a single sample. Treat *merged*, *promoted*,
  *serving* and *verified* as four separate claims — none of the last three is made.
- **The new counters are unexercised against real traffic.** They are unit-tested and
  cardinality-bounded, but no production sample has been seen.
- **The fixture is a point-in-time copy of the flag shape**, not a live mirror. A live
  configuration change that alters the shape will not fail this suite.

### Exactly what to do once this is serving

1. Read `store_scope_resolutions_total` split by `principal`. If logged-in resolutions are
   entirely `none` while a cohort flag is open, the resolver is answering wrongly in
   production — which, given the measurements in this PR, points at the artefact rather
   than the source.
2. Read `store_scope_applied_total` for `scope="absent"`. Any non-zero value on any entry
   point proves the scope is being lost between resolver and branch, and localises it to
   that entry point.
3. Read `store_scope_divergence_total`. Non-zero means the page gate and the read path
   disagree for a real viewer, and the `flag` label names the axis.

One of those three is non-zero. Which one it is settles #3983.
