### PR TITLE
test(notices): pin which notice each call site actually dismisses

### DIFF
--- a/src/components/Alerts/__tests__/notice-callsite-coverage.test.ts
+++ b/src/components/Alerts/__tests__/notice-callsite-coverage.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'fs';
+import path from 'path';
+import { FEATURE_NOTICES } from '~/components/Alerts/notice-registry';
+
+/**
+ * 🔴 SOURCE GATE — the CALL-SITE LEDGER for feature notices.
+ *
+ * WHAT THIS IS NOT. It does not pin any notice's id, and it cannot: a wrong key
+ * at a call site is a BEHAVIOURAL fault, so the thing that catches it is
+ * `notice-callsite.browser.test.tsx`, which mounts each component, clicks each
+ * dismiss control, and asserts the `alertId` actually sent. Read that file
+ * first — this one exists only to keep its population complete.
+ *
+ * WHAT IT IS. The behavioural guard covers the call sites that existed when it
+ * was written. Nothing stops a tenth site being added tomorrow with no test at
+ * all, and the suite would stay green — the same silence that let a
+ * mis-pointable id land in the first place. So this enumerates every
+ * `FEATURE_NOTICES.<key>` reference in the app graph and pins the
+ * file → keys map. It fails when the set GROWS (a new site with no guard),
+ * SHRINKS (a site deleted), or MOVES (a file re-pointed at a different entry),
+ * and the failure message says which test file the new site has to be added to.
+ *
+ * 🔴 The expected table is HAND-TYPED — file paths and key names both. It is
+ * deliberately not derived from a scan of the same source it is checking, which
+ * would agree with anything.
+ *
+ * KNOWN LIMIT, stated because it is the interesting one: this is blind to a
+ * WITHIN-FILE swap. `ReferralDashboardFull` uses three keys; exchanging which
+ * const is wired to which button leaves the file's key set identical and this
+ * gate passes. That case is covered — and was mutation-checked — only by the
+ * behavioural file. A ledger constrains the population, never the wiring.
+ */
+
+const SRC = path.resolve(__dirname, '../../../../src');
+
+const CODE_EXTENSIONS = new Set(['.ts', '.tsx']);
+const SKIP_DIRS = new Set(['node_modules', '__tests__', '__screenshots__']);
+
+/** The registry's own definition — it names every key by construction. */
+const REGISTRY_FILE = 'components/Alerts/notice-registry.ts';
+
+/**
+ * Test files are not call sites. `__tests__/` covers most of them, but this
+ * repo also places `*.browser.test.tsx` directly beside the component it
+ * exercises (see `src/components/generation_v2/inputs/`), so the directory skip
+ * alone would let a future notice test read as a production call site and fail
+ * this gate for writing the very guard it asks for.
+ */
+const isTestFile = (name: string) => /\.(test|spec)\.[cm]?[jt]sx?$/.test(name);
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) walk(full, out);
+    else if (CODE_EXTENSIONS.has(path.extname(entry)) && !isTestFile(entry)) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Strip comments before matching. This file and several components write
+ * `FEATURE_NOTICES.<something>` out in prose; an unstripped scan would count a
+ * documentation example as a call site.
+ */
+const stripComments = (s: string) =>
+  s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '');
+
+/** file (posix, relative to src/) → the registry keys it references, sorted. */
+function scanCallSites(): Record<string, string[]> {
+  const found: Record<string, string[]> = {};
+  for (const file of walk(SRC)) {
+    const rel = path.relative(SRC, file).split(path.sep).join('/');
+    if (rel === REGISTRY_FILE) continue;
+    const keys = new Set<string>();
+    for (const m of stripComments(readFileSync(file, 'utf8')).matchAll(
+      /FEATURE_NOTICES\.([A-Za-z0-9_$]+)/g
+    )) {
+      keys.add(m[1]);
+    }
+    if (keys.size > 0) found[rel] = [...keys].sort();
+  }
+  return found;
+}
+
+// 🔴 Hand-written. Every entry names the test that proves that file dismisses
+// the id it means to. Adding a row here without adding the behavioural case is
+// the one way to defeat this gate, and it takes a deliberate edit to do it.
+const CALL_SITE_LEDGER: Record<string, string[]> = {
+  // Guarded by notice-callsite.browser.test.tsx
+  'components/Modals/BuyBuzzModal.tsx': ['earnBlueBuzzRewards'],
+  'components/RemixGallery/RemixGalleryExplainer.tsx': ['remixGalleryExplainer'],
+  'components/Referrals/ReferralDashboard.tsx': ['referralKickback', 'referralLiteOnboarding'],
+  'components/Referrals/ReferralDashboardFull.tsx': [
+    'referralHowItWorks',
+    'referralKickback',
+    'referralTokenShop',
+  ],
+  // Guarded by feature-notice.characterization.browser.test.tsx
+  'components/Alerts/NavTidyNotice.tsx': ['navTidy'],
+  'components/Alerts/YellowBuzzMigrationNotice.tsx': ['yellowBuzzMigration'],
+  'components/Buzz/CryptoDeposit/OnrampGuidance.tsx': ['cryptoOnrampGuidance'],
+};
+
+describe('feature-notice call-site ledger', () => {
+  const actual = scanCallSites();
+
+  test('the scanner can see call sites at all', () => {
+    // Positive control. Every assertion below is a comparison against a scan,
+    // and a scan wired to nothing returns `{}` — which would make an emptied
+    // ledger pass and a "no new call sites" claim vacuous.
+    expect(Object.keys(actual).length).toBeGreaterThan(0);
+    expect(actual['components/Alerts/NavTidyNotice.tsx']).toContain('navTidy');
+  });
+
+  test('every file referencing FEATURE_NOTICES is a known, guarded call site', () => {
+    const unknown = Object.keys(actual).filter((f) => !(f in CALL_SITE_LEDGER));
+    expect(
+      unknown,
+      'A new feature-notice call site appeared. Add a behavioural case to ' +
+        'src/components/Alerts/__tests__/notice-callsite.browser.test.tsx that mounts it, ' +
+        'clicks its dismiss control and asserts the alertId as a HAND-TYPED literal — then ' +
+        'add it to CALL_SITE_LEDGER here. Do not add it to the ledger alone.'
+    ).toEqual([]);
+  });
+
+  test('every ledgered call site still exists', () => {
+    const missing = Object.keys(CALL_SITE_LEDGER).filter((f) => !(f in actual));
+    expect(
+      missing,
+      'A ledgered call site no longer references FEATURE_NOTICES. If the notice was removed, ' +
+        'drop its row here AND its behavioural case — and remember the id stays in real users’ ' +
+        'dismissedAlerts either way.'
+    ).toEqual([]);
+  });
+
+  test('each call site references exactly the registry keys the ledger pins', () => {
+    expect(
+      actual,
+      'The set of registry keys a call site reaches for has changed. If a file was re-pointed ' +
+        'at a different notice, that is the exact fault this gate exists for.'
+    ).toEqual(CALL_SITE_LEDGER);
+  });
+
+  test('no registry entry is dead — every notice has at least one call site', () => {
+    const referenced = new Set(Object.values(actual).flat());
+    const orphans = Object.keys(FEATURE_NOTICES).filter((k) => !referenced.has(k));
+    expect(
+      orphans,
+      'A registry entry is referenced by nothing. It renders nowhere, so no behavioural test ' +
+        'can guard it — remove the entry or wire it up.'
+    ).toEqual([]);
+  });
+});

