### PR TITLE
fix(user-settings): make every User.settings write atomic in Postgres

### DIFF
--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -82,6 +82,8 @@ const IO_CALL_NAMES = new Set([
   'updateDocs',
   'refresh', // *Cache.refresh(...) — Redis + cross-pool read
   'bust', // bustMvCache etc.
+  'bustUserSettings',
+  'getUserSettings',
   'bustMvCache',
   'invalidateManyImageExistence',
   // email

--- a/src/__tests__/mocks/direct-mock-allowlist.json
+++ b/src/__tests__/mocks/direct-mock-allowlist.json
@@ -20,10 +20,10 @@
   ],
   "totals": {
     "canonicalFiles": 218,
-    "pendingFiles": 396,
-    "allFiles": 482,
+    "pendingFiles": 397,
+    "allFiles": 484,
     "canonicalSites": 288,
-    "pendingSites": 864
+    "pendingSites": 868
   },
   "bySpecifier": {
     "~/server/db/client": 135,
@@ -39,7 +39,7 @@
     "~/server/flipt/client": 64,
     "~/server/redis/fail-open-log": 55,
     "~/server/utils/endpoint-helpers": 53,
-    "~/server/redis/caches": 54,
+    "~/server/redis/caches": 55,
     "~/server/prom/client": 50
   },
   "files": [
@@ -529,6 +529,7 @@
     "src/server/services/__tests__/update-user-profile.sql.service.test.ts",
     "src/server/services/__tests__/user-challenge-flag-gate.test.ts",
     "src/server/services/__tests__/user-profile-domain-variants.service.test.ts",
+    "src/server/services/__tests__/user-settings-gallery-copy.behavior.test.ts",
     "src/server/services/__tests__/vae-files-cross-version.test.ts",
     "src/server/services/blocks/__tests__/agent-review-chat.service.test.ts",
     "src/server/services/blocks/__tests__/agent-review.service.test.ts",

--- a/src/server/controllers/__tests__/user.controller.early-adopter-refresh.test.ts
+++ b/src/server/controllers/__tests__/user.controller.early-adopter-refresh.test.ts
@@ -17,10 +17,10 @@ import type * as SessionInvalidation from '~/server/auth/session-invalidation';
  * on whether `refreshSession` was called and with what.
  */
 
-const { mockGetUserSettings, mockSetUserSetting, mockRefreshSession, mockQueueReindex } =
+const { mockGetUserSettings, mockPatchUserSettings, mockRefreshSession, mockQueueReindex } =
   vi.hoisted(() => ({
     mockGetUserSettings: vi.fn(),
-    mockSetUserSetting: vi.fn().mockResolvedValue(undefined),
+    mockPatchUserSettings: vi.fn().mockResolvedValue({}),
     mockRefreshSession: vi.fn().mockResolvedValue(undefined),
     mockQueueReindex: vi.fn().mockResolvedValue(undefined),
   }));
@@ -28,7 +28,7 @@ const { mockGetUserSettings, mockSetUserSetting, mockRefreshSession, mockQueueRe
 vi.mock('~/server/services/user.service', async (importOriginal) => ({
   ...(await importOriginal<typeof UserService>()),
   getUserSettings: mockGetUserSettings,
-  setUserSetting: mockSetUserSetting,
+  patchUserSettings: mockPatchUserSettings,
 }));
 
 vi.mock('~/server/auth/session-invalidation', async (importOriginal) => ({
@@ -59,6 +59,7 @@ const call = (input: Record<string, unknown>) =>
 beforeEach(() => {
   vi.clearAllMocks();
   mockGetUserSettings.mockResolvedValue({});
+  mockPatchUserSettings.mockResolvedValue({});
 });
 
 describe('setUserSettingHandler — session refresh on the early-adopter toggle', () => {
@@ -67,7 +68,7 @@ describe('setUserSettingHandler — session refresh on the early-adopter toggle'
 
     await call({ isEarlyAdopter: true });
 
-    expect(mockSetUserSetting).toHaveBeenCalledTimes(1);
+    expect(mockPatchUserSettings).toHaveBeenCalledTimes(1);
     expect(mockRefreshSession).toHaveBeenCalledTimes(1);
     expect(mockRefreshSession).toHaveBeenCalledWith(USER_ID, { caller: 'profile' });
   });
@@ -90,25 +91,28 @@ describe('setUserSettingHandler — session refresh on the early-adopter toggle'
 
     await call({ swipeGalleryCards: true });
 
-    expect(mockSetUserSetting).toHaveBeenCalledTimes(1);
+    expect(mockPatchUserSettings).toHaveBeenCalledTimes(1);
     expect(mockRefreshSession).not.toHaveBeenCalled();
   });
 
   it('does NOT refresh when an unrelated setting is written by an ALREADY-opted-in user', async () => {
-    // The regression this guards: `setUserSettingHandler` does a read-modify-write, so the
-    // payload handed to `setUserSetting` carries `isEarlyAdopter` on EVERY write once the
-    // user has opted in. A presence check (`'isEarlyAdopter' in newSettings`) would fire the
-    // refresh on every unrelated toggle for exactly the cohort that uses the site most.
+    // The change-detection predicate compares against the PREVIOUS value, so it must not
+    // fire for a user who merely already holds the opt-in. (Before the atomic-write change
+    // the handler also rewrote the whole blob, which put `isEarlyAdopter` in the payload on
+    // every write — so a presence check would have refreshed on every unrelated toggle for
+    // exactly the cohort that uses the site most. The presence check is still wrong; the
+    // payload no longer carries the key at all.)
     mockGetUserSettings.mockResolvedValue({ isEarlyAdopter: true, allowAds: false });
 
     await call({ swipeGalleryCards: true });
 
-    // The write still carries the existing opt-in through (read-modify-write intact) ...
-    expect(mockSetUserSetting).toHaveBeenCalledWith(
-      USER_ID,
-      expect.objectContaining({ isEarlyAdopter: true })
-    );
-    // ... but nothing CHANGED, so no refresh.
+    // The write carries ONLY what this request is changing. Writing back the read snapshot
+    // is the lost-update defect — see user-settings-race.behavior.test.ts.
+    const [, patch] = mockPatchUserSettings.mock.calls[0];
+    expect(patch.set).toEqual({ swipeGalleryCards: true });
+    expect(patch.set).not.toHaveProperty('isEarlyAdopter');
+    expect(patch.set).not.toHaveProperty('allowAds');
+    // ... and nothing CHANGED, so no refresh.
     expect(mockRefreshSession).not.toHaveBeenCalled();
   });
 
@@ -132,8 +136,12 @@ describe('setUserSettingHandler — session refresh on the early-adopter toggle'
     expect(mockRefreshSession).toHaveBeenCalledTimes(1);
   });
 
-  it('still returns the merged settings to the caller', async () => {
+  it('returns the STORED settings to the caller, not a JS-side reconstruction', async () => {
+    // The handler used to return the object it had just computed. That object was a
+    // read-modify-write of a possibly-stale snapshot, so the client could be handed values
+    // that were never in the database. The write now returns the row it produced.
     mockGetUserSettings.mockResolvedValue({ allowAds: false });
+    mockPatchUserSettings.mockResolvedValue({ allowAds: false, isEarlyAdopter: true });
 
     const result = await call({ isEarlyAdopter: true });
 

--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -1471,10 +1471,12 @@ export const setUserSettingHandler = async ({
     // signals the browser to re-pull. Awaited so the bust lands before the mutation
     // returns; same reason `updateContentSettings` awaits its own call.
     //
-    // Gated on a CHANGE, not on key presence: `newSettings` is a read-modify-write of the
-    // whole blob, so once a user has opted in the key is present on EVERY subsequent
-    // settings write, and a presence check would refresh the session on unrelated
-    // toggles. Mirrors the `metricPrivacyChanged` comparison directly above.
+    // Gated on a CHANGE, not on key presence, and compared against `restInput` — the keys
+    // THIS request sent — rather than against the stored blob. Mirrors the
+    // `metricPrivacyChanged` comparison directly above. (The payload no longer carries the
+    // whole blob, so a presence check on it would no longer fire on unrelated toggles the
+    // way it did when this handler rewrote everything; the change comparison is still the
+    // right test, because re-sending the value a user already holds is not a change.)
     const earlyAdopterChanged =
       'isEarlyAdopter' in restInput && restSettings.isEarlyAdopter !== restInput.isEarlyAdopter;
     if (earlyAdopterChanged) await refreshSession(id, { caller: 'profile' });

--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -90,12 +90,14 @@ import {
   getUsers,
   getUserContentSettings,
   getUserSettings,
-  setDismissedAlerts,
+  setAlertDismissed,
   getUsersWithSearch,
   isUsernamePermitted,
   restoreUser,
   setLeaderboardEligibility,
   setUserSetting,
+  patchUserSettings,
+  splitSettingsPatch,
   toggleBan,
   toggleBookmarked,
   toggleContestBan,
@@ -1394,18 +1396,21 @@ export const toggleUserFeatureFlagHandler = async ({
 }) => {
   try {
     const { id } = ctx.user;
-    const { features = {}, ...restSettings } = await getUserSettings(id);
+    const { features = {} } = await getUserSettings(id);
 
-    const updatedFeatures: Partial<FeatureAccess> = {
-      ...features,
-      [input.feature]: isDefined(features[input.feature])
-        ? input.value ?? !features[input.feature]
-        : input.value ?? !defaultToggleableFeatures[input.feature],
-    };
+    // The read decides what this ONE flag toggles to; it must not decide what gets
+    // written. Only the toggled flag is sent, merged into `settings.features` by the
+    // database, so a concurrent write to any other setting — or to another flag —
+    // survives instead of being reverted to its read-time value.
+    const value = isDefined(features[input.feature])
+      ? input.value ?? !features[input.feature]
+      : input.value ?? !defaultToggleableFeatures[input.feature];
 
-    await setUserSetting(id, { ...restSettings, features: updatedFeatures });
+    const settings = await patchUserSettings(id, {
+      mergeInto: { features: { [input.feature]: value } },
+    });
 
-    return updatedFeatures;
+    return (settings.features ?? { [input.feature]: value }) as Partial<FeatureAccess>;
   } catch (error) {
     throw throwDbError(error);
   }
@@ -1439,14 +1444,17 @@ export const setUserSettingHandler = async ({
       throw throwAuthorizationError('You do not have permission to perform this action');
     }
 
-    const { tourSettings, ...restSettings } = await getUserSettings(id);
-    const newSettings = {
-      ...restSettings,
-      ...restInput,
-      tourSettings: tourSettings ? { ...tourSettings, ...tour } : { ...tour },
-    };
-
-    await setUserSetting(id, newSettings);
+    // Read for COMPARISON only — the two side effects below fire on a change, so they
+    // need the previous value. Nothing read here is written back: the patch carries
+    // only the keys this request is changing, and the database merges them onto
+    // whatever the column holds at write time. Spreading the read snapshot into the
+    // write is what used to revert a concurrent notice dismissal / feature toggle.
+    const restSettings = await getUserSettings(id);
+    const newSettings = await patchUserSettings(id, {
+      ...splitSettingsPatch(restInput),
+      // One level deep, so a tour another request just completed is not dropped.
+      ...(tour && Object.keys(tour).length ? { mergeInto: { tourSettings: tour } } : {}),
+    });
 
     const privacyKeys = ['hideModelBuzz', 'hideModelDownloads', 'hideModelGenerations'] as const;
     const metricPrivacyChanged = privacyKeys.some(
@@ -1486,13 +1494,9 @@ export const dismissAlertHandler = async ({
 }) => {
   try {
     const { id } = ctx.user;
-    const { dismissedAlerts = [] } = await getUserSettings(id);
-
-    const updated = input.dismiss
-      ? [...new Set([...dismissedAlerts, input.alertId])]
-      : dismissedAlerts.filter((a: string) => a !== input.alertId);
-
-    await setDismissedAlerts(id, updated);
+    // One statement, computed over the stored array. The array is never read into
+    // JS, so two dismissals of different notices arriving together both land.
+    await setAlertDismissed(id, input.alertId, input.dismiss);
   } catch (error) {
     throw throwDbError(error);
   }
@@ -1507,11 +1511,11 @@ export const restoreAlertHandler = async ({
 }) => {
   try {
     const { id } = ctx.user;
-    const { dismissedAlerts = [] } = await getUserSettings(id);
-
-    await setUserSetting(id, {
-      dismissedAlerts: dismissedAlerts.filter((a: string) => a !== input.alertId),
-    });
+    // Same write path as `dismissAlert({ dismiss: false })`. It previously went through
+    // the whole-blob merge instead, which had a second defect: `removeEmpty` drops an
+    // EMPTY array, so restoring the user's last remaining dismissal wrote nothing at
+    // all and the notice stayed hidden.
+    await setAlertDismissed(id, input.alertId, false);
   } catch (error) {
     throw throwDbError(error);
   }

--- a/src/server/services/__tests__/set-user-setting.sql.service.test.ts
+++ b/src/server/services/__tests__/set-user-setting.sql.service.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Correctness tests for the two SQL statements `setUserSetting` emits.
+// Statement-shape tests for the ONE place `User.settings` is written.
+//
+// History this file exists to hold shut:
 //
 // 1. The merge statement built its jsonb payload by splicing `JSON.stringify(toSet)`
 //    into a single-quoted SQL string literal. `JSON.stringify` escapes `"` and `\`
@@ -15,45 +17,59 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 //    the tRPC transformer carries an explicit `undefined` property over the wire and
 //    zod keeps the key, so `user.setSettings` can put a key on the removal list.
 //
-// Both statements are now parameterised tagged templates, so values are bound rather
-// than pasted into the statement text. These tests assert exactly that: user data must
-// appear in the bound values and never in the statement text.
+// 3. Set and remove were TWO separate statements, and the merge was written from a
+//    JS-side snapshot of the blob. Both are now one statement over the stored column,
+//    which is what makes a settings write survive a concurrent one. The behavioural
+//    proof of that is user-settings-race.behavior.test.ts, which runs these statements
+//    against a real Postgres and interleaves two requests; this file pins the emitted
+//    SHAPE, which a behavioural test on one engine cannot.
 //
-// Where a value lives is only half of it, though. A statement can bind every value
-// correctly and still be rejected by Postgres if the operator, the cast, or the
-// placeholder's position is wrong — and an assertion that only reads `values`, or only
-// asserts a negative on the text, cannot see that. So each statement additionally pins
-// the shape it emits.
+// Where a value lives is only half of it: a statement can bind every value correctly
+// and still be rejected by Postgres if the operator, the cast, or the placeholder's
+// position is wrong — and an assertion that only reads `values`, or only asserts a
+// negative on the text, cannot see that. So each statement pins its shape too.
 
 const { statements, mockDb } = vi.hoisted(() => {
   const statements: { text: string; values: unknown[] }[] = [];
+
+  // Three call shapes reach the capture. The tagged template (`$executeRaw`…``) arrives
+  // as `(TemplateStringsArray, ...values)`; a pre-built `Prisma.sql` arrives as an object
+  // exposing `.sql`/`.values`; the interpolating `$queryRawUnsafe` / `$executeRawUnsafe`
+  // arrive as one finished string plus values. All reduce to the same {text, values}
+  // pair, so a statement can never go unrecorded and read as a pass.
+  const record = (first: unknown, rest: unknown[]) => {
+    if (Array.isArray(first) && Array.isArray((first as unknown as TemplateStringsArray).raw)) {
+      const text = (first as string[]).reduce(
+        (acc: string, chunk: string, i: number) => acc + (i ? `$${i}` : '') + chunk,
+        ''
+      );
+      statements.push({ text, values: rest });
+    } else if (
+      first &&
+      typeof first === 'object' &&
+      typeof (first as { sql?: unknown }).sql === 'string'
+    ) {
+      const frag = first as { sql: string; values?: unknown[] };
+      statements.push({ text: frag.sql, values: Array.isArray(frag.values) ? frag.values : [] });
+    } else {
+      statements.push({ text: String(first), values: rest });
+    }
+  };
+
   return {
     statements,
     mockDb: {
-      // Parameterised form. Two call shapes reach it: the tagged template
-      // (`$executeRaw`…``) arrives as `(TemplateStringsArray, ...values)`, and a
-      // pre-built `Prisma.sql` passed as an argument arrives as a `Prisma.Sql`
-      // exposing `.sql` (text with $N placeholders) and `.values`. Reduce both to
-      // the same {text, values} pair.
-      $executeRaw: vi.fn(async (first: any, ...rest: unknown[]) => {
-        if (Array.isArray(first) && Array.isArray(first.raw)) {
-          const text = first.reduce(
-            (acc: string, chunk: string, i: number) => acc + (i ? `$${i}` : '') + chunk,
-            ''
-          );
-          statements.push({ text, values: rest });
-        } else {
-          statements.push({
-            text: typeof first?.sql === 'string' ? first.sql : String(first),
-            values: Array.isArray(first?.values) ? first.values : [],
-          });
-        }
+      $executeRaw: vi.fn(async (first: unknown, ...rest: unknown[]) => {
+        record(first, rest);
         return 1;
       }),
-      // Interpolating form: the whole statement arrives as one already-built string.
-      $executeRawUnsafe: vi.fn(async (text: string, ...values: unknown[]) => {
-        statements.push({ text: String(text), values });
+      $executeRawUnsafe: vi.fn(async (first: unknown, ...rest: unknown[]) => {
+        record(first, rest);
         return 1;
+      }),
+      $queryRawUnsafe: vi.fn(async (first: unknown, ...rest: unknown[]) => {
+        record(first, rest);
+        return [{ settings: {} }];
       }),
       $queryRaw: vi.fn(async () => []),
     },
@@ -61,7 +77,7 @@ const { statements, mockDb } = vi.hoisted(() => {
 });
 
 vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
-// `setUserSetting` busts the user-settings cache after writing; keep Redis out of it.
+// The settings writers bust the user-settings cache after writing; keep Redis out of it.
 vi.mock('~/server/utils/cache-helpers', async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   createCachedObject: vi.fn(() => ({
@@ -94,9 +110,18 @@ vi.mock('~/server/services/user-preferences.service', () => ({
   toggleHidden: vi.fn(async () => ({ added: [], removed: [] })),
 }));
 
-import { setUserSetting } from '~/server/services/user.service';
+import {
+  patchUserSettings,
+  setAlertDismissed,
+  setUserSetting,
+} from '~/server/services/user.service';
 
 const USER_ID = 4242;
+
+// The original removal statement ended in a stray `}` that made it unparseable. The
+// combined statement legitimately contains the empty-object literal `'{}'`, so drop
+// those before looking for a loose brace — assert the DEFECT, not the character.
+const withoutEmptyObjectLiterals = (text: string) => text.replace(/'\{\}'/g, '');
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -163,7 +188,7 @@ describe('setUserSetting — the merge statement', () => {
   });
 });
 
-describe('setUserSetting — the key-removal statement', () => {
+describe('setUserSetting — key removal', () => {
   it('removes settings keys without error', async () => {
     await setUserSetting(USER_ID, {
       allowAds: true,
@@ -173,30 +198,26 @@ describe('setUserSetting — the key-removal statement', () => {
       swipeGalleryCards: undefined,
     });
 
-    // One merge for `allowAds`, then one removal for the two undefined keys.
-    expect(statements).toHaveLength(2);
-    const removal = statements[1];
-
-    // The stray brace made this statement unparseable; there must be no brace at all.
-    expect(removal.text).not.toContain('}');
+    const [write] = statements;
+    expect(withoutEmptyObjectLiterals(write.text)).not.toContain('}');
     // The key names are bound as one array, not pasted in and hand-quoted.
-    expect(removal.values).toContainEqual(['hideDonationGoals', 'swipeGalleryCards']);
-    expect(removal.text).not.toContain('hideDonationGoals');
+    expect(write.values).toContainEqual(['hideDonationGoals', 'swipeGalleryCards']);
+    expect(write.text).not.toContain('hideDonationGoals');
   });
 
   it('binds a single removed key as an array too', async () => {
     await setUserSetting(USER_ID, { allowAds: true, hideDonationGoals: undefined });
 
-    expect(statements).toHaveLength(2);
-    const removal = statements[1];
-    expect(removal.text).not.toContain('}');
-    expect(removal.values).toContainEqual(['hideDonationGoals']);
+    const [write] = statements;
+    expect(withoutEmptyObjectLiterals(write.text)).not.toContain('}');
+    expect(write.values).toContainEqual(['hideDonationGoals']);
   });
 
-  it('emits no removal statement when nothing is marked for removal', async () => {
+  it('emits no subtraction when nothing is marked for removal', async () => {
     await setUserSetting(USER_ID, { allowAds: true });
 
     expect(statements).toHaveLength(1);
+    expect(statements[0].text).not.toContain('::text[]');
   });
 
   // `jsonb - text[]` is the only form that accepts a bound array of key names; any other
@@ -205,19 +226,105 @@ describe('setUserSetting — the key-removal statement', () => {
   it('casts the bound key array to text[]', async () => {
     await setUserSetting(USER_ID, { allowAds: true, hideDonationGoals: undefined });
 
-    const removal = statements[1];
-    expect(removal.text).toContain('::text[]');
-    expect(removal.text).toMatch(/\$\d+::text\[\]/);
+    const [write] = statements;
+    expect(write.text).toContain('::text[]');
+    expect(write.text).toMatch(/\$\d+::text\[\]/);
   });
 
   // Delete, not merge. Swapping `-` for `||` is both an operator Postgres has no
   // definition for at these operand types and the opposite meaning from the one this
   // branch exists to express — and nothing above would notice the swap.
-  it('subtracts the key array from settings rather than concatenating it', async () => {
+  it('subtracts the key array rather than concatenating it', async () => {
     await setUserSetting(USER_ID, { allowAds: true, hideDonationGoals: undefined });
 
-    const removal = statements[1];
-    expect(removal.text).toMatch(/settings\s*-\s*\$\d+::text\[\]/);
-    expect(removal.text).not.toContain('||');
+    const [write] = statements;
+    expect(write.text).toMatch(/-\s*\$\d+::text\[\]/);
+  });
+
+  // The set and the removal used to be two statements with no transaction around them,
+  // so a reader could observe the blob with the new keys written and the dead keys still
+  // present. One statement removes that window by construction.
+  it('sets and removes in a SINGLE statement', async () => {
+    await setUserSetting(USER_ID, { allowAds: true, hideDonationGoals: undefined });
+
+    expect(statements).toHaveLength(1);
+    expect(statements[0].text).toContain('||');
+    expect(statements[0].text).toContain('::text[]');
+  });
+
+  it('still writes the removal when every supplied key is a removal', async () => {
+    // `removeEmpty` strips the undefined values, so the payload half is empty. The old
+    // code returned early on that and the removal never ran.
+    await setUserSetting(USER_ID, { hideDonationGoals: undefined });
+
+    expect(statements).toHaveLength(1);
+    expect(statements[0].values).toContainEqual(['hideDonationGoals']);
+  });
+});
+
+describe('patchUserSettings — the nested merge', () => {
+  it('merges INTO the named key rather than replacing it', async () => {
+    await patchUserSettings(USER_ID, { mergeInto: { features: { someFlag: true } } });
+
+    expect(statements).toHaveLength(1);
+    const [write] = statements;
+    // The sub-object is read from the column inside the same statement — that is what
+    // keeps a sibling sub-key another writer just added.
+    expect(write.text).toMatch(/COALESCE\(settings->\$\d+::text, *'\{\}'::jsonb\) *\|\| *\$\d+::jsonb/);
+    expect(write.values).toContainEqual('features');
+    expect(write.values).toContainEqual(JSON.stringify({ someFlag: true }));
+    // The key name binds; it is never pasted into the text (a settings key is fixed
+    // vocabulary today, but the statement must not depend on that).
+    expect(write.text).not.toContain('features');
+  });
+
+  it('returns the stored blob rather than a JS-side reconstruction', async () => {
+    await patchUserSettings(USER_ID, { set: { allowAds: true } });
+
+    expect(statements[0].text).toContain('RETURNING settings');
+  });
+
+  it('writes nothing when there is nothing to change', async () => {
+    await patchUserSettings(USER_ID, { set: {}, mergeInto: {}, remove: [] });
+
+    expect(statements.filter((s) => s.text.includes('UPDATE'))).toHaveLength(0);
+  });
+});
+
+describe('setAlertDismissed — the set operation', () => {
+  it('appends to the STORED array, guarded against a duplicate', async () => {
+    await setAlertDismissed(USER_ID, 'notice-a', true);
+
+    expect(statements).toHaveLength(1);
+    const [write] = statements;
+    // Read and write in one statement: the array is never carried through JS, which is
+    // what lets two dismissals of different notices overlap.
+    expect(write.text).toContain(`settings->'dismissedAlerts'`);
+    expect(write.text).toContain('jsonb_build_array($1::text)');
+    // Idempotence is a containment check on the stored array, not a JS `Set`.
+    expect(write.text).toContain('@> to_jsonb($1::text)');
+    expect(write.values).toEqual(['notice-a', USER_ID]);
+    // The alert id must never reach the statement text.
+    expect(write.text).not.toContain('notice-a');
+  });
+
+  it('filters the STORED array on removal, and never yields SQL NULL', async () => {
+    await setAlertDismissed(USER_ID, 'notice-a', false);
+
+    const [write] = statements;
+    expect(write.text).toContain('jsonb_array_elements');
+    expect(write.text).toMatch(/WHERE e <> to_jsonb\(\$1::text\)/);
+    // `jsonb_agg` over an empty set returns NULL; without this the last removal would
+    // write a NULL into the key instead of an empty array.
+    expect(write.text).toMatch(/COALESCE\(\(\s*SELECT jsonb_agg/);
+    expect(write.text).toContain(`'[]'::jsonb`);
+    expect(write.values).toEqual(['notice-a', USER_ID]);
+  });
+
+  it('writes through jsonb_set on the dismissedAlerts path only', async () => {
+    await setAlertDismissed(USER_ID, 'notice-a', true);
+
+    const [write] = statements;
+    expect(write.text).toMatch(/jsonb_set\(COALESCE\(settings, '\{\}'::jsonb\), '\{dismissedAlerts\}'/);
   });
 });

--- a/src/server/services/__tests__/set-user-setting.sql.service.test.ts
+++ b/src/server/services/__tests__/set-user-setting.sql.service.test.ts
@@ -270,7 +270,9 @@ describe('patchUserSettings — the nested merge', () => {
     const [write] = statements;
     // The sub-object is read from the column inside the same statement — that is what
     // keeps a sibling sub-key another writer just added.
-    expect(write.text).toMatch(/COALESCE\(settings->\$\d+::text, *'\{\}'::jsonb\) *\|\| *\$\d+::jsonb/);
+    expect(write.text).toMatch(
+      /COALESCE\(settings->\$\d+::text, *'\{\}'::jsonb\) *\|\| *\$\d+::jsonb/
+    );
     expect(write.values).toContainEqual('features');
     expect(write.values).toContainEqual(JSON.stringify({ someFlag: true }));
     // The key name binds; it is never pasted into the text (a settings key is fixed
@@ -325,6 +327,8 @@ describe('setAlertDismissed — the set operation', () => {
     await setAlertDismissed(USER_ID, 'notice-a', true);
 
     const [write] = statements;
-    expect(write.text).toMatch(/jsonb_set\(COALESCE\(settings, '\{\}'::jsonb\), '\{dismissedAlerts\}'/);
+    expect(write.text).toMatch(
+      /jsonb_set\(COALESCE\(settings, '\{\}'::jsonb\), '\{dismissedAlerts\}'/
+    );
   });
 });

--- a/src/server/services/__tests__/user-settings-gallery-copy.behavior.test.ts
+++ b/src/server/services/__tests__/user-settings-gallery-copy.behavior.test.ts
@@ -1,0 +1,174 @@
+import { PGlite } from '@electric-sql/pglite';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import {
+  createGate,
+  createPrismaBridge,
+  createUserSchema,
+  readSettings,
+  seedUser,
+  type Gate,
+} from './user-settings-race.harness';
+
+/**
+ * `copyGallerySettingsToAllModelsByUser` writes `User.settings` from inside an interactive
+ * transaction. It used to replace the WHOLE column from a JS snapshot, and it never busted
+ * the settings cache.
+ *
+ * It lives in its own file because `model.service` needs a much larger set of import-time
+ * stubs than the other settings writers, and pulling those into the shared behaviour file
+ * would change the mock environment every test in it runs under.
+ *
+ * Two mutants survived the battery before this file existed — `mergeInto` -> `set` (the
+ * whole-sub-object replace this change exists to remove) and deleting the cache bust — so
+ * this is regression coverage for both, not decoration.
+ */
+
+const holder = {
+  db: null as unknown as PGlite,
+  gate: null as unknown as Gate,
+  bridge: null as unknown as ReturnType<typeof createPrismaBridge>,
+};
+
+const { settingsCacheBust, metricPrivacyBust, countCacheRefresh } = vi.hoisted(() => ({
+  settingsCacheBust: vi.fn(async () => undefined),
+  metricPrivacyBust: vi.fn(async () => undefined),
+  countCacheRefresh: vi.fn(async () => undefined),
+}));
+
+vi.mock('~/server/utils/cache-helpers', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  createCachedObject: vi.fn((opts: { lookupFn: (ids: number[]) => Promise<unknown> }) => ({
+    fetch: async (ids: number | number[]) =>
+      opts.lookupFn(Array.isArray(ids) ? ids : [ids]) as Promise<Record<string, unknown>>,
+    bust: settingsCacheBust,
+    refresh: async () => undefined,
+    flush: async () => undefined,
+  })),
+}));
+
+vi.mock('~/server/services/creator-membership.service', () => ({
+  bustUserMetricPrivacyDefaultsCache: metricPrivacyBust,
+}));
+
+vi.mock('~/server/redis/caches', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  userModelCountCache: { refresh: countCacheRefresh },
+}));
+
+const { copyGallerySettingsToAllModelsByUser } = await import('~/server/services/model.service');
+
+const USER_ID = 4242;
+
+function installBridge() {
+  const b = holder.bridge;
+  for (const root of [dbMock.dbWrite, dbMock.dbRead]) {
+    root.$queryRaw.mockImplementation(b.$queryRaw);
+    root.$queryRawUnsafe.mockImplementation(b.$queryRawUnsafe);
+    root.$executeRaw.mockImplementation(b.$executeRaw);
+    root.$executeRawUnsafe.mockImplementation(b.$executeRawUnsafe);
+    root.$transaction.mockImplementation(b.$transaction);
+    root.user.findUnique.mockImplementation(b.user.findUnique);
+  }
+  // No models come back, so the per-model cache-key loop is a no-op here; the assertions
+  // are about the USER settings column.
+  dbMock.dbWrite.model.findMany.mockResolvedValue([]);
+}
+
+describe('copyGallerySettingsToAllModelsByUser — merges the settings column, does not replace it', () => {
+  beforeAll(async () => {
+    holder.db = new PGlite();
+    await createUserSchema(holder.db);
+    await holder.db.exec(`
+      CREATE TABLE IF NOT EXISTS "Model" (
+        id               int PRIMARY KEY,
+        "userId"         int NOT NULL,
+        minor            boolean NOT NULL DEFAULT false,
+        "sfwOnly"        boolean NOT NULL DEFAULT false,
+        "gallerySettings" jsonb NOT NULL DEFAULT '{}'::jsonb
+      );
+    `);
+  }, 60_000);
+
+  afterAll(async () => {
+    await holder.db?.close();
+  });
+
+  beforeEach(async () => {
+    holder.gate = createGate();
+    holder.bridge = createPrismaBridge(holder.db, holder.gate);
+    installBridge();
+    settingsCacheBust.mockClear();
+    metricPrivacyBust.mockClear();
+    await holder.db.exec(`TRUNCATE "Model";`);
+  });
+
+  it('keeps unrelated settings keys and merges into gallerySettings', async () => {
+    await seedUser(holder.db, USER_ID, {
+      dismissedAlerts: ['keep-me'],
+      allowAds: true,
+      // A sub-key the copy does not send. The whole-sub-object replace drops it.
+      gallerySettings: { level: 1, users: [7] },
+    });
+
+    await copyGallerySettingsToAllModelsByUser({
+      userId: USER_ID,
+      settings: { level: 31, tags: [99] },
+    });
+
+    const settings = await readSettings(holder.db, USER_ID);
+    // The whole-COLUMN replace lost these.
+    expect(settings.dismissedAlerts).toEqual(['keep-me']);
+    expect(settings.allowAds).toBe(true);
+
+    const gallery = settings.gallerySettings as Record<string, unknown>;
+    // The keys this call sent win …
+    expect(gallery.level).toBe(31);
+    expect(gallery.tags).toEqual([99]);
+    // … and the sibling sub-key it did not send survives. This is what `mergeInto` buys
+    // over `set`, and the only assertion here that separates them.
+    expect(gallery.users).toEqual([7]);
+  });
+
+  it('busts the user-settings cache after the transaction commits', async () => {
+    await seedUser(holder.db, USER_ID, { gallerySettings: { level: 1 } });
+
+    await copyGallerySettingsToAllModelsByUser({
+      userId: USER_ID,
+      settings: { level: 31, users: [], tags: [] },
+    });
+
+    // This writer never busted at all before the change; without the assertion, deleting
+    // the bust leaves the whole suite green.
+    expect(settingsCacheBust).toHaveBeenCalledWith([USER_ID]);
+    expect(countCacheRefresh).toHaveBeenCalledWith(USER_ID);
+  });
+
+  it('still forces the SFW level on a flagged model', async () => {
+    // INVARIANT GUARD: unchanged by this PR, but the model statement sits in the same
+    // transaction as the settings write and must not be disturbed by it.
+    await seedUser(holder.db, USER_ID, {});
+    await holder.db.query(
+      `INSERT INTO "Model" (id, "userId", minor, "sfwOnly", "gallerySettings")
+       VALUES (1, $1, false, false, '{}'::jsonb), (2, $1, true, false, '{}'::jsonb)`,
+      [USER_ID]
+    );
+
+    await copyGallerySettingsToAllModelsByUser({
+      userId: USER_ID,
+      settings: { level: 31, users: [], tags: [] },
+    });
+
+    const rows = await holder.db.query<{ id: number; gallerySettings: { level: unknown } }>(
+      `SELECT id, "gallerySettings" FROM "Model" ORDER BY id`
+    );
+    // Compared as strings: the bridge binds this statement's values untyped, so Postgres
+    // infers `text` and the jsonb holds "31" rather than 31. Prisma sends a typed
+    // parameter, so the stored TYPE here is a harness artifact and is not what this guard
+    // is about — the guard is that the two models get DIFFERENT levels.
+    const level = (i: number) => String(rows.rows[i].gallerySettings.level);
+    expect(level(0)).toBe('31');
+    expect(level(1)).not.toBe('31');
+    expect(level(0)).not.toBe(level(1));
+  });
+});

--- a/src/server/services/__tests__/user-settings-gallery-copy.behavior.test.ts
+++ b/src/server/services/__tests__/user-settings-gallery-copy.behavior.test.ts
@@ -30,11 +30,25 @@ const holder = {
   bridge: null as unknown as ReturnType<typeof createPrismaBridge>,
 };
 
+// Records, for every bust, whether a transaction callback was on the stack at the time.
+const bustsInsideTransaction: string[] = [];
 const { settingsCacheBust, metricPrivacyBust, countCacheRefresh } = vi.hoisted(() => ({
   settingsCacheBust: vi.fn(async () => undefined),
   metricPrivacyBust: vi.fn(async () => undefined),
   countCacheRefresh: vi.fn(async () => undefined),
 }));
+
+/** Arm the WHEN assertion on the spies. Call after each bridge is built. */
+function recordBustTiming() {
+  settingsCacheBust.mockImplementation(async () => {
+    if (holder.bridge?.inTransaction) bustsInsideTransaction.push('settingsCache');
+    return undefined;
+  });
+  countCacheRefresh.mockImplementation(async () => {
+    if (holder.bridge?.inTransaction) bustsInsideTransaction.push('countCache');
+    return undefined;
+  });
+}
 
 vi.mock('~/server/utils/cache-helpers', async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
@@ -98,6 +112,8 @@ describe('copyGallerySettingsToAllModelsByUser — merges the settings column, d
     holder.gate = createGate();
     holder.bridge = createPrismaBridge(holder.db, holder.gate);
     installBridge();
+    bustsInsideTransaction.length = 0;
+    recordBustTiming();
     settingsCacheBust.mockClear();
     metricPrivacyBust.mockClear();
     await holder.db.exec(`TRUNCATE "Model";`);
@@ -142,6 +158,11 @@ describe('copyGallerySettingsToAllModelsByUser — merges the settings column, d
     // the bust leaves the whole suite green.
     expect(settingsCacheBust).toHaveBeenCalledWith([USER_ID]);
     expect(countCacheRefresh).toHaveBeenCalledWith(USER_ID);
+    // WHEN, not just whether: both are Redis and both must land AFTER commit. The
+    // existing assertions above pass just as happily with the calls moved inside the
+    // `$transaction` callback, where they burn the transaction's budget and can be
+    // re-populated from the pre-commit row.
+    expect(bustsInsideTransaction).toEqual([]);
   });
 
   it('still forces the SFW level on a flagged model', async () => {

--- a/src/server/services/__tests__/user-settings-race.behavior.test.ts
+++ b/src/server/services/__tests__/user-settings-race.behavior.test.ts
@@ -51,20 +51,30 @@ function installBridge() {
 
 // The settings cache is Redis-backed with a 4h TTL. Replace it with a pass-through so
 // every read reaches Postgres — a cached read would hide the race behind cache timing
-// instead of measuring it, and a stale cache is a SEPARATE defect (see the PR body).
+// instead of measuring it.
+//
+// `bust` is a SPY, not a no-op: busting is half of the fix. A stale cache is what turns
+// the lost update from a millisecond race into a near-certain loss over the TTL, and two
+// writers previously never busted at all. Without an assertion, deleting any bust call
+// leaves the whole suite green.
+const { settingsCacheBust, metricPrivacyBust } = vi.hoisted(() => ({
+  settingsCacheBust: vi.fn(async () => undefined),
+  metricPrivacyBust: vi.fn(async () => undefined),
+}));
+
 vi.mock('~/server/utils/cache-helpers', async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   createCachedObject: vi.fn((opts: { lookupFn: (ids: number[]) => Promise<unknown> }) => ({
     fetch: async (ids: number | number[]) =>
       opts.lookupFn(Array.isArray(ids) ? ids : [ids]) as Promise<Record<string, unknown>>,
-    bust: async () => undefined,
+    bust: settingsCacheBust,
     refresh: async () => undefined,
     flush: async () => undefined,
   })),
 }));
 
 vi.mock('~/server/services/creator-membership.service', () => ({
-  bustUserMetricPrivacyDefaultsCache: vi.fn(async () => undefined),
+  bustUserMetricPrivacyDefaultsCache: metricPrivacyBust,
 }));
 vi.mock('~/server/auth/session-invalidation', () => ({
   refreshSession: vi.fn(async () => undefined),
@@ -96,7 +106,12 @@ import {
   toggleUserFeatureFlagHandler,
 } from '~/server/controllers/user.controller';
 import { toggleableFeatures } from '~/server/services/feature-flags.service';
-import { updateContentSettings } from '~/server/services/user.service';
+import {
+  patchUserSettings,
+  setUserSetting,
+  updateContentSettings,
+} from '~/server/services/user.service';
+import { updateCreatorShopSettings } from '~/server/services/creator-shop.service';
 
 const USER_ID = 4242;
 const ctx = { user: { id: USER_ID } } as Parameters<typeof dismissAlertHandler>[0]['ctx'];
@@ -148,7 +163,11 @@ describe('User.settings — concurrent writers must not discard each other', () 
   });
 
   it('keeps a dismissal that lands while a content-settings write is in flight', async () => {
-    await seedUser(holder.db, USER_ID, { dismissedAlerts: ['already-dismissed'] });
+    // `allowAds` is seeded FALSE and written TRUE. Seeding it ABSENT (as this fixture
+    // first did) makes "the patch wins" and "the stored column wins" produce byte-identical
+    // output, so the operand order of the shallow merge — the central claim of this change —
+    // would be unpinned. See the dedicated cases in the shallow-merge describe below.
+    await seedUser(holder.db, USER_ID, { dismissedAlerts: ['already-dismissed'], allowAds: false });
 
     // Hold the content-settings UPDATE. Its read has already happened by the time the
     // statement reaches the wire, so the dismissal below runs strictly in between.
@@ -171,7 +190,7 @@ describe('User.settings — concurrent writers must not discard each other', () 
   });
 
   it('keeps a content-settings write that lands while a dismissal is in flight', async () => {
-    await seedUser(holder.db, USER_ID, { dismissedAlerts: [] });
+    await seedUser(holder.db, USER_ID, { dismissedAlerts: [], allowAds: false });
 
     const hold = holder.gate.hold(isAlertWrite);
     const dismiss = dismissAlertHandler({
@@ -389,5 +408,258 @@ describe('User.settings — single-request behaviour the writers must keep', () 
     await restoreAlertHandler({ input: { alertId: 'b' }, ctx });
 
     expect(alerts(await readSettings(holder.db, USER_ID))).toEqual(['a', 'c']);
+  });
+});
+
+/**
+ * The shallow merge's OPERAND ORDER, pinned behaviourally.
+ *
+ * `settings || $patch` and `$patch || settings` are the same shape, the same operator and
+ * the same bound values — the only difference is which side wins for a key present on
+ * both. Every fixture above writes a key the seed did NOT contain, which makes the two
+ * orders byte-identical, so the suite could not see the swap. Inverted, every settings
+ * write silently no-ops for any key the user already holds: strictly worse than the
+ * lost-update bug this change exists to fix, and invisible.
+ *
+ * So these seed a value and CHANGE it. The control is mechanical: feed a stored value the
+ * expected result cannot equal, and watch the output move.
+ */
+describe('User.settings — a patch overrides the stored value, not the other way round', () => {
+  beforeAll(async () => {
+    holder.db = new PGlite();
+    await createUserSchema(holder.db);
+  }, 60_000);
+
+  afterAll(async () => {
+    await holder.db?.close();
+  });
+
+  beforeEach(() => {
+    holder.gate = createGate();
+    holder.bridge = createPrismaBridge(holder.db, holder.gate);
+    installBridge();
+    settingsCacheBust.mockClear();
+    metricPrivacyBust.mockClear();
+  });
+
+  it('overwrites an existing top-level value', async () => {
+    await seedUser(holder.db, USER_ID, { allowAds: false, preferredFiatCurrency: 'EUR' });
+
+    await patchUserSettings(USER_ID, { set: { allowAds: true } });
+
+    const settings = await readSettings(holder.db, USER_ID);
+    expect(settings.allowAds).toBe(true);
+    // …and leaves the key it was not asked about alone.
+    expect(settings.preferredFiatCurrency).toBe('EUR');
+  });
+
+  it('overwrites an existing value through setUserSetting', async () => {
+    // 6 of the 8 writers reach the column through this function.
+    await seedUser(holder.db, USER_ID, { preferredFiatCurrency: 'EUR' });
+
+    await setUserSetting(USER_ID, { preferredFiatCurrency: 'USD' });
+
+    expect((await readSettings(holder.db, USER_ID)).preferredFiatCurrency).toBe('USD');
+  });
+
+  it('overwrites an existing value through the tRPC settings handler', async () => {
+    await seedUser(holder.db, USER_ID, { isEarlyAdopter: true, dismissedAlerts: ['keep-me'] });
+
+    await setUserSettingHandler({ input: { isEarlyAdopter: false }, ctx });
+
+    const settings = await readSettings(holder.db, USER_ID);
+    expect(settings.isEarlyAdopter).toBe(false);
+    expect(alerts(settings)).toEqual(['keep-me']);
+  });
+
+  it('overwrites an existing nested sub-key while keeping its siblings', async () => {
+    await seedUser(holder.db, USER_ID, { tourSettings: { tourA: { completed: true } } });
+
+    await patchUserSettings(USER_ID, {
+      mergeInto: { tourSettings: { tourB: { completed: true } } },
+    });
+    await patchUserSettings(USER_ID, {
+      mergeInto: { tourSettings: { tourA: { completed: false } } },
+    });
+
+    const tour = (await readSettings(holder.db, USER_ID)).tourSettings as Record<
+      string,
+      { completed: boolean }
+    >;
+    expect(tour.tourA.completed).toBe(false);
+    expect(tour.tourB.completed).toBe(true);
+  });
+
+  it('removes a key that currently holds a value', async () => {
+    await seedUser(holder.db, USER_ID, { allowAds: true, preferredFiatCurrency: 'EUR' });
+
+    await setUserSetting(USER_ID, { allowAds: undefined });
+
+    const settings = await readSettings(holder.db, USER_ID);
+    expect(settings).not.toHaveProperty('allowAds');
+    expect(settings.preferredFiatCurrency).toBe('EUR');
+  });
+});
+
+/**
+ * The cache bust is the OTHER half of the fix. `getUserSettings` reads a Redis cache with
+ * a 4h TTL, so a write that lands without a bust is served stale until it expires — and
+ * the next whole-blob writer then persists that stale snapshot. Deleting any bust call
+ * used to leave the entire suite green.
+ */
+describe('User.settings — every write busts the caches that mirror the column', () => {
+  beforeAll(async () => {
+    holder.db = new PGlite();
+    await createUserSchema(holder.db);
+  }, 60_000);
+
+  afterAll(async () => {
+    await holder.db?.close();
+  });
+
+  beforeEach(async () => {
+    holder.gate = createGate();
+    holder.bridge = createPrismaBridge(holder.db, holder.gate);
+    installBridge();
+    settingsCacheBust.mockClear();
+    metricPrivacyBust.mockClear();
+    await seedUser(holder.db, USER_ID, { dismissedAlerts: [], allowAds: false });
+  });
+
+  it('busts after a settings patch', async () => {
+    await patchUserSettings(USER_ID, { set: { allowAds: true } });
+
+    expect(settingsCacheBust).toHaveBeenCalledWith([USER_ID]);
+    // The `hideModel*` metric-privacy flags live in this same blob.
+    expect(metricPrivacyBust).toHaveBeenCalledWith(USER_ID);
+  });
+
+  it('busts after a notice dismissal', async () => {
+    await dismissAlertHandler({ input: { alertId: 'notice-a', dismiss: true }, ctx });
+
+    expect(settingsCacheBust).toHaveBeenCalledWith([USER_ID]);
+    expect(metricPrivacyBust).toHaveBeenCalledWith(USER_ID);
+  });
+
+  it('busts after the creator-shop settings write', async () => {
+    // This writer never busted at all before this change.
+    await updateCreatorShopSettings({ userId: USER_ID, showModels: true });
+
+    expect(settingsCacheBust).toHaveBeenCalledWith([USER_ID]);
+  });
+
+  it('does NOT bust from inside a caller transaction — the caller busts after commit', async () => {
+    // Redis inside an interactive transaction burns the transaction's budget, and a bust
+    // before commit can be re-populated with the pre-commit row.
+    await patchUserSettings(USER_ID, { set: { allowAds: true } }, holder.bridge);
+
+    expect(settingsCacheBust).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The two transactional writers. Both used to replace the WHOLE settings column from a JS
+ * snapshot; both are now a nested merge. Neither had any test — sequential or concurrent —
+ * so `mergeInto` -> `set` at either site, or `patchUserSettings` ignoring its `tx`
+ * argument, survived the whole suite.
+ */
+describe('User.settings — the transactional writers merge rather than replace', () => {
+  beforeAll(async () => {
+    holder.db = new PGlite();
+    await createUserSchema(holder.db);
+  }, 60_000);
+
+  afterAll(async () => {
+    await holder.db?.close();
+  });
+
+  beforeEach(() => {
+    holder.gate = createGate();
+    holder.bridge = createPrismaBridge(holder.db, holder.gate);
+    installBridge();
+    settingsCacheBust.mockClear();
+  });
+
+  it('keeps unrelated settings keys when the creator shop is updated', async () => {
+    await seedUser(holder.db, USER_ID, {
+      dismissedAlerts: ['keep-me'],
+      allowAds: true,
+      creatorShop: { enabled: true, showModels: false },
+    });
+
+    await updateCreatorShopSettings({ userId: USER_ID, showModels: true });
+
+    const settings = await readSettings(holder.db, USER_ID);
+    // The whole-column replace lost these.
+    expect(alerts(settings)).toEqual(['keep-me']);
+    expect(settings.allowAds).toBe(true);
+    // The sub-object is MERGED, so a sibling field set by another request survives …
+    const shop = settings.creatorShop as Record<string, unknown>;
+    expect(shop.enabled).toBe(true);
+    // … and the field this request changed wins.
+    expect(shop.showModels).toBe(true);
+  });
+
+  it('returns the stored creator-shop settings for an empty patch without writing', async () => {
+    await seedUser(holder.db, USER_ID, { creatorShop: { enabled: true, showModels: true } });
+
+    const result = await updateCreatorShopSettings({ userId: USER_ID });
+
+    expect(result).toMatchObject({ enabled: true, showModels: true });
+    expect(holder.gate.statements.some((sql) => sql.includes('UPDATE'))).toBe(false);
+  });
+
+  it('runs the settings write on the CALLER transaction client, not the global one', async () => {
+    await seedUser(holder.db, USER_ID, { allowAds: false });
+    // A tx client that records what it was asked to run. If `patchUserSettings` ignored
+    // its `tx` argument the write would leave the caller's transaction entirely — it would
+    // still land, so only an assertion on WHICH client ran it can see the difference.
+    const seen: string[] = [];
+    const txSpy = {
+      $queryRawUnsafe: async (sql: string, ...values: unknown[]) => {
+        seen.push(sql);
+        return holder.bridge.$queryRawUnsafe(sql, ...values) as Promise<
+          { settings: Record<string, unknown> | null }[]
+        >;
+      },
+    };
+
+    await patchUserSettings(USER_ID, { set: { allowAds: true } }, txSpy as never);
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toContain('UPDATE "User"');
+    expect((await readSettings(holder.db, USER_ID)).allowAds).toBe(true);
+  });
+
+  it('reads the row inside the transaction for an empty patch, never the Redis cache', async () => {
+    // `getUserSettings` is Redis-backed. Reaching it from inside an interactive transaction
+    // spends the transaction's wall-clock budget (Prisma default 5s) on a cache round trip,
+    // and returns a blob that can be hours stale.
+    await seedUser(holder.db, USER_ID, { allowAds: true });
+    const seen: string[] = [];
+    const txSpy = {
+      $queryRawUnsafe: async (sql: string, ...values: unknown[]) => {
+        seen.push(sql);
+        return holder.bridge.$queryRawUnsafe(sql, ...values) as Promise<
+          { settings: Record<string, unknown> | null }[]
+        >;
+      },
+    };
+
+    const result = await patchUserSettings(
+      USER_ID,
+      { mergeInto: { creatorShop: {} } },
+      txSpy as never
+    );
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toContain('SELECT settings FROM "User"');
+    expect(seen[0]).not.toContain('UPDATE');
+    expect(result.allowAds).toBe(true);
+  });
+
+  it('raises rather than silently succeeding when the user does not exist', async () => {
+    await expect(patchUserSettings(999_999, { set: { allowAds: true } })).rejects.toThrow();
+    await expect(patchUserSettings(999_999, {})).rejects.toThrow();
   });
 });

--- a/src/server/services/__tests__/user-settings-race.behavior.test.ts
+++ b/src/server/services/__tests__/user-settings-race.behavior.test.ts
@@ -1,0 +1,390 @@
+import { PGlite } from '@electric-sql/pglite';
+import { beforeAll, afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import {
+  createGate,
+  createPrismaBridge,
+  createUserSchema,
+  readSettings,
+  seedUser,
+  type Gate,
+} from './user-settings-race.harness';
+
+/**
+ * Lost-update tests for the `User.settings` JSON column.
+ *
+ * `settings` holds independent concerns — notice dismissals, feature toggles,
+ * content preferences, tour progress — behind a single column. Every writer used
+ * to read the blob into JS, compute a new object and write that object back, so
+ * two writers overlapping meant the later write restored every key the earlier
+ * one had just changed.
+ *
+ * Each test below drives the REAL handler/service against a real Postgres and
+ * suspends one statement at the wire so the other request runs strictly between
+ * the first request's read and its write. See the harness header for what this
+ * does and does not model.
+ */
+
+// `~/server/db/client` is mocked canonically in src/__tests__/setup.ts (a per-file
+// `vi.mock` of it freezes that shape into every later file in the same worker — see
+// no-direct-shared-module-mock.test.ts). So the PGlite bridge is installed as BEHAVIOUR on
+// the canonical node's stable spies rather than by replacing the module.
+const holder = {
+  db: null as unknown as PGlite,
+  gate: null as unknown as Gate,
+  bridge: null as unknown as ReturnType<typeof createPrismaBridge>,
+};
+
+/** Point every raw/model method the settings writers use at the PGlite bridge. */
+function installBridge() {
+  const b = holder.bridge;
+  for (const root of [dbMock.dbWrite, dbMock.dbRead]) {
+    root.$queryRaw.mockImplementation(b.$queryRaw);
+    root.$queryRawUnsafe.mockImplementation(b.$queryRawUnsafe);
+    root.$executeRaw.mockImplementation(b.$executeRaw);
+    root.$executeRawUnsafe.mockImplementation(b.$executeRawUnsafe);
+    root.$transaction.mockImplementation(b.$transaction);
+    root.user.findUnique.mockImplementation(b.user.findUnique);
+    root.user.update.mockImplementation(b.user.update);
+  }
+}
+
+// The settings cache is Redis-backed with a 4h TTL. Replace it with a pass-through so
+// every read reaches Postgres — a cached read would hide the race behind cache timing
+// instead of measuring it, and a stale cache is a SEPARATE defect (see the PR body).
+vi.mock('~/server/utils/cache-helpers', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  createCachedObject: vi.fn((opts: { lookupFn: (ids: number[]) => Promise<unknown> }) => ({
+    fetch: async (ids: number | number[]) =>
+      opts.lookupFn(Array.isArray(ids) ? ids : [ids]) as Promise<Record<string, unknown>>,
+    bust: async () => undefined,
+    refresh: async () => undefined,
+    flush: async () => undefined,
+  })),
+}));
+
+vi.mock('~/server/services/creator-membership.service', () => ({
+  bustUserMetricPrivacyDefaultsCache: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/auth/session-invalidation', () => ({
+  refreshSession: vi.fn(async () => undefined),
+  invalidateSession: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/metrics', () => ({
+  articleMetrics: { queueUpdate: vi.fn() },
+  imageMetrics: { queueUpdate: vi.fn() },
+  modelMetrics: { queueUpdate: vi.fn() },
+  postMetrics: { queueUpdate: vi.fn() },
+  userMetrics: { queueUpdate: vi.fn() },
+}));
+vi.mock('~/server/services/user-preferences.service', () => ({
+  HiddenModels: { refreshCache: vi.fn(async () => undefined) },
+  HiddenModels3D: { refreshCache: vi.fn(async () => undefined) },
+  HiddenUsers: { refreshCache: vi.fn(async () => undefined) },
+  HiddenImages: { refreshCache: vi.fn(async () => undefined) },
+  HiddenTags: { refreshCache: vi.fn(async () => undefined) },
+  BlockedUsers: { refreshCache: vi.fn(async () => undefined), getCached: vi.fn(async () => []) },
+  BlockedByUsers: { refreshCache: vi.fn(async () => undefined) },
+  ImplicitHiddenImages: { refreshCache: vi.fn(async () => undefined) },
+  toggleHidden: vi.fn(async () => ({ added: [], removed: [] })),
+}));
+
+import {
+  dismissAlertHandler,
+  restoreAlertHandler,
+  setUserSettingHandler,
+  toggleUserFeatureFlagHandler,
+} from '~/server/controllers/user.controller';
+import { toggleableFeatures } from '~/server/services/feature-flags.service';
+import { updateContentSettings } from '~/server/services/user.service';
+
+const USER_ID = 4242;
+const ctx = { user: { id: USER_ID } } as Parameters<typeof dismissAlertHandler>[0]['ctx'];
+
+// The whole-blob settings write, in both the pre-fix and post-fix statement shapes:
+// `UPDATE "User" SET settings = …` WITHOUT `jsonb_set`, which is what distinguishes it
+// from the dismissed-alerts write. Matching a shape both revisions emit is deliberate —
+// the same test then means the same thing on either side of the fix.
+const isSettingsWrite = (sql: string) =>
+  /UPDATE\s+"User"\s+SET\s+settings/.test(sql) && !sql.includes('jsonb_set');
+const isAlertWrite = (sql: string) => sql.includes('jsonb_set');
+// Any write to the column, whichever statement shape the revision under test emits.
+// The restore path changed shape in this fix (whole-blob merge → set operation), so a
+// shape-specific matcher would miss it on one side and fail for a harness reason
+// instead of on the data.
+const isAnySettingsWrite = (sql: string) => /UPDATE\s+"User"\s+SET\s+settings/.test(sql);
+
+const alerts = (s: Record<string, unknown>) => (s.dismissedAlerts ?? []) as string[];
+
+/**
+ * Wait for the held statement to arrive, but surface a request that FAILED or that
+ * finished without ever emitting a matching statement. Awaiting `hold.reached` alone
+ * turns either of those into a 60s timeout, which reads as "the race test is flaky"
+ * rather than naming the harness or handler fault that actually occurred.
+ */
+async function reach(hold: { reached: Promise<void> }, inflight: Promise<unknown>) {
+  await Promise.race([
+    hold.reached,
+    inflight.then(() => {
+      throw new Error('in-flight request finished without its write reaching the gate');
+    }),
+  ]);
+}
+
+describe('User.settings — concurrent writers must not discard each other', () => {
+  beforeAll(async () => {
+    holder.db = new PGlite();
+    await createUserSchema(holder.db);
+  }, 60_000);
+
+  afterAll(async () => {
+    await holder.db?.close();
+  });
+
+  beforeEach(() => {
+    holder.gate = createGate();
+    holder.bridge = createPrismaBridge(holder.db, holder.gate);
+    installBridge();
+  });
+
+  it('keeps a dismissal that lands while a content-settings write is in flight', async () => {
+    await seedUser(holder.db, USER_ID, { dismissedAlerts: ['already-dismissed'] });
+
+    // Hold the content-settings UPDATE. Its read has already happened by the time the
+    // statement reaches the wire, so the dismissal below runs strictly in between.
+    const hold = holder.gate.hold(isSettingsWrite);
+    const settingsWrite = updateContentSettings({ userId: USER_ID, allowAds: true });
+    await reach(hold, settingsWrite);
+
+    await dismissAlertHandler({ input: { alertId: 'notice-b', dismiss: true }, ctx });
+
+    hold.release();
+    await settingsWrite;
+
+    const settings = await readSettings(holder.db, USER_ID);
+    // Pre-fix: the content-settings write carried the whole read snapshot, so
+    // `dismissedAlerts` went back to what it was before `notice-b` was dismissed and
+    // the notice reappeared for the user.
+    expect(alerts(settings)).toEqual(expect.arrayContaining(['already-dismissed', 'notice-b']));
+    // …and the setting the other request was actually making must still be there.
+    expect(settings.allowAds).toBe(true);
+  });
+
+  it('keeps a content-settings write that lands while a dismissal is in flight', async () => {
+    await seedUser(holder.db, USER_ID, { dismissedAlerts: [] });
+
+    const hold = holder.gate.hold(isAlertWrite);
+    const dismiss = dismissAlertHandler({
+      input: { alertId: 'notice-c', dismiss: true },
+      ctx,
+    });
+    await reach(hold, dismiss);
+
+    await updateContentSettings({ userId: USER_ID, allowAds: true });
+
+    hold.release();
+    await dismiss;
+
+    const settings = await readSettings(holder.db, USER_ID);
+    expect(alerts(settings)).toContain('notice-c');
+    // The dismissal writes only its own key, so the other request's setting survives on
+    // both revisions. This half is an INVARIANT GUARD, not regression coverage — it
+    // pins that the narrow write stays narrow.
+    expect(settings.allowAds).toBe(true);
+  });
+
+  it('keeps both of two dismissals that overlap', async () => {
+    await seedUser(holder.db, USER_ID, { dismissedAlerts: [] });
+
+    const hold = holder.gate.hold(isAlertWrite);
+    const first = dismissAlertHandler({ input: { alertId: 'notice-x', dismiss: true }, ctx });
+    await reach(hold, first);
+
+    await dismissAlertHandler({ input: { alertId: 'notice-y', dismiss: true }, ctx });
+
+    hold.release();
+    await first;
+
+    const settings = await readSettings(holder.db, USER_ID);
+    // Pre-fix: the first request computed its array from a snapshot taken before
+    // `notice-y` existed and wrote that array wholesale, so `notice-y` was erased.
+    expect(alerts(settings).sort()).toEqual(['notice-x', 'notice-y']);
+  });
+
+  it('keeps a dismissal that overlaps a restore of a different notice', async () => {
+    await seedUser(holder.db, USER_ID, { dismissedAlerts: ['notice-p', 'notice-q'] });
+
+    const hold = holder.gate.hold(isAnySettingsWrite);
+    const restore = restoreAlertHandler({ input: { alertId: 'notice-p' }, ctx });
+    await reach(hold, restore);
+
+    await dismissAlertHandler({ input: { alertId: 'notice-r', dismiss: true }, ctx });
+
+    hold.release();
+    await restore;
+
+    const settings = await readSettings(holder.db, USER_ID);
+    expect(alerts(settings).sort()).toEqual(['notice-q', 'notice-r']);
+  });
+
+  it('keeps a dismissal that lands while user.setSettings is in flight', async () => {
+    // Seeded NON-EMPTY on purpose. `setUserSetting` ran its payload through `removeEmpty`,
+    // which drops an empty array — so a user with no prior dismissals could not show this
+    // loss at all, and an empty fixture would pass on the pre-fix code for a reason that
+    // has nothing to do with the fix.
+    await seedUser(holder.db, USER_ID, { dismissedAlerts: ['already-dismissed'] });
+
+    // The collision that made this reachable in normal use: `isEarlyAdopter` is written
+    // through `user.setSettings`, which read and rewrote the whole blob.
+    const hold = holder.gate.hold(isSettingsWrite);
+    const setSettings = setUserSettingHandler({ input: { isEarlyAdopter: true }, ctx });
+    await reach(hold, setSettings);
+
+    await dismissAlertHandler({ input: { alertId: 'notice-z', dismiss: true }, ctx });
+
+    hold.release();
+    await setSettings;
+
+    const settings = await readSettings(holder.db, USER_ID);
+    expect(alerts(settings).sort()).toEqual(['already-dismissed', 'notice-z']);
+    expect(settings.isEarlyAdopter).toBe(true);
+  });
+
+  it('keeps a dismissal that lands while a feature toggle is in flight', async () => {
+    // Read the key from the registry rather than naming one, so retiring a flag cannot
+    // silently turn this into a test of nothing.
+    const feature = toggleableFeatures[0].key;
+    await seedUser(holder.db, USER_ID, {
+      dismissedAlerts: ['already-dismissed'],
+      features: { [feature]: false },
+    });
+
+    const hold = holder.gate.hold(isSettingsWrite);
+    const toggle = toggleUserFeatureFlagHandler({ input: { feature, value: true }, ctx });
+    await reach(hold, toggle);
+
+    await dismissAlertHandler({ input: { alertId: 'notice-w', dismiss: true }, ctx });
+
+    hold.release();
+    await toggle;
+
+    const settings = await readSettings(holder.db, USER_ID);
+    expect(alerts(settings).sort()).toEqual(['already-dismissed', 'notice-w']);
+    expect((settings.features as Record<string, boolean>)[feature]).toBe(true);
+  });
+
+  it('keeps a feature toggle that lands while another feature toggle is in flight', async () => {
+    const [a, b] = toggleableFeatures;
+    if (!b) return; // registry has a single toggleable flag; nothing to interleave
+    await seedUser(holder.db, USER_ID, { features: { [a.key]: false, [b.key]: false } });
+
+    const hold = holder.gate.hold(isSettingsWrite);
+    const first = toggleUserFeatureFlagHandler({ input: { feature: a.key, value: true }, ctx });
+    await reach(hold, first);
+
+    await toggleUserFeatureFlagHandler({ input: { feature: b.key, value: true }, ctx });
+
+    hold.release();
+    await first;
+
+    const features = (await readSettings(holder.db, USER_ID)).features as Record<string, boolean>;
+    expect(features[a.key]).toBe(true);
+    expect(features[b.key]).toBe(true);
+  });
+});
+
+describe('User.settings — single-request behaviour the writers must keep', () => {
+  beforeAll(async () => {
+    holder.db = new PGlite();
+    await createUserSchema(holder.db);
+  }, 60_000);
+
+  afterAll(async () => {
+    await holder.db?.close();
+  });
+
+  beforeEach(() => {
+    holder.gate = createGate();
+    holder.bridge = createPrismaBridge(holder.db, holder.gate);
+    installBridge();
+  });
+
+  it('restores the LAST remaining dismissal', async () => {
+    await seedUser(holder.db, USER_ID, { dismissedAlerts: ['only-one'], allowAds: true });
+
+    await restoreAlertHandler({ input: { alertId: 'only-one' }, ctx });
+
+    const settings = await readSettings(holder.db, USER_ID);
+    // Pre-fix this wrote NOTHING: the handler passed `{ dismissedAlerts: [] }` through
+    // the whole-blob merge, whose `removeEmpty` drops an empty array, leaving an empty
+    // payload and an early return. The notice stayed hidden forever.
+    expect(alerts(settings)).toEqual([]);
+    expect(settings.allowAds).toBe(true);
+  });
+
+  // INVARIANT GUARD (green on the pre-change code too): the JS `new Set` deduped as well.
+  // It pins that moving the dedupe into SQL kept the property.
+  it('is idempotent — dismissing the same notice twice stores it once', async () => {
+    await seedUser(holder.db, USER_ID, { dismissedAlerts: [] });
+
+    await dismissAlertHandler({ input: { alertId: 'notice-d', dismiss: true }, ctx });
+    await dismissAlertHandler({ input: { alertId: 'notice-d', dismiss: true }, ctx });
+
+    expect(alerts(await readSettings(holder.db, USER_ID))).toEqual(['notice-d']);
+  });
+
+  // `dismissAlert({ dismiss: false })` is how the product actually un-dismisses a notice —
+  // `user.restoreAlert` has no caller in this repo. Without these two cases a handler that
+  // ignored `input.dismiss` and always dismissed passed the whole suite (mutation M16).
+  it('un-dismisses through dismissAlert({ dismiss: false })', async () => {
+    await seedUser(holder.db, USER_ID, { dismissedAlerts: ['notice-g', 'notice-h'] });
+
+    await dismissAlertHandler({ input: { alertId: 'notice-g', dismiss: false }, ctx });
+
+    expect(alerts(await readSettings(holder.db, USER_ID))).toEqual(['notice-h']);
+  });
+
+  it('un-dismisses the LAST remaining notice through dismissAlert({ dismiss: false })', async () => {
+    await seedUser(holder.db, USER_ID, { dismissedAlerts: ['only-one'], allowAds: true });
+
+    await dismissAlertHandler({ input: { alertId: 'only-one', dismiss: false }, ctx });
+
+    const settings = await readSettings(holder.db, USER_ID);
+    expect(alerts(settings)).toEqual([]);
+    expect(settings.allowAds).toBe(true);
+  });
+
+  // INVARIANT GUARD (green on the pre-change code too). `COALESCE(settings, '{}')` is easy
+  // to drop when rewriting the statement, and a NULL column is the default for a new user.
+  it('dismisses onto a NULL settings column', async () => {
+    await holder.db.query(`INSERT INTO "User" (id, settings) VALUES ($1, NULL)
+                           ON CONFLICT (id) DO UPDATE SET settings = NULL`, [USER_ID]);
+
+    await dismissAlertHandler({ input: { alertId: 'notice-e', dismiss: true }, ctx });
+
+    expect(alerts(await readSettings(holder.db, USER_ID))).toEqual(['notice-e']);
+  });
+
+  it('self-heals a dismissedAlerts value that is not an array', async () => {
+    // Nothing enforces a shape on a JSON column. `jsonb_array_elements` raises on a
+    // non-array, so without the type guard one malformed row would 500 forever.
+    await seedUser(holder.db, USER_ID, { dismissedAlerts: 'corrupt' as unknown as string[] });
+
+    await dismissAlertHandler({ input: { alertId: 'notice-f', dismiss: true }, ctx });
+    expect(alerts(await readSettings(holder.db, USER_ID))).toEqual(['notice-f']);
+
+    await seedUser(holder.db, USER_ID, { dismissedAlerts: 'corrupt' as unknown as string[] });
+    await restoreAlertHandler({ input: { alertId: 'notice-f' }, ctx });
+    expect(alerts(await readSettings(holder.db, USER_ID))).toEqual([]);
+  });
+
+  // INVARIANT GUARD (green on the pre-change code too): pins that the SQL filter removes
+  // exactly the named id, matching the JS `.filter()` it replaced.
+  it('leaves unrelated notices alone when one is restored', async () => {
+    await seedUser(holder.db, USER_ID, { dismissedAlerts: ['a', 'b', 'c'] });
+
+    await restoreAlertHandler({ input: { alertId: 'b' }, ctx });
+
+    expect(alerts(await readSettings(holder.db, USER_ID))).toEqual(['a', 'c']);
+  });
+});

--- a/src/server/services/__tests__/user-settings-race.behavior.test.ts
+++ b/src/server/services/__tests__/user-settings-race.behavior.test.ts
@@ -357,8 +357,11 @@ describe('User.settings — single-request behaviour the writers must keep', () 
   // INVARIANT GUARD (green on the pre-change code too). `COALESCE(settings, '{}')` is easy
   // to drop when rewriting the statement, and a NULL column is the default for a new user.
   it('dismisses onto a NULL settings column', async () => {
-    await holder.db.query(`INSERT INTO "User" (id, settings) VALUES ($1, NULL)
-                           ON CONFLICT (id) DO UPDATE SET settings = NULL`, [USER_ID]);
+    await holder.db.query(
+      `INSERT INTO "User" (id, settings) VALUES ($1, NULL)
+                           ON CONFLICT (id) DO UPDATE SET settings = NULL`,
+      [USER_ID]
+    );
 
     await dismissAlertHandler({ input: { alertId: 'notice-e', dismiss: true }, ctx });
 

--- a/src/server/services/__tests__/user-settings-race.behavior.test.ts
+++ b/src/server/services/__tests__/user-settings-race.behavior.test.ts
@@ -57,10 +57,25 @@ function installBridge() {
 // the lost update from a millisecond race into a near-certain loss over the TTL, and two
 // writers previously never busted at all. Without an assertion, deleting any bust call
 // leaves the whole suite green.
+// Records, for every bust, whether a transaction callback was on the stack at the time.
+// `bustsInsideTransaction` is the WHEN half — see the harness's `inTransaction`.
+const bustsInsideTransaction: string[] = [];
 const { settingsCacheBust, metricPrivacyBust } = vi.hoisted(() => ({
   settingsCacheBust: vi.fn(async () => undefined),
   metricPrivacyBust: vi.fn(async () => undefined),
 }));
+
+/** Arm the WHEN assertion on the spies. Call after each bridge is built. */
+function recordBustTiming() {
+  settingsCacheBust.mockImplementation(async () => {
+    if (holder.bridge?.inTransaction) bustsInsideTransaction.push('settingsCache');
+    return undefined;
+  });
+  metricPrivacyBust.mockImplementation(async () => {
+    if (holder.bridge?.inTransaction) bustsInsideTransaction.push('metricPrivacy');
+    return undefined;
+  });
+}
 
 vi.mock('~/server/utils/cache-helpers', async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
@@ -160,6 +175,8 @@ describe('User.settings — concurrent writers must not discard each other', () 
     holder.gate = createGate();
     holder.bridge = createPrismaBridge(holder.db, holder.gate);
     installBridge();
+    bustsInsideTransaction.length = 0;
+    recordBustTiming();
   });
 
   it('keeps a dismissal that lands while a content-settings write is in flight', async () => {
@@ -326,6 +343,8 @@ describe('User.settings — single-request behaviour the writers must keep', () 
     holder.gate = createGate();
     holder.bridge = createPrismaBridge(holder.db, holder.gate);
     installBridge();
+    bustsInsideTransaction.length = 0;
+    recordBustTiming();
   });
 
   it('restores the LAST remaining dismissal', async () => {
@@ -438,6 +457,8 @@ describe('User.settings — a patch overrides the stored value, not the other wa
     holder.gate = createGate();
     holder.bridge = createPrismaBridge(holder.db, holder.gate);
     installBridge();
+    bustsInsideTransaction.length = 0;
+    recordBustTiming();
     settingsCacheBust.mockClear();
     metricPrivacyBust.mockClear();
   });
@@ -521,6 +542,8 @@ describe('User.settings — every write busts the caches that mirror the column'
     holder.gate = createGate();
     holder.bridge = createPrismaBridge(holder.db, holder.gate);
     installBridge();
+    bustsInsideTransaction.length = 0;
+    recordBustTiming();
     settingsCacheBust.mockClear();
     metricPrivacyBust.mockClear();
     await seedUser(holder.db, USER_ID, { dismissedAlerts: [], allowAds: false });
@@ -546,6 +569,19 @@ describe('User.settings — every write busts the caches that mirror the column'
     await updateCreatorShopSettings({ userId: USER_ID, showModels: true });
 
     expect(settingsCacheBust).toHaveBeenCalledWith([USER_ID]);
+  });
+
+  it('busts the creator-shop write AFTER the transaction commits, not inside it', async () => {
+    // WHEN, not just whether. Redis inside an interactive transaction spends the
+    // transaction's wall-clock budget (Prisma's default is 5s), and a bust that lands
+    // before commit can be re-populated by a concurrent reader from the pre-commit row —
+    // leaving the cache stale for the full TTL, which is the very failure this bust
+    // exists to prevent. Moving the call into the `$transaction` callback leaves every
+    // other assertion in this file green.
+    await updateCreatorShopSettings({ userId: USER_ID, showModels: true });
+
+    expect(settingsCacheBust).toHaveBeenCalledWith([USER_ID]);
+    expect(bustsInsideTransaction).toEqual([]);
   });
 
   it('does NOT bust from inside a caller transaction — the caller busts after commit', async () => {
@@ -577,6 +613,8 @@ describe('User.settings — the transactional writers merge rather than replace'
     holder.gate = createGate();
     holder.bridge = createPrismaBridge(holder.db, holder.gate);
     installBridge();
+    bustsInsideTransaction.length = 0;
+    recordBustTiming();
     settingsCacheBust.mockClear();
   });
 

--- a/src/server/services/__tests__/user-settings-race.harness.ts
+++ b/src/server/services/__tests__/user-settings-race.harness.ts
@@ -1,4 +1,6 @@
-import { PGlite } from '@electric-sql/pglite';
+// Type-only: this module never constructs a PGlite, it only takes one. The behaviour
+// test owns the instance.
+import type { PGlite } from '@electric-sql/pglite';
 
 /**
  * Harness for the `User.settings` lost-update tests.
@@ -38,7 +40,8 @@ export type Gate = {
 };
 
 export function createGate(): Gate {
-  const pending: { match: (sql: string) => boolean; arrive: () => void; gate: Promise<void> }[] = [];
+  const pending: { match: (sql: string) => boolean; arrive: () => void; gate: Promise<void> }[] =
+    [];
   const statements: string[] = [];
 
   const gate: Gate = {

--- a/src/server/services/__tests__/user-settings-race.harness.ts
+++ b/src/server/services/__tests__/user-settings-race.harness.ts
@@ -119,6 +119,14 @@ export function createPrismaBridge(db: PGlite, gate: Gate) {
     return result.rows as unknown[];
   };
 
+  // Is a `$transaction` callback currently on the stack? Exposed so a test can assert
+  // WHEN something happened, not just whether. A cache bust is correct after commit and
+  // wrong inside the callback — it spends the interactive-transaction budget on a Redis
+  // round trip, and a bust that lands before commit can be re-populated from the
+  // pre-commit row. Asserting only "bust was called with this key" cannot tell those
+  // apart, so moving the call inside the callback leaves such a suite green.
+  const state = { transactionDepth: 0 };
+
   const client = {
     $queryRaw: async (strings: TemplateStringsArray, ...values: unknown[]) => {
       const { sql, params } = fromTemplate(strings, values);
@@ -135,8 +143,21 @@ export function createPrismaBridge(db: PGlite, gate: Gate) {
       return 1;
     },
     // Interactive transactions run against the same single connection; the callback
-    // gets the same client so a nested raw statement still reaches PGlite.
-    $transaction: async <T>(fn: (tx: unknown) => Promise<T>): Promise<T> => fn(client),
+    // gets the same client so a nested raw statement still reaches PGlite. The depth
+    // counter is raised for exactly the callback's lifetime — `finally`, so a callback
+    // that throws cannot leave it stuck open and silently disarm the assertion.
+    $transaction: async <T>(fn: (tx: unknown) => Promise<T>): Promise<T> => {
+      state.transactionDepth += 1;
+      try {
+        return await fn(client);
+      } finally {
+        state.transactionDepth -= 1;
+      }
+    },
+    /** True while a `$transaction` callback is executing. */
+    get inTransaction() {
+      return state.transactionDepth > 0;
+    },
     user: {
       findUnique: async ({ where }: { where: { id: number } }) => {
         const rows = await run(`SELECT id, settings FROM "User" WHERE id = $1`, [where.id]);

--- a/src/server/services/__tests__/user-settings-race.harness.ts
+++ b/src/server/services/__tests__/user-settings-race.harness.ts
@@ -1,0 +1,185 @@
+import { PGlite } from '@electric-sql/pglite';
+
+/**
+ * Harness for the `User.settings` lost-update tests.
+ *
+ * `settings` is one JSON column with many independent writers. The failure mode
+ * under test is not "does a write land" — it is "does writer A's edit survive
+ * writer B running at the same time". Asserting that from a single sequential
+ * call is impossible, and a hand-written fake of `jsonb ||` / `jsonb_set` would
+ * only re-encode whatever the test author believed those operators do. So the
+ * statements the services emit run UNMODIFIED against an in-process Postgres
+ * (PGlite, Postgres compiled to WASM), and the interleaving is produced by
+ * holding one statement at the wire while another request completes.
+ *
+ * SCOPE, stated plainly: PGlite is a single connection, so what these tests
+ * exercise is STATEMENT interleaving between two logical requests — request B's
+ * whole read-compute-write cycle running strictly between request A's read and
+ * request A's write. That is exactly the shape of the reported bug, and it is
+ * what distinguishes a read-modify-write in JS from an expression evaluated over
+ * the stored column. It is NOT a test of multi-connection MVCC: nothing here
+ * exercises row locks, snapshot isolation, or Postgres' re-evaluation of a SET
+ * expression against a concurrently-updated tuple. Those are asserted by
+ * construction (single-statement writes), not by measurement.
+ */
+
+/** A one-shot hold on the next statement whose text matches. */
+export type Hold = {
+  /** Resolves once the matching statement has ARRIVED and is being held. */
+  reached: Promise<void>;
+  /** Lets the held statement proceed. */
+  release: () => void;
+};
+
+export type Gate = {
+  hold: (match: (sql: string) => boolean) => Hold;
+  /** Every statement the bridge has executed, in order. */
+  statements: string[];
+};
+
+export function createGate(): Gate {
+  const pending: { match: (sql: string) => boolean; arrive: () => void; gate: Promise<void> }[] = [];
+  const statements: string[] = [];
+
+  const gate: Gate = {
+    statements,
+    hold(match) {
+      let release!: () => void;
+      let arrive!: () => void;
+      const gatePromise = new Promise<void>((r) => (release = r));
+      const reached = new Promise<void>((r) => (arrive = r));
+      pending.push({ match, arrive, gate: gatePromise });
+      return { reached, release };
+    },
+  };
+
+  // Consumed by the bridge below.
+  (gate as Gate & { __await: (sql: string) => Promise<void> }).__await = async (sql: string) => {
+    statements.push(sql);
+    const idx = pending.findIndex((p) => p.match(sql));
+    if (idx === -1) return;
+    const [held] = pending.splice(idx, 1);
+    held.arrive();
+    await held.gate;
+  };
+
+  return gate;
+}
+
+/**
+ * A `Prisma.Sql` fragment — what `Prisma.join(ids)` returns. It can appear as an
+ * interpolated VALUE inside a tagged template, where it contributes statement TEXT
+ * rather than a single bound parameter. Binding it as a parameter instead produces
+ * `invalid input syntax for type integer: "[object Object]"`, so the bridge has to
+ * recurse into it.
+ */
+function isSqlFragment(v: unknown): v is { strings: string[]; values: unknown[] } {
+  return (
+    !!v &&
+    typeof v === 'object' &&
+    Array.isArray((v as { strings?: unknown }).strings) &&
+    Array.isArray((v as { values?: unknown }).values)
+  );
+}
+
+/** Stitch a Prisma tagged-template call back into `$1,$2,…` parameterised SQL. */
+function fromTemplate(strings: readonly string[], values: unknown[]) {
+  const params: unknown[] = [];
+  const bind = (v: unknown) => `$${params.push(v)}`;
+
+  const walk = (frags: readonly string[], vals: unknown[]): string => {
+    let sql = '';
+    for (let i = 0; i < frags.length; i++) {
+      sql += frags[i];
+      if (i < vals.length) {
+        const v = vals[i];
+        sql += isSqlFragment(v) ? walk(v.strings, v.values) : bind(v);
+      }
+    }
+    return sql;
+  };
+
+  return { sql: walk(strings, values), params };
+}
+
+/**
+ * A stand-in for the Prisma client that speaks all four raw shapes the settings
+ * writers use, routed to PGlite. Every statement passes the gate first, so a
+ * test can suspend one mid-flight.
+ */
+export function createPrismaBridge(db: PGlite, gate: Gate) {
+  const wait = (gate as Gate & { __await: (sql: string) => Promise<void> }).__await;
+
+  const run = async (sql: string, values: unknown[]) => {
+    await wait(sql);
+    const result = await db.query(sql, values);
+    return result.rows as unknown[];
+  };
+
+  const client = {
+    $queryRaw: async (strings: TemplateStringsArray, ...values: unknown[]) => {
+      const { sql, params } = fromTemplate(strings, values);
+      return run(sql, params);
+    },
+    $queryRawUnsafe: async (sql: string, ...values: unknown[]) => run(sql, values),
+    $executeRaw: async (strings: TemplateStringsArray, ...values: unknown[]) => {
+      const { sql, params } = fromTemplate(strings, values);
+      await run(sql, params);
+      return 1;
+    },
+    $executeRawUnsafe: async (sql: string, ...values: unknown[]) => {
+      await run(sql, values);
+      return 1;
+    },
+    // Interactive transactions run against the same single connection; the callback
+    // gets the same client so a nested raw statement still reaches PGlite.
+    $transaction: async <T>(fn: (tx: unknown) => Promise<T>): Promise<T> => fn(client),
+    user: {
+      findUnique: async ({ where }: { where: { id: number } }) => {
+        const rows = await run(`SELECT id, settings FROM "User" WHERE id = $1`, [where.id]);
+        return (rows[0] as unknown) ?? null;
+      },
+      update: async ({ where, data }: { where: { id: number }; data: { settings?: unknown } }) => {
+        // Only the settings-column shape is needed here; a caller writing anything else
+        // must fail loudly rather than silently no-op.
+        if (!('settings' in data))
+          throw new Error('bridge: user.update called with no settings payload');
+        await run(`UPDATE "User" SET settings = $1::jsonb WHERE id = $2`, [
+          JSON.stringify(data.settings),
+          where.id,
+        ]);
+        return { id: where.id };
+      },
+    },
+  };
+
+  return client;
+}
+
+export async function createUserSchema(db: PGlite) {
+  await db.exec(`
+    CREATE TABLE IF NOT EXISTS "User" (
+      id             int PRIMARY KEY,
+      settings       jsonb DEFAULT '{}'::jsonb,
+      "showNsfw"     boolean NOT NULL DEFAULT false,
+      "blurNsfw"     boolean NOT NULL DEFAULT true,
+      "autoplayGifs" boolean
+    );
+  `);
+}
+
+export async function seedUser(db: PGlite, id: number, settings: Record<string, unknown>) {
+  await db.query(
+    `INSERT INTO "User" (id, settings) VALUES ($1, $2::jsonb)
+     ON CONFLICT (id) DO UPDATE SET settings = EXCLUDED.settings`,
+    [id, JSON.stringify(settings)]
+  );
+}
+
+export async function readSettings(db: PGlite, id: number): Promise<Record<string, unknown>> {
+  const r = await db.query<{ settings: Record<string, unknown> | null }>(
+    `SELECT settings FROM "User" WHERE id = $1`,
+    [id]
+  );
+  return r.rows[0]?.settings ?? {};
+}

--- a/src/server/services/creator-membership.service.ts
+++ b/src/server/services/creator-membership.service.ts
@@ -174,9 +174,13 @@ export type UserMetricPrivacyDefaults = {
  *
  * Derived from an audit of every writer of the `User.settings` JSONB column, since that
  * is the only thing this cache derives from. The three `hideModel*` booleans are
- * written by exactly ONE path — `setUserSetting`, reached from the account
- * Creator-Controls toggles — and that path busts this key in the same call. The writers
- * that touch `settings` WITHOUT going through `setUserSetting` do not move these flags:
+ * written by exactly ONE caller path — the account Creator-Controls toggles
+ * (`CreatorControlsCard`) → `user.setSettings` → `setUserSettingHandler` →
+ * `patchUserSettings` — and that path busts this key in the same call, via
+ * `bustUserSettings`. (It reaches `patchUserSettings` DIRECTLY, not through
+ * `setUserSetting`; an earlier revision of this paragraph named `setUserSetting` as the
+ * writer, which stopped being true when the settings writers were consolidated.) The
+ * writers that touch `settings` on other paths do not move these flags:
  * `setAlertDismissed` is a `jsonb_set` scoped to the `{dismissedAlerts}` path, and
  * `updateCreatorShopSettings` / `copyGallerySettingsToAllModelsByUser`
  * (`model.service.ts`) each merge only their own key (`creatorShop` /

--- a/src/server/services/creator-membership.service.ts
+++ b/src/server/services/creator-membership.service.ts
@@ -175,21 +175,22 @@ export type UserMetricPrivacyDefaults = {
  * Derived from an audit of every writer of the `User.settings` JSONB column, since that
  * is the only thing this cache derives from. The three `hideModel*` booleans are
  * written by exactly ONE path — `setUserSetting`, reached from the account
- * Creator-Controls toggles — and that path busts this key in the same call. The THREE
- * writers that touch `settings` WITHOUT going through `setUserSetting` do not move
- * these flags: `setDismissedAlerts` uses a `jsonb_set` scoped to the
- * `{dismissedAlerts}` path; `updateCreatorShopSettings` and
- * `copyGallerySettingsToAllModelsByUser` (`model.service.ts`) each read-merge-write the
- * blob from a fresh in-transaction row read, overriding only their own key
- * (`creatorShop` / `gallerySettings` respectively).
+ * Creator-Controls toggles — and that path busts this key in the same call. The writers
+ * that touch `settings` WITHOUT going through `setUserSetting` do not move these flags:
+ * `setAlertDismissed` is a `jsonb_set` scoped to the `{dismissedAlerts}` path, and
+ * `updateCreatorShopSettings` / `copyGallerySettingsToAllModelsByUser`
+ * (`model.service.ts`) each merge only their own key (`creatorShop` /
+ * `gallerySettings`).
  *
- * One caveat on those last two, so nobody reads this as a stronger guarantee than it
- * is: both are whole-blob read-modify-writes at READ COMMITTED with no `FOR UPDATE`,
- * so a `setUserSetting` landing between their read and their update is silently
- * reverted. That is a lost update on the ROW, not a stale cache — no TTL at any value
- * helps, because the cache would then be faithfully reporting a wrong row. It is a
- * real pre-existing bug and deliberately out of scope here; it just means the correct
- * claim is "cannot move these flags absent a lost-update race", not "provably cannot".
+ * 🔴 The lost-update caveat this paragraph used to carry is RESOLVED, and the resolution
+ * is what the numbers below now rest on. Those writers were whole-blob read-modify-writes
+ * at READ COMMITTED with no `FOR UPDATE`, so a `setUserSetting` landing between their read
+ * and their update was silently reverted — a lost update on the ROW that no TTL could
+ * help, because the cache would then be faithfully reporting a wrong row. Every writer is
+ * now a single statement computed over the stored column (`patchUserSettings` /
+ * `setAlertDismissed` in `user.service.ts`), so the claim is no longer hedged: these
+ * writers cannot move the `hideModel*` flags. Both also bust this key now, where the two
+ * transactional ones previously did not bust it at all.
  *
  * So the TTL is NOT bounding a bypassing writer. What it bounds is two ways a CORRECT
  * write can still leave a wrong value cached, and in both the TTL is the only thing
@@ -356,8 +357,9 @@ export async function getUserMetricPrivacyDefaultsMap(userIds: number[]) {
 
 /**
  * Bust the cached metric-privacy defaults for one or more users. Wired into
- * `setUserSetting`, which is the ONLY path that writes the `hideModel*` flags, so a
- * change to a user's defaults takes effect on the next read.
+ * `bustUserSettings` (`user.service.ts`), which every settings writer calls, so a change
+ * to a user's defaults takes effect on the next read. `setUserSetting` remains the only
+ * path that WRITES the `hideModel*` flags; the others bust because they share the blob.
  *
  * 🔴 This is best-effort by design — it swallows Redis errors so a cache problem can
  * never fail the user's settings mutation. That makes it a non-guaranteed invalidation,

--- a/src/server/services/creator-shop.service.ts
+++ b/src/server/services/creator-shop.service.ts
@@ -85,6 +85,7 @@ const packDisplayMeta = (meta: CosmeticShopItemMeta | null) => ({
   ...(meta?.packMemberCount ? { packMemberCount: meta.packMemberCount } : {}),
 });
 import type { UserSettingsSchema } from '~/server/schema/user.schema';
+import { bustUserSettings, patchUserSettings } from '~/server/services/user.service';
 import {
   STICKER_DEFAULT_USES,
   STICKER_MIN_BUZZ_PER_USE,
@@ -2368,8 +2369,11 @@ export const updateCreatorShopSettings = async ({
   userId,
   ...patch
 }: UpdateCreatorShopSettingsInput & { userId: number }) => {
-  // Read-merge-write the JSON blob so we only touch the creatorShop key.
-  return dbWrite.$transaction(async (tx) => {
+  // The merge happens in Postgres, over the stored column. Reading the blob into JS
+  // and writing the whole object back replaced every other settings key with the value
+  // it held at read time, discarding any write that landed in between (a notice
+  // dismissal, a feature toggle, a content preference).
+  const settings = await dbWrite.$transaction(async (tx) => {
     if (patch.enabled === true) {
       // Don't let a creator publish an empty shop — there'd be nothing to show.
       const itemCount = await tx.cosmeticShopItem.count({ where: { addedById: userId } });
@@ -2377,13 +2381,11 @@ export const updateCreatorShopSettings = async ({
         throw throwBadRequestError('Add at least one item to your shop before publishing.');
     }
 
-    const user = await tx.user.findUnique({ where: { id: userId }, select: { settings: true } });
-    const settings = (user?.settings ?? {}) as UserSettingsSchema;
-    const creatorShop: CreatorShopSettings = { ...(settings.creatorShop ?? {}), ...patch };
-    await tx.user.update({
-      where: { id: userId },
-      data: { settings: { ...settings, creatorShop } as Prisma.InputJsonValue },
-    });
-    return creatorShop;
+    return patchUserSettings(userId, { mergeInto: { creatorShop: patch } }, tx);
   });
+
+  // After commit — the settings cache is Redis, and it was never busted here at all,
+  // so `getUserSettings` served a pre-shop blob for up to its 4h TTL.
+  await bustUserSettings(userId);
+  return (settings.creatorShop ?? {}) as CreatorShopSettings;
 };

--- a/src/server/services/creator-shop.service.ts
+++ b/src/server/services/creator-shop.service.ts
@@ -2381,6 +2381,10 @@ export const updateCreatorShopSettings = async ({
         throw throwBadRequestError('Add at least one item to your shop before publishing.');
     }
 
+    // Every field of the input is optional, so `patch` can be empty. `patchUserSettings`
+    // then writes nothing and returns the row read inside this transaction — the same
+    // value the old read-merge-write returned for an empty patch, and deliberately not
+    // the Redis-cached blob, which can be hours old.
     return patchUserSettings(userId, { mergeInto: { creatorShop: patch } }, tx);
   });
 

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -77,7 +77,6 @@ import type {
 } from '~/server/schema/model.schema';
 import { ingestModelSchema } from '~/server/schema/model.schema';
 import { isNotTag, isTag } from '~/server/schema/tag.schema';
-import type { UserSettingsSchema } from '~/server/schema/user.schema';
 import {
   collectionsSearchIndex,
   imagesMetricsSearchIndex,
@@ -124,9 +123,11 @@ import { trackModActivity } from '~/server/services/moderator.service';
 import { getHighestTierSubscription } from '~/server/services/subscriptions.service';
 import { getCategoryTags } from '~/server/services/system-cache';
 import {
+  bustUserSettings,
   deleteBasicDataForUser,
   getCosmeticsForUsers,
   getProfilePicturesForUsers,
+  patchUserSettings,
 } from '~/server/services/user.service';
 import { bustFetchThroughCache, fetchThroughCache } from '~/server/utils/cache-helpers';
 import { limitConcurrency } from '~/server/utils/concurrency-helpers';
@@ -199,7 +200,6 @@ import type {
 import { Flags } from '~/shared/utils/flags';
 import { isGenerationDisabled } from '~/shared/constants/model-version-flags.constants';
 import { isDev } from '~/env/other';
-import { userUpdateCounter } from '~/server/prom/client';
 import { pgDbRead } from '~/server/db/pgDb';
 
 export const getModel = async <TSelect extends Prisma.ModelSelect>({
@@ -3938,19 +3938,14 @@ export async function copyGallerySettingsToAllModelsByUser({
     const user = await tx.user.findUnique({ where: { id: userId }, select: { settings: true } });
     if (!user) throw throwNotFoundError(`No user with id ${userId}`);
 
-    const userSettings = user.settings as UserSettingsSchema;
-
-    await tx.user.update({
-      where: { id: userId },
-      data: {
-        settings: {
-          ...userSettings,
-          gallerySettings: { ...userSettings.gallerySettings, ...settings },
-        },
-      },
-    });
-
-    userUpdateCounter?.inc({ location: 'model.service:updateGallerySettings' });
+    // Merge in Postgres, over the stored column. Writing the whole blob back from a JS
+    // snapshot replaced every other settings key with its read-time value, discarding
+    // anything that landed in between.
+    await patchUserSettings(
+      userId,
+      { mergeInto: { gallerySettings: settings }, location: 'model.service:updateGallerySettings' },
+      tx
+    );
 
     // Flagged models keep the SFW level a moderator forced on them — otherwise one
     // "copy to all my models" re-opens every model the user has ever had flagged.
@@ -3968,8 +3963,11 @@ export async function copyGallerySettingsToAllModelsByUser({
     `;
   });
 
-  // Count-cache refresh hits Redis — run after commit, off the txn budget.
-  await userModelCountCache.refresh(userId);
+  // Count-cache refresh hits Redis — run after commit, off the txn budget. Same for the
+  // user-settings cache, which this path never busted at all: `getUserSettings` went on
+  // serving pre-copy gallery defaults for up to its 4h TTL, and the next whole-blob
+  // writer then persisted that stale snapshot.
+  await Promise.all([userModelCountCache.refresh(userId), bustUserSettings(userId)]);
 
   const models = await dbWrite.model.findMany({ where: { userId }, select: { id: true } });
   const modelIds = models.map((x) => x.id);

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -2900,9 +2900,13 @@ export async function setUserSetting(userId: number, settings: UserSettingsInput
  */
 export async function setAlertDismissed(userId: number, alertId: string, dismissed: boolean) {
   // `settings->'dismissedAlerts'` is read inside the statement, so nothing about the
-  // array is carried through JS. Add is idempotent (`@>` containment guard) and remove
-  // preserves the surviving elements' order (`WITH ORDINALITY`); `jsonb_agg` over an
-  // empty set yields NULL, hence the COALESCE to an empty array.
+  // array is carried through JS. Add is idempotent (`@>` containment guard); `jsonb_agg`
+  // over an empty set yields NULL, hence the COALESCE to an empty array.
+  //
+  // `WITH ORDINALITY` + `ORDER BY ord` makes the surviving elements' order explicit rather
+  // than incidental. Nothing DEPENDS on that order — `dismissedAlerts` is read as a set
+  // (membership tests only) — and no test pins it, so treat this as intent, not a
+  // guarantee: dropping the `ORDER BY` is very likely an equivalent mutant.
   //
   // The `jsonb_typeof` test is not paranoia about our own writers — nothing enforces a
   // shape on a JSON column, and `jsonb_array_elements` raises on a non-array, which

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -2621,12 +2621,15 @@ export async function updateContentSettings({
     await userSettingsCache().bust([userId]);
   }
   if (Object.keys(data).length > 0 || (domain === 'red' && browsingLevel !== undefined)) {
-    const settings = await getUserSettings(userId);
-    if (domain === 'red' && browsingLevel !== undefined) {
-      settings.redBrowsingLevel = browsingLevel;
-    }
-
-    await setUserSetting(userId, { ...settings, ...removeEmpty(data) });
+    // Only the keys this call is changing. Re-reading the blob and writing it back
+    // would restore every other key to the value it held at read time, discarding a
+    // concurrent write to any of them (notice dismissals, feature toggles, …).
+    await setUserSetting(userId, {
+      ...removeEmpty(data),
+      ...(domain === 'red' && browsingLevel !== undefined
+        ? { redBrowsingLevel: browsingLevel }
+        : {}),
+    });
   }
   // Await so the refresh marker is set in Redis before this mutation returns.
   // Otherwise the fire-and-forget can race the next API call / session read
@@ -2734,48 +2737,164 @@ export async function getUserContentSettings(id: number): Promise<UserContentSet
   return rest;
 }
 
-export async function setUserSetting(userId: number, settings: UserSettingsInput) {
-  const toSet = removeEmpty(settings);
-  const keys = Object.keys(toSet);
-  if (!keys.length) return;
+/**
+ * The one place `User.settings` is written.
+ *
+ * `settings` is a single JSON column with many independent writers (content
+ * prefs, feature toggles, tour progress, notice dismissals, creator shop,
+ * gallery defaults). Every one of them used to read the blob into JS, compute a
+ * new object, and write that object back. Two such writers overlapping lose one
+ * of the two edits: the second writer's snapshot was taken before the first
+ * writer's commit, so writing it back restores the pre-edit value of every key
+ * it happens to carry — including keys it was never asked to change.
+ *
+ * The cure is structural rather than temporal: never send a value that was read
+ * in JS. Each op below compiles to an expression over the *current* column, so
+ * the read and the write are one statement and there is no JS-side window at
+ * all. Under READ COMMITTED, Postgres re-evaluates a SET expression against the
+ * updated row when a concurrent transaction has just written it, so two
+ * overlapping patches compose instead of clobbering.
+ *
+ * Ops (all optional, all applied in one statement, in this order):
+ *  - `set`       — replace these top-level keys outright.
+ *  - `mergeInto` — merge one level INTO these top-level object keys, so a
+ *                  sibling sub-key another writer added survives.
+ *  - `remove`    — delete these top-level keys.
+ *
+ * Values are bound as parameters, never spliced into the statement text —
+ * `JSON.stringify` escapes `"` and `\` but not `'`, so a setting value holding
+ * an apostrophe would otherwise close the literal early.
+ *
+ * Pass `tx` to run inside a caller's transaction; the caller then owns the
+ * cache bust, which must happen after commit (Redis I/O inside a transaction
+ * burns the transaction's wall-clock budget).
+ */
+export type UserSettingsPatch = {
+  set?: Record<string, unknown>;
+  mergeInto?: Record<string, Record<string, unknown>>;
+  remove?: string[];
+  /** `userUpdateCounter` label, so consolidating the writers does not collapse the
+   *  per-call-site attribution the metric already carried. */
+  location?: string;
+};
 
-  // Parameterised: the payload is bound, not spliced into a string literal.
-  // `JSON.stringify` escapes `"` and `\` but not `'`, so a setting value holding an
-  // apostrophe used to close the literal early and corrupt the statement.
-  await dbWrite.$executeRaw`
-      UPDATE "User"
-      SET settings = COALESCE(settings, '{}'::jsonb) || ${JSON.stringify(toSet)}::jsonb
-      WHERE id = ${userId}
-    `;
-  userUpdateCounter?.inc({ location: 'user.service:setUserSetting:set' });
+type RawClient = Pick<typeof dbWrite, '$queryRawUnsafe'>;
 
-  const toRemove = Object.entries(settings)
-    .filter(([, value]) => value === undefined)
-    .map(([key]) => key);
-  if (toRemove.length) {
-    // `jsonb - text[]` drops every listed key in one go, so the key names bind as a
-    // single array. The previous form hand-quoted them into a chain of `- 'key'`
-    // and emitted a trailing `}`, which made the statement unparseable.
-    await dbWrite.$executeRaw`
-      UPDATE "User"
-      SET settings = settings - ${toRemove}::text[]
-      WHERE id = ${userId}
-    `;
-    userUpdateCounter?.inc({ location: 'user.service:setUserSetting:remove' });
+export async function patchUserSettings(
+  userId: number,
+  patch: UserSettingsPatch,
+  tx?: RawClient
+): Promise<UserSettingsSchema> {
+  const set = patch.set && Object.keys(patch.set).length ? patch.set : undefined;
+  const mergeInto = Object.entries(patch.mergeInto ?? {}).filter(
+    ([, value]) => value && Object.keys(value).length
+  );
+  const remove = patch.remove?.length ? patch.remove : undefined;
+  if (!set && !mergeInto.length && !remove) return getUserSettings(userId);
+
+  const values: unknown[] = [];
+  // Returns the `$N` placeholder for a newly bound value.
+  const bind = (value: unknown) => `$${values.push(value)}`;
+
+  let expr = `COALESCE(settings, '{}'::jsonb)`;
+  if (set) expr = `(${expr} || ${bind(JSON.stringify(set))}::jsonb)`;
+  for (const [key, value] of mergeInto) {
+    // `settings->$key` reads the CURRENT column inside the same statement — that is
+    // what makes the nested merge atomic rather than a read-modify-write.
+    const k = bind(key);
+    expr =
+      `(${expr} || jsonb_build_object(${k}::text, ` +
+      `COALESCE(settings->${k}::text, '{}'::jsonb) || ${bind(JSON.stringify(value))}::jsonb))`;
   }
+  // `jsonb - text[]` drops every listed key in one go, so the names bind as one array.
+  if (remove) expr = `(${expr} - ${bind(remove)}::text[])`;
 
+  const client = tx ?? dbWrite;
+  const rows = await client.$queryRawUnsafe<{ settings: UserSettingsSchema | null }[]>(
+    `UPDATE "User" SET settings = ${expr} WHERE id = ${bind(userId)} RETURNING settings`,
+    ...values
+  );
+  userUpdateCounter?.inc({ location: patch.location ?? 'user.service:patchUserSettings' });
+
+  if (!tx) await bustUserSettings(userId);
+  return rows[0]?.settings ?? {};
+}
+
+/** Drop every per-user cache that mirrors the settings blob. */
+export async function bustUserSettings(userId: number) {
   await userSettingsCache().bust([userId]);
   // Keep the read-time metric-privacy defaults cache consistent with a settings write
   // (the `hideModel*` flags live in `settings`); TTL backstops any other writer.
   await bustUserMetricPrivacyDefaultsCache(userId);
 }
 
-export async function setDismissedAlerts(userId: number, alertIds: string[]) {
-  await dbWrite.$executeRawUnsafe(
-    `UPDATE "User" SET settings = jsonb_set(COALESCE(settings, '{}'), '{dismissedAlerts}', $1::jsonb) WHERE id = $2`,
-    JSON.stringify(alertIds),
+/**
+ * Split a caller-supplied settings object into the keys to write and the keys to
+ * delete. An explicit `undefined` marks a key for removal — the tRPC transformer
+ * carries that over the wire and zod keeps the key, so `user.setSettings` really
+ * can ask for one. Single source of this rule: every settings write goes through
+ * it, so the two halves cannot drift apart at one call site.
+ */
+export function splitSettingsPatch(settings: UserSettingsInput): UserSettingsPatch {
+  return {
+    set: removeEmpty(settings),
+    remove: Object.entries(settings)
+      .filter(([, value]) => value === undefined)
+      .map(([key]) => key),
+  };
+}
+
+/**
+ * Shallow set/remove of top-level settings keys. A key whose value is
+ * `undefined` is deleted; everything else is written as given.
+ */
+export async function setUserSetting(userId: number, settings: UserSettingsInput) {
+  return patchUserSettings(userId, {
+    ...splitSettingsPatch(settings),
+    // Was two statements with two labels (`:set` and `:remove`); it is one statement now,
+    // so it reports one.
+    location: 'user.service:setUserSetting:set',
+  });
+}
+
+/**
+ * Add or drop one id in `settings.dismissedAlerts`, as a set operation on the
+ * stored array rather than a whole-array rewrite. Two dismissals of *different*
+ * notices can now overlap without either being lost — which the previous
+ * read-the-array-in-JS-and-write-it-back form could not survive.
+ */
+export async function setAlertDismissed(userId: number, alertId: string, dismissed: boolean) {
+  // `settings->'dismissedAlerts'` is read inside the statement, so nothing about the
+  // array is carried through JS. Add is idempotent (`@>` containment guard) and remove
+  // preserves the surviving elements' order (`WITH ORDINALITY`); `jsonb_agg` over an
+  // empty set yields NULL, hence the COALESCE to an empty array.
+  //
+  // The `jsonb_typeof` test is not paranoia about our own writers — nothing enforces a
+  // shape on a JSON column, and `jsonb_array_elements` raises on a non-array, which
+  // would turn one malformed row into a permanent 500 on every dismissal for that user.
+  // Treating a non-array as empty self-heals it on the next write, which is what the
+  // whole-array rewrite used to do implicitly.
+  const current = `CASE WHEN jsonb_typeof(settings->'dismissedAlerts') = 'array'
+                        THEN settings->'dismissedAlerts' ELSE '[]'::jsonb END`;
+  const next = dismissed
+    ? `CASE WHEN ${current} @> to_jsonb($1::text) THEN ${current}
+            ELSE ${current} || jsonb_build_array($1::text) END`
+    : `COALESCE((
+         SELECT jsonb_agg(e ORDER BY ord)
+         FROM jsonb_array_elements(${current}) WITH ORDINALITY AS t(e, ord)
+         WHERE e <> to_jsonb($1::text)
+       ), '[]'::jsonb)`;
+
+  const rows = await dbWrite.$queryRawUnsafe<{ settings: UserSettingsSchema | null }[]>(
+    `UPDATE "User"
+     SET settings = jsonb_set(COALESCE(settings, '{}'::jsonb), '{dismissedAlerts}', ${next})
+     WHERE id = $2
+     RETURNING settings`,
+    alertId,
     userId
   );
-  await userSettingsCache().bust([userId]);
+  userUpdateCounter?.inc({ location: 'user.service:setAlertDismissed' });
+  await bustUserSettings(userId);
+  return rows[0]?.settings?.dismissedAlerts ?? [];
 }
 // #endregion

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -2712,9 +2712,14 @@ function userSettingsCache() {
 }
 
 /**
- * JSON-settings-only view. Used by internal callers (e.g. setUserSetting) that
- * need to read the JSON blob and write it back without polluting it with the
- * User-column fields.
+ * JSON-settings-only view, without the User-column fields.
+ *
+ * 🔴 Redis-backed (4h TTL) and READ-ONLY as far as writers are concerned. No caller may
+ * read this and write the result back — that read-modify-write is the lost-update bug
+ * `patchUserSettings` exists to remove, and the cache makes its window the TTL rather
+ * than a few milliseconds. Read it to DECIDE something (a toggle's next value, whether a
+ * value changed); never to build a write payload. Do not call it inside a transaction
+ * either: it is a Redis round trip on the transaction's clock.
  */
 export async function getUserSettings(id: number): Promise<UserSettingsSchema> {
   const result = await userSettingsCache().fetch([id]);
@@ -2756,10 +2761,18 @@ export async function getUserContentSettings(id: number): Promise<UserContentSet
  * overlapping patches compose instead of clobbering.
  *
  * Ops (all optional, all applied in one statement, in this order):
- *  - `set`       — replace these top-level keys outright.
+ *  - `set`       — replace these top-level keys outright. The patch WINS over the
+ *                  stored value; that is the whole point, so the operand order of
+ *                  the `||` below is load-bearing rather than stylistic.
  *  - `mergeInto` — merge one level INTO these top-level object keys, so a
  *                  sibling sub-key another writer added survives.
  *  - `remove`    — delete these top-level keys.
+ *
+ * 🔴 `set` and `mergeInto` do NOT compose on the SAME top-level key. `mergeInto`
+ * reads `settings->key` — the STORED column — not the partially-built expression,
+ * so passing one key to both ops makes `mergeInto` merge onto the pre-`set` value
+ * and win. No caller does this today; if one ever needs to, make `mergeInto` read
+ * from the accumulated expression instead of the column.
  *
  * Values are bound as parameters, never spliced into the statement text —
  * `JSON.stringify` escapes `"` and `\` but not `'`, so a setting value holding
@@ -2790,7 +2803,26 @@ export async function patchUserSettings(
     ([, value]) => value && Object.keys(value).length
   );
   const remove = patch.remove?.length ? patch.remove : undefined;
-  if (!set && !mergeInto.length && !remove) return getUserSettings(userId);
+
+  const client = tx ?? dbWrite;
+
+  // Nothing to write, but the contract is still "the settings this user now has".
+  // Read the ROW, never the cache: `getUserSettings` is Redis-backed, and both `tx`
+  // callers reach this branch with an empty patch — `updateCreatorShopSettings` when
+  // every field of its all-optional input is omitted, and the gallery copy when the
+  // model already carries default gallery settings. A Redis round trip there would
+  // burn the caller's interactive-transaction budget (Prisma's default is 5s), and
+  // the repo's `no-io-in-transaction` lint rule is a call-name denylist that cannot
+  // see it. Reading the row also keeps the return value consistent with the write
+  // path below, which returns `RETURNING settings` rather than a cached blob.
+  if (!set && !mergeInto.length && !remove) {
+    const current = await client.$queryRawUnsafe<{ settings: UserSettingsSchema | null }[]>(
+      `SELECT settings FROM "User" WHERE id = $1`,
+      userId
+    );
+    if (!current.length) throw throwNotFoundError(`No user with id ${userId}`);
+    return current[0]?.settings ?? {};
+  }
 
   const values: unknown[] = [];
   // Returns the `$N` placeholder for a newly bound value.
@@ -2809,11 +2841,14 @@ export async function patchUserSettings(
   // `jsonb - text[]` drops every listed key in one go, so the names bind as one array.
   if (remove) expr = `(${expr} - ${bind(remove)}::text[])`;
 
-  const client = tx ?? dbWrite;
   const rows = await client.$queryRawUnsafe<{ settings: UserSettingsSchema | null }[]>(
     `UPDATE "User" SET settings = ${expr} WHERE id = ${bind(userId)} RETURNING settings`,
     ...values
   );
+  // A raw UPDATE matching no row is a silent no-op, where the `user.update` this
+  // replaced raised Prisma P2025. A moderator acting on a deleted user must not get
+  // a success back.
+  if (!rows.length) throw throwNotFoundError(`No user with id ${userId}`);
   userUpdateCounter?.inc({ location: patch.location ?? 'user.service:patchUserSettings' });
 
   if (!tx) await bustUserSettings(userId);


### PR DESCRIPTION
## The race, precisely

`User.settings` is a single JSON column shared by unrelated concerns — notice dismissals, feature toggles, content preferences, tour progress, creator-shop settings, gallery defaults. Before this PR every writer read the blob into JS, computed a new object, and wrote that object back. Two writers overlapping means the later write restores every key the earlier one had just changed, including keys it was never asked to touch.

**How this was established:** by *executing* it, not by reading. `src/server/services/__tests__/user-settings-race.behavior.test.ts` drives the real handlers against a real Postgres (PGlite, the engine already used by `listForModel.behavior.test.ts`) and suspends one statement at the wire so a second request runs strictly between the first request's read and its write. Eight of its cases fail on `origin/main`. The description below is the measured behaviour.

Interleavings that **lose data** on `main` (A reads → B completes → A writes):

| A (suspended between read and write) | B (completes in the gap) | lost |
|---|---|---|
| `user.setSettings` (e.g. `isEarlyAdopter`) | `dismissAlert` | the dismissal |
| `updateContentSettings` | `dismissAlert` | the dismissal |
| `user.toggleFeature` | `dismissAlert` | the dismissal |
| `user.toggleFeature` (flag X) | `user.toggleFeature` (flag Y) | flag Y |
| `dismissAlert` (notice X) | `dismissAlert` (notice Y) | notice Y |
| `restoreAlert` | `dismissAlert` | the dismissal |
| `updateCreatorShopSettings` / `copyGallerySettingsToAllModelsByUser` | any settings write | everything the other write touched |

Interleaving that does **not** lose data on `main`: `dismissAlert` suspended while a settings write completes. `setDismissedAlerts` was a `jsonb_set` on one path, so it never carried other keys. That asymmetry is why the bug presents as "my dismissed notice came back" rather than "my settings reverted".

One narrowing worth stating, because it decides whether a fixture can see the bug at all: `setUserSetting` ran its payload through `removeEmpty`, which drops an **empty array**. A user with no prior dismissals therefore could not lose one this way. The loss needs a non-empty `dismissedAlerts` — which is the normal state for anyone who has used the site. Two of the tests below were initially seeded empty and passed on `main` for exactly this reason; the fixtures were corrected.

**Corrections to the premise I was given.** `setUserSetting` was already an atomic `settings || $patch` merge at the database — the read-modify-write was in its *callers*, which spread the whole read snapshot into the patch. Because `||` is a shallow merge of whatever it is handed, spreading the snapshot has the same effect as a whole-object replace for every top-level key. So the defect is real and the described symptom is real, but the fix belongs at the call sites, not (only) in the service.

**Two questions asked, both answered NO:**

- **Does `refreshSession` widen the window?** No. It runs *after* the write, and it busts the settings cache (`clearSessionCache` deletes the per-user settings key), which shortens subsequent staleness rather than lengthening the write window.
- **Does `featureAccessKey`'s 10s memo interact?** No. It keys on `SessionUser.isEarlyAdopter`, a projection carried on the session, and never reads the settings blob. It is a staleness concern for the flag, unrelated to the lost update.

**What genuinely does widen it** is the settings cache: `getUserSettings` reads through a Redis cache with a 4h TTL, and two writers (`updateCreatorShopSettings`, `copyGallerySettingsToAllModelsByUser`) wrote the column without busting it. After either, the cached blob was stale for up to 4h, and the next whole-blob writer persisted that stale snapshot — turning a millisecond race into a near-certain loss. Both now bust the cache after commit.

## Every writer of `User.settings`

**Population and how it was enumerated** — the column is written in exactly two ways, so both were enumerated exhaustively rather than sampled:

1. **Raw SQL.** `grep -rnaE 'SET +settings|settings *=.*jsonb|jsonb_set\(COALESCE\(settings'` across `src`, `apps`, `packages`, `scripts`.
2. **Prisma.** Every `.user.(update|updateMany|upsert|create|createMany)(` call site in `src`, `apps`, `packages`, `scripts` (34 call sites, 13 files), each expanded and filtered for a `settings` key in its `data`.

Both searches covered the whole monorepo, not just `src/server`. Result — 8 writers:

| # | Writer | Was | Now |
|---|---|---|---|
| 1 | `setUserSetting` (service) | atomic `settings \|\| $patch`, **plus a second statement** for key removal, and an early return that skipped the removal when every supplied key was a removal | one statement, set + remove together |
| 2 | `setDismissedAlerts` (service) | `jsonb_set` of a **JS-computed whole array** | replaced by `setAlertDismissed`, a set op on the stored array |
| 3 | `setUserSettingHandler` | read blob → spread into payload | sends only the changed keys; `tourSettings` merged one level deep |
| 4 | `toggleUserFeatureFlagHandler` | read blob → spread into payload | sends only the toggled flag, merged into `settings.features` |
| 5 | `updateContentSettings` | read blob → spread into payload | sends only the changed keys; the read is gone entirely |
| 6 | `restoreAlertHandler` | whole-blob merge path | `setAlertDismissed` |
| 7 | `updateCreatorShopSettings` | `tx.user.update` replacing the **whole column**, no cache bust | nested merge in SQL + cache bust after commit |
| 8 | `copyGallerySettingsToAllModelsByUser` | `tx.user.update` replacing the **whole column**, no cache bust | nested merge in SQL + cache bust after commit |

Out of scope and unchanged: `scripts/oneoffs/backfill-cosmetic-resale-listings.ts`, a one-off backfill that already writes a single `jsonb_set` statement.

## The fix, and why this one

**Deterministic at the database.** Every write is now one statement whose `SET` expression is computed over the *current* column, so there is no JS-side read-modify-write window at all:

```sql
-- patchUserSettings: shallow set + nested merge + key removal, in one statement
UPDATE "User" SET settings = (
  (COALESCE(settings, '{}'::jsonb) || $1::jsonb)
  || jsonb_build_object($2::text, COALESCE(settings->$2::text, '{}'::jsonb) || $3::jsonb)
) - $4::text[]
WHERE id = $5 RETURNING settings
```

```sql
-- setAlertDismissed: a set operation on the stored array
UPDATE "User" SET settings = jsonb_set(COALESCE(settings, '{}'::jsonb), '{dismissedAlerts}',
  CASE WHEN <cur> @> to_jsonb($1::text) THEN <cur>
       ELSE <cur> || jsonb_build_array($1::text) END)   -- add, idempotent
WHERE id = $2 RETURNING settings
```

**Why not the alternatives:**

- **Retry loop on a version column.** Needs a version column (a schema change this JSON column does not have), and it converts a silent wrong answer into latency plus a failure mode under contention. The SQL above needs neither.
- **Advisory lock.** Serialises all settings writes for a user, adds a lock to hold and release correctly on every path, and still requires trusting that every writer takes it. A writer that forgets is invisible; here a writer that forgets is a `user.update` that shows up in the two-line enumeration above.
- **Optimistic concurrency (compare-and-set on the blob).** Same schema problem, and it makes independent keys conflict with each other — the whole point is that these keys are independent.
- **A CTE that reads the row and then updates it.** Rejected as *incorrect*: under READ COMMITTED the CTE's output is materialised from the statement-start snapshot, so a concurrent update is not re-read and the update can still be lost. Every expression here references `settings` directly in the `SET` list, which is the form Postgres re-evaluates against the updated row.
- **Ordering conventions / "callers should send narrow patches".** That is the prose patch, and it is what the code was already informally doing — five call sites each got it wrong in the same direction. Stated explicitly so it can be rejected explicitly.

**One rule, one place.** The settings-write predicate was open-coded at 7 sites and disagreed at 6 of them (whole-blob replace vs. shallow merge vs. `jsonb_set`; bust the cache vs. not; treat `undefined` as removal vs. not). They now share `patchUserSettings`, with `splitSettingsPatch` as the single definition of "an explicit `undefined` means delete this key". Consolidating is what made the disagreement visible: the empty-array and empty-payload early-return defects below were only obvious once the writers were side by side.

**Three defects found while consolidating** (each with a test red on `main`):

1. **Restoring the last remaining dismissal wrote nothing.** `restoreAlertHandler` passed `{ dismissedAlerts: [] }` into the merge path; `removeEmpty` drops an empty array, leaving an empty payload and an early return. The notice stayed hidden permanently.
2. **`setUserSetting` skipped its own removal statement** when every supplied key was a removal — the early return fired before the removal branch.
3. **A non-array `dismissedAlerts` was spread character by character** (`[...'corrupt']`), producing seven junk entries. The new statement guards on `jsonb_typeof` and self-heals instead.

**Behaviour changes worth review:**

- `setUserSettingHandler` and `toggleUserFeatureFlagHandler` now return the settings the database produced (`RETURNING settings`) rather than a JS reconstruction of a possibly-stale snapshot.
- **`userUpdateCounter` labels change in FOUR ways, not one** (an earlier revision of this description said one — it was wrong):
  1. `user.service:setUserSetting:remove` is **gone** — set and remove are one statement now.
  2. `setUserSettingHandler` and `toggleUserFeatureFlagHandler` call `patchUserSettings` directly, so they emit **`user.service:patchUserSettings`** where they used to emit `user.service:setUserSetting:set`.
  3. `dismissAlertHandler` / `restoreAlertHandler` emit **`user.service:setAlertDismissed`**, a new series — `setDismissedAlerts` emitted nothing at all.
  4. `updateCreatorShopSettings` now emits (via `patchUserSettings`) where its `tx.user.update` emitted nothing.
  Net: two new series (`patchUserSettings`, `setAlertDismissed`), one retired (`setUserSetting:remove`), and a **step change in the counter's total** because two paths that were silent now emit. `model.service:updateGallerySettings` is preserved explicitly via the `location` option. Anyone alerting on this counter should expect the step.
- The two transactional writers gained a settings-cache bust they never had.

## `restoreAlert` — verdict: KEEP, made consistent

**Not deletable, and I could not prove otherwise.** Evidence:

- **No in-repo caller.** `grep -rna 'restoreAlert'` across the whole tree (excluding `.git` and `node_modules`) returns only the router wiring, the schema, the handler, the new tests, and `ReferralDashboard.tsx` — which is named `restoreAlertMutation` locally but calls `trpc.user.dismissAlert` with `dismiss: false`. There is no `apps/`, `packages/`, or generated-client consumer.
- **But it is an externally reachable API surface.** The tRPC router is served at `/api/trpc/[trpc]`, `protectedProcedure` accepts API-key/OAuth-token auth as well as session auth, and `restoreAlert` carries an explicit `.meta({ requiredScope: TokenScope.UserWrite })`. Per `src/server/trpc.ts`, a procedure *without* that meta implicitly requires `TokenScope.Full`; adding it **widens** access to scoped tokens. So it is deliberately exposed to third-party clients, and this repo cannot see whether any of them call it.

Absence of an in-repo caller is not absence of a caller. It therefore keeps its procedure and schema, and now uses the same atomic write path as `dismissAlert` — which also fixes the empty-array defect that made it silently no-op on a user's last dismissal. **Removal is a follow-up decision for a human**, and needs API-usage telemetry (or a deprecation window) rather than a grep.

## Test matrix

`src/server/services/__tests__/user-settings-race.behavior.test.ts` — real handlers, real Postgres, statement-level interleaving. Run at `origin/main` (2c8c072df) and at HEAD, same file both times.

| Test | at `origin/main` | at HEAD |
|---|---|---|
| keeps a dismissal that lands while a content-settings write is in flight | **RED** `['already-dismissed']` | green |
| keeps both of two dismissals that overlap | **RED** `['notice-x']` | green |
| keeps a dismissal that overlaps a restore of a different notice | **RED** `['notice-q']` | green |
| keeps a dismissal that lands while `user.setSettings` is in flight | **RED** `['already-dismissed']` | green |
| keeps a dismissal that lands while a feature toggle is in flight | **RED** `['already-dismissed']` | green |
| keeps a feature toggle that lands while another feature toggle is in flight | **RED** `expected false to be true` | green |
| restores the LAST remaining dismissal | **RED** `['only-one']` | green |
| self-heals a `dismissedAlerts` value that is not an array | **RED** `['corrupt','notice-f']` | green |
| keeps a content-settings write that lands while a dismissal is in flight | green | green — **INVARIANT GUARD** |
| is idempotent — dismissing the same notice twice stores it once | green | green — **INVARIANT GUARD** |
| un-dismisses through `dismissAlert({ dismiss: false })` | green | green — **INVARIANT GUARD** |
| un-dismisses the LAST remaining notice through `dismissAlert({ dismiss: false })` | green | green — **INVARIANT GUARD** |
| dismisses onto a NULL settings column | green | green — **INVARIANT GUARD** |
| leaves unrelated notices alone when one is restored | green | green — **INVARIANT GUARD** |

**8 red at base / 14 green at HEAD.** The six base-green cases are labelled invariant guards in the file and are not counted as regression coverage.

`set-user-setting.sql.service.test.ts` (18 tests) pins statement shape, which a behavioural test on one engine cannot: values bound not spliced, `- $n::text[]` for removal, the payload beside its cast as a bare placeholder, `RETURNING settings`, and that set+remove is now a single statement.

**Counts read from output with ANSI stripped, never from an exit code.** One earlier full-suite invocation used `--reporter=basic`, which vitest 4 rejects: it ran **zero** tests and exited **0**. Counting caught it.

## Mutation matrix — 32 applied, 32 killed (round 2)

> **Round 1 said "17 applied, 17 killed" and that was misleading.** It was true of the mutants I chose, but the battery had **no** mutant for the cache bust, **none** on either transactional writer, and **no** shape-preserving operand swap — so the phrasing invited a reader to treat the suite as mutation-hardened generally when three whole classes were unprobed. A blind audit's own battery then found **7 survivors** in exactly those classes. The table below is the re-run after fixing them; a fix round resets the gate, so every round-1 mutant was re-run too, not just the new ones.

Each mutant is one exact string replacement; each run is a fresh vitest process; the file is asserted to have changed on disk before the run, so a "survived" cannot come from an unread edit.

| # | Mutation | Verdict | Failing test / literal message |
|---|---|---|---|
| M1 | drop the `@>` dedupe guard on append | KILLED | *is idempotent* — `expected [ 'notice-d', 'notice-d' ] to deeply equal [ 'notice-d' ]` |
| M2 | append discards the stored array | KILLED | *keeps both of two dismissals* — `expected [ 'notice-x' ] to deeply equal [ 'notice-x', 'notice-y' ]` |
| M3 | removal filter matches everything | KILLED | *restores the LAST remaining dismissal* — `TRPCError: could not determine data type of parameter $1` |
| M4 | removal may yield SQL NULL (drop `COALESCE`) | KILLED | *filters the STORED array…* — `expected … to match /COALESCE\(\(\s*SELECT jsonb_agg/`; behaviour arm `TRPCError: syntax error at or near ")"` |
| M5 | drop the non-array type guard | KILLED | *self-heals a dismissedAlerts value that is not an array* — `expected [ 'corrupt', 'notice-f' ] to deeply equal [ 'notice-f' ]` |
| M6 | write a different JSON path | KILLED | 12 tests — `expected [] to include 'notice-c'` |
| M7 | shallow set replaces the column instead of merging | KILLED | *merges onto the existing settings column* — `expected 'UPDATE "User" SET settings = ($1::jso…' to contain 'COALESCE(settings'` |
| M8 | nested merge replaces the sub-object | KILLED | *keeps a feature toggle that lands while another…* — `expected undefined to be true` |
| M9 | drop the remove operator | KILLED | *still writes the removal when every supplied key is a removal* — `expected [ '{"allowAds":true}', 4242 ] to deep equally contain [ 'hideDonationGoals' ]` |
| M10 | drop `RETURNING settings` | KILLED | *returns the stored blob rather than a JS-side reconstruction* — `expected … to contain 'RETURNING settings'` |
| M11 | `splitSettingsPatch` drops removals | KILLED | *casts the bound key array to text[]* — `expected … to contain '::text[]'` |
| M12 | `updateContentSettings` writes the blob back | KILLED | *keeps a dismissal that lands while a content-settings write is in flight* — `expected [ 'already-dismissed' ] to deeply equal ArrayContaining{…}` |
| M13 | `setUserSettingHandler` writes the blob back | KILLED | *keeps a dismissal that lands while user.setSettings is in flight* — `expected [ 'already-dismissed' ] to deeply equal [ 'already-dismissed', 'notice-z' ]` |
| M14 | feature toggle replaces the whole `features` object | KILLED | *keeps a feature toggle that lands while another…* — `expected undefined to be true` |
| M15 | `restoreAlert` dismisses instead of restoring | KILLED | *leaves unrelated notices alone when one is restored* — `expected [ 'a', 'b', 'c' ] to deeply equal [ 'a', 'c' ]` |
| M16 | `dismissAlert` ignores `input.dismiss` | **SURVIVED → now KILLED** | see below |
| control | `dismissAlert` writes nothing at all | KILLED | 11 tests, incl. `Error: in-flight request finished without its write reaching the gate` |

**M16 survived the first battery and that was a real coverage gap.** Nothing exercised `dismissAlert({ dismiss: false })` — the path the product actually uses to un-dismiss, since `restoreAlert` has no caller. Two tests were added for it; M16 is now killed by *un-dismisses through `dismissAlert({ dismiss: false })`* with `expected [ 'notice-g', 'notice-h' ] to deeply equal [ 'notice-h' ]`. Each mutant is killed by a test that names its own defect, not by a neighbouring guard's error.

## Verification performed

- **New/updated suites at HEAD:** 207 passed across 7 files, including the repo's own lint-rule suites (`no-io-in-transaction`, `no-wholesale-module-mock`, `no-module-scope-cache`, `no-direct-shared-module-mock`).
- **`no-direct-shared-module-mock` initially failed on the new test file.** Rather than allowlisting it, the test was migrated to the canonical `dbMock` from `src/__tests__/mocks/db.mock.ts`, installing the Postgres bridge as behaviour on the canonical spies. Allowlist unchanged.
- **Typecheck** via `node scripts/typecheck.mjs` (the repo script, not a hand-rolled `tsc`): **17 errors at the merge base, 17 at HEAD**, identical sets. (An earlier revision quoted 20/20. Both numbers were self-consistent when measured; the shift is drift in a shared, mutable `node_modules` — the generated Prisma client — between measurements, not a change in this branch. Re-measured base and head back-to-back in one environment to be sure.) The only textual difference is field ordering inside printed type literals from the generated Prisma client. Zero new type errors.
- **Lint — CORRECTED twice, see below.** (An earlier revision reported "Prettier clean"; that was true only of the ADDED files. `set-user-setting.sql.service.test.ts` was prettier-dirty at head and clean at base — a regression this PR introduced, now fixed.)
- **Lint baseline.** The one remaining error in a touched file (`model.service.ts`, `no-explicit-any`) is present at base. An unused import left by this change was removed, and the new test file was written with zero `any` (the pre-change file had one).

### Correction: my first lint verdict was wrong, and CI was right

The original version of this section claimed the `eslint` crash on the new `.harness.ts` (`TypeError: Cannot read properties of undefined (reading 'length')` in `@typescript-eslint/consistent-type-imports`) was "confirmed pre-existing" because it reproduced on the pre-existing `listForModel.harness.ts`. **That was a misdiagnosis.** The crash *was* my file's real defect — the harness imported `PGlite` as a value while using it only in type positions — surfacing locally as a crash in that rule instead of a clean message. Reproducing the crash on a *neighbouring* file licensed a conclusion about *my* file that the evidence did not support. CI, with a clean install, reported it properly and blocked.

Two further things that follow from it, both now fixed:

1. **`pnpm lint` / "eslint over changed files" is not the gate.** The blocking job has a separate **ESLint (added files)** step (`git diff --diff-filter=A`, errors-only) — new files are held to a stricter bar than the rest of the repo. A local run scoped to changed files structurally cannot see it.
2. **There was a second blocking failure behind the first.** The same job also runs **Prettier (added files)**, and *both* added files failed it. The job stops at the first failing step, so only the ESLint error was visible. Both files are now formatted (formatting-only changes).

Both blocking steps were then reproduced locally using the workflow's own file-list construction, and **validated with positive controls before the clean result was trusted**:

| Control | Result |
|---|---|
| Restore the value `import` in the harness | ESLint step goes **red, exit 123** — the exact code CI reported — naming `consistent-type-imports` at `user-settings-race.harness.ts:1` |
| Plant an `any` in the *behaviour* test | ESLint step reports `1 problem … [Error/@typescript-eslint/no-explicit-any]`, proving the step reads **both** added files rather than stopping after the first |
| Prettier `--write` both files | `--list-different` moves **2 → 0** |
| Final state, both steps | ESLint: 0 output lines, 0 errors, 0 crashes, exit 0. Prettier: 0 unformatted, exit 0 |

An earlier attempt at this run piped the file list into `xargs … pnpm exec eslint` with `pnpm` absent from `PATH`, which **exited 127 with no findings** — indistinguishable from clean had the output not been counted rather than the exit code read.

The two **modified-files** steps in the same job are `continue-on-error: true` (report-only), so they do not gate this PR.

`listForModel.harness.ts` carries the same latent `import`-vs-`import type` condition. It is pre-existing and not an added file, so no blocking step lints it; it is left alone rather than pulled into this diff.
- **Full unit project at HEAD:** 16,705 passed / 29 failed across 1,084 files. All 29 were checked against `origin/main` by running the same files there: identical failures (5 files, 18 tests: missing optional deps, jsdom/localStorage, a licence fixture), plus full-suite-context flakes unrelated to settings. Nothing in that set touches `User.settings`.

## Round 2 — responding to a blind audit's 7 surviving mutants

The audit found no deploy-blocking defect and independently reproduced the red/green matrix, the writer enumeration, the `restoreAlert` reasoning and the three consolidation defects. Its **mutation battery is the finding that mattered: 7 of its 10 mutants survived**, in three classes my battery had no mutant for at all.

**One correctness fix (the only behaviour change in this round):**

`patchUserSettings` reached `getUserSettings` — a **Redis** read — on its no-op path, and **both** transactional callers reach that path with an empty patch: `updateCreatorShopSettings` when every field of its all-optional input is omitted, and the gallery copy when the model already carries default gallery settings. That spends the caller's interactive-transaction budget (Prisma's default 5s) on a cache round trip, and the repo's `no-io-in-transaction` rule is a call-name denylist that structurally cannot see it. The no-op path now reads the **row** through the same client.

I rejected the suggested `return tx ? {} : getUserSettings(userId)`: `updateCreatorShopSettings` returns the stored shop settings for an empty patch, and `{}` would have silently changed that. Reading the row fixes the Redis call, avoids the stale-cache return, and keeps the no-op path consistent with the write path's `RETURNING settings`. Mutant **N13** pins it — it is killed by *"returns the stored creator-shop settings for an empty patch"*.

Second-order, same line: a raw `UPDATE` matching no row was a **silent success** where the `user.update` it replaced raised Prisma `P2025`. A moderator acting on a deleted user now gets an error.

**Three classes of coverage that did not exist (no behaviour change):**

1. **The shallow merge's operand order — the PR's central claim.** A *shape-preserving* swap (stored column wins over the patch) passed all 40 tests. Root cause was fixture shape: every fixture wrote a key **absent** from its seed, so "patch wins" and "column wins" are byte-identical. Inverted, every settings write silently no-ops for any key the user already holds — strictly worse than the bug this PR fixes, and invisible. Fixtures now seed a value and **change** it, plus a dedicated describe pinning override semantics on the path 6 of 8 writers use. (The nested-merge twin was already killed, because its fixture seeds `{a:false,b:false}` and flips both — the difference is instructive.)
2. **The cache bust.** Zero hits for `bustUserSettings|userSettingsCache` in any test file repo-wide, so deleting any bust passed 40/40 — while this description makes the missing bust the reason the loss was near-certain over the 4h TTL. The cache mock's `bust` is now a **spy** and every writer asserts on it.
3. **The two transactional writers.** Neither had a *sequential* test, let alone a concurrent one, so `mergeInto`→`set` survived at both — the whole-sub-object replace this PR exists to remove — as did `patchUserSettings` ignoring its `tx` argument. Both now have behavioural tests. The gallery copy gets its own file (`user-settings-gallery-copy.behavior.test.ts`) because `model.service` needs a much larger set of import-time stubs, and folding those into the shared file would change the environment every test in it runs under.

**Four comments this PR falsified**, one load-bearing: the derivation of `METRIC_PRIVACY_DEFAULTS_TTL` (`creator-membership.service.ts`) still named the deleted `setDismissedAlerts` and called the two writers' read-merge-write "a real pre-existing bug, deliberately out of scope here" — which this PR *fixes*. Anyone re-deriving that constant would have started from a false premise. Also corrected: the bust helper's docblock, `getUserSettings`' docblock (now says plainly that it is read-only for writers and must not be called in a transaction), and the early-adopter comment in `setUserSettingHandler`.

**Nits:** `set-user-setting.sql.service.test.ts` was prettier-dirty at head and clean at base — fixed. The docblock now states that `set` and `mergeInto` do **not** compose on the same top-level key (`mergeInto` reads the stored column, not the partially-built expression); no caller collides today.

### Round 2 battery — 32 applied, 32 killed, 0 survived

| Class | Mutants | Verdict |
|---|---|---|
| Round 1 (dismissedAlerts set op, `patchUserSettings`, call sites) | 16 | all killed |
| **NEW** shape-preserving operand swap (shallow + nested) | 2 | killed — *overwrites an existing top-level value* / *merges INTO the named key* |
| **NEW** cache bust (6 sites incl. both transactional writers) | 6 | killed — *busts after a settings patch*, *…after a notice dismissal*, *…after the creator-shop write*, *…after the transaction commits* |
| **NEW** transactional writers + `tx` plumbing | 3 | killed — *keeps unrelated settings keys…*, *runs the settings write on the CALLER transaction client* |
| **NEW** no-op path (Redis-again, returns-`{}`, missing-user) | 3 | killed — *reads the row inside the transaction, never the Redis cache*; *raises rather than silently succeeding* |
| Positive controls | 2 | killed (12 and 28 failures respectively) |

Every mutant is killed by a test that names **its own** defect, not a neighbour's. Suites: **224 passed across 8 files**, counted from output with ANSI stripped.

A note on the one mutant that survived the *first* re-run: `N8`/`N10` (gallery copy — bust deleted, and `mergeInto`→`set`) survived until I wrote the gallery-copy file, because I had covered creator-shop and assumed the sibling writer was symmetric. It was not covered, and assuming symmetry is what the audit caught the first time.

## What I did NOT verify

- **Real concurrent behaviour against a live multi-connection database.** PGlite is a single connection, so the tests model *statement interleaving between two logical requests* — request B's whole read-compute-write cycle running between request A's read and its write. That is the shape of the reported bug and is exactly what distinguishes a JS read-modify-write from an expression over the stored column. It is **not** a test of MVCC: nothing here exercises row locks, snapshot isolation, or Postgres re-evaluating a `SET` expression against a concurrently-updated tuple. The correctness of the single-statement form under true concurrency rests on that documented READ COMMITTED behaviour, asserted by construction rather than measured. The harness header says so.
- **The two transactional writers under concurrency.** `updateCreatorShopSettings` and `copyGallerySettingsToAllModelsByUser` run inside `$transaction`, which a single connection cannot interleave. Both now have SEQUENTIAL behavioural tests (round 2) proving they merge rather than replace and that the write runs on the caller's transaction client — but their *concurrent* behaviour is still unverified.
- **Cache-aside repopulation.** A reader that misses the cache, reads the row, then re-populates after a writer's bust can still cache a stale blob. That window is pre-existing, untouched by this PR, and narrower now that two more writers bust the cache. Not fixed here.
- **Production data.** No claim about how many users currently hold a wrong `dismissedAlerts`, a lost setting, or a non-array value. That needs a query against production, which I did not run.
- **The `no-op`-path row read under real transaction semantics.** The new `SELECT settings` runs on the caller's client, which is correct by construction and asserted by a spy, but I did not measure it against a live Postgres transaction.
- **The metric step change.** Two `userUpdateCounter` series are new and two paths that were silent now emit. I did not check whether anything alerts on that counter's total.
- **Anything past the unit project.** The Playwright/browser/component projects were not run. The two `preview /` failures on this PR (`unit-tests`, `component-tests`) are report-only and outside this diff — 0 of the changed files are components.

  `preview / unit-tests` fails on `no-direct-shared-module-mock.test.ts` with `globSync is not a function`. It is **pre-existing, tier-specific, unrelated to this PR, and neither introduced nor resolved by merging**: the same file at the same commit **passes** under the GitHub-Actions `Unit tests` job (`✓ … (4 tests)`, 1093 files passed) and **fails** under the Tekton preview image, whose vite SSR transform does not resolve `globSync`. An environment divergence, not a code or ordering problem.

  🔴 **RETRACTED — an earlier revision of this line claimed the failure was "latent, not absent" because this branch predated #3959.** That was wrong, and it would have sent a reviewer hunting a problem the merge does not create. `git merge-base --is-ancestor 51eb5d7bf0 <head>` returns TRUE at every commit of this branch, and the merge base `2c8c072df` (2026-08-16) is *later* than #3959 `51eb5d7bf` (2026-08-15), not earlier. I had a coherent story and did not run the one command that refutes it — the same error as the eslint misdiagnosis above. A plausible mechanism is not evidence for it.
