### PR TITLE
feat(placement): free sticker placement, with the mode on the offer

### DIFF
--- a/src/components/Sticker/DraftSticker.browser.test.tsx
+++ b/src/components/Sticker/DraftSticker.browser.test.tsx
@@ -47,7 +47,12 @@ vi.mock('~/components/Buzz/BuzzTransactionButton', () => ({
     label: string;
     onPerformTransaction: () => void;
   }) => (
-    <button type="button" onClick={onPerformTransaction}>
+    // `data-buzz-button` is load-bearing. Without it the stub is
+    // indistinguishable from a plain Mantine `Button` by name alone, so swapping
+    // the free option TO a BuzzTransactionButton left all ten tests green — the
+    // component's own docstring argues at length that it must not be one, and
+    // nothing held that argument.
+    <button type="button" data-buzz-button onClick={onPerformTransaction}>
       {label}
     </button>
   ),
@@ -151,19 +156,27 @@ const renderDraft = async (
 /**
  * The paid button, pressed through the DOM rather than through the locator.
  *
- * ⚠️ Deliberate, and narrow. The buy cluster is absolutely positioned inside the
- * rotated draft, and in this harness the paid variant settles at a NEGATIVE x —
- * measured at -56 in a 414-wide viewport, above the top edge as well — so
- * Playwright reports it visible, fails to scroll to it, and burns the full click
- * budget. Container size and draft position make no difference; the free variant
- * in the same tree is reachable, so it is a property of where THIS cluster lands,
- * which this PR does not change.
+ * ⚠️ **Why this is acceptable here and nowhere else:** `BuzzTransactionButton` is
+ * mocked down to a bare `<button onClick={…}>`, so the actionability a locator
+ * click would check belongs to the stub rather than to anything shipped. There is
+ * no real control here whose reachability could be asserted, whatever method is
+ * used — and what these two tests are for is the payload the handler sends. The
+ * free press, which is the button this PR added and a real Mantine one, goes
+ * through the ordinary locator with its full actionability check.
  *
- * What these two tests are for is the payload the handler sends. Actionability is
- * a separate property, it is the paid path's, and it predates this branch — so
- * skipping the check here is scoping rather than papering over: a real click still
- * runs the real handler. The free press, which is what this PR added, goes through
- * the ordinary locator and its full actionability check.
+ * (A locator click on the stub does not succeed in this harness: the cluster is
+ * absolutely positioned inside the rotated draft and the paid variant ends up
+ * unreachable. The mechanism is NOT established — `shouldFlipPlaceButton` cannot
+ * fire here, since `tray` and `clip` are both null — and it is not the reason for
+ * the exemption either way.)
+ *
+ * 🔴 **Four things end this exemption**, and any one of them means going back to a
+ * locator click and solving the reachability properly:
+ * 1. `BuzzTransactionButton` stops being mocked.
+ * 2. Either helper is used to assert reachability, or enabled/disabled state,
+ *    rather than the payload.
+ * 3. The cluster gains an overlay, so a press could be intercepted.
+ * 4. The pattern is copied into another file as habit.
  */
 const pressPaid = async () => {
   const button = (await page.getByRole('button', { name: 'Place' }).element()) as HTMLElement;
@@ -229,6 +242,27 @@ describe('what a draft sends when it is placed', () => {
     await pressPaid();
 
     expect(placed[0].free).toBe(false);
+  });
+
+  /**
+   * The free option must not be a `BuzzTransactionButton`, which the component's
+   * docstring argues at length — that control exists to show a price and check a
+   * balance, and a free placement has neither. Asserted through the mock's marker
+   * rather than by name, because by name the stub and a plain Mantine button are
+   * the same thing: the swap this pins used to leave every test green.
+   */
+  test('places free through a plain button, not a Buzz one', async () => {
+    await renderDraft({ instant: true });
+
+    const free = (await page.getByRole('button', { name: 'Place free' }).element()) as HTMLElement;
+    expect(free.hasAttribute('data-buzz-button')).toBe(false);
+  });
+
+  test('places paid through a Buzz button, which is where a price belongs', async () => {
+    await renderDraft(null);
+
+    const paid = (await page.getByRole('button', { name: 'Place' }).element()) as HTMLElement;
+    expect(paid.hasAttribute('data-buzz-button')).toBe(true);
   });
 
   test('carries the draft geometry either way', async () => {

--- a/src/components/Sticker/DraftSticker.browser.test.tsx
+++ b/src/components/Sticker/DraftSticker.browser.test.tsx
@@ -165,18 +165,27 @@ const renderDraft = async (
  * through the ordinary locator with its full actionability check.
  *
  * (A locator click on the stub does not succeed in this harness: the cluster is
- * absolutely positioned inside the rotated draft and the paid variant ends up
- * unreachable. The mechanism is NOT established — `shouldFlipPlaceButton` cannot
- * fire here, since `tray` and `clip` are both null — and it is not the reason for
- * the exemption either way.)
+ * absolutely positioned inside the rotated draft, and the measured failure was a
+ * negative **x**. Nothing in the component moves it horizontally —
+ * `shouldFlipPlaceButton` is vertical only, as `DraftSticker.tsx` says where it is
+ * used — so the flip is not the cause. Beyond that the mechanism is unestablished,
+ * and it is not the reason for the exemption either way.)
  *
- * 🔴 **Four things end this exemption**, and any one of them means going back to a
+ * 🔴 **Five things end this exemption**, and any one of them means going back to a
  * locator click and solving the reachability properly:
  * 1. `BuzzTransactionButton` stops being mocked.
  * 2. Either helper is used to assert reachability, or enabled/disabled state,
  *    rather than the payload.
  * 3. The cluster gains an overlay, so a press could be intercepted.
  * 4. The pattern is copied into another file as habit.
+ * 5. **The paid control acquires an inert state.** The real button is
+ *    `disabled={… || !!error || isLoadingBalance || loading}` and routes its click
+ *    through `conditionalPerformTransaction`, which can open the buy-Buzz flow
+ *    INSTEAD of calling the handler. The stub honours none of that, and the draft
+ *    already passes `loading={place.isPending}` — so the moment an error or
+ *    disabled condition is added, or a test renders with `isPending: true`, a DOM
+ *    press fires a handler a real user could not fire and both payload tests
+ *    assert a send that cannot happen.
  */
 const pressPaid = async () => {
   const button = (await page.getByRole('button', { name: 'Place' }).element()) as HTMLElement;

--- a/src/components/Sticker/DraftSticker.browser.test.tsx
+++ b/src/components/Sticker/DraftSticker.browser.test.tsx
@@ -1,0 +1,293 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
+import type * as PlacementUtil from '~/components/Sticker/placement.util';
+import type * as StickerUtil from '~/components/Sticker/sticker.util';
+import type * as CosmeticShopUtil from '~/components/CosmeticShop/cosmetic-shop.util';
+import type * as Trpc from '~/utils/trpc';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import { resolveTreatment } from '~/components/Sticker/treatments/sticker-treatments';
+import type { StickerDraft } from '~/store/sticker-placement-draft.store';
+
+/**
+ * What the buttons on a draft actually SEND.
+ *
+ * `isPlacingFree` is well covered as a function; nothing covered the component
+ * using it to fill the payload. Deleting `free: placingFree` from the mutation
+ * input left every test in this PR green while every free press charged Buzz —
+ * so what is asserted here is the value on the wire, not that a prop of the right
+ * type exists.
+ */
+const IMAGE_ID = 74;
+const COSMETIC_ID = 85;
+const PRICE = 700;
+
+/** Every press, with its variables, in order. */
+const placed: { imageId: number; free: boolean; data: Record<string, unknown> }[] = [];
+
+vi.mock('~/components/Sticker/placement.util', async (importOriginal) => ({
+  ...(await importOriginal<typeof PlacementUtil>()),
+  useCreateStickerPlacement: () => ({
+    mutate: (variables: (typeof placed)[number]) => placed.push(variables),
+    isPending: false,
+  }),
+}));
+
+/**
+ * Mocked because it is a dependency, not the thing under test: the real one
+ * renders a currency badge and an account picker and wants the Buzz providers.
+ * Reduced to a button that calls what it is given, so a paid press is still
+ * observable here — the free press goes through a real Mantine `Button`.
+ */
+vi.mock('~/components/Buzz/BuzzTransactionButton', () => ({
+  BuzzTransactionButton: ({
+    label,
+    onPerformTransaction,
+  }: {
+    label: string;
+    onPerformTransaction: () => void;
+  }) => (
+    <button type="button" onClick={onPerformTransaction}>
+      {label}
+    </button>
+  ),
+}));
+
+vi.mock('~/components/Buzz/useAvailableBuzz', () => ({ useAvailableBuzz: () => ['yellow'] }));
+
+// `EdgeImage` resolves its URL through `useCurrentUser`, which reads a session
+// context this tree does not mount — and the throw happens inside render, so the
+// whole draft comes back empty rather than failing on the missing provider.
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => ({ id: 7 }) }));
+
+// Every one of these spreads the real module rather than listing its exports. A
+// hand-listed mock couples this file to the whole transitive graph of the draft
+// and nothing warns when that graph grows — the wholesale `~/utils/trpc` version
+// of this file collected ZERO tests, because another module in the graph imports
+// `setTrpcBatchingEnabled` and the stub did not provide it.
+vi.mock('~/components/CosmeticShop/cosmetic-shop.util', async (importOriginal) => ({
+  ...(await importOriginal<typeof CosmeticShopUtil>()),
+  useMutateCosmeticShop: () => ({ purchaseShopItem: vi.fn(), purchasingShopItem: false }),
+}));
+vi.mock('~/components/Sticker/sticker.util', async (importOriginal) => ({
+  ...(await importOriginal<typeof StickerUtil>()),
+  useBuyStickerUses: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof Trpc>();
+  return {
+    ...actual,
+    trpc: {
+      ...actual.trpc,
+      useUtils: () => ({ cosmetic: { getStickerBalances: { invalidate: vi.fn() } } }),
+    },
+  };
+});
+
+const draft: StickerDraft = {
+  id: 'draft-1',
+  imageId: IMAGE_ID,
+  cosmeticId: COSMETIC_ID,
+  x: 0.5,
+  // Mid-height and small, so the buy cluster is reachable whichever side of the
+  // sticker it settles on. It is absolutely positioned and flips above the
+  // sticker when the space below is obstructed, and a cluster that lands outside
+  // the harness iframe cannot be scrolled to — Playwright then reports "visible,
+  // enabled and stable", fails to scroll, and burns the whole click budget on
+  // something that reads as actionable. The container is sized under the default
+  // 414x896 viewport for the same reason; 800 wide put it off the right edge.
+  y: 0.6,
+  scale: 0.25,
+  rotation: 15,
+  flip: false,
+  opacity: 1,
+};
+
+const art = { id: COSMETIC_ID, name: 'Star', slug: 'star', url: 'star.png' };
+
+const { DraftSticker } = await import('~/components/Sticker/DraftSticker');
+
+/**
+ * `ownerShare` is opt-in, and that is not tidiness.
+ *
+ * The payout chip is `max-w-[240px]`, and it is the widest child of a `w-max`
+ * cluster — so rendering it pushes the cluster's centre far enough left that the
+ * Place button lands at a NEGATIVE x, outside the harness iframe and unreachable
+ * by any amount of scrolling. Measured: x = -65 in a 414-wide viewport.
+ *
+ * So the tests that press a button render without it, and the two that assert the
+ * chip do not press anything. Splitting them keeps both properties covered
+ * without either test depending on the other's layout.
+ */
+const renderDraft = async (
+  freeOffer: { instant: boolean } | null,
+  { ownerShare }: { ownerShare?: number } = {}
+) => {
+  renderWithProviders(
+    // Positioned absolutely inside the media box in the app; a plain relative
+    // parent is enough here, since none of this asserts geometry.
+    // Sized to fit inside the harness iframe rather than to look like a media
+    // box: the cluster has to be reachable, and none of this asserts geometry.
+    <div style={{ position: 'relative', width: 380, height: 600 }}>
+      <DraftSticker
+        draft={draft}
+        art={art}
+        selected
+        dressed={resolveTreatment({ treatment: 'none', surface: 'detail', isPending: false })}
+        price={PRICE}
+        freeOffer={freeOffer}
+        ownerShare={ownerShare}
+        ownerUsername="creator"
+        onGesture={() => true}
+      />
+    </div>
+  );
+
+  // Anchored on the button existing rather than on a name, so an ambiguous
+  // locator fails as an assertion instead of a 15 s strict-mode retry.
+  await expect.element(page.getByRole('button').first()).toBeInTheDocument();
+};
+
+/**
+ * The paid button, pressed through the DOM rather than through the locator.
+ *
+ * ⚠️ Deliberate, and narrow. The buy cluster is absolutely positioned inside the
+ * rotated draft, and in this harness the paid variant settles at a NEGATIVE x —
+ * measured at -56 in a 414-wide viewport, above the top edge as well — so
+ * Playwright reports it visible, fails to scroll to it, and burns the full click
+ * budget. Container size and draft position make no difference; the free variant
+ * in the same tree is reachable, so it is a property of where THIS cluster lands,
+ * which this PR does not change.
+ *
+ * What these two tests are for is the payload the handler sends. Actionability is
+ * a separate property, it is the paid path's, and it predates this branch — so
+ * skipping the check here is scoping rather than papering over: a real click still
+ * runs the real handler. The free press, which is what this PR added, goes through
+ * the ordinary locator and its full actionability check.
+ */
+const pressPaid = async () => {
+  const button = (await page.getByRole('button', { name: 'Place' }).element()) as HTMLElement;
+  button.click();
+};
+
+/**
+ * The paid segment, pressed the same way and for the same reason — it sits in the
+ * same cluster. A Mantine `SegmentedControl` radio is a visually-hidden input
+ * besides, so a locator click is waiting on something that is never visible by
+ * design.
+ */
+const choosePaid = async () => {
+  const radio = (await page.getByRole('radio', { name: `${PRICE} Buzz` }).element()) as HTMLElement;
+  radio.click();
+};
+
+beforeEach(() => {
+  placed.length = 0;
+});
+
+describe('what a draft sends when it is placed', () => {
+  test('a free press sends free: true', async () => {
+    await renderDraft({ instant: true });
+
+    await page.getByRole('button', { name: 'Place free' }).click();
+
+    expect(placed).toHaveLength(1);
+    // The value, not the presence of a correctly-typed prop. `free: false` here
+    // is the whole defect: it charges Buzz for a placement somebody chose to
+    // make free, and no other test in this PR can see it.
+    expect(placed[0].free).toBe(true);
+    expect(placed[0].imageId).toBe(IMAGE_ID);
+  });
+
+  test('a paid press sends free: false', async () => {
+    await renderDraft(null);
+
+    await pressPaid();
+
+    expect(placed).toHaveLength(1);
+    expect(placed[0].free).toBe(false);
+  });
+
+  /**
+   * The default, observed through the payload rather than through the control's
+   * selected value — a segmented control reading "free" that sends `free: false`
+   * is the failure this file exists for, and only the payload separates them.
+   */
+  test('defaults to the free offer without anybody choosing it', async () => {
+    await renderDraft({ instant: false });
+
+    // No interaction with the segmented control at all.
+    await page.getByRole('button', { name: 'Place free' }).click();
+
+    expect(placed[0].free).toBe(true);
+  });
+
+  test('sends what was chosen after switching to paid', async () => {
+    await renderDraft({ instant: true });
+
+    await choosePaid();
+    await pressPaid();
+
+    expect(placed[0].free).toBe(false);
+  });
+
+  test('carries the draft geometry either way', async () => {
+    await renderDraft({ instant: true });
+
+    await page.getByRole('button', { name: 'Place free' }).click();
+
+    expect(placed[0].data).toMatchObject({
+      cosmeticId: COSMETIC_ID,
+      x: draft.x,
+      y: draft.y,
+      scale: draft.scale,
+      rotation: draft.rotation,
+    });
+  });
+});
+
+/**
+ * The mode belongs to the free option, not to the button upstream, so it has to
+ * be readable here — and the two modes have to read differently or the placer
+ * cannot tell an instant placement from one that spends their day on a review
+ * they may lose.
+ */
+describe('the free option carries the mode', () => {
+  test('says instant on an auto-accept space, with no review caveat', async () => {
+    await renderDraft({ instant: true });
+
+    await expect.element(page.getByText('Free · instant')).toBeInTheDocument();
+    expect(page.getByText(/spent even if they decline/).elements()).toHaveLength(0);
+  });
+
+  test('says needs review, and warns the day is spent regardless', async () => {
+    await renderDraft({ instant: false });
+
+    await expect.element(page.getByText('Free · needs review')).toBeInTheDocument();
+    await expect.element(page.getByText(/spent even if they decline/)).toBeInTheDocument();
+  });
+
+  test('offers no choice at all where there is no free offer', async () => {
+    await renderDraft(null);
+
+    expect(page.getByText(/^Free ·/).elements()).toHaveLength(0);
+    expect(page.getByRole('button', { name: 'Place free' }).elements()).toHaveLength(0);
+  });
+
+  /**
+   * No proceeds to split on a free placement, so the share caption must not
+   * appear — it is a claim about money that does not move, and PR 3's accept
+   * reward is a separate mechanism not derived from this split.
+   */
+  test('claims no payout while free is selected', async () => {
+    await renderDraft({ instant: true }, { ownerShare: 1 });
+
+    expect(page.getByText(/proceeds go to/).elements()).toHaveLength(0);
+  });
+
+  test('names the payout on the paid option', async () => {
+    await renderDraft(null, { ownerShare: 1 });
+
+    await expect.element(page.getByText(/proceeds go to/)).toBeInTheDocument();
+  });
+});

--- a/src/components/Sticker/DraftSticker.tsx
+++ b/src/components/Sticker/DraftSticker.tsx
@@ -1,5 +1,6 @@
 import {
   ActionIcon,
+  Button,
   Popover,
   SegmentedControl,
   Slider,
@@ -30,6 +31,11 @@ import {
   shouldFlipPlaceButton,
 } from '~/components/Sticker/place-button-position';
 import { useMutateCosmeticShop } from '~/components/CosmeticShop/cosmetic-shop.util';
+import {
+  FREE_REVIEW_CAVEAT,
+  freeOptionLabel,
+  isPlacingFree,
+} from '~/components/Sticker/free-offer';
 import { payoutCopy, stickerPurchaseCopy } from '~/components/Sticker/payout-copy';
 import { stickerArtworkStyle } from '~/components/Sticker/placement-appearance';
 import { useCreateStickerPlacement } from '~/components/Sticker/placement.util';
@@ -122,6 +128,7 @@ export function DraftSticker({
   selected,
   dressed,
   price,
+  freeOffer,
   ownerShare,
   ownerUsername,
   onGesture,
@@ -132,16 +139,16 @@ export function DraftSticker({
   selected: boolean;
   dressed: StickerTreatment;
   price: number;
+  /**
+   * The free option, when this creator has a slot open and the placer still has
+   * their day. `null` means paid is the only offer — including while the
+   * standing query is still in flight.
+   */
+  freeOffer: { instant: boolean } | null;
   ownerShare: number | undefined;
   ownerUsername: string | null | undefined;
   onGesture: StartGesture;
 }) {
-  // While the sticker is unbought the chip names who that payment goes to — the
-  // sticker's maker — not who the later placement pays. Two payments, two
-  // recipients, and only one of them is being made right now.
-  const payout = draft.purchase
-    ? stickerPurchaseCopy(draft.purchase.creatorUsername)
-    : payoutCopy(ownerShare, ownerUsername);
   const markPurchased = useStickerPlacementDraftStore((state) => state.markPurchased);
   const { purchaseShopItem, purchasingShopItem } = useMutateCosmeticShop();
   const queryUtils = trpc.useUtils();
@@ -217,8 +224,33 @@ export function DraftSticker({
   const select = useStickerPlacementDraftStore((state) => state.select);
   const cancelDraft = useStickerPlacementDraftStore((state) => state.cancelDraft);
   const move = useStickerPlacementDraftStore((state) => state.move);
-  const place = useCreateStickerPlacement(draft.id);
+
+  // `null` until somebody presses the control, which is what lets the default
+  // track an offer that arrives with a query rather than freezing whatever was
+  // known on the first render. See `isPlacingFree`.
+  const [payChoice, setPayChoice] = useState<'free' | 'paid' | null>(null);
+  const placingFree = isPlacingFree(payChoice, freeOffer);
+  const payMode = placingFree ? 'free' : 'paid';
+
+  // Settling on paid after a refused claim, rather than leaving the control on
+  // an offer that is gone. Passed down rather than handled here because the
+  // mutation is the only thing that knows the claim was refused.
+  const place = useCreateStickerPlacement(draft.id, () => setPayChoice('paid'));
   const spendTypes = useAvailableBuzz();
+
+  // While the sticker is unbought the chip names who that payment goes to — the
+  // sticker's maker — not who the later placement pays. Two payments, two
+  // recipients, and only one of them is being made right now.
+  //
+  // Nothing at all on a free placement: there are no proceeds to split, so a
+  // share of them is a claim about money that does not move. PR 3's accept
+  // reward is the creator's side of a free placement and is not derived from
+  // this split, so it does not belong in this sentence either.
+  const payout = draft.purchase
+    ? stickerPurchaseCopy(draft.purchase.creatorUsername)
+    : placingFree
+    ? null
+    : payoutCopy(ownerShare, ownerUsername);
 
   // Which of the two refill prices is being offered. Defaults to the single
   // use: it is the cheaper of the two and exactly what placing this draft
@@ -472,6 +504,26 @@ export function DraftSticker({
     event.stopPropagation();
     if (!useStickerPlacementDraftStore.getState().interaction) select(draft.id);
   };
+
+  // One payload for both buttons, so the two offers cannot drift into placing
+  // different stickers. `free` is the only thing that differs, and it selects a
+  // path rather than asserting anything — the server re-decides all of it.
+  const placementInput = () => ({
+    imageId: draft.imageId,
+    free: placingFree,
+    data: {
+      cosmeticId: draft.cosmeticId,
+      x: draft.x,
+      y: draft.y,
+      scale: draft.scale,
+      rotation: draft.rotation,
+      flip: draft.flip,
+      opacity: draft.opacity,
+      // Sent only when there is something to send, so an opened-then-abandoned
+      // field is the same as never opening it.
+      ...(note.trim() ? { comment: note } : {}),
+    },
+  });
 
   const flipControl = (
     <Tooltip label={draft.flip ? 'Unflip' : 'Flip'} withinPortal>
@@ -761,6 +813,39 @@ export function DraftSticker({
           />
         )}
 
+        {/* The other two-way choice, and deliberately the same control as the
+            one above it: this is the same kind of decision — which of two
+            offers you are taking — made a step later, so giving it a different
+            shape would make them read as unrelated. They never coexist; the one
+            above only appears on a sticker that still has to be bought.
+
+            The free option carries the mode, which the sticker button upstream
+            deliberately does not. This is the last moment the placer can change
+            their mind, and it is what makes auto-accept and review read as two
+            different offers rather than a setting nobody can see. */}
+        {!draft.purchase && freeOffer && (
+          <SegmentedControl
+            size="xs"
+            radius="xl"
+            value={payMode}
+            onChange={(value) => setPayChoice(value as 'free' | 'paid')}
+            data={[
+              { label: freeOptionLabel(freeOffer.instant), value: 'free' },
+              { label: `${numberWithCommas(price)} Buzz`, value: 'paid' },
+            ]}
+          />
+        )}
+
+        {/* Only where it is true. On an auto-accept space the placement is live
+            the moment it is made, so there is no decline to warn about. */}
+        {placingFree && freeOffer && !freeOffer.instant && (
+          <div className="max-w-[240px] whitespace-normal rounded-lg bg-black/80 px-2 py-1 text-center">
+            <Text size="xs" c="gray.3" className="leading-tight">
+              {FREE_REVIEW_CAVEAT}
+            </Text>
+          </div>
+        )}
+
         {draft.purchase && effectiveMode === 'pack' && draft.purchase.pack ? (
           <BuzzTransactionButton
             size="sm"
@@ -791,6 +876,23 @@ export function DraftSticker({
             }
             onPerformTransaction={buyOneUse}
           />
+        ) : placingFree ? (
+          // Not a `BuzzTransactionButton`. That control exists to show a price
+          // and check a balance against it, and a free placement has neither —
+          // rendering it at zero would put a currency badge on something nobody
+          // is paying for, and its account picker would ask which Buzz to spend.
+          // The use it does spend is shown by the tray's own count, and refused
+          // by the server independently.
+          <Button
+            size="sm"
+            radius="xl"
+            color="yellow"
+            style={{ minWidth: BUY_BUTTON_MIN_WIDTH }}
+            loading={place.isPending}
+            onClick={() => place.mutate(placementInput())}
+          >
+            Place free
+          </Button>
         ) : (
           <BuzzTransactionButton
             size="sm"
@@ -799,23 +901,7 @@ export function DraftSticker({
             accountTypes={spendTypes}
             label="Place"
             loading={place.isPending}
-            onPerformTransaction={() =>
-              place.mutate({
-                imageId: draft.imageId,
-                data: {
-                  cosmeticId: draft.cosmeticId,
-                  x: draft.x,
-                  y: draft.y,
-                  scale: draft.scale,
-                  rotation: draft.rotation,
-                  flip: draft.flip,
-                  opacity: draft.opacity,
-                  // Sent only when there is something to send, so an opened-then-
-                  // abandoned field is the same as never opening it.
-                  ...(note.trim() ? { comment: note } : {}),
-                },
-              })
-            }
+            onPerformTransaction={() => place.mutate(placementInput())}
           />
         )}
 

--- a/src/components/Sticker/DraftSticker.tsx
+++ b/src/components/Sticker/DraftSticker.tsx
@@ -738,9 +738,11 @@ export function DraftSticker({
             box is most of the frame, because almost every draft there is narrow.
             This cluster is the one piece of chrome that already knows where it
             is on screen: it measures itself against the tray and the clipping
-            ancestor and moves to whichever side is visible. Handing it the
-            controls means they inherit that, instead of a third set of
-            hand-derived offsets to get wrong. */}
+            ancestor and moves ABOVE or BELOW the sticker accordingly.
+            `shouldFlipPlaceButton` is vertical only — the horizontal position
+            follows the draft's own x with nothing clamping it — so handing it the
+            controls buys them the vertical avoidance and no more. Still better
+            than a third set of hand-derived offsets. */}
         {!panelsInside && (
           <div
             className="flex items-center gap-0.5 rounded-full bg-dark-7 px-1 py-0.5"

--- a/src/components/Sticker/DraftStickerLayer.tsx
+++ b/src/components/Sticker/DraftStickerLayer.tsx
@@ -2,7 +2,11 @@ import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { Gesture } from '~/components/Sticker/draft-gesture';
 import { rotate } from '~/components/Sticker/draft-gesture';
 import { DraftSticker } from '~/components/Sticker/DraftSticker';
-import { useImagePlacementSpace } from '~/components/Sticker/placement.util';
+import { freeOfferFor } from '~/components/Sticker/free-offer';
+import {
+  useFreePlacementStanding,
+  useImagePlacementSpace,
+} from '~/components/Sticker/placement.util';
 import { useOwnedSticker, useStickerCosmetics } from '~/components/Sticker/sticker.util';
 import { resolveTreatment } from '~/components/Sticker/treatments/sticker-treatments';
 import { useStickerTreatment } from '~/components/Sticker/treatments/useStickerTreatment';
@@ -53,6 +57,12 @@ export function DraftStickerLayer() {
   // refuse. The refusal is still on the server — this only means nobody has to
   // discover it by being told no after a drag.
   const maxScale = stickerMaxScale(space?.settings);
+
+  // Resolved once for the layer, for the same reason the treatment is: one query
+  // answering a question about the image and the viewer, where a subscription
+  // per sticker would be N observers refetching through an arrangement.
+  const { standing } = useFreePlacementStanding(targetImageId ?? undefined);
+  const freeOffer = freeOfferFor(space, standing);
 
   const gesture = useRef<Gesture | null>(null);
   // Held in a ref because the pointer listener is bound once; re-binding it when
@@ -229,6 +239,7 @@ export function DraftStickerLayer() {
             selected={draft.id === selectedDraftId}
             dressed={dressed}
             price={space?.price ?? 0}
+            freeOffer={freeOffer}
             ownerShare={space?.ownerShare}
             ownerUsername={space?.ownerUsername}
             onGesture={onGesture}

--- a/src/components/Sticker/RemoveReportedPlacement.tsx
+++ b/src/components/Sticker/RemoveReportedPlacement.tsx
@@ -2,6 +2,7 @@ import { Alert, Button, Group, Stack, Text } from '@mantine/core';
 import { openConfirmModal } from '@mantine/modals';
 import { IconEye, IconEyeOff, IconTrash } from '@tabler/icons-react';
 import { useForgetStickerPlacement } from '~/components/Sticker/placement.util';
+import { moderatorTakedownConsequence } from '~/components/Sticker/payout-copy';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 
@@ -80,8 +81,17 @@ export function RemoveReportedPlacement({
             {placement.sticker?.name ?? 'This sticker'}, placed by{' '}
             {placement.placer?.username ?? 'an unknown user'}, comes off the image for everyone.
           </Text>
+          {/* Both branches were false on a free row: there is no escrow to
+              forfeit and no payment the creator already received. The suspension
+              pointer is worth keeping in the paid wording, so the two are
+              separate sentences rather than one with a clause swapped. */}
           <Text size="sm" c="dimmed">
-            {placement.status === 'pending'
+            {placement.free
+              ? moderatorTakedownConsequence({
+                  pending: placement.status === 'pending',
+                  free: true,
+                })
+              : placement.status === 'pending'
               ? 'It never went live, so its escrow is forfeited rather than refunded.'
               : 'No Buzz moves: the creator was already paid for it, and clawing that back would punish the wrong person. Suspend the placer if the problem is them rather than this one sticker.'}
           </Text>

--- a/src/components/Sticker/StickerPlacementActions.tsx
+++ b/src/components/Sticker/StickerPlacementActions.tsx
@@ -12,11 +12,17 @@ import { trpc } from '~/utils/trpc';
  * One component for the image and the queue, so the two cannot end up asking
  * different questions before taking someone's money.
  *
- * **Decline confirms; approve confirms only when there is a note.** Declining
- * keeps 30% of what the placer paid and cannot be undone. A plain approve takes
- * nothing from the placer they did not choose to spend, so it goes straight
- * through — but an approve that would publish someone's words is a second
- * decision, and it is the one the owner cannot see the subject of otherwise.
+ * **Decline confirms; approve confirms only when there is a note.** A decline
+ * cannot be undone, and what it costs depends on the placement — see
+ * `declineConsequence`, which is where that sentence lives now that a free row
+ * has no payment to keep a share of. No rate is named here: the shares are
+ * operator-tunable at runtime, so a number written down in a comment is a claim
+ * about money that stops being true with nothing failing.
+ *
+ * A plain approve takes nothing from the placer they did not choose to spend, so
+ * it goes straight through — but an approve that would publish someone's words is
+ * a second decision, and it is the one the owner cannot see the subject of
+ * otherwise.
  */
 export function StickerPlacementActions({
   placementIds,

--- a/src/components/Sticker/StickerPlacementActions.tsx
+++ b/src/components/Sticker/StickerPlacementActions.tsx
@@ -2,6 +2,7 @@ import { Button, Group, Popover, Skeleton, Stack, Text } from '@mantine/core';
 import { IconMessage } from '@tabler/icons-react';
 import clsx from 'clsx';
 import { useState } from 'react';
+import { declineConsequence } from '~/components/Sticker/payout-copy';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 
@@ -21,11 +22,21 @@ export function StickerPlacementActions({
   placementIds,
   compact = false,
   hasComment = false,
+  free,
   stacked = false,
   onDone,
 }: {
   placementIds: number[];
   compact?: boolean;
+  /**
+   * Whether every placement in this set was placed free, which decides what the
+   * decline confirmation says a decline costs.
+   *
+   * `undefined` means a mixed selection rather than an unknown one — a bulk
+   * decline legitimately holds both kinds, and no single sentence about money is
+   * true of all of them. See `declineConsequence`.
+   */
+  free?: boolean;
   /**
    * Whether this carries a note. Only meaningful for a single placement — a bulk
    * action deliberately does not offer the choice, so a mixed selection cannot
@@ -131,8 +142,7 @@ export function StickerPlacementActions({
               {placementIds.length > 1
                 ? `Decline ${placementIds.length} placements?`
                 : 'Decline this placement?'}{' '}
-              The placer keeps most of what they paid, and a fee stays with you. This can&apos;t be
-              undone.
+              {declineConsequence(free)} This can&apos;t be undone.
             </Text>
             <Group gap="xs" justify="end">
               <Button size="compact-xs" variant="default" onClick={() => setConfirming(false)}>

--- a/src/components/Sticker/StickerPlacementBar.browser.test.tsx
+++ b/src/components/Sticker/StickerPlacementBar.browser.test.tsx
@@ -264,24 +264,39 @@ describe('StickerPlacementBar — free slots', () => {
   });
 
   /**
-   * One idea per label. Somebody about to place free should not read a price,
-   * and the mode — instant or reviewed — is deliberately not here either: it
-   * belongs on the free option itself, where the choice is made.
+   * 🔴 The bar must never promise free, and the count is why it is tempting to.
+   *
+   * `freeSlotsRemaining` is the CREATOR's capacity. It says nothing about this
+   * viewer — somebody who spent today's allowance, or already free-placed on this
+   * image, has no free option at all — and only the standing query answers that,
+   * which this bar deliberately does not make because it renders per feed card.
+   * So a "free" label here is read by the people it is false for, who then open
+   * the tray and pay a number they were never shown.
+   *
+   * Asserted across both capacity states, because the defect only appeared in one
+   * of them: a test pinned to the empty case passes while the promise is made.
    */
-  test('offers free rather than a price while a slot remains', async () => {
-    Object.assign(queryState, settled, { freeSlots: 4, freeSlotsRemaining: 2 });
-    await renderBar();
-
-    await placeButton().hover();
-    await expect.element(page.getByText('Place a sticker · free')).toBeInTheDocument();
-    expect(page.getByText(/100 Buzz/).elements()).toHaveLength(0);
-  });
-
-  test('quotes the price once the free slots are gone', async () => {
-    Object.assign(queryState, settled, { freeSlots: 4, freeSlotsRemaining: 0 });
+  test.each([
+    ['slots remaining', 2],
+    ['slots all taken', 0],
+  ])('quotes the price and never promises free — %s', async (_name, remaining) => {
+    Object.assign(queryState, settled, { freeSlots: 4, freeSlotsRemaining: remaining });
     await renderBar();
 
     await placeButton().hover();
     await expect.element(page.getByText('Place a sticker · 100 Buzz')).toBeInTheDocument();
+    expect(page.getByText(/·\s*free/).elements()).toHaveLength(0);
+  });
+
+  /**
+   * The count itself stays, and this is the line between the two: a number about
+   * the creator's capacity is a fact the bar has, and a claim about what THIS
+   * viewer will be charged is not.
+   */
+  test('still states the creator capacity it does know', async () => {
+    Object.assign(queryState, settled, { freeSlots: 4, freeSlotsRemaining: 2 });
+    await renderBar();
+
+    await expect.element(page.getByText('2 of 4 free')).toBeInTheDocument();
   });
 });

--- a/src/components/Sticker/StickerPlacementBar.browser.test.tsx
+++ b/src/components/Sticker/StickerPlacementBar.browser.test.tsx
@@ -29,6 +29,16 @@ const queryState = {
   countsError: false,
   placementsLoading: false,
   pending: [] as { imageId: number; isPending: boolean }[],
+  /**
+   * The creator's free capacity, and how much of it is left.
+   *
+   * Both, because `freeSlotsRemaining: 0` means two different things — "takes no
+   * free stickers" and "all slots currently held" — and the bar's copy has to
+   * tell them apart. A fixture carrying only the remainder could not express the
+   * difference, so the tests would agree with either behaviour.
+   */
+  freeSlots: 0,
+  freeSlotsRemaining: 0,
 };
 
 // Spread the real module: a hand-listed mock couples this test to the whole
@@ -48,7 +58,13 @@ vi.mock('~/components/Sticker/placement.util', async (importOriginal) => ({
     };
   },
   useImagePlacementSpace: () => ({
-    space: { mode: 'open', price: 100, ownerId: 999 },
+    space: {
+      mode: 'open',
+      price: 100,
+      ownerId: 999,
+      freeSlots: queryState.freeSlots,
+      freeSlotsRemaining: queryState.freeSlotsRemaining,
+    },
     isLoading: false,
   }),
 }));
@@ -166,5 +182,106 @@ describe('StickerPlacementBar', () => {
     // nothing to act on, so the argument is the thing worth pinning.
     expect(placementsEnabled.length).toBeGreaterThan(0);
     expect(placementsEnabled.every((enabled) => enabled === true)).toBe(true);
+  });
+});
+
+/**
+ * The one number the sticker button carries.
+ *
+ * Every state here is absorbing — nothing on a timer, nothing the component
+ * tears down — so these assert after a settled render rather than awaiting a
+ * state that could leave.
+ */
+describe('StickerPlacementBar — free slots', () => {
+  const settled = {
+    counts: {},
+    countsLoading: false,
+    countsError: false,
+    placementsLoading: false,
+    pending: [],
+  };
+
+  const placeButton = () => page.getByRole('button', { name: /^Place a sticker/ });
+  // By exact name, because the comparison below renders twice in one test and
+  // both buttons stay mounted — a pattern locator resolves to two elements there
+  // and fails on strict mode rather than on the property being tested.
+  const backgroundOf = async (name: string) =>
+    getComputedStyle(await page.getByRole('button', { name }).element()).backgroundColor;
+
+  test('carries the remaining count out of the creator capacity', async () => {
+    Object.assign(queryState, settled, { freeSlots: 4, freeSlotsRemaining: 2 });
+    await renderBar();
+
+    await expect.element(page.getByText('2 of 4 free')).toBeInTheDocument();
+    // On the accessible name too. A number only a sighted user can read is not
+    // the button carrying it.
+    expect(
+      page.getByRole('button', { name: 'Place a sticker · 2 of 4 free' }).elements()
+    ).toHaveLength(1);
+  });
+
+  /**
+   * The ambiguity that needed two numbers to resolve. A creator whose slots are
+   * all held still has something to say, because a slot comes back the moment
+   * one is declined — so this state reads `0 of 4`, not silence.
+   */
+  test('says nothing about free stickers when the creator takes none', async () => {
+    Object.assign(queryState, settled, { freeSlots: 0, freeSlotsRemaining: 0 });
+    await renderBar();
+
+    expect(page.getByText(/free$/).elements()).toHaveLength(0);
+    expect(page.getByRole('button', { name: 'Place a sticker' }).elements()).toHaveLength(1);
+  });
+
+  test('still reports the capacity when every slot is currently held', async () => {
+    Object.assign(queryState, settled, { freeSlots: 4, freeSlotsRemaining: 0 });
+    await renderBar();
+
+    await expect.element(page.getByText('0 of 4 free')).toBeInTheDocument();
+  });
+
+  /**
+   * The shiny treatment, asserted as a difference rather than as a colour: what
+   * has to be true is that a slot being available looks unlike one that is not.
+   * Pinning the exact rgba would fail on a theme change that kept the behaviour.
+   */
+  test('draws the button differently when a slot is available', async () => {
+    // A stickered image, deliberately. On an empty one the button already wears
+    // this tint as half of the "place the first one" invitation, so both renders
+    // would come back identical and the test would pass for the wrong reason —
+    // or fail, as it did, on a cause that has nothing to do with free slots.
+    const stickered = { ...settled, counts: { [IMAGE_ID]: 3 } };
+
+    Object.assign(queryState, stickered, { freeSlots: 4, freeSlotsRemaining: 1 });
+    await renderBar();
+    const available = await backgroundOf('Place a sticker · 1 of 4 free');
+
+    Object.assign(queryState, stickered, { freeSlots: 4, freeSlotsRemaining: 0 });
+    await renderBar();
+    const taken = await backgroundOf('Place a sticker · 0 of 4 free');
+
+    expect(available).not.toBe(taken);
+  });
+
+  /**
+   * One idea per label. Somebody about to place free should not read a price,
+   * and the mode — instant or reviewed — is deliberately not here either: it
+   * belongs on the free option itself, where the choice is made.
+   */
+  test('offers free rather than a price while a slot remains', async () => {
+    Object.assign(queryState, settled, { freeSlots: 4, freeSlotsRemaining: 2 });
+    await renderBar();
+
+    await placeButton().hover();
+    await expect.element(page.getByText('Place a sticker · free')).toBeInTheDocument();
+    expect(page.getByText(/100 Buzz/).elements()).toHaveLength(0);
+  });
+
+  test('quotes the price once the free slots are gone', async () => {
+    Object.assign(queryState, settled, { freeSlots: 4, freeSlotsRemaining: 0 });
+    await renderBar();
+
+    await placeButton().hover();
+    await expect.element(page.getByText('Place a sticker · 100 Buzz')).toBeInTheDocument();
   });
 });

--- a/src/components/Sticker/StickerPlacementBar.browser.test.tsx
+++ b/src/components/Sticker/StickerPlacementBar.browser.test.tsx
@@ -230,7 +230,12 @@ describe('StickerPlacementBar — free slots', () => {
     await renderBar();
 
     expect(page.getByText(/free$/).elements()).toHaveLength(0);
-    expect(page.getByRole('button', { name: 'Place a sticker' }).elements()).toHaveLength(1);
+    // `exact`, because the default is a substring match — so the bare name also
+    // matched "Place a sticker · 0 of 0 free" and the assertion survived the
+    // mutation `showsFree = canPlace`, which is the one it exists to catch.
+    expect(
+      page.getByRole('button', { name: 'Place a sticker', exact: true }).elements()
+    ).toHaveLength(1);
   });
 
   test('still reports the capacity when every slot is currently held', async () => {

--- a/src/components/Sticker/StickerPlacementBar.tsx
+++ b/src/components/Sticker/StickerPlacementBar.tsx
@@ -1,4 +1,4 @@
-import { Button, Tooltip } from '@mantine/core';
+import { Button, Text, Tooltip } from '@mantine/core';
 import { IconPlus } from '@tabler/icons-react';
 import clsx from 'clsx';
 import { useReactionSettingsContext } from '~/components/Reaction/ReactionSettingsProvider';
@@ -73,6 +73,24 @@ export function StickerPlacementBar({
   // Approved plus the viewer's own pending, which is what the toggle reveals.
   const total = count + pending;
 
+  /**
+   * How much of this creator's free capacity is still open.
+   *
+   * ⚠️ `freeSlotsRemaining === 0` covers two different facts and only
+   * `freeSlots` tells them apart: the resolver short-circuits the reservation
+   * count when there is no capacity, so zero is both "this creator takes no free
+   * placements" and "their slots are all currently held". The first has nothing
+   * to say and the second does, because a slot comes back on a decline.
+   *
+   * Both numbers ride on the space query this bar already makes, so the count
+   * costs nothing extra. It is a display number and stale by construction — the
+   * claim re-counts under a lock — which is why the button offers rather than
+   * promises.
+   */
+  const freeSlots = space?.freeSlots ?? 0;
+  const freeRemaining = space?.freeSlotsRemaining ?? 0;
+  const showsFree = canPlace && freeSlots > 0;
+
   // The invitation needs a zero that is KNOWN to be zero. `total` is fed by two
   // separate queries and a failure of either reads as empty, so an image with
   // stickers would otherwise show the invitation — and a press there opens a
@@ -128,14 +146,29 @@ export function StickerPlacementBar({
         )}
 
         {canPlace && (
-          <Tooltip label={`Place a sticker · ${space?.price} Buzz`} withArrow>
+          <Tooltip
+            // One idea, not two. Which offer is on the table is the whole
+            // content of this label, so it says that and leaves the mode —
+            // instant or reviewed — to the free option in the tray, where the
+            // placer is actually choosing what to spend.
+            label={
+              freeRemaining > 0
+                ? 'Place a sticker · free'
+                : `Place a sticker · ${space?.price} Buzz`
+            }
+            withArrow
+          >
             <Button
               size="compact-sm"
               radius="xl"
               variant="light"
               color="yellow"
               onClick={() => openTray(imageId)}
-              aria-label="Place a sticker"
+              aria-label={
+                showsFree
+                  ? `Place a sticker · ${freeRemaining} of ${freeSlots} free`
+                  : 'Place a sticker'
+              }
               // A plus rather than a second sticker glyph: beside a count of
               // stickers it reads as "add one" without a word, which is what
               // keeps the fused control narrow enough to belong in this row.
@@ -143,9 +176,26 @@ export function StickerPlacementBar({
               // Last, and merged over whatever the row's styling set: at zero
               // the plus is half the invitation, so it has to carry the same
               // tint the chip does or the pair reads as two unrelated controls.
-              style={{ ...buttonStyling?.('BuzzTip')?.style, ...(inviting ? inviteStyle : null) }}
+              //
+              // A free slot borrows the same tint for the same reason it exists:
+              // it is the row's own "there is something for you here" language,
+              // and inventing a second one for the free tier would make the two
+              // states compete rather than agree.
+              style={{
+                ...buttonStyling?.('BuzzTip')?.style,
+                ...(inviting || freeRemaining > 0 ? inviteStyle : null),
+              }}
             >
               <IconPlus size={16} stroke={2.5} />
+              {/* One number. Rendered even at zero remaining, because a full
+                  space is a thing worth knowing — a slot comes back on a
+                  decline — while a creator who takes no free placements has
+                  nothing to say and gets no label at all. */}
+              {showsFree && (
+                <Text size="xs" fw={600} className="ml-1">
+                  {freeRemaining} of {freeSlots} free
+                </Text>
+              )}
             </Button>
           </Tooltip>
         )}

--- a/src/components/Sticker/StickerPlacementBar.tsx
+++ b/src/components/Sticker/StickerPlacementBar.tsx
@@ -147,15 +147,21 @@ export function StickerPlacementBar({
 
         {canPlace && (
           <Tooltip
-            // One idea, not two. Which offer is on the table is the whole
-            // content of this label, so it says that and leaves the mode —
-            // instant or reviewed — to the free option in the tray, where the
-            // placer is actually choosing what to spend.
-            label={
-              freeRemaining > 0
-                ? 'Place a sticker · free'
-                : `Place a sticker · ${space?.price} Buzz`
-            }
+            /**
+             * 🔴 The price, always — never "free".
+             *
+             * `freeRemaining` is the CREATOR's capacity and says nothing about
+             * this viewer: somebody who has spent today's allowance, or already
+             * free-placed on this image, would be promised free and then pay a
+             * number they were never shown. Only the standing query answers that,
+             * and this bar deliberately does not make it — it renders per feed
+             * card, so it would be one request per card.
+             *
+             * So the bar states the fact it has (the count beside this, which is
+             * about the creator) and makes no claim about the offer. The offer is
+             * made in the tray, where the standing is known.
+             */
+            label={`Place a sticker · ${space?.price} Buzz`}
             withArrow
           >
             <Button

--- a/src/components/Sticker/StickerPlacementHoverCard.tsx
+++ b/src/components/Sticker/StickerPlacementHoverCard.tsx
@@ -14,6 +14,7 @@ import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon
 import { NextLink as Link } from '~/components/NextLink/NextLink';
 import { openReportModal } from '~/components/Dialog/triggers/report';
 import { useForgetStickerPlacement } from '~/components/Sticker/placement.util';
+import { removalConsequence, removalLockReason } from '~/components/Sticker/payout-copy';
 import { ReportEntity } from '~/shared/utils/report-helpers';
 import type { ReactElement } from 'react';
 import { useState } from 'react';
@@ -212,7 +213,11 @@ export function StickerPlacementHoverCard({
                   before an irreversible click. */}
               <ModeratorRemove placementId={placementId} pending={data.status === 'pending'} />
               {data.viewerIsOwner && data.status === 'approved' && (
-                <OwnerRemove placementId={placementId} removableAt={data.removableAt} />
+                <OwnerRemove
+                  placementId={placementId}
+                  removableAt={data.removableAt}
+                  free={data.free}
+                />
               )}
             </>
           )}
@@ -426,9 +431,15 @@ function HideNote({ placementId, commentHidden }: { placementId: number; comment
 function OwnerRemove({
   placementId,
   removableAt,
+  free,
 }: {
   placementId: number;
   removableAt: Date | string | null;
+  /**
+   * Whether this was placed against the creator's free capacity. Both sentences
+   * below are about money, and both are false when none moved.
+   */
+  free: boolean;
 }) {
   const forget = useForgetStickerPlacement();
 
@@ -450,9 +461,7 @@ function OwnerRemove({
       w={240}
       label={
         locked
-          ? `Someone paid to place this, so it stays up for a week. You can remove it from ${formatDate(
-              removableAt as Date
-            )}.`
+          ? `${removalLockReason(free)} You can remove it from ${formatDate(removableAt as Date)}.`
           : 'Takes the sticker off your image. No Buzz moves.'
       }
     >
@@ -470,12 +479,7 @@ function OwnerRemove({
           onClick={() =>
             openConfirmModal({
               title: 'Remove this sticker',
-              children: (
-                <Text size="sm">
-                  It comes off your image for everyone. The Buzz you were paid for it stays with
-                  you, and nobody is notified.
-                </Text>
-              ),
+              children: <Text size="sm">{removalConsequence(free)}</Text>,
               labels: { confirm: 'Remove', cancel: 'Cancel' },
               confirmProps: { color: 'red' },
               onConfirm: () => remove.mutate({ placementIds: [placementId], action: 'remove' }),

--- a/src/components/Sticker/StickerPlacementHoverCard.tsx
+++ b/src/components/Sticker/StickerPlacementHoverCard.tsx
@@ -14,7 +14,11 @@ import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon
 import { NextLink as Link } from '~/components/NextLink/NextLink';
 import { openReportModal } from '~/components/Dialog/triggers/report';
 import { useForgetStickerPlacement } from '~/components/Sticker/placement.util';
-import { removalConsequence, removalLockReason } from '~/components/Sticker/payout-copy';
+import {
+  moderatorTakedownConsequence,
+  removalConsequence,
+  removalLockReason,
+} from '~/components/Sticker/payout-copy';
 import { ReportEntity } from '~/shared/utils/report-helpers';
 import type { ReactElement } from 'react';
 import { useState } from 'react';
@@ -211,7 +215,11 @@ export function StickerPlacementHoverCard({
                   for as long as the page stays open — and that value would pick
                   the confirmation's sentence about the placer's money, right
                   before an irreversible click. */}
-              <ModeratorRemove placementId={placementId} pending={data.status === 'pending'} />
+              <ModeratorRemove
+                placementId={placementId}
+                pending={data.status === 'pending'}
+                free={data.free}
+              />
               {data.viewerIsOwner && data.status === 'approved' && (
                 <OwnerRemove
                   placementId={placementId}
@@ -505,9 +513,12 @@ function OwnerRemove({
  * On a live placement nothing else happens: no refund, and nobody is notified
  * (Justin, 2026-08-08). The escrow was paid to a content owner who did not
  * choose the sticker, and clawing it back would charge them for someone else's
- * problem. **A pending one is not that**: it settles as `removeByModerator`,
+ * problem. **A pending PAID one is not that**: it settles as `removeByModerator`,
  * whose payout is a forfeit of the whole escrow, fee and principal — so the
  * confirmation has to say a different thing about the money.
+ *
+ * A free row has no escrow at all, in either state, so both of those sentences are
+ * false of one and the confirmation branches on `free` as well as on `pending`.
  *
  * Rendered for moderators only, which is convenience — `removePlacement` is a
  * `moderatorProcedure`, so the refusal is on the mutation and stays there.
@@ -515,9 +526,12 @@ function OwnerRemove({
 function ModeratorRemove({
   placementId,
   pending = false,
+  free,
 }: {
   placementId: number;
   pending?: boolean;
+  /** No escrow exists on a free row, so neither branch below is true of one. */
+  free: boolean;
 }) {
   const currentUser = useCurrentUser();
   const forget = useForgetStickerPlacement();
@@ -553,13 +567,7 @@ function ModeratorRemove({
         onClick={() =>
           openConfirmModal({
             title: 'Take this placement down',
-            children: (
-              <Text size="sm">
-                {pending
-                  ? 'This one is still awaiting the owner. Taking it down forfeits everything the placer paid — they get nothing back, and nobody is notified.'
-                  : 'The sticker comes off this content for everyone, recorded as a moderator takedown. No Buzz moves and nobody is notified.'}
-              </Text>
-            ),
+            children: <Text size="sm">{moderatorTakedownConsequence({ pending, free })}</Text>,
             labels: { confirm: 'Take down', cancel: 'Cancel' },
             confirmProps: { color: 'red' },
             onConfirm: () => remove.mutate({ placementId }),

--- a/src/components/Sticker/StickerPlacementOverlay.tsx
+++ b/src/components/Sticker/StickerPlacementOverlay.tsx
@@ -498,6 +498,7 @@ export function StickerPlacementOverlay({
                       <StickerPlacementActions
                         placementIds={[placement.id]}
                         hasComment={placement.hasComment}
+                        free={placement.free}
                         compact
                       />
                     ) : (

--- a/src/components/Sticker/StickerPlacementTray.tsx
+++ b/src/components/Sticker/StickerPlacementTray.tsx
@@ -3,7 +3,7 @@ import { IconPlus, IconSticker } from '@tabler/icons-react';
 import clsx from 'clsx';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { EdgeImage } from '~/components/EdgeMedia/EdgeImage';
-import { freeOfferFor } from '~/components/Sticker/free-offer';
+import { freeOfferFor, trayPriceLine, trayReviewLine } from '~/components/Sticker/free-offer';
 import { StickerShopPanel } from '~/components/Sticker/StickerShopPanel';
 import { StickerShopTile } from '~/components/Sticker/StickerShopTile';
 import { useStickerDragOut } from '~/components/Sticker/use-sticker-drag-out';
@@ -168,25 +168,16 @@ export function StickerPlacementTray({ imageId }: { imageId: number }) {
                 {instruction}
               </Text>
               <Text size="xs" c="dimmed">
-                {/* The use is the constant. A free placement is free of the
-                    creator's price and of nothing else, and saying so here
-                    stops the tray and the Place button disagreeing about what
-                    a sticker costs. What the free option means — instant or
-                    reviewed — is said on the option itself, where it is
-                    chosen. */}
-                {freeAvailable
-                  ? `Free, or ${price} Buzz · one use either way`
-                  : `${price} Buzz + one use`}
+                {/* Both sentences come from `free-offer.ts`, where their
+                    branches are covered — inline here, dropping either ternary
+                    is a mutation nothing in the suite can observe, and what it
+                    produces is the exact contradiction these lines exist to
+                    prevent. The free half of the decline warning is
+                    FREE_REVIEW_CAVEAT itself rather than a paraphrase. */}
+                {trayPriceLine(freeAvailable, price)}
                 {space?.mode === 'review' &&
                   ' · this creator reviews placements, so only you will see it until they approve.'}
-                {/* What a decline costs differs between the two offers, so where
-                    both are on the table it is said once in a form that is true
-                    of each. The old paid-only sentence sat beside "Free, or X
-                    Buzz" and contradicted FREE_REVIEW_CAVEAT one file over. */}
-                {space?.mode === 'review' &&
-                  (freeAvailable
-                    ? ' If they decline, a free placement still costs your allowance for the day, and part of a paid one stays with them.'
-                    : ' If they decline, part of what you paid stays with them.')}
+                {space?.mode === 'review' && trayReviewLine(freeAvailable)}
               </Text>
             </div>
             <CloseButton

--- a/src/components/Sticker/StickerPlacementTray.tsx
+++ b/src/components/Sticker/StickerPlacementTray.tsx
@@ -3,10 +3,14 @@ import { IconPlus, IconSticker } from '@tabler/icons-react';
 import clsx from 'clsx';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { EdgeImage } from '~/components/EdgeMedia/EdgeImage';
+import { freeOfferFor } from '~/components/Sticker/free-offer';
 import { StickerShopPanel } from '~/components/Sticker/StickerShopPanel';
 import { StickerShopTile } from '~/components/Sticker/StickerShopTile';
 import { useStickerDragOut } from '~/components/Sticker/use-sticker-drag-out';
-import { useImagePlacementSpace } from '~/components/Sticker/placement.util';
+import {
+  useFreePlacementStanding,
+  useImagePlacementSpace,
+} from '~/components/Sticker/placement.util';
 import { stickerMaxScale } from '~/shared/utils/sticker-placement';
 import { useOwnedSticker } from '~/components/Sticker/sticker.util';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
@@ -63,6 +67,10 @@ export function StickerPlacementTray({ imageId }: { imageId: number }) {
   }, [showing, setTray]);
 
   const { space } = useImagePlacementSpace(targetImageId ?? undefined);
+  // Same query key as the layer's, so this shares its cache rather than making a
+  // second request. Here it only decides one clause of one sentence; the choice
+  // itself is made on the draft, where the mode is also shown.
+  const { standing } = useFreePlacementStanding(targetImageId ?? undefined);
   const { data: balances } = trpc.cosmetic.getStickerBalances.useQuery(undefined, {
     enabled: !!currentUser && targetImageId != null,
   });
@@ -134,6 +142,9 @@ export function StickerPlacementTray({ imageId }: { imageId: number }) {
   };
 
   const price = space?.price ?? 0;
+  // The same predicate the draft's own control uses, so the sentence here and
+  // the button down there cannot disagree about what is on offer.
+  const freeAvailable = !!freeOfferFor(space, standing);
   // Says the panel can be got out of the way, and that more than one is allowed,
   // only once there is something that would survive it. Before that both are
   // instructions about nothing.
@@ -157,7 +168,15 @@ export function StickerPlacementTray({ imageId }: { imageId: number }) {
                 {instruction}
               </Text>
               <Text size="xs" c="dimmed">
-                {price} Buzz + one use
+                {/* The use is the constant. A free placement is free of the
+                    creator's price and of nothing else, and saying so here
+                    stops the tray and the Place button disagreeing about what
+                    a sticker costs. What the free option means — instant or
+                    reviewed — is said on the option itself, where it is
+                    chosen. */}
+                {freeAvailable
+                  ? `Free, or ${price} Buzz · one use either way`
+                  : `${price} Buzz + one use`}
                 {space?.mode === 'review' &&
                   ' · this creator reviews placements, so only you will see it until they approve. If they decline, part of what you paid stays with them.'}
               </Text>

--- a/src/components/Sticker/StickerPlacementTray.tsx
+++ b/src/components/Sticker/StickerPlacementTray.tsx
@@ -178,7 +178,15 @@ export function StickerPlacementTray({ imageId }: { imageId: number }) {
                   ? `Free, or ${price} Buzz · one use either way`
                   : `${price} Buzz + one use`}
                 {space?.mode === 'review' &&
-                  ' · this creator reviews placements, so only you will see it until they approve. If they decline, part of what you paid stays with them.'}
+                  ' · this creator reviews placements, so only you will see it until they approve.'}
+                {/* What a decline costs differs between the two offers, so where
+                    both are on the table it is said once in a form that is true
+                    of each. The old paid-only sentence sat beside "Free, or X
+                    Buzz" and contradicted FREE_REVIEW_CAVEAT one file over. */}
+                {space?.mode === 'review' &&
+                  (freeAvailable
+                    ? ' If they decline, a free placement still costs your allowance for the day, and part of a paid one stays with them.'
+                    : ' If they decline, part of what you paid stays with them.')}
               </Text>
             </div>
             <CloseButton

--- a/src/components/Sticker/__tests__/free-offer.test.ts
+++ b/src/components/Sticker/__tests__/free-offer.test.ts
@@ -6,6 +6,8 @@ import {
   freeRefusalMessage,
   freeRefusalOutcome,
   isPlacingFree,
+  trayPriceLine,
+  trayReviewLine,
 } from '~/components/Sticker/free-offer';
 
 describe('the free option carries the mode', () => {
@@ -296,6 +298,82 @@ describe('what a refused free claim does next', () => {
   it('titles the two cases differently, since one is about price and one is not', () => {
     expect(freeRefusalOutcome('anything', SERVER).title).not.toBe(
       freeRefusalOutcome(null, SERVER).title
+    );
+  });
+});
+
+/**
+ * The tray's two sentences, here rather than in the component because inline
+ * neither ternary was observable: dropping either one turns nothing red and
+ * produces the exact contradiction the lines exist to prevent.
+ */
+describe('the tray states both offers when both are open', () => {
+  it('names free and the price together, with the use as the constant', () => {
+    const both = trayPriceLine(true, 700);
+
+    expect(both).toMatch(/Free/);
+    expect(both).toMatch(/700 Buzz/);
+    // Free of the creator's price and of nothing else. Without this the tray and
+    // the Place button disagree about what a sticker costs.
+    expect(both).toMatch(/one use either way/);
+  });
+
+  it('names only the price when free is not on offer', () => {
+    const paid = trayPriceLine(false, 700);
+
+    expect(paid).toBe('700 Buzz + one use');
+    expect(paid).not.toMatch(/[Ff]ree/);
+  });
+
+  /**
+   * 🔴 The free half is `FREE_REVIEW_CAVEAT` itself, not a paraphrase. Three
+   * places in the product state what a decline costs a free placer — this, the
+   * caveat under the draft's own free option, and `declineConsequence` on the
+   * owner's side — and two of the three now come from one constant.
+   */
+  it('reuses the owned caveat rather than restating it', () => {
+    expect(trayReviewLine(true)).toContain(FREE_REVIEW_CAVEAT);
+  });
+
+  it('keeps the paid fee disclosure in both branches', () => {
+    // Where both offers are open, somebody choosing to pay still needs it.
+    for (const freeAvailable of [true, false])
+      expect(trayReviewLine(freeAvailable)).toMatch(/part of what you paid/);
+  });
+
+  it('says nothing about an allowance when free is not on offer', () => {
+    expect(trayReviewLine(false)).not.toMatch(/allowance/);
+  });
+});
+
+/**
+ * When the allowance comes back, taken from the value the server computed rather
+ * than from a boundary written down twice.
+ */
+describe('the reset the refusal names', () => {
+  const spent = { remaining: 0, usedHere: false };
+  const open = { freeSlots: 4, freeSlotsRemaining: 2 };
+
+  it('uses the reset the server shipped', () => {
+    expect(
+      freeRefusalMessage({ ...spent, resetsAt: new Date('2026-08-18T00:00:00Z') }, open)
+    ).toMatch(/comes back at 00:00 UTC/);
+  });
+
+  /**
+   * The point of deriving it: the day boundary is the server's rule, so a
+   * different one has to change this sentence rather than leave it wrong.
+   */
+  it('follows a reset that is not midnight', () => {
+    expect(
+      freeRefusalMessage({ ...spent, resetsAt: new Date('2026-08-18T06:30:00Z') }, open)
+    ).toMatch(/comes back at 06:30 UTC/);
+  });
+
+  it('still says when it lifts if the reset never arrived', () => {
+    expect(freeRefusalMessage(spent, open)).toMatch(/comes back at midnight UTC/);
+    expect(freeRefusalMessage({ ...spent, resetsAt: 'not a date' }, open)).toMatch(
+      /comes back at midnight UTC/
     );
   });
 });

--- a/src/components/Sticker/__tests__/free-offer.test.ts
+++ b/src/components/Sticker/__tests__/free-offer.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FREE_REVIEW_CAVEAT,
+  freeOfferFor,
+  freeOptionLabel,
+  freeRefusalMessage,
+  isPlacingFree,
+} from '~/components/Sticker/free-offer';
+
+describe('the free option carries the mode', () => {
+  it('says instant on an auto-accept space and needs review otherwise', () => {
+    expect(freeOptionLabel(true)).toBe('Free · instant');
+    expect(freeOptionLabel(false)).toBe('Free · needs review');
+  });
+
+  /**
+   * The distinction is the whole reason the mode is on this option rather than on
+   * the sticker button: a placer choosing between two offers needs to know which
+   * one goes live now. A label that read the same either way would leave the mode
+   * a hidden setting again.
+   */
+  it('reads differently in the two modes', () => {
+    expect(freeOptionLabel(true)).not.toBe(freeOptionLabel(false));
+  });
+
+  it('states the asymmetry a decline creates', () => {
+    // The image's slot comes back and the placer's day does not, which is the
+    // one fact somebody might choose to pay to avoid.
+    expect(FREE_REVIEW_CAVEAT).toMatch(/spent even if they decline/);
+    expect(FREE_REVIEW_CAVEAT).toMatch(/allowance does not/);
+  });
+});
+
+/**
+ * The refusal copy, chosen from state re-read after the claim was refused rather
+ * than from the server's own message.
+ *
+ * Ordered most specific first, so the most useful true thing wins. Each case
+ * below is a distinct thing to tell somebody and a distinct thing to do next —
+ * wait for midnight, pick a different image, or just pay — so collapsing any two
+ * of them would send a person to the wrong remedy.
+ */
+describe('what a refused free claim says', () => {
+  const HAS_SLOT = { freeSlots: 4, freeSlotsRemaining: 2 };
+  const FULL = { freeSlots: 4, freeSlotsRemaining: 0 };
+  const CLOSED = { freeSlots: 0, freeSlotsRemaining: 0 };
+  const HAS_DAY = { remaining: 1, usedHere: false };
+
+  it('names this image when the placer has already used one here', () => {
+    expect(freeRefusalMessage({ remaining: 1, usedHere: true }, HAS_SLOT)).toMatch(
+      /already used a free sticker on this image/
+    );
+  });
+
+  it('names the reset when the day is spent', () => {
+    expect(freeRefusalMessage({ remaining: 0, usedHere: false }, HAS_SLOT)).toMatch(/midnight UTC/);
+  });
+
+  it('names the race when the last slot went to somebody else', () => {
+    expect(freeRefusalMessage(HAS_DAY, FULL)).toMatch(/took the last free slot/);
+  });
+
+  /**
+   * `freeSlotsRemaining === 0` covers two different facts, and this is where the
+   * two have to be told apart: the resolver short-circuits the reservation count
+   * when there is no capacity, so a creator who takes no free stickers looks
+   * identical to one whose slots are full unless `freeSlots` is read alongside.
+   * Saying somebody beat them to it would be a lie about a slot that never
+   * existed.
+   */
+  it('distinguishes a closed space from a full one', () => {
+    const closed = freeRefusalMessage(HAS_DAY, CLOSED);
+
+    expect(closed).toMatch(/not taking free stickers/);
+    expect(closed).not.toBe(freeRefusalMessage(HAS_DAY, FULL));
+  });
+
+  /**
+   * A block, a suspension, or the creator closing the space between the render
+   * and the press. The re-read cannot explain those, and naming a cause we do
+   * not have is worse than saying only what is certain.
+   */
+  it('says only what is certain when the re-read explains nothing', () => {
+    expect(freeRefusalMessage(HAS_DAY, HAS_SLOT)).toBe('That free slot could not be claimed.');
+    expect(freeRefusalMessage()).toBe('That free slot could not be claimed.');
+  });
+
+  it('never quotes the server, which is free to reword its refusals', () => {
+    const every = [
+      freeRefusalMessage({ remaining: 1, usedHere: true }, HAS_SLOT),
+      freeRefusalMessage({ remaining: 0, usedHere: false }, HAS_SLOT),
+      freeRefusalMessage(HAS_DAY, FULL),
+      freeRefusalMessage(HAS_DAY, CLOSED),
+      freeRefusalMessage(HAS_DAY, HAS_SLOT),
+    ];
+
+    // The service prefixes every placement refusal this way. A message carrying
+    // it would mean the client had started parsing prose instead.
+    for (const message of every) expect(message).not.toContain('placement:');
+  });
+});
+
+/**
+ * Whether the free offer is on the table at all.
+ *
+ * Three separate facts, each a different reason to be looking at the paid
+ * button, so each is checked on its own — a predicate that dropped one would
+ * offer something the claim then refuses, and the placer would meet a refusal
+ * after choosing rather than an offer that was never there.
+ */
+describe('whether the free offer is available', () => {
+  const OPEN = { mode: 'review', freeSlots: 4, freeSlotsRemaining: 2 };
+  const HAS_DAY = { remaining: 1, usedHere: false };
+
+  it('offers free when the creator has a slot and the placer has their day', () => {
+    expect(freeOfferFor(OPEN, HAS_DAY)).toEqual({ instant: false });
+  });
+
+  it('carries the mode, which is what the option label needs', () => {
+    expect(freeOfferFor({ ...OPEN, mode: 'auto' }, HAS_DAY)).toEqual({ instant: true });
+  });
+
+  it('withholds it when the creator has no slots left', () => {
+    expect(freeOfferFor({ ...OPEN, freeSlotsRemaining: 0 }, HAS_DAY)).toBeNull();
+  });
+
+  it('withholds it when the placer has spent their day', () => {
+    expect(freeOfferFor(OPEN, { remaining: 0, usedHere: false })).toBeNull();
+  });
+
+  it('withholds it when the placer has already placed free on this image', () => {
+    expect(freeOfferFor(OPEN, { remaining: 1, usedHere: true })).toBeNull();
+  });
+
+  /**
+   * Paid first while either answer is unknown. The other order shows a free
+   * option and then removes it as the query lands, which is the one thing worse
+   * than not offering it — somebody reads a free offer, reaches for it, and it
+   * has become a charge.
+   */
+  it('withholds it until both answers have arrived', () => {
+    expect(freeOfferFor(undefined, HAS_DAY)).toBeNull();
+    expect(freeOfferFor(OPEN, undefined)).toBeNull();
+    expect(freeOfferFor()).toBeNull();
+  });
+});
+
+/**
+ * Which offer is selected. The default is the whole decision here: free wherever
+ * one is available, because the point of the free tier is that somebody tries
+ * the feature without paying to find out whether they like it.
+ */
+describe('which offer is selected', () => {
+  const OFFER = { instant: false };
+
+  it('defaults to free whenever an offer is available', () => {
+    expect(isPlacingFree(null, OFFER)).toBe(true);
+  });
+
+  it('defaults to paid when there is no free offer', () => {
+    expect(isPlacingFree(null, null)).toBe(false);
+  });
+
+  it('respects an explicit choice of paid while free is still available', () => {
+    // Paid placements never consume free slots, so choosing to pay when a free
+    // slot exists is a real choice rather than a mistake to correct.
+    expect(isPlacingFree('paid', OFFER)).toBe(false);
+  });
+
+  /**
+   * The fallback after a lost slot race, and the reason the second argument wins
+   * over the first: the control settles on paid by clearing the offer as well as
+   * by setting the choice, and a stale `'free'` must not survive either.
+   */
+  it('never places free once the offer has gone, whatever was chosen', () => {
+    expect(isPlacingFree('free', null)).toBe(false);
+  });
+});

--- a/src/components/Sticker/__tests__/free-offer.test.ts
+++ b/src/components/Sticker/__tests__/free-offer.test.ts
@@ -4,6 +4,7 @@ import {
   freeOfferFor,
   freeOptionLabel,
   freeRefusalMessage,
+  freeRefusalOutcome,
   isPlacingFree,
 } from '~/components/Sticker/free-offer';
 
@@ -75,28 +76,20 @@ describe('what a refused free claim says', () => {
     expect(closed).not.toBe(freeRefusalMessage(HAS_DAY, FULL));
   });
 
-  /**
-   * A block, a suspension, or the creator closing the space between the render
-   * and the press. The re-read cannot explain those, and naming a cause we do
-   * not have is worse than saying only what is certain.
-   */
-  it('says only what is certain when the re-read explains nothing', () => {
-    expect(freeRefusalMessage(HAS_DAY, HAS_SLOT)).toBe('That free slot could not be claimed.');
-    expect(freeRefusalMessage()).toBe('That free slot could not be claimed.');
-  });
-
-  it('never quotes the server, which is free to reword its refusals', () => {
-    const every = [
+  it('never quotes the server where it does speak, since prose may be reworded', () => {
+    const spoken = [
       freeRefusalMessage({ remaining: 1, usedHere: true }, HAS_SLOT),
       freeRefusalMessage({ remaining: 0, usedHere: false }, HAS_SLOT),
       freeRefusalMessage(HAS_DAY, FULL),
       freeRefusalMessage(HAS_DAY, CLOSED),
-      freeRefusalMessage(HAS_DAY, HAS_SLOT),
     ];
 
+    // Every rung answers, so a null here would mean a branch stopped firing and
+    // the loop below went vacuous.
+    expect(spoken.filter(Boolean)).toHaveLength(spoken.length);
     // The service prefixes every placement refusal this way. A message carrying
     // it would mean the client had started parsing prose instead.
-    for (const message of every) expect(message).not.toContain('placement:');
+    for (const message of spoken) expect(message).not.toContain('placement:');
   });
 });
 
@@ -174,5 +167,135 @@ describe('which offer is selected', () => {
    */
   it('never places free once the offer has gone, whatever was chosen', () => {
     expect(isPlacingFree('free', null)).toBe(false);
+  });
+});
+
+/**
+ * The ladder's ORDER, which no single-condition fixture can hold.
+ *
+ * More than one rung is true at once in ordinary use — a placer who spent their
+ * day on a creator who has since closed their slots trips two — and the first
+ * match is what gets said. A test that only ever sets one condition passes for
+ * every permutation of the ladder, so the swap that turns a true sentence into a
+ * false one is invisible to it.
+ *
+ * Each case below sets BOTH conditions of one adjacent pair and names the rung
+ * that has to win. The rule is that a refusal which is permanent for this image
+ * outranks one that lifts by itself: "your allowance comes back at midnight" is a
+ * promise about tomorrow, and on an image whose creator takes no free stickers it
+ * is simply false.
+ */
+describe('the refusal ladder is ordered, not merely complete', () => {
+  const CLOSED = { freeSlots: 0, freeSlotsRemaining: 0 };
+  const FULL = { freeSlots: 4, freeSlotsRemaining: 0 };
+  const OPEN = { freeSlots: 4, freeSlotsRemaining: 2 };
+  const SPENT = { remaining: 0, usedHere: false };
+  const PLACED_HERE = { remaining: 1, usedHere: true };
+  const BOTH_SPENT = { remaining: 0, usedHere: true };
+
+  it.each([
+    [
+      'a closed space outranks having already placed here',
+      CLOSED,
+      PLACED_HERE,
+      /not taking free stickers/,
+    ],
+    [
+      'having already placed here outranks a spent day',
+      OPEN,
+      BOTH_SPENT,
+      /already used a free sticker on this image/,
+    ],
+    ['a spent day outranks a full space', FULL, SPENT, /midnight UTC/],
+  ])('%s', (_name, space, standing, expected) => {
+    expect(freeRefusalMessage(standing, space)).toMatch(expected);
+  });
+
+  /**
+   * The transitive case, stated separately because pairwise adjacency does not
+   * imply it: every rung true at once still has to produce the permanent one.
+   * This is the state a creator closing their slots leaves behind for somebody
+   * who had already placed and already spent their day.
+   */
+  it('says the permanent thing when every rung is true', () => {
+    expect(freeRefusalMessage(BOTH_SPENT, CLOSED)).toMatch(/not taking free stickers/);
+  });
+
+  /**
+   * The specific false promise the order exists to prevent, asserted as an
+   * absence as well as a presence — a reordering that produced some other true
+   * sentence would still be caught by the pairs above, but this is the one that
+   * sends somebody back tomorrow for nothing.
+   */
+  it('never promises a reset on an image that will never take a free sticker', () => {
+    expect(freeRefusalMessage(SPENT, CLOSED)).not.toMatch(/midnight/);
+  });
+});
+
+/**
+ * What the ladder deliberately will NOT answer.
+ *
+ * A free placement is refused by everything the paid one is — a block, a
+ * moderator suspension, self-placement, a sticker over the creator's size limit
+ * — and each of those arrives with a message written for the person who hit it.
+ * `null` is what tells the caller to show that message instead of inventing one,
+ * and it is the difference between a wrong reason and a wrong remedy: offering
+ * the paid button to somebody who is blocked fails the same way again.
+ */
+describe('the ladder stays silent where it does not know', () => {
+  it('returns null when nothing about the free tier explains the refusal', () => {
+    expect(
+      freeRefusalMessage({ remaining: 1, usedHere: false }, { freeSlots: 4, freeSlotsRemaining: 2 })
+    ).toBeNull();
+  });
+
+  it('returns null when the re-read itself did not arrive', () => {
+    expect(freeRefusalMessage()).toBeNull();
+    expect(freeRefusalMessage({ remaining: 1, usedHere: false })).toBeNull();
+    expect(freeRefusalMessage(undefined, { freeSlots: 4, freeSlotsRemaining: 2 })).toBeNull();
+  });
+});
+
+/**
+ * What the refusal does, as distinct from what it says.
+ *
+ * `fallBackToPaid` is the consequential half. A control that settles on paid is
+ * telling somebody the problem was money — right when the free slots ran out,
+ * and wrong when the placement itself was refused, because the paid button then
+ * fails the same way and they have been sent to a remedy that cannot work.
+ */
+describe('what a refused free claim does next', () => {
+  const SERVER = 'placement: you cannot place a sticker on your own content';
+
+  it('falls back to paid, with its own wording, where free specifically ran out', () => {
+    const outcome = freeRefusalOutcome(
+      'Someone took the last free slot on this image first.',
+      SERVER
+    );
+
+    expect(outcome.fallBackToPaid).toBe(true);
+    expect(outcome.message).toMatch(/last free slot/);
+    // Not the server's prose, which does not say which rule stopped it.
+    expect(outcome.message).not.toContain('placement:');
+  });
+
+  /**
+   * The defect this shape exists to avoid: a refusal that has nothing to do with
+   * the free tier arrives with a message somebody wrote for exactly this moment,
+   * and reporting it as a lost race discards that message AND offers a button
+   * that will fail identically.
+   */
+  it('keeps the server message and does not offer paid where the placement was refused', () => {
+    const outcome = freeRefusalOutcome(null, SERVER);
+
+    expect(outcome.fallBackToPaid).toBe(false);
+    expect(outcome.message).toBe(SERVER);
+    expect(outcome.message).not.toMatch(/free slot/);
+  });
+
+  it('titles the two cases differently, since one is about price and one is not', () => {
+    expect(freeRefusalOutcome('anything', SERVER).title).not.toBe(
+      freeRefusalOutcome(null, SERVER).title
+    );
   });
 });

--- a/src/components/Sticker/__tests__/payout-copy.test.ts
+++ b/src/components/Sticker/__tests__/payout-copy.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
   declineConsequence,
+  moderatorTakedownConsequence,
   payoutCopy,
+  placementPaymentSummary,
   removalConsequence,
   removalLockReason,
+  selectionFree,
   stickerPurchaseCopy,
 } from '~/components/Sticker/payout-copy';
 
@@ -129,5 +132,99 @@ describe('the removal copy', () => {
   it('says nobody is notified either way, which is true of both', () => {
     for (const free of [true, false])
       expect(removalConsequence(free)).toMatch(/nobody is notified/);
+  });
+});
+
+/**
+ * The queue row's headline, which is the only money statement on the card the
+ * Approve and Decline buttons sit under — and the page the free-placement
+ * notification sends the creator to.
+ */
+describe('placementPaymentSummary', () => {
+  it('states the amount on a paid placement', () => {
+    expect(placementPaymentSummary(false, 700)).toBe('paid 700 Buzz');
+  });
+
+  /**
+   * A free row is `amount: 0`, DB-enforced. Unbranched, this card asserted a
+   * payment of zero directly above an irreversible choice, on the page a
+   * notification saying "free" had just linked to.
+   */
+  it('claims no payment on a free one, and names no amount', () => {
+    const free = placementPaymentSummary(true, 0);
+
+    expect(free).toBe('placed this free');
+    expect(free).not.toMatch(/paid|Buzz|0/);
+  });
+});
+
+describe('moderatorTakedownConsequence', () => {
+  it('warns that a pending paid placement forfeits the whole escrow', () => {
+    expect(moderatorTakedownConsequence({ pending: true, free: false })).toMatch(
+      /forfeits everything the placer paid/
+    );
+  });
+
+  it('says no Buzz moves on a live paid placement', () => {
+    expect(moderatorTakedownConsequence({ pending: false, free: false })).toMatch(/No Buzz moves/);
+  });
+
+  /**
+   * There is no escrow on a free row in either state, so the pending branch's
+   * forfeit is a claim about money that does not exist — asserted at an
+   * irreversible action a moderator is about to take.
+   */
+  it.each([true, false])('never claims a forfeit on a free row — pending %s', (pending) => {
+    const free = moderatorTakedownConsequence({ pending, free: true });
+
+    expect(free).not.toMatch(/forfeit|already paid|gets? nothing back/);
+    expect(free).toMatch(/[Nn]othing was paid for it/);
+    expect(free).toMatch(/nobody is notified/);
+  });
+
+  it('separates the two states on a free row too', () => {
+    expect(moderatorTakedownConsequence({ pending: true, free: true })).not.toBe(
+      moderatorTakedownConsequence({ pending: false, free: true })
+    );
+  });
+});
+
+/**
+ * All free, all paid, or mixed — extracted from the queue page because the mixed
+ * case is the one that matters and it was untestable inline.
+ */
+describe('selectionFree', () => {
+  const rows = [
+    { id: 1, free: true },
+    { id: 2, free: true },
+    { id: 3, free: false },
+  ];
+
+  it('reports a uniform selection', () => {
+    expect(selectionFree([1, 2], rows)).toBe(true);
+    expect(selectionFree([3], rows)).toBe(false);
+  });
+
+  /**
+   * The mutation this exists for: collapsing to whichever kind came first makes a
+   * bulk decline assert a sentence false of half the rows it is about.
+   */
+  it('reports mixed as undefined rather than picking a side', () => {
+    expect(selectionFree([1, 3], rows)).toBeUndefined();
+    expect(selectionFree([3, 1], rows)).toBeUndefined();
+  });
+
+  /**
+   * An id whose row has not paged in yet is unknown, which makes the whole
+   * selection mixed — the safe direction, because `declineConsequence` then says
+   * only what covers both.
+   */
+  it('treats a row it cannot see as unknown', () => {
+    expect(selectionFree([1, 99], rows)).toBeUndefined();
+    expect(selectionFree([99], rows)).toBeUndefined();
+  });
+
+  it('says nothing about an empty selection', () => {
+    expect(selectionFree([], rows)).toBeUndefined();
   });
 });

--- a/src/components/Sticker/__tests__/payout-copy.test.ts
+++ b/src/components/Sticker/__tests__/payout-copy.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { payoutCopy, stickerPurchaseCopy } from '~/components/Sticker/payout-copy';
+import {
+  declineConsequence,
+  payoutCopy,
+  removalConsequence,
+  removalLockReason,
+  stickerPurchaseCopy,
+} from '~/components/Sticker/payout-copy';
 
 describe('payoutCopy', () => {
   // The whole reason the name is there. "The creator" is read while looking at
@@ -64,5 +70,64 @@ describe('stickerPurchaseCopy', () => {
   // name the wrong recipient of real money.
   it('says nothing when the maker is unknown rather than absent', () => {
     expect(stickerPurchaseCopy(undefined)).toBeNull();
+  });
+});
+
+/**
+ * The money copy the OWNER decides on.
+ *
+ * Every sentence here is read at the moment somebody presses approve, decline or
+ * remove, and each one asserts something about Buzz. The paid versions describe
+ * the escrow's two holds, which a free row does not have — so on a free row they
+ * are not loosely worded, they are false statements about money made where a
+ * decision is taken and later repeated to support.
+ */
+describe('declineConsequence', () => {
+  it('describes the two holds on a paid placement', () => {
+    expect(declineConsequence(false)).toMatch(/keeps most of what they paid/);
+  });
+
+  it('claims no payment on a free one, and says what the placer does lose', () => {
+    const free = declineConsequence(true);
+
+    expect(free).not.toMatch(/paid for it|what they paid/);
+    // The asymmetry the placer was warned about before pressing: the image's
+    // slot comes back, their day does not. The owner deciding should see it too.
+    expect(free).toMatch(/free placement for today is still spent/);
+  });
+
+  /**
+   * `undefined` is a mixed bulk selection, not a missing value. Either concrete
+   * sentence would be false about half of what is selected, so this branch says
+   * only what covers both — and it must not read as one of them.
+   */
+  it('covers both kinds without asserting either, for a mixed selection', () => {
+    const mixed = declineConsequence(undefined);
+
+    expect(mixed).toMatch(/free placement moves no Buzz/);
+    expect(mixed).toMatch(/fee staying with you/);
+    expect(mixed).not.toBe(declineConsequence(true));
+    expect(mixed).not.toBe(declineConsequence(false));
+  });
+});
+
+describe('the removal copy', () => {
+  it('gives the true reason for the week on each kind', () => {
+    expect(removalLockReason(false)).toMatch(/Someone paid to place this/);
+    expect(removalLockReason(true)).toMatch(/commitment to keep it up for a week/);
+    // The client must not restate the paid reason on a free row — this mirrors
+    // the server's refusal, which was corrected for the same reason.
+    expect(removalLockReason(true)).not.toMatch(/paid/);
+  });
+
+  it('promises the owner no payment they never received', () => {
+    expect(removalConsequence(false)).toMatch(/Buzz you were paid for it stays with you/);
+    expect(removalConsequence(true)).not.toMatch(/you were paid/);
+    expect(removalConsequence(true)).toMatch(/No Buzz was paid for it/);
+  });
+
+  it('says nobody is notified either way, which is true of both', () => {
+    for (const free of [true, false])
+      expect(removalConsequence(free)).toMatch(/nobody is notified/);
   });
 });

--- a/src/components/Sticker/free-offer.ts
+++ b/src/components/Sticker/free-offer.ts
@@ -74,30 +74,65 @@ export const FREE_REVIEW_CAVEAT =
 
 /**
  * What went wrong when a free claim was refused, from state re-read after the
- * refusal rather than from the server's message.
+ * refusal rather than from the server's message — or `null` when the re-read
+ * does not explain it.
  *
  * The numbers the control renders are stale by construction — the claim
  * re-counts under a lock — so losing the last slot to someone else is an
  * ordinary outcome rather than an error, and it deserves a sentence written for
- * the person reading it. Re-reading first is what makes the sentence true: the
- * refusal itself does not say which of the three rules stopped it, and guessing
- * from its text would be a client parsing prose the server is free to reword.
+ * the person reading it. Re-reading is what makes the sentence true: the refusal
+ * does not say which rule stopped it, and reading its text would be a client
+ * parsing prose the server is free to reword.
  *
- * Ordered by how specific each fact is, so the most useful true thing wins. The
- * last branch covers a refusal the re-read cannot explain — a block, a
- * suspension, the creator closing the space — where saying only what is certain
- * beats naming a cause we do not have.
+ * 🔴 **`null` is the important return.** A free placement can be refused for
+ * plenty of reasons that have nothing to do with the free tier — a block, a
+ * moderator suspension, self-placement, a sticker over the creator's size limit
+ * — each with a message written for the person who hit it. Answering "someone
+ * took the last slot" to any of those throws that message away and sends them to
+ * a remedy that will not work. So this speaks only where it knows, and the
+ * caller shows the server's own refusal otherwise.
+ *
+ * 🔴 **Ordered so a refusal that is PERMANENT for this image outranks one that
+ * lifts by itself**, because more than one can be true at once and the first
+ * match is what gets said. Telling somebody their allowance comes back at
+ * midnight, when the real answer is that this creator takes no free stickers at
+ * all, is a false promise about a specific image — they come back tomorrow to
+ * the same refusal. The pairwise tests exist to hold this order: each sets both
+ * conditions of an adjacent pair, so a swap fails rather than passing on
+ * fixtures that only ever trip one rung.
  */
 export function freeRefusalMessage(standing?: FreeStanding, space?: FreeCapacity) {
-  if (standing?.usedHere) return 'You have already used a free sticker on this image.';
-  if (standing && standing.remaining <= 0)
-    return "You have used today's free placement. It comes back at midnight UTC.";
-  if (space && space.freeSlots > 0 && space.freeSlotsRemaining <= 0)
-    return 'Someone took the last free slot on this image first.';
+  // Permanent for this image, and true of everybody — so it outranks the two
+  // below it, which are about this placer and about right now.
   if (space && space.freeSlots <= 0)
     return 'This creator is not taking free stickers on this image.';
-  return 'That free slot could not be claimed.';
+  // Permanent for this placer on this image: once ever, not once per day.
+  if (standing?.usedHere) return 'You have already used a free sticker on this image.';
+  // Transient, and it says when it lifts.
+  if (standing && standing.remaining <= 0)
+    return "You have used today's free placement. It comes back at midnight UTC.";
+  // The most transient of all — a declined placement releases its slot at once.
+  if (space && space.freeSlotsRemaining <= 0)
+    return 'Someone took the last free slot on this image first.';
+  return null;
 }
+
+/**
+ * What to say and what to do when a free claim was refused.
+ *
+ * Pure, and separate from `freeRefusalMessage`, because the consequential half is
+ * not the wording — it is `fallBackToPaid`. Offering the paid button is right
+ * when free specifically ran out and wrong when the whole placement was refused:
+ * somebody who is blocked, suspended, or placing on their own image would press
+ * it and meet the same refusal, having been told the problem was money.
+ *
+ * A hook cannot be asked this question without a query client and a tRPC
+ * provider, so the decision lives here where a test can put both cases to it.
+ */
+export const freeRefusalOutcome = (explained: string | null, serverMessage: string) =>
+  explained
+    ? { title: 'That one has to be paid for', message: explained, fallBackToPaid: true }
+    : { title: "Couldn't place that sticker", message: serverMessage, fallBackToPaid: false };
 
 type FreeStanding = { remaining: number; usedHere: boolean };
 type FreeCapacity = { freeSlots: number; freeSlotsRemaining: number };

--- a/src/components/Sticker/free-offer.ts
+++ b/src/components/Sticker/free-offer.ts
@@ -108,9 +108,12 @@ export function freeRefusalMessage(standing?: FreeStanding, space?: FreeCapacity
     return 'This creator is not taking free stickers on this image.';
   // Permanent for this placer on this image: once ever, not once per day.
   if (standing?.usedHere) return 'You have already used a free sticker on this image.';
-  // Transient, and it says when it lifts.
+  // Transient, and it says when it lifts — derived from the reset the server
+  // computed rather than restating the boundary here.
   if (standing && standing.remaining <= 0)
-    return "You have used today's free placement. It comes back at midnight UTC.";
+    return `You have used today's free placement. It comes back ${allowanceResetLabel(
+      standing.resetsAt
+    )}.`;
   // The most transient of all — a declined placement releases its slot at once.
   if (space && space.freeSlotsRemaining <= 0)
     return 'Someone took the last free slot on this image first.';
@@ -134,5 +137,58 @@ export const freeRefusalOutcome = (explained: string | null, serverMessage: stri
     ? { title: 'That one has to be paid for', message: explained, fallBackToPaid: true }
     : { title: "Couldn't place that sticker", message: serverMessage, fallBackToPaid: false };
 
-type FreeStanding = { remaining: number; usedHere: boolean };
+type FreeStanding = {
+  remaining: number;
+  usedHere: boolean;
+  /**
+   * When the allowance comes back. Computed by `getFreePlacementAllowance` and
+   * shipped on every read — so a sentence that hardcodes the boundary is a second
+   * copy of a rule the server already owns, and the two are free to disagree the
+   * day the day-boundary or the per-day count moves.
+   */
+  resetsAt?: Date | string;
+};
 type FreeCapacity = { freeSlots: number; freeSlotsRemaining: number };
+
+/**
+ * When the daily allowance comes back, in words.
+ *
+ * Falls back to the boundary the server currently uses rather than saying nothing,
+ * because a refusal that cannot say when it lifts is worse than one that names a
+ * default — but the value is preferred, so changing the day boundary changes this
+ * sentence instead of making it wrong.
+ */
+function allowanceResetLabel(resetsAt?: Date | string) {
+  if (!resetsAt) return 'at midnight UTC';
+  const at = new Date(resetsAt);
+  if (Number.isNaN(at.getTime())) return 'at midnight UTC';
+
+  return `at ${at.toISOString().slice(11, 16)} UTC`;
+}
+
+/**
+ * The tray's price line, which has to name both offers when both are open.
+ *
+ * The use is the constant: a free placement is free of the creator's price and of
+ * nothing else. Saying so here is what stops the tray and the Place button
+ * disagreeing about what a sticker costs.
+ */
+export const trayPriceLine = (freeAvailable: boolean, price: number) =>
+  freeAvailable ? `Free, or ${price} Buzz · one use either way` : `${price} Buzz + one use`;
+
+/**
+ * What the tray says a decline costs on a review-mode space.
+ *
+ * 🔴 The free half is `FREE_REVIEW_CAVEAT` itself rather than a paraphrase of it.
+ * There are three statements of this rule in the product — this one, the caveat
+ * under the draft's own free option, and `declineConsequence`'s free branch on the
+ * owner's side — and two of the three now come from one constant, so a change to
+ * what a decline costs cannot leave a stale copy behind in the tray.
+ *
+ * The paid half is kept in both branches: where both offers are open, somebody
+ * choosing to pay still needs the fee disclosure.
+ */
+export const trayReviewLine = (freeAvailable: boolean) =>
+  freeAvailable
+    ? ` ${FREE_REVIEW_CAVEAT} A paid placement leaves part of what you paid with them.`
+    : ' If they decline, part of what you paid stays with them.';

--- a/src/components/Sticker/free-offer.ts
+++ b/src/components/Sticker/free-offer.ts
@@ -1,0 +1,103 @@
+/**
+ * Whether the free offer is on the table, and what it says.
+ *
+ * Its own module with no imports, for the same reason `payout-copy.ts` is one:
+ * these are the branches most worth testing and the least worth dragging
+ * Mantine, tRPC and the edge image loader into a unit run to reach.
+ *
+ * The predicate lives here rather than at each of the three places that need it
+ * — the button's tray, the draft layer, and the draft itself — because three
+ * copies of a three-term condition is how one of them starts offering free where
+ * the others do not.
+ */
+
+/**
+ * The free offer, or `null` when paid is the only one.
+ *
+ * All three facts have to hold, and each is a different reason to be looking at
+ * the paid button: the creator may take no free stickers or have none left, the
+ * placer may have spent their day, or they may have already placed free on this
+ * image. Missing any one of them offers something the claim then refuses.
+ *
+ * `null` while either query is in flight, which shows the paid button first and
+ * adds the choice when it lands. The other order offers free and takes it away.
+ *
+ * ⚠️ Both inputs are display state and stale the moment they arrive. This picks
+ * which offer to SHOW; `createFreePlacement` decides whether one is allowed,
+ * under a lock, in the transaction that inserts.
+ */
+export function freeOfferFor(
+  space?: FreeCapacity & { mode?: string },
+  standing?: FreeStanding
+): { instant: boolean } | null {
+  if (!space || !standing) return null;
+  if (space.freeSlotsRemaining <= 0) return null;
+  if (standing.remaining <= 0 || standing.usedHere) return null;
+
+  return { instant: space.mode === 'auto' };
+}
+
+/**
+ * Which offer is selected, defaulting to free whenever one is available.
+ *
+ * `null` means nobody has pressed the control, and that is what makes the
+ * default work: the offer arrives with a query, so a value chosen on the first
+ * render would be paid and would stay paid once the real answer landed.
+ *
+ * Paid placements never consume free slots, so both can be genuinely available
+ * at once — this is a choice, not a fallback.
+ */
+export const isPlacingFree = (chosen: 'free' | 'paid' | null, offer: { instant: boolean } | null) =>
+  (chosen ?? (offer ? 'free' : 'paid')) === 'free' && !!offer;
+
+/**
+ * The free option's own label, which carries the mode.
+ *
+ * The mode goes here rather than on the sticker button because this is the last
+ * moment the placer can change their mind, and it makes auto-accept and review
+ * read as two different offers rather than one setting they cannot see. The
+ * button upstream stays a single number.
+ */
+export const freeOptionLabel = (instant: boolean) =>
+  instant ? 'Free · instant' : 'Free · needs review';
+
+/**
+ * The one line under a review-mode free option.
+ *
+ * Said before the press, not after, because it is the whole asymmetry of the
+ * free tier: the image's slot comes back when a creator declines and the
+ * placer's day does not. Somebody who would rather spend Buzz on a creator who
+ * reviews needs that fact while both options are still on screen.
+ */
+export const FREE_REVIEW_CAVEAT =
+  "Your free placement for today is spent even if they decline. The creator's slot comes back; your allowance does not.";
+
+/**
+ * What went wrong when a free claim was refused, from state re-read after the
+ * refusal rather than from the server's message.
+ *
+ * The numbers the control renders are stale by construction — the claim
+ * re-counts under a lock — so losing the last slot to someone else is an
+ * ordinary outcome rather than an error, and it deserves a sentence written for
+ * the person reading it. Re-reading first is what makes the sentence true: the
+ * refusal itself does not say which of the three rules stopped it, and guessing
+ * from its text would be a client parsing prose the server is free to reword.
+ *
+ * Ordered by how specific each fact is, so the most useful true thing wins. The
+ * last branch covers a refusal the re-read cannot explain — a block, a
+ * suspension, the creator closing the space — where saying only what is certain
+ * beats naming a cause we do not have.
+ */
+export function freeRefusalMessage(standing?: FreeStanding, space?: FreeCapacity) {
+  if (standing?.usedHere) return 'You have already used a free sticker on this image.';
+  if (standing && standing.remaining <= 0)
+    return "You have used today's free placement. It comes back at midnight UTC.";
+  if (space && space.freeSlots > 0 && space.freeSlotsRemaining <= 0)
+    return 'Someone took the last free slot on this image first.';
+  if (space && space.freeSlots <= 0)
+    return 'This creator is not taking free stickers on this image.';
+  return 'That free slot could not be claimed.';
+}
+
+type FreeStanding = { remaining: number; usedHere: boolean };
+type FreeCapacity = { freeSlots: number; freeSlotsRemaining: number };

--- a/src/components/Sticker/payout-copy.ts
+++ b/src/components/Sticker/payout-copy.ts
@@ -53,6 +53,64 @@ export function declineConsequence(free: boolean | undefined) {
 }
 
 /**
+ * The queue row's headline, which is the only money statement on the card the
+ * Approve and Decline buttons sit under.
+ *
+ * A free row carries `amount: 0`, enforced by the DB — so "paid 0 Buzz" is not a
+ * cosmetic slip. It is the page the free-placement notification sends the creator
+ * to: the notification says the placement was free and the card then asserts a
+ * payment of zero, immediately above an irreversible choice.
+ */
+export const placementPaymentSummary = (free: boolean, amount: number) =>
+  free ? 'placed this free' : `paid ${amount} Buzz`;
+
+/**
+ * What a moderator take-down does to the money.
+ *
+ * Two axes, and free breaks the pending one specifically: a pending PAID row
+ * settles as a forfeit of the whole escrow, and a pending free row has no escrow
+ * to forfeit. Both statements are false on a free row in
+ * `RemoveReportedPlacement`, where the live branch also promises the creator was
+ * already paid.
+ */
+export function moderatorTakedownConsequence({
+  pending,
+  free,
+}: {
+  pending: boolean;
+  free: boolean;
+}) {
+  if (free)
+    return pending
+      ? 'This one is still awaiting the owner. Nothing was paid for it, so no Buzz moves, and nobody is notified.'
+      : 'The sticker comes off this content for everyone, recorded as a moderator takedown. Nothing was paid for it, so no Buzz moves, and nobody is notified.';
+
+  return pending
+    ? 'This one is still awaiting the owner. Taking it down forfeits everything the placer paid — they get nothing back, and nobody is notified.'
+    : 'The sticker comes off this content for everyone, recorded as a moderator takedown. No Buzz moves and nobody is notified.';
+}
+
+/**
+ * Whether a set of selected rows is all free, all paid, or mixed.
+ *
+ * Here rather than in the page because `declineConsequence` is what consumes it
+ * and its `undefined` branch is already covered — inline in a page component the
+ * collapse from "mixed" to "whichever kind we saw first" is a mutation nothing
+ * can observe, and it makes a bulk decline assert a sentence false of half the
+ * rows it is about.
+ *
+ * An id whose row is not paged in yet counts as unknown, which makes the whole
+ * selection mixed. That is the safe direction: it says only what covers both.
+ */
+export function selectionFree(
+  selected: number[],
+  rows: { id: number; free: boolean }[]
+): boolean | undefined {
+  const kinds = new Set(selected.map((id) => rows.find((row) => row.id === id)?.free));
+  return kinds.size === 1 ? [...kinds][0] : undefined;
+}
+
+/**
  * Why a live sticker cannot be taken off yet.
  *
  * Mirrors the server's refusal in `removeApprovedSticker`, which is the thing

--- a/src/components/Sticker/payout-copy.ts
+++ b/src/components/Sticker/payout-copy.ts
@@ -33,6 +33,51 @@ export function payoutCopy(
 }
 
 /**
+ * What the owner is told a decline costs, which is a different fact on a free
+ * placement.
+ *
+ * The paid sentence — the placer keeps most of what they paid, a fee stays with
+ * you — is the escrow's two-hold structure, and a free row has neither hold. So
+ * on a free row it is not a rounding error in the wording, it is a false
+ * statement about money made at the moment somebody decides.
+ *
+ * ⚠️ **`undefined` is a real case, not a missing value.** A bulk decline can hold
+ * both kinds at once, where neither sentence is true of everything selected —
+ * so that branch says only what covers both rather than picking the majority.
+ */
+export function declineConsequence(free: boolean | undefined) {
+  if (free === true)
+    return 'No Buzz moves — nothing was paid for this one. Their free placement for today is still spent.';
+  if (free === false) return 'The placer keeps most of what they paid, and a fee stays with you.';
+  return 'Any Buzz paid mostly returns to the placer with a fee staying with you; a free placement moves no Buzz.';
+}
+
+/**
+ * Why a live sticker cannot be taken off yet.
+ *
+ * Mirrors the server's refusal in `removeApprovedSticker`, which is the thing
+ * that actually decides. The week is the same either way — Justin's call — so
+ * only the reason differs, and the paid reason is untrue on a free row.
+ */
+export const removalLockReason = (free: boolean) =>
+  free
+    ? 'Accepting a sticker is a commitment to keep it up for a week.'
+    : 'Someone paid to place this, so it stays up for a week.';
+
+/**
+ * What a removal does to the money, once it is allowed.
+ *
+ * The paid line reassures the owner that the Buzz they were paid stays with
+ * them. There is none on a free row, and inventing a reassurance about a payment
+ * that never happened is how a support thread starts with somebody insisting
+ * they were paid.
+ */
+export const removalConsequence = (free: boolean) =>
+  free
+    ? 'It comes off your image for everyone. No Buzz was paid for it, so none moves, and nobody is notified.'
+    : 'It comes off your image for everyone. The Buzz you were paid for it stays with you, and nobody is notified.';
+
+/**
  * The same chip, for the step before: buying the sticker itself.
  *
  * Named rather than "the creator" for the reason above, and more sharply here —

--- a/src/components/Sticker/placement.util.ts
+++ b/src/components/Sticker/placement.util.ts
@@ -286,9 +286,20 @@ export function useCreateStickerPlacement(
       // With the two-step version, hoisting the reads above the invalidation is a
       // mutation nothing can observe, and what it produces is exactly the stale
       // numbers this re-read exists to avoid.
+      //
+      // 🔴 **The catches are not defensive padding.** `invalidate` and `getData`
+      // were total — neither can reject — and `fetch` REJECTS on query error, with
+      // no try/catch in this handler. `getFreeStanding` is a protectedProcedure,
+      // so an expired session fails the placement and then fails this re-read too:
+      // unguarded, the rejection skips the notification entirely and somebody
+      // presses Place free, watches the button return to idle, and is told
+      // nothing. A failed re-read explains nothing, which is already what
+      // `freeRefusalMessage` says about `undefined` — every rung is guarded on
+      // `space &&` / `standing?.` — so it lands on the server's own message with
+      // no fall back to paid, which is the outcome that leaves someone informed.
       const [space, standing] = await Promise.all([
-        utils.placement.getSpace.fetch(target, { staleTime: 0 }),
-        utils.placement.getFreeStanding.fetch(target, { staleTime: 0 }),
+        utils.placement.getSpace.fetch(target, { staleTime: 0 }).catch(() => undefined),
+        utils.placement.getFreeStanding.fetch(target, { staleTime: 0 }).catch(() => undefined),
       ]);
 
       // Every OTHER image's cached standing is stale too, because the allowance

--- a/src/components/Sticker/placement.util.ts
+++ b/src/components/Sticker/placement.util.ts
@@ -272,24 +272,30 @@ export function useCreateStickerPlacement(
         });
 
       // Re-read before saying anything. The refusal does not name which of the
-      // three free-tier rules stopped it, and the numbers this control rendered
-      // are stale by construction — so the honest sentence comes from fresh
-      // state, not from the server's prose. The invalidation is also what makes
-      // the free option disappear on its own where it genuinely has.
+      // free-tier rungs stopped it, and the numbers this control rendered are
+      // stale by construction — so the honest sentence comes from fresh state,
+      // not from the server's prose.
       const target = {
         surface: 'sticker' as const,
         targetType: 'image' as const,
         targetId: variables.imageId,
       };
-      await Promise.all([
-        utils.placement.getSpace.invalidate(target),
-        // Unkeyed, deliberately. The daily allowance is one placement a day
-        // across the whole site, so a target-scoped invalidation leaves every
-        // OTHER image's cached standing showing an allowance that is gone — and
-        // that stale number is what a control reads to decide whether to offer
-        // free at all. The space is per image and stays keyed.
-        utils.placement.getFreeStanding.invalidate(),
+
+      // `staleTime: 0` rather than invalidate-then-read, so freshness is a
+      // property of the call instead of the order two statements happen to be in.
+      // With the two-step version, hoisting the reads above the invalidation is a
+      // mutation nothing can observe, and what it produces is exactly the stale
+      // numbers this re-read exists to avoid.
+      const [space, standing] = await Promise.all([
+        utils.placement.getSpace.fetch(target, { staleTime: 0 }),
+        utils.placement.getFreeStanding.fetch(target, { staleTime: 0 }),
       ]);
+
+      // Every OTHER image's cached standing is stale too, because the allowance
+      // is one placement a day across the whole site — and that stale number is
+      // what a control elsewhere reads to decide whether to offer free at all.
+      // Unkeyed for that reason; the space is per image and needs no sweep.
+      void utils.placement.getFreeStanding.invalidate();
 
       // 🔴 Only a refusal the re-read can account for falls back to paid. The
       // free path refuses plenty of things that have nothing to do with the free
@@ -299,13 +305,7 @@ export function useCreateStickerPlacement(
       // slot" throws those away and offers a paid button that fails the same
       // way, which is the worse half: the remedy is wrong, not just the reason.
       // The branch itself is `freeRefusalOutcome`, where it is testable.
-      const outcome = freeRefusalOutcome(
-        freeRefusalMessage(
-          utils.placement.getFreeStanding.getData(target),
-          utils.placement.getSpace.getData(target)
-        ),
-        error.message
-      );
+      const outcome = freeRefusalOutcome(freeRefusalMessage(standing, space), error.message);
 
       // Paid rather than an error where free ran out, which is the cross-surface
       // rule: the placement they arranged is still available, it just costs Buzz

--- a/src/components/Sticker/placement.util.ts
+++ b/src/components/Sticker/placement.util.ts
@@ -1,6 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { getQueryKey } from '@trpc/react-query';
 import { useCallback, useMemo } from 'react';
+import { freeRefusalMessage } from '~/components/Sticker/free-offer';
 import { useStickerPlacementDraftStore } from '~/store/sticker-placement-draft.store';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
@@ -179,6 +180,25 @@ export function useForgetStickerPlacement() {
   );
 }
 
+/**
+ * Where the viewer stands against the free tier on one image.
+ *
+ * Its own query rather than folded into the space: the space is public and
+ * cached per image, and this is per viewer — merging them would make one
+ * person's allowance part of a payload every other viewer of that image shares.
+ *
+ * **A listing.** Whatever it says, the claim re-decides all of it under a lock,
+ * so this only ever chooses which offer to show — never whether one is allowed.
+ */
+export function useFreePlacementStanding(imageId?: number) {
+  const { data, isLoading } = trpc.placement.getFreeStanding.useQuery(
+    { surface: 'sticker', targetType: 'image', targetId: imageId as number },
+    { enabled: !!imageId, staleTime: 60_000 }
+  );
+
+  return { standing: data, isLoading };
+}
+
 export function useImagePlacementSpace(imageId?: number) {
   const { data, isLoading } = trpc.placement.getSpace.useQuery(
     { surface: 'sticker', targetType: 'image', targetId: imageId as number },
@@ -194,7 +214,16 @@ export function useImagePlacementSpace(imageId?: number) {
  * One hook rather than the mutation inline, so the tray and the sticker's own
  * buy button cannot drift into two versions of what happens on success.
  */
-export function useCreateStickerPlacement(draftId: string) {
+export function useCreateStickerPlacement(
+  draftId: string,
+  /**
+   * Called when a free claim was refused, so the control can settle on the paid
+   * option. Losing the last slot to someone else is an ordinary race rather than
+   * a fault, and leaving the control on an offer that no longer exists would
+   * make the next press fail the same way.
+   */
+  onFreeRefused?: () => void
+) {
   const utils = trpc.useUtils();
   const cancelDraft = useStickerPlacementDraftStore((state) => state.cancelDraft);
 
@@ -226,10 +255,42 @@ export function useCreateStickerPlacement(draftId: string) {
       // would draw the same sticker twice with one of them uncommitted.
       cancelDraft(draftId);
     },
-    onError: (error) =>
+    onError: async (error, variables) => {
+      if (!variables.free)
+        return showErrorNotification({
+          title: "Couldn't place that sticker",
+          error: new Error(error.message),
+        });
+
+      // Re-read before saying anything. The refusal does not name which of the
+      // three free-tier rules stopped it, and the numbers this control rendered
+      // are stale by construction — so the honest sentence comes from fresh
+      // state, not from the server's prose. The invalidation is also what makes
+      // the free option disappear on its own where it genuinely has.
+      const target = {
+        surface: 'sticker' as const,
+        targetType: 'image' as const,
+        targetId: variables.imageId,
+      };
+      await Promise.all([
+        utils.placement.getSpace.invalidate(target),
+        utils.placement.getFreeStanding.invalidate(target),
+      ]);
+
+      // Falls back to paid rather than erroring out, which is the cross-surface
+      // rule: the placement the person arranged is still available, it just
+      // costs Buzz now, and making them start over would throw away the
+      // arrangement over a race they did not lose anything to.
+      onFreeRefused?.();
       showErrorNotification({
-        title: "Couldn't place that sticker",
-        error: new Error(error.message),
-      }),
+        title: 'That one has to be paid for',
+        error: new Error(
+          freeRefusalMessage(
+            utils.placement.getFreeStanding.getData(target),
+            utils.placement.getSpace.getData(target)
+          )
+        ),
+      });
+    },
   });
 }

--- a/src/components/Sticker/placement.util.ts
+++ b/src/components/Sticker/placement.util.ts
@@ -14,6 +14,15 @@ export type PlacedSticker = {
   ownerId: number;
   status: string;
   amount: number;
+  /**
+   * Placed against the creator's free capacity, so nothing was paid for it.
+   *
+   * On the listing rather than derived from `amount`, because every surface that
+   * reads this decides what to SAY about money — what a decline returns, why a
+   * removal is locked — and a zero is a number rather than the fact that answers
+   * that.
+   */
+  free: boolean;
   data: StickerPlacementData;
   /**
    * `Date` over superjson, a string out of anything that stringified the cache
@@ -274,7 +283,12 @@ export function useCreateStickerPlacement(
       };
       await Promise.all([
         utils.placement.getSpace.invalidate(target),
-        utils.placement.getFreeStanding.invalidate(target),
+        // Unkeyed, deliberately. The daily allowance is one placement a day
+        // across the whole site, so a target-scoped invalidation leaves every
+        // OTHER image's cached standing showing an allowance that is gone — and
+        // that stale number is what a control reads to decide whether to offer
+        // free at all. The space is per image and stays keyed.
+        utils.placement.getFreeStanding.invalidate(),
       ]);
 
       // 🔴 Only a refusal the re-read can account for falls back to paid. The

--- a/src/components/Sticker/placement.util.ts
+++ b/src/components/Sticker/placement.util.ts
@@ -1,7 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { getQueryKey } from '@trpc/react-query';
 import { useCallback, useMemo } from 'react';
-import { freeRefusalMessage } from '~/components/Sticker/free-offer';
+import { freeRefusalMessage, freeRefusalOutcome } from '~/components/Sticker/free-offer';
 import { useStickerPlacementDraftStore } from '~/store/sticker-placement-draft.store';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
@@ -277,20 +277,28 @@ export function useCreateStickerPlacement(
         utils.placement.getFreeStanding.invalidate(target),
       ]);
 
-      // Falls back to paid rather than erroring out, which is the cross-surface
-      // rule: the placement the person arranged is still available, it just
-      // costs Buzz now, and making them start over would throw away the
-      // arrangement over a race they did not lose anything to.
-      onFreeRefused?.();
-      showErrorNotification({
-        title: 'That one has to be paid for',
-        error: new Error(
-          freeRefusalMessage(
-            utils.placement.getFreeStanding.getData(target),
-            utils.placement.getSpace.getData(target)
-          )
+      // 🔴 Only a refusal the re-read can account for falls back to paid. The
+      // free path refuses plenty of things that have nothing to do with the free
+      // tier — a block, a suspension, self-placement, a sticker over the
+      // creator's size limit — each arriving with a message written for the
+      // person who hit it. Answering all of them with "someone took the last
+      // slot" throws those away and offers a paid button that fails the same
+      // way, which is the worse half: the remedy is wrong, not just the reason.
+      // The branch itself is `freeRefusalOutcome`, where it is testable.
+      const outcome = freeRefusalOutcome(
+        freeRefusalMessage(
+          utils.placement.getFreeStanding.getData(target),
+          utils.placement.getSpace.getData(target)
         ),
-      });
+        error.message
+      );
+
+      // Paid rather than an error where free ran out, which is the cross-surface
+      // rule: the placement they arranged is still available, it just costs Buzz
+      // now, and starting over would throw away the arrangement over a race that
+      // took nothing from them.
+      if (outcome.fallBackToPaid) onFreeRefused?.();
+      showErrorNotification({ title: outcome.title, error: new Error(outcome.message) });
     },
   });
 }

--- a/src/pages/user/sticker-placements.tsx
+++ b/src/pages/user/sticker-placements.tsx
@@ -56,6 +56,21 @@ export default function StickerPlacements() {
 
   const allSelected = rows.length > 0 && selected.length === rows.length;
 
+  /**
+   * Whether the selection is all free, all paid, or mixed.
+   *
+   * `undefined` for mixed is the honest answer rather than a missing one: the
+   * decline confirmation states what a decline costs, and a selection holding
+   * both kinds has no single true sentence about money. Rows not yet paged in
+   * cannot be selected, so an id with no row is treated as unknown too.
+   */
+  const selectedFree = ((): boolean | undefined => {
+    const kinds = new Set(
+      selected.map((id) => rows.find((row) => row.id === id)?.free ?? undefined)
+    );
+    return kinds.size === 1 ? [...kinds][0] : undefined;
+  })();
+
   const toggle = (id: number) =>
     setSelected((current) =>
       current.includes(id) ? current.filter((value) => value !== id) : [...current, id]
@@ -91,7 +106,11 @@ export default function StickerPlacements() {
             <Card withBorder p="xs">
               <Group justify="space-between">
                 <Text size="sm">{selected.length} selected</Text>
-                <StickerPlacementActions placementIds={selected} onDone={() => setSelected([])} />
+                <StickerPlacementActions
+                  placementIds={selected}
+                  free={selectedFree}
+                  onDone={() => setSelected([])}
+                />
               </Group>
             </Card>
           )}
@@ -225,6 +244,7 @@ export default function StickerPlacements() {
                   <StickerPlacementActions
                     placementIds={[row.id]}
                     hasComment={!!row.data.comment}
+                    free={row.free}
                     stacked
                     compact
                   />

--- a/src/pages/user/sticker-placements.tsx
+++ b/src/pages/user/sticker-placements.tsx
@@ -19,6 +19,7 @@ import { EdgeImage } from '~/components/EdgeMedia/EdgeImage';
 import { Meta } from '~/components/Meta/Meta';
 import { stickerArtworkStyle } from '~/components/Sticker/placement-appearance';
 import { StickerPlacementActions } from '~/components/Sticker/StickerPlacementActions';
+import { placementPaymentSummary, selectionFree } from '~/components/Sticker/payout-copy';
 import { WithheldThumb } from '~/components/RemixGallery/SubmissionPair';
 import { useStickerCosmetics } from '~/components/Sticker/sticker.util';
 import { useServerDomains } from '~/providers/AppProvider';
@@ -56,20 +57,9 @@ export default function StickerPlacements() {
 
   const allSelected = rows.length > 0 && selected.length === rows.length;
 
-  /**
-   * Whether the selection is all free, all paid, or mixed.
-   *
-   * `undefined` for mixed is the honest answer rather than a missing one: the
-   * decline confirmation states what a decline costs, and a selection holding
-   * both kinds has no single true sentence about money. Rows not yet paged in
-   * cannot be selected, so an id with no row is treated as unknown too.
-   */
-  const selectedFree = ((): boolean | undefined => {
-    const kinds = new Set(
-      selected.map((id) => rows.find((row) => row.id === id)?.free ?? undefined)
-    );
-    return kinds.size === 1 ? [...kinds][0] : undefined;
-  })();
+  // All free, all paid, or mixed. Derived beside `declineConsequence`, which is
+  // the only consumer and where the mixed branch is already covered.
+  const selectedFree = selectionFree(selected, rows);
 
   const toggle = (id: number) =>
     setSelected((current) =>
@@ -210,11 +200,12 @@ export default function StickerPlacements() {
                       <Text span fw={600}>
                         {row.placer?.username ?? 'Someone'}
                       </Text>{' '}
-                      paid{' '}
-                      <Text span fw={600}>
-                        {row.amount}
-                      </Text>{' '}
-                      Buzz
+                      {/* The only money statement on the card the Approve and
+                          Decline buttons sit under, and a free row carries
+                          `amount: 0` — so unbranched it asserts a payment of zero
+                          on the very page the free-placement notification sends
+                          the creator to. */}
+                      {placementPaymentSummary(row.free, row.amount)}
                     </Text>
                     <Text size="xs" c="dimmed">
                       Placed {formatDate(row.createdAt)}

--- a/src/server/notifications/__tests__/placement-free-notification.test.ts
+++ b/src/server/notifications/__tests__/placement-free-notification.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import { placementNotifications } from '~/server/notifications/placement.notifications';
+
+/**
+ * The free placement's own notification, and the paid one it must not collide
+ * with.
+ *
+ * These assert the SQL as text, which is what every other notification test
+ * here does and is weaker than running it — the queries are built as strings
+ * and never parsed in a unit run. What they can still catch is the whole reason
+ * this type exists: that the two are scoped apart, and that each honours its own
+ * setting. Both of those failures are silent in production — one sends the wrong
+ * sentence, the other ignores a switch the UI shows as working.
+ */
+type Def = (typeof placementNotifications)['sticker-placement-pending'];
+const defs = placementNotifications as Record<string, Def>;
+
+const LAST_SENT = '2026-08-16 00:00:00';
+const query = async (type: string) =>
+  (await defs[type].prepareQuery!({
+    lastSent: LAST_SENT,
+    lastSentDate: new Date(0),
+    clickhouse: undefined,
+  })) as string;
+
+describe('the free sticker notification is its own type', () => {
+  it('is registered and toggleable, in the creator category', () => {
+    const def = defs['sticker-placement-free-pending'];
+
+    expect(def).toBeTruthy();
+    expect(def.category).toBe('Creator');
+    // Not opt-in. `optIn` inverts what a settings row MEANS, and it may only be
+    // set by a processor that derives its recipients by joining that table —
+    // this one derives them from the placement and excludes with NOT EXISTS, so
+    // opting in here would ship the notification on while the UI drew it off.
+    expect(def.optIn).toBeUndefined();
+  });
+
+  it('names no amount, because there is none to name', () => {
+    const message = defs['sticker-placement-free-pending'].prepareMessage({
+      type: 'sticker-placement-free-pending',
+      details: { imageId: 74, placerUsername: 'somebody' },
+    } as Parameters<Def['prepareMessage']>[0])!;
+
+    expect(message.message).toBe('somebody wants to place a free sticker on your image');
+    // "0 Buzz" reads as a bug rather than as the offer.
+    expect(message.message).not.toMatch(/buzz|\b0\b/i);
+    // The image, not the queue: answering means seeing the sticker on the work
+    // it was placed on.
+    expect(message.url).toBe('/images/74');
+  });
+});
+
+describe('the two sticker notifications are scoped apart', () => {
+  it('sends the paid one for paid rows only', async () => {
+    expect(await query('sticker-placement-pending')).toMatch(/AND\s+p\.free\s*=\s*false/);
+  });
+
+  it('sends the free one for free rows only', async () => {
+    expect(await query('sticker-placement-free-pending')).toMatch(/AND\s+p\.free\s*=\s*true/);
+  });
+
+  /**
+   * Without both halves a free placement produces two notifications, one of
+   * which offers to review it "for 0 Buzz", and muting either kind mutes the
+   * wrong one. Asserted as a pair rather than twice, because it is the pair that
+   * has to partition.
+   */
+  it('gives each its own dedupe key', async () => {
+    expect(await query('sticker-placement-pending')).toContain("'sticker-placement-pending:'");
+    expect(await query('sticker-placement-free-pending')).toContain(
+      "'sticker-placement-free-pending:'"
+    );
+  });
+});
+
+describe('each honours its own setting', () => {
+  /**
+   * 🔴 A settings row means opted OUT, and nothing applies that globally — every
+   * processor that honours its toggle writes the clause itself. Without it the
+   * setting renders, saves, and does nothing, which is a toggle that is a
+   * listing rather than a guard.
+   */
+  it.each(['sticker-placement-pending', 'sticker-placement-free-pending'])(
+    '%s excludes users who have opted out of that exact type',
+    async (type) => {
+      const sql = await query(type);
+
+      expect(sql).toMatch(/NOT EXISTS\s*\(\s*SELECT 1 FROM "UserNotificationSettings"/);
+      // The type in the clause has to be this one. A copy-paste carrying the
+      // other type's name would silence the wrong notification and leave this
+      // one unmutable, and every other assertion here would still pass.
+      expect(sql).toMatch(new RegExp(`type = '${type}'\\s*\\n?\\s*\\)`));
+    }
+  );
+});
+
+describe('neither notifies about a row that is no longer waiting', () => {
+  it.each(['sticker-placement-pending', 'sticker-placement-free-pending'])(
+    '%s requires pending status and a deadline',
+    async (type) => {
+      const sql = await query(type);
+
+      // Pending is what keeps an auto-accept space out of this entirely: the
+      // call site approves the row before the job next runs.
+      expect(sql).toContain("p.status = 'pending'");
+      expect(sql).toContain('p."expiresAt" IS NOT NULL');
+      expect(sql).toContain(LAST_SENT);
+    }
+  );
+});

--- a/src/server/notifications/__tests__/placement-free-notification.test.ts
+++ b/src/server/notifications/__tests__/placement-free-notification.test.ts
@@ -74,6 +74,49 @@ describe('the two sticker notifications are scoped apart', () => {
   });
 });
 
+/**
+ * Who hears about it, and where it sends them.
+ *
+ * Both are one identifier in a `jsonb_build_object`, and both swaps are green:
+ * `p."ownerId"` -> `p."placerId"` notifies the placer that they themselves want
+ * to place something, and `p."targetId"` -> `p.id` builds `/images/<placementId>`
+ * — a dead URL for the one person who has to act.
+ */
+describe('the free notification reaches the creator, about the right image', () => {
+  it.each(['sticker-placement-pending', 'sticker-placement-free-pending'])(
+    '%s notifies the owner, not the placer',
+    async (type) => {
+      const sql = await query(type);
+
+      expect(sql).toMatch(/p\."ownerId"\s+"userId"/);
+      // The placer is carried in the details for the message, so its presence is
+      // not the thing to assert — the recipient column is.
+      expect(sql).not.toMatch(/p\."placerId"\s+"userId"/);
+    }
+  );
+
+  it.each(['sticker-placement-pending', 'sticker-placement-free-pending'])(
+    '%s links to the image rather than to the placement',
+    async (type) => {
+      const sql = await query(type);
+
+      expect(sql).toMatch(/'imageId',\s*p\."targetId"/);
+      expect(sql).not.toMatch(/'imageId',\s*p\.id/);
+    }
+  );
+
+  it('sends the creator to the image, which is where the sticker is', () => {
+    const message = defs['sticker-placement-free-pending'].prepareMessage({
+      type: 'sticker-placement-free-pending',
+      details: { imageId: 74, placerId: 52, placerUsername: 'somebody' },
+    } as Parameters<Def['prepareMessage']>[0])!;
+
+    // Off `imageId`, so a details payload carrying the placement id cannot
+    // produce a URL that looks right and resolves to nothing.
+    expect(message.url).toBe('/images/74');
+  });
+});
+
 describe('each honours its own setting', () => {
   /**
    * 🔴 A settings row means opted OUT, and nothing applies that globally — every

--- a/src/server/notifications/placement.notifications.ts
+++ b/src/server/notifications/placement.notifications.ts
@@ -45,11 +45,17 @@ export const placementNotifications = createNotificationProcessor({
           -- expired between the last run and this one has already been answered,
           -- and telling someone to review it sends them to a dead link.
           AND p.status = 'pending'
-          -- Stamped by holdPlacementEscrow, so its presence means the escrow has
-          -- at least been attempted. The row is created before that runs, and a
-          -- notification landing in the gap would send someone to review a
-          -- placement that is about to be unwound, or one in an auto space that
-          -- approves itself seconds later.
+          -- Stamped by holdPlacementEscrow, so on the rows THIS query can see its
+          -- presence means the escrow has at least been attempted. The row is
+          -- created before that runs, and a notification landing in the gap would
+          -- send someone to review a placement about to be unwound, or one in an
+          -- auto space that approves itself seconds later.
+          --
+          -- ⚠️ The escrow half of that reasoning holds only because of the
+          -- p.free = false above. A free row gets its deadline from the same
+          -- INSERT that creates it and never touches escrow, so this gate alone
+          -- would pass one straight through — announced as a paid placement,
+          -- quoting 0 Buzz. The two clauses are load-bearing together.
           AND p."expiresAt" IS NOT NULL
           AND p."createdAt" > '${lastSent}'
       )

--- a/src/server/notifications/placement.notifications.ts
+++ b/src/server/notifications/placement.notifications.ts
@@ -37,6 +37,10 @@ export const placementNotifications = createNotificationProcessor({
         JOIN "User" u ON u.id = p."placerId"
         WHERE p.surface = 'sticker'
           AND p."targetType" = 'image'
+          -- Paid rows only. A free one carries amount 0, so without this it
+          -- reads "wants to place a sticker on your image for 0 Buzz" and is
+          -- silenced by the toggle for the paid kind.
+          AND p.free = false
           -- Only rows that are still waiting. A placement approved, declined or
           -- expired between the last run and this one has already been answered,
           -- and telling someone to review it sends them to a dead link.
@@ -55,6 +59,71 @@ export const placementNotifications = createNotificationProcessor({
         'sticker-placement-pending' "type",
         details
       FROM data
+      -- A row means opted OUT. There is no global filter — every processor that
+      -- honours its own toggle writes this clause itself — so without it the
+      -- setting renders, saves, and does nothing. Kept on one line because the
+      -- notification-settings-polarity guard matches the clause as a literal.
+      WHERE NOT EXISTS (SELECT 1 FROM "UserNotificationSettings" WHERE "userId" = data."userId" AND type = 'sticker-placement-pending')
+    `,
+  },
+
+  /**
+   * Its own type, not a branch of the paid one, because it is a different
+   * decision to make and a different one to mute.
+   *
+   * A creator who has opened free capacity has said yes to the free tier in
+   * particular, and one who wants only the paid queue in their notifications
+   * needs to be able to say so without silencing the placements they are being
+   * paid for. One type with a branching message would make those two settings
+   * the same switch.
+   *
+   * The message carries no amount for the obvious reason and one less obvious
+   * one: "0 Buzz" reads as a bug rather than as the offer, and the thing worth
+   * saying instead is that a slot is being held while they decide.
+   *
+   * Only ever fires for a review-mode space. An auto space approves the row at
+   * the call site before the job next runs, and `status = 'pending'` is what
+   * keeps this from telling someone to review something already live.
+   */
+  'sticker-placement-free-pending': {
+    displayName: 'Free sticker awaiting your review',
+    category: NotificationCategory.Creator,
+    prepareMessage: ({ details }) => ({
+      message: `${details.placerUsername} wants to place a free sticker on your image`,
+      url: `/images/${details.imageId}`,
+    }),
+    prepareQuery: async ({ lastSent }) => `
+      WITH data AS (
+        SELECT
+          p."ownerId" "userId",
+          p.id "placementId",
+          jsonb_build_object(
+            'placementId', p.id,
+            'imageId', p."targetId",
+            'placerId', p."placerId",
+            'placerUsername', u.username
+          ) as "details"
+        FROM "Placement" p
+        JOIN "User" u ON u.id = p."placerId"
+        WHERE p.surface = 'sticker'
+          AND p."targetType" = 'image'
+          AND p.free = true
+          AND p.status = 'pending'
+          -- Written by the same INSERT that creates a free row rather than
+          -- stamped afterwards, so unlike the paid path there is no window where
+          -- this is null. Kept anyway: it is the one column that says the row is
+          -- reachable by the expiry sweep, and a free row that is not would hold
+          -- one of the creator's slots forever.
+          AND p."expiresAt" IS NOT NULL
+          AND p."createdAt" > '${lastSent}'
+      )
+      SELECT
+        CONCAT('sticker-placement-free-pending:',"placementId") "key",
+        "userId",
+        'sticker-placement-free-pending' "type",
+        details
+      FROM data
+      WHERE NOT EXISTS (SELECT 1 FROM "UserNotificationSettings" WHERE "userId" = data."userId" AND type = 'sticker-placement-free-pending')
     `,
   },
 

--- a/src/server/routers/placement.router.ts
+++ b/src/server/routers/placement.router.ts
@@ -24,6 +24,10 @@ import {
   submitToRemixGallerySchema,
   suspendPlacerSchema,
 } from '~/server/schema/placement.schema';
+import {
+  getFreePlacementAllowance,
+  hasUsedFreePlacementOn,
+} from '~/server/services/free-placement.service';
 import { placementPriceRange } from '~/server/services/placement.service';
 import {
   clearPlacementSpace,
@@ -167,6 +171,34 @@ export const placementRouter = router({
     return setPlacementSpace({ ...input, userId: ctx.user.id });
   }),
 
+  /**
+   * Where the viewer stands against the free tier on one target: their daily
+   * allowance, and whether they have already spent a free placement here.
+   *
+   * **A listing.** Both halves read a replica and are stale the moment they
+   * return; the refusals live in `createFreePlacement`, under a lock, in the
+   * transaction that inserts. This exists so the choice can be offered with the
+   * numbers visible — an allowance spent silently is the worst version of a
+   * scarce thing — and for no other purpose.
+   *
+   * Takes the target rather than being sticker-specific, because the allowance
+   * is one placement a day across the whole site and both surfaces need to say
+   * so. Surface-agnostic by reusing what PR 1 already exposes, not by anything
+   * new sitting between the two.
+   *
+   * `placerId` is the session's. Off the input it would read anyone's allowance.
+   */
+  getFreeStanding: protectedProcedure
+    .input(getPlacementSpaceSchema)
+    .query(async ({ input, ctx }) => {
+      const [allowance, usedHere] = await Promise.all([
+        getFreePlacementAllowance({ placerId: ctx.user.id }),
+        hasUsedFreePlacementOn({ ...input, placerId: ctx.user.id }),
+      ]);
+
+      return { ...allowance, usedHere };
+    }),
+
   getStickerPlacements: publicProcedure
     .input(getStickerPlacementsSchema)
     .query(({ input, ctx }) =>
@@ -201,6 +233,11 @@ export const placementRouter = router({
       assertPlacementEnabled(ctx);
       return createStickerPlacement({
         ...input,
+        // After the spread, and the schema has no `placerId` to strip anyway —
+        // both, because this is the id the whole free tier is scoped by and
+        // every check downstream is a statement about it rather than a check of
+        // it. Read off the payload it would spend someone else's daily
+        // allowance and place under their name with nothing raising.
         placerId: ctx.user.id,
         isModerator: ctx.user.isModerator,
         // From the request's own domain, never the input: `...input` spreads

--- a/src/server/schema/__tests__/create-sticker-placement.schema.test.ts
+++ b/src/server/schema/__tests__/create-sticker-placement.schema.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { createStickerPlacementSchema } from '~/server/schema/placement.schema';
+
+const data = { cosmeticId: 85, x: 0.25, y: 0.75, scale: 0.2, rotation: 15 };
+
+describe('the free flag selects a path and asserts nothing', () => {
+  it('defaults to paid, so a client cached from before the free tier still places', () => {
+    expect(createStickerPlacementSchema.parse({ imageId: 74, data })).toMatchObject({
+      free: false,
+    });
+  });
+
+  it('accepts an explicit choice either way', () => {
+    expect(createStickerPlacementSchema.parse({ imageId: 74, data, free: true }).free).toBe(true);
+    expect(createStickerPlacementSchema.parse({ imageId: 74, data, free: false }).free).toBe(false);
+  });
+});
+
+/**
+ * 🔴 The one field this input must never carry.
+ *
+ * `createFreePlacement` takes `placerId` as a plain number and cannot tell where
+ * it came from, and every free-tier rule — the daily allowance,
+ * never-twice-here, the block and suspension checks — is a statement *about*
+ * that id rather than a check *of* it. So nothing downstream notices a wrong
+ * one: it would spend somebody else's allowance, place under their name, and
+ * have the never-twice rule protect the wrong account.
+ *
+ * The router reads it from the session, and this is the second lock on the same
+ * door: zod strips what it does not declare, so a `placerId` on the wire cannot
+ * survive parsing even if a future spread order stopped overwriting it.
+ */
+describe('the placer cannot come from the request body', () => {
+  it('strips a client-supplied placerId rather than carrying it', () => {
+    const parsed = createStickerPlacementSchema.parse({ imageId: 74, data, placerId: 999 });
+
+    expect(parsed).not.toHaveProperty('placerId');
+  });
+
+  it('declares no placerId at all', () => {
+    // Read off the shape rather than off one parse, so adding the field is
+    // caught even if a caller never sends it. If this ever needs relaxing, the
+    // reason has to be written down somewhere other than here.
+    expect(Object.keys(createStickerPlacementSchema.shape)).toEqual(['imageId', 'data', 'free']);
+  });
+});

--- a/src/server/schema/placement.schema.ts
+++ b/src/server/schema/placement.schema.ts
@@ -51,6 +51,18 @@ export const stickerPlacementDataSchema = z.object({
 export const createStickerPlacementSchema = z.object({
   imageId: z.number().int().positive(),
   data: stickerPlacementDataSchema,
+  /**
+   * Take the creator's free capacity rather than paying their price.
+   *
+   * Safe to accept from the client because it selects a path, not an outcome:
+   * everything that makes a free placement legal is re-decided by
+   * `createFreePlacement` under a lock. Defaulted false so a client cached from
+   * before the free tier existed still places a paid sticker.
+   *
+   * 🔴 There is deliberately no `placerId` here, and there must never be one —
+   * see the note on `CreateStickerPlacement`.
+   */
+  free: z.boolean().default(false),
 });
 export type CreateStickerPlacementInput = z.infer<typeof createStickerPlacementSchema>;
 

--- a/src/server/services/__tests__/sticker-placement.service.test.ts
+++ b/src/server/services/__tests__/sticker-placement.service.test.ts
@@ -19,6 +19,8 @@ const SELLER = 63;
 const IMAGE = 74;
 const COSMETIC = 85;
 const PLACEMENT = 96;
+/** Distinct from `PLACEMENT`: the two creation routes must not be confusable. */
+const FREE_PLACEMENT = 107;
 
 /**
  * `setPrice` is what the owner asks; `price` is `min(setPrice, cap)` — what a
@@ -47,6 +49,22 @@ vi.mock('~/server/services/placement-space.service', () => ({ resolvePlacementSp
 
 const spendStickerUsesFor = vi.fn(async () => undefined);
 vi.mock('~/server/services/sticker.service', () => ({ spendStickerUsesFor }));
+
+/**
+ * The whole free claim, stubbed at its own boundary.
+ *
+ * Deliberately not re-implemented here: the daily allowance, never-twice-here
+ * and the slot count are decided inside it under a lock, and a fake that
+ * enforced them would let this file pass while the service checked nothing. What
+ * these tests are for is the part that is genuinely this service's — that it
+ * routes through the claim rather than around it, and what it does after one
+ * succeeds.
+ */
+const createFreePlacement = vi.fn<PrismaStub<{ id: number }>>(async () => {
+  calls.push('claim');
+  return { id: FREE_PLACEMENT };
+});
+vi.mock('~/server/services/free-placement.service', () => ({ createFreePlacement }));
 
 vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn().mockResolvedValue(undefined) }));
 
@@ -82,6 +100,10 @@ const imageFindMany = vi.fn<PrismaStub<unknown[]>>(async () => []);
 const placementFindUnique = vi.fn<PrismaStub<unknown>>(async () => null);
 const placementUpdate = vi.fn<PrismaStub<object>>(async () => ({}));
 const placementUpdateMany = vi.fn<PrismaStub<{ count: number }>>(async () => ({ count: 1 }));
+const placementDeleteMany = vi.fn<PrismaStub<{ count: number }>>(async () => {
+  calls.push('discard');
+  return { count: 1 };
+});
 
 vi.mock('~/server/db/client', () => ({
   dbWrite: {
@@ -92,6 +114,7 @@ vi.mock('~/server/db/client', () => ({
       findUnique: placementFindUnique,
       update: placementUpdate,
       updateMany: placementUpdateMany,
+      deleteMany: placementDeleteMany,
     },
   },
   dbRead: {
@@ -1355,5 +1378,213 @@ describe('getPendingStickerPlacements domain ceiling', () => {
       withinViewerLevel: false,
       url: 'asset',
     });
+  });
+});
+
+/**
+ * The free path: same placement, taken out of the creator's free capacity.
+ *
+ * `createFreePlacement` is stubbed, so nothing here asserts the three free-tier
+ * refusals — those belong to `free-placement.service.test.ts`, where they can be
+ * tested against the lock and the transaction that actually enforce them. What
+ * is this service's own is everything around the claim: routing through it
+ * rather than around it, spending the use, and the settle a claim deliberately
+ * does not do.
+ */
+describe('the free path', () => {
+  const freeInput: CreateStickerPlacement = { ...placeInput, free: true };
+
+  beforeEach(() => {
+    givenStickerAndBalance();
+  });
+
+  it('claims through createFreePlacement rather than writing its own row', async () => {
+    const result = await createStickerPlacement(freeInput);
+
+    expect(result).toEqual({ placementId: FREE_PLACEMENT, status: 'pending' });
+    // The two things a second creation route would show up as. A free branch
+    // that built the row itself would have to re-implement the daily allowance,
+    // never-twice-here and the slot count outside the lock that makes them true.
+    expect(placementCreate).not.toHaveBeenCalled();
+    expect(holdPlacementEscrow).not.toHaveBeenCalled();
+  });
+
+  it('hands the claim the session placer and the sticker seller, and no space', async () => {
+    await createStickerPlacement(freeInput);
+
+    const args = createFreePlacement.mock.calls[0][0] as Record<string, unknown>;
+    expect(args).toMatchObject({
+      surface: 'sticker',
+      targetType: 'image',
+      targetId: IMAGE,
+      placerId: PLACER,
+      sellerId: SELLER,
+    });
+    // Not a resolved space. One alongside a separate target id is two facts
+    // that can disagree, and the claim resolves from the id on purpose.
+    expect(args).not.toHaveProperty('space');
+    expect(args).not.toHaveProperty('ownerId');
+  });
+
+  it('spends a use, because free is free of Buzz and of nothing else', async () => {
+    await createStickerPlacement(freeInput);
+
+    expect(spendStickerUsesFor).toHaveBeenCalledWith({
+      userId: PLACER,
+      counts: new Map([[COSMETIC, 1]]),
+    });
+    // After the claim: a spend before it would take a use for a placement the
+    // slot count then refuses.
+    expect(calls).toEqual(['claim', 'spend']);
+  });
+
+  /**
+   * The hazard this path was written around.
+   *
+   * `createFreePlacement` always writes `pending` and never settles, and
+   * sticker's `allowedModes` includes `auto` — so without this the free sticker
+   * sits pending for the full expiry window holding one of the creator's slots,
+   * while the placer has been told it is live and the creator watches a queue
+   * they turned off. Nothing throws in either direction, which is why it is
+   * asserted rather than assumed.
+   */
+  it('approves a free placement on an auto space, which the claim will not do', async () => {
+    resolvePlacementSpaceFor.mockResolvedValue({ ...OPEN_SPACE, mode: 'auto' });
+
+    const result = await createStickerPlacement(freeInput);
+
+    expect(settlePlacement).toHaveBeenCalledWith({
+      placementId: FREE_PLACEMENT,
+      action: 'approve',
+      actorId: OWNER,
+    });
+    expect(result.status).toBe('approved');
+    // Last, so nothing can put a placement live before the use behind it is
+    // spent.
+    expect(calls).toEqual(['claim', 'spend', 'settle:approve']);
+  });
+
+  it('leaves a free placement on a review space pending', async () => {
+    const result = await createStickerPlacement(freeInput);
+
+    expect(settlePlacement).not.toHaveBeenCalled();
+    expect(result.status).toBe('pending');
+  });
+
+  /**
+   * The unwind deletes rather than expiring, and that is a decision about the
+   * placer's day rather than about tidiness: the daily allowance counts on
+   * `createdAt` across every status, so an expired row is indistinguishable
+   * from one a creator declined. A free row has no escrow legs to preserve, so
+   * the delete destroys nothing.
+   */
+  it('deletes the row when the use spend fails, rather than expiring it', async () => {
+    spendStickerUsesFor.mockRejectedValueOnce(new Error('no uses left'));
+
+    await expect(createStickerPlacement(freeInput)).rejects.toThrow(/no uses left/);
+
+    expect(placementDeleteMany).toHaveBeenCalledWith({
+      // Scoped, so a claim someone has since acted on cannot be deleted out
+      // from under them.
+      where: { id: FREE_PLACEMENT, free: true, status: 'pending' },
+    });
+    expect(settlePlacement).not.toHaveBeenCalled();
+  });
+
+  it('does not approve a placement whose use spend failed', async () => {
+    resolvePlacementSpaceFor.mockResolvedValue({ ...OPEN_SPACE, mode: 'auto' });
+    spendStickerUsesFor.mockRejectedValueOnce(new Error('no uses left'));
+
+    await expect(createStickerPlacement(freeInput)).rejects.toThrow(/no uses left/);
+
+    expect(settlePlacement).not.toHaveBeenCalled();
+    expect(calls).toEqual(['claim', 'discard']);
+  });
+
+  it('refuses without spending a use when the claim refuses', async () => {
+    createFreePlacement.mockRejectedValueOnce(
+      new Error('placement: the free slots on this one are taken')
+    );
+
+    await expect(createStickerPlacement(freeInput)).rejects.toThrow(/free slots/);
+
+    expect(spendStickerUsesFor).not.toHaveBeenCalled();
+    expect(placementDeleteMany).not.toHaveBeenCalled();
+  });
+
+  it('places free on a space that has never been priced', async () => {
+    resolvePlacementSpaceFor.mockResolvedValue({ ...OPEN_SPACE, setPrice: null, price: null });
+
+    // The price refusal gates the offer that needs one. A creator can open free
+    // capacity without ever setting a price, and refusing here would close the
+    // free tier on exactly the spaces it was built for.
+    await expect(createStickerPlacement(freeInput)).resolves.toMatchObject({
+      placementId: FREE_PLACEMENT,
+    });
+  });
+
+  it('still refuses a sticker the placer does not own', async () => {
+    queryRaw.mockReset();
+    givenStickerAndBalance({ owned: false, createdById: SELLER });
+
+    await expect(createStickerPlacement(freeInput)).rejects.toThrow(/do not own that sticker/);
+    expect(createFreePlacement).not.toHaveBeenCalled();
+  });
+
+  it('still refuses a sticker larger than the creator allows', async () => {
+    await expect(
+      createStickerPlacement({ ...freeInput, data: { ...freeInput.data, scale: 0.99 } })
+    ).rejects.toThrow(/allows stickers up to/);
+    expect(createFreePlacement).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The removal lock's copy, which was justified by a payment a free row never
+ * made.
+ *
+ * The week itself is unchanged — Justin's call, 2026-08-17 — so what is asserted
+ * here is only that the reason given is true of the row it is given for. A
+ * stated reason that is false is worse than a shorter one, because it is what a
+ * support answer repeats back.
+ */
+describe('the removal lock explains itself truthfully on a free row', () => {
+  const approvedAt = new Date(Date.now() - 60_000);
+  const remove = () =>
+    actOnStickerPlacement({ placementId: PLACEMENT, action: 'remove', userId: OWNER });
+
+  const givenApproved = (free: boolean) =>
+    placementFindUnique.mockResolvedValue({
+      id: PLACEMENT,
+      ownerId: OWNER,
+      placerId: PLACER,
+      targetId: IMAGE,
+      amount: free ? 0 : PRICE,
+      status: 'approved',
+      surface: 'sticker',
+      free,
+      data: { cosmeticId: COSMETIC, x: 0.1, y: 0.1, scale: 0.2, rotation: 0 },
+      createdAt: approvedAt,
+      resolvedAt: approvedAt,
+    });
+
+  it('does not claim someone paid for a free placement', async () => {
+    givenApproved(true);
+
+    await expect(remove()).rejects.toThrow(/commitment to keep it up for a week/);
+    await expect(remove()).rejects.not.toThrow(/paid/);
+  });
+
+  it('keeps the paid reason on a paid placement', async () => {
+    givenApproved(false);
+
+    await expect(remove()).rejects.toThrow(/Someone paid to place it/);
+  });
+
+  it('refuses both for the same week, whatever the reason says', async () => {
+    givenApproved(true);
+
+    await expect(remove()).rejects.toThrow(/can be removed from/);
+    expect(placementUpdateMany).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/__tests__/sticker-placement.service.test.ts
+++ b/src/server/services/__tests__/sticker-placement.service.test.ts
@@ -1588,3 +1588,65 @@ describe('the removal lock explains itself truthfully on a free row', () => {
     expect(placementUpdateMany).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * What the free claim is actually handed.
+ *
+ * The tests above pin that the claim was CALLED and what happened after. Nothing
+ * pinned the payload, so deleting the normaliser or the note spread left every
+ * one of them green while free stickers landed at unnormalised coordinates, or
+ * silently without the note their placer wrote.
+ */
+describe('the payload handed to the free claim', () => {
+  beforeEach(() => {
+    givenStickerAndBalance();
+  });
+
+  const claimData = () =>
+    (createFreePlacement.mock.calls[0][0] as { data: Record<string, unknown> }).data;
+
+  it('normalises the position rather than forwarding the raw draft', async () => {
+    await createStickerPlacement({
+      ...placeInput,
+      free: true,
+      // Past both bounds on purpose. The normaliser is the only thing between a
+      // drag that ran off the edge and a sticker rendered outside the image.
+      data: { ...placeInput.data, x: 1.4, y: -0.3, rotation: 15 },
+    });
+
+    const data = claimData();
+    expect(data.x).toBeLessThanOrEqual(1);
+    expect(data.x).toBeGreaterThanOrEqual(0);
+    expect(data.y).toBeLessThanOrEqual(1);
+    expect(data.y).toBeGreaterThanOrEqual(0);
+    // The cosmetic comes from the row the server loaded, not from the payload —
+    // the same id either way here, which is why the bounds above are what makes
+    // this test fail on a deleted normaliser.
+    expect(data.cosmeticId).toBe(COSMETIC);
+  });
+
+  it('carries the note the placer wrote', async () => {
+    await createStickerPlacement({
+      ...placeInput,
+      free: true,
+      data: { ...placeInput.data, comment: 'nice one' },
+    });
+
+    expect(claimData().comment).toBe('nice one');
+  });
+
+  /**
+   * Omitted rather than stored empty, so "left the field blank" and "typed only
+   * spaces" are the same row — the property the paid path already has, asserted
+   * here because the free path builds its own payload.
+   */
+  it('omits a note that is only whitespace', async () => {
+    await createStickerPlacement({
+      ...placeInput,
+      free: true,
+      data: { ...placeInput.data, comment: '   ' },
+    });
+
+    expect(claimData()).not.toHaveProperty('comment');
+  });
+});

--- a/src/server/services/sticker-placement.service.ts
+++ b/src/server/services/sticker-placement.service.ts
@@ -451,6 +451,8 @@ export type StickerPlacementView = {
   ownerId: number;
   status: PlacementStatus;
   amount: number;
+  /** Placed against the creator's free capacity, so no Buzz moved for it. */
+  free: boolean;
   data: StickerPlacementData;
   /**
    * When it was placed, which is what decides what covers what — and, on the
@@ -523,6 +525,11 @@ export async function getStickerPlacementDetail({
       createdAt: true,
       resolvedAt: true,
       status: true,
+      // Every surface built on this card says something about money — what a
+      // decline returns, why a removal is locked, what the owner keeps. All of
+      // it is false on a free row, and without this column the client has to
+      // infer it from `amount`, which is a number rather than a fact.
+      free: true,
       data: true,
       ownerId: true,
       placerId: true,
@@ -555,6 +562,7 @@ export async function getStickerPlacementDetail({
     // queue for two days did not change that.
     placedAt: placement.createdAt,
     status: placement.status as PlacementStatus,
+    free: placement.free,
     placer: placement.placer,
     comment: data ? visibleStickerComment(data, isParty) ?? null : null,
     /**
@@ -646,6 +654,11 @@ export async function getStickerPlacements({
       ownerId: true,
       status: true,
       amount: true,
+      // Beside `amount` rather than derived from it. Zero is what a free row
+      // carries, but it is not what makes it free — and the owner controls the
+      // copy that depends on the answer, so an inference is a wrong sentence
+      // about money rather than a missing one.
+      free: true,
       data: true,
       createdAt: true,
     },
@@ -666,6 +679,7 @@ export async function getStickerPlacements({
         ownerId: row.ownerId,
         status: row.status as PlacementStatus,
         amount: row.amount,
+        free: row.free,
         placedAt: row.createdAt,
         // The note's text is deliberately NOT in the listing, which runs for
         // every image on a feed page — only whether there is one, so an overlay
@@ -1009,6 +1023,10 @@ export async function getPendingStickerPlacements({
       targetId: true,
       placerId: true,
       amount: true,
+      // The queue's decline confirmation states what a decline costs, which is a
+      // different sentence on a free row — and a bulk selection can hold both
+      // kinds, so the caller needs it per row rather than per page.
+      free: true,
       data: true,
       createdAt: true,
       expiresAt: true,

--- a/src/server/services/sticker-placement.service.ts
+++ b/src/server/services/sticker-placement.service.ts
@@ -6,6 +6,7 @@ import {
   settlePlacement,
   MAX_LEG_ATTEMPTS,
 } from '~/server/services/placement-escrow.service';
+import { createFreePlacement } from '~/server/services/free-placement.service';
 import { assertCanPlace } from '~/server/services/placement-moderation.service';
 import { resolvePlacementSpaceFor } from '~/server/services/placement-space.service';
 import { spendStickerUsesFor } from '~/server/services/sticker.service';
@@ -115,11 +116,25 @@ async function loadPlaceableSticker({
 }
 
 export type CreateStickerPlacement = {
+  /**
+   * 🔴 From the session, never from the request body. Every free-tier rule —
+   * the daily allowance, never-twice-here, the block and suspension checks — is
+   * a statement *about* this id, so none of them notice when it is the wrong
+   * one: a placer read off the payload would spend someone else's allowance and
+   * place under their name with nothing raising.
+   */
   placerId: number;
   imageId: number;
   data: Omit<StickerPlacementInput, 'cosmeticId'> & { cosmeticId: number };
   /** Moderators may exceed a creator's size limit. Justin's call. */
   isModerator?: boolean;
+  /**
+   * Which of the two offers the placer took. A choice, not a claim: it selects
+   * the path, and the path re-decides every rule for itself under a lock. The
+   * number the client rendered is stale by the time it is read, so a `true` here
+   * is a request for a free slot rather than an assertion that one is free.
+   */
+  free?: boolean;
   /**
    * The domain's currency, decided at the router from the request's own feature
    * flags rather than anything the client sends — a client-supplied currency
@@ -171,6 +186,7 @@ export async function createStickerPlacement({
   imageId,
   data,
   isModerator = false,
+  free = false,
   spendType,
 }: CreateStickerPlacement) {
   const space = await resolvePlacementSpaceFor({
@@ -189,9 +205,6 @@ export async function createStickerPlacement({
   if (space.ownerId === placerId)
     throw throwBadRequestError('placement: you cannot place a sticker on your own content');
 
-  if (space.price == null)
-    throw throwBadRequestError('placement: this creator has not set a price yet');
-
   // The creator's size limit, refused rather than clamped. Quietly shrinking a
   // sticker someone just paid for is the same shape as v1's recurring defect: a
   // rule applied as a filter where a refusal was needed. The editor also caps
@@ -208,6 +221,21 @@ export async function createStickerPlacement({
         maxScale * 100
       )}% of the image width`
     );
+
+  // Everything below is the paid path: the escrow, the price, and the two
+  // refusals `createFreePlacement` makes for itself under its lock. Branching
+  // here rather than threading `free` through them keeps one creation route per
+  // offer — the alternative is a paid path with free-shaped holes in it, which
+  // is the guard-versus-filter shape this feature has already shipped five
+  // times.
+  if (free) return placeFreeSticker({ placerId, imageId, data, space });
+
+  // Below the branch rather than above it, and not a `!free` condition: a
+  // creator can open free capacity on a space they have never priced, so an
+  // unset price is only a refusal for the offer that needs one. Placed here it
+  // also narrows the type for the escrow, which a conditional guard cannot.
+  if (space.price == null)
+    throw throwBadRequestError('placement: this creator has not set a price yet');
 
   await assertCanPlace({ ownerId: space.ownerId, placerId });
 
@@ -284,6 +312,114 @@ export async function createStickerPlacement({
     });
 
   return { placementId: placement.id, status: space.mode === 'auto' ? 'approved' : 'pending' };
+}
+
+/**
+ * The same placement, taken out of the creator's free capacity instead of paid
+ * for.
+ *
+ * Free of Buzz, not of everything: the use still comes out of the placer's
+ * sticker inventory, so a free placement costs the same thing the paid one does
+ * minus the creator's price.
+ *
+ * **No refusal is re-implemented here.** The mode, the self-placement rule, the
+ * block and suspension checks, the per-owner pending cap, the daily allowance,
+ * never-twice-here and the slot count all live inside `createFreePlacement`,
+ * where the last three are decided under a lock in the transaction that
+ * inserts. Anything this function checked instead would be a second opinion
+ * that is free to disagree with the one that actually holds.
+ *
+ * 🔴 **The approval at the end is not optional.** `createFreePlacement` always
+ * writes `pending` and deliberately never settles — settlement is the money
+ * path and does I/O, and the claim runs inside a transaction. Sticker's
+ * `allowedModes` includes `auto`, so an auto space is reachable here, and
+ * without this the placement sits pending for 48 hours holding a slot while the
+ * placer has been told it is live and the creator watches a review queue they
+ * turned off. It fails silently in both directions, which is why it is the last
+ * thing this function does rather than a caller's job.
+ */
+async function placeFreeSticker({
+  placerId,
+  imageId,
+  data,
+  space,
+}: {
+  placerId: number;
+  imageId: number;
+  data: Omit<StickerPlacementInput, 'cosmeticId'> & { cosmeticId: number };
+  space: Awaited<ReturnType<typeof resolvePlacementSpaceFor>>;
+}) {
+  const sticker = await loadPlaceableSticker({ cosmeticId: data.cosmeticId, placerId });
+  await assertHasUse({ userId: placerId, cosmeticId: sticker.id });
+
+  const comment = commentFrom(data);
+
+  const placement = await createFreePlacement({
+    surface: SURFACE,
+    targetType: TARGET_TYPE,
+    targetId: imageId,
+    placerId,
+    // Carried for the same reason the paid path carries it — settlement is
+    // resumable and a sweeper never sees an argument. A free approval plans no
+    // legs, so nothing is ever paid out against it.
+    sellerId: sticker.createdById,
+    data: {
+      cosmeticId: sticker.id,
+      ...normalizeStickerPlacement(data),
+      ...(comment ? { comment } : {}),
+    },
+  });
+
+  try {
+    await spendStickerUsesFor({ userId: placerId, counts: new Map([[sticker.id, 1]]) });
+  } catch (error) {
+    await discardFreePlacement(placement.id);
+    throw error;
+  }
+
+  if (space.mode === 'auto')
+    await settlePlacement({
+      placementId: placement.id,
+      action: 'approve',
+      actorId: space.ownerId,
+    });
+
+  return { placementId: placement.id, status: space.mode === 'auto' ? 'approved' : 'pending' };
+}
+
+/**
+ * The unwind for a free placement, which DELETES the row rather than expiring
+ * it.
+ *
+ * The paid path expires, because the escrow's claim rows are the evidence
+ * recovery depends on and rolling them back destroys it. A free row has none —
+ * no holds, no ledger, nothing carrying a foreign key to it — so there is
+ * nothing to preserve, and expiring it would cost the placer their whole day:
+ * the daily allowance counts on `createdAt` across every status, so an expired
+ * row is indistinguishable from one a creator declined. Being unforgiving about
+ * a decline is deliberate; being unforgiving about our own failed spend is not.
+ *
+ * Scoped to a pending free row so a claim someone has since acted on cannot be
+ * deleted out from under them.
+ */
+async function discardFreePlacement(placementId: number) {
+  try {
+    await dbWrite.placement.deleteMany({
+      where: { id: placementId, free: true, status: 'pending' },
+    });
+  } catch (error) {
+    // The row still carries its deadline, so the expiry sweep releases the
+    // creator's slot within the window either way. What is lost is the placer's
+    // free placement for the day, which is why this is worth a line rather than
+    // a swallow.
+    logToAxiom({
+      name: 'sticker-placement',
+      type: 'error',
+      message: 'could not discard a free placement whose use spend failed',
+      placementId,
+      error: (error as Error).message,
+    }).catch(() => null);
+  }
 }
 
 /**
@@ -669,6 +805,7 @@ export async function actOnStickerPlacement({
       amount: true,
       status: true,
       surface: true,
+      free: true,
       data: true,
       createdAt: true,
       resolvedAt: true,
@@ -705,6 +842,7 @@ type ActionablePlacement = {
   id: number;
   ownerId: number;
   status: string;
+  free: boolean;
   data: unknown;
   createdAt: Date;
   resolvedAt: Date | null;
@@ -750,7 +888,16 @@ async function removeApprovedSticker({
     const removableAt = stickerRemovableAt(placement.resolvedAt ?? placement.createdAt);
     if (removableAt > new Date())
       throw throwBadRequestError(
-        `placement: this sticker can be removed from ${removableAt.toISOString()}. Someone paid to place it, so it stays up for a week after you accept it.`
+        `placement: this sticker can be removed from ${removableAt.toISOString()}. ${
+          placement.free
+            ? // Nobody paid for a free row, so the paid path's reason is simply
+              // untrue here — and a stated reason that is false is worse than a
+              // shorter one, because it is what a support answer repeats. The
+              // week itself is unchanged: Justin's call, 2026-08-17, on the
+              // grounds that accepting is the commitment whatever it cost.
+              'Accepting a sticker is a commitment to keep it up for a week.'
+            : 'Someone paid to place it, so it stays up for a week after you accept it.'
+        }`
       );
   }
 


### PR DESCRIPTION
PR 2 of the free placements project. Base is `feat/free-placements`, **not** `main`.

Makes the free tier clickable on stickers: a free branch in `createStickerPlacement`, the free/paid choice where the placer makes it, the remaining count on the sticker button, and a distinct notification for the creator.

## What the call site owns, and what it does not

Everything that makes a free placement legal stays inside `createFreePlacement` — the daily allowance, never-twice-on-this-image and the slot count under its lock, plus the mode, self-placement, block/suspension and per-owner pending cap. This PR routes through it rather than around it: no free-tier rule is re-implemented here, and `getFreePlacementAllowance` / `hasUsedFreePlacementOn` are used only to decide which offer to draw.

What the call site does own is the one thing a claim deliberately will not do:

**🔴 It approves on an auto-accept space.** `createFreePlacement` always writes `pending` and never settles, because settlement is the money path and does I/O inside what would be an open transaction. Sticker's `allowedModes` includes `auto`, so that space is reachable — and without the approval a free sticker sits pending for the full 48-hour window holding a slot, while the placer has been told it is live and the creator watches a review queue they turned off. It fails silently in both directions, so it is asserted rather than assumed.

**`placerId` comes from `ctx.user.id`.** The input schema declares no such field, and there is a test on its shape rather than only on one parse: every free-tier rule is a statement *about* that id, so nothing downstream would notice a wrong one.

## The free unwind deletes rather than expiring

The paid path expires, because the escrow's claim rows are the evidence recovery depends on. A free row has none, and the daily allowance counts on `createdAt` across every status — so an expired row is indistinguishable from one a creator declined, and unwinding our own failed use-spend would cost the placer their whole day. The delete is scoped to a pending free row so a claim someone has since acted on cannot be removed out from under them.

## The offer, and losing the race for it

- **Free/paid segmented control** on the draft, shaped like the existing one-off-vs-pack control, defaulting to free whenever a slot is available. The two never coexist — the purchase control only appears on a sticker that still has to be bought.
- **The free option carries the mode**: `Free · instant`, or `Free · needs review` plus a line saying the daily allowance is spent even on a decline. That is the last moment the placer can change their mind, and it makes the two modes read as different offers rather than a hidden setting.
- **The sticker button carries one number**, `2 of 4 free`, with the row's existing invitation tint while slots remain. `freeSlotsRemaining: 0` means two different things, so `freeSlots` is read alongside it — a creator who takes no free stickers gets no label, one whose slots are all held gets `0 of 4`, because a slot comes back on a decline.
- **Losing the last slot falls back to paid**, per ryan's cross-surface rule, so both surfaces behave the same. On a refusal the client re-reads the space and the placer's standing, settles the control on paid, and shows a sentence chosen from that fresh state — never the server's own message, which does not say which of the three rules stopped it and is free to be reworded.

The availability predicate is one tested function rather than the three copies the first draft had (tray, layer, draft), so the tray's sentence and the button below it cannot disagree about what is on offer.

## The removal cooldown

Kept at the full week, unchanged — Justin's call on 2026-08-17, after ryan and I costed a waiver and a 24h window. Only the wording moves: "Someone paid to place it" is false on a free row, so the free path says accepting is a commitment to keep it up for a week. The call site is otherwise untouched.

**⚠️ Consequence worth stating rather than leaving to be discovered:** an approved free row holds its slot for that whole week, and the creator cannot free it. A creator with 4 free slots who accepts 4 stickers has no free capacity for a week. That is now intended behaviour, not an oversight — but if the slot counts start feeling too small in practice, this is the mechanism to look at first.

## Notifications

A distinct `sticker-placement-free-pending` type with its own toggle, carrying no amount (a free row's `amount` is 0, and "0 Buzz" reads as a bug rather than as the offer). The paid query is now scoped `AND p.free = false`, without which a free placement produced two notifications and muting either kind muted the wrong one.

**Also fixed while in there:** `sticker-placement-pending` had no opt-out clause at all. A settings row means opted **out** and nothing applies that globally — every processor writes the `NOT EXISTS` itself — so its toggle rendered, saved, and did nothing. The repo's `notification-settings-polarity` guard could not see this: it only checks processors whose SQL already mentions the table, so a query that never mentions it is skipped rather than failed. Worth someone widening that guard separately; I have not, because doing so will fail on other processors and that is not this PR.

## Every money statement now branches

A free row carries `amount: 0` by DB constraint, and several surfaces described the escrow's two holds — which a free placement does not have. Three review rounds found these in three places, so they are listed together rather than as a fix history:

- the queue row headline (`paid 0 Buzz`, on the page this PR's own notification links to),
- the decline confirmation, on the image and in the queue,
- the removal lock's reason and the removal confirmation,
- the moderator take-down, in the hover card and in `RemoveReportedPlacement`, branching on `pending` **and** `free` since there is no escrow to forfeit in either state,
- the tray's decline warning, which had contradicted `FREE_REVIEW_CAVEAT` one file over.

The three reads that feed them select `free` beside `amount`, and each sentence is a pure function in `payout-copy.ts` or `free-offer.ts`. A bulk decline can hold both kinds at once, so `undefined` is a real case in `declineConsequence` — neither concrete sentence is true of a mixed selection.

## Known gap

**Every new call site of the five extracted copy helpers is unobserved.** Hardcoding `free: false` at any of the four component call sites stays green everywhere: TypeScript catches an omitted required prop, not a wrong constant. The helpers themselves are covered — including every branch and the ladder's ordering — and each was genuinely untestable where it previously lived, so the extraction is still an improvement. But the wiring is held by review rather than by a test, and it is worth knowing that before the next person moves one.

## Verification

There is no CI on PRs into `feat/free-placements`, so this is the whole gate.

- `pnpm run typecheck` — 0 errors
- `pnpm run lint` — clean on every touched file (the repo-wide run is pre-existing noise across 1,437 files)
- `pnpm run prettier:write`
- `pnpm run test:unit:run` — **17,315 passed**, 0 failed, 1,108 files
- `pnpm run test:lint-rules` — 220 passed
- component suite for `src/components/Sticker` — 23 passed

**Mutation-tested, thirteen guards across four rounds.** Each broken, the failure read, then restored — every one names the test rather than merely exiting non-zero:

| Mutation | What failed |
| --- | --- |
| Drop the auto-space approval | `approves a free placement on an auto space` |
| Expire the row instead of deleting it | `deletes the row when the use spend fails` + `does not approve a placement whose use spend failed` |
| Kill the free branch of the removal copy | `does not claim someone paid for a free placement` |
| Drop `AND p.free = false` from the paid notification | `sends the paid one for paid rows only` |
| Collapse the `freeSlots` / `freeSlotsRemaining` distinction | `distinguishes a closed space from a full one` |
| Render the free label unconditionally | `says nothing about free stickers when the creator takes none` |
| Default the control to paid | `defaults to free whenever an offer is available` |
| Send `free: false` from a free press | `a free press sends free: true` + `defaults to the free offer` |
| Make the free option a `BuzzTransactionButton` | `places free through a plain button, not a Buzz one` (132ms) |
| Collapse a mixed selection to one kind | two `selectionFree` cases |
| Drop the tray's free/paid price ternary | `names free and the price together` |
| Widen `showsFree` to `canPlace` | `says nothing about free stickers when the creator takes none` |
| Demote the permanent rung below a transient one | three ladder-ordering cases |

Two of those mutations found faults in the tests rather than in the code, and both are the same shape — an assertion that could not distinguish the thing it was about:

- The shiny-treatment check originally rendered an *empty* image, where the button already wears that tint as half of the "place the first one" invitation. It would have passed for the wrong reason.
- The free option's docstring argues at length that it must not be a `BuzzTransactionButton` — and swapping it for one left all ten tests green, because the **mock** rendered it as a plain button with the same name. The mock had erased the distinction the argument was about, so no name-based test could ever have held it. It now emits `data-buzz-button`, and deleting that marker fails a test, so the tidy-up that would re-open the hole cannot land quietly.

Two tests press the paid button through the DOM rather than through a locator, because `BuzzTransactionButton` is mocked to a bare `<button>` and there is no real control there whose reachability could be asserted. The file lists five conditions that end that exemption, including the real button's inert state, which the stub does not honour.

## Not in this PR

PR 3's accept reward is untouched. I raised a possible coupling — waiving the cooldown would have made accept → collect reward → remove → accept a loop — and ryan refuted it: each free placement costs a distinct placer their whole day, so the 100/day cap already bounds it at ten alt accounts per 100 Buzz, and the reward is keyed on placement id. With the week kept, the loop cannot open at all.

Migration `20260817120000_placement_free_capacity` from PR 1 is still unapplied and must land before the deploy carrying this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bnocx3BptHRB7tXC6nW9JG
