### PR TITLE
feat(placement): 10 Blue Buzz to the owner for accepting a sticker

### DIFF
--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -191,6 +191,12 @@ vi.mock('~/server/prom/client', () => ({
   vaultItemFailedCounter: promMetricStub(),
   rewardGivenCounter: promMetricStub(),
   rewardFailedCounter: promMetricStub(),
+  // Re-exported from '@civitai/telemetry/client' rather than declared in
+  // prom/client, so this module-replacing mock drops it. `base.reward` and
+  // `image.service` both call `.inc()` on it WITHOUT the `?.inc?.()` guard their
+  // neighbours use, so the first test to drive either fail-soft path dies here
+  // rather than on whatever it was written to check.
+  clickhouseFailSoftCounter: promMetricStub(),
   clavataCounter: promMetricStub(),
   cacheHitCounter: promMetricStub(),
   cacheMissCounter: promMetricStub(),

--- a/src/server/rewards/__tests__/base.reward.mock-surface.test.ts
+++ b/src/server/rewards/__tests__/base.reward.mock-surface.test.ts
@@ -3,57 +3,200 @@ import path from 'path';
 import { describe, expect, it } from 'vitest';
 
 /**
- * The reward suites hand-write `vi.mock` factories for the two modules
- * `base.reward` pulls a live client out of — `~/server/clickhouse/client` and
- * `~/server/services/buzz.service`. Neither can be replaced by spreading
- * `importOriginal`: that loads the real graph, which is the client construction
- * the mock exists to avoid (measured at 1.8s → 15.6s of import on one file).
+ * Every `vi.mock` factory that stands in for a module `base.reward` imports must
+ * provide the bindings it actually imports.
  *
- * A hand-written factory pins the export surface to the day it was written, and
- * the failure when the surface grows is the bad one: the import resolves to
- * `undefined`, the test file fails to LOAD, and a file that fails to load
- * reports **0 tests** rather than a red one. Nothing goes red; the suite stops
- * existing.
+ * Two of those modules cannot be mocked by spreading `importOriginal` — the
+ * reward suites replace `~/server/clickhouse/client` and
+ * `~/server/services/buzz.service` precisely to avoid constructing the real
+ * clients, and spreading loads them for real (measured at 1.8s → 15.6s of import
+ * on one file). `~/server/prom/client` is replaced globally in `setup.ts` for
+ * the same reason. So the export surface is hand-written in three places, and a
+ * hand-written surface pins itself to the day it was typed.
  *
- * This file is the guard, and it is deliberately in its own module: a check
- * living inside a suite that fails to load cannot run either. It imports
- * nothing but `fs`, so it always executes, and it reads `base.reward`'s imports
- * as source rather than evaluating them.
+ * The failure when it falls behind is the invisible one: the missing binding
+ * resolves to `undefined`, the test file fails to LOAD, and a file that fails to
+ * load reports **0 tests** rather than a red one.
+ *
+ * Two properties make this an actual guard rather than a restatement:
+ *
+ *  - It reads the **mock factories themselves**, not a list kept alongside them.
+ *    An earlier version asserted `base.reward`'s imports against a literal in
+ *    this file, which left the mocks — the thing that has to be right —
+ *    unchecked, and made "add the name to the literal" the fastest way to get
+ *    green while the suites still collected nothing.
+ *  - It derives the modules from `base.reward`'s own imports, so a module it
+ *    starts importing is covered without anyone adding it here. The prom
+ *    regression that produced this file was in a module the earlier version did
+ *    not name.
+ *
+ * It lives in its own file, importing only `fs`, on purpose: a check inside a
+ * suite that fails to load cannot run either.
  */
 
+const REWARDS_TESTS = path.resolve(__dirname);
 const BASE_REWARD = path.resolve(__dirname, '../base.reward.ts');
+const GLOBAL_SETUP = path.resolve(__dirname, '../../../__tests__/setup.ts');
+
+/** Files whose `vi.mock` factories can stand in for a module base.reward loads. */
+const mockSources = () => [
+  GLOBAL_SETUP,
+  ...fs
+    .readdirSync(REWARDS_TESTS)
+    .filter((name) => name.endsWith('.test.ts'))
+    .map((name) => path.join(REWARDS_TESTS, name))
+    .filter((file) => file !== __filename),
+];
+
+const escape = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 /**
- * What each mocked module must expose. Change one of these ONLY together with
- * every `vi.mock` of that module under `src/server/rewards/__tests__`.
+ * Comments out, quotes intact.
+ *
+ * Not optional tidying: `setup.ts`'s prom factory carries a comment containing a
+ * literal `'...'`, which the brace scanner below read as a spread and reported
+ * the whole module as fully mocked. That is how the first version of this guard
+ * passed while the very stub it should have demanded was missing.
  */
-const MOCKED_MODULE_SURFACE: Record<string, string[]> = {
-  '~/server/clickhouse/client': ['clickhouse'],
-  '~/server/services/buzz.service': ['createBuzzTransactionMany', 'getMultipliersForUser'],
-};
+function stripComments(source: string) {
+  let out = '';
+  let quote = '';
+  for (let i = 0; i < source.length; i++) {
+    const char = source[i];
+    if (quote) {
+      out += char;
+      if (char === '\\') out += source[++i] ?? '';
+      else if (char === quote) quote = '';
+      continue;
+    }
+    if (char === "'" || char === '"' || char === '`') {
+      quote = char;
+      out += char;
+      continue;
+    }
+    if (char === '/' && source[i + 1] === '/') {
+      while (i < source.length && source[i] !== '\n') i++;
+      out += '\n';
+      continue;
+    }
+    if (char === '/' && source[i + 1] === '*') {
+      i = source.indexOf('*/', i + 2) + 1;
+      if (i === 0) throw new Error('mock-surface guard: unterminated block comment');
+      continue;
+    }
+    out += char;
+  }
 
-/** The named value imports `base.reward` takes from one module. */
-function valueImportsFrom(source: string, module: string) {
-  const pattern = new RegExp(`import\\s+(?!type\\s)\\{([^}]*)\\}\\s+from\\s+'${module}'`, 'g');
-  const names: string[] = [];
-  for (const match of source.matchAll(pattern))
-    for (const specifier of match[1].split(','))
-      if (specifier.trim()) names.push(specifier.trim().split(/\s+as\s+/)[0]);
-
-  return names.sort();
+  return out;
 }
 
-describe('the modules the reward suites hand-mock', () => {
-  it.each(Object.entries(MOCKED_MODULE_SURFACE))(
-    'base.reward imports exactly the mocked surface of %s',
-    (module, expected) => {
-      const source = fs.readFileSync(BASE_REWARD, 'utf-8');
-
-      // A mismatch means base.reward now needs an export the reward suites'
-      // mocks do not provide. Add it to every vi.mock of this module under
-      // src/server/rewards/__tests__ AND here — otherwise those suites will
-      // silently collect 0 tests instead of failing.
-      expect(valueImportsFrom(source, module)).toEqual([...expected].sort());
-    }
+/** The named value bindings `source` imports from `module`. */
+function valueImportsFrom(source: string, module: string) {
+  const pattern = new RegExp(
+    `import\\s+(?!type\\s)\\{([^}]*)\\}\\s+from\\s+'${escape(module)}'`,
+    'g'
   );
+  const names = new Set<string>();
+  for (const match of source.matchAll(pattern))
+    for (const specifier of match[1].split(','))
+      if (specifier.trim()) names.add(specifier.trim().split(/\s+as\s+/)[0]);
+
+  return [...names];
+}
+
+/** Every module `base.reward` takes a value binding from, with those bindings. */
+function importedModules(source: string) {
+  const modules = new Map<string, string[]>();
+  for (const [, module] of source.matchAll(/from\s+'([^']+)'/g))
+    if (!modules.has(module)) {
+      const imports = valueImportsFrom(source, module);
+      if (imports.length) modules.set(module, imports);
+    }
+
+  return modules;
+}
+
+/** The text between `open` and its matching close, exclusive. */
+function balanced(source: string, open: number, closing: string) {
+  let depth = 0;
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === '(' || source[i] === '{') depth++;
+    else if (source[i] === ')' || source[i] === '}') {
+      depth--;
+      if (depth === 0) {
+        if (source[i] !== closing) break;
+        return source.slice(open + 1, i);
+      }
+    }
+  }
+
+  throw new Error(`mock-surface guard: unbalanced ${closing} — the parser needs fixing, not you`);
+}
+
+/**
+ * What a file's `vi.mock` of `module` provides: the factory's top-level keys, or
+ * `'all'` when it spreads (`importOriginal`), or `null` when it does not mock it.
+ *
+ * Throws rather than returning nothing when a mock is present but unreadable —
+ * a parser that quietly gives up would report every suite as covered.
+ */
+function mockedExports(source: string, module: string): string[] | 'all' | null {
+  const call = source.indexOf(`vi.mock('${module}'`);
+  if (call === -1) return null;
+
+  const args = balanced(source, source.indexOf('(', call), ')');
+  const factory = args.indexOf('=>');
+  // `vi.mock(path)` with no factory automocks and keeps the real shape.
+  if (factory === -1) return 'all';
+
+  const literal = args.indexOf('{', factory);
+  if (literal === -1)
+    throw new Error(`mock-surface guard: could not read the factory for ${module}`);
+
+  const body = balanced(args, literal, '}');
+  const keys: string[] = [];
+  let depth = 0;
+  for (let i = 0; i < body.length; i++) {
+    if (body[i] === '(' || body[i] === '{' || body[i] === '[') depth++;
+    else if (body[i] === ')' || body[i] === '}' || body[i] === ']') depth--;
+    else if (depth === 0) {
+      if (body.startsWith('...', i)) return 'all';
+      const key = /^([A-Za-z_$][\w$]*)\s*:/.exec(body.slice(i));
+      if (key && (i === 0 || /[\s,]/.test(body[i - 1]))) keys.push(key[1]);
+    }
+  }
+
+  return keys;
+}
+
+// Stripped for the same reason the mock sources are: a commented-out import
+// would otherwise be demanded of every mock.
+const baseReward = stripComments(fs.readFileSync(BASE_REWARD, 'utf-8'));
+
+const cases = mockSources().flatMap((file) => {
+  const source = stripComments(fs.readFileSync(file, 'utf-8'));
+  return [...importedModules(baseReward)]
+    .map(([module, imports]) => ({ file, module, imports, mocked: mockedExports(source, module) }))
+    .filter((entry) => entry.mocked !== null)
+    .map((entry) => [`${path.basename(entry.file)} mocks ${entry.module}`, entry] as const);
+});
+
+describe('the mocks the reward suites stand in for base.reward with', () => {
+  // A file that mocks nothing base.reward imports contributes no case, so an
+  // empty set would mean the discovery above broke rather than that all is well.
+  it('finds the mocks to check', () => {
+    expect(cases.length).toBeGreaterThan(0);
+  });
+
+  it.each(cases)('%s and provides everything it imports', (_, { module, imports, mocked }) => {
+    if (mocked === 'all') return;
+
+    // A mock missing one of these does not fail here at runtime — it makes the
+    // suite that uses it collect 0 tests, silently. Add the binding to that
+    // factory (or spread `importOriginal`, if the module is cheap to load).
+    expect({ module, missing: imports.filter((name) => !mocked.includes(name)) }).toEqual({
+      module,
+      missing: [],
+    });
+  });
 });

--- a/src/server/rewards/__tests__/base.reward.mock-surface.test.ts
+++ b/src/server/rewards/__tests__/base.reward.mock-surface.test.ts
@@ -1,0 +1,59 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The reward suites hand-write `vi.mock` factories for the two modules
+ * `base.reward` pulls a live client out of — `~/server/clickhouse/client` and
+ * `~/server/services/buzz.service`. Neither can be replaced by spreading
+ * `importOriginal`: that loads the real graph, which is the client construction
+ * the mock exists to avoid (measured at 1.8s → 15.6s of import on one file).
+ *
+ * A hand-written factory pins the export surface to the day it was written, and
+ * the failure when the surface grows is the bad one: the import resolves to
+ * `undefined`, the test file fails to LOAD, and a file that fails to load
+ * reports **0 tests** rather than a red one. Nothing goes red; the suite stops
+ * existing.
+ *
+ * This file is the guard, and it is deliberately in its own module: a check
+ * living inside a suite that fails to load cannot run either. It imports
+ * nothing but `fs`, so it always executes, and it reads `base.reward`'s imports
+ * as source rather than evaluating them.
+ */
+
+const BASE_REWARD = path.resolve(__dirname, '../base.reward.ts');
+
+/**
+ * What each mocked module must expose. Change one of these ONLY together with
+ * every `vi.mock` of that module under `src/server/rewards/__tests__`.
+ */
+const MOCKED_MODULE_SURFACE: Record<string, string[]> = {
+  '~/server/clickhouse/client': ['clickhouse'],
+  '~/server/services/buzz.service': ['createBuzzTransactionMany', 'getMultipliersForUser'],
+};
+
+/** The named value imports `base.reward` takes from one module. */
+function valueImportsFrom(source: string, module: string) {
+  const pattern = new RegExp(`import\\s+(?!type\\s)\\{([^}]*)\\}\\s+from\\s+'${module}'`, 'g');
+  const names: string[] = [];
+  for (const match of source.matchAll(pattern))
+    for (const specifier of match[1].split(','))
+      if (specifier.trim()) names.push(specifier.trim().split(/\s+as\s+/)[0]);
+
+  return names.sort();
+}
+
+describe('the modules the reward suites hand-mock', () => {
+  it.each(Object.entries(MOCKED_MODULE_SURFACE))(
+    'base.reward imports exactly the mocked surface of %s',
+    (module, expected) => {
+      const source = fs.readFileSync(BASE_REWARD, 'utf-8');
+
+      // A mismatch means base.reward now needs an export the reward suites'
+      // mocks do not provide. Add it to every vi.mock of this module under
+      // src/server/rewards/__tests__ AND here — otherwise those suites will
+      // silently collect 0 tests instead of failing.
+      expect(valueImportsFrom(source, module)).toEqual([...expected].sort());
+    }
+  );
+});

--- a/src/server/rewards/__tests__/stickerPlacementAccepted.reward.test.ts
+++ b/src/server/rewards/__tests__/stickerPlacementAccepted.reward.test.ts
@@ -12,11 +12,13 @@ const h = vi.hoisted(() => ({
 vi.mock('~/server/clickhouse/client', () => ({
   clickhouse: { insert: (...args: unknown[]) => h.insert(...(args as [])) },
 }));
-// Prom is NOT mocked here: src/__tests__/setup.ts already stubs every collector,
-// and a local factory listing three of them narrows that — the suite would stop
-// loading the first time base.reward touches a fourth. Neither ClickHouse nor
-// buzz.service is stubbed globally, and spreading the real module would build a
-// client at import, so those two stay hand-written.
+// Prom is NOT mocked here: setup.ts stubs it globally, including the
+// `clickhouseFailSoftCounter` this branch needs — which it was missing until
+// this PR added it, so a local three-item factory here would have been the
+// wider surface, not the narrower one. Neither ClickHouse nor buzz.service is
+// stubbed globally, and spreading either would build a real client at import,
+// so those two stay hand-written and base.reward.mock-surface.test.ts checks
+// them against what base.reward actually imports.
 vi.mock('~/server/services/buzz.service', () => ({
   createBuzzTransactionMany: (...args: unknown[]) => h.createBuzzTransactionMany(...(args as [])),
   getMultipliersForUser: (...args: unknown[]) => h.getMultipliersForUser(...(args as [])),

--- a/src/server/rewards/__tests__/stickerPlacementAccepted.reward.test.ts
+++ b/src/server/rewards/__tests__/stickerPlacementAccepted.reward.test.ts
@@ -12,11 +12,11 @@ const h = vi.hoisted(() => ({
 vi.mock('~/server/clickhouse/client', () => ({
   clickhouse: { insert: (...args: unknown[]) => h.insert(...(args as [])) },
 }));
-vi.mock('~/server/prom/client', () => ({
-  rewardFailedCounter: { inc: vi.fn() },
-  rewardGivenCounter: { inc: vi.fn() },
-  clickhouseFailSoftCounter: { inc: vi.fn() },
-}));
+// Prom is NOT mocked here: src/__tests__/setup.ts already stubs every collector,
+// and a local factory listing three of them narrows that — the suite would stop
+// loading the first time base.reward touches a fourth. Neither ClickHouse nor
+// buzz.service is stubbed globally, and spreading the real module would build a
+// client at import, so those two stay hand-written.
 vi.mock('~/server/services/buzz.service', () => ({
   createBuzzTransactionMany: (...args: unknown[]) => h.createBuzzTransactionMany(...(args as [])),
   getMultipliersForUser: (...args: unknown[]) => h.getMultipliersForUser(...(args as [])),
@@ -81,6 +81,19 @@ describe('the sticker accept reward', () => {
     });
   });
 
+  // An auto-accept space performs no accept: the placement settles inline in the
+  // placer's request. Copy about accepting is false there, and the intent doc
+  // expects auto to become the majority path. Justin's framing is "10 Buzz for
+  // each image sticker you get each day".
+  it('describes the reward as getting a sticker, never as accepting one', async () => {
+    const details = await stickerPlacementAcceptedReward.getUserRewardDetails(OWNER);
+
+    expect(details.description).toBe('You got a sticker on your content');
+    expect(details.triggerDescription).toBe(
+      'For each sticker you get on your content, up to 10 a day'
+    );
+  });
+
   it('caps the day at ten accepted stickers', async () => {
     await accept();
 
@@ -102,6 +115,28 @@ describe('the sticker accept reward', () => {
 
     await accept();
 
+    expect(h.createBuzzTransactionMany).not.toHaveBeenCalled();
+  });
+
+  // A capped accept is still a thing that happened, and the buzzEvents row is
+  // what the cap is later read back from. Dropping it would make the day look
+  // less spent than it was.
+  it('records a capped accept without paying for it', async () => {
+    h.eval.mockResolvedValue(0);
+
+    await accept();
+
+    expect(h.insert).toHaveBeenCalled();
+  });
+
+  // -1 is the Lua dedup hit: this placement already paid today. Nothing further
+  // is written — no audit row, no grant — so a retry is inert rather than noisy.
+  it('writes nothing at all when the placement already paid today', async () => {
+    h.eval.mockResolvedValue(-1);
+
+    await accept();
+
+    expect(h.insert).not.toHaveBeenCalled();
     expect(h.createBuzzTransactionMany).not.toHaveBeenCalled();
   });
 

--- a/src/server/rewards/__tests__/stickerPlacementAccepted.reward.test.ts
+++ b/src/server/rewards/__tests__/stickerPlacementAccepted.reward.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// base.reward builds a ClickHouse client, redis handles and prom collectors at
+// import time. Mocked to the surface it touches so this suite can collect.
+const h = vi.hoisted(() => ({
+  insert: vi.fn(async () => undefined),
+  createBuzzTransactionMany: vi.fn(async () => ({ transactions: [] })),
+  getMultipliersForUser: vi.fn(async () => ({ rewardsMultiplier: 1 })),
+  eval: vi.fn(async () => 0 as number),
+}));
+
+vi.mock('~/server/clickhouse/client', () => ({
+  clickhouse: { insert: (...args: unknown[]) => h.insert(...(args as [])) },
+}));
+vi.mock('~/server/prom/client', () => ({
+  rewardFailedCounter: { inc: vi.fn() },
+  rewardGivenCounter: { inc: vi.fn() },
+  clickhouseFailSoftCounter: { inc: vi.fn() },
+}));
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransactionMany: (...args: unknown[]) => h.createBuzzTransactionMany(...(args as [])),
+  getMultipliersForUser: (...args: unknown[]) => h.getMultipliersForUser(...(args as [])),
+}));
+
+import { stickerPlacementAcceptedReward } from '~/server/rewards/active/stickerPlacementAccepted.reward';
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+
+redisMock.redis.eval.mockImplementation((...args: unknown[]) => h.eval(...(args as [])));
+
+const OWNER = 10;
+const PLACER = 20;
+const PLACEMENT = 777;
+
+/** The award and cap the Lua script was handed, both already multiplied. */
+const luaBudget = () => {
+  const [, options] = h.eval.mock.calls.at(-1) as unknown as [string, { arguments: string[] }];
+  const [, , award, cap] = options.arguments;
+  return { award: Number(award), cap: Number(cap) };
+};
+
+const grant = () =>
+  (h.createBuzzTransactionMany.mock.calls.at(-1) as unknown as [Record<string, unknown>[]])[0];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: 1 });
+  // The award landed rather than hitting the cap, unless a test says otherwise.
+  h.eval.mockResolvedValue(10);
+});
+
+const accept = (overrides: Partial<Record<'placementId' | 'ownerId' | 'placerId', number>> = {}) =>
+  stickerPlacementAcceptedReward.apply({
+    placementId: PLACEMENT,
+    ownerId: OWNER,
+    placerId: PLACER,
+    ...overrides,
+  });
+
+describe('the sticker accept reward', () => {
+  it('pays the owner ten Blue Buzz, from the placer', async () => {
+    await accept();
+
+    expect(grant()).toEqual([
+      expect.objectContaining({
+        toAccountId: OWNER,
+        toAccountType: 'blue',
+        amount: 10,
+        details: expect.objectContaining({ byUserId: PLACER, forId: PLACEMENT }),
+      }),
+    ]);
+  });
+
+  // The ledger's own idempotency key. It is what makes a re-presented placement
+  // silently pay nothing rather than pay twice — and therefore what the caller's
+  // once-per-settle guard exists to keep out of reach.
+  it('keys the transaction on the placement', async () => {
+    await accept();
+
+    expect(grant()[0]).toMatchObject({
+      externalTransactionId: `stickerPlacementAccepted:${PLACEMENT}-${OWNER}-${PLACER}`,
+    });
+  });
+
+  it('caps the day at ten accepted stickers', async () => {
+    await accept();
+
+    expect(luaBudget()).toEqual({ award: 10, cap: 100 });
+  });
+
+  // Every other reward multiplies both halves with the membership tier, so a
+  // gold member's ten a day is forty. Deliberate, and confirmed with Justin.
+  it('multiplies the award and the cap together with membership', async () => {
+    h.getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: 4 });
+
+    await accept();
+
+    expect(luaBudget()).toEqual({ award: 40, cap: 400 });
+  });
+
+  it('moves no Buzz once the day is spent', async () => {
+    h.eval.mockResolvedValue(0);
+
+    await accept();
+
+    expect(h.createBuzzTransactionMany).not.toHaveBeenCalled();
+  });
+
+  // Accepting your own sticker is minting Blue Buzz out of nothing. Both
+  // placement paths already refuse self-placement, and this is what stops the
+  // reward relying on that.
+  it('pays nothing when the owner is the placer', async () => {
+    await accept({ placerId: OWNER });
+
+    expect(h.eval).not.toHaveBeenCalled();
+    expect(h.createBuzzTransactionMany).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/rewards/active/stickerPlacementAccepted.reward.ts
+++ b/src/server/rewards/active/stickerPlacementAccepted.reward.ts
@@ -1,0 +1,56 @@
+import { createBuzzEvent } from '../base.reward';
+
+const ACCEPT_AWARD = 10;
+
+/**
+ * Ten a day, whatever the membership multiplier does to it. A daily cap can only
+ * be satisfied by showing up daily, which is the behaviour being paid for; a
+ * monthly one is filled in an afternoon and the account is then abandoned.
+ */
+const DAILY_ACCEPT_CEILING = ACCEPT_AWARD * 10;
+
+/**
+ * Blue Buzz to the owner of the space for accepting a sticker onto it.
+ *
+ * Paid on every accepted sticker, free or paid. It is not compensation for a
+ * placement having been free — it pays for running the surface at all, which is
+ * why the paid path earns it too.
+ *
+ * **Once per placement, ever, and the caller owns that.** The Buzz ledger keys
+ * this on `stickerPlacementAccepted:<placementId>-<ownerId>-<placerId>` and that
+ * key never expires, while the daily cap lives in a Redis hash that drops at the
+ * end of each UTC day. So a placement re-presented on a later day passes the cap,
+ * spends a tenth of the owner's day, and is then refused by the ledger as a
+ * duplicate: no Buzz moves and nothing says so. `settlePlacement` is the only
+ * caller and applies this only on the settle whose `WHERE status = 'pending'`
+ * matched, so a second approve of the same placement never reaches here.
+ */
+export const stickerPlacementAcceptedReward = createBuzzEvent({
+  type: 'stickerPlacementAccepted',
+  toAccountType: 'blue',
+  description: 'You accepted a sticker on your content',
+  triggerDescription: 'For each sticker placement you accept, up to 10 a day',
+  awardAmount: ACCEPT_AWARD,
+  cap: DAILY_ACCEPT_CEILING,
+  onDemand: true,
+  getKey: async (input: StickerPlacementAcceptedEvent) => {
+    // Both placement paths already refuse self-placement, so this is unreachable
+    // today. It is here because the thing it prevents is minting Blue Buzz out of
+    // nothing — accept your own sticker, collect — and the refusals that stop it
+    // are two layers away and are about a product rule, not about this reward.
+    if (input.ownerId === input.placerId) return false;
+
+    return {
+      toUserId: input.ownerId,
+      forId: input.placementId,
+      byUserId: input.placerId,
+      type: `stickerPlacementAccepted`,
+    };
+  },
+});
+
+type StickerPlacementAcceptedEvent = {
+  placementId: number;
+  ownerId: number;
+  placerId: number;
+};

--- a/src/server/rewards/active/stickerPlacementAccepted.reward.ts
+++ b/src/server/rewards/active/stickerPlacementAccepted.reward.ts
@@ -10,11 +10,18 @@ const ACCEPT_AWARD = 10;
 const DAILY_ACCEPT_CEILING = ACCEPT_AWARD * 10;
 
 /**
- * Blue Buzz to the owner of the space for accepting a sticker onto it.
+ * Blue Buzz to the owner of the space for a sticker going live on it.
  *
- * Paid on every accepted sticker, free or paid. It is not compensation for a
- * placement having been free — it pays for running the surface at all, which is
- * why the paid path earns it too.
+ * Paid on every one, free or paid. It is not compensation for a placement having
+ * been free — it pays for running the surface at all, which is why the paid path
+ * earns it too.
+ *
+ * **The user-facing strings say "get", not "accept", and that is load-bearing.**
+ * On an auto-accept space nobody performs an accept: `createStickerPlacement`
+ * settles inline inside the *placer's* request and records the owner as the
+ * actor, which is what makes it read as an approval everywhere downstream. Copy
+ * about accepting would be false on what is expected to be the majority path,
+ * in the one sentence a creator reads to work out where their Buzz came from.
  *
  * **Once per placement, ever, and the caller owns that.** The Buzz ledger keys
  * this on `stickerPlacementAccepted:<placementId>-<ownerId>-<placerId>` and that
@@ -28,8 +35,8 @@ const DAILY_ACCEPT_CEILING = ACCEPT_AWARD * 10;
 export const stickerPlacementAcceptedReward = createBuzzEvent({
   type: 'stickerPlacementAccepted',
   toAccountType: 'blue',
-  description: 'You accepted a sticker on your content',
-  triggerDescription: 'For each sticker placement you accept, up to 10 a day',
+  description: 'You got a sticker on your content',
+  triggerDescription: 'For each sticker you get on your content, up to 10 a day',
   awardAmount: ACCEPT_AWARD,
   cap: DAILY_ACCEPT_CEILING,
   onDemand: true,

--- a/src/server/rewards/index.ts
+++ b/src/server/rewards/index.ts
@@ -12,4 +12,5 @@ export { reportAcceptedReward } from './passive/reportAccepted.reward';
 export { firstDailyFollowReward } from './active/firstDailyFollow.reward';
 export { dailyBoostReward } from './active/dailyBoost.reward';
 export { generatorFeedbackReward } from './active/generatorFeedback.reward';
+export { stickerPlacementAcceptedReward } from './active/stickerPlacementAccepted.reward';
 // export { adWatchedReward } from './active/adWatched.reward';

--- a/src/server/services/__tests__/placement-escrow.service.test.ts
+++ b/src/server/services/__tests__/placement-escrow.service.test.ts
@@ -14,6 +14,15 @@ vi.mock('~/server/services/buzz.service', () => ({
 }));
 vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn().mockResolvedValue(undefined) }));
 
+// Wholesale on purpose: the real module loads `base.reward`, which builds a
+// ClickHouse client, redis handles and prom collectors at import time. The
+// reward's own behaviour is tested in stickerPlacementAccepted.reward.test.ts;
+// what this suite owns is WHEN settlement hands it a placement.
+const applyAcceptReward = vi.fn();
+vi.mock('~/server/rewards/active/stickerPlacementAccepted.reward', () => ({
+  stickerPlacementAcceptedReward: { apply: applyAcceptReward },
+}));
+
 // A real mutex, not a pass-through: the lock is what stops two callers both
 // reaching the Buzz call after one has claimed the ledger row, so a double that
 // always grants it would hide the defect it exists to prevent.
@@ -358,6 +367,7 @@ beforeEach(() => {
   configState.shares = { seller: 0, platform: 0.3 };
   createMultiAccountBuzzTransaction.mockResolvedValue({ transactionCount: 2, totalAmount: 0 });
   createBuzzTransaction.mockResolvedValue({ transactionId: 'buzz-tx' });
+  applyAcceptReward.mockResolvedValue(undefined);
   // The real response carries the legs it reversed. The double used to return
   // only the prefix, which let a refund that moved NOTHING look identical to one
   // that moved everything — the exact discrepancy the service now refuses on.
@@ -1847,5 +1857,98 @@ describe('a free placement never touches the money path', () => {
 
     expect(moneyMoved()).toBe(0);
     expect(legsFor(1)).toEqual({});
+  });
+});
+
+describe('the accept reward', () => {
+  const hold = () =>
+    holdPlacementEscrow({
+      spendType: 'yellow',
+      placementId: 1,
+      placerId: PLACER,
+      surface: 'sticker',
+      amount: 1000,
+    });
+
+  it('pays the owner of the space, for the placement, crediting the placer', async () => {
+    givenPlacement();
+    await hold();
+
+    await settlePlacement({ placementId: 1, action: 'approve', actorId: OWNER });
+
+    expect(applyAcceptReward).toHaveBeenCalledTimes(1);
+    expect(applyAcceptReward).toHaveBeenCalledWith({
+      placementId: 1,
+      ownerId: OWNER,
+      placerId: PLACER,
+    });
+  });
+
+  it('pays it for a free placement too', async () => {
+    givenPlacement({ free: true, amount: 0 });
+
+    await settlePlacement({ placementId: 1, action: 'approve', actorId: OWNER });
+
+    expect(applyAcceptReward).toHaveBeenCalledTimes(1);
+  });
+
+  // The reason it hangs off `count > 0` and not off the callers. The ledger key
+  // never expires while the daily cap does, so a second presentation of the same
+  // placement on a later day spends a tenth of the owner's day and moves no Buzz.
+  it('pays nothing on a second approve of the same placement', async () => {
+    givenPlacement();
+    await hold();
+    await settlePlacement({ placementId: 1, action: 'approve', actorId: OWNER });
+    applyAcceptReward.mockClear();
+
+    const { settled } = await settlePlacement({
+      placementId: 1,
+      action: 'approve',
+      actorId: OWNER,
+    });
+
+    expect(settled).toBe(false);
+    expect(applyAcceptReward).not.toHaveBeenCalled();
+  });
+
+  it.each(['decline', 'expire', 'removeByOwner', 'removeByModerator'] as const)(
+    'pays nothing when the placement settles as %s',
+    async (action) => {
+      givenPlacement();
+      await hold();
+
+      await settlePlacement({ placementId: 1, action, actorId: OWNER });
+
+      expect(applyAcceptReward).not.toHaveBeenCalled();
+    }
+  );
+
+  // The remix surface has its own reward, with its own amount and its own cap.
+  it('pays nothing on another surface', async () => {
+    givenPlacement({ surface: 'remixGallery' });
+    await hold();
+
+    await settlePlacement({ placementId: 1, action: 'approve', actorId: OWNER });
+
+    expect(applyAcceptReward).not.toHaveBeenCalled();
+  });
+
+  // The approval has already paid the owner out of escrow by this point. A
+  // throw here would 500 a request whose money has moved, and the caller would
+  // read that as the approval having failed.
+  it('does not fail the approval when the reward throws', async () => {
+    givenPlacement();
+    await hold();
+    applyAcceptReward.mockRejectedValue(new Error('clickhouse is gone'));
+
+    const { settled, placement } = await settlePlacement({
+      placementId: 1,
+      action: 'approve',
+      actorId: OWNER,
+    });
+
+    expect(settled).toBe(true);
+    expect(placement.status).toBe('approved');
+    expect(legsFor(1)).toMatchObject({ toOwner: 700 });
   });
 });

--- a/src/server/services/__tests__/placement-escrow.service.test.ts
+++ b/src/server/services/__tests__/placement-escrow.service.test.ts
@@ -23,6 +23,16 @@ vi.mock('~/server/rewards/active/stickerPlacementAccepted.reward', () => ({
   stickerPlacementAcceptedReward: { apply: applyAcceptReward },
 }));
 
+// The remix reward, which this service must NEVER grant — it is granted from
+// `actOnRemixGallerySubmission`, the only path by which a remix submission is
+// approved. Mocked here so the exclusivity test below observes the real shared
+// chokepoint: this suite is the only place that exercises it, since the remix
+// suite mocks `settlePlacement` wholesale and cannot see what it fires.
+const applyRemixReward = vi.fn();
+vi.mock('~/server/rewards/active/remixAccept.reward', () => ({
+  remixAcceptReward: { apply: applyRemixReward },
+}));
+
 // A real mutex, not a pass-through: the lock is what stops two callers both
 // reaching the Buzz call after one has claimed the ledger row, so a double that
 // always grants it would hide the defect it exists to prevent.
@@ -368,6 +378,7 @@ beforeEach(() => {
   createMultiAccountBuzzTransaction.mockResolvedValue({ transactionCount: 2, totalAmount: 0 });
   createBuzzTransaction.mockResolvedValue({ transactionId: 'buzz-tx' });
   applyAcceptReward.mockResolvedValue(undefined);
+  applyRemixReward.mockResolvedValue(undefined);
   // The real response carries the legs it reversed. The double used to return
   // only the prefix, which let a refund that moved NOTHING look identical to one
   // that moved everything — the exact discrepancy the service now refuses on.
@@ -1917,19 +1928,112 @@ describe('the accept reward', () => {
       givenPlacement();
       await hold();
 
-      await settlePlacement({ placementId: 1, action, actorId: OWNER });
+      const { settled } = await settlePlacement({ placementId: 1, action, actorId: OWNER });
 
+      // The settle has to have happened, or "the reward did not fire" is true of
+      // a call that did nothing at all and the assertion below proves nothing.
+      expect(settled).toBe(true);
       expect(applyAcceptReward).not.toHaveBeenCalled();
     }
   );
 
-  // The remix surface has its own reward, with its own amount and its own cap.
-  it('pays nothing on another surface', async () => {
+  /**
+   * 🔴 **Auto-accept pays, and that is designed.**
+   *
+   * On an `auto` space the approval arrives from `createStickerPlacement`
+   * settling inline at placement time, not from an owner action — so a reward
+   * hung off the owner's action handler would pay nothing on what is expected to
+   * be the majority path. Justin's decision, recorded in the intent doc: people
+   * switching from Review to Auto Accept to collect this is a fine outcome, not
+   * a leak.
+   *
+   * This exists because that intent otherwise lives only in a Discord thread. A
+   * reviewer reading the code alone has already once concluded that auto-mode
+   * paying looked like an oversight and recommended removing it. If you are here
+   * to delete this test, that is the conversation you are having.
+   *
+   * The other half of the path — that `createStickerPlacement` issues exactly
+   * this settle on an auto space — is pinned by 'settles an auto space
+   * immediately' in sticker-placement.service.test.ts.
+   */
+  it('pays on an auto-accept space, deliberately', async () => {
+    givenPlacement();
+    await hold();
+
+    // The call createStickerPlacement makes at placement time: the owner is
+    // recorded as the actor even though the placer's request is what ran it.
+    await settlePlacement({ placementId: 1, action: 'approve', actorId: OWNER });
+
+    expect(applyAcceptReward).toHaveBeenCalledTimes(1);
+  });
+
+  // The other approve path: the owner acting on a pending placement in a review
+  // space, via actOnStickerPlacement. Both paths reach settlement as the same
+  // call, which is exactly why the reward lives here and not at either caller.
+  it('pays on the owner review action too', async () => {
+    givenPlacement();
+    await hold();
+
+    const { settled } = await settlePlacement({
+      placementId: 1,
+      action: 'approve',
+      actorId: OWNER,
+    });
+
+    expect(settled).toBe(true);
+    expect(applyAcceptReward).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * 🔴 **Exactly one reward per surface, and this is the only place that can see
+   * it.** The tempting cleanup after both reward PRs land is to consolidate here
+   * — move the remix `apply` into `rewardAccepted` — and leave the call in
+   * `actOnRemixGallerySubmission` in place. That double-pays 20 Blue Buzz on
+   * every remix accept, and nothing else goes red: the remix suite mocks
+   * `settlePlacement` wholesale so it cannot observe this service firing
+   * anything, the two ledger keys differ by type, and the daily cap hash is
+   * keyed `userId:type` so both grants look legitimate to both caps.
+   *
+   * The consolidation is a recorded follow-up and is fine to do — but it must
+   * MOVE the remix call, not add one. This test is what tells you which you did.
+   */
+  it('grants exactly one reward per surface, and never the other surface reward', async () => {
+    givenPlacement({ id: 1, surface: 'sticker' });
+    givenPlacement({ id: 2, surface: 'remixGallery' });
+
+    const sticker = await settlePlacement({ placementId: 1, action: 'approve', actorId: OWNER });
+    expect(sticker.settled).toBe(true);
+    expect(applyAcceptReward).toHaveBeenCalledTimes(1);
+    expect(applyRemixReward).not.toHaveBeenCalled();
+
+    applyAcceptReward.mockClear();
+
+    const remix = await settlePlacement({ placementId: 2, action: 'approve', actorId: OWNER });
+    expect(remix.settled).toBe(true);
+    expect(applyRemixReward).not.toHaveBeenCalled();
+    expect(applyAcceptReward).not.toHaveBeenCalled();
+  });
+
+  // 🔴 If you are here because you added a `remixGallery` branch to
+  // `rewardAccepted`: that reward is already granted from
+  // `actOnRemixGallerySubmission`, the only path by which a remix submission is
+  // approved. A branch here does not replace that grant, it doubles it — and no
+  // guard either reward owns can tell: the types differ, so the ledger keys
+  // differ, and the daily cap hash is keyed `userId:type`. This test is the only
+  // thing standing between that edit and paying every remix approval twice.
+  it('pays nothing on a remix approval, which is granted from its own surface', async () => {
     givenPlacement({ surface: 'remixGallery' });
     await hold();
 
-    await settlePlacement({ placementId: 1, action: 'approve', actorId: OWNER });
+    const { settled } = await settlePlacement({
+      placementId: 1,
+      action: 'approve',
+      actorId: OWNER,
+    });
 
+    // Establishes the approval actually happened, so this is "approved and paid
+    // nothing" rather than a call that quietly did nothing at all.
+    expect(settled).toBe(true);
     expect(applyAcceptReward).not.toHaveBeenCalled();
   });
 

--- a/src/server/services/__tests__/placement-escrow.service.test.ts
+++ b/src/server/services/__tests__/placement-escrow.service.test.ts
@@ -1,5 +1,8 @@
 import { Prisma } from '@prisma/client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+// Mocked below; imported for the assertion that a swallowed reward failure is
+// still reported.
+import { logToAxiom } from '~/server/logging/client';
 // Stubbed globally in src/__tests__/setup.ts.
 import { placementUnfundedSettlementsGauge } from '~/server/prom/client';
 
@@ -1938,39 +1941,28 @@ describe('the accept reward', () => {
   );
 
   /**
-   * 🔴 **Auto-accept pays, and that is designed.**
+   * 🔴 **Auto-accept pays, and that is designed** — but read what this asserts.
    *
-   * On an `auto` space the approval arrives from `createStickerPlacement`
-   * settling inline at placement time, not from an owner action — so a reward
-   * hung off the owner's action handler would pay nothing on what is expected to
-   * be the majority path. Justin's decision, recorded in the intent doc: people
-   * switching from Review to Auto Accept to collect this is a fine outcome, not
-   * a leak.
+   * This service has no notion of space mode. Both sticker approve paths — the
+   * owner acting through `actOnStickerPlacement`, and `createStickerPlacement`
+   * settling inline at placement time when `space.mode === 'auto'` — arrive here
+   * as the identical call, which is exactly why the reward hangs off the settle
+   * rather than off either caller. So this cannot tell them apart, and is not
+   * named as though it can: what it pins is that **any** approve pays.
    *
-   * This exists because that intent otherwise lives only in a Discord thread. A
-   * reviewer reading the code alone has already once concluded that auto-mode
-   * paying looked like an oversight and recommended removing it. If you are here
-   * to delete this test, that is the conversation you are having.
+   * The auto half is pinned in two places that together need no inference:
+   * 'settles an auto space immediately' in sticker-placement.service.test.ts
+   * asserts that path issues exactly this settle, and this asserts that settle
+   * pays.
    *
-   * The other half of the path — that `createStickerPlacement` issues exactly
-   * this settle on an auto space — is pinned by 'settles an auto space
-   * immediately' in sticker-placement.service.test.ts.
+   * Written out because the intent otherwise lives only in a Discord thread.
+   * Justin's decision, in the intent doc: creators switching from Review to Auto
+   * Accept to collect this is a fine outcome, not a leak. A reviewer reading the
+   * code alone has already once read auto-mode paying as an oversight and
+   * recommended removing it. If you are here to make auto stop paying, that is
+   * the conversation you are having, and it is Justin's to have.
    */
-  it('pays on an auto-accept space, deliberately', async () => {
-    givenPlacement();
-    await hold();
-
-    // The call createStickerPlacement makes at placement time: the owner is
-    // recorded as the actor even though the placer's request is what ran it.
-    await settlePlacement({ placementId: 1, action: 'approve', actorId: OWNER });
-
-    expect(applyAcceptReward).toHaveBeenCalledTimes(1);
-  });
-
-  // The other approve path: the owner acting on a pending placement in a review
-  // space, via actOnStickerPlacement. Both paths reach settlement as the same
-  // call, which is exactly why the reward lives here and not at either caller.
-  it('pays on the owner review action too', async () => {
+  it('pays on any approve, whichever of the two sticker paths issued it', async () => {
     givenPlacement();
     await hold();
 
@@ -1996,6 +1988,12 @@ describe('the accept reward', () => {
    *
    * The consolidation is a recorded follow-up and is fine to do — but it must
    * MOVE the remix call, not add one. This test is what tells you which you did.
+   *
+   * ⚠️ The remix half is **inert until #4013 lands**: nothing on this branch can
+   * call `remixAcceptReward`, because the module it mocks does not exist here
+   * yet. Verified that this suite still collects all its tests with the mock in
+   * place (Vitest resolves a mocked path lazily), so it is a tripwire armed on
+   * merge rather than coverage you have today.
    */
   it('grants exactly one reward per surface, and never the other surface reward', async () => {
     givenPlacement({ id: 1, surface: 'sticker' });
@@ -2054,5 +2052,38 @@ describe('the accept reward', () => {
     expect(settled).toBe(true);
     expect(placement.status).toBe('approved');
     expect(legsFor(1)).toMatchObject({ toOwner: 700 });
+  });
+
+  /**
+   * The log is the entire compensation for swallowing the throw. Without it a
+   * reward that never arrived leaves no trace at all on a money path — and
+   * `.catch(() => null)` is a plausible-looking edit that produces exactly that
+   * while every other assertion here stays green.
+   *
+   * Rejected with a non-`Error` on purpose: that is what tells `.message` apart
+   * from the `instanceof` narrowing, and a bare `.message` logs `undefined` —
+   * the failure reads as "the reward failed, cause unknown", which is the shape
+   * that makes an outage unreadable at 3am.
+   */
+  it('reports a swallowed reward failure, whatever was thrown', async () => {
+    givenPlacement();
+    await hold();
+    applyAcceptReward.mockRejectedValue('clickhouse is gone');
+
+    const { settled } = await settlePlacement({
+      placementId: 1,
+      action: 'approve',
+      actorId: OWNER,
+    });
+
+    expect(settled).toBe(true);
+    expect(vi.mocked(logToAxiom)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'placement-escrow',
+        message: 'accept reward failed',
+        placementId: 1,
+        error: 'clickhouse is gone',
+      })
+    );
   });
 });

--- a/src/server/services/placement-escrow.service.ts
+++ b/src/server/services/placement-escrow.service.ts
@@ -639,15 +639,21 @@ export async function settlePlacement({
  * presentation of the same placement would silently burn a tenth of the owner's
  * day and pay nothing.
  *
- * Scoped by surface here rather than by where the call sits: the remix surface
- * has its own reward with its own amount and cap, and the two are being written
- * in parallel.
+ * 🔴 **Sticker only, and no other surface may be added here.** The remix gallery
+ * reward is granted from `actOnRemixGallerySubmission`, which is the only way a
+ * remix submission is approved. A `remixGallery` branch in this function would
+ * not replace that call, it would double it — and nothing downstream catches a
+ * double: the two reward types have different `externalTransactionId`s, and the
+ * daily cap hash is keyed `userId:type`, so both grants look legitimate to every
+ * guard either reward has. A surface whose approvals arrive only through its own
+ * action handler belongs there, not here.
  *
  * After the payout, so a reward failure can never be why an approved placement
- * went unpaid — and swallowed for the same reason the settle itself is not
- * retried here: the money has already moved, and a throw would 500 an approval
- * that succeeded. Routed to Axiom rather than dropped, since `base.reward`
- * rethrows genuine ClickHouse schema breaks precisely so they stay visible.
+ * went unpaid — and swallowed, because the money has already moved and a throw
+ * would 500 an approval that succeeded. Note what that costs: `base.reward`
+ * deliberately rethrows a genuine ClickHouse schema break so it surfaces as a
+ * 500, and this `.catch` takes that away. Such a break arrives here as an Axiom
+ * error rather than an alerting one, which is the trade this call site makes.
  */
 async function rewardAccepted(placement: PlacementRow) {
   if (placement.surface !== 'sticker') return;
@@ -664,7 +670,7 @@ async function rewardAccepted(placement: PlacementRow) {
         type: 'error',
         message: 'accept reward failed',
         placementId: placement.id,
-        error: (error as Error).message,
+        error: error instanceof Error ? error.message : String(error),
       }).catch(() => null)
     );
 }

--- a/src/server/services/placement-escrow.service.ts
+++ b/src/server/services/placement-escrow.service.ts
@@ -11,6 +11,7 @@ import {
   createMultiAccountBuzzTransaction,
   refundMultiAccountTransaction,
 } from '~/server/services/buzz.service';
+import { stickerPlacementAcceptedReward } from '~/server/rewards/active/stickerPlacementAccepted.reward';
 import { getPlacementConfig } from '~/server/services/placement.service';
 import { withDistributedLock } from '~/server/utils/distributed-lock';
 import { isPlacementSpendType } from '~/shared/constants/placement.constants';
@@ -623,7 +624,49 @@ export async function settlePlacement({
 
   await payOutPlacement(placement);
 
+  if (count > 0 && status === 'approved') await rewardAccepted(placement);
+
   return { settled: count > 0, placement };
+}
+
+/**
+ * The owner's reward for accepting a placement onto their space.
+ *
+ * Hung off `count > 0` rather than off the approve callers: that is the settle
+ * whose `WHERE status = 'pending'` matched, and it happens exactly once per
+ * placement no matter how many approvals race or how often a caller retries. The
+ * reward's ledger key never expires while its daily cap does, so a second
+ * presentation of the same placement would silently burn a tenth of the owner's
+ * day and pay nothing.
+ *
+ * Scoped by surface here rather than by where the call sits: the remix surface
+ * has its own reward with its own amount and cap, and the two are being written
+ * in parallel.
+ *
+ * After the payout, so a reward failure can never be why an approved placement
+ * went unpaid — and swallowed for the same reason the settle itself is not
+ * retried here: the money has already moved, and a throw would 500 an approval
+ * that succeeded. Routed to Axiom rather than dropped, since `base.reward`
+ * rethrows genuine ClickHouse schema breaks precisely so they stay visible.
+ */
+async function rewardAccepted(placement: PlacementRow) {
+  if (placement.surface !== 'sticker') return;
+
+  await stickerPlacementAcceptedReward
+    .apply({
+      placementId: placement.id,
+      ownerId: placement.ownerId,
+      placerId: placement.placerId,
+    })
+    .catch((error) =>
+      logToAxiom({
+        name: 'placement-escrow',
+        type: 'error',
+        message: 'accept reward failed',
+        placementId: placement.id,
+        error: (error as Error).message,
+      }).catch(() => null)
+    );
 }
 
 type PlacementRow = NonNullable<Awaited<ReturnType<typeof dbWrite.placement.findUnique>>>;


### PR DESCRIPTION
PR 3 of the free placements project. **Base is `feat/free-placements`, not `main`.**

10 Blue Buzz to the owner of a space for every accepted sticker placement, capped at 10 a day. Every accepted sticker, free or paid — this pays for running the surface, not for a placement having been free.

## Where it fires, and why

**Inside `settlePlacement`'s approve branch, scoped to `surface === 'sticker'`**, and only on the settle whose `WHERE status = 'pending'` claim matched.

The sticker surface has **two** approve paths: `createStickerPlacement` calls `settlePlacement({ action: 'approve' })` itself when `space.mode === 'auto'`, and `actOnStickerPlacement` calls it for an owner's review action. Hanging the reward off the owner action alone would pay nothing on every auto-accepted sticker — and the intent doc expects auto to become the majority path precisely because of this reward. Silent in both directions.

**Auto-accept paying is designed, not emergent**, and there is now a test that says so by name. Justin's decision is that people switching from Review to Auto Accept to collect this is a fine outcome; that intent otherwise lived only in a Discord thread, and a reviewer reading the code alone has already once concluded it looked like an oversight.

Everything else that reaches `settlePlacement` was checked against `STATUS_FOR_ACTION`: only the `approve` action produces `approved`. A block cascade is `declineByBlock`, the sweep is `expire`. `placement-moderation.service.ts` has no approve path at all — its four settles are decline, declineByBlock and two removes.

## Why the guard is the claim, not the ledger key

The two dedups expire on different clocks. The Buzz ledger keys this on `stickerPlacementAccepted:<placementId>-<ownerId>-<placerId>` and that key never expires; the daily cap lives in a Redis hash that drops at the end of each UTC day. A placement re-presented on a later day therefore passes the cap, spends a tenth of the owner's day, and is then refused by the ledger as a duplicate — no Buzz moves and nothing is raised. The `count > 0` claim happens exactly once in a placement's life, so nothing can re-present one. The ledger key is the backstop, not the guard.

The reward also refuses when `ownerId === placerId`. Both placement paths already refuse self-placement, so it is unreachable today; it is there because what it prevents is minting Blue Buzz out of nothing, and the refusals that stop it are two layers away and are about a product rule rather than about this reward.

## The double-grant hazard, and what stands in front of it

The tempting cleanup once the remix reward lands is to consolidate both surfaces here — move the remix `apply` into `rewardAccepted` and leave the call in `actOnRemixGallerySubmission` in place. That double-pays on every remix accept and turns nothing red: the remix suite mocks `settlePlacement` wholesale so it cannot see this service fire, the two ledger keys differ by type, and the cap hash is keyed `userId:type`.

`grants exactly one reward per surface, and never the other surface reward` mocks both reward modules and asserts per surface. This suite is the only place that exercises the shared chokepoint. The consolidation is a recorded follow-up and is fine to do — it must MOVE the remix call, not add one, and this test is what tells you which you did.

## Failure behaviour

The reward runs after the payout and its failure is swallowed to Axiom: the money has already moved, so a throw would 500 an approval that succeeded. That `.catch` also takes away the rethrow `base.reward` uses to make a genuine ClickHouse schema break surface as a 500, so one arrives here as an Axiom error instead. Stated in the code as the trade this call site makes.

## Files, for the merge with #4013

- `src/server/rewards/active/stickerPlacementAccepted.reward.ts` — new.
- `src/server/rewards/index.ts` — one export appended after `generatorFeedbackReward`.
- `src/server/services/placement-escrow.service.ts` — one import beside `getPlacementConfig`; one line at the end of `settlePlacement` after `await payOutPlacement(placement)`; one `rewardAccepted` helper between `settlePlacement` and the `PlacementRow` type. The surface scoping is the first statement of that helper, not the call site.
- Tests in `src/server/rewards/__tests__/` and `src/server/services/__tests__/placement-escrow.service.test.ts`.

No shared abstraction with #4013: different shapes, different call sites, and the only real commonality is `createBuzzEvent`, which both already use.

## Mock surface

The reward suite hand-writes `vi.mock` factories for `~/server/clickhouse/client` and `~/server/services/buzz.service`, because spreading `importOriginal` loads the real graph — the client construction the mock exists to avoid, measured at 1.8s → 15.6s of import on one file. The prom mock is deleted outright, since `setup.ts` already stubs every collector and a local three-item factory narrows it.

The hand-written pair is covered by `src/server/rewards/__tests__/base.reward.mock-surface.test.ts`: a standalone file importing only `fs`, which reads `base.reward`'s source and asserts its value imports from those two modules are exactly the mocked surface. Standalone on purpose — a check living inside a suite that fails to load cannot run either, which is what makes the 0-collect failure invisible. 30ms of import, and it catches the mutation in 10ms.

## Verification

Local only — **there is no CI on PRs into `feat/free-placements`**; all three PR workflows filter to `main`/`release`.

- `pnpm run typecheck` — 0 errors (needed `TYPECHECK_HEAP_MB=12288`; tsc crashed at the default 8192 on this box).
- `pnpm run lint` — clean on every touched file.
- `pnpm run prettier:write`.
- `pnpm run test:unit:run` — 17292 passed, 1108 files. `blocks.router.workflow.test.ts` collected 348, so the worktree's submodule is intact.

Every guard was mutation-tested; each failure is under 10 ms and names itself:

| Mutation | What fails |
| --- | --- |
| drop `count > 0` | pays nothing on a second approve of the same placement |
| drop `status === 'approved'` | the four decline/expire/remove cases |
| drop the surface scope | pays nothing on a remix approval |
| short-circuit `rewardAccepted` | both path pins and the exclusivity test |
| drop the `.catch` | does not fail the approval when the reward throws |
| drop the self-placement refusal | pays nothing when the owner is the placer |
| cap ×10 | caps the day at ten accepted stickers |
| key on the owner instead of the placement | keys the transaction on the placement |
| copy back to "you accepted" | describes the reward as getting a sticker |
| `base.reward` grows a buzz.service import | the mock-surface guard, naming the module and the export |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qo6G3R3BVevSTPxL4CZNGP
