### PR TITLE
feat(placement): free capacity primitive — slots, entitlement, escrow bypass

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260817120000_placement_free_capacity/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260817120000_placement_free_capacity/migration.sql
@@ -1,0 +1,120 @@
+-- Free placement capacity: how many free placements a space accepts, and which
+-- placements were made against that capacity rather than paid for.
+--
+-- APPLY BEFORE deploying the app that reads these. Both columns are additive and
+-- carry defaults that reproduce today's behaviour exactly, so an old pod is
+-- unaffected by their existence:
+--
+--   * "PlacementSpace"."freeSlots" is nullable with no default. NULL means the
+--     owner has never chosen, which the app resolves to the surface default.
+--     Old code never selects it and never writes it.
+--   * "Placement"."free" defaults to false, so every row an old pod writes is a
+--     paid placement, which is what it is.
+--
+-- NO BACKFILL, and none is needed: every placement that exists was paid for, and
+-- false is the truth for all of them.
+--
+-- ⚠️ THE UNSAFE DIRECTION IS A ROLLBACK WITH FREE ROWS ALREADY MADE. Old code
+-- does not know about `free`, so it settles such a row through the ordinary
+-- money path. That path derives its payout from RECEIPTED HOLDS, of which a free
+-- placement has none, so every leg computes to zero and is filtered out before it
+-- is persisted — old code moves no money for a free row and cannot. What it does
+-- lose is the reservation: old `resolvePlacementSpaceFor` does not count free
+-- rows, so a space's free slots are unbounded while rolled back. The surfaces
+-- that create free placements are behind the `sticker-placement` and
+-- `remix-gallery` Flipt flags; turn those off before rolling back and the set
+-- cannot grow.
+--
+-- ⚠️ NEVER DROP THESE COLUMNS on a rollback. `free` is the only record of which
+-- placements were never paid for, and dropping it would make a later roll-forward
+-- treat them as paid — reserving nothing, and offering a refund path to rows that
+-- have nothing behind them. Old Prisma clients emit explicit column lists, so
+-- leaving both in place costs nothing.
+
+SET lock_timeout = '5s';
+BEGIN;
+
+-- 1. How many free placements this space accepts. Uncapped here on purpose: the
+--    score/tier ceiling is computed at read, and a stored effective value would
+--    go stale the moment a membership lapses. The CHECK only keeps the column
+--    meaningful — a negative slot count is not a small number, it is nonsense
+--    that would make `cap - reserved` arithmetic hand out capacity nobody set.
+ALTER TABLE "PlacementSpace" ADD COLUMN IF NOT EXISTS "freeSlots" INTEGER;
+
+ALTER TABLE "PlacementSpace" DROP CONSTRAINT IF EXISTS "PlacementSpace_freeSlots_check";
+ALTER TABLE "PlacementSpace" ADD CONSTRAINT "PlacementSpace_freeSlots_check"
+  CHECK ("freeSlots" IS NULL OR "freeSlots" >= 0);
+
+-- 2. Whether this placement was made against free capacity.
+--
+--    NOT NULL with a default rather than nullable: there is no third state, and a
+--    NULL here would have to be interpreted by every reader that decides whether
+--    money moves.
+ALTER TABLE "Placement" ADD COLUMN IF NOT EXISTS "free" BOOLEAN NOT NULL DEFAULT false;
+
+-- 3. A free placement is worth zero, structurally.
+--
+--    The application never sizes a payout from `amount` — it reads receipted
+--    holds, and a free placement has none — so this does not prevent a payout on
+--    its own. What it prevents is a free row that LOOKS paid: `amount` is what
+--    every report, every support answer and every future reader will quote, and a
+--    free placement carrying a price is a row that says a creator earned
+--    something they did not.
+ALTER TABLE "Placement" DROP CONSTRAINT IF EXISTS "Placement_free_amount_check";
+ALTER TABLE "Placement" ADD CONSTRAINT "Placement_free_amount_check"
+  CHECK (NOT "free" OR "amount" = 0);
+
+-- 4. The index behind both entitlement checks — the daily allowance and the
+--    never-twice rule — which run inside the claim transaction and so sit on the
+--    latency path of every free placement.
+--
+--    PARTIAL (`WHERE "free"`), which Prisma cannot express: without the predicate
+--    this indexes every placement ever made in order to answer questions asked
+--    only about the free ones. Not CONCURRENTLY: the predicate matches zero rows
+--    at apply time, so the build is instant, and a cancelled CONCURRENTLY build
+--    leaves an INVALID index behind that then has to be found and dropped.
+CREATE INDEX IF NOT EXISTS "Placement_placerId_free_createdAt_idx"
+  ON "Placement" ("placerId", "free", "createdAt")
+  WHERE "free";
+
+COMMIT;
+
+-- 5. VERIFY THE SCHEMA. Every statement above is idempotent and reports success
+--    on a retry, so confirm each landed rather than reading a clean exit as
+--    proof.
+--
+--      SELECT table_name, column_name, is_nullable, data_type, column_default
+--      FROM information_schema.columns
+--      WHERE (table_name, column_name)
+--        IN (('PlacementSpace', 'freeSlots'), ('Placement', 'free'));
+--
+--    Expect two rows: a nullable `integer` with no default, and a NOT NULL
+--    `boolean` defaulting to false.
+--
+--      SELECT conname, pg_get_constraintdef(oid), convalidated FROM pg_constraint
+--      WHERE conname IN ('PlacementSpace_freeSlots_check', 'Placement_free_amount_check');
+--
+--    Both must report `convalidated = true`.
+--
+--      SELECT indexname, indexdef FROM pg_indexes
+--      WHERE indexname = 'Placement_placerId_free_createdAt_idx';
+--
+--    The definition must contain `WHERE free`. An index built without the
+--    predicate is not a smaller mistake — it is a full-table index that will be
+--    quietly maintained on every placement forever.
+--
+-- 6. VERIFY THE BEHAVIOUR, after the deploy. Nothing above proves the app writes
+--    these. Make one free placement, then:
+--
+--      SELECT id, free, amount, status, "expiresAt" FROM "Placement"
+--      ORDER BY id DESC LIMIT 5;
+--
+--    The new row must read `free = true`, `amount = 0`, and carry a NON-NULL
+--    `expiresAt`. The deadline is what releases the slot when the creator never
+--    acts; a free row without one holds its slot forever and no sweep will ever
+--    reach it.
+--
+--    Standing check afterwards — this should never return a row:
+--
+--      SELECT id, "createdAt" FROM "Placement"
+--      WHERE free AND "expiresAt" IS NULL AND status = 'pending';

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -7837,6 +7837,17 @@ model PlacementSpace {
   /// What the owner asks. The charged price is min(price, cap) computed at read; a
   /// stored effective price goes stale the moment a membership lapses.
   price      Int?
+  /// How many free placements this space accepts. NULL means the owner has never
+  /// chosen, which resolves to the surface's default (1) rather than to zero —
+  /// free capacity is opt-out. An explicit 0 is the owner taking none, which is
+  /// why this replaces an on/off toggle instead of sitting beside one.
+  ///
+  /// Stored uncapped and ceilinged at read by the score/tier table, exactly like
+  /// `price`: a stored effective value goes stale the moment a membership lapses.
+  ///
+  /// A column rather than a key in `settings`, because the foundation reads it
+  /// and `settings` is surface-owned by construction.
+  freeSlots  Int?
   /// Surface-owned settings, read only by the surface that wrote them — a max
   /// sticker size means nothing to a remix gallery. Kept as JSON so this layer
   /// does not grow a column per surface idea.
@@ -7876,7 +7887,20 @@ model Placement {
   removedBy             String?
   /// What the placer paid into escrow, in Buzz. Kept per row rather than read back from
   /// the space, whose price may move between placement and release.
+  ///
+  /// Always 0 on a free placement, and nothing reads it there — the payout is
+  /// derived from receipted holds, of which a free placement has none.
   amount                Int
+  /// A placement made against the space's free capacity rather than paid for.
+  ///
+  /// Escrow is bypassed entirely: zero-amount Buzz transactions are a landmine,
+  /// and the escrow's two-hold structure has neither a decline fee nor a
+  /// principal to hold. Settlement moves no money at all for one of these.
+  ///
+  /// On the row rather than inferred from `amount = 0`, which is also what a paid
+  /// placement into a zero-priced space looks like. It also has to be immutable
+  /// and readable by a sweeper that never saw the request that made it.
+  free                  Boolean   @default(false)
   /// Which Buzz the placer paid in, so the settlement pays the same kind back out.
   /// On the row for the same reason `amount` is: settlement is resumable, and the
   /// domain that decided the currency is not visible to a sweeper.
@@ -7938,6 +7962,17 @@ model Placement {
   /// `[ownerId, status]` above, which the moderation lookups still want.
   @@index([ownerId, surface, status, createdAt, id])
   @@index([placerId, status])
+  /// Both free-placement entitlement checks, which run inside the claim
+  /// transaction and so are on the latency path of every free placement: the
+  /// daily allowance (this placer, free rows, since midnight UTC) and the
+  /// never-twice rule (this placer, free rows, this target). One index serves
+  /// both because the allowance bounds a placer to one free row per day, so
+  /// "every free row this placer has" is a handful of tuples either way.
+  ///
+  /// Applied as a PARTIAL index (`WHERE free`) — see the migration. Prisma cannot
+  /// express the predicate, and without it this indexes every placement ever made
+  /// to answer questions only about the free ones.
+  @@index([placerId, free, createdAt])
   @@index([status, expiresAt])
   /// Applied as a PARTIAL index (`WHERE "metricCountedAt" IS NULL`) — see the
   /// migration. Prisma can express neither the predicate nor the reason the key

--- a/packages/civitai-db-schema/src/kysely/types.ts
+++ b/packages/civitai-db-schema/src/kysely/types.ts
@@ -3036,8 +3036,23 @@ export type Placement = {
   /**
    * What the placer paid into escrow, in Buzz. Kept per row rather than read back from
    * the space, whose price may move between placement and release.
+   *
+   * Always 0 on a free placement, and nothing reads it there — the payout is
+   * derived from receipted holds, of which a free placement has none.
    */
   amount: number;
+  /**
+   * A placement made against the space's free capacity rather than paid for.
+   *
+   * Escrow is bypassed entirely: zero-amount Buzz transactions are a landmine,
+   * and the escrow's two-hold structure has neither a decline fee nor a
+   * principal to hold. Settlement moves no money at all for one of these.
+   *
+   * On the row rather than inferred from `amount = 0`, which is also what a paid
+   * placement into a zero-priced space looks like. It also has to be immutable
+   * and readable by a sweeper that never saw the request that made it.
+   */
+  free: Generated<boolean>;
   /**
    * Which Buzz the placer paid in, so the settlement pays the same kind back out.
    * On the row for the same reason `amount` is: settlement is resumable, and the
@@ -3109,6 +3124,19 @@ export type PlacementSpace = {
    * stored effective price goes stale the moment a membership lapses.
    */
   price: number | null;
+  /**
+   * How many free placements this space accepts. NULL means the owner has never
+   * chosen, which resolves to the surface's default (1) rather than to zero —
+   * free capacity is opt-out. An explicit 0 is the owner taking none, which is
+   * why this replaces an on/off toggle instead of sitting beside one.
+   *
+   * Stored uncapped and ceilinged at read by the score/tier table, exactly like
+   * `price`: a stored effective value goes stale the moment a membership lapses.
+   *
+   * A column rather than a key in `settings`, because the foundation reads it
+   * and `settings` is surface-owned by construction.
+   */
+  freeSlots: number | null;
   /**
    * Surface-owned settings, read only by the surface that wrote them — a max
    * sticker size means nothing to a remix gallery. Kept as JSON so this layer

--- a/packages/civitai-db-schema/src/models.ts
+++ b/packages/civitai-db-schema/src/models.ts
@@ -5309,6 +5309,7 @@ export interface PlacementSpace {
   entityId: number;
   mode: string;
   price: number | null;
+  freeSlots: number | null;
   settings: JsonValue;
   createdAt: Date;
   updatedAt: Date;
@@ -5327,6 +5328,7 @@ export interface Placement {
   status: string;
   removedBy: string | null;
   amount: number;
+  free: boolean;
   spendType: string | null;
   sellerId: number | null;
   seller?: User | null;

--- a/src/components/Account/PlacementSpaceSection.freeSlots.browser.test.tsx
+++ b/src/components/Account/PlacementSpaceSection.freeSlots.browser.test.tsx
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import type * as TrpcModule from '~/utils/trpc';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * The free-slot control on the account settings page, and specifically the one
+ * property no server test can see: **what this page sends when the creator did
+ * not touch it.**
+ *
+ * `freeSlots` is three-way — NULL follows the surface default, a number stops
+ * following it, and 0 is the creator saying no. The mechanism only works while
+ * NULL survives an unrelated save. The first version of this control sent the
+ * on-screen number on every commit, so changing the mode wrote an explicit `1`;
+ * every assertion about the column, the cascade and the resolver stayed green,
+ * because each of them was true. Within a few weeks of ordinary use almost every
+ * space would have been frozen, and raising the default later would have reached
+ * nobody.
+ */
+
+const { mutate, spaces } = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  spaces: { value: [] as Record<string, unknown>[] },
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => ({ id: 7 }) }));
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ stickerPlacement: true }),
+}));
+vi.mock('~/utils/notifications', () => ({ showErrorNotification: vi.fn() }));
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcModule>()),
+  trpc: {
+    useUtils: () => ({ placement: { invalidate: vi.fn() } }),
+    placement: {
+      getPriceRange: {
+        useQuery: () => ({ data: { min: 50, max: 500, freeSlotCap: 4, score: 0, tier: 'free' } }),
+      },
+      getMySpaces: {
+        useQuery: () => ({ data: spaces.value, isPending: false, isError: false }),
+      },
+      getPending: { useQuery: () => ({ data: { items: [], nextCursor: null } }) },
+      setSpace: { useMutation: () => ({ mutate, isPending: false }) },
+    },
+  },
+}));
+
+import { PlacementSpaceSection } from '~/components/Account/PlacementSpaceSection';
+
+/** A space row as `getMySpaces` returns it. */
+const givenSpace = (freeSlots: number | null) => {
+  spaces.value = [
+    { entityType: 'user', entityId: 7, mode: 'review', price: 100, freeSlots, settings: {} },
+  ];
+};
+
+const lastPayload = () => mutate.mock.calls[mutate.mock.calls.length - 1][0];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  spaces.value = [];
+});
+
+describe('PlacementSpaceSection — what a save sends for freeSlots', () => {
+  test('an unrelated save leaves a NULL count untouched', async () => {
+    givenSpace(null);
+    renderWithProviders(<PlacementSpaceSection />);
+
+    await userEvent.click(page.getByText('Accept all'));
+
+    // Absent, not `null`. `null` is a different instruction — it CLEARS the
+    // level so it inherits — and both are distinguishable from a number, which
+    // is the whole point of the three-way schema. `toHaveProperty` rather than a
+    // value comparison, because `undefined` and an omitted key read the same in
+    // an equality assertion and only one of them is what the mutation sends.
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(lastPayload()).not.toHaveProperty('freeSlots', null);
+    expect(lastPayload().freeSlots).toBeUndefined();
+  });
+
+  test('an unrelated save leaves a stored count untouched too', async () => {
+    // The stored-number case is not covered by the NULL one. A control that sent
+    // its on-screen value would pass here by coincidence — the value happens to
+    // match — so this pins that the key is absent rather than that it is right.
+    givenSpace(3);
+    renderWithProviders(<PlacementSpaceSection />);
+
+    await userEvent.click(page.getByText('Accept all'));
+
+    expect(lastPayload().freeSlots).toBeUndefined();
+  });
+
+  // The negative control. Without it, "never send freeSlots" would pass every
+  // assertion above and the creator could never change the number at all.
+  test('moving the control sends the number', async () => {
+    givenSpace(null);
+    renderWithProviders(<PlacementSpaceSection />);
+
+    const slider = page.getByRole('slider', { name: /free stickers/i });
+    await expect.element(slider).toBeInTheDocument();
+    // Focused directly and driven by keyboard. A click on the thumb times out —
+    // it is a zero-size element the track paints over — and a synthesised drag
+    // does not reliably reach Mantine's `onChangeEnd`, which is what commits.
+    (slider.element() as HTMLElement).focus();
+    await userEvent.keyboard('{ArrowRight}');
+
+    expect(mutate).toHaveBeenCalled();
+    expect(typeof lastPayload().freeSlots).toBe('number');
+  });
+});

--- a/src/components/Account/PlacementSpaceSection.freeSlots.browser.test.tsx
+++ b/src/components/Account/PlacementSpaceSection.freeSlots.browser.test.tsx
@@ -106,6 +106,10 @@ describe('PlacementSpaceSection — what a save sends for freeSlots', () => {
     await userEvent.keyboard('{ArrowRight}');
 
     expect(mutate).toHaveBeenCalled();
-    expect(typeof lastPayload().freeSlots).toBe('number');
+    // The number CHOSEN, not merely a number. `typeof … === 'number'` passes for
+    // a control that sends its pre-move value, which moves the thumb, saves, and
+    // stores the old count. Fully determined: the space is unset, so the thumb
+    // rests on the surface default of 1 and one ArrowRight makes it 2.
+    expect(lastPayload().freeSlots).toBe(2);
   });
 });

--- a/src/components/Account/PlacementSpaceSection.tsx
+++ b/src/components/Account/PlacementSpaceSection.tsx
@@ -27,7 +27,11 @@ import { placementPriceCaption, PLACEMENT_SURFACES } from '~/shared/utils/placem
 import { showErrorNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 
-const { defaultMode: DEFAULT_MODE, defaultPrice: DEFAULT_PRICE } = PLACEMENT_SURFACES.sticker;
+const {
+  defaultMode: DEFAULT_MODE,
+  defaultPrice: DEFAULT_PRICE,
+  defaultFreeSlots: DEFAULT_FREE_SLOTS,
+} = PLACEMENT_SURFACES.sticker;
 
 /**
  * Account-level control over who may place stickers on this creator's images.
@@ -69,15 +73,22 @@ export function PlacementSpaceSection() {
   const [mode, setMode] = useState<string>(DEFAULT_MODE);
   const [price, setPrice] = useState<number | ''>(DEFAULT_PRICE ?? '');
   const [maxScale, setMaxScale] = useState(STICKER_PLACEMENT_DEFAULT_MAX_SCALE);
+  // Seeded from the surface default for the same reason as the mode: with no row
+  // the cascade resolves this space as taking one free sticker, and a control
+  // reading 0 would tell a creator their free slots are closed while they are
+  // open. The first commit then writes the number they are looking at.
+  const [freeSlots, setFreeSlots] = useState<number>(DEFAULT_FREE_SLOTS);
 
   useEffect(() => {
     if (!stored) {
       setMode(DEFAULT_MODE);
       setPrice(DEFAULT_PRICE ?? '');
+      setFreeSlots(DEFAULT_FREE_SLOTS);
       return;
     }
     setMode(stored.mode);
     setPrice(stored.price ?? '');
+    setFreeSlots(stored.freeSlots ?? DEFAULT_FREE_SLOTS);
     setMaxScale(stickerMaxScale(stored.settings as Record<string, unknown>));
   }, [stored]);
 
@@ -94,6 +105,7 @@ export function PlacementSpaceSection() {
       // page asserting a price the creator never chose — which the next commit
       // would then write into their row.
       setPrice(stored ? stored.price ?? '' : DEFAULT_PRICE ?? '');
+      setFreeSlots(stored?.freeSlots ?? DEFAULT_FREE_SLOTS);
       showErrorNotification({ title: "Couldn't save that", error: new Error(error.message) });
     },
   });
@@ -107,6 +119,11 @@ export function PlacementSpaceSection() {
   if (spacesPending || spacesFailed) return null;
 
   const cap = range?.max ?? 0;
+  const freeSlotCap = range?.freeSlotCap ?? 0;
+  // What the server will actually honour. A stored count above the cap is left
+  // alone rather than rewritten — the same treatment as a price above its cap —
+  // so the page has to say the smaller number instead of the one on the row.
+  const effectiveFreeSlots = Math.min(freeSlots, freeSlotCap);
   const waiting = pending?.items.length ?? 0;
   // One page's worth is a floor, not a total. Badging it as an exact number
   // tells an owner with 200 waiting that they have 50, which is the same lie
@@ -118,9 +135,19 @@ export function PlacementSpaceSection() {
     range?.max ?? null
   );
 
-  const commit = (nextMode: string, nextPrice: number | '', nextMaxScale = maxScale) =>
+  const commit = (
+    nextMode: string,
+    nextPrice: number | '',
+    nextMaxScale = maxScale,
+    nextFreeSlots = freeSlots
+  ) =>
     save.mutate({
       settings: { maxScale: nextMaxScale },
+      // Always sent, unlike the price. There is no "unset" position on this
+      // control — 0 is the creator saying no rather than the absence of an
+      // answer — so leaving it out would mean the number on screen and the number
+      // stored disagree the moment they touch anything else.
+      freeSlots: nextFreeSlots,
       surface: 'sticker',
       entityType: 'user',
       // Keyed by the owner's own id; the service refuses any other, so this
@@ -238,6 +265,46 @@ export function PlacementSpaceSection() {
           of the size of the image
         </Text>
       </Stack>
+
+      {/* Hidden entirely at a cap of 0 rather than shown disabled: a control whose
+          every position means the same thing is asking a question with one
+          answer, and the cap moves on its own as a score or a membership does. */}
+      {freeSlotCap > 0 && mode !== 'off' && (
+        <Stack gap={4}>
+          <Group gap={4} wrap="nowrap">
+            <Text size="sm" fw={500}>
+              Free stickers you&apos;ll accept
+            </Text>
+            <InfoPopover size="xs" iconProps={{ size: 14 }} width={320}>
+              <Text size="sm" maw={300} style={{ whiteSpace: 'normal' }}>
+                People get one free placement a day, and these are the slots they can spend it on. A
+                slot is held while a placement waits for you, and comes back if you decline it or
+                let it expire. Your maximum is {freeSlotCap}, set by your creator score and
+                membership tier. Paid placements never use these up.
+              </Text>
+            </InfoPopover>
+          </Group>
+          <Slider
+            value={Math.min(freeSlots, freeSlotCap)}
+            onChange={setFreeSlots}
+            onChangeEnd={(value) => commit(mode, price, maxScale, value)}
+            min={0}
+            max={freeSlotCap}
+            step={1}
+            label={null}
+            marks={[
+              { value: 0, label: 'None' },
+              { value: freeSlotCap, label: `${freeSlotCap}` },
+            ]}
+          />
+          <Text size="sm" c="dimmed" mt={16}>
+            <Text span fw={600} c="var(--mantine-color-text)">
+              {effectiveFreeSlots}
+            </Text>{' '}
+            {effectiveFreeSlots === 1 ? 'free sticker' : 'free stickers'} per image
+          </Text>
+        </Stack>
+      )}
 
       {/* The queue is otherwise unreachable: the notification links to the image,
           and nothing else in the app points at it. */}

