### PR TITLE
fix(home): stop a featured-pool edit deleting the auto-feature config

### DIFF
--- a/src/server/jobs/auto-feature-images.ts
+++ b/src/server/jobs/auto-feature-images.ts
@@ -12,10 +12,11 @@ export const autoFeatureImages = createJob('auto-feature-images', '20 * * * *', 
 
   const [lastRun, setLastRun] = await getJobDate('job:auto-feature-images');
   const result = await runAutoFeatureImages({ lastRun });
-  // The flag being on is a statement of intent, so a missing config is a misconfiguration rather
-  // than an off switch — and it is otherwise indistinguishable from the job working. It went
-  // unnoticed for three days once.
-  if ('reason' in result && result.reason === 'no-auto-feature-config')
+  // The flag being on is a statement of intent, so every bail below it is a fault rather than an
+  // off switch — and each one is otherwise indistinguishable from the job working. A missing config
+  // went unnoticed for three days once. `interval-not-elapsed` is the one that means "working",
+  // which caps this at the cron's 24/day.
+  if ('reason' in result && result.reason !== 'interval-not-elapsed')
     logToAxiom({ type: 'job-misconfigured', name: 'auto-feature-images', reason: result.reason });
   // Only a run that got as far as scoring counts as a run; a config or eligibility miss must not
   // push the next attempt an interval away.

--- a/src/server/jobs/auto-feature-images.ts
+++ b/src/server/jobs/auto-feature-images.ts
@@ -1,4 +1,5 @@
 import { FLIPT_FEATURE_FLAGS, isFlipt } from '~/server/flipt/client';
+import { logToAxiom } from '~/server/logging/client';
 import { runAutoFeatureImages } from '~/server/services/auto-feature-images.service';
 import { createJob, getJobDate } from './job';
 
@@ -11,6 +12,11 @@ export const autoFeatureImages = createJob('auto-feature-images', '20 * * * *', 
 
   const [lastRun, setLastRun] = await getJobDate('job:auto-feature-images');
   const result = await runAutoFeatureImages({ lastRun });
+  // The flag being on is a statement of intent, so a missing config is a misconfiguration rather
+  // than an off switch — and it is otherwise indistinguishable from the job working. It went
+  // unnoticed for three days once.
+  if ('reason' in result && result.reason === 'no-auto-feature-config')
+    logToAxiom({ type: 'job-misconfigured', name: 'auto-feature-images', reason: result.reason });
   // Only a run that got as far as scoring counts as a run; a config or eligibility miss must not
   // push the next attempt an interval away.
   if ('picked' in result) await setLastRun();

--- a/src/server/services/__tests__/home-block-featured-pool.test.ts
+++ b/src/server/services/__tests__/home-block-featured-pool.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as Eligibility from '~/server/jobs/refresh-featured-collections-eligibility';
 import type { HomeBlockMetaSchema } from '~/server/schema/home-block.schema';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 import '~/__tests__/mocks/redis.mock';
@@ -15,7 +16,8 @@ dbMock.dbRead.collection.findUnique.mockImplementation(async () => ({
 }));
 dbMock.dbWrite.homeBlock.findFirst.mockImplementation(async () => systemBlock);
 
-vi.mock('~/server/jobs/refresh-featured-collections-eligibility', () => ({
+vi.mock('~/server/jobs/refresh-featured-collections-eligibility', async (importOriginal) => ({
+  ...(await importOriginal<typeof Eligibility>()),
   computeFeaturedCollectionsState: vi.fn(),
 }));
 

--- a/src/server/services/__tests__/home-block-featured-pool.test.ts
+++ b/src/server/services/__tests__/home-block-featured-pool.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { HomeBlockMetaSchema } from '~/server/schema/home-block.schema';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import '~/__tests__/mocks/redis.mock';
+
+const SYSTEM_BLOCK_ID = 388990;
+
+const systemBlock = { id: SYSTEM_BLOCK_ID, metadata: {} as HomeBlockMetaSchema };
+const homeBlockUpdate = dbMock.dbWrite.homeBlock.update;
+
+dbMock.dbRead.collection.findUnique.mockImplementation(async () => ({
+  id: 555,
+  name: 'Val’s Picks',
+  write: 'Private',
+}));
+dbMock.dbWrite.homeBlock.findFirst.mockImplementation(async () => systemBlock);
+
+vi.mock('~/server/jobs/refresh-featured-collections-eligibility', () => ({
+  computeFeaturedCollectionsState: vi.fn(),
+}));
+
+const {
+  addCollectionToFeaturedPool,
+  removeCollectionFromFeaturedPool,
+  acknowledgeFeaturedCollection,
+} = await import('~/server/services/home-block.service');
+
+const autoFeature = {
+  collectionId: 107,
+  dryRun: false,
+  perRun: 5,
+  intervalHours: 6,
+} as NonNullable<NonNullable<HomeBlockMetaSchema['featuredCollections']>['autoFeature']>;
+
+const writtenPool = () => {
+  expect(homeBlockUpdate).toHaveBeenCalledTimes(1);
+  const metadata = homeBlockUpdate.mock.calls[0][0].data.metadata as HomeBlockMetaSchema;
+  return metadata.featuredCollections;
+};
+
+beforeEach(() => {
+  homeBlockUpdate.mockClear();
+  systemBlock.metadata = {
+    title: 'Featured Collections',
+    featuredCollections: {
+      collectionIds: [111, 222],
+      limit: 40,
+      rows: 2,
+      renderCount: 3,
+      nameSnapshots: { '111': 'One', '222': 'Two' },
+      writeSnapshots: { '111': 'Private', '222': 'Private' },
+      autoFeature,
+    },
+  } as HomeBlockMetaSchema;
+});
+
+describe('featured pool edits preserve fields they do not manage', () => {
+  it('keeps autoFeature when a collection is added', async () => {
+    await addCollectionToFeaturedPool({ collectionId: 555 });
+    const pool = writtenPool();
+    expect(pool?.collectionIds).toEqual([111, 222, 555]);
+    expect(pool?.autoFeature).toEqual(autoFeature);
+  });
+
+  it('keeps autoFeature when a collection is removed', async () => {
+    await removeCollectionFromFeaturedPool({ collectionId: 222 });
+    const pool = writtenPool();
+    expect(pool?.collectionIds).toEqual([111]);
+    expect(pool?.autoFeature).toEqual(autoFeature);
+  });
+
+  it('keeps autoFeature when a collection is acknowledged', async () => {
+    await acknowledgeFeaturedCollection({ collectionId: 555 });
+    expect(writtenPool()?.autoFeature).toEqual(autoFeature);
+  });
+
+  // The bug was field-by-field reconstruction, so pinning autoFeature alone would leave the next
+  // field added here in exactly the same position. This fails for any key that is dropped.
+  it('carries every stored key through a pool edit', async () => {
+    const before = Object.keys(systemBlock.metadata.featuredCollections ?? {}).sort();
+    await addCollectionToFeaturedPool({ collectionId: 555 });
+    expect(Object.keys(writtenPool() ?? {}).sort()).toEqual(expect.arrayContaining(before));
+  });
+});

--- a/src/server/services/home-block.service.ts
+++ b/src/server/services/home-block.service.ts
@@ -870,6 +870,10 @@ async function updateFeaturedPool(
   const newMetadata: HomeBlockMetaSchema = {
     ...metadata,
     featuredCollections: {
+      // Spread first: this object is rebuilt field by field, so anything stored here that these
+      // endpoints don't know about is deleted by a pool edit. `autoFeature` was lost that way and
+      // the job it configures silently stopped for three days.
+      ...metadata.featuredCollections,
       collectionIds: nextIds,
       limit: metadata.featuredCollections?.limit ?? FEATURED_COLLECTIONS_DEFAULTS.limit,
       rows: metadata.featuredCollections?.rows ?? FEATURED_COLLECTIONS_DEFAULTS.rows,


### PR DESCRIPTION
## What happened

The `auto-feature-images` job (#3855) ran exactly once in production — 2026-08-13 17:33 UTC, 5 images — and then stopped. Flag on, cron registered, nothing wrong with eligibility. It was returning `no-auto-feature-config` every hour.

`updateFeaturedPool` rebuilds `metadata.featuredCollections` field by field:

```ts
featuredCollections: {
  collectionIds: nextIds,
  limit: ...,
  rows: ...,
  // ...9 keys, and autoFeature is not one of them
}
```

So `addCollectionToFeaturedPool` / `removeCollectionFromFeaturedPool` / `acknowledgeFeaturedCollection` each delete any key they don't personally list. A mod added a collection to the pool on 2026-08-14 and that write erased the job's config.

Bounded from clones of the system block, which snapshot source metadata at creation: last clone carrying `autoFeature` 08-14 16:59 UTC, first clone without it 08-14 17:47 UTC, and the same edit took the pool from 11 to 12 entries.

## The fix

Spread the stored object before overriding. One line, and it covers every field added to this blob in future rather than just `autoFeature`.

The job also now logs to Axiom when the flag is on but no config is found. That state was previously indistinguishable from the job working normally, which is why it went unnoticed for three days.

## Prod

Config on block 388990 was restored by hand (`jsonb_set`, verified nothing else in the metadata moved). This PR stops the recurrence.

## Verification

- New test pins `autoFeature` across all three pool mutations, plus a key-set assertion so the next field added here is covered without a new test.
- Mutation-tested: removing the spread fails all 4 in under a second with `expected undefined to deeply equal { collectionId: 107, ... }` — a legible failure, not a hang.
- `typecheck` 0 errors; `eslint` clean on changed files; `test:unit:run` 17129 passed / 1098 files; `test:lint-rules` 220 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zUE29eyUFQsS1vMa45Sjm