### PR TITLE
fix(newsletter): handle the un-awaited settings-write rejection, and teach no-io-in-transaction the Promise.all shape

### DIFF
--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -39,6 +39,34 @@
  *     it. I/O between it and `commit()` burns the same budget, invisibly.
  *   - a named (non-inline) callback, same as the Prisma gap noted below.
  *
+ * KNOWN GAPS in WHICH AWAITED EXPRESSIONS ARE READ (the shapes below are inside
+ * a correctly-detected callback; the rule simply cannot see the call):
+ *   - the awaited value came from a VARIABLE: `const p = bustUserSettings(id);
+ *     await p;` — resolving it needs scope analysis this rule does not do. Same
+ *     for an array built in a variable: `await Promise.all(jobs)`.
+ *   - a combinator argument that is neither an array literal nor an inline
+ *     `.map`/`.flatMap` callback: `await Promise.all(ids.map(makeJob))`,
+ *     `await Promise.all([...jobs, bust(id)])` (the SPREAD element specifically —
+ *     the sibling elements beside it ARE read).
+ *   - `await (cond ? bustUserSettings(id) : Promise.resolve())` — a conditional
+ *     is not unwrapped.
+ *   - a call reached through a locally aliased binding: `const b =
+ *     bustUserSettings; await b(id);` — detection is by CALLED NAME, never
+ *     resolved to an import.
+ * 🔴 A shape absent from BOTH lists above is NOT thereby covered. These are the
+ * ones someone went looking for; the honest summary of this rule is that it reads
+ * a curated set of syntactic shapes, so treat a clean run as "none of the shapes
+ * below the awaits I can read", not "no I/O in any transaction".
+ *
+ * DELIBERATELY out of scope, not a gap: an UN-AWAITED call —
+ * `void bustUserSettings(id)`, `logToAxiom({})` on its own line, or
+ * `bustUserSettings(id).catch(noop)`. Those do not consume the transaction's
+ * wall-clock budget, and "make pure-logging calls fire-and-forget" is one of the
+ * two fixes this rule's own message prescribes. Flagging them would flag the
+ * remedy. (A fire-and-forget write is a different hazard — it can outlive a
+ * rolled-back transaction — but it is not THIS rule's, and it has no timeout to
+ * blow.) Pinned by a `valid` case in the rule's test file.
+ *
  * Interactive transactions hold a DB connection open under a wall-clock
  * timeout (Prisma default 5000ms, or an explicit `{ timeout }`). An awaited
  * network call inside the callback (HTTP fetch, image scanner, Buzz API,
@@ -54,6 +82,34 @@
  * Detection is a curated denylist of known I/O call names (low false-positive,
  * extend as new I/O helpers appear). Calls on the transaction client itself
  * (`tx.*`, including `tx.$queryRaw` / `tx.$executeRaw`) are always allowed.
+ *
+ * An `await` is read through three wrappers before the denylist is consulted:
+ * `.catch()/.then()/.finally()`; `Promise.all/allSettled/race/any` over an ARRAY
+ * LITERAL, whose elements are then each read the same way; and an inline
+ * `.map`/`.flatMap` callback with a concise (non-block) body passed to one of
+ * those combinators. One `await` can therefore report several calls. The
+ * combinator forms were added because `await Promise.all([cache.refresh(id),
+ * bustUserSettings(id)])` — the exact line in model.service.ts that motivated
+ * adding those two names to the denylist — passes its I/O as ARGUMENTS and so
+ * was invisible to the plain awaited-call walk. Measured on the pre-change rule:
+ * that shape produced 0 hits while the three direct-await cases beside it all
+ * flagged. Read the two gap lists above for what this still does not see.
+ *
+ * Blast radius of adding the combinator forms, measured over every .ts/.tsx under
+ * `src/` and `packages/` (5,310 files, 0 parse errors) with the rule run in
+ * isolation, immediately before and after the change: 6 reports -> 7. The one new
+ * report is a TRUE positive that was invisible before —
+ * `invalidateManyImageExistence(imageIds)` (N Redis `set`s) sharing a
+ * `Promise.all` with a legitimate `tx.image.deleteMany` inside
+ * `deleteBountyEntry`'s Prisma transaction, src/server/services/bountyEntry.service.ts.
+ * It is left reported rather than fixed here: hoisting a cache invalidation out of
+ * a transaction is a behaviour change to bounty deletion and wants its own diff,
+ * the same treatment `bugReportCounter` got from no-module-scope-cache. The rule
+ * is 'warn' and the file pre-exists, so it annotates and blocks nothing — see the
+ * severity note in .eslintrc.js.
+ *
+ * Re-derive that census rather than trusting the numbers above; they move.
+ *
  * Intentional exceptions should use:
  *   // eslint-disable-next-line local-rules/no-io-in-transaction -- <reason>
  */
@@ -94,6 +150,29 @@ const IO_CALL_NAMES = new Set([
 // underlying call (e.g. `await foo().catch(() => null)` -> inspect `foo()`).
 const PASSTHROUGH_MEMBERS = new Set(['catch', 'then', 'finally']);
 
+/**
+ * `Promise.<x>(...)` statics that AWAIT their operands as a unit. An
+ * `await Promise.all([bust(id), refresh(id)])` puts both calls on the
+ * transaction's clock exactly as two consecutive `await`s would — the calls are
+ * ARGUMENTS rather than the awaited expression, which is the only reason the
+ * plain awaited-call walk missed them. `race`/`any` are included because the
+ * operands still all START inside the transaction; settling early does not
+ * cancel the losers, so their latency is on the same budget as the winner's.
+ */
+const PROMISE_COMBINATORS = new Set(['all', 'allSettled', 'race', 'any']);
+
+/**
+ * Array methods that invoke their callback SYNCHRONOUSLY, so
+ * `Promise.all(ids.map((i) => bust(i)))` really does run `bust` inside the
+ * transaction. Restricted to these two on purpose: a callback passed to anything
+ * else (`register(cb)`, `on('x', cb)`, `describe(cb)`) may be stored and run
+ * later, and reading it would report deferred work that never touches the
+ * transaction's budget. Only the CONCISE-body form needs reading here: the
+ * block-bodied `ids.map(async (i) => { await bust(i); })` is already reported by
+ * the function-stack walk, so reading it here too would report it twice.
+ */
+const EAGER_ITERATION_METHODS = new Set(['map', 'flatMap']);
+
 /** Walk a member chain to its root object identifier name (e.g. tx.user.x -> "tx"). */
 function rootObjectName(node) {
   let cur = node;
@@ -113,12 +192,66 @@ function calleeName(callExpr) {
   return null;
 }
 
+/** `Promise.all(...)` / `.allSettled` / `.race` / `.any`. */
+function isPromiseCombinatorCall(expr) {
+  const callee = expr.callee;
+  return (
+    callee &&
+    callee.type === 'MemberExpression' &&
+    callee.object &&
+    callee.object.type === 'Identifier' &&
+    callee.object.name === 'Promise' &&
+    callee.property &&
+    callee.property.type === 'Identifier' &&
+    PROMISE_COMBINATORS.has(callee.property.name)
+  );
+}
+
 /**
- * Resolve the "effective" I/O call inside an awaited expression, unwrapping
- * `.catch()/.then()/.finally()` passthroughs. Returns { name, node } or null.
+ * For a combinator argument, the expression(s) that are evaluated inside the
+ * transaction: an array literal's own elements, or an eagerly-invoked
+ * `.map`/`.flatMap` callback's concise body.
  */
-function resolveIoCall(expr, txParamNames) {
-  if (!expr || expr.type !== 'CallExpression') return null;
+function combinatorOperands(arg) {
+  if (!arg) return [];
+  if (arg.type === 'ArrayExpression') {
+    // Returned whole. A hole (`[, x]`) is null and a `...spread` is a
+    // SpreadElement — neither is a CallExpression, so `collectIoCalls` drops both
+    // on its own; filtering them here would be an unkillable no-op. The spread's
+    // own array stays unresolvable (KNOWN GAPS), but its SIBLINGS are read.
+    return arg.elements;
+  }
+  if (
+    arg.type === 'CallExpression' &&
+    arg.callee.type === 'MemberExpression' &&
+    arg.callee.property &&
+    arg.callee.property.type === 'Identifier' &&
+    EAGER_ITERATION_METHODS.has(arg.callee.property.name)
+  ) {
+    // The callback's BODY, whatever it is. A CONCISE body is an expression, so an
+    // I/O call there is read. A BLOCK body is a BlockStatement and a non-function
+    // argument has no `body` at all — `collectIoCalls` drops both, which is not an
+    // accident: the block-bodied form's `await` is already reported by the
+    // function-stack walk, and descending into it here would report the same call
+    // TWICE. (An earlier draft filtered these out explicitly; that filter could not
+    // be killed by any mutation, because it only ever removed nodes
+    // `collectIoCalls` was going to reject anyway.)
+    return (arg.arguments || []).map((cb) => cb.body);
+  }
+  return [];
+}
+
+/**
+ * Collect every I/O call an awaited expression puts on the transaction's clock,
+ * unwrapping `.catch()/.then()/.finally()` passthroughs and descending through
+ * `Promise.all([...])`-style combinators. Appends `{ name, node }` to `out`.
+ *
+ * `depth` bounds the recursion: the shapes above nest (a combinator inside a
+ * `.catch()` inside a combinator), and a bound keeps a pathological or
+ * self-referential source from blowing the stack inside a lint run.
+ */
+function collectIoCalls(expr, txParamNames, out, depth) {
+  if (!expr || expr.type !== 'CallExpression' || depth > 8) return out;
   const name = calleeName(expr);
 
   // Unwrap promise passthroughs: await foo().catch(...) -> inspect foo()
@@ -128,15 +261,26 @@ function resolveIoCall(expr, txParamNames) {
     expr.callee.type === 'MemberExpression' &&
     expr.callee.object
   ) {
-    return resolveIoCall(expr.callee.object, txParamNames);
+    return collectIoCalls(expr.callee.object, txParamNames, out, depth + 1);
+  }
+
+  // `await Promise.all([bust(id), refresh(id)])` — the calls are arguments, not
+  // the awaited expression, but every one of them runs on the txn's budget.
+  if (isPromiseCombinatorCall(expr)) {
+    for (const arg of expr.arguments || []) {
+      for (const operand of combinatorOperands(arg)) {
+        collectIoCalls(operand, txParamNames, out, depth + 1);
+      }
+    }
+    return out;
   }
 
   // Allow calls on the transaction client itself: tx.*(...), tx.$queryRaw`...`
   const root = rootObjectName(expr.callee);
-  if (root && txParamNames.has(root)) return null;
+  if (root && txParamNames.has(root)) return out;
 
-  if (name && IO_CALL_NAMES.has(name)) return { name, node: expr };
-  return null;
+  if (name && IO_CALL_NAMES.has(name)) out.push({ name, node: expr });
+  return out;
 }
 
 const noIoInTransaction = {
@@ -234,8 +378,9 @@ const noIoInTransaction = {
       AwaitExpression(node) {
         if (txStack.length === 0) return;
         const txParamNames = txStack[txStack.length - 1];
-        const io = resolveIoCall(node.argument, txParamNames);
-        if (io) {
+        // One await can carry several I/O calls (`Promise.all([a(), b()])`), and
+        // each is a separate thing to move out — report them individually.
+        for (const io of collectIoCalls(node.argument, txParamNames, [], 0)) {
           context.report({ node: io.node, messageId: 'ioInTx', data: { name: io.name } });
         }
       },

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -246,12 +246,20 @@ function combinatorOperands(arg) {
  * unwrapping `.catch()/.then()/.finally()` passthroughs and descending through
  * `Promise.all([...])`-style combinators. Appends `{ name, node }` to `out`.
  *
- * `depth` bounds the recursion: the shapes above nest (a combinator inside a
- * `.catch()` inside a combinator), and a bound keeps a pathological or
- * self-referential source from blowing the stack inside a lint run.
+ * Unbounded on purpose. Every recursive step moves STRICTLY to a child node
+ * (`expr.callee.object`, or an operand of `expr`), and a parsed ESLint AST is
+ * finite and acyclic, so the recursion terminates at the tree's own depth — the
+ * `walkSkippingFunctions` helper further down this file recurses the same way. A
+ * draft carried a `depth > 8` cut-off with a comment about self-referential
+ * sources blowing the stack; nothing can produce that input, and removing it,
+ * loosening it to 1000, and dropping its increment on the passthrough branch all
+ * survived the rule's 54-test suite. Only tightening it to 1 was caught, i.e. it
+ * only ever measured itself. It went the way of the two other guards this rule
+ * shed for the same reason — a guard nothing can kill is not protection, it is a
+ * comment claiming protection.
  */
-function collectIoCalls(expr, txParamNames, out, depth) {
-  if (!expr || expr.type !== 'CallExpression' || depth > 8) return out;
+function collectIoCalls(expr, txParamNames, out) {
+  if (!expr || expr.type !== 'CallExpression') return out;
   const name = calleeName(expr);
 
   // Unwrap promise passthroughs: await foo().catch(...) -> inspect foo()
@@ -261,7 +269,7 @@ function collectIoCalls(expr, txParamNames, out, depth) {
     expr.callee.type === 'MemberExpression' &&
     expr.callee.object
   ) {
-    return collectIoCalls(expr.callee.object, txParamNames, out, depth + 1);
+    return collectIoCalls(expr.callee.object, txParamNames, out);
   }
 
   // `await Promise.all([bust(id), refresh(id)])` — the calls are arguments, not
@@ -269,7 +277,7 @@ function collectIoCalls(expr, txParamNames, out, depth) {
   if (isPromiseCombinatorCall(expr)) {
     for (const arg of expr.arguments || []) {
       for (const operand of combinatorOperands(arg)) {
-        collectIoCalls(operand, txParamNames, out, depth + 1);
+        collectIoCalls(operand, txParamNames, out);
       }
     }
     return out;
@@ -380,7 +388,7 @@ const noIoInTransaction = {
         const txParamNames = txStack[txStack.length - 1];
         // One await can carry several I/O calls (`Promise.all([a(), b()])`), and
         // each is a separate thing to move out — report them individually.
-        for (const io of collectIoCalls(node.argument, txParamNames, [], 0)) {
+        for (const io of collectIoCalls(node.argument, txParamNames, [])) {
           context.report({ node: io.node, messageId: 'ioInTx', data: { name: io.name } });
         }
       },

--- a/src/server/services/__tests__/newsletter-settings-mirror.test.ts
+++ b/src/server/services/__tests__/newsletter-settings-mirror.test.ts
@@ -117,7 +117,14 @@ describe('updateSubscription — the settings mirror write', () => {
 
     expect(logToAxiom).toHaveBeenCalledTimes(1);
     const [payload] = logToAxiom.mock.calls[0] as [Record<string, unknown>];
-    expect(payload.type).toBe('newsletter.settings-mirror.failed');
+    // 🔴 `type` is the SEVERITY the log pipeline reads as the level, NOT a free-text
+    // event name — so it is asserted against a severity WORD. An earlier revision put
+    // the event name in `type`, which lands the line at no recognised level and makes
+    // it findable only by someone who already knows the string. Since "the failure is
+    // still recorded" is the entire justification for swallowing this error, that is
+    // the assertion that has to exist. The event name belongs in `name`.
+    expect(payload.type).toBe('warning');
+    expect(payload.name).toBe('newsletter-settings-mirror-failed');
     // The REAL `safeError` (the canonical logging mock overrides only `logToAxiom`), so this
     // pins what actually reaches Axiom rather than what a local stub was told to return.
     // `toMatchObject` because the real helper also carries `stack` and the cause/inner

--- a/src/server/services/__tests__/newsletter-settings-mirror.test.ts
+++ b/src/server/services/__tests__/newsletter-settings-mirror.test.ts
@@ -27,10 +27,27 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  * on the pre-change code too.
  */
 
+/**
+ * `~/server/db/client` and `~/server/logging/client` are NOT mocked here. Both have a
+ * canonical mock registered globally in src/__tests__/setup.ts, and mocking them per file
+ * is what `no-direct-shared-module-mock` forbids — see docs/testing/shared-module-mocks.md.
+ * `dbRead` is unused by the path under test (only `getSubscription` touches it) so nothing
+ * from `db.mock` is imported either.
+ *
+ * 🔴 Consequence worth stating, because it makes one assertion below STRONGER rather than
+ * weaker: the canonical logging registration spreads the ORIGINAL module and overrides only
+ * `logToAxiom`, so `safeError` is the REAL implementation. An earlier draft of this file
+ * stubbed `safeError` to `{ message }` and then asserted the payload equalled `{ message }`
+ * — an expectation derived from the stub rather than from anything the code does. The
+ * codemod refused to convert that mock for exactly this reason ("factory replaces `safeError`
+ * with behaviour — it is a control surface, not a redundant re-export"), which was correct.
+ * The assertion now runs the real `safeError` and pins the fields it actually produces.
+ */
 const setUserSetting = vi.fn();
 const setSubscription = vi.fn();
-const logToAxiom = vi.fn(() => Promise.resolve());
 
+// Neither specifier below has a canonical mock: `~/server/services/user.service` is on the
+// PENDING list (counted, not enforced) and `~/server/integrations/beehiiv` is unguarded.
 vi.mock('~/server/services/user.service', () => ({
   setUserSetting: (...args: unknown[]) => setUserSetting(...args),
 }));
@@ -42,16 +59,10 @@ vi.mock('~/server/integrations/beehiiv', () => ({
   },
 }));
 
-vi.mock('~/server/db/client', () => ({
-  dbRead: { user: { findFirst: vi.fn() } },
-}));
-
-vi.mock('~/server/logging/client', () => ({
-  logToAxiom: (...args: unknown[]) => logToAxiom(...args),
-  safeError: (error: unknown) => ({ message: (error as Error)?.message }),
-}));
-
+import { loggingMock } from '~/__tests__/mocks/logging.mock';
 import { updateSubscription } from '~/server/services/newsletter.service';
+
+const logToAxiom = loggingMock.logToAxiom;
 
 const ARGS = { email: 'someone@example.com', userId: 7, subscribed: true };
 
@@ -107,7 +118,11 @@ describe('updateSubscription — the settings mirror write', () => {
     expect(logToAxiom).toHaveBeenCalledTimes(1);
     const [payload] = logToAxiom.mock.calls[0] as [Record<string, unknown>];
     expect(payload.type).toBe('newsletter.settings-mirror.failed');
-    expect(payload.error).toEqual({ message: 'No user with id 7' });
+    // The REAL `safeError` (the canonical logging mock overrides only `logToAxiom`), so this
+    // pins what actually reaches Axiom rather than what a local stub was told to return.
+    // `toMatchObject` because the real helper also carries `stack` and the cause/inner
+    // fields, none of which this test should freeze.
+    expect(payload.error).toMatchObject({ name: 'Error', message: 'No user with id 7' });
     // The Beehiiv side already committed and must NOT be retried or rolled back by
     // the mirror's failure.
     expect(setSubscription).toHaveBeenCalledTimes(1);

--- a/src/server/services/__tests__/newsletter-settings-mirror.test.ts
+++ b/src/server/services/__tests__/newsletter-settings-mirror.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `updateSubscription` writes Beehiiv FIRST and mirrors the result into
+ * `User.settings.newsletterSubscriber` second. That second write used to be
+ * un-awaited and uncaught:
+ *
+ *   await beehiiv.setSubscription({ email, subscribed });
+ *   if (userId) setUserSetting(userId, { newsletterSubscriber: subscribed });
+ *
+ * which was harmless only while `setUserSetting` could not fail: it was a bare
+ * `$executeRaw` that silently no-op'd when the row did not exist. It now throws
+ * NOT_FOUND on a zero-row update, so that line became a source of UNHANDLED
+ * PROMISE REJECTIONS — invisible to the mutation's own control flow, and to any
+ * test that only asserts the mutation resolves.
+ *
+ * The two things this suite pins are the two halves of that fix, and they have to
+ * be pinned SEPARATELY because either one alone still lets the mutation resolve:
+ *
+ *   1. the settings write is AWAITED — it finishes inside the request rather than
+ *      racing the response (this is what makes the unhandled-rejection shape
+ *      impossible rather than merely handled); and
+ *   2. its failure is CAUGHT and LOGGED, and does NOT fail the mutation — because
+ *      Beehiiv, the system of record, has already committed by then.
+ *
+ * A test asserting only "updateSubscription resolves" would be vacuous: it passes
+ * on the pre-change code too.
+ */
+
+const setUserSetting = vi.fn();
+const setSubscription = vi.fn();
+const logToAxiom = vi.fn(() => Promise.resolve());
+
+vi.mock('~/server/services/user.service', () => ({
+  setUserSetting: (...args: unknown[]) => setUserSetting(...args),
+}));
+
+vi.mock('~/server/integrations/beehiiv', () => ({
+  beehiiv: {
+    setSubscription: (...args: unknown[]) => setSubscription(...args),
+    getSubscription: vi.fn(),
+  },
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { user: { findFirst: vi.fn() } },
+}));
+
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: (...args: unknown[]) => logToAxiom(...args),
+  safeError: (error: unknown) => ({ message: (error as Error)?.message }),
+}));
+
+import { updateSubscription } from '~/server/services/newsletter.service';
+
+const ARGS = { email: 'someone@example.com', userId: 7, subscribed: true };
+
+/** A promise whose settlement this test controls, so ordering is asserted, not timed. */
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/** Let every already-queued microtask run, without introducing a timing dependency. */
+const drainMicrotasks = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+beforeEach(() => {
+  setUserSetting.mockReset();
+  setSubscription.mockReset();
+  logToAxiom.mockReset();
+  setSubscription.mockResolvedValue(undefined);
+  setUserSetting.mockResolvedValue({});
+  logToAxiom.mockResolvedValue(undefined);
+});
+
+describe('updateSubscription — the settings mirror write', () => {
+  it('does not resolve until the settings write has settled', async () => {
+    const gate = deferred();
+    setUserSetting.mockReturnValue(gate.promise);
+
+    let settled = false;
+    const call = updateSubscription({ ...ARGS }).then(() => {
+      settled = true;
+    });
+
+    await drainMicrotasks();
+    // Pre-change (un-awaited) this is already true: the mutation returned while the
+    // write was still in flight, which is exactly how its rejection escaped.
+    expect(settled).toBe(false);
+    expect(setUserSetting).toHaveBeenCalledTimes(1);
+
+    gate.resolve();
+    await call;
+    expect(settled).toBe(true);
+  });
+
+  it('a REJECTING settings write is logged and does not fail the mutation', async () => {
+    setUserSetting.mockRejectedValue(new Error('No user with id 7'));
+
+    await expect(updateSubscription({ ...ARGS })).resolves.toBeUndefined();
+
+    expect(logToAxiom).toHaveBeenCalledTimes(1);
+    const [payload] = logToAxiom.mock.calls[0] as [Record<string, unknown>];
+    expect(payload.type).toBe('newsletter.settings-mirror.failed');
+    expect(payload.error).toEqual({ message: 'No user with id 7' });
+    // The Beehiiv side already committed and must NOT be retried or rolled back by
+    // the mirror's failure.
+    expect(setSubscription).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs NOTHING when the settings write succeeds (negative control)', async () => {
+    await expect(updateSubscription({ ...ARGS })).resolves.toBeUndefined();
+
+    expect(setUserSetting).toHaveBeenCalledWith(7, { newsletterSubscriber: true });
+    expect(logToAxiom).not.toHaveBeenCalled();
+  });
+
+  it('a failing BEEHIIV call still throws — only the mirror is best-effort', async () => {
+    setSubscription.mockRejectedValue(new Error('beehiiv 500'));
+
+    await expect(updateSubscription({ ...ARGS })).rejects.toThrow('beehiiv 500');
+
+    // Nothing to mirror if the source of truth never changed.
+    expect(setUserSetting).not.toHaveBeenCalled();
+    expect(logToAxiom).not.toHaveBeenCalled();
+  });
+
+  it('writes no settings at all when there is no userId', async () => {
+    await expect(updateSubscription({ email: ARGS.email, subscribed: false })).resolves.toBe(
+      undefined
+    );
+
+    expect(setSubscription).toHaveBeenCalledTimes(1);
+    expect(setUserSetting).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/__tests__/no-io-in-transaction.test.ts
+++ b/src/server/services/__tests__/no-io-in-transaction.test.ts
@@ -63,6 +63,39 @@ ruleTester.run('no-io-in-transaction', rule, {
     `async function f(){ await db.transaction().execute(); }`,
     `async function f(){ await db.$transaction(); }`,
 
+    // ---- Promise combinators: FALSE-POSITIVE CONTROLS ----
+    // Every operand is tx-client work. If the combinator walk stopped allowing
+    // tx.* inside an array literal, this is what would go red.
+    `async function f(){ await db.$transaction(async (tx) => { await Promise.all([tx.image.deleteMany({}), tx.file.deleteMany({})]); }); }`,
+    // 🔴 The same control with DENYLISTED names, so it can actually observe the
+    // tx-root allowance. The fixture above cannot: `deleteMany` is not on the
+    // denylist, so it stays unreported whether or not the allowance runs. `refresh`
+    // and `bust` are, and `tx.*` is how a query builder legitimately spells them.
+    `async function f(){ await db.$transaction(async (tx) => { await Promise.all([tx.thing.refresh(), tx.cache.bust()]); }); }`,
+    // Un-awaited combinator: fire-and-forget is out of scope for the same reason a
+    // bare `fetch('x')` is — it does not consume the transaction's wall-clock
+    // budget, and "make it fire-and-forget" is one of the fixes the rule's own
+    // message prescribes. `void` is the explicit form of the same thing.
+    `async function f(){ await db.$transaction(async (tx) => { Promise.all([bustUserSettings(1)]); await tx.user.update({}); }); }`,
+    `async function f(){ await db.$transaction(async (tx) => { void bustUserSettings(1); await tx.user.update({}); }); }`,
+    // 🔴 EAGERNESS GUARD. A callback handed to something OTHER than .map/.flatMap
+    // may be stored and run long after the transaction commits, so its body must
+    // NOT be read. Loosening EAGER_ITERATION_METHODS to "any inline callback
+    // inside a combinator" is the tempting edit, and these are what kill it.
+    `async function f(){ await db.$transaction(async (tx) => { await Promise.all([emitter.on('x', () => bustUserSettings(1))]); }); }`,
+    `async function f(){ await db.$transaction(async (tx) => { await Promise.all(queue.register(() => bustUserSettings(1))); }); }`,
+    // A non-Promise object with an `all` method is not a combinator.
+    `async function f(){ await db.$transaction(async (tx) => { await settled.all([bustUserSettings(1)]); }); }`,
+
+    // ---- PINNED GAPS (see "KNOWN GAPS in WHICH AWAITED EXPRESSIONS ARE READ") ----
+    // The operand array is a variable, so its elements are not in this AST position.
+    `async function f(){ await db.$transaction(async (tx) => { const jobs = [bustUserSettings(1)]; await Promise.all(jobs); }); }`,
+    // A non-inline map callback is a reference the rule does not resolve.
+    `async function f(){ await db.$transaction(async (tx) => { await Promise.all(ids.map(makeJob)); }); }`,
+    // A spread's own array is likewise unresolvable (its SIBLINGS are read — see
+    // the invalid case below).
+    `async function f(){ await db.$transaction(async (tx) => { await Promise.all([...jobs]); }); }`,
+
     // ---- REGRESSION GUARD (FALSE NEGATIVE, current behavior) ----
     // A non-inline (named) $transaction callback is NOT analyzed: the rule only
     // inspects inline arrow/function-expression callbacks, so I/O inside a named
@@ -146,6 +179,90 @@ ruleTester.run('no-io-in-transaction', rule, {
     {
       code: `async function f(){ await kyselyWrite.transaction().execute(async (trx) => { await db.$transaction(async (tx) => { await tx.user.update({}); }); await fetch('x'); }); }`,
       errors: [{ messageId: 'ioInTx', data: { name: 'fetch' } }],
+    },
+
+    // ---- Promise combinators: the argument-position I/O the rule used to miss ----
+    // The live shape from model.service.ts (`copyGallerySettingsToAllModels`), the
+    // ONE of #3986's two writers the denylist addition could not actually reach:
+    // both calls are ARGUMENTS, so the awaited-call walk saw only `Promise.all`.
+    // Measured on the pre-change rule: 0 hits, while every direct-await case above
+    // flagged.
+    {
+      code: `async function f(){ await db.$transaction(async (tx) => { await Promise.all([userModelCountCache.refresh(1), bustUserSettings(1)]); }); }`,
+      errors: [
+        { messageId: 'ioInTx', data: { name: 'refresh' } },
+        { messageId: 'ioInTx', data: { name: 'bustUserSettings' } },
+      ],
+    },
+    // The live shape from bountyEntry.service.ts (`deleteBountyEntry`): a tx.*
+    // call and a Redis call in one array. Both arms in one fixture — the tx.*
+    // operand must stay unreported while its neighbour is reported.
+    {
+      code: `async function f(){ await db.$transaction(async (tx) => { await Promise.all([tx.image.deleteMany({}), invalidateManyImageExistence(ids)]); }); }`,
+      errors: [{ messageId: 'ioInTx', data: { name: 'invalidateManyImageExistence' } }],
+    },
+    // The other three combinators. `race`/`any` still start every operand inside
+    // the transaction — settling early does not cancel the losers.
+    {
+      code: `async function f(){ await db.$transaction(async (tx) => { await Promise.allSettled([bustUserSettings(1)]); }); }`,
+      errors: [{ messageId: 'ioInTx', data: { name: 'bustUserSettings' } }],
+    },
+    {
+      code: `async function f(){ await db.$transaction(async (tx) => { await Promise.race([fetch('x')]); }); }`,
+      errors: [{ messageId: 'ioInTx', data: { name: 'fetch' } }],
+    },
+    {
+      code: `async function f(){ await db.$transaction(async (tx) => { await Promise.any([sendEmail({})]); }); }`,
+      errors: [{ messageId: 'ioInTx', data: { name: 'sendEmail' } }],
+    },
+    // Combinator wrapped in a passthrough, and an element wrapped in one: the two
+    // unwrappers have to compose in both orders.
+    {
+      code: `async function f(){ await db.$transaction(async (tx) => { await Promise.all([bustUserSettings(1)]).catch(() => {}); }); }`,
+      errors: [{ messageId: 'ioInTx', data: { name: 'bustUserSettings' } }],
+    },
+    {
+      code: `async function f(){ await db.$transaction(async (tx) => { await Promise.all([logToAxiom({}).catch(() => {})]); }); }`,
+      errors: [{ messageId: 'ioInTx', data: { name: 'logToAxiom' } }],
+    },
+    // Nested combinators.
+    {
+      code: `async function f(){ await db.$transaction(async (tx) => { await Promise.all([Promise.allSettled([queueUpdate([])])]); }); }`,
+      errors: [{ messageId: 'ioInTx', data: { name: 'queueUpdate' } }],
+    },
+    // A spread defeats only ITSELF: the sibling literal element is still read.
+    {
+      code: `async function f(){ await db.$transaction(async (tx) => { await Promise.all([...jobs, bustUserSettings(1)]); }); }`,
+      errors: [{ messageId: 'ioInTx', data: { name: 'bustUserSettings' } }],
+    },
+    // `.map`/`.flatMap` with a CONCISE body — one keystroke (dropping
+    // `async`/`await`) from the block-bodied form the function-stack walk already
+    // caught, and invisible to it because there is no AwaitExpression at all.
+    {
+      code: `async function f(){ await db.$transaction(async (tx) => { await Promise.all(ids.map((i) => bustUserSettings(i))); }); }`,
+      errors: [{ messageId: 'ioInTx', data: { name: 'bustUserSettings' } }],
+    },
+    {
+      code: `async function f(){ await db.$transaction(async (tx) => { await Promise.all(groups.flatMap((g) => queueUpdate(g))); }); }`,
+      errors: [{ messageId: 'ioInTx', data: { name: 'queueUpdate' } }],
+    },
+    // 🔴 DOUBLE-REPORT GUARD. The BLOCK-bodied form is already reported once by
+    // the function-stack walk (its `await` is a real AwaitExpression inside the
+    // txn context). Reading block bodies in `combinatorOperands` too would report
+    // this line TWICE; RuleTester fails on the extra error, which is what pins the
+    // `body.type !== 'BlockStatement'` filter.
+    {
+      code: `async function f(){ await db.$transaction(async (tx) => { await Promise.all(ids.map(async (i) => { await bustUserSettings(i); })); }); }`,
+      errors: [{ messageId: 'ioInTx', data: { name: 'bustUserSettings' } }],
+    },
+    // Kysely side of the same shape, so the combinator walk is not accidentally
+    // wired to the Prisma matcher only.
+    {
+      code: `async function f(){ await db.transaction().execute(async (trx) => { await Promise.all([bustUserSettings(1), getUserSettings(1)]); }); }`,
+      errors: [
+        { messageId: 'ioInTx', data: { name: 'bustUserSettings' } },
+        { messageId: 'ioInTx', data: { name: 'getUserSettings' } },
+      ],
     },
 
     // ---- REGRESSION GUARD (FALSE POSITIVE, current behavior) ----

--- a/src/server/services/newsletter.service.ts
+++ b/src/server/services/newsletter.service.ts
@@ -5,6 +5,7 @@ import { setUserSetting } from '~/server/services/user.service';
 import { beehiiv } from '~/server/integrations/beehiiv';
 import type { UserSettingsSchema } from '~/server/schema/user.schema';
 import { dbRead } from '~/server/db/client';
+import { logToAxiom, safeError } from '~/server/logging/client';
 
 export async function updateSubscription({
   email,
@@ -14,7 +15,44 @@ export async function updateSubscription({
   if (!email) throw new Error('No email provided');
 
   await beehiiv.setSubscription({ email, subscribed: input.subscribed });
-  if (userId) setUserSetting(userId, { newsletterSubscriber: input.subscribed });
+
+  // 🔴 ORDER IS LOAD-BEARING, AND IT DECIDES WHAT THIS CATCH HAS TO DO.
+  //
+  // Beehiiv has already COMMITTED by this line, and there is no compensating call
+  // that un-does it cleanly, so a throw here would report failure for an operation
+  // that SUCCEEDED in the system of record. Beehiiv is that system of record:
+  // `getSubscription` below reads the live subscription state from it, never from
+  // this setting, and `settings.newsletterSubscriber` has no reader anywhere in
+  // the repo — it is a denormalised mirror, not the authority. Worse, the client
+  // rolls its optimistic toggle BACK on error (NewsletterToggle's `onError`), so a
+  // throw would show a subscribed user an "unsubscribed" switch. A stale mirror is
+  // the strictly smaller harm than a wrong answer about a real subscription.
+  //
+  // So: best-effort, logged, never fatal.
+  //
+  // This is not a no-op tidy-up. `setUserSetting` used to be a bare `$executeRaw`
+  // that silently no-op'd on a missing row; it now throws NOT_FOUND on a zero-row
+  // update (deliberately — a moderator acting on a deleted user must not get a
+  // success back). Un-awaited and uncaught, as this call was, that rejection
+  // became an UNHANDLED PROMISE REJECTION rather than a failed request: nothing in
+  // the mutation's own control flow could see it. The realistic path is narrow —
+  // `userId` is session-derived, so the row normally exists — but an account
+  // deleted or merged mid-request reaches it.
+  //
+  // The `await` is deliberate too: it keeps the write inside the request's
+  // lifetime instead of racing the response, which is what makes the
+  // unhandled-rejection shape structurally impossible rather than merely handled.
+  if (userId) {
+    try {
+      await setUserSetting(userId, { newsletterSubscriber: input.subscribed });
+    } catch (error) {
+      logToAxiom({
+        type: 'newsletter.settings-mirror.failed',
+        message: `newsletterSubscriber mirror write failed for user ${userId}`,
+        error: safeError(error),
+      }).catch(() => {});
+    }
+  }
 }
 
 export async function getSubscription(email?: string) {

--- a/src/server/services/newsletter.service.ts
+++ b/src/server/services/newsletter.service.ts
@@ -30,14 +30,23 @@ export async function updateSubscription({
   //
   // So: best-effort, logged, never fatal.
   //
-  // This is not a no-op tidy-up. `setUserSetting` used to be a bare `$executeRaw`
-  // that silently no-op'd on a missing row; it now throws NOT_FOUND on a zero-row
-  // update (deliberately — a moderator acting on a deleted user must not get a
-  // success back). Un-awaited and uncaught, as this call was, that rejection
-  // became an UNHANDLED PROMISE REJECTION rather than a failed request: nothing in
-  // the mutation's own control flow could see it. The realistic path is narrow —
-  // `userId` is session-derived, so the row normally exists — but an account
-  // deleted or merged mid-request reaches it.
+  // This is not a no-op tidy-up, and the hazard is OLDER than it looks. Un-awaited
+  // and uncaught, as this call was, ANY rejection from `setUserSetting` became an
+  // UNHANDLED PROMISE REJECTION rather than a failed request — nothing in the
+  // mutation's own control flow could see it. That was already true before the
+  // settings writes were made atomic: the previous implementation
+  // (`git show b6a2e537fa^:src/server/services/user.service.ts`) awaited a
+  // `$executeRaw` AND `userSettingsCache().bust()` AND
+  // `bustUserMetricPrivacyDefaultsCache()`, every one of which rejects on a DB or
+  // Redis fault. So the un-awaited shape was never safe; do not read this as a
+  // regression introduced by that change.
+  //
+  // What DID change is reachability. The old raw UPDATE matching zero rows was a
+  // silent no-op, so a missing user produced no rejection at all; it now throws
+  // NOT_FOUND (deliberately — a moderator acting on a deleted user must not get a
+  // success back). That turned a fault-only hazard into a deterministic one on an
+  // ordinary input. The path is still narrow — `userId` is session-derived, so the
+  // row normally exists — but an account deleted or merged mid-request reaches it.
   //
   // The `await` is deliberate too: it keeps the write inside the request's
   // lifetime instead of racing the response, which is what makes the
@@ -46,8 +55,28 @@ export async function updateSubscription({
     try {
       await setUserSetting(userId, { newsletterSubscriber: input.subscribed });
     } catch (error) {
+      // 🔴 `type` IS THE SEVERITY FIELD, not a free-text event name — the
+      // Alloy→Loki pipeline extracts it as the log level (see the SEVERITY FIELD
+      // note on `buildCentralErrorLog` in ~/server/logging/client). An event name
+      // here would land the line at no recognised level, discoverable only by
+      // someone who already knows the string — which would hollow out the entire
+      // justification for swallowing this error. The event name goes in `name`.
+      // Measured convention: of 601 `logToAxiom` sites with a literal `type`, 528
+      // use a severity word, and 535 of the 545 severity-typed ones (98%) carry a
+      // `name`. (The `api-key.service.ts` `type: 'oauth.*.failed'` shape this
+      // originally copied is 2 sites of the 73-site minority.)
+      //
+      // `warning`, not `error`: this write is best-effort BY DESIGN and its
+      // dominant reachable cause is a benign deleted/merged account, which is a
+      // client-fault NOT_FOUND rather than a server incident — the same split
+      // `classifyErrorFault` makes, and the reason the logging client routes
+      // client faults away from the error stream so they cannot flood it. Nearest
+      // in-tree precedent for a swallowed best-effort write failure is
+      // `donation-goal-cache-bust-failed`, also `warning`. Escalate to `error` if
+      // the volume ever says this is not the benign case.
       logToAxiom({
-        type: 'newsletter.settings-mirror.failed',
+        type: 'warning',
+        name: 'newsletter-settings-mirror-failed',
         message: `newsletterSubscriber mirror write failed for user ${userId}`,
         error: safeError(error),
       }).catch(() => {});

--- a/src/server/services/newsletter.service.ts
+++ b/src/server/services/newsletter.service.ts
@@ -55,9 +55,9 @@ export async function updateSubscription({
     try {
       await setUserSetting(userId, { newsletterSubscriber: input.subscribed });
     } catch (error) {
-      // 🔴 `type` IS THE SEVERITY FIELD, not a free-text event name — the
-      // Alloy→Loki pipeline extracts it as the log level (see the SEVERITY FIELD
-      // note on `buildCentralErrorLog` in ~/server/logging/client). An event name
+      // 🔴 `type` IS THE SEVERITY FIELD, not a free-text event name — the log
+      // pipeline extracts it as the level (see the SEVERITY FIELD note on
+      // `buildCentralErrorLog` in ~/server/logging/client). An event name
       // here would land the line at no recognised level, discoverable only by
       // someone who already knows the string — which would hollow out the entire
       // justification for swallowing this error. The event name goes in `name`.


### PR DESCRIPTION
Two follow-ups booked from the #3986 audit, graded 🟢 and deliberately deferred out of that PR. Neither is urgent; both close a real gap.

Base: `main` @ `0b4fdc3629`.

---

## 1. `newsletter.service` — a fire-and-forget call that can now throw

```ts
await beehiiv.setSubscription({ email, subscribed: input.subscribed });
if (userId) setUserSetting(userId, { newsletterSubscriber: input.subscribed });   // un-awaited, uncaught
```

Un-awaited and uncaught, **any** rejection from `setUserSetting` becomes an unhandled promise rejection — invisible to the mutation's own control flow.

**The hazard is older than the atomic-settings work, and an earlier revision of this PR said otherwise.** Checking history (`git show b6a2e537fa^:src/server/services/user.service.ts`), the previous implementation awaited a `$executeRaw` **and** `userSettingsCache().bust()` **and** `bustUserMetricPrivacyDefaultsCache()` — every one of which rejects on a DB or Redis fault. So this shape was never safe.

What changed is **reachability**, not existence. The old raw UPDATE matching zero rows was a silent no-op, so a missing user produced no rejection at all; it now throws `NOT_FOUND` (a deliberate fix — a moderator targeting a nonexistent user had briefly become a silent success). That turned a fault-only hazard into a deterministic one on an ordinary input. The path is still narrow — `userId` is session-derived, so the row normally exists — but a deleted or merged account mid-request reaches it.

*(Current throw path confirmed directly rather than inherited: `setUserSetting` → `patchUserSettings`, which does `if (!rows.length) throw throwNotFoundError(...)`.)*

### The decision: catch and log, not throw — and `await` it

`beehiiv.setSubscription` has **already committed** by that line and there is no clean compensating call, so these are materially different products, not a lint choice.

Reasons for best-effort:

- **Beehiiv is the system of record.** `getSubscription` reads live subscription state from Beehiiv, never from the setting.
- **`settings.newsletterSubscriber` has no reader anywhere in the repo** — grep finds exactly two occurrences: its `z.boolean().optional()` declaration in `user.schema.ts` and this write. It is a denormalised mirror, not an authority.
- **Throwing produces a wrong answer on screen.** `NewsletterToggle`'s `onError` rolls the optimistic toggle back, so a subscribed user would be shown an "unsubscribed" switch while Beehiiv has them subscribed. A stale mirror is the strictly smaller harm.
- The one realistic failure path — a deleted/merged account — is exactly the case where the mirror is moot.

The `await` is separate from the catch, and both are load-bearing. Awaiting keeps the write inside the request's lifetime instead of racing the response, which is what makes the unhandled-rejection shape structurally impossible rather than merely handled.

**The log had to be fixed too, and it is not cosmetic.** An earlier revision passed the event name in `type` (`type: 'newsletter.settings-mirror.failed'`), copying `api-key.service.ts`. But `type` is the field the log pipeline extracts as the **severity level** — documented on `buildCentralErrorLog` in `~/server/logging/client`. An event name there lands the line at no recognised level, findable only by someone who already knows the string. Since *"the failure is still recorded"* is the entire justification for swallowing this error, unfindable makes that justification hollow.

Convention measured rather than assumed: of **669** `logToAxiom` call sites, **601** carry a literal `type`, and **528 of those (88%)** use a severity word; **535 of the 545** severity-typed sites (**98%**) carry a separate `name`. The `api-key.service.ts` shape is 2 sites of the 73-site minority.

Now `type: 'warning'` + `name: 'newsletter-settings-mirror-failed'` + `error: safeError(error)`.

`warning` rather than `error` is a judgement call worth stating: this write is best-effort **by design**, and its dominant reachable cause is a benign deleted/merged account — a client-fault `NOT_FOUND` rather than a server incident. That is the same split the logging client itself makes to keep ordinary rejections out of the error stream, and the nearest in-tree precedent for a swallowed best-effort write failure (`donation-goal-cache-bust-failed`) is also `warning`. One word to escalate if volume ever says this is not the benign case.

---

## 2. `no-io-in-transaction` could not see I/O passed to `Promise.all`

#3986 added `bustUserSettings` and `getUserSettings` to `IO_CALL_NAMES` so a future Redis round trip inside a Prisma interactive transaction (5s default) is caught structurally. It reaches one of that PR's two writers. The other is:

```ts
await Promise.all([userModelCountCache.refresh(userId), bustUserSettings(userId)])
```

The I/O calls are *array arguments*, never the awaited expression, so the walk never saw them. This is **pre-existing rule behaviour, not a #3986 regression** — `refresh` was already on the denylist and was missed the same way. Measured on the pre-change rule: that shape produces **0 hits** while every direct-await case beside it flags.

This is defence-in-depth on the lint arm only. The behavioural test #3986 added already catches the regression at that writer.

### What changed

An awaited expression is now read through:

- `Promise.all` / `allSettled` / `race` / `any` over an **array literal** — each element read the same way (so passthrough-chained, nested-combinator and sibling-of-a-spread elements all work);
- an inline `.map`/`.flatMap` callback with a **concise body** passed to one of those.

One `await` can now report several calls.

**`.map`/`.flatMap` only, deliberately.** A callback handed to anything else (`register(cb)`, `on('x', cb)`) may be stored and run long after commit; reading it would report deferred work. Two `valid` cases pin this and go red if the check is loosened to "any inline callback".

**`void`-ed / un-awaited calls are deliberately NOT added.** They do not consume the transaction's wall-clock budget, and *"make pure-logging calls fire-and-forget"* is one of the two fixes the rule's own message prescribes — flagging them would flag the remedy. (A fire-and-forget write outliving a rolled-back transaction is a real but different hazard, with no timeout to blow.) This is now written in the header instead of being implicit in one `valid` fixture.

### `KNOWN GAPS` was overstating coverage

The existing block only listed gaps in *which transactions are detected*. Added a second list for gaps in *which awaited expressions are read*: a promise held in a variable, a non-inline map callback, a spread's own array, a conditional, an aliased binding — plus an explicit note that a shape absent from both lists is not thereby covered.

### Repo-wide measurement

Every `.ts`/`.tsx` under `src/` and `packages/` — **5,310 files, 0 parse errors** — with the rule run in isolation via eslint's `Linter`, immediately before and after the change in one environment:

| | reports | files |
|---|---|---|
| base `0b4fdc3629` | 6 | 3 |
| this branch | **7** | 3 |

**How I know the zero-ish delta is real** (both arms, every run):

- **Positive control** — a synthetic `await db.$transaction(async (tx) => { await bustUserSettings(1); })` must flag: **1 hit** on both runs. A run reporting 0 here aborts the census.
- **Negative control** — `await tx.user.update({})` inside the same callback must not: **0 hits** on both runs.
- Parse failures are counted, not swallowed. The first draft reported **33 parse errors** because `ecmaFeatures.jsx` was on for `.ts` files, where a generic arrow `<T>(x) => x` parses as an unterminated JSX tag — 33 files silently unscanned. Fixed by keying `jsx` to the extension; **0 parse errors** in both runs above.
- The harness reports only `ruleId === no-io-in-transaction`; an early version also counted "Definition for rule X was not found" problems, an artefact of running one rule.
- Cross-checked with a **second, differently-built instrument**: `npx eslint` with the repo's full config reproduces the one new site as `1 problem (0 errors, 1 warning)`.

**The one new report is a true positive**, `src/server/services/bountyEntry.service.ts:652` in `deleteBountyEntry`:

```ts
await Promise.all([
  tx.image.deleteMany({ where: { id: { in: imageIds } } }),
  invalidateManyImageExistence(imageIds),        // N Redis `set`s, on the txn's clock
]);
```

Left **reported, not fixed**: hoisting a cache invalidation out of a transaction is a behaviour change to bounty deletion and wants its own diff with its own verification — the same treatment `bugReportCounter` got from `no-module-scope-cache`.

**This rule annotates; it cannot gate.** Severity is `'warn'`, `lint.yml`'s added-files step is errors-only and its modified-files step is `continue-on-error`, and that file pre-exists. Nothing here becomes enforceable.

---

## Verification

### Red at base / green at HEAD

| suite | at `0b4fdc3629` | at HEAD |
|---|---|---|
| `newsletter-settings-mirror.test.ts` | **2 failed** / 3 passed | 5 passed |
| `no-io-in-transaction.test.ts` | **12 failed** / 41 passed | 54 passed |

Failures at base, verbatim:

```
× does not resolve until the settings write has settled
    AssertionError: expected true to be false
× a REJECTING settings write is logged and does not fail the mutation
    AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
× ...Promise.all([userModelCountCache.refresh(1), bustUserSettings(1)])...
    AssertionError: Should have 2 errors but had 0: []
```

**Labelled honestly:** 12 of the 13 new `invalid` cases are regression coverage. The double-report case and **all 13 new `valid` cases pass at base** — they are *invariant guards* (false-positive controls and pinned gaps), and are not counted as regression coverage. Likewise 3 of the 5 newsletter tests.

### Mutation matrix — 15 mutants, 0 survivors

Each applied as an exact string replacement with an occurrence-count assertion (so a missed edit cannot be scored SURVIVED), suite re-run, file restored; restored-tree control green at 59/59 afterwards.

| # | mutation | killed by |
|---|---|---|
| M1 | combinator branch disabled | `Should have 2 errors but had 0: []` (12 tests) |
| M2 | `allSettled` dropped from the set | `Should have 1 error but had 0: []` |
| M3 | `race` dropped from the set | `Should have 1 error but had 0: []` |
| M4 | `Promise` receiver check dropped | `Should have no errors but had 1` (`settled.all([...])`) |
| M5 | array-literal operands not read | `Should have 2 errors but had 0: []` (10 tests) |
| M6 | `.map`/`.flatMap` loosened to any callback | `Should have no errors but had 1` (`queue.register(...)`) |
| M7 | block-bodied map callbacks descended here too | `Should have 1 error but had 2` |
| M8 | tx-client allowance skipped for operands | `Should have no errors but had 2` (`tx.thing.refresh()`) |
| M9 | only the first I/O call of an await reported | `Should have 2 errors but had 1` |
| M10 | **positive control** — `fetch` dropped from the pre-existing denylist | `Should have 1 error but had 0: []` (9 tests) |
| M11 | the `await` removed | `expected true to be false` |
| M12 | the catch re-throws | `promise rejected "Error: No user with id 7" instead of resolving` |
| M13 | the log `type` renamed | `expected 'newsletter.something-else' to be 'newsletter.settings-mirror.failed'` |
| M14 | the error payload dropped from the log | `expected undefined to deeply equal { message: 'No user with id 7' }` |
| M15 | logs unconditionally | `expected "vi.fn()" to not be called at all, but actually been called 1 times` |

**Two drafted guards were deleted rather than left in looking load-bearing.** A `SpreadElement` filter and a `BlockStatement` filter both survived every mutation — they only ever removed nodes the caller already rejected, i.e. equivalent mutants. M7 above is the rewritten, realistic version of the second one (the naive "close the block-body gap" edit), and it dies.

### Typecheck

`pnpm typecheck` (its wrapper, which distinguishes a heap-crash from a clean run), base and head **back-to-back in one environment**: **54 errors on both sides, identical `file:line:col:code` set** — delta 0. All 54 are pre-existing artifacts of this worktree (absent `event-engine-common` submodule; a Prisma client in the shared `node_modules` generated against a different schema). The only textual difference between the two runs is tsc's member ordering inside anonymous type renderings.

Also: `prettier --check` clean on all four files (instrument validated against a deliberately-unformatted file first), and the whole `test:lint-rules` set green — 248 tests across 7 files, so no sibling rule regressed.

---

## What I did NOT verify

- **No runtime exercise of the newsletter path.** The mirror-write behaviour is verified against mocked `beehiiv`/`setUserSetting`, not against a real Beehiiv account or a real deleted-user row. The NOT_FOUND throw is read from `patchUserSettings`, not observed live.
- **No test asserts the literal absence of an `unhandledRejection` event.** That listener is timing-dependent; the awaited-ordering test and the log assertion are the deterministic statement of the same property.
- **`newsletterSubscriber` has no reader *in this repo*.** A warehouse/analytics query against the `User.settings` JSON column would not show up in a grep here. If one exists, the mirror is more load-bearing than the reasoning above assumes — worth a second opinion from whoever owns newsletter reporting.
- **The rule census covers `src/` and `packages/` only** — the same scope ESLint itself covers. `apps/` is out of lint scope (the Kysely-matcher note in the rule header already records this).
- **The new `bountyEntry.service.ts:652` warning is not fixed**, only reported.

---

## Update — `no-direct-shared-module-mock` violation, fixed

The first push was red on both test tiers, and it was mine, not a flake. `newsletter-settings-mirror.test.ts` directly `vi.mock`ed `~/server/db/client` and `~/server/logging/client`, both of which have a canonical mock registered globally in `src/__tests__/setup.ts`. A per-file `vi.mock` of one of those freezes that file's mock shape into every later file sharing the worker under `isolate: false` — which is exactly what the ratchet exists to prevent.

I could not see it when I first pushed: a pre-existing limitation in one test tier stopped the ratchet from evaluating at all, so it reported unrelated failures instead of this file. With that limitation lifted the guard runs and both tiers report this file identically — which is the useful part, since they disagreed before and agree now.

**Fixed per `scripts/test-perf/codemod-shared-mocks.mjs`:**

- The `~/server/db/client` mock is gone outright. The path under test never touches `dbRead` (only `getSubscription` does), so nothing from `db.mock` is imported either — the global registration is all that's needed.
- The `~/server/logging/client` mock is replaced by `loggingMock.logToAxiom`.

**The codemod's refusal was the real finding.** It declined to convert the logging mock automatically — *"factory replaces `safeError` with behaviour — it is a control surface, not a redundant re-export"* — and it was right. My factory stubbed `safeError` to `{ message }` and the suite then asserted the payload **equalled** `{ message }`: an expectation derived from my own stub rather than from anything the code does. The canonical registration spreads the original module and overrides only `logToAxiom`, so `safeError` is now the **real** implementation and the assertion pins what it actually produces (`toMatchObject({ name, message })`, leaving `stack` and the cause/inner fields unfrozen).

That is strictly stronger coverage, and it's measured rather than claimed: a **new mutant** — swap `safeError(error)` for `{ message: error.message }` — now fails with `expected { message: 'No user with id 7' } to match object { name: 'Error', … }`. Under the old stub that mutant was invisible. The canonical mock exposed everything the tests needed; no allowlist entry was added and none was warranted.

**Re-verified from scratch (a fix round resets the gate — none of this was carried over):**

| check | result |
|---|---|
| newsletter suite red-at-base `0b4fdc3629` | **2 failed** / 3 passed — same two tests, same messages |
| newsletter suite at HEAD | 5 passed |
| newsletter mutation battery, re-run in full | 6 mutants, **0 survivors**, each killed by its own named error, restored-tree control green |
| `no-direct-shared-module-mock` itself | **3/3 green**, including its own positive control (`actually scanned the test tree`) — the guard is observing, not vacuous |
| lint-rules set + ratchet + both new suites | **251 tests / 8 files**, all green |
| typecheck | 54 errors, identical `file:line:col:code` set to base — delta still 0 |
| eslint + prettier on the changed file | clean |


---

## Update 2 — adversarial audit follow-ups

Three findings, all closed. The two 🟡 are described in place above (the misattribution in the opening section, the log severity in the item-1 section); this section records the third and the re-verification.

### Deleted the `depth > 8` recursion bound — third unkillable guard in this rule

Every recursive step in `collectIoCalls` moves strictly to a **child** node, and a parsed AST is finite and acyclic, so the stack overflow its comment claimed to prevent is not reachable from any input. Removing it, loosening it to 1000, and dropping its increment on the passthrough branch **all survived** the 54-test suite; only tightening it to 1 was caught — i.e. it only ever measured itself.

Same class as the `SpreadElement` and `BlockStatement` filters already dropped from this rule, **except worse**: those were silent, this one carried a comment asserting a protection nothing demonstrates. A future reader would have trusted it. Deleted rather than softened, for consistency with the other two.

Direct evidence it was inert: the repo-wide census is byte-identical without it — **5,310 files, 0 parse errors, 7 reports**, positive control 1 / negative control 0.

### The battery broke on purpose, and was re-derived rather than relaxed

🔴 Changing the log shape **invalidated M13 and M14**, which pinned the old `type` string. A mutant edited to accommodate a change is exactly where a guard quietly stops guarding, so both were re-derived and two new ones added that pin precisely what the fix was about:

| # | mutation | killed by |
|---|---|---|
| M13 | event `name` renamed | `expected 'newsletter-something-else' to be 'newsletter-settings-mirror-failed'` |
| **M13b** | **severity regressed to an event-name string (the pre-fix bug)** | `expected 'newsletter.settings-mirror.failed' to be 'warning'` |
| **M13c** | **severity dropped entirely** | `expected undefined to be 'warning'` |
| M14 | error payload dropped | `expected undefined to match object { name: 'Error', … }` |

**M15's anchor had also drifted** — the new comment block sits between `} catch (error) {` and `logToAxiom({`, so its pattern matched 0 times. The battery's occurrence-count assertion reported it as `SKIPPED` and counted it against the run rather than silently scoring it `SURVIVED`. That is exactly what that assertion exists for, and it is the first time in this arc it has fired.

**M8 on the rule side** also had to be re-derived: it expressed itself via the now-deleted `depth`. Its replacement additionally asserts the **combinator fixture** is among its failures, so the tx-client allowance is proven reachable through the new code path and not only through the pre-existing direct-await one.

### Re-verification (a fix round resets the gate — nothing carried over)

| check | result |
|---|---|
| newsletter battery, full | **8 mutants, 0 survivors**, each by its own named error |
| rule battery, full | **10 mutants, 0 survivors**; M8 reachability assertion passes |
| red at base `0b4fdc3629`, both suites | **14 failed / 45 passed** |
| green at HEAD, both suites | **59/59** |
| `no-direct-shared-module-mock` | 3/3, including its own positive control |
| census | 5,310 files, 0 parse errors, 7 reports, controls 1/0 |
| typecheck | 54 errors, identical `file:line:col:code` set to base — delta 0 |
| eslint + prettier | clean on all changed files |

### Three 🟢 findings deliberately not acted on

- TS wrapper expressions (`as const`, `as any`, `!`, `satisfies`) are not unwrapped by the rule, and `Promise?.all` / `Promise['all']` are not recognised. **Zero occurrences in the tree** for either; both belong in the KNOWN GAPS lists if they ever appear.
- The `bountyEntry.service.ts:652` true positive sits in a `{ timeout: 30000 }` transaction rather than the 5s default, which makes leaving it reported-not-fixed more clearly right, not less.


Note on standing failures: `preview / unit-tests` was a standing red at the time this PR was opened and is no longer — it now evaluates the ratchet properly, and the failure it reported against this branch was real and is fixed above. It should not be dismissed as pre-existing. `preview / component-tests` (`MySubmissionsList.browser.test.tsx`, report-only) is unrelated to this branch.
