### PR TITLE
fix(review): demote the delivery rule, record that it did not work

### DIFF
--- a/.claude/agents/civitai-test-review.md
+++ b/.claude/agents/civitai-test-review.md
@@ -65,6 +65,46 @@ is still yours to catch.
 - A mutation-shaped test with no **negative control** — nothing proving the setup alone didn't already
   produce the asserted state.
 
+### Asserting the shape of the mock instead of the shape of the thing 🔴
+
+A test can observe something entirely real and still assert something that cannot separate the failure.
+This is a vacuous fixture in a different costume, and it is harder to see because the test *looks* like
+it is reaching into the implementation.
+
+The worked example: a test checking a raw SQL statement built its subject as
+`executeRaw.mock.calls.map(([strings]) => strings.join('?'))` — reassembling the tagged template
+**including a placeholder** — then asserted the result contained `SET LOCAL lock_timeout`. The statement
+was invalid *because* Postgres has no parameter form for `SET`, so the one thing that made it broken was
+the one thing the test reconstructed. It passed on precisely the broken form, and the feature's entire
+claim path threw on every call.
+
+Ask what the artifact under assertion actually is. A reassembled template, a mock's `.calls` shape, an
+argument count — these describe the harness. The emitted statement, the persisted row, the computed
+value describe the code. Assert the second.
+
+⚠️ Related: when a loose assertion is tightened, check it was **added to** rather than **replaced**. The
+fix for the example above asserted the literal and the absence of `$1`, and silently dropped the original
+`SET LOCAL lock_timeout` check — so `SET lock_timeout` without `LOCAL`, which leaks a timeout onto every
+later statement borrowing that pooled backend, passed the tightened test.
+
+### Mocking the layer where the thing under test actually happens 🔴
+
+A suite that `vi.mock`s the module where the behaviour lives cannot observe that behaviour, however good
+its assertions are. The test is then evidence about the caller only, and reads as evidence about the
+whole path.
+
+This bites hardest across a merge. Two PRs written in parallel each hooked the same event, one from
+inside a shared service and one from a caller *above* that service — a caller whose suite mocked the
+shared service wholesale. Each suite was sound in its own tree. But the obvious post-merge tidy-up
+(consolidate the two hooks, forget to delete one) would have fired the event twice on every occurrence
+and **turned not one test red**, because the suite that could have seen it had mocked the layer away.
+
+So: for each behaviour, name the layer it happens at, then check whether the suite asserting it has that
+layer mocked. Where a shared chokepoint exists, the test proving mutual exclusivity belongs in the suite
+that runs the real chokepoint — not in either caller's suite. And an assertion of the form
+`toHaveBeenCalledWith(...)` with no `toHaveBeenCalledTimes(1)` beside it does not catch a doubled call
+even from the layer it *can* see.
+
 ### Mocks that are too broad
 
 **Prefer `importOriginal` over hand-listed `vi.mock` exports.** A `vi.mock` listing exports by hand

--- a/.claude/skills/civitai-review/SKILL.md
+++ b/.claude/skills/civitai-review/SKILL.md
@@ -28,7 +28,10 @@ the normal case here, not the exception, so expect this rather than treating it 
 failure is upstream of anything this file can say — by the time you could read a workaround here, you
 would already have found the file.
 
