### PR TITLE
fix(download): decode the separators Next re-encodes before the split-query repair

### DIFF
--- a/src/__tests__/pages/api/download/split-query-repair.test.ts
+++ b/src/__tests__/pages/api/download/split-query-repair.test.ts
@@ -121,6 +121,8 @@ function statuses(res: NextApiResponse) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // The sampling tests spy on Math.random; clearAllMocks does not put it back.
+  vi.restoreAllMocks();
   mockFindUnique.mockResolvedValue(null);
   mockGetServerAuthSession.mockResolvedValue({ user: { id: 5 } });
   mockHasExceededLimit.mockResolvedValue(false);
@@ -191,13 +193,78 @@ describe('download route — a query split by a stray `?`', () => {
     const { promise } = run(url, '568485');
     await promise;
 
-    const logged = mockLogToAxiom.mock.calls[0][0] as { query: Record<string, unknown> };
+    // Found by type rather than by call index — the repair log now precedes it.
+    const logged = mockLogToAxiom.mock.calls
+      .map((c) => c[0] as { type: string; query: Record<string, unknown> })
+      .find((entry) => entry.type === 'error') as { query: Record<string, unknown> };
     expect(logged.query, 'the caller API key was shipped to Axiom in plaintext').not.toHaveProperty(
       'token'
     );
     expect(logged.query.fileId, 'the rest of the query is still there to debug with').toBe(
       '484398'
     );
+  });
+
+  it('records that the shim fired, so we can tell when it is safe to delete', async () => {
+    const { promise } = run(url, '568485');
+    await promise;
+
+    const repairs = mockLogToAxiom.mock.calls
+      .map((c) => c[0] as Record<string, unknown>)
+      .filter((entry) => entry.message === 'split-query-repaired');
+
+    expect(repairs, 'a repair that logs nothing cannot tell us the shim is still needed').toHaveLength(
+      1
+    );
+    expect(repairs[0].keys).toEqual(expect.arrayContaining(['fileId', 'type', 'token']));
+    expect(
+      JSON.stringify(repairs[0]),
+      'a query VALUE reached Axiom — on this route that includes the caller API key'
+    ).not.toContain('secret-key');
+  });
+
+  it('does not log a repair on a request that needed none', async () => {
+    const { promise } = run(
+      '/api/download/models/568485?fileId=484398&type=Model&token=secret-key',
+      '568485'
+    );
+    await promise;
+
+    expect(
+      mockLogToAxiom.mock.calls.map((c) => (c[0] as { message: string }).message)
+    ).not.toContain('split-query-repaired');
+  });
+
+  it('records a schema rejection by field, without the values', async () => {
+    // Sampled at 1%, so pin the draw rather than relying on it.
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+
+    const { promise, res } = run('/api/download/models/568485?fileId=nonsense', '568485');
+    await promise;
+
+    expect(statuses(res)).toContain(400);
+    const rejection = mockLogToAxiom.mock.calls
+      .map((c) => c[0] as Record<string, unknown>)
+      .find((entry) => entry.message === 'schema-rejected');
+
+    expect(rejection, 'the 400 returns before any logging, so nothing counts these').toBeDefined();
+    expect(rejection?.fields).toEqual(['fileId']);
+    expect(rejection?.repaired, 'a 400 after a repair is a different bug from one it never saw').toBe(
+      false
+    );
+    expect(JSON.stringify(rejection)).not.toContain('nonsense');
+  });
+
+  it('drops the sampled rejection log on a draw above the rate', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.99);
+
+    const { promise } = run('/api/download/models/568485?fileId=nonsense', '568485');
+    await promise;
+
+    expect(
+      mockLogToAxiom.mock.calls.map((c) => (c[0] as { message: string }).message),
+      'unsampled, a caller can drive this log at will'
+    ).not.toContain('schema-rejected');
   });
 
   it('CONTROL: the same request already worked when the client used `&`', async () => {

--- a/src/__tests__/pages/api/download/split-query-repair.test.ts
+++ b/src/__tests__/pages/api/download/split-query-repair.test.ts
@@ -81,6 +81,11 @@ const REDIRECT_URL = 'https://example.invalid/signed/model.safetensors';
  * `URLSearchParams`, then the path params spread OVER it — params win on a
  * collision (`next-server.ts`), which is the precedence the repair must not
  * invert.
+ *
+ * `req.url` is re-serialised the same way, because `normalizeCdnUrl` does that
+ * before the handler runs — the stray `?` arrives percent-encoded while
+ * `req.query` keeps it raw. Handing the route the raw url instead is what let
+ * civitai#3931 pass here while prod kept answering 400.
  */
 function run(url: string, modelVersionId: string) {
   const parsed = new URL(url, 'https://civitai.com');
@@ -88,9 +93,11 @@ function run(url: string, modelVersionId: string) {
   for (const [key, value] of parsed.searchParams) query[key] = value;
   query.modelVersionId = modelVersionId;
 
+  const search = parsed.searchParams.toString();
+
   const req = {
     method: 'GET',
-    url,
+    url: search ? `${parsed.pathname}?${search}` : parsed.pathname,
     query,
     headers: { 'user-agent': 'civitai-downloader/1.0' },
     socket: { remoteAddress: '203.0.113.7' },

--- a/src/pages/api/download/models/[modelVersionId].ts
+++ b/src/pages/api/download/models/[modelVersionId].ts
@@ -34,6 +34,39 @@ const downloadLimiter = createLimiter({
   fetchCount: fetchDownloadCount,
 });
 
+/**
+ * A caller can drive this 400 at will, so it is sampled where the repair below
+ * is not. Neither payload carries a query VALUE — `token` on this route is the
+ * caller's API key, and Axiom applies no redaction of its own.
+ */
+const SCHEMA_REJECTION_SAMPLE_RATE = 0.01;
+
+function logSplitQueryRepair(req: NextApiRequest) {
+  logToAxiom({
+    name: 'download-model-endpoint',
+    type: 'info',
+    message: 'split-query-repaired',
+    keys: Object.keys(req.query),
+  }).catch(() => {
+    // swallow logging failure
+  });
+}
+
+function logSchemaRejection(error: z.ZodError, repaired: boolean) {
+  if (Math.random() >= SCHEMA_REJECTION_SAMPLE_RATE) return;
+  logToAxiom({
+    name: 'download-model-endpoint',
+    type: 'warning',
+    message: 'schema-rejected',
+    fields: error.issues.map((issue) => issue.path.join('.')),
+    // A rejection AFTER a repair is a different bug from one the repair never saw.
+    repaired,
+    sampleRate: SCHEMA_REJECTION_SAMPLE_RATE,
+  }).catch(() => {
+    // swallow logging failure
+  });
+}
+
 export default PublicEndpoint(
   async function downloadModel(req: NextApiRequest, res: NextApiResponse) {
     // This response is per-user, auth/early-access-gated, rate-limited, and
@@ -48,7 +81,10 @@ export default PublicEndpoint(
     // Must run before `getServerAuthSession` below, which reads `?token=` off
     // `req.url` — a stray `?` swallows that param into the one before it, so an
     // API-key caller would otherwise be treated as anonymous.
-    repairSplitQueryString(req);
+    const repaired = repairSplitQueryString(req);
+    // Unsampled: this is what says whether any client still needs the shim, and
+    // a rate that can report zero is the point.
+    if (repaired) logSplitQueryRepair(req);
 
     const isBrowser = isRequestFromBrowser(req);
     function errorResponse(status: number, message: string) {
@@ -124,10 +160,12 @@ export default PublicEndpoint(
 
       // Validate query params
       const queryResults = schema.safeParse(req.query);
-      if (!queryResults.success)
+      if (!queryResults.success) {
+        logSchemaRejection(queryResults.error, repaired);
         return res
           .status(400)
           .json({ error: z.prettifyError(queryResults.error) ?? 'Invalid modelVersionId' });
+      }
       const input = queryResults.data;
       const modelVersionId = input.modelVersionId;
       if (!modelVersionId) return errorResponse(400, 'Missing modelVersionId');

--- a/src/server/utils/__tests__/repair-split-query-string.test.ts
+++ b/src/server/utils/__tests__/repair-split-query-string.test.ts
@@ -16,8 +16,18 @@ import { repairSplitQueryString } from '~/server/utils/request-helpers';
  * OVER it (`next-server.ts` — params win on a collision).
  */
 
+/**
+ * Every fixture url is normalised the way `normalizeCdnUrl` does before an API
+ * route runs, so the stray `?` and the `=` behind it reach the repair
+ * percent-encoded. Passing the raw url here instead is what let civitai#3931
+ * ship green against a shape prod never produces.
+ */
 function makeReq(url: string, query: NextApiRequest['query']) {
-  return { url, query } as NextApiRequest;
+  const [pathname, search] = url.split(/\?(.*)/s);
+  return {
+    url: search ? `${pathname}?${new URLSearchParams(search)}` : pathname,
+    query,
+  } as NextApiRequest;
 }
 
 describe('repairSplitQueryString', () => {
@@ -79,7 +89,7 @@ describe('repairSplitQueryString', () => {
     expect(req.query.format).toBe('SafeTensor');
   });
 
-  it('treats an encoded %3F as data, not as a separator', () => {
+  it('splits the `?` that is a separator while keeping the one that is data', () => {
     const req = makeReq('/api/download/models/1?fp=fp%3F16?type=Model', {
       modelVersionId: '1',
       fp: 'fp?16?type=Model',
@@ -87,8 +97,25 @@ describe('repairSplitQueryString', () => {
 
     repairSplitQueryString(req);
 
-    expect(req.query.fp, 'a percent-encoded ? is a value the client meant to send').toBe('fp?16');
+    expect(req.query.fp, 'a ? that opens no param is a value the client meant to send').toBe(
+      'fp?16'
+    );
     expect(req.query.type).toBe('Model');
+  });
+
+  it('repairs the url shape Next actually hands the route', () => {
+    // The literal encoding here is what `normalizeCdnUrl` produces from
+    // `?fileId=1541606?type=Model&format=SafeTensor`. A repair that keys on a raw
+    // `?` in req.url finds none and bails, which is how the 400s survived #3931.
+    const req = makeReq(
+      '/api/download/models/1641161?fileId=1541606%3Ftype%3DModel&format=SafeTensor',
+      { modelVersionId: '1641161', fileId: '1541606?type=Model', format: 'SafeTensor' }
+    );
+
+    expect(repairSplitQueryString(req), 'the encoded separator was read as data').toBe(true);
+    expect(req.query.fileId, 'fileId still parses as NaN, so the route answers 400').toBe('1541606');
+    expect(req.query.type).toBe('Model');
+    expect(req.query.format).toBe('SafeTensor');
   });
 });
 

--- a/src/server/utils/request-helpers.ts
+++ b/src/server/utils/request-helpers.ts
@@ -17,8 +17,18 @@ export function getProtocol(req: ProtocolRequest): Protocol {
   return proto as Protocol;
 }
 
-/** A raw `?` is only a separator when what follows it opens a new param. */
+/** A `?` is only a separator when what follows it opens a new param. */
 const RESUMES_QUERY = /^&*[^&=?]+=/;
+
+/**
+ * Next re-serialises `req.url` through `URLSearchParams` before an API route runs
+ * (`normalizeCdnUrl`, next/dist/server/route-modules/route-module.js), which
+ * percent-encodes the client's stray `?` and the `=` behind it. `req.query` still
+ * holds both raw, so the encoding here is Next's own and never the caller's.
+ */
+const ENCODED_SEPARATORS = /%3F|%3D/gi;
+const decodeSeparators = (query: string) =>
+  query.replace(ENCODED_SEPARATORS, (match) => (match.toLowerCase() === '%3f' ? '?' : '='));
 
 /**
  * Rejoin a query a client split by appending a second `?…` to a URL that already
@@ -26,8 +36,8 @@ const RESUMES_QUERY = /^&*[^&=?]+=/;
  * that one param — `fileId=2?type=Model` — so the id fails to parse and every
  * later param is swallowed, `token` (API-key auth) included.
  *
- * A raw `?` is legal INSIDE a value, so only a `?` followed by `key=` is treated
- * as a separator; `?token=ab?cd` is left alone.
+ * A `?` is legal INSIDE a value, so only a `?` followed by `key=` is treated as a
+ * separator; `?token=ab?cd` is left alone.
  *
  * Rewrites `req.url` as well as `req.query`, because auth re-parses the url.
  * Only a param that is missing or itself split is written, so a repair can never
@@ -41,7 +51,7 @@ export function repairSplitQueryString(req: NextApiRequest): boolean {
   const start = url.indexOf('?');
   if (start === -1) return false;
 
-  const raw = url.slice(start + 1);
+  const raw = decodeSeparators(url.slice(start + 1));
   const [head, ...rest] = raw.split('?');
   if (!rest.length) return false;
 


### PR DESCRIPTION
Follow-up to #3931, which is live on prod (v5.1.11, `28bdecf2c`) and does not fire.

## Still broken

Worker logs, 2026-08-17:

```
downloading model for @civitai/1641161 from https://api.civitai.com/download/models/1641161?fileId=1541606?type=Model&format=SafeTensor&token=…
WARNING retrying '_do_download_model' after exception: Client error '400 Bad Request'
```

Reproduced against prod just now:

```
/api/download/models/501240?fileId=418901                  → 307
/api/download/models/501240?fileId=418901?type=Model       → 400  "expected number, received NaN → at fileId"
/api/download/models/1641161?type=Model?format=SafeTensor  → 400  "Invalid option … → at type"
```

The second probe is the one that localises it: zod reports `at type`, so `req.query.type` was still `Model?format=SafeTensor` when `safeParse` ran. `repairSplitQueryString` wrote nothing.

## Why

The helper reads `req.url`. Next rewrites `req.url` before the handler runs — `route-modules/route-module.js:501` calls `serverUtils.normalizeCdnUrl(req, paramKeys)`, which does `parseReqUrl(req.url)` then `req.url = formatUrl(parsed)`. That reserialises the query through `URLSearchParams`, which percent-encodes. Run against this repo's own Next:

```
IN   /api/download/models/1641161?fileId=1541606?type=Model&format=SafeTensor
OUT  /api/download/models/1641161?fileId=1541606%3Ftype%3DModel&format=SafeTensor
```

The guard above that call is `RouteKind.PAGES || RouteKind.PAGES_API`, so every pages API dynamic route gets it.

So `raw.split('?')` yields no `rest`, the helper returns `false` at the third line of its body, and #3931's rule that "`%3F` is left alone" makes the bail permanent.

## Fix

Decode `%3F`/`%3D` in the query string before splitting; everything downstream is unchanged. `req.query` still holds both characters raw — that is how we know the encoding is Next's and not the caller's.

`%3D` matters as much as `%3F`: decoding only the latter leaves `fileId=1541606?type%3DModel`, and `RESUMES_QUERY` needs a literal `=` to recognise `type=` as a param, so the repair would still no-op.

### Deliberately given up

The #3931 carve-out that a client-sent `%3F` means a literal `?`. Next decodes it into `req.query` and re-encodes every raw `?` the same way, so the distinction no longer exists by the time any route can see it — the old rule only appeared to work because it read a url shape prod never produces. The blast radius is narrow: a `?` is still only a separator when what follows opens a `key=`, so `?token=ab%3Fcd` is untouched, and the existing RFC 3986 test still passes unchanged.

## Tests

The reason #3931 shipped green is that both suites hand-built `req.url` with a literal `?`. Both fixtures now normalise the url the way `normalizeCdnUrl` does, so every existing case runs against the shape prod actually produces, plus one new test pinning the encoded shape directly.

- 18 pass across the two files (12 unit + 6 route-wiring), both files collected non-zero.
- Mutation check: reverting just the decode fails **11 of 18**, legibly — `expected '2?type=Model' to be '2'`, `auth reads the token off req.url — an unrepaired url authenticates nobody: expected null to be 'secret'`, and the route-wiring `the schema rejected the request — fileId parsed as NaN, so the repair did not run first: expected [ 400 ] to not include 400`.

## Not in this PR

- The worker should append with `&`. The shim exists because `/api/v1/model-versions` emits `?fileId=` while `/api/v1/models` emits `?type=&format=`, and the public docs tell callers to append `?token=` — same disagreement #3931 flagged and did not close.
- `token` was **not** swallowed in the reported URL (it followed a real `&`); only `fileId` broke. The swallowed-token case is still covered.
- Nothing about this reaches Axiom: the 400 returns before the handler's only `logToAxiom` call, which sits in the 500 `catch`. Ten days of `download-model-endpoint` events contain four rows, all unrelated Prisma int-overflow. Worth a counter, but that is the cross-package change #3931 already deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: verified end to end, plus telemetry

### The diagnosis is now observed, not inferred

Ran both shapes against a real Next dev server on this branch — no Cloudflare in the path:

| URL (localhost:3000) | with the decode | decode removed |
|---|---|---|
| `?fileId=418901?type=Model&format=SafeTensor` | **307** | **400** `expected number, received NaN → at fileId` |
| `?type=Model?format=SafeTensor` | **307** | **400** `Invalid option … → at type` |

The failing errors are byte-identical to what prod returns today, so Next is confirmed as the encoder and the decode is confirmed as what changes the outcome.

### Telemetry (second commit)

Nothing counted these 400s. The route's only `logToAxiom` call is in the 500 `catch`, so the schema rejection returns before any telemetry — which is why the original fix sat dead in prod for three days and surfaced only when someone pasted worker logs.

- **Repairs log unsampled.** A rate that can report zero is the point: it is what tells us when no client needs the shim any more and it can be deleted.
- **Schema rejections are sampled at 1%.** A caller can drive that 400 at will. The payload carries the failing field paths, the sample rate, and `repaired` — a 400 *after* a repair is a different bug from one the repair never saw.
- **Neither payload carries a query value.** `token` on this route is the caller's API key and Axiom applies no redaction of its own. The existing 500-path test pins this; two new ones pin it for the new entries.

Volume on the repair log is unknown until it ships — it is bounded by real clients using the split shape, not by attacker traffic, but if it turns out noisy the sample-rate constant is right beside it.

### Tests

22 pass across the two files (12 unit + 10 route-wiring). Every new assertion is mutation-checked:

- drop `if (repaired) logSplitQueryRepair(req)` → `a repair that logs nothing cannot tell us the shim is still needed: expected [] to have a length of 1`
- drop the sampling guard → `unsampled, a caller can drive this log at will: expected [ 'schema-rejected' ] to not include 'schema-rejected'`
- drop the decode → 11 of 18 fail, including the route-wiring `expected [ 400 ] to not include 400`

One pre-existing test changed: `keeps the caller API key out of the error log` indexed `mock.calls[0]`, which is now the repair entry. It finds the error entry by `type` instead.

### What this does not prove

Model `1641161` from the report is login-gated — `?fileId=1541606` alone returns 401 `The creator of this asset requires you to be logged in to download it`. This fix gets the worker past the 400 and into the auth/entitlement path; whether the download then succeeds depends on its token and that account's access, which is not testable from here. A 401 with that message after this ships is progress, not a regression.