--- a/src/components/Account/PlacementSpaceSection.tsx
+++ b/src/components/Account/PlacementSpaceSection.tsx
@@ -22,16 +22,13 @@ import {
   STICKER_PLACEMENT_MIN_SCALE,
   stickerMaxScale,
 } from '~/shared/utils/sticker-placement';
+import { PlacementFreeSlotSlider } from '~/components/Placement/PlacementFreeSlotSlider';
 import { PlacementPriceSlider } from '~/components/Placement/PlacementPriceSlider';
 import { placementPriceCaption, PLACEMENT_SURFACES } from '~/shared/utils/placement';
 import { showErrorNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 
-const {
-  defaultMode: DEFAULT_MODE,
-  defaultPrice: DEFAULT_PRICE,
-  defaultFreeSlots: DEFAULT_FREE_SLOTS,
-} = PLACEMENT_SURFACES.sticker;
+const { defaultMode: DEFAULT_MODE, defaultPrice: DEFAULT_PRICE } = PLACEMENT_SURFACES.sticker;
 
 /**
  * Account-level control over who may place stickers on this creator's images.
@@ -73,22 +70,26 @@ export function PlacementSpaceSection() {
   const [mode, setMode] = useState<string>(DEFAULT_MODE);
   const [price, setPrice] = useState<number | ''>(DEFAULT_PRICE ?? '');
   const [maxScale, setMaxScale] = useState(STICKER_PLACEMENT_DEFAULT_MAX_SCALE);
-  // Seeded from the surface default for the same reason as the mode: with no row
-  // the cascade resolves this space as taking one free sticker, and a control
-  // reading 0 would tell a creator their free slots are closed while they are
-  // open. The first commit then writes the number they are looking at.
-  const [freeSlots, setFreeSlots] = useState<number>(DEFAULT_FREE_SLOTS);
+  // `null`, not the default value, and that distinction is the mechanism rather
+  // than a nicety: a stored number stops tracking the surface default when it
+  // moves. Seeding this to `1` and sending it on every commit wrote an explicit
+  // `1` the first time a creator touched anything else on this page, so within a
+  // few weeks of normal use raising the default would have reached nobody.
+  //
+  // It also cannot be recovered by diffing against the default, because "unset"
+  // and "deliberately set to 1" are the same number.
+  const [freeSlots, setFreeSlots] = useState<number | null>(null);
 
   useEffect(() => {
     if (!stored) {
       setMode(DEFAULT_MODE);
       setPrice(DEFAULT_PRICE ?? '');
-      setFreeSlots(DEFAULT_FREE_SLOTS);
+      setFreeSlots(null);
       return;
     }
     setMode(stored.mode);
     setPrice(stored.price ?? '');
-    setFreeSlots(stored.freeSlots ?? DEFAULT_FREE_SLOTS);
+    setFreeSlots(stored.freeSlots);
     setMaxScale(stickerMaxScale(stored.settings as Record<string, unknown>));
   }, [stored]);
 
@@ -105,7 +106,7 @@ export function PlacementSpaceSection() {
       // page asserting a price the creator never chose — which the next commit
       // would then write into their row.
       setPrice(stored ? stored.price ?? '' : DEFAULT_PRICE ?? '');
-      setFreeSlots(stored?.freeSlots ?? DEFAULT_FREE_SLOTS);
+      setFreeSlots(stored?.freeSlots ?? null);
       showErrorNotification({ title: "Couldn't save that", error: new Error(error.message) });
     },
   });
@@ -120,10 +121,6 @@ export function PlacementSpaceSection() {
 
   const cap = range?.max ?? 0;
   const freeSlotCap = range?.freeSlotCap ?? 0;
-  // What the server will actually honour. A stored count above the cap is left
-  // alone rather than rewritten — the same treatment as a price above its cap —
-  // so the page has to say the smaller number instead of the one on the row.
-  const effectiveFreeSlots = Math.min(freeSlots, freeSlotCap);
   const waiting = pending?.items.length ?? 0;
   // One page's worth is a floor, not a total. Badging it as an exact number
   // tells an owner with 200 waiting that they have 50, which is the same lie
@@ -139,14 +136,16 @@ export function PlacementSpaceSection() {
     nextMode: string,
     nextPrice: number | '',
     nextMaxScale = maxScale,
-    nextFreeSlots = freeSlots
+    /**
+     * Sent ONLY when the free-slot control was the thing that moved. `undefined`
+     * leaves the stored value alone, which for a creator who has never touched
+     * it means leaving it NULL — and NULL is what tracks the surface default.
+     * Sending the on-screen number on every commit is what froze it.
+     */
+    nextFreeSlots?: number
   ) =>
     save.mutate({
       settings: { maxScale: nextMaxScale },
-      // Always sent, unlike the price. There is no "unset" position on this
-      // control — 0 is the creator saying no rather than the absence of an
-      // answer — so leaving it out would mean the number on screen and the number
-      // stored disagree the moment they touch anything else.
       freeSlots: nextFreeSlots,
       surface: 'sticker',
       entityType: 'user',
@@ -270,40 +269,17 @@ export function PlacementSpaceSection() {
           every position means the same thing is asking a question with one
           answer, and the cap moves on its own as a score or a membership does. */}
       {freeSlotCap > 0 && mode !== 'off' && (
-        <Stack gap={4}>
-          <Group gap={4} wrap="nowrap">
-            <Text size="sm" fw={500}>
-              Free stickers you&apos;ll accept
-            </Text>
-            <InfoPopover size="xs" iconProps={{ size: 14 }} width={320}>
-              <Text size="sm" maw={300} style={{ whiteSpace: 'normal' }}>
-                People get one free placement a day, and these are the slots they can spend it on. A
-                slot is held while a placement waits for you, and comes back if you decline it or
-                let it expire. Your maximum is {freeSlotCap}, set by your creator score and
-                membership tier. Paid placements never use these up.
-              </Text>
-            </InfoPopover>
-          </Group>
-          <Slider
-            value={Math.min(freeSlots, freeSlotCap)}
-            onChange={setFreeSlots}
-            onChangeEnd={(value) => commit(mode, price, maxScale, value)}
-            min={0}
-            max={freeSlotCap}
-            step={1}
-            label={null}
-            marks={[
-              { value: 0, label: 'None' },
-              { value: freeSlotCap, label: `${freeSlotCap}` },
-            ]}
-          />
-          <Text size="sm" c="dimmed" mt={16}>
-            <Text span fw={600} c="var(--mantine-color-text)">
-              {effectiveFreeSlots}
-            </Text>{' '}
-            {effectiveFreeSlots === 1 ? 'free sticker' : 'free stickers'} per image
-          </Text>
-        </Stack>
+        <PlacementFreeSlotSlider
+          surface="sticker"
+          cap={freeSlotCap}
+          value={freeSlots}
+          noun={['free sticker', 'free stickers']}
+          onChange={setFreeSlots}
+          onCommit={(value) => {
+            setFreeSlots(value);
+            commit(mode, price, maxScale, value);
+          }}
+        />
       )}
 
       {/* The queue is otherwise unreachable: the notification links to the image,

--- a/src/components/Placement/PlacementFreeSlotSlider.tsx
+++ b/src/components/Placement/PlacementFreeSlotSlider.tsx
@@ -1,0 +1,91 @@
+import { Group, Slider, Stack, Text } from '@mantine/core';
+import { InfoPopover } from '~/components/InfoPopover/InfoPopover';
+import { effectiveFreeSlots, PLACEMENT_SURFACES } from '~/shared/utils/placement';
+import type { PlacementSurface } from '~/shared/utils/placement';
+
+/**
+ * How many free placements a creator will accept on a space.
+ *
+ * Shared for the same reason `PlacementPriceSlider` is: a creator meets this
+ * control on more than one surface and, once the per-image override lands, at
+ * more than one level. Two implementations of one decision is two sets of
+ * reachable answers, and the pasted pair this replaced had already diverged on
+ * whether the displayed number was floored at zero.
+ *
+ * Renders its own label and caption, unlike the price slider, because there is
+ * nothing surface-specific left to say once the noun is supplied — no
+ * inheriting, no off-grid, no over-cap disclosure. The caller passes the words
+ * for the thing being placed and nothing else.
+ */
+export function PlacementFreeSlotSlider({
+  surface,
+  cap,
+  value,
+  onChange,
+  onCommit,
+  /** Singular and plural of what is placed here: `['free sticker', 'free stickers']`. */
+  noun,
+}: {
+  surface: PlacementSurface;
+  /** The creator's ceiling. `0` hides the control — see below. */
+  cap: number;
+  /**
+   * What the creator has chosen, or `null` for "never chosen", which follows the
+   * surface default. The distinction is the whole mechanism: a stored number
+   * stops tracking the default when it moves, so a control that cannot express
+   * "unset" writes one on the first save and freezes it.
+   */
+  value: number | null;
+  onChange: (value: number) => void;
+  onCommit: (value: number) => void;
+  noun: [singular: string, plural: string];
+}) {
+  const set = value ?? PLACEMENT_SURFACES[surface].defaultFreeSlots;
+  // What the server will honour, through the shared helper rather than a local
+  // `Math.min`. A stored count above the cap is carried rather than rewritten —
+  // the same treatment a price gets — so the page has to state the smaller
+  // number instead of the one on the row.
+  const effective = effectiveFreeSlots(set, cap);
+
+  return (
+    <Stack gap={4}>
+      <Group gap={4} wrap="nowrap">
+        <Text size="sm" fw={500}>
+          Free {noun[1]} you&apos;ll accept
+        </Text>
+        <InfoPopover size="xs" iconProps={{ size: 14 }} width={320}>
+          <Text size="sm" maw={300} style={{ whiteSpace: 'normal' }}>
+            People get one free placement a day across the whole site, and these are the slots they
+            can spend it on. A slot is held while one waits for you, and comes back if you decline
+            it or let it expire. Your maximum is {cap}, set by your creator score and membership
+            tier. Paid placements never use these up.
+          </Text>
+        </InfoPopover>
+      </Group>
+      <Slider
+        // The visible label is a sibling `Text`, so without this the thumb
+        // reaches assistive tech — and any test driving it — as an unnamed
+        // slider, indistinguishable from the price one beside it.
+        thumbLabel={`Free ${noun[1]} you'll accept`}
+        value={effective}
+        onChange={onChange}
+        onChangeEnd={onCommit}
+        min={0}
+        max={cap}
+        step={1}
+        label={null}
+        marks={[
+          { value: 0, label: 'None' },
+          { value: cap, label: `${cap}` },
+        ]}
+      />
+      {/* Clears the marks, which sit under the track. */}
+      <Text size="sm" c="dimmed" mt={16}>
+        <Text span fw={600} c="var(--mantine-color-text)">
+          {effective}
+        </Text>{' '}
+        {effective === 1 ? noun[0] : noun[1]} per image
+      </Text>
+    </Stack>
+  );
+}

--- a/src/components/RemixGallery/RemixGallerySettings.tsx
+++ b/src/components/RemixGallery/RemixGallerySettings.tsx
@@ -6,6 +6,7 @@ import {
   Divider,
   Group,
   SegmentedControl,
+  Slider,
   Stack,
   Text,
 } from '@mantine/core';
@@ -30,6 +31,8 @@ import { trpc } from '~/utils/trpc';
  * There is no "accept all" here. A sticker comes from a moderated catalog; a
  * remix gallery accepts arbitrary user media, so every submission is reviewed.
  */
+const DEFAULT_FREE_SLOTS = PLACEMENT_SURFACES.remixGallery.defaultFreeSlots;
+
 export function RemixGallerySettings() {
   const features = useFeatureFlags();
   const currentUser = useCurrentUser();
@@ -59,11 +62,16 @@ export function RemixGallerySettings() {
   const [mode, setMode] = useState<string>(PLACEMENT_SURFACES.remixGallery.defaultMode);
   const [price, setPrice] = useState<number | ''>('');
   const [contentRule, setContentRule] = useState<RemixGalleryContentRule>('atOrBelow');
+  // Seeded from the surface default, like the mode above: a creator with no row
+  // takes one free submission, and a control reading 0 would tell them their free
+  // slots are closed on the one screen where they say so.
+  const [freeSlots, setFreeSlots] = useState<number>(DEFAULT_FREE_SLOTS);
 
   useEffect(() => {
     if (!stored) return;
     setMode(stored.mode);
     setPrice(stored.price ?? '');
+    setFreeSlots(stored.freeSlots ?? DEFAULT_FREE_SLOTS);
     setContentRule(remixGalleryContentRule(stored.settings as Record<string, unknown>));
   }, [stored]);
 
@@ -76,6 +84,10 @@ export function RemixGallerySettings() {
   if (!enabled || !currentUser) return null;
 
   const cap = range?.max ?? 0;
+  const freeSlotCap = range?.freeSlotCap ?? 0;
+  // A stored count above the cap is carried rather than rewritten, the same as a
+  // price above its cap, so the page states what the server will honour.
+  const effectiveFreeSlots = Math.min(freeSlots, freeSlotCap);
   const overCap = typeof price === 'number' && cap > 0 && price > cap;
   // Waiting on the owner, and waiting on someone else. Only the first is a
   // to-do, which is why it is the one badged in yellow.
@@ -93,10 +105,14 @@ export function RemixGallerySettings() {
   const commit = (
     nextMode: string,
     nextPrice: number | '',
-    nextRule: RemixGalleryContentRule = contentRule
+    nextRule: RemixGalleryContentRule = contentRule,
+    nextFreeSlots = freeSlots
   ) =>
     save.mutate({
       settings: { contentRule: nextRule },
+      // Always sent: there is no "unset" position on the control, because 0 is
+      // the creator saying no rather than the absence of an answer.
+      freeSlots: nextFreeSlots,
       surface: 'remixGallery',
       entityType: 'user',
       entityId: currentUser.id,
@@ -207,6 +223,46 @@ export function RemixGallerySettings() {
           ]}
         />
       </Stack>
+
+      {/* Hidden at a cap of 0 rather than shown disabled — every position would
+          mean the same thing — and hidden with the gallery closed, where there is
+          nothing to hold a slot on. */}
+      {freeSlotCap > 0 && mode !== 'off' && (
+        <Stack gap={4}>
+          <Group gap={4} wrap="nowrap">
+            <Text size="sm" fw={500}>
+              Free submissions you&apos;ll accept
+            </Text>
+            <InfoPopover size="xs" iconProps={{ size: 14 }} width={320}>
+              <Text size="sm" maw={300} style={{ whiteSpace: 'normal' }}>
+                People get one free placement a day across the whole site, and these are the slots
+                they can spend it on. A slot is held while a submission waits for you, and comes
+                back if you decline it or let it expire. Your maximum is {freeSlotCap}, set by your
+                creator score and membership tier. Paid submissions never use these up.
+              </Text>
+            </InfoPopover>
+          </Group>
+          <Slider
+            value={effectiveFreeSlots}
+            onChange={setFreeSlots}
+            onChangeEnd={(value) => commit(mode, price, contentRule, value)}
+            min={0}
+            max={freeSlotCap}
+            step={1}
+            label={null}
+            marks={[
+              { value: 0, label: 'None' },
+              { value: freeSlotCap, label: `${freeSlotCap}` },
+            ]}
+          />
+          <Text size="sm" c="dimmed" mt={16}>
+            <Text span fw={600} c="var(--mantine-color-text)">
+              {effectiveFreeSlots}
+            </Text>{' '}
+            free {effectiveFreeSlots === 1 ? 'submission' : 'submissions'} per image
+          </Text>
+        </Stack>
+      )}
 
       {/* Two directions, two buttons. A gallery owner both receives submissions
           and makes them, and the counts need somewhere to live — a link with an

--- a/src/components/RemixGallery/RemixGallerySettings.tsx
+++ b/src/components/RemixGallery/RemixGallerySettings.tsx
@@ -6,12 +6,12 @@ import {
   Divider,
   Group,
   SegmentedControl,
-  Slider,
   Stack,
   Text,
 } from '@mantine/core';
 import { useEffect, useState } from 'react';
 import { InfoPopover } from '~/components/InfoPopover/InfoPopover';
+import { PlacementFreeSlotSlider } from '~/components/Placement/PlacementFreeSlotSlider';
 import { PlacementPriceSlider } from '~/components/Placement/PlacementPriceSlider';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
@@ -31,8 +31,6 @@ import { trpc } from '~/utils/trpc';
  * There is no "accept all" here. A sticker comes from a moderated catalog; a
  * remix gallery accepts arbitrary user media, so every submission is reviewed.
  */
-const DEFAULT_FREE_SLOTS = PLACEMENT_SURFACES.remixGallery.defaultFreeSlots;
-
 export function RemixGallerySettings() {
   const features = useFeatureFlags();
   const currentUser = useCurrentUser();
@@ -62,16 +60,16 @@ export function RemixGallerySettings() {
   const [mode, setMode] = useState<string>(PLACEMENT_SURFACES.remixGallery.defaultMode);
   const [price, setPrice] = useState<number | ''>('');
   const [contentRule, setContentRule] = useState<RemixGalleryContentRule>('atOrBelow');
-  // Seeded from the surface default, like the mode above: a creator with no row
-  // takes one free submission, and a control reading 0 would tell them their free
-  // slots are closed on the one screen where they say so.
-  const [freeSlots, setFreeSlots] = useState<number>(DEFAULT_FREE_SLOTS);
+  // `null`, not the default value: a stored number stops tracking the surface
+  // default when it moves, and "unset" and "deliberately set to 1" are the same
+  // number, so this cannot be recovered by diffing against the default later.
+  const [freeSlots, setFreeSlots] = useState<number | null>(null);
 
   useEffect(() => {
     if (!stored) return;
     setMode(stored.mode);
     setPrice(stored.price ?? '');
-    setFreeSlots(stored.freeSlots ?? DEFAULT_FREE_SLOTS);
+    setFreeSlots(stored.freeSlots);
     setContentRule(remixGalleryContentRule(stored.settings as Record<string, unknown>));
   }, [stored]);
 
@@ -85,9 +83,6 @@ export function RemixGallerySettings() {
 
   const cap = range?.max ?? 0;
   const freeSlotCap = range?.freeSlotCap ?? 0;
-  // A stored count above the cap is carried rather than rewritten, the same as a
-  // price above its cap, so the page states what the server will honour.
-  const effectiveFreeSlots = Math.min(freeSlots, freeSlotCap);
   const overCap = typeof price === 'number' && cap > 0 && price > cap;
   // Waiting on the owner, and waiting on someone else. Only the first is a
   // to-do, which is why it is the one badged in yellow.
@@ -106,12 +101,15 @@ export function RemixGallerySettings() {
     nextMode: string,
     nextPrice: number | '',
     nextRule: RemixGalleryContentRule = contentRule,
-    nextFreeSlots = freeSlots
+    /**
+     * Sent ONLY when the free-slot control was the thing that moved. `undefined`
+     * leaves the stored value alone, and for a creator who has never touched it
+     * that means leaving it NULL — which is what tracks the surface default.
+     */
+    nextFreeSlots?: number
   ) =>
     save.mutate({
       settings: { contentRule: nextRule },
-      // Always sent: there is no "unset" position on the control, because 0 is
-      // the creator saying no rather than the absence of an answer.
       freeSlots: nextFreeSlots,
       surface: 'remixGallery',
       entityType: 'user',
@@ -228,40 +226,17 @@ export function RemixGallerySettings() {
           mean the same thing — and hidden with the gallery closed, where there is
           nothing to hold a slot on. */}
       {freeSlotCap > 0 && mode !== 'off' && (
-        <Stack gap={4}>
-          <Group gap={4} wrap="nowrap">
-            <Text size="sm" fw={500}>
-              Free submissions you&apos;ll accept
-            </Text>
-            <InfoPopover size="xs" iconProps={{ size: 14 }} width={320}>
-              <Text size="sm" maw={300} style={{ whiteSpace: 'normal' }}>
-                People get one free placement a day across the whole site, and these are the slots
-                they can spend it on. A slot is held while a submission waits for you, and comes
-                back if you decline it or let it expire. Your maximum is {freeSlotCap}, set by your
-                creator score and membership tier. Paid submissions never use these up.
-              </Text>
-            </InfoPopover>
-          </Group>
-          <Slider
-            value={effectiveFreeSlots}
-            onChange={setFreeSlots}
-            onChangeEnd={(value) => commit(mode, price, contentRule, value)}
-            min={0}
-            max={freeSlotCap}
-            step={1}
-            label={null}
-            marks={[
-              { value: 0, label: 'None' },
-              { value: freeSlotCap, label: `${freeSlotCap}` },
-            ]}
-          />
-          <Text size="sm" c="dimmed" mt={16}>
-            <Text span fw={600} c="var(--mantine-color-text)">
-              {effectiveFreeSlots}
-            </Text>{' '}
-            free {effectiveFreeSlots === 1 ? 'submission' : 'submissions'} per image
-          </Text>
-        </Stack>
+        <PlacementFreeSlotSlider
+          surface="remixGallery"
+          cap={freeSlotCap}
+          value={freeSlots}
+          noun={['free submission', 'free submissions']}
+          onChange={setFreeSlots}
+          onCommit={(value) => {
+            setFreeSlots(value);
+            commit(mode, price, contentRule, value);
+          }}
+        />
       )}
 
       {/* Two directions, two buttons. A gallery owner both receives submissions

--- a/src/server/schema/placement.schema.ts
+++ b/src/server/schema/placement.schema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { allBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constants';
-import { placementSurfaces } from '~/shared/utils/placement';
+import { PLACEMENT_SURFACES, placementSurfaces } from '~/shared/utils/placement';
 import { REMIX_GALLERY_MAX_PINNED } from '~/shared/utils/remix-gallery';
 import {
   STICKER_COMMENT_MAX_LENGTH,
@@ -97,11 +97,19 @@ export const placementSpaceSchema = z
     // moderated catalogue; nothing bounds what an image can be. Refused where
     // the value is stored rather than merely omitted from the settings picker —
     // a listing that filters is not a mutation that refuses.
-    if (input.surface === 'remixGallery' && input.mode === 'auto')
+    //
+    // Read from the surface table rather than naming `remixGallery` here, so
+    // this and the refusal on the acting side (`createFreePlacement`) cannot
+    // disagree about which modes a surface allows.
+    const allowed = PLACEMENT_SURFACES[input.surface].allowedModes as readonly string[];
+    if (!allowed.includes(input.mode))
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ['mode'],
-        message: 'Remix gallery submissions always need review',
+        message:
+          input.surface === 'remixGallery'
+            ? 'Remix gallery submissions always need review'
+            : 'That is not a mode this surface accepts',
       });
   });
 

--- a/src/server/schema/placement.schema.ts
+++ b/src/server/schema/placement.schema.ts
@@ -72,6 +72,13 @@ export const placementSpaceSchema = z
     // Distinguishes "leave whatever is set" from "clear it and inherit", which a
     // single optional number cannot: `undefined` keeps, `null` clears.
     price: z.number().int().min(0).nullable().optional(),
+    // Same three-way distinction as `price`, for the same reason: `undefined`
+    // keeps, `null` clears so the level inherits, a number sets. Bounded below
+    // only — the score/tier ceiling is applied at read, so refusing above it here
+    // would rewrite a creator's choice the moment their tier lapsed. The upper
+    // bound is a sanity limit on what may reach the column at all, well above the
+    // highest cap the table can produce.
+    freeSlots: z.number().int().min(0).max(1_000).nullable().optional(),
     // Surface-owned. Bounded here so a client cannot store a max size outside the
     // global limits; the reader clamps too, since the column is editable by hand.
     // Each surface reads only its own keys, so the union is carried rather than

--- a/src/server/services/__tests__/free-placement.service.test.ts
+++ b/src/server/services/__tests__/free-placement.service.test.ts
@@ -185,6 +185,7 @@ describe('createFreePlacement — the refusals the paid path makes', () => {
     // Outside the transaction, because it is I/O and `no-io-in-transaction`
     // guards that — and because a refusal should not first queue on a lock.
     expect(executeRaw).not.toHaveBeenCalled();
+    expect(dbMock.dbWrite.$executeRawUnsafe).not.toHaveBeenCalled();
   });
 
   it('checks the placer against the owner it resolved, not against the target', async () => {
@@ -297,7 +298,14 @@ describe('createFreePlacement — the free-tier refusals', () => {
 });
 
 describe('createFreePlacement — the lock', () => {
-  const rawStatements = () =>
+  /**
+   * The lock statements, reassembled from the tagged template.
+   *
+   * `join('?')` marks where a bound parameter goes, so this reads as SQL rather
+   * than as a mock's argument shape — which matters for exactly one statement
+   * below, where a parameter is the bug.
+   */
+  const lockStatements = () =>
     executeRaw.mock.calls.map(([strings]: [string[]]) => strings.join('?'));
 
   it('bounds how long a claim waits, so a wedged holder cannot pile up backends', async () => {
@@ -305,16 +313,30 @@ describe('createFreePlacement — the lock', () => {
 
     // `pg_advisory_xact_lock` waits forever by default, and Prisma's client-side
     // timeout does not cancel a backend already blocked inside the statement.
-    expect(rawStatements()[0]).toContain('SET LOCAL lock_timeout');
+    //
+    // 🔴 Asserted on `$executeRawUnsafe`, and on the LITERAL. Postgres has no
+    // parameter form for `SET`, so the tagged-template version sends
+    // `SET LOCAL lock_timeout = $1` and raises `syntax error at or near "$1"` —
+    // and because this is the first statement in the transaction, that does not
+    // merely make the timeout inert, it kills every claim. The previous version
+    // of this test rebuilt the template with a placeholder and asserted the
+    // prefix, which passes on precisely the broken form.
+    expect(dbMock.dbWrite.$executeRawUnsafe).toHaveBeenCalledTimes(1);
+    const [statement] = dbMock.dbWrite.$executeRawUnsafe.mock.calls[0];
+    expect(statement).toContain(`'3s'`);
+    expect(statement).not.toContain('$1');
   });
 
   it('takes the placer lock first and the target lock second', async () => {
     await claim();
 
-    const [, placerLock, targetLock] = rawStatements();
+    const [placerLock, targetLock] = lockStatements();
     expect(placerLock).toContain('pg_advisory_xact_lock');
     expect(targetLock).toContain('hashtext');
-    expect(executeRaw).toHaveBeenCalledTimes(3);
+    // The locks bind their arguments, unlike the `SET` above — advisory-lock
+    // functions are ordinary functions and take parameters.
+    expect(placerLock).toContain('?');
+    expect(executeRaw).toHaveBeenCalledTimes(2);
   });
 
   // Asserted on the calls because a unit test cannot observe Postgres
@@ -325,7 +347,7 @@ describe('createFreePlacement — the lock', () => {
     givenCounts({ reserved: 4 });
     await expect(claim()).rejects.toThrow(/free slots/);
 
-    const targetLockAt = executeRaw.mock.invocationCallOrder[2];
+    const targetLockAt = executeRaw.mock.invocationCallOrder[1];
     const reservedCountAt =
       placementCount.mock.invocationCallOrder[placementCount.mock.calls.length - 1];
     expect(targetLockAt).toBeLessThan(reservedCountAt);
@@ -337,8 +359,8 @@ describe('createFreePlacement — the lock', () => {
     givenCounts({ usedToday: FREE_PLACEMENTS_PER_DAY });
     await expect(claim()).rejects.toThrow(/today/);
 
-    // Two statements, not three: it refused before the target lock existed.
-    expect(executeRaw).toHaveBeenCalledTimes(2);
+    // One lock, not two: it refused before the target lock existed.
+    expect(executeRaw).toHaveBeenCalledTimes(1);
   });
 
   it('claims inside one transaction, so the count and the insert cannot be split', async () => {

--- a/src/server/services/__tests__/free-placement.service.test.ts
+++ b/src/server/services/__tests__/free-placement.service.test.ts
@@ -323,8 +323,28 @@ describe('createFreePlacement — the lock', () => {
     // prefix, which passes on precisely the broken form.
     expect(dbMock.dbWrite.$executeRawUnsafe).toHaveBeenCalledTimes(1);
     const [statement] = dbMock.dbWrite.$executeRawUnsafe.mock.calls[0];
+    // WHAT the statement is, kept alongside the two checks on how it is sent.
+    // Without it `SET LOCAL statement_timeout = '3s'` passes, and so does
+    // `SET lock_timeout = '3s'` — which on a pooled connection leaks a 3s lock
+    // timeout onto every later statement borrowing that backend, well outside
+    // this feature. The `$1` fix replaced this assertion instead of joining it;
+    // when tightening a test, add and keep.
+    expect(statement).toContain('SET LOCAL lock_timeout');
     expect(statement).toContain(`'3s'`);
     expect(statement).not.toContain('$1');
+  });
+
+  // The `SET` is on `$executeRawUnsafe` and the locks are on `$executeRaw`, so
+  // no per-mock call count can see their relative order. Move the `SET` below
+  // both acquisitions and every other assertion in this file stays green while
+  // the timeout is inert for the first and most contended wait — which is the
+  // entire reason the statement exists.
+  it('sets the timeout before it waits on anything', async () => {
+    await claim();
+
+    expect(dbMock.dbWrite.$executeRawUnsafe.mock.invocationCallOrder[0]).toBeLessThan(
+      executeRaw.mock.invocationCallOrder[0]
+    );
   });
 
   it('takes the placer lock first and the target lock second', async () => {

--- a/src/server/services/__tests__/free-placement.service.test.ts
+++ b/src/server/services/__tests__/free-placement.service.test.ts
@@ -2,8 +2,25 @@ import fs from 'fs';
 import path from 'path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { dbMock } from '~/__tests__/mocks/db.mock';
+import type * as PlacementModeration from '~/server/services/placement-moderation.service';
+import type * as PlacementSpaceService from '~/server/services/placement-space.service';
 import type { ResolvedPlacementSpace } from '~/server/services/placement-space.service';
-import { FREE_PLACEMENTS_PER_DAY } from '~/shared/utils/placement';
+import { FREE_PLACEMENTS_PER_DAY, PLACEMENT_SURFACES } from '~/shared/utils/placement';
+
+const resolveSpace = vi.fn();
+const assertCanPlace = vi.fn();
+
+// `reservedFreeSlots` is deliberately NOT stubbed: it is the predicate the claim
+// decides on, and a double would let the count-under-lock be tested against a
+// shape the real query does not have.
+vi.mock('~/server/services/placement-space.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof PlacementSpaceService>()),
+  resolvePlacementSpaceFor: resolveSpace,
+}));
+vi.mock('~/server/services/placement-moderation.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof PlacementModeration>()),
+  assertCanPlace,
+}));
 
 const { createFreePlacement, getFreePlacementAllowance } = await import(
   '~/server/services/free-placement.service'
@@ -11,60 +28,68 @@ const { createFreePlacement, getFreePlacementAllowance } = await import(
 
 const OWNER = 10;
 const PLACER = 20;
+const TARGET = 77;
 
 const placementCount = dbMock.dbWrite.placement.count;
 const placementCreate = dbMock.dbWrite.placement.create;
 const executeRaw = dbMock.dbWrite.$executeRaw;
 
 /**
- * The three counts the claim runs, told apart by their `where` rather than by
- * the order they happen to be called in.
+ * The four counts the claim runs, told apart by their `where` rather than by the
+ * order they happen to be called in.
  *
  * Ordering the answers with `mockResolvedValueOnce` would pass just as well if
- * the service asked the same question three times — which is the mistake worth
- * catching, since the daily allowance and the never-twice rule differ only in
- * their predicate.
+ * the service asked the same question four times — which is the mistake worth
+ * catching, since these differ only in their predicates.
  */
-const givenCounts = ({ usedToday = 0, alreadyHere = 0, reserved = 0 } = {}) =>
+const givenCounts = ({ usedToday = 0, pending = 0, alreadyHere = 0, reserved = 0 } = {}) =>
   placementCount.mockImplementation(async ({ where }: { where: Record<string, unknown> }) => {
     if (where.createdAt) return usedToday;
+    if (where.ownerId !== undefined) return pending;
     if (where.status) return reserved;
     if (where.targetId !== undefined) return alreadyHere;
     throw new Error(`unrecognised count: ${JSON.stringify(where)}`);
   });
 
-const givenSpace = (overrides: Partial<ResolvedPlacementSpace> = {}): ResolvedPlacementSpace => ({
-  ownerId: OWNER,
-  ownerUsername: 'creator',
-  mode: 'review',
-  setPrice: 100,
-  price: 100,
-  cap: 500,
-  ownerShare: 1,
-  setFreeSlots: 4,
-  freeSlots: 4,
-  freeSlotCap: 4,
-  // Deliberately generous, and deliberately ignored by the service: this is what
-  // the caller SHOWED someone, computed before their other checks ran. Every
-  // refusal below has to come from the counts re-read under the lock instead.
-  freeSlotsRemaining: 99,
-  settings: {},
-  ...overrides,
-});
+const givenSpace = (overrides: Partial<ResolvedPlacementSpace> = {}) =>
+  resolveSpace.mockResolvedValue({
+    ownerId: OWNER,
+    ownerUsername: 'creator',
+    mode: 'review',
+    setPrice: 100,
+    price: 100,
+    cap: 500,
+    ownerShare: 1,
+    setFreeSlots: 4,
+    freeSlots: 4,
+    freeSlotCap: 4,
+    // Deliberately generous, and deliberately ignored: this is what a surface
+    // SHOWS, computed before the caller's other checks ran. Every refusal below
+    // has to come from the counts re-read under the lock instead.
+    freeSlotsRemaining: 99,
+    settings: {},
+    ...overrides,
+  } satisfies ResolvedPlacementSpace);
 
-const claim = (space = givenSpace()) =>
+const claim = () =>
   createFreePlacement({
     surface: 'sticker',
     targetType: 'image',
-    targetId: 77,
+    targetId: TARGET,
     placerId: PLACER,
-    space,
     data: { cosmeticId: 5 },
   });
+
+const whereOf = (predicate: (where: Record<string, unknown>) => boolean) =>
+  placementCount.mock.calls
+    .map(([args]: [{ where: Record<string, unknown> }]) => args.where)
+    .find(predicate);
 
 beforeEach(() => {
   vi.clearAllMocks();
   givenCounts();
+  givenSpace();
+  assertCanPlace.mockResolvedValue(undefined);
   placementCreate.mockResolvedValue({ id: 1 });
 });
 
@@ -81,6 +106,114 @@ describe('createFreePlacement', () => {
     expect(written.expiresAt.getTime()).toBeGreaterThan(Date.now());
   });
 
+  // The owner is taken from the space this function resolved, from the target it
+  // was given. Passing a pre-resolved space alongside a separate target let the
+  // two disagree: a caller resolving once and looping would write a placement
+  // onto image B carrying image A's owner, sending the review and every payout
+  // attribution to the wrong creator with nothing raising.
+  it('resolves the space from the target it is about, not from an argument', async () => {
+    await claim();
+
+    expect(resolveSpace).toHaveBeenCalledWith({
+      surface: 'sticker',
+      targetType: 'image',
+      targetId: TARGET,
+    });
+    expect(placementCreate.mock.calls[0][0].data.targetId).toBe(TARGET);
+  });
+});
+
+/**
+ * Free is placement that costs no Buzz, not a lighter kind of placement. Every
+ * rule about who may place on whom is untouched by the price being zero, and the
+ * function's own docstring promises they are all here — a promise PR 2's author
+ * will read and rely on.
+ */
+describe('createFreePlacement — the refusals the paid path makes', () => {
+  it('refuses a space its owner has closed', async () => {
+    givenSpace({ mode: 'off' });
+
+    await expect(claim()).rejects.toThrow(/not accepting placements/);
+    expect(placementCreate).not.toHaveBeenCalled();
+  });
+
+  // A gallery row saying `auto` predates the rule that galleries always review.
+  // Refused where it is acted on, not only where it is written: a listing that
+  // filters is not a mutation that refuses.
+  it('refuses a mode the surface no longer allows, however the row got that way', async () => {
+    givenSpace({ mode: 'auto' });
+
+    await expect(
+      createFreePlacement({
+        surface: 'remixGallery',
+        targetType: 'image',
+        targetId: TARGET,
+        placerId: PLACER,
+        data: {},
+      })
+    ).rejects.toThrow(/not accepting placements/);
+    expect(placementCreate).not.toHaveBeenCalled();
+  });
+
+  it('still allows auto on a surface that permits it', async () => {
+    givenSpace({ mode: 'auto' });
+
+    await expect(claim()).resolves.toBeDefined();
+  });
+
+  // Free self-placement is not "harmless because no money moves" — it is the
+  // creator filling their own slots so nobody else can have them, which defeats
+  // the scarcity the feature is built on.
+  it('refuses placing on your own content', async () => {
+    givenSpace({ ownerId: PLACER });
+
+    await expect(claim()).rejects.toThrow(/your own content/);
+    expect(placementCreate).not.toHaveBeenCalled();
+  });
+
+  // The half the free path could not do without: a block declines the rows
+  // pending when it lands, but a moderator suspension is the only thing that
+  // stops tomorrow's placement. Without this a suspended placer keeps placing
+  // free ones forever.
+  it('refuses a suspended or blocked placer, before any lock is taken', async () => {
+    assertCanPlace.mockRejectedValue(
+      new Error('placement: your placement privileges are suspended')
+    );
+
+    await expect(claim()).rejects.toThrow(/suspended/);
+    expect(placementCreate).not.toHaveBeenCalled();
+    // Outside the transaction, because it is I/O and `no-io-in-transaction`
+    // guards that — and because a refusal should not first queue on a lock.
+    expect(executeRaw).not.toHaveBeenCalled();
+  });
+
+  it('checks the placer against the owner it resolved, not against the target', async () => {
+    await claim();
+
+    expect(assertCanPlace).toHaveBeenCalledWith({ ownerId: OWNER, placerId: PLACER });
+  });
+
+  it('refuses once the placer holds the maximum pending with this creator', async () => {
+    givenCounts({ pending: PLACEMENT_SURFACES.sticker.maxPendingPerOwner });
+
+    await expect(claim()).rejects.toThrow(/maximum pending/);
+    expect(placementCreate).not.toHaveBeenCalled();
+  });
+
+  it('counts that cap per surface and per owner, over pending rows only', async () => {
+    givenCounts({ pending: PLACEMENT_SURFACES.sticker.maxPendingPerOwner });
+    await expect(claim()).rejects.toThrow(/maximum pending/);
+
+    expect(whereOf((where) => where.ownerId !== undefined)).toMatchObject({
+      surface: 'sticker',
+      ownerId: OWNER,
+      placerId: PLACER,
+      status: 'pending',
+    });
+  });
+});
+
+describe('createFreePlacement — the free-tier refusals', () => {
   it('refuses once the slots on this image are taken', async () => {
     givenCounts({ reserved: 4 });
 
@@ -89,23 +222,23 @@ describe('createFreePlacement', () => {
   });
 
   it('counts a pending placement as holding its slot', async () => {
-    // The distinction the whole feature rests on. `reservedFreeSlots` asks for
-    // both statuses; if it asked only for `approved`, fifty people would submit
-    // into four slots and the creator would get a fifty-item review queue.
+    // The distinction the whole feature rests on. If the count asked only for
+    // `approved`, fifty people would submit into four slots and the creator
+    // would get a fifty-item review queue.
     givenCounts({ reserved: 4 });
     await expect(claim()).rejects.toThrow(/free slots/);
 
-    const [{ where }] = placementCount.mock.calls
-      .map(([args]: [{ where: Record<string, unknown> }]) => args)
-      .filter((args: { where: Record<string, unknown> }) => args.where.status);
-    expect((where.status as { in: string[] }).in).toEqual(
-      expect.arrayContaining(['pending', 'approved'])
+    const where = whereOf(
+      (candidate) => !!candidate.status && typeof candidate.status === 'object'
     );
-    expect(where.free).toBe(true);
+    expect((where?.status as { in: string[] }).in.slice().sort()).toEqual(['approved', 'pending']);
+    expect(where).toMatchObject({ free: true, surface: 'sticker', targetId: TARGET });
   });
 
   it('refuses a space whose owner takes no free placements', async () => {
-    await expect(claim(givenSpace({ freeSlots: 0 }))).rejects.toThrow(/not taking free/);
+    givenSpace({ freeSlots: 0 });
+
+    await expect(claim()).rejects.toThrow(/not taking free/);
     expect(placementCreate).not.toHaveBeenCalled();
   });
 
@@ -116,18 +249,30 @@ describe('createFreePlacement', () => {
     expect(placementCreate).not.toHaveBeenCalled();
   });
 
-  it('spends the day whatever became of the earlier placement', async () => {
+  it('asks about free rows only, in this UTC day, whatever became of them', async () => {
     givenCounts({ usedToday: FREE_PLACEMENTS_PER_DAY });
     await expect(claim()).rejects.toThrow(/today/);
 
-    // No status predicate, on purpose and asymmetrically with the slot count
-    // above: a decline or an expiry gives the IMAGE's slot back but not the
-    // placer's day. Refunding the day turns the free tier into an unlimited
-    // retry loop against whoever declines fastest.
-    const daily = placementCount.mock.calls
-      .map(([args]: [{ where: Record<string, unknown> }]) => args.where)
-      .find((where: Record<string, unknown>) => where.createdAt);
+    const daily = whereOf((where) => !!where.createdAt);
+    // `free: true` asserted, not assumed. Without it a PAID placement spends the
+    // free day, and every other test in this file stays green.
+    expect(daily).toMatchObject({ placerId: PLACER, free: true });
+    // No status predicate, asymmetrically with the slot count above: a decline or
+    // an expiry gives the IMAGE's slot back but not the placer's day. Refunding
+    // the day turns the free tier into an unlimited retry loop against whoever
+    // declines fastest.
     expect(daily).not.toHaveProperty('status');
+    // No surface predicate: the allowance is one placement a day across the
+    // site, not one per surface.
+    expect(daily).not.toHaveProperty('surface');
+
+    // The window itself. `gte: new Date(0)` makes the allowance once-ever and
+    // `gte: Date.now()` makes it never spend; both leave every assertion above
+    // untouched.
+    const since = (daily?.createdAt as { gte: Date }).gte;
+    expect(since.toISOString()).toMatch(/T00:00:00\.000Z$/);
+    expect(since.getTime()).toBeLessThanOrEqual(Date.now());
+    expect(Date.now() - since.getTime()).toBeLessThan(24 * 3_600_000);
   });
 
   it('refuses a second free placement on the same image, ever', async () => {
@@ -142,38 +287,58 @@ describe('createFreePlacement', () => {
     await expect(claim()).rejects.toThrow(/already used/);
 
     // An image posted and deleted daily is otherwise a farm for one account's
-    // alts: a day-scoped or status-scoped version of this check would let the
-    // same placer back onto the same image tomorrow, or after a decline.
-    const everHere = placementCount.mock.calls
-      .map(([args]: [{ where: Record<string, unknown> }]) => args.where)
-      .find(
-        (where: Record<string, unknown>) =>
-          where.targetId !== undefined && !where.createdAt && !where.status
-      );
+    // alts: a day-scoped or status-scoped version would let the same placer back
+    // onto the same image tomorrow, or after a decline.
+    const everHere = whereOf(
+      (where) => where.targetId !== undefined && !where.createdAt && !where.status
+    );
     expect(everHere).toMatchObject({ placerId: PLACER, free: true, surface: 'sticker' });
   });
+});
 
-  it('takes both locks before it counts anything, placer first', async () => {
-    // The race is two placers claiming the last slot, and the counts are only a
-    // decision if nothing can insert between them and the create. Asserted on the
-    // calls because a unit test cannot observe Postgres serialising: what it CAN
-    // pin is that the locks are taken, in one fixed order, before the reads that
-    // depend on them. A second call site acquiring them the other way round is
-    // the deadlock this ordering exists to prevent.
+describe('createFreePlacement — the lock', () => {
+  const rawStatements = () =>
+    executeRaw.mock.calls.map(([strings]: [string[]]) => strings.join('?'));
+
+  it('bounds how long a claim waits, so a wedged holder cannot pile up backends', async () => {
     await claim();
 
-    expect(executeRaw).toHaveBeenCalledTimes(2);
-    expect(executeRaw.mock.invocationCallOrder[0]).toBeLessThan(
-      placementCount.mock.invocationCallOrder[0]
-    );
-    expect(executeRaw.mock.invocationCallOrder[1]).toBeLessThan(
-      placementCount.mock.invocationCallOrder[0]
-    );
-    const [placerLock, targetLock] = executeRaw.mock.calls.map(([strings]: [string[]]) =>
-      strings.join('?')
-    );
+    // `pg_advisory_xact_lock` waits forever by default, and Prisma's client-side
+    // timeout does not cancel a backend already blocked inside the statement.
+    expect(rawStatements()[0]).toContain('SET LOCAL lock_timeout');
+  });
+
+  it('takes the placer lock first and the target lock second', async () => {
+    await claim();
+
+    const [, placerLock, targetLock] = rawStatements();
     expect(placerLock).toContain('pg_advisory_xact_lock');
     expect(targetLock).toContain('hashtext');
+    expect(executeRaw).toHaveBeenCalledTimes(3);
+  });
+
+  // Asserted on the calls because a unit test cannot observe Postgres
+  // serialising. What it CAN pin is that both locks are held before the reads
+  // that depend on them, in one fixed order — a second call site acquiring them
+  // the other way round is the deadlock this ordering exists to prevent.
+  it('holds the target lock before it counts what is reserved on the target', async () => {
+    givenCounts({ reserved: 4 });
+    await expect(claim()).rejects.toThrow(/free slots/);
+
+    const targetLockAt = executeRaw.mock.invocationCallOrder[2];
+    const reservedCountAt =
+      placementCount.mock.invocationCallOrder[placementCount.mock.calls.length - 1];
+    expect(targetLockAt).toBeLessThan(reservedCountAt);
+  });
+
+  // Everyone who has already spent their day would otherwise queue on a shared,
+  // contended lock to learn a fact about nobody but themselves.
+  it('answers the placer-only question before taking the shared target lock', async () => {
+    givenCounts({ usedToday: FREE_PLACEMENTS_PER_DAY });
+    await expect(claim()).rejects.toThrow(/today/);
+
+    // Two statements, not three: it refused before the target lock existed.
+    expect(executeRaw).toHaveBeenCalledTimes(2);
   });
 
   it('claims inside one transaction, so the count and the insert cannot be split', async () => {
@@ -183,9 +348,74 @@ describe('createFreePlacement', () => {
   });
 });
 
+/**
+ * The lock ordering is load-bearing and cannot be enforced by a type.
+ *
+ * PRs 2 and 4 are written by people who have not read the file that explains it,
+ * so "take them placer-first" must not be a rule anyone has to know. The keys are
+ * module-private and there is one acquisition site; this is what makes that a
+ * fact rather than an intention, and it fails on the commit that adds a second
+ * site rather than under load six months later.
+ */
+describe('the advisory locks have exactly one call site', () => {
+  /**
+   * Any advisory lock, of any arity.
+   *
+   * Deliberately not scoped to the two-argument form. Disjoint key spaces mean a
+   * one-argument lock can never *be* one of these — but a deadlock needs a cycle
+   * in the waits-for graph, not a shared key space, so a one-argument lock taken
+   * inside this transaction deadlocks against a caller taking them the other way
+   * round exactly as one in the same space would. An arity-scoped pattern is also
+   * brittle in both directions: `pg_advisory_xact_lock(hashtext(key), id)` is a
+   * two-argument call it would miss, and `pg_advisory_xact_lock(hashtext(a, b))`
+   * a one-argument call it would flag.
+   *
+   * An explicit expected list rather than a "no new matches" count: a count
+   * passes when one caller is added and another removed, and says nothing about
+   * which files it was happy with.
+   */
+  const ADVISORY_LOCK = /pg_advisory/;
+  const ALLOWED = ['services/article.service.ts', 'services/free-placement.service.ts'];
+
+  it('is taken only inside createFreePlacement', () => {
+    const root = path.resolve(__dirname, '../..');
+    const callers = fs
+      .readdirSync(root, { recursive: true, encoding: 'utf8' })
+      .map((name) => name.split(path.sep).join('/'))
+      // Excluded explicitly rather than left to luck: this file names the
+      // function it is guarding, so without this it matches itself.
+      .filter((name) => name.endsWith('.ts') && !name.includes('__tests__/'))
+      // Comments stripped first. `webhook-debounce.ts` explains the article
+      // service's lock in prose, and an allowlist entry for a file that takes no
+      // lock is an entry nobody can later tell from a real one.
+      .filter((name) =>
+        ADVISORY_LOCK.test(
+          fs
+            .readFileSync(path.join(root, name), 'utf8')
+            .replace(/\/\*[\s\S]*?\*\//g, '')
+            .replace(/\/\/[^\n]*/g, '')
+        )
+      );
+
+    expect(callers.sort()).toEqual(ALLOWED);
+  });
+
+  it('exports nothing but the three functions, so there is no lock to take', async () => {
+    const exported = await import('~/server/services/free-placement.service');
+
+    // Surface-shaped, not name-shaped: a pattern like /LOCK/ passes for a new
+    // export under any other name, which is most of them.
+    expect(Object.keys(exported).sort()).toEqual([
+      'createFreePlacement',
+      'getFreePlacementAllowance',
+      'hasUsedFreePlacementOn',
+    ]);
+  });
+});
+
 describe('getFreePlacementAllowance', () => {
   it('reports the day as spent and says when it comes back', async () => {
-    placementCount.mockResolvedValue(FREE_PLACEMENTS_PER_DAY);
+    dbMock.dbRead.placement.count.mockResolvedValue(FREE_PLACEMENTS_PER_DAY);
 
     const allowance = await getFreePlacementAllowance({ placerId: PLACER });
 
@@ -198,48 +428,22 @@ describe('getFreePlacementAllowance', () => {
   });
 
   it('never reports a negative remainder', async () => {
-    placementCount.mockResolvedValue(FREE_PLACEMENTS_PER_DAY + 5);
+    dbMock.dbRead.placement.count.mockResolvedValue(FREE_PLACEMENTS_PER_DAY + 5);
 
     expect((await getFreePlacementAllowance({ placerId: PLACER })).remaining).toBe(0);
   });
-});
 
-/**
- * The lock ordering is load-bearing and cannot be enforced by a type.
- *
- * PRs 2 and 4 are written by people who have not read the file that explains it,
- * so "take them placer-first" must not be a rule anyone has to know. The keys are
- * module-private and there is exactly one acquisition site; this is what makes
- * that a fact rather than an intention, and it fails on the commit that adds a
- * second site rather than under load six months later.
- */
-describe('the advisory locks have exactly one call site', () => {
-  // The TWO-argument form specifically: a comma before the first closing paren.
-  // `article.service.ts` takes one-argument locks, which Postgres keeps in a
-  // separate lock space — they can neither collide with these nor deadlock
-  // against them, so sweeping them up here would make the guard fail for a
-  // reason that is not a hazard, and it would then be relaxed rather than read.
-  const TWO_ARG_LOCK = /pg_advisory_xact_lock\([^)]*,/;
+  // The predicate is shared with the claim rather than written twice. Scope it by
+  // status in one copy and the surface offers a placement the mutation refuses.
+  it('asks the same question the claim decides on', async () => {
+    dbMock.dbRead.placement.count.mockResolvedValue(0);
+    await getFreePlacementAllowance({ placerId: PLACER });
+    const displayed = dbMock.dbRead.placement.count.mock.calls[0][0].where;
 
-  const serverFiles = (): string[] => {
-    const root = path.resolve(__dirname, '../..');
-    return fs
-      .readdirSync(root, { recursive: true, encoding: 'utf8' })
-      .filter((name) => name.endsWith('.ts') && !name.endsWith('.d.ts'))
-      .map((name) => path.join(root, name));
-  };
+    givenCounts();
+    await claim();
+    const decided = whereOf((where) => !!where.createdAt);
 
-  it('is taken only inside createFreePlacement', () => {
-    const callers = serverFiles().filter((file) =>
-      TWO_ARG_LOCK.test(fs.readFileSync(file, 'utf8'))
-    );
-
-    expect(callers.map((file) => path.basename(file))).toEqual(['free-placement.service.ts']);
-  });
-
-  it('does not export its lock keys, so there is nothing to take them with', async () => {
-    const exported = await import('~/server/services/free-placement.service');
-
-    expect(Object.keys(exported).filter((name) => /LOCK|lockKey/i.test(name))).toEqual([]);
+    expect(displayed).toEqual(decided);
   });
 });

--- a/src/server/services/__tests__/free-placement.service.test.ts
+++ b/src/server/services/__tests__/free-placement.service.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import type { ResolvedPlacementSpace } from '~/server/services/placement-space.service';
+import { FREE_PLACEMENTS_PER_DAY } from '~/shared/utils/placement';
+
+const { createFreePlacement, getFreePlacementAllowance } = await import(
+  '~/server/services/free-placement.service'
+);
+
+const OWNER = 10;
+const PLACER = 20;
+
+const placementCount = dbMock.dbWrite.placement.count;
+const placementCreate = dbMock.dbWrite.placement.create;
+const executeRaw = dbMock.dbWrite.$executeRaw;
+
+/**
+ * The three counts the claim runs, told apart by their `where` rather than by
+ * the order they happen to be called in.
+ *
+ * Ordering the answers with `mockResolvedValueOnce` would pass just as well if
+ * the service asked the same question three times — which is the mistake worth
+ * catching, since the daily allowance and the never-twice rule differ only in
+ * their predicate.
+ */
+const givenCounts = ({ usedToday = 0, alreadyHere = 0, reserved = 0 } = {}) =>
+  placementCount.mockImplementation(async ({ where }: { where: Record<string, unknown> }) => {
+    if (where.createdAt) return usedToday;
+    if (where.status) return reserved;
+    if (where.targetId !== undefined) return alreadyHere;
+    throw new Error(`unrecognised count: ${JSON.stringify(where)}`);
+  });
+
+const givenSpace = (overrides: Partial<ResolvedPlacementSpace> = {}): ResolvedPlacementSpace => ({
+  ownerId: OWNER,
+  ownerUsername: 'creator',
+  mode: 'review',
+  setPrice: 100,
+  price: 100,
+  cap: 500,
+  ownerShare: 1,
+  setFreeSlots: 4,
+  freeSlots: 4,
+  freeSlotCap: 4,
+  // Deliberately generous, and deliberately ignored by the service: this is what
+  // the caller SHOWED someone, computed before their other checks ran. Every
+  // refusal below has to come from the counts re-read under the lock instead.
+  freeSlotsRemaining: 99,
+  settings: {},
+  ...overrides,
+});
+
+const claim = (space = givenSpace()) =>
+  createFreePlacement({
+    surface: 'sticker',
+    targetType: 'image',
+    targetId: 77,
+    placerId: PLACER,
+    space,
+    data: { cosmeticId: 5 },
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  givenCounts();
+  placementCreate.mockResolvedValue({ id: 1 });
+});
+
+describe('createFreePlacement', () => {
+  it('writes a free row worth nothing, with a deadline on it', async () => {
+    await claim();
+
+    const written = placementCreate.mock.calls[0][0].data;
+    expect(written).toMatchObject({ free: true, amount: 0, status: 'pending', ownerId: OWNER });
+    // The deadline is what releases the slot when the creator never acts. A free
+    // row without one holds a slot forever and no sweep will reach it: the expiry
+    // query is `expiresAt <= now()`, which NULL never satisfies.
+    expect(written.expiresAt).toBeInstanceOf(Date);
+    expect(written.expiresAt.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('refuses once the slots on this image are taken', async () => {
+    givenCounts({ reserved: 4 });
+
+    await expect(claim()).rejects.toThrow(/free slots/);
+    expect(placementCreate).not.toHaveBeenCalled();
+  });
+
+  it('counts a pending placement as holding its slot', async () => {
+    // The distinction the whole feature rests on. `reservedFreeSlots` asks for
+    // both statuses; if it asked only for `approved`, fifty people would submit
+    // into four slots and the creator would get a fifty-item review queue.
+    givenCounts({ reserved: 4 });
+    await expect(claim()).rejects.toThrow(/free slots/);
+
+    const [{ where }] = placementCount.mock.calls
+      .map(([args]: [{ where: Record<string, unknown> }]) => args)
+      .filter((args: { where: Record<string, unknown> }) => args.where.status);
+    expect((where.status as { in: string[] }).in).toEqual(
+      expect.arrayContaining(['pending', 'approved'])
+    );
+    expect(where.free).toBe(true);
+  });
+
+  it('refuses a space whose owner takes no free placements', async () => {
+    await expect(claim(givenSpace({ freeSlots: 0 }))).rejects.toThrow(/not taking free/);
+    expect(placementCreate).not.toHaveBeenCalled();
+  });
+
+  it('refuses a second free placement in the same UTC day', async () => {
+    givenCounts({ usedToday: FREE_PLACEMENTS_PER_DAY });
+
+    await expect(claim()).rejects.toThrow(/today/);
+    expect(placementCreate).not.toHaveBeenCalled();
+  });
+
+  it('spends the day whatever became of the earlier placement', async () => {
+    givenCounts({ usedToday: FREE_PLACEMENTS_PER_DAY });
+    await expect(claim()).rejects.toThrow(/today/);
+
+    // No status predicate, on purpose and asymmetrically with the slot count
+    // above: a decline or an expiry gives the IMAGE's slot back but not the
+    // placer's day. Refunding the day turns the free tier into an unlimited
+    // retry loop against whoever declines fastest.
+    const daily = placementCount.mock.calls
+      .map(([args]: [{ where: Record<string, unknown> }]) => args.where)
+      .find((where: Record<string, unknown>) => where.createdAt);
+    expect(daily).not.toHaveProperty('status');
+  });
+
+  it('refuses a second free placement on the same image, ever', async () => {
+    givenCounts({ alreadyHere: 1 });
+
+    await expect(claim()).rejects.toThrow(/already used a free placement here/);
+    expect(placementCreate).not.toHaveBeenCalled();
+  });
+
+  it('asks about this image without a date or a status, so it means "ever"', async () => {
+    givenCounts({ alreadyHere: 1 });
+    await expect(claim()).rejects.toThrow(/already used/);
+
+    // An image posted and deleted daily is otherwise a farm for one account's
+    // alts: a day-scoped or status-scoped version of this check would let the
+    // same placer back onto the same image tomorrow, or after a decline.
+    const everHere = placementCount.mock.calls
+      .map(([args]: [{ where: Record<string, unknown> }]) => args.where)
+      .find(
+        (where: Record<string, unknown>) =>
+          where.targetId !== undefined && !where.createdAt && !where.status
+      );
+    expect(everHere).toMatchObject({ placerId: PLACER, free: true, surface: 'sticker' });
+  });
+
+  it('takes both locks before it counts anything, placer first', async () => {
+    // The race is two placers claiming the last slot, and the counts are only a
+    // decision if nothing can insert between them and the create. Asserted on the
+    // calls because a unit test cannot observe Postgres serialising: what it CAN
+    // pin is that the locks are taken, in one fixed order, before the reads that
+    // depend on them. A second call site acquiring them the other way round is
+    // the deadlock this ordering exists to prevent.
+    await claim();
+
+    expect(executeRaw).toHaveBeenCalledTimes(2);
+    expect(executeRaw.mock.invocationCallOrder[0]).toBeLessThan(
+      placementCount.mock.invocationCallOrder[0]
+    );
+    expect(executeRaw.mock.invocationCallOrder[1]).toBeLessThan(
+      placementCount.mock.invocationCallOrder[0]
+    );
+    const [placerLock, targetLock] = executeRaw.mock.calls.map(([strings]: [string[]]) =>
+      strings.join('?')
+    );
+    expect(placerLock).toContain('pg_advisory_xact_lock');
+    expect(targetLock).toContain('hashtext');
+  });
+
+  it('claims inside one transaction, so the count and the insert cannot be split', async () => {
+    await claim();
+
+    expect(dbMock.dbWrite.$transaction).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('getFreePlacementAllowance', () => {
+  it('reports the day as spent and says when it comes back', async () => {
+    placementCount.mockResolvedValue(FREE_PLACEMENTS_PER_DAY);
+
+    const allowance = await getFreePlacementAllowance({ placerId: PLACER });
+
+    expect(allowance).toMatchObject({ used: FREE_PLACEMENTS_PER_DAY, remaining: 0 });
+    expect(allowance.resetsAt.getTime()).toBeGreaterThan(Date.now());
+    // Midnight UTC, not the placer's midnight: a local day would refresh twice
+    // for anyone willing to change timezone, and two servers would disagree about
+    // which day a placement fell in.
+    expect(allowance.resetsAt.toISOString()).toMatch(/T00:00:00\.000Z$/);
+  });
+
+  it('never reports a negative remainder', async () => {
+    placementCount.mockResolvedValue(FREE_PLACEMENTS_PER_DAY + 5);
+
+    expect((await getFreePlacementAllowance({ placerId: PLACER })).remaining).toBe(0);
+  });
+});

--- a/src/server/services/__tests__/free-placement.service.test.ts
+++ b/src/server/services/__tests__/free-placement.service.test.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+import path from 'path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 import type { ResolvedPlacementSpace } from '~/server/services/placement-space.service';
@@ -199,5 +201,45 @@ describe('getFreePlacementAllowance', () => {
     placementCount.mockResolvedValue(FREE_PLACEMENTS_PER_DAY + 5);
 
     expect((await getFreePlacementAllowance({ placerId: PLACER })).remaining).toBe(0);
+  });
+});
+
+/**
+ * The lock ordering is load-bearing and cannot be enforced by a type.
+ *
+ * PRs 2 and 4 are written by people who have not read the file that explains it,
+ * so "take them placer-first" must not be a rule anyone has to know. The keys are
+ * module-private and there is exactly one acquisition site; this is what makes
+ * that a fact rather than an intention, and it fails on the commit that adds a
+ * second site rather than under load six months later.
+ */
+describe('the advisory locks have exactly one call site', () => {
+  // The TWO-argument form specifically: a comma before the first closing paren.
+  // `article.service.ts` takes one-argument locks, which Postgres keeps in a
+  // separate lock space — they can neither collide with these nor deadlock
+  // against them, so sweeping them up here would make the guard fail for a
+  // reason that is not a hazard, and it would then be relaxed rather than read.
+  const TWO_ARG_LOCK = /pg_advisory_xact_lock\([^)]*,/;
+
+  const serverFiles = (): string[] => {
+    const root = path.resolve(__dirname, '../..');
+    return fs
+      .readdirSync(root, { recursive: true, encoding: 'utf8' })
+      .filter((name) => name.endsWith('.ts') && !name.endsWith('.d.ts'))
+      .map((name) => path.join(root, name));
+  };
+
+  it('is taken only inside createFreePlacement', () => {
+    const callers = serverFiles().filter((file) =>
+      TWO_ARG_LOCK.test(fs.readFileSync(file, 'utf8'))
+    );
+
+    expect(callers.map((file) => path.basename(file))).toEqual(['free-placement.service.ts']);
+  });
+
+  it('does not export its lock keys, so there is nothing to take them with', async () => {
+    const exported = await import('~/server/services/free-placement.service');
+
+    expect(Object.keys(exported).filter((name) => /LOCK|lockKey/i.test(name))).toEqual([]);
   });
 });

--- a/src/server/services/__tests__/placement-escrow.service.test.ts
+++ b/src/server/services/__tests__/placement-escrow.service.test.ts
@@ -290,6 +290,10 @@ const givenPlacement = (overrides: Record<string, unknown> = {}) => {
     // double answer `undefined` where Postgres answers NULL, which is a
     // different thing to a `where: { spendType: null }` predicate.
     spendType: null,
+    // Present and false, as the column is on a real row. Left off, `free` reads
+    // `undefined` here where Postgres answers false — falsy either way today, and
+    // a difference the moment anything compares it rather than tests it.
+    free: false,
     expiresAt: null,
     resolvedAt: null,
     resolvedById: null,
@@ -1746,5 +1750,102 @@ describe('the Buzz call bound', () => {
     expect(BUZZ_CALL_TIMEOUT_MS).toBeLessThanOrEqual(120_000);
     expect(BUZZ_CALL_TIMEOUT_MS).toBeLessThan(LEG_RETRY_BACKOFF_MINUTES * 60_000);
     expect(BUZZ_CALL_TIMEOUT_MS).toBeGreaterThanOrEqual(10_000);
+  });
+});
+
+describe('a free placement never touches the money path', () => {
+  /**
+   * Escrow that a free row must not be able to release.
+   *
+   * Receipted, so `heldAmountsFor` counts it as real Buzz sitting in the escrow
+   * account. That state should be unreachable — the free path takes no holds and
+   * `holdPlacementEscrow` refuses a free row — and it is exactly the state the
+   * guard has to survive, because "unreachable" is a claim about today's callers
+   * and PRs 2 and 4 are the callers that do not exist yet.
+   *
+   * Without this fixture the free-row tests below are vacuous: with no holds,
+   * every branch of the payout already computes to zero and is filtered out, so
+   * deleting the guard would change nothing they observe.
+   */
+  const givenReceiptedHolds = () => {
+    db.legs.set('1:holdFee', {
+      placementId: 1,
+      kind: 'holdFee',
+      amount: 300,
+      transactionId: 'placement-1-holdFee',
+      attempts: 1,
+      createdAt: new Date(0),
+    });
+    db.legs.set('1:holdPrincipal', {
+      placementId: 1,
+      kind: 'holdPrincipal',
+      amount: 700,
+      transactionId: 'placement-1-holdPrincipal',
+      attempts: 1,
+      createdAt: new Date(0),
+    });
+  };
+
+  it('plans nothing on approval, even with escrow sitting behind the row', async () => {
+    givenPlacement({ free: true, amount: 0 });
+    givenReceiptedHolds();
+    clearMoneyMocks();
+
+    await settlePlacement({ placementId: 1, action: 'approve', actorId: OWNER });
+
+    expect(legsFor(1)).toEqual({ holdFee: 300, holdPrincipal: 700 });
+    expect(moneyMoved()).toBe(0);
+  });
+
+  it('takes no decline fee, so a decline costs the placer nothing', async () => {
+    givenPlacement({ free: true, amount: 0 });
+    givenReceiptedHolds();
+    clearMoneyMocks();
+
+    await settlePlacement({ placementId: 1, action: 'decline', actorId: OWNER });
+
+    expect(legsFor(1)).not.toHaveProperty('feeToOwner');
+    expect(moneyMoved()).toBe(0);
+  });
+
+  it('refunds nothing on expiry, because nothing was ever taken', async () => {
+    givenPlacement({ free: true, amount: 0 });
+    givenReceiptedHolds();
+    clearMoneyMocks();
+
+    await settlePlacement({ placementId: 1, action: 'expire' });
+
+    expect(legsFor(1)).not.toHaveProperty('principalToPlacer');
+    expect(moneyMoved()).toBe(0);
+  });
+
+  it('still settles the row, so the slot it holds is released', async () => {
+    givenPlacement({ free: true, amount: 0 });
+
+    const { settled, placement } = await settlePlacement({ placementId: 1, action: 'decline' });
+
+    // The money is the part that does nothing. The status transition is the part
+    // that matters — it is what takes the placement out of
+    // `FREE_SLOT_HOLDING_STATUSES` and hands the slot to the next placer.
+    expect(settled).toBe(true);
+    expect(placement.status).toBe('declined');
+  });
+
+  it('refuses to take escrow at all, rather than holding zero', async () => {
+    givenPlacement({ free: true, amount: 0 });
+    clearMoneyMocks();
+
+    await expect(
+      holdPlacementEscrow({
+        placementId: 1,
+        placerId: PLACER,
+        surface: 'sticker',
+        amount: 100,
+        spendType: 'yellow',
+      })
+    ).rejects.toThrow(/free/);
+
+    expect(moneyMoved()).toBe(0);
+    expect(legsFor(1)).toEqual({});
   });
 });

--- a/src/server/services/__tests__/placement-space.service.test.ts
+++ b/src/server/services/__tests__/placement-space.service.test.ts
@@ -212,7 +212,10 @@ describe('setPlacementSpace — the price guard', () => {
 });
 
 describe('resolvePlacementSpaceFor — free capacity', () => {
-  const placementCount = dbMock.dbWrite.placement.count;
+  // `dbRead`: the reservation feeds a display-only number on a public query, and
+  // the claim re-counts under its own lock. Everything else in this resolver
+  // reads the primary because it decides a mutation.
+  const placementCount = dbMock.dbRead.placement.count;
 
   const resolve = () =>
     resolvePlacementSpaceFor({ surface: 'sticker', targetType: 'image', targetId: 42 });

--- a/src/server/services/__tests__/placement-space.service.test.ts
+++ b/src/server/services/__tests__/placement-space.service.test.ts
@@ -10,10 +10,20 @@ const imageFindUnique = dbMock.dbWrite.image.findUnique;
 
 vi.mock('~/server/services/placement.service', async (importOriginal) => ({
   ...(await importOriginal<typeof PlacementService>()),
-  placementPriceRange: async () => ({ min: 0, max: 500, score: 0, tier: 'free' as const }),
+  placementPriceRange: async () => ({
+    min: 0,
+    max: 500,
+    freeSlotCap: capState.freeSlotCap,
+    score: 0,
+    tier: 'free' as const,
+  }),
 }));
 
-const { setPlacementSpace } = await import('~/server/services/placement-space.service');
+const capState = { freeSlotCap: 4 };
+
+const { resolvePlacementSpaceFor, setPlacementSpace } = await import(
+  '~/server/services/placement-space.service'
+);
 
 const OWNER = 7;
 const base = {
@@ -198,5 +208,130 @@ describe('setPlacementSpace — the price guard', () => {
     expect(PLACEMENT_SURFACES.remixGallery.defaultPrice!).toBeGreaterThanOrEqual(
       PLACEMENT_SURFACES.remixGallery.serverMinPrice
     );
+  });
+});
+
+describe('resolvePlacementSpaceFor — free capacity', () => {
+  const placementCount = dbMock.dbWrite.placement.count;
+
+  const resolve = () =>
+    resolvePlacementSpaceFor({ surface: 'sticker', targetType: 'image', targetId: 42 });
+
+  beforeEach(() => {
+    capState.freeSlotCap = 4;
+    imageFindUnique.mockResolvedValue({
+      id: 42,
+      userId: OWNER,
+      postId: null,
+      user: { username: 'creator' },
+    });
+    placementCount.mockResolvedValue(0);
+  });
+
+  it('gives an unconfigured space the surface default', async () => {
+    const space = await resolve();
+
+    expect(space.setFreeSlots).toBe(PLACEMENT_SURFACES.sticker.defaultFreeSlots);
+    expect(space.freeSlots).toBe(PLACEMENT_SURFACES.sticker.defaultFreeSlots);
+    expect(space.freeSlotsRemaining).toBe(PLACEMENT_SURFACES.sticker.defaultFreeSlots);
+  });
+
+  it('subtracts what is already reserved', async () => {
+    spaceFindMany.mockResolvedValue([
+      { entityType: 'image', mode: 'review', price: 100, freeSlots: 4 },
+    ]);
+    placementCount.mockResolvedValue(3);
+
+    expect((await resolve()).freeSlotsRemaining).toBe(1);
+  });
+
+  // Both statuses, and free rows only. A count that took every status would never
+  // release a slot after a decline; one that ignored `free` would let paid
+  // placements eat the free capacity, which the two counters exist to keep apart.
+  it('reserves against pending and approved free rows, and nothing else', async () => {
+    spaceFindMany.mockResolvedValue([
+      { entityType: 'image', mode: 'review', price: 100, freeSlots: 4 },
+    ]);
+
+    await resolve();
+
+    const { where } = placementCount.mock.calls[0][0];
+    expect(where).toMatchObject({
+      surface: 'sticker',
+      targetType: 'image',
+      targetId: 42,
+      free: true,
+    });
+    expect(where.status.in.slice().sort()).toEqual(['approved', 'pending']);
+  });
+
+  it('never reports negative room when the owner lowers their slider', async () => {
+    // Not a takeback: the placements they already accepted stay, and the space
+    // simply accepts nothing further until one is released.
+    spaceFindMany.mockResolvedValue([
+      { entityType: 'image', mode: 'review', price: 100, freeSlots: 1 },
+    ]);
+    placementCount.mockResolvedValue(3);
+
+    expect((await resolve()).freeSlotsRemaining).toBe(0);
+  });
+
+  it('ceilings a stored count at the cap without rewriting the row', async () => {
+    capState.freeSlotCap = 2;
+    spaceFindMany.mockResolvedValue([
+      { entityType: 'image', mode: 'review', price: 100, freeSlots: 9 },
+    ]);
+
+    const space = await resolve();
+
+    expect(space.setFreeSlots).toBe(9);
+    expect(space.freeSlots).toBe(2);
+  });
+
+  it('asks nothing of the database when the space takes no free placements', async () => {
+    spaceFindMany.mockResolvedValue([
+      { entityType: 'image', mode: 'review', price: 100, freeSlots: 0 },
+    ]);
+
+    const space = await resolve();
+
+    expect(space.freeSlotsRemaining).toBe(0);
+    // The answer is 0 whatever the count says, so the query is a round trip that
+    // cannot change it.
+    expect(placementCount).not.toHaveBeenCalled();
+  });
+});
+
+describe('setPlacementSpace — free slots', () => {
+  // The same three-way distinction as the price, and it has to be, because the
+  // per-image toggle sends `mode` and `price` and nothing else: without this an
+  // owner flipping one image on would silently clear their account-level count.
+  it('leaves a stored count alone when none is sent', async () => {
+    await setPlacementSpace({ ...base, mode: 'review' });
+
+    expect(priceWritten()).not.toHaveProperty('freeSlots');
+  });
+
+  it('clears a count to null so the level inherits again', async () => {
+    await setPlacementSpace({ ...base, mode: 'review', freeSlots: null });
+
+    expect(priceWritten()).toMatchObject({ freeSlots: null });
+  });
+
+  // Stored uncapped, exactly as the price is. A creator whose tier lapses and
+  // returns gets their number back rather than finding it silently rewritten to
+  // whatever their cap happened to be on the day they last saved.
+  it('stores a count above the current cap rather than refusing or clamping it', async () => {
+    await setPlacementSpace({ ...base, mode: 'review', freeSlots: 9 });
+
+    expect(priceWritten()).toMatchObject({ freeSlots: 9 });
+  });
+
+  // The state that replaces an on/off toggle. Written through, not treated as
+  // "unset", or the creator's no would resolve back to the surface default.
+  it('stores an explicit zero', async () => {
+    await setPlacementSpace({ ...base, mode: 'review', freeSlots: 0 });
+
+    expect(priceWritten()).toMatchObject({ freeSlots: 0 });
   });
 });

--- a/src/server/services/__tests__/placement-space.service.test.ts
+++ b/src/server/services/__tests__/placement-space.service.test.ts
@@ -315,6 +315,28 @@ describe('setPlacementSpace — free slots', () => {
     expect(priceWritten()).not.toHaveProperty('freeSlots');
   });
 
+  /**
+   * The `create` half, which every other test here reads past — `priceWritten()`
+   * is the `update` clause.
+   *
+   * This is the first-ever save for a space, and it is the likeliest place for
+   * the freeze-the-default failure to land: `freeSlots: freeSlots ?? 0` in the
+   * create clause writes an explicit `0` for a creator who has expressed no
+   * preference, permanently opting the space out of tracking the surface default
+   * AND closing it. Every assertion on the `update` side stays green.
+   */
+  it('creates a first-ever row with no count of its own, not with a zero', async () => {
+    await setPlacementSpace({ ...base, mode: 'review' });
+
+    expect(spaceUpsert.mock.calls[0][0].create).toMatchObject({ freeSlots: null });
+  });
+
+  it('creates with the count when the creator did choose one', async () => {
+    await setPlacementSpace({ ...base, mode: 'review', freeSlots: 0 });
+
+    expect(spaceUpsert.mock.calls[0][0].create).toMatchObject({ freeSlots: 0 });
+  });
+
   it('clears a count to null so the level inherits again', async () => {
     await setPlacementSpace({ ...base, mode: 'review', freeSlots: null });
 

--- a/src/server/services/__tests__/placement.service.test.ts
+++ b/src/server/services/__tests__/placement.service.test.ts
@@ -4,6 +4,7 @@ import {
   MAX_DECLINE_FEE_RATE,
   MIN_DECLINE_FEE_RATE,
   MIN_OWNER_SHARE,
+  PLACEMENT_FREE_SLOT_CAP_TIERS,
   PLACEMENT_PRICE_CAP_TIERS,
   PLACEMENT_SURFACES,
   placementSurfaces,
@@ -170,5 +171,72 @@ describe('placementPriceRange', () => {
     const range = await placementPriceRange(1, 'sticker');
     expect(range.score).toBe(0);
     expect(range.max).toBe(100);
+  });
+});
+
+describe('the free-slot cap table', () => {
+  const band = (caps: Record<string, number>) => [{ minScore: 0, caps }];
+
+  it('is what decides the free-slot cap, not the price table', async () => {
+    storedConfig({
+      priceCapTiers: band({ free: 999, bronze: 999, silver: 999, gold: 999 }),
+      freeSlotTiers: band({ free: 3, bronze: 4, silver: 5, gold: 6 }),
+    });
+
+    const range = await placementPriceRange(1, 'sticker');
+
+    // Two numbers from two tables through one query. Reading `max` for both is
+    // the failure this separates: a creator's Buzz ceiling is in the hundreds,
+    // and applied to slots it would be hundreds of free placements per image.
+    expect(range.freeSlotCap).toBe(3);
+    expect(range.max).toBe(999);
+  });
+
+  it('takes a per-surface override over the shared one', async () => {
+    storedConfig({
+      freeSlotTiers: band({ free: 2, bronze: 2, silver: 2, gold: 2 }),
+      freeSlotTiersBySurface: {
+        remixGallery: band({ free: 7, bronze: 7, silver: 7, gold: 7 }),
+      },
+    });
+
+    expect((await placementPriceRange(1, 'sticker')).freeSlotCap).toBe(2);
+    expect((await placementPriceRange(1, 'remixGallery')).freeSlotCap).toBe(7);
+  });
+
+  /**
+   * The failure this closes is not "the override is ignored" — it is the override
+   * falling back to the wrong table.
+   *
+   * A stored table with no zero band is unusable, and the shared helper that
+   * detects that has to be handed the FREE-SLOT defaults. Handed the price ones
+   * instead, a single malformed config edit silently grants 500-1000 free
+   * placements per space, which is the price cap read as a slot count.
+   */
+  it('falls back to the compiled free-slot table when the stored one is unusable', async () => {
+    storedConfig({ freeSlotTiers: band({ free: 5, bronze: 5, silver: 5, gold: 5 }) });
+    const configured = (await placementPriceRange(1, 'sticker')).freeSlotCap;
+
+    storedConfig({
+      freeSlotTiers: [{ minScore: 5_000, caps: { free: 5, bronze: 5, silver: 5, gold: 5 } }],
+    });
+    const fellBack = (await placementPriceRange(1, 'sticker')).freeSlotCap;
+
+    expect(configured).toBe(5);
+    // Asserted by identity against the compiled table rather than against a
+    // literal, the same way the price side is: a number would also match the
+    // price table's bottom band on the day someone gets the fallback wrong.
+    expect(fellBack).toBe(PLACEMENT_FREE_SLOT_CAP_TIERS[0].caps.free);
+    expect(fellBack).not.toBe(PLACEMENT_PRICE_CAP_TIERS[0].caps.free);
+  });
+
+  it('refuses a fractional slot count the same way it refuses a fractional price', async () => {
+    storedConfig({ freeSlotTiers: band({ free: 1.5, bronze: 2, silver: 3, gold: 4 }) });
+
+    // The whole config fails to parse and every accessor falls back, which is the
+    // documented behaviour: a bad edit must not take the feature down.
+    expect((await placementPriceRange(1, 'sticker')).freeSlotCap).toBe(
+      PLACEMENT_FREE_SLOT_CAP_TIERS[0].caps.free
+    );
   });
 });

--- a/src/server/services/free-placement.service.ts
+++ b/src/server/services/free-placement.service.ts
@@ -61,6 +61,13 @@ const TARGET_LOCK_CLASS = 0x74ee0002;
  * timeout does not cancel a backend already blocked inside the lock statement.
  * Without a bound, a wedged holder accumulates blocked backends on the write
  * pool rather than failing the claims that are queued behind it.
+ *
+ * ⚠️ Compiled into the statement below rather than bound as a parameter, because
+ * **Postgres has no parameter form for `SET`** — a tagged-template `$executeRaw`
+ * sends `$1` and the statement raises `syntax error at or near "$1"`. Every other
+ * `SET LOCAL` in this repo uses `$executeRawUnsafe` or a raw `client.query` for
+ * the same reason. A module constant, so "unsafe" is about the API's name and not
+ * about anything reaching it from a request.
  */
 const LOCK_TIMEOUT = '3s';
 
@@ -212,7 +219,7 @@ export async function createFreePlacement({
   const expiresAt = new Date(Date.now() + expiryHours * 3_600_000);
 
   return dbWrite.$transaction(async (tx) => {
-    await tx.$executeRaw`SET LOCAL lock_timeout = ${LOCK_TIMEOUT}`;
+    await tx.$executeRawUnsafe(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
     await tx.$executeRaw`SELECT pg_advisory_xact_lock(${PLACER_LOCK_CLASS}::int, ${placerId}::int)`;
 
     const usedToday = await countFreePlacementsToday(tx, placerId);

--- a/src/server/services/free-placement.service.ts
+++ b/src/server/services/free-placement.service.ts
@@ -1,0 +1,232 @@
+import type { Prisma } from '@prisma/client';
+import { dbWrite } from '~/server/db/client';
+import { getPlacementConfig } from '~/server/services/placement.service';
+import type { ResolvedPlacementSpace } from '~/server/services/placement-space.service';
+import { reservedFreeSlots } from '~/server/services/placement-space.service';
+import { throwBadRequestError } from '~/server/utils/errorHandling';
+import type { PlacementSpaceEntity, PlacementSurface } from '~/shared/utils/placement';
+import {
+  FREE_PLACEMENTS_PER_DAY,
+  PLACEMENT_SURFACES,
+  freePlacementDayStart,
+} from '~/shared/utils/placement';
+
+/**
+ * A placement made against a creator's free capacity instead of paid for.
+ *
+ * The whole free path is here rather than branched into each surface, and that
+ * is the point of this file: three refusals — capacity, the daily allowance, and
+ * never twice on the same target — have to hold together, under a lock, in the
+ * same transaction as the insert. A surface that built its own row and then
+ * checked would be a second creation route with the checks bolted on the
+ * outside, which is where the free tier stops being scarce.
+ *
+ * Escrow is bypassed **entirely**, not taken at zero. Zero-amount Buzz
+ * transactions are a landmine, and the escrow's two-hold structure has neither a
+ * decline fee nor a principal to hold — `holdPlacementEscrow` refuses a free row
+ * outright for that reason.
+ */
+
+/**
+ * Advisory-lock class keys. Two-argument advisory locks occupy a lock space
+ * distinct from the one-argument form, so these cannot collide with
+ * `article.service.ts`'s bare-id locks however its ids grow.
+ */
+const PLACER_LOCK_CLASS = 0x74ee0001;
+const TARGET_LOCK_CLASS = 0x74ee0002;
+
+/**
+ * A stable key for one space, hashed into the lock below.
+ *
+ * The surface is in it because the same image id is a valid target on both
+ * surfaces, and locking on the id alone would serialise a sticker placement
+ * behind an unrelated remix submission. Hash collisions are possible and
+ * harmless — two unrelated spaces sharing one serialise with each other, which
+ * costs a little contention and no correctness.
+ */
+const spaceLockKey = (
+  surface: PlacementSurface,
+  targetType: PlacementSpaceEntity,
+  targetId: number
+) => `${surface}:${targetType}:${targetId}`;
+
+export type CreateFreePlacement = {
+  surface: PlacementSurface;
+  targetType: PlacementSpaceEntity;
+  targetId: number;
+  placerId: number;
+  /**
+   * The space as `resolvePlacementSpaceFor` returned it, carried whole rather
+   * than as a handful of extracted numbers. The caller has already resolved it
+   * to check the mode and the owner, and passing the object means the owner and
+   * the capacity cannot arrive from two different resolutions of the same space.
+   *
+   * ⚠️ `freeSlotsRemaining` on it is NOT what this decides on — it was computed
+   * before the caller's other checks ran and is stale by the time it gets here.
+   * Only `freeSlots`, the capacity, is read; the reservation is re-counted under
+   * the lock.
+   */
+  space: ResolvedPlacementSpace;
+  /** Who sold the placed thing, when an approval would owe them a cut. */
+  sellerId?: number | null;
+  /** The surface's own payload. Opaque here, exactly as on the paid path. */
+  data: Prisma.InputJsonValue;
+};
+
+/**
+ * Claims a free slot and creates the placement, or refuses.
+ *
+ * **The race is closed by two transaction-scoped advisory locks, not by a unique
+ * constraint.** Neither rule this enforces is expressible as one: "at most N
+ * pending-or-approved free rows for this target" and "at most one free row for
+ * this placer today" are both counts, and Postgres has no partial-unique form
+ * for a count. The alternatives were a serializable transaction, which turns a
+ * lost race into a retry the caller has to write, and `withDistributedLock`,
+ * which returns null rather than running when Redis is down — a free placement
+ * would then be refused during a Redis outage while the paid path kept working.
+ * An advisory lock needs no extra infrastructure, releases on commit or rollback
+ * with nothing to leak, and makes count-then-insert atomic without anyone
+ * holding a row lock on `Placement`.
+ *
+ * Both locks are taken in a fixed order — placer, then target — because a
+ * placement takes both, and two callers acquiring them in opposite orders is the
+ * textbook deadlock. The order is arbitrary; that it is the same everywhere is
+ * not.
+ *
+ * The deadline is computed BEFORE the transaction opens and written by the same
+ * insert. `holdPlacementEscrow` stamps the paid path's deadline in a second
+ * statement, and its comment explains what a throw between the two costs: a
+ * pending row with a NULL `expiresAt` is never `<= now()`, so the expiry sweep
+ * steps over it forever. On the free path that row would also hold one of the
+ * creator's slots for good, so there is no window at all — one statement, one
+ * row, deadline included.
+ */
+export async function createFreePlacement({
+  surface,
+  targetType,
+  targetId,
+  placerId,
+  space,
+  sellerId,
+  data,
+}: CreateFreePlacement) {
+  if (space.freeSlots <= 0)
+    throw throwBadRequestError('placement: this creator is not taking free placements here');
+
+  // Read before the transaction opens: `getPlacementConfig` touches KeyValue, and
+  // I/O inside a transaction is a repo rule with its own lint guard. It falls
+  // back to the compiled defaults on its own rather than throwing, so there is no
+  // path where this leaves the deadline unset.
+  const expiryHours = (await getPlacementConfig()).expiryHours(surface);
+  const expiresAt = new Date(Date.now() + expiryHours * 3_600_000);
+
+  return dbWrite.$transaction(async (tx) => {
+    await tx.$executeRaw`SELECT pg_advisory_xact_lock(${PLACER_LOCK_CLASS}::int, ${placerId}::int)`;
+    await tx.$executeRaw`SELECT pg_advisory_xact_lock(${TARGET_LOCK_CLASS}::int, hashtext(${spaceLockKey(
+      surface,
+      targetType,
+      targetId
+    )}))`;
+
+    // Every status, deliberately. A decline or an expiry gives the image's slot
+    // back but NOT the placer's day — refunding the day would turn the free tier
+    // into an unlimited retry loop against whoever declines fastest.
+    const usedToday = await tx.placement.count({
+      where: { placerId, free: true, createdAt: { gte: freePlacementDayStart() } },
+    });
+    if (usedToday >= FREE_PLACEMENTS_PER_DAY)
+      throw throwBadRequestError(
+        'placement: you have used your free placement for today. It resets at midnight UTC.'
+      );
+
+    // Once ever: not once per day, and not scoped by status. An image posted and
+    // deleted daily is otherwise a farm for one account's alts. Scoped to this
+    // surface, because placing a sticker and submitting a remix are different
+    // acts on the same image and one should not consume the other.
+    const already = await tx.placement.count({
+      where: { placerId, free: true, surface, targetType, targetId },
+    });
+    if (already > 0)
+      throw throwBadRequestError(
+        `placement: you have already used a free placement here. Free ${PLACEMENT_SURFACES[surface].label} are once per image.`
+      );
+
+    // Re-counted inside the lock. `space.freeSlotsRemaining` is what the caller
+    // showed someone; this is what decides.
+    const reserved = await reservedFreeSlots(tx as typeof dbWrite, {
+      surface,
+      targetType,
+      targetId,
+    });
+    if (reserved >= space.freeSlots)
+      throw throwBadRequestError('placement: the free slots on this one are taken');
+
+    return tx.placement.create({
+      data: {
+        surface,
+        targetType,
+        targetId,
+        ownerId: space.ownerId,
+        placerId,
+        sellerId: sellerId ?? null,
+        free: true,
+        // Zero, and the DB enforces it. Nothing sizes a payout from this — the
+        // money path reads receipted holds, of which there are none — but every
+        // report and every support answer quotes it, and a free placement
+        // carrying a price says a creator earned something they did not.
+        amount: 0,
+        status: 'pending',
+        expiresAt,
+        data,
+      },
+      select: { id: true },
+    });
+  });
+}
+
+/**
+ * Where a placer stands against their daily allowance.
+ *
+ * For surfaces that need to say so before someone commits — the free/paid choice
+ * is worth making with the number visible, and an allowance spent silently is
+ * the worst version of a scarce thing.
+ *
+ * **A listing, not a guard.** It is stale the moment it returns, and the refusal
+ * lives in `createFreePlacement` under the lock. Do not gate a mutation on it.
+ */
+export async function getFreePlacementAllowance({ placerId }: { placerId: number }) {
+  const dayStart = freePlacementDayStart();
+  const used = await dbWrite.placement.count({
+    where: { placerId, free: true, createdAt: { gte: dayStart } },
+  });
+
+  return {
+    used,
+    remaining: Math.max(FREE_PLACEMENTS_PER_DAY - used, 0),
+    /** Midnight UTC ending the current day, when the allowance comes back. */
+    resetsAt: new Date(dayStart.getTime() + 24 * 3_600_000),
+  };
+}
+
+/**
+ * Whether this placer has already spent a free placement on this target.
+ *
+ * Same standing as the allowance above: a listing for the surface to render,
+ * never the thing a mutation decides on.
+ */
+export async function hasUsedFreePlacementOn({
+  placerId,
+  surface,
+  targetType,
+  targetId,
+}: {
+  placerId: number;
+  surface: PlacementSurface;
+  targetType: PlacementSpaceEntity;
+  targetId: number;
+}) {
+  const count = await dbWrite.placement.count({
+    where: { placerId, free: true, surface, targetType, targetId },
+  });
+  return count > 0;
+}

--- a/src/server/services/free-placement.service.ts
+++ b/src/server/services/free-placement.service.ts
@@ -1,10 +1,17 @@
 import type { Prisma } from '@prisma/client';
-import { dbWrite } from '~/server/db/client';
+import { dbRead, dbWrite } from '~/server/db/client';
 import { getPlacementConfig } from '~/server/services/placement.service';
-import type { ResolvedPlacementSpace } from '~/server/services/placement-space.service';
-import { reservedFreeSlots } from '~/server/services/placement-space.service';
+import { assertCanPlace } from '~/server/services/placement-moderation.service';
+import {
+  reservedFreeSlots,
+  resolvePlacementSpaceFor,
+} from '~/server/services/placement-space.service';
 import { throwBadRequestError } from '~/server/utils/errorHandling';
-import type { PlacementSpaceEntity, PlacementSurface } from '~/shared/utils/placement';
+import type {
+  PlacementSpaceEntity,
+  PlacementSpaceMode,
+  PlacementSurface,
+} from '~/shared/utils/placement';
 import {
   FREE_PLACEMENTS_PER_DAY,
   PLACEMENT_SURFACES,
@@ -15,11 +22,11 @@ import {
  * A placement made against a creator's free capacity instead of paid for.
  *
  * The whole free path is here rather than branched into each surface, and that
- * is the point of this file: three refusals — capacity, the daily allowance, and
- * never twice on the same target — have to hold together, under a lock, in the
- * same transaction as the insert. A surface that built its own row and then
+ * is the point of this file: **every refusal the paid path makes, plus the three
+ * the free tier adds, in one function**, with the free-tier ones under a lock in
+ * the same transaction as the insert. A surface that built its own row and then
  * checked would be a second creation route with the checks bolted on the
- * outside, which is where the free tier stops being scarce.
+ * outside — the guard-versus-filter shape this feature shipped five times in v1.
  *
  * Escrow is bypassed **entirely**, not taken at zero. Zero-amount Buzz
  * transactions are a landmine, and the escrow's two-hold structure has neither a
@@ -30,29 +37,35 @@ import {
 /**
  * Advisory-lock class keys.
  *
- * 🔴 **A free placement takes BOTH of these, and every caller must take them in
- * the order below — placer, then target.** Two callers acquiring them in
- * opposite orders deadlock: A holds the placer lock and waits for the target,
- * B holds the target lock and waits for the placer, and Postgres kills one of
- * them. That only happens when two placers are claiming at once, which is when
- * the feature is finally popular — so it will not show up in testing, and it
- * will show up on the day it costs the most.
+ * 🔴 **A free placement takes BOTH, and they must be taken in the order below —
+ * placer, then target.** Two callers acquiring them in opposite orders deadlock:
+ * A holds the placer lock and waits for the target, B holds the target lock and
+ * waits for the placer, and Postgres kills one. That needs two placers claiming
+ * at once, so it will not appear in testing and will appear when the feature is
+ * finally popular.
  *
- * Kept unexported, alongside the only two acquisitions in the codebase, so
- * "obey the order" is not a rule a future caller has to know: there is nowhere
- * else to take them from. A guard test asserts that stays true. If you find
- * yourself needing one of these somewhere else, the answer is to call
- * `createFreePlacement` rather than to export a lock.
- *
- * Two-argument advisory locks occupy a lock space distinct from the
- * one-argument form, so these cannot collide with `article.service.ts`'s
- * bare-id locks however its ids grow.
+ * The same hazard exists against **any** other lock taken inside this
+ * transaction, of any arity: a deadlock needs a cycle in the waits-for graph,
+ * not a shared key space. Kept unexported alongside the only acquisition site,
+ * with a guard test asserting the whole file list, so ordering is not a rule a
+ * future caller has to know. If you need a lock here, call `createFreePlacement`
+ * rather than export one.
  */
 const PLACER_LOCK_CLASS = 0x74ee0001;
 const TARGET_LOCK_CLASS = 0x74ee0002;
 
 /**
- * A stable key for one space, hashed into the lock below.
+ * How long a claim will wait for a lock before failing.
+ *
+ * `pg_advisory_xact_lock` waits forever by default, and Prisma's client-side
+ * timeout does not cancel a backend already blocked inside the lock statement.
+ * Without a bound, a wedged holder accumulates blocked backends on the write
+ * pool rather than failing the claims that are queued behind it.
+ */
+const LOCK_TIMEOUT = '3s';
+
+/**
+ * A stable key for one space, hashed into the target lock.
  *
  * The surface is in it because the same image id is a valid target on both
  * surfaces, and locking on the id alone would serialise a sticker placement
@@ -66,23 +79,48 @@ const spaceLockKey = (
   targetId: number
 ) => `${surface}:${targetType}:${targetId}`;
 
-export type CreateFreePlacement = {
+type PlacementClient = Pick<typeof dbWrite, 'placement'>;
+type SpaceTarget = {
   surface: PlacementSurface;
   targetType: PlacementSpaceEntity;
   targetId: number;
+};
+
+/**
+ * The daily entitlement, as one predicate.
+ *
+ * Every status, deliberately: a decline or an expiry gives the image's slot back
+ * but NOT the placer's day, because refunding the day turns the free tier into
+ * an unlimited retry loop against whoever declines fastest. Every surface, too —
+ * the allowance is one placement a day across the site, not one per surface.
+ *
+ * Written once because the claim decides on it and the UI displays it. Scope it
+ * by status later in one of two copies and the surface offers a placement the
+ * mutation refuses.
+ */
+const countFreePlacementsToday = (client: PlacementClient, placerId: number) =>
+  client.placement.count({
+    where: { placerId, free: true, createdAt: { gte: freePlacementDayStart() } },
+  });
+
+/**
+ * Never twice on the same target by the same placer, as one predicate.
+ *
+ * Once ever: not once per day, and not scoped by status. An image posted and
+ * deleted daily is otherwise a farm for one account's alts. Scoped to this
+ * surface, because placing a sticker and submitting a remix are different acts
+ * on the same image and one should not consume the other — and the daily
+ * allowance already makes that pair cost two days, so it raises no farm rate.
+ *
+ * Shared with the display path for the same reason as the daily count.
+ */
+const countFreePlacementsOn = (
+  client: PlacementClient,
+  { placerId, surface, targetType, targetId }: SpaceTarget & { placerId: number }
+) => client.placement.count({ where: { placerId, free: true, surface, targetType, targetId } });
+
+export type CreateFreePlacement = SpaceTarget & {
   placerId: number;
-  /**
-   * The space as `resolvePlacementSpaceFor` returned it, carried whole rather
-   * than as a handful of extracted numbers. The caller has already resolved it
-   * to check the mode and the owner, and passing the object means the owner and
-   * the capacity cannot arrive from two different resolutions of the same space.
-   *
-   * ⚠️ `freeSlotsRemaining` on it is NOT what this decides on — it was computed
-   * before the caller's other checks ran and is stale by the time it gets here.
-   * Only `freeSlots`, the capacity, is read; the reservation is re-counted under
-   * the lock.
-   */
-  space: ResolvedPlacementSpace;
   /** Who sold the placed thing, when an approval would owe them a cut. */
   sellerId?: number | null;
   /** The surface's own payload. Opaque here, exactly as on the paid path. */
@@ -92,88 +130,124 @@ export type CreateFreePlacement = {
 /**
  * Claims a free slot and creates the placement, or refuses.
  *
- * **The race is closed by two transaction-scoped advisory locks, not by a unique
- * constraint.** Neither rule this enforces is expressible as one: "at most N
- * pending-or-approved free rows for this target" and "at most one free row for
- * this placer today" are both counts, and Postgres has no partial-unique form
- * for a count. The alternatives were a serializable transaction, which turns a
- * lost race into a retry the caller has to write, and `withDistributedLock`,
- * which returns null rather than running when Redis is down — a free placement
- * would then be refused during a Redis outage while the paid path kept working.
- * An advisory lock needs no extra infrastructure, releases on commit or rollback
- * with nothing to leak, and makes count-then-insert atomic without anyone
- * holding a row lock on `Placement`.
+ * **The space is resolved here, from the target, rather than passed in.** A
+ * caller-supplied space and a separate `targetId` are two facts that can
+ * disagree: a caller resolving once and looping would write a placement onto
+ * image B carrying image A's owner, so the review queue and every payout
+ * attribution would belong to the wrong creator, with nothing raising. Resolving
+ * from the one identifier makes that unrepresentable rather than merely
+ * unlikely. It costs one extra resolution on a mutation path.
  *
- * Both locks are taken in a fixed order — placer, then target — because a
- * placement takes both, and two callers acquiring them in opposite orders is the
- * textbook deadlock. The order is arbitrary; that it is the same everywhere is
- * not.
+ * **The race is closed by two transaction-scoped advisory locks, not by a unique
+ * constraint.** Neither free-tier rule is expressible as one: "at most N held
+ * free rows on this target" and "at most one free row for this placer today" are
+ * both counts, and Postgres has no partial-unique form for a count. The
+ * alternatives were a serializable transaction, which turns a lost race into a
+ * retry every caller has to write, and `withDistributedLock`, which returns null
+ * rather than running when Redis is down — free placements would then be refused
+ * during a Redis outage while the paid path kept working. An advisory lock needs
+ * no extra infrastructure, releases on commit or rollback with nothing to leak,
+ * and makes count-then-insert atomic without holding a row lock on `Placement`.
+ *
+ * The placer's own check sits between the two acquisitions on purpose. Taking
+ * the shared target lock first would queue every placer who has already spent
+ * their day behind a contended lock to learn a fact about nobody but themselves.
  *
  * The deadline is computed BEFORE the transaction opens and written by the same
  * insert. `holdPlacementEscrow` stamps the paid path's deadline in a second
  * statement, and its comment explains what a throw between the two costs: a
  * pending row with a NULL `expiresAt` is never `<= now()`, so the expiry sweep
  * steps over it forever. On the free path that row would also hold one of the
- * creator's slots for good, so there is no window at all — one statement, one
- * row, deadline included.
+ * creator's slots for good, so there is no window at all.
  */
 export async function createFreePlacement({
   surface,
   targetType,
   targetId,
   placerId,
-  space,
   sellerId,
   data,
 }: CreateFreePlacement) {
+  const target = { surface, targetType, targetId };
+  const space = await resolvePlacementSpaceFor(target);
+
+  // Everything the paid path refuses, refused here too. The free path is not a
+  // lighter version of placement — it is placement that costs no Buzz, and every
+  // rule about who may place on whom is untouched by the price being zero.
+  //
+  // Two separate refusals that read as one. `off` is a valid stored mode, so it
+  // is IN `allowedModes` — the table says what may be written, not what may be
+  // placed into. A mode outside the table is the other case: a gallery row saying
+  // `auto` predates the rule that galleries always review, and would otherwise
+  // put arbitrary media live unreviewed. Both are refused where the placement is
+  // made, not only where the setting is stored.
+  const allowedModes = PLACEMENT_SURFACES[surface].allowedModes as readonly PlacementSpaceMode[];
+  if (space.mode === 'off' || !allowedModes.includes(space.mode))
+    throw throwBadRequestError('placement: this creator is not accepting placements here');
+
+  // Refused rather than allowed-because-it-is-free. On the paid path this is a
+  // product decision and not an accounting one — free self-placement would be
+  // the creator filling their own slots so nobody else can have them, which
+  // defeats the scarcity the whole feature is built on.
+  if (space.ownerId === placerId)
+    throw throwBadRequestError('placement: you cannot place on your own content');
+
   if (space.freeSlots <= 0)
     throw throwBadRequestError('placement: this creator is not taking free placements here');
 
-  // Read before the transaction opens: `getPlacementConfig` touches KeyValue, and
-  // I/O inside a transaction is a repo rule with its own lint guard. It falls
-  // back to the compiled defaults on its own rather than throwing, so there is no
-  // path where this leaves the deadline unset.
+  // Outside the transaction: it is I/O, which `no-io-in-transaction` guards, and
+  // it reads the primary so a suspension or a block committed seconds ago
+  // refuses rather than being one replica-lag behind.
+  //
+  // The suspension half is the one the free path could not do without. A block
+  // declines the rows pending when it lands; a moderator suspension is the only
+  // thing that stops tomorrow's placement, and without this call a suspended
+  // placer keeps placing free ones forever.
+  await assertCanPlace({ ownerId: space.ownerId, placerId });
+
+  // Read before the transaction opens, for the same no-I/O reason. It falls back
+  // to the compiled defaults rather than throwing, so there is no path where
+  // this leaves the deadline unset.
   const expiryHours = (await getPlacementConfig()).expiryHours(surface);
   const expiresAt = new Date(Date.now() + expiryHours * 3_600_000);
 
   return dbWrite.$transaction(async (tx) => {
+    await tx.$executeRaw`SET LOCAL lock_timeout = ${LOCK_TIMEOUT}`;
     await tx.$executeRaw`SELECT pg_advisory_xact_lock(${PLACER_LOCK_CLASS}::int, ${placerId}::int)`;
+
+    const usedToday = await countFreePlacementsToday(tx, placerId);
+    if (usedToday >= FREE_PLACEMENTS_PER_DAY)
+      throw throwBadRequestError(
+        'placement: you have used your free placement for today. It resets at midnight UTC.'
+      );
+
+    // Per (owner, placer), so the placer lock above already serialises it. The
+    // paid path's cap, applied here for the same reason: it bounds a review
+    // queue an owner can actually work through, and the owner's remedy for the
+    // rest is block.
+    const pending = await tx.placement.count({
+      where: { surface, ownerId: space.ownerId, placerId, status: 'pending' },
+    });
+    if (pending >= PLACEMENT_SURFACES[surface].maxPendingPerOwner)
+      throw throwBadRequestError(
+        'placement: you already have the maximum pending placements with this creator'
+      );
+
     await tx.$executeRaw`SELECT pg_advisory_xact_lock(${TARGET_LOCK_CLASS}::int, hashtext(${spaceLockKey(
       surface,
       targetType,
       targetId
     )}))`;
 
-    // Every status, deliberately. A decline or an expiry gives the image's slot
-    // back but NOT the placer's day — refunding the day would turn the free tier
-    // into an unlimited retry loop against whoever declines fastest.
-    const usedToday = await tx.placement.count({
-      where: { placerId, free: true, createdAt: { gte: freePlacementDayStart() } },
-    });
-    if (usedToday >= FREE_PLACEMENTS_PER_DAY)
-      throw throwBadRequestError(
-        'placement: you have used your free placement for today. It resets at midnight UTC.'
-      );
-
-    // Once ever: not once per day, and not scoped by status. An image posted and
-    // deleted daily is otherwise a farm for one account's alts. Scoped to this
-    // surface, because placing a sticker and submitting a remix are different
-    // acts on the same image and one should not consume the other.
-    const already = await tx.placement.count({
-      where: { placerId, free: true, surface, targetType, targetId },
-    });
+    const already = await countFreePlacementsOn(tx, { placerId, ...target });
     if (already > 0)
       throw throwBadRequestError(
         `placement: you have already used a free placement here. Free ${PLACEMENT_SURFACES[surface].label} are once per image.`
       );
 
-    // Re-counted inside the lock. `space.freeSlotsRemaining` is what the caller
-    // showed someone; this is what decides.
-    const reserved = await reservedFreeSlots(tx as typeof dbWrite, {
-      surface,
-      targetType,
-      targetId,
-    });
+    // Re-counted inside the lock. `space.freeSlotsRemaining` is what a surface
+    // shows someone; this is what decides.
+    const reserved = await reservedFreeSlots(tx, target);
     if (reserved >= space.freeSlots)
       throw throwBadRequestError('placement: the free slots on this one are taken');
 
@@ -207,14 +281,13 @@ export async function createFreePlacement({
  * is worth making with the number visible, and an allowance spent silently is
  * the worst version of a scarce thing.
  *
- * **A listing, not a guard.** It is stale the moment it returns, and the refusal
- * lives in `createFreePlacement` under the lock. Do not gate a mutation on it.
+ * **A listing, not a guard.** It is stale the moment it returns, reads a replica,
+ * and the refusal lives in `createFreePlacement` under the lock. Do not gate a
+ * mutation on it.
  */
 export async function getFreePlacementAllowance({ placerId }: { placerId: number }) {
   const dayStart = freePlacementDayStart();
-  const used = await dbWrite.placement.count({
-    where: { placerId, free: true, createdAt: { gte: dayStart } },
-  });
+  const used = await countFreePlacementsToday(dbRead, placerId);
 
   return {
     used,
@@ -230,19 +303,5 @@ export async function getFreePlacementAllowance({ placerId }: { placerId: number
  * Same standing as the allowance above: a listing for the surface to render,
  * never the thing a mutation decides on.
  */
-export async function hasUsedFreePlacementOn({
-  placerId,
-  surface,
-  targetType,
-  targetId,
-}: {
-  placerId: number;
-  surface: PlacementSurface;
-  targetType: PlacementSpaceEntity;
-  targetId: number;
-}) {
-  const count = await dbWrite.placement.count({
-    where: { placerId, free: true, surface, targetType, targetId },
-  });
-  return count > 0;
-}
+export const hasUsedFreePlacementOn = async (input: SpaceTarget & { placerId: number }) =>
+  (await countFreePlacementsOn(dbRead, input)) > 0;

--- a/src/server/services/free-placement.service.ts
+++ b/src/server/services/free-placement.service.ts
@@ -28,9 +28,25 @@ import {
  */
 
 /**
- * Advisory-lock class keys. Two-argument advisory locks occupy a lock space
- * distinct from the one-argument form, so these cannot collide with
- * `article.service.ts`'s bare-id locks however its ids grow.
+ * Advisory-lock class keys.
+ *
+ * 🔴 **A free placement takes BOTH of these, and every caller must take them in
+ * the order below — placer, then target.** Two callers acquiring them in
+ * opposite orders deadlock: A holds the placer lock and waits for the target,
+ * B holds the target lock and waits for the placer, and Postgres kills one of
+ * them. That only happens when two placers are claiming at once, which is when
+ * the feature is finally popular — so it will not show up in testing, and it
+ * will show up on the day it costs the most.
+ *
+ * Kept unexported, alongside the only two acquisitions in the codebase, so
+ * "obey the order" is not a rule a future caller has to know: there is nowhere
+ * else to take them from. A guard test asserts that stays true. If you find
+ * yourself needing one of these somewhere else, the answer is to call
+ * `createFreePlacement` rather than to export a lock.
+ *
+ * Two-argument advisory locks occupy a lock space distinct from the
+ * one-argument form, so these cannot collide with `article.service.ts`'s
+ * bare-id locks however its ids grow.
  */
 const PLACER_LOCK_CLASS = 0x74ee0001;
 const TARGET_LOCK_CLASS = 0x74ee0002;

--- a/src/server/services/placement-escrow.service.ts
+++ b/src/server/services/placement-escrow.service.ts
@@ -425,6 +425,20 @@ export async function holdPlacementEscrow({
   if (!Number.isSafeInteger(amount) || amount < 0)
     throw new Error(`placement escrow: amount must be a non-negative integer, got ${amount}`);
 
+  // A free placement must never reach the escrow, even for zero. `amount === 0`
+  // returns harmlessly below, so this is not about the money — it is about
+  // `expiresAt` and `spendType` being stamped by whichever path made the row, and
+  // about a caller that reached here having taken the wrong branch somewhere
+  // upstream. Refused on the mutation rather than absorbed, because absorbing it
+  // is how the free path silently acquires a second, half-built creation route.
+  const row = await dbWrite.placement.findUnique({
+    where: { id: placementId },
+    select: { free: true },
+  });
+  if (!row) throw new Error(`placement escrow: placement ${placementId} not found`);
+  if (row.free)
+    throw new Error(`placement escrow: placement ${placementId} is free and takes no escrow`);
+
   // Stamped from the surface's compiled default BEFORE the config is read.
   // `getPlacementConfig` touches KeyValue, so it can throw — and a throw here
   // used to leave a pending row with a null `expiresAt`, which is never
@@ -678,6 +692,16 @@ async function payoutLegsFor(
   placement: PlacementRow,
   held: Map<string, number>
 ): Promise<PlannedLeg[]> {
+  // A free placement never entered escrow, so there is nothing to release on any
+  // path: no principal, no decline fee, no seller split, no forfeit.
+  //
+  // Stated rather than left to arithmetic. Every branch below already computes to
+  // zero from the empty `held` map and would be filtered out before persisting —
+  // but that is a property of four separate expressions all happening to reduce
+  // to nothing, which the next person to add a leg has to rediscover. The row
+  // says it is free; this says what free means, once.
+  if (placement.free) return [];
+
   const fee = held.get('holdFee') ?? 0;
   const principal = held.get('holdPrincipal') ?? 0;
   const outcome = placementOutcomeFromStatus(

--- a/src/server/services/placement-space.service.ts
+++ b/src/server/services/placement-space.service.ts
@@ -110,7 +110,12 @@ export type ResolvedPlacementSpace = {
  * fully-booked paid image still shows its free slots as available.
  */
 export const reservedFreeSlots = (
-  client: typeof dbWrite,
+  /**
+   * Narrowed to the one model it touches so a transaction client satisfies it.
+   * The claim MUST pass its `tx` — counting on any other connection would read
+   * outside the lock it just took, and the count would be a listing again.
+   */
+  client: Pick<typeof dbWrite, 'placement'>,
   {
     surface,
     targetType,
@@ -181,13 +186,22 @@ export async function resolvePlacementSpaceFor({
   const { max: cap, freeSlotCap } = await placementPriceRange(ownerId, surface);
   const shares = (await getPlacementConfig()).approvalShares(surface);
 
-  const setFreeSlots = resolved.freeSlots ?? PLACEMENT_SURFACES[surface].defaultFreeSlots;
-  const freeSlots = effectiveFreeSlots(surface, setFreeSlots, freeSlotCap);
-  // Skipped when there is no capacity to reserve against, which a cap of 0 or a
-  // slider at 0 both produce: the answer is 0 either way, so the query is a round
-  // trip that cannot change it.
+  // `resolvePlacementSpace` is the one place the surface default is applied, so
+  // this reads it rather than defaulting again — the same shape as `setPrice`
+  // directly above.
+  const setFreeSlots = resolved.freeSlots;
+  const freeSlots = effectiveFreeSlots(setFreeSlots, freeSlotCap);
+  // `dbRead`, unlike everything above it. The rest of this function decides
+  // whether a mutation is allowed and what it charges, which a lagging replica
+  // must not answer; `freeSlotsRemaining` is display-only by construction — the
+  // claim re-counts under its own lock — and this read is on a public query
+  // reached from every image detail view.
+  //
+  // Skipped when there is no capacity to reserve against. That is rarer than it
+  // looks: the default and the bottom band are both 1, so it fires only for a
+  // creator who has explicitly closed their slots.
   const reserved =
-    freeSlots > 0 ? await reservedFreeSlots(dbWrite, { surface, targetType, targetId }) : 0;
+    freeSlots > 0 ? await reservedFreeSlots(dbRead, { surface, targetType, targetId }) : 0;
 
   return {
     ownerId,

--- a/src/server/services/placement-space.service.ts
+++ b/src/server/services/placement-space.service.ts
@@ -10,7 +10,9 @@ import type {
   PlacementSurface,
 } from '~/shared/utils/placement';
 import {
+  effectiveFreeSlots,
   effectivePlacementPrice,
+  FREE_SLOT_HOLDING_STATUSES,
   PLACEMENT_SURFACES,
   resolvePlacementSpace,
   surfaceAcceptsTarget,
@@ -68,9 +70,62 @@ export type ResolvedPlacementSpace = {
    * stop being true.
    */
   ownerShare: number;
+  /**
+   * The count the cascade resolved, before the cap — the same relationship
+   * `setPrice` has to `price`, so a caller can say "you have set 9, we are
+   * honouring 2" rather than only showing the smaller number.
+   */
+  setFreeSlots: number;
+  /** `min(setFreeSlots, freeSlotCap)`, computed here and never stored. */
+  freeSlots: number;
+  freeSlotCap: number;
+  /**
+   * How many free placements this space will still accept, right now.
+   *
+   * Never negative. A creator who lowers their slider below what is already
+   * reserved is not taking anything back — the placements they already accepted
+   * stay — so the space simply accepts nothing further until they release.
+   *
+   * ⚠️ This is what a caller SHOWS. It is not what a caller may decide on: by the
+   * time it is read the count is already stale. The refusal lives in
+   * `createFreePlacement`, which re-counts under a lock in the same transaction
+   * that inserts.
+   */
+  freeSlotsRemaining: number;
   /** Surface-owned; this layer carries it without reading inside it. */
   settings: PlacementSpaceSettings;
 };
+
+/**
+ * How many of a space's free slots are spoken for.
+ *
+ * Pending counts, and that is the whole feature: a free placement holds its slot
+ * from the moment it is made. Without it fifty people submit into four slots and
+ * the creator gets a fifty-item review queue — the exact outcome the slider
+ * exists to prevent. Declined, expired and removed rows are absent from the
+ * status list, so a released slot is claimable by the next caller with no sweep
+ * in between.
+ *
+ * Paid placements are not counted. The two counters are independent, so a
+ * fully-booked paid image still shows its free slots as available.
+ */
+export const reservedFreeSlots = (
+  client: typeof dbWrite,
+  {
+    surface,
+    targetType,
+    targetId,
+  }: { surface: PlacementSurface; targetType: PlacementSpaceEntity; targetId: number }
+) =>
+  client.placement.count({
+    where: {
+      surface,
+      targetType,
+      targetId,
+      free: true,
+      status: { in: [...FREE_SLOT_HOLDING_STATUSES] },
+    },
+  });
 
 /**
  * The space that governs one target, with the cascade already applied.
@@ -102,7 +157,7 @@ export async function resolvePlacementSpaceFor({
         { entityType: 'user', entityId: ownerId },
       ],
     },
-    select: { entityType: true, mode: true, price: true, settings: true },
+    select: { entityType: true, mode: true, price: true, freeSlots: true, settings: true },
   });
 
   const at = (entityType: PlacementSpaceEntity): PlacementSpaceSetting | undefined => {
@@ -111,6 +166,7 @@ export async function resolvePlacementSpaceFor({
       ? {
           mode: row.mode as PlacementSpaceMode,
           price: row.price,
+          freeSlots: row.freeSlots,
           settings: (row.settings ?? {}) as PlacementSpaceSettings,
         }
       : undefined;
@@ -122,8 +178,16 @@ export async function resolvePlacementSpaceFor({
     user: at('user'),
   });
 
-  const { max: cap } = await placementPriceRange(ownerId, surface);
+  const { max: cap, freeSlotCap } = await placementPriceRange(ownerId, surface);
   const shares = (await getPlacementConfig()).approvalShares(surface);
+
+  const setFreeSlots = resolved.freeSlots ?? PLACEMENT_SURFACES[surface].defaultFreeSlots;
+  const freeSlots = effectiveFreeSlots(surface, setFreeSlots, freeSlotCap);
+  // Skipped when there is no capacity to reserve against, which a cap of 0 or a
+  // slider at 0 both produce: the answer is 0 either way, so the query is a round
+  // trip that cannot change it.
+  const reserved =
+    freeSlots > 0 ? await reservedFreeSlots(dbWrite, { surface, targetType, targetId }) : 0;
 
   return {
     ownerId,
@@ -133,6 +197,10 @@ export async function resolvePlacementSpaceFor({
     price: effectivePlacementPrice(resolved.price, cap),
     cap,
     ownerShare: 1 - shares.seller - shares.platform,
+    setFreeSlots,
+    freeSlots,
+    freeSlotCap,
+    freeSlotsRemaining: Math.max(freeSlots - reserved, 0),
     settings: resolved.settings ?? {},
   };
 }
@@ -175,6 +243,7 @@ export async function setPlacementSpace({
   entityId,
   mode,
   price,
+  freeSlots,
   settings,
   userId,
 }: {
@@ -183,6 +252,17 @@ export async function setPlacementSpace({
   entityId: number;
   mode: PlacementSpaceMode;
   price?: number | null;
+  /**
+   * `undefined` leaves this level's count alone, `null` clears it so the level
+   * inherits again, and a number sets it — the same three-way distinction
+   * `price` carries, for the same reason: an unset count follows the surface
+   * default when that moves, where a stored one freezes today's.
+   *
+   * Stored uncapped. The score/tier ceiling is applied at read, exactly like the
+   * price cap, so a creator whose tier lapses and returns gets their number back
+   * rather than having found it silently rewritten.
+   */
+  freeSlots?: number | null;
   settings?: PlacementSpaceSettings;
   userId: number;
 }) {
@@ -230,9 +310,7 @@ export async function setPlacementSpace({
   // the floor; lets an existing one be carried.
   const floor = PLACEMENT_SURFACES[surface].serverMinPrice;
   if (price != null && price < floor && price !== existing?.price)
-    throw throwBadRequestError(
-      `placement: the lowest you can charge is ${floor} Buzz`
-    );
+    throw throwBadRequestError(`placement: the lowest you can charge is ${floor} Buzz`);
 
   await dbWrite.placementSpace.upsert({
     where: { surface_entityType_entityId: { surface, entityType, entityId } },
@@ -242,11 +320,13 @@ export async function setPlacementSpace({
       entityId,
       mode,
       price: price ?? null,
+      freeSlots: freeSlots ?? null,
       settings: (settings ?? {}) as Prisma.InputJsonValue,
     },
     update: {
       mode,
       ...(price === undefined ? {} : { price }),
+      ...(freeSlots === undefined ? {} : { freeSlots }),
       // Replaced wholesale, not merged: the caller sends the settings it owns,
       // and a merge here would make a removed key impossible to express.
       ...(settings === undefined ? {} : { settings: settings as Prisma.InputJsonValue }),
@@ -308,7 +388,14 @@ export const getPlacementSpaces = ({
 }) =>
   dbRead.placementSpace.findMany({
     where: { surface, entityType: 'user', entityId: userId },
-    select: { entityType: true, entityId: true, mode: true, price: true, settings: true },
+    select: {
+      entityType: true,
+      entityId: true,
+      mode: true,
+      price: true,
+      freeSlots: true,
+      settings: true,
+    },
   });
 
 /**
@@ -334,7 +421,7 @@ export async function getPlacementSpaceRow({
 
   return dbRead.placementSpace.findUnique({
     where: { surface_entityType_entityId: { surface, entityType, entityId } },
-    select: { mode: true, price: true, settings: true },
+    select: { mode: true, price: true, freeSlots: true, settings: true },
   });
 }
 

--- a/src/server/services/placement.service.ts
+++ b/src/server/services/placement.service.ts
@@ -9,6 +9,7 @@ import {
   PLACEMENT_FREE_SLOT_CAP_TIERS,
   PLACEMENT_PRICE_CAP_TIERS,
   PLACEMENT_SURFACES,
+  placementFreeSlotCap,
   placementPriceCap,
 } from '~/shared/utils/placement';
 
@@ -150,7 +151,7 @@ export async function placementPriceRange(
   return {
     min: PLACEMENT_SURFACES[surface].serverMinPrice,
     max: placementPriceCap(score, tier, config.priceCapTiers(surface)),
-    freeSlotCap: placementPriceCap(score, tier, config.freeSlotTiers(surface)),
+    freeSlotCap: placementFreeSlotCap(score, tier, config.freeSlotTiers(surface)),
     score,
     tier,
   };

--- a/src/server/services/placement.service.ts
+++ b/src/server/services/placement.service.ts
@@ -6,6 +6,7 @@ import type { PlacementPriceTier, PlacementSurface } from '~/shared/utils/placem
 import {
   clampApprovalShares,
   clampDeclineFeeRate,
+  PLACEMENT_FREE_SLOT_CAP_TIERS,
   PLACEMENT_PRICE_CAP_TIERS,
   PLACEMENT_SURFACES,
   placementPriceCap,
@@ -34,6 +35,8 @@ const placementConfigSchema = z.object({
   priceCapTiers: z.array(priceCapTierSchema).min(1).optional(),
   /** Per-surface override, so stickers and galleries can be priced apart later. */
   priceCapTiersBySurface: z.record(z.string(), z.array(priceCapTierSchema).min(1)).optional(),
+  freeSlotTiers: z.array(priceCapTierSchema).min(1).optional(),
+  freeSlotTiersBySurface: z.record(z.string(), z.array(priceCapTierSchema).min(1)).optional(),
   approvalShares: z
     .record(
       z.string(),
@@ -46,6 +49,8 @@ export type PlacementConfig = {
   declineFeeRate: (surface: PlacementSurface) => number;
   expiryHours: (surface: PlacementSurface) => number;
   priceCapTiers: (surface: PlacementSurface) => PlacementPriceTier[];
+  /** Same table shape and same resolver as the price caps — see the constant. */
+  freeSlotTiers: (surface: PlacementSurface) => PlacementPriceTier[];
   /** The only producer of the approved-placement shares. Nothing may pass its own. */
   approvalShares: (surface: PlacementSurface) => { seller: number; platform: number };
 };
@@ -79,7 +84,15 @@ export async function getPlacementConfig(): Promise<PlacementConfig> {
     expiryHours: (surface) =>
       clampExpiryHours(stored.expiryHours?.[surface], PLACEMENT_SURFACES[surface].expiryHours),
     priceCapTiers: (surface) =>
-      usablePriceCapTiers(stored.priceCapTiersBySurface?.[surface] ?? stored.priceCapTiers),
+      usableCapTiers(
+        stored.priceCapTiersBySurface?.[surface] ?? stored.priceCapTiers,
+        PLACEMENT_PRICE_CAP_TIERS
+      ),
+    freeSlotTiers: (surface) =>
+      usableCapTiers(
+        stored.freeSlotTiersBySurface?.[surface] ?? stored.freeSlotTiers,
+        PLACEMENT_FREE_SLOT_CAP_TIERS
+      ),
     approvalShares: (surface) =>
       clampApprovalShares(stored.approvalShares?.[surface] ?? {}, {
         seller: PLACEMENT_SURFACES[surface].defaultSellerShare,
@@ -91,14 +104,24 @@ export async function getPlacementConfig(): Promise<PlacementConfig> {
 export type PlacementPriceRange = {
   min: number;
   max: number;
+  /**
+   * The most free placements this creator may accept on one space.
+   *
+   * Carried here rather than on its own query because it is decided by the same
+   * two facts — creator score and membership tier — and both are one round trip
+   * each. A second endpoint would double that cost to answer with the same
+   * numbers, and would be free to disagree about them.
+   */
+  freeSlotCap: number;
   score: number;
   tier: 'free' | MembershipTier;
 };
 
 /**
- * The single authority on what a creator may charge. D and E must not each
- * reimplement the score-and-tier scaling, and nothing may persist the result —
- * the cap moves the moment a membership lapses or a score is recomputed.
+ * The single authority on what a creator may charge, and on how much free
+ * capacity they may offer. D and E must not each reimplement the score-and-tier
+ * scaling, and nothing may persist the result — the caps move the moment a
+ * membership lapses or a score is recomputed.
  */
 export async function placementPriceRange(
   userId: number,
@@ -127,6 +150,7 @@ export async function placementPriceRange(
   return {
     min: PLACEMENT_SURFACES[surface].serverMinPrice,
     max: placementPriceCap(score, tier, config.priceCapTiers(surface)),
+    freeSlotCap: placementPriceCap(score, tier, config.freeSlotTiers(surface)),
     score,
     tier,
   };
@@ -150,8 +174,8 @@ const clampExpiryHours = (hours: number | undefined, fallback: number) => {
  * it a cap of 0, i.e. a space nobody can be charged for. It fails toward free
  * rather than toward overcharging, but silently, and the schema can't see it.
  */
-const usablePriceCapTiers = (tiers: PlacementPriceTier[] | undefined) =>
-  tiers?.some((tier) => tier.minScore === 0) ? tiers : PLACEMENT_PRICE_CAP_TIERS;
+const usableCapTiers = (tiers: PlacementPriceTier[] | undefined, fallback: PlacementPriceTier[]) =>
+  tiers?.some((tier) => tier.minScore === 0) ? tiers : fallback;
 
 const MEMBERSHIP_TIERS: MembershipTier[] = ['bronze', 'silver', 'gold'];
 

--- a/src/server/services/sticker-placement.service.ts
+++ b/src/server/services/sticker-placement.service.ts
@@ -19,6 +19,7 @@ import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
 import type { PlacementStatus } from '~/shared/utils/placement';
 import {
   PLACEMENT_QUEUE_PAGE_SIZE,
+  PLACEMENT_SURFACES,
   encodePlacementQueueCursor,
   parsePlacementQueueCursor,
   placementQueueKeyset,
@@ -46,8 +47,11 @@ const TARGET_TYPE = 'image' as const;
  * A cap rather than a rate limit: the cost is already real Buzz, so this is not
  * about spam economics but about a review queue an owner can actually work
  * through. Their remedy for the rest is block, which declines all of them.
+ *
+ * In the surface table because the free path enforces it too, and three copies
+ * of one number is how they start disagreeing.
  */
-const MAX_PENDING_PER_OWNER = 10;
+const MAX_PENDING_PER_OWNER = PLACEMENT_SURFACES.sticker.maxPendingPerOwner;
 
 /**
  * The note on a placement, if this viewer may read it.

--- a/src/shared/utils/__tests__/placement.test.ts
+++ b/src/shared/utils/__tests__/placement.test.ts
@@ -551,14 +551,40 @@ describe('free capacity', () => {
   });
 
   it('starts the day at midnight UTC, wherever the placer is', () => {
-    const start = freePlacementDayStart(new Date('2026-08-17T23:59:59.999Z'));
+    // Both probes sit INSIDE one UTC day and straddle every real offset: 04:00Z
+    // is the previous local day west of UTC, 20:00Z the next local day east of
+    // it. Midnight-aligned probes alone would prove nothing about the day
+    // boundary at all.
+    for (const at of ['2026-08-17T04:00:00.000Z', '2026-08-17T20:00:00.000Z'])
+      expect(freePlacementDayStart(new Date(at)).toISOString()).toBe('2026-08-17T00:00:00.000Z');
 
-    expect(start.toISOString()).toBe('2026-08-17T00:00:00.000Z');
-    // A local-day boundary would let anyone willing to change timezone refresh
-    // the allowance twice, and would have two servers disagree about the day.
+    // The boundary itself, so the window is a day rather than merely aligned.
     expect(freePlacementDayStart(new Date('2026-08-18T00:00:00.000Z')).toISOString()).toBe(
       '2026-08-18T00:00:00.000Z'
     );
+  });
+
+  /**
+   * The timezone independence itself, which the probes above cannot reach.
+   *
+   * On a UTC runner a local-day boundary and a UTC one are the SAME function, so
+   * no input can separate them — and CI is UTC with no `TZ` pinned. Rather than
+   * write a test named for a property it can only fail on a machine that never
+   * gates the PR, the implementation floors the epoch, which has no ambient
+   * timezone to read. This asserts that shape: every result lands on a whole
+   * multiple of a day, which a calendar-getter version cannot promise off UTC.
+   */
+  it('lands on a whole day boundary, with no timezone to read', () => {
+    const day = 24 * 3_600_000;
+    for (const at of [0, 1, 1_000, day - 1, day, 1_786_000_000_000, Date.now()])
+      expect(freePlacementDayStart(new Date(at)).getTime() % day).toBe(0);
+  });
+
+  it('floors rather than rounds, so the day never starts in the future', () => {
+    for (const at of ['2026-08-17T00:00:00.000Z', '2026-08-17T23:59:59.999Z'].map(
+      (iso) => new Date(iso)
+    ))
+      expect(freePlacementDayStart(at).getTime()).toBeLessThanOrEqual(at.getTime());
   });
 
   it('is one placement a day, which is what makes free scarce', () => {

--- a/src/shared/utils/__tests__/placement.test.ts
+++ b/src/shared/utils/__tests__/placement.test.ts
@@ -493,25 +493,32 @@ describe('free capacity', () => {
       );
   });
 
-  it('gives an unset space the surface default rather than nothing', () => {
+  // The surface default is applied by the cascade and nowhere else, so an unset
+  // count never reaches this. Applying it here too had one read path defaulting
+  // three times, with two of them unreachable.
+  it('gives an unset space the surface default, in the cascade and only there', () => {
     for (const surface of placementSurfaces)
-      expect(effectiveFreeSlots(surface, null, 10)).toBe(
+      expect(resolvePlacementSpace(surface, {}).freeSlots).toBe(
         PLACEMENT_SURFACES[surface].defaultFreeSlots
       );
   });
 
   // The distinction that lets this replace an on/off toggle instead of sitting
   // beside one. Defaulting a stored 0 away would reopen a space its owner closed.
-  it('keeps an explicit zero, which is the creator saying no', () => {
-    expect(effectiveFreeSlots('sticker', 0, 10)).toBe(0);
+  it('keeps an explicit zero through the cascade, which is the creator saying no', () => {
+    expect(
+      resolvePlacementSpace('sticker', { user: { mode: 'review', price: 100, freeSlots: 0 } })
+        .freeSlots
+    ).toBe(0);
+    expect(effectiveFreeSlots(0, 10)).toBe(0);
   });
 
   it('ceilings a stored count without rewriting it', () => {
-    expect(effectiveFreeSlots('sticker', 8, 3)).toBe(3);
+    expect(effectiveFreeSlots(8, 3)).toBe(3);
   });
 
   it('cannot go negative, however the cap is misconfigured', () => {
-    expect(effectiveFreeSlots('sticker', 4, -2)).toBe(0);
+    expect(effectiveFreeSlots(4, -2)).toBe(0);
   });
 
   it('resolves image over post over account, independently of price', () => {

--- a/src/shared/utils/__tests__/placement.test.ts
+++ b/src/shared/utils/__tests__/placement.test.ts
@@ -3,8 +3,14 @@ import type { PlacementOutcome, PlacementStatus } from '~/shared/utils/placement
 import {
   clampDeclineFeeRate,
   declineFeeAmount,
+  effectiveFreeSlots,
   effectivePlacementPrice,
+  FREE_PLACEMENTS_PER_DAY,
+  FREE_SLOT_HOLDING_STATUSES,
+  freePlacementDayStart,
   isPlacementSurface,
+  PLACEMENT_FREE_SLOT_CAP_TIERS,
+  placementFreeSlotCap,
   MAX_DECLINE_FEE_RATE,
   MIN_DECLINE_FEE_RATE,
   PLACEMENT_SURFACES,
@@ -328,6 +334,7 @@ describe('space resolution', () => {
     expect(resolvePlacementSpace('sticker', {})).toEqual({
       mode: PLACEMENT_SURFACES.sticker.defaultMode,
       price: PLACEMENT_SURFACES.sticker.defaultPrice,
+      freeSlots: PLACEMENT_SURFACES.sticker.defaultFreeSlots,
       settings: {},
     });
   });
@@ -405,7 +412,12 @@ describe('space resolution', () => {
       image: mode('auto'),
       user: mode('off', 250),
     });
-    expect(resolved).toEqual({ mode: 'auto', price: 250, settings: {} });
+    expect(resolved).toEqual({
+      mode: 'auto',
+      price: 250,
+      freeSlots: PLACEMENT_SURFACES.sticker.defaultFreeSlots,
+      settings: {},
+    });
   });
 
   it('merges settings per key, with the most specific level winning', () => {
@@ -442,5 +454,107 @@ describe('the surface table', () => {
       expect(config.defaultDeclineFeeRate).toBeLessThanOrEqual(MAX_DECLINE_FEE_RATE);
       expect(config.expiryHours).toBeGreaterThan(0);
     }
+  });
+});
+
+describe('free capacity', () => {
+  // The two ends of the scale are decided and published; the middle is a
+  // judgement. Pinning both ends means a table edit that moves them is a
+  // deliberate change to this file rather than something a reviewer has to spot.
+  it('starts a new creator at one and tops out at ten', () => {
+    expect(placementFreeSlotCap(0, 'free')).toBe(1);
+    expect(placementFreeSlotCap(1_000_000, 'gold')).toBe(10);
+  });
+
+  it('never lets a lower tier or a lower score buy more slots', () => {
+    const tiers = ['free', 'bronze', 'silver', 'gold'] as const;
+    const scores = PLACEMENT_FREE_SLOT_CAP_TIERS.map((band) => band.minScore);
+
+    for (const score of scores)
+      for (let i = 1; i < tiers.length; i++)
+        expect(placementFreeSlotCap(score, tiers[i])).toBeGreaterThanOrEqual(
+          placementFreeSlotCap(score, tiers[i - 1])
+        );
+
+    for (const tier of tiers)
+      for (let i = 1; i < scores.length; i++)
+        expect(placementFreeSlotCap(scores[i], tier)).toBeGreaterThanOrEqual(
+          placementFreeSlotCap(scores[i - 1], tier)
+        );
+  });
+
+  // The same resolver as the price caps, deliberately — one mechanism, so a fix
+  // to the band-picking cannot land on one table and miss the other. This is what
+  // makes that reuse a fact rather than an intention.
+  it('is resolved by the price cap resolver, not a second one', () => {
+    for (const band of PLACEMENT_FREE_SLOT_CAP_TIERS)
+      expect(placementFreeSlotCap(band.minScore, 'gold')).toBe(
+        placementPriceCap(band.minScore, 'gold', PLACEMENT_FREE_SLOT_CAP_TIERS)
+      );
+  });
+
+  it('gives an unset space the surface default rather than nothing', () => {
+    for (const surface of placementSurfaces)
+      expect(effectiveFreeSlots(surface, null, 10)).toBe(
+        PLACEMENT_SURFACES[surface].defaultFreeSlots
+      );
+  });
+
+  // The distinction that lets this replace an on/off toggle instead of sitting
+  // beside one. Defaulting a stored 0 away would reopen a space its owner closed.
+  it('keeps an explicit zero, which is the creator saying no', () => {
+    expect(effectiveFreeSlots('sticker', 0, 10)).toBe(0);
+  });
+
+  it('ceilings a stored count without rewriting it', () => {
+    expect(effectiveFreeSlots('sticker', 8, 3)).toBe(3);
+  });
+
+  it('cannot go negative, however the cap is misconfigured', () => {
+    expect(effectiveFreeSlots('sticker', 4, -2)).toBe(0);
+  });
+
+  it('resolves image over post over account, independently of price', () => {
+    const resolved = resolvePlacementSpace('sticker', {
+      image: { mode: 'review', price: null, freeSlots: 2 },
+      post: { mode: 'review', price: 300, freeSlots: 5 },
+      user: { mode: 'review', price: 500, freeSlots: 9 },
+    });
+
+    expect(resolved.freeSlots).toBe(2);
+    // The price came from the post while the count came from the image, which is
+    // the whole reason these resolve separately: an owner who set their capacity
+    // once should keep it on an image they later reprice.
+    expect(resolved.price).toBe(300);
+  });
+
+  it('falls through a level that has not chosen', () => {
+    const resolved = resolvePlacementSpace('sticker', {
+      image: { mode: 'review', price: 100 },
+      user: { mode: 'review', price: 500, freeSlots: 6 },
+    });
+
+    expect(resolved.freeSlots).toBe(6);
+  });
+
+  // Pending is the point of the feature: without it fifty people submit into
+  // four slots and the creator gets a fifty-item review queue.
+  it('holds a slot while a placement is pending, and releases every other status', () => {
+    expect([...FREE_SLOT_HOLDING_STATUSES].sort()).toEqual(['approved', 'pending']);
+  });
+
+  it('starts the day at midnight UTC, wherever the placer is', () => {
+    const start = freePlacementDayStart(new Date('2026-08-17T23:59:59.999Z'));
+
+    expect(start.toISOString()).toBe('2026-08-17T00:00:00.000Z');
+    // A local-day boundary would let anyone willing to change timezone refresh
+    // the allowance twice, and would have two servers disagree about the day.
+    expect(freePlacementDayStart(new Date('2026-08-18T00:00:00.000Z')).toISOString()).toBe(
+      '2026-08-18T00:00:00.000Z'
+    );
+  });
+
+  it('is one placement a day, which is what makes free scarce', () => {
+    expect(FREE_PLACEMENTS_PER_DAY).toBe(1);
   });
 });

--- a/src/shared/utils/placement.ts
+++ b/src/shared/utils/placement.ts
@@ -109,6 +109,8 @@ export const PLACEMENT_SURFACES = {
     defaultPlatformShare: 0,
     expiryHours: 48,
     defaultFreeSlots: 1,
+    maxPendingPerOwner: 10,
+    allowedModes: ['off', 'review', 'auto'],
   },
   remixGallery: {
     label: 'remix galleries',
@@ -143,6 +145,10 @@ export const PLACEMENT_SURFACES = {
     defaultPlatformShare: 0,
     expiryHours: 48,
     defaultFreeSlots: 1,
+    maxPendingPerOwner: 10,
+    // Never `auto`: a gallery places arbitrary user-uploaded media on someone
+    // else's page, so every entry passes its owner.
+    allowedModes: ['off', 'review'],
   },
 } as const satisfies Record<
   PlacementSurface,
@@ -178,6 +184,24 @@ export const PLACEMENT_SURFACES = {
      * 0-1 makes this both the default and the maximum for a new creator.
      */
     defaultFreeSlots: number;
+    /**
+     * How many pending placements one placer may have waiting on one owner.
+     *
+     * A cap on a review queue an owner can work through, not a spam gate — the
+     * owner's remedy for the rest is block, which declines all of them.
+     *
+     * In the table because three call sites enforce it: both paid creation paths
+     * and the free one. It was two constants of the same value in two services
+     * before the free path needed a third.
+     */
+    maxPendingPerOwner: number;
+    /**
+     * Modes this surface may actually be in. A mode outside this list is refused
+     * where it is stored AND where it is acted on — a row written before a rule
+     * existed still reads back, and a listing that filters is not a mutation that
+     * refuses.
+     */
+    allowedModes: readonly PlacementSpaceMode[];
   }
 >;
 
@@ -302,7 +326,11 @@ export function resolvePlacementSpace(
     post?: PlacementSpaceSetting;
     user?: PlacementSpaceSetting;
   }
-): PlacementSpaceSetting {
+  // `freeSlots` narrowed to a number: this is the ONE place the surface default
+  // is applied, so callers read it rather than defaulting again. `price` is
+  // nullable here for a real reason — an unpriced space must not be charged for
+  // — where an unset slot count has an unambiguous answer.
+): PlacementSpaceSetting & { freeSlots: number } {
   const ordered = [levels.image, levels.post, levels.user];
   return {
     mode:
@@ -524,15 +552,15 @@ export const placementFreeSlotCap = (
 /**
  * What a space actually accepts, computed at read like the effective price.
  *
- * An unset count resolves to the surface default rather than to zero, because
- * free capacity is opt-out. `0` set explicitly is preserved — it is the creator
- * saying no, and defaulting it away would reopen a space they closed.
+ * Clamping only. Defaulting an unset count belongs to `resolvePlacementSpace`
+ * and happens there once — this used to re-apply it, which had one read path
+ * defaulting three times with two of them unreachable.
+ *
+ * The floor is not decoration: a misconfigured cap must not let `cap - reserved`
+ * hand out capacity nobody set.
  */
-export const effectiveFreeSlots = (
-  surface: PlacementSurface,
-  setSlots: number | null,
-  cap: number
-) => Math.max(Math.min(setSlots ?? PLACEMENT_SURFACES[surface].defaultFreeSlots, cap), 0);
+export const effectiveFreeSlots = (setSlots: number, cap: number) =>
+  Math.max(Math.min(setSlots, cap), 0);
 
 /**
  * How many free placements one placer may make in a UTC day, across every

--- a/src/shared/utils/placement.ts
+++ b/src/shared/utils/placement.ts
@@ -569,16 +569,27 @@ export const effectiveFreeSlots = (setSlots: number, cap: number) =>
  */
 export const FREE_PLACEMENTS_PER_DAY = 1;
 
+/** Milliseconds in a UTC day. Unix time has no leap seconds, so this is exact. */
+const DAY_MS = 24 * 3_600_000;
+
 /**
  * Midnight UTC for the day containing `at`.
  *
  * UTC rather than the placer's local day, so the allowance cannot be refreshed
  * twice by moving timezone, and so two servers never disagree about which day a
  * placement fell in.
+ *
+ * **Epoch arithmetic rather than calendar getters, because the calendar version
+ * is not testable where it matters.** Written as
+ * `Date.UTC(at.getUTCFullYear(), …)`, the one-character slip to
+ * `at.getFullYear()` produces a local-day boundary — and on a UTC runner, which
+ * is what CI is with no `TZ` pinned, the two are the *same function*. No test can
+ * separate them there, so a test claiming to would be asserting a property it
+ * cannot fail on. Flooring the epoch has no ambient timezone to read, so there is
+ * no such slip to make and the property is structural instead of hoped for.
  */
-export function freePlacementDayStart(at: Date = new Date()) {
-  return new Date(Date.UTC(at.getUTCFullYear(), at.getUTCMonth(), at.getUTCDate()));
-}
+export const freePlacementDayStart = (at: Date = new Date()) =>
+  new Date(Math.floor(at.getTime() / DAY_MS) * DAY_MS);
 
 /**
  * Statuses that hold a free slot.

--- a/src/shared/utils/placement.ts
+++ b/src/shared/utils/placement.ts
@@ -108,6 +108,7 @@ export const PLACEMENT_SURFACES = {
     // Changing this makes that copy false — change both or neither.
     defaultPlatformShare: 0,
     expiryHours: 48,
+    defaultFreeSlots: 1,
   },
   remixGallery: {
     label: 'remix galleries',
@@ -141,6 +142,7 @@ export const PLACEMENT_SURFACES = {
     // row: `approvalShares.remixGallery.platform`.
     defaultPlatformShare: 0,
     expiryHours: 48,
+    defaultFreeSlots: 1,
   },
 } as const satisfies Record<
   PlacementSurface,
@@ -166,6 +168,16 @@ export const PLACEMENT_SURFACES = {
     defaultSellerShare: number;
     defaultPlatformShare: number;
     expiryHours: number;
+    /**
+     * How many free placements a space accepts when its owner has never chosen.
+     *
+     * `1` rather than `0` because free capacity is opt-OUT, the same decision the
+     * gallery's `defaultMode` records: a creator who never opens these settings
+     * takes one free placement, which is what makes the habit reachable at all.
+     * It is still ceilinged by the score/tier cap, so the bottom band's range of
+     * 0-1 makes this both the default and the maximum for a new creator.
+     */
+    defaultFreeSlots: number;
   }
 >;
 
@@ -261,6 +273,17 @@ export type PlacementSpaceSettings = Record<string, unknown>;
 export type PlacementSpaceSetting = {
   mode: PlacementSpaceMode;
   price: number | null;
+  /**
+   * How many free placements this space accepts. `0` is a real answer — the
+   * creator taking none — which is why this replaces an on/off toggle rather
+   * than sitting beside one, and why `null` has to mean "unset" instead.
+   *
+   * A column rather than a key in `settings`. Both surfaces have the same
+   * concept and this layer reads it: `settings` is documented as surface-owned
+   * and never read here, so putting it there would either break that or force
+   * each surface to reimplement the reservation.
+   */
+  freeSlots?: number | null;
   settings?: PlacementSpaceSettings;
 };
 
@@ -288,6 +311,12 @@ export function resolvePlacementSpace(
     price:
       ordered.find((level) => level?.price != null)?.price ??
       PLACEMENT_SURFACES[surface].defaultPrice,
+    // Independently of `mode` and of `price`, for the same reason they are
+    // independent of each other: an owner who set their free capacity once, at
+    // the account level, should keep it on an image they later reprice.
+    freeSlots:
+      ordered.find((level) => level?.freeSlots != null)?.freeSlots ??
+      PLACEMENT_SURFACES[surface].defaultFreeSlots,
     // Merged per key, most specific last, rather than taking the first level
     // that has any settings at all: an owner who set a max size on their account
     // and something unrelated on one image should keep both.
@@ -449,6 +478,92 @@ export function placementPriceCap(
  */
 export const effectivePlacementPrice = (setPrice: number | null, cap: number) =>
   setPrice == null ? null : Math.max(Math.min(setPrice, cap), PLACEMENT_MIN_PRICE);
+
+// ---------------------------------------------------------------------------
+// Free capacity
+// ---------------------------------------------------------------------------
+
+/**
+ * How many free placements a creator may accept, capped by creator score and
+ * membership tier.
+ *
+ * Deliberately the same table shape, the same resolver (`placementPriceCap`) and
+ * the same `placement:config` override as the price caps above — this is the
+ * same idea applied to a different number, and a second mechanism for it would
+ * be two things to keep in agreement.
+ *
+ * The bottom band is 0-1: a brand-new creator takes one free placement, which is
+ * also `defaultFreeSlots`, so the default and the maximum coincide until they
+ * earn room to raise it. The top is 10, at gold on the highest score band.
+ *
+ * ⚠️ The middle bands are a judgement, not a measurement. The shape is the
+ * commitment: read at request time, overridable without a deploy, never written
+ * to a space or a placement row.
+ */
+export const PLACEMENT_FREE_SLOT_CAP_TIERS: PlacementPriceTier[] = [
+  { minScore: 0, caps: { free: 1, bronze: 2, silver: 3, gold: 4 } },
+  { minScore: 10_000, caps: { free: 2, bronze: 3, silver: 4, gold: 6 } },
+  { minScore: 25_000, caps: { free: 3, bronze: 4, silver: 6, gold: 8 } },
+  { minScore: 100_000, caps: { free: 4, bronze: 6, silver: 8, gold: 10 } },
+];
+
+/**
+ * The most free placements this creator may accept on one space.
+ *
+ * A thin naming of `placementPriceCap` over the free-slot table, not a second
+ * resolver: the band-picking rules (highest band at or below the score, unknown
+ * tier reads as free, a table with no zero band is unusable) are the same rules,
+ * and two copies of them would be free to drift.
+ */
+export const placementFreeSlotCap = (
+  score: number,
+  tier: PriceCapTier,
+  tiers: PlacementPriceTier[] = PLACEMENT_FREE_SLOT_CAP_TIERS
+) => placementPriceCap(score, tier, tiers);
+
+/**
+ * What a space actually accepts, computed at read like the effective price.
+ *
+ * An unset count resolves to the surface default rather than to zero, because
+ * free capacity is opt-out. `0` set explicitly is preserved — it is the creator
+ * saying no, and defaulting it away would reopen a space they closed.
+ */
+export const effectiveFreeSlots = (
+  surface: PlacementSurface,
+  setSlots: number | null,
+  cap: number
+) => Math.max(Math.min(setSlots ?? PLACEMENT_SURFACES[surface].defaultFreeSlots, cap), 0);
+
+/**
+ * How many free placements one placer may make in a UTC day, across every
+ * surface. The scarcity is the product: an unbounded free tier is a spam tier,
+ * and the people it costs are the creators who then close their spaces.
+ */
+export const FREE_PLACEMENTS_PER_DAY = 1;
+
+/**
+ * Midnight UTC for the day containing `at`.
+ *
+ * UTC rather than the placer's local day, so the allowance cannot be refreshed
+ * twice by moving timezone, and so two servers never disagree about which day a
+ * placement fell in.
+ */
+export function freePlacementDayStart(at: Date = new Date()) {
+  return new Date(Date.UTC(at.getUTCFullYear(), at.getUTCMonth(), at.getUTCDate()));
+}
+
+/**
+ * Statuses that hold a free slot.
+ *
+ * Pending is in the list and that is the entire point of the feature: without
+ * reservation, fifty people submit into four slots and the creator gets a
+ * fifty-item review queue, which is what the slider exists to prevent. Everything
+ * else — declined, expired, removed — releases the slot, immediately.
+ */
+export const FREE_SLOT_HOLDING_STATUSES = [
+  'pending',
+  'approved',
+] as const satisfies readonly PlacementStatus[];
 
 // ---------------------------------------------------------------------------
 // The split

--- a/src/shared/utils/remix-gallery.ts
+++ b/src/shared/utils/remix-gallery.ts
@@ -1,4 +1,5 @@
 import { NsfwLevel } from '~/server/common/enums';
+import { PLACEMENT_SURFACES } from '~/shared/utils/placement';
 
 /**
  * What a remix-gallery placement carries. Opaque to the placement foundation,
@@ -58,7 +59,8 @@ export const REMIX_GALLERY_ROW_WIDTH = 4;
  * about a review queue the owner can work through rather than about spam
  * economics. Their remedy for the rest is block.
  */
-export const REMIX_GALLERY_MAX_PENDING_PER_OWNER = 10;
+export const REMIX_GALLERY_MAX_PENDING_PER_OWNER =
+  PLACEMENT_SURFACES.remixGallery.maxPendingPerOwner;
 
 /**
  * How long an approved entry is protected from the owner removing it.


### PR DESCRIPTION
> [!IMPORTANT]
> **This PR ships a migration that has been applied nowhere, and we never run
> `prisma migrate deploy`.**
> `packages/civitai-db-schema/prisma/migrations/20260817120000_placement_free_capacity`
> must be run by hand against each environment **before** the deploy that carries
> this code. Details and the standing verification queries are at the bottom of
> this description and in the migration file itself. Do not merge-and-forget.

PR 1 of the free placements project: the capacity primitive everything else
builds on. It adds the concept and the claim; it does **not** wire the free path
into `createStickerPlacement` or `createRemixGallerySubmission` — those are PRs
2 and 4.

Intent and rationale: `_local/docs/plans/2026-08-17_free-placements.md`.

## What a free placement is

A placement space gains `freeSlots`: how many free placements that image
accepts. `0` is the creator taking none, so this replaces a separate on/off
toggle rather than sitting beside one.

A placer gets **one free placement per UTC day across every surface**, and may
never use a free placement twice on the same target. A decline or an expiry
gives the image's slot back but **not** the placer's day — refunding the day
turns the free tier into an unlimited retry loop against whoever declines
fastest.

## The cap bands

`PLACEMENT_FREE_SLOT_CAP_TIERS` reuses the `PLACEMENT_PRICE_CAP_TIERS` shape,
the same `placementPriceCap` resolver, and the same `placement:config` runtime
override (`freeSlotTiers`, `freeSlotTiersBySurface`). One mechanism, so a fix to
the band-picking cannot land on one table and miss the other.

| creator score | free | bronze | silver | gold |
|---|---|---|---|---|
| 0 | **1** | 2 | 3 | 4 |
| 10,000 | 2 | 3 | 4 | 6 |
| 25,000 | 3 | 4 | 6 | 8 |
| 100,000 | 4 | 6 | 8 | **10** |

The two ends were specified: 0-1 with a default of 1 at the bottom, 10 at gold
on the top band. The middle is my judgement — monotonic in both directions, with
membership worth roughly one band of score, so a paying creator at 0 sits where
a free creator at 10k-25k does. Both ends are pinned by tests so a table edit
that moves them is deliberate.

Stored uncapped and ceilinged at read, exactly like `price`: a creator whose
tier lapses and returns gets their number back rather than finding it silently
rewritten.

## How the slot race is solved

Two placers claiming the last slot is the obvious failure, and **neither rule is
expressible as a unique constraint** — "at most N held free rows on this target"
and "at most one free row for this placer today" are both counts.

`createFreePlacement` takes **two transaction-scoped Postgres advisory locks**,
in a fixed order (placer, then target, because a claim takes both and opposite
orders is the textbook deadlock), around a count-then-insert in one transaction.

Considered and rejected:

- **`withDistributedLock`** — returns null rather than running when Redis is
  down, so free placements would be refused during a Redis outage while the paid
  path kept working.
- **A serializable transaction** — turns a lost race into a retry every caller
  has to write.

An advisory lock needs no extra infrastructure, releases on commit or rollback
with nothing to leak, and makes count-then-insert atomic without holding a row
lock on `Placement`.

The claim lives in the primitive rather than in each surface on purpose: all
three refusals have to hold together, under the lock, in the same transaction as
the insert. A surface that built its own row and then checked would be a second
creation route with the checks bolted on the outside.

## Escrow

Bypassed **entirely**, not taken at zero. `holdPlacementEscrow` refuses a free
row outright, and `payoutLegsFor` returns no legs for one — no principal, no
decline fee, no seller split, no forfeit. The status transition still happens,
which is what releases the slot.

Reserved = pending + approved free rows, as a status predicate rather than a
stored counter, so decline / expiry / removal release a slot with no sweep in
between. Paid placements are not counted; the two counters are independent.

## Migration — needs applying by hand

`packages/civitai-db-schema/prisma/migrations/20260817120000_placement_free_capacity`

Adds `PlacementSpace.freeSlots`, `Placement.free`, two CHECK constraints and a
partial index. Both columns default to today's behaviour, so an old pod is
unaffected and no backfill is needed. **Apply before deploying.** The file
documents the rollback direction and the standing verification queries.

## Tests

Every guard was mutation-tested rather than assumed:

- reserved off-by-one, daily off-by-one, never-twice neutered, locks removed,
  deadline left unset — each fails 1-2 tests in under a second, by name.
- The free-row settlement tests seed **receipted** holds behind the row. Without
  that fixture they are vacuous: with no holds every payout branch already
  computes to zero, so deleting the guard would change nothing they observe.

## A note for PRs 2 and 4

`createFreePlacement` takes two advisory locks in a fixed order, and that order
is load-bearing: two callers taking them the other way round deadlock, and only
under concurrency — i.e. never in testing, and on the day the feature gets
popular. The lock keys are module-private with exactly one acquisition site, and
a guard test asserts that stays true, so this should not be a rule anyone has to
know. **If you need a lock here, call `createFreePlacement` rather than export
one.**

## One departure from the intent doc

The never-twice rule is scoped **per surface**: a free sticker on an image does
not consume the ability to submit a free remix to the same image. They are
different acts, the daily allowance already makes that pair cost two days, and
loosening later is additive where tightening is not. Recorded in the intent doc
and raised with ryan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012e1dXoYCT49aeMEzwSbAYB
