### PR TITLE
feat(rewards): control enabled, award amount and cap at runtime

### DIFF
--- a/packages/civitai-telemetry/src/client.ts
+++ b/packages/civitai-telemetry/src/client.ts
@@ -180,6 +180,10 @@ export const rewardFailedCounter = registerCounter({
   name: 'reward_failed_total',
   help: 'Reward failed',
 });
+export const rewardConfigReadFailedCounter = registerCounter({
+  name: 'reward_config_read_failed_total',
+  help: 'Runtime reward-config read failed; rewards ran on the last good config',
+});
 
 export const clavataCounter = registerCounter({
   name: 'clavata_req_total',

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -191,6 +191,7 @@ vi.mock('~/server/prom/client', () => ({
   vaultItemFailedCounter: promMetricStub(),
   rewardGivenCounter: promMetricStub(),
   rewardFailedCounter: promMetricStub(),
+  rewardConfigReadFailedCounter: promMetricStub(),
   clavataCounter: promMetricStub(),
   cacheHitCounter: promMetricStub(),
   cacheMissCounter: promMetricStub(),

--- a/src/components/Buzz/Rewards/DailyBoostRewardClaim.tsx
+++ b/src/components/Buzz/Rewards/DailyBoostRewardClaim.tsx
@@ -22,8 +22,13 @@ export function useDailyBoostReward() {
   const status = useGenerationStatus();
 
   const dailyBoostReward = rewards.find((reward) => reward.type === 'dailyBoost');
-  const isClaimed = dailyBoostReward ? dailyBoostReward.awarded > 0 : true;
-  const canShow = !!currentUser && !loadingRewards && !!status?.charge && !!dailyBoostReward && !isClaimed;
+  // Claimed means the reward fired today, not that it paid: a claim the cap
+  // trimmed to zero still consumed the day's dedup entry. Reading `awarded`
+  // leaves a button that never disappears, never pays, and reports success on
+  // every click until the daily reset.
+  const isClaimed = dailyBoostReward ? dailyBoostReward.awardedCount > 0 : true;
+  const canShow =
+    !!currentUser && !loadingRewards && !!status?.charge && !!dailyBoostReward && !isClaimed;
 
   return {
     canShow,

--- a/src/components/Buzz/Rewards/__tests__/useDailyBoostReward.test.ts
+++ b/src/components/Buzz/Rewards/__tests__/useDailyBoostReward.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as React from 'react';
+import type { act as actType } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+import type * as Trpc from '~/utils/trpc';
+
+const act = (React as unknown as { act: typeof actType }).act;
+
+/**
+ * `awarded > 0` used to double as "did the boost fire today". Once entries record
+ * what they paid, a claim the cap trimmed to zero pays nothing and reports
+ * `awarded: 0` — so reading the amount leaves a claim button that never
+ * disappears, never pays, and reports success on every click until the UTC reset.
+ * Reachable from this PR's own capability: `{"dailyBoost": {"cap": 0}}`.
+ */
+
+let rewards: unknown[] = [];
+const claim = vi.fn();
+
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof Trpc>()),
+  trpc: {
+    useUtils: () => ({ user: { userRewardDetails: { invalidate: vi.fn() } } }),
+    user: { userRewardDetails: { useQuery: () => ({ data: rewards, isLoading: false }) } },
+    buzz: {
+      claimDailyBoostReward: { useMutation: () => ({ mutate: claim, isPending: false }) },
+    },
+  },
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => ({ id: 1 }) }));
+
+vi.mock('~/components/ImageGeneration/GenerationForm/generation.utils', () => ({
+  useGenerationStatus: () => ({ charge: true }),
+}));
+
+import { useDailyBoostReward } from '~/components/Buzz/Rewards/DailyBoostRewardClaim';
+
+function readHook() {
+  let result: ReturnType<typeof useDailyBoostReward> | undefined;
+  const Probe = () => {
+    result = useDailyBoostReward();
+    return null;
+  };
+  const container = document.createElement('div');
+  const root = createRoot(container);
+  act(() => root.render(React.createElement(Probe)));
+  act(() => root.unmount());
+  return result!;
+}
+
+const boost = (over: Record<string, unknown>) => [
+  {
+    type: 'dailyBoost',
+    awardAmount: 25,
+    awarded: 0,
+    awardedCount: 0,
+    cap: 25,
+    onDemand: true,
+    accountType: 'blue',
+    ...over,
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  rewards = [];
+});
+
+describe('useDailyBoostReward', () => {
+  it('offers the claim when the boost has not fired today', () => {
+    rewards = boost({});
+
+    expect(readHook().canShow).toBe(true);
+  });
+
+  it('hides the claim after a normal claim', () => {
+    rewards = boost({ awarded: 25, awardedCount: 1 });
+
+    expect(readHook().canShow).toBe(false);
+  });
+
+  // The regression: paid nothing, but it fired, so the day's dedup entry is gone
+  // and every later click is a no-op the UI would report as a success.
+  it('hides the claim after one the cap trimmed to zero', () => {
+    rewards = boost({ awarded: 0, awardedCount: 1 });
+
+    expect(readHook().canShow).toBe(false);
+  });
+
+  it('shows nothing at all when the reward is disabled at runtime', () => {
+    rewards = [];
+
+    expect(readHook().canShow).toBe(false);
+  });
+});

--- a/src/pages/api/testing/rewards-config.ts
+++ b/src/pages/api/testing/rewards-config.ts
@@ -1,0 +1,35 @@
+/**
+ * Debug endpoint for runtime reward configuration.
+ * =============================================================================
+ *
+ * Hidden testing route. Guarded by the WEBHOOK_TOKEN via `?token=` query param.
+ *
+ * Usage:
+ *   GET /api/testing/rewards-config?token=$WEBHOOK_TOKEN
+ *
+ * Answers "which rewards are on, and at what amounts?" from one place, so an
+ * operator does not have to read the `rewards:config` KeyValue row and the
+ * reward definitions and reconcile them by hand. Each row reports the compiled
+ * default beside the effective value, and — the part a raw row read cannot show
+ * — any override field that was refused for being out of bounds or the wrong
+ * type.
+ *
+ * Read-only. It resolves through the same `resolveRewardConfig` the grant path
+ * uses, including its cache, so a change written in the last minute may not
+ * appear yet.
+ */
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+import * as rewardImports from '~/server/rewards';
+import { MAX_AWARD_AMOUNT, MAX_CAP, REWARD_CONFIG_KEY } from '~/server/rewards/reward-config';
+import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
+
+export default WebhookEndpoint(async function (req: NextApiRequest, res: NextApiResponse) {
+  const rewards = await Promise.all(Object.values(rewardImports).map((x) => x.describeConfig()));
+
+  return res.status(200).json({
+    key: REWARD_CONFIG_KEY,
+    bounds: { awardAmount: [0, MAX_AWARD_AMOUNT], cap: [0, MAX_CAP] },
+    rewards: rewards.sort((a, b) => a.type.localeCompare(b.type)),
+  });
+});

--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -1299,11 +1299,16 @@ export const userByReferralCodeHandler = async ({ input }: { input: UserByReferr
 export const userRewardDetailsHandler = async ({ ctx }: { ctx: ProtectedContext }) => {
   try {
     // TODO.Optimization: This will make multiple requests to redis, we could probably do it in one and make this faster. This will get slower as we add more Active rewards.
-    const rewardDetails = await Promise.all(
-      Object.values(rewards)
-        .filter((x) => x.visible)
-        .map((x) => x.getUserRewardDetails(ctx.user.id))
-    );
+    // `visible` is compile-time ("the kind of reward we advertise"); a null here
+    // is the runtime disable. Filtering `visible` first keeps an unadvertised
+    // reward off the config read entirely.
+    const rewardDetails = (
+      await Promise.all(
+        Object.values(rewards)
+          .filter((x) => x.visible)
+          .map((x) => x.getUserRewardDetails(ctx.user.id))
+      )
+    ).filter((x) => x !== null);
 
     // sort by `onDemand` first
     return orderBy(rewardDetails, ['onDemand', 'awardAmount'], ['desc', 'asc']);

--- a/src/server/rewards/__tests__/base.reward.config.test.ts
+++ b/src/server/rewards/__tests__/base.reward.config.test.ts
@@ -291,13 +291,14 @@ describe('the cap is never overshot, whatever the operator sets', () => {
   // thing that drives `remaining` negative. Without it the `Math.max(…, 0)` floor
   // in both the script and the model beside it is unreachable, so a mutant that
   // removes it survives and the reward starts paying negative Buzz.
-  // The cap must be lowered to exactly one below what was paid. Any deeper and
-  // the negative is invisible: `apply` treats every non-positive result as
-  // capped, so the floor's absence changes nothing observable. At -1 it collides
-  // with the script's ALREADY-AWARDED sentinel — `apply` returns early believing
-  // the event was a duplicate, and the entry is written as `a:-1`, which
-  // `parseEntryAmount` cannot read and the day total then counts as a full award.
-  it('pays nothing, and corrupts nothing, when a cap drops just below what was paid', async () => {
+  // Without the floor, `remaining` goes negative and the entry is written `a:-5`.
+  // `parseEntryAmount`'s `^a:(\d+)$` refuses the minus, so the day total treats
+  // that entry as a LEGACY one and counts it as a whole award. No payment is
+  // made either way — `apply` reads every non-positive result as capped — so the
+  // corrupted total is the only observable, and it appears at any negative depth.
+  // (Exactly -1 additionally collides with the script's already-awarded sentinel.
+  // Real, but not what this test measures, and not why the numbers below work.)
+  it('pays nothing, and corrupts nothing, when a cap drops below what was paid', async () => {
     configure({ testOnDemandReward: { awardAmount: 3, cap: 10 } });
     for (let i = 0; i < 4; i++) await onDemandReward().apply({ userId: 1, entityId: i });
     const paidBefore = paidSoFar().reduce((a, b) => a + b, 0);
@@ -309,10 +310,10 @@ describe('the cap is never overshot, whatever the operator sets', () => {
 
     expect(paidSoFar().reduce((a, b) => a + b, 0)).toBe(paidBefore);
 
-    // Raise the cap again to read the day back: while the cap sits below the
-    // total, `Math.min` clamps both the right and the wrong answer to the cap and
-    // the assertion proves nothing. Above it, an `a:-1` entry shows up — it is
-    // unparseable, so the total counts it as a whole award instead.
+    // Structurally required, not defensive: `getUserRewardDetails` clamps with
+    // `Math.min(sum, cap)`, so reading the day back while the cap is still below
+    // the total reports the cap. Deleting this re-raise turns the test red on
+    // correct code.
     invalidateRewardConfigCache();
     configure({ testOnDemandReward: { awardAmount: 3, cap: 100 } });
 

--- a/src/server/rewards/__tests__/base.reward.config.test.ts
+++ b/src/server/rewards/__tests__/base.reward.config.test.ts
@@ -48,7 +48,7 @@ vi.mock('~/server/services/buzz.service', () => ({
   getMultipliersForUser: (...args: any[]) => h.getMultipliersForUser(...args),
 }));
 
-import { createBuzzEvent } from '~/server/rewards/base.reward';
+import { createBuzzEvent, ON_DEMAND_REWARD_SCRIPT } from '~/server/rewards/base.reward';
 import type { BuzzEventLog } from '~/server/rewards/base.reward';
 import { goodContentReward } from '~/server/rewards/passive/goodContent.reward';
 import { invalidateRewardConfigCache } from '~/server/rewards/reward-config';
@@ -161,6 +161,23 @@ describe('apply() is gated before it does any work', () => {
     ]);
   });
 
+  // `tonumber('Infinity')` is nil in Lua, so an uncapped reward passing Infinity
+  // throws out of the script and into the triggering user mutation.
+  it('passes a finite cap for a reward that has none', async () => {
+    const uncapped = createBuzzEvent<{ userId: number; entityId: number }>({
+      type: 'testUncappedReward',
+      description: 'Test uncapped on-demand reward',
+      awardAmount: 5,
+      onDemand: true,
+      getKey,
+    });
+
+    await uncapped.apply({ userId: 1, entityId: 42 });
+
+    const [, options] = h.evalImpl.mock.calls[0] as any[];
+    expect(Number.isFinite(Number(options.arguments[3]))).toBe(true);
+  });
+
   it('uses the compiled amount and cap when no row exists', async () => {
     await onDemandReward().apply({ userId: 1, entityId: 42 });
 
@@ -221,9 +238,12 @@ describe('process() does not pay out a disabled reward’s backlog', () => {
   });
 });
 
-// The Lua is the thing under test here, so these drive a real in-memory Redis
-// hash through it rather than stubbing its return value: the cap arithmetic and
-// the per-entry bookkeeping are the behaviour, not an implementation detail.
+// 🔴 Nothing here executes the Lua. There is no Lua interpreter and no Redis in
+// the unit suite, so `runLua` below is a MODEL of the script, and these tests
+// verify what `apply` does with what the script returns — which is where the
+// over-cap payment lived. The script's own two properties are pinned separately
+// by source assertions at the bottom of this file, because without them a revert
+// of the script passes everything here: the model would keep behaving correctly.
 describe('the cap is never overshot, whatever the operator sets', () => {
   const hash = new Map<string, string>();
 
@@ -287,6 +307,31 @@ describe('the cap is never overshot, whatever the operator sets', () => {
     for (let i = 5; i < 10; i++) await onDemandReward().apply({ userId: 1, entityId: i });
 
     expect(paidSoFar().reduce((a, b) => a + b, 0)).toBe(10);
+  });
+
+  it('does not apply the multiplier twice to a trimmed grant', async () => {
+    h.getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: 2 });
+    configure({ testOnDemandReward: { awardAmount: 3, cap: 10 } });
+    const reward = onDemandReward();
+
+    // Effective award 6 against effective cap 20: three full grants, then 2.
+    for (let i = 0; i < 4; i++) await reward.apply({ userId: 1, entityId: i });
+
+    expect(paidSoFar()).toEqual([6, 6, 6, 2]);
+  });
+
+  // Guard against the cap's `Math.min` hiding a count-based total: with the cap
+  // reached, both readings collapse to the cap and the test proves nothing.
+  it('reports the day total from what was paid, not from the current award', async () => {
+    configure({ testOnDemandReward: { awardAmount: 2, cap: 100 } });
+    for (let i = 0; i < 5; i++) await onDemandReward().apply({ userId: 1, entityId: i });
+
+    invalidateRewardConfigCache();
+    configure({ testOnDemandReward: { awardAmount: 1, cap: 100 } });
+
+    // Five entries that paid 2 each. Counting them against the current award of
+    // 1 would report 5.
+    expect((await onDemandReward().getUserRewardDetails(1))?.awarded).toBe(10);
   });
 
   it('reports the same day total to the user as it paid', async () => {
@@ -359,6 +404,31 @@ describe('getUserRewardDetails() stops advertising a disabled reward', () => {
       awardAmount: AWARD_AMOUNT,
       cap: CAP,
     });
+  });
+});
+
+// Change-detectors, deliberately. The unit suite cannot run the script, so these
+// are the only thing standing between a revert of it and a green run — the model
+// in `runLua` above would go on producing the right numbers from the wrong code.
+describe('the on-demand Lua keeps the properties the model assumes', () => {
+  it('records what each entry paid, not when it happened', () => {
+    expect(ON_DEMAND_REWARD_SCRIPT).toContain("cache[ARGV[2]] = 'a:' .. tostring(toAward)");
+  });
+
+  it('sums the entries rather than counting them against the current award', () => {
+    expect(ON_DEMAND_REWARD_SCRIPT).toContain('for _, entry in pairs(cache) do');
+    expect(ON_DEMAND_REWARD_SCRIPT).toContain("string.match(tostring(entry), '^a:(%d+)$')");
+    // The accumulation itself, not just the parse above it: replacing this one
+    // line with `awarded + tonumber(ARGV[3])` restores the count-based reading
+    // while leaving every other line of the script intact.
+    expect(ON_DEMAND_REWARD_SCRIPT).toContain(
+      'awarded = awarded + (paid and tonumber(paid) or tonumber(ARGV[3]))'
+    );
+    expect(ON_DEMAND_REWARD_SCRIPT).not.toMatch(/count \* tonumber/);
+  });
+
+  it('reads a finite cap, since tonumber("Infinity") is nil in Lua', () => {
+    expect(ON_DEMAND_REWARD_SCRIPT).toContain('tonumber(ARGV[4])');
   });
 });
 

--- a/src/server/rewards/__tests__/base.reward.config.test.ts
+++ b/src/server/rewards/__tests__/base.reward.config.test.ts
@@ -334,6 +334,20 @@ describe('the cap is never overshot, whatever the operator sets', () => {
     expect((await onDemandReward().getUserRewardDetails(1))?.awarded).toBe(10);
   });
 
+  // `awarded` stopped being a proxy for "did it fire today" the moment entries
+  // recorded what they paid: a grant the cap trimmed to zero happened and paid
+  // nothing. `blocks.router`'s autoclaim gates on this rather than on the amount.
+  it('counts a claim that the cap trimmed to zero', async () => {
+    configure({ testOnDemandReward: { awardAmount: 3, cap: 0 } });
+    const reward = onDemandReward();
+
+    await reward.apply({ userId: 1, entityId: 1 });
+    const details = await reward.getUserRewardDetails(1);
+
+    expect(details?.awarded).toBe(0);
+    expect(details?.awardedCount).toBe(1);
+  });
+
   it('reports the same day total to the user as it paid', async () => {
     configure({ testOnDemandReward: { awardAmount: 3, cap: 10 } });
     const reward = onDemandReward();
@@ -410,25 +424,84 @@ describe('getUserRewardDetails() stops advertising a disabled reward', () => {
 // Change-detectors, deliberately. The unit suite cannot run the script, so these
 // are the only thing standing between a revert of it and a green run — the model
 // in `runLua` above would go on producing the right numbers from the wrong code.
+//
+// 🔴 The first version of this block pinned only the two lines THIS work changed,
+// and a reviewer executing the script found two survivors in the lines it did not:
+// deleting `- awarded` from the cap arithmetic removed the daily cap entirely, and
+// deleting the dedup block removed the double-award guard — both green, the second
+// because the model implements dedup itself and kept returning -1 for code that no
+// longer did. Anchoring what you edited is the natural failure here, because
+// nothing in your attention points at the rest. Hence the whole-body pin below,
+// which covers the properties nobody thought to enumerate.
 describe('the on-demand Lua keeps the properties the model assumes', () => {
+  const line = (needle: string) => expect(ON_DEMAND_REWARD_SCRIPT).toContain(needle);
+
+  it('refuses a duplicate event, which is the whole reason the script is atomic', () => {
+    expect(ON_DEMAND_REWARD_SCRIPT).toMatch(/if cache\[ARGV\[2\]\] then\s+return -1/);
+  });
+
   it('records what each entry paid, not when it happened', () => {
-    expect(ON_DEMAND_REWARD_SCRIPT).toContain("cache[ARGV[2]] = 'a:' .. tostring(toAward)");
+    line("cache[ARGV[2]] = 'a:' .. tostring(toAward)");
   });
 
   it('sums the entries rather than counting them against the current award', () => {
-    expect(ON_DEMAND_REWARD_SCRIPT).toContain('for _, entry in pairs(cache) do');
-    expect(ON_DEMAND_REWARD_SCRIPT).toContain("string.match(tostring(entry), '^a:(%d+)$')");
+    line('local awarded = 0');
+    line('for _, entry in pairs(cache) do');
+    line("string.match(tostring(entry), '^a:(%d+)$')");
     // The accumulation itself, not just the parse above it: replacing this one
     // line with `awarded + tonumber(ARGV[3])` restores the count-based reading
     // while leaving every other line of the script intact.
-    expect(ON_DEMAND_REWARD_SCRIPT).toContain(
-      'awarded = awarded + (paid and tonumber(paid) or tonumber(ARGV[3]))'
-    );
-    expect(ON_DEMAND_REWARD_SCRIPT).not.toMatch(/count \* tonumber/);
+    line('awarded = awarded + (paid and tonumber(paid) or tonumber(ARGV[3]))');
   });
 
-  it('reads a finite cap, since tonumber("Infinity") is nil in Lua', () => {
-    expect(ON_DEMAND_REWARD_SCRIPT).toContain('tonumber(ARGV[4])');
+  // Anchored on the operators, not on `ARGV[4]`: that name survives the deletion
+  // of the subtraction it was supposed to protect, which is how a mutant that
+  // abolished the daily cap passed.
+  it('subtracts what was already earned from the cap', () => {
+    line('local remaining = math.max(tonumber(ARGV[4]) - awarded, 0)');
+  });
+
+  it('never grants more than the cap left', () => {
+    line('local toAward = math.min(tonumber(ARGV[3]), remaining)');
+  });
+
+  it('persists the updated hash and expires it at end of day', () => {
+    line("redis.call('HSET', KEYS[1], ARGV[1], cjson.encode(cache))");
+    // Without this the hash never expires and the daily cap never resets.
+    line("redis.call('EXPIREAT', KEYS[1], tonumber(ARGV[5]))");
+  });
+
+  it('returns the trimmed amount, not the requested one', () => {
+    line('return toAward');
+  });
+
+  // The backstop for every property above and every one not listed. A reviewer
+  // found two holes by executing mutants; assume there are more nobody tried.
+  // This fails on any edit to the script including a reformat, which is the safe
+  // direction: updating it forces re-deriving the model in `runLua` beside it.
+  it('matches the script this suite was written against, line for line', () => {
+    const body = ON_DEMAND_REWARD_SCRIPT.split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l && !l.startsWith('--'));
+
+    expect(body).toEqual([
+      "local cacheJson = redis.call('HGET', KEYS[1], ARGV[1])",
+      "local cache = cjson.decode(cacheJson or '{}')",
+      'if cache[ARGV[2]] then',
+      'return -1',
+      'end',
+      'local awarded = 0',
+      'for _, entry in pairs(cache) do',
+      "local paid = string.match(tostring(entry), '^a:(%d+)$')",
+      'awarded = awarded + (paid and tonumber(paid) or tonumber(ARGV[3]))',
+      'end',
+      'local remaining = math.max(tonumber(ARGV[4]) - awarded, 0)',
+      'local toAward = math.min(tonumber(ARGV[3]), remaining)',
+      "cache[ARGV[2]] = 'a:' .. tostring(toAward)",
+      "redis.call('HSET', KEYS[1], ARGV[1], cjson.encode(cache))",
+      "redis.call('EXPIREAT', KEYS[1], tonumber(ARGV[5]))",
+      'return toAward',
+    ]);
   });
 });
 

--- a/src/server/rewards/__tests__/base.reward.config.test.ts
+++ b/src/server/rewards/__tests__/base.reward.config.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// WHY THIS SUITE EXISTS
+//
+// `rewards:config` turns a reward off, or changes its amount and cap, without a
+// deploy. There are THREE doors out of `createBuzzEvent` and the gate has to
+// hold on all of them:
+//
+//   apply()                 the inline grant path
+//   process()               the `rewards-process` cron, which pays the `pending`
+//                           rows apply() wrote earlier
+//   getUserRewardDetails()  the user-facing rewards list
+//
+// The process() gate is the one that is easy to leave untested. On-demand
+// rewards (firstDailyFollow, generatorFeedback, dailyBoost, ...) write `awarded`
+// or `capped` inline and NEVER write a `pending` row, so a suite built around
+// one of them enters the sweep zero times while looking like it covers it. The
+// sweep tests below therefore use PROCESSABLE rewards — a local one and the real
+// `goodContentReward` — which are the only rewards that can reach it.
+// ---------------------------------------------------------------------------
+
+const h = vi.hoisted(() => ({
+  insertImpl: vi.fn(async () => undefined),
+  queryImpl: vi.fn(async () => [] as unknown[]),
+  evalImpl: vi.fn(async () => 0 as number),
+  hGetImpl: vi.fn(async () => '{}'),
+  createBuzzTransactionMany: vi.fn(async () => ({ transactions: [] })),
+  getMultipliersForUser: vi.fn(async () => ({ rewardsMultiplier: 1 })),
+}));
+
+vi.mock('~/server/clickhouse/client', () => ({
+  clickhouse: {
+    insert: (...args: any[]) => h.insertImpl(...args),
+    $query: (...args: any[]) => h.queryImpl(...args),
+    query: vi.fn(async () => ({ json: async () => [] })),
+  },
+}));
+
+vi.mock('~/server/prom/client', () => ({
+  rewardFailedCounter: { inc: vi.fn() },
+  rewardGivenCounter: { inc: vi.fn() },
+  clickhouseFailSoftCounter: { inc: vi.fn() },
+}));
+
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransactionMany: (...args: any[]) => h.createBuzzTransactionMany(...args),
+  getMultipliersForUser: (...args: any[]) => h.getMultipliersForUser(...args),
+}));
+
+import { createBuzzEvent } from '~/server/rewards/base.reward';
+import type { BuzzEventLog } from '~/server/rewards/base.reward';
+import { goodContentReward } from '~/server/rewards/passive/goodContent.reward';
+import { invalidateRewardConfigCache } from '~/server/rewards/reward-config';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+
+redisMock.redis.eval.mockImplementation((...args: any[]) => h.evalImpl(...args));
+redisMock.redis.hGet.mockImplementation((...args: any[]) => h.hGetImpl(...args));
+
+const findUnique = dbMock.dbRead.keyValue.findUnique;
+const configure = (rewards: Record<string, unknown>) =>
+  findUnique.mockResolvedValue({ value: { rewards } });
+
+const AWARD_AMOUNT = 100;
+const CAP = 1000;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  invalidateRewardConfigCache();
+  findUnique.mockResolvedValue(null);
+  h.insertImpl.mockResolvedValue(undefined as any);
+  h.queryImpl.mockResolvedValue([]);
+  h.evalImpl.mockResolvedValue(AWARD_AMOUNT as any);
+  h.hGetImpl.mockResolvedValue('{}');
+  h.getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: 1 });
+});
+
+const getKey = vi.fn(async (input: { userId: number; entityId: number }) => ({
+  toUserId: input.userId,
+  forId: input.entityId,
+  byUserId: input.userId,
+}));
+
+const onDemandReward = () =>
+  createBuzzEvent<{ userId: number; entityId: number }>({
+    type: 'testOnDemandReward',
+    description: 'Test on-demand reward',
+    awardAmount: AWARD_AMOUNT,
+    cap: CAP,
+    onDemand: true,
+    getKey,
+  });
+
+const processableReward = () =>
+  createBuzzEvent<{ userId: number; entityId: number }>({
+    type: 'testProcessableReward',
+    description: 'Test processable reward',
+    awardAmount: AWARD_AMOUNT,
+    caps: [{ keyParts: ['toUserId'], interval: 'day', amount: CAP }],
+    getKey,
+  });
+
+const pendingEvents = (type: string): BuzzEventLog[] => [
+  { type, toUserId: 1, forId: 10, byUserId: 2, awardAmount: AWARD_AMOUNT, status: 'pending' },
+  { type, toUserId: 1, forId: 11, byUserId: 3, awardAmount: AWARD_AMOUNT, status: 'pending' },
+];
+
+const processCtx = (toProcess: BuzzEventLog[]) =>
+  ({ toProcess, lastUpdate: new Date(0), ch: {}, db: {} } as any);
+
+describe('apply() is gated before it does any work', () => {
+  it('does not resolve the key, the multiplier, the dedup entry or the audit row', async () => {
+    configure({ testOnDemandReward: { enabled: false } });
+
+    await onDemandReward().apply({ userId: 1, entityId: 42 });
+
+    // The order matters, not just the outcome: `orchestrator.router` calls apply
+    // once per feedback patch inside a live generation mutation, so a disabled
+    // reward must cost one early return rather than a DB read, a Redis script
+    // and a ClickHouse insert per patch.
+    expect(getKey).not.toHaveBeenCalled();
+    expect(h.getMultipliersForUser).not.toHaveBeenCalled();
+    expect(h.evalImpl).not.toHaveBeenCalled();
+    expect(h.insertImpl).not.toHaveBeenCalled();
+    expect(h.createBuzzTransactionMany).not.toHaveBeenCalled();
+  });
+
+  it('still grants when the config names the reward without disabling it', async () => {
+    configure({ testOnDemandReward: { awardAmount: 4 } });
+
+    await onDemandReward().apply({ userId: 1, entityId: 42 });
+
+    expect(getKey).toHaveBeenCalled();
+    expect(h.createBuzzTransactionMany).toHaveBeenCalled();
+  });
+
+  it('records the overridden amount, not the compiled one', async () => {
+    configure({ testOnDemandReward: { awardAmount: 4 } });
+
+    await onDemandReward().apply({ userId: 1, entityId: 42 });
+
+    expect(h.insertImpl).toHaveBeenCalledWith(
+      expect.objectContaining({ values: [expect.objectContaining({ awardAmount: 4 })] })
+    );
+  });
+
+  // The override moves the base number; membership still scales it afterwards.
+  it('applies the membership multiplier on top of the override', async () => {
+    h.getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: 2 });
+    configure({ testOnDemandReward: { awardAmount: 4, cap: 8 } });
+
+    await onDemandReward().apply({ userId: 1, entityId: 42 });
+
+    const [, options] = h.evalImpl.mock.calls[0] as any[];
+    // ARGV[3] = effective award, ARGV[4] = effective cap — both multiplied.
+    expect(options.arguments[2]).toBe('8');
+    expect(options.arguments[3]).toBe('16');
+    expect(h.createBuzzTransactionMany).toHaveBeenCalledWith([
+      expect.objectContaining({ amount: 8 }),
+    ]);
+  });
+
+  it('uses the compiled amount and cap when no row exists', async () => {
+    await onDemandReward().apply({ userId: 1, entityId: 42 });
+
+    const [, options] = h.evalImpl.mock.calls[0] as any[];
+    expect(options.arguments[2]).toBe(String(AWARD_AMOUNT));
+    expect(options.arguments[3]).toBe(String(CAP));
+  });
+});
+
+describe('process() does not pay out a disabled reward’s backlog', () => {
+  it('marks the pending rows terminally unqualified instead of awarding them', async () => {
+    configure({ testProcessableReward: { enabled: false } });
+    const toProcess = pendingEvents('testProcessableReward');
+
+    await processableReward().process(processCtx(toProcess));
+
+    // Terminal, not skipped: the job scans `time >= lastUpdate` and never looks
+    // back, so a skipped row would strand pending forever.
+    expect(toProcess.map((x) => x.status)).toEqual(['unqualified', 'unqualified']);
+    expect(toProcess.map((x) => x.awardAmount)).toEqual([0, 0]);
+    expect(h.createBuzzTransactionMany).not.toHaveBeenCalled();
+    // The rows are written back, or the sweep is a local mutation nobody sees.
+    expect(h.insertImpl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        values: toProcess.map(() => expect.objectContaining({ status: 'unqualified' })),
+      })
+    );
+  });
+
+  it('holds for a real processable reward, not only the local fixture', async () => {
+    configure({ goodContent: { enabled: false } });
+    const toProcess = pendingEvents('goodContent');
+
+    await goodContentReward.process(processCtx(toProcess));
+
+    expect(toProcess.map((x) => x.status)).toEqual(['unqualified', 'unqualified']);
+    expect(h.createBuzzTransactionMany).not.toHaveBeenCalled();
+  });
+
+  it('pays the backlog normally when the reward is enabled', async () => {
+    const toProcess = pendingEvents('testProcessableReward');
+
+    await processableReward().process(processCtx(toProcess));
+
+    expect(toProcess.map((x) => x.status)).toEqual(['awarded', 'awarded']);
+    expect(h.createBuzzTransactionMany).toHaveBeenCalled();
+  });
+
+  it('enforces the overridden cap rather than the compiled one', async () => {
+    configure({ testProcessableReward: { cap: 150 } });
+    const toProcess = pendingEvents('testProcessableReward');
+
+    await processableReward().process(processCtx(toProcess));
+
+    // Cap 150 against two 100-Buzz events: the first pays in full, the second is
+    // trimmed to the 50 that remains.
+    expect(toProcess.map((x) => x.awardAmount)).toEqual([100, 50]);
+  });
+});
+
+describe('getUserRewardDetails() stops advertising a disabled reward', () => {
+  it('returns null so the reward leaves the user-facing list', async () => {
+    configure({ testOnDemandReward: { enabled: false } });
+
+    expect(await onDemandReward().getUserRewardDetails(1)).toBeNull();
+  });
+
+  it('reports the overridden amount and cap, multiplier applied on top', async () => {
+    h.getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: 2 });
+    configure({ testOnDemandReward: { awardAmount: 4, cap: 8 } });
+
+    expect(await onDemandReward().getUserRewardDetails(1)).toMatchObject({
+      awardAmount: 8,
+      cap: 16,
+    });
+  });
+
+  it('reports the compiled values when nothing is overridden', async () => {
+    expect(await onDemandReward().getUserRewardDetails(1)).toMatchObject({
+      awardAmount: AWARD_AMOUNT,
+      cap: CAP,
+    });
+  });
+});
+
+describe('describeConfig() answers "which rewards are on" from one place', () => {
+  it('reports the default beside the effective value and names refused fields', async () => {
+    configure({ testProcessableReward: { enabled: false, awardAmount: 999999 } });
+
+    expect(await processableReward().describeConfig()).toMatchObject({
+      type: 'testProcessableReward',
+      defaults: { awardAmount: AWARD_AMOUNT, cap: CAP },
+      effective: { enabled: false, awardAmount: AWARD_AMOUNT, cap: CAP },
+      rejected: ['awardAmount'],
+    });
+  });
+});

--- a/src/server/rewards/__tests__/base.reward.config.test.ts
+++ b/src/server/rewards/__tests__/base.reward.config.test.ts
@@ -221,6 +221,122 @@ describe('process() does not pay out a disabled reward’s backlog', () => {
   });
 });
 
+// The Lua is the thing under test here, so these drive a real in-memory Redis
+// hash through it rather than stubbing its return value: the cap arithmetic and
+// the per-entry bookkeeping are the behaviour, not an implementation detail.
+describe('the cap is never overshot, whatever the operator sets', () => {
+  const hash = new Map<string, string>();
+
+  const runLua = (_script: string, opts: { arguments: string[] }) => {
+    const [field, cacheKey, award, cap] = opts.arguments;
+    const entries = JSON.parse(hash.get(field) ?? '{}') as Record<string, string>;
+    if (entries[cacheKey] !== undefined) return -1;
+
+    const awarded = Object.values(entries).reduce((sum, entry) => {
+      const paid = /^a:(\d+)$/.exec(entry);
+      return sum + (paid ? Number(paid[1]) : Number(award));
+    }, 0);
+    const toAward = Math.min(Number(award), Math.max(Number(cap) - awarded, 0));
+
+    entries[cacheKey] = `a:${toAward}`;
+    hash.set(field, JSON.stringify(entries));
+    return toAward;
+  };
+
+  beforeEach(() => {
+    hash.clear();
+    h.evalImpl.mockImplementation(runLua as any);
+    h.hGetImpl.mockImplementation(async (_key: string, field: string) => hash.get(field) ?? '{}');
+  });
+
+  const paidSoFar = () =>
+    h.createBuzzTransactionMany.mock.calls.flatMap(([events]: any) =>
+      events.map((x: any) => x.amount)
+    );
+
+  it('pays only what the cap leaves when the award does not divide it', async () => {
+    // Award 3 against cap 10: three full grants, then 1, then nothing. Paying the
+    // whole award on the trimmed grant would total 12 against a cap of 10.
+    configure({ testOnDemandReward: { awardAmount: 3, cap: 10 } });
+    const reward = onDemandReward();
+
+    for (let i = 0; i < 5; i++) await reward.apply({ userId: 1, entityId: i });
+
+    expect(paidSoFar()).toEqual([3, 3, 3, 1]);
+    expect(paidSoFar().reduce((a, b) => a + b, 0)).toBe(10);
+  });
+
+  it('pays at most the cap when the award is raised above it', async () => {
+    configure({ testOnDemandReward: { awardAmount: 5000, cap: 500 } });
+
+    await onDemandReward().apply({ userId: 1, entityId: 1 });
+
+    expect(paidSoFar()).toEqual([500]);
+  });
+
+  // The day's entries record what they paid. Deriving earnings as
+  // `count * the current award` instead lets an operator LOWER the award and
+  // increase that day's payout.
+  it('does not re-price the day when the award is lowered mid-day', async () => {
+    configure({ testOnDemandReward: { awardAmount: 2, cap: 10 } });
+    for (let i = 0; i < 5; i++) await onDemandReward().apply({ userId: 1, entityId: i });
+    expect(paidSoFar().reduce((a, b) => a + b, 0)).toBe(10);
+
+    invalidateRewardConfigCache();
+    configure({ testOnDemandReward: { awardAmount: 1, cap: 10 } });
+    for (let i = 5; i < 10; i++) await onDemandReward().apply({ userId: 1, entityId: i });
+
+    expect(paidSoFar().reduce((a, b) => a + b, 0)).toBe(10);
+  });
+
+  it('reports the same day total to the user as it paid', async () => {
+    configure({ testOnDemandReward: { awardAmount: 3, cap: 10 } });
+    const reward = onDemandReward();
+    for (let i = 0; i < 5; i++) await reward.apply({ userId: 1, entityId: i });
+
+    const details = await reward.getUserRewardDetails(1);
+
+    expect(details?.awarded).toBe(paidSoFar().reduce((a, b) => a + b, 0));
+  });
+});
+
+describe('a multi-entry cap table refuses the override', () => {
+  const twoCapReward = () =>
+    createBuzzEvent<{ userId: number; entityId: number }>({
+      type: 'testTwoCapReward',
+      description: 'Test reward with a day cap and a per-entity cap',
+      awardAmount: AWARD_AMOUNT,
+      caps: [
+        { keyParts: ['toUserId'], interval: 'day', amount: 1000 },
+        { keyParts: ['forId'], amount: 200 },
+      ],
+      getKey,
+    });
+
+  // `capOverridable` is the only thing standing between an operator raising the
+  // monthly cap and silently raising the per-entity one by the same number.
+  it('leaves both caps at their compiled amounts', async () => {
+    configure({ testTwoCapReward: { cap: 5000 } });
+
+    const described = await twoCapReward().describeConfig();
+
+    expect(described.capOverridable).toBe(false);
+    expect(described.effective.cap).toBeUndefined();
+    expect(described.rejected).toContain('cap');
+  });
+
+  it('enforces the compiled per-entity cap during processing', async () => {
+    configure({ testTwoCapReward: { cap: 5000 } });
+    const toProcess = pendingEvents('testTwoCapReward');
+
+    await twoCapReward().process(processCtx(toProcess));
+
+    // The tighter compiled cap (200 on forId) still trims a 100-Buzz event pair
+    // to itself rather than to the operator's 5000.
+    expect(toProcess.every((x) => x.awardAmount <= 200)).toBe(true);
+  });
+});
+
 describe('getUserRewardDetails() stops advertising a disabled reward', () => {
   it('returns null so the reward leaves the user-facing list', async () => {
     configure({ testOnDemandReward: { enabled: false } });

--- a/src/server/rewards/__tests__/base.reward.config.test.ts
+++ b/src/server/rewards/__tests__/base.reward.config.test.ts
@@ -512,41 +512,61 @@ describe('the on-demand Lua keeps the properties the model assumes', () => {
   // found two holes by executing mutants; assume there are more nobody tried.
   // This fails on any edit to the script including a reformat, which is the safe
   // direction: updating it forces re-deriving the model in `runLua` beside it.
-  // 🔴 Lua block comments open with `--[[` and close with `--]]`, and BOTH
-  // delimiters start with `--`. A normaliser that drops every `--` line deletes
-  // exactly the two lines that neutralise everything between them, leaving the
-  // commented-out body in the array where it matches the expectation perfectly.
-  // Wrapping the dedup block that way killed the double-award guard in Redis and
-  // passed every assertion in this file, including the named one, whose regex
-  // still matched source Lua would never execute. Strip block comments before
-  // dropping line comments, and refuse the delimiter outright as the floor.
-  it('has no block comment neutralising part of the script', () => {
-    expect(ON_DEMAND_REWARD_SCRIPT).not.toContain('--[[');
+  // Names the class for a legible failure. The pin below would catch it anyway.
+  it('has no long-bracket comment neutralising part of the script', () => {
+    expect(ON_DEMAND_REWARD_SCRIPT).not.toMatch(/--\[=*\[/);
   });
 
-  it('matches the script this suite was written against, line for line', () => {
-    const body = ON_DEMAND_REWARD_SCRIPT.replace(/--\[\[[\s\S]*?--\]\]/g, '')
-      .split('\n')
-      .map((l) => l.trim())
-      .filter((l) => l && !l.startsWith('--'));
-
-    expect(body).toEqual([
-      "local cacheJson = redis.call('HGET', KEYS[1], ARGV[1])",
-      "local cache = cjson.decode(cacheJson or '{}')",
-      'if cache[ARGV[2]] then',
-      'return -1',
-      'end',
-      'local awarded = 0',
-      'for _, entry in pairs(cache) do',
-      "local paid = string.match(tostring(entry), '^a:(%d+)$')",
-      'awarded = awarded + (paid and tonumber(paid) or tonumber(ARGV[3]))',
-      'end',
-      'local remaining = math.max(tonumber(ARGV[4]) - awarded, 0)',
-      'local toAward = math.min(tonumber(ARGV[3]), remaining)',
-      "cache[ARGV[2]] = 'a:' .. tostring(toAward)",
-      "redis.call('HSET', KEYS[1], ARGV[1], cjson.encode(cache))",
-      "redis.call('EXPIREAT', KEYS[1], tonumber(ARGV[5]))",
-      'return toAward',
+  // 🔴 This pin does NOT normalise, and that is the whole design.
+  //
+  // Three earlier versions each ignored something so the comparison would be
+  // stable, and each time the thing ignored was the attack. Trimming and dropping
+  // `--` lines let a `--[[ … --]]` wrapper delete its own delimiters and leave the
+  // commented-out body matching perfectly — the double-award guard dead in Redis,
+  // every assertion green. Stripping `--[[ … --]]` then let `--[==[ … --]==]`
+  // through, because Lua's long-bracket form takes any number of `=` and the `--`
+  // on the closer is just comment content. Each fix closed the spelling it was
+  // shown, not the class.
+  //
+  // A normaliser cannot be trusted here because "what can neutralise a line" is
+  // not a closed set. So nothing is ignored: every line of the script, including
+  // blank ones, comments and indentation, is compared verbatim. Split per line
+  // only so the failure is a one-line diff rather than a wall.
+  //
+  // ⚠️ What this is worth: it RAISES THE COST of a silent script revert. It does
+  // not prevent one, and it exists only because nothing in this repo can execute
+  // Lua. If another way to neutralise the script turns up, the answer is a Lua
+  // interpreter in devDependencies or an integration test against a real Redis —
+  // not another regex.
+  it('matches the script this suite was written against, verbatim', () => {
+    expect(ON_DEMAND_REWARD_SCRIPT.split('\n')).toEqual([
+      '',
+      "  local cacheJson = redis.call('HGET', KEYS[1], ARGV[1])",
+      "  local cache = cjson.decode(cacheJson or '{}')",
+      '',
+      '  -- Check if already awarded (dedup by cache key)',
+      '  if cache[ARGV[2]] then',
+      '    return -1',
+      '  end',
+      '',
+      "  -- Sum what the day's entries actually paid, and enforce the cap against that",
+      '  local awarded = 0',
+      '  for _, entry in pairs(cache) do',
+      "    local paid = string.match(tostring(entry), '^a:(%d+)$')",
+      '    awarded = awarded + (paid and tonumber(paid) or tonumber(ARGV[3]))',
+      '  end',
+      '  local remaining = math.max(tonumber(ARGV[4]) - awarded, 0)',
+      '  local toAward = math.min(tonumber(ARGV[3]), remaining)',
+      '',
+      '  -- Update cache with new entry',
+      "  cache[ARGV[2]] = 'a:' .. tostring(toAward)",
+      "  redis.call('HSET', KEYS[1], ARGV[1], cjson.encode(cache))",
+      '',
+      '  -- Set hash expiry to end of UTC day',
+      "  redis.call('EXPIREAT', KEYS[1], tonumber(ARGV[5]))",
+      '',
+      '  return toAward',
+      '',
     ]);
   });
 });

--- a/src/server/rewards/__tests__/base.reward.config.test.ts
+++ b/src/server/rewards/__tests__/base.reward.config.test.ts
@@ -286,6 +286,39 @@ describe('the cap is never overshot, whatever the operator sets', () => {
     expect(paidSoFar().reduce((a, b) => a + b, 0)).toBe(10);
   });
 
+  // Lowering a cap below what the day already paid is a first-week action on a
+  // feature whose whole purpose is changing caps at runtime, and it is the only
+  // thing that drives `remaining` negative. Without it the `Math.max(…, 0)` floor
+  // in both the script and the model beside it is unreachable, so a mutant that
+  // removes it survives and the reward starts paying negative Buzz.
+  // The cap must be lowered to exactly one below what was paid. Any deeper and
+  // the negative is invisible: `apply` treats every non-positive result as
+  // capped, so the floor's absence changes nothing observable. At -1 it collides
+  // with the script's ALREADY-AWARDED sentinel — `apply` returns early believing
+  // the event was a duplicate, and the entry is written as `a:-1`, which
+  // `parseEntryAmount` cannot read and the day total then counts as a full award.
+  it('pays nothing, and corrupts nothing, when a cap drops just below what was paid', async () => {
+    configure({ testOnDemandReward: { awardAmount: 3, cap: 10 } });
+    for (let i = 0; i < 4; i++) await onDemandReward().apply({ userId: 1, entityId: i });
+    const paidBefore = paidSoFar().reduce((a, b) => a + b, 0);
+    expect(paidBefore).toBe(10);
+
+    invalidateRewardConfigCache();
+    configure({ testOnDemandReward: { awardAmount: 3, cap: 9 } });
+    await onDemandReward().apply({ userId: 1, entityId: 99 });
+
+    expect(paidSoFar().reduce((a, b) => a + b, 0)).toBe(paidBefore);
+
+    // Raise the cap again to read the day back: while the cap sits below the
+    // total, `Math.min` clamps both the right and the wrong answer to the cap and
+    // the assertion proves nothing. Above it, an `a:-1` entry shows up — it is
+    // unparseable, so the total counts it as a whole award instead.
+    invalidateRewardConfigCache();
+    configure({ testOnDemandReward: { awardAmount: 3, cap: 100 } });
+
+    expect((await onDemandReward().getUserRewardDetails(1))?.awarded).toBe(paidBefore);
+  });
+
   it('pays at most the cap when the award is raised above it', async () => {
     configure({ testOnDemandReward: { awardAmount: 5000, cap: 500 } });
 
@@ -479,8 +512,21 @@ describe('the on-demand Lua keeps the properties the model assumes', () => {
   // found two holes by executing mutants; assume there are more nobody tried.
   // This fails on any edit to the script including a reformat, which is the safe
   // direction: updating it forces re-deriving the model in `runLua` beside it.
+  // 🔴 Lua block comments open with `--[[` and close with `--]]`, and BOTH
+  // delimiters start with `--`. A normaliser that drops every `--` line deletes
+  // exactly the two lines that neutralise everything between them, leaving the
+  // commented-out body in the array where it matches the expectation perfectly.
+  // Wrapping the dedup block that way killed the double-award guard in Redis and
+  // passed every assertion in this file, including the named one, whose regex
+  // still matched source Lua would never execute. Strip block comments before
+  // dropping line comments, and refuse the delimiter outright as the floor.
+  it('has no block comment neutralising part of the script', () => {
+    expect(ON_DEMAND_REWARD_SCRIPT).not.toContain('--[[');
+  });
+
   it('matches the script this suite was written against, line for line', () => {
-    const body = ON_DEMAND_REWARD_SCRIPT.split('\n')
+    const body = ON_DEMAND_REWARD_SCRIPT.replace(/--\[\[[\s\S]*?--\]\]/g, '')
+      .split('\n')
       .map((l) => l.trim())
       .filter((l) => l && !l.startsWith('--'));
 

--- a/src/server/rewards/__tests__/reward-config.test.ts
+++ b/src/server/rewards/__tests__/reward-config.test.ts
@@ -1,0 +1,230 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import {
+  invalidateRewardConfigCache,
+  MAX_AWARD_AMOUNT,
+  MAX_CAP,
+  resolveRewardConfig,
+  rewardOverrideSchema,
+} from '~/server/rewards/reward-config';
+
+// The compiled definition's values. Every fallback below asserts against THIS
+// object rather than a repeated literal, so a fallback that lands on some other
+// plausible number (the placement bug that produced caps 100x too large) fails
+// here instead of passing on a coincidence.
+const DEFAULTS = { awardAmount: 10, cap: 30, capOverridable: true } as const;
+
+const findUnique = dbMock.dbRead.keyValue.findUnique;
+const storedConfig = (value: unknown) => findUnique.mockResolvedValue({ value });
+const resolve = (overrides?: Partial<typeof DEFAULTS>) =>
+  resolveRewardConfig('testReward', { ...DEFAULTS, ...overrides });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  invalidateRewardConfigCache();
+  findUnique.mockResolvedValue(null);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('resolveRewardConfig', () => {
+  it('falls back to the compiled defaults when the row is missing or malformed', async () => {
+    for (const value of [null, 42, 'thirty', [], { rewards: 'all of them' }]) {
+      invalidateRewardConfigCache();
+      findUnique.mockResolvedValue(value === null ? null : { value });
+
+      const config = await resolve();
+
+      expect(config.enabled).toBe(true);
+      expect(config.awardAmount).toBe(DEFAULTS.awardAmount);
+      expect(config.cap).toBe(DEFAULTS.cap);
+    }
+  });
+
+  it('honours a well-formed override', async () => {
+    storedConfig({ rewards: { testReward: { enabled: false, awardAmount: 4, cap: 8 } } });
+
+    expect(await resolve()).toMatchObject({ enabled: false, awardAmount: 4, cap: 8 });
+  });
+
+  it('leaves a reward alone when the row names only other rewards', async () => {
+    storedConfig({ rewards: { someOtherReward: { enabled: false } } });
+
+    expect(await resolve()).toMatchObject({
+      enabled: true,
+      awardAmount: DEFAULTS.awardAmount,
+      cap: DEFAULTS.cap,
+    });
+  });
+
+  it('refuses every out-of-bounds amount and keeps the default instead of zero', async () => {
+    for (const awardAmount of [
+      -1,
+      10.5,
+      MAX_AWARD_AMOUNT + 1,
+      Number.NaN,
+      Infinity,
+      '50',
+      null,
+      { amount: 50 },
+    ]) {
+      invalidateRewardConfigCache();
+      storedConfig({ rewards: { testReward: { awardAmount } } });
+
+      const config = await resolve();
+
+      expect(config.awardAmount).toBe(DEFAULTS.awardAmount);
+      expect(config.rejected).toContain('awardAmount');
+    }
+  });
+
+  it('refuses every out-of-bounds cap and keeps the default', async () => {
+    for (const cap of [-1, 0.5, MAX_CAP + 1, Number.NaN, '30', true]) {
+      invalidateRewardConfigCache();
+      storedConfig({ rewards: { testReward: { cap } } });
+
+      const config = await resolve();
+
+      expect(config.cap).toBe(DEFAULTS.cap);
+      expect(config.rejected).toContain('cap');
+    }
+  });
+
+  it('accepts the bounds themselves, so the guard is a bound and not an off-by-one', async () => {
+    storedConfig({
+      rewards: { testReward: { awardAmount: MAX_AWARD_AMOUNT, cap: MAX_CAP } },
+    });
+
+    expect(await resolve()).toMatchObject({ awardAmount: MAX_AWARD_AMOUNT, cap: MAX_CAP });
+  });
+
+  it('accepts zero, which disables the payout without disabling the reward', async () => {
+    storedConfig({ rewards: { testReward: { awardAmount: 0, cap: 0 } } });
+
+    expect(await resolve()).toMatchObject({ enabled: true, awardAmount: 0, cap: 0 });
+  });
+
+  // The whole point of per-field rejection: an operator who turns a reward off
+  // and fat-fingers the cap in the same edit must still get the reward turned
+  // off. Dropping the whole entry on one bad field would silently re-enable it.
+  it('keeps the valid fields of an entry whose other fields are refused', async () => {
+    storedConfig({
+      rewards: { testReward: { enabled: false, awardAmount: 999999, cap: 8 } },
+    });
+
+    const config = await resolve();
+
+    expect(config.enabled).toBe(false);
+    expect(config.cap).toBe(8);
+    expect(config.awardAmount).toBe(DEFAULTS.awardAmount);
+    expect(config.rejected).toEqual(['awardAmount']);
+  });
+
+  it('treats a non-object entry as no override at all', async () => {
+    storedConfig({ rewards: { testReward: 'off' } });
+
+    expect(await resolve()).toMatchObject({
+      enabled: true,
+      awardAmount: DEFAULTS.awardAmount,
+      cap: DEFAULTS.cap,
+    });
+  });
+
+  it('refuses a non-boolean `enabled` rather than reading it as truthy', async () => {
+    for (const enabled of ['false', 0, 'no']) {
+      invalidateRewardConfigCache();
+      storedConfig({ rewards: { testReward: { enabled } } });
+
+      const config = await resolve();
+
+      expect(config.enabled).toBe(true);
+      expect(config.rejected).toContain('enabled');
+    }
+  });
+
+  // One number cannot say whether it means the daily cap or the monthly one.
+  it('refuses a cap override for a reward whose cap is a multi-entry table', async () => {
+    storedConfig({ rewards: { testReward: { awardAmount: 4, cap: 8 } } });
+
+    const config = await resolve({ capOverridable: false, cap: undefined });
+
+    expect(config.cap).toBeUndefined();
+    expect(config.rejected).toContain('cap');
+    // The refusal is scoped to the cap — the rest of the entry still applies.
+    expect(config.awardAmount).toBe(4);
+  });
+});
+
+describe('reward config cache', () => {
+  it('reads the row once per TTL, not once per grant', async () => {
+    storedConfig({ rewards: { testReward: { awardAmount: 4 } } });
+
+    for (let i = 0; i < 25; i++) await resolve();
+
+    expect(findUnique).toHaveBeenCalledTimes(1);
+  });
+
+  it('picks up a change within the stated 60s window', async () => {
+    vi.useFakeTimers();
+    storedConfig({ rewards: { testReward: { awardAmount: 4 } } });
+    expect((await resolve()).awardAmount).toBe(4);
+
+    storedConfig({ rewards: { testReward: { awardAmount: 7 } } });
+    vi.advanceTimersByTime(59_000);
+    expect((await resolve()).awardAmount).toBe(4);
+
+    vi.advanceTimersByTime(2_000);
+    expect((await resolve()).awardAmount).toBe(7);
+  });
+
+  it('takes a change immediately when the cache is invalidated', async () => {
+    storedConfig({ rewards: { testReward: { awardAmount: 4 } } });
+    expect((await resolve()).awardAmount).toBe(4);
+
+    storedConfig({ rewards: { testReward: { awardAmount: 7 } } });
+    invalidateRewardConfigCache();
+
+    expect((await resolve()).awardAmount).toBe(7);
+  });
+
+  // No negative caching: a transient KeyValue blip must not pin every reward to
+  // its compiled default for a full TTL.
+  it('does not cache a failed read', async () => {
+    findUnique.mockRejectedValueOnce(new Error('KeyValue unavailable'));
+
+    const first = await resolve();
+    expect(first.awardAmount).toBe(DEFAULTS.awardAmount);
+
+    storedConfig({ rewards: { testReward: { awardAmount: 7 } } });
+    expect((await resolve()).awardAmount).toBe(7);
+  });
+
+  it('never throws out of a reward grant, whatever the row read does', async () => {
+    findUnique.mockRejectedValue(new Error('KeyValue unavailable'));
+
+    await expect(resolve()).resolves.toMatchObject({
+      enabled: true,
+      awardAmount: DEFAULTS.awardAmount,
+      cap: DEFAULTS.cap,
+    });
+  });
+});
+
+describe('rewardOverrideSchema', () => {
+  // The admin mutation validates writes with this same schema. If it stopped
+  // being the single definition, what can be stored and what gets honoured
+  // would drift apart.
+  it('rejects at write time exactly what the read path refuses', () => {
+    expect(rewardOverrideSchema.safeParse({ awardAmount: MAX_AWARD_AMOUNT + 1 }).success).toBe(
+      false
+    );
+    expect(rewardOverrideSchema.safeParse({ cap: MAX_CAP + 1 }).success).toBe(false);
+    expect(rewardOverrideSchema.safeParse({ awardAmount: 10.5 }).success).toBe(false);
+    expect(rewardOverrideSchema.safeParse({ cap: -1 }).success).toBe(false);
+    expect(rewardOverrideSchema.safeParse({ enabled: false, awardAmount: 4, cap: 8 }).success).toBe(
+      true
+    );
+  });
+});

--- a/src/server/rewards/__tests__/reward-config.test.ts
+++ b/src/server/rewards/__tests__/reward-config.test.ts
@@ -1,11 +1,14 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 import {
+  getStoredRewardConfig,
   invalidateRewardConfigCache,
   MAX_AWARD_AMOUNT,
   MAX_CAP,
   resolveRewardConfig,
+  REWARD_CONFIG_KEY,
   rewardOverrideSchema,
+  setRewardConfig,
 } from '~/server/rewards/reward-config';
 
 // The compiled definition's values. Every fallback below asserts against THIS
@@ -122,14 +125,29 @@ describe('resolveRewardConfig', () => {
     expect(config.rejected).toEqual(['awardAmount']);
   });
 
-  it('treats a non-object entry as no override at all', async () => {
-    storedConfig({ rewards: { testReward: 'off' } });
+  // `{"dailyBoost": false}` is the shorthand an operator reaches for when they
+  // want a reward off. Resolving the whole-entry case to ON leaves it paying
+  // against an edit that reads, to whoever made it, like it worked — the same
+  // hole `coerceEnabled` closes for the field, one level up.
+  it('disables the reward when the whole entry is unreadable', async () => {
+    for (const entry of [false, true, 'off', 'disabled', null, 0, 42, []]) {
+      invalidateRewardConfigCache();
+      storedConfig({ rewards: { testReward: entry } });
 
-    expect(await resolve()).toMatchObject({
-      enabled: true,
-      awardAmount: DEFAULTS.awardAmount,
-      cap: DEFAULTS.cap,
-    });
+      const config = await resolve();
+
+      expect(config.enabled).toBe(false);
+      expect(config.rejected).toContain('enabled');
+      // The amounts still fall back rather than going to zero.
+      expect(config.awardAmount).toBe(DEFAULTS.awardAmount);
+      expect(config.cap).toBe(DEFAULTS.cap);
+    }
+  });
+
+  it('leaves a reward on for an empty object, which says nothing either way', async () => {
+    storedConfig({ rewards: { testReward: {} } });
+
+    expect(await resolve()).toMatchObject({ enabled: true, rejected: [] });
   });
 
   // A Retool text field produces the string, not the boolean. Falling back to the
@@ -252,10 +270,7 @@ describe('reward config cache', () => {
 });
 
 describe('rewardOverrideSchema', () => {
-  // The admin mutation validates writes with this same schema. If it stopped
-  // being the single definition, what can be stored and what gets honoured
-  // would drift apart.
-  it('rejects at write time exactly what the read path refuses', () => {
+  it('accepts and rejects the values the read path accepts and rejects', () => {
     expect(rewardOverrideSchema.safeParse({ awardAmount: MAX_AWARD_AMOUNT + 1 }).success).toBe(
       false
     );
@@ -265,5 +280,120 @@ describe('rewardOverrideSchema', () => {
     expect(rewardOverrideSchema.safeParse({ enabled: false, awardAmount: 4, cap: 8 }).success).toBe(
       true
     );
+  });
+});
+
+// The read path salvaging a bad row is what makes the write path's strictness
+// load-bearing: a row that reaches disk must be one the read path honours in
+// FULL, or an operator's edit half-applies and the surviving half is invisible.
+// Asserting the schema alone would leave that binding to a comment — replacing
+// `rewardConfigSchema.parse` with a passthrough has to turn something red.
+describe('setRewardConfig', () => {
+  const upsert = dbMock.dbWrite.keyValue.upsert;
+
+  it('refuses the whole write when any field is out of bounds', async () => {
+    await expect(
+      setRewardConfig({ rewards: { testReward: { awardAmount: MAX_AWARD_AMOUNT + 1 } } } as never)
+    ).rejects.toThrow();
+
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it('refuses a cap the read path would refuse', async () => {
+    await expect(
+      setRewardConfig({ rewards: { testReward: { cap: MAX_CAP + 1 } } } as never)
+    ).rejects.toThrow();
+
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  // The read path coerces `"false"` because Retool produces it; the write path
+  // does not, because an editor sending a string means the editor is wrong.
+  it('refuses a stringly-typed `enabled` that the read path would coerce', async () => {
+    await expect(
+      setRewardConfig({ rewards: { testReward: { enabled: 'false' } } } as never)
+    ).rejects.toThrow();
+
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it('refuses one bad reward even when another in the same row is valid', async () => {
+    await expect(
+      setRewardConfig({
+        rewards: { good: { enabled: false }, bad: { awardAmount: -1 } },
+      } as never)
+    ).rejects.toThrow();
+
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it('writes a valid row under the key the read path reads', async () => {
+    const config = { rewards: { testReward: { enabled: false, awardAmount: 4, cap: 8 } } };
+
+    await setRewardConfig(config);
+
+    expect(upsert).toHaveBeenCalledWith({
+      where: { key: REWARD_CONFIG_KEY },
+      create: { key: REWARD_CONFIG_KEY, value: config },
+      update: { value: config },
+    });
+  });
+
+  it('takes effect on the writing pod immediately rather than after the TTL', async () => {
+    storedConfig({ rewards: { testReward: { awardAmount: 4 } } });
+    expect((await resolve()).awardAmount).toBe(4);
+
+    storedConfig({ rewards: { testReward: { awardAmount: 7 } } });
+    await setRewardConfig({ rewards: { testReward: { awardAmount: 7 } } });
+
+    expect((await resolve()).awardAmount).toBe(7);
+  });
+
+  // Invalidating clears the last-good fallback too, so without seeding it here a
+  // read failure moments after the write re-enables the reward just disabled.
+  it('leaves the reward it just disabled disabled when the next read fails', async () => {
+    await setRewardConfig({ rewards: { testReward: { enabled: false, awardAmount: 4 } } });
+
+    findUnique.mockRejectedValue(new Error('KeyValue unavailable'));
+
+    expect(await resolve()).toMatchObject({ enabled: false, awardAmount: 4 });
+  });
+});
+
+describe('getStoredRewardConfig', () => {
+  it('returns the row as written, for an editor to render', async () => {
+    const stored = { rewards: { testReward: { enabled: false, cap: 8 } } };
+    storedConfig(stored);
+
+    expect(await getStoredRewardConfig()).toEqual({ value: stored, malformed: false });
+  });
+
+  // `setRewardConfig` replaces the whole row, so an editor shown `{}` for a row it
+  // could not parse would wipe every other reward's override on its first save —
+  // and `enabled: "false"` from a Retool text field is exactly such a row.
+  it('returns the RAW row when it would not survive a write, never an empty one', async () => {
+    const stored = {
+      rewards: { testReward: { enabled: 'false' }, otherReward: { awardAmount: 4 } },
+    };
+    storedConfig(stored);
+
+    expect(await getStoredRewardConfig()).toEqual({ value: stored, malformed: true });
+  });
+
+  it('does not throw on a row that is not even an object', async () => {
+    storedConfig('disabled');
+
+    expect(await getStoredRewardConfig()).toEqual({ value: 'disabled', malformed: true });
+  });
+
+  // Uncached on purpose: an operator fixing a refused field needs what is in the
+  // row, not what the read path salvaged, and not a minute-old copy of either.
+  it('reads through on every call', async () => {
+    storedConfig({ rewards: {} });
+
+    await getStoredRewardConfig();
+    await getStoredRewardConfig();
+
+    expect(findUnique).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/server/rewards/__tests__/reward-config.test.ts
+++ b/src/server/rewards/__tests__/reward-config.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import { dbMock } from '~/__tests__/mocks/db.mock';
+import { loggingMock } from '~/__tests__/mocks/logging.mock';
 import {
   getStoredRewardConfig,
   invalidateRewardConfigCache,
@@ -80,6 +81,10 @@ describe('resolveRewardConfig', () => {
 
       expect(config.awardAmount).toBe(DEFAULTS.awardAmount);
       expect(config.rejected).toContain('awardAmount');
+      // The other direction, which the rest of this file does not pin: a refused
+      // sibling must not take the reward down either. Everything else here is
+      // about fail-open; this is the fail-closed edge of the same function.
+      expect(config.enabled).toBe(true);
     }
   });
 
@@ -92,6 +97,7 @@ describe('resolveRewardConfig', () => {
 
       expect(config.cap).toBe(DEFAULTS.cap);
       expect(config.rejected).toContain('cap');
+      expect(config.enabled).toBe(true);
     }
   });
 
@@ -148,6 +154,58 @@ describe('resolveRewardConfig', () => {
     storedConfig({ rewards: { testReward: {} } });
 
     expect(await resolve()).toMatchObject({ enabled: true, rejected: [] });
+  });
+
+  // A non-strict object STRIPS an unknown key, so these would parse clean to `{}`
+  // and resolve to enabled with nothing rejected and nothing logged — the
+  // operator's edit reads as applied while the reward keeps paying.
+  it('disables on an entry made entirely of keys it does not recognise', async () => {
+    for (const entry of [{ enable: false }, { Enabled: false }, { disabled: true }]) {
+      invalidateRewardConfigCache();
+      storedConfig({ rewards: { testReward: entry } });
+
+      const config = await resolve();
+
+      expect(config.enabled).toBe(false);
+      expect(config.rejected).toEqual(Object.keys(entry));
+    }
+  });
+
+  // A stray annotation beside a real field should not take a reward down.
+  it('keeps the recognised fields and only reports the stray key', async () => {
+    storedConfig({ rewards: { testReward: { cap: 8, note: 'for the launch' } } });
+
+    expect(await resolve()).toMatchObject({ enabled: true, cap: 8, rejected: ['note'] });
+  });
+
+  // `usableOverride`'s doc promises a refused field does not re-enable a reward.
+  // The unpinned converse: it must not disable one either.
+  it('leaves a reward on when one field is refused and `enabled` is absent', async () => {
+    storedConfig({ rewards: { testReward: { awardAmount: -1, cap: 8 } } });
+
+    expect(await resolve()).toMatchObject({ enabled: true, cap: 8 });
+  });
+
+  // `{"dailyBoost": {...}}` — the row someone hand-editing in Retool writes. A
+  // non-strict envelope parses it as "no rewards key" and silently leaves
+  // everything on.
+  it('warns and runs unconfigured on a row written without the `rewards` wrapper', async () => {
+    storedConfig({ testReward: { enabled: false } });
+
+    expect(await resolve()).toMatchObject({
+      enabled: true,
+      awardAmount: DEFAULTS.awardAmount,
+    });
+    expect(await getStoredRewardConfig()).toMatchObject({ malformed: true });
+    // The WARNING is the whole difference a non-strict envelope makes: it would
+    // resolve to exactly the same values, silently. Asserting only the values
+    // tests nothing about the strictness.
+    expect(loggingMock.logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'reward-config',
+        message: expect.stringContaining('malformed reward config row'),
+      })
+    );
   });
 
   // A Retool text field produces the string, not the boolean. Falling back to the
@@ -290,10 +348,46 @@ describe('rewardOverrideSchema', () => {
 // `rewardConfigSchema.parse` with a passthrough has to turn something red.
 describe('setRewardConfig', () => {
   const upsert = dbMock.dbWrite.keyValue.upsert;
+  const MOD_ID = 99;
+
+  it('refuses a key the read path would not recognise', async () => {
+    await expect(
+      setRewardConfig({ rewards: { testReward: { enable: false } } } as never, MOD_ID)
+    ).rejects.toThrow();
+
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it('refuses a row written without the `rewards` wrapper', async () => {
+    await expect(
+      setRewardConfig({ testReward: { enabled: false } } as never, MOD_ID)
+    ).rejects.toThrow();
+
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  // A money-affecting moderator change with no attribution is not auditable.
+  it('records who made the change and what it replaced', async () => {
+    findUnique.mockResolvedValue({ value: { rewards: { testReward: { awardAmount: 4 } } } });
+
+    await setRewardConfig({ rewards: { testReward: { awardAmount: 7 } } }, MOD_ID);
+
+    expect(loggingMock.logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'reward-config',
+        userId: MOD_ID,
+        previous: JSON.stringify({ rewards: { testReward: { awardAmount: 4 } } }),
+        value: JSON.stringify({ rewards: { testReward: { awardAmount: 7 } } }),
+      })
+    );
+  });
 
   it('refuses the whole write when any field is out of bounds', async () => {
     await expect(
-      setRewardConfig({ rewards: { testReward: { awardAmount: MAX_AWARD_AMOUNT + 1 } } } as never)
+      setRewardConfig(
+        { rewards: { testReward: { awardAmount: MAX_AWARD_AMOUNT + 1 } } } as never,
+        MOD_ID
+      )
     ).rejects.toThrow();
 
     expect(upsert).not.toHaveBeenCalled();
@@ -301,7 +395,7 @@ describe('setRewardConfig', () => {
 
   it('refuses a cap the read path would refuse', async () => {
     await expect(
-      setRewardConfig({ rewards: { testReward: { cap: MAX_CAP + 1 } } } as never)
+      setRewardConfig({ rewards: { testReward: { cap: MAX_CAP + 1 } } } as never, MOD_ID)
     ).rejects.toThrow();
 
     expect(upsert).not.toHaveBeenCalled();
@@ -311,7 +405,7 @@ describe('setRewardConfig', () => {
   // does not, because an editor sending a string means the editor is wrong.
   it('refuses a stringly-typed `enabled` that the read path would coerce', async () => {
     await expect(
-      setRewardConfig({ rewards: { testReward: { enabled: 'false' } } } as never)
+      setRewardConfig({ rewards: { testReward: { enabled: 'false' } } } as never, MOD_ID)
     ).rejects.toThrow();
 
     expect(upsert).not.toHaveBeenCalled();
@@ -319,9 +413,12 @@ describe('setRewardConfig', () => {
 
   it('refuses one bad reward even when another in the same row is valid', async () => {
     await expect(
-      setRewardConfig({
-        rewards: { good: { enabled: false }, bad: { awardAmount: -1 } },
-      } as never)
+      setRewardConfig(
+        {
+          rewards: { good: { enabled: false }, bad: { awardAmount: -1 } },
+        } as never,
+        MOD_ID
+      )
     ).rejects.toThrow();
 
     expect(upsert).not.toHaveBeenCalled();
@@ -330,7 +427,7 @@ describe('setRewardConfig', () => {
   it('writes a valid row under the key the read path reads', async () => {
     const config = { rewards: { testReward: { enabled: false, awardAmount: 4, cap: 8 } } };
 
-    await setRewardConfig(config);
+    await setRewardConfig(config, MOD_ID);
 
     expect(upsert).toHaveBeenCalledWith({
       where: { key: REWARD_CONFIG_KEY },
@@ -344,7 +441,7 @@ describe('setRewardConfig', () => {
     expect((await resolve()).awardAmount).toBe(4);
 
     storedConfig({ rewards: { testReward: { awardAmount: 7 } } });
-    await setRewardConfig({ rewards: { testReward: { awardAmount: 7 } } });
+    await setRewardConfig({ rewards: { testReward: { awardAmount: 7 } } }, MOD_ID);
 
     expect((await resolve()).awardAmount).toBe(7);
   });
@@ -352,7 +449,7 @@ describe('setRewardConfig', () => {
   // Invalidating clears the last-good fallback too, so without seeding it here a
   // read failure moments after the write re-enables the reward just disabled.
   it('leaves the reward it just disabled disabled when the next read fails', async () => {
-    await setRewardConfig({ rewards: { testReward: { enabled: false, awardAmount: 4 } } });
+    await setRewardConfig({ rewards: { testReward: { enabled: false, awardAmount: 4 } } }, MOD_ID);
 
     findUnique.mockRejectedValue(new Error('KeyValue unavailable'));
 

--- a/src/server/rewards/__tests__/reward-config.test.ts
+++ b/src/server/rewards/__tests__/reward-config.test.ts
@@ -132,16 +132,41 @@ describe('resolveRewardConfig', () => {
     });
   });
 
-  it('refuses a non-boolean `enabled` rather than reading it as truthy', async () => {
-    for (const enabled of ['false', 0, 'no']) {
+  // A Retool text field produces the string, not the boolean. Falling back to the
+  // compiled default here means falling back to ON, so the operator reads their
+  // edit back, believes the reward is off, and it keeps paying.
+  it('honours the string spellings of `enabled` an operator actually types', async () => {
+    for (const enabled of ['false', 'False', ' FALSE ']) {
+      invalidateRewardConfigCache();
+      storedConfig({ rewards: { testReward: { enabled } } });
+
+      expect(await resolve()).toMatchObject({ enabled: false, rejected: [] });
+    }
+
+    for (const enabled of ['true', 'TRUE']) {
+      invalidateRewardConfigCache();
+      storedConfig({ rewards: { testReward: { enabled } } });
+
+      expect(await resolve()).toMatchObject({ enabled: true, rejected: [] });
+    }
+  });
+
+  it('treats an unreadable `enabled` as off rather than leaving the reward paying', async () => {
+    for (const enabled of [0, 1, 'no', 'off', null, {}]) {
       invalidateRewardConfigCache();
       storedConfig({ rewards: { testReward: { enabled } } });
 
       const config = await resolve();
 
-      expect(config.enabled).toBe(true);
+      expect(config.enabled).toBe(false);
       expect(config.rejected).toContain('enabled');
     }
+  });
+
+  it('leaves a reward on when `enabled` is absent entirely', async () => {
+    storedConfig({ rewards: { testReward: { awardAmount: 4 } } });
+
+    expect(await resolve()).toMatchObject({ enabled: true, rejected: [] });
   });
 
   // One number cannot say whether it means the daily cap or the monthly one.
@@ -190,7 +215,7 @@ describe('reward config cache', () => {
   });
 
   // No negative caching: a transient KeyValue blip must not pin every reward to
-  // its compiled default for a full TTL.
+  // its fallback for a full TTL.
   it('does not cache a failed read', async () => {
     findUnique.mockRejectedValueOnce(new Error('KeyValue unavailable'));
 
@@ -199,6 +224,20 @@ describe('reward config cache', () => {
 
     storedConfig({ rewards: { testReward: { awardAmount: 7 } } });
     expect((await resolve()).awardAmount).toBe(7);
+  });
+
+  // Falling back to the compiled defaults fails OPEN: the compiled default for
+  // `enabled` is on, so a KeyValue blip would resume paying every reward an
+  // operator had turned off, and `process` would then pay the backlog.
+  it('keeps a disabled reward disabled when the read later fails', async () => {
+    storedConfig({ rewards: { testReward: { enabled: false, awardAmount: 4 } } });
+    expect((await resolve()).enabled).toBe(false);
+
+    findUnique.mockRejectedValue(new Error('KeyValue unavailable'));
+    vi.useFakeTimers();
+    vi.advanceTimersByTime(120_000);
+
+    expect(await resolve()).toMatchObject({ enabled: false, awardAmount: 4 });
   });
 
   it('never throws out of a reward grant, whatever the row read does', async () => {

--- a/src/server/rewards/base.reward.ts
+++ b/src/server/rewards/base.reward.ts
@@ -13,6 +13,8 @@ import { redis, REDIS_KEYS } from '~/server/redis/client';
 import type { BuzzAccountType, BuzzSpendType } from '~/shared/constants/buzz.constants';
 import { TransactionType } from '~/shared/constants/buzz.constants';
 import { createBuzzTransactionMany, getMultipliersForUser } from '~/server/services/buzz.service';
+import type { ResolvedRewardConfig } from '~/server/rewards/reward-config';
+import { resolveRewardConfig } from '~/server/rewards/reward-config';
 import { hashifyObject } from '~/utils/string-helpers';
 import { isClickHouseConnectionError, withRetries } from '../utils/errorHandling';
 
@@ -83,24 +85,32 @@ export function createBuzzEvent<T>({
   const types = [type];
   if (isProcessable) types.push(...(buzzEvent.includeTypes ?? []));
 
+  const capEntries = 'caps' in buzzEvent ? buzzEvent.caps ?? [] : [];
+  // One number cannot say whether it means the daily cap or the monthly one, so
+  // a multi-entry table refuses the override rather than guessing an entry.
+  const capOverridable = isOnDemand || capEntries.length === 1;
+  const defaultCap =
+    'cap' in buzzEvent ? buzzEvent.cap : capEntries.length === 1 ? capEntries[0].amount : undefined;
+
+  const resolveConfig = () =>
+    resolveRewardConfig(type, { awardAmount, cap: defaultCap, capOverridable });
+
   const getUserRewardDetails = async (userId: number) => {
+    const config = await resolveConfig();
+    // A reward disabled at runtime must not stay advertised with an amount and
+    // a cap that will never pay.
+    if (!config.enabled) return null;
+
+    const intervalCap = capEntries.filter((cap) => !!cap.interval)?.[0];
     const data = {
       // We'll return the event details
       // so that they can be presented on the UI.
       type,
-      awardAmount,
+      awardAmount: config.awardAmount,
       description,
       onDemand: isOnDemand,
-      cap:
-        'cap' in buzzEvent
-          ? buzzEvent.cap
-          : 'caps' in buzzEvent
-          ? buzzEvent.caps?.filter((cap) => !!cap.interval)?.[0]?.amount
-          : undefined,
-      interval:
-        'caps' in buzzEvent
-          ? buzzEvent.caps?.filter((cap) => !!cap.interval)?.[0]?.interval
-          : undefined,
+      cap: config.cap ?? intervalCap?.amount,
+      interval: intervalCap?.interval,
       triggerDescription: buzzEvent.triggerDescription,
       tooltip: buzzEvent.tooltip,
       // -1 determines that this award is not on demand, as such, would require a full
@@ -186,13 +196,17 @@ export function createBuzzEvent<T>({
     );
   };
 
-  const processOnDemand = async (key: BuzzEventKey, multiplier: number) => {
+  const processOnDemand = async (
+    key: BuzzEventKey,
+    multiplier: number,
+    config: ResolvedRewardConfig
+  ) => {
     if (!isOnDemand) return false;
 
     const hashField = `${key.toUserId}:${type}`;
     const cacheKey = String(hashifyObject(key));
-    const effectiveAward = Math.ceil(awardAmount * multiplier);
-    const effectiveCap = Math.ceil((buzzEvent.cap ?? Infinity) * multiplier);
+    const effectiveAward = Math.ceil(config.awardAmount * multiplier);
+    const effectiveCap = Math.ceil((config.cap ?? Infinity) * multiplier);
     const now = Date.now().toString();
     const endOfDay = Math.floor(new Date().setUTCHours(23, 59, 59, 999) / 1000);
 
@@ -214,6 +228,13 @@ export function createBuzzEvent<T>({
 
   const apply = async (input: T, tracking?: { ip?: string }) => {
     if (!clickhouse) return;
+
+    // Gate before `getKey`. A disabled reward must cost one early return, not a
+    // getKey query, a multiplier lookup (Redis + DB), a Redis dedup script and a
+    // ClickHouse insert — `orchestrator.router` calls this once per feedback
+    // patch inside a live generation mutation.
+    const config = await resolveConfig();
+    if (!config.enabled) return;
 
     // Fail-soft (resolution): getKey / getMultipliersForUser / getTransactionDetails hit the DB/Redis/CH and
     // run SYNCHRONOUSLY inside the triggering user mutation (collection.saveItem, toggleFollow, post.update,
@@ -249,7 +270,7 @@ export function createBuzzEvent<T>({
     const key = { type, ...definedKey } as BuzzEventKey;
     const event: BuzzEventLog = {
       ...key,
-      awardAmount,
+      awardAmount: config.awardAmount,
       multiplier: rewardsMultiplier,
       status: 'pending',
       ip: ['::1', ''].includes(ip ?? '') ? undefined : ip,
@@ -257,7 +278,7 @@ export function createBuzzEvent<T>({
     };
 
     if (isOnDemand) {
-      const toAward = await processOnDemand(key, rewardsMultiplier);
+      const toAward = await processOnDemand(key, rewardsMultiplier, config);
       if (toAward === false) return; // already awarded
 
       event.status = toAward > 0 ? 'awarded' : 'capped';
@@ -324,6 +345,28 @@ export function createBuzzEvent<T>({
 
   const process = async (ctx: ProcessingContext) => {
     if (!isProcessable || !clickhouse) return;
+
+    const config = await resolveConfig();
+    // `apply` only writes a `pending` row for a processable reward; this job is
+    // what pays it. So gating `apply` alone still pays out everything already in
+    // the pipe when the reward was turned off. Skipping those rows would strand
+    // them, because the job scans `time >= lastUpdate` and never looks back —
+    // hence a terminal `unqualified`, the state `process` already uses for
+    // "seen, earns nothing".
+    //
+    // This lives in the reader rather than in a sweep hung off the config write:
+    // the row is a `KeyValue` that gets edited from Retool or psql, where no
+    // application code runs at all, and a per-run check also cannot lose the
+    // race against rows written between the flip and the next run.
+    if (!config.enabled) {
+      for (const event of ctx.toProcess) {
+        event.status = 'unqualified';
+        event.awardAmount = 0;
+      }
+      await updateBuzzEvents(ctx.toProcess);
+      return;
+    }
+
     await buzzEvent.preprocess?.(ctx);
     const targeted = ctx.toProcess.filter((event) => event.status !== 'unqualified');
 
@@ -373,7 +416,8 @@ export function createBuzzEvent<T>({
           const prevAward = prevAwards[key] ?? 0;
 
           // Determine amount remaining against cap
-          const remaining = Math.max(amount - prevAward, 0);
+          const capAmount = capOverridable ? config.cap ?? amount : amount;
+          const remaining = Math.max(capAmount - prevAward, 0);
           event.awardAmount = Math.min(event.awardAmount, remaining);
         }
       }
@@ -410,7 +454,7 @@ export function createBuzzEvent<T>({
           for (const event of chunk) {
             if (event.status !== 'unqualified') {
               event.status = 'pending';
-              event.awardAmount = awardAmount;
+              event.awardAmount = config.awardAmount;
             }
           }
           await updateBuzzEvents(chunk);
@@ -427,12 +471,31 @@ export function createBuzzEvent<T>({
     }
   };
 
+  /**
+   * The operator's answer to "which rewards are on, and at what amounts?".
+   * Resolves through the same `resolveConfig` the grant path uses, so what it
+   * reports and what gets paid cannot drift.
+   */
+  const describeConfig = async () => {
+    const config = await resolveConfig();
+    return {
+      type,
+      visible,
+      onDemand: isOnDemand,
+      capOverridable,
+      defaults: { awardAmount, cap: defaultCap },
+      effective: { enabled: config.enabled, awardAmount: config.awardAmount, cap: config.cap },
+      rejected: config.rejected,
+    };
+  };
+
   return {
     types,
     visible,
     apply,
     process,
     getUserRewardDetails,
+    describeConfig,
   };
 }
 

--- a/src/server/rewards/base.reward.ts
+++ b/src/server/rewards/base.reward.ts
@@ -33,7 +33,7 @@ const log = (event: BuzzEventLog, data: MixedObject) => {
     type: 'error',
     event: JSON.stringify(event),
     ...data,
-  }).catch();
+  }).catch(() => null);
 };
 
 // Lua script for atomic on-demand reward processing.
@@ -43,8 +43,16 @@ const log = (event: BuzzEventLog, data: MixedObject) => {
 // ARGV[2] = cache key (hashed event key for dedup)
 // ARGV[3] = effective award amount (already multiplied)
 // ARGV[4] = effective cap (already multiplied)
-// ARGV[5] = timestamp for cache entry
-// ARGV[6] = end-of-day unix timestamp for hash expiry
+// ARGV[5] = end-of-day unix timestamp for hash expiry
+//
+// Each dedup entry stores WHAT IT PAID (`a:<amount>`), not a timestamp. Deriving
+// the day's earnings as `entry count * the CURRENT award` instead means changing
+// the award mid-day rewrites history: at award 2 and cap 100, a user capped out
+// at 50 entries; drop the award to 1 to spend less and those same 50 entries
+// re-price to 50 earned, freeing 50 more — a day total of 150 from an edit meant
+// to reduce it. Entries written before this (timestamps) fall back to the old
+// count-based reading for the rest of the day; `rewardsDailyReset` clears the
+// hash at 00:00 UTC, after which every entry carries its own amount.
 const ON_DEMAND_REWARD_SCRIPT = `
   local cacheJson = redis.call('HGET', KEYS[1], ARGV[1])
   local cache = cjson.decode(cacheJson or '{}')
@@ -54,22 +62,30 @@ const ON_DEMAND_REWARD_SCRIPT = `
     return -1
   end
 
-  -- Count entries and enforce cap
-  local count = 0
-  for _ in pairs(cache) do count = count + 1 end
-  local awarded = count * tonumber(ARGV[3])
+  -- Sum what the day's entries actually paid, and enforce the cap against that
+  local awarded = 0
+  for _, entry in pairs(cache) do
+    local paid = string.match(tostring(entry), '^a:(%d+)$')
+    awarded = awarded + (paid and tonumber(paid) or tonumber(ARGV[3]))
+  end
   local remaining = math.max(tonumber(ARGV[4]) - awarded, 0)
   local toAward = math.min(tonumber(ARGV[3]), remaining)
 
   -- Update cache with new entry
-  cache[ARGV[2]] = ARGV[5]
+  cache[ARGV[2]] = 'a:' .. tostring(toAward)
   redis.call('HSET', KEYS[1], ARGV[1], cjson.encode(cache))
 
   -- Set hash expiry to end of UTC day
-  redis.call('EXPIREAT', KEYS[1], tonumber(ARGV[6]))
+  redis.call('EXPIREAT', KEYS[1], tonumber(ARGV[5]))
 
   return toAward
 `;
+
+/** `a:<amount>` as written by the Lua; `undefined` for a legacy timestamp entry. */
+function parseEntryAmount(entry: unknown): number | undefined {
+  const match = /^a:(\d+)$/.exec(String(entry));
+  return match ? Number(match[1]) : undefined;
+}
 
 export function createBuzzEvent<T>({
   type,
@@ -159,9 +175,16 @@ export function createBuzzEvent<T>({
 
     const typeCacheJson = (await redis.hGet(REDIS_KEYS.BUZZ_EVENTS, `${userId}:${type}`)) ?? '{}';
     const typeCache = JSON.parse(typeCacheJson);
-    const eventCount = Object.keys(typeCache).length;
 
-    data.awarded = Math.min(eventCount * data.awardAmount, data.cap ?? Infinity);
+    // Read the same per-entry amounts the Lua enforces the cap against, or the
+    // UI reports a different day total than the one being paid.
+    data.awarded = Math.min(
+      Object.values(typeCache).reduce<number>(
+        (sum, entry) => sum + (parseEntryAmount(entry) ?? data.awardAmount),
+        0
+      ),
+      data.cap ?? Infinity
+    );
 
     return data;
   };
@@ -206,8 +229,10 @@ export function createBuzzEvent<T>({
     const hashField = `${key.toUserId}:${type}`;
     const cacheKey = String(hashifyObject(key));
     const effectiveAward = Math.ceil(config.awardAmount * multiplier);
-    const effectiveCap = Math.ceil((config.cap ?? Infinity) * multiplier);
-    const now = Date.now().toString();
+    // An uncapped reward needs a finite ceiling: `tonumber('Infinity')` is nil in
+    // Lua, which would throw out of the script and into the user's mutation.
+    const effectiveCap =
+      config.cap === undefined ? Number.MAX_SAFE_INTEGER : Math.ceil(config.cap * multiplier);
     const endOfDay = Math.floor(new Date().setUTCHours(23, 59, 59, 999) / 1000);
 
     const result = (await redis.eval(ON_DEMAND_REWARD_SCRIPT, {
@@ -217,13 +242,13 @@ export function createBuzzEvent<T>({
         cacheKey,
         String(effectiveAward),
         String(effectiveCap),
-        now,
         String(endOfDay),
       ],
     })) as number;
 
     if (result === -1) return false; // Already awarded
-    return result; // 0 (capped) or effectiveAward
+    // `toAward` is what the cap left, which is NOT always the full award.
+    return { toAward: result, effectiveAward };
   };
 
   const apply = async (input: T, tracking?: { ip?: string }) => {
@@ -258,7 +283,7 @@ export function createBuzzEvent<T>({
         rewardType: type,
         error: (error as Error)?.message,
         stack: (error as Error)?.stack,
-      }).catch();
+      }).catch(() => null);
       rewardFailedCounter?.inc?.();
       return null;
     });
@@ -278,13 +303,26 @@ export function createBuzzEvent<T>({
     };
 
     if (isOnDemand) {
-      const toAward = await processOnDemand(key, rewardsMultiplier, config);
-      if (toAward === false) return; // already awarded
+      const outcome = await processOnDemand(key, rewardsMultiplier, config);
+      if (outcome === false) return; // already awarded
+      const { toAward, effectiveAward } = outcome;
 
       event.status = toAward > 0 ? 'awarded' : 'capped';
-      // Keep base awardAmount and multiplier for ClickHouse storage consistency.
-      // processOnDemand already enforced the cap using multiplied values.
-      if (event.status === 'capped') event.awardAmount = 0;
+      if (event.status === 'capped') {
+        event.awardAmount = 0;
+      } else if (toAward < effectiveAward) {
+        // The cap trimmed this grant. Paying the full award here is how an award
+        // that does not divide its cap overshoots it — 34 grants of 3 against a
+        // cap of 100 paid 102, and an operator raising the award above the cap
+        // would pay the whole award on the first grant. `toAward` is already
+        // multiplied, so record it whole and neutralise the multiplier rather
+        // than applying it twice in `sendAward`.
+        event.awardAmount = toAward;
+        event.multiplier = 1;
+      }
+      // Otherwise keep the base awardAmount and multiplier for ClickHouse
+      // storage consistency; processOnDemand enforced the cap on the multiplied
+      // values and this grant was not trimmed.
     }
 
     // Fail-soft: the inline `apply` path runs synchronously inside user mutations

--- a/src/server/rewards/base.reward.ts
+++ b/src/server/rewards/base.reward.ts
@@ -133,6 +133,9 @@ export function createBuzzEvent<T>({
       // clickhouse query to determine the awarded amount. For the time being, this won't be
       // done.
       awarded: -1,
+      // How many times the reward fired today, which is NOT derivable from
+      // `awarded`: a grant the cap trimmed to zero happened but paid nothing.
+      awardedCount: -1,
       accountType: buzzEvent.toAccountType ?? 'blue',
     };
 
@@ -178,8 +181,10 @@ export function createBuzzEvent<T>({
 
     // Read the same per-entry amounts the Lua enforces the cap against, or the
     // UI reports a different day total than the one being paid.
+    const entries = Object.values(typeCache);
+    data.awardedCount = entries.length;
     data.awarded = Math.min(
-      Object.values(typeCache).reduce<number>(
+      entries.reduce<number>(
         (sum, entry) => sum + (parseEntryAmount(entry) ?? data.awardAmount),
         0
       ),

--- a/src/server/rewards/base.reward.ts
+++ b/src/server/rewards/base.reward.ts
@@ -53,7 +53,7 @@ const log = (event: BuzzEventLog, data: MixedObject) => {
 // to reduce it. Entries written before this (timestamps) fall back to the old
 // count-based reading for the rest of the day; `rewardsDailyReset` clears the
 // hash at 00:00 UTC, after which every entry carries its own amount.
-const ON_DEMAND_REWARD_SCRIPT = `
+export const ON_DEMAND_REWARD_SCRIPT = `
   local cacheJson = redis.call('HGET', KEYS[1], ARGV[1])
   local cache = cjson.decode(cacheJson or '{}')
 

--- a/src/server/rewards/reward-config.ts
+++ b/src/server/rewards/reward-config.ts
@@ -1,0 +1,171 @@
+import { z } from 'zod';
+import { dbRead } from '~/server/db/client';
+import { logToAxiom } from '~/server/logging/client';
+
+export const REWARD_CONFIG_KEY = 'rewards:config';
+
+// Live award amounts run 1..500 and caps 25..1500, so these leave room for a
+// deliberate order-of-magnitude change while refusing the operator typo that
+// adds a zero to the largest of them.
+export const MAX_AWARD_AMOUNT = 5_000;
+export const MAX_CAP = 100_000;
+
+/**
+ * The single definition of an operator override. The admin mutation validates
+ * writes with this same schema, so what can be stored and what will be honoured
+ * cannot drift apart.
+ */
+export const rewardOverrideSchema = z.object({
+  enabled: z.boolean().optional(),
+  awardAmount: z.number().int().min(0).max(MAX_AWARD_AMOUNT).optional(),
+  cap: z.number().int().min(0).max(MAX_CAP).optional(),
+});
+
+export const rewardConfigSchema = z.object({
+  rewards: z.record(z.string(), rewardOverrideSchema).optional(),
+});
+
+export type RewardOverride = z.infer<typeof rewardOverrideSchema>;
+/** The honoured override plus the names of the fields that were refused. */
+export type RewardConfigEntry = { override: RewardOverride; rejected: string[] };
+export type RewardConfig = Record<string, RewardConfigEntry>;
+
+const OVERRIDE_FIELDS = ['enabled', 'awardAmount', 'cap'] as const;
+
+export type RewardDefaults = {
+  awardAmount: number;
+  cap?: number;
+  /**
+   * False for a reward whose cap is a multi-entry table: one number cannot say
+   * whether it means the daily or the monthly cap.
+   */
+  capOverridable: boolean;
+};
+
+export type ResolvedRewardConfig = {
+  enabled: boolean;
+  awardAmount: number;
+  cap?: number;
+  /** Fields an operator set that were refused, for the operator-facing view. */
+  rejected: string[];
+};
+
+const CONFIG_TTL_MS = 60 * 1000;
+
+type CacheEntry = { config: RewardConfig; expiresAt: number };
+
+// Cache the parsed config, not the resolved decision: `resolveRewardConfig`
+// still runs per call so a definition change or a differing default resolves
+// against the current values rather than a snapshot.
+let configCache: CacheEntry | null = null;
+const warnedMultiCap = new Set<string>();
+
+export function invalidateRewardConfigCache() {
+  configCache = null;
+  warnedMultiCap.clear();
+}
+
+const warn = (message: string, data: MixedObject) => {
+  logToAxiom({ name: 'reward-config', type: 'warning', message, ...data }).catch();
+};
+
+/**
+ * Keep the fields that parse rather than dropping the whole reward. An operator
+ * typo in `cap` must not silently re-enable a reward they turned off in the
+ * same edit.
+ */
+function usableOverride(type: string, value: unknown): RewardConfigEntry {
+  const parsed = rewardOverrideSchema.safeParse(value);
+  if (parsed.success) return { override: parsed.data, rejected: [] };
+
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    warn('Ignoring malformed reward override', { rewardType: type, stored: value });
+    return { override: {}, rejected: [...OVERRIDE_FIELDS] };
+  }
+
+  const record = value as MixedObject;
+  const override: RewardOverride = {};
+  const rejected: string[] = [];
+
+  for (const field of OVERRIDE_FIELDS) {
+    if (!(field in record)) continue;
+    const result = rewardOverrideSchema.shape[field].safeParse(record[field]);
+    if (result.success) Object.assign(override, { [field]: result.data });
+    else rejected.push(field);
+  }
+
+  warn('Rejected reward override fields', { rewardType: type, rejected, stored: record });
+  return { override, rejected };
+}
+
+async function loadConfig(): Promise<RewardConfig> {
+  const row = await dbRead.keyValue.findUnique({ where: { key: REWARD_CONFIG_KEY } });
+  const envelope = z
+    .object({ rewards: z.record(z.string(), z.unknown()).optional() })
+    .safeParse(row?.value ?? {});
+
+  if (!envelope.success) {
+    warn('Ignoring malformed reward config row', { stored: row?.value });
+    return {};
+  }
+
+  const config: RewardConfig = {};
+  for (const [type, value] of Object.entries(envelope.data.rewards ?? {}))
+    config[type] = usableOverride(type, value);
+
+  return config;
+}
+
+async function getRewardConfig(): Promise<RewardConfig> {
+  const now = Date.now();
+  if (configCache && configCache.expiresAt > now) return configCache.config;
+
+  try {
+    const config = await loadConfig();
+    configCache = { config, expiresAt: now + CONFIG_TTL_MS };
+    return config;
+  } catch (error) {
+    // No negative caching: a transient KeyValue failure must not pin every
+    // reward to its compiled default for a full TTL.
+    warn('Reward config read failed, using compiled defaults', {
+      error: (error as Error)?.message,
+    });
+    return {};
+  }
+}
+
+/**
+ * Compiled values are the defaults; the stored row only ever narrows or moves
+ * them. Nothing here can fall back to zero, and nothing here throws — a reward
+ * grant must not depend on the config read succeeding.
+ */
+export async function resolveRewardConfig(
+  type: string,
+  defaults: RewardDefaults
+): Promise<ResolvedRewardConfig> {
+  const entry = (await getRewardConfig())[type];
+  const override = entry?.override ?? {};
+  const rejected = [...(entry?.rejected ?? [])];
+
+  let cap = defaults.cap;
+  if (override.cap !== undefined) {
+    if (defaults.capOverridable) cap = override.cap;
+    else {
+      rejected.push('cap');
+      if (!warnedMultiCap.has(type)) {
+        warnedMultiCap.add(type);
+        warn('Refusing cap override for a reward with a multi-entry cap table', {
+          rewardType: type,
+          cap: override.cap,
+        });
+      }
+    }
+  }
+
+  return {
+    enabled: override.enabled ?? true,
+    awardAmount: override.awardAmount ?? defaults.awardAmount,
+    cap,
+    rejected,
+  };
+}

--- a/src/server/rewards/reward-config.ts
+++ b/src/server/rewards/reward-config.ts
@@ -17,15 +17,36 @@ export const MAX_CAP = 100_000;
  * writes with this same schema, so a typo dies at write time rather than
  * persisting as a row the read path quietly refuses.
  */
-export const rewardOverrideSchema = z.object({
-  enabled: z.boolean().optional(),
-  awardAmount: z.number().int().min(0).max(MAX_AWARD_AMOUNT).optional(),
-  cap: z.number().int().min(0).max(MAX_CAP).optional(),
-});
+// 🔴 `.strict()`, not the zod default. A non-strict object STRIPS an unknown key,
+// so `{"enable": false}` or `{"Enabled": false}` — a plausible hand-edit — would
+// parse clean to `{}` and resolve to enabled, with nothing rejected and nothing
+// logged. The operator's edit reads as applied and the reward keeps paying, which
+// is the exact hole this feature exists to close, one level in.
+export const rewardOverrideSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    awardAmount: z.number().int().min(0).max(MAX_AWARD_AMOUNT).optional(),
+    cap: z.number().int().min(0).max(MAX_CAP).optional(),
+  })
+  .strict();
 
+/**
+ * The tRPC input shape. NOT strict at the envelope: a base-procedure middleware
+ * adds `browsingLevel` to every input, and zod strips it here rather than
+ * refusing the call. The router passes only `rewards` on to the write, so the
+ * injected field cannot reach the row.
+ */
 export const rewardConfigSchema = z.object({
   rewards: z.record(z.string(), rewardOverrideSchema).optional(),
 });
+
+/**
+ * What a STORED row must look like. Strict, because a row written without the
+ * wrapper — `{"dailyBoost": {"enabled": false}}`, what someone hand-editing in
+ * Retool writes — would otherwise parse as an envelope with no `rewards` key,
+ * leave every reward on, and warn about nothing.
+ */
+export const storedRewardConfigSchema = rewardConfigSchema.strict();
 
 export type RewardOverride = z.infer<typeof rewardOverrideSchema>;
 /** The honoured override plus the names of the fields that were refused. */
@@ -115,9 +136,11 @@ function usableOverride(type: string, value: unknown): RewardConfigEntry {
   const record = value as MixedObject;
   const override: RewardOverride = {};
   const rejected: string[] = [];
+  let recognised = 0;
 
   for (const field of OVERRIDE_FIELDS) {
     if (!(field in record)) continue;
+    recognised++;
 
     if (field === 'enabled') {
       const coerced = coerceEnabled(record.enabled);
@@ -131,6 +154,18 @@ function usableOverride(type: string, value: unknown): RewardConfigEntry {
     else rejected.push(field);
   }
 
+  const unknown = Object.keys(record).filter(
+    (key) => !(OVERRIDE_FIELDS as readonly string[]).includes(key)
+  );
+  rejected.push(...unknown);
+
+  // An entry made ENTIRELY of keys we do not recognise is an instruction we
+  // cannot carry out — `{"enable": false}`, `{"disabled": true}` — so it disables
+  // rather than resolving to on. An entry that also sets a real field keeps that
+  // field and only reports the stray key: `{"cap": 8, "note": "launch"}` should
+  // not take a reward down.
+  if (recognised === 0 && unknown.length) override.enabled = false;
+
   warn('Rejected reward override fields', { rewardType: type, rejected, stored: record });
   return { override, rejected };
 }
@@ -141,14 +176,22 @@ function buildConfig(rewards: Record<string, unknown>): RewardConfig {
   return config;
 }
 
+// Strict, so a row missing the `rewards` wrapper is a parse failure that warns
+// rather than an envelope with no rewards in it that silently leaves every reward
+// enabled. The entries themselves stay `unknown` here — `usableOverride` salvages
+// them field by field, which the strict override schema would not.
+const envelopeSchema = z.object({ rewards: z.record(z.string(), z.unknown()).optional() }).strict();
+
 async function loadConfig(): Promise<RewardConfig> {
   const row = await dbRead.keyValue.findUnique({ where: { key: REWARD_CONFIG_KEY } });
-  const envelope = z
-    .object({ rewards: z.record(z.string(), z.unknown()).optional() })
-    .safeParse(row?.value ?? {});
+  const stored = row?.value ?? {};
+  const envelope = envelopeSchema.safeParse(stored);
 
   if (!envelope.success) {
-    warn('Ignoring malformed reward config row', { stored: row?.value });
+    // Fail-open, and loudly so: we cannot tell which rewards this row meant.
+    warn('Ignoring malformed reward config row — every reward is running unconfigured', {
+      stored,
+    });
     return {};
   }
 
@@ -205,12 +248,17 @@ export type StoredRewardConfig = {
  * empty form whose first save wipes every other reward's override.
  *
  * ⚠️ Two moderators editing at once are last-write-wins; there is no version
- * guard on the row.
+ * guard on the row. `malformed` is an ingredient for an editor to refuse a save,
+ * not a control — nothing enforces it yet.
+ *
+ * ⚠️ The value is UNPARSED, so a hand-written row can carry a `__proto__` own
+ * key through to the caller. Harmless to render; not harmless to spread or
+ * deep-merge. (The parsed paths drop it rather than assigning it.)
  */
 export async function getStoredRewardConfig(): Promise<StoredRewardConfig> {
   const row = await dbRead.keyValue.findUnique({ where: { key: REWARD_CONFIG_KEY } });
   const value = row?.value ?? {};
-  return { value, malformed: !rewardConfigSchema.safeParse(value).success };
+  return { value, malformed: !storedRewardConfigSchema.safeParse(value).success };
 }
 
 /**
@@ -222,14 +270,31 @@ export async function getStoredRewardConfig(): Promise<StoredRewardConfig> {
  * Only invalidates the caller's own cache — other pods pick the change up within
  * `CONFIG_TTL_MS`.
  */
-export async function setRewardConfig(config: z.infer<typeof rewardConfigSchema>) {
-  const value = rewardConfigSchema.parse(config);
+export async function setRewardConfig(config: z.infer<typeof rewardConfigSchema>, userId: number) {
+  const value = storedRewardConfigSchema.parse(config);
+
+  // Read the prior row for the audit line. Not a version guard — this is still an
+  // unconditional replace, and two moderators editing at once are last-write-wins.
+  const previous = (await dbRead.keyValue.findUnique({ where: { key: REWARD_CONFIG_KEY } }))?.value;
 
   await dbWrite.keyValue.upsert({
     where: { key: REWARD_CONFIG_KEY },
     create: { key: REWARD_CONFIG_KEY, value },
     update: { value },
   });
+
+  // A money-affecting change with no attribution is not auditable, and this one
+  // is reachable by any moderator. Axiom rather than `ctx.track`, because a new
+  // ClickHouse action outside the enum is dropped silently, and rather than
+  // `ModActivity`, whose unique key makes it a happened-once table.
+  logToAxiom({
+    name: 'reward-config',
+    type: 'info',
+    message: 'Reward config updated',
+    userId,
+    previous: JSON.stringify(previous ?? null),
+    value: JSON.stringify(value),
+  }).catch(() => null);
 
   invalidateRewardConfigCache();
   // Seed the fallback from what was just written. Clearing it and leaving it null

--- a/src/server/rewards/reward-config.ts
+++ b/src/server/rewards/reward-config.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
-import { dbRead } from '~/server/db/client';
+import { dbRead, dbWrite } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
+import { rewardConfigReadFailedCounter } from '~/server/prom/client';
+import { createTtlMemo } from '~/server/utils/ttl-memoize';
 
 export const REWARD_CONFIG_KEY = 'rewards:config';
 
@@ -11,9 +13,9 @@ export const MAX_AWARD_AMOUNT = 5_000;
 export const MAX_CAP = 100_000;
 
 /**
- * The single definition of an operator override. The admin mutation validates
- * writes with this same schema, so what can be stored and what will be honoured
- * cannot drift apart.
+ * The single definition of an operator override. `setRewardConfig` validates
+ * writes with this same schema, so a typo dies at write time rather than
+ * persisting as a row the read path quietly refuses.
  */
 export const rewardOverrideSchema = z.object({
   enabled: z.boolean().optional(),
@@ -50,24 +52,41 @@ export type ResolvedRewardConfig = {
   rejected: string[];
 };
 
-const CONFIG_TTL_MS = 60 * 1000;
+export const CONFIG_TTL_MS = 60 * 1000;
 
-type CacheEntry = { config: RewardConfig; expiresAt: number };
-
-// Cache the parsed config, not the resolved decision: `resolveRewardConfig`
-// still runs per call so a definition change or a differing default resolves
-// against the current values rather than a snapshot.
-let configCache: CacheEntry | null = null;
 const warnedMultiCap = new Set<string>();
 
-export function invalidateRewardConfigCache() {
-  configCache = null;
-  warnedMultiCap.clear();
-}
+// The last config we successfully read, kept as the fallback for a failed read.
+// Falling back to the COMPILED defaults instead would fail open: the default for
+// `enabled` is on, so a transient KeyValue blip would resume paying every reward
+// an operator had turned off, and `process` would then pay out what `apply`
+// wrote during the blip.
+let lastGoodConfig: RewardConfig | null = null;
 
 const warn = (message: string, data: MixedObject) => {
-  logToAxiom({ name: 'reward-config', type: 'warning', message, ...data }).catch();
+  logToAxiom({ name: 'reward-config', type: 'warning', message, ...data }).catch(() => null);
 };
+
+/**
+ * `enabled` is the one field where falling back to the compiled default is the
+ * wrong direction, because that default is ON. `"enabled": "false"` — what a
+ * text field in Retool produces — would leave the reward paying while the
+ * operator reads their edit back and believes it is off, with an Axiom warning
+ * as the only signal.
+ *
+ * So accept the spellings an operator actually types, and treat anything else
+ * PRESENT as off: a refused `enabled` stops the money and is loud. Absent still
+ * means on.
+ */
+function coerceEnabled(value: unknown): boolean | undefined {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'true') return true;
+    if (normalized === 'false') return false;
+  }
+  return undefined;
+}
 
 /**
  * Keep the fields that parse rather than dropping the whole reward. An operator
@@ -89,6 +108,14 @@ function usableOverride(type: string, value: unknown): RewardConfigEntry {
 
   for (const field of OVERRIDE_FIELDS) {
     if (!(field in record)) continue;
+
+    if (field === 'enabled') {
+      const coerced = coerceEnabled(record.enabled);
+      override.enabled = coerced ?? false;
+      if (coerced === undefined) rejected.push('enabled');
+      continue;
+    }
+
     const result = rewardOverrideSchema.shape[field].safeParse(record[field]);
     if (result.success) Object.assign(override, { [field]: result.data });
     else rejected.push(field);
@@ -116,22 +143,69 @@ async function loadConfig(): Promise<RewardConfig> {
   return config;
 }
 
-async function getRewardConfig(): Promise<RewardConfig> {
-  const now = Date.now();
-  if (configCache && configCache.expiresAt > now) return configCache.config;
+// Cache the parsed config, not the resolved decision: `resolveRewardConfig`
+// still runs per call so a definition change or a differing default resolves
+// against the current values rather than a snapshot. `createTtlMemo` caches only
+// a RESOLVED value, so a failed read is retried on the next call rather than
+// pinning a fallback for a whole TTL.
+// The clock is read per call rather than captured at module load, so a test can
+// advance time instead of waiting out a real minute.
+const configMemo = createTtlMemo(loadConfig, CONFIG_TTL_MS, () => Date.now());
 
+export function invalidateRewardConfigCache() {
+  configMemo.clear();
+  warnedMultiCap.clear();
+  lastGoodConfig = null;
+}
+
+async function getRewardConfig(): Promise<RewardConfig> {
   try {
-    const config = await loadConfig();
-    configCache = { config, expiresAt: now + CONFIG_TTL_MS };
+    const config = await configMemo();
+    lastGoodConfig = config;
     return config;
   } catch (error) {
-    // No negative caching: a transient KeyValue failure must not pin every
-    // reward to its compiled default for a full TTL.
-    warn('Reward config read failed, using compiled defaults', {
+    // Alertable, not just an Axiom line nobody watches: on this path every
+    // disabled reward is running on a stale answer.
+    rewardConfigReadFailedCounter?.inc?.();
+    warn('Reward config read failed, using the last good config', {
       error: (error as Error)?.message,
+      haveLastGood: !!lastGoodConfig,
     });
-    return {};
+    return lastGoodConfig ?? {};
   }
+}
+
+/**
+ * The stored row exactly as written, for an editor to render. Uncached and
+ * unsanitised on purpose: an operator fixing a refused field needs to see what
+ * is actually in the row, not what the read path salvaged from it.
+ */
+export async function getStoredRewardConfig(): Promise<z.infer<typeof rewardConfigSchema>> {
+  const row = await dbRead.keyValue.findUnique({ where: { key: REWARD_CONFIG_KEY } });
+  const parsed = rewardConfigSchema.safeParse(row?.value ?? {});
+  return parsed.success ? parsed.data : {};
+}
+
+/**
+ * Write-time validation is where an operator typo should die. The read path
+ * salvages what it can from a bad row because it must keep paying rewards; this
+ * refuses the whole write instead, so the row on disk is always one the read
+ * path will honour in full.
+ *
+ * Only invalidates the caller's own cache — other pods pick the change up within
+ * `CONFIG_TTL_MS`.
+ */
+export async function setRewardConfig(config: z.infer<typeof rewardConfigSchema>) {
+  const value = rewardConfigSchema.parse(config);
+
+  await dbWrite.keyValue.upsert({
+    where: { key: REWARD_CONFIG_KEY },
+    create: { key: REWARD_CONFIG_KEY, value },
+    update: { value },
+  });
+
+  invalidateRewardConfigCache();
+  return value;
 }
 
 /**

--- a/src/server/rewards/reward-config.ts
+++ b/src/server/rewards/reward-config.ts
@@ -61,6 +61,11 @@ const warnedMultiCap = new Set<string>();
 // `enabled` is on, so a transient KeyValue blip would resume paying every reward
 // an operator had turned off, and `process` would then pay out what `apply`
 // wrote during the blip.
+//
+// ⚠️ This narrows the fail-open window, it does not close it. A pod that has
+// never completed a successful read — a cold start during an outage — has no last
+// good config and still falls back to compiled defaults, i.e. everything enabled.
+// `reward_config_read_failed_total` is what makes that visible.
 let lastGoodConfig: RewardConfig | null = null;
 
 const warn = (message: string, data: MixedObject) => {
@@ -97,9 +102,14 @@ function usableOverride(type: string, value: unknown): RewardConfigEntry {
   const parsed = rewardOverrideSchema.safeParse(value);
   if (parsed.success) return { override: parsed.data, rejected: [] };
 
+  // A whole entry that is not an object disables the reward, for the same reason
+  // an unreadable `enabled` does — one level up. `{"dailyBoost": false}` is the
+  // shorthand an operator reaches for when they want a reward off, and so are
+  // `null` and `"disabled"`; resolving any of them to ON leaves the reward paying
+  // against an edit that reads, to whoever made it, like it worked.
   if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-    warn('Ignoring malformed reward override', { rewardType: type, stored: value });
-    return { override: {}, rejected: [...OVERRIDE_FIELDS] };
+    warn('Malformed reward override, disabling the reward', { rewardType: type, stored: value });
+    return { override: { enabled: false }, rejected: [...OVERRIDE_FIELDS] };
   }
 
   const record = value as MixedObject;
@@ -125,6 +135,12 @@ function usableOverride(type: string, value: unknown): RewardConfigEntry {
   return { override, rejected };
 }
 
+function buildConfig(rewards: Record<string, unknown>): RewardConfig {
+  const config: RewardConfig = {};
+  for (const [type, value] of Object.entries(rewards)) config[type] = usableOverride(type, value);
+  return config;
+}
+
 async function loadConfig(): Promise<RewardConfig> {
   const row = await dbRead.keyValue.findUnique({ where: { key: REWARD_CONFIG_KEY } });
   const envelope = z
@@ -136,11 +152,7 @@ async function loadConfig(): Promise<RewardConfig> {
     return {};
   }
 
-  const config: RewardConfig = {};
-  for (const [type, value] of Object.entries(envelope.data.rewards ?? {}))
-    config[type] = usableOverride(type, value);
-
-  return config;
+  return buildConfig(envelope.data.rewards ?? {});
 }
 
 // Cache the parsed config, not the resolved decision: `resolveRewardConfig`
@@ -175,15 +187,30 @@ async function getRewardConfig(): Promise<RewardConfig> {
   }
 }
 
+export type StoredRewardConfig = {
+  /** The row exactly as written. Not narrowed to the schema — see below. */
+  value: unknown;
+  /** True when the row would not survive `setRewardConfig`. */
+  malformed: boolean;
+};
+
 /**
- * The stored row exactly as written, for an editor to render. Uncached and
- * unsanitised on purpose: an operator fixing a refused field needs to see what
- * is actually in the row, not what the read path salvaged from it.
+ * The stored row exactly as written, for an editor to render. Uncached, so an
+ * operator fixing a refused field sees the row rather than a minute-old copy.
+ *
+ * 🔴 Returns the RAW value on a parse failure rather than an empty config.
+ * `setRewardConfig` has replace semantics, and the row this feature exists to
+ * fix — `enabled: "false"` from a Retool text field — is exactly the row that
+ * fails the parse. Rendering `{}` for it would show an editor a lossless-looking
+ * empty form whose first save wipes every other reward's override.
+ *
+ * ⚠️ Two moderators editing at once are last-write-wins; there is no version
+ * guard on the row.
  */
-export async function getStoredRewardConfig(): Promise<z.infer<typeof rewardConfigSchema>> {
+export async function getStoredRewardConfig(): Promise<StoredRewardConfig> {
   const row = await dbRead.keyValue.findUnique({ where: { key: REWARD_CONFIG_KEY } });
-  const parsed = rewardConfigSchema.safeParse(row?.value ?? {});
-  return parsed.success ? parsed.data : {};
+  const value = row?.value ?? {};
+  return { value, malformed: !rewardConfigSchema.safeParse(value).success };
 }
 
 /**
@@ -205,6 +232,10 @@ export async function setRewardConfig(config: z.infer<typeof rewardConfigSchema>
   });
 
   invalidateRewardConfigCache();
+  // Seed the fallback from what was just written. Clearing it and leaving it null
+  // means a failed read on this pod moments later falls back to compiled defaults
+  // — re-enabling the very reward this call just turned off.
+  lastGoodConfig = buildConfig(value.rewards ?? {});
   return value;
 }
 

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -3028,6 +3028,25 @@ describe('blocks.submitWorkflow — daily boost autoclaim', () => {
     expect(result.snapshot.workflowId).toBe('wf_real');
   });
 
+  // `getUserRewardDetails` returns null for a reward turned off through
+  // `rewards:config`. Without the null guard the submit 500s the first time
+  // anyone flips dailyBoost off.
+  it('submit still proceeds when the dailyBoost reward is disabled at runtime', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100 }));
+    happyVersionLookup();
+    happyUser();
+    mockGetUserBuzzAccounts.mockResolvedValue({ yellow: 5, blue: 0, green: 0 });
+    mockDailyBoostGetDetails.mockResolvedValue(null);
+    happySubmitSequence(25);
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+
+    expect(mockDailyBoostApply).not.toHaveBeenCalled();
+    expect(result.snapshot.autoClaim).toBeUndefined();
+    expect(result.snapshot.workflowId).toBe('wf_real');
+  });
+
   it('does NOT claim when the boost would NOT close the gap (hopeless)', async () => {
     mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 1000 }));
     happyVersionLookup();

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -750,6 +750,7 @@ beforeEach(() => {
   mockDailyBoostApply.mockResolvedValue(undefined);
   mockDailyBoostGetDetails.mockResolvedValue({
     awarded: 0,
+    awardedCount: 0,
     awardAmount: 25,
     accountType: 'blue',
     type: 'dailyBoost',
@@ -2974,10 +2975,11 @@ describe('blocks.submitWorkflow — daily boost autoclaim', () => {
     mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100 }));
     happyVersionLookup();
     happyUser();
-    // Balance short of cost but boost is already claimed (awarded > 0).
+    // Balance short of cost but the boost already fired today.
     mockGetUserBuzzAccounts.mockResolvedValue({ yellow: 10, blue: 0, green: 0 });
     mockDailyBoostGetDetails.mockResolvedValue({
       awarded: 25,
+      awardedCount: 1,
       awardAmount: 25,
       accountType: 'blue',
       type: 'dailyBoost',
@@ -3026,6 +3028,34 @@ describe('blocks.submitWorkflow — daily boost autoclaim', () => {
       accountType: 'blue',
     });
     expect(result.snapshot.workflowId).toBe('wf_real');
+  });
+
+  // A claim the cap trimmed to zero still consumed the day's dedup entry, so it
+  // pays nothing on every later attempt. Gating on the amount instead of the
+  // count would tell the iframe Buzz was claimed on every submit for the rest of
+  // the day.
+  it('does NOT claim again after a claim that the cap trimmed to zero', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100 }));
+    happyVersionLookup();
+    happyUser();
+    mockGetUserBuzzAccounts.mockResolvedValue({ yellow: 5, blue: 0, green: 0 });
+    mockDailyBoostGetDetails.mockResolvedValue({
+      awarded: 0,
+      awardedCount: 1,
+      awardAmount: 25,
+      accountType: 'blue',
+      type: 'dailyBoost',
+      description: 'd',
+      cap: 25,
+      onDemand: true,
+    });
+    happySubmitSequence(25);
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+
+    expect(mockDailyBoostApply).not.toHaveBeenCalled();
+    expect(result.snapshot.autoClaim).toBeUndefined();
   });
 
   // `getUserRewardDetails` returns null for a reward turned off through

--- a/src/server/routers/__tests__/reward-config.router.test.ts
+++ b/src/server/routers/__tests__/reward-config.router.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TRPCError } from '@trpc/server';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
+import type * as RewardConfig from '~/server/rewards/reward-config';
 
 /**
  * The reward config decides what every Buzz reward pays, so `moderatorProcedure`
@@ -24,7 +25,7 @@ const { mockGetStored, mockSetConfig, mockDescribeConfig } = vi.hoisted(() => ({
 }));
 
 vi.mock('~/server/rewards/reward-config', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('~/server/rewards/reward-config')>()),
+  ...(await importOriginal<typeof RewardConfig>()),
   getStoredRewardConfig: mockGetStored,
   setRewardConfig: mockSetConfig,
 }));

--- a/src/server/routers/__tests__/reward-config.router.test.ts
+++ b/src/server/routers/__tests__/reward-config.router.test.ts
@@ -121,8 +121,9 @@ describe('rewardConfig.set', () => {
 
     await caller.set({ rewards: { testReward: { enabled: false, awardAmount: 4 } } });
 
-    expect(mockSetConfig).toHaveBeenCalledWith({
-      rewards: { testReward: { enabled: false, awardAmount: 4 } },
-    });
+    expect(mockSetConfig).toHaveBeenCalledWith(
+      { rewards: { testReward: { enabled: false, awardAmount: 4 } } },
+      1
+    );
   });
 });

--- a/src/server/routers/__tests__/reward-config.router.test.ts
+++ b/src/server/routers/__tests__/reward-config.router.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TRPCError } from '@trpc/server';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+/**
+ * The reward config decides what every Buzz reward pays, so `moderatorProcedure`
+ * on both procedures is the whole access boundary. Drives the REAL router through
+ * `createCaller` so the middleware wiring decides, not an assertion about how the
+ * procedures were declared.
+ */
+
+const { mockGetStored, mockSetConfig, mockDescribeConfig } = vi.hoisted(() => ({
+  mockGetStored: vi.fn(async () => ({ rewards: {} })),
+  mockSetConfig: vi.fn(async (config: unknown) => config),
+  mockDescribeConfig: vi.fn(async () => ({
+    type: 'testReward',
+    visible: true,
+    onDemand: true,
+    capOverridable: true,
+    defaults: { awardAmount: 10, cap: 30 },
+    effective: { enabled: true, awardAmount: 10, cap: 30 },
+    rejected: [] as string[],
+  })),
+}));
+
+vi.mock('~/server/rewards/reward-config', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('~/server/rewards/reward-config')>()),
+  getStoredRewardConfig: mockGetStored,
+  setRewardConfig: mockSetConfig,
+}));
+
+vi.mock('~/server/rewards', () => ({
+  testReward: { describeConfig: mockDescribeConfig },
+}));
+
+import { rewardConfigRouter } from '~/server/routers/reward-config.router';
+
+function fakeCtx(user: unknown) {
+  return {
+    acceptableOrigin: true,
+    user,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: {} as never,
+    track: undefined,
+  };
+}
+
+const mod = { id: 1, isModerator: true, tier: 'free', username: 'mod', onboarding: 0x1f };
+const user = { id: 2, isModerator: false, tier: 'free', username: 'user', onboarding: 0x1f };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('rewardConfig router authz', () => {
+  const cases = [
+    { name: 'get', call: (c: ReturnType<typeof rewardConfigRouter.createCaller>) => c.get() },
+    {
+      name: 'set',
+      call: (c: ReturnType<typeof rewardConfigRouter.createCaller>) =>
+        c.set({ rewards: { testReward: { enabled: false } } }),
+    },
+  ];
+
+  for (const { name, call } of cases) {
+    it(`refuses a signed-in non-moderator on ${name}`, async () => {
+      const caller = rewardConfigRouter.createCaller(fakeCtx(user) as never);
+
+      await expect(call(caller)).rejects.toBeInstanceOf(TRPCError);
+      expect(mockSetConfig).not.toHaveBeenCalled();
+      expect(mockGetStored).not.toHaveBeenCalled();
+    });
+
+    it(`refuses an anonymous caller on ${name}`, async () => {
+      const caller = rewardConfigRouter.createCaller(fakeCtx(undefined) as never);
+
+      await expect(call(caller)).rejects.toBeInstanceOf(TRPCError);
+      expect(mockSetConfig).not.toHaveBeenCalled();
+      expect(mockGetStored).not.toHaveBeenCalled();
+    });
+
+    it(`admits a moderator on ${name}`, async () => {
+      const caller = rewardConfigRouter.createCaller(fakeCtx(mod) as never);
+
+      await expect(call(caller)).resolves.toBeDefined();
+    });
+  }
+});
+
+describe('rewardConfig.get', () => {
+  it('returns the stored row beside what the grant path resolved', async () => {
+    const caller = rewardConfigRouter.createCaller(fakeCtx(mod) as never);
+
+    const result = await caller.get();
+
+    expect(result.stored).toEqual({ rewards: {} });
+    expect(result.rewards).toHaveLength(1);
+    expect(result.rewards[0]).toMatchObject({ type: 'testReward', rejected: [] });
+  });
+});
+
+describe('rewardConfig.set', () => {
+  it('rejects an out-of-bounds override before it reaches the service', async () => {
+    const caller = rewardConfigRouter.createCaller(fakeCtx(mod) as never);
+
+    await expect(
+      caller.set({ rewards: { testReward: { awardAmount: 999_999 } } })
+    ).rejects.toBeInstanceOf(TRPCError);
+    expect(mockSetConfig).not.toHaveBeenCalled();
+  });
+
+  // A base-procedure middleware adds `browsingLevel` to every input, and it must
+  // not end up in the stored row: `set` has replace semantics, so junk written
+  // now is junk an editor reads back and saves again later.
+  it('passes the row through without the middleware-injected fields', async () => {
+    const caller = rewardConfigRouter.createCaller(fakeCtx(mod) as never);
+
+    await caller.set({ rewards: { testReward: { enabled: false, awardAmount: 4 } } });
+
+    expect(mockSetConfig).toHaveBeenCalledWith({
+      rewards: { testReward: { enabled: false, awardAmount: 4 } },
+    });
+  });
+});

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -7997,9 +7997,9 @@ async function maybeAutoClaimDailyBoost({
     return undefined;
   }
 
-  // Already claimed today, or the reward has no payout (e.g. user is
-  // rewardsIneligible — multiplier zeroed the amount).
-  if (boostDetails.awarded > 0 || boostDetails.awardAmount <= 0) return undefined;
+  // Disabled at runtime, already claimed today, or the reward has no payout
+  // (e.g. user is rewardsIneligible — multiplier zeroed the amount).
+  if (!boostDetails || boostDetails.awarded > 0 || boostDetails.awardAmount <= 0) return undefined;
 
   // Balance already covers the cost — boost would just sit unused today.
   if (balanceSum >= cost) return undefined;

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -7999,7 +7999,13 @@ async function maybeAutoClaimDailyBoost({
 
   // Disabled at runtime, already claimed today, or the reward has no payout
   // (e.g. user is rewardsIneligible — multiplier zeroed the amount).
-  if (!boostDetails || boostDetails.awarded > 0 || boostDetails.awardAmount <= 0) return undefined;
+  //
+  // Gated on the claim COUNT, not on `awarded > 0`: a claim the cap trimmed to
+  // zero still consumed the day's dedup entry, so an amount-based check would
+  // pass, `apply` would no-op against the dedup guard, and the iframe would be
+  // told Buzz was claimed on every submit for the rest of the day.
+  if (!boostDetails || boostDetails.awardedCount > 0 || boostDetails.awardAmount <= 0)
+    return undefined;
 
   // Balance already covers the cost — boost would just sit unused today.
   if (balanceSum >= cost) return undefined;

--- a/src/server/routers/index.ts
+++ b/src/server/routers/index.ts
@@ -146,6 +146,7 @@ export const appRouter = router({
   rewardsBonusEvent: lazy(() =>
     import('./rewards-bonus-event.router').then((m) => m.rewardsBonusEventRouter)
   ),
+  rewardConfig: lazy(() => import('./reward-config.router').then((m) => m.rewardConfigRouter)),
   oauthClient: lazy(() =>
     import('~/server/routers/oauth-client.router').then((m) => m.oauthClientRouter)
   ),

--- a/src/server/routers/reward-config.router.ts
+++ b/src/server/routers/reward-config.router.ts
@@ -1,0 +1,19 @@
+import * as rewardImports from '~/server/rewards';
+import {
+  getStoredRewardConfig,
+  rewardConfigSchema,
+  setRewardConfig,
+} from '~/server/rewards/reward-config';
+import { moderatorProcedure, router } from '~/server/trpc';
+
+export const rewardConfigRouter = router({
+  // `stored` is the row as written, for the editor's inputs; `rewards` is what
+  // the grant path actually resolved, including any field it refused.
+  get: moderatorProcedure.query(async () => ({
+    stored: await getStoredRewardConfig(),
+    rewards: (await Promise.all(Object.values(rewardImports).map((x) => x.describeConfig()))).sort(
+      (a, b) => a.type.localeCompare(b.type)
+    ),
+  })),
+  set: moderatorProcedure.input(rewardConfigSchema).mutation(({ input }) => setRewardConfig(input)),
+});

--- a/src/server/routers/reward-config.router.ts
+++ b/src/server/routers/reward-config.router.ts
@@ -16,5 +16,10 @@ export const rewardConfigRouter = router({
       (a, b) => a.type.localeCompare(b.type)
     ),
   })),
-  set: moderatorProcedure.input(rewardConfigSchema).mutation(({ input }) => setRewardConfig(input)),
+  // The input schema is what keeps the middleware's `browsingLevel` out of a row
+  // `set` replaces wholesale — zod strips unknown keys, and the router test
+  // asserts the service is called with the row alone.
+  set: moderatorProcedure
+    .input(rewardConfigSchema)
+    .mutation(({ input, ctx }) => setRewardConfig(input, ctx.user.id)),
 });

--- a/src/server/routers/reward-config.router.ts
+++ b/src/server/routers/reward-config.router.ts
@@ -7,8 +7,9 @@ import {
 import { moderatorProcedure, router } from '~/server/trpc';
 
 export const rewardConfigRouter = router({
-  // `stored` is the row as written, for the editor's inputs; `rewards` is what
-  // the grant path actually resolved, including any field it refused.
+  // `stored` is the row as written — raw, and flagged when it would not survive
+  // `set`, so an editor can refuse to save over a row it cannot faithfully show.
+  // `rewards` is what the grant path actually resolved, including refused fields.
   get: moderatorProcedure.query(async () => ({
     stored: await getStoredRewardConfig(),
     rewards: (await Promise.all(Object.values(rewardImports).map((x) => x.describeConfig()))).sort(


### PR DESCRIPTION
Buzz rewards read their award amount and cap from the compiled definition, so turning one off, or changing what it pays, needs a deploy. This adds a `rewards:config` `KeyValue` row that overrides `enabled`, `awardAmount` and `cap` per reward type at runtime.

**No reward is disabled or changed here.** The row ships absent, so behaviour is identical to today until someone writes it. #4012 deprecates two rewards and rebases onto this.

It also fixes **two pre-existing money bugs** in the on-demand grant path. They were unreachable only because every compiled award divides its cap and nobody could change one without a deploy — this PR hands an operator a control that reaches both. See [Two pre-existing bugs](#two-pre-existing-bugs-this-control-would-have-reached).

---

## Where the gate lives, and why that is the argument for this shape

It mirrors `placement:config` (`src/server/services/placement.service.ts`) — same `KeyValue` mechanism, same "compiled values are the defaults, the row only moves them" contract.

The check is inside `createBuzzEvent`, so it covers every call site regardless of how a reward was imported. That matters because the alternative way to deprecate a reward — removing its export from `src/server/rewards/index.ts` — leaves a reward that is imported direct-from-file still paying out.

`apply()` is **not** the only door, so the claim is deliberately narrower than that. There are three:

| door | what it does | what a disabled reward does |
|---|---|---|
| `apply()` | inline grant path | returns immediately |
| `process()` | the `rewards-process` cron, which pays the `pending` rows `apply` wrote | marks the backlog `unqualified` |
| `getUserRewardDetails()` | the user-facing rewards list | returns `null`, so the reward disappears |

All three are closures returned by the single `createBuzzEvent` factory, and nothing in the repo constructs a `BuzzEvent` any other way. That is the property the coverage rests on — one a reviewer can check, rather than an enumeration of call sites that goes stale.

### `apply()` short-circuits before `getKey`

First statement, not merely somewhere in the function. `orchestrator.router.ts` walks every feedback patch on a generation and calls `generatorFeedbackReward.apply` per patch. Gated late, a disabled reward would still run `getKey`, then `getMultipliersForUser` (Redis **and** DB), then the Redis Lua dedup script, then a ClickHouse insert — per patch, inside a live generation mutation, forever, to pay nothing. The user-visible behaviour is identical either way, which is why it is worth pinning: a test asserts the placement, not just the outcome, and moving the check below `getKey` fails it.

### What a flip does to in-flight rows

The question an operator will have five minutes after their first flip. For a **processable** reward, `apply` only writes a `pending` ClickHouse row; the cron is what pays it. So gating `apply` alone still pays out everything already in the pipe. Those rows are set to `status: 'unqualified'`, `awardAmount: 0` and written back — the terminal state `process` already uses for "seen, earns nothing".

Terminal rather than skipped, because the job scans `time >= lastUpdate` and never looks back: a skipped row would strand `pending` forever behind an advancing cursor.

This lives in the reader (`process`) rather than in a sweep hung off the config write, and not merely because it is simpler. The config is a `KeyValue` row, and rows like that get edited from Retool or psql, where **no application code runs at all** — a setter-side sweep would simply not happen, and the failure would be silent and indistinguishable from success, since the reward *does* stop paying while the backlog quietly strands. A per-run check also cannot lose the race against rows written between the flip and the next run.

**On-demand** rewards (`firstDailyFollow`, `generatorFeedback`, `dailyBoost`, ...) write `awarded`/`capped` inline and never write a `pending` row, so there is nothing in flight for them. This is also why the sweep's tests use processable rewards — a test built on an on-demand reward enters the sweep zero times while looking like it covers it.

---

## Two pre-existing bugs this control would have reached

### Over-cap payment when the award does not divide the cap

`apply` took `toAward` from the Lua (`min(award, remaining)`) and used only its **sign**, then paid the full `awardAmount * multiplier`. A partial-cap grant paid the whole award: award 3 against cap 100 paid 102 on the day, and an award raised above its cap paid the entire award on the first grant — `refereeCreated` at 5000 against a compiled cap of 500 would have paid 10x the cap.

`processOnDemand` now returns `{ toAward, effectiveAward }`, and a trimmed grant records `toAward` with `multiplier: 1`. `toAward` is already multiplied, so the untrimmed path keeps the base amount plus multiplier for ClickHouse consistency and only the trimmed grant is rewritten.

Fixed rather than refused: bounding overrides to caps they divide covers only the operator-reachable half and leaves the bug live for the compiled values.

### Lowering `awardAmount` mid-day increased that day's payout

The Lua derived earnings-so-far as `entry count * the CURRENT award`, with no record of what each entry actually paid. At award 2 and cap 100, a user caps out at 50 entries; an operator lowers the award to 1 to spend *less*, those same 50 entries re-price to 50 earned, 50 becomes available again, and the day totals 150. `getUserRewardDetails` recomputed the same way, so the UI agreed with the wrong number instead of exposing it.

Each dedup entry now stores **what it paid** (`a:<amount>`), the Lua sums those, and `getUserRewardDetails` reads the same values.

Safe to repurpose because the entry value was a timestamp **nothing reads** — every consumer of `REDIS_KEYS.BUZZ_EVENTS` was checked, and the only reader of these fields counted keys. `BuzzEventsCache` uses a different field format (`userId:deviceId:type`) and does not collide. Entries written before this deploy hold timestamps and fall back to the old count-based reading; `rewardsDailyReset` clears the hash at 00:00 UTC, so the mixed state lasts under a day and needs no migration.

This also makes the cap arithmetic exact rather than approximately right, since the cap is now enforced against what was actually paid.

⚠️ **Deploy timing:** pre-deploy entries keep the old count-based reading until `rewardsDailyReset` clears the hash at 00:00 UTC, so this bug stays live for those entries for up to 24 hours depending on the deploy window.

⚠️ **One meaning changed downstream.** `awarded` used to be a proxy for "did this reward fire today", because a capped grant still contributed a full award to the count-based total. Under the sum-based reading a grant trimmed to zero contributes 0. The daily-boost autoclaim in `blocks.router.ts` gated on `awarded > 0`, which would have made a zero-trimmed claim read as unclaimed forever — telling the iframe 25 Blue Buzz was claimed on every submit for the rest of the day while `apply` no-opped against the dedup guard. `getUserRewardDetails` now also returns `awardedCount`, and the autoclaim gates on that.

⚠️ **Analytics note:** on-demand ClickHouse rows now carry two shapes for `awardAmount` — base amount with the real multiplier when the grant was untrimmed, post-multiplier amount with `multiplier: 1` when it was trimmed. `awardAmount * multiplier` is correct in both. Nothing reads that column for cap math, but a dashboard summing `awardAmount` alone across on-demand types is summing mixed units.

### Bonus, found while fixing the first

An **uncapped** on-demand reward passed `Infinity` to the Lua, and `tonumber('Infinity')` is nil there — the script would have thrown into the triggering user mutation. Now a finite ceiling. No live reward is uncapped, so it was latent, but it is one `cap`-shaped edit away.

---

## Config shape

```json
{
  "rewards": {
    "firstDailyFollow": { "enabled": false },
    "goodContent": { "awardAmount": 1, "cap": 50 }
  }
}
```

Keyed by reward `type`, as a record — no hardcoded list of reward types anywhere, so a reward added tomorrow is controllable the moment it exists. Unknown keys are ignored rather than failing the row, so an operator can stage one ahead of a deploy.

**Cap is not one thing in this codebase.** On-demand rewards have `cap?: number`; processable ones have `caps: [{ keyParts, interval, amount }]`. Every processable reward has exactly one entry today, so `cap` maps to `caps[0].amount`. A reward with **two or more** entries refuses the cap override and logs, because one number cannot say whether it means the daily cap or the monthly one. That every reward has one entry today is precisely why the refusal has to exist now — the second entry someone adds is the moment a silent `caps[0]` starts being wrong. On `imagePostedToModel`'s shape (a monthly cap plus a per-image one), an operator setting the monthly number would otherwise raise the per-image cap by the same amount.

The membership multiplier is unchanged and still applies **after** the override.

## Cache: 60s, in-memory

`createTtlMemo` (`src/server/utils/ttl-memoize.ts`), the existing helper for this — **cache the config, resolve the decision fresh on every call**. Not the `placement` shape: `getPlacementConfig` does a `findUnique` per call, accepted there as pre-existing but not acceptable here, where `apply` runs on follows, reactions, posts and per-feedback-patch.

**Staleness window:** flipping a reward off takes effect within **60 seconds per pod**, and different pods cross over at different moments inside that window — so for up to a minute some requests grant and some do not. An operator watching a dashboard should expect a partial minute, not read it as a bug. There is no cross-pod invalidation; `invalidateRewardConfigCache()` clears the calling process only.

Redis-backed would make invalidation instant and shared, at the cost of a network hop on the hottest path in the reward system to save one `KeyValue` read per pod per minute. The point of the mechanism is to *time* a change, not to make one instantly.

**A failed read falls back to the last good config, not to the compiled defaults.** Falling back to compiled fails *open*: the compiled default for `enabled` is on, so a transient `KeyValue` blip would resume paying every reward an operator had turned off, and `process` would then pay out what `apply` wrote during the blip. The failure increments `reward_config_read_failed_total` so it is alertable rather than an Axiom line nobody watches. Still no negative caching — `createTtlMemo` caches only resolved values, so the next call retries. `setRewardConfig` seeds the last-good config from what it just wrote, so a failed read moments after a flip cannot re-enable the reward that flip disabled.

⚠️ **This narrows the fail-open window, it does not close it.** A pod that has never completed a successful read — a cold start during an outage — has no last-good config and falls back to compiled defaults, i.e. everything enabled. The counter is what makes that visible.

## Validation, and a deliberate asymmetry

`awardAmount` and `cap` must be integers in `[0, 5000]` and `[0, 100000]`. Live awards run 1–500 and caps 25–1500, so that refuses the typo that adds a zero to the largest of them while leaving room for a deliberate change. A 100x change *within* the bounds is intentional-only — a multiplicative "no more than Nx the default" rule would block the legitimate large change this mechanism exists for.

**The read path salvages; the write path refuses.** That asymmetry is intentional:

- **Read** (`resolveRewardConfig`) keeps the fields that parse and falls back per field, never to zero and never by throwing, because it must keep paying rewards through a bad row. An operator who turns a reward off and fat-fingers the cap in the same edit still gets the reward turned off.
- **Write** (`setRewardConfig`) validates the whole payload with the same `rewardConfigSchema` and refuses the entire write. A row that reaches disk is therefore always one the read path honours in full, and a typo dies at write time instead of persisting as something the read path quietly declines.

`enabled` is the one field where falling back to the compiled default is the **wrong direction**, because that default is on. `"enabled": "false"` — what a text field in Retool produces — would leave the reward paying while the operator reads their edit back and believes it is off. So the read path accepts the spellings operators actually type (`"true"`/`"false"`, any case, trimmed) and treats anything else *present* as **off**: a refused `enabled` stops the money and is loud. Absent still means on.

A wholly unreadable **entry** — `{"firstDailyFollow": false}`, `null`, `"disabled"` — also resolves to **off**, for the same reason one level up. `{"dailyBoost": false}` is the shorthand an operator reaches for when they want a reward off; resolving it to on leaves the reward paying against an edit that reads, to whoever made it, like it worked. An empty object `{}` is the one shape that stays on, because it genuinely says nothing either way.

*(I originally argued the opposite for the whole-entry case — that it carries no evidence of which field was meant. The counter-argument that changed it: `false` as an entry value is not evidence-free, it is the most likely spelling of an intentional disable, and the failure directions are not symmetric. Disabling on garbage is loud and reversible; staying on is silent and costs money.)*

Both schemas are `.strict()` where it counts. A non-strict object **strips** an unknown key, so `{"enable": false}` or `{"Enabled": false}` would parse clean to `{}`, resolve to enabled, reject nothing and log nothing — the operator's edit reads as applied while the reward keeps paying. An entry made **entirely** of unrecognised keys now disables; one that also sets a real field keeps it and only reports the stray key, so `{"cap": 8, "note": "launch"}` does not take a reward down. The stored-row schema is strict at the envelope too, so a row written without the `rewards` wrapper is a loud parse failure rather than a silently empty config. (The tRPC input schema is deliberately *not* envelope-strict — a base-procedure middleware injects `browsingLevel`, which zod strips.)

### Editor round-trip

`getStoredRewardConfig` returns the **raw** row plus a `malformed` flag, not a schema-narrowed copy. `setRewardConfig` has replace semantics, and the row this feature exists to fix — `enabled: "false"` from a Retool text field — is exactly the row that fails the parse. Returning `{}` for it would show an editor a lossless-looking empty form whose first save wipes every other reward's override.

⚠️ Two moderators editing at once are last-write-wins; there is no version guard on the row. `malformed` is the ingredient for an editor to refuse a save, not the control — nothing enforces it yet. **Recommended shape for the follow-up: put the guard on the server** (`set` refuses when the stored row is malformed unless explicitly forced) rather than on a client that does not exist yet.

⚠️ `getStoredRewardConfig` returns the row **unparsed**, so a hand-written row can carry a `__proto__` own key through to a caller. Harmless to render; not harmless to spread or deep-merge. (Both parse paths drop it rather than assigning it.) Noted in the function's docs for whoever builds the editor.

### Audit

`set` writes an Axiom record with the moderator's user id, the row written and the row it replaced. Axiom rather than `ctx.track`, because a ClickHouse action outside the enum is dropped silently; and rather than `ModActivity`, whose unique key on `(activity, entityType, entityId)` makes it a happened-once table, not an append-only log.

PR 1's placement equivalent had a fallback bug of exactly this shape (a malformed override fell back to the wrong table, producing caps 100x too large), so the fallbacks are asserted against the defaults object itself rather than repeated literals.

## `visible` and `enabled`

`visible` stays compile-time and means "the kind of reward we advertise at all". `enabled` is runtime. They compose as AND, inside `getUserRewardDetails` rather than in the handler — so a second listing site added later cannot silently miss the suppression. `userRewardDetailsHandler` filters the nulls; the existing `visible` filter still runs first, so an unadvertised reward never pays the config read.

Without this, a disabled reward would stay advertised to users with an amount and a cap that will never pay — a half-deprecation that is worse than the internal kind because it is user-facing.

`getUserRewardDetails` becoming nullable surfaced one other call site through the compiler: the daily-boost autoclaim in `blocks.router.ts`. A disabled `dailyBoost` now correctly means no autoclaim rather than a 500 on block submit.

## Legibility

This trades a compiler-checkable fact (the code is deleted) for a reader-checkable one, which is the right trade for what was asked, but it means an operator needs one place to answer "which rewards are on, and at what amounts?".

`GET /api/testing/rewards-config?token=$WEBHOOK_TOKEN` (read-only, `WebhookEndpoint`-guarded) returns one row per reward: compiled default beside effective value, whether the cap is overridable, and **which override fields were refused** — the thing a raw `KeyValue` read cannot show, since it shows what the operator wrote rather than what the system did with it. It resolves through the same `resolveRewardConfig` as the grant path, so it cannot drift from what actually pays.

`rewardConfig.get` (moderator tRPC) returns the same view plus the raw stored row and its `malformed` flag, for an editor's inputs.

## Admin UI — not here, deliberately

A follow-up against this PR. The shape: one row per reward in the moderator section, an on/off switch and two number inputs, the compiled default shown greyed behind each input so an operator can always see what they are departing from, writing through `rewardConfig.set`, and refusing to save while `stored.malformed` is true so an editor cannot overwrite a row it could not faithfully render. The mutation and `rewardOverrideSchema` are already in place and both are tested.

---

## Testing

74 new tests, across the config resolver, the reward factory, the moderator router (authz matrix through `createCaller`, both procedures, non-moderator and anonymous), the block autoclaim and the claim-button hook.

Every guard was mutation-tested — broken, run, checked that the failure is fast and names the problem, restored. **Latest pass: 16 mutants, 16 caught, 0 survivors.** It covers every property of the Lua script (including the block-comment attack applied to three separate blocks), the schema strictness, the whole-entry disable, unknown-key handling in both directions, the raw-row editor read, write-side validation, the audit record and its actor, the last-good seeding, the autoclaim count gate, the claim button, and the moderator gate on each procedure.

Two of that pass's first-run survivors were **vacuous tests of mine, not missing fixes** — worth stating because both are the same shape:

- the cap-lowered-below-paid test asserted a total that `Math.min` clamps to the cap either way, so the right and wrong answers were indistinguishable. It now raises the cap again before reading the day back, and pins the exact −1 case where a negative collides with the script's already-awarded sentinel.
- the missing-`rewards`-wrapper test asserted values a non-strict envelope produces identically. The **warning** is the entire difference strictness makes, so that is what it asserts now.

The earlier pass on the pre-review code, also all caught:

| mutation | how it fails |
|---|---|
| pay the full award on a cap-trimmed grant | `expected [3,3,3,3] to deeply equal [3,3,3,1]`; `expected [5000] to deeply equal [500]` |
| apply the multiplier twice to a trimmed grant | `expected [6,6,6,4] to deeply equal [6,6,6,2]` |
| derive the day from entry count × current award | script no longer contains the summing line |
| stop recording what each entry paid | script no longer contains the `a:` write |
| report the UI day total as count × award | `expected 5 to be 10` |
| an unreadable `enabled` leaves the reward on | `expected true to be false` |
| stop accepting the string spellings of `enabled` | rejected list non-empty for `"false"` |
| fail back to compiled defaults, not last-known | disabled reward came back enabled |
| treat every cap table as overridable | `expected true to be false` |
| drop the autoclaim null guard | submit threw |
| uncapped reward passes `Infinity` to Lua | `expected false to be true` |

Earlier rounds also pinned the gates themselves: removing the `apply` gate, **moving** it below `getKey`, removing the `process` sweep (on both a local fixture and the real `goodContentReward`), sweeping without writing rows back, `getUserRewardDetails` no longer returning null, dropping either bound, falling back to zero, and caching a failed read — all caught.

### 🔴 What the tests do NOT cover: the Lua is never executed

Nothing in this repo can run the on-demand Lua script — there is no Lua interpreter and no Redis in the unit suite, and `base.reward.failsoft.test.ts` stubs `redis.eval` the same way. The cap tests therefore drive a **JS model** of the script.

The model is genuinely useful — it is what catches the over-cap bug, which lives in `apply`'s use of the return value rather than in the script — but **it cannot see mutations to the script itself**: an early mutation pass reverted the Lua and every test stayed green, because the model went on producing correct numbers from reverted code.

**And the first attempt to close that gap was itself incomplete, which is the honest measure of what change-detectors buy you.** After a self-run pass reported 11 of 11 mutants caught, a reviewer executing their own mutants found **two survivors** — both in lines this work did not touch:

- deleting `- awarded` from `math.max(tonumber(ARGV[4]) - awarded, 0)` **abolished the daily cap entirely**, and passed, because the only assertion anchoring that line checked for the literal `tonumber(ARGV[4])`, which survives the deletion of the subtraction it was meant to protect;
- deleting the dedup block removed the double-award guard, and passed, because the JS model implements dedup itself and kept returning `-1` for code that no longer did.

The generalisable failure: **you write change-detectors while thinking about your own diff**, so the properties most in need of anchoring are the inherited ones, because nothing in your attention points at them.

The script is therefore now pinned **line for line** against an expected body, in addition to per-property assertions anchored on the operators rather than on identifier names. The whole-body pin fails on any edit including a reformat — the safe direction, and updating it forces re-deriving the model beside it. It is what caught one mutant (`HGET` → `nil`) on its own, and it is the only thing that catches a long STRING swallowing a block or a pure reindent.

**And that pin had a hole too, found the same way — twice.** Lua block comments open `--[[` and close `--]]`, and **both delimiters start with `--`**, which the pin's normaliser dropped as noise: wrapping the dedup block in one deleted its own delimiters from the normalised array and left the enclosed body matching perfectly. Double-award guard dead in Redis, every assertion green, and it reads as a comment in review. Stripping `--[[ … --]]` then let **`--[==[ … --]==]`** through, because Lua's long-bracket form takes any number of `=` signs.

**Four rounds, and every time the hole was in the guard's own normalisation step rather than in the property it checked:**

| round | the guard | what ignoring the wrong thing allowed |
|---|---|---|
| 1 | change-detectors for the lines this work changed | deleting `- awarded` and the dedup block, in lines it did not |
| 2 | `toContain('tonumber(ARGV[4])')` | deleting the arithmetic around the name it anchored on |
| 3 | `startsWith('--')` as "skip comments" | commenting out any block, invisibly |
| 4 | stripping `--[[ … --]]` | the same thing spelled `--[==[` |

Two distinct failures compound here, and the second is the more expensive because **each fix feels like progress**: attention follows the diff, so guards get written for what you changed — and then *each fix closes the spelling it was shown, not the class*.

**So the pin now normalises nothing.** "What can neutralise a line" is not a closed set, so every line of the script — blanks, comments, indentation — is compared verbatim, split per line only so a failure is a one-line diff. Verified against nine ways to neutralise a line: four nesting depths of block comment, a closer without the leading `--`, a plain line comment, a trailing opener appended to a live line, a long **string** swallowing the block, and a pure reindent. The last two are unreachable by any regex over comment syntax, which is the point.

**⚠️ What this pin is worth.** The Lua script is still **not executed by anything in CI**. The verbatim pin makes a silent revert impossible and forces the model beside it to be re-derived alongside any edit — but **it verifies the text, not the behaviour.** It exists only because nothing in this repo can execute Lua. **If that script grows much past its current 20 lines, or another way to neutralise it turns up, the answer is a Lua interpreter in devDependencies or an integration test against a real Redis — not a longer literal and not a sixth regex.** Written here so the next reader does not over-trust it.

**Follow-up (not in this PR):** executing the real script in tests needs a Lua interpreter dev-dependency. That is a deliberate decision with a maintenance tail and should be made on its own merits, not smuggled in at the end of a fix round. The evidence for whoever picks it up is above: change-detectors caught everything the second time, but only after a reviewer's execution found what the first set missed.

### Three harnesses that reported success while scoring the wrong signal

Read together, because they are one failure in three costumes. Each made a red thing look green, and each was caught by noticing a **shape** rather than a value — uniform 2-second timings, a suspiciously small file count, a command that printed nothing at all.

| harness | what it scored | what was actually true |
|---|---|---|
| mutation runner | non-zero exit = "mutant caught" | 14 crashes read as 14 catches; not one test had run |
| `rtk` summary line | `PASS (96) FAIL (0)` | the file collected **zero** tests |
| `eslint … \| grep -v … \| head` | empty output = clean | eslint was exiting **1**; `head` closes the pipe regardless |

The repo already has the rule for the third — *never filter a verification command's output* — written for typecheck. It is the same rule. `echo $?` was one character of shell away, and it is now how the local lint check is run.

### Methodology notes, because several passes of this were wrong

**The reporter flag.** `--reporter=basic` does not exist in vitest 4, so every run crashed before executing a single test. The harness now asserts a clean baseline through the identical command and requires a parsed `Tests N failed` line, so a run that executes nothing scores `NO TESTS RAN` rather than passing.

**Half an instruction is the same failure as a change-detector.** The CI lint gate is stricter on **added** files than the local script — it fails them on error-severity findings, where `prettier:check` only covers what git reports dirty. What failed was an inline `typeof import('...')` in a `vi.mock` factory, tripping `consistent-type-imports`. `CLAUDE.md` prescribes `importOriginal` **and**, in the same paragraph, says the inline form trips that rule and to use a top-level `import type * as`. I followed the half that solved the problem in front of me. Same mechanism as writing change-detectors for the lines you changed: attention lands on the part that answers the current question.

**The restore step destroyed uncommitted work.** The harness restored each mutated file with `git checkout --`. On the review-fix round `base.reward.ts` held **uncommitted** fixes, so the first mutant's restore silently reverted all of them — and the harness reported a clean CAUGHT and carried on. It surfaced only because the next mutation's anchor was missing. Earlier rounds were safe because the work happened to be committed first, which was luck rather than design. The harness now snapshots file contents and restores from the snapshot. Worth knowing for anyone else running a mutation harness over files they have not committed.

### Suite

`pnpm run lint` clean on changed files (remaining warnings pre-existing), `pnpm run test:lint-rules` 220 passed. `pnpm run test:unit:run` **17318 passed / 23 skipped across 1109 files** — with `blocks.router.workflow.test.ts` collecting its 350 tests, confirming the worktree's submodule is initialised and the run is not silently empty.

Typecheck: `node scripts/typecheck.mjs --incremental false` is clean. ⚠️ A plain `pnpm run typecheck` on this branch can report phantom `TS18047 'boostDetails' is possibly null` errors whose column offsets match the *pre-guard* text — a stale `tsconfig.tsbuildinfo` replaying old diagnostics. Not real; do not chase them.

## Not touched

`src/server/rewards/index.ts` — two agents are adding reward exports to it on `feat/free-placements` and a third has a deprecation PR queued against it. No per-reward-definition file changed either; the integration is entirely in `base.reward.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1jg4QCdjPABErRJxDrusg
