### PR TITLE
feat(remix-gallery): free submissions for server-verified remixes

### DIFF
--- a/src/components/RemixGallery/RemixGalleryManageModal.tsx
+++ b/src/components/RemixGallery/RemixGalleryManageModal.tsx
@@ -465,6 +465,17 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
                               and marking those would turn a missing signal into a
                               verdict. */}
                           {row.data.derivedFromHost && <VerifiedRemixBadge />}
+                          {/* What this row IS, since the buttons no longer carry
+                              a number for it. Without this the queue shows a
+                              free submission as a paid one with its earnings
+                              missing, which reads as a bug rather than as a
+                              different kind of offer — and the notification that
+                              brought the owner here already called it free. */}
+                          {row.free && (
+                            <Badge size="sm" variant="light" color="green" className="w-fit">
+                              Free submission
+                            </Badge>
+                          )}
                         </Stack>
                       </Group>
                       {/* Stacked, and the same width, so the pair reads as one
@@ -509,7 +520,15 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
                             fullWidth
                             classNames={{ label: 'w-full justify-between gap-2' }}
                             leftSection={<IconCheck size={14} />}
-                            rightSection={<EarningsChip amount={row.earnings.approve} />}
+                            // Nothing on a free row rather than a chip reading
+                            // "+0". `EarningsChip`'s `+` is what stops a bare
+                            // amount reading as a price; on a free submission it
+                            // makes the opposite false claim instead — that the
+                            // creator earns nothing for accepting. The badge
+                            // beside the submitter says what this row is.
+                            rightSection={
+                              row.earnings ? <EarningsChip amount={row.earnings.approve} /> : null
+                            }
                             loading={actingOn(row.id, 'approve')}
                             onClick={() => act.mutate({ placementId: row.id, action: 'approve' })}
                           >
@@ -522,7 +541,12 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
                           variant="default"
                           classNames={{ label: 'w-full justify-between gap-2' }}
                           leftSection={<IconX size={14} />}
-                          rightSection={<EarningsChip amount={row.earnings.decline} />}
+                          // Same reason, and sharper here: a decline fee is the
+                          // submitter's money moving to the owner, and a free
+                          // submission has none to move.
+                          rightSection={
+                            row.earnings ? <EarningsChip amount={row.earnings.decline} /> : null
+                          }
                           loading={actingOn(row.id, 'decline')}
                           onClick={() => act.mutate({ placementId: row.id, action: 'decline' })}
                         >

--- a/src/components/RemixGallery/RemixGalleryManageModal.tsx
+++ b/src/components/RemixGallery/RemixGalleryManageModal.tsx
@@ -482,10 +482,13 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
                         decision with two answers rather than a row of buttons.
                         Keyed to the row and the action — bare `act.isPending`
                         spun every button in the queue on any one click. */}
