### PR TITLE
feat(3d-models): track Model3D views, with a pageViews backfill

### DIFF
--- a/containers/clickhouse/docker-init/init.sh
+++ b/containers/clickhouse/docker-init/init.sh
@@ -388,7 +388,7 @@ clickhouse client -n <<-EOSQL
 
     create table if not exists default.daily_views
     (
-        entityType Enum8('User' = 1, 'Image' = 2, 'Post' = 3, 'Model' = 4, 'ModelVersion' = 5, 'Article' = 6, 'Collection' = 7, 'Bounty' = 8, 'BountyEntry' = 9),
+        entityType Enum8('User' = 1, 'Image' = 2, 'Post' = 3, 'Model' = 4, 'ModelVersion' = 5, 'Article' = 6, 'Collection' = 7, 'Bounty' = 8, 'BountyEntry' = 9, 'Model3D' = 12),
         entityId    UInt32,
         createdDate Date,
         views       UInt64
@@ -888,10 +888,10 @@ clickhouse client -n <<-EOSQL
 
     create table if not exists default.views
     (
-        type Enum8('ProfileView' = 1, 'ImageView' = 2, 'PostView' = 3, 'ModelView' = 4, 'ModelVersionView' = 5, 'ArticleView' = 6, 'CollectionView' = 7, 'BountyView' = 8, 'BountyEntryView' = 9),
+        type Enum8('ProfileView' = 1, 'ImageView' = 2, 'PostView' = 3, 'ModelView' = 4, 'ModelVersionView' = 5, 'ArticleView' = 6, 'CollectionView' = 7, 'BountyView' = 8, 'BountyEntryView' = 9, 'Model3DView' = 12),
         time          DateTime                                          default now(),
         userId        Int32                                             default 0,
-        entityType Enum8('User' = 1, 'Image' = 2, 'Post' = 3, 'Model' = 4, 'ModelVersion' = 5, 'Article' = 6, 'Collection' = 7, 'Bounty' = 8, 'BountyEntry' = 9),
+        entityType Enum8('User' = 1, 'Image' = 2, 'Post' = 3, 'Model' = 4, 'ModelVersion' = 5, 'Article' = 6, 'Collection' = 7, 'Bounty' = 8, 'BountyEntry' = 9, 'Model3D' = 12),
         entityId      Int32,
         ip            String                                            default '',
         userAgent     String                                            default '',
@@ -1384,7 +1384,7 @@ clickhouse client -n <<-EOSQL
     CREATE MATERIALIZED VIEW default.daily_views_mv
                 TO default.daily_views
                 (
-                entityType Enum8('User' = 1, 'Image' = 2, 'Post' = 3, 'Model' = 4, 'ModelVersion' = 5, 'Article' = 6, 'Collection' = 7, 'Bounty' = 8, 'BountyEntry' = 9),
+                entityType Enum8('User' = 1, 'Image' = 2, 'Post' = 3, 'Model' = 4, 'ModelVersion' = 5, 'Article' = 6, 'Collection' = 7, 'Bounty' = 8, 'BountyEntry' = 9, 'Model3D' = 12),
                 entityId Int32,
                 createdDate Date,
                 views UInt64

--- a/packages/civitai-shared/src/index.ts
+++ b/packages/civitai-shared/src/index.ts
@@ -4,3 +4,4 @@
 export * from './flags';
 export * from './browsing-levels';
 export * from './model-version-flags.constants';
+export * from './model3d-views.constants';

--- a/packages/civitai-shared/src/model3d-views.constants.ts
+++ b/packages/civitai-shared/src/model3d-views.constants.ts
@@ -1,0 +1,14 @@
+// Exclusive: the first day `Model3DView` events were written live. Everything
+// strictly before it in `daily_views` came from the `pageViews` backfill
+// (scripts/oneoffs/backfill-model3d-views.ts), which refuses to run unless its
+// `--until` equals this value.
+export const MODEL3D_VIEW_TRACKING_CUTOVER = '2026-08-18';
+
+// The two spans are not the same measurement, so a consumer that plots across
+// the boundary has to say so: before it, one row per page load; after it, one
+// beacon per detail-page mount debounced 1s. Detail page only — `/edit` and
+// `/reviews` are excluded on both sides.
+export const MODEL3D_VIEW_TRACKING_NOTE =
+  'Views before ' +
+  MODEL3D_VIEW_TRACKING_CUTOVER +
+  ' are backfilled from page-load history and are not directly comparable to tracked views after it.';

--- a/scripts/__tests__/backfill-model3d-views.test.ts
+++ b/scripts/__tests__/backfill-model3d-views.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { MODEL3D_VIEW_TRACKING_CUTOVER } from '@civitai/shared';
-import {
-  DEFAULT_FROM,
-  DETAIL_PREDICATE,
-  parseArgs,
-  previousDay,
-} from '../oneoffs/backfill-model3d-views.helpers';
+import { DEFAULT_FROM, parseArgs } from '../oneoffs/backfill-model3d-views.helpers';
 
 const CUTOVER = MODEL3D_VIEW_TRACKING_CUTOVER;
 
@@ -31,7 +26,6 @@ describe('parseArgs', () => {
 
   it('requires --until rather than defaulting it', () => {
     expect(() => parseArgs([])).toThrow(/--until <YYYY-MM-DD> is required/);
-    expect(() => parseArgs(['--dry-run'])).toThrow(/--until <YYYY-MM-DD> is required/);
   });
 
   it('rejects a malformed date instead of passing it into SQL', () => {
@@ -50,33 +44,5 @@ describe('parseArgs', () => {
 
   it('picks up --dry-run', () => {
     expect(parseArgs(['--until', CUTOVER, '--dry-run']).dryRun).toBe(true);
-  });
-});
-
-describe('previousDay', () => {
-  it('returns the inclusive last day covered by an exclusive --until', () => {
-    expect(previousDay(CUTOVER)).toBe('2026-08-17');
-  });
-
-  it('crosses month and year boundaries', () => {
-    expect(previousDay('2026-09-01')).toBe('2026-08-31');
-    expect(previousDay('2027-01-01')).toBe('2026-12-31');
-    expect(previousDay('2028-03-01')).toBe('2028-02-29');
-  });
-});
-
-describe('DETAIL_PREDICATE', () => {
-  // Shape checks only. The predicate is evaluated by ClickHouse's RE2, not by
-  // Node, so this suite cannot prove its matching behaviour — that was verified
-  // against 30 days of prod pageViews (82,319 counted / 399 edit+reviews
-  // excluded / 21 junk excluded) and is recorded in the helper's comment.
-  it('stays anchored so junk like /3d-modelshttps:/... cannot be swept in', () => {
-    expect(DETAIL_PREDICATE).toContain("'^/3d-models/[0-9]+");
-  });
-
-  it('excludes the owner surfaces by name, not by path shape', () => {
-    // `/3d-models/1/edit` and `/3d-models/1/my-slug` are the same shape, so an
-    // id-anchored regex alone still matches the edit page.
-    expect(DETAIL_PREDICATE).toMatch(/NOT match\([^)]*\(edit\|reviews\)/);
   });
 });

--- a/scripts/__tests__/backfill-model3d-views.test.ts
+++ b/scripts/__tests__/backfill-model3d-views.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { MODEL3D_VIEW_TRACKING_CUTOVER } from '@civitai/shared';
+import {
+  DEFAULT_FROM,
+  DETAIL_PREDICATE,
+  parseArgs,
+  previousDay,
+} from '../oneoffs/backfill-model3d-views.helpers';
+
+const CUTOVER = MODEL3D_VIEW_TRACKING_CUTOVER;
+
+describe('parseArgs', () => {
+  it('accepts --until at the cutover and defaults --from to the first Model3D row', () => {
+    expect(parseArgs(['--until', CUTOVER])).toEqual({
+      until: CUTOVER,
+      from: DEFAULT_FROM,
+      dryRun: false,
+    });
+  });
+
+  it('refuses an --until that is not the cutover', () => {
+    // daily_views sums on insert, so a backfill that stops short of (or runs past)
+    // the first live-tracked day leaves a gap or a doubled day that nothing detects.
+    expect(() => parseArgs(['--until', '2026-08-17'])).toThrow(
+      /must equal MODEL3D_VIEW_TRACKING_CUTOVER/
+    );
+    expect(() => parseArgs(['--until', '2026-08-19'])).toThrow(
+      /must equal MODEL3D_VIEW_TRACKING_CUTOVER/
+    );
+  });
+
+  it('requires --until rather than defaulting it', () => {
+    expect(() => parseArgs([])).toThrow(/--until <YYYY-MM-DD> is required/);
+    expect(() => parseArgs(['--dry-run'])).toThrow(/--until <YYYY-MM-DD> is required/);
+  });
+
+  it('rejects a malformed date instead of passing it into SQL', () => {
+    expect(() => parseArgs(['--until', "2026-08-18' OR 1=1 --"])).toThrow(/must be YYYY-MM-DD/);
+    expect(() => parseArgs(['--until', CUTOVER, '--from', 'yesterday'])).toThrow(
+      /must be YYYY-MM-DD/
+    );
+  });
+
+  it('rejects an empty or inverted range', () => {
+    expect(() => parseArgs(['--until', CUTOVER, '--from', CUTOVER])).toThrow(/strictly before/);
+    expect(() => parseArgs(['--until', CUTOVER, '--from', '2026-12-01'])).toThrow(
+      /strictly before/
+    );
+  });
+
+  it('picks up --dry-run', () => {
+    expect(parseArgs(['--until', CUTOVER, '--dry-run']).dryRun).toBe(true);
+  });
+});
+
+describe('previousDay', () => {
+  it('returns the inclusive last day covered by an exclusive --until', () => {
+    expect(previousDay(CUTOVER)).toBe('2026-08-17');
+  });
+
+  it('crosses month and year boundaries', () => {
+    expect(previousDay('2026-09-01')).toBe('2026-08-31');
+    expect(previousDay('2027-01-01')).toBe('2026-12-31');
+    expect(previousDay('2028-03-01')).toBe('2028-02-29');
+  });
+});
+
+describe('DETAIL_PREDICATE', () => {
+  // Shape checks only. The predicate is evaluated by ClickHouse's RE2, not by
+  // Node, so this suite cannot prove its matching behaviour — that was verified
+  // against 30 days of prod pageViews (82,319 counted / 399 edit+reviews
+  // excluded / 21 junk excluded) and is recorded in the helper's comment.
+  it('stays anchored so junk like /3d-modelshttps:/... cannot be swept in', () => {
+    expect(DETAIL_PREDICATE).toContain("'^/3d-models/[0-9]+");
+  });
+
+  it('excludes the owner surfaces by name, not by path shape', () => {
+    // `/3d-models/1/edit` and `/3d-models/1/my-slug` are the same shape, so an
+    // id-anchored regex alone still matches the edit page.
+    expect(DETAIL_PREDICATE).toMatch(/NOT match\([^)]*\(edit\|reviews\)/);
+  });
+});

--- a/scripts/__tests__/backfill-model3d-views.test.ts
+++ b/scripts/__tests__/backfill-model3d-views.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { MODEL3D_VIEW_TRACKING_CUTOVER } from '@civitai/shared';
-import { DEFAULT_FROM, parseArgs } from '../oneoffs/backfill-model3d-views.helpers';
+import {
+  DEFAULT_FROM,
+  DETAIL_PREDICATE,
+  parseArgs,
+} from '../oneoffs/backfill-model3d-views.helpers';
 
 const CUTOVER = MODEL3D_VIEW_TRACKING_CUTOVER;
 
@@ -44,5 +48,18 @@ describe('parseArgs', () => {
 
   it('picks up --dry-run', () => {
     expect(parseArgs(['--until', CUTOVER, '--dry-run']).dryRun).toBe(true);
+  });
+});
+
+describe('DETAIL_PREDICATE', () => {
+  // A shape check, deliberately: the predicate is evaluated by ClickHouse's RE2
+  // and never by Node, so no Node assertion can prove how it matches (that is
+  // verified against prod). This one still earns its place — it fails if the
+  // exclusion clause is removed, which is the plausible edit, since an
+  // id-anchored regex looks sufficient until you notice /3d-models/1/edit and
+  // /3d-models/1/my-slug are the same shape.
+  it('excludes the owner surfaces by name', () => {
+    expect(DETAIL_PREDICATE).toContain('(edit|reviews)');
+    expect(DETAIL_PREDICATE).toMatch(/AND NOT match\(/);
   });
 });

--- a/scripts/oneoffs/backfill-model3d-views.helpers.ts
+++ b/scripts/oneoffs/backfill-model3d-views.helpers.ts
@@ -6,16 +6,20 @@ import { MODEL3D_VIEW_TRACKING_CUTOVER } from '@civitai/shared';
 // First Model3D row in production. Nothing can have been viewed before it.
 export const DEFAULT_FROM = '2026-06-19';
 
+// The filter and the id extraction must stay in lockstep: a path the filter
+// admits but this pattern misses yields '', and toUInt32('') throws mid-query
+// over 570M rows. Derived from one constant so they cannot drift.
+export const ID_PATTERN = '^/3d-models/([0-9]+)';
+
 // Detail pages only. `/3d-models/<id>/edit` and `/3d-models/<id>/reviews` are
 // structurally identical to a slug segment, so they have to be excluded by name
 // rather than by shape — an anchored id regex alone still matches them.
 //
-// Evaluated by ClickHouse's RE2, not by Node. Verified against 30 days of prod
-// `pageViews`: 82,319 rows counted across 426 ids, 399 rows excluded as
-// edit/reviews, 21 junk rows (`/3d-models#`, `/3d-modelshttps:/...`) excluded.
+// Evaluated by ClickHouse's RE2, never by Node: a unit test of this string
+// proves nothing about how it matches.
 export const DETAIL_PREDICATE = `
-  match(path, '^/3d-models/[0-9]+([/?#]|$)')
-  AND NOT match(path, '^/3d-models/[0-9]+/(edit|reviews)([/?#]|$)')
+  match(path, '${ID_PATTERN}([/?#]|$)')
+  AND NOT match(path, '${ID_PATTERN}/(edit|reviews)([/?#]|$)')
 `;
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
@@ -35,8 +39,6 @@ export function parseArgs(argv: string[]) {
   if (!DATE_RE.test(from)) throw new Error(`--from must be YYYY-MM-DD, got "${from}"`);
   if (from >= until) throw new Error(`--from (${from}) must be strictly before --until (${until})`);
 
-  // The cutover is the contract between this backfill and live tracking. Letting
-  // them disagree is how you get a duplicated or missing day that nothing detects.
   if (until !== MODEL3D_VIEW_TRACKING_CUTOVER)
     throw new Error(
       `--until must equal MODEL3D_VIEW_TRACKING_CUTOVER (${MODEL3D_VIEW_TRACKING_CUTOVER}), got "${until}". ` +
@@ -44,10 +46,4 @@ export function parseArgs(argv: string[]) {
     );
 
   return { until, from, dryRun };
-}
-
-export function previousDay(date: string) {
-  const d = new Date(`${date}T00:00:00Z`);
-  d.setUTCDate(d.getUTCDate() - 1);
-  return d.toISOString().slice(0, 10);
 }

--- a/scripts/oneoffs/backfill-model3d-views.helpers.ts
+++ b/scripts/oneoffs/backfill-model3d-views.helpers.ts
@@ -1,0 +1,53 @@
+// Pure helpers for backfill-model3d-views.ts. Separate module so the test can
+// import them without pulling in the ClickHouse/Postgres clients the script
+// builds at load.
+import { MODEL3D_VIEW_TRACKING_CUTOVER } from '@civitai/shared';
+
+// First Model3D row in production. Nothing can have been viewed before it.
+export const DEFAULT_FROM = '2026-06-19';
+
+// Detail pages only. `/3d-models/<id>/edit` and `/3d-models/<id>/reviews` are
+// structurally identical to a slug segment, so they have to be excluded by name
+// rather than by shape — an anchored id regex alone still matches them.
+//
+// Evaluated by ClickHouse's RE2, not by Node. Verified against 30 days of prod
+// `pageViews`: 82,319 rows counted across 426 ids, 399 rows excluded as
+// edit/reviews, 21 junk rows (`/3d-models#`, `/3d-modelshttps:/...`) excluded.
+export const DETAIL_PREDICATE = `
+  match(path, '^/3d-models/[0-9]+([/?#]|$)')
+  AND NOT match(path, '^/3d-models/[0-9]+/(edit|reviews)([/?#]|$)')
+`;
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export function parseArgs(argv: string[]) {
+  const get = (flag: string) => {
+    const i = argv.indexOf(flag);
+    return i === -1 ? undefined : argv[i + 1];
+  };
+
+  const until = get('--until');
+  const from = get('--from') ?? DEFAULT_FROM;
+  const dryRun = argv.includes('--dry-run');
+
+  if (!until) throw new Error('--until <YYYY-MM-DD> is required (exclusive upper bound)');
+  if (!DATE_RE.test(until)) throw new Error(`--until must be YYYY-MM-DD, got "${until}"`);
+  if (!DATE_RE.test(from)) throw new Error(`--from must be YYYY-MM-DD, got "${from}"`);
+  if (from >= until) throw new Error(`--from (${from}) must be strictly before --until (${until})`);
+
+  // The cutover is the contract between this backfill and live tracking. Letting
+  // them disagree is how you get a duplicated or missing day that nothing detects.
+  if (until !== MODEL3D_VIEW_TRACKING_CUTOVER)
+    throw new Error(
+      `--until must equal MODEL3D_VIEW_TRACKING_CUTOVER (${MODEL3D_VIEW_TRACKING_CUTOVER}), got "${until}". ` +
+        `If the cutover moved, change the constant and redeploy — do not override it here.`
+    );
+
+  return { until, from, dryRun };
+}
+
+export function previousDay(date: string) {
+  const d = new Date(`${date}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() - 1);
+  return d.toISOString().slice(0, 10);
+}

--- a/scripts/oneoffs/backfill-model3d-views.ts
+++ b/scripts/oneoffs/backfill-model3d-views.ts
@@ -20,32 +20,61 @@ import { DETAIL_PREDICATE, ID_PATTERN, parseArgs } from './backfill-model3d-view
 
 type Row = { entityId: number; createdDate: string; views: number };
 
+// A dev server or preview deploy on a tracking branch writes to the SAME
+// ClickHouse as prod, so one developer opening a 3D model page puts a real
+// Model3DView row in `views`. Taking a bare min() over those would move the
+// detected cutover back to that day and quietly drop every day between it and
+// the real one. Production traffic on this surface runs ~2,700 views/day, so a
+// day is only the cutover if it clears a floor no incidental page load reaches.
+const MIN_ROWS_FOR_A_TRACKED_DAY = 50;
+
 async function main() {
   const { until, from, dryRun } = parseArgs(process.argv.slice(2));
   if (!clickhouse) throw new Error('ClickHouse client not initialized');
 
   console.log(`Range: [${from}, ${until})  ${dryRun ? '(dry run)' : ''}`);
 
-  // The constant is only a guess until tracking is live. The first day `views`
-  // actually holds a Model3DView IS the cutover; if it disagrees with the
+  // The constant is only a guess until tracking is live: the first day `views`
+  // holds real Model3DView traffic IS the cutover. If it disagrees with the
   // constant, one of the two spans is wrong — a gap if the deploy slipped past
   // it, an overlap if it landed early. Neither is visible once rows are written.
-  const live = await clickhouse.$query<{ firstDay: string; rows: number }>(`
-    SELECT min(createdDate) AS firstDay, count() AS rows
+  const byDay = await clickhouse.$query<{ createdDate: string; rows: number }>(`
+    SELECT createdDate, count() AS rows
     FROM default.views WHERE type = 'Model3DView'
+    GROUP BY createdDate ORDER BY createdDate
   `);
-  if (!Number(live?.[0]?.rows ?? 0))
-    throw new Error(
-      `No Model3DView rows in \`views\` yet. Deploy tracking first, then run this — ` +
-        `until tracking is live there is nothing to confirm the backfill's stopping point against.`
+  const trackedDays = (byDay ?? []).filter((d) => Number(d.rows) >= MIN_ROWS_FOR_A_TRACKED_DAY);
+  const firstTrackedDay = trackedDays[0]?.createdDate;
+
+  const strays = (byDay ?? []).filter(
+    (d) =>
+      Number(d.rows) < MIN_ROWS_FOR_A_TRACKED_DAY &&
+      (!firstTrackedDay || d.createdDate < firstTrackedDay)
+  );
+  if (strays.length)
+    console.warn(
+      `WARNING: ${strays.length} low-volume Model3DView day(s) before the cutover, ignored as ` +
+        `incidental (dev server or preview traffic): ` +
+        strays.map((d) => `${d.createdDate}=${d.rows}`).join(', ') +
+        `. They are in \`views\` and in \`daily_views\`; delete them if you want the pre-cutover span clean.`
     );
-  const firstTrackedDay = live[0].firstDay;
-  if (firstTrackedDay !== until)
+
+  if (!firstTrackedDay) {
+    const msg =
+      `No day in \`views\` has ${MIN_ROWS_FOR_A_TRACKED_DAY}+ Model3DView rows yet. Deploy tracking ` +
+      `first, then run this — until tracking is live there is nothing to confirm the stopping point against.`;
+    if (!dryRun) throw new Error(msg);
+    console.warn(`WARNING (dry run, continuing): ${msg}`);
+  } else if (firstTrackedDay !== until) {
     throw new Error(
-      `Cutover mismatch: first tracked day is ${firstTrackedDay}, --until is ${until}. ` +
-        `Set MODEL3D_VIEW_TRACKING_CUTOVER to ${firstTrackedDay} and redeploy, then re-run. ` +
-        `Backfilling to the wrong boundary leaves a permanently missing or doubled day.`
+      `Cutover mismatch: first tracked day is ${firstTrackedDay}, --until is ${until}.\n` +
+        `  ${firstTrackedDay} is almost certainly PARTIAL — tracking started mid-day, so beacons cover only\n` +
+        `  the hours after the deploy and pageViews covers the hours before. Pick one deliberately:\n` +
+        `    (a) set the constant to ${firstTrackedDay} — that day keeps only post-deploy views, the rest is lost;\n` +
+        `    (b) set it to the next UTC midnight and re-run after that day closes — no loss, one day's delay.\n` +
+        `  Do not treat (a) as the default fix just because it clears this error.`
     );
+  }
 
   const existing = await clickhouse.$query<{ rows: number }>(`
     SELECT count() AS rows FROM default.daily_views
@@ -58,7 +87,9 @@ async function main() {
         `Refusing to run — this table sums on insert, so a re-run would inflate every day it touches.`
     );
 
-  const candidates =
+  // Coerce rather than trusting the shape: count() is UInt64 and only arrives as
+  // a JS number because the shared client sets output_format_json_quote_64bit_integers.
+  const candidates: Row[] = (
     (await clickhouse.$query<Row>(`
       SELECT
         toUInt32(extract(path, '${ID_PATTERN}')) AS entityId,
@@ -70,7 +101,12 @@ async function main() {
         AND ${DETAIL_PREDICATE}
       GROUP BY entityId, createdDate
       ORDER BY createdDate, entityId
-    `)) ?? [];
+    `)) ?? []
+  ).map((r) => ({
+    entityId: Number(r.entityId),
+    createdDate: r.createdDate,
+    views: Number(r.views),
+  }));
 
   if (!candidates.length) {
     console.log('Nothing to backfill.');
@@ -121,10 +157,22 @@ async function main() {
   // Read the whole written range back rather than assuming it, and sum across
   // parts: SummingMergeTree merges in the background, so a raw row read can show
   // either the pre- or post-merge shape and both look reasonable.
-  const readback = await clickhouse.$query<{ rows: number; views: number }>(`
-    SELECT count() AS rows, sum(views) AS views FROM default.daily_views
-    WHERE entityType = 'Model3D' AND createdDate >= '${from}' AND createdDate < '${until}'
-  `);
+  //
+  // `select_sequential_consistency` because prod is a two-replica SharedMergeTree
+  // behind a load balancer: the insert and this read are separate requests and
+  // can land on different replicas, so a committed write is not necessarily
+  // visible to the next query. Without it this reports a false failure — and the
+  // pre-flight guard above then blocks the retry, since the rows really are there.
+  // `$query` takes no settings, so this goes through the underlying client.
+  const readbackResult = await clickhouse.query({
+    query: `
+      SELECT count() AS rows, sum(views) AS views FROM default.daily_views
+      WHERE entityType = 'Model3D' AND createdDate >= '${from}' AND createdDate < '${until}'
+    `,
+    format: 'JSONEachRow',
+    clickhouse_settings: { select_sequential_consistency: 1 },
+  });
+  const readback = await readbackResult.json<{ rows: number | string; views: number | string }>();
   const actualRows = Number(readback?.[0]?.rows ?? 0);
   const actualViews = Number(readback?.[0]?.views ?? 0);
 

--- a/scripts/oneoffs/backfill-model3d-views.ts
+++ b/scripts/oneoffs/backfill-model3d-views.ts
@@ -6,16 +6,17 @@
  * something to show on day one.
  *
  * Usage:
- *   npx ts-node scripts/oneoffs/backfill-model3d-views.ts --until 2026-08-18 --dry-run
- *   npx ts-node scripts/oneoffs/backfill-model3d-views.ts --until 2026-08-18
+ *   npm run tsscript scripts/oneoffs/backfill-model3d-views.ts -- --until 2026-08-18 --dry-run
+ *   npm run tsscript scripts/oneoffs/backfill-model3d-views.ts -- --until 2026-08-18
  *
- * Requires the ClickHouse enum widening in scripts/oneoffs/model3d-view-tracking.sql
- * to have been applied first — `daily_views.entityType` cannot hold 'Model3D' until then.
+ * Run this LAST: after the enum widening (scripts/oneoffs/model3d-view-tracking.sql)
+ * and after the tracking code is deployed. It verifies against live data that the
+ * cutover constant is the real first tracked day rather than trusting it.
  */
 
 import { clickhouse } from '~/server/clickhouse/client';
 import { getClient } from '~/server/db/db-helpers';
-import { DETAIL_PREDICATE, parseArgs, previousDay } from './backfill-model3d-views.helpers';
+import { DETAIL_PREDICATE, ID_PATTERN, parseArgs } from './backfill-model3d-views.helpers';
 
 type Row = { entityId: number; createdDate: string; views: number };
 
@@ -25,9 +26,28 @@ async function main() {
 
   console.log(`Range: [${from}, ${until})  ${dryRun ? '(dry run)' : ''}`);
 
-  // Refuse rather than double-count. `daily_views` is a SummingMergeTree, so a
-  // second run does not overwrite — it adds, and the result looks plausible.
-  const existing = await clickhouse.$query<{ rows: string }>(`
+  // The constant is only a guess until tracking is live. The first day `views`
+  // actually holds a Model3DView IS the cutover; if it disagrees with the
+  // constant, one of the two spans is wrong — a gap if the deploy slipped past
+  // it, an overlap if it landed early. Neither is visible once rows are written.
+  const live = await clickhouse.$query<{ firstDay: string; rows: number }>(`
+    SELECT min(createdDate) AS firstDay, count() AS rows
+    FROM default.views WHERE type = 'Model3DView'
+  `);
+  if (!Number(live?.[0]?.rows ?? 0))
+    throw new Error(
+      `No Model3DView rows in \`views\` yet. Deploy tracking first, then run this — ` +
+        `until tracking is live there is nothing to confirm the backfill's stopping point against.`
+    );
+  const firstTrackedDay = live[0].firstDay;
+  if (firstTrackedDay !== until)
+    throw new Error(
+      `Cutover mismatch: first tracked day is ${firstTrackedDay}, --until is ${until}. ` +
+        `Set MODEL3D_VIEW_TRACKING_CUTOVER to ${firstTrackedDay} and redeploy, then re-run. ` +
+        `Backfilling to the wrong boundary leaves a permanently missing or doubled day.`
+    );
+
+  const existing = await clickhouse.$query<{ rows: number }>(`
     SELECT count() AS rows FROM default.daily_views
     WHERE entityType = 'Model3D' AND createdDate >= '${from}' AND createdDate < '${until}'
   `);
@@ -38,35 +58,27 @@ async function main() {
         `Refusing to run — this table sums on insert, so a re-run would inflate every day it touches.`
     );
 
-  const aggregated = await clickhouse.$query<{
-    entityId: string;
-    createdDate: string;
-    views: string;
-  }>(`
-    SELECT
-      toUInt32(extract(path, '^/3d-models/([0-9]+)')) AS entityId,
-      toDate(time) AS createdDate,
-      count() AS views
-    FROM default.pageViews
-    WHERE toDate(time) >= '${from}' AND toDate(time) < '${until}'
-      AND path LIKE '/3d-models%'
-      AND ${DETAIL_PREDICATE}
-    GROUP BY entityId, createdDate
-    ORDER BY createdDate, entityId
-  `);
-
-  const candidates: Row[] = (aggregated ?? []).map((r) => ({
-    entityId: Number(r.entityId),
-    createdDate: r.createdDate,
-    views: Number(r.views),
-  }));
+  const candidates =
+    (await clickhouse.$query<Row>(`
+      SELECT
+        toUInt32(extract(path, '${ID_PATTERN}')) AS entityId,
+        toDate(time) AS createdDate,
+        count() AS views
+      FROM default.pageViews
+      WHERE toDate(time) >= '${from}' AND toDate(time) < '${until}'
+        AND path LIKE '/3d-models%'
+        AND ${DETAIL_PREDICATE}
+      GROUP BY entityId, createdDate
+      ORDER BY createdDate, entityId
+    `)) ?? [];
 
   if (!candidates.length) {
     console.log('Nothing to backfill.');
     return;
   }
 
-  // Ownership and existence live in Postgres; ClickHouse has no Model3D table.
+  // ClickHouse has no Model3D table, so a path id that resolves to nothing can
+  // only be caught here.
   const pg = getClient({ instance: 'primaryRead' });
   const ids = [...new Set(candidates.map((r) => r.entityId))];
   const { rows: known } = await pg.query<{ id: number }>(
@@ -86,50 +98,49 @@ async function main() {
       `[${unmappedIds.join(', ')}]`
   );
 
-  const boundaryDay = previousDay(until);
-  const expectedBoundary = mapped
-    .filter((r) => r.createdDate === boundaryDay)
-    .reduce((sum, r) => sum + r.views, 0);
+  const expectedRows = mapped.length;
+  const expectedViews = mapped.reduce((sum, r) => sum + r.views, 0);
 
   if (dryRun) {
-    const total = mapped.reduce((sum, r) => sum + r.views, 0);
-    console.log(`[DRY RUN] Would insert ${mapped.length} rows / ${total} views.`);
-    console.log(`[DRY RUN] Boundary day ${boundaryDay} would hold ${expectedBoundary} views.`);
+    console.log(`[DRY RUN] Would insert ${expectedRows} rows / ${expectedViews} views.`);
     return;
   }
 
+  // The shared client is built with `wait_for_async_insert: 0`, so by default
+  // `insert` resolves once the server has buffered the batch — before it is
+  // queryable, and without surfacing a server-side insert error at all. The
+  // verification below would then race the flush and report a false failure on a
+  // run that actually succeeded. Wait for this one.
   await clickhouse.insert({
     table: 'daily_views',
     values: mapped.map((r) => ({ entityType: 'Model3D', ...r })),
     format: 'JSONEachRow',
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 1 },
   });
 
-  // Read the boundary day back rather than assuming it. SummingMergeTree merges
-  // in the background, so this must sum across parts — a raw row read can show
+  // Read the whole written range back rather than assuming it, and sum across
+  // parts: SummingMergeTree merges in the background, so a raw row read can show
   // either the pre- or post-merge shape and both look reasonable.
-  const readback = await clickhouse.$query<{ views: string }>(`
-    SELECT sum(views) AS views FROM default.daily_views
-    WHERE entityType = 'Model3D' AND createdDate = '${boundaryDay}'
+  const readback = await clickhouse.$query<{ rows: number; views: number }>(`
+    SELECT count() AS rows, sum(views) AS views FROM default.daily_views
+    WHERE entityType = 'Model3D' AND createdDate >= '${from}' AND createdDate < '${until}'
   `);
-  const actualBoundary = Number(readback?.[0]?.views ?? 0);
+  const actualRows = Number(readback?.[0]?.rows ?? 0);
+  const actualViews = Number(readback?.[0]?.views ?? 0);
 
-  console.log(
-    `Boundary day ${boundaryDay}: expected ${expectedBoundary}, stored ${actualBoundary}.`
-  );
-  if (actualBoundary !== expectedBoundary)
+  if (actualRows !== expectedRows || actualViews !== expectedViews)
     throw new Error(
-      `Boundary mismatch on ${boundaryDay}: expected ${expectedBoundary}, found ${actualBoundary}. ` +
+      `Write verification failed for [${from}, ${until}): expected ${expectedRows} rows / ` +
+        `${expectedViews} views, found ${actualRows} / ${actualViews}. ` +
         `Inspect before re-running — this table sums, so a blind retry compounds the error.`
     );
 
-  console.log(`Inserted ${mapped.length} rows.`);
+  console.log(`Inserted ${expectedRows} rows / ${expectedViews} views, verified.`);
 }
 
-if (require.main === module) {
-  main()
-    .then(() => process.exit(0))
-    .catch((e) => {
-      console.error(e instanceof Error ? e.message : e);
-      process.exit(1);
-    });
-}
+main()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error(e instanceof Error ? e.message : e);
+    process.exit(1);
+  });

--- a/scripts/oneoffs/backfill-model3d-views.ts
+++ b/scripts/oneoffs/backfill-model3d-views.ts
@@ -1,0 +1,135 @@
+/**
+ * Backfill Model3D views into ClickHouse `daily_views` from `pageViews` history.
+ *
+ * Live `Model3DView` tracking starts at MODEL3D_VIEW_TRACKING_CUTOVER. This
+ * fills the span before it from page-load history so the Creator Studio has
+ * something to show on day one.
+ *
+ * Usage:
+ *   npx ts-node scripts/oneoffs/backfill-model3d-views.ts --until 2026-08-18 --dry-run
+ *   npx ts-node scripts/oneoffs/backfill-model3d-views.ts --until 2026-08-18
+ *
+ * Requires the ClickHouse enum widening in scripts/oneoffs/model3d-view-tracking.sql
+ * to have been applied first — `daily_views.entityType` cannot hold 'Model3D' until then.
+ */
+
+import { clickhouse } from '~/server/clickhouse/client';
+import { getClient } from '~/server/db/db-helpers';
+import { DETAIL_PREDICATE, parseArgs, previousDay } from './backfill-model3d-views.helpers';
+
+type Row = { entityId: number; createdDate: string; views: number };
+
+async function main() {
+  const { until, from, dryRun } = parseArgs(process.argv.slice(2));
+  if (!clickhouse) throw new Error('ClickHouse client not initialized');
+
+  console.log(`Range: [${from}, ${until})  ${dryRun ? '(dry run)' : ''}`);
+
+  // Refuse rather than double-count. `daily_views` is a SummingMergeTree, so a
+  // second run does not overwrite — it adds, and the result looks plausible.
+  const existing = await clickhouse.$query<{ rows: string }>(`
+    SELECT count() AS rows FROM default.daily_views
+    WHERE entityType = 'Model3D' AND createdDate >= '${from}' AND createdDate < '${until}'
+  `);
+  const existingRows = Number(existing?.[0]?.rows ?? 0);
+  if (existingRows > 0)
+    throw new Error(
+      `daily_views already holds ${existingRows} Model3D rows in [${from}, ${until}). ` +
+        `Refusing to run — this table sums on insert, so a re-run would inflate every day it touches.`
+    );
+
+  const aggregated = await clickhouse.$query<{
+    entityId: string;
+    createdDate: string;
+    views: string;
+  }>(`
+    SELECT
+      toUInt32(extract(path, '^/3d-models/([0-9]+)')) AS entityId,
+      toDate(time) AS createdDate,
+      count() AS views
+    FROM default.pageViews
+    WHERE toDate(time) >= '${from}' AND toDate(time) < '${until}'
+      AND path LIKE '/3d-models%'
+      AND ${DETAIL_PREDICATE}
+    GROUP BY entityId, createdDate
+    ORDER BY createdDate, entityId
+  `);
+
+  const candidates: Row[] = (aggregated ?? []).map((r) => ({
+    entityId: Number(r.entityId),
+    createdDate: r.createdDate,
+    views: Number(r.views),
+  }));
+
+  if (!candidates.length) {
+    console.log('Nothing to backfill.');
+    return;
+  }
+
+  // Ownership and existence live in Postgres; ClickHouse has no Model3D table.
+  const pg = getClient({ instance: 'primaryRead' });
+  const ids = [...new Set(candidates.map((r) => r.entityId))];
+  const { rows: known } = await pg.query<{ id: number }>(
+    'SELECT id FROM "Model3D" WHERE id = ANY($1::int[])',
+    [ids]
+  );
+  const knownIds = new Set(known.map((r) => r.id));
+
+  const mapped = candidates.filter((r) => knownIds.has(r.entityId));
+  const unmapped = candidates.filter((r) => !knownIds.has(r.entityId));
+
+  const unmappedIds = [...new Set(unmapped.map((r) => r.entityId))].sort((a, b) => a - b);
+  const unmappedViews = unmapped.reduce((sum, r) => sum + r.views, 0);
+  console.log(
+    `Mapped ${mapped.length} rows across ${knownIds.size} ids. ` +
+      `Dropped ${unmapped.length} rows / ${unmappedViews} views across ${unmappedIds.length} ids with no Model3D row: ` +
+      `[${unmappedIds.join(', ')}]`
+  );
+
+  const boundaryDay = previousDay(until);
+  const expectedBoundary = mapped
+    .filter((r) => r.createdDate === boundaryDay)
+    .reduce((sum, r) => sum + r.views, 0);
+
+  if (dryRun) {
+    const total = mapped.reduce((sum, r) => sum + r.views, 0);
+    console.log(`[DRY RUN] Would insert ${mapped.length} rows / ${total} views.`);
+    console.log(`[DRY RUN] Boundary day ${boundaryDay} would hold ${expectedBoundary} views.`);
+    return;
+  }
+
+  await clickhouse.insert({
+    table: 'daily_views',
+    values: mapped.map((r) => ({ entityType: 'Model3D', ...r })),
+    format: 'JSONEachRow',
+  });
+
+  // Read the boundary day back rather than assuming it. SummingMergeTree merges
+  // in the background, so this must sum across parts — a raw row read can show
+  // either the pre- or post-merge shape and both look reasonable.
+  const readback = await clickhouse.$query<{ views: string }>(`
+    SELECT sum(views) AS views FROM default.daily_views
+    WHERE entityType = 'Model3D' AND createdDate = '${boundaryDay}'
+  `);
+  const actualBoundary = Number(readback?.[0]?.views ?? 0);
+
+  console.log(
+    `Boundary day ${boundaryDay}: expected ${expectedBoundary}, stored ${actualBoundary}.`
+  );
+  if (actualBoundary !== expectedBoundary)
+    throw new Error(
+      `Boundary mismatch on ${boundaryDay}: expected ${expectedBoundary}, found ${actualBoundary}. ` +
+        `Inspect before re-running — this table sums, so a blind retry compounds the error.`
+    );
+
+  console.log(`Inserted ${mapped.length} rows.`);
+}
+
+if (require.main === module) {
+  main()
+    .then(() => process.exit(0))
+    .catch((e) => {
+      console.error(e instanceof Error ? e.message : e);
+      process.exit(1);
+    });
+}

--- a/scripts/oneoffs/model3d-view-tracking.sql
+++ b/scripts/oneoffs/model3d-view-tracking.sql
@@ -1,6 +1,6 @@
 -- Model3D view tracking — ClickHouse enum widening.
 --
--- APPLY ALL FOUR STEPS BEFORE DEPLOYING THE CODE THAT EMITS Model3DView, and run
+-- APPLY EVERY STEP BELOW BEFORE DEPLOYING THE CODE THAT EMITS Model3DView, and run
 -- steps 1-3 back to back without a pause. Between step 2 and step 3, `views`
 -- accepts a Model3D row while `daily_views_mv`'s declared header still holds
 -- nine arms — and if the MV push converts to its own header (the reason step 3

--- a/scripts/oneoffs/model3d-view-tracking.sql
+++ b/scripts/oneoffs/model3d-view-tracking.sql
@@ -1,0 +1,95 @@
+-- Model3D view tracking — ClickHouse enum widening.
+--
+-- APPLY ORDER (across the three tracking PRs):
+--   1. Scarlet's comics DDL FIRST (src/server/clickhouse/migrations/2026-08-17-comic-views.sql
+--      on feat/comic-view-tracking, PR #3993) — it takes enum indexes 10 and 11.
+--   2. Then this file. It takes index 12.
+--
+-- `ALTER TABLE ... MODIFY COLUMN` on an Enum8 REPLACES the whole type, it does
+-- not append to it. So every statement below restates all twelve arms,
+-- including Scarlet's 10 and 11. Applying a version of this file that omits her
+-- arms AFTER hers would silently delete 'ComicProject'/'ComicChapter' and
+-- invalidate any row already written with them.
+--
+-- Three columns carry an affected enum, not one: `views.entityType`,
+-- `views.type`, and `daily_views.entityType` (a separate enum on a separate
+-- table). All three are restated below.
+--
+-- ⚠️ Step 0 is not optional. Run it and confirm the current types match what
+-- this file expects before running anything else.
+--
+-- Appending enum values is metadata-only on both tables: no data rewrite, no
+-- part mutation, no downtime.
+
+-- === Step 0: confirm current state (read-only, run before anything else) =====
+SELECT table, name, type FROM system.columns
+WHERE database = 'default'
+  AND ((table = 'views' AND name IN ('type', 'entityType'))
+    OR (table = 'daily_views' AND name = 'entityType'))
+ORDER BY table, name;
+
+-- === Step 1: widen the MV target BEFORE the source ==========================
+-- `daily_views` is the sole materialized-view target carrying an Enum8 (verified
+-- against the other six MVs reading `views`: uniqueViewsDaily stores `type` as
+-- String, user_views/views_images_counts_mv compare the enum but store neither,
+-- and cohorts_first_seen/cohorts_monthly_activity/daily_user_counts_mv never
+-- reference it). If `views` were widened first, the first Model3D row would
+-- reach a target that cannot represent it.
+ALTER TABLE default.daily_views
+  MODIFY COLUMN entityType Enum8(
+    'User' = 1, 'Image' = 2, 'Post' = 3, 'Model' = 4, 'ModelVersion' = 5,
+    'Article' = 6, 'Collection' = 7, 'Bounty' = 8, 'BountyEntry' = 9,
+    'ComicProject' = 10, 'ComicChapter' = 11, 'Model3D' = 12
+  );
+
+-- === Step 2: widen the source table =========================================
+ALTER TABLE default.views
+  MODIFY COLUMN entityType Enum8(
+    'User' = 1, 'Image' = 2, 'Post' = 3, 'Model' = 4, 'ModelVersion' = 5,
+    'Article' = 6, 'Collection' = 7, 'Bounty' = 8, 'BountyEntry' = 9,
+    'ComicProject' = 10, 'ComicChapter' = 11, 'Model3D' = 12
+  );
+
+ALTER TABLE default.views
+  MODIFY COLUMN type Enum8(
+    'ProfileView' = 1, 'ImageView' = 2, 'PostView' = 3, 'ModelView' = 4,
+    'ModelVersionView' = 5, 'ArticleView' = 6, 'CollectionView' = 7,
+    'BountyView' = 8, 'BountyEntryView' = 9,
+    'ComicProjectView' = 10, 'ComicChapterView' = 11, 'Model3DView' = 12
+  );
+
+-- === Step 3: re-resolve the MV's own stored structure — AFTER steps 1 AND 2 ==
+-- `daily_views_mv` is a TO-materialized-view whose CREATE statement declares its
+-- own copy of the Enum8. Steps 1 and 2 do not rewrite that metadata, and if the
+-- MV converts pushed blocks to its declared structure rather than re-reading the
+-- target's, a Model3D row would fail the MV push — failing the insert into
+-- `views` for every view type, not just this one.
+--
+-- MODIFY QUERY re-derives the stored structure from the RESULT TYPES OF ITS
+-- SELECT, and that SELECT reads `default.views`. Running it before step 2 would
+-- re-derive the old nine-value enum off the un-widened source, pinning in place
+-- exactly the stale metadata this step exists to clear — and doing so in a way
+-- that looks handled. It must come last. (Caught by @scarlet; I had it between
+-- steps 1 and 2.)
+--
+-- The SELECT is the existing one restated byte-for-byte: this changes no
+-- behaviour, only the declared structure. Metadata-only.
+ALTER TABLE default.daily_views_mv
+  MODIFY QUERY
+    SELECT entityType, entityId, createdDate, count(*) AS views
+    FROM default.views
+    GROUP BY 1, 2, 3;
+
+-- === Step 4: verify (read-only) =============================================
+-- Expect three rows, each type ending in 'Model3D' = 12 / 'Model3DView' = 12 AND
+-- still carrying Scarlet's 10 and 11.
+SELECT table, name, type FROM system.columns
+WHERE database = 'default'
+  AND ((table = 'views' AND name IN ('type', 'entityType'))
+    OR (table = 'daily_views' AND name = 'entityType'))
+ORDER BY table, name;
+
+-- Confirms step 3 landed: the MV's own declared entityType must show twelve arms
+-- too, not nine.
+SELECT create_table_query FROM system.tables
+WHERE database = 'default' AND name = 'daily_views_mv';

--- a/scripts/oneoffs/model3d-view-tracking.sql
+++ b/scripts/oneoffs/model3d-view-tracking.sql
@@ -1,6 +1,14 @@
 -- Model3D view tracking — ClickHouse enum widening.
 --
--- APPLY ORDER (across the three tracking PRs):
+-- APPLY ALL FOUR STEPS BEFORE DEPLOYING THE CODE THAT EMITS Model3DView, and run
+-- steps 1-3 back to back without a pause. Between step 2 and step 3, `views`
+-- accepts a Model3D row while `daily_views_mv`'s declared header still holds
+-- nine arms — and if the MV push converts to its own header (the reason step 3
+-- exists), that push fails. Every view type on the site shares that insert path,
+-- and the client is configured `wait_for_async_insert: 0`, so the failure
+-- surfaces in Axiom and nowhere a human is looking.
+--
+-- APPLY ORDER ACROSS THE THREE TRACKING PRs:
 --   1. Scarlet's comics DDL FIRST (src/server/clickhouse/migrations/2026-08-17-comic-views.sql
 --      on feat/comic-view-tracking, PR #3993) — it takes enum indexes 10 and 11.
 --   2. Then this file. It takes index 12.
@@ -15,13 +23,17 @@
 -- `views.type`, and `daily_views.entityType` (a separate enum on a separate
 -- table). All three are restated below.
 --
--- ⚠️ Step 0 is not optional. Run it and confirm the current types match what
--- this file expects before running anything else.
---
--- Appending enum values is metadata-only on both tables: no data rewrite, no
--- part mutation, no downtime.
+-- Appending is metadata-only ONLY because every existing name→index pair is
+-- preserved. `entityType` is a sorting-key column in both tables, so renumbering
+-- or dropping an arm turns this from a metadata change into a rewrite of 1.68B
+-- `daily_views` rows and the whole of `views`.
 
--- === Step 0: confirm current state (read-only, run before anything else) =====
+-- === Step 0: confirm the starting state (read-only) =========================
+-- EXPECTED: all three types end at 'BountyEntry' = 9 / 'BountyEntryView' = 9 if
+-- Scarlet's file has not run yet, or at 'ComicChapter' = 11 /
+-- 'ComicChapterView' = 11 if it has. Anything carrying an arm past 11 means a
+-- migration this file does not know about has claimed indexes — STOP and
+-- reconcile, because the statements below would overwrite it.
 SELECT table, name, type FROM system.columns
 WHERE database = 'default'
   AND ((table = 'views' AND name IN ('type', 'entityType'))
@@ -29,12 +41,9 @@ WHERE database = 'default'
 ORDER BY table, name;
 
 -- === Step 1: widen the MV target BEFORE the source ==========================
--- `daily_views` is the sole materialized-view target carrying an Enum8 (verified
--- against the other six MVs reading `views`: uniqueViewsDaily stores `type` as
--- String, user_views/views_images_counts_mv compare the enum but store neither,
--- and cohorts_first_seen/cohorts_monthly_activity/daily_user_counts_mv never
--- reference it). If `views` were widened first, the first Model3D row would
--- reach a target that cannot represent it.
+-- `daily_views` is the sole materialized-view target carrying an Enum8. If
+-- `views` were widened first, the first Model3D row would reach a target that
+-- cannot represent it.
 ALTER TABLE default.daily_views
   MODIFY COLUMN entityType Enum8(
     'User' = 1, 'Image' = 2, 'Post' = 3, 'Model' = 4, 'ModelVersion' = 5,
@@ -60,20 +69,13 @@ ALTER TABLE default.views
 
 -- === Step 3: re-resolve the MV's own stored structure — AFTER steps 1 AND 2 ==
 -- `daily_views_mv` is a TO-materialized-view whose CREATE statement declares its
--- own copy of the Enum8. Steps 1 and 2 do not rewrite that metadata, and if the
--- MV converts pushed blocks to its declared structure rather than re-reading the
--- target's, a Model3D row would fail the MV push — failing the insert into
--- `views` for every view type, not just this one.
+-- own copy of the Enum8, which steps 1 and 2 do not rewrite.
 --
--- MODIFY QUERY re-derives the stored structure from the RESULT TYPES OF ITS
--- SELECT, and that SELECT reads `default.views`. Running it before step 2 would
+-- MODIFY QUERY re-derives that stored structure from the RESULT TYPES OF ITS
+-- SELECT, and the SELECT reads `default.views`. Running it before step 2 would
 -- re-derive the old nine-value enum off the un-widened source, pinning in place
 -- exactly the stale metadata this step exists to clear — and doing so in a way
--- that looks handled. It must come last. (Caught by @scarlet; I had it between
--- steps 1 and 2.)
---
--- The SELECT is the existing one restated byte-for-byte: this changes no
--- behaviour, only the declared structure. Metadata-only.
+-- that looks handled. It must come last.
 ALTER TABLE default.daily_views_mv
   MODIFY QUERY
     SELECT entityType, entityId, createdDate, count(*) AS views
@@ -81,8 +83,8 @@ ALTER TABLE default.daily_views_mv
     GROUP BY 1, 2, 3;
 
 -- === Step 4: verify (read-only) =============================================
--- Expect three rows, each type ending in 'Model3D' = 12 / 'Model3DView' = 12 AND
--- still carrying Scarlet's 10 and 11.
+-- Expect three rows, each carrying 'Model3D' = 12 / 'Model3DView' = 12 AND still
+-- carrying Scarlet's 10 and 11.
 SELECT table, name, type FROM system.columns
 WHERE database = 'default'
   AND ((table = 'views' AND name IN ('type', 'entityType'))

--- a/src/pages/3d-models/[id]/[[...slug]].tsx
+++ b/src/pages/3d-models/[id]/[[...slug]].tsx
@@ -63,6 +63,7 @@ import { NextLink as Link } from '~/components/NextLink/NextLink';
 import { PageLoader } from '~/components/PageLoader/PageLoader';
 import { RenderHtml } from '~/components/RenderHtml/RenderHtml';
 import { ShareButton } from '~/components/ShareButton/ShareButton';
+import { TrackView } from '~/components/TrackView/TrackView';
 import { dialogStore } from '~/components/Dialog/dialogStore';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
@@ -359,6 +360,7 @@ function Model3DDetailsPage({ id }: InferGetServerSidePropsType<typeof getServer
         deIndex: isDraft || isUnpublished,
       }}
     >
+      <TrackView entityId={model3d.id} entityType="Model3D" type="Model3DView" />
       <Container size="xl" pos="relative" className="pb-8">
         <LoadingOverlay visible={isRefetching} />
 

--- a/src/server/clickhouse/tracker.ts
+++ b/src/server/clickhouse/tracker.ts
@@ -56,7 +56,8 @@ export type ViewType =
   | 'ArticleView'
   | 'CollectionView'
   | 'BountyView'
-  | 'BountyEntryView';
+  | 'BountyEntryView'
+  | 'Model3DView';
 
 export type UserActivityType =
   | 'Registration'

--- a/src/server/schema/track.schema.ts
+++ b/src/server/schema/track.schema.ts
@@ -11,6 +11,7 @@ export const addViewSchema = z.object({
     'ArticleView',
     'BountyView',
     'BountyEntryView',
+    'Model3DView',
   ]),
   entityType: z.enum([
     'User',
@@ -21,6 +22,7 @@ export const addViewSchema = z.object({
     'Article',
     'Bounty',
     'BountyEntry',
+    'Model3D',
   ]),
   entityId: z.number(),
   ads: z.enum(['Member', 'Blocked', 'Served', 'Off']).optional(),


### PR DESCRIPTION
## ⚠️ Apply order — read before merging or applying anything

This is one of three parallel view-tracking PRs. The ClickHouse DDL in all three touches the **same two `Enum8` columns**, and `ALTER TABLE ... MODIFY COLUMN` on an enum **replaces the whole type — it does not append**.

**This PR's DDL is last. Scarlet's comics DDL takes enum indexes 10 and 11 and must be applied first. This one takes 12 and restates all twelve arms, including hers.**

That ordering is not a convention, it is load-bearing: a version of this file that omitted her arms and ran after hers would silently delete `ComicProject`/`ComicChapter` and invalidate every row already written with them. `scripts/oneoffs/model3d-view-tracking.sql` opens with a read-only step that prints the current column types so the applier confirms the expected starting state before running anything.

Appending enum values is **metadata-only** on both `views` and `daily_views` — no data rewrite, no part mutation, no downtime.

**Nothing in this PR has been applied to production.** The SQL needs a human to run it.

## What this adds

3D models had no entity view tracking: no `TrackView` on any `/3d-models` route, no `Model3D` arm in the ClickHouse enums, nothing in `daily_views`. `pageViews` has the history but nothing reads it.

- **Live tracking.** One `<TrackView entityId entityType="Model3D" type="Model3DView" />` on the detail page, reusing the existing `TrackView` → `/api/internal/pulse` → `Tracker.view()` path. No new component, no new endpoint, no new rollup table, no materialized view.
- **Enum arms.** `Model3DView` in `ViewType` (`tracker.ts`) and both arms in `addViewSchema` (`track.schema.ts`). The Postgres `EntityType` enum already had `Model3D`, so `Tracker.view()` needed no change.
- **Cutover constant.** `MODEL3D_VIEW_TRACKING_CUTOVER` + `MODEL3D_VIEW_TRACKING_NOTE` in `packages/civitai-shared/src/model3d-views.constants.ts`, re-exported from `@civitai/shared` so the Creator Studio can mark the pre-cutover span instead of hardcoding a date.
- **Backfill.** `scripts/oneoffs/backfill-model3d-views.ts` fills `daily_views` from `pageViews` history so the Studio has data on day one.
- **DDL.** `scripts/oneoffs/model3d-view-tracking.sql`.

### No new rollup table and no materialized view

`daily_views` is `ORDER BY (entityType, entityId, createdDate)`, so once it knows the `Model3D` arm a per-creator query is a primary-key prefix seek over at most 539 ids. An owner-keyed MV is the pattern for a creator's ids scattered across a huge id space; this is the opposite case.

Ownership resolves from Postgres (`Model3D.userId` → ids → literal `IN`). ClickHouse has no `Model3D` table and no ownership table for anything but images.

## What counts as a view

**One load of a 3D model's public detail page.** `/3d-models/<id>/edit` and `/3d-models/<id>/reviews` are excluded, on both sides of the cutover.

The edit page is the owner's own authoring surface, not consumption. Reviews is 174 rows in 30 days — 0.2% — and including it makes the label fuzzy for no signal.

**They are excluded by name, not by path shape, and that distinction matters.** `/3d-models/481/edit` and `/3d-models/481/my-slug` are structurally identical: one id, one segment. An anchored id regex alone matches the edit page perfectly happily — verified in ClickHouse's own RE2, where `^/3d-models/([0-9]+)(?:[/?#]|$)` extracted id 481 from 41 edit-page rows.

Known and accepted: a 3D model whose slug is literally `edit` or `reviews` would be excluded. That ambiguity already exists in the app's routing — Next resolves the static `[id]/edit` route ahead of the `[[...slug]]` catch-all — so the URL was never reaching the detail page anyway.

Also accepted, for parity with `ModelView` on `/models`: views are counted unconditionally, including an owner viewing their own draft or unpublished model. The backfill cannot distinguish self-views either, so making live tracking stricter than the backfill would put a visible step at the cutover.

## Regex verified in RE2, against production

Cross-checked in ClickHouse rather than only in a unit test, because a pattern can pass in Node and behave differently in RE2 — a plausible wrong number under a green suite. 30 days of `pageViews`:

| bucket | rows |
|---|---|
| counted (detail) | 82,319 across 426 ids |
| excluded — edit + reviews | 399 |
| excluded — index `/3d-models` | 200,231 |
| excluded — junk | 21 |

The junk bucket is the reason the pattern is anchored: `/3d-models#`, `/3d-modelshttps:/cyberdrop.cr`, and a URL-encoded Japanese SEO-spam string. Hostile path values are real.

Over 90 days, 471 of 473 viewed ids map to a live `Model3D` row. The two that don't are id `0` and id `2966359` (a Model id in a 3D-model URL). **The backfill reports them and drops them rather than absorbing them.**

## Backfill safety

`daily_views` is a `SummingMergeTree`: a second run does not overwrite, it **adds**, and the result looks entirely plausible. So:

- `--until` is **required** and **exclusive**, and must equal `MODEL3D_VIEW_TRACKING_CUTOVER`. It cannot be overridden from the CLI — if the cutover moves, the constant changes.
- **The cutover is checked against live data, not trusted.** The script refuses to run until `views` actually holds a `Model3DView`, then asserts that the first such day *is* `--until`. Without this, nothing tied the constant to the deploy: land a day early and the guard refuses the whole backfill, land a day late and that day gets neither backfill nor tracking — a permanently empty day nothing flags. Run this last, after the DDL and after the deploy.
- It **refuses to run** if `daily_views` already holds `Model3D` rows in the range.
- **It waits for the insert.** The shared client is built with `wait_for_async_insert: 0`, so by default `insert()` resolves once the server has buffered the batch — before it is queryable, and without surfacing a server-side insert error at all. This one call overrides that.
- **It verifies the whole written range** (count + sum) against what it aggregated, and fails loudly rather than assuming the write landed. The read-back sums across parts, because a background merge can leave either shape and both look reasonable.
- Malformed dates are rejected before reaching SQL.

## 🔴 A risk worth a second reviewer's eyes

`daily_views_mv` is a `TO`-materialized-view that declares **its own copy** of the `Enum8` in its CREATE statement. `ALTER TABLE daily_views MODIFY COLUMN` does not rewrite that MV metadata.

If the MV converts to its declared structure rather than re-reading the target's, the first `Model3D` row inserted into `views` fails the MV push — which fails the insert for **every view type on the site**, not just this one.

There is one ClickHouse (prod), so this could not be tested without a write. **Step 3 of the SQL adds `ALTER TABLE daily_views_mv MODIFY QUERY`, restating the existing SELECT byte-for-byte** — metadata-only, changes no behaviour, and correct whichever way the conversion actually works.

**That step has to run last, and I had it wrong.** My first version placed it between the two table ALTERs. `MODIFY QUERY` re-derives the MV's declared structure from the *result types of its SELECT*, and that SELECT reads `default.views` — so running it before `views` is widened re-derives the old nine-arm enum off the un-widened source, pinning in place exactly the staleness the step exists to clear, while reading as handled. Caught by @scarlet on the comics PR; the reasoning is in the file so the next reader gets it rather than just the order. Final order: `daily_views` → `views` → `daily_views_mv MODIFY QUERY`.

The other six MVs reading `views` are unaffected: `uniqueViewsDaily` stores `type` as `String`, `user_views` and `views_images_counts_mv` compare the enum but store neither, and `cohorts_first_seen` / `cohorts_monthly_activity` / `daily_user_counts_mv` never reference it. Verified off `system.columns` and each `create_table_query`.

## Scale

539 `Model3D` rows, 414 published, 17 deleted, 280 creators, first created 2026-06-19.

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm run lint` — the four new files are clean; the two edited files carry only pre-existing warnings, none at the changed lines
- `pnpm run prettier:write`
- `pnpm run test:unit:run` — 1098 files / 17131 tests passed, 1 file + 23 tests skipped
- New: `scripts/__tests__/backfill-model3d-views.test.ts` (6 tests) — cutover enforcement, missing/malformed/inverted ranges, `--dry-run`. There is deliberately **no test of `DETAIL_PREDICATE`**: it is evaluated by ClickHouse's RE2 and never by Node, so a Node assertion on it can only be a change-detector. It is verified against prod instead (numbers above).

## Second commit: what the reviews changed

Two subagent reviews ran against the first commit — one adversarial (safety, ClickHouse load, reuse, boundary handling), one simplification. The follow-up commit is **111 insertions against 136 deletions**. The findings that mattered:

1. **The write verification would have failed on a successful run.** `wait_for_async_insert: 0` meant the read-back raced the async flush, read 0, threw `Boundary mismatch`, and exited 1 — *after* the data was written. The retry would then hit this script's own "already holds N rows" guard and refuse. Non-deterministic: on a slow box the flush lands first and it passes.
2. **The verification only checked one day out of sixty.** A partial write losing June and July but landing the last day passed. And if the boundary day had no mapped rows, `0 === 0` verified nothing while reading as a verification.
3. **Nothing connected the cutover constant to the deploy** (see above).
4. **The DDL never said to apply before deploying the emitting code**, or to run steps 1-3 without a pause. That is load-bearing given step 3 moved last.
5. **`containers/clickhouse/docker-init/init.sh` still declared the nine-arm enums** in four places, so a fresh local container would silently drop every `Model3DView` row — `Tracker.track` swallows the error to Axiom. A developer would see a page that tracks nothing, with no error anywhere. This gap is shared with the comics PR; neither branch had touched it.
6. **Two of my tests were vacuous.** Both `DETAIL_PREDICATE` assertions matched substrings present in the *surviving* half of the predicate — delete the positive `match()` entirely and both still pass. Deleted rather than patched.
7. The documented `npx ts-node` invocation could not have resolved the `~/` imports; it is `npm run tsscript` like every sibling one-off.

Kept against advice: `MODEL3D_VIEW_TRACKING_NOTE` has no importer today and was flagged as speculative surface. It is there because the Creator Studio needs it to caption the pre-cutover span, which is the next PR.

## Third commit: applying the DDL created a new hazard

A third review ran against the fix commit, since fixes written under review pressure are where new bugs go and nobody had read that commit. It found one that only exists *because* the migration was applied.

**Before the enum widening, a `Model3DView` row could not be written — the nine-arm enum rejected it. That rejection was protecting us from something nobody had designed for.** Local dev's `CLICKHOUSE_HOST` is the same instance as prod (dev is prod-except-Postgres), and this branch puts a real `TrackView` on a real page on the normal `/api/internal/pulse` path. So now: anyone running a dev server or preview deploy on this branch who opens a 3D model page writes a genuine tracking row into prod `views`, and the MV derives a `daily_views` row from it.

That breaks the cutover guard added in the second commit, which took a bare `min(createdDate)`. One stray dev page load makes it report that day as the cutover and instruct the operator to set the constant to it — after which the backfill covers up to the stray day and live tracking covers from the real one, and **the days between are written by neither, permanently.** The guard would have been steering into data loss behind a confident error message.

- The cutover is now the first day clearing a floor no incidental page load reaches (50 rows, against ~2,700/day of real traffic). Sub-floor days before it are **reported**, not silently skipped.
- The mismatch error no longer prescribes a lossy repair as though it were the fix. The mismatched day is almost always partial (tracking starts mid-day), so it names both options — accept the partial day, or move to the next UTC midnight and lose nothing — and says not to take the first by default.
- **`select_sequential_consistency` on the readback.** Prod is a two-replica `SharedMergeTree` behind a load balancer; `wait_for_async_insert` guarantees the write committed, not that the next query's replica has caught up. A stale read reports a false failure, and the pre-flight guard then blocks the retry.
- Restored the `Number()` coercion the second commit dropped — it was what kept the script from depending on a client-level output-format setting.
- `--dry-run` works before the deploy again; the live check had broken it.

**A correction to the second commit's own message.** It claimed both deleted `DETAIL_PREDICATE` tests were vacuous. Only one was. The other asserted the `NOT match(... edit|reviews ...)` clause exists and *would* have failed on a real revert — it broke for an unrelated reason when the pattern moved into a shared constant, and was deleted under the wrong justification. Restored in a form that survives the refactor.

Verified clean by that review, with checks named: per-call `clickhouse_settings` genuinely override the client's (read from `@clickhouse/client@0.2.10` source, not docs); no `SummingMergeTree` merge can collapse inserted rows, since each is unique on `(entityType, entityId, createdDate)`; the interpolated `ID_PATTERN` is byte-identical in behaviour to the pre-refactor literal (174,436 rows either way over the real window); all four `init.sh` declarations were found and none missed; nothing imports the script, so dropping the `require.main` guard is safe.

## Merge-conflict warning for whoever lands second

`containers/clickhouse/docker-init/init.sh` lines 391, 891, 894 and 1387 are edited by **both** this PR and the comics PR (#3993). Git will conflict on the same lines, so it should not pass silently — but **the resolution must keep both sets of arms**: `'ComicProject' = 10, 'ComicChapter' = 11` and `'Model3D' = 12`. The SQL file's warning about enum restatement covers the prod DDL only, not this file. Scarlet has agreed to take the conflict if she merges second.

## Prod state

The DDL described above **has been applied**, with Justin's approval, and verified: all three columns plus the MV's own declared header carry twelve arms. A write probe confirmed the full path end to end — one row into `views`, out of the MV into `daily_views` as exactly 1, both tables cleaned back to zero. Metadata verification alone would not have proven the MV push works, which was the whole risk.

Not fixed here, flagged for someone to own: Scarlet's DDL lives at `src/server/clickhouse/migrations/` and this one at `scripts/oneoffs/`. Neither path exists for this purpose on `main` — two conventions in one week for files applied in sequence by one operator. Worth picking one before both land.
