### PR TITLE
fix(postgres-query): stop reporting failure for multi-statement SQL it ran

### DIFF
--- a/.claude/skills/postgres-query/SKILL.md
+++ b/.claude/skills/postgres-query/SKILL.md
@@ -131,17 +131,20 @@ node .claude/skills/postgres-query/query.mjs --dev --writable "UPDATE ..."
 credential, so `--writable` only lifts the client-side guard. Whether a write lands is decided by
 the role in that URL.
 
-**DDL does not work through this credential.** `DEV_DATABASE_URL` connects as a
-non-superuser role, and the dev database has a `ddl_command_end` event trigger that
-reassigns each new object's ownership to the schema owner — which the connecting
-role cannot become. Any `CREATE TABLE` therefore rolls back with:
+**DDL does work through this credential** — verified 2026-08-17 on both dev and the prod primary as
+role `civitai`: `ALTER TABLE ... ADD COLUMN`, `ADD CONSTRAINT`, `CREATE INDEX` and a
+`CREATE TABLE`/`DROP TABLE` round trip all succeeded. Migrations can be applied with `--writable`.
 
-```
-must be able to SET ROLE "<schema owner>"
-```
+This section previously said the opposite — that a `ddl_command_end` event trigger reassigning object
+ownership made any `CREATE TABLE` roll back with `must be able to SET ROLE "<schema owner>"`. Nobody
+has observed that, and it is contradicted by the run above. It cost an escalation to an infra owner
+that was not needed. If you do hit an ownership error, record what you ran and correct this section
+again rather than restoring the blanket claim.
 
-Having `CREATE` on the schema is not enough and does not indicate otherwise. Ask an
-infra owner to run the DDL, or for a role that is a member of the schema owner.
+⚠️ **A multi-statement script needs `--writable` even when its first statement is harmless.** The
+client-side write guard checks every statement's leading keyword, so a migration opening with
+`SET lock_timeout` / `BEGIN` is still refused on account of the `ALTER`s underneath. That is
+deliberate.
 
 ## Querying the notifications-db
 

--- a/.claude/skills/postgres-query/query.mjs
+++ b/.claude/skills/postgres-query/query.mjs
@@ -249,26 +249,35 @@ if (writable && target.readOnly) {
   process.exit(1);
 }
 
-// Client-side write guard. It matches the query's leading keyword, so it catches an accidental
+// Client-side write guard. It matches each statement's leading keyword, so it catches an accidental
 // write, not a determined one: anything nested deeper than a leading CTE gets through, and only
 // the role you connect as stops that. Comments and string literals are blanked first, so
 // `/* note */ DELETE` can't slip past and a SELECT mentioning "delete" in a literal isn't blocked.
