### PR TITLE
fix(review): make lane delivery an obligation on the agents

### DIFF
--- a/.claude/agents/civitai-correctness-review.md
+++ b/.claude/agents/civitai-correctness-review.md
@@ -162,3 +162,21 @@ Re-read the write-up rules at the top before you send it.
 **Findings only.** Do not inventory the checks you ran and found satisfied. Say plainly if the segment
 is clean — that is a real outcome and padding the list wastes the fix. One exception, one line: a
 hazard you confirmed is *not* a bug today but that the next edit would turn into one.
+
+## Delivering your report
+
+🔴 **Your findings reach nobody unless you deliver them.** Text you write in your own transcript is not
+sent anywhere. Finishing the analysis is not finishing the job.
+
+Return the report as your final message text. If you are running as a subagent whose own text does not
+reach whoever spawned you, send it explicitly instead. **Never go idle without reporting.**
+
+This is an obligation on you rather than advice, because of who pays for it. Whoever consolidates the
+lanes cannot tell a lane that went silent from a lane that found nothing — the two are identical from
+the outside. The consolidated review then reads as complete while missing your lane entirely, and the
+work you did is not merely lost, it is counted as evidence that there was nothing to find. A silent
+lane is worse than a failed one: a failure is visible. This has happened on a real run, and the lane
+that vanished held the sharpest finding of the round.
+
+The reasoning above is the rule, not the wording. Deliver in any situation where your findings would
+otherwise stop at you, including ones this paragraph did not anticipate.

--- a/.claude/agents/civitai-intent-review.md
+++ b/.claude/agents/civitai-intent-review.md
@@ -141,3 +141,21 @@ next, unrequested extras last.
 entry — the evidence column is enough. Say plainly when a PR delivers exactly what was asked; that is
 a real and welcome outcome, and it is worth stating in one sentence rather than being padded into a
 report.
+
+## Delivering your report
+
+🔴 **Your findings reach nobody unless you deliver them.** Text you write in your own transcript is not
+sent anywhere. Finishing the analysis is not finishing the job.
+
+Return the report as your final message text. If you are running as a subagent whose own text does not
+reach whoever spawned you, send it explicitly instead. **Never go idle without reporting.**
+
+This is an obligation on you rather than advice, because of who pays for it. Whoever consolidates the
+lanes cannot tell a lane that went silent from a lane that found nothing — the two are identical from
+the outside. The consolidated review then reads as complete while missing your lane entirely, and the
+work you did is not merely lost, it is counted as evidence that there was nothing to find. A silent
+lane is worse than a failed one: a failure is visible. This has happened on a real run, and the lane
+that vanished held the sharpest finding of the round.
+
+The reasoning above is the rule, not the wording. Deliver in any situation where your findings would
+otherwise stop at you, including ones this paragraph did not anticipate.

--- a/.claude/agents/civitai-perf-review.md
+++ b/.claude/agents/civitai-perf-review.md
@@ -156,3 +156,21 @@ are the second, and calling them all urgent is how the list stops being read.
 **Findings only.** Do not inventory the queries you checked and found cheap. Say plainly if the segment
 is clean. One exception, one line: a hot path the segment came close to but did not touch, where the
 next edit would.
+
+## Delivering your report
+
+🔴 **Your findings reach nobody unless you deliver them.** Text you write in your own transcript is not
+sent anywhere. Finishing the analysis is not finishing the job.
+
+Return the report as your final message text. If you are running as a subagent whose own text does not
+reach whoever spawned you, send it explicitly instead. **Never go idle without reporting.**
+
+This is an obligation on you rather than advice, because of who pays for it. Whoever consolidates the
+lanes cannot tell a lane that went silent from a lane that found nothing — the two are identical from
+the outside. The consolidated review then reads as complete while missing your lane entirely, and the
+work you did is not merely lost, it is counted as evidence that there was nothing to find. A silent
+lane is worse than a failed one: a failure is visible. This has happened on a real run, and the lane
+that vanished held the sharpest finding of the round.
+
+The reasoning above is the rule, not the wording. Deliver in any situation where your findings would
+otherwise stop at you, including ones this paragraph did not anticipate.

--- a/.claude/agents/civitai-reuse-review.md
+++ b/.claude/agents/civitai-reuse-review.md
@@ -169,3 +169,21 @@ need different work from the fixer.
 that is the bulk of a long report and none of it is actionable. Say plainly if the segment is clean —
 "nothing rebuilt" is a real and common outcome. Two exceptions, one line each: a duplicate you decided
 was *deliberate* and why, and an existing helper the segment should watch for on its next consumer.
+
+## Delivering your report
+
+🔴 **Your findings reach nobody unless you deliver them.** Text you write in your own transcript is not
+sent anywhere. Finishing the analysis is not finishing the job.
+
+Return the report as your final message text. If you are running as a subagent whose own text does not
+reach whoever spawned you, send it explicitly instead. **Never go idle without reporting.**
+
+This is an obligation on you rather than advice, because of who pays for it. Whoever consolidates the
+lanes cannot tell a lane that went silent from a lane that found nothing — the two are identical from
+the outside. The consolidated review then reads as complete while missing your lane entirely, and the
+work you did is not merely lost, it is counted as evidence that there was nothing to find. A silent
+lane is worse than a failed one: a failure is visible. This has happened on a real run, and the lane
+that vanished held the sharpest finding of the round.
+
+The reasoning above is the rule, not the wording. Deliver in any situation where your findings would
+otherwise stop at you, including ones this paragraph did not anticipate.

--- a/.claude/agents/civitai-test-review.md
+++ b/.claude/agents/civitai-test-review.md
@@ -186,3 +186,21 @@ Separate **"this test does not work"** from **"this behaviour is untested"** —
 **Findings only.** Do not inventory the tests you read and found sound. Say plainly if the segment's
 tests are solid; that is a real outcome. One exception, one line: a test you found weak but deliberately
 so, with the reason.
+
+## Delivering your report
+
+🔴 **Your findings reach nobody unless you deliver them.** Text you write in your own transcript is not
+sent anywhere. Finishing the analysis is not finishing the job.
+
+Return the report as your final message text. If you are running as a subagent whose own text does not
+reach whoever spawned you, send it explicitly instead. **Never go idle without reporting.**
+
+This is an obligation on you rather than advice, because of who pays for it. Whoever consolidates the
+lanes cannot tell a lane that went silent from a lane that found nothing — the two are identical from
+the outside. The consolidated review then reads as complete while missing your lane entirely, and the
+work you did is not merely lost, it is counted as evidence that there was nothing to find. A silent
+lane is worse than a failed one: a failure is visible. This has happened on a real run, and the lane
+that vanished held the sharpest finding of the round.
+
+The reasoning above is the rule, not the wording. Deliver in any situation where your findings would
+otherwise stop at you, including ones this paragraph did not anticipate.

--- a/.claude/skills/civitai-review/SKILL.md
+++ b/.claude/skills/civitai-review/SKILL.md
@@ -120,6 +120,12 @@ report then looks complete while missing a fifth of the review. It has happened 
 lane that vanished held the sharpest finding of the round. **Account for all five by name before you
 consolidate**, and treat "idle" as a question, not an answer.
 
+The same obligation is written into each of the five agent definitions, where it does not depend on the
+invoker remembering to pass it. Both are kept: they fail independently, and the redundancy costs a
+paragraph. ⚠️ **Do not read "I caught the silent lanes" as evidence the system works.** A run where
+someone already knew about this failure and watched for it proves nothing about the run where nobody
+does — which is every run after the one that discovered it.
+
 ## 3. Consolidate
 
 **Do not relay five reports.** Produce **three sections**, in this order:
@@ -164,6 +170,16 @@ permanent. They live in the conversation until they are fixed.
    whose findings were touched, and launch those together in one message as in step 2.
 4. Iterate.
 