-Bring them in from `main` before spawning anything:
+**Skip this step when the head under review is based on `main`** — the agents are already in the tree and
+the checkout is a no-op. This step is for integration-branch work only.
+
+Otherwise, bring them in from `main` before spawning anything:
 
 ```bash
 git checkout origin/main -- .claude
@@ -37,6 +40,17 @@ git checkout origin/main -- .claude
 The tree is detached and throwaway, so a dirty `.claude` in it costs nothing and can never reach a PR.
 Do not install the agents into `~/.claude/` instead: that is a second copy free to drift from the
 repo's, and the repo's is the authoritative one.
+
+⚠️ **That checkout STAGES the files, so the next `git checkout --detach` aborts** with local changes that
+would be overwritten — which is how you find out, halfway through moving the tree to the next review.
+Unstage and remove them first:
+
+```bash
+git reset -q
+rm -rf .claude/agents/civitai-*.md .claude/skills/civitai-review
+git checkout --detach <next-sha>
+git checkout origin/main -- .claude    # re-apply, if the new head predates the skill
+```
 
 ## 1. Scope the segment
 
@@ -106,25 +120,37 @@ Skip a lane only when the diff genuinely cannot contain its findings — no serv
 reason to skip perf. "No tests changed" is *a finding for the test lane*, not a reason to skip it. Say
 which you skipped and why.
 
-### Tell every lane how to deliver, and never read silence as a clean lane
+### Lanes routinely go idle without delivering. Chasing them is YOUR job, and it is the only control.
 
-🔴 **Each lane's prompt must say how its findings get back to you** — that its final message text *is*
-the return value, or, for an agent whose own transcript reaches nobody, that it must send the report
-explicitly. A lane that finishes with its report only in its transcript has delivered nothing, and it
-has no way to know that.
+🔴 **This is normal, not exceptional. Expect it every round.** Measured across one project's four review
+rounds: **6 of 13 lanes finished, went idle, and sent nothing.** In the worst round it was 4 of 4. Every
+one reported in full when re-pinged — re-pinging worked **8 times out of 8**.
 
-🔴 **A lane that goes idle without reporting has failed. Re-ping it.** Do not record it as a clean lane.
-This is the one failure this skill's own format actively hides: step 3 asks you to say plainly when a
-lane found nothing, which makes a lost lane and a clean lane read identically — and the consolidated
-report then looks complete while missing a fifth of the review. It has happened on a real run, and the
-lane that vanished held the sharpest finding of the round. **Account for all five by name before you
-consolidate**, and treat "idle" as a question, not an answer.
+🔴 **Account for every lane by name before you consolidate, and chase every silent one.** Not "should".
+A lane that goes idle without reporting has *failed*, and it is indistinguishable from a lane that found
+nothing — which is the one failure this skill's own format actively hides, since step 3 asks you to say
+plainly when a lane found nothing. The consolidated report then reads as complete while missing a fifth
+of the review. On the run that discovered this, the vanished lane held the sharpest finding of the round.
 
-The same obligation is written into each of the five agent definitions, where it does not depend on the
-invoker remembering to pass it. Both are kept: they fail independently, and the redundancy costs a
-paragraph. ⚠️ **Do not read "I caught the silent lanes" as evidence the system works.** A run where
-someone already knew about this failure and watched for it proves nothing about the run where nobody
-does — which is every run after the one that discovered it.
+Tell each lane in its prompt how its findings get back to you — final message text, or an explicit send
+for an agent whose own transcript reaches nobody. **Treat that as a hint that reduces the rate, not as a
+control that removes your obligation.**
+
+⚠️ **The agent-definition version of this rule was tried and did not work.** #4011 wrote the same
+obligation into all five agent definitions, where it would not depend on the invoker remembering.
+Measured before and after: **2 of 4 lanes silent before, 4 of 4 after.** The text is still in the agent
+files and is kept, because it costs a paragraph and may help at the margin — but it does not solve this,
+and the numbers are recorded here so nobody re-derives that fix and believes it worked.
+
+Stated plainly because the mechanism is the problem, not the wording: **prose in a definition cannot make
+delivery happen.** Do not spend effort making it work harder. A structural enforcement — something in the
+harness that requires a report before an agent can finish — would be the real fix, and it is not
+something a markdown file can do. **That is the open problem; this manual chase is the control until it
+is solved.** A known-manual control beats a fixed-looking automatic one.
+
+⚠️ And do not read "I caught the silent lanes" as evidence the system works. A run where someone already
+knew about this failure and watched for it proves nothing about the run where nobody does — which is
+every run after the one that discovered it.
 
 ## 3. Consolidate
 


### PR DESCRIPTION
Follow-up to #4010 and #4011, from the third and fourth rounds of using this review set.

## 1. The delivery rule is demoted, and #4011's failure is recorded rather than dropped

#4011 moved the lane-delivery obligation into all five agent definitions, on the theory that prose in the definition would not depend on the invoker remembering. **That was tested and it did not hold.**

| | lanes silent | of |
| --- | --- | --- |
| before #4011 | 2 | 4 |
| after #4011 | 4 | 4 |

Across four review rounds: **6 of 13 lanes finished, went idle and sent nothing.** Every one delivered in full when re-pinged — **re-pinging recovered 8 of 8**.

So the skill now says plainly that this is normal and expected, that the invoker **must** account for every lane by name and chase every silent one, and that the agent-definition text is a hint which reduces the rate rather than a control which removes the obligation. The text stays in the agent files; it costs a paragraph and may help at the margin.

The numbers are written down deliberately. A tooling doc that records a failed fix is more useful than one that quietly drops it — otherwise the next person re-derives "write the rule down harder", which is a mechanism this repo's own guidance is sceptical of elsewhere.

The open problem is stated rather than papered over: only harness-level enforcement — something that requires a report before an agent can finish — can actually fix this, and that is not something a markdown file can do. A known-manual control beats a fixed-looking automatic one.

## 2. Step 0's two warts, both found by hitting them

- `git checkout origin/main -- .claude` **stages** those files, so the next `git checkout --detach` aborts with local changes that would be overwritten — which you discover halfway through moving the tree to the next review. The unstage-and-remove sequence is now written out.
- The whole step is a **no-op when the head under review is based on `main`**, since the agents are already there. The text stated the condition correctly but read as unconditional, so it would get run needlessly.

## 3. Two related traps for the test agent

**Asserting the shape of the mock instead of the shape of the thing.** A test can observe something entirely real and still assert something that cannot separate the failure — a vacuous fixture in a different costume, harder to spot because the test *looks* like it reaches into the implementation. The worked example is a SQL assertion that reassembled a tagged template *including its placeholder* and then asserted a prefix, so the one thing that made the statement invalid was the one thing the test reconstructed. With a note that tightening a loose assertion must **add to** it rather than replace it — the fix for that example dropped the original check and let a differently-broken statement through.

**Mocking the layer where the behaviour actually happens.** A suite that mocks the module where the thing under test lives is evidence about the caller only, while reading as evidence about the whole path. It goes wrong across a merge, where two independently-sound suites can both miss a consolidated regression. Includes the rule that a mutual-exclusivity test belongs in the suite running the real chokepoint, not in either caller's suite, and that `toHaveBeenCalledWith` without `toHaveBeenCalledTimes(1)` does not catch a doubled call even at the layer it can see.

## Notes

Documentation only — no code, no tests, no schema. Both examples are stated structurally, without naming the services or the in-flight PRs they came from, since this repo is public and permanent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LcbNChPWpDvFBGGRGq9i5w