+//
+// EVERY statement, not just the first. A migration file opens with a comment block, then
+// `SET lock_timeout`, then `BEGIN` — so a guard reading only the leading keyword of the whole string
+// sees `SET`, passes it, and runs the `ALTER TABLE`s underneath without --writable. Splitting on `;`
+// is not a parser (a dollar-quoted body containing a semicolon can be split mid-body), but the
+// failure direction is a spurious refusal rather than a wave-through, which is the right way round.
 if (!writable || target.readOnly) {
-  const upperQuery = query
+  const blanked = query
     .replace(/'([^']|'')*'/g, "''")
     .replace(/--[^\n]*|\/\*[\s\S]*?\*\//g, ' ')
-    .toUpperCase()
-    .trim();
+    .toUpperCase();
   const writeOps = ['INSERT', 'UPDATE', 'DELETE', 'DROP', 'ALTER', 'TRUNCATE', 'CREATE'];
-  for (const op of writeOps) {
-    const nested = upperQuery.startsWith('WITH') && new RegExp(`\\(\\s*${op}\\b`).test(upperQuery);
-    if (upperQuery.startsWith(op) || nested) {
-      const ctx = target.readOnly
-        ? `${target.flag} is read-only.`
-        : 'Use --writable flag to confirm.';
-      console.error(`Error: Write operation detected (${op}). ${ctx}`);
-      console.error('This requires explicit user permission as it modifies the database.');
-      process.exit(1);
+  for (const statement of blanked.split(';')) {
+    const upperQuery = statement.trim();
+    if (!upperQuery) continue;
+    for (const op of writeOps) {
+      const nested = upperQuery.startsWith('WITH') && new RegExp(`\\(\\s*${op}\\b`).test(upperQuery);
+      if (upperQuery.startsWith(op) || nested) {
+        const ctx = target.readOnly
+          ? `${target.flag} is read-only.`
+          : 'Use --writable flag to confirm.';
+        console.error(`Error: Write operation detected (${op}). ${ctx}`);
+        console.error('This requires explicit user permission as it modifies the database.');
+        process.exit(1);
+      }
     }
   }
 }
@@ -279,38 +288,77 @@ async function main() {
 
     const finalQuery = explain ? `EXPLAIN ANALYZE ${query}` : query;
     const start = Date.now();
-    const result = await client.query(finalQuery);
+    const queryResult = await client.query(finalQuery);
     const elapsed = Date.now() - start;
 
+    // A MULTI-STATEMENT query resolves to an ARRAY of Results, one per statement, not to a single
+    // Result. Reading `.rows` off that array yields undefined and `.rows.length` throws — which the
+    // catch below reported as `Query error: Cannot read properties of undefined (reading 'length')`
+    // AFTER the server had already executed and committed every statement. So the tool announced a
+    // failure for work it had done: two people read that message as "the DDL was refused" and went
+    // looking for a permissions problem that did not exist. Normalise to a list and render each.
+    const results = Array.isArray(queryResult) ? queryResult : [queryResult];
+
     if (jsonOutput) {
-      console.log(JSON.stringify({
-        rows: result.rows,
-        rowCount: result.rowCount,
-        elapsed,
-        fields: result.fields?.map(f => f.name)
-      }, null, 2));
+      const shape = (r) => ({
+        rows: r.rows ?? [],
+        rowCount: r.rowCount,
+        command: r.command,
+        fields: r.fields?.map((f) => f.name),
+      });
+      // Single statement keeps the original flat shape so existing callers parsing this don't break.
+      console.log(
+        JSON.stringify(
+          results.length === 1
+            ? { ...shape(results[0]), elapsed }
+            : { statements: results.map(shape), elapsed },
+          null,
+          2
+        )
+      );
     } else if (explain) {
-      console.log(result.rows.map(r => r['QUERY PLAN']).join('\n'));
+      console.log(
+        results
+          .flatMap((r) => (r.rows ?? []).map((row) => row['QUERY PLAN']))
+          .join('\n')
+      );
       if (!quiet) {
         console.error(`\nQuery time: ${elapsed}ms`);
       }
     } else {
-      if (!quiet && result.fields) {
-        console.log('Columns:', result.fields.map(f => f.name).join(', '));
-        console.log('─'.repeat(60));
-      }
-
-      if (result.rows.length === 0) {
-        console.log('(no rows returned)');
-      } else {
-        // Pretty print rows
-        for (const row of result.rows) {
-          console.log(row);
+      results.forEach((result, i) => {
+        // Only label the statements when there is more than one — a single-statement run should look
+        // exactly as it always has.
+        if (!quiet && results.length > 1) {
+          console.log(`\n── statement ${i + 1}/${results.length}${result.command ? ` (${result.command})` : ''}`);
         }
-      }
+
+        if (!quiet && result.fields?.length) {
+          console.log('Columns:', result.fields.map((f) => f.name).join(', '));
+          console.log('─'.repeat(60));
+        }
+
+        const rows = result.rows ?? [];
+        if (!result.fields?.length) {
+          // A DDL / SET / BEGIN statement returns no field descriptors and no rows. Say what it did
+          // rather than "(no rows returned)", which reads like a query that found nothing.
+          if (!quiet) console.log(`${result.command ?? 'OK'} — no result set`);
+        } else if (rows.length === 0) {
+          console.log('(no rows returned)');
+        } else {
+          for (const row of rows) {
+            console.log(row);
+          }
+        }
+      });
 
       if (!quiet) {
-        console.error(`\n${result.rowCount} row(s) in ${elapsed}ms`);
+        const total = results.reduce((sum, r) => sum + (r.rowCount ?? 0), 0);
+        const label =
+          results.length > 1
+            ? `${results.length} statement(s), ${total} row(s)`
+            : `${results[0]?.rowCount ?? 0} row(s)`;
+        console.error(`\n${label} in ${elapsed}ms`);
       }
     }
   } catch (err) {


### PR DESCRIPTION
## The bug

`client.query()` resolves to an **array** of Results for a multi-statement query, not a single Result. The renderer read `.rows.length` off that array, threw on `undefined`, and the catch printed:

```
Query error: Cannot read properties of undefined (reading 'length')
```

with exit 1 — **after the server had already executed and committed every statement.**

So the tool announced a failure for work it had done. This is the inverse of the usual hazard, and it is worse, because the natural response is to go find out why the database refused you. Applying `20260817120000_placement_free_capacity` printed that error twice today; both times the migration had landed in full. Two people read it as the DDL being refused and went looking for a permissions problem that does not exist. One of them escalated to an infra owner for superuser access that was never needed.

## What changed

**1. Render every statement.** Normalise to a list. Single-statement output is byte-identical to before, and the single-statement `--json` shape is unchanged so existing callers keep parsing. Multi-statement runs get a per-statement header and a combined footer.

Statements with no field descriptors (DDL, `SET`, `BEGIN`) now print their command tag instead of `(no rows returned)`, which read like a query that found nothing rather than a statement that has no result set.

**2. The write guard now checks every statement, not just the first.** A migration file opens with a comment block, then `SET lock_timeout`, then `BEGIN` — so the old guard saw `SET`, passed it, and ran the `ALTER TABLE`s underneath **without `--writable`**. Splitting on `;` is not a parser (a dollar-quoted body containing a semicolon can be split mid-body), but that direction fails toward a spurious refusal rather than a wave-through, which is the right way round for a guard.

⚠️ Behaviour change: applying a migration through this skill now requires `--writable`. It always should have.

**3. `SKILL.md` corrected.** It claimed DDL does not work through this credential, because a `ddl_command_end` event trigger reassigns object ownership and any `CREATE TABLE` rolls back with `must be able to SET ROLE`. Not observed by anyone, and contradicted by today's run. Replaced with what was actually verified, plus a note telling the next person to record what they ran rather than restoring the blanket claim.

## Verification

Run against dev. Numbered as executed:

| # | case | result |
|---|---|---|
| 1 | single statement | unchanged — `Columns: a, b`, one row, `1 row(s)` |
| 2 | two SELECTs | both rendered, labelled `statement 1/2` and `2/2`, `2 statement(s), 2 row(s)` |
| 3 | comment + `SET` + `BEGIN` + `ALTER`, **no** `--writable` | **refused**: `Write operation detected (ALTER)` — this is the case the old guard waved through |
| 4 | `SELECT 'delete from users'` (control) | **not** refused — literal blanking still works, so the widened guard did not become trigger-happy |
| 5 | `--json`, two statements | `{ statements: [...], elapsed }`, both with rows/rowCount/command/fields |
| 6 | `CREATE TEMP TABLE` + `INSERT` + `SELECT` with `--writable` | all three rendered with command tags; **this is the shape that used to crash** |
| 7 | `CREATE TABLE` / `DROP TABLE` round trip on dev | both succeeded — the evidence behind the SKILL.md correction; probe table confirmed gone afterwards |

Case 4 is the control for case 3: widening a guard is only safe if it did not start refusing legitimate reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DvJSUkjAY9m6CQSEASVhT