### PR TITLE
feat(moderation): three alphabetised columns in the mod nav

### DIFF
--- a/src/components/Moderation/ModerationNav.tsx
+++ b/src/components/Moderation/ModerationNav.tsx
@@ -117,8 +117,14 @@ export function ModerationNav() {
         },
       ]
         .filter((i) => !i.hidden)
+        .sort((a, b) => a.label.localeCompare(b.label))
         .map((link) => (
-          <Menu.Item key={link.href} component={Link} href={link.href}>
+          <Menu.Item
+            key={link.href}
+            component={Link}
+            href={link.href}
+            className="break-inside-avoid"
+          >
             {link.label}
           </Menu.Item>
         )),
@@ -133,7 +139,7 @@ export function ModerationNav() {
         </LegacyActionIcon>
       </Menu.Target>
       <Menu.Dropdown
-        className="overflow-y-auto"
+        className="max-w-[calc(100vw-2rem)] columns-1 overflow-y-auto sm:columns-2 md:columns-3"
         style={{ maxHeight: 'calc(100dvh - 80px)' }}
       >
         {menuItems}


### PR DESCRIPTION
The moderator dropdown had grown to ~30 entries in a single insertion-ordered column — it scrolled, and nothing was where you would look for it.

- **Sorted by label** with `localeCompare`, applied **after** the `hidden` filter so a flagged-off entry cannot influence the layout.
- **Three columns** via CSS multi-column on the dropdown, so alphabetical runs read **down** each column rather than across.
- **Still data-driven**: adding an entry to the array remains the only step — no column assignment, no manual index.

Responsive (this repo maps Tailwind `sm` to 768px and `md` to 1024px): 1 column below 768, 2 from 768, 3 from 1024. Verified in-browser at 1440 / 900 / 800 / 700 / 600.

Note: the `w-*` classes tried first were dead — Mantine sets `width: max-content` inline on the dropdown, which wins, so the columns size themselves to their content.

Verification: `pnpm run typecheck` clean, `eslint` clean on the changed file, `prettier:write` applied, and the dropdown was rendered and screenshotted at each width above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHitGmaWdshHjg8QYXzs3s