### PR TITLE
test(perf): stop enforcing the PENDING mock count

### DIFF
--- a/docs/testing/shared-module-mock-migration.md
+++ b/docs/testing/shared-module-mock-migration.md
@@ -1,5 +1,15 @@
 # Migrating a test file onto the canonical shared mocks
 
+> ⚠️ **The bulk migration this was written for is STOPPED** (2026-08-16). It existed to make
+> `isolate: false` safe suite-wide; measurement showed the benefit is convex — 43% of files bought
+> 3% of the import saving, 100% buys 66% — so a partial migration is worth ~nothing and the full one
+> costs 601 files across 354 specifiers. `unit-fast` (#3975) was closed rather than merged.
+>
+> **This recipe is still current and still correct** for the case that remains: the
+> `no-direct-shared-module-mock` guard fails your build because you added a direct `vi.mock` of
+> `~/server/db/client`, `~/server/redis/client` or `~/server/logging/client`. Follow it for that.
+> Do not read it as a backlog to work through.
+
 The mechanism and the design are in [shared-module-mocks.md](./shared-module-mocks.md). This
 is the recipe: what to run, what to do by hand, and how to know you are done.
 

--- a/src/server/services/__tests__/no-direct-shared-module-mock.test.ts
+++ b/src/server/services/__tests__/no-direct-shared-module-mock.test.ts
@@ -116,22 +116,7 @@ describe('no-direct-shared-module-mock', () => {
     ).toEqual([]);
   });
 
-  /**
-   * The PENDING count is deliberately NOT asserted. There used to be a fourth test here pinning
-   * `pendingFiles.length` to reality, justified by keeping the migration dashboard's finish line
-   * honest.
-   *
-   * 🔴 That finish line no longer exists — the unisolation migration was stopped on 2026-08-16 and
-   * `unit-fast` (#3975) was closed rather than merged. What the assertion did in practice was fail
-   * the build of anyone who added a `vi.mock` of any of the 12 pending specifiers, until they ran
-   * `gen-mock-allowlist.mjs`, as bookkeeping for a burn-down nobody is burning down. It cost a
-   * teammate a red CI run on an unrelated PR the same week.
-   *
-   * `gen-mock-allowlist.mjs` still records the count. It is data, and reading it costs nothing;
-   * enforcing it costs everyone who touches a pending specifier.
-   *
-   * ⚠️ The three tests above are a different matter and stay. They guard the CANONICAL specifiers
-   * (`db/client`, `redis/client`, `logging/client`), whose canonical mocks ARE on `main` and are
-   * used by 264 migrated files. A regression there is a real defect, not a stale metric.
-   */
+  // PENDING is recorded by `gen-mock-allowlist.mjs`, deliberately not asserted: enforcing it
+  // failed the build of anyone adding a mock of a pending specifier, for a migration stopped on
+  // 2026-08-16 (#3975 closed). The tests above guard the CANONICAL specifiers and stay.
 });

--- a/src/server/services/__tests__/no-direct-shared-module-mock.test.ts
+++ b/src/server/services/__tests__/no-direct-shared-module-mock.test.ts
@@ -116,10 +116,22 @@ describe('no-direct-shared-module-mock', () => {
     ).toEqual([]);
   });
 
-  it('keeps the PENDING count current, so the remaining scope is never understated', () => {
-    const { pending } = scan();
-    // Counted, not enforced — but the recorded count has to match reality, or the dashboard
-    // reports a finish line that does not exist.
-    expect(Object.keys(pending).length).toBe((readAllowlist().pendingFiles ?? []).length);
-  });
+  /**
+   * The PENDING count is deliberately NOT asserted. There used to be a fourth test here pinning
+   * `pendingFiles.length` to reality, justified by keeping the migration dashboard's finish line
+   * honest.
+   *
+   * 🔴 That finish line no longer exists — the unisolation migration was stopped on 2026-08-16 and
+   * `unit-fast` (#3975) was closed rather than merged. What the assertion did in practice was fail
+   * the build of anyone who added a `vi.mock` of any of the 12 pending specifiers, until they ran
+   * `gen-mock-allowlist.mjs`, as bookkeeping for a burn-down nobody is burning down. It cost a
+   * teammate a red CI run on an unrelated PR the same week.
+   *
+   * `gen-mock-allowlist.mjs` still records the count. It is data, and reading it costs nothing;
+   * enforcing it costs everyone who touches a pending specifier.
+   *
+   * ⚠️ The three tests above are a different matter and stay. They guard the CANONICAL specifiers
+   * (`db/client`, `redis/client`, `logging/client`), whose canonical mocks ARE on `main` and are
+   * used by 264 migrated files. A regression there is a real defect, not a stale metric.
+   */
 });


### PR DESCRIPTION
Removes one assertion. The unisolation migration was stopped on 2026-08-16 and `unit-fast` (#3975) was closed rather than merged, which retires this assertion's only consumer.

## What it was for, in its own words

```js
// Counted, not enforced — but the recorded count has to match reality, or the dashboard
// reports a finish line that does not exist.
expect(Object.keys(pending).length).toBe((readAllowlist().pendingFiles ?? []).length);
```

**That finish line no longer exists.** What the assertion does in practice is fail the build of anyone who adds a `vi.mock` of any of the 12 PENDING specifiers, until they run `gen-mock-allowlist.mjs` — bookkeeping for a burn-down nobody is burning down.

It already cost someone: #3980 went red on a **correct** partial-spread `importOriginal` mock of `image.service`, with `expected 397 to be 396`, which names no file and sends you grepping.

`gen-mock-allowlist.mjs` still records the count. It is data — reading it costs nothing, enforcing it costs everyone who touches a pending specifier.

## What stays, and why the distinction matters

The other three tests are untouched:

- the positive control (`scanned > 800`), without which every claim below it is vacuously true
- **`adds no new direct mock of a module that has a canonical mock`** — the real guard
- `keeps the allowlist honest — a migrated file must be removed from it`

Those cover the **CANONICAL** specifiers — `~/server/db/client`, `~/server/redis/client`, `~/server/logging/client` — whose canonical mocks are on `main` and are used by 264 migrated files. A regression there is a live defect. PENDING is a progress metric for work that is no longer scheduled.

## Verified as a pair, not by observing a green run

```
main's version + a pending mock      RED    expected 399 to be 398   <- the tax, reproduced
this version   + a pending mock      GREEN                           <- removed
this version   + a canonical mock    RED    names the offending file <- still guards
this version, unmutated              GREEN  3 passed
```

The first line is the control: it proves the change is engaged and that this assertion — not something else — was what failed. The third proves the removal did not take the guard's teeth with it.

`pnpm run typecheck`: 0 errors. Prettier and eslint clean on the changed file.

## Context

Part of winding down the unisolation lane. `main` keeps everything that lane produced — the canonical mock system, the guard, the allowlist, 264 migrated files, the RSA keypair cache, and the #3960/#3961/#3962/#3957 work. Only the cancelled migration's bookkeeping goes.

⚠️ Unrelated and **not** fixed here, so it does not get lost: `test:lint-rules` runs **6 of the 10** `no-*` guards, and the four it skips include this one — so the 3-second convention command misses this class entirely and it only surfaces in the 3-minute suite. CLAUDE.md:165-166 claims it "runs all of them" and then lists four. Owned separately.
