### PR TITLE
docs(rewards): say that a bonus event scales the cap, not just the award

### DIFF
--- a/src/components/RewardsBonusEvent/RewardsBonusEventEditModal.tsx
+++ b/src/components/RewardsBonusEvent/RewardsBonusEventEditModal.tsx
@@ -4,14 +4,7 @@ import { useMemo } from 'react';
 import { Controller } from 'react-hook-form';
 import * as z from 'zod';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
-import {
-  Form,
-  InputCheckbox,
-  InputSelect,
-  InputText,
-  InputTextArea,
-  useForm,
-} from '~/libs/form';
+import { Form, InputCheckbox, InputSelect, InputText, InputTextArea, useForm } from '~/libs/form';
 import {
   REWARDS_BONUS_MULTIPLIER_OPTIONS,
   type UpsertRewardsBonusEventSchema,
@@ -145,7 +138,7 @@ export function RewardsBonusEventEditModal({
         <InputSelect
           name="multiplier"
           label="Multiplier"
-          description="Global Blue Buzz reward multiplier while this event is active."
+          description="Global Blue Buzz reward multiplier while this event is active — every reward type, not one feature. It scales each reward's daily CAP as well as its award, so a 100/day cap becomes 800/day for a member on a 4x tier during a 2x event."
           data={multiplierOptions}
           withAsterisk
         />
@@ -182,9 +175,7 @@ export function RewardsBonusEventEditModal({
               const startsAtValue = form.watch('startsAt');
               const today = dayjs().startOf('day').toDate();
               const minEndDate =
-                startsAtValue && startsAtValue.getTime() > today.getTime()
-                  ? startsAtValue
-                  : today;
+                startsAtValue && startsAtValue.getTime() > today.getTime() ? startsAtValue : today;
               return (
                 <DatePickerInput
                   label="Ends at"

--- a/src/pages/moderator/rewards-bonus-events.tsx
+++ b/src/pages/moderator/rewards-bonus-events.tsx
@@ -92,7 +92,10 @@ export default function RewardsBonusEventsPage() {
             <Stack gap={0}>
               <Title order={2}>Rewards Bonus Events</Title>
               <Text size="sm" c="dimmed">
-                Site-wide multipliers on Blue Buzz rewards. Highest-multiplier active event wins.
+                Site-wide multipliers on Blue Buzz rewards, across every reward type.
+                Highest-multiplier active event wins. The multiplier scales each reward&apos;s daily
+                cap as well as its award, so a 100/day cap is 800/day for a member on a 4x tier
+                during a 2x event.
               </Text>
             </Stack>
             <Button leftSection={<IconPlus size={16} />} onClick={() => openEdit()}>


### PR DESCRIPTION
The bonus-event screen already said *site-wide* and *global*. Neither it nor the multiplier field said that the multiplier scales each reward's **daily cap** as well as its award.

That is the part that surprises people, and it is what Justin was answering when he accepted the behaviour: **a 100/day cap is 800/day for a member on a 4x tier during a 2x event.** The number is what made it land, so the copy uses the number.

Two places, both where the decision actually gets made:

- the multiplier field's description in `RewardsBonusEventEditModal` — where the switch gets thrown
- the page subtitle on `/moderator/rewards-bonus-events`

Copy only. No behaviour change, no logic touched.

Kept separate from #4022 deliberately: that PR is mid-review pinned to a SHA, and moving it for two lines of copy costs more than the copy is worth. It touches `rewards-bonus-events.tsx` a few lines from #4022's own change, so whichever lands second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1jg4QCdjPABErRJxDrusg