### PR TITLE
feat(placement): remix accept reward — 20 Buzz × first 5 accepts a day

### DIFF
--- a/src/server/rewards/__tests__/remixAccept.reward.test.ts
+++ b/src/server/rewards/__tests__/remixAccept.reward.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `base.reward` builds a buzz client, redis handles and prom collectors at import
+// time. Mocked to the surface it touches so this suite can collect; what is under
+// test is the reward's own definition — who is paid, in what currency, keyed on
+// what, and against which cap.
+const h = vi.hoisted(() => ({
+  insert: vi.fn(async () => undefined),
+  createBuzzTransactionMany: vi.fn(async () => undefined),
+  getMultipliersForUser: vi.fn(async () => ({ rewardsMultiplier: 1 })),
+}));
+const { createBuzzTransactionMany, getMultipliersForUser } = h;
+
+vi.mock('~/server/clickhouse/client', () => ({
+  clickhouse: { insert: (...args: unknown[]) => h.insert(...args) },
+}));
+vi.mock('~/server/prom/client', () => ({
+  rewardFailedCounter: { inc: vi.fn() },
+  rewardGivenCounter: { inc: vi.fn() },
+  clickhouseFailSoftCounter: { inc: vi.fn() },
+}));
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransactionMany: h.createBuzzTransactionMany,
+  getMultipliersForUser: h.getMultipliersForUser,
+}));
+
+import { remixAcceptReward } from '~/server/rewards/active/remixAccept.reward';
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+
+/** Distinct, so a value reaching the wrong field cannot pass by colliding. */
+const OWNER = 41;
+const PLACER = 52;
+const PLACEMENT = 96;
+
+const AWARD = 20;
+const DAILY_CAP = 100;
+
+const accept = (over: Partial<Parameters<typeof remixAcceptReward.apply>[0]> = {}) =>
+  remixAcceptReward.apply({
+    placementId: PLACEMENT,
+    ownerId: OWNER,
+    placerId: PLACER,
+    ...over,
+  });
+
+/** The Lua call's ARGV, which is where the award and the cap are actually decided. */
+const lastEvalArgs = () => {
+  const [, options] = redisMock.redis.eval.mock.calls.at(-1) as [unknown, { arguments: string[] }];
+  return options.arguments;
+};
+
+const lastTransaction = () => createBuzzTransactionMany.mock.calls.at(-1)?.[0]?.[0];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: 1 });
+  // What the Lua script returns when the accept is inside the day's cap.
+  redisMock.redis.eval.mockResolvedValue(AWARD);
+});
+
+describe('remixAcceptReward', () => {
+  it('pays the owner in blue buzz, with the submitter recorded as the cause', async () => {
+    await accept();
+
+    expect(lastTransaction()).toMatchObject({
+      toAccountId: OWNER,
+      toAccountType: 'blue',
+      amount: AWARD,
+      details: { forId: PLACEMENT, byUserId: PLACER },
+    });
+  });
+
+  // The ledger key is the double-pay backstop under the caller's once-ever gate,
+  // and it is built from (forId, toUserId, byUserId). Keyed on anything the owner
+  // can produce twice — the host image, the submitted image — a second accept on
+  // the same host would be refused as a duplicate and pay nothing.
+  it('keys the ledger on the placement, not on either image', async () => {
+    await accept();
+
+    expect(lastTransaction()?.externalTransactionId).toBe(
+      `remixAccept:${PLACEMENT}-${OWNER}-${PLACER}`
+    );
+  });
+
+  // 20 × 5 = 100. At a cap equal to the award the first accept of the day would
+  // exhaust it and every later one would pay nothing, which is a different reward
+  // from the one that was designed.
+  it('asks redis for a cap of five accepts a day, not one', async () => {
+    await accept();
+
+    const [, , award, cap] = lastEvalArgs();
+    expect(award).toBe(String(AWARD));
+    expect(cap).toBe(String(DAILY_CAP));
+  });
+
+  // Rewards multiply with membership tier here as everywhere else, and the cap has
+  // to move with the award: multiplying one alone silently changes how many
+  // accepts a member is paid for.
+  it('scales the award and the cap together by the membership multiplier', async () => {
+    getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: 4 });
+    await accept();
+
+    const [, , award, cap] = lastEvalArgs();
+    expect(award).toBe(String(AWARD * 4));
+    expect(cap).toBe(String(DAILY_CAP * 4));
+  });
+
+  // The multiplier is the OWNER's — they are the one being paid. Reading the
+  // submitter's would let a gold-tier submitter mint four times the reward into a
+  // free account, and would pay two owners differently for the same accept.
+  it('reads the multiplier for the owner being paid', async () => {
+    await accept();
+
+    expect(getMultipliersForUser).toHaveBeenCalledWith(OWNER);
+  });
+
+  // Redis returns 0 once the day's cap is spent. The event is still recorded, so
+  // the dashboard can show the cap was reached, but no buzz moves.
+  it('records a capped accept without paying for it', async () => {
+    redisMock.redis.eval.mockResolvedValue(0);
+    await accept();
+
+    expect(h.insert).toHaveBeenCalled();
+    expect(createBuzzTransactionMany).not.toHaveBeenCalled();
+  });
+
+  // -1 is the Lua dedup hit: this placement already paid today. Nothing is
+  // recorded and nothing is paid.
+  it('does nothing for a placement already rewarded today', async () => {
+    redisMock.redis.eval.mockResolvedValue(-1);
+    await accept();
+
+    expect(h.insert).not.toHaveBeenCalled();
+    expect(createBuzzTransactionMany).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/rewards/__tests__/remixAccept.reward.test.ts
+++ b/src/server/rewards/__tests__/remixAccept.reward.test.ts
@@ -1,15 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // What is under test is the reward's own definition — who is paid, in what
-// currency, keyed on what, and against which cap. `base.reward` reaches
-// ClickHouse and the buzz service to do it, so both are spread from the real
-// module with only the two functions this suite observes replaced. Hand-listing
-// their exports instead would break the whole FILE — 0 collected, nothing red —
-// the day either module grows one, and `~/server/prom/client` is already stubbed
-// globally in `src/__tests__/setup.ts`, so it needs nothing here at all.
-import type * as ClickHouseClient from '~/server/clickhouse/client';
-import type * as BuzzService from '~/server/services/buzz.service';
-
+// currency, keyed on what, and against which cap. `base.reward` pulls a live
+// client out of the two modules below, so both are hand-written rather than
+// spread from `importOriginal`: the spread loads the real graph, which is the
+// client construction the mock exists to avoid (1.8s → 15.6s of import here).
+//
+// What makes a hand-written factory safe is `base.reward.mock-surface.test.ts`,
+// which reads `base.reward`'s imports as source and fails if either module's
+// surface grows past what these factories provide. Without that guard this
+// shape breaks the whole FILE — 0 collected, nothing red — the first time it
+// drifts. Change either factory only together with that file's
+// `MOCKED_MODULE_SURFACE`.
+//
+// `~/server/prom/client` needs nothing here: `src/__tests__/setup.ts` already
+// stubs it, and hand-listing three of its ~40 exports narrowed that stub.
 const h = vi.hoisted(() => ({
   insert: vi.fn(async () => undefined),
   createBuzzTransactionMany: vi.fn(async () => undefined),
@@ -17,12 +22,10 @@ const h = vi.hoisted(() => ({
 }));
 const { createBuzzTransactionMany, getMultipliersForUser } = h;
 
-vi.mock('~/server/clickhouse/client', async (importOriginal) => ({
-  ...(await importOriginal<typeof ClickHouseClient>()),
+vi.mock('~/server/clickhouse/client', () => ({
   clickhouse: { insert: (...args: unknown[]) => h.insert(...args) },
 }));
-vi.mock('~/server/services/buzz.service', async (importOriginal) => ({
-  ...(await importOriginal<typeof BuzzService>()),
+vi.mock('~/server/services/buzz.service', () => ({
   createBuzzTransactionMany: h.createBuzzTransactionMany,
   getMultipliersForUser: h.getMultipliersForUser,
 }));

--- a/src/server/rewards/__tests__/remixAccept.reward.test.ts
+++ b/src/server/rewards/__tests__/remixAccept.reward.test.ts
@@ -1,9 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// `base.reward` builds a buzz client, redis handles and prom collectors at import
-// time. Mocked to the surface it touches so this suite can collect; what is under
-// test is the reward's own definition — who is paid, in what currency, keyed on
-// what, and against which cap.
+// What is under test is the reward's own definition — who is paid, in what
+// currency, keyed on what, and against which cap. `base.reward` reaches
+// ClickHouse and the buzz service to do it, so both are spread from the real
+// module with only the two functions this suite observes replaced. Hand-listing
+// their exports instead would break the whole FILE — 0 collected, nothing red —
+// the day either module grows one, and `~/server/prom/client` is already stubbed
+// globally in `src/__tests__/setup.ts`, so it needs nothing here at all.
+import type * as ClickHouseClient from '~/server/clickhouse/client';
+import type * as BuzzService from '~/server/services/buzz.service';
+
 const h = vi.hoisted(() => ({
   insert: vi.fn(async () => undefined),
   createBuzzTransactionMany: vi.fn(async () => undefined),
@@ -11,15 +17,12 @@ const h = vi.hoisted(() => ({
 }));
 const { createBuzzTransactionMany, getMultipliersForUser } = h;
 
-vi.mock('~/server/clickhouse/client', () => ({
+vi.mock('~/server/clickhouse/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof ClickHouseClient>()),
   clickhouse: { insert: (...args: unknown[]) => h.insert(...args) },
 }));
-vi.mock('~/server/prom/client', () => ({
-  rewardFailedCounter: { inc: vi.fn() },
-  rewardGivenCounter: { inc: vi.fn() },
-  clickhouseFailSoftCounter: { inc: vi.fn() },
-}));
-vi.mock('~/server/services/buzz.service', () => ({
+vi.mock('~/server/services/buzz.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof BuzzService>()),
   createBuzzTransactionMany: h.createBuzzTransactionMany,
   getMultipliersForUser: h.getMultipliersForUser,
 }));
@@ -121,6 +124,17 @@ describe('remixAcceptReward', () => {
     await accept();
 
     expect(h.insert).toHaveBeenCalled();
+    expect(createBuzzTransactionMany).not.toHaveBeenCalled();
+  });
+
+  // The Blue Buzz minting path. Refused here rather than left to the submission
+  // path's `space.ownerId === placerId` refusal two layers up: that one is a
+  // product rule about who may submit, and this one is about who may be paid.
+  it('pays nothing for an owner accepting their own submission', async () => {
+    await accept({ placerId: OWNER });
+
+    expect(redisMock.redis.eval).not.toHaveBeenCalled();
+    expect(h.insert).not.toHaveBeenCalled();
     expect(createBuzzTransactionMany).not.toHaveBeenCalled();
   });
 

--- a/src/server/rewards/active/remixAccept.reward.ts
+++ b/src/server/rewards/active/remixAccept.reward.ts
@@ -43,15 +43,24 @@ export const remixAcceptReward = createBuzzEvent({
   awardAmount: ACCEPT_AWARD,
   cap: DAILY_ACCEPT_CEILING,
   onDemand: true,
-  getKey: async (input: RemixAcceptEvent) => ({
-    // The owner earns it; the submitter is recorded as the cause, not paid.
-    toUserId: input.ownerId,
-    // The Redis dedup anchor as well as the ledger's: distinct placements hash to
-    // distinct cache keys and each pays, while the same placement re-presented
-    // within the day is deduped.
-    forId: input.placementId,
-    byUserId: input.placerId,
-  }),
+  getKey: async (input: RemixAcceptEvent) => {
+    // Blue Buzz is minted here, so an owner accepting their own submission must
+    // pay nothing. Unreachable today — `createRemixGallerySubmission` refuses
+    // `space.ownerId === placerId` — but that is two layers away and a product
+    // rule, and this is the layer that makes the money. Kept rather than left to
+    // distance, and symmetrical with the sticker accept reward.
+    if (input.ownerId === input.placerId) return false;
+
+    return {
+      // The owner earns it; the submitter is recorded as the cause, not paid.
+      toUserId: input.ownerId,
+      // The Redis dedup anchor as well as the ledger's: distinct placements hash
+      // to distinct cache keys and each pays, while the same placement
+      // re-presented within the day is deduped.
+      forId: input.placementId,
+      byUserId: input.placerId,
+    };
+  },
 });
 
 type RemixAcceptEvent = {

--- a/src/server/rewards/active/remixAccept.reward.ts
+++ b/src/server/rewards/active/remixAccept.reward.ts
@@ -7,6 +7,11 @@ const ACCEPT_AWARD = 20;
 // this is a total: 20 Buzz for each of the first 5 accepts per UTC day.
 //   ⚠️ At `cap === ACCEPT_AWARD` the first accept of the day would exhaust it and
 //   every later one would award 0, which is not the reward that was designed.
+//   ⚠️ This is 100/day for REMIX accepts, not for accepting placements. The
+//   sticker accept reward carries its own separate 100/day against its own type
+//   key, so a creator running both surfaces can earn 200 in a day — and both
+//   numbers multiply by membership tier and again by any global bonus event.
+//   The two caps matching today is a coincidence, not a shared limit.
 const DAILY_ACCEPT_CEILING = ACCEPT_AWARD * 5;
 
 /**

--- a/src/server/rewards/active/remixAccept.reward.ts
+++ b/src/server/rewards/active/remixAccept.reward.ts
@@ -1,0 +1,61 @@
+import { createBuzzEvent } from '../base.reward';
+
+const ACCEPT_AWARD = 20;
+
+// Daily ceiling across every gallery the owner runs, not a per-submission cap.
+// The on-demand Lua cap counts all entries in the per-(user, type) daily hash, so
+// this is a total: 20 Buzz for each of the first 5 accepts per UTC day.
+//   ⚠️ At `cap === ACCEPT_AWARD` the first accept of the day would exhaust it and
+//   every later one would award 0, which is not the reward that was designed.
+const DAILY_ACCEPT_CEILING = ACCEPT_AWARD * 5;
+
+/**
+ * Blue-buzz reward paid to a creator for accepting a remix submission.
+ *
+ * Paid for **every** accepted submission, free or paid: this rewards running the
+ * surface at all, and is not compensation for a placement having been free.
+ *
+ * ONCE EVER PER PLACEMENT, and the guarantee is not this cap. `settlePlacement`
+ * claims its transition with `WHERE status = 'pending'`, so exactly one call in a
+ * placement's life returns `settled: true`, and the caller fires this only on
+ * that one. Nothing moves an approved row back to pending, so there is no second
+ * winning approve to fire on.
+ *
+ * That gate is load-bearing rather than belt-and-braces, because the two dedups
+ * underneath it expire on different clocks. The Buzz ledger keys this on the
+ * placement — `remixAccept:<placementId>-<ownerId>-<placerId>` — and that key
+ * never expires, while the on-demand dedup and the cap live in a Redis hash that
+ * expires at the end of the UTC day. So re-presenting an already-rewarded
+ * placement on a later day passes the dedup, **spends a slot of the owner's
+ * daily cap**, and is then refused by the ledger as a duplicate: the owner loses
+ * one of their five accepts for the day and no Buzz moves, silently. Any future
+ * caller that can hand this a placement it already paid for has to establish the
+ * same once-ever property before calling.
+ *
+ * The cap multiplies with membership tier, as every reward here does — a gold
+ * member's 100/day is 400/day. Known and accepted.
+ */
+export const remixAcceptReward = createBuzzEvent({
+  type: 'remixAccept',
+  toAccountType: 'blue',
+  description: 'You accepted a remix into your gallery',
+  triggerDescription: 'For each of the first 5 remix submissions you accept each day',
+  awardAmount: ACCEPT_AWARD,
+  cap: DAILY_ACCEPT_CEILING,
+  onDemand: true,
+  getKey: async (input: RemixAcceptEvent) => ({
+    // The owner earns it; the submitter is recorded as the cause, not paid.
+    toUserId: input.ownerId,
+    // The Redis dedup anchor as well as the ledger's: distinct placements hash to
+    // distinct cache keys and each pays, while the same placement re-presented
+    // within the day is deduped.
+    forId: input.placementId,
+    byUserId: input.placerId,
+  }),
+});
+
+type RemixAcceptEvent = {
+  placementId: number;
+  ownerId: number;
+  placerId: number;
+};

--- a/src/server/rewards/index.ts
+++ b/src/server/rewards/index.ts
@@ -13,4 +13,5 @@ export { firstDailyFollowReward } from './active/firstDailyFollow.reward';
 export { dailyBoostReward } from './active/dailyBoost.reward';
 export { generatorFeedbackReward } from './active/generatorFeedback.reward';
 export { stickerPlacementAcceptedReward } from './active/stickerPlacementAccepted.reward';
+export { remixAcceptReward } from './active/remixAccept.reward';
 // export { adWatchedReward } from './active/adWatched.reward';

--- a/src/server/services/__tests__/placement-escrow.service.test.ts
+++ b/src/server/services/__tests__/placement-escrow.service.test.ts
@@ -1989,11 +1989,9 @@ describe('the accept reward', () => {
    * The consolidation is a recorded follow-up and is fine to do — but it must
    * MOVE the remix call, not add one. This test is what tells you which you did.
    *
-   * ⚠️ The remix half is **inert until #4013 lands**: nothing on this branch can
-   * call `remixAcceptReward`, because the module it mocks does not exist here
-   * yet. Verified that this suite still collects all its tests with the mock in
-   * place (Vitest resolves a mocked path lazily), so it is a tripwire armed on
-   * merge rather than coverage you have today.
+   * The remix half was inert while `remixAcceptReward` did not exist on this
+   * branch — a tripwire armed on merge rather than coverage. #4013 landed it, so
+   * both halves are live and the mocked path now resolves to a real module.
    */
   it('grants exactly one reward per surface, and never the other surface reward', async () => {
     givenPlacement({ id: 1, surface: 'sticker' });
@@ -2033,6 +2031,10 @@ describe('the accept reward', () => {
     // nothing" rather than a call that quietly did nothing at all.
     expect(settled).toBe(true);
     expect(applyAcceptReward).not.toHaveBeenCalled();
+    // The reward the comment above is about. Without this the test asserted only
+    // that the STICKER reward stayed out of a remix approval, so the exact edit
+    // it warns against — a `remixGallery` branch here — left it green.
+    expect(applyRemixReward).not.toHaveBeenCalled();
   });
 
   // The approval has already paid the owner out of escrow by this point. A

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -760,6 +760,12 @@ describe('owner actions', () => {
 
     it('pays the owner for the accept, crediting the submitter as the cause', async () => {
       await approve();
+      // The count, not just the arguments. `toHaveBeenCalledWith` alone is
+      // satisfied by a doubled call, and the double-pay this reward has to avoid
+      // is a second `apply` — most plausibly a later refactor that moves the
+      // reward into the shared settle and leaves this call behind. That pays 20
+      // Blue Buzz twice for one accept and the argument assertion sees nothing.
+      expect(rewardApply).toHaveBeenCalledTimes(1);
       expect(rewardApply).toHaveBeenCalledWith({
         placementId: PLACEMENT,
         ownerId: OWNER,

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -43,6 +43,15 @@ vi.mock('~/server/services/placement-escrow.service', () => ({
 const assertCanPlace = vi.fn(async () => undefined);
 vi.mock('~/server/services/placement-moderation.service', () => ({ assertCanPlace }));
 
+// Stubbed rather than spread from the original: the real module loads
+// `base.reward`, which pulls the buzz service and its whole import graph into a
+// suite that mocks the escrow service precisely to keep it out. What the reward
+// itself does with these arguments is its own suite's job.
+const rewardApply = vi.fn(async () => undefined);
+vi.mock('~/server/rewards/active/remixAccept.reward', () => ({
+  remixAcceptReward: { apply: rewardApply },
+}));
+
 const resolvePlacementSpaceFor = vi.fn();
 vi.mock('~/server/services/placement-space.service', () => ({ resolvePlacementSpaceFor }));
 
@@ -671,6 +680,7 @@ describe('owner actions', () => {
   const pending = {
     id: PLACEMENT,
     ownerId: OWNER,
+    placerId: PLACER,
     status: 'pending',
     surface: 'remixGallery',
     data: { imageId: REMIX_IMAGE },
@@ -689,6 +699,11 @@ describe('owner actions', () => {
     await expect(
       actOnRemixGallerySubmission({ placementId: PLACEMENT, action: 'approve', userId: OWNER })
     ).rejects.toThrow(/no longer exists/i);
+    // The remix accept reward is scoped by this refusal and by nothing else. A
+    // sticker approval that reached it would pay the remix reward on top of the
+    // sticker one, which is the shape a bad merge between the two reward changes
+    // would take.
+    expect(rewardApply).not.toHaveBeenCalled();
   });
 
   it('re-checks the submission at approval, because a rating can move', async () => {
@@ -733,6 +748,56 @@ describe('owner actions', () => {
     await expect(
       actOnRemixGallerySubmission({ placementId: PLACEMENT, action: 'decline', userId: OWNER })
     ).rejects.toThrow(/already resolved/i);
+  });
+
+  describe('accept reward', () => {
+    const approve = () =>
+      actOnRemixGallerySubmission({ placementId: PLACEMENT, action: 'approve', userId: OWNER });
+
+    beforeEach(() => {
+      placementFindUnique.mockResolvedValue(pending);
+    });
+
+    it('pays the owner for the accept, crediting the submitter as the cause', async () => {
+      await approve();
+      expect(rewardApply).toHaveBeenCalledWith({
+        placementId: PLACEMENT,
+        ownerId: OWNER,
+        placerId: PLACER,
+      });
+    });
+
+    it('pays nothing for a decline', async () => {
+      await actOnRemixGallerySubmission({
+        placementId: PLACEMENT,
+        action: 'decline',
+        userId: OWNER,
+      });
+      expect(rewardApply).not.toHaveBeenCalled();
+    });
+
+    // The whole double-pay guard. `settlePlacement` claims pending → approved
+    // with `WHERE status = 'pending'`, so exactly one call in a placement's life
+    // returns settled: true, and the reward hangs off that. Move it above this
+    // check and a re-settle re-presents a placement the reward already paid:
+    // the ledger refuses it as a duplicate, no buzz moves, and the owner has
+    // silently lost one of their five accepts for the day.
+    it('pays nothing when the settle claimed nothing', async () => {
+      settlePlacement.mockResolvedValue({ settled: false });
+      await expect(approve()).rejects.toThrow(/already resolved/i);
+      expect(rewardApply).not.toHaveBeenCalled();
+    });
+
+    // The approval already committed and paid out of escrow before this runs, and
+    // it cannot be retried. Reporting it as failed would tell the owner their
+    // accept did not happen when the entry is live in their gallery.
+    it('still reports the approval when the reward fails', async () => {
+      rewardApply.mockRejectedValueOnce(new Error('buzz service down'));
+      await expect(approve()).resolves.toMatchObject({ settled: true });
+      expect(loggingMock.logToAxiom).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringMatching(/reward failed/i) })
+      );
+    });
   });
 
   it('refuses to remove a live entry inside the removal lock', async () => {

--- a/src/server/services/remix-gallery.service.ts
+++ b/src/server/services/remix-gallery.service.ts
@@ -5,6 +5,7 @@ import { ImageSort, NsfwLevel } from '~/server/common/enums';
 import type { SessionUser } from '~/types/session';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
+import { remixAcceptReward } from '~/server/rewards/active/remixAccept.reward';
 import { getAllImages } from '~/server/services/image.service';
 import { holdPlacementEscrow, settlePlacement } from '~/server/services/placement-escrow.service';
 import { assertCanPlace } from '~/server/services/placement-moderation.service';
@@ -451,6 +452,31 @@ export async function actOnRemixGallerySubmission({
   // appeared to work and did not is what this cost us on chunk D.
   if (!result.settled)
     throw throwBadRequestError('remix gallery: that submission was already resolved elsewhere');
+
+  // Fired only from behind that `settled` check, which is the whole double-pay
+  // guard: it is true for exactly one call in a placement's life. Re-presenting a
+  // placement this already paid for would spend a slot of the owner's daily cap
+  // and move no Buzz, silently — see `remixAcceptReward`.
+  //
+  // Swallowed rather than rethrown, unlike the reward's own inline fail-soft: the
+  // settle above already committed and paid out, so a throw here would report a
+  // failure for an approval that happened and cannot be retried.
+  if (action === 'approve')
+    await remixAcceptReward
+      .apply({
+        placementId: placement.id,
+        ownerId: placement.ownerId,
+        placerId: placement.placerId,
+      })
+      .catch((error) =>
+        logToAxiom({
+          name: 'remix-gallery',
+          type: 'error',
+          message: 'accept reward failed; the submission is approved and the owner unpaid',
+          placementId: placement.id,
+          error: error instanceof Error ? error.message : String(error),
+        }).catch(() => undefined)
+      );
 
   return result;
 }


### PR DESCRIPTION
PR 5 of the free placements project. Depends on nothing beyond PR 1, which is already on the base branch.

## What it does

20 Blue Buzz to the **space owner** for each of the first **5** remix submissions they accept per UTC day — a 100/day ceiling, by the same arithmetic as the sticker reward. Paid for **every** accepted submission, free or paid: this rewards running the surface at all, and is not compensation for a placement having been free.

The cap is daily, never monthly, and it multiplies with membership tier exactly as every other reward here does (a gold member's 100/day is 400/day). Both accepted knowingly per the intent doc.

## The double-pay guard

`settlePlacement` claims its transition with `WHERE status = 'pending'`, so exactly one call in a placement's life returns `settled: true`. The reward is fired from behind that flag and from nowhere else, and nothing moves an approved row back to pending — so a placement can be presented to the reward at most once, ever.

That gate is load-bearing rather than belt-and-braces, because the two dedups underneath it expire on different clocks. The Buzz ledger keys this on the placement (`remixAccept:<placementId>-<ownerId>-<placerId>`) and that key never expires; the on-demand dedup and the daily cap live in a Redis hash that expires at end of UTC day. Re-presenting an already-rewarded placement on a later day would pass the dedup, **spend a slot of the owner's daily cap**, and then be refused by the ledger as a duplicate: the owner loses one of their five accepts and no Buzz moves, silently. This is the hazard `firstDailyPost.reward.ts` documents; here it is closed at the call site rather than filtered after the fact.

## Surface scoping

`actOnRemixGallerySubmission` refuses any placement whose `surface` is not `remixGallery` before it does anything, and the reward sits behind that refusal. There is a test asserting a **sticker** placement routed here is refused **and** fires no remix reward — the assertion a bad merge with the sticker reward PR would break.

## Why the call site is the surface service, not the shared settle

Deliberate, and **it does not generalise to stickers**. `auto` mode is refused for remix galleries, so an owner action is the only route a submission has to `approved` — the owner-action path is the whole surface. `createStickerPlacement` is not like that: it settles directly when `space.mode === 'auto'`, so the equivalent sticker reward hung only off the owner-action path would pay nothing for every auto-accepted sticker, which is expected to be the majority path. Flagged to the sticker reward PR.

## Files touched, with anchors

Nothing in `placement-escrow.service.ts`.

- `src/server/rewards/active/remixAccept.reward.ts` — **new**
- `src/server/rewards/__tests__/remixAccept.reward.test.ts` — **new**, 7 tests
- `src/server/rewards/index.ts` — **one line added**, `export { remixAcceptReward } from './active/remixAccept.reward';`, appended after the `generatorFeedbackReward` line
- `src/server/services/remix-gallery.service.ts` — one import after `logToAxiom`, and one block in `actOnRemixGallerySubmission` immediately after the existing `if (!result.settled) throw …`
- `src/server/services/__tests__/remix-gallery.service.test.ts` — a reward mock beside the existing escrow mock, `placerId` added to the `pending` fixture, and 5 tests

## Fail-soft

The reward is awaited and its failure logged, not rethrown. The settle above already committed and paid out of escrow and cannot be retried, so a throw would tell the owner their accept did not happen while the entry is live in their gallery. This is narrower than `base.reward`'s own inline fail-soft, deliberately.

## Decisions recorded

- **A moderator approving on an owner's behalf pays the owner.** Decided, not overlooked. The entry ends up live in the owner's gallery either way, so they got the thing the reward is for. Suppressing it would mean an owner earns differently depending on which staff member resolved their queue, which is both worse and harder to explain.
- **No abstraction shared with the sticker accept reward.** The two are different shapes — 20 × first 5 here, 10 × every accept capped at 100 there — with different call sites, and the only genuine commonality is `createBuzzEvent`, which both already use. The caps agreeing at 100/day today is a coincidence that can change.
- No migration.

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm run lint` — no findings in any touched file (the repo's pre-existing count is unchanged)
- `pnpm run prettier:write`
- `pnpm run test:unit:run` — **17280 passed**, 23 skipped, 1106 files. `blocks.router.workflow.test.ts` collected 348, so the worktree's submodule is intact.

There is **no CI on PRs into `feat/free-placements`** — all three PR workflows filter to `main`/`release`. The above is the only gate.

### Mutation-tested guards

Each break was applied, run, and reverted. All five failed in under 15 ms with a message naming the problem.

| Mutation | Failure |
| --- | --- |
| Reward moved ahead of the `settled` check | `pays nothing when the settle claimed nothing` — *expected "vi.fn()" to not be called at all, but actually been called 1 times* |
| `ownerId` / `placerId` swapped at the call site | `pays the owner for the accept, crediting the submitter as the cause` |
| `action === 'approve'` scoping dropped | `pays nothing for a decline` |
| Surface refusal weakened to `if (!placement)` | `refuses a surface mismatch, so a sticker cannot be actioned here` |
| Cap lowered to one accept | `asks redis for a cap of five accepts a day, not one` — *expected '20' to be '100'* |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Abk9RAouwoYz4qEdnR7Scd
