### PR TITLE
fix(rewards): a stray top-level key no longer discards every override

### DIFF
--- a/src/server/rewards/__tests__/reward-config.test.ts
+++ b/src/server/rewards/__tests__/reward-config.test.ts
@@ -198,6 +198,53 @@ describe('resolveRewardConfig', () => {
   // `{"dailyBoost": {...}}` — the row someone hand-editing in Retool writes. A
   // non-strict envelope parses it as "no rewards key" and silently leaves
   // everything on.
+  // 🔴 The whole-row version of "a stray key beside a real field keeps the real
+  // field". A strict envelope discarded the entire map over one unrecognised
+  // top-level key, and every reward an operator had turned off resumed paying —
+  // the same situation as one level down, but with every reward as the blast
+  // radius and money as the direction.
+  // The assertion is about PAYMENT STATE, not about parsing. The failure this
+  // guards is money: a reward an operator turned off resuming payment. "The row
+  // parsed" would be green for a version of this that pays.
+  it('leaves a disabled reward disabled when the row carries a stray top-level key', async () => {
+    storedConfig({
+      rewards: { testReward: { enabled: false, awardAmount: 4 } },
+      note: 'for the launch',
+    });
+
+    const config = await resolve();
+
+    expect(config.enabled).toBe(false);
+    expect(config.awardAmount).toBe(4);
+  });
+
+  it('keeps every reward’s override, not just the first, past a stray key', async () => {
+    storedConfig({
+      rewards: { testReward: { enabled: false }, otherReward: { enabled: false } },
+      owner: 'ops',
+    });
+
+    expect((await resolve()).enabled).toBe(false);
+    expect((await resolveRewardConfig('otherReward', { ...DEFAULTS })).enabled).toBe(false);
+  });
+
+  it('warns about the stray rather than swallowing it', async () => {
+    storedConfig({ rewards: { testReward: { enabled: false } }, note: 'x', owner: 'ops' });
+
+    await resolve();
+
+    expect(loggingMock.logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('unrecognised top-level keys'),
+        strays: ['note', 'owner'],
+      })
+    );
+  });
+
+  it('still refuses to write a row with a stray top-level key', async () => {
+    await expect(setRewardConfig({ rewards: {}, note: 'x' } as never, 1)).rejects.toThrow();
+  });
+
   it('warns and runs unconfigured on a row written without the `rewards` wrapper', async () => {
     storedConfig({ testReward: { enabled: false } });
 
@@ -212,7 +259,7 @@ describe('resolveRewardConfig', () => {
     expect(loggingMock.logToAxiom).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'reward-config',
-        message: expect.stringContaining('malformed reward config row'),
+        message: expect.stringContaining('no `rewards` wrapper'),
       })
     );
   });

--- a/src/server/rewards/__tests__/reward-config.test.ts
+++ b/src/server/rewards/__tests__/reward-config.test.ts
@@ -241,8 +241,15 @@ describe('resolveRewardConfig', () => {
     );
   });
 
