### PR TITLE
docs(moderation): say what break-inside-avoid prevents

### DIFF
--- a/src/components/Moderation/ModerationNav.tsx
+++ b/src/components/Moderation/ModerationNav.tsx
@@ -119,6 +119,8 @@ export function ModerationNav() {
         .filter((i) => !i.hidden)
         .sort((a, b) => a.label.localeCompare(b.label))
         .map((link) => (
+          // Without break-inside-avoid an item can split across a column boundary,
+          // putting its label in one column and its padding in the next.
           <Menu.Item
             key={link.href}
             component={Link}


### PR DESCRIPTION
Follow-up to #4015. One comment, no behaviour change.

`break-inside-avoid` on the mod nav `Menu.Item`s looks decorative, and nothing visibly changes at the widths anyone happens to test — so it is the kind of class a tidy-up removes. Without it, CSS multi-column can split an item across a column boundary, putting its label in one column and its padding in the next. The comment says what breaks rather than what the class does.

A `[...items].sort(...)` guard was considered and deliberately left out: `.filter()` already returns a new array, so the sort never touches the array literal — including if that literal were ever hoisted to module scope. A redundant copy in the chain would read as load-bearing to the next reader while protecting nothing.

`pnpm run typecheck` clean (0 errors), `eslint` clean on the file, `prettier:write` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHitGmaWdshHjg8QYXzs3s