--- a/src/components/Alerts/__tests__/notice-callsite.browser.test.tsx
+++ b/src/components/Alerts/__tests__/notice-callsite.browser.test.tsx
@@ -1,0 +1,463 @@
+import React from 'react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import type * as TrpcUtils from '~/utils/trpc';
+import type { ReferralDashboardData } from '~/components/Referrals/dashboard.types';
+
+// =============================================================================
+// CALL-SITE → PERSISTED-ID guard.
+//
+// `notice-registry.test.ts` pins what each registry ENTRY's id is. Nothing
+// there pins that a given piece of UI reaches for the RIGHT entry. Before the
+// consolidation the id literal sat beside its component, so a notice could not
+// be mis-pointed; now that every site indexes one shared record, writing
+//     const ALERT_HOW_IT_WORKS = FEATURE_NOTICES.referralTokenShop.id;
+// makes two unrelated notices dismiss each other — per-user, invisible, and
+// with the whole suite still green.
+//
+// This file closes that. For every dismiss/restore affordance, it MOUNTS the
+// real component, CLICKS that specific control, and asserts the wire payload
+// the component actually sends. The claim is a RELATIONSHIP — "this control
+// dismisses this id" — not a restatement of the registry.
+//
+// 🔴 Every expected id below is a HAND-TYPED LITERAL, never derived from
+// `FEATURE_NOTICES`. Deriving it (`FEATURE_NOTICES.referralKickback.id`) would
+// make this file agree with any re-pointing or rename, which is the single
+// thing it exists to catch. The strings are the same ones already persisted in
+// real users' `User.settings.dismissedAlerts`; changing one is a data
+// migration, not a refactor. Same rule, and same reason, as the
+// `ID_AT_ITS_ORIGINAL_CALL_SITE` table in `notice-registry.test.ts`.
+//
+// COVERAGE — all 9 registry entries, 11 (affordance → id) pairs:
+//   here  earnBlueBuzzRewards     BuyBuzzModal / EarnRewardsBanner
+//   here  remixGalleryExplainer   RemixGallery / RemixGalleryExplainer
+//   here  referralLiteOnboarding  Referrals / ReferralDashboard   (dismiss + restore)
+//   here  referralKickback        Referrals / ReferralDashboard
+//   here  referralHowItWorks      Referrals / ReferralDashboardFull
+//   here  referralKickback        Referrals / ReferralDashboardFull
+//   here  referralTokenShop       Referrals / ReferralDashboardFull
+//   ↳ `feature-notice.characterization.browser.test.tsx` already asserts the
+//     same wire payload for the remaining three — navTidy,
+//     yellowBuzzMigration and cryptoOnrampGuidance (dismiss + restore). They
+//     are deliberately NOT duplicated here; that file is the older
+//     characterization record and re-asserting it would create two places to
+//     update. `notice-callsite-coverage.test.ts` is what fails if a tenth call
+//     site ever appears without landing in one of the two.
+// =============================================================================
+
+const mocks = vi.hoisted(() => {
+  const state = {
+    settings: { dismissedAlerts: [] } as Record<string, any> | undefined,
+    currentUser: { id: 1 } as any,
+    features: {} as Record<string, any>,
+    /** Every `user.dismissAlert` payload, in call order. The assertion target. */
+    mutateCalls: [] as Array<{ alertId: string; dismiss?: boolean }>,
+  };
+
+  // Same reactive-store shim as the characterization file: `setData` has to
+  // actually re-render, or an optimistic dismissal is observable only inside
+  // the fake cache and never on screen.
+  const listeners = new Set<() => void>();
+  const emit = () => listeners.forEach((l) => l());
+  const subscribe = (cb: () => void) => {
+    listeners.add(cb);
+    return () => void listeners.delete(cb);
+  };
+  const snapshot = () => state.settings;
+
+  const utils = {
+    user: {
+      getSettings: {
+        cancel: async () => undefined,
+        getData: () => state.settings,
+        setData: (_key: undefined, updater: any) => {
+          state.settings = typeof updater === 'function' ? updater(state.settings) : updater;
+          emit();
+        },
+        invalidate: () => undefined,
+      },
+    },
+  };
+
+  // Runs the component's REAL onMutate/onSettled against the fake cache, so the
+  // click path exercised here is the same one production takes.
+  const useDismissMutation = (opts: any) => ({
+    mutate: (vars: { alertId: string; dismiss?: boolean }) => {
+      state.mutateCalls.push(vars);
+      void Promise.resolve(opts?.onMutate?.(vars)).then((ctx) =>
+        opts?.onSettled?.(undefined, null, vars, ctx)
+      );
+    },
+    isPending: false,
+    isLoading: false,
+  });
+
+  return { state, subscribe, snapshot, utils, useDismissMutation };
+});
+
+// Browser mode serves native ESM, so `vi.hoisted` runs before React is
+// importable. The one mock needing a hook lives out here as a hoisted function
+// declaration and is called through an arrow, so it resolves at render time.
+function useSettingsQuery(_input?: unknown, opts?: { enabled?: boolean }) {
+  const data = React.useSyncExternalStore(mocks.subscribe, mocks.snapshot, mocks.snapshot);
+  const enabled = opts?.enabled ?? true;
+  return { data: enabled ? data : undefined, isLoading: false, isError: false };
+}
+
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcUtils>()),
+  trpc: {
+    user: {
+      getSettings: {
+        useQuery: (input?: unknown, opts?: { enabled?: boolean }) => useSettingsQuery(input, opts),
+      },
+      dismissAlert: { useMutation: mocks.useDismissMutation },
+    },
+    referral: { getTierBonuses: { useQuery: () => ({ data: undefined }) } },
+    subscriptions: { getPlans: { useQuery: () => ({ data: [] }) } },
+    useUtils: () => mocks.utils,
+  },
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => mocks.state.currentUser,
+}));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => mocks.state.features,
+  useFeatureFlagsReady: () => true,
+}));
+
+// `useAppContext` is listed as well as `useServerDomains`: something in this
+// import graph pulls it, and a factory that omits an export a consumer imports
+// fails the whole file at COLLECTION — reported as "no tests", not as a red
+// test. (`importOriginal` is not the fix here; the real provider does not load
+// in browser mode.)
+vi.mock('~/providers/AppProvider', () => ({
+  useAppContext: () => ({
+    serverDomains: {
+      green: { primary: 'civitai.green' },
+      blue: { primary: 'civitai.com' },
+      red: { primary: 'civitai.red' },
+    },
+    canIndex: true,
+    seed: Date.now(),
+    availableOAuthProviders: [],
+    verifiedBot: null,
+  }),
+  useServerDomains: () => ({ green: 'civitai.com', red: 'civitai.red', blue: 'civitai.blue' }),
+}));
+
+vi.mock('~/utils/sync-account', () => ({ syncAccount: (url: string) => url }));
+
+vi.mock('~/components/Payments/usePaymentProvider', () => ({
+  usePaymentProvider: () => 'Paddle',
+}));
+
+import { renderWithProviders } from '../../../../test/component-setup';
+import { EarnRewardsBanner } from '~/components/Modals/BuyBuzzModal';
+import { RemixGalleryExplainer } from '~/components/RemixGallery/RemixGalleryExplainer';
+import { ReferralDashboard } from '~/components/Referrals/ReferralDashboard';
+import { ReferralDashboardFull } from '~/components/Referrals/ReferralDashboardFull';
+
+beforeEach(() => {
+  mocks.state.settings = { dismissedAlerts: [] };
+  mocks.state.currentUser = { id: 1 };
+  mocks.state.features = {};
+  mocks.state.mutateCalls = [];
+});
+
+// -----------------------------------------------------------------------------
+// Locating ONE affordance among several that share an accessible name.
+//
+// `ReferralDashboardFull` renders THREE controls whose accessible name is
+// "Dismiss" — one Button and two CloseButtons. `getByRole('button', { name:
+// 'Dismiss' })` cannot separate them, and picking by index would silently
+// re-point itself the moment the cards are reordered, which is exactly the
+// class of bug this file exists to catch.
+//
+// So each control is found through the notice's OWN copy: take the deepest
+// element carrying a text fragment unique to that notice, then walk up until an
+// ancestor holds exactly ONE dismiss control. Two loud failures instead of a
+// silent wrong click — "no dismiss control" if the markup moves apart, and
+// "ambiguous" if a climb reaches a container holding several.
+// -----------------------------------------------------------------------------
+
+/** The deepest element whose text contains `snippet`. */
+function deepestContaining(snippet: string): HTMLElement {
+  const matches = (Array.from(document.querySelectorAll('*')) as HTMLElement[]).filter((el) =>
+    el.textContent?.includes(snippet)
+  );
+  if (matches.length === 0) {
+    throw new Error(`notice copy not on screen: no element contains ${JSON.stringify(snippet)}`);
+  }
+  const deepest = matches.find(
+    (el) => !matches.some((other) => other !== el && el.contains(other))
+  );
+  if (!deepest) throw new Error(`could not resolve a deepest node for ${JSON.stringify(snippet)}`);
+  return deepest;
+}
+
+const isDismissControl = (el: HTMLElement) =>
+  el.getAttribute('aria-label') === 'Dismiss' || el.textContent?.trim() === 'Dismiss';
+
+/**
+ * The single dismiss control belonging to the notice whose copy contains
+ * `snippet`.
+ */
+function dismissControlFor(snippet: string): HTMLElement {
+  let node: HTMLElement | null = deepestContaining(snippet);
+  while (node) {
+    const found = (Array.from(node.querySelectorAll('button')) as HTMLElement[]).filter(
+      isDismissControl
+    );
+    if (found.length === 1) return found[0];
+    if (found.length > 1) {
+      throw new Error(
+        `ambiguous: ${found.length} dismiss controls share the nearest ancestor of ` +
+          `${JSON.stringify(snippet)} — this helper can no longer attribute a click`
+      );
+    }
+    node = node.parentElement;
+  }
+  throw new Error(`no dismiss control found for ${JSON.stringify(snippet)}`);
+}
+
+/**
+ * One payload rendered as a flat string: `dismiss <id>` / `restore <id>`.
+ *
+ * Asserted BEFORE the raw array because a string-array diff prints both ids in
+ * full. `toEqual` on the objects truncates to `[ Array(1) ]` at this depth,
+ * which names the expected id (from the message) but hides the one the call
+ * site actually sent — and "which notice did it dismiss instead" is the whole
+ * question when this test goes red.
+ */
+const persistedSummary = () =>
+  mocks.state.mutateCalls.map((c) =>
+    c.dismiss === false ? `restore ${c.alertId}` : `dismiss ${c.alertId}`
+  );
+
+/** Assert the exact payloads sent so far, with the site named in the message. */
+function expectPersisted(site: string, expected: Array<{ alertId: string; dismiss?: boolean }>) {
+  const expectedSummary = expected.map((c) =>
+    c.dismiss === false ? `restore ${c.alertId}` : `dismiss ${c.alertId}`
+  );
+  return vi.waitFor(() => {
+    // Readable first: names both sides of the mismatch.
+    expect(
+      persistedSummary(),
+      `${site} must persist exactly ${JSON.stringify(expectedSummary)} — a mismatch here means ` +
+        `this call site is pointed at the wrong FEATURE_NOTICES entry, so it dismisses another ` +
+        `notice instead of its own`
+    ).toEqual(expectedSummary);
+    // Exact second: the summary above collapses `dismiss: true` and an omitted
+    // flag, which are equivalent on the wire but not identical payloads.
+    expect(mocks.state.mutateCalls, `${site} raw dismissAlert payloads`).toEqual(expected);
+  });
+}
+
+// -----------------------------------------------------------------------------
+// BuyBuzzModal — the blue-buzz rewards banner.
+// -----------------------------------------------------------------------------
+describe('BuyBuzzModal / EarnRewardsBanner', () => {
+  test('its Dismiss persists `earn-blue-buzz-rewards`', async () => {
+    renderWithProviders(<EarnRewardsBanner />);
+
+    await expect
+      .element(page.getByText('You can earn Blue Buzz for free, every day.', { exact: false }))
+      .toBeVisible();
+    await userEvent.click(page.getByRole('button', { name: 'Dismiss' }));
+
+    await expectPersisted('BuyBuzzModal / EarnRewardsBanner', [
+      { alertId: 'earn-blue-buzz-rewards' },
+    ]);
+  });
+
+  test('is gone once `earn-blue-buzz-rewards` is already dismissed', async () => {
+    // Negative control: proves the component reads THIS id from stored state,
+    // not merely that its button sends it. A site pointed elsewhere would still
+    // be on screen here.
+    mocks.state.settings = { dismissedAlerts: ['earn-blue-buzz-rewards'] };
+    renderWithProviders(
+      <>
+        <EarnRewardsBanner />
+        <span data-testid="buy-buzz-sentinel">mounted</span>
+      </>
+    );
+
+    await expect.element(page.getByTestId('buy-buzz-sentinel')).toBeVisible();
+    expect(document.querySelectorAll('[aria-label="Dismiss"]')).toHaveLength(0);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// RemixGalleryExplainer — inline gallery card.
+// -----------------------------------------------------------------------------
+describe('RemixGallery / RemixGalleryExplainer', () => {
+  test('its Dismiss persists `remix-gallery-explainer`', async () => {
+    renderWithProviders(<RemixGalleryExplainer />);
+
+    await expect.element(page.getByRole('button', { name: 'Dismiss' })).toBeVisible();
+    await userEvent.click(page.getByRole('button', { name: 'Dismiss' }));
+
+    await expectPersisted('RemixGallery / RemixGalleryExplainer', [
+      { alertId: 'remix-gallery-explainer' },
+    ]);
+  });
+
+  test('is gone once `remix-gallery-explainer` is already dismissed', async () => {
+    mocks.state.settings = { dismissedAlerts: ['remix-gallery-explainer'] };
+    renderWithProviders(
+      <>
+        <RemixGalleryExplainer />
+        <span data-testid="remix-sentinel">mounted</span>
+      </>
+    );
+
+    await expect.element(page.getByTestId('remix-sentinel')).toBeVisible();
+    expect(document.querySelectorAll('[aria-label="Dismiss"]')).toHaveLength(0);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// The two referral dashboards.
+//
+// `settledTokens > 0` is what mounts the lite dashboard's tickets card, which
+// is where its kickback alert lives. Everything else is the smallest shape that
+// renders; the fixture's values are irrelevant to these assertions, which read
+// only the `alertId` a click produces.
+// -----------------------------------------------------------------------------
+const referralData = {
+  code: 'TESTCODE',
+  balance: {
+    settledBlueBuzzLifetime: 0,
+    lifetimePoints: 0,
+    pendingPoints: 0,
+    lifetimeTokens: 3,
+    settledTokens: 3,
+    pendingTokens: 0,
+    expiringSoonTokens: 0,
+    nextTokenExpiresAt: null,
+  },
+  recentRewards: [],
+  milestones: [],
+  redemptions: [],
+  shopItems: [
+    { cost: 1, tier: 'bronze', durationDays: 14 },
+    { cost: 3, tier: 'silver', durationDays: 14 },
+  ],
+  milestoneLadder: [{ threshold: 1_000, bonus: 500 }],
+  conversionCount: 0,
+  referralGrant: null,
+  activeMembership: null,
+} as unknown as ReferralDashboardData;
+
+const referralProps = {
+  data: referralData,
+  shareLink: 'https://civitai.com/?ref=TESTCODE',
+  onRedeem: () => undefined,
+  isRedeeming: false,
+  pendingOffer: null,
+};
+
+describe('Referrals / ReferralDashboard (lite)', () => {
+  const KICKBACK_COPY = 'Tickets come from friends paying for a Membership with your code';
+
+  test('the onboarding stepper’s "Got it" persists `referral-lite-onboarding`', async () => {
+    renderWithProviders(<ReferralDashboard {...referralProps} />);
+
+    await expect.element(page.getByRole('button', { name: 'Got it' })).toBeVisible();
+    await userEvent.click(page.getByRole('button', { name: 'Got it' }));
+
+    await expectPersisted('ReferralDashboard (lite) onboarding stepper', [
+      { alertId: 'referral-lite-onboarding' },
+    ]);
+  });
+
+  test('the kickback alert’s Dismiss persists `referral-kickback-info`', async () => {
+    renderWithProviders(<ReferralDashboard {...referralProps} />);
+
+    await expect.element(page.getByText(KICKBACK_COPY, { exact: false })).toBeVisible();
+    await userEvent.click(dismissControlFor(KICKBACK_COPY));
+
+    await expectPersisted('ReferralDashboard (lite) kickback alert', [
+      { alertId: 'referral-kickback-info' },
+    ]);
+  });
+
+  test('"How does it work?" RESTORES `referral-lite-onboarding` with dismiss:false', async () => {
+    // The restore path sends a different payload shape, so it is a separate
+    // wiring that can be mis-pointed independently of the dismiss above.
+    mocks.state.settings = { dismissedAlerts: ['referral-lite-onboarding'] };
+    renderWithProviders(<ReferralDashboard {...referralProps} />);
+
+    await expect.element(page.getByRole('button', { name: 'How does it work?' })).toBeVisible();
+    await userEvent.click(page.getByRole('button', { name: 'How does it work?' }));
+
+    await expectPersisted('ReferralDashboard (lite) onboarding restore', [
+      { alertId: 'referral-lite-onboarding', dismiss: false },
+    ]);
+  });
+
+  test('each notice reads its OWN stored id — dismissing one leaves the other on screen', async () => {
+    // Negative control for both lite sites at once. If either were pointed at
+    // the other's entry, seeding one id would hide both (or neither).
+    mocks.state.settings = { dismissedAlerts: ['referral-lite-onboarding'] };
+    renderWithProviders(<ReferralDashboard {...referralProps} />);
+
+    await expect.element(page.getByText(KICKBACK_COPY, { exact: false })).toBeVisible();
+    expect(page.getByRole('button', { name: 'Got it' }).elements()).toHaveLength(0);
+  });
+});
+
+describe('Referrals / ReferralDashboardFull', () => {
+  const HOW_IT_WORKS_COPY = 'How it works';
+  const KICKBACK_COPY = 'When a friend joins via your code and pays for a Membership';
+  const TOKEN_SHOP_COPY = 'Tokens come from friends paying for a Membership with your code';
+
+  test('the "How it works" card’s Dismiss persists `referral-how-it-works`', async () => {
+    renderWithProviders(<ReferralDashboardFull {...referralProps} />);
+
+    await expect.element(page.getByText(KICKBACK_COPY, { exact: false })).toBeVisible();
+    await userEvent.click(dismissControlFor(HOW_IT_WORKS_COPY));
+
+    await expectPersisted('ReferralDashboardFull "How it works" card', [
+      { alertId: 'referral-how-it-works' },
+    ]);
+  });
+
+  test('the kickback alert’s Dismiss persists `referral-kickback-info`', async () => {
+    renderWithProviders(<ReferralDashboardFull {...referralProps} />);
+
+    await expect.element(page.getByText(KICKBACK_COPY, { exact: false })).toBeVisible();
+    await userEvent.click(dismissControlFor(KICKBACK_COPY));
+
+    await expectPersisted('ReferralDashboardFull kickback alert', [
+      { alertId: 'referral-kickback-info' },
+    ]);
+  });
+
+  test('the token-shop alert’s Dismiss persists `referral-token-shop-info`', async () => {
+    renderWithProviders(<ReferralDashboardFull {...referralProps} />);
+
+    await expect.element(page.getByText(TOKEN_SHOP_COPY, { exact: false })).toBeVisible();
+    await userEvent.click(dismissControlFor(TOKEN_SHOP_COPY));
+
+    await expectPersisted('ReferralDashboardFull token-shop alert', [
+      { alertId: 'referral-token-shop-info' },
+    ]);
+  });
+
+  test('the three notices read three DIFFERENT stored ids', async () => {
+    // The strongest negative control in this file, and the one that makes the
+    // shared-id case honest: `referral-kickback-info` is deliberately ONE id
+    // across both dashboards, so seeding it must hide the kickback alert while
+    // leaving "How it works" and the token-shop alert untouched.
+    mocks.state.settings = { dismissedAlerts: ['referral-kickback-info'] };
+    renderWithProviders(<ReferralDashboardFull {...referralProps} />);
+
+    await expect.element(page.getByText(TOKEN_SHOP_COPY, { exact: false })).toBeVisible();
+    expect(page.getByText(KICKBACK_COPY, { exact: false }).elements()).toHaveLength(0);
+    await expect.element(page.getByText(HOW_IT_WORKS_COPY, { exact: false })).toBeVisible();
+  });
+});

--- a/src/components/Modals/BuyBuzzModal.tsx
+++ b/src/components/Modals/BuyBuzzModal.tsx
@@ -47,13 +47,19 @@ export type BuyBuzzModalProps = {
   attribution?: BlockAttribution;
 };
 
-function EarnRewardsBanner({ initialBuzzType }: { initialBuzzType?: BuzzSpendType }) {
+/**
+ * Exported ONLY so `notice-callsite.browser.test.tsx` can mount it directly and
+ * assert which `alertId` its Dismiss control actually sends. Mounting the whole
+ * `BuyBuzzModal` to reach it would drag in the dialog context and the entire
+ * purchase layout, none of which the notice's wiring depends on. Pure export
+ * addition — no behaviour, props or rendering changed.
+ */
+export function EarnRewardsBanner({ initialBuzzType }: { initialBuzzType?: BuzzSpendType }) {
   const currentUser = useCurrentUser();
   const features = useFeatureFlags();
   const paymentProvider = usePaymentProvider();
   const isMember = currentUser?.isMember;
-  const showMemberUpsell =
-    !isMember && features.membershipsV2 && initialBuzzType === 'yellow';
+  const showMemberUpsell = !isMember && features.membershipsV2 && initialBuzzType === 'yellow';
 
   const {
     isDismissed,
@@ -95,8 +101,8 @@ function EarnRewardsBanner({ initialBuzzType }: { initialBuzzType?: BuzzSpendTyp
             Did you know? You can earn Blue Buzz for free, every day.
           </Text>
           <Text size="sm" c="dimmed">
-            React to posts, follow creators, give generator feedback, and make your first daily
-            post — plus earn more as others react to your work.
+            React to posts, follow creators, give generator feedback, and make your first daily post
+            — plus earn more as others react to your work.
           </Text>
           <Group gap="sm" wrap="wrap" mt={4}>
             <Button


### PR DESCRIPTION
## The gap

#3943 consolidated nine hand-rolled `dismissedAlerts` notices onto one registry. `notice-registry.test.ts` pins each entry's **id** as a hand-typed literal. Nothing pinned that a given piece of UI reaches for the **right entry**.

Before that refactor the id literal sat beside its component, so a notice could not be mis-pointed. Now every site indexes one shared record, so writing

```ts
const ALERT_HOW_IT_WORKS = FEATURE_NOTICES.referralTokenShop.id;
```

in `ReferralDashboardFull` makes two unrelated notices dismiss each other. Per-user, invisible in every response, and **the entire suite stays green** — the id table still passes, because every id is still correct. It is the *wiring* that is wrong.

Three of the nine notices already had a behavioural test covering this (`feature-notice.characterization.browser.test.tsx`). Six did not.

## What the guard pins, and which sites it covers

**All 9 registry entries / 11 (affordance → id) pairs.** The guard is **behavioural**: it mounts the real component, clicks the specific dismiss/restore control, and asserts the `alertId` the component actually puts on the wire. The claim is a *relationship* — "this control dismisses this id" — not a restatement of the registry.

| Registry key | Call site | Affordance | Guarded by |
|---|---|---|---|
| `earnBlueBuzzRewards` | `Modals/BuyBuzzModal` (`EarnRewardsBanner`) | Dismiss | **new** |
| `remixGalleryExplainer` | `RemixGallery/RemixGalleryExplainer` | Dismiss | **new** |
| `referralLiteOnboarding` | `Referrals/ReferralDashboard` | "Got it" **and** "How does it work?" (restore) | **new** |
| `referralKickback` | `Referrals/ReferralDashboard` | Dismiss | **new** |
| `referralHowItWorks` | `Referrals/ReferralDashboardFull` | Dismiss | **new** |
| `referralKickback` | `Referrals/ReferralDashboardFull` | Dismiss | **new** |
| `referralTokenShop` | `Referrals/ReferralDashboardFull` | Dismiss | **new** |
| `navTidy` | `Alerts/NavTidyNotice` | Dismiss | existing characterization |
| `yellowBuzzMigration` | `Alerts/YellowBuzzMigrationNotice` | Dismiss | existing characterization |
| `cryptoOnrampGuidance` | `Buzz/CryptoDeposit/OnrampGuidance` | Dismiss + restore | existing characterization |

The three existing ones are deliberately **not** duplicated — the mutation matrix below proves they are genuinely covered rather than assumed to be.

🔴 Every expected id is a **hand-typed literal**. Deriving one from `FEATURE_NOTICES` would make the guard agree with any re-pointing, which is the single thing it must not do. Same rule and same reason as `ID_AT_ITS_ORIGINAL_CALL_SITE`.

### Why behavioural, and the trade-off accepted

Three options were weighed:

1. **Export the module-level consts and assert them against literals.** Cheapest, but it pins the *const*, not the *wiring*: swapping which const is passed to which button leaves every such assertion green. It also would not cover `BuyBuzzModal` or the three existing sites, which have no const at all — they call `useFeatureNotice(FEATURE_NOTICES.x)` inline. Different guard shapes for different sites, and the weaker shape exactly where the risk is highest (the 3-notice file).
2. **Source-text / regex assertion.** Rejected as the primary guard: it is walkable by rewording, and it is blind to the same within-file swap. It *is* used, but only for coverage — see below.
3. **Assert the wire payload from a mounted component.** Chosen. It is the only option that pins affordance → id, it is the shape the repo already uses for these notices, and mutant M8 below is the concrete proof that the other two would have missed a real defect.

**Cost accepted:** it needs component mounting, so `EarnRewardsBanner` had to be exported (below), the two referral dashboards need a `ReferralDashboardProps` fixture, and it runs in the browser project rather than the fast node one. The fixture's values are irrelevant to the assertions — they read only the `alertId` a click produces — so no fixture value can collide with an expected constant.

**One helper deserves scrutiny:** `ReferralDashboardFull` renders **three** controls whose accessible name is `"Dismiss"` (one `Button`, two `CloseButton`s), so `getByRole('button', { name: 'Dismiss' })` cannot separate them, and picking by index would silently re-point itself the moment the cards are reordered — the exact bug class this PR exists to catch. Each control is instead found through its own notice's copy: take the deepest element carrying text unique to that notice, then walk up to the nearest ancestor holding exactly one dismiss control. It **throws** rather than guessing if the markup moves apart (`no dismiss control found for …`) or if a climb reaches several candidates (`ambiguous: N dismiss controls …`).

Each case also carries a negative control that seeds one id and asserts the *other* notices stay on screen — including the deliberate case where `referral-kickback-info` is **one shared id** across both dashboards.

## The coverage ledger (where the source scan belongs)

`notice-callsite-coverage.test.ts` pins the `file → registry keys` map so a *tenth* call site cannot be added with no guard at all and stay green. It is explicitly **not** the id guard and cannot be — **it is blind to a within-file swap**, which only the behavioural file catches. It follows the existing source-gate convention (`no-static-html2canvas-import.test.ts`), strips comments, skips test files, and carries a positive control so an empty scan cannot pass vacuously.

## Mutation matrix

Each mutant re-points **one** call site at a **different** registry key, runs both notice test files, then reverts. Every run was verified to still collect **27 tests** (12 new + 15 characterization), so no kill is a disguised collection failure. Reverts were checksum-verified. Every mutant was applied against the final committed bytes.

**11 / 11 killed. None survived.**

| # | Mutant | Result | Failing test → literal message |
|---|---|---|---|
| M1 | `BuyBuzzModal` `earnBlueBuzzRewards` → `navTidy` | KILLED 2/27 | *its Dismiss persists `earn-blue-buzz-rewards`* — ``BuyBuzzModal / EarnRewardsBanner must persist exactly ["dismiss earn-blue-buzz-rewards"] … expected [ 'dismiss nav-tidy-notice' ] to deeply equal [ 'dismiss earn-blue-buzz-rewards' ]`` |
| M2 | `RemixGalleryExplainer` `remixGalleryExplainer` → `navTidy` | KILLED 2/27 | ``RemixGallery / RemixGalleryExplainer must persist exactly ["dismiss remix-gallery-explainer"] … expected [ 'dismiss nav-tidy-notice' ] to deeply equal [ 'dismiss remix-gallery-explainer' ]`` |
| M3 | `ReferralDashboard` `referralLiteOnboarding` → `referralKickback` | KILLED 3/27 | ``ReferralDashboard (lite) onboarding stepper must persist exactly ["dismiss referral-lite-onboarding"] … expected [ 'dismiss referral-kickback-info' ] to deeply equal [ 'dismiss referral-lite-onboarding' ]`` |
| M4 | `ReferralDashboard` `referralKickback` → `referralLiteOnboarding` | KILLED 2/27 | ``ReferralDashboard (lite) kickback alert must persist exactly ["dismiss referral-kickback-info"] … expected [ 'dismiss referral-lite-onboarding' ] to deeply equal [ 'dismiss referral-kickback-info' ]`` |
| M5 | `ReferralDashboardFull` `referralHowItWorks` → `referralTokenShop` | KILLED 1/27 | ``ReferralDashboardFull "How it works" card must persist exactly ["dismiss referral-how-it-works"] … expected [ 'dismiss referral-token-shop-info' ] to deeply equal [ 'dismiss referral-how-it-works' ]`` |
| M6 | `ReferralDashboardFull` `referralKickback` → `referralHowItWorks` | KILLED 2/27 | ``ReferralDashboardFull kickback alert must persist exactly ["dismiss referral-kickback-info"] … expected [ 'dismiss referral-how-it-works' ] to deeply equal [ 'dismiss referral-kickback-info' ]`` |
| M7 | `ReferralDashboardFull` `referralTokenShop` → `referralKickback` | KILLED 2/27 | ``ReferralDashboardFull token-shop alert must persist exactly ["dismiss referral-token-shop-info"] … expected [ 'dismiss referral-kickback-info' ] to deeply equal [ 'dismiss referral-token-shop-info' ]`` |
| **M8** | **`ReferralDashboardFull`: swap `ALERT_KICKBACK` ↔ `ALERT_TOKEN_SHOP` at the BUTTONS** (file's key set unchanged) | KILLED 2/27 | both fire: ``… kickback alert … expected [ 'dismiss referral-token-shop-info' ] to deeply equal [ 'dismiss referral-kickback-info' ]`` and ``… token-shop alert … expected [ 'dismiss referral-kickback-info' ] to deeply equal [ 'dismiss referral-token-shop-info' ]`` |
| M9 | `NavTidyNotice` `navTidy` → `yellowBuzzMigration` | KILLED 2/27 | *characterization* — *dismissing persists `nav-tidy-notice` …* → ``expected [ Array(1) ] to deeply equal [ { alertId: 'nav-tidy-notice' } ]`` |
| M10 | `YellowBuzzMigrationNotice` `yellowBuzzMigration` → `navTidy` | KILLED 2/27 | *characterization* — *dismissing persists `yellow-buzz-migration` …* → ``expected [ { alertId: 'nav-tidy-notice' } ] to deeply equal [ Array(1) ]`` |
| M11 | `OnrampGuidance` `cryptoOnrampGuidance` → `navTidy` (all 3 sites) | KILLED 4/27 | *characterization* — *dismissing persists `crypto-onramp-guidance` …* → ``expected [ { alertId: 'nav-tidy-notice' } ] to deeply equal [ Array(1) ]`` |

**M8 is the one that justifies the design choice.** It leaves the file's set of referenced registry keys *identical*, so the ledger passes and any per-file or source-text guard passes. Only the behavioural assertions see it.

**M9–M11 are positive controls** carried deliberately: they die in the *pre-existing* characterization file, which is what turns "those three are already covered" from an assumption into a measurement.

### Ledger mutants (4 / 4 killed)

| # | Mutant | Result | Message |
|---|---|---|---|
| L1 | new `FEATURE_NOTICES` reference in an unledgered file | KILLED 2/5 | *A new feature-notice call site appeared. Add a behavioural case to … then add it to CALL_SITE_LEDGER here. Do not add it to the ledger alone.* |
| L2 | `ReferralDashboardFull` re-pointed `referralTokenShop` → `navTidy` | KILLED 2/5 | *The set of registry keys a call site reaches for has changed…* + *A registry entry is referenced by nothing…* `expected [ 'referralTokenShop' ] to deeply equal []` |
| L3 | `RemixGalleryExplainer` drops the registry for a bare literal | KILLED 3/5 | *A ledgered call site no longer references FEATURE_NOTICES…* |
| L4 | **negative control on the instrument**: scanner pattern matches nothing | KILLED 4/5 | positive-control test fires first: `expected 0 to be greater than 0` |

L4 is the check that the scan is wired to something: without it, "no new call sites" is indistinguishable from a scanner returning `{}`.

## Production code change

One, and it is a pure export addition:

```diff
-function EarnRewardsBanner({ initialBuzzType }: { initialBuzzType?: BuzzSpendType }) {
+export function EarnRewardsBanner({ initialBuzzType }: { initialBuzzType?: BuzzSpendType }) {
```

**No behaviour, props, or rendering changed.** Reaching it through `BuyBuzzModal` would require the dialog context and the entire purchase layout, none of which the notice's wiring depends on.

The other two hunks in that file are prettier re-wrapping (a wrapped boolean expression and a wrapped sentence). **The file was already prettier-dirty on `main`** — verified by checking `origin/main`'s copy at its real path — but `pnpm prettier:check` operates on *changed* files, so touching it at all makes the gate demand them.

**No notice id changed.** They are production data already stored in real users' `User.settings.dismissedAlerts`; changing one mints a new notice and re-shows the old one to everyone who had dismissed it.

## Test results

Counts read from output content with ANSI stripped, never from an exit code.

- `notice-callsite.browser.test.tsx` — **12 passed**
- `feature-notice.characterization.browser.test.tsx` — **15 passed** (unchanged)
- `notice-callsite-coverage.test.ts` — **5 passed**
- `notice-registry.test.ts` — **21 passed** (unchanged)
- Full component project — **156 files / 1664 tests passed**, 0 failed, 0 `test timed out` panics; the new file appears in that run at 12 tests
- Full unit projects (`--project 'unit*'`) — **1089 files / 17055 tests passed**, 1 file / 21 tests skipped, 0 failed, 0 timeout panics. Canary: `blocks.router.workflow.test.ts` collected **348** tests, so the run was not silently truncated by a missing `event-engine-common` submodule
- `pnpm run test:lint-rules` — **6 files / 220 passed**
- `pnpm typecheck` (repo wrapper, 8192 MB heap cap) — **0 type errors**
- `pnpm run prettier:check` — clean (and observed failing on the same command before the fix, so it is not a vacuous pass)
- `eslint` on the three changed files — **0 errors**, 5 `no-explicit-any` warnings in the mock scaffold. The pre-existing `feature-notice.characterization.browser.test.tsx` on `main` produces the **same 5 warnings** from the same scaffold pattern, so this is the established convention here, not new noise.

### CI

All blocking checks green: **Unit tests**, **Package unit tests**, **App unit tests**, **ESLint + Prettier (changed files)**, **Schema drift gate**, **event-engine-common pin**. `preview / component-tests` **passed** — so the new browser file also ran on CI's own Chromium, not only on the locally-substituted one.

**`preview / unit-tests` reports FAILURE (report-only, non-blocking) and it is not from this PR.** The controls:
- The blocking **Unit tests** job passed on this same commit (7m29s).
- The full unit suite run locally against this branch is **17055 passed / 0 failed**.
- Only two open PRs carry this check at all, and **both fail** — the other is #3986, which touches only server-side user-settings files and shares no file, import or surface with this PR.

I could **not** read that tier's actual log: the check's target URL points at the preview site, and the Tekton run is behind an auth gate I can't reach. So the claim above rests on those three controls, not on the log.

## What I did NOT verify

- **No production run.** Nothing was exercised against a real tRPC backend, a real `user.getSettings`, or a real `dismissAlert` write. The mutation is mocked, and the assertion is on the payload handed to `mutate` — not on what the server persists. A defect in `dismissAlertHandler` or in the schema is out of scope for this guard.
- **`ReferralDashboardData` is a cast fixture**, not the real router output. It supplies only the fields the two dashboards read. If a dashboard later reads a field the fixture lacks, these tests fail loudly at mount rather than silently — but the fixture is not a contract-fidelity check against the real `getDashboard` shape.
- **Locally the browser suite ran with `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH`** pointed at a Chromium the repo's playwright pin does not name (host bundle 1228; pin 1.57.0 wants 1200) — the documented NixOS escape hatch. *All the mutation results below were produced on that build.* CI's `preview / component-tests` passing on its own Chromium covers the green direction, but the eleven mutants were **not** re-run under CI's browser.
- **The referral dashboards' visibility conditions are only partially exercised.** The fixture sets `settledTokens > 0` to mount the lite dashboard's tickets card. Other gating paths (`showEarningsHero`, milestone ladders, shop grouping) are incidental to these assertions and are not asserted.
- **The ledger cannot see a within-file swap** — stated in its own header, and M8 is the demonstration that the behavioural file is what covers that case.