+  // Asserts the WRITE did not happen, not merely that something threw. A bare
+  // `rejects.toThrow()` passes here only because `beforeEach` nulls both row
+  // mocks, so the malformed guard cannot fire and the schema is the only thing
+  // left that can throw — a future edit seeding a bad row in shared setup would
+  // keep this green for the wrong reason.
   it('still refuses to write a row with a stray top-level key', async () => {
     await expect(setRewardConfig({ rewards: {}, note: 'x' } as never, 1)).rejects.toThrow();
+
+    expect(dbMock.dbWrite.keyValue.upsert).not.toHaveBeenCalled();
   });
 
   it('warns and runs unconfigured on a row written without the `rewards` wrapper', async () => {

--- a/src/server/rewards/reward-config.ts
+++ b/src/server/rewards/reward-config.ts
@@ -206,8 +206,10 @@ async function loadConfig(): Promise<RewardConfig> {
   const envelope = envelopeSchema.safeParse(stored);
 
   if (!envelope.success) {
-    // Not an object at all. Nothing here says which rewards were meant, so this
-    // is the one case with no better answer than running unconfigured.
+    // The row is not usable as an envelope: not an object at all, or `rewards`
+    // present but not a map (`{"rewards": "all of them"}`). Either way nothing
+    // here says which rewards were meant, so this is the one case with no better
+    // answer than running unconfigured.
     warn('Ignoring malformed reward config row — every reward is running unconfigured', {
       stored,
     });
@@ -218,11 +220,18 @@ async function loadConfig(): Promise<RewardConfig> {
   //
   // A strict envelope here threw the whole row away over one unrecognised key —
   // `{"rewards": {…}, "note": "for the launch"}` — and every reward an operator
-  // had turned off resumed paying. That is the same situation `usableOverride`
-  // already handles one level down, where the rule is "a stray key beside a real
-  // field keeps the real field", and it must fail the same way at both levels:
-  // the difference here is only that the blast radius is every reward at once,
-  // and the direction is paying rather than not paying.
+  // had turned off resumed paying. `usableOverride` already answers this one
+  // level down: **a stray key BESIDE a real field keeps the real field**. That
+  // rule holds at both levels, and it matters more here, because the blast
+  // radius is every reward at once and the direction is paying.
+  //
+  // ⚠️ The ALL-stray case deliberately diverges, and is not an oversight to
+  // harmonise. One level down, an entry of nothing but unknown keys DISABLES
+  // that reward — an instruction we cannot carry out, so we stop its money. Up
+  // here, a row with no `rewards` at all leaves every reward on compiled
+  // defaults, i.e. PAYING. The blast radius inverts the answer: there is no way
+  // to know which rewards a wrapper-less row meant, and disabling all of them
+  // over one stray key turns a typo into a site-wide reward outage.
   const strays = Object.keys(stored as MixedObject).filter((key) => key !== 'rewards');
 
   if (strays.length)

--- a/src/server/rewards/reward-config.ts
+++ b/src/server/rewards/reward-config.ts
@@ -197,7 +197,8 @@ function buildConfig(rewards: Record<string, unknown>): RewardConfig {
 // rather than an envelope with no rewards in it that silently leaves every reward
 // enabled. The entries themselves stay `unknown` here — `usableOverride` salvages
 // them field by field, which the strict override schema would not.
-const envelopeSchema = z.object({ rewards: z.record(z.string(), z.unknown()).optional() }).strict();
+// NOT strict, and that is the fix rather than an oversight — see `loadConfig`.
+const envelopeSchema = z.object({ rewards: z.record(z.string(), z.unknown()).optional() });
 
 async function loadConfig(): Promise<RewardConfig> {
   const row = await dbRead.keyValue.findUnique({ where: { key: REWARD_CONFIG_KEY } });
@@ -205,12 +206,32 @@ async function loadConfig(): Promise<RewardConfig> {
   const envelope = envelopeSchema.safeParse(stored);
 
   if (!envelope.success) {
-    // Fail-open, and loudly so: we cannot tell which rewards this row meant.
+    // Not an object at all. Nothing here says which rewards were meant, so this
+    // is the one case with no better answer than running unconfigured.
     warn('Ignoring malformed reward config row — every reward is running unconfigured', {
       stored,
     });
     return {};
   }
+
+  // 🔴 A stray TOP-LEVEL key must not discard a perfectly good `rewards` map.
+  //
+  // A strict envelope here threw the whole row away over one unrecognised key —
+  // `{"rewards": {…}, "note": "for the launch"}` — and every reward an operator
+  // had turned off resumed paying. That is the same situation `usableOverride`
+  // already handles one level down, where the rule is "a stray key beside a real
+  // field keeps the real field", and it must fail the same way at both levels:
+  // the difference here is only that the blast radius is every reward at once,
+  // and the direction is paying rather than not paying.
+  const strays = Object.keys(stored as MixedObject).filter((key) => key !== 'rewards');
+
+  if (strays.length)
+    warn(
+      envelope.data.rewards === undefined
+        ? 'Reward config row has no `rewards` wrapper — every reward is running unconfigured'
+        : 'Ignoring unrecognised top-level keys in the reward config row',
+      { strays, stored }
+    );
 
   return buildConfig(envelope.data.rewards ?? {});
 }


### PR DESCRIPTION
Item 1 of the fail-open family from #4019's review. **The one that pays money.**

## The defect

`{"rewards": {"firstDailyFollow": {"enabled": false}}, "note": "for the launch"}`

The envelope schema was `.strict()`, so that row failed to parse, `loadConfig` returned `{}`, and **every reward an operator had turned off resumed paying.** One unrecognised top-level key — an annotation, a leftover, anything — discards the entire map.

## Why it happened, since that is the useful part

One layer down, `usableOverride` already answers the same question the other way: **a stray key beside a real field keeps the real field** and reports the stray. `{"cap": 8, "note": "launch"}` keeps the cap.

I wrote both, twenty minutes apart, and neither said what the other did. I reached for strictness at the envelope to close a *different* hole — a row written without the `rewards` wrapper — without carrying up the rule I had just written. It reads like a deliberate choice, which is why it needs saying: it was not one.

The only differences at the envelope level are that the blast radius is **every reward at once** and the direction is **paying rather than not paying**. Both argue for the entry-level answer, harder.

## The fix

The read path keeps the valid map, warns about the strays by name, and carries a comment naming the entry-level behaviour it is now consistent with — so the next person harmonising these two layers does not have to work out which was deliberate.

**The write path stays strict.** `set` still refuses a row with a stray top-level key, so one cannot be persisted through the panel or the API. Same asymmetry as everywhere else in this file: the reader must keep paying rewards correctly through a bad row; the writer refuses to create one.

The wrapper-missing case (`{"dailyBoost": {…}}`) keeps its own distinct message. It is a different mistake from an annotation beside a valid map, and only one of the two has a recoverable map in it.

## Testing

Five new tests. **The assertions are about payment state, not about parsing** — the failure this guards is money, so "the row parsed" would be green for a version of this that pays:

- a disabled reward is **still disabled** when the row carries a stray key
- **every** reward's override survives, not just the first
- the strays are named in the warning rather than swallowed
- the write path still refuses them
- the wrapper-missing case keeps its own message

**5 mutants, 5 caught:** envelope strict again, stray detection returning nothing, the warn removed, the wrapper case collapsed into the ordinary one, and the write path going non-strict.

`node scripts/typecheck.mjs --incremental false` clean, eslint and prettier exit 0 on both files, full suite `EXIT=0` / `Test Files 1111 passed | 1 skipped (1112)` / `Tests 17384 passed | 23 skipped (17407)` / 0 loss markers.

## Scope

Items 2–8 of the family are tracked as an ordered follow-up, briefed by the handoff at `_local/docs/plans/reward-config-handoff-2026-08-17.md`. None of them is date-bound; this one was taken alone because it is the money-directional one and the reasoning behind it is not reconstructible from the item list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1jg4QCdjPABErRJxDrusg