### PR TITLE
feat(trpc): cap batch width at 30, observe it, and decouple the never-batch drift guard

### DIFF
--- a/src/components/Apps/AppActivityPanel.tsx
+++ b/src/components/Apps/AppActivityPanel.tsx
@@ -269,6 +269,14 @@ export function AppActivityPanel({
   // model versions via the existing `getVersionsByIds`, recipients via
   // `user.getById` coalesced through the tRPC http-batch link. The view renders
   // ids until the names settle (progressive), then swaps in @username / name.
+  //
+  // The `user.getById` fan-out is one call per DISTINCT recipient, so it can reach
+  // ~50 across the two feeds (limit 25 each) — above `TRPC_MAX_BATCH_SIZE`. That is
+  // safe: the batch link caps itself at the same constant and its dataloader SPLITS
+  // a wider fan-out across several requests rather than rejecting it (see `maxItems`
+  // in `src/utils/trpc.ts`), so no request is ever built above the server's cap. A
+  // bulk `user.getByIds` would collapse it to one query at any width and is the
+  // right follow-up; `getVersionsByIds` above is already that shape.
   const userIds = useMemo(
     () =>
       Array.from(

--- a/src/components/Apps/AppActivityPanel.tsx
+++ b/src/components/Apps/AppActivityPanel.tsx
@@ -272,11 +272,13 @@ export function AppActivityPanel({
   //
   // The `user.getById` fan-out is one call per DISTINCT recipient, so it can reach
   // ~50 across the two feeds (limit 25 each) — above `TRPC_MAX_BATCH_SIZE`. That is
-  // safe: the batch link caps itself at the same constant and its dataloader SPLITS
-  // a wider fan-out across several requests rather than rejecting it (see `maxItems`
-  // in `src/utils/trpc.ts`), so no request is ever built above the server's cap. A
-  // bulk `user.getByIds` would collapse it to one query at any width and is the
-  // right follow-up; `getVersionsByIds` above is already that shape.
+  // safe, but note WHICH bound does the work: the batch link's pre-existing
+  // `maxURLLength: 2083` already splits this shape at ~22-29 operations, below the
+  // item cap, and `maxItems` (see `src/utils/trpc.ts`) is the backstop. Either way
+  // the dataloader SPLITS a wider fan-out across several requests rather than
+  // rejecting it, so no request is ever built above the server's cap. A bulk
+  // `user.getByIds` would collapse it to one query at any width and is the right
+  // follow-up; `getVersionsByIds` above is already that shape.
   const userIds = useMemo(
     () =>
       Array.from(

--- a/src/components/Chat/ExistingChat.tsx
+++ b/src/components/Chat/ExistingChat.tsx
@@ -872,9 +872,30 @@ function DisplayMessages({
   // TODO we should be checking first if this exists in `chats`
   //      then, grab the content
   //      then, grab the user info from chatMembers (but what if its not there?)
-  const replyIds = chats
-    .filter((c) => isDefined(c.referenceMessageId))
-    .map((c) => c.referenceMessageId as number);
+  // DISTINCT reply targets, in INSERTION ORDER. `chats` comes from a query with no explicit
+  // limit (the schema default is 1000), and several messages commonly reply to the SAME
+  // message, so the un-deduplicated list fired one `getMessageById` per REPLY rather than per
+  // replied-to message. Those extra queries were never even read: the lookup below is
+  // `replyIds.indexOf(...)`, which always resolves to the first occurrence — so deduplicating
+  // is behaviour-identical and removes pure fan-out.
+  //
+  // Insertion order, NOT sorted — same reasoning as `useStickerCosmetics` in
+  // `src/components/Sticker/sticker.util.ts`: this list GROWS as the chat pages, and sorting
+  // would shift positions of already-fetched entries every time an older id arrives.
+  //
+  // Width still scales with the number of distinct replies in a long chat. That is safe under
+  // the batch-size cap because the batch link is capped at `TRPC_MAX_BATCH_SIZE` items and its
+  // dataloader SPLITS a wider fan-out across several requests rather than rejecting it (see
+  // `maxItems` in `src/utils/trpc.ts`). The real fix is a bulk `chat.getMessagesByIds`, which
+  // would make this one query regardless of width — deliberately left as a follow-up.
+  const replyIds = useMemo(
+    () => [
+      ...new Set(
+        chats.filter((c) => isDefined(c.referenceMessageId)).map((c) => c.referenceMessageId!)
+      ),
+    ],
+    [chats]
+  );
   const replyData = trpc.useQueries((t) =>
     replyIds.map((r) => t.chat.getMessageById({ messageId: r }))
   );

--- a/src/components/Chat/ExistingChat.tsx
+++ b/src/components/Chat/ExistingChat.tsx
@@ -873,21 +873,25 @@ function DisplayMessages({
   //      then, grab the content
   //      then, grab the user info from chatMembers (but what if its not there?)
   // DISTINCT reply targets, in INSERTION ORDER. `chats` comes from a query with no explicit
-  // limit (the schema default is 1000), and several messages commonly reply to the SAME
-  // message, so the un-deduplicated list fired one `getMessageById` per REPLY rather than per
-  // replied-to message. Those extra queries were never even read: the lookup below is
-  // `replyIds.indexOf(...)`, which always resolves to the first occurrence — so deduplicating
-  // is behaviour-identical and removes pure fan-out.
+  // limit (the schema default is 1000), and several messages commonly reply to the SAME message.
+  //
+  // ⚠️ This does NOT reduce the number of tRPC operations, and the batch width was never
+  // inflated by the duplicates: `@tanstack/query-core` collapses identical query keys, so N
+  // `useQueries` entries for the same `messageId` were already one cache entry and one fetch.
+  // What deduplicating removes is the per-duplicate query OBSERVER (and the array churn behind
+  // it) — marginally cheaper, behaviour-identical. It is behaviour-identical in the other
+  // direction too: the lookup below is `replyIds.indexOf(...)`, which always resolved to the
+  // first occurrence, so the duplicate entries were never read either.
   //
   // Insertion order, NOT sorted — same reasoning as `useStickerCosmetics` in
   // `src/components/Sticker/sticker.util.ts`: this list GROWS as the chat pages, and sorting
   // would shift positions of already-fetched entries every time an older id arrives.
   //
-  // Width still scales with the number of distinct replies in a long chat. That is safe under
-  // the batch-size cap because the batch link is capped at `TRPC_MAX_BATCH_SIZE` items and its
-  // dataloader SPLITS a wider fan-out across several requests rather than rejecting it (see
-  // `maxItems` in `src/utils/trpc.ts`). The real fix is a bulk `chat.getMessagesByIds`, which
-  // would make this one query regardless of width — deliberately left as a follow-up.
+  // The real fan-out (one operation per DISTINCT replied-to message) still scales with a long
+  // chat. That is bounded on the wire by the batch link's `maxURLLength` and `maxItems` (see
+  // `src/utils/trpc.ts`), whose dataloader SPLITS a wide fan-out across several requests rather
+  // than rejecting it. The real fix is a bulk `chat.getMessagesByIds`, which would make this one
+  // query regardless of width — deliberately left as a follow-up.
   const replyIds = useMemo(
     () => [
       ...new Set(

--- a/src/env/__tests__/server-schema-trpc-max-batch-size.test.ts
+++ b/src/env/__tests__/server-schema-trpc-max-batch-size.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { serverSchema } from '~/env/server-schema';
+import { TRPC_MAX_BATCH_SIZE } from '~/shared/constants/trpc.constants';
+
+/**
+ * TRPC_MAX_BATCH_SIZE is the server-side cap on how many procedure calls one batched tRPC
+ * request may carry. Its entire reason for being an env var is MID-INCIDENT correction: raising
+ * it is a config change on a Deployment instead of an image build plus a canary rollout.
+ *
+ * 🔴 WHY THIS IS TESTED AT THE SCHEMA. `serverSchema` is parsed once by `src/env/server.ts`,
+ * which THROWS on any invalid field. With the previous `.default(...)` spelling, a typo in that
+ * Deployment value ('' / '0' / '-5' / 'abc' / '12.5' / ' ') did not fall back to the default —
+ * it failed validation and crashed the ENTIRE app boot. An emergency lever that takes the fleet
+ * down when mistyped is worse than no lever, because it is reached for under exactly the
+ * conditions that produce typos. `.catch(...)` degrades any parse/validation failure to the
+ * compiled-in constant, i.e. to "the cap we shipped".
+ *
+ * These cases pin BEHAVIOUR — resolved value and does-not-throw — not the spelling of the
+ * schema expression, so any future refactor that preserves the fail-soft contract stays green
+ * and any that loses it goes red. `field.parse` exercises the real schema expression, taken off
+ * `serverSchema.shape`, not a paraphrase of it.
+ */
+const field = serverSchema.shape.TRPC_MAX_BATCH_SIZE;
+
+describe('TRPC_MAX_BATCH_SIZE env fail-soft', () => {
+  it('falls back to the compiled-in cap when unset — an unset env is the shipped default', () => {
+    expect(() => field.parse(undefined)).not.toThrow();
+    expect(field.parse(undefined)).toBe(TRPC_MAX_BATCH_SIZE);
+  });
+
+  it.each([
+    ['empty string', ''],
+    ['zero — would reject every batch', '0'],
+    ['negative', '-5'],
+    ['non-numeric', 'abc'],
+    ['a float', '12.5'],
+    ['whitespace only', ' '],
+  ])('resolves the default for %s WITHOUT throwing (boot survives a typo)', (_label, value) => {
+    // 🔴 Both halves matter and they are different claims. `not.toThrow()` is the boot-survival
+    // half: a throw here is what `src/env/server.ts` turns into a dead process. The value half
+    // is the direction: it must land on the compiled-in cap, never on 0/NaN/undefined, because
+    // `maxBatchSize: undefined` is how tRPC spells "no cap at all".
+    expect(() => field.parse(value)).not.toThrow();
+    expect(field.parse(value), `expected fallback for ${JSON.stringify(value)}`).toBe(
+      TRPC_MAX_BATCH_SIZE
+    );
+  });
+
+  it('passes a valid override through — otherwise the lever does nothing', () => {
+    // The positive control for the cases above: if the schema fell back on EVERYTHING, every
+    // assertion in this file would still pass while the env var was inert.
+    const parsed = field.parse('17');
+    expect(parsed).toBe(17);
+    expect(typeof parsed).toBe('number');
+    // Deliberately not the constant, so "17" cannot be satisfied by the fallback path.
+    expect(parsed).not.toBe(TRPC_MAX_BATCH_SIZE);
+  });
+});

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -411,12 +411,20 @@ export const serverSchema = z
     // (`maxBatchSize` on the adapter). Defaults to the compiled-in constant that the browser
     // batch link also mirrors, so an unset env is byte-identical to hardcoding it; the env var
     // exists so the cap can be corrected with a config change instead of an image build plus a
-    // canary rollout. Positive-integer guard for the same reason as IMAGE_SCANNING_MAX_PER_RUN:
-    // 0 or a non-number would disable the cap (or reject every batch) silently, so a bad
-    // hand-tune must fail loudly at boot. 🔴 RAISING is a safe rollback; LOWERING below the
-    // compiled-in constant is a tightening that 400s batches already-loaded browsers can still
-    // build — see `getTrpcMaxBatchSize` in `src/server/trpc/batch-cap.ts`.
-    TRPC_MAX_BATCH_SIZE: z.coerce.number().int().positive().default(TRPC_MAX_BATCH_SIZE),
+    // canary rollout. 🔴 FAIL SOFT, NOT LOUD — `.catch(...)` rather than `.default(...)`.
+    // `serverSchema` is parsed once by `src/env/server.ts`, which THROWS on any invalid field,
+    // so a `.default()` here meant a bad value ('' / '0' / '-5' / 'abc' / '12.5' / ' ') crashed
+    // the ENTIRE app boot. That is the wrong failure mode for a knob whose whole purpose is
+    // mid-incident correction: a typo on the Deployment would take the fleet down during the
+    // very incident the lever exists to fix. `.catch()` degrades any parse/validation failure
+    // to the compiled-in constant — i.e. to "the cap we shipped" — instead. The `.min(1)` floor
+    // is what makes 0 / negatives fall back rather than pass: 0 would reject every batch.
+    // Mirrors SEARCH_INDEX_MODEL_METRIC_FLUSH_INTERVAL_MS / EXTERNAL_MODERATION_TIMEOUT_MS.
+    // Pinned behaviourally by `src/env/__tests__/server-schema-trpc-max-batch-size.test.ts`.
+    // 🔴 RAISING is a safe rollback; LOWERING below the compiled-in constant is a tightening
+    // that 400s batches already-loaded browsers can still build — see `getTrpcMaxBatchSize` in
+    // `src/server/trpc/batch-cap.ts`.
+    TRPC_MAX_BATCH_SIZE: z.coerce.number().int().min(1).catch(TRPC_MAX_BATCH_SIZE),
     ORCHESTRATOR_ENDPOINT: isProd ? z.url() : z.url().optional(),
     ORCHESTRATOR_MODE: z.string().default('dev'),
     ORCHESTRATOR_ACCESS_TOKEN: z.string().default(''),

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -1,6 +1,7 @@
 // @ts-check
 import * as z from 'zod';
 import { zc } from '~/utils/schema-helpers';
+import { TRPC_MAX_BATCH_SIZE } from '~/shared/constants/trpc.constants';
 import {
   commaDelimitedStringArray,
   commaDelimitedStringObject,
@@ -406,6 +407,16 @@ export const serverSchema = z
     STORAGE_RESOLVER_ENDPOINT: z.string().optional(), // URL for storage-resolver microservice
     STORAGE_RESOLVER_AUTH: z.string().optional(), // Basic auth credentials (username:password)
     TRPC_ORIGINS: commaDelimitedStringArray().default([]),
+    // Server-side cap on how many procedure calls ONE batched tRPC request may carry
+    // (`maxBatchSize` on the adapter). Defaults to the compiled-in constant that the browser
+    // batch link also mirrors, so an unset env is byte-identical to hardcoding it; the env var
+    // exists so the cap can be corrected with a config change instead of an image build plus a
+    // canary rollout. Positive-integer guard for the same reason as IMAGE_SCANNING_MAX_PER_RUN:
+    // 0 or a non-number would disable the cap (or reject every batch) silently, so a bad
+    // hand-tune must fail loudly at boot. 🔴 RAISING is a safe rollback; LOWERING below the
+    // compiled-in constant is a tightening that 400s batches already-loaded browsers can still
+    // build — see `getTrpcMaxBatchSize` in `src/server/trpc/batch-cap.ts`.
+    TRPC_MAX_BATCH_SIZE: z.coerce.number().int().positive().default(TRPC_MAX_BATCH_SIZE),
     ORCHESTRATOR_ENDPOINT: isProd ? z.url() : z.url().optional(),
     ORCHESTRATOR_MODE: z.string().default('dev'),
     ORCHESTRATOR_ACCESS_TOKEN: z.string().default(''),

--- a/src/pages/api/trpc/[trpc].ts
+++ b/src/pages/api/trpc/[trpc].ts
@@ -6,9 +6,14 @@ import { isProd } from '~/env/other';
 import { createContext } from '~/server/createContext';
 import { logToAxiom, buildCentralErrorLog, wasServerFaultLogged } from '~/server/logging/client';
 import { recordTrpcError } from '~/server/prom/http-errors';
+import {
+  instrumentTrpcBatchRequest,
+  shouldSkipBatchCapLog,
+} from '~/server/prom/trpc-batch.metrics';
 import { isClientAbortError } from '~/server/utils/errorHandling';
 import { appRouter } from '~/server/routers';
 import { runWithSerializeCtx, serializeCtxFromRequest } from '~/server/logging/trpc-serialize-log';
+import { TRPC_MAX_BATCH_SIZE } from '~/shared/constants/trpc.constants';
 
 export const config = {
   api: {
@@ -26,6 +31,14 @@ const trpcHandler = createNextApiHandler({
   // `methodOverride: 'POST'` (see `src/utils/trpc.ts`); small queries stay GET so
   // the `responseMeta` Cache-Control headers below can still edge-cache them.
   allowMethodOverride: true,
+  // Bound how many procedure calls ONE HTTP request may carry. Batching otherwise decouples
+  // request rate from actual work — every request-counting control sees 1 where the server does
+  // N — and N is chosen by whoever builds the URL, not by our client bundle. tRPC checks this in
+  // `getRequestInfo`, i.e. BEFORE `createContext`, so an over-cap request costs URL parsing and
+  // nothing else. The browser's batch link mirrors the same constant via `maxItems` (see
+  // `src/utils/trpc.ts`); tRPC requires the client limit be <= the server's, or the browser 400s
+  // itself. Both read one constant so they cannot drift apart.
+  maxBatchSize: TRPC_MAX_BATCH_SIZE,
   responseMeta: ({ ctx, type, errors }) => {
     const headers: Record<string, string> = {};
     const willEdgeCache = ctx?.cache && !!ctx?.cache.edgeTTL && ctx?.cache.edgeTTL > 0;
@@ -55,6 +68,22 @@ const trpcHandler = createNextApiHandler({
     recordTrpcError(error, path);
 
     if (isProd) {
+      // Batch-cap rejection (see `maxBatchSize` above). The whole point of the cap is that an
+      // over-wide batch is rejected before any work happens; paying a stack capture +
+      // JSON.stringify(input) + an Axiom ingest per reject would put that cost straight back —
+      // on the event loop, once per request, during exactly the sustained abuse the cap exists
+      // to make cheap. The signal is not lost: `civitai_app_trpc_batch_width` observes every
+      // rejected request in its `over_limit="true"` series, with the actual width, which is
+      // strictly more useful than a log line whose `input` is always undefined (tRPC rejects
+      // before it parses inputs, so there is nothing to log).
+      //
+      // Narrow by construction — see `shouldSkipBatchCapLog`, which requires BOTH our own
+      // per-request over-cap marker AND a BAD_REQUEST code, so it cannot degrade into a blanket
+      // BAD_REQUEST skip that would hide real client-fault bugs. An over-cap request produces
+      // exactly one onError call (tRPC throws in getRequestInfo, before createContext), so this
+      // can only ever suppress the cap rejection itself.
+      if (shouldSkipBatchCapLog(req, error)) return error;
+
       // Auth-class rejections (FORBIDDEN / UNAUTHORIZED) are client-fault 4xx
       // responses — the status code already tells the caller + edge what
       // happened, and at scraper/bot scale these are the dominant noise in
@@ -161,6 +190,14 @@ const trpcHandler = createNextApiHandler({
 // handled natively by `allowMethodOverride: true` above (main), so no manual
 // restore step is needed here.
 export default withAxiom(async (req: NextApiRequest, res: NextApiResponse) => {
+  // Observe batch width BEFORE delegating, so the histogram sees widths that tRPC is about to
+  // reject — those requests resolve zero procedures and would otherwise leave no trace at all.
+  // The same call marks an over-cap request, which is what arms the onError log-skip above.
+  // Cheap by construction (a charCodeAt scan of the already-parsed `trpc` segment, no split)
+  // and non-throwing: on any internal failure it reports width 1, which cannot mark a request
+  // over-cap, so a broken metric degrades to "log normally" rather than "silently suppress".
+  instrumentTrpcBatchRequest(req);
+
   // Seed the request-scoped procedure-path context so the transformer's serialize
   // step (an awaited descendant of trpcHandler) can name the offending procedure
   // on an oversized/slow serialize. No-op wrapper when the instrument is disabled.

--- a/src/pages/api/trpc/[trpc].ts
+++ b/src/pages/api/trpc/[trpc].ts
@@ -13,7 +13,7 @@ import {
 import { isClientAbortError } from '~/server/utils/errorHandling';
 import { appRouter } from '~/server/routers';
 import { runWithSerializeCtx, serializeCtxFromRequest } from '~/server/logging/trpc-serialize-log';
-import { TRPC_MAX_BATCH_SIZE } from '~/shared/constants/trpc.constants';
+import { getTrpcMaxBatchSize } from '~/server/trpc/batch-cap';
 
 export const config = {
   api: {
@@ -34,11 +34,21 @@ const trpcHandler = createNextApiHandler({
   // Bound how many procedure calls ONE HTTP request may carry. Batching otherwise decouples
   // request rate from actual work — every request-counting control sees 1 where the server does
   // N — and N is chosen by whoever builds the URL, not by our client bundle. tRPC checks this in
-  // `getRequestInfo`, i.e. BEFORE `createContext`, so an over-cap request costs URL parsing and
-  // nothing else. The browser's batch link mirrors the same constant via `maxItems` (see
-  // `src/utils/trpc.ts`); tRPC requires the client limit be <= the server's, or the browser 400s
-  // itself. Both read one constant so they cannot drift apart.
-  maxBatchSize: TRPC_MAX_BATCH_SIZE,
+  // `getRequestInfo`, i.e. BEFORE `createContext`, so an over-cap request resolves zero
+  // procedures and creates no context.
+  //
+  // ⚠️ On a GET that means it costs URL parsing and nothing else. On a POST — legitimate here,
+  // `allowMethodOverride: true` lets a query carry its input in the body — Next has already
+  // parsed the body (up to the 17mb `sizeLimit` above) before this handler runs, and the adapter
+  // re-stringifies it before `resolveResponse`; the cap cannot avoid that. What it does avoid is
+  // the N-procedure amplification, on both methods.
+  //
+  // Env-overridable (`TRPC_MAX_BATCH_SIZE`, default = the shared constant), so a correction is a
+  // config change rather than a build + canary. The browser's batch link mirrors the compiled-in
+  // constant via `maxItems` (see `src/utils/trpc.ts`); tRPC requires the client limit be <= the
+  // server's — which is why RAISING this is safe and lowering it below the constant is not. See
+  // `getTrpcMaxBatchSize`.
+  maxBatchSize: getTrpcMaxBatchSize(),
   responseMeta: ({ ctx, type, errors }) => {
     const headers: Record<string, string> = {};
     const willEdgeCache = ctx?.cache && !!ctx?.cache.edgeTTL && ctx?.cache.edgeTTL > 0;
@@ -69,7 +79,7 @@ const trpcHandler = createNextApiHandler({
 
     if (isProd) {
       // Batch-cap rejection (see `maxBatchSize` above). The whole point of the cap is that an
-      // over-wide batch is rejected before any work happens; paying a stack capture +
+      // over-wide batch resolves no procedures; paying a stack capture +
       // JSON.stringify(input) + an Axiom ingest per reject would put that cost straight back —
       // on the event loop, once per request, during exactly the sustained abuse the cap exists
       // to make cheap. The signal is not lost: `civitai_app_trpc_batch_width` observes every

--- a/src/server/__tests__/trpc-batch-cap.test.ts
+++ b/src/server/__tests__/trpc-batch-cap.test.ts
@@ -1,0 +1,523 @@
+import { readFileSync } from 'fs';
+import { createServer, type Server } from 'http';
+import { join } from 'path';
+import type { AddressInfo } from 'net';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { initTRPC } from '@trpc/server';
+import { createNextApiHandler } from '@trpc/server/adapters/next';
+import { z } from 'zod';
+
+import {
+  TRPC_MAX_BATCH_SIZE,
+  OBSERVED_MAX_FIRST_PARTY_BATCH_WIDTH,
+} from '~/shared/constants/trpc.constants';
+import {
+  __resetTrpcBatchMetricsForTest,
+  boundedClientLabel,
+  computeBatchWidth,
+  instrumentTrpcBatchRequest,
+  isTrpcBatchOverCap,
+  markTrpcBatchOverCap,
+  observeTrpcBatchWidth,
+  shouldSkipBatchCapLog,
+  trpcBatchWidthHistogram,
+} from '~/server/prom/trpc-batch.metrics';
+
+/**
+ * Coverage for the tRPC BATCH-WIDTH CAP.
+ *
+ * tRPC batching lets one HTTP request carry N procedure calls, so request rate stops being a
+ * proxy for work: rate limits, connection caps and per-request timeouts all see 1 where the
+ * server does N, and N is chosen by whoever builds the URL. `TRPC_MAX_BATCH_SIZE` bounds N.
+ *
+ * The cap is only worth having if rejection is CHEAP, which requires it to happen before any
+ * per-request setup. tRPC rejects inside `getRequestInfo`, before `ctxManager.create()` — so
+ * the tests below assert not just the 400 but that ZERO procedures resolved and NO context was
+ * created. A status-code assertion alone would pass just as happily if the server had built a
+ * session, hit the DB for every one of 200 calls, and then returned 400.
+ *
+ * Lives in `src/server/__tests__/` rather than beside the route: `next build` fails on test
+ * files under `src/pages` (see `by-hash-ids-endpoint.test.ts`).
+ */
+
+// ---------------------------------------------------------------------------
+// Harness: a real node:http server, so `req`/`res` are genuine Node objects and
+// the adapter's stream handling, status writing and error envelope are all real.
+// ---------------------------------------------------------------------------
+
+type Handler = (req: NextApiRequest, res: NextApiResponse) => unknown;
+
+/**
+ * Populate `req.query` the way Next populates it for the dynamic route `pages/api/trpc/[trpc]`:
+ * the single `[trpc]` segment (decoded) plus the search params. Nothing else about the request
+ * is synthesised — it is a real `IncomingMessage` off a real socket.
+ */
+function serveHandler(handler: Handler): Promise<{ server: Server; url: string }> {
+  const server = createServer((req, res) => {
+    const url = new URL(req.url ?? '/', 'http://localhost');
+    const trpc = decodeURIComponent(url.pathname.replace(/^\/api\/trpc\//, ''));
+    const query: Record<string, string | string[]> = { trpc };
+    for (const key of new Set(url.searchParams.keys())) {
+      const all = url.searchParams.getAll(key);
+      query[key] = all.length > 1 ? all : all[0];
+    }
+    (req as unknown as NextApiRequest).query = query;
+    void (handler as (r: unknown, s: unknown) => unknown)(req, res);
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({ server, url: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+const closeServer = (server: Server) =>
+  new Promise<void>((resolve) => server.close(() => resolve()));
+
+/** Build a batched tRPC GET URL of exactly `width` calls to `path`. */
+function batchUrl(base: string, path: string, width: number) {
+  const paths = Array.from({ length: width }, () => path).join(',');
+  const input = JSON.stringify(
+    Object.fromEntries(Array.from({ length: width }, (_, i) => [i, { n: i }]))
+  );
+  return `${base}/api/trpc/${paths}?batch=1&input=${encodeURIComponent(input)}`;
+}
+
+// ---------------------------------------------------------------------------
+// A: the cap, on a router whose resolver calls we can count exactly
+// ---------------------------------------------------------------------------
+
+describe('maxBatchSize enforcement', () => {
+  const resolver = vi.fn(({ input }: { input: { n: number } }) => ({ echoed: input.n }));
+  const createContext = vi.fn(() => ({ hello: 'world' }));
+
+  const t = initTRPC.create();
+  const router = t.router({
+    echo: t.procedure.input(z.object({ n: z.number() })).query(resolver as never),
+  });
+
+  let server: Server;
+  let base: string;
+
+  beforeAll(async () => {
+    const handler = createNextApiHandler({
+      router,
+      createContext: createContext as never,
+      // The value under test, read from the same module production reads.
+      maxBatchSize: TRPC_MAX_BATCH_SIZE,
+      onError: () => undefined,
+    });
+    const started = await serveHandler(handler as Handler);
+    server = started.server;
+    base = started.url;
+  });
+
+  afterAll(async () => {
+    await closeServer(server);
+  });
+
+  beforeEach(() => {
+    resolver.mockClear();
+    createContext.mockClear();
+  });
+
+  it(`rejects a batch of ${
+    TRPC_MAX_BATCH_SIZE + 1
+  } with 400 and resolves ZERO procedures`, async () => {
+    const res = await fetch(batchUrl(base, 'echo', TRPC_MAX_BATCH_SIZE + 1));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    // A well-formed tRPC error envelope, not an unshaped crash — the client can surface this.
+    // (This router declares no transformer, so the envelope is untransformed; production's
+    // transformer wraps the same object one level deeper, under `error.json`.)
+    expect(body).toMatchObject({
+      error: { message: expect.any(String), data: { code: 'BAD_REQUEST', httpStatus: 400 } },
+    });
+
+    // 🔴 The load-bearing half. A 400 alone is compatible with the server having done all the
+    // work first; these two are what prove the rejection is free.
+    expect(resolver).not.toHaveBeenCalled();
+    expect(createContext).not.toHaveBeenCalled();
+  });
+
+  it(`accepts a batch of exactly ${TRPC_MAX_BATCH_SIZE} and resolves every call`, async () => {
+    const res = await fetch(batchUrl(base, 'echo', TRPC_MAX_BATCH_SIZE));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(body)).toBe(true);
+    expect(body).toHaveLength(TRPC_MAX_BATCH_SIZE);
+    expect(body[0]).toMatchObject({ result: { data: { echoed: 0 } } });
+    expect(resolver).toHaveBeenCalledTimes(TRPC_MAX_BATCH_SIZE);
+    expect(createContext).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts the widest batch first-party traffic actually emits', async () => {
+    const res = await fetch(batchUrl(base, 'echo', OBSERVED_MAX_FIRST_PARTY_BATCH_WIDTH));
+    expect(res.status).toBe(200);
+    expect(resolver).toHaveBeenCalledTimes(OBSERVED_MAX_FIRST_PARTY_BATCH_WIDTH);
+  });
+
+  it('rejects a very wide batch (the abuse shape) just as cheaply', async () => {
+    const res = await fetch(batchUrl(base, 'echo', 200));
+    expect(res.status).toBe(400);
+    expect(resolver).not.toHaveBeenCalled();
+    expect(createContext).not.toHaveBeenCalled();
+  });
+
+  it('leaves an UNBATCHED request untouched however long the path is', async () => {
+    // No `?batch=1` => not a batch call => the cap does not apply, and the comma-bearing path
+    // is one procedure name (which does not exist). Confirms the cap keys on `batch`, not on
+    // commas — otherwise a non-batched request could be rejected by counting separators.
+    const res = await fetch(`${base}/api/trpc/echo?input=${encodeURIComponent('{"n":1}')}`);
+    expect(res.status).toBe(200);
+    expect(resolver).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// B: batch-width measurement + the over-cap marker
+// ---------------------------------------------------------------------------
+
+const req = (query: Record<string, unknown>, headers: Record<string, unknown> = {}) =>
+  ({ query, headers } as unknown as NextApiRequest);
+
+describe('computeBatchWidth', () => {
+  it('counts comma-separated calls when batch=1', () => {
+    expect(computeBatchWidth(req({ trpc: 'a', batch: '1' }))).toBe(1);
+    expect(computeBatchWidth(req({ trpc: 'a,b', batch: '1' }))).toBe(2);
+    expect(computeBatchWidth(req({ trpc: 'a,b,c', batch: '1' }))).toBe(3);
+  });
+
+  it('agrees with tRPC: no batch=1 means width 1, whatever the path contains', () => {
+    expect(computeBatchWidth(req({ trpc: 'a,b,c,d' }))).toBe(1);
+    expect(computeBatchWidth(req({ trpc: 'a,b,c,d', batch: '0' }))).toBe(1);
+  });
+
+  it('reads the FIRST value of a repeated batch param, as URLSearchParams.get does', () => {
+    expect(computeBatchWidth(req({ trpc: 'a,b', batch: ['1', '0'] }))).toBe(2);
+    expect(computeBatchWidth(req({ trpc: 'a,b', batch: ['0', '1'] }))).toBe(1);
+  });
+
+  it('sums separators across a multi-segment path array', () => {
+    // Verified against the adapter rather than assumed: `createNextApiHandler` joins an array
+    // `req.query.trpc` with '/', NOT with ',', and tRPC then splits the joined string on ','.
+    // So ['a,b','c,d'] -> 'a,b/c,d' -> ['a','b/c','d'] = 3 calls, not 4. Counting separators
+    // across the elements reproduces that exactly; treating each element as its own call would
+    // over-report by one per extra segment.
+    expect(computeBatchWidth(req({ trpc: ['a,b', 'c,d'], batch: '1' }))).toBe(3);
+    expect(['a,b', 'c,d'].join('/').split(',').length).toBe(3); // the derivation, pinned
+  });
+
+  it('is total on malformed input rather than throwing', () => {
+    expect(computeBatchWidth(req({ batch: '1' }))).toBe(1);
+    expect(computeBatchWidth({} as NextApiRequest)).toBe(1);
+  });
+
+  it('measures the abusive widths the cap exists to reject', () => {
+    expect(computeBatchWidth(req({ trpc: Array(150).fill('a').join(','), batch: '1' }))).toBe(150);
+    expect(computeBatchWidth(req({ trpc: Array(200).fill('a').join(','), batch: '1' }))).toBe(200);
+  });
+});
+
+describe('boundedClientLabel', () => {
+  it('collapses to exactly three values so a crafted header cannot blow up cardinality', () => {
+    expect(boundedClientLabel('web')).toBe('web');
+    expect(boundedClientLabel(undefined)).toBe('none');
+    const crafted = ['a', 'b', 'c'].map((s) => boundedClientLabel(s.repeat(50)));
+    expect(new Set(crafted)).toEqual(new Set(['other']));
+    expect(boundedClientLabel(['web', 'spoof'])).toBe('web'); // first value, like a header read
+  });
+});
+
+describe('over-cap marker', () => {
+  it('is false by default and true once marked', () => {
+    const r = req({});
+    expect(isTrpcBatchOverCap(r)).toBe(false);
+    markTrpcBatchOverCap(r);
+    expect(isTrpcBatchOverCap(r)).toBe(true);
+  });
+
+  it('is per-request: marking one does not mark another', () => {
+    const a = req({});
+    const b = req({});
+    markTrpcBatchOverCap(a);
+    expect(isTrpcBatchOverCap(b)).toBe(false);
+  });
+
+  it('never throws on a non-object', () => {
+    expect(isTrpcBatchOverCap(undefined)).toBe(false);
+    expect(isTrpcBatchOverCap(null)).toBe(false);
+    expect(() => markTrpcBatchOverCap(null)).not.toThrow();
+  });
+});
+
+/**
+ * 🔴 This block exists because a mutation that DELETED the marking survived a fully green
+ * suite. Marking is what arms the log-storm skip, and losing it fails silently — the cap still
+ * rejects, the histogram still moves, and every rejected batch quietly resumes paying a stack
+ * capture + Axiom ingest. Nothing observable changes except the cost the cap exists to avoid.
+ * These are the behavioural pins that now kill that mutant.
+ */
+describe('instrumentTrpcBatchRequest (observe + mark, in one call)', () => {
+  const wide = (width: number) => req({ trpc: Array(width).fill('a').join(','), batch: '1' });
+
+  beforeEach(() => {
+    __resetTrpcBatchMetricsForTest();
+  });
+
+  it('marks a request ABOVE the cap', () => {
+    const r = wide(TRPC_MAX_BATCH_SIZE + 1);
+    expect(instrumentTrpcBatchRequest(r)).toBe(TRPC_MAX_BATCH_SIZE + 1);
+    expect(isTrpcBatchOverCap(r)).toBe(true);
+  });
+
+  it('does NOT mark a request exactly AT the cap', () => {
+    const r = wide(TRPC_MAX_BATCH_SIZE);
+    expect(instrumentTrpcBatchRequest(r)).toBe(TRPC_MAX_BATCH_SIZE);
+    expect(isTrpcBatchOverCap(r)).toBe(false);
+  });
+
+  it('does NOT mark an ordinary narrow request', () => {
+    const r = req({ trpc: 'a,b,c', batch: '1' });
+    instrumentTrpcBatchRequest(r);
+    expect(isTrpcBatchOverCap(r)).toBe(false);
+  });
+
+  it('observes the width as well as marking (one call does both)', async () => {
+    instrumentTrpcBatchRequest(wide(TRPC_MAX_BATCH_SIZE + 1));
+    expect(await bucketCount('true', 'none')).toBe(1);
+  });
+
+  it('makes the log-skip fire end to end for an over-cap request', () => {
+    // The chain the route depends on: instrument -> marker -> skip predicate. Asserting it
+    // here means deleting any link fails a test instead of silently reopening the log storm.
+    const over = wide(TRPC_MAX_BATCH_SIZE + 1);
+    const under = wide(TRPC_MAX_BATCH_SIZE);
+    instrumentTrpcBatchRequest(over);
+    instrumentTrpcBatchRequest(under);
+    expect(shouldSkipBatchCapLog(over, { code: 'BAD_REQUEST' })).toBe(true);
+    expect(shouldSkipBatchCapLog(under, { code: 'BAD_REQUEST' })).toBe(false);
+  });
+
+  it('is the call the route makes, before it delegates to the tRPC handler', () => {
+    const src = readFileSync(join(process.cwd(), 'src/pages/api/trpc/[trpc].ts'), 'utf8');
+    expect(src).toMatch(/^\s*instrumentTrpcBatchRequest\(req\);$/m);
+    expect(src.indexOf('instrumentTrpcBatchRequest(req);')).toBeLessThan(
+      src.indexOf('runWithSerializeCtx(')
+    );
+  });
+});
+
+describe('shouldSkipBatchCapLog (log-storm guard)', () => {
+  const capError = { code: 'BAD_REQUEST' as const };
+
+  it('skips the cap rejection', () => {
+    const r = req({});
+    markTrpcBatchOverCap(r);
+    expect(shouldSkipBatchCapLog(r, capError)).toBe(true);
+  });
+
+  // 🔴 NARROWNESS CONTROLS. Each isolates ONE conjunct, so a mutation that drops either is
+  // caught here rather than showing up as a silently-swallowed error class in production.
+  it('does NOT skip an ordinary BAD_REQUEST on an unmarked request', () => {
+    // The blanket-skip mutation ("skip every BAD_REQUEST") fails exactly here — this is a real
+    // failed-validation error and it must keep its Axiom ingest.
+    expect(shouldSkipBatchCapLog(req({}), capError)).toBe(false);
+  });
+
+  it('does NOT skip a non-BAD_REQUEST error on a marked request', () => {
+    const r = req({});
+    markTrpcBatchOverCap(r);
+    for (const code of ['INTERNAL_SERVER_ERROR', 'NOT_FOUND', 'TIMEOUT', 'FORBIDDEN']) {
+      expect(shouldSkipBatchCapLog(r, { code })).toBe(false);
+    }
+  });
+
+  it('does not skip when there is no error or no request', () => {
+    expect(shouldSkipBatchCapLog(req({}), undefined)).toBe(false);
+    expect(shouldSkipBatchCapLog(undefined, capError)).toBe(false);
+  });
+
+  /**
+   * Structural pin on the wiring: the predicate must be consulted in `onError` and must return
+   * BEFORE the Axiom ingest, or the log storm it exists to prevent is still paid. Source-level
+   * because the ORDER of two statements is the property under test, and the route's own module
+   * graph (appRouter, createContext) is not loadable in a unit test.
+   */
+  it('is wired into the route onError ahead of the Axiom ingest', () => {
+    const src = readFileSync(join(process.cwd(), 'src/pages/api/trpc/[trpc].ts'), 'utf8');
+    const skipAt = src.indexOf('shouldSkipBatchCapLog(req, error)');
+    const ingestAt = src.indexOf('await logToAxiom(');
+    expect(skipAt).toBeGreaterThan(-1);
+    expect(ingestAt).toBeGreaterThan(-1);
+    expect(skipAt).toBeLessThan(ingestAt);
+    // …and it must be an early return, not a bare call whose result is dropped.
+    expect(src).toMatch(/if \(shouldSkipBatchCapLog\(req, error\)\) return error;/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// C: the metric, with a positive control
+// ---------------------------------------------------------------------------
+
+/** Read `civitai_app_trpc_batch_width_count` for one label set (0 when the series is absent). */
+async function bucketCount(overLimit: 'true' | 'false', client = 'web'): Promise<number> {
+  const metric = await trpcBatchWidthHistogram.get();
+  const row = metric.values.find(
+    (v) =>
+      v.metricName === 'civitai_app_trpc_batch_width_count' &&
+      v.labels.over_limit === overLimit &&
+      v.labels.client === client
+  );
+  return typeof row?.value === 'number' ? row.value : 0;
+}
+
+/** Whether a series EXISTS for a label set, independent of its value. */
+async function seriesExists(overLimit: 'true' | 'false', client: string): Promise<boolean> {
+  const metric = await trpcBatchWidthHistogram.get();
+  return metric.values.some(
+    (v) =>
+      v.metricName === 'civitai_app_trpc_batch_width_count' &&
+      v.labels.over_limit === overLimit &&
+      v.labels.client === client
+  );
+}
+
+describe('civitai_app_trpc_batch_width histogram', () => {
+  beforeEach(() => {
+    __resetTrpcBatchMetricsForTest();
+  });
+
+  /**
+   * Without seeding, `over_limit="true"` is ABSENT until the first over-cap request a pod ever
+   * sees — so a dashboard reading "no data" cannot tell "zero rejections" from "the cap never
+   * shipped". Asserting PRESENCE (not the value, which is 0 either way) is what makes a real
+   * zero readable as a zero.
+   */
+  it('publishes every (over_limit, client) series at zero before any request', async () => {
+    for (const client of ['web', 'other', 'none']) {
+      expect({ client, over: await seriesExists('true', client) }).toEqual({ client, over: true });
+      expect({ client, under: await seriesExists('false', client) }).toEqual({
+        client,
+        under: true,
+      });
+    }
+    expect(await bucketCount('true')).toBe(0); // present AND zero
+  });
+
+  it('moves the over-cap series by exactly 1 for an over-cap request (positive control)', async () => {
+    // POSITIVE CONTROL first: prove the instrument can move at all, and by how much. A bare
+    // "the under-cap series stayed at 0" would be indistinguishable from a histogram wired to
+    // nothing, so both numbers are reported together.
+    const beforeOver = await bucketCount('true');
+    const beforeUnder = await bucketCount('false');
+
+    const width = observeTrpcBatchWidth(
+      req(
+        {
+          trpc: Array(TRPC_MAX_BATCH_SIZE + 1)
+            .fill('a')
+            .join(','),
+          batch: '1',
+        },
+        { 'x-client': 'web' }
+      )
+    );
+
+    const afterOver = await bucketCount('true');
+    const afterUnder = await bucketCount('false');
+
+    expect(width).toBe(TRPC_MAX_BATCH_SIZE + 1);
+    expect({ over: afterOver - beforeOver, under: afterUnder - beforeUnder }).toEqual({
+      over: 1,
+      under: 0,
+    });
+  });
+
+  it('classifies exactly at the cap as UNDER the limit (the cap is inclusive)', async () => {
+    observeTrpcBatchWidth(
+      req(
+        { trpc: Array(TRPC_MAX_BATCH_SIZE).fill('a').join(','), batch: '1' },
+        { 'x-client': 'web' }
+      )
+    );
+    expect({ over: await bucketCount('true'), under: await bucketCount('false') }).toEqual({
+      over: 0,
+      under: 1,
+    });
+  });
+
+  it('observes the WIDTH, not just a count, so the cap can be re-derived from live data', async () => {
+    observeTrpcBatchWidth(req({ trpc: 'a,b,c', batch: '1' }, { 'x-client': 'web' }));
+    const metric = await trpcBatchWidthHistogram.get();
+    // Select by LABELS, not just metric name: the series are pre-seeded, so a bare
+    // `find(_sum)` returns whichever seeded zero happens to come first.
+    const sum = metric.values.find(
+      (v) =>
+        v.metricName === 'civitai_app_trpc_batch_width_sum' &&
+        v.labels.over_limit === 'false' &&
+        v.labels.client === 'web'
+    );
+    expect(sum?.value).toBe(3);
+    // …and every OTHER series stayed at zero, so the 3 is attributable to this observation.
+    const otherSums = metric.values.filter(
+      (v) =>
+        v.metricName === 'civitai_app_trpc_batch_width_sum' &&
+        !(v.labels.over_limit === 'false' && v.labels.client === 'web')
+    );
+    expect(otherSums.map((v) => v.value)).toEqual(otherSums.map(() => 0));
+  });
+
+  it('labels an unknown client as `other`, keeping first-party traffic separable', async () => {
+    observeTrpcBatchWidth(req({ trpc: 'a,b', batch: '1' }, { 'x-client': 'definitely-not-web' }));
+    expect(await bucketCount('false', 'other')).toBe(1);
+    expect(await bucketCount('false', 'web')).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D: the two ends of the wire read ONE constant
+// ---------------------------------------------------------------------------
+
+/**
+ * The client limit must be <= the server's or the browser 400s itself, and a duplicated literal
+ * is exactly how that invariant rots. Asserting `TRPC_MAX_BATCH_SIZE === TRPC_MAX_BATCH_SIZE`
+ * would be vacuous, so this reads the two call sites and asserts each passes the SHARED
+ * IDENTIFIER — a hardcoded number on either side fails here.
+ */
+describe('client and server caps come from one shared constant', () => {
+  const read = (p: string) => readFileSync(join(process.cwd(), p), 'utf8');
+  const SERVER = 'src/pages/api/trpc/[trpc].ts';
+  const CLIENT = 'src/utils/trpc.ts';
+
+  it('the server adapter passes maxBatchSize: TRPC_MAX_BATCH_SIZE', () => {
+    const src = read(SERVER);
+    expect(src).toMatch(/maxBatchSize:\s*TRPC_MAX_BATCH_SIZE\s*,/);
+    expect(src).toMatch(
+      /import\s*\{[^}]*TRPC_MAX_BATCH_SIZE[^}]*\}\s*from\s*'~\/shared\/constants\/trpc\.constants'/
+    );
+    // No numeric literal smuggled in beside it.
+    expect(src).not.toMatch(/maxBatchSize:\s*\d/);
+  });
+
+  it('the client batch link passes maxItems: TRPC_MAX_BATCH_SIZE', () => {
+    const src = read(CLIENT);
+    expect(src).toMatch(/maxItems:\s*TRPC_MAX_BATCH_SIZE\s*,/);
+    expect(src).toMatch(
+      /import\s*\{[^}]*TRPC_MAX_BATCH_SIZE[^}]*\}\s*from\s*'~\/shared\/constants\/trpc\.constants'/
+    );
+    expect(src).not.toMatch(/maxItems:\s*\d/);
+  });
+
+  it('the shared module is the only place the number is written', () => {
+    const constants = read('src/shared/constants/trpc.constants.ts');
+    expect(constants).toMatch(
+      new RegExp(`export const TRPC_MAX_BATCH_SIZE = ${TRPC_MAX_BATCH_SIZE};`)
+    );
+  });
+});

--- a/src/server/__tests__/trpc-batch-cap.test.ts
+++ b/src/server/__tests__/trpc-batch-cap.test.ts
@@ -3,16 +3,19 @@ import { createServer, type Server } from 'http';
 import { join } from 'path';
 import type { AddressInfo } from 'net';
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { initTRPC } from '@trpc/server';
 import { createNextApiHandler } from '@trpc/server/adapters/next';
+import client from 'prom-client';
 import { z } from 'zod';
 
+import { resetEnv, setEnv } from '~/__tests__/mocks/env.mock';
 import {
   TRPC_MAX_BATCH_SIZE,
   OBSERVED_MAX_FIRST_PARTY_BATCH_WIDTH,
 } from '~/shared/constants/trpc.constants';
+import { getTrpcMaxBatchSize } from '~/server/trpc/batch-cap';
 import {
   __resetTrpcBatchMetricsForTest,
   boundedClientLabel,
@@ -22,6 +25,7 @@ import {
   markTrpcBatchOverCap,
   observeTrpcBatchWidth,
   shouldSkipBatchCapLog,
+  TRPC_BATCH_WIDTH_BUCKETS,
   trpcBatchWidthHistogram,
 } from '~/server/prom/trpc-batch.metrics';
 
@@ -51,8 +55,11 @@ type Handler = (req: NextApiRequest, res: NextApiResponse) => unknown;
 
 /**
  * Populate `req.query` the way Next populates it for the dynamic route `pages/api/trpc/[trpc]`:
- * the single `[trpc]` segment (decoded) plus the search params. Nothing else about the request
- * is synthesised — it is a real `IncomingMessage` off a real socket.
+ * the single `[trpc]` segment (decoded) plus the search params. For a POST it also drains and
+ * JSON-parses the body onto `req.body`, which is what Next's `bodyParser` does before the route
+ * runs — and which puts the adapter on its `"body" in req` path (`JSON.stringify(req.body)`),
+ * i.e. the same parse-then-re-stringify production pays. Nothing else about the request is
+ * synthesised: it is a real `IncomingMessage` off a real socket.
  */
 function serveHandler(handler: Handler): Promise<{ server: Server; url: string }> {
   const server = createServer((req, res) => {
@@ -64,7 +71,22 @@ function serveHandler(handler: Handler): Promise<{ server: Server; url: string }
       query[key] = all.length > 1 ? all : all[0];
     }
     (req as unknown as NextApiRequest).query = query;
-    void (handler as (r: unknown, s: unknown) => unknown)(req, res);
+
+    if (req.method === 'GET' || req.method === 'HEAD') {
+      void (handler as (r: unknown, s: unknown) => unknown)(req, res);
+      return;
+    }
+    const chunks: Buffer[] = [];
+    req.on('data', (c: Buffer) => chunks.push(c));
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8');
+      try {
+        (req as unknown as NextApiRequest).body = raw ? JSON.parse(raw) : undefined;
+      } catch {
+        (req as unknown as NextApiRequest).body = raw;
+      }
+      void (handler as (r: unknown, s: unknown) => unknown)(req, res);
+    });
   });
   return new Promise((resolve) => {
     server.listen(0, '127.0.0.1', () => {
@@ -84,6 +106,22 @@ function batchUrl(base: string, path: string, width: number) {
     Object.fromEntries(Array.from({ length: width }, (_, i) => [i, { n: i }]))
   );
   return `${base}/api/trpc/${paths}?batch=1&input=${encodeURIComponent(input)}`;
+}
+
+/**
+ * The same batch as a POST, which `allowMethodOverride: true` makes a legitimate shape for a
+ * QUERY: the path list stays in the URL, the inputs move into the body. Worth covering
+ * separately because the two methods do not cost the same — the body is parsed (and
+ * re-stringified by the adapter) before tRPC ever looks at the batch width.
+ */
+function postBatch(base: string, path: string, width: number) {
+  const paths = Array.from({ length: width }, () => path).join(',');
+  const body = Object.fromEntries(Array.from({ length: width }, (_, i) => [i, { n: i }]));
+  return fetch(`${base}/api/trpc/${paths}?batch=1`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -108,6 +146,10 @@ describe('maxBatchSize enforcement', () => {
       createContext: createContext as never,
       // The value under test, read from the same module production reads.
       maxBatchSize: TRPC_MAX_BATCH_SIZE,
+      // Mirrors production (`src/pages/api/trpc/[trpc].ts`), and is what makes a POST QUERY a
+      // legitimate shape here rather than a 405 — i.e. what makes the GET/POST symmetry cases
+      // below test the cap instead of the method map.
+      allowMethodOverride: true,
       onError: () => undefined,
     });
     const started = await serveHandler(handler as Handler);
@@ -167,6 +209,33 @@ describe('maxBatchSize enforcement', () => {
     expect(res.status).toBe(400);
     expect(resolver).not.toHaveBeenCalled();
     expect(createContext).not.toHaveBeenCalled();
+  });
+
+  // 🔴 GET/POST SYMMETRY. `allowMethodOverride: true` makes a POST query batch legitimate, so a
+  // cap enforced only on GET would leave the amplification reachable by changing one verb. It
+  // is NOT the same cost profile — Next parses the body before the handler and the adapter
+  // re-stringifies it, both before the width is checked — but the property that matters (zero
+  // procedures resolved, zero contexts created) must hold on both.
+  it(`rejects an over-cap POST batch too, resolving ZERO procedures`, async () => {
+    const res = await postBatch(base, 'echo', TRPC_MAX_BATCH_SIZE + 1);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body).toMatchObject({ error: { data: { code: 'BAD_REQUEST', httpStatus: 400 } } });
+    expect(resolver).not.toHaveBeenCalled();
+    expect(createContext).not.toHaveBeenCalled();
+  });
+
+  it('accepts an at-cap POST batch and resolves every call (the cap is not method-dependent)', async () => {
+    // The control for the case above: same verb, same body shape, width one lower. Without it a
+    // POST rejection could just as well mean "POST queries do not work here at all".
+    const res = await postBatch(base, 'echo', TRPC_MAX_BATCH_SIZE);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toHaveLength(TRPC_MAX_BATCH_SIZE);
+    expect(resolver).toHaveBeenCalledTimes(TRPC_MAX_BATCH_SIZE);
+    expect(createContext).toHaveBeenCalledTimes(1);
   });
 
   it('leaves an UNBATCHED request untouched however long the path is', async () => {
@@ -304,12 +373,32 @@ describe('instrumentTrpcBatchRequest (observe + mark, in one call)', () => {
     expect(shouldSkipBatchCapLog(under, { code: 'BAD_REQUEST' })).toBe(false);
   });
 
-  it('is the call the route makes, before it delegates to the tRPC handler', () => {
-    const src = readFileSync(join(process.cwd(), 'src/pages/api/trpc/[trpc].ts'), 'utf8');
-    expect(src).toMatch(/^\s*instrumentTrpcBatchRequest\(req\);$/m);
-    expect(src.indexOf('instrumentTrpcBatchRequest(req);')).toBeLessThan(
-      src.indexOf('runWithSerializeCtx(')
-    );
+  // NOTE: that the ROUTE makes this call, before delegating, is pinned behaviourally in
+  // `trpc-handler-wiring.test.ts` — it loads the real route with the adapter mocked and reads
+  // the marker from inside the delegate. It used to be a `^\s*…$` source-text match here, which
+  // a block comment walked straight through.
+
+  /**
+   * 🔴 The catch in `observeTrpcBatchWidth` returns 1, and the DIRECTION of that fallback is a
+   * safety property. A telemetry failure that returned a value ABOVE the cap would mark every
+   * such request over-cap, arming the `onError` skip and silently suppressing the Axiom ingest
+   * for every `BAD_REQUEST` in the process. Forcing the throw is the only way to reach it.
+   */
+  it('fails SAFE when measurement throws: width <= cap, and the request is not marked', () => {
+    const exploding = {
+      headers: {},
+      get query(): never {
+        throw new Error('measurement blew up');
+      },
+    } as unknown as NextApiRequest;
+
+    expect(() => observeTrpcBatchWidth(exploding)).not.toThrow();
+    expect(observeTrpcBatchWidth(exploding)).toBe(1);
+    expect(observeTrpcBatchWidth(exploding)).toBeLessThanOrEqual(TRPC_MAX_BATCH_SIZE);
+
+    expect(instrumentTrpcBatchRequest(exploding)).toBeLessThanOrEqual(TRPC_MAX_BATCH_SIZE);
+    expect(isTrpcBatchOverCap(exploding)).toBe(false);
+    expect(shouldSkipBatchCapLog(exploding, { code: 'BAD_REQUEST' })).toBe(false);
   });
 });
 
@@ -343,22 +432,11 @@ describe('shouldSkipBatchCapLog (log-storm guard)', () => {
     expect(shouldSkipBatchCapLog(undefined, capError)).toBe(false);
   });
 
-  /**
-   * Structural pin on the wiring: the predicate must be consulted in `onError` and must return
-   * BEFORE the Axiom ingest, or the log storm it exists to prevent is still paid. Source-level
-   * because the ORDER of two statements is the property under test, and the route's own module
-   * graph (appRouter, createContext) is not loadable in a unit test.
-   */
-  it('is wired into the route onError ahead of the Axiom ingest', () => {
-    const src = readFileSync(join(process.cwd(), 'src/pages/api/trpc/[trpc].ts'), 'utf8');
-    const skipAt = src.indexOf('shouldSkipBatchCapLog(req, error)');
-    const ingestAt = src.indexOf('await logToAxiom(');
-    expect(skipAt).toBeGreaterThan(-1);
-    expect(ingestAt).toBeGreaterThan(-1);
-    expect(skipAt).toBeLessThan(ingestAt);
-    // …and it must be an early return, not a bare call whose result is dropped.
-    expect(src).toMatch(/if \(shouldSkipBatchCapLog\(req, error\)\) return error;/);
-  });
+  // NOTE: that the route's `onError` actually CONSULTS this predicate — and returns before the
+  // Axiom ingest — is pinned behaviourally in `trpc-handler-wiring.test.ts`, by driving the real
+  // `onError` and asserting on the canonical `logToAxiom` spy (with the unmarked-request
+  // positive control beside it). The source-text version that lived here asserted the statement
+  // was SPELLED in the file, which a block comment satisfies with the code deleted.
 });
 
 // ---------------------------------------------------------------------------
@@ -391,6 +469,54 @@ async function seriesExists(overLimit: 'true' | 'false', client: string): Promis
 describe('civitai_app_trpc_batch_width histogram', () => {
   beforeEach(() => {
     __resetTrpcBatchMetricsForTest();
+  });
+
+  /**
+   * 🔴 The module's own INVARIANT comment says this metric must land on prom-client's DEFAULT
+   * registry, because `/api/metrics` scrapes that one. Nothing enforced it: adding
+   * `registers: [new client.Registry()]` to the constructor left every assertion in this file
+   * green while the series was never scraped by anything. Reading it back OFF the default
+   * registry — and asserting it is the same object this module exports — is what makes that
+   * mutant die.
+   */
+  it('is registered on the DEFAULT registry, which is the one /api/metrics scrapes', () => {
+    expect(client.register.getSingleMetric('civitai_app_trpc_batch_width')).toBe(
+      trpcBatchWidthHistogram
+    );
+  });
+
+  /**
+   * The cap's own value must be a bucket EDGE, or `le="<cap>"` stops reading as "accepted" and
+   * the histogram can no longer answer the question it exists for. Removing 30 from the list
+   * previously survived the whole suite.
+   */
+  it('has a bucket edge exactly at the cap', () => {
+    expect(TRPC_BATCH_WIDTH_BUCKETS).toContain(TRPC_MAX_BATCH_SIZE);
+    // Ascending, or prom-client silently mis-cumulates the buckets.
+    expect([...TRPC_BATCH_WIDTH_BUCKETS].sort((a, b) => a - b)).toEqual(TRPC_BATCH_WIDTH_BUCKETS);
+  });
+
+  /**
+   * The seed is destructive by construction: `Histogram.zero(labels)` REPLACES that label set's
+   * buckets/sum/count rather than no-op'ing on an existing series (unlike the
+   * `counter.inc({...}, 0)` pattern it was modelled on). This module can be evaluated more than
+   * once — that is why it is pinned on `globalThis` — so a module-scope seed that ran every time
+   * would wipe accumulated counts. Re-running the seeding function on a live series is the
+   * observable form of that bug.
+   */
+  it('does not lose accumulated counts when the module is evaluated a SECOND time', async () => {
+    observeTrpcBatchWidth(req({ trpc: 'a,b,c', batch: '1' }, { 'x-client': 'web' }));
+    expect(await bucketCount('false')).toBe(1); // positive control: the count is really there
+
+    // `vi.resetModules()` drops the module registry, so the next import RE-EVALUATES the module
+    // body — the second-evaluation case the `globalThis` pin exists for. A plain re-import would
+    // hit vitest's module cache and prove nothing. The histogram itself survives on `globalThis`,
+    // so `bucketCount` below still reads the same series.
+    vi.resetModules();
+    const reEvaluated = await import('~/server/prom/trpc-batch.metrics');
+    expect(reEvaluated.trpcBatchWidthHistogram).toBe(trpcBatchWidthHistogram); // same instance
+
+    expect(await bucketCount('false')).toBe(1); // an unconditional module-scope seed zeroes this
   });
 
   /**
@@ -485,39 +611,75 @@ describe('civitai_app_trpc_batch_width histogram', () => {
 // ---------------------------------------------------------------------------
 
 /**
- * The client limit must be <= the server's or the browser 400s itself, and a duplicated literal
- * is exactly how that invariant rots. Asserting `TRPC_MAX_BATCH_SIZE === TRPC_MAX_BATCH_SIZE`
- * would be vacuous, so this reads the two call sites and asserts each passes the SHARED
- * IDENTIFIER — a hardcoded number on either side fails here.
+ * 🔴 The two call sites are pinned BEHAVIOURALLY, in the files next door:
+ *  - server → `src/server/__tests__/trpc-handler-wiring.test.ts` reads `options.maxBatchSize`
+ *    off the object the real route hands the adapter;
+ *  - client → `src/utils/__tests__/trpc-batch-link-wiring.test.ts` reads `maxItems` off the
+ *    options `src/utils/trpc.ts` actually constructs, via a spy on `httpBatchStreamLink`.
+ * They used to be regexes over those two files. Both were walked by a block comment, so the cap
+ * could be deleted with this suite fully green.
+ *
+ * What remains here is the part that genuinely is a claim about the SOURCE — that the number is
+ * written in exactly one place — plus the env-resolution contract that decides what the server
+ * actually enforces.
  */
-describe('client and server caps come from one shared constant', () => {
-  const read = (p: string) => readFileSync(join(process.cwd(), p), 'utf8');
-  const SERVER = 'src/pages/api/trpc/[trpc].ts';
-  const CLIENT = 'src/utils/trpc.ts';
-
-  it('the server adapter passes maxBatchSize: TRPC_MAX_BATCH_SIZE', () => {
-    const src = read(SERVER);
-    expect(src).toMatch(/maxBatchSize:\s*TRPC_MAX_BATCH_SIZE\s*,/);
-    expect(src).toMatch(
-      /import\s*\{[^}]*TRPC_MAX_BATCH_SIZE[^}]*\}\s*from\s*'~\/shared\/constants\/trpc\.constants'/
-    );
-    // No numeric literal smuggled in beside it.
-    expect(src).not.toMatch(/maxBatchSize:\s*\d/);
-  });
-
-  it('the client batch link passes maxItems: TRPC_MAX_BATCH_SIZE', () => {
-    const src = read(CLIENT);
-    expect(src).toMatch(/maxItems:\s*TRPC_MAX_BATCH_SIZE\s*,/);
-    expect(src).toMatch(
-      /import\s*\{[^}]*TRPC_MAX_BATCH_SIZE[^}]*\}\s*from\s*'~\/shared\/constants\/trpc\.constants'/
-    );
-    expect(src).not.toMatch(/maxItems:\s*\d/);
+describe('the cap has one source, and the server resolves it through the env', () => {
+  // Per-file overrides are cleared between FILES, not between cases — and these cases
+  // deliberately move the cap, so leaving one set would silently retune every later assertion.
+  afterEach(() => {
+    resetEnv();
   });
 
   it('the shared module is the only place the number is written', () => {
-    const constants = read('src/shared/constants/trpc.constants.ts');
+    const constants = readFileSync(
+      join(process.cwd(), 'src/shared/constants/trpc.constants.ts'),
+      'utf8'
+    );
     expect(constants).toMatch(
       new RegExp(`export const TRPC_MAX_BATCH_SIZE = ${TRPC_MAX_BATCH_SIZE};`)
     );
+  });
+
+  it('defaults to the compiled-in constant when the env var is unset', () => {
+    // The production default path, and the one every other test in this file assumes.
+    expect(getTrpcMaxBatchSize()).toBe(TRPC_MAX_BATCH_SIZE);
+  });
+
+  it('takes a valid env override — the point of the var (rollback without a build)', () => {
+    setEnv({ TRPC_MAX_BATCH_SIZE: 7 });
+    expect(getTrpcMaxBatchSize()).toBe(7);
+    setEnv({ TRPC_MAX_BATCH_SIZE: 500 });
+    expect(getTrpcMaxBatchSize()).toBe(500);
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['zero (would reject every batch)', 0],
+    ['negative', -5],
+    ['non-integer', 12.5],
+    ['NaN', Number.NaN],
+    ['a string that slipped past the schema', '40' as unknown as number],
+  ])('falls back to the constant rather than uncapping on %s', (_label, value) => {
+    // 🔴 The direction matters: an unusable value must NOT become `maxBatchSize: undefined`,
+    // which is how tRPC spells "no cap". Every one of these fails toward "still capped".
+    setEnv({ TRPC_MAX_BATCH_SIZE: value });
+    expect(getTrpcMaxBatchSize()).toBe(TRPC_MAX_BATCH_SIZE);
+  });
+
+  it('the override reaches the over-cap classification, not just the adapter', async () => {
+    // Otherwise the metric (and the `onError` skip it arms) would keep labelling against the
+    // compiled-in constant while tRPC enforced something else — marking requests tRPC ACCEPTED
+    // as over-cap, and suppressing genuine BAD_REQUEST logs from their procedures.
+    __resetTrpcBatchMetricsForTest();
+    setEnv({ TRPC_MAX_BATCH_SIZE: 3 });
+
+    const r = req({ trpc: 'a,b,c,d', batch: '1' }, { 'x-client': 'web' }); // width 4 > 3
+    expect(instrumentTrpcBatchRequest(r)).toBe(4);
+    expect(isTrpcBatchOverCap(r)).toBe(true);
+    expect(await bucketCount('true')).toBe(1);
+
+    // …and the control: the same width is UNDER the compiled-in constant, so a classification
+    // still reading `TRPC_MAX_BATCH_SIZE` would have left it unmarked.
+    expect(4).toBeLessThan(TRPC_MAX_BATCH_SIZE);
   });
 });

--- a/src/server/__tests__/trpc-handler-wiring.test.ts
+++ b/src/server/__tests__/trpc-handler-wiring.test.ts
@@ -1,0 +1,190 @@
+import { TRPCError } from '@trpc/server';
+import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { resetEnv, setEnv } from '~/__tests__/mocks/env.mock';
+import { logToAxiom } from '~/server/logging/client';
+import {
+  __resetTrpcBatchMetricsForTest,
+  isTrpcBatchOverCap,
+} from '~/server/prom/trpc-batch.metrics';
+import { getTrpcMaxBatchSize } from '~/server/trpc/batch-cap';
+import { TRPC_MAX_BATCH_SIZE } from '~/shared/constants/trpc.constants';
+
+/**
+ * BEHAVIOURAL coverage for the wiring inside `src/pages/api/trpc/[trpc].ts`.
+ *
+ * 🔴 WHY THIS FILE EXISTS. Three properties of that route — the cap it hands the adapter, that
+ * it instruments the request before delegating, and that its `onError` consults the log-storm
+ * skip — used to be pinned by matching the route's SOURCE TEXT. Every one of those regexes was
+ * walked by wrapping the real line in a block comment: the code was gone, the string was still
+ * in the file, and the suite stayed green — including for the mutant that removes the cap
+ * entirely. A source-text guard asserts SPELLING, and spelling survives being commented out.
+ *
+ * The assertions below read values the module actually produced and effects it actually had, so
+ * there is nothing to spell around: comment the line out and the property is `undefined`, or the
+ * call never happens, and the assertion written for it fails by name.
+ *
+ * The route IS loadable in a unit test — the earlier claim that it is not was wrong. Its module
+ * graph pulls `appRouter` and `createContext`, and both are mockable; the adapter is mocked too,
+ * so what is under test is exactly the options object and handler this file constructs.
+ */
+
+/** Only the parts of the adapter options this file asserts on. */
+type CapturedOptions = {
+  maxBatchSize?: number;
+  allowMethodOverride?: boolean;
+  onError?: (opts: Record<string, unknown>) => unknown;
+};
+
+const h = vi.hoisted(() => ({
+  /** The options object the route hands `createNextApiHandler`. */
+  options: undefined as CapturedOptions | undefined,
+  /** Stands in for the adapter's handler, so "did the route delegate, and when" is observable. */
+  inner: vi.fn(),
+  /** Whether the request was ALREADY marked over-cap at the moment the route delegated. */
+  markedAtDelegation: undefined as boolean | undefined,
+}));
+
+vi.mock('~/server/routers', () => ({ appRouter: { __testRouter: true } }));
+vi.mock('~/server/createContext', () => ({ createContext: vi.fn() }));
+// withAxiom is a transparent wrapper here; the route's own body is what is under test.
+vi.mock('@civitai/next-axiom', () => ({ withAxiom: (fn: unknown) => fn }));
+vi.mock('@trpc/server/adapters/next', () => ({
+  createNextApiHandler: (options: CapturedOptions) => {
+    h.options = options;
+    return h.inner;
+  },
+}));
+// The route's Axiom ingest is `isProd`-gated, so without this the whole branch under test is
+// unreachable and the skip assertions below would pass for the wrong reason.
+vi.mock('~/env/other', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  isProd: true,
+}));
+
+const res = {} as NextApiResponse;
+let route: NextApiHandler;
+
+/**
+ * A cap deliberately DIFFERENT from `TRPC_MAX_BATCH_SIZE`, applied to the env before the route
+ * module is evaluated. The route resolves `maxBatchSize` once, at module scope — so asserting it
+ * equals this value (and not the constant) distinguishes "resolves the env-backed cap" from
+ * "hardcodes the compiled-in number", which are the same 30 in every other test here.
+ */
+const ROUTE_LOAD_CAP = 17;
+
+/** A request shaped the way Next populates `[trpc]`: decoded dynamic segment + search params. */
+const request = (width: number) =>
+  ({
+    method: 'GET',
+    headers: {},
+    query: { trpc: Array(width).fill('a').join(','), batch: '1' },
+  } as unknown as NextApiRequest);
+
+describe('src/pages/api/trpc/[trpc].ts wiring', () => {
+  beforeAll(async () => {
+    h.inner.mockImplementation((req: NextApiRequest) => {
+      h.markedAtDelegation = isTrpcBatchOverCap(req);
+    });
+    setEnv({ TRPC_MAX_BATCH_SIZE: ROUTE_LOAD_CAP });
+    route = (await import('~/pages/api/trpc/[trpc]')).default;
+    // Cleared immediately: every per-request assertion below is against the DEFAULT cap, which
+    // the metric resolves per call. Only the adapter options were frozen at import time.
+    resetEnv();
+  });
+
+  beforeEach(() => {
+    __resetTrpcBatchMetricsForTest();
+    h.inner.mockClear();
+    h.markedAtDelegation = undefined;
+    vi.mocked(logToAxiom).mockClear();
+  });
+
+  // -------------------------------------------------------------------------
+  // The cap actually reaches the adapter
+  // -------------------------------------------------------------------------
+
+  it('hands the adapter a maxBatchSize resolved from the env-backed cap', () => {
+    // Reads the VALUE the route produced. Commenting the line out makes this `undefined`, which
+    // is how tRPC spells "no cap at all" — the single most consequential mutant in this PR.
+    expect(h.options?.maxBatchSize).toBe(ROUTE_LOAD_CAP);
+    // …and not the compiled-in constant, so a hardcoded `maxBatchSize: 30` — which would look
+    // right and silently ignore the env override the rollback path depends on — fails here.
+    expect(h.options?.maxBatchSize).not.toBe(TRPC_MAX_BATCH_SIZE);
+    expect(Number.isInteger(h.options?.maxBatchSize)).toBe(true);
+    expect(h.options?.maxBatchSize).toBeGreaterThan(0);
+  });
+
+  it('with no override, that same resolution is the compiled-in constant', () => {
+    // The control for the case above: it is an OVERRIDE that moved the number, not a coincidence.
+    expect(getTrpcMaxBatchSize()).toBe(TRPC_MAX_BATCH_SIZE);
+  });
+
+  it('keeps allowMethodOverride on (a POST query is a supported shape, and is capped too)', () => {
+    expect(h.options?.allowMethodOverride).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // The request is instrumented BEFORE the adapter sees it
+  // -------------------------------------------------------------------------
+
+  it('marks an over-cap request BEFORE delegating to the tRPC handler', async () => {
+    const req = request(TRPC_MAX_BATCH_SIZE + 1);
+    await route(req, res);
+
+    expect(h.inner).toHaveBeenCalledTimes(1);
+    expect(h.inner).toHaveBeenCalledWith(req, res);
+    // ORDERING, not just occurrence: this is read INSIDE the delegate, so an instrument call
+    // moved after the delegation (or deleted) fails here.
+    expect(h.markedAtDelegation).toBe(true);
+    expect(isTrpcBatchOverCap(req)).toBe(true);
+  });
+
+  it('does not mark an under-cap request, but still delegates it', async () => {
+    const req = request(TRPC_MAX_BATCH_SIZE);
+    await route(req, res);
+
+    expect(h.inner).toHaveBeenCalledTimes(1);
+    expect(h.markedAtDelegation).toBe(false);
+    expect(isTrpcBatchOverCap(req)).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // onError consults the skip predicate — asserted by what it does, not what it says
+  // -------------------------------------------------------------------------
+
+  const capRejection = () =>
+    new TRPCError({ code: 'BAD_REQUEST', message: 'Batch call exceeds maximum size' });
+
+  const callOnError = (req: NextApiRequest, error: TRPCError) =>
+    h.options?.onError?.({ error, type: 'query', path: undefined, input: undefined, ctx: {}, req });
+
+  it('skips the Axiom ingest for a request the instrument marked over-cap', async () => {
+    const req = request(TRPC_MAX_BATCH_SIZE + 1);
+    await route(req, res); // marks it, exactly as production does
+    vi.mocked(logToAxiom).mockClear();
+
+    await callOnError(req, capRejection());
+    expect(vi.mocked(logToAxiom)).not.toHaveBeenCalled();
+  });
+
+  it('POSITIVE CONTROL: an identical BAD_REQUEST on an UNMARKED request IS ingested', async () => {
+    // Without this, "not called" above is indistinguishable from an onError wired to nothing —
+    // and from an `isProd` gate that never opened. Same error, same shape, one variable changed.
+    const req = request(2);
+    await route(req, res); // under cap => not marked
+
+    await callOnError(req, capRejection());
+    expect(vi.mocked(logToAxiom)).toHaveBeenCalledTimes(1);
+  });
+
+  it('still ingests a non-BAD_REQUEST error on a marked request (the skip stays narrow)', async () => {
+    const req = request(TRPC_MAX_BATCH_SIZE + 1);
+    await route(req, res);
+    vi.mocked(logToAxiom).mockClear();
+
+    await callOnError(req, new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'boom' }));
+    expect(vi.mocked(logToAxiom)).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/prom/trpc-batch.metrics.ts
+++ b/src/server/prom/trpc-batch.metrics.ts
@@ -1,0 +1,265 @@
+import client from 'prom-client';
+import type { NextApiRequest } from 'next';
+import { TRPC_MAX_BATCH_SIZE } from '~/shared/constants/trpc.constants';
+
+// ---------------------------------------------------------------------------
+// tRPC batch-width observability + the over-cap request marker
+// ---------------------------------------------------------------------------
+//
+// WHY: tRPC batching lets ONE HTTP request fan out to N procedure calls, which decouples
+// request rate from actual work — every request-counting control (rate limits, connection
+// caps, per-request timeouts) sees 1 where the server does N. `TRPC_MAX_BATCH_SIZE` bounds N;
+// this histogram is how we know whether that bound is in the right place, because it observes
+// EVERY batch width unconditionally — including widths above the cap, which are rejected and
+// would otherwise leave no trace at all.
+//
+// HOT PATH: this codebase is main-thread-CPU sensitive (Redis/Prisma OTEL spans were removed
+// for exactly this reason). Per request this costs one `charCodeAt` scan of the already-parsed
+// `trpc` query segment plus one histogram observation — deliberately NO `split(',')`, which
+// would allocate an N-element array of substrings on every batched request just to read its
+// length.
+//
+// 🔴 INVARIANT: import this module ONLY from the request webpack graph (API routes / pages).
+// prom-client keeps a per-graph default registry and `/api/metrics` scrapes the request
+// graph's; if an `instrumentation.*` import ever pulled this into the instrumentation graph
+// first, the histogram would register into the wrong registry and silently stop being scraped
+// (the PR #2451 class of bug — see the same note in `http-errors.ts`). Today the only
+// production importer is `src/pages/api/trpc/[trpc].ts`. Test-only imports are fine: they run
+// outside webpack entirely.
+
+const NAME = 'civitai_app_trpc_batch_width';
+
+/** Histogram buckets. Dense below the cap (where legitimate traffic lives), sparse above it
+ *  (where only rejected traffic lands) — 30 is a bucket edge so `le="30"` reads directly as
+ *  "accepted", and 25 sits just under it so the approach to the cap is visible before anything
+ *  is actually clipped. */
+export const TRPC_BATCH_WIDTH_BUCKETS = [1, 2, 3, 5, 10, 20, 25, 30, 50, 100, 150, 250];
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __civitaiTrpcBatchWidthHistogram: client.Histogram<string> | undefined;
+}
+
+// Pin on globalThis so HMR re-evals / a second request-graph eval reuse the one instance
+// instead of throwing prom-client's duplicate-registration error (same trap documented for
+// `httpErrorCounter` in http-errors.ts and `instrumentationRegistry` in prom/client.ts). The
+// `??` short-circuits BEFORE `new client.Histogram`, so the constructor runs once.
+export const trpcBatchWidthHistogram: client.Histogram<string> =
+  globalThis.__civitaiTrpcBatchWidthHistogram ??
+  (globalThis.__civitaiTrpcBatchWidthHistogram = new client.Histogram({
+    name: NAME,
+    help:
+      'Distribution of tRPC BATCH WIDTH (procedure calls carried by one HTTP request), observed ' +
+      'on every /api/trpc request before the request is handled. Non-batched requests (no ' +
+      '`?batch=1`) are observed as width 1. `over_limit="true"` means the width exceeded ' +
+      'TRPC_MAX_BATCH_SIZE and tRPC rejected the whole request with a 400 before createContext ' +
+      'ran — those requests resolve ZERO procedures, so they appear here and nowhere else. ' +
+      '`client` is a hard-bounded 3-value label (web|other|none) derived from the x-client ' +
+      'header; it is caller-supplied and is NOT authentication — treat `web` as "claims to be ' +
+      'the browser bundle", not as proof.',
+    buckets: TRPC_BATCH_WIDTH_BUCKETS,
+    labelNames: ['over_limit', 'client'],
+  }));
+
+/** Every value `client` can take. Enumerated so the series can be seeded (below). */
+const CLIENT_LABELS = ['web', 'other', 'none'] as const;
+
+/**
+ * Initialise all 6 (over_limit x client) series to zero.
+ *
+ * 🔴 A labelled histogram emits NOTHING for a label set until its first observation, so
+ * `over_limit="true"` would read `no data` until the first over-cap request ever seen by this
+ * pod — indistinguishable from "the cap is not wired up" or "this module never loaded", on the
+ * exact series whose job is to be read as evidence. Seeding makes a genuine zero observable as
+ * a zero. (Same reasoning, and the same fix, as the generation-model-substitution counters
+ * seeded from `src/pages/api/metrics.ts`.)
+ */
+function seedTrpcBatchWidthSeries(): void {
+  try {
+    for (const over_limit of ['true', 'false']) {
+      for (const client of CLIENT_LABELS) trpcBatchWidthHistogram.zero({ over_limit, client });
+    }
+  } catch {
+    /* never throw from telemetry */
+  }
+}
+
+seedTrpcBatchWidthSeries();
+
+const COMMA = 44; // ','.charCodeAt(0)
+
+/**
+ * Count `,` separators without allocating. `split(',')` would build an N-element array of
+ * substrings per batched request purely to read `.length`; this reads the same number off the
+ * string already in memory.
+ */
+function countSeparators(s: string): number {
+  let n = 0;
+  for (let i = 0; i < s.length; i++) if (s.charCodeAt(i) === COMMA) n++;
+  return n;
+}
+
+/**
+ * Next merges repeated query params into an array. tRPC reads `batch` via
+ * `URLSearchParams.get()`, which returns the FIRST occurrence — mirror that so a duplicated
+ * `?batch=1&batch=0` is classified the same way the server actually treats it.
+ */
+function firstValue(v: string | string[] | undefined): string | undefined {
+  if (typeof v === 'string') return v;
+  if (Array.isArray(v)) return v[0];
+  return undefined;
+}
+
+/**
+ * Batch width for a tRPC request, computed the way tRPC computes it: a request is a batch call
+ * only when `?batch=1`, and its width is `path.split(',').length`.
+ *
+ * The path comes from `req.query.trpc` — the `[trpc]` dynamic segment. Next hands it back as a
+ * string, or as an array when the route resolves to multiple segments (the adapter joins those
+ * with `/`, so separators in every element count).
+ *
+ * ⚠️ LOWER BOUND, not an exact mirror: tRPC applies its own `decodeURIComponent` to the path
+ * before splitting, on top of the decode Next already did. A doubly-encoded comma (`%252C`)
+ * therefore yields one more call server-side than this counts. The CAP is unaffected — it is
+ * enforced by tRPC itself, after its own decode — so this only means the histogram can
+ * under-report a deliberately double-encoded path. It never over-reports.
+ */
+export function computeBatchWidth(req: Pick<NextApiRequest, 'query'>): number {
+  const query = req?.query;
+  if (!query) return 1;
+  if (firstValue(query.batch) !== '1') return 1;
+
+  const trpc = query.trpc;
+  if (typeof trpc === 'string') return countSeparators(trpc) + 1;
+  if (Array.isArray(trpc)) {
+    let separators = 0;
+    for (const segment of trpc) separators += countSeparators(segment);
+    return separators + 1;
+  }
+  return 1;
+}
+
+/**
+ * Hard-bounded client label. Three values, forever: `web` (what the browser bundle sends — see
+ * the `x-client` header in `src/utils/trpc.ts`), `other` (any other value), `none` (absent).
+ * The header is caller-supplied, so this MUST collapse unknown values rather than pass them
+ * through — otherwise one crafted header per request blows up label cardinality.
+ */
+export function boundedClientLabel(raw: string | string[] | undefined): string {
+  const v = firstValue(raw);
+  if (v === undefined) return 'none';
+  return v === 'web' ? 'web' : 'other';
+}
+
+/**
+ * Observe one request's batch width and return it. Never throws — a telemetry failure must not
+ * break a request. On an internal failure it returns 1, which is the SAFE direction: 1 can
+ * never be mistaken for an over-cap request, so a broken metric degrades to "log this error
+ * normally" rather than to "silently suppress a log".
+ */
+export function observeTrpcBatchWidth(req: NextApiRequest): number {
+  try {
+    const width = computeBatchWidth(req);
+    trpcBatchWidthHistogram.observe(
+      {
+        over_limit: width > TRPC_MAX_BATCH_SIZE ? 'true' : 'false',
+        client: boundedClientLabel(req?.headers?.['x-client']),
+      },
+      width
+    );
+    return width;
+  } catch {
+    /* never throw from telemetry */
+    return 1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Over-cap request marker
+// ---------------------------------------------------------------------------
+//
+// A rejected batch still reaches the adapter's `onError`, where the default path pays a stack
+// capture, a `JSON.stringify(input)` and a log write. Under sustained abuse that is a log storm
+// on the exact requests the cap exists to make cheap — and it would be paid on the event loop.
+//
+// The marker is DELIBERATELY a request-scoped flag we set ourselves rather than a match on
+// tRPC's error message ("Batch call exceeds maximum size"). Matching library prose would make
+// the skip silently stop working — reopening the storm — on any upstream reword. This cannot
+// drift: the same code that measures the width sets the flag.
+//
+// Correctness relies on the ordering verified in `@trpc/server`'s `resolveResponse`: the
+// over-cap throw happens in `getRequestInfo`, BEFORE `ctxManager.create()`, so an over-cap
+// request produces exactly ONE `onError` call and it is always the cap rejection. The `req`
+// handed to `onError` is the original Node request object (the node-http adapter re-attaches
+// `opts.req`), which is why a property stamped here is visible there.
+//
+// `Symbol.for` (not `Symbol()`) so the marker survives the module being evaluated in more than
+// one graph — a second copy of this module would otherwise mint a different symbol and the
+// skip would silently never fire.
+const OVER_CAP_MARKER = Symbol.for('civitai.trpc.batchOverCap');
+
+/** Mark a request as having exceeded `TRPC_MAX_BATCH_SIZE`. Never throws. */
+export function markTrpcBatchOverCap(req: unknown): void {
+  try {
+    (req as Record<symbol, unknown>)[OVER_CAP_MARKER] = true;
+  } catch {
+    /* never throw from telemetry */
+  }
+}
+
+/** Whether this request was marked over-cap by `markTrpcBatchOverCap`. Never throws. */
+export function isTrpcBatchOverCap(req: unknown): boolean {
+  try {
+    return (req as Record<symbol, unknown> | undefined)?.[OVER_CAP_MARKER] === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The whole per-request entry point: observe the batch width, and mark the request when it
+ * exceeds the cap. Returns the width.
+ *
+ * 🔴 The `width > cap` branch lives HERE rather than in the route on purpose. A Next API page
+ * cannot be loaded in a unit test (its module graph pulls `appRouter` + `createContext`), so a
+ * branch written inline in the route is only ever pinnable by reading the source — and a
+ * mutation that deleted the marking survived a full green suite exactly that way. The marking
+ * is what arms the log-storm skip, so losing it fails SILENTLY: the cap still works, the metric
+ * still moves, and every rejected batch quietly starts paying a stack capture + Axiom ingest
+ * again. Keeping the branch in this module makes it behaviourally testable, and leaves the
+ * route with one unconditional call.
+ */
+export function instrumentTrpcBatchRequest(req: NextApiRequest): number {
+  const width = observeTrpcBatchWidth(req);
+  if (width > TRPC_MAX_BATCH_SIZE) markTrpcBatchOverCap(req);
+  return width;
+}
+
+/**
+ * Whether this `onError` invocation is a batch-cap rejection whose Axiom ingest should be
+ * skipped.
+ *
+ * NARROW BY CONSTRUCTION — both conjuncts are load-bearing:
+ *  - the request must carry OUR marker, so this can only ever match a request whose width we
+ *    measured above the cap. A blanket `code === 'BAD_REQUEST'` skip would hide real
+ *    client-fault bugs (failed zod validation, malformed payloads) across the entire API.
+ *  - the code must still be `BAD_REQUEST`, so if a marked request somehow produced some other
+ *    error it is logged normally.
+ *
+ * Deliberately NOT a match on tRPC's error message ("Batch call exceeds maximum size"): library
+ * prose is not an interface, and a reword would silently reopen the log storm this prevents.
+ *
+ * Exported raw so tests can drive it directly with both controls (same reason
+ * `b2PutMetricsMiddleware` is exported in `b2-put.metrics.ts`).
+ */
+export function shouldSkipBatchCapLog(req: unknown, error: { code?: string } | undefined): boolean {
+  return error?.code === 'BAD_REQUEST' && isTrpcBatchOverCap(req);
+}
+
+/** Test-only: clear the histogram between cases, back to the seeded (present-at-zero) state
+ *  production starts in — `reset()` alone would drop the seeded series and leave the test
+ *  environment observing something production never does. */
+export function __resetTrpcBatchMetricsForTest(): void {
+  trpcBatchWidthHistogram.reset();
+  seedTrpcBatchWidthSeries();
+}

--- a/src/server/prom/trpc-batch.metrics.ts
+++ b/src/server/prom/trpc-batch.metrics.ts
@@ -1,6 +1,6 @@
 import client from 'prom-client';
 import type { NextApiRequest } from 'next';
-import { TRPC_MAX_BATCH_SIZE } from '~/shared/constants/trpc.constants';
+import { getTrpcMaxBatchSize } from '~/server/trpc/batch-cap';
 
 // ---------------------------------------------------------------------------
 // tRPC batch-width observability + the over-cap request marker
@@ -30,9 +30,12 @@ import { TRPC_MAX_BATCH_SIZE } from '~/shared/constants/trpc.constants';
 const NAME = 'civitai_app_trpc_batch_width';
 
 /** Histogram buckets. Dense below the cap (where legitimate traffic lives), sparse above it
- *  (where only rejected traffic lands) — 30 is a bucket edge so `le="30"` reads directly as
- *  "accepted", and 25 sits just under it so the approach to the cap is visible before anything
- *  is actually clipped. */
+ *  (where only rejected traffic lands) — the DEFAULT cap is a bucket edge so `le="<cap>"` reads
+ *  directly as "accepted", and 25 sits just under it so the approach to the cap is visible
+ *  before anything is actually clipped. Pinned by a test: dropping the cap's own edge silently
+ *  destroys that reading. (Buckets are static, so an env override of `TRPC_MAX_BATCH_SIZE`
+ *  moves the effective cap OFF a bucket edge — the `over_limit` label stays exact, only the
+ *  `le=` reading becomes approximate.) */
 export const TRPC_BATCH_WIDTH_BUCKETS = [1, 2, 3, 5, 10, 20, 25, 30, 50, 100, 150, 250];
 
 declare global {
@@ -44,8 +47,13 @@ declare global {
 // instead of throwing prom-client's duplicate-registration error (same trap documented for
 // `httpErrorCounter` in http-errors.ts and `instrumentationRegistry` in prom/client.ts). The
 // `??` short-circuits BEFORE `new client.Histogram`, so the constructor runs once.
+//
+// `existingHistogram` is captured so the seeding below can tell "this module evaluation CREATED
+// the histogram" from "it found one that has been counting". See `seedTrpcBatchWidthSeries`.
+const existingHistogram = globalThis.__civitaiTrpcBatchWidthHistogram;
+
 export const trpcBatchWidthHistogram: client.Histogram<string> =
-  globalThis.__civitaiTrpcBatchWidthHistogram ??
+  existingHistogram ??
   (globalThis.__civitaiTrpcBatchWidthHistogram = new client.Histogram({
     name: NAME,
     help:
@@ -71,8 +79,18 @@ const CLIENT_LABELS = ['web', 'other', 'none'] as const;
  * `over_limit="true"` would read `no data` until the first over-cap request ever seen by this
  * pod — indistinguishable from "the cap is not wired up" or "this module never loaded", on the
  * exact series whose job is to be read as evidence. Seeding makes a genuine zero observable as
- * a zero. (Same reasoning, and the same fix, as the generation-model-substitution counters
- * seeded from `src/pages/api/metrics.ts`.)
+ * a zero. (Same reasoning as the generation-model-substitution counters, but NOT the same
+ * mechanism — see below.)
+ *
+ * 🔴 THIS IS DESTRUCTIVE AND MUST ONLY RUN ON A FRESHLY-CREATED HISTOGRAM.
+ * `generation-model-substitution.metrics.ts` seeds with `counter.inc({...}, 0)`, which is a
+ * genuine no-op on a series that already exists. `Histogram.zero(labels)` is not: prom-client
+ * implements it as an unconditional (re)initialisation of that label set's buckets, sum and
+ * count, so calling it on a live series WIPES everything accumulated under those labels. This
+ * module is pinned on `globalThis` precisely because it can be evaluated more than once (HMR,
+ * a second request-graph eval) — an unconditional module-scope seed would therefore reset all
+ * six series on the second evaluation, and the resulting hole would look exactly like the
+ * "the cap never fired" reading the seeding exists to prevent.
  */
 function seedTrpcBatchWidthSeries(): void {
   try {
@@ -84,14 +102,23 @@ function seedTrpcBatchWidthSeries(): void {
   }
 }
 
-seedTrpcBatchWidthSeries();
+// Only when THIS evaluation constructed the histogram. A re-evaluation reuses the pinned
+// instance, whose series are already present (and possibly non-zero) — re-seeding would erase
+// them. `__resetTrpcBatchMetricsForTest` is the deliberate exception: it resets on purpose.
+if (!existingHistogram) seedTrpcBatchWidthSeries();
 
 const COMMA = 44; // ','.charCodeAt(0)
 
 /**
- * Count `,` separators without allocating. `split(',')` would build an N-element array of
- * substrings per batched request purely to read `.length`; this reads the same number off the
- * string already in memory.
+ * Count `,` separators without allocating an intermediate array. `split(',')` builds an
+ * N-element array of substrings per batched request purely to read `.length`; this reads the
+ * same number off the string already in memory.
+ *
+ * ⚠️ NOT a throughput win — the opposite, measured: at width 200 this scan takes ~2266ns
+ * against `split(',').length`'s ~1885ns, because V8's `split` is native. The reason to keep it
+ * is ALLOCATION, not speed: no garbage per request on a main-thread-CPU-sensitive path. Both
+ * numbers are noise next to the request they measure; do not "optimise" either way on this
+ * comment alone.
  */
 function countSeparators(s: string): number {
   let n = 0;
@@ -153,16 +180,27 @@ export function boundedClientLabel(raw: string | string[] | undefined): string {
 
 /**
  * Observe one request's batch width and return it. Never throws — a telemetry failure must not
- * break a request. On an internal failure it returns 1, which is the SAFE direction: 1 can
- * never be mistaken for an over-cap request, so a broken metric degrades to "log this error
- * normally" rather than to "silently suppress a log".
+ * break a request.
+ *
+ * 🔴 THE CATCH'S RETURN VALUE IS A SAFETY PROPERTY, NOT A PLACEHOLDER. It returns 1, which is
+ * under any positive cap, so a failed measurement can never mark a request over-cap and a
+ * broken metric degrades to "log this error normally". A value ABOVE the cap here would invert
+ * that: every request whose measurement threw would be marked over-cap, arming the `onError`
+ * skip and suppressing the Axiom ingest for every `BAD_REQUEST` in the process — the log-storm
+ * guard turned into a blanket log-suppressor, silently. Pinned by a test that forces the throw.
  */
 export function observeTrpcBatchWidth(req: NextApiRequest): number {
   try {
     const width = computeBatchWidth(req);
     trpcBatchWidthHistogram.observe(
       {
-        over_limit: width > TRPC_MAX_BATCH_SIZE ? 'true' : 'false',
+        // The EFFECTIVE cap, not the compiled-in constant: the route builds `maxBatchSize` from
+        // the same `getTrpcMaxBatchSize()`, so `over_limit` labels exactly the requests tRPC
+        // will reject. Reading the constant here instead would mislabel every request between
+        // the two values whenever the env var overrides it — and, worse, would arm the
+        // `onError` log-skip on requests tRPC ACCEPTED, silently suppressing genuine
+        // BAD_REQUESTs from their procedures.
+        over_limit: width > getTrpcMaxBatchSize() ? 'true' : 'false',
         client: boundedClientLabel(req?.headers?.['x-client']),
       },
       width
@@ -198,7 +236,7 @@ export function observeTrpcBatchWidth(req: NextApiRequest): number {
 // skip would silently never fire.
 const OVER_CAP_MARKER = Symbol.for('civitai.trpc.batchOverCap');
 
-/** Mark a request as having exceeded `TRPC_MAX_BATCH_SIZE`. Never throws. */
+/** Mark a request as having exceeded the effective batch cap. Never throws. */
 export function markTrpcBatchOverCap(req: unknown): void {
   try {
     (req as Record<symbol, unknown>)[OVER_CAP_MARKER] = true;
@@ -220,18 +258,23 @@ export function isTrpcBatchOverCap(req: unknown): boolean {
  * The whole per-request entry point: observe the batch width, and mark the request when it
  * exceeds the cap. Returns the width.
  *
- * 🔴 The `width > cap` branch lives HERE rather than in the route on purpose. A Next API page
- * cannot be loaded in a unit test (its module graph pulls `appRouter` + `createContext`), so a
- * branch written inline in the route is only ever pinnable by reading the source — and a
- * mutation that deleted the marking survived a full green suite exactly that way. The marking
- * is what arms the log-storm skip, so losing it fails SILENTLY: the cap still works, the metric
- * still moves, and every rejected batch quietly starts paying a stack capture + Axiom ingest
- * again. Keeping the branch in this module makes it behaviourally testable, and leaves the
- * route with one unconditional call.
+ * 🔴 The `width > cap` branch lives HERE rather than in the route on purpose: it keeps the route
+ * to one unconditional call, and it is what makes the branch drivable in isolation. Losing the
+ * marking fails SILENTLY — the cap still works, the metric still moves, and every rejected batch
+ * quietly resumes paying a stack capture + Axiom ingest — so it needs a behavioural pin, and a
+ * mutation that deleted it did once survive a fully green suite.
+ *
+ * (The route itself IS unit-loadable, contrary to an earlier note here: mocking `~/server/routers`,
+ * `~/server/createContext` and the adapter is enough, and `trpc-handler-wiring.test.ts` does
+ * exactly that to assert the route calls this before delegating. Both pins are kept — this one
+ * covers the branch, that one covers the wiring.)
+ *
+ * Uses the EFFECTIVE cap so the marker cannot disagree with what tRPC enforced; see the
+ * `over_limit` note in `observeTrpcBatchWidth`.
  */
 export function instrumentTrpcBatchRequest(req: NextApiRequest): number {
   const width = observeTrpcBatchWidth(req);
-  if (width > TRPC_MAX_BATCH_SIZE) markTrpcBatchOverCap(req);
+  if (width > getTrpcMaxBatchSize()) markTrpcBatchOverCap(req);
   return width;
 }
 

--- a/src/server/trpc/batch-cap.ts
+++ b/src/server/trpc/batch-cap.ts
@@ -27,12 +27,23 @@ import { TRPC_MAX_BATCH_SIZE } from '~/shared/constants/trpc.constants';
  * the cap tRPC enforces and the cap the metric labels against cannot drift apart.
  */
 export function getTrpcMaxBatchSize(): number {
-  const configured = (env as { TRPC_MAX_BATCH_SIZE?: unknown }).TRPC_MAX_BATCH_SIZE;
-  // `serverSchema` already coerces + validates this (positive integer, defaulted), so in a
-  // correctly-booted process the guard below never fires. It is here because the failure it
-  // prevents is silent and total: handing `undefined` to `maxBatchSize` REMOVES the cap
-  // altogether, and nothing about that looks wrong from the outside. Falling back to the
-  // compiled-in constant fails toward "still capped".
+  // Read the schema-typed property DIRECTLY. `serverSchema` types this key `number`, and that
+  // type is the ONLY compile-time link between the schema key and this reader. A cast here
+  // (`env as { TRPC_MAX_BATCH_SIZE?: unknown }`) severs it: renaming or typo-ing the key in the
+  // schema would then produce zero typecheck errors and zero test failures, and this function
+  // would silently return the compiled-in default forever — i.e. the emergency lever would be
+  // dead exactly when someone reached for it.
+  const configured = env.TRPC_MAX_BATCH_SIZE;
+  // 🔴 WHAT THE FALLBACK BELOW IS, NOW THAT THE SCHEMA FAILS SOFT.
+  // `serverSchema` resolves this key with `.int().min(1).catch(TRPC_MAX_BATCH_SIZE)`, so a bad
+  // env value no longer crashes boot — the schema itself yields the compiled-in constant. In a
+  // process booted through `serverSchema` every value reaching here is therefore already a
+  // positive integer and this branch does NOT fire; it is not a production code path and must
+  // not be described as one. It is kept as a second layer for readers that do not come from
+  // that parse — chiefly the test env double, which substitutes `~/env/server` wholesale and
+  // can hand back anything — because the failure it prevents is silent and total: handing
+  // `undefined` to `maxBatchSize` REMOVES the cap altogether, and nothing about that looks
+  // wrong from the outside. Both layers fail toward "still capped".
   if (typeof configured === 'number' && Number.isInteger(configured) && configured > 0) {
     return configured;
   }

--- a/src/server/trpc/batch-cap.ts
+++ b/src/server/trpc/batch-cap.ts
@@ -1,0 +1,40 @@
+import { env } from '~/env/server';
+import { TRPC_MAX_BATCH_SIZE } from '~/shared/constants/trpc.constants';
+
+/**
+ * The EFFECTIVE server-side tRPC batch cap.
+ *
+ * ── WHY THIS IS AN ENV VAR AND NOT JUST THE CONSTANT ────────────────────────────────────────
+ * The compiled-in `TRPC_MAX_BATCH_SIZE` is the default, not the only way to set the cap. A cap
+ * that can only be changed by editing source means every correction — including "this is
+ * clipping real traffic, undo it now" — costs an image build plus a canary rollout. Reading it
+ * from the environment makes the corrective action a config change on a Deployment, which is
+ * the difference between a minutes-long rollback and a much longer one.
+ *
+ * 🔴 THE TWO DIRECTIONS ARE NOT SYMMETRIC, and only one of them is a safe rollback:
+ *  - RAISING (or effectively disabling, by setting a very large value) is safe at any moment.
+ *    The browser's `maxItems` is the compiled-in `TRPC_MAX_BATCH_SIZE`, so a client can never
+ *    build a request wider than the constant; a server cap above it simply stops binding.
+ *  - LOWERING BELOW `TRPC_MAX_BATCH_SIZE` is a tightening, not a rollback. Browsers holding the
+ *    current bundle keep coalescing up to the constant, so any batch between the new value and
+ *    the constant is rejected with a 400 that fails EVERY query in it at once. If the cap must
+ *    genuinely go below the constant, change the constant and ship it, so both ends move
+ *    together; use the env var for that only as a deliberate, monitored emergency.
+ *
+ * Read via a function rather than a module-scope constant so the value is resolved at the point
+ * of use — the route resolves it once when it builds the adapter options, and the batch-width
+ * metric resolves it per request to classify `over_limit`. Both go through THIS function, so
+ * the cap tRPC enforces and the cap the metric labels against cannot drift apart.
+ */
+export function getTrpcMaxBatchSize(): number {
+  const configured = (env as { TRPC_MAX_BATCH_SIZE?: unknown }).TRPC_MAX_BATCH_SIZE;
+  // `serverSchema` already coerces + validates this (positive integer, defaulted), so in a
+  // correctly-booted process the guard below never fires. It is here because the failure it
+  // prevents is silent and total: handing `undefined` to `maxBatchSize` REMOVES the cap
+  // altogether, and nothing about that looks wrong from the outside. Falling back to the
+  // compiled-in constant fails toward "still capped".
+  if (typeof configured === 'number' && Number.isInteger(configured) && configured > 0) {
+    return configured;
+  }
+  return TRPC_MAX_BATCH_SIZE;
+}

--- a/src/shared/constants/trpc.constants.ts
+++ b/src/shared/constants/trpc.constants.ts
@@ -1,0 +1,51 @@
+/**
+ * tRPC request-batching limits — the SINGLE source of truth for both ends of the wire.
+ *
+ * Imported by the server adapter (`src/pages/api/trpc/[trpc].ts` → `maxBatchSize`) AND by the
+ * browser batch link (`src/utils/trpc.ts` → `maxItems`). Keep it dependency-free so it can be
+ * pulled into the client bundle without dragging server code with it.
+ *
+ * ── WHY A CAP ───────────────────────────────────────────────────────────────────────────────
+ * tRPC batching lets ONE HTTP request carry N procedure calls (`?batch=1` + a comma-separated
+ * path list). That decouples request rate from actual work: a caller who sends the same number
+ * of HTTP requests can multiply the server-side procedure calls — and therefore CPU, DB and
+ * Redis load — by whatever N it chooses. Rate limits, connection limits and per-request
+ * timeouts all count requests, so none of them see the multiplier. Without a cap, N is
+ * unbounded and attacker-chosen.
+ *
+ * The client-side `maxURLLength` on the batch link is NOT a limit on this: it only shapes how
+ * OUR browser bundle groups its own operations. Anything speaking HTTP builds the URL itself.
+ */
+
+/**
+ * Maximum procedure calls accepted in a single batched tRPC request.
+ *
+ * tRPC rejects an over-cap batch with `BAD_REQUEST` (HTTP 400) inside `getRequestInfo`, which
+ * runs BEFORE `createContext` — so a rejected batch costs URL parsing and nothing else: no
+ * session lookup, no DB/Redis round-trip, no procedure resolution. That ordering is the entire
+ * cost argument for the cap, and `src/server/__tests__/trpc-batch-cap.test.ts` pins it by
+ * asserting zero procedures resolve on a rejected request.
+ *
+ * ── WHY 30 ──────────────────────────────────────────────────────────────────────────────────
+ * Measured against production batch widths: real first-party traffic tops out around width 14
+ * (see `OBSERVED_MAX_FIRST_PARTY_BATCH_WIDTH`), and the observed distribution is completely
+ * empty between 15 and 120. 30 therefore sits in a genuinely unused gap with ~2x headroom over
+ * anything the app has been seen to send, while still rejecting the wide automated batches that
+ * motivated the cap. The empty gap is what makes the number safe to pick: there is no
+ * legitimate traffic anywhere near it to clip.
+ *
+ * `civitai_app_trpc_batch_width` (see `src/server/prom/trpc-batch.metrics.ts`) observes every
+ * batch width unconditionally, so this number can be re-derived from live data rather than
+ * re-argued. Lower it only after checking that histogram.
+ */
+export const TRPC_MAX_BATCH_SIZE = 30;
+
+/**
+ * Widest batch the FIRST-PARTY app has been observed to emit in production.
+ *
+ * Not read at runtime — it exists so the cap carries its own justification, and so a future
+ * tightening of `TRPC_MAX_BATCH_SIZE` below real traffic fails CI (see
+ * `src/utils/__tests__/trpc-batching.test.ts`) instead of failing in production. Update it if a
+ * wider first-party batch is ever measured; the histogram above is the instrument.
+ */
+export const OBSERVED_MAX_FIRST_PARTY_BATCH_WIDTH = 14;

--- a/src/shared/constants/trpc.constants.ts
+++ b/src/shared/constants/trpc.constants.ts
@@ -1,9 +1,10 @@
 /**
  * tRPC request-batching limits — the SINGLE source of truth for both ends of the wire.
  *
- * Imported by the server adapter (`src/pages/api/trpc/[trpc].ts` → `maxBatchSize`) AND by the
- * browser batch link (`src/utils/trpc.ts` → `maxItems`). Keep it dependency-free so it can be
- * pulled into the client bundle without dragging server code with it.
+ * Imported by the browser batch link (`src/utils/trpc.ts` → `maxItems`) AND, as the DEFAULT for
+ * the server cap, by `src/env/server-schema.ts` (`TRPC_MAX_BATCH_SIZE`, resolved through
+ * `src/server/trpc/batch-cap.ts` → `maxBatchSize`). Keep it dependency-free so it can be pulled
+ * into the client bundle without dragging server code with it.
  *
  * ── WHY A CAP ───────────────────────────────────────────────────────────────────────────────
  * tRPC batching lets ONE HTTP request carry N procedure calls (`?batch=1` + a comma-separated
@@ -20,32 +21,62 @@
 /**
  * Maximum procedure calls accepted in a single batched tRPC request.
  *
+ * This value is BOTH the browser batch link's `maxItems` and the DEFAULT of the server's
+ * `TRPC_MAX_BATCH_SIZE` env var. The server's effective cap is whatever
+ * `getTrpcMaxBatchSize()` resolves (`src/server/trpc/batch-cap.ts`); the client's is always this
+ * constant, because a browser bundle cannot read server env. That asymmetry is deliberate and
+ * its safe direction is documented on `getTrpcMaxBatchSize`.
+ *
  * tRPC rejects an over-cap batch with `BAD_REQUEST` (HTTP 400) inside `getRequestInfo`, which
- * runs BEFORE `createContext` — so a rejected batch costs URL parsing and nothing else: no
- * session lookup, no DB/Redis round-trip, no procedure resolution. That ordering is the entire
- * cost argument for the cap, and `src/server/__tests__/trpc-batch-cap.test.ts` pins it by
- * asserting zero procedures resolve on a rejected request.
+ * runs BEFORE `createContext` — no session lookup, no DB/Redis round-trip, no procedure
+ * resolution, so the N-procedure amplification the cap exists to stop never happens.
+ * `src/server/__tests__/trpc-batch-cap.test.ts` pins that by asserting zero procedures resolve
+ * and zero contexts are created on a rejected request, for GET and for POST.
+ *
+ * ⚠️ Rejection is cheap, not free, and it is method-dependent. On a GET the request costs URL
+ * parsing and nothing else. On a POST (legitimate here — `allowMethodOverride: true` lets a
+ * query carry its input in the body) Next parses the body up to the route's 17mb limit BEFORE
+ * the handler runs, and the adapter re-stringifies it before `resolveResponse`, so an over-cap
+ * POST pays that regardless of the cap. Measured: an 8MB over-cap POST batch cost ~27.5ms of
+ * body parsing plus an 8MB re-stringify, and still resolved 0 procedures and created 0
+ * contexts. The cap removes the per-procedure amplification; it does not make a large POST free.
  *
  * ── WHY 30 ──────────────────────────────────────────────────────────────────────────────────
- * Measured against production batch widths: real first-party traffic tops out around width 14
- * (see `OBSERVED_MAX_FIRST_PARTY_BATCH_WIDTH`), and the observed distribution is completely
- * empty between 15 and 120. 30 therefore sits in a genuinely unused gap with ~2x headroom over
- * anything the app has been seen to send, while still rejecting the wide automated batches that
- * motivated the cap. The empty gap is what makes the number safe to pick: there is no
- * legitimate traffic anywhere near it to clip.
+ * Measured from Cloudflare `httpRequestsAdaptiveGroups` — the FULL request population, not a
+ * sampled or filtered access log — over 2026-08-15T10:00Z → 2026-08-16T10:00Z, ~2.87M tRPC
+ * requests. In that window first-party tRPC request paths max out at 400 characters (99.66% are
+ * ≤100), 95.84% of requests are batch width 1 and 99.84% are width ≤10. The over-wide batches
+ * that appear in production come from automated non-browser clients, at widths well above any
+ * first-party shape.
  *
- * `civitai_app_trpc_batch_width` (see `src/server/prom/trpc-batch.metrics.ts`) observes every
- * batch width unconditionally, so this number can be re-derived from live data rather than
- * re-argued. Lower it only after checking that histogram.
+ * 🔴 THE HONEST LIMIT OF THAT EVIDENCE: `trpcBatching` is currently `availability: ['mod']`
+ * (`src/server/services/feature-flags.service.ts`), so the measured population is largely
+ * UNBATCHED. The width distribution above is therefore not a forecast of what first-party
+ * traffic will emit once the flag ramps, and 30 is not "2x the widest thing users send" — it is
+ * a number chosen above every observed first-party shape and well below the automated ones.
+ *
+ * What actually makes the cap safe for first-party traffic is structural, not distributional:
+ *  - the pre-existing `maxURLLength: 2083` on the batch link already binds the named fan-out
+ *    shapes at 22–29 operations, i.e. below this cap, before `maxItems` is consulted at all;
+ *  - `maxItems` makes the link's dataloader SPLIT a wider fan-out across several ≤cap requests
+ *    rather than reject it, so no first-party request can be built above the cap at any width.
+ * `civitai_app_trpc_batch_width` (`src/server/prom/trpc-batch.metrics.ts`) observes every batch
+ * width unconditionally, so this number can be re-derived from live data — and MUST be
+ * re-derived from post-ramp data before anyone reads the pre-ramp distribution as a bound.
  */
 export const TRPC_MAX_BATCH_SIZE = 30;
 
 /**
- * Widest batch the FIRST-PARTY app has been observed to emit in production.
+ * Widest batch the FIRST-PARTY app was observed to emit in production when this cap was
+ * introduced.
  *
  * Not read at runtime — it exists so the cap carries its own justification, and so a future
  * tightening of `TRPC_MAX_BATCH_SIZE` below real traffic fails CI (see
- * `src/utils/__tests__/trpc-batching.test.ts`) instead of failing in production. Update it if a
- * wider first-party batch is ever measured; the histogram above is the instrument.
+ * `src/utils/__tests__/trpc-batching.test.ts`) instead of failing in production.
+ *
+ * 🔴 Read it as a FLOOR, not a bound. It was measured while `trpcBatching` was mod-gated (see
+ * the caveat above), so it describes a nearly-unbatched population — the same window puts
+ * 99.84% of all tRPC requests at width ≤10. Update it if a wider first-party batch is measured;
+ * the histogram is the instrument.
  */
 export const OBSERVED_MAX_FIRST_PARTY_BATCH_WIDTH = 14;

--- a/src/utils/__tests__/trpc-batch-link-wiring.test.ts
+++ b/src/utils/__tests__/trpc-batch-link-wiring.test.ts
@@ -1,0 +1,57 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import type * as TrpcClientModule from '@trpc/client';
+import { TRPC_MAX_BATCH_SIZE } from '~/shared/constants/trpc.constants';
+
+/**
+ * BEHAVIOURAL coverage for the options `src/utils/trpc.ts` hands the batch link.
+ *
+ * 🔴 WHY THIS FILE EXISTS. `maxItems: TRPC_MAX_BATCH_SIZE` used to be pinned by a regex over
+ * `src/utils/trpc.ts`'s source. Wrapping that line in a block comment left the regex satisfied
+ * and the suite green while the browser's item cap was gone — the client half of the same
+ * walkable-guard class as `trpc-handler-wiring.test.ts`.
+ *
+ * Instead of reading the file, this spies on `httpBatchStreamLink` and reads the options object
+ * the module ACTUALLY constructed. `~/utils/trpc` builds `trpcVanilla` at module scope, which
+ * calls `terminatingLink` eagerly — so simply importing the module exercises the real call site.
+ * The spy delegates to the real link, so nothing about the module's behaviour is faked.
+ */
+
+const h = vi.hoisted(() => ({ batchLinkOptions: [] as Record<string, unknown>[] }));
+
+vi.mock('@trpc/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof TrpcClientModule>();
+  return {
+    ...actual,
+    httpBatchStreamLink: (options: Record<string, unknown>) => {
+      h.batchLinkOptions.push(options);
+      return actual.httpBatchStreamLink(options as never);
+    },
+  };
+});
+
+describe('the browser batch link is built with the shared item cap', () => {
+  beforeAll(async () => {
+    await import('~/utils/trpc');
+  });
+
+  it('POSITIVE CONTROL: importing the module builds a batch link at all', () => {
+    // A zero here would make every assertion below vacuously true — "no options recorded" and
+    // "options recorded without maxItems" are indistinguishable otherwise.
+    expect(h.batchLinkOptions.length).toBeGreaterThan(0);
+  });
+
+  it('passes maxItems from the shared constant, not a literal', () => {
+    for (const options of h.batchLinkOptions) {
+      expect(options.maxItems).toBe(TRPC_MAX_BATCH_SIZE);
+    }
+  });
+
+  it('keeps the pre-existing URL budget, which is what actually binds today', () => {
+    // `maxURLLength` is the bound that splits the app's real fan-out shapes (22-29 ops), below
+    // `maxItems`. Losing it would move first-party safety onto the item cap alone, so it is
+    // asserted here rather than left implicit — and it must not silently change with the cap.
+    for (const options of h.batchLinkOptions) {
+      expect(options.maxURLLength).toBe(2083);
+    }
+  });
+});

--- a/src/utils/__tests__/trpc-batching.test.ts
+++ b/src/utils/__tests__/trpc-batching.test.ts
@@ -7,10 +7,15 @@ import {
   CACHEABLE_PROCEDURES,
   isLargeQuery,
   isTooLargeToBatch,
+  NEVER_BATCH_PROCEDURES,
   queryRetry,
   setTrpcBatchingEnabled,
   shouldBatch,
 } from '~/utils/trpc';
+import {
+  OBSERVED_MAX_FIRST_PARTY_BATCH_WIDTH,
+  TRPC_MAX_BATCH_SIZE,
+} from '~/shared/constants/trpc.constants';
 
 /**
  * Unit coverage for the tRPC batching split decision (`shouldBatch`) that the
@@ -275,13 +280,132 @@ describe('batch-size gate is distinct from the non-batch GET→POST gate (#1)', 
  * durable: add a new `edgeCacheIt` procedure without excluding it from batching and THIS
  * test fails — the batch link can't silently start de-caching authed feed queries.
  */
+/**
+ * Remove comments from TypeScript source, preserving newlines (so line-oriented parsing
+ * downstream is unaffected) and string/template contents (so a `//` inside a URL literal can't
+ * swallow the rest of the line).
+ *
+ * 🔴 This is the fix for a latent COUPLING bug, not a tidy-up. The derivation below used a bare
+ * `block.includes('edgeCacheIt(')` substring test, which also matched COMMENTED-OUT code —
+ * `image.getGenerationData`'s `edgeCacheIt` is commented out, so it was being derived as
+ * "cacheable" purely because the words were still in the file. With a batch-size cap in place
+ * that stops being harmless: anyone who later made this guard comment-aware would drop
+ * `image.getGenerationData` off the never-batch list, and the client would silently start
+ * batching a per-image query at feed width. Fixing that bug must not be able to open this one,
+ * so the procedure is now pinned separately via `NEVER_BATCH_PROCEDURES` for an independent
+ * reason (see its doc comment) and asserted below.
+ */
+export function stripTsComments(src: string): string {
+  type Mode = 'code' | 'line' | 'block' | 'single' | 'double' | 'template';
+  let mode: Mode = 'code';
+  let out = '';
+  let i = 0;
+  while (i < src.length) {
+    const c = src[i];
+    const c2 = src[i + 1];
+    if (mode === 'code') {
+      if (c === '/' && c2 === '/') {
+        mode = 'line';
+        i += 2;
+        continue;
+      }
+      if (c === '/' && c2 === '*') {
+        mode = 'block';
+        i += 2;
+        continue;
+      }
+      if (c === "'") mode = 'single';
+      else if (c === '"') mode = 'double';
+      else if (c === '`') mode = 'template';
+      out += c;
+      i += 1;
+      continue;
+    }
+    if (mode === 'line') {
+      // Keep the newline so line numbering / indent-based block splitting is preserved.
+      if (c === '\n') {
+        mode = 'code';
+        out += c;
+      }
+      i += 1;
+      continue;
+    }
+    if (mode === 'block') {
+      if (c === '*' && c2 === '/') {
+        mode = 'code';
+        i += 2;
+        continue;
+      }
+      if (c === '\n') out += c;
+      i += 1;
+      continue;
+    }
+    // Inside a string/template: copy through, honouring escapes so `\'` doesn't close it.
+    if (c === '\\') {
+      out += c + (c2 ?? '');
+      i += 2;
+      continue;
+    }
+    if (
+      (mode === 'single' && c === "'") ||
+      (mode === 'double' && c === '"') ||
+      (mode === 'template' && c === '`')
+    ) {
+      mode = 'code';
+    }
+    out += c;
+    i += 1;
+  }
+  return out;
+}
+
+describe('stripTsComments (drift-guard instrument)', () => {
+  // NEGATIVE CONTROL: the guard must NOT see a commented-out call...
+  it('does not report edgeCacheIt( from a line comment', () => {
+    const block = [
+      '  getGenerationData: publicProcedure',
+      '    // TODO: Add edgeCacheIt back after fixing the cache invalidation.',
+      '    // .use(',
+      '    //   edgeCacheIt({ ttl: CacheTTL.day })',
+      '    // )',
+      '    .query(({ input }) => getImageGenerationData(input)),',
+    ].join('\n');
+    expect(block.includes('edgeCacheIt(')).toBe(true); // the OLD substring test was fooled
+    expect(stripTsComments(block).includes('edgeCacheIt(')).toBe(false);
+  });
+
+  it('does not report edgeCacheIt( from a block comment', () => {
+    const block = '  x: publicProcedure\n    /* .use(edgeCacheIt({ ttl: 1 })) */\n    .query(f),';
+    expect(stripTsComments(block).includes('edgeCacheIt(')).toBe(false);
+  });
+
+  // ...POSITIVE CONTROL: and it must still see a real one, or the whole derivation is vacuous
+  // and every "in sync" assertion below passes by finding nothing.
+  it('still reports a real edgeCacheIt( call', () => {
+    const block = '  getAll: publicProcedure\n    .use(edgeCacheIt({ ttl: CacheTTL.hour }))\n';
+    expect(stripTsComments(block).includes('edgeCacheIt(')).toBe(true);
+  });
+
+  it('preserves line count so indent-based block splitting is unaffected', () => {
+    const src = 'a\n// c\n/* b\n b */\nd\n';
+    expect(stripTsComments(src).split('\n').length).toBe(src.split('\n').length);
+  });
+
+  it('does not treat // inside a string literal as a comment', () => {
+    const src = `const u = 'https://x.example/y'; edgeCacheIt({});`;
+    expect(stripTsComments(src).includes('edgeCacheIt(')).toBe(true);
+  });
+});
+
 describe('CACHEABLE_PROCEDURES stays in sync with the routers (batch-skip guard)', () => {
   const routersDir = join(process.cwd(), 'src/server/routers');
 
   // Map `<basename>.router.ts` -> tRPC key prefix from the appRouter registration:
   //   `key: lazy(() => import('.../x.router').then((m) => m.xRouter))`
   const buildFileToKey = (): Record<string, string> => {
-    const index = readFileSync(join(routersDir, 'index.ts'), 'utf8');
+    // Comment-aware for the same reason as the `edgeCacheIt(` scan: a commented-out `lazy()`
+    // registration is not a registered router, and must not mint a key.
+    const index = stripTsComments(readFileSync(join(routersDir, 'index.ts'), 'utf8'));
     const map: Record<string, string> = {};
     const re = /(\w+):\s*lazy\(\(\)\s*=>\s*import\(['"]([^'"]+)['"]\)/g;
     let m: RegExpExecArray | null;
@@ -314,7 +438,9 @@ describe('CACHEABLE_PROCEDURES stays in sync with the routers (batch-skip guard)
 
     for (const file of readdirSync(routersDir)) {
       if (!file.endsWith('.router.ts')) continue;
-      const content = readFileSync(join(routersDir, file), 'utf8');
+      // Comment-aware: a commented-out `edgeCacheIt(` is NOT an applied middleware. See
+      // `stripTsComments` above for why this correction is coupled to NEVER_BATCH_PROCEDURES.
+      const content = stripTsComments(readFileSync(join(routersDir, file), 'utf8'));
       if (!content.includes('edgeCacheIt(')) continue;
       const key = fileToKey[file];
       if (!key) {
@@ -342,6 +468,89 @@ describe('CACHEABLE_PROCEDURES stays in sync with the routers (batch-skip guard)
     const stale = listed.filter((p) => !derived.has(p));
     expect({ notListed, stale }).toEqual({ notListed: [], stale: [] });
     expect(listed).toEqual(expected);
+  });
+
+  /**
+   * The other half of the decoupling. `image.getGenerationData` used to appear in the derived
+   * set ONLY because the substring test matched its commented-out `edgeCacheIt`. Now that the
+   * derivation is comment-aware it correctly does not — so this asserts both facts at once:
+   * the guard no longer counts commented-out code, AND the procedure is still excluded from
+   * batching, by an independent mechanism that the derivation cannot reach.
+   */
+  it.each([
+    ['image.router.ts', 'image', 'getGenerationData'],
+    ['event.router.ts', 'event', 'getData'],
+  ])('does not derive %s#%s (its edgeCacheIt is commented out)', (file, key, procedure) => {
+    const raw = readFileSync(join(routersDir, file), 'utf8');
+    const block = procedureBlocks(stripTsComments(raw)).find((b) => b.name === procedure);
+
+    expect(buildFileToKey()[file]).toBe(key); // guard is looking at the right router
+    expect(block).toBeDefined();
+    // Raw source still contains the words somewhere — this is exactly what the OLD substring
+    // guard tripped on, and why both procedures looked derived when neither is.
+    expect(raw.includes('edgeCacheIt(')).toBe(true);
+    expect(block!.block.includes('edgeCacheIt(')).toBe(false);
+    expect(CACHEABLE_PROCEDURES.has(`${key}.${procedure}`)).toBe(false);
+  });
+
+  it('derives a procedure whose edgeCacheIt is REAL, in the same file', () => {
+    // Positive control for the pair above: the comment-aware strip must not have simply stopped
+    // detecting `edgeCacheIt` in `event.router.ts` altogether, which would make that assertion
+    // pass for the wrong reason.
+    expect(CACHEABLE_PROCEDURES.has('event.getTeamScores')).toBe(true);
+    expect(CACHEABLE_PROCEDURES.has('image.getResources')).toBe(true);
+  });
+});
+
+describe('NEVER_BATCH_PROCEDURES (independent of the edge-cache derivation)', () => {
+  beforeEach(() => {
+    setTrpcBatchingEnabled(true);
+    setWindowAuthed(true);
+  });
+  afterEach(() => {
+    setTrpcBatchingEnabled(false);
+    clearWindow();
+  });
+
+  it('pins both pending-cacheable procedures to the never-batch set', () => {
+    expect([...NEVER_BATCH_PROCEDURES].sort()).toEqual([
+      'event.getData',
+      'image.getGenerationData',
+    ]);
+  });
+
+  it.each([...NEVER_BATCH_PROCEDURES])(
+    'keeps %s unbatched even with every other condition satisfied',
+    (path) => {
+      // Same op shape that DOES batch, differing only in path — so a failure here can only be
+      // attributable to the never-batch set, not to some other condition failing.
+      expect(shouldBatch(op({ path: 'model.getInfinite' }))).toBe(true);
+      expect(shouldBatch(op({ path }))).toBe(false);
+    }
+  );
+
+  it('does not overlap CACHEABLE_PROCEDURES (one reason per procedure)', () => {
+    const overlap = [...NEVER_BATCH_PROCEDURES].filter((p) => CACHEABLE_PROCEDURES.has(p));
+    expect(overlap).toEqual([]);
+  });
+});
+
+describe('batch-size cap constants', () => {
+  /**
+   * Pins the widest batch first-party traffic has been measured to emit BELOW the cap. Tightening
+   * `TRPC_MAX_BATCH_SIZE` under real traffic then fails here rather than in production. If a
+   * wider first-party batch is genuinely measured, update
+   * `OBSERVED_MAX_FIRST_PARTY_BATCH_WIDTH` — and re-check the cap while doing it.
+   */
+  it('leaves headroom over the widest observed first-party batch', () => {
+    expect(OBSERVED_MAX_FIRST_PARTY_BATCH_WIDTH).toBeLessThan(TRPC_MAX_BATCH_SIZE);
+    // Not merely "below" — a cap one call above real traffic would clip on any new fan-out.
+    expect(TRPC_MAX_BATCH_SIZE).toBeGreaterThanOrEqual(2 * OBSERVED_MAX_FIRST_PARTY_BATCH_WIDTH);
+  });
+
+  it('is a positive integer (a non-integer or 0 would reject every batch)', () => {
+    expect(Number.isInteger(TRPC_MAX_BATCH_SIZE)).toBe(true);
+    expect(TRPC_MAX_BATCH_SIZE).toBeGreaterThan(0);
   });
 });
 

--- a/src/utils/trpc.ts
+++ b/src/utils/trpc.ts
@@ -303,14 +303,24 @@ function terminatingLink({
       url,
       headers,
       maxURLLength: 2083,
-      // Mirror the server's `maxBatchSize` (`src/pages/api/trpc/[trpc].ts`) from the SAME
-      // constant. tRPC requires the client limit be <= the server's: without this the browser
-      // would happily coalesce more operations than the server accepts and 400 itself, failing
+      // Mirror the server's `maxBatchSize` default (`src/pages/api/trpc/[trpc].ts`) from the
+      // SAME constant. tRPC requires the client limit be <= the server's: without this the
+      // browser could coalesce more operations than the server accepts and 400 itself, failing
       // every query in the batch. With it, the link's dataloader SPLITS an over-wide fan-out
       // into several <=cap requests instead — `groupItems` starts a new group whenever
       // `validate` rejects, and only ever rejects a lone operation, which can't happen here
-      // (one op is always <= the cap). That makes every first-party fan-out structurally safe
-      // under the cap, regardless of how wide any individual `useQueries` call gets.
+      // (one op is always <= the cap).
+      //
+      // ⚠️ DEFENCE IN DEPTH, not the primary bound. `maxURLLength: 2083` above already binds
+      // the fan-out shapes this app actually emits — the two `useQueries` sites reach the URL
+      // cap at 22–29 operations, i.e. BELOW `maxItems`, so today the URL budget is what splits
+      // them and this line never fires. It becomes load-bearing for short-path, no-input
+      // procedures (≈147 ops fit under the URL cap) and after the `trpcBatching` flag ramps
+      // past its current mod-only audience.
+      //
+      // 🔴 The server cap is env-overridable and this one is not (a browser bundle cannot read
+      // server env), so the two can diverge. Raising the server's is safe; lowering it below
+      // this constant means an already-loaded bundle can build a batch the server rejects.
       maxItems: TRPC_MAX_BATCH_SIZE,
     }),
     false: httpLinkWithLargeQuerySupport({ url, headers }),

--- a/src/utils/trpc.ts
+++ b/src/utils/trpc.ts
@@ -18,6 +18,7 @@ import { isDev } from '~/env/other';
 import { env } from '~/env/client';
 import { showErrorNotification } from '~/utils/notifications';
 import { removeEmpty } from '~/utils/object-helpers';
+import { TRPC_MAX_BATCH_SIZE } from '~/shared/constants/trpc.constants';
 
 type RequestHeaders = {
   'x-client-date': string;
@@ -190,7 +191,6 @@ export const CACHEABLE_PROCEDURES: ReadonlySet<string> = new Set([
   'article.getCivitaiNews',
   'bug.getLatest',
   'changelog.getLatest',
-  'event.getData',
   'event.getDonors',
   'event.getPartners',
   'event.getRewards',
@@ -200,7 +200,6 @@ export const CACHEABLE_PROCEDURES: ReadonlySet<string> = new Set([
   'generation.getStatus',
   'homeBlock.getHomeBlock',
   'image.get404Images',
-  'image.getGenerationData',
   'image.getResources',
   'model.getAll',
   'modelFile.getOptions',
@@ -219,12 +218,48 @@ export const CACHEABLE_PROCEDURES: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Procedures excluded from batching for reasons INDEPENDENT of edge-caching — i.e. ones the
+ * router-parsing guard above can never derive.
+ *
+ * Why this set exists at all: `CACHEABLE_PROCEDURES` is re-derived from the routers by
+ * `trpc-batching.test.ts`, so anything in it must be derivable. A procedure we want unbatched
+ * for a different reason has nowhere to live in that set without corrupting the derivation —
+ * and, worse, would sit there looking derived. Two sets, two mechanisms: neither can silently
+ * disable the other.
+ *
+ * Both current members are PENDING-CACHEABLE: their `edgeCacheIt` is commented out in the
+ * router with the intent of restoring it. They must stay unbatched anyway, because batching
+ * appends `?batch=1` and `edgeCacheIt` refuses to cache a batched request. If they started
+ * batching now, restoring the commented-out middleware would silently deliver zero edge-cache
+ * benefit — a one-line uncomment whose effect is cancelled somewhere else entirely, with
+ * nothing to point at.
+ *
+ * `image.getGenerationData` — `src/server/routers/image.router.ts` ("TODO: Add edgeCacheIt back
+ * after fixing the cache invalidation"). Also fired at feed/lightbox width, one call per image,
+ * which is precisely the fan-out shape the batch cap exists to bound.
+ *
+ * `event.getData` — `src/server/routers/event.router.ts`, `// .use(edgeCacheIt({ ttl:
+ * CacheTTL.lg }))`.
+ *
+ * 🔴 Neither was ever DELIBERATELY excluded: both were on the never-batch list only because the
+ * drift guard's substring test also matched their commented-out code. Making that guard
+ * comment-aware is what surfaced them, and it would otherwise have silently started batching
+ * both. Listing them here keeps today's behaviour unchanged and gives it an actual reason —
+ * changing it is a separate decision, on evidence, not a side effect of a bug fix.
+ */
+export const NEVER_BATCH_PROCEDURES: ReadonlySet<string> = new Set([
+  'event.getData',
+  'image.getGenerationData',
+]);
+
+/**
  * Route an operation to the streaming batch link only when ALL hold:
  *  - it's a `query` (mutations stay standalone — matches the historical link, and keeps
  *    the large-mutation POST path intact),
  *  - the `trpcBatching` flag is on for this user,
  *  - we're in an authenticated browser (see `isAuthedBrowser` — anon stays cacheable),
  *  - the procedure is NOT edge-cacheable for authed sessions (see `CACHEABLE_PROCEDURES`),
+ *  - the procedure is NOT excluded for a non-caching reason (see `NEVER_BATCH_PROCEDURES`),
  *  - the caller didn't opt out via `context.skipBatch === true`,
  *  - its encoded input fits the batch link's URL cap (`isTooLargeToBatch` — otherwise it
  *    would trip "Input is too big for a single dispatch"; excluded ops fall to the
@@ -241,6 +276,7 @@ export function shouldBatch(op: {
     trpcBatchingEnabled &&
     isAuthedBrowser() &&
     !CACHEABLE_PROCEDURES.has(op.path) &&
+    !NEVER_BATCH_PROCEDURES.has(op.path) &&
     op.context.skipBatch !== true &&
     !isTooLargeToBatch(op)
   );
@@ -262,7 +298,21 @@ function terminatingLink({
 }): TRPCLink<AppRouter> {
   return splitLink({
     condition: shouldBatch,
-    true: httpBatchStreamLink({ transformer: clientTransformer, url, headers, maxURLLength: 2083 }),
+    true: httpBatchStreamLink({
+      transformer: clientTransformer,
+      url,
+      headers,
+      maxURLLength: 2083,
+      // Mirror the server's `maxBatchSize` (`src/pages/api/trpc/[trpc].ts`) from the SAME
+      // constant. tRPC requires the client limit be <= the server's: without this the browser
+      // would happily coalesce more operations than the server accepts and 400 itself, failing
+      // every query in the batch. With it, the link's dataloader SPLITS an over-wide fan-out
+      // into several <=cap requests instead — `groupItems` starts a new group whenever
+      // `validate` rejects, and only ever rejects a lone operation, which can't happen here
+      // (one op is always <= the cap). That makes every first-party fan-out structurally safe
+      // under the cap, regardless of how wide any individual `useQueries` call gets.
+      maxItems: TRPC_MAX_BATCH_SIZE,
+    }),
     false: httpLinkWithLargeQuerySupport({ url, headers }),
   });
 }


### PR DESCRIPTION
## Problem

tRPC request batching lets a **single HTTP request carry N procedure calls** (`?batch=1` plus a comma-separated path list). That decouples request rate from actual work: rate limits, connection caps and per-request timeouts all count *requests*, so they see 1 where the server does N — and N is chosen by whoever builds the URL.

Today there is **no server-side limit at all** (`maxBatchSize` appears nowhere in `src/`). The client's `maxURLLength` is not a limit on this: it only shapes how our own browser bundle groups its operations. Anything speaking HTTP builds the URL itself.

## The cap

`TRPC_MAX_BATCH_SIZE = 30`, in one shared module read by **both** ends of the wire — and, on the server, **overridable at runtime** via the `TRPC_MAX_BATCH_SIZE` env var (declared in `src/env/server-schema.ts`, default = the shared constant, resolved through `src/server/trpc/batch-cap.ts`). A cap that can only be changed by editing source makes every correction — including "this is clipping real traffic, undo it" — cost an image build plus a canary rollout; this makes it a config change instead.

🔴 **The two directions are not symmetric.** Raising (or effectively disabling) is a safe rollback at any moment: the browser's `maxItems` is the compiled-in constant, so a client can never build a request wider than 30 and a larger server cap simply stops binding. **Lowering below 30 is a tightening, not a rollback** — already-loaded bundles keep coalescing up to 30, and anything between the new value and 30 gets a 400 that fails every query in it. If the cap must genuinely go below 30, change the constant and ship it so both ends move together.

### 🔴 A bad env value now FALLS BACK — it no longer crashes app boot

**This is a semantics change to `TRPC_MAX_BATCH_SIZE` since the previous revision of this PR.**

`serverSchema` is parsed once by `src/env/server.ts`, which **throws on any invalid field**. The knob was previously declared `z.coerce.number().int().positive().default(30)` — so a mistyped Deployment value (`''`, `'0'`, `'-5'`, `'abc'`, `'12.5'`, `' '`) did **not** fall back to the default. It failed validation and **took the entire app down at boot**, not just batching.

That is the wrong failure mode for a lever whose whole purpose is *mid-incident* correction: a typo would take the fleet down during the very incident the lever exists to fix. It also made `getTrpcMaxBatchSize`'s runtime guard unreachable in production, so its "fails toward still capped" docstring was false as written.

It now reads **`z.coerce.number().int().min(1).catch(TRPC_MAX_BATCH_SIZE)`**, following the precedent this repo already set for `SEARCH_INDEX_MODEL_METRIC_FLUSH_INTERVAL_MS` (#3243) and `EXTERNAL_MODERATION_TIMEOUT_MS`. Any parse or range failure resolves to the compiled-in constant instead of throwing. `.min(1)` is what makes `0` and negatives fall back rather than pass — `0` would reject every batch.

⚠️ **The operational trade, stated plainly.** A bad `TRPC_MAX_BATCH_SIZE` is now *silently ignored* in favour of the shipped cap. A lever that no-ops on a typo beats one that crash-loops on a typo, but it does mean a mistyped correction **looks like it applied and did not**. Confirm a change took effect by reading the `civitai_app_trpc_batch_width` `over_limit` series — not by the absence of a crash.

Pinned behaviourally by `src/env/__tests__/server-schema-trpc-max-batch-size.test.ts` (unset + the six bad values above each resolve the default *and* do not throw; `'17'` resolves to 17). The docstring on `getTrpcMaxBatchSize` has been corrected to say what the code now does: with the schema failing soft, that runtime guard is **not** a production path — it is a second layer for readers that do not come from the schema parse (chiefly the test env double), and it is described as exactly that.

### The schema↔reader link is now compile-time

`getTrpcMaxBatchSize` read the key through a cast, `(env as { TRPC_MAX_BATCH_SIZE?: unknown }).TRPC_MAX_BATCH_SIZE`. `env.TRPC_MAX_BATCH_SIZE` is already typed `number` by the schema, so the cast bought nothing and cost the only compile-time guard on that seam: with it in place, renaming or typo-ing the schema key produced **zero** type errors and **zero** test failures, and the emergency lever silently fell back to the default forever. It now reads the property directly, matching how the repo reads env elsewhere. Measured both ways — see **M23**.

### Why 30 — the measurement, and its honest limit

**Source:** Cloudflare `httpRequestsAdaptiveGroups` — the **full request population**, not a sampled or filtered access log.
**Window:** 2026-08-15T10:00Z → 2026-08-16T10:00Z, ~2.87M tRPC requests.

- First-party tRPC request paths max out at **400 characters**; 99.66% are ≤100.
- Batch widths: **95.84% are width 1**, **99.84% are ≤10**.
- The over-wide batches that do appear come from **automated non-browser clients**, at widths well above any first-party shape.

🔴 **The caveat, stated plainly because it bounds everything above.** `trpcBatching` is currently `availability: ['mod']` (`src/server/services/feature-flags.service.ts:77`), so this population is **largely unbatched**. The distribution is *not* a forecast of post-ramp first-party widths, and 30 is **not** "2× the widest thing users send". It is a number above every observed first-party shape and well below the automated ones.

What actually makes the cap safe for first-party traffic is **structural**, not distributional:

1. the **pre-existing `maxURLLength: 2083`** on the batch link already binds the named fan-out shapes at **22–29 operations** — below the cap, before `maxItems` is consulted at all;
2. the new client **`maxItems`** makes the dataloader **SPLIT** a wider fan-out across several ≤cap requests rather than fail it.

So `maxItems` is **defence in depth**, not the primary bound. It becomes load-bearing for short-path, no-input procedures (~147 ops fit under the URL cap) and after the flag ramps past its current mod-only audience. The previous revision of this PR oversold it, and oversold the "empty gap between 15 and 120" framing; both are corrected in the code comments too.

### What rejection actually costs

tRPC checks `maxBatchSize` inside `getRequestInfo`, which runs *before* `ctxManager.create()` — so an over-cap request **resolves zero procedures and creates no context**. The tests assert that directly rather than just asserting a 400.

⚠️ **Corrected claim:** the earlier "costs URL parsing and nothing else" is true for GET only. `allowMethodOverride: true` makes a **POST** query batch legitimate, and Next parses the body (up to the route's 17mb limit) *before* the handler runs, with the adapter re-stringifying it before `resolveResponse`. Measured: an over-cap POST batch with an 8MB body cost **~27.5ms body-parse + an 8MB re-stringify**, and still returned 400 with **0 resolver and 0 context calls**. The cap removes the N-procedure amplification on both methods; it does not make a large POST free. There is now a **GET/POST-symmetric** pair of tests, plus an at-cap POST control so a rejection can't be confused with "POST queries don't work here".

## Observability (always on, observe-only)

New `civitai_app_trpc_batch_width` histogram — buckets `[1,2,3,5,10,20,25,30,50,100,150,250]`, labelled `over_limit` and a **hard-bounded 3-value** `client` label (`web|other|none`; the header is caller-supplied, so unknown values collapse rather than blow up cardinality).

- Observed **before** delegating, so it sees the widths tRPC is about to reject — those requests resolve zero procedures and would otherwise leave no trace anywhere.
- Classified against the **effective** cap (`getTrpcMaxBatchSize()`), the same value the adapter gets. Reading the constant instead would, under an env override, mark requests tRPC *accepted* as over-cap and silently suppress genuine `BAD_REQUEST` logs from their procedures.
- All 6 label series are **seeded at zero**, so `over_limit="true"` reading `no data` cannot be confused with "the cap never shipped". 🔴 The seed is now **conditional on this evaluation having constructed the histogram**: `Histogram.zero(labels)` *replaces* that label set's buckets/sum/count (unlike the `counter.inc({...}, 0)` pattern it was modelled on, which is a genuine no-op), so the previous unconditional module-scope seed would have wiped all six series on a second module evaluation. The comment citing that pattern as "the same fix" was wrong and is corrected.
- Registered on the **default** registry — the one `/api/metrics` scrapes — and that is now asserted, because adding `registers: [new client.Registry()]` previously left the suite green while the metric was never scraped.

## Log-storm avoidance

`onError` already skips Axiom ingest for several codes but not `BAD_REQUEST`. Under sustained abuse every rejected batch would pay a stack capture, a `JSON.stringify(input)` and a log write — on the event loop, during exactly the traffic the cap exists to make cheap.

The skip is **narrow by construction** and requires *both* a per-request over-cap marker we set ourselves *and* a `BAD_REQUEST` code. It is deliberately **not** a match on tRPC's error message — library prose is not an interface. Ordinary `BAD_REQUEST`s keep full observability. The rejection is still counted, in the metric.

The telemetry catch's `return 1` is a **safety property**, not a placeholder: a value above the cap would mark every failed measurement over-cap and turn the narrow skip into a blanket log-suppressor. That direction is now pinned by a test that forces the throw.

## 🔴 Verification guards: four were walkable, and all four have been replaced

An adversarial audit found that four production-wiring properties were pinned by **matching source text** — and that each was defeated by wrapping the real line in a block comment. All four **survived a fully green suite**, including the one that removes the cap entirely.

They are now asserted **behaviourally**, on values the modules actually produce:

- **`src/server/__tests__/trpc-handler-wiring.test.ts`** (new) loads the *real* route with `~/server/routers`, `~/server/createContext` and the adapter mocked, and reads `options.maxBatchSize` off the object the route hands `createNextApiHandler`; drives the real handler and reads the over-cap marker *from inside the delegate* (so ordering, not just occurrence, is pinned); and drives the real `onError`, asserting on the canonical `logToAxiom` spy with an unmarked-request **positive control** beside it. (The earlier note that a Next API page "cannot be loaded in a unit test" was simply wrong, and is corrected in the code.)
- **`src/utils/__tests__/trpc-batch-link-wiring.test.ts`** (new) spies on `httpBatchStreamLink` and reads the options `src/utils/trpc.ts` actually constructs at module scope, with a positive control that a link is built at all.

The route's `maxBatchSize` is additionally asserted against an env override applied **before** the module is evaluated, so a hardcoded `maxBatchSize: 30` — which would look right and silently ignore the rollback path — fails too.

### Mutation matrix (24 mutants; **re-run IN FULL** after the F1/F2 fixes, not just the two new ones)

A fix round resets the verification gate, so the whole battery below was replayed against the post-fix tree, one mutant at a time, restoring from a pristine copy between each. Every mutant's anchor was asserted to match exactly once before it was applied (a mutant that fails to apply otherwise scores as SURVIVED). Battery baseline: **151 passed / 0 failed** across 10 files; each row's `passed`+`failed` still sums to 151, so no mutant scored SURVIVED by failing to load a suite.

| # | Mutant | Result |
|---|---|---|
| PC1 | positive control: `computeBatchWidth` always returns 1 | KILLED |
| M1 | block-comment `maxBatchSize: getTrpcMaxBatchSize()` | **KILLED** (was SURVIVED) |
| M2 | block-comment `instrumentTrpcBatchRequest(req);` | **KILLED** (was SURVIVED) |
| M3 | block-comment the `shouldSkipBatchCapLog` early return | **KILLED** (was SURVIVED) |
| M4 | block-comment `maxItems: TRPC_MAX_BATCH_SIZE` | **KILLED** (was SURVIVED) |
| M5 | histogram into a private registry (never scraped) | **KILLED** (was SURVIVED) |
| M6 | drop the cap's own bucket edge | **KILLED** (was SURVIVED) |
| M7 | telemetry catch returns 9999 instead of 1 | **KILLED** (was SURVIVED) |
| M8 | unconditional module-scope seed (wipes accumulated series) | **KILLED** (was the bug) |
| M9 | env resolution drops its validity guard (`undefined` ⇒ no cap) | KILLED |
| M10 | metric classifies against a hardcoded 30 | KILLED |
| M11 | marker uses a hardcoded 30 | KILLED |
| M12 | off-by-one: cap becomes exclusive (`>=`) | KILLED |
| M13 | log-skip degrades to a blanket `BAD_REQUEST` skip | KILLED |
| M14 | log-skip drops the error-code conjunct | KILLED |
| M15 | client label passes the raw header through | KILLED |
| M16 | width ignores `?batch=1` | KILLED |
| M17 | `firstValue` returns the last repeated param | KILLED |
| M18 | `allowMethodOverride` removed | KILLED |
| M19 | `stripTsComments` stops recognising block comments | KILLED |
| M20 | `shouldBatch` stops consulting `NEVER_BATCH_PROCEDURES` | KILLED |
| M21 | `ExistingChat` reply ids stop being deduplicated | **SURVIVED — deliberately** |
| M22 | schema drops the `.int().min(1)` validators (the F2 guard) | **KILLED** (was SURVIVED) |
| M23 | typo the schema key `TRPC_MAX_BATCH_SIZE` → `TRPC_MAX_BATCH_SIZ` (the F1 seam) | **KILLED** (was SURVIVED) |

M21 is the honest one: the dedupe is behaviour-identical (see below), so there is no behaviour to assert and a guard would be theatre. It is scored **structurally rather than by a run** — no test file in the repo references `ExistingChat`, so no suite can kill it; that is a stronger statement than a SURVIVED verdict from a battery that never loads the component.

**M22** (drop `.int().min(1)`, leaving `z.coerce.number().catch(...)`) fails **5** cases in the new schema test — `''`→0, `'0'`→0, `'-5'`→-5, `'12.5'`→12.5, `' '`→0 all pass through instead of falling back (`AssertionError: expected fallback for "": expected +0 to be 30`). Honest detail: the `'abc'` case still passes under this mutant, because `NaN` is rejected by `z.number()` itself and reaches `.catch()` without needing `.int()`. So `.min(1)` is doing the work for five of the six, and the sixth is covered by zod's own NaN handling.

**M23** is scored by **typecheck**, not by the suite, and was run as a three-arm experiment because a red arm alone attributes nothing:

| Arm | Tree | Typo applied | Result |
|---|---|---|---|
| A | post-fix (direct `env.TRPC_MAX_BATCH_SIZE`) | yes | **rc=2, +1 error** — `src/server/trpc/batch-cap.ts(36,26): error TS2551: Property 'TRPC_MAX_BATCH_SIZE' does not exist on type '{…}'. Did you mean 'TRPC_MAX_BATCH_SIZ'?` |
| B | pre-fix (the cast restored) | yes | **rc=0, 0 errors** — the identical typo is invisible. This is the SURVIVED the fix removes. |
| C | pre-fix (the cast restored) | no | rc=0, 0 errors — control, so arm B's zero is not an artefact of a broken run |

Both counts are deltas against this branch's own baseline of **0 type errors**. A second, independent layer was also measured: with the key typo-ed, the new schema test fails **all 8 cases at runtime** (`serverSchema.shape.TRPC_MAX_BATCH_SIZE` is `undefined`, so `field.parse` throws) — so the seam is pinned at compile time *and* at run time, by different mechanisms.

## Latent coupling bug fixed (and a second instance found)

`trpc-batching.test.ts` re-derived the never-batch set with a substring test, `block.includes('edgeCacheIt(')` — which **also matched commented-out code**. Two procedures were on the never-batch list purely because the words were still in the file:

- `image.getGenerationData` — `// TODO: Add edgeCacheIt back after fixing the cache invalidation.`
- `event.getData` — `// .use(edgeCacheIt({ ttl: CacheTTL.lg }))` ← **found by this fix**

With a batch cap in place that stops being harmless: anyone making the guard comment-aware would drop both off the never-batch list, and the client would silently start batching a per-image query at feed width.

So the fix is deliberately **two independent mechanisms**, neither able to disable the other:
1. the derivation is now comment-aware (a small TS comment stripper with its own positive *and* negative controls);
2. both procedures are pinned in a new `NEVER_BATCH_PROCEDURES` set for a reason the derivation cannot reach — they are **pending-cacheable**: batching appends `?batch=1`, which `edgeCacheIt` refuses to cache.

## First-party fan-out

Two `trpc.useQueries` sites could exceed 30. Both are bound below the cap by `maxURLLength` today, with `maxItems` behind them, so no truncation was introduced.

- **`ExistingChat`** — `chat.getMessageById` per replied-to message. Reply ids are now **deduplicated in insertion order**. ⚠️ **Corrected claim:** the previous revision said the un-deduplicated list "fired one `getMessageById` per reply". That is false — `@tanstack/query-core` already collapses identical query keys, so duplicate ids never produced extra tRPC operations or extra batch width. What the dedupe removes is the per-duplicate query **observer** (and the array churn behind it): marginally cheaper, behaviour-identical in both directions (the lookup is `replyIds.indexOf(...)`, which already resolved every duplicate to the first occurrence).
- **`AppActivityPanel`** — `user.getById` per distinct recipient, up to ~50 across two feeds. Already deduplicated; documented, not changed.

**Follow-ups (not in this PR):** bulk `chat.getMessagesByIds` and `user.getByIds` procedures would collapse both to one query at any width.

## Rollout note

There is a brief **stale-bundle window**. A browser holding a pre-PR bundle has no `maxItems`, so a short-path, no-input batch could exceed 30 and be rejected — failing every query in that batch at once, with no retry (the batch cohort runs `retry: 0`). Low probability (the cohort is mod-only today and the URL cap binds most shapes first) and transient (it clears as bundles refresh), but it is a real window, and the env var is the lever if it turns out to matter.

## Verification actually run

Node 22 locally (the repo's `engines` wants 24; see the CI note below).

- **`pnpm typecheck`** — `OK — 0 type errors`.
- **`eslint`** on all 11 changed/new files — **0 errors**; the only warnings are pre-existing lines in `src/utils/trpc.ts` outside the diff hunks.
- **Full `unit` project** — baseline on this branch *before* these fixes: `Test Files 1093 passed | 1 skipped (1094)`, `Tests 17128 passed | 21 skipped (17149)`, 0 failures. *After*: `Test Files 1095 passed | 1 skipped (1096)`, `Tests 17150 passed | 21 skipped (17171)`, 0 failures — +2 files and +22 tests, matching exactly what was added. Pass/fail lines were counted from the log, not read off an exit code.
- **Mutation testing — 24 mutants, 23 killed, 1 deliberately unguarded**, each killed by the assertion written for it (error text recorded), with a known-caught positive control (PC1) in the batch so a mutant that never executed could not be scored SURVIVED. The four block-comment mutants and both new ones (M22/M23) were **reproduced as SURVIVING on the pre-fix tree first**, so the matrix is red-then-green rather than green-only.

### Re-verification after the F1/F2 fixes

The fixes below landed after the run above, and a fix round resets the gate — so everything was re-measured on the post-fix tree rather than carried forward.

- **`pnpm typecheck`** — `rc=0`, **0 errors**, unchanged from this branch's pre-fix baseline of 0. (Counted by grepping `error TS` out of the log, not read off the exit code.)
- **`eslint`** on the three changed/new files — **0 errors, 0 warnings**. Instrument validated first: with a deliberate defect appended to `batch-cap.ts`, the same invocation reported **3 files linted, 1 error + 1 warning**, so the clean verdict is a fact about the code and not about an empty file list.
- **Full `unit` project** — `Test Files 1096 passed | 1 skipped (1097)`, `Tests 17158 passed | 21 skipped (17179)`, **0 failures**, 0 timeout panics. Against the pre-fix figures recorded above (1095 files / 17150 tests) that is **+1 file and +8 tests**, matching exactly the one test file added. Pass/fail counted from the log.
- **Mutation battery replayed in full** (24 mutants) on the post-fix tree, one at a time from a pristine copy, each anchor asserted to match exactly once before application. Battery baseline **151 passed / 0 failed**; every mutant row sums to 151, so none was scored SURVIVED through a suite that failed to load.
- **F2 behaviour proven on the real boot path, with a negative control.** `serverSchema.safeParse({...process.env, TRPC_MAX_BATCH_SIZE: <bad>})` — the exact call `src/env/server.ts` throws on — contributes **no issue** for the key for any of the six bad values, while the previous `.default()` spelling, run verbatim beside it as the control, **rejects all six**. Without that control a clean result would be indistinguishable from a probe wired to nothing. (13/13 green; the probe was temporary and is not committed.)
- The `maxBatchSize` → `getRequestInfo` → pre-`createContext` ordering, the `maxItems` splitting behaviour, and `Histogram.zero`'s destructive semantics were all read out of the installed `@trpc/server@11.17.0` / `@trpc/client@11.17.0` / `prom-client` source, not assumed.

### On the preview bot's `Unit tests ❌ unit:fail (report-only)`

**Environmental, not this PR.** The Tekton report-only unit tier ran the monorepo on `node:20-bookworm` while the repo declares `engines.node: ">=24.0.0 <25"`. `fs.globSync` was added in Node 22, so on Node 20 it is `undefined`, and `src/server/services/__tests__/no-direct-shared-module-mock.test.ts` (added in #3959, untouched by this branch) threw `TypeError: globSync is not a function` **4 times** — the entire failure. Everything else was green: `Test Files 1 failed | 1092 passed | 1 skipped`. The same suite is fully green locally on this branch. The runner image has since been bumped to `node:24-bookworm`, and preview builds after that bump report Node v24.19.0.

## Tests

Five files, **104 tests**, all green:

| File | Tests |
|---|---|
| `src/server/__tests__/trpc-batch-cap.test.ts` | 45 |
| `src/utils/__tests__/trpc-batching.test.ts` | 40 |
| `src/server/__tests__/trpc-handler-wiring.test.ts` (new) | 8 |
| `src/env/__tests__/server-schema-trpc-max-batch-size.test.ts` (new) | 8 |
| `src/utils/__tests__/trpc-batch-link-wiring.test.ts` (new) | 3 |

*(The previous revision of this description said 41 tests in `trpc-batch-cap.test.ts`; vitest reported 34. Both numbers are now measured, not remembered.)*

`trpc-batch-cap.test.ts` drives a **real `node:http` server** through `createNextApiHandler`, so status codes, the error envelope and the adapter's stream handling are all real:

- over-cap → **400**, well-formed tRPC error envelope, **and `resolver` called 0 times + `createContext` called 0 times**, on **GET and POST**;
- at cap → 200, all 30 resolved (GET and POST); the widest first-party width → 200; width 200 → rejected as cheaply;
- non-batched requests untouched however many commas the path has;
- metric **positive control**: an over-cap request moves `over_limit="true"` by exactly 1 while `over_limit="false"` stays at 0 — reported as the pair, never a bare zero;
- the env-backed cap: default, valid override, and six invalid values that must fall back to "still capped" rather than to "no cap";
- second-evaluation seeding, default-registry registration, the bucket edge at the cap, and the safe failure direction.

## Known follow-ups (deliberately not in this PR)

- **`stripTsComments` → `ts.createScanner`.** The hand-rolled stripper is real fragility (regex literals, JSX), though it fails loudly rather than silently, and this PR is already large.
- **`apps/orchestrator-gateway`'s uncapped `fetchRequestHandler`** — a different app, same class of exposure.
- 🔴 **No alert on `civitai_app_trpc_batch_width{over_limit="true", client="web"}`.** The histogram ships observe-only, so a first-party bundle starting to hit the cap — the exact stale-bundle / post-ramp failure this PR flags as its main risk — produces a series nobody is paged on. `client="web"` is the discriminating label: `other` climbing is the cap working as intended on automated clients, `web` climbing means we are clipping our own traffic. **No code for it belongs in this repo** — it is a Grafana alert in the private talos-infra repo, and it is tracked there rather than here.
- **The `typeof configured === 'number'` guard in `getTrpcMaxBatchSize`** is now equivalent-mutant territory for the schema-booted path (the schema can no longer yield a non-number). It is retained for the test-double path and documented as such; killing it would need a mutation the type system permits.
- Bulk `chat.getMessagesByIds` / `user.getByIds`.
- Once the histogram has post-ramp data, re-derive the cap from it — the pre-ramp distribution above is explicitly not a bound.

