### PR TITLE
fix(app-listings): resolve any top-level listing by slug in getMyListingForApp (#3984)

### DIFF
--- a/src/components/Apps/appListingEditorTabs.ts
+++ b/src/components/Apps/appListingEditorTabs.ts
@@ -81,11 +81,16 @@ export type EditorTabContext = {
  *                       gate an incidental PROXY: it happened to correlate with the truth
  *                       (off-site listings usually have no block) without ever expressing
  *                       it. `listingMedia` was split out of `listingContent` so the table
- *                       states the real constraint — the standalone media editor is hosted
- *                       by the BLOCK-keyed `getMyListingForApp` — and this gate now reads
- *                       it. Off-site media is still editable inside the details wizard,
- *                       which is why withholding the TAB loses nothing today.
- *                       Widening it is civitai/civitai#3893.
+ *                       states the real constraint, and this gate now reads it.
+ *                       🟡 That constraint is no longer "the host resolver is block-keyed":
+ *                       civitai/civitai#3984 re-keyed `getMyListingForApp` to take
+ *                       `appBlockId` OR `slug`, so the resolver reaches an off-site listing
+ *                       fine. What withholds the tab TODAY is the `ctx.appBlockId != null`
+ *                       clause below — the panel hands an `appBlockId` to
+ *                       `<ListingMediaEditor>`, and an off-site listing has none. Off-site
+ *                       media is still editable inside the details wizard, which is why
+ *                       withholding the TAB loses nothing today. Widening it (flip the cell
+ *                       AND re-key the panel onto the slug) is civitai/civitai#3893.
  *
  *   - `manifest`      — BOTH `capabilities.submitVersion` AND a backing block.
  *

--- a/src/pages/apps/listing/[appListingId]/edit.tsx
+++ b/src/pages/apps/listing/[appListingId]/edit.tsx
@@ -185,9 +185,12 @@ export default function AppListingEditPage() {
               </Tabs.Panel>
             ) : null}
 
-            {/* 🔴 `context.appBlockId` is non-null whenever this tab is in the set — the
-                media editor is hosted by the BLOCK-keyed `getMyListingForApp`, which is
-                exactly why `editorTabsFor` withholds the tab without one. */}
+            {/* 🔴 `context.appBlockId` is non-null whenever this tab is in the set — THIS
+                PANEL is block-keyed (it passes an `appBlockId` down), which is exactly why
+                `editorTabsFor` withholds the tab without one. Note the host resolver is
+                NOT the constraint any more: `getMyListingForApp` takes `appBlockId` OR
+                `slug` since civitai/civitai#3984. Re-keying this panel onto the slug is
+                civitai/civitai#3893. */}
             {tabs.includes('media') && context.appBlockId ? (
               <Tabs.Panel value="media" pt="md" data-testid="apps-edit-panel-media">
                 <ListingMediaEditor appBlockId={context.appBlockId} />

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -620,8 +620,11 @@ export const appListingsRouter = router({
     }),
 
   /**
-   * OWNER: resolve the caller's OWN listing by its backing `appBlockId` — the entry
-   * read for the owner-facing on-site listing-media page (`/apps/<appBlockId>/listing`).
+   * OWNER: resolve the caller's OWN listing by its backing `appBlockId` OR by its public
+   * `slug` — the entry read for the owner-facing on-site listing-media page
+   * (`/apps/<appBlockId>/listing`) and for non-web clients that only hold a slug.
+   * `appBlockId` takes PRECEDENCE: the slug arm runs only when it missed or was absent,
+   * and it resolves any TOP-LEVEL listing (either kind, any status) — civitai/civitai#3984.
    * Returns the `AppListing.id` the page passes to `beginListingRevision` + the asset
    * procs, plus the listing status / content rating / whether a revision is already
    * under review, AND the EDITABLE target's current assets (`assets` + `shadowId`) so

--- a/src/server/schema/blocks/offsite-listing.schema.ts
+++ b/src/server/schema/blocks/offsite-listing.schema.ts
@@ -226,7 +226,11 @@ export const getMyListingForAppSchema = z
     appBlockId: z.string().min(1).max(64).optional(),
     // The slug arm resolves ANY top-level listing (civitai/civitai#3984): the W13
     // pre-approval draft of a FIRST-version on-site app (no AppBlock yet), and an
-    // OFF-SITE listing, which never has an AppBlock to be keyed by at all.
+    // OFF-SITE listing, which in practice carries no AppBlock to be keyed by (0 rows
+    // of the `kind:'offsite'` + non-null `appBlockId` shape in production, measured
+    // 2026-08-11 — empirical, not structural; `appBlockId` is NOT a kind
+    // discriminator, see schema.full.prisma). `appBlockId` takes precedence when
+    // both are supplied.
     slug: z.string().min(1).max(64).optional(),
   })
   .refine((v) => v.appBlockId != null || v.slug != null, {

--- a/src/server/schema/blocks/offsite-listing.schema.ts
+++ b/src/server/schema/blocks/offsite-listing.schema.ts
@@ -214,16 +214,19 @@ export type BeginListingRevisionInput = z.infer<typeof beginListingRevisionSchem
 
 /**
  * OWNER: resolve the caller's OWN listing by its backing `appBlockId`
- * (`AppListing.appBlockId` is `@unique`) — the entry read for the owner-facing
- * on-site listing-media page. Returns the `AppListing.id` (the target for
- * `beginListingRevision` + the asset procs). Owner-bound in the service
- * (NOT_OWNED→FORBIDDEN, NOT_FOUND when no listing row exists for the app).
+ * (`AppListing.appBlockId` is `@unique`) or by its public `slug`
+ * (`AppListing.slug` is `@unique` across BOTH kinds) — the entry read for the
+ * owner-facing listing-media page and for non-web clients. Returns the
+ * `AppListing.id` (the target for `beginListingRevision` + the asset procs).
+ * Owner-bound in the service (NOT_OWNED→FORBIDDEN, NOT_FOUND when no listing
+ * row exists for the app).
  */
 export const getMyListingForAppSchema = z
   .object({
     appBlockId: z.string().min(1).max(64).optional(),
-    // W13 draft-at-submit: a FIRST-version app has no AppBlock yet, so the
-    // owner-media page resolves its pre-approval draft BY SLUG while pending.
+    // The slug arm resolves ANY top-level listing (civitai/civitai#3984): the W13
+    // pre-approval draft of a FIRST-version on-site app (no AppBlock yet), and an
+    // OFF-SITE listing, which never has an AppBlock to be keyed by at all.
     slug: z.string().min(1).max(64).optional(),
   })
   .refine((v) => v.appBlockId != null || v.slug != null, {

--- a/src/server/services/blocks/__tests__/app-access.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.service.test.ts
@@ -161,13 +161,16 @@ describe('capabilitiesForKind — capabilities are DERIVED, never configured', (
     //
     // 🔴 `listingMedia` is a SURFACE fact and is the newest, narrowest cell: an off-site
     // listing CAN hold and edit assets (the submit/edit wizard does exactly that, through
-    // listing-keyed asset procs), but the standalone media EDITOR is hosted by the
-    // BLOCK-keyed `getMyListingForApp`, so there is no id to open it with. It is split
+    // listing-keyed asset procs), and since civitai/civitai#3984 the standalone editor's
+    // HOST RESOLVER reaches it too — `getMyListingForApp` takes `appBlockId` OR `slug`.
+    // What still withholds the surface is the WEB tab gate `editorTabsFor`, whose `media`
+    // arm requires `ctx.appBlockId != null` on top of this cell, and an off-site listing
+    // has no block id to give it. The cell stays `false`, but for a NARROWER reason than
+    // it was written with: it is about the TAB now, not about the resolver. It is split
     // out from `listingContent` — which stays TRUE for both kinds, because listing
-    // scalars really are editable on both — so the table stops asserting a surface that
-    // does not exist. Tracked by
-    // https://github.com/civitai/civitai/issues/3893; flipping this cell is what that
-    // issue's fix does.
+    // scalars really are editable on both — so the table stops asserting a surface the UI
+    // does not offer. Tracked by https://github.com/civitai/civitai/issues/3893; flipping
+    // this cell (and dropping that block-id clause) is what that issue's fix does.
     expect(capabilitiesForKind('offsite')).toEqual({
       listingContent: true,
       listingMedia: false,

--- a/src/server/services/blocks/__tests__/app-collaborator.permission-matrix.test.ts
+++ b/src/server/services/blocks/__tests__/app-collaborator.permission-matrix.test.ts
@@ -150,7 +150,24 @@ beforeEach(() => {
     app: { userId: OWNER },
   });
   mockDb.appListing.findUnique.mockResolvedValue(draftListing());
-  mockDb.appListing.findFirst.mockResolvedValue(null);
+  // 🔴 PREDICATE-AWARE. Two different reads land on `appListing.findFirst`:
+  //   - `getMyListingForApp`'s SLUG arm (`where.slug`) — must HIT, or the off-site half
+  //     of that entry point could not resolve at all and its DENY cells would pass
+  //     vacuously (right verdict, wrong reason: NOT_FOUND, not the access gate);
+  //   - the shadow-existence probe (`where.revisionOfId`) — must MISS, or
+  //     `beginListingRevision` reports a shadow that does not exist.
+  mockDb.appListing.findFirst.mockImplementation(async (args: unknown) => {
+    const w = (args as { where?: Record<string, unknown> }).where ?? {};
+    if (w.slug == null) return null; // the shadow-existence probe
+    // 🔴 …and it HONOURS the rest of the clause. A mock that handed the row back for any
+    // `where` containing a slug would let the off-site ALLOW cells pass under the OLD,
+    // narrow `{ slug, kind:'onsite', appBlockId:null, status:'draft' }` clause too — i.e.
+    // it would assert nothing about the widening it exists to depend on. Measured: with
+    // this evaluation in place, restoring `kind:'onsite'` to the service reddens the
+    // off-site ALLOW cells; without it, they stay green.
+    const row = draftListing() as Record<string, unknown>;
+    return Object.entries(w).every(([f, v]) => f === 'slug' || row[f] === v) ? row : null;
+  });
   mockDb.appCollaborator.findFirst.mockImplementation(async (args: unknown) => {
     const w = (args as { where: { appListingId?: string; userId: number; status?: string } }).where;
     // 🔴 The seat lives on the LIVE parent listing. Honouring `appListingId` is what
@@ -208,6 +225,30 @@ const MATRIX: Record<string, Record<string, boolean>> = {
     stranger: false,
     moderator: false,
   },
+  // offsite-listing: getMyListingForApp (NO mod bypass).
+  //
+  // 🔴 THIS ROW USED TO LIVE IN A SEPARATE `ONSITE_ONLY` BUCKET, on the rationale that the
+  // proc "is keyed on an `appBlockId`; an off-site listing does not have one, so the proc
+  // is not denied for offsite — it is UNCALLABLE, the same structural mechanism that makes
+  // `submitVersion: false` real". 🔴 THAT MECHANISM NO LONGER EXISTS. civitai/civitai#3984
+  // re-keyed the proc to `appBlockId` OR `slug`, and the slug arm resolves any TOP-LEVEL
+  // listing of either kind — so an off-site listing IS reachable, and the classification
+  // was stale, not merely mis-worded. It is therefore kind-CROSSED like every other row:
+  // the off-site run calls it the way an off-site client must (by slug) and asserts the
+  // identical allow/deny column, which is the claim "the widening moved the refusal onto
+  // the OWNER GATE and changed nobody's access".
+  //
+  // (`CAPABILITIES_BY_KIND.offsite.listingMedia` stays `false` regardless: that cell is
+  // held by the WEB tab gate `editorTabsFor`, whose `media` arm still requires
+  // `ctx.appBlockId != null`. Flipping it is civitai/civitai#3893, not this.)
+  'offsite.getMyListingForApp': {
+    owner: true,
+    'accepted editor': true,
+    'PENDING editor': false,
+    'REJECTED editor': false,
+    stranger: false,
+    moderator: false,
+  },
   // app-collaborators: listCollaborators — the ROSTER read. A moderator DOES pass here
   // (the service takes an explicit isModerator), unlike the two author-edit gates above.
   'collaborators.list': {
@@ -221,23 +262,13 @@ const MATRIX: Record<string, Record<string, boolean>> = {
 };
 
 /**
- * Entry points that exist for ONE kind only, and why — so their absence from the
- * kind-crossed run reads as a decision rather than an oversight.
- *
- * `getMyListingForApp` is keyed on an `appBlockId`. An off-site listing does not have
- * one, so the proc is not "denied" for offsite — it is UNCALLABLE, which is the same
- * structural mechanism that makes `submitVersion: false` real.
+ * 🔴 THERE IS NO LONGER AN `ONSITE_ONLY` BUCKET. It held exactly one entry,
+ * `offsite.getMyListingForApp`, on the (once true, now false) rationale that the proc was
+ * block-keyed and therefore structurally UNCALLABLE for an off-site listing.
+ * civitai/civitai#3984 gave it a slug selector, so it is callable for both kinds and has
+ * moved into the kind-crossed {@link MATRIX} above. Do not re-add a bucket for it: an
+ * "absent for this kind" classification has to name a mechanism that still exists.
  */
-const ONSITE_ONLY: Record<string, Record<string, boolean>> = {
-  'offsite.getMyListingForApp': {
-    owner: true,
-    'accepted editor': true,
-    'PENDING editor': false,
-    'REJECTED editor': false,
-    stranger: false,
-    moderator: false,
-  },
-};
 
 const { getListingAssets } = await import('~/server/services/blocks/app-listing-assets.service');
 const { getMyListingForApp, getMyListingForEdit, beginListingRevision } = await import(
@@ -249,7 +280,14 @@ const RUNNERS: Record<string, (s: Subject) => Promise<unknown>> = {
   'assets.getListingAssets': (s) =>
     getListingAssets({ listingId: LIVE }, { id: s.id, isModerator: s.isModerator } as never),
   'offsite.getMyListingForEdit': (s) => getMyListingForEdit({ listingId: LIVE, userId: s.id }),
-  'offsite.getMyListingForApp': (s) => getMyListingForApp({ appBlockId: APP, userId: s.id }),
+  // 🔴 KIND-AWARE BY DESIGN: each kind is called the way its only real client CAN call
+  // it. An on-site caller holds the block id; an off-site listing has no AppBlock, so
+  // the slug is its only handle (civitai/civitai#3984). Hard-coding `appBlockId` for
+  // both would make the off-site row a test of the on-site selector.
+  'offsite.getMyListingForApp': (s) =>
+    KIND === 'offsite'
+      ? getMyListingForApp({ slug: 'my-app', userId: s.id })
+      : getMyListingForApp({ appBlockId: APP, userId: s.id }),
   'collaborators.list': (s) =>
     listCollaborators({ appListingId: LIVE, viewerUserId: s.id, isModerator: s.isModerator }),
 };
@@ -281,24 +319,6 @@ describe.each(KINDS)('permission matrix — kind=%s × role × entry point', (ki
     expect(row.kind).toBe(kind);
     expect(row.appBlockId).toBe(kind === 'onsite' ? APP : null);
   });
-});
-
-describe('ONSITE-ONLY entry points (block-keyed, so structurally absent for offsite)', () => {
-  beforeEach(() => {
-    KIND = 'onsite';
-    mockDb.appListing.findUnique.mockResolvedValue(draftListing());
-  });
-
-  for (const [entry, row] of Object.entries(ONSITE_ONLY)) {
-    for (const subject of SUBJECTS) {
-      const allowed = row[subject.label];
-      it(`${entry} · ${subject.label} → ${allowed ? 'ALLOW' : 'DENY'}`, async () => {
-        const call = RUNNERS[entry](subject);
-        if (allowed) await expect(call).resolves.toBeTruthy();
-        else await expect(call).rejects.toBeTruthy();
-      });
-    }
-  }
 });
 
 describe('matrix hygiene', () => {

--- a/src/server/services/blocks/__tests__/offsite-listing.edit-consolidate.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.edit-consolidate.service.test.ts
@@ -96,7 +96,9 @@ function editViewRow(ssRowId: string, overrides: Record<string, unknown> = {}) {
     coverId: 20,
     icon: { url: 'icon-key' },
     cover: { url: 'cover-key' },
-    screenshots: [{ id: ssRowId, imageId: 30, order: 0, caption: 'cap', image: { url: 'shot-key' } }],
+    screenshots: [
+      { id: ssRowId, imageId: 30, order: 0, caption: 'cap', image: { url: 'shot-key' } },
+    ],
     ...overrides,
   };
 }
@@ -146,7 +148,9 @@ beforeEach(() => {
   mockRead.oauthClient.findUnique.mockResolvedValue(null);
   mockWrite.appListing.findFirst.mockResolvedValue(null);
   mockWrite.appListing.update.mockImplementation(async (args: { data: unknown }) => args.data);
-  mockWrite.$transaction.mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) => cb(mockWrite));
+  mockWrite.$transaction.mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) =>
+    cb(mockWrite)
+  );
 });
 
 describe('getMyListingForEdit', () => {
@@ -183,7 +187,7 @@ describe('getMyListingForEdit', () => {
    * only the off-site row would survive `kind: 'offsite'`, and asserting only the on-site
    * row would survive `kind: 'onsite'`.
    */
-  it('🔴 returns the listing\'s REAL kind — off-site', async () => {
+  it("🔴 returns the listing's REAL kind — off-site", async () => {
     wireFindUnique(ownedRow({ status: 'draft', kind: 'offsite' }), {
       apl_parent: editViewRow('ss_parent'),
     });
@@ -191,7 +195,7 @@ describe('getMyListingForEdit', () => {
     expect(res.kind).toBe('offsite');
   });
 
-  it('🔴 returns the listing\'s REAL kind — on-site', async () => {
+  it("🔴 returns the listing's REAL kind — on-site", async () => {
     wireFindUnique(ownedRow({ status: 'draft', kind: 'onsite' }), {
       apl_parent: editViewRow('ss_parent'),
     });
@@ -289,6 +293,50 @@ describe('getMyListingForEdit', () => {
     expect(res.assets.screenshots[0].id).toBe('ss_shadow_new');
   });
 
+  /**
+   * 🟡 CHARACTERIZATION TEST — this pins what the code DOES today. It is not an
+   * assertion about what it SHOULD do, and it should not be read as one.
+   *
+   * `getMyListingForEdit` gates on ownership + status
+   * (`loadOwnedEditableListing`, then the shadow / removed / rejected switch) and
+   * contains NO `kind` check; neither do the listing-keyed asset procs
+   * (`loadOwnedListing`). So an APPROVED OFF-SITE listing goes down the whole
+   * shadow-revision media path: a shadow is minted, the prefill returns the
+   * SHADOW's asset row ids, and the caller is handed an editable target.
+   *
+   * Meanwhile `CAPABILITIES_BY_KIND.offsite.listingMedia` is `false`. That cell is
+   * read ONLY by the web tab gate (`src/components/Apps/appListingEditorTabs.ts`);
+   * no service consults it — unlike `earnings` and `submitVersion`, the two other
+   * `false` cells, which ARE enforced service-side.
+   *
+   * 🔴 OPEN QUESTION, deliberately NOT answered here (raised in the PR for
+   * civitai/civitai#3984 for whoever owns the capability table): is off-site media
+   * editing through the listing-keyed procs INTENDED — in which case the cell is
+   * stale — or a gap the `listingMedia: false` cell believes is closed, in which
+   * case the missing check is in the services, not in the tab gate? Whichever
+   * answer lands, re-label or invert this test; do not silently delete it.
+   */
+  it('CHARACTERIZATION: an APPROVED OFF-SITE listing gets the full shadow media path (no kind check)', async () => {
+    wireFindUnique(ownedRow({ kind: 'offsite', status: 'approved' }), {
+      apl_shadow_offsite: editViewRow('ss_shadow_offsite'),
+    });
+    mockRead.appListing.findFirst.mockResolvedValue(null);
+    mockWrite.appListing.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue({ id: 'apl_shadow_offsite' });
+
+    const res = await getMyListingForEdit({ listingId: 'apl_parent', userId: 7 });
+
+    // The listing really is off-site — no kind check refused it anywhere on the path.
+    expect(res.kind).toBe('offsite');
+    // …and it got everything the on-site media flow gets: a shadow, and the shadow's
+    // asset rows (the ids a "remove screenshot" would target).
+    expect(mockWrite.appListing.create).toHaveBeenCalled();
+    expect(res.shadowId).toBe('apl_shadow_offsite');
+    expect(res.assets.screenshots[0].id).toBe('ss_shadow_offsite');
+    expect(res.assets.icon).toEqual({ imageId: 10, url: 'edge:icon-key' });
+  });
+
   // -------------------------------------------------------------------------
   // 🔴 READ-AFTER-WRITE (the `getMyListingForEdit` half of the same guard).
   // The shadow is INSERTed on the PRIMARY; reading it back off the replica misses
@@ -364,26 +412,34 @@ describe('getMyListingForEdit', () => {
 
   it('rejects a non-owner (NOT_OWNED)', async () => {
     wireFindUnique(ownedRow({ userId: 999 }), { apl_parent: editViewRow('ss_parent') });
-    await expect(getMyListingForEdit({ listingId: 'apl_parent', userId: 7 })).rejects.toMatchObject({
-      code: 'NOT_OWNED',
-    });
+    await expect(getMyListingForEdit({ listingId: 'apl_parent', userId: 7 })).rejects.toMatchObject(
+      {
+        code: 'NOT_OWNED',
+      }
+    );
   });
 
   it('rejected → MUST_RESUBMIT; removed → FORBIDDEN; a shadow → INVALID_REVISION', async () => {
     wireFindUnique(ownedRow({ status: 'rejected' }), {});
-    await expect(getMyListingForEdit({ listingId: 'apl_parent', userId: 7 })).rejects.toMatchObject({
-      code: 'MUST_RESUBMIT',
-    });
+    await expect(getMyListingForEdit({ listingId: 'apl_parent', userId: 7 })).rejects.toMatchObject(
+      {
+        code: 'MUST_RESUBMIT',
+      }
+    );
 
     wireFindUnique(ownedRow({ status: 'removed' }), {});
-    await expect(getMyListingForEdit({ listingId: 'apl_parent', userId: 7 })).rejects.toMatchObject({
-      code: 'FORBIDDEN',
-    });
+    await expect(getMyListingForEdit({ listingId: 'apl_parent', userId: 7 })).rejects.toMatchObject(
+      {
+        code: 'FORBIDDEN',
+      }
+    );
 
     wireFindUnique(ownedRow({ revisionOfId: 'apl_parent2' }), {});
-    await expect(getMyListingForEdit({ listingId: 'apl_parent', userId: 7 })).rejects.toMatchObject({
-      code: 'INVALID_REVISION',
-    });
+    await expect(getMyListingForEdit({ listingId: 'apl_parent', userId: 7 })).rejects.toMatchObject(
+      {
+        code: 'INVALID_REVISION',
+      }
+    );
   });
 
   it('throws NOT_FOUND when the listing does not exist', async () => {

--- a/src/server/services/blocks/__tests__/offsite-listing.edit-consolidate.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.edit-consolidate.service.test.ts
@@ -294,8 +294,17 @@ describe('getMyListingForEdit', () => {
   });
 
   /**
-   * 🟡 CHARACTERIZATION TEST — this pins what the code DOES today. It is not an
-   * assertion about what it SHOULD do, and it should not be read as one.
+   * 🟢 THIS TEST ADDS NO COVERAGE — it is a LABEL on a path this file already exercises,
+   * and it is filed here so nobody counts it twice. Say it plainly: `ownedRow` DEFAULTS
+   * to `kind: 'offsite'` (see its definition), so the "APPROVED with NO prior shadow →
+   * CREATES one" case immediately above ALREADY drives an approved off-site listing
+   * through the entire shadow media path, and the "returns the listing's REAL kind —
+   * off-site" case already asserts the kind survives. Deleting the `it` below would not
+   * move a single line of coverage. It is kept for ONE reason: it names, in one place,
+   * the thing those two tests demonstrate incidentally, and it carries the open question.
+   *
+   * 🟡 CHARACTERIZATION — it pins what the code DOES today. It is not an assertion about
+   * what it SHOULD do, and it must not be read as one.
    *
    * `getMyListingForEdit` gates on ownership + status
    * (`loadOwnedEditableListing`, then the shadow / removed / rejected switch) and
@@ -313,10 +322,17 @@ describe('getMyListingForEdit', () => {
    * civitai/civitai#3984 for whoever owns the capability table): is off-site media
    * editing through the listing-keyed procs INTENDED — in which case the cell is
    * stale — or a gap the `listingMedia: false` cell believes is closed, in which
-   * case the missing check is in the services, not in the tab gate? Whichever
-   * answer lands, re-label or invert this test; do not silently delete it.
+   * case the missing check is in the services, not in the tab gate?
+   *
+   * 🔴 The evidence leans INTENDED, further than the question implies:
+   * `REVIEWABLE_LISTING_KINDS = ['onsite','offsite']` (`offsite-listing.service.ts`)
+   * means the revision submit → approve → apply chain accepts an off-site listing END TO
+   * END, not just the editor entry read. A media revision an off-site owner stages here
+   * can be submitted, reviewed and applied. So the `listingMedia: false` cell is a
+   * statement about ONE web tab, not about a closed service-side gap. Whichever answer
+   * lands, re-label or invert this test; do not silently delete it.
    */
-  it('CHARACTERIZATION: an APPROVED OFF-SITE listing gets the full shadow media path (no kind check)', async () => {
+  it('CHARACTERIZATION (already covered above): an APPROVED OFF-SITE listing gets the full shadow media path (no kind check)', async () => {
     wireFindUnique(ownedRow({ kind: 'offsite', status: 'approved' }), {
       apl_shadow_offsite: editViewRow('ss_shadow_offsite'),
     });

--- a/src/server/services/blocks/__tests__/offsite-listing.get-my-listing-for-app.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.get-my-listing-for-app.service.test.ts
@@ -6,8 +6,8 @@ import {
 } from '~/server/services/blocks/offsite-listing.service';
 
 /**
- * `getMyListingForApp` — the owner-gated `appBlockId` → `AppListing.id` resolver
- * for the on-site listing-media owner page. Covers the contract branches:
+ * `getMyListingForApp` — the owner-gated `appBlockId`-or-`slug` → `AppListing.id`
+ * resolver every listing-media surface is hosted on. Covers the contract branches:
  *   - owner happy-path → `{ appListingId, status, contentRating, hasPendingRevision,
  *     shadowId, editTargetId, editBlockedReason, assets }`
  *   - a listing owned by ANOTHER user → NOT_OWNED (router maps → FORBIDDEN)
@@ -447,23 +447,23 @@ describe('getMyListingForApp', () => {
   it.each([
     ['removed', 'this listing has been removed by a moderator and can no longer be edited'],
     ['rejected', 'this listing was rejected; submit a new listing instead of editing it'],
-  ])('🔴 a %s listing returns an inline editBlockedReason, not a blank page', async (
-    status,
-    expected
-  ) => {
-    wireFindUnique({
-      entry: { id: 'apl_onsite', userId: OWNER, status, contentRating: 'g', revisionOfId: null },
-      viewByListingId: { apl_onsite: editViewRow('apls_OWN') },
-    });
+  ])(
+    '🔴 a %s listing returns an inline editBlockedReason, not a blank page',
+    async (status, expected) => {
+      wireFindUnique({
+        entry: { id: 'apl_onsite', userId: OWNER, status, contentRating: 'g', revisionOfId: null },
+        viewByListingId: { apl_onsite: editViewRow('apls_OWN') },
+      });
 
-    const res = await getMyListingForApp({ appBlockId: 'my-block', userId: OWNER });
+      const res = await getMyListingForApp({ appBlockId: 'my-block', userId: OWNER });
 
-    expect(res.editBlockedReason).toBe(expected);
-    expect(res.status).toBe(status);
-    // It is a VERDICT, not a throw — the page still renders (alert + no editor), which
-    // is what the "don't collapse to NotFound" narrowing exists to preserve.
-    expect(mockWrite.appListing.create).not.toHaveBeenCalled();
-  });
+      expect(res.editBlockedReason).toBe(expected);
+      expect(res.status).toBe(status);
+      // It is a VERDICT, not a throw — the page still renders (alert + no editor), which
+      // is what the "don't collapse to NotFound" narrowing exists to preserve.
+      expect(mockWrite.appListing.create).not.toHaveBeenCalled();
+    }
+  );
 
   it('🔴 an internal SHADOW resolved directly is not an editable page', async () => {
     wireFindUnique({
@@ -510,13 +510,40 @@ describe('getMyListingForApp', () => {
     expect(editViewReads(mockWrite)).toEqual(['apl_shadow']);
     expect(editViewReads(mockRead)).toEqual([]);
   });
-
 });
 
-// W13 draft-at-submit — a FIRST-version app has no AppBlock yet, so the owner-media
-// page reaches its pre-approval draft BY SLUG (`appBlockId IS NULL`). These lock the
-// slug fallback: the owner reaches their pending draft; ownership is still enforced.
-describe('getMyListingForApp — pre-approval DRAFT slug resolver (pending, no AppBlock)', () => {
+/**
+ * A `where`-HONOURING stand-in for the slug fallback's `dbRead.appListing.findFirst`.
+ *
+ * 🔴 EVERY CASE BELOW IS A CLAIM ABOUT WHICH ROWS THE `where` CLAUSE ADMITS, so a mock
+ * that hands back a fixed row whatever the clause said would pass under ANY clause —
+ * including the narrow one this resolver used to carry. This evaluates the clause the
+ * service actually sent against a row set: an off-site row is admitted only because the
+ * service stopped asking for `kind: 'onsite'`, and a shadow is rejected only because it
+ * asks for `revisionOfId: null`.
+ */
+function wireSlugLookup(rows: Array<Record<string, unknown>>) {
+  mockRead.appListing.findFirst.mockImplementation(async (args: unknown) => {
+    const where = (args as { where?: Record<string, unknown> }).where ?? {};
+    const matches = (row: Record<string, unknown>) =>
+      Object.entries(where).every(([field, expected]) => {
+        // `{ not: … }` is the only Prisma filter object this clause has ever used
+        // (it is the narrowing offered in the issue thread), so support just that.
+        if (expected !== null && typeof expected === 'object' && 'not' in expected) {
+          return row[field] !== (expected as { not: unknown }).not;
+        }
+        return row[field] === expected;
+      });
+    return rows.find(matches) ?? null;
+  });
+}
+
+// The SLUG resolver. Two callers share it: the W13 pre-approval draft of a FIRST-version
+// on-site app (no AppBlock yet, so `appBlockId` cannot address it *yet*), and an OFF-SITE
+// listing, which has no AppBlock *ever* — civitai/civitai#3984. These lock what the slug
+// arm admits (any top-level listing, either kind, any status) and what it refuses (a
+// shadow revision), and that ownership is still enforced on the widened path.
+describe('getMyListingForApp — slug resolver (any top-level listing, either kind)', () => {
   it('resolves the pending draft BY SLUG when only a slug is given (no appBlockId lookup)', async () => {
     // 🔴 The pre-approval draft carries `appBlockId: null`, so it has no OauthClient in
     // its ownership chain and `AppListing.userId` IS its canonical owner — the resolver's
@@ -526,12 +553,15 @@ describe('getMyListingForApp — pre-approval DRAFT slug resolver (pending, no A
       id: 'apl_draft',
       userId: OWNER,
       kind: 'onsite',
+      slug: 'my-app',
       appBlockId: null,
       revisionOfId: null,
       status: 'draft',
       contentRating: 'g',
     };
-    mockRead.appListing.findFirst.mockResolvedValue(draft);
+    // Predicate-honouring, so this also pins that the WIDENED clause is a SUPERSET —
+    // the pre-approval draft is still admitted by it.
+    wireSlugLookup([draft]);
     // A draft is NOT approved → no shadow revision; it is its own EFFECTIVE edit target,
     // so the edit-view assets are read straight off `apl_draft` (#3476 projection).
     wireFindUnique({
@@ -560,11 +590,11 @@ describe('getMyListingForApp — pre-approval DRAFT slug resolver (pending, no A
         ([a]) => (a as { where?: { appBlockId?: string } })?.where?.appBlockId != null
       )
     ).toBe(false);
-    // Scoped to the EXACT pre-approval-draft shape (onsite / null appBlockId / draft).
+    // Scoped to a TOP-LEVEL listing by its globally-unique slug — no kind, appBlockId
+    // or status narrowing (civitai/civitai#3984). `revisionOfId: null` is the one
+    // remaining clause and it is load-bearing; see the shadow case below.
     expect(mockRead.appListing.findFirst).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { slug: 'my-app', kind: 'onsite', appBlockId: null, status: 'draft' },
-      })
+      expect.objectContaining({ where: { slug: 'my-app', revisionOfId: null } })
     );
   });
 
@@ -623,5 +653,154 @@ describe('getMyListingForApp — pre-approval DRAFT slug resolver (pending, no A
     const err = await getMyListingForApp({ slug: 'ghost', userId: OWNER }).catch((e) => e);
     expect(err).toBeInstanceOf(OffsiteRequestError);
     expect(err.code).toBe('NOT_FOUND');
+  });
+
+  // -------------------------------------------------------------------------
+  // 🔴 civitai/civitai#3984 — the arm used to read
+  // `{ slug, kind: 'onsite', appBlockId: null, status: 'draft' }`, which resolves
+  // NOTHING an OFF-SITE app can ever be: `kind: 'offsite'` is what it IS, and it has
+  // no AppBlock, so neither selector could address it and every listing-media surface
+  // hosted on this proc was unreachable for non-web clients. Measured against
+  // civitai.com at civitai/cli@1b20b99 (civitai/cli#422, #424): 4/4 off-site apps
+  // failed, 7/7 on-site passed, and `kind` predicted it exactly.
+  // -------------------------------------------------------------------------
+
+  /** An OFF-SITE listing: no AppBlock, ever. The slug is its only handle. */
+  const offsiteRow = (overrides: Record<string, unknown> = {}) => ({
+    id: 'apl_offsite',
+    userId: OWNER,
+    kind: 'offsite',
+    slug: 'radio',
+    appBlockId: null,
+    revisionOfId: null,
+    status: 'approved',
+    contentRating: 'g',
+    ...overrides,
+  });
+
+  it('🔴 an OFF-SITE listing resolves BY SLUG — the kind clause is gone', async () => {
+    const offsite = offsiteRow();
+    wireSlugLookup([offsite]);
+    wireFindUnique({
+      entry: null,
+      owned: offsite,
+      viewByListingId: { apl_offsite: editViewRow('apls_offsite') },
+    });
+    // Approved parent, no shadow minted yet → edited in place, nothing written.
+    withShadow(null);
+
+    const res = await getMyListingForApp({ slug: 'radio', userId: OWNER });
+
+    expect(res).toMatchObject({
+      appListingId: 'apl_offsite',
+      status: 'approved',
+      editTargetId: 'apl_offsite',
+      editBlockedReason: null,
+      shadowId: null,
+    });
+    // The whole point of the proc: the caller now holds the AppListing.id every
+    // listing-media surface is keyed on, plus the assets the publish floor checks.
+    expect(res.assets.icon.imageId).toBe(137918008);
+    expect(res.assets.cover.imageId).toBe(137918011);
+    // It is a READ. Resolving an off-site listing must not mint anything.
+    expect(mockWrite.appListing.create).not.toHaveBeenCalled();
+  });
+
+  it('🔴 an APPROVED ON-SITE listing resolves BY SLUG — the status clause is gone', async () => {
+    // An approved on-site app DOES carry an appBlockId; a client that only knows the
+    // slug still could not reach it, because the fallback demanded `status: 'draft'`
+    // AND `appBlockId: null`. Both are gone.
+    const approved = {
+      id: 'apl_live',
+      userId: OWNER,
+      kind: 'onsite',
+      slug: 'gen-matrix',
+      appBlockId: 'ab_live',
+      revisionOfId: null,
+      status: 'approved',
+      contentRating: 'pg13',
+      // The CANONICAL onsite owner is the block's app owner, not the denormalized
+      // column — wire it so the gate resolves through the path it uses in production.
+      appBlock: { app: { userId: OWNER } },
+    };
+    wireSlugLookup([approved]);
+    wireFindUnique({
+      entry: null,
+      owned: approved,
+      viewByListingId: { apl_live: editViewRow('apls_live') },
+    });
+    withShadow(null);
+
+    const res = await getMyListingForApp({ slug: 'gen-matrix', userId: OWNER });
+
+    expect(res).toMatchObject({
+      appListingId: 'apl_live',
+      status: 'approved',
+      editTargetId: 'apl_live',
+      editBlockedReason: null,
+    });
+    // Slug-only in, so the `appBlockId` findUnique arm was never entered.
+    expect(
+      mockRead.appListing.findUnique.mock.calls.some(
+        ([a]) => (a as { where?: { appBlockId?: string } })?.where?.appBlockId != null
+      )
+    ).toBe(false);
+  });
+
+  it('🔴 a slug owned by ANOTHER user → NOT_OWNED, not NOT_FOUND (the gate, not the where)', async () => {
+    // The BEHAVIOUR DELTA of #3984, pinned deliberately. Before, a stranger's slug was
+    // filtered out by the `where` and reported NOT_FOUND; now the row resolves and the
+    // OWNER GATE refuses it — which is what makes the gate, rather than an incidental
+    // clause, the thing enforcing access. Wired on BOTH lookups so the refusal is
+    // attributable to ownership and not to the ownership resolve finding nothing.
+    const strangers = offsiteRow({ userId: OTHER });
+    wireSlugLookup([strangers]);
+    wireFindUnique({ entry: null, owned: strangers });
+
+    await expect(getMyListingForApp({ slug: 'radio', userId: OWNER })).rejects.toMatchObject({
+      name: 'OffsiteRequestError',
+      code: 'NOT_OWNED',
+    });
+    // Refused before anything else is read.
+    expect(mockRead.appListingPublishRequest.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('🔴 a SHADOW revision’s synthetic `rev-` slug does NOT resolve → NOT_FOUND', async () => {
+    // `revisionOfId: null` is the one clause that had to STAY, and it is not
+    // decoration: a shadow is `kind` = its parent's, `appBlockId` NULL, status
+    // `draft` — it MATCHED the old, apparently-narrower clause. The old comment's
+    // "only ever sees a parent" held only because nobody knows a `rev-<ulid>` slug.
+    // Now it holds by construction.
+    const shadow = {
+      id: 'apl_shadow',
+      userId: OWNER,
+      kind: 'onsite',
+      slug: 'rev-01JABCDEF',
+      appBlockId: null,
+      revisionOfId: 'apl_parent',
+      status: 'draft',
+      contentRating: 'g',
+    };
+    wireSlugLookup([shadow]);
+    // 🔴 The edit view IS wired, and that is what makes this test discriminating. With
+    // it absent, a resolver that DID admit the shadow would still throw NOT_FOUND —
+    // from `loadListingEditView` missing its row, several steps later — and this case
+    // would pass under the very clause it exists to reject. Measured: it did exactly
+    // that on the first draft of this test. Wired, an admitted shadow RESOLVES and
+    // returns an `editBlockedReason` result, so the assertions below are the only
+    // thing standing between the two behaviours.
+    wireFindUnique({
+      entry: null,
+      owned: shadow,
+      viewByListingId: { apl_shadow: editViewRow('apls_shadow') },
+    });
+
+    const err = await getMyListingForApp({ slug: 'rev-01JABCDEF', userId: OWNER }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(OffsiteRequestError);
+    expect(err.code).toBe('NOT_FOUND');
+    // Refused by the RESOLVER, not by the owner gate and not by a later read: the
+    // caller owns this shadow, and the message names the unresolved slug.
+    expect(err.message).toBe('no listing found for app rev-01JABCDEF');
   });
 });

--- a/src/server/services/blocks/__tests__/offsite-listing.get-my-listing-for-app.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.get-my-listing-for-app.service.test.ts
@@ -540,9 +540,10 @@ function wireSlugLookup(rows: Array<Record<string, unknown>>) {
 
 // The SLUG resolver. Two callers share it: the W13 pre-approval draft of a FIRST-version
 // on-site app (no AppBlock yet, so `appBlockId` cannot address it *yet*), and an OFF-SITE
-// listing, which has no AppBlock *ever* — civitai/civitai#3984. These lock what the slug
-// arm admits (any top-level listing, either kind, any status) and what it refuses (a
-// shadow revision), and that ownership is still enforced on the widened path.
+// listing, which in practice carries no AppBlock at all — civitai/civitai#3984. These
+// lock what the slug arm admits (any top-level listing, either kind, any status) and what
+// it refuses (a shadow revision), that `appBlockId` takes PRECEDENCE over the slug, and
+// that ownership is still enforced on the widened path.
 describe('getMyListingForApp — slug resolver (any top-level listing, either kind)', () => {
   it('resolves the pending draft BY SLUG when only a slug is given (no appBlockId lookup)', async () => {
     // 🔴 The pre-approval draft carries `appBlockId: null`, so it has no OauthClient in
@@ -623,6 +624,79 @@ describe('getMyListingForApp — slug resolver (any top-level listing, either ki
     expect(editViewReads(mockRead)).toEqual(['apl_draft']);
   });
 
+  /**
+   * 🔴 SELECTOR PRECEDENCE — the OTHER half of `if (!listing && slug)`, and the half
+   * nothing pinned. The test above proves the slug arm RUNS on a miss; this one proves it
+   * does NOT run on a hit. Both selectors are optional and independent, so a caller can
+   * hand over an `appBlockId` and a slug that name DIFFERENT listings, and which one wins
+   * is a contract, not an implementation detail.
+   *
+   * Measured before this test existed: mutating `if (!listing && slug)` → `if (slug)`
+   * SURVIVED the whole 44-test battery. The slug row simply overwrote the block row and
+   * every assertion still held, because no case supplied two selectors that disagreed.
+   *
+   * The two rows are pairwise distinct on THREE observable fields — id, contentRating,
+   * and which listing's edit view is read — so no single hardcoded value can satisfy the
+   * assertions, and both rows are owned by the SAME user so ownership cannot be what
+   * decides the outcome.
+   */
+  it('🔴 PRECEDENCE: `appBlockId` WINS over a slug naming a DIFFERENT listing', async () => {
+    const blockRow = {
+      id: 'apl_block',
+      userId: OWNER,
+      kind: 'onsite',
+      slug: 'block-app',
+      appBlockId: 'my-block',
+      revisionOfId: null,
+      status: 'approved',
+      contentRating: 'pg13',
+      appBlock: { app: { userId: OWNER } },
+    };
+    const slugRow = {
+      id: 'apl_other',
+      userId: OWNER,
+      kind: 'offsite',
+      slug: 'other-app',
+      appBlockId: null,
+      revisionOfId: null,
+      status: 'approved',
+      contentRating: 'g',
+    };
+    const byId: Record<string, unknown> = { apl_block: blockRow, apl_other: slugRow };
+    const views: Record<string, unknown> = {
+      apl_block: editViewRow('apls_block'),
+      apl_other: editViewRow('apls_other'),
+    };
+    const impl = async (args: unknown) => {
+      const a = args as {
+        select?: Record<string, unknown>;
+        where?: { id?: string; appBlockId?: string };
+      };
+      if (a.where?.appBlockId != null) return blockRow;
+      if ('icon' in (a.select ?? {})) return views[a.where?.id ?? ''] ?? null;
+      // Both listings resolve their OWNER, so a mutant that lands on the slug row is
+      // refused by the identity assertions below rather than by NOT_OWNED.
+      return byId[a.where?.id ?? ''] ?? null;
+    };
+    mockRead.appListing.findUnique.mockImplementation(impl);
+    mockWrite.appListing.findUnique.mockImplementation(impl);
+    wireSlugLookup([slugRow]);
+    withShadow(null);
+
+    const res = await getMyListingForApp({
+      appBlockId: 'my-block',
+      slug: 'other-app',
+      userId: OWNER,
+    });
+
+    expect(res.appListingId).toBe('apl_block');
+    expect(res.contentRating).toBe('pg13');
+    // 🔴 SHORT-CIRCUIT, not last-write-wins: the slug query is never even issued.
+    expect(mockRead.appListing.findFirst).not.toHaveBeenCalled();
+    // …and the assets projected are the BLOCK listing's, not the slug listing's.
+    expect(editViewReads(mockRead)).toEqual(['apl_block']);
+  });
+
   it('a draft owned by ANOTHER user → NOT_OWNED (ownership still enforced on the slug path)', async () => {
     // The row is wired on BOTH lookups so the refusal is attributable to OWNERSHIP. With
     // only the slug lookup wired, the ownership resolve finds nothing and denies for
@@ -657,15 +731,24 @@ describe('getMyListingForApp — slug resolver (any top-level listing, either ki
 
   // -------------------------------------------------------------------------
   // 🔴 civitai/civitai#3984 — the arm used to read
-  // `{ slug, kind: 'onsite', appBlockId: null, status: 'draft' }`, which resolves
-  // NOTHING an OFF-SITE app can ever be: `kind: 'offsite'` is what it IS, and it has
-  // no AppBlock, so neither selector could address it and every listing-media surface
-  // hosted on this proc was unreachable for non-web clients. Measured against
-  // civitai.com at civitai/cli@1b20b99 (civitai/cli#422, #424): 4/4 off-site apps
-  // failed, 7/7 on-site passed, and `kind` predicted it exactly.
+  // `{ slug, kind: 'onsite', appBlockId: null, status: 'draft' }`, whose FIRST clause
+  // alone excludes every off-site listing: `kind: 'offsite'` is what it IS. And in
+  // practice an off-site listing carries no AppBlock either, so the other selector could
+  // not address it — every listing-media surface hosted on this proc was unreachable for
+  // non-web clients. Measured against civitai.com at civitai/cli@1b20b99
+  // (civitai/cli#422, #424): 4/4 off-site apps failed, 7/7 on-site passed, and `kind`
+  // predicted it exactly.
+  //
+  // 🟡 "off-site ⇒ no AppBlock" is EMPIRICAL, not structural, and this file does not
+  // depend on it: `appBlockId` is "set for EVERY backfilled row — on-site AND the #2821
+  // off-site rows … discriminate on `kind`, never on appBlockId nullness"
+  // (schema.full.prisma), and `mapAppBlockToListing` can mint `kind:'offsite'` with a
+  // non-null `appBlockId` — a shape measured at 0 rows in production on 2026-08-11
+  // (`appListingEditorTabs.ts`). The `kind` clause is what the widening had to drop;
+  // dropping the `appBlockId` clause covers the backfilled class too.
   // -------------------------------------------------------------------------
 
-  /** An OFF-SITE listing: no AppBlock, ever. The slug is its only handle. */
+  /** An OFF-SITE listing with no AppBlock — the common shape; the slug is its handle. */
   const offsiteRow = (overrides: Record<string, unknown> = {}) => ({
     id: 'apl_offsite',
     userId: OWNER,
@@ -747,6 +830,45 @@ describe('getMyListingForApp — slug resolver (any top-level listing, either ki
     ).toBe(false);
   });
 
+  /**
+   * 🔴 "ANY STATUS" IS A BEHAVIOURAL CLAIM, so it gets behavioural cases. Before these,
+   * the widening was only SPELLED — the sole thing that noticed a status narrowing was
+   * the structural `toHaveBeenCalledWith` pin on the draft case, and no case actually
+   * admitted a TERMINAL listing by slug. Measured: adding `status: { not: 'removed' }`
+   * back to the `where` killed exactly that one structural assertion and nothing else,
+   * so the `describe` title's "any status" was an unbacked claim.
+   *
+   * The two terminal statuses are the ones with something to say: they resolve, and come
+   * back as a VERDICT (`editBlockedReason`) rather than a throw — the same
+   * "don't collapse to NotFound" contract the `appBlockId` arm already has, now reachable
+   * by slug. One row per status, so a narrowing on EITHER one is caught.
+   */
+  it.each([
+    ['removed', 'this listing has been removed by a moderator and can no longer be edited'],
+    ['rejected', 'this listing was rejected; submit a new listing instead of editing it'],
+  ])(
+    '🔴 a %s listing RESOLVES BY SLUG and returns its editBlockedReason (any status)',
+    async (status, expected) => {
+      const dead = offsiteRow({ id: 'apl_dead', slug: 'dead-app', status });
+      wireSlugLookup([dead]);
+      wireFindUnique({
+        entry: null,
+        owned: dead,
+        viewByListingId: { apl_dead: editViewRow('apls_dead') },
+      });
+
+      const res = await getMyListingForApp({ slug: 'dead-app', userId: OWNER });
+
+      // It RESOLVED — a status narrowing on the `where` would throw NOT_FOUND here.
+      expect(res.appListingId).toBe('apl_dead');
+      expect(res.status).toBe(status);
+      // …and it came back as a verdict the surface can render, not an error.
+      expect(res.editBlockedReason).toBe(expected);
+      // Still a READ: a terminal listing must not mint a shadow on the way out.
+      expect(mockWrite.appListing.create).not.toHaveBeenCalled();
+    }
+  );
+
   it('🔴 a slug owned by ANOTHER user → NOT_OWNED, not NOT_FOUND (the gate, not the where)', async () => {
     // The BEHAVIOUR DELTA of #3984, pinned deliberately. Before, a stranger's slug was
     // filtered out by the `where` and reported NOT_FOUND; now the row resolves and the
@@ -767,10 +889,12 @@ describe('getMyListingForApp — slug resolver (any top-level listing, either ki
 
   it('🔴 a SHADOW revision’s synthetic `rev-` slug does NOT resolve → NOT_FOUND', async () => {
     // `revisionOfId: null` is the one clause that had to STAY, and it is not
-    // decoration: a shadow is `kind` = its parent's, `appBlockId` NULL, status
-    // `draft` — it MATCHED the old, apparently-narrower clause. The old comment's
-    // "only ever sees a parent" held only because nobody knows a `rev-<ulid>` slug.
-    // Now it holds by construction.
+    // decoration: a shadow is `kind: parent.kind`, `appBlockId` NULL, status `draft`
+    // (`beginListingRevision`). For an ON-SITE parent — the fixture below — that is
+    // exactly the old, apparently-narrower clause, so those shadows MATCHED it; a
+    // shadow of an OFF-SITE parent is `kind:'offsite'` and did not. Either way the old
+    // comment's "only ever sees a parent" held only because nobody knows a `rev-<ulid>`
+    // slug. Now it holds by construction, and this clause is the ONLY thing holding it.
     const shadow = {
       id: 'apl_shadow',
       userId: OWNER,

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -1643,18 +1643,28 @@ export type GetMyListingForAppResult = {
 };
 
 /**
- * OWNER: resolve the caller's OWN listing for the owner-facing on-site
- * listing-media page. Resolves by backing `appBlockId` (`AppListing.appBlockId` is
- * `@unique`) when the app is approved; falls back to the pre-approval DRAFT BY SLUG
- * (`kind='onsite', appBlockId IS NULL, status='draft'`) for a FIRST-version app that
- * is still pending (no AppBlock exists yet) — the W13 draft-at-submit wiring gap that
- * lets the author set media WHILE pending. At least one of `appBlockId` / `slug` must
- * be given. Returns the `AppListing.id` (the target the page then passes to
+ * OWNER: resolve the caller's OWN listing for a listing-media surface. TWO selectors,
+ * and `appBlockId` WINS: the backing `appBlockId` (`AppListing.appBlockId` is `@unique`)
+ * is tried first, and the slug arm runs only when that lookup MISSED or no `appBlockId`
+ * was supplied — so passing both a block id and a slug that name DIFFERENT listings
+ * returns the `appBlockId` one. At least one of the two must be given (enforced by the
+ * schema's `.refine`).
+ *
+ * The slug arm resolves ANY TOP-LEVEL listing — either `kind`, any `status`, with or
+ * without a backing `appBlockId` — narrowed only by `revisionOfId: null`
+ * (civitai/civitai#3984). It is deliberately NOT scoped to the W13 pre-approval draft it
+ * was first written for; that shape is one member of the set, alongside an OFF-SITE
+ * listing (which `appBlockId` cannot address, see the inline comment) and an approved
+ * on-site listing whose caller only holds the slug. A `removed` / `rejected` listing
+ * resolves too and comes back carrying an `editBlockedReason` instead of throwing, so
+ * the surface renders the reason rather than a blank page.
+ *
+ * Returns the `AppListing.id` (the target the caller then passes to
  * `beginListingRevision` + the owner-gated asset procs), the listing's lifecycle
  * status + content rating, and whether a revision is already under review.
  * Owner-bound: a listing owned by another user → NOT_OWNED (→FORBIDDEN); no listing
  * row for the app → NOT_FOUND. Kind-agnostic (works for both on-site and off-site
- * listings — the on-site owner UI is the first caller).
+ * listings — the on-site owner UI was the first caller).
  *
  * ALSO projects the EDITABLE target's current `assets` (+ its `shadowId`). Without
  * them the media editor had no way to see the icon/cover it is about to edit: it
@@ -1695,20 +1705,38 @@ export async function getMyListingForApp(opts: {
         select: entrySelect,
       })
     : null;
-  // SLUG fallback: resolve the listing by its globally-unique public slug when the
-  // `appBlockId` lookup missed (or only a slug was supplied). Two callers need it:
+  // SLUG fallback — 🔴 SECOND, and only on a MISS. `appBlockId` is the primary selector
+  // and wins whenever it resolves; this arm runs when that lookup missed or when no
+  // `appBlockId` was supplied. (Pinned: "appBlockId WINS over a slug naming a DIFFERENT
+  // listing" in `offsite-listing.get-my-listing-for-app.service.test.ts`.) Two callers
+  // need it:
   //   - (W13 draft-at-submit) a FIRST-version on-site app has no backing AppBlock yet,
   //     so its draft listing (minted at submit) has `appBlockId = NULL` and is only
   //     reachable BY SLUG while it is pending; and
-  //   - any client whose ONLY handle is the slug — an OFF-SITE listing has no AppBlock
-  //     at all, ever, so `appBlockId` can never address it (civitai/civitai#3984).
+  //   - any client whose ONLY handle is the slug — in particular an OFF-SITE listing,
+  //     which in practice carries no AppBlock, so `appBlockId` cannot address it
+  //     (civitai/civitai#3984).
+  //
+  // 🟡 "off-site ⇒ no AppBlock" is EMPIRICAL, NOT STRUCTURAL — do not restate it as
+  // "never, ever". `AppListing.appBlockId` is "set for EVERY backfilled row — on-site
+  // AND the #2821 off-site rows (both come from an AppBlock). It is NOT a kind
+  // discriminator: discriminate on `kind`, never on appBlockId nullness"
+  // (schema.full.prisma). Only a NATIVELY-created off-site listing leaves it NULL, and
+  // `mapAppBlockToListing` can still mint `kind:'offsite'` + a non-null `appBlockId`.
+  // That shape measured 0 rows in production on 2026-08-11 (see
+  // `resolveAccessibleAppBlockIds` / `appListingEditorTabs.ts`), so today the slug is
+  // the only handle every off-site listing has — but a backfilled class exists and the
+  // widening below is correct either way: it admits the row on EITHER selector.
   //
   // 🔴 `revisionOfId: null` IS LOAD-BEARING, not decoration. `beginListingRevision`
   // mints a shadow with a synthetic `rev-<ulid>` slug that is never public but IS a
-  // real row — kind copied from the parent, `appBlockId` NULL, status `draft` — i.e.
-  // it matched the previous, apparently-narrower clause. Excluding revisions here is
-  // what makes the comment below ("only ever sees a top-level parent") true by
-  // construction rather than by the accident that nobody knows a shadow's slug.
+  // real row — `kind: parent.kind`, `appBlockId` NULL, status `draft`. For an ON-SITE
+  // parent that is exactly the previous, apparently-narrower clause, so those shadows
+  // matched it; a shadow of an OFF-SITE parent is `kind:'offsite'` and did not. Either
+  // way, excluding revisions here is what makes the comment below ("only ever sees a
+  // top-level parent") true by construction rather than by the accident that nobody
+  // knows a shadow's slug — and it is now the ONLY clause standing between the widened
+  // arm and every shadow in the table.
   //
   // `AppListing.slug` is `@unique` across BOTH kinds (schema.full.prisma), so this is
   // unambiguous without an index change. Owner-bound below (unchanged): a slug that

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -1695,16 +1695,27 @@ export async function getMyListingForApp(opts: {
         select: entrySelect,
       })
     : null;
-  // (W13 draft-at-submit) Pre-approval DRAFT fallback: a FIRST-version app has no
-  // backing AppBlock yet, so its draft listing (minted at submit) has
-  // `appBlockId = NULL` and is only reachable BY SLUG. Resolve it when the appBlockId
-  // lookup missed (or only a slug was supplied) so the owner-media page can reach the
-  // draft to set icon/cover/screenshots WHILE the app is pending. Scoped to the exact
-  // pre-approval-draft shape so this can never resolve some other kind/status by slug.
-  // Owner-bound below (unchanged).
+  // SLUG fallback: resolve the listing by its globally-unique public slug when the
+  // `appBlockId` lookup missed (or only a slug was supplied). Two callers need it:
+  //   - (W13 draft-at-submit) a FIRST-version on-site app has no backing AppBlock yet,
+  //     so its draft listing (minted at submit) has `appBlockId = NULL` and is only
+  //     reachable BY SLUG while it is pending; and
+  //   - any client whose ONLY handle is the slug — an OFF-SITE listing has no AppBlock
+  //     at all, ever, so `appBlockId` can never address it (civitai/civitai#3984).
+  //
+  // 🔴 `revisionOfId: null` IS LOAD-BEARING, not decoration. `beginListingRevision`
+  // mints a shadow with a synthetic `rev-<ulid>` slug that is never public but IS a
+  // real row — kind copied from the parent, `appBlockId` NULL, status `draft` — i.e.
+  // it matched the previous, apparently-narrower clause. Excluding revisions here is
+  // what makes the comment below ("only ever sees a top-level parent") true by
+  // construction rather than by the accident that nobody knows a shadow's slug.
+  //
+  // `AppListing.slug` is `@unique` across BOTH kinds (schema.full.prisma), so this is
+  // unambiguous without an index change. Owner-bound below (unchanged): a slug that
+  // is not yours is refused by `resolveListingRole`, not by this `where`.
   if (!listing && slug) {
     listing = await dbRead.appListing.findFirst({
-      where: { slug, kind: 'onsite', appBlockId: null, status: 'draft' },
+      where: { slug, revisionOfId: null },
       select: entrySelect,
     });
   }

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -186,7 +186,12 @@ function summariseValue(value: unknown): unknown {
  */
 function readZipEntryCapped(
   entry: JSZip.JSZipObject,
-  opts: { maxFileSizeBytes: number; remainingTotalBytes: number; maxTotalBytes: number; path: string }
+  opts: {
+    maxFileSizeBytes: number;
+    remainingTotalBytes: number;
+    maxTotalBytes: number;
+    path: string;
+  }
 ): Promise<Buffer> {
   const { maxFileSizeBytes, remainingTotalBytes, maxTotalBytes, path } = opts;
   return new Promise<Buffer>((resolve, reject) => {
@@ -218,11 +223,7 @@ function readZipEntryCapped(
       if (size > remainingTotalBytes) {
         aborted = true;
         stream.pause();
-        reject(
-          new Error(
-            `bundle decompresses to more than ${maxTotalBytes} bytes (zip bomb?)`
-          )
-        );
+        reject(new Error(`bundle decompresses to more than ${maxTotalBytes} bytes (zip bomb?)`));
         return;
       }
       chunks.push(chunk);
@@ -365,7 +366,10 @@ const SCREENSHOT_NAME_REGEX = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
  * JPEG uploaded as `.png` is rejected too, so the content-type we serve is
  * always correct + consistent with the stored key).
  */
-export function detectImageType(buf: Buffer, claimedExt: ScreenshotExtension): ScreenshotExtension | null {
+export function detectImageType(
+  buf: Buffer,
+  claimedExt: ScreenshotExtension
+): ScreenshotExtension | null {
   const isPng =
     buf.length >= 8 &&
     buf[0] === 0x89 &&
@@ -457,7 +461,11 @@ export async function extractScreenshots(
     // NAME: must be a flat safe filename — no nested path, no traversal, no
     // leading dot. (jszip already normalises `..`, but reject any residual
     // slash / odd name explicitly rather than rely on that.)
-    if (filename.includes('/') || filename.includes('\\') || !SCREENSHOT_NAME_REGEX.test(filename)) {
+    if (
+      filename.includes('/') ||
+      filename.includes('\\') ||
+      !SCREENSHOT_NAME_REGEX.test(filename)
+    ) {
       throw new Error(
         `invalid screenshot filename "${rawPath}" — only flat names like ${SCREENSHOT_DIR}shot-1.png are allowed (no sub-directories, no "..", no leading dot)`
       );
@@ -1451,10 +1459,20 @@ async function closeOnsiteResetListingOnWithdraw(opts: {
  * `onDelete: SetNull` (DETACHED, not hard-deleted — same as off-site). Resolved BY SLUG
  * (no request→listing FK). No-op for a subsequent-version request (no such draft), an
  * already-cleaned draft, or a legacy pre-ship pending request.
+ *
+ * 🔴 DO NOT "CONSOLIDATE" THIS CLAUSE WITH `getMyListingForApp`'s. They look identical —
+ * this one still spells the exact pre-approval-draft shape that one used to — and
+ * civitai/civitai#3984 WIDENED that one to `{ slug, revisionOfId: null }` (any top-level
+ * listing, either kind, any status) because it is a READ whose access is enforced by the
+ * owner gate downstream. THIS is a `deleteMany` with no gate after it and no owner
+ * predicate: the same widening here would hard-delete whatever top-level row holds that
+ * slug — an off-site listing, an APPROVED listing, another user's listing — and there is
+ * nothing downstream to refuse it. The narrowness IS the authorization.
  */
 async function deleteOnsiteDraftListingForSlug(opts: { slug: string }): Promise<void> {
   const { dbWrite } = await import('~/server/db/client');
   await dbWrite.appListing.deleteMany({
+    // 🔴 NARROW ON PURPOSE — see the 🔴 note above (civitai/civitai#3984). Destructive.
     where: { slug: opts.slug, kind: 'onsite', appBlockId: null, status: 'draft' },
   });
 }
@@ -1755,8 +1773,10 @@ export async function enrichPushRequestRow(
   ref: string
 ): Promise<void> {
   try {
-    const { fileSummary, manifestDiffSummary, bundleSizeBytes } =
-      await computePushDiffSummaries(slug, ref);
+    const { fileSummary, manifestDiffSummary, bundleSizeBytes } = await computePushDiffSummaries(
+      slug,
+      ref
+    );
     const { dbWrite } = await import('~/server/db/client');
     await dbWrite.appBlockPublishRequest.updateMany({
       where: { id: publishRequestId, status: 'pending' },
@@ -1965,9 +1985,7 @@ export async function listPendingRequests(opts: ListPendingRequestsOptions = {})
       // it's the discriminator here (the fetch paths key off the equivalent
       // bundleKey since they need the S3 path).
       pushCommitUrl:
-        !r.bundleSha256 && r.forgejoCommitSha
-          ? repoCommitUrl(r.slug, r.forgejoCommitSha)
-          : null,
+        !r.bundleSha256 && r.forgejoCommitSha ? repoCommitUrl(r.slug, r.forgejoCommitSha) : null,
     })),
     nextCursor: hasNext ? items[items.length - 1].id : null,
   };
@@ -2025,9 +2043,7 @@ export async function listApprovedRequests(opts: ListPendingRequestsOptions = {}
       // Push rows have empty bundle pointers; bundleSha256 (selected, NOT NULL)
       // is the list-display discriminator (see listPendingRequests).
       pushCommitUrl:
-        !r.bundleSha256 && r.forgejoCommitSha
-          ? repoCommitUrl(r.slug, r.forgejoCommitSha)
-          : null,
+        !r.bundleSha256 && r.forgejoCommitSha ? repoCommitUrl(r.slug, r.forgejoCommitSha) : null,
     })),
     nextCursor: hasNext ? items[items.length - 1].id : null,
   };
@@ -2078,9 +2094,7 @@ export async function listRejectedRequests(opts: ListPendingRequestsOptions = {}
       // Push rows have empty bundle pointers; bundleSha256 (selected, NOT NULL)
       // is the list-display discriminator (see listPendingRequests).
       pushCommitUrl:
-        !r.bundleSha256 && r.forgejoCommitSha
-          ? repoCommitUrl(r.slug, r.forgejoCommitSha)
-          : null,
+        !r.bundleSha256 && r.forgejoCommitSha ? repoCommitUrl(r.slug, r.forgejoCommitSha) : null,
     })),
     nextCursor: hasNext ? items[items.length - 1].id : null,
   };
@@ -3151,7 +3165,10 @@ export async function markRequestDeployState(
       // advance). Log so a regression is greppable; not fatal.
       // eslint-disable-next-line no-console
       console.warn(
-        `[markRequestDeployState] no approved request matched (slug=${slug}, sha=${sha.slice(0, 12)}, state=${state})`
+        `[markRequestDeployState] no approved request matched (slug=${slug}, sha=${sha.slice(
+          0,
+          12
+        )}, state=${state})`
       );
     }
   } catch (err) {
@@ -3319,9 +3336,7 @@ function assertRetriggerableDeployState(
  * supersede guard below refuses even the stored sha once a NEWER version has been
  * approved for the app.
  */
-export async function retriggerBuild(
-  params: RetriggerBuildParams
-): Promise<RetriggerBuildResult> {
+export async function retriggerBuild(params: RetriggerBuildParams): Promise<RetriggerBuildResult> {
   const [{ dbWrite }, { env }] = await Promise.all([
     import('~/server/db/client'),
     import('~/env/server'),
@@ -3740,9 +3755,7 @@ export async function markReviewPreviewState(
         ...(opts?.requireActivePreview ? { deployState: { startsWith: 'preview-' } } : {}),
         // Stale-watcher guard: only advance if the row's current detail still
         // belongs to this build's sha (the serialized `"sha":"<sha>"` fragment).
-        ...(opts?.expectedSha
-          ? { deployDetail: { contains: `"sha":"${opts.expectedSha}"` } }
-          : {}),
+        ...(opts?.expectedSha ? { deployDetail: { contains: `"sha":"${opts.expectedSha}"` } } : {}),
       },
       data: {
         deployState: state,
@@ -3793,10 +3806,7 @@ export type PreviewRequestResult = {
  * property makes that non-accidental.
  */
 function gitBlobSha(content: Buffer): string {
-  return createHash('sha1')
-    .update(`blob ${content.byteLength}\0`)
-    .update(content)
-    .digest('hex');
+  return createHash('sha1').update(`blob ${content.byteLength}\0`).update(content).digest('hex');
 }
 
 /**
@@ -3924,9 +3934,7 @@ async function resolveReviewSourceSha(request: {
  * review-sandbox flag (gated in the router), so this never runs in prod until
  * enabled.
  */
-export async function previewRequest(
-  params: PreviewRequestParams
-): Promise<PreviewRequestResult> {
+export async function previewRequest(params: PreviewRequestParams): Promise<PreviewRequestResult> {
   const [{ dbRead }, { env }] = await Promise.all([
     import('~/server/db/client'),
     import('~/env/server'),
@@ -3959,7 +3967,9 @@ export async function previewRequest(
     const more =
       activeOthers.length > slugs.length ? `, +${activeOthers.length - slugs.length} more` : '';
     throw new Error(
-      `Review preview cap reached (${activeOthers.length}/${MAX_CONCURRENT_REVIEW_PREVIEWS} active): ${slugs.join(
+      `Review preview cap reached (${
+        activeOthers.length
+      }/${MAX_CONCURRENT_REVIEW_PREVIEWS} active): ${slugs.join(
         ', '
       )}${more}. Tear down a preview to free a slot.`
     );
@@ -4057,7 +4067,13 @@ export async function getReviewStatus(opts: {
   const { dbRead } = await import('~/server/db/client');
   const row = await dbRead.appBlockPublishRequest.findUnique({
     where: { id: opts.publishRequestId },
-    select: { id: true, status: true, deployState: true, deployDetail: true, deployUpdatedAt: true },
+    select: {
+      id: true,
+      status: true,
+      deployState: true,
+      deployDetail: true,
+      deployUpdatedAt: true,
+    },
   });
   if (!row) throw new Error(`publish request ${opts.publishRequestId} not found`);
   const isPreviewState =
@@ -4213,9 +4229,7 @@ export async function getReviewRequestById(publishRequestId: string): Promise<{
     bundleSizeBytes: r.bundleSizeBytes.toString(),
     reviewRepoUrl: reviewRepoUrl(r.slug),
     pushCommitUrl:
-      !r.bundleSha256 && r.forgejoCommitSha
-        ? repoCommitUrl(r.slug, r.forgejoCommitSha)
-        : null,
+      !r.bundleSha256 && r.forgejoCommitSha ? repoCommitUrl(r.slug, r.forgejoCommitSha) : null,
   };
   return { mode, request };
 }
@@ -4346,9 +4360,7 @@ export async function mintReviewBlockToken(opts: {
     parseManifestBuzzBudget,
     FORCED_SFW_CEILING,
   } = await import('./dev-scoped-mint.service');
-  const { REVIEW_RUN_FOR_REAL_BUZZ_CAP } = await import(
-    '~/shared/constants/block-scope.constants'
-  );
+  const { REVIEW_RUN_FOR_REAL_BUZZ_CAP } = await import('~/shared/constants/block-scope.constants');
 
   // The AUDITED clamp belt (SAME function both modes — never fork the clamp).
   //   - render-only (default): render-only allowlist + no spend → the spend scope
@@ -4379,9 +4391,7 @@ export async function mintReviewBlockToken(opts: {
     oauthAllowed: null,
     spendEntitled: runForReal,
     spendRequested: runForReal,
-    allowlist: runForReal
-      ? REVIEW_RUN_FOR_REAL_MINT_SCOPE_ALLOWLIST
-      : REVIEW_MINT_SCOPE_ALLOWLIST,
+    allowlist: runForReal ? REVIEW_RUN_FOR_REAL_MINT_SCOPE_ALLOWLIST : REVIEW_MINT_SCOPE_ALLOWLIST,
   });
 
   // Per-call Buzz budget — ONLY for run-for-real AND only if the spend scope
@@ -4918,14 +4928,10 @@ export async function rejectRequest(params: RejectRequestParams): Promise<void> 
   const { dbRead, dbWrite } = await import('~/server/db/client');
   const reason = params.rejectionReason.trim();
   if (reason.length < PUBLISH_REJECTION_REASON_MIN) {
-    throw new Error(
-      `rejection reason must be at least ${PUBLISH_REJECTION_REASON_MIN} characters`
-    );
+    throw new Error(`rejection reason must be at least ${PUBLISH_REJECTION_REASON_MIN} characters`);
   }
   if (reason.length > PUBLISH_REJECTION_REASON_MAX) {
-    throw new Error(
-      `rejection reason must be at most ${PUBLISH_REJECTION_REASON_MAX} characters`
-    );
+    throw new Error(`rejection reason must be at most ${PUBLISH_REJECTION_REASON_MAX} characters`);
   }
 
   const row = await dbRead.appBlockPublishRequest.findUnique({

--- a/src/shared/constants/app-capabilities.constants.ts
+++ b/src/shared/constants/app-capabilities.constants.ts
@@ -34,16 +34,21 @@ export type ListingCapability =
    * the table used to paper over. An off-site listing CAN hold and edit assets — the
    * submit/edit wizard does exactly that, and the asset procs themselves
    * (`setIcon`/`setCover`/`addScreenshot`/…) are already listing-keyed and seat-aware.
-   * What it cannot do is open the STANDALONE editor, because that surface is hosted by
-   * `appListings.getMyListingForApp`, whose input is an `appBlockId` — and an off-site
-   * listing has no AppBlock to name.
+   * What it cannot do is open the STANDALONE editor — but 🔴 THE HOST RESOLVER IS NO
+   * LONGER WHY. `appListings.getMyListingForApp` was re-keyed by civitai/civitai#3984
+   * and now takes `appBlockId` OR `slug`, resolving any top-level listing of either
+   * kind, so it addresses an off-site listing fine. What still withholds the surface is
+   * the WEB tab gate `editorTabsFor` (`src/components/Apps/appListingEditorTabs.ts`),
+   * whose `media` arm requires `ctx.appBlockId != null` on top of this cell — and an
+   * off-site listing has no block id to give it.
    *
    * So this cell is a statement about the SURFACE, not about the data model, and unlike
-   * `earnings` / `submitVersion` it is NOT structural — it is plumbing that has not been
-   * re-keyed yet. Tracked by https://github.com/civitai/civitai/issues/3893, whose fix is
-   * precisely "flip this cell to true". Until then, a table that claimed off-site media
-   * worked would be a permission table asserting more than holds, which is the exact
-   * defect class this feature keeps finding.
+   * `earnings` / `submitVersion` it is NOT structural — it is plumbing, half of which
+   * (the resolver) has now been re-keyed while the tab gate has not. Tracked by
+   * https://github.com/civitai/civitai/issues/3893, whose fix is precisely "flip this
+   * cell to true" (and drop the block-id clause from that `media` arm). Until then, a
+   * table that claimed off-site media worked would be a permission table asserting more
+   * than the UI offers, which is the exact defect class this feature keeps finding.
    */
   | 'listingMedia'
   /** Submit the listing for moderator review (`AppListingPublishRequest` + changelog). */
@@ -65,11 +70,13 @@ export type ListingCapability =
  *     indistinguishable from "earned nothing"; the read refuses instead.
  *   - `submitVersion` — STRUCTURAL. An off-site listing has no bundle and no Forgejo
  *     repo. There is nothing to push to and no credential to mint.
- *   - `listingMedia` — 🔴 NOT structural: PLUMBING. The data supports it; the surface's
- *     host resolver (`getMyListingForApp`) is block-keyed and has not been re-keyed yet.
- *     See its doc above and https://github.com/civitai/civitai/issues/3893. Flipping this
- *     cell is a real change with a real fix behind it, unlike the two above, which cannot
- *     be flipped without changing the schema.
+ *   - `listingMedia` — 🔴 NOT structural: PLUMBING. The data supports it, and since
+ *     civitai/civitai#3984 so does the host resolver (`getMyListingForApp` takes
+ *     `appBlockId` OR `slug`). What is left is the WEB tab gate: `editorTabsFor`'s
+ *     `media` arm also demands `ctx.appBlockId != null`, which an off-site listing
+ *     cannot supply. See its doc above and https://github.com/civitai/civitai/issues/3893.
+ *     Flipping this cell is a real change with a real fix behind it, unlike the two
+ *     above, which cannot be flipped without changing the schema.
  *
  * Everything else is identical across kinds, because an off-site listing carries the
  * same scalars, the same review flow (`AppListingPublishRequest`) and the same metric
@@ -88,8 +95,10 @@ export const CAPABILITIES_BY_KIND: Readonly<
   }),
   offsite: Object.freeze({
     listingContent: true,
-    // The standalone media editor is hosted by the BLOCK-keyed `getMyListingForApp`.
-    // Plumbing, not schema — civitai/civitai#3893 is the work that flips this.
+    // Held false by the WEB tab gate (`editorTabsFor`'s `media` arm also needs a
+    // non-null `appBlockId`), NOT by the host resolver — `getMyListingForApp` takes a
+    // slug since civitai/civitai#3984. Plumbing, not schema — civitai/civitai#3893 is
+    // the work that flips this.
     listingMedia: false,
     submitForReview: true,
     analytics: true,


### PR DESCRIPTION
> **Corrections applied 2026-08-16 after an adversarial audit** — four assertions in an
> earlier revision of this body were wrong or overstated and have been rewritten in place.
> See the [correction comment](https://github.com/civitai/civitai/pull/3989#issuecomment-5311163675) for the diff of what changed and
> why. No behaviour change: the `where` clause, the capability cell and `editorTabsFor`
> are untouched by the correction commit.

## What

Widen the slug arm of `appListings.getMyListingForApp` so a listing is resolvable by the
handle that identifies it publicly.

```diff
-      where: { slug, kind: 'onsite', appBlockId: null, status: 'draft' },
+      where: { slug, revisionOfId: null },
```

`getMyListingForApp` is the one hop that turns "the app I am authoring" into an
`AppListing.id`, and every listing-media surface is hosted on it. Its input schema has
always declared a `slug` selector, but the arm behind it was scoped to the W13
pre-approval draft shape — **on-site, no AppBlock yet, status `draft`** — whose very first
clause excludes every off-site listing (`kind: 'offsite'` is what it *is*), and which in
practice has no `AppBlock` for the other selector either. So the selector read as
supported and behaved as absent, and an approved on-site app was likewise
`appBlockId`-only.

**Selector precedence:** `appBlockId` is tried first and **wins**; the slug arm runs only
on a miss. That was already the behaviour and is now pinned by a test (it was not).

No schema change and no migration.

Resolves civitai/civitai#3984. Related: #3893 (the web Media-tab half — see below), and
civitai/civitai#4003 (rate-limiting follow-up — see the disclosure section).
Found client-side in civitai/cli#422 / civitai/cli#424, where the selector table was
measured live: 4/4 off-site apps 404 by slug, 7/7 on-site apps resolve by `appBlockId`.

## Why it is safe — the three premises, verified in this branch, not quoted

1. **`AppListing.slug` is `@unique` globally, across both kinds.**
   `packages/civitai-db-schema/prisma/schema.full.prisma:2812` —
   `slug String @unique`, with the comment *"Globally-unique store slug across BOTH
   kinds"*. No ambiguity, no new index.
   (The issue cites `schema.prisma:2818`; the file is `schema.full.prisma` and the line
   is 2812. Same declaration.)
2. **A public slug always names a top-level parent.** `beginListingRevision`
   (`offsite-listing.service.ts:1065`) gives a shadow a synthetic `rev-<ulid>` slug.
3. **The owner gate is downstream and selector-independent.**
   `resolveListingRole(listing.id, userId)` takes the resolved id and nothing else; it
   delegates to `resolveListingAccess`, which re-reads the row by id. Unchanged.

**Worth flagging on premise 2 — `revisionOfId: null` is load-bearing.** A shadow revision
is `kind: parent.kind`, `appBlockId` NULL, status `draft` (`beginListingRevision`
clones the parent's kind). For an **on-site** parent that is exactly the old clause, so
those shadows **matched** it; a shadow of an **off-site** parent is `kind: 'offsite'` and
did not. Either way the resolver's existing comment ("only ever sees a top-level parent")
held only because nobody knows a shadow's `rev-<ulid>` slug. On this branch it holds by
construction, and `revisionOfId: null` is now the **only** clause holding it — there is a
test that fails if it is dropped.

## On "an off-site listing has no AppBlock"

Stated carefully, because an earlier revision of this body said *"no AppBlock at all,
ever"* and that is **not** true:

- `schema.full.prisma:2849-2853` says `appBlockId` is *"Set for EVERY backfilled row — on-site
  **AND** the #2821 off-site rows (both come from an AppBlock). It is **NOT** a kind
  discriminator: discriminate on `kind`, never on appBlockId nullness."* Only a
  **natively-created** off-site listing leaves it NULL.
- `mapAppBlockToListing` can still mint `kind:'offsite'` with a non-null `appBlockId`.
  That shape measured **0 rows in production, 2026-08-11**
  (`src/components/Apps/appListingEditorTabs.ts:109-113`, `resolveAccessibleAppBlockIds`).

So: **empirically zero today, structurally possible, and a backfilled class exists.** The
widening is correct either way — the clause that had to go was `kind`, and dropping
`appBlockId: null` alongside it is what covers the backfilled class too.

## 🔴 Disclosure delta — please read and disagree if you want to

**A slug belonging to another user returns `NOT_OWNED` (→ tRPC `FORBIDDEN`) rather than
`NOT_FOUND` — but this is a WIDENING of an existing delta, not a new one.**

An earlier revision of this body said *"Before, the `where` filtered a stranger's row out
before the gate ran."* That is **wrong for the shape the old clause admitted.** The old
`where` had no owner predicate either, and `main` already carries a test asserting the
consequence:
`src/server/services/blocks/__tests__/offsite-listing.get-my-listing-for-app.service.test.ts:596`
— *"a draft owned by ANOTHER user → NOT_OWNED (ownership still enforced on the slug
path)"*. For a pre-approval on-site draft, `NOT_OWNED` was **already** the answer on
`main`.

What actually changes is the **size of the addressable set**: rows the old clause
excluded (off-site, approved, pending, rejected, removed, block-backed) now also reach the
owner gate and get `NOT_OWNED` instead of `NOT_FOUND`. The delta is real; it is the same
delta, over more rows.

**The justification is NOT "store slugs are already public in the catalog."** That was the
other wrong assertion here: `getAppDetail` is **approved-only**
(`app-listings.router.ts:1337`, `app-listing.service.ts` — *"a missing OR non-approved
(draft/pending/rejected) listing returns null"*), and the newly-addressable set is
precisely the **non-approved** rows a logged-out browser cannot see.

**The true justification is stronger:** the same cohort already has a *complete* existence
oracle over the *entire* slug namespace, via `submitExternalListing`
(`src/server/services/blocks/offsite-listing.service.ts:238-241`):

```ts
const existingListing = await dbRead.appListing.findUnique({
  where: { slug },            // no kind / status / revisionOfId filter
  select: { id: true },
});
if (existingListing) throw slugTakenError(slug);   // `slug "X" already taken`
```

**The residual, stated honestly:** that oracle is a **mutation** rate-limited to
**10/hour** (`app-listings.router.ts:477-483`); `getMyListingForApp` is an
**unrate-limited `.query`**. So this PR does not create the disclosure — it removes its
budget. Cohort is `appDeveloperProcedure` + the store Flipt gate (mods and gated app
devs), which is why it is tracked rather than fixed here:
**civitai/civitai#4003**. If you want it tightened in this PR instead, the cheap fix is
`rateLimit({ limit: 60, period: 60 })`, matching `getAppDetail` — say the word.

There is a test pinning the new verdict explicitly, so the delta is visible in the suite
rather than implied.

## Why the capability cell is NOT flipped, and what #3893 still owns

`CAPABILITIES_BY_KIND.offsite.listingMedia` stays `false` in this PR.

🔴 **But the reason changed, and every doc comment asserting the old reason has been
updated.** Five sites said the cell is held false because `getMyListingForApp` is
block-keyed. It is not block-keyed any more — *this PR* re-keyed it. What holds the cell
false is `editorTabsFor`'s `media` arm requiring `ctx.appBlockId != null`
(`src/components/Apps/appListingEditorTabs.ts:128`) **in addition to** the cell, plus the
panel in `edit.tsx` passing an `appBlockId` down. Flipping the cell without re-hosting
that surface either changes nothing or renders a tab that cannot load. That re-hosting is
**#3893**'s scope.

Corrected: `app-capabilities.constants.ts`, `appListingEditorTabs.ts`, `edit.tsx`, the
tRPC JSDoc in `app-listings.router.ts`, and the `listingMedia: false` rationale in
`app-access.service.test.ts`.

🔴 **One of them was an access-control classification, not just prose.**
`app-collaborator.permission-matrix.test.ts` filed the proc under `ONSITE_ONLY` with the
rationale *"it is UNCALLABLE [for offsite], which is the same structural mechanism that
makes `submitVersion: false` real."* That mechanism no longer exists, so the
**classification** was wrong, not merely the wording. The entry now lives in the
kind-crossed `MATRIX`, and the off-site half calls it the way an off-site client must —
by slug — asserting the identical allow/deny column. Its `findFirst` mock was made
**predicate-honouring** at the same time: restoring `kind:'onsite'` to the service now
reddens the off-site ALLOW cells (measured); a permissive mock would have passed under the
old clause too and asserted nothing.

## Not touched, on purpose: `deleteOnsiteDraftListingForSlug`

`publish-request.service.ts:1476` carries a clause that looks identical to the one this PR
deleted — `{ slug, kind: 'onsite', appBlockId: null, status: 'draft' }` — and it **must
stay narrow**. It is a `deleteMany` with no owner predicate and nothing downstream to
refuse it; the same widening there would hard-delete whatever top-level row holds the
slug. A cross-reference to #3984 is now in the code so a future "consolidation" cannot
quietly widen a destructive query.

## 🟢 Open question raised by the characterization test — not answered here

**The characterization test in `offsite-listing.edit-consolidate.service.test.ts` adds no
coverage**, and is now labelled as such. That file's `ownedRow` defaults to
`kind: 'offsite'`, so the pre-existing "APPROVED with NO prior shadow → CREATES one" case
above it **already** drives an approved off-site listing through the whole shadow media
path, and a pre-existing case already asserts `kind === 'offsite'` survives. Deleting the
test would not move a line of coverage. It is kept only because it names the question in
one place.

The question itself: `getMyListingForEdit` gates on ownership + status and has **no `kind`
check**; neither do the listing-keyed asset procs (`loadOwnedListing`). So an approved
off-site listing gets a shadow minted and the shadow's asset row ids returned — the full
media flow. Meanwhile `listingMedia: false` says off-site has no media surface, and that
cell is read **only** by the web tab gate; no service consults it (unlike `earnings` and
`submitVersion`, the two other `false` cells, which *are* enforced service-side).

🔴 **And it leans further than "an editor entry read slipped through":**
`REVIEWABLE_LISTING_KINDS = ['onsite', 'offsite']` (`offsite-listing.service.ts:1920`)
means the revision **submit → approve → apply** chain accepts an off-site listing **end to
end**. A media revision an off-site owner stages can be submitted, reviewed and applied.

**So: is off-site media editing through the listing-keyed procs INTENDED — in which case
the cell is a statement about one web tab and nothing more — or a gap the
`listingMedia: false` cell believes is closed, in which case the missing check is in the
services rather than in the tab gate?** That call belongs to whoever owns the capability
table, not to this PR. Re-label or invert the test by that decision; do not silently
delete it.

## Tests

`src/server/services/blocks/__tests__/offsite-listing.get-my-listing-for-app.service.test.ts`
— the `describe` was renamed (it is no longer draft-only). The four existing pre-approval
draft cases stay; the one that asserted the exact old `where` now asserts the new one.

New: an **off-site** listing resolves by slug; an **approved on-site** listing resolves by
slug; a slug owned by another user → `NOT_OWNED`; a **shadow's** synthetic `rev-` slug does
**not** resolve; **`appBlockId` wins over a slug naming a different listing**; a
**`removed`** and a **`rejected`** listing resolve by slug and return their
`editBlockedReason`.

**The mock honours the `where` clause.** The pre-existing slug tests stubbed
`findFirst` to return a fixed row whatever the clause said — which passes under *any*
clause, including the one being replaced. The new cases evaluate the clause the service
actually sent against a row set, so they are claims about the predicate rather than about
the stub. The same treatment was applied to the permission matrix's mock (see above).

### Mutation matrix

Every mutant below was applied to the narrowest expression that can be wrong, run, and
reverted. Counts are over the four touched test files (189 tests at HEAD).

| mutant | before the audit fixes | after |
| --- | --- | --- |
| `if (!listing && slug)` → `if (slug)` (precedence) | **SURVIVED 44/44** | **1 killed** — the precedence test, on `expected 'apl_other' to be 'apl_block'` |
| `+ status: { not: 'removed' }` | 1 killed — *only* the structural `toHaveBeenCalledWith` pin; no behavioural case noticed | **2 killed** — the pin **and** the `removed` behavioural row |
| `+ status: { not: 'rejected' }` | n/a | **2 killed** — the pin and the `rejected` row |
| restore `kind: 'onsite'` (the old clause's first term) | 3 killed | **7 killed** — incl. the two off-site `ALLOW` cells in the permission matrix, which is what makes that mock's predicate-honouring meaningful |
| restore `status: 'draft'` | 4 killed | **6 killed** |
| restore `appBlockId: null` | n/a | **2 killed** |
| drop **only** `revisionOfId: null` | 2 killed | **2 killed** — the shadow case + the `where` pin. Unchanged, as expected |
| none (HEAD) | 44/44 green | **189/189 green** |

Harness validated before any verdict was read from it: the first mutant run was a
**negative control** (restore `kind:'onsite'`) and it went red, so the runner can fail.

**One finding from doing this rather than assuming it:** the shadow case *passed* under
the old-clause mutant on its first draft — for the wrong reason. Without `viewByListingId`
wired, a resolver that *did* admit the shadow still threw `NOT_FOUND`, several steps
later, out of `loadListingEditView`. The test now wires the edit view, so an admitted
shadow *resolves* and the assertions are the only thing between the two behaviours. It is
written down in the test's own comment.

## Gate

- `pnpm run typecheck` — **OK, 0 type errors** (68s)
- `tsc -p tsconfig.tests.json --noEmit` (test files, excluded from the script above) —
  **738 pre-existing errors repo-wide, 0 in the 11 files this branch touches.** Positive
  control: the same grep finds 4 errors in a known-bad file, so the zero is a measurement
  and not a broken pattern.
- `pnpm run lint` — **4317 problems (368 errors, 3949 warnings), identical to the count on
  `main`**, which was run as a control. ESLint over the 11 changed files alone: **0
  errors**, 31 warnings, all pre-existing `_a is defined but never used` in mock blocks and
  one unused import I did not touch.
- `pnpm run prettier:write` — clean (see the note below)
- `pnpm run test:unit:run` — **Test Files 1092 passed | 1 skipped (1093)**,
  **Tests 17094 passed | 21 skipped (17115)**, 106s. Both projects
  (`unit` *and* `unit-native`) — `--project unit` alone would have run 1059 of 1065 and
  exited 0. Counts read from the summary, not from the exit code.

**The full suite caught something the per-file runs did not**, which is worth recording:
after the first mutation rounds the two touched files were green, but one new assertion
pinned the wrong literal (`'no listing found for …'` vs the real
`'no listing found for app …'`) and only the full run surfaced it.

`prettier-changed.mjs` formats whole **dirty files**, and this repo is not Prettier-clean,
so some hunks are Prettier reformatting pre-existing lines (most visibly in
`publish-request.service.ts`, where my actual change is one comment block). They are not
my edits. Flagging so a reviewer does not read them as intentional.

No `schema.full.prisma` change, so `db:check-generated` is not implicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNdYjxagYYedKVxuoaQT4T
