### PR TITLE
fix(rewards): turn off the follow and generator feedback rewards

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260817120000_disable_follow_and_feedback_rewards/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260817120000_disable_follow_and_feedback_rewards/migration.sql
@@ -1,0 +1,62 @@
+-- ============================================================
+-- Turn off the firstDailyFollow and generation-feedback Buzz rewards
+-- ============================================================
+-- Deprecated at Justin's request. Both rewards keep their definitions and their
+-- call sites; this row is what stops them paying, via the `rewards:config`
+-- mechanism in src/server/rewards/reward-config.ts.
+--
+-- Past grants are NOT touched. The Buzz ledger and the ClickHouse `buzzEvents`
+-- history stay exactly as they are; this only stops future awards.
+--
+-- ⚠️ MANUAL APPLY — the main civitai DB does NOT auto-apply migrations. This file
+-- is committed for history; a HUMAN applies the SQL below per environment
+-- (psql/retool). CI / deploy does NOT run it. Applying it IS the deprecation, so
+-- the timing is whoever runs it, not a deploy.
+--
+-- Reversible without a deploy: set either `enabled` back to true here, or use the
+-- `rewardConfig.set` moderator procedure. Verify the live state through
+-- GET /api/testing/rewards-config?token=$WEBHOOK_TOKEN, which resolves through
+-- the same code path as a grant.
+--
+-- MERGE, NOT REPLACE. The row is shared by every reward, so this must not clobber
+-- overrides someone else set:
+--   - Other rewards' entries are preserved.
+--   - Other fields on these two entries (`awardAmount`, `cap`) are preserved, so
+--     re-enabling restores whatever amount was configured.
+--   - ON CONFLICT DO UPDATE rather than DO NOTHING: with DO NOTHING, an existing
+--     row would leave both rewards paying while this migration reported success.
+--   - A non-object entry (`"firstDailyFollow": false`, `null`) is replaced rather
+--     than concatenated, because `||` errors on a non-object jsonb operand.
+INSERT INTO "KeyValue" ("key", "value")
+VALUES (
+  'rewards:config',
+  '{"rewards":{"firstDailyFollow":{"enabled":false},"generation-feedback":{"enabled":false}}}'::jsonb
+)
+ON CONFLICT ("key") DO UPDATE
+SET "value" = COALESCE("KeyValue"."value", '{}'::jsonb) || jsonb_build_object(
+  'rewards',
+  COALESCE(
+    CASE
+      WHEN jsonb_typeof("KeyValue"."value" -> 'rewards') = 'object'
+      THEN "KeyValue"."value" -> 'rewards'
+    END,
+    '{}'::jsonb
+  ) || jsonb_build_object(
+    'firstDailyFollow',
+    COALESCE(
+      CASE
+        WHEN jsonb_typeof("KeyValue"."value" #> '{rewards,firstDailyFollow}') = 'object'
+        THEN "KeyValue"."value" #> '{rewards,firstDailyFollow}'
+      END,
+      '{}'::jsonb
+    ) || '{"enabled":false}'::jsonb,
+    'generation-feedback',
+    COALESCE(
+      CASE
+        WHEN jsonb_typeof("KeyValue"."value" #> '{rewards,generation-feedback}') = 'object'
+        THEN "KeyValue"."value" #> '{rewards,generation-feedback}'
+      END,
+      '{}'::jsonb
+    ) || '{"enabled":false}'::jsonb
+  )
+);

--- a/src/__tests__/mocks/env.mock.ts
+++ b/src/__tests__/mocks/env.mock.ts
@@ -130,6 +130,11 @@ export const TEST_ENV_DEFAULTS: Record<string, unknown> = {
   S3_UPLOAD_ENDPOINT: 'http://localhost:9000',
   S3_IMAGE_UPLOAD_ENDPOINT: 'http://localhost:9000',
   ORCHESTRATOR_ENDPOINT: 'http://localhost:8080',
+  // orchestrator.caller constructs an OrchestratorCaller at MODULE scope and throws
+  // `Missing ORCHESTRATOR_ACCESS_TOKEN env` without this, so any suite whose graph
+  // reaches it (e.g. importing orchestrator.router) fails to collect. Worker-level for
+  // the same reason as the endpoint above — a per-file override arrives too late.
+  ORCHESTRATOR_ACCESS_TOKEN: 'test-orchestrator-token',
   SIGNALS_ENDPOINT: 'http://localhost:8081',
   // Read by clickhouse/client.ts at MODULE scope, so it has to be a worker-level default: a
   // per-file override arrives after that module was already evaluated for the worker. This

--- a/src/server/rewards/__tests__/deprecated-rewards.gate.test.ts
+++ b/src/server/rewards/__tests__/deprecated-rewards.gate.test.ts
@@ -1,7 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type * as UserService from '~/server/services/user.service';
-import type * as PromClient from '~/server/prom/client';
-import type * as EnvServer from '~/env/server';
 
 // ---------------------------------------------------------------------------
 // WHY THIS SUITE EXISTS
@@ -22,24 +20,15 @@ import type * as EnvServer from '~/env/server';
 // observes a real payment through the same seam. Without the control, a suite that
 // stopped reaching `sendAward` for any unrelated reason — a changed mock, a moved
 // import — would keep passing while proving nothing.
+//
+// 🔴 Do NOT mock `~/env/server` here, in any spelling. Importing `orchestrator.router`
+// below constructs an OrchestratorCaller at MODULE scope, whose two env vars are
+// worker-level defaults in the canonical `~/__tests__/mocks/env.mock`. An
+// `importOriginal` spread loads the REAL env and validates it: green locally, and
+// `Invalid environment variables` at COLLECTION wherever a `.env` is absent — surfaced
+// as an unrelated `vi.mock` hoisting error two frames out. Nothing catches it locally;
+// `~/env/server` is PENDING in `guarded-specifiers.ts`, counted rather than enforced.
 // ---------------------------------------------------------------------------
-
-// Importing `orchestrator.router` reaches `orchestrator.caller`, which constructs an
-// OrchestratorCaller at MODULE SCOPE and throws without these two. Overriding
-// `process.env` does not help — env is parsed once, before this file's hoisted
-// blocks run — so the values have to come from the env module itself. Neither is
-// ever used: no orchestrator HTTP call happens in this suite.
-vi.mock('~/env/server', async (importOriginal) => {
-  const actual = await importOriginal<typeof EnvServer>();
-  return {
-    ...actual,
-    env: {
-      ...actual.env,
-      ORCHESTRATOR_ENDPOINT: 'https://orchestrator.invalid',
-      ORCHESTRATOR_ACCESS_TOKEN: 'unused-in-test',
-    },
-  };
-});
 
 const h = vi.hoisted(() => ({
   insert: vi.fn(async () => undefined),
@@ -57,17 +46,6 @@ vi.mock('~/server/clickhouse/client', () => ({
     $query: (...args: any[]) => h.query(...args),
     query: vi.fn(async () => ({ json: async () => [] })),
   },
-}));
-
-// Spread rather than hand-list: this suite's import graph reaches user.controller
-// and the whole orchestrator router, so a listed subset breaks on the first counter
-// some unrelated module in that graph imports.
-vi.mock('~/server/prom/client', async (importOriginal) => ({
-  ...(await importOriginal<typeof PromClient>()),
-  rewardFailedCounter: { inc: vi.fn() },
-  rewardGivenCounter: { inc: vi.fn() },
-  clickhouseFailSoftCounter: { inc: vi.fn() },
-  rewardConfigReadFailedCounter: { inc: vi.fn() },
 }));
 
 vi.mock('~/server/services/buzz.service', () => ({

--- a/src/server/rewards/__tests__/deprecated-rewards.gate.test.ts
+++ b/src/server/rewards/__tests__/deprecated-rewards.gate.test.ts
@@ -1,0 +1,345 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type * as UserService from '~/server/services/user.service';
+import type * as PromClient from '~/server/prom/client';
+import type * as EnvServer from '~/env/server';
+
+// ---------------------------------------------------------------------------
+// WHY THIS SUITE EXISTS
+//
+// `firstDailyFollow` and `generation-feedback` are deprecated by a `rewards:config`
+// row rather than by deleting them, so the only thing standing between a follow (or
+// a generator feedback click) and a Blue Buzz grant is the gate inside `apply`.
+// base.reward.config.test.ts proves the gate works on a locally-built reward. This
+// suite proves it works FROM THE TWO CALL SITES THAT ACTUALLY PAY, using the real
+// exported reward objects rather than a fixture.
+//
+// The distinction is not academic. The earlier deletion-shaped version of this work
+// found that `user.controller` imports `firstDailyFollowReward` direct-from-file
+// while `orchestrator.router` imports from the barrel, so "the mechanism works" and
+// "this call site is covered" were separate questions once before.
+//
+// Every disabled-case assertion below is paired with an enabled control that
+// observes a real payment through the same seam. Without the control, a suite that
+// stopped reaching `sendAward` for any unrelated reason — a changed mock, a moved
+// import — would keep passing while proving nothing.
+// ---------------------------------------------------------------------------
+
+// Importing `orchestrator.router` reaches `orchestrator.caller`, which constructs an
+// OrchestratorCaller at MODULE SCOPE and throws without these two. Overriding
+// `process.env` does not help — env is parsed once, before this file's hoisted
+// blocks run — so the values have to come from the env module itself. Neither is
+// ever used: no orchestrator HTTP call happens in this suite.
+vi.mock('~/env/server', async (importOriginal) => {
+  const actual = await importOriginal<typeof EnvServer>();
+  return {
+    ...actual,
+    env: {
+      ...actual.env,
+      ORCHESTRATOR_ENDPOINT: 'https://orchestrator.invalid',
+      ORCHESTRATOR_ACCESS_TOKEN: 'unused-in-test',
+    },
+  };
+});
+
+const h = vi.hoisted(() => ({
+  insert: vi.fn(async () => undefined),
+  query: vi.fn(async () => [] as unknown[]),
+  createBuzzTransactionMany: vi.fn(async () => ({ transactions: [] })),
+  getMultipliersForUser: vi.fn(async () => ({ rewardsMultiplier: 1 })),
+  toggleFollowUser: vi.fn(async () => true),
+  patchWorkflowSteps: vi.fn(async () => undefined),
+  getOrchestratorToken: vi.fn(async () => 'token'),
+}));
+
+vi.mock('~/server/clickhouse/client', () => ({
+  clickhouse: {
+    insert: (...args: any[]) => h.insert(...args),
+    $query: (...args: any[]) => h.query(...args),
+    query: vi.fn(async () => ({ json: async () => [] })),
+  },
+}));
+
+// Spread rather than hand-list: this suite's import graph reaches user.controller
+// and the whole orchestrator router, so a listed subset breaks on the first counter
+// some unrelated module in that graph imports.
+vi.mock('~/server/prom/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof PromClient>()),
+  rewardFailedCounter: { inc: vi.fn() },
+  rewardGivenCounter: { inc: vi.fn() },
+  clickhouseFailSoftCounter: { inc: vi.fn() },
+  rewardConfigReadFailedCounter: { inc: vi.fn() },
+}));
+
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransactionMany: (...args: any[]) => h.createBuzzTransactionMany(...args),
+  getMultipliersForUser: (...args: any[]) => h.getMultipliersForUser(...args),
+  createBuzzTransaction: vi.fn(),
+}));
+
+vi.mock('~/server/services/user.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof UserService>()),
+  toggleFollowUser: (...args: any[]) => h.toggleFollowUser(...args),
+}));
+
+vi.mock('~/server/services/orchestrator/workflowSteps', () => ({
+  patchWorkflowSteps: (...args: any[]) => h.patchWorkflowSteps(...args),
+}));
+
+vi.mock('~/server/orchestrator/get-orchestrator-token', () => ({
+  getOrchestratorToken: (...args: any[]) => h.getOrchestratorToken(...args),
+}));
+
+vi.mock('~/server/search-index', () => ({ usersSearchIndex: { queueUpdate: vi.fn() } }));
+vi.mock('~/server/cloudflare/client', () => ({ purgeCache: vi.fn(async () => undefined) }));
+
+import { readFileSync } from 'node:fs';
+import { firstDailyFollowReward } from '~/server/rewards/active/firstDailyFollow.reward';
+import { generatorFeedbackReward } from '~/server/rewards';
+import * as rewardImports from '~/server/rewards';
+import { invalidateRewardConfigCache } from '~/server/rewards/reward-config';
+import {
+  toggleFollowUserHandler,
+  userRewardDetailsHandler,
+} from '~/server/controllers/user.controller';
+import { orchestratorRouter } from '~/server/routers/orchestrator.router';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+const AWARD = 10;
+
+const configRow = dbMock.dbRead.keyValue.findUnique;
+const disable = (...types: string[]) =>
+  configRow.mockResolvedValue({
+    value: { rewards: Object.fromEntries(types.map((type) => [type, { enabled: false }])) },
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  invalidateRewardConfigCache();
+  // No row at all: every reward runs on its compiled defaults, i.e. enabled. This
+  // is the control state, and it has to actually pay for the tests to mean anything.
+  configRow.mockResolvedValue(null);
+  h.getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: 1 });
+  h.toggleFollowUser.mockResolvedValue(true);
+  redisMock.redis.eval.mockResolvedValue(AWARD as never);
+  redisMock.redis.hGet.mockResolvedValue('{}' as never);
+});
+
+const paidTypes = () =>
+  h.createBuzzTransactionMany.mock.calls.flatMap(([transactions]: any) =>
+    (transactions as any[]).map((t) => t.details?.type)
+  );
+
+// ---------------------------------------------------------------------------
+// Call site 1 — firstDailyFollow, from user.controller's toggleFollowUserHandler.
+//
+// This is the call site that the deletion-shaped version of this work would have
+// silently left paying, because the reward is imported direct-from-file rather than
+// through `~/server/rewards`. `apply` is awaited here, so these assertions are
+// deterministic.
+// ---------------------------------------------------------------------------
+describe('firstDailyFollow — from toggleFollowUserHandler', () => {
+  const follow = () =>
+    toggleFollowUserHandler({
+      input: { targetUserId: 99 },
+      ctx: {
+        user: { id: 7 },
+        ip: '1.2.3.4',
+        track: { userEngagement: vi.fn(async () => undefined) },
+      },
+    } as never);
+
+  it('pays on a follow while the reward is enabled', async () => {
+    await follow();
+    expect(paidTypes()).toContain('firstDailyFollow');
+  });
+
+  it('pays nothing on a follow once the reward is disabled', async () => {
+    disable('firstDailyFollow');
+    await follow();
+    expect(h.createBuzzTransactionMany).not.toHaveBeenCalled();
+  });
+
+  it('does no work at all for the disabled reward — no dedup entry, no audit row', async () => {
+    disable('firstDailyFollow');
+    await follow();
+    // The gate is the first statement of `apply`, so nothing downstream of it runs.
+    // Asserting this rather than only the payment is what distinguishes "gated" from
+    // "granted zero", which would still burn the day's dedup entry.
+    expect(redisMock.redis.eval).not.toHaveBeenCalled();
+    expect(h.insert).not.toHaveBeenCalled();
+  });
+
+  it('still follows the user when the reward is disabled', async () => {
+    disable('firstDailyFollow');
+    const result = await follow();
+    // Deprecating a reward must not break the action that used to earn it.
+    expect(h.toggleFollowUser).toHaveBeenCalled();
+    expect(result).toEqual({ following: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Call site 2 — generation-feedback, from orchestrator.router's `patch`.
+//
+// ⚠️ This call site is FIRE-AND-FORGET, and that shapes the test. `patch` builds
+// `Promise.all(steps.map(step => step.patches.filter(...).map(async ...)))`, which
+// hands `Promise.all` an array of ARRAYS. Arrays are not thenables, so they resolve
+// to themselves immediately and the inner promises are awaited by nothing.
+//
+// So a bare `expect(...).not.toHaveBeenCalled()` after `await caller.patch(...)`
+// would pass whether the gate works or not — it runs before the grant would have
+// happened either way.
+//
+// The fix is `flushMicrotasks` plus a control that uses the SAME flush. Every
+// dependency on the grant path is mocked async, so the floating work is a pure
+// microtask chain with no timers in it: draining microtasks is exhaustive, where a
+// `setTimeout` or a `vi.waitFor` timeout would give the two cases windows of
+// different lengths and make the disabled assertion a race. The enabled control
+// observing a payment through the same flush is what proves the window is long
+// enough for the disabled case's silence to be evidence.
+// ---------------------------------------------------------------------------
+
+// Deep enough for the chain above (getKey → multipliers → Lua → CH insert →
+// sendAward), with room to spare; short enough that a genuine hang still fails fast.
+const flushMicrotasks = async () => {
+  for (let i = 0; i < 100; i++) await Promise.resolve();
+};
+describe('generation-feedback — from the orchestrator patch mutation', () => {
+  const patch = () =>
+    orchestratorRouter
+      .createCaller({
+        user: { id: 7 },
+        ip: '1.2.3.4',
+        features: {},
+        acceptableOrigin: true,
+        // Session auth, i.e. the browser path this mutation is actually called from.
+        tokenScope: TokenScope.Full,
+        apiKeyId: null,
+      } as never)
+      .patch({
+        steps: [
+          {
+            workflowId: 'wf_1',
+            stepName: 'step_1',
+            patches: [{ op: 'add', path: '/images/job_abc/feedback' }],
+          },
+        ],
+      });
+
+  // The control for the test below. If this ever stops observing a payment, the
+  // disabled case proves nothing and this failure is the warning.
+  it('pays for feedback while the reward is enabled', async () => {
+    await patch();
+    await flushMicrotasks();
+    expect(paidTypes()).toContain('generation-feedback');
+  });
+
+  it('pays nothing for feedback once the reward is disabled', async () => {
+    disable('generation-feedback');
+    await patch();
+    await flushMicrotasks();
+    expect(h.createBuzzTransactionMany).not.toHaveBeenCalled();
+  });
+
+  it('still applies the step patches when the reward is disabled', async () => {
+    disable('generation-feedback');
+    await patch();
+    // The feedback itself is persisted by `patchWorkflowSteps`, not by the reward.
+    expect(h.patchWorkflowSteps).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The advertising door. A reward that quietly stops paying is a support ticket; a
+// reward still listed at an amount it will never pay is a broken promise on a page.
+// ---------------------------------------------------------------------------
+describe('the rewards list stops advertising both', () => {
+  const listed = async () => {
+    const rewards = await userRewardDetailsHandler({ ctx: { user: { id: 7 } } } as never);
+    return rewards.map((r: { type: string }) => r.type);
+  };
+
+  it('lists both while they are enabled', async () => {
+    const types = await listed();
+    expect(types).toContain('firstDailyFollow');
+    expect(types).toContain('generation-feedback');
+  });
+
+  it('drops both once they are disabled', async () => {
+    disable('firstDailyFollow', 'generation-feedback');
+    const types = await listed();
+    expect(types).not.toContain('firstDailyFollow');
+    expect(types).not.toContain('generation-feedback');
+  });
+
+  it('leaves the other rewards listed', async () => {
+    disable('firstDailyFollow', 'generation-feedback');
+    const types = await listed();
+    // Scoping matters: the row is shared, and a gate keyed on the wrong thing would
+    // take the whole list down rather than two entries.
+    expect(types).toContain('dailyBoost');
+    expect(types.length).toBeGreaterThan(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Neither reward can exercise `process`. Both are `onDemand`, so `apply` writes
+// `awarded` or `capped` inline and never the `pending` row that `process` pays.
+// Recorded as an assertion rather than a comment so that making one of them
+// processable — which would put it back in the sweep's path — fails here.
+// ---------------------------------------------------------------------------
+describe('both are on-demand, so the process sweep does not apply to them', () => {
+  it.each([
+    ['firstDailyFollow', firstDailyFollowReward],
+    ['generation-feedback', generatorFeedbackReward],
+  ])('%s writes no pending row', async (_type, reward) => {
+    await reward.process({ toProcess: [], lastUpdate: new Date(0), ch: {}, db: {} } as never);
+    expect(h.query).not.toHaveBeenCalled();
+    expect(h.createBuzzTransactionMany).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The migration is the deprecation, and it addresses rewards by their `type`
+// STRING. A typo there is the quietest possible failure: the row writes, the SQL
+// reports success, and the reward keeps paying under a key nothing reads. Nothing
+// else in the codebase connects that file to these identifiers, so this is the only
+// place the two can be held together.
+// ---------------------------------------------------------------------------
+describe('the migration disables reward types that exist', () => {
+  const sql = readFileSync(
+    new URL(
+      '../../../../packages/civitai-db-schema/prisma/migrations/20260817120000_disable_follow_and_feedback_rewards/migration.sql',
+      import.meta.url
+    ),
+    'utf8'
+  );
+
+  const configured = JSON.parse(/VALUES \(\s*'rewards:config',\s*'([^']+)'/.exec(sql)?.[1] ?? '{}')
+    .rewards as Record<string, { enabled?: boolean }>;
+
+  const knownTypes = Object.values(rewardImports).flatMap((reward) => reward.types);
+
+  it('names exactly the two rewards this PR deprecates', () => {
+    expect(Object.keys(configured).sort()).toEqual(['firstDailyFollow', 'generation-feedback']);
+  });
+
+  it.each(['firstDailyFollow', 'generation-feedback'])('%s is a real reward type', (type) => {
+    expect(knownTypes).toContain(type);
+  });
+
+  it.each(['firstDailyFollow', 'generation-feedback'])('%s is turned off, not on', (type) => {
+    expect(configured[type]).toEqual({ enabled: false });
+  });
+
+  it('sets the same two keys in the ON CONFLICT branch as in the insert', () => {
+    // The insert and the merge branch name the rewards separately, so they can drift.
+    // A reward disabled on a fresh row but not on an existing one is the worst case:
+    // it works in preview, where the row is absent, and not in production.
+    for (const type of Object.keys(configured)) {
+      expect(sql).toContain(`'{rewards,${type}}'`);
+    }
+  });
+});


### PR DESCRIPTION
Deprecates two Buzz rewards at Justin's request, by turning them off at runtime rather than deleting them:

| Reward | Type | Amount | Cap |
|---|---|---|---|
| First daily follow | `firstDailyFollow` | 10 Blue Buzz | 30/day |
| Generator feedback | `generation-feedback` | 4 Blue Buzz | 40/day |

Both keep their definitions and both call sites. The `rewards:config` mechanism from #4019 is what stops them paying, so the timing is whoever applies the row rather than a deploy, and re-enabling is a config edit rather than a revert.

**Past grants are untouched.** The Buzz ledger and the ClickHouse `buzzEvents` history stay exactly as they are; this stops future awards only. The `block-buzz-read` projection keeps redacting both historical type strings, which is correct — old rows are no less sensitive for the reward being off.

## What changed

- **`packages/civitai-db-schema/prisma/migrations/20260817120000_disable_follow_and_feedback_rewards/migration.sql`** — sets `enabled: false` for both types in the `rewards:config` `KeyValue` row. **Manual apply**, per the repo's migration policy; applying it *is* the deprecation.
- **`src/server/rewards/__tests__/deprecated-rewards.gate.test.ts`** — 18 tests covering both call sites, the listing, and the migration itself.

No application code changes.

### The migration merges rather than replaces

The row is shared by every reward, so the `ON CONFLICT` branch preserves other rewards' entries and other fields on these two — re-enabling restores whatever `awardAmount` was configured. `DO NOTHING` would have been wrong in the quietest possible way: with a row already present, both rewards would keep paying while the migration reported success.

Verified read-only on the replica against four prior-row shapes (no table touched — the expression was evaluated over a `VALUES` list):

| Prior row | Result |
|---|---|
| no `rewards` key | key created, unrelated top-level fields preserved |
| `dailyBoost` set, `firstDailyFollow.awardAmount: 7` | both preserved, `enabled: false` added alongside the amount |
| `"firstDailyFollow": false`, `"generation-feedback": null` | replaced cleanly (`\|\|` errors on a non-object operand, hence the `jsonb_typeof` guards) |
| already disabled | idempotent |

## How to check what is actually on

`GET /api/testing/rewards-config?token=$WEBHOOK_TOKEN`. It resolves through the same `resolveRewardConfig` a grant uses, shows the compiled default beside the effective value, and lists any override field that was refused. That endpoint is the answer to "is this reward on?" — a config row is only checkable if you know where to look, and this is the one place that reconciles the row against the definitions for you.

Reverting needs no deploy: flip either `enabled` back, or use the `rewardConfig.set` moderator procedure.

## Tests, and how they fail

`base.reward.config.test.ts` already proves the gate works on a locally-built reward. This suite proves it works **from the two call sites that actually pay**, using the real exported reward objects.

Every disabled-case assertion is paired with an **enabled control that observes a real payment through the same seam**. Without the control, a suite that stopped reaching `sendAward` for any unrelated reason would keep passing while proving nothing.

Mutation-tested rather than assumed:

| Mutation | Result |
|---|---|
| remove `if (!config.enabled) return;` from `apply` | 3 failures, both call sites, with the real transaction in the message (`amount: 10`, `type: firstDailyFollow`) |
| remove `if (!config.enabled) return null;` from `getUserRewardDetails` | listing test fails: `expected [ 'encouragement', …(8) ] to not include 'firstDailyFollow'` |
| typo a reward key in the migration SQL | 3 failures naming the bad key |

### The orchestrator call site needed care

`orchestrator.router`'s `patch` builds `Promise.all(steps.map(step => step.patches.filter(...).map(async ...)))`, which hands `Promise.all` an array of **arrays**. Arrays are not thenables, so they resolve to themselves immediately and the inner promises are awaited by nothing — the reward call there is already fire-and-forget.

That makes a bare `expect(...).not.toHaveBeenCalled()` after `await caller.patch(...)` **vacuous**: it runs before the grant would have happened either way, so it passes whether or not the gate works. Every dependency on that path is mocked async and no timers are involved, so the fix is an exhaustive microtask drain used identically by both the enabled control and the disabled case — a `setTimeout` or a `vi.waitFor` timeout would give the two cases different windows and make the disabled assertion a race. The first version of this test used `vi.waitFor` and failed under mutation via a pretty-format error that aborted the suite and skipped a sibling test: the right outcome for the wrong reason. The current version produces three clean assertion failures and skips nothing.

That fire-and-forget is pre-existing and **not** fixed here. It also defeats `apply`'s deliberate rethrow of non-transport ClickHouse errors, which exists so a schema break surfaces as a loud 500 — at this call site there is nothing to surface into and nothing catching, so it becomes an unhandled rejection. Fixing it means a live generator mutation starts awaiting N reward round-trips it currently does not, and silent failures become 500s: a real behaviour change to a hot path, unrelated to deprecating anything, and its own PR.

Worth knowing for whoever re-enables `generation-feedback`: that call site's failures are invisible.

## What the two rewards are actually doing (ClickHouse, 90 days)

| Type | Rows | Awarded | Blue Buzz | Latest event |
|---|---|---|---|---|
| `firstDailyFollow` | 2,636,232 | 1,952,689 | 19,526,890 | minutes ago |
| `generation-feedback` | 0 | 0 | 0 | none in 90 days |

Two things follow, and neither changes what this PR does.

**`generation-feedback` has not fired once in 90 days.** It is being deprecated as a formality — the gate is what makes that explicit rather than assumed. Why it stopped firing is a separate question; the likeliest candidate is that no patch path reaching `patch` still matches `patch.path.includes('feedback')`, which would mean the call site has been dead code for some time.

**`firstDailyFollow` is very live** — ~29k grants a day, ~217k Blue Buzz a day. Applying this migration is a visible change for a lot of users, so it is worth flipping deliberately rather than incidentally. Surfacing the size, not questioning the decision.

## Findings that survive from the earlier deletion-shaped version of this work

- **The half-deprecation trap.** Removing a reward's barrel export does not stop it granting. `user.controller` imports `firstDailyFollowReward` **direct-from-file**, so the index export was never what gated it. Under config the risk axis moves: it is no longer *how the reward was imported* but *whether the gate covers every door out of `createBuzzEvent`*. #4019 gates all three — `apply` pays, `process` sweeps the backlog, `getUserRewardDetails` advertises — which is why this shape is more robust than the export ever was. Tested rather than assumed.
- **The import asymmetry is per-consumer, not per-reward.** `dailyBoostReward` is direct-imported at `buzz.controller.ts:7` and `blocks.router.ts:20`, and `appBlockReviewReward` at `blocks.router.ts:69`, both while also being barrel-exported. The two rewards here sat on *opposite* sides of it. So the question to ask is "does this consumer go through the barrel", not "was this reward imported properly". Converting those consumers is worth its own PR.
- **Both rewards are `onDemand: true`**, so they write `awarded` or `capped` inline and never the `pending` row that `process` pays. `process`'s disabled-reward sweep is real and tested in #4019, but **neither of these two rewards can exercise it** — a suite built around one of them enters the sweep zero times while looking like it covers it. Asserted here rather than left as a comment, so making one of them processable fails this suite.

## Operational note

Legacy dedup entries keep the pre-#4019 reading until `rewardsDailyReset` clears the hash at 00:00 UTC. That does not affect these two rewards' disable — the gate is upstream of the dedup hash entirely — but it is on the same mechanism and the tracker carries it as a hold on the config deploy.

## Verification

- `pnpm run typecheck` — 0 errors. (Blind to `__tests__`, so the new suite is covered by running it, not by this.)
- `pnpm run lint` — 0 errors on the new file; 9 `no-explicit-any` warnings, consistent with sibling test suites.
- `pnpm run prettier:write` — applied.
- `pnpm run test:unit:run` — full suite green; the new suite is 18 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gYYkESwT1M2dnVX7HjVYV