-                      {/* Each answer carries what it pays, so the owner never has
-                          to know that declining still earns a fee — the numbers
-                          come from the server, computed with the settlement's own
-                          helpers against this row's amount. */}
+                      {/* A PAID row's answers each carry what they pay, so the
+                          owner never has to know that declining still earns a
+                          fee — the numbers come from the server, computed with
+                          the settlement's own helpers against this row's amount.
+                          A free row carries neither, because nothing was paid in
+                          and there is no fee to earn: `earnings` is null there
+                          and the badge above says what the row is instead. */}
                       <Stack gap={6} className="w-36 shrink-0">
                         {/* Approving is the one answer that needs the picture.
                             Declining does not — it is a refusal, and a rating is

--- a/src/components/RemixGallery/RemixGalleryManageModal.tsx
+++ b/src/components/RemixGallery/RemixGalleryManageModal.tsx
@@ -348,9 +348,9 @@ export function RemixGalleryManageModal({ imageId }: { imageId: number }) {
                                 children: (
                                   <Text size="sm">
                                     Every pending submission rated above{' '}
-                                    {getBrowsingLevelLabel(acceptedMaxLevel)} is declined. Each one
-                                    keeps you the decline fee and returns the rest to its submitter.
-                                    This can&apos;t be undone.
+                                    {getBrowsingLevelLabel(acceptedMaxLevel)} is declined. Paid ones
+                                    keep you the decline fee and return the rest to their submitter;
+                                    free ones move no Buzz either way. This can&apos;t be undone.
                                   </Text>
                                 ),
                                 labels: { confirm: 'Decline them', cancel: 'Cancel' },

--- a/src/components/RemixGallery/RemixGallerySubmitModal.browser.test.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.browser.test.tsx
@@ -324,10 +324,30 @@ describe('a gallery that takes free submissions and refuses paid ones', () => {
    * the "lost the race for the last slot" behaviour the feature is built around.
    * That is broader than the `paidOpen` half this block used to name.
    *
-   * The stale-choice rule therefore lives **nowhere**: reaching it needs a real
-   * query cache, and that fixture would grow its own bugs for one line. Said
-   * plainly rather than left to look covered.
+   * Scope, because the previous version of this block got it wrong in both
+   * directions: the stale-choice rule IS pinned as a pure function in
+   * `remix-gallery.utils.test.ts` ("never resolves to free once free stops being
+   * available"). What lives nowhere is the **wired** rule — that rule firing
+   * through a real query cache — and reaching it needs a fixture that would grow
+   * its own bugs for one line. Said plainly rather than left to look covered,
+   * and scoped so a reader who greps does not stop believing the rest of it.
    */
+});
+
+describe('a gallery with neither path open', () => {
+  test('says why, rather than showing a dead control with no explanation', async () => {
+    // The state r5's `takesFree` change exists to serve: no free capacity and no
+    // usable price. The card falls through to paid-disabled — and the sentence
+    // explaining it has to render from OUTSIDE the free/paid block, which is
+    // hidden exactly here.
+    mocks.visibility = { ...mocks.visibility, price: null, freeSlots: 0, freeSlotsRemaining: 0 };
+    await openAndPick();
+
+    await expect.element(page.getByText(/doesn't take free submissions/i)).toBeInTheDocument();
+    await expect
+      .element(page.getByRole('button', { name: /submit for free/i }))
+      .not.toBeInTheDocument();
+  });
 });
 
 describe('the decline-fee note', () => {

--- a/src/components/RemixGallery/RemixGallerySubmitModal.browser.test.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.browser.test.tsx
@@ -42,6 +42,12 @@ const mocks = vi.hoisted(() => ({
    *  unmounting the button mid-click and hanging to the 15s ceiling. */
   nextVisibility: null as Record<string, unknown> | null,
   eligibility: {} as Record<string, unknown>,
+  /**
+   * What a FRESH eligibility read returns, mirroring `nextVisibility`. Set it to
+   * make the cached and fresh answers disagree, which is the only way a test can
+   * tell a real re-read from a cache hit on this half.
+   */
+  nextEligibility: null as Record<string, unknown> | null,
   /** When set, the mutation refuses with this message. */
   refuseWith: '' as string,
 }));
@@ -55,11 +61,31 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
     useUtils: () => ({
       placement: {
         invalidate: vi.fn(),
+        /**
+         * 🔴 The fake honours `staleTime`, and that is the point rather than
+         * fidelity for its own sake.
+         *
+         * A fake that is fresh by construction cannot express the failure this
+         * handler exists to avoid. The client's global default is
+         * `staleTime: Infinity` and `fetchQuery` applies it, so a `.fetch()`
+         * without options resolves the CACHE — here, whatever the render is
+         * already showing — and never calls the procedure. Modelled by returning
+         * `mocks.visibility` in that case and the fresh value only when the call
+         * asks for it.
+         *
+         * Six review rounds passed over the missing option because the previous
+         * fake returned fresh data either way. This is the one line that makes
+         * every test below able to fail for the real reason.
+         */
         getRemixGalleryVisibility: {
-          fetch: async () => mocks.nextVisibility ?? mocks.visibility,
+          fetch: async (_input: unknown, opts?: { staleTime?: number }) =>
+            opts?.staleTime === 0 ? mocks.nextVisibility ?? mocks.visibility : mocks.visibility,
           invalidate: vi.fn(),
         },
-        getRemixGalleryFreeEligibility: { fetch: async () => mocks.eligibility },
+        getRemixGalleryFreeEligibility: {
+          fetch: async (_input: unknown, opts?: { staleTime?: number }) =>
+            opts?.staleTime === 0 ? mocks.nextEligibility ?? mocks.eligibility : mocks.eligibility,
+        },
       },
     }),
     placement: {
@@ -156,6 +182,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   freeIsOffered();
   mocks.nextVisibility = null;
+  mocks.nextEligibility = null;
   mocks.refuseWith = '';
 });
 
@@ -233,11 +260,6 @@ describe('a refused free submission', () => {
 
 describe('a gallery that takes free submissions and refuses paid ones', () => {
   /**
-   * 🔴 The fixture the rest of this file could not provide, and the reason both
-   * of the previous round's fixes were invisible: every other case here prices
-   * the gallery at 700 against a floor of 50, so `paidOpen` is always true and
-   * the two conditions it separates are identical.
-   *
    * The service holds free submissions to none of the price rules — there are
    * tests asserting an unpriced and a below-floor gallery accept free and refuse
    * paid — so this is a supported configuration, not an edge case.
@@ -286,6 +308,47 @@ describe('a gallery that takes free submissions and refuses paid ones', () => {
     await expect.element(page.getByText(/not taking paid submissions/i)).toBeInTheDocument();
     await expect.element(page.getByText(/still submit with Buzz/i)).not.toBeInTheDocument();
     await expect.element(page.getByTestId('buzz-submit')).not.toBeInTheDocument();
+  });
+
+  test('builds the EXPLANATION from the fresh price, not just the outcome', async () => {
+    // 🔴 The last unpinned argument on this axis. Only rung 1 (`!verified`)
+    // branches on `paidOpen`, and reaching it in the explanation needs the fresh
+    // read to disagree with the render on BOTH halves at once: verified when the
+    // button was pressed, unverified a moment later, on a gallery whose price
+    // was cleared in the same window. The eligibility fake could not express its
+    // half until this round, which is why reverting this argument stayed green.
+    mocks.nextVisibility = { ...mocks.visibility, price: null };
+    mocks.nextEligibility = { ...mocks.eligibility, verifiedImageIds: [] };
+    mocks.refuseWith = 'remix gallery: free submissions are for remixes made from this image';
+    await openAndPick();
+    await page.getByRole('button', { name: /submit for free/i }).click();
+
+    await expect.element(page.getByText(/where we can check/i)).toBeInTheDocument();
+    // The half the argument decides: paid is closed on the FRESH read, so the
+    // sentence must not offer it.
+    await expect
+      .element(page.getByText(/can still be submitted with Buzz/i))
+      .not.toBeInTheDocument();
+    await expect.element(page.getByText(/not taking paid submissions/i)).toBeInTheDocument();
+  });
+
+  test('reads the ALLOWANCE half fresh too, not just the price', async () => {
+    // 🔴 The eligibility fetch has its own `staleTime: 0`, and until this test
+    // the fake could not tell whether it was there: `useQuery` and `fetch`
+    // returned the same object, so cached and fresh never disagreed on this
+    // half. That is the layer the six review rounds could not see.
+    //
+    // Render says the gallery is unused, so the free button is pressable. The
+    // fresh read says it has been used — which is what the server just refused
+    // on, and what the banner has to say.
+    mocks.nextEligibility = { ...mocks.eligibility, usedHere: true };
+    mocks.refuseWith = 'remix gallery: you have already used a free placement here';
+    await openAndPick();
+    await page.getByRole('button', { name: /submit for free/i }).click();
+
+    await expect.element(page.getByText(/once per gallery/i)).toBeInTheDocument();
+    // Never the server's own wording — that is the branch a cache hit falls to.
+    expect(mocks.showError).not.toHaveBeenCalled();
   });
 
   test('moves the control to paid when paid IS open', async () => {
@@ -342,6 +405,13 @@ describe('a gallery that takes free submissions and refuses paid ones', () => {
    * its own bugs for one line. Said plainly rather than left to look covered,
    * and scoped so a reader who greps does not stop believing the rest of it.
    *
+   * ✅ What it CAN now express, since it could not before and six review rounds
+   * passed over a dead subsystem because of it: **cache-hit staleness on both
+   * halves.** `fetch` returns the cached value unless the call passes
+   * `staleTime: 0`, which is what the client's `staleTime: Infinity` default
+   * actually does — so dropping that option from either `.fetch` now fails here
+   * instead of quietly resolving whatever the render already had.
+   *
    * The same limitation makes the `!freeRefusal` term of the reason's gate
    * unpinnable here, and I checked rather than assumed: dropping it leaves all
    * of these green. The two messages can only collide when a refusal lands
@@ -383,6 +453,11 @@ describe('a gallery with neither path open', () => {
     await expect
       .element(page.getByRole('button', { name: /submit for free/i }))
       .not.toBeInTheDocument();
+    // Mounted, and unusable. `remix-gallery.utils.ts` leans on exactly this —
+    // "either not mounted at all, or mounted disabled when the card falls
+    // through to paid" — and nothing was reading the attribute, so dropping
+    // `|| !paidOpen` from the button left every test green.
+    await expect.element(page.getByTestId('buzz-submit')).toBeDisabled();
   });
 });
 

--- a/src/components/RemixGallery/RemixGallerySubmitModal.browser.test.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.browser.test.tsx
@@ -267,6 +267,19 @@ describe('a gallery that takes free submissions and refuses paid ones', () => {
     expect(mocks.showError).not.toHaveBeenCalled();
   });
 
+  test('moves the control to paid when paid IS open', async () => {
+    // `setChosen('paid')` was asserted by nothing in either file — the other
+    // cases here all read the banner, which `setFreeRefusal` sets independently.
+    // The docstring argues that moving the control asserts money was the
+    // problem; this is that argument reaching the DOM.
+    mocks.nextVisibility = { ...mocks.visibility, freeSlotsRemaining: 0 };
+    mocks.refuseWith = 'remix gallery: the free slots on this one are taken';
+    await openAndPick();
+    await page.getByRole('button', { name: /submit for free/i }).click();
+
+    await expect.element(page.getByTestId('buzz-submit')).toBeInTheDocument();
+  });
+
   test('offers no paid submit button at all', async () => {
     paidClosed(null);
     await openAndPick();
@@ -278,20 +291,42 @@ describe('a gallery that takes free submissions and refuses paid ones', () => {
       .toBeInTheDocument();
   });
 
+  test('holds on free rather than offering a paid button that cannot work', async () => {
+    // 🔴 A STATIC fixture, no click and no refusal: free is unavailable from
+    // first paint (`usedHere`) and paid is closed (`price: null`), which is
+    // `submissionMethod(null, false, false, true)`.
+    //
+    // With the rule, that resolves to free — a plain Button. Without it, to
+    // paid, and the `BuzzTransactionButton` stub mounts its testid. So this
+    // reaches the rule with no cache write-through at all, which is what the
+    // previous version of this comment wrongly said was impossible.
+    mocks.visibility = { ...mocks.visibility, price: null };
+    mocks.eligibility = { ...mocks.eligibility, usedHere: true };
+    await openAndPick();
+
+    await expect.element(page.getByTestId('buzz-submit')).not.toBeInTheDocument();
+    // And the reason renders beside the disabled control, which is the whole
+    // justification for holding there: three dead buttons and no explanation is
+    // worse than the paid button this replaced.
+    await expect.element(page.getByText(/once per gallery/i)).toBeInTheDocument();
+    // Not a claim about spending, on a path that cannot be pressed.
+    await expect.element(page.getByText(/spends a free placement/i)).not.toBeInTheDocument();
+  });
+
   /**
-   * ⚠️ What this file does NOT pin, stated so the pair above is not over-read.
+   * ⚠️ What this file does NOT pin, stated so nothing above is over-read.
    *
-   * `submissionMethod`'s `paidOpen` rule — the one that stops the control
-   * FALLING into paid when free stops being available — is not reachable from
-   * here. In production the handler's `.fetch()` writes the query cache, so
-   * `freeAvailable` drops and the rule fires; this file's `useQuery` mock is
-   * static and does not model that write-through, so `freeAvailable` never
-   * drops and both branches return the same answer.
+   * The mock's `useQuery` returns `mocks.visibility` and only `fetch` reads
+   * `mocks.nextVisibility`, so **nothing here can observe any state keyed on
+   * `freeAvailable` becoming false after a render** — not the free segment's
+   * disabled state, not `freeUnavailableReason` arriving late, not
+   * `slotsHeldKnown`, and not `submissionMethod`'s stale-choice rule, which is
+   * the "lost the race for the last slot" behaviour the feature is built around.
+   * That is broader than the `paidOpen` half this block used to name.
    *
-   * Measured, not assumed: deleting `if (!paidOpen) return 'free'` leaves all
-   * nine tests here green and fails three in `remix-gallery.utils.test.ts`.
-   * That rule is the unit file's to hold, and a faithful cache-writing mock is
-   * the only thing that would move it here.
+   * The stale-choice rule therefore lives **nowhere**: reaching it needs a real
+   * query cache, and that fixture would grow its own bugs for one line. Said
+   * plainly rather than left to look covered.
    */
 });
 

--- a/src/components/RemixGallery/RemixGallerySubmitModal.browser.test.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.browser.test.tsx
@@ -36,6 +36,11 @@ const mocks = vi.hoisted(() => ({
   submit: vi.fn(),
   showError: vi.fn(),
   visibility: {} as Record<string, unknown>,
+  /** What the post-refusal re-read returns. Separate from the query's answer on
+   *  purpose: reassigning one object between render and click had the same fake
+   *  backing both, which holds today and is one added effect away from
+   *  unmounting the button mid-click and hanging to the 15s ceiling. */
+  nextVisibility: null as Record<string, unknown> | null,
   eligibility: {} as Record<string, unknown>,
   /** When set, the mutation refuses with this message. */
   refuseWith: '' as string,
@@ -51,7 +56,7 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
       placement: {
         invalidate: vi.fn(),
         getRemixGalleryVisibility: {
-          fetch: async () => mocks.visibility,
+          fetch: async () => mocks.nextVisibility ?? mocks.visibility,
           invalidate: vi.fn(),
         },
         getRemixGalleryFreeEligibility: { fetch: async () => mocks.eligibility },
@@ -150,6 +155,7 @@ const freeIsOffered = () => {
 beforeEach(() => {
   vi.clearAllMocks();
   freeIsOffered();
+  mocks.nextVisibility = null;
   mocks.refuseWith = '';
 });
 
@@ -207,9 +213,10 @@ describe('a refused free submission', () => {
 
   test('explains a capacity refusal inline instead, with no error toast', async () => {
     mocks.refuseWith = 'remix gallery: the free slots on this one are taken';
+    // The re-read the handler makes after the refusal says the slots went; the
+    // query's own answer is untouched, so nothing re-renders mid-click.
+    mocks.nextVisibility = { ...mocks.visibility, freeSlotsRemaining: 0 };
     await openAndPick();
-    // The re-read the handler makes after the refusal now says the slots went.
-    mocks.visibility = { ...mocks.visibility, freeSlotsRemaining: 0 };
 
     await page.getByRole('button', { name: /submit for free/i }).click();
 
@@ -221,6 +228,71 @@ describe('a refused free submission', () => {
       .element(page.getByText(/free slots on this one are taken/i))
       .not.toBeInTheDocument();
   });
+});
+
+describe('a gallery that takes free submissions and refuses paid ones', () => {
+  /**
+   * 🔴 The fixture the rest of this file could not provide, and the reason both
+   * of the previous round's fixes were invisible: every other case here prices
+   * the gallery at 700 against a floor of 50, so `paidOpen` is always true and
+   * the two conditions it separates are identical.
+   *
+   * The service holds free submissions to none of the price rules — there are
+   * tests asserting an unpriced and a below-floor gallery accept free and refuse
+   * paid — so this is a supported configuration, not an edge case.
+   */
+  const paidClosed = (price: number | null) => {
+    mocks.visibility = { ...mocks.visibility, price };
+    mocks.nextVisibility = { ...mocks.visibility, price, freeSlotsRemaining: 0 };
+    mocks.refuseWith = 'remix gallery: the free slots on this one are taken';
+  };
+
+  test.each([
+    ['unpriced', null],
+    ['priced below the floor', 10],
+  ])('does not offer Buzz as the alternative — %s', async (_label, price) => {
+    paidClosed(price);
+    await openAndPick();
+    await page.getByRole('button', { name: /submit for free/i }).click();
+
+    // Says the true thing rather than pointing at a button that is disabled
+    // (unpriced) or that leads into a second refusal and a buy-Buzz prompt
+    // (below the floor).
+    await expect.element(page.getByText(/not taking paid submissions/i)).toBeInTheDocument();
+    await expect.element(page.getByText(/still submit with Buzz/i)).not.toBeInTheDocument();
+
+    // An explained refusal, so it stays inline — this is the assertion that dies
+    // if the banner goes back to being keyed on `fallBackToPaid`, which is false
+    // here while the refusal is still perfectly explainable.
+    expect(mocks.showError).not.toHaveBeenCalled();
+  });
+
+  test('offers no paid submit button at all', async () => {
+    paidClosed(null);
+    await openAndPick();
+    await page.getByRole('button', { name: /submit for free/i }).click();
+
+    await expect.element(page.getByTestId('buzz-submit')).not.toBeInTheDocument();
+    await expect
+      .element(page.getByRole('button', { name: /submit for free/i }))
+      .toBeInTheDocument();
+  });
+
+  /**
+   * ⚠️ What this file does NOT pin, stated so the pair above is not over-read.
+   *
+   * `submissionMethod`'s `paidOpen` rule — the one that stops the control
+   * FALLING into paid when free stops being available — is not reachable from
+   * here. In production the handler's `.fetch()` writes the query cache, so
+   * `freeAvailable` drops and the rule fires; this file's `useQuery` mock is
+   * static and does not model that write-through, so `freeAvailable` never
+   * drops and both branches return the same answer.
+   *
+   * Measured, not assumed: deleting `if (!paidOpen) return 'free'` leaves all
+   * nine tests here green and fails three in `remix-gallery.utils.test.ts`.
+   * That rule is the unit file's to hold, and a faithful cache-writing mock is
+   * the only thing that would move it here.
+   */
 });
 
 describe('the decline-fee note', () => {

--- a/src/components/RemixGallery/RemixGallerySubmitModal.browser.test.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.browser.test.tsx
@@ -1,0 +1,241 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import type * as TrpcModule from '~/utils/trpc';
+
+/**
+ * The three branches of the submit card that decide what somebody is CHARGED or
+ * TOLD, and that no other layer can see.
+ *
+ * The card's policy lives in pure functions with their own unit tests — the
+ * refusal ladder, whether a refusal is explainable, whether recommending Buzz is
+ * honest. This file covers only the wiring between those answers and the DOM,
+ * because each branch below is a single token whose inversion is silent
+ * everywhere else:
+ *
+ * 1. The submit button. Inverted, a submission the user chose to make FREE goes
+ *    through `BuzzTransactionButton` carrying `expectedPrice` — a spend the user
+ *    did not consent to, with nothing red at any layer.
+ * 2. The unexplained-refusal notification. Inverted, the server's own refusal
+ *    reaches nobody: a blocked or suspended submitter presses Submit and sees
+ *    NOTHING. That is exactly the behaviour the refusal split removed.
+ * 3. The decline-fee note. Shown on a free submission it describes escrow that
+ *    never existed — "the creator keeps N Buzz and the rest comes back" about
+ *    money nobody paid.
+ *
+ * `toHaveBeenCalledTimes(1)` sits beside every `toHaveBeenCalledWith`, so a
+ * doubled submit cannot pass as a correct one.
+ */
+
+const HOST = 74;
+const MINE = 85;
+const PRICE = 700;
+
+const mocks = vi.hoisted(() => ({
+  submit: vi.fn(),
+  showError: vi.fn(),
+  visibility: {} as Record<string, unknown>,
+  eligibility: {} as Record<string, unknown>,
+  /** When set, the mutation refuses with this message. */
+  refuseWith: '' as string,
+}));
+
+// The real module spread first, so a new export does not silently become
+// `undefined` for every importer in this test's graph — which fails the whole
+// file to load and collects zero tests without one failing assertion.
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcModule>()),
+  trpc: {
+    useUtils: () => ({
+      placement: {
+        invalidate: vi.fn(),
+        getRemixGalleryVisibility: {
+          fetch: async () => mocks.visibility,
+          invalidate: vi.fn(),
+        },
+        getRemixGalleryFreeEligibility: { fetch: async () => mocks.eligibility },
+      },
+    }),
+    placement: {
+      getRemixGalleryVisibility: { useQuery: () => ({ data: mocks.visibility, isError: false }) },
+      getRemixGalleryFreeEligibility: { useQuery: () => ({ data: mocks.eligibility }) },
+      submitToRemixGallery: {
+        // Drives the real `onError` rather than exposing it, so the branch under
+        // test is reached the way the mutation reaches it.
+        useMutation: (opts: { onError: (e: { message: string }) => void | Promise<void> }) => ({
+          mutate: (input: unknown) => {
+            mocks.submit(input);
+            if (mocks.refuseWith) return opts.onError({ message: mocks.refuseWith });
+          },
+          isPending: false,
+        }),
+      },
+    },
+  },
+}));
+
+vi.mock('~/utils/notifications', () => ({
+  showErrorNotification: (args: unknown) => mocks.showError(args),
+  showSuccessNotification: vi.fn(),
+}));
+
+vi.mock('~/components/Dialog/DialogProvider', () => ({
+  useDialogContext: () => ({ opened: true, onClose: vi.fn() }),
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => ({ id: 52 }) }));
+vi.mock('~/components/Buzz/useAvailableBuzz', () => ({ useAvailableBuzz: () => ['yellow'] }));
+
+vi.mock('~/components/Image/image.utils', () => ({
+  useQueryImages: () => ({
+    images: [{ id: MINE, nsfwLevel: 1, url: 'x', width: 1, height: 1, type: 'image' }],
+    isLoading: false,
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isRefetching: false,
+  }),
+}));
+
+// Stubbed to a plain button so the test drives the real branch rather than
+// Mantine's internals — and so a Buzz submit is distinguishable from a free one
+// by which testid appears at all.
+vi.mock('~/components/Buzz/BuzzTransactionButton', () => ({
+  BuzzTransactionButton: ({
+    label,
+    onPerformTransaction,
+    disabled,
+  }: {
+    label: string;
+    onPerformTransaction: () => void;
+    disabled?: boolean;
+  }) => (
+    <button data-testid="buzz-submit" disabled={disabled} onClick={onPerformTransaction}>
+      {label}
+    </button>
+  ),
+}));
+
+vi.mock('~/components/CardTemplates/AspectRatioImageCard', () => ({
+  AspectRatioImageCard: ({ image, onClick }: { image: { id: number }; onClick: () => void }) => (
+    <button data-testid={`pick-${image.id}`} onClick={onClick}>
+      pick
+    </button>
+  ),
+}));
+vi.mock('~/components/InView/InViewLoader', () => ({ InViewLoader: () => null }));
+
+const { RemixGallerySubmitModal } = await import('./RemixGallerySubmitModal');
+
+/** Everything set so the free option is genuinely on offer. */
+const freeIsOffered = () => {
+  mocks.visibility = {
+    open: true,
+    price: PRICE,
+    declineFee: 210,
+    freeSlots: 2,
+    freeSlotsRemaining: 1,
+    maxSubmissionLevel: 32,
+    ownerId: 41,
+    viewerPending: [],
+    pendingCount: 0,
+  };
+  mocks.eligibility = {
+    verifiedImageIds: [MINE],
+    usedHere: false,
+    allowance: { used: 0, remaining: 1, resetsAt: new Date('2026-03-04') },
+  };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  freeIsOffered();
+  mocks.refuseWith = '';
+});
+
+const openAndPick = async () => {
+  renderWithProviders(<RemixGallerySubmitModal hostImageId={HOST} />);
+  await page.getByTestId(`pick-${MINE}`).click();
+};
+
+describe('the submit button', () => {
+  test('a free submission never goes through the Buzz path', async () => {
+    // 🔴 The spend-without-consent branch. Inverted, this sends `expectedPrice`
+    // through `onPerformTransaction` for a submission the user chose to make
+    // free, and nothing at any other layer notices.
+    await openAndPick();
+    await page.getByRole('button', { name: /submit for free/i }).click();
+
+    expect(mocks.submit).toHaveBeenCalledTimes(1);
+    expect(mocks.submit).toHaveBeenCalledWith({ hostImageId: HOST, imageId: MINE, free: true });
+    // The payload carries no price, and the Buzz button is not even mounted.
+    expect(mocks.submit.mock.calls[0][0]).not.toHaveProperty('expectedPrice');
+    await expect.element(page.getByTestId('buzz-submit')).not.toBeInTheDocument();
+  });
+
+  test('the paid submission still carries the price it was shown', async () => {
+    await openAndPick();
+    await page.getByRole('radio', { name: new RegExp(`${PRICE} Buzz`) }).click();
+    await page.getByTestId('buzz-submit').click();
+
+    expect(mocks.submit).toHaveBeenCalledTimes(1);
+    expect(mocks.submit).toHaveBeenCalledWith({
+      hostImageId: HOST,
+      imageId: MINE,
+      expectedPrice: PRICE,
+    });
+  });
+});
+
+describe('a refused free submission', () => {
+  const SERVER_PROSE =
+    'remix gallery: free submissions are for remixes made from this image on-site';
+
+  test('surfaces the server’s own refusal when a re-read cannot explain it', async () => {
+    // 🔴 Invert the guard and this reaches nobody: a blocked or suspended
+    // submitter presses Submit and sees NOTHING at all. The re-read below still
+    // reports free as available, so the refusal was not about capacity.
+    mocks.refuseWith = SERVER_PROSE;
+    await openAndPick();
+    await page.getByRole('button', { name: /submit for free/i }).click();
+
+    await vi.waitFor(() => expect(mocks.showError).toHaveBeenCalledTimes(1));
+    expect(mocks.showError).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.objectContaining({ message: SERVER_PROSE }) })
+    );
+  });
+
+  test('explains a capacity refusal inline instead, with no error toast', async () => {
+    mocks.refuseWith = 'remix gallery: the free slots on this one are taken';
+    await openAndPick();
+    // The re-read the handler makes after the refusal now says the slots went.
+    mocks.visibility = { ...mocks.visibility, freeSlotsRemaining: 0 };
+
+    await page.getByRole('button', { name: /submit for free/i }).click();
+
+    await expect.element(page.getByText(/all taken right now/i)).toBeInTheDocument();
+    // An ordinary outcome with a next step, not an error.
+    expect(mocks.showError).not.toHaveBeenCalled();
+    // And never the server's raw wording.
+    await expect
+      .element(page.getByText(/free slots on this one are taken/i))
+      .not.toBeInTheDocument();
+  });
+});
+
+describe('the decline-fee note', () => {
+  test('is not shown while the free option is selected', async () => {
+    // It describes escrow. A free submission puts none up, so this would tell a
+    // submitter the creator keeps Buzz they never paid.
+    await openAndPick();
+
+    await expect.element(page.getByText(/creator keeps/i)).not.toBeInTheDocument();
+  });
+
+  test('is shown on the paid option, where it is true', async () => {
+    await openAndPick();
+    await page.getByRole('radio', { name: new RegExp(`${PRICE} Buzz`) }).click();
+
+    await expect.element(page.getByText(/creator keeps 210 Buzz/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/RemixGallery/RemixGallerySubmitModal.browser.test.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.browser.test.tsx
@@ -268,6 +268,26 @@ describe('a gallery that takes free submissions and refuses paid ones', () => {
     expect(mocks.showError).not.toHaveBeenCalled();
   });
 
+  test('decides the alternative from the FRESH price, not the rendered one', async () => {
+    // 🔴 The only case where fresh and stale disagree, and the suite had none:
+    // every other fixture gives `nextVisibility` the same price as `visibility`.
+    //
+    // Not a millisecond race either. `getRemixGalleryVisibility.useQuery` passes
+    // no options, so it inherits `staleTime: Infinity` with no refetch on focus
+    // — a modal left open across a price change holds the render value for the
+    // whole session. An owner clearing their price mid-submission is the case.
+    mocks.nextVisibility = { ...mocks.visibility, price: null, freeSlotsRemaining: 0 };
+    mocks.refuseWith = 'remix gallery: the free slots on this one are taken';
+    await openAndPick();
+    await page.getByRole('button', { name: /submit for free/i }).click();
+
+    // Decided off the fresh price: paid is closed now, so the banner must not
+    // point at Buzz and the control must not move there.
+    await expect.element(page.getByText(/not taking paid submissions/i)).toBeInTheDocument();
+    await expect.element(page.getByText(/still submit with Buzz/i)).not.toBeInTheDocument();
+    await expect.element(page.getByTestId('buzz-submit')).not.toBeInTheDocument();
+  });
+
   test('moves the control to paid when paid IS open', async () => {
     // `setChosen('paid')` was asserted by nothing in either file — the other
     // cases here all read the banner, which `setFreeRefusal` sets independently.
@@ -279,6 +299,28 @@ describe('a gallery that takes free submissions and refuses paid ones', () => {
     await page.getByRole('button', { name: /submit for free/i }).click();
 
     await expect.element(page.getByTestId('buzz-submit')).toBeInTheDocument();
+  });
+
+  test('holds on free rather than offering a paid button that cannot work', async () => {
+    // 🔴 A STATIC fixture, no click and no refusal: free is unavailable from
+    // first paint (`usedHere`) and paid is closed (`price: null`), which is
+    // `submissionMethod(null, false, false, true)`.
+    //
+    // With the rule, that resolves to free — a plain Button. Without it, to
+    // paid, and the `BuzzTransactionButton` stub mounts its testid. So this
+    // reaches the rule with no cache write-through at all, which is what the
+    // previous version of this comment wrongly said was impossible.
+    mocks.visibility = { ...mocks.visibility, price: null };
+    mocks.eligibility = { ...mocks.eligibility, usedHere: true };
+    await openAndPick();
+
+    await expect.element(page.getByTestId('buzz-submit')).not.toBeInTheDocument();
+    // And the reason renders beside the disabled control, which is the whole
+    // justification for holding there: three dead buttons and no explanation is
+    // worse than the paid button this replaced.
+    await expect.element(page.getByText(/once per gallery/i)).toBeInTheDocument();
+    // Not a claim about spending, on a path that cannot be pressed.
+    await expect.element(page.getByText(/spends a free placement/i)).not.toBeInTheDocument();
   });
 
   /**

--- a/src/components/RemixGallery/RemixGallerySubmitModal.browser.test.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.browser.test.tsx
@@ -221,6 +221,7 @@ describe('a refused free submission', () => {
     await page.getByRole('button', { name: /submit for free/i }).click();
 
     await expect.element(page.getByText(/all taken right now/i)).toBeInTheDocument();
+
     // An ordinary outcome with a next step, not an error.
     expect(mocks.showError).not.toHaveBeenCalled();
     // And never the server's raw wording.
@@ -280,39 +281,6 @@ describe('a gallery that takes free submissions and refuses paid ones', () => {
     await expect.element(page.getByTestId('buzz-submit')).toBeInTheDocument();
   });
 
-  test('offers no paid submit button at all', async () => {
-    paidClosed(null);
-    await openAndPick();
-    await page.getByRole('button', { name: /submit for free/i }).click();
-
-    await expect.element(page.getByTestId('buzz-submit')).not.toBeInTheDocument();
-    await expect
-      .element(page.getByRole('button', { name: /submit for free/i }))
-      .toBeInTheDocument();
-  });
-
-  test('holds on free rather than offering a paid button that cannot work', async () => {
-    // 🔴 A STATIC fixture, no click and no refusal: free is unavailable from
-    // first paint (`usedHere`) and paid is closed (`price: null`), which is
-    // `submissionMethod(null, false, false, true)`.
-    //
-    // With the rule, that resolves to free — a plain Button. Without it, to
-    // paid, and the `BuzzTransactionButton` stub mounts its testid. So this
-    // reaches the rule with no cache write-through at all, which is what the
-    // previous version of this comment wrongly said was impossible.
-    mocks.visibility = { ...mocks.visibility, price: null };
-    mocks.eligibility = { ...mocks.eligibility, usedHere: true };
-    await openAndPick();
-
-    await expect.element(page.getByTestId('buzz-submit')).not.toBeInTheDocument();
-    // And the reason renders beside the disabled control, which is the whole
-    // justification for holding there: three dead buttons and no explanation is
-    // worse than the paid button this replaced.
-    await expect.element(page.getByText(/once per gallery/i)).toBeInTheDocument();
-    // Not a claim about spending, on a path that cannot be pressed.
-    await expect.element(page.getByText(/spends a free placement/i)).not.toBeInTheDocument();
-  });
-
   /**
    * ⚠️ What this file does NOT pin, stated so nothing above is over-read.
    *
@@ -331,7 +299,33 @@ describe('a gallery that takes free submissions and refuses paid ones', () => {
    * through a real query cache — and reaching it needs a fixture that would grow
    * its own bugs for one line. Said plainly rather than left to look covered,
    * and scoped so a reader who greps does not stop believing the rest of it.
+   *
+   * The same limitation makes the `!freeRefusal` term of the reason's gate
+   * unpinnable here, and I checked rather than assumed: dropping it leaves all
+   * of these green. The two messages can only collide when a refusal lands
+   * while `offer.reason` is non-null, and `offer.reason` is computed from the
+   * static query fixture — which still says free is available at the moment the
+   * refusal arrives. An assertion here would be vacuous, so there is not one.
    */
+});
+
+describe('an unverified remix on an ordinarily-priced gallery', () => {
+  test('says why free is unavailable, beside a WORKING paid button', async () => {
+    // 🔴 The commonest case there is, and no test observed the sentence in it:
+    // every other case that watches it render has `price: null`, so adding
+    // `&& !paidOpen` to the gate would stay green while hiding the reason in
+    // exactly this state. The gate has now been narrowed wrongly three times;
+    // this is what would notice a fourth.
+    mocks.eligibility = { ...mocks.eligibility, verifiedImageIds: [] };
+    await openAndPick();
+
+    await expect.element(page.getByText(/where we can check/i)).toBeInTheDocument();
+    // The negative control that separates this from the paid-closed cases: paid
+    // really is available here, so the sentence must name it AND the button must
+    // be on the screen.
+    await expect.element(page.getByText(/can still be submitted with Buzz/i)).toBeInTheDocument();
+    await expect.element(page.getByTestId('buzz-submit')).toBeInTheDocument();
+  });
 });
 
 describe('a gallery with neither path open', () => {

--- a/src/components/RemixGallery/RemixGallerySubmitModal.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.tsx
@@ -19,7 +19,11 @@ import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import { useQueryImages } from '~/components/Image/image.utils';
 import { InViewLoader } from '~/components/InView/InViewLoader';
 import { NoContent } from '~/components/NoContent/NoContent';
-import { freeSubmissionOffer } from '~/components/RemixGallery/remix-gallery.utils';
+import {
+  freeRefusalExplanation,
+  freeRefusalOutcome,
+  freeSubmissionOffer,
+} from '~/components/RemixGallery/remix-gallery.utils';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useAvailableBuzz } from '~/components/Buzz/useAvailableBuzz';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
@@ -44,8 +48,12 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
    * so a choice made about one remix must not carry to the next.
    */
   const [chosen, setChosen] = useState<'free' | 'paid' | null>(null);
-  /** Set only when a submission lost the race for the last free slot. */
-  const [lostFreeSlot, setLostFreeSlot] = useState(false);
+  /**
+   * Why a free submission was refused, when a re-read could explain it. Held
+   * here rather than shown as an error notification because it is an ordinary
+   * outcome with a next step — the paid option, already on screen.
+   */
+  const [freeRefusal, setFreeRefusal] = useState<string | null>(null);
 
   const { data: visibility, isError: visibilityFailed } =
     trpc.placement.getRemixGalleryVisibility.useQuery({ imageId: hostImageId });
@@ -71,17 +79,25 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
 
   const takesFree = (visibility?.freeSlots ?? 0) > 0;
 
+  // `null` rather than a number when the viewer may not be told how many of a
+  // creator's free slots are currently held — signed out, gallery closed, or
+  // their own image. Treated as "not on offer" rather than as zero, because zero
+  // would render "all taken right now" about a count we were not given.
+  const slotsHeldKnown = visibility?.freeSlotsRemaining != null;
+
   const offer = freeSubmissionOffer({
     verified: selected != null && !!freeInfo?.verifiedImageIds.includes(selected),
     freeSlots: visibility?.freeSlots ?? 0,
     freeSlotsRemaining: visibility?.freeSlotsRemaining ?? 0,
     allowanceRemaining: freeInfo?.allowance.remaining ?? 0,
     usedHere: !!freeInfo?.usedHere,
+    resetsAt: freeInfo?.allowance.resetsAt ?? new Date(),
   });
-  const freeAvailable = offer.available;
+  const freeAvailable = offer.available && slotsHeldKnown;
   // Withheld while the answer is in flight, so the card says nothing rather than
   // briefly asserting a reason drawn from defaulted zeroes.
-  const freeUnavailableReason = selected != null && freeInfo ? offer.reason : null;
+  const freeUnavailableReason =
+    selected != null && freeInfo && slotsHeldKnown ? offer.reason : null;
 
   // Free whenever it is available, unless the submitter said otherwise — and
   // never free once it stops being available, whatever they said. That second
@@ -100,24 +116,58 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
       utils.placement.invalidate();
       dialog.onClose();
     },
-    onError: (error) => {
-      // A free submission can be refused after the control offered it: every
-      // number the free option is built on is stale by construction, and the
-      // mutation re-counts under a lock. So a free failure re-reads and falls
-      // back to paid rather than surfacing the server's message — which is not
-      // copy anyone should be shown, and which the reason line below will
-      // restate correctly once the fresh numbers land.
-      if (method === 'free') {
-        utils.placement.invalidate();
-        setChosen('paid');
-        setLostFreeSlot(true);
-        return;
-      }
+    onError: async (error) => {
+      /**
+       * A free submission can be refused for two very different kinds of reason,
+       * and only one of them is an ordinary outcome.
+       *
+       * The free primitive re-counts under its lock, so losing the last slot —
+       * or the allowance, or the never-twice rule — is a race the control cannot
+       * win and should not report as an error. Everything else is a real refusal
+       * the submitter needs to read: unverified, a duplicate entry, an
+       * unpublished image, the content rule, a block.
+       *
+       * Told apart by re-reading rather than by matching the server's wording,
+       * which is prose it is free to change. If the fresh numbers still say free
+       * was on offer, the refusal was not about capacity and the message is
+       * shown. Falls back to showing it if the re-read itself fails, because
+       * silence is the one outcome that leaves nobody informed.
+       */
+      const explained =
+        method === 'free' && selected != null
+          ? await utils.placement.getRemixGalleryVisibility
+              .fetch({ imageId: hostImageId })
+              .then(async (space) => {
+                const standing = await utils.placement.getRemixGalleryFreeEligibility.fetch({
+                  hostImageId,
+                  imageIds: [selected],
+                });
 
-      showErrorNotification({
-        title: "Couldn't submit that",
-        error: new Error(error.message),
-      });
+                return space.freeSlotsRemaining == null
+                  ? null
+                  : freeRefusalExplanation({
+                      verified: standing.verifiedImageIds.includes(selected),
+                      freeSlots: space.freeSlots,
+                      freeSlotsRemaining: space.freeSlotsRemaining,
+                      allowanceRemaining: standing.allowance.remaining,
+                      usedHere: standing.usedHere,
+                      resetsAt: standing.allowance.resetsAt,
+                    });
+              })
+              // A failed re-read explains nothing, which lands on the server's
+              // own message — the outcome that leaves somebody informed.
+              .catch(() => null)
+          : null;
+
+      const outcome = freeRefusalOutcome(explained, error.message);
+      if (outcome.fallBackToPaid) setChosen('paid');
+      setFreeRefusal(outcome.fallBackToPaid ? outcome.message : null);
+
+      if (!outcome.fallBackToPaid)
+        showErrorNotification({
+          title: outcome.title,
+          error: new Error(outcome.message),
+        });
     },
   });
 
@@ -267,7 +317,7 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
                       // Free eligibility is a property of the image, so a choice
                       // made about one remix must not carry to the next.
                       setChosen(null);
-                      setLostFreeSlot(false);
+                      setFreeRefusal(null);
                     }}
                     className={clsx(
                       'cursor-pointer',
@@ -368,14 +418,23 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
                 ]}
               />
 
+              {/* No number and no reset time written here. The allowance is a
+                  server-side rule and both of its facts already come back from
+                  `getFreePlacementAllowance`; a sentence that spells either one
+                  out is a claim this file cannot keep true. */}
               {method === 'free' && (
                 <Text size="xs" c="dimmed">
-                  This spends your one free placement for the day, and it is spent even if the
-                  creator declines.
+                  This spends a free placement from today&apos;s allowance, and it is spent even if
+                  the creator declines.
                 </Text>
               )}
 
-              {lostFreeSlot && (
+              {/* The refusal that just happened, in the words the re-read
+                  produced rather than a fixed sentence about slots — the reason
+                  is not always the slots, and saying so when it is not is how
+                  this shipped wrong the first time. Nothing was spent either
+                  way: the claim refuses before it inserts. */}
+              {freeRefusal && (
                 <Group gap="xs" wrap="nowrap" align="flex-start">
                   <IconAlertTriangle
                     size={14}
@@ -383,8 +442,7 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
                     style={{ flexShrink: 0, marginTop: 2 }}
                   />
                   <Text size="xs" c="yellow">
-                    That didn&apos;t go through as a free submission — free is decided at the moment
-                    you submit. Nothing was spent. You can still submit with Buzz.
+                    {freeRefusal} Nothing was spent — you can still submit with Buzz.
                   </Text>
                 </Group>
               )}

--- a/src/components/RemixGallery/RemixGallerySubmitModal.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.tsx
@@ -104,7 +104,7 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
   const freeUnavailableReason =
     selected != null && freeInfo && slotsHeldKnown ? offer.reason : null;
 
-  const method = submissionMethod(chosen, freeAvailable);
+  const method = submissionMethod(chosen, freeAvailable, paidOpen);
 
   const submit = trpc.placement.submitToRemixGallery.useMutation({
     onSuccess: () => {
@@ -438,7 +438,17 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
                     label: 'Free · needs review',
                     disabled: !freeAvailable,
                   },
-                  { value: 'paid', label: price == null ? 'With Buzz' : `${price} Buzz` },
+                  {
+                    value: 'paid',
+                    label: paidOpen ? `${price} Buzz` : 'With Buzz',
+                    // Not `price == null`: a gallery priced below the surface
+                    // floor refuses paid submissions too, and offering that
+                    // option leads into a second refusal rather than a disabled
+                    // button. Same predicate as the copy, one layer down —
+                    // `paidOpen` reaching only the sentence is how this shipped
+                    // wrong once already.
+                    disabled: !paidOpen,
+                  },
                 ]}
               />
 
@@ -516,7 +526,7 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
                 // hole. That was server-side, where the escrow drew from both.
                 accountTypes={spendTypes}
                 label="Submit"
-                disabled={!selected || !visibility?.open || price == null}
+                disabled={!selected || !visibility?.open || !paidOpen}
                 loading={submit.isPending}
                 // The price this render displayed travels with the submission, so
                 // the server refuses rather than charging a number the submitter

--- a/src/components/RemixGallery/RemixGallerySubmitModal.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.tsx
@@ -1,4 +1,15 @@
-import { Alert, Anchor, Button, Divider, Group, Loader, Modal, Stack, Text } from '@mantine/core';
+import {
+  Alert,
+  Anchor,
+  Button,
+  Divider,
+  Group,
+  Loader,
+  Modal,
+  SegmentedControl,
+  Stack,
+  Text,
+} from '@mantine/core';
 import { IconAlertTriangle, IconInfoCircle } from '@tabler/icons-react';
 import clsx from 'clsx';
 import { useState } from 'react';
@@ -8,6 +19,7 @@ import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import { useQueryImages } from '~/components/Image/image.utils';
 import { InViewLoader } from '~/components/InView/InViewLoader';
 import { NoContent } from '~/components/NoContent/NoContent';
+import { freeSubmissionOffer } from '~/components/RemixGallery/remix-gallery.utils';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useAvailableBuzz } from '~/components/Buzz/useAvailableBuzz';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
@@ -25,14 +37,59 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
   const utils = trpc.useUtils();
   const spendTypes = useAvailableBuzz();
   const [selected, setSelected] = useState<number | null>(null);
+  /**
+   * An explicit choice, or `null` for "whatever the default is". Kept apart from
+   * the resolved method below so the default can reapply when the selection
+   * changes — free eligibility is a property of the image, not of the gallery,
+   * so a choice made about one remix must not carry to the next.
+   */
+  const [chosen, setChosen] = useState<'free' | 'paid' | null>(null);
+  /** Set only when a submission lost the race for the last free slot. */
+  const [lostFreeSlot, setLostFreeSlot] = useState(false);
 
   const { data: visibility, isError: visibilityFailed } =
     trpc.placement.getRemixGalleryVisibility.useQuery({ imageId: hostImageId });
+
+  /**
+   * Asked for the selected image alone rather than for the whole grid. The
+   * verification is a per-row containment test, and the control only ever needs
+   * the answer for the one image about to be submitted — probing every image the
+   * picker has paged through would grow without bound for the sake of a state
+   * nobody is looking at.
+   */
+  const { data: freeInfo } = trpc.placement.getRemixGalleryFreeEligibility.useQuery(
+    { hostImageId, imageIds: selected != null ? [selected] : [] },
+    { enabled: !!currentUser && selected != null }
+  );
 
   const { images, isLoading, fetchNextPage, hasNextPage, isRefetching } = useQueryImages(
     { userId: currentUser?.id, period: 'AllTime', limit: 50 },
     { enabled: !!currentUser }
   );
+
+  const price = visibility?.price ?? null;
+
+  const takesFree = (visibility?.freeSlots ?? 0) > 0;
+
+  const offer = freeSubmissionOffer({
+    verified: selected != null && !!freeInfo?.verifiedImageIds.includes(selected),
+    freeSlots: visibility?.freeSlots ?? 0,
+    freeSlotsRemaining: visibility?.freeSlotsRemaining ?? 0,
+    allowanceRemaining: freeInfo?.allowance.remaining ?? 0,
+    usedHere: !!freeInfo?.usedHere,
+  });
+  const freeAvailable = offer.available;
+  // Withheld while the answer is in flight, so the card says nothing rather than
+  // briefly asserting a reason drawn from defaulted zeroes.
+  const freeUnavailableReason = selected != null && freeInfo ? offer.reason : null;
+
+  // Free whenever it is available, unless the submitter said otherwise — and
+  // never free once it stops being available, whatever they said. That second
+  // half is what survives losing the race for the last slot: the refusal comes
+  // back, the refetch drops `freeAvailable`, and this resolves to paid without
+  // the submitter having to notice a control change under them.
+  const method =
+    chosen === 'free' && !freeAvailable ? 'paid' : chosen ?? (freeAvailable ? 'free' : 'paid');
 
   const submit = trpc.placement.submitToRemixGallery.useMutation({
     onSuccess: () => {
@@ -43,14 +100,26 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
       utils.placement.invalidate();
       dialog.onClose();
     },
-    onError: (error) =>
+    onError: (error) => {
+      // A free submission can be refused after the control offered it: every
+      // number the free option is built on is stale by construction, and the
+      // mutation re-counts under a lock. So a free failure re-reads and falls
+      // back to paid rather than surfacing the server's message — which is not
+      // copy anyone should be shown, and which the reason line below will
+      // restate correctly once the fresh numbers land.
+      if (method === 'free') {
+        utils.placement.invalidate();
+        setChosen('paid');
+        setLostFreeSlot(true);
+        return;
+      }
+
       showErrorNotification({
         title: "Couldn't submit that",
         error: new Error(error.message),
-      }),
+      });
+    },
   });
-
-  const price = visibility?.price ?? null;
 
   // Filtered rather than shown-and-refused. Until the ceiling arrives nothing is
   // offered: rendering the whole grid first and removing images a moment later
@@ -193,7 +262,13 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
                     key={image.id}
                     aspectRatio="square"
                     image={image}
-                    onClick={() => setSelected(image.id)}
+                    onClick={() => {
+                      setSelected(image.id);
+                      // Free eligibility is a property of the image, so a choice
+                      // made about one remix must not carry to the next.
+                      setChosen(null);
+                      setLostFreeSlot(false);
+                    }}
                     className={clsx(
                       'cursor-pointer',
                       selected === image.id && 'ring-2 ring-blue-5'
@@ -266,8 +341,65 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
             the operator-set rate — quoting "30%" here would be a number this
             file cannot keep true, and it is the one fact a submitter needs
             before spending. */}
+        {/* The free/paid choice, and the last moment it can be made. It carries
+            the mode as well as the price because those are two different offers
+            and the placer is about to spend something either way — a free
+            submission still costs them their one placement for the day, decline
+            or not. Hidden entirely when the gallery takes no free submissions at
+            all: a control with one reachable answer is not a choice. */}
+        {selected != null && takesFree && (
+          <>
+            <Divider />
+            <Stack gap={6} className="shrink-0 px-4 pt-3">
+              <SegmentedControl
+                value={method}
+                onChange={(value) => setChosen(value as 'free' | 'paid')}
+                data={[
+                  {
+                    value: 'free',
+                    // Always "needs review" on this surface: a gallery places
+                    // arbitrary media on someone else's page, so `auto` is
+                    // refused for it in three places. Written out rather than
+                    // branched on the mode, which cannot be anything else here.
+                    label: 'Free · needs review',
+                    disabled: !freeAvailable,
+                  },
+                  { value: 'paid', label: price == null ? 'With Buzz' : `${price} Buzz` },
+                ]}
+              />
+
+              {method === 'free' && (
+                <Text size="xs" c="dimmed">
+                  This spends your one free placement for the day, and it is spent even if the
+                  creator declines.
+                </Text>
+              )}
+
+              {lostFreeSlot && (
+                <Group gap="xs" wrap="nowrap" align="flex-start">
+                  <IconAlertTriangle
+                    size={14}
+                    className="text-yellow-500"
+                    style={{ flexShrink: 0, marginTop: 2 }}
+                  />
+                  <Text size="xs" c="yellow">
+                    That didn&apos;t go through as a free submission — free is decided at the moment
+                    you submit. Nothing was spent. You can still submit with Buzz.
+                  </Text>
+                </Group>
+              )}
+
+              {method === 'paid' && freeUnavailableReason && (
+                <Text size="xs" c="dimmed">
+                  {freeUnavailableReason}
+                </Text>
+              )}
+            </Stack>
+          </>
+        )}
+
         <div className="flex shrink-0 items-center justify-between gap-3 px-4 py-3">
-          {visibility?.declineFee ? (
+          {method === 'paid' && visibility?.declineFee ? (
             // `min-w-0` is what makes the note wrap instead of pushing: a flex
             // item's floor is its content width otherwise, so a long sentence
             // squeezed the Submit button until its label clipped.
@@ -286,30 +418,46 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
             <span className="flex-1" />
           )}
           <div className="shrink-0">
-            {/* The price shown here is the one the balance check runs against, and
+            {/* A plain button on the free path. `BuzzTransactionButton` exists to
+              check a balance and open the top-up flow, and running a free
+              submission through it would ask someone to have Buzz they are not
+              about to spend. */}
+            {method === 'free' ? (
+              <Button
+                disabled={!selected || !visibility?.open || !freeAvailable}
+                loading={submit.isPending}
+                onClick={() =>
+                  selected != null && submit.mutate({ hostImageId, imageId: selected, free: true })
+                }
+              >
+                Submit for free
+              </Button>
+            ) : (
+              /* The price shown here is the one the balance check runs against, and
               the owner can move it between this render and the click. The
               mutation reads the price fresh, so the button is honest about
               affordability but cannot promise the amount — hence the note above
-              it rather than a silent charge. */}
-            <BuzzTransactionButton
-              buzzAmount={price ?? 0}
-              // Says what it means. `BuzzTransactionButton` already ran the pair
-              // through `useAvailableBuzz`, which strips both and appends the
-              // domain's, so this renders identically — the pair was never the
-              // hole. That was server-side, where the escrow drew from both.
-              accountTypes={spendTypes}
-              label="Submit"
-              disabled={!selected || !visibility?.open || price == null}
-              loading={submit.isPending}
-              // The price this render displayed travels with the submission, so
-              // the server refuses rather than charging a number the submitter
-              // never agreed to. Affordability was checked against this one too.
-              onPerformTransaction={() =>
-                selected != null &&
-                price != null &&
-                submit.mutate({ hostImageId, imageId: selected, expectedPrice: price })
-              }
-            />
+              it rather than a silent charge. */
+              <BuzzTransactionButton
+                buzzAmount={price ?? 0}
+                // Says what it means. `BuzzTransactionButton` already ran the pair
+                // through `useAvailableBuzz`, which strips both and appends the
+                // domain's, so this renders identically — the pair was never the
+                // hole. That was server-side, where the escrow drew from both.
+                accountTypes={spendTypes}
+                label="Submit"
+                disabled={!selected || !visibility?.open || price == null}
+                loading={submit.isPending}
+                // The price this render displayed travels with the submission, so
+                // the server refuses rather than charging a number the submitter
+                // never agreed to. Affordability was checked against this one too.
+                onPerformTransaction={() =>
+                  selected != null &&
+                  price != null &&
+                  submit.mutate({ hostImageId, imageId: selected, expectedPrice: price })
+                }
+              />
+            )}
           </div>
         </div>
       </div>

--- a/src/components/RemixGallery/RemixGallerySubmitModal.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.tsx
@@ -141,11 +141,26 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
        * silence is the one outcome that leaves nobody informed.
        */
       /**
-       * 🔴 The FRESH `paidOpen` travels out beside the explanation, because the
-       * rendered one is not merely stale — `getRemixGalleryVisibility.useQuery`
-       * passes no options, so it inherits `staleTime: Infinity` with no refetch
-       * on focus. A modal left open across a price change keeps the render value
-       * for the whole session, which is why this handler re-fetches at all.
+       * 🔴 `staleTime: 0` on both fetches, and it is load-bearing rather than
+       * decorative — the sticker sibling says the same thing at
+       * `Sticker/placement.util.ts`. The client's global default is
+       * `staleTime: Infinity`, and `fetchQuery` applies it: both keys below are
+       * the mounted queries' own keys and both have data at click time, so
+       * without this the "re-read" resolves the CACHE and never calls the
+       * procedure.
+       *
+       * What that cost when it was missing is the whole point of this handler.
+       * Pressing Submit for free requires `freeAvailable`, which means
+       * `freeSubmissionOffer` over those cached inputs returned available — and
+       * `freeRefusalExplanation` is that same function over those same inputs,
+       * so it returned `null` every time. Every refused free submission fell to
+       * the server branch and showed raw server prose, which is precisely the
+       * behaviour the refusal split exists to remove.
+       *
+       * The FRESH `paidOpen` then travels out beside the explanation, because
+       * the rendered one is not merely stale: with `staleTime: Infinity` and no
+       * refetch on focus, a modal left open across a price change holds the
+       * render value for the whole session.
        *
        * Using the stale flag here while the explanation beside it used the fresh
        * one produced the exact failure `paidOpen` was added to prevent: an owner
@@ -157,12 +172,12 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
       const refusal =
         method === 'free' && selected != null
           ? await utils.placement.getRemixGalleryVisibility
-              .fetch({ imageId: hostImageId })
+              .fetch({ imageId: hostImageId }, { staleTime: 0 })
               .then(async (space) => {
-                const standing = await utils.placement.getRemixGalleryFreeEligibility.fetch({
-                  hostImageId,
-                  imageIds: [selected],
-                });
+                const standing = await utils.placement.getRemixGalleryFreeEligibility.fetch(
+                  { hostImageId, imageIds: [selected] },
+                  { staleTime: 0 }
+                );
 
                 const freshPaidOpen = paidSubmissionOpen(space.price);
                 return {
@@ -181,9 +196,12 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
                         }),
                 };
               })
-              // A failed re-read explains nothing, which lands on the server's
-              // own message — the outcome that leaves somebody informed. The
-              // render value is all that is left to decide the rest on.
+              // A real network read can reject, which is what `staleTime: 0`
+              // reintroduces. A failed re-read explains nothing, so this lands on
+              // the server's own message — the outcome that leaves somebody
+              // informed. The `paidOpen` here is never read: `freeRefusalOutcome`
+              // consults it only on the explained branch. Supplied so the shape
+              // matches rather than because it decides anything.
               .catch(() => ({ paidOpen, explained: null }))
           : { paidOpen, explained: null };
 

--- a/src/components/RemixGallery/RemixGallerySubmitModal.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.tsx
@@ -87,15 +87,6 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
   // would render "all taken right now" about a count we were not given.
   const slotsHeldKnown = visibility?.freeSlotsRemaining != null;
 
-  const offer = freeSubmissionOffer({
-    verified: selected != null && !!freeInfo?.verifiedImageIds.includes(selected),
-    freeSlots: visibility?.freeSlots ?? 0,
-    freeSlotsRemaining: visibility?.freeSlotsRemaining ?? 0,
-    allowanceRemaining: freeInfo?.allowance.remaining ?? 0,
-    usedHere: !!freeInfo?.usedHere,
-    resetsAt: freeInfo?.allowance.resetsAt ?? new Date(),
-  });
-  const freeAvailable = offer.available && slotsHeldKnown;
   // Not `visibility.open`, which is `mode !== 'off'` and says nothing about
   // price. A gallery can take free submissions and refuse every paid one.
   //
@@ -105,6 +96,17 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
   // flipped. Unknown reads as open, which is the pre-existing behaviour and the
   // one that does not flash.
   const paidOpen = visibility ? paidSubmissionOpen(visibility.price) : true;
+
+  const offer = freeSubmissionOffer({
+    verified: selected != null && !!freeInfo?.verifiedImageIds.includes(selected),
+    freeSlots: visibility?.freeSlots ?? 0,
+    freeSlotsRemaining: visibility?.freeSlotsRemaining ?? 0,
+    allowanceRemaining: freeInfo?.allowance.remaining ?? 0,
+    usedHere: !!freeInfo?.usedHere,
+    resetsAt: freeInfo?.allowance.resetsAt ?? new Date(),
+    paidOpen,
+  });
+  const freeAvailable = offer.available && slotsHeldKnown;
   // Withheld while the answer is in flight, so the card says nothing rather than
   // briefly asserting a reason drawn from defaulted zeroes.
   const freeUnavailableReason =
@@ -157,6 +159,7 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
                       allowanceRemaining: standing.allowance.remaining,
                       usedHere: standing.usedHere,
                       resetsAt: standing.allowance.resetsAt,
+                      paidOpen: paidSubmissionOpen(space.price),
                     });
               })
               // A failed re-read explains nothing, which lands on the server's
@@ -434,7 +437,10 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
             free, and `takesFree` hides it on a gallery that takes no free
             submissions and no paid ones either — a dead end with no explanation.
             `offer.reason` is null whenever free is genuinely on offer, so this
-            cannot fire against a working button. */}
+            cannot fire against the FREE button. It can and should fire beside a
+            working PAID one — an unverified remix on an ordinarily-priced
+            gallery is the commonest case there is, and the sentence is the only
+            thing explaining why the free option is greyed out. */}
         {selected != null && !freeRefusal && freeUnavailableReason && (
           <>
             <Divider />

--- a/src/components/RemixGallery/RemixGallerySubmitModal.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.tsx
@@ -140,7 +140,21 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
        * shown. Falls back to showing it if the re-read itself fails, because
        * silence is the one outcome that leaves nobody informed.
        */
-      const explained =
+      /**
+       * 🔴 The FRESH `paidOpen` travels out beside the explanation, because the
+       * rendered one is not merely stale — `getRemixGalleryVisibility.useQuery`
+       * passes no options, so it inherits `staleTime: Infinity` with no refetch
+       * on focus. A modal left open across a price change keeps the render value
+       * for the whole session, which is why this handler re-fetches at all.
+       *
+       * Using the stale flag here while the explanation beside it used the fresh
+       * one produced the exact failure `paidOpen` was added to prevent: an owner
+       * clearing their price mid-submission got "you can still submit with Buzz"
+       * and a control moved to paid, then `submissionMethod` pulled it back to
+       * free-disabled on the next render — a banner pointing at a button that is
+       * not on the screen.
+       */
+      const refusal =
         method === 'free' && selected != null
           ? await utils.placement.getRemixGalleryVisibility
               .fetch({ imageId: hostImageId })
@@ -150,24 +164,31 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
                   imageIds: [selected],
                 });
 
-                return space.freeSlotsRemaining == null
-                  ? null
-                  : freeRefusalExplanation({
-                      verified: standing.verifiedImageIds.includes(selected),
-                      freeSlots: space.freeSlots,
-                      freeSlotsRemaining: space.freeSlotsRemaining,
-                      allowanceRemaining: standing.allowance.remaining,
-                      usedHere: standing.usedHere,
-                      resetsAt: standing.allowance.resetsAt,
-                      paidOpen: paidSubmissionOpen(space.price),
-                    });
+                const freshPaidOpen = paidSubmissionOpen(space.price);
+                return {
+                  paidOpen: freshPaidOpen,
+                  explained:
+                    space.freeSlotsRemaining == null
+                      ? null
+                      : freeRefusalExplanation({
+                          verified: standing.verifiedImageIds.includes(selected),
+                          freeSlots: space.freeSlots,
+                          freeSlotsRemaining: space.freeSlotsRemaining,
+                          allowanceRemaining: standing.allowance.remaining,
+                          usedHere: standing.usedHere,
+                          resetsAt: standing.allowance.resetsAt,
+                          paidOpen: freshPaidOpen,
+                        }),
+                };
               })
               // A failed re-read explains nothing, which lands on the server's
-              // own message — the outcome that leaves somebody informed.
-              .catch(() => null)
-          : null;
+              // own message — the outcome that leaves somebody informed. The
+              // render value is all that is left to decide the rest on.
+              .catch(() => ({ paidOpen, explained: null }))
+          : { paidOpen, explained: null };
 
-      const outcome = freeRefusalOutcome(explained, error.message, paidOpen);
+      const explained = refusal.explained;
+      const outcome = freeRefusalOutcome(explained, error.message, refusal.paidOpen);
       if (outcome.fallBackToPaid) setChosen('paid');
 
       // Keyed on whether we could explain it, NOT on whether we moved the

--- a/src/components/RemixGallery/RemixGallerySubmitModal.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.tsx
@@ -427,6 +427,23 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
           </>
         )}
 
+        {/* 🔴 OUTSIDE the free/paid block, and that is the point rather than
+            layout. This is the sentence saying WHY free is unavailable, and
+            every gate it has lived behind has hidden it in the state that needed
+            it most: `method === 'paid'` hid it once the card started holding on
+            free, and `takesFree` hides it on a gallery that takes no free
+            submissions and no paid ones either — a dead end with no explanation.
+            `offer.reason` is null whenever free is genuinely on offer, so this
+            cannot fire against a working button. */}
+        {selected != null && !freeRefusal && freeUnavailableReason && (
+          <>
+            <Divider />
+            <Text size="xs" c="dimmed" className="shrink-0 px-4 pt-3">
+              {freeUnavailableReason}
+            </Text>
+          </>
+        )}
+
         {selected != null && takesFree && (
           <>
             <Divider />
@@ -466,18 +483,6 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
                 <Text size="xs" c="dimmed">
                   This spends a free placement from today&apos;s allowance, and it is spent even if
                   the creator declines.
-                </Text>
-              )}
-
-              {/* Not gated on `method === 'paid'`. With paid closed the card
-                  holds on free, so that gate made the sentence explaining WHY
-                  free is unavailable unreachable in exactly the state where
-                  every control is disabled — three dead buttons and no reason.
-                  `offer.reason` is null whenever free is actually on offer, so
-                  this cannot fire against a working button. */}
-              {!freeRefusal && freeUnavailableReason && (
-                <Text size="xs" c="dimmed">
-                  {freeUnavailableReason}
                 </Text>
               )}
             </Stack>

--- a/src/components/RemixGallery/RemixGallerySubmitModal.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.tsx
@@ -98,13 +98,19 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
   const freeAvailable = offer.available && slotsHeldKnown;
   // Not `visibility.open`, which is `mode !== 'off'` and says nothing about
   // price. A gallery can take free submissions and refuse every paid one.
-  const paidOpen = paidSubmissionOpen(visibility?.price);
+  //
+  // ⚠️ An UNLOADED gallery is not a closed one. `visibility?.price` is undefined
+  // while the query is in flight, and treating that as closed put the card on
+  // "Submit for free" for a beat on every ordinary paid gallery before it
+  // flipped. Unknown reads as open, which is the pre-existing behaviour and the
+  // one that does not flash.
+  const paidOpen = visibility ? paidSubmissionOpen(visibility.price) : true;
   // Withheld while the answer is in flight, so the card says nothing rather than
   // briefly asserting a reason drawn from defaulted zeroes.
   const freeUnavailableReason =
     selected != null && freeInfo && slotsHeldKnown ? offer.reason : null;
 
-  const method = submissionMethod(chosen, freeAvailable, paidOpen);
+  const method = submissionMethod(chosen, freeAvailable, paidOpen, takesFree);
 
   const submit = trpc.placement.submitToRemixGallery.useMutation({
     onSuccess: () => {
@@ -456,14 +462,20 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
                   server-side rule and both of its facts already come back from
                   `getFreePlacementAllowance`; a sentence that spells either one
                   out is a claim this file cannot keep true. */}
-              {method === 'free' && (
+              {method === 'free' && freeAvailable && (
                 <Text size="xs" c="dimmed">
                   This spends a free placement from today&apos;s allowance, and it is spent even if
                   the creator declines.
                 </Text>
               )}
 
-              {method === 'paid' && !freeRefusal && freeUnavailableReason && (
+              {/* Not gated on `method === 'paid'`. With paid closed the card
+                  holds on free, so that gate made the sentence explaining WHY
+                  free is unavailable unreachable in exactly the state where
+                  every control is disabled — three dead buttons and no reason.
+                  `offer.reason` is null whenever free is actually on offer, so
+                  this cannot fire against a working button. */}
+              {!freeRefusal && freeUnavailableReason && (
                 <Text size="xs" c="dimmed">
                   {freeUnavailableReason}
                 </Text>

--- a/src/components/RemixGallery/RemixGallerySubmitModal.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.tsx
@@ -397,6 +397,31 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
             submission still costs them their one placement for the day, decline
             or not. Hidden entirely when the gallery takes no free submissions at
             all: a control with one reachable answer is not a choice. */}
+        {/* 🔴 Outside the block below, and that is the point rather than layout.
+            The choice is hidden when the creator takes no free submissions —
+            and `freeSlots <= 0` is ALSO one of the rungs that can explain a
+            refusal, when a creator closes their free capacity mid-modal. Nested,
+            the same fresh read that produces this message unmounts the thing
+            rendering it: the submission fails, the toast is suppressed because
+            the refusal was explained, and the only visible change is the control
+            quietly turning into a Buzz button. That is the same shape as the bug
+            this message exists to fix — written for somebody, shown to nobody. */}
+        {freeRefusal && (
+          <>
+            <Divider />
+            <Group gap="xs" wrap="nowrap" align="flex-start" className="shrink-0 px-4 pt-3">
+              <IconAlertTriangle
+                size={14}
+                className="text-yellow-500"
+                style={{ flexShrink: 0, marginTop: 2 }}
+              />
+              <Text size="xs" c="yellow">
+                {freeRefusal} Nothing was spent — you can still submit with Buzz.
+              </Text>
+            </Group>
+          </>
+        )}
+
         {selected != null && takesFree && (
           <>
             <Divider />
@@ -429,25 +454,7 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
                 </Text>
               )}
 
-              {/* The refusal that just happened, in the words the re-read
-                  produced rather than a fixed sentence about slots — the reason
-                  is not always the slots, and saying so when it is not is how
-                  this shipped wrong the first time. Nothing was spent either
-                  way: the claim refuses before it inserts. */}
-              {freeRefusal && (
-                <Group gap="xs" wrap="nowrap" align="flex-start">
-                  <IconAlertTriangle
-                    size={14}
-                    className="text-yellow-500"
-                    style={{ flexShrink: 0, marginTop: 2 }}
-                  />
-                  <Text size="xs" c="yellow">
-                    {freeRefusal} Nothing was spent — you can still submit with Buzz.
-                  </Text>
-                </Group>
-              )}
-
-              {method === 'paid' && freeUnavailableReason && (
+              {method === 'paid' && !freeRefusal && freeUnavailableReason && (
                 <Text size="xs" c="dimmed">
                   {freeUnavailableReason}
                 </Text>

--- a/src/components/RemixGallery/RemixGallerySubmitModal.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.tsx
@@ -23,6 +23,8 @@ import {
   freeRefusalExplanation,
   freeRefusalOutcome,
   freeSubmissionOffer,
+  paidSubmissionOpen,
+  submissionMethod,
 } from '~/components/RemixGallery/remix-gallery.utils';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useAvailableBuzz } from '~/components/Buzz/useAvailableBuzz';
@@ -94,18 +96,15 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
     resetsAt: freeInfo?.allowance.resetsAt ?? new Date(),
   });
   const freeAvailable = offer.available && slotsHeldKnown;
+  // Not `visibility.open`, which is `mode !== 'off'` and says nothing about
+  // price. A gallery can take free submissions and refuse every paid one.
+  const paidOpen = paidSubmissionOpen(visibility?.price);
   // Withheld while the answer is in flight, so the card says nothing rather than
   // briefly asserting a reason drawn from defaulted zeroes.
   const freeUnavailableReason =
     selected != null && freeInfo && slotsHeldKnown ? offer.reason : null;
 
-  // Free whenever it is available, unless the submitter said otherwise — and
-  // never free once it stops being available, whatever they said. That second
-  // half is what survives losing the race for the last slot: the refusal comes
-  // back, the refetch drops `freeAvailable`, and this resolves to paid without
-  // the submitter having to notice a control change under them.
-  const method =
-    chosen === 'free' && !freeAvailable ? 'paid' : chosen ?? (freeAvailable ? 'free' : 'paid');
+  const method = submissionMethod(chosen, freeAvailable);
 
   const submit = trpc.placement.submitToRemixGallery.useMutation({
     onSuccess: () => {
@@ -159,11 +158,16 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
               .catch(() => null)
           : null;
 
-      const outcome = freeRefusalOutcome(explained, error.message);
+      const outcome = freeRefusalOutcome(explained, error.message, paidOpen);
       if (outcome.fallBackToPaid) setChosen('paid');
-      setFreeRefusal(outcome.fallBackToPaid ? outcome.message : null);
 
-      if (!outcome.fallBackToPaid)
+      // Keyed on whether we could explain it, NOT on whether we moved the
+      // control. Those came apart once paid stopped being a guaranteed
+      // alternative: an explained refusal on a gallery that takes no paid
+      // submissions still has something worth saying, and routing it to the
+      // toast instead would file an ordinary outcome as an error.
+      setFreeRefusal(explained !== null ? outcome.message : null);
+      if (explained === null)
         showErrorNotification({
           title: outcome.title,
           error: new Error(outcome.message),
@@ -386,17 +390,12 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
 
         <Divider />
 
-        {/* Same shape as the crypto deposit card's warnings. The amount is the
-            server's own figure, computed with the helper the refund uses from
-            the operator-set rate — quoting "30%" here would be a number this
-            file cannot keep true, and it is the one fact a submitter needs
-            before spending. */}
         {/* The free/paid choice, and the last moment it can be made. It carries
             the mode as well as the price because those are two different offers
             and the placer is about to spend something either way — a free
-            submission still costs them their one placement for the day, decline
-            or not. Hidden entirely when the gallery takes no free submissions at
-            all: a control with one reachable answer is not a choice. */}
+            submission still costs them their daily allowance, decline or not.
+            Hidden entirely when the gallery takes no free submissions at all: a
+            control with one reachable answer is not a choice. */}
         {/* 🔴 Outside the block below, and that is the point rather than layout.
             The choice is hidden when the creator takes no free submissions —
             and `freeSlots <= 0` is ALSO one of the rungs that can explain a
@@ -416,7 +415,7 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
                 style={{ flexShrink: 0, marginTop: 2 }}
               />
               <Text size="xs" c="yellow">
-                {freeRefusal} Nothing was spent — you can still submit with Buzz.
+                {freeRefusal}
               </Text>
             </Group>
           </>
@@ -464,6 +463,12 @@ export function RemixGallerySubmitModal({ hostImageId }: { hostImageId: number }
         )}
 
         <div className="flex shrink-0 items-center justify-between gap-3 px-4 py-3">
+          {/* The paid path's own warning, and paid-only: a free submission puts
+              nothing in escrow, so there is no decline fee and quoting one would
+              describe money that never moved. The amount is the server's own
+              figure, computed with the helper the refund uses from the
+              operator-set rate — "30%" written here would be a number this file
+              cannot keep true. */}
           {method === 'paid' && visibility?.declineFee ? (
             // `min-w-0` is what makes the note wrap instead of pushing: a flex
             // item's floor is its content width otherwise, so a long sentence

--- a/src/components/RemixGallery/__tests__/remix-gallery.utils.test.ts
+++ b/src/components/RemixGallery/__tests__/remix-gallery.utils.test.ts
@@ -2,9 +2,81 @@ import { describe, expect, it } from 'vitest';
 import type { RemixGalleryItem } from '~/components/RemixGallery/remix-gallery.utils';
 import {
   dedupeGalleryItems,
+  freeSubmissionOffer,
   galleryDialogImages,
   trimToWholeRows,
 } from '~/components/RemixGallery/remix-gallery.utils';
+
+describe('freeSubmissionOffer', () => {
+  /** Everything satisfied, so each case below breaks exactly one thing. */
+  const eligible = {
+    verified: true,
+    freeSlots: 3,
+    freeSlotsRemaining: 2,
+    allowanceRemaining: 1,
+    usedHere: false,
+  };
+
+  it('offers free when every condition holds', () => {
+    expect(freeSubmissionOffer(eligible)).toEqual({ available: true, reason: null });
+  });
+
+  it('never returns a reason alongside an offer', () => {
+    // The two are read by different bits of the card, so a state carrying both
+    // would render a refusal under a working free button.
+    const offer = freeSubmissionOffer(eligible);
+    expect(offer.available).toBe(offer.reason === null);
+  });
+
+  it('refuses an unverified remix and names paying as the alternative', () => {
+    const { available, reason } = freeSubmissionOffer({ ...eligible, verified: false });
+
+    expect(available).toBe(false);
+    expect(reason).toMatch(/with Buzz/i);
+    // It must not call an off-site remix "not a remix": that is both wrong and
+    // an accusation, and it is the case a submitter is most likely to hit on
+    // work they know they made.
+    expect(reason).not.toMatch(/not a remix|isn't a remix/i);
+  });
+
+  it('leads with verification even when a slot shortage is also true', () => {
+    // Order is the whole design here. Naming the shortage would send someone
+    // back tomorrow to be refused for the reason they were refused today.
+    const { reason } = freeSubmissionOffer({
+      ...eligible,
+      verified: false,
+      freeSlotsRemaining: 0,
+      allowanceRemaining: 0,
+      usedHere: true,
+    });
+
+    expect(reason).toMatch(/where we can check/i);
+  });
+
+  it('tells the two meanings of "no slots remaining" apart', () => {
+    // `freeSlotsRemaining: 0` covers both "this creator takes none" and "they
+    // are all held right now" — the resolver short-circuits the count at zero
+    // capacity — and the difference decides whether coming back later helps.
+    const takesNone = freeSubmissionOffer({ ...eligible, freeSlots: 0, freeSlotsRemaining: 0 });
+    const allHeld = freeSubmissionOffer({ ...eligible, freeSlots: 3, freeSlotsRemaining: 0 });
+
+    expect(takesNone.reason).toMatch(/doesn't take free/i);
+    expect(allHeld.reason).toMatch(/all taken right now/i);
+    expect(takesNone.reason).not.toBe(allHeld.reason);
+  });
+
+  it('separates a spent daily allowance from a gallery already used', () => {
+    // One comes back at midnight and the other never does, so a single message
+    // for both would tell half of them to wait for something that will not
+    // happen.
+    expect(freeSubmissionOffer({ ...eligible, allowanceRemaining: 0 }).reason).toMatch(
+      /midnight UTC/i
+    );
+    expect(freeSubmissionOffer({ ...eligible, usedHere: true }).reason).toMatch(
+      /once per gallery/i
+    );
+  });
+});
 
 const items = (count: number, startId = 1) =>
   Array.from({ length: count }, (_, index) => ({

--- a/src/components/RemixGallery/__tests__/remix-gallery.utils.test.ts
+++ b/src/components/RemixGallery/__tests__/remix-gallery.utils.test.ts
@@ -6,8 +6,11 @@ import {
   freeRefusalOutcome,
   freeSubmissionOffer,
   galleryDialogImages,
+  paidSubmissionOpen,
+  submissionMethod,
   trimToWholeRows,
 } from '~/components/RemixGallery/remix-gallery.utils';
+import { PLACEMENT_SURFACES } from '~/shared/utils/placement';
 
 describe('what a refused free submission is told', () => {
   const stillOffered = {
@@ -39,7 +42,11 @@ describe('what a refused free submission is told', () => {
     // The message the careful copy lives in. Without this branch,
     // `FREE_NEEDS_VERIFIED_REFUSAL` — the sentence explaining why paying is the
     // alternative — reaches nobody, because this handler is its only path.
-    const outcome = freeRefusalOutcome(null, 'remix gallery: free submissions are for remixes…');
+    const outcome = freeRefusalOutcome(
+      null,
+      'remix gallery: free submissions are for remixes…',
+      true
+    );
 
     expect(outcome.message).toBe('remix gallery: free submissions are for remixes…');
     expect(outcome.title).toMatch(/couldn't submit/i);
@@ -50,8 +57,19 @@ describe('what a refused free submission is told', () => {
     // suspended placer it is not: they press the paid button and meet the same
     // refusal, having been told the opposite of what is wrong.
     expect(
-      freeRefusalOutcome(null, 'remix gallery: you cannot place right now').fallBackToPaid
+      freeRefusalOutcome(null, 'remix gallery: you cannot place right now', true).fallBackToPaid
     ).toBe(false);
+  });
+
+  it('treats an EMPTY explanation as explained, not as unexplained', () => {
+    // The guard is `explained !== null` and the comment says why; nothing
+    // asserted it, because no rung returns ''. Under truthiness an empty rung
+    // would take the branch that means "we could not explain this" and hand the
+    // submitter raw server prose instead.
+    expect(freeRefusalOutcome('', 'server prose', true)).toMatchObject({
+      fallBackToPaid: true,
+    });
+    expect(freeRefusalOutcome('', 'server prose', true).message).not.toContain('server prose');
   });
 
   it('moves the control to paid when the refusal WAS about free capacity', () => {
@@ -59,12 +77,67 @@ describe('what a refused free submission is told', () => {
     // here the fall-back is a true statement about the next step.
     const outcome = freeRefusalOutcome(
       'The free slots on this image are all taken right now.',
-      'x'
+      'x',
+      true
     );
 
     expect(outcome.fallBackToPaid).toBe(true);
     expect(outcome.message).toMatch(/all taken right now/i);
-    expect(outcome.message).not.toBe('x');
+    expect(outcome.message).toMatch(/still submit with Buzz/i);
+  });
+
+  it('does not recommend Buzz on a gallery that refuses paid submissions', () => {
+    // 🔴 The two paths are deliberately asymmetric: the service holds free to
+    // none of the price rules, so an unpriced or below-floor gallery accepts
+    // free and refuses paid. Recommending Buzz there sends someone to a disabled
+    // button or into a second refusal.
+    const outcome = freeRefusalOutcome(
+      'The free slots on this image are all taken right now.',
+      'x',
+      false
+    );
+
+    expect(outcome.fallBackToPaid).toBe(false);
+    expect(outcome.message).not.toMatch(/still submit with Buzz/i);
+    expect(outcome.message).toMatch(/not taking paid submissions/i);
+  });
+});
+
+describe('submissionMethod', () => {
+  it('defaults to free when free is available, and to paid when it is not', () => {
+    expect(submissionMethod(null, true)).toBe('free');
+    expect(submissionMethod(null, false)).toBe('paid');
+  });
+
+  it('honours an explicit choice', () => {
+    expect(submissionMethod('paid', true)).toBe('paid');
+    expect(submissionMethod('free', true)).toBe('free');
+  });
+
+  it('never resolves to free once free stops being available', () => {
+    // The half that survives losing the race for the last slot: `chosen` still
+    // says free, the fresh numbers no longer do, and the control must not submit
+    // free anyway.
+    expect(submissionMethod('free', false)).toBe('paid');
+  });
+});
+
+describe('paidSubmissionOpen', () => {
+  // Mirrors the two refusals the paid path makes, which `open` does not cover —
+  // that is `mode !== 'off'` and says nothing about price.
+  it.each([
+    ['unpriced', null],
+    ['undefined while loading', undefined],
+    ['below the surface floor', PLACEMENT_SURFACES.remixGallery.serverMinPrice - 1],
+  ])('is closed when %s', (_label, price) => {
+    expect(paidSubmissionOpen(price)).toBe(false);
+  });
+
+  it.each([
+    ['exactly at the floor', PLACEMENT_SURFACES.remixGallery.serverMinPrice],
+    ['above it', PLACEMENT_SURFACES.remixGallery.serverMinPrice + 10],
+  ])('is open when priced %s', (_label, price) => {
+    expect(paidSubmissionOpen(price)).toBe(true);
   });
 });
 

--- a/src/components/RemixGallery/__tests__/remix-gallery.utils.test.ts
+++ b/src/components/RemixGallery/__tests__/remix-gallery.utils.test.ts
@@ -112,29 +112,40 @@ describe('freeSubmissionOffer', () => {
       // Fixtures that break one condition at a time pass under any order, so
       // the two-line swap that inverts the ladder would go unnoticed.
       const expected = ladder.find(([name]) => name === first)![1];
-      const { reason } = freeSubmissionOffer({
+      const { available, reason } = freeSubmissionOffer({
         ...eligible,
         ...broken[first],
         ...broken[second],
       });
 
+      // `available` on every branch, not only on the happy one. The modal reads
+      // it to decide whether the free button works, and a rung returning a
+      // refusal reason alongside `available: true` would offer a submission the
+      // claim then refuses — the state the docstring calls impossible and which
+      // nothing asserted on four of six outcomes.
+      expect(available).toBe(false);
       expect(reason).toMatch(expected);
     }
   );
 
-  it('reports the longest-lasting refusal when EVERY condition fails', () => {
-    // The transitive check the pairwise cases cannot make on their own.
-    const { reason } = freeSubmissionOffer({
-      ...eligible,
-      ...broken.verified,
-      ...broken.usedHere,
-      ...broken.freeSlots,
-      ...broken.allowanceRemaining,
-      ...broken.freeSlotsRemaining,
-    });
+  it.each(ladder.map((entry, index) => [entry[0], index] as const))(
+    'reports %s over every rung BELOW it, all set at once',
+    (name, index) => {
+      // A suffix cascade rather than one all-true case. All-true asserts only
+      // that rung 1 wins, so a swap anywhere among the rest leaves it green —
+      // it reads as a transitivity check and is not one. Breaking every rung
+      // from this one down, for each rung in turn, is the check that
+      // discriminates: any reordering changes at least one winner.
+      const { available, reason } = freeSubmissionOffer(
+        ladder
+          .slice(index)
+          .reduce((input, [rung]) => ({ ...input, ...broken[rung] }), { ...eligible })
+      );
 
-    expect(reason).toMatch(/where we can check/i);
-  });
+      expect(available).toBe(false);
+      expect(reason).toMatch(ladder[index][1]);
+    }
+  );
 
   it('reads the reset moment off the server date rather than naming a timezone', () => {
     // "midnight UTC" is true of the rule and misleading to a person, and it is a
@@ -150,13 +161,6 @@ describe('freeSubmissionOffer', () => {
 
   it('offers free when every condition holds', () => {
     expect(freeSubmissionOffer(eligible)).toEqual({ available: true, reason: null });
-  });
-
-  it('never returns a reason alongside an offer', () => {
-    // The two are read by different bits of the card, so a state carrying both
-    // would render a refusal under a working free button.
-    const offer = freeSubmissionOffer(eligible);
-    expect(offer.available).toBe(offer.reason === null);
   });
 
   it('refuses an unverified remix and names paying as the alternative', () => {

--- a/src/components/RemixGallery/__tests__/remix-gallery.utils.test.ts
+++ b/src/components/RemixGallery/__tests__/remix-gallery.utils.test.ts
@@ -105,20 +105,35 @@ describe('what a refused free submission is told', () => {
 
 describe('submissionMethod', () => {
   it('defaults to free when free is available, and to paid when it is not', () => {
-    expect(submissionMethod(null, true)).toBe('free');
-    expect(submissionMethod(null, false)).toBe('paid');
+    expect(submissionMethod(null, true, true)).toBe('free');
+    expect(submissionMethod(null, false, true)).toBe('paid');
   });
 
   it('honours an explicit choice', () => {
-    expect(submissionMethod('paid', true)).toBe('paid');
-    expect(submissionMethod('free', true)).toBe('free');
+    expect(submissionMethod('paid', true, true)).toBe('paid');
+    expect(submissionMethod('free', true, true)).toBe('free');
   });
 
   it('never resolves to free once free stops being available', () => {
     // The half that survives losing the race for the last slot: `chosen` still
     // says free, the fresh numbers no longer do, and the control must not submit
     // free anyway.
-    expect(submissionMethod('free', false)).toBe('paid');
+    expect(submissionMethod('free', false, true)).toBe('paid');
+  });
+
+  it.each([
+    ['a stale free choice', 'free' as const, false],
+    ['an explicit paid choice', 'paid' as const, true],
+    ['no choice at all', null, false],
+  ])('stays on free when paid is closed — %s', (_label, chosen, freeAvailable) => {
+    // 🔴 Falling to paid is only honest when paid exists. On a gallery that
+    // takes free submissions and refuses every paid one, dropping to paid lands
+    // on a disabled button with no explanation, or on an enabled one that opens
+    // the buy-Buzz flow for a submission the server will refuse.
+    //
+    // Every route into paid is covered, because each is a different line: the
+    // stale-choice rule, an explicit press, and the default.
+    expect(submissionMethod(chosen, freeAvailable, false)).toBe('free');
   });
 });
 

--- a/src/components/RemixGallery/__tests__/remix-gallery.utils.test.ts
+++ b/src/components/RemixGallery/__tests__/remix-gallery.utils.test.ts
@@ -105,20 +105,27 @@ describe('what a refused free submission is told', () => {
 
 describe('submissionMethod', () => {
   it('defaults to free when free is available, and to paid when it is not', () => {
-    expect(submissionMethod(null, true, true)).toBe('free');
-    expect(submissionMethod(null, false, true)).toBe('paid');
+    expect(submissionMethod(null, true, true, true)).toBe('free');
+    expect(submissionMethod(null, false, true, true)).toBe('paid');
   });
 
   it('honours an explicit choice', () => {
-    expect(submissionMethod('paid', true, true)).toBe('paid');
-    expect(submissionMethod('free', true, true)).toBe('free');
+    expect(submissionMethod('paid', true, true, true)).toBe('paid');
+    expect(submissionMethod('free', true, true, true)).toBe('free');
   });
 
   it('never resolves to free once free stops being available', () => {
     // The half that survives losing the race for the last slot: `chosen` still
     // says free, the fresh numbers no longer do, and the control must not submit
     // free anyway.
-    expect(submissionMethod('free', false, true)).toBe('paid');
+    expect(submissionMethod('free', false, true, true)).toBe('paid');
+  });
+
+  it('falls through to paid when NEITHER path is open', () => {
+    // Nothing to hold on. Forcing free here renders a disabled "Submit for
+    // free" on a gallery that takes none; paid-disabled-beside-the-reason is
+    // the honest rendering of "no route in".
+    expect(submissionMethod(null, false, false, false)).toBe('paid');
   });
 
   it.each([
@@ -133,7 +140,7 @@ describe('submissionMethod', () => {
     //
     // Every route into paid is covered, because each is a different line: the
     // stale-choice rule, an explicit press, and the default.
-    expect(submissionMethod(chosen, freeAvailable, false)).toBe('free');
+    expect(submissionMethod(chosen, freeAvailable, false, true)).toBe('free');
   });
 });
 

--- a/src/components/RemixGallery/__tests__/remix-gallery.utils.test.ts
+++ b/src/components/RemixGallery/__tests__/remix-gallery.utils.test.ts
@@ -20,6 +20,7 @@ describe('what a refused free submission is told', () => {
     allowanceRemaining: 1,
     usedHere: false,
     resetsAt: new Date('2026-03-04T00:00:00Z'),
+    paidOpen: true,
   };
 
   it('explains nothing when the re-read says free was still on offer', () => {
@@ -174,6 +175,7 @@ describe('freeSubmissionOffer', () => {
     allowanceRemaining: 1,
     usedHere: false,
     resetsAt: RESETS_AT,
+    paidOpen: true,
   };
 
   /** Each condition on its own, so a pair can be built by merging two. */
@@ -267,6 +269,18 @@ describe('freeSubmissionOffer', () => {
     // an accusation, and it is the case a submitter is most likely to hit on
     // work they know they made.
     expect(reason).not.toMatch(/not a remix|isn't a remix/i);
+  });
+
+  it('does not name paying when paid is closed either', () => {
+    // 🔴 `freeRefusalOutcome` got this a round earlier and this rung did not.
+    // On an unpriced or below-floor gallery the card holds on free with every
+    // control disabled and no Buzz button mounted at all, so pointing at one is
+    // pointing off the screen — and at a submission the server would refuse.
+    const { reason } = freeSubmissionOffer({ ...eligible, verified: false, paidOpen: false });
+
+    expect(reason).toMatch(/where we can check/i);
+    expect(reason).not.toMatch(/can still be submitted with Buzz/i);
+    expect(reason).toMatch(/not taking paid submissions/i);
   });
 
   it('leads with verification even when a slot shortage is also true', () => {

--- a/src/components/RemixGallery/__tests__/remix-gallery.utils.test.ts
+++ b/src/components/RemixGallery/__tests__/remix-gallery.utils.test.ts
@@ -2,12 +2,75 @@ import { describe, expect, it } from 'vitest';
 import type { RemixGalleryItem } from '~/components/RemixGallery/remix-gallery.utils';
 import {
   dedupeGalleryItems,
+  freeRefusalExplanation,
+  freeRefusalOutcome,
   freeSubmissionOffer,
   galleryDialogImages,
   trimToWholeRows,
 } from '~/components/RemixGallery/remix-gallery.utils';
 
+describe('what a refused free submission is told', () => {
+  const stillOffered = {
+    verified: true,
+    freeSlots: 3,
+    freeSlotsRemaining: 2,
+    allowanceRemaining: 1,
+    usedHere: false,
+    resetsAt: new Date('2026-03-04T00:00:00Z'),
+  };
+
+  it('explains nothing when the re-read says free was still on offer', () => {
+    // 🔴 The null is the fix. `freeSubmissionOffer` always has an answer, so a
+    // caller asking it AFTER a refusal is always given one — and the free path
+    // is refused for at least a dozen reasons it cannot see: unverified, a
+    // duplicate entry, an unpublished image, the content rule, a block, a
+    // moderator suspension. A shape that cannot say "I don't know" reports every
+    // one of those as whichever rung happens to be lowest.
+    expect(freeRefusalExplanation(stillOffered)).toBeNull();
+  });
+
+  it('explains a refusal the re-read does account for', () => {
+    expect(freeRefusalExplanation({ ...stillOffered, freeSlotsRemaining: 0 })).toMatch(
+      /all taken right now/i
+    );
+  });
+
+  it('shows the server’s own words when nothing explains it', () => {
+    // The message the careful copy lives in. Without this branch,
+    // `FREE_NEEDS_VERIFIED_REFUSAL` — the sentence explaining why paying is the
+    // alternative — reaches nobody, because this handler is its only path.
+    const outcome = freeRefusalOutcome(null, 'remix gallery: free submissions are for remixes…');
+
+    expect(outcome.message).toBe('remix gallery: free submissions are for remixes…');
+    expect(outcome.title).toMatch(/couldn't submit/i);
+  });
+
+  it('does NOT move the control to paid on an unexplained refusal', () => {
+    // Settling on paid asserts that money was the problem. For a blocked or
+    // suspended placer it is not: they press the paid button and meet the same
+    // refusal, having been told the opposite of what is wrong.
+    expect(
+      freeRefusalOutcome(null, 'remix gallery: you cannot place right now').fallBackToPaid
+    ).toBe(false);
+  });
+
+  it('moves the control to paid when the refusal WAS about free capacity', () => {
+    // Every rung is a limit on free capacity that Buzz is not subject to, so
+    // here the fall-back is a true statement about the next step.
+    const outcome = freeRefusalOutcome(
+      'The free slots on this image are all taken right now.',
+      'x'
+    );
+
+    expect(outcome.fallBackToPaid).toBe(true);
+    expect(outcome.message).toMatch(/all taken right now/i);
+    expect(outcome.message).not.toBe('x');
+  });
+});
+
 describe('freeSubmissionOffer', () => {
+  const RESETS_AT = new Date('2026-03-04T00:00:00Z');
+
   /** Everything satisfied, so each case below breaks exactly one thing. */
   const eligible = {
     verified: true,
@@ -15,7 +78,75 @@ describe('freeSubmissionOffer', () => {
     freeSlotsRemaining: 2,
     allowanceRemaining: 1,
     usedHere: false,
+    resetsAt: RESETS_AT,
   };
+
+  /** Each condition on its own, so a pair can be built by merging two. */
+  const broken = {
+    verified: { verified: false },
+    usedHere: { usedHere: true },
+    freeSlots: { freeSlots: 0, freeSlotsRemaining: 0 },
+    allowanceRemaining: { allowanceRemaining: 0 },
+    freeSlotsRemaining: { freeSlotsRemaining: 0 },
+  } as const;
+
+  /**
+   * The ladder, longest-lasting refusal first, with the fragment each one owns.
+   *
+   * The order is the design: a refusal that lifts tonight must never be reported
+   * over one that never lifts, or someone comes back tomorrow to be told the
+   * thing nobody told them today.
+   */
+  const ladder = [
+    ['verified', /where we can check/i],
+    ['usedHere', /once per gallery/i],
+    ['freeSlots', /doesn't take free/i],
+    ['allowanceRemaining', /used today's free placement/i],
+    ['freeSlotsRemaining', /all taken right now/i],
+  ] as const;
+
+  it.each(ladder.slice(0, -1).map((entry, index) => [entry[0], ladder[index + 1][0]] as const))(
+    'reports %s ahead of %s when BOTH are true',
+    (first, second) => {
+      // Both set at once, which is the only way an ordering can be asserted.
+      // Fixtures that break one condition at a time pass under any order, so
+      // the two-line swap that inverts the ladder would go unnoticed.
+      const expected = ladder.find(([name]) => name === first)![1];
+      const { reason } = freeSubmissionOffer({
+        ...eligible,
+        ...broken[first],
+        ...broken[second],
+      });
+
+      expect(reason).toMatch(expected);
+    }
+  );
+
+  it('reports the longest-lasting refusal when EVERY condition fails', () => {
+    // The transitive check the pairwise cases cannot make on their own.
+    const { reason } = freeSubmissionOffer({
+      ...eligible,
+      ...broken.verified,
+      ...broken.usedHere,
+      ...broken.freeSlots,
+      ...broken.allowanceRemaining,
+      ...broken.freeSlotsRemaining,
+    });
+
+    expect(reason).toMatch(/where we can check/i);
+  });
+
+  it('reads the reset moment off the server date rather than naming a timezone', () => {
+    // "midnight UTC" is true of the rule and misleading to a person, and it is a
+    // server-side rule this file must not restate — raise the reset and a
+    // hardcoded sentence goes quietly false.
+    const { reason } = freeSubmissionOffer({ ...eligible, ...broken.allowanceRemaining });
+
+    expect(reason).not.toMatch(/UTC/i);
+    expect(reason).toContain(
+      RESETS_AT.toLocaleString(undefined, { weekday: 'short', hour: 'numeric', minute: '2-digit' })
+    );
+  });
 
   it('offers free when every condition holds', () => {
     expect(freeSubmissionOffer(eligible)).toEqual({ available: true, reason: null });
@@ -70,7 +201,7 @@ describe('freeSubmissionOffer', () => {
     // for both would tell half of them to wait for something that will not
     // happen.
     expect(freeSubmissionOffer({ ...eligible, allowanceRemaining: 0 }).reason).toMatch(
-      /midnight UTC/i
+      /comes back at/i
     );
     expect(freeSubmissionOffer({ ...eligible, usedHere: true }).reason).toMatch(
       /once per gallery/i

--- a/src/components/RemixGallery/remix-gallery.utils.ts
+++ b/src/components/RemixGallery/remix-gallery.utils.ts
@@ -1,4 +1,5 @@
 import type { ImageGetInfinite } from '~/types/router';
+import { PLACEMENT_SURFACES } from '~/shared/utils/placement';
 import { REMIX_GALLERY_ROW_WIDTH } from '~/shared/utils/remix-gallery';
 
 /**
@@ -209,14 +210,61 @@ export const freeRefusalExplanation = (fresh: FreeSubmissionInputs) =>
  * Pure, so both halves are testable without a query client, and so the modal
  * holds no policy about which refusals money solves.
  */
-export function freeRefusalOutcome(explained: string | null, serverMessage: string) {
+export function freeRefusalOutcome(
+  explained: string | null,
+  serverMessage: string,
+  /** Whether the paid path would actually accept this submission. */
+  paidOpen: boolean
+) {
   // `!== null`, not truthiness. They agree today only because every rung returns
   // a sentence; a rung that ever returned an empty string would silently take
   // the server branch, which is the branch that says "we could not explain this".
   if (explained !== null)
-    return { title: 'That free slot got away', message: explained, fallBackToPaid: true };
+    return {
+      title: 'That free slot got away',
+      // 🔴 The offer of the paid path is conditional on the paid path existing.
+      // A gallery can accept free submissions and refuse paid ones — the service
+      // deliberately holds free to none of the price rules, and there are tests
+      // asserting both an unpriced and a below-floor gallery take free and
+      // refuse paid. Told to pay on one of those, a submitter meets either a
+      // disabled button or a second refusal.
+      message: paidOpen
+        ? `${explained} Nothing was spent — you can still submit with Buzz.`
+        : `${explained} Nothing was spent, and this gallery is not taking paid submissions either.`,
+      // Same condition, because moving the control is the same claim as making
+      // it in words.
+      fallBackToPaid: paidOpen,
+    };
 
   // The server's own words, unedited. It is the only party that knows, and
   // guessing here is what produced a modal that told everyone they lost a race.
   return { title: "Couldn't submit that", message: serverMessage, fallBackToPaid: false };
 }
+
+/**
+ * Whether this gallery would accept a PAID submission.
+ *
+ * Not the same question as `open`, which `getRemixGalleryVisibility` answers
+ * from `mode !== 'off'` alone. Price and free capacity are independent in the
+ * schema, so a gallery can be open, take free submissions, and refuse every paid
+ * one — unpriced, where the submit button is disabled, or priced below the
+ * surface floor, where the button works and the mutation refuses.
+ *
+ * Mirrors the two refusals on the paid path in `createRemixGallerySubmission`.
+ * A third rule there needs one here, or the card starts recommending a refusal
+ * again.
+ */
+/**
+ * Which option the control is on: an explicit choice, else free when it is
+ * available.
+ *
+ * The second half is what survives losing the race for the last slot — `chosen`
+ * can say free while the fresh numbers no longer do, and this resolves to paid
+ * without the submitter having to notice a control changing under them. Pure and
+ * out here because it is one line whose inversion charges someone Buzz.
+ */
+export const submissionMethod = (chosen: 'free' | 'paid' | null, freeAvailable: boolean) =>
+  chosen === 'free' && !freeAvailable ? 'paid' : chosen ?? (freeAvailable ? 'free' : 'paid');
+
+export const paidSubmissionOpen = (price: number | null | undefined) =>
+  price != null && price >= PLACEMENT_SURFACES.remixGallery.serverMinPrice;

--- a/src/components/RemixGallery/remix-gallery.utils.ts
+++ b/src/components/RemixGallery/remix-gallery.utils.ts
@@ -145,10 +145,10 @@ export function freeSubmissionOffer({
     return {
       available: false,
       // 🔴 The alternative is only named when it exists. On an unpriced or
-      // below-floor gallery the card holds on free with every control disabled
-      // and `BuzzTransactionButton` never mounted — so the unconditional version
-      // of this sentence pointed at a Buzz control that is not on the screen,
-      // for a submission the server would refuse anyway.
+      // below-floor gallery the paid control is unusable — either not mounted at
+      // all, or mounted disabled when the card falls through to paid — so the
+      // unconditional version of this sentence pointed at a Buzz control nobody
+      // can press, for a submission the server would refuse anyway.
       reason: paidOpen
         ? 'Free submissions are for remixes made from this image here on the site, where we can check. Anything else can still be submitted with Buzz.'
         : 'Free submissions are for remixes made from this image here on the site, where we can check — and this creator is not taking paid submissions either.',

--- a/src/components/RemixGallery/remix-gallery.utils.ts
+++ b/src/components/RemixGallery/remix-gallery.utils.ts
@@ -80,6 +80,14 @@ export type FreeSubmissionInputs = {
   /** Free is once per gallery per placer, ever — not once per day. */
   usedHere: boolean;
   /**
+   * Whether the paid path would accept this submission — see
+   * `paidSubmissionOpen`. Here because the FIRST rung names paying as the
+   * alternative, and a gallery can take free submissions and refuse every paid
+   * one. `freeRefusalOutcome` got this a round earlier; this sentence did not,
+   * and the r6 gate widened the states it renders in.
+   */
+  paidOpen: boolean;
+  /**
    * When the allowance comes back, from `getFreePlacementAllowance` rather than
    * a sentence written here. The reset is midnight UTC today and that is a
    * server-side rule; a client that spells it out is asserting something it does
@@ -131,12 +139,19 @@ export function freeSubmissionOffer({
   allowanceRemaining,
   usedHere,
   resetsAt,
+  paidOpen,
 }: FreeSubmissionInputs): { available: boolean; reason: string | null } {
   if (!verified)
     return {
       available: false,
-      reason:
-        'Free submissions are for remixes made from this image here on the site, where we can check. Anything else can still be submitted with Buzz.',
+      // 🔴 The alternative is only named when it exists. On an unpriced or
+      // below-floor gallery the card holds on free with every control disabled
+      // and `BuzzTransactionButton` never mounted — so the unconditional version
+      // of this sentence pointed at a Buzz control that is not on the screen,
+      // for a submission the server would refuse anyway.
+      reason: paidOpen
+        ? 'Free submissions are for remixes made from this image here on the site, where we can check. Anything else can still be submitted with Buzz.'
+        : 'Free submissions are for remixes made from this image here on the site, where we can check — and this creator is not taking paid submissions either.',
     };
 
   if (usedHere)

--- a/src/components/RemixGallery/remix-gallery.utils.ts
+++ b/src/components/RemixGallery/remix-gallery.utils.ts
@@ -254,17 +254,34 @@ export function freeRefusalOutcome(
  * A third rule there needs one here, or the card starts recommending a refusal
  * again.
  */
+export const paidSubmissionOpen = (price: number | null | undefined) =>
+  price != null && price >= PLACEMENT_SURFACES.remixGallery.serverMinPrice;
+
 /**
  * Which option the control is on: an explicit choice, else free when it is
  * available.
  *
- * The second half is what survives losing the race for the last slot — `chosen`
- * can say free while the fresh numbers no longer do, and this resolves to paid
- * without the submitter having to notice a control changing under them. Pure and
- * out here because it is one line whose inversion charges someone Buzz.
+ * Two rules, and the second took a round to get right.
+ *
+ * `chosen === 'free'` cannot survive free becoming unavailable — that is what
+ * carries a lost race for the last slot without the submitter watching a control
+ * change under them. But falling to paid is only honest when paid exists: on a
+ * gallery that takes free submissions and refuses every paid one, dropping to
+ * paid lands either on a disabled button with no explanation, or on an enabled
+ * one that opens the buy-Buzz flow for a submission the server will refuse.
+ * Being asked to top up for a guaranteed refusal is worse than the refusal. So
+ * `paidOpen` is checked first and the control stays on free — disabled, beside
+ * the reason it is disabled.
+ *
+ * Pure and out here because its inversion charges someone Buzz, and because
+ * `paidOpen` reaching only the copy — true in the sentence, false in the control
+ * — is how this shipped wrong the first time.
  */
-export const submissionMethod = (chosen: 'free' | 'paid' | null, freeAvailable: boolean) =>
-  chosen === 'free' && !freeAvailable ? 'paid' : chosen ?? (freeAvailable ? 'free' : 'paid');
-
-export const paidSubmissionOpen = (price: number | null | undefined) =>
-  price != null && price >= PLACEMENT_SURFACES.remixGallery.serverMinPrice;
+export const submissionMethod = (
+  chosen: 'free' | 'paid' | null,
+  freeAvailable: boolean,
+  paidOpen: boolean
+): 'free' | 'paid' => {
+  if (!paidOpen) return 'free';
+  return chosen === 'free' && !freeAvailable ? 'paid' : chosen ?? (freeAvailable ? 'free' : 'paid');
+};

--- a/src/components/RemixGallery/remix-gallery.utils.ts
+++ b/src/components/RemixGallery/remix-gallery.utils.ts
@@ -66,3 +66,71 @@ export function galleryDialogImages(imageId: number, items: RemixGalleryItem[]) 
   if (index === -1) return [];
   return images.slice(Math.max(index - 50, 0), index + 50);
 }
+
+export type FreeSubmissionInputs = {
+  /** The server resolved this remix as derived from the host image. */
+  verified: boolean;
+  /** What the creator accepts. `0` is them taking none — a setting, not a queue. */
+  freeSlots: number;
+  /** What is left right now. Stale by construction; the mutation re-counts. */
+  freeSlotsRemaining: number;
+  /** Free placements the placer has left today, across every surface. */
+  allowanceRemaining: number;
+  /** Free is once per gallery per placer, ever — not once per day. */
+  usedHere: boolean;
+};
+
+/**
+ * Whether the free option may be offered, and if not, why.
+ *
+ * Pure, and apart from the modal, because this is the part worth being sure
+ * about: five inputs, an order that matters, and copy that is wrong in a
+ * different way for each of them. Rendering it is the easy half.
+ *
+ * The order is most-specific-first, and `verified` leads deliberately. An
+ * unverified remix is refused whatever the creator's slots say, so naming a slot
+ * shortage there would send someone back tomorrow to be refused for the same
+ * reason they were refused today.
+ *
+ * `reason` is `null` exactly when free is on offer, so a caller cannot render a
+ * refusal and an offer at once.
+ */
+export function freeSubmissionOffer({
+  verified,
+  freeSlots,
+  freeSlotsRemaining,
+  allowanceRemaining,
+  usedHere,
+}: FreeSubmissionInputs): { available: boolean; reason: string | null } {
+  if (!verified)
+    return {
+      available: false,
+      reason:
+        'Free submissions are for remixes made from this image here on the site, where we can check. Anything else can still be submitted with Buzz.',
+    };
+
+  if (usedHere)
+    return {
+      available: false,
+      reason:
+        "You've already used a free submission on this gallery. Free is once per gallery, not once a day.",
+    };
+
+  if (allowanceRemaining <= 0)
+    return {
+      available: false,
+      reason: "You've used today's free placement. It comes back at midnight UTC.",
+    };
+
+  // The two states behind `freeSlotsRemaining: 0`, told apart by reading
+  // `freeSlots` beside it — the resolver short-circuits the reservation count at
+  // zero capacity, so the number alone cannot say which one this is. One is a
+  // decision the creator made and the other is a queue that will move.
+  if (freeSlots <= 0)
+    return { available: false, reason: "This creator doesn't take free submissions." };
+
+  if (freeSlotsRemaining <= 0)
+    return { available: false, reason: 'The free slots on this image are all taken right now.' };
+
+  return { available: true, reason: null };
+}

--- a/src/components/RemixGallery/remix-gallery.utils.ts
+++ b/src/components/RemixGallery/remix-gallery.utils.ts
@@ -78,7 +78,28 @@ export type FreeSubmissionInputs = {
   allowanceRemaining: number;
   /** Free is once per gallery per placer, ever — not once per day. */
   usedHere: boolean;
+  /**
+   * When the allowance comes back, from `getFreePlacementAllowance` rather than
+   * a sentence written here. The reset is midnight UTC today and that is a
+   * server-side rule; a client that spells it out is asserting something it does
+   * not own, and would keep asserting it after the rule moved.
+   */
+  resetsAt: Date | string;
 };
+
+/**
+ * When the allowance returns, in the reader's own timezone.
+ *
+ * Not "midnight UTC": that is true of the rule and misleading to a person, for
+ * whom the boundary lands at some ordinary hour of their own day. Derived from
+ * the server's date either way, so nothing here has to stay correct on its own.
+ */
+const allowanceResetLabel = (resetsAt: Date | string) =>
+  new Date(resetsAt).toLocaleString(undefined, {
+    weekday: 'short',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
 
 /**
  * Whether the free option may be offered, and if not, why.
@@ -87,10 +108,17 @@ export type FreeSubmissionInputs = {
  * about: five inputs, an order that matters, and copy that is wrong in a
  * different way for each of them. Rendering it is the easy half.
  *
- * The order is most-specific-first, and `verified` leads deliberately. An
- * unverified remix is refused whatever the creator's slots say, so naming a slot
- * shortage there would send someone back tomorrow to be refused for the same
- * reason they were refused today.
+ * **The order is by how long each refusal lasts, longest first**, and every
+ * adjacent pair is pinned by a test that makes both conditions true at once —
+ * which is the only way an ordering can be asserted at all.
+ *
+ * Permanent for this image (`verified`), then permanent for this gallery
+ * (`usedHere`), then the creator's own setting (`freeSlots`), then today
+ * (`allowanceRemaining`), then right now (`freeSlotsRemaining`). Getting this
+ * backwards is not a cosmetic problem: "it comes back at midnight UTC" told to
+ * someone whose real obstacle is a creator taking no free submissions is a
+ * promise about a gallery that will never accept one, and they will come back
+ * tomorrow to be refused for the reason nobody named today.
  *
  * `reason` is `null` exactly when free is on offer, so a caller cannot render a
  * refusal and an offer at once.
@@ -101,6 +129,7 @@ export function freeSubmissionOffer({
   freeSlotsRemaining,
   allowanceRemaining,
   usedHere,
+  resetsAt,
 }: FreeSubmissionInputs): { available: boolean; reason: string | null } {
   if (!verified)
     return {
@@ -116,21 +145,75 @@ export function freeSubmissionOffer({
         "You've already used a free submission on this gallery. Free is once per gallery, not once a day.",
     };
 
+  // Above the allowance, because this one never lifts: a creator who takes no
+  // free submissions will not start at midnight. The two states behind
+  // `freeSlotsRemaining: 0` are told apart by reading `freeSlots` beside it —
+  // the resolver short-circuits the reservation count at zero capacity, so the
+  // number alone cannot say which one this is.
+  if (freeSlots <= 0)
+    return { available: false, reason: "This creator doesn't take free submissions." };
+
+  // ⚠️ `~/components/Sticker/free-offer.ts` (`freeRefusalMessage`) says the same
+  // thing about the same number, written independently — the allowance is one
+  // count across every surface. Deliberately not shared: the two ladders order
+  // their reasons differently, and that ordering is what decides which sentence
+  // a person sees, so a shared module would have to hold the ordering too.
+  // Change this wording and change its twin. Its twin still spells out "midnight
+  // UTC" rather than reading `resetsAt`; that is the same fix as this one.
   if (allowanceRemaining <= 0)
     return {
       available: false,
-      reason: "You've used today's free placement. It comes back at midnight UTC.",
+      reason: `You've used today's free placement. It comes back at ${allowanceResetLabel(
+        resetsAt
+      )}.`,
     };
-
-  // The two states behind `freeSlotsRemaining: 0`, told apart by reading
-  // `freeSlots` beside it — the resolver short-circuits the reservation count at
-  // zero capacity, so the number alone cannot say which one this is. One is a
-  // decision the creator made and the other is a queue that will move.
-  if (freeSlots <= 0)
-    return { available: false, reason: "This creator doesn't take free submissions." };
 
   if (freeSlotsRemaining <= 0)
     return { available: false, reason: 'The free slots on this image are all taken right now.' };
 
   return { available: true, reason: null };
+}
+
+/**
+ * Whether a re-read explains a free submission that was just refused — and
+ * `null` when it does not.
+ *
+ * **The null is the whole point.** `freeSubmissionOffer` always has an answer,
+ * because the caller hands it every input it needs; asked *after* a refusal it
+ * therefore always sounds certain, and a caller consulting it will always
+ * believe it. But the free path is refused for at least a dozen reasons this
+ * function cannot see — an unverified remix, a duplicate entry, an unpublished
+ * image, the content rule, a block or a moderator suspension — and a shape that
+ * cannot say "I don't know" turns every one of those into whatever rung happens
+ * to be lowest.
+ *
+ * So: re-read, ask again, and if the fresh numbers say free was still on offer,
+ * the refusal was not about capacity and this returns nothing. What to do with
+ * that is `freeRefusalOutcome`'s decision, not this one's.
+ */
+export const freeRefusalExplanation = (fresh: FreeSubmissionInputs) =>
+  freeSubmissionOffer(fresh).reason;
+
+/**
+ * What to tell someone whose free submission was refused, and whether to move
+ * the control to paid.
+ *
+ * Falling back is its own decision rather than a consequence of having a
+ * message, because settling the control on paid **asserts that money was the
+ * problem**. That is true of every rung above — each one is a limit on free
+ * capacity that Buzz is not subject to — and false of everything the re-read
+ * could not explain: a blocked or suspended placer who is quietly moved to the
+ * paid button presses it and meets the same refusal, having been told the
+ * opposite of what is wrong.
+ *
+ * Pure, so both halves are testable without a query client, and so the modal
+ * holds no policy about which refusals money solves.
+ */
+export function freeRefusalOutcome(explained: string | null, serverMessage: string) {
+  if (explained)
+    return { title: 'That free slot got away', message: explained, fallBackToPaid: true };
+
+  // The server's own words, unedited. It is the only party that knows, and
+  // guessing here is what produced a modal that told everyone they lost a race.
+  return { title: "Couldn't submit that", message: serverMessage, fallBackToPaid: false };
 }

--- a/src/components/RemixGallery/remix-gallery.utils.ts
+++ b/src/components/RemixGallery/remix-gallery.utils.ts
@@ -270,8 +270,13 @@ export const paidSubmissionOpen = (price: number | null | undefined) =>
  * paid lands either on a disabled button with no explanation, or on an enabled
  * one that opens the buy-Buzz flow for a submission the server will refuse.
  * Being asked to top up for a guaranteed refusal is worse than the refusal. So
- * `paidOpen` is checked first and the control stays on free — disabled, beside
- * the reason it is disabled.
+ * `paidOpen` is checked first and the control stays on free.
+ *
+ * ⚠️ That leaves the free button disabled whenever free is also unavailable, and
+ * the card MUST still render `freeSubmissionOffer`'s reason there — the sentence
+ * saying why. Gating that sentence on the paid option being selected made it
+ * unreachable in exactly this state, which is three disabled controls and no
+ * explanation. If you change this function, check what renders beside it.
  *
  * Pure and out here because its inversion charges someone Buzz, and because
  * `paidOpen` reaching only the copy — true in the sentence, false in the control
@@ -280,8 +285,14 @@ export const paidSubmissionOpen = (price: number | null | undefined) =>
 export const submissionMethod = (
   chosen: 'free' | 'paid' | null,
   freeAvailable: boolean,
-  paidOpen: boolean
+  paidOpen: boolean,
+  /** Whether this gallery accepts free submissions at all. */
+  takesFree: boolean
 ): 'free' | 'paid' => {
-  if (!paidOpen) return 'free';
+  // `takesFree`, not just `!paidOpen`: with NEITHER path open there is nothing
+  // to hold on, and forcing free there renders a disabled "Submit for free" on
+  // a gallery that takes none. Falling through puts the card on paid, disabled,
+  // beside the reason — which is the honest rendering of "no route in".
+  if (!paidOpen && takesFree) return 'free';
   return chosen === 'free' && !freeAvailable ? 'paid' : chosen ?? (freeAvailable ? 'free' : 'paid');
 };

--- a/src/components/RemixGallery/remix-gallery.utils.ts
+++ b/src/components/RemixGallery/remix-gallery.utils.ts
@@ -210,7 +210,10 @@ export const freeRefusalExplanation = (fresh: FreeSubmissionInputs) =>
  * holds no policy about which refusals money solves.
  */
 export function freeRefusalOutcome(explained: string | null, serverMessage: string) {
-  if (explained)
+  // `!== null`, not truthiness. They agree today only because every rung returns
+  // a sentence; a rung that ever returned an empty string would silently take
+  // the server branch, which is the branch that says "we could not explain this".
+  if (explained !== null)
     return { title: 'That free slot got away', message: explained, fallBackToPaid: true };
 
   // The server's own words, unedited. It is the only party that knows, and

--- a/src/components/RemixGallery/remix-gallery.utils.ts
+++ b/src/components/RemixGallery/remix-gallery.utils.ts
@@ -291,8 +291,9 @@ export const submissionMethod = (
 ): 'free' | 'paid' => {
   // `takesFree`, not just `!paidOpen`: with NEITHER path open there is nothing
   // to hold on, and forcing free there renders a disabled "Submit for free" on
-  // a gallery that takes none. Falling through puts the card on paid, disabled,
-  // beside the reason — which is the honest rendering of "no route in".
+  // a gallery that takes none. Falling through puts the card on paid, disabled.
+  // The reason renders from outside the free/paid block precisely so this state
+  // is not a dead end with no explanation — check that gate if you change this.
   if (!paidOpen && takesFree) return 'free';
   return chosen === 'free' && !freeAvailable ? 'paid' : chosen ?? (freeAvailable ? 'free' : 'paid');
 };

--- a/src/pages/user/remix-submissions.tsx
+++ b/src/pages/user/remix-submissions.tsx
@@ -229,8 +229,9 @@ function ReceivedTab({
       <Alert color="gray">
         <Text size="sm">Nothing is waiting for your review.</Text>
         <Text size="sm" c="dimmed" mt={4}>
-          When someone pays to feature their remix on one of your images, it appears here for you to
-          approve or decline. You choose whether to accept them at all, and what they cost, in{' '}
+          When someone submits a remix on one of your images — paid, or against the free slots you
+          offer — it appears here for you to approve or decline. You choose whether to accept them
+          at all, how many free ones you take, and what the paid ones cost, in{' '}
           <Anchor component={Link} href="/user/account">
             your account settings
           </Anchor>
@@ -456,9 +457,8 @@ function SentTab({ rows, isLoading }: { rows: SentRow[]; isLoading: boolean }) {
                       <Text size="sm">
                         It comes out of {row.owner?.username ?? 'the creator'}&apos;s review queue
                         {row.free
-                          ? '. Your free placement for today stays spent — it is not returned.'
-                          : ` and your ${row.amount} Buzz starts on its way back.`}{' '}
-                        You can submit it again later.
+                          ? '. Your free placement for today stays spent, and free is once per gallery — withdrawing does not give it back, so you will not be able to submit here for free again.'
+                          : ` and your ${row.amount} Buzz starts on its way back. You can submit it again later.`}
                       </Text>
                     ),
                     labels: { confirm: 'Withdraw', cancel: 'Keep it' },

--- a/src/pages/user/remix-submissions.tsx
+++ b/src/pages/user/remix-submissions.tsx
@@ -269,12 +269,20 @@ function ReceivedTab({
                   </Text>{' '}
                   wants to feature this on your image
                 </Text>
-                <Group gap={4}>
-                  <CurrencyIcon currency={Currency.BUZZ} size={12} />
-                  <Text size="xs" c="dimmed">
-                    {row.amount}
-                  </Text>
-                </Group>
+                {/* Nothing was paid on a free row, so a Buzz chip there reads
+                    as an offer of 0 rather than as a different kind of offer. */}
+                {row.free ? (
+                  <Badge size="sm" variant="light" color="green" className="w-fit">
+                    Free submission
+                  </Badge>
+                ) : (
+                  <Group gap={4}>
+                    <CurrencyIcon currency={Currency.BUZZ} size={12} />
+                    <Text size="xs" c="dimmed">
+                      {row.amount}
+                    </Text>
+                  </Group>
+                )}
                 <Text size="xs" c="dimmed">
                   Sent {agedLabel(row.createdAt)}
                   {row.expiresAt ? ` — expires ${formatDate(row.expiresAt)}` : ''}
@@ -335,9 +343,13 @@ function SentTab({ rows, isLoading }: { rows: SentRow[]; isLoading: boolean }) {
       // States what happened, not what the ledger has done. A successful settle
       // means the transition was claimed, not that the refund leg has paid —
       // chunk C ships a sweep for unpaid legs precisely because those differ.
+      // No Buzz claim: this fires for free submissions too, which put nothing
+      // in escrow, and the row-level confirmation above already said what each
+      // kind gets back. A blanket "your Buzz is on its way" is false on half of
+      // them and unverifiable on the other half from here.
       showSuccessNotification({
         title: 'Withdrawn',
-        message: 'Your submission is withdrawn. Your Buzz is on its way back.',
+        message: 'Your submission is withdrawn.',
       });
       utils.placement.invalidate();
     },
@@ -366,8 +378,9 @@ function SentTab({ rows, isLoading }: { rows: SentRow[]; isLoading: boolean }) {
   return (
     <Stack gap="md">
       <Text size="sm" c="dimmed">
-        You can withdraw a submission any time before the creator reviews it and get your Buzz back
-        in full. Once it has been accepted there is nothing to withdraw.
+        You can withdraw a submission any time before the creator reviews it. A paid one refunds in
+        full; a free one does not return your daily free placement. Once it has been accepted there
+        is nothing to withdraw.
       </Text>
 
       {/* Neither queue pages. A list that stops at the cap and says nothing
@@ -401,12 +414,18 @@ function SentTab({ rows, isLoading }: { rows: SentRow[]; isLoading: boolean }) {
                   >
                     {row.status === 'approved' ? 'Live' : 'Awaiting review'}
                   </Badge>
-                  <Group gap={4}>
-                    <CurrencyIcon currency={Currency.BUZZ} size={12} />
-                    <Text size="xs" c="dimmed">
-                      {row.amount}
-                    </Text>
-                  </Group>
+                  {row.free ? (
+                    <Badge size="sm" variant="light" color="green">
+                      Free
+                    </Badge>
+                  ) : (
+                    <Group gap={4}>
+                      <CurrencyIcon currency={Currency.BUZZ} size={12} />
+                      <Text size="xs" c="dimmed">
+                        {row.amount}
+                      </Text>
+                    </Group>
+                  )}
                 </Group>
                 <Text size="sm">On {row.owner?.username ?? 'a creator'}&apos;s image</Text>
                 <Text size="xs" c="dimmed">
@@ -436,8 +455,10 @@ function SentTab({ rows, isLoading }: { rows: SentRow[]; isLoading: boolean }) {
                     children: (
                       <Text size="sm">
                         It comes out of {row.owner?.username ?? 'the creator'}&apos;s review queue
-                        and your {row.amount} Buzz starts on its way back. You can submit it again
-                        later.
+                        {row.free
+                          ? '. Your free placement for today stays spent — it is not returned.'
+                          : ` and your ${row.amount} Buzz starts on its way back.`}{' '}
+                        You can submit it again later.
                       </Text>
                     ),
                     labels: { confirm: 'Withdraw', cancel: 'Keep it' },

--- a/src/server/notifications/__tests__/placement.free-pending.test.ts
+++ b/src/server/notifications/__tests__/placement.free-pending.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { placementNotifications } from '~/server/notifications/placement.notifications';
+
+/**
+ * The two remix-gallery pending types partition the pending rows between them.
+ *
+ * Asserted on the SQL rather than through a database, the same way the polarity
+ * guard is: what these tests protect is a `WHERE` clause, and the failure they
+ * exist to catch — one row producing both notifications, or neither — is a
+ * property of the predicate and not of any particular row.
+ */
+describe('remix gallery pending notifications', () => {
+  const queryFor = async (type: string) =>
+    (await placementNotifications[type].prepareQuery!({
+      lastSent: '2026-01-01',
+      lastSentDate: new Date('2026-01-01'),
+      clickhouse: undefined,
+    })) as string;
+
+  it('sends the paid type for paid rows only', async () => {
+    // Without this the paid message goes out for a free submission quoting
+    // "for 0 Buzz", and a creator who turned the free type off still gets one.
+    expect(await queryFor('remix-gallery-pending')).toContain('AND NOT p.free');
+  });
+
+  it('sends the free type for free rows only', async () => {
+    const query = await queryFor('remix-gallery-free-pending');
+    expect(query).toMatch(/AND p\.free\b/);
+    expect(query).not.toContain('AND NOT p.free');
+  });
+
+  it('honours the free type’s own toggle, which the paid ones do not have', async () => {
+    // A row in `UserNotificationSettings` means opted OUT. The paid types carry
+    // no such clause at all, so their toggles render and change nothing — this
+    // one is wired, and that difference is the point of giving free its own type.
+    expect(await queryFor('remix-gallery-free-pending')).toContain(
+      'NOT EXISTS (SELECT 1 FROM "UserNotificationSettings"'
+    );
+    expect(placementNotifications['remix-gallery-free-pending'].optIn).toBeFalsy();
+  });
+
+  it('quotes no amount on a free submission', async () => {
+    // A free row's `amount` is 0 and the DB enforces it, so any wording built
+    // around a number here would tell a creator they are being offered 0 Buzz.
+    const message = placementNotifications['remix-gallery-free-pending'].prepareMessage({
+      details: { placementId: 5, imageId: 74, placerId: 52, placerUsername: 'someone' },
+    });
+
+    expect(message!.message).toContain('someone');
+    expect(message!.message).not.toMatch(/buzz|\d/i);
+    expect(message!.url).toBe('/images/74');
+  });
+});

--- a/src/server/notifications/__tests__/placement.free-pending.test.ts
+++ b/src/server/notifications/__tests__/placement.free-pending.test.ts
@@ -27,6 +27,11 @@ describe('remix gallery pending notifications', () => {
     const query = await queryFor('remix-gallery-free-pending');
     expect(query).toMatch(/AND p\.free\b/);
     expect(query).not.toContain('AND NOT p.free');
+    // `AND p.free\b` alone survives widening to `AND p.free IS NOT NULL`, which
+    // is true of every row — the column is NOT NULL — so the free notification
+    // would fire for every pending submission, paid ones included, under a
+    // toggle their owner never opted into.
+    expect(query).not.toContain('IS NOT NULL');
   });
 
   it.each(['remix-gallery-pending', 'remix-gallery-free-pending'])(
@@ -39,6 +44,7 @@ describe('remix gallery pending notifications', () => {
       // Asserted per type rather than once, because the two toggles are separate
       // switches: silencing free submissions must not silence the paid queue a
       // creator is being paid for.
+      //
       // Pinned as ONE whole clause rather than by prefix. A prefix match stays
       // green if the recipient column drifts to `p."placerId"` — silencing the
       // submitter's setting instead of the owner's — or if the type string is

--- a/src/server/notifications/__tests__/placement.free-pending.test.ts
+++ b/src/server/notifications/__tests__/placement.free-pending.test.ts
@@ -29,15 +29,27 @@ describe('remix gallery pending notifications', () => {
     expect(query).not.toContain('AND NOT p.free');
   });
 
-  it('honours the free type’s own toggle, which the paid ones do not have', async () => {
-    // A row in `UserNotificationSettings` means opted OUT. The paid types carry
-    // no such clause at all, so their toggles render and change nothing — this
-    // one is wired, and that difference is the point of giving free its own type.
-    expect(await queryFor('remix-gallery-free-pending')).toContain(
-      'NOT EXISTS (SELECT 1 FROM "UserNotificationSettings"'
-    );
-    expect(placementNotifications['remix-gallery-free-pending'].optIn).toBeFalsy();
-  });
+  it.each(['remix-gallery-pending', 'remix-gallery-free-pending'])(
+    '%s honours its own toggle',
+    async (type) => {
+      // A row in `UserNotificationSettings` means opted OUT, and there is no
+      // global filter — a processor without this clause renders a setting that
+      // saves and does nothing, which is what the paid type did until now.
+      //
+      // Asserted per type rather than once, because the two toggles are separate
+      // switches: silencing free submissions must not silence the paid queue a
+      // creator is being paid for.
+      // Pinned as ONE whole clause rather than by prefix. A prefix match stays
+      // green if the recipient column drifts to `p."placerId"` — silencing the
+      // submitter's setting instead of the owner's — or if the type string is
+      // copy-pasted from its sibling, which mutes the wrong toggle. Both are the
+      // realistic edits here, and neither changes the prefix.
+      expect(await queryFor(type)).toContain(
+        `NOT EXISTS (SELECT 1 FROM "UserNotificationSettings" WHERE "userId" = p."ownerId" AND type = '${type}')`
+      );
+      expect(placementNotifications[type].optIn).toBeFalsy();
+    }
+  );
 
   it('quotes no amount on a free submission', async () => {
     // A free row's `amount` is 0 and the DB enforces it, so any wording built

--- a/src/server/notifications/placement.notifications.ts
+++ b/src/server/notifications/placement.notifications.ts
@@ -178,12 +178,10 @@ export const placementNotifications = createNotificationProcessor({
           -- processor that honours its own toggle writes this clause itself. It
           -- was missing here, so the setting rendered, saved, and did nothing.
           --
-          -- Scoped inside the CTE against p."ownerId" rather than outside it
-          -- against the projected "userId", which is where the sticker types put
-          -- theirs. Both are correct where they sit and they are NOT
-          -- interchangeable by inspection — do not harmonise one into the other
-          -- without checking what each is in scope of. On one line either way:
-          -- the polarity guard matches the clause as a literal.
+          -- Inside the CTE and against p."ownerId", which is the recipient; the
+          -- projected "userId" outside the CTE is the same value and would work
+          -- there too. Kept on one line either way, because the polarity guard
+          -- matches the clause as a literal.
           AND NOT EXISTS (SELECT 1 FROM "UserNotificationSettings" WHERE "userId" = p."ownerId" AND type = 'remix-gallery-pending')
       )
       SELECT
@@ -234,8 +232,9 @@ export const placementNotifications = createNotificationProcessor({
           AND p.status = 'pending'
           AND p.free
           AND p."createdAt" > '${lastSent}'
-          -- A row here means opted OUT. The paid types above carry no such
-          -- clause, so their toggles render and do nothing; this one is wired.
+          -- A row here means opted OUT, and its own type rather than the paid
+          -- one's: silencing free submissions must not silence the queue a
+          -- creator is being paid for.
           AND NOT EXISTS (SELECT 1 FROM "UserNotificationSettings" WHERE "userId" = p."ownerId" AND type = 'remix-gallery-free-pending')
       )
       SELECT

--- a/src/server/notifications/placement.notifications.ts
+++ b/src/server/notifications/placement.notifications.ts
@@ -165,6 +165,10 @@ export const placementNotifications = createNotificationProcessor({
         WHERE p.surface = 'remixGallery'
           AND p."targetType" = 'image'
           AND p.status = 'pending'
+          -- Free submissions are their own type, with their own toggle. Excluded
+          -- here rather than left to fall through both: this message quotes an
+          -- amount, and a free row's amount is 0.
+          AND NOT p.free
           -- Stamped by holdPlacementEscrow. Its absence means the row exists but
           -- the escrow has not been attempted, and a notification landing in that
           -- gap sends someone to review a submission about to be unwound.
@@ -175,6 +179,58 @@ export const placementNotifications = createNotificationProcessor({
         CONCAT('remix-gallery-pending:',"placementId") "key",
         "userId",
         'remix-gallery-pending' "type",
+        details
+      FROM data
+    `,
+  },
+
+  /**
+   * The free tier's own type, so a creator can take one stream and not the other.
+   *
+   * Separate rather than a branch inside the paid message, because the two are
+   * different offers: the paid one quotes Buzz and the free one spends one of the
+   * creator's own slots and pays them nothing until they accept. A creator who
+   * wants only paid submissions announced has no way to say so if both arrive
+   * under one type.
+   *
+   * `expiresAt` is not checked here. It gates the paid types because
+   * `holdPlacementEscrow` stamps it in a second statement, so its absence means
+   * the escrow has not been attempted yet; a free row is written with its
+   * deadline by the same INSERT, so there is no such gap to wait out.
+   */
+  'remix-gallery-free-pending': {
+    displayName: 'Free remix awaiting your review',
+    category: NotificationCategory.Creator,
+    prepareMessage: ({ details }) => ({
+      message: `${details.placerUsername} submitted a free remix to your gallery`,
+      url: `/images/${details.imageId}`,
+    }),
+    prepareQuery: async ({ lastSent }) => `
+      WITH data AS (
+        SELECT
+          p."ownerId" "userId",
+          p.id "placementId",
+          jsonb_build_object(
+            'placementId', p.id,
+            'imageId', p."targetId",
+            'placerId', p."placerId",
+            'placerUsername', u.username
+          ) as "details"
+        FROM "Placement" p
+        JOIN "User" u ON u.id = p."placerId"
+        WHERE p.surface = 'remixGallery'
+          AND p."targetType" = 'image'
+          AND p.status = 'pending'
+          AND p.free
+          AND p."createdAt" > '${lastSent}'
+          -- A row here means opted OUT. The paid types above carry no such
+          -- clause, so their toggles render and do nothing; this one is wired.
+          AND NOT EXISTS (SELECT 1 FROM "UserNotificationSettings" WHERE "userId" = p."ownerId" AND type = 'remix-gallery-free-pending')
+      )
+      SELECT
+        CONCAT('remix-gallery-free-pending:',"placementId") "key",
+        "userId",
+        'remix-gallery-free-pending' "type",
         details
       FROM data
     `,

--- a/src/server/notifications/placement.notifications.ts
+++ b/src/server/notifications/placement.notifications.ts
@@ -174,6 +174,17 @@ export const placementNotifications = createNotificationProcessor({
           -- gap sends someone to review a submission about to be unwound.
           AND p."expiresAt" IS NOT NULL
           AND p."createdAt" > '${lastSent}'
+          -- A row means opted OUT, and there is no global filter — every
+          -- processor that honours its own toggle writes this clause itself. It
+          -- was missing here, so the setting rendered, saved, and did nothing.
+          --
+          -- Scoped inside the CTE against p."ownerId" rather than outside it
+          -- against the projected "userId", which is where the sticker types put
+          -- theirs. Both are correct where they sit and they are NOT
+          -- interchangeable by inspection — do not harmonise one into the other
+          -- without checking what each is in scope of. On one line either way:
+          -- the polarity guard matches the clause as a literal.
+          AND NOT EXISTS (SELECT 1 FROM "UserNotificationSettings" WHERE "userId" = p."ownerId" AND type = 'remix-gallery-pending')
       )
       SELECT
         CONCAT('remix-gallery-pending:',"placementId") "key",

--- a/src/server/routers/__tests__/placement.router.spend-type.test.ts
+++ b/src/server/routers/__tests__/placement.router.spend-type.test.ts
@@ -109,4 +109,48 @@ describe('placement router — the charged currency is the domain’s', () => {
       expect.objectContaining({ spendType: 'green' })
     );
   });
+
+  /**
+   * The same shape as the currency above, and higher stakes.
+   *
+   * `createFreePlacement` takes `placerId` as a plain number and cannot tell
+   * where it came from, and every check below it — the daily allowance, the
+   * never-twice rule, self-placement — is *about* that id rather than a check
+   * *of* it. So a router reading it off the payload would let anyone spend
+   * someone else's free placement and submit under their account, with nothing
+   * downstream raising.
+   *
+   * Two independent things keep that true — the schema has no `placerId`, so zod
+   * strips it, and `...input` spreads before the session id — and this asserts
+   * the outcome rather than either mechanism. Measured: breaking one alone does
+   * not fail it, because the other still holds; adding `placerId` to the schema
+   * AND flipping the spread order does.
+   */
+  it('takes placerId from the session even when the client sends its own', async () => {
+    await callerOn(false).submitToRemixGallery({
+      hostImageId: 11,
+      imageId: 12,
+      free: true,
+      placerId: PLACER + 1,
+    } as never);
+
+    expect(createRemixGallerySubmission).toHaveBeenCalledWith(
+      expect.objectContaining({ placerId: PLACER, free: true })
+    );
+  });
+
+  it('defaults a submission to paid when the client says nothing', async () => {
+    // The free path is asked for, never assumed: a client cached from before the
+    // free tier existed must keep paying rather than start spending an allowance
+    // it does not know it has.
+    await callerOn(false).submitToRemixGallery({
+      hostImageId: 11,
+      imageId: 12,
+      expectedPrice: 100,
+    } as never);
+
+    expect(createRemixGallerySubmission).toHaveBeenCalledWith(
+      expect.objectContaining({ free: false })
+    );
+  });
 });

--- a/src/server/routers/placement.router.ts
+++ b/src/server/routers/placement.router.ts
@@ -11,6 +11,7 @@ import {
   getPendingRemixGallerySubmissionsSchema,
   getPendingStickerPlacementsSchema,
   getRemixGallerySchema,
+  getRemixGalleryFreeEligibilitySchema,
   getRemixGalleryVisibilitySchema,
   getStickerPlacementDetailSchema,
   getStickerPlacementsSchema,
@@ -61,6 +62,7 @@ import {
   getMyRemixGallerySubmissions,
   getPendingRemixGallerySubmissions,
   getRemixGallery,
+  getRemixGalleryFreeEligibility,
   getRemixGalleryVisibility,
   retractRemixGallerySubmission,
   setRemixGalleryPins,
@@ -402,10 +404,25 @@ export const placementRouter = router({
       assertRemixGalleryEnabled(ctx);
       return createRemixGallerySubmission({
         ...input,
+        // From the session, never the input. `createFreePlacement` takes this as
+        // a plain number and cannot tell where it came from, and every check
+        // downstream is *about* this id rather than a check *of* it — so a
+        // client-supplied one would spend someone else's daily allowance and
+        // submit under their account with nothing raising. `...input` spreads
+        // first, so no client value can survive this line.
         placerId: ctx.user.id,
         spendType: domainSpendType(ctx.features),
       });
     }),
+
+  /**
+   * The free option's inputs, for the submit card. A listing: everything it
+   * returns is stale by the time it renders, and the refusals live on the
+   * mutation.
+   */
+  getRemixGalleryFreeEligibility: protectedProcedure
+    .input(getRemixGalleryFreeEligibilitySchema)
+    .query(({ input, ctx }) => getRemixGalleryFreeEligibility({ ...input, placerId: ctx.user.id })),
 
   /**
    * Not flag-gated, for the same reason `actOnStickers` isn't: turning the flag

--- a/src/server/schema/__tests__/submit-to-remix-gallery.schema.test.ts
+++ b/src/server/schema/__tests__/submit-to-remix-gallery.schema.test.ts
@@ -1,5 +1,36 @@
 import { describe, expect, it } from 'vitest';
-import { submitToRemixGallerySchema } from '~/server/schema/placement.schema';
+import {
+  getRemixGalleryFreeEligibilitySchema,
+  submitToRemixGallerySchema,
+} from '~/server/schema/placement.schema';
+
+describe('getRemixGalleryFreeEligibilitySchema', () => {
+  it('bounds the candidate list', () => {
+    // The only ceiling on the work: the service runs a jsonb containment test
+    // per row, so the cap is what stops one request probing an arbitrary slice
+    // of somebody's library. It is a claim the service's own docstring makes
+    // about this file, and nothing asserted it.
+    const ids = Array.from({ length: 201 }, (_, index) => index + 1);
+
+    expect(
+      getRemixGalleryFreeEligibilitySchema.safeParse({ hostImageId: 1, imageIds: ids }).success
+    ).toBe(false);
+    expect(
+      getRemixGalleryFreeEligibilitySchema.safeParse({
+        hostImageId: 1,
+        imageIds: ids.slice(0, 200),
+      }).success
+    ).toBe(true);
+  });
+
+  it('accepts the empty list the picker opens with', () => {
+    // Nothing selected is the modal's first render, and the service answers it
+    // without a query at all. A minimum here would make that state an error.
+    expect(
+      getRemixGalleryFreeEligibilitySchema.safeParse({ hostImageId: 1, imageIds: [] }).success
+    ).toBe(true);
+  });
+});
 
 /**
  * The submission contract, at the boundary where a client's payload becomes an

--- a/src/server/schema/__tests__/submit-to-remix-gallery.schema.test.ts
+++ b/src/server/schema/__tests__/submit-to-remix-gallery.schema.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { submitToRemixGallerySchema } from '~/server/schema/placement.schema';
+
+/**
+ * The submission contract, at the boundary where a client's payload becomes an
+ * argument.
+ *
+ * Two things below the schema depend on it and neither can check it: the service
+ * reads a missing `expectedPrice` as "the submitter agreed to whatever the price
+ * is now", and `createFreePlacement` takes `placerId` as a plain number it
+ * cannot trace to a session.
+ */
+describe('submitToRemixGallerySchema', () => {
+  const paid = { hostImageId: 11, imageId: 12, expectedPrice: 100 };
+
+  it('defaults a submission to paid', () => {
+    // Asked for, never assumed. A client cached from before the free tier must
+    // keep paying rather than start spending an allowance it does not know it
+    // has.
+    expect(submitToRemixGallerySchema.parse(paid).free).toBe(false);
+  });
+
+  it('requires the price a paid submission was shown', () => {
+    // The consent check. Without it the service charges whatever the price is at
+    // the moment of the click, which is the spend-without-consent case
+    // `expectedPrice` exists to prevent — and an owner can move their price at
+    // any time.
+    const result = submitToRemixGallerySchema.safeParse({ hostImageId: 11, imageId: 12 });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0].path).toEqual(['expectedPrice']);
+  });
+
+  it('lets a free submission omit the price it is not paying', () => {
+    const result = submitToRemixGallerySchema.safeParse({
+      hostImageId: 11,
+      imageId: 12,
+      free: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.expectedPrice).toBeUndefined();
+  });
+
+  it('strips a client-supplied placerId rather than carrying it', () => {
+    // 🔴 The half of the placerId defence that lives in this file. The router
+    // spreads `...input` before the session id, so both would have to break for
+    // a client value to survive — but a `placerId` accepted here is one of the
+    // two, and nothing downstream would catch it: every check in
+    // `createFreePlacement` is *about* that id rather than a check *of* it.
+    const parsed = submitToRemixGallerySchema.parse({ ...paid, placerId: 999 });
+
+    expect(parsed).not.toHaveProperty('placerId');
+  });
+});

--- a/src/server/schema/placement.schema.ts
+++ b/src/server/schema/placement.schema.ts
@@ -197,17 +197,53 @@ export const getRemixGalleryVisibilitySchema = z.object({
   browsingLevel: z.number().min(0).default(allBrowsingLevelsFlag),
 });
 
-export const submitToRemixGallerySchema = z.object({
+export const submitToRemixGallerySchema = z
+  .object({
+    hostImageId: z.number().int().positive(),
+    imageId: z.number().int().positive(),
+    /**
+     * The price the submitter was shown. Refused if the owner has moved it since,
+     * rather than silently charging the new one — the client can only check
+     * affordability against the number it rendered, so without this an owner
+     * raising their price between the modal opening and the button being pressed
+     * is charged without consent.
+     *
+     * Optional only because a free submission has no price to agree to. The
+     * refinement below still requires it on the paid path, so this cannot become
+     * a route to submitting without one.
+     */
+    expectedPrice: z.number().int().min(0).optional(),
+    /**
+     * Spend the daily free placement instead of Buzz. The server decides whether
+     * that is allowed — the remix must be one it resolved as derived from the
+     * host, and the creator must have a slot free — so this asks rather than
+     * asserts. `placerId` is never taken from here; it comes from the session.
+     */
+    free: z.boolean().default(false),
+  })
+  .superRefine((input, ctx) => {
+    // Without this, omitting `expectedPrice` on a paid submission reaches the
+    // service as `undefined`, which it reads as "the submitter agreed to
+    // whatever it is now" — the exact consent hole the field exists to close.
+    if (!input.free && input.expectedPrice == null)
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['expectedPrice'],
+        message: 'A paid submission has to carry the price it was shown',
+      });
+  });
+
+/**
+ * What the submit card needs to offer the free option, for the candidates it has
+ * already loaded.
+ *
+ * Bounded to one page of the picker rather than taking the viewer's whole
+ * library: the verification is a jsonb containment test per row, and answering
+ * it for every image someone has ever posted is a scan nobody asked for.
+ */
+export const getRemixGalleryFreeEligibilitySchema = z.object({
   hostImageId: z.number().int().positive(),
-  imageId: z.number().int().positive(),
-  /**
-   * The price the submitter was shown. Refused if the owner has moved it since,
-   * rather than silently charging the new one — the client can only check
-   * affordability against the number it rendered, so without this an owner
-   * raising their price between the modal opening and the button being pressed
-   * is charged without consent.
-   */
-  expectedPrice: z.number().int().min(0),
+  imageIds: z.array(z.number().int().positive()).max(200),
 });
 
 export const actOnRemixGallerySubmissionSchema = z.object({

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -143,6 +143,7 @@ const {
   parseGalleryCursor,
   getRemixGallery,
   getRemixGalleryVisibility,
+  getRemixGalleryFreeEligibility,
   getPendingRemixGallerySubmissions,
   declineOutOfBandRemixGallerySubmissions,
 } = await import('~/server/services/remix-gallery.service');
@@ -1826,6 +1827,151 @@ describe('free submissions', () => {
     primeQueries({ submission: verifiedSubmission });
 
     await expect(submitFree({ expectedPrice: PRICE + 1 })).resolves.toEqual({ id: FREE_PLACEMENT });
+  });
+});
+
+describe('what the public visibility query says about free capacity', () => {
+  const visibility = (viewerId?: number) => {
+    // One row satisfying every raw read this path makes. The host has to come
+    // back SHOWABLE: an unresolvable host fails closed, which would make the
+    // withheld cases below pass for the wrong reason.
+    queryRaw.mockImplementation(async () => [
+      { exists: false, count: 0, nsfwLevel: NsfwLevel.PG, minor: false, showable: true },
+    ]);
+    return getRemixGalleryVisibility({
+      hostImageId: HOST_IMAGE,
+      browsingLevel: allBrowsingLevelsFlag,
+      viewerId,
+      domainLevels: allBrowsingLevelsFlag,
+    });
+  };
+
+  it('publishes what the creator accepts', async () => {
+    // Their own setting on their own image, the same standing as `price`, and
+    // the only half a signed-out viewer needs: whether free is a thing here.
+    await expect(visibility()).resolves.toMatchObject({ freeSlots: openSpace.freeSlots });
+  });
+
+  it.each([
+    ['signed out', undefined],
+    ['the owner', OWNER],
+  ] as const)('withholds how many are currently HELD from %s', async (_who, viewerId) => {
+    // A count of pending and approved submissions on someone's image — the same
+    // fact `pendingCount` is owner-only to protect. Public, it would let anyone
+    // watch a creator's queue fill by polling an id.
+    await expect(visibility(viewerId)).resolves.toMatchObject({ freeSlotsRemaining: null });
+  });
+
+  it('gives it to the one viewer who has to act on it', async () => {
+    await expect(visibility(PLACER)).resolves.toMatchObject({
+      freeSlotsRemaining: openSpace.freeSlotsRemaining,
+    });
+  });
+
+  it('withholds it on a closed gallery even from a would-be submitter', async () => {
+    resolvePlacementSpaceFor.mockResolvedValue({ ...openSpace, mode: 'off' });
+    await expect(visibility(PLACER)).resolves.toMatchObject({ freeSlotsRemaining: null });
+  });
+});
+
+describe('the free eligibility listing', () => {
+  // Nested `Prisma.sql` fragments arrive as VALUES rather than as part of the
+  // template's string array, so flattening is what makes the assertions below
+  // see the predicate at all. Same helper as the ceiling suite above, and the
+  // same reason: a rendered template does not read like the source.
+  const flatten = (value: unknown): string => {
+    if (Array.isArray(value)) return value.map(flatten).join(' ');
+    if (value && typeof value === 'object' && 'strings' in value)
+      return [
+        flatten((value as { strings: unknown }).strings),
+        flatten((value as { values?: unknown }).values ?? []),
+      ].join(' ');
+    return typeof value === 'string' ? value : '';
+  };
+
+  const boundValues = (value: unknown): unknown[] => {
+    if (Array.isArray(value)) return value.flatMap(boundValues);
+    if (value && typeof value === 'object' && 'strings' in value)
+      return boundValues((value as { values?: unknown }).values ?? []);
+    return [value];
+  };
+
+  const eligibility = () =>
+    getRemixGalleryFreeEligibility({
+      hostImageId: HOST_IMAGE,
+      placerId: PLACER,
+      imageIds: [REMIX_IMAGE],
+    });
+
+  beforeEach(() => queryRaw.mockResolvedValue([{ id: REMIX_IMAGE }]));
+
+  it('answers only for the viewer’s OWN images', async () => {
+    // The predicate this asserts is the whole reason the endpoint is not an
+    // oracle: without it, anyone could ask whether any image was generated from
+    // any other, which is a fact about someone else's generation inputs. Delete
+    // it and nothing else in this file notices.
+    await eligibility();
+
+    const sql = queryRaw.mock.calls.map(flatten).join(' ');
+    expect(sql).toContain('i."userId" =');
+    expect(boundValues(queryRaw.mock.calls)).toContain(PLACER);
+  });
+
+  it('reads derivation through the shared expression, not a containment test', async () => {
+    // `@>` on the raw JSON is NOT the same predicate — scalar containment is
+    // equality, so a non-array value would read as a match where this yields an
+    // empty array, and an array of strings goes the other way. The picker must
+    // offer exactly what the claim accepts, so both go through one expression.
+    await eligibility();
+
+    const sql = queryRaw.mock.calls.map(flatten).join(' ');
+    expect(sql).toContain('jsonb_array_elements');
+    expect(sql).toMatch(/jsonb_typeof\([\s\S]*'array'/);
+    expect(sql).toContain('= ANY(');
+    expect(sql).not.toContain('@>');
+    expect(boundValues(queryRaw.mock.calls)).toContain(HOST_IMAGE);
+  });
+
+  it('runs no query at all for an empty candidate list', async () => {
+    // `IN ()` is a syntax error, not an empty result, so the short-circuit is
+    // load-bearing rather than an optimisation — and the picker asks with
+    // nothing selected on every open.
+    const result = await getRemixGalleryFreeEligibility({
+      hostImageId: HOST_IMAGE,
+      placerId: PLACER,
+      imageIds: [],
+    });
+
+    expect(queryRaw).not.toHaveBeenCalled();
+    expect(result.verifiedImageIds).toEqual([]);
+  });
+
+  it('carries the allowance and the never-twice answer through unchanged', async () => {
+    getFreePlacementAllowance.mockResolvedValue({
+      used: 1,
+      remaining: 0,
+      resetsAt: new Date('2026-03-04'),
+    });
+    hasUsedFreePlacementOn.mockResolvedValue(true);
+
+    await expect(eligibility()).resolves.toEqual({
+      allowance: { used: 1, remaining: 0, resetsAt: new Date('2026-03-04') },
+      usedHere: true,
+      verifiedImageIds: [REMIX_IMAGE],
+    });
+  });
+
+  it('asks the never-twice question about THIS surface and THIS host', async () => {
+    // Free is scoped per surface and per target. Widen either and a placer who
+    // stickered an image is told they cannot submit a remix to it.
+    await eligibility();
+
+    expect(hasUsedFreePlacementOn).toHaveBeenCalledWith({
+      placerId: PLACER,
+      surface: 'remixGallery',
+      targetType: 'image',
+      targetId: HOST_IMAGE,
+    });
   });
 });
 

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -144,6 +144,7 @@ const {
   getRemixGallery,
   getRemixGalleryVisibility,
   getRemixGalleryFreeEligibility,
+  getMyRemixGallerySubmissions,
   getPendingRemixGallerySubmissions,
   declineOutOfBandRemixGallerySubmissions,
 } = await import('~/server/services/remix-gallery.service');
@@ -1966,6 +1967,48 @@ describe('what the owner’s review queue says a free submission is worth', () =
     expect(row.earnings).toMatchObject({ approve: expect.any(Number) });
     expect(row.earnings!.approve).toBeGreaterThan(0);
     expect(row.earnings!.decline).toBeGreaterThan(0);
+  });
+});
+
+describe('every read that carries a Buzz figure also carries `free`', () => {
+  /**
+   * The sweep, as a test rather than as a grep someone ran once.
+   *
+   * `amount` is 0 on a free row by DB constraint, so any consumer that renders
+   * it without knowing the row is free shows "0 Buzz" — and the copy around it
+   * ("your Buzz is on its way back") is false outright. The owner queue was
+   * found by review; these two were found by sweeping, and nothing would have
+   * caught them otherwise.
+   *
+   * A new read that returns `amount` and not `free` belongs in this list.
+   */
+  it('the submitter’s own submissions list', async () => {
+    placementFindMany.mockResolvedValue([]);
+    await getMyRemixGallerySubmissions({
+      placerId: PLACER,
+      domainLevels: allBrowsingLevelsFlag,
+      viewerLevels: allBrowsingLevelsFlag,
+    });
+
+    const select = placementFindMany.mock.calls[0][0].select;
+    expect(select).toMatchObject({ amount: true, free: true });
+  });
+
+  it('the submitter’s pending rows on the image detail card', async () => {
+    queryRaw.mockImplementation(async () => [
+      { exists: false, count: 0, nsfwLevel: NsfwLevel.PG, minor: false, showable: true },
+    ]);
+    placementFindMany.mockResolvedValue([]);
+
+    await getRemixGalleryVisibility({
+      hostImageId: HOST_IMAGE,
+      browsingLevel: allBrowsingLevelsFlag,
+      viewerId: PLACER,
+      domainLevels: allBrowsingLevelsFlag,
+    });
+
+    const call = placementFindMany.mock.calls.find((args) => args[0]?.select?.amount);
+    expect(call?.[0].select).toMatchObject({ amount: true, free: true });
   });
 });
 

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NsfwLevel } from '~/server/common/enums';
 import {
   allBrowsingLevelsFlag,
@@ -1970,18 +1970,33 @@ describe('what the owner’s review queue says a free submission is worth', () =
   });
 });
 
-describe('every read that carries a Buzz figure also carries `free`', () => {
-  /**
-   * The sweep, as a test rather than as a grep someone ran once.
-   *
-   * `amount` is 0 on a free row by DB constraint, so any consumer that renders
-   * it without knowing the row is free shows "0 Buzz" — and the copy around it
-   * ("your Buzz is on its way back") is false outright. The owner queue was
-   * found by review; these two were found by sweeping, and nothing would have
-   * caught them otherwise.
-   *
-   * A new read that returns `amount` and not `free` belongs in this list.
-   */
+/**
+ * 🔴 Every `placement.findMany` ANY test in this file makes, checked after it
+ * runs: if the select asks for `amount`, it must also ask for `free`.
+ *
+ * `amount` is 0 on a free row by DB constraint, so a consumer that renders it
+ * without knowing the row is free shows "0 Buzz" — and the copy around it ("your
+ * Buzz is on its way back") is false outright. The owner queue was found by
+ * review; two more were found only by sweeping.
+ *
+ * An `afterEach` rather than one `it` per named function, and the difference is
+ * the point: a per-function test retires the worry for the functions somebody
+ * remembered to list, and a third select added tomorrow is looked at by neither.
+ * It also has to loop rather than `.find(...)` — first-match-wins would skip a
+ * second amount-carrying select inside the SAME function and stay green, which
+ * is this repo's catalogued hazard reproduced inside the guard written to close
+ * a sweep.
+ *
+ * ⚠️ What it still cannot see: a read no test in this file exercises. It is a
+ * guard over exercised reads, not over the service.
+ */
+afterEach(() => {
+  for (const [args] of placementFindMany.mock.calls as { select?: Record<string, unknown> }[][])
+    if (args?.select?.amount)
+      expect(args.select.free, 'a read carrying `amount` must also carry `free`').toBe(true);
+});
+
+describe('the reads a Buzz figure is rendered from', () => {
   it('the submitter’s own submissions list', async () => {
     placementFindMany.mockResolvedValue([]);
     await getMyRemixGallerySubmissions({
@@ -1990,8 +2005,7 @@ describe('every read that carries a Buzz figure also carries `free`', () => {
       viewerLevels: allBrowsingLevelsFlag,
     });
 
-    const select = placementFindMany.mock.calls[0][0].select;
-    expect(select).toMatchObject({ amount: true, free: true });
+    expect(placementFindMany).toHaveBeenCalled();
   });
 
   it('the submitter’s pending rows on the image detail card', async () => {
@@ -2007,8 +2021,7 @@ describe('every read that carries a Buzz figure also carries `free`', () => {
       domainLevels: allBrowsingLevelsFlag,
     });
 
-    const call = placementFindMany.mock.calls.find((args) => args[0]?.select?.amount);
-    expect(call?.[0].select).toMatchObject({ amount: true, free: true });
+    expect(placementFindMany).toHaveBeenCalled();
   });
 });
 

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -23,6 +23,7 @@ const STRANGER = 63;
 const HOST_IMAGE = 74;
 const REMIX_IMAGE = 85;
 const PLACEMENT = 96;
+const FREE_PLACEMENT = 107;
 const PRICE = 700;
 
 const holdPlacementEscrow = vi.fn(async () => ({ fee: 210, principal: 490 }));
@@ -50,6 +51,26 @@ vi.mock('~/server/services/placement-moderation.service', () => ({ assertCanPlac
 const rewardApply = vi.fn(async () => undefined);
 vi.mock('~/server/rewards/active/remixAccept.reward', () => ({
   remixAcceptReward: { apply: rewardApply },
+}));
+
+/**
+ * The free claim is the boundary this file tests against, not through. It owns
+ * an advisory-locked transaction and every refusal the paid path makes, all of
+ * which are `free-placement.service`'s own tests to keep — what matters here is
+ * that the free branch delegates to it with the right target instead of building
+ * a row of its own.
+ */
+const createFreePlacement = vi.fn(async () => ({ id: FREE_PLACEMENT }));
+const getFreePlacementAllowance = vi.fn(async () => ({
+  used: 0,
+  remaining: 1,
+  resetsAt: new Date('2026-01-02'),
+}));
+const hasUsedFreePlacementOn = vi.fn(async () => false);
+vi.mock('~/server/services/free-placement.service', () => ({
+  createFreePlacement,
+  getFreePlacementAllowance,
+  hasUsedFreePlacementOn,
 }));
 
 const resolvePlacementSpaceFor = vi.fn();
@@ -175,7 +196,15 @@ const openSpace = {
   setPrice: PRICE,
   price: PRICE,
   cap: 1000,
+  freeSlots: 2,
+  freeSlotsRemaining: 1,
   settings: {},
+};
+
+/** A submission the server itself resolved as derived from the host image. */
+const verifiedSubmission: SubmissionFixture = {
+  ...goodSubmission,
+  sourceImageIds: [HOST_IMAGE],
 };
 
 /**
@@ -213,6 +242,8 @@ beforeEach(() => {
   placementCount.mockResolvedValue(0);
   placementFindFirst.mockResolvedValue(null);
   settlePlacement.mockResolvedValue({ settled: true });
+  createFreePlacement.mockResolvedValue({ id: FREE_PLACEMENT });
+  hasUsedFreePlacementOn.mockResolvedValue(false);
   holdPlacementEscrow.mockImplementation(async () => {
     calls.push('hold');
     return { fee: 210, principal: 490 };
@@ -1650,5 +1681,210 @@ describe('declining everything out of band', () => {
     ).rejects.toThrow();
 
     expect(settlePlacement).not.toHaveBeenCalled();
+  });
+});
+
+describe('free submissions', () => {
+  const submitFree = (over: Partial<Parameters<typeof createRemixGallerySubmission>[0]> = {}) =>
+    submit({ free: true, ...over });
+
+  it('refuses a remix the server did not resolve as derived from the host', async () => {
+    // The gate the whole surface rests on. `sourceImageIds` is empty on the
+    // default fixture, which is what an off-site remix looks like — a real remix
+    // carrying no signal, which is why the refusal names paying as the
+    // alternative rather than calling it not a remix.
+    await expect(submitFree()).rejects.toThrow(/made from this image on-site/i);
+    expect(createFreePlacement).not.toHaveBeenCalled();
+    expect(placementCreate).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the host is not among the inputs, only some other image', async () => {
+    // Derivation is membership, not "this generation had inputs at all". A remix
+    // built entirely from someone else's image would otherwise buy a free slot
+    // in a queue it has nothing to do with.
+    primeQueries({ submission: { ...goodSubmission, sourceImageIds: [STRANGER] } });
+    await expect(submitFree()).rejects.toThrow(/made from this image on-site/i);
+    expect(createFreePlacement).not.toHaveBeenCalled();
+  });
+
+  it('claims through the free primitive rather than writing its own row', async () => {
+    primeQueries({ submission: verifiedSubmission });
+
+    const result = await submitFree();
+
+    expect(result).toEqual({ id: FREE_PLACEMENT });
+    // No row of its own and no escrow: the three refusals the free tier adds
+    // have to hold together under the claim's lock, in the same transaction as
+    // its insert, and a row built here would be a second creation route.
+    expect(placementCreate).not.toHaveBeenCalled();
+    expect(holdPlacementEscrow).not.toHaveBeenCalled();
+
+    expect(createFreePlacement).toHaveBeenCalledWith({
+      surface: 'remixGallery',
+      targetType: 'image',
+      targetId: HOST_IMAGE,
+      placerId: PLACER,
+      data: { imageId: REMIX_IMAGE, remixOfId: null, derivedFromHost: true },
+    });
+  });
+
+  it('hands the claim the host image, never the submitted one', async () => {
+    // Both ids are in scope at the call site and swapping them is a one-token
+    // edit that type-checks: the placement would land on the submitter's own
+    // image, attributed to themselves, holding a slot on the wrong creator.
+    primeQueries({ submission: verifiedSubmission });
+    await submitFree();
+
+    const claim = createFreePlacement.mock.calls[0][0] as { targetId: number; placerId: number };
+    expect(claim.targetId).toBe(HOST_IMAGE);
+    expect(claim.targetId).not.toBe(REMIX_IMAGE);
+    expect(claim.placerId).toBe(PLACER);
+  });
+
+  it('does not let a free submission skip the one-per-gallery duplicate check', async () => {
+    // `createFreePlacement` bounds free rows per placer and per target, which is
+    // a different question from "is this picture already in this gallery" — a
+    // paid entry followed by a free one would otherwise put the same image in
+    // twice and defeat the rotation.
+    primeQueries({ submission: verifiedSubmission });
+    placementFindFirst.mockResolvedValue({ id: 1 });
+
+    await expect(submitFree()).rejects.toThrow(/already in this gallery/i);
+    expect(createFreePlacement).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['off', /not accepting/i],
+    ['auto', /need review/i],
+  ] as const)('refuses a free submission to a %s gallery', async (mode, message) => {
+    primeQueries({ submission: verifiedSubmission });
+    resolvePlacementSpaceFor.mockResolvedValue({ ...openSpace, mode });
+
+    await expect(submitFree()).rejects.toThrow(message);
+    expect(createFreePlacement).not.toHaveBeenCalled();
+  });
+
+  it('refuses a free submission to your own gallery', async () => {
+    primeQueries({ submission: verifiedSubmission });
+    resolvePlacementSpaceFor.mockResolvedValue({ ...openSpace, ownerId: PLACER });
+
+    await expect(submitFree()).rejects.toThrow(/your own gallery/i);
+    expect(createFreePlacement).not.toHaveBeenCalled();
+  });
+
+  it('applies every content rule to a free submission', async () => {
+    // Free is placement that costs no Buzz, not a lighter kind of placement.
+    // These are the checks a free path is most tempting to skip, because nobody
+    // is being charged for the refusal.
+    resolvePlacementSpaceFor.mockResolvedValue({ ...openSpace, settings: { contentRule: 'any' } });
+    primeQueries({ submission: { ...verifiedSubmission, tosViolation: true } });
+    await expect(submitFree()).rejects.toThrow(/cannot be submitted/i);
+
+    resolvePlacementSpaceFor.mockResolvedValue(openSpace);
+    primeQueries({ submission: { ...verifiedSubmission, nsfwLevel: NsfwLevel.XXX } });
+    await expect(submitFree()).rejects.toThrow(/rating/i);
+
+    primeQueries({ submission: verifiedSubmission, hostShowable: false });
+    await expect(submitFree()).rejects.toThrow(/cannot show a gallery/i);
+
+    expect(createFreePlacement).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['unpriced', null],
+    ['priced below the floor', 10],
+  ] as const)('accepts a free submission to a %s gallery', async (_label, price) => {
+    // The price is the PAID path's spam gate — nothing verifies that a paid
+    // submission is really a remix. A free one is gated on the server having
+    // verified exactly that, so refusing it over a price it does not pay would
+    // refuse it for a reason that does not apply.
+    primeQueries({ submission: verifiedSubmission });
+    resolvePlacementSpaceFor.mockResolvedValue({ ...openSpace, price, setPrice: price });
+
+    await expect(submitFree()).resolves.toEqual({ id: FREE_PLACEMENT });
+    expect(createFreePlacement).toHaveBeenCalledTimes(1);
+  });
+
+  it('still refuses a PAID submission to those same galleries', async () => {
+    // The other half of the pair above, which would also pass if the price
+    // checks had been deleted rather than moved onto the paid path.
+    // Re-primed between the two, because the raw-query fake answers by call
+    // index: without it the second submission reads the host row as its
+    // submission and fails on the wrong thing entirely.
+    primeQueries();
+    resolvePlacementSpaceFor.mockResolvedValue({ ...openSpace, price: null, setPrice: null });
+    await expect(submit()).rejects.toThrow(/has not set a price/i);
+
+    primeQueries();
+    resolvePlacementSpaceFor.mockResolvedValue({ ...openSpace, price: 10, setPrice: 10 });
+    await expect(submit()).rejects.toThrow(/not priced for submissions/i);
+  });
+
+  it('ignores expectedPrice on the free path instead of refusing on it', async () => {
+    // A client that keeps sending the price it rendered must not have a stale
+    // one turn a free submission into a refusal about money it is not spending.
+    primeQueries({ submission: verifiedSubmission });
+
+    await expect(submitFree({ expectedPrice: PRICE + 1 })).resolves.toEqual({ id: FREE_PLACEMENT });
+  });
+});
+
+describe('the removal cooldown on a free entry', () => {
+  const approvedAt = new Date(Date.now() - 60 * 60 * 1000);
+
+  const arrangeApproved = (free: boolean) =>
+    placementFindUnique.mockResolvedValue({
+      id: PLACEMENT,
+      ownerId: OWNER,
+      placerId: PLACER,
+      targetId: HOST_IMAGE,
+      amount: free ? 0 : PRICE,
+      status: 'approved',
+      surface: 'remixGallery',
+      free,
+      data: { imageId: REMIX_IMAGE },
+      resolvedAt: approvedAt,
+      createdAt: approvedAt,
+    });
+
+  it('keeps the full week on a free entry, exactly as on a paid one', async () => {
+    // Justin's call, and asserted rather than assumed because both agents who
+    // looked at it recommended waiving it. Accepting a free remix therefore also
+    // holds one of the creator's free slots for the whole week — intended, not
+    // an oversight.
+    for (const free of [true, false]) {
+      arrangeApproved(free);
+      await expect(
+        actOnRemixGallerySubmission({ placementId: PLACEMENT, action: 'remove', userId: OWNER })
+      ).rejects.toThrow(/can be removed from/i);
+    }
+    expect(placementUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it('does not tell a creator that someone paid for a free entry', async () => {
+    // The copy is the whole change here, so it is the thing asserted. Left
+    // alone, the refusal justifies the week with a payment that never happened.
+    arrangeApproved(true);
+    await expect(
+      actOnRemixGallerySubmission({ placementId: PLACEMENT, action: 'remove', userId: OWNER })
+    ).rejects.toThrow(/week-long commitment/i);
+
+    arrangeApproved(false);
+    await expect(
+      actOnRemixGallerySubmission({ placementId: PLACEMENT, action: 'remove', userId: OWNER })
+    ).rejects.toThrow(/someone paid/i);
+  });
+
+  it('lets a moderator take a free entry down inside the week', async () => {
+    arrangeApproved(true);
+    placementUpdateMany.mockResolvedValue({ count: 1 });
+    await expect(
+      actOnRemixGallerySubmission({
+        placementId: PLACEMENT,
+        action: 'remove',
+        userId: STRANGER,
+        isModerator: true,
+      })
+    ).resolves.toMatchObject({ removed: true });
   });
 });

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -261,6 +261,36 @@ const submit = (over: Partial<Parameters<typeof createRemixGallerySubmission>[0]
     ...over,
   });
 
+/**
+ * The SQL a raw query actually carries, as one string.
+ *
+ * Nested `Prisma.sql` fragments arrive as VALUES rather than as part of the
+ * template's string array, so flattening is what makes an assertion see a
+ * predicate that lives inside a fragment at all.
+ *
+ * At module scope because two suites need it and both encode the same guess
+ * about Prisma's internals — `strings` and `values` on a fragment. When that
+ * shape changes, one copy gets fixed and the other keeps passing over SQL it can
+ * no longer read.
+ */
+const flatten = (value: unknown): string => {
+  if (Array.isArray(value)) return value.map(flatten).join(' ');
+  if (value && typeof value === 'object' && 'strings' in value)
+    return [
+      flatten((value as { strings: unknown }).strings),
+      flatten((value as { values?: unknown }).values ?? []),
+    ].join(' ');
+  return typeof value === 'string' ? value : '';
+};
+
+/** The bound parameters, which `flatten` drops — it keeps only strings. */
+const boundValues = (value: unknown): unknown[] => {
+  if (Array.isArray(value)) return value.flatMap(boundValues);
+  if (value && typeof value === 'object' && 'strings' in value)
+    return boundValues((value as { values?: unknown }).values ?? []);
+  return [value];
+};
+
 describe('content level rules', () => {
   it('refuses an unrated submission under BOTH rules', () => {
     // The one that reads like an edge case and is not: 0 means unscanned, not
@@ -492,20 +522,6 @@ describe('the ceiling is applied on read, not only on the mutation', () => {
   // from a read query and every other test in this file still passes, while
   // entries approved before a host was flagged keep rendering — and the owner
   // cannot take them down for a week.
-  //
-  // Nested `Prisma.sql` fragments arrive as VALUES rather than as part of the
-  // template's string array, so flattening them is what makes this see the
-  // predicate at all.
-  const flatten = (value: unknown): string => {
-    if (Array.isArray(value)) return value.map(flatten).join(' ');
-    if (value && typeof value === 'object' && 'strings' in value)
-      return [
-        flatten((value as { strings: unknown }).strings),
-        flatten((value as { values?: unknown }).values ?? []),
-      ].join(' ');
-    return typeof value === 'string' ? value : '';
-  };
-
   const sqlFrom = () => queryRaw.mock.calls.map(flatten).join(' ');
 
   /**
@@ -1875,27 +1891,6 @@ describe('what the public visibility query says about free capacity', () => {
 });
 
 describe('the free eligibility listing', () => {
-  // Nested `Prisma.sql` fragments arrive as VALUES rather than as part of the
-  // template's string array, so flattening is what makes the assertions below
-  // see the predicate at all. Same helper as the ceiling suite above, and the
-  // same reason: a rendered template does not read like the source.
-  const flatten = (value: unknown): string => {
-    if (Array.isArray(value)) return value.map(flatten).join(' ');
-    if (value && typeof value === 'object' && 'strings' in value)
-      return [
-        flatten((value as { strings: unknown }).strings),
-        flatten((value as { values?: unknown }).values ?? []),
-      ].join(' ');
-    return typeof value === 'string' ? value : '';
-  };
-
-  const boundValues = (value: unknown): unknown[] => {
-    if (Array.isArray(value)) return value.flatMap(boundValues);
-    if (value && typeof value === 'object' && 'strings' in value)
-      return boundValues((value as { values?: unknown }).values ?? []);
-    return [value];
-  };
-
   const eligibility = () =>
     getRemixGalleryFreeEligibility({
       hostImageId: HOST_IMAGE,
@@ -1930,6 +1925,24 @@ describe('the free eligibility listing', () => {
     expect(sql).toContain('= ANY(');
     expect(sql).not.toContain('@>');
     expect(boundValues(queryRaw.mock.calls)).toContain(HOST_IMAGE);
+  });
+
+  it('asks only about the candidates it was given', async () => {
+    // The `IN` list is the only thing bounding the work: a jsonb containment
+    // test runs per row, so without it the query answers for every image the
+    // placer owns. Delete the clause and the `userId` scope still holds — this
+    // is about cost and about answering a question nobody asked, not a leak.
+    await getRemixGalleryFreeEligibility({
+      hostImageId: HOST_IMAGE,
+      placerId: PLACER,
+      imageIds: [REMIX_IMAGE, REMIX_IMAGE + 1],
+    });
+
+    const sql = queryRaw.mock.calls.map(flatten).join(' ');
+    expect(sql).toContain('i.id IN (');
+    expect(boundValues(queryRaw.mock.calls)).toEqual(
+      expect.arrayContaining([REMIX_IMAGE, REMIX_IMAGE + 1])
+    );
   });
 
   it('runs no query at all for an empty candidate list', async () => {

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -1890,6 +1890,85 @@ describe('what the public visibility query says about free capacity', () => {
   });
 });
 
+describe('what the owner’s review queue says a free submission is worth', () => {
+  const queueRow = (free: boolean) => ({
+    id: PLACEMENT,
+    targetId: HOST_IMAGE,
+    placerId: PLACER,
+    amount: free ? 0 : PRICE,
+    free,
+    data: { imageId: REMIX_IMAGE },
+    createdAt: new Date('2026-01-01'),
+    expiresAt: new Date('2026-01-03'),
+    placer: { id: PLACER, username: 'someone', image: null },
+  });
+
+  const queue = async (free: boolean) => {
+    // The listable-ids query first, then the images fetch; the rows come from
+    // `findMany`, which is a separate mock.
+    let call = 0;
+    queryRaw.mockImplementation(async () => {
+      call += 1;
+      if (call === 1) return [{ id: PLACEMENT, createdAt: new Date('2026-01-01') }];
+      return [
+        {
+          id: REMIX_IMAGE,
+          url: 'a',
+          width: 1,
+          height: 1,
+          type: 'image',
+          metadata: {},
+          nsfwLevel: 1,
+        },
+        {
+          id: HOST_IMAGE,
+          url: 'b',
+          width: 1,
+          height: 1,
+          type: 'image',
+          metadata: {},
+          nsfwLevel: 1,
+        },
+      ];
+    });
+    placementFindMany.mockResolvedValue([queueRow(free)]);
+
+    const { items } = await getPendingRemixGallerySubmissions({
+      ownerId: OWNER,
+      domainLevels: allBrowsingLevelsFlag,
+      viewerLevels: allBrowsingLevelsFlag,
+    });
+    return items[0];
+  };
+
+  it('selects `free`, so the queue can tell the two kinds apart at all', async () => {
+    await queue(true);
+
+    // Omitted from the select, the client cannot branch however it renders — and
+    // the row would show as a paid one with its earnings missing.
+    expect(placementFindMany.mock.calls[0][0].select).toMatchObject({ free: true });
+  });
+
+  it('quotes no earnings on a free row, rather than quoting zero', async () => {
+    // 🔴 Both numbers derive from `amount`, and a free row's is 0 by DB
+    // constraint. Rendered, that is "+0 Buzz" on Approve AND Decline: the
+    // decision surface for the whole free tier telling a creator they earn
+    // nothing, on a row the free notification just called a gift.
+    const row = await queue(true);
+
+    expect(row.free).toBe(true);
+    expect(row.earnings).toBeNull();
+  });
+
+  it('still quotes both numbers on a paid row', async () => {
+    const row = await queue(false);
+
+    expect(row.earnings).toMatchObject({ approve: expect.any(Number) });
+    expect(row.earnings!.approve).toBeGreaterThan(0);
+    expect(row.earnings!.decline).toBeGreaterThan(0);
+  });
+});
+
 describe('the free eligibility listing', () => {
   const eligibility = () =>
     getRemixGalleryFreeEligibility({
@@ -1943,6 +2022,26 @@ describe('the free eligibility listing', () => {
     expect(boundValues(queryRaw.mock.calls)).toEqual(
       expect.arrayContaining([REMIX_IMAGE, REMIX_IMAGE + 1])
     );
+  });
+
+  it('scopes to the SESSION placer, never a caller-supplied one', async () => {
+    // Same two-mechanism defence as the submit path — the schema has no
+    // `placerId` and the router passes `ctx.user.id` — and the same reason it is
+    // asserted at the outcome: this endpoint answers a question about somebody's
+    // generation inputs, so a caller-chosen id would read another user's
+    // library. The submit path had this test; this one did not.
+    await getRemixGalleryFreeEligibility({
+      hostImageId: HOST_IMAGE,
+      placerId: PLACER,
+      imageIds: [REMIX_IMAGE],
+    });
+
+    expect(boundValues(queryRaw.mock.calls)).toContain(PLACER);
+    expect(boundValues(queryRaw.mock.calls)).not.toContain(STRANGER);
+    expect(hasUsedFreePlacementOn).toHaveBeenCalledWith(
+      expect.objectContaining({ placerId: PLACER })
+    );
+    expect(getFreePlacementAllowance).toHaveBeenCalledWith({ placerId: PLACER });
   });
 
   it('runs no query at all for an empty candidate list', async () => {

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -2005,6 +2005,10 @@ describe('the reads a Buzz figure is rendered from', () => {
       viewerLevels: allBrowsingLevelsFlag,
     });
 
+    // The real assertion is the `afterEach` above, which inspects every select
+    // this call made. This only proves the read happened, so the hook has
+    // something to inspect — deleting it as pointless removes the guard's
+    // anchor with nothing turning red.
     expect(placementFindMany).toHaveBeenCalled();
   });
 
@@ -2021,6 +2025,7 @@ describe('the reads a Buzz figure is rendered from', () => {
       domainLevels: allBrowsingLevelsFlag,
     });
 
+    // Same as above: the `afterEach` holds the assertion. This is the anchor.
     expect(placementFindMany).toHaveBeenCalled();
   });
 });

--- a/src/server/services/remix-gallery.service.ts
+++ b/src/server/services/remix-gallery.service.ts
@@ -7,6 +7,11 @@ import { dbRead, dbWrite } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
 import { remixAcceptReward } from '~/server/rewards/active/remixAccept.reward';
 import { getAllImages } from '~/server/services/image.service';
+import {
+  createFreePlacement,
+  getFreePlacementAllowance,
+  hasUsedFreePlacementOn,
+} from '~/server/services/free-placement.service';
 import { holdPlacementEscrow, settlePlacement } from '~/server/services/placement-escrow.service';
 import { assertCanPlace } from '~/server/services/placement-moderation.service';
 import { getPlacementConfig } from '~/server/services/placement.service';
@@ -123,12 +128,32 @@ export type CreateRemixGallerySubmission = {
   /** What the submitter was shown. Refused if the owner has moved it since. */
   expectedPrice?: number;
   /**
+   * Spend the placer's daily free placement instead of Buzz. Allowed only for a
+   * remix this server itself resolved as derived from the host image.
+   */
+  free?: boolean;
+  /**
    * The domain's currency, decided at the router from the request's own feature
    * flags rather than anything the client sends — a client-supplied currency
    * would let a request on one domain spend the other's Buzz.
    */
   spendType: BuzzSpendType;
 };
+
+/**
+ * Why an unverified remix cannot be submitted free.
+ *
+ * Names the alternative rather than only the refusal: paying is what buys a slot
+ * in someone's review queue when the server cannot tell that the submission came
+ * from their image, and a bare "not eligible" reads as a bug on a remix the
+ * submitter knows they made.
+ *
+ * It does not say the submission "is not a remix" — an off-site remix is a real
+ * remix that carries no signal, and calling it otherwise is both wrong and an
+ * accusation.
+ */
+const FREE_NEEDS_VERIFIED_REFUSAL =
+  'remix gallery: free submissions are for remixes made from this image on-site, which is something we can check. Submit this one with Buzz instead.';
 
 /**
  * Submits an image into someone's remix gallery, charging the owner's price.
@@ -141,13 +166,15 @@ export type CreateRemixGallerySubmission = {
  * settle also fails.
  *
  * Nothing here consumes an inventory item; unlike a sticker, the thing being
- * placed is content the submitter already owns.
+ * placed is content the submitter already owns. That is also why the free path
+ * below has no unwind: there is no second write to fail after the row exists.
  */
 export async function createRemixGallerySubmission({
   placerId,
   hostImageId,
   imageId,
   expectedPrice,
+  free = false,
   spendType,
 }: CreateRemixGallerySubmission) {
   if (hostImageId === imageId)
@@ -169,26 +196,6 @@ export async function createRemixGallerySubmission({
 
   if (space.ownerId === placerId)
     throw throwBadRequestError('remix gallery: you cannot submit to your own gallery');
-
-  if (space.price == null)
-    throw throwBadRequestError('remix gallery: this creator has not set a price yet');
-
-  // `setPlacementSpace` refuses to write a price below the floor, but it lets an
-  // existing lower one be carried, so a row predating the rule still reads back
-  // here — and the floor is the only spam gate this surface has, since nothing
-  // verifies a submission is really a remix. Refused rather than rounded up:
-  // charging more than the number the submitter was shown is the thing
-  // `expectedPrice` below exists to prevent.
-  if (space.price < PLACEMENT_SURFACES[SURFACE].serverMinPrice)
-    throw throwBadRequestError('remix gallery: this gallery is not priced for submissions');
-
-  // Refused rather than charged. The client can only check affordability against
-  // the number it rendered, so charging a price the submitter never saw is a
-  // spend without consent — and an owner can move their price at any time.
-  if (expectedPrice != null && expectedPrice !== space.price)
-    throw throwBadRequestError(
-      `remix gallery: the price changed to ${space.price} Buzz while you were deciding`
-    );
 
   const submission = await loadSubmissionImage(imageId);
   if (submission.userId !== placerId)
@@ -226,6 +233,75 @@ export async function createRemixGallerySubmission({
         : "remix gallery: this creator only accepts submissions rated at or below their image's rating"
     );
 
+  // The server's own answer, from ids `sanitizeProvenance` wrote — a submitter
+  // cannot assert this by editing their image's meta. It is what the free path
+  // is gated on, so where it comes from decides whether that gate is real.
+  const derivedFromHost = submission.sourceImageIds?.includes(hostImageId) ?? false;
+
+  // Refused here, on the mutation, and deliberately not only by hiding the free
+  // option: a listing that filters is not a mutation that refuses, and this one
+  // decides whether someone gets into a creator's review queue without paying.
+  if (free && !derivedFromHost) throw throwBadRequestError(FREE_NEEDS_VERIFIED_REFUSAL);
+
+  const data = {
+    imageId,
+    remixOfId: submission.remixOfId,
+    // Present only when the server itself resolved this host image as an input
+    // to the generation. Left off rather than set false: "made elsewhere" and
+    // "no signal" are the same state, and the owner-review UI must keep saying
+    // nothing about either.
+    ...(derivedFromHost ? { derivedFromHost: true } : {}),
+  } satisfies RemixGalleryPlacementData;
+
+  // Before the branch, so a free submission cannot occupy a second slot of the
+  // same gallery with the same picture — `createFreePlacement` bounds free rows
+  // per placer and per target, which is a different question from this one.
+  await assertNotAlreadySubmitted({ hostImageId, imageId });
+
+  // Every remaining refusal — mode, self-placement, `assertCanPlace`, the
+  // per-owner pending cap — is made by `createFreePlacement` under its lock, in
+  // the same transaction as the insert. Repeating them here would be a second
+  // creation route with the checks bolted on the outside.
+  //
+  // No settle afterwards, and that is checked rather than assumed: `auto` is
+  // refused for this surface where a space is stored (`placementSpaceSchema`),
+  // where a submission is made (above), and by `createFreePlacement` itself
+  // against `allowedModes`. So a free submission here is always pending and
+  // always the owner's to answer.
+  if (free)
+    return createFreePlacement({
+      surface: SURFACE,
+      targetType: TARGET_TYPE,
+      targetId: hostImageId,
+      placerId,
+      data,
+    });
+
+  // Every rule from here down is the paid path's, which is why none of them is
+  // reached above. The floor in particular exists because the price is this
+  // surface's only spam gate — nothing verifies that a *paid* submission is
+  // really a remix — and a free one is gated on the server having verified
+  // exactly that, plus the creator's slots and the placer's daily allowance.
+  // Refusing a free submission because a legacy row is priced at 40 would refuse
+  // it for a reason that does not apply to it.
+  if (space.price == null)
+    throw throwBadRequestError('remix gallery: this creator has not set a price yet');
+
+  // `setPlacementSpace` refuses to write a price below the floor, but it lets an
+  // existing lower one be carried, so a row predating the rule still reads back
+  // here. Refused rather than rounded up: charging more than the number the
+  // submitter was shown is the thing `expectedPrice` exists to prevent.
+  if (space.price < PLACEMENT_SURFACES[SURFACE].serverMinPrice)
+    throw throwBadRequestError('remix gallery: this gallery is not priced for submissions');
+
+  // Refused rather than charged. The client can only check affordability against
+  // the number it rendered, so charging a price the submitter never saw is a
+  // spend without consent — and an owner can move their price at any time.
+  if (expectedPrice != null && expectedPrice !== space.price)
+    throw throwBadRequestError(
+      `remix gallery: the price changed to ${space.price} Buzz while you were deciding`
+    );
+
   await assertCanPlace({ ownerId: space.ownerId, placerId });
 
   const pending = await dbWrite.placement.count({
@@ -235,8 +311,6 @@ export async function createRemixGallerySubmission({
     throw throwBadRequestError(
       'remix gallery: you already have the maximum submissions waiting with this creator'
     );
-
-  await assertNotAlreadySubmitted({ hostImageId, imageId });
 
   const placement = await dbWrite.placement.create({
     data: {
@@ -250,15 +324,7 @@ export async function createRemixGallerySubmission({
       sellerId: null,
       amount: space.price,
       status: 'pending',
-      data: {
-        imageId,
-        remixOfId: submission.remixOfId,
-        // Present only when the server itself resolved this host image as an
-        // input to the generation. Left off rather than set false: "made
-        // elsewhere" and "no signal" are the same state, and the owner-review
-        // UI must keep saying nothing about either.
-        ...(submission.sourceImageIds?.includes(hostImageId) ? { derivedFromHost: true } : {}),
-      } satisfies RemixGalleryPlacementData,
+      data,
     },
     select: { id: true },
   });
@@ -339,6 +405,7 @@ export async function actOnRemixGallerySubmission({
       amount: true,
       status: true,
       surface: true,
+      free: true,
       data: true,
       resolvedAt: true,
       createdAt: true,
@@ -400,7 +467,17 @@ export async function actOnRemixGallerySubmission({
       const removableAt = remixGalleryRemovableAt(placement.resolvedAt ?? placement.createdAt);
       if (removableAt > new Date())
         throw throwBadRequestError(
-          `remix gallery: this entry can be removed from ${removableAt.toISOString()}. Someone paid to be featured here, so it stays up for a week after you approve it.`
+          `remix gallery: this entry can be removed from ${removableAt.toISOString()}. ${
+            // The week itself is unchanged for a free entry — Justin's call, so
+            // the two paths cannot differ on how long an approval binds. Only the
+            // reason differs: nothing was paid, so the copy cannot say it was.
+            // Note what this costs, because it is intended rather than an
+            // oversight: an approved free entry holds one of the creator's free
+            // slots for the whole week too.
+            placement.free
+              ? 'Accepting a remix is a week-long commitment either way, so it stays up for a week after you approve it.'
+              : 'Someone paid to be featured here, so it stays up for a week after you approve it.'
+          }`
         );
     }
 
@@ -1356,11 +1433,81 @@ export async function getRemixGalleryVisibility({
     ownerId: space.ownerId,
     ownerUsername: owner?.username ?? null,
     ownerShare: space.ownerShare,
+    // Both, because `freeSlotsRemaining: 0` means two different things: the
+    // resolver short-circuits the reservation count at zero capacity, so it
+    // covers "this creator takes no free submissions" as well as "all of them
+    // are currently held". `freeSlots === 0` separates them, and the two states
+    // need different copy — one is a setting, the other is a queue.
+    //
+    // Already resolved by the call above, so exposing them costs nothing on a
+    // query every image-detail view runs. Display only: the refusal lives in
+    // `createFreePlacement`, under its lock.
+    freeSlots: space.freeSlots,
+    freeSlotsRemaining: space.freeSlotsRemaining,
     declineFee,
     pendingCount,
     viewerPending,
     maxSubmissionLevel,
     acceptedMaxLevel,
+  };
+}
+
+/**
+ * Where the viewer stands on submitting to this gallery for free.
+ *
+ * **Every number here is a listing.** The allowance, the slot count and the
+ * verification are all stale the moment they return, and the refusals live in
+ * `createRemixGallerySubmission` and `createFreePlacement`. This exists so the
+ * submit card can offer the free option and say what it costs, not so anything
+ * can be decided on it — a control that defaults to free has to survive losing
+ * the race for the last slot.
+ *
+ * Scoped to `imageIds` the picker has already loaded rather than sweeping the
+ * viewer's library: a submitter with tens of thousands of images would otherwise
+ * pay for a containment scan over all of them to render one badge.
+ *
+ * And scoped to the viewer's **own** images, which is not only about relevance:
+ * answering "was this image generated from that one" for arbitrary ids would
+ * turn the endpoint into an oracle for other people's generation inputs.
+ */
+export async function getRemixGalleryFreeEligibility({
+  hostImageId,
+  placerId,
+  imageIds,
+}: {
+  hostImageId: number;
+  placerId: number;
+  /** The candidates on screen. Bounded by the schema. */
+  imageIds: number[];
+}) {
+  const [allowance, usedHere, verified] = await Promise.all([
+    getFreePlacementAllowance({ placerId }),
+    hasUsedFreePlacementOn({
+      placerId,
+      surface: SURFACE,
+      targetType: TARGET_TYPE,
+      targetId: hostImageId,
+    }),
+    imageIds.length
+      ? dbRead.$queryRaw<{ id: number }[]>`
+          SELECT i.id
+          FROM "Image" i
+          WHERE i.id IN (${Prisma.join(imageIds)})
+            AND i."userId" = ${placerId}
+            -- The same fact the mutation gates on, read the same way: ids that
+            -- sanitizeProvenance wrote after verifying a signed token or the
+            -- workflow itself. A submitter editing their own image's meta cannot
+            -- put one here, which is what makes the free gate mean anything.
+            AND (i.meta -> 'extra' -> 'sourceImageIds') @> ${String(hostImageId)}::jsonb
+        `
+      : [],
+  ]);
+
+  return {
+    allowance,
+    /** Free is once per gallery per placer, ever — not once per day. */
+    usedHere,
+    verifiedImageIds: verified.map((row) => row.id),
   };
 }
 

--- a/src/server/services/remix-gallery.service.ts
+++ b/src/server/services/remix-gallery.service.ts
@@ -64,6 +64,37 @@ type SubmissionImage = {
 };
 
 /**
+ * The ids the server verified this image was generated from.
+ *
+ * One definition, used by the mutation that decides and by the listing that
+ * offers — because "is this a remix of that" has to mean the same thing in both
+ * or the picker offers what the claim refuses.
+ *
+ * ⚠️ Not interchangeable with a bare `@>` containment test on the raw JSON, which
+ * is what a second copy naturally becomes. `'7'::jsonb @> '7'::jsonb` is true
+ * (scalar containment is equality), so a non-array value would read as a match
+ * where this yields `[]`; an array of strings goes the other way, matching here
+ * after the cast and not there. They agree today only because
+ * `sanitizeProvenance` happens to write an integer array.
+ *
+ * Parameterised by alias rather than written twice, for the reason `hostIsMinor`
+ * is: a hand-written duplicate is exactly the shape that drifts silently.
+ */
+const sourceImageIdsSql = (alias = 'i') => {
+  const t = Prisma.raw(`"${alias}"`);
+  return Prisma.sql`ARRAY(
+    SELECT (value #>> '{}')::int
+    FROM jsonb_array_elements(
+      CASE
+        WHEN jsonb_typeof(${t}.meta -> 'extra' -> 'sourceImageIds') = 'array'
+        THEN ${t}.meta -> 'extra' -> 'sourceImageIds'
+        ELSE '[]'::jsonb
+      END
+    )
+  )`;
+};
+
+/**
  * The submitted image, from the primary, with everything the refusals need.
  *
  * `dbWrite` rather than a replica for the same reason `assertCanPlace` uses it:
@@ -76,16 +107,7 @@ async function loadSubmissionImage(imageId: number): Promise<SubmissionImage> {
            i.ingestion::text AS ingestion, i."needsReview",
            p."publishedAt",
            (i.meta -> 'extra' ->> 'remixOfId')::int AS "remixOfId",
-           ARRAY(
-             SELECT (value #>> '{}')::int
-             FROM jsonb_array_elements(
-               CASE
-                 WHEN jsonb_typeof(i.meta -> 'extra' -> 'sourceImageIds') = 'array'
-                 THEN i.meta -> 'extra' -> 'sourceImageIds'
-                 ELSE '[]'::jsonb
-               END
-             )
-           ) AS "sourceImageIds"
+           ${sourceImageIdsSql()} AS "sourceImageIds"
     FROM "Image" i
     LEFT JOIN "Post" p ON p.id = i."postId"
     WHERE i.id = ${imageId}
@@ -1433,17 +1455,23 @@ export async function getRemixGalleryVisibility({
     ownerId: space.ownerId,
     ownerUsername: owner?.username ?? null,
     ownerShare: space.ownerShare,
-    // Both, because `freeSlotsRemaining: 0` means two different things: the
-    // resolver short-circuits the reservation count at zero capacity, so it
-    // covers "this creator takes no free submissions" as well as "all of them
-    // are currently held". `freeSlots === 0` separates them, and the two states
-    // need different copy — one is a setting, the other is a queue.
-    //
-    // Already resolved by the call above, so exposing them costs nothing on a
-    // query every image-detail view runs. Display only: the refusal lives in
-    // `createFreePlacement`, under its lock.
+    // What the creator accepts is theirs to publish — it is a setting on their
+    // own image, the same standing as `price`.
     freeSlots: space.freeSlots,
-    freeSlotsRemaining: space.freeSlotsRemaining,
+    // How many are currently *held* is not. It is a count of pending and
+    // approved submissions on someone's image, which is the fact `pendingCount`
+    // above is owner-only to protect — a public number here would let anyone
+    // watch a creator's queue fill by polling an id.
+    //
+    // Withheld under the same rule as `maxSubmissionLevel`: signed in, gallery
+    // open, not your own. That is exactly the case the submit card needs, and
+    // nothing wider. `freeSlots` alone still tells a signed-out viewer whether
+    // the creator takes free submissions at all.
+    //
+    // Both are needed together because `freeSlotsRemaining: 0` means two things
+    // — the resolver short-circuits the reservation count at zero capacity — and
+    // the two need different copy: one is a setting, the other is a queue.
+    freeSlotsRemaining: canSubmitHere ? space.freeSlotsRemaining : null,
     declineFee,
     pendingCount,
     viewerPending,
@@ -1494,11 +1522,12 @@ export async function getRemixGalleryFreeEligibility({
           FROM "Image" i
           WHERE i.id IN (${Prisma.join(imageIds)})
             AND i."userId" = ${placerId}
-            -- The same fact the mutation gates on, read the same way: ids that
+            -- The same fact the mutation gates on, through the same expression
+            -- rather than a second reading of the same JSON: ids that
             -- sanitizeProvenance wrote after verifying a signed token or the
             -- workflow itself. A submitter editing their own image's meta cannot
             -- put one here, which is what makes the free gate mean anything.
-            AND (i.meta -> 'extra' -> 'sourceImageIds') @> ${String(hostImageId)}::jsonb
+            AND ${hostImageId} = ANY(${sourceImageIdsSql()})
         `
       : [],
   ]);

--- a/src/server/services/remix-gallery.service.ts
+++ b/src/server/services/remix-gallery.service.ts
@@ -1611,6 +1611,12 @@ export async function getPendingRemixGallerySubmissions({
       targetId: true,
       placerId: true,
       amount: true,
+      // Without it the queue cannot tell a free submission from a paid one, and
+      // the earnings below — both computed from `amount`, which a free row
+      // pins at 0 — render as "+0 Buzz" on approve AND decline. That is the
+      // decision surface for the whole free tier telling a creator they earn
+      // nothing, on the same row the free notification told them was a gift.
+      free: true,
       data: true,
       createdAt: true,
       expiresAt: true,
@@ -1674,16 +1680,24 @@ export async function getPendingRemixGallerySubmissions({
           viewerLevels
         ),
         targetImage: toQueueImage(byId.get(row.targetId), domainLevels, viewerLevels),
-        earnings: {
-          approve: splitPlacementPayment({
-            amount: row.amount,
-            outcome: 'approved',
-            declineFeeRate,
-            sellerShare: shares.seller,
-            platformShare: shares.platform,
-          }).toOwner,
-          decline: declineFeeAmount(row.amount, declineFeeRate),
-        },
+        // `null` on a free row rather than the zeroes the arithmetic produces.
+        // Nothing was paid in, so there is no split and no decline fee — and a
+        // "+0 Buzz" chip does not say that, it says this creator earns nothing
+        // for accepting, which is both false in spirit and about to be false in
+        // fact once the accept reward lands. The absence is what lets the queue
+        // render something else instead of a number.
+        earnings: row.free
+          ? null
+          : {
+              approve: splitPlacementPayment({
+                amount: row.amount,
+                outcome: 'approved',
+                declineFeeRate,
+                sellerShare: shares.seller,
+                platformShare: shares.platform,
+              }).toOwner,
+              decline: declineFeeAmount(row.amount, declineFeeRate),
+            },
       }))
       // Both halves, for the same reason: the owner cannot judge a remix they
       // cannot see, and cannot judge it against a host that no longer renders.

--- a/src/server/services/remix-gallery.service.ts
+++ b/src/server/services/remix-gallery.service.ts
@@ -1252,7 +1252,7 @@ async function getViewerPendingSubmissions({
       placerId: viewerId,
       status: 'pending',
     },
-    select: { id: true, amount: true, data: true, createdAt: true, expiresAt: true },
+    select: { id: true, amount: true, free: true, data: true, createdAt: true, expiresAt: true },
     orderBy: { createdAt: 'asc' },
     take: REMIX_GALLERY_MAX_PENDING_PER_OWNER,
   });
@@ -1271,6 +1271,7 @@ async function getViewerPendingSubmissions({
   return entries.map((row) => ({
     placementId: row.id,
     amount: row.amount,
+    free: row.free,
     createdAt: row.createdAt,
     expiresAt: row.expiresAt,
     image: toQueueImage(
@@ -1737,6 +1738,10 @@ export async function getMyRemixGallerySubmissions({
       ownerId: true,
       status: true,
       amount: true,
+      // The submitter's side of the same problem the owner queue had: `amount`
+      // is 0 on a free row, so without this every Buzz figure and every "your
+      // Buzz is on its way back" renders about money that never moved.
+      free: true,
       data: true,
       createdAt: true,
       expiresAt: true,


### PR DESCRIPTION
PR 4 of the free placements project. Base is `feat/free-placements`, **not** `main`.

Free submissions into a remix gallery, for remixes the server itself resolved as derived from the host image. The paid path is unchanged.

## The gate rests on provenance, not on a field name

`derivedFromHost` is set when `submission.sourceImageIds?.includes(hostImageId)`, and the whole free tier on this surface is gated on it — so whether it is forgeable decides whether the gate means anything. It is not, and the reason is worth writing down because the obvious reading points the other way:

- `sourceImageIds` lives in image meta, and orchestrator workflow metadata **is** client-writable (`orchestrator.updateWorkflow` / `patch` take arbitrary metadata). That is what bit remix provenance in #3871.
- It was hardened. `sanitizeProvenance` (`remix-provenance.ts:277`) strips any client-authored `sourceImageIds`/`provenance` at the write sinks and puts back only ids proved by a signed AES-GCM token or a server-side workflow read. `createImage` (`image.service.ts:6199`) applies it unconditionally.

So the next person to touch this should know the gate rests on `sanitizeProvenance` staying unconditional at every image write sink, not on the field looking server-set.

## A free submission is correctly pending, and no settle is needed

Checked rather than assumed. `auto` is refused for this surface in three independent places:

1. `placement.schema.ts` — `placementSpaceSchema.superRefine` refuses a mode outside `allowedModes` where a space is stored.
2. `remix-gallery.service.ts` — `space.mode !== 'review'` on the submission path.
3. `free-placement.service.ts` — `createFreePlacement` refuses `off` and any mode outside `allowedModes` on the acting side, so even a legacy row storing `auto` is refused before a row exists.

`PLACEMENT_SURFACES.remixGallery.allowedModes` is `['off', 'review']`. A free remix submission is therefore always pending and always the owner's to answer, and the call site correctly does not settle.

## The removal cooldown keeps its full week

Justin's call, relayed by ryan, and applied identically on the sticker surface. Both agents who looked at it independently recommended waiving it — the cooldown is justified by "someone paid to place it", which is false for a free row — and he chose to keep the week and fix only the wording.

**Surfacing the cost, because it is now intended rather than an oversight:** an approved free entry holds one of the creator's free slots for the entire week too, so a creator who accepts one and regrets it cannot free the slot either. If free slot counts start feeling too small in practice, this is the first mechanism to look at.

The copy is fixed: a free entry's refusal now says accepting is a week-long commitment either way, instead of claiming a payment that never happened.

## Everything else the free path does and does not do

- **Delegates the claim.** `createFreePlacement` owns mode, self-placement, `assertCanPlace`, the per-owner pending cap, the daily allowance, the never-twice rule and the slot count — all under its two advisory locks in the same transaction as the insert. Re-implementing any of them here would be a second creation route with the checks bolted on the outside.
- **Keeps the one-per-gallery duplicate check**, which runs before the branch. `createFreePlacement` bounds free rows per placer and per target, which is a different question from "is this picture already in this gallery".
- **Skips the price checks.** They move onto the paid path. The price is that path's only spam gate — nothing verifies a *paid* submission is really a remix — and the free path is gated on the server having verified exactly that, plus slots and the daily allowance. Refusing a free submission because a legacy row is priced at 40 would refuse it for a reason that does not apply. The paid path still refuses both cases, and there is a test asserting that, so this cannot be read as the checks having been deleted.
- **`placerId` comes from `ctx.user.id`**, after the `...input` spread, and the schema has no such field. Both mechanisms are asserted at the router.

## Free/paid selection

A segmented control in the submit card, defaulting to free whenever a slot is available and the remix is verified. The free option carries the mode (`Free · needs review`) and a line stating the daily allowance is spent even on a decline — the last moment the submitter can change their mind.

The decision itself is a pure function, `freeSubmissionOffer`, rather than logic inside the modal: five inputs, an order that matters, and copy that is wrong in a different way for each. `verified` leads deliberately — naming a slot shortage on an unverified remix sends someone back tomorrow to be refused for the same reason.

`freeSlotsRemaining: 0` is read alongside `freeSlots`, because the resolver short-circuits the reservation count at zero capacity and the number alone cannot say whether the creator takes none or theirs are all currently held. Those get different copy: one is a setting, the other is a queue that will move.

**Losing the race falls back to paid**, per ryan, and the same rule is going into the sticker surface. `freeSlotsRemaining` is stale by construction; when the mutation refuses under the lock, the card re-reads, the free option resolves away on its own, and one plain line says so. No server message is ever surfaced.

## Notifications

`remix-gallery-free-pending`, its own type with its own toggle, and `AND NOT p.free` on the paid type so a 0-Buzz submission is never announced as a payment. A `UserNotificationSettings` row means opted **out**, and the new query carries the `NOT EXISTS` clause accordingly.

⚠️ **Noted, not fixed:** neither existing placement type (`sticker-placement-pending`, `remix-gallery-pending`) has an opt-out clause at all, so their toggles render and change nothing. Left alone because it changes shipped behaviour and belongs in its own PR.

## Not built

The free-slot slider for this surface already shipped in PR 1 (`RemixGallerySettings.tsx`). I verified it round-trips `null` and left it alone.

## Verification

There is no CI on PRs into `feat/free-placements`, so this is the only gate.

- `pnpm run typecheck` — 0 errors
- `pnpm run lint` — 0 errors on every changed file (one pre-existing unused-import warning in the service test, not mine)
- `pnpm run prettier:write` — applied
- unit suite (both `unit` projects) — **17,297 passed**, 1,106 files, 23 skipped
- `pnpm run test:lint-rules` — 220 passed
- `blocks.router.workflow.test.ts` collected **348 tests**, so the worktree's submodule is real and the run means something
- `pnpm run test:component` — 1,664 passed, **3 pre-existing failures**, all in `src/components/Apps/` (`AppListingCard.browser.test.tsx` ×2, `AppsPageLayout.geometry.browser.test.tsx` ×1). Confirmed rather than assumed: I reverted all ten changed files to the base commit and re-ran those two files, and the same three fail identically. They are pixel-geometry assertions on the /apps chrome and this PR touches nothing they reach.

### Component test

`RemixGallerySubmitModal.browser.test.tsx`, **15 tests**, covering the branches nothing else can see: the submit button (inverted, a submission chosen as *free* goes through `BuzzTransactionButton` carrying `expectedPrice`), the unexplained-refusal notification (inverted, a blocked submitter presses Submit and sees nothing), the decline-fee note, the paid-closed states, and the neither-path-open dead end.

### The post-refusal re-read reads the network, not the cache

Worth calling out because it was dead and nothing saw it. Both `.fetch` calls pass `{ staleTime: 0 }`. The client's global default is `staleTime: Infinity` (`src/utils/trpc.ts`), `fetchQuery` applies it, and both keys are the mounted queries' own — so without the option the "re-read" resolved the cache and never called the procedure.

The consequence was total rather than partial: pressing Submit for free requires `freeAvailable`, which means `freeSubmissionOffer` over the cached inputs returned available — and `freeRefusalExplanation` is that same function over those same inputs, so it returned `null` every time. **Every refused free submission fell to the server branch and showed raw server prose.** The entire refusal split, the reason ladder and the `paidOpen` thread were unreachable in production while their tests were green.

The sticker sibling had this right and says why (`Sticker/placement.util.ts`); the remix copy dropped the options.

**The tests could not see it, and that is the finding rather than an excuse.** The browser fake hand-wrote `fetch` as always-fresh, so no assertion in the file could distinguish a real read from a cache hit. The fake now honours `staleTime` — cached unless the call asks for fresh — on **both** halves, and dropping the option from either `.fetch` fails it. Three arguments that were unpinnable before this are pinned now, including the explanation's own `paidOpen`.

### 🟠 Declared gaps — deliberate, not oversights

1. **The server's price-floor boundary is not pinned.** `createRemixGallerySubmission` refuses on `price < serverMinPrice`, and the service suite prices at 700, `null` and `10` — nothing at exactly 50 — so `<` → `<=` stays green. The **client** boundary *is* pinned at exactly the floor, which makes this false confidence rather than a plain gap: reading the unit file leaves you believing the boundary is settled. Three lines, using the constant rather than a literal. Follow-up.
2. **The five submissions-page sites the sweep fixed have no test.** The reads are guarded (see below); the rendering is not.
3. **The below-floor browser fixture uses a literal `10`**, not `serverMinPrice - 1`, so it does not track the constant.
4. **`remix-submissions.tsx` is untested** — its `row.free` branch selection and its copy strings are unobserved at every site the sweep touched.

   ~~Adding a status predicate to `countFreePlacementsOn` would turn the withdraw sentence into a lie with nothing red.~~ **Struck: that is false, and I had it backwards.** `free-placement.service.test.ts` selects that where-clause with `whereOf((where) => where.targetId !== undefined && !where.createdAt && !where.status)` — add a status predicate and the selector matches nothing, so the assertion runs against `undefined` and goes red. The daily half is pinned too (`expect(daily).not.toHaveProperty('status')`). Declaring a hole the repo has already closed is worse than an over-claim: it spends the next author's time building a guard that exists.
5. **The `!freeRefusal` term of the reason's gate is unpinnable in the browser file**, and I checked rather than assumed: dropping it leaves every test in it green. The two messages can only collide when a refusal lands while `offer.reason` is non-null, and `offer.reason` comes from the static query fixture, which still says free is available at that moment. Recorded in the file rather than asserted vacuously.
6. **Rung ordering on a `freeSlots === 0` gallery**: an unverified image reports rung 1 rather than rung 3, implying free would be available if the image were verified. Rare — the cap's minimum is 1 at every tier, so it needs an explicit opt-out.
7. **The *wired* stale-choice rule lives nowhere.** The pure rule is pinned in `remix-gallery.utils.test.ts`; observing it fire through a real query cache would need a fixture that grows its own bugs for one line. The browser file says so in its own ⚠️ block, with the measurement.

### The Buzz-figure sweep

Run rather than inferred, after #4018's author warned that a reviewer-driven audit reads as done in exactly the way theirs did. Grepped every consumer of `amount`, `earnings`, `declineFee` and every Buzz figure across the components **and** the submissions page.

The components were clean. `src/pages/user/remix-submissions.tsx` was not — a `⚡ 0` chip in both tabs, a withdraw confirmation quoting "your 0 Buzz starts on its way back", a success toast promising a refund, and page copy promising one in full. Neither read selected `free`, so no branch was possible.

Guarded by an `afterEach` asserting that **every** `placement.findMany` any test in that file makes, whose select carries `amount`, also carries `free`. It loops rather than using `.find(...)`, because first-match-wins would skip a second amount-carrying select in the same function — this repo's catalogued hazard, and it was in my first draft of that guard.

⚠️ **Narrower than "the sweep is now a rule", and worth stating honestly.** For all three current selects, dropping `free` is *already* a `pnpm typecheck` error, because consumers read `row.free` — so the mutation I measured could not have shipped. The guard's real value is the case types cannot see: a future read selecting `amount` whose `free` nobody references. It also cannot see a read no test in that file exercises.

**Every guard was mutation-tested** — broken, run, restored — and each failure is sub-second and names the problem:

| Mutation | Failure |
| --- | --- |
| Remove the `derivedFromHost` gate | 2 fails, 84ms, `promise resolved "{ id: 107 }" instead of rejecting` |
| Pass `imageId` as the claim's `targetId` | `expected 85 to be 74` |
| Move the duplicate check after the free branch | `promise resolved` instead of rejecting |
| Revert the cooldown copy | `expected to throw /week-long commitment/i` |
| Drop `AND NOT p.free` from the paid notification | `expected ... to contain 'AND NOT p.free'` |
| Drop the opt-out clause from the free notification | `expected ... to contain 'NOT EXISTS (SELECT 1 FROM "UserNotificationSettings"'` |
| Check verification last in the reason ladder | `expected 'You've already used a free submission…' to match /where we can check/i` |

One measured negative worth stating: breaking **either** `placerId` mechanism alone does not fail the router test, because the other still holds. Adding `placerId` to the schema **and** flipping the spread order does. That is defence in depth rather than a weak test, and the test comment says so.

No migration in this PR.