+🔴 **Narrowing on re-review narrows *which lanes run*, never *what each running lane sees*.** Give every
+re-run lane the complete updated diff, not only the hunks matching its own findings.
+
+Deciding a whole lane is irrelevant is cheap to get right — reuse has nothing to say about a one-line
+SQL fix. Deciding which *part* of a diff is relevant to a lane is the same guess the lane exists to make
+for us, and it is wrong in the case that matters: a fix in one lane's territory changes the code another
+lane's findings were about. A test lane shown only its own changed assertions reviews them against a
+function that no longer exists in the form it is imagining — new refusals mean new branches, and "is
+this test still meaningful" cannot be answered from the assertion alone.
+
 **A declined finding is a legitimate outcome, but it must come back with a reason.** The reviewer then
 either accepts the reason or escalates to Justin. 🔴 **Silent non-fixes are the failure mode here** — a
 finding that quietly doesn't appear in the next round has not been resolved, it has been lost. Track
@@ -191,8 +207,19 @@ git diff <old-sha> <new-sha>
 git show <new-sha>:<path>
 ```
 
-Then re-target only the lanes whose subject those files touch — the same rule as the loop above. Move
-the tree once every lane is idle, if at all.
+Then re-target only the lanes whose subject those files touch — the same rule as the loop above.
+
+**Move the tree only when every lane is idle**, and account for all five by name first, per step 2 — an
+idle lane that never reported is still holding a read you are about to invalidate. That is the safe
+moment and the only one. After the checkout, re-apply step 0:
+
+```bash
+git checkout --detach origin/<branch>
+git checkout origin/main -- .claude    # the branch still predates the skill
+```
+
+Without that second line the agents disappear again mid-review, and the next fan-out fails to resolve
+them.
 
 ## 5. Close out — the implementer's step, not the reviewer's
 


### PR DESCRIPTION
Follow-up to #4010, from the second round of the first real use of this review set.

## 1. The delivery rule moves into the five agent definitions

#4010 put it in the skill's step 2, which tells the *invoker* to instruct each lane. That only works if whoever runs the skill remembers — a property of that run, not of the system.

**The measurement that says the invoker is the wrong place.** Round 2 ran four lanes. Two of them finished, went idle, and delivered nothing; their reports existed only in their own transcripts. Both were running as **registered `civitai-*-review` agent types**, so this is the agents' default behaviour and not an artifact of how round 1 spawned them.

After the second silent lane I sent a one-line reminder to the two still running — "your report only reaches me if you send it, do not just go idle." Both delivered unprompted.

| Lane | Reminder | Delivered |
| --- | --- | --- |
| reuse | no | no — chased |
| correctness | no | no — chased |
| test | yes | yes |
| perf | yes | yes |

Two for two in each direction, same framework, same round, same tree, the reminder the only thing that differed. That is what this change installs permanently, in the place it cannot be forgotten.

Written as an obligation on the agent rather than as advice, with its reason attached: whoever consolidates cannot distinguish a lane that went silent from a lane that found nothing, so the review reads as complete while missing that lane, and the work is not merely lost — it is counted as evidence there was nothing to find. A silent lane is worse than a failed one, because a failure is visible. The paragraph ends by saying the reasoning is the rule, not the wording, so an agent applies it in cases the wording did not anticipate.

The skill's copy stays. The two fail independently and the redundancy costs a paragraph.

## 2. Narrowing on re-review narrows which lanes run, never what each lane sees

Every re-run lane gets the complete updated diff, not just the hunks matching its own findings.

Deciding a whole lane is irrelevant is cheap to get right. Deciding which *part* of a diff is relevant to a lane is the same guess the lane exists to make for us, and it is wrong exactly where it matters: a fix in one lane's territory changes the code another lane's findings were about. Concretely, in round 2 the correctness fixes added four refusals to the function the test lane's findings were assertions about — shown only its own changed assertions, it would have been reviewing them against a function that no longer exists in the form it was imagining.

## 3. The tree moves only when every lane is idle, and step 0 is re-applied after

Stated as the rule, with the account-for-all-five check first: an idle lane that never reported is still holding a read you are about to invalidate. The re-checkout also has to repeat `git checkout origin/main -- .claude`, because the branch under review still predates the skill — without it the agents disappear again mid-review and the next fan-out fails to resolve them.

## Also

One line noting that catching the silent lanes on the run that discovered the problem is not evidence the system works. That run had someone watching for it. Every subsequent run will not.

Documentation only — no code, no tests, no schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LcbNChPWpDvFBGGRGq9i5w
